### PR TITLE
TeamCity: add gated experimental buildx diagnostics step

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -250,10 +250,6 @@ object BuildDockerImage : BuildType({
 
 				echo "=== buildx inspect (default) ==="
 				docker buildx inspect --bootstrap || true
-
-				echo "=== try create a dedicated builder (docker-container driver) ==="
-				docker buildx create --name tc-builder --driver docker-container --use 2>/dev/null || docker buildx use tc-builder
-				docker buildx inspect --bootstrap
 			""".trimIndent()
 		}
 
@@ -266,6 +262,8 @@ object BuildDockerImage : BuildType({
 				#!/usr/bin/env bash
 				set -euo pipefail
 
+				docker buildx use default
+
 				CACHE_REF="registry.a8c.com/calypso/buildcache:canary"
 
 				cat > /tmp/Dockerfile.buildx-canary <<'EOF'
@@ -276,7 +274,7 @@ object BuildDockerImage : BuildType({
 				EOF
 
 				docker buildx build \
-				  --builder tc-builder \
+				  --builder default \
 				  --progress=plain \
 				  --platform=linux/amd64 \
 				  --cache-to=type=registry,ref="${'$'}CACHE_REF",mode=max \

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -250,6 +250,10 @@ object BuildDockerImage : BuildType({
 
 				echo "=== buildx inspect (default) ==="
 				docker buildx inspect --bootstrap || true
+
+				echo "=== try create a dedicated builder (docker-container driver) ==="
+				docker buildx create --name tc-builder --driver docker-container --use 2>/dev/null || docker buildx use tc-builder
+				docker buildx inspect --bootstrap
 			""".trimIndent()
 		}
 
@@ -262,8 +266,6 @@ object BuildDockerImage : BuildType({
 				#!/usr/bin/env bash
 				set -euo pipefail
 
-				docker buildx use default
-
 				CACHE_REF="registry.a8c.com/calypso/buildcache:canary"
 
 				cat > /tmp/Dockerfile.buildx-canary <<'EOF'
@@ -274,7 +276,7 @@ object BuildDockerImage : BuildType({
 				EOF
 
 				docker buildx build \
-				  --builder default \
+				  --builder tc-builder \
 				  --progress=plain \
 				  --platform=linux/amd64 \
 				  --cache-to=type=registry,ref="${'$'}CACHE_REF",mode=max \

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -258,6 +258,36 @@ object BuildDockerImage : BuildType({
 		}
 
 		script {
+			name = "Experimental buildx cache test"
+			conditions {
+				equals("EXPERIMENTAL_BUILDX", "true")
+			}
+			scriptContent = """
+				#!/usr/bin/env bash
+				set -euo pipefail
+
+				CACHE_REF="registry.a8c.com/calypso/buildcache:canary"
+
+				cat > /tmp/Dockerfile.buildx-canary <<'EOF'
+				# syntax=docker/dockerfile:1.7
+				FROM alpine:3.20
+				RUN --mount=type=cache,target=/root/.cache,id=canary-cache \
+				    sh -c 'date > /root/.cache/hello && cat /root/.cache/hello'
+				EOF
+
+				docker buildx build \
+				  --progress=plain \
+				  --platform=linux/amd64 \
+				  --cache-to=type=registry,ref="${'$'}CACHE_REF",mode=max \
+				  --cache-from=type=registry,ref="${'$'}CACHE_REF" \
+				  -f /tmp/Dockerfile.buildx-canary \
+				  --load \
+				  -t registry.a8c.com/calypso/buildx-canary:build-%build.number% \
+				  /tmp
+			""".trimIndent()
+		}
+
+		script {
 			name = "Webhook fail OR webhook done and push trunk tag for deploy"
 			executionMode = BuildStep.ExecutionMode.ALWAYS
 			conditions {

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -116,6 +116,14 @@ object BuildDockerImage : BuildType({
 			checked = "true",
 			unchecked = "false"
 		)
+		checkbox(
+			name = "EXPERIMENTAL_BUILDX",
+			value = "false",
+			label = "Run experimental buildx diagnostics.",
+			description = "Runs inline buildx diagnostics for manual/custom builds.",
+			checked = "true",
+			unchecked = "false"
+		)
 		param("env.WEBPACK_CACHE_INVALIDATED", "false")
 	}
 
@@ -220,6 +228,33 @@ object BuildDockerImage : BuildType({
 					registry.a8c.com/calypso/app:commit-${Settings.WpCalypso.paramRefs.buildVcsNumber}
 				""".trimIndent()
 			}
+		}
+
+		script {
+			name = "Experimental buildx diagnostics"
+			conditions {
+				equals("EXPERIMENTAL_BUILDX", "true")
+			}
+			scriptContent = """
+				#!/usr/bin/env bash
+				set -euo pipefail
+
+				echo "=== docker ==="
+				docker --version
+				docker version || true
+				docker info | sed -n '1,120p' || true
+
+				echo "=== buildx ==="
+				docker buildx version
+				docker buildx ls || true
+
+				echo "=== buildx inspect (default) ==="
+				docker buildx inspect --bootstrap || true
+
+				echo "=== try create a dedicated builder (docker-container driver) ==="
+				docker buildx create --name tc-builder --driver docker-container --use 2>/dev/null || docker buildx use tc-builder
+				docker buildx inspect --bootstrap
+			""".trimIndent()
 		}
 
 		script {

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -276,6 +276,7 @@ object BuildDockerImage : BuildType({
 				EOF
 
 				docker buildx build \
+				  --builder tc-builder \
 				  --progress=plain \
 				  --platform=linux/amd64 \
 				  --cache-to=type=registry,ref="${'$'}CACHE_REF",mode=max \

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -252,7 +252,12 @@ object BuildDockerImage : BuildType({
 				docker buildx inspect --bootstrap || true
 
 				echo "=== try create a dedicated builder (docker-container driver) ==="
-				docker buildx create --name tc-builder --driver docker-container --use 2>/dev/null || docker buildx use tc-builder
+				docker buildx rm tc-builder || true
+				docker buildx create \
+				  --name tc-builder \
+				  --driver docker-container \
+				  --driver-opt network=host \
+				  --use
 				docker buildx inspect --bootstrap
 			""".trimIndent()
 		}


### PR DESCRIPTION
Adds an EXPERIMENTAL_BUILDX parameter to the Web app Docker image build in TeamCity. When set to true for a custom build, it runs inline Docker/buildx diagnostics on this branch.