### PR TITLE
Fix Activity Log capitalization on Cloud.jetpack.com when Backups Enabled

### DIFF
--- a/client/my-sites/activity/activity-log-v2/index.tsx
+++ b/client/my-sites/activity/activity-log-v2/index.tsx
@@ -66,7 +66,7 @@ const ActivityLogV2: FunctionComponent = () => {
 	const jetpackCloudHeader = siteHasFullActivityLog ? (
 		<div className="activity-log-v2__header">
 			<div className="activity-log-v2__header-left">
-				<div className="activity-log-v2__header-title">{ translate( 'Activity log' ) }</div>
+				<div className="activity-log-v2__header-title">{ translate( 'Activity Log' ) }</div>
 				<div className="activity-log-v2__header-text">
 					{ translate( 'This is the complete event history for your site' ) }
 				</div>
@@ -125,9 +125,9 @@ const ActivityLogV2: FunctionComponent = () => {
 			{ siteId && <QuerySitePlans siteId={ siteId } /> }
 			{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 			{ siteId && <QuerySiteCredentials siteId={ siteId } /> }
-			<DocumentHead title={ translate( 'Activity log' ) } />
+			<DocumentHead title={ translate( 'Activity Log' ) } />
 			{ isJetpackCloud() && <SidebarNavigation /> }
-			<PageViewTracker path="/activity-log/:site" title="Activity log" />
+			<PageViewTracker path="/activity-log/:site" title="Activity Log" />
 			{ settingsUrl && <TimeMismatchWarning siteId={ siteId } settingsUrl={ settingsUrl } /> }
 			{ ( isJetpackCloud() || isA8CForAgencies() ) && ! isWPCOMSite ? (
 				jetpackCloudHeader


### PR DESCRIPTION
Fixes ACTLOG-48 where it was noted that Activity Log is rendered as "Activity log" instead of "Activity Log".

## Proposed Changes

Adjusts header for consistency. Also updates document title.

Before:

<img width="1347" height="642" alt="image" src="https://github.com/user-attachments/assets/bc4cc4a6-70a0-4e74-9e9c-cfae64553347" />

After:

<img width="1413" height="655" alt="image" src="https://github.com/user-attachments/assets/f58f4010-0ca1-4a07-ad2d-07d060c8805b" />


## Why are these changes being made?

- Noticed this while working on a customer site involving the Activity Log.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Access a site that has backup + extended Activity Log enabled: https://cloud.jetpack.com/activity-log/example.com
2. See that Activity Log is now properly capitalized in page heading. Previously rendered as “Activity log”. Also updates in document header.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
