### PR TITLE
Fix infinite render loop in the orchestrator chat

### DIFF
--- a/packages/agents-manager/src/hooks/use-checkpoint-action.ts
+++ b/packages/agents-manager/src/hooks/use-checkpoint-action.ts
@@ -1,4 +1,4 @@
-import { createElement, useEffect } from '@wordpress/element';
+import { createElement, useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { undo, Icon } from '@wordpress/icons';
 import type { UseCheckpointReturn } from '../utils/load-external-providers';
@@ -38,21 +38,28 @@ export default function useCheckpointAction(
 	registerMessageActions: RegisterMessageActions,
 	checkpoint?: UseCheckpointReturn
 ): void {
+	// Use a ref to access the latest checkpoint without re-triggering the effect.
+	// The actions callback is evaluated lazily per-message, so it always reads the current value.
+	const checkpointRef = useRef( checkpoint );
+	checkpointRef.current = checkpoint;
+
 	useEffect( () => {
-		if ( ! checkpoint ) {
+		if ( ! checkpointRef.current ) {
 			return;
 		}
 
 		registerMessageActions( {
 			id: 'agents-manager-checkpoint',
 			actions: ( message: UIMessage ) => {
-				if ( message.role !== 'agent' ) {
+				const cp = checkpointRef.current;
+
+				if ( ! cp || message.role !== 'agent' ) {
 					return [];
 				}
 
 				const checkpointId = getCheckpointId( message );
 
-				if ( ! checkpointId || ! checkpoint.hasCheckpoint( checkpointId ) ) {
+				if ( ! checkpointId || ! cp.hasCheckpoint( checkpointId ) ) {
 					return [];
 				}
 
@@ -66,7 +73,7 @@ export default function useCheckpointAction(
 						} ),
 						onClick: async () => {
 							try {
-								await checkpoint.restoreCheckpoint( checkpointId );
+								await cp.restoreCheckpoint( checkpointId );
 							} catch ( error ) {
 								// eslint-disable-next-line no-console
 								console.error( '[useCheckpointAction] Failed to restore checkpoint:', error );
@@ -76,5 +83,5 @@ export default function useCheckpointAction(
 				];
 			},
 		} );
-	}, [ registerMessageActions, checkpoint ] );
+	}, [ registerMessageActions ] );
 }


### PR DESCRIPTION
## Proposed Changes

- Fixes an infinite re-render loop in `OrchestratorChat` caused by `useCheckpointAction` re-registering message actions on every render.

### Root cause

The `useCheckpoint()` hook (from Big Sky) returns a new object reference on every render. `useCheckpointAction` had `checkpoint` as a `useEffect` dependency, so every render triggered the effect, which called `registerMessageActions`. This caused a cascade:

1. `checkpoint` new ref → effect fires → `registerMessageActions()` called
2. `registerMessageActions` calls `setRegistrations()` inside `useMessageActions`, creating a new registrations array
3. The `registrations` change triggers an effect in `useAgentChat` that re-transforms messages via `setState`, producing a new `uiMessages` array
4. New `messages` ref → `OrchestratorChat` re-renders → `useCheckpoint()` returns new object → loop repeats

### Fix

Store `checkpoint` in a `useRef` instead of including it as an effect dependency. Since the `actions` callback is already evaluated lazily (called per-message at render time), it reads the latest checkpoint value via `checkpointRef.current` — so behavior is fully preserved without re-triggering the effect.

## Testing Instructions

* To reproduce the issue (Before checking out this branch):
  * Sync the agents manager app with your sandbox - `yarn dev --sync`
  * Add a `console.log` line to `packages/agents-manager/src/components/orchestrator-chat/index.tsx`
  * Open the site editor with the unified experience enabled
  * Once the AI Chat is loaded, you should see a bunch of logs in the DevTools console

* Now checkout this branch
  * Run `yarn dev --sync` again just to make sure the latest changes are synced
  * Open the site editor again
  * You should not see infinite logs

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
