### PR TITLE
Login: route Woo signups to CIAB setup redirect

### DIFF
--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -53,6 +53,8 @@ export function pathWithLeadingSlash( path ) {
 
 export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, pathname ) {
 	const redirectTo = get( currentQuery, 'redirect_to', '' );
+	const ciabSetupRedirectTo =
+		'/setup/ai-site-builder-spec?source=ciab-sites-dashboard&ref=new-site-popover';
 
 	if (
 		// Match locales like `/log-in/jetpack/es`
@@ -137,6 +139,23 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 			oauth2_redirect: redirectTo,
 		} );
 		return `/start/wpcc?${ oauth2Params.toString() }`;
+	}
+
+	let hasCiabRedirectHost = false;
+	if ( redirectTo ) {
+		try {
+			const redirectToUrl = new URL( redirectTo );
+			hasCiabRedirectHost = [ 'my.woo.ai', 'my.woo.localhost' ].includes( redirectToUrl.hostname );
+		} catch {
+			// no-op
+		}
+	}
+
+	if ( get( currentQuery, 'from' ) === 'woo' || hasCiabRedirectHost ) {
+		const params = new URLSearchParams( {
+			redirect_to: ciabSetupRedirectTo,
+		} );
+		return `/start/account?${ params.toString() }`;
 	}
 
 	const signupFlow = get( currentQuery, 'signup_flow' );

--- a/client/lib/login/test/index.js
+++ b/client/lib/login/test/index.js
@@ -216,6 +216,45 @@ describe( 'getSignupUrl', () => {
 			'/start/account?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Fpublic.api%2Fconnect%2F%3Faction%3Dverify'
 		);
 	} );
+
+	test( 'from=woo uses the CIAB AI setup redirect', () => {
+		expect( getSignupUrl( { from: 'woo' }, '/log-in', null, 'en', '' ) ).toEqual(
+			'/start/account?redirect_to=%2Fsetup%2Fai-site-builder-spec%3Fsource%3Dciab-sites-dashboard%26ref%3Dnew-site-popover'
+		);
+	} );
+
+	test( 'CIAB redirect host in redirect_to uses the CIAB AI setup redirect', () => {
+		expect(
+			getSignupUrl( { redirect_to: 'https://my.woo.ai/sites' }, '/log-in', null, 'en', '' )
+		).toEqual(
+			'/start/account?redirect_to=%2Fsetup%2Fai-site-builder-spec%3Fsource%3Dciab-sites-dashboard%26ref%3Dnew-site-popover'
+		);
+	} );
+
+	test( 'non-CIAB from keeps existing behavior', () => {
+		expect( getSignupUrl( { from: 'reader' }, '/log-in', null, 'en', '' ) ).toEqual( '/start' );
+	} );
+
+	test( 'generic OAuth2 client keeps existing behavior in CIAB context', () => {
+		const oauth2Client = {
+			id: 123,
+			name: 'example',
+			title: 'Example',
+			url: 'https://example.com',
+		};
+
+		expect(
+			getSignupUrl(
+				{ from: 'woo', redirect_to: 'https://example.com/oauth' },
+				'/log-in',
+				oauth2Client,
+				'en',
+				''
+			)
+		).toEqual(
+			'/start/wpcc?oauth2_client_id=123&oauth2_redirect=https%3A%2F%2Fexample.com%2Foauth'
+		);
+	} );
 } );
 
 describe( 'getPluginTitle', () => {


### PR DESCRIPTION
Part of ARC-1615

## Proposed Changes

* Route Woo onboarding signups through the CIAB setup redirect path in login routing.
* Add login unit tests that cover Woo signup redirect behavior.

## Why are these changes being made?

* Woo onboarding signups should consistently land in the CIAB setup flow so account setup follows the expected path.

## Testing Instructions

* Run `yarn test-client client/lib/login/test/index.js`.
* Confirm the Woo signup login routing now resolves to the CIAB setup redirect behavior covered by the tests.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?