### PR TITLE
Theme Showcase: Add sectioned recommended layout for modern showcase

### DIFF
--- a/client/my-sites/themes/banners-modern/style.scss
+++ b/client/my-sites/themes/banners-modern/style.scss
@@ -34,7 +34,7 @@
 .banner-modern__description {
 	color: var( --studio-gray-80 );
 	font-size: $font-body-large;
-	line-height: 1.2;
+	line-height: 1.5;
 	margin-block-end: 24px;
 }
 

--- a/client/my-sites/themes/collections/collection-definitions.tsx
+++ b/client/my-sites/themes/collections/collection-definitions.tsx
@@ -16,7 +16,28 @@ export type ThemeCollectionDefinition = {
 	seeAllLink: string;
 };
 
-export const THEME_COLLECTIONS = {
+export const THEME_COLLECTIONS: Record< string, ThemeCollectionDefinition > = {
+	recommended: {
+		query: {
+			collection: 'recommended',
+			filter: '',
+			number: 20,
+			page: 1,
+			search: '',
+			tier: '',
+		},
+		get title() {
+			return translate( 'Our favorites' );
+		},
+		get fullTitle() {
+			return translate( 'Our favorites' );
+		},
+		collectionSlug: 'recommended-themes',
+		get description() {
+			return translate( 'Exceptional themes selected by the WordPress.com design team.' );
+		},
+		seeAllLink: '/themes/recommended/collection',
+	},
 	marketplace: {
 		query: {
 			collection: 'recommended',

--- a/client/my-sites/themes/collections/use-theme-collection.ts
+++ b/client/my-sites/themes/collections/use-theme-collection.ts
@@ -18,7 +18,8 @@ export interface ThemesQuery {
 	tier: string;
 	filter: string;
 	search: string;
-	collection: string;
+	collection?: string;
+	sort?: string;
 }
 
 export function useThemeCollection( query: ThemesQuery ) {

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -25,8 +25,8 @@ export default function ( router ) {
 	const showcaseRoutes = [
 		`/${ langParam }/themes/${ tierParam }/:view(collection)?`,
 		`/${ langParam }/themes/${ tierParam }/filter/:filter?/:view(collection)?`,
-		`/${ langParam }/themes/:category(all)?/${ tierParam }/:view(collection)?`,
-		`/${ langParam }/themes/:category(all)?/${ tierParam }/filter/:filter/:view(collection)?`,
+		`/${ langParam }/themes/:category(all|recommended)?/${ tierParam }/:view(collection)?`,
+		`/${ langParam }/themes/:category(all|recommended)?/${ tierParam }/filter/:filter/:view(collection)?`,
 		`/${ langParam }/themes/:vertical?/${ tierParam }/:view(collection)?`,
 		`/${ langParam }/themes/:vertical?/${ tierParam }/filter/:filter/:view(collection)?`,
 	];

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -31,16 +31,16 @@ export default function ( router ) {
 	const routesWithoutSites = [
 		`/${ langParam }/themes/${ tierParam }/:view(collection)?`,
 		`/${ langParam }/themes/${ tierParam }/filter/:filter/:view(collection)?`,
-		`/${ langParam }/themes/:category(all|my-themes)?/${ tierParam }/:view(collection)?`,
-		`/${ langParam }/themes/:category(all|my-themes)?/${ tierParam }/filter/:filter/:view(collection)?`,
+		`/${ langParam }/themes/:category(all|my-themes|recommended)?/${ tierParam }/:view(collection)?`,
+		`/${ langParam }/themes/:category(all|my-themes|recommended)?/${ tierParam }/filter/:filter/:view(collection)?`,
 		`/${ langParam }/themes/:vertical?/${ tierParam }/:view(collection)?`,
 		`/${ langParam }/themes/:vertical?/${ tierParam }/filter/:filter/:view(collection)?`,
 	];
 	const routesWithSites = [
 		`/${ langParam }/themes/${ tierParam }/:view(collection)?/:site_id(${ siteId })`,
 		`/${ langParam }/themes/${ tierParam }/filter/:filter/:view(collection)?/:site_id(${ siteId })`,
-		`/${ langParam }/themes/:category(all|my-themes)?/${ tierParam }/:view(collection)?/:site_id(${ siteId })`,
-		`/${ langParam }/themes/:category(all|my-themes)?/${ tierParam }/filter/:filter/:view(collection)?/:site_id(${ siteId })`,
+		`/${ langParam }/themes/:category(all|my-themes|recommended)?/${ tierParam }/:view(collection)?/:site_id(${ siteId })`,
+		`/${ langParam }/themes/:category(all|my-themes|recommended)?/${ tierParam }/filter/:filter/:view(collection)?/:site_id(${ siteId })`,
 		`/${ langParam }/themes/:vertical?/${ tierParam }/:view(collection)?/:site_id(${ siteId })`,
 		`/${ langParam }/themes/:vertical?/${ tierParam }/filter/:filter/:view(collection)?/:site_id(${ siteId })`,
 	];

--- a/client/my-sites/themes/sections-modern/recommended-sections.tsx
+++ b/client/my-sites/themes/sections-modern/recommended-sections.tsx
@@ -1,0 +1,215 @@
+import { getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
+import page from '@automattic/calypso-router';
+import { useTranslate, type TranslateResult } from 'i18n-calypso';
+import { useQueryThemes } from 'calypso/components/data/query-themes';
+import { ThemeBlock } from 'calypso/components/themes-list';
+import {
+	ThemesQuery,
+	useThemeCollection,
+} from 'calypso/my-sites/themes/collections/use-theme-collection';
+import { getThemeShowcaseEventRecorder } from 'calypso/my-sites/themes/events/theme-showcase-tracks';
+import { trackClick } from 'calypso/my-sites/themes/helpers';
+import { Theme } from 'calypso/types';
+import ThemeSectionHeader from './theme-section-header';
+import './style.scss';
+
+const FAVORITES_QUERY: ThemesQuery = {
+	collection: 'recommended',
+	number: 6,
+	tier: '',
+	filter: '',
+	search: '',
+	page: 1,
+};
+
+const FRESH_QUERY: ThemesQuery = {
+	collection: '',
+	number: 6,
+	tier: '',
+	filter: '',
+	search: '',
+	page: 1,
+};
+
+const PARTNER_QUERY: ThemesQuery = {
+	collection: 'recommended',
+	number: 6,
+	tier: 'marketplace',
+	filter: '',
+	search: '',
+	page: 1,
+};
+
+type ThemeSectionProps = {
+	title: string;
+	subtitle: TranslateResult;
+	buttonLabel: string;
+	seeAllUrl: string;
+	query: ThemesQuery;
+	sectionSlug: string;
+	sectionIndex: number;
+	getActionLabel: ( themeId: string ) => string;
+	getOptions: ( themeId: string ) => void;
+	getScreenshotUrl: ( themeId: string ) => string;
+};
+
+function ThemeSection( {
+	title,
+	subtitle,
+	buttonLabel,
+	seeAllUrl,
+	query,
+	sectionSlug,
+	sectionIndex,
+	getActionLabel,
+	getOptions,
+	getScreenshotUrl,
+}: ThemeSectionProps ) {
+	const {
+		getPrice,
+		themes,
+		isActive,
+		isInstalling,
+		isLivePreviewStarted,
+		siteId,
+		getThemeType,
+		getThemeTierForTheme,
+		filterString,
+		getThemeDetailsUrl,
+	} = useThemeCollection( query );
+	useQueryThemes( 'wpcom', query );
+
+	const { recordThemeClick, recordThemeStyleVariationClick, recordThemesStyleVariationMoreClick } =
+		getThemeShowcaseEventRecorder(
+			query,
+			themes,
+			filterString,
+			getThemeType,
+			getThemeTierForTheme,
+			isActive,
+			sectionSlug,
+			sectionIndex
+		);
+
+	const onScreenshotClick = ( themeId: string, resultsRank: number ) => {
+		trackClick( 'theme', 'screenshot' );
+		recordThemeClick( themeId, resultsRank, 'screenshot_info' );
+	};
+
+	const onStyleVariationClick = (
+		themeId: string,
+		resultsRank: number,
+		variation: { slug: string }
+	) => {
+		recordThemeClick( themeId, resultsRank, 'style_variation', variation?.slug );
+		if ( variation ) {
+			recordThemeStyleVariationClick( themeId, resultsRank, '', variation.slug );
+		} else {
+			recordThemesStyleVariationMoreClick( themeId, resultsRank );
+			const themeDetailsUrl = getThemeDetailsUrl( themeId );
+			if ( themeDetailsUrl ) {
+				page( themeDetailsUrl );
+			}
+		}
+	};
+
+	const handleSeeAll = () => {
+		page( seeAllUrl );
+		window.scrollTo( { top: 0 } );
+	};
+
+	return (
+		<div className="theme-section-modern">
+			<ThemeSectionHeader
+				title={ title }
+				subtitle={ subtitle }
+				buttonLabel={ buttonLabel }
+				onButtonClick={ handleSeeAll }
+			/>
+			<div className="theme-section-modern__grid">
+				{ themes.map( ( theme: Theme, index: number ) => (
+					<ThemeBlock
+						key={ theme.id }
+						getActionLabel={ getActionLabel }
+						getButtonOptions={ getOptions }
+						getPrice={ getPrice }
+						getScreenshotUrl={ getScreenshotUrl }
+						index={ index }
+						isActive={ isActive }
+						isInstalling={ isInstalling }
+						isLivePreviewStarted={ isLivePreviewStarted }
+						siteId={ siteId }
+						theme={ theme }
+						onMoreButtonClick={ recordThemeClick }
+						onMoreButtonItemClick={ recordThemeClick }
+						onScreenshotClick={ onScreenshotClick }
+						onStyleVariationClick={ onStyleVariationClick }
+					/>
+				) ) }
+			</div>
+		</div>
+	);
+}
+
+type RecommendedSectionsProps = {
+	getActionLabel: ( themeId: string ) => string;
+	getOptions: ( themeId: string ) => void;
+	getScreenshotUrl: ( themeId: string ) => string;
+};
+
+export default function RecommendedSections( {
+	getActionLabel,
+	getOptions,
+	getScreenshotUrl,
+}: RecommendedSectionsProps ) {
+	const translate = useTranslate();
+
+	return (
+		<div className="recommended-sections">
+			<ThemeSection
+				title={ translate( 'Our favorites' ) }
+				subtitle={ translate( 'Exceptional themes selected by the WordPress.com design team.' ) }
+				buttonLabel={ translate( 'See all' ) }
+				seeAllUrl="/themes/recommended/collection"
+				query={ FAVORITES_QUERY }
+				sectionSlug="favorites"
+				sectionIndex={ 0 }
+				getActionLabel={ getActionLabel }
+				getOptions={ getOptions }
+				getScreenshotUrl={ getScreenshotUrl }
+			/>
+			<ThemeSection
+				title={ translate( 'Fresh themes' ) }
+				subtitle={ translate( 'All the latest themes from WordPress.com designers.' ) }
+				buttonLabel={ translate( 'See all' ) }
+				seeAllUrl="/themes/all"
+				query={ FRESH_QUERY }
+				sectionSlug="fresh"
+				sectionIndex={ 1 }
+				getActionLabel={ getActionLabel }
+				getOptions={ getOptions }
+				getScreenshotUrl={ getScreenshotUrl }
+			/>
+			<ThemeSection
+				title={ translate( 'Partner themes' ) }
+				subtitle={
+					<>
+						{ translate( 'Level up your site with exclusive themes from expert partners.' ) }
+						<br />
+						{ translate( 'Available on %(planName)s plans with an additional theme subscription.', {
+							args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+						} ) }
+					</>
+				}
+				buttonLabel={ translate( 'See all' ) }
+				seeAllUrl="/themes/partner"
+				query={ PARTNER_QUERY }
+				sectionSlug="partner"
+				sectionIndex={ 2 }
+				getActionLabel={ getActionLabel }
+				getOptions={ getOptions }
+				getScreenshotUrl={ getScreenshotUrl }
+			/>
+		</div>
+	);
+}

--- a/client/my-sites/themes/sections-modern/recommended-sections.tsx
+++ b/client/my-sites/themes/sections-modern/recommended-sections.tsx
@@ -15,12 +15,12 @@ const FAVORITES_QUERY: ThemesQuery = {
 };
 
 const FRESH_QUERY: ThemesQuery = {
-	collection: '',
 	number: 6,
 	tier: '',
 	filter: '',
 	search: '',
 	page: 1,
+	sort: 'date',
 };
 
 const PARTNER_QUERY: ThemesQuery = {

--- a/client/my-sites/themes/sections-modern/recommended-sections.tsx
+++ b/client/my-sites/themes/sections-modern/recommended-sections.tsx
@@ -10,6 +10,8 @@ import {
 import { getThemeShowcaseEventRecorder } from 'calypso/my-sites/themes/events/theme-showcase-tracks';
 import { trackClick } from 'calypso/my-sites/themes/helpers';
 import { Theme } from 'calypso/types';
+import AIBuilderBanner from '../banners-modern/ai-builder-banner';
+import DIFMBanner from '../banners-modern/difm-banner';
 import ThemeSectionHeader from './theme-section-header';
 import './style.scss';
 
@@ -178,6 +180,7 @@ export default function RecommendedSections( {
 				getOptions={ getOptions }
 				getScreenshotUrl={ getScreenshotUrl }
 			/>
+			<AIBuilderBanner />
 			<ThemeSection
 				title={ translate( 'Fresh themes' ) }
 				subtitle={ translate( 'All the latest themes from WordPress.com designers.' ) }
@@ -190,6 +193,7 @@ export default function RecommendedSections( {
 				getOptions={ getOptions }
 				getScreenshotUrl={ getScreenshotUrl }
 			/>
+			<DIFMBanner />
 			<ThemeSection
 				title={ translate( 'Partner themes' ) }
 				subtitle={

--- a/client/my-sites/themes/sections-modern/recommended-sections.tsx
+++ b/client/my-sites/themes/sections-modern/recommended-sections.tsx
@@ -1,19 +1,9 @@
 import { getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
-import page from '@automattic/calypso-router';
-import { useTranslate, type TranslateResult } from 'i18n-calypso';
-import { useQueryThemes } from 'calypso/components/data/query-themes';
-import { ThemeBlock } from 'calypso/components/themes-list';
-import {
-	ThemesQuery,
-	useThemeCollection,
-} from 'calypso/my-sites/themes/collections/use-theme-collection';
-import { getThemeShowcaseEventRecorder } from 'calypso/my-sites/themes/events/theme-showcase-tracks';
-import { trackClick } from 'calypso/my-sites/themes/helpers';
-import { Theme } from 'calypso/types';
+import { useTranslate } from 'i18n-calypso';
+import { ThemesQuery } from 'calypso/my-sites/themes/collections/use-theme-collection';
 import AIBuilderBanner from '../banners-modern/ai-builder-banner';
 import DIFMBanner from '../banners-modern/difm-banner';
-import ThemeSectionHeader from './theme-section-header';
-import './style.scss';
+import ThemeSection from './theme-section';
 
 const FAVORITES_QUERY: ThemesQuery = {
 	collection: 'recommended',
@@ -41,117 +31,6 @@ const PARTNER_QUERY: ThemesQuery = {
 	search: '',
 	page: 1,
 };
-
-type ThemeSectionProps = {
-	title: string;
-	subtitle: TranslateResult;
-	buttonLabel: string;
-	seeAllUrl: string;
-	query: ThemesQuery;
-	sectionSlug: string;
-	sectionIndex: number;
-	getActionLabel: ( themeId: string ) => string;
-	getOptions: ( themeId: string ) => void;
-	getScreenshotUrl: ( themeId: string ) => string;
-};
-
-function ThemeSection( {
-	title,
-	subtitle,
-	buttonLabel,
-	seeAllUrl,
-	query,
-	sectionSlug,
-	sectionIndex,
-	getActionLabel,
-	getOptions,
-	getScreenshotUrl,
-}: ThemeSectionProps ) {
-	const {
-		getPrice,
-		themes,
-		isActive,
-		isInstalling,
-		isLivePreviewStarted,
-		siteId,
-		getThemeType,
-		getThemeTierForTheme,
-		filterString,
-		getThemeDetailsUrl,
-	} = useThemeCollection( query );
-	useQueryThemes( 'wpcom', query );
-
-	const { recordThemeClick, recordThemeStyleVariationClick, recordThemesStyleVariationMoreClick } =
-		getThemeShowcaseEventRecorder(
-			query,
-			themes,
-			filterString,
-			getThemeType,
-			getThemeTierForTheme,
-			isActive,
-			sectionSlug,
-			sectionIndex
-		);
-
-	const onScreenshotClick = ( themeId: string, resultsRank: number ) => {
-		trackClick( 'theme', 'screenshot' );
-		recordThemeClick( themeId, resultsRank, 'screenshot_info' );
-	};
-
-	const onStyleVariationClick = (
-		themeId: string,
-		resultsRank: number,
-		variation: { slug: string }
-	) => {
-		recordThemeClick( themeId, resultsRank, 'style_variation', variation?.slug );
-		if ( variation ) {
-			recordThemeStyleVariationClick( themeId, resultsRank, '', variation.slug );
-		} else {
-			recordThemesStyleVariationMoreClick( themeId, resultsRank );
-			const themeDetailsUrl = getThemeDetailsUrl( themeId );
-			if ( themeDetailsUrl ) {
-				page( themeDetailsUrl );
-			}
-		}
-	};
-
-	const handleSeeAll = () => {
-		page( seeAllUrl );
-		window.scrollTo( { top: 0 } );
-	};
-
-	return (
-		<div className="theme-section-modern">
-			<ThemeSectionHeader
-				title={ title }
-				subtitle={ subtitle }
-				buttonLabel={ buttonLabel }
-				onButtonClick={ handleSeeAll }
-			/>
-			<div className="theme-section-modern__grid">
-				{ themes.map( ( theme: Theme, index: number ) => (
-					<ThemeBlock
-						key={ theme.id }
-						getActionLabel={ getActionLabel }
-						getButtonOptions={ getOptions }
-						getPrice={ getPrice }
-						getScreenshotUrl={ getScreenshotUrl }
-						index={ index }
-						isActive={ isActive }
-						isInstalling={ isInstalling }
-						isLivePreviewStarted={ isLivePreviewStarted }
-						siteId={ siteId }
-						theme={ theme }
-						onMoreButtonClick={ recordThemeClick }
-						onMoreButtonItemClick={ recordThemeClick }
-						onScreenshotClick={ onScreenshotClick }
-						onStyleVariationClick={ onStyleVariationClick }
-					/>
-				) ) }
-			</div>
-		</div>
-	);
-}
 
 type RecommendedSectionsProps = {
 	getActionLabel: ( themeId: string ) => string;
@@ -207,6 +86,7 @@ export default function RecommendedSections( {
 				}
 				buttonLabel={ translate( 'See all' ) }
 				seeAllUrl="/themes/partner"
+				variant="dark"
 				query={ PARTNER_QUERY }
 				sectionSlug="partner"
 				sectionIndex={ 2 }

--- a/client/my-sites/themes/sections-modern/style.scss
+++ b/client/my-sites/themes/sections-modern/style.scss
@@ -2,14 +2,20 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
+.theme-section-modern {
+	margin-bottom: 96px;
+}
+
 .theme-section-header {
 	align-items: flex-end;
 	display: flex;
-	flex-wrap: wrap;
 	justify-content: space-between;
-	margin: 48px auto 0 auto;
+	margin: 48px auto;
 	max-width: 1220px;
-	padding: 24px;
+}
+
+.theme-section-header__headings {
+	padding-right: 24px;
 }
 
 .theme-section-header__title {
@@ -28,11 +34,27 @@
 .theme-section-header__subtitle {
 	color: var(--studio-gray-80);
 	font-size: $font-body-large;
-	line-height: 1.2;
+	line-height: 1.6;
 	margin: 0;
 }
 
 .theme-section-header__button.components-button.is-secondary {
 	--wp-components-color-accent: var(--studio-gray-80);
 	--wp-components-color-accent-darker-20: var(--studio-gray-100);
+}
+
+.theme-section-modern__grid {
+	display: grid;
+	gap: 24px;
+	grid-template-columns: 1fr;
+	margin: 0 auto;
+	max-width: 1220px;
+
+	@include break-small {
+		grid-template-columns: repeat(2, 1fr);
+	}
+
+	@include break-large {
+		grid-template-columns: repeat(3, 1fr);
+	}
 }

--- a/client/my-sites/themes/sections-modern/style.scss
+++ b/client/my-sites/themes/sections-modern/style.scss
@@ -3,7 +3,21 @@
 @import "@wordpress/base-styles/mixins";
 
 .theme-section-modern {
+	--theme-section-bg: var(--studio-white);
+	--theme-section-text: var(--studio-gray-100);
+	--theme-section-text-secondary: var(--studio-gray-80);
+
 	margin-bottom: 96px;
+	padding-inline: 24px;
+}
+
+.theme-section-modern.is-dark {
+	--theme-section-bg: var(--studio-gray-90);
+	--theme-section-text: var(--studio-white);
+	--theme-section-text-secondary: var(--studio-gray-10);
+
+	background-color: var(--theme-section-bg);
+	padding: 24px 24px 96px 24px;
 }
 
 .theme-section-header {
@@ -19,22 +33,22 @@
 }
 
 .theme-section-header__title {
-	color: var(--studio-gray-100);
+	color: var(--theme-section-text, var(--studio-gray-100));
 	font-family: $brand-serif;
 	font-size: rem(40px);
 	font-weight: 400;
 	line-height: 1.2;
 	margin: 0;
 
-	@include break-small {
+	@include break-medium {
 		font-size: rem(50px);
 	}
 }
 
 .theme-section-header__subtitle {
-	color: var(--studio-gray-80);
+	color: var(--theme-section-text-secondary, var(--studio-gray-80));
 	font-size: $font-body-large;
-	line-height: 1.6;
+	line-height: 1.5;
 	margin: 0;
 }
 
@@ -57,4 +71,23 @@
 	@include break-large {
 		grid-template-columns: repeat(3, 1fr);
 	}
+}
+
+.theme-section-modern.is-dark .theme-section-header__button.components-button.is-secondary {
+	--wp-components-color-accent: var(--studio-white);
+	--wp-components-color-accent-darker-20: var(--studio-gray-0);
+}
+
+.theme-section-modern.is-dark .theme-card__info-title {
+	color: var(--theme-section-text);
+}
+
+.theme-section-modern.is-dark .theme-tier-badge__without-background.theme-tier-badge__content {
+	color: var(--theme-section-text-secondary);
+}
+
+.recommended-sections .banner-modern {
+	margin: 96px auto;
+	max-width: calc( 1220px - 48px);
+	width: calc( 100% - 48px - 48px);
 }

--- a/client/my-sites/themes/sections-modern/test/recommended-sections.test.tsx
+++ b/client/my-sites/themes/sections-modern/test/recommended-sections.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import RecommendedSections from '../recommended-sections';
+
+jest.mock( '../theme-section', () => {
+	return {
+		__esModule: true,
+		default: ( {
+			title,
+			seeAllUrl,
+			variant,
+			sectionSlug,
+		}: {
+			title: string;
+			seeAllUrl: string;
+			variant?: string;
+			sectionSlug: string;
+		} ) => (
+			<div
+				data-testid={ `theme-section-${ sectionSlug }` }
+				data-variant={ variant ?? 'light' }
+				data-see-all-url={ seeAllUrl }
+			>
+				{ title }
+			</div>
+		),
+	};
+} );
+
+jest.mock( '../../banners-modern/ai-builder-banner', () => {
+	return {
+		__esModule: true,
+		default: () => <div data-testid="ai-builder-banner">AI Builder Banner</div>,
+	};
+} );
+
+jest.mock( '../../banners-modern/difm-banner', () => {
+	return {
+		__esModule: true,
+		default: () => <div data-testid="difm-banner">DIFM Banner</div>,
+	};
+} );
+
+const defaultProps = {
+	getActionLabel: jest.fn(),
+	getOptions: jest.fn(),
+	getScreenshotUrl: jest.fn(),
+};
+
+describe( 'RecommendedSections', () => {
+	test( 'renders all three sections', () => {
+		render( <RecommendedSections { ...defaultProps } /> );
+		expect( screen.getByTestId( 'theme-section-favorites' ) ).toBeVisible();
+		expect( screen.getByTestId( 'theme-section-fresh' ) ).toBeVisible();
+		expect( screen.getByTestId( 'theme-section-partner' ) ).toBeVisible();
+	} );
+
+	test( 'renders section titles', () => {
+		render( <RecommendedSections { ...defaultProps } /> );
+		expect( screen.getByText( 'Our favorites' ) ).toBeVisible();
+		expect( screen.getByText( 'Fresh themes' ) ).toBeVisible();
+		expect( screen.getByText( 'Partner themes' ) ).toBeVisible();
+	} );
+
+	test( 'renders AI Builder banner between favorites and fresh sections', () => {
+		render( <RecommendedSections { ...defaultProps } /> );
+		expect( screen.getByTestId( 'ai-builder-banner' ) ).toBeVisible();
+	} );
+
+	test( 'renders DIFM banner between fresh and partner sections', () => {
+		render( <RecommendedSections { ...defaultProps } /> );
+		expect( screen.getByTestId( 'difm-banner' ) ).toBeVisible();
+	} );
+
+	test( 'sets correct see-all URLs for each section', () => {
+		render( <RecommendedSections { ...defaultProps } /> );
+		expect( screen.getByTestId( 'theme-section-favorites' ) ).toHaveAttribute(
+			'data-see-all-url',
+			'/themes/recommended/collection'
+		);
+		expect( screen.getByTestId( 'theme-section-fresh' ) ).toHaveAttribute(
+			'data-see-all-url',
+			'/themes/all'
+		);
+		expect( screen.getByTestId( 'theme-section-partner' ) ).toHaveAttribute(
+			'data-see-all-url',
+			'/themes/partner'
+		);
+	} );
+
+	test( 'uses dark variant for partner section only', () => {
+		render( <RecommendedSections { ...defaultProps } /> );
+		expect( screen.getByTestId( 'theme-section-favorites' ) ).toHaveAttribute(
+			'data-variant',
+			'light'
+		);
+		expect( screen.getByTestId( 'theme-section-fresh' ) ).toHaveAttribute(
+			'data-variant',
+			'light'
+		);
+		expect( screen.getByTestId( 'theme-section-partner' ) ).toHaveAttribute(
+			'data-variant',
+			'dark'
+		);
+	} );
+
+	test( 'renders sections and banners in correct order', () => {
+		const { container } = render( <RecommendedSections { ...defaultProps } /> );
+		const children = Array.from(
+			container.querySelector( '.recommended-sections' )?.children ?? []
+		);
+		const testIds = children.map( ( el ) => el.getAttribute( 'data-testid' ) );
+		expect( testIds ).toEqual( [
+			'theme-section-favorites',
+			'ai-builder-banner',
+			'theme-section-fresh',
+			'difm-banner',
+			'theme-section-partner',
+		] );
+	} );
+} );

--- a/client/my-sites/themes/sections-modern/test/theme-section.test.tsx
+++ b/client/my-sites/themes/sections-modern/test/theme-section.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import ThemeSection from '../theme-section';
+
+const mockThemes = [
+	{ id: 'theme-1', name: 'Theme One', stylesheet: 'pub/theme-1' },
+	{ id: 'theme-2', name: 'Theme Two', stylesheet: 'pub/theme-2' },
+];
+
+jest.mock( 'calypso/components/data/query-themes', () => ( {
+	useQueryThemes: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/my-sites/themes/collections/use-theme-collection', () => ( {
+	useThemeCollection: jest.fn( () => ( {
+		themes: mockThemes,
+		getPrice: jest.fn(),
+		isActive: jest.fn(),
+		isInstalling: jest.fn(),
+		isLivePreviewStarted: jest.fn(),
+		siteId: null,
+		getThemeType: jest.fn(),
+		getThemeTierForTheme: jest.fn(),
+		filterString: '',
+		getThemeDetailsUrl: jest.fn(),
+	} ) ),
+} ) );
+
+jest.mock( 'calypso/my-sites/themes/events/theme-showcase-tracks', () => ( {
+	getThemeShowcaseEventRecorder: jest.fn( () => ( {
+		recordThemeClick: jest.fn(),
+		recordThemeStyleVariationClick: jest.fn(),
+		recordThemesStyleVariationMoreClick: jest.fn(),
+	} ) ),
+} ) );
+
+jest.mock( 'calypso/components/themes-list', () => ( {
+	ThemeBlock: ( { theme }: { theme: { id: string; name: string } } ) => (
+		<div data-testid={ `theme-block-${ theme.id }` }>{ theme.name }</div>
+	),
+} ) );
+
+jest.mock( 'calypso/my-sites/themes/helpers', () => ( {
+	trackClick: jest.fn(),
+} ) );
+
+const defaultProps = {
+	title: 'Our favorites',
+	subtitle: 'Exceptional themes selected by the WordPress.com design team.',
+	buttonLabel: 'See all',
+	seeAllUrl: '/themes/recommended/collection',
+	query: {
+		collection: 'recommended',
+		number: 6,
+		tier: '',
+		filter: '',
+		search: '',
+		page: 1,
+	},
+	sectionSlug: 'favorites',
+	sectionIndex: 0,
+	getActionLabel: jest.fn(),
+	getOptions: jest.fn(),
+	getScreenshotUrl: jest.fn(),
+};
+
+describe( 'ThemeSection', () => {
+	test( 'renders section title and subtitle', () => {
+		render( <ThemeSection { ...defaultProps } /> );
+		expect( screen.getByText( 'Our favorites' ) ).toBeVisible();
+		expect(
+			screen.getByText( 'Exceptional themes selected by the WordPress.com design team.' )
+		).toBeVisible();
+	} );
+
+	test( 'renders a theme block for each theme', () => {
+		render( <ThemeSection { ...defaultProps } /> );
+		expect( screen.getByTestId( 'theme-block-theme-1' ) ).toBeVisible();
+		expect( screen.getByTestId( 'theme-block-theme-2' ) ).toBeVisible();
+	} );
+
+	test( 'renders "See all" button', () => {
+		render( <ThemeSection { ...defaultProps } /> );
+		expect( screen.getByRole( 'button', { name: 'See all' } ) ).toBeVisible();
+	} );
+
+	test( 'applies light variant by default', () => {
+		const { container } = render( <ThemeSection { ...defaultProps } /> );
+		expect( container.querySelector( '.theme-section-modern' ) ).not.toHaveClass( 'is-dark' );
+	} );
+
+	test( 'applies dark variant class when variant is "dark"', () => {
+		const { container } = render( <ThemeSection { ...defaultProps } variant="dark" /> );
+		expect( container.querySelector( '.theme-section-modern' ) ).toHaveClass( 'is-dark' );
+	} );
+
+	test( 'renders empty grid when there are no themes', () => {
+		const { useThemeCollection } = jest.requireMock(
+			'calypso/my-sites/themes/collections/use-theme-collection'
+		);
+		useThemeCollection.mockReturnValueOnce( {
+			themes: [],
+			getPrice: jest.fn(),
+			isActive: jest.fn(),
+			isInstalling: jest.fn(),
+			isLivePreviewStarted: jest.fn(),
+			siteId: null,
+			getThemeType: jest.fn(),
+			getThemeTierForTheme: jest.fn(),
+			filterString: '',
+			getThemeDetailsUrl: jest.fn(),
+		} );
+
+		const { container } = render( <ThemeSection { ...defaultProps } /> );
+		expect( container.querySelector( '.theme-section-modern__grid' )?.children ).toHaveLength( 0 );
+	} );
+} );

--- a/client/my-sites/themes/sections-modern/theme-section-header.tsx
+++ b/client/my-sites/themes/sections-modern/theme-section-header.tsx
@@ -1,10 +1,11 @@
 import { Button } from '@wordpress/components';
+import type { TranslateResult } from 'i18n-calypso';
 
 import './style.scss';
 
 interface ThemeSectionHeaderProps {
 	title: string;
-	subtitle: string;
+	subtitle: TranslateResult;
 	buttonLabel?: string;
 	buttonHref?: string;
 	onButtonClick?: () => void;

--- a/client/my-sites/themes/sections-modern/theme-section.tsx
+++ b/client/my-sites/themes/sections-modern/theme-section.tsx
@@ -1,0 +1,128 @@
+import page from '@automattic/calypso-router';
+import clsx from 'clsx';
+import { useQueryThemes } from 'calypso/components/data/query-themes';
+import { ThemeBlock } from 'calypso/components/themes-list';
+import {
+	ThemesQuery,
+	useThemeCollection,
+} from 'calypso/my-sites/themes/collections/use-theme-collection';
+import { getThemeShowcaseEventRecorder } from 'calypso/my-sites/themes/events/theme-showcase-tracks';
+import { trackClick } from 'calypso/my-sites/themes/helpers';
+import { Theme } from 'calypso/types';
+import ThemeSectionHeader from './theme-section-header';
+import type { TranslateResult } from 'i18n-calypso';
+
+import './style.scss';
+
+export type ThemeSectionProps = {
+	title: string;
+	subtitle: TranslateResult;
+	buttonLabel: string;
+	seeAllUrl: string;
+	query: ThemesQuery;
+	sectionSlug: string;
+	sectionIndex: number;
+	variant?: 'light' | 'dark';
+	getActionLabel: ( themeId: string ) => string;
+	getOptions: ( themeId: string ) => void;
+	getScreenshotUrl: ( themeId: string ) => string;
+};
+
+export default function ThemeSection( {
+	title,
+	subtitle,
+	buttonLabel,
+	seeAllUrl,
+	query,
+	sectionSlug,
+	sectionIndex,
+	variant = 'light',
+	getActionLabel,
+	getOptions,
+	getScreenshotUrl,
+}: ThemeSectionProps ) {
+	const {
+		getPrice,
+		themes,
+		isActive,
+		isInstalling,
+		isLivePreviewStarted,
+		siteId,
+		getThemeType,
+		getThemeTierForTheme,
+		filterString,
+		getThemeDetailsUrl,
+	} = useThemeCollection( query );
+	useQueryThemes( 'wpcom', query );
+
+	const { recordThemeClick, recordThemeStyleVariationClick, recordThemesStyleVariationMoreClick } =
+		getThemeShowcaseEventRecorder(
+			query,
+			themes,
+			filterString,
+			getThemeType,
+			getThemeTierForTheme,
+			isActive,
+			sectionSlug,
+			sectionIndex
+		);
+
+	const onScreenshotClick = ( themeId: string, resultsRank: number ) => {
+		trackClick( 'theme', 'screenshot' );
+		recordThemeClick( themeId, resultsRank, 'screenshot_info' );
+	};
+
+	const onStyleVariationClick = (
+		themeId: string,
+		resultsRank: number,
+		variation: { slug: string }
+	) => {
+		recordThemeClick( themeId, resultsRank, 'style_variation', variation?.slug );
+		if ( variation ) {
+			recordThemeStyleVariationClick( themeId, resultsRank, '', variation.slug );
+		} else {
+			recordThemesStyleVariationMoreClick( themeId, resultsRank );
+			const themeDetailsUrl = getThemeDetailsUrl( themeId );
+			if ( themeDetailsUrl ) {
+				page( themeDetailsUrl );
+			}
+		}
+	};
+
+	const handleSeeAll = () => {
+		page( seeAllUrl );
+		window.scrollTo( { top: 0 } );
+	};
+
+	return (
+		<div className={ clsx( 'theme-section-modern', { 'is-dark': variant === 'dark' } ) }>
+			<ThemeSectionHeader
+				title={ title }
+				subtitle={ subtitle }
+				buttonLabel={ buttonLabel }
+				onButtonClick={ handleSeeAll }
+			/>
+			<div className="theme-section-modern__grid">
+				{ themes.map( ( theme: Theme, index: number ) => (
+					<ThemeBlock
+						key={ theme.id }
+						getActionLabel={ getActionLabel }
+						getButtonOptions={ getOptions }
+						getPrice={ getPrice }
+						getScreenshotUrl={ getScreenshotUrl }
+						index={ index }
+						isActive={ isActive }
+						isInstalling={ isInstalling }
+						isLivePreviewStarted={ isLivePreviewStarted }
+						siteId={ siteId }
+						theme={ theme }
+						onMoreButtonClick={ recordThemeClick }
+						onMoreButtonItemClick={ recordThemeClick }
+						onScreenshotClick={ onScreenshotClick }
+						onStyleVariationClick={ onStyleVariationClick }
+					/>
+				) ) }
+			</div>
+		</div>
+	);
+}

--- a/client/my-sites/themes/test/logged-out.jsx
+++ b/client/my-sites/themes/test/logged-out.jsx
@@ -21,9 +21,11 @@ jest.mock( 'calypso/lib/analytics/page-view-tracker', () =>
 jest.mock( 'calypso/my-sites/themes/theme-preview', () =>
 	require( 'calypso/components/empty-component' )
 );
-jest.mock( 'calypso/components/data/query-themes', () =>
-	require( 'calypso/components/empty-component' )
-);
+jest.mock( 'calypso/components/data/query-themes', () => ( {
+	__esModule: true,
+	default: require( 'calypso/components/empty-component' ).default,
+	useQueryThemes: jest.fn(),
+} ) );
 
 window.IntersectionObserver = jest.fn( () => ( {
 	observe: jest.fn(),
@@ -93,12 +95,12 @@ const themes = [
 	},
 ];
 
-const TestComponent = ( { store } ) => {
+const TestComponent = ( { store, ...props } ) => {
 	const queryClient = new QueryClient();
 	return (
 		<ReduxProvider store={ store }>
 			<QueryClientProvider client={ queryClient }>
-				<LoggedOutShowcase />
+				<LoggedOutShowcase { ...props } />
 			</QueryClientProvider>
 		</ReduxProvider>
 	);
@@ -116,7 +118,8 @@ describe( 'logged-out', () => {
 				themes.length
 			)
 		);
-		render( <TestComponent store={ store } /> );
+
+		render( <TestComponent store={ store } category="recommended" /> );
 
 		await waitFor( () => {
 			expect( screen.getByText( 'No themes match your search' ) ).toBeInTheDocument();
@@ -154,7 +157,7 @@ describe( 'logged-out', () => {
 			query: { ...DEFAULT_THEME_QUERY, collection: 'recommended' },
 			error: 'Error',
 		} );
-		render( <TestComponent store={ store } /> );
+		render( <TestComponent store={ store } category="recommended" /> );
 
 		await waitFor( () => {
 			expect( screen.queryByText( 'No themes match your search' ) ).toBeInTheDocument();

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -548,8 +548,8 @@ class ThemeShowcase extends Component {
 		const staticFilters = this.getStaticFilters();
 
 		if (
-			tabKey === staticFilters.RECOMMENDED?.key &&
 			this.isThemeShowcaseModern() &&
+			! this.props.category &&
 			! this.props.isCollectionView &&
 			! this.props.filter &&
 			! this.props.vertical &&

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -550,7 +550,11 @@ class ThemeShowcase extends Component {
 		if (
 			tabKey === staticFilters.RECOMMENDED?.key &&
 			this.isThemeShowcaseModern() &&
-			! this.props.isCollectionView
+			! this.props.isCollectionView &&
+			! this.props.filter &&
+			! this.props.vertical &&
+			! this.props.search &&
+			( ! this.props.tier || this.props.tier === 'all' )
 		) {
 			return (
 				<RecommendedSections

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -51,6 +51,7 @@ import {
 	isStaticFilter,
 	constructThemeShowcaseUrl,
 } from './helpers';
+import RecommendedSections from './sections-modern/recommended-sections';
 import ThemeErrors from './theme-errors';
 import ThemePreview from './theme-preview';
 import ThemeShowcaseHeader from './theme-showcase-header';
@@ -545,6 +546,20 @@ class ThemeShowcase extends Component {
 	renderThemes = ( themeProps ) => {
 		const tabKey = this.getSelectedTabFilter().key;
 		const staticFilters = this.getStaticFilters();
+
+		if (
+			tabKey === staticFilters.RECOMMENDED?.key &&
+			this.isThemeShowcaseModern() &&
+			! this.props.isCollectionView
+		) {
+			return (
+				<RecommendedSections
+					getActionLabel={ this.getActionLabel }
+					getOptions={ this.getThemeOptions }
+					getScreenshotUrl={ this.getScreenshotUrl }
+				/>
+			);
+		}
 
 		switch ( tabKey ) {
 			case staticFilters.MYTHEMES?.key:

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -649,11 +649,13 @@
 	}
 
 	.theme-card {
-		margin: 0 0 48px 0;
+		margin: 0;
 	}
 
 	.theme-card__image-container {
+		border: none;
 		border-radius: 8px;
+		box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.25);
 	}
 
 	// Hide style variation swatches for logged-out modern view

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -635,7 +635,7 @@
 // Modern theme card overrides (logged-out redesign)
 .theme-showcase.is-modern {
 	.themes__showcase {
-		padding: 0 24px;
+		padding: 0;
 	}
 
 	.themes-list {


### PR DESCRIPTION
Fixes DOTTHEM-309

## Proposed Changes

<img width="400" alt="calypso localhost_3000_themes" src="https://github.com/user-attachments/assets/976f2885-42e3-4125-a292-efd375548aa5" />

* Replace the single infinite-scroll theme list with a sectioned layout on `/themes` for logged-out users when the `themes/showcase-modern` flag is enabled.
* Three curated sections: "Our favorites" (recommended collection), "Fresh themes" (latest), and "Partner themes" (marketplace tier, dark variant).
* AI Builder and DIFM marketing banners interleaved between sections.
* Extract `ThemeSection` into a reusable component with data fetching, analytics, and CSS grid rendering.
* Add `/themes/recommended/collection` route for the "See all" link on the favorites section.
* Fall back to the regular theme list when any filter, search, tier, or vertical is active.

## Why are these changes being made?

This is the core integration step for the updated Themes landing page redesign. The sectioned layout provides a curated, structured browsing experience for logged-out users instead of a single undifferentiated infinite scroll, highlighting our best themes, newest additions, and partner offerings.

## Testing Instructions

* Enable the `themes/showcase-modern` feature flag.
* Visit `/themes` logged out — should see three sections with banners between them.
* The Partner themes section should have a dark background that extends edge-to-edge.
* Click "See all" on "Our favorites" — should navigate to `/themes/recommended/collection`.
* Click "See all" on "Fresh themes" — should navigate to `/themes/all`.
* Click "See all" on "Partner themes" — should navigate to `/themes/partner`.
* Apply a filter or search — the sectioned layout should disappear, replaced by the regular modern theme list.
* Visit `/themes` logged in — should show the regular theme showcase (no sections).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?