### PR TITLE
Themes: Add ThemeSectionHeader component

### DIFF
--- a/client/my-sites/themes/sections-modern/style.scss
+++ b/client/my-sites/themes/sections-modern/style.scss
@@ -1,0 +1,38 @@
+@import "@automattic/typography/styles/variables";
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.theme-section-header {
+	align-items: flex-end;
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	margin: 48px auto 0 auto;
+	max-width: 1220px;
+	padding: 24px;
+}
+
+.theme-section-header__title {
+	color: var(--studio-gray-100);
+	font-family: $brand-serif;
+	font-size: rem(40px);
+	font-weight: 400;
+	line-height: 1.2;
+	margin: 0;
+
+	@include break-small {
+		font-size: rem(50px);
+	}
+}
+
+.theme-section-header__subtitle {
+	color: var(--studio-gray-80);
+	font-size: $font-body-large;
+	line-height: 1.2;
+	margin: 0;
+}
+
+.theme-section-header__button.components-button.is-secondary {
+    --wp-components-color-accent: var(--studio-gray-80);
+    --wp-components-color-accent-darker-20: var(--studio-gray-100);
+}

--- a/client/my-sites/themes/sections-modern/style.scss
+++ b/client/my-sites/themes/sections-modern/style.scss
@@ -33,6 +33,6 @@
 }
 
 .theme-section-header__button.components-button.is-secondary {
-    --wp-components-color-accent: var(--studio-gray-80);
-    --wp-components-color-accent-darker-20: var(--studio-gray-100);
+	--wp-components-color-accent: var(--studio-gray-80);
+	--wp-components-color-accent-darker-20: var(--studio-gray-100);
 }

