### PR TITLE
Fix conversation history when Unified is enabled

### DIFF
--- a/packages/agents-manager/src/hooks/use-conversation-list.ts
+++ b/packages/agents-manager/src/hooks/use-conversation-list.ts
@@ -1,6 +1,7 @@
 import {
 	listConversationsFromServer,
 	createOdieBotId,
+	isOdieBotId,
 	type ServerConversationListItem,
 } from '@automattic/agenttic-client';
 import { useGetZendeskConversations } from '@automattic/zendesk-client';
@@ -18,7 +19,7 @@ export default function useConversationList() {
 	const { agentId, authProvider } = agentConfig!;
 	const urlSearchParams = new URLSearchParams( window.location.search );
 	const hasAgentParam = urlSearchParams.has( 'agent' );
-	const botId = hasAgentParam ? agentId : createOdieBotId( agentId );
+	const botId = hasAgentParam || isOdieBotId( agentId ) ? agentId : createOdieBotId( agentId );
 	const shouldUseUnifiedAgent = useShouldUseUnifiedAgent();
 
 	// Only fetch Zendesk conversations if the unified agent flag is enabled

--- a/packages/agents-manager/src/hooks/use-conversation.ts
+++ b/packages/agents-manager/src/hooks/use-conversation.ts
@@ -1,6 +1,7 @@
 import {
 	loadAllMessagesFromServer,
 	createOdieBotId,
+	isOdieBotId,
 	type Message,
 } from '@automattic/agenttic-client';
 import { useQuery } from '@tanstack/react-query';
@@ -37,7 +38,7 @@ export default function useConversation( {
 		queryFn: async () => {
 			const urlSearchParams = new URLSearchParams( window.location.search );
 			const hasAgentParam = urlSearchParams.has( 'agent' );
-			const botId = hasAgentParam ? agentId : createOdieBotId( agentId );
+			const botId = hasAgentParam || isOdieBotId( agentId ) ? agentId : createOdieBotId( agentId );
 
 			return await loadAllMessagesFromServer(
 				sessionId,


### PR DESCRIPTION
## Proposed Changes

- Fix 403 error when loading conversation history with the unified chat agent enabled
- `createOdieBotId()` was double-wrapping the unified chat agent ID (`wpcom-workflow-unified_chat`) into an invalid bot ID (`wpcom-agent-wpcom_workflow_unified_chat`), because the function expects a plain slug but the unified agent ID already follows the `{product}-{type}-{slug}` odie bot ID format
- Added `isOdieBotId()` check to skip the transformation when the agent ID is already valid


## Testing Instructions

* Sync the Agents Manager app with your sandbox
* Open a page where the AI Chat appears and click the `History` button - it should load the conversation history

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
