### PR TITLE
Dashboard Domains: Fix transfer page for domain connections (v2)

### DIFF
--- a/client/dashboard/domains/domain-overview/actions.tsx
+++ b/client/dashboard/domains/domain-overview/actions.tsx
@@ -16,16 +16,19 @@ import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+import { addQueryArgs } from '@wordpress/url';
 import { useCallback, useState } from 'react';
 import { useAuth } from '../../app/auth';
 import { domainRoute, domainsIndexRoute, domainTransferRoute } from '../../app/router/domains';
 import { purchaseSettingsRoute, cancelPurchaseRoute } from '../../app/router/me';
+import { getCurrentDashboard } from '../../app/routing';
 import { ActionList } from '../../components/action-list';
 import InlineSupportLink from '../../components/inline-support-link';
 import RemoveDomainDialog from '../../components/purchase-dialogs/remove-domain-dialog';
 import RouterLinkButton from '../../components/router-link-button';
 import { SectionHeader } from '../../components/section-header';
 import { getDomainRenewalUrl } from '../../utils/domain';
+import { redirectToDashboardLink, wpcomLink } from '../../utils/link';
 import {
 	shouldShowTransferAction,
 	shouldShowTransferInAction,
@@ -150,15 +153,20 @@ export default function Actions( { isDisabled }: { isDisabled?: boolean } ) {
 						title={ __( 'Bring your domain to WordPress.com' ) }
 						description={ __( 'Manage your site and domain all in one place.' ) }
 						actions={
-							<RouterLinkButton
+							<Button
 								size="compact"
 								variant="secondary"
-								// TODO: use the correct route once the domain transfer in route is created
-								to={ domainTransferRoute.fullPath }
-								params={ { domainName } }
+								href={ addQueryArgs( wpcomLink( '/setup/domain/use-my-domain' ), {
+									initialQuery: domainName,
+									initialMode: 'transfer-domain',
+									siteSlug: domain.site_slug,
+									dashboard: getCurrentDashboard(),
+									back_to: redirectToDashboardLink(),
+								} ) }
+								disabled={ isDisabled }
 							>
 								{ __( 'Transfer' ) }
-							</RouterLinkButton>
+							</Button>
 						}
 					/>
 				) }

--- a/client/dashboard/domains/domain-transfer/outbound-transfer.tsx
+++ b/client/dashboard/domains/domain-transfer/outbound-transfer.tsx
@@ -35,7 +35,11 @@ export default function OutboundTransfer( { domain }: { domain: Domain } ) {
 	const domainName = domain.domain;
 	const { recordTracksEvent } = useAnalytics();
 	const locale = useLocale();
-	const { data: whoisData, isLoading: isLoadingWhois } = useQuery( domainWhoisQuery( domainName ) );
+	const isDomainConnection = domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION;
+	const { data: whoisData, isLoading: isLoadingWhois } = useQuery( {
+		...domainWhoisQuery( domainName ),
+		enabled: ! isDomainConnection,
+	} );
 	const registrantEmail = findRegistrantWhois( whoisData )?.email;
 	const { mutate: updateDomainLock, isPending: isUpdatingDomainLock } = useMutation( {
 		...domainLockMutation( domainName ),


### PR DESCRIPTION
Re-lands #109200 for further investigation.

Fixes: DOMENG-395

## Summary
- Fix infinite login redirect loop on the domain transfer page for domain connections by skipping the WHOIS query (which returns `authorization_required` for externally registered domains)
- Fix the "Bring your domain to WordPress.com" action to link to the correct `/setup/domain/use-my-domain` stepper flow instead of the outbound transfer page

## Test plan
- [ ] Navigate to the domain overview page for a domain connection (e.g., `/domains/example.com`)
- [ ] Click the "Transfer" button — verify the transfer page loads without redirecting to login
- [ ] Click the "Bring your domain to WordPress.com" transfer button — verify it navigates to the use-my-domain stepper flow with correct query params

🤖 Generated with [Claude Code](https://claude.com/claude-code)