### PR TITLE
Theme Showcase: Restore the "Contact support" card for partner themes

### DIFF
--- a/client/my-sites/theme/theme-support-tab/index.jsx
+++ b/client/my-sites/theme/theme-support-tab/index.jsx
@@ -82,7 +82,7 @@ export default function ThemeSupportTab( { themeId } ) {
 						</Button>
 					</Card>
 
-					{ themeTier?.slug === 'community' || themeTier?.slug === 'partner' ? (
+					{ themeTier?.slug === 'community' ? (
 						<Card className="theme__sheet-card-support">
 							<Gridicon icon="notice-outline" size={ 48 } />
 							<div className="theme__sheet-card-support-details">


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTMKT-25

## Proposed Changes

* Restore the "Contact support" card for partner themes.

| Before | After |
|--------|--------|
| <img width="689" height="373" alt="Screenshot 2026-03-13 at 10 31 55" src="https://github.com/user-attachments/assets/ee62ca3b-8bc7-4d96-88e9-d31a371b04fc" /> | <img width="689" height="373" alt="Screenshot 2026-03-13 at 10 32 04" src="https://github.com/user-attachments/assets/6a783489-b3fa-4f1a-bf6b-6f074c96ab14" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Partner themes are purchased from WordPress.com. While we technically don't support them directly, we can at least point users to the right place. Without the "Contact support" card, this is not possible (or not straightforward).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log in to WordPress.com (the card is only displayed for logged-in users).
* Navigate to a Partner theme, e.g. `/theme/organic-stax`.
* Scroll to the bottom of the theme description.
* Confirm the "Contact support" card is displayed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
