### PR TITLE
e2e: Clean up stale like state before likes post test

### DIFF
--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -848,6 +848,34 @@ export class RestAPIClient {
 		return response;
 	}
 
+	/**
+	 * Likes or unlikes a post.
+	 *
+	 * @param {'like'|'unlike'} action Action to perform on the post.
+	 * @param {number} siteID Target site ID.
+	 * @param {number} postID Target post ID.
+	 */
+	async postLikeAction(
+		action: 'like' | 'unlike',
+		siteID: number,
+		postID: number
+	): Promise< any > {
+		const params: RequestParams = {
+			method: 'post',
+			headers: {
+				Authorization: await this.getAuthorizationHeader( 'bearer' ),
+				'Content-Type': this.getContentTypeHeader( 'json' ),
+			},
+		};
+
+		const endpoint =
+			action === 'like'
+				? this.getRequestURL( '1.1', `/sites/${ siteID }/posts/${ postID }/likes/new` )
+				: this.getRequestURL( '1.1', `/sites/${ siteID }/posts/${ postID }/likes/mine/delete` );
+
+		return await this.sendRequest( endpoint, params );
+	}
+
 	/* Media */
 
 	/**

--- a/test/e2e/specs/published-content/likes__post.ts
+++ b/test/e2e/specs/published-content/likes__post.ts
@@ -35,6 +35,7 @@ describe( 'Likes: Post', function () {
 	const otherUser = new TestAccount( 'defaultUser' );
 	let page: Page;
 	let restAPIClient: RestAPIClient;
+	let otherUserRestAPIClient: RestAPIClient;
 
 	let newPost: PostResponse;
 
@@ -45,12 +46,19 @@ describe( 'Likes: Post', function () {
 
 	it( 'Setup the test', async function () {
 		restAPIClient = new RestAPIClient( postingUser.credentials );
-		newPost = await restAPIClient.createPost(
-			postingUser.credentials.testSites?.primary.id as number,
-			{
-				title: DataHelper.getRandomPhrase(),
-			}
-		);
+		otherUserRestAPIClient = new RestAPIClient( otherUser.credentials );
+		const siteID = postingUser.credentials.testSites?.primary.id as number;
+
+		newPost = await restAPIClient.createPost( siteID, {
+			title: DataHelper.getRandomPhrase(),
+		} );
+
+		// Ensure neither user has a stale "liked" state on the post
+		// from a previous test run.
+		await Promise.allSettled( [
+			restAPIClient.postLikeAction( 'unlike', siteID, newPost.ID ),
+			otherUserRestAPIClient.postLikeAction( 'unlike', siteID, newPost.ID ),
+		] );
 	} );
 
 	describe( 'While authenticated', function () {


### PR DESCRIPTION
## Summary
- Add `postLikeAction` method to `RestAPIClient` for liking/unliking posts via the REST API
- In the `likes__post.ts` test setup, call unlike via API for both `postingUser` and `otherUser` to ensure neither has stale liked state from a previous run

## Test plan
- [x] Run `TEST_ON_ATOMIC=true GUTENBERG_EDGE=true yarn workspace wp-e2e-tests test -- specs/published-content/likes__post.ts` — all 6 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)