### PR TITLE
Domains in MSD: Hide 'Attach to a site' card when transfer is not allowed

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -5,6 +5,7 @@ import {
 	allSitesQuery,
 	connectedApplicationsQuery,
 	countryListQuery,
+	domainQuery,
 	geoLocationQuery,
 	isAutomatticianQuery,
 	monetizeSubscriptionsQuery,
@@ -278,6 +279,11 @@ export const purchaseSettingsIndexRoute = createRoute( {
 					? queryClient.ensureQueryData( siteMediaStorageQuery( purchase.blog_id ) )
 					: undefined,
 			] );
+		}
+
+		// Preload domain data to avoid layout shift for the "Attach to a site" card
+		if ( purchase.meta && purchase.is_domain ) {
+			await queryClient.ensureQueryData( domainQuery( purchase.meta ) ).catch( () => {} );
 		}
 	},
 } ).lazy( () =>

--- a/client/dashboard/domains/domain-overview/featured-card-site.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-site.tsx
@@ -22,7 +22,8 @@ export default function FeaturedCardSite( { domain }: Props ) {
 	const shouldShowAddAttachSite =
 		domain.is_domain_only_site &&
 		! domain.is_gravatar_restricted_domain &&
-		domain.subtype.id !== DomainSubtype.DOMAIN_TRANSFER;
+		domain.subtype.id !== DomainSubtype.DOMAIN_TRANSFER &&
+		domain.can_transfer_to_other_site;
 
 	return (
 		<OverviewCard

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -1116,6 +1116,10 @@ export default function PurchaseSettings() {
 		...siteBySlugQuery( purchase.site_slug ?? '' ),
 		enabled: Boolean( purchase.site_slug ) && ! isTemporarySitePurchase( purchase ),
 	} );
+	const { data: domain } = useQuery( {
+		...domainQuery( purchase.meta ?? '' ),
+		enabled: Boolean( purchase.meta ) && purchase.is_domain,
+	} );
 	const formattedExpiry = useFormattedTime( purchase.expiry_date ?? '' );
 	const formattedRenewal = useFormattedTime( purchase.renew_date ?? '' );
 	const upgradeUrl = getUpgradeUrl( purchase );
@@ -1233,7 +1237,8 @@ export default function PurchaseSettings() {
 					{ site &&
 						( site.options?.is_domain_only &&
 						purchase.is_domain &&
-						purchase.product_slug !== DomainProductSlugs.TRANSFER_IN ? (
+						purchase.product_slug !== DomainProductSlugs.TRANSFER_IN &&
+						domain?.can_transfer_to_other_site ? (
 							<OverviewCard
 								icon={ <Icon icon={ layout } /> }
 								title={ __( 'Attach to a site' ) }


### PR DESCRIPTION
Part of DOMENG-319

## Proposed Changes

Hide the "Attach to a site" overview card when `can_transfer_to_other_site` is false. Two locations:

- **Domain overview** (`featured-card-site.tsx`): Add `domain.can_transfer_to_other_site` to the existing `shouldShowAddAttachSite` condition.
- **Purchase settings** (`purchase-settings/index.tsx`): Fetch domain data via `domainQuery` and add `domain?.can_transfer_to_other_site` to the "Attach to a site" card condition.

## Why are these changes being made?

Users were seeing Sentry errors ("You do not have permission to transfer this domain") because the "Attach to a site" card linked to the transfer route even when the domain could not be transferred. PR #108039 hid the transfer action in the domain overview actions dropdown but missed these two card locations.

## Testing Instructions

- Open the domain overview page for a domain-only site where `can_transfer_to_other_site` is false
- Verify the "Attach to a site" card is no longer shown
- Open the purchase settings page for the same domain
- Verify the "Attach to a site" card is no longer shown there either
- For a domain where `can_transfer_to_other_site` is true, verify the card still appears in both locations

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

Co-Authored-By: Claude <noreply@anthropic.com>