### PR TITLE
DOTMART-122: Remove migration trial offering from onboarding flow

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -1,12 +1,10 @@
 import config from '@automattic/calypso-config';
-import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { Onboard } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { SITE_MIGRATION_FLOW } from '@automattic/onboarding';
 import { SiteExcerptData } from '@automattic/sites';
 import { useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
-import { HOSTING_INTENT_MIGRATE } from 'calypso/data/hosting/use-add-hosting-trial-mutation';
 import { HOW_TO_MIGRATE_OPTIONS } from 'calypso/landing/stepper/constants';
 import { useFlowState } from 'calypso/landing/stepper/declarative-flow/internals/state-manager/store';
 import { STEPS } from 'calypso/landing/stepper/declarative-flow/internals/steps';
@@ -508,11 +506,6 @@ const siteMigration: FlowV2< typeof initialize > = {
 							from: fromQueryParam ?? undefined,
 							plan: providedDependencies.plan as string,
 							historyBack: true,
-							extraQueryParams:
-								providedDependencies?.sendIntentWhenCreatingTrial &&
-								providedDependencies?.plan === PLAN_MIGRATION_TRIAL_MONTHLY
-									? { hosting_intent: HOSTING_INTENT_MIGRATE }
-									: {},
 						} );
 						return;
 					}

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/test/site-migration-flow.tsx
@@ -2,11 +2,10 @@
  * @jest-environment jsdom
  */
 // @ts-nocheck - TODO: Fix TypeScript issues
-import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
+import { PLAN_BUSINESS_MONTHLY } from '@automattic/calypso-products';
 import { isCurrentUserLoggedIn } from '@automattic/data-stores/src/user/selectors';
 import { waitFor } from '@testing-library/react';
 import nock from 'nock';
-import { HOSTING_INTENT_MIGRATE } from 'calypso/data/hosting/use-add-hosting-trial-mutation';
 import { HOW_TO_MIGRATE_OPTIONS } from 'calypso/landing/stepper/constants';
 import { useFlowState } from 'calypso/landing/stepper/declarative-flow/internals/state-manager/store';
 import { STEPS } from 'calypso/landing/stepper/declarative-flow/internals/steps';
