### PR TITLE
E2E Tests: cancel purchases before deleting sites or closing accounts

### DIFF
--- a/packages/calypso-e2e/src/lib/components/domain-search-component.ts
+++ b/packages/calypso-e2e/src/lib/components/domain-search-component.ts
@@ -176,7 +176,7 @@ export class DomainSearchComponent {
 		await addToCartButton.waitFor( { state: 'detached', timeout: 30000 } );
 
 		if ( waitForContinueButton ) {
-			const continueButton = row.getByRole( 'button', { name: 'Continue' } );
+			const continueButton = this.page.getByRole( 'button', { name: 'Continue' } );
 			await continueButton.waitFor();
 		}
 

--- a/packages/calypso-e2e/src/lib/components/domain-search-component.ts
+++ b/packages/calypso-e2e/src/lib/components/domain-search-component.ts
@@ -176,7 +176,7 @@ export class DomainSearchComponent {
 		await addToCartButton.waitFor( { state: 'detached', timeout: 30000 } );
 
 		if ( waitForContinueButton ) {
-			const continueButton = this.page.getByRole( 'button', { name: 'Continue' } );
+			const continueButton = this.page.getByRole( 'button', { name: 'Continue' } ).first();
 			await continueButton.waitFor();
 		}
 

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -20,6 +20,7 @@ import type {
 	MyAccountInformationResponse,
 	AccountClosureResponse,
 	SiteDeletionResponse,
+	SitePurchasesResponse,
 	CalypsoPreferencesResponse,
 	ErrorResponse,
 	AccountCredentials,
@@ -294,7 +295,7 @@ export class RestAPIClient {
 		const mySites: AllDomainsResponse = await this.getAllDomains();
 
 		const match = mySites.domains.filter( ( site: DomainData ) => {
-			site.blog_id === targetSite.id && site.domain === targetDomain;
+			return site.blog_id === targetSite.id && site.domain === targetDomain;
 		} );
 
 		if ( ! match ) {
@@ -323,6 +324,53 @@ export class RestAPIClient {
 
 		console.log( `Successfully deleted site ID ${ targetSite.domain }` );
 		return response;
+	}
+
+	/**
+	 * Returns the purchases for a given site.
+	 *
+	 * @param {number} siteID ID of the site.
+	 * @returns {Promise<SitePurchasesResponse>} Array of purchases for the site.
+	 */
+	async getSitePurchases( siteID: number ): Promise< SitePurchasesResponse > {
+		const params: RequestParams = {
+			method: 'get',
+			headers: {
+				Authorization: await this.getAuthorizationHeader( 'bearer' ),
+				'Content-Type': this.getContentTypeHeader( 'json' ),
+			},
+		};
+
+		return await this.sendRequest(
+			this.getRequestURL( '1.1', `/sites/${ siteID }/purchases` ),
+			params
+		);
+	}
+
+	/**
+	 * Cancels and removes a purchase by ID.
+	 *
+	 * @param {number} purchaseID ID of the purchase to cancel.
+	 */
+	async cancelPurchase( purchaseID: number ): Promise< void > {
+		const params: RequestParams = {
+			method: 'post',
+			headers: {
+				Authorization: await this.getAuthorizationHeader( 'bearer' ),
+				'Content-Type': this.getContentTypeHeader( 'json' ),
+			},
+		};
+
+		const response = await this.sendRequest(
+			this.getRequestURL( '2', `/purchases/${ purchaseID }/delete`, 'wpcom' ),
+			params
+		);
+
+		if ( response.hasOwnProperty( 'error' ) ) {
+			throw new Error(
+				`${ ( response as ErrorResponse ).error }: ${ ( response as ErrorResponse ).message }`
+			);
+		}
 	}
 
 	/* Invites */

--- a/packages/calypso-e2e/src/types/rest-api-client.types.ts
+++ b/packages/calypso-e2e/src/types/rest-api-client.types.ts
@@ -95,6 +95,16 @@ export interface SiteDeletionResponse {
 	status: string;
 }
 
+export interface PurchaseData {
+	ID: number;
+	blog_id: number;
+	product_name: string;
+}
+
+export interface SitePurchasesResponse {
+	purchases: Array< PurchaseData >;
+}
+
 export interface AccountClosureResponse {
 	success: boolean;
 }

--- a/test/e2e/specs/flows/setup-domain-and-plan__skip-plan.spec.ts
+++ b/test/e2e/specs/flows/setup-domain-and-plan__skip-plan.spec.ts
@@ -18,6 +18,7 @@ test.describe( 'Domain: Upsell (Skip Plan)', { tag: [ tags.CALYPSO_RELEASE ] }, 
 
 		await test.step( 'Given I clear any stale cart items', async function () {
 			await accountAtomic.restAPI.clearShoppingCart( siteId );
+			await accountAtomic.restAPI.clearMyShoppingCart( 'no-site' );
 		} );
 
 		await test.step( 'When I navigate to the domain-and-plan flow', async function () {

--- a/test/e2e/specs/flows/setup-domain__flows.spec.ts
+++ b/test/e2e/specs/flows/setup-domain__flows.spec.ts
@@ -7,7 +7,7 @@ import {
 	RestAPIClient,
 } from '@automattic/calypso-e2e';
 import { tags, test, expect } from '../../lib/pw-base';
-import { apiCloseAccount, apiDeleteSite } from '../shared';
+import { apiCancelSitePurchases, apiCloseAccount, apiDeleteSite } from '../shared';
 
 test.describe(
 	'Setup Domain Flows',
@@ -674,6 +674,8 @@ test.describe(
 				);
 
 				if ( account.newSiteDetails ) {
+					await apiCancelSitePurchases( restAPIClient, account.newSiteDetails.blog_details.blogid );
+
 					await apiDeleteSite( restAPIClient, {
 						url: account.newSiteDetails.blog_details.url,
 						id: account.newSiteDetails.blog_details.blogid,

--- a/test/e2e/specs/flows/start-launch-site__flows.spec.ts
+++ b/test/e2e/specs/flows/start-launch-site__flows.spec.ts
@@ -6,7 +6,7 @@ import {
 	RestAPIClient,
 } from '@automattic/calypso-e2e';
 import { tags, test } from '../../lib/pw-base';
-import { apiCloseAccount, apiDeleteSite } from '../shared';
+import { apiCancelSitePurchases, apiCloseAccount, apiDeleteSite } from '../shared';
 
 test.describe(
 	'Launch Site Flows',
@@ -366,6 +366,8 @@ test.describe(
 				);
 
 				if ( account.newSiteDetails ) {
+					await apiCancelSitePurchases( restAPIClient, account.newSiteDetails.blog_details.blogid );
+
 					await apiDeleteSite( restAPIClient, {
 						url: account.newSiteDetails.blog_details.url,
 						id: account.newSiteDetails.blog_details.blogid,

--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
@@ -24,7 +24,7 @@ import {
 	DomainSearchComponent,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
-import { apiCloseAccount } from '../shared';
+import { apiCancelSitePurchases, apiCloseAccount, apiDeleteSite } from '../shared';
 
 declare const browser: Browser;
 
@@ -279,6 +279,14 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 			},
 			newUserDetails.body.bearer_token
 		);
+
+		await apiCancelSitePurchases( restAPIClient, newSiteDetails.blog_details.blogid );
+
+		await apiDeleteSite( restAPIClient, {
+			url: newSiteDetails.blog_details.url,
+			id: newSiteDetails.blog_details.blogid,
+			name: newSiteDetails.blog_details.blogname,
+		} );
 
 		await apiCloseAccount( restAPIClient, {
 			userID: newUserDetails.body.user_id,

--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
@@ -69,7 +69,7 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 
 		it( 'Skip domain selection', async function () {
 			const signupDomainPage = new DomainSearchComponent( page );
-			await signupDomainPage.search( 'foo' );
+			await signupDomainPage.search( DataHelper.getBlogName() );
 			await signupDomainPage.skipPurchase();
 		} );
 

--- a/test/e2e/specs/onboarding/signup__with-theme-LOHP.spec.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-LOHP.spec.ts
@@ -5,7 +5,7 @@ import {
 	RestAPIClient,
 } from '@automattic/calypso-e2e';
 import { expect, tags, test } from '../../lib/pw-base';
-import { apiCloseAccount } from '../shared';
+import { apiCancelSitePurchases, apiCloseAccount } from '../shared';
 
 test.describe(
 	'Signup: Lifecycle: Logged Out Home Page, signup, onboard, launch and cancel subscription',
@@ -167,6 +167,10 @@ test.describe(
 					},
 					newUserThemeSignup.body.bearer_token
 				);
+
+				if ( newSiteDetails ) {
+					await apiCancelSitePurchases( restAPIClient, newSiteDetails.blog_details.blogid );
+				}
 
 				await apiCloseAccount( restAPIClient, {
 					userID: newUserThemeSignup.body.user_id,

--- a/test/e2e/specs/plans/plans__signup-business.spec.ts
+++ b/test/e2e/specs/plans/plans__signup-business.spec.ts
@@ -38,7 +38,7 @@ test.describe(
 			} );
 
 			await test.step( 'And I skip domain selection', async function () {
-				await componentDomainSearch.search( 'foo' );
+				await componentDomainSearch.search( helperData.getBlogName() );
 				await componentDomainSearch.skipPurchase();
 			} );
 

--- a/test/e2e/specs/plans/plans__signup-business.spec.ts
+++ b/test/e2e/specs/plans/plans__signup-business.spec.ts
@@ -1,6 +1,6 @@
 import { BrowserManager, RestAPIClient } from '@automattic/calypso-e2e';
 import { expect, tags, test } from '../../lib/pw-base';
-import { apiDeleteSite } from '../shared';
+import { apiCancelSitePurchases, apiDeleteSite } from '../shared';
 import type { NewSiteResponse, TestAccount } from '@automattic/calypso-e2e';
 
 test.describe(
@@ -69,7 +69,7 @@ test.describe(
 			} );
 		} );
 
-		test.afterAll( 'Delete the created site', async function () {
+		test.afterAll( 'Cancel purchases and delete the created site', async function () {
 			if ( ! siteCreatedFlag || ! newSiteDetails || ! accountUsed ) {
 				return;
 			}
@@ -78,6 +78,8 @@ test.describe(
 				username: accountUsed.credentials.username,
 				password: accountUsed.credentials.password,
 			} );
+
+			await apiCancelSitePurchases( restAPIClient, newSiteDetails.blog_details.blogid );
 
 			await apiDeleteSite( restAPIClient, {
 				url: newSiteDetails.blog_details.url,

--- a/test/e2e/specs/plans/plans__upgrade.ts
+++ b/test/e2e/specs/plans/plans__upgrade.ts
@@ -21,7 +21,7 @@ import {
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import { TEST_IMAGE_PATH } from '../constants';
-import { apiDeleteSite } from '../shared';
+import { apiCancelSitePurchases, apiDeleteSite } from '../shared';
 
 declare const browser: Browser;
 const postTitles = Array.from( { length: 2 }, () => DataHelper.getRandomPhrase() );
@@ -168,6 +168,8 @@ describe(
 			if ( ! siteCreatedFlag ) {
 				return;
 			}
+
+			await apiCancelSitePurchases( restAPIClient, newSiteDetails.blog_details.blogid );
 
 			await apiDeleteSite( restAPIClient, {
 				url: newSiteDetails.blog_details.url,

--- a/test/e2e/specs/shared/api-cancel-site-purchases.ts
+++ b/test/e2e/specs/shared/api-cancel-site-purchases.ts
@@ -1,0 +1,30 @@
+import { RestAPIClient } from '@automattic/calypso-e2e';
+
+/**
+ * Cancels all active purchases for a site via the REST API.
+ *
+ * This must be called before `apiDeleteSite` for any site that has an active
+ * paid subscription, otherwise the delete request will be rejected with a 403.
+ *
+ * @param {RestAPIClient} client Client to interact with the WP REST API.
+ * @param {number} siteID ID of the site whose purchases should be cancelled.
+ */
+export async function apiCancelSitePurchases(
+	client: RestAPIClient,
+	siteID: number
+): Promise< void > {
+	console.info( `Fetching purchases for siteID ${ siteID }` );
+
+	const { purchases } = await client.getSitePurchases( siteID );
+
+	if ( ! purchases || purchases.length === 0 ) {
+		console.info( `No purchases found for siteID ${ siteID }` );
+		return;
+	}
+
+	for ( const purchase of purchases ) {
+		console.info( `Cancelling purchase ${ purchase.ID } (${ purchase.product_name })` );
+		await client.cancelPurchase( purchase.ID );
+		console.info( `Cancelled purchase ${ purchase.ID }` );
+	}
+}

--- a/test/e2e/specs/shared/index.ts
+++ b/test/e2e/specs/shared/index.ts
@@ -1,3 +1,4 @@
+export * from './api-cancel-site-purchases';
 export * from './api-close-account';
 export * from './api-delete-site';
 export * from './swap-base-url';


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/CHE-450

## Proposed Changes

This cancels abandoned purchases and deletes created posts from E2E tests.

* Add `getSitePurchases` and `cancelPurchase` methods to `RestAPIClient`
* Add shared `apiCancelSitePurchases` helper for E2E test teardown
* Call `apiCancelSitePurchases` before `apiDeleteSite` in the `lifecycle__signup-onboarding-launch-cancel` and `plans__signup-business` specs
* Fix a missing `return` in the `filter()` callback in `RestAPIClient.getSiteByDomain`

## Why are these changes being made?

Deleting a site via the REST API fails if the site has an active paid subscription. E2E tests that purchase a plan during the test flow were leaving orphaned sites and accounts behind when teardown failed. This adds a cancellation step before deletion so cleanup completes reliably.

While working on the above, I also ran into test failures where P2 tests were creating and leaving posts on a test site, accumulated 11,000 posts and causing consistent test timeouts, so I modified the test to delete any created posts and will run a manual script to delete old posts.

## Testing Instructions

* The `lifecycle__signup-onboarding-launch-cancel` and `plans__signup-business` specs create a paid site as part of the test. Confirm that after the test runs, the site and account are fully deleted rather than left orphaned.
* No new UI changes — this is purely teardown/infrastructure.