### PR TITLE
Dashboard: respect optIn config before opt-in redirect

### DIFF
--- a/client/dashboard/app/router/root.tsx
+++ b/client/dashboard/app/router/root.tsx
@@ -21,7 +21,7 @@ export type RootRouterContext = {
 export const rootRoute = createRootRouteWithContext< RootRouterContext >()( {
 	component: Root,
 	notFoundComponent: NotFoundRoot,
-	beforeLoad: async ( { cause } ) => {
+	beforeLoad: async ( { cause, context } ) => {
 		if ( cause === 'preload' ) {
 			return;
 		}
@@ -29,6 +29,10 @@ export const rootRoute = createRootRouteWithContext< RootRouterContext >()( {
 		if ( cause === 'enter' ) {
 			// We are priming the query cache with Jetpack URLs so we can detect "site collisions" (i.e. two sites have the same slug)
 			queryClient.prefetchQuery( jetpackSiteUrlsQuery() );
+		}
+
+		if ( ! context.config.optIn ) {
+			return;
 		}
 
 		const user = queryClient.getQueryData< User >( AUTH_QUERY_KEY );


### PR DESCRIPTION
Reported p1773769706393529-slack-CRWCHQGUB

## Proposed Changes

* Make the root router obey `context.config.optIn` before evaluating the hosting-dashboard opt-in preference.
* Skip the opt-in redirect when the Dashboard app config has `optIn` disabled.
* Keep CIAB/Woo users in Dashboard instead of redirecting new users to Calypso.

## Why are these changes being made?

* The router should have been obeying the app's `optIn` config all along before running any hosting-dashboard opt-in redirect logic.
* Instead, the root route was always checking the `hosting-dashboard-opt-in` user preference for eligible users.
* CIAB/Woo sets `optIn` to `false`, so new users on `my.woo.ai` were being redirected out of the Multi-Site Dashboard even though opt-in is disabled for that experience.

## Testing Instructions

* Open Dashboard in a context where `config.optIn` is `false`, such as the Woo/CIAB flow.
* Sign in as a new eligible user and load the app.
* Confirm the app stays in Dashboard and does not redirect to Calypso.
* Confirm contexts with `config.optIn` enabled still follow the existing redirect behavior.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?