### PR TITLE
Add tracks events to Gift a Subscription modal

### DIFF
--- a/client/my-sites/subscribers/components/gift-modal/gift-modal.tsx
+++ b/client/my-sites/subscribers/components/gift-modal/gift-modal.tsx
@@ -54,7 +54,7 @@ const GiftSubscriptionModal = ( {
 		recordTracksEvent( 'calypso_subscribers_comp_confirm', {
 			site_id: siteId,
 			plan_id: plan_id,
-			user_id: user_id,
+			...( typeof user_id === 'number' ? { user_id: user_id } : { is_email_subscriber: true } ),
 		} );
 
 		dispatch(

--- a/client/my-sites/subscribers/components/gift-modal/gift-modal.tsx
+++ b/client/my-sites/subscribers/components/gift-modal/gift-modal.tsx
@@ -51,10 +51,11 @@ const GiftSubscriptionModal = ( {
 			user_id: user_id,
 		};
 
-		recordTracksEvent( 'calypso_subscribers_comp_confirm', {
+		recordTracksEvent( 'calypso_subscribers_comp_modal_confirm', {
 			site_id: siteId,
 			plan_id: plan_id,
-			...( typeof user_id === 'number' ? { user_id: user_id } : { is_email_subscriber: true } ),
+			user_id: typeof user_id === 'number' ? user_id : 0,
+			is_email_subscriber: typeof user_id !== 'number',
 		} );
 
 		dispatch(

--- a/client/my-sites/subscribers/components/gift-modal/gift-modal.tsx
+++ b/client/my-sites/subscribers/components/gift-modal/gift-modal.tsx
@@ -1,7 +1,8 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@automattic/components';
 import { Modal } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import ProductsSelector from 'calypso/my-sites/earn/components/add-edit-coupon-modal/products-selector';
 import { useDispatch } from 'calypso/state';
 import { requestAddGift } from 'calypso/state/memberships/gifts/actions';
@@ -33,6 +34,12 @@ const GiftSubscriptionModal = ( {
 
 	const [ planId, setPlanId ] = useState( 0 );
 
+	useEffect( () => {
+		recordTracksEvent( 'calypso_subscribers_comp_modal_open', {
+			site_id: siteId,
+		} );
+	}, [ siteId ] );
+
 	const title = translate( 'Gift a subscription' );
 
 	const text = translate( 'Select a plan to gift to this user: ' );
@@ -43,6 +50,12 @@ const GiftSubscriptionModal = ( {
 			plan_id: plan_id,
 			user_id: user_id,
 		};
+
+		recordTracksEvent( 'calypso_subscribers_comp_confirm', {
+			site_id: siteId,
+			plan_id: plan_id,
+			user_id: user_id,
+		} );
 
 		dispatch(
 			requestAddGift(


### PR DESCRIPTION
## Proposed Changes

Related to NL-444

* Add `calypso_subscribers_comp_modal_open` tracks event when the Gift a Subscription modal opens
* Add `calypso_subscribers_comp_confirm` tracks event when the user clicks Confirm (includes `site_id`, `plan_id`, `user_id`)
* For email-only subscribers, send `is_email_subscriber: true` instead of `user_id` to avoid leaking PII into Tracks

## Why are these changes being made?

* We currently have no analytics tracking on the Gift a Subscription modal. These events let us measure gifting intent (modal opens) and actual gift attempts (confirm clicks).
* Since `user_id` can be an email address for email-only subscribers, we avoid sending it as a Tracks property and instead send a boolean flag to distinguish the two subscriber types.

## Testing Instructions

* Navigate to a site's Subscribers page (for a site with the gift/coupons feature enabled)
* Open the Gift a Subscription modal for a subscriber
* Verify `calypso_subscribers_comp_modal_open` fires on open (check via browser console or Tracks debug)
* Select a plan and click Confirm
* Verify `calypso_subscribers_comp_confirm` fires with the correct `site_id`, `plan_id`, and `user_id`
* For an email-only subscriber, verify the confirm event has `is_email_subscriber: true` instead of `user_id`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)