### PR TITLE
A4A: Enable referral cobranded checkout flag and refine logo options

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/referral-logo.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/referral-logo.tsx
@@ -75,6 +75,13 @@ export default function ReferralLogo( { onChange }: Props ) {
 		} );
 	}, [ logoOption, logoPreviewUrl, agencyReferralsLogoUrl, onChange, selectedLogoFile ] );
 
+	let differentLogoLabel = translate( 'Upload my logo' );
+	if ( hasProfileLogo ) {
+		differentLogoLabel = translate( 'Use a different logo for this referral' );
+	} else if ( hasAgencyReferralsLogo ) {
+		differentLogoLabel = translate( 'Use this logo' );
+	}
+
 	return (
 		<VStack spacing={ 2 } className="checkout__logo-section">
 			<FormLabel style={ { marginBottom: 0 } } htmlFor="logo">
@@ -91,7 +98,7 @@ export default function ReferralLogo( { onChange }: Props ) {
 							? [ { label: translate( 'Use profile logo' ), value: 'profile' } ]
 							: [] ),
 						{
-							label: translate( 'Use a different logo for this referral' ),
+							label: differentLogoLabel,
 							value: 'different',
 						},
 						{

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -36,7 +36,7 @@
 		"a4a-dev-sites": true,
 		"a4a-pressable-referrals": true,
 		"a4a-pressable-premium-plans": true,
-		"a4a-referral-cobranded-checkout": false,
+		"a4a-referral-cobranded-checkout": true,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": true,
 		"a4a-signup-v2-via-email": false,

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -38,7 +38,7 @@
 		"a4a-dev-sites": true,
 		"a4a-pressable-referrals": true,
 		"a4a-pressable-premium-plans": true,
-		"a4a-referral-cobranded-checkout": false,
+		"a4a-referral-cobranded-checkout": true,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": true,
 		"a4a-signup-v2-via-email": false,


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/A4A-2202/janitorial-enable-the-a4a-referral-cobranded-checkout-feature-flag-on

## Proposed Changes

* Enable the `a4a-referral-cobranded-checkout` feature flag for A4A stage and production environments.
* Refine the referral logo radio options so the second option label is dynamic:
  * "Use a different logo for this referral" when a profile logo exists.
  * "Use this logo" when only an agency referrals logo exists.
  * "Upload my logo" when no logo exists yet.

## Why are these changes being made?

* Roll out the cobranded referral checkout experience beyond dev/horizon so agencies can use the same flow in stage and production.
* Make the referral logo choices clearer and more contextual, especially when an existing logo is already configured.

## Testing Instructions

* In the stage environment, verify that the cobranded referral checkout flow is available when requesting client payment.
* In the production environment, verify that the cobranded referral checkout flow is available when requesting client payment.
* With different logo states (profile logo only, referrals logo only, no logo), verify that the referral logo radio labels match the expected copy.


<img width="533" height="537" alt="Screenshot 2026-03-04 at 5 02 05 PM" src="https://github.com/user-attachments/assets/07108c20-a4b0-41b7-b59b-964a81e0a640" />

<img width="533" height="499" alt="Screenshot 2026-03-04 at 5 02 43 PM" src="https://github.com/user-attachments/assets/d0a750bf-e3ee-4b1e-be15-c8e0e4f691d3" />

<img width="533" height="542" alt="Screenshot 2026-03-04 at 5 03 19 PM" src="https://github.com/user-attachments/assets/a8fd3022-0886-45bc-84b6-897c33d3d8ed" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?