### PR TITLE
Reader: Update user profile page header

### DIFF
--- a/client/reader/user-profile/components/user-profile-header/index.tsx
+++ b/client/reader/user-profile/components/user-profile-header/index.tsx
@@ -2,6 +2,7 @@ import './style.scss';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useLayoutEffect, useRef, useState } from 'react';
+import GravatarIcon from 'calypso/assets/images/icons/gravatar.svg';
 import ReaderAvatar from 'calypso/blocks/reader-avatar';
 import AutoDirection from 'calypso/components/auto-direction';
 import SectionNav from 'calypso/components/section-nav';
@@ -58,7 +59,19 @@ const UserProfileHeader = ( { user, view }: UserProfileHeaderProps ): JSX.Elemen
 				<div className="user-profile-header__user-info">
 					<ReaderAvatar author={ { ...user, has_avatar: !! user.avatar_URL } } iconSize={ 56 } />
 					<div className="user-profile-header__names">
-						<h1>{ user.display_name }</h1>
+						<h1>
+							{ user.display_name }
+							{ user.profile_URL && (
+								<a
+									className="user-profile-header__gravatar-badge"
+									href={ user.profile_URL }
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									<img src={ GravatarIcon } alt="Gravatar" width={ 18 } height={ 18 } />
+								</a>
+							) }
+						</h1>
 						<p>@{ user.user_login }</p>
 					</div>
 				</div>

--- a/client/reader/user-profile/components/user-profile-header/index.tsx
+++ b/client/reader/user-profile/components/user-profile-header/index.tsx
@@ -67,8 +67,14 @@ const UserProfileHeader = ( { user, view }: UserProfileHeaderProps ): JSX.Elemen
 									href={ user.profile_URL }
 									target="_blank"
 									rel="noopener noreferrer"
+									aria-label={ translate( 'Go to Gravatar profile' ) }
 								>
-									<img src={ GravatarIcon } alt="Gravatar" width={ 18 } height={ 18 } />
+									<img
+										src={ GravatarIcon }
+										alt={ translate( 'Gravatar badge.' ) }
+										width={ 18 }
+										height={ 18 }
+									/>
 								</a>
 							) }
 						</h1>
@@ -94,6 +100,7 @@ const UserProfileHeader = ( { user, view }: UserProfileHeaderProps ): JSX.Elemen
 								<button
 									className="user-profile-header__bio-toggle"
 									onClick={ handleShowMoreToggle }
+									aria-hidden="true"
 								>
 									{ isExpanded ? translate( 'Show less' ) : translate( 'Show more' ) }
 								</button>

--- a/client/reader/user-profile/components/user-profile-header/index.tsx
+++ b/client/reader/user-profile/components/user-profile-header/index.tsx
@@ -1,6 +1,7 @@
 import './style.scss';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import { useLayoutEffect, useRef, useState } from 'react';
 import ReaderAvatar from 'calypso/blocks/reader-avatar';
 import AutoDirection from 'calypso/components/auto-direction';
 import SectionNav from 'calypso/components/section-nav';
