### PR TITLE
A4A: Remove dead code with hardcoded boolean variables

### DIFF
--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -206,9 +206,6 @@ const PartnerDirectoryDashboard = () => {
 		return 0;
 	}, [ isCompleted, hasDirectoryApproval, isValidFormData, applicationWasSubmitted ] );
 
-	// todo: to remove this when we the KB links are published.
-	const displayProgramLinks = true;
-
 	const programLinks = (
 		<StepSection
 			className="partner-directory-dashboard__learn-more-section"
@@ -337,7 +334,7 @@ const PartnerDirectoryDashboard = () => {
 						</Button>
 					</div>
 				</StepSection>
-				{ displayProgramLinks && programLinks }
+				{ programLinks }
 			</div>
 		);
 	}
@@ -443,7 +440,7 @@ const PartnerDirectoryDashboard = () => {
 					} }
 				/>
 			</StepSection>
-			{ displayProgramLinks && programLinks }
+			{ programLinks }
 		</>
 	);
 };

--- a/client/a8c-for-agencies/sections/purchases/billing/billing-dashboard.tsx
+++ b/client/a8c-for-agencies/sections/purchases/billing/billing-dashboard.tsx
@@ -22,8 +22,6 @@ export default function BillingDashboard() {
 
 	const title = translate( 'Billing' );
 
-	const partnerCanIssueLicense = true; // FIXME: get this from state
-
 	const onIssueNewLicenseClick = () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_billing_page_issue_license_click' ) );
 	};
