### PR TITLE
Design proposal: Onboarding stepper

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/components/onboarding-flow-stepper/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/onboarding-flow-stepper/index.tsx
@@ -1,0 +1,92 @@
+import { Icon } from '@wordpress/components';
+import { check } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
+import clsx from 'clsx';
+import { Fragment } from 'react';
+
+import './style.scss';
+
+export type OnboardingFlowStep = 'select-domain' | 'select-plan' | 'payment';
+
+interface OnboardingFlowStepperProps {
+	currentStep: OnboardingFlowStep;
+	/**
+	 * URLs for completed steps that should be navigable.
+	 * Only completed steps with a URL will be rendered as clickable buttons.
+	 */
+	stepUrls?: Partial< Record< OnboardingFlowStep, string > >;
+}
+
+const STEPS: OnboardingFlowStep[] = [ 'select-domain', 'select-plan', 'payment' ];
+
+export const OnboardingFlowStepper = ( { currentStep, stepUrls }: OnboardingFlowStepperProps ) => {
+	const { __ } = useI18n();
+	const currentIndex = STEPS.indexOf( currentStep );
+
+	const getStepLabel = ( id: OnboardingFlowStep ) => {
+		switch ( id ) {
+			case 'select-domain':
+				return __( 'Select a domain' );
+			case 'select-plan':
+				return __( 'Select a plan' );
+			case 'payment':
+				return __( 'Complete payment' );
+		}
+	};
+
+	return (
+		<nav className="onboarding-flow-stepper" aria-label={ __( 'Onboarding steps' ) }>
+			{ STEPS.map( ( id, index ) => {
+				const isCompleted = index < currentIndex;
+				const isActive = index === currentIndex;
+				const url = isCompleted ? stepUrls?.[ id ] : undefined;
+				const isClickable = Boolean( url );
+				const label = getStepLabel( id );
+
+				const stepContent = (
+					<>
+						<div className="onboarding-flow-stepper__circle">
+							<span className="onboarding-flow-stepper__number">{ index + 1 }</span>
+							{ isCompleted && (
+								<Icon className="onboarding-flow-stepper__check" icon={ check } size={ 10 } />
+							) }
+						</div>
+						<span className="onboarding-flow-stepper__label">{ label }</span>
+					</>
+				);
+
+				return (
+					<Fragment key={ id }>
+						{ index > 0 && (
+							<div className="onboarding-flow-stepper__connector" aria-hidden="true" />
+						) }
+						{ isClickable ? (
+							<button
+								type="button"
+								className={ clsx(
+									'onboarding-flow-stepper__step',
+									'is-completed',
+									'is-clickable'
+								) }
+								onClick={ () => window.location.assign( url! ) }
+								aria-label={ label }
+							>
+								{ stepContent }
+							</button>
+						) : (
+							<div
+								className={ clsx( 'onboarding-flow-stepper__step', {
+									'is-active': isActive,
+									'is-completed': isCompleted,
+								} ) }
+								aria-current={ isActive ? 'step' : undefined }
+							>
+								{ stepContent }
+							</div>
+						) }
+					</Fragment>
+				);
+			} ) }
+		</nav>
+	);
+};

