### PR TITLE
Survicate: Add account_age_in_days parameter and update its usage on MSD

### DIFF
--- a/client/dashboard/app/survicate/index.tsx
+++ b/client/dashboard/app/survicate/index.tsx
@@ -5,6 +5,7 @@ import {
 	shouldLoadSurvicate,
 	loadSurvicateScript,
 	setSurvicateVisitorTraits,
+	getAccountAgeInDays,
 	SURVICATE_WORKSPACE_ID,
 } from '@automattic/survicate';
 import { useViewportMatch } from '@wordpress/compose';
@@ -45,7 +46,10 @@ export function useSurvicate() {
 					return;
 				}
 
-				const cleanupTraits = setSurvicateVisitorTraits( { email: user.email } );
+				const cleanupTraits = setSurvicateVisitorTraits( {
+					email: user.email,
+					account_age_in_days: getAccountAgeInDays( user.date ).toString(),
+				} );
 				controller.signal.addEventListener( 'abort', cleanupTraits );
 			} )
 			.catch( () => {

--- a/client/dashboard/app/survicate/index.tsx
+++ b/client/dashboard/app/survicate/index.tsx
@@ -48,7 +48,7 @@ export function useSurvicate() {
 
 				const cleanupTraits = setSurvicateVisitorTraits( {
 					email: user.email,
-					account_age_in_days: getAccountAgeInDays( user.date ).toString(),
+					account_age_in_days: getAccountAgeInDays( user.date ),
 				} );
 				controller.signal.addEventListener( 'abort', cleanupTraits );
 			} )

--- a/client/dashboard/app/survicate/test/index.test.tsx
+++ b/client/dashboard/app/survicate/test/index.test.tsx
@@ -35,6 +35,7 @@ jest.mock( '@automattic/survicate', () => ( {
 	shouldLoadSurvicate: jest.fn(),
 	loadSurvicateScript: jest.fn(),
 	setSurvicateVisitorTraits: jest.fn(),
+	getAccountAgeInDays: jest.fn( () => 42 ),
 	SURVICATE_WORKSPACE_ID: 'test-workspace-id',
 } ) );
 
@@ -95,7 +96,10 @@ describe( 'useSurvicate', () => {
 		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
 
 		expect( mockedLoadScript ).toHaveBeenCalledWith( SURVICATE_WORKSPACE_ID );
-		expect( mockedSetTraits ).toHaveBeenCalledWith( { email: 'test@example.com' } );
+		expect( mockedSetTraits ).toHaveBeenCalledWith( {
+			email: 'test@example.com',
+			account_age_in_days: '42',
+		} );
 	} );
 
 	test( 'skips loading when config flag is disabled', () => {

--- a/client/dashboard/app/survicate/test/index.test.tsx
+++ b/client/dashboard/app/survicate/test/index.test.tsx
@@ -98,7 +98,7 @@ describe( 'useSurvicate', () => {
 		expect( mockedLoadScript ).toHaveBeenCalledWith( SURVICATE_WORKSPACE_ID );
 		expect( mockedSetTraits ).toHaveBeenCalledWith( {
 			email: 'test@example.com',
-			account_age_in_days: '42',
+			account_age_in_days: 42,
 		} );
 	} );
 

--- a/packages/survicate/src/index.ts
+++ b/packages/survicate/src/index.ts
@@ -1,4 +1,4 @@
 export { shouldLoadSurvicate, SURVICATE_WORKSPACE_ID } from './conditions';
 export { isSurvicateScriptLoaded, loadSurvicateScript } from './load-script';
 export { invokeSurvicateEvent } from './invoke-event';
-export { setSurvicateVisitorTraits } from './visitor-traits';
+export { getAccountAgeInDays, setSurvicateVisitorTraits } from './visitor-traits';

--- a/packages/survicate/src/test/visitor-traits.test.ts
+++ b/packages/survicate/src/test/visitor-traits.test.ts
@@ -2,7 +2,25 @@
  * @jest-environment jsdom
  */
 
-import { setSurvicateVisitorTraits } from '../visitor-traits';
+import { getAccountAgeInDays, setSurvicateVisitorTraits } from '../visitor-traits';
+
+const DAY_IN_MS = 86400000;
+
+describe( 'getAccountAgeInDays', () => {
+	test( 'should return the number of whole days since the given date string', () => {
+		const threeDaysAgo = new Date( Date.now() - 3 * DAY_IN_MS ).toISOString();
+		expect( getAccountAgeInDays( threeDaysAgo ) ).toBe( 3 );
+	} );
+
+	test( 'should floor partial days', () => {
+		const oneAndAHalfDaysAgo = new Date( Date.now() - 1.5 * DAY_IN_MS ).toISOString();
+		expect( getAccountAgeInDays( oneAndAHalfDaysAgo ) ).toBe( 1 );
+	} );
+
+	test( 'should return 0 for today', () => {
+		expect( getAccountAgeInDays( new Date().toISOString() ) ).toBe( 0 );
+	} );
+} );
 
 describe( 'setSurvicateVisitorTraits', () => {
 	beforeEach( () => {

--- a/packages/survicate/src/visitor-traits.ts
+++ b/packages/survicate/src/visitor-traits.ts
@@ -15,7 +15,7 @@ const DAY_IN_MS = 86400000;
 /**
  * Returns the number of whole days between a given date and now.
  */
-export function getAccountAgeInDays( registrationDate: number | Date ): number {
+export function getAccountAgeInDays( registrationDate: string ): number {
 	return Math.floor( ( Date.now() - new Date( registrationDate ).getTime() ) / DAY_IN_MS );
 }
 

--- a/packages/survicate/src/visitor-traits.ts
+++ b/packages/survicate/src/visitor-traits.ts
@@ -1,7 +1,7 @@
 declare global {
 	interface Window {
 		_sva?: {
-			setVisitorTraits?: ( traits: Record< string, string > ) => void;
+			setVisitorTraits?: ( traits: Record< string, string | number > ) => void;
 			addEventListener?: ( event: string, handler: () => void ) => void;
 			removeEventListener?: ( event: string, handler: () => void ) => void;
 			invokeEvent?: ( event: string ) => void;
@@ -10,12 +10,24 @@ declare global {
 	}
 }
 
+const DAY_IN_MS = 86400000;
+
+/**
+ * Returns the number of whole days between a given date and now.
+ */
+export function getAccountAgeInDays( registrationDate: number | Date ): number {
+	return Math.floor( ( Date.now() - new Date( registrationDate ).getTime() ) / DAY_IN_MS );
+}
+
 /**
  * Sets Survicate visitor traits (e.g. email) on the global `_sva` object.
  * Waits for the `SurvicateReady` window event before setting traits.
  * @returns A cleanup function that removes the event listener.
  */
-export function setSurvicateVisitorTraits( traits: { email: string } ): () => void {
+export function setSurvicateVisitorTraits( traits: {
+	email: string;
+	account_age_in_days?: string;
+} ): () => void {
 	const handler = function () {
 		if ( typeof window._sva !== 'undefined' && window._sva.setVisitorTraits ) {
 			window._sva.setVisitorTraits( traits );

--- a/packages/survicate/src/visitor-traits.ts
+++ b/packages/survicate/src/visitor-traits.ts
@@ -26,7 +26,7 @@ export function getAccountAgeInDays( registrationDate: string ): number {
  */
 export function setSurvicateVisitorTraits( traits: {
 	email: string;
-	account_age_in_days?: string;
+	account_age_in_days?: number;
 } ): () => void {
 	const handler = function () {
 		if ( typeof window._sva !== 'undefined' && window._sva.setVisitorTraits ) {


### PR DESCRIPTION
Task-related: DOTCOM-16000

## Proposed Changes

- Add a `getAccountAgeInDays( registrationDate )` utility to the `@automattic/survicate` package that computes the number of whole days since a given date.
- Use it in the Dashboard `useSurvicate` hook to pass `account_age_in_days` as a Survicate visitor trait.
- Update the Dashboard survicate test to cover the new trait.

## Why are these changes being made?

We want to use the account age to make targeted surveys for our users. This is a first step to have the account age calculation (`Math.floor((Date.now() - date) / DAY_IN_MS)`) into the shared `@automattic/survicate` package acting as a single source of truth for this logic, making it easier for other callers (e.g., Calypso classic) to adopt when they add `account_age_in_days` support.

## Testing Instructions

- Run the tests:
  ```bash
  yarn test-packages packages/survicate/src/test/
  yarn test-client client/dashboard/app/survicate/test/index.test.tsx
  ```
- On MSD, at the local storage, search for `FeedbackButton::allvisitor`  and ensure the `account_age_in_days` attribute is sent and has the correct value:

<img width="509" height="351" alt="image" src="https://github.com/user-attachments/assets/ebc12c5f-78f1-4928-b30d-90aac2436127" />



## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

Made with [Cursor](https://cursor.com)