### PR TITLE
agents-manager: translate: Add --jobs 4 argument to wp-babel-makepot

### DIFF
--- a/apps/agents-manager/package.json
+++ b/apps/agents-manager/package.json
@@ -27,7 +27,7 @@
 		"build:app": "calypso-build",
 		"dev": "yarn run calypso-apps-builder --localPath dist --remotePath /home/wpcom/public_html/widgets.wp.com/agents-manager",
 		"prepack": "yarn run clean && yarn run build",
-		"translate": "rm -rf dist/strings && wp-babel-makepot '../../{client,packages,apps}/**/*.{js,jsx,ts,tsx}' --ignore '**/node_modules/**,**/test/**,**/*.d.ts' --base '../../' --dir './dist/strings' --output './dist/agents-manager.pot' && node bin/merge-chunks-maps.js && build-app-languages --stringsFilePath='./dist/agents-manager.pot' --outputPath='./dist/languages' --outputFormat='JS'"
+		"translate": "rm -rf dist/strings && wp-babel-makepot '../../{client,packages,apps}/**/*.{js,jsx,ts,tsx}' --ignore '**/node_modules/**,**/test/**,**/*.d.ts' --base '../../' --dir './dist/strings' --jobs 4 --output './dist/agents-manager.pot' && node bin/merge-chunks-maps.js && build-app-languages --stringsFilePath='./dist/agents-manager.pot' --outputPath='./dist/languages' --outputFormat='JS'"
 	},
 	"dependencies": {
 		"@automattic/agents-manager": "workspace:^",


### PR DESCRIPTION

## Proposed Changes

* Now that wp-babel-makepot supports the `--jobs` argument (#109188), pass it `4` by default in agents-manager to speed up the translation. 

I didn't use `auto` because that uses (number of CPUS-1), and we build all the apps in parallel. If we put them all on auto, that might be a bit too many threads.

## Why are these changes being made?

*

## Testing Instructions

* Examine the files in ./dist/languages before and after this change, when running the app build. Should be the same.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
