### PR TITLE
E2E: Improve setup-domain flow test diagnostics

### DIFF
--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -25,6 +25,7 @@ const reporter: ReporterDescription[] = [
 			commit: process.env.BUILD_VCS_NUMBER || '',
 			appName: 'calypso',
 			repositoryName: 'Automattic/wp-calypso',
+			annotations: true,
 		},
 	],
 ];

--- a/test/e2e/specs/flows/setup-domain__flows.spec.ts
+++ b/test/e2e/specs/flows/setup-domain__flows.spec.ts
@@ -34,6 +34,10 @@ function annotateSite( siteDetails: NewSiteResponse ): void {
 	} );
 }
 
+function annotate( type: string, value: string ): void {
+	test.info().annotations.push( { type, description: value } );
+}
+
 test.describe(
 	'Setup Domain Flows',
 	{
@@ -71,6 +75,7 @@ test.describe(
 			} );
 
 			await test.step( 'And I search for a domain', async function () {
+				annotate( 'domain_search', targetDomain );
 				await componentDomainSearch.search( targetDomain );
 			} );
 
@@ -123,11 +128,14 @@ test.describe(
 			} );
 
 			await test.step( 'And I search for a domain', async function () {
-				await componentDomainSearch.search( helperData.getBlogName() );
+				const searchTerm = helperData.getBlogName();
+				annotate( 'domain_search', searchTerm );
+				await componentDomainSearch.search( searchTerm );
 			} );
 
 			await test.step( 'And I add the first suggestion to the cart', async function () {
 				selectedDomain = await componentDomainSearch.selectFirstSuggestion();
+				annotate( 'selected_domain', selectedDomain );
 			} );
 
 			await test.step( 'And I continue to the next step', async function () {
@@ -169,7 +177,9 @@ test.describe(
 			} );
 
 			await test.step( 'And I search for a domain to skip', async function () {
-				await componentDomainSearch.search( helperData.getBlogName() );
+				const searchTerm = helperData.getBlogName();
+				annotate( 'domain_search_skip', searchTerm );
+				await componentDomainSearch.search( searchTerm );
 			} );
 
 			await test.step( 'And I skip the domain purchase', async function () {
@@ -190,11 +200,14 @@ test.describe(
 			} );
 
 			await test.step( 'And I search for a domain', async function () {
-				await componentDomainSearch.search( helperData.getBlogName() );
+				const searchTerm = helperData.getBlogName();
+				annotate( 'domain_search', searchTerm );
+				await componentDomainSearch.search( searchTerm );
 			} );
 
 			await test.step( 'And I add the first suggestion to the cart', async function () {
 				selectedDomain = await componentDomainSearch.selectFirstSuggestion();
+				annotate( 'selected_domain', selectedDomain );
 			} );
 
 			await test.step( 'And I continue to the next step', async function () {
@@ -252,7 +265,9 @@ test.describe(
 			} );
 
 			await test.step( 'And I search for a domain to skip', async function () {
-				await componentDomainSearch.search( helperData.getBlogName() );
+				const searchTerm = helperData.getBlogName();
+				annotate( 'domain_search_skip', searchTerm );
+				await componentDomainSearch.search( searchTerm );
 			} );
 
 			await test.step( 'And I skip the domain purchase', async function () {
@@ -273,11 +288,14 @@ test.describe(
 			} );
 
 			await test.step( 'And I search for a domain', async function () {
-				await componentDomainSearch.search( helperData.getBlogName() );
+				const searchTerm = helperData.getBlogName();
+				annotate( 'domain_search', searchTerm );
+				await componentDomainSearch.search( searchTerm );
 			} );
 
 			await test.step( 'And I add the first suggestion to the cart', async function () {
 				selectedDomain = await componentDomainSearch.selectFirstSuggestion();
+				annotate( 'selected_domain', selectedDomain );
 			} );
 
 			await test.step( 'And I continue to the next step', async function () {
@@ -339,7 +357,9 @@ test.describe(
 			} );
 
 			await test.step( 'And I search for a domain to skip', async function () {
-				await componentDomainSearch.search( helperData.getBlogName() );
+				const searchTerm = helperData.getBlogName();
+				annotate( 'domain_search_skip', searchTerm );
+				await componentDomainSearch.search( searchTerm );
 			} );
 
 			await test.step( 'And I skip the domain purchase', async function () {
@@ -381,11 +401,14 @@ test.describe(
 			} );
 
 			await test.step( 'And I search for a domain', async function () {
-				await componentDomainSearch.search( helperData.getBlogName() );
+				const searchTerm = helperData.getBlogName();
+				annotate( 'domain_search', searchTerm );
+				await componentDomainSearch.search( searchTerm );
 			} );
 
 			await test.step( 'And I add the first suggestion to the cart', async function () {
 				selectedDomain = await componentDomainSearch.selectFirstSuggestion();
+				annotate( 'selected_domain', selectedDomain );
 			} );
 
 			await test.step( 'And I continue to the next step', async function () {
@@ -469,11 +492,14 @@ test.describe(
 			} );
 
 			await test.step( 'And I search for a domain', async function () {
-				await componentDomainSearch.search( helperData.getBlogName() );
+				const searchTerm = helperData.getBlogName();
+				annotate( 'domain_search', searchTerm );
+				await componentDomainSearch.search( searchTerm );
 			} );
 
 			await test.step( 'And I add the first suggestion to the cart', async function () {
 				selectedDomain = await componentDomainSearch.selectFirstSuggestion();
+				annotate( 'selected_domain', selectedDomain );
 			} );
 
 			await test.step( 'And I continue to the next step', async function () {
@@ -524,7 +550,9 @@ test.describe(
 			} );
 
 			await test.step( 'And I search for a domain to skip', async function () {
-				await componentDomainSearch.search( helperData.getBlogName() );
+				const searchTerm = helperData.getBlogName();
+				annotate( 'domain_search_skip', searchTerm );
+				await componentDomainSearch.search( searchTerm );
 			} );
 
 			await test.step( 'And I skip the domain purchase', async function () {
@@ -547,6 +575,7 @@ test.describe(
 
 			await test.step( 'And I add the first suggestion to the cart', async function () {
 				selectedDomain = await componentDomainSearch.selectFirstSuggestion();
+				annotate( 'selected_domain', selectedDomain );
 			} );
 
 			await test.step( 'And I continue to the next step', async function () {
@@ -595,7 +624,9 @@ test.describe(
 			} );
 
 			await test.step( 'And I search for a domain to skip', async function () {
-				await componentDomainSearch.search( helperData.getBlogName() );
+				const searchTerm = helperData.getBlogName();
+				annotate( 'domain_search_skip', searchTerm );
+				await componentDomainSearch.search( searchTerm );
 			} );
 
 			await test.step( 'And I skip the domain purchase', async function () {
@@ -642,6 +673,7 @@ test.describe(
 
 			await test.step( 'And I add the first suggestion to the cart', async function () {
 				selectedDomain = await componentDomainSearch.selectFirstSuggestion();
+				annotate( 'selected_domain', selectedDomain );
 			} );
 
 			await test.step( 'And I continue to the next step', async function () {
@@ -714,6 +746,7 @@ test.describe(
 			} );
 
 			await test.step( 'And I search for a domain', async function () {
+				annotate( 'domain_search', targetDomain );
 				await componentDomainSearch.search( targetDomain );
 			} );
 

--- a/test/e2e/specs/flows/setup-domain__flows.spec.ts
+++ b/test/e2e/specs/flows/setup-domain__flows.spec.ts
@@ -9,6 +9,31 @@ import {
 import { tags, test, expect } from '../../lib/pw-base';
 import { apiCloseAccount, apiDeleteSite } from '../shared';
 
+/**
+ * Annotates the current test with user and site details for easier debugging.
+ */
+function annotateUser( userDetails: NewUserResponse ): void {
+	test.info().annotations.push( {
+		type: 'user_id',
+		description: String( userDetails.body.user_id ),
+	} );
+	test.info().annotations.push( {
+		type: 'username',
+		description: userDetails.body.username,
+	} );
+}
+
+function annotateSite( siteDetails: NewSiteResponse ): void {
+	test.info().annotations.push( {
+		type: 'site_id',
+		description: String( siteDetails.blog_details.blogid ),
+	} );
+	test.info().annotations.push( {
+		type: 'site_slug',
+		description: siteDetails.blog_details.site_slug as string,
+	} );
+}
+
 test.describe(
 	'Setup Domain Flows',
 	{
@@ -42,6 +67,7 @@ test.describe(
 
 			await test.step( 'And I sign up as a new user', async function () {
 				newUserDetails = await pageUserSignUp.signupSocialFirstWithEmail( testUser.email );
+				annotateUser( newUserDetails );
 			} );
 
 			await test.step( 'And I search for a domain', async function () {
@@ -62,6 +88,7 @@ test.describe(
 
 			await test.step( `And I select the ${ planName } plan`, async function () {
 				const newSiteDetails = await pageSignupPickPlan.selectPlan( planName );
+				annotateSite( newSiteDetails );
 				accountsToCleanup.push( { testUser, newUserDetails, newSiteDetails } );
 			} );
 
@@ -91,6 +118,7 @@ test.describe(
 			await test.step( 'And I sign up as a new user', async function () {
 				const testUser = helperData.getNewTestUser();
 				const newUserDetails = await pageUserSignUp.signupSocialFirstWithEmail( testUser.email );
+				annotateUser( newUserDetails );
 				accountsToCleanup.push( { testUser, newUserDetails } );
 			} );
 
@@ -137,10 +165,14 @@ test.describe(
 
 			await test.step( 'And I sign up as a new user', async function () {
 				newUserDetails = await pageUserSignUp.signupSocialFirstWithEmail( testUser.email );
+				annotateUser( newUserDetails );
 			} );
 
-			await test.step( 'And I skip the domains step', async function () {
+			await test.step( 'And I search for a domain to skip', async function () {
 				await componentDomainSearch.search( helperData.getBlogName() );
+			} );
+
+			await test.step( 'And I skip the domain purchase', async function () {
 				await componentDomainSearch.skipPurchase();
 			} );
 
@@ -149,6 +181,7 @@ test.describe(
 					siteCreationPlan,
 					new RegExp( '.*/home/.*' )
 				);
+				annotateSite( newSiteDetails );
 				accountsToCleanup.push( { testUser, newUserDetails, newSiteDetails } );
 			} );
 
@@ -215,10 +248,14 @@ test.describe(
 
 			await test.step( 'And I sign up as a new user', async function () {
 				newUserDetails = await pageUserSignUp.signupSocialFirstWithEmail( testUser.email );
+				annotateUser( newUserDetails );
 			} );
 
-			await test.step( 'And I skip the domains step', async function () {
+			await test.step( 'And I search for a domain to skip', async function () {
 				await componentDomainSearch.search( helperData.getBlogName() );
+			} );
+
+			await test.step( 'And I skip the domain purchase', async function () {
 				await componentDomainSearch.skipPurchase();
 			} );
 
@@ -227,6 +264,7 @@ test.describe(
 					siteCreationPlan,
 					new RegExp( '.*/home/.*' )
 				);
+				annotateSite( newSiteDetails );
 				accountsToCleanup.push( { testUser, newUserDetails, newSiteDetails } );
 			} );
 
@@ -297,15 +335,20 @@ test.describe(
 
 			await test.step( 'And I sign up as a new user', async function () {
 				newUserDetails = await pageUserSignUp.signupSocialFirstWithEmail( testUser.email );
+				annotateUser( newUserDetails );
 			} );
 
-			await test.step( 'And I skip the domains step', async function () {
+			await test.step( 'And I search for a domain to skip', async function () {
 				await componentDomainSearch.search( helperData.getBlogName() );
+			} );
+
+			await test.step( 'And I skip the domain purchase', async function () {
 				await componentDomainSearch.skipPurchase();
 			} );
 
 			await test.step( `And I select the ${ planName } plan`, async function () {
 				newSiteDetails = await pageSignupPickPlan.selectPlan( planName );
+				annotateSite( newSiteDetails );
 				accountsToCleanup.push( { testUser, newUserDetails, newSiteDetails } );
 			} );
 
@@ -313,13 +356,17 @@ test.describe(
 				await pageCartCheckout.validateCartItem( `WordPress.com ${ planName }` );
 			} );
 
-			await test.step( 'When I enter billing and payment details', async function () {
+			await test.step( 'When I enter billing details', async function () {
 				const paymentDetails = helperData.getTestPaymentDetails();
 				await pageCartCheckout.enterBillingDetails( paymentDetails );
+			} );
+
+			await test.step( 'And I enter payment details', async function () {
+				const paymentDetails = helperData.getTestPaymentDetails();
 				await pageCartCheckout.enterPaymentDetails( paymentDetails );
 			} );
 
-			await test.step( 'When I can make the purchase', async function () {
+			await test.step( 'And I make the purchase', async function () {
 				await pageCartCheckout.purchase( { timeout: 90 * 1000 } );
 			} );
 
@@ -360,8 +407,11 @@ test.describe(
 				await pageCartCheckout.validateCartItem( selectedDomain );
 			} );
 
-			await test.step( 'And I navigate to Me > Purchases', async function () {
+			await test.step( 'And I navigate to Me', async function () {
 				await pageMyProfile.visit();
+			} );
+
+			await test.step( 'And I open the Purchases page', async function () {
 				await componentMeSidebar.openMobileMenu();
 				await componentMeSidebar.navigate( 'Purchases' );
 			} );
@@ -371,15 +421,20 @@ test.describe(
 					`WordPress.com ${ planName }`,
 					newSiteDetails.blog_details.site_slug as string
 				);
+			} );
+
+			await test.step( 'And I initiate plan cancellation', async function () {
 				await pagePurchases.cancelPurchase( 'Cancel plan' );
 			} );
 
-			await test.step( 'And I cancel the plan renewal', async function () {
+			await test.step( 'And I complete the cancellation flow', async function () {
 				await cancelAtomicPurchaseFlow( page, {
 					reason: 'Another reason…',
 					customReasonText: 'E2E TEST CANCELLATION',
 				} );
+			} );
 
+			await test.step( 'Then I see the refund confirmation', async function () {
 				await componentNotice.noticeShown(
 					'Your refund has been processed and your purchase removed.',
 					{
@@ -410,6 +465,7 @@ test.describe(
 
 			await test.step( 'And I sign up as a new user', async function () {
 				newUserDetails = await pageUserSignUp.signupSocialFirstWithEmail( testUser.email );
+				annotateUser( newUserDetails );
 			} );
 
 			await test.step( 'And I search for a domain', async function () {
@@ -430,6 +486,7 @@ test.describe(
 
 			await test.step( `And I select the ${ planName } plan`, async function () {
 				const newSiteDetails = await pageSignupPickPlan.selectPlan( planName );
+				annotateSite( newSiteDetails );
 				accountsToCleanup.push( { testUser, newUserDetails, newSiteDetails } );
 			} );
 
@@ -463,15 +520,20 @@ test.describe(
 
 			await test.step( 'And I sign up as a new user', async function () {
 				newUserDetails = await pageUserSignUp.signupSocialFirstWithEmail( testUser.email );
+				annotateUser( newUserDetails );
 			} );
 
-			await test.step( 'And I skip the domains step', async function () {
+			await test.step( 'And I search for a domain to skip', async function () {
 				await componentDomainSearch.search( helperData.getBlogName() );
+			} );
+
+			await test.step( 'And I skip the domain purchase', async function () {
 				await componentDomainSearch.skipPurchase();
 			} );
 
 			await test.step( `And I select the ${ planName } plan`, async function () {
 				newSiteDetails = await pageSignupPickPlan.selectPlan( planName );
+				annotateSite( newSiteDetails );
 				accountsToCleanup.push( { testUser, newUserDetails, newSiteDetails } );
 			} );
 
@@ -529,15 +591,20 @@ test.describe(
 
 			await test.step( 'And I sign up as a new user', async function () {
 				newUserDetails = await pageUserSignUp.signupSocialFirstWithEmail( testUser.email );
+				annotateUser( newUserDetails );
 			} );
 
-			await test.step( 'And I skip the domains step', async function () {
+			await test.step( 'And I search for a domain to skip', async function () {
 				await componentDomainSearch.search( helperData.getBlogName() );
+			} );
+
+			await test.step( 'And I skip the domain purchase', async function () {
 				await componentDomainSearch.skipPurchase();
 			} );
 
 			await test.step( `And I select the ${ planName } plan`, async function () {
 				newSiteDetails = await pageSignupPickPlan.selectPlan( planName );
+				annotateSite( newSiteDetails );
 				accountsToCleanup.push( { testUser, newUserDetails, newSiteDetails } );
 			} );
 
@@ -545,9 +612,13 @@ test.describe(
 				await pageCartCheckout.validateCartItem( `WordPress.com ${ planName }` );
 			} );
 
-			await test.step( 'When I enter billing and payment details', async function () {
+			await test.step( 'When I enter billing details', async function () {
 				const paymentDetails = helperData.getTestPaymentDetails();
 				await pageCartCheckout.enterBillingDetails( paymentDetails );
+			} );
+
+			await test.step( 'And I enter payment details', async function () {
+				const paymentDetails = helperData.getTestPaymentDetails();
 				await pageCartCheckout.enterPaymentDetails( paymentDetails );
 			} );
 
@@ -581,8 +652,11 @@ test.describe(
 				await pageCartCheckout.validateCartItem( selectedDomain );
 			} );
 
-			await test.step( 'And I navigate to Me > Purchases', async function () {
+			await test.step( 'And I navigate to Me', async function () {
 				await pageMyProfile.visit();
+			} );
+
+			await test.step( 'And I open the Purchases page', async function () {
 				await componentMeSidebar.openMobileMenu();
 				await componentMeSidebar.navigate( 'Purchases' );
 			} );
@@ -592,15 +666,20 @@ test.describe(
 					`WordPress.com ${ planName }`,
 					newSiteDetails.blog_details.site_slug as string
 				);
+			} );
+
+			await test.step( 'And I initiate plan cancellation', async function () {
 				await pagePurchases.cancelPurchase( 'Cancel plan' );
 			} );
 
-			await test.step( 'And I cancel the plan renewal', async function () {
+			await test.step( 'And I complete the cancellation flow', async function () {
 				await cancelAtomicPurchaseFlow( page, {
 					reason: 'Another reason…',
 					customReasonText: 'E2E TEST CANCELLATION',
 				} );
+			} );
 
+			await test.step( 'Then I see the refund confirmation', async function () {
 				await componentNotice.noticeShown(
 					'Your refund has been processed and your purchase removed.',
 					{
@@ -631,6 +710,7 @@ test.describe(
 
 			await test.step( 'And I sign up as a new user', async function () {
 				newUserDetails = await pageUserSignUp.signupSocialFirstWithEmail( testUser.email );
+				annotateUser( newUserDetails );
 			} );
 
 			await test.step( 'And I search for a domain', async function () {
@@ -651,6 +731,7 @@ test.describe(
 
 			await test.step( `And I select the ${ planName } plan`, async function () {
 				const newSiteDetails = await pageSignupPickPlan.selectPlan( planName );
+				annotateSite( newSiteDetails );
 				accountsToCleanup.push( { testUser, newUserDetails, newSiteDetails } );
 			} );
 


### PR DESCRIPTION
## Proposed Changes

- Add `annotateUser()`, `annotateSite()`, and `annotate()` helpers that attach metadata to Playwright test report annotations
- Annotate every test with `user_id`, `username`, `site_id`, `site_slug` for user/site traceability
- Annotate domain search steps with `domain_search`, `domain_search_skip`, and `selected_domain` to correlate failures with specific domains
- Break compound test steps into atomic operations for clearer failure identification
- No test logic changes — same assertions, same flow, same cleanup

## Why are these changes being made?

The `setup-domain__flows.spec.ts` tests are among the flakiest in the `@calypso-release` suite. Most failures appear related to domain search or cart interactions, but we lack the data to confirm. When a test fails, the report often points to a compound step (e.g. "And I skip the domains step") making it hard to tell which specific action failed or whether failures cluster around certain domains.

These changes improve observability so we can identify failure patterns before applying fixes:

- **User/site annotations**: Failed test reports show the exact user and site involved, making manual investigation and cleanup easier
- **Domain annotations**: Every domain search and selection is recorded (`domain_search`, `domain_search_skip`, `selected_domain`), so we can spot patterns like failures clustering around certain search terms or specific domain suggestions
- **Atomic steps**: Each `test.step` now does exactly one thing, so the failure report pinpoints the exact action (e.g. "enter billing details" vs "enter payment details")

## Testing Instructions

- Run the test suite: `cd test/e2e && yarn playwright test specs/flows/setup-domain__flows.spec.ts --reporter=list`
- On failure, check the Playwright report — annotations should show `user_id`, `username`, `site_id`, `site_slug`, `domain_search`, `selected_domain`, etc.
- Verify each step in the report corresponds to a single action

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)