### PR TITLE
Dashboard: Add favorite sites feature

### DIFF
--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -35,9 +35,11 @@ import type { Field, Operator, View } from '@wordpress/dataviews';
 function getDefaultFields( {
 	viewType,
 	queries,
+	viewFields,
 }: {
 	viewType?: string;
 	queries: AppConfig[ 'queries' ];
+	viewFields?: string[];
 } ): Field< Site >[] {
 	const visibilityLabels = getVisibilityLabels();
 	return [
@@ -47,7 +49,13 @@ function getDefaultFields( {
 			enableHiding: false,
 			enableGlobalSearch: true,
 			getValue: ( { item } ) => getSiteDisplayName( item ),
-			render: ( { field, item } ) => <Name site={ item } value={ field.getValue( { item } ) } />,
+			render: ( { field, item } ) => (
+				<Name
+					site={ item }
+					value={ field.getValue( { item } ) }
+					showFavorite={ viewFields?.includes( 'is_favorited' ) }
+				/>
+			),
 		},
 		{
 			id: 'is_favorited',
@@ -70,6 +78,7 @@ function getDefaultFields( {
 					/>
 				);
 			},
+			isVisible: () => false,
 		},
 		{
 			id: 'URL',
@@ -277,14 +286,16 @@ function getDefaultFields( {
 export function useFields( {
 	isAutomattician,
 	viewType,
+	viewFields,
 }: {
 	isAutomattician?: boolean;
 	viewType?: string;
+	viewFields?: string[];
 } ) {
 	const { queries } = useAppContext();
 
 	return useMemo( () => {
-		const defaultFields = getDefaultFields( { viewType, queries } );
+		const defaultFields = getDefaultFields( { viewType, queries, viewFields } );
 		return defaultFields.filter( ( field ) => {
 			if ( field.id === 'is_a8c' && ! isAutomattician ) {
 				return false;
@@ -300,7 +311,7 @@ export function useFields( {
 
 			return true;
 		} );
-	}, [ isAutomattician, viewType, queries ] );
+	}, [ isAutomattician, viewType, queries, viewFields ] );
 }
 
 export function sanitizeFields( fields: View[ 'fields' ] ) {

--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -1,4 +1,5 @@
-import { queryClient } from '@automattic/api-queries';
+import { queryClient, siteFavoriteMutation } from '@automattic/api-queries';
+import { useMutation } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import { useAuth } from '../../app/auth';
@@ -16,6 +17,7 @@ import { getSiteVisibility, getVisibilityLabels } from '../../utils/site-visibil
 import { getFormattedWordPressVersion } from '../../utils/wp-version';
 import {
 	AsyncEngagementStat,
+	Favorite,
 	LastBackup,
 	MediaStorage,
 	Name,
@@ -46,6 +48,28 @@ function getDefaultFields( {
 			enableGlobalSearch: true,
 			getValue: ( { item } ) => getSiteDisplayName( item ),
 			render: ( { field, item } ) => <Name site={ item } value={ field.getValue( { item } ) } />,
+		},
+		{
+			id: 'is_favorited',
+			label: __( 'Favorited' ),
+			type: 'boolean',
+			getValue: ( { item } ) => item.is_favorited,
+			elements: [
+				{ value: true, label: __( 'Yes' ) },
+				{ value: false, label: __( 'No' ) },
+			],
+			filterBy: {
+				operators: [ 'is' as Operator ],
+			},
+			render: function FavoritedField( { item } ) {
+				const { mutate } = useMutation( siteFavoriteMutation( item.ID ) );
+				return (
+					<Favorite
+						isFavorited={ item.is_favorited }
+						onToggle={ () => mutate( ! item.is_favorited ) }
+					/>
+				);
+			},
 		},
 		{
 			id: 'URL',

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -176,7 +176,7 @@ export default function Sites() {
 		}
 	);
 
-	const fields = useFields( { isAutomattician, viewType: view.type } );
+	const fields = useFields( { isAutomattician, viewType: view.type, viewFields: view.fields } );
 	const actions = useActions();
 
 	const [ isModalOpen, setIsModalOpen ] = useState( false );

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -85,6 +85,8 @@ const getFetchPaginatedSitesOptions = (
 			options.plan = filter.value.map( ( v: string ) => planSlugsByName?.[ v ] ).flat();
 		} else if ( filter.field === 'visibility' && filter.value ) {
 			options.visibility = filter.value;
+		} else if ( filter.field === 'is_favorited' && filter.value !== undefined ) {
+			options.is_favorited = filter.value;
 		}
 	} );
 

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -117,15 +117,25 @@ export function SiteLink( {
 	);
 }
 
-export function Name( { site, value }: { site: Site; value: string } ) {
+export function Name( {
+	site,
+	value,
+	showFavorite,
+}: {
+	site: Site;
+	value: string;
+	showFavorite?: boolean;
+} ) {
 	const { mutate } = useMutation( siteFavoriteMutation( site.ID ) );
 	return (
 		<HStack justify="flex-start" alignment="center" spacing={ 1 }>
 			<NameRenderer badge={ getSiteBadge( site ) } muted={ site.is_deleted } value={ value } />
-			<Favorite
-				isFavorited={ site.is_favorited }
-				onToggle={ () => mutate( ! site.is_favorited ) }
-			/>
+			{ showFavorite && (
+				<Favorite
+					isFavorited={ site.is_favorited }
+					onToggle={ () => mutate( ! site.is_favorited ) }
+				/>
+			) }
 		</HStack>
 	);
 }

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -5,9 +5,10 @@ import {
 	sitePHPVersionQuery,
 	siteEngagementStatsQuery,
 	siteUptimeQuery,
+	siteFavoriteMutation,
 } from '@automattic/api-queries';
 import { Badge } from '@automattic/ui';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import {
 	Button,
@@ -18,7 +19,7 @@ import {
 import { useResizeObserver } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
 import { starEmpty, starFilled } from '@wordpress/icons';
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { useAnalytics } from '../../app/analytics';
 import ComponentViewTracker from '../../components/component-view-tracker';
@@ -48,23 +49,30 @@ function LoadingIndicator( { label }: { label: string } ) {
 	return <TextBlur>{ label }</TextBlur>;
 }
 
-export function Favorite() {
-	const [ isFavorite, setIsFavorite ] = useState( false );
-
-	const toggleFavorite = useCallback( ( event: React.MouseEvent ) => {
-		event.stopPropagation();
-		event.preventDefault();
-		setIsFavorite( ( prev ) => ! prev );
-	}, [] );
+export function Favorite( {
+	isFavorited,
+	onToggle,
+}: {
+	isFavorited: boolean;
+	onToggle?: () => void;
+} ) {
+	const handleClick = useCallback(
+		( event: React.MouseEvent ) => {
+			event.stopPropagation();
+			event.preventDefault();
+			onToggle?.();
+		},
+		[ onToggle ]
+	);
 
 	return (
 		<Button
-			icon={ isFavorite ? starFilled : starEmpty }
-			label={ isFavorite ? __( 'Remove from favorites' ) : __( 'Add to favorites' ) }
-			onClick={ toggleFavorite }
+			icon={ isFavorited ? starFilled : starEmpty }
+			label={ isFavorited ? __( 'Remove from favorites' ) : __( 'Add to favorites' ) }
+			onClick={ onToggle ? handleClick : undefined }
 			size="small"
 			style={ {
-				color: isFavorite ? '#F0B849' : '#C3C4C7',
+				color: isFavorited ? '#F0B849' : '#C3C4C7',
 			} }
 		/>
 	);
@@ -110,10 +118,14 @@ export function SiteLink( {
 }
 
 export function Name( { site, value }: { site: Site; value: string } ) {
+	const { mutate } = useMutation( siteFavoriteMutation( site.ID ) );
 	return (
 		<HStack justify="flex-start" alignment="center" spacing={ 1 }>
 			<NameRenderer badge={ getSiteBadge( site ) } muted={ site.is_deleted } value={ value } />
-			<Favorite />
+			<Favorite
+				isFavorited={ site.is_favorited }
+				onToggle={ () => mutate( ! site.is_favorited ) }
+			/>
 		</HStack>
 	);
 }

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -10,12 +10,15 @@ import { Badge } from '@automattic/ui';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import {
+	Button,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	ExternalLink,
 } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
+import { starEmpty, starFilled } from '@wordpress/icons';
+import { useCallback, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { useAnalytics } from '../../app/analytics';
 import ComponentViewTracker from '../../components/component-view-tracker';
@@ -43,6 +46,28 @@ function IneligibleIndicator() {
 
 function LoadingIndicator( { label }: { label: string } ) {
 	return <TextBlur>{ label }</TextBlur>;
+}
+
+export function Favorite() {
+	const [ isFavorite, setIsFavorite ] = useState( false );
+
+	const toggleFavorite = useCallback( ( event: React.MouseEvent ) => {
+		event.stopPropagation();
+		event.preventDefault();
+		setIsFavorite( ( prev ) => ! prev );
+	}, [] );
+
+	return (
+		<Button
+			icon={ isFavorite ? starFilled : starEmpty }
+			label={ isFavorite ? __( 'Remove from favorites' ) : __( 'Add to favorites' ) }
+			onClick={ toggleFavorite }
+			size="small"
+			style={ {
+				color: isFavorite ? '#F0B849' : '#C3C4C7',
+			} }
+		/>
+	);
 }
 
 function getSiteManagementUrl( site: Site ) {
@@ -85,7 +110,12 @@ export function SiteLink( {
 }
 
 export function Name( { site, value }: { site: Site; value: string } ) {
-	return <NameRenderer badge={ getSiteBadge( site ) } muted={ site.is_deleted } value={ value } />;
+	return (
+		<HStack justify="flex-start" alignment="center" spacing={ 1 }>
+			<NameRenderer badge={ getSiteBadge( site ) } muted={ site.is_deleted } value={ value } />
+			<Favorite />
+		</HStack>
+	);
 }
 
 export function NameRenderer( {

--- a/packages/api-core/src/me-sites/fetchers.ts
+++ b/packages/api-core/src/me-sites/fetchers.ts
@@ -20,6 +20,7 @@ export interface FetchPaginatedSitesOptions extends FetchSitesOptions {
 	search?: string;
 	plan?: string[];
 	visibility?: string[];
+	is_favorited?: boolean;
 	sort_field?: string;
 	sort_direction?: string;
 	page?: number;
@@ -63,6 +64,7 @@ export async function fetchPaginatedSites(
 		search,
 		plan,
 		visibility,
+		is_favorited,
 		sort_field,
 		sort_direction,
 		page,
@@ -86,6 +88,7 @@ export async function fetchPaginatedSites(
 			search,
 			plan,
 			visibility,
+			is_favorited,
 			sort_field,
 			sort_direction,
 			page,

--- a/packages/api-core/src/me-sites/index.ts
+++ b/packages/api-core/src/me-sites/index.ts
@@ -1,1 +1,2 @@
 export * from './fetchers';
+export * from './mutators';

--- a/packages/api-core/src/me-sites/mutators.ts
+++ b/packages/api-core/src/me-sites/mutators.ts
@@ -1,0 +1,12 @@
+import { wpcom } from '../wpcom-fetcher';
+
+export async function setFavoriteSite(
+	siteId: number,
+	isFavorited: boolean
+): Promise< { is_favorited: boolean } > {
+	return wpcom.req.post( {
+		path: `/me/sites/${ siteId }/favorite`,
+		apiNamespace: 'wpcom/v2',
+		body: { is_favorited: isFavorited },
+	} );
+}

--- a/packages/api-core/src/site/fetchers.ts
+++ b/packages/api-core/src/site/fetchers.ts
@@ -36,6 +36,7 @@ export const SITE_FIELDS = [
 	'was_migration_trial',
 	'was_hosting_trial',
 	'was_upgraded_from_trial',
+	'is_favorited',
 	'is_garden',
 	'garden_name',
 	'garden_partner',

--- a/packages/api-core/src/site/types.ts
+++ b/packages/api-core/src/site/types.ts
@@ -78,6 +78,7 @@ export interface Site {
 	was_migration_trial: boolean;
 	was_hosting_trial: boolean;
 	was_upgraded_from_trial: boolean;
+	is_favorited: boolean;
 	is_garden: boolean;
 	garden_name: string | null;
 	garden_partner: string | null;

--- a/packages/api-queries/src/site.ts
+++ b/packages/api-queries/src/site.ts
@@ -4,6 +4,7 @@ import {
 	deleteSite,
 	launchSite,
 	restoreSite,
+	setFavoriteSite,
 	SITE_FIELDS,
 	SITE_OPTIONS,
 } from '@automattic/api-core';
@@ -152,5 +153,43 @@ export const siteRestoreMutation = ( siteId: number ) =>
 			queryClient.invalidateQueries( siteQueryFilter( siteId ) );
 			queryClient.invalidateQueries( { queryKey: [ 'site', siteId ] } );
 			queryClient.invalidateQueries( { queryKey: [ 'sites' ] } );
+		},
+	} );
+
+export const siteFavoriteMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: ( isFavorited: boolean ) => setFavoriteSite( siteId, isFavorited ),
+		onMutate: async ( isFavorited: boolean ) => {
+			await queryClient.cancelQueries( { queryKey: [ 'sites' ] } );
+
+			const updateSite = ( oldData?: Site ) => {
+				if ( ! oldData ) {
+					return oldData;
+				}
+				return { ...oldData, is_favorited: isFavorited };
+			};
+
+			queryClient.setQueriesData< { sites: Site[]; total: number } >(
+				{ queryKey: [ 'sites' ] },
+				( oldData ) => {
+					if ( ! oldData ) {
+						return oldData;
+					}
+					return {
+						...oldData,
+						sites: oldData.sites.map( ( site ) =>
+							site.ID === siteId ? { ...site, is_favorited: isFavorited } : site
+						),
+					};
+				}
+			);
+
+			queryClient.setQueriesData< Site >( siteQueryFilter( siteId ), updateSite );
+
+			return { siteId };
+		},
+		onError: () => {
+			queryClient.invalidateQueries( { queryKey: [ 'sites' ] } );
+			queryClient.invalidateQueries( siteQueryFilter( siteId ) );
 		},
 	} );


### PR DESCRIPTION
Part of DOTMSD-980

## Proposed Changes

* Add `is_favorited` property to the Site type and request it from the `/me/sites` API
* Add a star icon next to site names that toggles favorite state with optimistic updates
* Add `is_favorited` as a DataView field with filter support (`is` operator)
* Add `setFavoriteSite` mutator calling `POST /me/sites/{id}/favorite` (endpoint to be created)
* Wire filter-to-API mapping so `is_favorited` filter is passed as a query param

## Why are these changes being made?

Users managing multiple sites need a way to quickly access their most important sites. The favorite/star feature lets users mark sites they use frequently so they can filter to just those sites. This was a highly requested feature in A4A and is needed for the MSD as A4A migrates to it.

## Testing Instructions

* Navigate to the Sites list in the Dashboard
* Stars should appear next to each site name
* Clicking a star should toggle it (optimistic update — API endpoint not yet implemented)
* The "Favorited" filter should appear in the filter options
* Note: The backend endpoint (`POST /me/sites/{id}/favorite`) does not exist yet, so toggling will revert on error

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)