### PR TITLE
WordPress Settings: Show actual beta version from wp.org API

### DIFF
--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -35,6 +35,10 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 		enabled: canView,
 	} );
 
+	const { data: latestVersion } = useQuery( {
+		...wpOrgCoreVersionQuery(),
+		enabled: canView,
+	} );
 	const { data: betaVersion } = useQuery( {
 		...wpOrgCoreVersionQuery( 'beta' ),
 		enabled: canView,
@@ -54,18 +58,21 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 		version: currentVersion ?? '',
 	} );
 
+	const currentWpVersion = site.options?.software_version ?? '';
+
 	const fields: Field< { version: string } >[] = [
 		{
 			id: 'version',
 			label: __( 'WordPress version' ),
 			Edit: 'select',
 			elements: [
-				{ value: 'latest', label: getFormattedWordPressVersion( site, 'latest' ) },
+				{
+					value: 'latest',
+					label: formatWordPressVersion( latestVersion ?? currentWpVersion, 'latest' ),
+				},
 				{
 					value: 'beta',
-					label: betaVersion
-						? formatWordPressVersion( betaVersion, 'beta' )
-						: getFormattedWordPressVersion( site, 'beta' ),
+					label: formatWordPressVersion( betaVersion ?? currentWpVersion, 'beta' ),
 				},
 			],
 		},

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -2,7 +2,7 @@ import {
 	siteBySlugQuery,
 	siteWordPressVersionQuery,
 	siteWordPressVersionMutation,
-	wpOrgCoreVersionCheckQuery,
+	wpOrgCoreVersionQuery,
 } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import {
@@ -35,8 +35,8 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 		enabled: canView,
 	} );
 
-	const { data: betaVersionCheck } = useQuery( {
-		...wpOrgCoreVersionCheckQuery( 'beta' ),
+	const { data: betaVersion } = useQuery( {
+		...wpOrgCoreVersionQuery( 'beta' ),
 		enabled: canView,
 	} );
 
@@ -63,8 +63,8 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 				{ value: 'latest', label: getFormattedWordPressVersion( site, 'latest' ) },
 				{
 					value: 'beta',
-					label: betaVersionCheck?.offers?.[ 0 ]?.version
-						? formatWordPressVersion( betaVersionCheck.offers[ 0 ].version, 'beta' )
+					label: betaVersion
+						? formatWordPressVersion( betaVersion, 'beta' )
 						: getFormattedWordPressVersion( site, 'beta' ),
 				},
 			],

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -2,6 +2,7 @@ import {
 	siteBySlugQuery,
 	siteWordPressVersionQuery,
 	siteWordPressVersionMutation,
+	wpOrgCoreVersionCheckQuery,
 } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import {
@@ -21,7 +22,7 @@ import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import { getFormattedWordPressVersion } from '../../utils/wp-version';
+import { formatWordPressVersion, getFormattedWordPressVersion } from '../../utils/wp-version';
 import { canViewWordPressSettings } from '../features';
 import type { Field } from '@wordpress/dataviews';
 
@@ -33,6 +34,12 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 		...siteWordPressVersionQuery( site.ID ),
 		enabled: canView,
 	} );
