### PR TITLE
Marketplace: Add 1-minute fallback redirect on plugin install page

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -305,32 +305,14 @@ const MarketplaceProductInstall = ( {
 	// For marketplace plugins (e.g. sensei-pro), the atomic transfer + plugin install
 	// is initiated during checkout, not by this component. The wporg data is unavailable,
 	// so atomicFlow is never set. Once the site is atomic, poll for installed plugins
-	// and activate so that the existing redirect (installedPlugin && pluginActive) fires.
+	// so that the existing redirect (installedPlugin && pluginActive) fires.
 	const isMarketplacePluginFlow =
 		! atomicFlow && ! isPluginUploadFlow && !! pluginSlug && !! freshSite?.is_wpcom_atomic;
-	const hasDispatchedActivation = useRef( false );
 
 	useInterval(
 		() => dispatch( fetchSitePlugins( siteId ) ),
-		isMarketplacePluginFlow && ! installedPlugin ? 3000 : null
+		isMarketplacePluginFlow && ! pluginActive ? 3000 : null
 	);
-
-	useEffect( () => {
-		if (
-			isMarketplacePluginFlow &&
-			installedPlugin &&
-			! pluginActive &&
-			! hasDispatchedActivation.current
-		) {
-			hasDispatchedActivation.current = true;
-			dispatch(
-				activatePlugin( siteId, {
-					slug: installedPlugin?.slug,
-					id: installedPlugin?.id,
-				} )
-			);
-		}
-	}, [ isMarketplacePluginFlow, installedPlugin, pluginActive, siteId, dispatch ] );
 
 	const canManagePlugins = useSelector( ( state ) => {
 		return siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -314,6 +314,23 @@ const MarketplaceProductInstall = ( {
 		isMarketplacePluginFlow && ! pluginActive ? 3000 : null
 	);
 
+	// Fallback: if the plugin hasn't activated after 1 minute of polling,
+	// redirect anyway to prevent the user from being stuck on this page.
+	const pluginsUrlFinalRef = useRef( pluginsUrlFinal );
+	pluginsUrlFinalRef.current = pluginsUrlFinal;
+
+	useEffect( () => {
+		if ( ! isMarketplacePluginFlow ) {
+			return;
+		}
+		const timeout = setTimeout( () => {
+			if ( pluginsUrlFinalRef.current ) {
+				window.location.href = pluginsUrlFinalRef.current as string;
+			}
+		}, 60000 );
+		return () => clearTimeout( timeout );
+	}, [ isMarketplacePluginFlow ] );
+
 	const canManagePlugins = useSelector( ( state ) => {
 		return siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS );
 	} );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -32,7 +32,11 @@ import { transferStates } from 'calypso/state/automated-transfer/constants';
 import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors';
 import { getPurchaseFlowState } from 'calypso/state/marketplace/purchase-flow/selectors';
 import { MARKETPLACE_ASYNC_PROCESS_STATUS } from 'calypso/state/marketplace/types';
-import { installPlugin, activatePlugin } from 'calypso/state/plugins/installed/actions';
+import {
+	installPlugin,
+	activatePlugin,
+	fetchSitePlugins,
+} from 'calypso/state/plugins/installed/actions';
 import {
 	getPluginOnSite,
 	getStatusForPlugin,
@@ -297,6 +301,36 @@ const MarketplaceProductInstall = ( {
 
 	// Prefer fresh URL when available; if in atomic flow, wait for fresh URL
 	const pluginsUrlFinal = atomicFlow ? pluginsUrlFresh : pluginsUrlFresh || pluginsUrlSelector;
+
+	// For marketplace plugins (e.g. sensei-pro), the atomic transfer + plugin install
+	// is initiated during checkout, not by this component. The wporg data is unavailable,
+	// so atomicFlow is never set. Once the site is atomic, poll for installed plugins
+	// and activate so that the existing redirect (installedPlugin && pluginActive) fires.
+	const isMarketplacePluginFlow =
+		! atomicFlow && ! isPluginUploadFlow && !! pluginSlug && !! freshSite?.is_wpcom_atomic;
+	const hasDispatchedActivation = useRef( false );
+
+	useInterval(
+		() => dispatch( fetchSitePlugins( siteId ) ),
+		isMarketplacePluginFlow && ! installedPlugin ? 3000 : null
+	);
+
+	useEffect( () => {
+		if (
+			isMarketplacePluginFlow &&
+			installedPlugin &&
+			! pluginActive &&
+			! hasDispatchedActivation.current
+		) {
+			hasDispatchedActivation.current = true;
+			dispatch(
+				activatePlugin( siteId, {
+					slug: installedPlugin?.slug,
+					id: installedPlugin?.id,
+				} )
+			);
+		}
+	}, [ isMarketplacePluginFlow, installedPlugin, pluginActive, siteId, dispatch ] );
 
 	const canManagePlugins = useSelector( ( state ) => {
 		return siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS );


### PR DESCRIPTION
## Summary

- Adds a 1-minute timeout fallback on the marketplace plugin install page
- If the plugin polling hasn't resolved (plugin installed + active) within 60 seconds, redirects the user to the plugins page anyway
- Prevents users from being stuck indefinitely on the install loading screen

## Test plan

- [ ] Create a free site with the free plan
- [ ] Go to the plugin's page and select a marketplace plugin (e.g. sensei-pro)
- [ ] Purchase and upgrade, select the plan, go through checkout
- [ ] On the install screen, verify that if the plugin doesn't activate within 1 minute, you are redirected to the site's plugins page