### PR TITLE
E2E tests: clean up created P2 posts

### DIFF
--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -670,6 +670,35 @@ export class RestAPIClient {
 	}
 
 	/**
+	 * Gets a post by its URL.
+	 *
+	 * @param {number} siteID Target site ID.
+	 * @param {string} postURL URL of the post to retrieve.
+	 */
+	async getPostByURL( siteID: number, postURL: string ): Promise< PostResponse > {
+		const params: RequestParams = {
+			method: 'get',
+			headers: {
+				Authorization: await this.getAuthorizationHeader( 'bearer' ),
+				'Content-Type': this.getContentTypeHeader( 'json' ),
+			},
+		};
+
+		const url = this.getRequestURL( '1.1', `/sites/${ siteID }/post` );
+		url.searchParams.set( 'url', postURL );
+
+		const response = await this.sendRequest( url, params );
+
+		if ( response.hasOwnProperty( 'error' ) ) {
+			throw new Error(
+				`${ ( response as ErrorResponse ).error }: ${ ( response as ErrorResponse ).message }`
+			);
+		}
+
+		return response;
+	}
+
+	/**
 	 * Creates a post on the site.
 	 *
 	 * @param {number} siteID Target site ID.

--- a/test/e2e/specs/p2/p2__post.spec.ts
+++ b/test/e2e/specs/p2/p2__post.spec.ts
@@ -3,12 +3,17 @@ import {
 	P2Page,
 	IsolatedBlockEditorComponent,
 	ParagraphBlock,
+	RestAPIClient,
 } from '@automattic/calypso-e2e';
 import { ElementHandle } from 'playwright';
 import { tags, test } from '../../lib/pw-base';
+import type { TestAccount } from '@automattic/calypso-e2e';
 
 test.describe( 'P2: Post', { tag: [ tags.P2 ] }, () => {
 	const postContent = DataHelper.getTimestamp();
+
+	let publishedPostURL: string | undefined;
+	let accountUsed: TestAccount | undefined;
 
 	test( 'As a P2 user, I can create and publish a post with a paragraph block', async ( {
 		page,
@@ -16,6 +21,7 @@ test.describe( 'P2: Post', { tag: [ tags.P2 ] }, () => {
 	} ) => {
 		await test.step( 'Given I am authenticated as a P2 user', async function () {
 			await accountP2.authenticate( page );
+			accountUsed = accountP2;
 		} );
 
 		await test.step( 'And I navigate to the P2 site', async function () {
@@ -52,6 +58,22 @@ test.describe( 'P2: Post', { tag: [ tags.P2 ] }, () => {
 		await test.step( 'Then the post is published with the expected content', async function () {
 			const p2Page = new P2Page( page );
 			await p2Page.validatePostContent( postContent );
+			publishedPostURL = page.url();
 		} );
+	} );
+
+	test.afterAll( 'Delete the created post', async function () {
+		if ( ! publishedPostURL || ! accountUsed ) {
+			return;
+		}
+
+		const siteID = accountUsed.credentials.testSites?.primary.id;
+		if ( ! siteID ) {
+			return;
+		}
+
+		const restAPIClient = new RestAPIClient( accountUsed.credentials );
+		const post = await restAPIClient.getPostByURL( siteID, publishedPostURL );
+		await restAPIClient.deletePost( siteID, post.ID );
 	} );
 } );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-1775/e2e-tests-clean-up-created-p2-posts

## Proposed Changes

This adds a teardown to clean up the abandoned P2 posts created from the `As a P2 user, I can create and publish a post with a paragraph block` E2E.

## Why are these changes being made?

While working on https://github.com/Automattic/wp-calypso/pull/109079, I ran into some failures related to the `As a P2 user, I can create and publish a post with a paragraph block` test not being able to find a newly published post on p2endtoendtesting At the time, the site had more than 11,000 old posts from the test - likely causing the test to fail from query time, pagination, or something else.

This adds a teardown to the test to clean up the created post.

I also ran a script on the backend to clear out the old posts on the site - down to 2,700 at the time of this comment.
