### PR TITLE
Help Center: Document API endpoints in AGENTS.md

### DIFF
--- a/packages/help-center/AGENTS.md
+++ b/packages/help-center/AGENTS.md
@@ -86,8 +86,51 @@ This "always include both" rule exists because nearly everything in `packages/he
 
 - **i18n**: Use `@wordpress/i18n` for all user-facing strings. New strings won't be translated on Atomic until the next `jetpack-mu-plugin` release (twice daily).
 - **Components**: Prefer `@wordpress/components` over custom UI primitives.
-- **Data fetching**: Use TanStack Query hooks in `src/data/`. Follow existing patterns.
+- **Data fetching**: Use TanStack Query hooks in `src/data/`. Follow existing patterns. See the API Endpoints section below for full details.
 - **Styling**: SCSS. Global styles in `src/styles.scss`.
+
+## API Endpoints
+
+### Dual-endpoint pattern
+
+Data-fetching hooks use a dual-endpoint pattern controlled by `canAccessWpcomApis()`:
+
+- **Calypso / Simple sites**: `canAccessWpcomApis()` returns `true` → calls go through `wpcomRequest` to the WPcom REST API.
+- **Atomic sites**: `canAccessWpcomApis()` returns `false` → calls fall back to `apiFetch`, which hits WordPress REST API endpoints on the site itself (prefixed with `/help-center/`). These endpoints are registered by `jetpack-mu-plugin`.
+
+### WPcom REST API endpoints (used in Calypso / Simple)
+
+| Endpoint | Method | Hook | Description |
+|----------|--------|------|-------------|
+| `/wpcom/v2/help/ticket/new` | POST | `use-submit-support-ticket` | Submit a support ticket |
+| `/wpcom/v2/support-activity` | GET | `use-support-activity` | Fetch active support tickets (New, Open, Hold) |
+| `/wpcom/v2/help/support-status` | GET | `use-support-status` | Support eligibility, availability, tier |
+| `/rest/v1.2/me/sites/?include_domain_only=true` | GET | `use-user-sites` | List user sites |
+| `/rest/v1.1/sites/{siteId}?force=wpcom` | GET | `use-wpcom-site` | Single site details |
+| `/wpcom/v2/imports/analyze-url` | GET | `use-is-wporg-site` | Detect WP.org vs WP.com site |
+| `/wpcom/v2/sites/{siteId}/jetpack-search/ai/search` | GET | `use-jetpack-search-ai` | AI-powered help article search |
+| `/wpcom/v2/help/search` | GET | `use-help-search-query` | Search help articles |
+| `/wpcom/v2/agency/help/zendesk/create-ticket` | POST | `use-submit-a4a-support-ticket` | A4A agency ticket |
+| `/wpcom/v2/agency/help/pressable/support` | POST | `use-submit-a4a-support-ticket` | Pressable agency support |
+
+### apiFetch fallback endpoints (used on Atomic sites)
+
+When `canAccessWpcomApis()` is `false` (Atomic sites), these hooks fall back to `apiFetch` with the following paths:
+
+| Fallback path | Corresponding WPcom endpoint |
+|---------------|------------------------------|
+| `/help-center/ticket/new` | `/wpcom/v2/help/ticket/new` |
+| `/help-center/support-activity` | `/wpcom/v2/support-activity` |
+| `/help-center/support-status` | `/wpcom/v2/help/support-status` |
+| `/help-center/jetpack-search/ai/search` | `/wpcom/v2/sites/{siteId}/jetpack-search/ai/search` |
+| `/help-center/search` | `/wpcom/v2/help/search` |
+
+### External service integrations
+
+| Service | Package | Purpose |
+|---------|---------|---------|
+| Zendesk Smooch | `@automattic/zendesk-client` | Live chat messaging (init, auth, conversations) |
+| Odie AI Chat | `@automattic/odie-client` | AI-powered chat support, conversations, unread counts |
 
 ## Common Pitfalls
 
@@ -95,3 +138,4 @@ This "always include both" rule exists because nearly everything in `packages/he
 - **Multiple entry points**: `apps/help-center/` has 8 webpack entry points for different contexts (Gutenberg, wp-admin, disconnected, etc.). A change may behave differently across entry points.
 - **asset.json sync limitation**: If you add or remove `@wordpress/*` dependencies, the `.asset.json` files won't sync to the sandbox because Jetpack fetches them from production. You must deploy for dependency changes to take effect on Atomic.
 - **Disconnected variants**: Some entry points have "disconnected" versions (e.g., `help-center-gutenberg-disconnected.js`) that show a minimal UI. Make sure changes don't break these variants.
