### PR TITLE
A4A: Remove a4a-pressable-premium-plans feature flag

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { formatCurrency, formatNumberCompact } from '@automattic/number-formatters';
 import { external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -119,8 +118,7 @@ export default function PressablePlanSection( {
 			return pressablePlans.filter(
 				( plan ) =>
 					plan.slug.startsWith( 'pressable-signature-' ) ||
-					( isEnabled( 'a4a-pressable-premium-plans' ) &&
-						plan.slug.startsWith( 'pressable-premium-' ) )
+					plan.slug.startsWith( 'pressable-premium-' )
 			);
 		}
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/premium-plan-section.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/premium-plan-section.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { formatCurrency } from '@automattic/number-formatters';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { Button } from '@wordpress/components';
@@ -25,7 +24,6 @@ export default function PremiumPlanSection( {
 	banner: React.ReactNode;
 } ) {
 	const translate = useTranslate();
-	const isPremiumPlansEnabled = isEnabled( 'a4a-pressable-premium-plans' );
 
 	const { marketplaceType, toggleMarketplaceType } = useContext( MarketplaceTypeContext );
 
@@ -39,7 +37,7 @@ export default function PremiumPlanSection( {
 		dispatch(
 			recordTracksEvent( 'calypso_a4a_marketplace_hosting_pressable_premium_refer_now_click' )
 		);
-		if ( isPremiumPlansEnabled && marketplaceType !== 'referral' ) {
+		if ( marketplaceType !== 'referral' ) {
 			toggleMarketplaceType();
 		}
 	};
@@ -72,7 +70,7 @@ export default function PremiumPlanSection( {
 					<div className="premium-plan-section__cta-buttons">
 						<Button
 							href={
-								isPremiumPlansEnabled && marketplaceType !== 'referral'
+								marketplaceType !== 'referral'
 									? A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK
 									: A4A_MARKETPLACE_HOSTING_REFER_PRESSABLE_PREMIUM_PLAN_LINK
 							}

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -41,7 +41,6 @@
 		"a4a-partner-directory": false,
 		"a4a-partner-directory-lead-matching": true,
 		"a4a-pressable-referrals": true,
-		"a4a-pressable-premium-plans": true,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": true,
 		"a4a-signup-v2-via-email": false,

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -34,7 +34,6 @@
 		"a4a-partner-directory": false,
 		"a4a-partner-directory-lead-matching": false,
 		"a4a-pressable-referrals": true,
-		"a4a-pressable-premium-plans": true,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": true,
 		"a4a-signup-v2-via-email": false,

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -34,7 +34,6 @@
 		"a4a-partner-directory": false,
 		"a4a-partner-directory-lead-matching": false,
 		"a4a-pressable-referrals": true,
-		"a4a-pressable-premium-plans": true,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": true,
 		"a4a-signup-v2-via-email": false,

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -36,7 +36,6 @@
 		"a4a-partner-directory": false,
 		"a4a-partner-directory-lead-matching": false,
 		"a4a-pressable-referrals": true,
-		"a4a-pressable-premium-plans": true,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": true,
 		"a4a-signup-v2-via-email": false,


### PR DESCRIPTION
Context: pfSQfS-1sJ-p2

## Proposed Changes

This pull request removes the use of the `a4a-pressable-premium-plans` feature flag from both the codebase and all configuration files. The logic for displaying and handling Pressable premium plans is now always enabled, simplifying the code and configuration management.

**Feature flag removal and code simplification:**

* Removed all references to the `isEnabled` function and the `a4a-pressable-premium-plans` flag from `pressable-plan-section/index.tsx` and `premium-plan-section.tsx`, making premium plan functionality always available. [[1]](diffhunk://#diff-90afca4e8e508d38a7c96b34328bf37cab883f078e46077e4ab8c1e0f7c3657fL1) [[2]](diffhunk://#diff-90afca4e8e508d38a7c96b34328bf37cab883f078e46077e4ab8c1e0f7c3657fL122-R121) [[3]](diffhunk://#diff-919839f2ca06011619277822cf98d5debcd77e5f046371cd5c39dacd46bfa543L1) [[4]](diffhunk://#diff-919839f2ca06011619277822cf98d5debcd77e5f046371cd5c39dacd46bfa543L28) [[5]](diffhunk://#diff-919839f2ca06011619277822cf98d5debcd77e5f046371cd5c39dacd46bfa543L42-R40) [[6]](diffhunk://#diff-919839f2ca06011619277822cf98d5debcd77e5f046371cd5c39dacd46bfa543L75-R73)

**Configuration cleanup:**

* Deleted the `a4a-pressable-premium-plans` flag from all environment configuration files (`a8c-for-agencies-development.json`, `a8c-for-agencies-horizon.json`, `a8c-for-agencies-production.json`, `a8c-for-agencies-stage.json`), ensuring the flag is no longer used anywhere in the project. [[1]](diffhunk://#diff-b7fdfbca27fe9c8150a2cb73e811d96b030fad1f6072494c8291f188cef9779aL43) [[2]](diffhunk://#diff-1c75c03fadc6b49d3df97ba7dd9ba5ad3304c19beebef3584ffad47314e4ac5fL36) [[3]](diffhunk://#diff-6cae595596e0ea2cf4edffd0083ea7fb071702d10e058839990765fb49f4aa36L36) [[4]](diffhunk://#diff-75d25521c97285a60bd86cedb61e8660ece2a553e9e420e2bba8c2aee89f3cb1L38)

## Why are these changes being made?
Ensures our codebase is maintainable by removing irrelevant code.

## Testing Instructions
* Use the A4A live link and navigate to /marketplace/hosting/pressable page.
* Confirm there is no regression and Premium plans are still visible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?