### PR TITLE
Launch Site Flow: Deemphasize free plan in plans step

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -334,6 +334,8 @@ export function generateSteps( {
 			optionalDependencies: [ 'themeSlugWithRepo' ],
 			props: {
 				isLaunchPage: true,
+				isCustomDomainAllowedOnFreePlan: true,
+				deemphasizeFreePlan: true,
 			},
 		},
 

--- a/client/signup/steps/domains/index.tsx
+++ b/client/signup/steps/domains/index.tsx
@@ -9,7 +9,7 @@ import {
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { Button } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
-import { addQueryArgs, getQueryArg } from '@wordpress/url';
+import { addQueryArgs, getQueryArg, isURL } from '@wordpress/url';
 import { useMemo } from 'react';
 import { WPCOMDomainSearch } from 'calypso/components/domains/wpcom-domain-search';
 import { FreeDomainForAYearPromo } from 'calypso/components/domains/wpcom-domain-search/free-domain-for-a-year-promo';
@@ -80,6 +80,8 @@ const DomainSearchUI = (
 
 	// eslint-disable-next-line no-nested-ternary
 	const currentSiteUrl = site?.URL ? site.URL : siteSlug ? `https://${ siteSlug }` : undefined;
+	const currentSiteUrlHostname =
+		currentSiteUrl && isURL( currentSiteUrl ) ? new URL( currentSiteUrl ).hostname : undefined;
 	// eslint-disable-next-line no-nested-ternary
 	const currentSiteId = site?.ID ? site.ID : siteId ? parseInt( siteId, 10 ) : undefined;
 
@@ -168,14 +170,14 @@ const DomainSearchUI = (
 						stepSectionName: '',
 						domainItem,
 						isPurchasingItem: true,
-						siteUrl: domainItem.meta,
+						siteUrl: currentSiteUrlHostname ?? domainItem.meta,
 						domainCart,
 					},
 					{
 						...baseSubmitProvidedDependencies,
 						signupDomainOrigin: SIGNUP_DOMAIN_ORIGIN.CUSTOM,
 						domainItem,
-						siteUrl: domainItem.meta,
+						siteUrl: currentSiteUrlHostname ?? domainItem.meta,
 						domainCart,
 					}
 				);
@@ -201,6 +203,8 @@ const DomainSearchUI = (
 				goToNextStep();
 			},
 			onSkip( suggestion?: FreeDomainSuggestion ) {
+				const siteUrl = suggestion?.domain_name ?? currentSiteUrlHostname;
+
 				submitSignupStep(
 					{
 						...baseSubmitStepProps,
@@ -208,7 +212,7 @@ const DomainSearchUI = (
 						domainItem: undefined,
 						isPurchasingItem: false,
 						domainCart: [],
-						siteUrl: suggestion?.domain_name.replace( '.wordpress.com', '' ),
+						siteUrl: siteUrl?.replace( '.wordpress.com', '' ),
 					},
 					{
 						...baseSubmitProvidedDependencies,
@@ -216,7 +220,7 @@ const DomainSearchUI = (
 							? SIGNUP_DOMAIN_ORIGIN.FREE
 							: SIGNUP_DOMAIN_ORIGIN.CHOOSE_LATER,
 						domainCart: [],
-						siteUrl: suggestion?.domain_name,
+						siteUrl,
 					}
 				);
 
@@ -236,6 +240,7 @@ const DomainSearchUI = (
 		baseSubmitStepProps,
 		baseSubmitProvidedDependencies,
 		dashboard,
+		currentSiteUrlHostname,
 	] );
 
 	const allowedTldParam = queryObject.tld;

--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -39,6 +39,7 @@ export * from './jetpack-instant-search-modal-component';
 export * from './select-items-component';
 export * from './wp-admin-notice-component';
 export * from './wp-admin-sidebar-component';
+export * from './launch-celebration-component';
 
 export * from './me';
 

--- a/packages/calypso-e2e/src/lib/components/launch-celebration-component.ts
+++ b/packages/calypso-e2e/src/lib/components/launch-celebration-component.ts
@@ -1,0 +1,31 @@
+import { Locator, Page } from 'playwright';
+
+/**
+ * Component representing the site launch celebration modal.
+ *
+ * This modal appears on the `/home` page after a site is successfully launched,
+ * typically triggered via the `celebrateLaunch` URL parameter.
+ */
+export class LaunchCelebrationComponent {
+	private page: Page;
+	readonly heading: Locator;
+
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+		this.heading = this.page.getByRole( 'heading', { name: 'Congrats, your site is live!' } );
+	}
+
+	/**
+	 * Validates that the launch celebration modal is visible.
+	 *
+	 * Waits for the "Congrats, your site is live!" heading to appear on the page.
+	 */
+	async validateVisible(): Promise< void > {
+		await this.heading.waitFor();
+	}
+}

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -122,6 +122,47 @@ export class PlansPage {
 	}
 
 	/**
+	 * Opens the escape hatch modal by clicking the "start with a free plan" trigger link.
+	 */
+	async openEscapeHatch(): Promise< void > {
+		const locator = this.page.getByText( 'start with a free plan' );
+		await locator.first().click();
+	}
+
+	/**
+	 * Validates that the "No free custom domain" warning is visible in the escape hatch modal.
+	 */
+	async validateNoCustomDomainWarning( domainName: string ): Promise< void > {
+		await this.page
+			.getByText( `No free custom domain: Your site will be shown to visitors as ${ domainName }` )
+			.waitFor();
+	}
+
+	/**
+	 * Validates that the "Domain redirect" warning is visible in the escape hatch modal.
+	 */
+	async validateDomainRedirectWarning( domainName: string, siteSlug: string ): Promise< void > {
+		await this.page.getByText( `${ domainName } redirects to ${ siteSlug }` ).waitFor();
+	}
+
+	/**
+	 * Clicks the "Continue with Free" button in the escape hatch modal.
+	 *
+	 * This handles both the FreePlanFreeDomainDialog ("Continue with Free") and
+	 * the FreePlanPaidDomainDialog ("Continue with Free plan") variants.
+	 */
+	async clickContinueWithFree(): Promise< void > {
+		const continueWithFreePlanButton = this.page.getByRole( 'button', {
+			name: 'Continue with Free plan',
+		} );
+		if ( await continueWithFreePlanButton.isVisible() ) {
+			await continueWithFreePlanButton.click();
+		} else {
+			await this.page.getByRole( 'button', { name: 'Continue with Free' } ).click();
+		}
+	}
+
+	/**
 	 * Selects the plan on the modal upsell.
 	 *
 	 * @param {Plans} plan Plan to select.
@@ -131,17 +172,16 @@ export class PlansPage {
 			throw Error( `Unsupported plan to be selected in modal upsell: ${ plan }` );
 		}
 
-		const locator = this.page.getByText( 'start with a free plan' );
+		await this.openEscapeHatch();
 
-		await locator.first().click();
-
-		const continueWithPlanButton = this.page.getByRole( 'button', {
-			name: `Continue with ${ plan } plan`,
-		} );
-		if ( await continueWithPlanButton.isVisible() ) {
-			await continueWithPlanButton.click();
+		if ( plan === 'Free' ) {
+			await this.clickContinueWithFree();
 		} else {
-			await this.page.getByRole( 'button', { name: `Get ${ plan } plan` } ).click();
+			// Button text is "Get Personal - $X/month" so we match partially.
+			await this.page
+				.getByRole( 'button', { name: new RegExp( `Get ${ plan }` ) } )
+				.first()
+				.click();
 		}
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
@@ -145,4 +145,54 @@ export class SignupPickPlanPage {
 
 		await Promise.all( actions );
 	}
+
+	/**
+	 * Opens the escape hatch modal by clicking the "start with a free plan" trigger.
+	 *
+	 * Use this when you need to inspect or assert modal content before committing to a plan.
+	 *
+	 * @returns {Promise<void>}
+	 */
+	async openEscapeHatch(): Promise< void > {
+		await this.page.waitForURL( plansPageUrl );
+		await this.plansPage.openEscapeHatch();
+	}
+
+	/**
+	 * Validates that the "No free custom domain" warning is visible in the escape hatch modal.
+	 *
+	 * @param {string} domainName The domain name that will be shown to visitors.
+	 * @returns {Promise<void>}
+	 */
+	async validateNoCustomDomainWarning( domainName: string ): Promise< void > {
+		await this.plansPage.validateNoCustomDomainWarning( domainName );
+	}
+
+	/**
+	 * Validates that the "Domain redirect" warning is visible in the escape hatch modal.
+	 *
+	 * @param {string} domainName The domain name that will be shown to visitors.
+	 * @param {string} siteSlug The site slug.
+	 * @returns {Promise<void>}
+	 */
+	async validateDomainRedirectWarning( domainName: string, siteSlug: string ): Promise< void > {
+		await this.plansPage.validateDomainRedirectWarning( domainName, siteSlug );
+	}
+
+	/**
+	 * Clicks the "Continue with Free" button in the escape hatch modal and waits for navigation.
+	 *
+	 * Intended for use after `openEscapeHatch()` when skipping to a free plan with no domain.
+	 *
+	 * @param {RegExp} redirectUrl Optional URL pattern to wait for after clicking.
+	 * @returns {Promise<void>}
+	 */
+	async continueWithFreeViaEscapeHatch( redirectUrl?: RegExp ): Promise< void > {
+		redirectUrl ??= new RegExp( '.*/home/.*' );
+
+		await Promise.all( [
+			this.page.waitForURL( redirectUrl, { timeout: 30 * 1000 } ),
+			this.plansPage.clickContinueWithFree(),
+		] );
+	}
 }

--- a/test/e2e/lib/pw-base.ts
+++ b/test/e2e/lib/pw-base.ts
@@ -51,6 +51,7 @@ import {
 	IncognitoPage,
 	InvitePeoplePage,
 	JetpackTrafficPage,
+	LaunchCelebrationComponent,
 	LoginPage,
 	LOHPThemeSignupFlow,
 	MarketingPage,
@@ -169,6 +170,10 @@ export const test = base.extend<
 		 * Component for selecting items in various flows.
 		 */
 		componentSelectItems: SelectItemsComponent;
+		/**
+		 * Component for asserting the site launch celebration modal.
+		 */
+		componentLaunchCelebration: LaunchCelebrationComponent;
 		/**
 		 * Environment variables for the tests.
 		 */
@@ -418,6 +423,10 @@ export const test = base.extend<
 	componentSelectItems: async ( { page }, use ) => {
 		const selectItemsComponent = new SelectItemsComponent( page );
 		await use( selectItemsComponent );
+	},
+	componentLaunchCelebration: async ( { page }, use ) => {
+		const launchCelebrationComponent = new LaunchCelebrationComponent( page );
+		await use( launchCelebrationComponent );
 	},
 	componentSidebar: async ( { page }, use ) => {
 		const sidebarComponent = new SidebarComponent( page );

--- a/test/e2e/specs/flows/start-launch-site__flows.spec.ts
+++ b/test/e2e/specs/flows/start-launch-site__flows.spec.ts
@@ -148,6 +148,213 @@ test.describe(
 			} );
 		} );
 
+		test( 'As a new user, I can create a free site and launch it without purchasing a domain or a plan', async ( {
+			page,
+			componentDomainSearch,
+			componentLaunchCelebration,
+			helperData,
+			pageLogin,
+			pageSignupPickPlan,
+			pageUserSignUp,
+		} ) => {
+			const testUser = helperData.getNewTestUser();
+			let newUserDetails: NewUserResponse;
+			let newSiteDetails: NewSiteResponse;
+
+			await test.step( 'When I navigate to the Login page', async function () {
+				BrowserManager.setStoreCookie( page, { currency: 'USD' } );
+				await pageLogin.visit();
+			} );
+
+			await test.step( 'And I click on button to create a new account', async function () {
+				await pageLogin.clickCreateNewAccount();
+			} );
+
+			await test.step( 'And I sign up as a new user', async function () {
+				newUserDetails = await pageUserSignUp.signupSocialFirstWithEmail( testUser.email );
+			} );
+
+			await test.step( 'And I select a .wordpress.com domain name', async function () {
+				await componentDomainSearch.search( helperData.getBlogName() );
+				await componentDomainSearch.skipPurchase();
+			} );
+
+			await test.step( 'And I select WordPress.com Free plan', async function () {
+				newSiteDetails = await pageSignupPickPlan.selectPlan( 'Free', new RegExp( '.*/home/.*' ) );
+				accountsToCleanup.push( { testUser, newUserDetails, newSiteDetails } );
+			} );
+
+			await test.step( 'And I enter the launch-site flow', async function () {
+				await page.goto(
+					helperData.getCalypsoURL(
+						`/start/launch-site?siteSlug=${ newSiteDetails.blog_details.site_slug }`
+					)
+				);
+			} );
+
+			await test.step( 'And I skip the domain search', async function () {
+				await componentDomainSearch.skipPurchase();
+			} );
+
+			await test.step( 'And I open the escape hatch in the plans step', async function () {
+				await pageSignupPickPlan.openEscapeHatch();
+			} );
+
+			await test.step( 'Then I see the no custom domain warning', async function () {
+				await pageSignupPickPlan.validateNoCustomDomainWarning(
+					newSiteDetails.blog_details.site_slug
+				);
+			} );
+
+			await test.step( 'And I continue with the free plan', async function () {
+				await pageSignupPickPlan.continueWithFreeViaEscapeHatch();
+			} );
+
+			await test.step( 'Then I see the launch celebration modal', async function () {
+				await componentLaunchCelebration.validateVisible();
+			} );
+		} );
+
+		test( 'As a new user, I can create a free site then use launch-site flow to purchase a domain only', async ( {
+			page,
+			componentDomainSearch,
+			helperData,
+			pageCartCheckout,
+			pageLogin,
+			pageSignupPickPlan,
+			pageUserSignUp,
+		} ) => {
+			const testUser = helperData.getNewTestUser();
+			let selectedDomain: string;
+			let newUserDetails: NewUserResponse;
+			let newSiteDetails: NewSiteResponse;
+
+			await test.step( 'When I navigate to the Login page', async function () {
+				BrowserManager.setStoreCookie( page, { currency: 'USD' } );
+				await pageLogin.visit();
+			} );
+
+			await test.step( 'And I click on button to create a new account', async function () {
+				await pageLogin.clickCreateNewAccount();
+			} );
+
+			await test.step( 'And I sign up as a new user', async function () {
+				newUserDetails = await pageUserSignUp.signupSocialFirstWithEmail( testUser.email );
+			} );
+
+			await test.step( 'And I select a .wordpress.com domain name', async function () {
+				await componentDomainSearch.search( helperData.getBlogName() );
+				await componentDomainSearch.skipPurchase();
+			} );
+
+			await test.step( 'And I select WordPress.com Free plan', async function () {
+				newSiteDetails = await pageSignupPickPlan.selectPlan( 'Free', new RegExp( '.*/home/.*' ) );
+				accountsToCleanup.push( { testUser, newUserDetails, newSiteDetails } );
+			} );
+
+			await test.step( 'And I enter the launch-site flow', async function () {
+				await page.goto(
+					helperData.getCalypsoURL(
+						`/start/launch-site?siteSlug=${ newSiteDetails.blog_details.site_slug }`
+					)
+				);
+			} );
+
+			await test.step( 'And I search for a domain', async function () {
+				await componentDomainSearch.search( helperData.getBlogName() );
+			} );
+
+			await test.step( 'And I add the first suggestion to the cart', async function () {
+				selectedDomain = await componentDomainSearch.selectFirstSuggestion( false );
+			} );
+
+			await test.step( 'And I open the escape hatch in the plans step', async function () {
+				await pageSignupPickPlan.openEscapeHatch();
+			} );
+
+			await test.step( 'Then I see the domain redirect warning', async function () {
+				await pageSignupPickPlan.validateDomainRedirectWarning(
+					selectedDomain,
+					newSiteDetails.blog_details.site_slug
+				);
+			} );
+
+			await test.step( 'And I continue with the free plan', async function () {
+				await pageSignupPickPlan.continueWithFreeViaEscapeHatch( new RegExp( '.*/checkout/.*' ) );
+			} );
+
+			await test.step( 'Then I see the domain at checkout', async function () {
+				await pageCartCheckout.validateCartItem( selectedDomain );
+			} );
+		} );
+
+		test( 'As a new user, I can create a free site then use the launch-site flow to pick a domain, and continue to checkout by picking the plan within the escape hatch', async ( {
+			page,
+			componentDomainSearch,
+			helperData,
+			pageCartCheckout,
+			pageLogin,
+			pageSignupPickPlan,
+			pageUserSignUp,
+		} ) => {
+			const testUser = helperData.getNewTestUser();
+			const planName = 'Personal';
+			let selectedDomain: string;
+			let newUserDetails: NewUserResponse;
+			let newSiteDetails: NewSiteResponse;
+
+			await test.step( 'When I navigate to the Login page', async function () {
+				BrowserManager.setStoreCookie( page, { currency: 'USD' } );
+				await pageLogin.visit();
+			} );
+
+			await test.step( 'And I click on button to create a new account', async function () {
+				await pageLogin.clickCreateNewAccount();
+			} );
+
+			await test.step( 'And I sign up as a new user', async function () {
+				newUserDetails = await pageUserSignUp.signupSocialFirstWithEmail( testUser.email );
+			} );
+
+			await test.step( 'And I select a .wordpress.com domain name', async function () {
+				await componentDomainSearch.search( helperData.getBlogName() );
+				await componentDomainSearch.skipPurchase();
+			} );
+
+			await test.step( 'And I select WordPress.com Free plan', async function () {
+				newSiteDetails = await pageSignupPickPlan.selectPlan( 'Free', new RegExp( '.*/home/.*' ) );
+				accountsToCleanup.push( { testUser, newUserDetails, newSiteDetails } );
+			} );
+
+			await test.step( 'And I enter the launch-site flow', async function () {
+				await page.goto(
+					helperData.getCalypsoURL(
+						`/start/launch-site?siteSlug=${ newSiteDetails.blog_details.site_slug }`
+					)
+				);
+			} );
+
+			await test.step( 'And I search for a domain', async function () {
+				await componentDomainSearch.search( helperData.getBlogName() );
+			} );
+
+			await test.step( 'And I add the first suggestion to the cart', async function () {
+				selectedDomain = await componentDomainSearch.selectFirstSuggestion( false );
+			} );
+
+			await test.step( `And I select the ${ planName } plan via the escape hatch`, async function () {
+				await pageSignupPickPlan.selectEscapeHatchWithoutSiteCreation( planName );
+			} );
+
+			await test.step( `Then I see the ${ planName } plan at checkout`, async function () {
+				await pageCartCheckout.validateCartItem( `WordPress.com ${ planName }` );
+			} );
+
+			await test.step( 'And I see the domain at checkout', async function () {
+				await pageCartCheckout.validateCartItem( selectedDomain );
+			} );
+		} );
+
 		test.afterAll( 'Delete all user accounts generated', async function () {
 			for ( const account of accountsToCleanup ) {
 				const restAPIClient = new RestAPIClient(


### PR DESCRIPTION
Closes DATSCI-1162.

## Proposed Changes

In the `/start/launch-site?siteSlug=%s` flow, we were displaying the free plan within the grid, but we should actually deemphasize it, just like `onboarding-pm`.

| Before | After |
| --- | --- |
| <img width="1369" height="1184" alt="image" src="https://github.com/user-attachments/assets/cd3283e1-73e1-40b9-9100-d26af67cffe4" /> | <img width="1534" height="1124" alt="image" src="https://github.com/user-attachments/assets/29d027b2-be5f-4e2e-ac82-918e72fa617a" /> |

## Testing Instructions

### Free site and skipping the domain search

Verify you see the "don't miss you" modal after clicking "start with a free plan":

<img width="674" height="674" alt="image" src="https://github.com/user-attachments/assets/8b5156d4-3d15-4110-9f98-0fd004b65c9a" />

### Free site and picking a domain

Verify you see the paid plan required modal:

<img width="749" height="504" alt="image" src="https://github.com/user-attachments/assets/93978e11-47d5-4096-a5e1-11319f8c0c16" />

### Paid site and picking a domain

Verify your current plan has the "Keep this plan" CTA in the grid and you proceed to checkout with the chosen domain.