### PR TITLE
CIAB: Redirect accepted invites to store dashboard

### DIFF
--- a/client/lib/partner-branding.tsx
+++ b/client/lib/partner-branding.tsx
@@ -51,13 +51,14 @@ export interface CiabPartnerConfig {
 	isOAuth2Client?: ( oauth2Client: { id: number } | null ) => boolean;
 	/** Build a full dashboard URL for this partner given a path */
 	buildDashboardLink?: ( path: string ) => string;
-	/** Named redirect paths per use case. Each returns the path to pass to buildDashboardLink. */
+	/** Named redirects per use case. Each returns the final destination URL. */
 	redirects?: Partial< Record< CiabRedirectType, ( site: CiabRedirectSite ) => string > >;
 }
 
 /** Site context passed to redirect path builders */
 export interface CiabRedirectSite {
 	domain: string;
+	admin_url: string;
 	garden?: { partner: string; name: string };
 }
 
@@ -96,7 +97,7 @@ export const CIAB_PARTNERS: Record< string, CiabPartnerConfig > = {
 		isOAuth2Client: isCiabOAuth2Client,
 		buildDashboardLink: buildCiabDashboardLink,
 		redirects: {
-			'invite-accept': ( site ) => `/sites/${ site.domain }`,
+			'invite-accept': ( site ) => site.admin_url,
 		},
 	},
 };
