### PR TITLE
odyssey-stats: translate: Add --jobs 4 argument to wp-babel-makepot

### DIFF
--- a/apps/odyssey-stats/package.json
+++ b/apps/odyssey-stats/package.json
@@ -26,7 +26,7 @@
 		"test:js:watch": "yarn test:js --watch",
 		"test:size": "size-limit",
 		"teamcity:build-app": "yarn run build && yarn run test:size",
-		"translate": "rm -rf dist/strings && mkdir -p dist && wp-babel-makepot '../../{client,packages,apps}/**/*.{js,jsx,ts,tsx}' --ignore '**/node_modules/**,**/test/**,**/*.d.ts' --base '../../' --dir './dist/strings' --output './dist/odyssey-strings.pot' && build-app-languages --stringsFilePath=./dist/odyssey-strings.pot"
+		"translate": "rm -rf dist/strings && mkdir -p dist && wp-babel-makepot '../../{client,packages,apps}/**/*.{js,jsx,ts,tsx}' --ignore '**/node_modules/**,**/test/**,**/*.d.ts' --base '../../' --dir './dist/strings' --jobs 4 --output './dist/odyssey-strings.pot' && build-app-languages --stringsFilePath=./dist/odyssey-strings.pot"
 	},
 	"dependencies": {
 		"@automattic/calypso-color-schemes": "workspace:^",


### PR DESCRIPTION
Now that wp-babel-makepot supports the `--jobs` argument (#109188), pass it `4` by default in odyssey-stats to speed up the translation. 

I didn't use `auto` because that uses (number of CPUS-1), and we build all the apps in parallel. If we put them all on auto, that might be a bit too many threads.

## Proposed Changes

*

## Why are these changes being made?

*

## Testing Instructions


* Run `time yarn run teamcity:build-app` in the apps/odyssey-stats directory, before and after the change. Clean out `dist/` before running and make sure all files are the same.
* Can also make a new step that doesn't delete the file made by wp-babel-makepot:

```diff
diff --git a/apps/odyssey-stats/package.json b/apps/odyssey-stats/package.json
index 7e9c87995c0..3ca97078ec5 100644
--- a/apps/odyssey-stats/package.json
+++ b/apps/odyssey-stats/package.json
@@ -26,6 +26,7 @@
                "test:js:watch": "yarn test:js --watch",
                "test:size": "size-limit",
                "teamcity:build-app": "yarn run build && yarn run test:size",
+               "translate_half": "rm -rf dist/strings && mkdir -p dist && wp-babel-makepot '../../{client,packages,apps}/**/*.{js,jsx,ts,tsx}' --ignore '**/node_modules/**,**/test/**,**/*.d.ts' --base '../../' --dir './dist/strings' --jobs 4 --output './dist/odyssey-strings.pot'",
                "translate": "rm -rf dist/strings && mkdir -p dist && wp-babel-makepot '../../{client,packages,apps}/**/*.{js,jsx,ts,tsx}' --ignore '**/node_modules/**,**/test/**,**/*.d.ts' --base '../../'--dir './dist/strings' --jobs 4 --output './dist/odyssey-strings.pot' && build-app-languages --stringsFilePath=./dist/odyssey-strings.pot"
        },
        "dependencies": {
```

Then see that the odyssey-strings.pot is the same before and after.

* I Also tested by putting on wpcom and visiting `https://<site>/wp-admin/admin.php?page=stats#!/stats/insights/<site>?page=stats`, where <site> is a simple site.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
