### PR TITLE
MSD: point primary domain selector upsell to distractionless plans grid

### DIFF
--- a/client/dashboard/sites/domains/primary-domain-selector.tsx
+++ b/client/dashboard/sites/domains/primary-domain-selector.tsx
@@ -16,13 +16,15 @@ import {
 import { DataForm } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 import { useState, useMemo } from 'react';
 import { useAnalytics } from '../../app/analytics';
-import ComponentViewTracker from '../../components/component-view-tracker';
 import InlineSupportLink from '../../components/inline-support-link';
 import { Notice } from '../../components/notice';
-import { wpcomLink } from '../../utils/link';
+import UpsellCTAButton from '../../components/upsell-cta-button';
+import { redirectToDashboardLink, wpcomLink } from '../../utils/link';
 import { userHasFlag } from '../../utils/user';
+import { isSitePlanWooHosted } from '../plans';
 import type { Field } from '@wordpress/dataviews';
 
 interface PrimaryDomainSelectorProps {
@@ -110,15 +112,22 @@ const PrimaryDomainSelector = ( { domains, site, user }: PrimaryDomainSelectorPr
 
 	const renderMessage = () => {
 		if ( ! canUserSetPrimaryDomainOnThisSite ) {
+			const upgradeLink = isSitePlanWooHosted( site )
+				? wpcomLink( '/setup/woo-hosted-plans' )
+				: wpcomLink( '/setup/plan-upgrade' );
+			const backUrl = redirectToDashboardLink();
 			const message = createInterpolateElement(
 				'Your site plan doesn’t allow you to set a custom domain as a primary site address.<br/><upgradeLink>Upgrade to an annual paid plan</upgradeLink> and get a free one-year domain name registration or transfer. <learnMoreLink />',
 				{
 					upgradeLink: (
-						<a
-							href={ wpcomLink( `/plans/${ site.slug }` ) }
-							onClick={ () => {
-								recordTracksEvent( 'calypso_dashboard_primary_domain_selector_upgrade_link_click' );
-							} }
+						<UpsellCTAButton
+							variant="link"
+							href={ addQueryArgs( upgradeLink, {
+								siteSlug: site.slug,
+								cancel_to: backUrl,
+							} ) }
+							upsellId="site-domains-primary-domain-selector"
+							upsellFeatureId="domain"
 						/>
 					),
 					br: <br />,
@@ -126,12 +135,7 @@ const PrimaryDomainSelector = ( { domains, site, user }: PrimaryDomainSelectorPr
 				}
 			);
 
-			return (
-				<>
-					<ComponentViewTracker eventName="calypso_dashboard_primary_domain_selector_upgrade_link_impression" />
-					{ message }
-				</>
-			);
+			return message;
 		}
 
 		if ( domainsList.length === 0 ) {


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/109199#issuecomment-4045428963
Similar to https://github.com/Automattic/wp-calypso/pull/106553
More context on DOTCOM-14978

## Proposed Changes

This PR updates the following `Upgrade to an annual paid plan` upsell CTA to point to `/setup/plan-upgrade` instead of `wordpress.com/plans/:slug`.

<img width="636" height="225" alt="image" src="https://github.com/user-attachments/assets/7fabc720-dc22-4f72-adf0-3da4717cfd4d" />

I also replaced the link with the existing `<UpsellCTAButton>` component so that the upsell Tracks event props are recorded consistently. Also this component fires impression event automatically already.

## Why are these changes being made?

For consistency with the other upsells.

Basically we don't want to jump from MSD and Calypso old nav unification (my-sites) pages back-and-forth.

## Testing Instructions

1. Go to `/sites/:siteSlug/domains` of a Free site 
2. Click the upsell as shown above
3. Verify you land in the distraction-free plans grid.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
