### PR TITLE
Log Yarn inline-build failures from the `Dockerfile.base` cache stage

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -24,7 +24,12 @@ ENV COMMIT_SHA $commit_sha
 
 COPY . .
 
-RUN yarn --inline-builds \
+RUN { yarn --inline-builds || ( \
+		echo "==== yarn build log ===="; \
+		ls -t /tmp/xfs-*/build.log 2>/dev/null | head -n 1 | xargs -r cat; \
+		echo "==== end yarn build log ===="; \
+		exit 1; \
+	); } \
 	# Prime the production webpack cache flavor used by common PR Docker builds.
 	&& NODE_ENV=production yarn build-client
 


### PR DESCRIPTION
## Proposed Changes

* Wrap `yarn --inline-builds` in the `Dockerfile.base` cache stage with a failure handler.
* When `yarn --inline-builds` fails, print the most recent `/tmp/xfs-*/build.log` contents into the Docker build log before exiting.
* Leave the success path unchanged: if `yarn --inline-builds` succeeds, continue on to `NODE_ENV=production yarn build-client` as before.

## Why are these changes being made?

* Recent `Build base images` failures in the `cache` stage surfaced only the high-level Yarn `YN0009` summary in TeamCity, while the detailed workspace build log stayed hidden under `/tmp/xfs-*/build.log` inside the container.
* That makes failures harder to diagnose from TeamCity alone, especially when the cache stage reruns in later `Dockerfile.base` targets and fails before publishing any image.
* Printing the latest Yarn build log on failure gives us the actionable package-level errors directly in the TeamCity Docker output, without changing the successful build behavior.

## Testing Instructions

* Review `Dockerfile.base` and confirm the `cache` stage now prints:
  * `==== yarn build log ====`
  * the newest `/tmp/xfs-*/build.log`, if present
  * `==== end yarn build log ====`
  before exiting on `yarn --inline-builds` failure.
* Trigger `Calypso / Build base images` with a branch or commit that reproduces a `yarn --inline-builds` failure in the `cache` stage.
* Confirm the detailed Yarn workspace build log appears directly in the TeamCity Docker output, instead of only the summary `YN0009` message.
* Confirm successful runs still proceed from `yarn --inline-builds` to `NODE_ENV=production yarn build-client` with no extra output.
