### PR TITLE
Theme Showcase: Post design review polish (modern version)

### DIFF
--- a/client/components/theme-tier/theme-tier-badge/style.scss
+++ b/client/components/theme-tier/theme-tier-badge/style.scss
@@ -86,3 +86,10 @@
 		font-size: inherit;
 	}
 }
+
+.is-theme-showcase-modern {
+	.premium-badge,
+	.theme-tier-free-included-label {
+		border-radius: 24px;
+	}
+}

--- a/client/my-sites/themes/banners-modern/difm-banner.tsx
+++ b/client/my-sites/themes/banners-modern/difm-banner.tsx
@@ -22,7 +22,7 @@ const DIFMBanner = () => {
 				<p className="banner-modern__description">
 					{ preventWidows(
 						translate(
-							'Built by WordPress.com experts and fully managed for you\u2014no coding or setup required.'
+							'Launch faster and sell smarter with features designed to save time and delight your customers.'
 						)
 					) }
 				</p>

--- a/client/my-sites/themes/banners-modern/style.scss
+++ b/client/my-sites/themes/banners-modern/style.scss
@@ -16,6 +16,9 @@
 	@include break-mobile {
 		max-width: 60%;
 	}
+	@include break-large {
+		max-width: 40%;
+	}
 }
 
 .banner-modern__title {
@@ -75,6 +78,7 @@
 			var(--ai-builder-banner-linear-gradient-overlay),
 			url( ./ai-builder-background.png ) no-repeat bottom right -400px / cover,
 			var(--ai-builder-banner-linear-gradient-underlay);
+		padding: 40px;
 	}
 	@include break-medium {
 		background:
@@ -170,13 +174,20 @@
 	padding-bottom: 288px;
 
 	@include break-mobile {
-		background: url( ./difm-background.png ) no-repeat center right 24px / 35%;
+		background: url( ./difm-background.png ) no-repeat center right 40px / 35%;
 		background-color: var( --studio-gray-0 );
-		padding: 24px;
+		padding: 40px;
 	}
-
 	@include break-medium {
 		padding-bottom: 72px;
 		padding-top: 72px;
+	}
+	@include break-large {
+		background: url( ./difm-background.png ) no-repeat center right 40px / 50%;
+		background-color: var( --studio-gray-0 );
+	}
+	@include break-xlarge {
+		background: url( ./difm-background.png ) no-repeat center right 40px / 40%;
+		background-color: var( --studio-gray-0 );
 	}
 }

