### PR TITLE
MSD Purchases: fix cancellation offer thank you notice for auto-renew…

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -144,6 +144,10 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 			</>
 		);
 	}
+
+	if ( shouldShowCancellationNotice && cancellationOfferNotice ) {
+		return cancellationOfferNotice;
+	}
 }
 
 function shouldShowExpiredRenewNotice(

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -145,9 +145,7 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 		);
 	}
 
-	if ( shouldShowCancellationNotice && cancellationOfferNotice ) {
-		return cancellationOfferNotice;
-	}
+	return cancellationOfferNotice && cancellationOfferNotice;
 }
 
 function shouldShowExpiredRenewNotice(

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -145,7 +145,7 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 		);
 	}
 
-	return cancellationOfferNotice && cancellationOfferNotice;
+	return cancellationOfferNotice;
 }
 
 function shouldShowExpiredRenewNotice(


### PR DESCRIPTION
…al enabled purchases

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of SHILL-1698

## Proposed Changes

* Show the cancellation offer notice when no notices have previously been shown.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Customers with auto-renew enabled won't see the cancellation offer notice because previously only the scenarios where auto-renew was disabled were implemented.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

NOTE to A12s: you will need to sandbox the public api and short circuit the backend so that no refunds on this purchase are available. See the issue notes for how to do this.

Either:
* If you have a purchase from the previous test in #109215, go to the MSD with this patch and make sure you are still seeing the notice with auto-renew disabled. If you can see the cancellation offer notice thanking you for sticking with <product name>, then simply enable auto-renew. With auto-renew enabled, and this patch applied, you should still see the notice.

Or:
* Purchase an Akismet plan ( https://wordpress.com/checkout/akismet/ak_plus_yearly_1 )
* Go to the multisite dashboard billing page `/me/billing/purchases` and choose the Akismet product's "Manage purchase" link.
* Disable auto renew
* Make sure the "Cancel" button turns into a "Remove" button. click the "Remove" button.
* Click the checkbox and confirm to move onto the next page.
* Make sure you see a text box to leave comments. Click submit.
* You should see the cancellation offer. Verify everything looks correct.
* Click "Get discount"
* You should arrive on the purchase settings page for the new subscription with a notice at the top of the page thanking you for sticking with Akismet. Verify that it looks correct and do not dismiss this notice (do not click the X in the corner of the notice) yet.
* Enable auto-renew
* You should still see the cancellation offer notice at the top thanking you for sticking with <product name>.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
