### PR TITLE
Dashboard: re-enable user bootstrap

### DIFF
--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -34,7 +34,8 @@
 		"marketplace-redesign": true,
 		"mcp-settings": true,
 		"wordpress-ai-tools": true,
-		"two-factor/enhanced-security": true
+		"two-factor/enhanced-security": true,
+		"wpcom-user-bootstrap": false
 	},
 	"enable_all_sections": false,
 	"site_filter": [],

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -11,7 +11,7 @@
 			"oauth_client_id": 134405,
 			"wpcom_login_url": false,
 			"logout_url": "https://woo.com",
-			"features": { "oauth": true }
+			"features": { "oauth": true, "wpcom-user-bootstrap": false }
 		}
 	},
 	"i18n_default_locale_slug": "en",
@@ -33,7 +33,8 @@
 		"marketplace-redesign": true,
 		"mcp-settings": true,
 		"wordpress-ai-tools": true,
-		"two-factor/enhanced-security": true
+		"two-factor/enhanced-security": true,
+		"wpcom-user-bootstrap": true
 	},
 	"enable_all_sections": false,
 	"site_filter": [],

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -11,7 +11,7 @@
 			"oauth_client_id": 134405,
 			"wpcom_login_url": false,
 			"logout_url": "https://woo.com",
-			"features": { "oauth": true }
+			"features": { "oauth": true, "wpcom-user-bootstrap": false }
 		}
 	},
 	"i18n_default_locale_slug": "en",
@@ -32,7 +32,8 @@
 		"marketplace-redesign": true,
 		"mcp-settings": true,
 		"wordpress-ai-tools": true,
-		"two-factor/enhanced-security": true
+		"two-factor/enhanced-security": true,
+		"wpcom-user-bootstrap": true
 	},
 	"enable_all_sections": false,
 	"site_filter": [],

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -11,7 +11,7 @@
 			"oauth_client_id": 134405,
 			"wpcom_login_url": false,
 			"logout_url": "https://woo.com",
-			"features": { "oauth": true }
+			"features": { "oauth": true, "wpcom-user-bootstrap": false }
 		}
 	},
 	"i18n_default_locale_slug": "en",
@@ -31,7 +31,8 @@
 		"marketplace-redesign": true,
 		"mcp-settings": true,
 		"wordpress-ai-tools": true,
-		"two-factor/enhanced-security": true
+		"two-factor/enhanced-security": true,
+		"wpcom-user-bootstrap": true
 	},
 	"enable_all_sections": false,
 	"site_filter": [],


### PR DESCRIPTION
## Proposed Changes

* Add `wpcom-user-bootstrap` feature flag to all dashboard configs
* Disable bootstrap for `my.woo.ai` via `hostname_overrides` (OAuth host can't bootstrap via cookies)

## Why are these changes being made?

User bootstrap was lost when the Dashboard moved from `wordpress.com/v2` to `my.wordpress.com`. The new dashboard configs never carried over the `wpcom-user-bootstrap` flag. Without it, the user object fetch happens client-side on the critical path, blocking page load. Re-enabling bootstrap lets the server fetch the user during SSR and embed it as `window.currentUser`, removing it from the hot path.

## Testing Instructions


**Locally**
You will need these instructions PCYsg-5YE-p2, but the steps are something like
* Create `config/secrets.json` file (you can copy paste the `empty-secrets.json` file)
* Put the `wpcom_calypso_rest_api_key` and `wordpress_logged_in_cookie` values in there
* Manually edit `config/dashboard-development.json`
	* Toggle `"wpcom-user-bootstrap"` to `true`
* Run `yarn start-dashboard` locally
* test `http://my.localhost:3000`
	* You will find there is a `window.currentUser` global that comes from the server
	* In the network tab, filtered by fetch requests, you should see that the initial blocking request to `/me` is not there.

**After Merging**
* Deploy to horizon, load `my.wordpress.com` dashboard — verify `window.currentUser` is populated on initial page load
* Load `my.woo.ai` dashboard — verify bootstrap is NOT used (OAuth flow)


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?