### PR TITLE
Theme Showcase: Add FilterBarModern component

### DIFF
--- a/client/components/category-pill-navigation/index.tsx
+++ b/client/components/category-pill-navigation/index.tsx
@@ -25,6 +25,7 @@ type CategoryPillNavigationProps = {
 	}[];
 	selectedCategoryId: string;
 	onSelect?: ( selectedId: string ) => void;
+	disableMobileCollapse?: boolean;
 };
 
 export const CategoryPillNavigation = ( {
@@ -32,6 +33,7 @@ export const CategoryPillNavigation = ( {
 	categories,
 	selectedCategoryId,
 	onSelect = () => {},
+	disableMobileCollapse = false,
 }: CategoryPillNavigationProps ) => {
 	const locale = useLocale();
 	const isMobile = useMobileBreakpoint();
@@ -91,7 +93,7 @@ export const CategoryPillNavigation = ( {
 		} );
 	}, [ selectedCategoryId ] );
 
-	if ( isMobile ) {
+	if ( isMobile && ! disableMobileCollapse ) {
 		const selectedItem =
 			buttons?.find( ( { isActive } ) => isActive ) ||
 			categories.find( ( { id } ) => id === selectedCategoryId );

--- a/client/my-sites/themes/filter-bar-modern/index.tsx
+++ b/client/my-sites/themes/filter-bar-modern/index.tsx
@@ -3,6 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useState } from 'react';
 import { InView } from 'react-intersection-observer';
 import { CategoryPillNavigation } from 'calypso/components/category-pill-navigation';
+import Search, { SEARCH_MODE_ON_ENTER } from 'calypso/components/search';
 import { CustomSelectWrapper } from 'calypso/my-sites/themes/custom-select-wrapper';
 
 import './style.scss';
@@ -25,6 +26,8 @@ interface FilterBarModernProps {
 	selectedTier: string;
 	onTierSelect: ( attrs: { selectedItem: Tier } ) => void;
 	showTierFilter?: boolean;
+	searchQuery?: string;
+	onSearch?: ( query: string ) => void;
 }
 
 const FilterBarModern = ( {
@@ -35,9 +38,12 @@ const FilterBarModern = ( {
 	selectedTier,
 	onTierSelect,
 	showTierFilter = true,
+	searchQuery = '',
+	onSearch,
 }: FilterBarModernProps ) => {
 	const translate = useTranslate();
 	const [ isSticky, setIsSticky ] = useState( false );
+	const [ isSearchOpen, setIsSearchOpen ] = useState( false );
 
 	const pillCategories = useMemo(
 		() =>
@@ -92,6 +98,20 @@ const FilterBarModern = ( {
 			</InView>
 			<div className={ clsx( 'filter-bar-modern', { 'is-sticky': isSticky } ) }>
 				<div className="filter-bar-modern__content">
+					{ isSticky && onSearch && (
+						<div className="filter-bar-modern__search">
+							<Search
+								pinned
+								isOpen={ isSearchOpen }
+								onSearchOpen={ () => setIsSearchOpen( true ) }
+								onSearchClose={ () => setIsSearchOpen( false ) }
+								initialValue={ searchQuery }
+								onSearch={ onSearch }
+								placeholder={ translate( 'Search themes…' ) }
+								searchMode={ SEARCH_MODE_ON_ENTER }
+							/>
+						</div>
+					) }
 					<CategoryPillNavigation
 						categories={ pillCategories }
 						selectedCategoryId={ selectedCategory }

--- a/client/my-sites/themes/filter-bar-modern/index.tsx
+++ b/client/my-sites/themes/filter-bar-modern/index.tsx
@@ -1,5 +1,7 @@
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
+import { InView } from 'react-intersection-observer';
 import { CategoryPillNavigation } from 'calypso/components/category-pill-navigation';
 import { CustomSelectWrapper } from 'calypso/my-sites/themes/custom-select-wrapper';
 
@@ -35,6 +37,7 @@ const FilterBarModern = ( {
 	showTierFilter = true,
 }: FilterBarModernProps ) => {
 	const translate = useTranslate();
+	const [ isSticky, setIsSticky ] = useState( false );
 
 	const pillCategories = useMemo(
 		() =>
@@ -78,24 +81,36 @@ const FilterBarModern = ( {
 	}, [ tiers, selectedTier, translate ] );
 
 	return (
-		<div className="filter-bar-modern">
-			<CategoryPillNavigation
-				categories={ pillCategories }
-				selectedCategoryId={ selectedCategory }
-				onSelect={ handleCategorySelect }
-			/>
-			{ showTierFilter && (
-				<CustomSelectWrapper
-					className="filter-bar-modern__tier-select"
-					label={ translate( 'View' ) }
-					hideLabelFromVision={ false }
-					__next40pxDefaultSize
-					options={ tierOptions }
-					value={ tierValue }
-					onChange={ onTierSelect }
-				/>
-			) }
-		</div>
+		<>
+			<InView
+				rootMargin="-1px 0px 0px 0px"
+				threshold={ 1 }
+				fallbackInView
+				onChange={ ( inView ) => setIsSticky( ! inView ) }
+			>
+				<div className="filter-bar-modern__sentinel" />
+			</InView>
+			<div className={ clsx( 'filter-bar-modern', { 'is-sticky': isSticky } ) }>
+				<div className="filter-bar-modern__content">
+					<CategoryPillNavigation
+						categories={ pillCategories }
+						selectedCategoryId={ selectedCategory }
+						onSelect={ handleCategorySelect }
+					/>
+					{ showTierFilter && (
+						<CustomSelectWrapper
+							className="filter-bar-modern__tier-select"
+							label={ translate( 'View' ) }
+							hideLabelFromVision={ false }
+							__next40pxDefaultSize
+							options={ tierOptions }
+							value={ tierValue }
+							onChange={ onTierSelect }
+						/>
+					) }
+				</div>
+			</div>
+		</>
 	);
 };
 

--- a/client/my-sites/themes/filter-bar-modern/index.tsx
+++ b/client/my-sites/themes/filter-bar-modern/index.tsx
@@ -1,0 +1,102 @@
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useMemo } from 'react';
+import { CategoryPillNavigation } from 'calypso/components/category-pill-navigation';
+import { CustomSelectWrapper } from 'calypso/my-sites/themes/custom-select-wrapper';
+
+import './style.scss';
+
+interface Category {
+	key: string;
+	text: string;
+}
+
+interface Tier {
+	key: string;
+	name: string;
+}
+
+interface FilterBarModernProps {
+	categories: Category[];
+	selectedCategory: string;
+	onCategorySelect: ( category: Category ) => void;
+	tiers: Tier[];
+	selectedTier: string;
+	onTierSelect: ( attrs: { selectedItem: Tier } ) => void;
+	showTierFilter?: boolean;
+}
+
+const FilterBarModern = ( {
+	categories,
+	selectedCategory,
+	onCategorySelect,
+	tiers,
+	selectedTier,
+	onTierSelect,
+	showTierFilter = true,
+}: FilterBarModernProps ) => {
+	const translate = useTranslate();
+
+	const pillCategories = useMemo(
+		() =>
+			categories.map( ( category ) => ( {
+				id: category.key,
+				label: category.text,
+				link: '#',
+			} ) ),
+		[ categories ]
+	);
+
+	const handleCategorySelect = useCallback(
+		( selectedId: string ) => {
+			const category = categories.find( ( c ) => c.key === selectedId );
+			if ( category ) {
+				onCategorySelect( category );
+			}
+		},
+		[ categories, onCategorySelect ]
+	);
+
+	const tierOptions = useMemo(
+		() =>
+			tiers.map( ( tier ) => ( {
+				...tier,
+				className: tier.key === selectedTier ? 'is-selected' : '',
+			} ) ),
+		[ tiers, selectedTier ]
+	);
+
+	const tierValue = useMemo( () => {
+		const selectedTierObj = tiers.find( ( t ) => t.key === selectedTier );
+		return {
+			key: selectedTier,
+			name: String(
+				translate( 'View: %s', {
+					args: selectedTierObj?.name ?? '',
+				} )
+			),
+		};
+	}, [ tiers, selectedTier, translate ] );
+
+	return (
+		<div className="filter-bar-modern">
+			<CategoryPillNavigation
+				categories={ pillCategories }
+				selectedCategoryId={ selectedCategory }
+				onSelect={ handleCategorySelect }
+			/>
+			{ showTierFilter && (
+				<CustomSelectWrapper
+					className="filter-bar-modern__tier-select"
+					label={ translate( 'View' ) }
+					hideLabelFromVision={ false }
+					__next40pxDefaultSize
+					options={ tierOptions }
+					value={ tierValue }
+					onChange={ onTierSelect }
+				/>
+			) }
+		</div>
+	);
+};
+
+export default FilterBarModern;

--- a/client/my-sites/themes/filter-bar-modern/index.tsx
+++ b/client/my-sites/themes/filter-bar-modern/index.tsx
@@ -116,6 +116,7 @@ const FilterBarModern = ( {
 						categories={ pillCategories }
 						selectedCategoryId={ selectedCategory }
 						onSelect={ handleCategorySelect }
+						disableMobileCollapse
 					/>
 					{ showTierFilter && (
 						<CustomSelectWrapper

--- a/client/my-sites/themes/filter-bar-modern/style.scss
+++ b/client/my-sites/themes/filter-bar-modern/style.scss
@@ -28,6 +28,7 @@
 	margin: 0 auto;
 	max-width: 1220px;
 	padding: 40px 24px 16px 24px; // Top padding adjusted +24px to accommodate the external tier label
+	overflow-x: auto;
 
 	@media ( min-width: $break-wide ) {
 		padding-left: 0;
@@ -45,6 +46,12 @@
 		border: 1px solid #f2f2f2;
 		border-radius: 4px;
 
+		input {
+			@media ( min-width: $break-small ) {
+				font-size: rem( 13px );
+			}
+		}
+
 		.search__icon-navigation {
 			border-radius: 4px;
 		}
@@ -61,17 +68,34 @@
 		}
 	}
 	.search.is-open {
-		border: 1px solid #c3c4c7;
+		border: 1px solid var( --studio-gray-10 );
 	}
 }
 
 .filter-bar-modern__tier-select {
 	flex-shrink: 0;
+	margin-left: 16px;
 	margin-top: -24px; // Accommodate the external label
 	min-width: 120px;
+
+	@media ( min-width: $break-mobile ) {
+		margin-left: 0;
+	}
+
+	.components-input-control__container {
+		border-radius: 4px;
+	}
+
+	button {
+		height: 44px;
+	}
 
 	.components-custom-select-control__item.is-selected {
 		background-color: var( --studio-gray-80 );
 		color: var( --studio-white );
+	}
+
+	.components-input-base .components-input-control__container .components-input-control__backdrop {
+		border: 1px solid var( --studio-gray-10 );
 	}
 }

--- a/client/my-sites/themes/filter-bar-modern/style.scss
+++ b/client/my-sites/themes/filter-bar-modern/style.scss
@@ -2,15 +2,14 @@
 @import '@automattic/typography/styles/variables';
 
 .filter-bar-modern {
-	align-items: center;
-	display: flex;
+	background-color: var( --studio-white );
 	gap: 16px;
-	margin: 0 auto;
-	max-width: 1220px;
-	padding: 16px 24px;
+	position: sticky;
+	top: 0;
+	z-index: 3;
 
-	@media ( min-width: $break-wide ) {
-		padding: 16px 0;
+	&.is-sticky {
+		box-shadow: 0 0 8px hsla(0, 0%, 0%, 0.08); // Same as pattern-library
 	}
 
 	.category-pill-navigation {
@@ -18,17 +17,32 @@
 		min-width: 0;
 	}
 
-	// Override pill shape to be rounded (pill-shaped) per design specs
 	.category-pill-navigation__button {
 		text-decoration: none;
 	}
 }
 
+.filter-bar-modern__content {
+	align-items: center;
+	display: flex;
+	margin: 0 auto;
+	max-width: 1220px;
+	padding: 40px 24px 16px 24px; // Top padding adjusted +24px to accommodate the external tier label
+
+	@media ( min-width: $break-wide ) {
+		padding-left: 0;
+		padding-right: 0;
+	}
+}
+
+
 .filter-bar-modern__tier-select {
 	flex-shrink: 0;
-	min-width: 160px;
+	margin-top: -24px; // Accommodate the external label
+	min-width: 120px;
 
 	.components-custom-select-control__item.is-selected {
-		background-color: var( --wp-components-color-gray-300, #ddd );
+		background-color: var( --studio-gray-80 );
+		color: var( --studio-white );
 	}
 }

--- a/client/my-sites/themes/filter-bar-modern/style.scss
+++ b/client/my-sites/themes/filter-bar-modern/style.scss
@@ -36,6 +36,35 @@
 }
 
 
+.filter-bar-modern__search {
+	flex-shrink: 0;
+
+	.search {
+		margin-bottom: 0;
+		height: 42px;
+		border: 1px solid #f2f2f2;
+		border-radius: 4px;
+
+		.search__icon-navigation {
+			border-radius: 4px;
+		}
+	}
+	.search:not(.is-open) {
+		width: 42px;
+
+		.search__icon-navigation {
+			background: #f2f2f2;
+
+			svg {
+				width: 42px;
+			}
+		}
+	}
+	.search.is-open {
+		border: 1px solid #c3c4c7;
+	}
+}
+
 .filter-bar-modern__tier-select {
 	flex-shrink: 0;
 	margin-top: -24px; // Accommodate the external label

--- a/client/my-sites/themes/filter-bar-modern/style.scss
+++ b/client/my-sites/themes/filter-bar-modern/style.scss
@@ -28,7 +28,6 @@
 	margin: 0 auto;
 	max-width: 1220px;
 	padding: 40px 24px 16px 24px; // Top padding adjusted +24px to accommodate the external tier label
-	overflow-x: auto;
 
 	@media ( min-width: $break-wide ) {
 		padding-left: 0;

--- a/client/my-sites/themes/filter-bar-modern/style.scss
+++ b/client/my-sites/themes/filter-bar-modern/style.scss
@@ -1,0 +1,34 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@automattic/typography/styles/variables';
+
+.filter-bar-modern {
+	align-items: center;
+	display: flex;
+	gap: 16px;
+	margin: 0 auto;
+	max-width: 1220px;
+	padding: 16px 24px;
+
+	@media ( min-width: $break-wide ) {
+		padding: 16px 0;
+	}
+
+	.category-pill-navigation {
+		flex: 1;
+		min-width: 0;
+	}
+
+	// Override pill shape to be rounded (pill-shaped) per design specs
+	.category-pill-navigation__button {
+		text-decoration: none;
+	}
+}
+
+.filter-bar-modern__tier-select {
+	flex-shrink: 0;
+	min-width: 160px;
+
+	.components-custom-select-control__item.is-selected {
+		background-color: var( --wp-components-color-gray-300, #ddd );
+	}
+}

--- a/client/my-sites/themes/filter-bar-modern/test/index.test.tsx
+++ b/client/my-sites/themes/filter-bar-modern/test/index.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import FilterBarModern from '../index';
+
+// Mock CategoryPillNavigation to avoid its internal dependencies (LocalizedLink, Redux, etc.)
+const mockOnSelect = jest.fn();
+jest.mock( 'calypso/components/category-pill-navigation', () => ( {
+	CategoryPillNavigation: ( {
+		categories,
+		selectedCategoryId,
+		onSelect,
+	}: {
+		categories: Array< { id: string; label: string; link: string } >;
+		selectedCategoryId: string;
+		onSelect: ( id: string ) => void;
+	} ) => {
+		mockOnSelect.mockImplementation( onSelect );
+		return (
+			<div data-testid="category-pill-navigation">
+				{ categories.map( ( category ) => (
+					<button
+						key={ category.id }
+						onClick={ () => onSelect( category.id ) }
+						className={ category.id === selectedCategoryId ? 'is-active' : '' }
+					>
+						{ category.label }
+					</button>
+				) ) }
+			</div>
+		);
+	},
+} ) );
+
+// Mock CustomSelectWrapper to avoid SSR/WP component dependencies
+jest.mock( 'calypso/my-sites/themes/custom-select-wrapper', () => ( {
+	CustomSelectWrapper: ( {
+		options,
+		value,
+		onChange,
+		label,
+		className,
+	}: {
+		options: Array< { key: string; name: string } >;
+		value: { key: string; name: string };
+		onChange: ( attrs: { selectedItem: { key: string; name: string } } ) => void;
+		label: string;
+		className: string;
+		hideLabelFromVision?: boolean;
+		__next40pxDefaultSize?: boolean;
+	} ) => (
+		<div data-testid="tier-select" className={ className }>
+			<label>{ label }</label>
+			<select
+				value={ value.key }
+				onChange={ ( e ) => {
+					const tier = options.find( ( t ) => t.key === e.target.value );
+					if ( tier ) {
+						onChange( { selectedItem: tier } );
+					}
+				} }
+			>
+				{ options.map( ( option ) => (
+					<option key={ option.key } value={ option.key }>
+						{ option.name }
+					</option>
+				) ) }
+			</select>
+		</div>
+	),
+} ) );
+
+describe( 'FilterBarModern', () => {
+	const defaultProps = {
+		categories: [
+			{ key: 'recommended', text: 'Recommended' },
+			{ key: 'all', text: 'All' },
+			{ key: 'blog', text: 'Blog' },
+		],
+		selectedCategory: 'recommended',
+		onCategorySelect: jest.fn(),
+		tiers: [
+			{ key: 'all', name: 'All' },
+			{ key: 'free', name: 'Free' },
+			{ key: 'premium', name: 'Premium' },
+		],
+		selectedTier: 'all',
+		onTierSelect: jest.fn(),
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'renders category pills via CategoryPillNavigation', () => {
+		render( <FilterBarModern { ...defaultProps } /> );
+		expect( screen.getByTestId( 'category-pill-navigation' ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Recommended' } ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'All' } ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Blog' } ) ).toBeVisible();
+	} );
+
+	test( 'calls onCategorySelect when a pill is clicked', async () => {
+		const user = userEvent.setup();
+		render( <FilterBarModern { ...defaultProps } /> );
+		await user.click( screen.getByRole( 'button', { name: 'Blog' } ) );
+		expect( defaultProps.onCategorySelect ).toHaveBeenCalledWith(
+			expect.objectContaining( { key: 'blog' } )
+		);
+	} );
+
+	test( 'renders tier dropdown when showTierFilter is true', () => {
+		render( <FilterBarModern { ...defaultProps } showTierFilter /> );
+		expect( screen.getByTestId( 'tier-select' ) ).toBeVisible();
+	} );
+
+	test( 'hides tier dropdown when showTierFilter is false', () => {
+		render( <FilterBarModern { ...defaultProps } showTierFilter={ false } /> );
+		expect( screen.queryByTestId( 'tier-select' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders tier dropdown by default', () => {
+		render( <FilterBarModern { ...defaultProps } /> );
+		expect( screen.getByTestId( 'tier-select' ) ).toBeVisible();
+	} );
+
+	test( 'calls onTierSelect when tier changes', async () => {
+		const user = userEvent.setup();
+		render( <FilterBarModern { ...defaultProps } /> );
+		await user.selectOptions( screen.getByRole( 'combobox' ), 'free' );
+		expect( defaultProps.onTierSelect ).toHaveBeenCalledWith( {
+			selectedItem: expect.objectContaining( { key: 'free', name: 'Free' } ),
+		} );
+	} );
+} );

--- a/client/my-sites/themes/filter-bar-modern/test/index.test.tsx
+++ b/client/my-sites/themes/filter-bar-modern/test/index.test.tsx
@@ -1,9 +1,65 @@
 /**
  * @jest-environment jsdom
  */
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import FilterBarModern from '../index';
+
+// Mock InView to control sticky state in tests
+let mockInViewOnChange: ( inView: boolean ) => void;
+jest.mock( 'react-intersection-observer', () => ( {
+	InView: ( {
+		children,
+		onChange,
+	}: {
+		children: React.ReactNode;
+		onChange: ( inView: boolean ) => void;
+	} ) => {
+		mockInViewOnChange = onChange;
+		return <div data-testid="inview-sentinel">{ children }</div>;
+	},
+} ) );
+
+// Mock Search component
+jest.mock( 'calypso/components/search', () => {
+	const SearchMock = ( {
+		onSearch,
+		onSearchOpen,
+		onSearchClose,
+		placeholder,
+		isOpen,
+	}: {
+		onSearch: ( query: string ) => void;
+		onSearchOpen: () => void;
+		onSearchClose: () => void;
+		placeholder: string;
+		isOpen: boolean;
+		pinned?: boolean;
+		initialValue?: string;
+		searchMode?: string;
+	} ) => (
+		<div data-testid="search">
+			<input
+				type="text"
+				placeholder={ placeholder }
+				onChange={ ( e ) => onSearch( e.target.value ) }
+				data-is-open={ isOpen }
+			/>
+			<button data-testid="search-open" onClick={ onSearchOpen }>
+				Open
+			</button>
+			<button data-testid="search-close" onClick={ onSearchClose }>
+				Close
+			</button>
+		</div>
+	);
+	SearchMock.displayName = 'Search';
+	return {
+		__esModule: true,
+		default: SearchMock,
+		SEARCH_MODE_ON_ENTER: 'on-enter',
+	};
+} );
 
 // Mock CategoryPillNavigation to avoid its internal dependencies (LocalizedLink, Redux, etc.)
 const mockOnSelect = jest.fn();
@@ -132,6 +188,57 @@ describe( 'FilterBarModern', () => {
 		await user.selectOptions( screen.getByRole( 'combobox' ), 'free' );
 		expect( defaultProps.onTierSelect ).toHaveBeenCalledWith( {
 			selectedItem: expect.objectContaining( { key: 'free', name: 'Free' } ),
+		} );
+	} );
+
+	describe( 'search', () => {
+		const propsWithSearch = {
+			...defaultProps,
+			searchQuery: 'hello',
+			onSearch: jest.fn(),
+		};
+
+		test( 'does not render search when not sticky', () => {
+			render( <FilterBarModern { ...propsWithSearch } /> );
+			expect( screen.queryByTestId( 'search' ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'renders search when sticky and onSearch is provided', () => {
+			render( <FilterBarModern { ...propsWithSearch } /> );
+			// Simulate scrolling past the sentinel (inView = false → sticky)
+			act( () => mockInViewOnChange( false ) );
+			expect( screen.getByTestId( 'search' ) ).toBeVisible();
+		} );
+
+		test( 'does not render search when sticky but onSearch is not provided', () => {
+			render( <FilterBarModern { ...defaultProps } /> );
+			act( () => mockInViewOnChange( false ) );
+			expect( screen.queryByTestId( 'search' ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'search opens and closes', async () => {
+			const user = userEvent.setup();
+			render( <FilterBarModern { ...propsWithSearch } /> );
+			act( () => mockInViewOnChange( false ) );
+
+			const input = screen.getByRole( 'textbox' );
+			expect( input ).toHaveAttribute( 'data-is-open', 'false' );
+
+			await user.click( screen.getByTestId( 'search-open' ) );
+			expect( input ).toHaveAttribute( 'data-is-open', 'true' );
+
+			await user.click( screen.getByTestId( 'search-close' ) );
+			expect( input ).toHaveAttribute( 'data-is-open', 'false' );
+		} );
+
+		test( 'calls onSearch when typing', async () => {
+			const user = userEvent.setup();
+			render( <FilterBarModern { ...propsWithSearch } /> );
+			act( () => mockInViewOnChange( false ) );
+
+			const input = screen.getByRole( 'textbox' );
+			await user.type( input, 'blog' );
+			expect( propsWithSearch.onSearch ).toHaveBeenCalled();
 		} );
 	} );
 } );


### PR DESCRIPTION
Fixes DOTTHEM-303

## Proposed Changes

<img width="1237" height="86" alt="Screenshot 2026-03-02 at 17 50 12" src="https://github.com/user-attachments/assets/88c58dcf-b448-4097-b48c-f6407ccf89cb" />

- Add a new `FilterBarModern` component that combines category pill navigation, tier dropdown, and a collapsible sticky search into a single filter bar for the modernized theme showcase.
- Add a `disableMobileCollapse` prop to the shared `CategoryPillNavigation` component to prevent it from collapsing into a dropdown on small screens.

## Why are these changes being made?

The modernized theme showcase (logged-out experience) needs a unified filter bar that replaces the existing separate toolbar group and search controls. `FilterBarModern` reuses existing components (`CategoryPillNavigation`, `CustomSelectWrapper`, `Search`) and self-contains sticky behavior via `InView`.

## Testing Instructions

This PR introduces the `FilterBarModern` component but does not yet wire it into the theme showcase. To visually test it, add the following to `client/my-sites/themes/theme-showcase.jsx`:

1. Import the component:
```js
import FilterBarModern from './filter-bar-modern';
```

2. Render it right above the `themes__controls` div (around line 693):
```jsx
<FilterBarModern
  categories={ Object.values( tabFilters ) }
  selectedCategory={ this.getSelectedTabFilter().key }
  onCategorySelect={ ( category ) => this.onFilterClick( category ) }
  tiers={ tiers }
  selectedTier={ tier }
  onTierSelect={ this.onTierSelectFilter }
  showTierFilter={ premiumThemesEnabled && ! isMultisite }
  searchQuery={ search }
  onSearch={ this.doSearch }
/>
```

Then visit `/themes` (logged in or out) to see it side by side with the existing controls.

- Verify category pills render and are horizontally scrollable
- Verify the tier dropdown ("View") opens and selects correctly
- Scroll down to verify the sticky shadow appears
- When sticky, verify the search icon appears and expands/collapses on click
- Resize to mobile widths and verify the category pills do not collapse into a dropdown

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?