### PR TITLE
Fix notification tab labels untranslated in standalone widget

### DIFF
--- a/apps/notifications/src/app/note-panel/index.tsx
+++ b/apps/notifications/src/app/note-panel/index.tsx
@@ -27,12 +27,14 @@ const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
 
 const { Tabs } = unlock( privateApis );
 
-export const NOTIFICATION_TABS = Object.values( getFilters() ).map( ( { name, label } ) => ( {
-	name,
-	title: label,
-} ) );
+export const getNotificationTabs = () =>
+	Object.values( getFilters() ).map( ( { name, label } ) => ( {
+		name,
+		title: label,
+	} ) );
 
 const NotePanel = ( { isDismissible }: { isDismissible?: boolean } ) => {
+	const notificationTabs = getNotificationTabs();
 	const { params, goTo } = useNavigator();
 	const { filterName = 'all' } = params;
 	const tabRefs = useRef< Record< string, HTMLButtonElement > >( {} );
@@ -105,7 +107,7 @@ const NotePanel = ( { isDismissible }: { isDismissible?: boolean } ) => {
 								maxWidth: '100%',
 							} }
 						>
-							{ NOTIFICATION_TABS.map( ( { name, title } ) => (
+							{ notificationTabs.map( ( { name, title } ) => (
 								<Tabs.Tab
 									key={ name }
 									tabId={ name }

--- a/apps/notifications/src/app/note-panel/test/index.tsx
+++ b/apps/notifications/src/app/note-panel/test/index.tsx
@@ -2,7 +2,7 @@ import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Navigator } from '@wordpress/components';
 import { renderWithProvider } from '../../../testing-library';
-import NodePanel, { NOTIFICATION_TABS } from '../index';
+import NodePanel, { getNotificationTabs } from '../index';
 
 // Copied from https://github.com/WordPress/gutenberg/blob/adf3ef6d41df4e70f283a35f552631668131dd95/packages/components/src/tabs/test/index.tsx#L181.
 async function waitForComponentToBeInitializedWithSelectedTab(
@@ -37,9 +37,9 @@ describe( 'NotePanel', () => {
 	it( 'should render correctly', async () => {
 		const { getByText } = renderWithProvider( <NodePanel /> );
 
-		await waitForComponentToBeInitializedWithSelectedTab( NOTIFICATION_TABS[ 0 ].title );
+		await waitForComponentToBeInitializedWithSelectedTab( getNotificationTabs()[ 0 ].title );
 
-		NOTIFICATION_TABS.forEach( ( { title }: { title: string } ) => {
+		getNotificationTabs().forEach( ( { title }: { title: string } ) => {
 			expect( getByText( title ) ).toBeInTheDocument();
 		} );
 	} );
@@ -53,9 +53,9 @@ describe( 'NotePanel', () => {
 			</Navigator>
 		);
 
-		await waitForComponentToBeInitializedWithSelectedTab( NOTIFICATION_TABS[ 0 ].title );
+		await waitForComponentToBeInitializedWithSelectedTab( getNotificationTabs()[ 0 ].title );
 
-		const nextSelectedTab = NOTIFICATION_TABS[ 1 ];
+		const nextSelectedTab = getNotificationTabs()[ 1 ];
 		await userEvent.click( screen.getByRole( 'tab', { name: nextSelectedTab.title } ) );
 		await waitFor( () =>
 			expect(

--- a/apps/notifications/src/standalone/index.jsx
+++ b/apps/notifications/src/standalone/index.jsx
@@ -1,4 +1,5 @@
 import '@automattic/calypso-polyfills';
+import { setLocaleData } from '@wordpress/i18n';
 import { setLocale } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
@@ -24,8 +25,10 @@ const fetchLocale = async ( localeSlug ) => {
 			return;
 		}
 
-		// Set the locale for the i18n-calypso library
-		setLocale( await response.json() );
+		const localeData = await response.json();
+		// Sync @wordpress/i18n first — setLocale triggers re-renders that call __()
+		setLocaleData( localeData );
+		setLocale( localeData );
 	} catch {}
 };
 


### PR DESCRIPTION
Raised in p1773271723104299-slack-CRWCHQGUB

## Proposed Changes

- Sync `@wordpress/i18n` locale data via `setLocaleData()` before `setLocale()` in the standalone notifications entry point
- Move tab label evaluation from module scope into the render body so labels are computed after locale data loads
- Update test to use the new `getNotificationTabs()` helper

## Why are these changes being made?

Commit `1e5354a8bcb` changed `filters.js` from lazy `i18n-calypso` translate getters to direct `@wordpress/i18n` `__()` calls. The standalone widget (`widgets.wp.com/notifications`) only loaded locale data into `i18n-calypso` — never into `@wordpress/i18n` — so tab labels ("All", "Unread", etc.) stayed English regardless of user locale. Additionally, `NOTIFICATION_TABS` was evaluated at module scope before any locale data loaded.



## Testing Instructions

- Load `widgets.wp.com/notifications?locale=de` (or any non-English locale)
- Verify tab labels are translated (e.g. "Alle", "Ungelesen", etc. for German)
- `yarn test-apps -- apps/notifications` — all tests pass

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?