### PR TITLE
Reader: Update app title on sidebar

### DIFF
--- a/client/reader/components/header/style.scss
+++ b/client/reader/components/header/style.scss
@@ -8,7 +8,7 @@
 $component-icon-padding: 6px;
 
 :root {
-	--masterbar-height: 90px !important;
+	--masterbar-height: 65px !important;
 }
 
 .dashboard-header-bar {

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import clsx from 'clsx';
 import closest from 'component-closest';
-import i18n, { localize, useTranslate } from 'i18n-calypso';
+import i18n, { localize } from 'i18n-calypso';
 import { defer, startsWith } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -48,19 +48,6 @@ import ReaderSidebarRecent from './reader-sidebar-recent';
 import ReaderSidebarTags from './reader-sidebar-tags';
 import 'calypso/my-sites/sidebar/style.scss'; // Copy styles from the My Sites sidebar.
 import './style.scss';
-
-//TODO: Remove this component once the new reader MSD is enabled for all users
-const DeprecatedReaderSidebarHeader = () => {
-	const translate = useTranslate();
-	return (
-		<div className="sidebar-header">
-			<div>
-				<h3>{ translate( 'Reader' ) }</h3>
-				<p>{ translate( 'Keep up with your interests.' ) }</p>
-			</div>
-		</div>
-	);
-};
 
 const TrackingKeys = {
 	conversations: {
@@ -168,8 +155,7 @@ export class ReaderSidebar extends Component {
 
 		return (
 			<div className="sidebar-menu-container">
-				{ ! this.props.isMSDEnabled && <DeprecatedReaderSidebarHeader /> }
-				{ this.props.isMSDEnabled && <AppTitle /> }
+				<AppTitle />
 				<SidebarMenu>
 					<QueryReaderLists />
 					<QueryReaderTeams />

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -13,13 +13,6 @@
 	}
 }
 :root:has(.is-reader-msd-enabled) {
-	.sidebar-menu-container {
-		display: flex;
-		flex-direction: column;
-		gap: 24px;
-		padding: 0 16px;
-	}
-
 	.sidebar-header {
 		display: flex;
 		justify-content: space-between;
@@ -41,13 +34,6 @@
 
 //TODO: Remove this once the new reader MSD is enabled for all users (reader/enable-msd)
 :root:not(:has(.is-reader-msd-enabled)) {
-	.sidebar-menu-container {
-		display: flex;
-		flex-direction: column;
-		gap: 20px;
-		padding: 0 16px;
-	}
-
 	.sidebar-header {
 		display: flex;
 
@@ -73,6 +59,10 @@
 }
 
 body.is-section-reader {
+	.is-global-sidebar-visible {
+		--content-padding-top: 32px;
+	}
+
 	&.rtl .layout__content {
 		padding: calc( var( --masterbar-height ) + var( --content-padding-top ) )
 			calc( var( --sidebar-width-max ) ) var( --content-padding-bottom ) 16px;
@@ -84,10 +74,12 @@ body.is-section-reader {
 		min-height: 100vh;
 		padding-top: calc( var( --masterbar-height ) + var( --content-padding-top ) );
 		padding-bottom: var( --content-padding-bottom );
+
 		@media only screen and ( min-width: 782px ) {
 			padding: calc( var( --masterbar-height ) + var( --content-padding-top ) ) 16px
 				var( --content-padding-bottom ) calc( var( --sidebar-width-max ) ) !important;
 		}
+
 		.layout_primary > div {
 			padding-bottom: 0;
 		}
@@ -99,6 +91,21 @@ body.is-section-reader {
 
 	.has-no-masterbar .layout__content .main {
 		padding-top: var( --content-padding-top );
+	}
+
+	.sidebar__body {
+		padding-top: var(--content-padding-top);
+	}
+
+	.sidebar-menu-container {
+		display: flex;
+		flex-direction: column;
+		gap: 24px;
+		padding: 0 16px;
+
+		.app-title {
+			padding: 0;
+		}
 	}
 
 	@media only screen and ( max-width: 600px ) {
@@ -172,10 +179,10 @@ body.is-section-reader {
 			}
 		}
 	}
+
 	.sidebar__menu-icon {
 		margin-right: 12px;
 	}
-
 
 	.sidebar__menu-link-reader {
 		line-height: 1.8;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes: [READ-360](https://linear.app/a8c/issue/READ-360/reader-update-app-title-on-left-sidebar)

## Proposed Changes

- Remove description beneath the app title.
- Improve spacing in both classic view and MSD view (now consistent).

| Before | After |
| -------|------| 
| <img width="2622" height="2310" alt="wordpress com_reader" src="https://github.com/user-attachments/assets/e63fefff-f0b5-466a-82a8-6cbfe8fce639" /> | <img width="2880" height="2310" alt="calypso localhost_3000_reader" src="https://github.com/user-attachments/assets/d1a918b8-ef52-4d81-9dc7-fb52622ff04e" /> |
| <img width="2880" height="2310" alt="wordpress com_reader" src="https://github.com/user-attachments/assets/21cc95ad-6d59-442a-a54e-383b007a3167" /> | <img width="2880" height="2310" alt="calypso localhost_3000_reader" src="https://github.com/user-attachments/assets/bcbee6ee-9bb9-4beb-8162-be1c2f31cbb8" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- Part of "User Profile Redesign" project.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/reader` (non MSD view)
- Verify sidebar
- Enable Multi-Site Dashboard from account settings.
- Go to `/reader` (MSD view)
- Verify sidebar

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
