### PR TITLE
Fix Jetpack connection banner spacing in backport overview

### DIFF
--- a/client/sites/v2/site-overview/style.scss
+++ b/client/sites/v2/site-overview/style.scss
@@ -15,7 +15,7 @@
 	}
 
 	.dashboard-notice {
-		margin-block-end: 16px;
+		margin-block-end: 24px;
 	}
 
 	.dataviews-wrapper {

--- a/client/sites/v2/site-overview/style.scss
+++ b/client/sites/v2/site-overview/style.scss
@@ -14,6 +14,10 @@
 		display: none;
 	}
 
+	.dashboard-notice {
+		margin-block-end: 16px;
+	}
+
 	.dataviews-wrapper {
 		.dataviews-no-results {
 			// In v1 we specify margins for <p> globally in <body>.


### PR DESCRIPTION
## Proposed Changes

* Add `margin-block-end: 24px` to `.dashboard-notice` in the backport site overview styles to create spacing between the Jetpack connection error banner and the overview cards below it.

## Why are these changes being made?

The backport site overview sets `gap: 0` on `.dashboard-page-layout` to remove the default VStack spacing (since the header is hidden). This also removes spacing between the Jetpack connection error banner ("Your Jetpack site can not be reached at this time.") and the overview cards, causing them to touch. The dashboard client doesn't have this issue because its `PageLayout` VStack `spacing={8}` is preserved.

## Screenshots

| Before | After |
|--------|-------|
| <img width="2530" height="1858" alt="wordpress com_sites_abstracting blog" src="https://github.com/user-attachments/assets/e8198574-ab27-4510-84e9-d17ded82f6df" /> | <img width="2530" height="1858" alt="calypso localhost_3000_sites_abstracting blog" src="https://github.com/user-attachments/assets/860cd7f2-4e2b-4c80-b93c-ab51917fa0d8" /> |


## Testing Instructions

* Visit a backported site overview page for a Jetpack site that has a connection error.
* Verify the Jetpack connection banner has spacing below it, separating it from the overview cards.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?