### PR TITLE
FORNO-253 Fix Image Studio icons in P2

### DIFF
--- a/packages/image-studio/src/components/index.tsx
+++ b/packages/image-studio/src/components/index.tsx
@@ -160,7 +160,7 @@ function ImageStudioAgentChat( {
 			messages={ displayMessages as any }
 			variant="embedded"
 			placeholder={ placeholder }
-			className="image-studio-agent agenttic"
+			className="image-studio-agent agenttic dark"
 			onSubmit={ handleSubmit }
 			onStop={ agentChatProps.abortCurrentRequest }
 			isProcessing={ isProcessing }

--- a/packages/image-studio/src/components/style.scss
+++ b/packages/image-studio/src/components/style.scss
@@ -58,6 +58,40 @@ body.js.is-image-studio-open {
 	max-height: 100vh;
 	border-radius: 0;
 	transition: background-color 1s ease;
+	// Override host theme styles that leak into the modal.
+	// WordPress core sets `color: rgb(30, 30, 30)` on `.components-modal__frame button`.
+	// P2 theme sets `button:not(.toggle) { background-color: transparent }`.
+	// These break agenttic-ui's dark theme styling. The !important is needed to
+	// beat host theme specificity.
+	color: #fff !important;
+
+	button,
+	input,
+	select,
+	textarea {
+		color: inherit !important;
+	}
+
+	// Restore agenttic-ui button backgrounds stripped by P2's
+	// `button:not(.toggle) { background-color: transparent }` reset.
+	// That selector (1 class + 1 element) beats agenttic-ui's single-class
+	// selectors like `.button-module_primary`. This re-scopes the fix to
+	// only agenttic-ui buttons inside the modal.
+	.agenttic button[class*="button-module_primary"]:not(:disabled) {
+		background-color: var(--color-primary, #2d5af2) !important;
+	}
+
+	// Override host theme SVG fill/stroke rules for icon rendering.
+	// P2 and other themes apply global CSS fill properties on SVG elements,
+	// which override the fill/stroke inheritance used by @wordpress/icons
+	// and agenttic-ui icons (lucide-react).
+	svg:not([fill]) {
+		fill: currentColor !important;
+	}
+
+	svg[fill="none"] {
+		fill: none !important;
+	}
 
 	// Reset modal component defaults
 	h1,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Fix Image Studio to support dark mode on P2

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Dark mode of P2 broke the styling of Image Studio

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Install this PR to your sandbox
```
install-plugin.sh am forno-253/fix-icons-in-p2
```
* Sandbox `widgets.wp.com`
* Test on both Simple and P2 sites (fornop2 — proxy is required) 
* Verify that Send message, Close (X), Regenerate (Image Info), < and > buttons, Thumbs up/down buttons are all visible and correctly styled


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
