### PR TITLE
Fix CIAB store visibility card using sites list data

### DIFF
--- a/client/dashboard/app/hooks/use-cached-site.ts
+++ b/client/dashboard/app/hooks/use-cached-site.ts
@@ -1,0 +1,17 @@
+import { useQueryClient } from '@tanstack/react-query';
+import type { Site, FetchPaginatedSitesResponse } from '@automattic/api-core';
+
+/**
+ * Looks up a site in the cached sites list (/me/sites) without triggering a new fetch.
+ * Useful when the per-site endpoint returns stale or incorrect data.
+ */
+export function useCachedSite( siteId: number ): Site | undefined {
+	const queryClient = useQueryClient();
+
+	return queryClient
+		.getQueriesData< Site[] | FetchPaginatedSitesResponse >( {
+			predicate: ( query ) => query.queryKey[ 0 ] === 'sites' && query.state.status === 'success',
+		} )
+		.flatMap( ( [ , data ] ) => ( Array.isArray( data ) ? data : data?.sites ?? [] ) )
+		.find( ( s ) => s.ID === siteId );
+}

--- a/client/dashboard/sites/overview-visibility-card-ciab/index.tsx
+++ b/client/dashboard/sites/overview-visibility-card-ciab/index.tsx
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { published } from '@wordpress/icons';
+import { useCachedSite } from '../../app/hooks/use-cached-site';
 import { launch } from '../../components/icons';
 import OverviewCard from '../../components/overview-card';
 import JetpackConnectionWarningCard from '../overview-jetpack-connection-warning-card';
@@ -11,15 +12,17 @@ const CARD_PROPS = {
 };
 
 export default function VisibilityCardCiab( { site }: { site: Site } ) {
+	const cachedSite = useCachedSite( site.ID );
+
 	if ( site.__inaccessible_jetpack_error ) {
 		return <JetpackConnectionWarningCard { ...CARD_PROPS } />;
 	}
-
+	const isComingSoon = cachedSite?.is_coming_soon ?? site.is_coming_soon;
 	const link = site.options?.admin_url
 		? `${ site.options.admin_url }admin.php?page=next-admin&p=%2Fwoocommerce%2Fsettings%2Fgeneral`
 		: undefined;
 
-	if ( site.is_coming_soon ) {
+	if ( isComingSoon ) {
 		return (
 			<OverviewCard
 				{ ...CARD_PROPS }


### PR DESCRIPTION
## Proposed Changes

* Read `is_coming_soon` from the `/me/sites` list data instead of the per-site `/sites/{slug}` endpoint for the CIAB store visibility card.

## Why are these changes being made?

* The per-site API endpoint (`/sites/{slug}`) returns incorrect `is_coming_soon` for CIAB sites, causing the Store Visibility card on the site overview page to show "Live" when it should show "Coming Soon" (or vice versa). The `/me/sites` endpoint returns the correct value, so we now prefer that source.

## Testing Instructions

* Navigate to a CIAB site overview page (e.g., `/sites/{ciab-site-slug}`)
* Verify the Store Visibility card shows the correct status ("Coming Soon" or "Live") matching the actual site state
* Compare with the visibility shown in the sites list view, which should now be consistent

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?