### PR TITLE
Theme Showcase: Refine modern search field behaviours

### DIFF
--- a/client/components/search-themes/index.tsx
+++ b/client/components/search-themes/index.tsx
@@ -1,7 +1,7 @@
 import { SearchControl } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import './style.scss';
 
 interface SearchThemesProps {
@@ -12,6 +12,10 @@ interface SearchThemesProps {
 const SearchThemes: React.FC< SearchThemesProps > = ( { query, onSearch, recordTracksEvent } ) => {
 	const translate = useTranslate();
 	const [ searchInput, setSearchInput ] = useState( query );
+
+	useEffect( () => {
+		setSearchInput( query );
+	}, [ query ] );
 
 	const onClearSearch = useCallback( () => {
 		onSearch( '' );

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -9,6 +9,7 @@ import { connect, useSelector } from 'react-redux';
 import InfiniteScroll from 'calypso/components/infinite-scroll';
 import Theme from 'calypso/components/theme';
 import withIsFSEActive from 'calypso/data/themes/with-is-fse-active';
+import SearchMoreOptions from 'calypso/my-sites/themes/search-results-modern/search-more-options';
 import { getWooMyCustomThemeOptions } from 'calypso/my-sites/themes/theme-options';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
@@ -151,6 +152,16 @@ export const ThemesList = ( {
 	}, [ themes, translate, activeTheme, getButtonOptions, siteAdminUrl, siteSlug ] );
 
 	if ( ! loading && themes.length === 0 ) {
+		if ( props.isThemeShowcaseModern ) {
+			return (
+				<SearchMoreOptions
+					title={ translate( 'No themes found' ) }
+					subtitle={ translate( 'Try building your site another way.' ) }
+					searchTerm={ searchTerm }
+				/>
+			);
+		}
+
 		return (
 			<Empty
 				isFSEActive={ props.isFSEActive }

--- a/client/my-sites/themes/filter-bar-modern/index.tsx
+++ b/client/my-sites/themes/filter-bar-modern/index.tsx
@@ -31,6 +31,7 @@ interface FilterBarModernProps {
 	showTierFilter?: boolean;
 	searchQuery?: string;
 	onSearch?: ( query: string ) => void;
+	sentinelRef?: React.RefObject< HTMLDivElement >;
 }
 
 const FilterBarModern = ( {
@@ -43,6 +44,7 @@ const FilterBarModern = ( {
 	showTierFilter = true,
 	searchQuery = '',
 	onSearch,
+	sentinelRef,
 }: FilterBarModernProps ) => {
 	const translate = useTranslate();
 	const [ isSticky, setIsSticky ] = useState( false );
@@ -115,7 +117,7 @@ const FilterBarModern = ( {
 				fallbackInView
 				onChange={ ( inView ) => setIsSticky( ! inView ) }
 			>
-				<div className="filter-bar-modern__sentinel" />
+				<div className="filter-bar-modern__sentinel" ref={ sentinelRef } />
 			</InView>
 			<div className={ clsx( 'filter-bar-modern', { 'is-sticky': isSticky } ) }>
 				<div className="filter-bar-modern__content">

--- a/client/my-sites/themes/filter-bar-modern/index.tsx
+++ b/client/my-sites/themes/filter-bar-modern/index.tsx
@@ -127,6 +127,7 @@ const FilterBarModern = ( {
 								onSearchOpen={ handleSearchOpen }
 								onSearchClose={ handleSearchClose }
 								initialValue={ searchQuery }
+								value={ searchQuery }
 								onSearch={ onSearch }
 								placeholder={ translate( 'Search themes…' ) }
 								searchMode={ SEARCH_MODE_ON_ENTER }

--- a/client/my-sites/themes/test/logged-out.jsx
+++ b/client/my-sites/themes/test/logged-out.jsx
@@ -122,7 +122,7 @@ describe( 'logged-out', () => {
 		render( <TestComponent store={ store } category="recommended" /> );
 
 		await waitFor( () => {
-			expect( screen.getByText( 'No themes match your search' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'No themes found' ) ).toBeInTheDocument();
 		} );
 	} );
 
@@ -160,7 +160,7 @@ describe( 'logged-out', () => {
 		render( <TestComponent store={ store } category="recommended" /> );
 
 		await waitFor( () => {
-			expect( screen.queryByText( 'No themes match your search' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'No themes found' ) ).toBeInTheDocument();
 		} );
 	} );
 } );

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -80,6 +80,7 @@ class ThemeShowcase extends Component {
 		this.scrollRef = createRef();
 		this.bookmarkRef = createRef();
 		this.showcaseRef = createRef();
+		this.sentinelRef = createRef();
 
 		this.subjectFilters = this.getSubjectFilters( props );
 		this.subjectTermTable = getSubjectsFromTermTable( props.filterToTermTable );
@@ -270,6 +271,15 @@ class ThemeShowcase extends Component {
 	};
 
 	scrollToSearchInput = () => {
+		// In the modern showcase, scroll to the filter bar sentinel when sticky.
+		if ( this.isThemeShowcaseModern() ) {
+			const sentinel = this.sentinelRef.current;
+			if ( sentinel && sentinel.getBoundingClientRect().top < 0 ) {
+				sentinel.scrollIntoView( { behavior: 'smooth', block: 'start' } );
+			}
+			return;
+		}
+
 		// Scroll to the top of the showcase
 		if ( this.showcaseRef.current && this.state.shouldThemeControlsSticky ) {
 			this.showcaseRef.current.scrollIntoView( {
@@ -746,6 +756,7 @@ class ThemeShowcase extends Component {
 							) }
 							{ this.isThemeShowcaseModern() ? (
 								<FilterBarModern
+									sentinelRef={ this.sentinelRef }
 									categories={ Object.values( tabFilters ) }
 									selectedCategory={ this.getSelectedTabFilter().key }
 									onCategorySelect={ ( category ) =>

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -271,6 +271,7 @@ class ThemesSelection extends Component {
 					searchTerm={ query.search }
 					tabFilter={ tabFilter }
 					tier={ tier }
+					isThemeShowcaseModern={ this.props.isThemeShowcaseModern }
 				>
 					{ this.props.children }
 				</ThemesList>


### PR DESCRIPTION
Fixes DOTTHEM-333

## Proposed Changes

* Sync search state between the hero search (SearchThemes) and the sticky filter bar search (Search) so clearing or searching in one updates the other.
* Smooth scroll to the filter bar sentinel when the sticky bar is active, instead of jumping to the top of the page.
* Show the modern SearchMoreOptions empty state when no themes match the current filter/tier combination.

## Why are these changes being made?

The two search bars in the modern logged-out Theme Showcase maintained independent internal state — typing in one didn't update the other, and clearing one left the other stale. Additionally, triggering a search or filter change from the sticky bar caused a jarring instant scroll to the top. Finally, the legacy empty state was shown instead of the modern one when browsing with filters returned no results.

## Testing Instructions

* Visit the logged-out Theme Showcase with the `themes/showcase-modern` feature flag enabled.
* Type a search query in the hero search, scroll down so the sticky bar appears, and verify the sticky search reflects the same query.
* Use the sticky search to search or clear — verify it smooth scrolls to the filter bar instead of jumping to the top.
* Change filters or tiers to a combination that returns no themes and verify the modern "No themes found" empty state appears.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?