### PR TITLE
pre-commit-hook: replace deleted apps/phpcs.xml with WordPress standard

### DIFF
--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -137,9 +137,7 @@ toPHPCBF.forEach( ( file ) => console.log( `PHPCBF formatting staged file: ${ fi
 if ( toPHPCBF.length ) {
 	if ( phpcs ) {
 		try {
-			execSync(
-				`${ quotedPath( phpcbfPath ) } --standard=apps/phpcs.xml ${ toPHPCBF.join( ' ' ) }`
-			);
+			execSync( `${ quotedPath( phpcbfPath ) } --standard=WordPress ${ toPHPCBF.join( ' ' ) }` );
 		} catch ( error ) {
 			// PHPCBF returns a `0` or `1` exit code on success, and `2` on failures. ¯\_(ツ)_/¯
 			// https://github.com/squizlabs/PHP_CodeSniffer/blob/HEAD/src/Runner.php#L210
@@ -199,14 +197,10 @@ if ( toEslint.length ) {
 // and finally PHPCS
 if ( toPHPCS.length ) {
 	if ( phpcs ) {
-		const lintResult = spawnSync(
-			quotedPath( phpcsPath ),
-			[ '--standard=apps/phpcs.xml', ...toPHPCS ],
-			{
-				shell: true,
-				stdio: 'inherit',
-			}
-		);
+		const lintResult = spawnSync( quotedPath( phpcsPath ), [ '--standard=WordPress', ...toPHPCS ], {
+			shell: true,
+			stdio: 'inherit',
+		} );
 
 		if ( lintResult.status ) {
 			linterFailure();


### PR DESCRIPTION
apps/phpcs.xml was removed when the editing-toolkit plugin was deleted in #93238. The remaining PHP files (in apps/happy-blocks) follow the WordPress coding standard, so use

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-16229

## Proposed Changes

* On the pre-commit hooks file, update the php linter from `apps/phpcs.xml` to `WordPress`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The `apps/phpcs.xml` was removed a year and a half ago on https://github.com/Automattic/wp-calypso/commit/24a90a6c8dd#diff-a9e5eb4772c1345f0c9943f2bbe2f69d6a07f1c45398786d1bd9aca2d42b918f, and making changes on php files (the `happy-blocks` app has some) triggers a commit error:

<img width="3708" height="907" alt="image" src="https://github.com/user-attachments/assets/e5dc1796-ca2a-4543-93d9-d623ee13831f" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch locally
* Make any change on `apps/happy-blocks/block-library/search-card/index.php`
* `git add . && git commit -m "testing"`
* Check that the linter shows some errors:

<img width="3702" height="1539" alt="image" src="https://github.com/user-attachments/assets/62017db8-fb6e-437a-ba50-bfa36dbcb8d3" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
