### PR TITLE
Dashboard: Filter CIAB domains listing

### DIFF
--- a/client/dashboard/app-ciab/index.tsx
+++ b/client/dashboard/app-ciab/index.tsx
@@ -3,6 +3,7 @@ import {
 	sitesQuery,
 	paginatedSitesQuery,
 	dashboardSiteFiltersQuery,
+	domainsQuery,
 } from '@automattic/api-queries';
 /* eslint-enable no-restricted-imports */
 import config from '@automattic/calypso-config';
@@ -56,5 +57,6 @@ boot( {
 			paginatedSitesQuery( [ 'commerce-garden' ], fetchSitesOptions ),
 		dashboardSiteFiltersQuery: ( fields: FetchDashboardSiteFiltersParams[ 'fields' ] ) =>
 			dashboardSiteFiltersQuery( [ 'commerce-garden' ], fields ),
+		domainsQuery: () => domainsQuery( { garden: 'commerce' } ),
 	},
 } );

--- a/client/dashboard/app-dotcom/index.tsx
+++ b/client/dashboard/app-dotcom/index.tsx
@@ -3,6 +3,7 @@ import {
 	sitesQuery,
 	paginatedSitesQuery,
 	dashboardSiteFiltersQuery,
+	domainsQuery,
 } from '@automattic/api-queries';
 /* eslint-enable no-restricted-imports */
 import boot from '../app/boot';
@@ -52,5 +53,6 @@ boot( {
 			paginatedSitesQuery( 'all', fetchSiteOptions ),
 		dashboardSiteFiltersQuery: ( fields: FetchDashboardSiteFiltersParams[ 'fields' ] ) =>
 			dashboardSiteFiltersQuery( 'all', fields ),
+		domainsQuery: () => domainsQuery(),
 	},
 } );

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -3,6 +3,7 @@ import {
 	sitesQuery,
 	paginatedSitesQuery,
 	dashboardSiteFiltersQuery,
+	domainsQuery,
 } from '@automattic/api-queries';
 /* eslint-enable no-restricted-imports */
 import { createContext, useContext } from 'react';
@@ -57,6 +58,7 @@ export type AppConfig = {
 		dashboardSiteFiltersQuery: (
 			field: FetchDashboardSiteFiltersParams[ 'fields' ]
 		) => ReturnType< typeof dashboardSiteFiltersQuery >;
+		domainsQuery: () => ReturnType< typeof domainsQuery >;
 	};
 };
 
@@ -87,6 +89,7 @@ export const APP_CONTEXT_DEFAULT_CONFIG: AppConfig = {
 			paginatedSitesQuery( 'all', fetchSiteOptions ),
 		dashboardSiteFiltersQuery: ( fields: FetchDashboardSiteFiltersParams[ 'fields' ] ) =>
 			dashboardSiteFiltersQuery( 'all', fields ),
+		domainsQuery: () => domainsQuery(),
 	},
 };
 

