### PR TITLE
Fix hardcoded WooPayments plugin name on Jetpack Connect for WooDna

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -1332,19 +1332,16 @@ export class JetpackAuthorize extends Component {
 							<BrandHeader
 								title={ translate( 'Connect your account' ) }
 								description={ translate(
-									'To access all of the features and functionality in WooPayments, you’ll first need to connect {{siteName}}%(siteName)s{{/siteName}} to a WordPress.com account. For more information, please {{doc}}review our documentation{{/doc}}.',
+									'To access all of the features and functionality in %(pluginName)s, you’ll first need to connect {{siteName}}%(siteName)s{{/siteName}} to a WordPress.com account. For more information, please {{doc}}review our documentation{{/doc}}.',
 									{
 										args: {
+											pluginName: wooDna.getServiceName(),
 											siteName,
 										},
 										components: {
 											siteName: <span className="jetpack-connect__woo-brand-header-site-name" />,
 											doc: (
-												<a
-													href="https://woocommerce.com/document/connect-your-store-to-a-wordpress-com-account/"
-													target="_blank"
-													rel="noreferrer"
-												/>
+												<a href={ wooDna.getServiceHelpUrl() } target="_blank" rel="noreferrer" />
 											),
 										},
 									}

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -1335,13 +1335,19 @@ export class JetpackAuthorize extends Component {
 									'To access all of the features and functionality in %(pluginName)s, you’ll first need to connect {{siteName}}%(siteName)s{{/siteName}} to a WordPress.com account. For more information, please {{doc}}review our documentation{{/doc}}.',
 									{
 										args: {
-											pluginName: wooDna.getServiceName(),
+											pluginName: wooDna.getServiceName() || wooDna.getPluginName(),
 											siteName,
 										},
 										components: {
 											siteName: <span className="jetpack-connect__woo-brand-header-site-name" />,
-											doc: (
+											doc: wooDna.getServiceHelpUrl() ? (
 												<a href={ wooDna.getServiceHelpUrl() } target="_blank" rel="noreferrer" />
+											) : (
+												<a
+													href="https://woocommerce.com/document/connect-your-store-to-a-wordpress-com-account/"
+													target="_blank"
+													rel="noreferrer"
+												/>
 											),
 										},
 									}

--- a/client/jetpack-connect/woo-dna-config.js
+++ b/client/jetpack-connect/woo-dna-config.js
@@ -1,3 +1,6 @@
+const paramToPluginNameMap = {
+	'woocommerce-payments': 'WooPayments',
+};
 /**
  * This function abstracts the logic for the "Woo DNA" Jetpack flow. The Woo DNA flow is an exclusively Woo-branded
  * Jetpack connection flow. It's meant to be used by Woo extensions or services with the Jetpack Connection package.
@@ -27,4 +30,9 @@ export default ( query ) =>
 		 * @returns {string} URL with help about connecting Jetpack.
 		 */
 		getServiceHelpUrl: () => query.woodna_help_url,
+
+		/**
+		 * @returns {string} Mapped Woo extension name
+		 */
+		getPluginName: () => paramToPluginNameMap[ query.plugin_name ] || '',
 	} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Fixes hardcoded mention of "WooPayments" instead of grabbing service name and help text from the URL parameters

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It should be dynamic and grab the information from the URL query parameters instead of hard coded

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this locally
* Log in to wordpress.com
* Create a JN site
* Install WooCommerce
* Install Google for WooCommerce
* Connect to WordPress.com ( part of Google for WooCommerce setup )
* You'll see the connect page and it should look like this:

<img width="1464" height="1358" alt="image" src="https://github.com/user-attachments/assets/073c6884-273c-4237-b697-0a2deecf7563" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
