### PR TITLE
Theme Showcase: Add search results layout with community collection support

### DIFF
--- a/client/my-sites/themes/collections/collection-definitions.tsx
+++ b/client/my-sites/themes/collections/collection-definitions.tsx
@@ -1,4 +1,10 @@
 import { translate } from 'i18n-calypso';
+import type { TranslateResult } from 'i18n-calypso';
+
+export type ThemeCollectionDescription =
+	| TranslateResult
+	| ( ( options?: { search?: string } ) => TranslateResult )
+	| null;
 
 export type ThemeCollectionDefinition = {
 	query: {
@@ -12,7 +18,7 @@ export type ThemeCollectionDefinition = {
 	title: string;
 	fullTitle: string;
 	collectionSlug: string;
-	description: string | null;
+	description: ThemeCollectionDescription;
 	seeAllLink: string;
 };
 
@@ -79,5 +85,32 @@ export const THEME_COLLECTIONS: Record< string, ThemeCollectionDefinition > = {
 			return translate( 'Professional themes designed and developed by our partners.' );
 		},
 		seeAllLink: '/themes/partner',
+	},
+	community: {
+		query: {
+			collection: '',
+			filter: '',
+			number: 100,
+			page: 1,
+			search: '',
+			tier: '',
+		},
+		get title() {
+			return translate( 'Community themes' );
+		},
+		get fullTitle() {
+			return translate( 'Community themes' );
+		},
+		collectionSlug: 'community-themes',
+		description: ( { search } = {} ) =>
+			search
+				? translate(
+						'Explore "%(query)s" themes from the WordPress community, and upload to install when ready.',
+						{ args: { query: search } }
+				  )
+				: translate(
+						'Explore themes from the WordPress community, and upload to install when ready.'
+				  ),
+		seeAllLink: '/themes/community/collection',
 	},
 };

--- a/client/my-sites/themes/collections/theme-collection-view-header.jsx
+++ b/client/my-sites/themes/collections/theme-collection-view-header.jsx
@@ -7,10 +7,21 @@ import CollectionBackButton from 'calypso/my-sites/themes/collections/collection
 import { THEME_COLLECTIONS } from 'calypso/my-sites/themes/collections/collection-definitions';
 import './theme-collection-view-header.scss';
 