@@ -191,8 +192,8 @@ export function getCiabConfigFromGarden(
 
 /**
  * Get the partner redirect URL for a garden site and a specific use case.
- * Looks up the partner config from site.garden, resolves the path from the named redirect,
- * and builds the full dashboard URL. Returns null if the partner has no config for this redirect.
+ * Looks up the partner config from site.garden and resolves the destination URL
+ * from the named redirect. Returns null if the partner has no config for this redirect.
  */
 export function getPartnerRedirect(
 	redirectType: CiabRedirectType,
@@ -200,12 +201,11 @@ export function getPartnerRedirect(
 ): string | null {
 	const ciabConfig = getCiabConfigFromGarden( site?.garden?.partner, site?.garden?.name );
 
-	if ( ! ciabConfig?.buildDashboardLink || ! ciabConfig?.redirects?.[ redirectType ] || ! site ) {
+	if ( ! ciabConfig?.redirects?.[ redirectType ] || ! site ) {
 		return null;
 	}
 
-	const path = ciabConfig.redirects[ redirectType ]( site );
-	return ciabConfig.buildDashboardLink( path );
+	return ciabConfig.redirects[ redirectType ]( site );
 }
 
 /**

--- a/client/lib/partner-branding.tsx
+++ b/client/lib/partner-branding.tsx
@@ -5,7 +5,6 @@ import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import wooLogo from 'calypso/assets/images/icons/Woo_logo_color.svg';
-import { buildCiabDashboardLink } from 'calypso/dashboard/app-ciab/routing';
 import { isCiabOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { useSelector } from 'calypso/state';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
@@ -49,21 +48,7 @@ export interface CiabPartnerConfig {
 	domains?: string[];
 	/** Callback to check if an OAuth2 client belongs to this partner */
 	isOAuth2Client?: ( oauth2Client: { id: number } | null ) => boolean;
-	/** Build a full dashboard URL for this partner given a path */
-	buildDashboardLink?: ( path: string ) => string;
-	/** Named redirects per use case. Each returns the final destination URL. */
-	redirects?: Partial< Record< CiabRedirectType, ( site: CiabRedirectSite ) => string > >;
 }
-
-/** Site context passed to redirect path builders */
-export interface CiabRedirectSite {
-	domain: string;
-	admin_url: string;
-	garden?: { partner: string; name: string };
-}
-
-/** Known redirect use cases */
-export type CiabRedirectType = 'invite-accept';
 
 /**
  * CIAB Partners Configuration
@@ -95,10 +80,6 @@ export const CIAB_PARTNERS: Record< string, CiabPartnerConfig > = {
 		fontStyle: 'system',
 		domains: [ 'my.woo.ai', 'my.woo.localhost' ],
 		isOAuth2Client: isCiabOAuth2Client,
-		buildDashboardLink: buildCiabDashboardLink,
-		redirects: {
-			'invite-accept': ( site ) => site.admin_url,
-		},
 	},
 };
 
@@ -188,24 +169,6 @@ export function getCiabConfigFromGarden(
 
 	// Future: add mappings for other partners like "paypal"
 	return ciabConfig;
-}
-
-/**
- * Get the partner redirect URL for a garden site and a specific use case.
- * Looks up the partner config from site.garden and resolves the destination URL
- * from the named redirect. Returns null if the partner has no config for this redirect.
- */
-export function getPartnerRedirect(
-	redirectType: CiabRedirectType,
-	site?: CiabRedirectSite
-): string | null {
-	const ciabConfig = getCiabConfigFromGarden( site?.garden?.partner, site?.garden?.name );
-
-	if ( ! ciabConfig?.redirects?.[ redirectType ] || ! site ) {
-		return null;
-	}
-
-	return ciabConfig.redirects[ redirectType ]( site );
 }
 
 /**

--- a/client/lib/partner-branding.tsx
+++ b/client/lib/partner-branding.tsx
@@ -5,6 +5,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import wooLogo from 'calypso/assets/images/icons/Woo_logo_color.svg';
+import { buildCiabDashboardLink } from 'calypso/dashboard/app-ciab/routing';
 import { isCiabOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { useSelector } from 'calypso/state';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
@@ -48,7 +49,20 @@ export interface CiabPartnerConfig {
 	domains?: string[];
 	/** Callback to check if an OAuth2 client belongs to this partner */
 	isOAuth2Client?: ( oauth2Client: { id: number } | null ) => boolean;
+	/** Build a full dashboard URL for this partner given a path */
+	buildDashboardLink?: ( path: string ) => string;
+	/** Named redirect paths per use case. Each returns the path to pass to buildDashboardLink. */
+	redirects?: Partial< Record< CiabRedirectType, ( site: CiabRedirectSite ) => string > >;
 }
+
+/** Site context passed to redirect path builders */
+export interface CiabRedirectSite {
+	domain: string;
+	garden?: { partner: string; name: string };
+}
+
+/** Known redirect use cases */
+export type CiabRedirectType = 'invite-accept';
 
 /**
  * CIAB Partners Configuration
@@ -80,6 +94,10 @@ export const CIAB_PARTNERS: Record< string, CiabPartnerConfig > = {
 		fontStyle: 'system',
 		domains: [ 'my.woo.ai', 'my.woo.localhost' ],
 		isOAuth2Client: isCiabOAuth2Client,
+		buildDashboardLink: buildCiabDashboardLink,
+		redirects: {
+			'invite-accept': ( site ) => `/sites/${ site.domain }`,
+		},
 	},
 };
 
@@ -169,6 +187,25 @@ export function getCiabConfigFromGarden(
 
 	// Future: add mappings for other partners like "paypal"
 	return ciabConfig;
+}
+
+/**
+ * Get the partner redirect URL for a garden site and a specific use case.
+ * Looks up the partner config from site.garden, resolves the path from the named redirect,
+ * and builds the full dashboard URL. Returns null if the partner has no config for this redirect.
+ */
+export function getPartnerRedirect(
+	redirectType: CiabRedirectType,
+	site?: CiabRedirectSite
+): string | null {
+	const ciabConfig = getCiabConfigFromGarden( site?.garden?.partner, site?.garden?.name );
+
+	if ( ! ciabConfig?.buildDashboardLink || ! ciabConfig?.redirects?.[ redirectType ] || ! site ) {
+		return null;
+	}
+
+	const path = ciabConfig.redirects[ redirectType ]( site );
+	return ciabConfig.buildDashboardLink( path );
 }
 
 /**

--- a/client/my-sites/invites-unified/screens/accept-invite-screen.tsx
+++ b/client/my-sites/invites-unified/screens/accept-invite-screen.tsx
@@ -41,7 +41,7 @@ function toLegacyInvite( invite: Invite ) {
 			domain: blogDetails?.domain || '',
 			admin_url: blogDetails?.admin_url || '',
 			is_vip: blogDetails?.is_vip || false,
-			garden: blogDetails?.garden,
+			is_garden_site: blogDetails?.is_garden_site || false,
 		},
 		role: invite.invite?.meta?.role || '',
 		sentTo: invite.invite?.meta?.sent_to || '',

--- a/client/my-sites/invites-unified/screens/accept-invite-screen.tsx
+++ b/client/my-sites/invites-unified/screens/accept-invite-screen.tsx
@@ -41,6 +41,8 @@ function toLegacyInvite( invite: Invite ) {
 			domain: blogDetails?.domain || '',
 			admin_url: blogDetails?.admin_url || '',
 			is_vip: blogDetails?.is_vip || false,
+			is_garden_site: blogDetails?.is_garden_site || false,
+			garden: blogDetails?.garden,
 		},
 		role: invite.invite?.meta?.role || '',
 		sentTo: invite.invite?.meta?.sent_to || '',

--- a/client/my-sites/invites-unified/screens/accept-invite-screen.tsx
+++ b/client/my-sites/invites-unified/screens/accept-invite-screen.tsx
@@ -41,7 +41,6 @@ function toLegacyInvite( invite: Invite ) {
 			domain: blogDetails?.domain || '',
 			admin_url: blogDetails?.admin_url || '',
 			is_vip: blogDetails?.is_vip || false,
-			is_garden_site: blogDetails?.is_garden_site || false,
 			garden: blogDetails?.garden,
 		},
 		role: invite.invite?.meta?.role || '',

--- a/client/my-sites/invites/test/utils.tsx
+++ b/client/my-sites/invites/test/utils.tsx
@@ -1,0 +1,103 @@
+import { getRedirectAfterAccept } from '../utils';
+
+jest.mock( 'calypso/lib/logmein', () => ( {
+	logmeinUrl: ( _host: string, backUrl: string ) => backUrl,
+} ) );
+
+jest.mock( 'calypso/dashboard/utils/link', () => ( {
+	dashboardLink: ( path: string ) => `/dashboard${ path }`,
+} ) );
+
+function createInvite( overrides = {} ) {
+	return {
+		site: {
+			URL: 'https://example.com',
+			title: 'Test Site',
+			is_wpforteams_site: false,
+			ID: '123',
+			domain: 'example.com',
+			admin_url: 'https://example.com/wp-admin/',
+			is_vip: false,
+			...( overrides as Record< string, unknown > ),
+		},
+		role: 'administrator',
+		...overrides,
+	};
+}
+
+describe( 'getRedirectAfterAccept', () => {
+	describe( 'garden sites', () => {
+		it( 'redirects to admin_url for garden site with administrator role', () => {
+			const invite = createInvite( {
+				site: {
+					...createInvite().site,
+					is_garden_site: true,
+				},
+			} );
+
+			expect( getRedirectAfterAccept( invite, false ) ).toBe( 'https://example.com/wp-admin/' );
+		} );
+
+		it( 'redirects to admin_url for garden site with shop_manager role', () => {
+			const invite = createInvite( {
+				role: 'shop_manager',
+				site: {
+					...createInvite().site,
+					is_garden_site: true,
+				},
+			} );
+
+			expect( getRedirectAfterAccept( invite, false ) ).toBe( 'https://example.com/wp-admin/' );
+		} );
+
+		it( 'redirects to site URL for garden site with viewer role', () => {
+			const invite = createInvite( {
+				role: 'viewer',
+				site: {
+					...createInvite().site,
+					is_garden_site: true,
+				},
+			} );
+
+			expect( getRedirectAfterAccept( invite, false ) ).toBe( 'https://example.com' );
+		} );
+
+		it( 'redirects to site URL for garden site with follower role', () => {
+			const invite = createInvite( {
+				role: 'follower',
+				site: {
+					...createInvite().site,
+					is_garden_site: true,
+				},
+			} );
+
+			expect( getRedirectAfterAccept( invite, false ) ).toBe( 'https://example.com' );
+		} );
+
+		it( 'does not treat is_garden_site=false as a garden site', () => {
+			const invite = createInvite( {
+				site: {
+					...createInvite().site,
+					is_garden_site: false,
+				},
+			} );
+
+			const result = getRedirectAfterAccept( invite, false );
+			expect( result ).not.toBe( 'https://example.com/wp-admin/' );
+		} );
+	} );
+
+	describe( 'non-garden, non-vip sites', () => {
+		it( 'redirects to /sites for administrator without garden', () => {
+			const invite = createInvite();
+
+			expect( getRedirectAfterAccept( invite, false ) ).toBe( 'https://wordpress.com/sites' );
+		} );
+
+		it( 'redirects to /reader for viewer without garden', () => {
+			const invite = createInvite( { role: 'viewer' } );
+
+			expect( getRedirectAfterAccept( invite, false ) ).toBe( 'https://wordpress.com/reader' );
+		} );
+	} );
+} );

--- a/client/my-sites/invites/utils.tsx
+++ b/client/my-sites/invites/utils.tsx
@@ -3,7 +3,6 @@ import { addQueryArgs } from '@wordpress/url';
 import i18n from 'i18n-calypso';
 import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { logmeinUrl } from 'calypso/lib/logmein';
-import { getPartnerRedirect } from 'calypso/lib/partner-branding';
 
 type InviteType = {
 	site: {
@@ -14,7 +13,7 @@ type InviteType = {
 		domain: string;
 		admin_url: string;
 		is_vip: boolean;
-		garden?: { partner: string; name: string };
+		is_garden_site?: boolean;
 	};
 	role: string;
 };
@@ -195,13 +194,7 @@ export function getRedirectAfterAccept( invite: InviteType, hasDashboardOptIn: b
 		return isMissingLogmein ? redirect : destination;
 	};
 
-	// CIAB stores: redirect to the partner dashboard
-	const partnerRedirect = getPartnerRedirect( 'invite-accept', invite.site );
-	if ( partnerRedirect ) {
-		return partnerRedirect;
-	}
-
-	if ( invite.site.is_vip ) {
+	if ( invite.site.is_vip || invite.site.is_garden_site ) {
 		switch ( invite.role ) {
 			case 'viewer':
 			case 'follower':

--- a/client/my-sites/invites/utils.tsx
+++ b/client/my-sites/invites/utils.tsx
@@ -1,6 +1,7 @@
 import { determineUrlType, URL_TYPE } from '@automattic/calypso-url';
 import { addQueryArgs } from '@wordpress/url';
 import i18n from 'i18n-calypso';
+import { buildCiabDashboardLink } from 'calypso/dashboard/app-ciab/routing';
 import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { logmeinUrl } from 'calypso/lib/logmein';
 
@@ -13,6 +14,8 @@ type InviteType = {
 		domain: string;
 		admin_url: string;
 		is_vip: boolean;
+		is_garden_site?: boolean;
+		garden?: { partner: string; name: string };
 	};
 	role: string;
 };
@@ -192,6 +195,15 @@ export function getRedirectAfterAccept( invite: InviteType, hasDashboardOptIn: b
 		const isMissingLogmein = destination === remoteLoginHost;
 		return isMissingLogmein ? redirect : destination;
 	};
+
+	// CIAB stores: redirect to the store dashboard
+	if (
+		invite.site.is_garden_site &&
+		invite.site.garden?.partner === 'woo' &&
+		invite.site.garden?.name === 'commerce'
+	) {
+		return buildCiabDashboardLink( `/sites/${ invite.site.domain }` );
+	}
 
 	if ( invite.site.is_vip ) {
 		switch ( invite.role ) {

--- a/client/my-sites/invites/utils.tsx
+++ b/client/my-sites/invites/utils.tsx
@@ -1,9 +1,9 @@
 import { determineUrlType, URL_TYPE } from '@automattic/calypso-url';
 import { addQueryArgs } from '@wordpress/url';
 import i18n from 'i18n-calypso';
-import { buildCiabDashboardLink } from 'calypso/dashboard/app-ciab/routing';
 import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { logmeinUrl } from 'calypso/lib/logmein';
+import { getPartnerRedirect } from 'calypso/lib/partner-branding';
 
 type InviteType = {
 	site: {
@@ -14,7 +14,6 @@ type InviteType = {
 		domain: string;
 		admin_url: string;
 		is_vip: boolean;
-		is_garden_site?: boolean;
 		garden?: { partner: string; name: string };
 	};
 	role: string;
@@ -196,13 +195,10 @@ export function getRedirectAfterAccept( invite: InviteType, hasDashboardOptIn: b
 		return isMissingLogmein ? redirect : destination;
 	};
 
-	// CIAB stores: redirect to the store dashboard
-	if (
-		invite.site.is_garden_site &&
-		invite.site.garden?.partner === 'woo' &&
-		invite.site.garden?.name === 'commerce'
-	) {
-		return buildCiabDashboardLink( `/sites/${ invite.site.domain }` );
+	// CIAB stores: redirect to the partner dashboard
+	const partnerRedirect = getPartnerRedirect( 'invite-accept', invite.site );
+	if ( partnerRedirect ) {
+		return partnerRedirect;
 	}
 
 	if ( invite.site.is_vip ) {


### PR DESCRIPTION
Closes ARC-1517

## Proposed Changes

- After accepting a CIAB store invite, redirect users to the site's `wp-admin` instead of `wordpress.com/sites`.
- Pass `garden` data through the invite flow and extend the existing VIP redirect path to also handle garden (CIAB) sites.

## Why are these changes being made?

When a user accepts an invite for a CIAB store, they are redirected to `wordpress.com/sites`. This is confusing because CIAB store management happens in wp-admin. The existing VIP code path already redirects non-viewer/follower roles to `admin_url` — garden sites now reuse that same path.

## Testing Instructions

1. Use a CIAB store and invite a secondary account.
2. Log in with the secondary account on the local Calypso instance or a Calypso Live instance.
3. Navigate to the `/accept-invite` URL from the invitation email.
4. Accept the invite.
5. Verify you are redirected to the site's wp-admin instead of `/sites`.
6. Also verify that accepting as a viewer/follower role redirects to the site URL.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?