### PR TITLE
A4A: Add Plan data for the new Pressable storage addons.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
@@ -524,6 +524,41 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		storage: 1,
 		category: PRODUCT_CATEGORY_PRESSABLE_ADDON,
 	},
+	'pressable-addon-storage-2gb': {
+		slug: 'pressable-addon-storage-2gb',
+		install: 0,
+		visits: 0,
+		storage: 2,
+		category: PRODUCT_CATEGORY_PRESSABLE_ADDON,
+	},
+	'pressable-addon-storage-4gb': {
+		slug: 'pressable-addon-storage-4gb',
+		install: 0,
+		visits: 0,
+		storage: 4,
+		category: PRODUCT_CATEGORY_PRESSABLE_ADDON,
+	},
+	'pressable-addon-storage-8gb': {
+		slug: 'pressable-addon-storage-8gb',
+		install: 0,
+		visits: 0,
+		storage: 8,
+		category: PRODUCT_CATEGORY_PRESSABLE_ADDON,
+	},
+	'pressable-addon-storage-16gb': {
+		slug: 'pressable-addon-storage-16gb',
+		install: 0,
+		visits: 0,
+		storage: 16,
+		category: PRODUCT_CATEGORY_PRESSABLE_ADDON,
+	},
+	'pressable-addon-storage-32gb': {
+		slug: 'pressable-addon-storage-32gb',
+		install: 0,
+		visits: 0,
+		storage: 32,
+		category: PRODUCT_CATEGORY_PRESSABLE_ADDON,
+	},
 };
 
 export default function getPressablePlan( slug: string ) {


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/A4A-2223/support-extra-pressable-storage-via-add-on-combinations

## Proposed Changes

* Add missing Plan data for the new Pressable addons

## Why are these changes being made?

* This show accurate information about the addons in the marketplace.

## Testing Instructions

* Apply this patch 207358-ghe-Automattic/wpcom
* Use the A4A live link and navigate to `/marketplace/products` page.
* Click Pressable filter.
* View any details of the new storage addons.
* Confirm you see the storage capacity.

<img width="1124" height="773" alt="Screenshot 2026-03-13 at 8 33 49 PM" src="https://github.com/user-attachments/assets/72f0fa61-64fd-4a9b-abeb-d5a0479f2ed0" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?