### PR TITLE
Warn users when email forwarding will remove custom MX records

### DIFF
--- a/client/dashboard/emails/add-forwarder/index.tsx
+++ b/client/dashboard/emails/add-forwarder/index.tsx
@@ -1,6 +1,7 @@
 import { EmailProvider } from '@automattic/api-core';
 import {
 	addEmailForwarderMutation,
+	domainDnsQuery,
 	domainQuery,
 	userMailboxesQuery,
 } from '@automattic/api-queries';
@@ -10,6 +11,7 @@ import { useNavigate } from '@tanstack/react-router';
 import {
 	__experimentalVStack as VStack,
 	Button,
+	CheckboxControl,
 	FormTokenField,
 	Spinner,
 } from '@wordpress/components';
@@ -19,7 +21,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import emailValidator from 'email-validator';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { useAppContext } from '../../app/context';
@@ -98,6 +100,20 @@ function AddEmailForwarder() {
 		enabled: !! formData.domain,
 	} );
 
+	const { data: dnsData } = useQuery( {
+		...domainDnsQuery( formData.domain ),
+		enabled: !! formData.domain,
+	} );
+
+	const hasMxRecords = ( dnsData?.records ?? [] ).some( ( record ) => record.type === 'MX' );
+	const showMxWarning = !! domainData?.has_wpcom_nameservers && hasMxRecords;
+
+	const [ mxWarningAcknowledged, setMxWarningAcknowledged ] = useState( false );
+
+	useEffect( () => {
+		setMxWarningAcknowledged( false );
+	}, [ formData.domain ] );
+
 	const fields: Field< FormData >[] = useMemo(
 		() => [
 			{
@@ -157,7 +173,8 @@ function AddEmailForwarder() {
 		( isUntokenizedInputValidEmail || untokenizedInput.trim() === '' ) &&
 		! isDomainMaxForwardsReached &&
 		! willDomainMaxForwardsBeReached &&
-		! duplicateForwardAddresses.length;
+		! duplicateForwardAddresses.length &&
+		( ! showMxWarning || mxWarningAcknowledged );
 
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
@@ -368,6 +385,26 @@ function AddEmailForwarder() {
 											),
 											{ code: <code /> }
 										) }
+									</Notice>
+								) }
+
+								{ showMxWarning && (
+									<Notice variant="warning">
+										<VStack spacing={ 3 }>
+											<span>
+												{ __(
+													'Enabling email forwarding will replace your current MX records. If you are using an email service like Google Workspace or Microsoft 365, this will disable that email service.'
+												) }
+											</span>
+											<CheckboxControl
+												__nextHasNoMarginBottom
+												checked={ mxWarningAcknowledged }
+												onChange={ setMxWarningAcknowledged }
+												label={ __(
+													'I understand that adding email forwarding will replace my existing email configuration'
+												) }
+											/>
+										</VStack>
 									</Notice>
 								) }
 

