### PR TITLE
Fix large plugin upload handling and update size limit messages

### DIFF
--- a/client/blocks/upload-drop-zone/index.jsx
+++ b/client/blocks/upload-drop-zone/index.jsx
@@ -19,6 +19,7 @@ class UploadDropZone extends Component {
 	static propTypes = {
 		doUpload: PropTypes.func.isRequired,
 		disabled: PropTypes.bool,
+		onFileTooLarge: PropTypes.func,
 		// Connected
 		siteId: PropTypes.number,
 	};
@@ -36,9 +37,13 @@ class UploadDropZone extends Component {
 		debug( 'zip file:', file );
 
 		if ( file.size > MAX_UPLOAD_ZIP_SIZE ) {
-			this.props.errorNotice(
-				translate( 'Zip file is too large. Please upload a file under 50 MB.' )
-			);
+			if ( this.props.onFileTooLarge ) {
+				this.props.onFileTooLarge( file );
+			} else {
+				this.props.errorNotice(
+					translate( 'Zip file is too large. Please upload a file under 50 MB.' )
+				);
+			}
 			return;
 		}
 

--- a/client/blocks/upload-drop-zone/index.jsx
+++ b/client/blocks/upload-drop-zone/index.jsx
@@ -38,7 +38,7 @@ class UploadDropZone extends Component {
 
 		if ( file.size > MAX_UPLOAD_ZIP_SIZE ) {
 			if ( this.props.onFileTooLarge ) {
-				this.props.onFileTooLarge( file );
+				this.props.onFileTooLarge();
 			} else {
 				this.props.errorNotice(
 					translate( 'Zip file is too large. Please upload a file under %(maxSize)d MB.', {

--- a/client/blocks/upload-drop-zone/index.jsx
+++ b/client/blocks/upload-drop-zone/index.jsx
@@ -41,7 +41,9 @@ class UploadDropZone extends Component {
 				this.props.onFileTooLarge( file );
 			} else {
 				this.props.errorNotice(
-					translate( 'Zip file is too large. Please upload a file under 50 MB.' )
+					translate( 'Zip file is too large. Please upload a file under %(maxSize)d MB.', {
+						args: { maxSize: Math.floor( MAX_UPLOAD_ZIP_SIZE / 1000000 ) },
+					} )
 				);
 			}
 			return;

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -129,7 +129,7 @@ class PluginUpload extends Component {
 	}
 
 	renderFileTooLarge() {
-		const { translate, siteSlug } = this.props;
+		const { translate, siteAdminUrl } = this.props;
 
 		return (
 			<Notice
@@ -144,10 +144,7 @@ class PluginUpload extends Component {
 					}
 				) }
 			>
-				<NoticeAction
-					href={ `https://${ siteSlug }/wp-admin/plugin-install.php?tab=upload` }
-					external
-				>
+				<NoticeAction href={ `${ siteAdminUrl }plugin-install.php?tab=upload` } external>
 					{ translate( 'Go to WP Admin' ) }
 				</NoticeAction>
 			</Notice>

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -13,8 +13,11 @@ import FeatureExample from 'calypso/components/feature-example';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
 import HostingActivateStatus from 'calypso/hosting/server-settings/hosting-activate-status';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { MAX_UPLOAD_ZIP_SIZE } from 'calypso/lib/automated-transfer/constants';
 import { isHostingTrialSite } from 'calypso/sites-dashboard/utils';
 import {
 	fetchAutomatedTransferStatus,
@@ -76,6 +79,10 @@ class PluginUpload extends Component {
 		page.back();
 	};
 
+	handleFileTooLarge = () => {
+		this.setState( { fileTooLarge: true } );
+	};
+
 	onProceedClick = () => {
 		this.setState( {
 			showEligibility: false,
@@ -95,9 +102,14 @@ class PluginUpload extends Component {
 		const WrapperComponent = ! canUpload ? FeatureExample : Fragment;
 		return (
 			<WrapperComponent>
+				{ this.state.fileTooLarge && this.renderFileTooLarge() }
 				<Card>
 					{ ! inProgress && ! complete && (
-						<UploadDropZone doUpload={ uploadAction } disabled={ ! canUpload } />
+						<UploadDropZone
+							doUpload={ uploadAction }
+							disabled={ ! canUpload }
+							onFileTooLarge={ this.handleFileTooLarge }
+						/>
 					) }
 				</Card>
 			</WrapperComponent>
@@ -113,6 +125,32 @@ class PluginUpload extends Component {
 				action={ translate( 'Go to WP Admin' ) }
 				actionURL={ `${ siteAdminUrl }/plugin-install.php` }
 			/>
+		);
+	}
+
+	renderFileTooLarge() {
+		const { translate, siteSlug } = this.props;
+
+		return (
+			<Notice
+				status="is-warning"
+				showDismiss={ false }
+				text={ translate(
+					'This plugin exceeds the %(maxSize)d MB upload limit. You can upload it directly in WP Admin.',
+					{
+						args: {
+							maxSize: Math.floor( MAX_UPLOAD_ZIP_SIZE / 1000000 ),
+						},
+					}
+				) }
+			>
+				<NoticeAction
+					href={ `https://${ siteSlug }/wp-admin/plugin-install.php?tab=upload` }
+					external
+				>
+					{ translate( 'Go to WP Admin' ) }
+				</NoticeAction>
+			</Notice>
 		);
 	}
 

--- a/client/state/data-layer/wpcom/sites/plugins/new/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/index.js
@@ -1,5 +1,6 @@
 import { translate } from 'i18n-calypso';
 import { find, includes } from 'lodash';
+import { MAX_UPLOAD_ZIP_SIZE } from 'calypso/lib/automated-transfer/constants';
 import { INSTALL_PLUGIN } from 'calypso/lib/plugins/constants';
 import { PLUGIN_INSTALL_REQUEST_SUCCESS, PLUGIN_UPLOAD } from 'calypso/state/action-types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -32,7 +33,9 @@ export const uploadPlugin = ( action ) => {
 
 const showErrorNotice = ( error ) => {
 	const knownErrors = {
-		'too large': translate( 'The plugin zip file must be smaller than 10MB.' ),
+		'too large': translate( 'The plugin zip file must be smaller than %(maxSize)d MB.', {
+			args: { maxSize: Math.floor( MAX_UPLOAD_ZIP_SIZE / 1000000 ) },
+		} ),
 		incompatible: translate( 'The uploaded file is not a compatible plugin.' ),
 		unsupported_mime_type: translate( 'The uploaded file is not a valid zip.' ),
 	};

--- a/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
@@ -126,7 +126,7 @@ describe( 'receiveError', () => {
 				type: 'NOTICE_CREATE',
 				notice: expect.objectContaining( {
 					status: 'is-error',
-					text: 'The plugin zip file must be smaller than 10MB.',
+					text: 'The plugin zip file must be smaller than 50 MB.',
 					showDismiss: true,
 				} ),
 			} )

--- a/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
@@ -1,3 +1,4 @@
+import { MAX_UPLOAD_ZIP_SIZE } from 'calypso/lib/automated-transfer/constants';
 import { INSTALL_PLUGIN } from 'calypso/lib/plugins/constants';
 import { PLUGIN_INSTALL_REQUEST_SUCCESS } from 'calypso/state/action-types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -126,7 +127,9 @@ describe( 'receiveError', () => {
 				type: 'NOTICE_CREATE',
 				notice: expect.objectContaining( {
 					status: 'is-error',
-					text: 'The plugin zip file must be smaller than 50 MB.',
+					text: `The plugin zip file must be smaller than ${ Math.floor(
+						MAX_UPLOAD_ZIP_SIZE / 1000000
+					) } MB.`,
 					showDismiss: true,
 				} ),
 			} )


### PR DESCRIPTION
Supersedes #108823.

### Related Issues
- Related to DOTDEV-295

### Proposed Changes

Improve error handling / display of large plugin uploads:

| Before | After |
|--------|--------|
| <img width="3156" height="2256" alt="CleanShot 2026-03-05 at 12 06 05@2x" src="https://github.com/user-attachments/assets/2cd988a6-67c4-4222-b833-f290a5e35cf8" /> | <img width="3154" height="2176" alt="CleanShot 2026-03-05 at 12 05 24@2x" src="https://github.com/user-attachments/assets/456c8aa8-5462-48b1-8cc9-04cc4bbd9a85" /> | 

- Add an `onFileTooLarge` callback prop to `UploadDropZone` so consumers can handle oversized files differently from the default generic error notice
- In the plugin upload page, catch oversized files client-side and show an inline warning (using the `Notice` component) with a link to re-upload via WP Admin, instead of a plain text error notice that provides no guidance
- Update the data layer error message from the hardcoded "10MB" to dynamically derive the size from `MAX_UPLOAD_ZIP_SIZE`, so the message stays accurate if the limit changes
- Theme uploads continue to show the existing generic error notice (backwards compatible)

### Why are these changes being made?

When uploading a plugin zip exceeding 50 MB, the `UploadDropZone` component catches it client-side and shows a plain text error notice: "Zip file is too large. Please upload a file under 50 MB." This provides no guidance on what the user should do instead.

The marketplace install page had a dedicated `pluginTooBig` error screen with a WP Admin link, but it was only reachable via a server-side 413 response — which can no longer occur now that the client and server limits are both 50 MB.

This change intercepts oversized files on the plugin upload page and shows an inline warning with a direct link to WP Admin's plugin upload page, keeping the user on the same page so they can also try uploading a smaller file.

Additionally, the data layer's "too large" error message still said "10MB" (hardcoded from when the server limit was lower). This is updated to use the `MAX_UPLOAD_ZIP_SIZE` constant.

### Testing Instructions

1. Get a plugin zip file larger than 50 MB. You can use one from https://drive.google.com/drive/folders/1N5gEZtK62CzH-L2zjRXwgf6mJglF22S2?usp=sharing.
2. Build the app locally with `yarn && yarn start` or use the [Calypso Live link below](https://github.com/Automattic/wp-calypso/pull/109077#issuecomment-4004186677).
3. Go to `/plugins/upload/{site-slug}` and upload the plugin zip.
4. Verify that an inline warning notice appears above the dropzone with a "Go to WP Admin" link. The link should work correctly.
5. Verify the dropzone remains usable below the warning (user can try a smaller file).

### How AI was used in this PR
Claude Code implemented the initial plan and iterated on the approach (switching from a marketplace install page redirect to an inline Notice component, cleaning up dead code paths, using dynamic size constants) based on my feedback and code review. I have reviewed the whole generated code myself and with Copilot as well.

### Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you tested accessibility for your changes?