### PR TITLE
Agents Manager: Add `can_access_zendesk` context value

### DIFF
--- a/packages/agents-manager/src/components/agents-manager.tsx
+++ b/packages/agents-manager/src/components/agents-manager.tsx
@@ -103,7 +103,7 @@ function AgentSetup(): JSX.Element | null {
 
 			const siteId = typeof site?.ID === 'number' ? site.ID : undefined;
 
-			const config = createAgentConfig( {
+			const config = await createAgentConfig( {
 				sessionId,
 				siteId,
 				currentRoute,

--- a/packages/agents-manager/src/components/headless-agent-initializer.tsx
+++ b/packages/agents-manager/src/components/headless-agent-initializer.tsx
@@ -48,7 +48,7 @@ export default function HeadlessAgentInitializer( {
 
 			const siteId = typeof site?.ID === 'number' ? site.ID : undefined;
 
-			const config = createAgentConfig( {
+			const config = await createAgentConfig( {
 				sessionId,
 				siteId,
 				currentRoute,

--- a/packages/agents-manager/src/utils/agent-config.ts
+++ b/packages/agents-manager/src/utils/agent-config.ts
@@ -84,6 +84,7 @@ async function createWrappedContextProvider(
 	contextProvider: ContextProvider,
 	version?: string
 ): Promise< UseAgentChatConfig[ 'contextProvider' ] > {
+	const canAccessZendesk = await canConnectToZendesk();
 	return {
 		getClientContext: () => {
 			const pluginContext = contextProvider.getClientContext();
@@ -97,6 +98,7 @@ async function createWrappedContextProvider(
 
 			return {
 				...resolvedContext,
+				can_access_zendesk: canAccessZendesk,
 				constructorArguments: {
 					...( resolvedContext.constructorArguments || {} ),
 					...( version && { version } ),
@@ -115,7 +117,6 @@ async function createDefaultContextProvider(
 	version?: string
 ): Promise< UseAgentChatConfig[ 'contextProvider' ] > {
 	const canAccessZendesk = await canConnectToZendesk();
-
 	return {
 		getClientContext: () => ( {
 			url: window.location.href,

--- a/packages/agents-manager/src/utils/agent-config.ts
+++ b/packages/agents-manager/src/utils/agent-config.ts
@@ -9,6 +9,7 @@
 import { createCalypsoAuthProvider } from '../auth/calypso-auth-provider';
 import { ORCHESTRATOR_AGENT_ID, ORCHESTRATOR_AGENT_URL } from '../constants';
 import { getSessionStorageKey } from './agent-session';
+import { canConnectToZendesk } from './can-connect-to-zendesk';
 import type { ContextEntry, ToolProvider, ContextProvider } from '../extension-types';
 import type { UseAgentChatConfig, Ability as AgenticAbility } from '@automattic/agenttic-client';
 
@@ -79,10 +80,10 @@ function wrapToolProvider( toolProvider: ToolProvider ): UseAgentChatConfig[ 'to
 /**
  * Create a context provider that resolves context entries.
  */
-function createWrappedContextProvider(
+async function createWrappedContextProvider(
 	contextProvider: ContextProvider,
 	version?: string
-): UseAgentChatConfig[ 'contextProvider' ] {
+): Promise< UseAgentChatConfig[ 'contextProvider' ] > {
 	return {
 		getClientContext: () => {
 			const pluginContext = contextProvider.getClientContext();
@@ -108,16 +109,19 @@ function createWrappedContextProvider(
 /**
  * Create a default context provider for environments without a plugin context.
  */
-function createDefaultContextProvider(
+async function createDefaultContextProvider(
 	currentRoute: string | undefined,
 	environment: string,
 	version?: string
-): UseAgentChatConfig[ 'contextProvider' ] {
+): Promise< UseAgentChatConfig[ 'contextProvider' ] > {
+	const canAccessZendesk = await canConnectToZendesk();
+
 	return {
 		getClientContext: () => ( {
 			url: window.location.href,
 			pathname: currentRoute || window.location.pathname,
 			search: window.location.search,
+			can_access_zendesk: canAccessZendesk,
 			environment,
 			// TODO: Remove once agenttic-client supports top-level constructorArguments
 			...( version && { constructorArguments: { version } } ),
@@ -131,7 +135,9 @@ function createDefaultContextProvider(
  * Used by both the full Agents Manager UI and headless mode to ensure
  * consistent configuration.
  */
-export function createAgentConfig( options: CreateAgentConfigOptions ): UseAgentChatConfig {
+export async function createAgentConfig(
+	options: CreateAgentConfigOptions
+): Promise< UseAgentChatConfig > {
 	const {
 		sessionId,
 		siteId,
@@ -157,9 +163,13 @@ export function createAgentConfig( options: CreateAgentConfigOptions ): UseAgent
 	}
 
 	if ( contextProvider ) {
-		config.contextProvider = createWrappedContextProvider( contextProvider, version );
+		config.contextProvider = await createWrappedContextProvider( contextProvider, version );
 	} else {
-		config.contextProvider = createDefaultContextProvider( currentRoute, environment, version );
+		config.contextProvider = await createDefaultContextProvider(
+			currentRoute,
+			environment,
+			version
+		);
 	}
 
 	return config;

--- a/packages/agents-manager/src/utils/can-connect-to-zendesk.ts
+++ b/packages/agents-manager/src/utils/can-connect-to-zendesk.ts
@@ -1,0 +1,12 @@
+let cachedPromise: Promise< boolean > | null = null;
+
+export function canConnectToZendesk() {
+	// Parse the JSON to throw errors for all non-success responses
+	return (
+		cachedPromise ||
+		( cachedPromise = fetch( 'https://wpcom.zendesk.com/embeddable/config' )
+			.then( ( res ) => res.json() )
+			.then( ( data ) => !! data )
+			.catch( () => false ) )
+	);
+}


### PR DESCRIPTION
Fixes DOTCOM-15912

## Summary

Expose Zendesk accessibility to the agent so it can avoid offering handoff when Zendesk is unavailable.

## Changes

- **`can-connect-to-zendesk.ts`** — New util that fetches Zendesk embeddable config and caches the result; returns `true` when config is available, `false` on error or non-success. This fetches once per session and the value is cached in memory. We can't cache it for longer because the user might change their browser config.
- **`agent-config.ts`** — `createAgentConfig` is now async. Default context provider calls `canConnectToZendesk()` and adds `can_access_zendesk` to client context.
- **Callers** — `agents-manager.tsx` and `headless-agent-initializer.tsx` now `await createAgentConfig()`.

## Why are these changes being made?

To allow AI to route the user according to their ability to access Zendesk without having complicated client side logic.

## Testing Instructions

1. Run `yarn dev --sync` in `apps/agents-manager`.
2. Go to /wp-admin/profile.php (on wp.com) and opt-in to unified AI.
3. Go to site editor. The agents manager should appear.
5. Open the three-dots menu and start a new chat.
6. Open DevTools > Network.
7. Send a message to AI.
8. Inspect the sent message JSON and verify that the last item in the `content` array has `clientContext`, which should have `can_access_zendesk` set to true.