### PR TITLE
TeamCity: Remove unused e2e Slack notification step

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -977,32 +977,6 @@ object PlaywrightTestPRMatrix : BuildType({
 		}
 	}
 
-	steps {
-		bashNodeScript {
-			name = "Upload report and send Slack notification"
-			executionMode = BuildStep.ExecutionMode.RUN_ONLY_ON_FAILURE
-			conditions {
-				matches("teamcity.build.branch", ".*e2e.*")
-			}
-			scriptContent = """
-				ARCHIVE_NAME="%build.counter%-%build.vcs.number%-%PROJECT%"
-				export E2E_SECRETS_KEY="%E2E_SECRETS_ENCRYPTION_KEY_CURRENT%"
-
-				# Need to use -C to avoid creation of an unnecessary top level directory.
-				tar cvfz - -C test/e2e/output/html . | openssl enc -aes-256-cbc -salt -out ${'$'}{ARCHIVE_NAME}.tgz.enc -pass env:E2E_SECRETS_KEY
-
-				aws configure set aws_access_key_id %CALYPSO_E2E_DASHBOARD_AWS_S3_ACCESS_KEY_ID%
-				aws configure set aws_secret_access_key %CALYPSO_E2E_DASHBOARD_AWS_S3_SECRET_ACCESS_KEY%
-
-				aws s3 cp ${'$'}{ARCHIVE_NAME}.tgz.enc %CALYPSO_E2E_DASHBOARD_AWS_S3_ROOT%/archive/
-
-				# Send custom Slack notification
-				REPORT_URL="https://automattic.github.io/wp-calypso-test-results/r"
-				echo "##teamcity[notification notifier='slack' message='Report available: ${'$'}{REPORT_URL}/${'$'}{ARCHIVE_NAME}.tgz.enc|nBranch: %teamcity.build.branch%' sendTo='calypso-e2e-reports-ext' connectionId='PROJECT_EXT_11']"
-			""".trimIndent()
-			dockerImage = "%docker_image_e2e%"
-		}
-	}
 })
 
 object PlaywrightTestPreReleaseMatrix : BuildType({


### PR DESCRIPTION
Remove the `PlaywrightTestPRMatrix` build step that uploaded encrypted HTML reports to S3 and sent Slack notifications to `#calypso-e2e-reports-ext`

Context:

- This was added in #105620 for an external contributor during the Jest-to-Playwright migration (DOTCOM-14356) and is no longer needed
- Test execution is unaffected — steps are inherited from `CalypsoE2ETestsBuildTemplate`