### PR TITLE
Dashboard: Add na_site_preview flag to CIAB site preview iframes

### DIFF
--- a/client/dashboard/sites/overview-site-preview-card/index.tsx
+++ b/client/dashboard/sites/overview-site-preview-card/index.tsx
@@ -1,6 +1,7 @@
 import { useResizeObserver } from '@wordpress/compose';
 import { Card } from '../../components/card';
 import SiteIcon from '../../components/site-icon';
+import { isCommerceGarden } from '../../utils/site-types';
 import SitePreview from '../site-preview';
 import type { Site } from '@automattic/api-core';
 
@@ -39,7 +40,12 @@ const SitePreviewCard = ( { site }: { site: Site } ) => {
 						backgroundColor: '#f0f0f0',
 					} }
 				>
-					<SitePreview url={ url } scale={ width / 1200 } height={ height / ( width / 1200 ) } />
+					<SitePreview
+						url={ url }
+						scale={ width / 1200 }
+						height={ height / ( width / 1200 ) }
+						naSitePreview={ isCommerceGarden( site ) }
+					/>
 				</div>
 			) }
 		</Card>

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -28,6 +28,7 @@ import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { wpcomLink } from '../../utils/link';
 import { getSiteBadge } from '../../utils/site-badge';
 import { hasHostingFeature, hasJetpackModule } from '../../utils/site-features';
+import { isCommerceGarden } from '../../utils/site-types';
 import { getVisibilityLabels } from '../../utils/site-visibility';
 import { canManageSite } from '../features';
 import { isSitePlanTrial, isSitePlanWooHosted } from '../plans';
@@ -187,7 +188,12 @@ export function Preview( { site }: { site: Site } ) {
 				</div>
 			) }
 			{ width && ! iframeDisabled && (
-				<SitePreview url={ url } scale={ width / 1200 } height={ 1200 } />
+				<SitePreview
+					url={ url }
+					scale={ width / 1200 }
+					height={ 1200 }
+					naSitePreview={ isCommerceGarden( site ) }
+				/>
 			) }
 		</div>
 	);

--- a/client/dashboard/sites/site-preview/index.tsx
+++ b/client/dashboard/sites/site-preview/index.tsx
@@ -5,11 +5,13 @@ export default function SitePreview( {
 	scale = 1,
 	width = 1200,
 	height = 800,
+	naSitePreview = false,
 }: {
 	url: string;
 	scale?: number;
 	width?: number;
 	height?: number;
+	naSitePreview?: boolean;
 } ) {
 	// The /sites endpoint may return non-secure URLs. Often these _can_ be
 	// loaded securely, so it's worth trying to load over https. If it fails,
@@ -18,6 +20,8 @@ export default function SitePreview( {
 	// To do: check why the endpoint returns non-secure URLs when it will
 	// redirect to a secure URL.
 	const secureUrl = url.replace( /^http:\/\//, 'https://' );
+	const params =
+		'hide_banners=true&preview=true&iframe=true' + ( naSitePreview ? '&na_site_preview=1' : '' );
 	return (
 		<iframe
 			// Enabling sandbox disables most features, such as autoplay,
@@ -32,7 +36,7 @@ export default function SitePreview( {
 			title={ __( 'Site Preview' ) }
 			// Hide banners + `preview` hides cookie banners + `iframe` hides
 			// admin bar for atomic sites.
-			src={ `${ secureUrl }/?hide_banners=true&preview=true&iframe=true` }
+			src={ `${ secureUrl }/?${ params }` }
 			style={ {
 				display: 'block',
 				border: 'none',


### PR DESCRIPTION
Depends on 3599-ghe-Automattic/ciab-admin

## Summary
- Adds `na_site_preview=1` query parameter to the site preview iframe URL for Commerce Garden (CIAB) sites only
- Adds a `naSitePreview` prop to the `SitePreview` component

## Test plan
- Verify CIAB site preview iframes include `na_site_preview=1` in the src URL
- Verify non-CIAB site preview iframes do not include the `na_site_preview=1` param
- Verify site previews render correctly in both the sites grid view and the site overview page