### PR TITLE
Fix Reader Discover signup URL to use /start/reader flow

### DIFF
--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -78,6 +78,8 @@ const UniversalNavbarHeader = ( {
 			// url
 			sectionName === 'plugins'
 				? localizeUrl( '//wordpress.com/start/business', locale, isLoggedIn )
+				: sectionName === 'reader'
+				? localizeUrl( '//wordpress.com/start/reader', locale, isLoggedIn )
 				: localizeUrl( '//wordpress.com/start', locale, isLoggedIn ),
 			// query
 			sectionName

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -74,19 +74,15 @@ const UniversalNavbarHeader = ( {
 	}, [] );
 
 	if ( ! startUrl ) {
+		const startPaths: Record< string, string > = {
+			plugins: '//wordpress.com/start/business',
+			reader: '//wordpress.com/start/reader',
+		};
+		const startPath = startPaths[ sectionName ] ?? '//wordpress.com/start';
+
 		startUrl = addQueryArgs(
-			// url
-			sectionName === 'plugins'
-				? localizeUrl( '//wordpress.com/start/business', locale, isLoggedIn )
-				: sectionName === 'reader'
-				? localizeUrl( '//wordpress.com/start/reader', locale, isLoggedIn )
-				: localizeUrl( '//wordpress.com/start', locale, isLoggedIn ),
-			// query
-			sectionName
-				? {
-						ref: sectionName + '-lp',
-				  }
-				: {}
+			localizeUrl( startPath, locale, isLoggedIn ),
+			sectionName ? { ref: sectionName + '-lp' } : {}
 		);
 	}
 

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -78,7 +78,7 @@ const UniversalNavbarHeader = ( {
 			plugins: '//wordpress.com/start/business',
 			reader: '//wordpress.com/start/reader',
 		};
-		const startPath = startPaths[ sectionName ] ?? '//wordpress.com/start';
+		const startPath = ( sectionName && startPaths[ sectionName ] ) ?? '//wordpress.com/start';
 
 		startUrl = addQueryArgs(
 			localizeUrl( startPath, locale, isLoggedIn ),


### PR DESCRIPTION
Part of READ-432

## Proposed Changes

* Add `reader` section handling to the `startUrl` logic in the universal header navigation, routing to `/start/reader` instead of the generic `/start` flow.

## Why are these changes being made?

When a logged-out user visits /discover and clicks "Get Started", they are sent to `/start/?ref=reader-lp` — the generic site-building onboarding. This should route to `/start/reader?ref=reader-lp` for the Reader-focused signup flow.

The `startUrl` ternary in the universal header already special-cases `plugins` → `/start/business`. This adds the same pattern for `reader` → `/start/reader`.

## Testing Instructions

1. Visit /discover while logged out
2. Click "Get Started" in the upper right
3. Verify the URL is `/start/reader?ref=reader-lp` (not `/start/?ref=reader-lp`)
4. Confirm other sections (plugins, default) still route correctly

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?