--- a/client/my-sites/email/email-forwarding/email-forwarding-add-new-compact-list.tsx
+++ b/client/my-sites/email/email-forwarding/email-forwarding-add-new-compact-list.tsx
@@ -10,11 +10,13 @@ type Props = {
 	onAddedEmailForwards: () => void;
 	selectedDomainName: string;
 	showFormHeader?: boolean;
+	showMxWarning?: boolean;
 };
 
 const EmailForwardingAddNewCompactList = ( {
 	onAddedEmailForwards,
 	selectedDomainName,
+	showMxWarning,
 }: Props ) => {
 	const selectedSiteId = useSelector( getSelectedSiteId );
 
@@ -57,6 +59,7 @@ const EmailForwardingAddNewCompactList = ( {
 					existingEmailForwards={ existingEmailForwards }
 					selectedDomainName={ selectedDomainName }
 					disabled={ isAddingEmailForward }
+					showMxWarning={ showMxWarning }
 				/>
 			</div>
 		</form>

--- a/client/my-sites/email/email-forwards-add/add-new-form/index.tsx
+++ b/client/my-sites/email/email-forwards-add/add-new-form/index.tsx
@@ -18,6 +18,10 @@ export function NewForwardForm( {
 	const [ destinations, setDestinations ] = React.useState< string[] >( [] );
 	const [ mxWarningAcknowledged, setMxWarningAcknowledged ] = React.useState( false );
 
+	React.useEffect( () => {
+		setMxWarningAcknowledged( false );
+	}, [ showMxWarning ] );
+
 	const existingForwardsForMailbox = existingEmailForwards?.filter(
 		( forward ) =>
 			forward.mailbox.localeCompare( mailbox, undefined, { sensitivity: 'base' } ) === 0

--- a/client/my-sites/email/email-forwards-add/add-new-form/index.tsx
+++ b/client/my-sites/email/email-forwards-add/add-new-form/index.tsx
@@ -1,6 +1,6 @@
 import { Button, CheckboxControl, Notice } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import React from 'react';
+import { useState } from 'react';
 import { DestinationsInput } from './destination-input';
 import { SourceInput } from './source-input';
 import { isValidMailbox } from './utils';
@@ -14,13 +14,9 @@ export function NewForwardForm( {
 	showMxWarning,
 }: NewForwardFormProps ) {
 	const translate = useTranslate();
-	const [ mailbox, setMailbox ] = React.useState( '' );
-	const [ destinations, setDestinations ] = React.useState< string[] >( [] );
-	const [ mxWarningAcknowledged, setMxWarningAcknowledged ] = React.useState( false );
-
-	React.useEffect( () => {
-		setMxWarningAcknowledged( false );
-	}, [ showMxWarning ] );
+	const [ mailbox, setMailbox ] = useState( '' );
+	const [ destinations, setDestinations ] = useState< string[] >( [] );
+	const [ mxWarningAcknowledged, setMxWarningAcknowledged ] = useState( false );
 
 	const existingForwardsForMailbox = existingEmailForwards?.filter(
 		( forward ) =>

--- a/client/my-sites/email/email-forwards-add/add-new-form/index.tsx
+++ b/client/my-sites/email/email-forwards-add/add-new-form/index.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@wordpress/components';
+import { Button, CheckboxControl, Notice } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { DestinationsInput } from './destination-input';
@@ -11,10 +11,12 @@ export function NewForwardForm( {
 	selectedDomainName,
 	existingEmailForwards,
 	disabled,
+	showMxWarning,
 }: NewForwardFormProps ) {
 	const translate = useTranslate();
 	const [ mailbox, setMailbox ] = React.useState( '' );
 	const [ destinations, setDestinations ] = React.useState< string[] >( [] );
+	const [ mxWarningAcknowledged, setMxWarningAcknowledged ] = React.useState( false );
 
 	const existingForwardsForMailbox = existingEmailForwards?.filter(
 		( forward ) =>
@@ -37,9 +39,31 @@ export function NewForwardForm( {
 				onChange={ setDestinations }
 				mailbox={ mailbox }
 			/>
+			{ showMxWarning && (
+				<Notice status="warning" isDismissible={ false }>
+					<p>
+						{ translate(
+							'Enabling email forwarding will replace your current MX records. If you are using an email service like Google Workspace or Microsoft 365, this will disable that email service.'
+						) }
+					</p>
+					<CheckboxControl
+						__nextHasNoMarginBottom
+						checked={ mxWarningAcknowledged }
+						onChange={ setMxWarningAcknowledged }
+						label={ translate(
+							'I understand that adding email forwarding will replace my existing email configuration'
+						) }
+					/>
+				</Notice>
+			) }
 			<div>
 				<Button
-					disabled={ ! isValidMailbox( mailbox ) || destinations.length < 1 || disabled }
+					disabled={
+						! isValidMailbox( mailbox ) ||
+						destinations.length < 1 ||
+						disabled ||
+						( showMxWarning && ! mxWarningAcknowledged )
+					}
 					variant="primary"
 					type="submit"
 				>

--- a/client/my-sites/email/email-forwards-add/add-new-form/test/index.tsx
+++ b/client/my-sites/email/email-forwards-add/add-new-form/test/index.tsx
@@ -1,0 +1,73 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import React from 'react';
+import { NewForwardForm } from '../index';
+
+jest.mock( 'i18n-calypso', () => ( {
+	useTranslate: () => ( text: string ) => text,
+} ) );
+
+const defaultProps = {
+	selectedDomainName: 'example.com',
+	existingEmailForwards: [],
+	disabled: false,
+};
+
+describe( 'NewForwardForm MX warning', () => {
+	it( 'does not show MX warning when showMxWarning is false', () => {
+		render( <NewForwardForm { ...defaultProps } showMxWarning={ false } /> );
+
+		expect( screen.queryByText( /will replace your current MX records/i ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'does not show MX warning when showMxWarning is undefined', () => {
+		render( <NewForwardForm { ...defaultProps } /> );
+
+		expect( screen.queryByText( /will replace your current MX records/i ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows MX warning when showMxWarning is true', () => {
+		render( <NewForwardForm { ...defaultProps } showMxWarning /> );
+
+		// Target the <p> element directly to avoid matching ancestor nodes
+		// that also contain the text (Notice wraps children in a content div).
+		expect(
+			screen.getByText( ( _, el ) => {
+				return (
+					el?.tagName === 'P' &&
+					/will replace your current MX records/i.test( el?.textContent ?? '' )
+				);
+			} )
+		).toBeVisible();
+		expect( screen.getByLabelText( /I understand that adding email forwarding/i ) ).toBeVisible();
+	} );
+
+	it( 'disables submit button when MX warning is shown and not acknowledged', () => {
+		render( <NewForwardForm { ...defaultProps } showMxWarning /> );
+
+		expect( screen.getByRole( 'button', { name: /Confirm forwards/i } ) ).toBeDisabled();
+	} );
+
+	it( 'allows acknowledging the MX warning via checkbox', async () => {
+		const user = userEvent.setup();
+
+		render( <NewForwardForm { ...defaultProps } showMxWarning /> );
+
+		const checkbox = screen.getByLabelText( /I understand that adding email forwarding/i );
+		expect( checkbox ).not.toBeChecked();
+
+		await user.click( checkbox );
+
+		expect( checkbox ).toBeChecked();
+	} );
+
+	it( 'keeps submit button disabled without MX warning when form is incomplete', () => {
+		render( <NewForwardForm { ...defaultProps } showMxWarning={ false } /> );
+
+		// No mailbox or destinations entered — should still be disabled.
+		expect( screen.getByRole( 'button', { name: /Confirm forwards/i } ) ).toBeDisabled();
+	} );
+} );

--- a/client/my-sites/email/email-forwards-add/add-new-form/test/index.tsx
+++ b/client/my-sites/email/email-forwards-add/add-new-form/test/index.tsx
@@ -64,6 +64,29 @@ describe( 'NewForwardForm MX warning', () => {
 		expect( checkbox ).toBeChecked();
 	} );
 
+	it( 'enables submit button when form is filled and MX warning is acknowledged', async () => {
+		const user = userEvent.setup();
+
+		render( <NewForwardForm { ...defaultProps } showMxWarning /> );
+
+		// Fill in the mailbox name.
+		await user.type( screen.getByRole( 'textbox', { name: /Forward from/i } ), 'info' );
+
+		// Add a forwarding destination via FormTokenField.
+		const destinationInput = screen.getByRole( 'combobox', { name: /Forward to/i } );
+		await user.type( destinationInput, 'test@other.com' );
+		await user.keyboard( '{Enter}' );
+
+		// Button should still be disabled — warning not acknowledged yet.
+		expect( screen.getByRole( 'button', { name: /Confirm forwards/i } ) ).toBeDisabled();
+
+		// Acknowledge the MX warning.
+		await user.click( screen.getByLabelText( /I understand that adding email forwarding/i ) );
+
+		// Now the button should be enabled.
+		expect( screen.getByRole( 'button', { name: /Confirm forwards/i } ) ).toBeEnabled();
+	} );
+
 	it( 'keeps submit button disabled without MX warning when form is incomplete', () => {
 		render( <NewForwardForm { ...defaultProps } showMxWarning={ false } /> );
 

--- a/client/my-sites/email/email-forwards-add/add-new-form/types.ts
+++ b/client/my-sites/email/email-forwards-add/add-new-form/types.ts
@@ -21,4 +21,5 @@ export interface NewForwardFormProps {
 	selectedDomainName: string;
 	existingEmailForwards: EmailAccountEmail[];
 	disabled: boolean;
+	showMxWarning?: boolean;
 }

--- a/client/my-sites/email/email-forwards-add/index.tsx
+++ b/client/my-sites/email/email-forwards-add/index.tsx
@@ -4,6 +4,7 @@ import { CALYPSO_CONTACT } from '@automattic/urls';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
+import QueryDomainDns from 'calypso/components/data/query-domain-dns';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import HeaderCake from 'calypso/components/header-cake';
@@ -22,6 +23,7 @@ import {
 	getPurchaseNewEmailAccountPath,
 } from 'calypso/my-sites/email/paths';
 import { useSelector } from 'calypso/state';
+import { getDomainDns } from 'calypso/state/domains/dns/selectors';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import {
 	getDomainsBySiteId,
@@ -60,6 +62,13 @@ const EmailForwardsAdd = ( {
 
 	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) );
 	const selectedDomain = getSelectedDomain( { domains, selectedDomainName } );
+
+	const domainDns = useSelector( ( state ) => getDomainDns( state, selectedDomainName ) );
+	const hasMxRecords = ( domainDns?.records ?? [] ).some(
+		( record: { type: string } ) => record.type === 'MX'
+	);
+	const showMxWarning = !! selectedDomain?.hasWpcomNameservers && hasMxRecords;
+
 	const cannotAddEmailWarningReason = getCurrentUserCannotAddEmailReason( selectedDomain );
 	const isGravatarRestrictedDomain =
 		cannotAddEmailWarningReason?.code === EMAIL_WARNING_CODE_GRAVATAR_DOMAIN;
@@ -137,6 +146,7 @@ const EmailForwardsAdd = ( {
 						onAddedEmailForwards={ onAddedEmailForwards }
 						selectedDomainName={ selectedDomainName }
 						showFormHeader={ showFormHeader }
+						showMxWarning={ showMxWarning }
 					/>
 				) }
 			</Card>
@@ -147,6 +157,8 @@ const EmailForwardsAdd = ( {
 			<QueryProductsList />
 
 			{ selectedSite && <QuerySiteDomains siteId={ selectedSite.ID } /> }
+
+			<QueryDomainDns domain={ selectedDomainName } />
 
 			<Main wideLayout className="email-forwards-add">
 				<DocumentHead title={ translate( 'Add New Email Forwards' ) } />

--- a/client/my-sites/email/email-forwards-add/index.tsx
+++ b/client/my-sites/email/email-forwards-add/index.tsx
@@ -158,7 +158,7 @@ const EmailForwardsAdd = ( {
 
 			{ selectedSite && <QuerySiteDomains siteId={ selectedSite.ID } /> }
 
-			<QueryDomainDns domain={ selectedDomainName } />
+			{ selectedDomainName && <QueryDomainDns domain={ selectedDomainName } /> }
 
 			<Main wideLayout className="email-forwards-add">
 				<DocumentHead title={ translate( 'Add New Email Forwards' ) } />


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTEMP-48

## Proposed Changes

This adds warnings to the email forwarding form both in Calypso and the MSD. The warning appears if the domain's DNS is hosted on WPcom _and_ there are custom MX records. The warning shows a checkbox warning the user that their existing email confirmation will be replaced. They're required to check the box in order to create the forward.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

It wasn't clear to users that existing email DNS entries would be replaced which lead to confusion and users accidentally breaking their email setup.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

You'll need to create a site with a Premium or Business plan. Then purchase a domain attached to that site. Then add a custom MX record to the domain.

### To test Calypso:
* Visit `http://calypso.localhost:3000/email/:domainName/forwarding/add/:domainName?source=purchase`
* Verify you see the warning:
<img width="1117" height="695" alt="image" src="https://github.com/user-attachments/assets/18818256-a927-4e82-820a-b96bd382e108" />
* Entering values into the form and checking the box should enable the "Confirm forwards" button.

### To test the MSD:
* Visit `http://my.localhost:3000/emails/add-forwarder` and select your domain from the pulldown.
* Verify you see the warning:
<img width="739" height="440" alt="image" src="https://github.com/user-attachments/assets/bb9bd026-df8a-44af-a324-1dd36b57aafa" />
* Entering values into the form and checking the box should enable the "Save" button.

### Other
Visit both screens for a domain that either does not have DNS hosted at WPcom or does not have custom MX records and verify the warning doesn't appear.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
