### PR TITLE
Fix VAT details link returning 404 on Jetpack Cloud

### DIFF
--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Button, Card, FormLabel } from '@automattic/components';
 import { formatCurrency } from '@automattic/number-formatters';
@@ -296,7 +297,15 @@ function UserVatDetails( { transaction }: { transaction: BillingTransaction } ) 
 					{
 						components: {
 							noPrint: <span className="receipt__no-print" />,
-							vatDetailsLink: <a href={ vatDetailsPath } />,
+							vatDetailsLink: (
+								<a
+									href={
+										config( 'env_id' ).includes( 'jetpack-cloud' )
+											? 'https://wordpress.com/me/purchases/vat-details'
+											: vatDetailsPath
+									}
+								/>
+							),
 							emailReceiptLink: (
 								<Button
 									plain

--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Button, Card, FormLabel } from '@automattic/components';
 import { formatCurrency } from '@automattic/number-formatters';
@@ -23,6 +22,7 @@ import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import TextareaAutosize from 'calypso/components/textarea-autosize';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { billingHistory, vatDetails as vatDetailsPath } from 'calypso/me/purchases/paths';
 import titles from 'calypso/me/purchases/titles';
 import useVatDetails from 'calypso/me/purchases/vat-info/use-vat-details';
@@ -300,7 +300,7 @@ function UserVatDetails( { transaction }: { transaction: BillingTransaction } ) 
 							vatDetailsLink: (
 								<a
 									href={
-										config( 'env_id' ).includes( 'jetpack-cloud' )
+										isJetpackCloud()
 											? 'https://wordpress.com/me/purchases/vat-details'
 											: vatDetailsPath
 									}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

This issue was reported by a customer who encountered the 404 error on Jetpack Cloud. 10926431-zd-a8c

## Proposed Changes

When on Jetpack Cloud, redirect the VAT details link to the full WordPress.com URL instead of using a relative path that doesn't exist on Cloud.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

On Jetpack Cloud (`cloud.jetpack.com`), clicking the "VAT details" link on a billing receipt returns a 404 error because the `/me/purchases/vat-details` route doesn't exist on Jetpack Cloud — it only exists on WordPress.com.

This fix checks if we're on Jetpack Cloud, and if so, links to the full `https://wordpress.com/me/purchases/vat-details` URL instead.

### Note on Long-term Solution

This is a quick fix to resolve the 404 error for users now. A more complete long-term solution would be to register the VAT details route directly in Jetpack Cloud, so users don't have to leave the site. That would require backend work and is outside the scope of this PR.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. When on Jetpack Cloud, navigate to Purchases > Billing History
2. For a receipt that has VAT details, click the three vertical dots and then click "View receipt"
3. Where it says, "You can edit your VAT details on this page, click on "on this page"
7. **Before:** 404 error on Jetpack Cloud
8. **After:** Redirects to `wordpress.com/me/purchases/vat-details`

<img width="1818" height="793" alt="jp-cloud_404-vat-details" src="https://github.com/user-attachments/assets/ff6f0199-f859-4e86-9aec-7a88320c947f" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?