### PR TITLE
Help Center: Route CIAB users to production Zendesk

### DIFF
--- a/apps/help-center/config.js
+++ b/apps/help-center/config.js
@@ -1,9 +1,11 @@
 /* global helpCenterData */
 const isProxied = typeof helpCenterData !== 'undefined' && helpCenterData?.isProxied;
+const isCIAB = typeof helpCenterData !== 'undefined' && helpCenterData?.isCommerceGarden;
+const envValue = isProxied && ! isCIAB ? 'staging' : 'production';
 
 window.configData = {
-	env_id: isProxied ? 'staging' : 'production',
-	env: isProxied ? 'staging' : 'production',
+	env_id: envValue,
+	env: envValue,
 	features: {
 		'help/gpt-response': true,
 	},


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/WOOPRD-2981/help-center-send-users-to-prod-zendesk

## Proposed Changes

* When `helpCenterData.isCommerceGarden` is set, force `env_id` and `env` to `'production'` so that CIAB users are routed to production Zendesk instead of the staging instance.

## Why are these changes being made?

In CIAB, `helpCenterData.isProxied` can be `true`, which causes the Help Center config to set `env` to `'staging'`. This makes `isTestModeEnvironment()` return `true`, routing support requests to the staging Zendesk instance and showing the "STAGING VERSION OF ZENDESK" message. CIAB users should always go to production Zendesk.

## Testing Instructions

1. Sandbox `widgets.wp.com`.
2. Run `cd apps/help-center && yarn dev --sync`.
3. Visit a CIAB site and open the Help Center.
4. Ask to talk to a human and verify the "STAGING VERSION OF ZENDESK" message no longer appears.

