### PR TITLE
Prime the base image webpack cache for the common production build flavor

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -165,7 +165,7 @@ object BuildBaseImages : BuildType({
 					registry.a8c.com/calypso/base:%image_tag%
 					registry.a8c.com/calypso/base:%build.number%
 				""".trimIndent()
-				commandArgs = "--no-cache --target base --build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber}"
+				commandArgs = "--no-cache --target base --build-arg workers=32 --build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber}"
 			}
 			param("dockerImage.platform", "linux")
 		}

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -6,6 +6,7 @@ FROM node:22.9.0-bullseye-slim as cache
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ARG node_memory=16384
+ARG workers=32
 ARG commit_sha="(unknown)"
 WORKDIR /calypso
 ENV NPM_CONFIG_CACHE=/calypso/.cache
@@ -15,6 +16,7 @@ ENV PROFILE=true
 ENV SKIP_TSC=true
 ENV CALYPSO_ENV=production
 ENV BUILD_TRANSLATION_CHUNKS=true
+ENV WORKERS=$workers
 ENV NODE_OPTIONS=--max-old-space-size=$node_memory
 ENV HOME=/calypso
 ENV IS_CI=true
@@ -23,8 +25,8 @@ ENV COMMIT_SHA $commit_sha
 COPY . .
 
 RUN yarn --inline-builds \
-	# Prime webpack caches, including sourcemaps.
-	&& NODE_ENV=production SOURCEMAP=hidden-source-map yarn build-client
+	# Prime the production webpack cache flavor used by common PR Docker builds.
+	&& NODE_ENV=production yarn build-client
 
 ENTRYPOINT [ "/bin/bash" ]
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -25,8 +25,9 @@ ENV COMMIT_SHA $commit_sha
 COPY . .
 
 RUN yarn --inline-builds \
-	# Prime the production webpack cache flavor used by common PR Docker builds.
-	&& NODE_ENV=production yarn build-client
+	# Prime both production webpack cache flavors used by PR and trunk/manual Sentry builds.
+	&& NODE_ENV=production yarn build-client \
+	&& NODE_ENV=production SOURCEMAP=hidden-source-map yarn build-client
 
 ENTRYPOINT [ "/bin/bash" ]
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -25,9 +25,8 @@ ENV COMMIT_SHA $commit_sha
 COPY . .
 
 RUN yarn --inline-builds \
-	# Prime both production webpack cache flavors used by PR and trunk/manual Sentry builds.
-	&& NODE_ENV=production yarn build-client \
-	&& NODE_ENV=production SOURCEMAP=hidden-source-map yarn build-client
+	# Prime the production webpack cache flavor used by common PR Docker builds.
+	&& NODE_ENV=production yarn build-client
 
 ENTRYPOINT [ "/bin/bash" ]
 


### PR DESCRIPTION
## Proposed Changes

* Change the `Dockerfile.base` cache-priming build to run `NODE_ENV=production yarn build-client` without `SOURCEMAP=hidden-source-map`, so it warms the production `devtool=none` cache flavor used by common PR Docker builds.
* Set `WORKERS=32` in the `Dockerfile.base` cache stage.
* Pass `--build-arg workers=32` from the `Build base images` TeamCity job so the scheduled base-image priming path stays aligned with the main Docker build configuration.

## Why are these changes being made?

* The webpack cache-keying change on trunk now correctly separates cache flavors by effective `devtool`.
* That exposed a priming mismatch: `Dockerfile.base` was still warming `hidden-source-map`, while the common PR Docker build path typically consumes `devtool=none`.
* The main Docker build path also runs with `WORKERS=32`, which affects the `thread-loader` configuration used in the webpack transpile rules.
* This PR intentionally optimizes the common PR path first, without adding a second expensive `build-client` run to the scheduled `Build base images` job.

## Testing Instructions

* Review `Dockerfile.base` and confirm the cache stage now:
  * sets `WORKERS=32`
  * runs `NODE_ENV=production yarn build-client`
  * no longer forces `SOURCEMAP=hidden-source-map`
* Review `.teamcity/settings.kts` and confirm the `Build base image` step passes `--build-arg workers=32`.
* Run the `Build base images` TeamCity build on `trunk` and confirm it publishes a refreshed `registry.a8c.com/calypso/base` image successfully.
* After that image is published, run a representative PR `Web app / Docker image` build and confirm it can reuse the warmed `client-mode=production__devtool=none` webpack cache flavor.
* Expect default-branch/manual Sentry builds to remain a separate `hidden-source-map` cache flavor; this PR does not try to warm that variant yet.
