### PR TITLE
Reader: Support arrow keys to navigate posts

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -264,24 +264,26 @@ export class FullPostView extends Component {
 			return;
 		}
 
-		switch ( event.keyCode ) {
-			// Close full post - Esc
-			case 27: {
+		switch ( event.key ) {
+			// Close full post.
+			case 'Escape': {
 				return this.handleBack( event );
 			}
 
-			// Like post - l
-			case 76: {
+			// Like post.
+			case 'l': {
 				return this.handleLike();
 			}
 
-			// Next post - j
-			case 74: {
+			// Next post.
+			case 'ArrowRight':
+			case 'j': {
 				return this.goToPost( this.props.nextPostKey );
 			}
 
-			// Previous post - k
-			case 75: {
+			// Previous post.
+			case 'ArrowLeft':
+			case 'k': {
 				return this.goToPost( this.props.previousPostKey );
 			}
 		}

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -314,34 +314,36 @@ class ReaderStream extends Component {
 			return;
 		}
 
-		switch ( event.keyCode ) {
-			// Move selection down - j
-			case 74: {
+		switch ( event.key ) {
+			// Move selection down.
+			case 'ArrowRight':
+			case 'j': {
 				return this.selectNextItem();
 			}
 
-			// Move selection up - k
-			case 75: {
+			// Move selection up.
+			case 'ArrowLeft':
+			case 'k': {
 				return this.selectPrevItem();
 			}
 
-			// Open selection - Enter
-			case 13: {
+			// Open selection.
+			case 'Enter': {
 				return this.handleOpenSelection();
 			}
 
-			// Open selection in a new tab - v
-			case 86: {
+			// Open selection in a new tab.
+			case 'v': {
 				return this.handleOpenSelectionNewTab();
 			}
 
-			// Like selection - l
-			case 76: {
+			// Like selection.
+			case 'l': {
 				return this.toggleLikeOnSelectedPost();
 			}
 
-			// Go to top - .
-			case 190: {
+			// Go to top.
+			case '.': {
 				return this.goToTop();
 			}
 		}

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -341,11 +341,6 @@ class ReaderStream extends Component {
 			case 'l': {
 				return this.toggleLikeOnSelectedPost();
 			}
-
-			// Go to top.
-			case '.': {
-				return this.goToTop();
-			}
 		}
 	};
 
@@ -388,13 +383,6 @@ class ReaderStream extends Component {
 		const toggler = likedPost ? this.props.unlikePost : this.props.likePost;
 		toggler( selectedPost.site_ID, selectedPost.ID, { source: 'reader' } );
 	}
-
-	goToTop = () => {
-		const { streamKey, updateCount } = this.props;
-		if ( updateCount > 0 ) {
-			this.props.showUpdates( { streamKey } );
-		}
-	};
 
 	getVisibleItemIndexes() {
 		return (


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes: [READ-354](https://linear.app/a8c/issue/READ-354/reader-adds-arrow-navigation-similar-to-jk-navigation)

## Proposed Changes

Add arrow keys navigation alongside J, K navigation.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Arrow keys are more user friendly to users that aren't familiar with J, K navigation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to /reader.
2. Open any reader card.
3. Verify navigation is working as expected using J, K and arrow keys.
4. Press escape.
5. Verify navigation on feed stream view.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
