### PR TITLE
Revert "TeamCity: restore git mtimes before Build base images (#109088)"

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -155,13 +155,6 @@ object BuildBaseImages : BuildType({
 	}
 
 	steps {
-		bashNodeScript {
-			name = "Restore git mtime"
-			dockerImage = "%docker_image_e2e%"
-			scriptContent = """
-				/usr/lib/git-core/git-restore-mtime --force --commit-time --skip-missing
-			""".trimIndent()
-		}
 		dockerCommand {
 			name = "Build base image"
 			commandType = build {


### PR DESCRIPTION
This reverts commit 6615be0089d94546b066a05400a987ea75f9767b.


Part of #

## Proposed Changes

*

## Why are these changes being made?

*

## Testing Instructions


*

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
