### PR TITLE
CIAB MSD: drop /ciab base path by using different live link container name

### DIFF
--- a/.github/workflows/calypso-live.yml
+++ b/.github/workflows/calypso-live.yml
@@ -48,7 +48,6 @@ jobs:
             }
 
             const link = `https://calypso.live?${{steps.build_link.outputs.QUERY}}`;
-            const ciabLink = `https://calypso.live/ciab?${{steps.build_link.outputs.QUERY}}`;
 
             const body = trimIndent(`
               <!--calypso-live-watermark:apr@v1-->
@@ -102,12 +101,12 @@ jobs:
               </details>
               <details>
                 <summary>
-                  Dashboard Live (CIAB) <a href="${ciabLink}&env=dashboard">(direct link)</a>
+                  Dashboard Live (CIAB) <a href="${link}&env=dashboard">(direct link)</a>
                 </summary>
                 <table>
                   <tr>
                     <td>
-                      <a href="${ciabLink}&env=dashboard">${ciabLink}&env=dashboard</a>
+                      <a href="${link}&env=dashboard-ciab">${link}&env=dashboard-ciab</a>
                     </td>
                   </tr>
                 </table>

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -41,12 +41,12 @@ object BuildDockerImage : BuildType({
 
     data class EnvConfig(
         val label: String,
-        val baseUrl: String = "https://calypso.live",
         val envQuery: String, // e.g. "" or "&env=jetpack"
         val qrEnv: String,    // e.g. "flags=oauth" or "env=jetpack&flags=oauth"
     )
 
     val imageBase = "registry.a8c.com/calypso/app"
+	val baseUrl = "https://calypso.live"
 
     val environments = listOf(
         EnvConfig(
@@ -71,9 +71,8 @@ object BuildDockerImage : BuildType({
 		),
 		EnvConfig(
 			label = "Dashboard Live (CIAB)",
-			baseUrl = "https://calypso.live/ciab",
-			envQuery = "&env=dashboard",
-			qrEnv = "env=dashboard&flags=oauth",
+			envQuery = "&env=dashboard-ciab",
+			qrEnv = "env=dashboard-ciab&flags=oauth",
 		)
     )
 
@@ -82,11 +81,11 @@ object BuildDockerImage : BuildType({
             appendLine(
                 """
                 <details>
-                  <summary>${env.label} <a href="${env.baseUrl}?image=$imageBase:build-%build.number%${env.envQuery}">(direct link)</a></summary>
+                  <summary>${env.label} <a href="${baseUrl}?image=$imageBase:build-%build.number%${env.envQuery}">(direct link)</a></summary>
                   <table>
                     <tr>
                       <td>
-                        <a href="${env.baseUrl}?image=$imageBase:build-%build.number%${env.envQuery}">${env.baseUrl}?image=$imageBase:build-%build.number%${env.envQuery}</a>
+                        <a href="${baseUrl}?image=$imageBase:build-%build.number%${env.envQuery}">${baseUrl}?image=$imageBase:build-%build.number%${env.envQuery}</a>
                       </td>
                     </tr>
                   </table>

--- a/client/dashboard/app-ciab/index.tsx
+++ b/client/dashboard/app-ciab/index.tsx
@@ -8,7 +8,6 @@ import {
 /* eslint-enable no-restricted-imports */
 import config from '@automattic/calypso-config';
 import boot from '../app/boot';
-import { getCiabDashboardBasePath } from './routing';
 import './translations';
 import type {
 	FetchSitesOptions,
@@ -20,7 +19,7 @@ import './style.scss';
 boot( {
 	name: 'CIAB',
 	posthog: config.isEnabled( 'posthog-tracking' ) ? config( 'ciab_posthog_api_key' ) : undefined,
-	basePath: getCiabDashboardBasePath( window.location.hostname ),
+	basePath: '/',
 	mainRoute: '/sites',
 	Logo: null,
 	supports: {

--- a/client/dashboard/app-ciab/routing.ts
+++ b/client/dashboard/app-ciab/routing.ts
@@ -3,11 +3,12 @@ import config from '@automattic/calypso-config';
 const CIAB_DASHBOARD_ALLOWED_HOSTNAMES = [ 'my.woo.localhost', 'my.woo.ai' ];
 
 export function isAllowedCiabDashboardHostname( hostname?: string ): boolean {
-	return CIAB_DASHBOARD_ALLOWED_HOSTNAMES.includes( hostname ?? '' );
-}
+	// Calypso Live links
+	if ( hostname?.endsWith( '-ciab.calypso.live' ) ) {
+		return true;
+	}
 
-export function getCiabDashboardBasePath( hostname: string ): string {
-	return isAllowedCiabDashboardHostname( hostname ) ? '/' : '/ciab';
+	return CIAB_DASHBOARD_ALLOWED_HOSTNAMES.includes( hostname ?? '' );
 }
 
 export function buildCiabDashboardLink( path: string = '' ) {

--- a/client/dashboard/app-dotcom/routing.ts
+++ b/client/dashboard/app-dotcom/routing.ts
@@ -5,7 +5,7 @@ const DOTCOM_DASHBOARD_ALLOWED_HOSTNAMES = [ 'my.localhost', 'my.wordpress.com' 
 export function isAllowedDotcomDashboardHostname( hostname?: string ): boolean {
 	// Calypso Live links
 	if ( hostname?.endsWith( '.calypso.live' ) ) {
-		return true;
+		return ! hostname?.endsWith( '-ciab.calypso.live' );
 	}
 
 	return DOTCOM_DASHBOARD_ALLOWED_HOSTNAMES.includes( hostname ?? '' );

--- a/client/dashboard/app/routing.ts
+++ b/client/dashboard/app/routing.ts
@@ -1,9 +1,5 @@
-import {
-	buildCiabDashboardLink,
-	getCiabDashboardBasePath,
-	isAllowedCiabDashboardHostname,
-} from '../app-ciab/routing';
-import { buildDotcomDashboardLink, isAllowedDotcomDashboardHostname } from '../app-dotcom/routing';
+import { buildCiabDashboardLink, isAllowedCiabDashboardHostname } from '../app-ciab/routing';
+import { buildDotcomDashboardLink } from '../app-dotcom/routing';
 import type { DashboardType } from './types';
 
 /**
@@ -11,15 +7,7 @@ import type { DashboardType } from './types';
  * Used in dashboard environments.
  */
 export function getCurrentDashboard(): DashboardType {
-	const hostname = window.location.hostname;
-	const pathname = window.location.pathname;
-
-	if ( isAllowedDotcomDashboardHostname( hostname ) ) {
-		if ( pathname.startsWith( getCiabDashboardBasePath( hostname ) ) ) {
-			return 'ciab';
-		}
-	}
-	if ( isAllowedCiabDashboardHostname( hostname ) ) {
+	if ( isAllowedCiabDashboardHostname( window.location.hostname ) ) {
 		return 'ciab';
 	}
 	return 'dotcom';

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -1118,9 +1118,6 @@ export default function pages() {
 				isAllowedCiabDashboardHostname( req.hostname )
 			);
 		} );
-		handleRoute( CIAB_DASHBOARD_SECTION_DEFINITION, '/ciab', 'entry-dashboard-ciab', ( req ) => {
-			return isAllowedDotcomDashboardHostname( req.hostname );
-		} );
 	}
 
 	sections


### PR DESCRIPTION
Context: pet6gk-2KG-p2#comment-2010

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

To distinguish between dotcom-MSD and CIAB-MSD, for Dashboard Live links (`container-*.calypso.live`), we prepend the path with a `/ciab` prefix. For example:

- `container-*.calypso.live/sites` => dotcom site list
- `container-*.calypso.live/ciab/sites` => CIAB site list

With this PR, we will disambiguate by container name (hostname) instead, by appending `-ciab` suffix as follows (via https://github.com/Automattic/dserve/pull/231):

- `container-*.calypso.live/sites` => dotcom site list
- `container-*-ciab.calypso.live/sites` => CIAB site list

## Why are these changes being made?

We want to serve non-dashboard screens in the dashboard origin (domain). The existing `/ciab` path prefix makes this hard to do.

## Testing Instructions

1. Click the `Dashboard Live (dotcom)` link; verify you land in dotcom site list.
1. Click the `Dashboard Live (CIAB)` link; verify you land in CIAB site list.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?