### PR TITLE
Domain-Only Flow: Redirect to site home if the user chooses to create a site for the domain

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -107,7 +107,7 @@ function getLaunchDestination( dependencies ) {
 	return addQueryArgs( { celebrateLaunch: 'true' }, `/home/${ dependencies.siteSlug }` );
 }
 
-function getDomainSignupFlowDestination( { siteId, designType, siteSlug } ) {
+function getDomainSignupFlowDestination( { designType, siteSlug } ) {
 	const dashboardType = new URLSearchParams( window.location.search ).get( 'dashboard' );
 
 	// This designType represents a new site.
@@ -116,7 +116,7 @@ function getDomainSignupFlowDestination( { siteId, designType, siteSlug } ) {
 			return dashboardLink( `/sites/${ siteSlug }/domains` );
 		}
 
-		return addQueryArgs( { siteId }, '/start/setup-site' );
+		return `/home/${ siteSlug }`;
 	} else if ( designType === 'existing-site' ) {
 		if ( dashboardType ) {
 			return dashboardLink( `/sites/${ siteSlug }/domains` );


### PR DESCRIPTION
Part of DATSCI-1169.

# Proposed Changes
* In the domain-only signup flow, when a user selects "create a new site" for their domain, redirect them to `/home/:siteSlug` instead of re-entering the site setup flow.

## Why are these changes being made?
* The previous redirect sent users back to `/start/setup-site`, which is unnecessary after they've already gone through the domain signup flow. Sending them to the site home provides a cleaner post-purchase experience.

## Testing Instructions
1. Start the domain-only signup flow (e.g. `/start/domain`).
2. Proceed through until the step where you choose what to do with the domain.
3. Select the option to **create a new site** for the domain and complete the flow. Pick the free plan and also a paid one.
4. Verify that you land on `/home/:siteSlug` instead of being redirected to the site setup wizard.
