### PR TITLE
Enable ciab/custom-branding feature flag across all environments

### DIFF
--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -14,7 +14,7 @@
 	"features": {
 		"catch-js-errors": true,
 		"ciab/allow-domain-features": true,
-		"ciab/custom-branding": false,
+		"ciab/custom-branding": true,
 		"cookie-banner": false,
 		"rum-tracking/logstash": true,
 		"dashboard/v2": false,

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -15,7 +15,7 @@
 		"catch-js-errors": true,
 		"posthog-tracking": true,
 		"ciab/allow-domain-features": true,
-		"ciab/custom-branding": false,
+		"ciab/custom-branding": true,
 		"cookie-banner": true,
 		"bilmur-script": true,
 		"rum-tracking/logstash": true,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -14,7 +14,7 @@
 	"features": {
 		"catch-js-errors": true,
 		"ciab/allow-domain-features": true,
-		"ciab/custom-branding": false,
+		"ciab/custom-branding": true,
 		"cookie-banner": false,
 		"rum-tracking/logstash": true,
 		"dashboard/v2": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -19,7 +19,7 @@
 		"catch-js-errors": true,
 		"checkout/checkout-version": false,
 		"ciab/allow-domain-features": true,
-		"ciab/custom-branding": false,
+		"ciab/custom-branding": true,
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/razorpay": true,

--- a/config/production.json
+++ b/config/production.json
@@ -32,7 +32,7 @@
 		"posthog-tracking": true,
 		"checkout/checkout-version": false,
 		"ciab/allow-domain-features": true,
-		"ciab/custom-branding": false,
+		"ciab/custom-branding": true,
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/razorpay": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -32,7 +32,7 @@
 		"checkout/checkout-version": true,
 		"help-center/logged-out": true,
 		"ciab/allow-domain-features": true,
-		"ciab/custom-branding": false,
+		"ciab/custom-branding": true,
 		"checkout/razorpay": true,
 		"checkout/stripe-upi": true,
 		"current-site/domain-warning": false,


### PR DESCRIPTION
## Proposed Changes

* Enable the `ciab/custom-branding` feature flag in all config environments where it was previously disabled: `production`, `wpcalypso`, `horizon`, `dashboard-production`, `dashboard-stage`, and `dashboard-horizon`.

## Why are these changes being made?

* The `ciab/custom-branding` flag was only enabled in `development` and `stage` configs. This change enables it across all remaining environments to roll out custom branding support for CIAB partners.

## Testing Instructions

* Verify the feature flag is enabled by checking `config.isEnabled( 'ciab/custom-branding' )` returns `true` in all environments.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?