### PR TITLE
Add @automattic/design-types to break circular dependency between data-stores and design-picker

### DIFF
--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -48,6 +48,7 @@
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/calypso-config": "workspace:^",
 		"@automattic/calypso-products": "workspace:^",
+		"@automattic/design-types": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/js-utils": "workspace:^",
 		"@automattic/number-formatters": "^1.1.0",
@@ -78,7 +79,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"@automattic/design-picker": "workspace:^",
 		"@remix-run/router": "^1.5.0",
 		"jest-fetch-mock": "^3.0.3",
 		"nock": "^13.5.6",

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -8,8 +8,7 @@ import { ProfilerData, ReadymadeTemplate } from './types';
 import type { DomainTransferData, State } from '.';
 import type { FeatureId } from '../shared-types';
 import type { DomainSuggestion } from '@automattic/api-core';
-// somewhat hacky, but resolves the circular dependency issue
-import type { Design, StyleVariation } from '@automattic/design-picker/src/types';
+import type { Design, StyleVariation } from '@automattic/design-types';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 // copied from design picker to avoid a circular dependency

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -11,8 +11,7 @@ import type {
 import type { FeatureId } from '../shared-types';
 import type { GlobalStyles } from '../site';
 import type { DomainSuggestion } from '@automattic/api-core';
-// somewhat hacky, but resolves the circular dependency issue
-import type { Design, StyleVariation } from '@automattic/design-picker/src/types';
+import type { Design, StyleVariation } from '@automattic/design-types';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import type { Reducer } from 'redux';
 

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -33,7 +33,7 @@ import type {
 } from './types';
 import type { WpcomClientCredentials } from '../shared-types';
 import type { RequestTemplate } from '../templates';
-import type { Design, DesignOptions } from '@automattic/design-picker/src/types'; // Import from a specific file directly to avoid the circular dependencies
+import type { Design, DesignOptions } from '@automattic/design-types';
 
 export function createActions( clientCreds: WpcomClientCredentials ) {
 	const fetchSite = () => ( {

--- a/packages/data-stores/src/starter-designs-queries/types.ts
+++ b/packages/data-stores/src/starter-designs-queries/types.ts
@@ -1,4 +1,4 @@
-import type { Category, Design } from '@automattic/design-picker/src/types';
+import type { Category, Design } from '@automattic/design-types';
 
 export interface StarterDesigns {
 	filters: { subject: Record< string, Category > };

--- a/packages/data-stores/src/starter-designs-queries/use-starter-design-by-slug.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-design-by-slug.ts
@@ -1,7 +1,7 @@
 import { useLocale } from '@automattic/i18n-utils';
 import { useQuery, UseQueryResult, QueryOptions } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
-import type { Design } from '@automattic/design-picker/src/types';
+import type { Design } from '@automattic/design-types';
 
 interface Options extends QueryOptions< Design > {
 	enabled?: boolean;

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
@@ -10,7 +10,7 @@ import type {
 	StyleVariation,
 	PreviewData,
 	DesignType,
-} from '@automattic/design-picker/src/types';
+} from '@automattic/design-types';
 
 interface StarterDesignsQueryParams {
 	seed?: string;

--- a/packages/data-stores/tsconfig.json
+++ b/packages/data-stores/tsconfig.json
@@ -13,7 +13,7 @@
 		{ "path": "../calypso-config" },
 		{ "path": "../api-core" },
 		{ "path": "../api-queries" },
-		{ "path": "../global-styles" },
+		{ "path": "../design-types" },
 		{ "path": "../i18n-utils" },
 		{ "path": "../shopping-cart" },
 		{ "path": "../js-utils" }

--- a/packages/design-picker/package.json
+++ b/packages/design-picker/package.json
@@ -39,6 +39,7 @@
 	"dependencies": {
 		"@automattic/calypso-config": "workspace:^",
 		"@automattic/components": "workspace:^",
+		"@automattic/design-types": "workspace:^",
 		"@automattic/global-styles": "workspace:^",
 		"@automattic/js-utils": "workspace:^",
 		"@automattic/onboarding": "workspace:^",

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -1,114 +1,15 @@
-import type { GlobalStylesObject } from '@automattic/global-styles';
-
-export interface Category {
-	slug: string;
-	name: string;
-	description?: string;
-}
-
-export interface StyleVariation extends GlobalStylesObject {}
-
-export interface StyleVariationSettingsColorPalette {
-	color: string;
-	name: string;
-	slug: string;
-}
-
-export interface StyleVariationPreview {
-	color: StyleVariationPreviewColorPalette;
-}
-
-export interface StyleVariationPreviewColorPalette {
-	base?: string;
-	contrast?: string;
-	background?: string;
-	foreground?: string;
-	primary?: string;
-	secondary?: string;
-	tertiary?: string;
-}
-
-export interface StyleVariationStylesColor {
-	background?: string;
-	text?: string;
-}
-
-export interface DesignRecipe {
-	stylesheet?: string;
-	pattern_ids?: number[] | string[];
-	pattern_html?: string;
-	header_pattern_ids?: number[] | string[];
-	header_html?: string;
-	footer_pattern_ids?: number[] | string[];
-	footer_html?: string;
-	color_variation_title?: string;
-	font_variation_title?: string;
-	slug?: string;
-}
-
-export interface SoftwareSet {
-	slug: string;
-}
-
-/**
- * For measuring what kind of the design user picked.
- */
-export type DesignType =
-	| 'vertical'
-	| 'premium' // The design is non-free, Design.design_tier will have more nuance.
-	| 'standard' // The design is free.
-	| 'default' // The default design and it means user skipped the step and didn't select any design.
-	| 'anchor-fm'
-	| 'assembler';
-
-export interface PreviewData {
-	site_title?: string;
-	site_tagline?: string;
-	site_logo_url?: string;
-}
-
-export interface Design {
-	slug: string;
-	title: string;
-	description?: string;
-	recipe?: DesignRecipe;
-	is_externally_managed?: boolean;
-	is_bundled_with_woo?: boolean;
-	categories: Category[];
-	is_featured_picks?: boolean; // Whether this design will be featured in the sidebar. Example: Blank Canvas
-	showFirst?: boolean; // Whether this design will appear at the top, regardless of category
-	preview?: 'static';
-	design_type?: DesignType;
-	design_tier: string | null;
-	style_variations?: StyleVariation[];
-	price?: string;
-	software_sets?: SoftwareSet[];
-	is_virtual?: boolean;
-	preview_data?: PreviewData;
-	screenshot?: string;
-	demo_uri?: string;
-	default?: boolean;
-
-	/** @deprecated TODO: replace both with just stylesheet */
-	stylesheet?: string;
-	theme: string;
-}
-
-export interface DesignOptions {
-	styleVariation?: StyleVariation;
-	globalStyles?: GlobalStylesObject;
-	/** Potentially runs Headstart. */
-	enableThemeSetup?: boolean;
-}
-
-export interface DesignPreviewOptions {
-	language?: string;
-	site_title?: string;
-	site_tagline?: string;
-	viewport_height?: number;
-	use_screenshot_overrides?: boolean;
-	disable_viewport_height?: boolean;
-	remove_assets?: boolean;
-	style_variation?: StyleVariation;
-	viewport_unit_to_px?: boolean;
-}
+export type {
+	Category,
+	Design,
+	DesignOptions,
+	DesignPreviewOptions,
+	DesignRecipe,
+	DesignType,
+	PreviewData,
+	SoftwareSet,
+	StyleVariation,
+	StyleVariationPreview,
+	StyleVariationPreviewColorPalette,
+	StyleVariationSettingsColorPalette,
+	StyleVariationStylesColor,
+} from '@automattic/design-types';

--- a/packages/design-picker/src/utils/__tests__/designs.test.ts
+++ b/packages/design-picker/src/utils/__tests__/designs.test.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_VIEWPORT_HEIGHT } from '../../constants';
-import { Design, DesignPreviewOptions } from '../../types';
 import { getDesignPreviewUrl } from '../designs';
+import type { Design, DesignPreviewOptions } from '../../types';
 
 const mergeDesign = ( currentDesign, newDesign ) => ( {
 	...currentDesign,

--- a/packages/design-picker/src/utils/is-locked-style-variation.ts
+++ b/packages/design-picker/src/utils/is-locked-style-variation.ts
@@ -1,5 +1,5 @@
-import { StyleVariation } from '../types';
 import { isDefaultGlobalStylesVariationSlug } from './global-styles';
+import type { StyleVariation } from '../types';
 
 export function isLockedStyleVariation( {
 	isPremiumTheme,

--- a/packages/design-picker/tsconfig.json
+++ b/packages/design-picker/tsconfig.json
@@ -10,6 +10,7 @@
 	"exclude": [ "**/__tests__/*", "**/__mocks__/*", "**/*.stories.tsx" ],
 	"references": [
 		{ "path": "../calypso-config" },
+		{ "path": "../design-types" },
 		{ "path": "../global-styles" },
 		{ "path": "../js-utils" },
 		{ "path": "../onboarding" },

--- a/packages/design-types/package.json
+++ b/packages/design-types/package.json
@@ -1,0 +1,45 @@
+{
+	"name": "@automattic/design-types",
+	"version": "1.0.0",
+	"description": "Shared design-related TypeScript contracts.",
+	"homepage": "https://github.com/Automattic/wp-calypso",
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic Inc.",
+	"main": "dist/cjs/index.js",
+	"module": "dist/esm/index.js",
+	"types": "dist/types/index.d.ts",
+	"calypso:src": "src/index.ts",
+	"exports": {
+		".": {
+			"calypso:src": "./src/index.ts",
+			"types": "./dist/types/index.d.ts",
+			"import": "./dist/esm/index.js",
+			"require": "./dist/cjs/index.js"
+		}
+	},
+	"sideEffects": false,
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/design-types"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"bugs": "https://github.com/Automattic/wp-calypso/issues",
+	"files": [
+		"dist",
+		"src"
+	],
+	"scripts": {
+		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
+		"prepare": "yarn run build",
+		"prepack": "yarn run clean && yarn run build",
+		"watch": "tsc --build ./tsconfig.json --watch"
+	},
+	"devDependencies": {
+		"@automattic/calypso-typescript-config": "workspace:^",
+		"typescript": "^5.8.3"
+	}
+}

--- a/packages/design-types/src/index.ts
+++ b/packages/design-types/src/index.ts
@@ -1,0 +1,157 @@
+export interface Color {
+	color: string;
+	name: string;
+	slug: string;
+	default?: string;
+}
+
+export interface FontFamily {
+	fontFamily: string;
+	name: string;
+	slug: string;
+}
+
+export interface Typography {
+	fontFamily?: string;
+	fontSize?: string;
+	fontStyle?: string;
+	fontWeight?: string;
+	lineHeight?: string;
+}
+
+export interface GlobalStylesObject {
+	id?: number;
+	slug?: string;
+	title?: string;
+	inline_css?: string;
+	settings: {
+		color?: {
+			palette: {
+				default: Color[];
+				theme: Color[];
+			};
+		};
+	};
+	styles: {
+		color?: Color;
+		elements?: {
+			heading: {
+				typography: Typography;
+			};
+		};
+		typography?: Typography;
+		blocks?: Record< string, { variations?: object } >;
+	};
+}
+
+export interface Category {
+	slug: string;
+	name: string;
+	description?: string;
+}
+
+export interface StyleVariation extends GlobalStylesObject {}
+
+export interface StyleVariationSettingsColorPalette {
+	color: string;
+	name: string;
+	slug: string;
+}
+
+export interface StyleVariationPreview {
+	color: StyleVariationPreviewColorPalette;
+}
+
+export interface StyleVariationPreviewColorPalette {
+	base?: string;
+	contrast?: string;
+	background?: string;
+	foreground?: string;
+	primary?: string;
+	secondary?: string;
+	tertiary?: string;
+}
+
+export interface StyleVariationStylesColor {
+	background?: string;
+	text?: string;
+}
+
+export interface DesignRecipe {
+	stylesheet?: string;
+	pattern_ids?: number[] | string[];
+	pattern_html?: string;
+	header_pattern_ids?: number[] | string[];
+	header_html?: string;
+	footer_pattern_ids?: number[] | string[];
+	footer_html?: string;
+	color_variation_title?: string;
+	font_variation_title?: string;
+	slug?: string;
+}
+
+export interface SoftwareSet {
+	slug: string;
+}
+
+/**
+ * For measuring what kind of the design user picked.
+ */
+export type DesignType =
+	| 'vertical'
+	| 'premium' // The design is non-free, Design.design_tier will have more nuance.
+	| 'standard' // The design is free.
+	| 'default' // The default design and it means user skipped the step and didn't select any design.
+	| 'anchor-fm'
+	| 'assembler';
+
+export interface PreviewData {
+	site_title?: string;
+	site_tagline?: string;
+	site_logo_url?: string;
+}
+
+export interface Design {
+	slug: string;
+	title: string;
+	description?: string;
+	recipe?: DesignRecipe;
+	is_externally_managed?: boolean;
+	is_bundled_with_woo?: boolean;
+	categories: Category[];
+	is_featured_picks?: boolean; // Whether this design will be featured in the sidebar. Example: Blank Canvas
+	showFirst?: boolean; // Whether this design will appear at the top, regardless of category
+	preview?: 'static';
+	design_type?: DesignType;
+	design_tier: string | null;
+	style_variations?: StyleVariation[];
+	price?: string;
+	software_sets?: SoftwareSet[];
+	is_virtual?: boolean;
+	preview_data?: PreviewData;
+	screenshot?: string;
+	demo_uri?: string;
+	default?: boolean;
+	/** @deprecated TODO: replace both with just stylesheet */
+	stylesheet?: string;
+	theme: string;
+}
+
+export interface DesignOptions {
+	styleVariation?: StyleVariation;
+	globalStyles?: GlobalStylesObject;
+	/** Potentially runs Headstart. */
+	enableThemeSetup?: boolean;
+}
+
+export interface DesignPreviewOptions {
+	language?: string;
+	site_title?: string;
+	site_tagline?: string;
+	viewport_height?: number;
+	use_screenshot_overrides?: boolean;
+	disable_viewport_height?: boolean;
+	remove_assets?: boolean;
+	style_variation?: StyleVariation;
+	viewport_unit_to_px?: boolean;
+}

--- a/packages/design-types/tsconfig-cjs.json
+++ b/packages/design-types/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig",
+	"compilerOptions": {
+		"module": "commonjs",
+		"outDir": "dist/cjs"
+	}
+}

--- a/packages/design-types/tsconfig.json
+++ b/packages/design-types/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "@automattic/calypso-typescript-config/ts-package.json",
+	"compilerOptions": {
+		"declarationDir": "dist/types",
+		"outDir": "dist/esm",
+		"rootDir": "src"
+	},
+	"include": [ "src" ]
+}

--- a/packages/global-styles/package.json
+++ b/packages/global-styles/package.json
@@ -43,6 +43,7 @@
 		"@automattic/calypso-config": "workspace:^",
 		"@automattic/calypso-sentry": "workspace:^",
 		"@automattic/components": "workspace:^",
+		"@automattic/design-types": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/typography": "workspace:^",
 		"@tanstack/react-query": "^5.83.0",

--- a/packages/global-styles/src/types.ts
+++ b/packages/global-styles/src/types.ts
@@ -1,23 +1,5 @@
-export interface Color {
-	color: string;
-	name: string;
-	slug: string;
-	default?: string;
-}
-
-export interface FontFamily {
-	fontFamily: string;
-	name: string;
-	slug: string;
-}
-
-export interface Typography {
-	fontFamily?: string;
-	fontSize?: string;
-	fontStyle?: string;
-	fontWeight?: string;
-	lineHeight?: string;
-}
+import type { GlobalStylesObject } from '@automattic/design-types';
+export type { Color, FontFamily, GlobalStylesObject, Typography } from '@automattic/design-types';
 
 export type SetConfigCallback = ( config: GlobalStylesObject ) => GlobalStylesObject;
 
@@ -29,31 +11,6 @@ export interface GlobalStylesContextObject {
 	merged?: GlobalStylesObject;
 	setUserConfig?: SetConfig;
 	isReady?: boolean;
-}
-
-export interface GlobalStylesObject {
-	id?: number;
-	slug?: string;
-	title?: string;
-	inline_css?: string;
-	settings: {
-		color?: {
-			palette: {
-				default: Color[];
-				theme: Color[];
-			};
-		};
-	};
-	styles: {
-		color?: Color;
-		elements?: {
-			heading: {
-				typography: Typography;
-			};
-		};
-		typography?: Typography;
-		blocks?: Record< string, { variations?: object } >;
-	};
 }
 
 export enum GlobalStylesVariationType {

--- a/packages/global-styles/tsconfig.json
+++ b/packages/global-styles/tsconfig.json
@@ -12,6 +12,7 @@
 		{ "path": "../calypso-sentry" },
 		{ "path": "../calypso-products" },
 		{ "path": "../components" },
+		{ "path": "../design-types" },
 		{ "path": "../i18n-utils" }
 	]
 }

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -26,6 +26,7 @@
 		{ "path": "./composite-checkout" },
 		{ "path": "./create-calypso-config" },
 		{ "path": "./data-stores" },
+		{ "path": "./design-types" },
 		{ "path": "./design-picker" },
 		{ "path": "./design-preview" },
 		{ "path": "./domain-search" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1141,7 +1141,7 @@ __metadata:
     "@automattic/calypso-config": "workspace:^"
     "@automattic/calypso-products": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
-    "@automattic/design-picker": "workspace:^"
+    "@automattic/design-types": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
     "@automattic/js-utils": "workspace:^"
     "@automattic/number-formatters": "npm:^1.1.0"
@@ -1184,6 +1184,7 @@ __metadata:
     "@automattic/calypso-config": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
+    "@automattic/design-types": "workspace:^"
     "@automattic/global-styles": "workspace:^"
     "@automattic/js-utils": "workspace:^"
     "@automattic/onboarding": "workspace:^"
@@ -1277,6 +1278,15 @@ __metadata:
   dependenciesMeta:
     sass-embedded:
       optional: true
+  languageName: unknown
+  linkType: soft
+
+"@automattic/design-types@workspace:^, @automattic/design-types@workspace:packages/design-types":
+  version: 0.0.0-use.local
+  resolution: "@automattic/design-types@workspace:packages/design-types"
+  dependencies:
+    "@automattic/calypso-typescript-config": "workspace:^"
+    typescript: "npm:^5.8.3"
   languageName: unknown
   linkType: soft
 
@@ -1439,6 +1449,7 @@ __metadata:
     "@automattic/calypso-sentry": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
+    "@automattic/design-types": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
     "@automattic/typography": "workspace:^"
     "@tanstack/react-query": "npm:^5.83.0"


### PR DESCRIPTION
## Problem

There is a circular dependency between data-stores and design-picker.

Data-stores needs design-picker for types, but design-picker needs onboarding, and onboarding needs data-stores.

We currently use a deep import to get around this, but I'm trying to clean up things and stop an intermittent build problem.

## Proposed Changes

* Add a new package, `@automattic/design-types` that has the shared design types.
* data-stores can import directly from design-types.
* `design-picker/src/types` becomes a re-export layer over design-types, so anyone already referring to design-picker types isn't affected.
  * We could clean these up later. For example, make design-preview import from design-types.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

* `yarn workspace @automattic/design-types run build` should work
* `tsc --build` should work for `design-types`, `global-styles`, `design-picker, `data-stores`, `design-preview`, and `help-center`.
* Note that typescript types are the only thing that changed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
