### PR TITLE
Theme Showcase: Add and update modern Theme Showcase events

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -21,7 +21,10 @@ import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { updateThemes } from 'calypso/state/themes/actions/theme-update';
-import { isExternallyManagedTheme as getIsExternallyManagedTheme } from 'calypso/state/themes/selectors';
+import {
+	getThemeType,
+	isExternallyManagedTheme as getIsExternallyManagedTheme,
+} from 'calypso/state/themes/selectors';
 import { setThemesBookmark } from 'calypso/state/themes/themes-ui/actions';
 import ThemeMoreButton from './more-button';
 
@@ -348,7 +351,7 @@ export class Theme extends Component {
 	};
 
 	renderImageOverlay = () => {
-		const { isThemeShowcaseModern, buttonContents, theme } = this.props;
+		const { isThemeShowcaseModern, buttonContents, theme, themeType } = this.props;
 
 		if ( ! isThemeShowcaseModern ) {
 			return null;
@@ -361,6 +364,24 @@ export class Theme extends Component {
 			return null;
 		}
 
+		const eventProps = {
+			theme: theme.id,
+			theme_tier: theme.theme_tier?.slug,
+			theme_type: themeType,
+		};
+
+		const handlePreviewButtonClick = ( e ) => {
+			e.stopPropagation();
+			e.preventDefault();
+			this.props.recordTracksEvent( 'calypso_themeshowcase_theme_preview_click', eventProps );
+			previewOption.action?.( theme.id );
+		};
+
+		const handleSignupButtonClick = ( e ) => {
+			this.props.recordTracksEvent( 'calypso_themeshowcase_theme_signup_click', eventProps );
+			e.stopPropagation();
+		};
+
 		return (
 			<div className="theme__overlay-buttons">
 				{ previewOption && (
@@ -368,11 +389,7 @@ export class Theme extends Component {
 						__next40pxDefaultSize
 						variant="secondary"
 						className="theme__overlay-button theme__overlay-button-preview"
-						onClick={ ( e ) => {
-							e.stopPropagation();
-							e.preventDefault();
-							previewOption.action?.( theme.id );
-						} }
+						onClick={ handlePreviewButtonClick }
 					>
 						{ this.props.translate( 'Preview demo' ) }
 					</WPButton>
@@ -383,9 +400,7 @@ export class Theme extends Component {
 						variant="primary"
 						className="theme__overlay-button theme__overlay-button-get-started"
 						href={ signupOption.getUrl?.( theme.id ) }
-						onClick={ ( e ) => {
-							e.stopPropagation();
-						} }
+						onClick={ handleSignupButtonClick }
 					>
 						{ this.props.translate( 'Get started' ) }
 					</WPButton>
@@ -445,6 +460,7 @@ const ConnectedTheme = connect(
 			isExternallyManagedTheme,
 			siteSlug: getSiteSlug( state, siteId ),
 			isThemeShowcaseModern,
+			themeType: getThemeType( state, theme.id ),
 		};
 	},
 	{ recordTracksEvent, setThemesBookmark, updateThemes }

--- a/client/components/theme/test/index.jsx
+++ b/client/components/theme/test/index.jsx
@@ -21,6 +21,7 @@ describe( 'Theme', () => {
 		translate: ( string ) => string,
 		setThemesBookmark: () => {},
 		onScreenshotClick: () => {},
+		recordTracksEvent: jest.fn(),
 	};
 
 	describe( 'rendering', () => {

--- a/client/my-sites/themes/filter-bar-modern/index.tsx
+++ b/client/my-sites/themes/filter-bar-modern/index.tsx
@@ -5,6 +5,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { InView } from 'react-intersection-observer';
 import { CategoryPillNavigation } from 'calypso/components/category-pill-navigation';
 import Search, { SEARCH_MODE_ON_ENTER } from 'calypso/components/search';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { CustomSelectWrapper } from 'calypso/my-sites/themes/custom-select-wrapper';
 import { DEFAULT_STATIC_FILTER } from 'calypso/state/themes/constants';
 import { constructThemeShowcaseUrl } from '../helpers';
@@ -46,6 +47,16 @@ const FilterBarModern = ( {
 	const translate = useTranslate();
 	const [ isSticky, setIsSticky ] = useState( false );
 	const [ isSearchOpen, setIsSearchOpen ] = useState( false );
+
+	const handleSearchOpen = useCallback( () => {
+		recordTracksEvent( 'calypso_themeshowcase_filter_search_expand' );
+		setIsSearchOpen( true );
+	}, [] );
+
+	const handleSearchClose = useCallback( () => {
+		recordTracksEvent( 'calypso_themeshowcase_filter_search_clear_icon_click' );
+		setIsSearchOpen( false );
+	}, [] );
 
 	const pillCategories = useMemo(
 		() =>
@@ -113,8 +124,8 @@ const FilterBarModern = ( {
 							<Search
 								pinned
 								isOpen={ isSearchOpen }
-								onSearchOpen={ () => setIsSearchOpen( true ) }
-								onSearchClose={ () => setIsSearchOpen( false ) }
+								onSearchOpen={ handleSearchOpen }
+								onSearchClose={ handleSearchClose }
 								initialValue={ searchQuery }
 								onSearch={ onSearch }
 								placeholder={ translate( 'Search themes…' ) }

--- a/client/my-sites/themes/filter-bar-modern/index.tsx
+++ b/client/my-sites/themes/filter-bar-modern/index.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Icon, starEmpty } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -5,7 +6,6 @@ import { useCallback, useMemo, useState } from 'react';
 import { InView } from 'react-intersection-observer';
 import { CategoryPillNavigation } from 'calypso/components/category-pill-navigation';
 import Search, { SEARCH_MODE_ON_ENTER } from 'calypso/components/search';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { CustomSelectWrapper } from 'calypso/my-sites/themes/custom-select-wrapper';
 import { DEFAULT_STATIC_FILTER } from 'calypso/state/themes/constants';
 import { constructThemeShowcaseUrl } from '../helpers';

--- a/client/my-sites/themes/search-results-modern/index.tsx
+++ b/client/my-sites/themes/search-results-modern/index.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import page from '@automattic/calypso-router';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
@@ -219,15 +220,20 @@ export default function SearchResultsModern( {
 			{ hasWporgThemes && (
 				<div className="search-results-modern__section">
 					<ThemeSectionHeader
-						title={ translate( 'Community themes' ) }
-						subtitle={ translate(
-							'Explore "%(query)s" themes from the WordPress community, and upload to install when ready.',
-							{ args: { query: search } }
-						) }
+						title={ THEME_COLLECTIONS.community.title }
+						subtitle={
+							typeof THEME_COLLECTIONS.community.description === 'function'
+								? THEME_COLLECTIONS.community.description( { search } )
+								: THEME_COLLECTIONS.community.description
+						}
 						buttonLabel={ hasMoreWporgThemes ? translate( 'See all' ) : undefined }
 						onButtonClick={
 							hasMoreWporgThemes
 								? () => {
+										recordTracksEvent( 'calypso_themeshowcase_collection_see_all_click', {
+											collection: THEME_COLLECTIONS.community.collectionSlug,
+											collection_index: 1,
+										} );
 										page(
 											buildRelativeSearchUrl( THEME_COLLECTIONS.community.seeAllLink, search )
 										);

--- a/client/my-sites/themes/sections-modern/test/theme-section.test.tsx
+++ b/client/my-sites/themes/sections-modern/test/theme-section.test.tsx
@@ -83,7 +83,7 @@ describe( 'ThemeSection', () => {
 
 	test( 'renders "See all" button', () => {
 		render( <ThemeSection { ...defaultProps } /> );
-		expect( screen.getByRole( 'button', { name: 'See all' } ) ).toBeVisible();
+		expect( screen.getByRole( 'link', { name: 'See all' } ) ).toBeVisible();
 	} );
 
 	test( 'applies light variant by default', () => {

--- a/client/my-sites/themes/sections-modern/theme-section-header.tsx
+++ b/client/my-sites/themes/sections-modern/theme-section-header.tsx
@@ -5,7 +5,7 @@ import './style.scss';
 
 interface ThemeSectionHeaderProps {
 	title: TranslateResult;
-	subtitle: TranslateResult;
+	subtitle: TranslateResult | null;
 	buttonLabel?: string;
 	buttonHref?: string;
 	onButtonClick?: () => void;

--- a/client/my-sites/themes/sections-modern/theme-section.tsx
+++ b/client/my-sites/themes/sections-modern/theme-section.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import page from '@automattic/calypso-router';
 import clsx from 'clsx';
 import { useQueryThemes } from 'calypso/components/data/query-themes';
@@ -90,6 +91,9 @@ export default function ThemeSection( {
 	};
 
 	const handleSeeAll = () => {
+		recordTracksEvent( 'calypso_themeshowcase_section_see_all_click', {
+			section: sectionSlug,
+		} );
 		page( seeAllUrl );
 		window.scrollTo( { top: 0 } );
 	};
@@ -99,6 +103,7 @@ export default function ThemeSection( {
 			<ThemeSectionHeader
 				title={ title }
 				subtitle={ subtitle }
+				buttonHref={ seeAllUrl }
 				buttonLabel={ buttonLabel }
 				onButtonClick={ handleSeeAll }
 			/>

--- a/client/my-sites/themes/themes-faq/index.tsx
+++ b/client/my-sites/themes/themes-faq/index.tsx
@@ -21,9 +21,14 @@ export default function ThemesFAQ() {
 		( faqArgs: { id: string; isExpanded: boolean } ) => {
 			const { id, isExpanded } = faqArgs;
 			dispatch(
-				recordTracksEvent( isExpanded ? 'calypso_themes_faq_open' : 'calypso_themes_faq_closed', {
-					faq_id: id,
-				} )
+				recordTracksEvent(
+					isExpanded
+						? 'calypso_themeshowcase_faq_open_click'
+						: 'calypso_themeshowcase_faq_close_click',
+					{
+						faq_id: id,
+					}
+				)
 			);
 		},
 		[ dispatch ]


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTTHEM-322

## Proposed Changes

* Add modern filter bar search expand and close events.
* Add modern Community themes collection events.
* Add modern home sections events.
* Add modern theme card overlay events.
* Update modern theme FAQs events.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* For consistency with the broader Tracks events system.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Theme Showcase logged-out and using the `themes/showcase-modern` feature flag.
* Look at the DOTTHEM-322 audit to know what to click and what to expect.
* Open the browser's dev tools' network tab and filter by `calypso_themeshowcase_` for convenience.
* Click around and ensure the expected event shows up in the network tab.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
