### PR TITLE
Help Center: Add MCP route to query mapping

### DIFF
--- a/packages/help-center/src/route-to-query-mapping.ts
+++ b/packages/help-center/src/route-to-query-mapping.ts
@@ -8,6 +8,7 @@ export const useQueryForRoute = ( currentRoute: string ) => {
 		'/hosting-config/': __( 'hosting configuration' ),
 		'/marketing/sharing-buttons/': __( 'social share' ),
 		'/me/get-apps': __( 'wordpress apps' ),
+		'/me/mcp': __( 'mcp' ),
 		'/me/notifications': __( 'notification settings' ),
 		'/me/privacy': __( 'privacy' ),
 		'/me/site-blocks': __( 'blocked sites' ),


### PR DESCRIPTION
## Summary
- Adds `/me/mcp` → `"mcp"` to the Help Center route-to-query mapping so MCP-related articles are suggested when users open the Help Center on `/me/mcp` and `/me/mcp-setup`.

Closes DOTCOM-16397

## Testing Instructions

### Calypso

1. Run `yarn start`.
2. Navigate to `/me/mcp` or `/me/mcp-setup`.
3. Open the Help Center and verify that MCP-related articles are suggested.
