### PR TITLE
Survicate: Fire CES survey events after purchase, cancellation, and refund

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -24,6 +24,7 @@ import {
 	removePurchaseMutation,
 	userPreferenceQuery,
 } from '@automattic/api-queries';
+import { invokeSurvicateEvent } from '@automattic/survicate';
 import { useSuspenseQuery, useQuery, useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { __experimentalVStack as VStack } from '@wordpress/components';
@@ -898,6 +899,7 @@ export default function CancelPurchase() {
 								type: 'snackbar',
 							}
 						);
+						invokeSurvicateEvent( 'purchaseRefunded' );
 						navigate( {
 							to: purchaseSettingsRoute.fullPath,
 							params: { purchaseId: purchase.ID },
@@ -990,6 +992,7 @@ export default function CancelPurchase() {
 					);
 				}
 				createSuccessNotice( successMessage, { type: 'snackbar' } );
+				invokeSurvicateEvent( 'purchaseRemoved' );
 				navigate( {
 					to: purchaseSettingsRoute.fullPath,
 					params: { purchaseId: purchase.ID },
@@ -1036,6 +1039,7 @@ export default function CancelPurchase() {
 						),
 						{ type: 'snackbar' }
 					);
+					invokeSurvicateEvent( 'purchaseCancelled' );
 					navigate( {
 						to: purchaseSettingsRoute.fullPath,
 						params: { purchaseId: purchase.ID },

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -14,6 +14,7 @@ import {
 import page from '@automattic/calypso-router';
 import { Card, CompactCard } from '@automattic/components';
 import { formatCurrency } from '@automattic/number-formatters';
+import { invokeSurvicateEvent } from '@automattic/survicate';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import moment from 'moment';
 import { Component } from 'react';
@@ -353,6 +354,11 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 				this.props.refreshSitePlans( this.props.purchase.siteId );
 				this.props.clearPurchases();
 				this.props.successNotice( result.message, { displayOnNextPage: true, duration: 10000 } );
+				if ( refundable ) {
+					invokeSurvicateEvent( 'purchaseRefunded' );
+				} else {
+					invokeSurvicateEvent( 'purchaseCancelled' );
+				}
 				const managePurchaseUrl = ( this.props.getManagePurchaseUrlFor ?? managePurchase )(
 					this.props.siteSlug,
 					this.props.purchaseId

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -170,6 +170,7 @@ class RemovePurchase extends Component {
 		}
 
 		await this.handlePurchaseRemoval( purchase );
+		invokeSurvicateEvent( 'purchaseRemoved' );
 
 		page( purchaseListUrl );
 	};
@@ -179,7 +180,6 @@ class RemovePurchase extends Component {
 
 		try {
 			await this.props.removePurchase( purchase.id, userId );
-			invokeSurvicateEvent( 'purchaseRemoved' );
 
 			const productName = getName( purchase );
 			let successMessage;

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -12,6 +12,7 @@ import {
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { CompactCard, Gridicon } from '@automattic/components';
+import { invokeSurvicateEvent } from '@automattic/survicate';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -178,6 +179,7 @@ class RemovePurchase extends Component {
 
 		try {
 			await this.props.removePurchase( purchase.id, userId );
+			invokeSurvicateEvent( 'purchaseRemoved' );
 
 			const productName = getName( purchase );
 			let successMessage;

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -18,7 +18,6 @@ import {
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Card } from '@automattic/components';
-import { invokeSurvicateEvent } from '@automattic/survicate';
 import { css, Global } from '@emotion/react';
 import { dispatch } from '@wordpress/data';
 import { localize } from 'i18n-calypso';
@@ -261,7 +260,6 @@ export class CheckoutThankYou extends Component<
 		}
 
 		recordTracksEvent( 'calypso_checkout_thank_you_view' );
-		invokeSurvicateEvent( 'purchaseCompleted' );
 
 		window.scrollTo( 0, 0 );
 	}

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -18,6 +18,7 @@ import {
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Card } from '@automattic/components';
+import { invokeSurvicateEvent } from '@automattic/survicate';
 import { css, Global } from '@emotion/react';
 import { dispatch } from '@wordpress/data';
 import { localize } from 'i18n-calypso';
@@ -260,6 +261,7 @@ export class CheckoutThankYou extends Component<
 		}
 
 		recordTracksEvent( 'calypso_checkout_thank_you_view' );
+		invokeSurvicateEvent( 'purchaseCompleted' );
 
 		window.scrollTo( 0, 0 );
 	}

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -4,6 +4,7 @@ import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Step } from '@automattic/onboarding';
 import { useShoppingCart } from '@automattic/shopping-cart';
+import { invokeSurvicateEvent } from '@automattic/survicate';
 import { AUTO_RENEWAL } from '@automattic/urls';
 import { useTranslate } from 'i18n-calypso';
 import React, { useState, useEffect, useRef } from 'react';
@@ -275,6 +276,9 @@ function useRedirectOnTransactionSuccess( {
 		}
 
 		didRedirect.current = true;
+		if ( ! redirectInstructions.isError && ! redirectInstructions.isUnknown ) {
+			invokeSurvicateEvent( 'purchaseCompleted' );
+		}
 		if ( isConnectAfterCheckoutFlow ) {
 			setHeadingText( connectingJetpackText );
 		}

--- a/packages/survicate/src/index.ts
+++ b/packages/survicate/src/index.ts
@@ -1,3 +1,4 @@
 export { shouldLoadSurvicate, SURVICATE_WORKSPACE_ID } from './conditions';
 export { isSurvicateScriptLoaded, loadSurvicateScript } from './load-script';
+export { invokeSurvicateEvent } from './invoke-event';
 export { setSurvicateVisitorTraits } from './visitor-traits';

--- a/packages/survicate/src/invoke-event.ts
+++ b/packages/survicate/src/invoke-event.ts
@@ -1,0 +1,7 @@
+export function invokeSurvicateEvent( eventName: string ): boolean {
+	if ( typeof window._sva !== 'undefined' && window._sva.invokeEvent ) {
+		window._sva.invokeEvent( eventName );
+		return true;
+	}
+	return false;
+}

--- a/packages/survicate/src/test/invoke-event.test.ts
+++ b/packages/survicate/src/test/invoke-event.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { invokeSurvicateEvent } from '../invoke-event';
+
+describe( 'invokeSurvicateEvent', () => {
+	beforeEach( () => {
+		window._sva = undefined;
+	} );
+
+	afterEach( () => {
+		window._sva = undefined;
+	} );
+
+	test( 'should return true and call invokeEvent when window._sva.invokeEvent exists', () => {
+		const invokeEvent = jest.fn();
+		window._sva = { invokeEvent };
+
+		const result = invokeSurvicateEvent( 'testEvent' );
+
+		expect( result ).toBe( true );
+		expect( invokeEvent ).toHaveBeenCalledWith( 'testEvent' );
+	} );
+
+	test( 'should return false when window._sva is undefined', () => {
+		window._sva = undefined;
+
+		const result = invokeSurvicateEvent( 'testEvent' );
+
+		expect( result ).toBe( false );
+	} );
+
+	test( 'should return false when invokeEvent is not available on _sva', () => {
+		window._sva = {};
+
+		const result = invokeSurvicateEvent( 'testEvent' );
+
+		expect( result ).toBe( false );
+	} );
+
+	test( 'should not throw in any case', () => {
+		window._sva = undefined;
+		expect( () => invokeSurvicateEvent( 'testEvent' ) ).not.toThrow();
+
+		window._sva = {};
+		expect( () => invokeSurvicateEvent( 'testEvent' ) ).not.toThrow();
+
+		window._sva = { invokeEvent: jest.fn() };
+		expect( () => invokeSurvicateEvent( 'testEvent' ) ).not.toThrow();
+	} );
+} );


### PR DESCRIPTION
Part of DOTCOM-15994

## Proposed Changes

* Add `invokeSurvicateEvent()` utility to `@automattic/survicate` package for firing Survicate events via `window._sva.invokeEvent()`
* Fire `purchaseCompleted` event after successful checkout in `checkout-thank-you`
* Fire `purchaseRefunded`, `purchaseCancelled`, and `purchaseRemoved` events in Dashboard cancel-purchase flow
* Fire `purchaseRefunded` / `purchaseCancelled` events in Classic Calypso cancel-purchase flow
* Fire `purchaseRemoved` event in Classic Calypso remove-purchase flow

## Why are these changes being made?

We want to trigger CES (Customer Effort Score) surveys after purchase, cancellation, and refund actions. The actual surveys are configured externally in Survicate — this PR sends the right events at the right moments so Survicate can display the surveys. Survicate is already loaded for English-locale desktop users.

## Testing Instructions

* Verify that `invokeSurvicateEvent` calls `window._sva.invokeEvent()` when available and returns `true`, or returns `false` gracefully when Survicate is not loaded.
* After a successful checkout, confirm `purchaseCompleted` event is fired on the thank-you page.
* After cancelling a purchase with refund, confirm `purchaseRefunded` event is fired (both Dashboard and Classic flows).
* After turning off auto-renew, confirm `purchaseCancelled` event is fired (both Dashboard and Classic flows).
* After removing an expired purchase, confirm `purchaseRemoved` event is fired (both Dashboard and Classic flows).
* Run `yarn test-packages packages/survicate` — all tests pass.


- Test 1: Cancel a plan and make sure the survey shows:

	<img width="1617" height="834" alt="image" src="https://github.com/user-attachments/assets/387d1a6c-972d-4557-a922-49c25ae9949b" />

- Test 2: Remove a plan and make sure the survey shows:

	<img width="1617" height="831" alt="image" src="https://github.com/user-attachments/assets/e914e657-3d2b-4024-b4f3-b22a6d9b7c36" />


- Teste 3: At MSD, cancel a plan and make sure the survey shows:

	<img width="1614" height="760" alt="image" src="https://github.com/user-attachments/assets/a37a056a-1f66-43dc-a7cd-59615ed5f005" />


- Test 4: At Calypso, purchase completed:

<img width="1294" height="729" alt="image" src="https://github.com/user-attachments/assets/389afd6d-f2f0-495a-8ff3-ac188291417a" />


### Event Summary

| Event | When | Files |
|---|---|---|
| `purchaseCompleted` | After successful checkout | `checkout-thank-you/index.tsx` |
| `purchaseCancelled` | After turning off auto-renew | Dashboard & Classic `cancel-purchase/index.tsx` |
| `purchaseRefunded` | After cancel-with-refund | Dashboard & Classic `cancel-purchase/index.tsx` |
| `purchaseRemoved` | After removing expired purchase | Dashboard `cancel-purchase/index.tsx`, Classic `remove-purchase/index.jsx` |

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?