### PR TITLE
Launch Site Flow: Annotate automatically skipped domain step within launch site flow with was_skipped property

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -1014,7 +1014,7 @@ function excludeDomainStep( stepName, tracksEventValue, submitSignupStep ) {
 	const domainItem = undefined;
 	const domainCart = undefined;
 
-	submitSignupStep( { stepName, domainItem }, { domainItem, domainCart } );
+	submitSignupStep( { stepName, domainItem, wasSkipped: true }, { domainItem, domainCart } );
 	recordExcludeStepEvent( stepName, tracksEventValue );
 
 	fulfilledDependencies = [ 'domainItem', 'domainCart', 'siteId', 'siteSlug', 'themeItem' ];

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -140,7 +140,7 @@ describe( 'isDomainFulfilled', () => {
 		isDomainFulfilled( stepName, undefined, nextProps );
 
 		expect( submitSignupStep ).toHaveBeenCalledWith(
-			{ stepName, domainItem: undefined },
+			{ stepName, domainItem: undefined, wasSkipped: true },
 			{ domainItem: undefined }
 		);
 	} );


### PR DESCRIPTION
Closes DATSCI-1174.

## Proposed Changes

When the user attempts to launch a site with a paid domain and a paid plan, we skip both steps in the `launch-site` flow. To identify such cases within Tracks, we add a new property to `calypso_signup_actions_submit_step` called `was_skipped: true`.

While the plans step was getting it, the same couldn't be said about the domains one. This PR changes that.

## Why are these changes being made?

Analytics completeness.

## Testing Instructions

Enter `/start/launch-site?siteSlug=%s` where `%s` is a site that has a paid domain and a plan.

You should observe the `calypso_signup_actions_submit_step` event being dispatched with `step: 'domains-launch', was_skipped: true`.