### PR TITLE
Fix woo-hosted plan downgrade routing to checkout instead of support chat

### DIFF
--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -55,7 +55,7 @@ import { DEFAULT_FLOW, getFlowFromURL, getStepFromURL } from './utils/get-flow-f
 import { startStepperPerformanceTracking } from './utils/performance-tracking';
 import { getSessionId } from './utils/use-session-id';
 import { WindowLocaleEffectManager } from './utils/window-locale-effect-manager';
-import type { CurrentUser, HelpCenterSelect } from '@automattic/data-stores';
+import type { CurrentUser, HelpCenterSelect, HelpCenterDispatch } from '@automattic/data-stores';
 import type { AnyAction } from 'redux';
 import type { WpcomRequestParams } from 'wpcom-proxy-request';
 
@@ -76,10 +76,10 @@ const getSiteIdFromURL = () => {
 };
 
 /**
- * Flows that should not render the Help Center at all. The stepper has no masterbar or help
- * button, so the Help Center can only auto-open from persisted preferences, which is disruptive.
- * Flows that programmatically open the Help Center (e.g., hundred-year-plan, do-it-for-me)
- * should NOT be added to this set.
+ * Flows that should not render the Help Center. The stepper has no masterbar or help button, so
+ * the Help Center can only auto-open from persisted preferences in these flows, which is
+ * disruptive. Flows that programmatically open the Help Center (e.g., hundred-year-plan,
+ * do-it-for-me) should NOT be added to this set.
  */
 const FLOWS_WITHOUT_HELP_CENTER = new Set< string >( [
 	AI_SITE_BUILDER_FLOW,
@@ -236,6 +236,12 @@ async function main() {
 	} else if ( 'useSteps' in flow ) {
 		// V1 flows have to be enhanced by changing their `useSteps` hook.
 		flow = enhanceFlowWithAuth( flow );
+	}
+
+	// Clear any persisted help_center_open preference before React renders so the
+	// isHelpCenterShown resolver won't auto-open the Help Center in this flow.
+	if ( flowName === WOO_HOSTED_PLANS_FLOW ) {
+		( dispatch( HELP_CENTER_STORE ) as HelpCenterDispatch[ 'dispatch' ] ).showHelpCenter( false );
 	}
 
 	const root = createRoot( document.getElementById( 'wpcom' ) as HTMLElement );

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -6,6 +6,7 @@ import {
 	setRequester as setDataStoresRequester,
 	UserActions,
 	User as UserStore,
+	HelpCenter,
 } from '@automattic/data-stores';
 import {
 	AI_SITE_BUILDER_FLOW,
@@ -15,7 +16,7 @@ import {
 	setRequester as setOnboardingRequester,
 } from '@automattic/onboarding';
 import { QueryClientProvider } from '@tanstack/react-query';
-import { dispatch } from '@wordpress/data';
+import { useSelect, dispatch } from '@wordpress/data';
 import defaultCalypsoI18n from 'i18n-calypso';
 import { createRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
@@ -54,7 +55,7 @@ import { DEFAULT_FLOW, getFlowFromURL, getStepFromURL } from './utils/get-flow-f
 import { startStepperPerformanceTracking } from './utils/performance-tracking';
 import { getSessionId } from './utils/use-session-id';
 import { WindowLocaleEffectManager } from './utils/window-locale-effect-manager';
-import type { CurrentUser } from '@automattic/data-stores';
+import type { CurrentUser, HelpCenterSelect } from '@automattic/data-stores';
 import type { AnyAction } from 'redux';
 import type { WpcomRequestParams } from 'wpcom-proxy-request';
 
@@ -75,17 +76,35 @@ const getSiteIdFromURL = () => {
 };
 
 /**
- * Flows that should not render the Help Center. The stepper has no masterbar or help button, so
- * the Help Center can only auto-open from persisted preferences in these flows, which is
- * disruptive. Flows that programmatically open the Help Center (e.g., hundred-year-plan,
- * do-it-for-me) should NOT be added to this set.
+ * Flows that should not render the Help Center at all. The stepper has no masterbar or help
+ * button, so the Help Center can only auto-open from persisted preferences, which is disruptive.
+ * Flows that programmatically open the Help Center (e.g., hundred-year-plan, do-it-for-me)
+ * should NOT be added to this set.
  */
 const FLOWS_WITHOUT_HELP_CENTER = new Set< string >( [
 	AI_SITE_BUILDER_FLOW,
 	AI_SITE_BUILDER_SPEC_FLOW,
 	DOMAIN_FLOW,
-	WOO_HOSTED_PLANS_FLOW,
 ] );
+
+const HELP_CENTER_STORE = HelpCenter.register();
+
+/**
+ * Mounts the Help Center only when programmatically opened. Prevents the disruptive auto-open
+ * from persisted preferences while still allowing on-demand opens (e.g., plan downgrade support).
+ */
+function LazyHelpCenter( { currentUser }: { currentUser: UserStore.CurrentUser } ) {
+	const isHelpCenterShown = useSelect(
+		( select ) => ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).isHelpCenterShown(),
+		[]
+	);
+
+	if ( ! isHelpCenterShown ) {
+		return null;
+	}
+
+	return <AsyncHelpCenterApp currentUser={ currentUser } sectionName="stepper" />;
+}
 
 async function main() {
 	const { pathname, search } = window.location;
@@ -237,13 +256,16 @@ async function main() {
 							id="notices"
 						/>
 					</BrowserRouter>
-					{ ! FLOWS_WITHOUT_HELP_CENTER.has( flowName ) && (
-						<AsyncHelpCenterApp
-							requireLogin
-							currentUser={ user as UserStore.CurrentUser }
-							sectionName="stepper"
-						/>
-					) }
+					{ ! FLOWS_WITHOUT_HELP_CENTER.has( flowName ) &&
+						( flowName === WOO_HOSTED_PLANS_FLOW ? (
+							<LazyHelpCenter currentUser={ user as UserStore.CurrentUser } />
+						) : (
+							<AsyncHelpCenterApp
+								requireLogin
+								currentUser={ user as UserStore.CurrentUser }
+								sectionName="stepper"
+							/>
+						) ) }
 					{ 'development' === process.env.NODE_ENV && (
 						<AsyncLoad require="calypso/components/webpack-build-monitor" placeholder={ null } />
 					) }

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
@@ -265,7 +265,6 @@ function useGenerateActionCallback( {
 			/* 3. In the logged-in plans dashboard, handle plan downgrades and plan downgrade tracks events */
 			if (
 				sitePlanSlug &&
-				! flowName &&
 				intent !== 'plans-p2' &&
 				intent !== 'plans-blog-onboarding' &&
 				! availableForPurchase

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
@@ -10,6 +10,7 @@ import {
 import page from '@automattic/calypso-router';
 import { AddOns, Plans } from '@automattic/data-stores';
 import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
+import { WOO_HOSTED_PLANS_FLOW } from '@automattic/onboarding';
 import { useCanConnectToZendeskMessaging } from '@automattic/zendesk-client';
 import { useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
@@ -265,6 +266,7 @@ function useGenerateActionCallback( {
 			/* 3. In the logged-in plans dashboard, handle plan downgrades and plan downgrade tracks events */
 			if (
 				sitePlanSlug &&
+				( ! flowName || flowName === WOO_HOSTED_PLANS_FLOW ) &&
 				intent !== 'plans-p2' &&
 				intent !== 'plans-blog-onboarding' &&
 				! availableForPurchase


### PR DESCRIPTION
Resolves [SHILL-1723](https://linear.app/a8c/issue/SHILL-1723/plan-downgrade-error-says-upgrade)

## Proposed Changes

* In `use-generate-action-callback.ts`, scope the downgrade handler guard to also allow `WOO_HOSTED_PLANS_FLOW` (`! flowName || flowName === WOO_HOSTED_PLANS_FLOW`), so plan downgrades in the woo-hosted-plans stepper flow route to the downgrade handler (support chat / cancel flow) instead of falling through to checkout.
* In `stepper/index.tsx`, remove `WOO_HOSTED_PLANS_FLOW` from `FLOWS_WITHOUT_HELP_CENTER` and add a `LazyHelpCenter` wrapper that only mounts `AsyncHelpCenterApp` when the store's `isHelpCenterShown` becomes true — allowing on-demand support chat for plan downgrades. Before React renders, `showHelpCenter(false)` is dispatched to clear any persisted `help_center_open` preference so the `isHelpCenterShown` resolver doesn't auto-open the Help Center via stale state.

## Why are these changes being made?

When a CIAB merchant on a Woo Hosted Pro plan clicks "Downgrade" to switch to Basic, the click falls through to `handleUpgradeClick` which sends the plan to checkout. The shopping cart rejects plan-type downgrades, showing a confusing "Sorry, that plan is not a valid upgrade from your current plan" error.

**Root cause 1 — wrong routing:** The `! flowName` guard on the downgrade handler block (added in #92015) prevents `handleDowngradeClick` from firing in any stepper flow. `woo-hosted-plans` is a stepper flow for logged-in users with existing plans, so the guard must allow it. The fix scopes the guard rather than removing it entirely, keeping other stepper flows (e.g. `plan-upgrade`) unaffected.

**Root cause 2 — Help Center not mounted:** `WOO_HOSTED_PLANS_FLOW` was in `FLOWS_WITHOUT_HELP_CENTER` (#108650) to prevent auto-open from persisted preferences. But `handleDowngradeClick` dispatches to the Help Center store, which requires the component to be mounted. The `LazyHelpCenter` wrapper keeps it unmounted on page load (no auto-open) but mounts on demand when opened programmatically. The persisted preference is also cleared before render because the `isHelpCenterShown` resolver would otherwise read a stale `help_center_open=true` and auto-open despite the lazy mount.

| Scenario | Before | After |
|----------|--------|-------|
| Woo Hosted Pro → clicks "Downgrade" to Basic | Falls through to checkout → error | Opens support chat |
| Woo Hosted plans page loads with persisted help_center_open | Help Center auto-opens | Stays closed |
| Plan-upgrade flow user clicks downgrade | Falls through to checkout | Falls through to checkout (unchanged) |
| Signup flow user selects any plan | Goes to checkout | Goes to checkout (unchanged) |

## Testing Instructions

**Environment:**
- [ ] Enable Store Sandbox mode
- [ ] `public-api.wordpress.com` sandboxed

### Bug fix: Woo Hosted downgrade

1. Log into WordPress.com with a CIAB account that has an active **Woo Hosted Pro** plan
2. Navigate to `/setup/woo-hosted-plans/plans?siteSlug={your-site-slug}`
3. Verify that Pro shows "Your plan" and Basic shows "Downgrade"
4. Click "Downgrade" on the Basic plan card
5. Verify that the **help center / support chat opens** instead of navigating to checkout
6. Verify that **no checkout error** appears

### Regression: Woo Hosted upgrade still works

7. Log in with a CIAB account that has an active **Woo Hosted Basic** plan
8. Navigate to `/setup/woo-hosted-plans/plans?siteSlug={your-site-slug}`
9. Click the upgrade button on the Pro plan card
10. Verify that it navigates to `/checkout/{siteSlug}/woo_hosted_pro_plan_yearly` and checkout loads correctly

### Regression: Help Center does not auto-open

11. In another tab, open `wordpress.com/sites` and open the Help Center (click the help button in the masterbar)
12. Navigate to `/setup/woo-hosted-plans/plans?siteSlug={your-site-slug}`
13. Verify that the **Help Center does NOT auto-open** on page load

### Regression: Non-owner buttons on /plans (from #92015)

14. Have two WordPress.com accounts. On Account A's site, purchase a **Premium** or **Business** plan
15. Add Account B as an **admin** on Account A's site
16. Log in as Account B and navigate to `/plans/{site-slug}`
17. Click an **Upgrade** button — verify it opens the **help center / Wapuu** window (not checkout)
18. Click a **Downgrade** button — verify it also opens the **help center / Wapuu** window (not checkout)

### Regression: Signup flows unaffected

19. Open an incognito window and navigate to `/setup/onboarding`
20. Proceed through the onboarding flow to the plans step
21. Select any plan — verify it proceeds to site creation / checkout as expected

### Regression: plan-upgrade flow unaffected

22. Navigate to `/setup/plan-upgrade/plans?siteSlug={your-site-slug}` on a site with an existing plan
23. Click an upgrade plan — verify it navigates to checkout

### Regression: Help Center disabled in other excluded flows

24. Navigate to `/setup/domain`
25. Verify that the Help Center does **not** appear (still excluded via `FLOWS_WITHOUT_HELP_CENTER`)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you checked for TypeScript, React or other console errors?