@@ -16,26 +17,40 @@ interface UserProfileHeaderProps {
 
 const UserProfileHeader = ( { user, view }: UserProfileHeaderProps ): JSX.Element => {
 	const translate = useTranslate();
-	const userProfileUrlWithUsername = getUserProfileUrl( user.user_login ?? '' );
+	const [ isExpanded, setIsExpanded ] = useState( false );
+	const [ showMoreToggle, setShowMoreToggle ] = useState( false );
+	const bioRef = useRef< HTMLParagraphElement >( null );
+
+	useLayoutEffect( () => {
+		const bioElement = bioRef.current;
+		if ( bioElement ) {
+			const isOverflowing = bioElement.scrollHeight > bioElement.clientHeight;
+			setShowMoreToggle( isOverflowing );
+		}
+	}, [ user.bio ] );
+
+	const handleShowMoreToggle = () => {
+		setIsExpanded( ! isExpanded );
+	};
+
+	const userProfileUrl = getUserProfileUrl( user.user_login ?? String( user.ID ) );
 	const navigationItems = [
 		{
 			label: translate( 'Posts' ),
-			path: userProfileUrlWithUsername,
+			path: userProfileUrl,
 			selected: view === 'posts',
 		},
 		{
 			label: translate( 'Lists' ),
-			path: `${ userProfileUrlWithUsername }/lists`,
+			path: `${ userProfileUrl }/lists`,
 			selected: view === 'lists',
 		},
 		{
 			label: translate( 'Recommended Blogs' ),
-			path: `${ userProfileUrlWithUsername }/recommended-blogs`,
+			path: `${ userProfileUrl }/recommended-blogs`,
 			selected: view === 'recommended-blogs',
 		},
 	];
-
-	const selectedTab = navigationItems.find( ( item ) => item.selected )?.label || '';
 
 	return (
 		<>
@@ -51,12 +66,28 @@ const UserProfileHeader = ( { user, view }: UserProfileHeaderProps ): JSX.Elemen
 				{ user.bio && (
 					<AutoDirection>
 						<div className="user-profile-header__bio">
-							<p className={ clsx( 'user-profile-header__bio-desc' ) }>{ user.bio }</p>
+							<p
+								ref={ bioRef }
+								className={ clsx( 'user-profile-header__bio-desc', {
+									'is-clamped': ! isExpanded,
+									'is-expanded': isExpanded,
+								} ) }
+							>
+								{ user.bio }
+							</p>
+							{ showMoreToggle && (
+								<button
+									className="user-profile-header__bio-toggle"
+									onClick={ handleShowMoreToggle }
+								>
+									{ isExpanded ? translate( 'Show less' ) : translate( 'Show more' ) }
+								</button>
+							) }
 						</div>
 					</AutoDirection>
 				) }
 			</header>
-			<SectionNav enforceTabsView selectedText={ selectedTab } variation="minimal">
+			<SectionNav enforceTabsView variation="minimal">
 				<NavTabs>
 					{ navigationItems.map( ( item ) => (
 						<NavItem key={ item.path } path={ item.path } selected={ item.selected }>

--- a/client/reader/user-profile/components/user-profile-header/index.tsx
+++ b/client/reader/user-profile/components/user-profile-header/index.tsx
@@ -1,6 +1,6 @@
-import { external, Icon } from '@wordpress/icons';
+import './style.scss';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import React, { useEffect, useRef, useState } from 'react';
 import ReaderAvatar from 'calypso/blocks/reader-avatar';
 import AutoDirection from 'calypso/components/auto-direction';
 import SectionNav from 'calypso/components/section-nav';
@@ -8,8 +8,6 @@ import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import { UserProfileData } from 'calypso/lib/user/user';
 import { getUserProfileUrl } from 'calypso/reader/user-profile/user-profile.utils';
-
-import './style.scss';
 
 interface UserProfileHeaderProps {
 	user: UserProfileData;
@@ -39,69 +37,24 @@ const UserProfileHeader = ( { user, view }: UserProfileHeaderProps ): JSX.Elemen
 
 	const selectedTab = navigationItems.find( ( item ) => item.selected )?.label || '';
 
-	const avatarElement = (
-		<ReaderAvatar author={ { ...user, has_avatar: !! user.avatar_URL } } iconSize={ 116 } />
-	);
-
-	const bioRef = useRef< HTMLSpanElement >( null );
-	const [ isClamped, setIsClamped ] = useState( false );
-
-	useEffect( () => {
-		if ( bioRef.current ) {
-			const element = bioRef.current;
-			const originalHeight = element.offsetHeight;
-
-			// Temporarily remove the clamp
-			element.style.webkitLineClamp = 'unset';
-			const fullHeight = element.scrollHeight;
-
-			// Restore the clamp
-			element.style.webkitLineClamp = '3';
-
-			// Determine if the text is clamped
-			setIsClamped( fullHeight > originalHeight );
-		}
-	}, [ user.bio ] );
-
 	return (
-		<div className="user-profile-header">
-			<header className="user-profile-header__main">
-				<div
-					className="user-profile-header__avatar user-profile-header__avatar-desktop"
-					data-testid="desktop-avatar"
-				>
-					{ avatarElement }
-				</div>
-				<AutoDirection>
-					<div className="user-profile-header__details">
-						<div className="user-profile-header__display-name">
-							<div
-								className="user-profile-header__avatar user-profile-header__avatar-mobile"
-								data-testid="mobile-avatar"
-							>
-								{ avatarElement }
-							</div>
-
-							<h1>{ user.display_name }</h1>
-						</div>
-						{ user.bio && (
-							<div className="user-profile-header__bio">
-								<p className="user-profile-header__bio-desc">
-									<span ref={ bioRef } className="user-profile-header__bio-desc-text">
-										{ user.bio }
-									</span>
-
-									{ isClamped && user.profile_URL && (
-										<a className="user-profile-header__bio-desc-link" href={ user.profile_URL }>
-											{ translate( 'Read More' ) }{ ' ' }
-											<Icon width={ 18 } height={ 18 } icon={ external } />
-										</a>
-									) }
-								</p>
-							</div>
-						) }
+		<>
+			<header className="user-profile-header">
+				<div className="user-profile-header__user-info">
+					<ReaderAvatar author={ { ...user, has_avatar: !! user.avatar_URL } } iconSize={ 56 } />
+					<div className="user-profile-header__names">
+						<h1>{ user.display_name }</h1>
+						<p>@{ user.user_login }</p>
 					</div>
-				</AutoDirection>
+				</div>
+
+				{ user.bio && (
+					<AutoDirection>
+						<div className="user-profile-header__bio">
+							<p className={ clsx( 'user-profile-header__bio-desc' ) }>{ user.bio }</p>
+						</div>
+					</AutoDirection>
+				) }
 			</header>
 			<SectionNav enforceTabsView selectedText={ selectedTab } variation="minimal">
 				<NavTabs>
@@ -112,7 +65,7 @@ const UserProfileHeader = ( { user, view }: UserProfileHeaderProps ): JSX.Elemen
 					) ) }
 				</NavTabs>
 			</SectionNav>
-		</div>
+		</>
 	);
 };
 

--- a/client/reader/user-profile/components/user-profile-header/index.tsx
+++ b/client/reader/user-profile/components/user-profile-header/index.tsx
@@ -72,7 +72,9 @@ const UserProfileHeader = ( { user, view }: UserProfileHeaderProps ): JSX.Elemen
 								</a>
 							) }
 						</h1>
-						<p>@{ user.user_login }</p>
+						<p>
+							<span dir="ltr">@{ user.user_login }</span>
+						</p>
 					</div>
 				</div>
 

--- a/client/reader/user-profile/components/user-profile-header/style.scss
+++ b/client/reader/user-profile/components/user-profile-header/style.scss
@@ -40,16 +40,27 @@
 		font-size: rem( 14px );
 		line-height: 20px;
 		margin-bottom: 0;
+		overflow: hidden;
 		position: relative;
+		transition: max-height 0.3s ease-in-out;
 		white-space: pre-line;
 
 		&.is-clamped {
-			display: -webkit-box;
-			line-clamp: 3;
-			overflow: hidden;
-			-webkit-line-clamp: 3;
-			-webkit-box-orient: vertical;
+			max-height: 60px; // 3 lines × 20px line-height.
 		}
+
+		&.is-expanded {
+			max-height: 1000px; // Large enough to accommodate any bio length.
+		}
+	}
+
+	.user-profile-header__bio-toggle {
+		color: var( --studio-gray-60 );
+		cursor: pointer;
+		font-size: rem( 14px );
+		margin-top: 4px;
+		padding: 0;
+		text-decoration: underline;
 	}
 
 	.section-nav-tab__link {

--- a/client/reader/user-profile/components/user-profile-header/style.scss
+++ b/client/reader/user-profile/components/user-profile-header/style.scss
@@ -3,173 +3,63 @@
 
 .is-section-reader {
 	.user-profile-header {
-		max-width: 768px;
-		margin: 0 auto;
-		overflow: hidden;
+		padding: 20px 0 12px;
+	}
 
-		&::after {
-			@include long-content-fade( $size: 16px );
-		}
+	.user-profile-header__user-info {
+		display: flex;
+		gap: 12px;
+		margin-bottom: 12px;
 
-		&__main {
-			display: flex;
-			padding: 0 0 24px;
-			align-items: center;
-
-			@media only screen and ( max-width: 1300px ) {
-				padding-top: 20px;
-			}
-		}
-
-		&__avatar {
-			margin-right: 24px;
-			flex-shrink: 0;
-			width: 116px;
-			height: 116px;
+		.reader-avatar {
+			margin: 0;
 
 			img {
-				border-radius: 100%;
-				width: 100%;
-				height: 100%;
-			}
-
-			&-mobile {
-				width: 72px;
-				height: 72px;
-				margin-right: 16px;
-				display: block;
-
-				@include break-mobile {
-					display: none;
-				}
-			}
-
-			&-desktop {
-				display: none;
-
-				@include break-mobile {
-					display: block;
-					margin-right: 24px;
-					width: 116px;
-					height: 116px;
-				}
+				max-width: initial;
 			}
 		}
 
-		&__details {
-			flex: 1;
-			min-width: 0;
-		}
-
-		&__display-name {
-			font-family: 'Noto Serif', Georgia, 'Times New Roman', Times, serif;
-			font-size: $font-title-medium;
-			font-weight: 600;
-			line-height: 1.5;
-			margin-bottom: 16px;
-			display: flex;
-			align-items: center;
-			text-wrap: nowrap;
-
-			@include break-mobile {
-				font-size: $font-title-large;
-				margin-bottom: 8px;
-				display: block;
-			}
-		}
-
-		&__bio {
-			font-size: $font-body-large;
-			color: var( --color-text-subtle );
-
-			@include break-mobile {
-				font-size: $font-body;
-			}
-		}
-
-		&__bio-desc {
-			margin: 0;
-			position: relative;
-
-			&-text {
-				-webkit-line-clamp: 3;
-				line-clamp: 3;
-				display: -webkit-box;
-				-webkit-box-orient: vertical;
-				overflow: hidden;
-			}
-
-			&-link {
-				position: absolute;
-				bottom: 0;
-				right: 0;
-				display: inline-flex;
-				gap: 4px;
-				align-items: center;
-				z-index: z-index("user-profile-header", ".user-profile-header__bio-desc-link");
-				color: var(--color-text-subtle);
-				text-decoration: underline;
-				background: #fff;
-
-				&::before {
-					content: "";
-					position: absolute;
-					top: 0;
-					bottom: 0;
-					right: 100%;
-					background: linear-gradient(to right, transparent 0%, #fff 100%);
-					width: 40px;
-				}
-			}
-		}
-
-		.section-nav-tab__link {
-			&:hover {
-				background: none;
-			}
-		}
-
-		.section-nav-tab__text {
+		h1 {
+			font-family: Inter, sans-serif;
 			font-weight: 500;
-			color: var( --studio-black );
+			font-size: rem( 32px );
+			line-height: 32px;
+			margin-bottom: 5px;
 		}
 
-		/* Ensure the fader and read more link follow the same format as the content. AutoDirection will add
-		the direction property to the content if it doesn't match the interface's language type. However, it
-		will not adjust the fader and link since one doesn't have text content and the other is in the
-		interface langauage. This prevents the fader and link from appearing on the correct side of the
-		description. */
-		.user-profile-header__bio-desc-text[direction="ltr"] ~ .user-profile-header__bio-desc-link {
-			/*!rtl:ignore*/
-			right: 0;
-			/*!rtl:ignore*/
-			left: auto;
-
-			&::before {
-				/*!rtl:ignore*/
-				right: 100%;
-				/*!rtl:ignore*/
-				left: auto;
-				/*!rtl:ignore*/
-				background: linear-gradient(to right, transparent 0%, #fff 100%);
-			}
-		}
-
-		.user-profile-header__bio-desc-text[direction="rtl"] ~ .user-profile-header__bio-desc-link {
-			/*!rtl:ignore*/
-			left: 0;
-			/*!rtl:ignore*/
-			right: auto;
-
-			&::before {
-				/*!rtl:ignore*/
-				left: 100%;
-				/*!rtl:ignore*/
-				right: auto;
-				/*!rtl:ignore*/
-				background: linear-gradient(to left, transparent 0%, #fff 100%);
-			}
+		p {
+			color: var( --studio-gray-40 );
+			font-size: rem( 14px );
+			line-height: 20px;
+			margin-bottom: 0;
 		}
 	}
-}
 
+	p.user-profile-header__bio-desc {
+		color: var( --studio-gray-40 );
+		font-size: rem( 14px );
+		line-height: 20px;
+		margin-bottom: 0;
+		position: relative;
+		white-space: pre-line;
+
+		&.is-clamped {
+			display: -webkit-box;
+			line-clamp: 3;
+			overflow: hidden;
+			-webkit-line-clamp: 3;
+			-webkit-box-orient: vertical;
+		}
+	}
+
+	.section-nav-tab__link {
+		&:hover {
+			background: none;
+		}
+	}
+
+	.section-nav-tab__text {
+		font-weight: 500;
+		color: var( --studio-black );
+	}
+}

--- a/client/reader/user-profile/components/user-profile-header/style.scss
+++ b/client/reader/user-profile/components/user-profile-header/style.scss
@@ -20,9 +20,12 @@
 		}
 
 		h1 {
+			align-items: center;
+			display: flex;
 			font-family: Inter, sans-serif;
 			font-weight: 500;
 			font-size: rem( 32px );
+			gap: 8px;
 			line-height: 32px;
 			margin-bottom: 5px;
 		}
@@ -33,6 +36,10 @@
 			line-height: 20px;
 			margin-bottom: 0;
 		}
+	}
+
+	.user-profile-header__gravatar-badge {
+		display: flex;
 	}
 
 	p.user-profile-header__bio-desc {

--- a/client/reader/user-profile/components/user-profile-header/test/index.tsx
+++ b/client/reader/user-profile/components/user-profile-header/test/index.tsx
@@ -1,40 +1,25 @@
 /**
  * @jest-environment jsdom
  */
-// @ts-nocheck - TODO: Fix TypeScript issues
 
 import { render, screen } from '@testing-library/react';
-import React from 'react';
-import { UserData } from 'calypso/lib/user/user';
+import { UserProfileData } from 'calypso/lib/user/user';
 import UserProfileHeader from '../index';
 
-jest.mock( '@wordpress/icons', () => ( {
-	external: 'mock-external-icon',
-	Icon: ( { icon } ) => <span data-testid="icon">{ icon }</span>,
-} ) );
-
-jest.mock( 'calypso/blocks/reader-avatar', () => ( { author, iconSize } ) => (
-	<div data-testid="reader-avatar" data-author-id={ author.ID } data-icon-size={ iconSize }>
-		{ author.avatar_URL && <img src={ author.avatar_URL } alt="avatar" data-testid="avatar-img" /> }
-	</div>
+jest.mock( 'calypso/blocks/reader-avatar', () => ( { author }: { author: UserProfileData } ) => (
+	<div data-testid="reader-avatar" data-author-id={ author.ID }></div>
 ) );
 
-jest.mock( 'calypso/components/section-nav', () => ( { children } ) => (
-	<div data-testid="section-nav">{ children }</div>
-) );
-
-jest.mock( 'calypso/components/section-nav/tabs', () => ( { children } ) => (
-	<div data-testid="nav-tabs">{ children }</div>
-) );
-
-jest.mock( 'calypso/components/section-nav/item', () => ( { children, path, selected } ) => (
-	<a href={ path } data-testid="nav-item" data-selected={ selected ? 'true' : 'false' }>
-		{ children }
-	</a>
-) );
+jest.mock(
+	'calypso/components/section-nav/tabs',
+	() =>
+		( { children }: { children: React.ReactNode } ) => (
+			<div data-testid="nav-tabs">{ children }</div>
+		)
+);
 
 describe( 'UserProfileHeader', () => {
-	const defaultUser: UserData = {
+	const defaultUser: UserProfileData = {
 		ID: 123,
 		user_login: 'testuser',
 		display_name: 'Test User',
@@ -48,38 +33,29 @@ describe( 'UserProfileHeader', () => {
 	} );
 
 	test( 'should render the avatar with correct user information', () => {
-		render( <UserProfileHeader user={ defaultUser } /> );
+		render( <UserProfileHeader user={ defaultUser } view="posts" /> );
 
-		const avatars = screen.getAllByTestId( 'reader-avatar' );
-		expect( avatars[ 0 ] ).toBeInTheDocument();
-		expect( avatars[ 0 ] ).toHaveAttribute( 'data-author-id', defaultUser.ID.toString() );
-
-		// Test that desktop and mobile versions are properly rendered
-		const desktopAvatar = screen.getByTestId( 'desktop-avatar' );
-		expect( desktopAvatar ).toBeInTheDocument();
-
-		const mobileAvatar = screen.getByTestId( 'mobile-avatar' );
-		expect( mobileAvatar ).toBeInTheDocument();
+		const avatar = screen.getByTestId( 'reader-avatar' );
+		expect( avatar ).toBeInTheDocument();
+		expect( avatar ).toHaveAttribute( 'data-author-id', defaultUser.ID.toString() );
 	} );
 
 	test( 'should render the user display name', () => {
-		render( <UserProfileHeader user={ defaultUser } /> );
+		render( <UserProfileHeader user={ defaultUser } view="posts" /> );
 
 		// Check if display name is rendered
 		const displayNameEl = screen.getByText( defaultUser.display_name ?? '' );
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( displayNameEl ).toBeInTheDocument();
 	} );
 
 	test( 'should render navigation tabs with Posts, Lists, and Recommended Blogs options', () => {
-		render( <UserProfileHeader user={ defaultUser } /> );
+		const { container } = render( <UserProfileHeader user={ defaultUser } view="posts" /> );
 
 		// Check if navigation section is rendered
-		expect( screen.getByTestId( 'section-nav' ) ).toBeInTheDocument();
-		expect( screen.getByTestId( 'nav-tabs' ) ).toBeInTheDocument();
+		expect( container.querySelector( '.section-nav' ) ).toBeInTheDocument();
 
 		// Check for navigation items
-		const navItems = screen.getAllByTestId( 'nav-item' );
+		const navItems = screen.getAllByRole( 'menuitem' );
 		expect( navItems.length ).toBe( 3 ); // Posts, Lists, and Recommended Blogs
 
 		// Check nav item content - should have Posts, Lists, and Recommended Blogs
@@ -90,7 +66,7 @@ describe( 'UserProfileHeader', () => {
 	} );
 
 	test( 'should not render bio section when user has no bio', () => {
-		render( <UserProfileHeader user={ defaultUser } /> );
+		render( <UserProfileHeader user={ defaultUser } view="posts" /> );
 
 		// Bio section should not be present
 		const bioSection = document.querySelector( '.user-profile-header__bio' );
@@ -103,7 +79,7 @@ describe( 'UserProfileHeader', () => {
 			bio: 'This is my test biography that describes me as a test user.',
 		};
 
-		render( <UserProfileHeader user={ userWithBio } /> );
+		render( <UserProfileHeader user={ userWithBio } view="posts" /> );
 
 		// Bio section should be present
 		const bioText = screen.getByText( userWithBio.bio );

--- a/client/reader/user-profile/components/user-profile-header/test/index.tsx
+++ b/client/reader/user-profile/components/user-profile-header/test/index.tsx
@@ -3,6 +3,7 @@
  */
 
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { UserProfileData } from 'calypso/lib/user/user';
 import UserProfileHeader from '../index';
 
@@ -43,34 +44,25 @@ describe( 'UserProfileHeader', () => {
 	test( 'should render the user display name', () => {
 		render( <UserProfileHeader user={ defaultUser } view="posts" /> );
 
-		// Check if display name is rendered
 		const displayNameEl = screen.getByText( defaultUser.display_name ?? '' );
 		expect( displayNameEl ).toBeInTheDocument();
 	} );
 
 	test( 'should render navigation tabs with Posts, Lists, and Recommended Blogs options', () => {
-		const { container } = render( <UserProfileHeader user={ defaultUser } view="posts" /> );
+		render( <UserProfileHeader user={ defaultUser } view="posts" /> );
 
-		// Check if navigation section is rendered
-		expect( container.querySelector( '.section-nav' ) ).toBeInTheDocument();
-
-		// Check for navigation items
 		const navItems = screen.getAllByRole( 'menuitem' );
 		expect( navItems.length ).toBe( 3 ); // Posts, Lists, and Recommended Blogs
 
-		// Check nav item content - should have Posts, Lists, and Recommended Blogs
-		const navTexts = navItems.map( ( item ) => item.textContent );
-		expect( navTexts ).toContain( 'Posts' );
-		expect( navTexts ).toContain( 'Lists' );
-		expect( navTexts ).toContain( 'Recommended Blogs' );
+		expect( screen.getByRole( 'menuitem', { name: 'Posts' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'menuitem', { name: 'Lists' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'menuitem', { name: 'Recommended Blogs' } ) ).toBeInTheDocument();
 	} );
 
 	test( 'should not render bio section when user has no bio', () => {
 		render( <UserProfileHeader user={ defaultUser } view="posts" /> );
 
-		// Bio section should not be present
-		const bioSection = document.querySelector( '.user-profile-header__bio' );
-		expect( bioSection ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: /show more/i } ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'should render bio section when user has a bio', () => {
@@ -84,5 +76,57 @@ describe( 'UserProfileHeader', () => {
 		// Bio section should be present
 		const bioText = screen.getByText( userWithBio.bio );
 		expect( bioText ).toBeInTheDocument();
+	} );
+
+	test( 'should render Gravatar badge when user has profile_URL', () => {
+		render( <UserProfileHeader user={ defaultUser } view="posts" /> );
+
+		const gravatarBadge = screen.getByRole( 'link', { name: /gravatar/i } );
+		expect( gravatarBadge ).toBeInTheDocument();
+		expect( gravatarBadge ).toHaveAttribute( 'href', defaultUser.profile_URL );
+
+		const gravatarIcon = screen.getByRole( 'img', { name: /gravatar/i } );
+		expect( gravatarIcon ).toBeInTheDocument();
+	} );
+
+	test( 'should not render Gravatar badge when user does not have profile_URL', () => {
+		const userWithoutGravatarProfile = {
+			...defaultUser,
+			profile_URL: undefined,
+		};
+
+		render( <UserProfileHeader user={ userWithoutGravatarProfile } view="posts" /> );
+
+		expect( screen.queryByRole( 'link', { name: /gravatar/i } ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'should show "Show more" button for long bio and expand on click', async () => {
+		const longBio = 'This is a very long biography that spans multiple lines. '.repeat( 10 ).trim();
+		const userWithLongBio = { ...defaultUser, bio: longBio };
+
+		const { container, rerender } = render(
+			<UserProfileHeader user={ userWithLongBio } view="posts" />
+		);
+
+		const bioDesc = container.querySelector( '.user-profile-header__bio-desc' );
+		expect( bioDesc ).toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: /show more/i } ) ).not.toBeInTheDocument();
+
+		// Mock scrollHeight to simulate overflow (needed for useLayoutEffect check)
+		Object.defineProperty( bioDesc, 'scrollHeight', { value: 200, configurable: true } );
+		Object.defineProperty( bioDesc, 'clientHeight', { value: 60, configurable: true } );
+		// Re-render with slightly different bio to trigger useLayoutEffect
+		rerender(
+			<UserProfileHeader user={ { ...userWithLongBio, bio: longBio + '.' } } view="posts" />
+		);
+
+		const showMoreButton = screen.getByRole( 'button', { name: /show more/i } );
+		expect( showMoreButton ).toBeInTheDocument();
+		expect( bioDesc ).toHaveClass( 'is-clamped' );
+
+		await userEvent.click( showMoreButton );
+
+		expect( bioDesc ).toHaveClass( 'is-expanded' );
+		expect( screen.getByRole( 'button', { name: /show less/i } ) ).toBeInTheDocument();
 	} );
 } );

--- a/client/reader/user-profile/components/user-profile-header/test/index.tsx
+++ b/client/reader/user-profile/components/user-profile-header/test/index.tsx
@@ -37,7 +37,7 @@ describe( 'UserProfileHeader', () => {
 		render( <UserProfileHeader user={ defaultUser } view="posts" /> );
 
 		const avatar = screen.getByTestId( 'reader-avatar' );
-		expect( avatar ).toBeInTheDocument();
+		expect( avatar ).toBeVisible();
 		expect( avatar ).toHaveAttribute( 'data-author-id', defaultUser.ID.toString() );
 	} );
 
@@ -45,7 +45,7 @@ describe( 'UserProfileHeader', () => {
 		render( <UserProfileHeader user={ defaultUser } view="posts" /> );
 
 		const displayNameEl = screen.getByText( defaultUser.display_name ?? '' );
-		expect( displayNameEl ).toBeInTheDocument();
+		expect( displayNameEl ).toBeVisible();
 	} );
 
 	test( 'should render navigation tabs with Posts, Lists, and Recommended Blogs options', () => {
@@ -54,15 +54,15 @@ describe( 'UserProfileHeader', () => {
 		const navItems = screen.getAllByRole( 'menuitem' );
 		expect( navItems.length ).toBe( 3 ); // Posts, Lists, and Recommended Blogs
 
-		expect( screen.getByRole( 'menuitem', { name: 'Posts' } ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'menuitem', { name: 'Lists' } ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'menuitem', { name: 'Recommended Blogs' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'menuitem', { name: 'Posts' } ) ).toBeVisible();
+		expect( screen.getByRole( 'menuitem', { name: 'Lists' } ) ).toBeVisible();
+		expect( screen.getByRole( 'menuitem', { name: 'Recommended Blogs' } ) ).toBeVisible();
 	} );
 
 	test( 'should not render bio section when user has no bio', () => {
 		render( <UserProfileHeader user={ defaultUser } view="posts" /> );
 
-		expect( screen.queryByRole( 'button', { name: /show more/i } ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /show more/i ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'should render bio section when user has a bio', () => {
@@ -75,18 +75,18 @@ describe( 'UserProfileHeader', () => {
 
 		// Bio section should be present
 		const bioText = screen.getByText( userWithBio.bio );
-		expect( bioText ).toBeInTheDocument();
+		expect( bioText ).toBeVisible();
 	} );
 
 	test( 'should render Gravatar badge when user has profile_URL', () => {
 		render( <UserProfileHeader user={ defaultUser } view="posts" /> );
 
 		const gravatarBadge = screen.getByRole( 'link', { name: /gravatar/i } );
-		expect( gravatarBadge ).toBeInTheDocument();
+		expect( gravatarBadge ).toBeVisible();
 		expect( gravatarBadge ).toHaveAttribute( 'href', defaultUser.profile_URL );
 
-		const gravatarIcon = screen.getByRole( 'img', { name: /gravatar/i } );
-		expect( gravatarIcon ).toBeInTheDocument();
+		const gravatarIcon = screen.getByRole( 'img', { name: /gravatar badge./i } );
+		expect( gravatarIcon ).toBeVisible();
 	} );
 
 	test( 'should not render Gravatar badge when user does not have profile_URL', () => {
@@ -104,13 +104,11 @@ describe( 'UserProfileHeader', () => {
 		const longBio = 'This is a very long biography that spans multiple lines. '.repeat( 10 ).trim();
 		const userWithLongBio = { ...defaultUser, bio: longBio };
 
-		const { container, rerender } = render(
-			<UserProfileHeader user={ userWithLongBio } view="posts" />
-		);
+		const { rerender } = render( <UserProfileHeader user={ userWithLongBio } view="posts" /> );
 
-		const bioDesc = container.querySelector( '.user-profile-header__bio-desc' );
-		expect( bioDesc ).toBeInTheDocument();
-		expect( screen.queryByRole( 'button', { name: /show more/i } ) ).not.toBeInTheDocument();
+		const bioDesc = screen.getByText( longBio );
+		expect( bioDesc ).toBeVisible();
+		expect( screen.queryByText( /show more/i ) ).not.toBeInTheDocument();
 
 		// Mock scrollHeight to simulate overflow (needed for useLayoutEffect check)
 		Object.defineProperty( bioDesc, 'scrollHeight', { value: 200, configurable: true } );
@@ -120,13 +118,13 @@ describe( 'UserProfileHeader', () => {
 			<UserProfileHeader user={ { ...userWithLongBio, bio: longBio + '.' } } view="posts" />
 		);
 
-		const showMoreButton = screen.getByRole( 'button', { name: /show more/i } );
-		expect( showMoreButton ).toBeInTheDocument();
+		const showMoreButton = screen.getByText( /show more/i );
+		expect( showMoreButton ).toBeVisible();
 		expect( bioDesc ).toHaveClass( 'is-clamped' );
 
 		await userEvent.click( showMoreButton );
 
 		expect( bioDesc ).toHaveClass( 'is-expanded' );
-		expect( screen.getByRole( 'button', { name: /show less/i } ) ).toBeInTheDocument();
+		expect( screen.getByText( /show less/i ) ).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes: [READ-359](https://linear.app/a8c/issue/READ-359), [READ-366](https://linear.app/a8c/issue/READ-366)

## Proposed Changes

- Update user profile header to better different it with Blogs/Feeds header.
- Preserve line breaks in user bio and allow reading full bio inside the Reader (previously after 3 lines we were showing Reader more link which direct users to Gravatar).
- Add Gravatar badge (if exists) alongside name of the user.

| Before | After |
| -------|------| 
| <img width="1632" height="1228" alt="image" src="https://github.com/user-attachments/assets/eb63bae3-8031-4cc7-9657-0b0de4e24dbd" /> |  <img width="1585" height="1226" alt="image" src="https://github.com/user-attachments/assets/86caf192-8989-49ba-a786-09b0ea105e2a" /> |
|  <img width="1586" height="1223" alt="image" src="https://github.com/user-attachments/assets/68fef509-f430-45ed-8054-264072129882" /> | <img width="1587" height="1229" alt="image" src="https://github.com/user-attachments/assets/16861841-aca4-4a72-948d-46fe7eb142bf" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of the "User Profile Page Redesign" project.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to different user profile pages and verify that the layout matches with design.
- Test the changes on profiles having RTL languages.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
