### PR TITLE
Improve login error message when security key not supported

### DIFF
--- a/client/state/login/actions/login-user-with-security-key.js
+++ b/client/state/login/actions/login-user-with-security-key.js
@@ -65,7 +65,7 @@ export const loginUserWithSecurityKey = () => ( dispatch, getState ) => {
 					'It seems the page is not active for authentication. Please click anywhere on the page and try again while keeping the window open.'
 				),
 				NotAllowedError: translate(
-					'The security key interaction timed out or was canceled. Please try again.'
+					'The security key request was denied or timed out. If your browser does not support security keys, please use another verification method.'
 				),
 				AbortError: translate( 'The security key interaction was canceled. Please try again.' ),
 				SecurityError: translate(


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

Some browsers, like the Telegram in-app browser, doesn't support WebAuthn at all. 

This error message tips people to potentially try another method. 

Before:
<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/47b04db9-4889-4a98-852b-d7ddd41bfc04" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Does the text read ok? 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
