### PR TITLE
Docker: Make profiling opt-in

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -116,6 +116,14 @@ object BuildDockerImage : BuildType({
 			checked = "true",
 			unchecked = "false"
 		)
+		checkbox(
+			name = "PROFILE",
+			value = "false",
+			label = "Enable profiling",
+			description = "Enables webpack progress and filesystem cache profiling inside the Docker build.",
+			checked = "true",
+			unchecked = "false"
+		)
 		param("env.WEBPACK_CACHE_INVALIDATED", "false")
 	}
 
@@ -191,6 +199,7 @@ object BuildDockerImage : BuildType({
 			--build-arg use_cache=true
 			--build-arg base_image=%base_image%
 			--build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber}
+			--build-arg profile=%PROFILE%
 			--build-arg manual_sentry_release=%MANUAL_SENTRY_RELEASE%
 			--build-arg is_default_branch=%teamcity.build.branch.is_default%
 			--build-arg sentry_auth_token=%SENTRY_AUTH_TOKEN%

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -148,6 +148,14 @@ object BuildBaseImages : BuildType({
 	params {
 		param("build.prefix", "1.0")
 		param("image_tag", "latest")
+		checkbox(
+			name = "PROFILE",
+			value = "false",
+			label = "Enable profiling",
+			description = "Enables webpack progress and filesystem cache profiling while building the base images.",
+			checked = "true",
+			unchecked = "false"
+		)
 	}
 
 	vcs {
@@ -163,7 +171,7 @@ object BuildBaseImages : BuildType({
 					path = "Dockerfile.base"
 				}
 				namesAndTags = "registry.a8c.com/calypso/base:%build.number%"
-				commandArgs = "--no-cache --target base --build-arg workers=32 --build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber}"
+				commandArgs = "--no-cache --target base --build-arg workers=32 --build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber} --build-arg profile=%PROFILE%"
 			}
 			param("dockerImage.platform", "linux")
 		}
@@ -174,7 +182,7 @@ object BuildBaseImages : BuildType({
 					path = "Dockerfile.base"
 				}
 				namesAndTags = "registry.a8c.com/calypso/ci-e2e:%build.number%"
-				commandArgs = "--target ci-e2e --build-arg workers=32 --build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber}"
+				commandArgs = "--target ci-e2e --build-arg workers=32 --build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber} --build-arg profile=%PROFILE%"
 			}
 			param("dockerImage.platform", "linux")
 		}
@@ -185,7 +193,7 @@ object BuildBaseImages : BuildType({
 					path = "Dockerfile.base"
 				}
 				namesAndTags = "registry.a8c.com/calypso/ci-wpcom:%build.number%"
-				commandArgs = "--target ci-wpcom --build-arg workers=32 --build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber}"
+				commandArgs = "--target ci-wpcom --build-arg workers=32 --build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber} --build-arg profile=%PROFILE%"
 			}
 			param("dockerImage.platform", "linux")
 		}

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,9 @@ ENV SENTRY_AUTH_TOKEN $sentry_auth_token
 ARG commit_sha="(unknown)"
 ARG workers=4
 ARG node_memory=8192
+ARG profile=false
 ENV CONTAINER 'docker'
-ENV PROFILE=true
+ENV PROFILE=$profile
 ENV COMMIT_SHA $commit_sha
 ENV CALYPSO_ENV production
 ENV WORKERS $workers

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -8,11 +8,12 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG node_memory=16384
 ARG workers=32
 ARG commit_sha="(unknown)"
+ARG profile=false
 WORKDIR /calypso
 ENV NPM_CONFIG_CACHE=/calypso/.cache
 ENV PERSISTENT_CACHE=true
 ENV GENERATE_CACHE_IMAGE=true
-ENV PROFILE=true
+ENV PROFILE=$profile
 ENV SKIP_TSC=true
 ENV CALYPSO_ENV=production
 ENV BUILD_TRANSLATION_CHUNKS=true

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -117,6 +117,7 @@ const webpackCacheVersion = JSON.stringify( {
 	emitStats: shouldEmitStats,
 	concatenateModules: shouldConcatenateModules,
 	hotReload: shouldHotReload,
+	profile: shouldProfile,
 } );
 
 if ( shouldCreateSentryRelease ) {
@@ -456,13 +457,17 @@ const webpackConfig = {
 						config: webpackCacheBuildDependencies,
 					},
 					cacheDirectory: path.resolve( cachePath, 'webpack' ),
-					profile: true,
+					profile: shouldProfile,
 					version: webpackCacheVersion,
 					readonly: shouldUseReadonlyCache,
 				},
-				infrastructureLogging: {
-					debug: /webpack\.cache/,
-				},
+				...( shouldProfile
+					? {
+							infrastructureLogging: {
+								debug: /webpack\.cache/,
+							},
+					  }
+					: {} ),
 				snapshot: {
 					managedPaths: [
 						path.resolve( __dirname, '../node_modules' ),


### PR DESCRIPTION
Currently, the dockerfiles hardcode env.PROFILE=true, which turns ProgressPlugin in profiling mode. Cache profiling is also hardcoded on.  Typically, profiling has some amount of overhead on performance, and should only be on when someone is actively looking at it. Let's do an experiment and see if we get any perf gains from turning off profiling.

## Proposed Changes

*

## Why are these changes being made?

*

## Testing Instructions


*

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
