### PR TITLE
Agents manager: add first-class workflow agent config

### DIFF
--- a/apps/agents-manager/agents-manager-with-provider.js
+++ b/apps/agents-manager/agents-manager-with-provider.js
@@ -11,6 +11,7 @@ export default function AgentsManagerWithProvider() {
 				sectionName={ agentsManagerData.sectionName || 'wp-admin' }
 				currentUser={ agentsManagerData.currentUser }
 				site={ agentsManagerData.site }
+				agentConfig={ agentsManagerData.agentConfig }
 			/>
 		</QueryClientProvider>
 	);

--- a/apps/agents-manager/headless-agent-with-provider.js
+++ b/apps/agents-manager/headless-agent-with-provider.js
@@ -13,6 +13,7 @@ export default function HeadlessAgentWithProvider() {
 			<HeadlessAgentInitializer
 				site={ helpCenterData?.site }
 				currentRoute={ window.location.pathname }
+				agentConfig={ helpCenterData?.agentConfig }
 			/>
 		</QueryClientProvider>
 	);

--- a/packages/agents-manager/README.md
+++ b/packages/agents-manager/README.md
@@ -20,7 +20,14 @@ import AgentsManager from '@automattic/agents-manager';
 function MyApp() {
 	const site = { ID: 456, URL: 'https://example.com' };
 
-	return <AgentsManager currentRoute="/dashboard" sectionName="dashboard" site={ site } />;
+	return (
+		<AgentsManager
+			currentRoute="/dashboard"
+			sectionName="dashboard"
+			site={ site }
+			agentConfig={ { agentId: 'workflow', botSlug: 'wpcom-workflow-unified_chat' } }
+		/>
+	);
 }
 ```
 
@@ -32,7 +39,13 @@ Use `HeadlessAgentInitializer` when you need to create the agent without renderi
 import { HeadlessAgentInitializer } from '@automattic/agents-manager';
 
 function MyApp() {
-	return <HeadlessAgentInitializer site={ site } currentRoute="/media" />;
+	return (
+		<HeadlessAgentInitializer
+			site={ site }
+			currentRoute="/media"
+			agentConfig={ { agentId: 'workflow', botSlug: 'wpcom-workflow-unified_chat' } }
+		/>
+	);
 }
 ```
 
@@ -81,6 +94,7 @@ See `src/hooks/use-setup-custom-actions/README.md` for details.
 | `currentUser`  | `CurrentUser` (optional)       | Current user (from `@automattic/data-stores`). Sets `isLoggedIn`. |
 | `site`         | `AgentsManagerSite` (optional) | The selected site object (from `@automattic/data-stores`).        |
 | `currentRoute` | `string` (optional)            | The current route path.                                           |
+| `agentConfig`  | `AgentConfigOverrides` (optional) | Explicit agent routing config (`agentId`, `version`, `botSlug`). |
 | `handleClose`  | `() => void` (optional)        | Called when the agent is closed.                                  |
 
 ### Exported Hooks and Utilities

--- a/packages/agents-manager/src/components/agents-manager.tsx
+++ b/packages/agents-manager/src/components/agents-manager.tsx
@@ -11,7 +11,11 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { AgentsManagerContextProvider, useAgentsManagerContext } from '../contexts';
 import { useEmptyViewSuggestions } from '../hooks/use-empty-view-suggestions';
 import { AGENTS_MANAGER_STORE } from '../stores';
-import { createAgentConfig, getAgentConfig } from '../utils/agent-config';
+import {
+	createAgentConfig,
+	getAgentConfig,
+	type AgentConfigOverrides,
+} from '../utils/agent-config';
 import { getSessionId, clearSessionId } from '../utils/agent-session';
 import { loadExternalProviders, type LoadedProviders } from '../utils/load-external-providers';
 import AgentDock from './agent-dock';
@@ -26,6 +30,8 @@ export interface AgentsManagerProps {
 	site?: AgentsManagerSite | null;
 	/** The current route path. */
 	currentRoute?: string;
+	/** Optional explicit agent configuration overrides. */
+	agentConfig?: AgentConfigOverrides;
 	/** Called when the agent is closed. */
 	handleClose?: () => void;
 }
