### PR TITLE
Theme Showcase: Fix missing padding in the modern filter bar

### DIFF
--- a/client/my-sites/themes/filter-bar-modern/style.scss
+++ b/client/my-sites/themes/filter-bar-modern/style.scss
@@ -80,10 +80,7 @@
 	flex-shrink: 0;
 	margin-top: -24px; // Accommodate the external label
 	min-width: 120px;
-
-	@media ( min-width: $break-mobile ) {
-		margin-left: 0;
-	}
+	padding-left: 16px;
 
 	.components-input-control__container {
 		border-radius: 4px;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTTHEM-327

## Proposed Changes

* Fixes missing padding in the logged-out Theme Showcase modern filter bar.

| Before | After |
|--------|--------|
| <img width="1076" height="90" alt="Screenshot 2026-03-11 at 14 36 36" src="https://github.com/user-attachments/assets/9cc9e37a-0bcf-4cee-912d-b8c5c42899c5" /> | <img width="1076" height="90" alt="Screenshot 2026-03-11 at 14 36 48" src="https://github.com/user-attachments/assets/fbaf9010-0c06-4995-a324-345b853628cc" /> | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the logged-out Theme Showcase with the `themes/showcase-modern` feature flag enabled (currently only in the development environment).
* Scroll the filter bar all the way to the end.
* Ensure there's some space between the last filter and the tier dropdown.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
