### PR TITLE
Domains: Handle permission errors with proper UI instead of 500

### DIFF
--- a/client/dashboard/app/logger/index.tsx
+++ b/client/dashboard/app/logger/index.tsx
@@ -12,6 +12,7 @@ function isBenignError( error: Error ) {
 	switch ( error.name ) {
 		case 'AuthorizationRequiredError':
 		case 'ReauthorizationRequiredError':
+		case 'DomainPermissionError':
 			return true;
 	}
 

--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -125,6 +125,7 @@ export const domainRoute = createRoute( {
 	} ),
 	getParentRoute: () => rootRoute,
 	path: 'domains/$domainName',
+	errorComponent: lazyRouteComponent( () => import( '../../domains/domain/error' ) ),
 	loader: async ( { params: { domainName }, location } ) => {
 		const domain = await queryClient.ensureQueryData( domainQuery( domainName ) );
 		const isNameServersSubRoute = location.pathname.includes( '/name-servers' );

--- a/client/dashboard/domains/domain/error.tsx
+++ b/client/dashboard/domains/domain/error.tsx
@@ -1,0 +1,34 @@
+import { Link } from '@tanstack/react-router';
+import { __ } from '@wordpress/i18n';
+import UnknownError from '../../app/500';
+import { domainRoute } from '../../app/router/domains';
+import Notice from '../../components/notice';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import { DomainPermissionError } from '../../utils/domain-permissions';
+
+export default function DomainError( { error }: { error: Error } ) {
+	if ( ! ( error instanceof DomainPermissionError ) ) {
+		return <UnknownError error={ error } />;
+	}
+
+	const { domainName } = domainRoute.useParams();
+
+	return (
+		<PageLayout
+			header={ <PageHeader title={ domainName } /> }
+			notices={
+				<Notice
+					variant="warning"
+					actions={
+						<Link to={ domainRoute.fullPath } params={ { domainName } }>
+							{ __( 'Go back to domain overview' ) }
+						</Link>
+					}
+				>
+					{ error.message }
+				</Notice>
+			}
+		/>
+	);
+}

--- a/client/dashboard/domains/domain/error.tsx
+++ b/client/dashboard/domains/domain/error.tsx
@@ -8,11 +8,11 @@ import PageLayout from '../../components/page-layout';
 import { DomainPermissionError } from '../../utils/domain-permissions';
 
 export default function DomainError( { error }: { error: Error } ) {
+	const { domainName } = domainRoute.useParams();
+
 	if ( ! ( error instanceof DomainPermissionError ) ) {
 		return <UnknownError error={ error } />;
 	}
-
-	const { domainName } = domainRoute.useParams();
 
 	return (
 		<PageLayout
@@ -20,11 +20,7 @@ export default function DomainError( { error }: { error: Error } ) {
 			notices={
 				<Notice
 					variant="warning"
-					actions={
-						<Link to={ domainRoute.fullPath } params={ { domainName } }>
-							{ __( 'Go back to domain overview' ) }
-						</Link>
-					}
+					actions={ <Link to="/domains">{ __( 'Go back to domains' ) }</Link> }
 				>
 					{ error.message }
 				</Notice>

--- a/client/dashboard/utils/domain-permissions.ts
+++ b/client/dashboard/utils/domain-permissions.ts
@@ -4,6 +4,13 @@ import { isSupportSession } from '@automattic/calypso-support-session';
 import { __, sprintf } from '@wordpress/i18n';
 import type { Domain } from '@automattic/api-core';
 
+export class DomainPermissionError extends Error {
+	constructor( message: string ) {
+		super( message );
+		this.name = 'DomainPermissionError';
+	}
+}
+
 /**
  * Individual domain check functions
  * Each function checks a specific condition and returns true if the check passes, false if it fails
@@ -202,7 +209,7 @@ function checkDomainPermissions(
 
 	for ( const { check, getErrorMessage } of checks ) {
 		if ( ! check( domain ) ) {
-			throw new Error( getErrorMessage( domain ) );
+			throw new DomainPermissionError( getErrorMessage( domain ) );
 		}
 	}
 }


### PR DESCRIPTION
Part of DOMENG-321

## Proposed Changes

- Add a `DomainPermissionError` custom error class to distinguish domain permission denials from unexpected errors.
- Add an `errorComponent` to `domainRoute` that catches `DomainPermissionError` and displays a warning notice with the API-provided reason, linking back to the domains list. Non-permission errors fall through to the existing 500 page.
- Register `DomainPermissionError` as benign in the dashboard logger so it no longer gets reported to Sentry.

## Why are these changes being made?

When a user navigates to a domain sub-page (DNS, name servers, contact info, etc.) for a domain that restricts management — for example, a Gravatar-linked domain where DNS cannot be edited — the permission check in `domainRoute.loader` throws an error. Because `domainRoute` had no `errorComponent`, this error fell through to the global 500 page and was reported to Sentry as an unexpected bug ([CALYPSO-2GAJ](https://a8c.sentry.io/issues/7144189408/)), even though it represents expected business logic.

## Testing Instructions

1. Navigate to the Dashboard domain DNS page for a domain linked to a Gravatar profile (one where the API returns `can_manage_dns_records: false` and `cannot_manage_dns_records_reason` is set).
2. Verify you see a warning notice with the permission reason instead of a "500 Error" page.
3. Verify the "Go back to domains" link navigates to the domains list.
4. Verify no error is reported to Sentry (check browser console for `captureException` calls).
5. Navigate to a DNS page for a normal domain and verify it still works as expected.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

Co-Authored-By: Claude <noreply@anthropic.com>