### PR TITLE
WPCOM Gutenberg RTC: Introduce wpcom-gutenberg-rtc app

### DIFF
--- a/apps/wpcom-gutenberg-rtc/README.md
+++ b/apps/wpcom-gutenberg-rtc/README.md
@@ -1,0 +1,53 @@
+# wpcom-gutenberg-rtc
+
+Real-time collaboration provider for the Gutenberg editor on WordPress.com. Replaces Gutenberg's default HTTP polling with a PingHub WebSocket-based transport for low-latency, push-based document synchronization and presence.
+
+## Why This Is a Calypso App
+
+PingHub authenticates via cookies scoped to `public-api.wordpress.com`. The Gutenberg editor runs on a different origin — the site's own domain for Atomic sites, or `*.wordpress.com` for Simple sites — so it cannot directly open a WebSocket to PingHub (the browser won't attach the cookies).
+
+The solution is to load a hidden bridge iframe from `widgets.wp.com` that proxies WebSocket traffic via `postMessage`. This app builds and deploys the RTC bundle to `widgets.wp.com/wpcom-gutenberg-rtc/`, where Jetpack enqueues it into the editor. Because the iframe bridge handles auth, the parent page's origin (Atomic, or any Jetpack-connected site) doesn't matter. See the [rest-proxy](https://public-api.wordpress.com/wp-admin/rest-proxy/) for the list of allowed origins and their limitations.
+
+## File Structure
+
+| File                     | Role                                                                     |
+| ------------------------ | ------------------------------------------------------------------------ |
+| `src/index.ts`           | Entry point: registers the PingHub provider via `wp.hooks.addFilter`     |
+| `src/types.d.ts`         | Window global type declarations                                          |
+| `src/providers/pinghub/` | PingHub Yjs provider — see [its README](src/providers/pinghub/README.md) |
+
+## Development
+
+```bash
+# Dev build + sync to sandbox
+cd apps/wpcom-gutenberg-rtc
+yarn dev --sync
+
+# Production build + sync
+cd apps/wpcom-gutenberg-rtc
+yarn build --sync
+```
+
+Both commands use `calypso-apps-builder` to compile webpack bundles and sync them to `widgets.wp.com/wpcom-gutenberg-rtc/` on your sandbox.
+
+## Sandbox Testing
+
+1. Sandbox `widgets.wp.com`.
+2. Run `yarn dev --sync` from `apps/wpcom-gutenberg-rtc/`.
+3. Visit a Simple or Atomic site with the `wpcom-gutenberg-rtc-enabled` blog sticker.
+4. Open the Gutenberg editor on a post or page.
+5. Open the same post in a second browser/tab to verify real-time sync and presence.
+
+## Deployment
+
+1. Connect to your sandbox and run: `install-plugin.sh wpcom-gutenberg-rtc --release`
+2. Merge the PR.
+3. Deploy wpcom: `deploy wpcom`
+
+## How It Works
+
+When the editor loads, `index.ts` checks `window.wpcomGutenbergRTC.providers` for enabled providers. If `"pinghub"` is present, it registers a `ProviderCreator` via the `sync.providers` filter. See the [PingHub provider README](src/providers/pinghub/README.md) for full details on architecture, wire protocol, and reconnection.
+
+## Externals
+
+`@wordpress/sync` and `yjs` are resolved to `wp.sync` and `wp.sync.Y` globals respectively, to avoid bundling duplicate Yjs instances (which breaks shared document types).

--- a/apps/wpcom-gutenberg-rtc/package.json
+++ b/apps/wpcom-gutenberg-rtc/package.json
@@ -1,0 +1,39 @@
+{
+	"name": "@automattic/wpcom-gutenberg-rtc",
+	"version": "1.0.0",
+	"description": "Real-time collaboration provider for the Gutenberg editor on WordPress.com.",
+	"homepage": "https://github.com/Automattic/wp-calypso",
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic Inc.",
+	"sideEffects": true,
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Automattic/wp-calypso.git",
+		"directory": "apps/wpcom-gutenberg-rtc"
+	},
+	"private": true,
+	"bugs": "https://github.com/Automattic/wp-calypso/issues",
+	"scripts": {
+		"build:app": "calypso-build",
+		"clean": "rm -rf dist",
+		"build": "NODE_ENV=production yarn dev",
+		"dev": "yarn run calypso-apps-builder --localPath dist --remotePath /home/wpcom/public_html/widgets.wp.com/wpcom-gutenberg-rtc",
+		"teamcity:build-app": "yarn run build"
+	},
+	"dependencies": {
+		"@wordpress/hooks": "^4.23.0",
+		"@wordpress/sync": "^1.23.0",
+		"lib0": "^0.2.117",
+		"y-protocols": "^1.0.7",
+		"yjs": "^13.6.29"
+	},
+	"devDependencies": {
+		"@automattic/calypso-apps-builder": "workspace:^",
+		"@automattic/calypso-build": "workspace:^",
+		"@wordpress/dependency-extraction-webpack-plugin": "^6.24.0",
+		"@wordpress/readable-js-assets-webpack-plugin": "^3.24.0",
+		"postcss": "^8.5.3",
+		"typescript": "^5.8.3",
+		"webpack": "^5.99.8"
+	}
+}

