### PR TITLE
A4A: Add dedicated TeamCity build config for A4A E2E tests

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -27,6 +27,7 @@ object WebApp : Project({
 	buildType(PlaywrightTestPRMatrix)
 	buildType(PlaywrightTestPreReleaseMatrix)
 	buildType(PlaywrightTestDashboardPRMatrix)
+	buildType(PlaywrightTestA4APRMatrix)
 	buildType(JestPreReleaseE2ETests)
 	buildType(PreReleaseE2ETests)
 	buildType(AuthenticationE2ETests)
@@ -1045,6 +1046,60 @@ object PlaywrightTestDashboardPRMatrix : BuildType({
 				+:client/dashboard/**
 				+:packages/**
 				+:test/e2e/specs/dashboard/**
+			""".trimIndent()
+		}
+	}
+
+	dependencies {
+		snapshot(BuildDockerImage) {
+			onDependencyFailure = FailureAction.FAIL_TO_START
+		}
+	}
+})
+
+
+object PlaywrightTestA4APRMatrix : BuildType({
+	templates(CalypsoE2ETestsBuildTemplate)
+	id("calypso_WebApp_A4A_E2E_Playwright_Test_Matrix")
+	uuid = "1ac8958e-d3e6-4fd1-a0f5-d1b2614900e3"
+	name = "A4A E2E Tests (PR)"
+	description = "Runs Automattic for Agencies e2e tests on pull requests using Playwright Test runner with build matrix"
+
+	params {
+		param("TEST_GROUP", "@a8c-for-agencies")
+		param("DOCKER_IMAGE_BUILD_NUMBER", "${BuildDockerImage.depParamRefs.buildNumber}")
+	}
+
+	features {
+		matrix {
+			param("PROJECT", listOf(
+				value("desktop", label = "Desktop"),
+				value("mobile", label = "Mobile"),
+			))
+		}
+		pullRequests {
+			vcsRootExtId = "${Settings.WpCalypso.id}"
+			provider = github {
+				authType = token {
+					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
+				}
+				filterAuthorRole = PullRequests.GitHubRoleFilter.EVERYBODY
+			}
+		}
+	}
+
+	triggers {
+		vcs {
+			branchFilter = """
+				+:*
+				-:pull*
+				-:trunk
+			""".trimIndent()
+			triggerRules = """
+				-:**.md
+				+:client/a8c-for-agencies/**
+				+:packages/**
+				+:test/e2e/specs/a8c-for-agencies/**
 			""".trimIndent()
 		}
 	}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -1098,7 +1098,6 @@ object PlaywrightTestA4APRMatrix : BuildType({
 			triggerRules = """
 				-:**.md
 				+:client/a8c-for-agencies/**
-				+:packages/**
 				+:test/e2e/specs/a8c-for-agencies/**
 			""".trimIndent()
 		}

--- a/test/e2e/specs/a8c-for-agencies/signup__smoke.spec.ts
+++ b/test/e2e/specs/a8c-for-agencies/signup__smoke.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, tags } from '../../lib/pw-base';
 
 /**
- * Verify the A4A > Signup page loads
+ * Verify the A4A > Signup page loads.
  */
 test.describe( 'Automattic For Agencies: Sign Up Page', { tag: [ tags.A8C_FOR_AGENCIES ] }, () => {
 	test( 'As an unauthenticated web agency owner, I can enter my agency details and see these displayed', async ( {

--- a/test/e2e/specs/a8c-for-agencies/signup__smoke.spec.ts
+++ b/test/e2e/specs/a8c-for-agencies/signup__smoke.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, tags } from '../../lib/pw-base';
 
 /**
- * Verify the A4A > Signup page loads.
+ * Verify the A4A > Signup page loads
  */
 test.describe( 'Automattic For Agencies: Sign Up Page', { tag: [ tags.A8C_FOR_AGENCIES ] }, () => {
 	test( 'As an unauthenticated web agency owner, I can enter my agency details and see these displayed', async ( {


### PR DESCRIPTION
## Proposed Changes

* Add a new `PlaywrightTestA4APRMatrix` TeamCity build configuration that runs A4A Playwright specs (`@a8c-for-agencies` tag) on PRs.
* The build is modeled after the existing `PlaywrightTestDashboardPRMatrix` — runs desktop + mobile matrix, triggered only by changes to `client/a8c-for-agencies/**` or `test/e2e/specs/a8c-for-agencies/**`.

## Why are these changes being made?

The A4A Playwright E2E specs (`signup__smoke.spec.ts`, `partner-directory__smoke.spec.ts`) were tagged `@a8c-for-agencies` but no TeamCity build configuration existed to run them in CI. The default PR build only runs `@calypso-pr` tagged tests, so A4A specs were effectively never executed on PRs. This adds a dedicated CI check ("A4A E2E Tests (PR)") so A4A regressions are caught automatically when A4A code or specs change.

## Testing Instructions

* After merge, the new "A4A E2E Tests (PR)" check will appear on PRs that touch `client/a8c-for-agencies/` or `test/e2e/specs/a8c-for-agencies/` (TeamCity reads config from trunk).
* In the TeamCity build log, confirm:
  - "Determine test group" step shows `TEST_GROUP is set to: @a8c-for-agencies`
  - "Run e2e tests" step runs `yarn test:pw:desktop --grep=@a8c-for-agencies` (and mobile)
  - The A4A specs are listed in the test output

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
