### PR TITLE
Add plan card properties to PlanProduct in api-core

### DIFF
--- a/packages/api-core/src/plans/types.ts
+++ b/packages/api-core/src/plans/types.ts
@@ -3,6 +3,23 @@ export interface PlanProductFeatureHighlight {
 	items: string[];
 }
 
+export interface PlanCardFeature {
+	text: string;
+	available: boolean;
+}
+
+export interface PlanProductComparisonFeature {
+	key: string;
+	title: string;
+	tiers: string[];
+	billing_periods?: number[];
+}
+
+export interface PlanProductComparisonGroup {
+	group: string;
+	features: PlanProductComparisonFeature[];
+}
+
 export interface PlanProductDowngrade {
 	product_id: number;
 	bill_period: number;
@@ -40,7 +57,10 @@ export interface PlanProduct {
 	// Descriptive properties
 	description: string;
 	tagline: string | null;
+	plan_card_name: string | null;
 	features_highlight?: PlanProductFeatureHighlight[];
+	plan_card_features?: PlanCardFeature[];
+	features_comparison?: PlanProductComparisonGroup[];
 
 	// Downgrade options
 	downgrade_paths: PlanProductDowngrade[];


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

This PR adds some TypeScript types to the plan data returned by the plans API endpoint based on the data added in the following PRs:

- 206574-ghe-Automattic/wpcom
- 206745-ghe-Automattic/wpcom
- 206610-ghe-Automattic/wpcom
- 206753-ghe-Automattic/wpcom
- 206767-ghe-Automattic/wpcom

This data was added for https://github.com/Automattic/wp-calypso/pull/109131 but that PR isn't the only place it might eventually be used.

