### PR TITLE
Fix timeouts in fse__temp-smoke-test.ts

### DIFF
--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -82,7 +82,12 @@ export class SidebarComponent {
 
 		// Sub-level menu item selector.
 		if ( subitem ) {
+			// Clicking the top-level item may trigger a client-side React
+			// navigation or a full page load. Either way, wait for the
+			// expanded submenu and the specific subitem link to be visible
+			// before interacting with it.
 			const subitemSelector = `.is-toggle-open a:has(:text-is("${ subitem }"):visible), .wp-menu-open .wp-submenu a:has(:text-is("${ subitem }"):visible)`;
+			await this.page.locator( subitemSelector ).first().waitFor();
 			const hrefSubItemSelector = ( await this.page.getAttribute(
 				subitemSelector,
 				'href'

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -89,10 +89,10 @@ export class SidebarComponent {
 			// all operations to avoid inconsistency if the DOM changes.
 			const subitemLocator = this.page
 				.locator(
-					`.is-toggle-open a:text-is("${ subitem }"), .wp-menu-open .wp-submenu a:text-is("${ subitem }")`
+					`.is-toggle-open a:has(:text-is("${ subitem }")), .wp-menu-open .wp-submenu a:text-is("${ subitem }")`
 				)
 				.first();
-			await subitemLocator.waitFor( { state: 'attached' } );
+			await subitemLocator.waitFor();
 			const hrefSubItemSelector = ( await subitemLocator.getAttribute( 'href' ) ) as string;
 
 			await subitemLocator.dispatchEvent( 'click' );

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -85,15 +85,17 @@ export class SidebarComponent {
 			// Clicking the top-level item may trigger a client-side React
 			// navigation or a full page load. Either way, wait for the
 			// expanded submenu and the specific subitem link to be visible
-			// before interacting with it.
-			const subitemSelector = `.is-toggle-open a:has(:text-is("${ subitem }"):visible), .wp-menu-open .wp-submenu a:has(:text-is("${ subitem }"):visible)`;
-			await this.page.locator( subitemSelector ).first().waitFor();
-			const hrefSubItemSelector = ( await this.page.getAttribute(
-				subitemSelector,
-				'href'
-			) ) as string;
+			// before interacting with it. Use a single locator instance for
+			// all operations to avoid inconsistency if the DOM changes.
+			const subitemLocator = this.page
+				.locator(
+					`.is-toggle-open a:has(:text-is("${ subitem }"):visible), .wp-menu-open .wp-submenu a:has(:text-is("${ subitem }"):visible)`
+				)
+				.first();
+			await subitemLocator.waitFor();
+			const hrefSubItemSelector = ( await subitemLocator.getAttribute( 'href' ) ) as string;
 
-			await this.page.dispatchEvent( subitemSelector, 'click' );
+			await subitemLocator.dispatchEvent( 'click' );
 			await this.page.waitForURL( `**${ hrefSubItemSelector }`, {
 				waitUntil: 'domcontentloaded',
 			} );

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -89,10 +89,10 @@ export class SidebarComponent {
 			// all operations to avoid inconsistency if the DOM changes.
 			const subitemLocator = this.page
 				.locator(
-					`.is-toggle-open a:has(:text-is("${ subitem }"):visible), .wp-menu-open .wp-submenu a:has(:text-is("${ subitem }"):visible)`
+					`.is-toggle-open a:text-is("${ subitem }"), .wp-menu-open .wp-submenu a:text-is("${ subitem }")`
 				)
 				.first();
-			await subitemLocator.waitFor();
+			await subitemLocator.waitFor( { state: 'attached' } );
 			const hrefSubItemSelector = ( await subitemLocator.getAttribute( 'href' ) ) as string;
 
 			await subitemLocator.dispatchEvent( 'click' );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* Attempt to fix fse__temp-smoke-test.ts that keeps failing for Gutenberg, by updating sidebar-components.ts.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To make the tests pass.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm that E2E Tests Desktop all pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
