### PR TITLE
Add the experiment that splits cancellations from refunds

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-full-text.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-full-text.tsx
@@ -1,8 +1,8 @@
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { intlFormat } from 'date-fns';
-import { shouldShowRefundEligibilityNotice } from '../../../utils/purchase';
 import RefundAmountString from './refund-amount-string';
+import { useShowRefundEligibilityNotice } from './use-show-refund-eligibility-notice';
 import type { Purchase } from '@automattic/api-core';
 
 interface CancellationFullTextProps {
@@ -18,6 +18,7 @@ export default function CancellationFullText( {
 }: CancellationFullTextProps ) {
 	const { expiry_date: expiryDate } = purchase;
 	const expirationDate = intlFormat( expiryDate, { dateStyle: 'medium' }, { locale: 'en-US' } );
+	const showRefundEligibilityNotice = useShowRefundEligibilityNotice( purchase );
 
 	const refundAmountString = RefundAmountString( {
 		purchase,
@@ -26,7 +27,7 @@ export default function CancellationFullText( {
 	} );
 
 	// Skip refund text for refundable dotcom plans since refund is offered via the notice
-	if ( refundAmountString && ! shouldShowRefundEligibilityNotice( purchase ) ) {
+	if ( refundAmountString && ! showRefundEligibilityNotice ) {
 		return createInterpolateElement(
 			sprintf(
 				/* translators: $(refundText)s is of the form "[currency-symbol][amount]" i.e. "$20" */

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -56,7 +56,6 @@ import {
 	isAkismetProduct,
 	isPartnerPurchase,
 	isOneTimePurchase,
-	shouldShowRefundEligibilityNotice,
 } from '../../../utils/purchase';
 import CancelHeaderTitle from './cancel-header-title';
 import CancelPurchaseForm from './cancel-purchase-form';
@@ -82,6 +81,7 @@ import MarketPlaceSubscriptionsDialog from './marketplace-subscriptions-dialog';
 import nextStep from './next-step';
 import RefundEligibilityNotice from './refund-eligibility-notice';
 import TimeRemainingNotice from './time-remaining-notice';
+import { useShowRefundEligibilityNotice } from './use-show-refund-eligibility-notice';
 import type { CancelPurchaseState } from './types';
 import type {
 	Purchase,
@@ -349,6 +349,8 @@ export default function CancelPurchase() {
 		error: offerApplyError,
 	} = useMutation( applyCancellationOfferMutation( purchase.blog_id, purchase.ID ) );
 	const marketingSurveyMutate = useMutation( marketingSurveyMutation() );
+
+	const showRefundEligibilityNotice = useShowRefundEligibilityNotice( purchase );
 
 	// Handler helpers
 	const purchases = purchase && sitePurchases;
@@ -683,7 +685,7 @@ export default function CancelPurchase() {
 		// (not the refund link), they're opting for an auto-renew cancellation — no refund, so
 		// no need to ask about the domain. Skip straight to the survey.
 		const skippingDomainOptionsForAutoRenew =
-			shouldShowRefundEligibilityNotice( purchase ) && cancelIntent !== 'refund';
+			showRefundEligibilityNotice && cancelIntent !== 'refund';
 
 		const needsDomainOptions =
 			! skippingDomainOptionsForAutoRenew &&
@@ -1098,10 +1100,7 @@ export default function CancelPurchase() {
 			effectiveFlowType = CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND;
 		}
 		// If default Cancel button on refundable wpcom plan, use auto-renew flow
-		else if (
-			flowType === CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND &&
-			shouldShowRefundEligibilityNotice( purchase )
-		) {
+		else if ( flowType === CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND && showRefundEligibilityNotice ) {
 			effectiveFlowType = CANCEL_FLOW_TYPE.CANCEL_AUTORENEW;
 		}
 
@@ -1368,7 +1367,7 @@ export default function CancelPurchase() {
 			notices={
 				! state.surveyShown &&
 				! state.showDomainOptionsStep &&
-				( shouldShowRefundEligibilityNotice( purchase ) ? (
+				( showRefundEligibilityNotice ? (
 					<RefundEligibilityNotice
 						purchase={ purchase }
 						onClaimRefund={ onCancellationStartForRefund }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/refund-eligibility-notice.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/refund-eligibility-notice.tsx
@@ -2,11 +2,9 @@ import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import Notice from '../../../components/notice';
-import {
-	hasAmountAvailableToRefund,
-	shouldShowRefundEligibilityNotice,
-} from '../../../utils/purchase';
+import { hasAmountAvailableToRefund } from '../../../utils/purchase';
 import RefundAmountString from './refund-amount-string';
+import { useShowRefundEligibilityNotice } from './use-show-refund-eligibility-notice';
 import type { Purchase } from '@automattic/api-core';
 
 interface RefundEligibilityNoticeProps {
@@ -18,10 +16,9 @@ export default function RefundEligibilityNotice( {
 	purchase,
 	onClaimRefund,
 }: RefundEligibilityNoticeProps ) {
-	if (
-		! shouldShowRefundEligibilityNotice( purchase ) ||
-		! hasAmountAvailableToRefund( purchase )
-	) {
+	const showRefundEligibilityNotice = useShowRefundEligibilityNotice( purchase );
+
+	if ( ! showRefundEligibilityNotice || ! hasAmountAvailableToRefund( purchase ) ) {
 		return null;
 	}
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/refund-information.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/refund-information.tsx
@@ -2,11 +2,8 @@ import config from '@automattic/calypso-config';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { Text } from '../../../components/text';
-import {
-	hasAmountAvailableToRefund,
-	isOneTimePurchase,
-	shouldShowRefundEligibilityNotice,
-} from '../../../utils/purchase';
+import { hasAmountAvailableToRefund, isOneTimePurchase } from '../../../utils/purchase';
+import { useShowRefundEligibilityNotice } from './use-show-refund-eligibility-notice';
 import type { Purchase, Domain } from '@automattic/api-core';
 
 interface CancelPurchaseRefundInformationProps {
@@ -25,7 +22,7 @@ const CancelPurchaseRefundInformation = ( {
 	let text;
 
 	// Treat refundable dotcom plans as non-refundable since refund is offered via the notice
-	const treatAsNonRefundable = shouldShowRefundEligibilityNotice( purchase );
+	const treatAsNonRefundable = useShowRefundEligibilityNotice( purchase );
 
 	if ( purchase.is_refundable && ! treatAsNonRefundable ) {
 		if ( purchase.is_domain_registration ) {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/use-show-refund-eligibility-notice.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/use-show-refund-eligibility-notice.ts
@@ -1,0 +1,18 @@
+import { useExperiment } from 'calypso/lib/explat';
+import { shouldShowRefundEligibilityNotice } from '../../../utils/purchase';
+import type { Purchase } from '@automattic/api-core';
+
+const EXPERIMENT_NAME = 'calypso_split_cancel_refund_20260316';
+
+/**
+ * Returns true if the refund eligibility notice should be shown for the given purchase.
+ *
+ * The notice is shown when the user is assigned to the treatment variation of the
+ * calypso_split_cancel_refund experiment and the purchase is a refundable WordPress.com plan.
+ */
+export function useShowRefundEligibilityNotice( purchase: Purchase ): boolean {
+	const [ isLoadingExperiment, experimentAssignment ] = useExperiment( EXPERIMENT_NAME );
+	const isInTreatment =
+		! isLoadingExperiment && experimentAssignment?.variationName === 'treatment';
+	return shouldShowRefundEligibilityNotice( purchase, isInTreatment );
+}

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -8,7 +8,6 @@ import {
 	TitanMailSlugs,
 	WPCOM_DIFM_LITE,
 } from '@automattic/api-core';
-import config from '@automattic/calypso-config';
 import { formatNumber } from '@automattic/number-formatters';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
@@ -676,16 +675,20 @@ export function hasAmountAvailableToRefund( purchase: Purchase ) {
 /**
  * Returns true if the refund eligibility notice should be shown for the given purchase.
  *
- * The notice is shown for refundable WordPress.com plans when the feature flag is enabled.
+ * The notice is shown for refundable WordPress.com plans when the experiment is enabled.
  * When shown, the notice replaces the standard refund flow with an auto-renew cancellation
  * flow, offering the refund as an explicit opt-in action instead.
+ *
+ * @param purchase  - the purchase to check
+ * @param isEnabled - whether the user is assigned to the treatment variation of the
+ *                    calypso_split_cancel_refund experiment. Use the
+ *                    `useShowRefundEligibilityNotice` hook to determine this in React components.
  */
-export function shouldShowRefundEligibilityNotice( purchase: Purchase ): boolean {
-	return (
-		config.isEnabled( 'calypso/refund-eligibility-notice' ) &&
-		hasAmountAvailableToRefund( purchase ) &&
-		isDotcomPlan( purchase )
-	);
+export function shouldShowRefundEligibilityNotice(
+	purchase: Purchase,
+	isEnabled: boolean
+): boolean {
+	return isEnabled && hasAmountAvailableToRefund( purchase ) && isDotcomPlan( purchase );
 }
 
 /**

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import {
 	isDomainRegistration,
 	isDomainTransfer,
@@ -30,6 +29,7 @@ import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import CancelPurchaseForm from 'calypso/components/marketing-survey/cancel-purchase-form';
 import { CANCEL_FLOW_TYPE } from 'calypso/components/marketing-survey/cancel-purchase-form/constants';
 import { getSelectedDomain } from 'calypso/lib/domains';
+import { useExperiment } from 'calypso/lib/explat';
 import {
 	getName,
 	purchaseType,
@@ -120,6 +120,7 @@ export interface CancelPurchaseConnectedProps {
 	isHundredYearDomain: boolean | undefined;
 	isJetpack: boolean;
 	isJetpackPurchase: boolean;
+	isRefundEligibilityNoticeEnabled: boolean;
 	productsList: Record< string, { product_type: string; billing_product_slug: string } >;
 	purchase: Purchases.Purchase;
 	purchases: Purchases.Purchase[];
@@ -612,7 +613,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 
 	shouldUseAutoRenewFlow = ( purchase: Purchases.Purchase ) => {
 		return Boolean(
-			config.isEnabled( 'calypso/refund-eligibility-notice' ) &&
+			this.props.isRefundEligibilityNoticeEnabled &&
 				hasAmountAvailableToRefund( purchase ) &&
 				isPlan( purchase ) &&
 				isWpComPlan( purchase?.productSlug )
@@ -1030,7 +1031,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 	}
 }
 
-export default connect(
+const ConnectedCancelPurchase = connect(
 	( state, props: CancelPurchaseProps ) => {
 		const purchase = getByPurchaseId( state, props.purchaseId );
 		const isJetpackPurchase =
@@ -1061,3 +1062,19 @@ export default connect(
 	},
 	{ recordTracksEvent, clearPurchases, refreshSitePlans, successNotice, errorNotice }
 )( localize( withLocalizedMoment( CancelPurchase ) ) );
+
+function CancelPurchaseWithExperiment( props: CancelPurchaseProps ) {
+	const [ isLoadingExperiment, experimentAssignment ] = useExperiment(
+		'calypso_split_cancel_refund_20260316'
+	);
+	const isRefundEligibilityNoticeEnabled =
+		! isLoadingExperiment && experimentAssignment?.variationName === 'treatment';
+	return (
+		<ConnectedCancelPurchase
+			{ ...props }
+			isRefundEligibilityNoticeEnabled={ isRefundEligibilityNoticeEnabled }
+		/>
+	);
+}
+
+export default CancelPurchaseWithExperiment;

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -129,6 +129,10 @@ export interface CancelPurchaseConnectedProps {
 
 export interface CancelPurchaseProps {
 	getManagePurchaseUrlFor?: GetManagePurchaseUrlFor;
+	getConfirmCancelDomainUrlFor?: (
+		targetSiteSlug: string,
+		targetPurchaseId: string | number
+	) => string;
 	purchaseId: number;
 	purchaseListUrl?: string;
 	siteSlug: string;

--- a/config/development.json
+++ b/config/development.json
@@ -50,7 +50,6 @@
 		"calypso/all-domain-management": true,
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,
-		"calypso/refund-eligibility-notice": false,
 		"checkout/checkout-version": true,
 		"ciab/allow-domain-features": true,
 		"ciab/custom-branding": true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-16051

## Proposed Changes

Rather than having a flag, conditionally launch this with an experiment. It won't enable it immediately because the experiment is not launched.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

* In ExPlat, follow the instructions fro calypso_split_cancel_refund_20260316 and test both control and treatment
* For treatment:
<img width="1367" height="676" alt="Screenshot 2026-03-16 at 13 30 14" src="https://github.com/user-attachments/assets/f0471af2-43bf-4153-bc06-f9f16e323a42" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
