### PR TITLE
Marketplace: Fix plugin install redirect for non-wporg plugins

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -305,32 +305,14 @@ const MarketplaceProductInstall = ( {
 	// For marketplace plugins (e.g. sensei-pro), the atomic transfer + plugin install
 	// is initiated during checkout, not by this component. The wporg data is unavailable,
 	// so atomicFlow is never set. Once the site is atomic, poll for installed plugins
-	// and activate so that the existing redirect (installedPlugin && pluginActive) fires.
+	// so that the existing redirect (installedPlugin && pluginActive) fires.
 	const isMarketplacePluginFlow =
 		! atomicFlow && ! isPluginUploadFlow && !! pluginSlug && !! freshSite?.is_wpcom_atomic;
-	const hasDispatchedActivation = useRef( false );
 
 	useInterval(
 		() => dispatch( fetchSitePlugins( siteId ) ),
-		isMarketplacePluginFlow && ! installedPlugin ? 3000 : null
+		isMarketplacePluginFlow && ! pluginActive ? 3000 : null
 	);
-
-	useEffect( () => {
-		if (
-			isMarketplacePluginFlow &&
-			installedPlugin &&
-			! pluginActive &&
-			! hasDispatchedActivation.current
-		) {
-			hasDispatchedActivation.current = true;
-			dispatch(
-				activatePlugin( siteId, {
-					slug: installedPlugin?.slug,
-					id: installedPlugin?.id,
-				} )
-			);
-		}
-	}, [ isMarketplacePluginFlow, installedPlugin, pluginActive, siteId, dispatch ] );
 
 	const canManagePlugins = useSelector( ( state ) => {
 		return siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -307,7 +307,11 @@ const MarketplaceProductInstall = ( {
 	// so atomicFlow is never set. Once the site is atomic, poll for installed plugins
 	// so that the existing redirect (installedPlugin && pluginActive) fires.
 	const isMarketplacePluginFlow =
-		! atomicFlow && ! isPluginUploadFlow && !! pluginSlug && !! freshSite?.is_wpcom_atomic;
+		! atomicFlow &&
+		! isPluginUploadFlow &&
+		!! pluginSlug &&
+		!! freshSite?.is_wpcom_atomic &&
+		wporgPlugin?.wporg === false;
 
 	useInterval(
 		() => dispatch( fetchSitePlugins( siteId ) ),

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -32,7 +32,11 @@ import { transferStates } from 'calypso/state/automated-transfer/constants';
 import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors';
 import { getPurchaseFlowState } from 'calypso/state/marketplace/purchase-flow/selectors';
 import { MARKETPLACE_ASYNC_PROCESS_STATUS } from 'calypso/state/marketplace/types';
-import { installPlugin, activatePlugin } from 'calypso/state/plugins/installed/actions';
+import {
+	installPlugin,
+	activatePlugin,
+	fetchSitePlugins,
+} from 'calypso/state/plugins/installed/actions';
 import {
 	getPluginOnSite,
 	getStatusForPlugin,
@@ -297,6 +301,36 @@ const MarketplaceProductInstall = ( {
 
 	// Prefer fresh URL when available; if in atomic flow, wait for fresh URL
 	const pluginsUrlFinal = atomicFlow ? pluginsUrlFresh : pluginsUrlFresh || pluginsUrlSelector;
+
+	// For marketplace plugins (e.g. sensei-pro), the atomic transfer + plugin install
+	// is initiated during checkout, not by this component. The wporg data is unavailable,
+	// so atomicFlow is never set. Once the site is atomic, poll for installed plugins
+	// and activate so that the existing redirect (installedPlugin && pluginActive) fires.
+	const isMarketplacePluginFlow =
+		! atomicFlow && ! isPluginUploadFlow && !! pluginSlug && !! freshSite?.is_wpcom_atomic;
+	const hasDispatchedActivation = useRef( false );
+
+	useInterval(
+		() => dispatch( fetchSitePlugins( siteId ) ),
+		isMarketplacePluginFlow && ! installedPlugin ? 3000 : null
+	);
+
+	useEffect( () => {
+		if (
+			isMarketplacePluginFlow &&
+			installedPlugin &&
+			! pluginActive &&
+			! hasDispatchedActivation.current
+		) {
+			hasDispatchedActivation.current = true;
+			dispatch(
+				activatePlugin( siteId, {
+					slug: installedPlugin?.slug,
+					id: installedPlugin?.id,
+				} )
+			);
+		}
+	}, [ isMarketplacePluginFlow, installedPlugin, pluginActive, siteId, dispatch ] );
 
 	const canManagePlugins = useSelector( ( state ) => {
 		return siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS );


### PR DESCRIPTION
## Proposed Changes

* Add handling for marketplace-only plugins (e.g. sensei-pro) on the install page after checkout

## Why are these changes being made?

Marketplace-only plugins are not available on wordpress.org (their wporg API returns 404), so the install flow in `MarketplaceProductInstall` never initializes — `atomicFlow` is never set to `true`, and the redirect after atomic transfer never fires. The user gets stuck on the install page indefinitely.

The atomic transfer + plugin install for these plugins is initiated during checkout, not by this component. Once the site becomes atomic, we need to:
1. Poll for installed plugins (`fetchSitePlugins`) to detect the plugin
3. Let the existing redirect condition (`installedPlugin && pluginActive`) handle the navigation

## Testing Instructions

1. Create a free site with the free plan
2. Go to the plugin's page and select a marketplace-only plugin (e.g. sensei-pro)
3. Purchase and upgrade — select the plan and go through checkout
4. Ensure you are redirected to the site after you see the loading state on the install screen

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?