### PR TITLE
A4A: A4A-2205 remove co-branded referrals flag gating

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { FormLabel, Tooltip } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
@@ -90,8 +89,6 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 		logoUrl: string;
 	} | null >( null );
 
-	const isCobrandedCheckoutEnabled = isEnabled( 'a4a-referral-cobranded-checkout' );
-
 	const ctaButtonRef = useRef< HTMLButtonElement >( null );
 
 	const [ showVerifyAccountToolip, setShowVerifyAccountToolip ] = useState( false );
@@ -125,10 +122,7 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 	const hasCompletedForm = !! email && !! message;
 	// Disable Send/Copy when "Use a different logo" is selected but no logo is uploaded
 	const isDifferentLogoWithoutUpload =
-		isCobrandedCheckoutEnabled &&
-		referralLogo.option === 'different' &&
-		! referralLogo.file &&
-		! referralLogo.logoUrl;
+		referralLogo.option === 'different' && ! referralLogo.file && ! referralLogo.logoUrl;
 	const hasPressableAddonsInCheckout = useMemo(
 		() => checkoutItems.some( ( item ) => isPressableAddonProduct( item.slug ) ),
 		[ checkoutItems ]
@@ -152,10 +146,6 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 	const buildLogoPayload = useCallback( async (): Promise<
 		{ type: 'profile' | 'custom' | 'none'; url?: string } | undefined | 'error'
 	> => {
-		if ( ! isCobrandedCheckoutEnabled ) {
-			return undefined;
-		}
-
 		let logo: { type: 'profile' | 'custom' | 'none'; url?: string } | undefined;
 
 		if ( referralLogo.option === 'profile' ) {
@@ -214,7 +204,6 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 	}, [
 		agencyId,
 		dispatch,
-		isCobrandedCheckoutEnabled,
 		lastUploadedFile,
 		referralLogo.file,
 		referralLogo.logoUrl,
@@ -279,9 +268,7 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 						: 'calypso_a4a_marketplace_referral_checkout_request_payment_copy_click',
 					{
 						term_pricing: termPricing,
-						...( isCobrandedCheckoutEnabled && referralLogo.option
-							? { logo_type: referralLogo.option }
-							: {} ),
+						...( referralLogo.option ? { logo_type: referralLogo.option } : {} ),
 					}
 				)
 			);
@@ -361,7 +348,6 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 			hasPressableAddonsInCheckout,
 			dispatch,
 			termPricing,
-			isCobrandedCheckoutEnabled,
 			referralLogo.option,
 			buildLogoPayload,
 			requestPayment,
@@ -412,7 +398,7 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 						}
 					/>
 				</FormFieldset>
-				{ isCobrandedCheckoutEnabled && <ReferralLogo onChange={ onReferralLogoChange } /> }
+				<ReferralLogo onChange={ onReferralLogoChange } />
 			</div>
 
 			<NoticeSummary type="request-client-payment" />
@@ -468,19 +454,17 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 						) }
 					</Tooltip>
 				</div>
-				{ isCobrandedCheckoutEnabled && (
-					<Button
-						variant="link"
-						onClick={ async () => {
-							dispatch( recordTracksEvent( 'calypso_a4a_client_referral_email_preview_click' ) );
-							const logoUrlForPreview = await getLogoUrlForPreview( referralLogo, profileLogoUrl );
-							setPreviewLogoUrl( logoUrlForPreview );
-							setIsPreviewOpen( true );
-						} }
-					>
-						{ translate( 'Preview referral email' ) }
-					</Button>
-				) }
+				<Button
+					variant="link"
+					onClick={ async () => {
+						dispatch( recordTracksEvent( 'calypso_a4a_client_referral_email_preview_click' ) );
+						const logoUrlForPreview = await getLogoUrlForPreview( referralLogo, profileLogoUrl );
+						setPreviewLogoUrl( logoUrlForPreview );
+						setIsPreviewOpen( true );
+					} }
+				>
+					{ translate( 'Preview referral email' ) }
+				</Button>
 			</VStack>
 
 			<ReferralEmailPreviewModal

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -41,7 +41,6 @@
 		"a4a-partner-directory": false,
 		"a4a-pressable-referrals": true,
 		"a4a-pressable-premium-plans": true,
-		"a4a-referral-cobranded-checkout": true,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": true,
 		"a4a-signup-v2-via-email": false,

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -34,7 +34,6 @@
 		"a4a-partner-directory": false,
 		"a4a-pressable-referrals": true,
 		"a4a-pressable-premium-plans": true,
-		"a4a-referral-cobranded-checkout": true,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": true,
 		"a4a-signup-v2-via-email": false,

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -34,7 +34,6 @@
 		"a4a-partner-directory": false,
 		"a4a-pressable-referrals": true,
 		"a4a-pressable-premium-plans": true,
-		"a4a-referral-cobranded-checkout": true,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": true,
 		"a4a-signup-v2-via-email": false,

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -36,7 +36,6 @@
 		"a4a-partner-directory": false,
 		"a4a-pressable-referrals": true,
 		"a4a-pressable-premium-plans": true,
-		"a4a-referral-cobranded-checkout": true,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": true,
 		"a4a-signup-v2-via-email": false,


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-2205/co-branded-referrals-remove-all-the-feature-flags-and-logic-behind-it

## Proposed Changes

- Remove the `a4a-referral-cobranded-checkout` feature flag from A4A config.
- Remove flag branching and make co-branded referral checkout logo selection + email preview always available.

## Why are these changes being made?

- Co-branded referrals are no longer gated, so the flag and conditional logic can be removed to reduce complexity and avoid drift between code paths.

## Testing Instructions

- Navigate to A4A → Marketplace → checkout → “Request client payment”.
- Verify the logo selection UI is present.
- Verify “Preview referral email” is available and opens the preview.
- Select “Use a different logo” and confirm Send/Copy are disabled until a logo is uploaded/provided.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?