### PR TITLE
Theme Showcase: Integrate FilterBarModern into ThemeShowcase

### DIFF
--- a/client/components/category-pill-navigation/index.tsx
+++ b/client/components/category-pill-navigation/index.tsx
@@ -22,6 +22,7 @@ type CategoryPillNavigationProps = {
 		id: string;
 		label?: string;
 		link: string;
+		icon?: React.ReactElement< typeof Icon >;
 	}[];
 	selectedCategoryId: string;
 	onSelect?: ( selectedId: string ) => void;
@@ -182,6 +183,7 @@ export const CategoryPillNavigation = ( {
 								'is-active': category.id === selectedCategoryId,
 							} ) }
 						>
+							{ category.icon }
 							{ category.label }
 						</LocalizedLink>
 					) ) }

--- a/client/components/theme-tier/constants.js
+++ b/client/components/theme-tier/constants.js
@@ -40,12 +40,18 @@ export const THEME_TIERS = {
 		get label() {
 			return getIncludedWithLabel( PLAN_PERSONAL );
 		},
+		get labelModern() {
+			return translate( 'Personal' );
+		},
 		minimumUpsellPlan: PLAN_PERSONAL,
 		isFilterable: true,
 	},
 	[ THEME_TIER_PREMIUM ]: {
 		get label() {
 			return getIncludedWithLabel( PLAN_PREMIUM );
+		},
+		get labelModern() {
+			return translate( 'Premium' );
 		},
 		minimumUpsellPlan: PLAN_PREMIUM,
 		isFilterable: true,

--- a/client/my-sites/themes/filter-bar-modern/index.tsx
+++ b/client/my-sites/themes/filter-bar-modern/index.tsx
@@ -52,15 +52,15 @@ const FilterBarModern = ( {
 			categories.map( ( category ) => ( {
 				id: category.key,
 				label: category.text,
-				// @ts-expect-error constructThemeShowcaseUrl is untyped JS
 				link: constructThemeShowcaseUrl( {
 					tier: selectedTier,
 					category: category.key,
 					search: searchQuery,
 					isLoggedIn: false,
 				} ),
-				icon:
-					category.key === DEFAULT_STATIC_FILTER ? <Icon icon={ starEmpty } size={ 26 } /> : null,
+				...( category.key === DEFAULT_STATIC_FILTER && {
+					icon: <Icon icon={ starEmpty } size={ 26 } />,
+				} ),
 			} ) ),
 		[ categories, searchQuery, selectedTier ]
 	);

--- a/client/my-sites/themes/filter-bar-modern/index.tsx
+++ b/client/my-sites/themes/filter-bar-modern/index.tsx
@@ -56,12 +56,13 @@ const FilterBarModern = ( {
 				link: constructThemeShowcaseUrl( {
 					tier: selectedTier,
 					category: category.key,
+					search: searchQuery,
 					isLoggedIn: false,
 				} ),
 				icon:
 					category.key === DEFAULT_STATIC_FILTER ? <Icon icon={ starEmpty } size={ 26 } /> : null,
 			} ) ),
-		[ categories, selectedTier ]
+		[ categories, searchQuery, selectedTier ]
 	);
 
 	const handleCategorySelect = useCallback(

--- a/client/my-sites/themes/filter-bar-modern/index.tsx
+++ b/client/my-sites/themes/filter-bar-modern/index.tsx
@@ -1,3 +1,4 @@
+import { Icon, starEmpty } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useState } from 'react';
@@ -5,7 +6,8 @@ import { InView } from 'react-intersection-observer';
 import { CategoryPillNavigation } from 'calypso/components/category-pill-navigation';
 import Search, { SEARCH_MODE_ON_ENTER } from 'calypso/components/search';
 import { CustomSelectWrapper } from 'calypso/my-sites/themes/custom-select-wrapper';