+
+	const { data: betaVersionCheck } = useQuery( {
+		...wpOrgCoreVersionCheckQuery( 'beta' ),
+		enabled: canView,
+	} );
+
 	const mutation = useMutation( {
 		...siteWordPressVersionMutation( site.ID ),
 		meta: {
@@ -54,7 +61,12 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 			Edit: 'select',
 			elements: [
 				{ value: 'latest', label: getFormattedWordPressVersion( site, 'latest' ) },
-				{ value: 'beta', label: getFormattedWordPressVersion( site, 'beta' ) },
+				{
+					value: 'beta',
+					label: betaVersionCheck?.offers?.[ 0 ]?.version
+						? formatWordPressVersion( betaVersionCheck.offers[ 0 ].version, 'beta' )
+						: getFormattedWordPressVersion( site, 'beta' ),
+				},
 			],
 		},
 	];

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -124,3 +124,4 @@ export * from './site-themes';
 export * from './site-update-schedules';
 export * from './site-users';
 export * from './upgrades';
+export * from './wp-org';

--- a/packages/api-core/src/wp-org/fetchers.ts
+++ b/packages/api-core/src/wp-org/fetchers.ts
@@ -1,0 +1,19 @@
+import type { WpOrgCoreVersionCheck } from './types';
+
+export async function fetchWpOrgCoreVersionCheck(
+	channel: string = 'latest'
+): Promise< WpOrgCoreVersionCheck > {
+	const response = await fetch(
+		`https://api.wordpress.org/core/version-check/1.7/?channel=${ channel }`,
+		{
+			method: 'GET',
+			headers: { Accept: 'application/json' },
+		}
+	);
+
+	if ( ! response.ok ) {
+		throw new Error( `Failed to fetch WordPress core version check: ${ response.status }` );
+	}
+
+	return response.json();
+}

--- a/packages/api-core/src/wp-org/fetchers.ts
+++ b/packages/api-core/src/wp-org/fetchers.ts
@@ -1,8 +1,8 @@
 import type { WpOrgCoreVersionCheck } from './types';
 
-export async function fetchWpOrgCoreVersionCheck(
+export async function fetchWpOrgCoreVersion(
 	channel: string = 'latest'
-): Promise< WpOrgCoreVersionCheck > {
+): Promise< string | undefined > {
 	const response = await fetch(
 		`https://api.wordpress.org/core/version-check/1.7/?channel=${ channel }`,
 		{
@@ -15,5 +15,6 @@ export async function fetchWpOrgCoreVersionCheck(
 		throw new Error( `Failed to fetch WordPress core version check: ${ response.status }` );
 	}
 
-	return response.json();
+	const data: WpOrgCoreVersionCheck = await response.json();
+	return data.offers?.[ 0 ]?.version;
 }

--- a/packages/api-core/src/wp-org/index.ts
+++ b/packages/api-core/src/wp-org/index.ts
@@ -1,0 +1,2 @@
+export * from './fetchers';
+export * from './types';

--- a/packages/api-core/src/wp-org/types.ts
+++ b/packages/api-core/src/wp-org/types.ts
@@ -1,0 +1,22 @@
+export interface WpOrgCoreVersionOffer {
+	response: string;
+	download: string;
+	locale: string;
+	packages: {
+		full: string;
+		no_content: string;
+		new_bundled: string;
+		partial: boolean;
+		rollback: boolean;
+	};
+	current: string;
+	version: string;
+	php_version: string;
+	mysql_version: string;
+	new_bundled: string;
+	partial_version: boolean;
+}
+
+export interface WpOrgCoreVersionCheck {
+	offers: WpOrgCoreVersionOffer[];
+}

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -120,3 +120,4 @@ export * from './site-collision-listener';
 export * from './site';
 export * from './sites';
 export * from './upgrades';
+export * from './wp-org-core-version';

--- a/packages/api-queries/src/wp-org-core-version.ts
+++ b/packages/api-queries/src/wp-org-core-version.ts
@@ -1,9 +1,9 @@
-import { fetchWpOrgCoreVersionCheck } from '@automattic/api-core';
+import { fetchWpOrgCoreVersion } from '@automattic/api-core';
 import { queryOptions } from '@tanstack/react-query';
 
-export const wpOrgCoreVersionCheckQuery = ( channel: string = 'latest' ) =>
+export const wpOrgCoreVersionQuery = ( channel: string = 'latest' ) =>
 	queryOptions( {
-		queryKey: [ 'wp-org-core-version-check', channel ],
-		queryFn: () => fetchWpOrgCoreVersionCheck( channel ),
-		staleTime: 1000 * 60 * 60,
+		queryKey: [ 'wp-org-core-version', channel ],
+		queryFn: () => fetchWpOrgCoreVersion( channel ),
+		staleTime: 1000 * 60 * 60 * 24,
 	} );

--- a/packages/api-queries/src/wp-org-core-version.ts
+++ b/packages/api-queries/src/wp-org-core-version.ts
@@ -1,0 +1,9 @@
+import { fetchWpOrgCoreVersionCheck } from '@automattic/api-core';
+import { queryOptions } from '@tanstack/react-query';
+
+export const wpOrgCoreVersionCheckQuery = ( channel: string = 'latest' ) =>
+	queryOptions( {
+		queryKey: [ 'wp-org-core-version-check', channel ],
+		queryFn: () => fetchWpOrgCoreVersionCheck( channel ),
+		staleTime: 1000 * 60 * 60,
+	} );


### PR DESCRIPTION
Fixes: DOTMSD-1131

## Proposed Changes

* Add `fetchWpOrgCoreVersionCheck` fetcher in `@automattic/api-core` under `wp-org/` to call the WordPress.org core version-check API (`/core/version-check/1.7/`).
* Add `wpOrgCoreVersionCheckQuery` in `@automattic/api-queries` wrapping the fetcher with a 1-hour stale time.
* Update the WordPress Settings page to fetch the latest & beta channel version and display the real beta version number in the dropdown.

## Why are these changes being made?

* Previously the beta option in the WordPress version selector showed the site's current version with a "(Beta)" suffix, which wasn't accurate. Now it fetches the actual beta version from the wp.org API so users see the real version they'd be switching to.

## Testing Instructions

* Navigate to a staging site's WordPress Settings page in the Dashboard.
* Verify the beta option in the version dropdown shows the actual beta version from wp.org (e.g., "7.0 (Beta)") rather than the site's current version.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)