### PR TITLE
CIAB: Apply partner branding font override to setup user step title

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -3,6 +3,7 @@ import { Step, StepContainer } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { createInterpolateElement, useEffect, useState } from '@wordpress/element';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
 import { AnyAction } from 'redux';
@@ -148,14 +149,18 @@ const UserStepComponent: StepType = function UserStep( {
 		}
 		const heading = (
 			// The locale suggestions are going to be reworked. Don't worry about it now.
-			<>
+			<div
+				className={ clsx( {
+					'is-ciab-font-system': ciabConfig?.fontStyle === 'system',
+				} ) }
+			>
 				{ localeSuggestions }
 				<Step.Heading
 					text={ headingText }
 					align={ isExperimentVariant ? 'left' : undefined }
 					size={ isMessagingVariation ? 'small' : undefined }
 				/>
-			</>
+			</div>
 		);
 
 		const topBar = (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
@@ -2,6 +2,11 @@
 @import "@automattic/components/src/styles/typography";
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
+.is-ciab-font-system .step-container-v2__heading h1.wp-brand-font {
+	font-family: $default-font;
+}
 
 $gray-100: #101517;
 $gray-60: #50575e;

--- a/client/signup/steps/user/style.scss
+++ b/client/signup/steps/user/style.scss
@@ -6,6 +6,10 @@
 		font-family: $default-font;
 	}
 }
+
+.is-ciab-font-system .step-container-v2__heading h1.wp-brand-font {
+	font-family: $default-font;
+}
 /* End: CIAB partner branding font styles for signup page */
 
 body.is-section-signup .signup {

--- a/client/signup/steps/user/style.scss
+++ b/client/signup/steps/user/style.scss
@@ -6,10 +6,6 @@
 		font-family: $default-font;
 	}
 }
-
-.is-ciab-font-system .step-container-v2__heading h1.wp-brand-font {
-	font-family: $default-font;
-}
 /* End: CIAB partner branding font styles for signup page */
 
 body.is-section-signup .signup {


### PR DESCRIPTION
## Proposed Changes

* Apply the partner branding system font override to the `Step.Heading` title in the onboarding/setup user step, matching the existing behavior in the login flow.

## Why are these changes being made?

When a CIAB partner (e.g., Woo) has `fontStyle: 'system'` configured, the login flow correctly overrides the WordPress brand font on the heading title with the system font. However, the setup/onboarding user step was not applying this override — the title kept using the `wp-brand-font` class without any partner-specific font override.

This adds a wrapper `div` with the `is-ciab-font-system` class (conditionally applied when `ciabConfig?.fontStyle === 'system'`) and a corresponding SCSS rule to override the brand font on the `Step.Heading` `h1`.

## Testing Instructions

* Navigate to the onboarding/setup user step with a CIAB partner `?from=` parameter that has `fontStyle: 'system'` configured.
* Verify the heading title uses the system font instead of the WordPress brand font.
* Verify the login flow still works as before.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?