### PR TITLE
Magic login: hide Jetpack app promo for branded flows

### DIFF
--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -165,9 +165,10 @@ export class MagicLogin extends Component {
 
 		const isA4A = query?.redirect_to?.includes( 'agencies.automattic.com/client' ) ?? false;
 		const isMobileApp = isIosOAuth2Client( oauth2Client ) || isAndroidOAuth2Client( oauth2Client );
+		const hasPartnerBranding = Boolean( this.props.ciabConfig );
 
 		if ( showCheckYourEmail ) {
-			if ( isA4A || isMobileApp ) {
+			if ( isA4A || isMobileApp || hasPartnerBranding ) {
 				return null;
 			}
 			return (
@@ -214,7 +215,7 @@ export class MagicLogin extends Component {
 						</a>
 					}
 				/>
-				{ ! oauth2Client && ! isMobileApp && (
+				{ ! oauth2Client && ! isMobileApp && ! hasPartnerBranding && (
 					<AppPromo
 						title={ translate( 'Stay logged in with the Jetpack Mobile App' ) }
 						campaign="calypso-login-link"

--- a/client/login/magic-login/test/index.test.jsx
+++ b/client/login/magic-login/test/index.test.jsx
@@ -98,4 +98,31 @@ describe( 'magic-login branding behavior', () => {
 			} )
 		);
 	} );
+
+	it( 'hides the app promo in check-your-email when partner branding is enabled', () => {
+		const instance = new MagicLogin( {
+			...baseProps,
+			showCheckYourEmail: true,
+			ciabConfig: { id: 'woo', displayName: 'Woo' },
+		} );
+
+		expect( instance.renderLinks() ).toBeNull();
+	} );
+
+	it( 'shows the app promo in check-your-email when partner branding is not enabled', () => {
+		const instance = new MagicLogin( {
+			...baseProps,
+			showCheckYourEmail: true,
+			ciabConfig: null,
+		} );
+
+		expect( instance.renderLinks() ).toEqual(
+			expect.objectContaining( {
+				props: expect.objectContaining( {
+					campaign: 'calypso-login-link-check-email',
+					className: 'magic-link-app-promo',
+				} ),
+			} )
+		);
+	} );
 } );


### PR DESCRIPTION
Part of ARC-1607

## Proposed Changes

* Hide the Jetpack App promo widget in magic login when partner branding is active (`Boolean( ciabConfig )`), including both promo render paths in `renderLinks()`.
* Keep existing exclusions for A4A and mobile/oauth app paths unchanged.
* Add unit tests for check-your-email behavior to verify the promo is hidden when partner branding exists and shown when it does not.

## Why are these changes being made?

* ARC-1607 requires partner-branded login experiences to avoid showing the generic Jetpack App promo widget.

## Testing Instructions

* Run `yarn test-client client/login/magic-login/test/index.test.jsx` and confirm all tests pass.

Manual testing:

* Go to `calypso.localhost:3000/log-in/link?from=woo`
* Check that there is no Jetpack App widget
<img width="3006" height="1598" alt="image" src="https://github.com/user-attachments/assets/1902a658-ec41-4484-9449-42665845fbda" />



## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?