### PR TITLE
wpcom-gutenberg-rtc: Fix external yjs dependency

### DIFF
--- a/apps/wpcom-gutenberg-rtc/webpack.config.js
+++ b/apps/wpcom-gutenberg-rtc/webpack.config.js
@@ -50,11 +50,13 @@ function getWebpackConfig( env = { WP: true }, argv = {} ) {
 		],
 		externals: {
 			// Resolve @wordpress/sync to the global `wp.sync` provided by WordPress.
-			'@wordpress/sync': 'wp.sync',
+			// Array format is required for nested property access (dot-separated
+			// strings are treated as a single variable name by webpack).
+			'@wordpress/sync': [ 'wp', 'sync' ],
 			// Resolve Yjs to the global `wp.sync.Y` to avoid two separate Yjs
 			// instances, which breaks shared document types. See:
 			// https://github.com/yjs/yjs/issues/438
-			yjs: 'wp.sync.Y',
+			yjs: [ 'wp', 'sync', 'Y' ],
 		},
 	};
 }


### PR DESCRIPTION
Part of DOTCOM-16207

## Proposed Changes

- Fix webpack externals for `yjs` and `@wordpress/sync` by switching from dot-separated strings to array format. Otherwise, you will see following error
  ```
  Uncaught TypeError: Cannot read properties of undefined (reading 'encodeStateVector')
  ```

## Why are these changes being made?

Webpack treats dot-separated string externals (e.g. `'wp.sync.Y'`) as a single variable name (`window['wp.sync.Y']`), not as a property chain. This caused `Y` to be `undefined` at runtime, breaking `y-protocols/sync` calls like `encodeStateVector`.

The array format (`['wp', 'sync', 'Y']`) produces proper chained property access (`window.wp.sync.Y`), correctly resolving to the Yjs instance exposed by WordPress's `@wordpress/sync` package.

## Testing Instructions

1. Sandbox `widgets.wp.com`.
2. Run `cd apps/wpcom-gutenberg-rtc && yarn dev --sync`.
3. Visit a simple site with the RTC enabled.
4. Edit page/post — verify no `Cannot read properties of undefined` errors in the console.
5. Open the same post in a second tab and verify real-time sync works.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?