+- **API changes require backend work**: The API endpoints listed above are not defined in this repo. The frontend only sends search queries and renders whatever the API returns — it does not control which articles are returned. If a change requires different results (e.g., showing different articles on a specific page), the API backend must be updated: the WPcom REST API for Calypso/Simple, and `jetpack-mu-plugin` (which registers the `/help-center/*` fallback routes) for Atomic. Always flag this when proposing changes that affect API behavior.

--- a/packages/help-center/AGENTS.md
+++ b/packages/help-center/AGENTS.md
@@ -11,6 +11,15 @@
 
 Most code lives here in `packages/help-center/`. The `apps/help-center/` app handles building and deploying the webpack bundles that serve Simple sites, Atomic sites, and CIAB.
 
+## Backend
+
+The Help Center backend lives in `jetpack-mu-plugin` (outside this repo). It is responsible for:
+
+1. **Loading the Help Center** in wp-admin, the block editor, CIAB, `/support`, and `/forums` — it enqueues the webpack bundles built by `apps/help-center/` from `widgets.wp.com`.
+2. **Registering the `/help-center/*` REST API endpoints** used on Atomic sites when `canAccessWpcomApis()` returns `false`. These proxy requests to the WPcom REST API so the same frontend code works in both contexts.
+
+Any change that requires new API endpoints, different API behavior, or loading the Help Center in a new context requires work in `jetpack-mu-plugin`, not in this repo.
+
 ## Architecture
 
 ### State Management
@@ -70,10 +79,12 @@ See `apps/help-center/AGENTS.md` for more details on the build/sync layer.
 ## Testing Instructions
 
 ### Calypso
+
 1. Run `yarn start`.
 2. Open the Help Center and verify [describe expected behavior].
 
 ### Simple/Atomic/CIAB
+
 1. Sandbox `widgets.wp.com`.
 2. Run `cd apps/help-center && yarn dev --sync`.
 3. Visit any Simple, Atomic, or CIAB site (the site itself does not need sandboxing).
