### PR TITLE
ThemesList: Replace defaultProps with JS default parameters

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -62,24 +62,32 @@ const getWarningModalComponent = ( isDefaultWooExpressTheme, isCurrentThemeAIGen
 	}
 };
 
-export const ThemesList = ( { tabFilter, ...props } ) => {
-	const {
-		themes,
-		translate,
-		isSiteWooExpressOrEcomFreeTrial,
-		siteSlug,
-		siteAdminUrl,
-		getButtonOptions,
-	} = props;
+export const ThemesList = ( {
+	tabFilter,
+	loading = false,
+	searchTerm = '',
+	themes = [],
+	recordTracksEvent = noop,
+	fetchNextPage: fetchNextPageProp = noop,
+	placeholderCount = DEFAULT_THEME_QUERY.number,
+	getActionLabel = () => '',
+	isActive = () => false,
+	getPrice = () => '',
+	isInstalling = () => false,
+	isLivePreviewStarted = () => false,
+	...props
+} ) => {
+	const { translate, isSiteWooExpressOrEcomFreeTrial, siteSlug, siteAdminUrl, getButtonOptions } =
+		props;
 	const themesListRef = useRef( null );
 	const [ showSecondUpsellNudge, setShowSecondUpsellNudge ] = useState( false );
 	const updateShowSecondUpsellNudge = useCallback( () => {
 		const minColumnWidth = 320; // $theme-item-min-width: 320px;
 		const margin = 32; // $theme-item-horizontal-margin: 32px;
 		const columnsPerRow = getGridColumns( themesListRef, minColumnWidth, margin );
-		const result = columnsPerRow && props.themes.length >= columnsPerRow * 6;
+		const result = columnsPerRow && themes.length >= columnsPerRow * 6;
 		setShowSecondUpsellNudge( result );
-	}, [ props.themes.length ] );
+	}, [ themes.length ] );
 
 	useEffect( () => {
 		updateShowSecondUpsellNudge();
@@ -92,9 +100,9 @@ export const ThemesList = ( { tabFilter, ...props } ) => {
 	const selectedSite = useSelector( getSelectedSite );
 	const fetchNextPage = useCallback(
 		( options ) => {
-			props.fetchNextPage( options );
+			fetchNextPageProp( options );
 		},
-		[ props.fetchNextPage ]
+		[ fetchNextPageProp ]
 	);
 
 	const [ openWarningModal, setOpenWarningModal ] = useState( false );
@@ -104,7 +112,7 @@ export const ThemesList = ( { tabFilter, ...props } ) => {
 	);
 
 	const goToWooDesignWithAI = () => {
-		props.recordTracksEvent( 'calypso_themeshowcase_woo_design_with_ai_cta_click', {
+		recordTracksEvent( 'calypso_themeshowcase_woo_design_with_ai_cta_click', {
 			is_ai_generated: activeTheme?.is_ai_generated,
 		} );
 
@@ -142,13 +150,13 @@ export const ThemesList = ( { tabFilter, ...props } ) => {
 		];
 	}, [ themes, translate, activeTheme, getButtonOptions, siteAdminUrl, siteSlug ] );
 
-	if ( ! props.loading && props.themes.length === 0 ) {
+	if ( ! loading && themes.length === 0 ) {
 		return (
 			<Empty
 				isFSEActive={ props.isFSEActive }
-				recordTracksEvent={ props.recordTracksEvent }
-				searchTerm={ props.searchTerm }
-				translate={ props.translate }
+				recordTracksEvent={ recordTracksEvent }
+				searchTerm={ searchTerm }
+				translate={ translate }
 				upsellCardDisplayed={ props.upsellCardDisplayed }
 			/>
 		);
@@ -183,6 +191,11 @@ export const ThemesList = ( { tabFilter, ...props } ) => {
 					theme={ theme }
 					index={ index }
 					tabFilter={ tabFilter }
+					getActionLabel={ getActionLabel }
+					isActive={ isActive }
+					getPrice={ getPrice }
+					isInstalling={ isInstalling }
+					isLivePreviewStarted={ isLivePreviewStarted }
 					{ ...props }
 				/>
 			) ) }
@@ -204,7 +217,7 @@ export const ThemesList = ( { tabFilter, ...props } ) => {
 				/>
 			) }
 			{ props.children }
-			{ props.loading && <LoadingPlaceholders placeholderCount={ props.placeholderCount } /> }
+			{ loading && <LoadingPlaceholders placeholderCount={ placeholderCount } /> }
 			<InfiniteScroll nextPageMethod={ fetchNextPage } />
 		</div>
 	);
@@ -238,21 +251,6 @@ ThemesList.propTypes = {
 	tier: PropTypes.string,
 	upsellCardDisplayed: PropTypes.func,
 	children: PropTypes.node,
-};
-
-ThemesList.defaultProps = {
-	loading: false,
-	searchTerm: '',
-	themes: [],
-	recordTracksEvent: noop,
-	fetchNextPage: noop,
-	placeholderCount: DEFAULT_THEME_QUERY.number,
-	optionsGenerator: () => [],
-	getActionLabel: () => '',
-	isActive: () => false,
-	getPrice: () => '',
-	isInstalling: () => false,
-	isLivePreviewStarted: () => false,
 };
 
 export function ThemeBlock( props ) {


### PR DESCRIPTION
Fixes DOTTHEM-318

## Proposed Changes

Fix a console warning on the Theme Showcase in dev environment.

```
react-dom.development.js:86 Warning: ThemesList: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
    at ThemesList (app:///./components/themes-list/index.jsx:105:3)
    at eval (app:///./data/themes/with-is-fse-active.js:24:76)
    at eval (app:///../packages/i18n-calypso/src/localize.js:31:67)
    at ConnectFunction (app:///../node_modules/react-redux/dist/react-redux.mjs:715:103)
    at div
    at ThemesSelection (app:///./my-sites/themes/themes-selection.jsx:67:5)
    at ConnectFunction (app:///../node_modules/react-redux/dist/react-redux.mjs:715:103)
    at ThemesSelectionWithPage (app:///./my-sites/themes/themes-selection.jsx:420:5)
    at div
    at div
    at div
    at div
    at ThemeShowcase (app:///./my-sites/themes/theme-showcase.jsx:119:5)
    at eval (app:///../packages/i18n-calypso/src/localize.js:31:67)
    at ConnectFunction (app:///../node_modules/react-redux/dist/react-redux.mjs:715:103)
    at main
    at Main (app:///./components/main/index.tsx:15:3)
    at eval (app:///./my-sites/themes/single-site-wpcom.jsx:39:5)
    at ConnectFunction (app:///../node_modules/react-redux/dist/react-redux.mjs:715:103)
    at eval (app:///./state/sites/hooks/with-site-global-styles-on-personal.tsx:18:161)
    at eval (app:///./data/themes/with-is-fse-active.js:24:76)
    at eval (app:///../packages/i18n-calypso/src/localize.js:31:67)
    at ConnectFunction (app:///../node_modules/react-redux/dist/react-redux.mjs:715:103)
    at SingleSiteThemeShowcaseWithOptions (app:///./my-sites/themes/single-site.jsx:26:5)
    at eval (app:///../packages/i18n-calypso/src/localize.js:31:67)
    at ConnectFunction (app:///../node_modules/react-redux/dist/react-redux.mjs:715:103)
    at div
    at div
    at div
    at Layout (app:///./layout/index.jsx:209:5)
    at ConnectFunction (app:///../node_modules/react-redux/dist/react-redux.mjs:715:103)
    at WithCurrentRoute (app:///./components/route/index.js:60:30)
    at MomentProvider (app:///./components/localized-moment/provider.js:30:5)
    at ConnectFunction (app:///../node_modules/react-redux/dist/react-redux.mjs:715:103)
    at Provider (app:///../node_modules/react-redux/dist/react-redux.mjs:891:11)
    at QueryClientProvider (app:///../node_modules/@tanstack/react-query/build/modern/QueryClientProvider.js:28:3)
    at RouteProvider (app:///./components/route/index.js:28:3)
    at I18nProvider (app:///../node_modules/@wordpress/react-i18n/build-module/index.js:62:5)
    at LocaleProvider (app:///../packages/i18n-utils/src/locale-context.tsx:30:3)
    at CalypsoI18nProvider (app:///./components/calypso-i18n-provider/index.tsx:27:3)
    at ProviderWrappedLayout (app:///./controller/index.web.js:111:3)
```


* Move all values from `ThemesList.defaultProps` to JavaScript default parameters in the function signature.
* Update internal references from `props.themes`, `props.loading`, `props.searchTerm`, `props.recordTracksEvent`, `props.fetchNextPage`, `props.placeholderCount` to use the destructured variables directly.
* Rename the `fetchNextPage` prop to `fetchNextPageProp` to avoid collision with the local `fetchNextPage` callback.
* Pass extracted props (`getActionLabel`, `isActive`, `getPrice`, `isInstalling`, `isLivePreviewStarted`) explicitly to `ThemeBlock`, since they are no longer part of the `...props` rest object.
* Remove the `ThemesList.defaultProps` block entirely.
* Drop `optionsGenerator` from defaults — it existed in `defaultProps` but not in `propTypes` and is unused.

## Why are these changes being made?

* React will remove `defaultProps` support for function components in a future major release. This change moves the defaults inline to silence the deprecation warning and future-proof the component.

## Testing Instructions

* Visit the theme showcase page on a wpcom site (e.g. `/themes`).
* Verify themes load and display correctly.
* Verify infinite scroll, loading placeholders, and the empty state ("No themes match your search") all still work.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?