### PR TITLE
UnitTests CI: Increase timeout, skip Playwright browsers, make trunk check more efficient

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -392,6 +392,11 @@ object RunAllUnitTests : BuildType({
 		artifacts => artifacts
 	""".trimIndent()
 
+	params {
+		// Unit tests don't exercise Playwright browsers, so avoid downloading them during yarn install.
+		param("env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD", "1")
+	}
+
 	vcs {
 		root(Settings.WpCalypso)
 		cleanCheckout = true
@@ -506,12 +511,13 @@ object RunAllUnitTests : BuildType({
 		bashNodeScript {
 			name = "Tag build"
 			executionMode = BuildStep.ExecutionMode.RUN_ON_SUCCESS
+			conditions {
+				equals("teamcity.build.branch.is_default", "true")
+			}
 			scriptContent = """
 				set -x
 
-				if [[ "%teamcity.build.branch.is_default%" == "true" ]] ; then
-					curl -s -X POST -H "Content-Type: text/plain" --data "release-candidate" -u "%system.teamcity.auth.userId%:%system.teamcity.auth.password%" "%teamcity.serverUrl%/httpAuth/app/rest/builds/id:%teamcity.build.id%/tags/"
-				fi
+				curl -s -X POST -H "Content-Type: text/plain" --data "release-candidate" -u "%system.teamcity.auth.userId%:%system.teamcity.auth.password%" "%teamcity.serverUrl%/httpAuth/app/rest/builds/id:%teamcity.build.id%/tags/"
 			""".trimIndent()
 		}
 	}
@@ -526,7 +532,7 @@ object RunAllUnitTests : BuildType({
 	}
 
 	failureConditions {
-		executionTimeoutMin = 10
+		executionTimeoutMin = 15
 	}
 	features {
 		feature {


### PR DESCRIPTION


## Proposed Changes

Unit tests are randomly timing out at the 10 minute mark, even when nothing is going wrong.
* Increase timeout from 10 to 15 minutes. 
* Stop them from downloading Playwright browsers they won't use.
* The "tag build" only runs on trunk, but it always starts a container. In a failing build, it spent 18 seconds starting up a container just to check `[[ false == true ]]` and quit.  Instead, move the condition outward so teamcity only does it on trunk.

## Why are these changes being made?

*

## Testing Instructions


*

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
