### PR TITLE
Partner Branding: detect partner from client_id and remove oauth2_redirect check

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -981,7 +981,7 @@ export default connect(
 			oauth2Client,
 			isFromAutomatticForAgenciesPlugin:
 				'automattic-for-agencies-client' === get( getCurrentQueryArguments( state ), 'from' ),
-			allowedSocialServices: getPartnerAllowedSocialServices(),
+			allowedSocialServices: getPartnerAllowedSocialServices( oauth2Client ),
 			isWooJPC: isWooJPCFlow( state ),
 			isWoo: getIsWoo( state ),
 			redirectTo: getRedirectToOriginal( state ),

--- a/client/lib/oauth2-clients.js
+++ b/client/lib/oauth2-clients.js
@@ -73,3 +73,8 @@ export const isPartnerPortalOAuth2Client = ( oauth2Client ) => {
 export const isVIPOAuth2Client = ( oauth2Client ) => {
 	return oauth2Client?.id === 76596;
 };
+
+export const isCiabOAuth2Client = ( oauth2Client ) => {
+	// 134404 => CIAB Dev, 134405 => CIAB Staging/Production.
+	return oauth2Client && [ 134404, 134405 ].includes( oauth2Client.id );
+};

--- a/client/lib/partner-branding.tsx
+++ b/client/lib/partner-branding.tsx
@@ -44,6 +44,8 @@ export interface CiabPartnerConfig {
 	fontStyle?: 'system';
 	/** Domains that identify this partner in redirect URLs (e.g., ['my.woo.ai']) */
 	domains?: string[];
+	/** OAuth2 client IDs that identify this partner */
+	clientIds?: number[];
 }
 
 /**
@@ -75,6 +77,7 @@ export const CIAB_PARTNERS: Record< string, CiabPartnerConfig > = {
 		ssoProviders: [ 'paypal', 'google', 'apple', 'magic-login' ],
 		fontStyle: 'system',
 		domains: [ 'my.woo.ai', 'my.woo.localhost' ],
+		clientIds: [ 134404, 134405 ], // 134404 = Dev, 134405 = Staging/Production
 	},
 };
 
@@ -233,6 +236,38 @@ export function getCiabConfigFromRedirectUrl(
 }
 
 /**
+ * Get CIAB partner config by matching a client_id query parameter against partner client IDs.
+ */
+export function getCiabConfigFromClientId(): CiabPartnerConfig | null {
+	if ( typeof window === 'undefined' ) {
+		return null;
+	}
+
+	const params = new URLSearchParams( window.location.search );
+	const clientIdParam = params.get( 'client_id' );
+
+	if ( ! clientIdParam ) {
+		return null;
+	}
+
+	const clientId = Number( clientIdParam );
+
+	if ( Number.isNaN( clientId ) ) {
+		return null;
+	}
+
+	for ( const partnerConfig of Object.values( CIAB_PARTNERS ) ) {
+		if ( partnerConfig.clientIds?.includes( clientId ) ) {
+			if ( config.isEnabled( partnerConfig.featureFlag ) ) {
+				return partnerConfig;
+			}
+		}
+	}
+
+	return null;
+}
+
+/**
  * Read a query parameter from the current URL.
  */
 function getSearchParam( name: string ): string | null {
@@ -250,16 +285,16 @@ function getSearchParam( name: string ): string | null {
  * Detection precedence (first match wins):
  *   1. hostname           — window.location.hostname against partner domains
  *   2. branding code      — ?from= query param (transitional, see getCiabConfigFromBrandingCode)
- *   3. redirect_to        — hostname inside ?redirect_to= URL
- *   4. oauth2_redirect    — hostname inside ?oauth2_redirect= URL
+ *   3. client_id          — ?client_id= query param matched against partner OAuth2 client IDs
+ *   4. redirect_to        — hostname inside ?redirect_to= URL
  *   5. session storage    — persisted partner from a previous detection in this session
  */
 export function detectCiabConfig(): CiabPartnerConfig | null {
 	const detected =
 		getCiabConfigFromCurrentDomain() ??
 		getCiabConfigFromBrandingCode() ??
-		getCiabConfigFromRedirectUrl( getSearchParam( 'redirect_to' ) ) ??
-		getCiabConfigFromRedirectUrl( getSearchParam( 'oauth2_redirect' ) );
+		getCiabConfigFromClientId() ??
+		getCiabConfigFromRedirectUrl( getSearchParam( 'redirect_to' ) );
 
 	if ( detected ) {
 		persistCiabPartnerId( detected.id );
@@ -337,7 +372,7 @@ export function usePartnerBranding(): UsePartnerBrandingResult {
 	const initialQuery = useSelector( getInitialQueryArguments );
 	const from = currentQuery?.from || initialQuery?.from;
 	const redirectTo = currentQuery?.redirect_to || initialQuery?.redirect_to;
-	const oauth2Redirect = currentQuery?.oauth2_redirect || initialQuery?.oauth2_redirect;
+	const clientId = currentQuery?.client_id || initialQuery?.client_id;
 
 	return useMemo( () => {
 		const ciabConfig = detectCiabConfig();
@@ -364,7 +399,7 @@ export function usePartnerBranding(): UsePartnerBrandingResult {
 			topBarLogo,
 			signupTosElement,
 		};
-	}, [ from, redirectTo, oauth2Redirect, translate ] );
+	}, [ from, redirectTo, clientId, translate ] );
 }
 
 /**

--- a/client/lib/partner-branding.tsx
+++ b/client/lib/partner-branding.tsx
@@ -5,7 +5,9 @@ import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import wooLogo from 'calypso/assets/images/icons/Woo_logo_color.svg';
+import { isCiabOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { useSelector } from 'calypso/state';
+import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 import type {
@@ -44,8 +46,8 @@ export interface CiabPartnerConfig {
 	fontStyle?: 'system';
 	/** Domains that identify this partner in redirect URLs (e.g., ['my.woo.ai']) */
 	domains?: string[];
-	/** OAuth2 client IDs that identify this partner */
-	clientIds?: number[];
+	/** Callback to check if an OAuth2 client belongs to this partner */
+	isOAuth2Client?: ( oauth2Client: { id: number } | null ) => boolean;
 }
 
 /**
@@ -77,7 +79,7 @@ export const CIAB_PARTNERS: Record< string, CiabPartnerConfig > = {
 		ssoProviders: [ 'paypal', 'google', 'apple', 'magic-login' ],
 		fontStyle: 'system',
 		domains: [ 'my.woo.ai', 'my.woo.localhost' ],
-		clientIds: [ 134404, 134405 ], // 134404 = Dev, 134405 = Staging/Production
+		isOAuth2Client: isCiabOAuth2Client,
 	},
 };
 
@@ -236,28 +238,17 @@ export function getCiabConfigFromRedirectUrl(
 }
 
 /**
- * Get CIAB partner config by matching a client_id query parameter against partner client IDs.
+ * Get CIAB partner config by matching an OAuth2 client (from Redux store) against partner configs.
  */
-export function getCiabConfigFromClientId(): CiabPartnerConfig | null {
-	if ( typeof window === 'undefined' ) {
-		return null;
-	}
-
-	const params = new URLSearchParams( window.location.search );
-	const clientIdParam = params.get( 'client_id' );
-
-	if ( ! clientIdParam ) {
-		return null;
-	}
-
-	const clientId = Number( clientIdParam );
-
-	if ( Number.isNaN( clientId ) ) {
+export function getCiabConfigFromOAuth2Client(
+	oauth2Client: { id: number } | null | undefined
+): CiabPartnerConfig | null {
+	if ( ! oauth2Client ) {
 		return null;
 	}
 
 	for ( const partnerConfig of Object.values( CIAB_PARTNERS ) ) {
-		if ( partnerConfig.clientIds?.includes( clientId ) ) {
+		if ( partnerConfig.isOAuth2Client?.( oauth2Client ) ) {
 			if ( config.isEnabled( partnerConfig.featureFlag ) ) {
 				return partnerConfig;
 			}
@@ -280,20 +271,21 @@ function getSearchParam( name: string ): string | null {
 /**
  * Detect CIAB partner config from globally available values.
  *
- * Callers should NOT pass values — the detector reads from window.location internally.
+ * The oauth2Client parameter comes from Redux (getCurrentOAuth2Client).
+ * Other detection sources read from window.location internally.
  *
  * Detection precedence (first match wins):
  *   1. hostname           — window.location.hostname against partner domains
  *   2. branding code      — ?from= query param (transitional, see getCiabConfigFromBrandingCode)
- *   3. client_id          — ?client_id= query param matched against partner OAuth2 client IDs
+ *   3. OAuth2 client      — current OAuth2 client from Redux store matched against partner configs
  *   4. redirect_to        — hostname inside ?redirect_to= URL
  *   5. session storage    — persisted partner from a previous detection in this session
  */
-export function detectCiabConfig(): CiabPartnerConfig | null {
+export function detectCiabConfig( oauth2Client?: { id: number } | null ): CiabPartnerConfig | null {
 	const detected =
 		getCiabConfigFromCurrentDomain() ??
 		getCiabConfigFromBrandingCode() ??
-		getCiabConfigFromClientId() ??
+		getCiabConfigFromOAuth2Client( oauth2Client ) ??
 		getCiabConfigFromRedirectUrl( getSearchParam( 'redirect_to' ) );
 
 	if ( detected ) {
@@ -324,8 +316,10 @@ export function detectCiabConfig(): CiabPartnerConfig | null {
  * Returns the array of allowed SSO providers or null if no restrictions apply.
  * @returns Array of allowed service names (e.g., ['paypal', 'google', 'apple']) or null
  */
-export function getPartnerAllowedSocialServices(): AllowedSocialService[] | null {
-	const ciabConfig = detectCiabConfig();
+export function getPartnerAllowedSocialServices(
+	oauth2Client?: { id: number } | null
+): AllowedSocialService[] | null {
+	const ciabConfig = detectCiabConfig( oauth2Client );
 	return ciabConfig?.ssoProviders ?? null;
 }
 
@@ -372,10 +366,10 @@ export function usePartnerBranding(): UsePartnerBrandingResult {
 	const initialQuery = useSelector( getInitialQueryArguments );
 	const from = currentQuery?.from || initialQuery?.from;
 	const redirectTo = currentQuery?.redirect_to || initialQuery?.redirect_to;
-	const clientId = currentQuery?.client_id || initialQuery?.client_id;
+	const oauth2Client = useSelector( getCurrentOAuth2Client );
 
 	return useMemo( () => {
-		const ciabConfig = detectCiabConfig();
+		const ciabConfig = detectCiabConfig( oauth2Client );
 		const hasCustomBranding = ciabConfig !== null;
 
 		// Build logo element for TopBar
@@ -399,7 +393,7 @@ export function usePartnerBranding(): UsePartnerBrandingResult {
 			topBarLogo,
 			signupTosElement,
 		};
-	}, [ from, redirectTo, clientId, translate ] );
+	}, [ from, redirectTo, oauth2Client, translate ] );
 }
 
 /**

--- a/client/lib/test/partner-branding.tsx
+++ b/client/lib/test/partner-branding.tsx
@@ -5,7 +5,7 @@ import config from '@automattic/calypso-config';
 import {
 	getCiabConfigFromCurrentDomain,
 	getCiabConfigFromBrandingCode,
-	getCiabConfigFromClientId,
+	getCiabConfigFromOAuth2Client,
 	getCiabConfigFromRedirectUrl,
 	getCiabConfigFromGarden,
 	detectCiabConfig,
@@ -154,54 +154,43 @@ describe( 'partner-branding', () => {
 		} );
 	} );
 
-	describe( 'getCiabConfigFromClientId', () => {
-		test( 'returns partner config when client_id matches dev ID', () => {
-			setLocation( 'wordpress.com', '?client_id=134404' );
-
-			const result = getCiabConfigFromClientId();
+	describe( 'getCiabConfigFromOAuth2Client', () => {
+		test( 'returns partner config when oauth2Client matches dev ID', () => {
+			const result = getCiabConfigFromOAuth2Client( { id: 134404 } );
 
 			expect( result ).not.toBeNull();
 			expect( result?.id ).toBe( 'woo' );
 		} );
 
-		test( 'returns partner config when client_id matches production ID', () => {
-			setLocation( 'wordpress.com', '?client_id=134405' );
-
-			const result = getCiabConfigFromClientId();
+		test( 'returns partner config when oauth2Client matches production ID', () => {
+			const result = getCiabConfigFromOAuth2Client( { id: 134405 } );
 
 			expect( result ).not.toBeNull();
 			expect( result?.id ).toBe( 'woo' );
 		} );
 
-		test( 'returns null when client_id does not match any partner', () => {
-			setLocation( 'wordpress.com', '?client_id=99999' );
-
-			const result = getCiabConfigFromClientId();
+		test( 'returns null when oauth2Client does not match any partner', () => {
+			const result = getCiabConfigFromOAuth2Client( { id: 99999 } );
 
 			expect( result ).toBeNull();
 		} );
 
-		test( 'returns null when client_id is absent', () => {
-			setLocation( 'wordpress.com' );
-
-			const result = getCiabConfigFromClientId();
+		test( 'returns null when oauth2Client is null', () => {
+			const result = getCiabConfigFromOAuth2Client( null );
 
 			expect( result ).toBeNull();
 		} );
 
-		test( 'returns null when client_id is not a number', () => {
-			setLocation( 'wordpress.com', '?client_id=abc' );
-
-			const result = getCiabConfigFromClientId();
+		test( 'returns null when oauth2Client is undefined', () => {
+			const result = getCiabConfigFromOAuth2Client( undefined );
 
 			expect( result ).toBeNull();
 		} );
 
 		test( 'returns null when feature flag is disabled', () => {
 			( config.isEnabled as jest.Mock ).mockReturnValue( false );
-			setLocation( 'wordpress.com', '?client_id=134404' );
 
-			const result = getCiabConfigFromClientId();
+			const result = getCiabConfigFromOAuth2Client( { id: 134404 } );
 
 			expect( result ).toBeNull();
 		} );
@@ -244,28 +233,28 @@ describe( 'partner-branding', () => {
 			expect( result?.id ).toBe( 'woo' );
 		} );
 
-		test( 'from wins over client_id when conflicting', () => {
-			setLocation( 'wordpress.com', '?from=woo&client_id=99999' );
+		test( 'from wins over oauth2Client when conflicting', () => {
+			setLocation( 'wordpress.com', '?from=woo' );
 
-			const result = detectCiabConfig();
-
-			expect( result ).not.toBeNull();
-			expect( result?.id ).toBe( 'woo' );
-		} );
-
-		test( 'client_id matching still works when no hostname or from match', () => {
-			setLocation( 'wordpress.com', '?client_id=134404' );
-
-			const result = detectCiabConfig();
+			const result = detectCiabConfig( { id: 99999 } );
 
 			expect( result ).not.toBeNull();
 			expect( result?.id ).toBe( 'woo' );
 		} );
 
-		test( 'client_id wins over redirect_to when conflicting', () => {
-			setLocation( 'wordpress.com', '?client_id=134405&redirect_to=https://example.com' );
+		test( 'oauth2Client matching still works when no hostname or from match', () => {
+			setLocation( 'wordpress.com' );
 
-			const result = detectCiabConfig();
+			const result = detectCiabConfig( { id: 134404 } );
+
+			expect( result ).not.toBeNull();
+			expect( result?.id ).toBe( 'woo' );
+		} );
+
+		test( 'oauth2Client wins over redirect_to when conflicting', () => {
+			setLocation( 'wordpress.com', '?redirect_to=https://example.com' );
+
+			const result = detectCiabConfig( { id: 134405 } );
 
 			expect( result ).not.toBeNull();
 			expect( result?.id ).toBe( 'woo' );

--- a/client/lib/test/partner-branding.tsx
+++ b/client/lib/test/partner-branding.tsx
@@ -5,6 +5,7 @@ import config from '@automattic/calypso-config';
 import {
 	getCiabConfigFromCurrentDomain,
 	getCiabConfigFromBrandingCode,
+	getCiabConfigFromClientId,
 	getCiabConfigFromRedirectUrl,
 	getCiabConfigFromGarden,
 	detectCiabConfig,
@@ -153,6 +154,59 @@ describe( 'partner-branding', () => {
 		} );
 	} );
 
+	describe( 'getCiabConfigFromClientId', () => {
+		test( 'returns partner config when client_id matches dev ID', () => {
+			setLocation( 'wordpress.com', '?client_id=134404' );
+
+			const result = getCiabConfigFromClientId();
+
+			expect( result ).not.toBeNull();
+			expect( result?.id ).toBe( 'woo' );
+		} );
+
+		test( 'returns partner config when client_id matches production ID', () => {
+			setLocation( 'wordpress.com', '?client_id=134405' );
+
+			const result = getCiabConfigFromClientId();
+
+			expect( result ).not.toBeNull();
+			expect( result?.id ).toBe( 'woo' );
+		} );
+
+		test( 'returns null when client_id does not match any partner', () => {
+			setLocation( 'wordpress.com', '?client_id=99999' );
+
+			const result = getCiabConfigFromClientId();
+
+			expect( result ).toBeNull();
+		} );
+
+		test( 'returns null when client_id is absent', () => {
+			setLocation( 'wordpress.com' );
+
+			const result = getCiabConfigFromClientId();
+
+			expect( result ).toBeNull();
+		} );
+
+		test( 'returns null when client_id is not a number', () => {
+			setLocation( 'wordpress.com', '?client_id=abc' );
+
+			const result = getCiabConfigFromClientId();
+
+			expect( result ).toBeNull();
+		} );
+
+		test( 'returns null when feature flag is disabled', () => {
+			( config.isEnabled as jest.Mock ).mockReturnValue( false );
+			setLocation( 'wordpress.com', '?client_id=134404' );
+
+			const result = getCiabConfigFromClientId();
+
+			expect( result ).toBeNull();
+		} );
+	} );
+
 	describe( 'detectCiabConfig — precedence', () => {
 		test( 'hostname wins over conflicting from query param', () => {
 			setLocation( 'my.woo.ai', '?from=other' );
@@ -190,8 +244,26 @@ describe( 'partner-branding', () => {
 			expect( result?.id ).toBe( 'woo' );
 		} );
 
-		test( 'from wins over oauth2_redirect when conflicting', () => {
-			setLocation( 'wordpress.com', '?from=woo&oauth2_redirect=https://example.com' );
+		test( 'from wins over client_id when conflicting', () => {
+			setLocation( 'wordpress.com', '?from=woo&client_id=99999' );
+
+			const result = detectCiabConfig();
+
+			expect( result ).not.toBeNull();
+			expect( result?.id ).toBe( 'woo' );
+		} );
+
+		test( 'client_id matching still works when no hostname or from match', () => {
+			setLocation( 'wordpress.com', '?client_id=134404' );
+
+			const result = detectCiabConfig();
+
+			expect( result ).not.toBeNull();
+			expect( result?.id ).toBe( 'woo' );
+		} );
+
+		test( 'client_id wins over redirect_to when conflicting', () => {
+			setLocation( 'wordpress.com', '?client_id=134405&redirect_to=https://example.com' );
 
 			const result = detectCiabConfig();
 
@@ -201,27 +273,6 @@ describe( 'partner-branding', () => {
 
 		test( 'redirect_to matching still works when no hostname or from match', () => {
 			setLocation( 'wordpress.com', '?redirect_to=https://my.woo.ai/dashboard' );
-
-			const result = detectCiabConfig();
-
-			expect( result ).not.toBeNull();
-			expect( result?.id ).toBe( 'woo' );
-		} );
-
-		test( 'oauth2_redirect matching still works when nothing else matches', () => {
-			setLocation( 'wordpress.com', '?oauth2_redirect=https://my.woo.ai/dashboard' );
-
-			const result = detectCiabConfig();
-
-			expect( result ).not.toBeNull();
-			expect( result?.id ).toBe( 'woo' );
-		} );
-
-		test( 'redirect_to wins over oauth2_redirect when conflicting', () => {
-			setLocation(
-				'wordpress.com',
-				'?redirect_to=https://my.woo.ai&oauth2_redirect=https://example.com'
-			);
 
 			const result = detectCiabConfig();
 

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -396,7 +396,7 @@ const mapState = ( state ) => {
 			'jetpack-onboarding',
 		isWooJPC: isWooJPCFlow( state ),
 		publicToken: getMagicLoginPublicToken( state ),
-		ciabConfig: detectCiabConfig(),
+		ciabConfig: detectCiabConfig( getCurrentOAuth2Client( state ) ),
 	};
 };
 

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -494,7 +494,7 @@ export default connect(
 				'automattic-for-agencies-client' === get( getCurrentQueryArguments( state ), 'from' ) ||
 				'automattic-for-agencies-client' ===
 					new URLSearchParams( getRedirectToOriginal( state )?.split( '?' )[ 1 ] ).get( 'from' ),
-			ciabConfig: detectCiabConfig(),
+			ciabConfig: detectCiabConfig( oauth2Client ),
 			isManualRenewalImmediateLoginAttempt: wasManualRenewalImmediateLoginAttempted( state ),
 			isUserLoggedIn: isUserLoggedIn( state ),
 			isWooPaymentsFlow: isWooCommercePaymentsOnboardingFlow( state ),

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -560,7 +560,7 @@ export class UserStep extends Component {
 			}
 		}
 
-		const allowedSocialServices = getPartnerAllowedSocialServices();
+		const allowedSocialServices = getPartnerAllowedSocialServices( this.props.oauth2Client );
 
 		return (
 			<>

--- a/client/state/oauth2-clients/reducer.js
+++ b/client/state/oauth2-clients/reducer.js
@@ -144,6 +144,18 @@ export const initialClientsData = {
 		title: 'Blaze Pro',
 		url: 'https://blazepro.tumblr.com',
 	},
+	134404: {
+		id: 134404,
+		name: 'ciab',
+		title: 'CIAB by Woo',
+		url: 'https://my.woo.ai',
+	},
+	134405: {
+		id: 134405,
+		name: 'ciab',
+		title: 'CIAB by Woo',
+		url: 'https://my.woo.ai',
+	},
 };
 
 export function clients( state = initialClientsData, action ) {

--- a/client/state/oauth2-clients/selectors.js
+++ b/client/state/oauth2-clients/selectors.js
@@ -4,7 +4,7 @@ import 'calypso/state/oauth2-clients/init';
  * Gets the OAuth2 client data.
  * @param  {Object}   state  Global state tree
  * @param  {number} clientId OAuth2 Client ID
- * @returns {{ title: string; icon: string; name: string; } | null} OAuth2 client data
+ * @returns {{ id: number; title: string; icon: string; name: string; } | null} OAuth2 client data
  */
 export const getOAuth2Client = ( state, clientId ) => {
 	return state?.oauth2Clients?.clients?.[ clientId ] ?? null;

--- a/client/state/oauth2-clients/ui/selectors.js
+++ b/client/state/oauth2-clients/ui/selectors.js
@@ -14,7 +14,7 @@ export function getCurrentOAuth2ClientId( state ) {
 /**
  * Gets the OAuth2 client data.
  * @param  {Object}   state  Global state tree
- * @returns {{ title: string; icon: string; name: string; } | null} OAuth2 client data
+ * @returns {{ id: number; title: string; icon: string; name: string; } | null} OAuth2 client data
  */
 export const getCurrentOAuth2Client = ( state ) => {
 	const currentClientId = getCurrentOAuth2ClientId( state );


### PR DESCRIPTION
## Summary
 - Register CIAB OAuth2 client IDs (134404, 134405) in `client/state/oauth2-clients/reducer.js`
 - Add `isCiabOAuth2Client()` helper to `client/lib/oauth2-clients.js`, following the existing pattern for Woo, Jetpack Cloud, A4A, etc.
 - Refactor `getCiabConfigFromClientId()` → `getCiabConfigFromOAuth2Client()` to accept the Redux oauth2Client object instead of parsing `?client_id=` from the URL directly
 - Thread the oauth2Client from Redux state through `detectCiabConfig()`, `getPartnerAllowedSocialServices()`, `usePartnerBranding()`, and all callsites
 - Remove `oauth2_redirect` URL parameter from the detection chain

## Test plan
- [ ] Visit login/signup with `?client_id=134404` and verify Woo branding appears
- [ ] Visit login/signup with `?client_id=134405` and verify Woo branding appears
- [ ] Verify `?oauth2_redirect=` no longer triggers partner branding
- [ ] Verify existing detection methods (hostname, `?from=`, `?redirect_to=`, session storage) still work