### PR TITLE
Fix purchase item static icon sizing

### DIFF
--- a/client/me/purchases/purchase-item/index.tsx
+++ b/client/me/purchases/purchase-item/index.tsx
@@ -150,7 +150,7 @@ export function PurchaseItemSiteIcon( {
 	if ( ! iconUrl && isJetpackPurchase ) {
 		content = (
 			<div className="purchase-item__static-icon">
-				<img src={ jetpackIcon } alt="Jetpack icon" />;
+				<img src={ jetpackIcon } alt="Jetpack icon" />
 			</div>
 		);
 	}

--- a/client/me/purchases/style.scss
+++ b/client/me/purchases/style.scss
@@ -150,6 +150,11 @@
 	height: 36px;
 	border-radius: 2px;
 	overflow: hidden;
+
+	img {
+		width: 100%;
+		height: 100%;
+	}
 }
 
 .purchase-item__title {


### PR DESCRIPTION
## Proposed Changes

* Add `width: 100%; height: 100%` to `img` elements inside `.purchase-item__static-icon` so icons (Jetpack, Akismet, Passport) fill the 36x36 container consistently.
* Remove stray semicolons after JSX self-closing tags in `PurchaseItemSiteIcon`.

## Why are these changes being made?

Static icons in the purchases list were not sized to fill their 36x36 container. The Jetpack icon (81x81 intrinsic SVG size) would overflow and get clipped, while other icons rendered at inconsistent sizes. The `SiteIcon` component correctly renders at 36x36 via its `size` prop, but the `<img>` elements for static icons had no explicit sizing.

## Screenshots

| Before | After |
|--------|-------|
|  <img width="205" height="57" alt="Screenshot 2026-03-11 at 9 19 25 AM" src="https://github.com/user-attachments/assets/a056878d-aee0-417b-8939-5584e43d070e" />  |  <img width="163" height="57" alt="Screenshot 2026-03-11 at 9 19 35 AM" src="https://github.com/user-attachments/assets/14fc7fd9-ffd6-4246-bc3b-4b56507785a9" />  |


## Testing Instructions

* Navigate to Purchases → view a purchase with a Jetpack, Akismet, or Passport icon.
* Verify the icon fills the 36x36 container and matches the size of other site icons.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)