### PR TITLE
feat(stats): improve referrer spam management

### DIFF
--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -391,10 +391,10 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( {
 												: translate( 'View details', {
 														context: 'Stats: Button label to see the detailed content of a panel',
 												  } ),
+										onClick: onShowMoreClick,
 								  }
 								: undefined
 						}
-						onShowMoreClick={ onShowMoreClick }
 						overlay={ moduleOverlay }
 						listItemClassName={ listItemClassName }
 					/>

--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -379,7 +379,7 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( {
 						heroElement={ heroElement }
 						mainItemLabel={ optionLabels[ selectedOption ]?.headerLabel }
 						toggleControl={ toggleControlComponent }
-						showMore={
+						footerAction={
 							summaryUrl
 								? {
 										url: getFinalSummaryUrl(),

--- a/client/my-sites/stats/features/modules/stats-referrers/spam-referrers-modal.scss
+++ b/client/my-sites/stats/features/modules/stats-referrers/spam-referrers-modal.scss
@@ -4,6 +4,12 @@
 }
 
 .spam-referrers-modal {
+	.components-spinner {
+		display: block;
+		margin-inline: auto;
+		margin-block: 48px;
+	}
+
 	.spam-referrers-modal__empty {
 		color: var( --color-text-subtle );
 	}

--- a/client/my-sites/stats/features/modules/stats-referrers/spam-referrers-modal.scss
+++ b/client/my-sites/stats/features/modules/stats-referrers/spam-referrers-modal.scss
@@ -18,6 +18,7 @@
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
+		gap: 16px;
 		padding: 8px 0;
 		border-block-end: 1px solid var( --color-border-subtle );
 
@@ -29,5 +30,6 @@
 	.spam-referrers-modal__domain {
 		font-weight: 500;
 		word-break: break-all;
+		min-width: 0;
 	}
 }

--- a/client/my-sites/stats/features/modules/stats-referrers/spam-referrers-modal.scss
+++ b/client/my-sites/stats/features/modules/stats-referrers/spam-referrers-modal.scss
@@ -1,5 +1,6 @@
 .spam-referrers-modal.components-modal__frame {
-	max-width: 520px;
+	width: 520px;
+	max-width: 100%;
 }
 
 .spam-referrers-modal {

--- a/client/my-sites/stats/features/modules/stats-referrers/spam-referrers-modal.scss
+++ b/client/my-sites/stats/features/modules/stats-referrers/spam-referrers-modal.scss
@@ -1,0 +1,32 @@
+.spam-referrers-modal.components-modal__frame {
+	max-width: 520px;
+}
+
+.spam-referrers-modal {
+	.spam-referrers-modal__empty {
+		color: var( --color-text-subtle );
+	}
+
+	.spam-referrers-modal__list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+	}
+
+	.spam-referrers-modal__item {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 8px 0;
+		border-block-end: 1px solid var( --color-border-subtle );
+
+		&:last-child {
+			border-block-end: none;
+		}
+	}
+
+	.spam-referrers-modal__domain {
+		font-weight: 500;
+		word-break: break-all;
+	}
+}

--- a/client/my-sites/stats/features/modules/stats-referrers/spam-referrers-modal.scss
+++ b/client/my-sites/stats/features/modules/stats-referrers/spam-referrers-modal.scss
@@ -32,4 +32,10 @@
 		word-break: break-all;
 		min-width: 0;
 	}
+
+	.spam-referrers-modal__note {
+		color: var( --color-text-subtle );
+		font-size: 0.875rem;
+		margin-block-end: 16px;
+	}
 }

--- a/client/my-sites/stats/features/modules/stats-referrers/spam-referrers-modal.tsx
+++ b/client/my-sites/stats/features/modules/stats-referrers/spam-referrers-modal.tsx
@@ -1,5 +1,5 @@
-import { NoticeBanner, Spinner } from '@automattic/components';
-import { Button, Modal } from '@wordpress/components';
+import { NoticeBanner } from '@automattic/components';
+import { Button, Modal, Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useCallback } from 'react';
 import useSpamReferrersQuery, {

--- a/client/my-sites/stats/features/modules/stats-referrers/spam-referrers-modal.tsx
+++ b/client/my-sites/stats/features/modules/stats-referrers/spam-referrers-modal.tsx
@@ -77,6 +77,9 @@ const SpamReferrersModal: React.FC< SpamReferrersModalProps > = ( { siteId, onCl
 							) }
 						</NoticeBanner>
 					) }
+					<p className="spam-referrers-modal__note">
+						{ translate( 'Note: Changes may take a few minutes to appear in your stats.' ) }
+					</p>
 					<ul ref={ listRef } className="spam-referrers-modal__list">
 						{ domains.map( ( item ) => (
 							<li key={ item.domain } className="spam-referrers-modal__item">

--- a/client/my-sites/stats/features/modules/stats-referrers/spam-referrers-modal.tsx
+++ b/client/my-sites/stats/features/modules/stats-referrers/spam-referrers-modal.tsx
@@ -19,11 +19,18 @@ const SpamReferrersModal: React.FC< SpamReferrersModalProps > = ( { siteId, onCl
 	const { data, isLoading, isError: isFetchError } = useSpamReferrersQuery( siteId );
 	const { mutate: unspamReferrer, isError: isUnspamError } = useUnspamReferrerMutation( siteId );
 	const hasChangesRef = useRef( false );
+	const listRef = useRef< HTMLUListElement >( null );
 
 	const handleUnspam = useCallback(
 		( domain: string ) => {
 			hasChangesRef.current = true;
 			unspamReferrer( domain );
+			// The optimistic update removes the focused button from the DOM,
+			// which drops focus to document.body and breaks Escape-to-close.
+			// Restore focus to the modal after the DOM update.
+			requestAnimationFrame( () => {
+				listRef.current?.closest< HTMLDivElement >( '.components-modal__frame' )?.focus();
+			} );
 		},
 		[ unspamReferrer ]
 	);
@@ -71,7 +78,7 @@ const SpamReferrersModal: React.FC< SpamReferrersModalProps > = ( { siteId, onCl
 							) }
 						</NoticeBanner>
 					) }
-					<ul className="spam-referrers-modal__list">
+					<ul ref={ listRef } className="spam-referrers-modal__list">
 						{ domains.map( ( item ) => (
 							<li key={ item.domain } className="spam-referrers-modal__item">
 								<span className="spam-referrers-modal__domain">{ item.domain }</span>

--- a/client/my-sites/stats/features/modules/stats-referrers/spam-referrers-modal.tsx
+++ b/client/my-sites/stats/features/modules/stats-referrers/spam-referrers-modal.tsx
@@ -1,4 +1,5 @@
 import { Spinner } from '@automattic/components';
+import NoticeBanner from '@automattic/components/src/notice-banner';
 import { Button, Modal } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useCallback } from 'react';
@@ -15,8 +16,8 @@ interface SpamReferrersModalProps {
 
 const SpamReferrersModal: React.FC< SpamReferrersModalProps > = ( { siteId, onClose } ) => {
 	const translate = useTranslate();
-	const { data, isLoading } = useSpamReferrersQuery( siteId );
-	const { mutate: unspamReferrer } = useUnspamReferrerMutation( siteId );
+	const { data, isLoading, isError: isFetchError } = useSpamReferrersQuery( siteId );
+	const { mutate: unspamReferrer, isError: isUnspamError } = useUnspamReferrerMutation( siteId );
 	const hasChangesRef = useRef( false );
 
 	const handleUnspam = useCallback(
@@ -40,24 +41,47 @@ const SpamReferrersModal: React.FC< SpamReferrersModalProps > = ( { siteId, onCl
 			className="spam-referrers-modal"
 		>
 			{ isLoading && <Spinner /> }
-			{ ! isLoading && domains.length === 0 && (
-				<p className="spam-referrers-modal__empty">
+			{ isFetchError && (
+				<NoticeBanner level="error" hideCloseButton>
 					{ translate(
-						'No spam referrers yet. To mark a referrer as spam, hover over it in the referrers list and click the warning icon. Spam referrers are hidden from future stats but historical data is not affected.'
+						'Sorry, something went wrong loading spam referrers. Please try again later.'
 					) }
-				</p>
+				</NoticeBanner>
 			) }
-			{ ! isLoading && domains.length > 0 && (
-				<ul className="spam-referrers-modal__list">
-					{ domains.map( ( item ) => (
-						<li key={ item.domain } className="spam-referrers-modal__item">
-							<span className="spam-referrers-modal__domain">{ item.domain }</span>
-							<Button variant="link" isDestructive onClick={ () => handleUnspam( item.domain ) }>
-								{ translate( 'Remove' ) }
-							</Button>
-						</li>
-					) ) }
-				</ul>
+			{ ! isLoading && ! isFetchError && domains.length === 0 && (
+				<div className="spam-referrers-modal__empty">
+					<p>
+						{ translate(
+							'No spam referrers yet. To mark a referrer as spam, hover over it in the referrers list and click the warning icon.'
+						) }
+					</p>
+					<p>
+						{ translate(
+							'Spam referrers are hidden from future stats but historical data is not affected.'
+						) }
+					</p>
+				</div>
+			) }
+			{ ! isLoading && ! isFetchError && domains.length > 0 && (
+				<>
+					{ isUnspamError && (
+						<NoticeBanner level="error" hideCloseButton>
+							{ translate(
+								'Sorry, something went wrong removing the spam referrer. Please try again.'
+							) }
+						</NoticeBanner>
+					) }
+					<ul className="spam-referrers-modal__list">
+						{ domains.map( ( item ) => (
+							<li key={ item.domain } className="spam-referrers-modal__item">
+								<span className="spam-referrers-modal__domain">{ item.domain }</span>
+								<Button variant="link" isDestructive onClick={ () => handleUnspam( item.domain ) }>
+									{ translate( 'Remove' ) }
+								</Button>
+							</li>
+						) ) }
+					</ul>
+				</>
 			) }
 		</Modal>
 	);

--- a/client/my-sites/stats/features/modules/stats-referrers/spam-referrers-modal.tsx
+++ b/client/my-sites/stats/features/modules/stats-referrers/spam-referrers-modal.tsx
@@ -1,0 +1,51 @@
+import { Button, Modal } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import useSpamReferrersQuery, {
+	useUnspamReferrerMutation,
+} from 'calypso/my-sites/stats/hooks/use-spam-referrers-query';
+
+import './spam-referrers-modal.scss';
+
+interface SpamReferrersModalProps {
+	siteId: number;
+	onClose: () => void;
+}
+
+const SpamReferrersModal: React.FC< SpamReferrersModalProps > = ( { siteId, onClose } ) => {
+	const translate = useTranslate();
+	const { data, isLoading } = useSpamReferrersQuery( siteId );
+	const { mutate: unspamReferrer } = useUnspamReferrerMutation( siteId );
+
+	const domains = data?.domains ?? [];
+
+	return (
+		<Modal
+			title={ translate( 'Spam referrers' ) }
+			onRequestClose={ onClose }
+			className="spam-referrers-modal"
+		>
+			{ isLoading && <p>{ translate( 'Loading…' ) }</p> }
+			{ ! isLoading && domains.length === 0 && (
+				<p className="spam-referrers-modal__empty">
+					{ translate(
+						'No spam referrers yet. To mark a referrer as spam, hover over it in the referrers list and click the warning icon. Spam referrers are hidden from future stats but historical data is not affected.'
+					) }
+				</p>
+			) }
+			{ ! isLoading && domains.length > 0 && (
+				<ul className="spam-referrers-modal__list">
+					{ domains.map( ( item ) => (
+						<li key={ item.domain } className="spam-referrers-modal__item">
+							<span className="spam-referrers-modal__domain">{ item.domain }</span>
+							<Button variant="link" isDestructive onClick={ () => unspamReferrer( item.domain ) }>
+								{ translate( 'Remove' ) }
+							</Button>
+						</li>
+					) ) }
+				</ul>
+			) }
+		</Modal>
+	);
+};
+
+export default SpamReferrersModal;

--- a/client/my-sites/stats/features/modules/stats-referrers/spam-referrers-modal.tsx
+++ b/client/my-sites/stats/features/modules/stats-referrers/spam-referrers-modal.tsx
@@ -1,5 +1,6 @@
 import { Button, Modal } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { useRef, useCallback } from 'react';
 import useSpamReferrersQuery, {
 	useUnspamReferrerMutation,
 } from 'calypso/my-sites/stats/hooks/use-spam-referrers-query';
@@ -8,20 +9,33 @@ import './spam-referrers-modal.scss';
 
 interface SpamReferrersModalProps {
 	siteId: number;
-	onClose: () => void;
+	onClose: ( hasChanges: boolean ) => void;
 }
 
 const SpamReferrersModal: React.FC< SpamReferrersModalProps > = ( { siteId, onClose } ) => {
 	const translate = useTranslate();
 	const { data, isLoading } = useSpamReferrersQuery( siteId );
 	const { mutate: unspamReferrer } = useUnspamReferrerMutation( siteId );
+	const hasChangesRef = useRef( false );
+
+	const handleUnspam = useCallback(
+		( domain: string ) => {
+			hasChangesRef.current = true;
+			unspamReferrer( domain );
+		},
+		[ unspamReferrer ]
+	);
+
+	const handleClose = useCallback( () => {
+		onClose( hasChangesRef.current );
+	}, [ onClose ] );
 
 	const domains = data?.domains ?? [];
 
 	return (
 		<Modal
 			title={ translate( 'Spam referrers' ) }
-			onRequestClose={ onClose }
+			onRequestClose={ handleClose }
 			className="spam-referrers-modal"
 		>
 			{ isLoading && <p>{ translate( 'Loading…' ) }</p> }
@@ -37,7 +51,7 @@ const SpamReferrersModal: React.FC< SpamReferrersModalProps > = ( { siteId, onCl
 					{ domains.map( ( item ) => (
 						<li key={ item.domain } className="spam-referrers-modal__item">
 							<span className="spam-referrers-modal__domain">{ item.domain }</span>
-							<Button variant="link" isDestructive onClick={ () => unspamReferrer( item.domain ) }>
+							<Button variant="link" isDestructive onClick={ () => handleUnspam( item.domain ) }>
 								{ translate( 'Remove' ) }
 							</Button>
 						</li>

--- a/client/my-sites/stats/features/modules/stats-referrers/spam-referrers-modal.tsx
+++ b/client/my-sites/stats/features/modules/stats-referrers/spam-referrers-modal.tsx
@@ -1,5 +1,4 @@
-import { Spinner } from '@automattic/components';
-import NoticeBanner from '@automattic/components/src/notice-banner';
+import { NoticeBanner, Spinner } from '@automattic/components';
 import { Button, Modal } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useCallback } from 'react';

--- a/client/my-sites/stats/features/modules/stats-referrers/spam-referrers-modal.tsx
+++ b/client/my-sites/stats/features/modules/stats-referrers/spam-referrers-modal.tsx
@@ -1,3 +1,4 @@
+import { Spinner } from '@automattic/components';
 import { Button, Modal } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useCallback } from 'react';
@@ -38,7 +39,7 @@ const SpamReferrersModal: React.FC< SpamReferrersModalProps > = ( { siteId, onCl
 			onRequestClose={ handleClose }
 			className="spam-referrers-modal"
 		>
-			{ isLoading && <p>{ translate( 'Loading…' ) }</p> }
+			{ isLoading && <Spinner /> }
 			{ ! isLoading && domains.length === 0 && (
 				<p className="spam-referrers-modal__empty">
 					{ translate(

--- a/client/my-sites/stats/features/modules/stats-referrers/stats-referrers.tsx
+++ b/client/my-sites/stats/features/modules/stats-referrers/stats-referrers.tsx
@@ -1,6 +1,7 @@
 import { StatsCard } from '@automattic/components';
 import { megaphone } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -16,6 +17,7 @@ import EmptyModuleCard from '../../../components/empty-module-card/empty-module-
 import StatsModule from '../../../stats-module';
 import { StatsEmptyActionSocial } from '../shared';
 import StatsCardSkeleton from '../shared/stats-card-skeleton';
+import SpamReferrersModal from './spam-referrers-modal';
 import type { StatsDefaultModuleProps, StatsStateProps } from '../types';
 
 const StatsReferrers: React.FC< StatsDefaultModuleProps > = ( {
@@ -31,6 +33,7 @@ const StatsReferrers: React.FC< StatsDefaultModuleProps > = ( {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const statType = 'statsReferrers';
+	const [ isSpamModalOpen, setIsSpamModalOpen ] = useState( false );
 
 	const isSiteJetpackNotAtomic = useSelector( ( state ) =>
 		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
@@ -105,7 +108,18 @@ const StatsReferrers: React.FC< StatsDefaultModuleProps > = ( {
 					listItemClassName={ listItemClassName }
 					skipQuery
 					isRealTime={ isRealTime }
+					summaryFooterAction={
+						summary && ! shouldGateStatsModule
+							? { label: translate( 'Manage spam referrers' ) }
+							: undefined
+					}
+					onShowMoreClick={
+						summary && ! shouldGateStatsModule ? () => setIsSpamModalOpen( true ) : undefined
+					}
 				/>
+			) }
+			{ isSpamModalOpen && (
+				<SpamReferrersModal siteId={ siteId } onClose={ () => setIsSpamModalOpen( false ) } />
 			) }
 			{ presentEmptyUI && (
 				// show empty state

--- a/client/my-sites/stats/features/modules/stats-referrers/stats-referrers.tsx
+++ b/client/my-sites/stats/features/modules/stats-referrers/stats-referrers.tsx
@@ -2,11 +2,11 @@ import { StatsCard } from '@automattic/components';
 import { megaphone } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useCallback } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import StatsInfoArea from 'calypso/my-sites/stats/features/modules/shared/stats-info-area';
 import { useShouldGateStats } from 'calypso/my-sites/stats/hooks/use-should-gate-stats';
+import { useSelector, useDispatch } from 'calypso/state';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { requestSiteStats } from 'calypso/state/stats/lists/actions';
 import {

--- a/client/my-sites/stats/features/modules/stats-referrers/stats-referrers.tsx
+++ b/client/my-sites/stats/features/modules/stats-referrers/stats-referrers.tsx
@@ -1,13 +1,14 @@
 import { StatsCard } from '@automattic/components';
 import { megaphone } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useState, useCallback } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import StatsInfoArea from 'calypso/my-sites/stats/features/modules/shared/stats-info-area';
 import { useShouldGateStats } from 'calypso/my-sites/stats/hooks/use-should-gate-stats';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { requestSiteStats } from 'calypso/state/stats/lists/actions';
 import {
 	isRequestingSiteStatsForQuery,
 	getSiteStatsNormalizedData,
@@ -31,9 +32,20 @@ const StatsReferrers: React.FC< StatsDefaultModuleProps > = ( {
 	isRealTime = false,
 } ) => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const statType = 'statsReferrers';
 	const [ isSpamModalOpen, setIsSpamModalOpen ] = useState( false );
+
+	const handleSpamModalClose = useCallback(
+		( hasChanges: boolean ) => {
+			setIsSpamModalOpen( false );
+			if ( hasChanges ) {
+				dispatch( requestSiteStats( siteId, statType, query ) );
+			}
+		},
+		[ dispatch, siteId, query ]
+	);
 
 	const isSiteJetpackNotAtomic = useSelector( ( state ) =>
 		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
@@ -119,7 +131,7 @@ const StatsReferrers: React.FC< StatsDefaultModuleProps > = ( {
 				/>
 			) }
 			{ isSpamModalOpen && (
-				<SpamReferrersModal siteId={ siteId } onClose={ () => setIsSpamModalOpen( false ) } />
+				<SpamReferrersModal siteId={ siteId } onClose={ handleSpamModalClose } />
 			) }
 			{ presentEmptyUI && (
 				// show empty state

--- a/client/my-sites/stats/features/modules/stats-referrers/stats-referrers.tsx
+++ b/client/my-sites/stats/features/modules/stats-referrers/stats-referrers.tsx
@@ -120,13 +120,14 @@ const StatsReferrers: React.FC< StatsDefaultModuleProps > = ( {
 					listItemClassName={ listItemClassName }
 					skipQuery
 					isRealTime={ isRealTime }
-					summaryFooterAction={
+					footerAction={
 						summary && ! shouldGateStatsModule
-							? { label: translate( 'Manage spam referrers' ) }
+							? {
+									label: translate( 'Manage spam referrers' ),
+									onClick: () => setIsSpamModalOpen( true ),
+									ariaLabel: translate( 'Manage spam referrers' ) as string,
+							  }
 							: undefined
-					}
-					onShowMoreClick={
-						summary && ! shouldGateStatsModule ? () => setIsSpamModalOpen( true ) : undefined
 					}
 				/>
 			) }

--- a/client/my-sites/stats/features/modules/stats-utm/stats-module-utm-overlay.tsx
+++ b/client/my-sites/stats/features/modules/stats-utm/stats-module-utm-overlay.tsx
@@ -57,7 +57,7 @@ const StatsModuleUTMOverlay: React.FC< StatsModuleUTMOverlayProps > = ( {
 			data={ fakeData }
 			mainItemLabel="Posts by Source / Medium"
 			splitHeader
-			showMore={ {
+			footerAction={ {
 				label: 'View all',
 			} }
 			overlay={

--- a/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
+++ b/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
@@ -248,7 +248,7 @@ const StatsModuleUTM = ( {
 						titleNodes={ titleNodes }
 						emptyMessage={ <div>{ moduleStrings.empty }</div> }
 						metricLabel={ metricLabel }
-						showMore={
+						footerAction={
 							displaySummaryLink && ! summary
 								? {
 										url: getHref(),

--- a/client/my-sites/stats/hooks/use-spam-referrers-query.ts
+++ b/client/my-sites/stats/hooks/use-spam-referrers-query.ts
@@ -21,6 +21,7 @@ export default function useSpamReferrersQuery( siteId: number | null ) {
 		queryKey: [ QUERY_KEY_BASE, siteId ],
 		queryFn: () => fetchSpamReferrers( siteId as number ),
 		enabled: !! siteId,
+		staleTime: 0,
 	} );
 }
 

--- a/client/my-sites/stats/hooks/use-spam-referrers-query.ts
+++ b/client/my-sites/stats/hooks/use-spam-referrers-query.ts
@@ -33,7 +33,16 @@ export function useUnspamReferrerMutation( siteId: number | null ) {
 			const wpcomSite = wpcom.site( siteId );
 			return wpcomSite.statsReferrersSpamDelete( domain );
 		},
-		onSuccess: ( _data, domain ) => {
+		onMutate: async ( domain ) => {
+			// Cancel any outgoing refetches so they don't overwrite our optimistic update.
+			await queryClient.cancelQueries( { queryKey: [ QUERY_KEY_BASE, siteId ] } );
+
+			// Snapshot the previous value for rollback.
+			const previous = queryClient.getQueryData< SpamReferrersResponse >( [
+				QUERY_KEY_BASE,
+				siteId,
+			] );
+
 			// Optimistically remove the domain from the cached list.
 			queryClient.setQueryData< SpamReferrersResponse >( [ QUERY_KEY_BASE, siteId ], ( old ) => {
 				if ( ! old ) {
@@ -43,6 +52,14 @@ export function useUnspamReferrerMutation( siteId: number | null ) {
 					domains: old.domains.filter( ( item ) => item.domain !== domain ),
 				};
 			} );
+
+			return { previous };
+		},
+		onError: ( _error, _domain, context ) => {
+			// Roll back to the previous value on error.
+			if ( context?.previous ) {
+				queryClient.setQueryData( [ QUERY_KEY_BASE, siteId ], context.previous );
+			}
 		},
 		retry: 1,
 		retryDelay: 3 * 1000,

--- a/client/my-sites/stats/hooks/use-spam-referrers-query.ts
+++ b/client/my-sites/stats/hooks/use-spam-referrers-query.ts
@@ -61,6 +61,10 @@ export function useUnspamReferrerMutation( siteId: number | null ) {
 				queryClient.setQueryData( [ QUERY_KEY_BASE, siteId ], context.previous );
 			}
 		},
+		onSettled: () => {
+			// Always refetch after mutation to ensure server/client consistency.
+			queryClient.invalidateQueries( { queryKey: [ QUERY_KEY_BASE, siteId ] } );
+		},
 		retry: 1,
 		retryDelay: 3 * 1000,
 	} );

--- a/client/my-sites/stats/hooks/use-spam-referrers-query.ts
+++ b/client/my-sites/stats/hooks/use-spam-referrers-query.ts
@@ -1,0 +1,59 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import getDefaultQueryParams from './default-query-params';
+
+interface SpamReferrer {
+	domain: string;
+}
+
+interface SpamReferrersResponse {
+	domains: SpamReferrer[];
+}
+
+const QUERY_KEY_BASE = 'stats-spam-referrers';
+
+// TODO: Replace mock with real API call once the GET endpoint is available.
+// Real implementation:
+// const fetchSpamReferrers = ( siteId: number ): Promise< SpamReferrersResponse > =>
+// 	wpcom.req.get( { path: `/sites/${ siteId }/stats/referrers/spam` } );
+const fetchSpamReferrers = ( siteId: number ): Promise< SpamReferrersResponse > => {
+	// eslint-disable-next-line no-console
+	console.warn( 'useSpamReferrersQuery: using mock data. Replace with real API call.' );
+	void siteId;
+	return Promise.resolve( {
+		domains: [ { domain: 'mock-spam-referrer-1.com' }, { domain: 'mock-spam-referrer-2.net' } ],
+	} );
+};
+
+export default function useSpamReferrersQuery( siteId: number | null ) {
+	return useQuery( {
+		...getDefaultQueryParams(),
+		queryKey: [ QUERY_KEY_BASE, siteId ],
+		queryFn: () => fetchSpamReferrers( siteId as number ),
+		enabled: !! siteId,
+	} );
+}
+
+export function useUnspamReferrerMutation( siteId: number | null ) {
+	const queryClient = useQueryClient();
+
+	return useMutation( {
+		mutationFn: ( domain: string ) => {
+			const wpcomSite = wpcom.site( siteId );
+			return wpcomSite.statsReferrersSpamDelete( domain );
+		},
+		onSuccess: ( _data, domain ) => {
+			// Optimistically remove the domain from the cached list.
+			queryClient.setQueryData< SpamReferrersResponse >( [ QUERY_KEY_BASE, siteId ], ( old ) => {
+				if ( ! old ) {
+					return { domains: [] };
+				}
+				return {
+					domains: old.domains.filter( ( item ) => item.domain !== domain ),
+				};
+			} );
+		},
+		retry: 1,
+		retryDelay: 3 * 1000,
+	} );
+}

--- a/client/my-sites/stats/hooks/use-spam-referrers-query.ts
+++ b/client/my-sites/stats/hooks/use-spam-referrers-query.ts
@@ -65,7 +65,6 @@ export function useUnspamReferrerMutation( siteId: number | null ) {
 			// Always refetch after mutation to ensure server/client consistency.
 			queryClient.invalidateQueries( { queryKey: [ QUERY_KEY_BASE, siteId ] } );
 		},
-		retry: 1,
-		retryDelay: 3 * 1000,
+		retry: false,
 	} );
 }

--- a/client/my-sites/stats/hooks/use-spam-referrers-query.ts
+++ b/client/my-sites/stats/hooks/use-spam-referrers-query.ts
@@ -12,18 +12,8 @@ interface SpamReferrersResponse {
 
 const QUERY_KEY_BASE = 'stats-spam-referrers';
 
-// TODO: Replace mock with real API call once the GET endpoint is available.
-// Real implementation:
-// const fetchSpamReferrers = ( siteId: number ): Promise< SpamReferrersResponse > =>
-// 	wpcom.req.get( { path: `/sites/${ siteId }/stats/referrers/spam` } );
-const fetchSpamReferrers = ( siteId: number ): Promise< SpamReferrersResponse > => {
-	// eslint-disable-next-line no-console
-	console.warn( 'useSpamReferrersQuery: using mock data. Replace with real API call.' );
-	void siteId;
-	return Promise.resolve( {
-		domains: [ { domain: 'mock-spam-referrer-1.com' }, { domain: 'mock-spam-referrer-2.net' } ],
-	} );
-};
+const fetchSpamReferrers = ( siteId: number ): Promise< SpamReferrersResponse > =>
+	wpcom.req.get( { path: `/sites/${ siteId }/stats/referrers/spam`, apiVersion: '1.1' } );
 
 export default function useSpamReferrersQuery( siteId: number | null ) {
 	return useQuery( {

--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -93,7 +93,7 @@ const StatModuleFollowers = ( { className } ) => {
 			mainItemLabel={ translate( 'Subscriber' ) }
 			metricLabel={ translate( 'Since' ) }
 			splitHeader
-			showMore={ {
+			footerAction={ {
 				url: subscriberManagementUrl,
 				label: translate( 'Manage subscribers' ),
 			} }

--- a/client/my-sites/stats/stats-list/action-spam.jsx
+++ b/client/my-sites/stats/stats-list/action-spam.jsx
@@ -106,7 +106,7 @@ class StatsActionSpam extends Component {
 				</Tooltip>
 				{ this.props.inHorizontalBarList && this.state.showConfirmDialog && (
 					<Modal
-						title={ this.props.translate( 'Mark as spam' ) }
+						title={ this.props.translate( 'Mark as spam?' ) }
 						onRequestClose={ this.closeConfirmDialog }
 						className="action-spam__confirm-modal"
 						// React synthetic events from portals bubble through the component
@@ -120,13 +120,17 @@ class StatsActionSpam extends Component {
 						} }
 					>
 						<p>
-							{ this.props.translate( "Are you sure you want to mark '%(domain)s' as spam?", {
-								args: { domain: this.props.data?.domain },
-							} ) }
+							{ this.props.translate(
+								'Marking {{strong}}%(domain)s{{/strong}} as spam will hide this referrer from your future stats. Historical stats will not be affected.',
+								{
+									args: { domain: this.props.data?.domain },
+									components: { strong: <strong /> },
+								}
+							) }
 						</p>
 						<p>
 							{ this.props.translate(
-								'This will hide this referrer from your future stats. Historical stats will not be affected. You can undo this later from the spam referrers list.'
+								'You can undo this action and manage spam referrers from the referrers detail page.'
 							) }
 						</p>
 						<div style={ { display: 'flex', justifyContent: 'flex-end', gap: '8px' } }>

--- a/client/my-sites/stats/stats-list/action-spam.jsx
+++ b/client/my-sites/stats/stats-list/action-spam.jsx
@@ -109,6 +109,15 @@ class StatsActionSpam extends Component {
 						title={ this.props.translate( 'Mark as spam' ) }
 						onRequestClose={ this.closeConfirmDialog }
 						className="action-spam__confirm-modal"
+						// React synthetic events from portals bubble through the component
+						// tree, not the DOM tree. Without this, Enter/Space inside the modal
+						// would reach the parent row's onKeyDown handler and navigate to the
+						// referrer URL. Escape is allowed through so the modal can still close.
+						onKeyDown={ ( event ) => {
+							if ( event.key !== 'Escape' ) {
+								event.stopPropagation();
+							}
+						} }
 					>
 						<p>
 							{ this.props.translate( "Are you sure you want to mark '%(domain)s' as spam?", {

--- a/client/my-sites/stats/stats-list/action-spam.jsx
+++ b/client/my-sites/stats/stats-list/action-spam.jsx
@@ -130,7 +130,7 @@ class StatsActionSpam extends Component {
 						</p>
 						<p>
 							{ this.props.translate(
-								'You can undo this action and manage spam referrers from the referrers detail page.'
+								'You can undo this action and manage spam referrers from the referrers detail page. Changes may take a few minutes to appear in your stats.'
 							) }
 						</p>
 						<div className="action-spam__confirm-modal-actions">

--- a/client/my-sites/stats/stats-list/action-spam.jsx
+++ b/client/my-sites/stats/stats-list/action-spam.jsx
@@ -117,6 +117,11 @@ class StatsActionSpam extends Component {
 								args: { domain: this.props.data?.domain },
 							} ) }
 						</p>
+						<p>
+							{ this.props.translate(
+								'This will hide this referrer from your future stats. Historical stats will not be affected. You can undo this later from the spam referrers list.'
+							) }
+						</p>
 					</Dialog>
 				) }
 			</li>

--- a/client/my-sites/stats/stats-list/action-spam.jsx
+++ b/client/my-sites/stats/stats-list/action-spam.jsx
@@ -1,5 +1,4 @@
-import { Dialog } from '@automattic/components';
-import { Tooltip } from '@wordpress/components';
+import { Button, Modal, Tooltip } from '@wordpress/components';
 import { Icon, warning } from '@wordpress/icons';
 import clsx from 'clsx';
 import debugFactory from 'debug';
@@ -95,22 +94,11 @@ class StatsActionSpam extends Component {
 						</span>
 					</button>
 				</Tooltip>
-				{ this.props.inHorizontalBarList && (
-					<Dialog
-						isVisible={ this.state.showConfirmDialog }
-						buttons={ [
-							{
-								action: 'cancel',
-								label: this.props.translate( 'Cancel' ),
-							},
-							{
-								action: 'delete',
-								label: this.props.translate( 'Mark as Spam' ),
-								isPrimary: true,
-								onClick: this.markAsSpam,
-							},
-						] }
-						onClose={ this.closeConfirmDialog }
+				{ this.props.inHorizontalBarList && this.state.showConfirmDialog && (
+					<Modal
+						title={ this.props.translate( 'Mark as spam' ) }
+						onRequestClose={ this.closeConfirmDialog }
+						className="action-spam__confirm-modal"
 					>
 						<p>
 							{ this.props.translate( "Are you sure you want to mark '%(domain)s' as spam?", {
@@ -122,7 +110,15 @@ class StatsActionSpam extends Component {
 								'This will hide this referrer from your future stats. Historical stats will not be affected. You can undo this later from the spam referrers list.'
 							) }
 						</p>
-					</Dialog>
+						<div style={ { display: 'flex', justifyContent: 'flex-end', gap: '8px' } }>
+							<Button variant="tertiary" onClick={ this.closeConfirmDialog }>
+								{ this.props.translate( 'Cancel' ) }
+							</Button>
+							<Button variant="primary" onClick={ this.markAsSpam }>
+								{ this.props.translate( 'Mark as spam' ) }
+							</Button>
+						</div>
+					</Modal>
 				) }
 			</li>
 		);

--- a/client/my-sites/stats/stats-list/action-spam.jsx
+++ b/client/my-sites/stats/stats-list/action-spam.jsx
@@ -133,7 +133,7 @@ class StatsActionSpam extends Component {
 								'You can undo this action and manage spam referrers from the referrers detail page.'
 							) }
 						</p>
-						<div style={ { display: 'flex', justifyContent: 'flex-end', gap: '8px' } }>
+						<div className="action-spam__confirm-modal-actions">
 							<Button variant="tertiary" onClick={ this.closeConfirmDialog }>
 								{ this.props.translate( 'Cancel' ) }
 							</Button>

--- a/client/my-sites/stats/stats-list/action-spam.jsx
+++ b/client/my-sites/stats/stats-list/action-spam.jsx
@@ -4,8 +4,10 @@ import clsx from 'clsx';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
+import { connect } from 'react-redux';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import wpcom from 'calypso/lib/wp';
+import { requestSiteStats } from 'calypso/state/stats/lists/actions';
 import './actions-spam.scss';
 
 const debug = debugFactory( 'calypso:stats:action-spam' );
@@ -58,7 +60,15 @@ class StatsActionSpam extends Component {
 		}
 
 		const wpcomSite = wpcom.site( this.props.data.siteID );
-		wpcomSite[ spamType ].call( wpcomSite, this.props.data.domain, function () {} );
+		wpcomSite[ spamType ].call( wpcomSite, this.props.data.domain, () => {
+			if ( this.props.statsQuery ) {
+				this.props.requestSiteStats(
+					this.props.data.siteID,
+					'statsReferrers',
+					this.props.statsQuery
+				);
+			}
+		} );
 		gaRecordEvent( 'Stats', gaEvent + ' in ' + this.props.moduleName + ' List' );
 	}
 
@@ -125,4 +135,4 @@ class StatsActionSpam extends Component {
 	}
 }
 
-export default localize( StatsActionSpam );
+export default connect( null, { requestSiteStats } )( localize( StatsActionSpam ) );

--- a/client/my-sites/stats/stats-list/actions-spam.scss
+++ b/client/my-sites/stats/stats-list/actions-spam.scss
@@ -8,3 +8,9 @@
 .action-spam__confirm-modal.components-modal__frame {
 	max-width: 520px;
 }
+
+.action-spam__confirm-modal-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+}

--- a/client/my-sites/stats/stats-list/actions-spam.scss
+++ b/client/my-sites/stats/stats-list/actions-spam.scss
@@ -1,10 +1,3 @@
-// TODO: Remove this once /stats/day/referrers/example.com uses the new horizontal bar lists.
-@media (min-width: "783px") {
-	.stats-card .stats-list__spam-label {
-		display: none;
-	}
-}
-
 .action-spam__confirm-modal.components-modal__frame {
 	max-width: 520px;
 }

--- a/client/my-sites/stats/stats-list/actions-spam.scss
+++ b/client/my-sites/stats/stats-list/actions-spam.scss
@@ -4,3 +4,7 @@
 		display: none;
 	}
 }
+
+.action-spam__confirm-modal.components-modal__frame {
+	max-width: 520px;
+}

--- a/client/my-sites/stats/stats-list/stats-list-actions.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-actions.jsx
@@ -12,7 +12,7 @@ import Promote from './action-promote';
 import Spam from './action-spam';
 import OpenUTMBuilder from './action-utm-builder';
 
-function useActionItems( { data, moduleName } ) {
+function useActionItems( { data, moduleName, statsQuery } ) {
 	return useMemo( () => {
 		const actionItems = [];
 
@@ -47,6 +47,7 @@ function useActionItems( { data, moduleName } ) {
 								inHorizontalBarList
 								key={ action.type }
 								moduleName={ moduleNameTitle }
+								statsQuery={ statsQuery }
 							/>
 						);
 						break;
@@ -83,7 +84,7 @@ function useActionItems( { data, moduleName } ) {
 			}
 		}
 		return actionItems;
-	}, [ data, moduleName ] );
+	}, [ data, moduleName, statsQuery ] );
 }
 
 /**
@@ -96,9 +97,10 @@ const StatsListActions = ( {
 	children,
 	isMobileMenuVisible,
 	onMobileMenuClick,
+	statsQuery,
 } ) => {
 	const translate = useTranslate();
-	const actionItems = useActionItems( { data, moduleName } );
+	const actionItems = useActionItems( { data, moduleName, statsQuery } );
 
 	return actionItems?.length || children ? (
 		<>

--- a/client/my-sites/stats/stats-list/stats-list-card.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-card.jsx
@@ -43,7 +43,6 @@ const StatsListCard = ( {
 	overlay, // an overlay used to hide the module behind a blur overlay
 	hasNoBackground,
 	formatValue,
-	onShowMoreClick,
 	statsQuery,
 } ) => {
 	const moduleNameTitle = titlecase( moduleType );
@@ -137,7 +136,8 @@ const StatsListCard = ( {
 					? {
 							url: showMore?.url,
 							label: showMore?.label,
-							onClick: onShowMoreClick || undefined,
+							onClick: showMore?.onClick,
+							ariaLabel: showMore?.ariaLabel,
 					  }
 					: undefined
 			}

--- a/client/my-sites/stats/stats-list/stats-list-card.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-card.jsx
@@ -44,6 +44,7 @@ const StatsListCard = ( {
 	hasNoBackground,
 	formatValue,
 	onShowMoreClick,
+	statsQuery,
 } ) => {
 	const moduleNameTitle = titlecase( moduleType );
 	const debug = debugFactory( `calypso:stats:list:${ moduleType }` );
@@ -84,6 +85,7 @@ const StatsListCard = ( {
 				isMobileMenuVisible={ isVisible }
 				inStatsListCard
 				onMobileMenuClick={ ( event ) => toggleMobileMenu( event, isVisible, key ) }
+				statsQuery={ statsQuery }
 			>
 				{ item?.link && (
 					<OpenLink href={ item.link } key={ `link-${ key }` } moduleName={ moduleType } />

--- a/client/my-sites/stats/stats-list/stats-list-card.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-card.jsx
@@ -19,7 +19,7 @@ import StatsListCountryFlag from './stats-list-country-flag';
 const StatsListCard = ( {
 	data,
 	moduleType,
-	showMore,
+	footerAction,
 	title,
 	titleNodes,
 	downloadCsv,
@@ -131,16 +131,7 @@ const StatsListCard = ( {
 	return (
 		<StatsCard
 			title={ title }
-			footerAction={
-				showMore
-					? {
-							url: showMore?.url,
-							label: showMore?.label,
-							onClick: showMore?.onClick,
-							ariaLabel: showMore?.ariaLabel,
-					  }
-					: undefined
-			}
+			footerAction={ footerAction }
 			emptyMessage={ emptyMessage }
 			isEmpty={ ! loader && ( ! data || ! data?.length ) }
 			titleNodes={ titleNodes }

--- a/client/my-sites/stats/stats-list/style.scss
+++ b/client/my-sites/stats/stats-list/style.scss
@@ -981,4 +981,9 @@ ul.module-content-list-legend {
 	.stats-list-actions__mobile-toggle {
 		display: block;
 	}
+
+	// Prevent the card from clipping the dropdown menu.
+	.stats-card__content:has( .stats-list-actions--expanded ) {
+		overflow: visible;
+	}
 }

--- a/client/my-sites/stats/stats-list/style.scss
+++ b/client/my-sites/stats/stats-list/style.scss
@@ -609,11 +609,11 @@ ul.module-content-list-item-action-submenu {
 	}
 
 	// Color spam action red
-	.module-content-list-item-action-wrapper.spam {
-		color: var( --color-error );
+	@include breakpoint-deprecated( '<480px' ) {
+		.module-content-list-item-action-wrapper.spam {
+			color: var( --color-error );
 
-		// Hover state
-		@include breakpoint-deprecated( '>480px' ) {
+			// Hover state
 			&:hover {
 				color: var( --color-error-30 );
 			}

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -52,8 +52,7 @@ class StatsModule extends Component {
 		formatValue: PropTypes.func,
 		minutesLimit: PropTypes.number,
 		isRealTime: PropTypes.bool,
-		summaryFooterAction: PropTypes.object,
-		onShowMoreClick: PropTypes.func,
+		footerAction: PropTypes.object,
 	};
 
 	static defaultProps = {
@@ -296,14 +295,14 @@ class StatsModule extends Component {
 		// TODO: Support error state in redux store
 		const hasError = false;
 
-		const { summaryFooterAction, onShowMoreClick } = this.props;
+		const { footerAction } = this.props;
 		const summaryLink = ! this.props.hideSummaryLink && this.getSummaryLink();
 		const displaySummaryLink = data && summaryLink;
 
 		// Determine showMore action for StatsListCard.
 		let showMoreAction;
-		if ( summary && summaryFooterAction ) {
-			showMoreAction = summaryFooterAction;
+		if ( summary && footerAction ) {
+			showMoreAction = footerAction;
 		} else if ( displaySummaryLink && ! summary ) {
 			showMoreAction = {
 				url: summaryLink,
@@ -338,7 +337,6 @@ class StatsModule extends Component {
 					emptyMessage={ emptyMessage }
 					metricLabel={ metricLabel }
 					showMore={ showMoreAction }
-					onShowMoreClick={ onShowMoreClick }
 					error={ hasError && <ErrorPanel /> }
 					loader={ isLoading && <StatsModulePlaceholder isLoading={ isLoading } /> }
 					heroElement={

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -299,12 +299,12 @@ class StatsModule extends Component {
 		const summaryLink = ! this.props.hideSummaryLink && this.getSummaryLink();
 		const displaySummaryLink = data && summaryLink;
 
-		// Determine showMore action for StatsListCard.
-		let showMoreAction;
+		// Determine footer action for StatsListCard.
+		let resolvedFooterAction;
 		if ( summary && footerAction ) {
-			showMoreAction = footerAction;
+			resolvedFooterAction = footerAction;
 		} else if ( displaySummaryLink && ! summary ) {
-			showMoreAction = {
+			resolvedFooterAction = {
 				url: summaryLink,
 				label:
 					data.length >= 10
@@ -336,7 +336,7 @@ class StatsModule extends Component {
 					titleNodes={ titleNodes }
 					emptyMessage={ emptyMessage }
 					metricLabel={ metricLabel }
-					showMore={ showMoreAction }
+					footerAction={ resolvedFooterAction }
 					error={ hasError && <ErrorPanel /> }
 					loader={ isLoading && <StatsModulePlaceholder isLoading={ isLoading } /> }
 					heroElement={

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -52,6 +52,8 @@ class StatsModule extends Component {
 		formatValue: PropTypes.func,
 		minutesLimit: PropTypes.number,
 		isRealTime: PropTypes.bool,
+		summaryFooterAction: PropTypes.object,
+		onShowMoreClick: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -294,8 +296,27 @@ class StatsModule extends Component {
 		// TODO: Support error state in redux store
 		const hasError = false;
 
+		const { summaryFooterAction, onShowMoreClick } = this.props;
 		const summaryLink = ! this.props.hideSummaryLink && this.getSummaryLink();
 		const displaySummaryLink = data && summaryLink;
+
+		// Determine showMore action for StatsListCard.
+		let showMoreAction;
+		if ( summary && summaryFooterAction ) {
+			showMoreAction = summaryFooterAction;
+		} else if ( displaySummaryLink && ! summary ) {
+			showMoreAction = {
+				url: summaryLink,
+				label:
+					data.length >= 10
+						? translate( 'View all', {
+								context: 'Stats: Button link to show more detailed stats information',
+						  } )
+						: translate( 'View details', {
+								context: 'Stats: Button label to see the detailed content of a panel',
+						  } ),
+			};
+		}
 		const isAllTime = this.isAllTimeList();
 
 		const emptyMessage = isRealTime ? 'gathering info…' : moduleStrings.empty;
@@ -316,21 +337,8 @@ class StatsModule extends Component {
 					titleNodes={ titleNodes }
 					emptyMessage={ emptyMessage }
 					metricLabel={ metricLabel }
-					showMore={
-						displaySummaryLink && ! summary
-							? {
-									url: summaryLink,
-									label:
-										data.length >= 10
-											? translate( 'View all', {
-													context: 'Stats: Button link to show more detailed stats information',
-											  } )
-											: translate( 'View details', {
-													context: 'Stats: Button label to see the detailed content of a panel',
-											  } ),
-							  }
-							: undefined
-					}
+					showMore={ showMoreAction }
+					onShowMoreClick={ onShowMoreClick }
 					error={ hasError && <ErrorPanel /> }
 					loader={ isLoading && <StatsModulePlaceholder isLoading={ isLoading } /> }
 					heroElement={

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -354,6 +354,7 @@ class StatsModule extends Component {
 					showLeftIcon={ path === 'authors' }
 					listItemClassName={ listItemClassName }
 					hasNoBackground={ hasNoBackground }
+					statsQuery={ query }
 					overlay={
 						siteId &&
 						statType &&

--- a/client/my-sites/stats/stats-reach/index.jsx
+++ b/client/my-sites/stats/stats-reach/index.jsx
@@ -93,7 +93,7 @@ export const StatsReach = ( props ) => {
 				useShortNumber
 				// Shares don't have a summary page yet.
 				// TODO: limit to 5 items after summary page is added.
-				// showMore={ ... }
+				// footerAction={ ... }
 				// TODO: add error state once it's implemented
 				loader={
 					( isLoadingFollowData || isLoadingPublicize ) && (

--- a/packages/components/src/horizontal-bar-list/stats-card.scss
+++ b/packages/components/src/horizontal-bar-list/stats-card.scss
@@ -126,6 +126,7 @@
 		display: block;
 		color: var(--color-text);
 		text-decoration: none; // TODO: Should this be a tertiary button component instead?
+		cursor: pointer;
 
 		&:visited {
 			color: $font-color;
@@ -135,6 +136,10 @@
 		&:focus {
 			text-decoration: underline;
 		}
+	}
+
+	button.stats-card--footer {
+		text-align: start;
 	}
 
 	&.stats-card__hasoverlay {

--- a/packages/components/src/horizontal-bar-list/stats-card.tsx
+++ b/packages/components/src/horizontal-bar-list/stats-card.tsx
@@ -158,10 +158,11 @@ const StatsCard = ( props: StatsCardProps ) => {
 							className={ `${ BASE_CLASS_NAME }--footer` }
 							onClick={ footerAction.onClick }
 							aria-label={
-								translate( 'View all %(title)s', {
+								footerAction.ariaLabel ??
+								( translate( 'View all %(title)s', {
 									args: { title: title.toLocaleLowerCase?.() ?? title.toLowerCase() },
 									comment: '"View all posts & pages", "View all referrers", etc.',
-								} ) as string
+								} ) as string )
 							}
 						>
 							{ footerAction.label || translate( 'View all' ) }
@@ -171,10 +172,11 @@ const StatsCard = ( props: StatsCardProps ) => {
 							className={ `${ BASE_CLASS_NAME }--footer` }
 							href={ footerAction?.url }
 							aria-label={
-								translate( 'View all %(title)s', {
+								footerAction.ariaLabel ??
+								( translate( 'View all %(title)s', {
 									args: { title: title.toLocaleLowerCase?.() ?? title.toLowerCase() },
 									comment: '"View all posts & pages", "View all referrers", etc.',
-								} ) as string
+								} ) as string )
 							}
 						>
 							{ footerAction.label || translate( 'View all' ) }

--- a/packages/components/src/horizontal-bar-list/stats-card.tsx
+++ b/packages/components/src/horizontal-bar-list/stats-card.tsx
@@ -173,6 +173,7 @@ const StatsCard = ( props: StatsCardProps ) => {
 						<a
 							className={ `${ BASE_CLASS_NAME }--footer` }
 							href={ footerAction?.url }
+							onClick={ footerAction.onClick }
 							aria-label={ footerAriaLabel }
 						>
 							{ footerLabel }

--- a/packages/components/src/horizontal-bar-list/stats-card.tsx
+++ b/packages/components/src/horizontal-bar-list/stats-card.tsx
@@ -124,10 +124,12 @@ const StatsCard = ( props: StatsCardProps ) => {
 
 	const footerAriaLabel =
 		footerAction?.ariaLabel ??
-		( translate( 'View all %(title)s', {
-			args: { title: title.toLocaleLowerCase?.() ?? title.toLowerCase() },
-			comment: '"View all posts & pages", "View all referrers", etc.',
-		} ) as string );
+		( typeof title === 'string'
+			? ( translate( 'View all %(title)s', {
+					args: { title: title.toLocaleLowerCase() },
+					comment: '"View all posts & pages", "View all referrers", etc.',
+			  } ) as string )
+			: ( translate( 'View all' ) as string ) );
 	const footerLabel = footerAction?.label || translate( 'View all' );
 
 	return (

--- a/packages/components/src/horizontal-bar-list/stats-card.tsx
+++ b/packages/components/src/horizontal-bar-list/stats-card.tsx
@@ -122,6 +122,14 @@ const StatsCard = ( props: StatsCardProps ) => {
 		return simpleHeaderNode;
 	};
 
+	const footerAriaLabel =
+		footerAction?.ariaLabel ??
+		( translate( 'View all %(title)s', {
+			args: { title: title.toLocaleLowerCase?.() ?? title.toLowerCase() },
+			comment: '"View all posts & pages", "View all referrers", etc.',
+		} ) as string );
+	const footerLabel = footerAction?.label || translate( 'View all' );
+
 	return (
 		<div
 			className={ clsx( className, BASE_CLASS_NAME, {
@@ -157,29 +165,17 @@ const StatsCard = ( props: StatsCardProps ) => {
 						<button
 							className={ `${ BASE_CLASS_NAME }--footer` }
 							onClick={ footerAction.onClick }
-							aria-label={
-								footerAction.ariaLabel ??
-								( translate( 'View all %(title)s', {
-									args: { title: title.toLocaleLowerCase?.() ?? title.toLowerCase() },
-									comment: '"View all posts & pages", "View all referrers", etc.',
-								} ) as string )
-							}
+							aria-label={ footerAriaLabel }
 						>
-							{ footerAction.label || translate( 'View all' ) }
+							{ footerLabel }
 						</button>
 					) : (
 						<a
 							className={ `${ BASE_CLASS_NAME }--footer` }
 							href={ footerAction?.url }
-							aria-label={
-								footerAction.ariaLabel ??
-								( translate( 'View all %(title)s', {
-									args: { title: title.toLocaleLowerCase?.() ?? title.toLowerCase() },
-									comment: '"View all posts & pages", "View all referrers", etc.',
-								} ) as string )
-							}
+							aria-label={ footerAriaLabel }
 						>
-							{ footerAction.label || translate( 'View all' ) }
+							{ footerLabel }
 						</a>
 					) ) }
 			</div>

--- a/packages/components/src/horizontal-bar-list/stats-card.tsx
+++ b/packages/components/src/horizontal-bar-list/stats-card.tsx
@@ -152,20 +152,34 @@ const StatsCard = ( props: StatsCardProps ) => {
 						{ isEmpty ? emptyMessage : children }
 					</div>
 				</div>
-				{ footerAction && (
-					<a
-						className={ `${ BASE_CLASS_NAME }--footer` }
-						href={ footerAction?.url }
-						aria-label={
-							translate( 'View all %(title)s', {
-								args: { title: title.toLocaleLowerCase?.() ?? title.toLowerCase() },
-								comment: '"View all posts & pages", "View all referrers", etc.',
-							} ) as string
-						}
-					>
-						{ footerAction.label || translate( 'View all' ) }
-					</a>
-				) }
+				{ footerAction &&
+					( footerAction.onClick && ! footerAction.url ? (
+						<button
+							className={ `${ BASE_CLASS_NAME }--footer` }
+							onClick={ footerAction.onClick }
+							aria-label={
+								translate( 'View all %(title)s', {
+									args: { title: title.toLocaleLowerCase?.() ?? title.toLowerCase() },
+									comment: '"View all posts & pages", "View all referrers", etc.',
+								} ) as string
+							}
+						>
+							{ footerAction.label || translate( 'View all' ) }
+						</button>
+					) : (
+						<a
+							className={ `${ BASE_CLASS_NAME }--footer` }
+							href={ footerAction?.url }
+							aria-label={
+								translate( 'View all %(title)s', {
+									args: { title: title.toLocaleLowerCase?.() ?? title.toLowerCase() },
+									comment: '"View all posts & pages", "View all referrers", etc.',
+								} ) as string
+							}
+						>
+							{ footerAction.label || translate( 'View all' ) }
+						</a>
+					) ) }
 			</div>
 			{ overlay && <div className={ `${ BASE_CLASS_NAME }__overlay` }>{ overlay }</div> }
 		</div>

--- a/packages/components/src/horizontal-bar-list/types.ts
+++ b/packages/components/src/horizontal-bar-list/types.ts
@@ -84,6 +84,7 @@ export type StatsCardProps = {
 		label?: string;
 		url?: string;
 		onClick?: ( event?: React.MouseEvent | React.KeyboardEvent ) => void;
+		ariaLabel?: string;
 	};
 	/**
 	 * @property {boolean} isEmpty - renders an empty card with a message (`emptyMessage`) when true. It doesn't render column labels.


### PR DESCRIPTION
## Proposed Changes

* Add a spam referrers management modal on the referrers detail page for viewing and removing spam referrers
* Add TanStack Query hook for the `/stats/referrers/spam` API with optimistic updates
* Migrate mark-as-spam confirmation dialog from legacy `Dialog` to `@wordpress/components` `Modal`
* Rename `showMore` prop to `footerAction` across `StatsCard` and `StatsListCard` for clarity
* Support button-style footer actions and `onClick` on anchor footer actions in `StatsCard`

Related work:

* 210747-ghe-Automattic/wpcom
* 210748-ghe-Automattic/wpcom
* https://github.com/Automattic/jetpack/pull/47566

<details><summary>UX screen recording</summary>
<p>



https://github.com/user-attachments/assets/203d4dc6-81c5-4e65-941e-7559798b6ca0



</p>
</details> 

<details><summary>Screenshots</summary>
<p>


<img width="2428" height="2024" alt="manage-referrers-button" src="https://github.com/user-attachments/assets/ca9d83fa-7575-4907-989a-a75688d9b781" /> 
<img width="2428" height="2024" alt="manage-referrers-mark" src="https://github.com/user-attachments/assets/9060ad17-ca0d-42d3-8e39-668311e47614" />
<img width="2428" height="2024" alt="manage-referrers-list" src="https://github.com/user-attachments/assets/e521479c-8a4e-44cd-9c3b-111d991a98ae" /> 
<img width="2424" height="2024" alt="manage-referrers-error" src="https://github.com/user-attachments/assets/e8261ddc-443e-48e7-a8b4-4629590bebc9" />
<img width="2428" height="2024" alt="manage-referrers-list-empty" src="https://github.com/user-attachments/assets/7d49ce85-537a-4b7c-aad2-57e19e28d25e" />


</p>
</details> 

## Why are these changes being made?

See p1772464364989299-slack-C04PWEZSYFL and p1772647352583179-slack-C0438NHCLSY. 

Users need a way to manage referrer spam — marking domains as spam to hide them from stats, and undoing that action later. Previously, the only way to mark spam was inline with no way to undo. This adds a management modal accessible from the referrers detail page footer, with proper data refresh, error handling, and accessible keyboard interactions.

## Testing Instructions

> [!important]
> This feature requires applying a yet to be published REST API endpoint to your sandbox: 207232-ghe-Automattic/wpcom

* **Dashboard** (`/stats/day/{slug}`): Hover over a referrer row, click the warning icon to mark as spam. Verify the confirmation dialog opens correctly. Verify "Manage spam referrers" does NOT appear in the dashboard card footer.
* **Referrers detail page** (`/stats/day/referrers/{slug}`): Verify "Manage spam referrers" appears in the card footer. Click it to open the modal. Click "Remove" on a domain — verify it disappears immediately and the modal remains dismissable with Escape. Close the modal and verify the referrers list refreshes.
* **Keyboard navigation**: Open the mark-as-spam confirmation dialog, verify pressing Enter activates the focused button (not the domain link). Verify Escape closes the modal.
* **Error states**: Verify error banners appear if the API fails (can test by going offline).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?