### PR TITLE
Plugins: Use plan from available features for upgrade nudge

### DIFF
--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -66,13 +66,10 @@ import {
 	FEATURE_INSTALL_PLUGINS,
 	PLAN_FREE,
 	PLAN_BUSINESS,
-	PLAN_BUSINESS_2_YEARS,
 	PLAN_PREMIUM,
-	PLAN_PREMIUM_2_YEARS,
 	PLAN_PERSONAL,
-	PLAN_PERSONAL_2_YEARS,
 	PLAN_BLOGGER,
-	PLAN_BLOGGER_2_YEARS,
+	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 } from '@automattic/calypso-products';
 import { screen } from '@testing-library/react';
 import { merge } from 'lodash';
@@ -131,33 +128,53 @@ describe( 'Search view', () => {
 
 describe( 'Upsell Nudge should get appropriate plan constant', () => {
 	test.each( [ PLAN_FREE, PLAN_BLOGGER, PLAN_PERSONAL, PLAN_PREMIUM ] )(
-		`Business 1 year for (%s)`,
+		`Cheapest plan for (%s)`,
 		( product_slug ) => {
 			const initialState = {
 				sites: {
 					items: { 1: { jetpack: false, plan: { product_slug } } },
-					features: { 1: { data: [ FEATURE_INSTALL_PLUGINS ] } },
+					features: {
+						1: {
+							data: {
+								active: [],
+								available: {
+									[ FEATURE_INSTALL_PLUGINS ]: [ PLAN_PERSONAL ],
+									[ WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS ]: [ PLAN_PERSONAL ],
+								},
+							},
+						},
+					},
 				},
 			};
 			render( <PluginsBrowser />, { initialState } );
 			const nudge = screen.getByTestId( 'upsell-nudge' );
 			expect( nudge ).toBeVisible();
-			expect( nudge ).toHaveTextContent( PLAN_BUSINESS );
+			expect( nudge ).toHaveTextContent( PLAN_PERSONAL );
 		}
 	);
 
-	test.each( [ PLAN_BLOGGER_2_YEARS, PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM_2_YEARS ] )(
-		`Business 2 year for (%s)`,
-		( product_slug ) => {
-			const initialState = {
-				sites: { items: { 1: { jetpack: false, plan: { product_slug } } } },
-			};
-			render( <PluginsBrowser />, { initialState } );
-			const nudge = screen.getByTestId( 'upsell-nudge' );
-			expect( nudge ).toBeVisible();
-			expect( nudge ).toHaveTextContent( PLAN_BUSINESS_2_YEARS );
-		}
-	);
+	test( 'should use business plan when it is the cheapest for the feature', () => {
+		const initialState = {
+			sites: {
+				items: { 1: { jetpack: false, plan: { product_slug: PLAN_FREE } } },
+				features: {
+					1: {
+						data: {
+							active: [],
+							available: {
+								[ FEATURE_INSTALL_PLUGINS ]: [ PLAN_BUSINESS ],
+								[ WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS ]: [ PLAN_BUSINESS ],
+							},
+						},
+					},
+				},
+			},
+		};
+		render( <PluginsBrowser />, { initialState } );
+		const nudge = screen.getByTestId( 'upsell-nudge' );
+		expect( nudge ).toBeVisible();
+		expect( nudge ).toHaveTextContent( PLAN_BUSINESS );
+	} );
 } );
 
 describe( 'PluginsBrowser basic tests', () => {

--- a/client/my-sites/plugins/plugins-discovery-page/test/upgrade-nudge.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/test/upgrade-nudge.jsx
@@ -1,0 +1,150 @@
+/** @jest-environment jsdom */
+
+jest.mock( 'calypso/blocks/upsell-nudge', () => ( { plan, title, feature } ) => (
+	<div data-testid="upsell-nudge" data-plan={ plan } data-feature={ feature }>
+		{ title }
+	</div>
+) );
+
+import {
+	FEATURE_INSTALL_PLUGINS,
+	PLAN_FREE,
+	PLAN_PERSONAL,
+	PLAN_BUSINESS,
+	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
+} from '@automattic/calypso-products';
+import { screen } from '@testing-library/react';
+import { merge } from 'lodash';
+import { reducer as ui } from 'calypso/state/ui/reducer';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import UpgradeNudge from '../upgrade-nudge';
+
+const siteId = 1;
+
+// State where paid plugins are on a cheaper plan than free plugin installs,
+// so paidPluginsOnLowerPlan = true and the general upsell nudge renders.
+const baseState = {
+	ui: { selectedSiteId: siteId },
+	sites: {
+		items: {
+			[ siteId ]: {
+				ID: siteId,
+				slug: 'example.wordpress.com',
+				plan: { product_slug: PLAN_FREE },
+			},
+		},
+		features: {
+			[ siteId ]: {
+				data: {
+					active: [],
+					available: {
+						[ FEATURE_INSTALL_PLUGINS ]: [ PLAN_PERSONAL ],
+						[ WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS ]: [ PLAN_FREE ],
+					},
+				},
+			},
+		},
+	},
+	currentUser: {
+		capabilities: { [ siteId ]: { manage_options: true } },
+	},
+};
+
+const render = ( props = {}, stateOverrides = {} ) =>
+	renderWithProvider( <UpgradeNudge siteSlug="example.wordpress.com" { ...props } />, {
+		initialState: merge( {}, baseState, stateOverrides ),
+		reducers: { ui },
+	} );
+
+describe( 'UpgradeNudge', () => {
+	test( 'should use the cheapest plan from plansForInstallPlugins', () => {
+		render();
+		const nudge = screen.getByTestId( 'upsell-nudge' );
+		expect( nudge ).toBeVisible();
+		expect( nudge ).toHaveAttribute( 'data-plan', PLAN_PERSONAL );
+	} );
+
+	test( 'should show the plan name in the title', () => {
+		render();
+		const nudge = screen.getByTestId( 'upsell-nudge' );
+		expect( nudge.textContent ).toContain( 'Personal' );
+	} );
+
+	test( 'should use the correct plan when business is the cheapest', () => {
+		render(
+			{},
+			{
+				sites: {
+					features: {
+						[ siteId ]: {
+							data: {
+								active: [],
+								available: {
+									[ FEATURE_INSTALL_PLUGINS ]: [ PLAN_BUSINESS ],
+									[ WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS ]: [ PLAN_FREE ],
+								},
+							},
+						},
+					},
+				},
+			}
+		);
+		const nudge = screen.getByTestId( 'upsell-nudge' );
+		expect( nudge ).toHaveAttribute( 'data-plan', PLAN_BUSINESS );
+	} );
+
+	test( 'should pass FEATURE_INSTALL_PLUGINS as the feature', () => {
+		render();
+		const nudge = screen.getByTestId( 'upsell-nudge' );
+		expect( nudge ).toHaveAttribute( 'data-feature', FEATURE_INSTALL_PLUGINS );
+	} );
+
+	test( 'should not render when site already has FEATURE_INSTALL_PLUGINS', () => {
+		render(
+			{},
+			{
+				sites: {
+					features: {
+						[ siteId ]: {
+							data: {
+								active: [ FEATURE_INSTALL_PLUGINS ],
+								available: {
+									[ FEATURE_INSTALL_PLUGINS ]: [ PLAN_PERSONAL ],
+									[ WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS ]: [ PLAN_FREE ],
+								},
+							},
+						},
+					},
+				},
+			}
+		);
+		expect( screen.queryByTestId( 'upsell-nudge' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'should not render for jetpack non-atomic sites', () => {
+		render(
+			{},
+			{
+				sites: {
+					items: {
+						[ siteId ]: {
+							jetpack: true,
+							options: { is_automated_transfer: false },
+						},
+					},
+				},
+			}
+		);
+		expect( screen.queryByTestId( 'upsell-nudge' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'should not render when no site is selected', () => {
+		render(
+			{},
+			{
+				ui: { selectedSiteId: null },
+			}
+		);
+		expect( screen.queryByTestId( 'upsell-nudge' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/my-sites/plugins/plugins-discovery-page/upgrade-nudge.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/upgrade-nudge.jsx
@@ -1,11 +1,9 @@
 import { isEnabled } from '@automattic/calypso-config';
 import {
 	FEATURE_INSTALL_PLUGINS,
-	findFirstSimilarPlanKey,
 	getPlan,
 	PLAN_ECOMMERCE_MONTHLY,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
-	TYPE_BUSINESS,
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
@@ -110,9 +108,7 @@ const UpgradeNudge = ( {
 		);
 	}
 
-	const plan = findFirstSimilarPlanKey( sitePlan.product_slug, {
-		type: TYPE_BUSINESS,
-	} );
+	const plan = plansForInstallPlugins[ 0 ];
 
 	// This banner upsells the ability to install free and paid plugins on a eCommerce plan.
 	if ( isEcommerceTrial ) {
@@ -132,12 +128,12 @@ const UpgradeNudge = ( {
 		);
 	}
 
-	const title = translate( 'Access thousands of plugins with the %(businessPlanName)s Plan', {
-		args: { businessPlanName: getPlan( plan )?.getTitle() },
+	const title = translate( 'Access thousands of plugins with the %(planName)s Plan', {
+		args: { planName: getPlan( plan )?.getTitle() },
 	} );
 
 	const description = translate( 'Free domain included.' );
-	// This banner upsells the ability to install free and paid plugins on a Business plan.
+	// This banner upsells the ability to install free and paid plugins.
 	return (
 		<UpsellNudge
 			compactButton={ false }


### PR DESCRIPTION
Related to DOTMKT-3

## Proposed Changes

* Replace the hardcoded `TYPE_BUSINESS` plan lookup (`findFirstSimilarPlanKey`) in the `UpgradeNudge` component with the first plan from `plansForInstallPlugins`, which is already fetched via `getPlansForFeature`.
* Update the title string from `businessPlanName` to `planName` to reflect that the plan is no longer necessarily Business.
* Remove unused imports (`findFirstSimilarPlanKey`, `TYPE_BUSINESS`).
* Add dedicated unit tests for `UpgradeNudge` and update existing `PluginsBrowser` tests.

## Why are these changes being made?

The upgrade nudge was hardcoded to always recommend the Business plan for plugin installation. Since plugin installation is now available on lower-tier plans, the nudge should dynamically show the appropriate plan based on available features, similar to what was done in #109157 for the plugin details CTA.

## Testing Instructions

* Navigate to `/plugins` on a site with a Free plan.
* Verify the upgrade nudge shows the correct plan name (not necessarily "Business").
* Verify the "Free domain included" description is still shown.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?