### PR TITLE
Clean up complimentary subscription modal styling

### DIFF
--- a/client/my-sites/earn/components/add-edit-coupon-modal/products-selector.tsx
+++ b/client/my-sites/earn/components/add-edit-coupon-modal/products-selector.tsx
@@ -17,12 +17,14 @@ type ProductsSelectorProps = {
 	onSelectedPlanIdsChange: ( ids_list: number[] ) => void;
 	initialSelectedList: number[];
 	allowMultiple: boolean;
+	showLabel?: boolean;
 };
 
 const ProductsSelector = ( {
 	onSelectedPlanIdsChange,
 	initialSelectedList,
 	allowMultiple,
+	showLabel = true,
 }: ProductsSelectorProps ) => {
 	const [ selectedPlanIds, setSelectedPlanIds ] = useState( initialSelectedList ?? [] );
 
@@ -125,7 +127,7 @@ const ProductsSelector = ( {
 	return (
 		<FormFieldset className="memberships__dialog-sections-products">
 			<QueryMemberships siteId={ selectedSiteId ?? 0 } />
-			<FormLabel htmlFor="coupon_code">{ translate( 'Products' ) }</FormLabel>
+			{ showLabel && <FormLabel htmlFor="coupon_code">{ translate( 'Products' ) }</FormLabel> }
 			<ToolbarDropdownMenu
 				icon={ chevronDown }
 				label={ selectedProductSummary }

--- a/client/my-sites/subscribers/components/gift-modal/gift-modal.tsx
+++ b/client/my-sites/subscribers/components/gift-modal/gift-modal.tsx
@@ -97,6 +97,7 @@ const GiftSubscriptionModal = ( {
 				</Button>
 				<Button
 					variant="primary"
+					isBusy={ isSubmitting }
 					onClick={ () => giftSubscription( planId, userId, username ) }
 					disabled={ planId === 0 || isSubmitting }
 				>

--- a/client/my-sites/subscribers/components/gift-modal/gift-modal.tsx
+++ b/client/my-sites/subscribers/components/gift-modal/gift-modal.tsx
@@ -1,11 +1,12 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Button } from '@automattic/components';
-import { Modal } from '@wordpress/components';
+import { Modal, Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import ProductsSelector from 'calypso/my-sites/earn/components/add-edit-coupon-modal/products-selector';
 import { useDispatch } from 'calypso/state';
 import { requestAddGift } from 'calypso/state/memberships/gifts/actions';
+
+import './style.scss';
 
 type GiftSubscriptionModalProps = {
 	userId: number | string;
@@ -40,10 +41,6 @@ const GiftSubscriptionModal = ( {
 			site_id: siteId,
 		} );
 	}, [ siteId ] );
-
-	const title = translate( 'Gift a subscription' );
-
-	const text = translate( 'Select a plan to gift to this user: ' );
 
 	const giftSubscription = ( plan_id: number, user_id: number | string, username: string ) => {
 		setIsSubmitting( true );
@@ -82,21 +79,25 @@ const GiftSubscriptionModal = ( {
 	};
 
 	return (
-		<Modal overlayClassName="confirm-modal" title={ title } onRequestClose={ onClose }>
-			{ text && <p>{ text }</p> }
+		<Modal
+			overlayClassName="complimentary-subscription-modal"
+			title={ translate( 'Gift a subscription' ) }
+			onRequestClose={ onClose }
+		>
+			<p>{ translate( 'Select a plan to gift to this user:' ) }</p>
 			<ProductsSelector
 				onSelectedPlanIdsChange={ ( list ) => setPlanId( list[ 0 ] ?? 0 ) }
 				initialSelectedList={ [] }
 				allowMultiple={ false }
+				showLabel={ false }
 			/>
-			<div className="confirm-modal__buttons">
-				<Button className="confirm-modal__cancel" onClick={ onClose }>
+			<div className="complimentary-subscription-modal__buttons">
+				<Button onClick={ onClose } variant="tertiary">
 					{ translate( 'Cancel' ) }
 				</Button>
 				<Button
+					variant="primary"
 					onClick={ () => giftSubscription( planId, userId, username ) }
-					primary
-					busy={ isSubmitting }
 					disabled={ planId === 0 || isSubmitting }
 				>
 					{ translate( 'Confirm' ) }

--- a/client/my-sites/subscribers/components/gift-modal/gift-modal.tsx
+++ b/client/my-sites/subscribers/components/gift-modal/gift-modal.tsx
@@ -84,7 +84,7 @@ const GiftSubscriptionModal = ( {
 			title={ translate( 'Gift a subscription' ) }
 			onRequestClose={ onClose }
 		>
-			<p>{ translate( 'Select a plan to gift to this user:' ) }</p>
+			<p>{ translate( 'Select a plan to gift to this user: ' ) }</p>
 			<ProductsSelector
 				onSelectedPlanIdsChange={ ( list ) => setPlanId( list[ 0 ] ?? 0 ) }
 				initialSelectedList={ [] }

--- a/client/my-sites/subscribers/components/gift-modal/style.scss
+++ b/client/my-sites/subscribers/components/gift-modal/style.scss
@@ -1,0 +1,18 @@
+.complimentary-subscription-modal {
+	.complimentary-subscription-modal__buttons {
+		display: flex;
+		gap: 16px;
+		justify-content: flex-end;
+	}
+
+	.memberships__dialog-sections-products .components-dropdown-menu {
+		width: 100%;
+
+		.components-button.has-icon.has-text {
+			justify-content: space-between;
+			flex-direction: row-reverse;
+			width: 100%;
+			border: 1px solid var(--wp-components-color-gray-600, #949494);
+		}
+	}
+}


### PR DESCRIPTION
Fixes: NL-520

| Before | After |
|--------|--------|
| <img width="455" height="471" alt="Screen Shot 2026-03-18 at 15 40 28" src="https://github.com/user-attachments/assets/efc3211f-5c29-4043-962a-4320dc8fb76d" /> | <img width="460" height="432" alt="Screen Shot 2026-03-18 at 15 39 45" src="https://github.com/user-attachments/assets/96374ca4-50d2-441a-b1d6-12e44e426295" /> |
| <img width="426" height="316" alt="Screen Shot 2026-03-18 at 15 42 50" src="https://github.com/user-attachments/assets/e11500a8-887b-4633-be31-e0ad96745863" /> | <img width="543" height="372" alt="Screen Shot 2026-03-18 at 15 31 04" src="https://github.com/user-attachments/assets/657dc039-05cb-41cf-977b-473d832c0e25" /> |

## Summary
- Switch to `@wordpress/components` Button with `variant` props to align with Core modal standards
- Remove redundant "Products" label by adding `showLabel` prop to `ProductsSelector`
- Add dedicated stylesheet for modal layout and dropdown styling
- Rename overlay class from generic `confirm-modal` to `complimentary-subscription-modal`

## Test plan

1. Enable Gift Subscriptions on a site that has Newsletter plans already
2. Go to the Subscribers table `/subscribers/yourwordpresssite.com`
3. Click `Gift a subscription` under the action menu for a subscriber
4. View the modal and compare to production