### PR TITLE
Prime both production webpack cache flavors in `Dockerfile.base`

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -25,8 +25,9 @@ ENV COMMIT_SHA $commit_sha
 COPY . .
 
 RUN yarn --inline-builds \
-	# Prime the production webpack cache flavor used by common PR Docker builds.
-	&& NODE_ENV=production yarn build-client
+	# Prime the production webpack cache flavors used by PR builds and trunk/Sentry builds.
+	&& NODE_ENV=production yarn build-client \
+	&& NODE_ENV=production SOURCEMAP=hidden-source-map yarn build-client
 
 ENTRYPOINT [ "/bin/bash" ]
 


### PR DESCRIPTION
## Proposed Changes

* Update the `Dockerfile.base` cache stage to run both production client builds after `yarn --inline-builds`.
* Prime the default production flavor with `NODE_ENV=production yarn build-client`.
* Prime the Sentry/trunk production flavor with `NODE_ENV=production SOURCEMAP=hidden-source-map yarn build-client`.

## Why are these changes being made?

* The earlier webpack cache keying change split production filesystem cache entries by build flavor, including `devtool=none` and `devtool=hidden-source-map`.
* We then fixed base-image publishing so `registry.a8c.com/calypso/base:latest` reliably points at the same image as the numbered base-image tag.
* A follow-up test with `base_image=registry.a8c.com/calypso/base:1.0.4162` showed the primed `devtool=none` flavor materially speeds up PR Docker builds once the warmed base image is actually consumed.
* At that point, the remaining gap is that trunk and manual Sentry-release builds still use the separate `hidden-source-map` cache flavor. Priming both flavors in the cache stage keeps the common PR path warm without leaving the trunk/Sentry path cold.

## Testing Instructions

* Review `Dockerfile.base` and confirm the cache stage now runs both production builds after `yarn --inline-builds`.
* Trigger `Calypso / Build base images` on `trunk`.
* Confirm the `Build base image` step completes within an acceptable time window and publishes updated `registry.a8c.com/calypso/base` tags.
* Trigger a representative PR `Calypso / Web app / Docker image` build using the default `%base_image%`.
* In the Docker build log, confirm webpack restores cached content for `/calypso/.cache/evergreen/webpack/client-mode=production__devtool=none`.
* Trigger a trunk or manual Sentry-release Docker build.
* In that log, confirm webpack restores cached content for `/calypso/.cache/evergreen/webpack/client-mode=production__devtool=hidden-source-map`.
