### PR TITLE
webpack persistent cache: Use brotli compression

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -460,6 +460,7 @@ const webpackConfig = {
 					profile: shouldProfile,
 					version: webpackCacheVersion,
 					readonly: shouldUseReadonlyCache,
+					compression: 'brotli',
 				},
 				...( shouldProfile
 					? {


### PR DESCRIPTION
## Proposed Changes

* In the webpack persistent cache, turn on `brotli` compression.

I think it will be overall a win:
* When we build the "Base Image", we ship around a webpack persistent filesystem cache of data. This is currently 3 gigs. This is sent to our docker image repo and other agents pull from it.
* In my tests, both brotli and gzip reduced the size from 3 gigs to around ~900megs without affecting the build time materially. (I was not able to get a "compression added X time" measurement, but the build was "normal' within fluctuations).
* The "Push Images" step on the base image to the repository, takes usually 4 - 4.5 minutes. When testing and using this branch to make a base image, it only took 1.5 minutes.
* The build on this branch from reading the image still took only 5 minutes total.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the "build base images" TC step and kick off a custom build on this branch with parameters customized to have `image_tag=pr-109373-brotli`
* Wait for that to finish
* Go to the "docker image" TC step and kick off a custom build on this branch with parameters customized to have `base_image=example.com/calypso/base:pr-109373-brotli` (with example.com swapped out for our domain name for the docker registry)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
