### PR TITLE
Refactor out account/site creation from tests.

### DIFF
--- a/test/e2e/specs/flows/setup-domain__flows.spec.ts
+++ b/test/e2e/specs/flows/setup-domain__flows.spec.ts
@@ -1,13 +1,53 @@
 import {
 	BrowserManager,
 	cancelAtomicPurchaseFlow,
+	DataHelper,
 	NewSiteResponse,
 	NewTestUserDetails,
 	NewUserResponse,
 	RestAPIClient,
+	UserSignupPage,
 } from '@automattic/calypso-e2e';
+import { Page } from 'playwright';
 import { tags, test, expect } from '../../lib/pw-base';
 import { apiCloseAccount, apiDeleteSite } from '../shared';
+
+/**
+ * Signs up a new user via the UI and creates a site via the REST API.
+ *
+ * This avoids the flaky onboarding UI flow (skip domains → select plan → captureNewSiteResponse)
+ * while still using the required UI signup (no user-creation API exists).
+ */
+async function signupAndCreateSiteViaAPI( {
+	page,
+	pageUserSignUp,
+	helperData,
+}: {
+	page: Page;
+	pageUserSignUp: UserSignupPage;
+	helperData: typeof DataHelper;
+} ): Promise< {
+	testUser: NewTestUserDetails;
+	newUserDetails: NewUserResponse;
+	newSiteDetails: NewSiteResponse;
+	restAPIClient: RestAPIClient;
+} > {
+	const testUser = helperData.getNewTestUser();
+
+	// Sign up via the domain flow entry point (authenticates the browser).
+	await page.goto( helperData.getCalypsoURL( '/setup/domain' ) );
+	const newUserDetails = await pageUserSignUp.signupSocialFirstWithEmail( testUser.email );
+
+	// Create the site via REST API instead of going through onboarding UI.
+	const restAPIClient = new RestAPIClient(
+		{ username: testUser.username, password: testUser.password },
+		newUserDetails.body.bearer_token
+	);
+	const siteName = helperData.getBlogName();
+	const newSiteDetails = await restAPIClient.createSite( { name: siteName, title: siteName } );
+
+	return { testUser, newUserDetails, newSiteDetails, restAPIClient };
+}
 
 test.describe(
 	'Setup Domain Flows',
@@ -125,34 +165,24 @@ test.describe(
 			pageSignupPickPlan,
 			pageUserSignUp,
 		} ) => {
-			const siteCreationPlan = 'Free';
-			const testUser = helperData.getNewTestUser();
-			let newUserDetails: NewUserResponse;
 			let newSiteDetails: NewSiteResponse;
 			let selectedDomain: string;
 
-			await test.step( 'When I enter the onboarding flow', async function () {
-				await page.goto( helperData.getCalypsoURL( '/setup' ) );
+			await test.step( 'Given I have signed up and created a free site via API', async function () {
+				const result = await signupAndCreateSiteViaAPI( {
+					page,
+					pageUserSignUp,
+					helperData,
+				} );
+				newSiteDetails = result.newSiteDetails;
+				accountsToCleanup.push( {
+					testUser: result.testUser,
+					newUserDetails: result.newUserDetails,
+					newSiteDetails: result.newSiteDetails,
+				} );
 			} );
 
-			await test.step( 'And I sign up as a new user', async function () {
-				newUserDetails = await pageUserSignUp.signupSocialFirstWithEmail( testUser.email );
-			} );
-
-			await test.step( 'And I skip the domains step', async function () {
-				await componentDomainSearch.search( helperData.getBlogName() );
-				await componentDomainSearch.skipPurchase();
-			} );
-
-			await test.step( `And I select the ${ siteCreationPlan } plan`, async function () {
-				newSiteDetails = await pageSignupPickPlan.selectPlan(
-					siteCreationPlan,
-					new RegExp( '.*/home/.*' )
-				);
-				accountsToCleanup.push( { testUser, newUserDetails, newSiteDetails } );
-			} );
-
-			await test.step( 'And I enter the domain flow', async function () {
+			await test.step( 'When I enter the domain flow', async function () {
 				await page.goto( helperData.getCalypsoURL( '/setup/domain' ) );
 			} );
 
@@ -202,35 +232,25 @@ test.describe(
 			pageSignupPickPlan,
 			pageUserSignUp,
 		} ) => {
-			const siteCreationPlan = 'Free';
 			const domainAdditionPlan = 'Personal';
-			const testUser = helperData.getNewTestUser();
-			let newUserDetails: NewUserResponse;
 			let newSiteDetails: NewSiteResponse;
 			let selectedDomain: string;
 
-			await test.step( 'When I enter the onboarding flow', async function () {
-				await page.goto( helperData.getCalypsoURL( '/setup' ) );
+			await test.step( 'Given I have signed up and created a free site via API', async function () {
+				const result = await signupAndCreateSiteViaAPI( {
+					page,
+					pageUserSignUp,
+					helperData,
+				} );
+				newSiteDetails = result.newSiteDetails;
+				accountsToCleanup.push( {
+					testUser: result.testUser,
+					newUserDetails: result.newUserDetails,
+					newSiteDetails: result.newSiteDetails,
+				} );
 			} );
 
-			await test.step( 'And I sign up as a new user', async function () {
-				newUserDetails = await pageUserSignUp.signupSocialFirstWithEmail( testUser.email );
-			} );
-
-			await test.step( 'And I skip the domains step', async function () {
-				await componentDomainSearch.search( helperData.getBlogName() );
-				await componentDomainSearch.skipPurchase();
-			} );
-
-			await test.step( `And I select the ${ siteCreationPlan } plan`, async function () {
-				newSiteDetails = await pageSignupPickPlan.selectPlan(
-					siteCreationPlan,
-					new RegExp( '.*/home/.*' )
-				);
-				accountsToCleanup.push( { testUser, newUserDetails, newSiteDetails } );
-			} );
-
-			await test.step( 'And I enter the domain flow', async function () {
+			await test.step( 'When I enter the domain flow', async function () {
 				await page.goto( helperData.getCalypsoURL( '/setup/domain' ) );
 			} );
 
@@ -451,31 +471,25 @@ test.describe(
 			pageUserSignUp,
 		} ) => {
 			const planName = 'Personal';
-			const testUser = helperData.getNewTestUser();
 			let selectedDomain: string;
 			let newSiteDetails: NewSiteResponse;
-			let newUserDetails: NewUserResponse;
 
-			await test.step( 'When I enter the onboarding flow', async function () {
+			await test.step( 'Given I have signed up and created a free site via API', async function () {
 				BrowserManager.setStoreCookie( page, { currency: 'USD' } );
-				await page.goto( helperData.getCalypsoURL( '/setup' ) );
+				const result = await signupAndCreateSiteViaAPI( {
+					page,
+					pageUserSignUp,
+					helperData,
+				} );
+				newSiteDetails = result.newSiteDetails;
+				accountsToCleanup.push( {
+					testUser: result.testUser,
+					newUserDetails: result.newUserDetails,
+					newSiteDetails: result.newSiteDetails,
+				} );
 			} );
 
-			await test.step( 'And I sign up as a new user', async function () {
-				newUserDetails = await pageUserSignUp.signupSocialFirstWithEmail( testUser.email );
-			} );
-
-			await test.step( 'And I skip the domains step', async function () {
-				await componentDomainSearch.search( helperData.getBlogName() );
-				await componentDomainSearch.skipPurchase();
-			} );
-
-			await test.step( `And I select the ${ planName } plan`, async function () {
-				newSiteDetails = await pageSignupPickPlan.selectPlan( planName );
-				accountsToCleanup.push( { testUser, newUserDetails, newSiteDetails } );
-			} );
-
-			await test.step( 'And I enter the domain flow with pre-selected site', async function () {
+			await test.step( 'When I enter the domain flow with pre-selected site', async function () {
 				await page.goto(
 					helperData.getCalypsoURL(
 						`/setup/domain?siteSlug=${ newSiteDetails.blog_details.site_slug as string }`


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
