### PR TITLE
Help Center: Remove Survicate feedback survey integration

### DIFF
--- a/client/layout/help-center-loader.tsx
+++ b/client/layout/help-center-loader.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { HelpCenter } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { useBreakpoint } from '@automattic/viewport-react';
@@ -38,7 +37,6 @@ export default function HelpCenterLoader( { sectionName, loadHelpCenter, current
 	const selectedSite = useSelector( getSelectedSite );
 	const primarySiteSlug = useSelector( getPrimarySiteSlug );
 	const primarySite = useSelector( ( state ) => getSiteBySlug( state, primarySiteSlug ) );
-	const haveSurvicateEnabled = isEnabled( 'survicate_enabled_at_help_center' );
 
 	if ( ! loadHelpCenter ) {
 		return null;
@@ -68,7 +66,6 @@ export default function HelpCenterLoader( { sectionName, loadHelpCenter, current
 			site={ selectedSite || primarySite }
 			currentUser={ user }
 			hasPurchases={ hasPurchases }
-			haveSurvicateEnabled={ haveSurvicateEnabled }
 			// hide Calypso's version of the help-center on Desktop, because the Editor has its own help-center
 			hidden={ sectionName === 'gutenberg-editor' && isDesktop }
 			onboardingUrl={ onboardingUrl() }

--- a/client/lib/analytics/survicate.js
+++ b/client/lib/analytics/survicate.js
@@ -44,35 +44,3 @@ export function addSurvicate( { email, registrationDate } ) {
 		.then( () => setTraits() )
 		.catch( () => {} );
 }
-
-/**
- * Triggers the Help Center feedback survey and ensures the Survicate overlay
- * closes when the user clicks outside the modal.
- * This is needed as the Survicate overlay click doesn't close correctly.
- * See: https://a8c.slack.com/archives/C04H4NY6STW/p1766088738895199?thread_ts=1765290523.386849&cid=C04H4NY6STW
- */
-export function showHelpCenterFeedbackSurvey() {
-	const survicate = window._sva;
-
-	if ( ! survicate?.invokeEvent ) {
-		return;
-	}
-
-	const handleSurveyDisplayed = () => {
-		const overlay = document.querySelector( '#survicate-box .sv__overlay' );
-
-		if ( ! overlay ) {
-			return;
-		}
-
-		const handleOverlayClick = () => {
-			survicate.destroyVisitor?.();
-		};
-
-		overlay.addEventListener( 'click', handleOverlayClick, { once: true } );
-		survicate.removeEventListener?.( 'survey_displayed', handleSurveyDisplayed );
-	};
-
-	survicate.addEventListener?.( 'survey_displayed', handleSurveyDisplayed );
-	survicate.invokeEvent( 'showFeedbackSurveyFromHelpCenter' );
-}

--- a/client/lib/analytics/test/survicate.js
+++ b/client/lib/analytics/test/survicate.js
@@ -26,10 +26,6 @@ jest.mock( 'calypso/lib/i18n-utils', () => ( {
 	getLocaleSlug: jest.fn(),
 } ) );
 
-jest.mock( '@automattic/i18n-utils', () => ( {
-	localizeUrl: ( url ) => url,
-} ) );
-
 jest.mock( '@automattic/survicate', () => ( {
 	shouldLoadSurvicate: jest.fn(),
 	loadSurvicateScript: jest.fn(),
@@ -39,15 +35,7 @@ jest.mock( '@automattic/survicate', () => ( {
 	SURVICATE_WORKSPACE_ID: 'test-workspace-id',
 } ) );
 
-jest.mock( '@wordpress/react-i18n', () => ( {
-	useI18n: () => ( {
-		__: ( text ) => text,
-	} ),
-} ) );
-
-jest.mock( 'react-router-dom', () => ( {
-	useNavigate: () => jest.fn(),
-} ) );
+jest.mock( 'debug', () => () => jest.fn() );
 
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
@@ -59,12 +47,7 @@ import {
 	getAccountAgeInDays,
 } from '@automattic/survicate';
 import { isMobile } from '@automattic/viewport';
-import { render } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import React from 'react';
 import { getLocaleSlug } from 'calypso/lib/i18n-utils';
-import { HelpCenterMoreResources } from '../../../../packages/help-center/src/components/help-center-more-resources';
-import { HelpCenterRequiredContextProvider } from '../../../../packages/help-center/src/contexts/HelpCenterContext';
 
 const flushPromises = () => new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
 
@@ -220,145 +203,3 @@ describe( 'survicate', () => {
 	} );
 } );
 
-describe( 'HelpCenterMoreResources', () => {
-	let showHelpCenterFeedbackSurvey;
-	const renderComponent = ( contextValue = {} ) =>
-		render(
-			<HelpCenterRequiredContextProvider
-				value={ {
-					sectionName: 'test-section',
-					...contextValue,
-				} }
-			>
-				<HelpCenterMoreResources />
-			</HelpCenterRequiredContextProvider>
-		);
-
-	beforeEach( () => {
-		delete window._sva;
-		recordTracksEvent.mockClear();
-		// Set up fresh module imports
-		jest.isolateModules( () => {
-			const survicateModule = require( 'calypso/lib/analytics/survicate' );
-			showHelpCenterFeedbackSurvey = survicateModule.showHelpCenterFeedbackSurvey;
-		} );
-	} );
-
-	afterEach( () => {
-		delete window._sva;
-	} );
-
-	test( 'does not render feedback button when survicate is disabled', () => {
-		const { queryByRole } = renderComponent( { haveSurvicateEnabled: false } );
-
-		expect(
-			queryByRole( 'button', {
-				name: 'Share feedback',
-			} )
-		).toBeNull();
-	} );
-
-	test( 'does not render feedback button when survicate widget is unavailable', () => {
-		const { queryByRole } = renderComponent( { haveSurvicateEnabled: true } );
-
-		expect(
-			queryByRole( 'button', {
-				name: 'Share feedback',
-			} )
-		).toBeNull();
-	} );
-
-	test( 'renders feedback button and triggers survicate event when available', async () => {
-		const invokeEvent = jest.fn();
-		const addEventListener = jest.fn();
-		const removeEventListener = jest.fn();
-		const destroyVisitor = jest.fn();
-
-		window._sva = {
-			invokeEvent,
-			addEventListener,
-			removeEventListener,
-			destroyVisitor,
-		};
-
-		const { queryByRole } = renderComponent( { haveSurvicateEnabled: true } );
-		const button = queryByRole( 'button', {
-			name: 'Share feedback',
-		} );
-
-		expect( button ).not.toBeNull();
-
-		const user = userEvent.setup();
-		if ( button ) {
-			await user.click( button );
-		}
-
-		expect( invokeEvent ).toHaveBeenCalledWith( 'showFeedbackSurveyFromHelpCenter' );
-		expect( recordTracksEvent ).toHaveBeenCalledWith(
-			'calypso_help_moreresources_click',
-			expect.objectContaining( {
-				resource: 'feedback-survey',
-				section: 'test-section',
-			} )
-		);
-	} );
-
-	test( 'does not invoke events when _sva is unavailable', () => {
-		delete window._sva;
-
-		// Should exit early without errors
-		expect( () => showHelpCenterFeedbackSurvey() ).not.toThrow();
-	} );
-
-	test( 'invokes Survicate event and wires overlay click to destroy visitor', () => {
-		const overlay = document.createElement( 'div' );
-		overlay.className = 'sv__overlay sv__overlay--dark';
-
-		const overlayAddEventListener = jest.fn();
-
-		overlay.addEventListener = overlayAddEventListener;
-		document.body.appendChild( overlay );
-
-		let surveyDisplayedHandler;
-		const invokeEvent = jest.fn();
-		const destroyVisitor = jest.fn();
-		const removeEventListener = jest.fn();
-		const addEventListener = jest.fn( ( event, handler ) => {
-			if ( event === 'survey_displayed' ) {
-				surveyDisplayedHandler = handler;
-			}
-		} );
-
-		document.querySelector = jest.fn( () => overlay );
-
-		window._sva = {
-			addEventListener,
-			removeEventListener,
-			invokeEvent,
-			destroyVisitor,
-		};
-
-		showHelpCenterFeedbackSurvey();
-
-		expect( addEventListener ).toHaveBeenCalled();
-		expect( typeof surveyDisplayedHandler ).toBe( 'function' );
-		expect( invokeEvent ).toHaveBeenCalledWith( 'showFeedbackSurveyFromHelpCenter' );
-
-		// Simulate Survicate emitting the survey display event
-		surveyDisplayedHandler?.();
-
-		expect( overlayAddEventListener ).toHaveBeenCalled();
-		const [ overlayCall ] = overlayAddEventListener.mock.calls;
-		expect( overlayCall?.[ 0 ] ).toBe( 'click' );
-		expect( typeof overlayCall?.[ 1 ] ).toBe( 'function' );
-		expect( overlayCall?.[ 2 ] ).toEqual( { once: true } );
-
-		overlayCall?.[ 1 ]?.();
-
-		expect( destroyVisitor ).toHaveBeenCalled();
-		expect( removeEventListener ).toHaveBeenCalled();
-		const [ removeCall ] = removeEventListener.mock.calls;
-		expect( removeCall?.[ 0 ] ).toBe( 'survey_displayed' );
-		expect( removeCall?.[ 1 ] ).toBe( surveyDisplayedHandler );
-	} );
-} );

--- a/client/lib/analytics/test/survicate.js
+++ b/client/lib/analytics/test/survicate.js
@@ -3,10 +3,6 @@
  */
 
 // Mock dependencies before importing the module
-jest.mock( '@automattic/calypso-analytics', () => ( {
-	recordTracksEvent: jest.fn(),
-} ) );
-
 jest.mock( '@automattic/calypso-config', () => {
 	const config = jest.fn();
 
@@ -35,9 +31,9 @@ jest.mock( '@automattic/survicate', () => ( {
 	SURVICATE_WORKSPACE_ID: 'test-workspace-id',
 } ) );
 
+// Mock debug module used transitively by calypso-config.
 jest.mock( 'debug', () => () => jest.fn() );
 
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import {
 	shouldLoadSurvicate,
@@ -70,12 +66,6 @@ describe( 'survicate', () => {
 			mayWeLoadSurvicateScript = survicateModule.mayWeLoadSurvicateScript;
 			addSurvicate = survicateModule.addSurvicate;
 		} );
-	} );
-
-	afterAll( () => {
-		// Clean up document and window objects
-		document.body.innerHTML = '';
-		window.location = null;
 	} );
 
 	describe( 'mayWeLoadSurvicateScript', () => {
@@ -202,4 +192,3 @@ describe( 'survicate', () => {
 		} );
 	} );
 } );
-

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -11,7 +11,6 @@
 	"google_recaptcha_site_key": false,
 	"hotjar_enabled": false,
 	"survicate_enabled": false,
-	"survicate_enabled_at_help_center": true,
 	"hostname": false,
 	"hostname_allowlist": false,
 	"hostname_overrides": false,

--- a/config/development.json
+++ b/config/development.json
@@ -196,7 +196,6 @@
 		"stats/paid-wpcom-v3": true,
 		"stats/real-time-tab": true,
 		"subscriber-importer": true,
-		"survicate_enabled_at_help_center": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -121,7 +121,6 @@
 		"stats/paid-wpcom-v2": true,
 		"stats/real-time-tab": false,
 		"subscriber-importer": true,
-		"survicate_enabled_at_help_center": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,

--- a/config/production.json
+++ b/config/production.json
@@ -159,7 +159,6 @@
 		"stats/paid-wpcom-v3": true,
 		"stats/real-time-tab": false,
 		"subscriber-importer": true,
-		"survicate_enabled_at_help_center": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -158,7 +158,6 @@
 		"stats/paid-wpcom-v3": true,
 		"stats/real-time-tab": false,
 		"subscriber-importer": true,
-		"survicate_enabled_at_help_center": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,

--- a/packages/help-center/src/components/help-center-more-resources.tsx
+++ b/packages/help-center/src/components/help-center-more-resources.tsx
@@ -1,11 +1,9 @@
-/* eslint-disable no-restricted-imports */
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { backup, chevronRight, external, Icon, page, rss, thumbsUp, video } from '@wordpress/icons';
+import { backup, chevronRight, external, Icon, page, rss, video } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useNavigate } from 'react-router-dom';
-import { showHelpCenterFeedbackSurvey } from 'calypso/lib/analytics/survicate';
 import { useFeatureConfig, useHelpCenterContext } from '../contexts/HelpCenterContext';
 
 import './help-center-more-resources.scss';
@@ -75,26 +73,6 @@ export const HelpCenterMoreResources = () => {
 						</div>
 					</li>
 				) }
-				{ featureConfig.moreResources.feedback &&
-					typeof window._sva !== 'undefined' &&
-					window._sva?.invokeEvent && (
-						<li className="help-center-more-resources__resource-item help-center-link__item">
-							<div className="help-center-more-resources__resource-cell help-center-link__cell">
-								<button
-									type="button"
-									onClick={ () => {
-										trackMoreResourcesButtonClick( 'feedback-survey' );
-										showHelpCenterFeedbackSurvey();
-									} }
-									className="help-center-more-resources__survicate"
-								>
-									<Icon icon={ thumbsUp } size={ 24 } />
-									<span>{ __( 'Share feedback', __i18n_text_domain__ ) }</span>
-									<Icon icon={ chevronRight } size={ 20 } />
-								</button>
-							</div>
-						</li>
-					) }
 				{ featureConfig.moreResources.courses && (
 					<li className="help-center-more-resources__resource-item help-center-link__item">
 						<div className="help-center-more-resources__resource-cell help-center-link__cell">

--- a/packages/help-center/src/components/types.d.ts
+++ b/packages/help-center/src/components/types.d.ts
@@ -8,9 +8,6 @@ interface Window {
 			| ( ( callback: ( data: string | number ) => void ) => void )
 			| { id: number; value: string }[]
 	) => void;
-	_sva?: {
-		invokeEvent?: ( eventName: string ) => void;
-	};
 }
 
 declare module '*.jpg';

--- a/packages/help-center/src/contexts/HelpCenterContext.tsx
+++ b/packages/help-center/src/contexts/HelpCenterContext.tsx
@@ -21,7 +21,6 @@ export type HelpCenterRequiredInformation = {
 		id: number;
 		pressableId?: number;
 	} | null;
-	haveSurvicateEnabled: boolean;
 	/**
 	 * Product identifier. Defaults to 'wpcom' when omitted.
 	 */
@@ -75,7 +74,6 @@ const defaultContext: HelpCenterRequiredInformation = {
 	googleMailServiceFamily: '',
 	onboardingUrl: '',
 	agency: null,
-	haveSurvicateEnabled: false,
 };
 
 const HelpCenterRequiredContext = createContext< HelpCenterRequiredInformation >( defaultContext );
@@ -105,16 +103,9 @@ export function useHelpCenterContext() {
  * Defaults to the 'wpcom' product when no product is specified.
  */
 export function useFeatureConfig(): HelpCenterFeatureConfig {
-	const { product = 'wpcom', haveSurvicateEnabled } = useHelpCenterContext();
+	const { product = 'wpcom' } = useHelpCenterContext();
 
 	return useMemo( () => {
-		const preset = PRODUCT_PRESETS[ product ];
-		return {
-			...preset,
-			moreResources: {
-				...preset.moreResources,
-				feedback: preset.moreResources.feedback && haveSurvicateEnabled,
-			},
-		};
-	}, [ product, haveSurvicateEnabled ] );
+		return PRODUCT_PRESETS[ product ];
+	}, [ product ] );
 }

--- a/packages/help-center/src/feature-config/presets.ts
+++ b/packages/help-center/src/feature-config/presets.ts
@@ -20,7 +20,6 @@ const wpcomPreset: HelpCenterFeatureConfig = {
 		supportHistory: true,
 		courses: true,
 		productUpdates: true,
-		feedback: true,
 		supportGuidesUrl: null,
 	},
 	contactForm: {
@@ -48,7 +47,6 @@ const a4aPreset: HelpCenterFeatureConfig = {
 		supportHistory: false,
 		courses: true,
 		productUpdates: true,
-		feedback: false,
 		supportGuidesUrl: null,
 	},
 	contactForm: {
@@ -76,7 +74,6 @@ const commerceGardenPreset: HelpCenterFeatureConfig = {
 		supportHistory: true,
 		courses: false,
 		productUpdates: false,
-		feedback: true,
 		supportGuidesUrl: 'https://ciabattasupportguides.wpcomstaging.com/',
 	},
 	contactForm: {

--- a/packages/help-center/src/feature-config/types.ts
+++ b/packages/help-center/src/feature-config/types.ts
@@ -32,8 +32,6 @@ export type HelpCenterFeatureConfig = {
 		courses: boolean;
 		/** Show the "Product updates" external link. */
 		productUpdates: boolean;
-		/** Show the "Share feedback" Survicate button. */
-		feedback: boolean;
 		/** URL for the "Support guides" external link. Null to hide. */
 		supportGuidesUrl: string | null;
 	};


### PR DESCRIPTION
Task-related: DOTCOM-16327

## Proposed Changes

* Remove the "Share feedback" button from the Help Center's More Resources section
* Remove the `haveSurvicateEnabled` context prop and feature flag plumbing
* Remove the `feedback` field from the feature config type and all product presets

| Before | After |
|--------|--------|
| <img width="1502" height="1001" alt="image" src="https://github.com/user-attachments/assets/d091d994-5e62-472a-affa-4ca4695c6262" /> | <img width="1500" height="999" alt="image" src="https://github.com/user-attachments/assets/01a07a21-3365-4022-9a3e-67d8f11e93c2" /> | 

## Why are these changes being made?

Survicate is no longer needed in the Help Center as we're using targeted events to have a better conversion. This cleans up the integration — the feedback survey button, the `survicate_enabled_at_help_center` config flag, and all related context/type plumbing.

## Testing Instructions

### Calypso

1. Run `yarn start`.
2. Open the Help Center and navigate to "More resources".
3. Verify the "Share feedback" button is no longer shown.
4. Verify the remaining resources (Support history, Courses, Product updates) still render correctly.

### Simple/Atomic/CIAB

1. Sandbox `widgets.wp.com`.
2. Run `cd apps/help-center && yarn dev --sync`.
3. Visit any Simple, Atomic, or CIAB site.
4. Open the Help Center and verify the "Share feedback" button is gone and other resources render correctly.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)