### PR TITLE
A4A: Reframe onboarding tour nav labels as jobs to be done

### DIFF
--- a/client/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour-sections.tsx
+++ b/client/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour-sections.tsx
@@ -97,8 +97,71 @@ export default function useOnboardingTourSections() {
 				},
 			},
 			{
+				id: 'partner-directory',
+				title: translate( 'Get more leads' ),
+				bannerImage: OnboardingTourBannerPartnerDirectory,
+				isDarkBanner: true,
+				content: {
+					title: translate( 'Get leads from multiple agency directories' ),
+					descriptions: [
+						translate(
+							"By partnering with us, you're eligible to be listed on up to four agency directories across our Woo, Pressable, WordPress.com, and Jetpack sites."
+						),
+						translate(
+							'To get listed on these directories, you have to qualify for our Agency Partner tier and demonstrate expertise with each of the brands that you would like to be listed with.'
+						),
+					],
+				},
+				renderableActions: ( { onNext, onClose }: RenderableActionProps ): RenderableAction[] => {
+					return [
+						{
+							label: translate( 'Check out Partner Directories' ),
+							variant: 'secondary',
+							href: A4A_PARTNER_DIRECTORY_LINK,
+							onClick: () => onExplore( 'partner-directory', onClose ),
+						},
+						{
+							label: translate( 'Next benefit' ),
+							variant: 'primary',
+							onClick: () => onNextBenefit( 'partner-directory', onNext ),
+						},
+					];
+				},
+			},
+			{
+				id: 'referrals',
+				title: translate( 'Earn commissions' ),
+				bannerImage: OnboardingTourBannerReferrals,
+				content: {
+					title: translate( 'Track referrals and commissions with ease' ),
+					descriptions: [
+						translate(
+							"Send referrals through the marketplace, then head to your referrals dashboard to view total commissions, upcoming payouts, and the status of your clients' products and hosting."
+						),
+						translate(
+							"You'll earn a 20% recurring commission for referring Pressable or WordPress.com hosting, and a 50% recurring commission for referring Woo or Jetpack products."
+						),
+					],
+				},
+				renderableActions: ( { onNext, onClose }: RenderableActionProps ): RenderableAction[] => {
+					return [
+						{
+							label: translate( 'View Referrals Dashboard' ),
+							variant: 'secondary',
+							href: A4A_REFERRALS_DASHBOARD,
+							onClick: () => onExplore( 'referrals', onClose ),
+						},
+						{
+							label: translate( 'Next benefit' ),
+							variant: 'primary',
+							onClick: () => onNextBenefit( 'referrals', onNext ),
+						},
+					];
+				},
+			},
+			{
 				id: 'sites',
-				title: translate( 'Sites' ),
+				title: translate( 'Manage client sites' ),
 				bannerImage: OnboardingTourBannerSites,
 				content: {
 					title: translate( 'One dashboard. Every site. Seamless management.' ),
@@ -142,7 +205,7 @@ export default function useOnboardingTourSections() {
 			},
 			{
 				id: 'marketplace',
-				title: translate( 'Marketplace' ),
+				title: translate( 'Buy products & hosting' ),
 				bannerImage: OnboardingTourBannerMarketplace,
 				isDarkBanner: true,
 				content: {
@@ -171,68 +234,8 @@ export default function useOnboardingTourSections() {
 				},
 			},
 			{
-				id: 'purchases',
-				title: translate( 'Purchases' ),
-				bannerImage: OnboardingTourBannerPurchases,
-				isDarkBanner: true,
-				content: {
-					title: translate( 'Easily manage all your purchases in one spot.' ),
-					descriptions: [
-						translate(
-							'Assign Jetpack products and Woo extensions, launch WordPress.com sites, manage Pressable hosting, and access all your billing and invoices—no digging required.'
-						),
-					],
-				},
-				renderableActions: ( { onNext, onClose }: RenderableActionProps ): RenderableAction[] => {
-					return [
-						{
-							label: translate( 'View purchases' ),
-							variant: 'secondary',
-							href: A4A_PURCHASES_LINK,
-							onClick: () => onExplore( 'purchases', onClose ),
-						},
-						{
-							label: translate( 'Next benefit' ),
-							variant: 'primary',
-							onClick: () => onNextBenefit( 'purchases', onNext ),
-						},
-					];
-				},
-			},
-			{
-				id: 'referrals',
-				title: translate( 'Referrals' ),
-				bannerImage: OnboardingTourBannerReferrals,
-				content: {
-					title: translate( 'Track referrals and commissions with ease' ),
-					descriptions: [
-						translate(
-							"Send referrals through the marketplace, then head to your referrals dashboard to view total commissions, upcoming payouts, and the status of your clients' products and hosting."
-						),
-						translate(
-							"You'll earn a 20% recurring commission for referring Pressable or WordPress.com hosting, and a 50% recurring commission for referring Woo or Jetpack products."
-						),
-					],
-				},
-				renderableActions: ( { onNext, onClose }: RenderableActionProps ): RenderableAction[] => {
-					return [
-						{
-							label: translate( 'View Referrals Dashboard' ),
-							variant: 'secondary',
-							href: A4A_REFERRALS_DASHBOARD,
-							onClick: () => onExplore( 'referrals', onClose ),
-						},
-						{
-							label: translate( 'Next benefit' ),
-							variant: 'primary',
-							onClick: () => onNextBenefit( 'referrals', onNext ),
-						},
-					];
-				},
-			},
-			{
 				id: 'migrations',
-				title: translate( 'Migrations' ),
+				title: translate( 'Move to better hosting' ),
 				bannerImage: OnboardingTourBannerMigrations,
 				content: {
 					title: translate( 'Better hosting for your clients. Up to $10K for you.' ),
@@ -263,7 +266,7 @@ export default function useOnboardingTourSections() {
 			},
 			{
 				id: 'woopayments',
-				title: translate( 'WooPayments' ),
+				title: translate( 'Monetize Woo stores' ),
 				bannerImage: OnboardingTourBannerWooPayments,
 				isDarkBanner: true,
 				content: {
@@ -298,7 +301,7 @@ export default function useOnboardingTourSections() {
 			},
 			{
 				id: 'reports',
-				title: translate( 'Reports' ),
+				title: translate( 'Report to clients' ),
 				bannerImage: OnboardingTourBannerReports,
 				isDarkBanner: true,
 				content: {
@@ -329,40 +332,8 @@ export default function useOnboardingTourSections() {
 				},
 			},
 			{
-				id: 'partner-directory',
-				title: translate( 'Partner Directories' ),
-				bannerImage: OnboardingTourBannerPartnerDirectory,
-				isDarkBanner: true,
-				content: {
-					title: translate( 'Get leads from multiple agency directories' ),
-					descriptions: [
-						translate(
-							"By partnering with us, you're eligible to be listed on up to four agency directories across our Woo, Pressable, WordPress.com, and Jetpack sites."
-						),
-						translate(
-							'To get listed on these directories, you have to qualify for our Agency Partner tier and demonstrate expertise with each of the brands that you would like to be listed with.'
-						),
-					],
-				},
-				renderableActions: ( { onNext, onClose }: RenderableActionProps ): RenderableAction[] => {
-					return [
-						{
-							label: translate( 'Check out Partner Directories' ),
-							variant: 'secondary',
-							href: A4A_PARTNER_DIRECTORY_LINK,
-							onClick: () => onExplore( 'partner-directory', onClose ),
-						},
-						{
-							label: translate( 'Next benefit' ),
-							variant: 'primary',
-							onClick: () => onNextBenefit( 'partner-directory', onNext ),
-						},
-					];
-				},
-			},
-			{
 				id: 'agency-tiers',
-				title: translate( 'Agency Tiers' ),
+				title: translate( 'Level up your agency' ),
 				bannerImage: OnboardingTourBannerAgencyTiers,
 				content: {
 					title: translate( 'Resources and rewards tailored for your growth' ),
@@ -390,7 +361,7 @@ export default function useOnboardingTourSections() {
 			},
 			{
 				id: 'team',
-				title: translate( 'Team' ),
+				title: translate( 'Collaborate as a team' ),
 				bannerImage: OnboardingTourBannerTeam,
 				content: {
 					title: translate( 'Invite your team. Reclaim your time.' ),
@@ -417,8 +388,37 @@ export default function useOnboardingTourSections() {
 				},
 			},
 			{
+				id: 'purchases',
+				title: translate( 'Manage billing' ),
+				bannerImage: OnboardingTourBannerPurchases,
+				isDarkBanner: true,
+				content: {
+					title: translate( 'Easily manage all your purchases in one spot.' ),
+					descriptions: [
+						translate(
+							'Assign Jetpack products and Woo extensions, launch WordPress.com sites, manage Pressable hosting, and access all your billing and invoices—no digging required.'
+						),
+					],
+				},
+				renderableActions: ( { onNext, onClose }: RenderableActionProps ): RenderableAction[] => {
+					return [
+						{
+							label: translate( 'View purchases' ),
+							variant: 'secondary',
+							href: A4A_PURCHASES_LINK,
+							onClick: () => onExplore( 'purchases', onClose ),
+						},
+						{
+							label: translate( 'Next benefit' ),
+							variant: 'primary',
+							onClick: () => onNextBenefit( 'purchases', onNext ),
+						},
+					];
+				},
+			},
+			{
 				id: 'growth-call',
-				title: translate( 'Free growth call' ),
+				title: translate( 'Get growth advice' ),
 				bannerImage: OnboardingTourBannerGrowthCall,
 				isDarkBanner: true,
 				content: {


### PR DESCRIPTION
## Proposed Changes

- Rename the 11 sidebar section labels in the onboarding tour from feature names to outcome-oriented labels
- Reorder sections so lead-generation and earning opportunities appear earlier in the flow

## Why are these changes being made?

The onboarding tour sidebar previously used feature names as labels (e.g. "Sites", "Marketplace", "Referrals"). These names describe what the features are, but don't communicate what an agency can accomplish with them.

Reframing labels around jobs to be done (e.g. "Get more leads", "Earn commissions", "Manage client sites") helps agencies immediately understand the value of each section before clicking into it, improving tour completion and feature discovery.

The reordering surfaces high-value earning opportunities (leads, commissions) earlier so agencies see the platform's revenue potential upfront.

## Testing Instructions

1. Navigate to A4A → Overview and open the onboarding tour
2. Verify the sidebar shows the updated labels in the new order
3. Click through each section and verify all content is intact
4. Relaunch the tour from the sidebar button and confirm it resumes correctly

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?