### PR TITLE
Stats: Fix likes heading to say 'Page likes' for pages

### DIFF
--- a/client/my-sites/stats/post-detail-highlights-section/index.tsx
+++ b/client/my-sites/stats/post-detail-highlights-section/index.tsx
@@ -72,7 +72,9 @@ export default function PostDetailHighlightsSection( {
 
 					<Card className="highlight-card">
 						<div className="highlight-card-heading">
-							<span>{ translate( 'Post likes' ) }</span>
+							<span>
+								{ post?.type === 'page' ? translate( 'Page likes' ) : translate( 'Post likes' ) }
+							</span>
 							<Count count={ post?.like_count || 0 } />
 						</div>
 						<PostLikes siteId={ siteId } postId={ postId } postType={ post?.type } />


### PR DESCRIPTION
Fixes STATS-130

## Proposed Changes

* Display "Page likes" instead of "Post likes" in the stats highlights section when viewing stats for a page

## Why are these changes being made?

When viewing stats for a page (not a post), the likes widget heading incorrectly showed "Post likes" while other UI strings correctly displayed "page". This creates an inconsistent user experience.

## Testing Instructions

1. Navigate to stats for a **page** (not a post) in wp-admin
2. Look at the likes widget heading in the highlights section
3. Verify it now says "Page likes" instead of "Post likes"
4. Also verify that for regular posts, it still says "Post likes"

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?