### PR TITLE
Agents manager: support workflow bot slug via query params

### DIFF
--- a/packages/agents-manager/src/components/agents-manager.tsx
+++ b/packages/agents-manager/src/components/agents-manager.tsx
@@ -70,9 +70,9 @@ function AgentSetup(): JSX.Element | null {
 	const isChatRoute = pathname.startsWith( '/chat' );
 	const isNewChat = isChatRoute && !! state?.isNewChat;
 	const routeSessionId = isChatRoute && state?.sessionId;
-	// Read agent/version overrides from browser URL (?agent=, ?version=).
+	// Read agent/version/slug overrides from browser URL (?agent=, ?version=, ?slug= or ?bot=).
 	// PersistentRouter (memory router) does not track window.location.search.
-	const { agentId, version } = getAgentConfig();
+	const { agentId, version, botSlug } = getAgentConfig();
 	const sessionId = isNewChat ? '' : routeSessionId || getSessionId( agentId );
 
 	useEffect( () => {
@@ -112,13 +112,34 @@ function AgentSetup(): JSX.Element | null {
 				environment: 'calypso',
 				agentId,
 				version,
+				botSlug,
+			} );
+
+			// eslint-disable-next-line no-console
+			console.info( '[AgentsManager Debug] Agent config initialized (dock)', {
+				agentId: config.agentId,
+				agentUrl: config.agentUrl,
+				sessionId: config.sessionId,
+				version,
+				botSlug,
+				locationSearch: window.location.search,
 			} );
 
 			setAgentConfig( config );
 		}
 
 		initializeAgent();
-	}, [ agentId, version, currentRoute, isNewChat, navigate, sessionId, setAgentConfig, site?.ID ] );
+	}, [
+		agentId,
+		version,
+		botSlug,
+		currentRoute,
+		isNewChat,
+		navigate,
+		sessionId,
+		setAgentConfig,
+		site?.ID,
+	] );
 
 	const loadedProviders = loadedProvidersRef.current;
 

--- a/packages/agents-manager/src/components/agents-manager.tsx
+++ b/packages/agents-manager/src/components/agents-manager.tsx
@@ -115,16 +115,6 @@ function AgentSetup(): JSX.Element | null {
 				botSlug,
 			} );
 
-			// eslint-disable-next-line no-console
-			console.info( '[AgentsManager Debug] Agent config initialized (dock)', {
-				agentId: config.agentId,
-				agentUrl: config.agentUrl,
-				sessionId: config.sessionId,
-				version,
-				botSlug,
-				locationSearch: window.location.search,
-			} );
-
 			setAgentConfig( config );
 		}
 

--- a/packages/agents-manager/src/components/headless-agent-initializer.tsx
+++ b/packages/agents-manager/src/components/headless-agent-initializer.tsx
@@ -8,7 +8,7 @@
 
 import { useAgentChat } from '@automattic/agenttic-client';
 import { useEffect, useState, useRef } from '@wordpress/element';
-import { createAgentConfig } from '../utils/agent-config';
+import { createAgentConfig, getAgentConfig } from '../utils/agent-config';
 import { getSessionId } from '../utils/agent-session';
 import { loadExternalProviders, type LoadedProviders } from '../utils/load-external-providers';
 import type { UseAgentChatConfig } from '@automattic/agenttic-client';
