### PR TITLE
Stepper: remove plans from critical path

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util/build-upgrade-function.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util/build-upgrade-function.ts
@@ -3,38 +3,10 @@ import {
 	FEATURE_UPLOAD_THEMES_PLUGINS,
 	isEcommerce,
 	planHasFeature,
-	UrlFriendlyTermType,
 } from '@automattic/calypso-products';
-import { getUrlParts } from '@automattic/calypso-url';
-import { PlansIntent } from '@automattic/plans-grid-next';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { getPlanCartItem } from 'calypso/lib/cart-values/cart-items';
-import { UnifiedPlansStepProps } from './unified-plans-step';
-
-export type SupportedIntervalTypes = Extract<
-	UrlFriendlyTermType,
-	'monthly' | 'yearly' | '2yearly' | '3yearly'
->;
-export const supportedIntervalTypes: SupportedIntervalTypes[] = [
-	'monthly',
-	'yearly',
-	'2yearly',
-	'3yearly',
-];
-
-export const getIntervalType = (
-	path?: string,
-	defaultType = 'yearly'
-): SupportedIntervalTypes => {
-	const url = path ?? window?.location?.href ?? '';
-	const intervalType = getUrlParts( url ).searchParams.get( 'intervalType' ) || defaultType;
-
-	return (
-		supportedIntervalTypes.includes( intervalType as SupportedIntervalTypes )
-			? intervalType
-			: defaultType
-	) as SupportedIntervalTypes;
-};
+import { UnifiedPlansStepProps } from '../unified-plans-step';
 
 export const buildUpgradeFunction = (
 	planProps: {
@@ -112,13 +84,3 @@ export const buildUpgradeFunction = (
 	submitSignupStep( step, signupVals );
 	goToNextStep();
 };
-
-export function getVisualSplitPlansIntent( intent?: string | null ): PlansIntent | null {
-	if ( intent === 'default_websitebuilder' ) {
-		return 'plans-website-builder';
-	}
-	if ( intent === 'default_hosting' ) {
-		return 'plans-wordpress-hosting';
-	}
-	return null;
-}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util/get-interval-type.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util/get-interval-type.ts
@@ -1,0 +1,16 @@
+import { getUrlParts } from '@automattic/calypso-url';
+import { type SupportedIntervalTypes, supportedIntervalTypes } from './supported-interval-types';
+
+export const getIntervalType = (
+	path?: string,
+	defaultType = 'yearly'
+): SupportedIntervalTypes => {
+	const url = path ?? window?.location?.href ?? '';
+	const intervalType = getUrlParts( url ).searchParams.get( 'intervalType' ) || defaultType;
+
+	return (
+		supportedIntervalTypes.includes( intervalType as SupportedIntervalTypes )
+			? intervalType
+			: defaultType
+	) as SupportedIntervalTypes;
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util/get-visual-split-plans-intent.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util/get-visual-split-plans-intent.ts
@@ -1,0 +1,11 @@
+import { type PlansIntent } from '@automattic/plans-grid-next';
+
+export function getVisualSplitPlansIntent( intent?: string | null ): PlansIntent | null {
+	if ( intent === 'default_websitebuilder' ) {
+		return 'plans-website-builder';
+	}
+	if ( intent === 'default_hosting' ) {
+		return 'plans-wordpress-hosting';
+	}
+	return null;
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util/index.ts
@@ -1,0 +1,4 @@
+export { supportedIntervalTypes, type SupportedIntervalTypes } from './supported-interval-types';
+export { getIntervalType } from './get-interval-type';
+export { buildUpgradeFunction } from './build-upgrade-function';
+export { getVisualSplitPlansIntent } from './get-visual-split-plans-intent';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util/package.json
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util/package.json
@@ -1,0 +1,3 @@
+{
+	"sideEffects": false
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util/supported-interval-types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util/supported-interval-types.ts
@@ -1,0 +1,13 @@
+import { type UrlFriendlyTermType } from '@automattic/calypso-products';
+
+export type SupportedIntervalTypes = Extract<
+	UrlFriendlyTermType,
+	'monthly' | 'yearly' | '2yearly' | '3yearly'
+>;
+
+export const supportedIntervalTypes: SupportedIntervalTypes[] = [
+	'monthly',
+	'yearly',
+	'2yearly',
+	'3yearly',
+];

--- a/client/landing/stepper/stores.ts
+++ b/client/landing/stepper/stores.ts
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { Onboard, Plans, Site, StepperInternal, User } from '@automattic/data-stores';
+import { Onboard, Site, StepperInternal, User } from '@automattic/data-stores';
 
 export const ONBOARD_STORE = Onboard.register();
 export const STEPPER_INTERNAL_STORE = StepperInternal.register();
@@ -10,5 +10,3 @@ export const SITE_STORE = Site.register( {
 } );
 
 export const USER_STORE = User.register();
-
-export const PLANS_STORE = Plans.register();


### PR DESCRIPTION
The PR removes plan data (`calypso-products`) from the Stepper entry point critical path. Individual steps will still load it as needed, just not the Stepper framework as a whole.

This should remove over 160KB (~38KB gzipped) of JS from the Stepper critical path.

## Proposed Changes

* Remove the `PLANS_STORE`, which no longer seems to be in use
* Modularise `unified-plans/util`, so that only the utils that need plan data end up loading it
* Add a `package.json` file to `unified-plans/util`, to ensure it's tree-shaken correctly

## Why are these changes being made?

* To remove unnecessary plan data from the Stepper critical path, and thus improve loading performance.

## Testing Instructions

- Smoke-test Stepper and ensure that it works properly, particularly any steps that involve displaying plan data.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
