### PR TITLE
Calypso apps: Build wpcom-gutenberg-rtc on teamcity

### DIFF
--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -44,6 +44,7 @@ object WPComPlugins : Project({
 					"help-center-release-build",
 					"agents-manager-release-build",
 					"design-system-docs-release-build",
+					"wpcom-gutenberg-rtc-release-build",
 				)
 			}
 			dataToKeep = everything()
@@ -127,6 +128,7 @@ object CalypsoApps: BuildType({
 		apps/help-center/dist => help-center.zip
 		apps/agents-manager/dist => agents-manager.zip
 		apps/design-system-docs/dist => design-system-docs.zip
+		apps/wpcom-gutenberg-rtc/dist => wpcom-gutenberg-rtc.zip
 	""".trimIndent()
 
 	steps {


### PR DESCRIPTION
Part of DOTCOM-16207

## Proposed Changes

- Add `wpcom-gutenberg-rtc` to the TeamCity build configuration in `WPComPlugins.kt`.
- Add artifact rule to collect `apps/wpcom-gutenberg-rtc/dist` as a release zip.
- Add `wpcom-gutenberg-rtc-release-build` tag to the cleanup keep rule so release builds are preserved.

No build step changes are needed — the existing build step auto-discovers apps with a `teamcity:build-app` script.

## Why are these changes being made?

The new `wpcom-gutenberg-rtc` app (introduced in #109167) needs to be built and deployed via TeamCity like other Calypso apps.

## Testing Instructions

1. Verify the TeamCity build runs successfully and produces a `wpcom-gutenberg-rtc.zip` artifact.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?