### PR TITLE
Dashboard: Fix OAuth logout redirect destination

### DIFF
--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -10,8 +10,8 @@
 		"my.woo.localhost": {
 			"oauth_client_id": 134404,
 			"wpcom_login_url": false,
-			"logout_url": "http://my.woo.localhost:3000",
-			"features": { "oauth": true }
+			"logout_url": "https://woo.com",
+			"features": { "oauth": true, "always_use_logout_url": true }
 		}
 	},
 	"i18n_default_locale_slug": "en",

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -11,7 +11,7 @@
 			"oauth_client_id": 134405,
 			"wpcom_login_url": false,
 			"logout_url": "https://woo.com",
-			"features": { "oauth": true, "wpcom-user-bootstrap": false }
+			"features": { "oauth": true, "wpcom-user-bootstrap": false, "always_use_logout_url": true }
 		}
 	},
 	"i18n_default_locale_slug": "en",

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -11,7 +11,7 @@
 			"oauth_client_id": 134405,
 			"wpcom_login_url": false,
 			"logout_url": "https://woo.com",
-			"features": { "oauth": true, "wpcom-user-bootstrap": false }
+			"features": { "oauth": true, "wpcom-user-bootstrap": false, "always_use_logout_url": true }
 		}
 	},
 	"i18n_default_locale_slug": "en",

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -11,7 +11,7 @@
 			"oauth_client_id": 134405,
 			"wpcom_login_url": false,
 			"logout_url": "https://woo.com",
-			"features": { "oauth": true, "wpcom-user-bootstrap": false }
+			"features": { "oauth": true, "wpcom-user-bootstrap": false, "always_use_logout_url": true }
 		}
 	},
 	"i18n_default_locale_slug": "en",


### PR DESCRIPTION
Part of DOTMSD-1113

## Proposed Changes

* Enable `always_use_logout_url` in `my.woo.ai` / `my.woo.localhost` hostname overrides across all Dashboard configs (dev, horizon, stage, production)
* Update dev `logout_url` from `http://my.woo.localhost:3000` to `https://woo.com`

## Why are these changes being made?

When the Dashboard runs in OAuth mode (e.g. `my.woo.ai`), `logout()` needs to redirect to `woo.com` instead of using `user.logout_URL`. The `always_use_logout_url` flag forces `logout()` to use the config-provided `logout_url`. The existing `clearStore()` → `store.clearAll()` call already deletes the OAuth token from localStorage (https://github.com/Automattic/wp-calypso/blob/775195cce91b7732a6746985887bedb055eea8f0/client/dashboard/app/auth/index.tsx#L189), so no code changes are needed — only config.

## Testing Instructions

* Run `yarn start-dashboard` with `my.woo.localhost` hostname
* Log in via OAuth, then log out
* Verify redirect goes to `woo.com`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?