### PR TITLE
CIAB: Update plans page free trial description copy

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -17,7 +17,7 @@ import { isDesktop as isDesktopViewport, subscribeIsDesktop } from '@automattic/
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import clsx from 'clsx';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { useTranslate } from 'i18n-calypso';
 import { parse as parseQs } from 'qs';
 import AsyncLoad from 'calypso/components/async-load';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -466,7 +466,15 @@ function UnifiedPlansStep( {
 		}
 
 		if ( intent === 'plans-woo-hosted' ) {
-			return translate( 'Your free trial ends soon - select a plan to keep your online store.' );
+			return i18n.fixMe( {
+				text: 'Your free trial ends soon. Select a plan to keep access to your store admin.',
+				newCopy: translate(
+					'Your free trial ends soon. Select a plan to keep access to your store admin.'
+				),
+				oldCopy: translate(
+					'Your free trial ends soon - select a plan to keep your online store.'
+				),
+			} );
 		}
 
 		if ( useEmailOnboardingSubheader ) {


### PR DESCRIPTION
Resolves SHILL-1711

## Proposed Changes

* Update the CIAB plans page subheader from "Your free trial ends soon - select a plan to keep your online store." to "Your free trial ends soon. Select a plan to keep access to your store admin."
* Use `i18n.fixMe()` to gracefully fall back to the old string until translations are ready for non-English locales

## Why are these changes being made?

The current copy references keeping "your online store" which is vague. The updated copy more accurately describes what happens — users need a plan to keep access to the store admin.

## Testing Instructions

* Open the CIAB plans page for a commerce garden site from https://my.wordpress.com/sites (or create a new one)
    * http://calypso.localhost:3000/setup/woo-hosted-plans/plans?siteSlug={site_slug}
* Verify the subheader reads "Your free trial ends soon. Select a plan to keep access to your store admin."

## Screenshot
<img width="1429" height="838" alt="Screenshot 2026-03-11 at 12 53 14 PM" src="https://github.com/user-attachments/assets/158ce424-2c7f-4b16-9a1b-1d01d1b8eeee" />


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?