### PR TITLE
CIAB: use front-end build for the animation

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
@@ -60,7 +60,7 @@ const SiteSpec: StepType = function SiteSpec() {
 		const specId = specData.session_id || '';
 		const blogId = siteCreationPromise ? await siteCreationPromise : null;
 
-		let url = `/setup/ai-site-builder/?create_garden_site=1&spec_id=${ encodeURIComponent(
+		let url = `/setup/ai-site-builder/?create_garden_site=1&trigger_backend_build=0&spec_id=${ encodeURIComponent(
 			specId
 		) }`;
 		if ( blogId ) {

--- a/client/lib/site-spec/utils.ts
+++ b/client/lib/site-spec/utils.ts
@@ -199,7 +199,7 @@ export function getCiabSiteSpecConfig(): SiteSpecConfig {
 	const ref = new URLSearchParams( window.location.search ).get( 'ref' );
 
 	return {
-		buildSiteUrl: '/setup/ai-site-builder/?create_garden_site=1&spec_id=',
+		buildSiteUrl: '/setup/ai-site-builder/?create_garden_site=1&trigger_backend_build=0&spec_id=',
 		backButton: {
 			enabled: ref === 'new-site-popover',
 			url: buildCiabDashboardLink( '/sites' ),

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -217,7 +217,7 @@ export const createSiteWithCart = async (
 				...( flowName === AI_SITE_BUILDER_FLOW &&
 					gardenName === 'commerce' &&
 					specId && {
-						trigger_backend_build: true,
+						trigger_backend_build: false,
 					} ),
 			},
 		},


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #WOOPRD-2398

## Proposed Changes

Updates the http://calypso.localhost:3000/setup/ai-site-builder-spec?source=ciab-sites-dashboard&ref=new-site-popover flow to use the front-end build, so we can show build animations. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. http://calypso.localhost:3000/setup/ai-site-builder-spec?source=ciab-sites-dashboard&ref=new-site-popover
2. Complete it
3. Be taken to front-end build

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
