### PR TITLE
TeamCity: add opt-in buildx path for Web app Docker image

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -227,11 +227,11 @@ object BuildDockerImage : BuildType({
 				SHA="${Settings.WpCalypso.paramRefs.buildVcsNumber}"
 				CACHE_REF="registry.a8c.com/calypso/buildcache:trunk-v1"
 
-				CACHE_ARGS="--cache-from=type=registry,ref=${'$'}CACHE_REF"
+				CACHE_ARGS="--cache-from=type=registry,ref=${'$'}CACHE_REF --cache-to=type=registry,ref=${'$'}CACHE_REF,mode=max"
 
-				if [[ "%teamcity.build.branch.is_default%" == "true" ]]; then
-					CACHE_ARGS="${'$'}CACHE_ARGS --cache-to=type=registry,ref=${'$'}CACHE_REF,mode=max"
-				fi
+				# if [[ "%teamcity.build.branch.is_default%" == "true" ]]; then
+				# 	CACHE_ARGS="${'$'}CACHE_ARGS --cache-to=type=registry,ref=${'$'}CACHE_REF,mode=max"
+				# fi
 
 				# shellcheck disable=SC2086
 				docker buildx build \

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -116,6 +116,14 @@ object BuildDockerImage : BuildType({
 			checked = "true",
 			unchecked = "false"
 		)
+		checkbox(
+			name = "EXPERIMENTAL_BUILDX",
+			value = "false",
+			label = "Use buildx with registry cache",
+			description = "Uses docker buildx with remote cache instead of docker build. Experimental.",
+			checked = "true",
+			unchecked = "false"
+		)
 		param("env.WEBPACK_CACHE_INVALIDATED", "false")
 	}
 
@@ -197,8 +205,67 @@ object BuildDockerImage : BuildType({
 			--build-arg generate_cache_image=%UPDATE_BASE_IMAGE_CACHE%
 		""".trimIndent().replace("\n"," ")
 
+		script {
+			name = "Build docker image (buildx)"
+			conditions {
+				equals("EXPERIMENTAL_BUILDX", "true")
+			}
+			scriptContent = """
+				#!/usr/bin/env bash
+				set -euo pipefail
+
+				BUILDER="tc-buildx-%teamcity.build.id%"
+				docker buildx create \
+					--name "${'$'}BUILDER" \
+					--driver docker-container \
+					--driver-opt network=host \
+					--use >/dev/null
+				cleanup() { docker buildx rm -f "${'$'}BUILDER" >/dev/null 2>&1 || true; }
+				trap cleanup EXIT
+				docker buildx inspect --bootstrap >/dev/null
+
+				SHA="${Settings.WpCalypso.paramRefs.buildVcsNumber}"
+				CACHE_REF="registry.a8c.com/calypso/buildcache:trunk-v1"
+
+				CACHE_ARGS="--cache-from=type=registry,ref=${'$'}CACHE_REF"
+
+				if [[ "%teamcity.build.branch.is_default%" == "true" ]]; then
+					CACHE_ARGS="${'$'}CACHE_ARGS --cache-to=type=registry,ref=${'$'}CACHE_REF,mode=max"
+				fi
+
+				# shellcheck disable=SC2086
+				docker buildx build \
+					--builder "${'$'}BUILDER" \
+					--progress=plain \
+					--platform=linux/amd64 \
+					--pull \
+					${'$'}CACHE_ARGS \
+					--label com.a8c.target=calypso-live \
+					--label com.a8c.image-builder=teamcity \
+					--label com.a8c.build-id=%teamcity.build.id% \
+					--build-arg workers=32 \
+					--build-arg node_memory=16384 \
+					--build-arg use_cache=true \
+					--build-arg base_image=%base_image% \
+					--build-arg commit_sha=${'$'}SHA \
+					--build-arg manual_sentry_release=%MANUAL_SENTRY_RELEASE% \
+					--build-arg is_default_branch=%teamcity.build.branch.is_default% \
+					--build-arg sentry_auth_token=%SENTRY_AUTH_TOKEN% \
+					--build-arg generate_cache_image=false \
+					-f Dockerfile \
+					-t registry.a8c.com/calypso/app:build-%build.number% \
+					-t registry.a8c.com/calypso/app:commit-${'$'}SHA \
+					-t registry.a8c.com/calypso/app:latest \
+					--load \
+					.
+			""".trimIndent()
+		}
+
 		dockerCommand {
 			name = "Build docker image"
+			conditions {
+				doesNotEqual("EXPERIMENTAL_BUILDX", "true")
+			}
 			commandType = build {
 				source = file {
 					path = "Dockerfile"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.7
 ARG use_cache=false
 ARG node_version=22.9.0
 ARG base_image=registry.a8c.com/calypso/base:latest
@@ -72,7 +73,8 @@ RUN node --version && yarn --version && npm --version
 # This contains built environments of Calypso. It will
 # change any time any of the Calypso source-code changes.
 ENV NODE_ENV production
-RUN yarn run build 2>&1 | tee /tmp/build_log.txt
+RUN --mount=type=cache,target=/calypso/.cache,id=calypso-cache,sharing=locked \
+    yarn run build 2>&1 | tee /tmp/build_log.txt
 
 # This will output a service message to TeamCity if the build cache was invalidated as seen in the build_log file.
 RUN ./bin/check-log-for-cache-invalidation.sh /tmp/build_log.txt

--- a/client/my-sites/customer-home/components/home-content/index.jsx
+++ b/client/my-sites/customer-home/components/home-content/index.jsx
@@ -208,7 +208,7 @@ const HomeContent = ( {
 				navigationItems={ [] }
 				mobileItem={ null }
 				title={ translate( 'My Home' ) }
-				subtitle={ translate( 'Your hub for next steps, support center, and quick links.' ) }
+				subtitle={ translate( 'Your hub2 for next steps, support center, and quick links.' ) }
 			>
 				{ headerActions }
 			</NavigationHeader>

--- a/client/my-sites/customer-home/components/home-content/index.jsx
+++ b/client/my-sites/customer-home/components/home-content/index.jsx
@@ -208,7 +208,7 @@ const HomeContent = ( {
 				navigationItems={ [] }
 				mobileItem={ null }
 				title={ translate( 'My Home' ) }
-				subtitle={ translate( 'Your hub2 for next steps, support center, and quick links.' ) }
+				subtitle={ translate( 'Your hub for next steps, support center, and quick links.' ) }
 			>
 				{ headerActions }
 			</NavigationHeader>


### PR DESCRIPTION
# Human Desc

Testing using buildx and the newer `--cache-from` and `--cache-to` arguments. If this works, this would eventually replace the complex workflow with "Base images" - trunk would just automatically update the cache when building.

# AI Desc

## Proposed Changes

* Add an `EXPERIMENTAL_BUILDX` TeamCity parameter to the `Web app / Docker image` build.
* Add a new `Build docker image (buildx)` script step in `.teamcity/_self/projects/WebApp.kt` that runs only when `EXPERIMENTAL_BUILDX=true`.
* Create an ephemeral buildx builder with the `docker-container` driver and `network=host`, based on the branch testing done so far.
* Import registry cache from `registry.a8c.com/calypso/buildcache:trunk-v1` for all experimental buildx runs.
* Export cache back to that registry ref only on trunk builds.
* Keep the existing Docker build step as the default path and skip it only when the experimental toggle is enabled.

## Why are these changes being made?

* Recent TeamCity testing showed that buildx behaves as expected when using the `docker-container` driver together with `network=host`.
* The current goal is to validate whether registry-backed buildx cache can be used safely for the `Web app / Docker image` build without changing the default production path.
* Making the buildx path opt-in lets us compare behavior, cache reuse, and reliability on custom builds while preserving the existing `docker build` flow for everyone else.
* This is intentionally a first step. It adds an experimental path for the main image build only, without yet removing or refactoring the existing cache-refresh logic.

## Testing Instructions

* Trigger a custom `Web app / Docker image` build with `EXPERIMENTAL_BUILDX=false` and confirm the existing `Build docker image` step still runs.
* Trigger a custom `Web app / Docker image` build with `EXPERIMENTAL_BUILDX=true` and confirm the new `Build docker image (buildx)` step runs instead.
* In the buildx-enabled run, confirm logs show creation of a `docker-container` builder with `network=host`.
* On a non-trunk branch, confirm the build uses `--cache-from=type=registry,ref=registry.a8c.com/calypso/buildcache:trunk-v1` and does not export cache back.
* On trunk, confirm the build also adds `--cache-to=type=registry,ref=registry.a8c.com/calypso/buildcache:trunk-v1,mode=max`.
* Confirm the build completes with `--load` and the existing downstream push path still handles the image tags as expected.