-
+import { DEFAULT_STATIC_FILTER } from 'calypso/state/themes/constants';
+import { constructThemeShowcaseUrl } from '../helpers';
 import './style.scss';
 
 interface Category {
@@ -50,9 +52,16 @@ const FilterBarModern = ( {
 			categories.map( ( category ) => ( {
 				id: category.key,
 				label: category.text,
-				link: '#',
+				// @ts-expect-error constructThemeShowcaseUrl is untyped JS
+				link: constructThemeShowcaseUrl( {
+					tier: selectedTier,
+					category: category.key,
+					isLoggedIn: false,
+				} ),
+				icon:
+					category.key === DEFAULT_STATIC_FILTER ? <Icon icon={ starEmpty } size={ 26 } /> : null,
 			} ) ),
-		[ categories ]
+		[ categories, selectedTier ]
 	);
 
 	const handleCategorySelect = useCallback(

--- a/client/my-sites/themes/filter-bar-modern/style.scss
+++ b/client/my-sites/themes/filter-bar-modern/style.scss
@@ -15,10 +15,14 @@
 	.category-pill-navigation {
 		flex: 1;
 		min-width: 0;
-	}
 
-	.category-pill-navigation__button {
-		text-decoration: none;
+		.category-pill-navigation__button {
+			text-decoration: none;
+
+			&:first-child {
+				margin-left: 0;
+			}
+		}
 	}
 }
 
@@ -38,6 +42,7 @@
 
 .filter-bar-modern__search {
 	flex-shrink: 0;
+	margin-right: 16px;
 
 	.search {
 		margin-bottom: 0;
@@ -73,7 +78,6 @@
 
 .filter-bar-modern__tier-select {
 	flex-shrink: 0;
-	margin-left: 16px;
 	margin-top: -24px; // Accommodate the external label
 	min-width: 120px;
 

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -167,6 +167,19 @@ export function isStaticFilter( currentFilter ) {
 	return Object.values( STATIC_FILTERS ).includes( currentFilter );
 }
 
+/**
+ * @param {Object} params
+ * @param {string} [params.category] Theme category slug, omitted from URL if it matches the default static filter.
+ * @param {string} [params.vertical] Vertical slug segment.
+ * @param {string} [params.tier] Pricing tier slug (e.g. "free", "premium"). Omitted when "all".
+ * @param {string} [params.filter] Additional filter segment appended as `/filter/{value}`.
+ * @param {string} [params.siteSlug] Site slug appended at the end of the URL.
+ * @param {string} [params.search] Search query string appended as a query parameter.
+ * @param {string} [params.locale] Locale code used to localize the resulting path.
+ * @param {boolean} [params.isLoggedIn] Whether the user is logged in, affects path localization.
+ * @param {boolean} [params.isCollectionView] Whether to include the `/collection` segment.
+ * @returns {string} The constructed theme showcase URL.
+ */
 export function constructThemeShowcaseUrl( {
 	category,
 	vertical,

--- a/client/my-sites/themes/hero-modern/style.scss
+++ b/client/my-sites/themes/hero-modern/style.scss
@@ -26,7 +26,7 @@ $hero-modern-navbar-height: 57px; // UniversalHeaderNavigation
 
 	.full-width-section__content {
 		max-width: 1220px;
-		padding: 48px 24px;
+		padding: 48px 0;
 
 		@media (min-width: $break-small) {
 			background: url(./illustration.svg) no-repeat right clamp(-500px, 70vw - 900px, 0px) bottom;
@@ -42,6 +42,11 @@ $hero-modern-navbar-height: 57px; // UniversalHeaderNavigation
 .hero-modern__content {
 	flex: 1;
 	max-width: 700px;
+	padding-left: 24px;
+
+	@media ( min-width: $break-wide ) {
+		padding-left: 0;
+	}
 }
 
 .hero-modern__title {

--- a/client/my-sites/themes/hero-modern/style.scss
+++ b/client/my-sites/themes/hero-modern/style.scss
@@ -42,7 +42,7 @@ $hero-modern-navbar-height: 57px; // UniversalHeaderNavigation
 .hero-modern__content {
 	flex: 1;
 	max-width: 700px;
-	padding-left: 24px;
+	padding: 0 24px;
 
 	@media ( min-width: $break-wide ) {
 		padding-left: 0;

--- a/client/my-sites/themes/test/logged-out.jsx
+++ b/client/my-sites/themes/test/logged-out.jsx
@@ -35,6 +35,8 @@ window.IntersectionObserver = jest.fn( () => ( {
 	unobserve: jest.fn(),
 } ) );
 
+Element.prototype.scrollBy = jest.fn();
+
 const themes = [
 	{
 		author: 'AudioTheme',

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -22,6 +22,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { THEME_COLLECTIONS } from 'calypso/my-sites/themes/collections/collection-definitions';
 import ShowcaseThemeCollection from 'calypso/my-sites/themes/collections/showcase-theme-collection';
 import ThemeCollectionViewHeader from 'calypso/my-sites/themes/collections/theme-collection-view-header';
+import FilterBarModern from 'calypso/my-sites/themes/filter-bar-modern';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
 import getSiteFeaturesById from 'calypso/state/selectors/get-site-features';
@@ -689,14 +690,32 @@ class ThemeShowcase extends Component {
 									/>
 								</InView>
 							) }
-							<div
-								className={ clsx( 'themes__controls', {
-									'is-sticky': this.state.shouldThemeControlsSticky,
-								} ) }
-							>
-								<div className="theme__search-container">
-									<div className="theme__search">
-										{ ! isThemeShowcaseModern && (
+							{ isThemeShowcaseModern ? (
+								<FilterBarModern
+									categories={ Object.values( tabFilters ) }
+									selectedCategory={ this.getSelectedTabFilter().key }
+									onCategorySelect={ ( category ) =>
+										this.onFilterClick(
+											Object.values( tabFilters ).find(
+												( tabFilter ) => tabFilter.key === category.key
+											)
+										)
+									}
+									tiers={ tiers }
+									selectedTier={ tier }
+									onTierSelect={ this.onTierSelectFilter }
+									searchQuery={ search }
+									onSearch={ this.doSearch }
+									showTierFilter={ !! tabFilters && premiumThemesEnabled && ! isMultisite }
+								/>
+							) : (
+								<div
+									className={ clsx( 'themes__controls', {
+										'is-sticky': this.state.shouldThemeControlsSticky,
+									} ) }
+								>
+									<div className="theme__search-container">
+										<div className="theme__search">
 											<div className="theme__search-input">
 												<SearchThemes
 													query={
@@ -706,45 +725,50 @@ class ThemeShowcase extends Component {
 													recordTracksEvent={ this.recordSearchThemesTracksEvent }
 												/>
 											</div>
-										) }
-										{ tabFilters && premiumThemesEnabled && ! isMultisite && (
-											<CustomSelectWrapper
-												className="theme__tier-select"
-												label={ translate( 'Filters' ) }
-												hideLabelFromVision
-												__next40pxDefaultSize
-												options={ tiers.map( ( t ) => {
-													return { ...t, className: t.key === tier ? 'is-selected' : '' };
-												} ) }
-												value={ {
-													key: tier,
-													name: translate( 'View: %s', {
-														args: this.getTiers().find( ( t ) => t.key === tier ).name,
-													} ),
-												} }
-												onChange={ this.onTierSelectFilter }
+											{ tabFilters && premiumThemesEnabled && ! isMultisite && (
+												<CustomSelectWrapper
+													className="theme__tier-select"
+													label={ translate( 'Filters' ) }
+													hideLabelFromVision
+													__next40pxDefaultSize
+													options={ tiers.map( ( t ) => {
+														return {
+															...t,
+															className: t.key === tier ? 'is-selected' : '',
+														};
+													} ) }
+													value={ {
+														key: tier,
+														name: translate( 'View: %s', {
+															args: this.getTiers().find( ( t ) => t.key === tier ).name,
+														} ),
+													} }
+													onChange={ this.onTierSelectFilter }
+												/>
+											) }
+										</div>
+									</div>
+									<div
+										className={ clsx( 'themes__filters', {
+											'is-woo-express': isSiteWooExpress,
+										} ) }
+									>
+										{ tabFilters && ! isSiteECommerceFreeTrial && (
+											<ThemesToolbarGroup
+												items={ Object.values( tabFilters ) }
+												selectedKey={ this.getSelectedTabFilter().key }
+												onSelect={ ( key ) =>
+													this.onFilterClick(
+														Object.values( tabFilters ).find(
+															( tabFilter ) => tabFilter.key === key
+														)
+													)
+												}
 											/>
 										) }
 									</div>
 								</div>
-								<div
-									className={ clsx( 'themes__filters', {
-										'is-woo-express': isSiteWooExpress,
-									} ) }
-								>
-									{ tabFilters && ! isSiteECommerceFreeTrial && (
-										<ThemesToolbarGroup
-											items={ Object.values( tabFilters ) }
-											selectedKey={ this.getSelectedTabFilter().key }
-											onSelect={ ( key ) =>
-												this.onFilterClick(
-													Object.values( tabFilters ).find( ( tabFilter ) => tabFilter.key === key )
-												)
-											}
-										/>
-									) }
-								</div>
-							</div>
+							) }
 						</>
 					) }
 					{ isCollectionView && (

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -145,6 +145,9 @@ class ThemeShowcase extends Component {
 
 	isThemeDiscoveryEnabled = () => config.isEnabled( 'themes/discovery' );
 
+	isThemeShowcaseModern = () =>
+		config.isEnabled( 'themes/showcase-modern' ) && ! this.props.isLoggedIn;
+
 	getStaticFilters() {
 		const { translate } = this.props;
 		return {
@@ -217,11 +220,16 @@ class ThemeShowcase extends Component {
 			if ( ! THEME_TIERS[ tier ]?.isFilterable ) {
 				return availableTiers;
 			}
+
+			const label = this.isThemeShowcaseModern()
+				? THEME_TIERS[ tier ].labelModern || THEME_TIERS[ tier ].label
+				: THEME_TIERS[ tier ].label;
+
 			return [
 				...availableTiers,
 				{
 					key: tier,
-					name: THEME_TIERS[ tier ].label,
+					name: label,
 				},
 			];
 		}, [] );
@@ -603,7 +611,6 @@ class ThemeShowcase extends Component {
 		} = this.props;
 		const tier = this.props.tier || 'all';
 		const canonicalUrl = 'https://wordpress.com' + pathName;
-		const isThemeShowcaseModern = config.isEnabled( 'themes/showcase-modern' ) && ! isLoggedIn;
 		const staticFilters = this.getStaticFilters();
 
 		// Update the filters to accommodate updates/translations from the API.
@@ -690,7 +697,7 @@ class ThemeShowcase extends Component {
 									/>
 								</InView>
 							) }
-							{ isThemeShowcaseModern ? (
+							{ this.isThemeShowcaseModern() ? (
 								<FilterBarModern
 									categories={ Object.values( tabFilters ) }
 									selectedCategory={ this.getSelectedTabFilter().key }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -150,6 +150,7 @@ class ThemeShowcase extends Component {
 
 	getStaticFilters() {
 		const { translate } = this.props;
+		const isThemeShowcaseModern = this.isThemeShowcaseModern();
 		return {
 			MYTHEMES: {
 				key: STATIC_FILTERS.MYTHEMES,
@@ -160,7 +161,7 @@ class ThemeShowcase extends Component {
 			RECOMMENDED: {
 				key: STATIC_FILTERS.RECOMMENDED,
 				get text() {
-					return translate( 'Recommended' );
+					return isThemeShowcaseModern ? translate( 'Discover' ) : translate( 'Recommended' );
 				},
 			},
 			ALL: {


### PR DESCRIPTION
Fixes DOTTHEM-304

## Proposed Changes

* When the `themes/showcase-modern` feature flag is enabled for logged-out users, render the new `FilterBarModern` component instead of the legacy `themes__controls` and `themes__filters` blocks.
* The legacy controls are preserved as-is in the else branch for logged-in users and when the flag is off.
* Add `scrollBy` mock to logged-out tests to support `CategoryPillNavigation` rendering.
* Minor style adjustments to `FilterBarModern` and `HeroModern` (pill spacing, search margin, tier select margin, alignments).

| Before | After |
|--------|--------|
| <img width="1139" height="479" alt="Screenshot 2026-03-03 at 12 20 45" src="https://github.com/user-attachments/assets/ca18c88f-3cfd-48c9-ba4c-4ecf81af1276" /> | <img width="1139" height="620" alt="Screenshot 2026-03-03 at 12 20 29" src="https://github.com/user-attachments/assets/03911498-547c-42cc-aba1-3334ef254a28" /> |
| - | Sticky filter bar<br><img width="1139" height="322" alt="Screenshot 2026-03-03 at 12 21 04" src="https://github.com/user-attachments/assets/afb9c8cd-a3aa-4351-985c-d63768dc4936" /> | 
| - | Sticky filter bar (search expanded)<br><img width="1139" height="322" alt="Screenshot 2026-03-03 at 12 21 23" src="https://github.com/user-attachments/assets/22f99c8e-9d23-4240-8da0-836e3984f437" /> | 

## Why are these changes being made?

This integrates the modern filter bar (category pills + tier dropdown + sticky search) into the Theme Showcase page, replacing the classic search input and toolbar group for the new logged-out experience.

## Testing Instructions

* Enable the `themes/showcase-modern` feature flag.
* Visit `/themes` logged out — should see the modern filter bar with category pills, tier dropdown, and sticky search on scroll.
* Visit `/themes` logged in — should see the legacy controls unchanged.
* Try changing filters and tiers.
  * Navigations should work like before.
  * Each filter button should have the appropriate URL attached.
* Run `yarn test-client client/my-sites/themes/test/logged-out.jsx` — all 3 tests pass.
* Run `yarn test-client client/my-sites/themes/filter-bar-modern/test/index.test.tsx` — all 11 tests pass.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?