### PR TITLE
A4A: Hosting dash - show renewal and payment method options

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-payment-method.tsx
@@ -2,7 +2,12 @@ import { useNavigate, Link } from '@tanstack/react-router';
 import { Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { __, sprintf, _x } from '@wordpress/i18n';
 import { changePaymentMethodRoute } from '../../app/router/me';
-import { isExpired, isRenewing, isAkismetFreeProduct } from '../../utils/purchase';
+import {
+	isExpired,
+	isRenewing,
+	isAkismetFreeProduct,
+	isA4ABillingDragonPurchase,
+} from '../../utils/purchase';
 import { PaymentMethodImage } from './payment-method-image';
 import type { Purchase } from '@automattic/api-core';
 
@@ -34,7 +39,7 @@ export function PurchasePaymentMethod( {
 		isExpired( purchase ) ||
 		purchase.partner_name ||
 		isAkismetFreeProduct( purchase ) ||
-		( isSiteMissing && ! purchase.is_domain )
+		( isSiteMissing && ! purchase.is_domain && ! isA4ABillingDragonPurchase( purchase ) )
 	) {
 		return null;
 	}

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -92,6 +92,7 @@ import {
 	isWpcomFlexSubscription,
 	isAkismetFreeProduct,
 	isInExpirationGracePeriod,
+	isA4ABillingDragonPurchase,
 } from '../../../utils/purchase';
 import BillingFlexUsageCard from '../../billing-flex-usage';
 import { PurchasePaymentMethod } from '../purchase-payment-method';
@@ -181,7 +182,8 @@ function canPurchaseBeUpgraded( purchase: Purchase ): boolean {
 	return Boolean(
 		purchase.is_upgradable &&
 			getUpgradeUrl( purchase ) &&
-			! isJetpackTemporarySitePurchase( purchase )
+			! isJetpackTemporarySitePurchase( purchase ) &&
+			! isA4ABillingDragonPurchase( purchase )
 	);
 }
 
@@ -393,7 +395,7 @@ function UpgradeActionButton( { purchase }: { purchase: Purchase } ) {
 
 function ReSubscribeActionButton( { purchase }: { purchase: Purchase } ) {
 	const { recordTracksEvent } = useAnalytics();
-	if ( ! isExpired( purchase ) ) {
+	if ( ! isExpired( purchase ) || isA4ABillingDragonPurchase( purchase ) ) {
 		return null;
 	}
 	return (
@@ -523,7 +525,7 @@ function ReinstallButton( { purchase }: { purchase: Purchase } ) {
 	);
 }
 
-function PurchaseSettingsActions( { purchase }: { purchase: Purchase } ) {
+export function PurchaseSettingsActions( { purchase }: { purchase: Purchase } ) {
 	return (
 		<VStack spacing={ 4 }>
 			<ActionList>

--- a/client/dashboard/me/billing-purchases/purchase-settings/test/actions.test.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/test/actions.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen } from '@testing-library/react';
+import { render } from '../../../../test-utils';
+import { PurchaseSettingsActions } from '../index';
+import type { Purchase } from '@automattic/api-core';
+
+function createPurchase( overrides: Partial< Purchase > = {} ): Purchase {
+	return {
+		ID: 1,
+		user_id: 1,
+		product_slug: 'business-bundle',
+		product_name: 'WordPress.com Business',
+		product_type: 'bundle',
+		expiry_status: 'auto-renewing',
+		subscription_status: 'active',
+		is_upgradable: false,
+		is_cancelable: false,
+		is_removable: false,
+		is_renewable: false,
+		is_rechargeable: true,
+		is_refundable: false,
+		can_explicit_renew: false,
+		can_disable_auto_renew: true,
+		is_auto_renew_enabled: true,
+		is_plan: true,
+		is_domain: false,
+		is_jetpack_plan_or_product: false,
+		meta: '',
+		domain: 'example.wordpress.com',
+		site_slug: 'example.wordpress.com',
+		...overrides,
+	} as Purchase;
+}
+
+describe( '<PurchaseSettingsActions>', () => {
+	test( 'shows upgrade button for a normal upgradable purchase', () => {
+		const purchase = createPurchase( { is_upgradable: true } );
+		render( <PurchaseSettingsActions purchase={ purchase } /> );
+
+		expect( screen.getByRole( 'button', { name: 'Upgrade' } ) ).toBeVisible();
+	} );
+
+	test( 'hides upgrade button for an A4A billing dragon purchase', () => {
+		const purchase = createPurchase( {
+			is_upgradable: true,
+			meta: 'is-a4a',
+			domain: 'siteless.a4a.com',
+		} );
+		render( <PurchaseSettingsActions purchase={ purchase } /> );
+
+		expect( screen.queryByRole( 'button', { name: 'Upgrade' } ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'shows re-subscribe button for a normal expired purchase', () => {
+		const purchase = createPurchase( {
+			expiry_status: 'expired',
+			subscription_status: 'expired',
+		} );
+		render( <PurchaseSettingsActions purchase={ purchase } /> );
+
+		expect( screen.getByRole( 'button', { name: 'Pick another plan' } ) ).toBeVisible();
+	} );
+
+	test( 'hides re-subscribe button for an expired A4A billing dragon purchase', () => {
+		const purchase = createPurchase( {
+			expiry_status: 'expired',
+			subscription_status: 'expired',
+			meta: 'is-a4a',
+			domain: 'siteless.a4a.com',
+		} );
+		render( <PurchaseSettingsActions purchase={ purchase } /> );
+
+		expect( screen.queryByRole( 'button', { name: 'Pick another plan' } ) ).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'button', { name: 'Pick another product' } )
+		).not.toBeInTheDocument();
+	} );
+} );

--- a/client/dashboard/me/billing-purchases/test/purchase-payment-method.test.tsx
+++ b/client/dashboard/me/billing-purchases/test/purchase-payment-method.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen } from '@testing-library/react';
+import { render } from '../../../test-utils';
+import { PurchasePaymentMethod } from '../purchase-payment-method';
+import type { Purchase } from '@automattic/api-core';
+
+function createPurchase( overrides: Partial< Purchase > = {} ): Purchase {
+	return {
+		ID: 1,
+		expiry_status: 'auto-renewing',
+		is_iap_purchase: false,
+		is_domain: false,
+		is_rechargeable: true,
+		partner_name: undefined,
+		payment_type: 'credit_card',
+		payment_card_id: '12345',
+		payment_card_type: 'visa',
+		payment_card_display_brand: 'Visa',
+		payment_details: '4242',
+		product_slug: 'jetpack_complete',
+		meta: '',
+		...overrides,
+	} as Purchase;
+}
+
+describe( '<PurchasePaymentMethod>', () => {
+	test( 'renders payment method for a normal purchase', () => {
+		const purchase = createPurchase();
+		render( <PurchasePaymentMethod purchase={ purchase } /> );
+
+		expect( screen.getByText( /\*{4} \*{4} \*{4} 4242/ ) ).toBeVisible();
+	} );
+
+	test( 'returns null when site is missing for a non-domain, non-A4A purchase', () => {
+		const purchase = createPurchase( { is_domain: false, meta: '' } );
+		const { container } = render( <PurchasePaymentMethod purchase={ purchase } isSiteMissing /> );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	test( 'renders payment method for a siteless A4A billing dragon purchase', () => {
+		const purchase = createPurchase( {
+			meta: 'is-a4a',
+			domain: 'siteless.a4a.com',
+			is_domain: false,
+		} );
+		render( <PurchasePaymentMethod purchase={ purchase } isSiteMissing /> );
+
+		expect( screen.getByText( /\*{4} \*{4} \*{4} 4242/ ) ).toBeVisible();
+	} );
+
+	test( 'renders payment method for a domain purchase even when site is missing', () => {
+		const purchase = createPurchase( { is_domain: true, meta: 'example.com' } );
+		render( <PurchasePaymentMethod purchase={ purchase } isSiteMissing /> );
+
+		expect( screen.getByText( /\*{4} \*{4} \*{4} 4242/ ) ).toBeVisible();
+	} );
+} );

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -209,8 +209,12 @@ export function isTransferredOwnership(
 	);
 }
 
+export function isA4ABillingDragonPurchase( purchase: Purchase ): boolean {
+	return purchase.meta === 'is-a4a';
+}
+
 export function isA4ATemporarySitePurchase( purchase: Purchase ): boolean {
-	return isTemporarySitePurchase( purchase ) && purchase.meta === 'is-a4a';
+	return isTemporarySitePurchase( purchase ) && isA4ABillingDragonPurchase( purchase );
 }
 
 export function isAkismetTemporarySitePurchase( purchase: Purchase ): boolean {

--- a/client/dashboard/utils/test/purchase-a4a.ts
+++ b/client/dashboard/utils/test/purchase-a4a.ts
@@ -1,0 +1,50 @@
+import { isA4ABillingDragonPurchase, isA4ATemporarySitePurchase } from '../purchase';
+import type { Purchase } from '@automattic/api-core';
+
+describe( 'isA4ABillingDragonPurchase', () => {
+	test( 'should return true when purchase meta is "is-a4a"', () => {
+		const purchase = { meta: 'is-a4a' } as Purchase;
+		expect( isA4ABillingDragonPurchase( purchase ) ).toBe( true );
+	} );
+
+	test( 'should return false when purchase meta is a domain name', () => {
+		const purchase = { meta: 'example.com' } as Purchase;
+		expect( isA4ABillingDragonPurchase( purchase ) ).toBe( false );
+	} );
+
+	test( 'should return false when purchase meta is empty', () => {
+		const purchase = { meta: '' } as Purchase;
+		expect( isA4ABillingDragonPurchase( purchase ) ).toBe( false );
+	} );
+
+	test( 'should return false when purchase meta is undefined', () => {
+		const purchase = { meta: undefined } as Purchase;
+		expect( isA4ABillingDragonPurchase( purchase ) ).toBe( false );
+	} );
+} );
+
+describe( 'isA4ATemporarySitePurchase', () => {
+	test( 'should return true for a siteless A4A billing dragon purchase', () => {
+		const purchase = {
+			domain: 'siteless.a4a.com',
+			meta: 'is-a4a',
+		} as Purchase;
+		expect( isA4ATemporarySitePurchase( purchase ) ).toBe( true );
+	} );
+
+	test( 'should return false for an A4A purchase on a real site', () => {
+		const purchase = {
+			domain: 'example.com',
+			meta: 'is-a4a',
+		} as Purchase;
+		expect( isA4ATemporarySitePurchase( purchase ) ).toBe( false );
+	} );
+
+	test( 'should return false for a non-A4A temporary site purchase', () => {
+		const purchase = {
+			domain: 'siteless.jetpack.com',
+			meta: '',
+		} as Purchase;
+		expect( isA4ATemporarySitePurchase( purchase ) ).toBe( false );
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Linear issues:
* https://linear.app/a8c/issue/A4A-1561/allow-clients-to-manually-renew-and-enable-auto-renew
* https://linear.app/a8c/issue/A4A-2078/allow-updating-payment-method-per-subscriptions

Equivalent changes on classic billing management page: https://github.com/Automattic/wp-calypso/pull/109032

## Proposed Changes

For all A4A bd subscriptions:
  * Show the "Renew now" option
  * Show the "Change payment method" option
  * Hide the "Upgrade" option

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As we start renewing A4A BD subscriptions we need to give users more ability to manage their subscriptions, in the same way they would with a normalA4A subscription.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* TBD

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
