### PR TITLE
A4A: Show renewal and change payment method options - RETRY #109032

### DIFF
--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -408,7 +408,7 @@ class ManagePurchase extends Component<
 			return null;
 		}
 
-		if ( isPartnerPurchase( purchase ) || purchase.meta === 'is-a4a' ) {
+		if ( isPartnerPurchase( purchase ) || isA4ABillingDragonPurchase( purchase ) ) {
 			return null;
 		}
 
@@ -578,7 +578,7 @@ class ManagePurchase extends Component<
 			return null;
 		}
 
-		if ( isPartnerPurchase( purchase ) || purchase.meta === 'is-a4a' ) {
+		if ( isPartnerPurchase( purchase ) || isA4ABillingDragonPurchase( purchase ) ) {
 			return null;
 		}
 

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -169,6 +169,7 @@ import {
 	isAkismetTemporarySitePurchase,
 	isMarketplaceTemporarySitePurchase,
 	isA4ATemporarySitePurchase,
+	isA4ABillingDragonPurchase,
 	getCancelPurchaseSurveyCompletedPreferenceKey,
 } from '../utils';
 import PurchaseNotice from './notices';
@@ -369,11 +370,12 @@ class ManagePurchase extends Component<
 			return null;
 		}
 		if (
-			isPartnerPurchase( purchase ) ||
+			( isPartnerPurchase( purchase ) && ! isA4ABillingDragonPurchase( purchase ) ) ||
 			! isRenewable( purchase ) ||
 			( ! this.props.site &&
 				! isAkismetTemporarySitePurchase( purchase ) &&
-				! isMarketplaceTemporarySitePurchase( purchase ) ) ||
+				! isMarketplaceTemporarySitePurchase( purchase ) &&
+				! isA4ABillingDragonPurchase( purchase ) ) ||
 			isAkismetFreeProduct( purchase ) ||
 			( is100Year( purchase ) && ! isCloseToExpiration( purchase ) )
 		) {
@@ -403,6 +405,10 @@ class ManagePurchase extends Component<
 	renderUpgradeButton( preventRenewal: boolean ) {
 		const { purchase, translate } = this.props;
 		if ( ! purchase ) {
+			return null;
+		}
+
+		if ( isPartnerPurchase( purchase ) || purchase.meta === 'is-a4a' ) {
 			return null;
 		}
 
@@ -447,11 +453,12 @@ class ManagePurchase extends Component<
 		}
 
 		if (
-			isPartnerPurchase( purchase ) ||
+			( isPartnerPurchase( purchase ) && ! isA4ABillingDragonPurchase( purchase ) ) ||
 			! isRenewable( purchase ) ||
 			( ! this.props.site &&
 				! isAkismetTemporarySitePurchase( purchase ) &&
-				! isMarketplaceTemporarySitePurchase( purchase ) ) ||
+				! isMarketplaceTemporarySitePurchase( purchase ) &&
+				! isA4ABillingDragonPurchase( purchase ) ) ||
 			isAkismetFreeProduct( purchase )
 		) {
 			return null;
@@ -571,6 +578,10 @@ class ManagePurchase extends Component<
 			return null;
 		}
 
+		if ( isPartnerPurchase( purchase ) || purchase.meta === 'is-a4a' ) {
+			return null;
+		}
+
 		const isUpgradeablePlan =
 			purchase &&
 			isPlan( purchase ) &&
@@ -638,14 +649,15 @@ class ManagePurchase extends Component<
 			return null;
 		}
 
-		if ( isPartnerPurchase( purchase ) ) {
+		if ( isPartnerPurchase( purchase ) && ! isA4ABillingDragonPurchase( purchase ) ) {
 			return null;
 		}
 
 		if (
 			! this.props.site &&
 			! isAkismetTemporarySitePurchase( purchase ) &&
-			! isMarketplaceTemporarySitePurchase( purchase )
+			! isMarketplaceTemporarySitePurchase( purchase ) &&
+			! isA4ABillingDragonPurchase( purchase )
 		) {
 			return null;
 		}
@@ -1385,7 +1397,7 @@ class ManagePurchase extends Component<
 									: purchaseType( purchase ) }
 							</div>
 							<div className="manage-purchase__price">