@@ -727,8 +726,7 @@ describe( 'Site Migration Flow', () => {
 					from: STEPS.SITE_MIGRATION_UPGRADE_PLAN,
 					dependencies: {
 						goToCheckout: true,
-						plan: PLAN_MIGRATION_TRIAL_MONTHLY,
-						sendIntentWhenCreatingTrial: true,
+						plan: PLAN_BUSINESS_MONTHLY,
 					},
 					query: {
 						siteSlug: 'example.wordpress.com',
@@ -739,12 +737,11 @@ describe( 'Site Migration Flow', () => {
 
 				expect( goToCheckout ).toHaveBeenCalledWith( {
 					destination: `/setup/site-migration/${ STEPS.SITE_MIGRATION_INSTRUCTIONS.slug }?siteSlug=example.wordpress.com&from=https%3A%2F%2Fsite-to-be-migrated.com&siteId=123`,
-					extraQueryParams: { hosting_intent: HOSTING_INTENT_MIGRATE },
 					flowName: 'site-migration',
 					from: 'https://site-to-be-migrated.com',
 					siteSlug: 'example.wordpress.com',
 					stepName: STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug,
-					plan: PLAN_MIGRATION_TRIAL_MONTHLY,
+					plan: PLAN_BUSINESS_MONTHLY,
 					historyBack: true,
 				} );
 			} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
@@ -1,7 +1,6 @@
-import { PLAN_MIGRATION_TRIAL_MONTHLY, getPlan, type PlanSlug } from '@automattic/calypso-products';
+import { getPlan, type PlanSlug } from '@automattic/calypso-products';
 import { Step } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
-import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -23,7 +22,6 @@ const SiteMigrationUpgradePlan: StepType< {
 	submits: {
 		goToCheckout?: boolean;
 		plan?: string;
-		sendIntentWhenCreatingTrial?: boolean;
 		verifyEmail?: boolean;
 	};
 } > = ( { navigation } ) => {
@@ -46,14 +44,6 @@ const SiteMigrationUpgradePlan: StepType< {
 		},
 		[ navigation ]
 	);
-
-	const handleFreeTrialClick = useCallback( () => {
-		navigation.submit?.( {
-			goToCheckout: true,
-			plan: PLAN_MIGRATION_TRIAL_MONTHLY,
-			sendIntentWhenCreatingTrial: true,
-		} );
-	}, [ navigation ] );
 
 	if ( ! siteItem || ! siteSlug ) {
 		return <Step.Loading />;
@@ -83,20 +73,6 @@ const SiteMigrationUpgradePlan: StepType< {
 					onUpgradeClick={ handleUpgradeClick }
 					coupon={ queryParams.get( 'coupon' ) ?? undefined }
 				/>
-				<div className="site-migration-upgrade-plan__trial-section">
-					<p className="site-migration-upgrade-plan__trial-description">
-						{ translate(
-							'Not sure which plan is right for you? Try our 7-day trial to see how your site turns out.'
-						) }
-					</p>
-					<Button
-						className="site-migration-upgrade-plan__trial-button"
-						variant="secondary"
-						onClick={ handleFreeTrialClick }
-					>
-						{ translate( 'Try a free 7-day trial' ) }
-					</Button>
-				</div>
 			</Step.WideLayout>
 		</>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/style.scss
@@ -40,25 +40,4 @@
 			max-width: 616px;
 		}
 	}
-
-	// Trial section styles
-	&__trial-section {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		margin-top: 2rem;
-		padding-top: 2rem;
-	}
-
-	&__trial-description {
-		color: var( --color-text-subtle );
-		font-size: 0.875rem;
-		text-align: center;
-		margin: 0 0 1rem;
-		max-width: 400px;
-	}
-
-	&__trial-button.components-button.is-secondary {
-		font-weight: 500;
-	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/test/index.tsx
@@ -2,17 +2,13 @@
  * @jest-environment jsdom
  */
 // @ts-nocheck - TODO: Fix TypeScript issues
-import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import nock from 'nock';
 import React from 'react';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import SiteMigrationUpgradePlan from '../';
 import { StepProps } from '../../../types';
 import { mockStepProps, renderStep } from '../../test/helpers';
-
-const planSlug = PLAN_MIGRATION_TRIAL_MONTHLY;
 
 // Mock MigrationPlansGrid with a simplified version that triggers onUpgradeClick
 jest.mock( '../migration-plans-grid', () => {
@@ -48,35 +44,12 @@ jest.mock( 'calypso/landing/stepper/hooks/use-site-slug', () => ( {
 	URL: 'https://site-url.wordpress.com',
 } );
 
-const mockApi = () => nock( 'https://public-api.wordpress.com:443' );
-
-interface TrialEligibilityResponse {
-	eligible: boolean;
-	error_code: string;
-}
-
-const API_RESPONSE_EMAIL_VERIFIED = {
-	eligible: true,
-	error_code: 'email-verified',
-};
-
-const mockTrialEligibilityAPI = ( payload: TrialEligibilityResponse ) => {
-	mockApi()
-		.get( `/wpcom/v2/sites/site-id/hosting/trial/check-eligibility/${ planSlug }` )
-		.reply( 200, payload );
-};
-
 describe( 'SiteMigrationUpgradePlan', () => {
 	const render = ( props?: Partial< StepProps > ) => {
 		const combinedProps = { ...mockStepProps( props ) };
 
 		return renderStep( <SiteMigrationUpgradePlan { ...combinedProps } /> );
 	};
-
-	beforeAll( () => {
-		nock.disableNetConnect();
-		mockTrialEligibilityAPI( API_RESPONSE_EMAIL_VERIFIED );
-	} );
 
 	it( 'selects the monthly plan', async () => {
 		const navigation = { submit: jest.fn() };
@@ -102,18 +75,10 @@ describe( 'SiteMigrationUpgradePlan', () => {
 		} );
 	} );
 
-	it( 'selects the free trial', async () => {
+	it( 'does not render a free trial button', () => {
 		const navigation = { submit: jest.fn() };
 		render( { navigation } );
 
-		await userEvent.click(
-			await screen.findByRole( 'button', { name: /Try a free 7-day trial/ } )
-		);
-
-		expect( navigation.submit ).toHaveBeenCalledWith( {
-			goToCheckout: true,
-			plan: PLAN_MIGRATION_TRIAL_MONTHLY,
-			sendIntentWhenCreatingTrial: true,
-		} );
+		expect( screen.queryByRole( 'button', { name: /Try a free 7-day trial/ } ) ).toBeNull();
 	} );
 } );


### PR DESCRIPTION
Part of DOTMART-122

## Proposed Changes

* Remove the migration trial CTA from the site migration upgrade plan step.
* Remove trial-only checkout intent coupling (`hosting_intent=migrate`) from the migration flow checkout handoff.
* Keep paid-plan selection and post-checkout destination routing unchanged.
* Update targeted unit tests to reflect the new behavior:
  * upgrade step no longer renders a free-trial option
  * migration flow checkout assertions no longer expect trial-specific query params

## Why are these changes being made?

* The migrations onboarding flow currently offers a 7-day migration trial that maps to a Business plan under the hood.
* That path creates follow-up friction for users who later want to self-serve Personal/Premium purchases.
* Product direction for DOTMART-122 is to disable/remove the trial offering in this flow now.
* This PR implements the narrowest change surface to do that, avoiding broad refactors and keeping review scope small.

## Testing Instructions

* Navigate to http://calypso.localhost:3000/setup/site-migration
* Enter a WordPress site URL (e.g., https://thisisatestsite.wordpress.com) and proceed through the flow
* At the "Import or Migrate" step, verify the badge says "Available on paid plans" (not "50% off")
* At the "Let us migrate your site" click on "Get started"
* Confirm the trial CTA is no longer shown on the migration upgrade-plan step. ( footer )
* Confirm monthly/yearly paid plan selection still submits correctly and opens checkout.
* Confirm migration flow checkout call no longer includes trial-specific `hosting_intent` query params.
* Confirm existing destination behavior after checkout is unchanged for SSH and non-SSH paths.

<img width="2990" height="1598" alt="image" src="https://github.com/user-attachments/assets/62cd907f-c3b8-43b9-a0bd-1b74b11b96f2" />


Automated tests run:

* `yarn test-client client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/test/index.tsx`
* `yarn test-client client/landing/stepper/declarative-flow/flows/site-migration-flow/test/site-migration-flow.tsx`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?