### PR TITLE
Dashboard: OAuth-aware auth for Woo hostnames (take 2)

### DIFF
--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -79,10 +79,29 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 		}
 
 		authErrorHandled.current = true;
+
+		if ( config.isEnabled( 'oauth' ) ) {
+			const redirectUri = new URL( '/api/oauth/token', window.location.origin );
+			redirectUri.search = new URLSearchParams( {
+				next: window.location.pathname + window.location.search,
+			} ).toString();
+
+			const authUri = new URL( 'https://public-api.wordpress.com/oauth2/authorize' );
+			authUri.search = new URLSearchParams( {
+				response_type: 'token',
+				client_id: String( config( 'oauth_client_id' ) ),
+				redirect_uri: redirectUri.toString(),
+				scope: 'global',
+				blog_id: '0',
+			} ).toString();
+
+			window.location.replace( authUri.toString() );
+			return;
+		}
+
 		const currentPath = window.location.href;
 		const path = config( 'wpcom_login_url' ) || '/log-in';
 		const loginUrl = `${ path }?redirect_to=${ encodeURIComponent( currentPath ) }`;
-
 		window.location.href = loginUrl;
 	}, [] );
 

--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -11,6 +11,7 @@ import {
 	type MutationCacheNotifyEvent,
 } from '@tanstack/react-query';
 import { createContext, useContext, useMemo, useEffect, useRef, useCallback } from 'react';
+import { OAUTH_CALLBACK_PATH } from './oauth-callback';
 import type { WPError } from '@automattic/api-core';
 
 export const AUTH_QUERY_KEY = [ 'auth', 'user' ];
