### PR TITLE
Backups: use date as primary title instead of repetitive summary

### DIFF
--- a/client/dashboard/sites/backups/backup-details.tsx
+++ b/client/dashboard/sites/backups/backup-details.tsx
@@ -3,7 +3,6 @@ import { useMutation } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import {
 	__experimentalGrid as Grid,
-	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	Button,
 	Icon,
@@ -139,7 +138,7 @@ export function BackupDetails( { backup, site, timezoneString, gmtOffset }: Back
 		<Card>
 			<CardHeader style={ { flexDirection: 'column', alignItems: 'stretch' } }>
 				<SectionHeader
-					title={ backup.summary }
+					title={ formattedTime }
 					decoration={ <Icon icon={ gridiconToWordPressIcon( backup.gridicon ) } /> }
 					actions={ ! isSmallViewport ? actions : null }
 				/>
@@ -150,17 +149,15 @@ export function BackupDetails( { backup, site, timezoneString, gmtOffset }: Back
 					<Text size={ 14 } weight={ 500 }>
 						{ backup.content.text }
 					</Text>
-					<HStack alignment="left" spacing={ 1 }>
-						<Text variant="muted">{ formattedTime }</Text>
-						{ backup.actor?.name && (
-							<Text variant="muted">
-								{
+					<Text variant="muted">
+						{ backup.actor?.name
+							? `${ backup.summary } ${ sprintf(
 									/* translators: %s is the name of the person/system who performed the backup */
-									sprintf( __( 'by %s' ), backup.actor.name )
-								}
-							</Text>
-						) }
-					</HStack>
+									__( 'by %s' ),
+									backup.actor.name
+							  ) }`
+							: backup.summary }
+					</Text>
 					<Grid templateColumns="repeat(auto-fit, minmax(200px, 1fr))">
 						{ backup.streams ? (
 							backup.streams.map( ( item, index ) => (

--- a/client/dashboard/sites/backups/backups-list.tsx
+++ b/client/dashboard/sites/backups/backups-list.tsx
@@ -13,9 +13,9 @@ import type { View } from '@wordpress/dataviews';
 
 const defaultView: View = {
 	type: 'list',
-	fields: [ 'date', 'content_text' ],
+	fields: [ 'content_text' ],
 	mediaField: 'icon',
-	titleField: 'title',
+	titleField: 'date',
 	perPage: 10,
 	sort: {
 		field: 'date',

--- a/client/dashboard/sites/backups/dataviews/fields.tsx
+++ b/client/dashboard/sites/backups/dataviews/fields.tsx
@@ -1,5 +1,5 @@
 import { Icon } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { FormattedTime } from '../../../components/formatted-time';
 import { gridiconToWordPressIcon } from '../../../utils/gridicons';
 import type { ActivityLogEntry, ActivityLogGroupCountResponse } from '@automattic/api-core';
@@ -53,16 +53,6 @@ export function getFields(
 					className="dashboard-backups__list-icon"
 				/>
 			),
-		},
-		{
-			id: 'title',
-			label: __( 'Title' ),
-			getValue: ( { item } ) => {
-				// translators: %s is the name of the person who performed the action
-				const actor = item.actor?.name ? ` ${ sprintf( __( 'by %s' ), item.actor.name ) }` : '';
-				return item.summary + actor;
-			},
-			enableGlobalSearch: true,
 		},
 		{
 			id: 'date',

--- a/client/dashboard/sites/backups/test/index.test.tsx
+++ b/client/dashboard/sites/backups/test/index.test.tsx
@@ -196,7 +196,7 @@ test.each( summaryTestCases )(
 		renderBackupsListPage();
 
 		await waitFor( () => {
-			expect( screen.getAllByText( summary ) ).toHaveLength( 2 );
+			expect( screen.getByText( summary ) ).toBeVisible();
 		} );
 	}
 );


### PR DESCRIPTION
The backup list and detail panel always showed "Backup and scan complete by Jetpack" as the title, which was redundant across entries. Replace it with the formatted date/time, and move the summary to a muted meta line.

## Proposed Changes

* Replace the repetitive "Backup and scan complete by Jetpack" title with the formatted date/time in both the backup
  list and detail panel.
* Move the backup summary (e.g., "Backup and scan complete by Jetpack") to a muted meta line in the detail panel.
* Remove the now-unused `title` field from the DataViews field definitions.

## Why are these changes being made?

* @crisbusquets pointed out that the backup list displayed "Backup and scan complete by Jetpack" as the title for every single entry, making it hard to distinguish between backups at a glance. The date/time (e.g.: "Mar 6, 2026, 4:42 PM") and backup contents (e.g.: "13 plugins, 3 themes, 7 uploads, 1 post, 3 pages") are far more useful for identifying a specific backup.

### Before

The list and detail panel both prominently showed the same summary text for every entry:

<img width="1387" height="430" alt="image" src="https://github.com/user-attachments/assets/dd4fab4c-34b6-448b-a9e0-e78966b6b13d" />


### After

The date/time is now the primary title, with the backup contents as the subtitle. The summary is preserved as muted
  text in the detail panel:

<img width="1391" height="430" alt="image" src="https://github.com/user-attachments/assets/361b1fe3-b817-4064-b56a-c5c9ff2d617d" />

## Testing Instructions

* Navigate to an Atomic site's Backups page (Sites → [site] → Backups).
* Verify the backup list shows the date/time as the title and the backup contents as the meta line below it.
* Select a backup and verify the detail panel shows the date/time as the header, backup contents below it, and the
  summary (e.g.: "Backup and scan complete by Jetpack") as meta/muted text.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
