### PR TITLE
MSD > Security: Update two-step auth copy and enable enhanced security in production

### DIFF
--- a/client/dashboard/me/security-two-step-auth/main-page/application-passwords/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/application-passwords/index.tsx
@@ -2,7 +2,6 @@ import {
 	twoStepAuthApplicationPasswordsQuery,
 	deleteTwoStepAuthApplicationPasswordMutation,
 } from '@automattic/api-queries';
-import { localizeUrl } from '@automattic/i18n-utils';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import {
 	Button,
@@ -10,7 +9,6 @@ import {
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
@@ -18,7 +16,6 @@ import { useAnalytics } from '../../../../app/analytics';
 import { useLocale } from '../../../../app/locale';
 import { ActionList } from '../../../../components/action-list';
 import ConfirmModal from '../../../../components/confirm-modal';
-import InlineSupportLink from '../../../../components/inline-support-link';
 import { SectionHeader } from '../../../../components/section-header';
 import RegisterApplicationPassword from './register-application-password';
 import type { TwoStepAuthApplicationPassword } from '@automattic/api-core';
@@ -124,20 +121,8 @@ export default function ApplicationPasswords() {
 						<SectionHeader
 							level={ 3 }
 							title={ __( 'Application passwords' ) }
-							description={ createInterpolateElement(
-								__(
-									'Generate a custom password for each third-party application you authorize to use your WordPress.com account. <learnMoreLink />'
-								),
-								{
-									learnMoreLink: (
-										<InlineSupportLink
-											supportPostId={ 263616 }
-											supportLink={ localizeUrl(
-												'https://wordpress.com/support/security/two-step-authentication/application-specific-passwords'
-											) }
-										/>
-									),
-								}
+							description={ __(
+								'Create a password for each third-party app connected to your WordPress.com account.'
 							) }
 						/>
 						<VStack style={ { flexShrink: 0 } }>

--- a/client/dashboard/me/security-two-step-auth/main-page/security-keys/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/security-keys/index.tsx
@@ -75,12 +75,12 @@ const SecurityKeysList = ( {
 						description={
 							isBrowserSupported
 								? createInterpolateElement(
-										__( 'Use a <securityKeyLink /> to login to your account.' ),
+										__(
+											'Use a <securityKeyLink>security key</securityKeyLink> to log in to your account.'
+										),
 										{
 											securityKeyLink: (
-												<InlineSupportLink supportContext="two-step-authentication-security-key">
-													{ __( 'security key' ) }
-												</InlineSupportLink>
+												<InlineSupportLink supportContext="two-step-authentication-security-key" />
 											),
 										}
 								  )

--- a/client/dashboard/me/security-two-step-auth/main-page/security-keys/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/security-keys/index.tsx
@@ -75,11 +75,9 @@ const SecurityKeysList = ( {
 						description={
 							isBrowserSupported
 								? createInterpolateElement(
-										__(
-											'Security keys offer a more robust form of two-step authentication. <learnMoreLink />'
-										),
+										__( 'Use a <securityKey /> to login to your account.' ),
 										{
-											learnMoreLink: (
+											securityKey: (
 												<InlineSupportLink supportContext="two-step-authentication-security-key" />
 											),
 										}

--- a/client/dashboard/me/security-two-step-auth/main-page/security-keys/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/security-keys/index.tsx
@@ -75,10 +75,12 @@ const SecurityKeysList = ( {
 						description={
 							isBrowserSupported
 								? createInterpolateElement(
-										__( 'Use a <securityKey /> to login to your account.' ),
+										__( 'Use a <securityKeyLink /> to login to your account.' ),
 										{
-											securityKey: (
-												<InlineSupportLink supportContext="two-step-authentication-security-key" />
+											securityKeyLink: (
+												<InlineSupportLink supportContext="two-step-authentication-security-key">
+													{ __( 'security key' ) }
+												</InlineSupportLink>
 											),
 										}
 								  )

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -24,7 +24,7 @@
 		"marketplace-redesign": true,
 		"mcp-settings": true,
 		"wordpress-ai-tools": true,
-		"two-factor/enhanced-security": false
+		"two-factor/enhanced-security": true
 	},
 	"enable_all_sections": false,
 	"site_filter": [],

--- a/config/production.json
+++ b/config/production.json
@@ -165,6 +165,7 @@
 		"themes/subscription-purchases": false,
 		"themes/universal-header": true,
 		"plugins/universal-header": true,
+		"two-factor/enhanced-security": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/pull/108539

## Proposed Changes

- Simplify application passwords description copy (removed inline support link and verbose wording)
- Update security keys description to be more concise, with explicit "security key" link text pointing to the support article
- Enable `two-factor/enhanced-security` feature flag in `dashboard-production.json`

## Why are these changes being made?

Clean up the two-step authentication page copy to be more concise and user-friendly, and enable the enhanced security feature in production.

## Screenshot

<img width="751" height="589" alt="Screenshot 2026-03-09 at 12 48 30 PM" src="https://github.com/user-attachments/assets/d11e108f-7956-4ecb-a8c4-ebee267f1a7a" />



## Testing Instructions

- Navigate to the Dashboard **Security > Two-step authentication** page
- Verify the "Security keys" section shows: "Use a **security key** to log in to your account." (with "security key" as a support link)
- Verify the "Application passwords" section shows: "Create a password for each third-party app connected to your WordPress.com account."
- Verify the "Enhanced Security" section is enabled on the production env file.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?