### PR TITLE
Renewal pricing: fix UI issues in the pricing grid

### DIFF
--- a/packages/plans-grid-next/src/components/shared/action-button/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/action-button/index.tsx
@@ -217,6 +217,23 @@ const ActionButton = ( {
 				</>
 			);
 		}
+	} else if (
+		showPostButtonText &&
+		postButtonText &&
+		showBillingDescriptionForIncreasedRenewalPrice
+	) {
+		actionButton = (
+			<>
+				{ actionButton }
+				<span
+					className={ clsx( 'plans-grid-next-action-button__label', {
+						'is-left-aligned': showBillingDescriptionForIncreasedRenewalPrice,
+					} ) }
+				>
+					{ postButtonText }
+				</span>
+			</>
+		);
 	}
 
 	return (

--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -246,7 +246,16 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 	if ( isAnyPlanPriceDiscounted ) {
 		return (
 			<div className="plans-grid-next-header-price">
-				<div className="plans-grid-next-header-price__badge is-hidden">' '</div>
+				{ showBillingDescriptionForIncreasedRenewalPrice === 'crossed_price' && savings ? (
+					<div className="plans-grid-next-header-price__badge">
+						{ translate( 'Save %(savings)d%%', {
+							args: { savings },
+							comment: 'Example: Save 35%',
+						} ) }
+					</div>
+				) : (
+					<div className="plans-grid-next-header-price__badge is-hidden">' '</div>
+				) }
 				{ isLargeCurrency ? (
 					<div className="plans-grid-next-header-price__pricing-group is-large-currency">
 						<PlanPrice

--- a/packages/plans-grid-next/src/components/test/header-price.tsx
+++ b/packages/plans-grid-next/src/components/test/header-price.tsx
@@ -4,6 +4,8 @@
 /**
  * Default mock implementations
  */
+const mockUseHeaderPriceContext = jest.fn();
+
 jest.mock( '@wordpress/element', () => ( {
 	...jest.requireActual( '@wordpress/element' ),
 	useCallback: jest.fn(),
@@ -24,10 +26,7 @@ jest.mock( '@automattic/data-stores', () => ( {
 } ) );
 
 jest.mock( '../shared/header-price/header-price-context', () => ( {
-	useHeaderPriceContext: () => ( {
-		isAnyPlanPriceDiscounted: false,
-		setIsAnyPlanPriceDiscounted: jest.fn(),
-	} ),
+	useHeaderPriceContext: () => mockUseHeaderPriceContext(),
 } ) );
 
 import {
@@ -35,7 +34,9 @@ import {
 	PLAN_ANNUAL_PERIOD,
 	PLAN_ENTERPRISE_GRID_WPCOM,
 	PLAN_PERSONAL,
+	PLAN_PERSONAL_MONTHLY,
 } from '@automattic/calypso-products';
+import { Plans } from '@automattic/data-stores';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render } from '@testing-library/react';
 import React, { useMemo } from 'react';
@@ -57,6 +58,11 @@ describe( 'HeaderPrice', () => {
 
 	beforeEach( () => {
 		jest.clearAllMocks();
+		mockUseHeaderPriceContext.mockReturnValue( {
+			isAnyPlanPriceDiscounted: false,
+			setIsAnyPlanPriceDiscounted: jest.fn(),
+		} );
+		( Plans.usePricingMetaForGridPlans as jest.Mock ).mockReturnValue( {} );
 	} );
 
 	test( 'should render raw and discounted prices when discount exists', () => {
@@ -185,5 +191,81 @@ describe( 'HeaderPrice', () => {
 		const badge = container.querySelector( '.plans-grid-next-header-price__badge' );
 
 		expect( badge ).toHaveTextContent( 'One time discount' );
+	} );
+
+	test( 'should display "Save x%" badge in renewal experiment for downgraded-site style pricing', () => {
+		const pricing = {
+			currencyCode: 'USD',
+			originalPrice: { full: 120, monthly: 10 },
+			discountedPrice: { full: null, monthly: null },
+			billingPeriod: PLAN_ANNUAL_PERIOD,
+		};
+
+		mockUseHeaderPriceContext.mockReturnValue( {
+			isAnyPlanPriceDiscounted: true,
+			setIsAnyPlanPriceDiscounted: jest.fn(),
+		} );
+		( Plans.usePricingMetaForGridPlans as jest.Mock ).mockReturnValue( {
+			[ PLAN_PERSONAL_MONTHLY ]: {
+				originalPrice: { monthly: 20, full: 240 },
+				discountedPrice: { monthly: null, full: null },
+			},
+		} );
+
+		usePlansGridContext.mockImplementation( () => ( {
+			gridPlansIndex: {
+				[ PLAN_PERSONAL ]: {
+					current: false,
+					isMonthlyPlan: true,
+					pricing,
+				},
+			},
+			showBillingDescriptionForIncreasedRenewalPrice: 'crossed_price',
+		} ) );
+
+		const { container } = render( <HeaderPrice { ...defaultProps } />, { wrapper: Wrapper } );
+		const badge = container.querySelector( '.plans-grid-next-header-price__badge' );
+
+		expect( badge ).toHaveTextContent( 'Save 50%' );
+	} );
+
+	test( 'should keep the fallback badge hidden in crossed_price when savings is zero', () => {
+		const pricing = {
+			currencyCode: 'USD',
+			originalPrice: { full: 120, monthly: 10 },
+			discountedPrice: { full: null, monthly: null },
+			billingPeriod: PLAN_ANNUAL_PERIOD,
+		};
+
+		mockUseHeaderPriceContext.mockReturnValue( {
+			isAnyPlanPriceDiscounted: true,
+			setIsAnyPlanPriceDiscounted: jest.fn(),
+		} );
+		( Plans.usePricingMetaForGridPlans as jest.Mock ).mockReturnValue( {
+			[ PLAN_PERSONAL_MONTHLY ]: {
+				originalPrice: { monthly: 10, full: 120 },
+				discountedPrice: { monthly: null, full: null },
+			},
+		} );
+
+		usePlansGridContext.mockImplementation( () => ( {
+			gridPlansIndex: {
+				[ PLAN_PERSONAL ]: {
+					current: false,
+					isMonthlyPlan: true,
+					pricing,
+				},
+			},
+			showBillingDescriptionForIncreasedRenewalPrice: 'crossed_price',
+		} ) );
+
+		const { container } = render( <HeaderPrice { ...defaultProps } />, { wrapper: Wrapper } );
+		const visibleBadge = container.querySelector(
+			'.plans-grid-next-header-price__badge:not(.is-hidden)'
+		);
+		const hiddenBadge = container.querySelector( '.plans-grid-next-header-price__badge.is-hidden' );
+
+		expect( visibleBadge ).toBeNull();
+		expect( hiddenBadge ).toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of M4R73CH-1665

## Proposed Changes

* Fix several UI issues for displaying increased renewal prices:
* 1. Show the 'Save x' banner on a previously expired plan.
* 2. Show the 'Auto-renews at x' text for the plans lower than the current one.

Issue 1 before:
<img width="1288" height="767" alt="Screenshot 2026-03-24 at 16 42 05" src="https://github.com/user-attachments/assets/1f1f6e51-6dfc-4c9a-a954-98f33bdb4ec3" />

Issue 1 after:
<img width="1271" height="755" alt="after-downgrade-from-premium-business-coupon" src="https://github.com/user-attachments/assets/f0d5383a-1b2f-4249-bd1a-bb3587d74ee6" />

Issue 2 before:
<img width="1288" height="429" alt="Screenshot 2026-03-24 at 16 33 10" src="https://github.com/user-attachments/assets/86b99aad-6a33-4705-b37e-72f0d84a9244" />
Issue 2 after:
<img width="1288" height="429" alt="Screenshot 2026-03-24 at 16 35 08" src="https://github.com/user-attachments/assets/8a6d9d1b-0313-457f-a09d-b0c9c02781df" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To achieve consistent presentation of the adjusted prices.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox public-api.
* To show the new prices edit wpcom-billing.php and add `return false` after line 1454 and replace `return null` with `return 'crossed_price'` on line 1502. Replace `return [ false, null ];` with `return [ false, 'crossed_price' ];` in client/my-sites/plans-features-main/hooks/use-renewal-price-experiment.ts.
* Navigate to the plans grid and confirm that everything works correctly. Test when the current site is on a Business plan or was previously on another paid plan.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
