### PR TITLE
Theme Showcase: Add modern plan upgrade banners

### DIFF
--- a/client/my-sites/themes/banners-modern/plan-upgrade-banner.tsx
+++ b/client/my-sites/themes/banners-modern/plan-upgrade-banner.tsx
@@ -9,6 +9,7 @@ import {
 	PLAN_BUSINESS_MONTHLY,
 } from '@automattic/calypso-products';
 import { Button } from '@wordpress/components';
+import { Icon, check } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
@@ -19,27 +20,6 @@ import { getProductCost, getProductDisplayCost } from 'calypso/state/products-li
 import type { IAppState } from 'calypso/state/types';
 
 import './style.scss';
-
-const CheckCircleIcon = () => (
-	<svg
-		className="plan-upgrade-banner__check-icon"
-		width="24"
-		height="24"
-		viewBox="0 0 24 24"
-		fill="none"
-		xmlns="http://www.w3.org/2000/svg"
-		aria-hidden="true"
-	>
-		<circle cx="12" cy="12" r="12" fill="currentColor" />
-		<path
-			d="M7.5 12.5l3 3 6-6"
-			stroke="white"
-			strokeWidth="2"
-			strokeLinecap="round"
-			strokeLinejoin="round"
-		/>
-	</svg>
-);
 
 interface PlanUpgradeBannerProps {
 	planSlug: typeof PLAN_PERSONAL | typeof PLAN_PREMIUM | typeof PLAN_BUSINESS;
@@ -101,13 +81,13 @@ const PlanUpgradeBanner = ( { planSlug, variant = 'light' }: PlanUpgradeBannerPr
 			className={ clsx( 'banner-modern plan-upgrade-banner', { 'is-dark': variant === 'dark' } ) }
 		>
 			<div className="plan-upgrade-banner__plan">
-				<h2 className="plan-upgrade-banner__title">
+				<h2 className="banner-modern__title plan-upgrade-banner__title">
 					{
 						// translators: %(planName)s is the plan name - e.g. Business or Premium
 						translate( '%(planName)s plan', { args: { planName: plan.getTitle() } } )
 					}
 				</h2>
-				<p className="plan-upgrade-banner__description">
+				<p className="banner-modern__description plan-upgrade-banner__description">
 					{
 						// @ts-ignore - getPlanTagline is not typed as existing on all plan types, but it is in practice
 						preventWidows( plan.getPlanTagline() )
@@ -121,7 +101,9 @@ const PlanUpgradeBanner = ( { planSlug, variant = 'light' }: PlanUpgradeBannerPr
 				<ul className="plan-upgrade-banner__features-list">
 					{ features.map( ( feature, index ) => (
 						<li key={ index } className="plan-upgrade-banner__features-item">
-							<CheckCircleIcon />
+							<div className="plan-upgrade-banner__check-icon">
+								<Icon icon={ check } size={ 18 } />
+							</div>
 							<span>{ feature.getTitle() }</span>
 						</li>
 					) ) }
@@ -141,7 +123,9 @@ const PlanUpgradeBanner = ( { planSlug, variant = 'light' }: PlanUpgradeBannerPr
 						<input type="radio" checked={ ! isMonthly } onChange={ () => setIsMonthly( false ) } />
 						<span>{ translate( 'Annually' ) }</span>
 						<span className="plan-upgrade-banner__billing-savings">
-							{ translate( '(save %(percent)s%%)', { args: { percent: annualDiscount } } ) }
+							{ annualDiscount
+								? translate( '(save %(percent)s%%)', { args: { percent: annualDiscount } } )
+								: '' }
 						</span>
 					</label>
 				</fieldset>

--- a/client/my-sites/themes/banners-modern/plan-upgrade-banner.tsx
+++ b/client/my-sites/themes/banners-modern/plan-upgrade-banner.tsx
@@ -1,10 +1,22 @@
+import {
+	getFeatureByKey,
+	getPlan,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_MONTHLY,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_MONTHLY,
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_MONTHLY,
+} from '@automattic/calypso-products';
 import { Button } from '@wordpress/components';
-import { useInstanceId } from '@wordpress/compose';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
+import { useSelector } from 'react-redux';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { preventWidows } from 'calypso/lib/formatting';
+import { getProductCost, getProductDisplayCost } from 'calypso/state/products-list/selectors';
+import type { IAppState } from 'calypso/state/types';
 
 import './style.scss';
 
@@ -30,89 +42,119 @@ const CheckCircleIcon = () => (
 );
 
 interface PlanUpgradeBannerProps {
+	planSlug: typeof PLAN_PERSONAL | typeof PLAN_PREMIUM | typeof PLAN_BUSINESS;
 	variant?: 'light' | 'dark';
 }
 
-const PlanUpgradeBanner = ( { variant = 'light' }: PlanUpgradeBannerProps ) => {
+const monthlyPlansMap = {
+	[ PLAN_PERSONAL ]: PLAN_PERSONAL_MONTHLY,
+	[ PLAN_PREMIUM ]: PLAN_PREMIUM_MONTHLY,
+	[ PLAN_BUSINESS ]: PLAN_BUSINESS_MONTHLY,
+};
+
+const PlanUpgradeBanner = ( { planSlug, variant = 'light' }: PlanUpgradeBannerProps ) => {
 	const translate = useTranslate();
-	const instanceId = useInstanceId( PlanUpgradeBanner );
-	const [ billingPeriod, setBillingPeriod ] = useState< 'monthly' | 'annually' >( 'monthly' );
+	const [ isMonthly, setIsMonthly ] = useState< boolean >( false );
+
+	const plan = getPlan( planSlug );
+
+	const monthlyPlanSlug = monthlyPlansMap[ planSlug ];
+	const monthlyPlan = getPlan( monthlyPlanSlug );
+
+	const costMonth = useSelector(
+		( state: IAppState ) => getProductCost( state, monthlyPlanSlug ) || 0
+	);
+	const displayCostMonth = useSelector( ( state: IAppState ) =>
+		getProductDisplayCost( state, monthlyPlanSlug )
+	);
+	const costYear = useSelector( ( state: IAppState ) => getProductCost( state, planSlug ) || 0 );
+	const displayCostYear = useSelector( ( state: IAppState ) =>
+		getProductDisplayCost( state, planSlug )
+	);
+
+	const costMonthAnnualized = costMonth * 12;
+	const annualDiscount = Math.floor(
+		( ( costYear - costMonthAnnualized ) / costMonthAnnualized ) * -100
+	);
 
 	const trackClick = useCallback( () => {
-		recordTracksEvent( 'calypso_themeshowcase_plan_upgrade_banner_click' );
-	}, [] );
+		recordTracksEvent( 'calypso_themeshowcase_plan_upgrade_banner_click', {
+			plan: isMonthly ? monthlyPlanSlug : planSlug,
+		} );
+	}, [ isMonthly, monthlyPlanSlug, planSlug ] );
 
-	const features = [
-		translate( 'Free domain for one year' ),
-		translate( 'Install plugins & themes' ),
-		translate( 'Real-time backups' ),
-	];
+	if ( ! plan || ! monthlyPlan ) {
+		return null;
+	}
 
-	const price = billingPeriod === 'monthly' ? 38 : 30;
+	const amount = isMonthly ? displayCostMonth : displayCostYear;
+	const period = isMonthly ? translate( '/month' ) : translate( '/year' );
+	// @ts-ignore - if plan or monthlyPlan are null, the component doesn't render
+	const pathSlug = isMonthly ? monthlyPlan.getPathSlug() : plan.getPathSlug();
+
+	// @ts-ignore - getSignupFeatures is not typed as existing on all plan types, but it is in practice
+	const featureSlugs: string[] = plan.getSignupFeatures();
+	const features = featureSlugs.map( getFeatureByKey ).filter( Boolean );
 
 	return (
 		<div
 			className={ clsx( 'banner-modern plan-upgrade-banner', { 'is-dark': variant === 'dark' } ) }
 		>
 			<div className="plan-upgrade-banner__plan">
-				<h2 className="plan-upgrade-banner__title">{ translate( 'Business plan' ) }</h2>
+				<h2 className="plan-upgrade-banner__title">
+					{
+						// translators: %(planName)s is the plan name - e.g. Business or Premium
+						translate( '%(planName)s plan', { args: { planName: plan.getTitle() } } )
+					}
+				</h2>
 				<p className="plan-upgrade-banner__description">
-					{ preventWidows(
-						translate(
-							'Instantly unlock thousands of different themes and install your own when you choose the Business plan.'
-						)
-					) }
+					{
+						// @ts-ignore - getPlanTagline is not typed as existing on all plan types, but it is in practice
+						preventWidows( plan.getPlanTagline() )
+					}
 				</p>
 			</div>
 			<div className="plan-upgrade-banner__features">
 				<h3 className="plan-upgrade-banner__features-heading">
-					{ translate( "What's included" ) }
+					{ translate( 'What’s included' ) }
 				</h3>
 				<ul className="plan-upgrade-banner__features-list">
 					{ features.map( ( feature, index ) => (
 						<li key={ index } className="plan-upgrade-banner__features-item">
 							<CheckCircleIcon />
-							<span>{ feature }</span>
+							<span>{ feature.getTitle() }</span>
 						</li>
 					) ) }
 				</ul>
 			</div>
 			<div className="plan-upgrade-banner__pricing">
 				<div className="plan-upgrade-banner__price">
-					<span className="plan-upgrade-banner__price-currency">$</span>
-					<span className="plan-upgrade-banner__price-amount">{ price }</span>
-					<span className="plan-upgrade-banner__price-period">{ translate( '/month' ) }</span>
+					<span className="plan-upgrade-banner__price-amount">{ amount }</span>
+					<span className="plan-upgrade-banner__price-period">{ period }</span>
 				</div>
 				<fieldset className="plan-upgrade-banner__billing-toggle">
 					<label className="plan-upgrade-banner__billing-option">
-						<input
-							type="radio"
-							name={ `plan-upgrade-billing-${ instanceId }` }
-							checked={ billingPeriod === 'monthly' }
-							onChange={ () => setBillingPeriod( 'monthly' ) }
-						/>
+						<input type="radio" checked={ isMonthly } onChange={ () => setIsMonthly( true ) } />
 						<span>{ translate( 'Monthly' ) }</span>
 					</label>
 					<label className="plan-upgrade-banner__billing-option">
-						<input
-							type="radio"
-							name={ `plan-upgrade-billing-${ instanceId }` }
-							checked={ billingPeriod === 'annually' }
-							onChange={ () => setBillingPeriod( 'annually' ) }
-						/>
+						<input type="radio" checked={ ! isMonthly } onChange={ () => setIsMonthly( false ) } />
 						<span>{ translate( 'Annually' ) }</span>
 						<span className="plan-upgrade-banner__billing-savings">
-							{ translate( '(save %(percent)s%%)', { args: { percent: 37 } } ) }
+							{ translate( '(save %(percent)s%%)', { args: { percent: annualDiscount } } ) }
 						</span>
 					</label>
 				</fieldset>
 				<Button
 					className="plan-upgrade-banner__cta"
 					variant="primary"
-					href="/plans"
+					href={ `/start/${ pathSlug }/?ref=themes-lp` }
 					onClick={ trackClick }
 				>
-					{ translate( 'Get Business' ) }
+					{
+						// translators: %(planName)s is the plan name - e.g. Business or Premium
+						translate( 'Get %(planName)s', { args: { planName: plan.getTitle() } } )
+					}
 				</Button>
 			</div>
 		</div>

--- a/client/my-sites/themes/banners-modern/plan-upgrade-banner.tsx
+++ b/client/my-sites/themes/banners-modern/plan-upgrade-banner.tsx
@@ -1,0 +1,122 @@
+import { Button } from '@wordpress/components';
+import { useInstanceId } from '@wordpress/compose';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useState } from 'react';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { preventWidows } from 'calypso/lib/formatting';
+
+import './style.scss';
+
+const CheckCircleIcon = () => (
+	<svg
+		className="plan-upgrade-banner__check-icon"
+		width="24"
+		height="24"
+		viewBox="0 0 24 24"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+		aria-hidden="true"
+	>
+		<circle cx="12" cy="12" r="12" fill="currentColor" />
+		<path
+			d="M7.5 12.5l3 3 6-6"
+			stroke="white"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		/>
+	</svg>
+);
+
+interface PlanUpgradeBannerProps {
+	variant?: 'light' | 'dark';
+}
+
+const PlanUpgradeBanner = ( { variant = 'light' }: PlanUpgradeBannerProps ) => {
+	const translate = useTranslate();
+	const instanceId = useInstanceId( PlanUpgradeBanner );
+	const [ billingPeriod, setBillingPeriod ] = useState< 'monthly' | 'annually' >( 'monthly' );
+
+	const trackClick = useCallback( () => {
+		recordTracksEvent( 'calypso_themeshowcase_plan_upgrade_banner_click' );
+	}, [] );
+
+	const features = [
+		translate( 'Free domain for one year' ),
+		translate( 'Install plugins & themes' ),
+		translate( 'Real-time backups' ),
+	];
+
+	const price = billingPeriod === 'monthly' ? 38 : 30;
+
+	return (
+		<div
+			className={ clsx( 'banner-modern plan-upgrade-banner', { 'is-dark': variant === 'dark' } ) }
+		>
+			<div className="plan-upgrade-banner__plan">
+				<h2 className="plan-upgrade-banner__title">{ translate( 'Business plan' ) }</h2>
+				<p className="plan-upgrade-banner__description">
+					{ preventWidows(
+						translate(
+							'Instantly unlock thousands of different themes and install your own when you choose the Business plan.'
+						)
+					) }
+				</p>
+			</div>
+			<div className="plan-upgrade-banner__features">
+				<h3 className="plan-upgrade-banner__features-heading">
+					{ translate( "What's included" ) }
+				</h3>
+				<ul className="plan-upgrade-banner__features-list">
+					{ features.map( ( feature, index ) => (
+						<li key={ index } className="plan-upgrade-banner__features-item">
+							<CheckCircleIcon />
+							<span>{ feature }</span>
+						</li>
+					) ) }
+				</ul>
+			</div>
+			<div className="plan-upgrade-banner__pricing">
+				<div className="plan-upgrade-banner__price">
+					<span className="plan-upgrade-banner__price-currency">$</span>
+					<span className="plan-upgrade-banner__price-amount">{ price }</span>
+					<span className="plan-upgrade-banner__price-period">{ translate( '/month' ) }</span>
+				</div>
+				<fieldset className="plan-upgrade-banner__billing-toggle">
+					<label className="plan-upgrade-banner__billing-option">
+						<input
+							type="radio"
+							name={ `plan-upgrade-billing-${ instanceId }` }
+							checked={ billingPeriod === 'monthly' }
+							onChange={ () => setBillingPeriod( 'monthly' ) }
+						/>
+						<span>{ translate( 'Monthly' ) }</span>
+					</label>
+					<label className="plan-upgrade-banner__billing-option">
+						<input
+							type="radio"
+							name={ `plan-upgrade-billing-${ instanceId }` }
+							checked={ billingPeriod === 'annually' }
+							onChange={ () => setBillingPeriod( 'annually' ) }
+						/>
+						<span>{ translate( 'Annually' ) }</span>
+						<span className="plan-upgrade-banner__billing-savings">
+							{ translate( '(save %(percent)s%%)', { args: { percent: 37 } } ) }
+						</span>
+					</label>
+				</fieldset>
+				<Button
+					className="plan-upgrade-banner__cta"
+					variant="primary"
+					href="/plans"
+					onClick={ trackClick }
+				>
+					{ translate( 'Get Business' ) }
+				</Button>
+			</div>
+		</div>
+	);
+};
+
+export default PlanUpgradeBanner;

--- a/client/my-sites/themes/banners-modern/style.scss
+++ b/client/my-sites/themes/banners-modern/style.scss
@@ -210,12 +210,15 @@
 	display: grid;
 	gap: 24px;
 	grid-template-columns: 1fr;
+	margin: 48px auto;
 	padding: 24px;
+	width: calc( 100% - 24px - 24px );
 
 	@include break-medium {
 		align-items: center;
 		grid-template-columns: 1fr 1fr 1fr;
 		padding: 40px;
+		width: calc( 100% - 40px - 40px );
 	}
 }
 

--- a/client/my-sites/themes/banners-modern/style.scss
+++ b/client/my-sites/themes/banners-modern/style.scss
@@ -194,64 +194,60 @@
 
 // Plan upgrade banner
 .plan-upgrade-banner {
-	--plan-banner-bg: var( --studio-gray-0 );
-	--plan-banner-text: var( --studio-gray-100 );
-	--plan-banner-text-secondary: var( --studio-gray-80 );
-	--plan-banner-text-tertiary: var( --studio-gray-60 );
 	--plan-banner-accent: var( --studio-blue-50 );
+
+	--plan-banner-bg: var( --studio-blue-5 );
+	--plan-banner-title: var( --studio-gray-100 );
+	--plan-banner-description: var( --studio-gray-80 );
+	--plan-banner-features: var( --studio-gray-80 );
+	--plan-banner-feature-check: var( --plan-banner-accent );
+	--plan-banner-price: var( --studio-gray-80 );
 	--plan-banner-radio-border: var( --studio-gray-20 );
 	--plan-banner-radio-bg: var( --studio-white );
 
 	background-color: var( --plan-banner-bg );
-	border-inline-start: 4px solid var( --plan-banner-accent );
+	border: 1px solid var( --plan-banner-accent );
 	display: grid;
 	gap: 24px;
 	grid-template-columns: 1fr;
-	padding: 32px 24px;
+	padding: 24px;
 
 	@include break-medium {
 		align-items: center;
-		grid-template-columns: 2fr 1.5fr 1.5fr;
-		padding: 32px;
+		grid-template-columns: 1fr 1fr 1fr;
+		padding: 40px;
 	}
 }
 
 .plan-upgrade-banner.is-dark {
-	--plan-banner-bg: var( --studio-gray-90 );
-	--plan-banner-text: var( --studio-white );
-	--plan-banner-text-secondary: var( --studio-gray-20 );
-	--plan-banner-text-tertiary: var( --studio-gray-30 );
+	--plan-banner-bg: var( --studio-gray-80 );
+	--plan-banner-title: var( --studio-gray-0 );
+	--plan-banner-description: var( --studio-gray-0 );
+	--plan-banner-features: var( --studio-white );
+	--plan-banner-feature-check: var( --studio-gray-5 );
+	--plan-banner-price: var( --studio-white );
 	--plan-banner-radio-border: var( --studio-gray-50 );
-	--plan-banner-radio-bg: var( --studio-gray-90 );
+	--plan-banner-radio-bg: var( --studio-white );
 
-	border-inline-start: none;
+	border: none;
 }
 
 .plan-upgrade-banner__title {
-	color: var( --plan-banner-text );
-	font-family: $brand-serif;
-	font-size: rem( 32px );
-	font-weight: 400;
-	line-height: 1.2;
-	margin: 0;
-
-	@include break-medium {
-		font-size: rem( 40px );
-	}
+	color: var( --plan-banner-title );
+	font-size: $font-title-large;
 }
-
 .plan-upgrade-banner__description {
-	color: var( --plan-banner-text-secondary );
+	color: var( --plan-banner-description );
 	font-size: $font-body;
-	line-height: 1.5;
-	margin: 8px 0 0;
+	margin-bottom: 0;
+	text-wrap: balance;
 }
 
 .plan-upgrade-banner__features-heading {
-	color: var( --plan-banner-text );
+	color: var( --plan-banner-features );
 	font-size: $font-body;
 	font-weight: 600;
-	margin: 0 0 12px;
+	margin-bottom: 8px;
 }
 
 .plan-upgrade-banner__features-list {
@@ -262,67 +258,73 @@
 
 .plan-upgrade-banner__features-item {
 	align-items: center;
-	color: var( --plan-banner-text-secondary );
+	color: var( --plan-banner-features );
 	display: flex;
-	font-size: $font-body;
+	font-size: $font-body-small;
 	gap: 8px;
 	line-height: 1.5;
-
-	& + & {
-		margin-block-start: 8px;
-	}
+	margin: 8px 0;
 }
 
 .plan-upgrade-banner__check-icon {
-	color: var( --plan-banner-accent );
+	background-color: var( --plan-banner-feature-check );
+	border-radius: 50%;
+	fill: var( --plan-banner-bg );
 	flex-shrink: 0;
-	height: 20px;
-	width: 20px;
+	height: 18px;
+	width: 18px;
 }
 
 .plan-upgrade-banner__price {
 	align-items: flex-start;
 	display: flex;
 	gap: 2px;
-	margin-block-end: 8px;
+	margin-block-end: 16px;
 }
 
 .plan-upgrade-banner__price-amount {
-	color: var( --plan-banner-text );
+	color: var( --plan-banner-price );
 	font-family: $brand-serif;
-	font-size: rem( 56px );
+	font-size: $font-headline-medium;
 	font-weight: 400;
 	line-height: 1;
 }
 
 .plan-upgrade-banner__price-period {
 	align-self: flex-end;
-	color: var( --plan-banner-text-tertiary );
-	font-size: $font-body;
-	margin-block-end: 8px;
+	color: var( --plan-banner-price );
+	font-size: $font-body-small;
+	margin-bottom: 8px;
 }
 
 .plan-upgrade-banner__billing-toggle {
+	align-items: flex-start;
 	border: none;
 	display: flex;
 	gap: 16px;
-	margin: 0 0 16px;
+	margin: 0 0 24px;
 	padding: 0;
 }
 
 .plan-upgrade-banner__billing-option {
 	align-items: center;
-	color: var( --plan-banner-text-secondary );
+	color: var( --plan-banner-price );
 	cursor: pointer;
 	display: flex;
-	font-size: $font-body;
+	font-size: $font-body-small;
 	gap: 6px;
+
+	&:last-child {
+		flex-wrap: wrap;
+	}
 
 	input[type='radio'] {
 		appearance: none;
-		border: 2px solid var( --plan-banner-radio-border );
+		background-color: var( --plan-banner-radio-bg );
+		border: 1px solid var( --plan-banner-radio-border );
 		border-radius: 50%;
 		cursor: pointer;
+		flex-shrink: 0;
 		height: 20px;
 		margin: 0;
 		width: 20px;
@@ -331,13 +333,12 @@
 	input[type='radio']:checked {
 		background-color: var( --plan-banner-accent );
 		border-color: var( --plan-banner-accent );
-		box-shadow: inset 0 0 0 3px var( --plan-banner-radio-bg );
+		box-shadow: inset 0 0 0 2px var( --plan-banner-radio-bg );
 	}
 }
 
 .plan-upgrade-banner__billing-savings {
-	color: var( --plan-banner-text-tertiary );
-	font-size: $font-body-small;
+	font-size: $font-body-extra-small;
 }
 
 .plan-upgrade-banner__cta.components-button.is-primary {
@@ -346,9 +347,8 @@
 	--wp-components-color-accent-darker-20: var( --studio-blue-70 );
 
 	border-radius: 4px;
-	font-size: $font-body;
+	font-size: $font-body-small;
 	height: auto;
-	justify-content: center;
 	padding: 12px 24px;
 	width: 100%;
 }

--- a/client/my-sites/themes/banners-modern/style.scss
+++ b/client/my-sites/themes/banners-modern/style.scss
@@ -287,13 +287,6 @@
 	margin-block-end: 8px;
 }
 
-.plan-upgrade-banner__price-currency {
-	color: var( --plan-banner-text );
-	font-size: rem( 20px );
-	line-height: 1;
-	margin-block-start: 8px;
-}
-
 .plan-upgrade-banner__price-amount {
 	color: var( --plan-banner-text );
 	font-family: $brand-serif;

--- a/client/my-sites/themes/banners-modern/style.scss
+++ b/client/my-sites/themes/banners-modern/style.scss
@@ -191,3 +191,171 @@
 		background-color: var( --studio-gray-0 );
 	}
 }
+
+// Plan upgrade banner
+.plan-upgrade-banner {
+	--plan-banner-bg: var( --studio-gray-0 );
+	--plan-banner-text: var( --studio-gray-100 );
+	--plan-banner-text-secondary: var( --studio-gray-80 );
+	--plan-banner-text-tertiary: var( --studio-gray-60 );
+	--plan-banner-accent: var( --studio-blue-50 );
+	--plan-banner-radio-border: var( --studio-gray-20 );
+	--plan-banner-radio-bg: var( --studio-white );
+
+	background-color: var( --plan-banner-bg );
+	border-inline-start: 4px solid var( --plan-banner-accent );
+	display: grid;
+	gap: 24px;
+	grid-template-columns: 1fr;
+	padding: 32px 24px;
+
+	@include break-medium {
+		align-items: center;
+		grid-template-columns: 2fr 1.5fr 1.5fr;
+		padding: 32px;
+	}
+}
+
+.plan-upgrade-banner.is-dark {
+	--plan-banner-bg: var( --studio-gray-90 );
+	--plan-banner-text: var( --studio-white );
+	--plan-banner-text-secondary: var( --studio-gray-20 );
+	--plan-banner-text-tertiary: var( --studio-gray-30 );
+	--plan-banner-radio-border: var( --studio-gray-50 );
+	--plan-banner-radio-bg: var( --studio-gray-90 );
+
+	border-inline-start: none;
+}
+
+.plan-upgrade-banner__title {
+	color: var( --plan-banner-text );
+	font-family: $brand-serif;
+	font-size: rem( 32px );
+	font-weight: 400;
+	line-height: 1.2;
+	margin: 0;
+
+	@include break-medium {
+		font-size: rem( 40px );
+	}
+}
+
+.plan-upgrade-banner__description {
+	color: var( --plan-banner-text-secondary );
+	font-size: $font-body;
+	line-height: 1.5;
+	margin: 8px 0 0;
+}
+
+.plan-upgrade-banner__features-heading {
+	color: var( --plan-banner-text );
+	font-size: $font-body;
+	font-weight: 600;
+	margin: 0 0 12px;
+}
+
+.plan-upgrade-banner__features-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.plan-upgrade-banner__features-item {
+	align-items: center;
+	color: var( --plan-banner-text-secondary );
+	display: flex;
+	font-size: $font-body;
+	gap: 8px;
+	line-height: 1.5;
+
+	& + & {
+		margin-block-start: 8px;
+	}
+}
+
+.plan-upgrade-banner__check-icon {
+	color: var( --plan-banner-accent );
+	flex-shrink: 0;
+	height: 20px;
+	width: 20px;
+}
+
+.plan-upgrade-banner__price {
+	align-items: flex-start;
+	display: flex;
+	gap: 2px;
+	margin-block-end: 8px;
+}
+
+.plan-upgrade-banner__price-currency {
+	color: var( --plan-banner-text );
+	font-size: rem( 20px );
+	line-height: 1;
+	margin-block-start: 8px;
+}
+
+.plan-upgrade-banner__price-amount {
+	color: var( --plan-banner-text );
+	font-family: $brand-serif;
+	font-size: rem( 56px );
+	font-weight: 400;
+	line-height: 1;
+}
+
+.plan-upgrade-banner__price-period {
+	align-self: flex-end;
+	color: var( --plan-banner-text-tertiary );
+	font-size: $font-body;
+	margin-block-end: 8px;
+}
+
+.plan-upgrade-banner__billing-toggle {
+	border: none;
+	display: flex;
+	gap: 16px;
+	margin: 0 0 16px;
+	padding: 0;
+}
+
+.plan-upgrade-banner__billing-option {
+	align-items: center;
+	color: var( --plan-banner-text-secondary );
+	cursor: pointer;
+	display: flex;
+	font-size: $font-body;
+	gap: 6px;
+
+	input[type='radio'] {
+		appearance: none;
+		border: 2px solid var( --plan-banner-radio-border );
+		border-radius: 50%;
+		cursor: pointer;
+		height: 20px;
+		margin: 0;
+		width: 20px;
+	}
+
+	input[type='radio']:checked {
+		background-color: var( --plan-banner-accent );
+		border-color: var( --plan-banner-accent );
+		box-shadow: inset 0 0 0 3px var( --plan-banner-radio-bg );
+	}
+}
+
+.plan-upgrade-banner__billing-savings {
+	color: var( --plan-banner-text-tertiary );
+	font-size: $font-body-small;
+}
+
+.plan-upgrade-banner__cta.components-button.is-primary {
+	--wp-components-color-accent: var( --plan-banner-accent );
+	--wp-components-color-accent-darker-10: var( --studio-blue-60 );
+	--wp-components-color-accent-darker-20: var( --studio-blue-70 );
+
+	border-radius: 4px;
+	font-size: $font-body;
+	height: auto;
+	justify-content: center;
+	padding: 12px 24px;
+	width: 100%;
+}

--- a/client/my-sites/themes/banners-modern/test/plan-upgrade-banner.test.tsx
+++ b/client/my-sites/themes/banners-modern/test/plan-upgrade-banner.test.tsx
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { PLAN_BUSINESS, PLAN_PREMIUM } from '@automattic/calypso-products';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import PlanUpgradeBanner from '../plan-upgrade-banner';
@@ -10,64 +11,74 @@ jest.mock( 'calypso/lib/analytics/tracks', () => ( {
 	recordTracksEvent: ( ...args: unknown[] ) => mockRecordTracksEvent( ...args ),
 } ) );
 
+jest.mock( 'react-redux', () => ( {
+	...jest.requireActual( 'react-redux' ),
+	useSelector: jest.fn( () => '$96' ),
+} ) );
+
 describe( 'PlanUpgradeBanner', () => {
 	beforeEach( () => {
 		mockRecordTracksEvent.mockClear();
 	} );
 
-	test( 'renders title', () => {
-		render( <PlanUpgradeBanner /> );
-		expect( screen.getByText( 'Business plan' ) ).toBeVisible();
-	} );
-
-	test( 'renders description', () => {
-		render( <PlanUpgradeBanner /> );
-		expect( screen.getByText( /Instantly unlock thousands of different themes/ ) ).toBeVisible();
+	test( 'renders plan title and description', () => {
+		render( <PlanUpgradeBanner planSlug={ PLAN_BUSINESS } /> );
+		expect( screen.getByRole( 'heading', { level: 2 } ) ).toBeVisible();
+		expect( screen.getByRole( 'heading', { level: 3 } ) ).toBeVisible();
 	} );
 
 	test( 'renders features list', () => {
-		render( <PlanUpgradeBanner /> );
-		expect( screen.getByText( 'Free domain for one year' ) ).toBeVisible();
-		expect( screen.getByText( 'Install plugins & themes' ) ).toBeVisible();
-		expect( screen.getByText( 'Real-time backups' ) ).toBeVisible();
+		render( <PlanUpgradeBanner planSlug={ PLAN_BUSINESS } /> );
+		const items = screen.getAllByRole( 'listitem' );
+		expect( items.length ).toBeGreaterThan( 0 );
 	} );
 
-	test( 'renders CTA button linking to plans page', () => {
-		render( <PlanUpgradeBanner /> );
-		const button = screen.getByRole( 'link', { name: 'Get Business' } );
+	test( 'renders CTA button', () => {
+		render( <PlanUpgradeBanner planSlug={ PLAN_BUSINESS } /> );
+		const button = screen.getByRole( 'link', { name: /Get/ } );
 		expect( button ).toBeVisible();
-		expect( button ).toHaveAttribute( 'href', '/plans' );
+		expect( button ).toHaveAttribute( 'href', expect.stringContaining( '/start/' ) );
 	} );
 
-	test( 'tracks click event when CTA is clicked', async () => {
+	test( 'tracks click event with plan slug when CTA is clicked', async () => {
 		const user = userEvent.setup();
-		render( <PlanUpgradeBanner /> );
-		const button = screen.getByRole( 'link', { name: 'Get Business' } );
+		render( <PlanUpgradeBanner planSlug={ PLAN_BUSINESS } /> );
+		const button = screen.getByRole( 'link', { name: /Get/ } );
 		await user.click( button );
 		expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
-			'calypso_themeshowcase_plan_upgrade_banner_click'
+			'calypso_themeshowcase_plan_upgrade_banner_click',
+			expect.objectContaining( { plan: expect.any( String ) } )
 		);
 	} );
 
 	test( 'renders light variant by default', () => {
-		const { container } = render( <PlanUpgradeBanner /> );
+		const { container } = render( <PlanUpgradeBanner planSlug={ PLAN_BUSINESS } /> );
 		expect( container.querySelector( '.plan-upgrade-banner' ) ).not.toHaveClass( 'is-dark' );
 	} );
 
 	test( 'renders dark variant when specified', () => {
-		const { container } = render( <PlanUpgradeBanner variant="dark" /> );
+		const { container } = render( <PlanUpgradeBanner planSlug={ PLAN_BUSINESS } variant="dark" /> );
 		expect( container.querySelector( '.plan-upgrade-banner' ) ).toHaveClass( 'is-dark' );
 	} );
 
-	test( 'toggles billing period and updates price', async () => {
+	test( 'toggles billing period between monthly and annually', async () => {
 		const user = userEvent.setup();
-		render( <PlanUpgradeBanner /> );
+		render( <PlanUpgradeBanner planSlug={ PLAN_BUSINESS } /> );
 
-		expect( screen.getByText( '38' ) ).toBeVisible();
-
+		const monthlyRadio = screen.getByLabelText( /Monthly/ );
 		const annuallyRadio = screen.getByLabelText( /Annually/ );
-		await user.click( annuallyRadio );
 
-		expect( screen.getByText( '30' ) ).toBeVisible();
+		// Starts on annually
+		expect( annuallyRadio ).toBeChecked();
+		expect( monthlyRadio ).not.toBeChecked();
+
+		await user.click( monthlyRadio );
+		expect( monthlyRadio ).toBeChecked();
+		expect( annuallyRadio ).not.toBeChecked();
+	} );
+
+	test( 'renders with different plan slugs', () => {
+		const { container } = render( <PlanUpgradeBanner planSlug={ PLAN_PREMIUM } /> );
+		expect( container.querySelector( '.plan-upgrade-banner' ) ).toBeVisible();
 	} );
 } );

--- a/client/my-sites/themes/banners-modern/test/plan-upgrade-banner.test.tsx
+++ b/client/my-sites/themes/banners-modern/test/plan-upgrade-banner.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PlanUpgradeBanner from '../plan-upgrade-banner';
+
+const mockRecordTracksEvent = jest.fn();
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {
+	recordTracksEvent: ( ...args: unknown[] ) => mockRecordTracksEvent( ...args ),
+} ) );
+
+describe( 'PlanUpgradeBanner', () => {
+	beforeEach( () => {
+		mockRecordTracksEvent.mockClear();
+	} );
+
+	test( 'renders title', () => {
+		render( <PlanUpgradeBanner /> );
+		expect( screen.getByText( 'Business plan' ) ).toBeVisible();
+	} );
+
+	test( 'renders description', () => {
+		render( <PlanUpgradeBanner /> );
+		expect( screen.getByText( /Instantly unlock thousands of different themes/ ) ).toBeVisible();
+	} );
+
+	test( 'renders features list', () => {
+		render( <PlanUpgradeBanner /> );
+		expect( screen.getByText( 'Free domain for one year' ) ).toBeVisible();
+		expect( screen.getByText( 'Install plugins & themes' ) ).toBeVisible();
+		expect( screen.getByText( 'Real-time backups' ) ).toBeVisible();
+	} );
+
+	test( 'renders CTA button linking to plans page', () => {
+		render( <PlanUpgradeBanner /> );
+		const button = screen.getByRole( 'link', { name: 'Get Business' } );
+		expect( button ).toBeVisible();
+		expect( button ).toHaveAttribute( 'href', '/plans' );
+	} );
+
+	test( 'tracks click event when CTA is clicked', async () => {
+		const user = userEvent.setup();
+		render( <PlanUpgradeBanner /> );
+		const button = screen.getByRole( 'link', { name: 'Get Business' } );
+		await user.click( button );
+		expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_themeshowcase_plan_upgrade_banner_click'
+		);
+	} );
+
+	test( 'renders light variant by default', () => {
+		const { container } = render( <PlanUpgradeBanner /> );
+		expect( container.querySelector( '.plan-upgrade-banner' ) ).not.toHaveClass( 'is-dark' );
+	} );
+
+	test( 'renders dark variant when specified', () => {
+		const { container } = render( <PlanUpgradeBanner variant="dark" /> );
+		expect( container.querySelector( '.plan-upgrade-banner' ) ).toHaveClass( 'is-dark' );
+	} );
+
+	test( 'toggles billing period and updates price', async () => {
+		const user = userEvent.setup();
+		render( <PlanUpgradeBanner /> );
+
+		expect( screen.getByText( '38' ) ).toBeVisible();
+
+		const annuallyRadio = screen.getByLabelText( /Annually/ );
+		await user.click( annuallyRadio );
+
+		expect( screen.getByText( '30' ) ).toBeVisible();
+	} );
+} );

--- a/client/my-sites/themes/sections-modern/recommended-sections.tsx
+++ b/client/my-sites/themes/sections-modern/recommended-sections.tsx
@@ -3,6 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { ThemesQuery } from 'calypso/my-sites/themes/collections/use-theme-collection';
 import AIBuilderBanner from '../banners-modern/ai-builder-banner';
 import DIFMBanner from '../banners-modern/difm-banner';
+import PlanUpgradeBanner from '../banners-modern/plan-upgrade-banner';
 import ThemeSection from './theme-section';
 
 const FAVORITES_QUERY: ThemesQuery = {
@@ -90,6 +91,7 @@ export default function RecommendedSections( {
 				query={ PARTNER_QUERY }
 				sectionSlug="partner"
 				sectionIndex={ 2 }
+				banner={ <PlanUpgradeBanner variant="dark" /> }
 				getActionLabel={ getActionLabel }
 				getOptions={ getOptions }
 				getScreenshotUrl={ getScreenshotUrl }

--- a/client/my-sites/themes/sections-modern/recommended-sections.tsx
+++ b/client/my-sites/themes/sections-modern/recommended-sections.tsx
@@ -1,4 +1,4 @@
-import { getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
+import { getPlan, PLAN_BUSINESS, PLAN_PREMIUM } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import { ThemesQuery } from 'calypso/my-sites/themes/collections/use-theme-collection';
 import AIBuilderBanner from '../banners-modern/ai-builder-banner';
@@ -91,7 +91,12 @@ export default function RecommendedSections( {
 				query={ PARTNER_QUERY }
 				sectionSlug="partner"
 				sectionIndex={ 2 }
-				banner={ <PlanUpgradeBanner planSlug={ PLAN_BUSINESS } variant="dark" /> }
+				banner={
+					<>
+						<PlanUpgradeBanner planSlug={ PLAN_PREMIUM } variant="light" />
+						<PlanUpgradeBanner planSlug={ PLAN_BUSINESS } variant="dark" />
+					</>
+				}
 				getActionLabel={ getActionLabel }
 				getOptions={ getOptions }
 				getScreenshotUrl={ getScreenshotUrl }

--- a/client/my-sites/themes/sections-modern/recommended-sections.tsx
+++ b/client/my-sites/themes/sections-modern/recommended-sections.tsx
@@ -91,7 +91,7 @@ export default function RecommendedSections( {
 				query={ PARTNER_QUERY }
 				sectionSlug="partner"
 				sectionIndex={ 2 }
-				banner={ <PlanUpgradeBanner variant="dark" /> }
+				banner={ <PlanUpgradeBanner planSlug={ PLAN_BUSINESS } variant="dark" /> }
 				getActionLabel={ getActionLabel }
 				getOptions={ getOptions }
 				getScreenshotUrl={ getScreenshotUrl }

--- a/client/my-sites/themes/sections-modern/recommended-sections.tsx
+++ b/client/my-sites/themes/sections-modern/recommended-sections.tsx
@@ -1,4 +1,4 @@
-import { getPlan, PLAN_BUSINESS, PLAN_PREMIUM } from '@automattic/calypso-products';
+import { getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import { ThemesQuery } from 'calypso/my-sites/themes/collections/use-theme-collection';
 import AIBuilderBanner from '../banners-modern/ai-builder-banner';
@@ -91,12 +91,7 @@ export default function RecommendedSections( {
 				query={ PARTNER_QUERY }
 				sectionSlug="partner"
 				sectionIndex={ 2 }
-				banner={
-					<>
-						<PlanUpgradeBanner planSlug={ PLAN_PREMIUM } variant="light" />
-						<PlanUpgradeBanner planSlug={ PLAN_BUSINESS } variant="dark" />
-					</>
-				}
+				banner={ <PlanUpgradeBanner planSlug={ PLAN_BUSINESS } variant="dark" /> }
 				getActionLabel={ getActionLabel }
 				getOptions={ getOptions }
 				getScreenshotUrl={ getScreenshotUrl }

--- a/client/my-sites/themes/sections-modern/style.scss
+++ b/client/my-sites/themes/sections-modern/style.scss
@@ -97,7 +97,7 @@
 	color: var(--theme-section-text-secondary);
 }
 
-.recommended-sections .banner-modern {
+.recommended-sections .banner-modern:not(.plan-upgrade-banner) {
 	margin: 108px auto;
 	max-width: calc( 1220px - 48px);
 	width: calc( 100% - 48px - 48px);
@@ -108,6 +108,5 @@
 	}
 }
 .recommended-sections .banner-modern.plan-upgrade-banner {
-	margin: 48px auto 0 auto;
-	width: auto;
+	margin-bottom: 0;
 }

--- a/client/my-sites/themes/sections-modern/style.scss
+++ b/client/my-sites/themes/sections-modern/style.scss
@@ -107,3 +107,7 @@
 		width: calc( 100% - 48px - 80px);
 	}
 }
+.recommended-sections .banner-modern.plan-upgrade-banner {
+	margin: 48px auto 0 auto;
+	width: auto;
+}

--- a/client/my-sites/themes/sections-modern/theme-section.tsx
+++ b/client/my-sites/themes/sections-modern/theme-section.tsx
@@ -24,6 +24,7 @@ export type ThemeSectionProps = {
 	sectionSlug: string;
 	sectionIndex: number;
 	variant?: 'light' | 'dark';
+	banner?: React.ReactNode;
 	getActionLabel: ( themeId: string ) => string;
 	getOptions: ( themeId: string ) => void;
 	getScreenshotUrl: ( themeId: string ) => string;
@@ -38,6 +39,7 @@ export default function ThemeSection( {
 	sectionSlug,
 	sectionIndex,
 	variant = 'light',
+	banner,
 	getActionLabel,
 	getOptions,
 	getScreenshotUrl,
@@ -127,6 +129,7 @@ export default function ThemeSection( {
 						onStyleVariationClick={ onStyleVariationClick }
 					/>
 				) ) }
+				{ banner }
 			</div>
 		</div>
 	);

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -42,6 +42,7 @@ import {
 } from 'calypso/state/themes/selectors';
 import { getThemesBookmark } from 'calypso/state/themes/themes-ui/selectors';
 import EligibilityWarningModal from './atomic-transfer-dialog';
+import PlanUpgradeBanner from './banners-modern/plan-upgrade-banner';
 import { CustomSelectWrapper } from './custom-select-wrapper';
 import {
 	addTracking,
@@ -462,6 +463,9 @@ class ThemeShowcase extends Component {
 								}
 							/>
 						</>
+					) }
+					{ this.isThemeShowcaseModern() && tier && (
+						<PlanUpgradeBanner planSlug={ THEME_TIERS[ tier ].minimumUpsellPlan } />
 					) }
 				</ThemesSelection>
 			</div>

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -640,7 +640,7 @@
 
 	.themes-list {
 		gap: 48px;
-		margin: 0 auto;
+		margin: 0 auto 96px auto;
 
 		@include break-small {
 			grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
@@ -649,11 +649,6 @@
 
 		.plan-upgrade-banner {
 			grid-row-start: 3;
-			margin: 48px auto;
-			width: calc( 100% - 24px - 24px );
-			@include break-medium {
-				width: calc( 100% - 40px - 40px );
-			}
 		}
 	}
 

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -646,6 +646,15 @@
 			grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
 			max-width: 1220px;
 		}
+
+		.plan-upgrade-banner {
+			grid-row-start: 3;
+			margin: 48px auto;
+			width: calc( 100% - 24px - 24px );
+			@include break-medium {
+				width: calc( 100% - 40px - 40px );
+			}
+		}
 	}
 
 	.theme-card {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTTHEM-335

## Proposed Changes

* Add plan upgrade banners to the modern Theme Showcase.
* These banners support three plans (Personal, Premium, Business), and two variants (light, dark).

| Header | Header |
|--------|--------|
| Personal / light | <img width="1169" height="274" alt="Screenshot 2026-03-19 at 16 04 40" src="https://github.com/user-attachments/assets/0e88ffd2-c4c4-43a8-b08b-33ad2c0fd14d" /> |
| Premium / light | <img width="1169" height="274" alt="Screenshot 2026-03-19 at 16 04 55" src="https://github.com/user-attachments/assets/0cc14772-04b4-411a-8d53-42dfcad2362b" /> |
| Business / light | <img width="1169" height="274" alt="Screenshot 2026-03-19 at 16 05 03" src="https://github.com/user-attachments/assets/6d87adfd-189d-4b85-ae67-1b7da2433650" /> |
| Business / dark | <img width="1169" height="274" alt="Screenshot 2026-03-19 at 16 05 15" src="https://github.com/user-attachments/assets/9f22c7fe-1127-41cd-81d6-1217776f2f8f" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The modern logged-out Theme Showcase displays contextual upgrade banners depending on the tier filter.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the logged-out Theme Showcase with the `themes/showcase-modern` feature flag enabled.
* In the main page, look at the dark "Partner themes" section, and play around with the upgrade banner (Business plan, dark variant).
* Now change the tier filter.
* Ensure there's a corresponding upgrade banner (contextual plan, light variant) in the third row of the list.
* Pick the free tier.
* Ensure there's no upgrade banner displayed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