-								{ isPartnerPurchase( purchase ) ? (
+								{ isPartnerPurchase( purchase ) && ! isA4ABillingDragonPurchase( purchase ) ? (
 									<div className="manage-purchase__contact-partner">
 										{ translate( 'Please contact %(partnerName)s for details', {
 											args: {
@@ -1415,7 +1427,7 @@ class ManagePurchase extends Component<
 						) }
 					</header>
 					{ this.renderPurchaseDescription() }
-					{ ! isPartnerPurchase( purchase ) && (
+					{ ( ! isPartnerPurchase( purchase ) || isA4ABillingDragonPurchase( purchase ) ) && (
 						<PurchaseMeta
 							purchaseId={ purchase.id }
 							siteSlug={ siteSlug }
@@ -1424,6 +1436,7 @@ class ManagePurchase extends Component<
 							getChangePaymentMethodUrlFor={
 								getChangePaymentMethodUrlFor ?? getChangePaymentMethodPath
 							}
+							isA4ABillingDragonPurchase={ isA4ABillingDragonPurchase( purchase ) }
 						/>
 					) }
 				</Card>

--- a/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
@@ -21,7 +21,10 @@ import {
 	isExpired,
 	isInExpirationGracePeriod,
 } from 'calypso/lib/purchases';
-import { isAkismetTemporarySitePurchase } from 'calypso/me/purchases/utils';
+import {
+	isAkismetTemporarySitePurchase,
+	isA4ATemporarySitePurchase,
+} from 'calypso/me/purchases/utils';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getAllDomains } from 'calypso/state/sites/domains/selectors';
@@ -58,7 +61,8 @@ function PurchaseMetaExpiration( {
 	const moment = useLocalizedMoment();
 	const isProductOwner = purchase?.userId === useSelector( getCurrentUserId );
 	const isJetpackPurchase = isJetpackPlan( purchase ) || isJetpackProduct( purchase );
-	const isCancellableSitelessPurchase = isAkismetTemporarySitePurchase( purchase );
+	const isCancellableSitelessPurchase =
+		isAkismetTemporarySitePurchase( purchase ) || isA4ATemporarySitePurchase( purchase );
 	const isAutorenewalEnabled = purchase?.isAutoRenewEnabled ?? false;
 	const isJetpackPurchaseUsingPrimaryCancellationFlow =
 		isJetpackPurchase && config.isEnabled( 'jetpack/cancel-through-main-flow' );

--- a/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
@@ -24,6 +24,7 @@ import {
 import {
 	isAkismetTemporarySitePurchase,
 	isA4ATemporarySitePurchase,
+	isA4ABillingDragonPurchase,
 } from 'calypso/me/purchases/utils';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
@@ -89,7 +90,10 @@ function PurchaseMetaExpiration( {
 	if ( isRenewable( purchase ) && ! isExpired( purchase ) ) {
 		const dateSpan = <span className="manage-purchase__detail-date-span" />;
 		// If a jetpack site has been disconnected, the "site" prop will be null here.
-		const shouldRenderToggle = ( isCancellableSitelessPurchase || site ) && isProductOwner;
+		// We allow the empty site if an A4A BD purchase since clients often don't have access to the site so it'll be null.
+		const shouldRenderToggle =
+			( isCancellableSitelessPurchase || site || isA4ABillingDragonPurchase( purchase ) ) &&
+			isProductOwner;
 
 		const autoRenewToggle = shouldRenderToggle ? (
 			<AutoRenewToggle

--- a/client/me/purchases/manage-purchase/purchase-meta-payment-details.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-payment-details.tsx
@@ -13,6 +13,7 @@ interface PaymentProps {
 	siteSlug?: string;
 	site?: SiteDetails;
 	isAkismetPurchase: boolean;
+	isA4ABillingDragonPurchase?: boolean;
 }
 
 function PurchaseMetaPaymentDetails( {
@@ -21,6 +22,7 @@ function PurchaseMetaPaymentDetails( {
 	siteSlug,
 	site,
 	isAkismetPurchase,
+	isA4ABillingDragonPurchase,
 }: PaymentProps ) {
 	const { paymentMethods: cards } = useStoredPaymentMethods( { type: 'card' } );
 	const handleEditPaymentMethodClick = () => {
@@ -41,7 +43,7 @@ function PurchaseMetaPaymentDetails( {
 		! canEditPaymentDetails( purchase ) ||
 		! isPaidWithCreditCard( purchase ) ||
 		! siteSlug ||
-		( ! site && ! isAkismetPurchase )
+		( ! site && ! isAkismetPurchase && ! isA4ABillingDragonPurchase )
 	) {
 		return <li>{ paymentDetails }</li>;
 	}

--- a/client/me/purchases/manage-purchase/purchase-meta.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.tsx
@@ -62,7 +62,7 @@ export default function PurchaseMeta( {
 	siteSlug,
 	getChangePaymentMethodUrlFor,
 	getManagePurchaseUrlFor = managePurchase,
-	isA4ABillingDragonPurchase: isA4ABillingDragon = false,
+	isA4ABillingDragonPurchase = false,
 }: PurchaseMetaProps ) {
 	const translate = useTranslate();
 
@@ -155,7 +155,7 @@ export default function PurchaseMeta( {
 					siteSlug={ siteSlug }
 					site={ site ?? undefined }
 					isAkismetPurchase={ isAkismetPurchase }
-					isA4ABillingDragonPurchase={ isA4ABillingDragon }
+					isA4ABillingDragonPurchase={ isA4ABillingDragonPurchase }
 				/>
 			</ul>
 			{ showJetpackUserLicense && <PurchaseJetpackUserLicense purchaseId={ purchaseId } /> }

--- a/client/me/purchases/manage-purchase/purchase-meta.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.tsx
@@ -53,6 +53,7 @@ export interface PurchaseMetaProps {
 	siteSlug: string;
 	getChangePaymentMethodUrlFor: GetChangePaymentMethodUrlFor;
 	getManagePurchaseUrlFor?: GetManagePurchaseUrlFor;
+	isA4ABillingDragonPurchase?: boolean;
 }
 
 export default function PurchaseMeta( {
@@ -61,6 +62,7 @@ export default function PurchaseMeta( {
 	siteSlug,
 	getChangePaymentMethodUrlFor,
 	getManagePurchaseUrlFor = managePurchase,
+	isA4ABillingDragonPurchase: isA4ABillingDragon = false,
 }: PurchaseMetaProps ) {
 	const translate = useTranslate();
 
@@ -153,6 +155,7 @@ export default function PurchaseMeta( {
 					siteSlug={ siteSlug }
 					site={ site ?? undefined }
 					isAkismetPurchase={ isAkismetPurchase }
+					isA4ABillingDragonPurchase={ isA4ABillingDragon }
 				/>
 			</ul>
 			{ showJetpackUserLicense && <PurchaseJetpackUserLicense purchaseId={ purchaseId } /> }

--- a/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
+++ b/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
@@ -295,4 +295,162 @@ describe( 'Purchase Management Buttons', () => {
 			expect( screen.queryByText( /Upgrade/ ) ).not.toBeInTheDocument();
 		}
 	);
+
+	it( 'renders payment method nav item for A4A billingdragon purchase on a real site', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.2/me/payment-methods?expired=include' )
+			.reply( 200 );
+
+		const store = createMockReduxStoreForPurchase( {
+			...purchase,
+			meta: 'is-a4a',
+		} );
+
+		render(
+			<QueryClientProvider client={ queryClient }>
+				<ReduxProvider store={ store }>
+					<ManagePurchase
+						purchaseId={ Number( purchase.ID ) }
+						isSiteLevel
+						siteSlug="onecooltestsite.com"
+					/>
+				</ReduxProvider>
+			</QueryClientProvider>
+		);
+
+		expect( await screen.findByText( /(?:Add|Change) payment method/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders payment method nav item for A4A billingdragon purchase on a siteless holding site', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.2/me/payment-methods?expired=include' )
+			.reply( 200 );
+
+		const a4aPurchase = {
+			...purchase,
+			meta: 'is-a4a',
+			domain: 'siteless.agencies.automattic.com',
+		};
+
+		// Don't include a site in the store to simulate siteless purchase
+		const store = createReduxStore(
+			{
+				currentUser: { id: Number( a4aPurchase.user_id ) },
+				plans: { items: [] },
+				purchases: {
+					data: [ a4aPurchase ],
+					hasLoadedUserPurchasesFromServer: true,
+					hasLoadedSitePurchasesFromServer: true,
+				},
+				productsList: { items: {} },
+				sites: {
+					items: {},
+					plans: {},
+					requesting: {},
+					domains: { requesting: {}, items: {} },
+				},
+				plugins: {
+					premium: { plugins: {} },
+				},
+				ui: { selectSiteId: a4aPurchase.blog_id },
+			},
+			( state ) => state
+		);
+
+		render(
+			<QueryClientProvider client={ queryClient }>
+				<ReduxProvider store={ store }>
+					<ManagePurchase
+						purchaseId={ Number( a4aPurchase.ID ) }
+						isSiteLevel
+						siteSlug="siteless.agencies.automattic.com"
+					/>
+				</ReduxProvider>
+			</QueryClientProvider>
+		);
+
+		expect( await screen.findByText( /(?:Add|Change) payment method/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders renew button for A4A billingdragon purchase', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.2/me/payment-methods?expired=include' )
+			.reply( 200 );
+
+		const store = createMockReduxStoreForPurchase( {
+			...purchase,
+			meta: 'is-a4a',
+			is_renewable: true,
+			can_explicit_renew: true,
+		} );
+
+		render(
+			<QueryClientProvider client={ queryClient }>
+				<ReduxProvider store={ store }>
+					<ManagePurchase
+						purchaseId={ Number( purchase.ID ) }
+						isSiteLevel
+						siteSlug="onecooltestsite.com"
+					/>
+				</ReduxProvider>
+			</QueryClientProvider>
+		);
+
+		expect( await screen.findByText( /Renew now/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders renewal nav item for A4A billingdragon purchase', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.2/me/payment-methods?expired=include' )
+			.reply( 200 );
+
+		const store = createMockReduxStoreForPurchase( {
+			...purchase,
+			meta: 'is-a4a',
+			is_renewable: true,
+			can_explicit_renew: true,
+		} );
+
+		render(
+			<QueryClientProvider client={ queryClient }>
+				<ReduxProvider store={ store }>
+					<ManagePurchase
+						purchaseId={ Number( purchase.ID ) }
+						isSiteLevel
+						siteSlug="onecooltestsite.com"
+					/>
+				</ReduxProvider>
+			</QueryClientProvider>
+		);
+
+		// business-bundle is an annual WP.com plan, so the nav item shows "Renew annually" instead of "Renew now"
+		expect( await screen.findByText( /Renew annually/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'does not render an upgrade button for A4A billingdragon purchase', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.2/me/payment-methods?expired=include' )
+			.reply( 200 );
+
+		const store = createMockReduxStoreForPurchase( {
+			...purchase,
+			meta: 'is-a4a',
+		} );
+
+		render(
+			<QueryClientProvider client={ queryClient }>
+				<ReduxProvider store={ store }>
+					<ManagePurchase
+						purchaseId={ Number( purchase.ID ) }
+						isSiteLevel
+						siteSlug="onecooltestsite.com"
+					/>
+				</ReduxProvider>
+			</QueryClientProvider>
+		);
+
+		// Wait for component to fully render
+		await screen.findByText( /(?:Add|Change) payment method/ );
+		expect( screen.queryByText( /Upgrade/ ) ).not.toBeInTheDocument();
+	} );
 } );

--- a/client/me/purchases/purchase-item/index.tsx
+++ b/client/me/purchases/purchase-item/index.tsx
@@ -60,6 +60,7 @@ import {
 	isAkismetTemporarySitePurchase,
 	isMarketplaceTemporarySitePurchase,
 	isA4ATemporarySitePurchase,
+	isA4ABillingDragonPurchase,
 } from '../utils';
 import OwnerInfo from './owner-info';
 import type { Purchases, SiteDetails } from '@automattic/data-stores';
@@ -357,7 +358,8 @@ export function PurchaseItemStatus( {
 		isDisconnectedSite &&
 		! isAkismetTemporarySitePurchase( purchase ) &&
 		! isMarketplaceTemporarySitePurchase( purchase ) &&
-		! isA4ATemporarySitePurchase( purchase )
+		! isA4ATemporarySitePurchase( purchase ) &&
+		! isA4ABillingDragonPurchase( purchase )
 	) {
 		if ( isJetpackTemporarySitePurchase( purchase ) ) {
 			return (
@@ -883,7 +885,8 @@ class PurchaseItem extends Component<
 			if (
 				! isDisconnectedSite ||
 				purchase.isJetpackPlanOrProduct ||
-				isTemporarySitePurchase( purchase )
+				isTemporarySitePurchase( purchase ) ||
+				isA4ABillingDragonPurchase( purchase )
 			) {
 				onClick = () => {
 					window.scrollTo( 0, 0 );

--- a/client/me/purchases/utils.ts
+++ b/client/me/purchases/utils.ts
@@ -73,6 +73,10 @@ export function isA4ATemporarySitePurchase( purchase: Purchase ): boolean {
 	return isTemporarySitePurchase( purchase ) && meta === 'is-a4a';
 }
 
+export function isA4ABillingDragonPurchase( purchase: Purchase ): boolean {
+	return purchase.meta === 'is-a4a';
+}
+
 export function getCancelPurchaseSurveyCompletedPreferenceKey(
 	purchaseId: string | number
 ): string {

--- a/client/me/purchases/utils.ts
+++ b/client/me/purchases/utils.ts
@@ -69,8 +69,7 @@ export function isJetpackTemporarySitePurchase( purchase: Purchase ): boolean {
 }
 
 export function isA4ATemporarySitePurchase( purchase: Purchase ): boolean {
-	const { meta } = purchase;
-	return isTemporarySitePurchase( purchase ) && meta === 'is-a4a';
+	return isTemporarySitePurchase( purchase ) && isA4ABillingDragonPurchase( purchase );
 }
 
 export function isA4ABillingDragonPurchase( purchase: Purchase ): boolean {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

This is a retry of the [original PR](https://github.com/Automattic/wp-calypso/pull/109032) that failed to build.
See:
* p1772834930312529-slack-C02DQP0FP
* https://github.com/Automattic/wp-calypso/pull/109032


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?