### PR TITLE
Odyssey Stats: Replace Button from @automattic/components with @wordpress/components

### DIFF
--- a/apps/odyssey-stats/src/widget/modules.scss
+++ b/apps/odyssey-stats/src/widget/modules.scss
@@ -51,6 +51,10 @@ $jp-gray: #dcdcde;
 	&.is-primary {
 		color: var(--studio-white);
 		background: var(--studio-black);
+
+		&:hover:not(.is-busy) {
+			background: $emerald-hover-color;
+		}
 	}
 
 	// Use secondary styles (previously transparent)

--- a/apps/odyssey-stats/src/widget/modules.scss
+++ b/apps/odyssey-stats/src/widget/modules.scss
@@ -40,8 +40,8 @@ $jp-gray: #dcdcde;
 	}
 }
 
-// Use base component styling of `@automattic/components/Button`
-.button.jetpack-emerald-button {
+// Use base component styling of `@wordpress/components/Button`
+.components-button.jetpack-emerald-button {
 	font-weight: 600;
 
 	&:focus {
@@ -53,8 +53,8 @@ $jp-gray: #dcdcde;
 		background: var(--studio-black);
 	}
 
-	// Use `transparent` styling as secondary styles
-	&.is-transparent {
+	// Use secondary styles (previously transparent)
+	&.is-secondary {
 		color: var(--studio-black);
 		background: inset 0 0 0 1.5px var(--studio-white);
 

--- a/apps/odyssey-stats/src/widget/modules.tsx
+++ b/apps/odyssey-stats/src/widget/modules.tsx
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
-import { Button } from '@automattic/components';
 import { protect, akismet } from '@automattic/components/src/icons';
 import { formatNumberCompact } from '@automattic/number-formatters';
+import { Button } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useState, FunctionComponent } from 'react';
@@ -73,9 +73,9 @@ const ModuleCard: FunctionComponent< ModuleCardProps > = ( {
 						<div className="stats-widget-module__info">
 							{ error === 'not_active' && (
 								<Button
-									primary
+									variant="primary"
 									className="jetpack-emerald-button"
-									busy={ disabled }
+									isBusy={ disabled }
 									onClick={ onActivateProduct }
 								>
 									{ translate( 'Activate' ) }
@@ -83,9 +83,9 @@ const ModuleCard: FunctionComponent< ModuleCardProps > = ( {
 							) }
 							{ error === 'not_installed' && (
 								<Button
-									transparent
+									variant="secondary"
 									className="jetpack-emerald-button"
-									busy={ disabled }
+									isBusy={ disabled }
 									onClick={ onActivateProduct }
 								>
 									{ translate( 'Install' ) }


### PR DESCRIPTION
Fixes STATS-237

## Proposed Changes

- Replace `@automattic/components` Button with `@wordpress/components` Button in Odyssey Stats modules widget
- Update prop names to match `@wordpress/components` API:
  - `primary` → `variant="primary"`
  - `transparent` → `variant="secondary"`
  - `busy` → `isBusy`
- Update SCSS selectors to target the new class names:
  - `.button` → `.components-button`
  - `.is-transparent` → `.is-secondary`

## Why are these changes being made?

This change aligns with the codebase convention to prefer `@wordpress/components` primitives over `@automattic/components` as documented in client/AGENTS.md:

> Prefer `@wordpress/components` primitives (Button, Modal, Card, etc.).

The functionality remains identical while reducing dependency on internal component libraries.

## Testing Instructions

1. Navigate to a Jetpack site's wp-admin Dashboard
2. Check the Stats widget with Protect and Akismet modules
3. For sites where modules are not activated:
   - The "Activate" button (primary variant) should appear with black background
   - The "Install" button (secondary variant) should appear with outlined style
4. Click the buttons and verify the `isBusy` loading state works correctly
5. Verify hover states work correctly for both button variants


| before | after |
|------|------|
|<img width="300" alt="Screenshot 2026-03-17 at 12 13 45 PM" src="https://github.com/user-attachments/assets/7d2bd29f-176b-48fd-ba95-f8a971fd8f62" />| <img width="300"  alt="Screenshot 2026-03-17 at 12 11 17 PM" src="https://github.com/user-attachments/assets/b3132330-84f6-4696-8840-839baf26d5bb" />|

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?