### PR TITLE
Guard base cache publishing to default-branch TeamCity builds

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -295,6 +295,7 @@ object BuildDockerImage : BuildType({
 			name = "Rebuild cache image"
 			conditions {
 				equals("UPDATE_BASE_IMAGE_CACHE", "true")
+				equals("teamcity.build.branch.is_default", "true")
 			}
 			commandType = build {
 				source = file {
@@ -314,6 +315,7 @@ object BuildDockerImage : BuildType({
 			name = "Push cache image"
 			conditions {
 				equals("UPDATE_BASE_IMAGE_CACHE", "true")
+				equals("teamcity.build.branch.is_default", "true")
 			}
 			commandType = push {
 				namesAndTags = "registry.a8c.com/calypso/base:%base_image_publish_tag%"


### PR DESCRIPTION
## Proposed Changes

* Add a default-branch condition to the `Rebuild cache image` TeamCity step.
* Add a default-branch condition to the `Push cache image` TeamCity step.
* Prevent non-default-branch builds from publishing the shared `calypso/base` cache image, even if `UPDATE_BASE_IMAGE_CACHE` is enabled manually.

## Why are these changes being made?

* The current TeamCity configuration allows PR builds to rebuild and push the shared base cache image when `UPDATE_BASE_IMAGE_CACHE=true`.
* That creates a safety risk: a PR-specific webpack cache can be published to the shared base image tag and then consumed by unrelated builds.
* Restricting cache-image rebuild and push steps to default-branch builds closes that escape hatch without changing the existing trunk cache refresh path.

## Testing Instructions

* Review `.teamcity/_self/projects/WebApp.kt` and confirm both `Rebuild cache image` and `Push cache image` require `teamcity.build.branch.is_default == true`.
* In TeamCity, verify a PR build does not run those steps even if `UPDATE_BASE_IMAGE_CACHE=true`.
* In TeamCity, verify a default-branch build can still run those steps when `UPDATE_BASE_IMAGE_CACHE=true`.
