### PR TITLE
Add new style of interventions

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/get-solutions-for-reason.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/get-solutions-for-reason.ts
@@ -1,10 +1,8 @@
 /**
  * Solution card config for the cancellation solutions-cards upsell step.
- * Labels are intended to be passed to translate() in the UI for i18n.
  */
 export type SolutionCardConfig = {
 	id: string;
-	label: string;
 };
 
 const SOLUTION_IDS = {
@@ -27,180 +25,180 @@ const SOLUTION_IDS = {
 
 /** Too expensive: Expensive for the features offered */
 const SOLUTIONS_TOO_EXPENSIVE: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.CHANGE_PLAN, label: 'Change plan' },
-	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS, label: 'Renew now and pay less' },
-	{ id: SOLUTION_IDS.SWITCH_TO_MONTHLY, label: 'Switch to monthly payments' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.CHANGE_PLAN },
+	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS },
+	{ id: SOLUTION_IDS.SWITCH_TO_MONTHLY },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Too expensive: Lack of flexibility for the price (lackOfCustomization under price/budget) */
 const SOLUTIONS_LACK_OF_FLEXIBILITY: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.CHANGE_PLAN, label: 'Change plan' },
-	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS, label: 'Renew now and pay less' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.CHANGE_PLAN },
+	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Too expensive: Found competitor / Free plan is enough */
 const SOLUTIONS_FOUND_BETTER_OR_FREE: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS, label: 'Renew now and pay less' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Too expensive: Budget changed */
 const SOLUTIONS_BUDGET_CONSTRAINTS: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.CHANGE_PLAN, label: 'Change plan' },
-	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS, label: 'Renew now and pay less' },
-	{ id: SOLUTION_IDS.SWITCH_TO_MONTHLY, label: 'Switch to monthly payments' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.CHANGE_PLAN },
+	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS },
+	{ id: SOLUTION_IDS.SWITCH_TO_MONTHLY },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Too hard to use: Dashboard / Editor (with AI option) */
 const SOLUTIONS_HARD_TO_USE_WITH_AI: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.BUILT_BY, label: 'Let us build for you' },
-	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.BUILT_BY },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Too hard to use: Takes too much time / Tutorials not helpful (no AI option) */
 const SOLUTIONS_HARD_TO_USE_SUPPORT_ONLY: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.BUILT_BY, label: 'Let us build for you' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.BUILT_BY },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Cannot install plugins */
 const SOLUTIONS_CANNOT_INSTALL_PLUGINS: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.UPGRADE_FULL_ACCESS, label: 'Upgrade for full access' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.UPGRADE_FULL_ACCESS },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Cannot upload themes */
 const SOLUTIONS_CANNOT_UPLOAD_THEMES: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.UPGRADE_FULL_ACCESS, label: 'Upgrade for full access' },
-	{ id: SOLUTION_IDS.GET_THEME_ADDON, label: 'Get our theme add-on' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.UPGRADE_FULL_ACCESS },
+	{ id: SOLUTION_IDS.GET_THEME_ADDON },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Limited customization */
 const SOLUTIONS_LIMITED_CUSTOMIZATION: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.UPGRADE_FULL_ACCESS, label: 'Upgrade for full access' },
-	{ id: SOLUTION_IDS.GET_CSS_ADDON, label: 'Get our CSS add-on' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.UPGRADE_FULL_ACCESS },
+	{ id: SOLUTION_IDS.GET_CSS_ADDON },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Missing functionality */
 const SOLUTIONS_MISSING_FUNCTIONALITY: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.UPGRADE_FULL_ACCESS, label: 'Upgrade for full access' },
-	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.UPGRADE_FULL_ACCESS },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Core features missing */
 const SOLUTIONS_CORE_FEATURES_MISSING: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.FIND_GUIDES, label: 'Find easy step-by-step guides' },
-	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.FIND_GUIDES },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Too slow */
 const SOLUTIONS_TOO_SLOW: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.MAKE_SITE_FASTER, label: 'Make your site faster' },
-	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS, label: 'Renew now and pay less' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.MAKE_SITE_FASTER },
+	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Bugs or glitches */
 const SOLUTIONS_BUGS_OR_GLITCHES: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS, label: 'Renew now and pay less' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Migration problems */
 const SOLUTIONS_MIGRATION_PROBLEMS: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.USE_MIGRATION_TOOLS, label: 'Use our migration tools' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.USE_MIGRATION_TOOLS },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Downtime */
 const SOLUTIONS_DOWNTIME: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS, label: 'Renew now and pay less' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Trouble connecting or transferring (domain) */
 const SOLUTIONS_TROUBLE_CONNECTING_OR_TRANSFERRING: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.USE_DOMAIN_GUIDE, label: 'Use our domain guide' },
-	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.USE_DOMAIN_GUIDE },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Confused about domains */
 const SOLUTIONS_CONFUSED_ABOUT_DOMAINS: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.USE_DOMAIN_GUIDE, label: 'Use our domain guide' },
-	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.USE_DOMAIN_GUIDE },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Domain incorrect */
 const SOLUTIONS_DOMAIN_INCORRECT: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.EXPLORE_DOMAIN_OPTIONS, label: 'Explore more domain options' },
-	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.EXPLORE_DOMAIN_OPTIONS },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Wrong plan */
 const SOLUTIONS_WRONG_PLAN: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.CHANGE_PLAN, label: 'Change plan' },
-	{ id: SOLUTION_IDS.SWITCH_TO_MONTHLY, label: 'Switch to monthly payments' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.CHANGE_PLAN },
+	{ id: SOLUTION_IDS.SWITCH_TO_MONTHLY },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Wrong site */
 const SOLUTIONS_WRONG_SITE: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.MOVE_SUBSCRIPTION, label: 'Move your subscription' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.MOVE_SUBSCRIPTION },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Plan didn't match (noMatch) */
 const SOLUTIONS_NO_MATCH: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Slow or unhelpful support */
 const SOLUTIONS_SLOW_OR_UNHELPFUL: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
-	{ id: SOLUTION_IDS.FIND_GUIDES, label: 'Find easy step-by-step guides' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT },
+	{ id: SOLUTION_IDS.FIND_GUIDES },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** No human support */
 const SOLUTIONS_NO_HUMAN_SUPPORT: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** AI insufficient */
 const SOLUTIONS_AI_INSUFFICIENT: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.FIND_GUIDES, label: 'Find easy step-by-step guides' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.FIND_GUIDES },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Project changed */
 const SOLUTIONS_PROJECT_CHANGED: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Just exploring */
 const SOLUTIONS_JUST_EXPLORING: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** May return */
 const SOLUTIONS_MAY_RETURN: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS, label: 'Renew now and pay less' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /**

--- a/client/components/marketing-survey/cancel-purchase-form/get-solutions-for-reason.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/get-solutions-for-reason.ts
@@ -20,7 +20,6 @@ const SOLUTION_IDS = {
 	USE_MIGRATION_TOOLS: 'use-migration-tools',
 	USE_DOMAIN_GUIDE: 'use-domain-guide',
 	EXPLORE_DOMAIN_OPTIONS: 'explore-domain-options',
-	MOVE_SUBSCRIPTION: 'move-subscription',
 } as const;
 
 /** Too expensive: Expensive for the features offered */
@@ -153,10 +152,7 @@ const SOLUTIONS_WRONG_PLAN: SolutionCardConfig[] = [
 ];
 
 /** Wrong site */
-const SOLUTIONS_WRONG_SITE: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.MOVE_SUBSCRIPTION },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
-];
+const SOLUTIONS_WRONG_SITE: SolutionCardConfig[] = [ { id: SOLUTION_IDS.SPEAK_WITH_SUPPORT } ];
 
 /** Plan didn't match (noMatch) */
 const SOLUTIONS_NO_MATCH: SolutionCardConfig[] = [

--- a/client/components/marketing-survey/cancel-purchase-form/get-solutions-for-reason.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/get-solutions-for-reason.ts
@@ -170,6 +170,7 @@ const SOLUTIONS_SLOW_OR_UNHELPFUL: SolutionCardConfig[] = [
 /** No human support */
 const SOLUTIONS_NO_HUMAN_SUPPORT: SolutionCardConfig[] = [
 	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT },
+	{ id: SOLUTION_IDS.FIND_GUIDES },
 	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 

--- a/client/components/marketing-survey/cancel-purchase-form/get-solutions-for-reason.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/get-solutions-for-reason.ts
@@ -20,6 +20,8 @@ const SOLUTION_IDS = {
 	FIND_GUIDES: 'find-guides',
 	MAKE_SITE_FASTER: 'make-site-faster',
 	USE_MIGRATION_TOOLS: 'use-migration-tools',
+	USE_DOMAIN_GUIDE: 'use-domain-guide',
+	EXPLORE_DOMAIN_OPTIONS: 'explore-domain-options',
 } as const;
 
 /** Too expensive: Expensive for the features offered */
@@ -123,6 +125,27 @@ const SOLUTIONS_DOWNTIME: SolutionCardConfig[] = [
 	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
 ];
 
+/** Trouble connecting or transferring (domain) */
+const SOLUTIONS_TROUBLE_CONNECTING_OR_TRANSFERRING: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.USE_DOMAIN_GUIDE, label: 'Use our domain guide' },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Confused about domains */
+const SOLUTIONS_CONFUSED_ABOUT_DOMAINS: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.USE_DOMAIN_GUIDE, label: 'Use our domain guide' },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Domain incorrect */
+const SOLUTIONS_DOMAIN_INCORRECT: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.EXPLORE_DOMAIN_OPTIONS, label: 'Explore more domain options' },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
 /**
  * Returns the ordered list of solution cards for the given cancellation sub-reason,
  * or null when this reason has no solutions step.
@@ -173,6 +196,14 @@ export function getSolutionsForReason( reason: string ): SolutionCardConfig[] | 
 			return [ ...SOLUTIONS_MIGRATION_PROBLEMS ];
 		case 'downtime':
 			return [ ...SOLUTIONS_DOWNTIME ];
+
+		// Domain-related
+		case 'troubleConnectingOrTransferring':
+			return [ ...SOLUTIONS_TROUBLE_CONNECTING_OR_TRANSFERRING ];
+		case 'confusedAboutDomains':
+			return [ ...SOLUTIONS_CONFUSED_ABOUT_DOMAINS ];
+		case 'domainIncorrect':
+			return [ ...SOLUTIONS_DOMAIN_INCORRECT ];
 
 		default:
 			return null;

--- a/client/components/marketing-survey/cancel-purchase-form/get-solutions-for-reason.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/get-solutions-for-reason.ts
@@ -1,0 +1,93 @@
+/**
+ * Solution card config for the cancellation solutions-cards upsell step.
+ * Labels are intended to be passed to translate() in the UI for i18n.
+ */
+export type SolutionCardConfig = {
+	id: string;
+	label: string;
+};
+
+const SOLUTION_IDS = {
+	CHANGE_PLAN: 'change-plan',
+	RENEW_NOW_PAY_LESS: 'renew-now-pay-less',
+	SWITCH_TO_MONTHLY: 'switch-to-monthly',
+	SPEAK_WITH_SUPPORT: 'speak-with-support',
+	BUILT_BY: 'built-by',
+	ASK_AI_ASSISTANT: 'ask-ai-assistant',
+} as const;
+
+/** Too expensive: Expensive for the features offered */
+const SOLUTIONS_TOO_EXPENSIVE: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.CHANGE_PLAN, label: 'Change plan' },
+	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS, label: 'Renew now and pay less' },
+	{ id: SOLUTION_IDS.SWITCH_TO_MONTHLY, label: 'Switch to monthly payments' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Too expensive: Lack of flexibility for the price (lackOfCustomization under price/budget) */
+const SOLUTIONS_LACK_OF_FLEXIBILITY: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.CHANGE_PLAN, label: 'Change plan' },
+	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS, label: 'Renew now and pay less' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Too expensive: Found competitor / Free plan is enough */
+const SOLUTIONS_FOUND_BETTER_OR_FREE: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS, label: 'Renew now and pay less' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Too expensive: Budget changed */
+const SOLUTIONS_BUDGET_CONSTRAINTS: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.CHANGE_PLAN, label: 'Change plan' },
+	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS, label: 'Renew now and pay less' },
+	{ id: SOLUTION_IDS.SWITCH_TO_MONTHLY, label: 'Switch to monthly payments' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Too hard to use: Dashboard / Editor (with AI option) */
+const SOLUTIONS_HARD_TO_USE_WITH_AI: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.BUILT_BY, label: 'Let us build for you' },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Too hard to use: Takes too much time / Tutorials not helpful (no AI option) */
+const SOLUTIONS_HARD_TO_USE_SUPPORT_ONLY: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.BUILT_BY, label: 'Let us build for you' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/**
+ * Returns the ordered list of solution cards for the given cancellation sub-reason,
+ * or null when this reason has no solutions step.
+ */
+export function getSolutionsForReason( reason: string ): SolutionCardConfig[] | null {
+	switch ( reason ) {
+		// Too expensive
+		case 'tooExpensive':
+			return [ ...SOLUTIONS_TOO_EXPENSIVE ];
+		case 'lackOfCustomization':
+			return [ ...SOLUTIONS_LACK_OF_FLEXIBILITY ];
+		case 'foundBetterValue':
+		case 'freeIsGoodEnough':
+			return [ ...SOLUTIONS_FOUND_BETTER_OR_FREE ];
+		case 'budgetConstraints':
+			return [ ...SOLUTIONS_BUDGET_CONSTRAINTS ];
+		case 'otherPriceValue':
+			return null;
+
+		// Too hard to use
+		case 'complicatedDashboard':
+		case 'difficultEditor':
+			return [ ...SOLUTIONS_HARD_TO_USE_WITH_AI ];
+		case 'tooMuchTimeToLearn':
+		case 'inadequateOnboarding':
+			return [ ...SOLUTIONS_HARD_TO_USE_SUPPORT_ONLY ];
+		case 'otherTooHardToUse':
+			return null;
+
+		default:
+			return null;
+	}
+}

--- a/client/components/marketing-survey/cancel-purchase-form/get-solutions-for-reason.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/get-solutions-for-reason.ts
@@ -14,6 +14,12 @@ const SOLUTION_IDS = {
 	SPEAK_WITH_SUPPORT: 'speak-with-support',
 	BUILT_BY: 'built-by',
 	ASK_AI_ASSISTANT: 'ask-ai-assistant',
+	UPGRADE_FULL_ACCESS: 'upgrade-for-full-access',
+	GET_THEME_ADDON: 'get-theme-addon',
+	GET_CSS_ADDON: 'get-css-addon',
+	FIND_GUIDES: 'find-guides',
+	MAKE_SITE_FASTER: 'make-site-faster',
+	USE_MIGRATION_TOOLS: 'use-migration-tools',
 } as const;
 
 /** Too expensive: Expensive for the features offered */
@@ -58,6 +64,65 @@ const SOLUTIONS_HARD_TO_USE_SUPPORT_ONLY: SolutionCardConfig[] = [
 	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
 ];
 
+/** Cannot install plugins */
+const SOLUTIONS_CANNOT_INSTALL_PLUGINS: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.UPGRADE_FULL_ACCESS, label: 'Upgrade for full access' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Cannot upload themes */
+const SOLUTIONS_CANNOT_UPLOAD_THEMES: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.UPGRADE_FULL_ACCESS, label: 'Upgrade for full access' },
+	{ id: SOLUTION_IDS.GET_THEME_ADDON, label: 'Get our theme add-on' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Limited customization */
+const SOLUTIONS_LIMITED_CUSTOMIZATION: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.UPGRADE_FULL_ACCESS, label: 'Upgrade for full access' },
+	{ id: SOLUTION_IDS.GET_CSS_ADDON, label: 'Get our CSS add-on' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Missing functionality */
+const SOLUTIONS_MISSING_FUNCTIONALITY: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.UPGRADE_FULL_ACCESS, label: 'Upgrade for full access' },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Core features missing */
+const SOLUTIONS_CORE_FEATURES_MISSING: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.FIND_GUIDES, label: 'Find easy step-by-step guides' },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Too slow */
+const SOLUTIONS_TOO_SLOW: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.MAKE_SITE_FASTER, label: 'Make your site faster' },
+	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS, label: 'Renew now and pay less' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Bugs or glitches */
+const SOLUTIONS_BUGS_OR_GLITCHES: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS, label: 'Renew now and pay less' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Migration problems */
+const SOLUTIONS_MIGRATION_PROBLEMS: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.USE_MIGRATION_TOOLS, label: 'Use our migration tools' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Downtime */
+const SOLUTIONS_DOWNTIME: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS, label: 'Renew now and pay less' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
 /**
  * Returns the ordered list of solution cards for the given cancellation sub-reason,
  * or null when this reason has no solutions step.
@@ -86,6 +151,28 @@ export function getSolutionsForReason( reason: string ): SolutionCardConfig[] | 
 			return [ ...SOLUTIONS_HARD_TO_USE_SUPPORT_ONLY ];
 		case 'otherTooHardToUse':
 			return null;
+
+		// Missing features / limitations
+		case 'cannotInstallPlugins':
+			return [ ...SOLUTIONS_CANNOT_INSTALL_PLUGINS ];
+		case 'cannotUploadThemes':
+			return [ ...SOLUTIONS_CANNOT_UPLOAD_THEMES ];
+		case 'limitedCustomization':
+			return [ ...SOLUTIONS_LIMITED_CUSTOMIZATION ];
+		case 'missingFunctionality':
+			return [ ...SOLUTIONS_MISSING_FUNCTIONALITY ];
+		case 'coreFeaturesMissing':
+			return [ ...SOLUTIONS_CORE_FEATURES_MISSING ];
+
+		// Performance / reliability
+		case 'tooSlow':
+			return [ ...SOLUTIONS_TOO_SLOW ];
+		case 'bugsOrGlitches':
+			return [ ...SOLUTIONS_BUGS_OR_GLITCHES ];
+		case 'migrationProblems':
+			return [ ...SOLUTIONS_MIGRATION_PROBLEMS ];
+		case 'downtime':
+			return [ ...SOLUTIONS_DOWNTIME ];
 
 		default:
 			return null;

--- a/client/components/marketing-survey/cancel-purchase-form/get-solutions-for-reason.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/get-solutions-for-reason.ts
@@ -22,6 +22,7 @@ const SOLUTION_IDS = {
 	USE_MIGRATION_TOOLS: 'use-migration-tools',
 	USE_DOMAIN_GUIDE: 'use-domain-guide',
 	EXPLORE_DOMAIN_OPTIONS: 'explore-domain-options',
+	MOVE_SUBSCRIPTION: 'move-subscription',
 } as const;
 
 /** Too expensive: Expensive for the features offered */
@@ -146,6 +147,62 @@ const SOLUTIONS_DOMAIN_INCORRECT: SolutionCardConfig[] = [
 	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
 ];
 
