### PR TITLE
Dashboard: Re-enable OAuth for Woo dashboard hostnames

### DIFF
--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -6,6 +6,14 @@
 	"survicate_enabled": true,
 	"hostname": "my.localhost",
 	"hostname_allowlist": [ "my.localhost", "my.woo.localhost" ],
+	"hostname_overrides": {
+		"my.woo.localhost": {
+			"oauth_client_id": 134404,
+			"wpcom_login_url": false,
+			"logout_url": "http://my.woo.localhost:3000",
+			"features": { "oauth": true }
+		}
+	},
 	"i18n_default_locale_slug": "en",
 	"port": 3000,
 	"wpcom_signup_id": "39911",

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -6,6 +6,14 @@
 	"survicate_enabled": true,
 	"hostname": "my.wordpress.com",
 	"hostname_allowlist": [ "my.wordpress.com", "my.woo.ai" ],
+	"hostname_overrides": {
+		"my.woo.ai": {
+			"oauth_client_id": 134405,
+			"wpcom_login_url": false,
+			"logout_url": "https://woo.com",
+			"features": { "oauth": true }
+		}
+	},
 	"i18n_default_locale_slug": "en",
 	"wpcom_signup_id": "39911",
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -6,6 +6,14 @@
 	"survicate_enabled": true,
 	"hostname": "my.wordpress.com",
 	"hostname_allowlist": [ "my.wordpress.com", "my.woo.ai" ],
+	"hostname_overrides": {
+		"my.woo.ai": {
+			"oauth_client_id": 134405,
+			"wpcom_login_url": false,
+			"logout_url": "https://woo.com",
+			"features": { "oauth": true }
+		}
+	},
 	"i18n_default_locale_slug": "en",
 	"wpcom_signup_id": "39911",
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -6,6 +6,14 @@
 	"survicate_enabled": true,
 	"hostname": "my.wordpress.com",
 	"hostname_allowlist": [ "my.wordpress.com", "my.woo.ai" ],
+	"hostname_overrides": {
+		"my.woo.ai": {
+			"oauth_client_id": 134405,
+			"wpcom_login_url": false,
+			"logout_url": "https://woo.com",
+			"features": { "oauth": true }
+		}
+	},
 	"i18n_default_locale_slug": "en",
 	"wpcom_signup_id": "39911",
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",


### PR DESCRIPTION
Reverts #109187

## Proposed Changes

* Restore `hostname_overrides` config across all dashboard environments (development, horizon, production, stage), re-enabling OAuth-based auth for Woo dashboard hostnames.

## Why are these changes being made?

* #109187 reverted the Woo dashboard to cookie-based auth, removing the `hostname_overrides` that enabled OAuth. This PR re-enables OAuth-based auth for the Woo dashboard hostnames (`my.woo.localhost` / `my.woo.ai`). The 207270-ghe-Automattic/wpcom change fixes why the revert was necessary.

## Testing Instructions

> [!important]
> Testers will need to add the 207270-ghe-Automattic/wpcom changes to their sandbox.

> [!important]
> **It is important to use `yarn start-dashboard` specifically!**

1. You might want to use an incognito window to make sure any residual tokens are gone
1. `yarn start-dashboard`
3. Visit `http://my.woo.localhost:3000` — should redirect to `public-api.wordpress.com/oauth2/authorize` with `client_id=134404`
4. After authorizing, should redirect back to `/oauth/token`, store the token, and land on the dashboard
5. Smoke test _all the things_
6. Visit `http://my.localhost:3000` — should work as before (cookie auth)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?