### PR TITLE
Enable Akismet cancellation offers in MSD

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -194,13 +194,11 @@ function shouldAddCancellationOfferStep(
 function getBasicSurveySteps( {
 	purchase,
 	upsell,
-	cancellationOffer,
 	hasQuestionTwo,
 	plans,
 }: {
 	purchase: Purchase;
 	upsell: CancelPurchaseState[ 'upsell' ];
-	cancellationOffer: CancellationOffer | undefined;
 	hasQuestionTwo: boolean;
 	plans: PlanProduct[];
 } ): string[] {
@@ -218,7 +216,7 @@ function getBasicSurveySteps( {
 		return [];
 	}
 	if ( isJetpack ) {
-		return availableJetpackSurveySteps( purchase, flowType, cancellationOffer );
+		return availableJetpackSurveySteps( purchase, flowType );
 	}
 	if ( purchase.is_domain_registration ) {
 		return [ FEEDBACK_STEP, NEXT_ADVENTURE_STEP ];
@@ -257,7 +255,6 @@ function getAllSurveySteps( {
 	let steps = getBasicSurveySteps( {
 		purchase,
 		upsell,
-		cancellationOffer,
 		hasQuestionTwo,
 		plans,
 	} );

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -202,6 +202,7 @@ function getBasicSurveySteps( {
 } ): string[] {
 	const flowType = getPurchaseCancellationFlowType( purchase );
 	const isJetpack = purchase.is_jetpack_plan_or_product;
+	const isAkismet = isAkismetProduct( purchase );
 	const downgradePlan = getDowngradePlanForPurchase( plans, purchase, upsell );
 	const isDowngradePlan = [ 'downgrade-monthly', 'downgrade-personal' ].includes( upsell ?? '' );
 	const hasExpired = purchase.expiry_status === 'expired';
@@ -213,7 +214,7 @@ function getBasicSurveySteps( {
 	) {
 		return [];
 	}
-	if ( isJetpack ) {
+	if ( isJetpack || isAkismet ) {
 		return availableJetpackSurveySteps( purchase, flowType, cancellationOffer );
 	}
 	if ( purchase.is_domain_registration ) {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -147,11 +147,7 @@ function getOfferDiscountBasedOnPurchasePrice(
 	return Math.round( offerDiscountPercentage );
 }
 
-function availableJetpackSurveySteps(
-	purchase: Purchase,
-	flowType: CancelFlowType,
-	cancellationOffer: CancellationOffer | undefined
-): string[] {
+function availableJetpackSurveySteps( purchase: Purchase, flowType: CancelFlowType ): string[] {
 	const availableSteps = [];
 
 	// If the plan is already expired or is a temporary Jetpack purchase (license),
@@ -170,6 +166,18 @@ function availableJetpackSurveySteps(
 	}
 
 	if ( CANCEL_FLOW_TYPE.REMOVE === flowType ) {
+		availableSteps.push( FEEDBACK_STEP );
+	}
+
+	return availableSteps;
+}
+
+function shouldAddCancellationOfferStep(
+	purchase: Purchase,
+	flowType: CancelFlowType,
+	cancellationOffer: CancellationOffer | undefined
+): boolean {
+	if ( CANCEL_FLOW_TYPE.REMOVE === flowType ) {
 		const isOfferPriceSameOrLowerThanPurchasePrice = cancellationOffer
 			? purchase.amount >= cancellationOffer.original_price
 			: false;
@@ -178,13 +186,9 @@ function availableJetpackSurveySteps(
 			cancellationOffer
 		);
 
-		availableSteps.push( FEEDBACK_STEP );
-		if ( isOfferPriceSameOrLowerThanPurchasePrice && offerDiscountBasedFromPurchasePrice >= 10 ) {
-			availableSteps.push( CANCELLATION_OFFER_STEP );
-		}
+		return isOfferPriceSameOrLowerThanPurchasePrice && offerDiscountBasedFromPurchasePrice >= 10;
 	}
-
-	return availableSteps;
+	return false;
 }
 
 function getBasicSurveySteps( {
@@ -202,7 +206,6 @@ function getBasicSurveySteps( {
 } ): string[] {
 	const flowType = getPurchaseCancellationFlowType( purchase );
 	const isJetpack = purchase.is_jetpack_plan_or_product;
-	const isAkismet = isAkismetProduct( purchase );
 	const downgradePlan = getDowngradePlanForPurchase( plans, purchase, upsell );
 	const isDowngradePlan = [ 'downgrade-monthly', 'downgrade-personal' ].includes( upsell ?? '' );
 	const hasExpired = purchase.expiry_status === 'expired';
@@ -214,7 +217,7 @@ function getBasicSurveySteps( {
 	) {
 		return [];
 	}
-	if ( isJetpack || isAkismet ) {
+	if ( isJetpack ) {
 		return availableJetpackSurveySteps( purchase, flowType, cancellationOffer );
 	}
 	if ( purchase.is_domain_registration ) {
@@ -270,6 +273,10 @@ function getAllSurveySteps( {
 		const stepsToRemove = [ FEEDBACK_STEP, NEXT_ADVENTURE_STEP ];
 		steps = steps.filter( ( step ) => ! stepsToRemove.includes( step ) );
 		steps = [ REMOVE_PLAN_STEP, ...steps ];
+	}
+
+	if ( shouldAddCancellationOfferStep( purchase, flowType, cancellationOffer ) ) {
+		steps.push( CANCELLATION_OFFER_STEP );
 	}
 
 	return steps;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of SHILL-1698

## Proposed Changes

* Enable Akismet cancellation offer support in multi site dashboard

| Cancellation Offer Step | Approval Notice |
|-------------------------|-----------------|
| <img width="712" height="508" alt="Screenshot 2026-03-12 at 12 21 59 PM" src="https://github.com/user-attachments/assets/d8d9fc3a-817c-49bd-a5cb-d7d23a9cfbd1" /> | <img width="707" height="530" alt="Screenshot 2026-03-12 at 12 22 10 PM" src="https://github.com/user-attachments/assets/4bfa8c6d-b3dd-4cce-a0e4-2a42663fa4d6" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To allow the customer to accept Akismet cancellation offers in the multi site dashboard.
* To allow the customer to accept cancellation offers from other products in the multi site dashboard when those offers are created.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

NOTE to A12s: you will need to sandbox the public api and short circuit the backend so that no refunds on this purchase are available. See the issue notes for how to do this.

Test you can accept the offer:
* Purchase an Akismet plan ( https://wordpress.com/checkout/akismet/ak_plus_yearly_1 )
* Go to the multisite dashboard billing page `/me/billing/purchases` and choose the Akismet product's "Manage purchase" link.
* Disable auto renew
* Make sure the "Cancel" button turns into a "Remove" button. click the "Remove" button.
* Click the checkbox and confirm to move onto the next page.
* Make sure you see a text box to leave comments. Click submit.
* You should see the cancellation offer. Verify everything looks correct.
* Click "Get discount"
* You should arrive on the purchase settings page for the new subscription with a notice at the top of the page thanking you for sticking with Akismet. Verify that it looks correct and do not dismiss this notice (do not click the X in the corner of the notice) yet.
* Click the renew button, which should send you to checkout for a renewal at the discounted price mentioned in the cancellation offer. Pay at checkout and you should be redirected to the purchase settings page, verify that the "Thank you for sticking with Akismet" notice is now gone and that the renewal price is the regular price.

Test you don't need to accept the offer:
* Purchase an Akismet plan ( https://wordpress.com/checkout/akismet/ak_plus_yearly_1 )
* In the multi site dashboard, visit `/me/billing/purchases` and manage the Akismet purchase
* Disable auto renew
* Click "Remove"
* Accept the features lost and continue with removing the product, when it asks why, choose budget reasons, continue to next page.
* You should see the introductory offer. Verify everything looks correct.
* Click "No thanks" and confirm that your purchase was removed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