--- a/client/landing/stepper/declarative-flow/internals/components/onboarding-flow-stepper/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/components/onboarding-flow-stepper/style.scss
@@ -1,0 +1,149 @@
+// Gutenberg design tokens
+// heading-small: @include heading-small() → font-size: $font-size-x-small (11px), font-weight: $font-weight-medium (500)
+// $font-family-body: system font stack
+// $gray-900: #1e1e1e (active/done)
+// $gray-600: #949494 (inactive)
+// link hover: var(--wp-admin-theme-color)
+
+.onboarding-flow-stepper {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	margin-block-end: 40px;
+
+	// Mobile-first: connectors expand to fill space between circles
+	&__connector {
+		flex: 1;
+		height: 1px;
+		background: $gray-600;
+		min-width: 12px;
+		max-width: 64px;
+		opacity: 0.4;
+		margin-inline: 8px;
+	}
+
+	&__step {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		flex-shrink: 0;
+	}
+
+	// Reset button element for clickable completed steps
+	&__step.is-clickable {
+		background: none;
+		border: none;
+		padding: 0;
+		cursor: pointer;
+		font: inherit;
+
+		&:hover {
+			.onboarding-flow-stepper__circle {
+				border-color: var(--wp-admin-theme-color);
+				color: var(--wp-admin-theme-color);
+			}
+
+			.onboarding-flow-stepper__number,
+			.onboarding-flow-stepper__check {
+				color: var(--wp-admin-theme-color);
+				fill: var(--wp-admin-theme-color);
+			}
+
+			.onboarding-flow-stepper__label {
+				color: var(--wp-admin-theme-color);
+				text-decoration: underline;
+			}
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--wp-admin-theme-color);
+			outline-offset: 2px;
+			border-radius: 2px;
+		}
+	}
+
+	&__circle {
+		width: 20px;
+		height: 20px;
+		border-radius: 50%;
+		border: 1.5px solid $gray-600;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		flex-shrink: 0;
+		color: $gray-600;
+		box-sizing: border-box;
+	}
+
+	// heading-small: $font-size-x-small / $font-weight-medium / $font-family-headings
+	&__number {
+		font-family: $font-family-body;
+		font-size: $font-size-x-small; // 11px
+		font-weight: $font-weight-medium; // 500
+		line-height: 1;
+	}
+
+	&__check {
+		fill: currentColor;
+		display: none; // desktop-only, enabled below
+	}
+
+	&__label {
+		display: none; // desktop-only, enabled below
+		font-family: $font-family-body;
+		font-size: 14px;
+		font-weight: 400;
+		color: $gray-600;
+		white-space: nowrap;
+	}
+
+	// Done/completed steps
+	&__step.is-completed {
+		.onboarding-flow-stepper__circle {
+			border-color: $gray-900;
+			color: $gray-900;
+		}
+
+		.onboarding-flow-stepper__label {
+			color: $gray-900;
+		}
+	}
+
+	// Active (current) step
+	&__step.is-active {
+		.onboarding-flow-stepper__circle {
+			background: $gray-900;
+			border-color: $gray-900;
+			color: #fff;
+		}
+
+		.onboarding-flow-stepper__label {
+			color: $gray-900;
+			font-weight: 600;
+		}
+	}
+
+	// Desktop: hide connectors, show labels and swap number → checkmark on completed steps
+	@include break-small {
+		gap: 24px;
+
+		&__connector {
+			display: none;
+		}
+
+		&__label {
+			display: block;
+		}
+
+		&__step.is-completed {
+			.onboarding-flow-stepper__number {
+				display: none;
+			}
+
+			.onboarding-flow-stepper__check {
+				display: block;
+			}
+		}
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -40,6 +40,7 @@ import { useSite } from '../../../../hooks/use-site';
 import { useSiteIdParam } from '../../../../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
+import { OnboardingFlowStepper } from '../../components/onboarding-flow-stepper';
 import HundredYearPlanStepWrapper from '../hundred-year-plan-step-wrapper';
 import type { Step as StepType } from '../../types';
 import type { FreeDomainSuggestion } from '@automattic/api-core';
@@ -422,6 +423,13 @@ const DomainSearchStep: StepType< {
 			);
 		};
 
