### PR TITLE
Launch Site: Only open celebration modal after re-fetching the site's domains

### DIFF
--- a/client/my-sites/customer-home/components/home-content/index.jsx
+++ b/client/my-sites/customer-home/components/home-content/index.jsx
@@ -85,7 +85,11 @@ const HomeContent = ( {
 	const { data: layout, isLoading, error: homeLayoutError } = useHomeLayoutQuery( siteId );
 	const { skipCurrentView } = useSkipCurrentViewMutation( siteId );
 
-	const { data: allDomains = [], isSuccess } = useGetDomainsQuery( site?.ID ?? null, {
+	const {
+		data: allDomains = [],
+		isSuccess,
+		isFetchedAfterMount,
+	} = useGetDomainsQuery( site?.ID ?? null, {
 		retry: false,
 	} );
 
@@ -111,10 +115,10 @@ const HomeContent = ( {
 	usePurchasePlanNotification( siteId, site?.plan?.product_slug );
 
 	useEffect( () => {
-		if ( getQueryArgs().celebrateLaunch === 'true' && isSuccess ) {
+		if ( getQueryArgs().celebrateLaunch === 'true' && isSuccess && isFetchedAfterMount ) {
 			setCelebrateLaunchModalIsOpen( true );
 		}
-	}, [ isSuccess ] );
+	}, [ isSuccess, isFetchedAfterMount ] );
 
 	useEffect( () => {
 		if ( ! isSiteLaunching && launchedSiteId === siteId ) {


### PR DESCRIPTION
Closes DATSCI-1171.

## Proposed changes

Fixes a bug where the "Celebrate Launch" modal would show a domain upsell immediately after launching a site, even if the user has purchased a domain, before the site domains query had a chance to re-fetch updated data from the server.

The `CelebrateLaunchModal` uses the domains list to decide whether to show a domain upsell. When the modal opened right after launching, it was reading stale cached data, even though the launch process may have included purchasing a domain.

The fix gates the modal on `isFetchedAfterMount` from `useGetDomainsQuery`, ensuring the modal only renders after the query completes at least one fresh fetch during the current page lifecycle.

## Testing Instructions

1. Create a free site in `/setup/onboarding`
2. Click the "Launch site" button in the site's masterbar
3. Pick a domain, but don't pick a plan (use the escape hatch to continue on the free plan)
4. Purchase the domain

Upon being redirected back to home, verify you see the launched site celebration modal _without_ the domain upsell.

Launch a different site without purchasing a domain, and this time verify you see the domain upsell.