### PR TITLE
Fix unified invite crash for logged-in accepts and constrain logged-out layout

### DIFF
--- a/client/my-sites/invites-unified/index.tsx
+++ b/client/my-sites/invites-unified/index.tsx
@@ -1,5 +1,7 @@
+import { Step } from '@automattic/onboarding';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
+import { getCiabConfigFromGarden } from 'calypso/lib/partner-branding';
 import normalizeInvite from 'calypso/my-sites/invites/invite-accept/utils/normalize-invite';
 import LoggedOutInviteAccept from 'calypso/my-sites/invites/invite-accept-logged-out';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -38,6 +40,17 @@ export function UnifiedInviteAccept( {
 	inviteError,
 }: UnifiedInviteAcceptProps ) {
 	const isLoggedIn = useSelector( isUserLoggedIn );
+	const blogDetails = ( inviteData as { blog_details?: InviteBlogDetails } )?.blog_details;
+	const branding =
+		blogDetails?.is_garden_site && blogDetails.garden
+			? getCiabConfigFromGarden( blogDetails.garden.partner, blogDetails.garden.name, {
+					persistToSession: true,
+			  } )
+			: null;
+	const topBarLogoConfig = branding?.compactLogo ?? branding?.logo;
+	const topBarLogo = topBarLogoConfig?.src ? (
+		<img { ...topBarLogoConfig } alt={ topBarLogoConfig.alt } />
+	) : undefined;
 	const legacyLoggedOutInvite = useMemo< LegacyLoggedOutInvite | null >( () => {
 		if ( isLoggedIn || ! inviteData || ! ( inviteData as { invite?: unknown } ).invite ) {
 			return null;
@@ -60,15 +73,17 @@ export function UnifiedInviteAccept( {
 		}
 
 		return (
-			<div className="invites-unified__logged-out-shell">
-				<LoggedOutInviteAccept invite={ legacyLoggedOutInvite } forceMatchingEmail={ false } />
+			<div className="invites-unified__logged-out-layout">
+				<Step.TopBar logo={ topBarLogo } />
+				<div className="invites-unified__logged-out-shell">
+					<LoggedOutInviteAccept invite={ legacyLoggedOutInvite } forceMatchingEmail={ false } />
+				</div>
 			</div>
 		);
 	}
 
 	// Already a member → show already-member screen
 	if ( inviteError?.error && isAlreadyMemberError( inviteError.error ) ) {
-		const blogDetails = ( inviteData as { blog_details?: InviteBlogDetails } )?.blog_details;
 		return <AlreadyMemberScreen blogDetails={ blogDetails } />;
 	}
 

--- a/client/my-sites/invites-unified/index.tsx
+++ b/client/my-sites/invites-unified/index.tsx
@@ -37,7 +37,7 @@ export function UnifiedInviteAccept( {
 }: UnifiedInviteAcceptProps ) {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const legacyLoggedOutInvite = useMemo< LegacyLoggedOutInvite | null >( () => {
-		if ( ! inviteData ) {
+		if ( isLoggedIn || ! inviteData || ! ( inviteData as { invite?: unknown } ).invite ) {
 			return null;
 		}
 
@@ -49,7 +49,7 @@ export function UnifiedInviteAccept( {
 			activationKey,
 			authKey,
 		};
-	}, [ inviteData, inviteKey, activationKey, authKey ] );
+	}, [ isLoggedIn, inviteData, inviteKey, activationKey, authKey ] );
 
 	// Render logged-out invite signup in unified flow.
 	if ( ! isLoggedIn ) {

--- a/client/my-sites/invites-unified/index.tsx
+++ b/client/my-sites/invites-unified/index.tsx
@@ -8,6 +8,8 @@ import AlreadyMemberScreen from './screens/already-member-screen';
 import { isAlreadyMemberError } from './utils';
 import type { Invite, InviteBlogDetails, InviteError } from './types';
 
+import './style.scss';
+
 interface LegacyLoggedOutInvite {
 	inviteKey: string;
 	activationKey?: string;
@@ -57,7 +59,11 @@ export function UnifiedInviteAccept( {
 			return null;
 		}
 
-		return <LoggedOutInviteAccept invite={ legacyLoggedOutInvite } forceMatchingEmail={ false } />;
+		return (
+			<div className="invites-unified__logged-out-shell">
+				<LoggedOutInviteAccept invite={ legacyLoggedOutInvite } forceMatchingEmail={ false } />
+			</div>
+		);
 	}
 
 	// Already a member → show already-member screen

--- a/client/my-sites/invites-unified/screens/test/accept-invite-screen.test.tsx
+++ b/client/my-sites/invites-unified/screens/test/accept-invite-screen.test.tsx
@@ -8,6 +8,24 @@ import configureStore from 'redux-mock-store';
 import { AcceptInviteScreen } from '../accept-invite-screen';
 import type { Invite } from '../../types';
 
+const mockCenteredColumnLayout = jest.fn(
+	( {
+		children,
+		heading,
+		topBar,
+	}: {
+		children: React.ReactNode;
+		heading: React.ReactNode;
+		topBar: React.ReactNode;
+	} ) => (
+		<div data-testid="step-layout">
+			{ topBar }
+			{ heading }
+			{ children }
+		</div>
+	)
+);
+
 // Mock external dependencies
 jest.mock(
 	'@automattic/calypso-router',
@@ -39,21 +57,13 @@ jest.mock(
 			TopBar: ( { logo }: { logo?: React.ReactNode } ) => (
 				<div data-testid="step-topbar">{ logo }</div>
 			),
-			CenteredColumnLayout: ( {
-				children,
-				heading,
-				topBar,
-			}: {
+			CenteredColumnLayout: ( props: {
 				children: React.ReactNode;
 				heading: React.ReactNode;
 				topBar: React.ReactNode;
-			} ) => (
-				<div data-testid="step-layout">
-					{ topBar }
-					{ heading }
-					{ children }
-				</div>
-			),
+				columnWidth: number;
+				verticalAlign: string;
+			} ) => mockCenteredColumnLayout( props ),
 		},
 	} ),
 	{ virtual: true }
@@ -244,6 +254,7 @@ const setupUser = ( userOverrides = {} ) => {
 describe( 'AcceptInviteScreen', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
+		mockCenteredColumnLayout.mockClear();
 		mockAcceptInvite.mockReturnValue( { type: 'ACCEPT_INVITE' } );
 		mockDispatch.mockImplementation( ( action: unknown ) => {
 			if ( typeof action === 'function' ) {
@@ -255,6 +266,25 @@ describe( 'AcceptInviteScreen', () => {
 	} );
 
 	describe( 'rendering', () => {
+		test( 'passes centered layout props', () => {
+			const store = createStore();
+			const invite = createInvite();
+
+			render(
+				<Provider store={ store }>
+					<AcceptInviteScreen invite={ invite } />
+				</Provider>
+			);
+
+			expect( mockCenteredColumnLayout ).toHaveBeenCalled();
+			expect( mockCenteredColumnLayout.mock.calls[ 0 ][ 0 ] ).toEqual(
+				expect.objectContaining( {
+					columnWidth: 4,
+					verticalAlign: 'center',
+				} )
+			);
+		} );
+
 		test( 'renders the user card with current user info', () => {
 			const store = createStore();
 			const invite = createInvite();

--- a/client/my-sites/invites-unified/screens/test/already-member-screen.test.tsx
+++ b/client/my-sites/invites-unified/screens/test/already-member-screen.test.tsx
@@ -8,6 +8,24 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import { AlreadyMemberScreen } from '../already-member-screen';
 
+const mockCenteredColumnLayout = jest.fn(
+	( {
+		children,
+		heading,
+		topBar,
+	}: {
+		children: React.ReactNode;
+		heading: React.ReactNode;
+		topBar: React.ReactNode;
+	} ) => (
+		<div data-testid="step-layout">
+			{ topBar }
+			{ heading }
+			{ children }
+		</div>
+	)
+);
+
 jest.mock(
 	'@automattic/onboarding',
 	() => ( {
@@ -21,21 +39,13 @@ jest.mock(
 			TopBar: ( { logo }: { logo?: React.ReactNode } ) => (
 				<div data-testid="step-topbar">{ logo }</div>
 			),
-			CenteredColumnLayout: ( {
-				children,
-				heading,
-				topBar,
-			}: {
+			CenteredColumnLayout: ( props: {
 				children: React.ReactNode;
 				heading: React.ReactNode;
 				topBar: React.ReactNode;
-			} ) => (
-				<div data-testid="step-layout">
-					{ topBar }
-					{ heading }
-					{ children }
-				</div>
-			),
+				columnWidth: number;
+				verticalAlign: string;
+			} ) => mockCenteredColumnLayout( props ),
 		},
 	} ),
 	{ virtual: true }
@@ -149,11 +159,30 @@ const setupUser = ( userOverrides = {} ) => {
 describe( 'AlreadyMemberScreen', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
+		mockCenteredColumnLayout.mockClear();
 		mockDispatch.mockReturnValue( undefined );
 		setupUser();
 	} );
 
 	describe( 'rendering', () => {
+		test( 'passes centered layout props', () => {
+			const store = createStore();
+
+			render(
+				<Provider store={ store }>
+					<AlreadyMemberScreen />
+				</Provider>
+			);
+
+			expect( mockCenteredColumnLayout ).toHaveBeenCalled();
+			expect( mockCenteredColumnLayout.mock.calls[ 0 ][ 0 ] ).toEqual(
+				expect.objectContaining( {
+					columnWidth: 4,
+					verticalAlign: 'center',
+				} )
+			);
+		} );
+
 		test( 'renders the title and description', () => {
 			const store = createStore();
 

--- a/client/my-sites/invites-unified/screens/test/email-mismatch-screen.test.tsx
+++ b/client/my-sites/invites-unified/screens/test/email-mismatch-screen.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { EmailMismatchScreen } from '../email-mismatch-screen';
+
+const mockCenteredColumnLayout = jest.fn(
+	( {
+		children,
+		heading,
+		topBar,
+	}: {
+		children: React.ReactNode;
+		heading: React.ReactNode;
+		topBar: React.ReactNode;
+	} ) => (
+		<div data-testid="step-layout">
+			{ topBar }
+			{ heading }
+			{ children }
+		</div>
+	)
+);
+
+jest.mock(
+	'@automattic/onboarding',
+	() => ( {
+		Step: {
+			Heading: ( { text, subText }: { text: string; subText: string } ) => (
+				<div data-testid="step-heading">
+					<h1>{ text }</h1>
+					<p>{ subText }</p>
+				</div>
+			),
+			TopBar: ( { logo }: { logo?: React.ReactNode } ) => (
+				<div data-testid="step-topbar">{ logo }</div>
+			),
+			CenteredColumnLayout: ( props: {
+				children: React.ReactNode;
+				heading: React.ReactNode;
+				topBar: React.ReactNode;
+				columnWidth: number;
+				verticalAlign: string;
+			} ) => mockCenteredColumnLayout( props ),
+		},
+	} ),
+	{ virtual: true }
+);
+
+jest.mock( '@wordpress/url', () => ( {
+	addQueryArgs: ( url: string, query: { email_address: string } ) =>
+		`${ url }&email_address=${ encodeURIComponent( query.email_address ) }`,
+} ) );
+
+jest.mock( 'calypso/components/connect-screen/action-buttons', () => ( {
+	ActionButtons: ( {
+		primaryLabel,
+		primaryOnClick,
+	}: {
+		primaryLabel: string;
+		primaryOnClick: () => void;
+	} ) => <button onClick={ primaryOnClick }>{ primaryLabel }</button>,
+} ) );
+
+jest.mock( 'calypso/components/data/document-head', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+
+jest.mock( 'calypso/layout/body-section-css-class', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+
+const mockRecordTracksEvent = jest.fn();
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {
+	recordTracksEvent: ( ...args: unknown[] ) => mockRecordTracksEvent( ...args ),
+} ) );
+
+const mockNavigate = jest.fn();
+jest.mock( 'calypso/lib/navigate', () => ( {
+	navigate: ( url: string ) => mockNavigate( url ),
+} ) );
+
+jest.mock( 'calypso/lib/paths', () => ( {
+	login: ( { redirectTo }: { redirectTo: string } ) =>
+		`/log-in?redirect_to=${ encodeURIComponent( redirectTo ) }`,
+} ) );
+
+jest.mock( '../style.scss', () => ( {} ) );
+
+describe( 'EmailMismatchScreen', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockCenteredColumnLayout.mockClear();
+	} );
+
+	test( 'passes centered layout props', () => {
+		render(
+			<EmailMismatchScreen
+				inviteSentTo="invited@example.com"
+				isKnownUser
+				trackingProps={ { unified: true } }
+			/>
+		);
+
+		expect( mockCenteredColumnLayout ).toHaveBeenCalled();
+		expect( mockCenteredColumnLayout.mock.calls[ 0 ][ 0 ] ).toEqual(
+			expect.objectContaining( {
+				columnWidth: 4,
+				verticalAlign: 'center',
+			} )
+		);
+	} );
+
+	test( 'shows sign in button label for known users', () => {
+		render(
+			<EmailMismatchScreen
+				inviteSentTo="invited@example.com"
+				isKnownUser
+				trackingProps={ { unified: true } }
+			/>
+		);
+
+		expect( screen.getByText( 'Sign in as invited@example.com' ) ).toBeVisible();
+	} );
+
+	test( 'shows register button label for unknown users', () => {
+		render(
+			<EmailMismatchScreen
+				inviteSentTo="invited@example.com"
+				isKnownUser={ false }
+				trackingProps={ { unified: true } }
+			/>
+		);
+
+		expect( screen.getByText( 'Register as invited@example.com' ) ).toBeVisible();
+	} );
+
+	test( 'tracks and navigates with invite email when button is clicked', async () => {
+		const user = userEvent.setup();
+		render(
+			<EmailMismatchScreen
+				inviteSentTo="invited@example.com"
+				isKnownUser
+				trackingProps={ { role: 'administrator', unified: true } }
+			/>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Sign in as invited@example.com' } ) );
+
+		expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_invite_accept_logged_in_sign_in_link_click',
+			expect.objectContaining( { role: 'administrator', unified: true } )
+		);
+		expect( mockNavigate ).toHaveBeenCalledWith(
+			expect.stringContaining( 'email_address=invited%40example.com' )
+		);
+	} );
+} );

--- a/client/my-sites/invites-unified/style.scss
+++ b/client/my-sites/invites-unified/style.scss
@@ -1,10 +1,20 @@
 @import '@wordpress/base-styles/breakpoints';
 
+.invites-unified__logged-out-layout {
+	background: #fdfdfd;
+	min-height: 100vh;
+	width: 100%;
+
+	.logged-out-wp-logo {
+		display: none;
+	}
+}
+
 .invites-unified__logged-out-shell {
 	box-sizing: border-box;
 	margin: 0 auto;
 	max-width: 32rem;
-	padding: 0 1rem;
+	padding: 1.5rem 1rem 0;
 	width: 100%;
 }
 

--- a/client/my-sites/invites-unified/style.scss
+++ b/client/my-sites/invites-unified/style.scss
@@ -1,0 +1,15 @@
+@import '@wordpress/base-styles/breakpoints';
+
+.invites-unified__logged-out-shell {
+	box-sizing: border-box;
+	margin: 0 auto;
+	max-width: 32rem;
+	padding: 0 1rem;
+	width: 100%;
+}
+
+@media ( max-width: $break-mobile ) {
+	.invites-unified__logged-out-shell {
+		padding: 0;
+	}
+}

--- a/client/my-sites/invites-unified/test/index.test.tsx
+++ b/client/my-sites/invites-unified/test/index.test.tsx
@@ -8,6 +8,37 @@ import configureStore from 'redux-mock-store';
 import { UnifiedInviteAccept } from '../index';
 
 const mockNormalizeInvite = jest.fn();
+const mockTopBar = jest.fn();
+
+jest.mock( '@automattic/onboarding', () => ( {
+	Step: {
+		TopBar: ( props: { logo?: React.ReactNode } ) => {
+			mockTopBar( props );
+			return (
+				<div data-testid="invite-top-bar">
+					{ props.logo ? <div data-testid="invite-top-bar-logo">{ props.logo }</div> : null }
+				</div>
+			);
+		},
+	},
+} ) );
+
+jest.mock( 'calypso/lib/partner-branding', () => ( {
+	getCiabConfigFromGarden: () => ( {
+		compactLogo: {
+			src: 'https://example.com/compact-logo.svg',
+			alt: 'Compact Logo',
+			width: 32,
+			height: 32,
+		},
+		logo: {
+			src: 'https://example.com/logo.svg',
+			alt: 'Logo',
+			width: 120,
+			height: 32,
+		},
+	} ),
+} ) );
 
 jest.mock( 'calypso/my-sites/invites/invite-accept/utils/normalize-invite', () => ( {
 	__esModule: true,
@@ -50,6 +81,11 @@ const defaultProps = {
 		blog_details: {
 			title: 'Test Store',
 			domain: 'test.store',
+			is_garden_site: true,
+			garden: {
+				partner: 'woo',
+				name: 'commerce',
+			},
 		},
 		invite: {
 			meta: {
@@ -62,6 +98,7 @@ const defaultProps = {
 describe( 'UnifiedInviteAccept', () => {
 	beforeEach( () => {
 		mockNormalizeInvite.mockReset();
+		mockTopBar.mockClear();
 		mockLoggedOutInviteAccept.mockClear();
 		mockAlreadyMemberScreen.mockClear();
 		mockNormalizeInvite.mockReturnValue( {
@@ -90,11 +127,18 @@ describe( 'UnifiedInviteAccept', () => {
 		);
 
 		expect( screen.getByTestId( 'logged-out-invite-screen' ) ).toBeVisible();
+		const topBar = screen.getByTestId( 'invite-top-bar' );
+		expect( topBar ).toBeVisible();
+		expect( screen.getByTestId( 'invite-top-bar-logo' ) ).toBeVisible();
+		const shell = screen
+			.getByTestId( 'logged-out-invite-screen' )
+			.closest( '.invites-unified__logged-out-shell' );
+		expect( shell ).not.toBeNull();
+		expect( topBar.closest( '.invites-unified__logged-out-layout' ) ).not.toBeNull();
 		expect(
-			screen
-				.getByTestId( 'logged-out-invite-screen' )
-				.closest( '.invites-unified__logged-out-shell' )
-		).not.toBeNull();
+			topBar.compareDocumentPosition( shell as Node ) & Node.DOCUMENT_POSITION_FOLLOWING
+		).toBe( Node.DOCUMENT_POSITION_FOLLOWING );
+		expect( mockTopBar.mock.calls[ 0 ][ 0 ].logo ).toBeDefined();
 	} );
 
 	test( 'renders AcceptInviteScreen when user is logged in', () => {

--- a/client/my-sites/invites-unified/test/index.test.tsx
+++ b/client/my-sites/invites-unified/test/index.test.tsx
@@ -15,6 +15,7 @@ jest.mock( 'calypso/my-sites/invites/invite-accept/utils/normalize-invite', () =
 } ) );
 
 const mockLoggedOutInviteAccept = jest.fn();
+const mockAlreadyMemberScreen = jest.fn();
 
 jest.mock( 'calypso/my-sites/invites/invite-accept-logged-out', () => ( {
 	__esModule: true,
@@ -32,8 +33,13 @@ jest.mock( '../screens/accept-invite-screen', () => ( {
 
 jest.mock( '../screens/already-member-screen', () => ( {
 	__esModule: true,
-	default: () => <div data-testid="already-member-screen">AlreadyMemberScreen</div>,
+	default: ( props: unknown ) => {
+		mockAlreadyMemberScreen( props );
+		return <div data-testid="already-member-screen">AlreadyMemberScreen</div>;
+	},
 } ) );
+
+jest.mock( '../style.scss', () => ( {} ) );
 
 const mockStore = configureStore();
 
@@ -57,6 +63,7 @@ describe( 'UnifiedInviteAccept', () => {
 	beforeEach( () => {
 		mockNormalizeInvite.mockReset();
 		mockLoggedOutInviteAccept.mockClear();
+		mockAlreadyMemberScreen.mockClear();
 		mockNormalizeInvite.mockReturnValue( {
 			inviteKey: 'abc123',
 			role: 'administrator',
@@ -83,6 +90,11 @@ describe( 'UnifiedInviteAccept', () => {
 		);
 
 		expect( screen.getByTestId( 'logged-out-invite-screen' ) ).toBeVisible();
+		expect(
+			screen
+				.getByTestId( 'logged-out-invite-screen' )
+				.closest( '.invites-unified__logged-out-shell' )
+		).not.toBeNull();
 	} );
 
 	test( 'renders AcceptInviteScreen when user is logged in', () => {
@@ -100,6 +112,35 @@ describe( 'UnifiedInviteAccept', () => {
 
 		expect( mockLoggedOutInviteAccept ).not.toHaveBeenCalled();
 		expect( screen.getByTestId( 'accept-invite-screen' ) ).toBeInTheDocument();
+		expect( mockNormalizeInvite ).not.toHaveBeenCalled();
+	} );
+
+	test( 'does not normalize invite data for logged-in already-member flow with partial invite data', () => {
+		const store = mockStore( { currentUser: { id: 1 } } );
+		const partialInviteData = {
+			blog_details: {
+				title: 'Test Store',
+				domain: 'test.store',
+			},
+		};
+
+		render(
+			<Provider store={ store }>
+				<UnifiedInviteAccept
+					{ ...defaultProps }
+					inviteData={ partialInviteData }
+					inviteError={ { error: 'already_member', message: 'Already a member' } }
+				/>
+			</Provider>
+		);
+
+		expect( screen.getByTestId( 'already-member-screen' ) ).toBeVisible();
+		expect( mockNormalizeInvite ).not.toHaveBeenCalled();
+		expect( mockAlreadyMemberScreen ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				blogDetails: partialInviteData.blog_details,
+			} )
+		);
 	} );
 
 	test( 'passes activationKey and authKey to logged-out invite screen', () => {


### PR DESCRIPTION

## Proposed Changes

* Stop eagerly normalizing invite payloads in the unified entrypoint for logged-in requests, and only normalize in the logged-out flow when `inviteData.invite` is present.
* Wrap the logged-out unified invite experience in a local shell with a max-width centered container so the form no longer stretches full-width.
* Extend test coverage with a logged-in already-member regression test, logged-out shell assertion, centered-layout contract assertions, and a new `EmailMismatchScreen` test suite.

## Why are these changes being made?

* The logged-in already-member path can receive partial invite data that only includes `blog_details`; eager normalization assumed `invite` existed and crashed while reading `invite_slug`.
* The unified logged-out branch lacked a local width-constrained wrapper, so its form could render stretched across the content area instead of centered.

## Testing Instructions

* Run `yarn test-client client/my-sites/invites-unified/test/index.test.tsx client/my-sites/invites-unified/screens/test/accept-invite-screen.test.tsx client/my-sites/invites-unified/screens/test/already-member-screen.test.tsx client/my-sites/invites-unified/screens/test/email-mismatch-screen.test.tsx`
* Confirm all four suites pass.

**Manual tests**

Layout tests
* Before applying this patch, send a store invite to an alias e-mail that you use ( or any email that you have access to that is different than the store owner )
* You'll see that the layout is stretched full width
* Apply this patch and check the same link ( replace `wordpress.com` with `calypso.localhost:3000` or the Calypso live link )
* You should see that the layout is fixed.

Logged in invite accept crash tests
* Before applying this patch, send a store invite to an alias e-mail that you use
* Open the link on a browser that you have the store owner account logged in to wordpress.com
* The page should be crashing
* Apply this patch
* Try the link replacing `wordpress.com` with `calypso.localhost:3000` it should not crash

## Screenshot
<img width="3010" height="1604" alt="image" src="https://github.com/user-attachments/assets/cfaeb3cd-4246-4978-bedd-e622a071c425" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Follow-up Update

* Added a full-width unified `Step.TopBar` above the logged-out invite content, using CIAB branding from invite blog details with `compactLogo` fallback to `logo` so logo placement now matches logged-in unified screens.
* Updated unified logged-out styles to enforce a topbar + centered-content structure and hide the legacy absolute `.logged-out-wp-logo` from `LoggedOutInviteAccept`, preventing duplicate logos.
