### PR TITLE
A4A: Update Migration and Site Tagging copies to be more clear and concise.

### DIFF
--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/empty-state.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/empty-state.tsx
@@ -29,10 +29,10 @@ export default function MigrationsCommissionsEmptyState( {
 	return (
 		<StepSection heading={ translate( 'View your migrated websites and commisions right here.' ) }>
 			<StepSectionItem
-				heading={ translate( "We'll tag the sites we moved for you once they're transferred." ) }
+				heading={ translate( 'Concierge Migrations' ) }
 				description={ preventWidows(
 					translate(
-						"If you picked the concierge service, we'll move your sites for you. Once we're done, you'll see them here, and they'll add to your commissions."
+						"If you picked the concierge service, we'll move your sites for you. Once we're done, you'll see them here and they'll be available for tagging."
 					)
 				) }
 			/>

--- a/client/a8c-for-agencies/sections/migrations/tag-sites-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/tag-sites-modal/index.tsx
@@ -150,9 +150,7 @@ export default function MigrationsTagSitesModal( {
 				</Button>
 			}
 			title={ translate( 'Tag your transferred sites for commission.' ) }
-			subtile={ translate(
-				"Select the sites you moved on your own. We'll check the migration and tag them as ready for your commission."
-			) }
+			subtile={ translate( 'Select the sites you moved on your own.' ) }
 		>
 			<div className="migrations-tag-sites-modal__instruction">
 				<Icon size={ 18 } icon={ info } />


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/A4A-2022/update-the-wording-for-tagging-sites-as-its-confusing

## Proposed Changes

* Agencies should know that they need to tag their own sites. So few of the copies are not accurate and need to be updated.
<img width="971" height="240" alt="Screenshot 2026-03-17 at 5 45 28 PM" src="https://github.com/user-attachments/assets/dcab9a74-6140-46ed-a56c-9a39d247a0aa" />
<img width="712" height="154" alt="Screenshot 2026-03-17 at 5 45 50 PM" src="https://github.com/user-attachments/assets/42240fed-718c-4a81-a314-d9aeac471b25" />

## Why are these changes being made?

* We need to ensure our copies are clear and concise to set expectations and prevent misunderstandings.

## Testing Instructions

* Use the A4A live link and navigate to `/migrations/commissions`.
* Make sure you don't have any existing migrations so the overview copies are rendered.
* Confirm the text is correct.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