+/** Wrong plan */
+const SOLUTIONS_WRONG_PLAN: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.CHANGE_PLAN, label: 'Change plan' },
+	{ id: SOLUTION_IDS.SWITCH_TO_MONTHLY, label: 'Switch to monthly payments' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Wrong site */
+const SOLUTIONS_WRONG_SITE: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.MOVE_SUBSCRIPTION, label: 'Move your subscription' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Plan didn't match (noMatch) */
+const SOLUTIONS_NO_MATCH: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Slow or unhelpful support */
+const SOLUTIONS_SLOW_OR_UNHELPFUL: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
+	{ id: SOLUTION_IDS.FIND_GUIDES, label: 'Find easy step-by-step guides' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** No human support */
+const SOLUTIONS_NO_HUMAN_SUPPORT: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** AI insufficient */
+const SOLUTIONS_AI_INSUFFICIENT: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.FIND_GUIDES, label: 'Find easy step-by-step guides' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Project changed */
+const SOLUTIONS_PROJECT_CHANGED: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Just exploring */
+const SOLUTIONS_JUST_EXPLORING: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** May return */
+const SOLUTIONS_MAY_RETURN: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS, label: 'Renew now and pay less' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
 /**
  * Returns the ordered list of solution cards for the given cancellation sub-reason,
  * or null when this reason has no solutions step.
@@ -204,6 +261,30 @@ export function getSolutionsForReason( reason: string ): SolutionCardConfig[] | 
 			return [ ...SOLUTIONS_CONFUSED_ABOUT_DOMAINS ];
 		case 'domainIncorrect':
 			return [ ...SOLUTIONS_DOMAIN_INCORRECT ];
+
+		// Wrong plan or site
+		case 'wrongPlan':
+			return [ ...SOLUTIONS_WRONG_PLAN ];
+		case 'wrongSite':
+			return [ ...SOLUTIONS_WRONG_SITE ];
+		case 'noMatch':
+			return [ ...SOLUTIONS_NO_MATCH ];
+
+		// Bad support experience
+		case 'slowOrUnhelpful':
+			return [ ...SOLUTIONS_SLOW_OR_UNHELPFUL ];
+		case 'noHumanSupport':
+			return [ ...SOLUTIONS_NO_HUMAN_SUPPORT ];
+		case 'AIInsufficient':
+			return [ ...SOLUTIONS_AI_INSUFFICIENT ];
+
+		// Other / lifecycle
+		case 'projectChanged':
+			return [ ...SOLUTIONS_PROJECT_CHANGED ];
+		case 'justExploring':
+			return [ ...SOLUTIONS_JUST_EXPLORING ];
+		case 'mayReturn':
+			return [ ...SOLUTIONS_MAY_RETURN ];
 
 		default:
 			return null;

--- a/client/components/marketing-survey/cancel-purchase-form/get-solutions-for-reason.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/get-solutions-for-reason.ts
@@ -14,7 +14,6 @@ const SOLUTION_IDS = {
 	ASK_AI_ASSISTANT: 'ask-ai-assistant',
 	UPGRADE_FULL_ACCESS: 'upgrade-for-full-access',
 	GET_THEME_ADDON: 'get-theme-addon',
-	GET_CSS_ADDON: 'get-css-addon',
 	FIND_GUIDES: 'find-guides',
 	MAKE_SITE_FASTER: 'make-site-faster',
 	USE_MIGRATION_TOOLS: 'use-migration-tools',
@@ -80,7 +79,6 @@ const SOLUTIONS_CANNOT_UPLOAD_THEMES: SolutionCardConfig[] = [
 /** Limited customization */
 const SOLUTIONS_LIMITED_CUSTOMIZATION: SolutionCardConfig[] = [
 	{ id: SOLUTION_IDS.UPGRADE_FULL_ACCESS },
-	{ id: SOLUTION_IDS.GET_CSS_ADDON },
 	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import {
 	isGSuiteOrGoogleWorkspace,
 	isPlan,
@@ -42,6 +43,7 @@ import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import getSite from 'calypso/state/sites/selectors/get-site';
 import { CANCEL_FLOW_TYPE } from './constants';
 import enrichedSurveyData from './enriched-survey-data';
+import { getSolutionsForReason } from './get-solutions-for-reason';
 import { getUpsellType } from './get-upsell-type';
 import initialSurveyState from './initial-survey-state';
 import nextStep from './next-step';
@@ -54,6 +56,7 @@ import { AtomicRevertStep } from './step-components/atomic-revert-step';
 import EducationContentStep from './step-components/educational-content-step';
 import FeedbackStep from './step-components/feedback-step';
 import NextAdventureStep from './step-components/next-adventure-step';
+import SolutionsCardsUpsellStep from './step-components/solutions-cards-upsell-step';
 import UpsellStep from './step-components/upsell-step';
 import {
 	ATOMIC_REVERT_STEP,
@@ -399,6 +402,26 @@ class CancelPurchaseForm extends Component {
 						site={ site }
 						onDecline={ isLastStep ? this.onSubmit : this.clickNext }
 						cancellationReason={ this.state.questionOneText }
+					/>
+				);
+			}
+
+			const solutions = getSolutionsForReason( this.state.questionOneText || '' );
+			const useSolutionsCards =
+				config.isEnabled( 'cancel-flow/solutions-cards-upsell' ) &&
+				solutions &&
+				solutions.length > 0;
+
+			if ( useSolutionsCards ) {
+				return (
+					<SolutionsCardsUpsellStep
+						cancellationReason={ this.state.questionOneText }
+						closeDialog={ this.closeDialog }
+						onClickDowngrade={ this.downgradeClick }
+						onClickFreeMonthOffer={ this.freeMonthOfferClick }
+						onDeclineUpsell={ isLastStep ? this.onSubmit : this.clickNext }
+						purchase={ purchase }
+						site={ site }
 					/>
 				);
 			}

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -410,10 +410,14 @@ class CancelPurchaseForm extends Component {
 				return (
 					<SolutionsCardsUpsellStep
 						cancellationReason={ this.state.questionOneText }
+						cancelBundledDomain={ this.props.cancelBundledDomain }
 						closeDialog={ this.closeDialog }
+						downgradePlanPrice={ this.props.downgradePlanToMonthlyPrice }
+						includedDomainPurchase={ this.props.includedDomainPurchase }
 						onClickDowngrade={ this.downgradeClick }
 						onDeclineUpsell={ isLastStep ? this.onSubmit : this.clickNext }
 						purchase={ purchase }
+						refundAmount={ this.getRefundAmount() }
 						site={ site }
 					/>
 				);

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -398,6 +398,27 @@ class CancelPurchaseForm extends Component {
 			const allSteps = this.getAllSurveySteps();
 			const isLastStep = surveyStep === allSteps[ allSteps.length - 1 ];
 
+			const solutions = getSolutionsForReason( this.state.questionOneText || '' );
+			const useSolutionsCards =
+				config.isEnabled( 'cancel-flow/solutions-cards-upsell' ) &&
+				solutions &&
+				solutions.length > 0;
+
+			// When flag is on and we have solution cards for this reason, show them
+			// instead of the legacy education or single-upsell step.
+			if ( useSolutionsCards ) {
+				return (
+					<SolutionsCardsUpsellStep
+						cancellationReason={ this.state.questionOneText }
+						closeDialog={ this.closeDialog }
+						onClickDowngrade={ this.downgradeClick }
+						onDeclineUpsell={ isLastStep ? this.onSubmit : this.clickNext }
+						purchase={ purchase }
+						site={ site }
+					/>
+				);
+			}
+
 			if ( upsell.startsWith( 'education:' ) ) {
 				return (
 					<EducationContentStep
@@ -405,26 +426,6 @@ class CancelPurchaseForm extends Component {
 						site={ site }
 						onDecline={ isLastStep ? this.onSubmit : this.clickNext }
 						cancellationReason={ this.state.questionOneText }
-					/>
-				);
-			}
-
-			const solutions = getSolutionsForReason( this.state.questionOneText || '' );
-			const useSolutionsCards =
-				config.isEnabled( 'cancel-flow/solutions-cards-upsell' ) &&
-				solutions &&
-				solutions.length > 0;
-
-			if ( useSolutionsCards ) {
-				return (
-					<SolutionsCardsUpsellStep
-						cancellationReason={ this.state.questionOneText }
-						closeDialog={ this.closeDialog }
-						onClickDowngrade={ this.downgradeClick }
-						onClickFreeMonthOffer={ this.freeMonthOfferClick }
-						onDeclineUpsell={ isLastStep ? this.onSubmit : this.clickNext }
-						purchase={ purchase }
-						site={ site }
 					/>
 				);
 			}

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -196,18 +196,21 @@ class CancelPurchaseForm extends Component {
 			this.recordClickRadioEvent( 'radio_1_2', value );
 		}
 
+		const upsellFromType = getUpsellType( value, {
+			productSlug: purchase?.productSlug || '',
+			canRefund: !! parseFloat( this.getRefundAmount() ),
+			canDowngrade: !! downgradeClick,
+			canOfferFreeMonth:
+				!! freeMonthOfferClick && ! purchaseIsAlreadyExtended && ! isRefundable( purchase ),
+		} );
+		const hasSolutionsCards =
+			config.isEnabled( 'cancel-flow/solutions-cards-upsell' ) &&
+			( getSolutionsForReason( value )?.length ?? 0 ) > 0;
 		const newState = {
 			...this.state,
 			questionOneText: value,
 			questionOneDetails: detailsValue || questionOneDetails,
-			upsell:
-				getUpsellType( value, {
-					productSlug: purchase?.productSlug || '',
-					canRefund: !! parseFloat( this.getRefundAmount() ),
-					canDowngrade: !! downgradeClick,
-					canOfferFreeMonth:
-						!! freeMonthOfferClick && ! purchaseIsAlreadyExtended && ! isRefundable( purchase ),
-				} ) || '',
+			upsell: upsellFromType || ( hasSolutionsCards ? 'solutions-cards' : '' ),
 		};
 		this.setState( newState );
 	};

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solution-cards-config.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solution-cards-config.ts
@@ -30,6 +30,12 @@ export type CardActionContext = {
 		siteUrl: string;
 		siteId: number;
 	} ) => void;
+	setOpenOdieWithContext: ( config: {
+		initialMessage: string;
+		section: string;
+		siteUrl: string;
+		siteId: number;
+	} ) => void;
 };
 
 export type SolutionCardConfigEntry = {
@@ -103,7 +109,17 @@ export const SOLUTION_CARD_CONFIG: SolutionCardConfigEntry[] = [
 		id: 'ask-ai-assistant',
 		title: 'Ask our AI assistant',
 		subtitle: 'Use our AI assistant to quickly find solutions.',
-		// No CTA yet – card is label-only
+		onClick: ( ctx ) => {
+			ctx.setOpenOdieWithContext( {
+				initialMessage:
+					"User is contacting from pre-cancellation form. Cancellation reason they've given: " +
+					ctx.cancellationReason,
+				section: 'pre-cancellation-upsell',
+				siteUrl: ctx.site.URL,
+				siteId: ctx.site.ID,
+			} );
+			ctx.closeDialog();
+		},
 	},
 	{
 		id: 'upgrade-for-full-access',

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solution-cards-config.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solution-cards-config.ts
@@ -123,7 +123,7 @@ export const SOLUTION_CARD_CONFIG: SolutionCardConfigEntry[] = [
 	},
 	{
 		id: 'upgrade-for-full-access',
-		title: 'Upgrade for full access',
+		title: 'Pick another paid plan for access to more features',
 		subtitle: 'Get the business plan to access all available plugins and themes.',
 		getHref: ( ctx ) => ctx.changePlanUrl,
 		onClick: ( ctx ) => {

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solution-cards-config.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solution-cards-config.ts
@@ -142,16 +142,6 @@ export const SOLUTION_CARD_CONFIG: SolutionCardConfigEntry[] = [
 		},
 	},
 	{
-		id: 'get-css-addon',
-		title: 'Get our CSS add-on',
-		subtitle: 'Customize every design detail with a simple add-on.',
-		getHref: ( ctx ) => ctx.changePlanUrl,
-		onClick: ( ctx ) => {
-			page( ctx.changePlanUrl );
-			ctx.closeDialog();
-		},
-	},
-	{
 		id: 'find-guides',
 		title: 'Find easy step-by-step guides',
 		subtitle: 'Browse our guides and get back on track quickly.',

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solution-cards-config.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solution-cards-config.ts
@@ -1,0 +1,195 @@
+import page from '@automattic/calypso-router';
+import { localizeUrl } from '@automattic/i18n-utils';
+import type { SiteDetails } from '@automattic/data-stores';
+import type { Purchase } from 'calypso/lib/purchases/types';
+import type { ReactElement } from 'react';
+
+const BUILT_BY_URL = 'https://wordpress.com/website-design-service/?ref=wpcom-cancel-flow';
+const RENEW_COUPON = 'biz25';
+const SUPPORT_URL = localizeUrl( 'https://wordpress.com/support/' );
+const SITE_SPEED_URL = localizeUrl( 'https://wordpress.com/support/site-speed/' );
+const SITE_MIGRATION_URL = localizeUrl( 'https://wordpress.com/support/site-migration/' );
+const DOMAINS_SUPPORT_URL = localizeUrl( 'https://wordpress.com/support/domains/' );
+const DOMAINS_EXPLORE_URL = localizeUrl( 'https://wordpress.com/domains/' );
+
+function getLiveChatUrlForPlans( site: SiteDetails, purchase: Purchase ): string {
+	return `/purchases/subscriptions/${ site.slug }/${ purchase.id }`;
+}
+
+export type CardActionContext = {
+	site: SiteDetails;
+	purchase: Purchase;
+	closeDialog: () => void;
+	changePlanUrl: string;
+	renewNowUrl: string;
+	cancellationReason: string;
+	onClickDowngrade?: ( upsell: string ) => void;
+	setNewMessagingChat: ( config: {
+		initialMessage: string;
+		section: string;
+		siteUrl: string;
+		siteId: number;
+	} ) => void;
+};
+
+export type SolutionCardConfigEntry = {
+	id: string;
+	/** Literal string for translate() - i18n */
+	title: string;
+	/** Optional literal for translate() - maps to SummaryButton description */
+	subtitle?: string;
+	/** Optional icon/decoration - maps to SummaryButton decoration */
+	decoration?: ReactElement;
+	getHref?: ( ctx: CardActionContext ) => string | undefined;
+	onClick?: ( ctx: CardActionContext ) => void;
+};
+
+export const SOLUTION_CARD_CONFIG: SolutionCardConfigEntry[] = [
+	{
+		id: 'change-plan',
+		title: 'Change plan',
+		subtitle: 'Find a plan that better suits your needs.',
+		getHref: ( ctx ) => ctx.changePlanUrl,
+		onClick: ( ctx ) => {
+			page( ctx.changePlanUrl );
+			ctx.closeDialog();
+		},
+	},
+	{
+		id: 'renew-now-pay-less',
+		title: 'Renew now and pay less',
+		subtitle: 'Get an exclusive 25% discount automatically applied at checkout.',
+		getHref: ( ctx ) => ctx.renewNowUrl,
+		onClick: ( ctx ) => {
+			page( ctx.renewNowUrl );
+			ctx.closeDialog();
+		},
+	},
+	{
+		id: 'switch-to-monthly',
+		title: 'Switch to monthly payments',
+		subtitle: 'Keep things flexible with monthly billing.',
+		onClick: ( ctx ) => {
+			ctx.onClickDowngrade?.( 'downgrade-monthly' );
+		},
+	},
+	{
+		id: 'speak-with-support',
+		title: 'Speak with our support team',
+		subtitle: "We're here to answer any of your questions.",
+		onClick: ( ctx ) => {
+			page( getLiveChatUrlForPlans( ctx.site, ctx.purchase ) );
+			ctx.setNewMessagingChat( {
+				initialMessage:
+					"User is contacting us from pre-cancellation form. Cancellation reason they've given: " +
+					ctx.cancellationReason,
+				section: 'pre-cancellation-upsell',
+				siteUrl: ctx.site.URL,
+				siteId: ctx.site.ID,
+			} );
+			ctx.closeDialog();
+		},
+	},
+	{
+		id: 'built-by',
+		title: 'Let us build for you',
+		subtitle: 'Our team can build your site so you can focus on what matters.',
+		getHref: () => BUILT_BY_URL,
+		onClick: () => {
+			window.location.replace( BUILT_BY_URL );
+		},
+	},
+	{
+		id: 'ask-ai-assistant',
+		title: 'Ask our AI assistant',
+		subtitle: 'Use our AI assistant to quickly find solutions.',
+		// No CTA yet – card is label-only
+	},
+	{
+		id: 'upgrade-for-full-access',
+		title: 'Upgrade for full access',
+		subtitle: 'Get the business plan to access all available plugins and themes.',
+		getHref: ( ctx ) => ctx.changePlanUrl,
+		onClick: ( ctx ) => {
+			page( ctx.changePlanUrl );
+			ctx.closeDialog();
+		},
+	},
+	{
+		id: 'get-theme-addon',
+		title: 'Get our theme add-on',
+		subtitle: 'Unlock premium themes with a simple add-on.',
+		getHref: ( ctx ) => ctx.changePlanUrl,
+		onClick: ( ctx ) => {
+			page( ctx.changePlanUrl );
+			ctx.closeDialog();
+		},
+	},
+	{
+		id: 'get-css-addon',
+		title: 'Get our CSS add-on',
+		subtitle: 'Customize every design detail with a simple add-on.',
+		getHref: ( ctx ) => ctx.changePlanUrl,
+		onClick: ( ctx ) => {
+			page( ctx.changePlanUrl );
+			ctx.closeDialog();
+		},
+	},
+	{
+		id: 'find-guides',
+		title: 'Find easy step-by-step guides',
+		subtitle: 'Browse our guides and get back on track quickly.',
+		getHref: () => SUPPORT_URL,
+		onClick: () => {
+			window.open( SUPPORT_URL, '_blank' );
+		},
+	},
+	{
+		id: 'make-site-faster',
+		title: 'Make your site faster',
+		subtitle: 'Run our free speed test and get personalized recommendations.',
+		getHref: () => SITE_SPEED_URL,
+		onClick: () => {
+			window.open( SITE_SPEED_URL, '_blank' );
+		},
+	},
+	{
+		id: 'use-migration-tools',
+		title: 'Use our migration tools',
+		subtitle: 'Expert assistance or seamless importers for quick moves.',
+		getHref: () => SITE_MIGRATION_URL,
+		onClick: () => {
+			window.open( SITE_MIGRATION_URL, '_blank' );
+		},
+	},
+	{
+		id: 'use-domain-guide',
+		title: 'Use our domain guide',
+		subtitle: 'Follow our simple guide to get connected quickly.',
+		getHref: () => DOMAINS_SUPPORT_URL,
+		onClick: () => {
+			window.open( DOMAINS_SUPPORT_URL, '_blank' );
+		},
+	},
+	{
+		id: 'explore-domain-options',
+		title: 'Explore more domain options',
+		subtitle: "Our search tool finds great alternatives you'll love.",
+		getHref: () => DOMAINS_EXPLORE_URL,
+		onClick: () => {
+			window.open( DOMAINS_EXPLORE_URL, '_blank' );
+		},
+	},
+	{
+		id: 'move-subscription',
+		title: 'Move your subscription',
+		subtitle: 'Transfer your subscription to another site you own.',
+		getHref: ( ctx ) => `/purchases/subscriptions/${ ctx.site.slug }/${ ctx.purchase.id }`,
+		onClick: ( ctx ) => {
+			page( `/purchases/subscriptions/${ ctx.site.slug }/${ ctx.purchase.id }` );
+			ctx.closeDialog();
+		},
+	},
+];
+
+export { BUILT_BY_URL, RENEW_COUPON, getLiveChatUrlForPlans };

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solution-cards-config.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solution-cards-config.ts
@@ -23,6 +23,7 @@ export type CardActionContext = {
 	renewNowUrl: string;
 	cancellationReason: string;
 	onClickDowngrade?: ( upsell: string ) => void;
+	onSelectSwitchToMonthly?: () => void;
 	setNewMessagingChat: ( config: {
 		initialMessage: string;
 		section: string;
@@ -75,7 +76,7 @@ export const SOLUTION_CARD_CONFIG: SolutionCardConfigEntry[] = [
 		title: 'Switch to monthly payments',
 		subtitle: 'Keep things flexible with monthly billing.',
 		onClick: ( ctx ) => {
-			ctx.onClickDowngrade?.( 'downgrade-monthly' );
+			ctx.onSelectSwitchToMonthly?.();
 		},
 	},
 	{

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solution-cards-config.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solution-cards-config.ts
@@ -1,4 +1,3 @@
-import { PRODUCT_WPCOM_UNLIMITED_THEMES } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { localizeUrl } from '@automattic/i18n-utils';
 import type { SiteDetails } from '@automattic/data-stores';
@@ -133,11 +132,11 @@ export const SOLUTION_CARD_CONFIG: SolutionCardConfigEntry[] = [
 	},
 	{
 		id: 'get-theme-addon',
-		title: 'Get our theme add-on',
-		subtitle: 'Unlock premium themes with a simple add-on.',
-		getHref: ( ctx ) => `/checkout/${ ctx.site.slug }/${ PRODUCT_WPCOM_UNLIMITED_THEMES }`,
+		title: 'Change your plan',
+		subtitle: 'Unlock premium themes on another plan.',
+		getHref: ( ctx ) => `/plans/${ ctx.site.slug }`,
 		onClick: ( ctx ) => {
-			page( `/checkout/${ ctx.site.slug }/${ PRODUCT_WPCOM_UNLIMITED_THEMES }` );
+			page( `/plans/${ ctx.site.slug }` );
 			ctx.closeDialog();
 		},
 	},

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solution-cards-config.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solution-cards-config.ts
@@ -197,16 +197,6 @@ export const SOLUTION_CARD_CONFIG: SolutionCardConfigEntry[] = [
 			ctx.closeDialog();
 		},
 	},
-	{
-		id: 'move-subscription',
-		title: 'Move your subscription',
-		subtitle: 'Transfer your subscription to another site you own.',
-		getHref: ( ctx ) => `/purchases/subscriptions/${ ctx.site.slug }/${ ctx.purchase.id }`,
-		onClick: ( ctx ) => {
-			page( `/purchases/subscriptions/${ ctx.site.slug }/${ ctx.purchase.id }` );
-			ctx.closeDialog();
-		},
-	},
 ];
 
 export { BUILT_BY_URL, RENEW_COUPON, getLiveChatUrlForPlans };

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solution-cards-config.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solution-cards-config.ts
@@ -11,7 +11,6 @@ const SUPPORT_URL = localizeUrl( 'https://wordpress.com/support/' );
 const SITE_SPEED_URL = localizeUrl( 'https://wordpress.com/support/site-speed/' );
 const SITE_MIGRATION_URL = localizeUrl( 'https://wordpress.com/support/site-migration/' );
 const DOMAINS_SUPPORT_URL = localizeUrl( 'https://wordpress.com/support/domains/' );
-const DOMAINS_EXPLORE_URL = localizeUrl( 'https://wordpress.com/domains/' );
 
 function getLiveChatUrlForPlans( site: SiteDetails, purchase: Purchase ): string {
 	return `/purchases/subscriptions/${ site.slug }/${ purchase.id }`;
@@ -192,9 +191,10 @@ export const SOLUTION_CARD_CONFIG: SolutionCardConfigEntry[] = [
 		id: 'explore-domain-options',
 		title: 'Explore more domain options',
 		subtitle: "Our search tool finds great alternatives you'll love.",
-		getHref: () => DOMAINS_EXPLORE_URL,
-		onClick: () => {
-			window.open( DOMAINS_EXPLORE_URL, '_blank' );
+		getHref: ( ctx ) => `/domains/add/${ ctx.site.slug }`,
+		onClick: ( ctx ) => {
+			page( `/domains/add/${ ctx.site.slug }` );
+			ctx.closeDialog();
 		},
 	},
 	{

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solution-cards-config.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solution-cards-config.ts
@@ -1,3 +1,4 @@
+import { PRODUCT_WPCOM_UNLIMITED_THEMES } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { localizeUrl } from '@automattic/i18n-utils';
 import type { SiteDetails } from '@automattic/data-stores';
@@ -135,9 +136,9 @@ export const SOLUTION_CARD_CONFIG: SolutionCardConfigEntry[] = [
 		id: 'get-theme-addon',
 		title: 'Get our theme add-on',
 		subtitle: 'Unlock premium themes with a simple add-on.',
-		getHref: ( ctx ) => ctx.changePlanUrl,
+		getHref: ( ctx ) => `/checkout/${ ctx.site.slug }/${ PRODUCT_WPCOM_UNLIMITED_THEMES }`,
 		onClick: ( ctx ) => {
-			page( ctx.changePlanUrl );
+			page( `/checkout/${ ctx.site.slug }/${ PRODUCT_WPCOM_UNLIMITED_THEMES }` );
 			ctx.closeDialog();
 		},
 	},

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -93,7 +93,7 @@ function getTranslatedTitle( id: string, translate: ( s: string ) => string ): s
 		case 'upgrade-for-full-access':
 			return translate( 'Upgrade for full access' );
 		case 'get-theme-addon':
-			return translate( 'Get our theme add-on' );
+			return translate( 'Change your plan' );
 		case 'get-css-addon':
 			return translate( 'Get our CSS add-on' );
 		case 'find-guides':
@@ -133,7 +133,7 @@ function getTranslatedSubtitle(
 		case 'upgrade-for-full-access':
 			return translate( 'Get the business plan to access all available plugins and themes.' );
 		case 'get-theme-addon':
-			return translate( 'Unlock premium themes with a simple add-on.' );
+			return translate( 'Unlock premium themes on another plan.' );
 		case 'get-css-addon':
 			return translate( 'Customize every design detail with a simple add-on.' );
 		case 'find-guides':

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -35,7 +35,10 @@ import type { Purchase } from 'calypso/lib/purchases/types';
 
 const HELP_CENTER_STORE = HelpCenter.register();
 
-const CARD_ICONS: Record< string, import('@wordpress/icons').IconType > = {
+const CARD_ICONS: Record<
+	string,
+	React.ComponentType | { path: React.ReactNode; viewBox?: string }
+> = {
 	'change-plan': reusableBlock,
 	'switch-to-monthly': calendar,
 	'speak-with-support': comment,
@@ -170,7 +173,7 @@ export default function SolutionsCardsUpsellStep( {
 	const translate = useTranslate();
 	const [ busyButton, setBusyButton ] = useState( '' );
 	const solutions = getSolutionsForReason( cancellationReason );
-	const { setNewMessagingChat } = useDataStoreDispatch( HELP_CENTER_STORE );
+	const { setNewMessagingChat, setOpenOdieWithContext } = useDataStoreDispatch( HELP_CENTER_STORE );
 
 	const showSwitchToMonthly = isAnnualOrLongerPlan( purchase.productSlug );
 	const filteredSolutions = solutions?.filter(
@@ -193,6 +196,7 @@ export default function SolutionsCardsUpsellStep( {
 		cancellationReason,
 		onClickDowngrade,
 		setNewMessagingChat,
+		setOpenOdieWithContext,
 	};
 
 	const handleDecline = () => {

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -204,9 +204,6 @@ export default function SolutionsCardsUpsellStep( {
 	return (
 		<div className="cancel-purchase-form__upsell">
 			<div className="cancel-purchase-form__upsell-content">
-				<div className="cancel-purchase-form__upsell-subheader">
-					{ translate( 'Here is an idea' ) }
-				</div>
 				<FormattedHeader
 					brandFont
 					headerText={ translate( 'Have you tried any of these options?' ) }

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -43,6 +43,18 @@ function getTranslatedTitle( id: string, translate: ( s: string ) => string ): s
 			return translate( 'Let us build for you' );
 		case 'ask-ai-assistant':
 			return translate( 'Ask our AI assistant' );
+		case 'upgrade-for-full-access':
+			return translate( 'Upgrade for full access' );
+		case 'get-theme-addon':
+			return translate( 'Get our theme add-on' );
+		case 'get-css-addon':
+			return translate( 'Get our CSS add-on' );
+		case 'find-guides':
+			return translate( 'Find easy step-by-step guides' );
+		case 'make-site-faster':
+			return translate( 'Make your site faster' );
+		case 'use-migration-tools':
+			return translate( 'Use our migration tools' );
 		default:
 			return '';
 	}

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -55,6 +55,10 @@ function getTranslatedTitle( id: string, translate: ( s: string ) => string ): s
 			return translate( 'Make your site faster' );
 		case 'use-migration-tools':
 			return translate( 'Use our migration tools' );
+		case 'use-domain-guide':
+			return translate( 'Use our domain guide' );
+		case 'explore-domain-options':
+			return translate( 'Explore more domain options' );
 		default:
 			return '';
 	}

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -21,7 +21,6 @@ import {
 	reusableBlock,
 	search,
 	shipping,
-	shuffle,
 	trendingUp,
 	upload,
 } from '@wordpress/icons';
@@ -51,7 +50,6 @@ const CARD_ICONS: Record< string, React.ReactElement > = {
 	'use-migration-tools': shipping,
 	'use-domain-guide': globe,
 	'explore-domain-options': search,
-	'move-subscription': shuffle,
 };
 
 function getDecorationForCard( cardId: string ) {
@@ -104,8 +102,6 @@ function getTranslatedTitle( id: string, translate: ( s: string ) => string ): s
 			return translate( 'Use our domain guide' );
 		case 'explore-domain-options':
 			return translate( 'Explore more domain options' );
-		case 'move-subscription':
-			return translate( 'Move your subscription' );
 		default:
 			return '';
 	}
@@ -144,8 +140,6 @@ function getTranslatedSubtitle(
 			return translate( 'Follow our simple guide to get connected quickly.' );
 		case 'explore-domain-options':
 			return translate( "Our search tool finds great alternatives you'll love." );
-		case 'move-subscription':
-			return translate( 'Transfer your subscription to another site you own.' );
 		default:
 			return undefined;
 	}

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -11,7 +11,6 @@ import {
 	Icon,
 	brush,
 	calendar,
-	code,
 	comment,
 	commentContent,
 	globe,
@@ -44,7 +43,6 @@ const CARD_ICONS: Record< string, React.ReactElement > = {
 	'ask-ai-assistant': commentContent,
 	'upgrade-for-full-access': upload,
 	'get-theme-addon': brush,
-	'get-css-addon': code,
 	'find-guides': postList,
 	'make-site-faster': trendingUp,
 	'use-migration-tools': shipping,
@@ -90,8 +88,6 @@ function getTranslatedTitle( id: string, translate: ( s: string ) => string ): s
 			return translate( 'Pick another paid plan for access to more features' );
 		case 'get-theme-addon':
 			return translate( 'Change your plan' );
-		case 'get-css-addon':
-			return translate( 'Get our CSS add-on' );
 		case 'find-guides':
 			return translate( 'Find easy step-by-step guides' );
 		case 'make-site-faster':
@@ -128,8 +124,6 @@ function getTranslatedSubtitle(
 			return translate( 'Get the business plan to access all available plugins and themes.' );
 		case 'get-theme-addon':
 			return translate( 'Unlock premium themes on another plan.' );
-		case 'get-css-addon':
-			return translate( 'Customize every design detail with a simple add-on.' );
 		case 'find-guides':
 			return translate( 'Browse our guides and get back on track quickly.' );
 		case 'make-site-faster':

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -241,7 +241,7 @@ export default function SolutionsCardsUpsellStep( {
 								href={ href }
 								onClick={ hasAction ? handleClick : undefined }
 								showArrow={ hasAction }
-								density="low"
+								density="medium"
 							/>
 						);
 					} ) }

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -238,7 +238,7 @@ export default function SolutionsCardsUpsellStep( {
 								href={ href }
 								onClick={ hasAction ? handleClick : undefined }
 								showArrow={ hasAction }
-								density="medium"
+								density="medium-low"
 							/>
 						);
 					} ) }

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -26,7 +26,7 @@ import {
 	upload,
 } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import React, { useState } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { getSolutionsForReason } from '../get-solutions-for-reason';
 import { CardActionContext, RENEW_COUPON, SOLUTION_CARD_CONFIG } from './solution-cards-config';
@@ -35,7 +35,7 @@ import type { Purchase } from 'calypso/lib/purchases/types';
 
 const HELP_CENTER_STORE = HelpCenter.register();
 
-const CARD_ICONS: Record< string, unknown > = {
+const CARD_ICONS: Record< string, React.ComponentType > = {
 	'change-plan': reusableBlock,
 	'switch-to-monthly': calendar,
 	'speak-with-support': comment,
@@ -54,11 +54,11 @@ const CARD_ICONS: Record< string, unknown > = {
 };
 
 function getDecorationForCard( cardId: string ) {
-	const icon = CARD_ICONS[ cardId ];
-	if ( ! icon ) {
+	const IconComponent = CARD_ICONS[ cardId ];
+	if ( ! IconComponent ) {
 		return undefined;
 	}
-	return <Icon icon={ icon } size={ 24 } />;
+	return <Icon icon={ <IconComponent /> } size={ 24 } />;
 }
 
 function isAnnualOrLongerPlan( productSlug: string ): boolean {

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -59,6 +59,8 @@ function getTranslatedTitle( id: string, translate: ( s: string ) => string ): s
 			return translate( 'Use our domain guide' );
 		case 'explore-domain-options':
 			return translate( 'Explore more domain options' );
+		case 'move-subscription':
+			return translate( 'Move your subscription' );
 		default:
 			return '';
 	}

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -159,12 +159,14 @@ export default function SolutionsCardsUpsellStep( {
 						return (
 							<SummaryButton
 								key={ card.id }
+								className="cancel-purchase-form__solution-card"
 								title={ getTranslatedTitle( card.id, translate ) }
 								description={ getTranslatedSubtitle( card.id, translate ) }
 								decoration={ config.decoration }
 								href={ href }
 								onClick={ hasAction ? handleClick : undefined }
 								showArrow={ hasAction }
+								density="medium"
 							/>
 						);
 					} ) }

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -89,7 +89,7 @@ function getTranslatedTitle( id: string, translate: ( s: string ) => string ): s
 		case 'ask-ai-assistant':
 			return translate( 'Ask our AI assistant' );
 		case 'upgrade-for-full-access':
-			return translate( 'Upgrade for full access' );
+			return translate( 'Pick another paid plan for access to more features' );
 		case 'get-theme-addon':
 			return translate( 'Change your plan' );
 		case 'get-css-addon':

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -30,6 +30,7 @@ import React, { useState } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { getSolutionsForReason } from '../get-solutions-for-reason';
 import { CardActionContext, RENEW_COUPON, SOLUTION_CARD_CONFIG } from './solution-cards-config';
+import UpsellStep from './upsell-step';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { Purchase } from 'calypso/lib/purchases/types';
 
@@ -152,23 +153,32 @@ function getTranslatedSubtitle(
 
 type SolutionsCardsUpsellStepProps = {
 	cancellationReason: string;
+	cancelBundledDomain?: boolean;
 	closeDialog: () => void;
+	downgradePlanPrice?: number | null;
+	includedDomainPurchase?: object;
 	onClickDowngrade?: ( upsell: string ) => void;
 	onDeclineUpsell: () => void;
 	purchase: Purchase;
+	refundAmount?: string;
 	site: SiteDetails;
 };
 
 export default function SolutionsCardsUpsellStep( {
 	cancellationReason = '',
+	cancelBundledDomain,
 	closeDialog,
+	downgradePlanPrice,
+	includedDomainPurchase,
 	onClickDowngrade,
 	onDeclineUpsell,
 	purchase,
+	refundAmount,
 	site,
 }: SolutionsCardsUpsellStepProps ) {
 	const translate = useTranslate();
 	const [ busyButton, setBusyButton ] = useState( '' );
+	const [ showDowngradeStep, setShowDowngradeStep ] = useState( false );
 	const solutions = getSolutionsForReason( cancellationReason );
 	const { setNewMessagingChat, setOpenOdieWithContext } = useDataStoreDispatch( HELP_CENTER_STORE );
 
@@ -192,9 +202,28 @@ export default function SolutionsCardsUpsellStep( {
 		renewNowUrl,
 		cancellationReason,
 		onClickDowngrade,
+		onSelectSwitchToMonthly: () => setShowDowngradeStep( true ),
 		setNewMessagingChat,
 		setOpenOdieWithContext,
 	};
+
+	if ( showDowngradeStep ) {
+		return (
+			<UpsellStep
+				upsell="downgrade-monthly"
+				cancellationReason={ cancellationReason }
+				cancelBundledDomain={ cancelBundledDomain }
+				closeDialog={ closeDialog }
+				downgradePlanPrice={ downgradePlanPrice }
+				includedDomainPurchase={ includedDomainPurchase }
+				onClickDowngrade={ onClickDowngrade }
+				onDeclineUpsell={ () => setShowDowngradeStep( false ) }
+				purchase={ purchase }
+				refundAmount={ refundAmount }
+				site={ site }
+			/>
+		);
+	}
 
 	const handleDecline = () => {
 		setBusyButton( 'decline' );

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -246,7 +246,7 @@ export default function SolutionsCardsUpsellStep( {
 						);
 					} ) }
 				</div>
-				<div className="cancel-purchase-form__upsell-buttons">
+				<div>
 					<Button
 						variant="secondary"
 						onClick={ handleDecline }

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -229,7 +229,11 @@ export default function SolutionsCardsUpsellStep( {
 			<div className="cancel-purchase-form__upsell-content">
 				<FormattedHeader
 					brandFont
-					headerText={ translate( 'Have you tried any of these options?' ) }
+					headerText={
+						filteredSolutions.length === 1
+							? translate( "Before you cancel, here's an idea:" )
+							: translate( 'Have you tried any of these options?' )
+					}
 				/>
 				<div className="cancel-purchase-form__upsell-solutions-cards">
 					{ filteredSolutions.map( ( card ) => {

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -35,10 +35,7 @@ import type { Purchase } from 'calypso/lib/purchases/types';
 
 const HELP_CENTER_STORE = HelpCenter.register();
 
-const CARD_ICONS: Record<
-	string,
-	React.ComponentType | { path: React.ReactNode; viewBox?: string } | React.ReactElement
-> = {
+const CARD_ICONS: Record< string, React.ReactElement > = {
 	'change-plan': reusableBlock,
 	'switch-to-monthly': calendar,
 	'speak-with-support': comment,

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -7,6 +7,24 @@ import { SummaryButton } from '@automattic/components';
 import { HelpCenter } from '@automattic/data-stores';
 import { Button } from '@wordpress/components';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
+import {
+	Icon,
+	brush,
+	calendar,
+	code,
+	comment,
+	commentContent,
+	globe,
+	people,
+	percent,
+	postList,
+	reusableBlock,
+	search,
+	shipping,
+	shuffle,
+	trendingUp,
+	upload,
+} from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -16,6 +34,32 @@ import type { SiteDetails } from '@automattic/data-stores';
 import type { Purchase } from 'calypso/lib/purchases/types';
 
 const HELP_CENTER_STORE = HelpCenter.register();
+
+const CARD_ICONS: Record< string, unknown > = {
+	'change-plan': reusableBlock,
+	'switch-to-monthly': calendar,
+	'speak-with-support': comment,
+	'renew-now-pay-less': percent,
+	'built-by': people,
+	'ask-ai-assistant': commentContent,
+	'upgrade-for-full-access': upload,
+	'get-theme-addon': brush,
+	'get-css-addon': code,
+	'find-guides': postList,
+	'make-site-faster': trendingUp,
+	'use-migration-tools': shipping,
+	'use-domain-guide': globe,
+	'explore-domain-options': search,
+	'move-subscription': shuffle,
+};
+
+function getDecorationForCard( cardId: string ) {
+	const icon = CARD_ICONS[ cardId ];
+	if ( ! icon ) {
+		return undefined;
+	}
+	return <Icon icon={ icon } size={ 24 } />;
+}
 
 function isAnnualOrLongerPlan( productSlug: string ): boolean {
 	return (
@@ -189,7 +233,7 @@ export default function SolutionsCardsUpsellStep( {
 								className="cancel-purchase-form__solution-card"
 								title={ getTranslatedTitle( card.id, translate ) }
 								description={ getTranslatedSubtitle( card.id, translate ) }
-								decoration={ config.decoration }
+								decoration={ config.decoration ?? getDecorationForCard( card.id ) }
 								href={ href }
 								onClick={ hasAction ? handleClick : undefined }
 								showArrow={ hasAction }

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -1,0 +1,167 @@
+import {
+	isWpComAnnualPlan,
+	isWpComBiennialPlan,
+	isWpComTriennialPlan,
+} from '@automattic/calypso-products';
+import { SummaryButton } from '@automattic/components';
+import { HelpCenter } from '@automattic/data-stores';
+import { Button } from '@wordpress/components';
+import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { getSolutionsForReason } from '../get-solutions-for-reason';
+import { CardActionContext, RENEW_COUPON, SOLUTION_CARD_CONFIG } from './solution-cards-config';
+import type { SiteDetails } from '@automattic/data-stores';
+import type { Purchase } from 'calypso/lib/purchases/types';
+
+const HELP_CENTER_STORE = HelpCenter.register();
+
+function isAnnualOrLongerPlan( productSlug: string ): boolean {
+	return (
+		isWpComAnnualPlan( productSlug ) ||
+		isWpComBiennialPlan( productSlug ) ||
+		isWpComTriennialPlan( productSlug )
+	);
+}
+
+function getConfigForId( id: string ) {
+	return SOLUTION_CARD_CONFIG.find( ( c ) => c.id === id );
+}
+
+function getTranslatedTitle( id: string, translate: ( s: string ) => string ): string {
+	switch ( id ) {
+		case 'change-plan':
+			return translate( 'Change plan' );
+		case 'renew-now-pay-less':
+			return translate( 'Renew now and pay less' );
+		case 'switch-to-monthly':
+			return translate( 'Switch to monthly payments' );
+		case 'speak-with-support':
+			return translate( 'Speak with our support team' );
+		case 'built-by':
+			return translate( 'Let us build for you' );
+		case 'ask-ai-assistant':
+			return translate( 'Ask our AI assistant' );
+		default:
+			return '';
+	}
+}
+
+function getTranslatedSubtitle(
+	id: string,
+	translate: ( s: string ) => string
+): string | undefined {
+	switch ( id ) {
+		// Add subtitle cases when config has subtitle for this id
+		default:
+			return undefined;
+	}
+	void translate; // reserved for future subtitle translations
+}
+
+type SolutionsCardsUpsellStepProps = {
+	cancellationReason: string;
+	closeDialog: () => void;
+	onClickDowngrade?: ( upsell: string ) => void;
+	onDeclineUpsell: () => void;
+	purchase: Purchase;
+	site: SiteDetails;
+};
+
+export default function SolutionsCardsUpsellStep( {
+	cancellationReason = '',
+	closeDialog,
+	onClickDowngrade,
+	onDeclineUpsell,
+	purchase,
+	site,
+}: SolutionsCardsUpsellStepProps ) {
+	const translate = useTranslate();
+	const [ busyButton, setBusyButton ] = useState( '' );
+	const solutions = getSolutionsForReason( cancellationReason );
+	const { setNewMessagingChat } = useDataStoreDispatch( HELP_CENTER_STORE );
+
+	const showSwitchToMonthly = isAnnualOrLongerPlan( purchase.productSlug );
+	const filteredSolutions = solutions.filter(
+		( card ) => card.id !== 'switch-to-monthly' || showSwitchToMonthly
+	);
+
+	if ( ! filteredSolutions?.length ) {
+		return null;
+	}
+
+	const changePlanUrl = `/plans/${ site.slug }`;
+	const renewNowUrl = `/checkout/${ site.slug }/${ purchase.productSlug }?coupon=${ RENEW_COUPON }`;
+
+	const context: CardActionContext = {
+		site,
+		purchase,
+		closeDialog,
+		changePlanUrl,
+		renewNowUrl,
+		cancellationReason,
+		onClickDowngrade,
+		setNewMessagingChat,
+	};
+
+	const handleDecline = () => {
+		setBusyButton( 'decline' );
+		onDeclineUpsell();
+	};
+
+	return (
+		<div className="cancel-purchase-form__upsell">
+			<div className="cancel-purchase-form__upsell-content">
+				<div className="cancel-purchase-form__upsell-subheader">
+					{ translate( 'Here is an idea' ) }
+				</div>
+				<FormattedHeader
+					brandFont
+					headerText={ translate( 'Have you tried any of these options?' ) }
+				/>
+				<div className="cancel-purchase-form__upsell-solutions-cards">
+					{ filteredSolutions.map( ( card ) => {
+						const config = getConfigForId( card.id );
+						if ( ! config ) {
+							return null;
+						}
+						const href = config.getHref?.( context );
+						const hasAction =
+							Boolean( href ) ||
+							Boolean( config.onClick ) ||
+							( card.id === 'switch-to-monthly' && onClickDowngrade );
+						const handleClick = ( e: React.MouseEvent ) => {
+							if ( href && config.onClick ) {
+								e.preventDefault();
+							}
+							config.onClick?.( context );
+						};
+
+						return (
+							<SummaryButton
+								key={ card.id }
+								title={ getTranslatedTitle( card.id, translate ) }
+								description={ getTranslatedSubtitle( card.id, translate ) }
+								decoration={ config.decoration }
+								href={ href }
+								onClick={ hasAction ? handleClick : undefined }
+								showArrow={ hasAction }
+							/>
+						);
+					} ) }
+				</div>
+				<div className="cancel-purchase-form__upsell-buttons">
+					<Button
+						variant="secondary"
+						onClick={ handleDecline }
+						isBusy={ busyButton === 'decline' }
+						disabled={ Boolean( busyButton && busyButton !== 'decline' ) }
+					>
+						{ translate( 'No thanks, cancel my plan' ) }
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -71,11 +71,39 @@ function getTranslatedSubtitle(
 	translate: ( s: string ) => string
 ): string | undefined {
 	switch ( id ) {
-		// Add subtitle cases when config has subtitle for this id
+		case 'change-plan':
+			return translate( 'Find a plan that better suits your needs.' );
+		case 'renew-now-pay-less':
+			return translate( 'Get an exclusive 25% discount automatically applied at checkout.' );
+		case 'switch-to-monthly':
+			return translate( 'Keep things flexible with monthly billing.' );
+		case 'speak-with-support':
+			return translate( "We're here to answer any of your questions." );
+		case 'built-by':
+			return translate( 'Our team can build your site so you can focus on what matters.' );
+		case 'ask-ai-assistant':
+			return translate( 'Use our AI assistant to quickly find solutions.' );
+		case 'upgrade-for-full-access':
+			return translate( 'Get the business plan to access all available plugins and themes.' );
+		case 'get-theme-addon':
+			return translate( 'Unlock premium themes with a simple add-on.' );
+		case 'get-css-addon':
+			return translate( 'Customize every design detail with a simple add-on.' );
+		case 'find-guides':
+			return translate( 'Browse our guides and get back on track quickly.' );
+		case 'make-site-faster':
+			return translate( 'Run our free speed test and get personalized recommendations.' );
+		case 'use-migration-tools':
+			return translate( 'Expert assistance or seamless importers for quick moves.' );
+		case 'use-domain-guide':
+			return translate( 'Follow our simple guide to get connected quickly.' );
+		case 'explore-domain-options':
+			return translate( "Our search tool finds great alternatives you'll love." );
+		case 'move-subscription':
+			return translate( 'Transfer your subscription to another site you own.' );
 		default:
 			return undefined;
 	}
-	void translate; // reserved for future subtitle translations
 }
 
 type SolutionsCardsUpsellStepProps = {
@@ -101,7 +129,7 @@ export default function SolutionsCardsUpsellStep( {
 	const { setNewMessagingChat } = useDataStoreDispatch( HELP_CENTER_STORE );
 
 	const showSwitchToMonthly = isAnnualOrLongerPlan( purchase.productSlug );
-	const filteredSolutions = solutions.filter(
+	const filteredSolutions = solutions?.filter(
 		( card ) => card.id !== 'switch-to-monthly' || showSwitchToMonthly
 	);
 
@@ -145,10 +173,9 @@ export default function SolutionsCardsUpsellStep( {
 							return null;
 						}
 						const href = config.getHref?.( context );
-						const hasAction =
-							Boolean( href ) ||
-							Boolean( config.onClick ) ||
-							( card.id === 'switch-to-monthly' && onClickDowngrade );
+						const hasAction = Boolean(
+							href || config.onClick || ( card.id === 'switch-to-monthly' && onClickDowngrade )
+						);
 						const handleClick = ( e: React.MouseEvent ) => {
 							if ( href && config.onClick ) {
 								e.preventDefault();
@@ -166,7 +193,7 @@ export default function SolutionsCardsUpsellStep( {
 								href={ href }
 								onClick={ hasAction ? handleClick : undefined }
 								showArrow={ hasAction }
-								density="medium"
+								density="low"
 							/>
 						);
 					} ) }

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -35,7 +35,7 @@ import type { Purchase } from 'calypso/lib/purchases/types';
 
 const HELP_CENTER_STORE = HelpCenter.register();
 
-const CARD_ICONS: Record< string, React.ComponentType > = {
+const CARD_ICONS: Record< string, import('@wordpress/icons').IconType > = {
 	'change-plan': reusableBlock,
 	'switch-to-monthly': calendar,
 	'speak-with-support': comment,
@@ -54,11 +54,11 @@ const CARD_ICONS: Record< string, React.ComponentType > = {
 };
 
 function getDecorationForCard( cardId: string ) {
-	const IconComponent = CARD_ICONS[ cardId ];
-	if ( ! IconComponent ) {
+	const icon = CARD_ICONS[ cardId ];
+	if ( ! icon ) {
 		return undefined;
 	}
-	return <Icon icon={ <IconComponent /> } size={ 24 } />;
+	return <Icon icon={ icon } size={ 24 } />;
 }
 
 function isAnnualOrLongerPlan( productSlug: string ): boolean {

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -37,7 +37,7 @@ const HELP_CENTER_STORE = HelpCenter.register();
 
 const CARD_ICONS: Record<
 	string,
-	React.ComponentType | { path: React.ReactNode; viewBox?: string }
+	React.ComponentType | { path: React.ReactNode; viewBox?: string } | React.ReactElement
 > = {
 	'change-plan': reusableBlock,
 	'switch-to-monthly': calendar,

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
@@ -32,7 +32,7 @@ type UpsellProps = {
 	acceptButtonUrl?: string;
 	declineButtonText?: TranslateResult;
 	onAccept?: () => void;
-	onDecline: () => void;
+	onDecline?: () => void;
 };
 
 function Upsell( { image, ...props }: UpsellProps ) {
@@ -101,15 +101,15 @@ type StepProps = {
 	upsell: UpsellType;
 	site: SiteDetails;
 	purchase: Purchase;
-	refundAmount: string;
-	downgradePlanPrice: number | null;
-	closeDialog: () => void;
-	cancelBundledDomain: boolean;
-	includedDomainPurchase: object;
-	onDeclineUpsell: () => void;
+	refundAmount?: string;
+	downgradePlanPrice?: number | null;
+	closeDialog?: () => void;
+	cancelBundledDomain?: boolean;
+	includedDomainPurchase?: object;
+	onDeclineUpsell?: () => void;
 	onClickFreeMonthOffer?: () => void;
 	onClickDowngrade?: ( upsell: string ) => void;
-	cancellationReason: string;
+	cancellationReason?: string;
 };
 
 export default function UpsellStep( { upsell, site, purchase, ...props }: StepProps ) {

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { isEnabled } from '@automattic/calypso-config';
 import { getPlan, PLAN_PERSONAL, PLAN_BUSINESS } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { HelpCenter } from '@automattic/data-stores';
@@ -42,9 +43,11 @@ function Upsell( { image, ...props }: UpsellProps ) {
 	return (
 		<div className="cancel-purchase-form__upsell">
 			<div className="cancel-purchase-form__upsell-content">
-				<div className="cancel-purchase-form__upsell-subheader">
-					{ translate( 'Here is an idea' ) }
-				</div>
+				{ ! isEnabled( 'cancel-flow/solutions-cards-upsell' ) && (
+					<div className="cancel-purchase-form__upsell-subheader">
+						{ translate( 'Here is an idea' ) }
+					</div>
+				) }
 				<FormattedHeader brandFont headerText={ props.title } />
 				<div className="cancel-purchase-form__upsell-text">{ props.children }</div>
 				<div className="cancel-purchase-form__upsell-buttons">

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
@@ -156,7 +156,7 @@ export default function UpsellStep( { upsell, site, purchase, ...props }: StepPr
 							siteId: site.ID,
 						} );
 
-						props.closeDialog();
+						props.closeDialog?.();
 					} }
 					onDecline={ props.onDeclineUpsell }
 					image={ imgLiveChat }
@@ -266,7 +266,10 @@ export default function UpsellStep( { upsell, site, purchase, ...props }: StepPr
 									'You can downgrade immediately and get a partial refund of %(refundAmount)s.',
 									{
 										args: {
-											refundAmount: formatCurrency( parseFloat( refundAmount ), currencyCode ),
+											refundAmount: formatCurrency(
+												parseFloat( refundAmount ?? '0' ),
+												currencyCode
+											),
 										},
 									}
 							  )

--- a/client/components/marketing-survey/cancel-purchase-form/style.scss
+++ b/client/components/marketing-survey/cancel-purchase-form/style.scss
@@ -247,6 +247,13 @@
 	line-height: 1.8;
 }
 
+.cancel-purchase-form__upsell-solutions-cards {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	margin: 1rem 0;
+}
+
 .cancel-purchase-form__upsell-buttons {
 	display: flex;
 	flex-direction: row;

--- a/client/components/marketing-survey/cancel-purchase-form/style.scss
+++ b/client/components/marketing-survey/cancel-purchase-form/style.scss
@@ -251,7 +251,7 @@
 	display: flex;
 	flex-direction: column;
 	gap: 0;
-	margin: 1rem 0;
+	margin: 0 0 1.25rem;
 	border: 1px solid var(--studio-gray-10);
 	border-radius: 4px;
 	overflow: hidden;

--- a/client/components/marketing-survey/cancel-purchase-form/style.scss
+++ b/client/components/marketing-survey/cancel-purchase-form/style.scss
@@ -261,6 +261,15 @@
 		border-radius: 0;
 		border-bottom: 1px solid var(--studio-gray-5);
 
+		/* Vertically center the icon (decoration) with the card content */
+		> * {
+			align-items: center;
+		}
+
+		.summary-button-decoration {
+			align-items: center;
+		}
+
 		&:last-child {
 			border-bottom: none;
 		}

--- a/client/components/marketing-survey/cancel-purchase-form/style.scss
+++ b/client/components/marketing-survey/cancel-purchase-form/style.scss
@@ -257,10 +257,6 @@
 	overflow: hidden;
 
 	.cancel-purchase-form__solution-card.summary-button {
-		width: 100%;
-		border-radius: 0;
-		border-bottom: 1px solid var(--studio-gray-5);
-
 		/* Vertically center the icon (decoration) with the card content */
 		> * {
 			align-items: center;

--- a/client/components/marketing-survey/cancel-purchase-form/style.scss
+++ b/client/components/marketing-survey/cancel-purchase-form/style.scss
@@ -250,8 +250,21 @@
 .cancel-purchase-form__upsell-solutions-cards {
 	display: flex;
 	flex-direction: column;
-	gap: 12px;
+	gap: 0;
 	margin: 1rem 0;
+	border: 1px solid var(--studio-gray-10);
+	border-radius: 4px;
+	overflow: hidden;
+
+	.cancel-purchase-form__solution-card.summary-button {
+		width: 100%;
+		border-radius: 0;
+		border-bottom: 1px solid var(--studio-gray-5);
+
+		&:last-child {
+			border-bottom: none;
+		}
+	}
 }
 
 .cancel-purchase-form__upsell-buttons {

--- a/client/dashboard/app/help-center/index.ts
+++ b/client/dashboard/app/help-center/index.ts
@@ -67,6 +67,31 @@ export function useHelpCenter() {
 		return ( dispatch( HELP_CENTER_STORE ) as HelpCenterDispatch ).setSubject( subject );
 	}, [] );
 
+	const setNewMessagingChat = useCallback(
+		async ( {
+			initialMessage,
+			section,
+			siteUrl,
+			siteId,
+		}: {
+			initialMessage: string;
+			section?: string;
+			siteUrl?: string;
+			siteId?: string;
+		} ) => {
+			const url = addQueryArgs( '/odie', {
+				provider: 'zendesk',
+				userFieldMessage: initialMessage,
+				section,
+				siteUrl,
+				siteId,
+			} );
+			await setNavigateToRoute( url );
+			await setShowHelpCenter( true );
+		},
+		[ setNavigateToRoute, setShowHelpCenter ]
+	);
+
 	const setOpenOdieWithContext = useCallback(
 		async ( {
 			initialMessage,
@@ -97,6 +122,7 @@ export function useHelpCenter() {
 		setShowHelpCenter,
 		setNavigateToRoute,
 		setSubject,
+		setNewMessagingChat,
 		setOpenOdieWithContext,
 	};
 }

--- a/client/dashboard/app/help-center/index.ts
+++ b/client/dashboard/app/help-center/index.ts
@@ -66,11 +66,26 @@ export function useHelpCenter() {
 		return ( dispatch( HELP_CENTER_STORE ) as HelpCenterDispatch ).setSubject( subject );
 	}, [] );
 
+	const setOpenOdieWithContext = useCallback(
+		async ( args: {
+			initialMessage: string;
+			section?: string;
+			siteUrl?: string;
+			siteId?: string | number;
+		} ) => {
+			await ensureHelpCenterLoaded();
+
+			return ( dispatch( HELP_CENTER_STORE ) as HelpCenterDispatch ).setOpenOdieWithContext( args );
+		},
+		[]
+	);
+
 	return {
 		isLoading,
 		isShown,
 		setShowHelpCenter,
 		setNavigateToRoute,
 		setSubject,
+		setOpenOdieWithContext,
 	};
 }

--- a/client/dashboard/app/help-center/index.ts
+++ b/client/dashboard/app/help-center/index.ts
@@ -1,4 +1,5 @@
 import { dispatch, useSelect } from '@wordpress/data';
+import { addQueryArgs } from '@wordpress/url';
 import { useCallback, useState, useRef } from 'react';
 // eslint-disable-next-line no-restricted-imports
 import type {
@@ -67,17 +68,27 @@ export function useHelpCenter() {
 	}, [] );
 
 	const setOpenOdieWithContext = useCallback(
-		async ( args: {
+		async ( {
+			initialMessage,
+			section,
+			siteUrl,
+			siteId,
+		}: {
 			initialMessage: string;
 			section?: string;
 			siteUrl?: string;
 			siteId?: string | number;
 		} ) => {
-			await ensureHelpCenterLoaded();
-
-			return ( dispatch( HELP_CENTER_STORE ) as HelpCenterDispatch ).setOpenOdieWithContext( args );
+			const url = addQueryArgs( '/odie', {
+				userFieldMessage: initialMessage,
+				section,
+				siteUrl,
+				siteId: siteId != null ? String( siteId ) : undefined,
+			} );
+			await setNavigateToRoute( url );
+			await setShowHelpCenter( true );
 		},
-		[]
+		[ setNavigateToRoute, setShowHelpCenter ]
 	);
 
 	return {

--- a/client/dashboard/components/summary-button-list/index.tsx
+++ b/client/dashboard/components/summary-button-list/index.tsx
@@ -24,7 +24,7 @@ export function SummaryButtonList( {
 	children,
 }: SummaryButtonListProps ) {
 	const titleId = useInstanceId( SummaryButtonList, 'dashboard-summary-button-list__title' );
-	const isMediumDensity = density === 'medium';
+	const useCardWrapper = density === 'medium' || density === 'medium-low';
 	// Clone children and override their density prop.
 	const clonedChildren = Children.map( children, ( child ) => {
 		if ( isValidElement( child ) ) {
@@ -48,7 +48,7 @@ export function SummaryButtonList( {
 			{ clonedChildren }
 		</ul>
 	);
-	if ( isMediumDensity ) {
+	if ( useCardWrapper ) {
 		return (
 			<Card className={ className }>
 				{ header && <CardHeader>{ header }</CardHeader> }

--- a/client/dashboard/components/summary-button-list/style.scss
+++ b/client/dashboard/components/summary-button-list/style.scss
@@ -20,7 +20,8 @@
 		}
 	}
 
-	&.has-density-medium {
+	&.has-density-medium,
+	&.has-density-medium-low {
 		.dashboard-summary-button-list__children-list-wrapper {
 			// TODO: remove once the `CardBody` natively supports having no padding.
 			padding: 0;

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
@@ -175,7 +175,6 @@ function SurveyContent( {
 					onClickDowngrade={ downgradeClick }
 					onClickFreeMonthOffer={ freeMonthOfferClick }
 					onDeclineUpsell={ isLastStep ? onSubmit : clickNext }
-					plans={ plans }
 					purchase={ purchase }
 				/>
 			);

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
@@ -173,7 +173,6 @@ function SurveyContent( {
 					cancellationReason={ questionOneText }
 					closeDialog={ closeDialog }
 					onClickDowngrade={ downgradeClick }
-					onClickFreeMonthOffer={ freeMonthOfferClick }
 					onDeclineUpsell={ isLastStep ? onSubmit : clickNext }
 					purchase={ purchase }
 				/>

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
@@ -462,7 +462,7 @@ function getSurveyTitle( surveyStep: string ) {
 		return '';
 	}
 	if ( surveyStep === UPSELL_STEP ) {
-		return __( 'Here is an idea' );
+		return '';
 	}
 
 	return __( 'Before you go, please answer a few quick questions to help us improve.' );

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
@@ -160,10 +160,14 @@ function SurveyContent( {
 				<SolutionsCardsUpsellStep
 					cancellationInProgress={ cancellationInProgress }
 					cancellationReason={ questionOneText }
+					cancelBundledDomain={ cancelBundledDomain }
 					closeDialog={ closeDialog }
+					downgradePlan={ downgradePlan }
+					includedDomainPurchase={ includedDomainPurchase }
 					onClickDowngrade={ downgradeClick }
 					onDeclineUpsell={ isLastStep ? onSubmit : clickNext }
 					purchase={ purchase }
+					refundAmount={ refundAmount }
 				/>
 			);
 		}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Button, __experimentalVStack as VStack } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
@@ -5,11 +6,13 @@ import { intlFormat } from 'date-fns';
 import { ButtonStack } from '../../../../components/button-stack';
 import { SectionHeader } from '../../../../components/section-header';
 import { CANCEL_FLOW_TYPE, CancelFlowType } from '../../../../utils/purchase';
+import { getSolutionsForReason } from '../get-solutions-for-reason';
 import { AtomicRevertStep } from './step-components/atomic-revert-step';
 import EducationContentStep from './step-components/educational-content-step';
 import FeedbackStep from './step-components/feedback-step';
 import JetpackCancellationOfferStep from './step-components/jetpack-cancellation-offer-step';
 import NextAdventureStep from './step-components/next-adventure-step';
+import SolutionsCardsUpsellStep from './step-components/solutions-cards-upsell-step';
 import UpsellStep from './step-components/upsell-step';
 import {
 	ATOMIC_REVERT_STEP,
@@ -155,6 +158,25 @@ function SurveyContent( {
 					onDecline={ isLastStep ? onSubmit : clickNext }
 					siteSlug={ siteSlug }
 					type={ upsell }
+				/>
+			);
+		}
+
+		const solutions = getSolutionsForReason( questionOneText ?? '' );
+		const useSolutionsCards =
+			config.isEnabled( 'cancel-flow/solutions-cards-upsell' ) && solutions && solutions.length > 0;
+
+		if ( useSolutionsCards ) {
+			return (
+				<SolutionsCardsUpsellStep
+					cancellationInProgress={ cancellationInProgress }
+					cancellationReason={ questionOneText }
+					closeDialog={ closeDialog }
+					onClickDowngrade={ downgradeClick }
+					onClickFreeMonthOffer={ freeMonthOfferClick }
+					onDeclineUpsell={ isLastStep ? onSubmit : clickNext }
+					plans={ plans }
+					purchase={ purchase }
 				/>
 			);
 		}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
@@ -151,17 +151,6 @@ function SurveyContent( {
 	if ( surveyStep === UPSELL_STEP ) {
 		const isLastStep = surveyStep === allSteps?.[ allSteps.length - 1 ];
 
-		if ( upsell?.startsWith( 'education:' ) ) {
-			return (
-				<EducationContentStep
-					cancellationReason={ questionOneText }
-					onDecline={ isLastStep ? onSubmit : clickNext }
-					siteSlug={ siteSlug }
-					type={ upsell }
-				/>
-			);
-		}
-
 		const solutions = getSolutionsForReason( questionOneText ?? '' );
 		const useSolutionsCards =
 			config.isEnabled( 'cancel-flow/solutions-cards-upsell' ) && solutions && solutions.length > 0;
@@ -175,6 +164,17 @@ function SurveyContent( {
 					onClickDowngrade={ downgradeClick }
 					onDeclineUpsell={ isLastStep ? onSubmit : clickNext }
 					purchase={ purchase }
+				/>
+			);
+		}
+
+		if ( upsell?.startsWith( 'education:' ) ) {
+			return (
+				<EducationContentStep
+					cancellationReason={ questionOneText }
+					onDecline={ isLastStep ? onSubmit : clickNext }
+					siteSlug={ siteSlug }
+					type={ upsell }
 				/>
 			);
 		}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -68,11 +68,11 @@ function isAnnualOrLongerPlan( purchase: Purchase ): boolean {
 	);
 }
 
-const SUPPORT_GUIDES_URL = localizeUrl( 'https://wordpress.com/support/' );
-const SITE_SPEED_URL = localizeUrl( 'https://wordpress.com/support/site-speed/' );
-const SITE_MIGRATION_URL = localizeUrl( 'https://wordpress.com/support/site-migration/' );
-const DOMAIN_GUIDE_URL = localizeUrl( 'https://wordpress.com/support/domains/' );
-const DOMAINS_EXPLORE_URL = localizeUrl( 'https://wordpress.com/domains/' );
+const SUPPORT_GUIDES_URL = localizeUrl( wpcomLink( '/support/' ) );
+const SITE_SPEED_URL = localizeUrl( wpcomLink( '/support/site-speed/' ) );
+const SITE_MIGRATION_URL = localizeUrl( wpcomLink( '/support/site-migration/' ) );
+const DOMAIN_GUIDE_URL = localizeUrl( wpcomLink( '/support/domains/' ) );
+const DOMAINS_EXPLORE_URL = localizeUrl( wpcomLink( '/domains/' ) );
 
 function getCardHref(
 	cardId: string,

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -33,7 +33,8 @@ const DOMAINS_EXPLORE_URL = localizeUrl( 'https://wordpress.com/domains/' );
 function getCardHref(
 	cardId: string,
 	changePlanUrl: string,
-	renewNowUrl: string
+	renewNowUrl: string,
+	subscriptionsUrl?: string
 ): string | undefined {
 	if ( cardId === 'change-plan' || cardId === 'upgrade-for-full-access' ) {
 		return changePlanUrl;
@@ -62,6 +63,9 @@ function getCardHref(
 	if ( cardId === 'explore-domain-options' ) {
 		return DOMAINS_EXPLORE_URL;
 	}
+	if ( cardId === 'move-subscription' && subscriptionsUrl ) {
+		return subscriptionsUrl;
+	}
 	return undefined;
 }
 
@@ -82,6 +86,7 @@ function getCardOnClick(
 		'use-migration-tools',
 		'use-domain-guide',
 		'explore-domain-options',
+		'move-subscription',
 	];
 	if ( navCardIds.includes( cardId ) ) {
 		return ( e: React.MouseEvent ) => {
@@ -125,6 +130,8 @@ function getCardTitle( cardId: string ): string {
 			return __( 'Use our domain guide' );
 		case 'explore-domain-options':
 			return __( 'Explore more domain options' );
+		case 'move-subscription':
+			return __( 'Move your subscription' );
 		default:
 			return '';
 	}
@@ -163,6 +170,9 @@ export default function SolutionsCardsUpsellStep( {
 	const changePlanUrl = wpcomLink( `/plans/${ purchase.site_slug }` );
 	const renewNowUrl = wpcomLink(
 		`/checkout/${ purchase.site_slug }/${ purchase.product_slug }?coupon=${ RENEW_COUPON }`
+	);
+	const subscriptionsUrl = wpcomLink(
+		`/purchases/subscriptions/${ purchase.site_slug }/${ purchase.ID }`
 	);
 
 	const handleCardAction = ( solutionId: string ) => {
@@ -208,6 +218,9 @@ export default function SolutionsCardsUpsellStep( {
 			case 'explore-domain-options':
 				window.open( DOMAINS_EXPLORE_URL, '_blank' );
 				break;
+			case 'move-subscription':
+				window.location.href = subscriptionsUrl;
+				break;
 			case 'ask-ai-assistant':
 				// No CTA yet – card is label-only
 				break;
@@ -235,8 +248,9 @@ export default function SolutionsCardsUpsellStep( {
 							card.id === 'use-migration-tools' ||
 							card.id === 'use-domain-guide' ||
 							card.id === 'explore-domain-options' ||
+							card.id === 'move-subscription' ||
 							( card.id === 'switch-to-monthly' && onClickDowngrade ) );
-					const href = getCardHref( card.id, changePlanUrl, renewNowUrl );
+					const href = getCardHref( card.id, changePlanUrl, renewNowUrl, subscriptionsUrl );
 					const onClick = getCardOnClick( card.id, hasAction, handleCardAction );
 					const title = getCardTitle( card.id );
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -1,4 +1,5 @@
 import { SubscriptionBillPeriod } from '@automattic/api-core';
+import { localizeUrl } from '@automattic/i18n-utils';
 import {
 	Button,
 	__experimentalHeading as Heading,
@@ -23,12 +24,16 @@ function isAnnualOrLongerPlan( purchase: Purchase ): boolean {
 	);
 }
 
+const SUPPORT_GUIDES_URL = localizeUrl( 'https://wordpress.com/support/' );
+const SITE_SPEED_URL = localizeUrl( 'https://wordpress.com/support/site-speed/' );
+const SITE_MIGRATION_URL = localizeUrl( 'https://wordpress.com/support/site-migration/' );
+
 function getCardHref(
 	cardId: string,
 	changePlanUrl: string,
 	renewNowUrl: string
 ): string | undefined {
-	if ( cardId === 'change-plan' ) {
+	if ( cardId === 'change-plan' || cardId === 'upgrade-for-full-access' ) {
 		return changePlanUrl;
 	}
 	if ( cardId === 'renew-now-pay-less' ) {
@@ -36,6 +41,18 @@ function getCardHref(
 	}
 	if ( cardId === 'built-by' ) {
 		return BUILT_BY_URL;
+	}
+	if ( cardId === 'get-theme-addon' || cardId === 'get-css-addon' ) {
+		return changePlanUrl;
+	}
+	if ( cardId === 'find-guides' ) {
+		return SUPPORT_GUIDES_URL;
+	}
+	if ( cardId === 'make-site-faster' ) {
+		return SITE_SPEED_URL;
+	}
+	if ( cardId === 'use-migration-tools' ) {
+		return SITE_MIGRATION_URL;
 	}
 	return undefined;
 }
@@ -45,7 +62,18 @@ function getCardOnClick(
 	hasAction: boolean,
 	handleCardAction: ( id: string ) => void
 ): ( ( e: React.MouseEvent ) => void ) | ( () => void ) | undefined {
-	if ( cardId === 'built-by' || cardId === 'change-plan' || cardId === 'renew-now-pay-less' ) {
+	const navCardIds = [
+		'built-by',
+		'change-plan',
+		'renew-now-pay-less',
+		'upgrade-for-full-access',
+		'get-theme-addon',
+		'get-css-addon',
+		'find-guides',
+		'make-site-faster',
+		'use-migration-tools',
+	];
+	if ( navCardIds.includes( cardId ) ) {
 		return ( e: React.MouseEvent ) => {
 			e.preventDefault();
 			handleCardAction( cardId );
@@ -71,6 +99,18 @@ function getCardTitle( cardId: string ): string {
 			return __( 'Let us build for you' );
 		case 'ask-ai-assistant':
 			return __( 'Ask our AI assistant' );
+		case 'upgrade-for-full-access':
+			return __( 'Upgrade for full access' );
+		case 'get-theme-addon':
+			return __( 'Get our theme add-on' );
+		case 'get-css-addon':
+			return __( 'Get our CSS add-on' );
+		case 'find-guides':
+			return __( 'Find easy step-by-step guides' );
+		case 'make-site-faster':
+			return __( 'Make your site faster' );
+		case 'use-migration-tools':
+			return __( 'Use our migration tools' );
 		default:
 			return '';
 	}
@@ -114,6 +154,7 @@ export default function SolutionsCardsUpsellStep( {
 	const handleCardAction = ( solutionId: string ) => {
 		switch ( solutionId ) {
 			case 'change-plan':
+			case 'upgrade-for-full-access':
 				window.location.href = changePlanUrl;
 				break;
 			case 'renew-now-pay-less':
@@ -134,6 +175,19 @@ export default function SolutionsCardsUpsellStep( {
 			case 'built-by':
 				window.location.replace( BUILT_BY_URL );
 				break;
+			case 'get-theme-addon':
+			case 'get-css-addon':
+				window.location.href = changePlanUrl;
+				break;
+			case 'find-guides':
+				window.open( SUPPORT_GUIDES_URL, '_blank' );
+				break;
+			case 'make-site-faster':
+				window.open( SITE_SPEED_URL, '_blank' );
+				break;
+			case 'use-migration-tools':
+				window.open( SITE_MIGRATION_URL, '_blank' );
+				break;
 			case 'ask-ai-assistant':
 				// No CTA yet – card is label-only
 				break;
@@ -153,6 +207,12 @@ export default function SolutionsCardsUpsellStep( {
 							card.id === 'built-by' ||
 							card.id === 'change-plan' ||
 							card.id === 'renew-now-pay-less' ||
+							card.id === 'upgrade-for-full-access' ||
+							card.id === 'get-theme-addon' ||
+							card.id === 'get-css-addon' ||
+							card.id === 'find-guides' ||
+							card.id === 'make-site-faster' ||
+							card.id === 'use-migration-tools' ||
 							( card.id === 'switch-to-monthly' && onClickDowngrade ) );
 					const href = getCardHref( card.id, changePlanUrl, renewNowUrl );
 					const onClick = getCardOnClick( card.id, hasAction, handleCardAction );

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -29,7 +29,7 @@ import { useHelpCenter } from '../../../../../app/help-center';
 import DashboardSummaryButton from '../../../../../components/summary-button';
 import { wpcomLink } from '../../../../../utils/link';
 import { getSolutionsForReason } from '../../get-solutions-for-reason';
-import type { PlanProduct, Purchase } from '@automattic/api-core';
+import type { Purchase } from '@automattic/api-core';
 
 const BUILT_BY_URL = wpcomLink( '/website-design-service/?ref=wpcom-cancel-flow' );
 const RENEW_COUPON = 'biz25';
@@ -226,7 +226,6 @@ type SolutionsCardsUpsellStepProps = {
 	onClickDowngrade?: ( upsell: string ) => void;
 	onDeclineUpsell?: () => void;
 	purchase: Purchase;
-	plans: PlanProduct[];
 };
 
 export default function SolutionsCardsUpsellStep( {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -337,7 +337,11 @@ export default function SolutionsCardsUpsellStep( {
 	return (
 		<VStack spacing={ 6 }>
 			<SummaryButtonList
-				title={ __( 'Before canceling, you can consider these options:' ) }
+				title={
+					filteredSolutions.length === 1
+						? __( "Before you cancel, here's an idea:" )
+						: __( 'Before canceling, you can consider these options:' )
+				}
 				density="medium-low"
 			>
 				{ filteredSolutions.map( ( card ) => {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -234,7 +234,7 @@ export default function SolutionsCardsUpsellStep( {
 	purchase,
 }: SolutionsCardsUpsellStepProps ) {
 	const solutions = getSolutionsForReason( cancellationReason );
-	const { setSubject, setShowHelpCenter } = useHelpCenter();
+	const { setSubject, setShowHelpCenter, setOpenOdieWithContext } = useHelpCenter();
 
 	const showSwitchToMonthly = isAnnualOrLongerPlan( purchase );
 	const filteredSolutions = solutions?.filter(
@@ -299,9 +299,18 @@ export default function SolutionsCardsUpsellStep( {
 			case 'move-subscription':
 				window.location.href = subscriptionsUrl;
 				break;
-			case 'ask-ai-assistant':
-				// No CTA yet – card is label-only
+			case 'ask-ai-assistant': {
+				const initialMessage =
+					"User is contacting from pre-cancellation form. Cancellation reason they've given: " +
+					cancellationReason;
+				setOpenOdieWithContext( {
+					initialMessage,
+					section: 'pre-cancellation-upsell',
+					siteId: purchase.blog_id,
+				} );
+				closeDialog?.();
 				break;
+			}
 			default:
 				break;
 		}
@@ -315,21 +324,21 @@ export default function SolutionsCardsUpsellStep( {
 			>
 				{ filteredSolutions.map( ( card ) => {
 					const hasAction = Boolean(
-						card.id !== 'ask-ai-assistant' &&
-							( card.id === 'speak-with-support' ||
-								card.id === 'built-by' ||
-								card.id === 'change-plan' ||
-								card.id === 'renew-now-pay-less' ||
-								card.id === 'upgrade-for-full-access' ||
-								card.id === 'get-theme-addon' ||
-								card.id === 'get-css-addon' ||
-								card.id === 'find-guides' ||
-								card.id === 'make-site-faster' ||
-								card.id === 'use-migration-tools' ||
-								card.id === 'use-domain-guide' ||
-								card.id === 'explore-domain-options' ||
-								card.id === 'move-subscription' ||
-								( card.id === 'switch-to-monthly' && onClickDowngrade ) )
+						card.id === 'speak-with-support' ||
+							card.id === 'ask-ai-assistant' ||
+							card.id === 'built-by' ||
+							card.id === 'change-plan' ||
+							card.id === 'renew-now-pay-less' ||
+							card.id === 'upgrade-for-full-access' ||
+							card.id === 'get-theme-addon' ||
+							card.id === 'get-css-addon' ||
+							card.id === 'find-guides' ||
+							card.id === 'make-site-faster' ||
+							card.id === 'use-migration-tools' ||
+							card.id === 'use-domain-guide' ||
+							card.id === 'explore-domain-options' ||
+							card.id === 'move-subscription' ||
+							( card.id === 'switch-to-monthly' && onClickDowngrade )
 					);
 					const href = getCardHref(
 						card.id,

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -234,7 +234,7 @@ export default function SolutionsCardsUpsellStep( {
 	purchase,
 }: SolutionsCardsUpsellStepProps ) {
 	const solutions = getSolutionsForReason( cancellationReason );
-	const { setSubject, setShowHelpCenter, setOpenOdieWithContext } = useHelpCenter();
+	const { setNewMessagingChat, setOpenOdieWithContext } = useHelpCenter();
 
 	const showSwitchToMonthly = isAnnualOrLongerPlan( purchase );
 	const filteredSolutions = solutions?.filter(
@@ -269,8 +269,10 @@ export default function SolutionsCardsUpsellStep( {
 				const initialMessage =
 					"User is contacting us from pre-cancellation form. Cancellation reason they've given: " +
 					cancellationReason;
-				setSubject( initialMessage );
-				setShowHelpCenter( true );
+				setNewMessagingChat( {
+					initialMessage,
+					section: 'pre-cancellation-upsell',
+				} );
 				closeDialog?.();
 				break;
 			}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -15,7 +15,6 @@ import {
 	reusableBlock,
 	search,
 	shipping,
-	shuffle,
 	trendingUp,
 	upload,
 } from '@wordpress/icons';
@@ -47,7 +46,6 @@ const CARD_ICONS: Record< string, IconType > = {
 	'use-migration-tools': shipping,
 	'use-domain-guide': globe,
 	'explore-domain-options': search,
-	'move-subscription': shuffle,
 };
 
 function getDecorationForCard( cardId: string ) {
@@ -105,9 +103,6 @@ function getCardHref(
 	if ( cardId === 'explore-domain-options' ) {
 		return dashboardLink( `/sites/${ siteSlug }/domains` );
 	}
-	if ( cardId === 'move-subscription' && subscriptionsUrl ) {
-		return subscriptionsUrl;
-	}
 	return undefined;
 }
 
@@ -128,7 +123,6 @@ function getCardOnClick(
 		'use-migration-tools',
 		'use-domain-guide',
 		'explore-domain-options',
-		'move-subscription',
 	];
 	if ( navCardIds.includes( cardId ) ) {
 		return ( e: React.MouseEvent ) => {
@@ -172,8 +166,6 @@ function getCardTitle( cardId: string ): string {
 			return __( 'Use our domain guide' );
 		case 'explore-domain-options':
 			return __( 'Explore more domain options' );
-		case 'move-subscription':
-			return __( 'Move your subscription' );
 		default:
 			return '';
 	}
@@ -210,8 +202,6 @@ function getCardDescription( cardId: string ): string {
 			return __( 'Follow our simple guide to get connected quickly.' );
 		case 'explore-domain-options':
 			return __( "Our search tool finds great alternatives you'll love." );
-		case 'move-subscription':
-			return __( 'Transfer your subscription to another site you own.' );
 		default:
 			return '';
 	}
@@ -327,9 +317,6 @@ export default function SolutionsCardsUpsellStep( {
 			case 'explore-domain-options':
 				window.location.href = dashboardLink( `/sites/${ purchase.site_slug }/domains` );
 				break;
-			case 'move-subscription':
-				window.location.href = subscriptionsUrl;
-				break;
 			case 'ask-ai-assistant': {
 				const initialMessage =
 					"User is contacting from pre-cancellation form. Cancellation reason they've given: " +
@@ -368,8 +355,7 @@ export default function SolutionsCardsUpsellStep( {
 							card.id === 'make-site-faster' ||
 							card.id === 'use-migration-tools' ||
 							card.id === 'use-domain-guide' ||
-							card.id === 'explore-domain-options' ||
-							card.id === 'move-subscription'
+							card.id === 'explore-domain-options'
 					);
 					const href = getCardHref(
 						card.id,

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -158,7 +158,7 @@ function getCardTitle( cardId: string ): string {
 		case 'upgrade-for-full-access':
 			return __( 'Upgrade for full access' );
 		case 'get-theme-addon':
-			return __( 'Get our theme add-on' );
+			return __( 'Change your plan' );
 		case 'get-css-addon':
 			return __( 'Get our CSS add-on' );
 		case 'find-guides':
@@ -196,7 +196,7 @@ function getCardDescription( cardId: string ): string {
 		case 'upgrade-for-full-access':
 			return __( 'Get the business plan to access all available plugins and themes.' );
 		case 'get-theme-addon':
-			return __( 'Unlock premium themes with a simple add-on.' );
+			return __( 'Unlock premium themes on another plan.' );
 		case 'get-css-addon':
 			return __( 'Customize every design detail with a simple add-on.' );
 		case 'find-guides':

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -308,7 +308,7 @@ export default function SolutionsCardsUpsellStep( {
 
 	return (
 		<VStack spacing={ 6 }>
-			<SummaryButtonList title={ __( 'Have you tried any of these options?' ) } density="low">
+			<SummaryButtonList title={ __( 'Have you tried any of these options?' ) } density="medium">
 				{ filteredSolutions.map( ( card ) => {
 					const hasAction = Boolean(
 						card.id !== 'ask-ai-assistant' &&
@@ -347,7 +347,6 @@ export default function SolutionsCardsUpsellStep( {
 							href={ href }
 							onClick={ onClick }
 							showArrow={ hasAction }
-							density="low"
 						/>
 					);
 				} ) }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -5,7 +5,6 @@ import { __ } from '@wordpress/i18n';
 import {
 	brush,
 	calendar,
-	code,
 	comment,
 	commentContent,
 	globe,
@@ -40,7 +39,6 @@ const CARD_ICONS: Record< string, IconType > = {
 	'ask-ai-assistant': commentContent,
 	'upgrade-for-full-access': upload,
 	'get-theme-addon': brush,
-	'get-css-addon': code,
 	'find-guides': postList,
 	'make-site-faster': trendingUp,
 	'use-migration-tools': shipping,
@@ -85,7 +83,7 @@ function getCardHref(
 	if ( cardId === 'built-by' ) {
 		return BUILT_BY_URL;
 	}
-	if ( cardId === 'get-theme-addon' || cardId === 'get-css-addon' ) {
+	if ( cardId === 'get-theme-addon' ) {
 		return changePlanUrl;
 	}
 	if ( cardId === 'find-guides' ) {
@@ -117,7 +115,6 @@ function getCardOnClick(
 		'renew-now-pay-less',
 		'upgrade-for-full-access',
 		'get-theme-addon',
-		'get-css-addon',
 		'find-guides',
 		'make-site-faster',
 		'use-migration-tools',
@@ -154,8 +151,6 @@ function getCardTitle( cardId: string ): string {
 			return __( 'Pick another paid plan for access to more features' );
 		case 'get-theme-addon':
 			return __( 'Change your plan' );
-		case 'get-css-addon':
-			return __( 'Get our CSS add-on' );
 		case 'find-guides':
 			return __( 'Find easy step-by-step guides' );
 		case 'make-site-faster':
@@ -190,8 +185,6 @@ function getCardDescription( cardId: string ): string {
 			return __( 'Get the business plan to access all available plugins and themes.' );
 		case 'get-theme-addon':
 			return __( 'Unlock premium themes on another plan.' );
-		case 'get-css-addon':
-			return __( 'Customize every design detail with a simple add-on.' );
 		case 'find-guides':
 			return __( 'Browse our guides and get back on track quickly.' );
 		case 'make-site-faster':
@@ -299,7 +292,6 @@ export default function SolutionsCardsUpsellStep( {
 				window.location.replace( BUILT_BY_URL );
 				break;
 			case 'get-theme-addon':
-			case 'get-css-addon':
 				window.location.href = changePlanUrl;
 				break;
 			case 'find-guides':
@@ -354,7 +346,6 @@ export default function SolutionsCardsUpsellStep( {
 							card.id === 'switch-to-monthly' ||
 							card.id === 'upgrade-for-full-access' ||
 							card.id === 'get-theme-addon' ||
-							card.id === 'get-css-addon' ||
 							card.id === 'find-guides' ||
 							card.id === 'make-site-faster' ||
 							card.id === 'use-migration-tools' ||

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -311,7 +311,7 @@ export default function SolutionsCardsUpsellStep( {
 		<VStack spacing={ 6 }>
 			<SummaryButtonList
 				title={ __( 'Before canceling, you can consider these options:' ) }
-				density="medium"
+				density="medium-low"
 			>
 				{ filteredSolutions.map( ( card ) => {
 					const hasAction = Boolean(

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -31,7 +31,7 @@ import { wpcomLink } from '../../../../../utils/link';
 import { getSolutionsForReason } from '../../get-solutions-for-reason';
 import type { PlanProduct, Purchase } from '@automattic/api-core';
 
-const BUILT_BY_URL = 'https://wordpress.com/website-design-service/?ref=wpcom-cancel-flow';
+const BUILT_BY_URL = wpcomLink( '/website-design-service/?ref=wpcom-cancel-flow' );
 const RENEW_COUPON = 'biz25';
 
 const CARD_ICONS: Record< string, unknown > = {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -21,6 +21,7 @@ import {
 } from '@wordpress/icons';
 import * as React from 'react';
 import { useHelpCenter } from '../../../../../app/help-center';
+import { ButtonStack } from '../../../../../components/button-stack';
 import DashboardSummaryButton from '../../../../../components/summary-button';
 import { SummaryButtonList } from '../../../../../components/summary-button-list';
 import { dashboardLink, wpcomLink } from '../../../../../utils/link';
@@ -351,9 +352,11 @@ export default function SolutionsCardsUpsellStep( {
 					);
 				} ) }
 			</SummaryButtonList>
-			<Button variant="secondary" onClick={ onDeclineUpsell } disabled={ cancellationInProgress }>
-				{ __( 'No thanks, cancel my plan' ) }
-			</Button>
+			<ButtonStack justify="flex-start">
+				<Button variant="secondary" onClick={ onDeclineUpsell } disabled={ cancellationInProgress }>
+					{ __( 'No thanks, cancel my plan' ) }
+				</Button>
+			</ButtonStack>
 		</VStack>
 	);
 }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -1,0 +1,177 @@
+import { SubscriptionBillPeriod } from '@automattic/api-core';
+import {
+	Button,
+	__experimentalHeading as Heading,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import * as React from 'react';
+import { useHelpCenter } from '../../../../../app/help-center';
+import DashboardSummaryButton from '../../../../../components/summary-button';
+import { wpcomLink } from '../../../../../utils/link';
+import { getSolutionsForReason } from '../../get-solutions-for-reason';
+import type { PlanProduct, Purchase } from '@automattic/api-core';
+
+const BUILT_BY_URL = 'https://wordpress.com/website-design-service/?ref=wpcom-cancel-flow';
+const RENEW_COUPON = 'biz25';
+
+function isAnnualOrLongerPlan( purchase: Purchase ): boolean {
+	return (
+		purchase.bill_period_days === SubscriptionBillPeriod.PLAN_ANNUAL_PERIOD ||
+		purchase.bill_period_days === SubscriptionBillPeriod.PLAN_BIENNIAL_PERIOD ||
+		purchase.bill_period_days === SubscriptionBillPeriod.PLAN_TRIENNIAL_PERIOD
+	);
+}
+
+function getCardHref(
+	cardId: string,
+	changePlanUrl: string,
+	renewNowUrl: string
+): string | undefined {
+	if ( cardId === 'change-plan' ) {
+		return changePlanUrl;
+	}
+	if ( cardId === 'renew-now-pay-less' ) {
+		return renewNowUrl;
+	}
+	if ( cardId === 'built-by' ) {
+		return BUILT_BY_URL;
+	}
+	return undefined;
+}
+
+function getCardOnClick(
+	cardId: string,
+	hasAction: boolean,
+	handleCardAction: ( id: string ) => void
+): ( ( e: React.MouseEvent ) => void ) | ( () => void ) | undefined {
+	if ( cardId === 'built-by' || cardId === 'change-plan' || cardId === 'renew-now-pay-less' ) {
+		return ( e: React.MouseEvent ) => {
+			e.preventDefault();
+			handleCardAction( cardId );
+		};
+	}
+	if ( hasAction ) {
+		return () => handleCardAction( cardId );
+	}
+	return undefined;
+}
+
+function getCardTitle( cardId: string ): string {
+	switch ( cardId ) {
+		case 'change-plan':
+			return __( 'Change plan' );
+		case 'renew-now-pay-less':
+			return __( 'Renew now and pay less' );
+		case 'switch-to-monthly':
+			return __( 'Switch to monthly payments' );
+		case 'speak-with-support':
+			return __( 'Speak with our support team' );
+		case 'built-by':
+			return __( 'Let us build for you' );
+		case 'ask-ai-assistant':
+			return __( 'Ask our AI assistant' );
+		default:
+			return '';
+	}
+}
+
+type SolutionsCardsUpsellStepProps = {
+	cancellationReason?: string;
+	cancellationInProgress?: boolean;
+	closeDialog?: () => void;
+	onClickDowngrade?: ( upsell: string ) => void;
+	onDeclineUpsell?: () => void;
+	purchase: Purchase;
+	plans: PlanProduct[];
+};
+
+export default function SolutionsCardsUpsellStep( {
+	cancellationReason = '',
+	cancellationInProgress,
+	closeDialog,
+	onClickDowngrade,
+	onDeclineUpsell,
+	purchase,
+}: SolutionsCardsUpsellStepProps ) {
+	const solutions = getSolutionsForReason( cancellationReason );
+	const { setSubject, setShowHelpCenter } = useHelpCenter();
+
+	const showSwitchToMonthly = isAnnualOrLongerPlan( purchase );
+	const filteredSolutions = solutions?.filter(
+		( card ) => card.id !== 'switch-to-monthly' || showSwitchToMonthly
+	);
+
+	if ( ! filteredSolutions?.length ) {
+		return null;
+	}
+
+	const changePlanUrl = wpcomLink( `/plans/${ purchase.site_slug }` );
+	const renewNowUrl = wpcomLink(
+		`/checkout/${ purchase.site_slug }/${ purchase.product_slug }?coupon=${ RENEW_COUPON }`
+	);
+
+	const handleCardAction = ( solutionId: string ) => {
+		switch ( solutionId ) {
+			case 'change-plan':
+				window.location.href = changePlanUrl;
+				break;
+			case 'renew-now-pay-less':
+				window.location.href = renewNowUrl;
+				break;
+			case 'switch-to-monthly':
+				onClickDowngrade?.( 'downgrade-monthly' );
+				break;
+			case 'speak-with-support': {
+				const initialMessage =
+					"User is contacting us from pre-cancellation form. Cancellation reason they've given: " +
+					cancellationReason;
+				setSubject( initialMessage );
+				setShowHelpCenter( true );
+				closeDialog?.();
+				break;
+			}
+			case 'built-by':
+				window.location.replace( BUILT_BY_URL );
+				break;
+			case 'ask-ai-assistant':
+				// No CTA yet – card is label-only
+				break;
+			default:
+				break;
+		}
+	};
+
+	return (
+		<VStack spacing={ 6 }>
+			<Heading level={ 3 }>{ __( 'Have you tried any of these options?' ) }</Heading>
+			<VStack spacing={ 3 }>
+				{ filteredSolutions.map( ( card ) => {
+					const hasAction =
+						card.id !== 'ask-ai-assistant' &&
+						( card.id === 'speak-with-support' ||
+							card.id === 'built-by' ||
+							card.id === 'change-plan' ||
+							card.id === 'renew-now-pay-less' ||
+							( card.id === 'switch-to-monthly' && onClickDowngrade ) );
+					const href = getCardHref( card.id, changePlanUrl, renewNowUrl );
+					const onClick = getCardOnClick( card.id, hasAction, handleCardAction );
+					const title = getCardTitle( card.id );
+
+					return (
+						<DashboardSummaryButton
+							key={ card.id }
+							title={ title }
+							href={ href }
+							onClick={ onClick }
+							showArrow={ hasAction }
+						/>
+					);
+				} ) }
+			</VStack>
+			<Button variant="secondary" onClick={ onDeclineUpsell } disabled={ cancellationInProgress }>
+				{ __( 'No thanks, cancel my plan' ) }
+			</Button>
+		</VStack>
+	);
+}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -1,11 +1,6 @@
 import { SubscriptionBillPeriod } from '@automattic/api-core';
 import { localizeUrl } from '@automattic/i18n-utils';
-import {
-	Button,
-	Icon,
-	__experimentalHeading as Heading,
-	__experimentalVStack as VStack,
-} from '@wordpress/components';
+import { Button, Icon, __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import {
 	brush,
@@ -27,6 +22,7 @@ import {
 import * as React from 'react';
 import { useHelpCenter } from '../../../../../app/help-center';
 import DashboardSummaryButton from '../../../../../components/summary-button';
+import { SummaryButtonList } from '../../../../../components/summary-button-list';
 import { wpcomLink } from '../../../../../utils/link';
 import { getSolutionsForReason } from '../../get-solutions-for-reason';
 import type { Purchase } from '@automattic/api-core';
@@ -312,8 +308,7 @@ export default function SolutionsCardsUpsellStep( {
 
 	return (
 		<VStack spacing={ 6 }>
-			<Heading level={ 3 }>{ __( 'Have you tried any of these options?' ) }</Heading>
-			<VStack spacing={ 3 }>
+			<SummaryButtonList title={ __( 'Have you tried any of these options?' ) } density="low">
 				{ filteredSolutions.map( ( card ) => {
 					const hasAction = Boolean(
 						card.id !== 'ask-ai-assistant' &&
@@ -350,7 +345,7 @@ export default function SolutionsCardsUpsellStep( {
 						/>
 					);
 				} ) }
-			</VStack>
+			</SummaryButtonList>
 			<Button variant="secondary" onClick={ onDeclineUpsell } disabled={ cancellationInProgress }>
 				{ __( 'No thanks, cancel my plan' ) }
 			</Button>

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -234,22 +234,23 @@ export default function SolutionsCardsUpsellStep( {
 			<Heading level={ 3 }>{ __( 'Have you tried any of these options?' ) }</Heading>
 			<VStack spacing={ 3 }>
 				{ filteredSolutions.map( ( card ) => {
-					const hasAction =
+					const hasAction = Boolean(
 						card.id !== 'ask-ai-assistant' &&
-						( card.id === 'speak-with-support' ||
-							card.id === 'built-by' ||
-							card.id === 'change-plan' ||
-							card.id === 'renew-now-pay-less' ||
-							card.id === 'upgrade-for-full-access' ||
-							card.id === 'get-theme-addon' ||
-							card.id === 'get-css-addon' ||
-							card.id === 'find-guides' ||
-							card.id === 'make-site-faster' ||
-							card.id === 'use-migration-tools' ||
-							card.id === 'use-domain-guide' ||
-							card.id === 'explore-domain-options' ||
-							card.id === 'move-subscription' ||
-							( card.id === 'switch-to-monthly' && onClickDowngrade ) );
+							( card.id === 'speak-with-support' ||
+								card.id === 'built-by' ||
+								card.id === 'change-plan' ||
+								card.id === 'renew-now-pay-less' ||
+								card.id === 'upgrade-for-full-access' ||
+								card.id === 'get-theme-addon' ||
+								card.id === 'get-css-addon' ||
+								card.id === 'find-guides' ||
+								card.id === 'make-site-faster' ||
+								card.id === 'use-migration-tools' ||
+								card.id === 'use-domain-guide' ||
+								card.id === 'explore-domain-options' ||
+								card.id === 'move-subscription' ||
+								( card.id === 'switch-to-monthly' && onClickDowngrade ) )
+					);
 					const href = getCardHref( card.id, changePlanUrl, renewNowUrl, subscriptionsUrl );
 					const onClick = getCardOnClick( card.id, hasAction, handleCardAction );
 					const title = getCardTitle( card.id );
@@ -257,10 +258,12 @@ export default function SolutionsCardsUpsellStep( {
 					return (
 						<DashboardSummaryButton
 							key={ card.id }
+							className="cancel-purchase-form__solution-card"
 							title={ title }
 							href={ href }
 							onClick={ onClick }
 							showArrow={ hasAction }
+							density="medium"
 						/>
 					);
 				} ) }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -309,7 +309,10 @@ export default function SolutionsCardsUpsellStep( {
 
 	return (
 		<VStack spacing={ 6 }>
-			<SummaryButtonList title={ __( 'Have you tried any of these options?' ) } density="medium">
+			<SummaryButtonList
+				title={ __( 'Before canceling, you can consider these options:' ) }
+				density="medium"
+			>
 				{ filteredSolutions.map( ( card ) => {
 					const hasAction = Boolean(
 						card.id !== 'ask-ai-assistant' &&

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -2,10 +2,28 @@ import { SubscriptionBillPeriod } from '@automattic/api-core';
 import { localizeUrl } from '@automattic/i18n-utils';
 import {
 	Button,
+	Icon,
 	__experimentalHeading as Heading,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import {
+	brush,
+	calendar,
+	code,
+	comment,
+	commentContent,
+	globe,
+	people,
+	percent,
+	postList,
+	reusableBlock,
+	search,
+	shipping,
+	shuffle,
+	trendingUp,
+	upload,
+} from '@wordpress/icons';
 import * as React from 'react';
 import { useHelpCenter } from '../../../../../app/help-center';
 import DashboardSummaryButton from '../../../../../components/summary-button';
@@ -15,6 +33,32 @@ import type { PlanProduct, Purchase } from '@automattic/api-core';
 
 const BUILT_BY_URL = 'https://wordpress.com/website-design-service/?ref=wpcom-cancel-flow';
 const RENEW_COUPON = 'biz25';
+
+const CARD_ICONS: Record< string, unknown > = {
+	'change-plan': reusableBlock,
+	'switch-to-monthly': calendar,
+	'speak-with-support': comment,
+	'renew-now-pay-less': percent,
+	'built-by': people,
+	'ask-ai-assistant': commentContent,
+	'upgrade-for-full-access': upload,
+	'get-theme-addon': brush,
+	'get-css-addon': code,
+	'find-guides': postList,
+	'make-site-faster': trendingUp,
+	'use-migration-tools': shipping,
+	'use-domain-guide': globe,
+	'explore-domain-options': search,
+	'move-subscription': shuffle,
+};
+
+function getDecorationForCard( cardId: string ) {
+	const icon = CARD_ICONS[ cardId ];
+	if ( ! icon ) {
+		return undefined;
+	}
+	return <Icon icon={ icon } size={ 24 } />;
+}
 
 function isAnnualOrLongerPlan( purchase: Purchase ): boolean {
 	return (
@@ -299,6 +343,7 @@ export default function SolutionsCardsUpsellStep( {
 							className="cancel-purchase-form__solution-card"
 							title={ title }
 							description={ getCardDescription( card.id ) }
+							decoration={ getDecorationForCard( card.id ) }
 							href={ href }
 							onClick={ onClick }
 							showArrow={ hasAction }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -26,7 +26,8 @@ import DashboardSummaryButton from '../../../../../components/summary-button';
 import { SummaryButtonList } from '../../../../../components/summary-button-list';
 import { dashboardLink, wpcomLink } from '../../../../../utils/link';
 import { getSolutionsForReason } from '../../get-solutions-for-reason';
-import type { Purchase } from '@automattic/api-core';
+import UpsellStep from './upsell-step';
+import type { PlanProduct, Purchase } from '@automattic/api-core';
 
 const BUILT_BY_URL = wpcomLink( '/website-design-service/?ref=wpcom-cancel-flow' );
 const RENEW_COUPON = 'biz25';
@@ -219,20 +220,29 @@ function getCardDescription( cardId: string ): string {
 type SolutionsCardsUpsellStepProps = {
 	cancellationReason?: string;
 	cancellationInProgress?: boolean;
+	cancelBundledDomain?: boolean;
 	closeDialog?: () => void;
+	downgradePlan?: PlanProduct | null;
+	includedDomainPurchase?: Purchase;
 	onClickDowngrade?: ( upsell: string ) => void;
 	onDeclineUpsell?: () => void;
 	purchase: Purchase;
+	refundAmount?: number;
 };
 
 export default function SolutionsCardsUpsellStep( {
 	cancellationReason = '',
 	cancellationInProgress,
+	cancelBundledDomain,
 	closeDialog,
+	downgradePlan,
+	includedDomainPurchase,
 	onClickDowngrade,
 	onDeclineUpsell,
 	purchase,
+	refundAmount,
 }: SolutionsCardsUpsellStepProps ) {
+	const [ showDowngradeStep, setShowDowngradeStep ] = React.useState( false );
 	const solutions = getSolutionsForReason( cancellationReason );
 	const { setNewMessagingChat, setOpenOdieWithContext } = useHelpCenter();
 
@@ -243,6 +253,25 @@ export default function SolutionsCardsUpsellStep( {
 
 	if ( ! filteredSolutions?.length ) {
 		return null;
+	}
+
+	if ( showDowngradeStep ) {
+		return (
+			<UpsellStep
+				upsell="downgrade-monthly"
+				cancellationReason={ cancellationReason }
+				cancellationInProgress={ cancellationInProgress }
+				cancelBundledDomain={ cancelBundledDomain }
+				currencyCode={ purchase.currency_code }
+				downgradePlan={ downgradePlan }
+				includedDomainPurchase={ includedDomainPurchase }
+				onClickDowngrade={ onClickDowngrade }
+				onDeclineUpsell={ () => setShowDowngradeStep( false ) }
+				plans={ [] }
+				purchase={ purchase }
+				refundAmount={ refundAmount }
+			/>
+		);
 	}
 
 	const changePlanUrl = wpcomLink( `/plans/${ purchase.site_slug }` );
@@ -263,7 +292,7 @@ export default function SolutionsCardsUpsellStep( {
 				window.location.href = renewNowUrl;
 				break;
 			case 'switch-to-monthly':
-				onClickDowngrade?.( 'downgrade-monthly' );
+				setShowDowngradeStep( true );
 				break;
 			case 'speak-with-support': {
 				const initialMessage =
@@ -331,6 +360,7 @@ export default function SolutionsCardsUpsellStep( {
 							card.id === 'built-by' ||
 							card.id === 'change-plan' ||
 							card.id === 'renew-now-pay-less' ||
+							card.id === 'switch-to-monthly' ||
 							card.id === 'upgrade-for-full-access' ||
 							card.id === 'get-theme-addon' ||
 							card.id === 'get-css-addon' ||
@@ -339,8 +369,7 @@ export default function SolutionsCardsUpsellStep( {
 							card.id === 'use-migration-tools' ||
 							card.id === 'use-domain-guide' ||
 							card.id === 'explore-domain-options' ||
-							card.id === 'move-subscription' ||
-							( card.id === 'switch-to-monthly' && onClickDowngrade )
+							card.id === 'move-subscription'
 					);
 					const href = getCardHref(
 						card.id,

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -23,7 +23,7 @@ import * as React from 'react';
 import { useHelpCenter } from '../../../../../app/help-center';
 import DashboardSummaryButton from '../../../../../components/summary-button';
 import { SummaryButtonList } from '../../../../../components/summary-button-list';
-import { wpcomLink } from '../../../../../utils/link';
+import { dashboardLink, wpcomLink } from '../../../../../utils/link';
 import { getSolutionsForReason } from '../../get-solutions-for-reason';
 import type { Purchase } from '@automattic/api-core';
 
@@ -68,13 +68,13 @@ const SUPPORT_GUIDES_URL = localizeUrl( wpcomLink( '/support/' ) );
 const SITE_SPEED_URL = localizeUrl( wpcomLink( '/support/site-speed/' ) );
 const SITE_MIGRATION_URL = localizeUrl( wpcomLink( '/support/site-migration/' ) );
 const DOMAIN_GUIDE_URL = localizeUrl( wpcomLink( '/support/domains/' ) );
-const DOMAINS_EXPLORE_URL = localizeUrl( wpcomLink( '/domains/' ) );
 
 function getCardHref(
 	cardId: string,
 	changePlanUrl: string,
 	renewNowUrl: string,
-	subscriptionsUrl?: string
+	subscriptionsUrl: string | undefined,
+	siteSlug: string
 ): string | undefined {
 	if ( cardId === 'change-plan' || cardId === 'upgrade-for-full-access' ) {
 		return changePlanUrl;
@@ -101,7 +101,7 @@ function getCardHref(
 		return DOMAIN_GUIDE_URL;
 	}
 	if ( cardId === 'explore-domain-options' ) {
-		return DOMAINS_EXPLORE_URL;
+		return dashboardLink( `/sites/${ siteSlug }/domains` );
 	}
 	if ( cardId === 'move-subscription' && subscriptionsUrl ) {
 		return subscriptionsUrl;
@@ -293,7 +293,7 @@ export default function SolutionsCardsUpsellStep( {
 				window.open( DOMAIN_GUIDE_URL, '_blank' );
 				break;
 			case 'explore-domain-options':
-				window.open( DOMAINS_EXPLORE_URL, '_blank' );
+				window.location.href = dashboardLink( `/sites/${ purchase.site_slug }/domains` );
 				break;
 			case 'move-subscription':
 				window.location.href = subscriptionsUrl;
@@ -327,7 +327,13 @@ export default function SolutionsCardsUpsellStep( {
 								card.id === 'move-subscription' ||
 								( card.id === 'switch-to-monthly' && onClickDowngrade ) )
 					);
-					const href = getCardHref( card.id, changePlanUrl, renewNowUrl, subscriptionsUrl );
+					const href = getCardHref(
+						card.id,
+						changePlanUrl,
+						renewNowUrl,
+						subscriptionsUrl,
+						purchase.site_slug
+					);
 					const onClick = getCardOnClick( card.id, hasAction, handleCardAction );
 					const title = getCardTitle( card.id );
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -27,6 +27,8 @@ function isAnnualOrLongerPlan( purchase: Purchase ): boolean {
 const SUPPORT_GUIDES_URL = localizeUrl( 'https://wordpress.com/support/' );
 const SITE_SPEED_URL = localizeUrl( 'https://wordpress.com/support/site-speed/' );
 const SITE_MIGRATION_URL = localizeUrl( 'https://wordpress.com/support/site-migration/' );
+const DOMAIN_GUIDE_URL = localizeUrl( 'https://wordpress.com/support/domains/' );
+const DOMAINS_EXPLORE_URL = localizeUrl( 'https://wordpress.com/domains/' );
 
 function getCardHref(
 	cardId: string,
@@ -54,6 +56,12 @@ function getCardHref(
 	if ( cardId === 'use-migration-tools' ) {
 		return SITE_MIGRATION_URL;
 	}
+	if ( cardId === 'use-domain-guide' ) {
+		return DOMAIN_GUIDE_URL;
+	}
+	if ( cardId === 'explore-domain-options' ) {
+		return DOMAINS_EXPLORE_URL;
+	}
 	return undefined;
 }
 
@@ -72,6 +80,8 @@ function getCardOnClick(
 		'find-guides',
 		'make-site-faster',
 		'use-migration-tools',
+		'use-domain-guide',
+		'explore-domain-options',
 	];
 	if ( navCardIds.includes( cardId ) ) {
 		return ( e: React.MouseEvent ) => {
@@ -111,6 +121,10 @@ function getCardTitle( cardId: string ): string {
 			return __( 'Make your site faster' );
 		case 'use-migration-tools':
 			return __( 'Use our migration tools' );
+		case 'use-domain-guide':
+			return __( 'Use our domain guide' );
+		case 'explore-domain-options':
+			return __( 'Explore more domain options' );
 		default:
 			return '';
 	}
@@ -188,6 +202,12 @@ export default function SolutionsCardsUpsellStep( {
 			case 'use-migration-tools':
 				window.open( SITE_MIGRATION_URL, '_blank' );
 				break;
+			case 'use-domain-guide':
+				window.open( DOMAIN_GUIDE_URL, '_blank' );
+				break;
+			case 'explore-domain-options':
+				window.open( DOMAINS_EXPLORE_URL, '_blank' );
+				break;
 			case 'ask-ai-assistant':
 				// No CTA yet – card is label-only
 				break;
@@ -213,6 +233,8 @@ export default function SolutionsCardsUpsellStep( {
 							card.id === 'find-guides' ||
 							card.id === 'make-site-faster' ||
 							card.id === 'use-migration-tools' ||
+							card.id === 'use-domain-guide' ||
+							card.id === 'explore-domain-options' ||
 							( card.id === 'switch-to-monthly' && onClickDowngrade ) );
 					const href = getCardHref( card.id, changePlanUrl, renewNowUrl );
 					const onClick = getCardOnClick( card.id, hasAction, handleCardAction );

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -157,7 +157,7 @@ function getCardTitle( cardId: string ): string {
 		case 'ask-ai-assistant':
 			return __( 'Ask our AI assistant' );
 		case 'upgrade-for-full-access':
-			return __( 'Upgrade for full access' );
+			return __( 'Pick another paid plan for access to more features' );
 		case 'get-theme-addon':
 			return __( 'Change your plan' );
 		case 'get-css-addon':

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -1,6 +1,6 @@
 import { SubscriptionBillPeriod } from '@automattic/api-core';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { Button, Icon, __experimentalVStack as VStack } from '@wordpress/components';
+import { Button, Icon, __experimentalVStack as VStack, type IconType } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import {
 	brush,
@@ -30,7 +30,7 @@ import type { Purchase } from '@automattic/api-core';
 const BUILT_BY_URL = wpcomLink( '/website-design-service/?ref=wpcom-cancel-flow' );
 const RENEW_COUPON = 'biz25';
 
-const CARD_ICONS: Record< string, unknown > = {
+const CARD_ICONS: Record< string, IconType > = {
 	'change-plan': reusableBlock,
 	'switch-to-monthly': calendar,
 	'speak-with-support': comment,

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -137,6 +137,44 @@ function getCardTitle( cardId: string ): string {
 	}
 }
 
+function getCardDescription( cardId: string ): string {
+	switch ( cardId ) {
+		case 'change-plan':
+			return __( 'Find a plan that better suits your needs.' );
+		case 'renew-now-pay-less':
+			/* translators: % is the discount amount (e.g. 25%) */
+			return __( 'Get an exclusive 25% discount automatically applied at checkout.' );
+		case 'switch-to-monthly':
+			return __( 'Keep things flexible with monthly billing.' );
+		case 'speak-with-support':
+			return __( "We're here to answer any of your questions." );
+		case 'built-by':
+			return __( 'Our team can build your site so you can focus on what matters.' );
+		case 'ask-ai-assistant':
+			return __( 'Use our AI assistant to quickly find solutions.' );
+		case 'upgrade-for-full-access':
+			return __( 'Get the business plan to access all available plugins and themes.' );
+		case 'get-theme-addon':
+			return __( 'Unlock premium themes with a simple add-on.' );
+		case 'get-css-addon':
+			return __( 'Customize every design detail with a simple add-on.' );
+		case 'find-guides':
+			return __( 'Browse our guides and get back on track quickly.' );
+		case 'make-site-faster':
+			return __( 'Run our free speed test and get personalized recommendations.' );
+		case 'use-migration-tools':
+			return __( 'Expert assistance or seamless importers for quick moves.' );
+		case 'use-domain-guide':
+			return __( 'Follow our simple guide to get connected quickly.' );
+		case 'explore-domain-options':
+			return __( "Our search tool finds great alternatives you'll love." );
+		case 'move-subscription':
+			return __( 'Transfer your subscription to another site you own.' );
+		default:
+			return '';
+	}
+}
+
 type SolutionsCardsUpsellStepProps = {
 	cancellationReason?: string;
 	cancellationInProgress?: boolean;
@@ -260,10 +298,11 @@ export default function SolutionsCardsUpsellStep( {
 							key={ card.id }
 							className="cancel-purchase-form__solution-card"
 							title={ title }
+							description={ getCardDescription( card.id ) }
 							href={ href }
 							onClick={ onClick }
 							showArrow={ hasAction }
-							density="medium"
+							density="low"
 						/>
 					);
 				} ) }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/upsell-step.tsx
@@ -1,16 +1,14 @@
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { formatCurrency, formatNumber } from '@automattic/number-formatters';
-import {
-	Button,
-	__experimentalHeading as Heading,
-	__experimentalVStack as VStack,
-} from '@wordpress/components';
+import { Button, __experimentalVStack as VStack } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import * as React from 'react';
 import { useAnalytics } from '../../../../../app/analytics';
 import { useHelpCenter } from '../../../../../app/help-center';
 import { ButtonStack } from '../../../../../components/button-stack';
+import { Card, CardBody } from '../../../../../components/card';
+import { SectionHeader } from '../../../../../components/section-header';
 import { redirectToDashboardLink, wpcomLink } from '../../../../../utils/link';
 import type { PlanProduct, Purchase } from '@automattic/api-core';
 
@@ -28,25 +26,27 @@ function Upsell( { ...props }: UpsellProps ) {
 	const declineButtonText = __( 'Cancel my current plan' );
 
 	return (
-		<VStack spacing={ 6 }>
-			<VStack>
-				<Heading>{ props.title }</Heading>
-				<div className="cancel-purchase-form__upsell-text">{ props.children }</div>
-			</VStack>
-			<ButtonStack justify="flex-start">
-				<Button
-					variant="primary"
-					href={ props.acceptButtonUrl }
-					onClick={ props.onAccept }
-					isBusy={ props.isBusy }
-				>
-					{ props.acceptButtonText }
-				</Button>
-				<Button variant="secondary" onClick={ props.onDecline } disabled={ props.isBusy }>
-					{ declineButtonText }
-				</Button>
-			</ButtonStack>
-		</VStack>
+		<Card>
+			<CardBody>
+				<VStack spacing={ 6 }>
+					<SectionHeader level={ 3 } title={ props.title } />
+					<div className="cancel-purchase-form__upsell-text">{ props.children }</div>
+					<ButtonStack justify="flex-start">
+						<Button
+							variant="primary"
+							href={ props.acceptButtonUrl }
+							onClick={ props.onAccept }
+							isBusy={ props.isBusy }
+						>
+							{ props.acceptButtonText }
+						</Button>
+						<Button variant="secondary" onClick={ props.onDecline } disabled={ props.isBusy }>
+							{ declineButtonText }
+						</Button>
+					</ButtonStack>
+				</VStack>
+			</CardBody>
+		</Card>
 	);
 }
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-solutions-for-reason.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-solutions-for-reason.ts
@@ -20,7 +20,6 @@ const SOLUTION_IDS = {
 	USE_MIGRATION_TOOLS: 'use-migration-tools',
 	USE_DOMAIN_GUIDE: 'use-domain-guide',
 	EXPLORE_DOMAIN_OPTIONS: 'explore-domain-options',
-	MOVE_SUBSCRIPTION: 'move-subscription',
 } as const;
 
 /** Too expensive: Expensive for the features offered */
@@ -153,10 +152,7 @@ const SOLUTIONS_WRONG_PLAN: SolutionCardConfig[] = [
 ];
 
 /** Wrong site */
-const SOLUTIONS_WRONG_SITE: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.MOVE_SUBSCRIPTION },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
-];
+const SOLUTIONS_WRONG_SITE: SolutionCardConfig[] = [ { id: SOLUTION_IDS.SPEAK_WITH_SUPPORT } ];
 
 /** Plan didn't match (noMatch) */
 const SOLUTIONS_NO_MATCH: SolutionCardConfig[] = [

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-solutions-for-reason.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-solutions-for-reason.ts
@@ -170,6 +170,7 @@ const SOLUTIONS_SLOW_OR_UNHELPFUL: SolutionCardConfig[] = [
 /** No human support */
 const SOLUTIONS_NO_HUMAN_SUPPORT: SolutionCardConfig[] = [
 	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT },
+	{ id: SOLUTION_IDS.FIND_GUIDES },
 	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-solutions-for-reason.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-solutions-for-reason.ts
@@ -20,6 +20,8 @@ const SOLUTION_IDS = {
 	FIND_GUIDES: 'find-guides',
 	MAKE_SITE_FASTER: 'make-site-faster',
 	USE_MIGRATION_TOOLS: 'use-migration-tools',
+	USE_DOMAIN_GUIDE: 'use-domain-guide',
+	EXPLORE_DOMAIN_OPTIONS: 'explore-domain-options',
 } as const;
 
 /** Too expensive: Expensive for the features offered */
@@ -123,6 +125,27 @@ const SOLUTIONS_DOWNTIME: SolutionCardConfig[] = [
 	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
 ];
 
+/** Trouble connecting or transferring (domain) */
+const SOLUTIONS_TROUBLE_CONNECTING_OR_TRANSFERRING: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.USE_DOMAIN_GUIDE, label: 'Use our domain guide' },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Confused about domains */
+const SOLUTIONS_CONFUSED_ABOUT_DOMAINS: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.USE_DOMAIN_GUIDE, label: 'Use our domain guide' },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Domain incorrect */
+const SOLUTIONS_DOMAIN_INCORRECT: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.EXPLORE_DOMAIN_OPTIONS, label: 'Explore more domain options' },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
 /**
  * Returns the ordered list of solution cards for the given cancellation sub-reason,
  * or null when this reason has no solutions step.
@@ -173,6 +196,14 @@ export function getSolutionsForReason( reason: string ): SolutionCardConfig[] | 
 			return [ ...SOLUTIONS_MIGRATION_PROBLEMS ];
 		case 'downtime':
 			return [ ...SOLUTIONS_DOWNTIME ];
+
+		// Domain-related
+		case 'troubleConnectingOrTransferring':
+			return [ ...SOLUTIONS_TROUBLE_CONNECTING_OR_TRANSFERRING ];
+		case 'confusedAboutDomains':
+			return [ ...SOLUTIONS_CONFUSED_ABOUT_DOMAINS ];
+		case 'domainIncorrect':
+			return [ ...SOLUTIONS_DOMAIN_INCORRECT ];
 
 		default:
 			return null;

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-solutions-for-reason.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-solutions-for-reason.ts
@@ -14,6 +14,12 @@ const SOLUTION_IDS = {
 	SPEAK_WITH_SUPPORT: 'speak-with-support',
 	BUILT_BY: 'built-by',
 	ASK_AI_ASSISTANT: 'ask-ai-assistant',
+	UPGRADE_FULL_ACCESS: 'upgrade-for-full-access',
+	GET_THEME_ADDON: 'get-theme-addon',
+	GET_CSS_ADDON: 'get-css-addon',
+	FIND_GUIDES: 'find-guides',
+	MAKE_SITE_FASTER: 'make-site-faster',
+	USE_MIGRATION_TOOLS: 'use-migration-tools',
 } as const;
 
 /** Too expensive: Expensive for the features offered */
@@ -58,6 +64,65 @@ const SOLUTIONS_HARD_TO_USE_SUPPORT_ONLY: SolutionCardConfig[] = [
 	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
 ];
 
+/** Cannot install plugins */
+const SOLUTIONS_CANNOT_INSTALL_PLUGINS: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.UPGRADE_FULL_ACCESS, label: 'Upgrade for full access' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Cannot upload themes */
+const SOLUTIONS_CANNOT_UPLOAD_THEMES: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.UPGRADE_FULL_ACCESS, label: 'Upgrade for full access' },
+	{ id: SOLUTION_IDS.GET_THEME_ADDON, label: 'Get our theme add-on' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Limited customization */
+const SOLUTIONS_LIMITED_CUSTOMIZATION: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.UPGRADE_FULL_ACCESS, label: 'Upgrade for full access' },
+	{ id: SOLUTION_IDS.GET_CSS_ADDON, label: 'Get our CSS add-on' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Missing functionality */
+const SOLUTIONS_MISSING_FUNCTIONALITY: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.UPGRADE_FULL_ACCESS, label: 'Upgrade for full access' },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Core features missing */
+const SOLUTIONS_CORE_FEATURES_MISSING: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.FIND_GUIDES, label: 'Find easy step-by-step guides' },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Too slow */
+const SOLUTIONS_TOO_SLOW: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.MAKE_SITE_FASTER, label: 'Make your site faster' },
+	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS, label: 'Renew now and pay less' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Bugs or glitches */
+const SOLUTIONS_BUGS_OR_GLITCHES: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS, label: 'Renew now and pay less' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Migration problems */
+const SOLUTIONS_MIGRATION_PROBLEMS: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.USE_MIGRATION_TOOLS, label: 'Use our migration tools' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Downtime */
+const SOLUTIONS_DOWNTIME: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS, label: 'Renew now and pay less' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
 /**
  * Returns the ordered list of solution cards for the given cancellation sub-reason,
  * or null when this reason has no solutions step.
@@ -86,6 +151,28 @@ export function getSolutionsForReason( reason: string ): SolutionCardConfig[] | 
 			return [ ...SOLUTIONS_HARD_TO_USE_SUPPORT_ONLY ];
 		case 'otherTooHardToUse':
 			return null;
+
+		// Missing features / limitations
+		case 'cannotInstallPlugins':
+			return [ ...SOLUTIONS_CANNOT_INSTALL_PLUGINS ];
+		case 'cannotUploadThemes':
+			return [ ...SOLUTIONS_CANNOT_UPLOAD_THEMES ];
+		case 'limitedCustomization':
+			return [ ...SOLUTIONS_LIMITED_CUSTOMIZATION ];
+		case 'missingFunctionality':
+			return [ ...SOLUTIONS_MISSING_FUNCTIONALITY ];
+		case 'coreFeaturesMissing':
+			return [ ...SOLUTIONS_CORE_FEATURES_MISSING ];
+
+		// Performance / reliability
+		case 'tooSlow':
+			return [ ...SOLUTIONS_TOO_SLOW ];
+		case 'bugsOrGlitches':
+			return [ ...SOLUTIONS_BUGS_OR_GLITCHES ];
+		case 'migrationProblems':
+			return [ ...SOLUTIONS_MIGRATION_PROBLEMS ];
+		case 'downtime':
+			return [ ...SOLUTIONS_DOWNTIME ];
 
 		default:
 			return null;

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-solutions-for-reason.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-solutions-for-reason.ts
@@ -1,10 +1,8 @@
 /**
  * Solution card config for the cancellation solutions-cards upsell step.
- * Labels are intended to be passed to __() in the UI for i18n.
  */
 export type SolutionCardConfig = {
 	id: string;
-	label: string;
 };
 
 const SOLUTION_IDS = {
@@ -27,180 +25,180 @@ const SOLUTION_IDS = {
 
 /** Too expensive: Expensive for the features offered */
 const SOLUTIONS_TOO_EXPENSIVE: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.CHANGE_PLAN, label: 'Change plan' },
-	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS, label: 'Renew now and pay less' },
-	{ id: SOLUTION_IDS.SWITCH_TO_MONTHLY, label: 'Switch to monthly payments' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.CHANGE_PLAN },
+	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS },
+	{ id: SOLUTION_IDS.SWITCH_TO_MONTHLY },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Too expensive: Lack of flexibility for the price (lackOfCustomization under price/budget) */
 const SOLUTIONS_LACK_OF_FLEXIBILITY: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.CHANGE_PLAN, label: 'Change plan' },
-	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS, label: 'Renew now and pay less' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.CHANGE_PLAN },
+	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Too expensive: Found competitor / Free plan is enough */
 const SOLUTIONS_FOUND_BETTER_OR_FREE: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS, label: 'Renew now and pay less' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Too expensive: Budget changed */
 const SOLUTIONS_BUDGET_CONSTRAINTS: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.CHANGE_PLAN, label: 'Change plan' },
-	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS, label: 'Renew now and pay less' },
-	{ id: SOLUTION_IDS.SWITCH_TO_MONTHLY, label: 'Switch to monthly payments' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.CHANGE_PLAN },
+	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS },
+	{ id: SOLUTION_IDS.SWITCH_TO_MONTHLY },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Too hard to use: Dashboard / Editor (with AI option) */
 const SOLUTIONS_HARD_TO_USE_WITH_AI: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.BUILT_BY, label: 'Let us build for you' },
-	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.BUILT_BY },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Too hard to use: Takes too much time / Tutorials not helpful (no AI option) */
 const SOLUTIONS_HARD_TO_USE_SUPPORT_ONLY: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.BUILT_BY, label: 'Let us build for you' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.BUILT_BY },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Cannot install plugins */
 const SOLUTIONS_CANNOT_INSTALL_PLUGINS: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.UPGRADE_FULL_ACCESS, label: 'Upgrade for full access' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.UPGRADE_FULL_ACCESS },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Cannot upload themes */
 const SOLUTIONS_CANNOT_UPLOAD_THEMES: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.UPGRADE_FULL_ACCESS, label: 'Upgrade for full access' },
-	{ id: SOLUTION_IDS.GET_THEME_ADDON, label: 'Get our theme add-on' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.UPGRADE_FULL_ACCESS },
+	{ id: SOLUTION_IDS.GET_THEME_ADDON },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Limited customization */
 const SOLUTIONS_LIMITED_CUSTOMIZATION: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.UPGRADE_FULL_ACCESS, label: 'Upgrade for full access' },
-	{ id: SOLUTION_IDS.GET_CSS_ADDON, label: 'Get our CSS add-on' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.UPGRADE_FULL_ACCESS },
+	{ id: SOLUTION_IDS.GET_CSS_ADDON },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Missing functionality */
 const SOLUTIONS_MISSING_FUNCTIONALITY: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.UPGRADE_FULL_ACCESS, label: 'Upgrade for full access' },
-	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.UPGRADE_FULL_ACCESS },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Core features missing */
 const SOLUTIONS_CORE_FEATURES_MISSING: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.FIND_GUIDES, label: 'Find easy step-by-step guides' },
-	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.FIND_GUIDES },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Too slow */
 const SOLUTIONS_TOO_SLOW: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.MAKE_SITE_FASTER, label: 'Make your site faster' },
-	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS, label: 'Renew now and pay less' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.MAKE_SITE_FASTER },
+	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Bugs or glitches */
 const SOLUTIONS_BUGS_OR_GLITCHES: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS, label: 'Renew now and pay less' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Migration problems */
 const SOLUTIONS_MIGRATION_PROBLEMS: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.USE_MIGRATION_TOOLS, label: 'Use our migration tools' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.USE_MIGRATION_TOOLS },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Downtime */
 const SOLUTIONS_DOWNTIME: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS, label: 'Renew now and pay less' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Trouble connecting or transferring (domain) */
 const SOLUTIONS_TROUBLE_CONNECTING_OR_TRANSFERRING: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.USE_DOMAIN_GUIDE, label: 'Use our domain guide' },
-	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.USE_DOMAIN_GUIDE },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Confused about domains */
 const SOLUTIONS_CONFUSED_ABOUT_DOMAINS: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.USE_DOMAIN_GUIDE, label: 'Use our domain guide' },
-	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.USE_DOMAIN_GUIDE },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Domain incorrect */
 const SOLUTIONS_DOMAIN_INCORRECT: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.EXPLORE_DOMAIN_OPTIONS, label: 'Explore more domain options' },
-	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.EXPLORE_DOMAIN_OPTIONS },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Wrong plan */
 const SOLUTIONS_WRONG_PLAN: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.CHANGE_PLAN, label: 'Change plan' },
-	{ id: SOLUTION_IDS.SWITCH_TO_MONTHLY, label: 'Switch to monthly payments' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.CHANGE_PLAN },
+	{ id: SOLUTION_IDS.SWITCH_TO_MONTHLY },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Wrong site */
 const SOLUTIONS_WRONG_SITE: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.MOVE_SUBSCRIPTION, label: 'Move your subscription' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.MOVE_SUBSCRIPTION },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Plan didn't match (noMatch) */
 const SOLUTIONS_NO_MATCH: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Slow or unhelpful support */
 const SOLUTIONS_SLOW_OR_UNHELPFUL: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
-	{ id: SOLUTION_IDS.FIND_GUIDES, label: 'Find easy step-by-step guides' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT },
+	{ id: SOLUTION_IDS.FIND_GUIDES },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** No human support */
 const SOLUTIONS_NO_HUMAN_SUPPORT: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** AI insufficient */
 const SOLUTIONS_AI_INSUFFICIENT: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.FIND_GUIDES, label: 'Find easy step-by-step guides' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.FIND_GUIDES },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Project changed */
 const SOLUTIONS_PROJECT_CHANGED: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** Just exploring */
 const SOLUTIONS_JUST_EXPLORING: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /** May return */
 const SOLUTIONS_MAY_RETURN: SolutionCardConfig[] = [
-	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS, label: 'Renew now and pay less' },
-	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
 /**

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-solutions-for-reason.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-solutions-for-reason.ts
@@ -22,6 +22,7 @@ const SOLUTION_IDS = {
 	USE_MIGRATION_TOOLS: 'use-migration-tools',
 	USE_DOMAIN_GUIDE: 'use-domain-guide',
 	EXPLORE_DOMAIN_OPTIONS: 'explore-domain-options',
+	MOVE_SUBSCRIPTION: 'move-subscription',
 } as const;
 
 /** Too expensive: Expensive for the features offered */
@@ -146,6 +147,62 @@ const SOLUTIONS_DOMAIN_INCORRECT: SolutionCardConfig[] = [
 	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
 ];
 
+/** Wrong plan */
+const SOLUTIONS_WRONG_PLAN: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.CHANGE_PLAN, label: 'Change plan' },
+	{ id: SOLUTION_IDS.SWITCH_TO_MONTHLY, label: 'Switch to monthly payments' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Wrong site */
+const SOLUTIONS_WRONG_SITE: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.MOVE_SUBSCRIPTION, label: 'Move your subscription' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Plan didn't match (noMatch) */
+const SOLUTIONS_NO_MATCH: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Slow or unhelpful support */
+const SOLUTIONS_SLOW_OR_UNHELPFUL: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
+	{ id: SOLUTION_IDS.FIND_GUIDES, label: 'Find easy step-by-step guides' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** No human support */
+const SOLUTIONS_NO_HUMAN_SUPPORT: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** AI insufficient */
+const SOLUTIONS_AI_INSUFFICIENT: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.FIND_GUIDES, label: 'Find easy step-by-step guides' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Project changed */
+const SOLUTIONS_PROJECT_CHANGED: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Just exploring */
+const SOLUTIONS_JUST_EXPLORING: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** May return */
+const SOLUTIONS_MAY_RETURN: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS, label: 'Renew now and pay less' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
 /**
  * Returns the ordered list of solution cards for the given cancellation sub-reason,
  * or null when this reason has no solutions step.
@@ -204,6 +261,30 @@ export function getSolutionsForReason( reason: string ): SolutionCardConfig[] | 
 			return [ ...SOLUTIONS_CONFUSED_ABOUT_DOMAINS ];
 		case 'domainIncorrect':
 			return [ ...SOLUTIONS_DOMAIN_INCORRECT ];
+
+		// Wrong plan or site
+		case 'wrongPlan':
+			return [ ...SOLUTIONS_WRONG_PLAN ];
+		case 'wrongSite':
+			return [ ...SOLUTIONS_WRONG_SITE ];
+		case 'noMatch':
+			return [ ...SOLUTIONS_NO_MATCH ];
+
+		// Bad support experience
+		case 'slowOrUnhelpful':
+			return [ ...SOLUTIONS_SLOW_OR_UNHELPFUL ];
+		case 'noHumanSupport':
+			return [ ...SOLUTIONS_NO_HUMAN_SUPPORT ];
+		case 'AIInsufficient':
+			return [ ...SOLUTIONS_AI_INSUFFICIENT ];
+
+		// Other / lifecycle
+		case 'projectChanged':
+			return [ ...SOLUTIONS_PROJECT_CHANGED ];
+		case 'justExploring':
+			return [ ...SOLUTIONS_JUST_EXPLORING ];
+		case 'mayReturn':
+			return [ ...SOLUTIONS_MAY_RETURN ];
 
 		default:
 			return null;

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-solutions-for-reason.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-solutions-for-reason.ts
@@ -1,0 +1,93 @@
+/**
+ * Solution card config for the cancellation solutions-cards upsell step.
+ * Labels are intended to be passed to __() in the UI for i18n.
+ */
+export type SolutionCardConfig = {
+	id: string;
+	label: string;
+};
+
+const SOLUTION_IDS = {
+	CHANGE_PLAN: 'change-plan',
+	RENEW_NOW_PAY_LESS: 'renew-now-pay-less',
+	SWITCH_TO_MONTHLY: 'switch-to-monthly',
+	SPEAK_WITH_SUPPORT: 'speak-with-support',
+	BUILT_BY: 'built-by',
+	ASK_AI_ASSISTANT: 'ask-ai-assistant',
+} as const;
+
+/** Too expensive: Expensive for the features offered */
+const SOLUTIONS_TOO_EXPENSIVE: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.CHANGE_PLAN, label: 'Change plan' },
+	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS, label: 'Renew now and pay less' },
+	{ id: SOLUTION_IDS.SWITCH_TO_MONTHLY, label: 'Switch to monthly payments' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Too expensive: Lack of flexibility for the price (lackOfCustomization under price/budget) */
+const SOLUTIONS_LACK_OF_FLEXIBILITY: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.CHANGE_PLAN, label: 'Change plan' },
+	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS, label: 'Renew now and pay less' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Too expensive: Found competitor / Free plan is enough */
+const SOLUTIONS_FOUND_BETTER_OR_FREE: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS, label: 'Renew now and pay less' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Too expensive: Budget changed */
+const SOLUTIONS_BUDGET_CONSTRAINTS: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.CHANGE_PLAN, label: 'Change plan' },
+	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS, label: 'Renew now and pay less' },
+	{ id: SOLUTION_IDS.SWITCH_TO_MONTHLY, label: 'Switch to monthly payments' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Too hard to use: Dashboard / Editor (with AI option) */
+const SOLUTIONS_HARD_TO_USE_WITH_AI: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.BUILT_BY, label: 'Let us build for you' },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT, label: 'Ask our AI assistant' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/** Too hard to use: Takes too much time / Tutorials not helpful (no AI option) */
+const SOLUTIONS_HARD_TO_USE_SUPPORT_ONLY: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.BUILT_BY, label: 'Let us build for you' },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT, label: 'Speak with our support team' },
+];
+
+/**
+ * Returns the ordered list of solution cards for the given cancellation sub-reason,
+ * or null when this reason has no solutions step.
+ */
+export function getSolutionsForReason( reason: string ): SolutionCardConfig[] | null {
+	switch ( reason ) {
+		// Too expensive
+		case 'tooExpensive':
+			return [ ...SOLUTIONS_TOO_EXPENSIVE ];
+		case 'lackOfCustomization':
+			return [ ...SOLUTIONS_LACK_OF_FLEXIBILITY ];
+		case 'foundBetterValue':
+		case 'freeIsGoodEnough':
+			return [ ...SOLUTIONS_FOUND_BETTER_OR_FREE ];
+		case 'budgetConstraints':
+			return [ ...SOLUTIONS_BUDGET_CONSTRAINTS ];
+		case 'otherPriceValue':
+			return null;
+
+		// Too hard to use
+		case 'complicatedDashboard':
+		case 'difficultEditor':
+			return [ ...SOLUTIONS_HARD_TO_USE_WITH_AI ];
+		case 'tooMuchTimeToLearn':
+		case 'inadequateOnboarding':
+			return [ ...SOLUTIONS_HARD_TO_USE_SUPPORT_ONLY ];
+		case 'otherTooHardToUse':
+			return null;
+
+		default:
+			return null;
+	}
+}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-solutions-for-reason.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-solutions-for-reason.ts
@@ -14,7 +14,6 @@ const SOLUTION_IDS = {
 	ASK_AI_ASSISTANT: 'ask-ai-assistant',
 	UPGRADE_FULL_ACCESS: 'upgrade-for-full-access',
 	GET_THEME_ADDON: 'get-theme-addon',
-	GET_CSS_ADDON: 'get-css-addon',
 	FIND_GUIDES: 'find-guides',
 	MAKE_SITE_FASTER: 'make-site-faster',
 	USE_MIGRATION_TOOLS: 'use-migration-tools',
@@ -80,7 +79,6 @@ const SOLUTIONS_CANNOT_UPLOAD_THEMES: SolutionCardConfig[] = [
 /** Limited customization */
 const SOLUTIONS_LIMITED_CUSTOMIZATION: SolutionCardConfig[] = [
 	{ id: SOLUTION_IDS.UPGRADE_FULL_ACCESS },
-	{ id: SOLUTION_IDS.GET_CSS_ADDON },
 	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-upsell-type.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-upsell-type.ts
@@ -60,6 +60,8 @@ export function getUpsellType(
 
 			break;
 
+		case 'complicatedDashboard':
+		case 'difficultEditor':
 		case 'freeIsGoodEnough':
 		case 'foundBetterValue':
 		case 'tooMuchTimeToLearn':

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -24,6 +24,7 @@ import {
 	removePurchaseMutation,
 	userPreferenceQuery,
 } from '@automattic/api-queries';
+import config from '@automattic/calypso-config';
 import { invokeSurvicateEvent } from '@automattic/survicate';
 import { useSuspenseQuery, useQuery, useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
@@ -75,6 +76,7 @@ import {
 import CancellationPreSurveyContent from './cancellation-pre-survey-content';
 import DomainRemovalFlow from './domain-removal-flow';
 import enrichedSurveyData from './enriched-survey-data';
+import { getSolutionsForReason } from './get-solutions-for-reason';
 import { getUpsellType } from './get-upsell-type';
 import initialSurveyState from './initial-survey-state';
 import MarketPlaceSubscriptionsDialog from './marketplace-subscriptions-dialog';
@@ -774,16 +776,19 @@ export default function CancelPurchase() {
 			recordClickRadioEvent( 'radio_1_2', value );
 		}
 
+		const upsellType = getUpsellType( value, purchase, {
+			canDowngrade: !! downgradeClick,
+			canOfferFreeMonth: !! freeMonthOfferClick && ! hasBeenExtended && ! purchase.is_refundable,
+		} );
+		const hasSolutionsCards =
+			config.isEnabled( 'cancel-flow/solutions-cards-upsell' ) &&
+			( getSolutionsForReason( value )?.length ?? 0 ) > 0;
+
 		setState( ( state ) => ( {
 			...state,
 			questionOneText: value,
 			questionOneDetails: detailsValue || questionOneDetails,
-			upsell:
-				getUpsellType( value, purchase, {
-					canDowngrade: !! downgradeClick,
-					canOfferFreeMonth:
-						!! freeMonthOfferClick && ! hasBeenExtended && ! purchase.is_refundable,
-				} ) || '',
+			upsell: upsellType || ( hasSolutionsCards ? 'solutions-cards' : '' ),
 		} ) );
 	};
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -1353,6 +1353,10 @@ export default function CancelPurchase() {
 	);
 	const description =
 		state.surveyStep === CANCELLATION_OFFER_STEP ? cancellationOfferDescription : null;
+	const isSolutionsStep =
+		state.surveyStep === UPSELL_STEP &&
+		config.isEnabled( 'cancel-flow/solutions-cards-upsell' ) &&
+		( getSolutionsForReason( state.questionOneText ?? '' )?.length ?? 0 ) > 0;
 	return (
 		<PageLayout
 			size="small"
@@ -1382,101 +1386,157 @@ export default function CancelPurchase() {
 				) )
 			}
 		>
-			<Card>
-				<CardBody>
-					<VStack spacing={ 6 }>
-						<CancelPurchaseForm
-							atomicRevertCheckOne={ state.atomicRevertCheckOne }
-							atomicRevertCheckTwo={ state.atomicRevertCheckTwo }
-							atomicRevertOnClickCheckOne={ atomicRevertOnClickCheckOne }
-							atomicRevertOnClickCheckTwo={ atomicRevertOnClickCheckTwo }
-							atomicTransfer={ atomicTransfer }
-							cancelBundledDomain={ state.cancelBundledDomain }
-							cancellationInProgress={ state.isLoading }
-							cancellationOffer={ cancellationOffer }
-							clickNext={ clickNext }
-							closeDialog={ closeDialog }
-							disableButtons={ state.isLoading }
-							downgradeClick={ downgradeClick }
-							downgradePlan={ downgradePlan }
-							flowType={ flowType }
-							freeMonthOfferClick={ freeMonthOfferClick }
-							hasBackupsFeature={ hasBackupsFeature }
-							importQuestionRadio={ state.importQuestionRadio }
-							includedDomainPurchase={ includedDomainPurchase }
-							isAkismet={ isAkismet }
-							isApplyingOffer={ isApplyingOffer }
-							isImport={ isImport }
-							isNextAdventureValid={ state.isNextAdventureValid }
-							isShowing={ state.isShowingMarketplaceSubscriptionsDialog }
-							isSubmitting={ state.isSubmitting }
-							isVisible={ state.surveyShown }
-							offerDiscountBasedFromPurchasePrice={ offerDiscountBasedFromPurchasePrice }
-							onClickAcceptForCancellationOffer={ onClickAcceptForCancellationOffer }
-							onGetCancellationOffer={ onGetCancellationOffer }
-							onImportRadioChange={ onImportRadioChange }
-							onNextAdventureValidationChange={ onNextAdventureValidationChange }
-							onRadioOneChange={ onRadioOneChange }
-							onRadioTwoChange={ onRadioTwoChange }
-							onSubmit={ onSubmit }
-							onSurveyComplete={ onSurveyComplete }
-							onTextOneChange={ onTextOneChange }
-							onTextThreeChange={ onTextThreeChange }
-							onTextTwoChange={ onTextTwoChange }
-							plans={ plans }
-							purchase={ purchase }
-							questionOneOrder={ state.questionOneOrder }
-							questionOneRadio={ state.questionOneRadio }
-							questionOneText={ state.questionOneText }
-							questionTwoOrder={ state.questionTwoOrder }
-							questionTwoRadio={ state.questionTwoRadio }
-							questionTwoText={ state.questionTwoText }
-							refundAmount={ purchase.total_refund_amount }
-							siteSlug={ siteSlug }
-							solution={ state.solution }
-							surveyStep={ state.surveyStep }
-							allSteps={ allSteps }
-							upsell={ state.upsell }
-						/>
-						{ ! state.surveyShown && (
-							<CancellationPreSurveyContent
-								purchase={ purchase }
-								includedDomainPurchase={ includedDomainPurchase }
+			{ isSolutionsStep ? (
+				<CancelPurchaseForm
+					atomicRevertCheckOne={ state.atomicRevertCheckOne }
+					atomicRevertCheckTwo={ state.atomicRevertCheckTwo }
+					atomicRevertOnClickCheckOne={ atomicRevertOnClickCheckOne }
+					atomicRevertOnClickCheckTwo={ atomicRevertOnClickCheckTwo }
+					atomicTransfer={ atomicTransfer }
+					cancelBundledDomain={ state.cancelBundledDomain }
+					cancellationInProgress={ state.isLoading }
+					cancellationOffer={ cancellationOffer }
+					clickNext={ clickNext }
+					closeDialog={ closeDialog }
+					disableButtons={ state.isLoading }
+					downgradeClick={ downgradeClick }
+					downgradePlan={ downgradePlan }
+					flowType={ flowType }
+					freeMonthOfferClick={ freeMonthOfferClick }
+					hasBackupsFeature={ hasBackupsFeature }
+					importQuestionRadio={ state.importQuestionRadio }
+					includedDomainPurchase={ includedDomainPurchase }
+					isAkismet={ isAkismet }
+					isApplyingOffer={ isApplyingOffer }
+					isImport={ isImport }
+					isNextAdventureValid={ state.isNextAdventureValid }
+					isShowing={ state.isShowingMarketplaceSubscriptionsDialog }
+					isSubmitting={ state.isSubmitting }
+					isVisible={ state.surveyShown }
+					offerDiscountBasedFromPurchasePrice={ offerDiscountBasedFromPurchasePrice }
+					onClickAcceptForCancellationOffer={ onClickAcceptForCancellationOffer }
+					onGetCancellationOffer={ onGetCancellationOffer }
+					onImportRadioChange={ onImportRadioChange }
+					onNextAdventureValidationChange={ onNextAdventureValidationChange }
+					onRadioOneChange={ onRadioOneChange }
+					onRadioTwoChange={ onRadioTwoChange }
+					onSubmit={ onSubmit }
+					onSurveyComplete={ onSurveyComplete }
+					onTextOneChange={ onTextOneChange }
+					onTextThreeChange={ onTextThreeChange }
+					onTextTwoChange={ onTextTwoChange }
+					plans={ plans }
+					purchase={ purchase }
+					questionOneOrder={ state.questionOneOrder }
+					questionOneRadio={ state.questionOneRadio }
+					questionOneText={ state.questionOneText }
+					questionTwoOrder={ state.questionTwoOrder }
+					questionTwoRadio={ state.questionTwoRadio }
+					questionTwoText={ state.questionTwoText }
+					refundAmount={ purchase.total_refund_amount }
+					siteSlug={ siteSlug }
+					solution={ state.solution }
+					surveyStep={ state.surveyStep }
+					allSteps={ allSteps }
+					upsell={ state.upsell }
+				/>
+			) : (
+				<Card>
+					<CardBody>
+						<VStack spacing={ 6 }>
+							<CancelPurchaseForm
+								atomicRevertCheckOne={ state.atomicRevertCheckOne }
+								atomicRevertCheckTwo={ state.atomicRevertCheckTwo }
+								atomicRevertOnClickCheckOne={ atomicRevertOnClickCheckOne }
+								atomicRevertOnClickCheckTwo={ atomicRevertOnClickCheckTwo }
 								atomicTransfer={ atomicTransfer }
-								selectedDomain={ selectedDomain }
-								state={ state }
-								purchaseCancelFeatures={ purchaseCancelFeatures }
-								onCancelConfirmationStateChange={ onCancelConfirmationStateChange }
-								onDomainConfirmationChange={ onDomainConfirmationChange }
-								onCustomerConfirmedUnderstandingChange={ onCustomerConfirmedUnderstandingChange }
-								onKeepSubscriptionClick={ onKeepSubscriptionClick }
-								onCancellationComplete={ onCancellationComplete }
-								onCancellationStart={ onCancellationStart }
-								shouldHandleMarketplaceSubscriptions={ shouldHandleMarketplaceSubscriptions }
-								showMarketplaceDialog={ showMarketplaceDialog }
+								cancelBundledDomain={ state.cancelBundledDomain }
+								cancellationInProgress={ state.isLoading }
+								cancellationOffer={ cancellationOffer }
+								clickNext={ clickNext }
+								closeDialog={ closeDialog }
+								disableButtons={ state.isLoading }
+								downgradeClick={ downgradeClick }
+								downgradePlan={ downgradePlan }
+								flowType={ flowType }
+								freeMonthOfferClick={ freeMonthOfferClick }
+								hasBackupsFeature={ hasBackupsFeature }
+								importQuestionRadio={ state.importQuestionRadio }
+								includedDomainPurchase={ includedDomainPurchase }
+								isAkismet={ isAkismet }
+								isApplyingOffer={ isApplyingOffer }
+								isImport={ isImport }
+								isNextAdventureValid={ state.isNextAdventureValid }
+								isShowing={ state.isShowingMarketplaceSubscriptionsDialog }
+								isSubmitting={ state.isSubmitting }
+								isVisible={ state.surveyShown }
+								offerDiscountBasedFromPurchasePrice={ offerDiscountBasedFromPurchasePrice }
+								onClickAcceptForCancellationOffer={ onClickAcceptForCancellationOffer }
+								onGetCancellationOffer={ onGetCancellationOffer }
+								onImportRadioChange={ onImportRadioChange }
+								onNextAdventureValidationChange={ onNextAdventureValidationChange }
+								onRadioOneChange={ onRadioOneChange }
+								onRadioTwoChange={ onRadioTwoChange }
+								onSubmit={ onSubmit }
+								onSurveyComplete={ onSurveyComplete }
+								onTextOneChange={ onTextOneChange }
+								onTextThreeChange={ onTextThreeChange }
+								onTextTwoChange={ onTextTwoChange }
+								plans={ plans }
+								purchase={ purchase }
+								questionOneOrder={ state.questionOneOrder }
+								questionOneRadio={ state.questionOneRadio }
+								questionOneText={ state.questionOneText }
+								questionTwoOrder={ state.questionTwoOrder }
+								questionTwoRadio={ state.questionTwoRadio }
+								questionTwoText={ state.questionTwoText }
+								refundAmount={ purchase.total_refund_amount }
+								siteSlug={ siteSlug }
+								solution={ state.solution }
+								surveyStep={ state.surveyStep }
+								allSteps={ allSteps }
+								upsell={ state.upsell }
 							/>
-						) }
-						{ shouldHandleMarketplaceSubscriptions() && (
-							<MarketPlaceSubscriptionsDialog
-								activeSubscriptions={ activeSubscriptions }
-								bodyParagraphText={ _n(
-									'This subscription will be cancelled. It will be removed when it expires.',
-									'These subscriptions will be cancelled. They will be removed when they expire.',
-									activeSubscriptions.length
-								) }
-								closeDialog={ closeMarketplaceSubscriptionsDialog }
-								isDialogVisible
-								planName={ planName ?? '' }
-								/* Translators: This button cancels the active plan and all active Marketplace subscriptions on the site */
-								primaryButtonText={ __( 'Continue' ) }
-								removePlan={ handleMarketplaceDialogContinue }
-								/* Translators: %(plan)s is the name of the plan being cancelled */
-								sectionHeadingText={ sprintf( __( 'Cancel %(plan)s' ), { plan: planName } ) }
-							/>
-						) }
-					</VStack>
-				</CardBody>
-			</Card>
+							{ ! state.surveyShown && (
+								<CancellationPreSurveyContent
+									purchase={ purchase }
+									includedDomainPurchase={ includedDomainPurchase }
+									atomicTransfer={ atomicTransfer }
+									selectedDomain={ selectedDomain }
+									state={ state }
+									purchaseCancelFeatures={ purchaseCancelFeatures }
+									onCancelConfirmationStateChange={ onCancelConfirmationStateChange }
+									onDomainConfirmationChange={ onDomainConfirmationChange }
+									onCustomerConfirmedUnderstandingChange={ onCustomerConfirmedUnderstandingChange }
+									onKeepSubscriptionClick={ onKeepSubscriptionClick }
+									onCancellationComplete={ onCancellationComplete }
+									onCancellationStart={ onCancellationStart }
+									shouldHandleMarketplaceSubscriptions={ shouldHandleMarketplaceSubscriptions }
+									showMarketplaceDialog={ showMarketplaceDialog }
+								/>
+							) }
+							{ shouldHandleMarketplaceSubscriptions() && (
+								<MarketPlaceSubscriptionsDialog
+									activeSubscriptions={ activeSubscriptions }
+									bodyParagraphText={ _n(
+										'This subscription will be cancelled. It will be removed when it expires.',
+										'These subscriptions will be cancelled. They will be removed when they expire.',
+										activeSubscriptions.length
+									) }
+									closeDialog={ closeMarketplaceSubscriptionsDialog }
+									isDialogVisible
+									planName={ planName ?? '' }
+									/* Translators: This button cancels the active plan and all active Marketplace subscriptions on the site */
+									primaryButtonText={ __( 'Continue' ) }
+									removePlan={ handleMarketplaceDialogContinue }
+									/* Translators: %(plan)s is the name of the plan being cancelled */
+									sectionHeadingText={ sprintf( __( 'Cancel %(plan)s' ), { plan: planName } ) }
+								/>
+							) }
+						</VStack>
+					</CardBody>
+				</Card>
+			) }
 		</PageLayout>
 	);
 }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/style.scss
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/style.scss
@@ -27,3 +27,14 @@
 	font-weight: 500;
 	font-size: 0.875rem;
 }
+
+/* Vertically center the icon (decoration) in solutions cards */
+.cancel-purchase-form__solution-card.summary-button {
+	> * {
+		align-items: center;
+	}
+
+	.summary-button-decoration {
+		align-items: center;
+	}
+}

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -24,6 +24,7 @@
 	"features": {
 		"always_use_logout_url": true,
 		"calypso/ai-site-builder-flow": true,
+		"cancel-flow/solutions-cards-upsell": true,
 		"ciab/allow-domain-features": true,
 		"cookie-banner": false,
 		"rum-tracking/logstash": true,

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -24,7 +24,7 @@
 	"features": {
 		"always_use_logout_url": true,
 		"calypso/ai-site-builder-flow": true,
-		"cancel-flow/solutions-cards-upsell": true,
+		"cancel-flow/solutions-cards-upsell": false,
 		"ciab/allow-domain-features": true,
 		"cookie-banner": false,
 		"rum-tracking/logstash": true,

--- a/config/development.json
+++ b/config/development.json
@@ -50,6 +50,8 @@
 		"calypso/all-domain-management": true,
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,
+		"calypso/refund-eligibility-notice": false,
+		"cancel-flow/solutions-cards-upsell": true,
 		"checkout/checkout-version": true,
 		"ciab/allow-domain-features": true,
 		"ciab/custom-branding": true,

--- a/config/development.json
+++ b/config/development.json
@@ -51,7 +51,7 @@
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,
 		"calypso/refund-eligibility-notice": false,
-		"cancel-flow/solutions-cards-upsell": true,
+		"cancel-flow/solutions-cards-upsell": false,
 		"checkout/checkout-version": true,
 		"ciab/allow-domain-features": true,
 		"ciab/custom-branding": true,

--- a/packages/components/src/summary-button/index.stories.tsx
+++ b/packages/components/src/summary-button/index.stories.tsx
@@ -77,3 +77,13 @@ export const MediumDensity: Story = {
 		badges: badgeOptions[ 'Two Badges' ],
 	},
 };
+
+export const MediumLowDensity: Story = {
+	args: {
+		title: 'Email Configuration',
+		description: 'Setup email forwarding for your domain.',
+		density: 'medium-low',
+		decoration: <Icon icon={ envelope } />,
+		badges: badgeOptions[ 'Two Badges' ],
+	},
+};

--- a/packages/components/src/summary-button/index.tsx
+++ b/packages/components/src/summary-button/index.tsx
@@ -52,6 +52,7 @@ function UnforwardedSummaryButton(
 	ref: React.ForwardedRef< HTMLAnchorElement | HTMLButtonElement >
 ) {
 	const hasLowDensity = density === 'low';
+	const showsDescription = density === 'low' || density === 'medium-low';
 	return (
 		<Button
 			// Forward additional props to support standard attributes like mouse events.
@@ -74,7 +75,7 @@ function UnforwardedSummaryButton(
 								</Text>
 							) }
 							<Text className="summary-button-title">{ title }</Text>
-							{ description && hasLowDensity && (
+							{ description && showsDescription && (
 								<Text variant="muted" className="summary-button-description">
 									{ description }
 								</Text>

--- a/packages/components/src/summary-button/index.tsx
+++ b/packages/components/src/summary-button/index.tsx
@@ -74,7 +74,7 @@ function UnforwardedSummaryButton(
 								</Text>
 							) }
 							<Text className="summary-button-title">{ title }</Text>
-							{ description && hasLowDensity && (
+							{ description && (
 								<Text variant="muted" className="summary-button-description">
 									{ description }
 								</Text>

--- a/packages/components/src/summary-button/index.tsx
+++ b/packages/components/src/summary-button/index.tsx
@@ -74,7 +74,7 @@ function UnforwardedSummaryButton(
 								</Text>
 							) }
 							<Text className="summary-button-title">{ title }</Text>
-							{ description && (
+							{ description && hasLowDensity && (
 								<Text variant="muted" className="summary-button-description">
 									{ description }
 								</Text>

--- a/packages/components/src/summary-button/style.scss
+++ b/packages/components/src/summary-button/style.scss
@@ -28,7 +28,8 @@
 			}
 		}
 
-		&.has-density-medium {
+		&.has-density-medium,
+		&.has-density-medium-low {
 			&:not(:focus-visible, :last-child) {
 				border-bottom: 1px solid color-mix(in srgb, var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9)) 12%, transparent);
 			}
@@ -71,7 +72,8 @@
 		background-color: #fff;
 	}
 
-	&.has-density-medium {
+	&.has-density-medium,
+	&.has-density-medium-low {
 		padding: $grid-unit-20 $grid-unit-30;
 		border-bottom: 1px solid $gray-100;
 		border-radius: 0;

--- a/packages/components/src/summary-button/test/index.tsx
+++ b/packages/components/src/summary-button/test/index.tsx
@@ -51,4 +51,16 @@ describe( 'SummaryButton', () => {
 		expect( screen.queryByText( 'Test Description' ) ).toBeNull();
 		expect( screen.queryByText( 'Test Strapline' ) ).toBeNull();
 	} );
+	test( 'should render description but not strapline in medium-low density mode', () => {
+		render(
+			<SummaryButton
+				title="Test Title"
+				description="Test Description"
+				strapline="Test Strapline"
+				density="medium-low"
+			/>
+		);
+		expect( screen.getByText( 'Test Description' ) ).toBeVisible();
+		expect( screen.queryByText( 'Test Strapline' ) ).toBeNull();
+	} );
 } );

--- a/packages/components/src/summary-button/types.ts
+++ b/packages/components/src/summary-button/types.ts
@@ -1,6 +1,6 @@
 import type { Badge } from '@automattic/ui';
 
-export type Density = 'low' | 'medium';
+export type Density = 'low' | 'medium-low' | 'medium';
 
 /**
  * `badges` property of `SummaryButton` component is used to display `Badge`
@@ -40,15 +40,13 @@ export interface SummaryButtonProps {
 	density?: Density;
 	/**
 	 * Optional supporting text that provides additional context or detail about the linked page.
-	 * For now, this property is only rendered in `low` density variant.
-	 * We might revisit adding this in more variants in the future.
+	 * Rendered in `low` and `medium-low` density variants.
 	 */
 	description?: React.ReactNode;
 	/**
 	 * A brief, optional line of text used to highlight important information,
 	 * such as a warning or status.
-	 * For now, this property is only rendered in `low` density variant.
-	 * We might revisit adding this in more variants in the future.
+	 * Only rendered in `low` density variant.
 	 */
 	strapline?: string;
 	/**

--- a/packages/components/src/summary-button/types.ts
+++ b/packages/components/src/summary-button/types.ts
@@ -34,12 +34,14 @@ export interface SummaryButtonProps {
 	 */
 	onClick?: React.MouseEventHandler;
 	/**
-	 * Adjusts spacing and layout. Higher density reduces padding and hides
-	 * optional elements like the strapline to create a more compact appearance.
+	 * Adjusts spacing and layout. Higher density reduces padding and may hide
+	 * optional elements like the description to create a more compact appearance.
 	 */
 	density?: Density;
 	/**
 	 * Optional supporting text that provides additional context or detail about the linked page.
+	 * For now, this property is only rendered in `low` density variant.
+	 * We might revisit adding this in more variants in the future.
 	 */
 	description?: React.ReactNode;
 	/**

--- a/packages/components/src/summary-button/types.ts
+++ b/packages/components/src/summary-button/types.ts
@@ -34,14 +34,12 @@ export interface SummaryButtonProps {
 	 */
 	onClick?: React.MouseEventHandler;
 	/**
-	 * Adjusts spacing and layout. Higher density reduces padding and may hide
-	 * optional elements like the description to create a more compact appearance.
+	 * Adjusts spacing and layout. Higher density reduces padding and hides
+	 * optional elements like the strapline to create a more compact appearance.
 	 */
 	density?: Density;
 	/**
 	 * Optional supporting text that provides additional context or detail about the linked page.
-	 * For now, this property is only rendered in `low` density variant.
-	 * We might revisit adding this in more variants in the future.
 	 */
 	description?: React.ReactNode;
 	/**

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -317,5 +317,4 @@ export type HelpCenterAction =
 			| typeof setHelpCenterOptions
 			| typeof setCurrentUser
 	  >
-	| GeneratorReturnType< typeof setShowHelpCenter >
-	| GeneratorReturnType< typeof setOpenOdieWithContext >;
+	| GeneratorReturnType< typeof setShowHelpCenter >;

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -253,6 +253,31 @@ export const setNavigateToOdie = function* () {
 	yield setShowHelpCenter( true );
 };
 
+/**
+ * Open the Help Center on the Odie (AI) assistant with optional context.
+ * Does not add provider=zendesk, so the user stays in the AI chat instead of human support.
+ */
+export const setOpenOdieWithContext = function* ( {
+	initialMessage,
+	section,
+	siteUrl,
+	siteId,
+}: {
+	initialMessage: string;
+	section?: string;
+	siteUrl?: string;
+	siteId?: string | number;
+} ) {
+	const url = addQueryArgs( '/odie', {
+		userFieldMessage: initialMessage,
+		section,
+		siteUrl,
+		siteId: siteId != null ? String( siteId ) : undefined,
+	} );
+	yield setNavigateToRoute( url );
+	yield setShowHelpCenter( true );
+};
+
 export const setShowSupportDoc = function* ( link: string, postId?: number, blogId?: number ) {
 	const params = new URLSearchParams( {
 		link,
@@ -292,4 +317,5 @@ export type HelpCenterAction =
 			| typeof setHelpCenterOptions
 			| typeof setCurrentUser
 	  >
-	| GeneratorReturnType< typeof setShowHelpCenter >;
+	| GeneratorReturnType< typeof setShowHelpCenter >
+	| GeneratorReturnType< typeof setOpenOdieWithContext >;


### PR DESCRIPTION
Part of DOTCOM-13705

## Proposed Changes

This is a work in progress.

It adds a new style of interventions (in the code they're called solutions, which is a legacy way to address these. I should probably rename them to interventions)

Where the code is:
- Added 15 interventions
- Hidden behind a flag so we can run an experiment
- Some don't work and are fixable, for example, upgrades that don't have a checkout link
- Some are missing confirmation modals (downgrade to monthly)
- Some are pending confirmation

I wanted to implement this in the old dashboard and then port it to the new but the AI kept confusing both, so the PR contains changes in both areas. I've not decided if I'll split it in two, for now this is just convenience for me when talking to AI.

## Why are these changes being made?

* Don't guess what the problem is, ask

## Testing Instructions

* TBD

/me/purchases
<img width="614" height="514" alt="Screenshot 2026-03-10 at 17 24 34" src="https://github.com/user-attachments/assets/4e7c21e1-7c88-4d80-b06d-81e6f0bae773" />

MSD
<img width="724" height="567" alt="Screenshot 2026-03-10 at 17 23 46" src="https://github.com/user-attachments/assets/ebf1f98a-387d-44ad-a5b0-5b6295dc3d85" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
