### PR TITLE
A4A: Polish checkout notice summary typography and styles

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/notice-summary.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/notice-summary.tsx
@@ -3,6 +3,7 @@ import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
+import { preventWidows } from 'calypso/lib/formatting';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
@@ -128,7 +129,7 @@ export default function NoticeSummary( { type }: Props ) {
 			{ title && <h3>{ title }</h3> }
 			{ items.map( ( item, index ) => (
 				<div key={ `notice-item-${ index }` } className="checkout__summary-notice-item">
-					{ item }
+					{ preventWidows( item ) }
 				</div>
 			) ) }
 		</div>

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style-v1.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style-v1.scss
@@ -189,7 +189,7 @@
 	}
 
 	h3 {
-		margin-block: 24px;
+		margin-block: 24px 8px;
 		@include heading-large;
 		color: var( --color-neutral-70 );
 	}

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -130,7 +130,7 @@
 
 	.components-button.is-primary:disabled {
 		&:hover {
-			background-color: var(--color-accent-5);
+			background-color: var(--color-primary-50);
 		}
 	}
 


### PR DESCRIPTION
Context p1772615286921659/1772609235.630789-slack-C0A34L1Q7J9

## Proposed Changes

- **Notice summary typography:** Use `preventWidows()` on checkout notice summary items so single words don’t sit alone on the last line.
- **Checkout summary spacing:** Reduce the bottom margin of the notice summary `h3` from 24px to 8px for tighter spacing between the title and the list.
- **Disabled primary button:** Use `--color-primary-50` for the disabled primary button hover background in A4A (replacing `--color-accent-5`) for consistent design tokens.

## Why are these changes being made?

- Improves readability of the checkout notice summary with better typography (no widows).
- Aligns notice summary spacing with the intended design.
- Aligns disabled primary button styling with the correct design token in the A4A stylesheet.

## Testing Instructions

1. Go to A4A → Marketplace and proceed to checkout.
2. On the checkout summary/notice step, confirm notice list items don’t show single words on the last line (preventWidows).
3. Confirm the heading above the notice list has reduced space below it (8px).
4. Find a primary button (Send to client) in a disabled state and hover; confirm the hover background uses the primary-50 token (no visual regression).

<img width="471" height="515" alt="Screenshot 2026-03-06 at 10 53 04 AM" src="https://github.com/user-attachments/assets/1507173a-dee1-488a-ade1-aee27210fac8" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?