### PR TITLE
Theme Showcase: Modernize collection view header and theme list padding

### DIFF
--- a/client/my-sites/themes/collections/theme-collection-view-header.scss
+++ b/client/my-sites/themes/collections/theme-collection-view-header.scss
@@ -110,3 +110,26 @@
 		max-width: 680px;
 	}
 }
+
+.is-theme-showcase-modern .theme-showcase.is-collection-view .theme-collection-view-header:not(.is-logged-in) {
+	$navbar-height: 57px;
+
+	margin-top: -$navbar-height;
+	padding-top: calc(#{$navbar-height} + 32px);
+	padding-inline: max(24px, calc(50% - 610px));
+	background: linear-gradient(150deg, var(--studio-white) 30%, var(--studio-blue-50) 90%);
+
+	@include breakpoint-deprecated(">660px") {
+		padding-top: calc(#{$navbar-height} + 48px);
+	}
+
+	.formatted-header {
+		margin-inline: 0;
+	}
+
+	.formatted-header__title,
+	.formatted-header__subtitle,
+	.theme-collection-view-header__back {
+		color: var(--studio-gray-90);
+	}
+}

--- a/client/my-sites/themes/hero-modern/style.scss
+++ b/client/my-sites/themes/hero-modern/style.scss
@@ -16,6 +16,10 @@ $hero-modern-navbar-height: 57px; // UniversalHeaderNavigation
 		background: inherit !important;
 		border: 1px solid var(--studio-gray-100);
 	}
+
+	.themes__selection {
+		padding-inline: 24px;
+	}
 }
 
 


### PR DESCRIPTION
Fixes DOTTHEM-310

## Proposed Changes

<img width="1649" height="787" alt="Screenshot 2026-03-10 at 18 53 16" src="https://github.com/user-attachments/assets/aba20118-c9d3-4fc9-8081-6ca60ec6f803" />

* Apply the modern gradient background (`linear-gradient(150deg, white 30%, blue-50 90%)`) to the collection view header when `is-theme-showcase-modern` is active, replacing the solid `#e5f4ff`.
* Pull the header under the transparent masterbar with negative margin/padding (same technique as `hero-modern`).
* Constrain header content to `max-width: 1220px` centered, using `padding-inline: max(24px, calc(50% - 610px))`.
* Set header text (title, subtitle, back link) to `--studio-gray-90`.
* Add `padding-inline: 24px` to `.themes__selection` in the modern showcase, matching `.theme-section-modern`.

## Why are these changes being made?

When navigating from the modern sectioned homepage into a collection view ("see all"), the header and layout should match the modern design language — gradient background, transparent masterbar overlay, consistent text colors, and aligned content widths.

## Testing Instructions

* Enable the `themes/showcase-modern` feature flag.
* Visit the logged-out theme showcase.
* Click "See all" on a recommended section to enter a collection view.
* Verify the collection header has the gradient background (white → blue), the masterbar is transparent overlaying the gradient, text is gray, and content aligns with the theme grid below.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?