### PR TITLE
Mailing Lists: add new mailing list category for AI Tips

### DIFF
--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -114,6 +114,8 @@ class MainComponent extends Component {
 			return this.props.translate( 'Learn Faster to Grow Faster' );
 		} else if ( 'wp_studio' === category ) {
 			return this.props.translate( 'WordPress Studio' );
+		} else if ( 'ai_tips' === category ) {
+			return this.props.translate( 'AI Tips' );
 		} else if ( 'jetpack_marketing' === category ) {
 			return this.props.translate( 'Jetpack Suggestions' );
 		} else if ( 'jetpack_research' === category ) {
@@ -178,6 +180,10 @@ class MainComponent extends Component {
 		} else if ( 'wp_studio' === category ) {
 			return this.props.translate(
 				'WordPress Studio news, announcements, tips, and feature spotlights.'
+			);
+		} else if ( 'ai_tips' === category ) {
+			return this.props.translate(
+				'AI insights, breakthroughs, tips, and new feature highlights.'
 			);
 		} else if ( 'jetpack_marketing' === category ) {
 			return this.props.translate( 'Tips for getting the most out of Jetpack.' );


### PR DESCRIPTION
This change adds proper Calypso (UI) support for a new mailing list category, AI Tips. The backend work on adding the new mailing list category for AI Tips was completed via .

## Testing Instructions

Visit [this unsubscribe URL](http://calypso.localhost:3000/mailing-lists/unsubscribe?category=ai_tips&email=comics%40gmail.com&hmac=f8c7a481d08274ad85794900a14b5d8e). Confirm that the subscribe and resubscribe actions work, and that the title and description of the message are correctly displayed.

<img width="2570" height="754" alt="CleanShot 2026-03-17 at 18 04 14@2x" src="https://github.com/user-attachments/assets/b765e383-5f76-47b1-ad54-454b3ae5a1ae" />