@@ -37,6 +43,7 @@ export default function AgentsManager( {
 	currentUser,
 	site,
 	currentRoute,
+	agentConfig,
 }: AgentsManagerProps ): JSX.Element | null {
 	// Wait for the store to load before rendering PersistentRouter
 	// This ensures router history is restored from persisted state
@@ -53,7 +60,7 @@ export default function AgentsManager( {
 		<AgentsManagerContextProvider value={ { sectionName, currentUser, site, currentRoute } }>
 			<QueryClientProvider client={ queryClient }>
 				<PersistentRouter>
-					<AgentSetup />
+					<AgentSetup agentConfigOverrides={ agentConfig } />
 				</PersistentRouter>
 			</QueryClientProvider>
 		</AgentsManagerContextProvider>
@@ -61,7 +68,11 @@ export default function AgentsManager( {
 }
 
 // Separate component that uses hooks within `PersistentRouter` context
-function AgentSetup(): JSX.Element | null {
+function AgentSetup( {
+	agentConfigOverrides,
+}: {
+	agentConfigOverrides?: AgentConfigOverrides;
+} ): JSX.Element | null {
 	const { site, currentRoute, agentConfig, setAgentConfig } = useAgentsManagerContext();
 	const loadedProvidersRef = useRef< LoadedProviders | null >( null );
 	const navigate = useNavigate();
@@ -70,9 +81,9 @@ function AgentSetup(): JSX.Element | null {
 	const isChatRoute = pathname.startsWith( '/chat' );
 	const isNewChat = isChatRoute && !! state?.isNewChat;
 	const routeSessionId = isChatRoute && state?.sessionId;
-	// Read agent/version overrides from browser URL (?agent=, ?version=).
+	// Resolve explicit config overrides first, then URL query params as fallback.
 	// PersistentRouter (memory router) does not track window.location.search.
-	const { agentId, version } = getAgentConfig();
+	const { agentId, version, botSlug } = getAgentConfig( agentConfigOverrides );
 	const sessionId = isNewChat ? '' : routeSessionId || getSessionId( agentId );
 
 	useEffect( () => {
@@ -112,13 +123,24 @@ function AgentSetup(): JSX.Element | null {
 				environment: 'calypso',
 				agentId,
 				version,
+				botSlug,
 			} );
 
 			setAgentConfig( config );
 		}
 
 		initializeAgent();
-	}, [ agentId, version, currentRoute, isNewChat, navigate, sessionId, setAgentConfig, site?.ID ] );
+	}, [
+		agentId,
+		version,
+		botSlug,
+		currentRoute,
+		isNewChat,
+		navigate,
+		sessionId,
+		setAgentConfig,
+		site?.ID,
+	] );
 
 	const loadedProviders = loadedProvidersRef.current;
 

--- a/packages/agents-manager/src/components/headless-agent-initializer.tsx
+++ b/packages/agents-manager/src/components/headless-agent-initializer.tsx
@@ -8,9 +8,10 @@
 
 import { useAgentChat } from '@automattic/agenttic-client';
 import { useEffect, useState, useRef } from '@wordpress/element';
-import { createAgentConfig } from '../utils/agent-config';
+import { createAgentConfig, getAgentConfig } from '../utils/agent-config';
 import { getSessionId } from '../utils/agent-session';
 import { loadExternalProviders, type LoadedProviders } from '../utils/load-external-providers';
+import type { AgentConfigOverrides } from '../utils/agent-config';
 import type { UseAgentChatConfig } from '@automattic/agenttic-client';
 import type { HelpCenterSite } from '@automattic/data-stores';
 
@@ -19,6 +20,8 @@ export interface HeadlessAgentInitializerProps {
 	site?: HelpCenterSite | null;
 	/** The current route path. */
 	currentRoute?: string;
+	/** Optional explicit agent configuration overrides. */
+	agentConfig?: AgentConfigOverrides;
 }
 
 /**
@@ -29,11 +32,15 @@ export interface HeadlessAgentInitializerProps {
 export default function HeadlessAgentInitializer( {
 	site = null,
 	currentRoute,
+	agentConfig,
 }: HeadlessAgentInitializerProps ): JSX.Element | null {
-	const [ agentConfig, setAgentConfig ] = useState< UseAgentChatConfig | null >( null );
+	const [ resolvedAgentConfig, setResolvedAgentConfig ] = useState< UseAgentChatConfig | null >(
+		null
+	);
 	const loadedProvidersRef = useRef< LoadedProviders | null >( null );
+	const { agentId, version, botSlug } = getAgentConfig( agentConfig );
 
-	const sessionId = getSessionId();
+	const sessionId = getSessionId( agentId );
 
 	useEffect( () => {
 		async function initializeAgent(): Promise< void > {
@@ -42,8 +49,6 @@ export default function HeadlessAgentInitializer( {
 			if ( ! providers ) {
 				providers = await loadExternalProviders();
 				loadedProvidersRef.current = providers;
-				// eslint-disable-next-line no-console
-				console.log( '[HeadlessAgentInitializer] Loaded external providers' );
 			}
 
 			const siteId = typeof site?.ID === 'number' ? site.ID : undefined;
@@ -55,21 +60,22 @@ export default function HeadlessAgentInitializer( {
 				toolProvider: providers.toolProvider,
 				contextProvider: providers.contextProvider,
 				environment: 'wp-admin',
+				agentId,
+				version,
+				botSlug,
 			} );
 
-			setAgentConfig( config );
-			// eslint-disable-next-line no-console
-			console.log( '[HeadlessAgentInitializer] Agent config created' );
+			setResolvedAgentConfig( config );
 		}
 
 		initializeAgent();
-	}, [ currentRoute, sessionId, site?.ID ] );
+	}, [ agentId, version, botSlug, currentRoute, sessionId, site?.ID ] );
 
-	if ( ! agentConfig ) {
+	if ( ! resolvedAgentConfig ) {
 		return null;
 	}
 
-	return <AgentInitializerInner agentConfig={ agentConfig } />;
+	return <AgentInitializerInner agentConfig={ resolvedAgentConfig } />;
 }
 
 /**

--- a/packages/agents-manager/src/global.d.ts
+++ b/packages/agents-manager/src/global.d.ts
@@ -11,6 +11,11 @@ declare const agentsManagerData:
 			agentProviders?: string[];
 			useUnifiedExperience?: boolean;
 			helpCenterUrl?: string;
+			agentConfig?: {
+				agentId?: string;
+				version?: string;
+				botSlug?: string;
+			};
 	  }
 	| undefined;
 

--- a/packages/agents-manager/src/index.ts
+++ b/packages/agents-manager/src/index.ts
@@ -5,6 +5,7 @@ export { default as HeadlessAgentInitializer } from './components/headless-agent
 export type { HeadlessAgentInitializerProps } from './components/headless-agent-initializer';
 
 export { AGENTS_MANAGER_STORE } from './stores';
+export type { AgentConfigOverrides } from './utils/agent-config';
 
 // Utility for checking unified experience from inline script data
 export { getUseUnifiedExperienceFromInlineData } from './utils/load-external-providers';

--- a/packages/agents-manager/src/utils/agent-config.ts
+++ b/packages/agents-manager/src/utils/agent-config.ts
@@ -24,6 +24,17 @@ export interface CreateAgentConfigOptions {
 	agentId?: string;
 	/** Override the agent version (e.g., from query string). Passed via constructorArguments. */
 	version?: string;
+	/** Override bot slug (e.g., for workflow agent configurations). */
+	botSlug?: string;
+}
+
+export interface AgentConfigOverrides {
+	/** Explicit agent ID to use (for example `workflow`). */
+	agentId?: string;
+	/** Optional constructor argument version. */
+	version?: string;
+	/** Optional constructor argument slug for workflow bot selection. */
+	botSlug?: string;
 }
 
 /**
@@ -82,7 +93,9 @@ function wrapToolProvider( toolProvider: ToolProvider ): UseAgentChatConfig[ 'to
  */
 async function createWrappedContextProvider(
 	contextProvider: ContextProvider,
-	version?: string
+	environment: string,
+	version?: string,
+	botSlug?: string
 ): Promise< UseAgentChatConfig[ 'contextProvider' ] > {
 	const canAccessZendesk = await canConnectToZendesk();
 	return {
@@ -96,12 +109,21 @@ async function createWrappedContextProvider(
 				  }
 				: pluginContext;
 
+			const fallbackContext = {
+				url: window.location.href,
+				pathname: window.location.pathname,
+				search: window.location.search,
+				environment,
+			};
+
 			return {
+				...fallbackContext,
 				...resolvedContext,
 				can_access_zendesk: canAccessZendesk,
 				constructorArguments: {
 					...( resolvedContext.constructorArguments || {} ),
 					...( version && { version } ),
+					...( botSlug && { slug: botSlug } ),
 				},
 			};
 		},
@@ -114,7 +136,8 @@ async function createWrappedContextProvider(
 async function createDefaultContextProvider(
 	currentRoute: string | undefined,
 	environment: string,
-	version?: string
+	version?: string,
+	botSlug?: string
 ): Promise< UseAgentChatConfig[ 'contextProvider' ] > {
 	const canAccessZendesk = await canConnectToZendesk();
 	return {
@@ -125,7 +148,12 @@ async function createDefaultContextProvider(
 			can_access_zendesk: canAccessZendesk,
 			environment,
 			// TODO: Remove once agenttic-client supports top-level constructorArguments
-			...( version && { constructorArguments: { version } } ),
+			...( ( version || botSlug ) && {
+				constructorArguments: {
+					...( version && { version } ),
+					...( botSlug && { slug: botSlug } ),
+				},
+			} ),
 		} ),
 	};
 }
@@ -148,6 +176,7 @@ export async function createAgentConfig(
 		environment = 'calypso',
 		agentId = ORCHESTRATOR_AGENT_ID,
 		version,
+		botSlug,
 	} = options;
 
 	const config: UseAgentChatConfig = {
@@ -164,12 +193,18 @@ export async function createAgentConfig(
 	}
 
 	if ( contextProvider ) {
-		config.contextProvider = await createWrappedContextProvider( contextProvider, version );
+		config.contextProvider = await createWrappedContextProvider(
+			contextProvider,
+			environment,
+			version,
+			botSlug
+		);
 	} else {
 		config.contextProvider = await createDefaultContextProvider(
 			currentRoute,
 			environment,
-			version
+			version,
+			botSlug
 		);
 	}
 
@@ -177,20 +212,27 @@ export async function createAgentConfig(
 }
 
 /**
- * Get agent configuration from query string parameters or defaults.
- * Allows overriding agent ID and version via URL for testing purposes.
+ * Resolve agent config from explicit overrides, query string, and defaults.
+ * Priority: explicit overrides > query params > defaults.
  *
  * Query parameters:
  * - `agent`: Override the agent ID (e.g., ?agent=wpcom-workflow-support_chat)
  * - `version`: Override the agent version (e.g., ?version=1.0.25)
+ * - `slug` or `bot`: Override workflow/configurable bot slug
  */
-export function getAgentConfig(): { agentId: string; version?: string } {
+export function getAgentConfig( overrides: AgentConfigOverrides = {} ): {
+	agentId: string;
+	version?: string;
+	botSlug?: string;
+} {
 	const urlSearchParams = new URLSearchParams( window.location.search );
 	const agentIdParam = urlSearchParams.get( 'agent' );
 	const versionParam = urlSearchParams.get( 'version' );
+	const botSlugParam = urlSearchParams.get( 'slug' ) || urlSearchParams.get( 'bot' );
 
 	return {
-		agentId: agentIdParam || ORCHESTRATOR_AGENT_ID,
-		version: versionParam || undefined,
+		agentId: overrides.agentId || agentIdParam || ORCHESTRATOR_AGENT_ID,
+		version: overrides.version || versionParam || undefined,
+		botSlug: overrides.botSlug || botSlugParam || undefined,
 	};
 }

--- a/packages/agents-manager/src/utils/test/agent-config.test.ts
+++ b/packages/agents-manager/src/utils/test/agent-config.test.ts
@@ -1,0 +1,95 @@
+import { ORCHESTRATOR_AGENT_ID } from '../../constants';
+import { createAgentConfig, getAgentConfig } from '../agent-config';
+import type { ContextProvider } from '../../extension-types';
+
+describe( 'agent-config', () => {
+	beforeEach( () => {
+		window.history.replaceState( {}, '', '/' );
+	} );
+
+	describe( 'getAgentConfig', () => {
+		it( 'returns defaults when no overrides are provided', () => {
+			expect( getAgentConfig() ).toEqual( {
+				agentId: ORCHESTRATOR_AGENT_ID,
+				version: undefined,
+				botSlug: undefined,
+			} );
+		} );
+
+		it( 'uses query params when explicit overrides are not provided', () => {
+			window.history.replaceState( {}, '', '/?agent=workflow&version=1.0.1&slug=slug-a' );
+
+			expect( getAgentConfig() ).toEqual( {
+				agentId: 'workflow',
+				version: '1.0.1',
+				botSlug: 'slug-a',
+			} );
+		} );
+
+		it( 'accepts `bot` alias for bot slug query param', () => {
+			window.history.replaceState( {}, '', '/?agent=workflow&bot=slug-b' );
+
+			expect( getAgentConfig() ).toEqual( {
+				agentId: 'workflow',
+				version: undefined,
+				botSlug: 'slug-b',
+			} );
+		} );
+
+		it( 'prioritizes explicit overrides over query params', () => {
+			window.history.replaceState( {}, '', '/?agent=wp-orchestrator&version=old&slug=old-slug' );
+
+			expect(
+				getAgentConfig( {
+					agentId: 'workflow',
+					version: '2.0.0',
+					botSlug: 'new-slug',
+				} )
+			).toEqual( {
+				agentId: 'workflow',
+				version: '2.0.0',
+				botSlug: 'new-slug',
+			} );
+		} );
+	} );
+
+	describe( 'createAgentConfig', () => {
+		it( 'adds bot slug to constructorArguments for default context provider', () => {
+			const config = createAgentConfig( {
+				sessionId: 'session-1',
+				agentId: 'workflow',
+				botSlug: 'workflow-bot',
+			} );
+
+			expect( config.contextProvider?.getClientContext().constructorArguments ).toEqual( {
+				slug: 'workflow-bot',
+			} );
+		} );
+
+		it( 'merges version and bot slug with existing constructor arguments', () => {
+			const contextProvider: ContextProvider = {
+				getClientContext: () => ( {
+					url: 'https://example.com',
+					pathname: '/wp-admin',
+					search: '',
+					environment: 'wp-admin',
+					constructorArguments: { existing: 'value' },
+				} ),
+			};
+
+			const config = createAgentConfig( {
+				sessionId: 'session-2',
+				agentId: 'workflow',
+				version: '1.2.3',
+				botSlug: 'workflow-bot',
+				contextProvider,
+			} );
+
+			expect( config.contextProvider?.getClientContext().constructorArguments ).toEqual( {
+				existing: 'value',
+				version: '1.2.3',
+				slug: 'workflow-bot',
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
## Summary
- add first-class `agentConfig` support to `AgentsManager` and `HeadlessAgentInitializer`
- support explicit `agentId`, `version`, and `botSlug` overrides in agent config resolution
- include `botSlug` in `constructorArguments.slug` for both default and wrapped context providers
- wire inline runtime config from `agentsManagerData.agentConfig` and `helpCenterData.agentConfig`
- keep query params (`agent`, `version`, `slug|bot`) as fallback only

## Why
This implements proper runtime wiring for workflow agent routing/configuration without relying on query parameters as the primary mechanism.

I verified the approach with query parameters works ([PR](https://github.com/Automattic/wp-calypso/pull/109196)), so this is proper implementation for the same concept.

## Example Runtime Config
```js
agentConfig: {
  agentId: 'workflow',
  botSlug: 'wpcom-workflow-unified_chat',
}
```

## Testing
1. `yarn workspace @automattic/agents-manager run build`
2. `yarn exec jest -c packages/agents-manager/jest.config.js packages/agents-manager/src/utils/test/agent-config.test.ts --runInBand`

### Manual Validation
1. In Calypso, run `cd apps/agents-manager && yarn dev --sync`
2. Sandbox both your site domain and `widgets.wp.com`
3. Ensure inline data includes:
   - `agentsManagerData.agentConfig = { agentId: 'workflow', botSlug: 'wpcom-workflow-unified_chat' }`
4. Hard refresh wp-admin and open AI chat
5. Confirm requests go to `/wpcom/v2/ai/agent/workflow` and constructor args include `slug`

## Notes
- This PR is independent of the query-param PR and can be reviewed/merged on its own.
