### PR TITLE
Mailing Lists: Add AI Tips to User Notification Settings

### DIFF
--- a/client/me/notification-settings/wpcom-settings/index.jsx
+++ b/client/me/notification-settings/wpcom-settings/index.jsx
@@ -38,6 +38,7 @@ const options = {
 	digest: 'digest',
 	reports: 'reports',
 	news_developer: 'news_developer',
+	ai_tips: 'ai_tips',
 	scheduled_updates: 'scheduled_updates',
 };
 
@@ -171,6 +172,15 @@ class WPCOMNotifications extends Component {
 					title={ translate( 'Developer Newsletter' ) }
 					description={ translate(
 						'A once-monthly roundup of notable news for WordPress developers.'
+					) }
+				/>
+
+				<EmailCategory
+					name={ options.ai_tips }
+					isEnabled={ get( settings, options.ai_tips ) }
+					title={ translate( 'AI Tips' ) }
+					description={ translate(
+						'AI insights, breakthroughs, tips, and new feature highlights.'
 					) }
 				/>
 


### PR DESCRIPTION
Add `ai_tips` as a new email category option in the WPCOM notification settings page.

## Testing instructions

Visit [Notification settings](/me/notifications/updates). Confirm that the subscribe and resubscribe actions work, and that the title and description of the message are correctly displayed.

<img width="500" height="2020" alt="CleanShot 2026-03-19 at 11 01 58@2x" src="https://github.com/user-attachments/assets/41cef23f-2200-4e8c-ad59-b5747bc5d373" />

<img width="500" height="1996" alt="CleanShot 2026-03-19 at 11 02 12@2x" src="https://github.com/user-attachments/assets/20c4c03b-aafc-4044-8ede-d898aa2d16c2" />