### PR TITLE
Agents Manager: Fix some issues for the ZD human support

### DIFF
--- a/packages/agents-manager/src/components/escalation-button/index.tsx
+++ b/packages/agents-manager/src/components/escalation-button/index.tsx
@@ -1,15 +1,16 @@
 import { SummaryButton } from '@automattic/components';
 import { __ } from '@wordpress/i18n';
-import './style.scss';
 import { useNavigate } from 'react-router-dom';
 import { useAgentsManagerContext } from '../../contexts';
 import { getSessionId as getStoredSessionId } from '../../utils/agent-session';
+import './style.scss';
 
 export function EscalationButton() {
 	const { agentConfig } = useAgentsManagerContext();
 	const sessionId = agentConfig?.sessionId || getStoredSessionId( agentConfig?.agentId );
 
 	const navigate = useNavigate();
+
 	return (
 		<SummaryButton
 			className="agents-manager__escalation-button"

--- a/packages/agents-manager/src/components/escalation-button/style.scss
+++ b/packages/agents-manager/src/components/escalation-button/style.scss
@@ -1,19 +1,14 @@
 .agents-manager__escalation-button.summary-button.components-button {
 	text-align: start;
-}
+	background-color: var( --color-background );
+	border-color: var( --color-muted );
 
-.agents-manager-chat--docked {
-	.agents-manager__escalation-button.summary-button.components-button {
-		background-color: #2f2f2f;
-		border-color: #464646;
+	&:hover:not( :disabled ) {
+		border-color: var( --color-muted );
+		background-color: color-mix( in srgb, var( --color-foreground ) 8%, transparent );
+	}
 
-		&:hover {
-			border-color: #494949;
-			background-color: #595959;
-		}
-
-		.summary-button-title {
-			color: #fff;
-		}
+	.summary-button-title {
+		color: var( --color-foreground );
 	}
 }

--- a/packages/agents-manager/src/components/zendesk-chat/style.scss
+++ b/packages/agents-manager/src/components/zendesk-chat/style.scss
@@ -17,6 +17,7 @@
 		background: #ccc;
 		flex: 1;
 	}
+
 	&::after {
 		display: block;
 		content: '';

--- a/packages/agents-manager/src/utils/convert-tool-message-to-component.ts
+++ b/packages/agents-manager/src/utils/convert-tool-message-to-component.ts
@@ -40,7 +40,7 @@ export function convertToolMessagesToComponents( {
 					{
 						type: 'component',
 						component: EscalationButton,
-					} as any,
+					},
 				],
 			};
 		}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to #108442. Use `agenttic-ui`'s theme colors for ZD's escalation button

## Proposed Changes

* Use `agenttic-ui`'s theme colors for ZD's escalation button
* Remove unnecessary type
* Format code

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Use `agenttic-ui`'s theme colors for ZD's escalation button

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This is a minor change, I will go self-review, test, and then merge

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
