### PR TITLE
e2e: Improve I can sign up for a new Premium plan site using a theme test

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/logged-out-themes-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/logged-out-themes-page.ts
@@ -6,13 +6,49 @@ import { Locator, Page } from 'playwright';
 export class LoggedOutThemesPage {
 	private page: Page;
 	readonly firstThemeCard: Locator;
+	private readonly firstThemeCardContainer: Locator;
+	private readonly themePlaceholders: Locator;
 
 	/**
 	 * Constructs an instance of the logged-out themes showcase page.
 	 */
 	constructor( page: Page ) {
 		this.page = page;
-		this.firstThemeCard = this.page.locator( '[data-e2e-theme]' ).first();
+		this.firstThemeCardContainer = this.page.locator( '[data-e2e-theme]' ).first();
+		this.firstThemeCard = this.firstThemeCardContainer.locator( '.theme-card__image' );
+		this.themePlaceholders = this.page.locator( '.themes-list .is-placeholder' );
+	}
+
+	/**
+	 * Waits for the currently visible theme list to finish updating.
+	 *
+	 * The showcase keeps previous results rendered while a new filter request is in flight,
+	 * so we wait for placeholder cards to disappear before clicking a theme.
+	 */
+	private async waitForThemeResultsToSettle(): Promise< void > {
+		await this.firstThemeCardContainer.waitFor( { state: 'visible', timeout: 30_000 } );
+
+		const firstPlaceholder = this.themePlaceholders.first();
+		try {
+			await firstPlaceholder.waitFor( { state: 'visible', timeout: 2_000 } );
+			await firstPlaceholder.waitFor( { state: 'hidden', timeout: 30_000 } );
+		} catch {
+			// If placeholders never appear, the results were already settled.
+		}
+
+		await this.firstThemeCard.waitFor( { state: 'visible', timeout: 30_000 } );
+	}
+
+	/**
+	 * Opens the first theme currently shown in the showcase.
+	 */
+	async selectFirstThemeCard(): Promise< void > {
+		await this.waitForThemeResultsToSettle();
+		await this.firstThemeCard.scrollIntoViewIfNeeded();
+		await Promise.all( [
+			this.page.waitForURL( /\/theme\//, { timeout: 30_000 } ),
+			this.firstThemeCard.click(),
+		] );
 	}
 
 	/**
@@ -21,7 +57,14 @@ export class LoggedOutThemesPage {
 	 * @param {string} filter - The filter to apply.
 	 */
 	async filterBy( filter: string ) {
+		const currentUrl = this.page.url();
 		await this.page.getByRole( 'combobox', { name: 'Filters' } ).click();
-		await this.page.getByRole( 'option', { name: filter } ).click();
+		await Promise.all( [
+			this.page
+				.waitForURL( ( url ) => url.toString() !== currentUrl, { timeout: 30_000 } )
+				.catch( () => null ),
+			this.page.getByRole( 'option', { name: filter } ).click(),
+		] );
+		await this.waitForThemeResultsToSettle();
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
@@ -112,6 +112,13 @@ export class UserSignupPage {
 	}
 
 	/**
+	 * Waits until one of the supported signup form variants is ready.
+	 */
+	async waitUntilLoaded(): Promise< void > {
+		await this.waitForSignupForm();
+	}
+
+	/**
 	 * Navigates to the /start endpoint.
 	 *
 	 * @param {{path: string}: string } param1 Key/value pair of the path to be appended to /start. E.g. /start/premium is the premium plan signup flow.

--- a/test/e2e/specs/onboarding/signup__with-theme-LOHP.spec.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-LOHP.spec.ts
@@ -50,13 +50,14 @@ test.describe(
 				await flowLOHPThemeSignup.loggedOutHomePage.exploreThemesLink.click();
 
 				await flowLOHPThemeSignup.loggedOutThemesPage.filterBy( 'Free' );
-				await flowLOHPThemeSignup.loggedOutThemesPage.firstThemeCard.click();
+				await flowLOHPThemeSignup.loggedOutThemesPage.selectFirstThemeCard();
 
 				themeSlug = await flowLOHPThemeSignup.visitCalypsoGetStartedLinkForTheme();
 			} );
 
 			await test.step( 'Then I see the "Create your account" page', async function () {
-				await expect( flowLOHPThemeSignup.userSignupPage.createYourAccountHeading ).toBeVisible();
+				await flowLOHPThemeSignup.userSignupPage.waitUntilLoaded();
+				await expect( flowLOHPThemeSignup.userSignupPage.emailInput ).toBeVisible();
 			} );
 
 			await test.step( 'When I sign up with my email', async function () {


### PR DESCRIPTION


<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
