### PR TITLE
Reader: Add controls and preload metadata to video elements

### DIFF
--- a/client/lib/post-normalizer/rule-content-disable-autoplay.js
+++ b/client/lib/post-normalizer/rule-content-disable-autoplay.js
@@ -26,8 +26,10 @@ export function disableAutoPlayOnMedia( post, dom ) {
 	}
 	dom.querySelectorAll( 'audio, video' ).forEach( ( el ) => {
 		el.autoplay = false;
-		el.controls = true;
-		el.preload = 'metadata';
+		if ( el.tagName === 'VIDEO' ) {
+			el.controls = true;
+			el.preload = 'metadata';
+		}
 	} );
 	return post;
 }

--- a/client/lib/post-normalizer/rule-content-disable-autoplay.js
+++ b/client/lib/post-normalizer/rule-content-disable-autoplay.js
@@ -24,7 +24,11 @@ export function disableAutoPlayOnMedia( post, dom ) {
 	if ( ! dom ) {
 		throw new Error( 'this transform must be used as part of withContentDOM' );
 	}
-	dom.querySelectorAll( 'audio, video' ).forEach( ( el ) => ( el.autoplay = false ) );
+	dom.querySelectorAll( 'audio, video' ).forEach( ( el ) => {
+		el.autoplay = false;
+		el.controls = true;
+		el.preload = 'metadata';
+	} );
 	return post;
 }
 

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -242,14 +242,12 @@ describe( 'index', () => {
 			} );
 		} );
 
-		test( 'should strip autoplay attributes from audio and add controls and preload', () => {
+		test( 'should strip autoplay attributes from audio', () => {
 			const post = {
 				content: '<audio autoplay="1"></audio>',
 			};
 			const normalized = withContentDOM( [ disableAutoPlayOnMedia ] )( post );
-			expect( normalized ).toEqual( {
-				content: '<audio controls="" preload="metadata"></audio>',
-			} );
+			expect( normalized ).toEqual( { content: '<audio></audio>' } );
 		} );
 
 		test( 'should strip autoplay like attributes from iframes', () => {

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -232,20 +232,24 @@ describe( 'index', () => {
 	} );
 
 	describe( 'content.disableAutoPlayOnMediaShortcodes', () => {
-		test( 'should strip autoplay attributes from video', () => {
+		test( 'should strip autoplay attributes from video and add controls and preload', () => {
 			const post = {
 				content: '<video autoplay="1"></video>',
 			};
 			const normalized = withContentDOM( [ disableAutoPlayOnMedia ] )( post );
-			expect( normalized ).toEqual( { content: '<video></video>' } );
+			expect( normalized ).toEqual( {
+				content: '<video controls="" preload="metadata"></video>',
+			} );
 		} );
 
-		test( 'should strip autoplay attributes from audio', () => {
+		test( 'should strip autoplay attributes from audio and add controls and preload', () => {
 			const post = {
 				content: '<audio autoplay="1"></audio>',
 			};
 			const normalized = withContentDOM( [ disableAutoPlayOnMedia ] )( post );
-			expect( normalized ).toEqual( { content: '<audio></audio>' } );
+			expect( normalized ).toEqual( {
+				content: '<audio controls="" preload="metadata"></audio>',
+			} );
 		} );
 
 		test( 'should strip autoplay like attributes from iframes', () => {


### PR DESCRIPTION
Fixes READ-428

## Proposed Changes

* When the post normalizer disables `autoplay` on `<video>` and `<audio>` elements, also add `controls` to the video tag so users can manually play the media.
* Set `preload` to `"metadata"` to override the server-side `preload="none"`, allowing the browser to fetch video dimensions for proper sizing without downloading the full file.

## Why are these changes being made?

When a post author uses the common `autoplay muted loop` pattern for silent GIF-like videos, the Reader's `disableAutoPlayOnMedia` normalizer strips `autoplay` but doesn't compensate — leaving the video with no playback controls and no autoplay. The result is an inert, unplayable video element on the page.

Additionally, the REST API adds `preload="none"` to video elements, which prevents the browser from fetching even basic metadata (dimensions, duration). Combined with the API also stripping the `style` attribute (which may contain `aspect-ratio`), videos render at incorrect dimensions until the user somehow triggers playback.

This client-side fix addresses both issues. A separate server-side fix for the API attribute stripping (`style`, `muted`, `playsinline`) is tracked in READ-428.

## Testing Instructions

* Open a Reader post that contains a native `<video>` element (not a VideoPress or YouTube embed), e.g. https://wordpress.com/reader/feeds/177597274/posts/5997860374
* Before this change: the video appears as a thin empty bar with no way to play it.
* After this change: the video shows native browser controls (play/pause, volume, progress) and renders at the correct aspect ratio.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?