### PR TITLE
Add/migration wpcom detection

### DIFF
--- a/client/blocks/import/capture/capture-input.tsx
+++ b/client/blocks/import/capture/capture-input.tsx
@@ -26,7 +26,6 @@ interface Props {
 	onInputEnter: OnInputEnter;
 	placeholder?: string;
 	skipInitialChecking?: boolean;
-	customInfoContent?: React.ReactNode;
 }
 const CaptureInput: FunctionComponent< Props > = ( props ) => {
 	const {
@@ -40,7 +39,6 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 		dontHaveSiteAddressLabel,
 		hideImporterListLink = false,
 		nextLabelText,
-		customInfoContent,
 	} = props;
 
 	const translate = useTranslate();
@@ -125,14 +123,6 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 		);
 	}
 
-	function renderInfoContent() {
-		if ( ! customInfoContent ) {
-			return null;
-		}
-
-		return <div className="capture-input__info">{ customInfoContent }</div>;
-	}
-
 	return (
 		<form className="import__capture" onSubmit={ onFormSubmit }>
 			<FormFieldset>
@@ -151,7 +141,6 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 					value={ urlValue }
 					placeholder={ placeholder }
 					onChange={ onChange }
-					aria-describedby={ customInfoContent ? 'wpcom-info-message' : undefined }
 				/>
 
 				<FormSettingExplanation>{ renderError() }</FormSettingExplanation>
@@ -173,8 +162,6 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 						}
 					) }
 			</div>
-
-			{ renderInfoContent() }
 		</form>
 	);
 };

--- a/client/blocks/import/capture/capture-input.tsx
+++ b/client/blocks/import/capture/capture-input.tsx
@@ -26,6 +26,7 @@ interface Props {
 	onInputEnter: OnInputEnter;
 	placeholder?: string;
 	skipInitialChecking?: boolean;
+	customInfoContent?: React.ReactNode;
 }
 const CaptureInput: FunctionComponent< Props > = ( props ) => {
 	const {
@@ -39,6 +40,7 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 		dontHaveSiteAddressLabel,
 		hideImporterListLink = false,
 		nextLabelText,
+		customInfoContent,
 	} = props;
 
 	const translate = useTranslate();
@@ -47,6 +49,7 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 	const [ submitted, setSubmitted ] = useState( false );
 	const [ validationMessage, setValidationMessage ] = useState( '' );
 	const lastInvalidValue = useRef< string | undefined >();
+	const errorRef = useRef< HTMLDivElement >( null );
 	const showValidationMsg = hasError || ( submitted && ! isValid );
 	const { search } = useLocation();
 
@@ -88,15 +91,46 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 
 	function onFormSubmit( e: FormEvent< HTMLFormElement > ) {
 		e.preventDefault();
-		isValid && onInputEnter( urlValue );
-		setSubmitted( true );
 
-		if ( ! isValid && urlValue?.length > 4 && urlValue !== lastInvalidValue.current ) {
-			lastInvalidValue.current = urlValue;
-			recordTracksEvent( 'calypso_importer_capture_input_invalid', {
-				url: urlValue,
-			} );
+		if ( ! isValid ) {
+			// Move focus to error for accessibility
+			errorRef.current?.focus();
+			setSubmitted( true );
+
+			if ( urlValue?.length > 4 && urlValue !== lastInvalidValue.current ) {
+				lastInvalidValue.current = urlValue;
+				recordTracksEvent( 'calypso_importer_capture_input_invalid', {
+					url: urlValue,
+				} );
+			}
+			return;
 		}
+
+		onInputEnter( urlValue );
+		setSubmitted( true );
+	}
+
+	function renderError() {
+		if ( ! showValidationMsg ) {
+			return null;
+		}
+
+		return (
+			<div className="capture-input__error" role="alert" aria-live="assertive" ref={ errorRef }>
+				<Icon icon={ info } size={ 20 } />{ ' ' }
+				{ validationMessage
+					? validationMessage
+					: translate( 'Please enter a valid website address. You can copy and paste.' ) }
+			</div>
+		);
+	}
+
+	function renderInfoContent() {
+		if ( ! customInfoContent ) {
+			return null;
+		}
+
+		return <div className="capture-input__info">{ customInfoContent }</div>;
 	}
 
 	return (
@@ -117,20 +151,10 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 					value={ urlValue }
 					placeholder={ placeholder }
 					onChange={ onChange }
+					aria-describedby={ customInfoContent ? 'wpcom-info-message' : undefined }
 				/>
 
-				<FormSettingExplanation>
-					<span className={ clsx( { 'is-error': showValidationMsg } ) }>
-						{ showValidationMsg && (
-							<>
-								<Icon icon={ info } size={ 20 } />{ ' ' }
-								{ validationMessage
-									? validationMessage
-									: translate( 'Please enter a valid website address. You can copy and paste.' ) }
-							</>
-						) }
-					</span>
-				</FormSettingExplanation>
+				<FormSettingExplanation>{ renderError() }</FormSettingExplanation>
 			</FormFieldset>
 
 			<NextButton type="submit">{ nextLabelText ?? translate( 'Continue' ) }</NextButton>
@@ -149,6 +173,8 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 						}
 					) }
 			</div>
+
+			{ renderInfoContent() }
 		</form>
 	);
 };

--- a/client/blocks/import/capture/style.scss
+++ b/client/blocks/import/capture/style.scss
@@ -73,12 +73,12 @@
 }
 
 .capture-input__error {
-	margin-top: 8px;
-	padding: 8px 12px;
+	margin-top: 0.5rem;
+	padding: 0.5rem 0.75rem;
 	color: var(--color-error);
 	background-color: var(--color-error-light);
 	border-radius: 4px;
-	font-size: 14px;
+	font-size: 0.875rem;
 
 	&:focus {
 		outline: 2px solid var(--color-error);

--- a/client/blocks/import/capture/style.scss
+++ b/client/blocks/import/capture/style.scss
@@ -85,8 +85,3 @@
 		outline-offset: 2px;
 	}
 }
-
-.capture-input__info {
-	margin-top: 8px;
-	// Info content provides its own styling
-}

