### PR TITLE
Theme Showcase: Limit fresh themes section to query.number

### DIFF
--- a/client/my-sites/themes/collections/use-theme-collection.ts
+++ b/client/my-sites/themes/collections/use-theme-collection.ts
@@ -23,8 +23,9 @@ export interface ThemesQuery {
 }
 
 export function useThemeCollection( query: ThemesQuery ) {
-	const themes =
+	const allThemes =
 		useSelector( ( state ) => getThemesForQueryIgnoringPage( state, 'wpcom', query ) ) || [];
+	const themes = query.number ? allThemes.slice( 0, query.number ) : allThemes;
 
 	const siteId = useSelector( getSelectedSiteId );
 


### PR DESCRIPTION
Fixes DOTTHEM-326

## Proposed Changes

* Slice the themes array in `useThemeCollection` to respect `query.number`, ensuring sections like "Fresh themes" always display at most 6 themes.

## Why are these changes being made?

The `getThemesForQueryIgnoringPage` selector aggregates themes across all pages for a given query shape. After navigating the showcase (e.g., browsing "See all"), more themes accumulate in Redux state. Returning to the home page, the "Fresh themes" section would then show all accumulated themes instead of the intended 6.

## Testing Instructions

* Navigate to the logged-out Theme Showcase home page.
* Verify the "Fresh themes" section shows 6 themes.
* Click "See all" to browse more themes, then navigate back to the home page.
* Verify the "Fresh themes" section still shows only 6 themes.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?