### PR TITLE
Help Center: Track route changes in CIAB admin to update resources

### DIFF
--- a/apps/help-center/help-center-ciab-admin.js
+++ b/apps/help-center/help-center-ciab-admin.js
@@ -1,11 +1,87 @@
-/* global __i18n_text_domain__ */
+/* global __i18n_text_domain__, helpCenterData */
 import './config';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
 import { dispatch, select, subscribe } from '@wordpress/data';
+import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { createRoot } from 'react-dom/client';
 import './help-center.scss';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
-import loadHelpCenter from './async-help-center';
+
+function useCurrentRoute() {
+	const [ route, setRoute ] = useState(
+		() => window.location.pathname + window.location.search + window.location.hash
+	);
+
+	useEffect( () => {
+		const updateRoute = () => {
+			setRoute( window.location.pathname + window.location.search + window.location.hash );
+		};
+
+		const originalPushState = window.history.pushState;
+		const originalReplaceState = window.history.replaceState;
+
+		window.history.pushState = function ( ...args ) {
+			originalPushState.apply( this, args );
+			updateRoute();
+		};
+		window.history.replaceState = function ( ...args ) {
+			originalReplaceState.apply( this, args );
+			updateRoute();
+		};
+
+		window.addEventListener( 'popstate', updateRoute );
+
+		return () => {
+			window.history.pushState = originalPushState;
+			window.history.replaceState = originalReplaceState;
+			window.removeEventListener( 'popstate', updateRoute );
+		};
+	}, [] );
+
+	return route;
+}
+
+function HelpCenterWithRouteTracking( { HelpCenter } ) {
+	const currentRoute = useCurrentRoute();
+	const botProps = helpCenterData.isCommerceGarden
+		? { newInteractionsBotSlug: 'ciab-workflow-support_chat' }
+		: {};
+
+	return (
+		<HelpCenter
+			locale={ helpCenterData.locale }
+			sectionName={ helpCenterData.sectionName || 'gutenberg-editor' }
+			currentUser={ helpCenterData.currentUser }
+			site={ helpCenterData.site }
+			hasPurchases={ false }
+			onboardingUrl="https://wordpress.com/start"
+			handleClose={ () => dispatch( 'automattic/help-center' ).setShowHelpCenter( false ) }
+			product={ helpCenterData.isCommerceGarden ? 'commerce-garden' : undefined }
+			currentRoute={ currentRoute }
+			{ ...botProps }
+		/>
+	);
+}
+
+function loadHelpCenter() {
+	if ( document.getElementById( 'jetpack-help-center' ) ) {
+		return Promise.resolve();
+	}
+	const queryClient = new QueryClient();
+	const container = document.createElement( 'div' );
+	container.id = 'jetpack-help-center';
+	document.body.appendChild( container );
+
+	return import( '@automattic/help-center' ).then( ( { default: HelpCenter } ) =>
+		createRoot( container ).render(
+			<QueryClientProvider client={ queryClient }>
+				<HelpCenterWithRouteTracking HelpCenter={ HelpCenter } />
+			</QueryClientProvider>
+		)
+	);
+}
 
 async function shouldAutoLoadHelpCenter() {
 	const preferences = canAccessWpcomApis()


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/WOODOCS-2840/help-center-update-resources-on-page-changes

## Proposed Changes

* Inline the Help Center loading logic from `async-help-center.js` into `help-center-ciab-admin.js`.
* Add a `useCurrentRoute` hook that monitors `pushState`, `replaceState`, and `popstate` events, from CIAB page transitions
* Pass the current route as the `currentRoute` prop to `HelpCenter`, so support resources update when the user navigates within the CIAB admin.

## Why are these changes being made?

Previously, the CIAB Help Center did not track route changes, so the support resources shown remained static regardless of which admin page the user navigated to. By tracking the current route and passing it to the Help Center, the displayed resources now stay relevant to the page the user is viewing.

## Testing Instructions

1. Sandbox `widgets.wp.com` (the sites themselves do not need sandboxing).
2. Run `cd apps/help-center && yarn dev --sync`.
3. Visit a CIAB site admin.
4. Open the Help Center.
5. Navigate to a different admin page.
6. Verify that the Help Center resources update to reflect the new page.
