### PR TITLE
MSD: show disconnected sites as notice on site list

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -1,5 +1,6 @@
 import { HostingFeatures, DotcomFeatures, LogType } from '@automattic/api-core';
 import {
+	allSitesQuery,
 	bigSkyPluginQuery,
 	codeDeploymentQuery,
 	codeDeploymentsQuery,
@@ -37,6 +38,7 @@ import {
 	siteStaticFile404SettingQuery,
 	siteWordPressVersionQuery,
 	queryClient,
+	userPurchasesQuery,
 } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
 import { isSupportSession } from '@automattic/calypso-support-session';
@@ -81,6 +83,8 @@ export const sitesRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'sites',
 	loader: async () => {
+		queryClient.prefetchQuery( allSitesQuery() );
+		queryClient.prefetchQuery( userPurchasesQuery() );
 		await Promise.all( [
 			queryClient.ensureQueryData( isAutomatticianQuery() ),
 			queryClient.ensureQueryData( rawUserPreferencesQuery() ),

--- a/client/dashboard/sites/notice-inaccessible-sites.tsx
+++ b/client/dashboard/sites/notice-inaccessible-sites.tsx
@@ -4,11 +4,11 @@ import { Link } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import Notice from '../components/notice';
-import { isDotcomPlan } from '../utils/purchase';
+import { isDotcomPlan, isExpired } from '../utils/purchase';
 import type { Purchase } from '@automattic/api-core';
 
 function isDisconnectedSite( purchase: Purchase, siteIds: Set< number > ): boolean {
-	return isDotcomPlan( purchase ) && ! siteIds.has( purchase.blog_id );
+	return isDotcomPlan( purchase ) && ! isExpired( purchase ) && ! siteIds.has( purchase.blog_id );
 }
 
 export default function InaccessibleSitesNotice() {

--- a/client/dashboard/sites/notice-inaccessible-sites.tsx
+++ b/client/dashboard/sites/notice-inaccessible-sites.tsx
@@ -1,0 +1,54 @@
+import { allSitesQuery, userPurchasesQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { Link } from '@tanstack/react-router';
+import { __ } from '@wordpress/i18n';
+import { useMemo } from 'react';
+import Notice from '../components/notice';
+import { isDotcomPlan } from '../utils/purchase';
+import type { Purchase } from '@automattic/api-core';
+
+function isDisconnectedSite( purchase: Purchase, siteIds: Set< number > ): boolean {
+	return isDotcomPlan( purchase ) && ! siteIds.has( purchase.blog_id );
+}
+
+export default function InaccessibleSitesNotice() {
+	const { data: purchases } = useQuery( userPurchasesQuery() );
+	const { data: sites } = useQuery( allSitesQuery() );
+
+	const inaccessibleSiteSlugs = useMemo( () => {
+		if ( ! purchases || ! sites ) {
+			return [];
+		}
+
+		const siteIds = new Set( sites.map( ( site ) => site.ID ) );
+		const inaccessibleSiteSlugs = new Set< string >();
+
+		for ( const purchase of purchases ) {
+			if ( isDisconnectedSite( purchase, siteIds ) ) {
+				inaccessibleSiteSlugs.add( purchase.site_slug );
+			}
+		}
+
+		return [ ...inaccessibleSiteSlugs ];
+	}, [ purchases, sites ] );
+
+	if ( inaccessibleSiteSlugs.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<Notice variant="error" title={ __( 'You have inaccessible sites' ) }>
+			<p>
+				{ __( 'You no longer have access to the following sites. Please review and take action.' ) }
+			</p>
+
+			<ul>
+				{ inaccessibleSiteSlugs.map( ( slug ) => (
+					<li key={ slug }>
+						<Link to={ `/sites/${ slug }` }>{ slug }</Link>
+					</li>
+				) ) }
+			</ul>
+		</Notice>
+	);
+}

--- a/client/dashboard/sites/notices.tsx
+++ b/client/dashboard/sites/notices.tsx
@@ -6,6 +6,7 @@ import InlineSupportLink from '../components/inline-support-link';
 import Notice from '../components/notice';
 import { OptInWelcome } from '../components/opt-in-welcome';
 import { isDashboardBackport } from '../utils/is-dashboard-backport';
+import InaccessibleSitesNotice from './notice-inaccessible-sites';
 
 const RestoringSitesNotices = ( { onClose }: { onClose?: () => void } ) => {
 	return (
@@ -39,6 +40,7 @@ export const SitesNotices = () => {
 	return (
 		<>
 			<OptInWelcome tracksContext="sites" />
+			<InaccessibleSitesNotice />
 			{ isRestoringAccount && (
 				<RestoringSitesNotices
 					onClose={ () =>


### PR DESCRIPTION
Part of DOTMSD-1106

> [!NOTE]
> This is a proof-of-concept PR; see the linked issue for discussion.

## Proposed Changes

Show disconnected Atomic sites as a notice above the site list as follows:

<img width="1015" height="575" alt="image" src="https://github.com/user-attachments/assets/76172d5d-088f-408d-bf91-96baab74e010" />

## Caveats

- All users will need to fetch all sites and purchases on `/sites`.
- It will have layout shift for users that do have inaccessible sites 😢 

## Why are these changes being made?

If a WoW site has disabled Jetpack connection, it will disappear from site list, preventing site owner to realize that they have a broken site.

## Testing Instructions

1. Purchase a site with Business plan
2. Transfer to Atomic
3. Enable SSH access in Settings -> SSH
4. SSH to that site
5. Run `wp jetpack disconnect blog`
6. Go to `/sites`
7. Wait and verify the notice appears
8. Verify you can click the site and go to site overview (with error message)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
