### PR TITLE
Reader: Fix ReaderFeedHeader not showing on large screens

### DIFF
--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -38,12 +38,10 @@ class ReaderFeedHeader extends Component {
 		const siteTitle = getSiteName( { feed, site } );
 		const siteUrl = getSiteUrl( { feed, site } );
 		const siteIcon = site ? get( site, 'icon.img' ) : null;
-		const wideDisplay = width > 900;
 		const narrowDisplay = width < 480;
 
 		const classes = clsx( 'reader-feed-header', {
 			'is-placeholder': ! site && ! feed,
-			'is-wide-display': wideDisplay,
 		} );
 
 		let feedIcon = feed ? feed.site_icon ?? get( feed, 'image' ) : null;
@@ -103,7 +101,7 @@ class ReaderFeedHeader extends Component {
 
 							<div className="reader-feed-header__description">{ description }</div>
 
-							{ ! wideDisplay && followerCount && (
+							{ followerCount && (
 								<div className="reader-feed-header__follow-count">
 									{ ' ' }
 									{ translate( '%s subscriber', '%s subscribers', {
@@ -116,9 +114,7 @@ class ReaderFeedHeader extends Component {
 						</div>
 					</Card>
 				</AutoDirection>
-				{ ! wideDisplay && (
-					<ReaderFeedHeaderFollow feed={ feed } site={ site } streamKey={ streamKey } />
-				) }
+				<ReaderFeedHeaderFollow feed={ feed } site={ site } streamKey={ streamKey } />
 			</div>
 		);
 	}

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -1,3 +1,18 @@
+.is-site-stream.is-two-columns {
+	.reader-feed-header__site {
+		align-items: center;
+		margin-bottom: 36px;
+	}
+
+	.reader-feed-header__follow-count {
+		display: none;
+	}
+
+	.reader-feed-header .reader-feed-header__follow {
+		display: none;
+	}
+}
+
 .reader-feed-header .reader-feed-header__site {
 	display: flex;
 	margin-bottom: 16px;
@@ -28,10 +43,6 @@
 	}
 }
 
-.reader-feed-header.is-wide-display .reader-feed-header__site {
-	align-items: center;
-	margin-bottom: 36px;
-}
 
 .reader-feed-header__seen-button {
 	align-items: center;

--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -5,7 +5,6 @@ import QueryPostCounts from 'calypso/components/data/query-post-counts';
 import QueryReaderFeed from 'calypso/components/data/query-reader-feed';
 import QueryReaderSite from 'calypso/components/data/query-reader-site';
 import { useSiteTags } from 'calypso/data/site-tags/use-site-tags';
-import withDimensions from 'calypso/lib/with-dimensions';
 import ReaderBackButton from 'calypso/reader/components/back-button';
 import FeedError from 'calypso/reader/feed-error';
 import { getFollowerCount, getSiteName } from 'calypso/reader/get-helpers';
@@ -56,12 +55,12 @@ const FeedStream = ( props ) => {
 		return <FeedError sidebarTitle={ title } />;
 	}
 
-	const streamSidebar = () => (
+	const streamSidebar = ( isWideLayout ) => (
 		<FeedStreamSidebar
 			feed={ feed }
 			followerCount={ followerCount }
 			postCount={ postCount }
-			showFollow={ props.width > 900 }
+			isWideLayout={ isWideLayout }
 			site={ site }
 			streamKey={ props.streamKey }
 			tags={ siteTags.data }
@@ -96,4 +95,4 @@ const FeedStream = ( props ) => {
 	);
 };
 
-export default withDimensions( FeedStream );
+export default FeedStream;

--- a/client/reader/site-stream/index.jsx
+++ b/client/reader/site-stream/index.jsx
@@ -7,7 +7,6 @@ import QueryPostCounts from 'calypso/components/data/query-post-counts';
 import QueryReaderFeed from 'calypso/components/data/query-reader-feed';
 import QueryReaderSite from 'calypso/components/data/query-reader-site';
 import { useSiteTags } from 'calypso/data/site-tags/use-site-tags';
-import withDimensions from 'calypso/lib/with-dimensions';
 import FeedError from 'calypso/reader/feed-error';
 import { getFollowerCount } from 'calypso/reader/get-helpers';
 import SiteBlocked from 'calypso/reader/site-blocked';
@@ -51,13 +50,14 @@ const SiteStream = ( props ) => {
 		return <FeedError sidebarTitle={ title } />;
 	}
 
-	const streamSidebar = () => (
+	const streamSidebar = ( isWideLayout ) => (
 		<FeedStreamSidebar
 			feed={ feed }
 			followerCount={ followerCount }
 			postCount={ postCount }
-			showFollow={ props.width > 900 }
+			isWideLayout={ isWideLayout }
 			site={ site }
+			streamKey={ props.streamKey }
 			tags={ siteTags.data }
 		/>
 	);
@@ -89,4 +89,4 @@ const SiteStream = ( props ) => {
 	);
 };
 
-export default withDimensions( SiteStream );
+export default SiteStream;

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -668,9 +668,10 @@ class ReaderStream extends Component {
 		// TODO: `following` probably shouldn't be added as a class to every stream, but style selectors need
 		// to be updated before we can remove it.
 		let baseClassnames = clsx( 'following', this.props.className );
-
-		// @TODO: has error of invalid tag?
-		const sidebarContentFn = this.props.streamSidebar;
+		const SidebarContent =
+			typeof this.props.streamSidebar === 'function'
+				? this.props.streamSidebar( wideDisplay )
+				: null;
 
 		if ( hasNoPosts ) {
 			let emptyBody = this.props.emptyContent?.();
@@ -680,11 +681,11 @@ class ReaderStream extends Component {
 
 			// In wide display with a sidebar, render the two-column layout so the sidebar
 			// (with follow button, subscriber count, tags) remains visible for empty feeds.
-			if ( wideDisplay && sidebarContentFn && streamType !== 'search' ) {
+			if ( wideDisplay && SidebarContent && streamType !== 'search' ) {
 				body = (
 					<div className="stream__two-column">
 						<div className="reader__content">{ emptyBody }</div>
-						<div className="stream__right-column">{ sidebarContentFn?.() }</div>
+						<div className="stream__right-column">{ SidebarContent }</div>
 					</div>
 				);
 				baseClassnames = clsx( 'is-two-columns', baseClassnames );
@@ -713,7 +714,7 @@ class ReaderStream extends Component {
 			);
 
 			// Exclude the sidebar layout for the search stream, since it's handled by `<SiteResults>`.
-			if ( ! sidebarContentFn || streamType === 'search' ) {
+			if ( ! SidebarContent || streamType === 'search' ) {
 				body = (
 					<div className="reader__content">
 						{ isReaderCouncilStream && <CustomerCouncilBanner translate={ translate } /> }
@@ -728,7 +729,7 @@ class ReaderStream extends Component {
 							{ isReaderCouncilStream && <CustomerCouncilBanner translate={ translate } /> }
 							{ bodyContent }
 						</div>
-						<div className="stream__right-column">{ sidebarContentFn?.() }</div>
+						<div className="stream__right-column">{ SidebarContent }</div>
 					</div>
 				);
 				baseClassnames = clsx( 'is-two-columns', baseClassnames );
@@ -766,7 +767,7 @@ class ReaderStream extends Component {
 								<div className="reader__content">{ bodyContent }</div>
 							) }
 							{ this.state.selectedTab === 'sites' && (
-								<div className="stream__right-column">{ sidebarContentFn?.() }</div>
+								<div className="stream__right-column">{ SidebarContent }</div>
 							) }
 						</div>
 					</>

--- a/client/reader/stream/site-feed-sidebar/index.jsx
+++ b/client/reader/stream/site-feed-sidebar/index.jsx
@@ -5,13 +5,12 @@ import ReaderFeedHeaderFollow from 'calypso/blocks/reader-feed-header/follow';
 import TagLink from 'calypso/blocks/reader-post-card/tag-link';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
-import '../style.scss';
 
 const FeedStreamSidebar = ( {
 	feed,
 	followerCount,
 	postCount,
-	showFollow,
+	isWideLayout,
 	site,
 	streamKey,
 	tags,
@@ -37,7 +36,7 @@ const FeedStreamSidebar = ( {
 	return (
 		<>
 			<div className="reader-feed-header__follow">
-				{ showFollow && (
+				{ isWideLayout && (
 					<ReaderFeedHeaderFollow feed={ feed } site={ site } streamKey={ streamKey } />
 				) }
 			</div>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes: [READ-355](https://linear.app/a8c/issue/READ-355/reader-mark-all-as-seen-hidden-at-certain-window-widths)

## Proposed Changes

- Remove `wideDisplay` calculation from sub components and use the value calculated on `Stream` component.
- In one component I'm using CSS approach as passing `wideDisplay` value was a bit complex (either pass by context or calculate inside the component) 

| Before | After |
| -------|------| 
| <img width="1374" height="1011" alt="image" src="https://github.com/user-attachments/assets/f9a1b17e-8c37-4d0c-9419-0dbecca29f85" /> | <img width="1358" height="1012" alt="image" src="https://github.com/user-attachments/assets/5aa68e8c-ac5b-4050-8ccf-052f17b30c46" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We are calculating wide widths in two different components which was causing a mismatch. Now we rely on `wideDisplay` value calculated in `Stream` component.

## Testing Instructions

1. Go to `/reader/feeds/ID`.
1. Verify `ReaderFeedHeader` is now appearing as expected i.e. below the header when sidebar is hidden.
1. Go to `/reader/blogs/ID`.
1. Verify `ReaderFeedHeader` is now appearing as expected i.e. below the header when sidebar is hidden.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
