### PR TITLE
Allow gifting subscriptions to email-only subscribers

### DIFF
--- a/client/my-sites/subscribers/components/gift-modal/gift-modal.tsx
+++ b/client/my-sites/subscribers/components/gift-modal/gift-modal.tsx
@@ -37,7 +37,7 @@ const GiftSubscriptionModal = ( {
 
 	const text = translate( 'Select a plan to gift to this user: ' );
 
-	const giftSubscription = ( plan_id: number, user_id: number, username: string ) => {
+	const giftSubscription = ( plan_id: number, user_id: number | string, username: string ) => {
 		const giftDetails: Gift = {
 			gift_id: null,
 			plan_id: plan_id,

--- a/client/my-sites/subscribers/components/gift-modal/gift-modal.tsx
+++ b/client/my-sites/subscribers/components/gift-modal/gift-modal.tsx
@@ -7,7 +7,7 @@ import { useDispatch } from 'calypso/state';
 import { requestAddGift } from 'calypso/state/memberships/gifts/actions';
 
 type GiftSubscriptionModalProps = {
-	userId: number;
+	userId: number | string;
 	siteId: number;
 	username: string;
 	onCancel: () => void;
@@ -16,7 +16,7 @@ type GiftSubscriptionModalProps = {
 
 type Gift = {
 	gift_id: number | null;
-	user_id: number;
+	user_id: number | string;
 	plan_id: number;
 };
 

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -182,7 +182,8 @@ export default function SubscriberDataViews( {
 				subscriberId && ! isNaN( parseInt( subscriberId, 10 ) )
 					? parseInt( subscriberId, 10 )
 					: undefined,
-			userId: subscriberDetails?.user_id,
+			userId:
+				typeof subscriberDetails?.user_id === 'number' ? subscriberDetails.user_id : undefined,
 			enabled: !! subscriberId && !! siteId,
 		} );
 
@@ -428,12 +429,9 @@ export default function SubscriberDataViews( {
 
 					if ( ! subscriber.user_id ) {
 						dispatch(
-							errorNotice(
-								translate(
-									'This subscriber needs to create a WordPress.com account before they can receive a gift subscription.'
-								),
-								{ duration: 10000 }
-							)
+							errorNotice( translate( 'Unable to gift a subscription to this subscriber.' ), {
+								duration: 10000,
+							} )
 						);
 						return;
 					}

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -429,7 +429,7 @@ export default function SubscriberDataViews( {
 
 					if ( ! subscriber.user_id ) {
 						dispatch(
-							errorNotice( translate( 'Unable to gift a subscription to this subscriber.' ), {
+							errorNotice( translate( 'Unable to comp a subscription for this subscriber.' ), {
 								duration: 10000,
 							} )
 						);

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -426,10 +426,7 @@ export default function SubscriberDataViews( {
 						return;
 					}
 
-					// TODO: Subscriber.user_id is typed as number but can be a string
-					// (e.g., email address) at runtime. The type should be widened to
-					// number | string and downstream consumers updated to validate.
-					if ( ! subscriber.user_id || isNaN( Number( subscriber.user_id ) ) ) {
+					if ( ! subscriber.user_id ) {
 						dispatch(
 							errorNotice(
 								translate(

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -394,7 +394,7 @@ export default function SubscriberDataViews( {
 			return [];
 		}
 
-		const baseActions = [
+		const baseActions: Action< Subscriber >[] = [
 			{
 				id: 'view',
 				label: translate( 'View' ),
@@ -419,6 +419,8 @@ export default function SubscriberDataViews( {
 			baseActions.push( {
 				id: 'gift',
 				label: translate( 'Gift a subscription' ),
+				isEligible: ( subscriber: Subscriber ) =>
+					!! ( subscriber.user_id || subscriber.email_address ),
 				callback: ( items: Subscriber[] ) => {
 					const subscriber = items[ 0 ];
 					if ( ! subscriber ) {

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -7,10 +7,9 @@ import { useMemo, useState, useCallback, useEffect } from '@wordpress/element';
 import { trash } from '@wordpress/icons';
 import { translate, fixMe } from 'i18n-calypso';
 import { useSubscribedNewsletterCategories } from 'calypso/data/newsletter-categories';
-import { useSelector, useDispatch } from 'calypso/state';
+import { useSelector } from 'calypso/state';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { getCouponsAndGiftsEnabledForSiteId } from 'calypso/state/memberships/settings/selectors';
-import { errorNotice } from 'calypso/state/notices/actions';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import { isSimpleSite, getSiteSlug } from 'calypso/state/sites/selectors';
@@ -104,7 +103,6 @@ export default function SubscriberDataViews( {
 	isUnverified,
 	subscriberId,
 }: SubscriberDataViewsProps ) {
-	const dispatch = useDispatch();
 	const isMobile = useBreakpoint( '<660px' );
 	const recordSubscriberClicked = useRecordSubscriberClicked();
 	const recordSubscriberSearch = useRecordSubscriberSearch();
@@ -427,15 +425,6 @@ export default function SubscriberDataViews( {
 						return;
 					}
 
-					if ( ! subscriber.user_id ) {
-						dispatch(
-							errorNotice( translate( 'Unable to comp a subscription for this subscriber.' ), {
-								duration: 10000,
-							} )
-						);
-						return;
-					}
-
 					onGiftSubscription( subscriber );
 				},
 				isPrimary: false,
@@ -449,7 +438,6 @@ export default function SubscriberDataViews( {
 		handleUnsubscribe,
 		onGiftSubscription,
 		couponsAndGiftsEnabled,
-		dispatch,
 	] );
 
 	const handleViewChange = useCallback(

--- a/client/my-sites/subscribers/helpers/index.ts
+++ b/client/my-sites/subscribers/helpers/index.ts
@@ -22,11 +22,12 @@ const getSubscribersCacheKey = ( {
 const getSubscriberDetailsCacheKey = (
 	siteId: number | undefined | null,
 	subscriptionId: number | undefined,
-	userId: number | undefined,
+	userId: number | string | undefined,
 	type: string
 ) => [ 'subscriber-details', siteId, subscriptionId, userId, type ];
 
-const getSubscriberDetailsType = ( userId: number | undefined ) => ( userId ? 'wpcom' : 'email' );
+const getSubscriberDetailsType = ( userId: number | string | undefined ) =>
+	userId ? 'wpcom' : 'email';
 
 const getSubscriptionIdFromSubscriber = ( subscriber: Subscriber ): number => {
 	return (

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -61,8 +61,8 @@ const SubscribersPage = ( { subscriberId }: Props ) => {
 
 	const [ giftUserId, setGiftUserId ] = useState< number | string | null >( null );
 	const [ giftUsername, setGiftUsername ] = useState( '' );
-	const onGiftSubscription = ( { user_id, display_name }: Subscriber ) => {
-		setGiftUserId( user_id );
+	const onGiftSubscription = ( { user_id, email_address, display_name }: Subscriber ) => {
+		setGiftUserId( user_id || email_address );
 		setGiftUsername( display_name );
 	};
 

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -59,7 +59,7 @@ const SubscribersPage = ( { subscriberId }: Props ) => {
 		}
 	}, [ siteId, getSubscribersImports ] );
 
-	const [ giftUserId, setGiftUserId ] = useState( 0 );
+	const [ giftUserId, setGiftUserId ] = useState< number | string | null >( null );
 	const [ giftUsername, setGiftUsername ] = useState( '' );
 	const onGiftSubscription = ( { user_id, display_name }: Subscriber ) => {
 		setGiftUserId( user_id );
@@ -79,13 +79,13 @@ const SubscribersPage = ( { subscriberId }: Props ) => {
 						subscriberId={ isSubscriberIdValid ? subscriberId : undefined }
 					/>
 
-					{ giftUserId !== 0 && (
+					{ giftUserId !== null && (
 						<GiftSubscriptionModal
 							siteId={ siteId ?? 0 }
 							userId={ giftUserId }
 							username={ giftUsername }
-							onCancel={ () => setGiftUserId( 0 ) }
-							onConfirm={ () => setGiftUserId( 0 ) }
+							onCancel={ () => setGiftUserId( null ) }
+							onConfirm={ () => setGiftUserId( null ) }
 						/>
 					) }
 				</SubscriberValidationGate>

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -62,7 +62,7 @@ const SubscribersPage = ( { subscriberId }: Props ) => {
 	const [ giftUserId, setGiftUserId ] = useState< number | string | null >( null );
 	const [ giftUsername, setGiftUsername ] = useState( '' );
 	const onGiftSubscription = ( { user_id, email_address, display_name }: Subscriber ) => {
-		setGiftUserId( user_id || email_address );
+		setGiftUserId( user_id || email_address || null );
 		setGiftUsername( display_name );
 	};
 

--- a/client/my-sites/subscribers/tracks/use-record-subscriber-clicked.ts
+++ b/client/my-sites/subscribers/tracks/use-record-subscriber-clicked.ts
@@ -5,7 +5,7 @@ const useRecordSubscriberClicked = () => {
 
 	return (
 		where: 'title' | 'icon' | 'row' | 'list',
-		tracksProps: { site_id?: number | null; subscription_id?: number; user_id?: number }
+		tracksProps: { site_id?: number | null; subscription_id?: number; user_id?: number | string }
 	) => {
 		recordSubscribersTracksEvent(
 			`calypso_subscribers_subscriber_${ where }_clicked`,

--- a/client/my-sites/subscribers/tracks/use-record-subscriber-removed.ts
+++ b/client/my-sites/subscribers/tracks/use-record-subscriber-removed.ts
@@ -6,7 +6,7 @@ const useRecordSubscriberRemoved = () => {
 	return ( tracksProps: {
 		site_id?: number | null;
 		subscription_id?: number;
-		user_id?: number;
+		user_id?: number | string;
 	} ) => {
 		recordSubscribersTracksEvent( 'calypso_subscribers_subscriber_removed', tracksProps );
 	};

--- a/client/my-sites/subscribers/types/index.ts
+++ b/client/my-sites/subscribers/types/index.ts
@@ -25,7 +25,7 @@ export type SubscriptionPlan = {
 };
 
 export type Subscriber = {
-	user_id: number;
+	user_id: number | string;
 	// Fields for new helper library
 	email_subscription_id?: number;
 	wpcom_subscription_id?: number;

--- a/client/state/memberships/gifts/actions.js
+++ b/client/state/memberships/gifts/actions.js
@@ -29,7 +29,9 @@ export const requestAddGift = ( siteId, gift, noticeText, onConfirm ) => {
 			.post(
 				{
 					method: 'POST',
-					path: `/sites/${ siteId }/memberships/gifts/` + gift.user_id + '/' + gift.plan_id,
+					path: `/sites/${ siteId }/memberships/gifts/${ encodeURIComponent( gift.user_id ) }/${
+						gift.plan_id
+					}`,
 					apiNamespace: 'wpcom/v2',
 				},
 				null


### PR DESCRIPTION
Fixes NL-440

## Proposed Changes

* Reverts the `isNaN( Number() )` guard from #108723 that blocked email-only subscribers from receiving gift subscriptions
* Removes the `! subscriber.user_id` guard entirely — CSV-imported subscribers have `user_id: 0`, which was blocking the gift action even though the back-end now supports gifting by email
* Falls back to `email_address` when `user_id` is falsy, so the gift API receives the subscriber's email in the URL path (e.g., `POST /gifts/jane@example.com/$plan_id`)
* Guards against the edge case where both `user_id` and `email_address` are falsy — falls back to `null` to prevent the gift modal from rendering
* Hides the "Gift a subscription" action entirely for subscribers missing both `user_id` and `email_address`, using the DataViews `isEligible` callback
* URL-encodes `user_id` in the gift API request path to safely handle email addresses containing special characters
* Widens the `user_id` type from `number` to `number | string` through the gift subscription flow (`Subscriber` type, `GiftSubscriptionModal`, helpers, tracks events)
* Switches the gift modal visibility state from a `0` sentinel to `null` for correctness with the widened type
* Narrows the `userId` passed to `useSubscribedNewsletterCategories` to only pass numeric IDs, since that hook is unrelated to gifting
* Cleans up unused `errorNotice`, `useDispatch`, and `dispatch` references from the data views component

<img width="250" height="258" alt="Screenshot 2026-03-10 at 4 00 23 PM" src="https://github.com/user-attachments/assets/988a56cf-528e-4678-a4c7-fb00b170aee8" />


## Why are these changes being made?

The back-end now supports gifting to email-only accounts. The gifts endpoint accepts an email address in place of a numeric user ID (`POST /gifts/jane@example.com/$plan_id`), creating a non-TOS account on the fly for CSV-imported subscribers (Case 3 in the back-end PR). The front-end guards that previously rejected non-numeric or falsy `user_id` values are no longer needed. The `Subscriber.user_id` type is also corrected to reflect what the API actually returns.

This PR depends on the back-end change landing first.

## Testing Instructions

* Navigate to the Subscribers page for a site with coupons/gifts enabled
* Find an email-only subscriber (no WordPress.com account, `user_id: 0`)
* Click the "Gift a subscription" action
* Verify the gift flow proceeds and the subscription is created
* Verify that subscribers with a WordPress.com account can still receive gifts as before
* (Edge case) If a subscriber has neither `user_id` nor `email_address`, verify the "Gift a subscription" action is not shown

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)