### PR TITLE
Partner Branding: add CIAB consent copy to login ToS (ARC-1608)

### DIFF
--- a/client/lib/partner-branding.tsx
+++ b/client/lib/partner-branding.tsx
@@ -403,7 +403,7 @@ export function getPartnerSignupTosElement(
 		case 'woo':
 			return createInterpolateElement(
 				translate(
-					'Just a little reminder that by continuing with any of the options below, you agree to our <tosLink>Terms of Service</tosLink> and <privacyLink>Privacy Policy</privacyLink>.'
+					'Just a little reminder that by continuing with any of the options below, you agree to our <tosLink>Terms of Service</tosLink> and <privacyLink>Privacy Policy</privacyLink>. WordPress.com is used to manage your account.'
 				),
 				linkComponents
 			);

--- a/client/lib/test/partner-branding.tsx
+++ b/client/lib/test/partner-branding.tsx
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import config from '@automattic/calypso-config';
+import { render, screen } from '@testing-library/react';
 import {
 	getCiabConfigFromCurrentDomain,
 	getCiabConfigFromBrandingCode,
@@ -343,6 +344,8 @@ describe( 'partner-branding', () => {
 			const tosElement = getPartnerSignupTosElement( CIAB_PARTNERS.woo, mockTranslate );
 
 			expect( tosElement ).toBeDefined();
+			render( <>{ tosElement }</> );
+			expect( screen.getByText( /WordPress.com is used to manage your account\./ ) ).toBeVisible();
 		} );
 
 		test( 'returns undefined when no partner config is provided', () => {

--- a/client/login/wp-login/hooks/get-heading-subtext.tsx
+++ b/client/login/wp-login/hooks/get-heading-subtext.tsx
@@ -1,11 +1,13 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { type LocalizeProps } from 'i18n-calypso';
+import type { CiabPartnerConfig } from 'calypso/lib/partner-branding';
 
 interface Props {
 	isSocialFirst: boolean;
 	twoFactorAuthType: string;
 	action?: string;
 	isWooJPC?: boolean;
+	ciabConfig?: CiabPartnerConfig | null;
 	translate: LocalizeProps[ 'translate' ];
 }
 
@@ -18,6 +20,7 @@ const getHeadingSubText = ( {
 	action,
 	translate,
 	isWooJPC,
+	ciabConfig,
 }: Props ) => {
 	if ( ! isSocialFirst || twoFactorAuthType ) {
 		return null;
@@ -25,27 +28,49 @@ const getHeadingSubText = ( {
 
 	const tos = (
 		<span className="wp-login__one-login-layout-tos">
-			{ translate(
-				'By continuing with any of the options below, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
-				{
-					components: {
-						tosLink: (
-							<a
-								href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-								target="_blank"
-								rel="noopener noreferrer"
-							/>
-						),
-						privacyLink: (
-							<a
-								href={ localizeUrl( 'https://automattic.com/privacy/' ) }
-								target="_blank"
-								rel="noopener noreferrer"
-							/>
-						),
-					},
-				}
-			) }
+			{ ciabConfig
+				? translate(
+						'By continuing with any of the options below, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}. WordPress.com is used to manage your account.',
+						{
+							components: {
+								tosLink: (
+									<a
+										href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+								privacyLink: (
+									<a
+										href={ localizeUrl( 'https://automattic.com/privacy/' ) }
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+							},
+						}
+				  )
+				: translate(
+						'By continuing with any of the options below, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+						{
+							components: {
+								tosLink: (
+									<a
+										href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+								privacyLink: (
+									<a
+										href={ localizeUrl( 'https://automattic.com/privacy/' ) }
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+							},
+						}
+				  ) }
 		</span>
 	);
 

--- a/client/login/wp-login/hooks/test/get-heading-subtext.test.tsx
+++ b/client/login/wp-login/hooks/test/get-heading-subtext.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react';
+import getHeadingSubText from '../get-heading-subtext';
+
+describe( 'getHeadingSubText', () => {
+	const translate = ( text: string ) => text;
+
+	test( 'appends partner consent copy when ToS is primary', () => {
+		const subtext = getHeadingSubText( {
+			isSocialFirst: true,
+			twoFactorAuthType: '',
+			action: 'login',
+			translate,
+			isWooJPC: false,
+			ciabConfig: {
+				id: 'woo',
+				displayName: 'Woo',
+				featureFlag: 'ciab/custom-branding',
+				logo: { src: 'logo.svg', alt: 'Woo' },
+				ssoProviders: [ 'google' ],
+			},
+		} );
+
+		render( <>{ subtext?.primary }</> );
+
+		expect( screen.getByText( /WordPress.com is used to manage your account\./ ) ).toBeVisible();
+	} );
+
+	test( 'appends partner consent copy when ToS is secondary', () => {
+		const subtext = getHeadingSubText( {
+			isSocialFirst: true,
+			twoFactorAuthType: '',
+			action: 'login',
+			translate,
+			isWooJPC: true,
+			ciabConfig: {
+				id: 'woo',
+				displayName: 'Woo',
+				featureFlag: 'ciab/custom-branding',
+				logo: { src: 'logo.svg', alt: 'Woo' },
+				ssoProviders: [ 'google' ],
+			},
+		} );
+
+		render( <>{ subtext?.secondary }</> );
+
+		expect( screen.getByText( /WordPress.com is used to manage your account\./ ) ).toBeVisible();
+	} );
+} );

--- a/client/login/wp-login/hooks/test/get-heading-subtext.test.tsx
+++ b/client/login/wp-login/hooks/test/get-heading-subtext.test.tsx
@@ -3,10 +3,11 @@
  */
 
 import { render, screen } from '@testing-library/react';
+import { useTranslate } from 'i18n-calypso';
 import getHeadingSubText from '../get-heading-subtext';
 
 describe( 'getHeadingSubText', () => {
-	const translate = ( text: string ) => text;
+	const translate = ( ( text ) => text ) as ReturnType< typeof useTranslate >;
 
 	test( 'appends partner consent copy when ToS is primary', () => {
 		const subtext = getHeadingSubText( {

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -423,6 +423,7 @@ function getInitialHeadingState( props, translate ) {
 		action,
 		translate,
 		isWooJPC,
+		ciabConfig,
 	} );
 
 	return {


### PR DESCRIPTION
Part of ARC-1608

## Proposed Changes

* Add the partner consent sentence to the Woo partner ToS copy in partner branding.
* Pass `ciabConfig` into login heading subtext so partner login screens include the same consent copy.
* Add and update unit tests to cover the new consent copy behavior in both partner branding and login heading subtext.

## Why are these changes being made?

* ARC-1608 requires explicit consent language to clarify that WordPress.com manages the account for partner-branded login flows.

## Testing Instructions

* Run `yarn test-client client/lib/test/partner-branding.tsx`.
* Run `yarn test-client client/login/wp-login/hooks/test/get-heading-subtext.test.tsx`.
* Verify the Woo partner login flow shows: "WordPress.com is used to manage your account." in the ToS text.

<img width="3012" height="1596" alt="image" src="https://github.com/user-attachments/assets/7cb32605-3c29-42cf-b3b6-e346ad514e31" />
<img width="3008" height="1596" alt="image" src="https://github.com/user-attachments/assets/9ec19fb5-f5a3-4baf-996c-6640b86bd910" />
<img width="3014" height="1594" alt="image" src="https://github.com/user-attachments/assets/6607c4c8-a303-4a32-bc02-c80fa893b25b" />
<img width="3008" height="754" alt="image" src="https://github.com/user-attachments/assets/c5065998-357b-45be-8629-a2b22a2a51f3" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes across browsers, keyboard navigation, and assistive technologies? (PCYsg-S3g-p2)
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?