### PR TITLE
Dashboard: Show warning cards and limit navigation when Jetpack connection is broken

### DIFF
--- a/client/dashboard/app/router/index.tsx
+++ b/client/dashboard/app/router/index.tsx
@@ -24,6 +24,7 @@ declare module '@tanstack/react-router' {
 		 * The check is performed in siteRoute.beforeLoad against getSiteTypeFeatureSupports(site).
 		 */
 		requiresSiteTypeSupport?: SiteTypeFeature;
+		availableToInaccessibleJetpackSites?: boolean;
 	}
 }
 

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -121,7 +121,7 @@ export const siteRoute = createRoute( {
 
 		if (
 			site.__inaccessible_jetpack_error &&
-			! matches.some( ( match ) => getInaccessibleJetpackAllowedRoutes().includes( match.routeId ) )
+			! matches.some( ( match ) => match.staticData?.availableToInaccessibleJetpackSites )
 		) {
 			throw redirect( { to: overviewUrl } );
 		}
@@ -176,6 +176,7 @@ export const siteRoute = createRoute( {
 );
 
 export const siteOverviewRoute = createRoute( {
+	staticData: { availableToInaccessibleJetpackSites: true },
 	getParentRoute: () => siteRoute,
 	path: '/',
 	loader: async ( { params: { siteSlug }, preload } ) => {
@@ -523,6 +524,7 @@ export const siteBackupDownloadRoute = createRoute( {
 );
 
 export const siteDomainsRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'domains', availableToInaccessibleJetpackSites: true },
 	head: () => ( {
 		meta: [
 			{
@@ -1500,11 +1502,6 @@ export const createSitesRoutes = ( config: AppConfig ) => {
 // Defined as a `function` so that routes defined earlier can reference routes defined later.
 function getDifmLiteAllowedRoutes() {
 	return [ siteDifmLiteInProgressRoute.id, siteDomainsRoute.id ];
-}
-
-// Site routes allowed when the Jetpack connection is broken.
-function getInaccessibleJetpackAllowedRoutes() {
-	return [ siteOverviewRoute.id, siteDomainsRoute.id ];
 }
 
 function redirectAsNotAllowed( options: {

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -119,7 +119,11 @@ export const siteRoute = createRoute( {
 			throw redirectAsNotAllowed( { to: overviewUrl } );
 		}
 
-		if ( site.__inaccessible_jetpack_error && ! location.pathname.endsWith( overviewUrl ) ) {
+		if (
+			site.__inaccessible_jetpack_error &&
+			! location.pathname.endsWith( overviewUrl ) &&
+			! location.pathname.startsWith( `${ overviewUrl }/domains` )
+		) {
 			throw redirect( { to: overviewUrl } );
 		}
 

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -119,10 +119,6 @@ export const siteRoute = createRoute( {
 			throw redirectAsNotAllowed( { to: overviewUrl } );
 		}
 
-		if ( site.__inaccessible_jetpack_error && ! location.pathname.endsWith( overviewUrl ) ) {
-			throw redirect( { to: overviewUrl } );
-		}
-
 		const trialExpiredUrl = `/sites/${ siteSlug }/trial-ended`;
 		if ( hasSiteTrialEnded( site ) && ! location.pathname.includes( trialExpiredUrl ) ) {
 			throw redirect( { to: trialExpiredUrl } );

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -121,7 +121,6 @@ export const siteRoute = createRoute( {
 
 		if (
 			site.__inaccessible_jetpack_error &&
-			! location.pathname.endsWith( overviewUrl ) &&
 			! matches.some( ( match ) => getInaccessibleJetpackAllowedRoutes().includes( match.routeId ) )
 		) {
 			throw redirect( { to: overviewUrl } );
@@ -1505,7 +1504,7 @@ function getDifmLiteAllowedRoutes() {
 
 // Site routes allowed when the Jetpack connection is broken.
 function getInaccessibleJetpackAllowedRoutes() {
-	return [ siteDomainsRoute.id ];
+	return [ siteOverviewRoute.id, siteDomainsRoute.id ];
 }
 
 function redirectAsNotAllowed( options: {

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -122,7 +122,7 @@ export const siteRoute = createRoute( {
 		if (
 			site.__inaccessible_jetpack_error &&
 			! location.pathname.endsWith( overviewUrl ) &&
-			! location.pathname.startsWith( `${ overviewUrl }/domains` )
+			! matches.some( ( match ) => getInaccessibleJetpackAllowedRoutes().includes( match.routeId ) )
 		) {
 			throw redirect( { to: overviewUrl } );
 		}
@@ -1501,6 +1501,11 @@ export const createSitesRoutes = ( config: AppConfig ) => {
 // Defined as a `function` so that routes defined earlier can reference routes defined later.
 function getDifmLiteAllowedRoutes() {
 	return [ siteDifmLiteInProgressRoute.id, siteDomainsRoute.id ];
+}
+
+// Site routes allowed when the Jetpack connection is broken.
+function getInaccessibleJetpackAllowedRoutes() {
+	return [ siteDomainsRoute.id ];
 }
 
 function redirectAsNotAllowed( options: {

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -119,6 +119,10 @@ export const siteRoute = createRoute( {
 			throw redirectAsNotAllowed( { to: overviewUrl } );
 		}
 
+		if ( site.__inaccessible_jetpack_error && ! location.pathname.endsWith( overviewUrl ) ) {
+			throw redirect( { to: overviewUrl } );
+		}
+
 		const trialExpiredUrl = `/sites/${ siteSlug }/trial-ended`;
 		if ( hasSiteTrialEnded( site ) && ! location.pathname.includes( trialExpiredUrl ) ) {
 			throw redirect( { to: trialExpiredUrl } );

--- a/client/dashboard/sites/overview-backup-card/index.tsx
+++ b/client/dashboard/sites/overview-backup-card/index.tsx
@@ -8,6 +8,7 @@ import OverviewCard from '../../components/overview-card';
 import { useTimeSince } from '../../components/time-since';
 import { getBackupUrl } from '../../utils/site-backup';
 import HostingFeatureGatedWithOverviewCard from '../hosting-feature-gated-with-overview-card';
+import JetpackConnectionWarningCard from '../overview-jetpack-connection-warning-card';
 import type { Site, SiteActivityLog } from '@automattic/api-core';
 
 const CARD_PROPS = {
@@ -101,6 +102,10 @@ function BackupCardContent( { site }: { site: Site } ) {
 }
 
 export default function BackupCard( { site }: { site: Site } ) {
+	if ( site.__inaccessible_jetpack_error ) {
+		return <JetpackConnectionWarningCard { ...CARD_PROPS } />;
+	}
+
 	return (
 		<HostingFeatureGatedWithOverviewCard
 			site={ site }

--- a/client/dashboard/sites/overview-backup-card/index.tsx
+++ b/client/dashboard/sites/overview-backup-card/index.tsx
@@ -8,9 +8,10 @@ import OverviewCard from '../../components/overview-card';
 import { useTimeSince } from '../../components/time-since';
 import { getBackupUrl } from '../../utils/site-backup';
 import HostingFeatureGatedWithOverviewCard from '../hosting-feature-gated-with-overview-card';
+import JetpackConnectionWarningCard from '../overview-jetpack-connection-warning-card';
 import type { Site, SiteActivityLog } from '@automattic/api-core';
 
-export const CARD_PROPS = {
+const CARD_PROPS = {
 	icon: backup,
 	title: __( 'Last backup' ),
 	tracksId: 'site-overview-backups',
@@ -101,6 +102,10 @@ function BackupCardContent( { site }: { site: Site } ) {
 }
 
 export default function BackupCard( { site }: { site: Site } ) {
+	if ( site.__inaccessible_jetpack_error ) {
+		return <JetpackConnectionWarningCard { ...CARD_PROPS } />;
+	}
+
 	return (
 		<HostingFeatureGatedWithOverviewCard
 			site={ site }

--- a/client/dashboard/sites/overview-backup-card/index.tsx
+++ b/client/dashboard/sites/overview-backup-card/index.tsx
@@ -8,10 +8,9 @@ import OverviewCard from '../../components/overview-card';
 import { useTimeSince } from '../../components/time-since';
 import { getBackupUrl } from '../../utils/site-backup';
 import HostingFeatureGatedWithOverviewCard from '../hosting-feature-gated-with-overview-card';
-import JetpackConnectionWarningCard from '../overview-jetpack-connection-warning-card';
 import type { Site, SiteActivityLog } from '@automattic/api-core';
 
-const CARD_PROPS = {
+export const CARD_PROPS = {
 	icon: backup,
 	title: __( 'Last backup' ),
 	tracksId: 'site-overview-backups',
@@ -102,10 +101,6 @@ function BackupCardContent( { site }: { site: Site } ) {
 }
 
 export default function BackupCard( { site }: { site: Site } ) {
-	if ( site.__inaccessible_jetpack_error ) {
-		return <JetpackConnectionWarningCard { ...CARD_PROPS } />;
-	}
-
 	return (
 		<HostingFeatureGatedWithOverviewCard
 			site={ site }

--- a/client/dashboard/sites/overview-jetpack-connection-warning-card/index.tsx
+++ b/client/dashboard/sites/overview-jetpack-connection-warning-card/index.tsx
@@ -1,0 +1,21 @@
+import { __ } from '@wordpress/i18n';
+import OverviewCard from '../../components/overview-card';
+import type { OverviewCardProps } from '../../components/overview-card';
+
+export default function JetpackConnectionWarningCard( {
+	icon,
+	title,
+	tracksId,
+}: Pick< OverviewCardProps, 'icon' | 'title' | 'tracksId' > ) {
+	return (
+		<OverviewCard
+			icon={ icon }
+			title={ title }
+			tracksId={ tracksId }
+			heading={ __( 'Connection issue' ) }
+			description={ __( 'Jetpack is unable to reach your site.' ) }
+			externalLink="https://jetpack.com/support/getting-started-with-jetpack/fixing-jetpack-connection-issues/"
+			intent="warning"
+		/>
+	);
+}

--- a/client/dashboard/sites/overview-jetpack-connection-warning-card/index.tsx
+++ b/client/dashboard/sites/overview-jetpack-connection-warning-card/index.tsx
@@ -1,3 +1,4 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { __ } from '@wordpress/i18n';
 import OverviewCard from '../../components/overview-card';
 import type { OverviewCardProps } from '../../components/overview-card';
@@ -14,7 +15,9 @@ export default function JetpackConnectionWarningCard( {
 			tracksId={ tracksId }
 			heading={ __( 'Connection issue' ) }
 			description={ __( 'Jetpack is unable to reach your site.' ) }
-			externalLink="https://jetpack.com/support/getting-started-with-jetpack/fixing-jetpack-connection-issues/"
+			externalLink={ localizeUrl(
+				'https://jetpack.com/support/getting-started-with-jetpack/fixing-jetpack-connection-issues/'
+			) }
 			intent="warning"
 		/>
 	);

--- a/client/dashboard/sites/overview-latest-activity-card/index.tsx
+++ b/client/dashboard/sites/overview-latest-activity-card/index.tsx
@@ -65,11 +65,7 @@ export default function LatestActivityCard( {
 	isCompact?: boolean;
 } ) {
 	const notGroup = getActivityLogHiddenGroups( site );
-	const hasJetpackError = !! site.__inaccessible_jetpack_error;
-	const { data } = useQuery( {
-		...siteLastFiveActivityLogEntriesQuery( site.ID, notGroup ),
-		enabled: ! hasJetpackError,
-	} );
+	const { data } = useQuery( siteLastFiveActivityLogEntriesQuery( site.ID, notGroup ) );
 	const { recordTracksEvent } = useAnalytics();
 
 	const view = {
@@ -84,38 +80,30 @@ export default function LatestActivityCard( {
 		recordTracksEvent( 'calypso_dashboard_site_overview_see_all_activity_click' );
 	};
 
-	const renderActivityContent = () => {
-		if ( hasJetpackError ) {
-			return <p>{ __( 'Activity is unavailable due to a Jetpack connection issue.' ) }</p>;
-		}
-
-		if ( data === undefined ) {
-			return <TextSkeleton length={ 30 } />;
-		}
-
-		return (
-			<DataViews< ActivityLogEntry >
-				data={ data }
-				fields={ fields }
-				view={ view }
-				onChangeView={ () => {} }
-				getItemId={ ( item ) => item.activity_id }
-				paginationInfo={ { totalItems: data.length, totalPages: 1 } }
-				defaultLayouts={ { list: {} } }
-				empty={ <p>{ __( 'No activity yet.' ) }</p> }
-			>
-				<DataViews.Layout />
-			</DataViews>
-		);
-	};
-
 	return (
 		<Card role="article" className="dashboard-overview-latest-activity-card">
 			<CardHeader>
 				<SectionHeader title={ __( 'Latest activity' ) } level={ 3 } />
 			</CardHeader>
-			<CardBody>{ renderActivityContent() }</CardBody>
-			{ ! hasJetpackError && data && data.length > 0 && (
+			<CardBody>
+				{ data === undefined ? (
+					<TextSkeleton length={ 30 } />
+				) : (
+					<DataViews< ActivityLogEntry >
+						data={ data }
+						fields={ fields }
+						view={ view }
+						onChangeView={ () => {} }
+						getItemId={ ( item ) => item.activity_id }
+						paginationInfo={ { totalItems: data.length, totalPages: 1 } }
+						defaultLayouts={ { list: {} } }
+						empty={ <p>{ __( 'No activity yet.' ) }</p> }
+					>
+						<DataViews.Layout />
+					</DataViews>
+				) }
+			</CardBody>
+			{ data && data.length > 0 && (
 				<SummaryButtonCardFooter
 					title={ __( 'See all activity' ) }
 					href={ getActivityLogUrl( site ) }

--- a/client/dashboard/sites/overview-latest-activity-card/index.tsx
+++ b/client/dashboard/sites/overview-latest-activity-card/index.tsx
@@ -65,7 +65,11 @@ export default function LatestActivityCard( {
 	isCompact?: boolean;
 } ) {
 	const notGroup = getActivityLogHiddenGroups( site );
-	const { data } = useQuery( siteLastFiveActivityLogEntriesQuery( site.ID, notGroup ) );
+	const hasJetpackError = !! site.__inaccessible_jetpack_error;
+	const { data } = useQuery( {
+		...siteLastFiveActivityLogEntriesQuery( site.ID, notGroup ),
+		enabled: ! hasJetpackError,
+	} );
 	const { recordTracksEvent } = useAnalytics();
 
 	const view = {
@@ -80,30 +84,38 @@ export default function LatestActivityCard( {
 		recordTracksEvent( 'calypso_dashboard_site_overview_see_all_activity_click' );
 	};
 
+	const renderActivityContent = () => {
+		if ( hasJetpackError ) {
+			return <p>{ __( 'Activity is unavailable due to a Jetpack connection issue.' ) }</p>;
+		}
+
+		if ( data === undefined ) {
+			return <TextSkeleton length={ 30 } />;
+		}
+
+		return (
+			<DataViews< ActivityLogEntry >
+				data={ data }
+				fields={ fields }
+				view={ view }
+				onChangeView={ () => {} }
+				getItemId={ ( item ) => item.activity_id }
+				paginationInfo={ { totalItems: data.length, totalPages: 1 } }
+				defaultLayouts={ { list: {} } }
+				empty={ <p>{ __( 'No activity yet.' ) }</p> }
+			>
+				<DataViews.Layout />
+			</DataViews>
+		);
+	};
+
 	return (
 		<Card role="article" className="dashboard-overview-latest-activity-card">
 			<CardHeader>
 				<SectionHeader title={ __( 'Latest activity' ) } level={ 3 } />
 			</CardHeader>
-			<CardBody>
-				{ data === undefined ? (
-					<TextSkeleton length={ 30 } />
-				) : (
-					<DataViews< ActivityLogEntry >
-						data={ data }
-						fields={ fields }
-						view={ view }
-						onChangeView={ () => {} }
-						getItemId={ ( item ) => item.activity_id }
-						paginationInfo={ { totalItems: data.length, totalPages: 1 } }
-						defaultLayouts={ { list: {} } }
-						empty={ <p>{ __( 'No activity yet.' ) }</p> }
-					>
-						<DataViews.Layout />
-					</DataViews>
-				) }
-			</CardBody>
-			{ data && data.length > 0 && (
+			<CardBody>{ renderActivityContent() }</CardBody>
+			{ ! hasJetpackError && data && data.length > 0 && (
 				<SummaryButtonCardFooter
 					title={ __( 'See all activity' ) }
 					href={ getActivityLogUrl( site ) }

--- a/client/dashboard/sites/overview-performance-card/index.tsx
+++ b/client/dashboard/sites/overview-performance-card/index.tsx
@@ -10,6 +10,7 @@ import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { getPerformanceStatus, getStatusIntent, getStatusText } from '../../utils/site-performance';
 import { getSiteVisibilityURL } from '../../utils/site-url';
 import HostingFeatureGatedWithOverviewCard from '../hosting-feature-gated-with-overview-card';
+import JetpackConnectionWarningCard from '../overview-jetpack-connection-warning-card';
 import { useSitePerformanceData } from '../performance/use-site-performance-data';
 import type { SitePerformanceReport, Site } from '@automattic/api-core';
 
@@ -165,6 +166,10 @@ function PerformanceCardContent( { site }: { site: Site } ) {
 }
 
 export default function PerformanceCard( { site }: { site: Site } ) {
+	if ( site.__inaccessible_jetpack_error ) {
+		return <JetpackConnectionWarningCard { ...CARD_PROPS } />;
+	}
+
 	return (
 		<HostingFeatureGatedWithOverviewCard
 			site={ site }

--- a/client/dashboard/sites/overview-performance-card/index.tsx
+++ b/client/dashboard/sites/overview-performance-card/index.tsx
@@ -10,11 +10,10 @@ import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { getPerformanceStatus, getStatusIntent, getStatusText } from '../../utils/site-performance';
 import { getSiteVisibilityURL } from '../../utils/site-url';
 import HostingFeatureGatedWithOverviewCard from '../hosting-feature-gated-with-overview-card';
-import JetpackConnectionWarningCard from '../overview-jetpack-connection-warning-card';
 import { useSitePerformanceData } from '../performance/use-site-performance-data';
 import type { SitePerformanceReport, Site } from '@automattic/api-core';
 
-const CARD_PROPS = {
+export const CARD_PROPS = {
 	icon: chartBar,
 	title: __( 'Performance' ),
 	tracksId: 'site-overview-performance',
@@ -166,10 +165,6 @@ function PerformanceCardContent( { site }: { site: Site } ) {
 }
 
 export default function PerformanceCard( { site }: { site: Site } ) {
-	if ( site.__inaccessible_jetpack_error ) {
-		return <JetpackConnectionWarningCard { ...CARD_PROPS } />;
-	}
-
 	return (
 		<HostingFeatureGatedWithOverviewCard
 			site={ site }

--- a/client/dashboard/sites/overview-performance-card/index.tsx
+++ b/client/dashboard/sites/overview-performance-card/index.tsx
@@ -10,10 +10,11 @@ import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { getPerformanceStatus, getStatusIntent, getStatusText } from '../../utils/site-performance';
 import { getSiteVisibilityURL } from '../../utils/site-url';
 import HostingFeatureGatedWithOverviewCard from '../hosting-feature-gated-with-overview-card';
+import JetpackConnectionWarningCard from '../overview-jetpack-connection-warning-card';
 import { useSitePerformanceData } from '../performance/use-site-performance-data';
 import type { SitePerformanceReport, Site } from '@automattic/api-core';
 
-export const CARD_PROPS = {
+const CARD_PROPS = {
 	icon: chartBar,
 	title: __( 'Performance' ),
 	tracksId: 'site-overview-performance',
@@ -165,6 +166,10 @@ function PerformanceCardContent( { site }: { site: Site } ) {
 }
 
 export default function PerformanceCard( { site }: { site: Site } ) {
+	if ( site.__inaccessible_jetpack_error ) {
+		return <JetpackConnectionWarningCard { ...CARD_PROPS } />;
+	}
+
 	return (
 		<HostingFeatureGatedWithOverviewCard
 			site={ site }

--- a/client/dashboard/sites/overview-scan-card/index.tsx
+++ b/client/dashboard/sites/overview-scan-card/index.tsx
@@ -9,6 +9,7 @@ import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { wpcomLink } from '../../utils/link';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import HostingFeatureGatedWithOverviewCard from '../hosting-feature-gated-with-overview-card';
+import JetpackConnectionWarningCard from '../overview-jetpack-connection-warning-card';
 import type { SiteScan, Site } from '@automattic/api-core';
 
 const CARD_PROPS = {
@@ -93,6 +94,10 @@ function ScanCardContent( { site }: { site: Site } ) {
 }
 
 export default function ScanCard( { site }: { site: Site } ) {
+	if ( site.__inaccessible_jetpack_error ) {
+		return <JetpackConnectionWarningCard { ...CARD_PROPS } />;
+	}
+
 	return (
 		<HostingFeatureGatedWithOverviewCard
 			site={ site }

--- a/client/dashboard/sites/overview-scan-card/index.tsx
+++ b/client/dashboard/sites/overview-scan-card/index.tsx
@@ -9,10 +9,9 @@ import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { wpcomLink } from '../../utils/link';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import HostingFeatureGatedWithOverviewCard from '../hosting-feature-gated-with-overview-card';
-import JetpackConnectionWarningCard from '../overview-jetpack-connection-warning-card';
 import type { SiteScan, Site } from '@automattic/api-core';
 
-const CARD_PROPS = {
+export const CARD_PROPS = {
 	icon: shield,
 	title: __( 'Last scan' ),
 	tracksId: 'site-overview-scan',
@@ -94,10 +93,6 @@ function ScanCardContent( { site }: { site: Site } ) {
 }
 
 export default function ScanCard( { site }: { site: Site } ) {
-	if ( site.__inaccessible_jetpack_error ) {
-		return <JetpackConnectionWarningCard { ...CARD_PROPS } />;
-	}
-
 	return (
 		<HostingFeatureGatedWithOverviewCard
 			site={ site }

--- a/client/dashboard/sites/overview-scan-card/index.tsx
+++ b/client/dashboard/sites/overview-scan-card/index.tsx
@@ -9,9 +9,10 @@ import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { wpcomLink } from '../../utils/link';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import HostingFeatureGatedWithOverviewCard from '../hosting-feature-gated-with-overview-card';
+import JetpackConnectionWarningCard from '../overview-jetpack-connection-warning-card';
 import type { SiteScan, Site } from '@automattic/api-core';
 
-export const CARD_PROPS = {
+const CARD_PROPS = {
 	icon: shield,
 	title: __( 'Last scan' ),
 	tracksId: 'site-overview-scan',
@@ -93,6 +94,10 @@ function ScanCardContent( { site }: { site: Site } ) {
 }
 
 export default function ScanCard( { site }: { site: Site } ) {
+	if ( site.__inaccessible_jetpack_error ) {
+		return <JetpackConnectionWarningCard { ...CARD_PROPS } />;
+	}
+
 	return (
 		<HostingFeatureGatedWithOverviewCard
 			site={ site }

--- a/client/dashboard/sites/overview-site-fields/index.tsx
+++ b/client/dashboard/sites/overview-site-fields/index.tsx
@@ -80,7 +80,7 @@ const SiteOverviewFields = ( { site }: { site: Site } ) => {
 		);
 	}
 
-	if ( wpVersion ) {
+	if ( wpVersion && ! site.__inaccessible_jetpack_error ) {
 		fields.push(
 			<MetadataItem key="wp-version" title={ __( 'WordPress' ) }>
 				{ isSelfHostedJetpackConnected( site ) ? (
@@ -92,7 +92,7 @@ const SiteOverviewFields = ( { site }: { site: Site } ) => {
 		);
 	}
 
-	if ( hasPHPFeature ) {
+	if ( hasPHPFeature && ! site.__inaccessible_jetpack_error ) {
 		fields.push(
 			<MetadataItem key="php" title={ __( 'PHP' ) }>
 				<Link to={ `/sites/${ site.slug }/settings/php` }>

--- a/client/dashboard/sites/overview-visibility-card-ciab/index.tsx
+++ b/client/dashboard/sites/overview-visibility-card-ciab/index.tsx
@@ -2,14 +2,19 @@ import { __ } from '@wordpress/i18n';
 import { published } from '@wordpress/icons';
 import { launch } from '../../components/icons';
 import OverviewCard from '../../components/overview-card';
+import JetpackConnectionWarningCard from '../overview-jetpack-connection-warning-card';
 import type { Site } from '@automattic/api-core';
 
-export const CARD_PROPS = {
+const CARD_PROPS = {
 	title: __( 'Store Visibility' ),
 	tracksId: 'site-overview-visibility-ciab',
 };
 
 export default function VisibilityCardCiab( { site }: { site: Site } ) {
+	if ( site.__inaccessible_jetpack_error ) {
+		return <JetpackConnectionWarningCard { ...CARD_PROPS } />;
+	}
+
 	const link = site.options?.admin_url
 		? `${ site.options.admin_url }admin.php?page=next-admin&p=%2Fwoocommerce%2Fsettings%2Fgeneral`
 		: undefined;

--- a/client/dashboard/sites/overview-visibility-card-ciab/index.tsx
+++ b/client/dashboard/sites/overview-visibility-card-ciab/index.tsx
@@ -4,7 +4,7 @@ import { launch } from '../../components/icons';
 import OverviewCard from '../../components/overview-card';
 import type { Site } from '@automattic/api-core';
 
-const CARD_PROPS = {
+export const CARD_PROPS = {
 	title: __( 'Store Visibility' ),
 	tracksId: 'site-overview-visibility-ciab',
 };

--- a/client/dashboard/sites/overview-visibility-card/index.tsx
+++ b/client/dashboard/sites/overview-visibility-card/index.tsx
@@ -6,12 +6,12 @@ import { launch } from '../../components/icons';
 import OverviewCard from '../../components/overview-card';
 import { wpcomLink } from '../../utils/link';
 import { getSiteVisibilityURL } from '../../utils/site-url';
-import JetpackConnectionWarningCard from '../overview-jetpack-connection-warning-card';
 import type { Site } from '@automattic/api-core';
 
-const CARD_PROPS = {
+export const CARD_PROPS = {
+	icon: launch,
 	title: __( 'Visibility' ),
-	trackId: 'site-overview-visibility',
+	tracksId: 'site-overview-visibility',
 };
 
 function getLaunchpadChecklistSlug( site: Site ) {
@@ -43,7 +43,6 @@ function VisibilityCardUnlaunched( { site }: { site: Site } ) {
 	return (
 		<OverviewCard
 			{ ...CARD_PROPS }
-			icon={ launch }
 			{ ...( isLaunchpadCompleted
 				? {
 						heading: __( 'Launch site' ),
@@ -69,7 +68,6 @@ function VisibilityCardComingSoon( { site }: { site: Site } ) {
 	return (
 		<OverviewCard
 			{ ...CARD_PROPS }
-			icon={ launch }
 			heading={ __( 'Coming soon' ) }
 			description={
 				site.is_wpcom_staging_site
@@ -111,12 +109,6 @@ function VisibilityCardPublic( { site }: { site: Site } ) {
 }
 
 export default function VisibilityCard( { site }: { site: Site } ) {
-	if ( site.__inaccessible_jetpack_error ) {
-		return (
-			<JetpackConnectionWarningCard title={ CARD_PROPS.title } tracksId={ CARD_PROPS.trackId } />
-		);
-	}
-
 	if ( site.launch_status === 'unlaunched' ) {
 		return <VisibilityCardUnlaunched site={ site } />;
 	}

--- a/client/dashboard/sites/overview-visibility-card/index.tsx
+++ b/client/dashboard/sites/overview-visibility-card/index.tsx
@@ -6,9 +6,10 @@ import { launch } from '../../components/icons';
 import OverviewCard from '../../components/overview-card';
 import { wpcomLink } from '../../utils/link';
 import { getSiteVisibilityURL } from '../../utils/site-url';
+import JetpackConnectionWarningCard from '../overview-jetpack-connection-warning-card';
 import type { Site } from '@automattic/api-core';
 
-export const CARD_PROPS = {
+const CARD_PROPS = {
 	icon: launch,
 	title: __( 'Visibility' ),
 	tracksId: 'site-overview-visibility',
@@ -109,6 +110,10 @@ function VisibilityCardPublic( { site }: { site: Site } ) {
 }
 
 export default function VisibilityCard( { site }: { site: Site } ) {
+	if ( site.__inaccessible_jetpack_error ) {
+		return <JetpackConnectionWarningCard { ...CARD_PROPS } />;
+	}
+
 	if ( site.launch_status === 'unlaunched' ) {
 		return <VisibilityCardUnlaunched site={ site } />;
 	}

--- a/client/dashboard/sites/overview-visibility-card/index.tsx
+++ b/client/dashboard/sites/overview-visibility-card/index.tsx
@@ -6,6 +6,7 @@ import { launch } from '../../components/icons';
 import OverviewCard from '../../components/overview-card';
 import { wpcomLink } from '../../utils/link';
 import { getSiteVisibilityURL } from '../../utils/site-url';
+import JetpackConnectionWarningCard from '../overview-jetpack-connection-warning-card';
 import type { Site } from '@automattic/api-core';
 
 const CARD_PROPS = {
@@ -110,6 +111,12 @@ function VisibilityCardPublic( { site }: { site: Site } ) {
 }
 
 export default function VisibilityCard( { site }: { site: Site } ) {
+	if ( site.__inaccessible_jetpack_error ) {
+		return (
+			<JetpackConnectionWarningCard title={ CARD_PROPS.title } tracksId={ CARD_PROPS.trackId } />
+		);
+	}
+
 	if ( site.launch_status === 'unlaunched' ) {
 		return <VisibilityCardUnlaunched site={ site } />;
 	}

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -94,7 +94,7 @@ function OverviewCardSlot( {
 	if ( site.__inaccessible_jetpack_error ) {
 		return <JetpackConnectionWarningCard { ...cardProps } />;
 	}
-	return <>{ children }</>;
+	return children;
 }
 
 function SiteOverviewPrimaryCards( { site, spacing }: { site: Site; spacing: number } ) {

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -21,24 +21,30 @@ import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { isSelfHostedJetpackConnected, isCommerceGarden } from '../../utils/site-types';
 import AgencySiteShareCard from '../overview-agency-site-share-card';
-import BackupCard from '../overview-backup-card';
+import BackupCard, { CARD_PROPS as BACKUP_CARD_PROPS } from '../overview-backup-card';
 import DIFMUpsellCard from '../overview-difm-upsell-card';
 import DomainsCard from '../overview-domains-card';
 import OverviewFlexUsageCard from '../overview-flex-usage-card';
+import JetpackConnectionWarningCard from '../overview-jetpack-connection-warning-card';
 import LatestActivityCard from '../overview-latest-activity-card';
 import MigrateSiteCard from '../overview-migrate-site-card';
-import PerformanceCard from '../overview-performance-card';
+import PerformanceCard, {
+	CARD_PROPS as PERFORMANCE_CARD_PROPS,
+} from '../overview-performance-card';
 import PlanCard from '../overview-plan-card';
-import ScanCard from '../overview-scan-card';
+import ScanCard, { CARD_PROPS as SCAN_CARD_PROPS } from '../overview-scan-card';
 import SiteActionMenu from '../overview-site-action-menu';
 import SiteOverviewFields from '../overview-site-fields';
 import SitePreviewCard from '../overview-site-preview-card';
 import SubscribersCard from '../overview-subscribers-card';
-import VisibilityCard from '../overview-visibility-card';
-import VisibilityCardCiab from '../overview-visibility-card-ciab';
+import VisibilityCard, { CARD_PROPS as VISIBILITY_CARD_PROPS } from '../overview-visibility-card';
+import VisibilityCardCiab, {
+	CARD_PROPS as VISIBILITY_CIAB_CARD_PROPS,
+} from '../overview-visibility-card-ciab';
 import { InaccessibleJetpackNotice } from '../site/notices';
 import StagingSiteSyncDropdown from '../staging-site-sync-dropdown';
 import { StorageWarningBanner } from './storage-warning-banner';
+import type { OverviewCardProps } from '../../components/overview-card';
 import type { Site } from '@automattic/api-core';
 import type { WPBreakpoint } from '@wordpress/compose/build-types/hooks/use-viewport-match';
 import './style.scss';
@@ -77,12 +83,28 @@ function getGridLayout( {
 	};
 }
 
+function OverviewCardSlot( {
+	site,
+	children,
+	...cardProps
+}: {
+	site: Site;
+	children: React.ReactNode;
+} & Pick< OverviewCardProps, 'icon' | 'title' | 'tracksId' > ) {
+	if ( site.__inaccessible_jetpack_error ) {
+		return <JetpackConnectionWarningCard { ...cardProps } />;
+	}
+	return <>{ children }</>;
+}
+
 function SiteOverviewPrimaryCards( { site, spacing }: { site: Site; spacing: number } ) {
 	if ( isCommerceGarden( site ) ) {
 		return (
 			<Grid columns={ 1 } rows={ 2 } gap={ spacing }>
 				<PlanCard site={ site } />
-				<VisibilityCardCiab site={ site } />
+				<OverviewCardSlot site={ site } { ...VISIBILITY_CIAB_CARD_PROPS }>
+					<VisibilityCardCiab site={ site } />
+				</OverviewCardSlot>
 			</Grid>
 		);
 	}
@@ -93,8 +115,14 @@ function SiteOverviewPrimaryCards( { site, spacing }: { site: Site; spacing: num
 				const showVisibilityCard = ! site.is_wpcom_flex;
 				return (
 					<Grid columns={ 1 } rows={ showVisibilityCard ? 2 : 1 } gap={ spacing }>
-						{ showVisibilityCard && <VisibilityCard site={ site } /> }
-						<BackupCard site={ site } />
+						{ showVisibilityCard && (
+							<OverviewCardSlot site={ site } { ...VISIBILITY_CARD_PROPS }>
+								<VisibilityCard site={ site } />
+							</OverviewCardSlot>
+						) }
+						<OverviewCardSlot site={ site } { ...BACKUP_CARD_PROPS }>
+							<BackupCard site={ site } />
+						</OverviewCardSlot>
 					</Grid>
 				);
 			} )() }
@@ -109,9 +137,15 @@ function SiteOverviewPrimaryCards( { site, spacing }: { site: Site; spacing: num
 					if ( site.plan?.is_free && ! site.is_wpcom_staging_site ) {
 						return <MigrateSiteCard site={ site } />;
 					}
-					return <PerformanceCard site={ site } />;
+					return (
+						<OverviewCardSlot site={ site } { ...PERFORMANCE_CARD_PROPS }>
+							<PerformanceCard site={ site } />
+						</OverviewCardSlot>
+					);
 				} )() }
-				<ScanCard site={ site } />
+				<OverviewCardSlot site={ site } { ...SCAN_CARD_PROPS }>
+					<ScanCard site={ site } />
+				</OverviewCardSlot>
 			</Grid>
 			<PlanCard site={ site } />
 		</>
@@ -146,7 +180,9 @@ function SiteOverviewSecondaryCards( {
 					<DomainsCard site={ site } />
 				) : (
 					<>
-						<LatestActivityCard site={ site } isCompact={ isSmallViewport } />
+						{ ! site.__inaccessible_jetpack_error && (
+							<LatestActivityCard site={ site } isCompact={ isSmallViewport } />
+						) }
 						<VStack spacing={ spacing } justify="start">
 							{ showFlexUsageCard && <OverviewFlexUsageCard site={ site } /> }
 							{ ! isSelfHostedJetpackConnectedSite && ! site.is_wpcom_staging_site && (

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -21,30 +21,24 @@ import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { isSelfHostedJetpackConnected, isCommerceGarden } from '../../utils/site-types';
 import AgencySiteShareCard from '../overview-agency-site-share-card';
-import BackupCard, { CARD_PROPS as BACKUP_CARD_PROPS } from '../overview-backup-card';
+import BackupCard from '../overview-backup-card';
 import DIFMUpsellCard from '../overview-difm-upsell-card';
 import DomainsCard from '../overview-domains-card';
 import OverviewFlexUsageCard from '../overview-flex-usage-card';
-import JetpackConnectionWarningCard from '../overview-jetpack-connection-warning-card';
 import LatestActivityCard from '../overview-latest-activity-card';
 import MigrateSiteCard from '../overview-migrate-site-card';
-import PerformanceCard, {
-	CARD_PROPS as PERFORMANCE_CARD_PROPS,
-} from '../overview-performance-card';
+import PerformanceCard from '../overview-performance-card';
 import PlanCard from '../overview-plan-card';
-import ScanCard, { CARD_PROPS as SCAN_CARD_PROPS } from '../overview-scan-card';
+import ScanCard from '../overview-scan-card';
 import SiteActionMenu from '../overview-site-action-menu';
 import SiteOverviewFields from '../overview-site-fields';
 import SitePreviewCard from '../overview-site-preview-card';
 import SubscribersCard from '../overview-subscribers-card';
-import VisibilityCard, { CARD_PROPS as VISIBILITY_CARD_PROPS } from '../overview-visibility-card';
-import VisibilityCardCiab, {
-	CARD_PROPS as VISIBILITY_CIAB_CARD_PROPS,
-} from '../overview-visibility-card-ciab';
+import VisibilityCard from '../overview-visibility-card';
+import VisibilityCardCiab from '../overview-visibility-card-ciab';
 import { InaccessibleJetpackNotice } from '../site/notices';
 import StagingSiteSyncDropdown from '../staging-site-sync-dropdown';
 import { StorageWarningBanner } from './storage-warning-banner';
-import type { OverviewCardProps } from '../../components/overview-card';
 import type { Site } from '@automattic/api-core';
 import type { WPBreakpoint } from '@wordpress/compose/build-types/hooks/use-viewport-match';
 import './style.scss';
@@ -83,28 +77,12 @@ function getGridLayout( {
 	};
 }
 
-function OverviewCardSlot( {
-	site,
-	children,
-	...cardProps
-}: {
-	site: Site;
-	children: React.ReactNode;
-} & Pick< OverviewCardProps, 'icon' | 'title' | 'tracksId' > ) {
-	if ( site.__inaccessible_jetpack_error ) {
-		return <JetpackConnectionWarningCard { ...cardProps } />;
-	}
-	return children;
-}
-
 function SiteOverviewPrimaryCards( { site, spacing }: { site: Site; spacing: number } ) {
 	if ( isCommerceGarden( site ) ) {
 		return (
 			<Grid columns={ 1 } rows={ 2 } gap={ spacing }>
 				<PlanCard site={ site } />
-				<OverviewCardSlot site={ site } { ...VISIBILITY_CIAB_CARD_PROPS }>
-					<VisibilityCardCiab site={ site } />
-				</OverviewCardSlot>
+				<VisibilityCardCiab site={ site } />
 			</Grid>
 		);
 	}
@@ -115,14 +93,8 @@ function SiteOverviewPrimaryCards( { site, spacing }: { site: Site; spacing: num
 				const showVisibilityCard = ! site.is_wpcom_flex;
 				return (
 					<Grid columns={ 1 } rows={ showVisibilityCard ? 2 : 1 } gap={ spacing }>
-						{ showVisibilityCard && (
-							<OverviewCardSlot site={ site } { ...VISIBILITY_CARD_PROPS }>
-								<VisibilityCard site={ site } />
-							</OverviewCardSlot>
-						) }
-						<OverviewCardSlot site={ site } { ...BACKUP_CARD_PROPS }>
-							<BackupCard site={ site } />
-						</OverviewCardSlot>
+						{ showVisibilityCard && <VisibilityCard site={ site } /> }
+						<BackupCard site={ site } />
 					</Grid>
 				);
 			} )() }
@@ -137,15 +109,9 @@ function SiteOverviewPrimaryCards( { site, spacing }: { site: Site; spacing: num
 					if ( site.plan?.is_free && ! site.is_wpcom_staging_site ) {
 						return <MigrateSiteCard site={ site } />;
 					}
-					return (
-						<OverviewCardSlot site={ site } { ...PERFORMANCE_CARD_PROPS }>
-							<PerformanceCard site={ site } />
-						</OverviewCardSlot>
-					);
+					return <PerformanceCard site={ site } />;
 				} )() }
-				<OverviewCardSlot site={ site } { ...SCAN_CARD_PROPS }>
-					<ScanCard site={ site } />
-				</OverviewCardSlot>
+				<ScanCard site={ site } />
 			</Grid>
 			<PlanCard site={ site } />
 		</>

--- a/client/dashboard/sites/overview/test/index.test.tsx
+++ b/client/dashboard/sites/overview/test/index.test.tsx
@@ -278,4 +278,24 @@ describe( '<SiteOverview>', () => {
 		expect( getCard( 'Month-to-date site usage' ) ).toBeVisible();
 		expect( getCard( 'The perfect domain awaits' ) ).toBeVisible();
 	} );
+
+	test( 'renders the overview of an inaccessible Jetpack site', async () => {
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
+
+		mockSite( {
+			...site,
+			is_wpcom_atomic: true,
+			__inaccessible_jetpack_error: new Error( 'Connection failed' ),
+		} as Site );
+
+		render( <SiteOverview siteSlug={ site.slug } /> );
+		await screen.findByRole( 'heading', { name: 'Test Site' } );
+
+		expect( getCard( 'Last backup' ) ).toHaveTextContent( 'Connection issue' );
+		expect( getCard( 'Last scan' ) ).toHaveTextContent( 'Connection issue' );
+		expect( getCard( 'Performance' ) ).toHaveTextContent( 'Connection issue' );
+		expect( getCard( 'Visibility' ) ).toHaveTextContent( 'Connection issue' );
+		expect( getCard( 'Plan' ) ).toBeVisible();
+		expect( screen.queryByText( 'Latest activity' ) ).not.toBeInTheDocument();
+	} );
 } );

--- a/client/dashboard/sites/site-menu/index.tsx
+++ b/client/dashboard/sites/site-menu/index.tsx
@@ -1,32 +1,28 @@
 import { isSupportSession } from '@automattic/calypso-support-session';
 import { __ } from '@wordpress/i18n';
+import {
+	siteOverviewRoute,
+	siteDeploymentsRoute,
+	sitePerformanceRoute,
+	siteMonitoringRoute,
+	siteLogsRoute,
+	siteScanRoute,
+	siteBackupsRoute,
+	siteDomainsRoute,
+	siteSettingsRoute,
+} from '../../app/router/sites';
 import MenuDivider from '../../components/menu-divider';
 import ResponsiveMenu from '../../components/responsive-menu';
 import { hasSiteTrialEnded } from '../../utils/site-trial';
 import { getSiteTypeFeatureSupports } from '../../utils/site-type-feature-support';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import type { Site } from '@automattic/api-core';
+import type { AnyRoute } from '@tanstack/react-router';
 
 const SiteMenu = ( { site }: { site: Site } ) => {
 	const siteSlug = site.slug;
 
 	const siteTypeSupports = getSiteTypeFeatureSupports( site );
-
-	if ( site.__inaccessible_jetpack_error ) {
-		return (
-			<ResponsiveMenu label={ __( 'Site Menu' ) } prefix={ <MenuDivider /> }>
-				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }` } activeOptions={ { exact: true } }>
-					{ __( 'Overview' ) }
-				</ResponsiveMenu.Item>
-				{ siteTypeSupports.domains && (
-					<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/domains` }>
-						{ __( 'Domains' ) }
-					</ResponsiveMenu.Item>
-				) }
-			</ResponsiveMenu>
-		);
-	}
-
 	if ( hasSiteTrialEnded( site ) ) {
 		return (
 			<ResponsiveMenu label={ __( 'Site Menu' ) } prefix={ <MenuDivider /> }>
@@ -57,47 +53,54 @@ const SiteMenu = ( { site }: { site: Site } ) => {
 		);
 	}
 
+	const isAvailable = ( route: AnyRoute ) =>
+		! site.__inaccessible_jetpack_error ||
+		route.options.staticData?.availableToInaccessibleJetpackSites;
+
 	return (
 		<ResponsiveMenu label={ __( 'Site Menu' ) } prefix={ <MenuDivider /> }>
-			<ResponsiveMenu.Item to={ `/sites/${ siteSlug }` } activeOptions={ { exact: true } }>
-				{ __( 'Overview' ) }
-			</ResponsiveMenu.Item>
-			{ siteTypeSupports.deployments && (
+			{ isAvailable( siteOverviewRoute ) && (
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }` } activeOptions={ { exact: true } }>
+					{ __( 'Overview' ) }
+				</ResponsiveMenu.Item>
+			) }
+			{ isAvailable( siteDeploymentsRoute ) && siteTypeSupports.deployments && (
 				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/deployments` }>
 					{ __( 'Deployments' ) }
 				</ResponsiveMenu.Item>
 			) }
-			{ siteTypeSupports.performance && (
+			{ isAvailable( sitePerformanceRoute ) && siteTypeSupports.performance && (
 				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/performance` }>
 					{ __( 'Performance' ) }
 				</ResponsiveMenu.Item>
 			) }
-			{ siteTypeSupports.monitoring && (
+			{ isAvailable( siteMonitoringRoute ) && siteTypeSupports.monitoring && (
 				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/monitoring` }>
 					{ __( 'Monitoring' ) }
 				</ResponsiveMenu.Item>
 			) }
-			{ siteTypeSupports.logs && (
+			{ isAvailable( siteLogsRoute ) && siteTypeSupports.logs && (
 				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/logs` }>
 					{ __( 'Logs' ) }
 				</ResponsiveMenu.Item>
 			) }
-			{ siteTypeSupports.scan && (
+			{ isAvailable( siteScanRoute ) && siteTypeSupports.scan && (
 				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/scan` }>
 					{ __( 'Scan' ) }
 				</ResponsiveMenu.Item>
 			) }
-			{ siteTypeSupports.backups && (
+			{ isAvailable( siteBackupsRoute ) && siteTypeSupports.backups && (
 				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/backups` }>
 					{ __( 'Backups' ) }
 				</ResponsiveMenu.Item>
 			) }
-			{ siteTypeSupports.domains && (
+			{ isAvailable( siteDomainsRoute ) && siteTypeSupports.domains && (
 				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/domains` }>
 					{ __( 'Domains' ) }
 				</ResponsiveMenu.Item>
 			) }
-			{ siteTypeSupports.settings &&
+			{ isAvailable( siteSettingsRoute ) &&
+				siteTypeSupports.settings &&
 				site.capabilities?.manage_options &&
 				! isSelfHostedJetpackConnected( site ) && (
 					<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/settings` }>

--- a/client/dashboard/sites/site-menu/index.tsx
+++ b/client/dashboard/sites/site-menu/index.tsx
@@ -12,6 +12,16 @@ const SiteMenu = ( { site }: { site: Site } ) => {
 
 	const siteTypeSupports = getSiteTypeFeatureSupports( site );
 
+	if ( site.__inaccessible_jetpack_error ) {
+		return (
+			<ResponsiveMenu label={ __( 'Site Menu' ) } prefix={ <MenuDivider /> }>
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }` } activeOptions={ { exact: true } }>
+					{ __( 'Overview' ) }
+				</ResponsiveMenu.Item>
+			</ResponsiveMenu>
+		);
+	}
+
 	if ( hasSiteTrialEnded( site ) ) {
 		return (
 			<ResponsiveMenu label={ __( 'Site Menu' ) } prefix={ <MenuDivider /> }>

--- a/client/dashboard/sites/site-menu/index.tsx
+++ b/client/dashboard/sites/site-menu/index.tsx
@@ -18,6 +18,11 @@ const SiteMenu = ( { site }: { site: Site } ) => {
 				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }` } activeOptions={ { exact: true } }>
 					{ __( 'Overview' ) }
 				</ResponsiveMenu.Item>
+				{ siteTypeSupports.domains && (
+					<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/domains` }>
+						{ __( 'Domains' ) }
+					</ResponsiveMenu.Item>
+				) }
 			</ResponsiveMenu>
 		);
 	}


### PR DESCRIPTION
Fixes: DOTMSD-1105, DOTMSD-1083

## Proposed Changes

* **Router redirect**: Redirect to overview on direct URL access when the site has an inaccessible Jetpack connection error. Domains pages remain accessible.
* **Menu restriction**: Hide all navigation items except "Overview" and "Domains" when the Jetpack connection is broken.
* **Warning cards**: Show per-card Jetpack connection warning cards (Visibility, Backup, Scan, Performance, CIAB) via an `OverviewCardSlot` wrapper at the composition layer — individual cards have no knowledge of Jetpack errors.
* **Activity card**: Hide the Latest Activity card entirely when Jetpack is disconnected (no data available).
* **Site fields**: Hide WordPress version and PHP version metadata when Jetpack connection is broken (data is unreliable).
* **Bug fix**: Fix `trackId` → `tracksId` typo in VisibilityCard CARD_PROPS and add missing `icon`.

## Why are these changes being made?

When a Jetpack connection is broken, the overview page shows a helpful troubleshooting banner. However, users could still navigate to other pages (Settings, Backups, Scan, etc.) that depend on the Jetpack connection, where they'd encounter confusing generic error messages instead of the actionable troubleshooting guidance.

## Architecture

The Jetpack error handling is centralized at appropriate layers:

| Layer | File | Responsibility |
|-------|------|---------------|
| Router | `app/router/sites.tsx` | Redirect non-overview/domains URLs on page load |
| Menu | `sites/site-menu/index.tsx` | Show only Overview + Domains nav items |
| Composition | `sites/overview/index.tsx` | `OverviewCardSlot` wrapper renders warning cards; hides LatestActivityCard |
| Leaf (data) | `sites/overview-site-fields/index.tsx` | Hide unreliable WP/PHP version fields |

Individual overview cards (BackupCard, ScanCard, etc.) are completely unaware of Jetpack connection errors.

## Screenshots

| Before | After |
|--------|--------|
| ![Screen Recording on 2026-03-10 at 02-11-43](https://github.com/user-attachments/assets/f3e93583-b64d-4a2f-894c-c4d2fc0b4193) | ![Screen Recording on 2026-03-11 at 01-10-08](https://github.com/user-attachments/assets/2f2722d6-b6ad-467f-a0e3-64e20cc7cf37) |


## Considerations

We explored adding a route-level redirect to automatically send users back to the overview page when visiting a sub-page with a broken Jetpack connection. The parent route's beforeLoad works for direct URL access (page load), but TanStack Router does not re-run the parent beforeLoad on client-side navigation between child routes. We also tried child route beforeLoad and loader approaches, but neither fired reliably on client-side navigation.

For now, hiding the nav items is the pragmatic fix — users won't see links to pages that won't work. However this does leave our experience not in an ideal state. When the user's Jetpack connection breaks while they are viewing a page in the multi-site dashboard, they will not be forcefully redirect to the overview. They will remain on the page.

<img src="https://github.com/user-attachments/assets/5e12cd80-e3c7-4c81-9bb3-ce9f4da2808a" width="400px" >

## Testing Instructions

* Find or simulate a site with an inaccessible Jetpack connection error (the site object should have `__inaccessible_jetpack_error` set).
* Navigate directly to a sub-page URL (e.g. `/sites/{slug}/monitoring`) — verify it redirects to the overview.
* Verify that the site menu only shows "Overview" and "Domains" items.
* Verify that the existing troubleshooting banner still appears on the overview page.
* Verify that overview cards (Visibility, Backup, Scan, Performance) show "Connection issue" warning cards.
* Verify that Latest Activity section is hidden.
* Verify that WordPress version and PHP version are hidden from site fields.
* For CIAB sites: verify the Store Visibility card also shows the warning.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)