### PR TITLE
Remove domains/suggestions-pp feature flag

### DIFF
--- a/client/lib/domains/suggestions/index.ts
+++ b/client/lib/domains/suggestions/index.ts
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	isDomainForGravatarFlow,
 	isHundredYearPlanFlow,
@@ -32,8 +31,6 @@ export const getSuggestionsVendor = ( {
 	isSignup,
 	isDomainOnly,
 }: DomainSuggestionsVendorOptions = {} ): DomainSuggestionQueryVendor => {
-	const isEnabledSuggestionsPP = isEnabled( 'domains/suggestions-pp' );
-
 	if ( isCiab ) {
 		return 'ciab';
 	}
@@ -44,16 +41,16 @@ export const getSuggestionsVendor = ( {
 		return '100-year-domains';
 	}
 	if ( flowName === 'domains/add' ) {
-		return isEnabledSuggestionsPP ? 'wpcom_suggestions_premium' : 'variation8_front';
+		return 'wpcom_suggestions_premium';
 	}
 	if ( isNewsletterFlow( flowName ) ) {
 		return 'newsletter';
 	}
 	if ( isSignup && ! isDomainOnly ) {
-		return isEnabledSuggestionsPP ? 'wpcom_suggestions_standard' : 'variation4_front';
+		return 'wpcom_suggestions_standard';
 	}
 	if ( isPremium ) {
-		return isEnabledSuggestionsPP ? 'wpcom_suggestions_premium' : 'variation8_front';
+		return 'wpcom_suggestions_premium';
 	}
 	return 'variation2_front';
 };


### PR DESCRIPTION
Part of [DOMENG-304: Locked (paid) Domain Search Placements 1.1](https://linear.app/a8c/issue/DOMENG-304/locked-paid-domain-search-placements-11)

## Proposed Changes

* Remove the `domains/suggestions-pp` feature flag from the domain suggestions vendor selection logic.
* Simplify `getSuggestionsVendor` by using the premium/standard vendor values directly instead of conditionally checking the flag.
* Remove the unused `@automattic/calypso-config` import.

## Why are these changes being made?

The `domains/suggestions-pp` feature flag has served its purpose and the premium/standard suggestion vendors are now the default behavior. Removing the flag simplifies the code and eliminates dead conditional branches.

## Testing Instructions

* Verify domain suggestions still work correctly in signup flows, domain-only flows, and the `domains/add` flow.
* Confirm the correct vendor is returned for each flow type (e.g., `wpcom_suggestions_standard` for signup, `wpcom_suggestions_premium` for premium/domain-add).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?