### PR TITLE
Theme Showcase: Adapt modern header styles to single theme pages

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -150,7 +150,9 @@ const LayoutLoggedOut = ( {
 			userAllowedToHelpCenter );
 
 	const isThemeShowcaseModern =
-		sectionName === 'themes' && isEnabled( 'themes/showcase-modern' ) && ! isLoggedIn;
+		[ 'themes', 'theme' ].includes( sectionName ) &&
+		isEnabled( 'themes/showcase-modern' ) &&
+		! isLoggedIn;
 
 	const classes = {
 		[ 'is-group-' + sectionGroup ]: sectionGroup,

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -813,3 +813,27 @@ $button-border: 4px;
 		padding-left: 1.5rem;
 	}
 }
+
+.is-theme-showcase-modern {
+	.theme__sheet {
+		margin: 0 24px;
+	}
+
+	&.is-section-theme .theme__sheet .navigation-header,
+	&.is-section-theme .theme__sheet .theme__sheet-retired-notice,
+	.theme__sheet-columns {
+		max-width: 1220px;
+		padding: 24px 0;
+	}
+
+	@include breakpoint-deprecated( '<960px' ) {
+		.theme__sheet-column-header .theme__sheet-main,
+		.theme__sheet-reviews-summary,
+		.theme__sheet-column-left {
+			padding: 0;
+		}
+		.theme__sheet-features .card.is-compact {
+			padding: 16px 0;
+		}
+	}
+}

--- a/client/my-sites/theme/theme-support-tab/style.scss
+++ b/client/my-sites/theme/theme-support-tab/style.scss
@@ -1,7 +1,7 @@
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/variables";
 
-.theme__sheet-card-support {
+.card.theme__sheet-card-support {
 	align-items: center;
 	display: grid;
 	gap: 0 20px;

--- a/client/my-sites/themes/hero-modern/style.scss
+++ b/client/my-sites/themes/hero-modern/style.scss
@@ -3,23 +3,8 @@
 
 $hero-modern-navbar-height: 57px; // UniversalHeaderNavigation
 
-.is-section-themes.is-theme-showcase-modern.has-no-sidebar {
-	.masterbar-menu .masterbar {
-		background: transparent;
-		border-bottom-color: transparent;
-		height: 56px;
-		position: relative;
-	}
-
-	.cta-btn-nav {
-		color: var(--studio-gray-100) !important;
-		background: inherit !important;
-		border: 1px solid var(--studio-gray-100);
-	}
-
-	.themes__selection {
-		padding-inline: 24px;
-	}
+.is-theme-showcase-modern.has-no-sidebar .themes__selection {
+	padding-inline: 24px;
 }
 
 

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -55,6 +55,19 @@ $studio-blue-15: #e5f4ff;
 				}
 			}
 		}
+
+		&.is-theme-showcase-modern {
+			.masterbar-menu .masterbar {
+				background: transparent;
+				border-bottom-color: transparent;
+			}
+
+			.cta-btn-nav {
+				color: var(--studio-gray-100) !important;
+				background: inherit !important;
+				border: 1px solid var(--studio-gray-100);
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes DOTTHEM-328

## Proposed Changes

<img width="3300" height="3820" alt="calypso localhost_3000_theme_parr" src="https://github.com/user-attachments/assets/61af9565-130c-4cee-b4fb-21a8358ba96b" />


- Extend the modern theme showcase layout to individual theme pages (`is-section-theme`), not just the themes listing.
- Move masterbar transparency and CTA button styles from `hero-modern` to `universal-header-navigation` so they apply across both sections.
- Add layout constraints (max-width, padding, margins) for single theme sheet pages under the modern showcase.
- Bump `.theme__sheet-card-support` selector specificity to prevent style conflicts.

## Why are these changes being made?

The modern theme showcase redesign was only applied to the themes listing page. Individual theme pages still used the old layout width and header styling, creating visual inconsistency. This PR unifies both views under the same modern showcase design.

## Testing Instructions

1. Visit the logged-out theme showcase (e.g., `/themes`) with the `themes/showcase-modern` feature flag enabled.
2. Confirm the modern header styling (transparent masterbar, styled CTA button) is present.
3. Navigate to an individual theme page (e.g., `/theme/suspended`).
4. Confirm the same modern header styling applies and the page content respects the `1220px` max-width constraint.
5. Resize the browser below 960px and verify padding adjustments look correct.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?