### PR TITLE
MSD: correctly go back to previous steps when cancelling /setup/domain's checkout

### DIFF
--- a/client/dashboard/domains/add-domain-button.tsx
+++ b/client/dashboard/domains/add-domain-button.tsx
@@ -9,7 +9,7 @@ import { useAppContext } from '../app/context';
 import { siteRoute } from '../app/router/sites';
 import { getCurrentDashboard } from '../app/routing';
 import { getDomainConnectionSetupTemplateUrl } from '../utils/domain-url';
-import { wpcomLink } from '../utils/link';
+import { redirectToDashboardLink, wpcomLink } from '../utils/link';
 
 function buildDomainQueryArgs( siteSlug?: string, adminUrl?: string ) {
 	const queryArgs: Record< string, string > = {};
@@ -25,6 +25,8 @@ function buildDomainQueryArgs( siteSlug?: string, adminUrl?: string ) {
 	if ( dashboard === 'ciab' && adminUrl ) {
 		queryArgs.redirect_to = `${ adminUrl }admin.php?page=next-admin&p=%2Fwoocommerce%2Fonboarding`;
 	}
+
+	queryArgs.back_to = redirectToDashboardLink();
 
 	return queryArgs;
 }

--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -99,6 +99,7 @@ const domain: FlowV2< typeof initialize > = {
 		const isCiab = dashboard === 'ciab';
 
 		const redirectTo = useQuery().get( 'redirect_to' ) || undefined;
+		const backTo = useQuery().get( 'back_to' ) || undefined;
 		const defaultRedirect = dashboardLink( `/sites/${ siteSlug }/domains` );
 
 		const goToCheckout = ( siteSlug: string ) => {
@@ -139,6 +140,7 @@ const domain: FlowV2< typeof initialize > = {
 						addQueryArgs( '/setup/domain', {
 							siteSlug,
 							redirect_to: redirectTo,
+							...( backTo && { back_to: backTo } ),
 							...( dashboard && { dashboard } ),
 						} ),
 						window.location.href
@@ -191,6 +193,7 @@ const domain: FlowV2< typeof initialize > = {
 								addQueryArgs( '/setup/domain', {
 									siteSlug,
 									redirect_to: redirectTo,
+									...( backTo && { back_to: backTo } ),
 									...( dashboard && { dashboard } ),
 								} ),
 								window.location.href

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -383,13 +383,7 @@ const DomainSearchStep: StepType< {
 			} else if ( 'general-settings' === source && siteSlug ) {
 				backDestination = `/settings/general/${ siteSlug }`;
 				backLabelText = __( 'Back to General Settings' );
-			} else if ( ! isOnboardingFlow( flow ) && navigation.goBack ) {
-				backDestination = navigation.goBack;
-				backLabelText = __( 'Back' );
 			} else {
-				backDestination = defaultBackUrl;
-				backLabelText = sitesBackLabelText;
-
 				const isSafeBackTo =
 					isRelativeUrl( backTo ) ||
 					dashboardOrigins().some( ( origin ) => backTo?.startsWith( origin ) );
@@ -397,6 +391,12 @@ const DomainSearchStep: StepType< {
 				if ( isSafeBackTo ) {
 					backDestination = backTo;
 					backLabelText = __( 'Back' );
+				} else if ( ! isOnboardingFlow( flow ) && navigation.goBack ) {
+					backDestination = navigation.goBack;
+					backLabelText = __( 'Back' );
+				} else {
+					backDestination = defaultBackUrl;
+					backLabelText = sitesBackLabelText;
 				}
 			}
 


### PR DESCRIPTION
Part of DOTMSD-1126 -- fixing back button behavior

## Proposed Changes

Pass and forward `back_to` param to all checkout URLs constructed by the domain flow (`/setup/domain`), so that canceling checkout will land to that `back_to` URL.

## Testing Instructions

### MSD - dotcom

1. Click `Dashboard (dotcom) Live` link.
1. Navigate to a site domains page (`/sites/:siteSlug/domains`).
3. Click "Add domain name" → "Search domain names".
4. Select a domain and proceed to plan selection and then checkout.
5. Click the back/cancel button in checkout.
6. Verify you land on /setup/domain.
7. Click the back button in the top bar.
8. Verify you return to the original site domains page.


### MSD - CIAB

1. Click `Dashboard (CIAB) Live` link.
1. Navigate to a site domains page (`/sites/:siteSlug/domains`).
3. Click "Add domain name" → "Search domain names".
4. Select a domain and proceed to checkout.
5. Click the back/cancel button in checkout.
6. Verify you land on /setup/domain.
7. Click the back button in the top bar.
8. Verify you return to the original site domains page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
