### PR TITLE
MSD: add missing calypso/ai-site-builder-flow flag in dashboard envs

### DIFF
--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -23,6 +23,7 @@
 	"logout_url": "https://|subdomain|wordpress.com",
 	"features": {
 		"always_use_logout_url": true,
+		"calypso/ai-site-builder-flow": true,
 		"ciab/allow-domain-features": true,
 		"cookie-banner": false,
 		"rum-tracking/logstash": true,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -20,6 +20,7 @@
 	"wpcom_url": "https://wpcalypso.wordpress.com",
 	"wpcom_login_url": "https://wordpress.com/log-in",
 	"features": {
+		"calypso/ai-site-builder-flow": true,
 		"catch-js-errors": true,
 		"ciab/allow-domain-features": true,
 		"ciab/custom-branding": false,

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -20,6 +20,7 @@
 	"wpcom_url": "https://wordpress.com",
 	"wpcom_login_url": "https://wordpress.com/log-in",
 	"features": {
+		"calypso/ai-site-builder-flow": true,
 		"catch-js-errors": true,
 		"posthog-tracking": true,
 		"ciab/allow-domain-features": true,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -20,6 +20,7 @@
 	"wpcom_url": "https://wordpress.com",
 	"wpcom_login_url": "https://wordpress.com/log-in",
 	"features": {
+		"calypso/ai-site-builder-flow": true,
 		"catch-js-errors": true,
 		"ciab/allow-domain-features": true,
 		"ciab/custom-branding": false,


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/109199

## Proposed Changes

We forgot to add the `calypso/ai-site-builder-flow` feature flag, which allows us to actually finish the new site creation flow. 🤦 


## Testing Instructions

1. Click the dashboard live link (CIAB)
2. Click Add new store
3. Verify you can complete the flow and land in the new store's wp-admin.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
