### PR TITLE
A4A: Sort Pressable products correctly.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/lib/product-filter.ts
+++ b/client/a8c-for-agencies/sections/marketplace/lib/product-filter.ts
@@ -320,9 +320,9 @@ export function filterProductsAndPlansByType(
 
 		case PRODUCT_TYPE_PRESSABLE_ADDON:
 			return (
-				allProductsAndPlans?.filter( ( { family_slug } ) =>
-					isPressableAddonProduct( family_slug )
-				) || []
+				allProductsAndPlans
+					?.filter( ( { family_slug } ) => isPressableAddonProduct( family_slug ) )
+					.sort( ( a, b ) => a.name.localeCompare( b.name, undefined, { numeric: true } ) ) || []
 			);
 
 		case PRODUCT_TYPE_WOO_EXTENSION:

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-product-and-plans-with-pressable-visibility.ts
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-product-and-plans-with-pressable-visibility.ts
@@ -15,7 +15,7 @@ export default function useProductAndPlansWithPressableVisibility(
 		}
 
 		const pressableAddonProductIds = new Set(
-			products.pressableAddons.map( ( product ) => product.product_id ).sort()
+			products.pressableAddons.map( ( product ) => product.product_id )
 		);
 
 		return {

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-product-and-plans-with-pressable-visibility.ts
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-product-and-plans-with-pressable-visibility.ts
@@ -15,7 +15,7 @@ export default function useProductAndPlansWithPressableVisibility(
 		}
 
 		const pressableAddonProductIds = new Set(
-			products.pressableAddons.map( ( product ) => product.product_id )
+			products.pressableAddons.map( ( product ) => product.product_id ).sort()
 		);
 
 		return {


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/A4A-2223/support-extra-pressable-storage-via-add-on-combinations

## Proposed Changes

* Ensure that the Pressable addons are sorted correctly in the Marketplace.

<img width="1582" height="939" alt="Screenshot 2026-03-12 at 9 12 22 PM" src="https://github.com/user-attachments/assets/a794da55-6b55-4c50-842f-b353e328b471" />


## Why are these changes being made?

* The Pressable addons are not properly sorted making it hard to explore the products.

## Testing Instructions

* Apply this 207358-ghe-Automattic/wpcom
* Use the A4A live link and navigate to the `/marketplace/products` page. Make sure you are using the Agency account that is on the BD system.
* Click the Pressable filter.
* Confirm that the products are sorted properly. See screenshot above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?