### PR TITLE
Agents manager: preserve provider clientContext defaults and WooAI env compat

### DIFF
--- a/packages/agents-manager/src/components/agents-manager.tsx
+++ b/packages/agents-manager/src/components/agents-manager.tsx
@@ -62,7 +62,8 @@ export default function AgentsManager( {
 
 // Separate component that uses hooks within `PersistentRouter` context
 function AgentSetup(): JSX.Element | null {
-	const { site, currentRoute, agentConfig, setAgentConfig } = useAgentsManagerContext();
+	const { site, currentRoute, sectionName, agentConfig, setAgentConfig } =
+		useAgentsManagerContext();
 	const loadedProvidersRef = useRef< LoadedProviders | null >( null );
 	const navigate = useNavigate();
 	const { pathname, state } = useLocation();
@@ -73,6 +74,10 @@ function AgentSetup(): JSX.Element | null {
 	// Read agent/version overrides from browser URL (?agent=, ?version=).
 	// PersistentRouter (memory router) does not track window.location.search.
 	const { agentId, version } = getAgentConfig();
+	let environment: 'calypso' | 'wp-admin' | 'ciab-admin' = 'calypso';
+	if ( [ 'wp-admin', 'ciab-admin' ].includes( sectionName ) ) {
+		environment = sectionName as 'wp-admin' | 'ciab-admin';
+	}
 	const sessionId = isNewChat ? '' : routeSessionId || getSessionId( agentId );
 
 	useEffect( () => {
@@ -109,7 +114,7 @@ function AgentSetup(): JSX.Element | null {
 				currentRoute,
 				toolProvider: providers.toolProvider,
 				contextProvider: providers.contextProvider,
-				environment: 'calypso',
+				environment,
 				agentId,
 				version,
 			} );
@@ -118,7 +123,17 @@ function AgentSetup(): JSX.Element | null {
 		}
 
 		initializeAgent();
-	}, [ agentId, version, currentRoute, isNewChat, navigate, sessionId, setAgentConfig, site?.ID ] );
+	}, [
+		agentId,
+		version,
+		currentRoute,
+		isNewChat,
+		navigate,
+		sessionId,
+		setAgentConfig,
+		site?.ID,
+		environment,
+	] );
 
 	const loadedProviders = loadedProvidersRef.current;
 

--- a/packages/agents-manager/src/components/agents-manager.tsx
+++ b/packages/agents-manager/src/components/agents-manager.tsx
@@ -75,7 +75,9 @@ function AgentSetup(): JSX.Element | null {
 	// PersistentRouter (memory router) does not track window.location.search.
 	const { agentId, version } = getAgentConfig();
 	let environment: 'calypso' | 'wp-admin' | 'ciab-admin' = 'calypso';
-	if ( [ 'wp-admin', 'ciab-admin' ].includes( sectionName ) ) {
+	if ( sectionName === 'wooai-admin' ) {
+		environment = 'wp-admin';
+	} else if ( [ 'wp-admin', 'ciab-admin' ].includes( sectionName ) ) {
 		environment = sectionName as 'wp-admin' | 'ciab-admin';
 	}
 	const sessionId = isNewChat ? '' : routeSessionId || getSessionId( agentId );

--- a/packages/agents-manager/src/utils/agent-config.ts
+++ b/packages/agents-manager/src/utils/agent-config.ts
@@ -19,7 +19,7 @@ export interface CreateAgentConfigOptions {
 	currentRoute?: string;
 	toolProvider?: ToolProvider;
 	contextProvider?: ContextProvider;
-	environment?: 'calypso' | 'wp-admin';
+	environment?: 'calypso' | 'wp-admin' | 'ciab-admin';
 	/** Override the agent ID (e.g., from query string). Defaults to ORCHESTRATOR_AGENT_ID. */
 	agentId?: string;
 	/** Override the agent version (e.g., from query string). Passed via constructorArguments. */
@@ -82,6 +82,8 @@ function wrapToolProvider( toolProvider: ToolProvider ): UseAgentChatConfig[ 'to
  */
 async function createWrappedContextProvider(
 	contextProvider: ContextProvider,
+	currentRoute: string | undefined,
+	environment: string,
 	version?: string
 ): Promise< UseAgentChatConfig[ 'contextProvider' ] > {
 	const canAccessZendesk = await canConnectToZendesk();
@@ -96,7 +98,15 @@ async function createWrappedContextProvider(
 				  }
 				: pluginContext;
 
+			const fallbackContext = {
+				url: window.location.href,
+				pathname: currentRoute || window.location.pathname,
+				search: window.location.search,
+				environment,
+			};
+
 			return {
+				...fallbackContext,
 				...resolvedContext,
 				can_access_zendesk: canAccessZendesk,
 				constructorArguments: {
@@ -164,7 +174,12 @@ export async function createAgentConfig(
 	}
 
 	if ( contextProvider ) {
-		config.contextProvider = await createWrappedContextProvider( contextProvider, version );
+		config.contextProvider = await createWrappedContextProvider(
+			contextProvider,
+			currentRoute,
+			environment,
+			version
+		);
 	} else {
 		config.contextProvider = await createDefaultContextProvider(
 			currentRoute,


### PR DESCRIPTION
## Summary

This PR isolates the abilities/context transport fixes from workflow endpoint work.

### Changes
- Ensure `createAgentConfig` preserves required top-level `clientContext` keys (`url`, `pathname`, `search`, `environment`) even when a provider context omits them.
- Derive environment from section in `AgentsManager`, with WooAI compatibility mapping:
  - `sectionName: wooai-admin` -> `clientContext.environment: wp-admin`
  - existing `wp-admin` / `ciab-admin` behavior preserved

## Why

We observed cases where provider-supplied context had structured fields (`page`, `store`, etc.) but missed top-level keys expected by backend filtering. That can lead to tool eligibility/filtering failures downstream.

The WooAI section name is useful for frontend segmentation, but backend routing currently expects established environment values, so we normalize to `wp-admin` for compatibility.

## Related
- Woo AI variant work: https://github.com/woocommerce/woocommerce-ai/pull/39
- Calypso wooai variant entrypoint: https://github.com/Automattic/wp-calypso/pull/109271

## Test Plan
- Confirm payload sent to orchestrator includes:
  - `clientContext.url`
  - `clientContext.pathname`
  - `clientContext.search`
  - `clientContext.environment` (`wp-admin` when section is `wooai-admin`)
- Confirm tools are no longer filtered out due to missing context fields in WooAI wp-admin flows.
