### PR TITLE
Make `Build base images` publish deterministic `latest` tags

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -161,10 +161,7 @@ object BuildBaseImages : BuildType({
 				source = file {
 					path = "Dockerfile.base"
 				}
-				namesAndTags = """
-					registry.a8c.com/calypso/base:%image_tag%
-					registry.a8c.com/calypso/base:%build.number%
-				""".trimIndent()
+				namesAndTags = "registry.a8c.com/calypso/base:%build.number%"
 				commandArgs = "--no-cache --target base --build-arg workers=32 --build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber}"
 			}
 			param("dockerImage.platform", "linux")
@@ -175,10 +172,7 @@ object BuildBaseImages : BuildType({
 				source = file {
 					path = "Dockerfile.base"
 				}
-				namesAndTags = """
-					registry.a8c.com/calypso/ci-e2e:%image_tag%
-					registry.a8c.com/calypso/ci-e2e:%build.number%
-				""".trimIndent()
+				namesAndTags = "registry.a8c.com/calypso/ci-e2e:%build.number%"
 				commandArgs = "--target ci-e2e"
 			}
 			param("dockerImage.platform", "linux")
@@ -189,13 +183,42 @@ object BuildBaseImages : BuildType({
 				source = file {
 					path = "Dockerfile.base"
 				}
-				namesAndTags = """
-					registry.a8c.com/calypso/ci-wpcom:%image_tag%
-					registry.a8c.com/calypso/ci-wpcom:%build.number%
-				""".trimIndent()
+				namesAndTags = "registry.a8c.com/calypso/ci-wpcom:%build.number%"
 				commandArgs = "--target ci-wpcom"
 			}
 			param("dockerImage.platform", "linux")
+		}
+		script {
+			name = "Retag images for publish"
+			scriptContent = """
+				#!/usr/bin/env bash
+				set -euo pipefail
+
+				retag_image() {
+					local repo=${'$'}1
+					local numbered_tag="${'$'}repo:%build.number%"
+					local publish_tag="${'$'}repo:%image_tag%"
+
+					docker tag "${'$'}numbered_tag" "${'$'}publish_tag"
+
+					local numbered_id
+					local publish_id
+					numbered_id=$(docker image inspect "${'$'}numbered_tag" --format '{{.Id}}')
+					publish_id=$(docker image inspect "${'$'}publish_tag" --format '{{.Id}}')
+
+					echo "${'$'}numbered_tag id=${'$'}numbered_id"
+					echo "${'$'}publish_tag id=${'$'}publish_id"
+
+					if [[ "${'$'}numbered_id" != "${'$'}publish_id" ]]; then
+						echo "Tag mismatch for ${'$'}repo"
+						exit 1
+					fi
+				}
+
+				retag_image registry.a8c.com/calypso/base
+				retag_image registry.a8c.com/calypso/ci-e2e
+				retag_image registry.a8c.com/calypso/ci-wpcom
+			""".trimIndent()
 		}
 		dockerCommand {
 			name = "Push images"

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -12,6 +12,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.perfmon
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.pullRequests
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
 import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
 import jetbrains.buildServer.configs.kotlin.v2019_2.project


### PR DESCRIPTION
## Proposed Changes

* Change `Build base images` to build only the numbered tags for `base`, `ci-e2e`, and `ci-wpcom`.
* Add a `Retag images for publish` script step that explicitly tags each numbered image as `%image_tag%`.
* Verify locally in that script that each numbered tag and publish tag resolve to the same Docker image ID before the push step runs.

## Why are these changes being made?

* Recent `Build base images` runs successfully primed the webpack cache into the numbered base image, but follow-on app builds still showed cold-cache behavior when using `registry.a8c.com/calypso/base:latest`.
* A direct test overriding `base_image=registry.a8c.com/calypso/base:1.0.4158` restored the production webpack pack and materially reduced build time, which shows the primed cache exists in the numbered image.
* The scheduled `Build base images` run for `1.0.4158` pushed `registry.a8c.com/calypso/base:latest` and `registry.a8c.com/calypso/base:1.0.4158` with different digests. The same mismatch also appeared for `ci-e2e`.
* That points to the multi-tag build/publish flow not reliably leaving `%image_tag%` pointed at the same image as `%build.number%`. Explicit retagging and a local image-ID check makes the published tags deterministic before the push step starts.

## Testing Instructions

* Review `.teamcity/settings.kts` and confirm the three `Dockerfile.base` build steps now build only `%build.number%` tags.
* Confirm the new `Retag images for publish` step tags `base`, `ci-e2e`, and `ci-wpcom` from `%build.number%` to `%image_tag%` and compares their local image IDs.
* Trigger `Calypso / Build base images` on `trunk`.
* In the `Retag images for publish` step, confirm each tag pair reports the same local image ID.
* Confirm the push step publishes both `%build.number%` and `%image_tag%` for all three images successfully.
* After that run completes, trigger a representative `Calypso / Web app / Docker image` build using the default `%base_image%`.
* In the Docker build log, confirm webpack restores cached pack contents from `/calypso/.cache/evergreen/webpack/client-mode=production__devtool=none` instead of logging `No pack exists`.
