### PR TITLE
Lazily load 'he' dependency

### DIFF
--- a/packages/api-core/src/me/fetchers.ts
+++ b/packages/api-core/src/me/fetchers.ts
@@ -1,16 +1,20 @@
-import { decode } from 'he';
 import { wpcom } from '../wpcom-fetcher';
 import type { User, TwoStep } from './types';
 
-function decodeEntities( text: string ) {
+async function decode( text: string ) {
+	const { decode } = await import( 'he' );
+	return decode( text );
+}
+
+async function decodeEntities( text: string ) {
 	// Bypass decode if text doesn't include entities
 	if ( 'string' !== typeof text || -1 === text.indexOf( '&' ) ) {
 		return text;
 	}
-
 	return decode( text );
 }
-function decodeUserObject( user: User ): User {
+
+async function decodeUserObject( user: User ): Promise< User > {
 	const decodedKeys = [ 'display_name', 'description', 'user_URL' ];
 	const decodedUser = { ...user };
 
@@ -21,7 +25,7 @@ function decodeUserObject( user: User ): User {
 
 		const value = decodedUser[ key ];
 		if ( typeof value === 'string' ) {
-			decodedUser[ key ] = decodeEntities( value ) as never;
+			decodedUser[ key ] = ( await decodeEntities( value ) ) as never;
 		}
 	}
 

--- a/packages/api-core/src/me/fetchers.ts
+++ b/packages/api-core/src/me/fetchers.ts
@@ -1,9 +1,13 @@
 import { wpcom } from '../wpcom-fetcher';
 import type { User, TwoStep } from './types';
 
-async function decode( text: string ) {
-	const { decode } = await import( 'he' );
-	return decode( text );
+let decode: Promise< typeof import('he').decode > | undefined;
+
+async function decodeText( text: string ) {
+	if ( ! decode ) {
+		decode = ( async () => ( await import( 'he' ) ).decode )();
+	}
+	return ( await decode )( text );
 }
 
 async function decodeEntities( text: string ) {
@@ -11,7 +15,7 @@ async function decodeEntities( text: string ) {
 	if ( 'string' !== typeof text || -1 === text.indexOf( '&' ) ) {
 		return text;
 	}
-	return decode( text );
+	return await decodeText( text );
 }
 
 async function decodeUserObject( user: User ): Promise< User > {


### PR DESCRIPTION
The `he` dependency is quite large, at ~69KB (29KB gzipped), and is currently being loaded as part of the critical path.

However, the library is only used when fetching the user object, and even then only when the user object happens to include HTML entities.

Since `fetchUser` is async anyway, we can take advantage of this and load `he` lazily only when needed, i.e. when the user object does include HTML entities.

## Proposed Changes

* Lazily load `he` only when needed.

## Why are these changes being made?

* To reduce the amount of JS on the critical path and improve loading performance.

## Testing Instructions

Smoke-test the application and ensure everything works properly.
The testing instructions in #106837 might also help.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
