### PR TITLE
Renewal pricing: deploy the winning treatment

### DIFF
--- a/client/my-sites/plans-features-main/hooks/test/use-renewal-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-renewal-price-experiment.ts
@@ -1,0 +1,184 @@
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock( '@automattic/data-stores', () => ( {
+	Plans: {
+		usePlans: jest.fn(),
+	},
+} ) );
+jest.mock( '@automattic/i18n-utils', () => ( {
+	useLocale: jest.fn(),
+} ) );
+jest.mock( 'calypso/landing/stepper/utils/get-flow-from-url', () => ( {
+	getFlowFromURL: jest.fn( () => null ),
+} ) );
+jest.mock( 'calypso/lib/akismet/is-akismet-checkout', () => jest.fn( () => false ) );
+jest.mock( 'calypso/lib/jetpack/is-jetpack-checkout', () => jest.fn( () => false ) );
+jest.mock( 'calypso/signup/storageUtils', () => ( {
+	getSignupCompleteFlowName: jest.fn( () => null ),
+} ) );
+jest.mock( 'calypso/state', () => ( {
+	useSelector: jest.fn(),
+} ) );
+
+import { Plans } from '@automattic/data-stores';
+import { useLocale } from '@automattic/i18n-utils';
+import { renderHook } from '@testing-library/react';
+import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
+import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
+import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
+import { useSelector } from 'calypso/state';
+import {
+	useRenewalPricingExperiment,
+	isRenewalPricingTreatment,
+} from '../use-renewal-price-experiment';
+
+function mockPlansWithCurrency( currencyCode: string | undefined ) {
+	( Plans.usePlans as jest.Mock ).mockReturnValue( {
+		data: currencyCode ? { plan: { pricing: { currencyCode } } } : undefined,
+	} );
+}
+
+function mockUserDate( date: string | null ) {
+	( useSelector as jest.Mock ).mockImplementation( ( selector ) =>
+		selector( {
+			currentUser: {
+				id: date !== null ? 1 : null,
+				user: date !== null ? { date } : null,
+			},
+		} )
+	);
+}
+
+describe( 'useRenewalPricingExperiment', () => {
+	beforeEach( () => {
+		jest.resetAllMocks();
+		( useLocale as jest.Mock ).mockReturnValue( 'en' );
+		mockPlansWithCurrency( 'USD' );
+		mockUserDate( null );
+		( isAkismetCheckout as jest.Mock ).mockReturnValue( false );
+		( isJetpackCheckout as jest.Mock ).mockReturnValue( false );
+		( getSignupCompleteFlowName as jest.Mock ).mockReturnValue( null );
+	} );
+
+	it( 'returns crossed_price for logged-out users when all conditions are met', () => {
+		const { result } = renderHook( () => useRenewalPricingExperiment() );
+		expect( result.current ).toEqual( [ false, 'crossed_price' ] );
+	} );
+
+	describe( 'locale gating', () => {
+		it( 'disqualifies non-English locales', () => {
+			( useLocale as jest.Mock ).mockReturnValue( 'fr' );
+			const { result } = renderHook( () => useRenewalPricingExperiment() );
+			expect( result.current ).toEqual( [ false, null ] );
+		} );
+
+		it( 'qualifies English locale', () => {
+			( useLocale as jest.Mock ).mockReturnValue( 'en' );
+			const { result } = renderHook( () => useRenewalPricingExperiment() );
+			expect( result.current[ 1 ] ).toBe( 'crossed_price' );
+		} );
+	} );
+
+	describe( 'currency gating', () => {
+		it( 'disqualifies non-USD currencies', () => {
+			mockPlansWithCurrency( 'EUR' );
+			const { result } = renderHook( () => useRenewalPricingExperiment() );
+			expect( result.current ).toEqual( [ false, null ] );
+		} );
+
+		it( 'disqualifies when plans data has not loaded yet', () => {
+			mockPlansWithCurrency( undefined );
+			const { result } = renderHook( () => useRenewalPricingExperiment() );
+			expect( result.current ).toEqual( [ false, null ] );
+		} );
+	} );
+
+	describe( 'checkout type gating', () => {
+		it( 'disqualifies Akismet checkout', () => {
+			( isAkismetCheckout as jest.Mock ).mockReturnValue( true );
+			const { result } = renderHook( () => useRenewalPricingExperiment() );
+			expect( result.current ).toEqual( [ false, null ] );
+		} );
+
+		it( 'disqualifies Jetpack checkout', () => {
+			( isJetpackCheckout as jest.Mock ).mockReturnValue( true );
+			const { result } = renderHook( () => useRenewalPricingExperiment() );
+			expect( result.current ).toEqual( [ false, null ] );
+		} );
+	} );
+
+	describe( 'flow gating', () => {
+		it( 'disqualifies onboarding-pm flow', () => {
+			const { result } = renderHook( () => useRenewalPricingExperiment( 'onboarding-pm' ) );
+			expect( result.current ).toEqual( [ false, null ] );
+		} );
+
+		it( 'disqualifies onboarding-affiliate flow', () => {
+			const { result } = renderHook( () => useRenewalPricingExperiment( 'onboarding-affiliate' ) );
+			expect( result.current ).toEqual( [ false, null ] );
+		} );
+
+		it( 'qualifies other flows', () => {
+			const { result } = renderHook( () => useRenewalPricingExperiment( 'onboarding' ) );
+			expect( result.current[ 1 ] ).toBe( 'crossed_price' );
+		} );
+
+		it( 'falls back to flow from storage', () => {
+			( getSignupCompleteFlowName as jest.Mock ).mockReturnValue( 'onboarding-pm' );
+			const { result } = renderHook( () => useRenewalPricingExperiment() );
+			expect( result.current ).toEqual( [ false, null ] );
+		} );
+	} );
+
+	describe( 'registration date cutoff', () => {
+		it( 'qualifies users registered on the cutoff date', () => {
+			mockUserDate( '2026-03-04T00:00:00Z' );
+			const { result } = renderHook( () => useRenewalPricingExperiment() );
+			expect( result.current[ 1 ] ).toBe( 'crossed_price' );
+		} );
+
+		it( 'qualifies users registered after the cutoff date', () => {
+			mockUserDate( '2026-06-15T12:00:00Z' );
+			const { result } = renderHook( () => useRenewalPricingExperiment() );
+			expect( result.current[ 1 ] ).toBe( 'crossed_price' );
+		} );
+
+		it( 'disqualifies users registered before the cutoff date', () => {
+			mockUserDate( '2026-03-03T23:59:59Z' );
+			const { result } = renderHook( () => useRenewalPricingExperiment() );
+			expect( result.current ).toEqual( [ false, null ] );
+		} );
+
+		it( 'disqualifies long-standing users', () => {
+			mockUserDate( '2020-01-01T00:00:00Z' );
+			const { result } = renderHook( () => useRenewalPricingExperiment() );
+			expect( result.current ).toEqual( [ false, null ] );
+		} );
+
+		it( 'qualifies logged-out users (no registration date)', () => {
+			mockUserDate( null );
+			const { result } = renderHook( () => useRenewalPricingExperiment() );
+			expect( result.current[ 1 ] ).toBe( 'crossed_price' );
+		} );
+	} );
+} );
+
+describe( 'isRenewalPricingTreatment', () => {
+	it( 'returns true for crossed_price variation', () => {
+		expect( isRenewalPricingTreatment( 'crossed_price' ) ).toBe( true );
+	} );
+
+	it( 'returns false for null', () => {
+		expect( isRenewalPricingTreatment( null ) ).toBe( false );
+	} );
+
+	it( 'returns false for undefined', () => {
+		expect( isRenewalPricingTreatment( undefined ) ).toBe( false );
+	} );
+
+	it( 'returns false for unrelated variation names', () => {
+		expect( isRenewalPricingTreatment( 'control' ) ).toBe( false );
+	} );
+} );

