### PR TITLE
A4A: Remove dead code, stale comments, and unimplemented actions

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/constants.ts
+++ b/client/a8c-for-agencies/components/items-dashboard/constants.ts
@@ -2,7 +2,6 @@ import { DataViewsState } from './items-dataviews/interfaces';
 
 export const DATAVIEWS_TABLE = 'table';
 export const DATAVIEWS_LIST = 'list';
-//export const DATAVIEWS_GRID = 'grid';
 
 export const initialDataViewsState: DataViewsState = {
 	filters: [],

--- a/client/a8c-for-agencies/components/pending-payment-notification/index.tsx
+++ b/client/a8c-for-agencies/components/pending-payment-notification/index.tsx
@@ -9,9 +9,6 @@ import { A4A_INVOICES_LINK } from '../sidebar-menu/lib/constants';
 
 import './style.scss';
 
-// TODO: Uncomment this if we would want to dismiss the notification.
-// const PENDING_PAYMENT_NOTIFICATION_DISMISS_PREFERENCE = 'pending-payment-notification-dismissed';
-
 export default function PendingPaymentNotification( { isFullWidth }: { isFullWidth?: boolean } ) {
 	const isBdCheckoutEnabled = isEnabled( 'a4a-bd-checkout' );
 	const invoices = useFetchInvoices( { starting_after: '', ending_before: '' }, undefined, 'open' );

--- a/client/a8c-for-agencies/components/pressable-usage-limit-notice/index.tsx
+++ b/client/a8c-for-agencies/components/pressable-usage-limit-notice/index.tsx
@@ -55,8 +55,6 @@ export const PressableUsageLimitNotice = () => {
 	}
 
 	const level = pressablePlanUsageLimitExceeded ? 'warning' : 'info';
-	// todo: add learn more link
-	const learnMoreLink = false;
 
 	return (
 		<LayoutBanner
@@ -87,21 +85,6 @@ export const PressableUsageLimitNotice = () => {
 				>
 					{ translate( 'Upgrade now' ) }
 				</Button>
-
-				{ learnMoreLink && (
-					<Button
-						variant="secondary"
-						target="_blank"
-						href={ learnMoreLink }
-						onClick={ () => {
-							dispatch(
-								recordTracksEvent( 'calypso_a4a_pressable_limit_notification_learn_more_click' )
-							);
-						} }
-					>
-						{ translate( 'Learn more ↗' ) }
-					</Button>
-				) }
 			</div>
 		</LayoutBanner>
 	);

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-referrals-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-referrals-menu-items.tsx
@@ -75,7 +75,7 @@ const useReferralsMenuItems = ( path: string ) => {
 			.map( ( item ) => ( {
 				...item,
 				isSelected: item.link === path,
-			} ) ); //FIXME: Fix this once we enable the automated referrals feature flag
+			} ) );
 	}, [ accountStatus, path, showIndicator, translate ] );
 	return menuItems;
 };

