### PR TITLE
Checkout: support multiple subscription IDs in /checkout/renew route

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
@@ -485,15 +485,18 @@ function useAddRenewalBySubscriptionId( {
 			} );
 			return;
 		}
-		const cartItem = createRequestCartProduct( {
-			product_slug: '',
-			extra: {
-				purchaseId: String( originalPurchaseId ),
-				purchaseType: 'renewal',
-			},
-		} );
-		debug( 'preparing renewal from subscription ID', originalPurchaseId );
-		dispatch( { type: 'RENEWALS_ADD', products: [ cartItem ] } );
+		const subscriptionIds = String( originalPurchaseId ).split( ',' );
+		const cartItems = subscriptionIds.map( ( subscriptionId ) =>
+			createRequestCartProduct( {
+				product_slug: '',
+				extra: {
+					purchaseId: subscriptionId,
+					purchaseType: 'renewal',
+				},
+			} )
+		);
+		debug( 'preparing renewals from subscription IDs', originalPurchaseId );
+		dispatch( { type: 'RENEWALS_ADD', products: cartItems } );
 	}, [ addHandler, dispatch, originalPurchaseId, translate ] );
 }
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-1730/checkout-renewal-urls-are-no-longer-supporting-multiple-subscriptions

## Proposed Changes

* Update `useAddRenewalBySubscriptionId` to split a comma-separated subscription ID string and create one cart item per ID, rather than passing the entire string as a single `purchaseId`

## Why are these changes being made?

* The `/checkout/renew/:subscriptionId` route is meant to support comma-separated subscription IDs (e.g. `/checkout/renew/12345,15554,5343`) so that multiple renewals can be initiated in one visit
* Previously, `useAddRenewalBySubscriptionId` passed the full string to a single `createRequestCartProduct` call, so only one (invalid) cart item would be created instead of one per subscription
* The existing `useAddRenewalItems` code path already handles comma-separated purchase IDs the same way — this brings the subscription-ID-only path into parity

## Testing Instructions

* Use a site with multiple subscriptions.
* Visit `/checkout/renew/12345` (replacing the number with the actual subscription ID of one subscription) and confirm checkout loads with a single renewal item in the cart
* Visit `/checkout/renew/12345,15554` (replacing the numbers with multiple subscription IDs on the same site) and confirm checkout loads with three separate renewal items in the cart, one for each subscription ID
