### PR TITLE
Fix redirect_to XSS via javascript: URL scheme in change-payment-method

### DIFF
--- a/client/dashboard/me/billing-purchases/change-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/change-payment-method.tsx
@@ -67,7 +67,11 @@ function ChangePaymentMethod() {
 		if ( redirect_to ) {
 			try {
 				const parsed = new URL( redirect_to );
-				if ( purchase.domain && parsed.hostname === purchase.domain ) {
+				if (
+					purchase.domain &&
+					( parsed.protocol === 'https:' || parsed.protocol === 'http:' ) &&
+					parsed.hostname === purchase.domain
+				) {
 					window.location.href = redirect_to;
 					return;
 				}


### PR DESCRIPTION
Resolves DOTCOM-16409

## Proposed Changes

* Add URL protocol validation (`https:` / `http:` only) to the `redirect_to` query parameter check in the change-payment-method success callback

## Why are these changes being made?

The `redirect_to` parameter on the change-payment-method route only validated the hostname against `purchase.domain`, without restricting the URL scheme. This allowed an attacker to craft a `javascript:` URI (e.g., `javascript://victim.com/%0aalert(document.cookie)`) that passes the hostname check but executes arbitrary JavaScript when assigned to `window.location.href` after a successful payment method change.

| Scenario | Before | After |
|----------|--------|-------|
| `redirect_to=https://victim.com/page` | Allowed | Allowed |
| `redirect_to=javascript://victim.com/%0aalert(1)` | Allowed (XSS) | Rejected — falls through to default navigation |
| `redirect_to=data:text/html,...` | Allowed | Rejected |

## Testing Instructions

**Environment:**
- [ ] Enable Store Sandbox mode
- [ ] `public-api.wordpress.com` sandboxed

**Steps:**

1. Find a purchase with a known domain (e.g., `example.com`) and note its purchase ID
2. Navigate to `/me/billing/purchases/{purchaseId}/payment-method/change?redirect_to=javascript://example.com/%0aalert(document.cookie)`
3. Complete the payment method change flow
4. Verify that you are redirected to the default purchase settings page (not the `javascript:` URI)
5. Navigate to `/me/billing/purchases/{purchaseId}/payment-method/change?redirect_to=https://example.com/some-page`
6. Complete the payment method change flow
7. Verify that you are redirected to `https://example.com/some-page` (valid HTTPS redirect still works)

| # | Scenario | Expected Result |
|---|----------|-----------------|
| 1 | `redirect_to=javascript://domain/%0aalert(1)` | Rejected — redirects to purchase settings |
| 2 | `redirect_to=data:text/html,<script>alert(1)</script>` | Rejected — redirects to purchase settings |
| 3 | `redirect_to=https://purchase.domain/page` | Accepted — redirects to the URL |
| 4 | `redirect_to=http://purchase.domain/page` | Accepted — redirects to the URL |
| 5 | `redirect_to=https://evil.com/page` | Rejected — hostname mismatch |
| 6 | No `redirect_to` param | Redirects to purchase settings (default) |

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
