### PR TITLE
Checkout: do not compare renewal price to monthly in sidebar

### DIFF
--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -5,7 +5,6 @@ import {
 	isTriennially,
 	isWpComPlan,
 	isYearly,
-	type PlanSlug,
 } from '@automattic/calypso-products';
 import colorStudio from '@automattic/color-studio';
 import { FormStatus, useFormStatus, Button } from '@automattic/composite-checkout';
@@ -26,7 +25,9 @@ import {
 import styled from '@emotion/styled';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import useEquivalentMonthlyTotals from 'calypso/my-sites/checkout/utils/use-equivalent-monthly-totals';
+import useEquivalentMonthlyTotals, {
+	getOriginalAmountIntegerForDisplay,
+} from 'calypso/my-sites/checkout/utils/use-equivalent-monthly-totals';
 import { useSelector } from 'calypso/state';
 import {
 	getIsOnboardingAffiliateFlow,
@@ -390,8 +391,7 @@ function SingleProductAndCostOverridesList( { product }: { product: ResponseCart
 
 	const monthlyPrices = useEquivalentMonthlyTotals( [ product ] );
 
-	const originalAmountInteger =
-		monthlyPrices[ product.product_slug as PlanSlug ] || product.item_original_subtotal_integer;
+	const originalAmountInteger = getOriginalAmountIntegerForDisplay( product, monthlyPrices );
 	const originalAmountDisplay = formatCurrency( originalAmountInteger, product.currency, {
 		isSmallestUnit: true,
 		stripZeros: true,

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -20,7 +20,6 @@ import {
 	isAkismetProduct,
 	isWooExpressPlan,
 	PLAN_100_YEARS,
-	type PlanSlug,
 } from '@automattic/calypso-products';
 import colorStudio from '@automattic/color-studio';
 import { Gridicon } from '@automattic/components';
@@ -42,7 +41,9 @@ import * as React from 'react';
 import { hasFreeCouponTransfersOnly } from 'calypso/lib/cart-values/cart-items';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
-import useEquivalentMonthlyTotals from 'calypso/my-sites/checkout/utils/use-equivalent-monthly-totals';
+import useEquivalentMonthlyTotals, {
+	getOriginalAmountIntegerForDisplay,
+} from 'calypso/my-sites/checkout/utils/use-equivalent-monthly-totals';
 import { useSelector } from 'calypso/state';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import getAkismetProductFeatures from '../lib/get-akismet-product-features';
@@ -167,8 +168,7 @@ function CheckoutSummaryPriceList() {
 	const monthlyPrices = useEquivalentMonthlyTotals( responseCart.products );
 
 	const subtotalBeforeDiscounts = responseCart.products.reduce( ( subtotal, product ) => {
-		const originalAmountInteger =
-			monthlyPrices[ product.product_slug as PlanSlug ] || product.item_original_subtotal_integer;
+		const originalAmountInteger = getOriginalAmountIntegerForDisplay( product, monthlyPrices );
 		// In specific cases (e.g. premium domains) the original price (renewal) is lower than the due price.
 		return subtotal + Math.max( product.item_subtotal_integer, originalAmountInteger );
 	}, 0 );

--- a/client/my-sites/checkout/utils/use-equivalent-monthly-totals.ts
+++ b/client/my-sites/checkout/utils/use-equivalent-monthly-totals.ts
@@ -58,3 +58,23 @@ export default function useEquivalentMonthlyTotals(
 		[ eligibleProducts, pricing ]
 	);
 }
+
+/**
+ * Returns the original amount integer for a product, used for displaying a crossed-out price.
+ * For renewals, this is always the product's own original subtotal (not the monthly equivalent),
+ * since the monthly comparison is only meaningful for new purchases.
+ *
+ * @param product - The cart product.
+ * @param monthlyPrices - Map of plan slug to equivalent monthly total, from `useEquivalentMonthlyTotals`.
+ */
+export function getOriginalAmountIntegerForDisplay(
+	product: ResponseCartProduct,
+	monthlyPrices: Record< PlanSlug, number >
+): number {
+	if ( product.is_renewal ) {
+		return product.item_original_subtotal_integer;
+	}
+	return (
+		monthlyPrices[ product.product_slug as PlanSlug ] || product.item_original_subtotal_integer
+	);
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/CHE-449/unknownunclear-crossed-out-savings-price-appears-on-manual-renewals-in

## Proposed Changes

This PR stops using the monthly price as a comparison for renewals in the checkout sidebar price summary box.

This only affects manual renewals in checkout, not new purchases.

Before             |  After
:-------------------------:|:-------------------------:
<img width="410" height="289" alt="Screenshot 2026-03-18 at 2 20 36 PM" src="https://github.com/user-attachments/assets/b47a94f5-347c-4288-a36d-2acb7856423d" /> | <img width="408" height="271" alt="Screenshot 2026-03-18 at 2 21 57 PM" src="https://github.com/user-attachments/assets/089b4fef-cf95-4f25-8fff-3ffcb0595059" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The checkout site sidebar price summary box was added as a way to help users understand why they were seeing a given price (originally https://github.com/Automattic/wp-calypso/pull/86360 and https://github.com/Automattic/wp-calypso/pull/87732).

In https://github.com/Automattic/wp-calypso/pull/103022 that was amended to show the price not just compared to its undiscounted version but also compared to the price of the monthly variant of that same product. Even though the comparison is not explained in the sidebar (that's perhaps a separate issue), this works because the main checkout UI column displays the prices of all variants as a list.

However, when a manual renewal of a product is in the cart, this comparison is confusing because there's nothing to compare it to. Since, as mentioned, there's no explanation for this difference, users believe they have misunderstood something.

I think there are two options to fix this: we could either explain the discount in the sidebar, or we could stop showing it for renewals. Since explaining it will require more design work, we're going to just remove it for the time being.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Add a renewal product to your cart and visit checkout.
- Verify that the sidebar does not show a crossed-out price (unless there's another discount like a coupon).
