### PR TITLE
Fix full-width flash on Discover tags navigation initial load

### DIFF
--- a/client/reader/discover/components/tags-navigation/index.tsx
+++ b/client/reader/discover/components/tags-navigation/index.tsx
@@ -26,21 +26,23 @@ export const useRecommendedTags = (): Tag[] => {
 	const locale = useLocale();
 	const translate = useTranslate();
 
+	const promptSlug = isBloganuary() ? 'bloganuary' : 'dailyprompt';
+	const promptTitle = isBloganuary() ? translate( 'Bloganuary' ) : translate( 'Daily prompts' );
+
 	const { data: interestTags = [] } = useQuery< InterestResponse, unknown, Tag[] >( {
 		queryKey: [ 'read/interests', locale ],
 		queryFn: () =>
 			wpcom.req.get( { path: '/read/interests', apiNamespace: 'wpcom/v2' }, { _locale: locale } ),
-		select: ( data ) => data.interests,
+		select: ( data ) => {
+			const tags = data.interests;
+			// Add dailyprompt to the front of tags if not present.
+			const hasPromptTab = tags.some( ( tag ) => tag.slug === promptSlug );
+			if ( ! hasPromptTab ) {
+				return [ { title: promptTitle, slug: promptSlug }, ...tags ];
+			}
+			return tags;
+		},
 	} );
-
-	const promptSlug = isBloganuary() ? 'bloganuary' : 'dailyprompt';
-	const promptTitle = isBloganuary() ? translate( 'Bloganuary' ) : translate( 'Daily prompts' );
-
-	// Add dailyprompt to the front of interestTags if not present.
-	const hasPromptTab = interestTags.filter( ( tag ) => tag.slug === promptSlug ).length;
-	if ( ! hasPromptTab ) {
-		interestTags.unshift( { title: promptTitle, slug: promptSlug } );
-	}
 
 	return interestTags;
 };


### PR DESCRIPTION
Fixes READ-422

## Proposed Changes

* Move the "prepend Daily Prompts tab" logic from the component body into `useQuery`'s `select` transform in `useRecommendedTags`.

## Why are these changes being made?

When `useRecommendedTags` first renders, the query data is `[]` (empty). The old code ran `interestTags.unshift(...)` on every render, so on the initial render it produced an array with a single "Daily prompts" tab. That single tab rendered at full width inside `ScrollableHorizontalNavigation` / `SegmentedControl`, causing a visible flash before the real tags loaded and the layout corrected itself.

By moving the prepend logic into `select`, the prompt tab is only added once actual API data arrives, so the component never renders with a single stretched tab.

## Testing Instructions

* Visit https://wordpress.com/discover/tags?selectedTag=dailyprompt
* On initial page load, observe that the first tag ("Daily prompts") no longer briefly stretches to full width before the other tags appear.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?