### PR TITLE
Subscribers: add Remove action for complimentary subscriptions

### DIFF
--- a/client/my-sites/subscribers/components/remove-comp-modal/remove-comp-modal.tsx
+++ b/client/my-sites/subscribers/components/remove-comp-modal/remove-comp-modal.tsx
@@ -1,0 +1,89 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { useQueryClient } from '@tanstack/react-query';
+import { Modal, Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import { useDispatch } from 'calypso/state';
+import { requestDeleteGift } from 'calypso/state/memberships/gifts/actions';
+
+import './style.scss';
+
+type RemoveCompModalProps = {
+	siteId: number;
+	giftId: number;
+	planName: string;
+	username: string;
+	onClose: () => void;
+	onRemoved: () => void;
+};
+
+const RemoveCompModal = ( {
+	siteId,
+	giftId,
+	planName,
+	username,
+	onClose,
+	onRemoved,
+}: RemoveCompModalProps ) => {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const queryClient = useQueryClient();
+	const [ isSubmitting, setIsSubmitting ] = useState( false );
+
+	const handleRemove = () => {
+		setIsSubmitting( true );
+
+		recordTracksEvent( 'calypso_subscribers_remove_comp_confirm', {
+			site_id: siteId,
+			gift_id: giftId,
+		} );
+
+		dispatch(
+			requestDeleteGift(
+				siteId,
+				giftId,
+				translate( 'Removed complimentary subscription from "%(username)s".', {
+					args: { username },
+				} )
+			)
+		).then( () => {
+			queryClient.invalidateQueries( { queryKey: [ 'subscribers', siteId ] } );
+			queryClient.invalidateQueries( { queryKey: [ 'subscriber-details', siteId ] } );
+			setIsSubmitting( false );
+			onRemoved();
+		} );
+	};
+
+	return (
+		<Modal
+			overlayClassName="remove-comp-modal"
+			title={ translate( 'Remove complimentary subscription' ) }
+			onRequestClose={ onClose }
+			size="medium"
+		>
+			<p>
+				{ translate(
+					'Are you sure you want to remove the complimentary "%(planName)s" subscription from %(username)s? They will lose access to the paid content in this plan.',
+					{
+						args: { planName, username },
+					}
+				) }
+			</p>
+			<div className="remove-comp-modal__buttons">
+				<Button onClick={ onClose } variant="tertiary">
+					{ translate( 'Cancel' ) }
+				</Button>
+				<Button
+					variant="primary"
+					isBusy={ isSubmitting }
+					onClick={ handleRemove }
+					disabled={ isSubmitting }
+				>
+					{ translate( 'Remove' ) }
+				</Button>
+			</div>
+		</Modal>
+	);
+};
+
+export default RemoveCompModal;

--- a/client/my-sites/subscribers/components/remove-comp-modal/style.scss
+++ b/client/my-sites/subscribers/components/remove-comp-modal/style.scss
@@ -1,0 +1,28 @@
+@import "@automattic/color-studio/dist/color-variables";
+@import "@automattic/typography/styles/variables";
+
+.remove-comp-modal {
+	// Match the ConfirmModal styles used by UnsubscribeModal.
+	.components-modal__frame {
+		max-width: 563px;
+	}
+
+	.components-modal__header {
+		border-bottom-color: $studio-gray-0;
+		padding: 18px 24px;
+
+		.components-modal__header-heading {
+			font-size: $font-body;
+		}
+	}
+
+	.components-modal__content {
+		padding: 24px;
+	}
+
+	.remove-comp-modal__buttons {
+		display: flex;
+		gap: 10px;
+		justify-content: flex-end;
+	}
+}

--- a/client/my-sites/subscribers/components/remove-comp-modal/test/remove-comp-modal.test.tsx
+++ b/client/my-sites/subscribers/components/remove-comp-modal/test/remove-comp-modal.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import RemoveCompModal from '../remove-comp-modal';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockDispatch: jest.Mock = jest.fn( ( action: any ) => {
+	if ( typeof action === 'function' ) {
+		return action( mockDispatch );
+	}
+	return action;
+} );
+
+jest.mock( 'calypso/state', () => ( {
+	useDispatch: () => mockDispatch,
+} ) );
+
+jest.mock( 'calypso/state/memberships/gifts/actions', () => ( {
+	requestDeleteGift: jest.fn( () => () => Promise.resolve() ),
+} ) );
+
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
+
+const mockStore = configureStore();
+
+function renderModal( props = {} ) {
+	const store = mockStore( {} );
+	const queryClient = new QueryClient();
+	const defaultProps = {
+		siteId: 123,
+		giftId: 456,
+		planName: 'Premium Newsletter',
+		username: 'testuser',
+		onClose: jest.fn(),
+		onRemoved: jest.fn(),
+	};
+
+	return {
+		...render(
+			<Provider store={ store }>
+				<QueryClientProvider client={ queryClient }>
+					<RemoveCompModal { ...defaultProps } { ...props } />
+				</QueryClientProvider>
+			</Provider>
+		),
+		props: { ...defaultProps, ...props },
+	};
+}
+
+describe( 'RemoveCompModal', () => {
+	it( 'renders modal with plan name and username', () => {
+		renderModal();
+
+		expect( screen.getByText( /Remove complimentary subscription/ ) ).toBeVisible();
+		expect( screen.getByText( /Premium Newsletter/ ) ).toBeVisible();
+		expect( screen.getByText( /They will lose access/ ) ).toBeVisible();
+		expect( screen.getByText( /testuser/ ) ).toBeVisible();
+	} );
+
+	it( 'calls onClose when Cancel is clicked', async () => {
+		const user = userEvent.setup();
+		const { props } = renderModal();
+
+		await user.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+
+		expect( props.onClose ).toHaveBeenCalled();
+	} );
+
+	it( 'calls requestDeleteGift and onRemoved when Remove is clicked', async () => {
+		const { requestDeleteGift } = jest.requireMock( 'calypso/state/memberships/gifts/actions' );
+		const user = userEvent.setup();
+		const { props } = renderModal();
+
+		await user.click( screen.getByRole( 'button', { name: 'Remove' } ) );
+
+		expect( requestDeleteGift ).toHaveBeenCalledWith( 123, 456, expect.any( String ) );
+		// Wait for the promise to resolve
+		await screen.findByRole( 'button', { name: 'Remove' } );
+		expect( props.onRemoved ).toHaveBeenCalled();
+	} );
+
+	it( 'disables Remove button while submitting', async () => {
+		const { requestDeleteGift } = jest.requireMock( 'calypso/state/memberships/gifts/actions' );
+		// Make the request hang indefinitely
+		requestDeleteGift.mockImplementation( () => () => new Promise( () => {} ) );
+
+		const user = userEvent.setup();
+		renderModal();
+
+		await user.click( screen.getByRole( 'button', { name: 'Remove' } ) );
+
+		expect( screen.getByRole( 'button', { name: 'Remove' } ) ).toBeDisabled();
+	} );
+} );

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -63,6 +63,7 @@ type SubscriberDataViewsProps = {
 	siteId: number | null;
 	isUnverified: boolean;
 	onGiftSubscription: ( subscriber: Subscriber ) => void;
+	onRemoveComp: ( giftId: number, planName: string, username: string ) => void;
 	subscriberId?: string;
 };
 
@@ -142,6 +143,7 @@ const defaultView: ViewTable = {
 export default function SubscriberDataViews( {
 	siteId,
 	onGiftSubscription,
+	onRemoveComp,
 	isUnverified,
 	subscriberId,
 }: SubscriberDataViewsProps ) {
@@ -768,6 +770,12 @@ export default function SubscriberDataViews( {
 							onClose={ handleClose }
 							onUnsubscribe={ ( subscriber ) => handleUnsubscribe( [ subscriber ] ) }
 							onGiftSubscription={ couponsAndGiftsEnabled ? onGiftSubscription : undefined }
+							onRemoveComp={
+								couponsAndGiftsEnabled
+									? ( giftId, planName ) =>
+											onRemoveComp( giftId, planName, subscriberDetails.display_name )
+									: undefined
+							}
 							newsletterCategoriesEnabled={ subscribedNewsletterCategoriesData?.enabled }
 							newsletterCategories={ subscribedNewsletterCategoriesData?.newsletterCategories }
 						/>

--- a/client/my-sites/subscribers/components/subscriber-details/styles.scss
+++ b/client/my-sites/subscribers/components/subscriber-details/styles.scss
@@ -55,6 +55,19 @@
 			line-height: rem(20px);
 			letter-spacing: -0.15px;
 		}
+
+		.subscriber-details__remove-comp-button {
+			margin-inline-start: 4px;
+			padding: 0;
+			height: auto;
+			min-height: auto;
+			vertical-align: text-bottom;
+			color: $studio-gray-60;
+
+			&:hover {
+				color: $studio-gray-80;
+			}
+		}
 		@media (max-width: $break-large) {
 			flex-direction: column;
 		}

--- a/client/my-sites/subscribers/components/subscriber-details/subscriber-details.tsx
+++ b/client/my-sites/subscribers/components/subscriber-details/subscriber-details.tsx
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import { TimeSince } from '@automattic/components';
-import { Button, ExternalLink } from '@wordpress/components';
+import { Button, ExternalLink, Icon } from '@wordpress/components';
+import { trash } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { NewsletterCategory } from 'calypso/data/newsletter-categories/types';
@@ -22,6 +23,7 @@ type SubscriberDetailsProps = {
 	onClose?: () => void;
 	onUnsubscribe?: ( subscriber: Subscriber ) => void;
 	onGiftSubscription?: ( subscriber: Subscriber ) => void;
+	onRemoveComp?: ( giftId: number, planName: string ) => void;
 };
 
 const SubscriberDetails = ( {
@@ -34,6 +36,7 @@ const SubscriberDetails = ( {
 	onClose,
 	onUnsubscribe,
 	onGiftSubscription,
+	onRemoveComp,
 }: SubscriberDetailsProps ) => {
 	const translate = useTranslate();
 	const subscriptionPlans = useSubscriptionPlans( subscriber );
@@ -57,6 +60,22 @@ const SubscriberDetails = ( {
 					{ translate( 'Comp', {
 						comment: 'Short for "complimentary" — a free subscription granted by the site creator',
 					} ) }
+					{ onRemoveComp && subscriptionPlan.gift_id && (
+						<Button
+							className="subscriber-details__remove-comp-button"
+							variant="tertiary"
+							aria-label={ String(
+								translate( 'Remove complimentary subscription: %(planName)s', {
+									args: { planName: subscriptionPlan.title ?? '' },
+								} )
+							) }
+							onClick={ () =>
+								onRemoveComp( subscriptionPlan.gift_id!, subscriptionPlan.title ?? '' )
+							}
+						>
+							<Icon icon={ trash } size={ 18 } />
+						</Button>
+					) }
 				</div>
 			);
 		}

--- a/client/my-sites/subscribers/hooks/use-subscription-plans.ts
+++ b/client/my-sites/subscribers/hooks/use-subscription-plans.ts
@@ -13,11 +13,13 @@ export type SubscriptionPlanData = {
 	title?: string;
 	is_gift: boolean;
 	is_free: boolean;
+	gift_id?: number;
 };
 
 type PlanData = {
 	is_gift: boolean;
 	renewal_price: number;
+	gift_id?: number;
 	renewalPrice: string;
 	when: string;
 	start_date: string;
@@ -70,6 +72,7 @@ const useSubscriptionPlans = ( subscriber: Subscriber ): SubscriptionPlanData[] 
 			const result = subscriptions.map( ( subscription: SubscriptionPlan ) => {
 				const {
 					is_gift,
+					gift_id,
 					currency,
 					renewal_price,
 					renew_interval,
@@ -80,7 +83,7 @@ const useSubscriptionPlans = ( subscriber: Subscriber ): SubscriptionPlanData[] 
 				const renewalPrice = formatRenewalPrice( renewal_price, currency );
 				const when = getPaymentInterval( renew_interval, inactive_renew_interval );
 
-				return { is_gift, renewal_price, renewalPrice, when, start_date, title };
+				return { is_gift, gift_id, renewal_price, renewalPrice, when, start_date, title };
 			} );
 
 			return result || defaultSubscription;
@@ -112,6 +115,7 @@ const useSubscriptionPlans = ( subscriber: Subscriber ): SubscriptionPlanData[] 
 				title: plan.title,
 				is_gift: plan.is_gift,
 				is_free: plan.renewal_price === 0,
+				gift_id: plan.gift_id,
 			} ) );
 		}
 		return [];

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -9,6 +9,7 @@ import Main from 'calypso/components/main';
 import SubscriberValidationGate from 'calypso/components/subscribers-validation-gate';
 import { useCompleteLaunchpadTaskWithNoticeOnLoad } from 'calypso/launchpad/hooks/use-complete-launchpad-task-with-notice-on-load';
 import GiftSubscriptionModal from 'calypso/my-sites/subscribers/components/gift-modal/gift-modal';
+import RemoveCompModal from 'calypso/my-sites/subscribers/components/remove-comp-modal/remove-comp-modal';
 import { SubscriberDataViews } from 'calypso/my-sites/subscribers/components/subscriber-data-views';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { Subscriber } from './types';
@@ -66,6 +67,12 @@ const SubscribersPage = ( { subscriberId }: Props ) => {
 		setGiftUsername( display_name );
 	};
 
+	const [ removeComp, setRemoveComp ] = useState< {
+		giftId: number;
+		planName: string;
+		username: string;
+	} | null >( null );
+
 	return (
 		<>
 			<QueryMembershipsSettings siteId={ siteId ?? 0 } source="calypso" />
@@ -76,6 +83,9 @@ const SubscribersPage = ( { subscriberId }: Props ) => {
 						siteId={ siteId }
 						isUnverified={ isUnverified }
 						onGiftSubscription={ onGiftSubscription }
+						onRemoveComp={ ( giftId, planName, username ) =>
+							setRemoveComp( { giftId, planName, username } )
+						}
 						subscriberId={ isSubscriberIdValid ? subscriberId : undefined }
 					/>
 
@@ -86,6 +96,17 @@ const SubscribersPage = ( { subscriberId }: Props ) => {
 							username={ giftUsername }
 							onClose={ () => setGiftUserId( null ) }
 							onConfirm={ () => setGiftUserId( null ) }
+						/>
+					) }
+
+					{ removeComp !== null && (
+						<RemoveCompModal
+							siteId={ siteId ?? 0 }
+							giftId={ removeComp.giftId }
+							planName={ removeComp.planName }
+							username={ removeComp.username }
+							onClose={ () => setRemoveComp( null ) }
+							onRemoved={ () => setRemoveComp( null ) }
 						/>
 					) }
 				</SubscriberValidationGate>


### PR DESCRIPTION
Part of NL-29

## Proposed Changes

* Add a "Remove" link button next to each comp plan in the subscriber detail view's Paid upgrade column
* Add a confirmation modal (`RemoveCompModal`) using `@wordpress/components` Modal that warns before revoking
* Pass `gift_id` through `useSubscriptionPlans` hook so the detail view can identify which comp to remove
* Wire the existing `requestDeleteGift` DELETE endpoint to the new UI
* Invalidate subscriber queries after removal so the UI refreshes

<img width="1165" height="184" alt="Screenshot 2026-03-23 at 5 14 46 PM" src="https://github.com/user-attachments/assets/ecee2a1f-3d2e-4708-8f64-abea1f2f6f53" />
<img width="582" height="272" alt="Screenshot 2026-03-23 at 5 27 14 PM" src="https://github.com/user-attachments/assets/30f0fc48-3e22-4c81-ae70-5dd10f4f79fd" />
<img width="646" height="87" alt="Screenshot 2026-03-19 at 10 31 10 AM" src="https://github.com/user-attachments/assets/446cb4ee-1ddc-4f29-a376-f0bf8e0c8cca" />


## Why are these changes being made?

Creators currently have no way to revoke a complimentary subscription once given. The backend DELETE endpoint already exists but there was no UI to trigger it. Since a subscriber can have multiple comps, the remove action is placed inline next to each comp plan rather than as a single button, so creators can target a specific plan.

## Testing Instructions

* Navigate to Subscribers page for a site with coupons & gifts enabled
* Click into a subscriber who has a complimentary subscription
* In the Paid upgrade column, verify a trash icon appears next to "Comp"
* Click the trash icon — verify a confirmation modal appears with the plan name and subscriber name
* Click "Cancel" — verify the modal closes without changes
* Click "Remove" in the modal — verify a success notice appears and the comp is removed from the subscriber's plan list
* Verify the "Comp a subscription" button in the footer still works for adding new comps

Known issue: the subscribers list will not update immediately because of back-end caching.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)