### PR TITLE
Limit available dashboard routes for ciab

### DIFF
--- a/client/dashboard/app-ciab/routing.ts
+++ b/client/dashboard/app-ciab/routing.ts
@@ -11,6 +11,29 @@ export function isAllowedCiabDashboardHostname( hostname?: string ): boolean {
 	return CIAB_DASHBOARD_ALLOWED_HOSTNAMES.includes( hostname ?? '' );
 }
 
+export function isAllowedCiabLegacyRoute( path: string = '' ): boolean {
+	const allowedStepperFlows = [
+		'ai-site-builder-spec',
+		'ai-site-builder',
+		'woo-hosted-plans',
+		'domain',
+		'domain-transfer',
+	];
+
+	if ( path.startsWith( '/checkout/' ) ) {
+		return true;
+	}
+
+	// Only allow specific stepper flows on CIAB.
+	if ( path === '/setup' || path.startsWith( '/setup/' ) ) {
+		const flow = path.split( '/' )[ 2 ];
+		return allowedStepperFlows.includes( flow ?? '' );
+	}
+
+	// Disallow other routes (like /start, /setup, etc.)
+	return false;
+}
+
 export function buildCiabDashboardLink( path: string = '' ) {
 	if ( config( 'env' ) === 'development' ) {
 		return new URL( path, 'http://my.woo.localhost:3000' ).href;

--- a/client/dashboard/app/routing.ts
+++ b/client/dashboard/app/routing.ts
@@ -1,9 +1,32 @@
-import { buildCiabDashboardLink, isAllowedCiabDashboardHostname } from '../app-ciab/routing';
+import {
+	buildCiabDashboardLink,
+	isAllowedCiabDashboardHostname,
+	isAllowedCiabLegacyRoute,
+} from '../app-ciab/routing';
 import { buildDotcomDashboardLink, isAllowedDotcomDashboardHostname } from '../app-dotcom/routing';
 import type { DashboardType } from './types';
 
-export function isAllowedDashboardHostname( hostname?: string ): boolean {
-	return isAllowedDotcomDashboardHostname( hostname ) || isAllowedCiabDashboardHostname( hostname );
+/**
+ * Checks if the given route is allowed on the requesting dashboard hostname.
+ * All routes are allowed on dotcom. On CIAB, route policy is delegated to
+ * the CIAB routing module.
+ */
+export function isAllowedDashboardRoute( {
+	hostname,
+	path,
+}: {
+	hostname?: string;
+	path?: string;
+} ): boolean {
+	if ( isAllowedDotcomDashboardHostname( hostname ) ) {
+		return true;
+	}
+
+	if ( isAllowedCiabDashboardHostname( hostname ) ) {
+		return isAllowedCiabLegacyRoute( path );
+	}
+
+	return false;
 }
 
 export function getDashboardFromHostname( hostname?: string ): DashboardType | undefined {

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -18,10 +18,7 @@ import { get, includes } from 'lodash';
 import { stringify } from 'qs';
 // eslint-disable-next-line no-restricted-imports
 import superagent from 'superagent'; // Don't have Node.js fetch lib yet.
-import {
-	getDashboardFromHostname,
-	isAllowedDashboardHostname,
-} from 'calypso/dashboard/app/routing';
+import { getDashboardFromHostname, isAllowedDashboardRoute } from 'calypso/dashboard/app/routing';
 import { isAllowedCiabDashboardHostname } from 'calypso/dashboard/app-ciab/routing';
 import { CIAB_DASHBOARD_SECTION_DEFINITION } from 'calypso/dashboard/app-ciab/section';
 import { isAllowedDotcomDashboardHostname } from 'calypso/dashboard/app-dotcom/routing';
@@ -1106,14 +1103,14 @@ export default function pages() {
 	if ( isDashboardEnv() || calypsoEnv === 'development' ) {
 		const signupSectionDefinition = sections.find( ( s ) => s.name === 'signup' );
 		handleSectionPath( signupSectionDefinition, '/start', undefined, ( req ) =>
-			isAllowedDashboardHostname( req.hostname )
+			isAllowedDashboardRoute( { hostname: req.hostname, path: req.path } )
 		);
 		const checkoutSectionDefinition = sections.find( ( s ) => s.name === 'checkout' );
 		handleSectionPath( checkoutSectionDefinition, '/checkout', undefined, ( req ) =>
-			isAllowedDashboardHostname( req.hostname )
+			isAllowedDashboardRoute( { hostname: req.hostname, path: req.path } )
 		);
 		handleSectionPath( STEPPER_SECTION_DEFINITION, '/setup', 'entry-stepper', ( req ) =>
-			isAllowedDashboardHostname( req.hostname )
+			isAllowedDashboardRoute( { hostname: req.hostname, path: req.path } )
 		);
 		DASHBOARD_SECTION_PATHS.forEach( ( route ) => {
 			handleSectionPath(


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/109199, cc @fushar 

We don't want all the stepper flows available for all dashboards. `https://my.woo.ai/start` shouldn't exist right now for example, it'd be creating a non-ciab site which would be quite confusing.