### PR TITLE
Fix Reader search posts disappearing due to missing site.posts

### DIFF
--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -96,7 +96,7 @@ function createStreamDataFromPosts( posts, dateProperty ) {
 }
 
 function createStreamItemFromSite( site, dateProperty ) {
-	const post = site.posts[ 0 ] ?? null;
+	const post = site.posts?.[ 0 ] ?? null;
 	if ( ! post ) {
 		return null;
 	}
@@ -133,7 +133,7 @@ function createStreamDataFromSites( sites, dateProperty ) {
 			streamItems.push( streamItem );
 		}
 
-		const post = site.posts[ 0 ];
+		const post = site.posts?.[ 0 ];
 		if ( post !== undefined ) {
 			streamPosts.push( post );
 		}

--- a/client/state/data-layer/wpcom/read/streams/test/index.js
+++ b/client/state/data-layer/wpcom/read/streams/test/index.js
@@ -308,4 +308,91 @@ describe( 'streams', () => {
 			] );
 		} );
 	} );
+
+	describe( 'handlePage with sites data (custom_recs_sites_with_images)', () => {
+		const makeSiteAction = () =>
+			deepfreeze( requestPageAction( { streamKey: 'custom_recs_sites_with_images', page: 1 } ) );
+
+		it( 'should not throw when a site is missing the posts property', () => {
+			const siteAction = makeSiteAction();
+			const siteData = deepfreeze( { sites: [ { blog_ID: 1 } ] } );
+			expect( () => handlePage( siteAction, siteData ) ).not.toThrow();
+		} );
+
+		const findReceivePageAction = ( result ) =>
+			result.find( ( a ) => typeof a === 'object' && a.type === 'READER_STREAMS_PAGE_RECEIVE' );
+
+		it( 'should skip sites with missing posts and return empty stream items', () => {
+			const siteAction = makeSiteAction();
+			const siteData = deepfreeze( { sites: [ { blog_ID: 1 } ] } );
+			const result = handlePage( siteAction, siteData );
+			const receivePageAction = findReceivePageAction( result );
+			expect( receivePageAction.payload.streamItems ).toEqual( [] );
+		} );
+
+		it( 'should skip sites with an empty posts array', () => {
+			const siteAction = makeSiteAction();
+			const siteData = deepfreeze( { sites: [ { blog_ID: 1, posts: [] } ] } );
+			const result = handlePage( siteAction, siteData );
+			const receivePageAction = findReceivePageAction( result );
+			expect( receivePageAction.payload.streamItems ).toEqual( [] );
+		} );
+
+		it( 'should create stream items from sites with valid posts', () => {
+			const siteAction = makeSiteAction();
+			const siteData = deepfreeze( {
+				sites: [
+					{
+						blog_ID: 1,
+						name: 'Test Site',
+						description: 'A test',
+						icon: { ico: 'icon.png' },
+						posts: [
+							{
+								ID: 10,
+								site_ID: 1,
+								date: '2026-01-01',
+								URL: 'https://example.com/post',
+								feed_ID: 100,
+								feed_URL: 'https://example.com/feed',
+							},
+						],
+					},
+				],
+			} );
+			const result = handlePage( siteAction, siteData );
+			const receivePageAction = findReceivePageAction( result );
+			expect( receivePageAction.payload.streamItems ).toHaveLength( 1 );
+			expect( receivePageAction.payload.streamItems[ 0 ] ).toMatchObject( {
+				postId: 10,
+				date: '2026-01-01',
+				url: 'https://example.com/post',
+				site_name: 'Test Site',
+				site_icon: 'icon.png',
+			} );
+		} );
+
+		it( 'should handle a mix of sites with and without posts', () => {
+			const siteAction = makeSiteAction();
+			const siteData = deepfreeze( {
+				sites: [
+					{
+						blog_ID: 1,
+						name: 'Valid Site',
+						posts: [ { ID: 10, site_ID: 1, date: '2026-01-01', URL: 'https://example.com/a' } ],
+					},
+					{ blog_ID: 2, name: 'No Posts Property' },
+					{ blog_ID: 3, name: 'Empty Posts', posts: [] },
+					{
+						blog_ID: 4,
+						name: 'Another Valid Site',
+						posts: [ { ID: 20, site_ID: 4, date: '2026-01-02', URL: 'https://example.com/b' } ],
+					},
+				],
+			} );
+			const result = handlePage( siteAction, siteData );
+			const receivePageAction = findReceivePageAction( result );
+			expect( receivePageAction.payload.streamItems ).toHaveLength( 2 );
+		} );
+	} );
 } );


### PR DESCRIPTION
See READ-421

## Proposed Changes

* Add optional chaining (`site.posts?.[ 0 ]`) in `createStreamItemFromSite` and `createStreamDataFromSites` to guard against site objects missing the `posts` property.

## Why are these changes being made?

The `/read/recommendations/sites` API (used by the `custom_recs_sites_with_images` stream) sometimes returns site objects without a `posts` property. When this happens, accessing `site.posts[0]` throws a `TypeError`, which propagates as `stream.error` and replaces the entire Reader search post list with an error state — making posts randomly disappear.

This client-side fix makes the code resilient to the missing data by gracefully skipping sites without posts. We'll also deploy a change on the API side for added goodness, to ensure site objects always include a `posts` array (even if empty).

## Testing Instructions

* Go to https://wordpress.com/reader/search
* Observe that posts load and remain visible
* Previously, posts would intermittently disappear when the recommendations API returned sites without a `posts` property

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?