### PR TITLE
notifications: translate: Add --jobs 4 argument to wp-babel-makepot

### DIFF
--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -23,7 +23,7 @@
 		"test:js": "yarn run -T test-apps apps/notifications",
 		"test:js:watch": "yarn test:js --watch",
 		"teamcity:build-app": "yarn build",
-		"translate": "rm -rf dist/strings && wp-babel-makepot '../../{client,packages,apps}/**/*.{js,jsx,ts,tsx}' --ignore '**/node_modules/**,**/test/**,**/*.d.ts' --base './' --dir './dist/strings' --output './dist/notifications.pot' && build-app-languages --stringsFilePath='./dist/notifications.pot' --outputPath='./dist/languages'"
+		"translate": "rm -rf dist/strings && wp-babel-makepot '../../{client,packages,apps}/**/*.{js,jsx,ts,tsx}' --ignore '**/node_modules/**,**/test/**,**/*.d.ts' --base './' --dir './dist/strings' --jobs 4 --output './dist/notifications.pot' && build-app-languages --stringsFilePath='./dist/notifications.pot' --outputPath='./dist/languages'"
 	},
 	"dependencies": {
 		"@automattic/calypso-color-schemes": "workspace:^",


### PR DESCRIPTION
Now that wp-babel-makepot supports the `--jobs` argument (#109188), pass it `4` by default in help-center to speed up the translation. 

I didn't use `auto` because that uses (number of CPUS-1), and we build all the apps in parallel. If we put them all on auto, that might be a bit too many threads.


## Proposed Changes

*

## Why are these changes being made?

*

## Testing Instructions


* Examine the files in ./dist/languages before and after this change, when running the app build. Should be the same.
* Notifications should continue to work (in various languages).

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