--- a/apps/wpcom-gutenberg-rtc/package.json
+++ b/apps/wpcom-gutenberg-rtc/package.json
@@ -22,7 +22,7 @@
 	},
 	"dependencies": {
 		"@wordpress/hooks": "^4.23.0",
-		"@wordpress/sync": "^1.41.0",
+		"@wordpress/sync": "^1.23.0",
 		"lib0": "^0.2.117",
 		"y-protocols": "^1.0.7",
 		"yjs": "^13.6.29"

--- a/apps/wpcom-gutenberg-rtc/package.json
+++ b/apps/wpcom-gutenberg-rtc/package.json
@@ -22,7 +22,7 @@
 	},
 	"dependencies": {
 		"@wordpress/hooks": "^4.23.0",
-		"@wordpress/sync": "^1.23.0",
+		"@wordpress/sync": "^1.41.0",
 		"lib0": "^0.2.117",
 		"y-protocols": "^1.0.7",
 		"yjs": "^13.6.29"

--- a/apps/wpcom-gutenberg-rtc/src/index.ts
+++ b/apps/wpcom-gutenberg-rtc/src/index.ts
@@ -1,0 +1,29 @@
+import { addFilter } from '@wordpress/hooks';
+import { createPingHubProvider } from './providers/pinghub';
+
+/**
+ * Register providers (e.g. PingHub) supplied by the server, and disable HTTP polling by returning only this provider.
+ */
+function registerWpcomGutenbergProviders() {
+	const getProviders = () => {
+		if ( ! window.wpcomGutenbergRTC?.providers ) {
+			return [];
+		}
+
+		return window.wpcomGutenbergRTC.providers
+			.map( ( provider: string ) => {
+				switch ( provider ) {
+					case 'pinghub': {
+						return createPingHubProvider();
+					}
+					default:
+						return null;
+				}
+			} )
+			.filter( Boolean );
+	};
+
+	addFilter( 'sync.providers', 'wpcom/gutenberg-rtc-providers', () => getProviders() );
+}
+
+registerWpcomGutenbergProviders();

--- a/apps/wpcom-gutenberg-rtc/src/providers/pinghub/README.md
+++ b/apps/wpcom-gutenberg-rtc/src/providers/pinghub/README.md
@@ -1,0 +1,258 @@
+# PingHub Yjs Provider
+
+A Yjs provider for Gutenberg that enables real-time collaborative editing via PingHub WebSockets. It uses persistent WebSocket connections through a hidden iframe bridge to the WordPress.com REST proxy, providing push-based, low-latency updates.
+
+## Architecture
+
+```
+┌─────────────────┐                              ┌─────────────────┐
+│    Client A      │                             │    Client B     │
+│  ┌───────────┐  │                              │  ┌───────────┐  │
+│  │  Y.Doc    │  │                              │  │  Y.Doc    │  │
+│  │ Awareness │  │                              │  │ Awareness │  │
+│  └─────┬─────┘  │                              │  └─────┬─────┘  │
+│        │        │                              │        │        │
+│  ┌─────┴─────┐  │                              │  ┌─────┴─────┐  │
+│  │ PingHub   │  │                              │  │ PingHub   │  │
+│  │ Provider  │  │                              │  │ Provider  │  │
+│  └─────┬─────┘  │                              │  └─────┴─────┘  │
+│  ┌─────┴─────┐  │                              │  ┌─────┴─────┐  │
+│  │ PingHub   │  │                              │  │ PingHub   │  │
+│  │ Manager   │  │                              │  │ Manager   │  │
+│  └─────┬─────┘  │                              │  └─────┴─────┘  │
+└────────┼────────┘                              └────────┼────────┘
+         │                                                │
+         │            WebSocket (PingHub)                 │
+         └────────────────────┬───────────────────────────┘
+                              │
+                    ┌─────────┴─────────┐
+                    │  WordPress.com    │
+                    │  PingHub Service  │
+                    │  (WebSocket relay)│
+                    └───────────────────┘
+```
+
+## File Structure
+
+| File                  | Role                                                                                                |
+| --------------------- | --------------------------------------------------------------------------------------------------- |
+| `index.ts`            | Public export: `createPingHubProvider`                                                              |
+| `pinghub-provider.ts` | `PingHubProvider` class + `createPingHubProvider` factory: thin shell that delegates to the manager |
+| `pinghub-manager.ts`  | `pinghubManager` module: per-room Yjs sync protocol, awareness, reconnection logic                  |
+| `pinghub-bridge.ts`   | `PingHubBridge` class: WebSocket communication with PingHub via the REST proxy iframe               |
+
+## Usage
+
+### Basic Setup
+
+```ts
+import { createPingHubProvider } from './providers/pinghub';
+```
+
+#### 1. Register the provider creator
+
+`createPingHubProvider` returns a `ProviderCreator` compatible with Gutenberg's sync manager. The bridge is created lazily on first use.
+
+```ts
+import { addFilter } from '@wordpress/hooks';
+
+const providerCreator = createPingHubProvider();
+
+addFilter( 'sync.providers', 'my-plugin/pinghub', ( providers ) => {
+	return [ ...providers, providerCreator ];
+} );
+```
+
+The sync manager calls the provider creator for each entity being edited. Currently only `postType/post` and `postType/page` entities with a non-null `objectId` get a PingHub channel; all other entity types receive a no-op provider.
+
+#### 2. Listen for connection status
+
+```ts
+const result = await providerCreator( { objectType, objectId, ydoc, awareness } );
+
+result.on( 'status', ( { status } ) => {
+	// status: 'connecting' | 'connected' | 'disconnected'
+	console.log( 'PingHub status:', status );
+} );
+```
+
+#### 3. Clean up
+
+```ts
+result.destroy();
+```
+
+This broadcasts a final awareness removal to peers and tears down all listeners. Window-level event handlers are automatically removed when the last provider is destroyed.
+
+## How It Works
+
+### 1. Initialization
+
+When the editor loads, `gutenberg-rtc.ts` checks `window.wpcomGutenbergRTC.providers` for enabled providers. If `"pinghub"` is present, it registers a `ProviderCreator` via the `sync.providers` filter.
+
+Gutenberg's sync manager calls the provider creator for each entity being edited. Currently only `postType/post` and `postType/page` entities with a non-null `objectId` get a PingHub channel; all other entity types (collections, patterns, etc.) receive a no-op provider.
+
+### 2. Provider → Manager → Bridge
+
+The layered architecture separates concerns:
+
+- **`PingHubProvider`** — thin shell per entity. Owns the `Awareness` instance and emits `status` events. Delegates all transport to the manager via `pinghubManager.registerRoom()` / `pinghubManager.unregisterRoom()`.
+- **`pinghubManager`** — manages all rooms. Each `registerRoom()` call creates a per-room connection that handles Yjs sync protocol, awareness broadcasting, and reconnection with exponential backoff. Also owns the shared bridge and window event listeners (`beforeunload`, `pagehide`, `visibilitychange`).
+- **`PingHubBridge`** — singleton (lazy-created on first room registration). Manages the hidden iframe and multiplexes all PingHub channels over it via `postMessage`.
+
+### 3. Channel Path
+
+Each post maps to a PingHub channel:
+
+```
+/pinghub/wpcom/rtc/{blogId}/{objectType}-{objectId}
+```
+
+For example: `/pinghub/wpcom/rtc/12345/postType-post-42`
+
+The blog ID is resolved from WordPress globals (`_currentSiteId`, `wpcomGutenberg.blogId`, or `currentBlogId`). The room name (`postType-post-42`) is constructed by the provider; the bridge prepends the `/pinghub/wpcom/rtc/{blogId}/` prefix internally.
+
+### 4. PingHub Bridge
+
+#### Why a PingHub Bridge?
+
+PingHub is a WebSocket service on `public-api.wordpress.com`, and the user's auth cookies are scoped to that domain. The editor page runs on a different origin (e.g., `wordpress.com/post/...` or a custom site domain), so it **cannot directly open a WebSocket** to PingHub — the browser won't attach the cookies.
+
+The solution is the **REST proxy iframe pattern** already used elsewhere in WordPress.com:
+
+```
+Editor page (origin A)              Hidden iframe (origin B = public-api.wordpress.com)
+┌──────────────────┐                ┌──────────────────────────┐
+│                  │  postMessage   │                          │
+│  PingHubBridge   │ ─────────────→ | REST proxy page          │
+│  (JS)            │ ←───────────── | ● Has auth cookies       │
+│                  │  postMessage   │ ● Opens real WebSocket   │
+└──────────────────┘                └──────────────────────────┘
+```
+
+The iframe loads a page from `public-api.wordpress.com`, so the browser attaches the user's cookies. The iframe internally opens the real WebSocket to PingHub. The editor communicates with the iframe via `postMessage`, which works cross-origin by design.
+
+#### PingHub Bridge setup
+
+On construction, the bridge either reuses an existing REST-proxy iframe already in the DOM or creates a new hidden one (1×1 px, off-screen). When the proxy page inside the iframe loads, it posts `"ready"` back to the parent. The bridge queues any `connect`/`send` calls until this ready signal arrives.
+
+#### Connect flow
+
+```
+Editor (Bridge)             PingHub Bridge (REST proxy)      PingHub server
+  │                                │                                │
+  │ postMessage({                  │                                │
+  │   action: 'connect',           │                                │
+  │   path: '/pinghub/…',          │                                │
+  │   callback: '1'                │                                │
+  │ })                             │                                │
+  │ ──────────────────────────────→│                                │
+  │                                │  WebSocket.open(path)          │
+  │                                │ ──────────────────────────────→│
+  │                                │                                │
+  │                                │  onopen                        │
+  │                                │ ←──────────────────────────────│
+  │  postMessage(                  │                                │
+  │    [{type:'open'}, 200, '1']   │                                │
+  │  )                             │                                │
+  │ ←──────────────────────────────│                                │
+  │                                │                                │
+  │  connect() Promise resolves    │                                │
+```
+
+The `callback` ID links each response back to the original request. The bridge maintains `callbackToPath` / `pathToCallback` maps to route incoming messages to the right path handlers.
+
+#### Message transport
+
+**Sending:** Manager calls `bridge.send(room, Uint8Array)` → bridge base64-encodes the bytes (because `postMessage` JSON can't carry binary) → posts `{ action: 'send', path, message: '<base64>' }` to iframe → iframe forwards over the real WebSocket.
+
+**Receiving:** PingHub pushes a message to the WebSocket inside the iframe → iframe posts it back as `[{type:'message', data:'<base64>'}, 200, callbackId]` → bridge decodes base64 to `Uint8Array` and invokes registered `onMessage` handlers for that path.
+
+#### Multiplexing
+
+One iframe serves **all** PingHub channels. Each channel is identified by its `path` string. The bridge maintains per-path handler sets (`openHandlers`, `closeHandlers`, `messageHandlers`), so multiple rooms (one per open post) share the same bridge and iframe, each listening on their own path.
+
+#### Edge cases
+
+| Scenario                        | How the bridge handles it                                                                                       |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| **Already connected**           | If `connectedPaths` has the path, fires open handlers immediately without sending another connect               |
+| **Duplicate connect in flight** | Subsequent `connect()` calls for the same path join the existing waiter list instead of opening a second socket |
+| **Already subscribed (444)**    | Proxy returns status 444 — bridge treats it as a successful open                                                |
+| **Non-base64 text frames**      | Falls back to `textToBytes()` if base64 decode throws                                                           |
+| **Blob data**                   | Converts asynchronously via `blob.arrayBuffer()`                                                                |
+
+#### Chunking
+
+PingHub has a per-frame size limit. The bridge automatically **chunks** outgoing messages larger than 256 bytes and **reassembles** incoming chunked frames:
+
+- Messages ≤ 256 bytes are sent as a single frame.
+- Larger messages are split into chunks of up to 251 bytes (256 minus the 5-byte chunk header).
+- Each chunk frame: `[0xFE magic, msgId high, msgId low, totalChunks, chunkIndex, ...payload]`.
+- The receiver buffers chunks by `path:msgId` and delivers the full reassembled message once all chunks arrive.
+
+Both sender and receiver handle chunking transparently — the manager layer sees only complete `Uint8Array` messages.
+
+### 5. Wire Protocol
+
+Every message sent by the manager is a `Uint8Array` with the following structure:
+
+```
+[varuint senderClientID] [varuint msgType] [type-specific payload]
+```
+
+The `senderClientID` prefix lets each client filter out its own messages (echoed back by PingHub's broadcast relay).
+
+| `msgType`       | Value  | Payload                                                      |
+| --------------- | ------ | ------------------------------------------------------------ |
+| `MSG_SYNC`      | `0x00` | Yjs sync protocol data (sync step 1, sync step 2, or update) |
+| `MSG_AWARENESS` | `0x01` | `varuint8array`-encoded awareness update                     |
+
+### 6. Sync Protocol
+
+The Yjs sync handshake runs over the PingHub channel:
+
+1. **Client A connects** → sends `sync_step1` (its state vector) as a `MSG_SYNC` frame.
+2. **PingHub relays** the message to all other subscribers on the channel.
+3. **Client B receives** → processes the sync step, generates `sync_step2` (the updates A is missing), and sends it back. Because this is pub/sub (not point-to-point), Client B also sends its own `sync_step1` the first time it sees a peer's `sync_step1`, so both sides complete the handshake.
+4. **Ongoing edits** → each client sends `MSG_SYNC` update frames for every Yjs `update` event (ignoring updates originated from `pinghub-manager` to avoid echo loops).
+
+### 7. Awareness
+
+Awareness state (presence, cursor positions) is synchronized alongside document updates:
+
+- **On connect**: the manager broadcasts the local awareness state to all peers.
+- **On local change**: awareness updates (`added`, `updated`, `removed` client IDs) are sent immediately as `MSG_AWARENESS` frames.
+- **On remote message**: incoming awareness updates are applied locally via `y-protocols/awareness`.
+- **On page hide**: the manager broadcasts a removal for the local client ID so peers immediately learn the user has left (uses synchronous `postMessage` which survives page teardown).
+- **On destroy**: a final awareness removal is broadcast before tearing down listeners.
+
+### 8. Reconnection
+
+When the WebSocket connection drops:
+
+1. Emit `disconnected` status (suppressed during page unload to avoid a brief flash).
+2. Schedule a reconnect with **exponential backoff**: starting at 1 s, doubling each attempt, capped at 30 s.
+3. Emit `connecting` before each retry.
+4. On success: `handleWsOpen` fires, re-sends `sync_step1` and broadcasts awareness.
+5. When the tab returns to the foreground (`visibilitychange`), any disconnected rooms reconnect immediately (backoff resets).
+
+### 9. Connection Status
+
+The provider emits `status` events compatible with Gutenberg's `ConnectionStatus` interface:
+
+| Status         | When                                    |
+| -------------- | --------------------------------------- |
+| `connecting`   | Initial connection or reconnect attempt |
+| `connected`    | WebSocket open, sync step 1 sent        |
+| `disconnected` | WebSocket closed or provider destroyed  |
+
+### 10. Lifecycle
+
+Window-level event handlers are shared across all active rooms:
+
+- `beforeunload` → sets an unload flag so `handleWsClose` suppresses the disconnect status.
+- `pagehide` → broadcasts awareness removal for every connected room.
+- `visibilitychange` → reconnects any disconnected rooms when the tab becomes visible.
+
+Listeners are registered when the first room is created and removed when the last one is unregistered.

--- a/apps/wpcom-gutenberg-rtc/src/providers/pinghub/index.ts
+++ b/apps/wpcom-gutenberg-rtc/src/providers/pinghub/index.ts
@@ -1,0 +1,1 @@
+export { createPingHubProvider } from './pinghub-provider';

--- a/apps/wpcom-gutenberg-rtc/src/providers/pinghub/pinghub-bridge.ts
+++ b/apps/wpcom-gutenberg-rtc/src/providers/pinghub/pinghub-bridge.ts
@@ -1,0 +1,686 @@
+type BridgeEventMap = {
+	open: () => void;
+	close: ( code: number, reason: string ) => void;
+	message: ( data: Uint8Array ) => void;
+};
+
+/** Body of a PingHub proxy response (open, close, message, or error). */
+type ProxyResponseBody = {
+	type: 'open' | 'close' | 'message' | 'error';
+	code?: number;
+	reason?: string;
+	text?: string;
+	data?: ArrayBuffer | Blob | string;
+};
+
+/** Normalized proxy response we can handle in one place. */
+type NormalizedProxyResponse = {
+	body: ProxyResponseBody;
+	code: number;
+	callback: string;
+};
+
+const IFRAME_SRC_BASE = 'https://public-api.wordpress.com/wp-admin/rest-proxy/';
+const PROXY_ORIGIN = 'https://public-api.wordpress.com';
+const PROXY_ALREADY_SUBSCRIBED = 444;
+const PROXY_READY_TIMEOUT_MS = 30 * 1000;
+
+const CHUNK_MAGIC = 0xfe;
+const CHUNK_HEADER_LEN = 5; // magic(1) + msgId(2) + totalChunks(1) + chunkIndex(1)
+const MAX_PAYLOAD_BEFORE_CHUNK = 256;
+const MAX_CHUNK_BUFFERS = 64;
+
+/**
+ * Encode a Uint8Array into a base64 string for text-frame transport.
+ *
+ * @param u8 - Bytes to encode.
+ * @returns Base64-encoded string.
+ */
+function uint8ArrayToBase64( u8: Uint8Array ): string {
+	let binary = '';
+	for ( let i = 0; i < u8.length; i++ ) {
+		binary += String.fromCharCode( u8[ i ] );
+	}
+	return btoa( binary );
+}
+
+/**
+ * Decode a base64 string back into a Uint8Array.
+ *
+ * @param base64 - Base64-encoded string.
+ * @returns Decoded bytes.
+ */
+function base64ToUint8Array( base64: string ): Uint8Array {
+	const binary = atob( base64 );
+	const u8 = new Uint8Array( binary.length );
+	for ( let i = 0; i < binary.length; i++ ) {
+		u8[ i ] = binary.charCodeAt( i );
+	}
+	return u8;
+}
+
+/**
+ * Build a single chunk buffer: [CHUNK_MAGIC, msgIdHi, msgIdLo, totalChunks, chunkIndex, ...payload].
+ *
+ * @param msgId       - Message identifier (per path).
+ * @param totalChunks - Total chunks for this message.
+ * @param chunkIndex  - Zero-based index of this chunk.
+ * @param payload     - Slice of the original payload for this chunk.
+ * @returns Encoded chunk including header and payload.
+ */
+function buildChunk(
+	msgId: number,
+	totalChunks: number,
+	chunkIndex: number,
+	payload: Uint8Array
+): Uint8Array {
+	const out = new Uint8Array( CHUNK_HEADER_LEN + payload.length );
+	out[ 0 ] = CHUNK_MAGIC;
+	out[ 1 ] = ( msgId >> 8 ) & 0xff; // eslint-disable-line no-bitwise
+	out[ 2 ] = msgId & 0xff; // eslint-disable-line no-bitwise
+	out[ 3 ] = totalChunks;
+	out[ 4 ] = chunkIndex;
+	out.set( payload, CHUNK_HEADER_LEN );
+	return out;
+}
+
+/**
+ * Parse chunk header. Returns null if not a chunk or invalid.
+ *
+ * @param data - Candidate frame bytes.
+ * @returns Parsed header and payload, or null if not a chunk.
+ */
+function parseChunkHeader( data: Uint8Array ): {
+	msgId: number;
+	totalChunks: number;
+	chunkIndex: number;
+	payload: Uint8Array;
+} | null {
+	if ( data.length < CHUNK_HEADER_LEN || data[ 0 ] !== CHUNK_MAGIC ) {
+		return null;
+	}
+	return {
+		msgId: data[ 1 ] * 256 + data[ 2 ],
+		totalChunks: data[ 3 ],
+		chunkIndex: data[ 4 ],
+		payload: data.subarray( CHUNK_HEADER_LEN ),
+	};
+}
+
+/**
+ * Convert a string to bytes by taking the low byte of each char code.
+ *
+ * @param str - The string to convert.
+ * @returns Byte array.
+ */
+function textToBytes( str: string ): Uint8Array {
+	const u8 = new Uint8Array( str.length );
+	for ( let i = 0; i < str.length; i++ ) {
+		// eslint-disable-next-line no-bitwise
+		u8[ i ] = str.charCodeAt( i ) & 0xff;
+	}
+	return u8;
+}
+
+/**
+ * Parse event.data (string or already an object) into a plain value.
+ *
+ * @param data - The postMessage data (possibly a JSON string).
+ * @returns Parsed value or null.
+ */
+function parseRaw( data: unknown ): unknown {
+	if ( typeof data === 'string' ) {
+		try {
+			return JSON.parse( data );
+		} catch {
+			return null;
+		}
+	}
+	return data;
+}
+
+/**
+ * Try to parse the array format: [ body, code, headers?, callback ] or [ code, body, headers?, callback ].
+ *
+ * @param raw - The array payload from the proxy.
+ * @returns Normalized response or null if not a valid array response.
+ */
+function parseArrayResponse( raw: unknown[] ): NormalizedProxyResponse | null {
+	if ( raw.length < 3 ) {
+		return null;
+	}
+
+	const callbackRaw = raw[ raw.length - 1 ];
+	const callback = callbackRaw != null ? String( callbackRaw ) : '';
+	if ( ! callback ) {
+		return null;
+	}
+
+	let code: number;
+	let bodyObj: unknown;
+	const first = raw[ 0 ];
+	const second = raw[ 1 ];
+	const firstIsCode =
+		typeof first === 'number' ||
+		( typeof first === 'string' && first !== '' && ! Number.isNaN( Number( first ) ) );
+
+	// Order A: [ body, code, headers?, callback ]
+	if ( typeof first === 'object' && first !== null ) {
+		bodyObj = first;
+		code = Number( raw[ raw.length - 2 ] );
+	}
+	// Order B: [ code, body, headers?, callback ] (code may be number or string from JSON)
+	else if ( firstIsCode && typeof second === 'object' && second !== null ) {
+		bodyObj = second;
+		code = Number( first );
+	} else {
+		return null;
+	}
+
+	// Inner body may be at .body or the object itself (e.g. { type: 'open' } or { body: { type, ... } })
+	const body =
+		( bodyObj as { body?: ProxyResponseBody } ).body ??
+		( ( bodyObj as { type?: string } ).type !== undefined ? bodyObj : null );
+	if (
+		typeof body !== 'object' ||
+		! body ||
+		typeof ( body as ProxyResponseBody ).type !== 'string'
+	) {
+		return null;
+	}
+	return { body: body as ProxyResponseBody, code, callback };
+}
+
+/**
+ * Try to parse the legacy object format: { callback, body: { type, ... }, code? }.
+ *
+ * @param raw - The object payload from the proxy.
+ * @returns Normalized response or null if not a valid legacy response.
+ */
+function parseLegacyObjectResponse(
+	raw: Record< string, unknown >
+): NormalizedProxyResponse | null {
+	const o = raw as { callback?: string; body?: ProxyResponseBody; code?: number };
+	if ( typeof o.callback !== 'string' || ! o.body || typeof o.body !== 'object' ) {
+		return null;
+	}
+	return {
+		body: o.body as ProxyResponseBody,
+		code: typeof o.code === 'number' ? o.code : 0,
+		callback: o.callback,
+	};
+}
+
+/**
+ * Normalize proxy response (array or legacy object) into a single shape.
+ *
+ * Proxy sends either an array `[ body, code, headers?, callback ]` (supports_args)
+ * or a legacy object with `.callback` and `.body`.
+ *
+ * @param raw - The parsed postMessage payload.
+ * @returns Normalized response or null if not a valid proxy response.
+ */
+function normalizeProxyResponse( raw: unknown ): NormalizedProxyResponse | null {
+	if ( ! raw || typeof raw !== 'object' ) {
+		return null;
+	}
+
+	if ( Array.isArray( raw ) ) {
+		return parseArrayResponse( raw );
+	}
+
+	return parseLegacyObjectResponse( raw as Record< string, unknown > );
+}
+
+/**
+ * Get the blog ID from the WordPress globals.
+ *
+ * @returns The blog ID or null if it cannot be determined.
+ */
+function getBlogId(): number | null {
+	if ( typeof window._currentSiteId === 'number' ) {
+		return window._currentSiteId;
+	}
+	if ( typeof window.wpcomGutenberg?.blogId === 'number' ) {
+		return window.wpcomGutenberg.blogId;
+	}
+	if ( typeof window.currentBlogId === 'number' ) {
+		return window.currentBlogId;
+	}
+	return null;
+}
+
+export class PingHubBridge {
+	private iframe: HTMLIFrameElement;
+	private ready = false;
+	private readyResolvers: Array< () => void > = [];
+	private openHandlers = new Map< string, Set< () => void > >();
+	private closeHandlers = new Map< string, Set< ( code: number, reason: string ) => void > >();
+	private messageHandlers = new Map< string, Set< ( data: Uint8Array ) => void > >();
+	private callbackSeq = 1;
+	private pending = new Map< string, () => void >();
+	private callbackToPath = new Map< string, string >();
+	private pathToCallback = new Map< string, string >();
+	/** Paths that have received 'open' and not yet 'close' or disconnect – one socket per path. */
+	private connectedPaths = new Set< string >();
+	/** Paths with a connect request in flight; waiters are resolved when we get open or error. */
+	private connectingPathWaiters = new Map<
+		string,
+		Array< { resolve: () => void; reject: ( err: Error ) => void } >
+	>();
+	/** Per-path message id for chunked sends. */
+	private chunkMsgIdByPath = new Map< string, number >();
+	/** Reassembly buffer: key = path + ':' + msgId, value = { totalChunks, chunks } */
+	private chunkBuffers = new Map<
+		string,
+		{ totalChunks: number; chunks: Map< number, Uint8Array > }
+	>();
+
+	/** Reuse an existing proxy iframe or create a new one and start listening for messages. */
+	constructor() {
+		const existing = document.querySelector(
+			`iframe[src^="${ IFRAME_SRC_BASE }"]`
+		) as HTMLIFrameElement | null;
+		this.iframe = existing ?? this.createIframe();
+		window.addEventListener( 'message', this.handleMessage );
+	}
+
+	/**
+	 * Build the full PingHub path for a room name.
+	 *
+	 * @param room - Short room identifier (e.g. "postType-post-42").
+	 * @returns Full PingHub channel path.
+	 */
+	private fullPath( room: string ): string {
+		const blogId = getBlogId();
+		if ( ! blogId ) {
+			throw new Error( 'Cannot determine blog ID for PingHub bridge' );
+		}
+
+		return `/pinghub/wpcom/rtc/${ blogId }/${ room }`;
+	}
+
+	/**
+	 * Create and append a hidden proxy iframe to the document body.
+	 *
+	 * @returns The created iframe element.
+	 */
+	private createIframe(): HTMLIFrameElement {
+		const iframe = document.createElement( 'iframe' );
+		iframe.style.cssText = 'position:absolute;left:-9999px;width:1px;height:1px;';
+		iframe.src = `${ IFRAME_SRC_BASE }?v=2.0#${ window.location.origin }`;
+		document.body.appendChild( iframe );
+		return iframe;
+	}
+
+	/**
+	 * Post a structured message to the proxy iframe.
+	 *
+	 * @param msg - The message to send.
+	 */
+	private postToProxy( msg: Record< string, unknown > ): void {
+		this.iframe.contentWindow?.postMessage( msg, PROXY_ORIGIN );
+	}
+
+	/**
+	 * Return a promise that resolves once the proxy iframe signals readiness.
+	 *
+	 * @returns Resolves when the proxy is ready.
+	 */
+	private waitReady(): Promise< void > {
+		if ( this.ready ) {
+			return Promise.resolve();
+		}
+		return new Promise( ( resolve, reject ) => {
+			this.readyResolvers.push( resolve );
+			setTimeout( () => {
+				if ( ! this.ready ) {
+					reject( new Error( 'PingHub proxy iframe did not become ready in time' ) );
+				}
+			}, PROXY_READY_TIMEOUT_MS );
+		} );
+	}
+
+	/**
+	 * Handle incoming postMessage events from the proxy iframe.
+	 *
+	 * @param event - The MessageEvent from the proxy.
+	 */
+	private handleMessage = ( event: MessageEvent ): void => {
+		if ( event.origin !== PROXY_ORIGIN ) {
+			return;
+		}
+
+		const data = event.data;
+
+		// 1) Ready / cookie-auth
+		if (
+			data === 'ready' ||
+			( data?.type === 'pinghub-proxy' && data?.body?.type === 'cookie-auth' )
+		) {
+			this.ready = true;
+			this.readyResolvers.splice( 0 ).forEach( ( r ) => r() );
+			return;
+		}
+
+		// 2) Proxy JSON response (array or object)
+		const raw = parseRaw( data );
+		const response = normalizeProxyResponse( raw );
+		if ( response ) {
+			this.handleProxyResponse( response );
+		}
+	};
+
+	/**
+	 * Resolve or reject all connect waiters for a path.
+	 *
+	 * @param path    - The PingHub path.
+	 * @param success - Whether the connect succeeded.
+	 */
+	private settleConnectWaiters( path: string | undefined, success: boolean ): void {
+		const waiters = path ? this.connectingPathWaiters.get( path ) : undefined;
+		if ( waiters ) {
+			const err = new Error( 'PingHub connect failed' );
+			waiters.forEach( ( w ) => ( success ? w.resolve() : w.reject( err ) ) );
+			this.connectingPathWaiters.delete( path! );
+		}
+	}
+
+	/**
+	 * Route a normalized proxy response to the appropriate handler by message type.
+	 *
+	 * @param res - The normalized proxy response.
+	 */
+	private handleProxyResponse( res: NormalizedProxyResponse ): void {
+		const { body, code, callback } = res;
+		const path = this.callbackToPath.get( callback );
+		const resolvePending = this.pending.get( callback );
+		if ( resolvePending ) {
+			this.pending.delete( callback );
+		}
+
+		switch ( body.type ) {
+			case 'open':
+				if ( path ) {
+					this.connectedPaths.add( path );
+					this.openHandlers.get( path )?.forEach( ( h ) => h() );
+				}
+				this.settleConnectWaiters( path, true );
+				break;
+			case 'close':
+				if ( path ) {
+					this.connectedPaths.delete( path );
+					this.closeHandlers
+						.get( path )
+						?.forEach( ( h ) => h( body.code ?? 1000, body.reason ?? '' ) );
+				}
+				if ( resolvePending ) {
+					resolvePending();
+				}
+				break;
+			case 'message':
+				if ( path && body.data !== undefined ) {
+					this.dispatchToHandlers( path, body.data );
+				}
+				break;
+			case 'error':
+				// Proxy returns 444 "already subscribed" when we connect the same path twice – treat as success.
+				if ( path && ( code === PROXY_ALREADY_SUBSCRIBED || body.text === 'already subscribed' ) ) {
+					this.connectedPaths.add( path );
+					this.openHandlers.get( path )?.forEach( ( h ) => h() );
+					this.settleConnectWaiters( path, true );
+				} else {
+					if ( path ) {
+						this.callbackToPath.delete( callback );
+						this.pathToCallback.delete( path );
+					}
+					this.settleConnectWaiters( path, false );
+					if ( resolvePending ) {
+						resolvePending();
+					}
+				}
+				break;
+			default:
+				if ( resolvePending ) {
+					resolvePending();
+				}
+		}
+	}
+
+	/**
+	 * Dispatches received data to path handlers.
+	 *
+	 * Incoming frames may be:
+	 * - Base64 string (text frame): decoded to Uint8Array, then treated as chunk or whole message.
+	 * - Chunk (first byte CHUNK_MAGIC): buffered by path+msgId; when all chunks received, reassembled in order (chunk 0, 1, …) and passed once to handlers. Non-chunk messages are passed through.
+	 *
+	 * @param path - PingHub path for the message.
+	 * @param data - Raw payload from the proxy.
+	 */
+	private dispatchToHandlers( path: string, data: ArrayBuffer | Blob | string ): void {
+		const handlers = this.messageHandlers.get( path );
+		if ( ! handlers?.size ) {
+			return;
+		}
+
+		const run = ( u8: Uint8Array ) => {
+			const parsed = parseChunkHeader( u8 );
+			if ( parsed ) {
+				this.reassembleChunk( path, parsed, handlers );
+				return;
+			}
+			handlers.forEach( ( h ) => h( u8 ) );
+		};
+		if ( typeof data === 'string' ) {
+			try {
+				run( base64ToUint8Array( data ) );
+			} catch {
+				// Fallback: treat as raw bytes (e.g. proxy sent non-base64 text)
+				run( textToBytes( data ) );
+			}
+		} else if ( data instanceof ArrayBuffer ) {
+			run( new Uint8Array( data ) );
+		} else if ( data instanceof Blob ) {
+			data.arrayBuffer().then( ( ab ) => run( new Uint8Array( ab ) ) );
+		}
+	}
+
+	/**
+	 * Buffer incoming chunks and dispatch the reassembled message when all chunks have arrived.
+	 *
+	 * @param path               - PingHub path for the message.
+	 * @param parsed             - Parsed chunk header and payload.
+	 * @param parsed.msgId       - Message identifier shared across all chunks of one message.
+	 * @param parsed.totalChunks - Total number of chunks expected.
+	 * @param parsed.chunkIndex  - Zero-based index of this chunk.
+	 * @param parsed.payload     - Payload bytes for this chunk.
+	 * @param handlers           - Set of handlers to invoke with the reassembled message.
+	 */
+	private reassembleChunk(
+		path: string,
+		parsed: { msgId: number; totalChunks: number; chunkIndex: number; payload: Uint8Array },
+		handlers: Set< ( data: Uint8Array ) => void >
+	): void {
+		const key = `${ path }:${ parsed.msgId }`;
+		let buf = this.chunkBuffers.get( key );
+		if ( ! buf ) {
+			// Drop oldest incomplete buffers when the cap is reached.
+			if ( this.chunkBuffers.size >= MAX_CHUNK_BUFFERS ) {
+				const oldest = this.chunkBuffers.keys().next().value;
+				if ( oldest !== undefined ) {
+					this.chunkBuffers.delete( oldest );
+				}
+			}
+			buf = { totalChunks: parsed.totalChunks, chunks: new Map() };
+			this.chunkBuffers.set( key, buf );
+		}
+		buf.chunks.set( parsed.chunkIndex, parsed.payload );
+		if ( buf.chunks.size !== buf.totalChunks ) {
+			return;
+		}
+
+		this.chunkBuffers.delete( key );
+		const parts: Uint8Array[] = [];
+		for ( let i = 0; i < buf.totalChunks; i++ ) {
+			const chunk = buf.chunks.get( i );
+			if ( ! chunk ) {
+				// Missing chunk index — discard the incomplete message.
+				return;
+			}
+			parts.push( chunk );
+		}
+		const totalLen = parts.reduce( ( s, p ) => s + p.length, 0 );
+		const reassembled = new Uint8Array( totalLen );
+		let offset = 0;
+		for ( const p of parts ) {
+			reassembled.set( p, offset );
+			offset += p.length;
+		}
+		handlers.forEach( ( h ) => h( reassembled ) );
+	}
+
+	/**
+	 * Return the handler map for a given event type.
+	 *
+	 * @param event - The event name.
+	 * @returns The corresponding handler map.
+	 */
+	private handlersFor< E extends keyof BridgeEventMap >(
+		event: E
+	): Map< string, Set< BridgeEventMap[ E ] > > {
+		switch ( event ) {
+			case 'open':
+				return this.openHandlers as Map< string, Set< BridgeEventMap[ E ] > >;
+			case 'close':
+				return this.closeHandlers as Map< string, Set< BridgeEventMap[ E ] > >;
+			case 'message':
+				return this.messageHandlers as Map< string, Set< BridgeEventMap[ E ] > >;
+			default:
+				throw new Error( `Unknown bridge event: ${ String( event ) }` );
+		}
+	}
+
+	/**
+	 * Register an event handler for a channel path.
+	 *
+	 * @param path    - PingHub channel path.
+	 * @param event   - Event name: 'open', 'close', or 'message'.
+	 * @param handler - Callback for the event.
+	 */
+	on< E extends keyof BridgeEventMap >(
+		path: string,
+		event: E,
+		handler: BridgeEventMap[ E ]
+	): void {
+		const map = this.handlersFor( event );
+		let set = map.get( path );
+		if ( ! set ) {
+			set = new Set();
+			map.set( path, set );
+		}
+		set.add( handler );
+	}
+
+	/**
+	 * Remove a previously registered event handler.
+	 *
+	 * @param path    - PingHub channel path.
+	 * @param event   - Event name: 'open', 'close', or 'message'.
+	 * @param handler - The handler to remove.
+	 */
+	off< E extends keyof BridgeEventMap >(
+		path: string,
+		event: E,
+		handler: BridgeEventMap[ E ]
+	): void {
+		this.handlersFor( event ).get( path )?.delete( handler );
+	}
+
+	async connect( room: string ): Promise< void > {
+		await this.waitReady();
+
+		// Already connected: no new socket, just notify so handlers run.
+		if ( this.connectedPaths.has( room ) ) {
+			this.openHandlers.get( room )?.forEach( ( h ) => h() );
+			return;
+		}
+
+		// Connect already in flight for this room: wait for it instead of sending another.
+		const existing = this.connectingPathWaiters.get( room );
+		if ( existing ) {
+			return new Promise( ( resolve, reject ) => existing.push( { resolve, reject } ) );
+		}
+
+		const waiters: Array< { resolve: () => void; reject: ( err: Error ) => void } > = [];
+		this.connectingPathWaiters.set( room, waiters );
+
+		const callback = String( this.callbackSeq++ );
+		this.callbackToPath.set( callback, room );
+		this.pathToCallback.set( room, callback );
+
+		this.postToProxy( {
+			type: 'pinghub-proxy',
+			action: 'connect',
+			path: this.fullPath( room ),
+			callback,
+			supports_args: true,
+			binary: false,
+		} );
+
+		return new Promise( ( resolve, reject ) => {
+			waiters.push( { resolve, reject } );
+		} );
+	}
+
+	async disconnect( room: string ): Promise< void > {
+		await this.waitReady();
+		this.connectedPaths.delete( room );
+		const callback = this.pathToCallback.get( room );
+		if ( callback ) {
+			this.callbackToPath.delete( callback );
+			this.pathToCallback.delete( room );
+		}
+		return new Promise( ( resolve ) => {
+			const discCallback = String( this.callbackSeq++ );
+			this.pending.set( discCallback, () => resolve() );
+			this.postToProxy( {
+				type: 'pinghub-proxy',
+				action: 'disconnect',
+				path: this.fullPath( room ),
+				callback: discCallback,
+			} );
+		} );
+	}
+
+	send( room: string, data: Uint8Array ): void {
+		if ( ! this.iframe.contentWindow ) {
+			return;
+		}
+
+		const proxyPath = this.fullPath( room );
+		const sendOne = ( payload: Uint8Array ) => {
+			this.postToProxy( {
+				type: 'pinghub-proxy',
+				action: 'send',
+				path: proxyPath,
+				message: uint8ArrayToBase64( payload ),
+			} );
+		};
+
+		if ( data.length <= MAX_PAYLOAD_BEFORE_CHUNK ) {
+			sendOne( data );
+			return;
+		}
+
+		const msgId = ( this.chunkMsgIdByPath.get( room ) ?? 0 ) & 0xffff; // eslint-disable-line no-bitwise
+		this.chunkMsgIdByPath.set( room, msgId + 1 );
+		const chunkSize = MAX_PAYLOAD_BEFORE_CHUNK - CHUNK_HEADER_LEN;
+		const totalChunks = Math.ceil( data.length / chunkSize );
+		for ( let i = 0; i < totalChunks; i++ ) {
+			const start = i * chunkSize;
+			const payload = data.subarray( start, Math.min( start + chunkSize, data.length ) );
+			const chunk = buildChunk( msgId, totalChunks, i, payload );
+			sendOne( chunk );
+		}
+	}
+}

--- a/apps/wpcom-gutenberg-rtc/src/providers/pinghub/pinghub-manager.ts
+++ b/apps/wpcom-gutenberg-rtc/src/providers/pinghub/pinghub-manager.ts
@@ -1,0 +1,460 @@
+import * as decoding from 'lib0/decoding';
+import * as encoding from 'lib0/encoding';
+import * as awarenessProtocol from 'y-protocols/awareness';
+import * as syncProtocol from 'y-protocols/sync';
+import { PingHubBridge } from './pinghub-bridge';
+import type { Awareness, ConnectionStatus } from '@wordpress/sync';
+import type * as Y from 'yjs';
+
+const MSG_SYNC = 0x00;
+const MSG_AWARENESS = 0x01;
+const RECONNECT_BASE_DELAY_MS = 1000;
+const RECONNECT_MAX_DELAY_MS = 30 * 1000;
+const PINGHUB_MANAGER_ORIGIN = 'pinghub-manager';
+
+interface RegisterRoomOptions {
+	room: string;
+	doc: Y.Doc;
+	awareness: Awareness;
+	onStatusChange: ( status: ConnectionStatus ) => void;
+	onSync: () => void;
+}
+
+const rooms: Map< string, PingHubConnection > = new Map();
+let bridge: PingHubBridge | null = null;
+let isUnloadPending = false;
+let areListenersRegistered = false;
+let keepaliveWorker: Worker | null = null;
+
+/**
+ * Manages a single room's real-time synchronization via PingHub.
+ *
+ * Handles Yjs sync protocol, awareness broadcasting, and reconnection with
+ * exponential backoff. Delegates transport to the shared PingHubBridge.
+ */
+class PingHubConnection {
+	private readonly room: string;
+	private readonly clientId: number;
+	private readonly doc: Y.Doc;
+	private readonly awareness: Awareness;
+	private readonly onStatusChange: ( status: ConnectionStatus ) => void;
+	private readonly onSync: () => void;
+
+	public connected = false;
+	private syncStep1RepliedTo = new Set< number >();
+	public reconnectTimer: ReturnType< typeof setTimeout > | null = null;
+	public reconnectDelay = RECONNECT_BASE_DELAY_MS;
+
+	public constructor( options: RegisterRoomOptions ) {
+		this.room = options.room;
+		this.doc = options.doc;
+		this.clientId = options.doc.clientID;
+		this.awareness = options.awareness;
+		this.onStatusChange = options.onStatusChange;
+		this.onSync = options.onSync;
+
+		this.doc.on( 'update', this.handleDocUpdate );
+		this.awareness.on( 'change', this.handleAwarenessChange );
+		if ( bridge ) {
+			bridge.on( this.room, 'open', this.handleWsOpen );
+			bridge.on( this.room, 'close', this.handleWsClose );
+			bridge.on( this.room, 'message', this.handleWsMessage );
+		}
+	}
+
+	/**
+	 * Tear down the connection: remove listeners, cancel reconnection, disconnect.
+	 */
+	public destroy(): void {
+		if ( this.connected ) {
+			this.removeAwareness( 'provider-destroy' );
+		}
+
+		if ( this.reconnectTimer !== null ) {
+			clearTimeout( this.reconnectTimer );
+			this.reconnectTimer = null;
+		}
+
+		this.doc.off( 'update', this.handleDocUpdate );
+		this.awareness.off( 'change', this.handleAwarenessChange );
+		if ( bridge ) {
+			bridge.off( this.room, 'open', this.handleWsOpen );
+			bridge.off( this.room, 'close', this.handleWsClose );
+			bridge.off( this.room, 'message', this.handleWsMessage );
+			bridge.disconnect( this.room );
+		}
+	}
+
+	/**
+	 * Connect the room to PingHub via the shared bridge.
+	 */
+	public connect(): void {
+		if ( ! bridge ) {
+			return;
+		}
+		this.onStatusChange( { status: 'connecting' } );
+		bridge.connect( this.room ).catch( () => {
+			this.onStatusChange( { status: 'disconnected' } );
+			this.scheduleReconnect();
+		} );
+	}
+
+	/**
+	 * Broadcast awareness removal to peers.
+	 *
+	 * @param reason - Reason for removal (e.g. 'page-hide', 'provider-destroy').
+	 */
+	public removeAwareness( reason: string ): void {
+		awarenessProtocol.removeAwarenessStates( this.awareness, [ this.clientId ], reason );
+	}
+
+	/**
+	 * Re-broadcast local awareness state to peers.
+	 *
+	 * Called periodically by the keepalive worker to prevent the y-protocols
+	 * awareness timeout (30s) from removing this client on remote peers.
+	 */
+	public broadcastLocalAwareness(): void {
+		if ( ! this.connected ) {
+			return;
+		}
+		const localState = this.awareness.getLocalState();
+		if ( localState ) {
+			// setLocalState updates the clock and lastUpdated in meta, but
+			// does NOT emit 'change' when the state is deep-equal to the
+			// previous one. We call it to bump the meta, then manually
+			// encode and broadcast so the update reaches remote peers.
+			this.awareness.setLocalState( localState );
+			const update = awarenessProtocol.encodeAwarenessUpdate( this.awareness, [ this.clientId ] );
+			this.broadcastAwareness( update );
+		}
+	}
+
+	/**
+	 * Send a message, prepending the client ID.
+	 *
+	 * @param u8 - Encoded message payload.
+	 */
+	private send( u8: Uint8Array ): void {
+		if ( ! bridge ) {
+			return;
+		}
+		const enc = encoding.createEncoder();
+		encoding.writeVarUint( enc, this.clientId );
+		encoding.writeUint8Array( enc, u8 );
+		bridge.send( this.room, encoding.toUint8Array( enc ) );
+	}
+
+	/**
+	 * Send a Yjs sync step 1 message to initiate document synchronization.
+	 */
+	private sendSyncStep1(): void {
+		const enc = encoding.createEncoder();
+		encoding.writeVarUint( enc, MSG_SYNC );
+		syncProtocol.writeSyncStep1( enc, this.doc );
+		this.send( encoding.toUint8Array( enc ) );
+	}
+
+	/**
+	 * Broadcast an awareness update to all peers.
+	 *
+	 * @param awarenessUpdate - Encoded awareness update.
+	 */
+	private broadcastAwareness( awarenessUpdate: Uint8Array ): void {
+		const enc = encoding.createEncoder();
+		encoding.writeVarUint( enc, MSG_AWARENESS );
+		encoding.writeVarUint8Array( enc, awarenessUpdate );
+		this.send( encoding.toUint8Array( enc ) );
+	}
+
+	/**
+	 * Schedule a reconnection attempt with exponential backoff.
+	 */
+	private scheduleReconnect(): void {
+		if ( this.reconnectTimer !== null ) {
+			return;
+		}
+		this.reconnectTimer = setTimeout( () => {
+			this.reconnectTimer = null;
+			if ( rooms.has( this.room ) ) {
+				this.connect();
+			}
+		}, this.reconnectDelay );
+		this.reconnectDelay = Math.min( this.reconnectDelay * 2, RECONNECT_MAX_DELAY_MS );
+	}
+
+	/**
+	 * Handle WebSocket open. Sends sync step 1 and local awareness state.
+	 */
+	private handleWsOpen = (): void => {
+		if ( ! rooms.has( this.room ) ) {
+			return;
+		}
+		this.connected = true;
+		this.syncStep1RepliedTo.clear();
+		this.reconnectDelay = RECONNECT_BASE_DELAY_MS;
+		this.onStatusChange( { status: 'connected' } );
+
+		this.sendSyncStep1();
+
+		// Only broadcast our own awareness state. Other peers will
+		// announce themselves; re-broadcasting their states could
+		// resurrect stale entries and cause duplicate peers.
+		if ( this.awareness.getLocalState() ) {
+			const update = awarenessProtocol.encodeAwarenessUpdate( this.awareness, [ this.clientId ] );
+			this.broadcastAwareness( update );
+		}
+	};
+
+	/**
+	 * Handle WebSocket close. Schedules reconnection.
+	 */
+	private handleWsClose = (): void => {
+		this.connected = false;
+		if ( ! rooms.has( this.room ) ) {
+			return;
+		}
+		if ( ! isUnloadPending ) {
+			this.onStatusChange( { status: 'disconnected' } );
+		}
+		this.scheduleReconnect();
+	};
+
+	/**
+	 * Handle incoming WebSocket messages. Dispatches sync and awareness messages.
+	 *
+	 * @param data - Raw message payload.
+	 */
+	private handleWsMessage = ( data: Uint8Array ): void => {
+		if ( ! rooms.has( this.room ) ) {
+			return;
+		}
+
+		const dec = decoding.createDecoder( data );
+		const senderClientID = decoding.readVarUint( dec );
+
+		if ( senderClientID === this.clientId ) {
+			return;
+		}
+
+		const msgType = decoding.readVarUint( dec );
+
+		switch ( msgType ) {
+			case MSG_SYNC: {
+				const innerType = dec.arr[ dec.pos ];
+
+				const enc = encoding.createEncoder();
+				encoding.writeVarUint( enc, MSG_SYNC );
+				syncProtocol.readSyncMessage( dec, enc, this.doc, PINGHUB_MANAGER_ORIGIN );
+				this.onSync();
+
+				const reply = encoding.toUint8Array( enc );
+				if ( reply.length > 1 ) {
+					this.send( reply );
+				}
+
+				if (
+					innerType === syncProtocol.messageYjsSyncStep1 &&
+					! this.syncStep1RepliedTo.has( senderClientID )
+				) {
+					this.syncStep1RepliedTo.add( senderClientID );
+					this.sendSyncStep1();
+					// Send our awareness so the new peer sees us immediately.
+					const awarenessUpdate = awarenessProtocol.encodeAwarenessUpdate( this.awareness, [
+						this.clientId,
+					] );
+					this.broadcastAwareness( awarenessUpdate );
+				}
+				return;
+			}
+			case MSG_AWARENESS: {
+				const update = decoding.readVarUint8Array( dec );
+				awarenessProtocol.applyAwarenessUpdate( this.awareness, update, PINGHUB_MANAGER_ORIGIN );
+				break;
+			}
+			default:
+				break;
+		}
+	};
+
+	/**
+	 * Handle local Yjs document updates. Broadcasts the update to peers.
+	 *
+	 * @param update - Yjs document update.
+	 * @param origin - Origin of the update.
+	 */
+	private handleDocUpdate = ( update: Uint8Array, origin: unknown ): void => {
+		if ( ! rooms.has( this.room ) || origin === PINGHUB_MANAGER_ORIGIN || ! this.connected ) {
+			return;
+		}
+
+		const enc = encoding.createEncoder();
+		encoding.writeVarUint( enc, MSG_SYNC );
+		syncProtocol.writeUpdate( enc, update );
+		this.send( encoding.toUint8Array( enc ) );
+	};
+
+	/**
+	 * Handle local awareness changes. Broadcasts the changes to peers.
+	 *
+	 * @param changes         - Changed client IDs.
+	 * @param changes.added   - Newly added client IDs.
+	 * @param changes.updated - Updated client IDs.
+	 * @param changes.removed - Removed client IDs.
+	 */
+	private handleAwarenessChange = ( {
+		added,
+		updated,
+		removed,
+	}: {
+		added: number[];
+		updated: number[];
+		removed: number[];
+	} ): void => {
+		if ( ! this.connected ) {
+			return;
+		}
+		const changed = added.concat( updated ).concat( removed );
+		const update = awarenessProtocol.encodeAwarenessUpdate( this.awareness, changed );
+		this.broadcastAwareness( update );
+	};
+}
+
+/**
+ * Create a Web Worker that sends periodic 'tick' messages for awareness keepalive.
+ *
+ * @returns Worker
+ */
+function createKeepaliveWorker(): Worker {
+	// Inline the worker code as a Blob URL so it runs on the page's origin.
+	// A cross-origin Worker (e.g. from widgets.wp.com on a *.wordpress.com page)
+	// would be blocked by the browser's same-origin policy.
+	const blob = new Blob( [ 'setInterval(()=>postMessage("tick"),25e3)' ], {
+		type: 'application/javascript',
+	} );
+	const worker = new Worker( URL.createObjectURL( blob ) );
+	worker.onmessage = () => {
+		for ( const [ , connection ] of rooms ) {
+			connection.broadcastLocalAwareness();
+		}
+	};
+	return worker;
+}
+
+/**
+ * Tear down the keepalive worker.
+ */
+function destroyKeepaliveWorker(): void {
+	if ( keepaliveWorker ) {
+		keepaliveWorker.terminate();
+		keepaliveWorker = null;
+	}
+}
+
+/**
+ * Suppress disconnect status flash during page navigation.
+ */
+function handleBeforeUnload(): void {
+	isUnloadPending = true;
+}
+
+/**
+ * Broadcast awareness removal for all connected rooms when the page is hidden.
+ */
+function handlePageHide(): void {
+	for ( const [ , connection ] of rooms ) {
+		if ( connection.connected ) {
+			connection.removeAwareness( 'page-hide' );
+		}
+	}
+}
+
+/**
+ * Reconnect all disconnected rooms when the page becomes visible again.
+ */
+function handleVisibilityChange(): void {
+	if ( document.visibilityState !== 'visible' ) {
+		return;
+	}
+	isUnloadPending = false;
+	for ( const [ , connection ] of rooms ) {
+		if ( connection.connected ) {
+			continue;
+		}
+		if ( connection.reconnectTimer !== null ) {
+			clearTimeout( connection.reconnectTimer );
+			connection.reconnectTimer = null;
+		}
+		connection.reconnectDelay = RECONNECT_BASE_DELAY_MS;
+		connection.connect();
+	}
+}
+
+/**
+ * Register a room for real-time synchronization via PingHub.
+ *
+ * Creates the shared bridge lazily on first call. Each room gets its own
+ * PingHubConnection that handles sync protocol, awareness, and reconnection.
+ *
+ * @param options                - Registration options.
+ * @param options.room           - Room name.
+ * @param options.doc            - Yjs document to synchronize.
+ * @param options.awareness      - Awareness instance for cursor/presence data.
+ * @param options.onStatusChange - Callback for connection status changes.
+ * @param options.onSync         - Callback invoked on each sync message.
+ */
+function registerRoom( options: RegisterRoomOptions ): void {
+	if ( rooms.has( options.room ) ) {
+		return;
+	}
+
+	// Lazy-create bridge on first registration.
+	if ( ! bridge ) {
+		bridge = new PingHubBridge();
+	}
+
+	const connection = new PingHubConnection( options );
+	rooms.set( options.room, connection );
+
+	if ( ! areListenersRegistered ) {
+		window.addEventListener( 'beforeunload', handleBeforeUnload );
+		window.addEventListener( 'pagehide', handlePageHide );
+		document.addEventListener( 'visibilitychange', handleVisibilityChange );
+		areListenersRegistered = true;
+	}
+
+	if ( ! keepaliveWorker ) {
+		keepaliveWorker = createKeepaliveWorker();
+	}
+
+	connection.connect();
+}
+
+/**
+ * Unregister a room, removing all listeners and disconnecting from PingHub.
+ * @param room - Room name.
+ */
+function unregisterRoom( room: string ): void {
+	const connection = rooms.get( room );
+	if ( ! connection ) {
+		return;
+	}
+
+	connection.destroy();
+	rooms.delete( room );
+
+	if ( rooms.size === 0 ) {
+		if ( areListenersRegistered ) {
+			window.removeEventListener( 'beforeunload', handleBeforeUnload );
+			window.removeEventListener( 'pagehide', handlePageHide );
+			document.removeEventListener( 'visibilitychange', handleVisibilityChange );
+			areListenersRegistered = false;
+		}
+		destroyKeepaliveWorker();
+	}
+}
+
+export const pinghubManager = {
+	registerRoom,
+	unregisterRoom,
+};

--- a/apps/wpcom-gutenberg-rtc/src/providers/pinghub/pinghub-manager.ts
+++ b/apps/wpcom-gutenberg-rtc/src/providers/pinghub/pinghub-manager.ts
@@ -3,7 +3,8 @@ import * as encoding from 'lib0/encoding';
 import * as awarenessProtocol from 'y-protocols/awareness';
 import * as syncProtocol from 'y-protocols/sync';
 import { PingHubBridge } from './pinghub-bridge';
-import type { Awareness, ConnectionStatus } from '@wordpress/sync';
+import type { ConnectionStatus } from '../../sync-types';
+import type { Awareness } from 'y-protocols/awareness';
 import type * as Y from 'yjs';
 
 const MSG_SYNC = 0x00;

--- a/apps/wpcom-gutenberg-rtc/src/providers/pinghub/pinghub-provider.ts
+++ b/apps/wpcom-gutenberg-rtc/src/providers/pinghub/pinghub-provider.ts
@@ -1,7 +1,7 @@
 import { ObservableV2 } from 'lib0/observable';
 import { Awareness } from 'y-protocols/awareness';
 import { pinghubManager } from './pinghub-manager';
-import type { ConnectionStatus, ProviderCreator, ProviderCreatorResult } from '@wordpress/sync';
+import type { ConnectionStatus, ProviderCreator, ProviderCreatorResult } from '../../sync-types';
 import type * as Y from 'yjs';
 
 interface ProviderOptions {

--- a/apps/wpcom-gutenberg-rtc/src/providers/pinghub/pinghub-provider.ts
+++ b/apps/wpcom-gutenberg-rtc/src/providers/pinghub/pinghub-provider.ts
@@ -1,0 +1,163 @@
+import { ObservableV2 } from 'lib0/observable';
+import { Awareness } from 'y-protocols/awareness';
+import { pinghubManager } from './pinghub-manager';
+import type { ConnectionStatus, ProviderCreator, ProviderCreatorResult } from '@wordpress/sync';
+import type * as Y from 'yjs';
+
+interface ProviderOptions {
+	awareness?: Awareness;
+	debug?: boolean;
+	room: string;
+	ydoc: Y.Doc;
+}
+
+type PingHubEvents = {
+	status: ( status: ConnectionStatus ) => void;
+};
+
+/**
+ * Yjs provider that uses PingHub WebSockets for real-time synchronization.
+ * Thin shell that delegates transport, sync protocol, and reconnection to
+ * the shared pinghub-manager module.
+ */
+class PingHubProvider extends ObservableV2< PingHubEvents > {
+	protected readonly awareness: Awareness;
+	protected status: ConnectionStatus[ 'status' ] = 'disconnected';
+	protected synced = false;
+	public constructor( private readonly options: ProviderOptions ) {
+		super();
+		this.log( 'Initializing', { room: options.room } );
+
+		this.awareness = options.awareness ?? new Awareness( options.ydoc );
+		this.connect();
+	}
+
+	/**
+	 * Connect to the endpoint and initialize sync.
+	 */
+	public connect(): void {
+		this.log( 'Connecting' );
+
+		pinghubManager.registerRoom( {
+			room: this.options.room,
+			doc: this.options.ydoc,
+			awareness: this.awareness,
+			onStatusChange: this.emitStatus,
+			onSync: this.onSync,
+		} );
+	}
+
+	/**
+	 * Disconnect the provider and allow reconnection later.
+	 */
+	public disconnect(): void {
+		this.log( 'Disconnecting' );
+
+		pinghubManager.unregisterRoom( this.options.room );
+		this.emitStatus( { status: 'disconnected' } );
+	}
+
+	/**
+	 * Destroy the provider and cleanup resources.
+	 */
+	public override destroy(): void {
+		this.disconnect();
+		super.destroy();
+	}
+
+	/**
+	 * Emit connection status, mirroring HttpPollingProvider semantics:
+	 * - Avoid duplicate emissions for the same status (unless there is an error).
+	 * - Only emit `connecting` when transitioning from `disconnected`.
+	 *
+	 * @param options        - Connection status object.
+	 * @param options.error  - Optional error details.
+	 * @param options.status - New connection status.
+	 */
+	protected emitStatus = ( { error, status }: ConnectionStatus ): void => {
+		if ( this.status === status && ! error ) {
+			return;
+		}
+		if ( status === 'connecting' && this.status !== 'disconnected' ) {
+			return;
+		}
+
+		this.log( 'Status change', { status, error } );
+
+		this.status = status;
+		this.emit( 'status', [ { error, status } ] );
+	};
+
+	/**
+	 * Log debug messages if debugging is enabled.
+	 *
+	 * @param message - Log message.
+	 * @param debug   - Optional debug context.
+	 */
+	protected log = ( message: string, debug: object = {} ): void => {
+		if ( this.options.debug ) {
+			// eslint-disable-next-line no-console
+			console.log( `[${ this.constructor.name }]: ${ message }`, {
+				room: this.options.room,
+				...debug,
+			} );
+		}
+	};
+
+	/**
+	 * Handle synchronization events from the manager.
+	 */
+	protected onSync = (): void => {
+		if ( ! this.synced ) {
+			this.synced = true;
+			this.log( 'Synced' );
+		}
+	};
+}
+
+/**
+ * Build a room name from an object type and ID.
+ *
+ * @param objectType - The type of the object.
+ * @param objectId   - The ID of the object.
+ * @returns The room name (e.g. "postType-post-42").
+ */
+function getRoom( objectType: string, objectId: string | null ): string {
+	const normalizedType = objectType.replaceAll( '/', '-' );
+	const id = objectId ?? 'collection';
+	return `${ normalizedType }-${ id }`;
+}
+
+/**
+ * Create a provider creator function for the PingHubProvider.
+ *
+ * @returns Provider creator compatible with the sync manager.
+ */
+export function createPingHubProvider(): ProviderCreator {
+	return async ( { awareness, objectType, objectId, ydoc } ): Promise< ProviderCreatorResult > => {
+		/**
+		 * Only post-like entities with a concrete ID are supported now.
+		 */
+		const SUPPORTED_OBJECT_TYPES = new Set( [ 'postType/post', 'postType/page' ] );
+		if ( ! SUPPORTED_OBJECT_TYPES.has( objectType ) || ! objectId ) {
+			return {
+				destroy: () => {},
+				on: () => {},
+			};
+		}
+
+		const room = getRoom( objectType, objectId );
+		const provider = new PingHubProvider( {
+			awareness,
+			room,
+			ydoc,
+		} );
+
+		return {
+			destroy: () => provider.destroy(),
+			on: ( event, callback ) => {
+				provider.on( event, callback );
+			},
+		};
+	};
+}

--- a/apps/wpcom-gutenberg-rtc/src/providers/pinghub/pinghub-provider.ts
+++ b/apps/wpcom-gutenberg-rtc/src/providers/pinghub/pinghub-provider.ts
@@ -70,11 +70,12 @@ class PingHubProvider extends ObservableV2< PingHubEvents > {
 	 * - Avoid duplicate emissions for the same status (unless there is an error).
 	 * - Only emit `connecting` when transitioning from `disconnected`.
 	 *
-	 * @param options        - Connection status object.
-	 * @param options.error  - Optional error details.
-	 * @param options.status - New connection status.
+	 * @param connectionStatus - Connection status object.
 	 */
-	protected emitStatus = ( { error, status }: ConnectionStatus ): void => {
+	protected emitStatus = ( connectionStatus: ConnectionStatus ): void => {
+		const error = connectionStatus.status === 'disconnected' ? connectionStatus.error : undefined;
+		const { status } = connectionStatus;
+
 		if ( this.status === status && ! error ) {
 			return;
 		}
@@ -85,7 +86,7 @@ class PingHubProvider extends ObservableV2< PingHubEvents > {
 		this.log( 'Status change', { status, error } );
 
 		this.status = status;
-		this.emit( 'status', [ { error, status } ] );
+		this.emit( 'status', [ connectionStatus ] );
 	};
 
 	/**

--- a/apps/wpcom-gutenberg-rtc/src/sync-types.ts
+++ b/apps/wpcom-gutenberg-rtc/src/sync-types.ts
@@ -1,0 +1,90 @@
+/**
+ * Local type definitions for @wordpress/sync provider types.
+ *
+ * TODO: Remove this file and import directly from '@wordpress/sync' once
+ * we upgrade to @wordpress/sync >= 1.41.0, which exports these types.
+ * The current version (^1.23.0) does not include ProviderCreator,
+ * ProviderCreatorResult, or ConnectionStatus in its public API.
+ *
+ * The upgrade is blocked by `@wordpress/block-editor` 14.18.0, which pins
+ * `@wordpress/sync` to ^1.23.0 and causes a dependency resolution conflict
+ * when a newer version is requested.
+ */
+
+import type { Awareness } from 'y-protocols/awareness';
+import type * as Y from 'yjs';
+
+/**
+ * Connection error codes that can occur in sync providers.
+ */
+export type ConnectionErrorCode =
+	| 'authentication-error'
+	| 'connection-expired'
+	| 'connection-limit-exceeded'
+	| 'unknown-error';
+
+/**
+ * Sync connection error object.
+ */
+export interface ConnectionError extends Error {
+	code: ConnectionErrorCode;
+}
+
+/**
+ * Current connection status of a sync provider.
+ */
+export interface ConnectionStatusConnected {
+	status: 'connected';
+}
+export interface ConnectionStatusConnecting {
+	status: 'connecting';
+}
+export interface ConnectionStatusDisconnected {
+	status: 'disconnected';
+	error?: ConnectionError;
+	retryInMs?: number;
+}
+export type ConnectionStatus =
+	| ConnectionStatusConnected
+	| ConnectionStatusConnecting
+	| ConnectionStatusDisconnected;
+
+/**
+ * Event map for provider events.
+ */
+export interface ProviderEventMap {
+	status: ConnectionStatus;
+}
+
+/**
+ * Generic event listener type for providers.
+ */
+export type ProviderOn = < K extends keyof ProviderEventMap >(
+	event: K,
+	callback: ( data: ProviderEventMap[ K ] ) => void
+) => void;
+
+/**
+ * Result returned by a provider creator function.
+ */
+export interface ProviderCreatorResult {
+	destroy: () => void;
+	on: ProviderOn;
+}
+
+/**
+ * Options passed to a provider creator function.
+ */
+export interface ProviderCreatorOptions {
+	objectType: string;
+	objectId: string | null;
+	ydoc: Y.Doc;
+	awareness?: Awareness;
+}
+
+/**
+ * A function that creates a sync provider for a given entity.
+ */
+export type ProviderCreator = (
+	options: ProviderCreatorOptions
+) => Promise< ProviderCreatorResult >;

--- a/apps/wpcom-gutenberg-rtc/src/types.d.ts
+++ b/apps/wpcom-gutenberg-rtc/src/types.d.ts
@@ -1,0 +1,14 @@
+declare global {
+	interface Window {
+		_currentSiteId?: number;
+		currentBlogId?: number;
+		wpcomGutenberg?: {
+			blogId?: number;
+		};
+		wpcomGutenbergRTC?: {
+			providers: string[];
+		};
+	}
+}
+
+export {};

--- a/apps/wpcom-gutenberg-rtc/tsconfig.json
+++ b/apps/wpcom-gutenberg-rtc/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@automattic/calypso-build/tsconfig",
+	"exclude": [ "node_modules" ],
+	"compilerOptions": {
+		"allowJs": true
+	}
+}

--- a/apps/wpcom-gutenberg-rtc/webpack.config.js
+++ b/apps/wpcom-gutenberg-rtc/webpack.config.js
@@ -1,0 +1,62 @@
+const path = require( 'path' );
+const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );
+const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+const ReadableJsAssetsWebpackPlugin = require( '@wordpress/readable-js-assets-webpack-plugin' );
+const webpack = require( 'webpack' );
+
+const isDevelopment = process.env.NODE_ENV !== 'production';
+
+/**
+ * Return a webpack config object
+ *
+ * @param   {Object}  env                           environment options
+ * @param   {Object}  argv                          options map
+ * @returns {Object}                                webpack config
+ */
+function getWebpackConfig( env = { WP: true }, argv = {} ) {
+	const outputPath = path.join( __dirname, 'dist' );
+	const webpackConfig = getBaseWebpackConfig( env, argv );
+
+	return {
+		...webpackConfig,
+		mode: isDevelopment ? 'development' : 'production',
+		devtool: isDevelopment ? 'inline-cheap-source-map' : 'source-map',
+		entry: {
+			'wpcom-gutenberg-rtc': path.join( __dirname, 'src', 'index.ts' ),
+		},
+		output: {
+			...webpackConfig.output,
+			path: outputPath,
+			filename: '[name].min.js',
+			chunkFilename: '[id].[contenthash:8].min.js',
+		},
+		optimization: {
+			...webpackConfig.optimization,
+			// disable module concatenation so that instances of `__()` are not renamed
+			concatenateModules: false,
+		},
+		plugins: [
+			...webpackConfig.plugins.filter(
+				( plugin ) => plugin.constructor.name !== 'DependencyExtractionWebpackPlugin'
+			),
+			new webpack.DefinePlugin( {
+				'process.env.NODE_DEBUG': JSON.stringify( process.env.NODE_DEBUG || false ),
+			} ),
+			new DependencyExtractionWebpackPlugin( {
+				outputFilename: '[name].asset.json',
+				outputFormat: 'json',
+			} ),
+			new ReadableJsAssetsWebpackPlugin(),
+		],
+		externals: {
+			// Resolve @wordpress/sync to the global `wp.sync` provided by WordPress.
+			'@wordpress/sync': 'wp.sync',
+			// Resolve Yjs to the global `wp.sync.Y` to avoid two separate Yjs
+			// instances, which breaks shared document types. See:
+			// https://github.com/yjs/yjs/issues/438
+			yjs: 'wp.sync.Y',
+		},
+	};
+}
+
+module.exports = getWebpackConfig;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2649,6 +2649,25 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@automattic/wpcom-gutenberg-rtc@workspace:apps/wpcom-gutenberg-rtc":
+  version: 0.0.0-use.local
+  resolution: "@automattic/wpcom-gutenberg-rtc@workspace:apps/wpcom-gutenberg-rtc"
+  dependencies:
+    "@automattic/calypso-apps-builder": "workspace:^"
+    "@automattic/calypso-build": "workspace:^"
+    "@wordpress/dependency-extraction-webpack-plugin": "npm:^6.24.0"
+    "@wordpress/hooks": "npm:^4.23.0"
+    "@wordpress/readable-js-assets-webpack-plugin": "npm:^3.24.0"
+    "@wordpress/sync": "npm:^1.23.0"
+    lib0: "npm:^0.2.117"
+    postcss: "npm:^8.5.3"
+    typescript: "npm:^5.8.3"
+    webpack: "npm:^5.99.8"
+    y-protocols: "npm:^1.0.7"
+    yjs: "npm:^13.6.29"
+  languageName: unknown
+  linkType: soft
+
 "@automattic/wpcom-template-parts@workspace:^, @automattic/wpcom-template-parts@workspace:packages/wpcom-template-parts":
   version: 0.0.0-use.local
   resolution: "@automattic/wpcom-template-parts@workspace:packages/wpcom-template-parts"
@@ -24930,15 +24949,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lib0@npm:^0.2.42, lib0@npm:^0.2.74":
-  version: 0.2.82
-  resolution: "lib0@npm:0.2.82"
+"lib0@npm:^0.2.117, lib0@npm:^0.2.42, lib0@npm:^0.2.74, lib0@npm:^0.2.85, lib0@npm:^0.2.99":
+  version: 0.2.117
+  resolution: "lib0@npm:0.2.117"
   dependencies:
     isomorphic.js: "npm:^0.2.4"
   bin:
+    0ecdsa-generate-keypair: bin/0ecdsa-generate-keypair.js
     0gentesthtml: bin/gentesthtml.js
     0serve: bin/0serve.js
-  checksum: f25d54dc998f968942ead4925c8b8da44c4d1777d32d3ddb73d142f7987d5c4c4e38497331de17a2cf272b7d4a28db58691f5757cebb36074e027178c45bd485
+  checksum: d1b9205890d5d0cbd95ffdb0d6df6f9fd2c315b89e195fc9b015f3778046fb34bc12e94205ccf410a3073b836444045dcef6671fa2f6d5a7f70ebf8b6b0c0616
   languageName: node
   linkType: hard
 
@@ -38661,12 +38681,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"y-protocols@npm:^1.0.5":
-  version: 1.0.5
-  resolution: "y-protocols@npm:1.0.5"
+"y-protocols@npm:^1.0.5, y-protocols@npm:^1.0.7":
+  version: 1.0.7
+  resolution: "y-protocols@npm:1.0.7"
   dependencies:
-    lib0: "npm:^0.2.42"
-  checksum: 6117d6658f3947cbcb8964db771d97f5947086eed2e738e69d67cc823b781b9e6c861973ba0a1d16d672332289cb84582d2d18b1dee6c6ef9d98b6b0bd3f34e1
+    lib0: "npm:^0.2.85"
+  peerDependencies:
+    yjs: ^13.0.0
+  checksum: 70e14ab50b9200e97602c5effc3e14ae4ea0f51479a1628569af7cc12a6739fbc02484335828f5c508a4bf6fa0c3ef5ae1c17e13346b7a6093abeb9627f59021
   languageName: node
   linkType: hard
 
@@ -38814,12 +38836,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yjs@npm:~13.6.6":
-  version: 13.6.7
-  resolution: "yjs@npm:13.6.7"
+"yjs@npm:^13.6.29, yjs@npm:~13.6.6":
+  version: 13.6.29
+  resolution: "yjs@npm:13.6.29"
   dependencies:
-    lib0: "npm:^0.2.74"
-  checksum: fd2cdcafa0c558f41ac5e16e82295e51b0084248c9339f512f2f293bc613fd03e99fe41376fcb180683c93b35841c41342e1c078fc5128dde683f7ac2a9a23d7
+    lib0: "npm:^0.2.99"
+  checksum: f300786ea63deac8a83e85598707ab9542e0a90b72fc0a1bcc77a58e618799de531ba4f85bcf349e647ad9e72bc4186edf50c4ecf67c8144cd53d3ac80d27351
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2658,7 +2658,7 @@ __metadata:
     "@wordpress/dependency-extraction-webpack-plugin": "npm:^6.24.0"
     "@wordpress/hooks": "npm:^4.23.0"
     "@wordpress/readable-js-assets-webpack-plugin": "npm:^3.24.0"
-    "@wordpress/sync": "npm:^1.23.0"
+    "@wordpress/sync": "npm:^1.41.0"
     lib0: "npm:^0.2.117"
     postcss: "npm:^8.5.3"
     typescript: "npm:^5.8.3"
@@ -10804,15 +10804,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/simple-peer@npm:^9.11.5":
-  version: 9.11.8
-  resolution: "@types/simple-peer@npm:9.11.8"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: ef55b05fb2d12ed790d8e3b46d96bb84224c67bbcdfb6a867d14129ffc77f7b3edbf66b1eb5e737953d1f1b2ce9928f3505fe29061bfb048016616beaf866ef8
-  languageName: node
-  linkType: hard
-
 "@types/smooch@npm:^5.3.7":
   version: 5.3.7
   resolution: "@types/smooch@npm:5.3.7"
@@ -13138,21 +13129,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/sync@npm:^1.23.0":
-  version: 1.23.0
-  resolution: "@wordpress/sync@npm:1.23.0"
+"@wordpress/sync@npm:^1.23.0, @wordpress/sync@npm:^1.41.0":
+  version: 1.41.0
+  resolution: "@wordpress/sync@npm:1.41.0"
   dependencies:
-    "@babel/runtime": "npm:7.25.7"
-    "@types/simple-peer": "npm:^9.11.5"
-    "@wordpress/url": "npm:^4.23.0"
-    import-locals: "npm:^2.0.0"
-    lib0: "npm:^0.2.42"
-    simple-peer: "npm:^9.11.0"
-    y-indexeddb: "npm:~9.0.11"
-    y-protocols: "npm:^1.0.5"
-    y-webrtc: "npm:~10.2.5"
-    yjs: "npm:~13.6.6"
-  checksum: 1376273090f8a5c1ae883115834ec5b1e5b1e91fdeaa7d0d74eec1c2d9c46cefd6fe7db48238c2900561ac2537eeae1726573b841f6308b9246844f01ac3c7b0
+    "@wordpress/api-fetch": "npm:^7.41.0"
+    "@wordpress/hooks": "npm:^4.41.0"
+    "@wordpress/private-apis": "npm:^1.41.0"
+    "@wordpress/undo-manager": "npm:^1.41.0"
+    diff: "npm:^8.0.3"
+    fast-deep-equal: "npm:^3.1.3"
+    lib0: "npm:0.2.99"
+    y-protocols: "npm:^1.0.7"
+    yjs: "npm:13.6.29"
+  checksum: 63f432ad80e1421fb926f9489934d8065d4f907c97d10cac39c84716487a7fb5a11668905481df4cd9158dbc9df80ec8dc480db2c97cd2615e643101144e0ae6
   languageName: node
   linkType: hard
 
@@ -13204,13 +13194,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/undo-manager@npm:^1.23.0":
-  version: 1.23.0
-  resolution: "@wordpress/undo-manager@npm:1.23.0"
+"@wordpress/undo-manager@npm:^1.23.0, @wordpress/undo-manager@npm:^1.41.0":
+  version: 1.41.0
+  resolution: "@wordpress/undo-manager@npm:1.41.0"
   dependencies:
-    "@babel/runtime": "npm:7.25.7"
-    "@wordpress/is-shallow-equal": "npm:^5.23.0"
-  checksum: 0aadf230c2dc0dccdc7aa7bd4c0ee415132335277aa4fd939f81bc53670280b1b490bee34a58e08174b38f4927e0b23176e08da78322ae0ac96ee365b4f7ce44
+    "@wordpress/is-shallow-equal": "npm:^5.41.0"
+  checksum: a242564710623ec834c63f2773f3dcc8b5aa7a505b2d87c70e499d67d56642ab32c27ecc9fdd0a89843247caeff44d9fe6fb036605b5b54e620dcaf860f71f43
   languageName: node
   linkType: hard
 
@@ -18217,6 +18206,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"diff@npm:^8.0.3":
+  version: 8.0.3
+  resolution: "diff@npm:8.0.3"
+  checksum: d29321c70d3545fdcb56c5fdd76028c3f04c012462779e062303d4c3c531af80d2c360c26b871e6e2b9a971d2422d47e1779a859106c4cac4b5d2d143df70e20
+  languageName: node
+  linkType: hard
+
 "dir-compare@npm:^2.4.0":
   version: 2.4.0
   resolution: "dir-compare@npm:2.4.0"
@@ -18991,13 +18987,6 @@ __metadata:
   version: 2.0.3
   resolution: "err-code@npm:2.0.3"
   checksum: b642f7b4dd4a376e954947550a3065a9ece6733ab8e51ad80db727aaae0817c2e99b02a97a3d6cecc648a97848305e728289cf312d09af395403a90c9d4d8a66
-  languageName: node
-  linkType: hard
-
-"err-code@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "err-code@npm:3.0.1"
-  checksum: 78b1c50500adebde6699b8d27b8ce4728c132dcaad75b5d18ba44f6ccb28769d1fff8368ae1164be4559dac8b95d4e26bb15b480ba9999e0cd0f0c64beaf1b24
   languageName: node
   linkType: hard
 
@@ -21192,13 +21181,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-browser-rtc@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "get-browser-rtc@npm:1.1.0"
-  checksum: ec59dab0e1a79ebcbc7da4bb5bef2e96d6728c1bf3707ef2d7124f9e1f64bc7678c16adb96dc8dbb8dddeefea4cf8d5175cd94f9c4931230cc0f8ae9c5dd2a2d
-  languageName: node
-  linkType: hard
-
 "get-caller-file@npm:^2.0.1, get-caller-file@npm:^2.0.5":
   version: 2.0.5
   resolution: "get-caller-file@npm:2.0.5"
@@ -22784,13 +22766,6 @@ __metadata:
   bin:
     import-local-fixture: fixtures/cli.js
   checksum: 593ec592c5c2c0849f94b81198077b53e342f02bd7a7cc3f8a3dd5b52f40a37003b3b2922a80b4e7b565c0f7c951a41849a03852c4e68144fff84bf892d129cb
-  languageName: node
-  linkType: hard
-
-"import-locals@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "import-locals@npm:2.0.0"
-  checksum: b576b794fca1e596c76ed371a4d99bd18bd967a85d33eb00544ad79bd18ff9f1a42ccd9d0af13fd74e2a0ccbdbf6f63cce3fe4d20f1591828bf52a3058fcbb83
   languageName: node
   linkType: hard
 
@@ -24949,7 +24924,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lib0@npm:^0.2.117, lib0@npm:^0.2.42, lib0@npm:^0.2.74, lib0@npm:^0.2.85, lib0@npm:^0.2.99":
+"lib0@npm:0.2.99":
+  version: 0.2.99
+  resolution: "lib0@npm:0.2.99"
+  dependencies:
+    isomorphic.js: "npm:^0.2.4"
+  bin:
+    0ecdsa-generate-keypair: bin/0ecdsa-generate-keypair.js
+    0gentesthtml: bin/gentesthtml.js
+    0serve: bin/0serve.js
+  checksum: 24f914e5ab025a3e647396a22dcdb748754a9ce9eb1b98ac9a51e4a25d589c4382c82dda8330252c77f2755288097ccb3654e34eb03b1ae957422f8ebeae04d2
+  languageName: node
+  linkType: hard
+
+"lib0@npm:^0.2.117, lib0@npm:^0.2.85, lib0@npm:^0.2.99":
   version: 0.2.117
   resolution: "lib0@npm:0.2.117"
   dependencies:
@@ -30850,13 +30838,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"queue-microtask@npm:^1.2.3":
-  version: 1.2.3
-  resolution: "queue-microtask@npm:1.2.3"
-  checksum: 900a93d3cdae3acd7d16f642c29a642aea32c2026446151f0778c62ac089d4b8e6c986811076e1ae180a694cedf077d453a11b58ff0a865629a4f82ab558e102
-  languageName: node
-  linkType: hard
-
 "queue@npm:6.0.2":
   version: 6.0.2
   resolution: "queue@npm:6.0.2"
@@ -34331,21 +34312,6 @@ __metadata:
   version: 0.5.9
   resolution: "simple-html-tokenizer@npm:0.5.9"
   checksum: 6fa24dd3a532292dc34ea80bb7e20deeca14079bae1031d50fc18ea5e493c63d48f9958a32cf449e6ddd79d6e3f3cabfe890472af69eb5f99c1795e2c36e933b
-  languageName: node
-  linkType: hard
-
-"simple-peer@npm:^9.11.0":
-  version: 9.11.1
-  resolution: "simple-peer@npm:9.11.1"
-  dependencies:
-    buffer: "npm:^6.0.3"
-    debug: "npm:^4.3.2"
-    err-code: "npm:^3.0.1"
-    get-browser-rtc: "npm:^1.1.0"
-    queue-microtask: "npm:^1.2.3"
-    randombytes: "npm:^2.1.0"
-    readable-stream: "npm:^3.6.0"
-  checksum: 69089d2977ededc7e193754169dc92ad0b7d83aac2883d7cfe51b0c40bd589dec0ab8bfcecb9205c37bed5f589e5275fd64bffff43069d4b35c69bdca02283c8
   languageName: node
   linkType: hard
 
@@ -38576,7 +38542,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^7.2.0, ws@npm:^7.3.1, ws@npm:^7.5.10":
+"ws@npm:^7.3.1, ws@npm:^7.5.10":
   version: 7.5.10
   resolution: "ws@npm:7.5.10"
   peerDependencies:
@@ -38670,18 +38636,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"y-indexeddb@npm:~9.0.11":
-  version: 9.0.11
-  resolution: "y-indexeddb@npm:9.0.11"
-  dependencies:
-    lib0: "npm:^0.2.74"
-  peerDependencies:
-    yjs: ^13.0.0
-  checksum: 2968254276535daa476048a51056942019a92746507146b7322cf577a02aaca047aa81a54121832a2233c48c8c0bd53bdb28050ef60dc8164e54160190f2b22c
-  languageName: node
-  linkType: hard
-
-"y-protocols@npm:^1.0.5, y-protocols@npm:^1.0.7":
+"y-protocols@npm:^1.0.7":
   version: 1.0.7
   resolution: "y-protocols@npm:1.0.7"
   dependencies:
@@ -38689,23 +38644,6 @@ __metadata:
   peerDependencies:
     yjs: ^13.0.0
   checksum: 70e14ab50b9200e97602c5effc3e14ae4ea0f51479a1628569af7cc12a6739fbc02484335828f5c508a4bf6fa0c3ef5ae1c17e13346b7a6093abeb9627f59021
-  languageName: node
-  linkType: hard
-
-"y-webrtc@npm:~10.2.5":
-  version: 10.2.5
-  resolution: "y-webrtc@npm:10.2.5"
-  dependencies:
-    lib0: "npm:^0.2.42"
-    simple-peer: "npm:^9.11.0"
-    ws: "npm:^7.2.0"
-    y-protocols: "npm:^1.0.5"
-  dependenciesMeta:
-    ws:
-      optional: true
-  bin:
-    y-webrtc-signaling: bin/server.js
-  checksum: 8590dcc5a69be704b3c7373d4bbb97572369689eb7338351cd38a99ee14f2befc6afed322b8f4c9b15bec6203354d0dab78c9fd133442042e4d9d028aaec445c
   languageName: node
   linkType: hard
 
@@ -38836,7 +38774,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yjs@npm:^13.6.29, yjs@npm:~13.6.6":
+"yjs@npm:13.6.29, yjs@npm:^13.6.29":
   version: 13.6.29
   resolution: "yjs@npm:13.6.29"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2658,7 +2658,7 @@ __metadata:
     "@wordpress/dependency-extraction-webpack-plugin": "npm:^6.24.0"
     "@wordpress/hooks": "npm:^4.23.0"
     "@wordpress/readable-js-assets-webpack-plugin": "npm:^3.24.0"
-    "@wordpress/sync": "npm:^1.41.0"
+    "@wordpress/sync": "npm:^1.23.0"
     lib0: "npm:^0.2.117"
     postcss: "npm:^8.5.3"
     typescript: "npm:^5.8.3"
@@ -10804,6 +10804,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/simple-peer@npm:^9.11.5":
+  version: 9.11.9
+  resolution: "@types/simple-peer@npm:9.11.9"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 90583cd3440524da1fb6e1b58827bf1c0bf56d6dd08d591fa30b2ac6af048b826f55b82fcbe147ac99fdc821c7a14f3158ad8d79c08f18316902a4ef65c63db2
+  languageName: node
+  linkType: hard
+
 "@types/smooch@npm:^5.3.7":
   version: 5.3.7
   resolution: "@types/smooch@npm:5.3.7"
@@ -13129,20 +13138,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/sync@npm:^1.23.0, @wordpress/sync@npm:^1.41.0":
-  version: 1.41.0
-  resolution: "@wordpress/sync@npm:1.41.0"
+"@wordpress/sync@npm:^1.23.0":
+  version: 1.23.0
+  resolution: "@wordpress/sync@npm:1.23.0"
   dependencies:
-    "@wordpress/api-fetch": "npm:^7.41.0"
-    "@wordpress/hooks": "npm:^4.41.0"
-    "@wordpress/private-apis": "npm:^1.41.0"
-    "@wordpress/undo-manager": "npm:^1.41.0"
-    diff: "npm:^8.0.3"
-    fast-deep-equal: "npm:^3.1.3"
-    lib0: "npm:0.2.99"
-    y-protocols: "npm:^1.0.7"
-    yjs: "npm:13.6.29"
-  checksum: 63f432ad80e1421fb926f9489934d8065d4f907c97d10cac39c84716487a7fb5a11668905481df4cd9158dbc9df80ec8dc480db2c97cd2615e643101144e0ae6
+    "@babel/runtime": "npm:7.25.7"
+    "@types/simple-peer": "npm:^9.11.5"
+    "@wordpress/url": "npm:^4.23.0"
+    import-locals: "npm:^2.0.0"
+    lib0: "npm:^0.2.42"
+    simple-peer: "npm:^9.11.0"
+    y-indexeddb: "npm:~9.0.11"
+    y-protocols: "npm:^1.0.5"
+    y-webrtc: "npm:~10.2.5"
+    yjs: "npm:~13.6.6"
+  checksum: 1376273090f8a5c1ae883115834ec5b1e5b1e91fdeaa7d0d74eec1c2d9c46cefd6fe7db48238c2900561ac2537eeae1726573b841f6308b9246844f01ac3c7b0
   languageName: node
   linkType: hard
 
@@ -13194,7 +13204,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/undo-manager@npm:^1.23.0, @wordpress/undo-manager@npm:^1.41.0":
+"@wordpress/undo-manager@npm:^1.23.0":
   version: 1.41.0
   resolution: "@wordpress/undo-manager@npm:1.41.0"
   dependencies:
@@ -18206,13 +18216,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"diff@npm:^8.0.3":
-  version: 8.0.3
-  resolution: "diff@npm:8.0.3"
-  checksum: d29321c70d3545fdcb56c5fdd76028c3f04c012462779e062303d4c3c531af80d2c360c26b871e6e2b9a971d2422d47e1779a859106c4cac4b5d2d143df70e20
-  languageName: node
-  linkType: hard
-
 "dir-compare@npm:^2.4.0":
   version: 2.4.0
   resolution: "dir-compare@npm:2.4.0"
@@ -18987,6 +18990,13 @@ __metadata:
   version: 2.0.3
   resolution: "err-code@npm:2.0.3"
   checksum: b642f7b4dd4a376e954947550a3065a9ece6733ab8e51ad80db727aaae0817c2e99b02a97a3d6cecc648a97848305e728289cf312d09af395403a90c9d4d8a66
+  languageName: node
+  linkType: hard
+
+"err-code@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "err-code@npm:3.0.1"
+  checksum: 78b1c50500adebde6699b8d27b8ce4728c132dcaad75b5d18ba44f6ccb28769d1fff8368ae1164be4559dac8b95d4e26bb15b480ba9999e0cd0f0c64beaf1b24
   languageName: node
   linkType: hard
 
@@ -21181,6 +21191,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-browser-rtc@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "get-browser-rtc@npm:1.1.0"
+  checksum: ec59dab0e1a79ebcbc7da4bb5bef2e96d6728c1bf3707ef2d7124f9e1f64bc7678c16adb96dc8dbb8dddeefea4cf8d5175cd94f9c4931230cc0f8ae9c5dd2a2d
+  languageName: node
+  linkType: hard
+
 "get-caller-file@npm:^2.0.1, get-caller-file@npm:^2.0.5":
   version: 2.0.5
   resolution: "get-caller-file@npm:2.0.5"
@@ -22766,6 +22783,13 @@ __metadata:
   bin:
     import-local-fixture: fixtures/cli.js
   checksum: 593ec592c5c2c0849f94b81198077b53e342f02bd7a7cc3f8a3dd5b52f40a37003b3b2922a80b4e7b565c0f7c951a41849a03852c4e68144fff84bf892d129cb
+  languageName: node
+  linkType: hard
+
+"import-locals@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "import-locals@npm:2.0.0"
+  checksum: b576b794fca1e596c76ed371a4d99bd18bd967a85d33eb00544ad79bd18ff9f1a42ccd9d0af13fd74e2a0ccbdbf6f63cce3fe4d20f1591828bf52a3058fcbb83
   languageName: node
   linkType: hard
 
@@ -24924,20 +24948,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lib0@npm:0.2.99":
-  version: 0.2.99
-  resolution: "lib0@npm:0.2.99"
-  dependencies:
-    isomorphic.js: "npm:^0.2.4"
-  bin:
-    0ecdsa-generate-keypair: bin/0ecdsa-generate-keypair.js
-    0gentesthtml: bin/gentesthtml.js
-    0serve: bin/0serve.js
-  checksum: 24f914e5ab025a3e647396a22dcdb748754a9ce9eb1b98ac9a51e4a25d589c4382c82dda8330252c77f2755288097ccb3654e34eb03b1ae957422f8ebeae04d2
-  languageName: node
-  linkType: hard
-
-"lib0@npm:^0.2.117, lib0@npm:^0.2.85, lib0@npm:^0.2.99":
+"lib0@npm:^0.2.117, lib0@npm:^0.2.42, lib0@npm:^0.2.74, lib0@npm:^0.2.85, lib0@npm:^0.2.99":
   version: 0.2.117
   resolution: "lib0@npm:0.2.117"
   dependencies:
@@ -30838,6 +30849,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"queue-microtask@npm:^1.2.3":
+  version: 1.2.3
+  resolution: "queue-microtask@npm:1.2.3"
+  checksum: 900a93d3cdae3acd7d16f642c29a642aea32c2026446151f0778c62ac089d4b8e6c986811076e1ae180a694cedf077d453a11b58ff0a865629a4f82ab558e102
+  languageName: node
+  linkType: hard
+
 "queue@npm:6.0.2":
   version: 6.0.2
   resolution: "queue@npm:6.0.2"
@@ -34312,6 +34330,21 @@ __metadata:
   version: 0.5.9
   resolution: "simple-html-tokenizer@npm:0.5.9"
   checksum: 6fa24dd3a532292dc34ea80bb7e20deeca14079bae1031d50fc18ea5e493c63d48f9958a32cf449e6ddd79d6e3f3cabfe890472af69eb5f99c1795e2c36e933b
+  languageName: node
+  linkType: hard
+
+"simple-peer@npm:^9.11.0":
+  version: 9.11.1
+  resolution: "simple-peer@npm:9.11.1"
+  dependencies:
+    buffer: "npm:^6.0.3"
+    debug: "npm:^4.3.2"
+    err-code: "npm:^3.0.1"
+    get-browser-rtc: "npm:^1.1.0"
+    queue-microtask: "npm:^1.2.3"
+    randombytes: "npm:^2.1.0"
+    readable-stream: "npm:^3.6.0"
+  checksum: 69089d2977ededc7e193754169dc92ad0b7d83aac2883d7cfe51b0c40bd589dec0ab8bfcecb9205c37bed5f589e5275fd64bffff43069d4b35c69bdca02283c8
   languageName: node
   linkType: hard
 
@@ -38557,9 +38590,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.11.0, ws@npm:^8.13.0, ws@npm:^8.2.3":
-  version: 8.18.1
-  resolution: "ws@npm:8.18.1"
+"ws@npm:^8.11.0, ws@npm:^8.13.0, ws@npm:^8.14.2, ws@npm:^8.2.3":
+  version: 8.19.0
+  resolution: "ws@npm:8.19.0"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -38568,7 +38601,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: e498965d6938c63058c4310ffb6967f07d4fa06789d3364829028af380d299fe05762961742971c764973dce3d1f6a2633fe8b2d9410c9b52e534b4b882a99fa
+  checksum: 4741d9b9bc3f9c791880882414f96e36b8b254e34d4b503279d6400d9a4b87a033834856dbdd94ee4b637944df17ea8afc4bce0ff4a1560d2166be8855da5b04
   languageName: node
   linkType: hard
 
@@ -38636,7 +38669,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"y-protocols@npm:^1.0.7":
+"y-indexeddb@npm:~9.0.11":
+  version: 9.0.12
+  resolution: "y-indexeddb@npm:9.0.12"
+  dependencies:
+    lib0: "npm:^0.2.74"
+  peerDependencies:
+    yjs: ^13.0.0
+  checksum: b31fbc12ef4a7d71f09212db02570af07c6a17b02537ce4cbb29f0549137adcbebf613cb2af63fa1d13e0932645be0293a4e7189cb5bf5dc6263cf2f72b65004
+  languageName: node
+  linkType: hard
+
+"y-protocols@npm:^1.0.5, y-protocols@npm:^1.0.6, y-protocols@npm:^1.0.7":
   version: 1.0.7
   resolution: "y-protocols@npm:1.0.7"
   dependencies:
@@ -38644,6 +38688,25 @@ __metadata:
   peerDependencies:
     yjs: ^13.0.0
   checksum: 70e14ab50b9200e97602c5effc3e14ae4ea0f51479a1628569af7cc12a6739fbc02484335828f5c508a4bf6fa0c3ef5ae1c17e13346b7a6093abeb9627f59021
+  languageName: node
+  linkType: hard
+
+"y-webrtc@npm:~10.2.5":
+  version: 10.2.6
+  resolution: "y-webrtc@npm:10.2.6"
+  dependencies:
+    lib0: "npm:^0.2.42"
+    simple-peer: "npm:^9.11.0"
+    ws: "npm:^8.14.2"
+    y-protocols: "npm:^1.0.6"
+  peerDependencies:
+    yjs: ^13.6.8
+  dependenciesMeta:
+    ws:
+      optional: true
+  bin:
+    y-webrtc-signaling: bin/server.js
+  checksum: 47284dccab2f8e16db03e2201d47f96b32a7427c72a19f9b21f5dee7d45047817a9faee4c7b3c6a7475f9127223f83a7606edbf60ebdce5a79be4648fc1521c9
   languageName: node
   linkType: hard
 
@@ -38774,7 +38837,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yjs@npm:13.6.29, yjs@npm:^13.6.29":
+"yjs@npm:^13.6.29, yjs@npm:~13.6.6":
   version: 13.6.29
   resolution: "yjs@npm:13.6.29"
   dependencies:


### PR DESCRIPTION
Part of DOTCOM-16207

## Proposed Changes

- Introduce `apps/wpcom-gutenberg-rtc`, a new Calypso app that provides a PingHub WebSocket-based real-time collaboration provider for the Gutenberg editor.
- Moves the gutenberg-rtc source from `jetpack-mu-wpcom` into its own Calypso app, built and deployed to `widgets.wp.com/wpcom-gutenberg-rtc/`.
- Configures webpack to externalize `@wordpress/sync` → `wp.sync` and `yjs` → `wp.sync.Y` to avoid duplicate Yjs instances.
- Inlines the keepalive worker via a Blob URL to avoid cross-origin Worker restrictions (the script is served from `widgets.wp.com` but runs on the site's own origin).

## Why are these changes being made?

PingHub authenticates via cookies scoped to `public-api.wordpress.com`. The Gutenberg editor runs on a different origin (the site's own domain for Atomic sites, or `*.wordpress.com` for Simple sites), so it cannot directly open a WebSocket to PingHub. By deploying the RTC bundle as a Calypso app to `widgets.wp.com`, we can use the existing REST proxy iframe bridge pattern to handle auth — the parent page's origin doesn't matter.

## Testing Instructions

0. Apply https://github.com/Automattic/jetpack/pull/47535 to your sandbox to your sandbox
1. Sandbox `widgets.wp.com` and your simple site
2. Run `cd apps/wpcom-gutenberg-rtc && yarn dev --sync`.
3. Add following code to enable the feature on your sandbox
    ```php
    // mu-plugins/0-sandbox.php
    add_filter( 'wpcom_is_gutenberg_rtc_enabled', '__return_true' );
   ```
4. Go to WP Admin > Settings > Writing to enable RTC
5. Edit a post
6. Check the network request, switch to Socket tab
7. Ensure there is a connection to `postType-post-$postId`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?