### PR TITLE
Update `@types/smooch`

### DIFF
--- a/packages/help-center/package.json
+++ b/packages/help-center/package.json
@@ -65,7 +65,7 @@
 	"devDependencies": {
 		"@automattic/calypso-color-schemes": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"@types/smooch": "^5.3.7",
+		"@types/smooch": "^5.6.0",
 		"postcss": "^8.5.3",
 		"typescript": "^5.8.3"
 	},

--- a/packages/help-center/src/components/help-center-smooch.tsx
+++ b/packages/help-center/src/components/help-center-smooch.tsx
@@ -165,7 +165,6 @@ const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } )
 			if ( message?.source?.type === 'web' && message.source?.id ) {
 				setZendeskClientId( message.source?.id );
 				// Unregister the listener after setting the client ID
-				// @ts-expect-error -- 'off' is not part of the def.
 				Smooch?.off?.( 'message:sent', clientIdListener );
 			}
 		},
@@ -250,19 +249,12 @@ const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } )
 		}
 
 		return () => {
-			// @ts-expect-error -- 'off' is not part of the def.
 			Smooch?.off?.( 'message:received', getUnreadListener );
-			// @ts-expect-error -- 'off' is not part of the def.
 			Smooch?.off?.( 'message:sent', clientIdListener );
-			// @ts-expect-error -- 'off' is not part of the def.
 			Smooch?.off?.( 'disconnected', disconnectedListener );
-			// @ts-expect-error -- 'off' is not part of the def.
 			Smooch?.off?.( 'reconnecting', reconnectingListener );
-			// @ts-expect-error -- 'off' is not part of the def.
 			Smooch?.off?.( 'connected', connectedListener );
-			// @ts-expect-error -- 'off' is not part of the def.
 			Smooch?.off?.( 'typing:stop', typingStopListener );
-			// @ts-expect-error -- 'off' is not part of the def.
 			Smooch?.off?.( 'typing:start', typingStartListener );
 		};
 	}, [

--- a/packages/odie-client/package.json
+++ b/packages/odie-client/package.json
@@ -69,7 +69,7 @@
 		"@types/autosize": "^4.0.3",
 		"@types/jest": "^29.5.14",
 		"@types/react": "^18.3.23",
-		"@types/smooch": "^5.3.7",
+		"@types/smooch": "^5.6.0",
 		"jest": "^29.7.0",
 		"typescript": "^5.8.3"
 	}

--- a/packages/odie-client/src/hooks/use-zendesk-message-listener.ts
+++ b/packages/odie-client/src/hooks/use-zendesk-message-listener.ts
@@ -54,7 +54,6 @@ export const useZendeskMessageListener = () => {
 		Smooch.on( 'message:received', messageListener );
 
 		return () => {
-			// @ts-expect-error -- 'off' is not part of the def.
 			Smooch?.off?.( 'message:received', messageListener );
 		};
 	}, [ isChatLoaded, messageListener ] );

--- a/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
+++ b/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
@@ -354,17 +354,11 @@ export const useManagedZendeskChat = () => {
 			Smooch.on( 'typing:stop', typingStopListener );
 
 			return () => {
-				// @ts-expect-error -- 'off' is not part of the def.
 				Smooch.off?.( 'message:received', getUnreadListener );
-				// @ts-expect-error -- 'off' is not part of the def.
 				Smooch.off?.( 'disconnected', disconnectedListener );
-				// @ts-expect-error -- 'off' is not part of the def.
 				Smooch.off?.( 'reconnecting', reconnectingListener );
-				// @ts-expect-error -- 'off' is not part of the def.
 				Smooch.off?.( 'connected', connectedListener );
-				// @ts-expect-error -- 'off' is not part of the def.
 				Smooch.off?.( 'typing:stop', typingStopListener );
-				// @ts-expect-error -- 'off' is not part of the def.
 				Smooch.off?.( 'typing:start', typingStartListener );
 			};
 		}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1551,7 +1551,7 @@ __metadata:
     "@automattic/zendesk-client": "workspace:^"
     "@popperjs/core": "npm:^2.11.8"
     "@tanstack/react-query": "npm:^5.83.0"
-    "@types/smooch": "npm:^5.3.7"
+    "@types/smooch": "npm:^5.6.0"
     "@wordpress/base-styles": "npm:^5.23.0"
     "@wordpress/components": "npm:^32.1.0"
     "@wordpress/i18n": "npm:^5.23.0"
@@ -1946,7 +1946,7 @@ __metadata:
     "@types/autosize": "npm:^4.0.3"
     "@types/jest": "npm:^29.5.14"
     "@types/react": "npm:^18.3.23"
-    "@types/smooch": "npm:^5.3.7"
+    "@types/smooch": "npm:^5.6.0"
     "@wordpress/api-fetch": "npm:7.23.0"
     "@wordpress/data": "npm:^10.23.0"
     "@wordpress/element": "npm:^6.23.0"
@@ -10813,10 +10813,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/smooch@npm:^5.3.7":
-  version: 5.3.7
-  resolution: "@types/smooch@npm:5.3.7"
-  checksum: b37b0a50037933e4b2313b0e1f0a31df1c9d8a033ff994eb7342720596a9941745a9b6fd1012ab58f828397a5e76d493d818eeb1bfb6576453021afbfc0bf115
+"@types/smooch@npm:^5.6.0":
+  version: 5.6.0
+  resolution: "@types/smooch@npm:5.6.0"
+  checksum: b6c68651df64ba314e07f6c69fb2daaec64de15d8b66a17630e29c43b17e8582678e7a827a1c2c3e05f86503f234a2e98489985ce791f0c03b04ecff821eca77
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-16284

## Proposed Changes

* Update `@types/smooch` after I added the `off` method on https://github.com/DefinitelyTyped/DefinitelyTyped/pull/74641

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
