### PR TITLE
Add supported plans to the big sky free trial redirect on home

### DIFF
--- a/client/state/sites/plans/selectors/is-site-big-sky-trial.ts
+++ b/client/state/sites/plans/selectors/is-site-big-sky-trial.ts
@@ -1,4 +1,8 @@
 import {
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_MONTHLY,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_PERSONAL_3_YEARS,
 	PLAN_BUSINESS,
 	PLAN_BUSINESS_MONTHLY,
 	PLAN_BUSINESS_2_YEARS,
@@ -7,6 +11,10 @@ import {
 	PLAN_PREMIUM_MONTHLY,
 	PLAN_PREMIUM_2_YEARS,
 	PLAN_PREMIUM_3_YEARS,
+	PLAN_ECOMMERCE_MONTHLY,
+	PLAN_ECOMMERCE_2_YEARS,
+	PLAN_ECOMMERCE_3_YEARS,
+	PLAN_ECOMMERCE,
 } from '@automattic/calypso-products';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getCurrentPlan } from '.';
@@ -27,6 +35,14 @@ export default function isSiteBigSkyTrial( state: AppState, siteId: number ) {
 
 	const currentPlan = getCurrentPlan( state, siteId );
 	const bigSkyPlans = [
+		PLAN_PERSONAL,
+		PLAN_PERSONAL_MONTHLY,
+		PLAN_PERSONAL_2_YEARS,
+		PLAN_PERSONAL_3_YEARS,
+		PLAN_ECOMMERCE,
+		PLAN_ECOMMERCE_MONTHLY,
+		PLAN_ECOMMERCE_2_YEARS,
+		PLAN_ECOMMERCE_3_YEARS,
 		PLAN_BUSINESS,
 		PLAN_BUSINESS_MONTHLY,
 		PLAN_BUSINESS_2_YEARS,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to p1773247938451999-slack-C06121P56QZ

## Proposed Changes

Add all supported plans to big sky free trial check. 

These should match what we have in the backend. Check `class.wpcom-features.php` in wpcom repo: 

```
self::BIG_SKY                           => array(
	self::WPCOM_PERSONAL_PLANS,
	self::WPCOM_BUSINESS_PLANS,
	self::WPCOM_PREMIUM_PLANS,
	self::WPCOM_ECOMMERCE_PLANS,
),
```

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Because the wordpress.com/home page was still redirecting for personal plan users and others. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Verify this check isn't used anywhere else important

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?