### PR TITLE
Image Studio: Improve CIAB compatibility

### DIFF
--- a/packages/image-studio/src/components/canvas-controls/style.scss
+++ b/packages/image-studio/src/components/canvas-controls/style.scss
@@ -69,6 +69,19 @@
 	.agents-manager-feedback-input {
 		width: 300px;
 
+		.components-base-control__label {
+			color: var( --color-muted-foreground );
+		}
+
+		.components-button.is-tertiary {
+			color: var( --color-muted-foreground );
+
+			&:hover,
+			&:focus {
+				color: var( --color-foreground );
+			}
+		}
+
 		&,
 		&__inner {
 			margin: 0;

--- a/packages/image-studio/src/components/header/style.scss
+++ b/packages/image-studio/src/components/header/style.scss
@@ -172,6 +172,7 @@
 
 	&__title {
 		font-weight: 600;
+		font-size: 16px;
 		text-align: center;
 		white-space: nowrap;
 		display: flex;

--- a/packages/image-studio/src/components/sidebar/editable-field.scss
+++ b/packages/image-studio/src/components/sidebar/editable-field.scss
@@ -10,6 +10,7 @@
 	}
 
 	.components-text-control__input,
+	.components-text-control__input[type="text"],
 	.components-textarea-control__input {
 		background-color: #2f2f2f;
 		border-color: #3f3f3f;

--- a/packages/image-studio/src/components/style.scss
+++ b/packages/image-studio/src/components/style.scss
@@ -208,7 +208,7 @@ body.js.is-image-studio-open {
 	display: inline-block;
 	background-color: #1f2c70;
 	color: #9fadfb;
-	font-size: 12px;
+	font-size: $text-xs;
 	font-weight: 400;
 	line-height: 20px;
 }
@@ -238,7 +238,7 @@ body.js.is-image-studio-open {
 			padding-bottom: 1em;
 			position: relative;
 			padding-top: 1em;
-			padding-right: 1rem;
+			padding-right: 1em;
 			gap: 0;
 			scrollbar-width: thin;
 			scrollbar-color: rgba(255, 255, 255, 0.5) transparent;
@@ -270,8 +270,6 @@ body.js.is-image-studio-open {
 
 	.Message-module_message {
 		color: #fff;
-		font-size: 0.875rem;
-		line-height: 1.6;
 		padding-bottom: 0;
 
 		p {
@@ -329,16 +327,12 @@ body.js.is-image-studio-open {
 		}
 
 		&_heading {
-			font-size: 0.875rem;
-			line-height: 1.6;
 			color: #fff;
 			padding: 0 12px;
 			margin-bottom: 48px !important;
 		}
 
 		&_help {
-			font-size: 0.875rem;
-			line-height: 1.6;
 			color: #fff;
 			padding: 0 12px;
 		}
@@ -424,8 +418,6 @@ body.js.is-image-studio-open {
 
 	.Textarea-module_textarea {
 		color: #e0e0e0;
-		font-size: 0.875rem;
-		line-height: 1.625;
 		box-shadow: none;
 		background-color: transparent;
 
@@ -565,7 +557,7 @@ body.js.is-image-studio-open {
 
 	// Style label below image
 	&__label {
-		font-size: 0.75rem;
+		font-size: $text-xs;
 		font-weight: 400;
 		text-align: center;
 		line-height: 1.3;

--- a/packages/image-studio/src/components/styles/_variables.scss
+++ b/packages/image-studio/src/components/styles/_variables.scss
@@ -14,3 +14,5 @@ $color-hover-overlay: rgba(255, 255, 255, 0.1);
 
 $breakpoint-medium-up: "min-width: 768px";
 $breakpoint-medium-down: "max-width: 767px";
+
+$text-xs: 12px;

--- a/packages/image-studio/src/index.tsx
+++ b/packages/image-studio/src/index.tsx
@@ -31,6 +31,7 @@ declare const imageStudioData: ImageStudioData | undefined;
 declare global {
 	interface Window {
 		__bigSkyImageStudioInitialized?: boolean;
+		imageStudioData?: ImageStudioData;
 	}
 }
 

--- a/packages/image-studio/src/index.tsx
+++ b/packages/image-studio/src/index.tsx
@@ -27,7 +27,6 @@ interface ImageStudioData {
 	environment?: 'wp-admin' | 'ciab-admin';
 }
 
-declare const imageStudioData: ImageStudioData | undefined;
 declare global {
 	interface Window {
 		__bigSkyImageStudioInitialized?: boolean;
@@ -49,6 +48,9 @@ function getCapabilities( environment?: ImageStudioData[ 'environment' ] ) {
 	};
 }
 
+// Computed once at module load — environment is a static global that never changes.
+const capabilities = getCapabilities( window.imageStudioData?.environment );
+
 /**
  * Initialize the Image Studio integration for WordPress Media Library.
  * Uses WordPress data store patterns instead of DOM manipulation.
@@ -62,7 +64,7 @@ function initImageStudioIntegration(): void {
 	window.__bigSkyImageStudioInitialized = true;
 
 	// Validate required globals
-	if ( typeof imageStudioData === 'undefined' || ! imageStudioData?.enabled ) {
+	if ( ! window.imageStudioData?.enabled ) {
 		return;
 	}
 
@@ -100,8 +102,6 @@ function ImageStudioIntegration(): JSX.Element | null {
 		} ),
 		[]
 	);
-
-	const capabilities = getCapabilities( imageStudioData?.environment );
 
 	// Navigation is only available when opened from media library
 	const isMediaLibraryContext = window.pagenow === 'upload';

--- a/packages/image-studio/src/index.tsx
+++ b/packages/image-studio/src/index.tsx
@@ -41,7 +41,7 @@ declare global {
  * environment they're running in.
  */
 function getCapabilities( environment?: ImageStudioData[ 'environment' ] ) {
-	const isWpAdmin = environment === 'wp-admin';
+	const isWpAdmin = ! environment || environment === 'wp-admin';
 
 	return {
 		// Link to the classic WP Media Library image editor.

--- a/packages/image-studio/src/index.tsx
+++ b/packages/image-studio/src/index.tsx
@@ -24,14 +24,28 @@ import {
 
 interface ImageStudioData {
 	enabled?: boolean | string;
+	environment?: 'wp-admin' | 'ciab-admin';
 }
 
 declare const imageStudioData: ImageStudioData | undefined;
-
 declare global {
 	interface Window {
 		__bigSkyImageStudioInitialized?: boolean;
 	}
+}
+
+/**
+ * Environment-derived feature capabilities. Centralises environment checks so
+ * components can ask "is this feature available?" without knowing which
+ * environment they're running in.
+ */
+function getCapabilities( environment?: ImageStudioData[ 'environment' ] ) {
+	const isWpAdmin = environment === 'wp-admin';
+
+	return {
+		// Link to the classic WP Media Library image editor.
+		classicMediaEditor: isWpAdmin,
+	};
 }
 
 /**
@@ -85,6 +99,8 @@ function ImageStudioIntegration(): JSX.Element | null {
 		} ),
 		[]
 	);
+
+	const capabilities = getCapabilities( imageStudioData?.environment );
 
 	// Navigation is only available when opened from media library
 	const isMediaLibraryContext = window.pagenow === 'upload';
@@ -447,7 +463,9 @@ function ImageStudioIntegration(): JSX.Element | null {
 			onSave={ handleSave }
 			onDiscard={ handleDiscard }
 			onExit={ handleExit }
-			onClassicMediaEditorNavigation={ handleClassicMediaEditorNavigation }
+			onClassicMediaEditorNavigation={
+				capabilities.classicMediaEditor ? handleClassicMediaEditorNavigation : undefined
+			}
 			onNavigatePrevious={ isMediaLibraryContext ? handleNavigatePrevious : undefined }
 			onNavigateNext={ isMediaLibraryContext ? handleNavigateNext : undefined }
 			hasPreviousImage={ hasPreviousImage && ! hasUnsavedChanges }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of FORNO-250

## Proposed Changes

* Removes some font size overrides from Image Studio. 
* Overrides some CIAB wp-component styles
* Skip rendering the `Media Library` escape hatch button in CIAB contexts

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Font sizes used by Agenttic are relative to the `--base-font-size` variable. We were setting overrides in rems which leads to inconsistent sizing when the base font size is not equal to 1 rem. This PR removes the overrides and uses the standard Agenttic sizes.
* Make form styling consistent between ciab-admin and wp-admin
* Support hiding unsupported UI features like Media Library escape hatch in non wp-admin envs.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `bin/jetpack-downloader test jetpack forno-250/image-studio-ciab-support`
* `install-plugin.sh am forno-250/fix/font-sizes` on your sandbox
* Sandbox `widgets.wp.com`
* Sandbox your test site
* Visit the site and launch Image Studio
* Verify the font sizes for the messages and chat input look correct
* Verify `Media Library` button is present on wp-admin sites
* To test on CIAB follow the instructions in 3814-ghe-Automattic/ciab-admin

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
