### PR TITLE
Theme Showcase: Add FAQ accordion section

### DIFF
--- a/client/my-sites/themes/sections-modern/style.scss
+++ b/client/my-sites/themes/sections-modern/style.scss
@@ -9,6 +9,10 @@
 
 	margin-bottom: 96px;
 	padding-inline: 24px;
+
+	&:last-child {
+		margin-bottom: 0;
+	}
 }
 
 .theme-section-modern.is-dark {

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -56,6 +56,7 @@ import RecommendedSections from './sections-modern/recommended-sections';
 import ThemeErrors from './theme-errors';
 import ThemePreview from './theme-preview';
 import ThemeShowcaseHeader from './theme-showcase-header';
+import ThemesFAQ from './themes-faq';
 import ThemesSelection from './themes-selection';
 import ThemesToolbarGroup from './themes-toolbar-group';
 import './theme-showcase.scss';
@@ -844,6 +845,7 @@ class ThemeShowcase extends Component {
 						{ ! isSiteWooExpressOrEcomFreeTrial && this.renderBanner() }
 						{ this.renderThemes( themeProps ) }
 					</div>
+					{ this.isThemeShowcaseModern() && <ThemesFAQ /> }
 					{ siteId && <QuerySitePlans siteId={ siteId } /> }
 					{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 					<QueryProductsList />

--- a/client/my-sites/themes/themes-faq/index.tsx
+++ b/client/my-sites/themes/themes-faq/index.tsx
@@ -75,21 +75,23 @@ export default function ThemesFAQ() {
 
 	return (
 		<div className="themes-faq">
-			<div className="themes-faq__header">
-				<h2 className="themes-faq__title">{ translate( 'Themes FAQs' ) }</h2>
-			</div>
-			<div className="themes-faq__list">
-				{ faqItems.map( ( item ) => (
-					<FoldableFAQ
-						key={ item.id }
-						id={ item.id }
-						question={ item.question }
-						onToggle={ onToggle }
-						icon="cross-small"
-					>
-						{ item.answer }
-					</FoldableFAQ>
-				) ) }
+			<div className="themes-faq__wrapper">
+				<div className="themes-faq__header">
+					<h2 className="themes-faq__title">{ translate( 'Themes FAQs' ) }</h2>
+				</div>
+				<div className="themes-faq__list">
+					{ faqItems.map( ( item ) => (
+						<FoldableFAQ
+							key={ item.id }
+							id={ item.id }
+							question={ item.question }
+							onToggle={ onToggle }
+							icon="cross-small"
+						>
+							{ item.answer }
+						</FoldableFAQ>
+					) ) }
+				</div>
 			</div>
 		</div>
 	);

--- a/client/my-sites/themes/themes-faq/index.tsx
+++ b/client/my-sites/themes/themes-faq/index.tsx
@@ -1,0 +1,96 @@
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+import FoldableFAQ from 'calypso/components/foldable-faq';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+import './style.scss';
+
+interface FAQItem {
+	id: string;
+	question: string | React.ReactNode;
+	answer: string | React.ReactNode;
+}
+
+export default function ThemesFAQ() {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const onToggle = useCallback(
+		( faqArgs: { id: string; isExpanded: boolean } ) => {
+			const { id, isExpanded } = faqArgs;
+			dispatch(
+				recordTracksEvent( isExpanded ? 'calypso_themes_faq_open' : 'calypso_themes_faq_closed', {
+					faq_id: id,
+				} )
+			);
+		},
+		[ dispatch ]
+	);
+
+	const faqItems: FAQItem[] = [
+		{
+			id: 'what-is-theme',
+			question: translate( 'What is a WordPress theme?' ),
+			answer: translate(
+				'A WordPress theme controls the design and layout of your website. It determines how your site looks to visitors, including colors, typography, page templates, and overall structure.'
+			),
+		},
+		{
+			id: 'change-theme',
+			question: translate( 'Can I change my theme later?' ),
+			answer: translate(
+				'Yes, you can switch themes at any time. Your content is preserved when you change themes, though you may need to adjust some settings to match the new design.'
+			),
+		},
+		{
+			id: 'customize-theme',
+			question: translate( 'Can I customize my theme?' ),
+			answer: translate(
+				'Absolutely. Most themes let you customize colors, fonts, layouts, and more through the Site Editor. You can make your site look unique without writing any code.'
+			),
+		},
+		{
+			id: 'free-vs-premium',
+			question: translate( 'What is the difference between free and premium themes?' ),
+			answer: translate(
+				'Free themes offer a solid foundation for your site. Premium themes typically include more advanced design options, additional templates, and dedicated support from the theme developer.'
+			),
+		},
+		{
+			id: 'theme-performance',
+			question: translate( 'Do themes affect site performance?' ),
+			answer: translate(
+				'Themes can impact loading speed and performance. All themes on WordPress.com are reviewed for quality, but simpler themes with fewer features generally load faster.'
+			),
+		},
+		{
+			id: 'theme-mobile',
+			question: translate( 'Are themes mobile-friendly?' ),
+			answer: translate(
+				'Yes. All themes on WordPress.com are responsive and designed to look great on desktops, tablets, and mobile devices.'
+			),
+		},
+	];
+
+	return (
+		<div className="themes-faq">
+			<div className="themes-faq__header">
+				<h2 className="themes-faq__title">{ translate( 'Themes FAQs' ) }</h2>
+			</div>
+			<div className="themes-faq__list">
+				{ faqItems.map( ( item ) => (
+					<FoldableFAQ
+						key={ item.id }
+						id={ item.id }
+						question={ item.question }
+						onToggle={ onToggle }
+						icon="cross-small"
+					>
+						{ item.answer }
+					</FoldableFAQ>
+				) ) }
+			</div>
+		</div>
+	);
+}

--- a/client/my-sites/themes/themes-faq/index.tsx
+++ b/client/my-sites/themes/themes-faq/index.tsx
@@ -1,3 +1,4 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
@@ -30,45 +31,117 @@ export default function ThemesFAQ() {
 
 	const faqItems: FAQItem[] = [
 		{
-			id: 'what-is-theme',
-			question: translate( 'What is a WordPress theme?' ),
+			id: 'themes',
+			question: translate( 'What are WordPress themes?' ),
 			answer: translate(
-				'A WordPress theme controls the design and layout of your website. It determines how your site looks to visitors, including colors, typography, page templates, and overall structure.'
+				'Themes help structure your website’s design, ensuring consistency in layout, fonts, and colors—without needing to code. They provide a ready-to-go design, so you don’t need to start from scratch, while still allowing you to personalize it to suit your brand.'
 			),
 		},
 		{
-			id: 'change-theme',
-			question: translate( 'Can I change my theme later?' ),
+			id: 'premium-themes',
+			question: translate( 'What are Premium WordPress themes?' ),
 			answer: translate(
-				'Yes, you can switch themes at any time. Your content is preserved when you change themes, though you may need to adjust some settings to match the new design.'
+				'Premium themes are professionally designed themes available to paid plan customers. They often include advanced layouts, additional customization options, and unique design features not found in free themes.'
 			),
 		},
 		{
-			id: 'customize-theme',
-			question: translate( 'Can I customize my theme?' ),
+			id: 'paid-themes',
+			question: translate( 'Why do some WordPress themes cost money?' ),
 			answer: translate(
-				'Absolutely. Most themes let you customize colors, fonts, layouts, and more through the Site Editor. You can make your site look unique without writing any code.'
+				'Premium themes take more time and expertise to design, and often come with extra features or support from the theme creators. They’re included with WordPress.com paid plans, so you don’t need to purchase them separately.'
 			),
 		},
 		{
-			id: 'free-vs-premium',
-			question: translate( 'What is the difference between free and premium themes?' ),
+			id: 'edit-themes',
+			question: translate( 'Can I edit my theme?' ),
 			answer: translate(
-				'Free themes offer a solid foundation for your site. Premium themes typically include more advanced design options, additional templates, and dedicated support from the theme developer.'
+				'Yes. You can customize your theme with the Site Editor—changing colors, fonts, layouts, and even templates—while keeping your content intact. Some themes also include their own built-in customization options.'
 			),
 		},
 		{
-			id: 'theme-performance',
-			question: translate( 'Do themes affect site performance?' ),
+			id: 'change-theme-after-launch',
+			question: translate( 'Can I change my WordPress theme after my site is launched?' ),
 			answer: translate(
-				'Themes can impact loading speed and performance. All themes on WordPress.com are reviewed for quality, but simpler themes with fewer features generally load faster.'
+				'Absolutely. You can switch themes at any time. It won’t delete your content, but you may need to reconfigure some elements on the new design.'
 			),
 		},
 		{
-			id: 'theme-mobile',
-			question: translate( 'Are themes mobile-friendly?' ),
+			id: 'third-party-themes',
+			question: translate(
+				'Can I install themes from third-party sources on my WordPress.com site?'
+			),
 			answer: translate(
-				'Yes. All themes on WordPress.com are responsive and designed to look great on desktops, tablets, and mobile devices.'
+				'Yes. On paid {{a}}WordPress.com{{/a}} plans, you can upload themes from other sources, including custom themes you’ve built.',
+				{
+					components: {
+						a: <a href={ localizeUrl( 'https://wordpress.com' ) } />,
+					},
+				}
+			),
+		},
+		{
+			id: 'download-themes',
+			question: translate( 'Can I download WordPress themes from WordPress.com?' ),
+			answer: translate(
+				'Only free themes can be downloaded from {{awpcom}}WordPress.com{{/awpcom}}. If you need more downloadable themes, check the {{awporg}}WordPress.org theme directory{{/awporg}}.',
+				{
+					components: {
+						awpcom: <a href={ localizeUrl( 'https://wordpress.com' ) } />,
+						awporg: <a href="https://wordpress.org/themes/" rel="noreferrer" target="_blank" />,
+					},
+				}
+			),
+		},
+		{
+			id: 'create-themes',
+			question: translate( 'Can I create my own WordPress themes?' ),
+			answer: translate(
+				'Yes—if you’re on a paid plan, you can upload and use your own custom themes. Developers can also build themes locally and deploy them using tools like GitHub and WP-CLI. Check out {{a}}WordPress Studio{{/a}} for local theme development.',
+				{
+					components: {
+						a: <a href="https://developer.wordpress.com/studio/" />,
+					},
+				}
+			),
+		},
+		{
+			id: 'themes-templates',
+			question: translate( 'What is the difference between a theme and a template?' ),
+			answer: translate(
+				'A theme is the overall design framework for your site. Templates are individual layouts within a theme, such as a single post layout or a page template. Themes contain many templates.'
+			),
+		},
+		{
+			id: 'accessibility',
+			question: translate( 'Is my theme accessible and mobile-friendly?' ),
+			answer: translate(
+				'Yes. All {{a}}WordPress.com{{/a}} themes are designed to be responsive (mobile-friendly) and meet accessibility best practices. You can preview how your site looks on different devices in the Site Editor.',
+				{
+					components: {
+						a: <a href={ localizeUrl( 'https://wordpress.com' ) } />,
+					},
+				}
+			),
+		},
+		{
+			id: 'demos',
+			question: translate( 'Why doesn’t my theme look the same as the demo after I install it?' ),
+			answer: translate(
+				'Demo sites often use sample content and images to show what’s possible. When you install a theme, your own content is applied — so it may look different until you customize it with your own pages, menus, and media.'
+			),
+		},
+		{
+			id: 'switch-themes',
+			question: translate( 'How simple is it to switch themes?' ),
+			answer: translate(
+				'Switching is quick and takes just a few clicks in your dashboard. Your content won’t be lost, and you can preview a new theme before activating it.'
+			),
+		},
+		{
+			id: 'try-themes',
+			question: translate( 'Can I try out a new theme without losing my content?' ),
+			answer: translate(
+				'Yes. You can preview themes in the Customizer or Site Editor before publishing changes. Your content stays safe, so you can experiment freely. Sites on the Business plan can test new themes on a staging site, which is a private copy of your public site for testing purposes.'
 			),
 		},
 	];

--- a/client/my-sites/themes/themes-faq/style.scss
+++ b/client/my-sites/themes/themes-faq/style.scss
@@ -1,0 +1,106 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
+.themes-faq {
+	display: flex;
+	flex-direction: column;
+	gap: 32px;
+	padding: 40px 20px;
+	background-color: var( --studio-gray-100 );
+
+	@include break-large {
+		padding: 64px;
+	}
+
+	@include break-large {
+		flex-direction: row;
+		gap: 64px;
+	}
+
+	@include breakpoint-deprecated( '<1400px' ) {
+		// Override the margin from `.layout__primary .main`
+		margin-bottom: -88px;
+	}
+
+	a,
+	a:hover,
+	a:active,
+	a:visited {
+		color: inherit;
+	}
+}
+
+.themes-faq__header {
+	flex: 0.85;
+
+	@include break-large {
+		width: 200px;
+	}
+}
+
+.themes-faq__title {
+	font-family: $brand-serif;
+	font-size: rem( 40px );
+	font-weight: 400;
+	line-height: 1.2;
+	color: var( --studio-white );
+	margin: 0;
+
+	@include break-large {
+		font-size: rem( 50px );
+	}
+}
+
+.themes-faq__list {
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+	gap: 16px;
+
+	.foldable-faq {
+		padding: 0;
+		background-color: var( --studio-gray-90 );
+		border-radius: 4px;
+	}
+
+	.foldable-faq.is-expanded .foldable-faq__question .gridicon {
+		fill: var( --studio-gray-90 );
+		background-color: var( --studio-white );
+		transform: rotate( 0 );
+	}
+
+	.foldable-faq__question {
+		width: 100%;
+		padding: 20px;
+
+		.gridicon {
+			fill: var( --studio-white );
+			order: 1;
+			margin-inline-start: auto;
+			border: 1px solid var( --studio-white );
+			border-radius: 50%;
+			padding: 2px;
+			box-sizing: content-box;
+			transform: rotate( -45deg );
+			transition:
+				transform 0.2s ease-in-out,
+				fill 0.2s ease-in-out,
+				background-color 0.2s ease-in-out;
+		}
+	}
+
+	.foldable-faq__question-text {
+		padding-inline-start: 0;
+		font-size: rem( 16px );
+		font-weight: 400;
+		color: var( --studio-white );
+	}
+
+	.foldable-faq__answer {
+		border-bottom: none;
+		color: var( --studio-gray-20 );
+		font-size: rem( 14px );
+		line-height: 1.6;
+		padding-inline: 20px;
+	}
+}

--- a/client/my-sites/themes/themes-faq/style.scss
+++ b/client/my-sites/themes/themes-faq/style.scss
@@ -2,24 +2,25 @@
 @import '@wordpress/base-styles/mixins';
 
 .themes-faq {
-	display: flex;
-	flex-direction: column;
-	gap: 32px;
-	padding: 40px 20px;
 	background-color: var( --studio-gray-100 );
-
-	@include break-large {
-		padding: 64px;
-	}
-
-	@include break-large {
-		flex-direction: row;
-		gap: 64px;
-	}
+	padding: 24px 24px 96px 24px;
 
 	@include breakpoint-deprecated( '<1400px' ) {
 		// Override the margin from `.layout__primary .main`
 		margin-bottom: -88px;
+	}
+}
+
+.themes-faq__wrapper {
+	display: flex;
+	flex-direction: column;
+	gap: 32px;
+	max-width: 1220px;
+	margin: 48px auto 0 auto;
+
+	@include break-large {
+		flex-direction: row;
+		gap: 64px;
 	}
 
 	a,


### PR DESCRIPTION
Fixes DOTTHEM-321

## Proposed Changes

<img width="3802" height="2610" alt="calypso localhost_3000_themes" src="https://github.com/user-attachments/assets/49447e00-f359-47b5-a478-684def4d2c48" />


* Add a `ThemesFAQ` component with 13 FAQ items using `FoldableFAQ`, mirroring the `PluginsFAQ` pattern.
* Render the FAQ section at the bottom of the themes showcase when `isThemeShowcaseModern()` is true.
* Track accordion open/close events via `calypso_themes_faq_open` / `calypso_themes_faq_closed`.
* Remove bottom margin from last `theme-section-modern` to avoid extra spacing before the FAQ.

## Why are these changes being made?

* Adds a FAQ section to the modernized themes landing page to help users find answers to common theme-related questions.

## Testing Instructions

* Visit `/themes` logged out (incognito) with the `themes/showcase-modern` feature flag enabled.
* Scroll to the bottom of the page and verify the FAQ section appears with a dark background.
* Click FAQ items to expand/collapse and verify the accordion animation works.
* Verify Tracks events fire on open/close (check console or network tab).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?