-export default function ThemeCollectionViewHeader( { backUrl, filter, tier, isLoggedIn } ) {
+export default function ThemeCollectionViewHeader( {
+	backUrl,
+	filter,
+	tier,
+	options,
+	isLoggedIn,
+} ) {
 	const keyParts = [ tier, filter ];
 	const key = keyParts.filter( ( part ) => !! part ).join( '-' ) || 'recommended';
-	const { title, description } = THEME_COLLECTIONS[ key ];
+	const collection = THEME_COLLECTIONS[ key ];
+	const title = collection.title;
+	const description =
+		typeof collection.description === 'function'
+			? collection.description( options )
+			: collection.description;
 
 	const classnames = clsx( 'theme-collection-view-header', {
 		'is-logged-in': isLoggedIn,

--- a/client/my-sites/themes/collections/theme-collection-view-header.scss
+++ b/client/my-sites/themes/collections/theme-collection-view-header.scss
@@ -124,11 +124,29 @@
 	}
 
 	.formatted-header {
-		margin-inline: 0;
+		margin: 0;
 	}
 
-	.formatted-header__title,
-	.formatted-header__subtitle,
+	.formatted-header__title {
+		color: var( --studio-gray-100 );
+		font-family: $brand-serif;
+		font-size: rem( 40px );
+		font-weight: 400;
+		line-height: 1.2;
+		margin: 0;
+
+		@include break-medium {
+			font-size: rem( 50px );
+		}
+	}
+
+	.formatted-header__subtitle {
+		color: var( --studio-gray-80 );
+		font-size: $font-body-large;
+		line-height: 1.5;
+		margin-block-end: 24px;
+	}
+
 	.theme-collection-view-header__back {
 		color: var(--studio-gray-90);
 	}

--- a/client/my-sites/themes/search-results-modern/index.tsx
+++ b/client/my-sites/themes/search-results-modern/index.tsx
@@ -3,6 +3,8 @@ import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { useQueryThemes } from 'calypso/components/data/query-themes';
 import { ThemeBlock } from 'calypso/components/themes-list';
+import { buildRelativeSearchUrl } from 'calypso/lib/build-url';
+import { THEME_COLLECTIONS } from 'calypso/my-sites/themes/collections/collection-definitions';
 import { useThemeCollection } from 'calypso/my-sites/themes/collections/use-theme-collection';
 import { getThemeShowcaseEventRecorder } from 'calypso/my-sites/themes/events/theme-showcase-tracks';
 import { trackClick } from 'calypso/my-sites/themes/helpers';
@@ -17,6 +19,8 @@ import type { ThemesQuery } from 'calypso/my-sites/themes/collections/use-theme-
 import type { Theme } from 'calypso/types';
 
 import './style.scss';
+
+const WPORG_THEMES_LIMIT = 6;
 
 interface SearchResultsModernProps {
 	search: string;
@@ -92,6 +96,10 @@ export default function SearchResultsModern( {
 
 	const hasWpcomThemes = wpcomThemes.length > 0;
 	const hasWporgThemes = wporgThemes.length > 0;
+	const hasMoreWporgThemes = wporgThemes.length > WPORG_THEMES_LIMIT;
+	const displayedWporgThemes = hasMoreWporgThemes
+		? wporgThemes.slice( 0, WPORG_THEMES_LIMIT )
+		: wporgThemes;
 	const hasAnyThemes = hasWpcomThemes || hasWporgThemes;
 
 	// Analytics for wpcom section.
@@ -216,8 +224,19 @@ export default function SearchResultsModern( {
 							'Explore "%(query)s" themes from the WordPress community, and upload to install when ready.',
 							{ args: { query: search } }
 						) }
+						buttonLabel={ hasMoreWporgThemes ? translate( 'See all' ) : undefined }
+						onButtonClick={
+							hasMoreWporgThemes
+								? () => {
+										page(
+											buildRelativeSearchUrl( THEME_COLLECTIONS.community.seeAllLink, search )
+										);
+										window.scrollTo( { top: 0 } );
+								  }
+								: undefined
+						}
 					/>
-					{ renderThemeGrid( wporgThemes, wporgEventRecorder ) }
+					{ renderThemeGrid( displayedWporgThemes, wporgEventRecorder ) }
 				</div>
 			) }
 

--- a/client/my-sites/themes/search-results-modern/index.tsx
+++ b/client/my-sites/themes/search-results-modern/index.tsx
@@ -201,7 +201,7 @@ export default function SearchResultsModern( {
 			{ hasWpcomThemes && (
 				<div className="search-results-modern__section">
 					<ThemeSectionHeader
-						title={ translate( 'Results for %(query)s', { args: { query: search } } ) }
+						title={ translate( 'Results for "%(query)s"', { args: { query: search } } ) }
 						subtitle=""
 					/>
 					{ renderThemeGrid( wpcomThemes, wpcomEventRecorder ) }
@@ -213,7 +213,8 @@ export default function SearchResultsModern( {
 					<ThemeSectionHeader
 						title={ translate( 'Community themes' ) }
 						subtitle={ translate(
-							'Explore themes from the WordPress community, and upload to install when ready.'
+							'Explore "%(query)s" themes from the WordPress community, and upload to install when ready.',
+							{ args: { query: search } }
 						) }
 					/>
 					{ renderThemeGrid( wporgThemes, wporgEventRecorder ) }

--- a/client/my-sites/themes/search-results-modern/index.tsx
+++ b/client/my-sites/themes/search-results-modern/index.tsx
@@ -1,0 +1,229 @@
+import page from '@automattic/calypso-router';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import { useQueryThemes } from 'calypso/components/data/query-themes';
+import { ThemeBlock } from 'calypso/components/themes-list';
+import { useThemeCollection } from 'calypso/my-sites/themes/collections/use-theme-collection';
+import { getThemeShowcaseEventRecorder } from 'calypso/my-sites/themes/events/theme-showcase-tracks';
+import { trackClick } from 'calypso/my-sites/themes/helpers';
+import ThemeSectionHeader from 'calypso/my-sites/themes/sections-modern/theme-section-header';
+import { useSelector } from 'calypso/state';
+import {
+	getThemesForQueryIgnoringPage,
+	isRequestingThemesForQuery,
+} from 'calypso/state/themes/selectors';
+import SearchMoreOptions from './search-more-options';
+import type { ThemesQuery } from 'calypso/my-sites/themes/collections/use-theme-collection';
+import type { Theme } from 'calypso/types';
+
+import './style.scss';
+
+interface SearchResultsModernProps {
+	search: string;
+	filter: string;
+	tier: string;
+	getActionLabel: ( themeId: string ) => string;
+	getOptions: ( themeId: string ) => void;
+	getScreenshotUrl: ( themeId: string ) => string;
+}
+
+export default function SearchResultsModern( {
+	search,
+	filter,
+	tier,
+	getActionLabel,
+	getOptions,
+	getScreenshotUrl,
+}: SearchResultsModernProps ) {
+	const translate = useTranslate();
+
+	const wpcomQuery: ThemesQuery = useMemo(
+		() => ( {
+			search,
+			filter,
+			tier,
+			number: 100,
+			page: 1,
+		} ),
+		[ search, filter, tier ]
+	);
+
+	// Append filter terms to search string for wporg (same logic as ThemesSelection).
+	const wporgQuery = useMemo(
+		() => ( {
+			...wpcomQuery,
+			page: 1,
+			search: filter
+				? `${ search } ${ filter.replaceAll( 'subject:', '' ).replace( /[+-]/g, ' ' ) }`
+				: search,
+		} ),
+		[ wpcomQuery, search, filter ]
+	);
+
+	// Fetch themes from both sources.
+	useQueryThemes( 'wpcom', wpcomQuery );
+	useQueryThemes( 'wporg', wporgQuery );
+
+	// Get wpcom themes.
+	const {
+		getPrice,
+		themes: wpcomThemes,
+		isActive,
+		isInstalling,
+		isLivePreviewStarted,
+		siteId,
+		getThemeType,
+		getThemeTierForTheme,
+		filterString,
+		getThemeDetailsUrl,
+	} = useThemeCollection( wpcomQuery );
+
+	// Get wporg themes from Redux.
+	const wporgThemes: Theme[] =
+		useSelector( ( state ) => getThemesForQueryIgnoringPage( state, 'wporg', wporgQuery ) ) || [];
+
+	const isLoadingWpcom = useSelector( ( state ) =>
+		isRequestingThemesForQuery( state, 'wpcom', wpcomQuery )
+	);
+	const isLoadingWporg = useSelector( ( state ) =>
+		isRequestingThemesForQuery( state, 'wporg', wporgQuery )
+	);
+	const isLoading = isLoadingWpcom || isLoadingWporg;
+
+	const hasWpcomThemes = wpcomThemes.length > 0;
+	const hasWporgThemes = wporgThemes.length > 0;
+	const hasAnyThemes = hasWpcomThemes || hasWporgThemes;
+
+	// Analytics for wpcom section.
+	const wpcomEventRecorder = getThemeShowcaseEventRecorder(
+		wpcomQuery,
+		wpcomThemes,
+		filterString,
+		getThemeType,
+		getThemeTierForTheme,
+		isActive,
+		'search-wpcom',
+		0
+	);
+
+	// Analytics for wporg section.
+	const wporgEventRecorder = getThemeShowcaseEventRecorder(
+		wporgQuery,
+		wporgThemes,
+		filterString,
+		getThemeType,
+		getThemeTierForTheme,
+		isActive,
+		'search-wporg',
+		1
+	);
+
+	const handleScreenshotClick = (
+		recorder: ReturnType< typeof getThemeShowcaseEventRecorder >,
+		themeId: string,
+		resultsRank: number
+	) => {
+		trackClick( 'theme', 'screenshot' );
+		recorder.recordThemeClick( themeId, resultsRank, 'screenshot_info' );
+	};
+
+	const handleStyleVariationClick = (
+		recorder: ReturnType< typeof getThemeShowcaseEventRecorder >,
+		themeId: string,
+		resultsRank: number,
+		variation: { slug: string }
+	) => {
+		recorder.recordThemeClick( themeId, resultsRank, 'style_variation', variation?.slug );
+		if ( variation ) {
+			recorder.recordThemeStyleVariationClick( themeId, resultsRank, '', variation.slug );
+		} else {
+			recorder.recordThemesStyleVariationMoreClick( themeId, resultsRank );
+			const themeDetailsUrl = getThemeDetailsUrl( themeId );
+			if ( themeDetailsUrl ) {
+				page( themeDetailsUrl );
+			}
+		}
+	};
+
+	const renderThemeGrid = (
+		themes: Theme[],
+		recorder: ReturnType< typeof getThemeShowcaseEventRecorder >
+	) => (
+		<div className="search-results-modern__grid">
+			{ themes.map( ( theme: Theme, index: number ) => (
+				<ThemeBlock
+					key={ theme.id }
+					getActionLabel={ getActionLabel }
+					getButtonOptions={ getOptions }
+					getPrice={ getPrice }
+					getScreenshotUrl={ getScreenshotUrl }
+					index={ index }
+					isActive={ isActive }
+					isInstalling={ isInstalling }
+					isLivePreviewStarted={ isLivePreviewStarted }
+					siteId={ siteId }
+					theme={ theme }
+					onMoreButtonClick={ recorder.recordThemeClick }
+					onMoreButtonItemClick={ recorder.recordThemeClick }
+					onScreenshotClick={ ( themeId: string, resultsRank: number ) =>
+						handleScreenshotClick( recorder, themeId, resultsRank )
+					}
+					onStyleVariationClick={ (
+						themeId: string,
+						resultsRank: number,
+						variation: { slug: string }
+					) => handleStyleVariationClick( recorder, themeId, resultsRank, variation ) }
+				/>
+			) ) }
+		</div>
+	);
+
+	// While loading, don't render the "no results" state.
+	if ( isLoading && ! hasAnyThemes ) {
+		return null;
+	}
+
+	// No results.
+	if ( ! hasAnyThemes ) {
+		return (
+			<div className="search-results-modern">
+				<SearchMoreOptions
+					title={ translate( 'No themes found' ) }
+					subtitle={ translate( 'Try building your site another way.' ) }
+					searchTerm={ search }
+				/>
+			</div>
+		);
+	}
+
+	return (
+		<div className="search-results-modern">
+			{ hasWpcomThemes && (
+				<div className="search-results-modern__section">
+					<ThemeSectionHeader
+						title={ translate( 'Results for %(query)s', { args: { query: search } } ) }
+						subtitle=""
+					/>
+					{ renderThemeGrid( wpcomThemes, wpcomEventRecorder ) }
+				</div>
+			) }
+
+			{ hasWporgThemes && (
+				<div className="search-results-modern__section">
+					<ThemeSectionHeader
+						title={ translate( 'Community themes' ) }
+						subtitle={ translate(
+							'Explore themes from the WordPress community, and upload to install when ready.'
+						) }
+					/>
+					{ renderThemeGrid( wporgThemes, wporgEventRecorder ) }
+				</div>
+			) }
+
+			<SearchMoreOptions
+				title={ translate( 'More options to create your site' ) }
+				searchTerm={ search }
+			/>
+		</div>
+	);
+}

--- a/client/my-sites/themes/search-results-modern/style.scss
+++ b/client/my-sites/themes/search-results-modern/style.scss
@@ -85,3 +85,31 @@
 	--wp-components-color-accent-darker-20: var( --studio-gray-100 );
 	width: fit-content;
 }
+
+.search-results-modern {
+	padding-inline: 24px;
+}
+
+.search-results-modern__section {
+	margin-bottom: 96px;
+}
+
+.search-results-modern__grid {
+	display: grid;
+	gap: 24px;
+	grid-template-columns: 1fr;
+	margin: 0 auto;
+	max-width: 1220px;
+
+	@include break-small {
+		grid-template-columns: repeat( 2, 1fr );
+	}
+
+	@include break-large {
+		grid-template-columns: repeat( 3, 1fr );
+	}
+}
+
+.search-results-modern .search-more-options {
+	padding-inline: 0;
+}

--- a/client/my-sites/themes/search-results-modern/test/search-results-modern.test.tsx
+++ b/client/my-sites/themes/search-results-modern/test/search-results-modern.test.tsx
@@ -59,6 +59,11 @@ jest.mock( 'calypso/lib/analytics/tracks', () => ( {
 	recordTracksEvent: jest.fn(),
 } ) );
 
+jest.mock( 'calypso/lib/build-url', () => ( {
+	buildRelativeSearchUrl: ( url: string, search: string ) =>
+		search ? `${ url }?s=${ search }` : url,
+} ) );
+
 const defaultProps = {
 	search: 'portfolio',
 	filter: '',
@@ -90,7 +95,7 @@ describe( 'SearchResultsModern', () => {
 	test( 'renders wpcom section when there are wpcom themes', () => {
 		mockWpcomThemes = [ { id: 'theme-1', name: 'Theme One' } ];
 		render( <SearchResultsModern { ...defaultProps } /> );
-		expect( screen.getByRole( 'heading', { name: /Results for portfolio/ } ) ).toBeVisible();
+		expect( screen.getByRole( 'heading', { name: /Results for.*portfolio/ } ) ).toBeVisible();
 		expect( screen.getByTestId( 'theme-block-theme-1' ) ).toBeVisible();
 	} );
 
@@ -98,7 +103,7 @@ describe( 'SearchResultsModern', () => {
 		mockWporgThemes = [ { id: 'theme-2', name: 'Theme Two' } ];
 		render( <SearchResultsModern { ...defaultProps } /> );
 		expect( screen.getByRole( 'heading', { name: 'Community themes' } ) ).toBeVisible();
-		expect( screen.getByText( /Explore themes from the WordPress community/ ) ).toBeVisible();
+		expect( screen.getByText( /Explore.*themes from the WordPress community/ ) ).toBeVisible();
 		expect( screen.getByTestId( 'theme-block-theme-2' ) ).toBeVisible();
 	} );
 
@@ -106,7 +111,7 @@ describe( 'SearchResultsModern', () => {
 		mockWpcomThemes = [ { id: 'theme-1', name: 'Theme One' } ];
 		mockWporgThemes = [ { id: 'theme-2', name: 'Theme Two' } ];
 		render( <SearchResultsModern { ...defaultProps } /> );
-		expect( screen.getByRole( 'heading', { name: /Results for portfolio/ } ) ).toBeVisible();
+		expect( screen.getByRole( 'heading', { name: /Results for.*portfolio/ } ) ).toBeVisible();
 		expect( screen.getByRole( 'heading', { name: 'Community themes' } ) ).toBeVisible();
 	} );
 
@@ -134,5 +139,34 @@ describe( 'SearchResultsModern', () => {
 		mockWpcomThemes = [ { id: 'theme-1', name: 'Theme One' } ];
 		render( <SearchResultsModern { ...defaultProps } /> );
 		expect( screen.queryByText( 'Community themes' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'limits community themes to 6 and shows "See all" button', () => {
+		mockWporgThemes = Array.from( { length: 8 }, ( _, i ) => ( {
+			id: `theme-${ i + 1 }`,
+			name: `Theme ${ i + 1 }`,
+		} ) );
+		render( <SearchResultsModern { ...defaultProps } /> );
+		// Only 6 themes should be rendered.
+		for ( let i = 1; i <= 6; i++ ) {
+			expect( screen.getByTestId( `theme-block-theme-${ i }` ) ).toBeVisible();
+		}
+		expect( screen.queryByTestId( 'theme-block-theme-7' ) ).not.toBeInTheDocument();
+		expect( screen.queryByTestId( 'theme-block-theme-8' ) ).not.toBeInTheDocument();
+		// "See all" button should be visible.
+		expect( screen.getByRole( 'button', { name: 'See all' } ) ).toBeVisible();
+	} );
+
+	test( 'does not show "See all" button when 6 or fewer community themes', () => {
+		mockWporgThemes = Array.from( { length: 6 }, ( _, i ) => ( {
+			id: `theme-${ i + 1 }`,
+			name: `Theme ${ i + 1 }`,
+		} ) );
+		render( <SearchResultsModern { ...defaultProps } /> );
+		// All 6 themes should be rendered.
+		for ( let i = 1; i <= 6; i++ ) {
+			expect( screen.getByTestId( `theme-block-theme-${ i }` ) ).toBeVisible();
+		}
+		expect( screen.queryByRole( 'button', { name: 'See all' } ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/my-sites/themes/search-results-modern/test/search-results-modern.test.tsx
+++ b/client/my-sites/themes/search-results-modern/test/search-results-modern.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import SearchResultsModern from '../index';
+
+let mockWpcomThemes: Array< { id: string; name: string } > = [];
+let mockWporgThemes: Array< { id: string; name: string } > = [];
+let mockIsRequesting = false;
+
+jest.mock( 'calypso/components/data/query-themes', () => ( {
+	useQueryThemes: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/my-sites/themes/collections/use-theme-collection', () => ( {
+	useThemeCollection: () => ( {
+		getPrice: jest.fn(),
+		themes: mockWpcomThemes,
+		isActive: jest.fn(),
+		isInstalling: jest.fn(),
+		isLivePreviewStarted: jest.fn(),
+		siteId: null,
+		getThemeType: jest.fn(),
+		getThemeTierForTheme: jest.fn(),
+		filterString: '',
+		getThemeDetailsUrl: jest.fn(),
+	} ),
+} ) );
+
+jest.mock( 'calypso/state/themes/selectors', () => ( {
+	getThemesForQueryIgnoringPage: () => mockWporgThemes,
+	isRequestingThemesForQuery: () => mockIsRequesting,
+} ) );
+
+jest.mock( 'calypso/my-sites/themes/events/theme-showcase-tracks', () => ( {
+	getThemeShowcaseEventRecorder: jest.fn( () => ( {
+		recordThemeClick: jest.fn(),
+		recordThemeStyleVariationClick: jest.fn(),
+		recordThemesStyleVariationMoreClick: jest.fn(),
+	} ) ),
+} ) );
+
+jest.mock( 'calypso/components/themes-list', () => ( {
+	ThemeBlock: ( { theme }: { theme: { id: string; name: string } } ) => (
+		<div data-testid={ `theme-block-${ theme.id }` }>{ theme.name }</div>
+	),
+} ) );
+
+jest.mock( 'calypso/my-sites/themes/helpers', () => ( {
+	trackClick: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/state', () => ( {
+	useSelector: ( selector: ( state: unknown ) => unknown ) => selector( {} ),
+	useDispatch: () => jest.fn(),
+} ) );
+
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
+
+const defaultProps = {
+	search: 'portfolio',
+	filter: '',
+	tier: '',
+	getActionLabel: () => 'Activate',
+	getOptions: () => ( {} ),
+	getScreenshotUrl: () => 'https://example.com/screenshot.png',
+};
+
+describe( 'SearchResultsModern', () => {
+	beforeEach( () => {
+		mockWpcomThemes = [];
+		mockWporgThemes = [];
+		mockIsRequesting = false;
+	} );
+
+	test( 'renders "No themes found" when there are no results', () => {
+		render( <SearchResultsModern { ...defaultProps } /> );
+		expect( screen.getByRole( 'heading', { name: 'No themes found' } ) ).toBeVisible();
+		expect( screen.getByText( /Try building your site another way/ ) ).toBeVisible();
+	} );
+
+	test( 'renders nothing while loading with no themes yet', () => {
+		mockIsRequesting = true;
+		const { container } = render( <SearchResultsModern { ...defaultProps } /> );
+		expect( container.innerHTML ).toBe( '' );
+	} );
+
+	test( 'renders wpcom section when there are wpcom themes', () => {
+		mockWpcomThemes = [ { id: 'theme-1', name: 'Theme One' } ];
+		render( <SearchResultsModern { ...defaultProps } /> );
+		expect( screen.getByRole( 'heading', { name: /Results for portfolio/ } ) ).toBeVisible();
+		expect( screen.getByTestId( 'theme-block-theme-1' ) ).toBeVisible();
+	} );
+
+	test( 'renders community section when there are wporg themes', () => {
+		mockWporgThemes = [ { id: 'theme-2', name: 'Theme Two' } ];
+		render( <SearchResultsModern { ...defaultProps } /> );
+		expect( screen.getByRole( 'heading', { name: 'Community themes' } ) ).toBeVisible();
+		expect( screen.getByText( /Explore themes from the WordPress community/ ) ).toBeVisible();
+		expect( screen.getByTestId( 'theme-block-theme-2' ) ).toBeVisible();
+	} );
+
+	test( 'renders both sections when there are wpcom and wporg themes', () => {
+		mockWpcomThemes = [ { id: 'theme-1', name: 'Theme One' } ];
+		mockWporgThemes = [ { id: 'theme-2', name: 'Theme Two' } ];
+		render( <SearchResultsModern { ...defaultProps } /> );
+		expect( screen.getByRole( 'heading', { name: /Results for portfolio/ } ) ).toBeVisible();
+		expect( screen.getByRole( 'heading', { name: 'Community themes' } ) ).toBeVisible();
+	} );
+
+	test( 'renders "More options" section when there are some results', () => {
+		mockWpcomThemes = [ { id: 'theme-1', name: 'Theme One' } ];
+		render( <SearchResultsModern { ...defaultProps } /> );
+		expect(
+			screen.getByRole( 'heading', { name: 'More options to create your site' } )
+		).toBeVisible();
+	} );
+
+	test( 'does not render "More options" subtitle when there are results', () => {
+		mockWpcomThemes = [ { id: 'theme-1', name: 'Theme One' } ];
+		render( <SearchResultsModern { ...defaultProps } /> );
+		expect( screen.queryByText( /Try building your site another way/ ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'hides wpcom section when there are no wpcom themes', () => {
+		mockWporgThemes = [ { id: 'theme-2', name: 'Theme Two' } ];
+		render( <SearchResultsModern { ...defaultProps } /> );
+		expect( screen.queryByText( /Results for/ ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'hides wporg section when there are no wporg themes', () => {
+		mockWpcomThemes = [ { id: 'theme-1', name: 'Theme One' } ];
+		render( <SearchResultsModern { ...defaultProps } /> );
+		expect( screen.queryByText( 'Community themes' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/my-sites/themes/sections-modern/theme-section-header.tsx
+++ b/client/my-sites/themes/sections-modern/theme-section-header.tsx
@@ -4,7 +4,7 @@ import type { TranslateResult } from 'i18n-calypso';
 import './style.scss';
 
 interface ThemeSectionHeaderProps {
-	title: string;
+	title: TranslateResult;
 	subtitle: TranslateResult;
 	buttonLabel?: string;
 	buttonHref?: string;

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -51,6 +51,7 @@ import {
 	isStaticFilter,
 	constructThemeShowcaseUrl,
 } from './helpers';
+import SearchResultsModern from './search-results-modern';
 import RecommendedSections from './sections-modern/recommended-sections';
 import ThemeErrors from './theme-errors';
 import ThemePreview from './theme-preview';
@@ -558,6 +559,19 @@ class ThemeShowcase extends Component {
 		) {
 			return (
 				<RecommendedSections
+					getActionLabel={ this.getActionLabel }
+					getOptions={ this.getThemeOptions }
+					getScreenshotUrl={ this.getScreenshotUrl }
+				/>
+			);
+		}
+
+		if ( this.isThemeShowcaseModern() && this.props.search ) {
+			return (
+				<SearchResultsModern
+					search={ this.props.search }
+					filter={ this.props.filter || '' }
+					tier={ this.props.tier || '' }
 					getActionLabel={ this.getActionLabel }
 					getOptions={ this.getThemeOptions }
 					getScreenshotUrl={ this.getScreenshotUrl }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -566,7 +566,7 @@ class ThemeShowcase extends Component {
 			);
 		}
 
-		if ( this.isThemeShowcaseModern() && this.props.search ) {
+		if ( this.isThemeShowcaseModern() && this.props.search && ! this.props.isCollectionView ) {
 			return (
 				<SearchResultsModern
 					search={ this.props.search }
@@ -607,6 +607,16 @@ class ThemeShowcase extends Component {
 			addTracking( this.props.options ),
 			( option ) => ! ( option.hideForTheme && option.hideForTheme( theme, this.props.siteId ) )
 		);
+	};
+
+	getThemeSource = ( staticFilters ) => {
+		if ( this.props.tier === 'community' ) {
+			return 'wporg';
+		}
+		if ( this.props.category === staticFilters.MYTHEMES?.key ) {
+			return null;
+		}
+		return 'wpcom';
 	};
 
 	onCollectionSeeAll = ( { filter = '', tier = '' } ) => {
@@ -676,7 +686,7 @@ class ThemeShowcase extends Component {
 			trackScrollPage: this.props.trackScrollPage,
 			scrollToSearchInput: this.scrollToSearchInput,
 			getOptions: this.getThemeOptions,
-			source: this.props.category !== staticFilters.MYTHEMES.key ? 'wpcom' : null,
+			source: this.getThemeSource( staticFilters ),
 			isThemeShowcaseModern: this.isThemeShowcaseModern(),
 		};
 
@@ -820,11 +830,12 @@ class ThemeShowcase extends Component {
 								isCollectionView: false,
 								tier: '',
 								filter: '',
-								search: '',
+								search: this.props.tier === 'community' ? this.props.search : '',
 								category: this.getDefaultStaticFilter().key,
 							} ) }
 							filter={ this.props.filter }
 							tier={ this.props.tier }
+							options={ { search: this.props.search } }
 							isLoggedIn={ isLoggedIn }
 						/>
 					) }

--- a/client/state/themes/selectors/get-themes-for-query-ignoring-page.js
+++ b/client/state/themes/selectors/get-themes-for-query-ignoring-page.js
@@ -14,7 +14,7 @@ import 'calypso/state/themes/init';
  * Returns an array of normalized themes for the themes query, including all
  * known queried pages, or null if the themes for the query are not known.
  * @param  {Object}  state  Global state tree
- * @param  {number}  siteId Site ID
+ * @param  {number|string}  siteId Site ID or theme source (e.g. 'wpcom', 'wporg')
  * @param  {Object}  query  Theme query object
  * @returns {?Array}         Themes for the theme query
  */

--- a/client/state/themes/selectors/is-requesting-themes-for-query-ignoring-page.js
+++ b/client/state/themes/selectors/is-requesting-themes-for-query-ignoring-page.js
@@ -12,7 +12,7 @@ import 'calypso/state/themes/init';
  * Returns true if currently requesting themes for the themes query, regardless
  * of page, or false otherwise.
  * @param  {Object}  state  Global state tree
- * @param  {number}  siteId Site ID
+ * @param  {number|string}  siteId Site ID or theme source (e.g. 'wpcom', 'wporg')
  * @param  {Object}  query  Theme query object
  * @returns {boolean}        Whether themes are being requested
  */

--- a/client/state/themes/selectors/is-requesting-themes-for-query.js
+++ b/client/state/themes/selectors/is-requesting-themes-for-query.js
@@ -6,7 +6,7 @@ import 'calypso/state/themes/init';
  * Returns true if currently requesting themes for the themes query, or false
  * otherwise.
  * @param  {Object}  state  Global state tree
- * @param  {number}  siteId Site ID
+ * @param  {number|string}  siteId Site ID or theme source (e.g. 'wpcom', 'wporg')
  * @param  {Object}  query  Theme query object
  * @returns {boolean}        Whether themes are being requested
  */


### PR DESCRIPTION
Fixes DOTTHEM-320

## Proposed Changes

| Search result page | No results | Community collection |
|--------|--------|--------|
| <img width="200" alt="calypso localhost_3000_themes_all_s=parr" src="https://github.com/user-attachments/assets/44463f23-d06b-461c-bb82-44fcfe88a3db" /> | <img width="200" alt="calypso localhost_3000_themes_all_s=parr (2)" src="https://github.com/user-attachments/assets/db0d1071-978c-4aec-88f9-8df60df9a340" /> | <img width="200" alt="calypso localhost_3000_themes_all_s=parr (1)" src="https://github.com/user-attachments/assets/54c7b874-8678-47cf-825e-cf4cdd4d2d7d" /> | 

- Add `SearchResultsModern` component that renders sectioned search results (WP.com themes, Community themes, "More options" CTA) when the modern theme showcase is active.
- Add `community` collection definition to `THEME_COLLECTIONS` with search-aware description.
- Update collection system to support dynamic descriptions via an options object (`ThemeCollectionDescription` type).
- Limit community themes section to 6 results with a "See all" button navigating to `/themes/community/collection?s=<query>`.
- Route community collection views to use `wporg` as theme source.
- Skip `SearchResultsModern` when in collection view so the collection page renders correctly.

## Why are these changes being made?

The modern theme showcase needs a dedicated search results layout that separates WP.com and community (wporg) themes into distinct sections, rather than interlacing them. Community themes are capped at 6 with a "See all" link to a full collection view, matching the pattern used by other theme sections (e.g., recommended, partner).

## Testing Instructions

- Enable `themes/showcase-modern` feature flag.
- Visit `/themes` logged out to see the modern showcase.
- Search for a term (e.g., "portfolio") — results should show WP.com section, Community section (max 6 themes), and "More options" CTA.
- If > 6 community themes, a "See all" button should appear and navigate to `/themes/community/collection?s=portfolio`.
- The collection view should show the full list of community themes with proper header and back navigation.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?