@@ -35,12 +33,7 @@ export default function BillingDashboard() {
 					<Title>{ title } </Title>
 					<Actions className="a4a-billing__header-actions">
 						<MobileSidebarNavigation />
-						<Button
-							disabled={ ! partnerCanIssueLicense }
-							href={ partnerCanIssueLicense ? A4A_MARKETPLACE_LINK : undefined }
-							onClick={ onIssueNewLicenseClick }
-							primary
-						>
+						<Button href={ A4A_MARKETPLACE_LINK } onClick={ onIssueNewLicenseClick } primary>
 							{ translate( 'Issue new license' ) }
 						</Button>
 					</Actions>

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-list/empty.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-list/empty.tsx
@@ -1,4 +1,4 @@
-import { Button, Gridicon } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { A4A_MARKETPLACE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useFetchLicenseCounts from 'calypso/a8c-for-agencies/data/purchases/use-fetch-license-counts';
@@ -35,31 +35,9 @@ export default function LicenseListEmpty( { filter }: Props ) {
 		dispatch( recordTracksEvent( 'calypso_a4a_license_list_empty_issue_license_click' ) );
 	};
 
-	const showLearnMoreLink = false; // FIXME: Remove this once the correct link is added
-
 	return (
 		<div className="license-list__empty-list">
 			<h2>{ licenseFilterStatusTitle }</h2>
-
-			{ showLearnMoreLink && filter === LicenseFilter.NotRevoked && (
-				<p>
-					{ translate(
-						'Learn more about {{a}}adding licenses and billing {{icon}}{{/icon}}{{/a}}.',
-						{
-							components: {
-								a: (
-									<a
-										href="https://" // FIXME: add the correct link
-										target="_blank"
-										rel="noreferrer"
-									/>
-								),
-								icon: <Gridicon icon="external" size={ 16 } />,
-							},
-						}
-					) }
-				</p>
-			) }
 
 			{ filter === LicenseFilter.Detached && hasAssignedLicenses && (
 				<p>{ translate( 'Every license you own is currently attached to a site.' ) }</p>

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-list/empty.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-list/empty.tsx
@@ -19,8 +19,6 @@ export default function LicenseListEmpty( { filter }: Props ) {
 
 	const hasAssignedLicenses = data?.[ LicenseFilter.Attached ] > 0;
 
-	const partnerCanIssueLicense = true; // FIXME: get this from state
-
 	const licenseFilterStatusTitleMap = {
 		[ LicenseFilter.NotRevoked ]: translate( 'No active licenses' ),
 		[ LicenseFilter.Attached ]: translate( 'No assigned licenses.' ),
@@ -43,11 +41,7 @@ export default function LicenseListEmpty( { filter }: Props ) {
 				<p>{ translate( 'Every license you own is currently attached to a site.' ) }</p>
 			) }
 
-			<Button
-				disabled={ ! partnerCanIssueLicense }
-				href={ partnerCanIssueLicense ? A4A_MARKETPLACE_LINK : undefined }
-				onClick={ onIssueNewLicense }
-			>
+			<Button href={ A4A_MARKETPLACE_LINK } onClick={ onIssueNewLicense }>
 				{ translate( 'Issue new license' ) }
 			</Button>
 		</div>

--- a/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/index.tsx
@@ -54,8 +54,6 @@ export default function LicensesOverview( {
 		sortField,
 	};
 
-	const partnerCanIssueLicense = true; // FIXME: get this from state
-
 	const onIssueNewLicenseClick = () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_license_list_issue_license_click' ) );
 	};
@@ -73,12 +71,7 @@ export default function LicensesOverview( {
 						<Title>{ title } </Title>
 						<Actions className="a4a-licenses__header-actions">
 							<MobileSidebarNavigation />
-							<Button
-								disabled={ ! partnerCanIssueLicense }
-								href={ partnerCanIssueLicense ? A4A_MARKETPLACE_LINK : undefined }
-								onClick={ onIssueNewLicenseClick }
-								primary
-							>
+							<Button href={ A4A_MARKETPLACE_LINK } onClick={ onIssueNewLicenseClick } primary>
 								{ translate( 'Issue new license' ) }
 							</Button>
 						</Actions>

--- a/client/a8c-for-agencies/sections/purchases/licenses/revoke-license-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/revoke-license-dialog/index.tsx
@@ -154,28 +154,11 @@ export default function RevokeLicenseDialog( {
 			);
 		}
 
-		const showLearnMoreLink = false; // FIXME: Remove this once the correct link is added
-
 		return (
 			<>
 				<p>
 					{ translate(
 						'A revoked license cannot be reused, and the associated site will no longer have access to the provisioned product. You will stop being billed for this license immediately.'
-					) }
-					{ showLearnMoreLink && (
-						<>
-							&nbsp;
-							<a
-								className="revoke-license-dialog__learn-more"
-								href="https://" // FIXME: Add URL
-								target="_blank"
-								rel="noreferrer noopener"
-							>
-								{ translate( 'Learn more about revoking licenses' ) }
-								&nbsp;
-								<Gridicon icon="external" size={ 18 } />
-							</a>
-						</>
 					) }
 				</p>
 				<ul>


### PR DESCRIPTION
Context: pfSQfS-1sJ-p2

## Proposed Changes

This pull request primarily removes temporary feature flags and placeholder logic related to program links, license issuing, and "Learn more" links throughout the partner directory and billing UI. The changes simplify the codebase by eliminating unused variables and conditionals, ensuring that program links and license issuing buttons are always shown, and removing placeholder "Learn more" links that were not yet implemented.

Key changes include:

**Removal of temporary feature flags and placeholder logic:**
- Removed the `displayProgramLinks` flag and now always display `programLinks` in the partner directory dashboard (`index.tsx`). [[1]](diffhunk://#diff-ceb71444581e12894880fc95b14016736d25a765fe5c6c6796f20b03094d5905L209-L211) [[2]](diffhunk://#diff-ceb71444581e12894880fc95b14016736d25a765fe5c6c6796f20b03094d5905L340-R337) [[3]](diffhunk://#diff-ceb71444581e12894880fc95b14016736d25a765fe5c6c6796f20b03094d5905L446-R443)
- Removed the `partnerCanIssueLicense` flag and related conditionals; the "Issue new license" button is now always enabled and links directly to the marketplace in billing and licenses UI components (`billing-dashboard.tsx`, `license-list/empty.tsx`, `licenses-overview/index.tsx`). [[1]](diffhunk://#diff-de1013e3d0bd6cdab43953a6d899ff3b270c0441b79627d58c35c297a19583a6L25-L26) [[2]](diffhunk://#diff-de1013e3d0bd6cdab43953a6d899ff3b270c0441b79627d58c35c297a19583a6L38-R36) [[3]](diffhunk://#diff-bfd763ea2408e238621340980a21796b303c6faad2860033e688a9667a16e95cL22-L23) [[4]](diffhunk://#diff-bfd763ea2408e238621340980a21796b303c6faad2860033e688a9667a16e95cL38-R44) [[5]](diffhunk://#diff-c63e2d5c08a0d2dd0b4947cc5621244ccbd43f5e7219372e791d55208347b55cL57-L58) [[6]](diffhunk://#diff-c63e2d5c08a0d2dd0b4947cc5621244ccbd43f5e7219372e791d55208347b55cL76-R74)

**Cleanup of placeholder "Learn more" links:**
- Removed unused and placeholder "Learn more" links and associated flags from the license list empty state and revoke license dialog components (`empty.tsx`, `revoke-license-dialog/index.tsx`). [[1]](diffhunk://#diff-bfd763ea2408e238621340980a21796b303c6faad2860033e688a9667a16e95cL38-R44) [[2]](diffhunk://#diff-5afe920b27ef7a2c9e9301ae5f94987bb4efed39d4beff7bc5e2c19540ceb465L157-L179)

**Minor code cleanup:**
- Removed unused imports (e.g., `Gridicon`) from the license list empty state component (`empty.tsx`).

## Why are these changes being made?

Ensures our codebase are maintainable by removing irrelevant codes.

## Testing Instructions

* Use A4A live link and navigate to the Licenses page, Partner Directory Overview page
* Confirm no regression.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?