--- a/client/a8c-for-agencies/sections/settings/index.tsx
+++ b/client/a8c-for-agencies/sections/settings/index.tsx
@@ -6,7 +6,6 @@ import { SETTINGS_AGENCY_PROFILE_TAB } from './constants';
 import { settingsContext } from './controller';
 
 export default function () {
-	// todo: we have only one tab, this redirect /settings to /settings/agency-profile
 	page( A4A_SETTINGS_LINK, () => {
 		page.redirect( `${ A4A_SETTINGS_LINK }/${ SETTINGS_AGENCY_PROFILE_TAB }` );
 	} );

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/backup/routes.ts
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/backup/routes.ts
@@ -19,20 +19,6 @@ import {
 	wrapInSiteOffsetProvider,
 } from './controller';
 
-/* Todo: This code from Jetpack Cloud is not working properly. Commented.
-const notFoundIfNotEnabled = ( context, next ) => {
-	const state = context.store.getState();
-	const siteId = getSelectedSiteId( state );
-	const showJetpackSection = isJetpackSectionEnabledForSite( state, siteId );
-
-	if ( ! isJetpackCloud() && ! showJetpackSection ) {
-		return notFound( context, next );
-	}
-
-	next();
-};
-*/
-
 const processBackupContext: Callback = ( context: Context, next ) => {
 	context.params.feature = JETPACK_BACKUP_ID;
 	next();
@@ -52,8 +38,6 @@ export default function ( basePath: string ) {
 		showUnavailableForMultisites,
 		showNotAuthorizedForNonAdmins,
 		sitesContext,
-		//wpcomAtomicTransfer( WPCOMUpsellPage ),
-		//notFoundIfNotEnabled,
 		makeLayout,
 		clientRender
 	);
@@ -69,8 +53,6 @@ export default function ( basePath: string ) {
 		showUnavailableForMultisites,
 		showNotAuthorizedForNonAdmins,
 		sitesContext,
-		//wpcomAtomicTransfer( WPCOMUpsellPage ),
-		//notFoundIfNotEnabled,
 		makeLayout,
 		clientRender
 	);
@@ -86,8 +68,6 @@ export default function ( basePath: string ) {
 		showUnavailableForMultisites,
 		showNotAuthorizedForNonAdmins,
 		sitesContext,
-		//wpcomAtomicTransfer( WPCOMUpsellPage ),
-		//notFoundIfNotEnabled,
 		makeLayout,
 		clientRender
 	);
@@ -103,8 +83,6 @@ export default function ( basePath: string ) {
 		showUnavailableForMultisites,
 		showNotAuthorizedForNonAdmins,
 		sitesContext,
-		//wpcomAtomicTransfer( WPCOMUpsellPage ),
-		//notFoundIfNotEnabled,
 		makeLayout,
 		clientRender
 	);
@@ -120,8 +98,6 @@ export default function ( basePath: string ) {
 		showUnavailableForMultisites,
 		showNotAuthorizedForNonAdmins,
 		sitesContext,
-		//wpcomAtomicTransfer( WPCOMUpsellPage ),
-		//notFoundIfNotEnabled,
 		makeLayout,
 		clientRender
 	);
@@ -138,8 +114,6 @@ export default function ( basePath: string ) {
 		showUnavailableForMultisites,
 		showNotAuthorizedForNonAdmins,
 		sitesContext,
-		//wpcomAtomicTransfer( WPCOMUpsellPage ),
-		//notFoundIfNotEnabled,
 		makeLayout,
 		clientRender
 	);

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/scan/routes.ts
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/scan/routes.ts
@@ -15,21 +15,6 @@ import {
 	wrapInSiteOffsetProvider,
 } from './controller';
 
-/* Todo: This code from Jetpack Cloud is not working properly. Commented.
-const notFoundIfNotEnabled: Callback = ( context: Context, next ) => {
-	const state = context.store.getState();
-	const siteId = getSelectedSiteId( state );
-	const showJetpackSection = isJetpackSectionEnabledForSite( state, siteId );
-	const isWPCOMSite = getIsSiteWPCOM( state, siteId );
-
-	if ( isWPCOMSite || ( ! isJetpackCloud() && ! showJetpackSection ) ) {
-		context.featurePreview = 'Not Connected';
-	}
-
-	next();
-};
-*/
-
 const processScanContext: Callback = ( context: Context, next ) => {
 	context.params.feature = JETPACK_SCAN_ID;
 	next();
@@ -50,8 +35,6 @@ export default function ( basePath: string ) {
 		showUnavailableForMultisites,
 		showNotAuthorizedForNonAdmins,
 		sitesContext,
-		//wpcomAtomicTransfer( WPCOMScanUpsellPage ),
-		//notFoundIfNotEnabled,
 		makeLayout,
 		clientRender
 	);
@@ -68,9 +51,6 @@ export default function ( basePath: string ) {
 		showUnavailableForMultisites,
 		showNotAuthorizedForNonAdmins,
 		sitesContext,
-		//notFoundIfNotEnabled,
-		//wpcomAtomicTransfer( WPCOMScanUpsellPage ),
-		//
 		makeLayout,
 		clientRender
 	);

--- a/client/a8c-for-agencies/sections/team/primary/team-list/columns.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/columns.tsx
@@ -179,11 +179,6 @@ export const ActionColumn = ( {
 			  ]
 			: [
 					{
-						name: 'password-reset',
-						label: translate( 'Send password reset' ),
-						isEnabled: false, // FIXME: Implement this action
-					},
-					{
 						name: 'transfer-ownership',
 						label: translate( 'Transfer ownership' ),
 						isEnabled: member.status === 'active' && currentUser.email !== member.email,


### PR DESCRIPTION
Context: pfSQfS-1sJ-p2

## Proposed Changes

                                                                               
                                                                                                                                                     
  - Remove large commented-out `notFoundIfNotEnabled` blocks and commented middleware calls in Jetpack backup/scan route files
  - Remove dead `learnMoreLink` code (hardcoded to `false`) in Pressable usage limit notice                                                          
  - Remove commented-out `DATAVIEWS_GRID` export and stale TODO preference constant        
  - Remove never-enabled "Send password reset" team action                                                                                           
  - Remove stale FIXME and TODO comments in referrals menu and settings routes   

## Why are these changes being made?

Ensures our codebase is maintainable by removing irrelevant code.

## Testing Instructions
    
  - [ ] Verify Jetpack backup and scan routes still load correctly                                                                                   
  - [ ] Verify Pressable usage limit notice renders without errors                                                                                   
  - [ ] Verify team member action menu works (transfer ownership, remove member, etc.)
  - [ ] Verify referrals sidebar menu renders correctly                                                                                              
  - [ ] Verify settings page redirect still works        

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?