@@ -100,37 +111,37 @@ Data-fetching hooks use a dual-endpoint pattern controlled by `canAccessWpcomApi
 
 ### WPcom REST API endpoints (used in Calypso / Simple)
 
-| Endpoint | Method | Hook | Description |
-|----------|--------|------|-------------|
-| `/wpcom/v2/help/ticket/new` | POST | `use-submit-support-ticket` | Submit a support ticket |
-| `/wpcom/v2/support-activity` | GET | `use-support-activity` | Fetch active support tickets (New, Open, Hold) |
-| `/wpcom/v2/help/support-status` | GET | `use-support-status` | Support eligibility, availability, tier |
-| `/rest/v1.2/me/sites/?include_domain_only=true` | GET | `use-user-sites` | List user sites |
-| `/rest/v1.1/sites/{siteId}?force=wpcom` | GET | `use-wpcom-site` | Single site details |
-| `/wpcom/v2/imports/analyze-url` | GET | `use-is-wporg-site` | Detect WP.org vs WP.com site |
-| `/wpcom/v2/sites/{siteId}/jetpack-search/ai/search` | GET | `use-jetpack-search-ai` | AI-powered help article search |
-| `/wpcom/v2/help/search` | GET | `use-help-search-query` | Search help articles |
-| `/wpcom/v2/agency/help/zendesk/create-ticket` | POST | `use-submit-a4a-support-ticket` | A4A agency ticket |
-| `/wpcom/v2/agency/help/pressable/support` | POST | `use-submit-a4a-support-ticket` | Pressable agency support |
+| Endpoint                                            | Method | Hook                            | Description                                    |
+| --------------------------------------------------- | ------ | ------------------------------- | ---------------------------------------------- |
+| `/wpcom/v2/help/ticket/new`                         | POST   | `use-submit-support-ticket`     | Submit a support ticket                        |
+| `/wpcom/v2/support-activity`                        | GET    | `use-support-activity`          | Fetch active support tickets (New, Open, Hold) |
+| `/wpcom/v2/help/support-status`                     | GET    | `use-support-status`            | Support eligibility, availability, tier        |
+| `/rest/v1.2/me/sites/?include_domain_only=true`     | GET    | `use-user-sites`                | List user sites                                |
+| `/rest/v1.1/sites/{siteId}?force=wpcom`             | GET    | `use-wpcom-site`                | Single site details                            |
+| `/wpcom/v2/imports/analyze-url`                     | GET    | `use-is-wporg-site`             | Detect WP.org vs WP.com site                   |
+| `/wpcom/v2/sites/{siteId}/jetpack-search/ai/search` | GET    | `use-jetpack-search-ai`         | AI-powered help article search                 |
+| `/wpcom/v2/help/search`                             | GET    | `use-help-search-query`         | Search help articles                           |
+| `/wpcom/v2/agency/help/zendesk/create-ticket`       | POST   | `use-submit-a4a-support-ticket` | A4A agency ticket                              |
+| `/wpcom/v2/agency/help/pressable/support`           | POST   | `use-submit-a4a-support-ticket` | Pressable agency support                       |
 
 ### apiFetch fallback endpoints (used on Atomic sites)
 
 When `canAccessWpcomApis()` is `false` (Atomic sites), these hooks fall back to `apiFetch` with the following paths:
 
-| Fallback path | Corresponding WPcom endpoint |
-|---------------|------------------------------|
-| `/help-center/ticket/new` | `/wpcom/v2/help/ticket/new` |
-| `/help-center/support-activity` | `/wpcom/v2/support-activity` |
-| `/help-center/support-status` | `/wpcom/v2/help/support-status` |
+| Fallback path                           | Corresponding WPcom endpoint                        |
+| --------------------------------------- | --------------------------------------------------- |
+| `/help-center/ticket/new`               | `/wpcom/v2/help/ticket/new`                         |
+| `/help-center/support-activity`         | `/wpcom/v2/support-activity`                        |
+| `/help-center/support-status`           | `/wpcom/v2/help/support-status`                     |
 | `/help-center/jetpack-search/ai/search` | `/wpcom/v2/sites/{siteId}/jetpack-search/ai/search` |
-| `/help-center/search` | `/wpcom/v2/help/search` |
+| `/help-center/search`                   | `/wpcom/v2/help/search`                             |
 
 ### External service integrations
 
-| Service | Package | Purpose |
-|---------|---------|---------|
-| Zendesk Smooch | `@automattic/zendesk-client` | Live chat messaging (init, auth, conversations) |
-| Odie AI Chat | `@automattic/odie-client` | AI-powered chat support, conversations, unread counts |
+| Service        | Package                      | Purpose                                               |
+| -------------- | ---------------------------- | ----------------------------------------------------- |
+| Zendesk Smooch | `@automattic/zendesk-client` | Live chat messaging (init, auth, conversations)       |
+| Odie AI Chat   | `@automattic/odie-client`    | AI-powered chat support, conversations, unread counts |
 
 ## Common Pitfalls
 
@@ -138,4 +149,4 @@ When `canAccessWpcomApis()` is `false` (Atomic sites), these hooks fall back to 
 - **Multiple entry points**: `apps/help-center/` has 8 webpack entry points for different contexts (Gutenberg, wp-admin, disconnected, etc.). A change may behave differently across entry points.
 - **asset.json sync limitation**: If you add or remove `@wordpress/*` dependencies, the `.asset.json` files won't sync to the sandbox because Jetpack fetches them from production. You must deploy for dependency changes to take effect on Atomic.
 - **Disconnected variants**: Some entry points have "disconnected" versions (e.g., `help-center-gutenberg-disconnected.js`) that show a minimal UI. Make sure changes don't break these variants.
-- **API changes require backend work**: The API endpoints listed above are not defined in this repo. The frontend only sends search queries and renders whatever the API returns — it does not control which articles are returned. If a change requires different results (e.g., showing different articles on a specific page), the API backend must be updated: the WPcom REST API for Calypso/Simple, and `jetpack-mu-plugin` (which registers the `/help-center/*` fallback routes) for Atomic. Always flag this when proposing changes that affect API behavior.
+- **API changes require backend work**: The API endpoints listed above are not defined in this repo. The frontend only sends search queries and renders whatever the API returns. If a change requires new endpoints or different API behavior, see the Backend section above.


### PR DESCRIPTION
## Summary
- Documents all API endpoints the Help Center calls, including the dual-endpoint pattern (WPcom REST API vs `apiFetch` fallback for Atomic sites)
- Adds a pitfall note clarifying that the frontend does not control which articles are returned — API backend changes are needed for that (WPcom REST API + `jetpack-mu-plugin`)

## Test plan
- [ ] Review `packages/help-center/AGENTS.md` for accuracy
- [ ] Verify the documented endpoints match the actual hooks in `src/data/` and `src/hooks/`
