### PR TITLE
Reader: Update recent dropdown menu

### DIFF
--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -1,4 +1,7 @@
+import 'calypso/my-sites/sidebar/style.scss'; // Copy styles from the My Sites sidebar.
+import './style.scss';
 import page from '@automattic/calypso-router';
+import { Icon, plus } from '@wordpress/icons';
 import clsx from 'clsx';
 import closest from 'component-closest';
 import i18n, { localize, useTranslate } from 'i18n-calypso';
@@ -46,8 +49,6 @@ import ReaderSidebarNudges from './reader-sidebar-nudges';
 import ReaderSidebarOrganizations from './reader-sidebar-organizations';
 import ReaderSidebarRecent from './reader-sidebar-recent';
 import ReaderSidebarTags from './reader-sidebar-tags';
-import 'calypso/my-sites/sidebar/style.scss'; // Copy styles from the My Sites sidebar.
-import './style.scss';
 
 //TODO: Remove this component once the new reader MSD is enabled for all users
 const DeprecatedReaderSidebarHeader = () => {
@@ -263,6 +264,13 @@ export class ReaderSidebar extends Component {
 					) }
 
 					<SidebarSeparator />
+
+					<SidebarItem
+						label={ translate( 'New Subscription' ) }
+						onNavigate={ () => recordReaderTracksEvent( 'calypso_reader_sidebar_add_new_clicked' ) }
+						customIcon={ <Icon className="sidebar__menu-icon" icon={ plus } viewBox="2 0 24 24" /> }
+						link="/reader/new"
+					/>
 
 					<SidebarItem
 						className={ ReaderSidebarHelper.itemLinkClass( '/reader/subscriptions', path, {

--- a/client/reader/sidebar/reader-sidebar-recent/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-recent/index.tsx
@@ -1,7 +1,5 @@
 import './style.scss';
 import page from '@automattic/calypso-router';
-import { Icon } from '@wordpress/components';
-import { plus } from '@wordpress/icons';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import React, { useState } from 'react';
@@ -17,6 +15,7 @@ import { getSelectedRecentFeedId } from 'calypso/state/reader-ui/sidebar/selecto
 import { AppState } from 'calypso/types';
 import { AllIcon } from '../icons/all';
 import { MenuItem, MenuItemLink } from '../menu';
+
 // Not complete, just useful fields for now
 type Site = {
 	ID: number;
@@ -111,17 +110,6 @@ const ReaderSidebarRecent = ( {
 			materialIconStyle={ null }
 			expandableIconClick={ onClick }
 		>
-			<MenuItem key="add" selected={ path.startsWith( '/reader/new' ) }>
-				<MenuItemLink
-					href="/reader/new"
-					className="sidebar__menu-link"
-					onClick={ () => recordReaderTracksEvent( 'calypso_reader_sidebar_add_new_clicked' ) }
-				>
-					<Icon icon={ plus } viewBox="2 0 24 24" />
-					<span>{ translate( 'Add new' ) }</span>
-				</MenuItemLink>
-			</MenuItem>
-
 			<MenuItem key="all" selected={ isRecentStream && selectedSiteFeedId === null }>
 				<MenuItemLink
 					href="/reader"

--- a/client/reader/sidebar/reader-sidebar-recent/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-recent/index.tsx
@@ -39,7 +39,7 @@ type Props = {
 	translate: ( key: string ) => string;
 };
 
-const SITE_DISPLAY_CUTOFF = 8;
+const SITE_DISPLAY_CUTOFF = 5;
 const RECENT_PATH_REGEX = /^\/reader(?:\/recent\/\d+)?\/?(?:\?|$)/;
 
 const ReaderSidebarRecent = ( {
@@ -56,7 +56,6 @@ const ReaderSidebarRecent = ( {
 	const isRecentStream = RECENT_PATH_REGEX.test( path );
 
 	let sitesToShow = showAllSites ? sites : sites.slice( 0, SITE_DISPLAY_CUTOFF );
-	// const totalUnseenCount = sites.reduce( ( total, site ) => total + site.unseen_count, 0 );
 
 	const selectedSite = sites.find( ( site ) => site.feed_ID === selectedSiteFeedId );
 	if ( selectedSite && ! sitesToShow.includes( selectedSite ) ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes: [READ-361](https://linear.app/a8c/issue/READ-361)

## Proposed Changes

- Show 5 sites in recent dropdown menu.
- Move "Add New" menu item from inside the recent dropdown to main sidebar

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of "User Profile Redesign" project

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/reader`
- Verify changes on sidebar.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
