### PR TITLE
Add/paid plugin plan selection before checkout

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
@@ -31,11 +31,13 @@ function useUpgradeHandler( {
 	coupon,
 	cartHandler,
 	redirectTo,
+	pluginSlug,
 }: {
 	siteSlug?: string | null;
 	coupon?: string;
 	cartHandler?: ( cartItems?: MinimalRequestCartProduct[] | null ) => void;
 	redirectTo?: string;
+	pluginSlug?: string;
 } ) {
 	const processCartItems = useCallback(
 		( cartItems?: MinimalRequestCartProduct[] | null ) => {
@@ -60,9 +62,16 @@ function useUpgradeHandler( {
 				? getPlanPath( cartItemForPlan.product_slug )
 				: '';
 
-			const checkoutUrl = cartItemForStorageAddOn
+			let checkoutUrl = cartItemForStorageAddOn
 				? `/checkout/${ siteSlug }/${ planPath },${ cartItemForStorageAddOn.product_slug }:-q-${ cartItemForStorageAddOn.quantity }`
 				: `/checkout/${ siteSlug }/${ planPath }`;
+
+			// Append plugin if present
+			if ( pluginSlug ) {
+				checkoutUrl = cartItemForStorageAddOn
+					? `${ checkoutUrl },${ pluginSlug }`
+					: `/checkout/${ siteSlug }/${ planPath },${ pluginSlug }`;
+			}
 
 			const checkoutUrlWithArgs = addQueryArgs(
 				{ ...( coupon && { coupon } ), ...( redirectTo && { redirect_to: redirectTo } ) },
@@ -72,7 +81,7 @@ function useUpgradeHandler( {
 			page( checkoutUrlWithArgs );
 			return;
 		},
-		[ siteSlug, coupon, cartHandler, redirectTo ]
+		[ siteSlug, coupon, cartHandler, redirectTo, pluginSlug ]
 	);
 
 	return useCallback(
@@ -161,6 +170,7 @@ function useGenerateActionCallback( {
 	coupon,
 	isGatingBusinessQ1,
 	redirectTo,
+	pluginSlug,
 }: {
 	currentPlan: Plans.SitePlan | undefined;
 	eligibleForFreeHostingTrial: boolean;
@@ -177,6 +187,7 @@ function useGenerateActionCallback( {
 	 */
 	isGatingBusinessQ1?: boolean;
 	redirectTo?: string;
+	pluginSlug?: string;
 } ): UseActionCallback {
 	const siteSlug = useSelector( ( state: IAppState ) => getSiteSlug( state, siteId ) );
 	const siteUrl = useSelector( ( state: IAppState ) => siteId && getSiteUrl( state, siteId ) );
@@ -195,6 +206,7 @@ function useGenerateActionCallback( {
 		coupon,
 		cartHandler,
 		redirectTo,
+		pluginSlug,
 	} );
 	const handleDowngradeClick = useDowngradeHandler( {
 		siteSlug,

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -79,6 +79,7 @@ export default function useGenerateActionHook( {
 	reflectStorageSelectionInPlanPrices,
 	isGatingBusinessQ1,
 	redirectTo,
+	pluginSlug,
 }: {
 	siteId?: number | null;
 	cartHandler?: ( cartItems?: MinimalRequestCartProduct[] | null ) => void;
@@ -98,6 +99,7 @@ export default function useGenerateActionHook( {
 	 */
 	isGatingBusinessQ1?: boolean;
 	redirectTo?: string;
+	pluginSlug?: string;
 } ): UseAction {
 	const translate = useTranslate();
 	const currentPlan = Plans.useCurrentPlan( { siteId } );
@@ -130,6 +132,7 @@ export default function useGenerateActionHook( {
 		coupon,
 		isGatingBusinessQ1,
 		redirectTo,
+		pluginSlug,
 	} );
 
 	const useActionHook = ( {

--- a/client/my-sites/plans-features-main/hooks/use-plan-type-destination-callback.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-type-destination-callback.ts
@@ -16,11 +16,11 @@ const usePlanTypeDestinationCallback = () => {
 		( props: Partial< PlanTypeSelectorProps >, additionalArgs: PathArgs = {} ) => {
 			const { intervalType = '' } = additionalArgs;
 
-			// Preserve redirect_to from the current URL so it survives interval changes.
-			const currentRedirectTo =
-				typeof window !== 'undefined'
-					? new URLSearchParams( window.location.search ).get( 'redirect_to' )
-					: null;
+			// Preserve redirect_to and plugin from the current URL so they survive interval changes.
+			const currentSearchParams =
+				typeof window !== 'undefined' ? new URLSearchParams( window.location.search ) : null;
+			const currentRedirectTo = currentSearchParams?.get( 'redirect_to' );
+			const currentPlugin = currentSearchParams?.get( 'plugin' );
 
 			const defaultArgs = {
 				customerType: undefined,
@@ -28,6 +28,7 @@ const usePlanTypeDestinationCallback = () => {
 				feature: props.selectedFeature,
 				plan: props.selectedPlan,
 				...( currentRedirectTo && { redirect_to: currentRedirectTo } ),
+				...( currentPlugin && { plugin: currentPlugin } ),
 			};
 			// remove empty values from additionalArgs
 			const _additionalArgs = Object.keys( additionalArgs ).reduce( ( acc, key ) => {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -117,6 +117,7 @@ export interface PlansFeaturesMainProps {
 	selectedFeature?: string;
 	onUpgradeClick?: ( cartItems?: MinimalRequestCartProduct[] | null ) => void;
 	redirectTo?: string;
+	pluginSlug?: string;
 	redirectToAddDomainFlow?: boolean;
 	hidePlanTypeSelector?: boolean;
 	paidDomainName?: string;
@@ -201,6 +202,7 @@ const PlansFeaturesMain = ( {
 	onUpgradeClick,
 	hidePlanTypeSelector,
 	redirectTo,
+	pluginSlug,
 	redirectToAddDomainFlow,
 	siteId,
 	selectedPlan,
@@ -438,6 +440,7 @@ const PlansFeaturesMain = ( {
 		reflectStorageSelectionInPlanPrices: true,
 		isGatingBusinessQ1: !! differentiatorsVariant,
 		redirectTo,
+		pluginSlug,
 	} );
 
 	const isDomainOnlySite = useSelector( ( state: IAppState ) =>

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -56,6 +56,7 @@ export function plans( context, next ) {
 			coupon={ coupon }
 			discountEndDate={ context.query.ts }
 			redirectTo={ context.query.redirect_to }
+			pluginSlug={ context.query.plugin }
 			redirectToAddDomainFlow={
 				context.query.addDomainFlow !== undefined
 					? context.query.addDomainFlow === 'true'

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -70,6 +70,7 @@ class PlansComponent extends Component {
 		customerType: PropTypes.string,
 		selectedFeature: PropTypes.string,
 		redirectTo: PropTypes.string,
+		pluginSlug: PropTypes.string,
 		selectedSite: PropTypes.object,
 	};
 
@@ -168,6 +169,7 @@ class PlansComponent extends Component {
 				selectedFeature={ this.props.selectedFeature }
 				selectedPlan={ this.props.selectedPlan }
 				redirectTo={ this.props.redirectTo }
+				pluginSlug={ this.props.pluginSlug }
 				coupon={ this.props.coupon }
 				discountEndDate={ this.props.discountEndDate }
 				siteId={ selectedSite?.ID }

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -10,7 +10,7 @@ import { useTranslate } from 'i18n-calypso';
 import React, { useCallback, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
-import { getProductSlugByPeriodVariation, marketplacePlanToAdd } from 'calypso/lib/plugins/utils';
+import { getProductSlugByPeriodVariation } from 'calypso/lib/plugins/utils';
 import useAtomicSiteHasEquivalentFeatureToPlugin from 'calypso/my-sites/plugins/use-atomic-site-has-equivalent-feature-to-plugin';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
@@ -289,12 +289,12 @@ function onClickInstallPlugin( {
 		const product_slug = getProductSlugByPeriodVariation( variation, productsList );
 
 		if ( upgradeAndInstall ) {
-			// We also need to add a business plan to the cart.
+			// Redirect to plans page to let user choose a plan, then checkout with plan + plugin
+			const installPluginURL = `/marketplace/plugin/${ plugin.slug }/install/${ selectedSite.slug }`;
 			return page(
-				`/checkout/${ selectedSite.slug }/${ marketplacePlanToAdd(
-					selectedSite?.plan,
-					billingPeriod
-				) },${ product_slug }`
+				`/plans/${ selectedSite.slug }?plan=personal_bundle&plugin=${ encodeURIComponent(
+					product_slug
+				) }&redirect_to=${ encodeURIComponent( installPluginURL ) }`
 			);
 		}
 

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -292,7 +292,7 @@ function onClickInstallPlugin( {
 			// Redirect to plans page to let user choose a plan, then checkout with plan + plugin
 			const installPluginURL = `/marketplace/plugin/${ plugin.slug }/install/${ selectedSite.slug }`;
 			return page(
-				`/plans/${ selectedSite.slug }?plan=personal_bundle&plugin=${ encodeURIComponent(
+				`/plans/${ selectedSite.slug }?plan=personal-bundle&plugin=${ encodeURIComponent(
 					product_slug
 				) }&redirect_to=${ encodeURIComponent( installPluginURL ) }`
 			);
@@ -312,7 +312,7 @@ function onClickInstallPlugin( {
 	if ( upgradeAndInstall ) {
 		// Redirect to plans page to let user choose a plan, then redirect to plugin install
 		return page(
-			`/plans/${ selectedSite.slug }?plan=personal_bundle&redirect_to=${ encodeURIComponent(
+			`/plans/${ selectedSite.slug }?plan=personal-bundle&redirect_to=${ encodeURIComponent(
 				installPluginURL
 			) }`
 		);

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -121,7 +121,6 @@ export const PlanUSPS: React.FC< Props > = ( {
 	pluginSlug,
 	shouldUpgrade,
 	isFreePlan,
-	isMarketplaceProduct,
 	billingPeriod,
 } ) => {
 	const translate = useTranslate();

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -131,9 +131,8 @@ export const PlanUSPS: React.FC< Props > = ( {
 
 	const { isPreinstalledPremiumPlugin } = usePreinstalledPremiumPlugin( pluginSlug );
 
-	// Plugins are available on all paid plans for free (non-marketplace, non-premium-preinstalled) plugins
-	const isPluginAvailableOnAllPlans =
-		! isMarketplaceProduct && ! isPreinstalledPremiumPlugin && shouldUpgrade;
+	// Plugins are available on all paid plans (excluding preinstalled premium plugins)
+	const isPluginAvailableOnAllPlans = ! isPreinstalledPremiumPlugin && shouldUpgrade;
 
 	const isAnnualPeriod = billingPeriod === IntervalLength.ANNUALLY;
 	const supportText = usePluginsSupportText();

--- a/test/e2e/specs/plugins/plugins__purchase.ts
+++ b/test/e2e/specs/plugins/plugins__purchase.ts
@@ -9,6 +9,7 @@ import {
 	BrowserManager,
 	SecretsManager,
 	PluginsPage,
+	PlansPage,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 
@@ -50,6 +51,11 @@ describe( 'Plugins: Add multiple to cart', function () {
 
 		it( 'Click on install button', async function () {
 			await pluginsPage.clickInstallPlugin();
+		} );
+
+		it( 'Select a plan on the plans page', async function () {
+			const plansPage = new PlansPage( page );
+			await plansPage.selectPlan( 'Personal' );
 		} );
 
 		it.each( [ 'WordPress.com', pluginName ] )( '%s is added to cart', async function ( target ) {


### PR DESCRIPTION
Related to DOTMKT-1

## Proposed Changes

- For marketplace (paid) plugins that require a plan upgrade, redirect users to the plans page (`/plans/:site`) instead of going directly to checkout
- Pass the plugin product slug via the `plugin` query parameter through the plans page flow
- When a plan is selected, both the plan and the plugin product are added to the checkout URL (e.g., `/checkout/:site/:plan,:pluginSlug`)
- This allows users to choose their preferred plan before purchasing, consistent with the free plugin flow introduced in #109006

**Note:** This PR depends on #109006 and should be merged after it.

## Why are these changes being made?

Previously, paid plugins that required a plan upgrade would skip the plans page and go directly to checkout with a hardcoded plan. This change gives users the ability to choose their preferred plan before purchasing, creating a consistent experience for both free and paid plugins.

## Testing Instructions

- On a free site, navigate to a paid marketplace plugin (e.g., `/plugins/jetpack-search/:site`)
- Click "Purchase and activate"
- Verify you're redirected to `/plans/:site?plan=personal_bundle&plugin=:productSlug`
- Select any plan
- Verify you're redirected to checkout with both the plan and the plugin in the URL (e.g., `/checkout/:site/:selectedPlan,:pluginSlug`)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?