### PR TITLE
Fire page view event when switching tabs within Calypso dashboard site settings

### DIFF
--- a/client/dashboard/app/analytics/super-props.ts
+++ b/client/dashboard/app/analytics/super-props.ts
@@ -2,7 +2,7 @@ import { siteBySlugQuery, sitesQueryKey } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import type { User, Site } from '@automattic/api-core';
 import type { QueryClient } from '@tanstack/react-query';
-import type { AnyRouter } from '@tanstack/react-router';
+import type { AnyRouter, RouterState } from '@tanstack/react-router';
 
 export const getSuperProps = ( user: User, router: AnyRouter, queryClient: QueryClient ) => () => {
 	const superProps = {
@@ -42,9 +42,8 @@ export const getSuperProps = ( user: User, router: AnyRouter, queryClient: Query
 /**
  * Normalize the path by removing leading double slashes and trailing slashes.
  */
-export function getNormalizedPath( router: AnyRouter ) {
-	const leafMatch = router.state.matches.at( -1 );
-	const basePath = router.basepath ?? '';
+export function getNormalizedPath( matches: RouterState[ 'matches' ], basePath = '' ) {
+	const leafMatch = matches.at( -1 );
 	const routeId = leafMatch?.routeId ?? '';
 
 	const normalizedBasePath = basePath.endsWith( '/' ) ? basePath.slice( 0, -1 ) : basePath;

--- a/client/dashboard/app/layout.tsx
+++ b/client/dashboard/app/layout.tsx
@@ -45,7 +45,7 @@ function AnalyticsProviderWithClient( {
 	const analyticsClient: AnalyticsClient = useMemo(
 		() => ( {
 			recordTracksEvent( eventName, properties ) {
-				const path = getNormalizedPath( router );
+				const path = getNormalizedPath( router.state.matches, router.basepath );
 				recordTracksEvent( eventName, {
 					path,
 					...properties,

--- a/client/dashboard/components/page-view-tracker/index.tsx
+++ b/client/dashboard/components/page-view-tracker/index.tsx
@@ -1,23 +1,25 @@
-import { useRouter } from '@tanstack/react-router';
-import { useEffect, useRef } from 'react';
+import { useRouter, useRouterState } from '@tanstack/react-router';
+import { useEffect, useMemo, useRef } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { getNormalizedPath } from '../../app/analytics/super-props';
 
 export function PageViewTracker() {
 	const router = useRouter();
+	const { matches: routerMatches, status: routerStatus } = useRouterState();
 	const { recordPageView } = useAnalytics();
 	const lastPath = useRef< string | null >( null );
 
-	useEffect( () => {
-		if ( router.state.status !== 'pending' ) {
-			const path = getNormalizedPath( router );
+	const path = useMemo(
+		() => getNormalizedPath( routerMatches, router.basepath ),
+		[ routerMatches, router.basepath ]
+	);
 
-			if ( path && ( ! lastPath.current || lastPath.current !== path ) ) {
-				recordPageView( path, document.title );
-				lastPath.current = path;
-			}
+	useEffect( () => {
+		if ( routerStatus !== 'pending' && lastPath.current !== path ) {
+			recordPageView( path, document.title );
+			lastPath.current = path;
 		}
-	}, [ router, router.state.status, router.state.location.href, recordPageView ] );
+	}, [ path, recordPageView, routerStatus ] );
 
 	return null;
 }

--- a/client/dashboard/components/page-view-tracker/index.tsx
+++ b/client/dashboard/components/page-view-tracker/index.tsx
@@ -15,7 +15,7 @@ export function PageViewTracker() {
 	);
 
 	useEffect( () => {
-		if ( routerStatus !== 'pending' && lastPath.current !== path ) {
+		if ( routerStatus !== 'pending' && path && lastPath.current !== path ) {
 			recordPageView( path, document.title );
 			lastPath.current = path;
 		}


### PR DESCRIPTION
Closes DATSCI-1170.

## Proposed Changes

Fixes a problem where route changes did not trigger a page view event. This was happening because `router.state` is not reactive. The fix was to use a different hook, `useRouterState`, that subscribes to the state changes within the router, and then uses that information within the hook.

## Testing Instructions

Verify the page_view event tracking is not broken within MSD. Additionally:

1. Enter `/sites/%s/settings` (Calypso dashboard)
2. Verify the page view event for settings gets fired
3. Click the site visibility submenu item
4. Verify the site visibility page view event fired
5. Click the "Settings" menu item (or click the breadcrumb)
6. Verify the page view event for settings gets fired