### PR TITLE
Stats: Fix subscriber chart Y-axis to always start from zero

### DIFF
--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -282,7 +282,7 @@ export default function SubscribersChartSection( {
 							height={ 300 }
 							curveType="monotone" // can use smooth, linear, monotone
 							EmptyState={ () => null }
-							zeroBaseline={ lineChartData.length > 1 }
+							zeroBaseline
 							formatTimeTick={ formatTimeTick }
 							placeholder={ <StatsModulePlaceholder className="is-chart" isLoading /> }
 						/>


### PR DESCRIPTION
Fixes STATS-229

## Proposed Changes

- Always enable `zeroBaseline` for the LineChart subscriber chart instead of only when paid subscribers exist

## Why are these changes being made?

The subscriber count chart in Stats > Subscribers was constraining the Y-axis to the min/max of actual subscriber data, making tiny fluctuations appear dramatic. A variance of 4 subscribers out of ~140 would fill the entire chart height, visually suggesting catastrophic drops/gains when the actual change was negligible.

This fix ensures the Y-axis always starts from 0 so that subscriber changes are shown in proper proportion.

## Testing Instructions

1. Navigate to Stats > Subscribers on any site with subscriber data
2. Verify the Y-axis starts from 0 (or near 0) instead of the minimum subscriber value
3. Confirm small subscriber count changes appear proportionally small on the chart
4. Test with both single series (just subscribers) and dual series (subscribers + paid subscribers)

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?