### PR TITLE
Domains: Guard transfer links and redirect on permission failure

### DIFF
--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -144,9 +144,7 @@ export const domainRoute = createRoute( {
 				checkDomainTransferPermissions( domain );
 			} catch ( error ) {
 				dispatch( noticesStore ).createWarningNotice(
-					error instanceof Error
-						? error.message
-						: __( 'You do not have permission to transfer this domain.' ),
+					__( 'You do not have permission to transfer this domain.' ),
 					{ type: 'snackbar' }
 				);
 				throw redirect( {

--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -28,7 +28,9 @@ import {
 	lazyRouteComponent,
 	Outlet,
 } from '@tanstack/react-router';
+import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import {
 	checkDomainNameServersPermissions,
 	checkDomainTransferPermissions,
@@ -138,7 +140,20 @@ export const domainRoute = createRoute( {
 		}
 
 		if ( isTransferSubRoute ) {
-			checkDomainTransferPermissions( domain );
+			try {
+				checkDomainTransferPermissions( domain );
+			} catch ( error ) {
+				dispatch( noticesStore ).createWarningNotice(
+					error instanceof Error
+						? error.message
+						: __( 'You do not have permission to transfer this domain.' ),
+					{ type: 'snackbar' }
+				);
+				throw redirect( {
+					to: '/domains/$domainName',
+					params: { domainName },
+				} );
+			}
 		}
 
 		if ( isContactInfoSubRoute ) {

--- a/client/dashboard/components/purchase-dialogs/remove-domain-dialog.tsx
+++ b/client/dashboard/components/purchase-dialogs/remove-domain-dialog.tsx
@@ -94,25 +94,27 @@ export default function RemoveDomainDialog( {
 								) }
 							</Text>
 						) }
-						<Text as="p">
-							{ createInterpolateElement(
-								__(
-									'If you want to use <domain /> with another provider you can <transferLink>transfer it</transferLink>.'
-								),
-								{
-									domain: <strong>{ domain.domain }</strong>,
-									transferLink: (
-										<RouterLinkButton
-											variant="link"
-											to={ domainTransferRoute.fullPath }
-											params={ { domainName: domain.domain } }
-										>
-											{ __( 'Transfer' ) }
-										</RouterLinkButton>
+						{ ( domain.can_transfer_to_any_user || domain.can_transfer_to_other_site ) && (
+							<Text as="p">
+								{ createInterpolateElement(
+									__(
+										'If you want to use <domain /> with another provider you can <transferLink>transfer it</transferLink>.'
 									),
-								}
-							) }
-						</Text>
+									{
+										domain: <strong>{ domain.domain }</strong>,
+										transferLink: (
+											<RouterLinkButton
+												variant="link"
+												to={ domainTransferRoute.fullPath }
+												params={ { domainName: domain.domain } }
+											>
+												{ __( 'Transfer' ) }
+											</RouterLinkButton>
+										),
+									}
+								) }
+							</Text>
+						) }
 						<Text as="p">{ __( 'Do you still want to continue with deleting your domain?' ) }</Text>
 					</>
 				) }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-warning-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-warning-step.tsx
@@ -33,6 +33,8 @@ export default function DomainRemovalWarningStep( {
 		enabled: Boolean( domainName ),
 	} );
 
+	const canTransfer = domain?.can_transfer_to_any_user || domain?.can_transfer_to_other_site;
+
 	return (
 		<VStack spacing={ 8 }>
 			<VStack spacing={ 3 }>
@@ -61,29 +63,46 @@ export default function DomainRemovalWarningStep( {
 				) }
 
 				<Text>
-					{ createInterpolateElement(
-						/* translators: <domainName /> is the domain name */
-						__(
-							'If you want to use <domainName /> with another provider you can <moveLink>move it to another service</moveLink> or <transferLink>transfer it to another provider</transferLink>.'
-						),
-						{
-							domainName: <strong>{ domainName }</strong>,
-							moveLink: (
-								<RouterLinkButton
-									variant="link"
-									to="/domains/$domainName"
-									params={ { domainName } }
-								/>
-							),
-							transferLink: (
-								<RouterLinkButton
-									variant="link"
-									to="/domains/$domainName/transfer"
-									params={ { domainName } }
-								/>
-							),
-						}
-					) }
+					{ canTransfer
+						? createInterpolateElement(
+								/* translators: <domainName /> is the domain name */
+								__(
+									'If you want to use <domainName /> with another provider you can <moveLink>move it to another service</moveLink> or <transferLink>transfer it to another provider</transferLink>.'
+								),
+								{
+									domainName: <strong>{ domainName }</strong>,
+									moveLink: (
+										<RouterLinkButton
+											variant="link"
+											to="/domains/$domainName"
+											params={ { domainName } }
+										/>
+									),
+									transferLink: (
+										<RouterLinkButton
+											variant="link"
+											to="/domains/$domainName/transfer"
+											params={ { domainName } }
+										/>
+									),
+								}
+						  )
+						: createInterpolateElement(
+								/* translators: <domainName /> is the domain name */
+								__(
+									'If you want to use <domainName /> with another provider you can <moveLink>move it to another service</moveLink>.'
+								),
+								{
+									domainName: <strong>{ domainName }</strong>,
+									moveLink: (
+										<RouterLinkButton
+											variant="link"
+											to="/domains/$domainName"
+											params={ { domainName } }
+										/>
+									),
+								}
+						  ) }
 				</Text>
 
 				<Text>{ __( 'Do you still want to continue with deleting your domain?' ) }</Text>


### PR DESCRIPTION
Fixes DOMENG-319

## Proposed Changes

* Hide the "transfer it" link in the delete domain dialog when the domain cannot be transferred
* Show a version of the text without the transfer link in the cancel purchase domain removal step when the domain cannot be transferred
* Redirect to domain overview (with a snackbar warning) instead of throwing an unhandled error when navigating to the transfer route for a non-transferable domain

## Why are these changes being made?

Sentry keeps re-opening DOMENG-319 because several UI paths link to the `/transfer` route without checking transfer permissions. PR #108039 hid the main Transfer button in the domain overview, but missed these entry points:

1. The "Delete domain" dialog (`remove-domain-dialog.tsx`) unconditionally showed a "transfer it" link
2. The cancel purchase domain removal step (`domain-removal-warning-step.tsx`) unconditionally showed a "transfer it to another provider" link
3. Direct URL navigation or bookmarks could still reach the transfer route

When a user navigated to the transfer route for a non-transferable domain, `checkDomainTransferPermissions` threw an error that was caught by the global error boundary and reported to Sentry.

## Testing Instructions

1. Find a domain where both `can_transfer_to_any_user` and `can_transfer_to_other_site` are false (e.g., a recently registered domain or one in redemption)
2. Navigate to the domain overview and open the "Delete" dialog — verify the "transfer it" link is no longer shown
3. Navigate to the cancel purchase flow for that domain — verify only the "move it to another service" link appears (no "transfer it to another provider")
4. Navigate directly to `/domains/<domain>/transfer` — verify you are redirected to the domain overview with a snackbar warning

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

Co-Authored-By: Claude <noreply@anthropic.com>