### PR TITLE
Fix plans card navigation for expired trial sites

### DIFF
--- a/client/dashboard/components/overview-card/index.tsx
+++ b/client/dashboard/components/overview-card/index.tsx
@@ -91,13 +91,18 @@ export default function OverviewCard( {
 		return <>&nbsp;</>;
 	};
 
-	const isRelativeLink = link && ( isRelativeUrl( link ) || isOnboardingUrl( link ) );
+	// Stepper/onboarding flows are not considered relative links because they can't be loaded by TanStack Router.
+	const isOnboarding = link && isOnboardingUrl( link );
+	const isRelativeLink = link && isRelativeUrl( link ) && ! isOnboarding;
 
 	let relativeLink: string | undefined = undefined;
+	let onboardingLink: string | undefined = undefined;
 	let externalLink: string | undefined = undefined;
 
 	if ( externalLinkProp ) {
 		externalLink = externalLinkProp;
+	} else if ( isOnboarding ) {
+		onboardingLink = link;
 	} else if ( isRelativeLink ) {
 		relativeLink = link;
 	} else {
@@ -125,7 +130,7 @@ export default function OverviewCard( {
 							{ title }
 						</Text>
 					</HStack>
-					{ relativeLink && ! progress && (
+					{ ( relativeLink || onboardingLink ) && ! progress && (
 						<Icon
 							className="dashboard-overview-card__link-icon"
 							icon={ isRTL() ? chevronLeft : chevronRight }
@@ -206,6 +211,18 @@ export default function OverviewCard( {
 				<Link to={ relativeLink } className="dashboard-overview-card__link" onClick={ handleClick }>
 					{ topContent }
 				</Link>
+			);
+		}
+
+		if ( onboardingLink ) {
+			return (
+				<a
+					href={ onboardingLink }
+					className="dashboard-overview-card__link"
+					onClick={ handleClick }
+				>
+					{ topContent }
+				</a>
 			);
 		}
 


### PR DESCRIPTION
## Summary

On CIAB sites with an expired free trial, clicking the plans card threw a TanStack Router error ("No route found") instead of navigating to the woo-hosted-plans stepper flow

The problem was that the OverviewCard rendered onboarding URLs (/setup/*, /start/*) as TanStack Router <Link> components, but these are stepper routes served by a different client app, not dashboard routes.
To fix, this PR renders onboarding URLs as plain <a> tags (same-tab, full page navigation) so the browser loads the stepper app correctly.

  ## Test plan

  - On a CIAB site with an expired trial plan, click the plans card on the site overview. It should navigate to the woo-hosted-plans stepper
  - On a CIAB site with a paid plan, click the plans card → should navigate to /me/billing/purchases/{id} within the dashboard