### PR TITLE
Domain Search: Show free subdomain option for .wordpress.com queries

### DIFF
--- a/packages/domain-search/src/components/search-bar/input.tsx
+++ b/packages/domain-search/src/components/search-bar/input.tsx
@@ -1,6 +1,6 @@
 import { useDebounce } from '@wordpress/compose';
 import { useI18n } from '@wordpress/react-i18n';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useDomainSearch } from '../../page/context';
 import { DomainSearchControls } from '../../ui';
 
@@ -10,6 +10,10 @@ export const Input = () => {
 	const { __ } = useI18n();
 	const { query, setQuery, events } = useDomainSearch();
 	const [ localQuery, setLocalQuery ] = useState( query );
+
+	useEffect( () => {
+		setLocalQuery( query );
+	}, [ query ] );
 
 	const debouncedPropagateQuery = useDebounce( setQuery, DELAY_TIMEOUT );
 

--- a/packages/domain-search/src/components/skip-suggestion/index.tsx
+++ b/packages/domain-search/src/components/skip-suggestion/index.tsx
@@ -1,4 +1,5 @@
 import { useIsMutating, useQuery } from '@tanstack/react-query';
+import { isWpcomSubdomainQuery, stripWpcomSubdomainSuffix } from '../../helpers';
 import { useDomainSearch } from '../../page/context';
 import { DomainSearchSkipSuggestion } from '../../ui';
 
@@ -7,7 +8,10 @@ const SkipSuggestion = () => {
 
 	const isMutating = useIsMutating();
 
-	const { data: suggestion } = useQuery( queries.freeSuggestion( query ) );
+	const isWpcomSubdomain = isWpcomSubdomainQuery( query );
+	const normalizedQuery = isWpcomSubdomain ? stripWpcomSubdomainSuffix( query ) : query;
+
+	const { data: suggestion } = useQuery( queries.freeSuggestion( normalizedQuery ) );
 
 	if ( currentSiteUrl ) {
 		return (
@@ -20,9 +24,12 @@ const SkipSuggestion = () => {
 	}
 
 	if ( suggestion ) {
+		const isUnavailable = isWpcomSubdomain && suggestion.domain_name !== query;
+
 		return (
 			<DomainSearchSkipSuggestion
 				freeSuggestion={ suggestion.domain_name }
+				unavailableDomain={ isUnavailable ? query : undefined }
 				onSkip={ () => events.onSkip( suggestion ) }
 				disabled={ !! isMutating }
 			/>

--- a/packages/domain-search/src/components/skip-suggestion/index.tsx
+++ b/packages/domain-search/src/components/skip-suggestion/index.tsx
@@ -4,7 +4,7 @@ import { useDomainSearch } from '../../page/context';
 import { DomainSearchSkipSuggestion } from '../../ui';
 
 const SkipSuggestion = () => {
-	const { queries, query, currentSiteUrl, events } = useDomainSearch();
+	const { queries, query, currentSiteUrl, events, setQuery } = useDomainSearch();
 
 	const isMutating = useIsMutating();
 
@@ -31,6 +31,7 @@ const SkipSuggestion = () => {
 				freeSuggestion={ suggestion.domain_name }
 				unavailableDomain={ isUnavailable ? query : undefined }
 				onSkip={ () => events.onSkip( suggestion ) }
+				onSuggestionClick={ () => setQuery( suggestion.domain_name ) }
 				disabled={ !! isMutating }
 			/>
 		);

--- a/packages/domain-search/src/components/skip-suggestion/test/index.tsx
+++ b/packages/domain-search/src/components/skip-suggestion/test/index.tsx
@@ -90,9 +90,7 @@ describe( 'SkipSuggestion', () => {
 				</TestDomainSearchWithSuggestions>
 			);
 
-			expect(
-				await screen.findByText( 'Start free with a WordPress.com subdomain' )
-			).toBeInTheDocument();
+			expect( await screen.findByText( /Start free with / ) ).toBeInTheDocument();
 			expect( screen.getByText( 'Upgrade to a custom domain name anytime.' ) ).toBeInTheDocument();
 
 			const skipButton = screen.getByRole( 'button', {
@@ -123,9 +121,7 @@ describe( 'SkipSuggestion', () => {
 				</TestDomainSearchWithSuggestions>
 			);
 
-			expect(
-				await screen.findByText( 'Start free with a WordPress.com subdomain' )
-			).toBeInTheDocument();
+			expect( await screen.findByText( /Start free with / ) ).toBeInTheDocument();
 			expect( screen.getByText( 'Upgrade to a custom domain name anytime.' ) ).toBeInTheDocument();
 
 			expect( freeSuggestionQuery.isDone() ).toBe( true );

--- a/packages/domain-search/src/helpers/index.ts
+++ b/packages/domain-search/src/helpers/index.ts
@@ -1,5 +1,6 @@
 export { getRootDomain } from './get-root-domain';
 export { getTld } from './get-tld';
 export { isSubdomain } from './is-subdomain';
+export { isWpcomSubdomainQuery, stripWpcomSubdomainSuffix } from './is-wpcom-subdomain-query';
 export { parseDomainAgainstTldList } from './parse-domain-against-tld-list';
 export { parseMatchReasons } from './parse-match-reasons';

--- a/packages/domain-search/src/helpers/is-wpcom-subdomain-query.ts
+++ b/packages/domain-search/src/helpers/is-wpcom-subdomain-query.ts
@@ -1,11 +1,11 @@
-const WPCOM_SUBDOMAIN_SUFFIXES = [ '.wordpress.com', '.wp.com' ];
+const WPCOM_SUBDOMAIN_SUFFIX = '.wordpress.com';
 
 /**
  * Detects whether a search query is for a WordPress.com subdomain
- * (e.g. "mysite.wordpress.com" or "mysite.wp.com").
+ * (e.g. "mysite.wordpress.com").
  */
 export function isWpcomSubdomainQuery( query: string ): boolean {
-	return WPCOM_SUBDOMAIN_SUFFIXES.some( ( suffix ) => query.endsWith( suffix ) );
+	return query.endsWith( WPCOM_SUBDOMAIN_SUFFIX );
 }
 
 /**
@@ -13,10 +13,8 @@ export function isWpcomSubdomainQuery( query: string ): boolean {
  * subdomain label (e.g. "mysite.wordpress.com" → "mysite").
  */
 export function stripWpcomSubdomainSuffix( query: string ): string {
-	for ( const suffix of WPCOM_SUBDOMAIN_SUFFIXES ) {
-		if ( query.endsWith( suffix ) ) {
-			return query.slice( 0, -suffix.length );
-		}
+	if ( query.endsWith( WPCOM_SUBDOMAIN_SUFFIX ) ) {
+		return query.slice( 0, -WPCOM_SUBDOMAIN_SUFFIX.length );
 	}
 	return query;
 }

--- a/packages/domain-search/src/helpers/is-wpcom-subdomain-query.ts
+++ b/packages/domain-search/src/helpers/is-wpcom-subdomain-query.ts
@@ -1,0 +1,22 @@
+const WPCOM_SUBDOMAIN_SUFFIXES = [ '.wordpress.com', '.wp.com' ];
+
+/**
+ * Detects whether a search query is for a WordPress.com subdomain
+ * (e.g. "mysite.wordpress.com" or "mysite.wp.com").
+ */
+export function isWpcomSubdomainQuery( query: string ): boolean {
+	return WPCOM_SUBDOMAIN_SUFFIXES.some( ( suffix ) => query.endsWith( suffix ) );
+}
+
+/**
+ * Strips the WordPress.com subdomain suffix from a query, returning just the
+ * subdomain label (e.g. "mysite.wordpress.com" → "mysite").
+ */
+export function stripWpcomSubdomainSuffix( query: string ): string {
+	for ( const suffix of WPCOM_SUBDOMAIN_SUFFIXES ) {
+		if ( query.endsWith( suffix ) ) {
+			return query.slice( 0, -suffix.length );
+		}
+	}
+	return query;
+}

--- a/packages/domain-search/src/hooks/use-suggestions-list.ts
+++ b/packages/domain-search/src/hooks/use-suggestions-list.ts
@@ -1,7 +1,7 @@
 import { type DomainAvailability, DomainAvailabilityStatus } from '@automattic/api-core';
 import { DefinedUseQueryResult, useQueries, useQuery, UseQueryResult } from '@tanstack/react-query';
 import { useMemo } from 'react';
-import { getTld } from '../helpers';
+import { getTld, isWpcomSubdomainQuery, stripWpcomSubdomainSuffix } from '../helpers';
 import { addAvailabilityAsSuggestion } from '../helpers/add-availability-as-suggestion';
 import { isSupportedPremiumDomain } from '../helpers/is-supported-premium-domain';
 import { partitionSuggestions } from '../helpers/partition-suggestions';
@@ -27,15 +27,18 @@ const availablePremiumDomainsCombinator = (
 export const useSuggestionsList = () => {
 	const { query, queries, config } = useDomainSearch();
 
+	const isWpcomSubdomain = isWpcomSubdomainQuery( query );
+	const freeSuggestionQuery = isWpcomSubdomain ? stripWpcomSubdomainSuffix( query ) : query;
+
 	const { data: suggestions = [], isLoading: isLoadingSuggestions } = useQuery( {
 		...queries.domainSuggestions( query ),
 		enabled: true,
 	} );
 
-	const isFqdnQuery = !! getTld( query );
+	const isFqdnQuery = ! isWpcomSubdomain && !! getTld( query );
 
 	const { isLoading: isLoadingFreeSuggestion } = useQuery( {
-		...queries.freeSuggestion( query ),
+		...queries.freeSuggestion( freeSuggestionQuery ),
 		enabled: config.skippable && ! isFqdnQuery,
 	} );
 

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -762,7 +762,9 @@ describe( 'ResultsPage', () => {
 			expect(
 				await screen.findByText( 'taken.wordpress.com is not available' )
 			).toBeInTheDocument();
-			expect( screen.getByText( 'Try taken123.wordpress.com instead?' ) ).toBeInTheDocument();
+			expect(
+				screen.getByRole( 'button', { name: 'taken123.wordpress.com' } )
+			).toBeInTheDocument();
 			expect( screen.queryByLabelText( /Skip purchase/ ) ).not.toBeInTheDocument();
 		} );
 	} );

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -716,6 +716,55 @@ describe( 'ResultsPage', () => {
 				screen.queryByLabelText( 'Skip purchase and continue with testcom.wordpress.com' )
 			).not.toBeInTheDocument();
 		} );
+
+		it( 'renders the skip suggestion when searching for an available WordPress.com subdomain', async () => {
+			mockGetSuggestionsQuery( {
+				params: { query: 'mysite.wordpress.com' },
+				suggestions: [ buildSuggestion( { domain_name: 'mysite.com' } ) ],
+			} );
+
+			mockGetFreeSuggestionQuery( {
+				params: { query: 'mysite' },
+				freeSuggestion: buildFreeSuggestion( { domain_name: 'mysite.wordpress.com' } ),
+			} );
+
+			render(
+				<TestDomainSearch config={ { skippable: true } } query="mysite.wordpress.com">
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			expect(
+				await screen.findByText( 'Start free with mysite.wordpress.com' )
+			).toBeInTheDocument();
+			expect(
+				screen.getByLabelText( 'Skip purchase and continue with mysite.wordpress.com' )
+			).toBeInTheDocument();
+		} );
+
+		it( 'renders unavailable notice when the searched WordPress.com subdomain is taken', async () => {
+			mockGetSuggestionsQuery( {
+				params: { query: 'taken.wordpress.com' },
+				suggestions: [ buildSuggestion( { domain_name: 'taken.com' } ) ],
+			} );
+
+			mockGetFreeSuggestionQuery( {
+				params: { query: 'taken' },
+				freeSuggestion: buildFreeSuggestion( { domain_name: 'taken123.wordpress.com' } ),
+			} );
+
+			render(
+				<TestDomainSearch config={ { skippable: true } } query="taken.wordpress.com">
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			expect(
+				await screen.findByText( 'taken.wordpress.com is not available' )
+			).toBeInTheDocument();
+			expect( screen.getByText( 'Try taken123.wordpress.com instead?' ) ).toBeInTheDocument();
+			expect( screen.queryByLabelText( /Skip purchase/ ) ).not.toBeInTheDocument();
+		} );
 	} );
 
 	describe( 'tracking', () => {

--- a/packages/domain-search/src/ui/domain-search-skip-suggestion/index.tsx
+++ b/packages/domain-search/src/ui/domain-search-skip-suggestion/index.tsx
@@ -15,6 +15,7 @@ interface Props {
 	unavailableDomain?: string;
 	existingSiteUrl?: string;
 	onSkip: () => void;
+	onSuggestionClick?: () => void;
 	disabled?: boolean;
 	isBusy?: boolean;
 }
@@ -24,6 +25,7 @@ const DomainSearchSkipSuggestion = ( {
 	unavailableDomain,
 	existingSiteUrl,
 	onSkip,
+	onSuggestionClick,
 	disabled,
 	isBusy,
 }: Props ) => {
@@ -56,10 +58,15 @@ const DomainSearchSkipSuggestion = ( {
 			__( '%(domain)s is not available' ),
 			{ domain: unavailableDomain }
 		);
-		subtitle = sprintf(
-			// translators: %(suggestion)s is an alternative free WordPress.com subdomain
-			__( 'Try %(suggestion)s instead?' ),
-			{ suggestion: freeSuggestion }
+		subtitle = createInterpolateElement(
+			sprintf(
+				// translators: %(suggestion)s is an alternative free WordPress.com subdomain
+				__( 'Try <link>%(suggestion)s</link> instead?' ),
+				{ suggestion: freeSuggestion }
+			),
+			{
+				link: <Button variant="link" onClick={ () => onSuggestionClick?.() } />,
+			}
 		);
 		showButton = false;
 	} else if ( freeSuggestion ) {

--- a/packages/domain-search/src/ui/domain-search-skip-suggestion/index.tsx
+++ b/packages/domain-search/src/ui/domain-search-skip-suggestion/index.tsx
@@ -12,6 +12,7 @@ import './style.scss';
 
 interface Props {
 	freeSuggestion?: string;
+	unavailableDomain?: string;
 	existingSiteUrl?: string;
 	onSkip: () => void;
 	disabled?: boolean;
@@ -20,6 +21,7 @@ interface Props {
 
 const DomainSearchSkipSuggestion = ( {
 	freeSuggestion,
+	unavailableDomain,
 	existingSiteUrl,
 	onSkip,
 	disabled,
@@ -28,6 +30,7 @@ const DomainSearchSkipSuggestion = ( {
 	let title;
 	let subtitle;
 	let buttonText = __( 'Skip purchase' );
+	let showButton = true;
 
 	if ( existingSiteUrl ) {
 		const [ domain, ...tld ] = existingSiteUrl.split( '.' );
@@ -47,8 +50,24 @@ const DomainSearchSkipSuggestion = ( {
 				tld: <strong style={ { whiteSpace: 'nowrap' } } />,
 			}
 		);
+	} else if ( freeSuggestion && unavailableDomain ) {
+		title = sprintf(
+			// translators: %(domain)s is the WordPress.com subdomain the user searched for
+			__( '%(domain)s is not available' ),
+			{ domain: unavailableDomain }
+		);
+		subtitle = sprintf(
+			// translators: %(suggestion)s is an alternative free WordPress.com subdomain
+			__( 'Try %(suggestion)s instead?' ),
+			{ suggestion: freeSuggestion }
+		);
+		showButton = false;
 	} else if ( freeSuggestion ) {
-		title = __( 'Start free with a WordPress.com subdomain' );
+		title = sprintf(
+			// translators: %(domain)s is the free WordPress.com subdomain
+			__( 'Start free with %(domain)s' ),
+			{ domain: freeSuggestion }
+		);
 		subtitle = __( 'Upgrade to a custom domain name anytime.' );
 		buttonText = __( 'Start Free' );
 	}
@@ -68,18 +87,22 @@ const DomainSearchSkipSuggestion = ( {
 			}
 			subtitle={ subtitle && <Text>{ subtitle }</Text> }
 			right={
-				<Button
-					className="domain-search-skip-suggestion__btn"
-					variant="secondary"
-					// translators: %(domain)s is the domain name
-					label={ sprintf( __( 'Skip purchase and continue with %(domain)s' ), { domain } ) }
-					onClick={ onSkip }
-					disabled={ disabled }
-					isBusy={ isBusy && ! disabled }
-					__next40pxDefaultSize
-				>
-					{ buttonText }
-				</Button>
+				showButton ? (
+					<Button
+						className="domain-search-skip-suggestion__btn"
+						variant="secondary"
+						// translators: %(domain)s is the domain name
+						label={ sprintf( __( 'Skip purchase and continue with %(domain)s' ), {
+							domain,
+						} ) }
+						onClick={ onSkip }
+						disabled={ disabled }
+						isBusy={ isBusy && ! disabled }
+						__next40pxDefaultSize
+					>
+						{ buttonText }
+					</Button>
+				) : undefined
 			}
 		/>
 	);


### PR DESCRIPTION
Part of DOMENG-440

## Proposed Changes

* Detect `*.wordpress.com` queries in domain search and treat them as non-FQDN queries so the free subdomain option is shown
* Strip the `.wordpress.com` suffix before calling the free suggestion API to get the correct subdomain suggestion
* Show contextual messaging on the skip suggestion card:
  - **Available**: "Start free with mysite.wordpress.com" + Start Free button
  - **Taken**: "xxxx.wordpress.com is not available" / "Try xxxxx.wordpress.com instead?" with no button

| Before (trunk) | After (unavailable) | After (avaliable)
|--------|-------| - |
| <img src="https://github.com/user-attachments/assets/d98d3109-dd08-49dd-8bf9-d39649d29a28" width="600" /> | <img src="https://github.com/user-attachments/assets/1743fa3b-c327-40f8-b9ce-81b05a1e9c68" width="600" /> | <img width="600" src="https://github.com/user-attachments/assets/fb01c5ec-61eb-415c-a642-b1b6949afa06" />|

## Why are these changes being made?

When users search for `*.wordpress.com` queries (e.g. `xxxx.wordpress.com`), it disables the free suggestion query and hides the "Start free" card entirely. This is a recurring user pain point (DOMENG-440, DOTOBRD-418, DOTOBRD-398).

## Testing Instructions

1. Run `yarn start` and navigate to the domain search step in any onboarding flow
2. Search for `xxxxx.wordpress.com` — verify the free subdomain card appears with "Start free with mysite.wordpress.com"
3. Search for an already-taken WordPress.com subdomain — verify the card shows "{domain} is not available" with an alternative suggestion and no Start Free button
4. Search for a regular domain like `mysite.com` — verify the free subdomain card is still hidden (FQDN behavior unchanged)
5. Search for `mysite` — verify the free subdomain card shows as before

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)