### PR TITLE
Preserve Woo flow context when navigating from magic login to password login

### DIFF
--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -91,6 +91,21 @@ export function login( {
 		url = addQueryArgs( { 'wccom-from': wccomFrom }, url );
 	}
 
+	// When `from` is not explicitly provided, try to extract it from the `redirectTo` URL.
+	// This handles Woo flows (Core Profiler, Payments, etc.) where `from` is embedded
+	// in the redirect_to URL rather than being a top-level query parameter.
+	// See: isWooCommerceCoreProfilerFlow, isWooDnaFlow selectors for the same pattern.
+	if ( ! from && redirectTo ) {
+		try {
+			const redirectFromValue = new URLSearchParams( redirectTo.split( '?' )[ 1 ] ).get( 'from' );
+			if ( redirectFromValue ) {
+				from = redirectFromValue;
+			}
+		} catch {
+			// ignore parsing errors
+		}
+	}
+
 	if ( from ) {
 		url = addQueryArgs( { from }, url );
 	}
@@ -117,6 +132,21 @@ export function login( {
 
 	if ( gravatarFlow ) {
 		url = addQueryArgs( { gravatar_flow: '1' }, url );
+	}
+
+	// Same fallback pattern as `from` above — extract plugin_name from redirectTo
+	// when not explicitly provided. Needed for WooCommerce Payments flow detection.
+	if ( ! pluginName && redirectTo ) {
+		try {
+			const redirectPluginName = new URLSearchParams( redirectTo.split( '?' )[ 1 ] ).get(
+				'plugin_name'
+			);
+			if ( redirectPluginName ) {
+				pluginName = redirectPluginName;
+			}
+		} catch {
+			// ignore parsing errors
+		}
 	}
 
 	if ( pluginName ) {

--- a/client/lib/paths/login/test/index.js
+++ b/client/lib/paths/login/test/index.js
@@ -57,4 +57,44 @@ describe( 'login', () => {
 		const url = login( { isJetpack: true, useMagicLink: true } );
 		expect( url ).toBe( '/log-in/jetpack' );
 	} );
+
+	test( 'should extract "from" from redirectTo when not explicitly provided', () => {
+		const url = login( {
+			isJetpack: true,
+			redirectTo:
+				'https://site.com/wp-admin/admin.php?page=wc-admin&from=woocommerce-core-profiler',
+		} );
+		expect( url ).toContain( 'from=woocommerce-core-profiler' );
+	} );
+
+	test( 'should not override explicit "from" with value from redirectTo', () => {
+		const url = login( {
+			isJetpack: true,
+			from: 'explicit-value',
+			redirectTo:
+				'https://site.com/wp-admin/admin.php?page=wc-admin&from=woocommerce-core-profiler',
+		} );
+		expect( url ).toContain( 'from=explicit-value' );
+		expect( url ).not.toContain( 'from=woocommerce-core-profiler' );
+	} );
+
+	test( 'should extract "plugin_name" from redirectTo when not explicitly provided', () => {
+		const url = login( {
+			isJetpack: true,
+			redirectTo:
+				'https://site.com/wp-admin/admin.php?page=wc-admin&plugin_name=woocommerce-payments',
+		} );
+		expect( url ).toContain( 'plugin_name=woocommerce-payments' );
+	} );
+
+	test( 'should not override explicit "pluginName" with value from redirectTo', () => {
+		const url = login( {
+			isJetpack: true,
+			pluginName: 'explicit-plugin',
+			redirectTo:
+				'https://site.com/wp-admin/admin.php?page=wc-admin&plugin_name=woocommerce-payments',
+		} );
+		expect( url ).toContain( 'plugin_name=explicit-plugin' );
+		expect( url ).not.toContain( 'plugin_name=woocommerce-payments' );
+	} );
 } );

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -1,4 +1,3 @@
-import page from '@automattic/calypso-router';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -148,7 +147,10 @@ export class MagicLogin extends Component {
 
 		const loginParameters = buildEnterPasswordLoginParameters( this.props, options );
 
-		page( login( loginParameters ) );
+		// Use full page navigation instead of client-side routing because the magic
+		// login routes and the wp-login routes are registered as separate router groups.
+		// The page() client-side router updates the URL but doesn't re-dispatch across groups.
+		window.location.assign( login( loginParameters ) );
 	};
 
 	renderLinks() {


### PR DESCRIPTION
## Proposed Changes

Slack discussion - p1772496344802299-slack-C0800LPNCET

* Extract `from` and `plugin_name` from the `redirect_to` URL as a fallback in the `login()` path builder when they are not provided as explicit parameters.
* Fix navigation when clicking "Use username and password instead" on the magic login page — replace client-side `page()` routing with full page navigation (`window.location.assign()`).

## Why are these changes being made?

**Bug 1 — Woo flow context lost:** In Woo flows (Core Profiler, Payments, WooDNA), the `from` and `plugin_name` parameters can be embedded inside the `redirect_to` URL rather than being top-level query parameters. When the magic login page builds the "Use username and password instead" URL, it passes `from: query?.from` — which is `undefined` when `from` is only in `redirect_to`. This causes the destination login page to lose the Woo flow context (logo, headings, connect flow) and fall back to the generic Jetpack experience.

**Bug 2 — Navigation doesn't happen:** The magic login routes and the wp-login routes are registered as separate `router()` groups in `client/login/index.web.js`. When `page()` (the client-side router) is called to navigate from `/log-in/link` to `/log-in`, it updates the URL but doesn't re-dispatch across route groups — so no page re-render occurs. This bug also reproduces in production.

<details>
<summary>🤖 AI-generated details</summary>

### Files changed
- `client/lib/paths/login/index.js` — Added fallback extraction of `from` and `plugin_name` from `redirectTo` URL when not explicitly provided. Explicit values always take priority.
- `client/lib/paths/login/test/index.js` — Added 4 test cases: extraction of `from` and `plugin_name` from `redirectTo`, and verification that explicit values are not overridden.
- `client/login/magic-login/index.jsx` — Replaced `page()` with `window.location.assign()` for the "Use username and password instead" navigation. Removed unused `page` import.

### Implementation notes
The `from`/`plugin_name` fallback uses `new URLSearchParams(redirectTo.split('?')[1]).get('from')` — the same pattern established in:
- `client/state/selectors/is-woo-dna-flow.ts` (lines 32-39)
- `client/state/selectors/is-woocommerce-core-profiler-flow.ts` (line 17)

Both `from` and `plugin_name` are extracted because `isWooCommercePaymentsOnboardingFlow` requires both for detection.

Parsing errors are silently caught to avoid breaking the URL builder for malformed redirect URLs.

The navigation fix uses `window.location.assign()` because magic login routes (`/log-in/link`) and wp-login routes (`/log-in`) are registered as separate `router()` groups in `client/login/index.web.js`. The `page()` client-side router updates the URL but doesn't re-dispatch across groups.

### Architectural context
The `login()` function in `client/lib/paths/login/index.js` is the central URL builder for all login page navigation. It is called from:
- `client/login/magic-login/index.jsx` — "Use username and password instead" link
- `client/blocks/login/login-form.jsx` — Magic login link, lost password link
- `client/blocks/login/lost-password-form.jsx` — Post-reset navigation
- `client/login/magic-login/handle-emailed-link-form-jetpack-connect.tsx` — 2FA redirect after magic link auth

All callers pass `from: query?.from` which can be `undefined` when the value is embedded in `redirect_to`. The URL builder fix ensures parameters propagate correctly without requiring changes to every caller.

</details>

## Testing Instructions


1. Start the dev server: `NODE_OPTIONS="--max-old-space-size=8192" yarn start`
2. Create a new JN site with WooCommerce and WooPayments. Then start the NOX from Payments Settings.
3. When you try to log using Jetpack, copy the link, and use a private browser window. You'll be asked to use a username/email.
4. Use this email (p1773062137707719/1772496344.802299-slack-C0800LPNCET) to force the wanted screen

<img width="1190" height="1222" alt="CleanShot 2026-03-09 at 13 16 10@2x" src="https://github.com/user-attachments/assets/59a59754-c433-4531-8950-b831717b33a9" />

5. Click on the "Use username and password instead". You should be redirected to a Woo-powered flow.
6. Refresh the page, you should still see a Woo powered flow.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
