### PR TITLE
e2e: Update Jetpack Settings tab locators for new navigation

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/wp-admin/jetpack-dashboard-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/wp-admin/jetpack-dashboard-page.ts
@@ -57,18 +57,31 @@ export class JetpackDashboardPage {
 			.click();
 		await this.page.waitForURL( new RegExp( `page=jetpack#/${ param.view }`, 'i' ) );
 
-		// Click on the tab.
-		await this.page
-			.getByRole( 'main' )
-			.getByRole( 'menuitem', { name: param.tab, exact: true } )
-			.click();
+		if ( param.view === 'Settings' ) {
+			// Settings tabs are NavLink elements inside a <nav> landmark.
+			const nav = this.page
+				.getByRole( 'main' )
+				.getByRole( 'navigation', { name: 'Jetpack settings sections' } );
 
-		// Filter the nav tabs to elements that have `.is-selected` (should be only one),
-		// and verify the resulting element is the tab that was clicked on earlier.
-		await this.page
-			.getByRole( 'main' )
-			.filter( { has: this.page.locator( '.is-selected' ) } )
-			.filter( { hasText: param.tab } )
-			.waitFor();
+			await nav.getByRole( 'link', { name: param.tab, exact: true } ).click();
+
+			// Verify the clicked tab is now active (NavLink sets aria-current="page").
+			await nav
+				.getByRole( 'link', { name: param.tab, exact: true } )
+				.and( this.page.locator( '[aria-current="page"]' ) )
+				.waitFor();
+		} else {
+			// Dashboard tabs use NavItem components (role="menuitem" + .is-selected).
+			await this.page
+				.getByRole( 'main' )
+				.getByRole( 'menuitem', { name: param.tab, exact: true } )
+				.click();
+
+			await this.page
+				.getByRole( 'main' )
+				.filter( { has: this.page.locator( '.is-selected' ) } )
+				.filter( { hasText: param.tab } )
+				.waitFor();
+		}
 	}
 }


### PR DESCRIPTION
Part of Automattic/jetpack#47490

Part of JETPACK-1411

## Proposed Changes

* Update `JetpackDashboardPage.clickTab()` to use view-specific locator strategies:
  * **Settings**: Find tabs as `link` elements within the `<nav>` landmark, verify active state via `aria-current="page"`
  * **Dashboard**: Unchanged — still uses `menuitem` role and `.is-selected` class

## Why are these changes being made?

Jetpack PR [#47490](https://github.com/Automattic/jetpack/pull/47490) migrated the Settings page navigation from Calypso's `NavItem` components (`<li role="menuitem">` + `.is-selected`) to React Router `NavLink` elements (`<a>` inside a `<nav>` landmark + `aria-current="page"`).

The e2e test's `getByRole('menuitem', { name: 'Security' })` locator no longer matches the new DOM structure, causing `jetpack__dashboard-smoke.ts` to fail with a 15s timeout on every Settings tab click.

## Testing Instructions

* Run the Jetpack dashboard smoke test: `yarn test test/e2e/specs/jetpack/jetpack__dashboard-smoke.ts`
* Verify Settings tabs (Security, Performance, Writing, etc.) are clicked successfully
* Verify Dashboard tabs (At a Glance, My Plan) still work

## Pre-merge Checklist

- [x] Has the general commit checklist been followed?
- [ ] Have you written new tests for your changes?
- [x] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?