### PR TITLE
Partner Branding: make featureFlag optional so partners without one are always active

### DIFF
--- a/client/lib/partner-branding.tsx
+++ b/client/lib/partner-branding.tsx
@@ -34,8 +34,8 @@ export interface CiabPartnerConfig {
 	id: string;
 	/** Display name shown in UI (e.g., "Woo") */
 	displayName: string;
-	/** Feature flag to enable/disable this partner */
-	featureFlag: string;
+	/** Feature flag to enable/disable this partner. If omitted, the partner is always active. */
+	featureFlag?: string;
 	/** Logo configuration */
 	logo: LogoConfig;
 	/** Compact logo for TopBar (falls back to logo if not provided) */
@@ -82,6 +82,10 @@ export const CIAB_PARTNERS: Record< string, CiabPartnerConfig > = {
 		isOAuth2Client: isCiabOAuth2Client,
 	},
 };
+
+function isPartnerEnabled( partnerConfig: CiabPartnerConfig ): boolean {
+	return ! partnerConfig.featureFlag || config.isEnabled( partnerConfig.featureFlag );
+}
 
 const CIAB_PARTNER_SESSION_KEY = 'calypso.ciab.partner-id';
 
@@ -173,7 +177,7 @@ export function getCiabConfigFromGarden(
 function getCiabConfigByHostname( hostname: string ): CiabPartnerConfig | null {
 	for ( const partnerConfig of Object.values( CIAB_PARTNERS ) ) {
 		if ( partnerConfig.domains?.includes( hostname ) ) {
-			if ( config.isEnabled( partnerConfig.featureFlag ) ) {
+			if ( isPartnerEnabled( partnerConfig ) ) {
 				return partnerConfig;
 			}
 		}
@@ -208,7 +212,7 @@ export function getCiabConfigFromBrandingCode(): CiabPartnerConfig | null {
 
 	if ( from && CIAB_PARTNERS[ from ] ) {
 		const partnerConfig = CIAB_PARTNERS[ from ];
-		if ( config.isEnabled( partnerConfig.featureFlag ) ) {
+		if ( isPartnerEnabled( partnerConfig ) ) {
 			return partnerConfig;
 		}
 	}
@@ -249,7 +253,7 @@ export function getCiabConfigFromOAuth2Client(
 
 	for ( const partnerConfig of Object.values( CIAB_PARTNERS ) ) {
 		if ( partnerConfig.isOAuth2Client?.( oauth2Client ) ) {
-			if ( config.isEnabled( partnerConfig.featureFlag ) ) {
+			if ( isPartnerEnabled( partnerConfig ) ) {
 				return partnerConfig;
 			}
 		}
@@ -300,7 +304,7 @@ export function detectCiabConfig( oauth2Client?: { id: number } | null ): CiabPa
 	if ( persistedPartnerId ) {
 		const persistedConfig = CIAB_PARTNERS[ persistedPartnerId ];
 
-		if ( persistedConfig && config.isEnabled( persistedConfig.featureFlag ) ) {
+		if ( persistedConfig && isPartnerEnabled( persistedConfig ) ) {
 			return persistedConfig;
 		}
 

--- a/client/lib/test/partner-branding.tsx
+++ b/client/lib/test/partner-branding.tsx
@@ -17,6 +17,7 @@ import {
 	clearPersistedCiabPartnerId,
 	CIAB_PARTNERS,
 } from '../partner-branding';
+import type { CiabPartnerConfig } from '../partner-branding';
 import type { useTranslate } from 'i18n-calypso';
 
 // Mock the config module
@@ -396,20 +397,20 @@ describe( 'partner-branding', () => {
 	} );
 
 	describe( 'partner without featureFlag is always active', () => {
-		const testPartner = {
+		const testPartner: CiabPartnerConfig = {
 			id: 'test-no-flag',
 			displayName: 'Test',
 			logo: { src: 'test.svg', alt: 'Test' },
-			ssoProviders: [ 'google' ] as const,
+			ssoProviders: [ 'google' ],
 			domains: [ 'test.example.com' ],
 		};
 
 		beforeEach( () => {
-			( CIAB_PARTNERS as Record< string, typeof testPartner > )[ 'test-no-flag' ] = testPartner;
+			( CIAB_PARTNERS as Record< string, CiabPartnerConfig > )[ 'test-no-flag' ] = testPartner;
 		} );
 
 		afterEach( () => {
-			delete ( CIAB_PARTNERS as Record< string, unknown > )[ 'test-no-flag' ];
+			delete ( CIAB_PARTNERS as Record< string, CiabPartnerConfig > )[ 'test-no-flag' ];
 		} );
 
 		test( 'getCiabConfigFromCurrentDomain returns partner even when all feature flags are disabled', () => {

--- a/client/lib/test/partner-branding.tsx
+++ b/client/lib/test/partner-branding.tsx
@@ -395,6 +395,44 @@ describe( 'partner-branding', () => {
 		} );
 	} );
 
+	describe( 'partner without featureFlag is always active', () => {
+		const testPartner = {
+			id: 'test-no-flag',
+			displayName: 'Test',
+			logo: { src: 'test.svg', alt: 'Test' },
+			ssoProviders: [ 'google' ] as const,
+			domains: [ 'test.example.com' ],
+		};
+
+		beforeEach( () => {
+			( CIAB_PARTNERS as Record< string, typeof testPartner > )[ 'test-no-flag' ] = testPartner;
+		} );
+
+		afterEach( () => {
+			delete ( CIAB_PARTNERS as Record< string, unknown > )[ 'test-no-flag' ];
+		} );
+
+		test( 'getCiabConfigFromCurrentDomain returns partner even when all feature flags are disabled', () => {
+			( config.isEnabled as jest.Mock ).mockReturnValue( false );
+			setLocation( 'test.example.com' );
+
+			const result = getCiabConfigFromCurrentDomain();
+
+			expect( result ).not.toBeNull();
+			expect( result?.id ).toBe( 'test-no-flag' );
+		} );
+
+		test( 'getCiabConfigFromBrandingCode returns partner even when all feature flags are disabled', () => {
+			( config.isEnabled as jest.Mock ).mockReturnValue( false );
+			setLocation( 'wordpress.com', '?from=test-no-flag' );
+
+			const result = getCiabConfigFromBrandingCode();
+
+			expect( result ).not.toBeNull();
+			expect( result?.id ).toBe( 'test-no-flag' );
+		} );
+	} );
+
 	describe( 'CIAB_PARTNERS', () => {
 		test( 'woo partner has required configuration', () => {
 			const wooConfig = CIAB_PARTNERS.woo;


### PR DESCRIPTION
## Proposed Changes

* Made `featureFlag` optional in `CiabPartnerConfig` interface.
* Added `isPartnerEnabled()` helper that treats a missing `featureFlag` as always active.
* Updated all 4 feature-flag check sites to use the new helper.
* Added tests to verify partners without a `featureFlag` are detected even when all flags are disabled.

## Why are these changes being made?

When adding a new CIAB partner that doesn't need a feature flag gate, the current code requires a `featureFlag` to be set. This change makes `featureFlag` optional so that partners without one are considered always active, simplifying partner onboarding.

## Testing Instructions

* Run `yarn test-client client/lib/test/partner-branding.tsx` and verify all 44 tests pass, including the 2 new ones under "partner without featureFlag is always active".

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?