### PR TITLE
e2e: Fix i18n editor test to locate title inside iframe

### DIFF
--- a/test/e2e/specs/i18n/i18n__editor.spec.ts
+++ b/test/e2e/specs/i18n/i18n__editor.spec.ts
@@ -49,7 +49,8 @@ test.describe( 'I18N: Editor', { tag: [ tags.I18N, tags.DESKTOP_ONLY ] }, () => 
 			 */
 			await test.step( 'Then languages other than English show non-English translations', async () => {
 				const englishText = 'Add title';
-				const titleLocator = page.locator( 'h1.wp-block-post-title' );
+				const editorCanvas = await pageEditor.getEditorCanvas();
+				const titleLocator = editorCanvas.locator( '.editor-post-title__input' );
 				const accessibleName = await titleLocator.getAttribute( 'aria-label' );
 				const placeholderText = await titleLocator
 					.locator( 'span' )


### PR DESCRIPTION
## Proposed Changes

* Use `pageEditor.getEditorCanvas()` instead of `page.locator()` to access elements inside the editor iframe
* Switch to `.editor-post-title__input` selector, consistent with the rest of the codebase

## Why are these changes being made?

The Gutenberg editor now renders the post content area inside an iframe. The i18n editor test was using `page.locator('h1.wp-block-post-title')` which only searches the top-level page, causing it to time out since the title element is inside the iframe.

## Testing Instructions

* Run `yarn playwright test i18n/i18n__editor.spec.ts --reporter=list --project=chrome` from `test/e2e/`
* All 17 locale tests should pass

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)