@@ -81,7 +82,7 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 		authErrorHandled.current = true;
 
 		if ( config.isEnabled( 'oauth' ) ) {
-			const redirectUri = new URL( '/api/oauth/token', window.location.origin );
+			const redirectUri = new URL( OAUTH_CALLBACK_PATH, window.location.origin );
 			redirectUri.search = new URLSearchParams( {
 				next: window.location.pathname + window.location.search,
 			} ).toString();

--- a/client/dashboard/app/auth/oauth-callback.ts
+++ b/client/dashboard/app/auth/oauth-callback.ts
@@ -1,0 +1,32 @@
+import store from 'store';
+
+export const OAUTH_CALLBACK_PATH = '/oauth/token';
+
+/**
+ * Handle the OAuth token callback before React mounts.
+ * Must run before AuthProvider, which would otherwise redirect away.
+ * Returns true if the callback was handled (caller should return early).
+ */
+export function handleOAuthCallback(): boolean {
+	if ( window.location.pathname !== OAUTH_CALLBACK_PATH ) {
+		return false;
+	}
+
+	const hash = new URLSearchParams( window.location.hash.substring( 1 ) );
+
+	const accessToken = hash.get( 'access_token' );
+	if ( accessToken ) {
+		store.set( 'wpcom_token', accessToken );
+	}
+
+	const expiresIn = hash.get( 'expires_in' );
+	if ( expiresIn ) {
+		store.set( 'wpcom_token_expires_in', expiresIn );
+	}
+
+	const params = new URLSearchParams( window.location.search );
+	const next = params.get( 'next' ) || '/';
+	document.location.replace( next );
+
+	return true;
+}

--- a/client/dashboard/app/boot.tsx
+++ b/client/dashboard/app/boot.tsx
@@ -11,6 +11,7 @@ import '@wordpress/commands/build-style/style.css';
 import loadDevHelpers from 'calypso/lib/load-dev-helpers';
 import wpcom from 'calypso/lib/wp';
 import isDashboardEnv from '../utils/is-dashboard-env';
+import { handleOAuthCallback } from './auth/oauth-callback';
 import { loadPreferencesHelper } from './dev-tools/preferences';
 import Layout from './layout';
 import limitTotalSnackbars from './snackbars/limit-total-snackbars';
@@ -19,6 +20,10 @@ import type { AppConfig } from './context';
 import './style.scss';
 
 function boot( config: AppConfig ) {
+	if ( handleOAuthCallback() ) {
+		return;
+	}
+
 	if ( ! isDashboardEnv() && ! isEnabled( 'dashboard/v2' ) && ! isSupportSession() ) {
 		throw new Error( 'Multi-site Dashboard is not enabled' );
 	}

--- a/client/dashboard/section.ts
+++ b/client/dashboard/section.ts
@@ -1,1 +1,9 @@
-export const DASHBOARD_SECTION_PATHS = [ '/', '/sites', '/domains', '/emails', '/plugins', '/me' ];
+export const DASHBOARD_SECTION_PATHS = [
+	'/',
+	'/sites',
+	'/domains',
+	'/emails',
+	'/plugins',
+	'/me',
+	'/oauth/token',
+];

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -30,22 +30,35 @@ import { serialize } from 'calypso/state/utils';
 const debug = debugFactory( 'calypso:server-render' );
 
 /**
- * Returns per-request clientData with hostname overridden when the request
- * arrives on an allowed alternate hostname (e.g. behind a reverse proxy).
- * When the request hostname is not in the allowlist, the clientData is
- * returned unchanged — the configured default hostname is used.
- * When no hostname_allowlist is configured, returns clientData as-is.
+ * Returns per-request clientData customized for the request hostname.
+ * Overrides hostname when the request arrives on an allowed alternate
+ * hostname, and applies any hostname-specific overrides (features, OAuth
+ * client, login/logout URLs, etc.) from hostname_overrides config.
  */
 export function customizeClientDataForRequest( req, baseClientData ) {
-	const allowlist = config( 'hostname_allowlist' );
-	if ( ! Array.isArray( allowlist ) ) {
-		return baseClientData;
-	}
 	const reqHostname = req.hostname;
-	if ( allowlist.includes( reqHostname ) && reqHostname !== config( 'hostname' ) ) {
-		return { ...baseClientData, hostname: reqHostname };
+	let clientData = baseClientData;
+
+	const hostnameAllowlist = config( 'hostname_allowlist' );
+	if (
+		Array.isArray( hostnameAllowlist ) &&
+		hostnameAllowlist.includes( reqHostname ) &&
+		reqHostname !== config( 'hostname' )
+	) {
+		clientData = { ...clientData, hostname: reqHostname };
 	}
-	return baseClientData;
+
+	const hostnameOverrides = config( 'hostname_overrides' );
+	if ( typeof hostnameOverrides === 'object' && hostnameOverrides[ reqHostname ] ) {
+		const { features: overrideFeatures, ...overrideData } = hostnameOverrides[ reqHostname ];
+		clientData = {
+			...clientData,
+			...overrideData,
+			features: { ...clientData.features, ...overrideFeatures },
+		};
+	}
+
+	return clientData;
 }
 
 const HOUR_IN_MS = 3600000;

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -14,6 +14,7 @@
 	"survicate_enabled_at_help_center": true,
 	"hostname": false,
 	"hostname_allowlist": false,
+	"hostname_overrides": false,
 	"i18n_default_locale_slug": "en",
 	"lasagna_url": "wss://rt-api.wordpress.com/socket",
 	"login_url": false,

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -6,6 +6,14 @@
 	"survicate_enabled": true,
 	"hostname": "my.localhost",
 	"hostname_allowlist": [ "my.localhost", "my.woo.localhost" ],
+	"hostname_overrides": {
+		"my.woo.localhost": {
+			"oauth_client_id": 134404,
+			"wpcom_login_url": false,
+			"logout_url": "http://my.woo.localhost:3000",
+			"features": { "oauth": true }
+		}
+	},
 	"i18n_default_locale_slug": "en",
 	"port": 3000,
 	"wpcom_signup_id": "39911",

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -6,6 +6,14 @@
 	"survicate_enabled": true,
 	"hostname": "my.wordpress.com",
 	"hostname_allowlist": [ "my.wordpress.com", "my.woo.ai" ],
+	"hostname_overrides": {
+		"my.woo.ai": {
+			"oauth_client_id": 134405,
+			"wpcom_login_url": false,
+			"logout_url": "https://woo.com",
+			"features": { "oauth": true }
+		}
+	},
 	"i18n_default_locale_slug": "en",
 	"wpcom_signup_id": "39911",
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -6,6 +6,14 @@
 	"survicate_enabled": true,
 	"hostname": "my.wordpress.com",
 	"hostname_allowlist": [ "my.wordpress.com", "my.woo.ai" ],
+	"hostname_overrides": {
+		"my.woo.ai": {
+			"oauth_client_id": 134405,
+			"wpcom_login_url": false,
+			"logout_url": "https://woo.com",
+			"features": { "oauth": true }
+		}
+	},
 	"i18n_default_locale_slug": "en",
 	"wpcom_signup_id": "39911",
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -6,6 +6,14 @@
 	"survicate_enabled": true,
 	"hostname": "my.wordpress.com",
 	"hostname_allowlist": [ "my.wordpress.com", "my.woo.ai" ],
+	"hostname_overrides": {
+		"my.woo.ai": {
+			"oauth_client_id": 134405,
+			"wpcom_login_url": false,
+			"logout_url": "https://woo.com",
+			"features": { "oauth": true }
+		}
+	},
 	"i18n_default_locale_slug": "en",
 	"wpcom_signup_id": "39911",
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",

--- a/config/development.json
+++ b/config/development.json
@@ -6,6 +6,14 @@
 	"protocol": "http",
 	"hostname": "calypso.localhost",
 	"hostname_allowlist": [ "calypso.localhost", "my.localhost", "my.woo.localhost" ],
+	"hostname_overrides": {
+		"my.woo.localhost": {
+			"oauth_client_id": 134404,
+			"wpcom_login_url": "/connect",
+			"logout_url": "http://my.woo.localhost:3000",
+			"features": { "oauth": true }
+		}
+	},
 	"port": 3000,
 	"i18n_default_locale_slug": "en",
 	"siftscience_key": "e00e878351",


### PR DESCRIPTION
Another attempt at #109038, part of DOTMSD-1115

## Proposed Changes

* When `oauth` feature is enabled (Woo hostnames), redirect to the WordPress.com OAuth authorize endpoint on auth failure instead of the cookie-based login URL.
* Add `hostname_overrides` config key to inject per-hostname feature flags and settings (OAuth client ID, login/logout URLs).
* Handle the OAuth token callback at `/oauth/token` — extract the access token from the URL hash, store it in localStorage, and redirect to the original page.
* Add `/oauth/token` to `DASHBOARD_SECTION_PATHS` so the server serves the SPA shell for the callback URL.

The issue with #109038 that this PR fixes is that the dashboard container didn't have an `/api/auth/token` route at all. I've implemented that simple route inside the dashboard code rather than pulling in the heavier Calypso implementation.

## Why are these changes being made?

The Dashboard served on `my.woo.ai` cannot use WordPress.com session cookies (different domain). This wires up the OAuth implicit-grant flow so the Dashboard can authenticate via `public-api.wordpress.com/oauth2/authorize` when running on Woo hostnames, while `my.wordpress.com` continues using cookie auth unchanged.

## Known Issues

* **2FA reauth check**: Users with 2FA enabled will hit `two_step_reauthorization_required` on the `/me` route because OAuth tokens always report reauth as required. This redirects to the Calypso reauth page which doesn't work cross-origin. A backend change is needed to fix the two-step API response for OAuth tokens before this works correctly for 2FA users.

## Testing Instructions

So far only tested on `localhost`, but I think that is ok to merge.

> [!important]
> **It is important to use `yarn start-dashboard` specifically!**

1. `yarn start-dashboard`
2. Visit `http://my.woo.localhost:3000` — should redirect to `public-api.wordpress.com/oauth2/authorize` with `client_id=134404`
3. After authorizing, should redirect back to `/oauth/token`, store the token, and land on the dashboard
4. Visit `http://my.localhost:3000` — should work as before (cookie auth)