--- a/client/my-sites/themes/sections-modern/test/theme-section-header.test.tsx
+++ b/client/my-sites/themes/sections-modern/test/theme-section-header.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ThemeSectionHeader from '../theme-section-header';
+
+describe( 'ThemeSectionHeader', () => {
+	const defaultProps = {
+		title: 'Our Favorites',
+		subtitle: 'Hand-picked themes we love',
+		buttonLabel: 'See all',
+		onButtonClick: jest.fn(),
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'renders title and subtitle', () => {
+		render( <ThemeSectionHeader { ...defaultProps } /> );
+		expect( screen.getByText( 'Our Favorites' ) ).toBeVisible();
+		expect( screen.getByText( 'Hand-picked themes we love' ) ).toBeVisible();
+	} );
+
+	test( 'renders title as h2', () => {
+		render( <ThemeSectionHeader { ...defaultProps } /> );
+		expect( screen.getByRole( 'heading', { level: 2, name: 'Our Favorites' } ) ).toBeVisible();
+	} );
+
+	test( 'renders button with provided label', () => {
+		render( <ThemeSectionHeader { ...defaultProps } /> );
+		expect( screen.getByRole( 'button', { name: 'See all' } ) ).toBeVisible();
+	} );
+
+	test( 'calls onButtonClick when button is clicked', async () => {
+		const user = userEvent.setup();
+		render( <ThemeSectionHeader { ...defaultProps } /> );
+		await user.click( screen.getByRole( 'button', { name: 'See all' } ) );
+		expect( defaultProps.onButtonClick ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'does not render button when buttonLabel is omitted', () => {
+		render( <ThemeSectionHeader title="Our Favorites" subtitle="Hand-picked themes we love" /> );
+		expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'does not render button when onButtonClick is omitted', () => {
+		render(
+			<ThemeSectionHeader
+				title="Our Favorites"
+				subtitle="Hand-picked themes we love"
+				buttonLabel="See all"
+			/>
+		);
+		expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/my-sites/themes/sections-modern/test/theme-section-header.test.tsx
+++ b/client/my-sites/themes/sections-modern/test/theme-section-header.test.tsx
@@ -45,7 +45,7 @@ describe( 'ThemeSectionHeader', () => {
 		expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
 	} );
 
-	test( 'does not render button when onButtonClick is omitted', () => {
+	test( 'does not render button when only buttonLabel is provided', () => {
 		render(
 			<ThemeSectionHeader
 				title="Our Favorites"
@@ -54,5 +54,38 @@ describe( 'ThemeSectionHeader', () => {
 			/>
 		);
 		expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders as a link when buttonHref is provided', () => {
+		render(
+			<ThemeSectionHeader
+				title="Our Favorites"
+				subtitle="Hand-picked themes we love"
+				buttonLabel="See all"
+				buttonHref="/themes/favorites"
+			/>
+		);
+		const link = screen.getByRole( 'link', { name: 'See all' } );
+		expect( link ).toBeVisible();
+		expect( link ).toHaveAttribute( 'href', '/themes/favorites' );
+	} );
+
+	test( 'renders as a link with onClick when both buttonHref and onButtonClick are provided', async () => {
+		const handleClick = jest.fn();
+		const user = userEvent.setup();
+		render(
+			<ThemeSectionHeader
+				title="Our Favorites"
+				subtitle="Hand-picked themes we love"
+				buttonLabel="See all"
+				buttonHref="/themes/favorites"
+				onButtonClick={ handleClick }
+			/>
+		);
+		const link = screen.getByRole( 'link', { name: 'See all' } );
+		expect( link ).toHaveAttribute( 'href', '/themes/favorites' );
+		await user.click( link );
+		expect( handleClick ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/client/my-sites/themes/sections-modern/theme-section-header.tsx
+++ b/client/my-sites/themes/sections-modern/theme-section-header.tsx
@@ -6,6 +6,7 @@ interface ThemeSectionHeaderProps {
 	title: string;
 	subtitle: string;
 	buttonLabel?: string;
+	buttonHref?: string;
 	onButtonClick?: () => void;
 }
 
@@ -13,6 +14,7 @@ export default function ThemeSectionHeader( {
 	title,
 	subtitle,
 	buttonLabel,
+	buttonHref,
 	onButtonClick,
 }: ThemeSectionHeaderProps ) {
 	return (
@@ -21,10 +23,11 @@ export default function ThemeSectionHeader( {
 				<h2 className="theme-section-header__title">{ title }</h2>
 				<p className="theme-section-header__subtitle">{ subtitle }</p>
 			</div>
-			{ !! buttonLabel && onButtonClick && (
+			{ !! buttonLabel && ( buttonHref || onButtonClick ) && (
 				<Button
 					className="theme-section-header__button"
 					variant="secondary"
+					href={ buttonHref }
 					onClick={ onButtonClick }
 				>
 					{ buttonLabel }

--- a/client/my-sites/themes/sections-modern/theme-section-header.tsx
+++ b/client/my-sites/themes/sections-modern/theme-section-header.tsx
@@ -1,0 +1,35 @@
+import { Button } from '@wordpress/components';
+
+import './style.scss';
+
+interface ThemeSectionHeaderProps {
+	title: string;
+	subtitle: string;
+	buttonLabel?: string;
+	onButtonClick?: () => void;
+}
+
+export default function ThemeSectionHeader( {
+	title,
+	subtitle,
+	buttonLabel,
+	onButtonClick,
+}: ThemeSectionHeaderProps ) {
+	return (
+		<div className="theme-section-header">
+			<div className="theme-section-header__headings">
+				<h2 className="theme-section-header__title">{ title }</h2>
+				<p className="theme-section-header__subtitle">{ subtitle }</p>
+			</div>
+			{ !! buttonLabel && onButtonClick && (
+				<Button
+					className="theme-section-header__button"
+					variant="secondary"
+					onClick={ onButtonClick }
+				>
+					{ buttonLabel }
+				</Button>
+			) }
+		</div>
+	);
+}


### PR DESCRIPTION
Fixes DOTTHEM-306

## Proposed Changes

<img width="1066" height="796" alt="Screenshot 2026-03-05 at 14 12 17" src="https://github.com/user-attachments/assets/e45e3d06-ea2a-4be1-9f76-d6823f459e1e" />

* Add a new `ThemeSectionHeader` presentational component that renders a title, subtitle, and an optional "see all" action button.

## Why are these changes being made?

The Themes Landing Page redesign needs a reusable section header for the Recommended layout sections (Our Favorites, Fresh Themes, Partner Themes). This component is analogous to the `.theme-collection__meta` block in `ThemeCollection`, but without the carousel navigation arrows.

## Testing Instructions

* `yarn test-client client/my-sites/themes/sections-modern/test/theme-section-header.test.tsx` — all 6 tests should pass.
* To preview the component visually, temporarily add a `ThemeSectionHeader` to `client/my-sites/themes/theme-showcase.jsx` behind the `isThemeShowcaseModern()` gate (see the unstaged changes in the working branch for an example):
  ```jsx
  import ThemeSectionHeader from 'calypso/my-sites/themes/sections-modern/theme-section-header';

  // After the FilterBarModern block:
  { this.isThemeShowcaseModern() && (
      <ThemeSectionHeader
          title="Our Favorites"
          subtitle="Hand-picked themes we love"
          buttonLabel="See all"
          onButtonClick={ () => {} }
      />
  ) }
  ```
  Then visit the logged-out `/themes` page with the `themes/showcase-modern` feature flag enabled.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?