### PR TITLE
MSD: consolidate plan/purchase upgrade url logic

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -1,6 +1,4 @@
 import {
-	ProductUpgradeMap,
-	AkismetUpgradesProductMap,
 	SubscriptionBillPeriod,
 	DomainProductSlugs,
 	useMyDomainInputMode,
@@ -94,6 +92,7 @@ import {
 	isInExpirationGracePeriod,
 	isA4ABillingDragonPurchase,
 } from '../../../utils/purchase';
+import { getSitePurchaseUpgradeUrl } from '../../../utils/site-url';
 import BillingFlexUsageCard from '../../billing-flex-usage';
 import { PurchasePaymentMethod } from '../purchase-payment-method';
 import AkismetApiKeyCard from './akismet-api-key-card';
@@ -111,46 +110,6 @@ const SPACING = {
 
 function renewPurchase( purchase: Purchase ): void {
 	window.location.href = getRenewalUrlFromPurchase( purchase );
-}
-
-function getUpgradeUrl( purchase: Purchase ): string | undefined {
-	if ( isAkismetProduct( purchase ) ) {
-		// For the first Iteration of Calypso Akismet checkout we are only suggesting
-		// for immediate upgrades to the next plan. We will change this in the future
-		// with appropriate page.
-		const url = AkismetUpgradesProductMap[ purchase.product_slug ];
-		if ( ! url ) {
-			return undefined;
-		}
-		const isAbsolute =
-			url.startsWith( 'http://' ) || url.startsWith( 'https://' ) || url.startsWith( '//' );
-		if ( ! isAbsolute ) {
-			return wpcomLink( url );
-		}
-		return url;
-	}
-
-	const upgradeProductSlug = ProductUpgradeMap[ purchase.product_slug ];
-	if ( upgradeProductSlug ) {
-		return wpcomLink( `/checkout/${ purchase.site_slug }/${ upgradeProductSlug }` );
-	}
-
-	if ( purchase.is_jetpack_backup_t1 || isJetpackT1SecurityPlan( purchase ) ) {
-		return wpcomLink( `/plans/storage/${ purchase.site_slug }` );
-	}
-
-	if ( purchase.is_jetpack_plan_or_product ) {
-		return wpcomLink( `/plans/${ purchase.site_slug }` );
-	}
-
-	if ( purchase.is_woo_hosted_product ) {
-		return addQueryArgs( wpcomLink( '/setup/woo-hosted-plans' ), {
-			siteSlug: purchase.site_slug,
-			dashboard: getCurrentDashboard(),
-		} );
-	}
-
-	return getWpcomPlanGridUrl( purchase.site_slug );
 }
 
 function getExpiredNewPlanUrl( purchase: Purchase ): string {
@@ -181,7 +140,7 @@ function getWpcomPlanGridUrl( siteSlug: string | undefined ): string {
 function canPurchaseBeUpgraded( purchase: Purchase ): boolean {
 	return Boolean(
 		purchase.is_upgradable &&
-			getUpgradeUrl( purchase ) &&
+			getSitePurchaseUpgradeUrl( purchase ) &&
 			! isJetpackTemporarySitePurchase( purchase ) &&
 			! isA4ABillingDragonPurchase( purchase )
 	);
@@ -260,7 +219,7 @@ function PurchaseActionMenu( { purchase }: { purchase: Purchase } ) {
 	const { user } = useAuth();
 	const canBeRenewed =
 		purchase.can_explicit_renew && String( user.ID ) === String( purchase.user_id );
-	const upgradeUrl = getUpgradeUrl( purchase );
+	const upgradeUrl = getSitePurchaseUpgradeUrl( purchase );
 	const { recordTracksEvent } = useAnalytics();
 	const menuItems = [
 		canPurchaseBeUpgraded( purchase ) && upgradeUrl && (
@@ -366,7 +325,7 @@ function UpgradeActionButton( { purchase }: { purchase: Purchase } ) {
 	if ( ! canPurchaseBeUpgraded( purchase ) ) {
 		return null;
 	}
-	const upgradeUrl = getUpgradeUrl( purchase );
+	const upgradeUrl = getSitePurchaseUpgradeUrl( purchase );
 	if ( ! upgradeUrl ) {
 		return null;
 	}
@@ -1173,7 +1132,7 @@ export default function PurchaseSettings() {
 	} );
 	const formattedExpiry = useFormattedTime( purchase.expiry_date ?? '' );
 	const formattedRenewal = useFormattedTime( purchase.renew_date ?? '' );
-	const upgradeUrl = getUpgradeUrl( purchase );
+	const upgradeUrl = getSitePurchaseUpgradeUrl( purchase );
 	const willRenew = Boolean(
 		! isExpired( purchase ) && purchase.renew_date && ! isExpiring( purchase )
 	);

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -10,12 +10,10 @@ import { Link } from '@tanstack/react-router';
 import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { addQueryArgs } from '@wordpress/url';
 import { differenceInCalendarDays } from 'date-fns';
 import { useAnalytics } from '../../../app/analytics';
 import { useAuth } from '../../../app/auth';
 import { changePaymentMethodRoute, purchaseSettingsRoute } from '../../../app/router/me';
-import { getCurrentDashboard } from '../../../app/routing';
 import Notice from '../../../components/notice';
 import { getRelativeTimeString } from '../../../utils/datetime';
 import { wpcomLink } from '../../../utils/link';
@@ -33,6 +31,7 @@ import {
 	isInExpirationGracePeriod,
 	isAkismetFreeProduct,
 } from '../../../utils/purchase';
+import { getSitePurchaseUpgradeUrl } from '../../../utils/site-url';
 import { CancellationOfferNotice } from './cancellation-offer-notice';
 import {
 	OtherRenewablePurchasesNotice,
@@ -321,26 +320,16 @@ function InAppPurchaseNotice( { purchase }: { purchase: Purchase } ) {
 function TrialNotice( { purchase }: { purchase: Purchase } ) {
 	const { recordTracksEvent } = useAnalytics();
 	const onClickUpgrade = () => {
-		if ( purchase.product_slug === WooHostedPlans.WOO_HOSTED_FREE_TRIAL_PLAN_MONTHLY ) {
+		if (
+			purchase.product_slug === WooHostedPlans.WOO_HOSTED_FREE_TRIAL_PLAN_MONTHLY ||
+			purchase.product_slug === DotcomPlans.ECOMMERCE_TRIAL_MONTHLY
+		) {
 			recordTracksEvent( 'calypso_subscription_trial_notice_cta_clicked', {
 				current_plan_slug: purchase.product_slug,
 				to_checkout: false,
 			} );
 
-			window.location.href = addQueryArgs( wpcomLink( '/setup/woo-hosted-plans' ), {
-				siteSlug: purchase.site_slug ?? '',
-				dashboard: getCurrentDashboard(),
-			} );
-			return;
-		}
-
-		if ( purchase.product_slug === DotcomPlans.ECOMMERCE_TRIAL_MONTHLY ) {
-			recordTracksEvent( 'calypso_subscription_trial_notice_cta_clicked', {
-				current_plan_slug: purchase.product_slug,
-				to_checkout: false,
-			} );
-
-			window.location.href = wpcomLink( `/plans/${ purchase.site_slug ?? '' }` );
+			window.location.href = getSitePurchaseUpgradeUrl( purchase ) ?? '';
 			return;
 		}
 

--- a/client/dashboard/sites/domains/primary-domain-selector.tsx
+++ b/client/dashboard/sites/domains/primary-domain-selector.tsx
@@ -16,15 +16,13 @@ import {
 import { DataForm } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { addQueryArgs } from '@wordpress/url';
 import { useState, useMemo } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import InlineSupportLink from '../../components/inline-support-link';
 import { Notice } from '../../components/notice';
 import UpsellCTAButton from '../../components/upsell-cta-button';
-import { redirectToDashboardLink, wpcomLink } from '../../utils/link';
+import { getSitePlanUpgradeUrl } from '../../utils/site-url';
 import { userHasFlag } from '../../utils/user';
-import { isSitePlanWooHosted } from '../plans';
 import type { Field } from '@wordpress/dataviews';
 
 interface PrimaryDomainSelectorProps {
@@ -112,20 +110,13 @@ const PrimaryDomainSelector = ( { domains, site, user }: PrimaryDomainSelectorPr
 
 	const renderMessage = () => {
 		if ( ! canUserSetPrimaryDomainOnThisSite ) {
-			const upgradeLink = isSitePlanWooHosted( site )
-				? wpcomLink( '/setup/woo-hosted-plans' )
-				: wpcomLink( '/setup/plan-upgrade' );
-			const backUrl = redirectToDashboardLink();
 			const message = createInterpolateElement(
 				'Your site plan doesn’t allow you to set a custom domain as a primary site address.<br/><upgradeLink>Upgrade to an annual paid plan</upgradeLink> and get a free one-year domain name registration or transfer. <learnMoreLink />',
 				{
 					upgradeLink: (
 						<UpsellCTAButton
 							variant="link"
-							href={ addQueryArgs( upgradeLink, {
-								siteSlug: site.slug,
-								cancel_to: backUrl,
-							} ) }
+							href={ getSitePlanUpgradeUrl( site ) }
 							upsellId="site-domains-primary-domain-selector"
 							upsellFeatureId="domain"
 						/>

--- a/client/dashboard/sites/overview-plan-card/index.tsx
+++ b/client/dashboard/sites/overview-plan-card/index.tsx
@@ -17,10 +17,10 @@ import { PurchaseExpiryStatus } from '../../components/purchase-expiry-status';
 import {
 	getJetpackProductsForSite,
 	getSitePlanDisplayName,
-	useSitePlanManageURL,
 	JETPACK_PRODUCTS,
 } from '../../utils/site-plan';
 import { isSelfHostedJetpackConnected, isCommerceGarden } from '../../utils/site-types';
+import { getSitePlanUrl } from '../../utils/site-url';
 import SiteBandwidthStat from './site-bandwidth-stat';
 import SiteStorageStat from './site-storage-stat';
 import type { Purchase, Site } from '@automattic/api-core';
@@ -60,7 +60,6 @@ function JetpackPlanCard( {
 	purchase?: Purchase;
 	isLoading: boolean;
 } ) {
-	const url = useSitePlanManageURL( site );
 	const products = getJetpackProductsForSite( site );
 	const productsToDisplay = products.length > 0 ? products : JETPACK_PRODUCTS;
 
@@ -70,7 +69,7 @@ function JetpackPlanCard( {
 			icon={ <JetpackLogo /> }
 			heading={ getSitePlanDisplayName( site ) }
 			description={ getCardDescription( site, purchase ) }
-			link={ url }
+			link={ getSitePlanUrl( site ) }
 			tracksId="site-overview-plan"
 			isLoading={ isLoading }
 			bottom={
@@ -107,14 +106,13 @@ function WpcomPlanCard( {
 	purchase?: Purchase;
 	isLoading: boolean;
 } ) {
-	const url = useSitePlanManageURL( site, purchase );
 	return (
 		<OverviewCard
 			title={ __( 'Plan' ) }
 			icon={ wordpress }
 			heading={ getSitePlanDisplayName( site ) }
 			description={ getCardDescription( site, purchase ) }
-			link={ url }
+			link={ getSitePlanUrl( site, purchase ) }
 			tracksId="site-overview-plan"
 			isLoading={ isLoading }
 			bottom={ <SitePlanStats site={ site } /> }
@@ -147,14 +145,13 @@ function WpcomStagingSitePlanCard( { site }: { site: Site } ) {
 }
 
 function AgencyPlanCard( { site, isLoading }: { site: Site; isLoading: boolean } ) {
-	const url = useSitePlanManageURL( site );
 	return (
 		<OverviewCard
 			title={ __( 'Development license' ) }
 			icon={ wordpress }
 			heading={ getSitePlanDisplayName( site ) }
 			description={ __( 'Managed by Automattic for Agencies.' ) }
-			link={ url }
+			link={ getSitePlanUrl( site ) }
 			tracksId="site-overview-plan"
 			isLoading={ isLoading }
 			bottom={ <SitePlanStats site={ site } /> }
@@ -171,14 +168,13 @@ function CommerceGardenPlanCard( {
 	purchase?: Purchase;
 	isLoading: boolean;
 } ) {
-	const url = useSitePlanManageURL( site, purchase );
 	return (
 		<OverviewCard
 			title={ __( 'Plan' ) }
 			icon={ commerceGardenPlan }
 			heading={ getSitePlanDisplayName( site ) }
 			description={ getCardDescription( site, purchase ) }
-			link={ url }
+			link={ getSitePlanUrl( site, purchase ) }
 			tracksId="plan"
 			isLoading={ isLoading }
 		/>

--- a/client/dashboard/sites/settings-plan/summary.tsx
+++ b/client/dashboard/sites/settings-plan/summary.tsx
@@ -4,7 +4,8 @@ import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { payment } from '@wordpress/icons';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
-import { getSitePlanDisplayName, useSitePlanManageURL } from '../../utils/site-plan';
+import { getSitePlanDisplayName } from '../../utils/site-plan';
+import { getSitePlanUrl } from '../../utils/site-url';
 import { isRelativeUrl } from '../../utils/url';
 import type { Site } from '@automattic/api-core';
 import type { Density } from '@automattic/components/src/summary-button/types';
@@ -23,7 +24,7 @@ export default function SettingsPlanSummary( {
 		enabled: !! plan?.id,
 	} );
 
-	const url = useSitePlanManageURL( site, purchase );
+	const url = getSitePlanUrl( site, purchase );
 	if ( ! url || ! isRelativeUrl( url ) ) {
 		return null;
 	}

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -28,9 +28,10 @@ import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { wpcomLink } from '../../utils/link';
 import { getSiteBadge } from '../../utils/site-badge';
 import { hasHostingFeature, hasJetpackModule } from '../../utils/site-features';
+import { getSitePlanUpgradeUrl } from '../../utils/site-url';
 import { getVisibilityLabels } from '../../utils/site-visibility';
 import { canManageSite } from '../features';
-import { isSitePlanTrial, isSitePlanWooHosted } from '../plans';
+import { isSitePlanTrial } from '../plans';
 import SitePreview from '../site-preview';
 import { JetpackLogo } from './jetpack-logo';
 import type { SiteBadge, SiteBlockingStatus, SiteVisibility } from '../../types';
@@ -350,12 +351,9 @@ function SiteLaunchNag( { siteSlug }: { siteSlug: string } ) {
 	);
 }
 
-function PlanRenewNag( { site, source }: { site: Pick< Site, 'slug' | 'plan' >; source: string } ) {
+function PlanRenewNag( { site, source }: { site: Site; source: string } ) {
 	const { recordTracksEvent } = useAnalytics();
 	const isTrial = isSitePlanTrial( site );
-	const upgradeLink = isSitePlanWooHosted( site )
-		? wpcomLink( `/setup/woo-hosted-plans/${ site.slug }` )
-		: wpcomLink( `/plans/${ site.slug }` );
 
 	return (
 		<>
@@ -366,7 +364,7 @@ function PlanRenewNag( { site, source }: { site: Pick< Site, 'slug' | 'plan' >; 
 			<ExternalLink
 				href={
 					isTrial
-						? upgradeLink
+						? getSitePlanUpgradeUrl( site )
 						: wpcomLink( `/checkout/${ site.slug }/${ site.plan?.product_slug }` )
 				}
 				onClick={ () => {
@@ -410,7 +408,7 @@ export function Plan( {
 	isOwner,
 	value,
 }: {
-	nag: { isExpired: false } | { isExpired: true; site: Pick< Site, 'slug' | 'plan' > };
+	nag: { isExpired: false } | { isExpired: true; site: Site };
 	isSelfHostedJetpackConnected: boolean;
 	isJetpack: boolean;
 	isOwner?: boolean;

--- a/client/dashboard/utils/site-plan.ts
+++ b/client/dashboard/utils/site-plan.ts
@@ -1,5 +1,4 @@
 import { JetpackPlans, JetpackFeatures } from '@automattic/api-core';
-import { useRouter } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import {
 	chartBar,
@@ -11,14 +10,8 @@ import {
 	shield,
 	video,
 } from '@wordpress/icons';
-import { addQueryArgs } from '@wordpress/url';
-import { purchaseSettingsRoute, purchasesRoute } from '../app/router/me';
-import { getCurrentDashboard } from '../app/routing';
 import { hasPlanFeature } from '../utils/site-features';
-import { isDashboardBackport } from './is-dashboard-backport';
-import { redirectToDashboardLink, wpcomLink } from './link';
-import { isCommerceGarden, isSelfHostedJetpackConnected } from './site-types';
-import type { JetpackFeatureSlug, Purchase, Site } from '@automattic/api-core';
+import type { JetpackFeatureSlug, Site } from '@automattic/api-core';
 
 export const JETPACK_PRODUCTS = [
 	{
@@ -108,52 +101,4 @@ export function getSitePlanDisplayName( site: Site ) {
 	}
 
 	return plan.product_name || plan.product_name_short;
-}
-
-export function useSitePlanManageURL( site: Site, purchase?: Purchase ) {
-	const router = useRouter();
-	const host = typeof window !== 'undefined' ? window.location.host : 'wordpress.com';
-	const protocol = typeof window !== 'undefined' ? window.location.protocol : 'https:';
-
-	if ( site.is_wpcom_staging_site ) {
-		return undefined;
-	}
-
-	if ( isSelfHostedJetpackConnected( site ) ) {
-		return `https://cloud.jetpack.com/purchases/subscriptions/${ site.slug }`;
-	}
-
-	if ( site.is_a4a_dev_site ) {
-		return `https://agencies.automattic.com/sites/overview/${ site.slug }`;
-	}
-
-	if ( site.plan?.is_free ) {
-		const backUrl = redirectToDashboardLink();
-
-		return isCommerceGarden( site )
-			? addQueryArgs( wpcomLink( '/setup/woo-hosted-plans' ), {
-					siteSlug: site.slug,
-					dashboard: getCurrentDashboard(),
-			  } )
-			: addQueryArgs( wpcomLink( '/setup/plan-upgrade' ), {
-					siteSlug: site.slug,
-					cancel_to: backUrl,
-					dashboard: getCurrentDashboard(),
-			  } );
-	}
-
-	if ( isDashboardBackport() ) {
-		return `${ protocol }//${ host }/purchases/subscriptions/${ site.slug }/${ purchase?.ID }`;
-	}
-
-	// Use the purchase settings page if the purchase is provided.
-	if ( purchase ) {
-		return router.buildLocation( {
-			to: purchaseSettingsRoute.fullPath,
-			params: { purchaseId: purchase.ID },
-		} ).href;
-	}
-
-	// Default to the account purchases page.
-	return purchasesRoute.fullPath;
 }

--- a/client/dashboard/utils/site-url.ts
+++ b/client/dashboard/utils/site-url.ts
@@ -108,7 +108,11 @@ export function getSitePurchaseUpgradeUrl( purchase: Purchase ) {
 
 	const upgradeProductSlug = ProductUpgradeMap[ purchase.product_slug ];
 	if ( upgradeProductSlug ) {
-		return wpcomLink( `/checkout/${ purchase.site_slug }/${ upgradeProductSlug }` );
+		const backUrl = redirectToDashboardLink();
+		return addQueryArgs( wpcomLink( `/checkout/${ purchase.site_slug }/${ upgradeProductSlug }` ), {
+			redirect_to: backUrl,
+			cancel_to: backUrl,
+		} );
 	}
 
 	if ( purchase.is_jetpack_backup_t1 || isJetpackT1SecurityPlan( purchase ) ) {

--- a/client/dashboard/utils/site-url.ts
+++ b/client/dashboard/utils/site-url.ts
@@ -1,6 +1,12 @@
+import { ProductUpgradeMap, AkismetUpgradesProductMap } from '@automattic/api-core';
 import { addQueryArgs } from '@wordpress/url';
+import { getCurrentDashboard } from '../app/routing';
+import { isSitePlanTrial, isSitePlanWooHosted } from '../sites/plans';
+import { isDashboardBackport } from './is-dashboard-backport';
+import { redirectToDashboardLink, wpcomLink } from './link';
+import { isAkismetProduct, isJetpackT1SecurityPlan } from './purchase';
 import { isSelfHostedJetpackConnected } from './site-types';
-import type { Site } from '@automattic/api-core';
+import type { Purchase, Site } from '@automattic/api-core';
 
 /**
  * Returns a user-friendly version of the site's URL.
@@ -45,4 +51,102 @@ export function getSiteVisibilityURL( site: Site, queryArgs?: { back_to: 'site-o
 	}
 
 	return addQueryArgs( `/sites/${ site.slug }/settings/site-visibility`, queryArgs );
+}
+
+/**
+ * Given a site and its current plan's purchase (if any), this function does the following:
+ *
+ * - If the site is a wpcom site without a purchase, returns the URL to upgrade the site plan.
+ * - Otherwise, returns the most appropriate URL to manage the site's current plan.
+ */
+export function getSitePlanUrl( site: Site, purchase?: Purchase ) {
+	if ( site.is_wpcom_staging_site ) {
+		return undefined;
+	}
+
+	if ( isSelfHostedJetpackConnected( site ) ) {
+		return `https://cloud.jetpack.com/purchases/subscriptions/${ site.slug }`;
+	}
+
+	if ( site.is_a4a_dev_site ) {
+		return `https://agencies.automattic.com/sites/overview/${ site.slug }`;
+	}
+
+	if ( ! purchase ) {
+		return getSitePlanUpgradeUrl( site );
+	}
+
+	return isDashboardBackport()
+		? wpcomLink( `/purchases/subscriptions/${ site.slug }/${ purchase.ID }` )
+		: `/me/billing/purchases/${ purchase.ID }`;
+}
+
+export function getSitePlanUpgradeUrl( site: Site ) {
+	return buildSitePlanUpgradeUrl( {
+		siteSlug: site.slug,
+		isTrial: isSitePlanTrial( site ),
+		isWooHosted: isSitePlanWooHosted( site ),
+	} );
+}
+
+export function getSitePurchaseUpgradeUrl( purchase: Purchase ) {
+	if ( isAkismetProduct( purchase ) ) {
+		// For the first Iteration of Calypso Akismet checkout we are only suggesting
+		// for immediate upgrades to the next plan. We will change this in the future
+		// with appropriate page.
+		const url = AkismetUpgradesProductMap[ purchase.product_slug ];
+		if ( ! url ) {
+			return undefined;
+		}
+		const isAbsolute =
+			url.startsWith( 'http://' ) || url.startsWith( 'https://' ) || url.startsWith( '//' );
+		if ( ! isAbsolute ) {
+			return wpcomLink( url );
+		}
+		return url;
+	}
+
+	const upgradeProductSlug = ProductUpgradeMap[ purchase.product_slug ];
+	if ( upgradeProductSlug ) {
+		return wpcomLink( `/checkout/${ purchase.site_slug }/${ upgradeProductSlug }` );
+	}
+
+	if ( purchase.is_jetpack_backup_t1 || isJetpackT1SecurityPlan( purchase ) ) {
+		return wpcomLink( `/plans/storage/${ purchase.site_slug }` );
+	}
+
+	if ( purchase.is_jetpack_plan_or_product ) {
+		return wpcomLink( `/plans/${ purchase.site_slug }` );
+	}
+
+	return buildSitePlanUpgradeUrl( {
+		siteSlug: purchase.site_slug,
+		isTrial: purchase.is_trial_plan,
+		isWooHosted: purchase.is_woo_hosted_product,
+	} );
+}
+
+function buildSitePlanUpgradeUrl( {
+	siteSlug,
+	isTrial,
+	isWooHosted,
+}: {
+	siteSlug: string;
+	isTrial: boolean;
+	isWooHosted: boolean;
+} ) {
+	if ( isTrial && ! isWooHosted ) {
+		return wpcomLink( `/plans/${ siteSlug }` );
+	}
+
+	const backUrl = redirectToDashboardLink();
+	const link = isWooHosted
+		? wpcomLink( '/setup/woo-hosted-plans' )
+		: wpcomLink( '/setup/plan-upgrade' );
+
+	return addQueryArgs( link, {
+		siteSlug: siteSlug,
+		cancel_to: backUrl,
+		dashboard: getCurrentDashboard(),
+	} );
 }


### PR DESCRIPTION
Part of DOTMSD-1126 -- fixing back button on CIAB stepper screens

## Proposed Changes

Consolidate plan and purchase upgrade URL logic into shared utility functions in `client/dashboard/utils/site-url.ts`, which set up the `cancel_to` param correctly.

- `getSitePlanUrl( site, purchase? )`: returns the URL to manage or upgrade a site's plan. If the site has no purchase (free plan), it returns the upgrade URL via`getSitePlanUpgradeUrl()`. Otherwise, it returns the plan/purchase management page.
- `getSitePlanUpgradeUrl( site )` : returns the URL to upgrade a site's plan, given a `Site` object.
- `getSitePurchaseUpgradeUrl( purchase )`: returns the URL to upgrade a purchase, given a `Purchase` object.

## Why are these changes being made?

Three main reasons:

- so that we don't forget that CIAB site plan's URL is special: `/setup/woo-hosted-plans`
- so that we don't forget to pass `cancel_to` query param to make the back button on stepper screens work
- so that the functions can be reused easily across screens (which is already happening)


## Testing Instructions

You can smoke test this PR as follows

> [!NOTE]  
> For each case, verify you can click at top-left back link and it goes to the previous MSD screen.

`getSitePlanUrl()`:

Visit your site's overview screen; click the Plan card:

<img width="1371" height="595" alt="image" src="https://github.com/user-attachments/assets/37a15e0d-e418-424b-adee-1052cb4b4fde" />

- for Free site: it should go to `/setup/plan-upgrade`
- for site with paid plan: it should go to `/me/billing/purchases/:purchaseId`

`getSitePurchaseUpgradeUrl( )`:

After clicking the Plan card of a non-Free site, you will see the purchase details:

<img width="1097" height="631" alt="image" src="https://github.com/user-attachments/assets/42aa2f0c-7ab4-4a3b-ba17-7385aa44455a" />

Click the Upgrade button:

- for CIAB plan (make sure you're on CIAB-MSD): it should go to `/setup/woo-hosted-plans`
- for wpcom plan: it should go to `/setup/plan-upgrade`
- for wpcom trial plan (e.g. Commerce Trial): it should go to old `/plans/:siteSlug` page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
