### PR TITLE
Agents Manager: Pass site_id for per-site state storage

### DIFF
--- a/packages/agents-manager/src/components/agents-manager.tsx
+++ b/packages/agents-manager/src/components/agents-manager.tsx
@@ -1,6 +1,7 @@
 import { getAgentManager } from '@automattic/agenttic-client';
 import {
 	AgentsManagerSelect,
+	AgentsManager as AgentsManagerStore,
 	type AgentsManagerSite,
 	type CurrentUser,
 } from '@automattic/data-stores';
@@ -38,6 +39,9 @@ export default function AgentsManager( {
 	site,
 	currentRoute,
 }: AgentsManagerProps ): JSX.Element | null {
+	// Set site ID before the store resolver triggers, so state is fetched per-site.
+	AgentsManagerStore.setCurrentSiteId( typeof site?.ID === 'number' ? site.ID : undefined );
+
 	// Wait for the store to load before rendering PersistentRouter
 	// This ensures router history is restored from persisted state
 	const { hasLoaded: isStoreReady } = useSelect( ( select ) => {

--- a/packages/agents-manager/src/utils/persist-agents-manager-state.ts
+++ b/packages/agents-manager/src/utils/persist-agents-manager-state.ts
@@ -1,3 +1,4 @@
+import { AgentsManager } from '@automattic/data-stores';
 import apiFetch from '@wordpress/api-fetch';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 
@@ -5,19 +6,21 @@ import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
  * Persists agents manager state to the server.
  */
 export function persistAgentsManagerState( data: Record< string, unknown > ): void {
+	const siteId = AgentsManager.getCurrentSiteId();
+
 	if ( canAccessWpcomApis() ) {
 		wpcomRequest( {
 			path: '/agents-manager/state',
 			apiNamespace: 'wpcom/v2',
 			method: 'POST',
-			body: { state: data },
+			body: { state: data, site_id: siteId },
 		} ).catch( () => {} );
 	} else {
 		apiFetch( {
 			global: true,
 			path: '/agents-manager/open-state',
 			method: 'PUT',
-			data,
+			data: { ...data, site_id: siteId },
 		} as Parameters< typeof apiFetch >[ 0 ] ).catch( () => {} );
 	}
 }

--- a/packages/data-stores/src/agents-manager/actions.ts
+++ b/packages/data-stores/src/agents-manager/actions.ts
@@ -5,6 +5,27 @@ import { GeneratorReturnType } from '../mapped-types';
 import type { APIFetchOptions } from '../shared-types';
 
 /**
+ * Current site ID for per-site state storage.
+ * Set via `setCurrentSiteId()` before the store resolver runs.
+ */
+let currentSiteId: number | undefined;
+
+/**
+ * Set the current site ID for per-site state storage.
+ * Must be called before the agents manager store resolver triggers.
+ */
+export function setCurrentSiteId( siteId: number | undefined ): void {
+	currentSiteId = siteId;
+}
+
+/**
+ * Get the current site ID for per-site state storage.
+ */
+export function getCurrentSiteId(): number | undefined {
+	return currentSiteId;
+}
+
+/**
  * Partial state object for saving agents manager preferences
  */
 type AgentsManagerState = {
@@ -52,7 +73,7 @@ export function* saveAgentsManagerState( state: AgentsManagerState ) {
 			path: '/agents-manager/state',
 			apiNamespace: 'wpcom/v2',
 			method: 'POST',
-			body: { state: saveState },
+			body: { state: saveState, site_id: currentSiteId },
 		} ).catch( () => {} );
 	} else {
 		// Use the promise version to do that action without waiting for the result.
@@ -60,7 +81,7 @@ export function* saveAgentsManagerState( state: AgentsManagerState ) {
 			global: true,
 			path: '/agents-manager/open-state',
 			method: 'PUT',
-			data: saveState,
+			data: { ...saveState, site_id: currentSiteId },
 		} as APIFetchOptions ).catch( () => {} );
 	}
 }

--- a/packages/data-stores/src/agents-manager/index.ts
+++ b/packages/data-stores/src/agents-manager/index.ts
@@ -9,6 +9,7 @@ import reducer, { State } from './reducer';
 import { getAgentsManagerState } from './resolvers';
 import * as selectors from './selectors';
 export type { State };
+export { setCurrentSiteId, getCurrentSiteId } from './actions';
 
 let isRegistered = false;
 

--- a/packages/data-stores/src/agents-manager/resolvers.ts
+++ b/packages/data-stores/src/agents-manager/resolvers.ts
@@ -9,6 +9,7 @@ import {
 	setIsLoading,
 	setHasLoaded,
 	setFloatingPosition,
+	getCurrentSiteId,
 } from './actions';
 import type { APIFetchOptions } from '../shared-types';
 
@@ -25,14 +26,17 @@ type AgentsManagerStateResponse = {
 export function* getAgentsManagerState() {
 	yield setIsLoading( true );
 	try {
+		const siteId = getCurrentSiteId();
+		const siteIdQuery = siteId ? `?site_id=${ siteId }` : '';
+
 		const state: AgentsManagerStateResponse = canAccessWpcomApis()
 			? yield wpcomRequest( {
-					path: '/agents-manager/state',
+					path: `/agents-manager/state${ siteIdQuery }`,
 					apiNamespace: 'wpcom/v2',
 			  } )
 			: yield apiFetch( {
 					global: true,
-					path: '/agents-manager/open-state',
+					path: `/agents-manager/open-state${ siteIdQuery }`,
 			  } as APIFetchOptions );
 
 		if ( state.agents_manager_router_history ) {


### PR DESCRIPTION
## Summary
- Fixes active chat session bleeding between stores (WOOAI-384)
- Threads `site_id` through all Agents Manager state read/write paths so preferences are stored per-site
- Uses a module-level variable (`setCurrentSiteId`/`getCurrentSiteId`) set in the `AgentsManager` component before the store resolver triggers
- All 3 write paths (resolver fetch, save state, persist router history) now include `site_id`

### Files changed
- `data-stores/agents-manager/actions.ts` — `setCurrentSiteId`/`getCurrentSiteId` + include `site_id` in save requests
- `data-stores/agents-manager/resolvers.ts` — include `site_id` in initial state fetch
- `data-stores/agents-manager/index.ts` — export new functions
- `agents-manager/components/agents-manager.tsx` — call `setCurrentSiteId(site.ID)` before store init
- `agents-manager/utils/persist-agents-manager-state.ts` — include `site_id` in router history persistence

## Test plan
- [ ] Chat on Store A in Calypso — state saved with `site_id`
- [ ] Switch to Store B — should start fresh, not show Store A's conversation
- [ ] Go back to Store A — conversation should still be there
- [ ] Open two stores in separate tabs — independent state
- [ ] Verify backward compat: if backend doesn't support `site_id` yet, falls back gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)