### PR TITLE
Fix missing `env_id` value in the Agents Manager

### DIFF
--- a/apps/agents-manager/agents-manager-ciab.js
+++ b/apps/agents-manager/agents-manager-ciab.js
@@ -10,7 +10,7 @@
  * without touching the admin bar or Site Hub. Help Center continues to manage
  * its own button in the Site Hub independently.
  */
-
+import './config';
 import { createRoot } from 'react-dom/client';
 import AgentsManagerWithProvider from './agents-manager-with-provider';
 

--- a/apps/agents-manager/agents-manager-gutenberg.js
+++ b/apps/agents-manager/agents-manager-gutenberg.js
@@ -1,3 +1,4 @@
+import './config';
 import { registerPlugin } from '@wordpress/plugins';
 import AgentsManagerWithProvider from './agents-manager-with-provider';
 

--- a/apps/agents-manager/agents-manager-with-provider.js
+++ b/apps/agents-manager/agents-manager-with-provider.js
@@ -1,4 +1,5 @@
 /* global agentsManagerData */
+import './config';
 import AgentsManager from '@automattic/agents-manager';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 

--- a/apps/agents-manager/agents-manager-wp-admin-disconnected.js
+++ b/apps/agents-manager/agents-manager-wp-admin-disconnected.js
@@ -10,7 +10,7 @@
  * The help icon is already provided by the PHP admin bar Item component
  * as a direct link to the help page. This file just adds tracking for clicks.
  */
-
+import './config';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 
 // Import WordPress admin bar integration styles

--- a/apps/agents-manager/agents-manager-wp-admin.js
+++ b/apps/agents-manager/agents-manager-wp-admin.js
@@ -1,3 +1,4 @@
+import './config';
 import { createRoot } from 'react-dom/client';
 import AgentsManagerWithProvider from './agents-manager-with-provider';
 import HeadlessAgentWithProvider from './headless-agent-with-provider';

--- a/apps/agents-manager/block-notes.js
+++ b/apps/agents-manager/block-notes.js
@@ -4,6 +4,7 @@
  * Entry point for the standalone Block Notes bundle.
  * Loaded on pages where Block Notes should be active (Block Editor, Post Editor, etc. )
  */
+import './config';
 
 /**
  * External dependencies

--- a/apps/agents-manager/config.js
+++ b/apps/agents-manager/config.js
@@ -1,0 +1,8 @@
+/* global agentsManagerData */
+const isDevMode = typeof agentsManagerData !== 'undefined' && agentsManagerData?.isDevMode;
+const envValue = isDevMode ? 'staging' : 'production';
+
+window.configData = {
+	env_id: envValue,
+	env: envValue,
+};


### PR DESCRIPTION
Fixes 
<img width="1614" height="2064" alt="image" src="https://github.com/user-attachments/assets/fd2c82c9-a1fc-4016-b588-d9fff4543348" />
