### PR TITLE
Fingerprint: lazy load and run

### DIFF
--- a/client/lib/wp/handlers/fingerprint.js
+++ b/client/lib/wp/handlers/fingerprint.js
@@ -1,6 +1,6 @@
 // Internal module cache.
 // Exported for use in testing.
-/** @type { result?: string } */
+/** @type { result?: string|undefined } */
 export const cache = {};
 
 /**

--- a/client/lib/wp/handlers/fingerprint.js
+++ b/client/lib/wp/handlers/fingerprint.js
@@ -1,6 +1,6 @@
 // Internal module cache.
 // Exported for use in testing.
-/** @type { result?: string|undefined } */
+/** @type { result?: string|undefined, promise?: Promise<any> } */
 export const cache = {};
 
 /**
@@ -8,15 +8,17 @@ export const cache = {};
  * if needed.
  * @returns string|undefined The fingerprint.
  */
-async function getFingerprint() {
+function getFingerprint() {
 	if ( 'result' in cache ) {
-		return cache.result;
+		return Promise.resolve( cache.result );
 	}
-	const { load } = await import( '@fingerprintjs/fingerprintjs' );
-	const agent = await load( { monitoring: false } );
-	const result = await agent.get();
-	cache.result = result.visitorId;
-	return cache.result;
+	cache.promise ??= ( async () => {
+		const { load } = await import( '@fingerprintjs/fingerprintjs' );
+		const agent = await load( { monitoring: false } );
+		const result = await agent.get();
+		cache.result = result.visitorId;
+	} )();
+	return cache.promise.then( () => cache.result );
 }
 
 /**

--- a/client/lib/wp/handlers/fingerprint.js
+++ b/client/lib/wp/handlers/fingerprint.js
@@ -1,27 +1,4 @@
-let cached;
-let hasLoaded = false;
-let enabled = true;
-
-// NOTE: This method is only used for testing.
-export function __enableFingerprint() {
-	enabled = true;
-}
-
-// NOTE: This method is only used for testing.
-export function __disableFingerprint() {
-	enabled = false;
-}
-
-/**
- * Loads the `fingerprintjs` library and retrieves a fingerprint.
- * This gets stored in a local cache.
- */
-async function loadFingerprint() {
-	const { load } = await import( '@fingerprintjs/fingerprintjs' );
-	const agent = await load( { monitoring: false } );
-	const result = await agent.get();
-	cached = result.visitorId;
-}
+export const cache = {};
 
 /**
  * Returns the fingerprint, loading the library and generating it
@@ -29,21 +6,21 @@ async function loadFingerprint() {
  * @returns string|undefined The fingerprint.
  */
 async function getFingerprint() {
-	if ( ! enabled ) {
-		return undefined;
+	if ( 'result' in cache ) {
+		return cache.result;
 	}
-	if ( ! hasLoaded ) {
-		await loadFingerprint();
-		hasLoaded = true;
-	}
-	return cached;
+	const { load } = await import( '@fingerprintjs/fingerprintjs' );
+	const agent = await load( { monitoring: false } );
+	const result = await agent.get();
+	cache.result = result.visitorId;
+	return cache.result;
 }
 
 /**
  * Updates `wpcom` to pass a fingerprint if one is present.
  * @param {Object} wpcom Original WPCOM instance
  */
-export function injectFingerprint( wpcom ) {
+export async function injectFingerprint( wpcom ) {
 	const request = wpcom.request.bind( wpcom );
 
 	wpcom.request = async function ( params, callback ) {

--- a/client/lib/wp/handlers/fingerprint.js
+++ b/client/lib/wp/handlers/fingerprint.js
@@ -25,7 +25,7 @@ async function getFingerprint() {
  * Updates `wpcom` to pass a fingerprint if one is present.
  * @param {Object} wpcom Original WPCOM instance
  */
-export async function injectFingerprint( wpcom ) {
+export function injectFingerprint( wpcom ) {
 	const request = wpcom.request.bind( wpcom );
 
 	wpcom.request = async function ( params, callback ) {

--- a/client/lib/wp/handlers/fingerprint.js
+++ b/client/lib/wp/handlers/fingerprint.js
@@ -1,3 +1,5 @@
+// Internal module cache.
+// Exported for use in testing.
 export const cache = {};
 
 /**

--- a/client/lib/wp/handlers/fingerprint.js
+++ b/client/lib/wp/handlers/fingerprint.js
@@ -8,9 +8,9 @@ export const cache = {};
  * if needed.
  * @returns string|undefined The fingerprint.
  */
-function getFingerprint() {
+async function getFingerprint() {
 	if ( 'result' in cache ) {
-		return Promise.resolve( cache.result );
+		return cache.result;
 	}
 	cache.promise ??= ( async () => {
 		const { load } = await import( '@fingerprintjs/fingerprintjs' );
@@ -18,7 +18,8 @@ function getFingerprint() {
 		const result = await agent.get();
 		cache.result = result.visitorId;
 	} )();
-	return cache.promise.then( () => cache.result );
+	await cache.promise;
+	return cache.result;
 }
 
 /**

--- a/client/lib/wp/handlers/fingerprint.js
+++ b/client/lib/wp/handlers/fingerprint.js
@@ -1,15 +1,42 @@
-import { load } from '@fingerprintjs/fingerprintjs';
+let cached;
+let hasLoaded = false;
+let enabled = true;
 
-let fingerprint;
-export async function loadFingerprint() {
+// NOTE: This method is only used for testing.
+export function __enableFingerprint() {
+	enabled = true;
+}
+
+// NOTE: This method is only used for testing.
+export function __disableFingerprint() {
+	enabled = false;
+}
+
+/**
+ * Loads the `fingerprintjs` library and retrieves a fingerprint.
+ * This gets stored in a local cache.
+ */
+async function loadFingerprint() {
+	const { load } = await import( '@fingerprintjs/fingerprintjs' );
 	const agent = await load( { monitoring: false } );
 	const result = await agent.get();
-	fingerprint = result.visitorId;
+	cached = result.visitorId;
 }
-if ( document.readyState !== 'loading' ) {
-	loadFingerprint();
-} else {
-	document.addEventListener( 'DOMContentLoaded', loadFingerprint );
+
+/**
+ * Returns the fingerprint, loading the library and generating it
+ * if needed.
+ * @returns string|undefined The fingerprint.
+ */
+async function getFingerprint() {
+	if ( ! enabled ) {
+		return undefined;
+	}
+	if ( ! hasLoaded ) {
+		await loadFingerprint();
+		hasLoaded = true;
+	}
+	return cached;
 }
 
 /**
@@ -19,15 +46,18 @@ if ( document.readyState !== 'loading' ) {
 export function injectFingerprint( wpcom ) {
 	const request = wpcom.request.bind( wpcom );
 
-	wpcom.request = function ( params, callback ) {
-		if ( fingerprint && params?.path === '/me/transactions' ) {
-			params = {
-				...params,
-				headers: {
-					...( params.headers || {} ),
-					'X-Fingerprint': fingerprint,
-				},
-			};
+	wpcom.request = async function ( params, callback ) {
+		if ( params?.path === '/me/transactions' ) {
+			const fingerprint = await getFingerprint();
+			if ( fingerprint ) {
+				params = {
+					...params,
+					headers: {
+						...( params.headers || {} ),
+						'X-Fingerprint': fingerprint,
+					},
+				};
+			}
 		}
 		return request( params, callback );
 	};

--- a/client/lib/wp/handlers/fingerprint.js
+++ b/client/lib/wp/handlers/fingerprint.js
@@ -1,5 +1,6 @@
 // Internal module cache.
 // Exported for use in testing.
+/** @type { result?: string } */
 export const cache = {};
 
 /**

--- a/client/lib/wp/handlers/fingerprint.js
+++ b/client/lib/wp/handlers/fingerprint.js
@@ -1,25 +1,24 @@
 // Internal module cache.
 // Exported for use in testing.
-/** @type { result?: string|undefined, promise?: Promise<any> } */
+/** @type { result?: Promise<string|undefined> } */
 export const cache = {};
 
 /**
  * Returns the fingerprint, loading the library and generating it
  * if needed.
- * @returns string|undefined The fingerprint.
+ * @returns {Promise<string|undefined>} The fingerprint.
  */
 async function getFingerprint() {
-	if ( 'result' in cache ) {
-		return cache.result;
+	if ( ! cache.result ) {
+		cache.result = ( async () => {
+			const { load } = await import( '@fingerprintjs/fingerprintjs' );
+			const agent = await load( { monitoring: false } );
+			const result = await agent.get();
+			return result.visitorId;
+		} )();
 	}
-	cache.promise ??= ( async () => {
-		const { load } = await import( '@fingerprintjs/fingerprintjs' );
-		const agent = await load( { monitoring: false } );
-		const result = await agent.get();
-		cache.result = result.visitorId;
-	} )();
-	await cache.promise;
-	return cache.result;
+
+	return await cache.result;
 }
 
 /**

--- a/client/lib/wp/handlers/test/fingerprint.test.ts
+++ b/client/lib/wp/handlers/test/fingerprint.test.ts
@@ -23,7 +23,7 @@ describe( '#injectFingerprint', () => {
 
 	test( 'should not inject X-Fingerprint header when fingerprint is not available', async () => {
 		// Populate the cache, so that we get `undefined` as the fingerprint value.
-		fingerprintModule.cache.result = undefined;
+		fingerprintModule.cache.result = Promise.resolve( undefined );
 		fingerprintModule.injectFingerprint( wpcom );
 
 		await wpcom.request( { path: '/me/transactions' }, callback );

--- a/client/lib/wp/handlers/test/fingerprint.test.ts
+++ b/client/lib/wp/handlers/test/fingerprint.test.ts
@@ -2,14 +2,10 @@
  * @jest-environment jsdom
  */
 
-import {
-	type loadFingerprint as loadFingerprintType,
-	type injectFingerprint as injectFingerprintType,
-} from '../fingerprint';
+import type * as fingerprintModuleType from '../fingerprint';
 
 describe( '#injectFingerprint', () => {
-	let loadFingerprint: typeof loadFingerprintType;
-	let injectFingerprint: typeof injectFingerprintType;
+	let fingerprintModule: typeof fingerprintModuleType;
 	let wpcom: { request: jest.Mock };
 	let originalRequest: jest.Mock;
 	const callback = jest.fn();
@@ -17,7 +13,8 @@ describe( '#injectFingerprint', () => {
 	beforeAll( async () => {
 		jest.spyOn( document, 'readyState', 'get' ).mockReturnValue( 'loading' );
 		jest.spyOn( document, 'addEventListener' ).mockImplementation( () => {} );
-		( { loadFingerprint, injectFingerprint } = await import( '../fingerprint' ) );
+		fingerprintModule = await import( '../fingerprint' );
+		fingerprintModule.__disableFingerprint();
 	} );
 
 	beforeEach( () => {
@@ -26,22 +23,22 @@ describe( '#injectFingerprint', () => {
 	} );
 
 	test( 'should not inject X-Fingerprint header when fingerprint is not available', async () => {
-		injectFingerprint( wpcom );
+		fingerprintModule.injectFingerprint( wpcom );
 
-		wpcom.request( { path: '/me/transactions' }, callback );
+		await wpcom.request( { path: '/me/transactions' }, callback );
 
 		expect( originalRequest ).toHaveBeenCalledWith( { path: '/me/transactions' }, callback );
 	} );
 
-	describe( 'when fingerprint is loaded', () => {
-		beforeAll( async () => {
-			await loadFingerprint();
+	describe( 'when fingerprint is enabled', () => {
+		beforeAll( () => {
+			fingerprintModule.__enableFingerprint();
 		} );
 
-		test( 'should inject fingerprint header for transactions path', () => {
-			injectFingerprint( wpcom );
+		test( 'should inject fingerprint header for transactions path', async () => {
+			fingerprintModule.injectFingerprint( wpcom );
 
-			wpcom.request( { path: '/me/transactions' }, callback );
+			await wpcom.request( { path: '/me/transactions' }, callback );
 
 			expect( originalRequest ).toHaveBeenCalledWith(
 				{
@@ -54,18 +51,18 @@ describe( '#injectFingerprint', () => {
 			);
 		} );
 
-		test( 'should not inject header for other paths', () => {
-			injectFingerprint( wpcom );
+		test( 'should not inject header for other paths', async () => {
+			fingerprintModule.injectFingerprint( wpcom );
 
-			wpcom.request( { path: '/me/settings' }, callback );
+			await wpcom.request( { path: '/me/settings' }, callback );
 
 			expect( originalRequest ).toHaveBeenCalledWith( { path: '/me/settings' }, callback );
 		} );
 
-		test( 'should merge with existing headers if present', () => {
-			injectFingerprint( wpcom );
+		test( 'should merge with existing headers if present', async () => {
+			fingerprintModule.injectFingerprint( wpcom );
 
-			wpcom.request(
+			await wpcom.request(
 				{ path: '/me/transactions', headers: { 'Content-Type': 'application/json' } },
 				callback
 			);

--- a/client/lib/wp/handlers/test/fingerprint.test.ts
+++ b/client/lib/wp/handlers/test/fingerprint.test.ts
@@ -14,7 +14,6 @@ describe( '#injectFingerprint', () => {
 		jest.spyOn( document, 'readyState', 'get' ).mockReturnValue( 'loading' );
 		jest.spyOn( document, 'addEventListener' ).mockImplementation( () => {} );
 		fingerprintModule = await import( '../fingerprint' );
-		fingerprintModule.__disableFingerprint();
 	} );
 
 	beforeEach( () => {
@@ -23,6 +22,8 @@ describe( '#injectFingerprint', () => {
 	} );
 
 	test( 'should not inject X-Fingerprint header when fingerprint is not available', async () => {
+		// Populate the cache, so that we get `undefined` as the fingerprint value.
+		( fingerprintModule.cache as { result?: string } ).result = undefined;
 		fingerprintModule.injectFingerprint( wpcom );
 
 		await wpcom.request( { path: '/me/transactions' }, callback );
@@ -32,7 +33,9 @@ describe( '#injectFingerprint', () => {
 
 	describe( 'when fingerprint is enabled', () => {
 		beforeAll( () => {
-			fingerprintModule.__enableFingerprint();
+			// Clear the cache, so that we can run through the usual steps of
+			// retrieving a fingerprint value.
+			delete ( fingerprintModule.cache as { result?: string } )[ 'result' ];
 		} );
 
 		test( 'should inject fingerprint header for transactions path', async () => {

--- a/client/lib/wp/handlers/test/fingerprint.test.ts
+++ b/client/lib/wp/handlers/test/fingerprint.test.ts
@@ -23,7 +23,7 @@ describe( '#injectFingerprint', () => {
 
 	test( 'should not inject X-Fingerprint header when fingerprint is not available', async () => {
 		// Populate the cache, so that we get `undefined` as the fingerprint value.
-		( fingerprintModule.cache as { result?: string } ).result = undefined;
+		fingerprintModule.cache.result = undefined;
 		fingerprintModule.injectFingerprint( wpcom );
 
 		await wpcom.request( { path: '/me/transactions' }, callback );
@@ -35,7 +35,7 @@ describe( '#injectFingerprint', () => {
 		beforeAll( () => {
 			// Clear the cache, so that we can run through the usual steps of
 			// retrieving a fingerprint value.
-			delete ( fingerprintModule.cache as { result?: string } )[ 'result' ];
+			delete fingerprintModule.cache[ 'result' ];
 		} );
 
 		test( 'should inject fingerprint header for transactions path', async () => {


### PR DESCRIPTION
`fingerprintjs` is currently loaded statically, which means it's part of the initial bundle on every route. This is unnecessary, because it's only needed on transactions, e.g. when a user purchases an upgrade plan.

This PR lazily loads the `fingerprintjs` library only when a transaction is about to take place, removing ~30KB (~13KB gzipped) from the critical path. 

## Proposed Changes

* Lazily import `fingerprintjs` on transactions
* Update the tests to match the new implementation

## Why are these changes being made?

* To remove unnecessary JS from the critical path

## Testing Instructions

(Shamelessly copied from #102973)

Verify that transaction requests continue to include the `X-Fingerprint` header:

1. Go to http://calypso.localhost:3000
2. Enable store sandbox
3. Open DevTools Network tab, optionally filtering to "transactions" to easily identify relevant request
4. Go to "Upgrades" and purchase an upgrade (use store sandbox workflow)
5. Look at "Headers" for `/me/transactions` request
6. Observe `X-Fingerprint` header with value of ~32 numbers and letters

Verify that added tests pass:

* `yarn test-client client/lib/wp/handlers/test/fingerprint.test.ts`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
