### PR TITLE
CIAB: don't need to run the backend site build anymore

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -222,25 +222,6 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 				throw new Error( 'Invalid early_created_site parameter.' );
 			}
 
-			// Trigger the AI site builder job. This queues an async job that waits
-			// for provisioning to complete, then runs the Site Builder Workflow Agent.
-			try {
-				await wpcomRequest( {
-					path: `/sites/${ blogId }/big-sky/trigger-backend-build`,
-					apiNamespace: 'wpcom/v2',
-					method: 'POST',
-					body: {
-						spec_id: urlQueryParams.get( 'spec_id' ),
-					},
-				} );
-			} catch ( error ) {
-				// eslint-disable-next-line no-console
-				console.error( 'Failed to trigger backend build:', error );
-				throw new Error(
-					'We were unable to build your store. Please try again or contact support.'
-				);
-			}
-
 			// Poll until the provisioning is considered complete.
 			// Skip the initial delay since the site may have been provisioning for minutes already.
 			await pollForGardenProvisioning( blogId, 22, 5000, 0 );


### PR DESCRIPTION
Closes BSKY-1818

## Proposed Changes

- remove queued async job to trigger the Big Sky backend build, since we no longer want to run this as we're running the build on the front end

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

with both builds running was causing duplicate pages to show up on the site, could be other potential issues

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

http://my.woo.localhost:3000/sites and make a new site. Verify in the CIAB admin under design > pages that there are no duplicate pages

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
