### PR TITLE
Reader: Implements product feedback on new subscriptions page

### DIFF
--- a/client/landing/subscriptions/components/add-sites-button/add-sites-button.tsx
+++ b/client/landing/subscriptions/components/add-sites-button/add-sites-button.tsx
@@ -1,5 +1,5 @@
-import { Gridicon } from '@automattic/components';
 import { Button } from '@wordpress/components';
+import { Icon, plus } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
@@ -46,7 +46,7 @@ const AddSitesButton = () => {
 				onClick={ handleClick }
 				href={ isDiscoverV3Enabled() && isEmailVerified ? '/reader/new' : undefined }
 			>
-				<Gridicon className="subscriptions-add-sites__button-icon" icon="plus" size={ 24 } />
+				<Icon className="subscriptions-add-sites__button-icon" icon={ plus } />
 				<span className="subscriptions-add-sites__button-text">
 					{ translate( 'New subscription' ) }
 				</span>

--- a/client/landing/subscriptions/components/add-sites-button/styles.scss
+++ b/client/landing/subscriptions/components/add-sites-button/styles.scss
@@ -13,9 +13,6 @@
 
 		.subscriptions-add-sites__button-icon {
 			display: block;
-			margin-top: 0;
-			margin-right: 0 !important;
-			top: 0;
 		}
 	}
 }

--- a/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
+++ b/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
@@ -1,8 +1,7 @@
 import './styles.scss';
 import { FormInputValidation } from '@automattic/components';
 import { SubscriptionManager } from '@automattic/data-stores';
