### PR TITLE
Reader: Improve display of posts having no title

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -42,7 +42,7 @@ import {
 	recordTrackForPost,
 	recordPermalinkClick,
 } from 'calypso/reader/stats';
-import { showSelectedPost } from 'calypso/reader/utils';
+import { getPostTitleFallback, showSelectedPost } from 'calypso/reader/utils';
 import { requestPostComments } from 'calypso/state/comments/actions';
 import { isCommentsApiDisabled } from 'calypso/state/comments/selectors/get-comments-api-disabled';
 import { like as likePost, unlike as unlikePost } from 'calypso/state/posts/likes/actions';
@@ -759,7 +759,9 @@ export class FullPostView extends Component {
 					{ ! post || post._state === 'pending' ? (
 						<DocumentHead title={ translate( 'Loading' ) } />
 					) : (
-						<DocumentHead title={ `${ post.title } ‹ ${ siteName } ‹ Reader` } />
+						<DocumentHead
+							title={ `${ post.title || getPostTitleFallback( post ) } ‹ ${ siteName } ‹ Reader` }
+						/>
 					) }
 					{ post && post.feed_ID && <QueryReaderFeed feedId={ +post.feed_ID } /> }
 					{ post && ! post.is_external && post.site_ID && (

--- a/client/blocks/reader-full-post/post-navigation.scss
+++ b/client/blocks/reader-full-post/post-navigation.scss
@@ -11,12 +11,12 @@
 	display: flex;
 	text-decoration: none;
 	color: var( --color-text );
-	padding: 8px;
+	padding: 8px 0;
 	transition: opacity 0.2s ease-in-out;
 	background: none;
 	border: none;
 	border-radius: 4px;
-	max-width: 50%;
+	max-width: 40%;
 	height: auto;
 	justify-content: flex-start;
 

--- a/client/blocks/reader-full-post/post-navigation.tsx
+++ b/client/blocks/reader-full-post/post-navigation.tsx
@@ -1,3 +1,4 @@
+import './post-navigation.scss';
 import {
 	__experimentalDivider as Divider,
 	__experimentalHStack as HStack,
@@ -7,8 +8,7 @@ import {
 import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-
-import './post-navigation.scss';
+import { getPostTitleFallback } from 'calypso/reader/utils';
 
 interface PostKey {
 	feedId?: number;
@@ -17,7 +17,9 @@ interface PostKey {
 }
 
 interface Post {
-	title?: string;
+	title: string;
+	excerpt: string;
+	content: string;
 }
 
 interface NavigationButtonProps {
@@ -79,7 +81,7 @@ const NavigationButton = ( { direction, post, postKey, onNavigate }: NavigationB
 				>
 					<span className="reader-full-post-navigation__link-label">{ label }</span>
 					<Text className="reader-full-post-navigation__link-title" truncate numberOfLines={ 2 }>
-						{ post?.title || translate( 'Loading…' ) }
+						{ post ? post?.title || getPostTitleFallback( post ) : translate( 'Loading…' ) }
 					</Text>
 				</VStack>
 				{ isNext && <Icon icon={ icon } size={ 18 } /> }

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -56,7 +56,7 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 		type: 'list',
 		search: '',
 		fields: [],
-		perPage: 10,
+		perPage: 15,
 		page: 1,
 		titleField: 'post',
 		mediaField: 'icon',
@@ -248,6 +248,7 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 				</div>
 				<aside className="recent-feed__list-column-content">
 					<DataViews< ReaderPost | PaddingItem >
+						config={ { perPageSizes: [ 15, 30, 50, 100 ] } }
 						getItemId={ ( item: ReaderPost | PaddingItem, index = 0 ) =>
 							item.postId?.toString() ?? `item-${ index }`
 						}

--- a/client/reader/recent/recent-post-field.tsx
+++ b/client/reader/recent/recent-post-field.tsx
@@ -1,10 +1,16 @@
 import { forwardRef } from 'react';
 import ReaderFeaturedImage from 'calypso/blocks/reader-featured-image';
 import AutoDirection from 'calypso/components/auto-direction';
-import type { PostItem } from './types';
+import { getPostTitleFallback } from 'calypso/reader/utils';
 
 interface RecentPostFieldProps {
-	post: PostItem;
+	post: {
+		title: string;
+		excerpt: string;
+		content: string;
+		featured_image: string;
+		site_name: string;
+	};
 }
 
 const RecentPostField = forwardRef< HTMLDivElement, RecentPostFieldProps >( ( { post }, ref ) => {
@@ -16,7 +22,9 @@ const RecentPostField = forwardRef< HTMLDivElement, RecentPostFieldProps >( ( { 
 		<div className="recent-post-field" ref={ ref } role="button" tabIndex={ 0 }>
 			<AutoDirection>
 				<div className="recent-post-field__title">
-					<div className="recent-post-field__title-text">{ post?.title }</div>
+					<div className="recent-post-field__title-text">
+						{ post?.title || getPostTitleFallback( post ) }
+					</div>
 					<div className="recent-post-field__site-name">{ post?.site_name }</div>
 				</div>
 			</AutoDirection>

--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -199,13 +199,6 @@ body.is-reader-full-post {
 		display: none;
 		overflow-y: auto;
 		height: 100%;
-		scrollbar-width: thin;
-		scrollbar-gutter: stable both-edges;
-		scrollbar-color: transparent transparent;
-
-		&:hover {
-			scrollbar-color: #949494 transparent;
-		}
 
 		&.overlay {
 			display: block;

--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -108,6 +108,7 @@ body.is-reader-full-post {
 
 			.dataviews-view-list__field-wrapper {
 				min-width: 0;
+				min-height: 35px;
 			}
 
 			div[role='row'] {
@@ -140,6 +141,7 @@ body.is-reader-full-post {
 					width: 24px;
 					height: 24px;
 					background-color: transparent;
+					top: 2px;
 
 					&::after {
 						box-shadow: none;
@@ -192,11 +194,18 @@ body.is-reader-full-post {
 		}
 	}
 
-	&__post-column {
+	.recent-feed__post-column {
 		@extend %column-shared;
 		display: none;
 		overflow-y: auto;
 		height: 100%;
+		scrollbar-width: thin;
+		scrollbar-gutter: stable both-edges;
+		scrollbar-color: transparent transparent;
+
+		&:hover {
+			scrollbar-color: #949494 transparent;
+		}
 
 		&.overlay {
 			display: block;
@@ -204,7 +213,7 @@ body.is-reader-full-post {
 
 		&-engagement-bar {
 			position: fixed;
-			bottom: calc(var( --content-padding-bottom ) - 1px);
+			bottom: calc( var( --content-padding-bottom ) - 1px );
 			height: 60px;
 			background: var( --color-surface );
 			border-radius: 0 0 $feed-card-border-radius $feed-card-border-radius;

--- a/client/reader/test/utils.ts
+++ b/client/reader/test/utils.ts
@@ -2,7 +2,12 @@ import page from '@automattic/calypso-router';
 import { AppState } from 'calypso/types';
 import { FRESHLY_PRESSED_TAB } from '../discover/helper';
 import { DISCOVER_PREFIX } from '../discover/routes';
-import { getSafeImageUrlForReader, showSelectedPost, getCurrentTabFromURL } from '../utils';
+import {
+	getSafeImageUrlForReader,
+	showSelectedPost,
+	getCurrentTabFromURL,
+	getPostTitleFallback,
+} from '../utils';
 
 jest.mock( '@automattic/calypso-router', () => jest.fn() );
 
@@ -78,6 +83,59 @@ describe( 'reader utils', () => {
 			expect( getCurrentTabFromURL( '/discover', DISCOVER_PREFIX, 'my-default-tab' ) ).toEqual(
 				'my-default-tab'
 			);
+		} );
+	} );
+
+	describe( 'getPostTitleFallback', () => {
+		it( 'returns the post title when it exists', () => {
+			const post = { title: 'My Post Title', excerpt: 'Some excerpt', content: 'Some content' };
+			expect( getPostTitleFallback( post ) ).toEqual( 'My Post Title' );
+		} );
+
+		it( 'returns truncated excerpt when title is empty', () => {
+			const post = {
+				title: '',
+				excerpt:
+					'This is a very long excerpt that should be truncated because it exceeds the maximum length allowed',
+				content: 'Some content',
+			};
+
+			const result = getPostTitleFallback( post );
+			expect( result.length ).toBeLessThanOrEqual( 60 );
+		} );
+
+		it( 'returns truncated content when title and excerpt are empty', () => {
+			const post = {
+				title: '',
+				excerpt: '',
+				content:
+					'This is a very long content that should be truncated because it exceeds the maximum length allowed',
+			};
+			const result = getPostTitleFallback( post );
+			expect( result.length ).toBeLessThanOrEqual( 60 );
+		} );
+
+		it( 'strips HTML tags from excerpt', () => {
+			const post = {
+				title: '',
+				excerpt: '<p>This is <strong>formatted</strong> text</p>',
+				content: '',
+			};
+			expect( getPostTitleFallback( post ) ).toEqual( 'This is formatted text' );
+		} );
+
+		it( 'strips HTML tags from content', () => {
+			const post = {
+				title: '',
+				excerpt: '',
+				content: '<div><img src="photo.jpg" /><p>Content after image</p></div>',
+			};
+			expect( getPostTitleFallback( post ) ).toEqual( 'Content after image' );
+		} );
+
+		it( 'returns fallback value when title, excerpt, and content are empty', () => {
+			const post = { title: '', excerpt: '', content: '' };
+			expect( getPostTitleFallback( post, 'Untitled Post' ) ).toEqual( 'Untitled Post' );
 		} );
 	} );
 } );

--- a/client/reader/utils.ts
+++ b/client/reader/utils.ts
@@ -3,7 +3,9 @@ import page from '@automattic/calypso-router';
 import { safeImageUrl, getUrlParts } from '@automattic/calypso-url';
 import { removeLocaleFromPathLocaleInFront } from '@automattic/i18n-utils';
 import { addQueryArgs, getQueryArgs, removeQueryArgs } from '@wordpress/url';
+import { truncate } from 'lodash';
 import { Dispatch } from 'redux';
+import { stripHTML } from 'calypso/lib/formatting/strip-html';
 import XPostHelper, { isXPost } from 'calypso/reader/xpost-helper';
 import { getPostByKey } from 'calypso/state/reader/posts/selectors';
 import { AppState } from 'calypso/types';
@@ -183,4 +185,22 @@ export function getCurrentTabFromURL(
 	}
 
 	return path.replace( /^\//, '' );
+}
+
+export function getPostTitleFallback(
+	post: {
+		title: string;
+		excerpt: string;
+		content: string;
+	},
+	fallbackValue: string = ''
+): string {
+	if ( post.title ) {
+		return post.title;
+	}
+
+	const plainContent = stripHTML( post.excerpt || post.content ); // Get plain text without HTML tags.
+	const derivedTitle = truncate( plainContent, { length: 60, separator: /,? +/ } ).trim();
+
+	return derivedTitle || fallbackValue;
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes: [READ-301](https://linear.app/a8c/issue/READ-301)

## Proposed Changes

- On "Full Post" layout, improve view of posts having no title.
- On Full Post view improve view of navigation items for posts having no title.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Posts without title weren't looking good in some views.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Subscribe "reader/feeds/9730918" as this have lot of posts without title.
1. Verify that the feed posts are looking good in both "Full Post" and "Recent" layout.
1. Verify that the navigation items below the full post view isn't showing `Loading...` text even when the data is loaded.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
