### PR TITLE
Smooch fixes

### DIFF
--- a/packages/odie-client/src/components/notices/use-connection-status-notice.tsx
+++ b/packages/odie-client/src/components/notices/use-connection-status-notice.tsx
@@ -19,20 +19,23 @@ export default function useConnectionStatusNotice( isLiveChat: boolean = false )
 
 	useEffect( () => {
 		if ( connectionStatus === 'disconnected' ) {
-			const connectionTimeout = setTimeout( () => {
-				setSecondsSinceDisconnected( secondsSinceDisconnected + 1 );
-				if ( secondsSinceDisconnected >= WARNING_THRESHOLD ) {
-					setShouldWarn( true );
-				}
+			const connectionInterval = setInterval( () => {
+				setSecondsSinceDisconnected( ( prev ) => prev + 1 );
 			}, 1000 );
-			return () => clearTimeout( connectionTimeout );
+			return () => clearInterval( connectionInterval );
 		} else if ( connectionStatus === 'connected' ) {
 			setSecondsSinceDisconnected( 0 );
 			// Show the "Connected" notice for 2 seconds then auto-hide it.
 			const hidingReconnectedTimeout = setTimeout( setShouldWarn, 2000, false );
 			return () => clearTimeout( hidingReconnectedTimeout );
 		}
-	}, [ connectionStatus, secondsSinceDisconnected ] );
+	}, [ connectionStatus ] );
+
+	useEffect( () => {
+		if ( secondsSinceDisconnected >= WARNING_THRESHOLD ) {
+			setShouldWarn( true );
+		}
+	}, [ secondsSinceDisconnected ] );
 
 	if ( secondsSinceDisconnected < WARNING_THRESHOLD && connectionStatus !== 'connected' ) {
 		return undefined;

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -138,6 +138,10 @@ export const useCreateZendeskConversation = () => {
 			return;
 		}
 
+		if ( ! conversation ) {
+			return;
+		}
+
 		try {
 			if ( activeInteractionId ) {
 				interaction = await addEventToInteraction( {


### PR DESCRIPTION
Taken from https://github.com/Automattic/wp-calypso/pull/108827

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTCOM-15974](https://linear.app/a8c/issue/DOTCOM-15974)

## Proposed Changes

* Use `setInterval` instead of `setTimeout` to show the connection status notice.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
