### PR TITLE
Revert "Stats: Fix subscriber chart Y-axis to always start from zero"

### DIFF
--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -282,7 +282,7 @@ export default function SubscribersChartSection( {
 							height={ 300 }
 							curveType="monotone" // can use smooth, linear, monotone
 							EmptyState={ () => null }
-							zeroBaseline
+							zeroBaseline={ lineChartData.length > 1 }
 							formatTimeTick={ formatTimeTick }
 							placeholder={ <StatsModulePlaceholder className="is-chart" isLoading /> }
 						/>


### PR DESCRIPTION
Reverts Automattic/wp-calypso#109313