### PR TITLE
Email forwarding: Replace any types in email forward mutation hooks

### DIFF
--- a/client/data/emails/types.ts
+++ b/client/data/emails/types.ts
@@ -95,6 +95,7 @@ export type DomainsQueryData = {
 };
 
 // Response from the `/domains/${ domain }/email/new` API endpoint
-export type AddEmailForwardResponse = {
+export type AddEmailForwardResponse = Array< {
 	created: boolean;
-};
+	verified: boolean;
+} >;

--- a/client/data/emails/types.ts
+++ b/client/data/emails/types.ts
@@ -77,3 +77,24 @@ export type Mailbox = {
 	temporary?: boolean;
 	target: string;
 };
+
+// Raw shape of a domain entry in the `/sites/${ siteId }/domains` API response
+type RawDomain = {
+	domain: string;
+	email_forwards_count: number;
+};
+
+// Raw query cache shape for the email accounts query (`useGetEmailAccountsQuery`)
+export type EmailAccountsQueryData = {
+	accounts: EmailAccount[];
+};
+
+// Raw query cache shape for the domains query (`useGetDomainsQuery`)
+export type DomainsQueryData = {
+	domains: RawDomain[];
+};
+
+// Response from the `/domains/${ domain }/email/new` API endpoint
+export type AddEmailForwardResponse = {
+	created: boolean;
+};

--- a/client/data/emails/use-add-email-forward-mutation.tsx
+++ b/client/data/emails/use-add-email-forward-mutation.tsx
@@ -8,7 +8,12 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getCacheKey as getEmailAccountsQueryKey } from './use-get-email-accounts-query';
-import type { ResponseError } from './types';
+import type {
+	AddEmailForwardResponse,
+	DomainsQueryData,
+	EmailAccountsQueryData,
+	ResponseError,
+} from './types';
 import type { UseMutationOptions } from '@tanstack/react-query';
 
 const ArrayOfFive = new Array( 5 );
@@ -19,7 +24,8 @@ type AddMailboxFormData = {
 };
 
 type Context = {
-	[ key: string ]: any;
+	emailAccountsQueryData: EmailAccountsQueryData | undefined;
+	domainsQueryData: DomainsQueryData | undefined;
 };
 
 const MUTATION_KEY = 'addEmailForward';
