### PR TITLE
Image Studio: Persist metadata to attachment on canvas update

### DIFF
--- a/packages/image-studio/src/abilities/update-canvas-image.ts
+++ b/packages/image-studio/src/abilities/update-canvas-image.ts
@@ -146,9 +146,47 @@ export async function registerUpdateCanvasImageAbility(): Promise< void > {
 					metadata = { ...metadata, [ key ]: value };
 				}
 
-				if ( metadata !== canvasMetadata ) {
+				const hasNewMetadata = Object.keys( input?.metadata || {} ).length > 0;
+				const hasMetadataChanged = Object.entries( metadata ).some(
+					( [ key, value ] ) => canvasMetadata[ key as keyof CanvasMetadata ] !== value
+				);
+				const shouldCopyExistingMetadata = ! hasNewMetadata && mode === ImageStudioMode.Edit;
+				const shouldPersistMetadata = shouldCopyExistingMetadata || hasNewMetadata;
+
+				if ( hasMetadataChanged ) {
 					setHasUpdatedMetadata( true );
 					setCanvasMetadata( metadata );
+				}
+
+				// Persist metadata to the attachment: either new metadata from the agent,
+				// or in edit mode, copy existing canvas metadata to the new attachment.
+				if ( shouldPersistMetadata ) {
+					const { title, caption, description, alt_text } = metadata;
+					try {
+						await dispatch( coreStore ).saveEntityRecord(
+							'postType',
+							'attachment',
+							{
+								id: attachmentId,
+								title,
+								caption,
+								description,
+								alt_text,
+							},
+							{ throwOnError: true }
+						);
+					} catch ( error ) {
+						window.console?.warn?.(
+							`[Image Studio] Failed to persist metadata for attachment ${ attachmentId }:`,
+							error
+						);
+
+						trackImageStudioError( {
+							mode,
+							errorType: 'save_metadata_failed',
+							attachmentId,
+						} );
+					}
 				}
 
 				// In Generate mode (originalAttachmentId is null), ALL images are drafts

--- a/packages/image-studio/src/utils/tracking.ts
+++ b/packages/image-studio/src/utils/tracking.ts
@@ -186,6 +186,7 @@ interface TrackImageStudioErrorOptions {
 		| 'draft_cleanup_failed'
 		| 'draft_cleanup_permission_denied'
 		| 'delete_permanently_failed'
+		| 'save_metadata_failed'
 		| 'other';
 	attachmentId?: number;
 }


### PR DESCRIPTION

Part of FORNO-227

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* Ports Big Sky PR 5663 to this repo.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* When images are generated or edited, metadata (title, caption, description, alt_text) is now saved to the attachment immediately via saveEntityRecord, rather than only on explicit user save. Prevents metadata loss when users close the tab without saving. In edit mode, existing canvas metadata is copied to the new attachment automatically.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `install-plugin.sh am forno-227-persist-site-metadata` on your sandbox
* Sandbox `widgets.wp.com`
* Enable Unified chat
* Follow testing steps from Big Sky PR 5663

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
