### PR TITLE
Billing: Sync behavior of Jetpack auto-renew with v1

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -605,7 +605,8 @@ function getFields( {
 						return (
 							<ActionList.ActionItem
 								title={ __( 'Subscription renewal' ) }
-								description={ helpText }
+								description={ helpText?.toString() }
+								actions={ {} }
 							/>
 						);
 					}
@@ -614,7 +615,7 @@ function getFields( {
 							title={ __( 'Your subscription is inactive' ) }
 							description={ sprintf(
 								// translators: date is a formatted expiry date
-								__( 'Expires on %(date)s' ),
+								__( 'Expires on %(date)s.' ),
 								{
 									date: formatDate( new Date( purchase.expiry_date ), locale, {
 										dateStyle: 'long',

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -605,8 +605,10 @@ function getFields( {
 						return (
 							<ActionList.ActionItem
 								title={ __( 'Subscription renewal' ) }
-								description={ helpText?.toString() }
-								actions={ {} }
+								description={ ( (): string => {
+									return typeof helpText === 'string' ? helpText : helpText?.props?.children ?? '';
+								} )() }
+								actions={ <></> }
 							/>
 						);
 					}

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -606,7 +606,7 @@ function getFields( {
 							<ActionList.ActionItem
 								title={ __( 'Subscription renewal' ) }
 								description={ ( (): string => {
-									return typeof helpText === 'string' ? helpText : helpText?.props?.children ?? '';
+									return typeof helpText === 'string' ? helpText : '';
 								} )() }
 								actions={ <></> }
 							/>

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -600,6 +600,39 @@ function getFields( {
 					}
 					return undefined;
 				} )();
+				if ( purchase.is_jetpack_plan_or_product ) {
+					if ( purchase.is_auto_renew_enabled ) {
+						return (
+							<ActionList.ActionItem
+								title={ __( 'Subscription renewal' ) }
+								description={ helpText }
+							/>
+						);
+					}
+					return (
+						<ActionList.ActionItem
+							title={ __( 'Your subscription is inactive' ) }
+							description={ sprintf(
+								// translators: date is a formatted expiry date
+								__( 'Expires on %(date)s' ),
+								{
+									date: formatDate( new Date( purchase.expiry_date ), locale, {
+										dateStyle: 'long',
+									} ),
+								}
+							) }
+							actions={
+								<Button
+									variant="secondary"
+									size="compact"
+									onClick={ () => onChange( { is_auto_renew_enabled: true } ) }
+								>
+									{ __( 'Re-activate subscription' ) }
+								</Button>
+							}
+						/>
+					);
+				}
 				return (
 					<ToggleControl
 						__nextHasNoMarginBottom
@@ -619,6 +652,7 @@ function getFields( {
 		},
 		{
 			id: 'purchase_payment_method',
+			isVisible: ( item ) => item.is_auto_renew_enabled,
 			Edit: ( { data: purchase } ) => {
 				return <PurchasePaymentMethod purchase={ purchase } showUpdateButton />;
 			},


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes CHE-417

## Proposed Changes

* Modify how the auto-renew enabled toggle works for Jetpack purchases to include only the option to re-activate the subscription.

| Environment  | Auto renew enabled | Auto renew disabled |
|---|--------------------|----------------------|
| Multi-site dashboard <br /><em>(changes in this PR)</em> | <img width="678" height="211" alt="Screenshot 2026-03-16 at 1 48 15 PM" src="https://github.com/user-attachments/assets/0f63a74e-abe3-430a-be47-bd053faa5efa" /> | <img width="686" height="163" alt="Screenshot 2026-03-16 at 1 48 42 PM" src="https://github.com/user-attachments/assets/fc9d0b68-3260-4025-80de-51f13d0a2e22" /> |
| Calypso v1<br /><em>(for reference)<em> | <img width="246" height="152" alt="Screenshot 2026-03-16 at 1 49 22 PM" src="https://github.com/user-attachments/assets/3d9a0181-98bc-480a-bfb6-58f2b60a6f13" /> | <img width="247" height="151" alt="Screenshot 2026-03-16 at 1 48 56 PM" src="https://github.com/user-attachments/assets/170932b7-fe98-455a-868b-f557c753adce" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The v1 version of this flow does not have a link to enable or disable auto-renew. Instead, auto-renew can only be enabled, and the purchase cancelled (which disables auto renew).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to the multi-site dashboard's active upgrades page (`/me/billing/purchases`)
* Choose a Jetpack purchase and click "Manage Purchase"
* If auto renew is disabled, you should see a button under "Manage subscription" which is labeled "Re-activate subscription". If auto renew is enabled, you should see "Subscription renewal" / "You will be billed on <date>".
* Toggle auto renew by either clicking the "Re-activate subscription" button or by cancelling the subscription. Refer to the last bullet point to verify that the correct behavior is present after toggling.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
