### PR TITLE
Image Studio: Increase padding between upgrade notice message and button

### DIFF
--- a/packages/image-studio/src/components/notice/style.scss
+++ b/packages/image-studio/src/components/notice/style.scss
@@ -56,6 +56,7 @@
 
 		.components-notice__action.components-button {
 			margin-left: 0;
+			margin-top: 8px;
 		}
 	}
 }


### PR DESCRIPTION
## Proposed Changes

* Add `margin-top: 8px` to the upgrade notice action button to increase vertical spacing between the message and the "Upgrade plan" button.

## Why are these changes being made?

* The upgrade notice in Image Studio had the message text and action button too close together, making it feel cramped. This adds breathing room for better readability.

### Before

<img width="834" height="276" alt="image" src="https://github.com/user-attachments/assets/db4edc92-c4c8-43a8-b1e6-78c72a7fc0a3" />


### After

<img width="433" height="145" alt="image" src="https://github.com/user-attachments/assets/13b2249b-9f5d-49a8-8b87-7b90e71f7012" />


## Testing Instructions

1. Pull the latest `trunk` on your sandbox
2. Run `install-plugin.sh am forno-228-path-to-upgrade-increase-padding-between-message-and-button` on your sandbox
3. Route requests for `widgets.wp.com` to your sandbox
4. Use the test site set up instructions in the linear issue 
5. Turn off your AutoProxxy and try to generate an image


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)