### PR TITLE
Theme Showcase: Fix style variation ribbon overflowing on small screens

### DIFF
--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -829,8 +829,12 @@ $button-border: 4px;
 	@include breakpoint-deprecated( '<960px' ) {
 		.theme__sheet-column-header .theme__sheet-main,
 		.theme__sheet-reviews-summary,
-		.theme__sheet-column-left {
+		.theme__sheet-column-left,
+		.theme__sheet-style-variations {
 			padding: 0;
+		}
+		.theme__sheet-reviews-summary {
+			padding-top: 16px;
 		}
 		.theme__sheet-features .card.is-compact {
 			padding: 16px 0;

--- a/packages/global-styles/src/components/global-styles-variations/style.scss
+++ b/packages/global-styles/src/components/global-styles-variations/style.scss
@@ -34,6 +34,10 @@
 	}
 }
 
+.global-styles-variations__type {
+	min-width: 100px;
+}
+
 .global-styles-variations__header {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
Fixes DOTTHEM-329

## Proposed Changes

| Screen | Before | After |
|--------|--------|--------|
| Logged-in | <img width="700" height="516" alt="Screenshot 2026-03-12 at 18 01 08" src="https://github.com/user-attachments/assets/7f90b89f-d682-4586-8f51-fefffe91d0c5" /> | <img width="700" height="516" alt="Screenshot 2026-03-12 at 18 02 08" src="https://github.com/user-attachments/assets/c9c87395-8fce-401d-a9ce-0d48ed93507b" /> |
| Logged-out (current) | <img width="700" height="516" alt="Screenshot 2026-03-12 at 18 00 28" src="https://github.com/user-attachments/assets/1192291c-790c-4fbe-a174-1ea1fcbd1041" /> | <img width="700" height="516" alt="Screenshot 2026-03-12 at 18 00 38" src="https://github.com/user-attachments/assets/d022cf23-576e-4ef5-8b84-b50aaf9c8173" /> |
| Logged-out (modern) | <img width="700" height="516" alt="Screenshot 2026-03-12 at 17 47 18" src="https://github.com/user-attachments/assets/f3c8952e-c897-4463-a66a-a16d0243dbc7" /> | <img width="700" height="516" alt="Screenshot 2026-03-12 at 17 47 29" src="https://github.com/user-attachments/assets/d9f6dcdd-38e5-4c47-9703-b4b8f28e9a79" /> | 

* Set a `min-width: 100px` on `.global-styles-variations__type` so it no longer overflows its container.

## Why are these changes being made?

On small screens, the style variations ribbon on single theme pages was overflowing horizontally because it was missing a min-width.

## Testing Instructions

* Navigate to a single theme page (e.g., `/theme/<theme-slug>`) that has style variations.
* Resize the browser window below 960px.
* Verify the style variation ribbon no longer overflows and wraps correctly.
* Verify the reviews summary section still has appropriate top spacing.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?