### PR TITLE
zendesk-client: Fix undeclared dependency by replacing direct help-center import with data-stores

### DIFF
--- a/packages/zendesk-client/package.json
+++ b/packages/zendesk-client/package.json
@@ -34,6 +34,7 @@
 	},
 	"dependencies": {
 		"@automattic/calypso-analytics": "workspace:^",
+		"@automattic/data-stores": "workspace:^",
 		"@tanstack/react-query": "^5.83.0",
 		"@wordpress/api-fetch": "^7.23.0",
 		"@wordpress/element": "^6.23.0",

--- a/packages/zendesk-client/package.json
+++ b/packages/zendesk-client/package.json
@@ -37,6 +37,7 @@
 		"@automattic/data-stores": "workspace:^",
 		"@tanstack/react-query": "^5.83.0",
 		"@wordpress/api-fetch": "^7.23.0",
+		"@wordpress/data": "^10.23.0",
 		"@wordpress/element": "^6.23.0",
 		"@wordpress/url": "^4.23.0",
 		"react": "^18.3.1",

--- a/packages/zendesk-client/src/use-get-unread-conversations.ts
+++ b/packages/zendesk-client/src/use-get-unread-conversations.ts
@@ -1,8 +1,10 @@
-import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
+import { HelpCenter } from '@automattic/data-stores';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { useCallback } from 'react';
 import Smooch from 'smooch';
 import type { ZendeskConversation } from './types';
+
+const HELP_CENTER_STORE = HelpCenter.register();
 
 export const calculateUnread = (
 	conversations: Conversation[] | ZendeskConversation[] | undefined | null

--- a/yarn.lock
+++ b/yarn.lock
@@ -2688,6 +2688,7 @@ __metadata:
     "@automattic/data-stores": "workspace:^"
     "@tanstack/react-query": "npm:^5.83.0"
     "@wordpress/api-fetch": "npm:^7.23.0"
+    "@wordpress/data": "npm:^10.23.0"
     "@wordpress/element": "npm:^6.23.0"
     "@wordpress/url": "npm:^4.23.0"
     react: "npm:^18.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2685,6 +2685,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
+    "@automattic/data-stores": "workspace:^"
     "@tanstack/react-query": "npm:^5.83.0"
     "@wordpress/api-fetch": "npm:^7.23.0"
     "@wordpress/element": "npm:^6.23.0"


### PR DESCRIPTION
## Problem

`zendesk-client` is importing HELP_CENTER_STORE directly from `@automattic/help-center/src/stores`, which isn't declared as a dependency. This is working in normal builds but sometimes failing in cold builds when help-center isn't resolved yet.

This file is a oneliner that just calls HelpCenter.register() from `@automattic/data-stores` and exports it, so we shouldn't need the extra layer. This was also making a hidden dependency to `@wordpress/data`.

## Proposed Changes

* Replace the deep import with HelpCenter.register() from data-stores, and add data-stores as a dependency. This is the same thing that other users of the help center store do, like `support-articles/src/hooks/use-content-filter.ts`.
* Add `@wordpress/data` as a dependency, since it's listed as a peerDep to `@automattic/data-stores`.

## Why are these changes being made?

*

## Testing Instructions


* `yarn run build` in packages/zendesk-client

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
