### PR TITLE
Theme Showcase: Integrate logged-out SEO content with HeroModern

### DIFF
--- a/client/my-sites/themes/hero-modern/index.tsx
+++ b/client/my-sites/themes/hero-modern/index.tsx
@@ -1,32 +1,32 @@
-import { useTranslate } from 'i18n-calypso';
 import FullWidthSection from 'calypso/components/full-width-section';
 import { SearchThemes } from 'calypso/components/search-themes';
 import { preventWidows } from 'calypso/lib/formatting';
-
+import useThemeShowcaseLoggedOutSeoContent from '../use-theme-showcase-logged-out-seo-content';
 import './style.scss';
 
 interface HeroModernProps {
+	filter: string;
 	searchQuery: string;
+	tier: string;
 	onSearch: ( query: string ) => void;
 	onSearchTracksEvent: ( eventName: string, eventProperties?: object ) => void;
 }
 
-const HeroModern = ( { searchQuery, onSearch, onSearchTracksEvent }: HeroModernProps ) => {
-	const translate = useTranslate();
+const HeroModern = ( {
+	filter,
+	searchQuery,
+	tier,
+	onSearch,
+	onSearchTracksEvent,
+}: HeroModernProps ) => {
+	const loggedOutSeoContent = useThemeShowcaseLoggedOutSeoContent( filter, tier );
+	const { header, description } = loggedOutSeoContent;
 
 	return (
 		<FullWidthSection enabled className="hero-modern">
 			<div className="hero-modern__content">
-				<h1 className="hero-modern__title">
-					{ preventWidows( translate( 'Beautiful themes for every idea' ) ) }
-				</h1>
-				<p className="hero-modern__description">
-					{ preventWidows(
-						translate(
-							'Choose from thousands of free and premium themes to launch your blog, portfolio, store, or business — and customize every detail to make it your own.'
-						)
-					) }
-				</p>
+				<h1 className="hero-modern__title">{ preventWidows( header ) }</h1>
+				<p className="hero-modern__description">{ preventWidows( description ) }</p>
 				<div className="hero-modern__search">
 					<SearchThemes
 						query={ searchQuery }

--- a/client/my-sites/themes/hero-modern/test/index.test.tsx
+++ b/client/my-sites/themes/hero-modern/test/index.test.tsx
@@ -10,9 +10,23 @@ jest.mock( 'calypso/components/search-themes', () => ( {
 	),
 } ) );
 
+jest.mock( '../../use-theme-showcase-logged-out-seo-content', () => ( {
+	__esModule: true,
+	default: () => ( {
+		title: 'WordPress Themes | 1000s of Options for All WordPress Sites',
+		header: 'Beautiful themes for every idea',
+		description:
+			'Choose from thousands of free and premium themes to launch your blog, portfolio, store, or business—and customize every detail to make it your own.',
+		metaDescription:
+			'Choose from thousands of free and premium themes to launch your blog, portfolio, store, or business—and customize every detail to make it your own.',
+	} ),
+} ) );
+
 describe( 'HeroModern', () => {
 	const defaultProps = {
+		filter: '',
 		searchQuery: '',
+		tier: '',
 		onSearch: jest.fn(),
 		onSearchTracksEvent: jest.fn(),
 	};

--- a/client/my-sites/themes/theme-showcase-header.jsx
+++ b/client/my-sites/themes/theme-showcase-header.jsx
@@ -125,7 +125,9 @@ export default function ThemeShowcaseHeader( {
 		if ( isThemeShowcaseModern ) {
 			return (
 				<HeroModern
+					filter={ filter }
 					searchQuery={ search || '' }
+					tier={ tier }
 					onSearch={ onSearch }
 					onSearchTracksEvent={ onSearchTracksEvent }
 				/>

--- a/client/my-sites/themes/use-theme-showcase-logged-out-seo-content.js
+++ b/client/my-sites/themes/use-theme-showcase-logged-out-seo-content.js
@@ -6,6 +6,7 @@ import {
 } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
+import { useIsThemeShowcaseModernEnabled } from './hooks/use-is-theme-showcase-modern-enabled';
 
 function findParsedFilter( filter, content ) {
 	const splitFilters = filter?.replace( 'subject:', '' )?.split( '+' ) || [];
@@ -16,6 +17,7 @@ function findParsedFilter( filter, content ) {
 
 export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 	const translate = useTranslate();
+	const isThemeShowcaseModern = useIsThemeShowcaseModernEnabled();
 
 	/**
 	 * SEO content:
@@ -28,10 +30,16 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 			recommended: {
 				all: {
 					title: translate( 'WordPress Themes | 1000s of Options for All WordPress Sites' ),
-					header: translate( 'Find the perfect theme for your website' ),
-					description: translate(
-						'Professional WordPress themes for business, blogs, and ecommerce. 1000+ mobile-responsive designs with easy customization. Browse free and premium.'
-					),
+					header: isThemeShowcaseModern
+						? translate( 'Beautiful themes for every idea' )
+						: translate( 'Find the perfect theme for your website' ),
+					description: isThemeShowcaseModern
+						? translate(
+								'Choose from thousands of free and premium themes to launch your blog, portfolio, store, or business—and customize every detail to make it your own.'
+						  )
+						: translate(
+								'Professional WordPress themes for business, blogs, and ecommerce. 1000+ mobile-responsive designs with easy customization. Browse free and premium.'
+						  ),
 				},
 				free: {
 					title: translate( 'Free WordPress Themes' ),
@@ -898,7 +906,7 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 				},
 			},
 		} ),
-		[ translate ]
+		[ isThemeShowcaseModern, translate ]
 	);
 
 	const parsedFilter =


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTTHEM-331

## Proposed Changes

* Integrate logged-out SEO content with HeroModern

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* In https://github.com/Automattic/wp-calypso/pull/108976, I implemented the new hero for the logged-out Theme Showcase, temporarily ignoring the SEO content dependent on filters and tiers.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Theme Showcase logged-out and using the `themes/showcase-modern` feature flag.
* Click on various filters and tiers.
* Ensure the hero's title and description change accordingly.

**Note**: not all combinations have different titles and descriptions. When missing, they fall back to the filter:recommended/tier:all one (`/themes`: "Beautiful themes for every idea").

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
