### PR TITLE
Help Center: Fix warning callout icon vertical alignment

### DIFF
--- a/packages/support-articles/src/components/help-center-article/help-center-article.scss
+++ b/packages/support-articles/src/components/help-center-article/help-center-article.scss
@@ -216,7 +216,7 @@
 				}
 
 				.is-vertically-aligned-center {
-					align-self: center;
+					align-self: flex-start;
 				}
 
 				.wp-block-jetpack-layout-grid {


### PR DESCRIPTION
Part of DOTSUP-445

## Proposed Changes

* Change `align-self: center` to `align-self: flex-start` on `.is-vertically-aligned-center` inside `.callout .wp-block-column`, so the warning icon stays top-aligned with the first line of text in multi-line callout blocks.

## Why are these changes being made?

In support articles, warning callout blocks (e.g., the domain transfer warning) display an icon (⚠️) alongside multi-line text. The icon was vertically centered relative to the full text block, making it look visually misaligned. Top-aligning it matches common UI patterns for callout/alert components.

## Testing Instructions

### Calypso

1. Run `yarn start`.
2. Open the Help Center and search for "domain transfer".
3. Open the "Transfer a domain to another registrar" article.
4. Scroll to the warning callout — verify the ⚠️ icon is top-aligned with the first line of text.

### Simple/Atomic/CIAB

1. Sandbox `widgets.wp.com`.
2. Run `cd apps/help-center && yarn dev --sync`.
3. Visit any Simple, Atomic, or CIAB site (the site itself does not need sandboxing).
4. Open the Help Center and navigate to any article with a warning callout.
5. Verify the icon is top-aligned with the first line of text.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?