### PR TITLE
ARC-1570: Persist CIAB branding across session navigation

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -31,7 +31,7 @@ import {
 	isGravatarOAuth2Client,
 	isGravPoweredOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
-import { getPartnerAllowedSocialServices } from 'calypso/lib/partner-branding';
+import { getEffectivePartnerAllowedSocialServices } from 'calypso/lib/partner-branding';
 import { login } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -981,9 +981,9 @@ export default connect(
 			oauth2Client,
 			isFromAutomatticForAgenciesPlugin:
 				'automattic-for-agencies-client' === get( getCurrentQueryArguments( state ), 'from' ),
-			allowedSocialServices: getPartnerAllowedSocialServices(
-				get( getCurrentQueryArguments( state ), 'from' ) ||
-					get( getInitialQueryArguments( state ), 'from' )
+			allowedSocialServices: getEffectivePartnerAllowedSocialServices(
+				get( getCurrentQueryArguments( state ), 'from' ),
+				get( getInitialQueryArguments( state ), 'from' )
 			),
 			isWooJPC: isWooJPCFlow( state ),
 			isWoo: getIsWoo( state ),

--- a/client/lib/partner-branding.tsx
+++ b/client/lib/partner-branding.tsx
@@ -76,25 +76,96 @@ export const CIAB_PARTNERS: Record< string, CiabPartnerConfig > = {
 	},
 };
 
+const CIAB_PARTNER_SESSION_KEY = 'calypso.ciab.partner-id';
+
+function getFirstFromValue( from: string | string[] | undefined ): string | undefined {
+	if ( Array.isArray( from ) ) {
+		return from[ 0 ];
+	}
+
+	return from;
+}
+
+function getSessionStorage(): Storage | null {
+	if ( typeof window === 'undefined' ) {
+		return null;
+	}
+
+	try {
+		return window.sessionStorage;
+	} catch {
+		return null;
+	}
+}
+
+export function readPersistedCiabPartnerId(): string | null {
+	const sessionStorage = getSessionStorage();
+
+	if ( ! sessionStorage ) {
+		return null;
+	}
+
+	try {
+		return sessionStorage.getItem( CIAB_PARTNER_SESSION_KEY );
+	} catch {
+		return null;
+	}
+}
+
+export function persistCiabPartnerId( partnerId: string ): void {
+	const sessionStorage = getSessionStorage();
+
+	if ( ! sessionStorage || ! partnerId ) {
+		return;
+	}
+
+	try {
+		sessionStorage.setItem( CIAB_PARTNER_SESSION_KEY, partnerId );
+	} catch {
+		// Ignore storage write failures.
+	}
+}
+
+export function clearPersistedCiabPartnerId(): void {
+	const sessionStorage = getSessionStorage();
+
+	if ( ! sessionStorage ) {
+		return;
+	}
+
+	try {
+		sessionStorage.removeItem( CIAB_PARTNER_SESSION_KEY );
+	} catch {
+		// Ignore storage clear failures.
+	}
+}
+
 /**
  * Get CIAB partner config from garden info
  * Maps garden partner/name combinations to CIAB branding configs
  */
 export function getCiabConfigFromGarden(
 	gardenPartner?: string,
-	gardenName?: string
+	gardenName?: string,
+	options: { persistToSession?: boolean } = {}
 ): CiabPartnerConfig | null {
 	if ( ! gardenPartner || ! gardenName ) {
 		return null;
 	}
 
+	let ciabConfig: CiabPartnerConfig | null = null;
+
 	// Map garden partners to branding configs
 	if ( gardenPartner === 'woo' && gardenName === 'commerce' ) {
-		return CIAB_PARTNERS.woo ?? null;
+		ciabConfig = CIAB_PARTNERS.woo ?? null;
+	}
+
+	if ( ciabConfig && options.persistToSession ) {
+		persistCiabPartnerId( ciabConfig.id );
 	}
 
 	// Future: add mappings for other partners like "paypal"
-	return null;
+	return ciabConfig;
 }
 
 /**
@@ -102,7 +173,7 @@ export function getCiabConfigFromGarden(
  * Returns the full partner config or null if not a CIAB partner
  */
 export function getCiabConfig( from: string | string[] | undefined ): CiabPartnerConfig | null {
-	const fromValue = Array.isArray( from ) ? from[ 0 ] : from;
+	const fromValue = getFirstFromValue( from );
 
 	if ( fromValue && CIAB_PARTNERS[ fromValue ] ) {
 		const partnerConfig = CIAB_PARTNERS[ fromValue ];
@@ -115,6 +186,47 @@ export function getCiabConfig( from: string | string[] | undefined ): CiabPartne
 	return null;
 }
 
+export function getEffectiveCiabConfig(
+	currentFrom: string | string[] | undefined,
+	initialFrom: string | string[] | undefined = undefined
+): CiabPartnerConfig | null {
+	const currentFromValue = getFirstFromValue( currentFrom );
+
+	if ( currentFromValue !== undefined ) {
+		const currentCiabConfig = getCiabConfig( currentFromValue );
+
+		if ( currentCiabConfig ) {
+			persistCiabPartnerId( currentCiabConfig.id );
+			return currentCiabConfig;
+		}
+
+		clearPersistedCiabPartnerId();
+		return null;
+	}
+
+	const initialCiabConfig = getCiabConfig( initialFrom );
+
+	if ( initialCiabConfig ) {
+		persistCiabPartnerId( initialCiabConfig.id );
+		return initialCiabConfig;
+	}
+
+	const persistedPartnerId = readPersistedCiabPartnerId();
+
+	if ( ! persistedPartnerId ) {
+		return null;
+	}
+
+	const persistedCiabConfig = getCiabConfig( persistedPartnerId );
+
+	if ( ! persistedCiabConfig ) {
+		clearPersistedCiabPartnerId();
+		return null;
+	}
+
+	return persistedCiabConfig;
+}
+
 /**
  * Get allowed social services for a partner from URL 'from' param
  * Returns the array of allowed SSO providers or null if no restrictions apply
@@ -125,6 +237,15 @@ export function getPartnerAllowedSocialServices(
 	from: string | string[] | undefined
 ): AllowedSocialService[] | null {
 	const ciabConfig = getCiabConfig( from );
+	return ciabConfig?.ssoProviders ?? null;
+}
+
+export function getEffectivePartnerAllowedSocialServices(
+	currentFrom: string | string[] | undefined,
+	initialFrom: string | string[] | undefined = undefined
+): AllowedSocialService[] | null {
+	const ciabConfig = getEffectiveCiabConfig( currentFrom, initialFrom );
+
 	return ciabConfig?.ssoProviders ?? null;
 }
 
@@ -162,15 +283,11 @@ export interface UsePartnerBrandingResult {
  */
 export function usePartnerBranding(): UsePartnerBrandingResult {
 	const translate = useTranslate();
-	const from = useSelector( ( state ) => {
-		const fromCurrent = get( getCurrentQueryArguments( state ), 'from' );
-		const fromInitial = get( getInitialQueryArguments( state ), 'from' );
-
-		return fromCurrent || fromInitial;
-	} );
+	const fromCurrent = useSelector( ( state ) => get( getCurrentQueryArguments( state ), 'from' ) );
+	const fromInitial = useSelector( ( state ) => get( getInitialQueryArguments( state ), 'from' ) );
 
 	return useMemo( () => {
-		const ciabConfig = getCiabConfig( from );
+		const ciabConfig = getEffectiveCiabConfig( fromCurrent, fromInitial );
 		const hasCustomBranding = ciabConfig !== null;
 
 		// Build logo element for TopBar
@@ -194,7 +311,7 @@ export function usePartnerBranding(): UsePartnerBrandingResult {
 			topBarLogo,
 			signupTosElement,
 		};
-	}, [ from, translate ] );
+	}, [ fromCurrent, fromInitial, translate ] );
 }
 
 /**

--- a/client/lib/test/partner-branding.tsx
+++ b/client/lib/test/partner-branding.tsx
@@ -1,28 +1,45 @@
 /**
  * @jest-environment jsdom
  */
+import config from '@automattic/calypso-config';
 import {
 	CIAB_PARTNERS,
+	clearPersistedCiabPartnerId,
+	getEffectiveCiabConfig,
+	getEffectivePartnerAllowedSocialServices,
 	getCiabConfig,
 	getCiabConfigFromGarden,
 	getPartnerAllowedSocialServices,
 	getPartnerSignupTosElement,
+	persistCiabPartnerId,
+	readPersistedCiabPartnerId,
 } from '../partner-branding';
 import type { useTranslate } from 'i18n-calypso';
 
 // Mock the config module
 jest.mock( '@automattic/calypso-config', () => {
 	const config = () => null;
-	config.isEnabled = ( feature: string ) => {
+	config.isEnabled = jest.fn( ( feature: string ) => {
 		if ( feature === 'ciab/custom-branding' ) {
 			return true;
 		}
 		return false;
-	};
+	} );
 	return config;
 } );
 
 describe( 'partner-branding', () => {
+	beforeEach( () => {
+		clearPersistedCiabPartnerId();
+		( config.isEnabled as jest.Mock ).mockImplementation( ( feature: string ) => {
+			if ( feature === 'ciab/custom-branding' ) {
+				return true;
+			}
+
+			return false;
+		} );
+	} );
+
 	describe( 'getCiabConfig', () => {
 		test( 'returns partner config when from param matches a valid partner', () => {
 			const config = getCiabConfig( 'woo' );
@@ -83,6 +100,62 @@ describe( 'partner-branding', () => {
 			const config = getCiabConfigFromGarden( 'woo', 'unknown' );
 
 			expect( config ).toBeNull();
+		} );
+
+		test( 'persists partner id when requested', () => {
+			getCiabConfigFromGarden( 'woo', 'commerce', { persistToSession: true } );
+
+			expect( readPersistedCiabPartnerId() ).toBe( 'woo' );
+		} );
+	} );
+
+	describe( 'session persistence', () => {
+		test( 'persists and reads partner id', () => {
+			persistCiabPartnerId( 'woo' );
+
+			expect( readPersistedCiabPartnerId() ).toBe( 'woo' );
+		} );
+
+		test( 'uses current from when present and persists it', () => {
+			const config = getEffectiveCiabConfig( 'woo', undefined );
+
+			expect( config?.id ).toBe( 'woo' );
+			expect( readPersistedCiabPartnerId() ).toBe( 'woo' );
+		} );
+
+		test( 'uses persisted partner when from params are missing', () => {
+			persistCiabPartnerId( 'woo' );
+
+			const config = getEffectiveCiabConfig( undefined, undefined );
+
+			expect( config?.id ).toBe( 'woo' );
+		} );
+
+		test( 'clears persisted partner when current from is invalid', () => {
+			persistCiabPartnerId( 'woo' );
+
+			const config = getEffectiveCiabConfig( 'unknown', undefined );
+
+			expect( config ).toBeNull();
+			expect( readPersistedCiabPartnerId() ).toBeNull();
+		} );
+
+		test( 'clears persisted partner when feature flag is disabled', () => {
+			persistCiabPartnerId( 'woo' );
+			( config.isEnabled as jest.Mock ).mockReturnValue( false );
+
+			const effectiveConfig = getEffectiveCiabConfig( undefined, undefined );
+
+			expect( effectiveConfig ).toBeNull();
+			expect( readPersistedCiabPartnerId() ).toBeNull();
+		} );
+
+		test( 'returns social services from persisted partner', () => {
+			persistCiabPartnerId( 'woo' );
+
+			const services = getEffectivePartnerAllowedSocialServices( undefined, undefined );
+
+			expect( services ).toEqual( CIAB_PARTNERS.woo.ssoProviders );
 		} );
 	} );
 

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -15,7 +15,7 @@ import {
 	isIosOAuth2Client,
 	isStudioAppOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
-import { getCiabConfig, getPartnerSignupTosElement } from 'calypso/lib/partner-branding';
+import { getEffectiveCiabConfig, getPartnerSignupTosElement } from 'calypso/lib/partner-branding';
 import { login } from 'calypso/lib/paths';
 import OneLoginFooter from 'calypso/login/wp-login/components/one-login-footer';
 import OneLoginLayout from 'calypso/login/wp-login/components/one-login-layout';
@@ -396,7 +396,7 @@ const mapState = ( state ) => {
 			'jetpack-onboarding',
 		isWooJPC: isWooJPCFlow( state ),
 		publicToken: getMagicLoginPublicToken( state ),
-		ciabConfig: getCiabConfig( currentQuery.from || initialQuery.from ),
+		ciabConfig: getEffectiveCiabConfig( currentQuery.from, initialQuery.from ),
 	};
 };
 

--- a/client/login/magic-login/test/index.test.jsx
+++ b/client/login/magic-login/test/index.test.jsx
@@ -4,7 +4,7 @@ import { getPartnerSignupTosElement } from 'calypso/lib/partner-branding';
 import { getMagicLoginInitialHeaders, MagicLogin } from '../index';
 
 jest.mock( 'calypso/lib/partner-branding', () => ( {
-	getCiabConfig: jest.fn(),
+	getEffectiveCiabConfig: jest.fn(),
 	getPartnerSignupTosElement: jest.fn(),
 } ) );
 

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -21,7 +21,7 @@ import {
 	isCrowdsignalOAuth2Client,
 	isVIPOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
-import { getCiabConfig } from 'calypso/lib/partner-branding';
+import { getEffectiveCiabConfig } from 'calypso/lib/partner-branding';
 import isPassportRedirect from 'calypso/lib/passport/is-passport-redirect';
 import { login } from 'calypso/lib/paths';
 import { getHeaderText } from 'calypso/login/wp-login/hooks/get-header-text';
@@ -494,9 +494,9 @@ export default connect(
 				'automattic-for-agencies-client' === get( getCurrentQueryArguments( state ), 'from' ) ||
 				'automattic-for-agencies-client' ===
 					new URLSearchParams( getRedirectToOriginal( state )?.split( '?' )[ 1 ] ).get( 'from' ),
-			ciabConfig: getCiabConfig(
-				get( getCurrentQueryArguments( state ), 'from' ) ||
-					get( getInitialQueryArguments( state ), 'from' )
+			ciabConfig: getEffectiveCiabConfig(
+				get( getCurrentQueryArguments( state ), 'from' ),
+				get( getInitialQueryArguments( state ), 'from' )
 			),
 			isManualRenewalImmediateLoginAttempt: wasManualRenewalImmediateLoginAttempted( state ),
 			isUserLoggedIn: isUserLoggedIn( state ),

--- a/client/my-sites/invites-unified/screens/accept-invite-screen.tsx
+++ b/client/my-sites/invites-unified/screens/accept-invite-screen.tsx
@@ -55,7 +55,9 @@ function getBrandingFromBlogDetails( blogDetails?: InviteBlogDetails ): CiabPart
 		return null;
 	}
 
-	return getCiabConfigFromGarden( blogDetails.garden.partner, blogDetails.garden.name );
+	return getCiabConfigFromGarden( blogDetails.garden.partner, blogDetails.garden.name, {
+		persistToSession: true,
+	} );
 }
 
 interface AcceptInviteScreenProps {

--- a/client/my-sites/invites-unified/screens/already-member-screen.tsx
+++ b/client/my-sites/invites-unified/screens/already-member-screen.tsx
@@ -58,7 +58,9 @@ export function AlreadyMemberScreen( { blogDetails }: AlreadyMemberScreenProps )
 	};
 
 	const branding = blogDetails?.garden
-		? getCiabConfigFromGarden( blogDetails.garden.partner, blogDetails.garden.name )
+		? getCiabConfigFromGarden( blogDetails.garden.partner, blogDetails.garden.name, {
+				persistToSession: true,
+		  } )
 		: null;
 
 	const topBarLogoConfig = branding?.compactLogo ?? branding?.logo;

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -139,7 +139,7 @@ class InviteAcceptLoggedOut extends Component {
 		const gardenName = site?.garden?.name;
 		const gardenPartner = site?.garden?.partner;
 
-		return getCiabConfigFromGarden( gardenPartner, gardenName );
+		return getCiabConfigFromGarden( gardenPartner, gardenName, { persistToSession: true } );
 	};
 
 	loginUser = () => {

--- a/client/my-sites/invites/test/invite-accept-logged-out.jsx
+++ b/client/my-sites/invites/test/invite-accept-logged-out.jsx
@@ -122,7 +122,9 @@ describe( 'InviteAcceptLoggedOut branding', () => {
 			</Provider>
 		);
 
-		expect( mockGetCiabConfigFromGarden ).toHaveBeenCalledWith( 'woo', 'commerce' );
+		expect( mockGetCiabConfigFromGarden ).toHaveBeenCalledWith( 'woo', 'commerce', {
+			persistToSession: true,
+		} );
 		expect( screen.getByRole( 'img', { name: 'Woo' } ) ).toBeVisible();
 		expect( screen.getByTestId( 'body-section-css-class' ) ).toHaveTextContent(
 			'is-ciab-font-system'
@@ -140,7 +142,9 @@ describe( 'InviteAcceptLoggedOut branding', () => {
 			</Provider>
 		);
 
-		expect( mockGetCiabConfigFromGarden ).toHaveBeenCalledWith( 'woo', 'enterprise' );
+		expect( mockGetCiabConfigFromGarden ).toHaveBeenCalledWith( 'woo', 'enterprise', {
+			persistToSession: true,
+		} );
 		expect( screen.queryByRole( 'img', { name: 'Woo' } ) ).not.toBeInTheDocument();
 		expect( document.querySelector( '.logged-out-wp-logo' )?.tagName.toLowerCase() ).toBe( 'svg' );
 		expect( screen.getByTestId( 'body-section-css-class' ) ).toHaveTextContent( '' );
@@ -155,7 +159,9 @@ describe( 'InviteAcceptLoggedOut branding', () => {
 			</Provider>
 		);
 
-		expect( mockGetCiabConfigFromGarden ).toHaveBeenCalledWith( undefined, undefined );
+		expect( mockGetCiabConfigFromGarden ).toHaveBeenCalledWith( undefined, undefined, {
+			persistToSession: true,
+		} );
 		expect( screen.queryByRole( 'img', { name: 'Woo' } ) ).not.toBeInTheDocument();
 		expect( document.querySelector( '.logged-out-wp-logo' )?.tagName.toLowerCase() ).toBe( 'svg' );
 	} );

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -24,7 +24,7 @@ import {
 	isVIPOAuth2Client,
 	isStudioAppOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
-import { getPartnerAllowedSocialServices } from 'calypso/lib/partner-branding';
+import { getEffectivePartnerAllowedSocialServices } from 'calypso/lib/partner-branding';
 import { login } from 'calypso/lib/paths';
 import LoginContextProvider, { useLoginContext } from 'calypso/login/login-context';
 import OneLoginLayout from 'calypso/login/wp-login/components/one-login-layout';
@@ -46,6 +46,7 @@ import { errorNotice } from 'calypso/state/notices/actions';
 import { fetchOAuth2ClientData } from 'calypso/state/oauth2-clients/actions';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 import getIsAkismet from 'calypso/state/selectors/get-is-akismet';
 import getIsBlazePro from 'calypso/state/selectors/get-is-blaze-pro';
 import getIsWoo from 'calypso/state/selectors/get-is-woo';
@@ -545,7 +546,7 @@ export class UserStep extends Component {
 	}
 
 	renderSignupForm() {
-		const { oauth2Client, isWoo, from } = this.props;
+		const { oauth2Client, isWoo, currentFrom, initialFrom } = this.props;
 		const isPasswordless = true;
 		let socialService;
 		let socialServiceResponse;
@@ -560,7 +561,10 @@ export class UserStep extends Component {
 			}
 		}
 
-		const allowedSocialServices = getPartnerAllowedSocialServices( from );
+		const allowedSocialServices = getEffectivePartnerAllowedSocialServices(
+			currentFrom,
+			initialFrom
+		);
 
 		return (
 			<>
@@ -708,6 +712,8 @@ const ConnectedUser = connect(
 			isWooJPC: isWooJPCFlow( state ),
 			isBlazePro,
 			from: get( getCurrentQueryArguments( state ), 'from' ),
+			currentFrom: get( getCurrentQueryArguments( state ), 'from' ),
+			initialFrom: get( getInitialQueryArguments( state ), 'from' ),
 			userLoggedIn: isUserLoggedIn( state ),
 			isOnboardingAffiliateFlow: getIsOnboardingAffiliateFlow( state ),
 			isA4A,


### PR DESCRIPTION
Part of ARC-1570

## Proposed Changes

* add a session-aware CIAB branding resolver in `client/lib/partner-branding.tsx` that persists partner id in `sessionStorage` once detected and reuses it when `from` is absent
* standardize login and signup consumers to use effective CIAB branding resolution for config and allowed social providers
* persist CIAB branding when it is detected from garden metadata in invite entry flows so follow-up `/log-in` and `/start` routes keep branding
* add and update unit tests for resolver precedence, invalidation, and invite flow persistence wiring

## Why are these changes being made?

* ARC-1570 requires CIAB branding to remain consistent across logged-out navigation branches when subsequent routes no longer include the `from` query param.
* this change prevents branding regressions (logo, ToS, provider restrictions) by centralizing resolution precedence and persisting only for the current browser session.

## Testing Instructions

* Run:
  * `yarn test-client client/lib/test/partner-branding.tsx`
  * `yarn test-client client/login/magic-login/test/index.test.jsx`
  * `yarn test-client client/my-sites/invites/test/invite-accept-logged-out.jsx`
  * `yarn test-client client/my-sites/invites-unified/screens/test/accept-invite-screen.test.tsx`
  * `yarn test-client client/my-sites/invites-unified/screens/test/already-member-screen.test.tsx`
* Manual smoke test:
  * open `/start?from=woo` and confirm Woo branding appears
  * navigate through logged-out flow pages that drop `from` (for example `/log-in`, invite/connect routes)
  * confirm branding remains applied in the same tab session
  * open a fresh tab/session and confirm branding is not implicitly carried over unless detected again

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?