### PR TITLE
Theme Showcase: Update modern tier selector design

### DIFF
--- a/client/my-sites/themes/filter-bar-modern/index.tsx
+++ b/client/my-sites/themes/filter-bar-modern/index.tsx
@@ -101,13 +101,9 @@ const FilterBarModern = ( {
 		const selectedTierObj = tiers.find( ( t ) => t.key === selectedTier );
 		return {
 			key: selectedTier,
-			name: String(
-				translate( 'View: %s', {
-					args: selectedTierObj?.name ?? '',
-				} )
-			),
+			name: selectedTierObj?.name ?? '',
 		};
-	}, [ tiers, selectedTier, translate ] );
+	}, [ tiers, selectedTier ] );
 
 	return (
 		<>

--- a/client/my-sites/themes/filter-bar-modern/style.scss
+++ b/client/my-sites/themes/filter-bar-modern/style.scss
@@ -31,7 +31,7 @@
 	display: flex;
 	margin: 0 auto;
 	max-width: 1220px;
-	padding: 16px 24px;
+	padding: 24px;
 
 	@media ( min-width: $break-wide ) {
 		padding-left: 0;

--- a/client/my-sites/themes/filter-bar-modern/style.scss
+++ b/client/my-sites/themes/filter-bar-modern/style.scss
@@ -31,7 +31,7 @@
 	display: flex;
 	margin: 0 auto;
 	max-width: 1220px;
-	padding: 40px 24px 16px 24px; // Top padding adjusted +24px to accommodate the external tier label
+	padding: 16px 24px;
 
 	@media ( min-width: $break-wide ) {
 		padding-left: 0;
@@ -78,16 +78,31 @@
 
 .filter-bar-modern__tier-select {
 	flex-shrink: 0;
-	margin-top: -24px; // Accommodate the external label
 	min-width: 120px;
 	padding-left: 16px;
+	position: relative;
+
+	.components-base-control__label {
+		color: var( --studio-gray-60 );
+		font-size: 11px;
+		left: 28px; // 16px padding-left + 12px inner padding
+		line-height: 1;
+		margin-bottom: 0;
+		pointer-events: none;
+		position: absolute;
+		text-transform: none;
+		top: 8px;
+		z-index: 1;
+	}
 
 	.components-input-control__container {
 		border-radius: 4px;
 	}
 
 	button {
+		font-size: 14px;
 		height: 44px;
+		padding-top: 14px;
 	}
 
 	.components-custom-select-control__item.is-selected {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTTHEM-332

## Proposed Changes

* Update the tier selector in the modern logged-out Theme Showcase to match the design specs.

| Header | Header |
|--------|--------|
| <img width="145" height="325" alt="Screenshot 2026-03-17 at 12 59 49" src="https://github.com/user-attachments/assets/03762b3e-929b-48dd-a9fe-a10d6d420d7b" /> | <img width="145" height="305" alt="Screenshot 2026-03-17 at 12 59 29" src="https://github.com/user-attachments/assets/227e0314-db25-411b-b2a9-71c1a3c29073" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

I decided to delay redesigning the tier dropdown in the first iteration of the filter bar, to avoid changing Core visual behaviour. This change iterates on that with a simple CSS change.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the logged-out Theme Showcase with the `themes/showcase-modern` feature flag enabled.
* Ensure the tier dropdown looks and feel as expected at every screen size.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
