### PR TITLE
Revert "Dashboard: OAuth-aware auth for Woo hostnames"

### DIFF
--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -79,29 +79,10 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 		}
 
 		authErrorHandled.current = true;
-
-		if ( config.isEnabled( 'oauth' ) ) {
-			const redirectUri = new URL( '/api/oauth/token', window.location.origin );
-			redirectUri.search = new URLSearchParams( {
-				next: window.location.pathname + window.location.search,
-			} ).toString();
-
-			const authUri = new URL( 'https://public-api.wordpress.com/oauth2/authorize' );
-			authUri.search = new URLSearchParams( {
-				response_type: 'token',
-				client_id: String( config( 'oauth_client_id' ) ),
-				redirect_uri: redirectUri.toString(),
-				scope: 'global',
-				blog_id: '0',
-			} ).toString();
-
-			window.location.replace( authUri.toString() );
-			return;
-		}
-
 		const currentPath = window.location.href;
 		const path = config( 'wpcom_login_url' ) || '/log-in';
 		const loginUrl = `${ path }?redirect_to=${ encodeURIComponent( currentPath ) }`;
+
 		window.location.href = loginUrl;
 	}, [] );
 

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -30,35 +30,22 @@ import { serialize } from 'calypso/state/utils';
 const debug = debugFactory( 'calypso:server-render' );
 
 /**
- * Returns per-request clientData customized for the request hostname.
- * Overrides hostname when the request arrives on an allowed alternate
- * hostname, and applies any hostname-specific overrides (features, OAuth
- * client, login/logout URLs, etc.) from hostname_overrides config.
+ * Returns per-request clientData with hostname overridden when the request
+ * arrives on an allowed alternate hostname (e.g. behind a reverse proxy).
+ * When the request hostname is not in the allowlist, the clientData is
+ * returned unchanged — the configured default hostname is used.
+ * When no hostname_allowlist is configured, returns clientData as-is.
  */
 export function customizeClientDataForRequest( req, baseClientData ) {
+	const allowlist = config( 'hostname_allowlist' );
+	if ( ! Array.isArray( allowlist ) ) {
+		return baseClientData;
+	}
 	const reqHostname = req.hostname;
-	let clientData = baseClientData;
-
-	const hostnameAllowlist = config( 'hostname_allowlist' );
-	if (
-		Array.isArray( hostnameAllowlist ) &&
-		hostnameAllowlist.includes( reqHostname ) &&
-		reqHostname !== config( 'hostname' )
-	) {
-		clientData = { ...clientData, hostname: reqHostname };
+	if ( allowlist.includes( reqHostname ) && reqHostname !== config( 'hostname' ) ) {
+		return { ...baseClientData, hostname: reqHostname };
 	}
-
-	const hostnameOverrides = config( 'hostname_overrides' );
-	if ( typeof hostnameOverrides === 'object' && hostnameOverrides[ reqHostname ] ) {
-		const { features: overrideFeatures, ...overrideData } = hostnameOverrides[ reqHostname ];
-		clientData = {
-			...clientData,
-			...overrideData,
-			features: { ...clientData.features, ...overrideFeatures },
-		};
-	}
-
-	return clientData;
+	return baseClientData;
 }
 
 const HOUR_IN_MS = 3600000;

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -14,7 +14,6 @@
 	"survicate_enabled_at_help_center": true,
 	"hostname": false,
 	"hostname_allowlist": false,
-	"hostname_overrides": false,
 	"i18n_default_locale_slug": "en",
 	"lasagna_url": "wss://rt-api.wordpress.com/socket",
 	"login_url": false,

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -6,14 +6,6 @@
 	"survicate_enabled": true,
 	"hostname": "my.localhost",
 	"hostname_allowlist": [ "my.localhost", "my.woo.localhost" ],
-	"hostname_overrides": {
-		"my.woo.localhost": {
-			"oauth_client_id": 134404,
-			"wpcom_login_url": false,
-			"logout_url": "http://my.woo.localhost:3000",
-			"features": { "oauth": true }
-		}
-	},
 	"i18n_default_locale_slug": "en",
 	"port": 3000,
 	"wpcom_signup_id": "39911",

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -6,14 +6,6 @@
 	"survicate_enabled": true,
 	"hostname": "my.wordpress.com",
 	"hostname_allowlist": [ "my.wordpress.com", "my.woo.ai" ],
-	"hostname_overrides": {
-		"my.woo.ai": {
-			"oauth_client_id": 134405,
-			"wpcom_login_url": false,
-			"logout_url": "https://woo.com",
-			"features": { "oauth": true }
-		}
-	},
 	"i18n_default_locale_slug": "en",
 	"wpcom_signup_id": "39911",
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -6,14 +6,6 @@
 	"survicate_enabled": true,
 	"hostname": "my.wordpress.com",
 	"hostname_allowlist": [ "my.wordpress.com", "my.woo.ai" ],
-	"hostname_overrides": {
-		"my.woo.ai": {
-			"oauth_client_id": 134405,
-			"wpcom_login_url": false,
-			"logout_url": "https://woo.com",
-			"features": { "oauth": true }
-		}
-	},
 	"i18n_default_locale_slug": "en",
 	"wpcom_signup_id": "39911",
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -6,14 +6,6 @@
 	"survicate_enabled": true,
 	"hostname": "my.wordpress.com",
 	"hostname_allowlist": [ "my.wordpress.com", "my.woo.ai" ],
-	"hostname_overrides": {
-		"my.woo.ai": {
-			"oauth_client_id": 134405,
-			"wpcom_login_url": false,
-			"logout_url": "https://woo.com",
-			"features": { "oauth": true }
-		}
-	},
 	"i18n_default_locale_slug": "en",
 	"wpcom_signup_id": "39911",
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",

--- a/config/development.json
+++ b/config/development.json
@@ -6,14 +6,6 @@
 	"protocol": "http",
 	"hostname": "calypso.localhost",
 	"hostname_allowlist": [ "calypso.localhost", "my.localhost", "my.woo.localhost" ],
-	"hostname_overrides": {
-		"my.woo.localhost": {
-			"oauth_client_id": 134404,
-			"wpcom_login_url": "/connect",
-			"logout_url": "http://my.woo.localhost:3000",
-			"features": { "oauth": true }
-		}
-	},
 	"port": 3000,
 	"i18n_default_locale_slug": "en",
 	"siftscience_key": "e00e878351",


### PR DESCRIPTION
Reverts Automattic/wp-calypso#109038

When trying to auth with OAuth in `my.woo.ai` you get taken to `/api/oauth/token`

<img width="1992" height="354" alt="CleanShot 2026-03-06 at 14 59 40@2x" src="https://github.com/user-attachments/assets/127699ee-4291-4dca-a957-77ccb6cde094" />

But that's not routed correctly on this domain, so we're not quite ready yet.