### PR TITLE
Checkout: use generic renewal route for siteless renewal links

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -124,6 +124,15 @@ export function checkoutRenewalBySubscriptionId( context, next ) {
 	next();
 }
 
+// Redirect old-style renewal URLs (e.g. /checkout/:product/renew/:purchaseId[/:domain])
+// to the new /checkout/renew/:subscriptionId route, preserving any query parameters.
+export function redirectToRenewalBySubscriptionId( context ) {
+	const { purchaseId } = context.params;
+	const newPath = `/checkout/renew/${ purchaseId }`;
+	const redirectUrl = context.querystring ? `${ newPath }?${ context.querystring }` : newPath;
+	page.redirect( redirectUrl );
+}
+
 function sitelessCheckout( context, next, extraProps ) {
 	const state = context.store.getState();
 	const isLoggedOut = ! isUserLoggedIn( state );

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -18,6 +18,7 @@ import {
 	checkoutUnifiedSiteless,
 	checkoutA4ASiteless,
 	checkoutRenewalBySubscriptionId,
+	redirectToRenewalBySubscriptionId,
 	checkoutThankYou,
 	licensingPendingAsyncActivation,
 	licensingThankYouManualActivationInstructions,
@@ -395,25 +396,9 @@ export default function () {
 		clientRender
 	);
 
-	// A renewal link without a site is not allowed, but we send the user to
-	// checkout anyway so they can see a helpful error message.
-	page(
-		'/checkout/:product/renew/:purchaseId',
-		redirectLoggedOut,
-		noSite,
-		checkout,
-		makeLayout,
-		clientRender
-	);
+	page( '/checkout/:product/renew/:purchaseId', redirectToRenewalBySubscriptionId );
 
-	page(
-		'/checkout/:product/renew/:purchaseId/:domain',
-		redirectLoggedOut,
-		siteSelection,
-		checkout,
-		makeLayout,
-		clientRender
-	);
+	page( '/checkout/:product/renew/:purchaseId/:domain', redirectToRenewalBySubscriptionId );
 
 	// Gift purchases work without a site, so do not include the `siteSelection`
 	// middleware.


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-1726/siteless-renewals-handle-siteless-renewals-with-generic-renewal-route

## Proposed Changes

* Add `redirectToRenewalBySubscriptionId` controller function that redirects any old-style renewal URL to `/checkout/renew/:subscriptionId`, preserving query parameters
* Replace the middleware chains on old-style `/renew/:purchaseId` route  generic with and without domain) with a simple redirect to the new route

## Why are these changes being made?

* The new `/checkout/renew/:subscriptionId` route derives product and site info from the subscription record alone, making it a simpler and more reliable entry point for renewals
* Old-style renewal URLs (e.g. `/checkout/a4a_wp_bundle_business_yearly:is-a4a/renew/1142610/siteless.a4a.com::tKzH...`) encode product slugs and domain info that are no longer needed — consolidating all renewal traffic through the new route reduces the surface area of the checkout routing logic

## Testing Instructions

* Visit an old-style renewal URL such as `/checkout/a4a_wp_bundle_business_yearly:is-a4a/renew/1142610/siteless.a4a.com::tKzHtsDOlQsgMOFqoq8hSwkG?cancel_to=https%3A%2F%2Fmy.wordpress.com%2Fme%2Fbilling%2Fpurchases%2F1142610%2F&redirect_to=https%3A%2F%2Fmy.wordpress.com%2Fme%2Fbilling%2Fpurchases%2F1142610%2F` and confirm it redirects to `/checkout/renew/1142610` with `cancel_to` and `redirect_to` query params intact
* Confirm the same for the other old-style route shapes: `/checkout/akismet/:productSlug/renew/:purchaseId`, `/checkout/marketplace/:productSlug/renew/:purchaseId`, `/checkout/passport/:productSlug/renew/:purchaseId`, and `/checkout/:product/renew/:purchaseId` (no domain)
* Confirm that the `/checkout/renew/:subscriptionId` route itself still loads checkout correctly after the redirect
