### PR TITLE
Reader: Show subscription detail screen for RSS feeds

### DIFF
--- a/client/blocks/reader-site-subscription/details.tsx
+++ b/client/blocks/reader-site-subscription/details.tsx
@@ -1,9 +1,10 @@
 import './styles.scss';
+import page from '@automattic/calypso-router';
 import { Badge, TimeSince } from '@automattic/components';
 import { SubscriptionManager, Reader } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
-import { useTranslate } from 'i18n-calypso';
+import { fixMe, useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
 import { SiteIcon } from 'calypso/blocks/site-icon';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -119,7 +120,19 @@ const SiteSubscriptionDetails = ( {
 		// todo: style the button (underline, color?, etc.)
 		const Resubscribe = () => (
 			<Button
-				onClick={ () => subscribe( { blog_id: blogId, url } ) }
+				onClick={ () =>
+					subscribe(
+						{ blog_id: blogId, url },
+						{
+							onSuccess: ( response ): void => {
+								const subscriptionId = response.subscription?.ID;
+								if ( subscriptionId ) {
+									page( `/reader/subscriptions/${ subscriptionId }` );
+								}
+							},
+						}
+					)
+				}
 				disabled={ subscribing || unsubscribing }
 				variant="secondary"
 			>
@@ -134,13 +147,20 @@ const SiteSubscriptionDetails = ( {
 			setNotice( {
 				type: NoticeType.Success,
 				action: <Resubscribe />,
-				message: translate(
-					'You have successfully unsubscribed and will no longer receive emails from %s.',
-					{
+				message: fixMe( {
+					text: 'You have successfully unsubscribed from %s.',
+					newCopy: translate( 'You have successfully unsubscribed from %s.', {
 						args: [ name ],
 						comment: 'Name of the site that the user has unsubscribed from.',
-					}
-				),
+					} ),
+					oldCopy: translate(
+						'You have successfully unsubscribed and will no longer receive emails from %s.',
+						{
+							args: [ name ],
+							comment: 'Name of the site that the user has unsubscribed from.',
+						}
+					),
+				} ),
 			} );
 		}
 		if ( unsubscribeError ) {

--- a/client/blocks/reader-site-subscription/details.tsx
+++ b/client/blocks/reader-site-subscription/details.tsx
@@ -1,3 +1,4 @@
+import './styles.scss';
 import { Badge, TimeSince } from '@automattic/components';
 import { SubscriptionManager, Reader } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
@@ -21,7 +22,6 @@ import {
 import SiteSubscriptionSettings from './settings';
 import SiteSubscriptionSubheader from './site-subscription-subheader';
 import SubscribeToNewsletterCategories from './subscribe-to-newsletter-categories';
-import './styles.scss';
 
 const SiteSubscriptionDetails = ( {
 	subscriptionId,
@@ -239,23 +239,29 @@ const SiteSubscriptionDetails = ( {
 
 			{ siteSubscribed && (
 				<>
-					<SiteSubscriptionSettings
-						subscriptionId={ subscriptionId }
-						blogId={ blogId }
-						notifyMeOfNewPosts={ !! deliveryMethods.notification?.send_posts }
-						emailMeNewPosts={ !! deliveryMethods.email?.send_posts }
-						deliveryFrequency={
-							deliveryMethods.email?.post_delivery_frequency ??
-							Reader.EmailDeliveryFrequency.Instantly
-						}
-						emailMeNewComments={ !! deliveryMethods.email?.send_comments }
-					/>
-
-					{ !! deliveryMethods.email?.send_posts && (
-						<SubscribeToNewsletterCategories siteId={ blogId } />
+					{ !! blogId && (
+						<>
+							<SiteSubscriptionSettings
+								subscriptionId={ subscriptionId }
+								blogId={ blogId }
+								notifyMeOfNewPosts={ !! deliveryMethods.notification?.send_posts }
+								emailMeNewPosts={ !! deliveryMethods.email?.send_posts }
+								deliveryFrequency={
+									deliveryMethods.email?.post_delivery_frequency ??
+									Reader.EmailDeliveryFrequency.Instantly
+								}
+								emailMeNewComments={ !! deliveryMethods.email?.send_comments }
+							/>
+							<hr className="subscriptions__separator" />
+						</>
 					) }
 
-					<hr className="subscriptions__separator" />
+					{ !! deliveryMethods.email?.send_posts && (
+						<>
+							<SubscribeToNewsletterCategories siteId={ blogId } />
+							<hr className="subscriptions__separator" />
+						</>
+					) }
 
 					{ /* TODO: Move to SiteSubscriptionInfo component when payment details are in. */ }
 					<div className="site-subscription-info">

--- a/client/blocks/reader-site-subscription/subscribe-to-newsletter-categories.tsx
+++ b/client/blocks/reader-site-subscription/subscribe-to-newsletter-categories.tsx
@@ -41,7 +41,6 @@ const SubscribeToNewsletterCategories = ( { siteId }: SubscribeToNewsletterCateg
 
 	return (
 		<>
-			<hr className="subscriptions__separator" />
 			<div className="site-subscription-info">
 				<h2 className="site-subscription-info__heading">
 					{ translate( 'Newsletter categories' ) }

--- a/client/landing/subscriptions/components/site-subscriptions-list/site-subscription-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/site-subscription-row.tsx
@@ -213,13 +213,6 @@ const SiteSubscriptionRow = ( {
 
 	const siteTitleUrl = useMemo( () => {
 		if ( isReaderPortal ) {
-			const feedUrl = `/reader/feeds/${ feed_id }`;
-
-			if ( ! blog_id ) {
-				// The site subscription page does not support non-wpcom feeds yet
-				return feedUrl;
-			}
-
 			if ( resubscribed ) {
 				// If the site was resubscribed, the id of the optmistic update is not the same as the id of the new subscription
 				return `/reader/site/subscription/${ blog_id }`;

--- a/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
@@ -20,6 +20,7 @@ type SubscribeResponse = {
 	success?: boolean;
 	subscribed?: boolean;
 	subscription?: {
+		ID: string;
 		blog_ID: string;
 		delivery_frequency: string;
 		status: string;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes: [READ-358](https://linear.app/a8c/issue/READ-358/reader-show-subscription-detail-screen-for-rss-feeds-as-well)

## Proposed Changes

1. Show subscription detail screen for RSS feeds.
2. Fix state data after resubscribing from subscription detail screen.

For translators:

<img width="2880" height="2310" alt="wordpress com_reader" src="https://github.com/user-attachments/assets/8b1477da-ca07-4f4f-b0eb-56400af0d36b" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

On "reader/subscriptions" screen when user clicks on WPCOM subscription then user is redirected to Subscription Detail screen but when user click on non-WPCOM subscription then they are redirected to RSS feeds source which is confusing.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to /reader/subscriptions
- Open detail view of WPCOM and non-WPCOM feeds.
- Verify correct data is appearing (dependent 206754-ghe-Automattic/wpcom)
- Verify Unsub > Resub > Unsub is working fine i.e. ID on url changed and data shown is also updated.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?