### PR TITLE
Key webpack persistent cache by build flavor and config inputs

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -80,20 +80,34 @@ if ( ! sourceMapType && shouldCreateSentryRelease ) {
 
 const webpackCacheBuildDependencies = [
 	__filename,
+	// Top-level config inputs that change compilation behavior
 	path.resolve( __dirname, '../package.json' ),
 	path.resolve( __dirname, '../babel.config.js' ),
-	path.resolve( __dirname, '../yarn.lock' ),
-	path.resolve( __dirname, '../.yarnrc.yml' ),
+	// Config modules used by this webpack config
+	require.resolve( './webpack.common' ),
+	require.resolve( './server/config' ),
+	// Local build tools that influence compilation
+	require.resolve( '../build-tools/babel/babel-loader-cache-identifier' ),
+	require.resolve( '../build-tools/webpack/assets-writer-plugin.js' ),
+	require.resolve( '../build-tools/webpack/generate-chunks-map-plugin' ),
+	require.resolve( '../build-tools/webpack/readonly-cache-plugin' ),
+	require.resolve( '../build-tools/webpack/require-chunk-callback-plugin' ),
 	require.resolve( '../build-tools/webpack/sections-loader' ),
+	// Workspace config helper modules used to build rules/plugins
+	require.resolve( '@automattic/calypso-build/webpack/file-loader' ),
+	require.resolve( '@automattic/calypso-build/webpack/minify' ),
+	require.resolve( '@automattic/calypso-build/webpack/sass' ),
+	require.resolve( '@automattic/calypso-build/webpack/transpile' ),
+	require.resolve( '@automattic/calypso-build/webpack/util' ),
+	// Dependency graph changes
+	path.resolve( __dirname, '../yarn.lock' ),
 ];
 
-const cacheFlavorParts = [
-	`mode=${ isDevelopment ? 'development' : 'production' }`,
-	`devtool=${ sourceMapType || 'none' }`,
-];
+const cacheFlavorParts = [ `mode=${ bundleEnv }`, `devtool=${ sourceMapType || 'none' }` ];
 const webpackCacheName = `client-${ cacheFlavorParts.join( '__' ) }`;
 
-// Inputs that should invalidate a cache flavor.
+// These are things that should invalidate everything.
+// Or inputs that mean "the old cache is wrong".
 const webpackCacheVersion = JSON.stringify( {
 	bundleEnv,
 	nodeEnv: process.env.NODE_ENV || null,
@@ -104,7 +118,6 @@ const webpackCacheVersion = JSON.stringify( {
 	sectionLimit: process.env.SECTION_LIMIT || null,
 	emitStats: shouldEmitStats,
 	concatenateModules: shouldConcatenateModules,
-	hotReload: shouldHotReload,
 } );
 
 if ( shouldCreateSentryRelease ) {

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -84,8 +84,12 @@ const webpackCacheBuildDependencies = [
 	path.resolve( __dirname, '../babel.config.js' ),
 ];
 
+const cacheFlavorParts = [ `devtool=${ sourceMapType || 'none' }` ];
+const cacheName = `client-${ cacheFlavorParts.join( '__' ) }`;
+
+// These are things that should invalidate everything.
+// Or inputs that mean "the old cache is wrong".
 const webpackCacheVersion = JSON.stringify( {
-	browserslistEnv,
 	bundleEnv,
 	nodeEnv: process.env.NODE_ENV || null,
 	calypsoEnv: process.env.CALYPSO_ENV || null,
@@ -93,8 +97,6 @@ const webpackCacheVersion = JSON.stringify( {
 	minify: shouldMinify,
 	entryLimit: process.env.ENTRY_LIMIT || null,
 	sectionLimit: process.env.SECTION_LIMIT || null,
-	sourceMapType: sourceMapType || null,
-	sentryRelease: shouldCreateSentryRelease,
 } );
 
 if ( shouldCreateSentryRelease ) {
@@ -431,6 +433,7 @@ const webpackConfig = {
 		? {
 				cache: {
 					type: 'filesystem',
+					name: cacheName,
 					buildDependencies: {
 						config: webpackCacheBuildDependencies,
 					},

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -78,6 +78,25 @@ if ( ! sourceMapType && shouldCreateSentryRelease ) {
 	sourceMapType = 'eval';
 }
 
+const webpackCacheBuildDependencies = [
+	__filename,
+	path.resolve( __dirname, '../package.json' ),
+	path.resolve( __dirname, '../babel.config.js' ),
+];
+
+const webpackCacheVersion = JSON.stringify( {
+	browserslistEnv,
+	bundleEnv,
+	nodeEnv: process.env.NODE_ENV || null,
+	calypsoEnv: process.env.CALYPSO_ENV || null,
+	buildChunksMap: shouldBuildChunksMap,
+	minify: shouldMinify,
+	entryLimit: process.env.ENTRY_LIMIT || null,
+	sectionLimit: process.env.SECTION_LIMIT || null,
+	sourceMapType: sourceMapType || null,
+	sentryRelease: shouldCreateSentryRelease,
+} );
+
 if ( shouldCreateSentryRelease ) {
 	console.log(
 		"A sentry release is being created because the auth token exists and we're either on the trunk branch or the manual checkbox has been toggled."
@@ -413,19 +432,11 @@ const webpackConfig = {
 				cache: {
 					type: 'filesystem',
 					buildDependencies: {
-						config: [ __filename ],
+						config: webpackCacheBuildDependencies,
 					},
 					cacheDirectory: path.resolve( cachePath, 'webpack' ),
 					profile: true,
-					version: [
-						// No need to add BROWSERSLIST, as it is already part of the cacheDirectory
-						shouldBuildChunksMap,
-						shouldMinify,
-						process.env.ENTRY_LIMIT,
-						process.env.SECTION_LIMIT,
-						process.env.NODE_ENV,
-						process.env.CALYPSO_ENV,
-					].join( '-' ),
+					version: webpackCacheVersion,
 				},
 				infrastructureLogging: {
 					debug: /webpack\.cache/,

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -101,13 +101,13 @@ const webpackCacheBuildDependencies = [
 	require.resolve( '@automattic/calypso-build/webpack/util' ),
 	// Dependency graph changes
 	path.resolve( __dirname, '../yarn.lock' ),
+	path.resolve( __dirname, '../.yarnrc.yml' ),
 ];
 
 const cacheFlavorParts = [ `mode=${ bundleEnv }`, `devtool=${ sourceMapType || 'none' }` ];
 const webpackCacheName = `client-${ cacheFlavorParts.join( '__' ) }`;
 
-// These are things that should invalidate everything.
-// Or inputs that mean "the old cache is wrong".
+// Inputs that should invalidate a cache flavor.
 const webpackCacheVersion = JSON.stringify( {
 	bundleEnv,
 	nodeEnv: process.env.NODE_ENV || null,
@@ -118,6 +118,7 @@ const webpackCacheVersion = JSON.stringify( {
 	sectionLimit: process.env.SECTION_LIMIT || null,
 	emitStats: shouldEmitStats,
 	concatenateModules: shouldConcatenateModules,
+	hotReload: shouldHotReload,
 } );
 
 if ( shouldCreateSentryRelease ) {

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -80,12 +80,31 @@ if ( ! sourceMapType && shouldCreateSentryRelease ) {
 
 const webpackCacheBuildDependencies = [
 	__filename,
+	// Top-level config inputs that change compilation behavior
 	path.resolve( __dirname, '../package.json' ),
 	path.resolve( __dirname, '../babel.config.js' ),
+	// Config modules used by this webpack config
+	require.resolve( './webpack.common' ),
+	require.resolve( './server/config' ),
+	// Local build tools that influence compilation
+	require.resolve( '../build-tools/babel/babel-loader-cache-identifier' ),
+	require.resolve( '../build-tools/webpack/assets-writer-plugin.js' ),
+	require.resolve( '../build-tools/webpack/generate-chunks-map-plugin' ),
+	require.resolve( '../build-tools/webpack/readonly-cache-plugin' ),
+	require.resolve( '../build-tools/webpack/require-chunk-callback-plugin' ),
+	require.resolve( '../build-tools/webpack/sections-loader' ),
+	// Workspace config helper modules used to build rules/plugins
+	require.resolve( '@automattic/calypso-build/webpack/file-loader' ),
+	require.resolve( '@automattic/calypso-build/webpack/minify' ),
+	require.resolve( '@automattic/calypso-build/webpack/sass' ),
+	require.resolve( '@automattic/calypso-build/webpack/transpile' ),
+	require.resolve( '@automattic/calypso-build/webpack/util' ),
+	// Dependency graph changes
+	path.resolve( __dirname, '../yarn.lock' ),
 ];
 
-const cacheFlavorParts = [ `devtool=${ sourceMapType || 'none' }` ];
-const cacheName = `client-${ cacheFlavorParts.join( '__' ) }`;
+const cacheFlavorParts = [ `mode=${ bundleEnv }`, `devtool=${ sourceMapType || 'none' }` ];
+const webpackCacheName = `client-${ cacheFlavorParts.join( '__' ) }`;
 
 // These are things that should invalidate everything.
 // Or inputs that mean "the old cache is wrong".
@@ -97,6 +116,8 @@ const webpackCacheVersion = JSON.stringify( {
 	minify: shouldMinify,
 	entryLimit: process.env.ENTRY_LIMIT || null,
 	sectionLimit: process.env.SECTION_LIMIT || null,
+	emitStats: shouldEmitStats,
+	concatenateModules: shouldConcatenateModules,
 } );
 
 if ( shouldCreateSentryRelease ) {
@@ -433,7 +454,7 @@ const webpackConfig = {
 		? {
 				cache: {
 					type: 'filesystem',
-					name: cacheName,
+					name: webpackCacheName,
 					buildDependencies: {
 						config: webpackCacheBuildDependencies,
 					},

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -80,34 +80,20 @@ if ( ! sourceMapType && shouldCreateSentryRelease ) {
 
 const webpackCacheBuildDependencies = [
 	__filename,
-	// Top-level config inputs that change compilation behavior
 	path.resolve( __dirname, '../package.json' ),
 	path.resolve( __dirname, '../babel.config.js' ),
-	// Config modules used by this webpack config
-	require.resolve( './webpack.common' ),
-	require.resolve( './server/config' ),
-	// Local build tools that influence compilation
-	require.resolve( '../build-tools/babel/babel-loader-cache-identifier' ),
-	require.resolve( '../build-tools/webpack/assets-writer-plugin.js' ),
-	require.resolve( '../build-tools/webpack/generate-chunks-map-plugin' ),
-	require.resolve( '../build-tools/webpack/readonly-cache-plugin' ),
-	require.resolve( '../build-tools/webpack/require-chunk-callback-plugin' ),
-	require.resolve( '../build-tools/webpack/sections-loader' ),
-	// Workspace config helper modules used to build rules/plugins
-	require.resolve( '@automattic/calypso-build/webpack/file-loader' ),
-	require.resolve( '@automattic/calypso-build/webpack/minify' ),
-	require.resolve( '@automattic/calypso-build/webpack/sass' ),
-	require.resolve( '@automattic/calypso-build/webpack/transpile' ),
-	require.resolve( '@automattic/calypso-build/webpack/util' ),
-	// Dependency graph changes
 	path.resolve( __dirname, '../yarn.lock' ),
+	path.resolve( __dirname, '../.yarnrc.yml' ),
+	require.resolve( '../build-tools/webpack/sections-loader' ),
 ];
 
-const cacheFlavorParts = [ `mode=${ bundleEnv }`, `devtool=${ sourceMapType || 'none' }` ];
+const cacheFlavorParts = [
+	`mode=${ isDevelopment ? 'development' : 'production' }`,
+	`devtool=${ sourceMapType || 'none' }`,
+];
 const webpackCacheName = `client-${ cacheFlavorParts.join( '__' ) }`;
 
-// These are things that should invalidate everything.
-// Or inputs that mean "the old cache is wrong".
+// Inputs that should invalidate a cache flavor.
 const webpackCacheVersion = JSON.stringify( {
 	bundleEnv,
 	nodeEnv: process.env.NODE_ENV || null,
@@ -118,6 +104,7 @@ const webpackCacheVersion = JSON.stringify( {
 	sectionLimit: process.env.SECTION_LIMIT || null,
 	emitStats: shouldEmitStats,
 	concatenateModules: shouldConcatenateModules,
+	hotReload: shouldHotReload,
 } );
 
 if ( shouldCreateSentryRelease ) {


### PR DESCRIPTION
## Proposed Changes

* Split the client webpack filesystem cache into explicit cache flavors with `cache.name`, using the bundle mode and effective `devtool` value (`none`, `eval`, `hidden-source-map`, etc.).
* Replace the old dash-joined cache `version` string with a serialized object that captures the build toggles this config actually responds to, including minification, chunk-map generation, entry/section limits, `NODE_ENV`, `CALYPSO_ENV`, stats emission, module concatenation, and hot reload.
* Expand `buildDependencies.config` so webpack invalidates the cache when relevant top-level config, lockfile, or local webpack/build-tool modules change.

## Why are these changes being made?

* The current persistent cache is still under-keyed relative to how `client/webpack.config.js` behaves.
* In practice, different build flavors can produce materially different compilations even when they currently share the same cache namespace. The main example is `devtool` / sourcemap mode, which differs across common PR builds, local development, and trunk/manual Sentry-release builds.
* This branch also makes the cache more honest about its inputs. Changes to shared webpack helpers, `babel.config.js`, package metadata, or the dependency graph should invalidate the cache instead of relying on manual cache bumps.
* That makes cache reuse safer in CI and reduces the chance of restoring stale filesystem-cache entries across incompatible build modes.
* Under the current TeamCity setup, `Dockerfile.base` still primes the `hidden-source-map` flavor, so this change is primarily about correctness first. Optimizing the warmed cache for the common PR path remains a follow-up.

## Testing Instructions

* Review `client/webpack.config.js` and confirm the persistent cache now defines all three of:
  * `cache.name`
  * an expanded `buildDependencies.config`
  * a JSON-stringified `cache.version`
* Run:
  `node -e "process.env.PERSISTENT_CACHE='true'; process.env.CALYPSO_ENV='production'; process.env.NODE_ENV='production'; process.env.BROWSERSLIST_ENV='evergreen'; const config=require('./client/webpack.config.js'); console.log(config.cache.name); console.log(config.cache.buildDependencies.config); console.log(config.cache.version);"`
  and verify the cache name is `client-mode=production__devtool=none`, the build dependencies include the added config/build-tool files, and the version is a serialized object rather than the old dash-joined string.
* Run:
  `node -e "process.env.PERSISTENT_CACHE='true'; process.env.CALYPSO_ENV='development'; process.env.NODE_ENV='development'; process.env.BROWSERSLIST_ENV='evergreen'; const config=require('./client/webpack.config.js'); console.log(config.cache.name); console.log(config.cache.version);"`
  and verify the cache name switches to the development flavor (`client-mode=development__devtool=eval`) and the version reflects development-specific inputs such as hot reload.
* Optionally, set `SENTRY_AUTH_TOKEN` together with `IS_DEFAULT_BRANCH=true` or `MANUAL_SENTRY_RELEASE=true` and verify the cache name switches to the `hidden-source-map` flavor when `SOURCEMAP` is otherwise unset.
* In CI, expect a one-time invalidation from the old cache layout, followed by reuse only for later builds with the same cache flavor and version inputs.
* Keep in mind that the currently published base image is still primed with `SOURCEMAP=hidden-source-map` in `Dockerfile.base`, so production PR builds that use `devtool=none` may not benefit from that warmed cache until the priming step is updated separately.
