### PR TITLE
Dashboard: OAuth-aware auth for Woo hostnames

### DIFF
--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -79,10 +79,29 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 		}
 
 		authErrorHandled.current = true;
+
+		if ( config.isEnabled( 'oauth' ) ) {
+			const redirectUri = new URL( '/api/oauth/token', window.location.origin );
+			redirectUri.search = new URLSearchParams( {
+				next: window.location.pathname + window.location.search,
+			} ).toString();
+
+			const authUri = new URL( 'https://public-api.wordpress.com/oauth2/authorize' );
+			authUri.search = new URLSearchParams( {
+				response_type: 'token',
+				client_id: String( config( 'oauth_client_id' ) ),
+				redirect_uri: redirectUri.toString(),
+				scope: 'global',
+				blog_id: '0',
+			} ).toString();
+
+			window.location.replace( authUri.toString() );
+			return;
+		}
+
 		const currentPath = window.location.href;
 		const path = config( 'wpcom_login_url' ) || '/log-in';
 		const loginUrl = `${ path }?redirect_to=${ encodeURIComponent( currentPath ) }`;
-
 		window.location.href = loginUrl;
 	}, [] );
 

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -30,22 +30,35 @@ import { serialize } from 'calypso/state/utils';
 const debug = debugFactory( 'calypso:server-render' );
 
 /**
- * Returns per-request clientData with hostname overridden when the request
- * arrives on an allowed alternate hostname (e.g. behind a reverse proxy).
- * When the request hostname is not in the allowlist, the clientData is
- * returned unchanged — the configured default hostname is used.
- * When no hostname_allowlist is configured, returns clientData as-is.
+ * Returns per-request clientData customized for the request hostname.
+ * Overrides hostname when the request arrives on an allowed alternate
+ * hostname, and applies any hostname-specific overrides (features, OAuth
+ * client, login/logout URLs, etc.) from hostname_overrides config.
  */
 export function customizeClientDataForRequest( req, baseClientData ) {
-	const allowlist = config( 'hostname_allowlist' );
-	if ( ! Array.isArray( allowlist ) ) {
-		return baseClientData;
-	}
 	const reqHostname = req.hostname;
-	if ( allowlist.includes( reqHostname ) && reqHostname !== config( 'hostname' ) ) {
-		return { ...baseClientData, hostname: reqHostname };
+	let clientData = baseClientData;
+
+	const hostnameAllowlist = config( 'hostname_allowlist' );
+	if (
+		Array.isArray( hostnameAllowlist ) &&
+		hostnameAllowlist.includes( reqHostname ) &&
+		reqHostname !== config( 'hostname' )
+	) {
+		clientData = { ...clientData, hostname: reqHostname };
 	}
-	return baseClientData;
+
+	const hostnameOverrides = config( 'hostname_overrides' );
+	if ( typeof hostnameOverrides === 'object' && hostnameOverrides[ reqHostname ] ) {
+		const { features: overrideFeatures, ...overrideData } = hostnameOverrides[ reqHostname ];
+		clientData = {
+			...clientData,
+			...overrideData,
+			features: { ...clientData.features, ...overrideFeatures },
+		};
+	}
+
+	return clientData;
 }
 
 const HOUR_IN_MS = 3600000;

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -14,6 +14,7 @@
 	"survicate_enabled_at_help_center": true,
 	"hostname": false,
 	"hostname_allowlist": false,
+	"hostname_overrides": false,
 	"i18n_default_locale_slug": "en",
 	"lasagna_url": "wss://rt-api.wordpress.com/socket",
 	"login_url": false,

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -6,6 +6,14 @@
 	"survicate_enabled": true,
 	"hostname": "my.localhost",
 	"hostname_allowlist": [ "my.localhost", "my.woo.localhost" ],
+	"hostname_overrides": {
+		"my.woo.localhost": {
+			"oauth_client_id": 134404,
+			"wpcom_login_url": false,
+			"logout_url": "http://my.woo.localhost:3000",
+			"features": { "oauth": true }
+		}
+	},
 	"i18n_default_locale_slug": "en",
 	"port": 3000,
 	"wpcom_signup_id": "39911",

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -6,6 +6,14 @@
 	"survicate_enabled": true,
 	"hostname": "my.wordpress.com",
 	"hostname_allowlist": [ "my.wordpress.com", "my.woo.ai" ],
+	"hostname_overrides": {
+		"my.woo.ai": {
+			"oauth_client_id": 134405,
+			"wpcom_login_url": false,
+			"logout_url": "https://woo.com",
+			"features": { "oauth": true }
+		}
+	},
 	"i18n_default_locale_slug": "en",
 	"wpcom_signup_id": "39911",
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -6,6 +6,14 @@
 	"survicate_enabled": true,
 	"hostname": "my.wordpress.com",
 	"hostname_allowlist": [ "my.wordpress.com", "my.woo.ai" ],
+	"hostname_overrides": {
+		"my.woo.ai": {
+			"oauth_client_id": 134405,
+			"wpcom_login_url": false,
+			"logout_url": "https://woo.com",
+			"features": { "oauth": true }
+		}
+	},
 	"i18n_default_locale_slug": "en",
 	"wpcom_signup_id": "39911",
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -6,6 +6,14 @@
 	"survicate_enabled": true,
 	"hostname": "my.wordpress.com",
 	"hostname_allowlist": [ "my.wordpress.com", "my.woo.ai" ],
+	"hostname_overrides": {
+		"my.woo.ai": {
+			"oauth_client_id": 134405,
+			"wpcom_login_url": false,
+			"logout_url": "https://woo.com",
+			"features": { "oauth": true }
+		}
+	},
 	"i18n_default_locale_slug": "en",
 	"wpcom_signup_id": "39911",
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",

--- a/config/development.json
+++ b/config/development.json
@@ -6,6 +6,14 @@
 	"protocol": "http",
 	"hostname": "calypso.localhost",
 	"hostname_allowlist": [ "calypso.localhost", "my.localhost", "my.woo.localhost" ],
+	"hostname_overrides": {
+		"my.woo.localhost": {
+			"oauth_client_id": 134404,
+			"wpcom_login_url": "/connect",
+			"logout_url": "http://my.woo.localhost:3000",
+			"features": { "oauth": true }
+		}
+	},
 	"port": 3000,
 	"i18n_default_locale_slug": "en",
 	"siftscience_key": "e00e878351",


### PR DESCRIPTION
Part of DOTMSD-1115

## Proposed Changes

* When `oauth` feature is enabled (Woo hostnames), redirect to the WordPress.com OAuth authorize endpoint on auth failure instead of the cookie-based login URL.
* Add `hostname_overrides` config key to inject per-hostname feature flags and settings (OAuth client ID, login/logout URLs).

## Why are these changes being made?

The Dashboard served on `my.woo.ai` cannot use WordPress.com session cookies (different domain). This wires up the OAuth implicit-grant flow so the Dashboard can authenticate via `public-api.wordpress.com/oauth2/authorize` when running on Woo hostnames, while `my.wordpress.com` continues using cookie auth unchanged.

## Testing Instructions

So far only tested on `localhost`, but I think that is ok to merge.

1. `yarn start-dashboard`
2. Visit `http://my.woo.localhost:3000` — should redirect to `public-api.wordpress.com/oauth2/authorize` with `client_id=134404`
3. Visit `http://my.localhost:3000` — should work as before (cookie auth)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?