### PR TITLE
Agents Manager: add search for conversation history

### DIFF
--- a/packages/agents-manager/src/components/conversation-history-view/index.tsx
+++ b/packages/agents-manager/src/components/conversation-history-view/index.tsx
@@ -1,5 +1,5 @@
-import { Button } from '@wordpress/components';
-import { useRef } from '@wordpress/element';
+import { Button, SearchControl } from '@wordpress/components';
+import { useMemo, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import useConversationList from '../../hooks/use-conversation-list';
 import { LocalConversationListItem } from '../../types';
@@ -16,11 +16,31 @@ export default function ConversationHistoryView( { onSelectConversation, onNewCh
 	// To use the latest onSelectConversation in the callback
 	const onSelectConversationRef = useRef( onSelectConversation );
 	onSelectConversationRef.current = onSelectConversation;
+	const [ searchInput, setSearchInput ] = useState( '' );
 
 	const { conversations, isLoading, isError } = useConversationList();
+	const normalizedSearch = searchInput.trim().toLowerCase();
+	const filteredConversations = useMemo( () => {
+		if ( ! normalizedSearch ) {
+			return conversations;
+		}
+
+		return conversations.filter( ( conversation ) =>
+			( conversation.first_message?.content ?? '' ).toLowerCase().includes( normalizedSearch )
+		);
+	}, [ conversations, normalizedSearch ] );
+	const hasSearch = normalizedSearch.length > 0;
 
 	return (
 		<div className="agents-manager-conversation-history-view">
+			<div className="agents-manager-conversation-history-view__search">
+				<SearchControl
+					value={ searchInput }
+					onChange={ setSearchInput }
+					onClick={ ( e ) => e.currentTarget.focus() }
+					placeholder={ __( 'Search past chats', '__i18n_text_domain__' ) }
+				/>
+			</div>
 			<div className="agents-manager-conversation-history-view__content">
 				{ /* States: loading → error → empty → list */ }
 				{ isLoading && (
@@ -43,9 +63,21 @@ export default function ConversationHistoryView( { onSelectConversation, onNewCh
 						</p>
 					</div>
 				) }
-				{ ! isLoading && ! isError && conversations.length > 0 && (
+				{ ! isLoading &&
+					! isError &&
+					conversations.length > 0 &&
+					hasSearch &&
+					filteredConversations.length === 0 && (
+						<div className="agents-manager-conversation-history-view__empty">
+							<p>{ __( 'No matching conversations', '__i18n_text_domain__' ) }</p>
+							<p className="agents-manager-conversation-history-view__empty-hint">
+								{ __( 'Try a different search term', '__i18n_text_domain__' ) }
+							</p>
+						</div>
+					) }
+				{ ! isLoading && ! isError && filteredConversations.length > 0 && (
 					<div className="agents-manager-conversation-history-view__list">
-						{ conversations.map( ( conversation ) => (
+						{ filteredConversations.map( ( conversation ) => (
 							<ConversationListItem
 								key={ conversation.session_id ?? conversation.conversation_id }
 								conversation={ conversation }

--- a/packages/agents-manager/src/components/conversation-history-view/style.scss
+++ b/packages/agents-manager/src/components/conversation-history-view/style.scss
@@ -1,4 +1,5 @@
 @import '../../styles/mixins.scss';
+@import '@wordpress/base-styles/variables';
 
 .agents-manager-conversation-history-view {
 	display: flex;
@@ -7,6 +8,36 @@
 	width: 100%;
 	min-height: 0;
 	padding-top: 12px;
+
+	&__search {
+		flex-shrink: 0;
+		padding: 0 8px 8px;
+
+		.components-search-control {
+			.components-input-control__container {
+				background-color: #f2f2f2;
+			}
+
+			.components-input-base {
+				border-radius: 16px;
+				color: var( --color-text );
+			}
+
+			.components-input-control__input {
+				color: var( --color-text );
+			}
+
+			.components-input-control__backdrop {
+				opacity: 0;
+			}
+
+			&:focus-within {
+				.components-input-control__backdrop {
+					opacity: 1;
+				}
+			}
+		}
+	}
 
 	&__content {
 		flex: 1;
@@ -82,6 +113,28 @@
 // Docked chat styles override
 @include docked-chat-without-modal {
 	.agents-manager-conversation-history-view {
+		&__search {
+			padding: 0 0 8px;
+
+			.components-search-control {
+				.components-input-control__container {
+					background-color: $gray-800;
+
+					.components-input-control__prefix {
+						color: #f2f2f2;
+					}
+
+					.components-input-control__input {
+						color: $white;
+
+						&::placeholder {
+							color: #f2f2f2;
+						}
+					}
+				}
+			}
+		}
+
 		&__content {
 			padding-top: 0;
 			padding-left: 0;

--- a/packages/agents-manager/src/components/test/ConversationHistoryView.test.tsx
+++ b/packages/agents-manager/src/components/test/ConversationHistoryView.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ConversationHistoryView from '../conversation-history-view';
+
+const mockUseConversationList = jest.fn();
+
+jest.mock( '../../hooks/use-conversation-list', () => ( {
+	__esModule: true,
+	default: () => mockUseConversationList(),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text: string ) => text,
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	Button: ( {
+		children,
+		onClick,
+		className,
+	}: {
+		children: unknown;
+		onClick?: () => void;
+		className?: string;
+	} ) => (
+		<button type="button" onClick={ onClick } className={ className }>
+			{ children }
+		</button>
+	),
+	SearchControl: ( {
+		value,
+		onChange,
+		placeholder,
+	}: {
+		value: string;
+		onChange: ( value: string ) => void;
+		placeholder?: string;
+	} ) => (
+		<input
+			type="search"
+			aria-label={ placeholder ?? 'Search' }
+			placeholder={ placeholder }
+			value={ value }
+			onChange={ ( e ) => onChange( e.target.value ) }
+		/>
+	),
+} ) );
+
+jest.mock( '../conversation-list-item', () => ( {
+	__esModule: true,
+	default: ( {
+		conversation,
+		onClick,
+	}: {
+		conversation: { first_message?: { content?: string } };
+		onClick: ( conversation: unknown ) => void;
+	} ) => (
+		<button type="button" onClick={ () => onClick( conversation ) }>
+			{ conversation.first_message?.content ?? 'Untitled conversation' }
+		</button>
+	),
+} ) );
+
+jest.mock( '../conversation-list-skeleton', () => ( {
+	__esModule: true,
+	default: () => <div>Loading</div>,
+} ) );
+
+describe( 'ConversationHistoryView', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockUseConversationList.mockReturnValue( {
+			conversations: [
+				{
+					session_id: 'session-1',
+					first_message: {
+						content: 'How do I configure DNS records?',
+						created_at: '2026-03-04 11:00:00',
+					},
+				},
+				{
+					session_id: 'session-2',
+					first_message: {
+						content: 'Set up WooCommerce shipping zones',
+						created_at: '2026-03-03 10:00:00',
+					},
+				},
+			],
+			isLoading: false,
+			isError: false,
+		} );
+	} );
+
+	it( 'shows all conversations when search is empty', () => {
+		render(
+			<ConversationHistoryView onSelectConversation={ jest.fn() } onNewChat={ jest.fn() } />
+		);
+
+		expect( screen.getByText( 'How do I configure DNS records?' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Set up WooCommerce shipping zones' ) ).toBeInTheDocument();
+	} );
+
+	it( 'filters conversations by search text (case-insensitive)', async () => {
+		const user = userEvent.setup();
+		render(
+			<ConversationHistoryView onSelectConversation={ jest.fn() } onNewChat={ jest.fn() } />
+		);
+
+		await user.type( screen.getByRole( 'searchbox', { name: /search past chats/i } ), 'Woo' );
+
+		expect( screen.queryByText( 'How do I configure DNS records?' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'Set up WooCommerce shipping zones' ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows no-matching-conversations state when search has no results', async () => {
+		const user = userEvent.setup();
+		render(
+			<ConversationHistoryView onSelectConversation={ jest.fn() } onNewChat={ jest.fn() } />
+		);
+
+		await user.type(
+			screen.getByRole( 'searchbox', { name: /search past chats/i } ),
+			'nonexistent query'
+		);
+
+		expect( screen.getByText( 'No matching conversations' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Try a different search term' ) ).toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
Part of BSKY-1704

## Proposed Changes

* Add a search field to Agents Manager conversation history (`/history`) so past chats can be filtered by their first message content.
* Apply case-insensitive client-side filtering as the user types.
* Add a dedicated empty state when a query has no matches.
* Keep existing loading/error/no-history states and “Start a new chat” flow unchanged.
* Add unit tests for: default list rendering, filtering behavior, and no-results state.

## Why are these changes being made?

* Agents Manager conversation history was missing search, making it difficult to find older chats quickly.
* This change adds lightweight in-view filtering without changing conversation loading or navigation behavior.

## Testing Instructions

* Run:
  * `yarn jest --config packages/agents-manager/jest.config.js packages/agents-manager/src/components/test/ConversationHistoryView.test.tsx`
* Open Agents Manager history (`/history`) in Calypso.
* Verify:
  * With an empty query, all history items are shown.
  * Typing a matching query filters list items immediately.
  * Typing a non-matching query shows “No matching conversations”.
  * Clearing the query restores the full list.
  * “Start a new chat” still works.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