--- a/client/blocks/import/capture/style.scss
+++ b/client/blocks/import/capture/style.scss
@@ -71,3 +71,22 @@
 		}
 	}
 }
+
+.capture-input__error {
+	margin-top: 8px;
+	padding: 8px 12px;
+	color: var(--color-error);
+	background-color: var(--color-error-light);
+	border-radius: 4px;
+	font-size: 14px;
+
+	&:focus {
+		outline: 2px solid var(--color-error);
+		outline-offset: 2px;
+	}
+}
+
+.capture-input__info {
+	margin-top: 8px;
+	// Info content provides its own styling
+}

--- a/client/blocks/import/capture/test/index.tsx
+++ b/client/blocks/import/capture/test/index.tsx
@@ -88,6 +88,55 @@ describe( 'CaptureInput', () => {
 	} );
 } );
 
+describe( 'CaptureInput - custom info content', () => {
+	it( 'should render custom info content when provided', () => {
+		const customInfo = <div data-testid="custom-info">Custom info message</div>;
+
+		render(
+			<MemoryRouter>
+				<CaptureInput customInfoContent={ customInfo } onInputEnter={ jest.fn() } />
+			</MemoryRouter>
+		);
+
+		expect( screen.getByTestId( 'custom-info' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should associate info with input via aria-describedby', () => {
+		const customInfo = <div id="wpcom-info-message">Info</div>;
+
+		render(
+			<MemoryRouter>
+				<CaptureInput customInfoContent={ customInfo } onInputEnter={ jest.fn() } />
+			</MemoryRouter>
+		);
+
+		const input = screen.getByLabelText( /Enter the URL/i );
+		expect( input ).toHaveAttribute( 'aria-describedby', 'wpcom-info-message' );
+	} );
+} );
+
+describe( 'CaptureInput - backward compatibility', () => {
+	it( 'should work without customInfoContent prop', () => {
+		const { container } = render(
+			<MemoryRouter>
+				<CaptureInput onInputEnter={ jest.fn() } />
+			</MemoryRouter>
+		);
+
+		expect( container.querySelector( '.capture-input__info' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should render default error when hasError=true without custom content', () => {
+		render(
+			<MemoryRouter>
+				<CaptureInput hasError onInputEnter={ jest.fn() } />
+			</MemoryRouter>
+		);
+
+		expect( screen.getByText( /Please enter a valid website address/i ) ).toBeInTheDocument();
+	} );
+} );
+
 describe( 'URL Validation', () => {
 	it.each( [
 		{
@@ -147,5 +196,18 @@ describe( 'URL Validation', () => {
 		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
 
 		expect( screen.getByText( error ) ).toBeInTheDocument();
+	} );
+
+	it( 'should have proper ARIA attributes on error', async () => {
+		const onInputEnter = jest.fn();
+		render(
+			<MemoryRouter>
+				<CaptureInput hasError onInputEnter={ onInputEnter } />
+			</MemoryRouter>
+		);
+
+		const errorElement = screen.getByRole( 'alert' );
+		expect( errorElement ).toBeInTheDocument();
+		expect( errorElement ).toHaveAttribute( 'aria-live', 'assertive' );
 	} );
 } );

--- a/client/blocks/import/capture/test/index.tsx
+++ b/client/blocks/import/capture/test/index.tsx
@@ -88,55 +88,6 @@ describe( 'CaptureInput', () => {
 	} );
 } );
 
-describe( 'CaptureInput - custom info content', () => {
-	it( 'should render custom info content when provided', () => {
-		const customInfo = <div data-testid="custom-info">Custom info message</div>;
-
-		render(
-			<MemoryRouter>
-				<CaptureInput customInfoContent={ customInfo } onInputEnter={ jest.fn() } />
-			</MemoryRouter>
-		);
-
-		expect( screen.getByTestId( 'custom-info' ) ).toBeInTheDocument();
-	} );
-
-	it( 'should associate info with input via aria-describedby', () => {
-		const customInfo = <div id="wpcom-info-message">Info</div>;
-
-		render(
-			<MemoryRouter>
-				<CaptureInput customInfoContent={ customInfo } onInputEnter={ jest.fn() } />
-			</MemoryRouter>
-		);
-
-		const input = screen.getByLabelText( /Enter the URL/i );
-		expect( input ).toHaveAttribute( 'aria-describedby', 'wpcom-info-message' );
-	} );
-} );
-
-describe( 'CaptureInput - backward compatibility', () => {
-	it( 'should work without customInfoContent prop', () => {
-		const { container } = render(
-			<MemoryRouter>
-				<CaptureInput onInputEnter={ jest.fn() } />
-			</MemoryRouter>
-		);
-
-		expect( container.querySelector( '.capture-input__info' ) ).not.toBeInTheDocument();
-	} );
-
-	it( 'should render default error when hasError=true without custom content', () => {
-		render(
-			<MemoryRouter>
-				<CaptureInput hasError onInputEnter={ jest.fn() } />
-			</MemoryRouter>
-		);
-
-		expect( screen.getByText( /Please enter a valid website address/i ) ).toBeInTheDocument();
-	} );
-} );
-
 describe( 'URL Validation', () => {
 	it.each( [
 		{

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -152,6 +152,13 @@ const siteMigration: FlowV2< typeof initialize > = {
 						action: SiteMigrationIdentifyAction;
 						host?: string;
 					};
+
+					// Handle wpcom sites - navigate to already-wpcom step
+					// This check must be FIRST, before SSH migration logic
+					if ( action === 'already-wpcom' ) {
+						return navigate( paths.alreadyWpcomPath( { from } ) );
+					}
+
 					const hasDestinationSite = hasSite( siteId, siteSlug );
 					const isSSHMigrationAvailable = config.isEnabled( 'migration/ssh-migration' );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-already-wpcom/components/form/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-already-wpcom/components/form/index.tsx
@@ -1,15 +1,18 @@
 import { FormLabel } from '@automattic/components';
+import { useLocale } from '@automattic/i18n-utils';
 import { NextButton } from '@automattic/onboarding';
 import { CheckboxControl } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { FC, useEffect } from 'react';
+import { FC, useState } from 'react';
 import { Control, Controller, FieldError, useForm } from 'react-hook-form';
 import { useSearchParams } from 'react-router-dom';
 import FormTextArea from 'calypso/components/forms/form-textarea';
 import Notice from 'calypso/components/notice';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
+import { useSubmitMigrationTicket } from 'calypso/landing/stepper/hooks/use-submit-migration-ticket';
 import { logToLogstash } from 'calypso/lib/logstash';
+import wp from 'calypso/lib/wp';
 import {
 	type TicketMigrationData,
 	useMigrationTicketMutation,
@@ -89,18 +92,68 @@ interface FormProps {
 	onComplete: () => void;
 }
 
+const extractDomainFromUrl = ( url: string ) => {
+	try {
+		const parsedUrl = new URL( url );
+		return parsedUrl.hostname;
+	} catch {
+		return url;
+	}
+};
+
+interface SiteInfo {
+	ID: number;
+}
+
+interface Domain {
+	domain: string;
+	wpcom_domain: boolean;
+	is_wpcom_staging_domain: boolean;
+}
+
+interface DomainsResponse {
+	domains: Domain[];
+}
+
+/**
+ * Looks up the wpcom subdomain (e.g., "markbiekorg.wordpress.com") for a given domain.
+ * This is needed because the ticket creation API stores tickets by the wpcom subdomain,
+ * not by custom domains.
+ */
+const getWpcomSubdomain = async ( domain: string ): Promise< string > => {
+	// First, get site info to retrieve the site ID
+	const siteInfo: SiteInfo = await wp.req.get( {
+		path: `/sites/${ encodeURIComponent( domain ) }`,
+		apiVersion: '1.1',
+	} );
+
+	// Then, get domains list to find the wpcom subdomain
+	const domainsResponse: DomainsResponse = await wp.req.get( {
+		path: `/sites/${ siteInfo.ID }/domains`,
+		apiVersion: '1.1',
+	} );
+
+	// Find the wpcom subdomain (not the staging domain)
+	const wpcomDomain = domainsResponse.domains.find(
+		( d ) => d.wpcom_domain && ! d.is_wpcom_staging_domain
+	);
+
+	return wpcomDomain?.domain ?? domain;
+};
+
 const Form: FC< FormProps > = ( { onComplete } ) => {
 	const translate = useTranslate();
-	const siteSlug = useSiteSlugParam() ?? '';
+	const locale = useLocale();
+	const siteSlug = useSiteSlugParam();
 	const [ queryParams ] = useSearchParams();
 	const from = queryParams.get( 'from' );
+	const [ isSubmitting, setIsSubmitting ] = useState( false );
 
-	const {
-		mutate: createTicket,
-		isSuccess,
-		error,
-		isPending,
-	} = useMigrationTicketMutation( siteSlug );
+	// Use the destination siteSlug if available, otherwise extract domain from the source wpcom site URL
+	const targetSiteSlug = siteSlug || ( from ? extractDomainFromUrl( from ) : '' );
+
+	const { sendTicketAsync: createZendeskTicket } = useSubmitMigrationTicket();
+	const { mutateAsync: createSurveyTicket } = useMigrationTicketMutation( targetSiteSlug );
 
 	const {
 		control,
@@ -109,7 +162,7 @@ const Form: FC< FormProps > = ( { onComplete } ) => {
 		setError,
 		formState: { errors },
 	} = useForm< TicketMigrationData >( {
-		disabled: isPending,
+		disabled: isSubmitting,
 		defaultValues: {
 			intents: [],
 			otherDetails: '',
@@ -119,32 +172,7 @@ const Form: FC< FormProps > = ( { onComplete } ) => {
 	const isOtherChecked = intents.includes( 'other' );
 	const errorMessage = errors?.root?.message ?? errors?.intents?.message;
 
-	useEffect( () => {
-		if ( error ) {
-			setError( 'root', {
-				type: 'manual',
-				message: translate( 'Something went wrong. Please try again.' ),
-			} );
-			logToLogstash( {
-				message: 'Error submitting migration ticket',
-				feature: 'calypso_client',
-				extra: {
-					siteSlug,
-					step: 'site-migration-already-wpcom',
-					from,
-					error: error.message,
-				},
-			} );
-		}
-	}, [ error, setError, translate ] );
-
-	useEffect( () => {
-		if ( isSuccess ) {
-			onComplete();
-		}
-	}, [ isSuccess, onComplete ] );
-
-	const onSubmit = handleSubmit( ( data: TicketMigrationData ) => {
+	const onSubmit = handleSubmit( async ( data: TicketMigrationData ) => {
 		if ( data.intents.length === 0 ) {
 			setError( 'intents', {
 				type: 'manual',
@@ -152,10 +180,46 @@ const Form: FC< FormProps > = ( { onComplete } ) => {
 			} );
 			return;
 		}
-		createTicket( {
-			intents: data.intents,
-			otherDetails: data.otherDetails,
-		} );
+
+		setIsSubmitting( true );
+
+		try {
+			// Look up the wpcom subdomain for ticket creation
+			// The ticket API stores tickets by wpcom subdomain, not custom domains
+			const wpcomSiteSlug = await getWpcomSubdomain( targetSiteSlug );
+
+			// Create ZenDesk ticket (required before survey can be submitted)
+			await createZendeskTicket( {
+				locale,
+				from_url: from ?? '',
+				blog_url: wpcomSiteSlug,
+			} );
+
+			// Submit survey
+			await createSurveyTicket( {
+				intents: data.intents,
+				otherDetails: data.otherDetails,
+			} );
+
+			onComplete();
+		} catch ( submitError ) {
+			setError( 'root', {
+				type: 'manual',
+				message: translate( 'Something went wrong. Please try again.' ),
+			} );
+			logToLogstash( {
+				message: 'Error submitting migration survey',
+				feature: 'calypso_client',
+				extra: {
+					siteSlug: targetSiteSlug,
+					step: 'site-migration-already-wpcom',
+					from,
+					error: submitError instanceof Error ? submitError.message : String( submitError ),
+				},
+			} );
+		} finally {
+			setIsSubmitting( false );
+		}
 	} );
 
 	return (
@@ -206,7 +270,7 @@ const Form: FC< FormProps > = ( { onComplete } ) => {
 						/>
 					) }
 				</div>
-				<NextButton disabled={ isPending } type="submit">
+				<NextButton disabled={ isSubmitting } type="submit">
 					{ translate( 'Continue' ) }
 				</NextButton>
 			</form>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-already-wpcom/components/form/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-already-wpcom/components/form/index.tsx
@@ -12,7 +12,6 @@ import Notice from 'calypso/components/notice';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { useSubmitMigrationTicket } from 'calypso/landing/stepper/hooks/use-submit-migration-ticket';
 import { logToLogstash } from 'calypso/lib/logstash';
-import wp from 'calypso/lib/wp';
 import {
 	type TicketMigrationData,
 	useMigrationTicketMutation,
@@ -103,46 +102,6 @@ const extractDomainFromUrl = ( url: string ) => {
 	}
 };
 
-interface SiteInfo {
-	ID: number;
-}
-
-interface Domain {
-	domain: string;
-	wpcom_domain: boolean;
-	is_wpcom_staging_domain: boolean;
-}
-
-interface DomainsResponse {
-	domains: Domain[];
-}
-
-/**
- * Looks up the wpcom subdomain (e.g., "markbiekorg.wordpress.com") for a given domain.
- * This is needed because the ticket creation API stores tickets by the wpcom subdomain,
- * not by custom domains.
- */
-const getWpcomSubdomain = async ( domain: string ): Promise< string > => {
-	// First, get site info to retrieve the site ID
-	const siteInfo: SiteInfo = await wp.req.get( {
-		path: `/sites/${ encodeURIComponent( domain ) }`,
-		apiVersion: '1.1',
-	} );
-
-	// Then, get domains list to find the wpcom subdomain
-	const domainsResponse: DomainsResponse = await wp.req.get( {
-		path: `/sites/${ siteInfo.ID }/domains`,
-		apiVersion: '1.1',
-	} );
-
-	// Find the wpcom subdomain (not the staging domain)
-	const wpcomDomain = domainsResponse.domains.find(
-		( d ) => d.wpcom_domain && ! d.is_wpcom_staging_domain
-	);
-
-	return wpcomDomain?.domain ?? domain;
-};
-
 const Form: FC< FormProps > = ( { onComplete } ) => {
 	const translate = useTranslate();
 	const locale = useLocale();
@@ -198,15 +157,11 @@ const Form: FC< FormProps > = ( { onComplete } ) => {
 		setIsSubmitting( true );
 
 		try {
-			// Look up the wpcom subdomain for ticket creation
-			// The ticket API stores tickets by wpcom subdomain, not custom domains
-			const wpcomSiteSlug = await getWpcomSubdomain( targetSiteSlug );
-
 			// Create ZenDesk ticket (required before survey can be submitted)
 			await createZendeskTicket( {
 				locale,
 				from_url: from ?? '',
-				blog_url: wpcomSiteSlug,
+				blog_url: targetSiteSlug,
 			} );
 
 			// Submit survey

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-already-wpcom/components/form/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-already-wpcom/components/form/index.tsx
@@ -181,6 +181,23 @@ const Form: FC< FormProps > = ( { onComplete } ) => {
 			return;
 		}
 
+		if ( ! targetSiteSlug ) {
+			setError( 'root', {
+				type: 'manual',
+				message: translate( 'Something went wrong. Please try again.' ),
+			} );
+			logToLogstash( {
+				message: 'Missing targetSiteSlug in migration survey submission',
+				feature: 'calypso_client',
+				extra: {
+					step: 'site-migration-already-wpcom',
+					siteSlug: siteSlug ?? '',
+					from: from ?? '',
+				},
+			} );
+			return;
+		}
+
 		setIsSubmitting( true );
 
 		try {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-already-wpcom/components/form/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-already-wpcom/components/form/index.tsx
@@ -5,7 +5,7 @@ import { CheckboxControl } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { FC, useState } from 'react';
-import { Control, Controller, FieldError, useForm } from 'react-hook-form';
+import { Control, Controller, FieldError, RegisterOptions, useForm } from 'react-hook-form';
 import { useSearchParams } from 'react-router-dom';
 import FormTextArea from 'calypso/components/forms/form-textarea';
 import Notice from 'calypso/components/notice';
@@ -21,12 +21,14 @@ interface CheckboxProps {
 	label: string;
 	control: Control< TicketMigrationData >;
 	value: string;
+	rules?: RegisterOptions< TicketMigrationData, 'intents' >;
 }
 
-const CheckboxIntents = ( { label, control, value }: CheckboxProps ) => (
+const CheckboxIntents = ( { label, control, value, rules }: CheckboxProps ) => (
 	<Controller
 		control={ control }
 		name="intents"
+		rules={ rules }
 		render={ ( { field } ) => {
 			return (
 				<CheckboxControl
@@ -160,6 +162,7 @@ const Form: FC< FormProps > = ( { onComplete } ) => {
 		handleSubmit,
 		watch,
 		setError,
+		clearErrors,
 		formState: { errors },
 	} = useForm< TicketMigrationData >( {
 		disabled: isSubmitting,
@@ -173,13 +176,7 @@ const Form: FC< FormProps > = ( { onComplete } ) => {
 	const errorMessage = errors?.root?.message ?? errors?.intents?.message;
 
 	const onSubmit = handleSubmit( async ( data: TicketMigrationData ) => {
-		if ( data.intents.length === 0 ) {
-			setError( 'intents', {
-				type: 'manual',
-				message: translate( 'Please select an option.' ),
-			} );
-			return;
-		}
+		clearErrors( 'root' );
 
 		if ( ! targetSiteSlug ) {
 			setError( 'root', {
@@ -265,6 +262,10 @@ const Form: FC< FormProps > = ( { onComplete } ) => {
 						value="transfer-my-domain-to-wordpress-com"
 						label={ translate( 'Transfer my domain to WordPress.com' ) }
 						control={ control }
+						rules={ {
+							validate: ( value: string[] ) =>
+								value.length > 0 || translate( 'Please select an option.' ),
+						} }
 					/>
 					<CheckboxIntents
 						value="copy-one-of-my-existing-sites-on-wordpress-com"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-already-wpcom/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-already-wpcom/style.scss
@@ -30,6 +30,10 @@
 	gap: 16px;
 }
 
+.already-wpcom__form-checkbox-control {
+	margin: 8px 0;
+}
+
 .already-wpcom__form .components-checkbox-control__label {
 	font-size: 0.875rem;
 	font-weight: 400;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-already-wpcom/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-already-wpcom/test/index.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { logToLogstash } from 'calypso/lib/logstash';
+import wp from 'calypso/lib/wp';
 import SiteMigrationAlreadyWPCOM from '../';
 import { StepProps } from '../../../types';
 import { mockStepProps, renderStep, RenderStepOptions } from '../../test/helpers/index';
@@ -15,6 +16,11 @@ import { mockStepProps, renderStep, RenderStepOptions } from '../../test/helpers
 jest.mock( 'wpcom-proxy-request', () => jest.fn() );
 jest.mock( 'calypso/landing/stepper/hooks/use-site-slug-param' );
 jest.mock( 'calypso/lib/logstash' );
+jest.mock( 'calypso/lib/wp', () => ( {
+	req: {
+		get: jest.fn(),
+	},
+} ) );
 
 const continueButton = () => screen.getByRole( 'button', { name: 'Continue' } );
 const intentByName = ( intent: string ) => screen.getByRole( 'checkbox', { name: intent } );
@@ -30,6 +36,25 @@ describe( 'SiteMigrationAlreadyWPCOM', () => {
 		jest.clearAllMocks();
 		( wpcomRequest as jest.Mock ).mockResolvedValue( { success: true } );
 		( useSiteSlugParam as jest.Mock ).mockReturnValue( 'site-url.wordpress.com' );
+
+		// Mock wp.req.get for site info and domains lookup
+		( wp.req.get as jest.Mock ).mockImplementation( ( { path } ) => {
+			if ( path.includes( '/sites/' ) && path.includes( '/domains' ) ) {
+				return Promise.resolve( {
+					domains: [
+						{
+							domain: 'site-url.wordpress.com',
+							wpcom_domain: true,
+							is_wpcom_staging_domain: false,
+						},
+					],
+				} );
+			}
+			if ( path.includes( '/sites/' ) ) {
+				return Promise.resolve( { ID: 12345 } );
+			}
+			return Promise.resolve( {} );
+		} );
 	} );
 
 	it( 'renders the site domain from the query params', () => {
@@ -89,6 +114,19 @@ describe( 'SiteMigrationAlreadyWPCOM', () => {
 		await userEvent.type( otherDetails(), 'Test Details' );
 		await userEvent.click( continueButton() );
 
+		// First call should be ZenDesk ticket creation
+		expect( wpcomRequest ).toHaveBeenCalledWith( {
+			path: '/help/migration-ticket/new',
+			apiNamespace: 'wpcom/v2',
+			method: 'POST',
+			body: {
+				locale: 'en',
+				from_url: 'https://example.com',
+				blog_url: 'site-url.wordpress.com',
+			},
+		} );
+
+		// Second call should be survey submission
 		expect( wpcomRequest ).toHaveBeenCalledWith( {
 			path: '/sites/site-url.wordpress.com/automated-migration/wpcom-survey',
 			apiNamespace: 'wpcom/v2',
@@ -107,11 +145,62 @@ describe( 'SiteMigrationAlreadyWPCOM', () => {
 		expect( navigation.submit ).toHaveBeenCalled();
 	} );
 
-	it( 'shows error when something goes wrong in submission', async () => {
+	it( 'shows error when wpcom subdomain lookup fails', async () => {
 		const navigation = { submit: jest.fn() };
 		render( { navigation }, { initialEntry: '/some-path?from=https://example.com' } );
 
-		( wpcomRequest as jest.Mock ).mockRejectedValue( new Error( 'Some error message' ) );
+		( wp.req.get as jest.Mock ).mockRejectedValue( new Error( 'Site lookup error' ) );
+
+		await userEvent.click( intentByName( 'Transfer my domain to WordPress.com' ) );
+		await userEvent.click( continueButton() );
+
+		expect( await screen.findByText( /Something went wrong. Please try again./ ) ).toBeVisible();
+		expect( logToLogstash ).toHaveBeenCalledWith( {
+			message: 'Error submitting migration survey',
+			feature: 'calypso_client',
+			extra: {
+				siteSlug: 'site-url.wordpress.com',
+				step: 'site-migration-already-wpcom',
+				from: 'https://example.com',
+				error: 'Site lookup error',
+			},
+		} );
+
+		expect( navigation.submit ).not.toHaveBeenCalled();
+	} );
+
+	it( 'shows error when ZenDesk ticket creation fails', async () => {
+		const navigation = { submit: jest.fn() };
+		render( { navigation }, { initialEntry: '/some-path?from=https://example.com' } );
+
+		( wpcomRequest as jest.Mock ).mockRejectedValue( new Error( 'ZenDesk error' ) );
+
+		await userEvent.click( intentByName( 'Transfer my domain to WordPress.com' ) );
+		await userEvent.click( continueButton() );
+
+		expect( await screen.findByText( /Something went wrong. Please try again./ ) ).toBeVisible();
+		expect( logToLogstash ).toHaveBeenCalledWith( {
+			message: 'Error submitting migration survey',
+			feature: 'calypso_client',
+			extra: {
+				siteSlug: 'site-url.wordpress.com',
+				step: 'site-migration-already-wpcom',
+				from: 'https://example.com',
+				error: 'ZenDesk error',
+			},
+		} );
+
+		expect( navigation.submit ).not.toHaveBeenCalled();
+	} );
+
+	it( 'shows error when survey submission fails', async () => {
+		const navigation = { submit: jest.fn() };
+		render( { navigation }, { initialEntry: '/some-path?from=https://example.com' } );
+
+		// First call (ZenDesk ticket) succeeds, second call (survey) fails
+		( wpcomRequest as jest.Mock )
+			.mockResolvedValueOnce( { success: true } )
+			.mockRejectedValueOnce( new Error( 'Survey error' ) );
 
 		await userEvent.click( intentByName( 'Transfer my domain to WordPress.com' ) );
 		await userEvent.click( intentByName( 'Other' ) );
@@ -120,13 +209,13 @@ describe( 'SiteMigrationAlreadyWPCOM', () => {
 
 		expect( await screen.findByText( /Something went wrong. Please try again./ ) ).toBeVisible();
 		expect( logToLogstash ).toHaveBeenCalledWith( {
-			message: 'Error submitting migration ticket',
+			message: 'Error submitting migration survey',
 			feature: 'calypso_client',
 			extra: {
 				siteSlug: 'site-url.wordpress.com',
 				step: 'site-migration-already-wpcom',
 				from: 'https://example.com',
-				error: 'Some error message',
+				error: 'Survey error',
 			},
 		} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-already-wpcom/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-already-wpcom/test/index.tsx
@@ -8,7 +8,6 @@ import React from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { logToLogstash } from 'calypso/lib/logstash';
-import wp from 'calypso/lib/wp';
 import SiteMigrationAlreadyWPCOM from '../';
 import { StepProps } from '../../../types';
 import { mockStepProps, renderStep, RenderStepOptions } from '../../test/helpers/index';
@@ -16,11 +15,6 @@ import { mockStepProps, renderStep, RenderStepOptions } from '../../test/helpers
 jest.mock( 'wpcom-proxy-request', () => jest.fn() );
 jest.mock( 'calypso/landing/stepper/hooks/use-site-slug-param' );
 jest.mock( 'calypso/lib/logstash' );
-jest.mock( 'calypso/lib/wp', () => ( {
-	req: {
-		get: jest.fn(),
-	},
-} ) );
 
 const continueButton = () => screen.getByRole( 'button', { name: 'Continue' } );
 const intentByName = ( intent: string ) => screen.getByRole( 'checkbox', { name: intent } );
@@ -36,25 +30,6 @@ describe( 'SiteMigrationAlreadyWPCOM', () => {
 		jest.clearAllMocks();
 		( wpcomRequest as jest.Mock ).mockResolvedValue( { success: true } );
 		( useSiteSlugParam as jest.Mock ).mockReturnValue( 'site-url.wordpress.com' );
-
-		// Mock wp.req.get for site info and domains lookup
-		( wp.req.get as jest.Mock ).mockImplementation( ( { path } ) => {
-			if ( path.includes( '/sites/' ) && path.includes( '/domains' ) ) {
-				return Promise.resolve( {
-					domains: [
-						{
-							domain: 'site-url.wordpress.com',
-							wpcom_domain: true,
-							is_wpcom_staging_domain: false,
-						},
-					],
-				} );
-			}
-			if ( path.includes( '/sites/' ) ) {
-				return Promise.resolve( { ID: 12345 } );
-			}
-			return Promise.resolve( {} );
-		} );
 	} );
 
 	it( 'renders the site domain from the query params', () => {
@@ -143,30 +118,6 @@ describe( 'SiteMigrationAlreadyWPCOM', () => {
 		} );
 
 		expect( navigation.submit ).toHaveBeenCalled();
-	} );
-
-	it( 'shows error when wpcom subdomain lookup fails', async () => {
-		const navigation = { submit: jest.fn() };
-		render( { navigation }, { initialEntry: '/some-path?from=https://example.com' } );
-
-		( wp.req.get as jest.Mock ).mockRejectedValue( new Error( 'Site lookup error' ) );
-
-		await userEvent.click( intentByName( 'Transfer my domain to WordPress.com' ) );
-		await userEvent.click( continueButton() );
-
-		expect( await screen.findByText( /Something went wrong. Please try again./ ) ).toBeVisible();
-		expect( logToLogstash ).toHaveBeenCalledWith( {
-			message: 'Error submitting migration survey',
-			feature: 'calypso_client',
-			extra: {
-				siteSlug: 'site-url.wordpress.com',
-				step: 'site-migration-already-wpcom',
-				from: 'https://example.com',
-				error: 'Site lookup error',
-			},
-		} );
-
-		expect( navigation.submit ).not.toHaveBeenCalled();
 	} );
 
 	it( 'shows error when ZenDesk ticket creation fails', async () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -1,5 +1,6 @@
 import { formatNumber } from '@automattic/number-formatters';
 import { Step } from '@automattic/onboarding';
+import { useQueryClient } from '@tanstack/react-query';
 import { next, published, shield } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { type FC, useEffect, useState, useCallback } from 'react';
@@ -10,6 +11,7 @@ import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-q
 import { useHostingProviderQuery } from 'calypso/data/site-profiler/use-hosting-provider-query';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { urlToDomain } from 'calypso/lib/url';
 import { ChecklistCard } from '../../components/checklist-card';
 import { useSitePreviewMShotImageHandler } from '../site-migration-instructions/site-preview/hooks/use-site-preview-mshot-image-handler';
@@ -20,7 +22,7 @@ import './style.scss';
 
 interface Props {
 	hasError?: boolean;
-	onComplete: ( siteInfo: UrlData, hostingProviderSlug?: string ) => void;
+	onComplete: ( siteInfo: UrlData, hostingProviderSlug?: string, isWpcom?: boolean ) => void;
 	onSkip: () => void;
 	hideImporterListLink: boolean;
 	flowName: string;
@@ -35,6 +37,7 @@ export const Analyzer: FC< Props > = ( {
 } ) => {
 	const translate = useTranslate();
 	const [ siteURL, setSiteURL ] = useState< string >( '' );
+	const queryClient = useQueryClient();
 	const {
 		data: siteInfo,
 		isError: hasError,
@@ -56,10 +59,23 @@ export const Analyzer: FC< Props > = ( {
 		isFetchingHosting ||
 		( isFetched && ! hasError && ! hostingProviderData && ! hasHostingError );
 
+	// Handle completion - pass wpcom flag to let flow handle navigation
 	useEffect( () => {
-		// Only complete when we have both site info AND hosting info (or hosting check failed)
 		if ( siteInfo && ( hostingProviderData || hasHostingError ) ) {
-			onComplete( siteInfo, hostingProviderData?.hosting_provider?.slug );
+			const isWpcomSite = siteInfo?.platform_data?.is_wpcom === true;
+
+			// Track wpcom detection
+			if ( isWpcomSite ) {
+				recordTracksEvent( 'calypso_migration_wpcom_site_detected', {
+					site_url: siteInfo.url,
+					step: 'identify',
+					is_wpcom: siteInfo.platform_data?.is_wpcom ?? false,
+					is_wpengine: siteInfo.platform_data?.is_wpengine ?? false,
+					is_pressable: siteInfo.platform_data?.is_pressable ?? false,
+				} );
+			}
+
+			onComplete( siteInfo, hostingProviderData?.hosting_provider?.slug, isWpcomSite );
 		}
 	}, [ onComplete, siteInfo, hostingProviderData, hasHostingError ] );
 
@@ -103,7 +119,13 @@ export const Analyzer: FC< Props > = ( {
 			<div className="import__capture-container">
 				<CaptureInput
 					onInputEnter={ setSiteURL }
-					onInputChange={ () => setSiteURL( '' ) }
+					onInputChange={ () => {
+						// Invalidate previous query to ensure fresh fetch
+						if ( siteURL ) {
+							queryClient.removeQueries( { queryKey: [ 'analyze-url-', siteURL ] } );
+						}
+						setSiteURL( '' );
+					} }
 					hasError={ hasError }
 					skipInitialChecking
 					onDontHaveSiteAddressClick={ onSkip }
@@ -124,7 +146,10 @@ export const Analyzer: FC< Props > = ( {
 	);
 };
 
-export type SiteMigrationIdentifyAction = 'continue' | 'skip_platform_identification';
+export type SiteMigrationIdentifyAction =
+	| 'continue'
+	| 'skip_platform_identification'
+	| 'already-wpcom';
 
 const SiteMigrationIdentify: StepType< {
 	submits:
@@ -163,9 +188,13 @@ const SiteMigrationIdentify: StepType< {
 
 	const stepContent = (
 		<Analyzer
-			onComplete={ ( { platform, url }, hostingProviderSlug ) =>
-				handleSubmit( 'continue', { platform, from: url, host: hostingProviderSlug } )
-			}
+			onComplete={ ( { platform, url }, hostingProviderSlug, isWpcom ) => {
+				if ( isWpcom ) {
+					handleSubmit( 'already-wpcom', { platform, from: url, host: hostingProviderSlug } );
+				} else {
+					handleSubmit( 'continue', { platform, from: url, host: hostingProviderSlug } );
+				}
+			} }
 			hideImporterListLink={ urlQueryParams.get( 'hide_importer_link' ) === 'true' }
 			onSkip={ () => {
 				handleSubmit( 'skip_platform_identification' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
@@ -5,10 +5,11 @@ import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
-import SiteMigrationIdentify from '..';
+import SiteMigrationIdentify, { Analyzer } from '..';
 import { UrlData } from '../../../../../../../blocks/import/types';
 import { StepProps } from '../../../types';
 import { RenderStepOptions, mockStepProps, renderStep } from '../../test/helpers';
+import { createNonWpcomUrlData, createWpcomUrlData } from './test-utils/fixtures';
 
 jest.mock( 'calypso/landing/stepper/declarative-flow/internals/state-manager/store', () => ( {
 	useFlowState: jest.fn( () => ( {
@@ -204,5 +205,174 @@ describe( 'SiteMigrationIdentify', () => {
 
 		expect( screen.queryByRole( 'button', { name: /Back/ } ) ).not.toBeInTheDocument();
 		expect( screen.queryByRole( 'link', { name: /Back/ } ) ).not.toBeInTheDocument();
+	} );
+} );
+
+describe( 'SiteMigrationIdentify - wpcom detection', () => {
+	beforeAll( () => nock.disableNetConnect() );
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should call onComplete with isWpcom=true for wpcom sites', async () => {
+		const mockSiteInfo = createWpcomUrlData();
+		const mockOnComplete = jest.fn();
+
+		mockApi()
+			.get( '/wpcom/v2/imports/analyze-url' )
+			.query( { site_url: mockSiteInfo.url } )
+			.reply( 200, mockSiteInfo );
+
+		mockApi()
+			.get( '/wpcom/v2/sites/mysite.wordpress.com/hosting-provider' )
+			.reply( 404, { error: 'Not found' } );
+
+		const { getByLabelText, getByRole } = renderStep(
+			<Analyzer
+				onComplete={ mockOnComplete }
+				onSkip={ jest.fn() }
+				onVisibilityChange={ jest.fn() }
+				hideImporterListLink={ false }
+				flowName="site-migration"
+			/>
+		);
+
+		await userEvent.type( getByLabelText( /Site address/ ), mockSiteInfo.url );
+		await userEvent.click( getByRole( 'button', { name: /Check my site/ } ) );
+
+		await waitFor( () => {
+			expect( mockOnComplete ).toHaveBeenCalledWith( mockSiteInfo, undefined, true );
+		} );
+	} );
+
+	it( 'should call onComplete with isWpcom=false for non-wpcom sites', async () => {
+		const mockSiteInfo = createNonWpcomUrlData();
+		const mockOnComplete = jest.fn();
+
+		mockApi()
+			.get( '/wpcom/v2/imports/analyze-url' )
+			.query( { site_url: mockSiteInfo.url } )
+			.reply( 200, mockSiteInfo );
+
+		mockApi()
+			.get( `/wpcom/v2/sites/${ encodeURIComponent( mockSiteInfo.url ) }/hosting-provider` )
+			.reply( 404 );
+
+		const { getByLabelText, getByText } = renderStep(
+			<Analyzer
+				onComplete={ mockOnComplete }
+				onSkip={ jest.fn() }
+				onVisibilityChange={ jest.fn() }
+				hideImporterListLink={ false }
+				flowName="site-migration"
+			/>
+		);
+
+		await userEvent.type( getByLabelText( /Site address/ ), mockSiteInfo.url );
+		await userEvent.click( getByText( 'Check my site' ) );
+
+		await waitFor( () => {
+			expect( mockOnComplete ).toHaveBeenCalledWith( mockSiteInfo, undefined, false );
+		} );
+	} );
+
+	it( 'submits with already-wpcom action when wpcom site detected', async () => {
+		const mockSiteInfo = createWpcomUrlData();
+		const submit = jest.fn();
+
+		mockApi()
+			.get( '/wpcom/v2/imports/analyze-url' )
+			.query( { site_url: mockSiteInfo.url } )
+			.reply( 200, mockSiteInfo );
+
+		mockApi()
+			.get( '/wpcom/v2/sites/mysite.wordpress.com/hosting-provider' )
+			.reply( 404, { error: 'Not found' } );
+
+		render( { navigation: { submit } } );
+
+		await userEvent.type( getInput(), mockSiteInfo.url );
+		await userEvent.click( screen.getByRole( 'button', { name: /Check my site/ } ) );
+
+		await waitFor( () => {
+			expect( submit ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					action: 'already-wpcom',
+					from: mockSiteInfo.url,
+				} )
+			);
+		} );
+	} );
+
+	it( 'should prioritize errors over wpcom detection', async () => {
+		const mockOnComplete = jest.fn();
+
+		mockApi()
+			.get( '/wpcom/v2/imports/analyze-url' )
+			.query( { site_url: 'invalid-url' } )
+			.reply( 400, { error: 'invalid_url' } );
+
+		const { getByLabelText, getByText, getByRole } = renderStep(
+			<Analyzer
+				onComplete={ mockOnComplete }
+				onSkip={ jest.fn() }
+				onVisibilityChange={ jest.fn() }
+				hideImporterListLink={ false }
+				flowName="site-migration"
+			/>
+		);
+
+		await userEvent.type( getByLabelText( /Site address/ ), 'invalid-url' );
+		await userEvent.click( getByText( 'Check my site' ) );
+
+		// Should show error
+		await waitFor( () => {
+			expect( getByRole( 'alert' ) ).toBeVisible();
+		} );
+
+		expect( mockOnComplete ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should track analytics when wpcom site detected', async () => {
+		const mockSiteInfo = createWpcomUrlData();
+		const mockOnComplete = jest.fn();
+		const recordTracksEventSpy = jest.spyOn(
+			require( 'calypso/lib/analytics/tracks' ),
+			'recordTracksEvent'
+		);
+
+		mockApi()
+			.get( '/wpcom/v2/imports/analyze-url' )
+			.query( { site_url: mockSiteInfo.url } )
+			.reply( 200, mockSiteInfo );
+
+		mockApi()
+			.get( `/wpcom/v2/sites/${ encodeURIComponent( mockSiteInfo.url ) }/hosting-provider` )
+			.reply( 404 );
+
+		const { getByLabelText, getByText } = renderStep(
+			<Analyzer
+				onComplete={ mockOnComplete }
+				onSkip={ jest.fn() }
+				onVisibilityChange={ jest.fn() }
+				hideImporterListLink={ false }
+				flowName="site-migration"
+			/>
+		);
+
+		await userEvent.type( getByLabelText( /Site address/ ), mockSiteInfo.url );
+		await userEvent.click( getByText( 'Check my site' ) );
+
+		await waitFor( () => {
+			expect( recordTracksEventSpy ).toHaveBeenCalledWith(
+				'calypso_migration_wpcom_site_detected',
+				expect.objectContaining( {
+					site_url: mockSiteInfo.url,
+					step: 'identify',
+				} )
+			);
+		} );
+
+		recordTracksEventSpy.mockRestore();
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/test-utils/fixtures.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/test-utils/fixtures.ts
@@ -1,0 +1,28 @@
+import type { UrlData } from 'calypso/blocks/import/types';
+
+export const createMockUrlData = ( overrides?: Partial< UrlData > ): UrlData => ( {
+	url: 'https://example.com',
+	platform: 'wordpress' as const,
+	platform_data: {
+		is_wpcom: false,
+		is_wpengine: false,
+		is_pressable: false,
+	},
+	meta: {
+		title: 'Test Site',
+		favicon: null,
+	},
+	...overrides,
+} );
+
+export const createWpcomUrlData = ( url = 'https://mysite.wordpress.com' ): UrlData =>
+	createMockUrlData( {
+		url,
+		platform_data: { is_wpcom: true, is_wpengine: false, is_pressable: false },
+	} );
+
+export const createNonWpcomUrlData = ( url = 'https://example.com' ): UrlData =>
+	createMockUrlData( {
+		url,
+		platform_data: { is_wpcom: false, is_wpengine: false, is_pressable: false },
+	} );

--- a/test/e2e/specs/tools/import__sites-wordpress.spec.ts
+++ b/test/e2e/specs/tools/import__sites-wordpress.spec.ts
@@ -60,7 +60,7 @@ test.describe(
 			pageImportContentWordpressQuestion,
 			sitePublic,
 		} ) => {
-			const wordpressSiteURL = 'https://test.wordpress.com/';
+			const wordpressSiteURL = 'https://test.wordpress.org/';
 
 			await test.step( 'When I visit the "Let\'s find your site" page as coming from the wp-admin Tools > Import page', async function () {
 				await pageImportLetsFindYourSite.visit( sitePublic.blog_details.site_slug );
@@ -114,7 +114,7 @@ test.describe(
 			pageImportContentWordpressQuestion,
 			sitePublic,
 		} ) => {
-			const wordpressSiteURL = 'https://test.wordpress.com/';
+			const wordpressSiteURL = 'https://test.wordpress.org/';
 
 			await test.step( 'When I visit the "Import Content" page for my new site', async function () {
 				await pageImportContent.visit( sitePublic.blog_details.site_slug );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCON-105

## Proposed Changes

Follow-up to #108408 with an additional change to fix an import E2E test.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

See #108408

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