--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -7,7 +7,6 @@ import {
 	domainGlueRecordsQuery,
 	domainNameServersQuery,
 	sslDetailsQuery,
-	domainsQuery,
 	mailboxesQuery,
 	siteByIdQuery,
 	queryClient,
@@ -58,7 +57,7 @@ export const domainsIndexRoute = createRoute( {
 	path: '/',
 	loader: async ( { context } ) => {
 		await Promise.all( [
-			queryClient.ensureQueryData( domainsQuery() ),
+			queryClient.ensureQueryData( context.config.queries.domainsQuery() ),
 			queryClient.ensureQueryData( context.config.queries.sitesQuery() ),
 			queryClient.ensureQueryData( rawUserPreferencesQuery() ),
 		] );

--- a/client/dashboard/app/router/emails.tsx
+++ b/client/dashboard/app/router/emails.tsx
@@ -1,7 +1,6 @@
 import { EmailBox, isWpError } from '@automattic/api-core';
 import {
 	domainQuery,
-	domainsQuery,
 	mailboxAccountsQuery,
 	productsQuery,
 	queryClient,
@@ -36,10 +35,10 @@ export const emailsRoute = createRoute( {
 export const emailsIndexRoute = createRoute( {
 	getParentRoute: () => emailsRoute,
 	path: '/',
-	loader: async () => {
+	loader: async ( { context } ) => {
 		await Promise.all( [
 			queryClient.ensureQueryData( userMailboxesQuery() ),
-			queryClient.ensureQueryData( domainsQuery() ),
+			queryClient.ensureQueryData( context.config.queries.domainsQuery() ),
 			queryClient.ensureQueryData( rawUserPreferencesQuery() ),
 		] );
 	},
@@ -85,8 +84,8 @@ export const chooseDomainRoute = createRoute( {
 	} ),
 	getParentRoute: () => emailsRoute,
 	path: 'choose-domain',
-	loader: async () => {
-		queryClient.prefetchQuery( domainsQuery() );
+	loader: async ( { context } ) => {
+		queryClient.prefetchQuery( context.config.queries.domainsQuery() );
 	},
 } ).lazy( () =>
 	import( '../../emails/choose-domain' ).then( ( d ) =>

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -16,7 +16,6 @@ import {
 	siteDefensiveModeSettingsQuery,
 	siteDifmWebsiteContentQuery,
 	siteDomainsQuery,
-	domainsQuery,
 	siteJetpackModulesQuery,
 	siteJetpackSettingsQuery,
 	siteMediaStorageQuery,
@@ -608,12 +607,12 @@ export const siteSettingsSiteVisibilityRoute = createRoute( {
 			throw redirectAsNotAllowed( { to: siteSettingsRoute.fullPath, params: { siteSlug } } );
 		}
 	},
-	loader: async ( { params: { siteSlug } } ) => {
+	loader: async ( { context, params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 
 		await Promise.all( [
 			queryClient.ensureQueryData( siteSettingsQuery( site.ID ) ),
-			queryClient.ensureQueryData( domainsQuery() ),
+			queryClient.ensureQueryData( context.config.queries.domainsQuery() ),
 			site.is_coming_soon &&
 				hasPlanFeature( site, DotcomFeatures.SITE_PREVIEW_LINKS ) &&
 				queryClient.ensureQueryData( sitePreviewLinksQuery( site.ID ) ),

--- a/client/dashboard/domains/dataviews/bulk-actions-progress-notice.tsx
+++ b/client/dashboard/domains/dataviews/bulk-actions-progress-notice.tsx
@@ -1,7 +1,8 @@
-import { bulkDomainUpdateStatusQuery, domainsQuery } from '@automattic/api-queries';
+import { bulkDomainUpdateStatusQuery } from '@automattic/api-queries';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useEffect, useState } from 'react';
+import { useAppContext } from '../../app/context';
 import { Notice } from '../../components/notice';
 import type { BulkDomainUpdateStatusQueryFnData } from '@automattic/api-core';
 
@@ -19,6 +20,7 @@ const getLastJob = ( data: BulkDomainUpdateStatusQueryFnData | undefined ) => {
 export const BulkActionsProgressNotice = () => {
 	const [ lastId, setLastId ] = useState( '' );
 	const queryClient = useQueryClient();
+	const { queries } = useAppContext();
 	const [ shouldShowCompleteNotice, setShouldShowCompleteNotice ] = useState( false );
 
 	const { data } = useQuery( {
@@ -59,9 +61,9 @@ export const BulkActionsProgressNotice = () => {
 
 	useEffect( () => {
 		if ( shouldRefetchAllDomainsQuery ) {
-			queryClient.refetchQueries( domainsQuery() );
+			queryClient.refetchQueries( queries.domainsQuery() );
 		}
-	}, [ shouldRefetchAllDomainsQuery, queryClient ] );
+	}, [ shouldRefetchAllDomainsQuery, queryClient, queries ] );
 
 	if ( ! data ) {
 		return null;

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -1,9 +1,9 @@
 import { DomainStatus, DomainSubtype } from '@automattic/api-core';
-import { domainsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { dateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
+import { useAppContext } from '../../app/context';
 import { Text } from '../../components/text';
 import { DomainNameField } from './field-domain-name';
 import { DomainSiteField } from './field-domain-site';
@@ -24,7 +24,8 @@ export const useFields = ( {
 	showPrimaryDomainBadge?: boolean;
 	inOverview?: boolean;
 } = {} ) => {
-	const { data: domains } = useQuery( domainsQuery() );
+	const { queries } = useAppContext();
+	const { data: domains } = useQuery( queries.domainsQuery() );
 
 	const siteElements = useMemo( () => {
 		if ( ! domains ) {

--- a/client/dashboard/domains/domain/index.tsx
+++ b/client/dashboard/domains/domain/index.tsx
@@ -1,9 +1,10 @@
 import { DomainSubtype } from '@automattic/api-core';
-import { domainQuery, domainsQuery } from '@automattic/api-queries';
+import { domainQuery } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { Outlet } from '@tanstack/react-router';
 import { __experimentalHStack as HStack, Icon } from '@wordpress/components';
 import { globe } from '@wordpress/icons';
+import { useAppContext } from '../../app/context';
 import useBuildCurrentRouteLink from '../../app/hooks/use-build-current-route-link';
 import { domainRoute } from '../../app/router/domains';
 import HeaderBar from '../../components/header-bar';
@@ -13,9 +14,10 @@ import type { DomainSummary } from '@automattic/api-core';
 import './style.scss';
 
 function Domain() {
+	const { queries } = useAppContext();
 	const { domainName } = domainRoute.useParams();
 	const domains = useQuery( {
-		...domainsQuery(),
+		...queries.domainsQuery(),
 		select: ( data ) => {
 			return data.filter( ( domain ) => domain.subtype.id !== DomainSubtype.DEFAULT_ADDRESS );
 		},

--- a/client/dashboard/domains/index.tsx
+++ b/client/dashboard/domains/index.tsx
@@ -1,5 +1,4 @@
 import { DomainSubtype } from '@automattic/api-core';
-import { domainsQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
@@ -54,7 +53,7 @@ function Domains() {
 	} );
 
 	const { data: domains } = useSuspenseQuery( {
-		...domainsQuery(),
+		...queries.domainsQuery(),
 		select: ( data ) => {
 			return data.filter( ( domain ) => domain.subtype.id !== DomainSubtype.DEFAULT_ADDRESS );
 		},

--- a/client/dashboard/emails/choose-domain/index.tsx
+++ b/client/dashboard/emails/choose-domain/index.tsx
@@ -1,5 +1,4 @@
 import { Domain, DomainSubtype, DomainSummary } from '@automattic/api-core';
-import { domainsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import {
@@ -15,6 +14,7 @@ import { chevronLeft, chevronRight, Icon } from '@wordpress/icons';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import Breadcrumbs from '../../app/breadcrumbs';
+import { useAppContext } from '../../app/context';
 import { chooseEmailSolutionRoute } from '../../app/router/emails';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
@@ -24,9 +24,10 @@ import AddNewDomain from '../components/add-new-domain';
 import './styles.css';
 
 export default function ChooseDomain() {
+	const { queries } = useAppContext();
 	const router = useRouter();
 
-	const { data: allDomains, isLoading: isLoading } = useQuery( domainsQuery() );
+	const { data: allDomains, isLoading: isLoading } = useQuery( queries.domainsQuery() );
 	const eligibleDomains = ( allDomains ?? [] ).filter(
 		( d ) => d.current_user_is_owner && d.subtype.id !== DomainSubtype.DEFAULT_ADDRESS
 	);

--- a/client/dashboard/emails/index.tsx
+++ b/client/dashboard/emails/index.tsx
@@ -1,5 +1,5 @@
 import { DomainSubtype, EmailBox } from '@automattic/api-core';
-import { domainsQuery, userMailboxesQuery } from '@automattic/api-queries';
+import { userMailboxesQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { Button } from '@wordpress/components';
@@ -7,6 +7,7 @@ import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from 'react';
+import { useAppContext } from '../app/context';
 import { usePersistentView } from '../app/hooks/use-persistent-view';
 import { PerformanceTrackerStop } from '../app/performance-tracking';
 import { addEmailForwarderRoute, chooseDomainRoute, emailsRoute } from '../app/router/emails';
@@ -28,10 +29,11 @@ import type { Email } from './types';
 import './style.scss';
 
 function Emails() {
+	const { queries } = useAppContext();
 	const navigate = useNavigate();
 	const { data: allEmailAccounts } = useSuspenseQuery( userMailboxesQuery() );
 	const { domainName: domainNameFilter }: { domainName?: string } = emailsRoute.useSearch();
-	const { data: allDomains } = useSuspenseQuery( domainsQuery() );
+	const { data: allDomains } = useSuspenseQuery( queries.domainsQuery() );
 	const domains = ( allDomains ?? [] ).filter(
 		( d ) => d.current_user_is_owner && d.subtype.id !== DomainSubtype.DEFAULT_ADDRESS
 	);

--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -1,10 +1,11 @@
-import { domainsQuery, siteBySlugQuery, siteRedirectQuery } from '@automattic/api-queries';
+import { siteBySlugQuery, siteRedirectQuery } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useAuth } from '../../app/auth';
+import { useAppContext } from '../../app/context';
 import { usePersistentView } from '../../app/hooks/use-persistent-view';
 import { PerformanceTrackerStop } from '../../app/performance-tracking';
 import { siteRoute, siteDomainsRoute, siteSettingsRedirectRoute } from '../../app/router/sites';
@@ -28,11 +29,12 @@ function getDomainId( domain: DomainSummary ) {
 }
 
 function SiteDomains() {
+	const { queries } = useAppContext();
 	const { siteSlug } = siteRoute.useParams();
 	const { user } = useAuth();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: siteDomains, isLoading } = useQuery( {
-		...domainsQuery(),
+		...queries.domainsQuery(),
 		select: ( data ) => {
 			return data.filter( ( domain ) => domain.blog_id === site.ID );
 		},

--- a/client/dashboard/sites/overview-domains-card/index.tsx
+++ b/client/dashboard/sites/overview-domains-card/index.tsx
@@ -1,9 +1,10 @@
 import { DomainSubtype, type DomainSummary, type Site } from '@automattic/api-core';
-import { domainsQuery, siteCurrentPlanQuery } from '@automattic/api-queries';
+import { siteCurrentPlanQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
+import { useAppContext } from '../../app/context';
 import { siteDomainsRoute } from '../../app/router/sites';
 import { CalloutSkeleton } from '../../components/callout-skeleton';
 import { Card, CardHeader, CardBody } from '../../components/card';
@@ -81,10 +82,11 @@ const SiteDomainDataViews = ( { site, domains }: { site: Site; domains: DomainSu
 };
 
 export default function DomainsCard( { site }: { site: Site } ) {
+	const { queries } = useAppContext();
 	const isCommerceGardenSite = isCommerceGarden( site );
 	const { data: sitePlan } = useQuery( siteCurrentPlanQuery( site.ID ) );
 	const { data: siteDomains } = useQuery( {
-		...domainsQuery(),
+		...queries.domainsQuery(),
 		select: ( data ) => data.filter( ( domain ) => domain.blog_id === site.ID ),
 	} );
 

--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -1,11 +1,12 @@
 import { DomainSubtype } from '@automattic/api-core';
-import { domainsQuery, siteSettingsMutation } from '@automattic/api-queries';
+import { siteSettingsMutation } from '@automattic/api-queries';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { __experimentalVStack as VStack, Button, CheckboxControl } from '@wordpress/components';
 import { DataForm } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
+import { useAppContext } from '../../app/context';
 import { NavigationBlocker } from '../../app/navigation-blocker';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
@@ -118,8 +119,9 @@ const robotForm = {
 } satisfies Form;
 
 export function PrivacyForm( { site, settings }: { site: Site; settings: SiteSettings } ) {
+	const { queries } = useAppContext();
 	const { data: domains = [] } = useQuery( {
-		...domainsQuery(),
+		...queries.domainsQuery(),
 		select: ( data ) => {
 			return data.filter( ( domain ) => domain.blog_id === site.ID );
 		},

--- a/client/dashboard/sites/site-change-address-modal/content.tsx
+++ b/client/dashboard/sites/site-change-address-modal/content.tsx
@@ -2,7 +2,6 @@ import { DomainSubtype, FreeSiteAddressType } from '@automattic/api-core';
 import {
 	validateSiteAddressChangeMutation,
 	changeSiteAddressChangeMutation,
-	domainsQuery,
 } from '@automattic/api-queries';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
@@ -14,6 +13,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { check, closeSmall } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
+import { useAppContext } from '../../app/context';
 import { ButtonStack } from '../../components/button-stack';
 import SuffixInputControl from '../../components/input-control/suffix-input-control';
 import Notice from '../../components/notice';
@@ -65,9 +65,10 @@ const NewSiteAddressForm = ( {
 	onSubmit: ( data: NewSiteAddressFormData ) => void;
 	onCancel: () => void;
 } ) => {
+	const { queries } = useAppContext();
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const { data: siteDomains } = useQuery( {
-		...domainsQuery(),
+		...queries.domainsQuery(),
 		select: ( data ) => {
 			return data.filter( ( domain ) => domain.blog_id === site.ID );
 		},

--- a/client/dashboard/sites/site-launch-button/index.tsx
+++ b/client/dashboard/sites/site-launch-button/index.tsx
@@ -1,11 +1,12 @@
 import { DotcomPlans } from '@automattic/api-core';
-import { domainsQuery, siteLaunchMutation } from '@automattic/api-queries';
+import { siteLaunchMutation } from '@automattic/api-queries';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
+import { useAppContext } from '../../app/context';
 import { getCurrentDashboard } from '../../app/routing';
 import { redirectToDashboardLink, wpcomLink } from '../../utils/link';
 import {
@@ -30,9 +31,10 @@ export function SiteLaunchButton( {
 		onLaunch: () => void;
 	} >;
 } ) {
+	const { queries } = useAppContext();
 	const { recordTracksEvent } = useAnalytics();
 	const { data: domains = [], isLoading } = useQuery( {
-		...domainsQuery(),
+		...queries.domainsQuery(),
 		select: ( data ) => data.filter( ( domain ) => domain.blog_id === site.ID ),
 	} );
 	const launchMutation = useMutation( {

--- a/packages/api-core/src/domains/fetchers.ts
+++ b/packages/api-core/src/domains/fetchers.ts
@@ -1,8 +1,19 @@
 import { wpcom } from '../wpcom-fetcher';
 import type { BulkDomainUpdateStatusQueryFnData, DomainSummary } from './types';
 
-export async function fetchDomains(): Promise< DomainSummary[] > {
-	const { domains } = await wpcom.req.get( { path: '/all-domains', apiVersion: '1.2' } );
+export interface FetchDomainsOptions {
+	garden?: string;
+}
+
+export async function fetchDomains( options?: FetchDomainsOptions ): Promise< DomainSummary[] > {
+	const queryParams: Record< string, string > = {};
+	if ( options?.garden ) {
+		queryParams.garden = options.garden;
+	}
+	const { domains } = await wpcom.req.get(
+		{ path: '/all-domains', apiVersion: '1.2' },
+		queryParams
+	);
 	return domains;
 }
 

--- a/packages/api-queries/src/domain-transfer.ts
+++ b/packages/api-queries/src/domain-transfer.ts
@@ -13,7 +13,6 @@ import {
 } from '@automattic/api-core';
 import { mutationOptions, queryOptions } from '@tanstack/react-query';
 import { domainQuery } from './domain';
-import { domainsQuery } from './domains';
 import { queryClient } from './query-client';
 import type { Domain } from '@automattic/api-core';
 
@@ -79,7 +78,7 @@ export const domainTransferToUserMutation = ( domain: string, siteId: number ) =
 	mutationOptions( {
 		mutationFn: ( userId: string ) => domainTransferToUser( domain, siteId, userId ),
 		onSuccess: () => {
-			queryClient.invalidateQueries( domainsQuery() );
+			queryClient.invalidateQueries( { queryKey: [ 'domains' ] } );
 		},
 	} );
 
@@ -103,6 +102,6 @@ export const startDomainInboundTransferMutation = ( domain: string, siteId: numb
 		onSuccess: () => {
 			queryClient.invalidateQueries( domainQuery( domain ) );
 			queryClient.invalidateQueries( domainInboundTransferStatusQuery( domain ) );
-			queryClient.invalidateQueries( domainsQuery() );
+			queryClient.invalidateQueries( { queryKey: [ 'domains' ] } );
 		},
 	} );

--- a/packages/api-queries/src/domains.ts
+++ b/packages/api-queries/src/domains.ts
@@ -6,19 +6,20 @@ import {
 	DomainUpdateStatus,
 	fetchAvailableTlds,
 	fetchBulkDomainUpdateStatus,
+	fetchDomains,
 	fetchDomainSuggestions,
 	fetchFreeDomainSuggestion,
+	type FetchDomainsOptions,
 	type JobStatus,
 	type DomainSuggestionQuery,
 } from '@automattic/api-core';
-import { fetchDomains } from '@automattic/api-core';
 import { mutationOptions, queryOptions } from '@tanstack/react-query';
 import { queryClient } from './query-client';
 
-export const domainsQuery = () =>
+export const domainsQuery = ( options?: FetchDomainsOptions ) =>
 	queryOptions( {
-		queryKey: [ 'domains' ],
-		queryFn: fetchDomains,
+		queryKey: [ 'domains', ...( options ? [ options ] : [] ) ],
+		queryFn: () => fetchDomains( options ),
 	} );
 
 export const domainSuggestionsQuery = (

--- a/packages/api-queries/src/domains.ts
+++ b/packages/api-queries/src/domains.ts
@@ -18,7 +18,7 @@ import { queryClient } from './query-client';
 
 export const domainsQuery = ( options?: FetchDomainsOptions ) =>
 	queryOptions( {
-		queryKey: [ 'domains', ...( options ? [ options ] : [] ) ],
+		queryKey: [ 'domains', options ],
 		queryFn: () => fetchDomains( options ),
 	} );
 

--- a/packages/api-queries/src/site-address-change.ts
+++ b/packages/api-queries/src/site-address-change.ts
@@ -5,7 +5,6 @@ import {
 	type ChangeSiteAddressData,
 } from '@automattic/api-core';
 import { mutationOptions } from '@tanstack/react-query';
-import { domainsQuery } from './domains';
 import { queryClient } from './query-client';
 import { siteQueryFilter } from './site';
 
@@ -19,6 +18,6 @@ export const changeSiteAddressChangeMutation = () =>
 		mutationFn: ( data: ChangeSiteAddressData ) => changeSiteAddress( data ),
 		onSuccess: ( data, { siteId } ) => {
 			queryClient.invalidateQueries( siteQueryFilter( siteId ) );
-			queryClient.invalidateQueries( domainsQuery() );
+			queryClient.invalidateQueries( { queryKey: [ 'domains' ] } );
 		},
 	} );

--- a/packages/api-queries/src/site-domains.ts
+++ b/packages/api-queries/src/site-domains.ts
@@ -1,6 +1,5 @@
 import { fetchSiteDomains, setPrimaryDomain } from '@automattic/api-core';
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
-import { domainsQuery } from './domains';
 import { queryClient } from './query-client';
 import { siteQueryFilter } from './site';
 
@@ -19,6 +18,6 @@ export const siteSetPrimaryDomainMutation = () =>
 			setPrimaryDomain( siteId, domain ),
 		onSuccess: ( data, { siteId } ) => {
 			queryClient.invalidateQueries( siteQueryFilter( siteId ) );
-			queryClient.invalidateQueries( domainsQuery() );
+			queryClient.invalidateQueries( { queryKey: [ 'domains' ] } );
 		},
 	} );


### PR DESCRIPTION
Part of DOMAINS-2036
Depends on 206132-ghe-Automattic/wpcom

## Proposed Changes

- Add `garden` parameter support to `fetchDomains()` in `@automattic/api-core` and `domainsQuery()` in `@automattic/api-queries`
- Add `domainsQuery` to the `AppConfig` context (following the same pattern as `sitesQuery`)
- Configure the CIAB dashboard to pass `{ garden: 'commerce' }` to filter domains to only the garden's domains
- Update all dashboard consumers to use the context-based `domainsQuery()` instead of importing directly

## Why are these changes being made?

The CIAB Domains listing page at `/ciab/domains` was showing all dotcom domains instead of only the commerce garden's domains. The `/rest/v1.2/all-domains` API call was missing the `?garden=commerce` query parameter that filters results to only the garden's domains.

## Testing Instructions

1. Navigate to the CIAB dashboard at `my.wordpress.com/ciab/domains`
2. Verify the domains listing only shows commerce garden domains
3. Verify the regular dotcom dashboard at `my.wordpress.com/domains` still shows all domains as before
4. Check the network tab to confirm the CIAB request includes `?garden=commerce` in the `/all-domains` API call

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)