### PR TITLE
SSR the legacy masterbar in MSD and async load it's JS

### DIFF
--- a/client/dashboard/app/boot.tsx
+++ b/client/dashboard/app/boot.tsx
@@ -19,6 +19,11 @@ import type { AppConfig } from './context';
 
 import './style.scss';
 
+// Masterbar CSS loaded statically so it's available for SSR (the component is server-rendered).
+// eslint-disable-next-line no-restricted-imports
+import 'calypso/layout/masterbar/style.scss';
+import './interim-omnibar/style.scss';
+
 function boot( config: AppConfig ) {
 	if ( handleOAuthCallback() ) {
 		return;

--- a/client/dashboard/app/boot.tsx
+++ b/client/dashboard/app/boot.tsx
@@ -1,6 +1,6 @@
 import { persistQueryClientPromise } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
-import { initSentry } from '@automattic/calypso-sentry';
+import { captureException, initSentry } from '@automattic/calypso-sentry';
 import {
 	isSupportSession,
 	maybeInitializeSupportSession,
@@ -39,6 +39,10 @@ function boot( config: AppConfig ) {
 		throw new Error( 'No root element found' );
 	}
 	const root = createRoot( rootElement );
+
+	if ( isEnabled( 'dashboard/omnibar' ) ) {
+		import( './interim-omnibar' ).then( ( m ) => m.default() ).catch( captureException );
+	}
 
 	persistQueryClientPromise.then( () => {
 		root.render( <Layout config={ config } /> );

--- a/client/dashboard/app/interim-omnibar/index.tsx
+++ b/client/dashboard/app/interim-omnibar/index.tsx
@@ -1,9 +1,7 @@
 import { fetchUser } from '@automattic/api-core';
 import { queryClient, siteByIdQuery } from '@automattic/api-queries';
-import { createRoot } from 'react-dom/client';
+import { hydrateRoot } from 'react-dom/client';
 import { AUTH_QUERY_KEY } from '../auth';
-
-import './style.scss';
 
 export default async function loadOmnibar() {
 	const container = document.getElementById( 'wpcom-omnibar' );
@@ -16,15 +14,18 @@ export default async function loadOmnibar() {
 		queryClient.fetchQuery( { queryKey: AUTH_QUERY_KEY, queryFn: fetchUser } ),
 	] );
 
-	const site = user.primary_blog
-		? await queryClient.fetchQuery( siteByIdQuery( user.primary_blog ) )
-		: null;
-
 	const wpcom = document.getElementById( 'wpcom' );
 	if ( wpcom ) {
 		wpcom.style.marginTop = 'var(--masterbar-height, 47px)';
 	}
 
-	const root = createRoot( container );
+	// Hydrate the server-rendered omnibar with null props first to match SSR output,
+	// then immediately re-render with real data.
+	const root = hydrateRoot( container, <InterimOmnibar user={ null } site={ null } /> );
+
+	const site = user.primary_blog
+		? await queryClient.fetchQuery( siteByIdQuery( user.primary_blog ) )
+		: null;
+
 	root.render( <InterimOmnibar user={ user } site={ site } /> );
 }

--- a/client/dashboard/app/interim-omnibar/index.tsx
+++ b/client/dashboard/app/interim-omnibar/index.tsx
@@ -1,0 +1,30 @@
+import { fetchUser } from '@automattic/api-core';
+import { queryClient, siteByIdQuery } from '@automattic/api-queries';
+import { createRoot } from 'react-dom/client';
+import { AUTH_QUERY_KEY } from '../auth';
+
+import './style.scss';
+
+export default async function loadOmnibar() {
+	const container = document.getElementById( 'wpcom-omnibar' );
+	if ( ! container ) {
+		return;
+	}
+
+	const [ { InterimOmnibar }, user ] = await Promise.all( [
+		import( './interim-omnibar' ),
+		queryClient.fetchQuery( { queryKey: AUTH_QUERY_KEY, queryFn: fetchUser } ),
+	] );
+
+	const site = user.primary_blog
+		? await queryClient.fetchQuery( siteByIdQuery( user.primary_blog ) )
+		: null;
+
+	const wpcom = document.getElementById( 'wpcom' );
+	if ( wpcom ) {
+		wpcom.style.marginTop = 'var(--masterbar-height, 47px)';
+	}
+
+	const root = createRoot( container );
+	root.render( <InterimOmnibar user={ user } site={ site } /> );
+}

--- a/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
+++ b/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
@@ -1,0 +1,97 @@
+/* eslint-disable no-restricted-imports */
+import { isEcommercePlan } from '@automattic/calypso-products';
+import { Provider as ReduxProvider } from 'react-redux';
+import { MasterbarLoggedIn } from 'calypso/layout/masterbar/logged-in';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { getLogoutUrl } from 'calypso/lib/user/shared-utils';
+import { siteUsesWpAdminInterface } from 'calypso/sites-dashboard/utils';
+import type { User } from '@automattic/api-core';
+import type { Site } from '@automattic/api-core/src/site/types';
+
+const noop = () => {};
+
+// Fake Redux store so child components using connect() (e.g. Notifications) don't crash.
+// Just the three methods react-redux's Provider needs.
+const noopStore = {
+	getState: () => ( {} ),
+	dispatch: () => ( {} ),
+	subscribe: () => () => {},
+};
+
+interface Props {
+	user: User;
+	site: Site | null;
+}
+
+export function InterimOmnibar( { user, site }: Props ) {
+	const siteId = user.primary_blog ?? null;
+	const siteSlug = site?.slug ?? null;
+	const siteAdminUrl = site?.options?.admin_url ?? null;
+
+	return (
+		<ReduxProvider store={ noopStore }>
+			<MasterbarLoggedIn
+				// User
+				user={ user }
+				hasNoSites={ user.site_count === 0 }
+				// Site identity
+				siteId={ siteId }
+				site={ site }
+				siteSlug={ siteSlug }
+				siteTitle={ site?.name ?? '' }
+				siteUrl={ site?.URL ?? '' }
+				siteAdminUrl={ siteAdminUrl }
+				siteHomeUrl={ site?.URL ?? '' }
+				sitePlanName={ site?.plan?.product_name_short ?? '' }
+				currentSelectedSiteSlug={ siteSlug }
+				// Site flags
+				isEcommerce={ isEcommercePlan( site?.plan?.product_slug ) }
+				isClassicView={ !! site && siteUsesWpAdminInterface( site ) }
+				isSimpleSite={ !! site && ! site.jetpack }
+				isJetpackNotAtomic={ !! site && site.jetpack && ! site.is_wpcom_atomic }
+				domainOnlySite={ !! site?.options?.is_domain_only }
+				isUnlaunchedSite={ site?.launch_status === 'unlaunched' }
+				isTrial={ false }
+				isSiteP2={ !! site?.options?.is_wpforteams_site }
+				isP2Hub={ !! site?.options?.p2_hub_blog_id && site.options.p2_hub_blog_id === site.ID }
+				isManageSiteOptionsEnabled={ !! site?.capabilities?.manage_options }
+				isA4ADevSite={ !! site?.is_a4a_dev_site }
+				isAtomicAndEditingToolkitDeactivated={ false }
+				// Navigation / layout
+				section=""
+				sectionGroup=""
+				currentLayoutFocus={ null }
+				currentRoute={ window.location.pathname }
+				previousPath=""
+				newPostUrl={ siteAdminUrl ? `${ siteAdminUrl }post-new.php` : '' }
+				newPageUrl={ siteAdminUrl ? `${ siteAdminUrl }post-new.php?post_type=page` : '' }
+				// Feature flags
+				isCheckout={ false }
+				isCheckoutPending={ false }
+				isCheckoutFailed={ false }
+				loadHelpCenterIcon={ false }
+				isGlobalSidebarVisible={ false }
+				isGravatarDomain={ false }
+				dashboardOptIn
+				useUnifiedAgent={ false }
+				isSupportSession={ false }
+				isNotificationsShowing={ false }
+				isMigrationInProgress={ false }
+				migrationStatus={ null }
+				adminMenu={ null }
+				// Actions
+				setNextLayoutFocus={ noop }
+				activateNextLayoutFocus={ noop }
+				recordTracksEvent={ recordTracksEvent }
+				updateSiteMigrationMeta={ noop }
+				savePreference={ noop }
+				requestAdminMenu={ noop }
+				redirectToLogout={ () => {
+					const logoutUrl = getLogoutUrl( user );
+					window.location.href = logoutUrl;
+				} }
+				launchSiteOrRedirectToLaunchSignupFlow={ noop }
+			/>
+		</ReduxProvider>
+	);
+}

--- a/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
+++ b/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
@@ -4,9 +4,7 @@ import { Provider as ReduxProvider } from 'react-redux';
 import { MasterbarLoggedIn } from 'calypso/layout/masterbar/logged-in';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getLogoutUrl } from 'calypso/lib/user/shared-utils';
-import { siteUsesWpAdminInterface } from 'calypso/sites-dashboard/utils';
-import type { User } from '@automattic/api-core';
-import type { Site } from '@automattic/api-core/src/site/types';
+import type { User, Site } from '@automattic/api-core';
 
 const noop = () => {};
 
@@ -16,14 +14,22 @@ const noopStore = {
 	getState: () => ( {} ),
 	dispatch: () => ( {} ),
 	subscribe: () => () => {},
-};
+} as unknown as Parameters< typeof ReduxProvider >[ 0 ][ 'store' ];
+
+// Minimal placeholder so MasterbarLoggedIn doesn't crash during SSR.
+const emptyUser = {
+	display_name: '',
+	username: '',
+	site_count: 0,
+} as unknown as User;
 
 interface Props {
-	user: User;
+	user: User | null;
 	site: Site | null;
 }
 
-export function InterimOmnibar( { user, site }: Props ) {
+export function InterimOmnibar( { user: userProp, site }: Props ) {
+	const user = userProp ?? emptyUser;
 	const siteId = user.primary_blog ?? null;
 	const siteSlug = site?.slug ?? null;
 	const siteAdminUrl = site?.options?.admin_url ?? null;
@@ -44,9 +50,11 @@ export function InterimOmnibar( { user, site }: Props ) {
 				siteHomeUrl={ site?.URL ?? '' }
 				sitePlanName={ site?.plan?.product_name_short ?? '' }
 				currentSelectedSiteSlug={ siteSlug }
+				// TODO: Audit site-specific flags to see which we need to handle in the interim omnibar, and which can be hardcoded to false.
 				// Site flags
-				isEcommerce={ isEcommercePlan( site?.plan?.product_slug ) }
-				isClassicView={ !! site && siteUsesWpAdminInterface( site ) }
+				isEcommerce={ isEcommercePlan( site?.plan?.product_slug ?? '' ) }
+				// isClassicView={ !! site && siteUsesWpAdminInterface( site ) }
+				isClassicView
 				isSimpleSite={ !! site && ! site.jetpack }
 				isJetpackNotAtomic={ !! site && site.jetpack && ! site.is_wpcom_atomic }
 				domainOnlySite={ !! site?.options?.is_domain_only }
@@ -61,7 +69,7 @@ export function InterimOmnibar( { user, site }: Props ) {
 				section=""
 				sectionGroup=""
 				currentLayoutFocus={ null }
-				currentRoute={ window.location.pathname }
+				currentRoute={ typeof window !== 'undefined' ? window.location.pathname : '/' }
 				previousPath=""
 				newPostUrl={ siteAdminUrl ? `${ siteAdminUrl }post-new.php` : '' }
 				newPageUrl={ siteAdminUrl ? `${ siteAdminUrl }post-new.php?post_type=page` : '' }
@@ -87,8 +95,10 @@ export function InterimOmnibar( { user, site }: Props ) {
 				savePreference={ noop }
 				requestAdminMenu={ noop }
 				redirectToLogout={ () => {
-					const logoutUrl = getLogoutUrl( user );
-					window.location.href = logoutUrl;
+					if ( userProp ) {
+						const logoutUrl = getLogoutUrl( userProp );
+						window.location.href = logoutUrl;
+					}
 				} }
 				launchSiteOrRedirectToLaunchSignupFlow={ noop }
 			/>

--- a/client/dashboard/app/interim-omnibar/style.scss
+++ b/client/dashboard/app/interim-omnibar/style.scss
@@ -1,0 +1,11 @@
+#wpcom-omnibar {
+	--color-masterbar-background: #1d2327;
+	--color-masterbar-text: #f0f0f1;
+	--color-masterbar-icon: rgba(240, 246, 252, 0.6);
+	--color-masterbar-highlight: #72aee6;
+	--color-masterbar-border: #8c8f94;
+	--color-masterbar-item-hover-background: #2c3338;
+	--color-masterbar-item-active-background: #23282d;
+	--color-masterbar-unread-dot-background: var(--color-accent-20, #d54e21);
+	--color-masterbar-submenu-text: #c3c4c7;
+}

--- a/client/dashboard/app/routing.ts
+++ b/client/dashboard/app/routing.ts
@@ -44,6 +44,9 @@ export function getDashboardFromHostname( hostname?: string ): DashboardType | u
  * Used in dashboard environments.
  */
 export function getCurrentDashboard(): DashboardType {
+	if ( typeof window === 'undefined' ) {
+		return 'dotcom';
+	}
 	return getDashboardFromHostname( window.location.hostname ) ?? 'dotcom';
 }
 
@@ -52,6 +55,9 @@ export function getCurrentDashboard(): DashboardType {
  * Used in non-dashboard environments to know which dashboard the user came from.
  */
 export function getDashboardFromQuery(): DashboardType | undefined {
+	if ( typeof window === 'undefined' ) {
+		return undefined;
+	}
 	const params = new URLSearchParams( window.location.search );
 	const dashboard = params.get( 'dashboard' );
 

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -20,6 +20,7 @@ import Head from 'calypso/components/head';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import Loading from 'calypso/components/loading';
 import WooCommerceLogo from 'calypso/components/woocommerce-logo';
+import { InterimOmnibar } from 'calypso/dashboard/app/interim-omnibar/interim-omnibar';
 import { getDashboardStepperLogo } from 'calypso/dashboard/app/stepper-logo';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { isGravPoweredOAuth2Client, isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
@@ -163,7 +164,11 @@ class Document extends Component {
 					} ) }
 				>
 					{ /* eslint-disable wpcalypso/jsx-classname-namespace, react/no-danger */ }
-					{ dashboard && <div id="wpcom-omnibar" /> }
+					{ dashboard && config.isEnabled( 'dashboard/omnibar' ) && (
+						<div id="wpcom-omnibar">
+							<InterimOmnibar user={ null } site={ null } />
+						</div>
+					) }
 					{ renderedLayout ? (
 						<div
 							id="wpcom"

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -163,6 +163,7 @@ class Document extends Component {
 					} ) }
 				>
 					{ /* eslint-disable wpcalypso/jsx-classname-namespace, react/no-danger */ }
+					{ dashboard && <div id="wpcom-omnibar" /> }
 					{ renderedLayout ? (
 						<div
 							id="wpcom"

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -834,6 +834,8 @@ class MasterbarLoggedIn extends Component {
 	}
 }
 
+export { MasterbarLoggedIn };
+
 export default connect(
 	( state ) => {
 		const sectionGroup = getSectionGroup( state );

--- a/client/layout/masterbar/masterbar-notifications/notifications-button.jsx
+++ b/client/layout/masterbar/masterbar-notifications/notifications-button.jsx
@@ -85,7 +85,8 @@ class MasterbarItemNotifications extends Component {
 	render() {
 		const classes = clsx( this.props.className, 'masterbar-notifications', {
 			'is-active':
-				this.props.isNotificationsOpen || window.location.pathname === '/reader/notifications',
+				this.props.isNotificationsOpen ||
+				( typeof window !== 'undefined' && window.location.pathname === '/reader/notifications' ),
 			'has-unread': this.state.newNote,
 			'is-initial-load': this.state.animationState === -1,
 		} );


### PR DESCRIPTION
Fixes DOTMSD-1135

## Proposed Changes

* Add `dashboard/omnibar` feature flag (off by default) to gate the legacy masterbar in MSD
* Server-render the masterbar shell (with null user/site) into `<div id="wpcom-omnibar">` so the bar paints immediately on page load
* Client hydrates the server-rendered HTML, then re-renders with real user/site data once fetched
* Async-load the masterbar JS + standalone noop Redux store into a separate chunk
* Statically import masterbar CSS in the dashboard entrypoint so styles are available at SSR time
* Add SSR-safe `typeof window` guards in `routing.ts` and `notifications-button.jsx`
  * I guess this is the first time they've been server rendered.

Stacked on top of https://github.com/Automattic/wp-calypso/pull/109489, which makes the OmniBar localisable using the new localisation package.

## What this PR is NOT doing

* Does not remove the MSD's existing top bar
* None of the masterbar buttons are wired up to be clickable yet
* Sticky scrolling not implemented
* The server currently renders with no user or site data

We can follow up with these in separate PRs

## Testing Instructions

### Enable the feature

The `dashboard/omnibar` flag must be enabled in the JSON config file — I don't think server respects query params like `?flags=`

1. Edit `config/dashboard-development.json`
2. Add `"dashboard/omnibar": true` to the `features` object
3. `yarn start-dashboard`

### With feature flag enabled (MSD)

1. Load the dashboard at `my.localhost:3000`
2. Confirm the masterbar appears above the dashboard immediately (server-rendered shell, unstyled briefly then styled)
3. Confirm the masterbar populates with user gravatar/name after hydration
4. Check the browser console for errors

### Regression: flag disabled (MSD)

1. Remove or set `"dashboard/omnibar": false` in `config/dashboard-development.json`
2. `yarn start-dashboard`
3. Confirm MSD loads normally with no masterbar and no console errors

### Regression: Calypso v1

1. `yarn start`
2. Load `calypso.localhost:3000`
3. Confirm the classic Calypso masterbar works as before — no regressions from the `notifications-button.jsx` SSR guard

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?