### PR TITLE
build-packages: Pass --topological

### DIFF
--- a/bin/build-packages-if-needed.sh
+++ b/bin/build-packages-if-needed.sh
@@ -4,7 +4,7 @@
 # prerequisite packages were cleaned and need to be prepared again.
 if [ ! -d "packages/create-calypso-config/dist" ] ; then
 	echo "Building packages..."
-	yarn workspaces foreach --all --parallel --verbose run prepare
+	yarn workspaces foreach --all --parallel --topological --verbose run prepare
 else
 	echo "Packages are built."
 fi

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
 		"build-docker": "node bin/build-docker.js",
 		"build-languages": "yarn run translate && node bin/build-languages.js",
 		"build-languages-if-enabled": "node -e \"(process.env.BUILD_TRANSLATION_CHUNKS === 'true' || process.env.ENABLE_FEATURES === 'use-translation-chunks') && process.exit(1)\" || yarn run build-languages",
-		"build-packages": "{ [ \"${SKIP_TSC:-}\" = \"true\" ] || tsc --build packages/tsconfig.json; } && yarn workspaces foreach --all --parallel --verbose run prepare",
+		"build-packages": "{ [ \"${SKIP_TSC:-}\" = \"true\" ] || tsc --build packages/tsconfig.json; } && yarn workspaces foreach --all --parallel --topological --verbose run prepare",
 		"build-server": "mkdir -p build && BROWSERSLIST_ENV=server webpack --config client/webpack.config.node.js --stats-preset errors-only && yarn run build-server:copy-modules",
 		"build-server-stats": "NODE_ENV=production CALYPSO_ENV=production EMIT_STATS=true yarn run build-server",
 		"build-server:copy-modules": "node -e \"process.env.CALYPSO_ENV === 'production' && process.exit(1)\" || node bin/copy-production-modules.js",


### PR DESCRIPTION
While watching the calypso builds, I've seen intermittent failures like this:
```
16:17:39   #15 86.34 ➤ YN0000: │ wp-calypso@workspace:. STDOUT [@automattic/calypso-products]: ../calypso-config/src/desktop.ts(1,33): error TS2306: File '/calypso/packages/create-calypso-config/dist/types/index.d.ts' is not a module.
16:17:39   #15 86.34 ➤ YN0000: │ wp-calypso@workspace:. STDOUT [@automattic/calypso-products]: ../calypso-config/src/index.ts(1,26): error TS2306: File '/calypso/packages/create-calypso-config/dist/types/index.d.ts' is not a module.
16:17:39   #15 86.34 ➤ YN0000: │ wp-calypso@workspace:. STDOUT [@automattic/calypso-products]: ../calypso-config/src/index.ts(4,33): error TS2306: File '/calypso/packages/create-calypso-config/dist/types/index.d.ts' is not a module.
16:17:39   #15 86.34 ➤ YN0000: │ wp-calypso@workspace:. STDOUT [@automattic/calypso-products]: Process exited (exit code 2), completed in 33s 730ms
```

I believe they're due to the packages compiling in the wrong order. Using --parallel --topological should force them to compile in the right order.  I tested, and only saw a minor speed penalty when building locally. (48->54 seconds). That seems worth it to avoid random failures, if this works.

See https://yarnpkg.com/cli/workspaces/foreach

## Proposed Changes

*

## Why are these changes being made?

*

## Testing Instructions


* ` yarn run clean ; time yarn run build-packages`

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
