### PR TITLE
Dockerfile: delete sourcemaps in the build layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,13 +111,13 @@ RUN yarn run build-packages:web
 # change any time any of the Calypso source-code changes.
 ENV NODE_ENV production
 ARG generate_cache_image=false
-RUN GENERATE_CACHE_IMAGE=$generate_cache_image yarn run build 2>&1 | tee /tmp/build_log.txt
+# Delete sourcemaps in the same layer as the build so trunk's hidden-source-map
+# artifacts do not have to be committed and then whiteouted in a later snapshot.
+RUN GENERATE_CACHE_IMAGE=$generate_cache_image yarn run build 2>&1 | tee /tmp/build_log.txt \
+	&& find /calypso/build /calypso/public -name "*.*.map" -delete
 
 # This will output a service message to TeamCity if the build cache was invalidated as seen in the build_log file.
 RUN ./bin/check-log-for-cache-invalidation.sh /tmp/build_log.txt
-
-# Delete any sourcemaps which may have been generated to avoid creating a large artifact.
-RUN find /calypso/build /calypso/public -name "*.*.map" -delete
 
 ###################
 # A cache-only update can be generated with "docker build --target update-base-cache"


### PR DESCRIPTION
## Proposed Changes

For the trunk build, we use hidden source maps with sentry like so.
* Run the build which generates hidden source maps, which are uploaded to sentry by a webpack plugin.
* Use `find -delete` in a subsequent step (almost the next one) to stop the sourcemaps from being deployed.

This PR combines the "run build && find -delete sourcemaps" into one docker RUN command, meaning that Docker/BuildKit won't have to commit all of them to a build layer only to remove them in the next step. I hypothesize this will give docker less work to do and reduce variance.

## Why are these changes being made?

*

## Testing Instructions


* Watch the next trunk build and ensure that sourcemaps still get uploaded

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
