### PR TITLE
A4A: Remove requirements for BD system for referring Pressable Premium plans.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
@@ -18,8 +18,7 @@ import getPressablePlan, {
 	PressablePlan,
 } from 'calypso/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan';
 import PlanSelectionFilter from 'calypso/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter';
-import { useDispatch, useSelector } from 'calypso/state';
-import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import HostingPlanSection from '../../common/hosting-plan-section';
 import CustomPlanCardContent from './custom-plan-card-content';
@@ -110,8 +109,6 @@ export default function PressablePlanSection( {
 	} );
 
 	const selectedPlanInfo = selectedPlan ? getPressablePlan( selectedPlan.slug ) : null;
-
-	const isBDBillingSystem = useSelector( getActiveAgency )?.billing_system === 'billingdragon';
 
 	const filteredPressablePlans = useMemo( () => {
 		if ( ! pressablePlans ) {
@@ -281,7 +278,6 @@ export default function PressablePlanSection( {
 	const isCustomPlan = ! selectedPlan;
 
 	const hasNewPremiumPlans =
-		isBDBillingSystem &&
 		isReferralMode &&
 		filteredPressablePlans.some( ( plan ) => plan.slug.startsWith( 'pressable-premium-' ) );
 

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
@@ -5,8 +5,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import A4ASlider, { Option } from 'calypso/a8c-for-agencies/components/slider';
 import useSliderPersistence from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-slider-persistence';
-import { useDispatch, useSelector } from 'calypso/state';
-import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	FILTER_TYPE_INSTALL,
@@ -65,13 +64,9 @@ export default function PlanSelectionFilter( {
 
 	const isPremiumPlanTab = selectedTab === PLAN_CATEGORY_PREMIUM;
 
-	const isBDBillingSystem = useSelector( getActiveAgency )?.billing_system === 'billingdragon';
-
 	// Currently, we only want the premium plans for referral mode
 	const hasNewPremiumPlans =
-		isBDBillingSystem &&
-		isReferralMode &&
-		plans.some( ( plan ) => plan.slug.startsWith( 'pressable-premium-' ) );
+		isReferralMode && plans.some( ( plan ) => plan.slug.startsWith( 'pressable-premium-' ) );
 
 	const lowPlanOptions = useMemo(
 		() =>


### PR DESCRIPTION
Context: p1772548966997179-slack-C091P0A65U5

## Proposed Changes

Currently, only agencies already in the BD system can refer Premium plans. This PR removes the BD system requirement for referring Pressable Premium plans.

## Why are these changes being made?

* This allows agencies that are still using legacy systems to refer Pressable Premium plans.

## Testing Instructions
* First, use an Agency that is still on a legacy system. You can create a new one and set it's billing scheme to Legacy via the MC tool.
* Switch your billing scheme to **877**. You can do it in the Billing scheme MC tool.
* Use the A4A live link and navigate to `/marketplace/hosting/pressable` page.
* Switch the Referral mode toggle.
* Confirm that you can see and select Premium plans.
* Proceed to refer and complete the entire referral process.
* Confirm everything is working.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?