### PR TITLE
A4A: Remove a4a-help-center feature flag

### DIFF
--- a/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
+++ b/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
@@ -1,6 +1,4 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Button, Gravatar } from '@automattic/components';
-import { Icon, chevronDown } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useRef, useState } from 'react';
@@ -140,14 +138,10 @@ const ProfileDropdown = ( { dropdownPosition = 'down' }: ProfileDropdownProps ) 
 	const dropdownRef = useRef( null );
 	useOutsideClickCallback( dropdownRef, onCloseMenu );
 
-	const withHelpCenter = isEnabled( 'a4a-help-center' );
-
 	return (
 		<nav
 			ref={ dropdownRef }
-			className={ clsx( 'a4a-sidebar__profile-dropdown', `is-align-menu-${ dropdownPosition }`, {
-				'with-help-center': withHelpCenter,
-			} ) }
+			className={ clsx( 'a4a-sidebar__profile-dropdown', `is-align-menu-${ dropdownPosition }` ) }
 			aria-label={
 				translate( 'User menu', {
 					comment: 'Label used to differentiate navigation landmarks in screen readers',
@@ -167,18 +161,9 @@ const ProfileDropdown = ( { dropdownPosition = 'down' }: ProfileDropdownProps ) 
 					size={ 32 }
 					alt={ translate( 'My Profile', { textOnly: true } ) }
 				/>
-
-				{ ! withHelpCenter && (
-					<div className="a4a-sidebar__profile-dropdown-button-label">
-						<span className="a4a-sidebar__profile-dropdown-button-label-text">
-							{ user?.display_name }
-						</span>
-						<Icon icon={ chevronDown } />
-					</div>
-				) }
 			</Button>
 
-			{ withHelpCenter && <SidebarHelpCenter /> }
+			<SidebarHelpCenter />
 			<DropdownMenu isExpanded={ isMenuExpanded } setMenuExpanded={ setMenuExpanded } />
 		</nav>
 	);

--- a/client/a8c-for-agencies/components/sidebar/header/style.scss
+++ b/client/a8c-for-agencies/components/sidebar/header/style.scss
@@ -19,9 +19,6 @@ $profile-dropdown-menu-height: 250px;
 
 .a4a-sidebar__profile-dropdown {
 	position: relative;
-}
-
-.a4a-sidebar__profile-dropdown.with-help-center {
 	display: flex;
 	flex-direction: row;
 	align-items: center;
@@ -44,23 +41,6 @@ $profile-dropdown-menu-height: 250px;
 	height: 100%;
 
 	cursor: pointer;
-}
-
-.a4a-sidebar__profile-dropdown-button-label {
-	display: flex;
-	flex-direction: row;
-	justify-content: center;
-	align-items: flex-start;
-	gap: 4px;
-	color: var(--color-sidebar-text);
-}
-
-.a4a-sidebar__profile-dropdown-button-label-text {
-	max-width: 160px;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	position: relative;
 }
 
 html.accessible-focus .a4a-sidebar__profile-dropdown-button:focus {
@@ -167,6 +147,3 @@ a.a4a-sidebar__external-link {
 	}
 }
 
-.a4a-sidebar__profile-dropdown-button-label svg {
-	fill: var(--color-sidebar-text);
-}

--- a/client/a8c-for-agencies/components/sidebar/index.tsx
+++ b/client/a8c-for-agencies/components/sidebar/index.tsx
@@ -1,11 +1,8 @@
-import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { useBreakpoint } from '@automattic/viewport-react';
-import { Icon, starEmpty } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect } from 'react';
-import { isClientView } from 'calypso/a8c-for-agencies/sections/purchases/payment-methods/lib/is-client-view';
+import { useEffect } from 'react';
 import JetpackIcons from 'calypso/components/jetpack/jetpack-icons';
 import Sidebar, {
 	SidebarV2Main as SidebarMain,
@@ -17,7 +14,7 @@ import Sidebar, {
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
-import A4AContactSupportWidget, { CONTACT_URL_HASH_FRAGMENT } from '../a4a-contact-support-widget';
+import { CONTACT_URL_HASH_FRAGMENT } from '../a4a-contact-support-widget';
 import ProvideFeedback from '../a4a-feedback/provide-feedback';
 import { withOnboardingTour } from '../hoc/with-onboarding-tour';
 import SidebarHeader from './header';
@@ -64,16 +61,7 @@ const A4ASidebar = ( {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const isClient = isClientView();
 	const isNarrowView = useBreakpoint( '<660px' );
-
-	const onShowUserSupportForm = useCallback( () => {
-		dispatch( recordTracksEvent( 'calypso_jetpack_sidebar_share_product_feedback_click' ) );
-	}, [ dispatch ] );
-
-	const contactUsText = isClient
-		? translate( 'Contact support' )
-		: translate( 'Contact sales & support' );
 
 	// When the sidebar is not displayed (narrow view), we need to set the layout focus to the preview.
 	// This is because, on a narrow view, we want to display the sidebar to navigate to all available pages
@@ -134,21 +122,10 @@ const A4ASidebar = ( {
 						/>
 					) }
 
-					{ ! isEnabled( 'a4a-help-center' ) && (
-						<SidebarNavigatorMenuItem
-							title={ contactUsText }
-							link={ CONTACT_URL_HASH_FRAGMENT }
-							path=""
-							icon={ <Icon icon={ starEmpty } /> }
-							onClickMenuItem={ onShowUserSupportForm }
-						/>
-					) }
-
 					{ withUserProfileFooter && <ProfileDropdown dropdownPosition="up" /> }
 				</ul>
 			</SidebarFooter>
 
-			{ ! isEnabled( 'a4a-help-center' ) && <A4AContactSupportWidget /> }
 			<ProvideFeedback />
 		</Sidebar>
 	);

--- a/client/a8c-for-agencies/hooks/use-help-center.ts
+++ b/client/a8c-for-agencies/hooks/use-help-center.ts
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { HelpCenter } from '@automattic/data-stores';
 import {
 	useDispatch as useDataStoreDispatch,
@@ -50,7 +49,7 @@ export default function useHelpCenter() {
 				window.location.hash === CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT ||
 				window.location.hash === CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT;
 
-			if ( hasSupportFormHash && isEnabled( 'a4a-help-center' ) ) {
+			if ( hasSupportFormHash ) {
 				const isMigrationRequest =
 					window.location.hash === CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT;
 

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -28,7 +28,6 @@
 	],
 	"oauth_client_id": 95928,
 	"features": {
-		"a4a-help-center": true,
 		"ad-tracking": false,
 		"a8c-for-agencies": true,
 		"a8c-for-agencies/import-site-from-wpcom": true,

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -25,7 +25,6 @@
 		}
 	],
 	"features": {
-		"a4a-help-center": true,
 		"ad-tracking": false,
 		"a8c-for-agencies": true,
 		"cookie-banner": false,

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -27,7 +27,6 @@
 	],
 	"oauth_client_id": 95932,
 	"features": {
-		"a4a-help-center": true,
 		"ad-tracking": true,
 		"a8c-for-agencies": true,
 		"cookie-banner": true,

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -27,7 +27,6 @@
 	],
 	"oauth_client_id": 95931,
 	"features": {
-		"a4a-help-center": true,
 		"ad-tracking": false,
 		"a8c-for-agencies": true,
 		"a8c-for-agencies/import-site-from-wpcom": true,


### PR DESCRIPTION
Context: pfSQfS-1sJ-p2

## Proposed Changes

This pull request removes the feature flag for the "a4a-help-center" and makes the Help Center functionality always enabled in the A8C for Agencies sidebar. It also cleans up related conditional code, removes unused styles and configuration, and simplifies the sidebar and profile dropdown components.

Key changes include:

**Help Center Feature Flag Removal:**

* Removed the `a4a-help-center` feature flag from all configuration files, making the Help Center always enabled. [[1]](diffhunk://#diff-b7fdfbca27fe9c8150a2cb73e811d96b030fad1f6072494c8291f188cef9779aL31) [[2]](diffhunk://#diff-1c75c03fadc6b49d3df97ba7dd9ba5ad3304c19beebef3584ffad47314e4ac5fL28) [[3]](diffhunk://#diff-6cae595596e0ea2cf4edffd0083ea7fb071702d10e058839990765fb49f4aa36L30) [[4]](diffhunk://#diff-75d25521c97285a60bd86cedb61e8660ece2a553e9e420e2bba8c2aee89f3cb1L30)
* Eliminated all conditional checks for `isEnabled('a4a-help-center')` in the codebase, so Help Center components are always rendered. [[1]](diffhunk://#diff-4ce8f8290c44139508c453c3672226f4aa5bb483798f2a917c489b9a9b49aa7fL143-R144) [[2]](diffhunk://#diff-4ce8f8290c44139508c453c3672226f4aa5bb483798f2a917c489b9a9b49aa7fL170-R166) [[3]](diffhunk://#diff-017ce2da9f5b5de4019e7b56d70b5b4a35258cddaf0ff22cde885f573038bfbdL137-L151) [[4]](diffhunk://#diff-180c605250d4095e7413c9fc73326babca1cf9240996fb0f7f6cab5c1db937fcL53-R52)

**Sidebar and Profile Dropdown Simplification:**

* Removed the conditional rendering and associated logic for showing the Help Center and support contact widgets, streamlining the sidebar and profile dropdown UI. [[1]](diffhunk://#diff-4ce8f8290c44139508c453c3672226f4aa5bb483798f2a917c489b9a9b49aa7fL143-R144) [[2]](diffhunk://#diff-4ce8f8290c44139508c453c3672226f4aa5bb483798f2a917c489b9a9b49aa7fL170-R166) [[3]](diffhunk://#diff-017ce2da9f5b5de4019e7b56d70b5b4a35258cddaf0ff22cde885f573038bfbdL137-L151)

**Code and Style Cleanup:**

* Deleted unused imports and removed obsolete CSS classes and styles related to the previous conditional UI for the profile dropdown. [[1]](diffhunk://#diff-4ce8f8290c44139508c453c3672226f4aa5bb483798f2a917c489b9a9b49aa7fL1-L3) [[2]](diffhunk://#diff-1abec861450e4335b56678951148ac42e81cc91b52f5e4b3ce0fee937433cdc2L22-L24) [[3]](diffhunk://#diff-1abec861450e4335b56678951148ac42e81cc91b52f5e4b3ce0fee937433cdc2L49-L65) [[4]](diffhunk://#diff-1abec861450e4335b56678951148ac42e81cc91b52f5e4b3ce0fee937433cdc2L170-L172) [[5]](diffhunk://#diff-017ce2da9f5b5de4019e7b56d70b5b4a35258cddaf0ff22cde885f573038bfbdL1-R5) [[6]](diffhunk://#diff-017ce2da9f5b5de4019e7b56d70b5b4a35258cddaf0ff22cde885f573038bfbdL20-R17) [[7]](diffhunk://#diff-017ce2da9f5b5de4019e7b56d70b5b4a35258cddaf0ff22cde885f573038bfbdL67-L77) [[8]](diffhunk://#diff-180c605250d4095e7413c9fc73326babca1cf9240996fb0f7f6cab5c1db937fcL1)

These changes ensure the Help Center is consistently available and reduce code complexity by removing feature flag checks and related UI branching.

## Why are these changes being made?

* Ensures our codebase are maintainable by removing irrelevant codes.

## Testing Instructions

* Use the A4A live link and navigate to `/overivew` page.
* Verify that there is no regression on the Help center functionality.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?