### PR TITLE
MSD Billing: Fix atomic plan revert confirmation checkbox

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
@@ -30,6 +30,7 @@ interface CancellationMainContentProps {
 	onCancelConfirmationStateChange: ( newState: Partial< CancelPurchaseState > ) => void;
 	onDomainConfirmationChange: ( checked: boolean ) => void;
 	onCustomerConfirmedUnderstandingChange: ( checked: boolean ) => void;
+	onCustomerConfirmedUnderstandingAtomicPlanRevert: ( checked: boolean ) => void;
 	onKeepSubscriptionClick: () => void;
 	onCancelClick?: () => void;
 }
@@ -56,6 +57,7 @@ export default function CancellationMainContent( {
 	onCancelConfirmationStateChange,
 	onDomainConfirmationChange,
 	onCustomerConfirmedUnderstandingChange,
+	onCustomerConfirmedUnderstandingAtomicPlanRevert,
 	onKeepSubscriptionClick,
 	onCancelClick,
 }: CancellationMainContentProps ) {
@@ -158,6 +160,9 @@ export default function CancellationMainContent( {
 				state={ state }
 				onDomainConfirmationChange={ onDomainConfirmationChange }
 				onCustomerConfirmedUnderstandingChange={ onCustomerConfirmedUnderstandingChange }
+				onCustomerConfirmedUnderstandingAtomicPlanRevert={
+					onCustomerConfirmedUnderstandingAtomicPlanRevert
+				}
 				onKeepSubscriptionClick={ onKeepSubscriptionClick }
 				onCancelClick={ onCancelClick }
 			/>

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-pre-survey-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-pre-survey-content.tsx
@@ -18,6 +18,7 @@ interface CancellationPreSurveyContentProps {
 	onCancelConfirmationStateChange: ( newState: Partial< CancelPurchaseState > ) => void;
 	onDomainConfirmationChange: ( checked: boolean ) => void;
 	onCustomerConfirmedUnderstandingChange: ( checked: boolean ) => void;
+	onCustomerConfirmedUnderstandingAtomicPlanRevert: ( checked: boolean ) => void;
 	onKeepSubscriptionClick: () => void;
 	onCancellationComplete: () => void;
 	onCancellationStart: () => void;
@@ -35,6 +36,7 @@ export default function CancellationPreSurveyContent( {
 	onCancelConfirmationStateChange,
 	onDomainConfirmationChange,
 	onCustomerConfirmedUnderstandingChange,
+	onCustomerConfirmedUnderstandingAtomicPlanRevert,
 	onKeepSubscriptionClick,
 	onCancellationComplete,
 	onCancellationStart,
@@ -62,6 +64,9 @@ export default function CancellationPreSurveyContent( {
 			onCancelConfirmationStateChange={ onCancelConfirmationStateChange }
 			onDomainConfirmationChange={ onDomainConfirmationChange }
 			onCustomerConfirmedUnderstandingChange={ onCustomerConfirmedUnderstandingChange }
+			onCustomerConfirmedUnderstandingAtomicPlanRevert={
+				onCustomerConfirmedUnderstandingAtomicPlanRevert
+			}
 			onKeepSubscriptionClick={ onKeepSubscriptionClick }
 			onCancelClick={
 				shouldHandleMarketplaceSubscriptions() ? showMarketplaceDialog : onCancellationStart

--- a/client/dashboard/me/billing-purchases/cancel-purchase/confirm-checkbox.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/confirm-checkbox.tsx
@@ -17,6 +17,7 @@ interface ConfirmCheckboxProps {
 	state: CancelPurchaseState;
 	onDomainConfirmationChange: ( checked: boolean ) => void;
 	onCustomerConfirmedUnderstandingChange: ( checked: boolean ) => void;
+	onCustomerConfirmedUnderstandingAtomicPlanRevert: ( checked: boolean ) => void;
 }
 
 export default function ConfirmCheckbox( {
@@ -25,6 +26,7 @@ export default function ConfirmCheckbox( {
 	state,
 	onDomainConfirmationChange,
 	onCustomerConfirmedUnderstandingChange,
+	onCustomerConfirmedUnderstandingAtomicPlanRevert,
 }: ConfirmCheckboxProps ) {
 	const isDomainRegistrationPurchase = purchase && purchase.is_domain_registration;
 
@@ -76,6 +78,7 @@ export default function ConfirmCheckbox( {
 					onChange={ ( checked ) => {
 						if ( atomicTransfer?.created_at ) {
 							onCustomerConfirmedUnderstandingChange( checked );
+							onCustomerConfirmedUnderstandingAtomicPlanRevert( checked );
 							return;
 						}
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -1313,6 +1313,10 @@ export default function CancelPurchase() {
 		setState( ( state ) => ( { ...state, customerConfirmedUnderstanding: checked } ) );
 	};
 
+	const onCustomerConfirmedUnderstandingAtomicPlanRevert = ( checked: boolean ) => {
+		setState( ( state ) => ( { ...state, atomicRevertConfirmed: checked } ) );
+	};
+
 	if ( isHundredYearDomain ) {
 		redirectBack();
 		return null;
@@ -1508,6 +1512,9 @@ export default function CancelPurchase() {
 									onCancelConfirmationStateChange={ onCancelConfirmationStateChange }
 									onDomainConfirmationChange={ onDomainConfirmationChange }
 									onCustomerConfirmedUnderstandingChange={ onCustomerConfirmedUnderstandingChange }
+									onCustomerConfirmedUnderstandingAtomicPlanRevert={
+										onCustomerConfirmedUnderstandingAtomicPlanRevert
+									}
 									onKeepSubscriptionClick={ onKeepSubscriptionClick }
 									onCancellationComplete={ onCancellationComplete }
 									onCancellationStart={ onCancellationStart }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/plan-product-revert-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/plan-product-revert-content.tsx
@@ -16,6 +16,7 @@ interface PlanProductRevertContentProps {
 	state: CancelPurchaseState;
 	onDomainConfirmationChange: ( checked: boolean ) => void;
 	onCustomerConfirmedUnderstandingChange: ( checked: boolean ) => void;
+	onCustomerConfirmedUnderstandingAtomicPlanRevert: ( checked: boolean ) => void;
 	onKeepSubscriptionClick: () => void;
 	onCancelClick?: () => void;
 }
@@ -27,6 +28,7 @@ export default function PlanProductRevertContent( {
 	state,
 	onDomainConfirmationChange,
 	onCustomerConfirmedUnderstandingChange,
+	onCustomerConfirmedUnderstandingAtomicPlanRevert,
 	onKeepSubscriptionClick,
 	onCancelClick,
 }: PlanProductRevertContentProps ) {
@@ -50,6 +52,9 @@ export default function PlanProductRevertContent( {
 					state={ state }
 					onDomainConfirmationChange={ onDomainConfirmationChange }
 					onCustomerConfirmedUnderstandingChange={ onCustomerConfirmedUnderstandingChange }
+					onCustomerConfirmedUnderstandingAtomicPlanRevert={
+						onCustomerConfirmedUnderstandingAtomicPlanRevert
+					}
 				/>
 			) }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes [CHE-457](https://linear.app/a8c/issue/CHE-457/cannot-remove-a-plan-on-wordpresscom-after-checking-the-confirmation)

## Proposed Changes

* Resolve an issue where Atomic plans with bundled domains could not be cancelled because the checkbox did not enable the remove button.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The application is expecting `atomicRevertConfirmed` to be `true` if the checkbox was checked, but this wasn't being set.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try to remove a plan purchased with a domain for a site that has gone atomic in the MSD. 
* Check the checkbox to confirm that you understand your plan will change.
* The "Remove" button should change from a disabled state to an enabled state.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