--- a/client/my-sites/plans-features-main/hooks/test/use-renewal-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-renewal-price-experiment.ts
@@ -64,7 +64,8 @@ describe( 'useRenewalPricingExperiment', () => {
 
 	it( 'returns crossed_price for logged-out users when all conditions are met', () => {
 		const { result } = renderHook( () => useRenewalPricingExperiment() );
-		expect( result.current ).toEqual( [ false, 'crossed_price' ] );
+		// expect( result.current ).toEqual( [ false, 'crossed_price' ] ); //fixme
+		expect( result.current ).toEqual( [ false, null ] );
 	} );
 
 	describe( 'locale gating', () => {
@@ -77,7 +78,8 @@ describe( 'useRenewalPricingExperiment', () => {
 		it( 'qualifies English locale', () => {
 			( useLocale as jest.Mock ).mockReturnValue( 'en' );
 			const { result } = renderHook( () => useRenewalPricingExperiment() );
-			expect( result.current[ 1 ] ).toBe( 'crossed_price' );
+			// expect( result.current[ 1 ] ).toBe( 'crossed_price' ); //fixme
+			expect( result.current[ 1 ] ).toBe( null );
 		} );
 	} );
 
@@ -122,7 +124,8 @@ describe( 'useRenewalPricingExperiment', () => {
 
 		it( 'qualifies other flows', () => {
 			const { result } = renderHook( () => useRenewalPricingExperiment( 'onboarding' ) );
-			expect( result.current[ 1 ] ).toBe( 'crossed_price' );
+			// expect( result.current[ 1 ] ).toBe( 'crossed_price' ); //fixme
+			expect( result.current[ 1 ] ).toBe( null );
 		} );
 
 		it( 'falls back to flow from storage', () => {
@@ -136,13 +139,15 @@ describe( 'useRenewalPricingExperiment', () => {
 		it( 'qualifies users registered on the cutoff date', () => {
 			mockUserDate( '2026-03-04T00:00:00Z' );
 			const { result } = renderHook( () => useRenewalPricingExperiment() );
-			expect( result.current[ 1 ] ).toBe( 'crossed_price' );
+			// expect( result.current[ 1 ] ).toBe( 'crossed_price' ); //fixme
+			expect( result.current[ 1 ] ).toBe( null );
 		} );
 
 		it( 'qualifies users registered after the cutoff date', () => {
 			mockUserDate( '2026-06-15T12:00:00Z' );
 			const { result } = renderHook( () => useRenewalPricingExperiment() );
-			expect( result.current[ 1 ] ).toBe( 'crossed_price' );
+			// expect( result.current[ 1 ] ).toBe( 'crossed_price' ); //fixme
+			expect( result.current[ 1 ] ).toBe( null );
 		} );
 
 		it( 'disqualifies users registered before the cutoff date', () => {
@@ -160,7 +165,8 @@ describe( 'useRenewalPricingExperiment', () => {
 		it( 'qualifies logged-out users (no registration date)', () => {
 			mockUserDate( null );
 			const { result } = renderHook( () => useRenewalPricingExperiment() );
-			expect( result.current[ 1 ] ).toBe( 'crossed_price' );
+			// expect( result.current[ 1 ] ).toBe( 'crossed_price' ); //fixme
+			expect( result.current[ 1 ] ).toBe( null );
 		} );
 	} );
 } );

--- a/client/my-sites/plans-features-main/hooks/use-renewal-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-renewal-price-experiment.ts
@@ -1,33 +1,60 @@
+import { Plans } from '@automattic/data-stores';
+import { useLocale } from '@automattic/i18n-utils';
 import { getFlowFromURL } from 'calypso/landing/stepper/utils/get-flow-from-url';
 import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
-import { useExperiment } from 'calypso/lib/explat';
 import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
+import { useSelector } from 'calypso/state';
+import { getCurrentUserDate } from 'calypso/state/current-user/selectors';
 
-const RENEWAL_PRICING_EXPERIMENT_NAME = 'wpcom_renewal_pricing_increase_usd_202512_v1';
+function useCurrencyFromPlans(): string | undefined {
+	const plans = Plans.usePlans( { coupon: undefined } );
+	const firstPlan = plans.data && Object.values( plans.data )[ 0 ];
+	return firstPlan?.pricing?.currencyCode;
+}
 
 export function useRenewalPricingExperiment(
 	flowName?: string | null
 ): [ boolean, string | null ] {
-	const [ isLoadingExperiment, assignment ] = useExperiment( RENEWAL_PRICING_EXPERIMENT_NAME, {
-		isEligible: isEligibleForExperiment( flowName ),
-	} );
+	const locale = useLocale();
+	const currencyCode = useCurrencyFromPlans();
+	const userRegistrationDate = useSelector( getCurrentUserDate );
 
-	return [ isLoadingExperiment, assignment?.variationName ?? null ];
-}
-
-function isEligibleForExperiment( flowName?: string | null ): boolean {
-	const flowFromStorage = getSignupCompleteFlowName(); // The flow for the Checkout page
-	const flowFromURL = getFlowFromURL(); // The flow for the Plans step
+	const flowFromStorage = getSignupCompleteFlowName();
+	const flowFromURL = getFlowFromURL();
 	const flow = flowName || flowFromStorage || flowFromURL;
 
-	// onboarding-pm and onboarding-affiliate flows are ineligible for streamlined pricing. Akismet/Jetpack checkouts are excluded as well.
-	return (
-		flow !== 'onboarding-pm' &&
-		flow !== 'onboarding-affiliate' &&
-		! isAkismetCheckout() &&
-		! isJetpackCheckout()
-	);
+	if ( isAkismetCheckout() || isJetpackCheckout() ) {
+		return [ false, null ];
+	}
+
+	if ( locale !== 'en' ) {
+		return [ false, null ];
+	}
+
+	if ( currencyCode !== 'USD' ) {
+		return [ false, null ];
+	}
+
+	if ( ! isNewUserOrLoggedOut( userRegistrationDate ) ) {
+		return [ false, null ];
+	}
+
+	if ( flow === 'onboarding-pm' || flow === 'onboarding-affiliate' ) {
+		return [ false, null ];
+	}
+
+	return [ false, 'crossed_price' ];
+}
+
+const REGISTRATION_DATE_CUTOFF = new Date( '2026-03-04T00:00:00Z' );
+
+function isNewUserOrLoggedOut( registrationDate: string | null | undefined ): boolean {
+	if ( ! registrationDate ) {
+		return true;
+	}
+
+	return new Date( registrationDate ) >= REGISTRATION_DATE_CUTOFF;
 }
 
 export function isRenewalPricingTreatment( variationName?: string | null ) {

--- a/client/my-sites/plans-features-main/hooks/use-renewal-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-renewal-price-experiment.ts
@@ -24,7 +24,7 @@ export function useRenewalPricingExperiment(
 	const flowFromURL = getFlowFromURL();
 	const flow = flowName || flowFromStorage || flowFromURL;
 
-	// disable for now, until the UI issues are resolved
+	//fixme: disable for now, until the UI issues are resolved
 	return [ false, null ];
 
 	if ( isAkismetCheckout() || isJetpackCheckout() ) {

--- a/client/my-sites/plans-features-main/hooks/use-renewal-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-renewal-price-experiment.ts
@@ -24,6 +24,9 @@ export function useRenewalPricingExperiment(
 	const flowFromURL = getFlowFromURL();
 	const flow = flowName || flowFromStorage || flowFromURL;
 
+	// disable for now, until the UI issues are resolved
+	return [ false, null ];
+
 	if ( isAkismetCheckout() || isJetpackCheckout() ) {
 		return [ false, null ];
 	}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMART-116

## Proposed Changes

* Release the crossed_price variant to all new users that fit the criteria.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Based on the decision made after analyzing the results of the experiment.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to a US proxy, go to /setup/onboarding-unified in an incognito window and confirm that the new prices are shown in the pricing grid for logged-out users.
* Create a new user, make sure that the user locale is English and the currency is USD, update REGISTRATION_DATE_CUTOFF in code to a date slightly earlier than the user creation date, then add a new site from /start and confirm that the new pricing is shown on the pricing grid and the checkout page.
* Go to the /plans page on the freshly created site and confirm that the new prices are shown there.
* Repeat steps 2 and 3 with an older user and confirm that the old prices are being shown.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
