### PR TITLE
Align `Dockerfile.base` build args across `Build base images` targets

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -174,7 +174,7 @@ object BuildBaseImages : BuildType({
 					path = "Dockerfile.base"
 				}
 				namesAndTags = "registry.a8c.com/calypso/ci-e2e:%build.number%"
-				commandArgs = "--target ci-e2e"
+				commandArgs = "--target ci-e2e --build-arg workers=32 --build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber}"
 			}
 			param("dockerImage.platform", "linux")
 		}
@@ -185,7 +185,7 @@ object BuildBaseImages : BuildType({
 					path = "Dockerfile.base"
 				}
 				namesAndTags = "registry.a8c.com/calypso/ci-wpcom:%build.number%"
-				commandArgs = "--target ci-wpcom"
+				commandArgs = "--target ci-wpcom --build-arg workers=32 --build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber}"
 			}
 			param("dockerImage.platform", "linux")
 		}


### PR DESCRIPTION
# Human Description

Because the commit_sha is referenced directly in the dockerfile.base:
```
ENV COMMIT_SHA $commit_sha
```

The "Build CI e2e image" cannot reuse the work done by the "Build base image" unless the same $commit_sha is passed in to both. Align the arguments passed to all three images built.

# AI Description

## Proposed Changes

* Pass `--build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber}` to the `Build CI e2e image` TeamCity step.
* Pass `--build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber}` to the `Build CI wpcom image` TeamCity step.
* Pass `--build-arg workers=32` to those same steps so all `Dockerfile.base` targets use the same explicit worker setting as the `Build base image` step.

## Why are these changes being made?

* `Build base images` currently invokes `Dockerfile.base` three times in one job, but only the first target (`base`) receives the cache-relevant build args that identify the commit and worker configuration.
* That causes the later `ci-e2e` and `ci-wpcom` builds to miss reuse of the already-built `cache` stage and rerun `yarn --inline-builds` plus the client cache-priming build inside the same TeamCity job.
* In the failed `Build base images` run `#1.0.4157`, `Build base image` succeeded, but `Build CI e2e image` rebuilt the `cache` stage and hit a workspace package build failure while rerunning that setup work.
* Aligning the build args across all three targets reduces avoidable cache fragmentation within the scheduled base-image job and should make the follow-on targets reuse the cache-producing layers from the first step.

## Testing Instructions

* Review `.teamcity/settings.kts` and confirm all three `Dockerfile.base` build steps now pass the same explicit `workers=32` and `commit_sha` build args.
* Trigger `Calypso / Build base images` on `trunk`.
* Confirm `Build base image` still succeeds.
* In the `Build CI e2e image` and `Build CI wpcom image` logs, confirm the `cache` stage from `Dockerfile.base` is reused rather than rerunning `yarn --inline-builds && NODE_ENV=production yarn build-client`.
* Confirm the job publishes refreshed `registry.a8c.com/calypso/base`, `registry.a8c.com/calypso/ci-e2e`, and `registry.a8c.com/calypso/ci-wpcom` images successfully.
