### PR TITLE
Launch Site Flow: Do not treat it as a site management flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -307,6 +307,7 @@ export function generateFlows( {
 			providesDependenciesInQuery: [ 'siteSlug' ],
 			hideProgressIndicator: true,
 			lastModified: '2019-11-22',
+			excludeFromManageSiteFlows: true,
 			get pageTitle() {
 				return translate( 'Launch your site' );
 			},


### PR DESCRIPTION
Closes DATSCI-1175.

## Proposed Changes

Adds `launch-site` to the list of flows that are not related to site creation (i.e., part of the subset of flows that "manage a site").

The site management flow logic prevents duplicate site creation when the back button is clicked or the flow is reentered. I believe this was introduced when we didn't have `siteSlug` as a parameter, which should absolutely be the source of truth for all operations within Start.

A site creation flow becomes a site management flow by the time the user enters checkout. This is to treat the back button case (prevent duplicated site creation) or reentering a flow, as said above. The information is saved in session storage and retrieved right before redirecting to checkout.

Because the Launch Site flow was being treated as a site management flow, and the relevant information is saved in session storage, going through the flow two times with different sites (let them be A and B) in the same session introduced a conflict where you go through the flow for site B, but see checkout for site A.

Adding Launch Site to the list of site management flow exceptions fixes the problem.

## Testing Instructions

### In production

On a new browser window, enter `/start/launch-site?siteSlug=%siteA` then proceed to checkout. Keep the same browser window, then enter `/start/launch-site?siteSlug=%siteB` with a different site and go through the flow again. You should see checkout for siteA instead of siteB.

### This branch

Repeat the steps above, but this time verify you're actually in checkout for siteB.