### PR TITLE
Image Studio: Support additional Jetpack AI entry points

### DIFF
--- a/packages/image-studio/src/extensions/image-generation-handler-extension.ts
+++ b/packages/image-studio/src/extensions/image-generation-handler-extension.ts
@@ -51,12 +51,11 @@ export const addImageStudioHandler = (
 		extra?: Record< string, unknown >;
 	}
 ): ( () => void ) | null => {
-	const { entryPoint, onImageSelect } = context;
-
-	// Validate required callback to handle malformed filter contexts gracefully
-	if ( typeof onImageSelect !== 'function' ) {
+	if ( ! context || typeof context.onImageSelect !== 'function' ) {
 		return _defaultHandler;
 	}
+
+	const { entryPoint, onImageSelect } = context;
 
 	const studioEntryPoint = isKnownSurface( entryPoint )
 		? ENTRY_POINT_MAP[ entryPoint ]

--- a/packages/image-studio/src/extensions/image-generation-handler-extension.ts
+++ b/packages/image-studio/src/extensions/image-generation-handler-extension.ts
@@ -1,0 +1,85 @@
+import { dispatch } from '@wordpress/data';
+import { ImageStudioEntryPoint, store as imageStudioStore } from '../store';
+import { ImageStudioMode } from '../types';
+import { type ImageData } from '../utils/get-image-data';
+import { trackImageStudioOpened } from '../utils/tracking';
+
+/**
+ * Known Jetpack AI surfaces that can open Image Studio.
+ * Add new surfaces here as they are implemented on the Jetpack side.
+ */
+type JetpackAISurface = 'featured-image' | 'social-media';
+
+/**
+ * Map Jetpack surface entry points to Image Studio entry points for tracking.
+ * These are distinct from JetpackExternalMedia* entry points which come from
+ * the external media modal. These JetpackAI* entry points track usage from
+ * the jetpack.ai.imageGenerationHandler filter (AI sidebar, social media UI).
+ */
+const ENTRY_POINT_MAP: Record< JetpackAISurface, ImageStudioEntryPoint > = {
+	'featured-image': ImageStudioEntryPoint.JetpackAIFeaturedImage,
+	'social-media': ImageStudioEntryPoint.JetpackAISocialMedia,
+};
+
+/**
+ * Type guard to check if an entry point string is a known Jetpack AI surface.
+ * @param value - The entry point string to check.
+ * @returns Whether the value is a known Jetpack AI surface.
+ */
+const isKnownSurface = ( value: string ): value is JetpackAISurface =>
+	Object.prototype.hasOwnProperty.call( ENTRY_POINT_MAP, value );
+/**
+ * Unified filter callback for `jetpack.ai.imageGenerationHandler`.
+ *
+ * Returns a click handler that opens Image Studio in generate mode.
+ * Works for all Jetpack surfaces — the `entryPoint` field in context
+ * determines tracking metadata. The `onImageSelect` callback abstracts
+ * away surface-specific image handling (e.g. setting featured image vs
+ * updating social media attachments).
+ * @param _defaultHandler       - The default handler value (null when no plugin hooks the filter).
+ * @param context               - Context about the current Jetpack surface.
+ * @param context.entryPoint    - Which surface is calling: 'featured-image' | 'social-media'.
+ * @param context.onImageSelect - Callback to deliver the selected image back to the Jetpack surface.
+ * @param context.extra         - Optional surface-specific metadata (placement, disabled, etc.).
+ * @returns A click handler that opens Image Studio, or the default handler if context is invalid.
+ */
+export const addImageStudioHandler = (
+	_defaultHandler: null,
+	context: {
+		entryPoint: string;
+		onImageSelect: ( image: { id: number; url: string; mime?: string } ) => void;
+		extra?: Record< string, unknown >;
+	}
+): ( () => void ) | null => {
+	const { entryPoint, onImageSelect } = context;
+
+	// Validate required callback to handle malformed filter contexts gracefully
+	if ( typeof onImageSelect !== 'function' ) {
+		return _defaultHandler;
+	}
+
+	const studioEntryPoint = isKnownSurface( entryPoint )
+		? ENTRY_POINT_MAP[ entryPoint ]
+		: ImageStudioEntryPoint.EditorSidebar;
+
+	return () => {
+		trackImageStudioOpened( {
+			mode: ImageStudioMode.Generate,
+			attachmentId: undefined,
+			entryPoint: studioEntryPoint,
+		} );
+
+		dispatch( imageStudioStore ).openImageStudio(
+			undefined, // Generate mode (no existing attachment)
+			( image: ImageData | null ) => {
+				if ( image?.id && image?.url ) {
+					onImageSelect( {
+						id: image.id,
+						url: image.url,
+					} );
+				}
+			},
+			studioEntryPoint
+		);
+	};
+};

--- a/packages/image-studio/src/extensions/index.test.ts
+++ b/packages/image-studio/src/extensions/index.test.ts
@@ -12,6 +12,7 @@ jest.mock( '@wordpress/hooks', () => ( {
 const mockAddImageStudioMediaSource = jest.fn();
 const mockWithImageStudioGenerateButton = jest.fn();
 const mockWithImageStudioToolbarButton = jest.fn();
+const mockAddImageStudioHandler = jest.fn();
 
 jest.mock( './external-media-source-extension', () => ( {
 	addImageStudioMediaSource: mockAddImageStudioMediaSource,
@@ -23,6 +24,10 @@ jest.mock( './generate-button-extension', () => ( {
 
 jest.mock( './image-toolbar-extension', () => ( {
 	withImageStudioToolbarButton: mockWithImageStudioToolbarButton,
+} ) );
+
+jest.mock( './image-generation-handler-extension', () => ( {
+	addImageStudioHandler: mockAddImageStudioHandler,
 } ) );
 
 describe( 'Extension Registration', () => {
@@ -41,7 +46,7 @@ describe( 'Extension Registration', () => {
 
 			registerBlockEditorFilters();
 
-			expect( mockAddFilter ).toHaveBeenCalledTimes( 3 );
+			expect( mockAddFilter ).toHaveBeenCalledTimes( 4 );
 
 			// Verify toolbar button filter
 			expect( mockAddFilter ).toHaveBeenCalledWith(
@@ -63,6 +68,13 @@ describe( 'Extension Registration', () => {
 				'big-sky/generate-button',
 				mockWithImageStudioGenerateButton
 			);
+
+			// Verify image generation handler filter
+			expect( mockAddFilter ).toHaveBeenCalledWith(
+				'jetpack.ai.imageGenerationHandler',
+				'big-sky/image-studio',
+				mockAddImageStudioHandler
+			);
 		} );
 
 		it( 'should only register filters once (idempotency)', () => {
@@ -72,8 +84,8 @@ describe( 'Extension Registration', () => {
 			registerBlockEditorFilters();
 			registerBlockEditorFilters();
 
-			// Should only call addFilter 3 times total (not 9)
-			expect( mockAddFilter ).toHaveBeenCalledTimes( 3 );
+			// Should only call addFilter 4 times total (not 12)
+			expect( mockAddFilter ).toHaveBeenCalledTimes( 4 );
 		} );
 
 		it( 'should use correct namespace for filters', () => {

--- a/packages/image-studio/src/extensions/index.ts
+++ b/packages/image-studio/src/extensions/index.ts
@@ -1,6 +1,7 @@
 import { addFilter } from '@wordpress/hooks';
 import { addImageStudioMediaSource } from './external-media-source-extension';
 import { withImageStudioGenerateButton } from './generate-button-extension';
+import { addImageStudioHandler } from './image-generation-handler-extension';
 import { withImageStudioToolbarButton } from './image-toolbar-extension';
 
 let filtersRegistered = false;
@@ -20,4 +21,7 @@ export function registerBlockEditorFilters() {
 	);
 
 	addFilter( 'editor.MediaUpload', 'big-sky/generate-button', withImageStudioGenerateButton );
+
+	// Unified handler for AI image generation surfaces (featured image, social, future surfaces)
+	addFilter( 'jetpack.ai.imageGenerationHandler', 'big-sky/image-studio', addImageStudioHandler );
 }

--- a/packages/image-studio/src/store/index.ts
+++ b/packages/image-studio/src/store/index.ts
@@ -45,6 +45,9 @@ export enum ImageStudioEntryPoint {
 	EditorSidebar = 'editor_sidebar',
 	JetpackExternalMediaBlock = 'jetpack_external_media_block',
 	JetpackExternalMediaFeaturedImage = 'jetpack_external_media_featured_image',
+	// Entry points for jetpack.ai.imageGenerationHandler filter
+	JetpackAIFeaturedImage = 'jetpack_ai_featured_image',
+	JetpackAISocialMedia = 'jetpack_ai_social_media',
 }
 
 export interface ImageStudioState {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Migrates Big Sky PR 5673 to Calypso

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To enable Image Studio to override Jetpack AI in the Jetpack AI sidebar and Jetpack Social plugin

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `install-plugin.sh am image-studio-jetpack-sidebar` on your sandbox
* Sandbox `widgets.wp.com`
* Open the post editor
* Expand the Jetpack sidebar 
* Ensure `Generate Image` appears in the `Improve with AI` section

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
