### PR TITLE
A4A: Fix referral commissions data accuracy

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/lib/generate-commissions-csv.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/generate-commissions-csv.ts
@@ -81,14 +81,23 @@ function findMatchingPurchase(
 	if ( ! referral?.purchases?.length ) {
 		return null;
 	}
-	const purchase = referral.purchases.find( ( p ) => p.product_id === productId );
-	if ( ! purchase || purchase.status === 'pending' || purchase.status === 'error' ) {
-		return null;
-	}
 	const product = products.find( ( p ) =>
-		[ p.product_id, p.monthly_product_id, p.yearly_product_id ].includes( productId )
+		[ p.product_id, p.monthly_product_id, p.yearly_product_id, p.alternative_product_id ].includes(
+			productId
+		)
 	);
 	if ( ! product ) {
+		return null;
+	}
+	const purchase = referral.purchases.find( ( p ) =>
+		[
+			product.product_id,
+			product.monthly_product_id,
+			product.yearly_product_id,
+			product.alternative_product_id,
+		].includes( p.product_id )
+	);
+	if ( ! purchase || purchase.status === 'pending' || purchase.status === 'error' ) {
 		return null;
 	}
 	return { referral, purchase, product };

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/commissions-column.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/commissions-column.tsx
@@ -20,7 +20,7 @@ export default function CommissionsColumn( { referral }: { referral: Referral } 
 	const { areNextAndCurrentPayoutDatesEqual } = useGetPayoutData();
 
 	const totalPendingCommission = areNextAndCurrentPayoutDatesEqual
-		? formatCurrency( previousQuarterExpectedCommission, 'USD' )
+		? formatCurrency( currentQuarterExpectedCommission, 'USD' )
 		: formatCurrency( previousQuarterExpectedCommission + currentQuarterExpectedCommission, 'USD' );
 
 	if ( isFetching ) {


### PR DESCRIPTION
Context p1771839085042399-slack-C091P0A65U5

## Proposed Changes

* Support alternative product ids when matching purchases in the referral commissions CSV, so rows are not silently dropped.
* Fix the commissions column to show the current quarter's expected commission instead of the previous (already paid) quarter when the next and current payout dates are equal.

## Why are these changes being made?

* Some referral products use an `alternative_product_id`, and the previous matching logic only checked the primary, monthly, and yearly product ids. This caused valid purchases to be missed, resulting in incomplete CSV exports.
* When the next payout date equals the current payout date, the commissions column was incorrectly displaying `previousQuarterExpectedCommission` (already paid out) instead of `currentQuarterExpectedCommission`, showing stale data to agencies.

## Testing Instructions

* Identify or create a referral whose product has an `alternative_product_id` configured.
* Generate the commissions CSV and verify that the purchase is correctly matched and the row appears.
* For the column fix: confirm that when `areNextAndCurrentPayoutDatesEqual` is true, the displayed commission reflects the current quarter amount, not the previous quarter.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if applicable?