-import { Button, TextControl } from '@wordpress/components';
-import { check, Icon } from '@wordpress/icons';
+import { Button, SearchControl } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
@@ -118,19 +117,16 @@ const AddSitesForm = ( {
 		<>
 			<form onSubmit={ onSubmit } className="subscriptions-add-sites__form--container">
 				<div className="subscriptions-add-sites__form-field">
-					<TextControl
-						className={ clsx(
-							'subscriptions-add-sites__form-input',
-							inputFieldError ? 'is-error' : ''
-						) }
+					<SearchControl
+						className={ clsx( 'subscriptions-add-sites__form-input', {
+							'is-error': !! inputFieldError,
+						} ) }
 						disabled={ subscribing }
-						placeholder={ placeholder || translate( 'https://www.site.com' ) }
+						placeholder={ placeholder || 'https://www.site.com' }
 						value={ inputValue }
 						onChange={ onTextFieldChange }
-						help={ isValidInput ? <Icon icon={ check } data-testid="check-icon" /> : undefined }
 						onBlur={ () => validateInputValue( inputValue, true ) }
 						__next40pxDefaultSize
-						__nextHasNoMarginBottom
 					/>
 
 					{ inputFieldError ? <FormInputValidation isError text={ inputFieldError } /> : null }

--- a/client/landing/subscriptions/components/add-sites-form/styles.scss
+++ b/client/landing/subscriptions/components/add-sites-form/styles.scss
@@ -11,27 +11,18 @@
 		flex: 1;
 	}
 
-	.components-base-control.is-error input {
-		border-color: var(--color-error);
+	.components-input-base {
+		border-radius: 4px;
+	}
 
-		&:focus {
-			box-shadow: 0 0 0 2px var(--color-error-10);
+	.components-input-control-prefix-wrapper {
+		svg {
+			fill: var(--studio-gray-30);
 		}
 	}
 
-	.is-error .components-base-control__field {
-		margin-bottom: 6px;
-	}
-
-	.components-text-control__input {
-		border-color: var(--studio-gray-10);
+	.components-input-control__input {
 		border-radius: 4px;
-		box-sizing: border-box;
-		font-size: 0.875rem;
-		padding: rem(10px) rem(16px);
-		/* We need to allow space for the SVG checkmark */
-		padding-right: calc(0.5rem + 24px);
-		height: 40px;
 
 		&::placeholder {
 			color: var(--studio-gray-20);
@@ -40,35 +31,31 @@
 		&[disabled] {
 			background: var(--studio-gray-5);
 		}
+	}
 
-		&:focus {
-			border-color: var(--studio-gray-10);
-			box-shadow: 0 0 0 2px var(--color-primary-10);
-			outline: none;
+	.components-input-control__container div.components-input-control__backdrop {
+		border-color: var(--studio-gray-10);
+	}
+
+	.is-error {
+		.components-input-control__container {
+			.components-input-control__backdrop {
+				border-color: var(--color-error);
+			}
+
+			&:focus .components-input-control__backdrop {
+				box-shadow: 0 0 0 0.5px var(--color-error);
+			}
 		}
+	}
+
+	.form-input-validation.is-error {
+		margin-top: 6px;
 	}
 
 	.subscriptions-add-sites__save-button {
 		&[disabled] {
 			cursor: not-allowed;
-		}
-	}
-
-	.components-base-control {
-		position: relative;
-	}
-
-	.components-base-control__help {
-		display: flex;
-		align-items: center;
-		margin: 0;
-		position: absolute;
-		top: 0;
-		right: 0.5rem;
-		height: 100%;
-
-		svg {
-			fill: var(--color-success-50);
 		}
 	}
 

--- a/client/landing/subscriptions/components/add-sites-form/test/add-sites-form.test.tsx
+++ b/client/landing/subscriptions/components/add-sites-form/test/add-sites-form.test.tsx
@@ -29,7 +29,7 @@ describe( 'AddSitesForm', () => {
 
 	test( 'displays an error message with invalid URL', () => {
 		renderWithContextProvider( <AddSitesForm { ...mockProps } /> );
-		const input = screen.getByRole( 'textbox' );
+		const input = screen.getByRole( 'searchbox' );
 
 		fireEvent.change( input, {
 			target: { value: 'not-a-url' },
@@ -42,7 +42,7 @@ describe( 'AddSitesForm', () => {
 
 	test( 'does not display an error message with valid URL', () => {
 		renderWithContextProvider( <AddSitesForm { ...mockProps } /> );
-		const input = screen.getByRole( 'textbox' );
+		const input = screen.getByRole( 'searchbox' );
 
 		fireEvent.change( input, {
 			target: { value: 'https://www.valid-url.com' },
@@ -55,7 +55,7 @@ describe( 'AddSitesForm', () => {
 
 	test( 'does not display an error message when input field is empty and blurred', () => {
 		renderWithContextProvider( <AddSitesForm { ...mockProps } /> );
-		const input = screen.getByRole( 'textbox' );
+		const input = screen.getByRole( 'searchbox' );
 
 		fireEvent.change( input, {
 			target: { value: '' },
@@ -66,23 +66,9 @@ describe( 'AddSitesForm', () => {
 		expect( screen.queryByText( 'Please enter a valid URL' ) ).not.toBeInTheDocument();
 	} );
 
-	test( 'displays a check icon when a valid URL is entered', () => {
-		renderWithContextProvider( <AddSitesForm { ...mockProps } /> );
-		const input = screen.getByRole( 'textbox' );
-
-		fireEvent.change( input, {
-			target: { value: 'https://www.valid-url.com' },
-		} );
-
-		fireEvent.blur( input );
-
-		const checkIcon = screen.getByTestId( 'check-icon' );
-		expect( checkIcon ).toBeInTheDocument();
-	} );
-
 	test( 'disables the Add site button when an invalid URL is entered', () => {
 		renderWithContextProvider( <AddSitesForm { ...mockProps } /> );
-		const input = screen.getByRole( 'textbox' );
+		const input = screen.getByRole( 'searchbox' );
 		const addButton = screen.getByRole( 'button', { name: 'Add site' } );
 
 		fireEvent.change( input, {
@@ -96,7 +82,7 @@ describe( 'AddSitesForm', () => {
 
 	test( 'disables the Add site button immediately when typing invalid URL', () => {
 		renderWithContextProvider( <AddSitesForm { ...mockProps } /> );
-		const input = screen.getByRole( 'textbox' );
+		const input = screen.getByRole( 'searchbox' );
 		const addButton = screen.getByRole( 'button', { name: 'Add site' } );
 
 		fireEvent.change( input, { target: { value: 'not-a-valid-url' } } );
@@ -106,7 +92,7 @@ describe( 'AddSitesForm', () => {
 
 	test( 'enables the Add site button immediately when typing valid URL', () => {
 		renderWithContextProvider( <AddSitesForm { ...mockProps } /> );
-		const input = screen.getByRole( 'textbox' );
+		const input = screen.getByRole( 'searchbox' );
 		const addButton = screen.getByRole( 'button', { name: 'Add site' } );
 
 		fireEvent.change( input, { target: { value: 'https://example.com' } } );
@@ -123,7 +109,7 @@ describe( 'AddSitesForm', () => {
 
 	test( 'disables button when transitioning from valid to invalid URL', () => {
 		renderWithContextProvider( <AddSitesForm { ...mockProps } /> );
-		const input = screen.getByRole( 'textbox' );
+		const input = screen.getByRole( 'searchbox' );
 		const addButton = screen.getByRole( 'button', { name: 'Add site' } );
 
 		fireEvent.change( input, { target: { value: 'https://example.com' } } );

--- a/client/landing/subscriptions/components/feed-preview/index.tsx
+++ b/client/landing/subscriptions/components/feed-preview/index.tsx
@@ -102,6 +102,7 @@ export default function FeedPreview( props: FeedPreviewProps ): JSX.Element | nu
 								useCompactCards
 								suppressSiteNameLink
 								restoreScroll={ false }
+								showDefaultEmptyContentIfMissing={ false }
 							/>
 						</div>
 					) : (

--- a/client/landing/subscriptions/components/feed-preview/index.tsx
+++ b/client/landing/subscriptions/components/feed-preview/index.tsx
@@ -99,10 +99,10 @@ export default function FeedPreview( props: FeedPreviewProps ): JSX.Element | nu
 								showFollowButton={ false }
 								showBack={ false }
 								trackScrollPage={ () => {} }
+								restoreScroll={ false }
 								useCompactCards
 								suppressSiteNameLink
-								restoreScroll={ false }
-								showDefaultEmptyContentIfMissing={ false }
+								hideDefaultEmptyContentIfMissing
 							/>
 						</div>
 					) : (

--- a/client/landing/subscriptions/components/site-subscriptions-list/styles/site-subscriptions-list.scss
+++ b/client/landing/subscriptions/components/site-subscriptions-list/styles/site-subscriptions-list.scss
@@ -26,10 +26,6 @@
 		&.header {
 			padding-bottom: 12px;
 			padding-top: 0;
-
-			@media (max-width: $break-small) {
-				display: none;
-			}
 		}
 
 		.title-cell {

--- a/client/landing/subscriptions/components/site-subscriptions-list/styles/site-subscriptions-list.scss
+++ b/client/landing/subscriptions/components/site-subscriptions-list/styles/site-subscriptions-list.scss
@@ -24,7 +24,7 @@
 		}
 
 		&.header {
-			padding-bottom: $font-code;
+			padding-bottom: 12px;
 			padding-top: 0;
 
 			@media (max-width: $break-small) {

--- a/client/landing/subscriptions/styles/list-actions-bar.scss
+++ b/client/landing/subscriptions/styles/list-actions-bar.scss
@@ -1,7 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
 
 %list-actions-bar {
-	margin-bottom: 57px;
+	margin-bottom: 24px;
 	display: flex;
 	justify-content: flex-start;
 	align-items: center;

--- a/client/reader/new-subscription/components/add-subscription-form/index.tsx
+++ b/client/reader/new-subscription/components/add-subscription-form/index.tsx
@@ -63,7 +63,7 @@ export default function AddSubscriptionForm( props: AddSubscriptionFormProps ): 
 					className={ `reader-add-subscription__form${ isEmailVerified ? '' : ' is-disabled' }` }
 				>
 					{ isAddNewTab && (
-						<h2 className="reader-add-subscription__form-title">
+						<h2 className="reader-add-subscription__form-desc">
 							{ translate( 'Add new sites, newsletters, and RSS feeds to your reading list.' ) }
 						</h2>
 					) }

--- a/client/reader/new-subscription/components/add-subscription-form/index.tsx
+++ b/client/reader/new-subscription/components/add-subscription-form/index.tsx
@@ -63,7 +63,7 @@ export default function AddSubscriptionForm( props: AddSubscriptionFormProps ): 
 					className={ `reader-add-subscription__form${ isEmailVerified ? '' : ' is-disabled' }` }
 				>
 					{ isAddNewTab && (
-						<h2 className="reader-add-subscription__form-desc">
+						<h2 className="reader-add-subscription__form-title">
 							{ translate( 'Add new sites, newsletters, and RSS feeds to your reading list.' ) }
 						</h2>
 					) }

--- a/client/reader/new-subscription/components/add-subscription-form/style.scss
+++ b/client/reader/new-subscription/components/add-subscription-form/style.scss
@@ -23,7 +23,7 @@
 	}
 }
 
-.reader-add-subscription__form-desc {
+.reader-add-subscription__form-title {
 	margin-bottom: 12px;
 }
 

--- a/client/reader/new-subscription/components/add-subscription-form/style.scss
+++ b/client/reader/new-subscription/components/add-subscription-form/style.scss
@@ -1,24 +1,30 @@
 @import '@wordpress/base-styles/mixins';
 @import '@wordpress/base-styles/breakpoints';
 
-.new-subscription-navigation .section-nav-tabs__list {
-	overflow: auto;
+.new-subscription-navigation {
+	margin-bottom: 24px;
 
-	@include break-small {
-		overflow: hidden;
+	.section-nav-tabs__list {
+		overflow: auto;
+
+		@include break-small {
+			overflow: hidden;
+		}
+	}
+
+	.section-nav-tab__link {
+		padding-top: 0;
 	}
 }
 
 .reader-add-subscription {
-	padding: 10px 0;
-
 	strong {
 		font-weight: 700;
 	}
 }
 
-.reader-add-subscription__form-title {
-	margin-bottom: 10px;
+.reader-add-subscription__form-desc {
+	margin-bottom: 12px;
 }
 
 .reader-add-subscription__instructions {
@@ -53,5 +59,5 @@
 .reader-add-subscription__subscriptions-title {
 	font-size: $font-title-small;
 	font-weight: 500;
-	margin-bottom: 10px;
+	margin: 24px 0 12px;
 }

--- a/client/reader/site-subscriptions-manager/style.scss
+++ b/client/reader/site-subscriptions-manager/style.scss
@@ -34,15 +34,6 @@ body.is-section-reader .layout.is-section-reader .site-subscriptions-manager {
 		@extend %search-component-subscriptions-style;
 	}
 
-	.site-subscriptions-list-actions-bar,
-	.site-subscriptions-list,
-	.recommended-sites,
-	.navigation-header {
-		@media (max-width: $break-small) {
-			padding: 0 16px;
-		}
-	}
-
 	&__header-h-stack {
 		margin: 0 0 26px;
 
@@ -64,10 +55,6 @@ body.is-section-reader .layout.is-section-reader .site-subscriptions-manager {
 				}
 			}
 		}
-	}
-
-	.site-subscriptions-manager__nav {
-		margin-bottom: 32px;
 	}
 
 	hr.subscriptions__separator {
@@ -105,6 +92,21 @@ body.is-section-reader .layout.is-section-reader .site-subscriptions-manager {
 		font-family: "SF Pro Text", $sans;
 		line-height: $font-title-small;
 		margin: 48px 0 16px;
+	}
+}
+
+.site-subscriptions-manager__nav {
+	margin-bottom: 24px;
+
+	.section-nav-tab__link {
+		padding-top: 0;
+
+		.count {
+			@media (max-width: $break-mobile) {
+				border-color: var(--color-border);
+				color: var(--color-text);
+			}
+		}
 	}
 }
 

--- a/client/reader/site-subscriptions-manager/subscriptions-manager-wrapper.tsx
+++ b/client/reader/site-subscriptions-manager/subscriptions-manager-wrapper.tsx
@@ -104,6 +104,7 @@ const SubscriptionsManagerWrapper = ( {
 					className="site-subscriptions-manager__nav"
 					selectedText={ selectedTabText }
 					variation="minimal"
+					enforceTabsView
 				>
 					<NavTabs>
 						<NavItem

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -80,7 +80,7 @@ class ReaderStream extends Component {
 		placeholderFactory: PropTypes.func,
 		recsStreamKey: PropTypes.string,
 		restoreScroll: PropTypes.bool,
-		showDefaultEmptyContentIfMissing: PropTypes.bool,
+		hideDefaultEmptyContentIfMissing: PropTypes.bool,
 		showFollowButton: PropTypes.bool,
 		showFollowInHeader: PropTypes.bool,
 		sidebarTabTitle: PropTypes.string,
@@ -104,7 +104,6 @@ class ReaderStream extends Component {
 		isMain: true,
 		onUpdatesShown: noop,
 		restoreScroll: true,
-		showDefaultEmptyContentIfMissing: true,
 		showFollowButton: true,
 		showFollowInHeader: false,
 		suppressSiteNameLink: false,
@@ -675,7 +674,7 @@ class ReaderStream extends Component {
 
 		if ( hasNoPosts ) {
 			let emptyBody = this.props.emptyContent?.();
-			if ( ! emptyBody && this.props.showDefaultEmptyContentIfMissing ) {
+			if ( ! emptyBody && ! this.props.hideDefaultEmptyContentIfMissing ) {
 				emptyBody = <EmptyContent />;
 			}
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes: [READ-349](https://linear.app/a8c/issue/READ-349/reader-product-feedback)

## Proposed Changes

- Improves spacing on "New Subscriptions" page.
- Show subscriptions table header on small screens.
- Replace check mark on text control with "X" icon.
- Don't show stream placeholder on feed preview.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

 UI Improvements after product QA.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/reader/new?flags=reader/discover-v3`
- Verify spacing is now consistent (using only `24px` and `10px`)
- Switch to mobile view and verify subscription table now have the header.
- Type any input on text control and verify "X" icon is appearing now instead of check mark (on valid input).
- Search "aol.com", verify no placeholder is shown now.
- Go to `/reader/subscriptions`. Verify both desktop and mobile view having improved spacing.

| Before | After |
| -------|------| 
| <img width="412" height="863" alt="image" src="https://github.com/user-attachments/assets/548e3975-6d02-4ef8-a080-04c32667b258" /> | <img width="406" height="862" alt="image" src="https://github.com/user-attachments/assets/c5bb99eb-395e-4e46-a973-3e8f3a0bd261" /> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
