### PR TITLE
E2E: fix domain upsell skip plan test

### DIFF
--- a/test/e2e/specs/flows/setup-domain-and-plan__skip-plan.spec.ts
+++ b/test/e2e/specs/flows/setup-domain-and-plan__skip-plan.spec.ts
@@ -12,12 +12,12 @@ test.describe( 'Domain: Upsell (Skip Plan)', { tag: [ tags.CALYPSO_RELEASE ] }, 
 		const siteSlug = accountAtomic.getSiteURL( { protocol: false } );
 		const siteId = accountAtomic.credentials.testSites?.primary?.id as number;
 
-		await test.step( 'Given I clear any stale cart items', async function () {
-			await accountAtomic.restAPI.clearShoppingCart( siteId );
-		} );
-
 		await test.step( `And I am authenticated as '${ accountAtomic.accountName }'`, async function () {
 			await accountAtomic.authenticate( page );
+		} );
+
+		await test.step( 'Given I clear any stale cart items', async function () {
+			await accountAtomic.restAPI.clearShoppingCart( siteId );
 		} );
 
 		await test.step( 'When I navigate to the domain-and-plan flow', async function () {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1778/e2e-fix-domain-upsell-skip-plan-test

## Proposed Changes

This switches the order of operations for the `As a user with a qualifying yearly plan, I skip plan selection and go directly to checkout` to first authenticate as a user before attempting to clear any existing purchases from the cart.

Split from https://github.com/Automattic/wp-calypso/pull/109079