### PR TITLE
Survicate: Fire migrationStarted and migrationCompleted events for site migrations

### DIFF
--- a/client/dashboard/sites/migration-overview/started-difm-content-info.tsx
+++ b/client/dashboard/sites/migration-overview/started-difm-content-info.tsx
@@ -1,4 +1,5 @@
 import { siteMigrationZendeskTicketQuery, cancelSiteMigrationQuery } from '@automattic/api-queries';
+import { invokeSurvicateEvent } from '@automattic/survicate';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import {
@@ -12,7 +13,7 @@ import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { globe, group, scheduled } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
-import { Fragment, useState } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody, CardDivider } from '../../components/card';
@@ -116,6 +117,11 @@ function CancellationModal( { site, onClose }: { site: Site; onClose: () => void
 
 export function StartedDIFMContentInfo( { site }: { site: Site } ) {
 	const { recordTracksEvent } = useAnalytics();
+
+	useEffect( () => {
+		invokeSurvicateEvent( 'migrationStarted' );
+	}, [] );
+
 	const [ isCancellationModalOpen, setIsCancellationModalOpen ] = useState( false );
 	const { data: ticketId } = useQuery( {
 		...siteMigrationZendeskTicketQuery( site.ID ),

--- a/client/dashboard/sites/migration-overview/started-difm-content-info.tsx
+++ b/client/dashboard/sites/migration-overview/started-difm-content-info.tsx
@@ -118,9 +118,7 @@ function CancellationModal( { site, onClose }: { site: Site; onClose: () => void
 export function StartedDIFMContentInfo( { site }: { site: Site } ) {
 	const { recordTracksEvent } = useAnalytics();
 
-	useEffect( () => {
-		invokeSurvicateEvent( 'migrationStarted' );
-	}, [] );
+	useEffect( () => invokeSurvicateEvent( 'migrationStarted' ), [] );
 
 	const [ isCancellationModalOpen, setIsCancellationModalOpen ] = useState( false );
 	const { data: ticketId } = useQuery( {

--- a/client/dashboard/sites/ssh-migration-complete/index.tsx
+++ b/client/dashboard/sites/ssh-migration-complete/index.tsx
@@ -1,8 +1,10 @@
 import { siteBySlugQuery } from '@automattic/api-queries';
+import { invokeSurvicateEvent } from '@automattic/survicate';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack, Button, ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { useEffect } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
@@ -17,6 +19,11 @@ export default function SSHMigrationComplete( { siteSlug }: { siteSlug: string }
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 
 	const { recordTracksEvent } = useAnalytics();
+
+	useEffect( () => {
+		invokeSurvicateEvent( 'migrationCompleted' );
+	}, [] );
+
 	const sourceSiteDomain = site.options?.migration_source_site_domain;
 	const siteDomain = sourceSiteDomain?.replace( /^https?:\/\/|\/+$/g, '' );
 

--- a/client/dashboard/sites/ssh-migration-complete/index.tsx
+++ b/client/dashboard/sites/ssh-migration-complete/index.tsx
@@ -20,9 +20,7 @@ export default function SSHMigrationComplete( { siteSlug }: { siteSlug: string }
 
 	const { recordTracksEvent } = useAnalytics();
 
-	useEffect( () => {
-		invokeSurvicateEvent( 'migrationCompleted' );
-	}, [] );
+	useEffect( () => invokeSurvicateEvent( 'migrationCompleted' ), [] );
 
 	const sourceSiteDomain = site.options?.migration_source_site_domain;
 	const siteDomain = sourceSiteDomain?.replace( /^https?:\/\/|\/+$/g, '' );

--- a/client/sites/overview/components/migration-overview/components/migration-ssh-complete.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-ssh-complete.tsx
@@ -1,5 +1,7 @@
+import { invokeSurvicateEvent } from '@automattic/survicate';
 import { Button, ExternalLink } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import { HostingCard } from 'calypso/components/hosting-card';
 import { HostingHeroButton } from 'calypso/components/hosting-hero';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -9,6 +11,11 @@ import type { SiteDetails } from '@automattic/data-stores';
 
 export const MigrationSSHComplete = ( { site }: { site: SiteDetails } ) => {
 	const translate = useTranslate();
+
+	useEffect( () => {
+		invokeSurvicateEvent( 'migrationCompleted' );
+	}, [] );
+
 	const sourceSiteDomain = site?.options?.migration_source_site_domain
 		? urlToDomain( site.options.migration_source_site_domain )
 		: null;

--- a/client/sites/overview/components/migration-overview/components/migration-ssh-complete.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-ssh-complete.tsx
@@ -12,9 +12,7 @@ import type { SiteDetails } from '@automattic/data-stores';
 export const MigrationSSHComplete = ( { site }: { site: SiteDetails } ) => {
 	const translate = useTranslate();
 
-	useEffect( () => {
-		invokeSurvicateEvent( 'migrationCompleted' );
-	}, [] );
+	useEffect( () => invokeSurvicateEvent( 'migrationCompleted' ), [] );
 
 	const sourceSiteDomain = site?.options?.migration_source_site_domain
 		? urlToDomain( site.options.migration_source_site_domain )

--- a/packages/survicate/src/invoke-event.ts
+++ b/packages/survicate/src/invoke-event.ts
@@ -1,7 +1,24 @@
-export function invokeSurvicateEvent( eventName: string ): boolean {
+/**
+ * Invokes a Survicate event by name.
+ * If the SDK is already loaded, fires immediately. Otherwise waits for the
+ * `SurvicateReady` window event before invoking.
+ * @returns A cleanup function that removes the event listener.
+ */
+export function invokeSurvicateEvent( eventName: string ): () => void {
 	if ( typeof window._sva !== 'undefined' && window._sva.invokeEvent ) {
 		window._sva.invokeEvent( eventName );
-		return true;
+		return () => {};
 	}
-	return false;
+
+	const handler = () => {
+		if ( typeof window._sva !== 'undefined' && window._sva.invokeEvent ) {
+			window._sva.invokeEvent( eventName );
+		}
+	};
+
+	window.addEventListener( 'SurvicateReady', handler, { once: true } );
+
+	return () => {
+		window.removeEventListener( 'SurvicateReady', handler );
+	};
 }

--- a/packages/survicate/src/test/invoke-event.test.ts
+++ b/packages/survicate/src/test/invoke-event.test.ts
@@ -13,30 +13,76 @@ describe( 'invokeSurvicateEvent', () => {
 		window._sva = undefined;
 	} );
 
-	test( 'should return true and call invokeEvent when window._sva.invokeEvent exists', () => {
+	test( 'should call invokeEvent immediately when window._sva.invokeEvent exists', () => {
 		const invokeEvent = jest.fn();
 		window._sva = { invokeEvent };
 
-		const result = invokeSurvicateEvent( 'testEvent' );
+		invokeSurvicateEvent( 'testEvent' );
 
-		expect( result ).toBe( true );
 		expect( invokeEvent ).toHaveBeenCalledWith( 'testEvent' );
 	} );
 
-	test( 'should return false when window._sva is undefined', () => {
-		window._sva = undefined;
+	test( 'should return a cleanup function', () => {
+		const cleanup = invokeSurvicateEvent( 'testEvent' );
 
-		const result = invokeSurvicateEvent( 'testEvent' );
-
-		expect( result ).toBe( false );
+		expect( typeof cleanup ).toBe( 'function' );
 	} );
 
-	test( 'should return false when invokeEvent is not available on _sva', () => {
+	test( 'should invoke event when SurvicateReady fires and SDK was not ready initially', () => {
+		const invokeEvent = jest.fn();
+		window._sva = undefined;
+
+		invokeSurvicateEvent( 'testEvent' );
+
+		expect( invokeEvent ).not.toHaveBeenCalled();
+
+		window._sva = { invokeEvent };
+		window.dispatchEvent( new Event( 'SurvicateReady' ) );
+
+		expect( invokeEvent ).toHaveBeenCalledWith( 'testEvent' );
+	} );
+
+	test( 'should not invoke event when cleanup is called before SurvicateReady', () => {
+		const invokeEvent = jest.fn();
+
+		const cleanup = invokeSurvicateEvent( 'testEvent' );
+
+		cleanup();
+
+		window._sva = { invokeEvent };
+		window.dispatchEvent( new Event( 'SurvicateReady' ) );
+
+		expect( invokeEvent ).not.toHaveBeenCalled();
+	} );
+
+	test( 'should only invoke once even if SurvicateReady fires multiple times', () => {
+		const invokeEvent = jest.fn();
+		window._sva = undefined;
+
+		invokeSurvicateEvent( 'testEvent' );
+
+		window._sva = { invokeEvent };
+		window.dispatchEvent( new Event( 'SurvicateReady' ) );
+		window.dispatchEvent( new Event( 'SurvicateReady' ) );
+
+		expect( invokeEvent ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'should not throw when _sva is undefined at SurvicateReady time', () => {
+		window._sva = undefined;
+
+		invokeSurvicateEvent( 'testEvent' );
+
+		expect( () => window.dispatchEvent( new Event( 'SurvicateReady' ) ) ).not.toThrow();
+	} );
+
+	test( 'should not throw when invokeEvent is not available on _sva at SurvicateReady time', () => {
+		window._sva = undefined;
+
+		invokeSurvicateEvent( 'testEvent' );
+
 		window._sva = {};
-
-		const result = invokeSurvicateEvent( 'testEvent' );
-
-		expect( result ).toBe( false );
+		expect( () => window.dispatchEvent( new Event( 'SurvicateReady' ) ) ).not.toThrow();
 	} );
 
 	test( 'should not throw in any case', () => {


### PR DESCRIPTION
Part of DOTCOM-15996

## Proposed Changes

* Add `migrationStarted` event for sites for the "Add new site" > "Migrate to WordPress.com" flow
* Add `migrationCompleted` to the Dashboard migration completion page
* Add `migrationCompleted` to the Calypso migration completion page
* Modified `packages/survicate/src/invoke-event.ts` to fire after the Survicate was loaded

## Why are these changes being made?

There are currently no Survicate events for migrations. This helps us to offer targeted surveys for when a migration starts and when it ends.

## Testing Instructions

**Note**: Remember to add the `test_survey=true` parameter to validate it.

* Navigate to the migration completion page (Dashboard or legacy Calypso) and check for the event `migrationCompleted`:

	http://my.localhost:3000/sites/{siteDomain}/ssh-migration-complete?test_survey=true
	
	<img width="1505" height="1175" alt="image" src="https://github.com/user-attachments/assets/fe6c49dc-7136-404b-a890-92ab244720a3" />


	http://calypso.localhost:3000/sites/{siteDomain}?ssh-migration=completed&test_survey=true

	<img width="1505" height="783" alt="image" src="https://github.com/user-attachments/assets/8c731eba-340a-4c56-90c7-5f97cba95ecf" />


* Start a new migration at the "Add new site" > "Migrate to WordPress.com" flow, to make sure we fire the `migrationStarted` event:

	http://my.localhost:3000/sites/{siteDomain}/migration-overview?test_survey=true

	<img width="1506" height="1200" alt="image" src="https://github.com/user-attachments/assets/6c837219-1af8-48c9-9e2c-020af45c64da" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)