@@ -41,7 +47,7 @@ export function useIsLoading() {
 export default function useAddEmailForwardMutation(
 	domainName: string,
 	mutationOptions: Omit<
-		UseMutationOptions< any, ResponseError, AddMailboxFormData, Context >,
+		UseMutationOptions< AddEmailForwardResponse, ResponseError, AddMailboxFormData, Context >,
 		'mutationFn'
 	> = {}
 ) {
@@ -74,11 +80,12 @@ export default function useAddEmailForwardMutation(
 		await queryClient.cancelQueries( { queryKey: emailAccountsQueryKey } );
 		await queryClient.cancelQueries( { queryKey: domainsQueryKey } );
 
-		const previousEmailAccountsQueryData = queryClient.getQueryData< any >( emailAccountsQueryKey );
+		const previousEmailAccountsQueryData =
+			queryClient.getQueryData< EmailAccountsQueryData >( emailAccountsQueryKey );
 		const emailForwards = previousEmailAccountsQueryData?.accounts?.[ 0 ]?.emails;
 
 		// Optimistically add email forward to `useGetEmailAccountsQuery` data
-		if ( emailForwards ) {
+		if ( previousEmailAccountsQueryData && emailForwards ) {
 			const newEmailForwards = orderBy(
 				[
 					...emailForwards,
@@ -108,7 +115,8 @@ export default function useAddEmailForwardMutation(
 			} );
 		}
 
-		const previousDomainsQueryData = queryClient.getQueryData< any >( domainsQueryKey );
+		const previousDomainsQueryData =
+			queryClient.getQueryData< DomainsQueryData >( domainsQueryKey );
 
 		// Optimistically increment `email_forwards_count` in `useGetDomainsQuery` data
 		if ( previousDomainsQueryData ) {
@@ -133,8 +141,8 @@ export default function useAddEmailForwardMutation(
 		}
 
 		return {
-			[ JSON.stringify( emailAccountsQueryKey ) ]: previousEmailAccountsQueryData,
-			[ JSON.stringify( domainsQueryKey ) ]: previousDomainsQueryData,
+			emailAccountsQueryData: previousEmailAccountsQueryData,
+			domainsQueryData: previousDomainsQueryData,
 		};
 	};
 
@@ -142,12 +150,8 @@ export default function useAddEmailForwardMutation(
 		suppliedOnError?.( error, variables, context );
 
 		if ( context ) {
-			queryClient.setQueryData(
-				emailAccountsQueryKey,
-				context[ JSON.stringify( emailAccountsQueryKey ) ]
-			);
-
-			queryClient.setQueryData( domainsQueryKey, context[ JSON.stringify( domainsQueryKey ) ] );
+			queryClient.setQueryData( emailAccountsQueryKey, context.emailAccountsQueryData );
+			queryClient.setQueryData( domainsQueryKey, context.domainsQueryData );
 		}
 
 		const noticeComponents = {
@@ -183,7 +187,7 @@ export default function useAddEmailForwardMutation(
 		dispatch( errorNotice( errorMessage ) );
 	};
 
-	return useMutation< any, ResponseError, AddMailboxFormData, Context >( {
+	return useMutation< AddEmailForwardResponse, ResponseError, AddMailboxFormData, Context >( {
 		mutationFn: ( { mailbox, destinations } ) =>
 			wp.req.post( `/domains/${ encodeURIComponent( domainName ) }/email/new`, {
 				mailbox,

--- a/client/data/emails/use-remove-email-forward-mutation.tsx
+++ b/client/data/emails/use-remove-email-forward-mutation.tsx
@@ -8,11 +8,18 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getCacheKey as getEmailAccountsQueryKey } from './use-get-email-accounts-query';
-import type { EmailAccountEmail, AlterDestinationParams, Mailbox } from './types';
+import type {
+	AlterDestinationParams,
+	DomainsQueryData,
+	EmailAccountEmail,
+	EmailAccountsQueryData,
+	Mailbox,
+} from './types';
 import type { UseMutationOptions } from '@tanstack/react-query';
 
 type Context = {
-	[ key: string ]: any;
+	emailAccountsQueryData: EmailAccountsQueryData | undefined;
+	domainsQueryData: DomainsQueryData | undefined;
 };
 
 const MUTATION_KEY = 'removeEmailForward';
@@ -26,7 +33,7 @@ const MUTATION_KEY = 'removeEmailForward';
 export default function useRemoveEmailForwardMutation(
 	domainName: string,
 	mutationOptions: Omit<
-		UseMutationOptions< any, unknown, AlterDestinationParams, Context >,
+		UseMutationOptions< Mailbox, unknown, AlterDestinationParams, Context >,
 		'mutationFn'
 	> = {}
 ) {
@@ -58,12 +65,13 @@ export default function useRemoveEmailForwardMutation(
 		await queryClient.cancelQueries( { queryKey: emailAccountsQueryKey } );
 		await queryClient.cancelQueries( { queryKey: domainsQueryKey } );
 
-		const previousEmailAccountsQueryData = queryClient.getQueryData< any >( emailAccountsQueryKey );
+		const previousEmailAccountsQueryData =
+			queryClient.getQueryData< EmailAccountsQueryData >( emailAccountsQueryKey );
 
 		const emailForwards = previousEmailAccountsQueryData?.accounts?.[ 0 ]?.emails;
 
 		// Optimistically remove email forward from `useGetEmailAccountsQuery` data
-		if ( emailForwards ) {
+		if ( previousEmailAccountsQueryData && emailForwards ) {
 			queryClient.setQueryData( emailAccountsQueryKey, {
 				...previousEmailAccountsQueryData,
 				accounts: [
@@ -81,7 +89,8 @@ export default function useRemoveEmailForwardMutation(
 			} );
 		}
 
-		const previousDomainsQueryData = queryClient.getQueryData< any >( domainsQueryKey );
+		const previousDomainsQueryData =
+			queryClient.getQueryData< DomainsQueryData >( domainsQueryKey );
 
 		// Optimistically decrement `email_forwards_count` in `useGetDomainsQuery` data
 		if ( previousDomainsQueryData ) {
@@ -106,8 +115,8 @@ export default function useRemoveEmailForwardMutation(
 		}
 
 		return {
-			[ JSON.stringify( emailAccountsQueryKey ) ]: previousEmailAccountsQueryData,
-			[ JSON.stringify( domainsQueryKey ) ]: previousDomainsQueryData,
+			emailAccountsQueryData: previousEmailAccountsQueryData,
+			domainsQueryData: previousDomainsQueryData,
 		};
 	};
 
@@ -115,12 +124,8 @@ export default function useRemoveEmailForwardMutation(
 		suppliedOnError?.( error, emailForward, context );
 
 		if ( context ) {
-			queryClient.setQueryData(
-				emailAccountsQueryKey,
-				context[ JSON.stringify( emailAccountsQueryKey ) ]
-			);
-
-			queryClient.setQueryData( domainsQueryKey, context[ JSON.stringify( domainsQueryKey ) ] );
+			queryClient.setQueryData( emailAccountsQueryKey, context.emailAccountsQueryData );
+			queryClient.setQueryData( domainsQueryKey, context.domainsQueryData );
 		}
 
 		const emailAddress = getEmailAddress( emailForward );

--- a/client/data/emails/use-update-email-forward-mutation.tsx
+++ b/client/data/emails/use-update-email-forward-mutation.tsx
@@ -6,7 +6,7 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getCacheKey as getEmailAccountsQueryKey } from './use-get-email-accounts-query';
-import type { AlterDestinationParams, EmailAccountEmail } from './types';
+import type { AlterDestinationParams, EmailAccountEmail, EmailAccountsQueryData } from './types';
 import type { UpdateEmailForwardResponse } from '@automattic/api-core';
 import type { UseMutationOptions } from '@tanstack/react-query';
 
@@ -15,7 +15,7 @@ type UpdateEmailForwardParams = AlterDestinationParams & {
 };
 
 type Context = {
-	[ key: string ]: any;
+	emailAccountsQueryData: EmailAccountsQueryData | undefined;
 };
 
 const MUTATION_KEY = 'updateEmailForward';
@@ -75,12 +75,13 @@ export default function useUpdateEmailForwardMutation(
 
 		await queryClient.cancelQueries( { queryKey: emailAccountsQueryKey } );
 
-		const previousEmailAccountsQueryData = queryClient.getQueryData< any >( emailAccountsQueryKey );
+		const previousEmailAccountsQueryData =
+			queryClient.getQueryData< EmailAccountsQueryData >( emailAccountsQueryKey );
 
 		const emailForwards = previousEmailAccountsQueryData?.accounts?.[ 0 ]?.emails;
 
 		// Optimistically update the forward's target in `useGetEmailAccountsQuery` data
-		if ( emailForwards ) {
+		if ( previousEmailAccountsQueryData && emailForwards ) {
 			queryClient.setQueryData( emailAccountsQueryKey, {
 				...previousEmailAccountsQueryData,
 				accounts: [
@@ -102,7 +103,7 @@ export default function useUpdateEmailForwardMutation(
 		}
 
 		return {
-			[ JSON.stringify( emailAccountsQueryKey ) ]: previousEmailAccountsQueryData,
+			emailAccountsQueryData: previousEmailAccountsQueryData,
 		};
 	};
 
@@ -110,10 +111,7 @@ export default function useUpdateEmailForwardMutation(
 		suppliedOnError?.( error, params, context );
 
 		if ( context ) {
-			queryClient.setQueryData(
-				emailAccountsQueryKey,
-				context[ JSON.stringify( emailAccountsQueryKey ) ]
-			);
+			queryClient.setQueryData( emailAccountsQueryKey, context.emailAccountsQueryData );
 		}
 
 		dispatch(


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes DOTDEV-396

## Proposed Changes

This PR fixes the`any` type in the email forward mutation hooks by defining the new types in `client/data/emails/types.ts`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Currently, we are using the type `any` in the email forward mutation hooks which is not the best practice. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Review the code
* Pull the changes from this branch or use the Calypso Live Link
* Ensure that you have a site with a custom domain
* Navigate to `/emails`
* Add an email forward 
* Confirm it works as expected
* Edit an email forward
* Confirm it works as expected
* Confirm that there are no type errors and no console errors
* Confirm all the checks are passing

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
