### PR TITLE
CIAB: Replace PayPal references with WooPayments in plans comparison

### DIFF
--- a/packages/calypso-products/src/feature-group-plan-map.ts
+++ b/packages/calypso-products/src/feature-group-plan-map.ts
@@ -485,7 +485,11 @@ export const featureGroups: Partial< FeatureGroupMap > = {
 	},
 	[ FEATURE_GROUP_WOO_HOSTED_PAYMENTS ]: {
 		slug: FEATURE_GROUP_WOO_HOSTED_PAYMENTS,
-		getTitle: () => i18n.translate( 'Accept payments with PayPal' ),
+		getTitle: () =>
+			i18n.getLocaleSlug()?.startsWith( 'en' ) ||
+			i18n.hasTranslation( 'Accept payments with WooPayments' )
+				? i18n.translate( 'Accept payments with WooPayments' )
+				: i18n.translate( 'Accept payments with PayPal' ),
 		getFeatures: () => [
 			FEATURE_WOO_HOSTED_SEAMLESS_CHECKOUT,
 			FEATURE_WOO_HOSTED_ACCEPT_CARD_PAYMENTS,

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1661,7 +1661,7 @@ const getWooHostedPlanCompareFeatures = (): string[] => [
 	FEATURE_WOO_HOSTED_AI_BUILDER,
 	FEATURE_WOO_HOSTED_CSV_IMPORTER,
 	FEATURE_WOO_HOSTED_FREE_DOMAIN_1_YEAR,
-	// Accept payments with PayPal
+	// Accept payments with WooPayments
 	FEATURE_WOO_HOSTED_SEAMLESS_CHECKOUT,
 	FEATURE_WOO_HOSTED_ACCEPT_CARD_PAYMENTS,
 	// Sell products and bookable services


### PR DESCRIPTION
Part of SHILL-1719

## Proposed Changes

* Replace "Accept payments with PayPal" with "Accept payments with WooPayments" in the CIAB plans detailed comparison table header
* Update the corresponding comment in `plans-list.tsx`
* Use `hasTranslation()` to gracefully fall back to the old PayPal string until WooPayments translations are ready for non-English locales

## Why are these changes being made?

The CIAB plans comparison table incorrectly references PayPal instead of WooPayments. This fixes the detailed comparison table header text.

The summary table PayPal copy change is handled separately in a companion PR.

## Testing Instructions

* Open the CIAB plans page for a commerce garden site from https://my.wordpress.com/sites (or create a new one)
    * http://calypso.localhost:3000/setup/woo-hosted-plans/plans?siteSlug={site_slug}
* Scroll to the detailed comparison table
* Verify the section header reads "Accept payments with WooPayments" instead of "Accept payments with PayPal"
* Switch to a non-English locale and verify it falls back to the PayPal string if the WooPayments translation isn't available yet

## Screenshot
<img width="1429" height="838" alt="Screenshot 2026-03-11 at 12 35 09 PM" src="https://github.com/user-attachments/assets/844f5639-8ce1-4446-a90a-9846b47e3079" />


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?