### PR TITLE
CIAB: Replace PayPal reference with WooPayments in plans summary table

### DIFF
--- a/packages/calypso-products/src/features-list.tsx
+++ b/packages/calypso-products/src/features-list.tsx
@@ -2918,7 +2918,11 @@ const FEATURES_LIST: FeatureList = {
 	},
 	[ FEATURE_WOO_HOSTED_PAYPAL_INTEGRATON ]: {
 		getSlug: () => FEATURE_WOO_HOSTED_PAYPAL_INTEGRATON,
-		getTitle: () => i18n.translate( 'Connected seamlessly to your PayPal account' ),
+		getTitle: () =>
+			i18n.getLocaleSlug()?.startsWith( 'en' ) ||
+			i18n.hasTranslation( 'Connected seamlessly to your WooPayments account' )
+				? i18n.translate( 'Connected seamlessly to your WooPayments account' )
+				: i18n.translate( 'Connected seamlessly to your PayPal account' ),
 		getDescription: () => '',
 	},
 	[ FEATURE_WOO_HOSTED_MARKETING_TOOLS ]: {


### PR DESCRIPTION
Part of SHILL-1713

## Proposed Changes

* Replace "Connected seamlessly to your PayPal account" with "Connected seamlessly to your WooPayments account" in the CIAB plans summary comparison table
* Use `hasTranslation()` to gracefully fall back to the old PayPal string until WooPayments translations are ready for non-English locales

## Why are these changes being made?

The CIAB plans summary table shows "Connected seamlessly to your PayPal account" under both Basic and Pro plans. This should reference WooPayments instead.

The detailed comparison table header change is handled separately in PR #109176.

## Testing Instructions

* Open the CIAB plans page for a commerce garden site from https://my.wordpress.com/sites (or create a new one)
    * http://calypso.localhost:3000/setup/woo-hosted-plans/plans?siteSlug={site_slug}
* View the plans summary comparison table
* Verify the feature text reads "Connected seamlessly to your WooPayments account" instead of "Connected seamlessly to your PayPal account"
* Switch to a non-English locale and verify it falls back to the PayPal string if the WooPayments translation isn't available yet

## Screenshot
<img width="1419" height="779" alt="Screenshot 2026-03-11 at 12 34 28 PM" src="https://github.com/user-attachments/assets/2035ef18-c43f-409a-b204-b5b1bc2d6e6d" />


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?