### PR TITLE
Site Launch Standardization: Redirect back to wp-admin after completing the flow

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -104,6 +104,13 @@ function getSignupDestination( { siteSlug, redirect_to, localeSlug, flowName } )
 }
 
 function getLaunchDestination( dependencies ) {
+	if ( dependencies.refParameter === 'wp-admin' ) {
+		return addQueryArgs(
+			{ 'celebrate-launch': 'true' },
+			`https://${ dependencies.siteSlug }/wp-admin`
+		);
+	}
+
 	return addQueryArgs( { celebrateLaunch: 'true' }, `/home/${ dependencies.siteSlug }` );
 }
 

--- a/test/e2e/specs/onboarding/launch-site__wp-admin.spec.ts
+++ b/test/e2e/specs/onboarding/launch-site__wp-admin.spec.ts
@@ -1,0 +1,135 @@
+import {
+	RestAPIClient,
+	type NewSiteResponse,
+	type NewTestUserDetails,
+	type NewUserResponse,
+} from '@automattic/calypso-e2e';
+import { expect, tags, test } from '../../lib/pw-base';
+import { apiCloseAccount, apiDeleteSite, swapBaseUrl } from '../shared';
+
+test.describe(
+	'Onboarding: Launch site from WP Admin',
+	{ tag: [ tags.CALYPSO_RELEASE, tags.JETPACK_WPCOM_INTEGRATION, tags.DESKTOP_ONLY ] },
+	() => {
+		const accountsToCleanup: {
+			testUser: NewTestUserDetails;
+			newUserDetails: NewUserResponse;
+			newSiteDetails?: NewSiteResponse;
+		}[] = [];
+
+		test( 'As a user with an unlaunched site, I can launch it via the WP Admin launch button and be redirected back at the end of the flow', async ( {
+			page,
+			componentDomainSearch,
+			componentLaunchCelebration,
+			helperData,
+			pageSignupPickPlan,
+			environment,
+			pageUserSignUp,
+			viewportName,
+		} ) => {
+			test.skip(
+				viewportName === 'mobile',
+				'Skipping for mobile viewport as the launch site button is not available'
+			);
+
+			const testUser = helperData.getNewTestUser();
+			let newUserDetails: NewUserResponse;
+			let newSiteDetails: NewSiteResponse;
+			let siteSlug: string;
+
+			await test.step( 'When I enter the onboarding flow', async function () {
+				await page.goto( helperData.getCalypsoURL( '/setup/onboarding' ) );
+			} );
+
+			await test.step( 'And I sign up as a new user', async function () {
+				newUserDetails = await pageUserSignUp.signupSocialFirstWithEmail( testUser.email );
+			} );
+
+			await test.step( 'And I select a .wordpress.com domain name', async function () {
+				await componentDomainSearch.search( helperData.getBlogName() );
+				await componentDomainSearch.skipPurchase();
+			} );
+
+			await test.step( 'And I select the WordPress.com Free plan', async function () {
+				newSiteDetails = await pageSignupPickPlan.selectPlan( 'Free', new RegExp( '.*/home/.*' ) );
+				siteSlug = newSiteDetails.blog_details.site_slug;
+				accountsToCleanup.push( { testUser, newUserDetails, newSiteDetails } );
+			} );
+
+			await test.step( 'When I navigate to WP Admin for my new site', async function () {
+				await page.goto( `https://${ siteSlug }/wp-admin` );
+			} );
+
+			await test.step( 'And I click on the launch site button in the admin bar', async function () {
+				const launchSiteButtonHref = await page
+					.getByRole( 'menuitem', { name: 'Launch site' } )
+					.getAttribute( 'href' );
+
+				if ( ! launchSiteButtonHref ) {
+					throw new Error( 'Launch site button not found' );
+				}
+
+				const launchSiteUrl = new URL( launchSiteButtonHref );
+				expect( launchSiteUrl.searchParams.get( 'siteSlug' ) ).toBe( siteSlug );
+				expect( launchSiteUrl.searchParams.get( 'ref' ) ).toBe( 'wp-admin' );
+
+				const launchSiteUrlWithSwappedOrigin = swapBaseUrl(
+					launchSiteButtonHref,
+					environment.CALYPSO_BASE_URL
+				);
+
+				await page.goto( launchSiteUrlWithSwappedOrigin );
+			} );
+
+			await test.step( 'Then I am redirected to the launch-site flow on WPCOM', async function () {
+				await page.waitForURL( /start\/launch-site/, { timeout: 30_000 } );
+			} );
+
+			await test.step( 'And I skip the domain search', async function () {
+				await componentDomainSearch.skipPurchase();
+			} );
+
+			await test.step( 'And I open the escape hatch to skip the plan', async function () {
+				await pageSignupPickPlan.openEscapeHatch();
+			} );
+
+			await test.step( 'And I continue with the Free plan', async function () {
+				await pageSignupPickPlan.continueWithFreeViaEscapeHatch( new RegExp( '.*/wp-admin.*' ) );
+			} );
+
+			await test.step( 'Then I am redirected back to WP Admin', async function () {
+				expect( page.url() ).toMatch( /\/wp-admin/ );
+			} );
+
+			await test.step( 'And the launch celebration modal is displayed', async function () {
+				await componentLaunchCelebration.validateVisible();
+			} );
+		} );
+
+		test.afterAll( 'Delete all user accounts generated', async function () {
+			for ( const account of accountsToCleanup ) {
+				const restAPIClient = new RestAPIClient(
+					{
+						username: account.testUser.username,
+						password: account.testUser.password,
+					},
+					account.newUserDetails.body.bearer_token
+				);
+
+				if ( account.newSiteDetails ) {
+					await apiDeleteSite( restAPIClient, {
+						url: account.newSiteDetails.blog_details.url,
+						id: account.newSiteDetails.blog_details.blogid,
+						name: account.newSiteDetails.blog_details.blogname,
+					} );
+				}
+
+				await apiCloseAccount( restAPIClient, {
+					userID: account.newUserDetails.body.user_id,
+					username: account.newUserDetails.body.username,
+					email: account.testUser.email,
+				} );
+			}
+		} );
+	}
+);