@@ -32,8 +32,9 @@ export default function HeadlessAgentInitializer( {
 }: HeadlessAgentInitializerProps ): JSX.Element | null {
 	const [ agentConfig, setAgentConfig ] = useState< UseAgentChatConfig | null >( null );
 	const loadedProvidersRef = useRef< LoadedProviders | null >( null );
+	const { agentId, version, botSlug } = getAgentConfig();
 
-	const sessionId = getSessionId();
+	const sessionId = getSessionId( agentId );
 
 	useEffect( () => {
 		async function initializeAgent(): Promise< void > {
@@ -55,6 +56,19 @@ export default function HeadlessAgentInitializer( {
 				toolProvider: providers.toolProvider,
 				contextProvider: providers.contextProvider,
 				environment: 'wp-admin',
+				agentId,
+				version,
+				botSlug,
+			} );
+
+			// eslint-disable-next-line no-console
+			console.info( '[AgentsManager Debug] Agent config initialized (headless)', {
+				agentId: config.agentId,
+				agentUrl: config.agentUrl,
+				sessionId: config.sessionId,
+				version,
+				botSlug,
+				locationSearch: window.location.search,
 			} );
 
 			setAgentConfig( config );
@@ -63,7 +77,7 @@ export default function HeadlessAgentInitializer( {
 		}
 
 		initializeAgent();
-	}, [ currentRoute, sessionId, site?.ID ] );
+	}, [ agentId, version, botSlug, currentRoute, sessionId, site?.ID ] );
 
 	if ( ! agentConfig ) {
 		return null;

--- a/packages/agents-manager/src/components/headless-agent-initializer.tsx
+++ b/packages/agents-manager/src/components/headless-agent-initializer.tsx
@@ -43,8 +43,6 @@ export default function HeadlessAgentInitializer( {
 			if ( ! providers ) {
 				providers = await loadExternalProviders();
 				loadedProvidersRef.current = providers;
-				// eslint-disable-next-line no-console
-				console.log( '[HeadlessAgentInitializer] Loaded external providers' );
 			}
 
 			const siteId = typeof site?.ID === 'number' ? site.ID : undefined;
@@ -61,19 +59,7 @@ export default function HeadlessAgentInitializer( {
 				botSlug,
 			} );
 
-			// eslint-disable-next-line no-console
-			console.info( '[AgentsManager Debug] Agent config initialized (headless)', {
-				agentId: config.agentId,
-				agentUrl: config.agentUrl,
-				sessionId: config.sessionId,
-				version,
-				botSlug,
-				locationSearch: window.location.search,
-			} );
-
 			setAgentConfig( config );
-			// eslint-disable-next-line no-console
-			console.log( '[HeadlessAgentInitializer] Agent config created' );
 		}
 
 		initializeAgent();

--- a/packages/agents-manager/src/utils/agent-config.ts
+++ b/packages/agents-manager/src/utils/agent-config.ts
@@ -23,6 +23,8 @@ export interface CreateAgentConfigOptions {
 	agentId?: string;
 	/** Override the agent version (e.g., from query string). Passed via constructorArguments. */
 	version?: string;
+	/** Override bot slug (e.g., for WorkflowAgent when agentId is `workflow`). */
+	botSlug?: string;
 }
 
 /**
@@ -81,7 +83,8 @@ function wrapToolProvider( toolProvider: ToolProvider ): UseAgentChatConfig[ 'to
  */
 function createWrappedContextProvider(
 	contextProvider: ContextProvider,
-	version?: string
+	version?: string,
+	botSlug?: string
 ): UseAgentChatConfig[ 'contextProvider' ] {
 	return {
 		getClientContext: () => {
@@ -99,6 +102,7 @@ function createWrappedContextProvider(
 				constructorArguments: {
 					...( resolvedContext.constructorArguments || {} ),
 					...( version && { version } ),
+					...( botSlug && { slug: botSlug } ),
 				},
 			};
 		},
@@ -111,7 +115,8 @@ function createWrappedContextProvider(
 function createDefaultContextProvider(
 	currentRoute: string | undefined,
 	environment: string,
-	version?: string
+	version?: string,
+	botSlug?: string
 ): UseAgentChatConfig[ 'contextProvider' ] {
 	return {
 		getClientContext: () => ( {
@@ -120,7 +125,12 @@ function createDefaultContextProvider(
 			search: window.location.search,
 			environment,
 			// TODO: Remove once agenttic-client supports top-level constructorArguments
-			...( version && { constructorArguments: { version } } ),
+			...( ( version || botSlug ) && {
+				constructorArguments: {
+					...( version && { version } ),
+					...( botSlug && { slug: botSlug } ),
+				},
+			} ),
 		} ),
 	};
 }
@@ -141,6 +151,7 @@ export function createAgentConfig( options: CreateAgentConfigOptions ): UseAgent
 		environment = 'calypso',
 		agentId = ORCHESTRATOR_AGENT_ID,
 		version,
+		botSlug,
 	} = options;
 
 	const config: UseAgentChatConfig = {
@@ -157,9 +168,14 @@ export function createAgentConfig( options: CreateAgentConfigOptions ): UseAgent
 	}
 
 	if ( contextProvider ) {
-		config.contextProvider = createWrappedContextProvider( contextProvider, version );
+		config.contextProvider = createWrappedContextProvider( contextProvider, version, botSlug );
 	} else {
-		config.contextProvider = createDefaultContextProvider( currentRoute, environment, version );
+		config.contextProvider = createDefaultContextProvider(
+			currentRoute,
+			environment,
+			version,
+			botSlug
+		);
 	}
 
 	return config;
@@ -172,14 +188,17 @@ export function createAgentConfig( options: CreateAgentConfigOptions ): UseAgent
  * Query parameters:
  * - `agent`: Override the agent ID (e.g., ?agent=wpcom-workflow-support_chat)
  * - `version`: Override the agent version (e.g., ?version=1.0.25)
+ * - `slug` or `bot`: Override workflow/configurable bot slug while keeping `agent` fixed
  */
-export function getAgentConfig(): { agentId: string; version?: string } {
+export function getAgentConfig(): { agentId: string; version?: string; botSlug?: string } {
 	const urlSearchParams = new URLSearchParams( window.location.search );
 	const agentIdParam = urlSearchParams.get( 'agent' );
 	const versionParam = urlSearchParams.get( 'version' );
+	const botSlugParam = urlSearchParams.get( 'slug' ) || urlSearchParams.get( 'bot' );
 
 	return {
 		agentId: agentIdParam || ORCHESTRATOR_AGENT_ID,
 		version: versionParam || undefined,
+		botSlug: botSlugParam || undefined,
 	};
 }


### PR DESCRIPTION
## Summary
- add `slug` / `bot` query-param parsing in agents-manager config (`getAgentConfig`)
- pass bot slug via `constructorArguments.slug` while preserving existing `agent` + `version` behavior
- wire query-based agent config into both dock and headless initializers

This PR is mostly for testing purposes and awareness, not really planning to merge it as is.

## Manual Testing (Sandbox)
1. Check out this branch and install deps if needed:
   - `git checkout codex/add/workflow-bot-slug-query-param`
   - `yarn install`
2. Start the Agents Manager app watcher from Calypso:
   - `cd apps/agents-manager`
   - `yarn dev --sync`
3. Point both domains to your sandbox:
   - sandbox your test site domain
   - sandbox `widgets.wp.com` as well (this is required because Agents Manager assets are served from widgets)
   - if using hosts-file-based sandboxing, ensure both site domain and `widgets.wp.com` are mapped to the sandbox target
4. In wp-admin, do a hard reload (`Cmd+Shift+R`) after switching sandbox routing.
5. Open AI chat with query params (example):
   - `?agent=workflow&slug=wpcom-workflow-unified_chat`
   - `bot` works as an alias to `slug` (`?agent=workflow&bot=wpcom-workflow-unified_chat`)
6. Verify in Network:
   - request goes to `https://public-api.wordpress.com/wpcom/v2/ai/agent/workflow`
   - request context includes `constructorArguments.slug = wpcom-workflow-unified_chat`
7. Optional behavior check:
   - use a prompt that should trigger support escalation and confirm workflow-agent behavior is returned

## Sandbox Cleanup
When done testing, in your sandbox environment run:
- `git checkout widgets.wp.com`
- `git clean -df widgets.wp.com`

## Notes
- `yarn dev --sync` is for `apps/agents-manager` (not repo root).
- this PR only adds query-param based routing/slug override; first-class config wiring will follow in a separate PR.
