### PR TITLE
Help Center: Wait for DOM ready before mounting in wp-admin

### DIFF
--- a/apps/help-center/help-center-wp-admin.js
+++ b/apps/help-center/help-center-wp-admin.js
@@ -230,14 +230,22 @@ function AdminHelpCenterContent() {
 	);
 }
 
-// Check for agents-manager-masterbar first, then fall back to help-center-masterbar
-const target =
-	document.getElementById( 'agents-manager-masterbar' ) ||
-	document.getElementById( 'help-center-masterbar' );
-if ( target ) {
-	createRoot( target ).render(
-		<QueryClientProvider client={ queryClient }>
-			<AdminHelpCenterContent />
-		</QueryClientProvider>
-	);
+function mountHelpCenter() {
+	const target =
+		document.getElementById( 'agents-manager-masterbar' ) ||
+		document.getElementById( 'help-center-masterbar' );
+
+	if ( target ) {
+		createRoot( target ).render(
+			<QueryClientProvider client={ queryClient }>
+				<AdminHelpCenterContent />
+			</QueryClientProvider>
+		);
+	}
+}
+
+if ( document.readyState === 'loading' ) {
+	document.addEventListener( 'DOMContentLoaded', mountHelpCenter );
+} else {
+	mountHelpCenter();
 }


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-16231/help-center-not-showing-in-forums

## Proposed Changes                                                                                                                                                
                                                                                                                                                                     
  * Wrap the Help Center wp-admin mounting logic in a `mountHelpCenter()` function                                                                                   
  * Defer mounting with a `DOMContentLoaded` listener when the document is still loading                                                                             
                                                                                                                                                                     
  ## Why are these changes being made?                                                                                                                               
                                                                                                                                                                     
In /forums, the js to mount the Help Center did load before the DOM was loaded, causing errors. This is now fixed. 

On most wp-admin pages, the script probably loads after the masterbar markup, so it works by accident. On /forums the script likely runs before the masterbar is in the DOM.


  ## Testing Instructions

  * Open a wp-admin page where the Help Center is loaded
  * Verify the Help Center renders correctly
  * Check the browser console for errors