### PR TITLE
MSD: show disconnected Atomic sites on site list (alt 2)

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -3,6 +3,7 @@ import {
 	bigSkyPluginQuery,
 	codeDeploymentQuery,
 	codeDeploymentsQuery,
+	dashboardSiteIssuesQuery,
 	githubInstallationsQuery,
 	isAutomatticianQuery,
 	productsQuery,
@@ -81,6 +82,7 @@ export const sitesRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'sites',
 	loader: async () => {
+		queryClient.prefetchQuery( dashboardSiteIssuesQuery() );
 		await Promise.all( [
 			queryClient.ensureQueryData( isAutomatticianQuery() ),
 			queryClient.ensureQueryData( rawUserPreferencesQuery() ),

--- a/client/dashboard/sites/notices.tsx
+++ b/client/dashboard/sites/notices.tsx
@@ -6,6 +6,7 @@ import InlineSupportLink from '../components/inline-support-link';
 import Notice from '../components/notice';
 import { OptInWelcome } from '../components/opt-in-welcome';
 import { isDashboardBackport } from '../utils/is-dashboard-backport';
+import SiteIssues from './site-issues';
 
 const RestoringSitesNotices = ( { onClose }: { onClose?: () => void } ) => {
 	return (
@@ -39,6 +40,7 @@ export const SitesNotices = () => {
 	return (
 		<>
 			<OptInWelcome tracksContext="sites" />
+			<SiteIssues />
 			{ isRestoringAccount && (
 				<RestoringSitesNotices
 					onClose={ () =>

--- a/client/dashboard/sites/site-issues/index.tsx
+++ b/client/dashboard/sites/site-issues/index.tsx
@@ -1,0 +1,30 @@
+import { dashboardSiteIssuesQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { Link } from '@tanstack/react-router';
+import { __ } from '@wordpress/i18n';
+import Notice from '../../components/notice';
+
+export default function SiteIssues() {
+	const { data } = useQuery( dashboardSiteIssuesQuery() );
+	const disconnectedAtomicSites = data?.disconnected_atomic_sites ?? [];
+
+	if ( disconnectedAtomicSites.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<Notice variant="error" title={ __( 'You have inaccessible sites' ) }>
+			<p>
+				{ __( 'You no longer have access to the following sites. Please review and take action.' ) }
+			</p>
+
+			<ul>
+				{ disconnectedAtomicSites.map( ( site ) => (
+					<li key={ site.ID }>
+						<Link to={ `/sites/${ site.slug }` }>{ site.slug }</Link>
+					</li>
+				) ) }
+			</ul>
+		</Notice>
+	);
+}

--- a/packages/api-core/src/dashboard-site-list/fetchers.ts
+++ b/packages/api-core/src/dashboard-site-list/fetchers.ts
@@ -1,6 +1,10 @@
 import { wpcom } from '../wpcom-fetcher';
 import type { FetchSiteTypes } from '../me-sites';
-import type { FetchDashboardSiteFiltersParams, DashboardFilters } from './types';
+import type {
+	DashboardFilters,
+	DashboardSiteIssues,
+	FetchDashboardSiteFiltersParams,
+} from './types';
 
 export async function fetchDashboardSiteFilters(
 	site_types: FetchSiteTypes,
@@ -13,4 +17,11 @@ export async function fetchDashboardSiteFilters(
 			site_types: site_types !== 'all' ? site_types : undefined,
 		}
 	);
+}
+
+export async function fetchDashboardSiteIssues(): Promise< DashboardSiteIssues > {
+	return wpcom.req.get( {
+		path: '/dashboard/site-issues',
+		apiNamespace: 'wpcom/v2',
+	} );
 }

--- a/packages/api-core/src/dashboard-site-list/types.ts
+++ b/packages/api-core/src/dashboard-site-list/types.ts
@@ -5,3 +5,12 @@ export interface FetchDashboardSiteFiltersParams {
 export interface DashboardFilters {
 	plan?: Array< { name: string; value: string; name_en: string } >;
 }
+
+export interface DisconnectedAtomicSite {
+	ID: number;
+	slug: string;
+}
+
+export interface DashboardSiteIssues {
+	disconnected_atomic_sites: DisconnectedAtomicSite[];
+}

--- a/packages/api-queries/src/dashboard-site-list.ts
+++ b/packages/api-queries/src/dashboard-site-list.ts
@@ -1,4 +1,4 @@
-import { fetchDashboardSiteFilters } from '@automattic/api-core';
+import { fetchDashboardSiteFilters, fetchDashboardSiteIssues } from '@automattic/api-core';
 import { queryOptions } from '@tanstack/react-query';
 import type { FetchSiteTypes, FetchDashboardSiteFiltersParams } from '@automattic/api-core';
 
@@ -9,4 +9,10 @@ export const dashboardSiteFiltersQuery = (
 	queryOptions( {
 		queryKey: [ 'dashboard-site-filters', siteTypes, fields ],
 		queryFn: () => fetchDashboardSiteFilters( siteTypes, fields ),
+	} );
+
+export const dashboardSiteIssuesQuery = () =>
+	queryOptions( {
+		queryKey: [ 'dashboard-site-issues' ],
+		queryFn: () => fetchDashboardSiteIssues(),
 	} );


### PR DESCRIPTION
Part of DOTMSD-1106
Alternative to https://github.com/Automattic/wp-calypso/pull/109047, where the logic is on wpcom backend

> [!NOTE]
> This is a proof-of-concept PR; see the linked issue for discussion.

## Proposed Changes

Show disconnected Atomic sites as a notice above the site list as follows:

<img width="1015" height="575" alt="image" src="https://github.com/user-attachments/assets/76172d5d-088f-408d-bf91-96baab74e010" />

## Why are these changes being made?

If a WoW site has disabled Jetpack connection, it will disappear from site list, preventing site owner to realize that they have a broken site.

## Testing Instructions

1. SANDBOX 206348-ghe-Automattic/wpcom
1. Purchase a site with Business plan
2. Transfer to Atomic
3. Enable SSH access in Settings -> SSH
4. SSH to that site
5. Run `wp jetpack disconnect user <your username> --force` to disconnect yourself from that site
6. Go to `/sites`
7. Wait and verify the notice appears
8. Verify you can click the site and go to site overview (with error message)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?