--- a/test/e2e/specs/shared/index.ts
+++ b/test/e2e/specs/shared/index.ts
@@ -1,5 +1,6 @@
 export * from './api-close-account';
 export * from './api-delete-site';
+export * from './swap-base-url';
 
 /**
  * This is a fix for e2e test that was deployed on Christmas eve as an emergency fix. Please remove and fix the root cause.

--- a/test/e2e/specs/shared/swap-base-url.ts
+++ b/test/e2e/specs/shared/swap-base-url.ts
@@ -1,0 +1,15 @@
+/**
+ * Swaps the base URL of a given URL to a new base URL.
+ * @param url The URL to swap the base URL of.
+ * @param newBaseUrl The new base URL to swap the base URL of the given URL to.
+ * @returns The URL with the swapped base URL.
+ */
+export function swapBaseUrl( url: string, newBaseUrl: string ) {
+	const urlObject = new URL( url );
+
+	const baseUrl = new URL( newBaseUrl );
+
+	urlObject.protocol = baseUrl.protocol;
+	urlObject.host = baseUrl.host;
+	return urlObject.toString();
+}


### PR DESCRIPTION
Closes DATSCI-1163.

## Proposed Changes

If the user wants to launch their site and they're coming from WP Admin, redirect back to it after the flow finishes. Right now, we're redirecting to the Calypso home page.

## Testing Instructions

Apply [this Jetpack PR](https://github.com/Automattic/jetpack/pull/47638) to your Simple or Atomic **unlaunched** site.

Enter the site's WP Admin and verify the Launch Site button link (as shown below) has the `ref=wp-admin` query parameter:

<img width="423" height="121" alt="image" src="https://github.com/user-attachments/assets/84a3f67d-5b3b-4120-ad3a-653c17566ac9" />

Don't click the link. Instead, copy it and replace the origin with this PR's Calypso Live link or `calypso.localhost:3000` if you're running locally.

Go through the flow and verify that, at the end, you return to WP Admin and see the site launch modal on the screen.