--- a/client/my-sites/themes/banners-modern/test/difm-banner.test.tsx
+++ b/client/my-sites/themes/banners-modern/test/difm-banner.test.tsx
@@ -22,9 +22,7 @@ describe( 'DIFMBanner', () => {
 
 	test( 'renders subtitle', () => {
 		render( <DIFMBanner /> );
-		expect(
-			screen.getByText( /Built by WordPress\.com experts and fully managed for you/ )
-		).toBeVisible();
+		expect( screen.getByText( /Launch faster and sell smarter with features/ ) ).toBeVisible();
 	} );
 
 	test( 'renders CTA button linking to DIFM landing page', () => {

--- a/client/my-sites/themes/filter-bar-modern/style.scss
+++ b/client/my-sites/themes/filter-bar-modern/style.scss
@@ -19,6 +19,11 @@
 		.category-pill-navigation__button {
 			text-decoration: none;
 
+			&:not(.is-active):hover, &:not(.is-active):focus {
+				background-color: var( --studio-gray-10 );
+				color: var( --studio-gray-80 );
+			}
+
 			&:first-child {
 				margin-left: 0;
 			}
@@ -31,7 +36,7 @@
 	display: flex;
 	margin: 0 auto;
 	max-width: 1220px;
-	padding: 24px;
+	padding: 32px 24px;
 
 	@media ( min-width: $break-wide ) {
 		padding-left: 0;

--- a/client/my-sites/themes/hero-modern/style.scss
+++ b/client/my-sites/themes/hero-modern/style.scss
@@ -45,6 +45,7 @@ $hero-modern-navbar-height: 57px; // UniversalHeaderNavigation
 	font-weight: 400;
 	line-height: 1;
 	margin: 0 0 8px 0;
+	text-wrap: balance;
 
 	@media ( min-width: $break-small ) {
 		font-size: rem(70px);
@@ -56,6 +57,7 @@ $hero-modern-navbar-height: 57px; // UniversalHeaderNavigation
 	font-size: $font-body-large;
 	line-height: 1.5;
 	margin: 0;
+	text-wrap: balance;
 }
 
 .hero-modern__search {
@@ -70,11 +72,15 @@ $hero-modern-navbar-height: 57px; // UniversalHeaderNavigation
 		height: 55px;
 
 		.components-input-control__container {
+			.components-input-control__prefix {
+				color: var(--studio-gray-30);
+			}
 			input.components-input-control__input {
+				color: var(--studio-gray-90);
 				font-size: $font-body;
 			}
 			.components-input-control__backdrop {
-				border-color: var(--studio-gray-5);
+				border-color: transparent;
 				border-radius: 4px;
 			}
 		}

--- a/client/my-sites/themes/sections-modern/style.scss
+++ b/client/my-sites/themes/sections-modern/style.scss
@@ -101,4 +101,9 @@
 	margin: 108px auto;
 	max-width: calc( 1220px - 48px);
 	width: calc( 100% - 48px - 48px);
+
+	@include break-mobile {
+		max-width: calc( 1220px - 80px);
+		width: calc( 100% - 48px - 80px);
+	}
 }

--- a/client/my-sites/themes/sections-modern/style.scss
+++ b/client/my-sites/themes/sections-modern/style.scss
@@ -21,7 +21,7 @@
 	--theme-section-text-secondary: var(--studio-gray-10);
 
 	background-color: var(--theme-section-bg);
-	padding: 24px 24px 96px 24px;
+	padding: 48px 24px 96px 24px;
 }
 
 .theme-section-header {

--- a/client/my-sites/themes/sections-modern/style.scss
+++ b/client/my-sites/themes/sections-modern/style.scss
@@ -7,7 +7,7 @@
 	--theme-section-text: var(--studio-gray-100);
 	--theme-section-text-secondary: var(--studio-gray-80);
 
-	margin-bottom: 96px;
+	margin-bottom: 108px;
 	padding-inline: 24px;
 
 	&:last-child {
@@ -64,6 +64,8 @@
 .theme-section-header__button.components-button.is-secondary {
 	--wp-components-color-accent: var(--studio-gray-80);
 	--wp-components-color-accent-darker-20: var(--studio-gray-100);
+	padding-left: 20px;
+	padding-right: 20px;
 }
 
 .theme-section-modern__grid {
@@ -96,7 +98,7 @@
 }
 
 .recommended-sections .banner-modern {
-	margin: 96px auto;
+	margin: 108px auto;
 	max-width: calc( 1220px - 48px);
 	width: calc( 100% - 48px - 48px);
 }

--- a/client/my-sites/themes/sections-modern/style.scss
+++ b/client/my-sites/themes/sections-modern/style.scss
@@ -70,7 +70,7 @@
 
 .theme-section-modern__grid {
 	display: grid;
-	gap: 24px;
+	gap: 48px;
 	grid-template-columns: 1fr;
 	margin: 0 auto;
 	max-width: 1220px;

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -639,10 +639,10 @@
 	}
 
 	.themes-list {
+		gap: 48px;
 		margin: 0 auto;
 
 		@include break-small {
-			gap: 32px;
 			grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
 			max-width: 1220px;
 		}
@@ -656,6 +656,14 @@
 		border: none;
 		border-radius: 8px;
 		box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.25);
+	}
+
+	.theme-card__info {
+		height: auto;
+	}
+
+	.theme-card__info-title {
+		font-size: 18px;
 	}
 
 	// Hide style variation swatches for logged-out modern view

--- a/client/my-sites/themes/themes-faq/index.tsx
+++ b/client/my-sites/themes/themes-faq/index.tsx
@@ -155,7 +155,7 @@ export default function ThemesFAQ() {
 		<div className="themes-faq">
 			<div className="themes-faq__wrapper">
 				<div className="themes-faq__header">
-					<h2 className="themes-faq__title">{ translate( 'Themes FAQs' ) }</h2>
+					<h2 className="themes-faq__title">{ translate( 'WordPress theme FAQs' ) }</h2>
 				</div>
 				<div className="themes-faq__list">
 					{ faqItems.map( ( item ) => (

--- a/client/my-sites/themes/themes-faq/style.scss
+++ b/client/my-sites/themes/themes-faq/style.scss
@@ -46,9 +46,11 @@
 	line-height: 1.2;
 	color: var( --studio-white );
 	margin: 0;
+	text-wrap: balance;
 
 	@include break-large {
 		font-size: rem( 50px );
+		max-width: 500px;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTTHEM 337

## Proposed Changes

* Use text-wrap: balance for the hero title and description.
* Update hero search details: no border, gray-90 color, gray-30 icon.
* Filter hover state: background gray-10, no color change.
* Filter bar: 32px vertical padding.
* See all buttons: 20px horizontal padding.
* Theme cards gap: 48px (also remove .theme-card__info height).
* Theme tier pills: 20px radius.
* Theme name: 18px.
* Home sections: 108px bottom margins.
* Banners: 40px padding on large screens.
* Banner headings: 40% max-width on large screens.
* DIFM banner: check description copy: "Launch faster and sell smarter with features designed to save time and delight your customers."
* DIFM banner: increase the background image size.
* Partner themes section: 96px vertical padding.
* FAQs title: check copy "WordPress theme FAQs", and split 2 lines after WordPress.

| Before | After |
|--------|--------|
| <img width="1051" height="5000" alt="wordpress com_themes_flags=themes_showcase-modern" src="https://github.com/user-attachments/assets/a4965269-42d6-4505-b19d-0fe72b01ac84" /> | <img width="1047" height="5000" alt="calypso localhost_3000_themes" src="https://github.com/user-attachments/assets/3fd52edf-ebea-4a33-8728-09dceda3c3aa" /> | 

## Why are these changes being made?

* Minor adjustments following design review.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the logged-out Theme Showcase with the `themes/showcase-modern` feature flag enabled.
* Ensure the landing page looks like the design.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
