### PR TITLE
Dashboard: Register CIAB OAuth client IDs for branding

### DIFF
--- a/client/lib/oauth2-clients.js
+++ b/client/lib/oauth2-clients.js
@@ -70,6 +70,11 @@ export const isPartnerPortalOAuth2Client = ( oauth2Client ) => {
 	return oauth2Client && [ 102832, 103914 ].includes( oauth2Client.id );
 };
 
+export const isCiabOAuth2Client = ( oauth2Client ) => {
+	// 134404 => CIAB Dev, 134405 => CIAB Staging/Production.
+	return oauth2Client && [ 134404, 134405 ].includes( oauth2Client.id );
+};
+
 export const isVIPOAuth2Client = ( oauth2Client ) => {
 	return oauth2Client?.id === 76596;
 };

--- a/client/state/oauth2-clients/reducer.js
+++ b/client/state/oauth2-clients/reducer.js
@@ -144,6 +144,18 @@ export const initialClientsData = {
 		title: 'Blaze Pro',
 		url: 'https://blazepro.tumblr.com',
 	},
+	134404: {
+		id: 134404,
+		name: 'ciab',
+		title: 'CIAB by Woo',
+		url: 'https://woo.com',
+	},
+	134405: {
+		id: 134405,
+		name: 'ciab',
+		title: 'CIAB by Woo',
+		url: 'https://woo.com',
+	},
 };
 
 export function clients( state = initialClientsData, action ) {


### PR DESCRIPTION
Stacked on #109038
Fixes DOTMSD-1114

## Proposed Changes

- Add CIAB OAuth client entries (134404 dev, 134405 staging/prod) to `initialClientsData` in the oauth2-clients reducer
- Add `isCiabOAuth2Client` utility function in `client/lib/oauth2-clients.js`

## Why are these changes being made?

The Dashboard on `my.woo.ai` uses OAuth instead of cookie auth. Registering the client IDs in Redux enables branding on the WordPress.com OAuth authorize/login pages — the same mechanism other OAuth clients use:

- `client/layout/logged-out.jsx` applies `classes[oauth2Client.name]` as a CSS class and renders `<OauthClientMasterbar>` (line ~208-212)
- `client/login/wp-login/components/heading-logo.tsx` renders client-specific logos
- `client/login/wp-login/hooks/get-header-text.tsx` customizes header text per client
- `client/layout/masterbar/oauth-client.jsx` renders the OAuth masterbar with client title/icon

See existing examples: `isWooOAuth2Client` usage in `client/layout/logged-out.jsx`, `client/login/wp-login/index.jsx`, `client/signup/steps/user/index.jsx`.

## Testing Instructions

1. In an incognito tab navigate to `my.woo.localhost:3000`
  1a. Or navigate directly to `https://public-api.wordpress.com/oauth2/authorize?client_id=134404&response_type=code&redirect_uri=https://my.woo.localhost:3000` (or use `134405`)
2. Open DevTools and inspect the `<body>` or layout wrapper — confirm the `ciab`
3. The `<OauthClientMasterbar>` should render showing "CIAB by Woo" as the client title
4. The "Back to CIAB by Woo" link should point to `https://woo.com`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?