### PR TITLE
Newsletter Settings: Redirect to wp-admin Jetpack Newsletter settings

### DIFF
--- a/client/my-sites/site-settings/settings-controller.js
+++ b/client/my-sites/site-settings/settings-controller.js
@@ -1,37 +1,18 @@
-import { isWpComPersonalPlan, isWpComPremiumPlan } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import titlecase from 'to-title-case';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
 import { navigate } from 'calypso/lib/navigate';
 import { sectionify } from 'calypso/lib/route';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
-import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
-import { getSiteOption, getSiteUrl } from 'calypso/state/sites/selectors';
-import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
+import { getSiteUrl } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-export function redirectToJetpackNewsletterSettingsIfNeeded( context, next ) {
+export function redirectToJetpackNewsletterSettings( context ) {
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
 	const siteUrl = getSiteUrl( state, siteId );
 
-	const isAtomic = isSiteWpcomAtomic( state, siteId );
-	const hasClassicAdminInterfaceStyle =
-		getSiteOption( state, siteId, 'wpcom_admin_interface' ) === 'wp-admin';
-
-	// Check if site has Personal or Premium plan
-	const sitePlan = getSitePlan( state, siteId );
-	const isPersonalOrPremiumPlan =
-		sitePlan &&
-		( isWpComPersonalPlan( sitePlan.product_slug ) || isWpComPremiumPlan( sitePlan.product_slug ) );
-
-	// Only redirect if it's atomic with classic admin interface AND not Personal/Premium plan
-	if ( hasClassicAdminInterfaceStyle && isAtomic && ! isPersonalOrPremiumPlan ) {
-		navigate( `${ siteUrl }/wp-admin/admin.php?page=jetpack#/newsletter` );
-		return;
-	}
-
-	next();
+	navigate( `${ siteUrl }/wp-admin/admin.php?page=jetpack-newsletter` );
 }
 
 /**

--- a/client/my-sites/site-settings/settings-newsletter/controller.ts
+++ b/client/my-sites/site-settings/settings-newsletter/controller.ts
@@ -1,8 +1,0 @@
-import { createElement } from 'react';
-import NewsletterSettings from './main';
-import type { Callback } from '@automattic/calypso-router';
-
-export const createNewsletterSettings: Callback = ( context, next ) => {
-	context.primary = createElement( NewsletterSettings );
-	next();
-};

--- a/client/my-sites/site-settings/settings-newsletter/index.ts
+++ b/client/my-sites/site-settings/settings-newsletter/index.ts
@@ -1,21 +1,7 @@
 import page from '@automattic/calypso-router';
-import { makeLayout, render as clientRender } from 'calypso/controller';
-import { navigation, siteSelection } from 'calypso/my-sites/controller';
-import {
-	redirectToJetpackNewsletterSettingsIfNeeded,
-	siteSettings,
-} from 'calypso/my-sites/site-settings/settings-controller';
-import { createNewsletterSettings } from './controller';
+import { siteSelection } from 'calypso/my-sites/controller';
+import { redirectToJetpackNewsletterSettings } from 'calypso/my-sites/site-settings/settings-controller';
 
 export default function () {
-	page(
-		'/settings/newsletter/:site_id',
-		siteSelection,
-		redirectToJetpackNewsletterSettingsIfNeeded,
-		navigation,
-		siteSettings,
-		createNewsletterSettings,
-		makeLayout,
-		clientRender
-	);
+	page( '/settings/newsletter/:site_id', siteSelection, redirectToJetpackNewsletterSettings );
 }


### PR DESCRIPTION
Fixes DOTCOM-16249

## Proposed Changes

* Unconditionally redirect `/settings/newsletter/:site` to the new Jetpack Newsletter settings screen at `wp-admin/admin.php?page=jetpack-newsletter`.
* Remove the previous conditional redirect logic that only applied to atomic sites with classic admin interface.
* Clean up unused imports from `settings-controller.js`.

## Why are these changes being made?

The newsletter settings are moving to a dedicated Jetpack Newsletter settings screen in wp-admin. This redirect ensures users visiting the Calypso newsletter settings route are sent to the new location.

> [!WARNING]
> This shouldn't be merged until the Newsletter Settings screen has been deployed to simple and WoW sites as it impacts all sites, not just those opted in.

## Testing Instructions

* Visit `/settings/newsletter/<your-site-slug>` in Calypso
* Verify you are redirected to `<site-url>/wp-admin/admin.php?page=jetpack-newsletter`
* The latter page should show the newsletter settings screen, assuming you have opted in to testing. See pdtkmj-4rt-p2

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?