### PR TITLE
Dashboard: Infer siteSlug from route params in perf tracking

### DIFF
--- a/client/dashboard/app/performance-tracking.ts
+++ b/client/dashboard/app/performance-tracking.ts
@@ -1,7 +1,7 @@
 import { queryClient } from '@automattic/api-queries';
 import { cancel, start, stop } from '@automattic/browser-data-collector';
 import config from '@automattic/calypso-config';
-import { useRouter } from '@tanstack/react-router';
+import { useParams, useRouter } from '@tanstack/react-router';
 import { useLayoutEffect } from 'react';
 import { isDashboardBackport } from '../utils/is-dashboard-backport';
 import { getSiteFromCache } from './analytics/super-props';
@@ -68,7 +68,8 @@ export function startPerformanceTracking( routeId: string ) {
  * Hook to stop performance tracking.
  * Use in functional components where the page is considered "loaded".
  */
-export function usePerformanceTrackerStop( siteSlug?: string ) {
+export function usePerformanceTrackerStop() {
+	const { siteSlug } = useParams( { strict: false } );
 	const router = useRouter();
 	const routeId = ( router.state.pendingMatches ?? router.state.matches ).at( -1 )?.routeId;
 
@@ -91,7 +92,7 @@ export function usePerformanceTrackerStop( siteSlug?: string ) {
  * Component to stop performance tracking.
  * Place this where the page is considered "loaded".
  */
-export function PerformanceTrackerStop( { siteSlug }: { siteSlug?: string } ): null {
-	usePerformanceTrackerStop( siteSlug );
+export function PerformanceTrackerStop() {
+	usePerformanceTrackerStop();
 	return null;
 }

--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -143,7 +143,7 @@ export function BackupsListPage() {
 		if ( selectedBackup ) {
 			return (
 				<>
-					<PerformanceTrackerStop siteSlug={ siteSlug } />
+					<PerformanceTrackerStop />
 					<BackupDetails
 						backup={ selectedBackup }
 						site={ site }
@@ -156,7 +156,7 @@ export function BackupsListPage() {
 
 		return (
 			<>
-				{ ! isLoadingActivityLog && <PerformanceTrackerStop siteSlug={ siteSlug } /> }
+				{ ! isLoadingActivityLog && <PerformanceTrackerStop /> }
 				<BackupsList
 					activityLog={ activityLog }
 					isLoadingActivityLog={ isLoadingActivityLog }
@@ -244,7 +244,7 @@ export function BackupsListPage() {
 						renderMobileView()
 					) : (
 						<Grid columns={ columns } templateColumns="40% 1fr">
-							{ ! isLoadingActivityLog && <PerformanceTrackerStop siteSlug={ siteSlug } /> }
+							{ ! isLoadingActivityLog && <PerformanceTrackerStop /> }
 							<BackupsList
 								activityLog={ activityLog }
 								isLoadingActivityLog={ isLoadingActivityLog }
@@ -259,7 +259,7 @@ export function BackupsListPage() {
 					) }
 				</>
 			) }
-			{ ! hasBackups && <PerformanceTrackerStop siteSlug={ siteSlug } /> }
+			{ ! hasBackups && <PerformanceTrackerStop /> }
 		</PageLayout>
 	);
 }

--- a/client/dashboard/sites/deployments-list/index.tsx
+++ b/client/dashboard/sites/deployments-list/index.tsx
@@ -230,7 +230,7 @@ function DeploymentsList() {
 					/>
 				</Modal>
 			) }
-			{ ! isLoading && <PerformanceTrackerStop siteSlug={ siteSlug } /> }
+			{ ! isLoading && <PerformanceTrackerStop /> }
 		</PageLayout>
 	);
 }

--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -108,7 +108,7 @@ function SiteDomains() {
 					defaultLayouts={ DEFAULT_LAYOUTS }
 				/>
 			</DataViewsCard>
-			{ ! isLoading && <PerformanceTrackerStop siteSlug={ siteSlug } /> }
+			{ ! isLoading && <PerformanceTrackerStop /> }
 		</PageLayout>
 	);
 }

--- a/client/dashboard/sites/hosting-feature-gated-with-callout/index.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-callout/index.tsx
@@ -85,7 +85,7 @@ export default function HostingFeatureGatedWithCallout( {
 
 				return (
 					<>
-						<PerformanceTrackerStop siteSlug={ props.site.slug } />
+						<PerformanceTrackerStop />
 						{ wrapCallout( upsellCallout ) }
 						{ backButton }
 					</>
@@ -102,7 +102,7 @@ export default function HostingFeatureGatedWithCallout( {
 
 				return (
 					<>
-						<PerformanceTrackerStop siteSlug={ props.site.slug } />
+						<PerformanceTrackerStop />
 						{ wrapCallout( activationCallout ) }
 						{ backButton }
 					</>

--- a/client/dashboard/sites/logs/dataviews/index.tsx
+++ b/client/dashboard/sites/logs/dataviews/index.tsx
@@ -362,7 +362,7 @@ function SiteLogsDataViews( {
 					onClick={ () => dataviewsRef.current?.scrollTo( { top: 0, behavior: 'smooth' } ) }
 				/>
 			) }
-			{ ! isLoadingLogQuery && <PerformanceTrackerStop siteSlug={ site.slug } /> }
+			{ ! isLoadingLogQuery && <PerformanceTrackerStop /> }
 		</>
 	);
 }

--- a/client/dashboard/sites/monitoring/index.tsx
+++ b/client/dashboard/sites/monitoring/index.tsx
@@ -68,7 +68,7 @@ function SiteMonitoringBody( {
 	return (
 		<VStack alignment="stretch" spacing={ isSmallViewport ? 5 : 10 }>
 			{ /* Similar to the site overview page, we mark the page as loaded one the layout is looking correct */ }
-			<PerformanceTrackerStop siteSlug={ site.slug } />
+			<PerformanceTrackerStop />
 
 			<MonitoringPerformanceCard site={ site } timeRange={ hoursMap[ timeRange ] } />
 

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -277,7 +277,7 @@ function SiteOverview( {
 					/>
 				) }
 			</GuidedTourContextProvider>
-			<PerformanceTrackerStop siteSlug={ siteSlug } />
+			<PerformanceTrackerStop />
 		</PageLayout>
 	);
 }

--- a/client/dashboard/sites/performance/index.tsx
+++ b/client/dashboard/sites/performance/index.tsx
@@ -200,7 +200,7 @@ function SitePerformance() {
 			) : (
 				<SitePerformanceContent site={ site } />
 			) }
-			<PerformanceTrackerStop siteSlug={ siteSlug } />
+			<PerformanceTrackerStop />
 		</HostingFeatureGatedWithCallout>
 	);
 }

--- a/client/dashboard/sites/scan-active/index.tsx
+++ b/client/dashboard/sites/scan-active/index.tsx
@@ -92,7 +92,7 @@ export function ActiveThreatsDataViews( {
 
 	return (
 		<>
-			{ ! isLoading && <PerformanceTrackerStop siteSlug={ site.slug } /> }
+			{ ! isLoading && <PerformanceTrackerStop /> }
 			<DataViews< Threat >
 				actions={ actions }
 				data={ filteredData }

--- a/client/dashboard/sites/scan-history/index.tsx
+++ b/client/dashboard/sites/scan-history/index.tsx
@@ -86,7 +86,7 @@ export function ScanHistoryDataViews( {
 
 	return (
 		<>
-			{ ! isLoading && <PerformanceTrackerStop siteSlug={ site.slug } /> }
+			{ ! isLoading && <PerformanceTrackerStop /> }
 			<DataViews< Threat >
 				actions={ actions }
 				data={ filteredData }

--- a/client/dashboard/sites/scan/index.tsx
+++ b/client/dashboard/sites/scan/index.tsx
@@ -90,7 +90,7 @@ function SiteScan( { scanTab }: { scanTab: 'active' | 'history' } ) {
 		if ( isScanInProgress ) {
 			return (
 				<>
-					<PerformanceTrackerStop siteSlug={ siteSlug } />
+					<PerformanceTrackerStop />
 					<ScanStatus scanState={ scanState } />
 				</>
 			);

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -104,7 +104,7 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 			) }
 			<SiteActions site={ site } />
 			<DangerZone site={ site } />
-			<PerformanceTrackerStop siteSlug={ siteSlug } />
+			<PerformanceTrackerStop />
 		</PageLayout>
 	);
 }


### PR DESCRIPTION
## Proposed Changes

* `PerformanceTrackerStop` / `usePerformanceTrackerStop` now read `siteSlug` from TanStack Router params via `useParams({ strict: false })` instead of accepting it as a prop.
* Remove the `siteSlug` prop from all call sites across the dashboard.

## Why are these changes being made?

Every site page had to manually thread `siteSlug` into `PerformanceTrackerStop`. This was repetitive, easy to forget on new pages, and occasionally inconsistent (some passed the route param, others passed `site.slug`). Since the slug is already in the URL for every site route, the component can just read it from the router — eliminating boilerplate and a class of copy-paste bugs.

## Testing Instructions

* Navigate to any site-specific dashboard page (overview, backups, plugins, scan, settings, etc.) and verify RUM `perf.nav` events still include `siteId` / `siteIsAtomic` metadata.
* Navigate to a non-site page (e.g. `/plugins/manage`, `/me/profile`) and confirm `perf.nav` fires without `siteId`.
* Full-page load and in-app navigation should both work.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?