### PR TITLE
Fix 'Due today' price with stacked cost overrides

### DIFF
--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -157,10 +157,7 @@ function LineItemIntroOfferCostOverrideDetail( {
 			: undefined;
 	const dueAmount = tosData?.renewal_price_integer;
 	const renewAmount = tosData?.regular_renewal_price_integer;
-	const dueTodayAmount =
-		product.cost_overrides?.find(
-			( override ) => override.override_code === costOverride.overrideCode
-		)?.new_subtotal_integer ?? product.item_subtotal_integer;
+	const dueTodayAmount = product.item_subtotal_integer;
 	if ( ! dueDate || ! dueAmount || ! renewAmount ) {
 		return null;
 	}


### PR DESCRIPTION
Closes DOMENG-486

## Proposed Changes

* Use `product.item_subtotal_integer` for the "Due today" amount instead of looking up the introductory offer cost override's `new_subtotal_integer`.

## Why are these changes being made?

When a premium domain with High/Low pricing has both an introductory offer and a sale coupon applied, the "Due today" label in checkout shows the wrong price.

This happens because the code in `LineItemIntroOfferCostOverrideDetail` uses `.find()` on `cost_overrides` to locate the introductory offer override and displays its `new_subtotal_integer` as the "Due today" amount. This worked when the intro offer was the only override, but breaks when a sale coupon is stacked on top:

1. `introductory-offer`: $80 → $1,100 (High/Low price increase)
2. `sale-coupon-discount-1`: $1,100 → $275 (75% sale discount)

The `.find()` matches the first override and shows $1,100, ignoring the subsequent sale coupon that reduces the price to $275.

The fix replaces the override lookup with `product.item_subtotal_integer`, which already reflects the final price after **all** cost overrides have been applied. This is safe for existing cases because when there is only a single intro offer override, `item_subtotal_integer` equals that override's `new_subtotal_integer`.

**Note:** There is a separate, pre-existing issue where the price shown next to the domain name (US$80) doesn't match the actual amount being charged (US$275). This will be addressed in a follow-up PR.

|![Screenshot 2026-03-20 at 17 01 10](https://github.com/user-attachments/assets/16760def-3a12-403a-8046-745358d5a66e)|![Screenshot 2026-03-20 at 17 01 04](https://github.com/user-attachments/assets/5936c6ba-4024-4929-97cb-f584474c2f07)|
|:--:|:--:|
|BEFORE|AFTER|

## Testing Instructions

1. Add a premium domain with High/Low pricing to the cart (e.g., a `.art` domain).
2. Apply a sale coupon that discounts the domain.
3. Verify the "Due today" label in the order summary shows the final discounted price (after all overrides), not the intermediate introductory offer price.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)