+		const stepperHeading = (
+			<>
+				{ isOnboardingFlow( flow ) && <OnboardingFlowStepper currentStep="select-domain" /> }
+				<Step.Heading text={ headerText } subText={ subHeaderText } />
+			</>
+		);
+
 		return (
 			<Step.CenteredColumnLayout
 				topBar={
@@ -431,8 +439,9 @@ const DomainSearchStep: StepType< {
 					/>
 				}
 				columnWidth={ 10 }
+				headingColumnWidth={ 10 }
 				className="step-container-v2--domain-search"
-				heading={ <Step.Heading text={ headerText } subText={ subHeaderText } /> }
+				heading={ stepperHeading }
 			>
 				{ domainSearchElement }
 			</Step.CenteredColumnLayout>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -43,6 +43,7 @@ import {
 import { useSiteGlobalStylesOnPersonal } from 'calypso/state/sites/hooks/use-site-global-styles-on-personal';
 import { getSiteBySlug } from 'calypso/state/sites/selectors';
 import { ONBOARD_STORE } from '../../../../stores';
+import { OnboardingFlowStepper } from '../../components/onboarding-flow-stepper';
 import { getIntervalType } from './util';
 import type { OnboardSelect, SiteDetails } from '@automattic/data-stores';
 import type { StepState } from 'calypso/state/signup/progress/schema';
@@ -610,6 +611,12 @@ function UnifiedPlansStep( {
 					}
 					heading={
 						<>
+							{ flowName === ONBOARDING_FLOW && (
+								<OnboardingFlowStepper
+									currentStep="select-plan"
+									stepUrls={ { 'select-domain': '/setup/onboarding' } }
+								/>
+							) }
 							{ ( intent === 'plans-website-builder' || intent === 'plans-wordpress-hosting' ) && (
 								<IntentToggle
 									currentIntent={ intent }

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -40,6 +40,7 @@ import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useCallback } from 'react';
 import Loading from 'calypso/components/loading';
+import { OnboardingFlowStepper } from 'calypso/landing/stepper/declarative-flow/internals/components/onboarding-flow-stepper';
 import { useInitialIsInStepContainerV2FlowContext } from 'calypso/layout/utils';
 import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
 import {
@@ -869,6 +870,17 @@ export default function CheckoutMainContent( {
 			<Step.TwoColumnLayout
 				firstColumnWidth={ 8 }
 				secondColumnWidth={ 4 }
+				heading={
+					isSignupCheckout ? (
+						<OnboardingFlowStepper
+							currentStep="payment"
+							stepUrls={ {
+								'select-domain': '/setup/onboarding',
+								'select-plan': '/setup/onboarding/plans',
+							} }
+						/>
+					) : undefined
+				}
 				topBar={ ( { isLargeViewport } ) => {
 					const topBar = (
 						<Step.TopBar
@@ -1021,14 +1033,7 @@ const StepContainerV2CheckoutFixer = styled.div< {
 				height: 100%;
 
 				&:before {
-					content: '';
-					display: block;
-					background: var( --color-neutral-0 );
-					position: fixed;
-					top: calc( var( --step-container-v2-top-bar-height ) * -1 );
-					transform: translateX( calc( var( --left-padding ) * -1 ) );
-					width: 100vw;
-					bottom: 0;
+					display: none;
 				}
 			}
 


### PR DESCRIPTION
This is a design draft part of [DatSci: Optimization - Step by Step Progress Bar In Onboarding Flow](https://linear.app/a8c/project/datsci-optimization-step-by-step-progress-bar-in-onboarding-flow-a85dfc7f529a)

## Proposed Changes

* Introduces a new `OnboardingFlowStepper` component that surfaces progress through the domain → plan → checkout onboarding flow
* Completed steps are clickable and navigate back to that step
* Removes the full-bleed grey sidebar background on the Checkout page in the StepContainerV2 context to allow the component to take a centered position, being consistent with the other pages. 

<img width="2912" height="1832" alt="image" src="https://github.com/user-attachments/assets/db3c9d08-e9e0-424b-a953-98e835bb11e8" />


## Testing Instructions

1. Start an onboarding flow at `/setup/onboarding`
2. **Domain search step** — stepper should show step 1 (Select a domain) as active
3. **Plans step** — stepper should show step 1 as completed (✓ checkmark on desktop), step 2 active. Clicking "Select a domain" should navigate back to `/setup/onboarding`
4. **Checkout** — stepper should show steps 1 and 2 as completed and clickable, step 3 active. No grey background on the sidebar.
5. On mobile, connector lines between circles should have 8px margin on each side.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?