### PR TITLE
Image Studio: Use __i18n_text_domain__ for all translatable strings

### DIFF
--- a/packages/image-studio/src/components/header/index.tsx
+++ b/packages/image-studio/src/components/header/index.tsx
@@ -122,10 +122,10 @@ export const Header = ( {
 			case ImageStudioEntryPoint.EditorSidebar:
 			case ImageStudioEntryPoint.JetpackExternalMediaBlock:
 			case ImageStudioEntryPoint.JetpackExternalMediaFeaturedImage:
-				return __( 'Save & Apply', 'big-sky' );
+				return __( 'Save & Apply', __i18n_text_domain__ );
 			case ImageStudioEntryPoint.MediaLibrary:
 			default:
-				return __( 'Save', 'big-sky' );
+				return __( 'Save', __i18n_text_domain__ );
 		}
 	};
 
@@ -138,16 +138,16 @@ export const Header = ( {
 			case ImageStudioEntryPoint.EditorSidebar:
 			case ImageStudioEntryPoint.JetpackExternalMediaBlock:
 			case ImageStudioEntryPoint.JetpackExternalMediaFeaturedImage:
-				return __( 'Save and apply image', 'big-sky' );
+				return __( 'Save and apply image', __i18n_text_domain__ );
 			case ImageStudioEntryPoint.MediaLibrary:
 			default:
-				return __( 'Save displayed image to Media Library', 'big-sky' );
+				return __( 'Save displayed image to Media Library', __i18n_text_domain__ );
 		}
 	};
 
 	let navButtonDisabledTooltip: string | undefined;
 	if ( hasDrafts || hasUpdatedMetadata ) {
-		navButtonDisabledTooltip = __( 'Save or discard your changes', 'big-sky' );
+		navButtonDisabledTooltip = __( 'Save or discard your changes', __i18n_text_domain__ );
 	}
 
 	useKeyboardShortcut( 'mod+z', () => onAnnotationUndo?.(), {
@@ -359,7 +359,9 @@ export const Header = ( {
 								isBusy={ isSaving }
 								onClick={ onSave }
 								label={ getSaveButtonLabel( entryPoint ) }
-								text={ isSaving ? __( 'Saving…', 'big-sky' ) : getSaveButtonText( entryPoint ) }
+								text={
+									isSaving ? __( 'Saving…', __i18n_text_domain__ ) : getSaveButtonText( entryPoint )
+								}
 							/>
 						</Fragment>
 					) }

--- a/packages/image-studio/src/components/image-feedback-buttons/index.tsx
+++ b/packages/image-studio/src/components/image-feedback-buttons/index.tsx
@@ -83,19 +83,19 @@ export const ImageFeedbackButtons = ( {
 			actions: [
 				{
 					id: 'feedback-up',
-					label: __( 'Good response', 'default' ),
+					label: __( 'Good response', __i18n_text_domain__ ),
 					icon: <ThumbsUpIcon />,
 					onClick: () => handleFeedback( 'up' ),
-					tooltip: __( 'Good response', 'default' ),
+					tooltip: __( 'Good response', __i18n_text_domain__ ),
 					disabled: selectedFeedback === 'down',
 					pressed: selectedFeedback === 'up',
 				},
 				{
 					id: 'feedback-down',
-					label: __( 'Bad response', 'default' ),
+					label: __( 'Bad response', __i18n_text_domain__ ),
 					icon: <ThumbsDownIcon />,
 					onClick: () => handleFeedback( 'down' ),
-					tooltip: __( 'Bad response', 'default' ),
+					tooltip: __( 'Bad response', __i18n_text_domain__ ),
 					disabled: selectedFeedback === 'up',
 					pressed: selectedFeedback === 'down',
 				},

--- a/packages/image-studio/src/components/index.tsx
+++ b/packages/image-studio/src/components/index.tsx
@@ -527,7 +527,7 @@ const ImageStudioContent = withInstanceId(
 									/>
 								) : (
 									<div className="image-studio-agent-loading">
-										{ __( 'Loading AI assistant…', 'big-sky' ) }
+										{ __( 'Loading AI assistant…', __i18n_text_domain__ ) }
 									</div>
 								)
 							}

--- a/packages/image-studio/src/components/sidebar/index.tsx
+++ b/packages/image-studio/src/components/sidebar/index.tsx
@@ -58,7 +58,7 @@ export function ImageStudioAltTextSidebar( {
 
 	let deletePermanentlyDisabledTooltip: string | undefined;
 	if ( ! canDeletePermanently ) {
-		deletePermanentlyDisabledTooltip = __( 'Save or discard your changes', 'big-sky' );
+		deletePermanentlyDisabledTooltip = __( 'Save or discard your changes', __i18n_text_domain__ );
 	}
 
 	const attachmentId = useSelect(
@@ -149,26 +149,28 @@ export function ImageStudioAltTextSidebar( {
 						variant="link"
 						isDestructive
 						disabled={ ! canDeletePermanently }
-						label={ deletePermanentlyDisabledTooltip || __( 'Delete permanently', 'big-sky' ) }
+						label={
+							deletePermanentlyDisabledTooltip || __( 'Delete permanently', __i18n_text_domain__ )
+						}
 						showTooltip
 						accessibleWhenDisabled={ !! deletePermanentlyDisabledTooltip }
 						onClick={ () => setIsDeleteDialogOpen( true ) }
 					>
-						{ __( 'Delete permanently', 'big-sky' ) }
+						{ __( 'Delete permanently', __i18n_text_domain__ ) }
 					</Button>
 					{ isDeleteDialogOpen && (
 						<ConfirmationDialog
 							isOpen={ isDeleteDialogOpen }
 							onClose={ () => setIsDeleteDialogOpen( false ) }
-							title={ __( 'Delete this item', 'big-sky' ) }
+							title={ __( 'Delete this item', __i18n_text_domain__ ) }
 							actions={ [
 								{
-									text: __( 'Cancel', 'big-sky' ),
+									text: __( 'Cancel', __i18n_text_domain__ ),
 									onClick: () => setIsDeleteDialogOpen( false ),
 									variant: 'secondary',
 								},
 								{
-									text: __( 'Delete permanently', 'big-sky' ),
+									text: __( 'Delete permanently', __i18n_text_domain__ ),
 									onClick: async () => {
 										// Close dialog first to prevent interaction during deletion
 										// The exit overlay will appear once deletion starts
@@ -184,7 +186,7 @@ export function ImageStudioAltTextSidebar( {
 						>
 							{ __(
 								'You are about to permanently delete this item from your site. This action cannot be undone.',
-								'big-sky'
+								__i18n_text_domain__
 							) }
 						</ConfirmationDialog>
 					) }

--- a/packages/image-studio/src/hooks/use-delete-permanently.ts
+++ b/packages/image-studio/src/hooks/use-delete-permanently.ts
@@ -137,7 +137,7 @@ export function useDeletePermanently( {
 		const targetAttachmentId = attachmentIdRef.current;
 
 		if ( ! targetAttachmentId ) {
-			addNoticeRef.current( __( 'Cannot delete - no image found', 'big-sky' ), 'error' );
+			addNoticeRef.current( __( 'Cannot delete - no image found', __i18n_text_domain__ ), 'error' );
 			isDeletingRef.current = false;
 			setIsExiting( false );
 			return;
@@ -184,7 +184,10 @@ export function useDeletePermanently( {
 			// and page reload on upload.php so the deleted image is removed from the grid
 			onExitRef.current( true );
 		} catch ( error ) {
-			addNoticeRef.current( __( 'Failed to delete image. Please try again.', 'big-sky' ), 'error' );
+			addNoticeRef.current(
+				__( 'Failed to delete image. Please try again.', __i18n_text_domain__ ),
+				'error'
+			);
 
 			trackImageStudioError( {
 				mode,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of FORNO-222

## Proposed Changes

* Replace 16 hardcoded 'big-sky' and 'default' text domains with __i18n_text_domain__ across 5 files in packages/image-studio

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* After the BigSky feature parity PR (#108710) was merged, some translatable strings in Image Studio were still using hardcoded text domains ('big-sky' or 'default') instead of the build-time `__i18n_text_domain__` variable. This fixes those.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch and run yarn install
- Run `yarn test-packages --testPathPattern='packages/image-studio'` and confirm all tests pass
- Verify no remaining hardcoded text domains: `grep -rn "'big-sky'" packages/image-studio/src/`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
