### PR TITLE
Stats: Add tooltip note to clarify visitors aggregate counting

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -124,7 +124,11 @@ Object.defineProperty( CHART_VISITORS, 'label', {
 	get: () => translate( 'Visitors', { context: 'noun' } ),
 } );
 Object.defineProperty( CHART_VISITORS, 'aggregateNote', {
-	get: () => translate( 'Totals are summed per-period, not unique overall.' ),
+	get: () =>
+		translate( 'Totals are summed per-period, not unique overall.', {
+			comment:
+				'Explanation for the Visitors stats chart: the total visitors value is calculated by adding up the visitors count in each time bucket (day/week/month), so it is not a unique visitor count across the entire selected date range.',
+		} ),
 } );
 Object.defineProperty( CHART_LIKES, 'label', {
 	get: () => translate( 'Likes', { context: 'noun' } ),

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -123,6 +123,9 @@ Object.defineProperty( CHART_VIEWS, 'label', {
 Object.defineProperty( CHART_VISITORS, 'label', {
 	get: () => translate( 'Visitors', { context: 'noun' } ),
 } );
+Object.defineProperty( CHART_VISITORS, 'aggregateNote', {
+	get: () => translate( 'Totals are summed per-period, not unique overall.' ),
+} );
 Object.defineProperty( CHART_LIKES, 'label', {
 	get: () => translate( 'Likes', { context: 'noun' } ),
 } );

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -125,9 +125,9 @@ Object.defineProperty( CHART_VISITORS, 'label', {
 } );
 Object.defineProperty( CHART_VISITORS, 'aggregateNote', {
 	get: () =>
-		translate( 'Totals are summed per-period, not unique overall.', {
+		translate( 'Per-period sum, not unique overall.', {
 			comment:
-				'Explanation for the Visitors stats chart: the total visitors value is calculated by adding up the visitors count in each time bucket (day/week/month), so it is not a unique visitor count across the entire selected date range.',
+				'Explanation for the Visitors stats chart: the total visitors value is calculated by adding up the visitors count in each time bucket (day/week/month), so it may differ from the unique visitor count across the entire selected date range.',
 		} ),
 } );
 Object.defineProperty( CHART_LIKES, 'label', {

--- a/client/my-sites/stats/stats-tabs/index.jsx
+++ b/client/my-sites/stats/stats-tabs/index.jsx
@@ -86,6 +86,7 @@ class StatsTabs extends Component {
 					previousValue,
 					format: tab.format,
 					hasPreviousData: !! previousData,
+					aggregateNote: aggregate ? tab.aggregateNote : undefined,
 				};
 
 				return <StatTab key={ tabOptions.attr } { ...tabOptions } />;

--- a/client/my-sites/stats/stats-tabs/tab.jsx
+++ b/client/my-sites/stats/stats-tabs/tab.jsx
@@ -23,6 +23,7 @@ class StatsTabsTab extends Component {
 		previousValue: PropTypes.number,
 		value: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ),
 		format: PropTypes.func,
+		aggregateNote: PropTypes.string,
 	};
 
 	state = {
@@ -68,6 +69,7 @@ class StatsTabsTab extends Component {
 			previousValue,
 			value,
 			hasPreviousData,
+			aggregateNote,
 		} = this.props;
 
 		const tabClass = clsx( 'stats-tab', className, {
@@ -130,6 +132,7 @@ class StatsTabsTab extends Component {
 									value={ value }
 									label={ label.toLocaleLowerCase() }
 									previousValue={ previousValue }
+									note={ aggregateNote }
 								/>
 							</Popover>
 						</div>


### PR DESCRIPTION
Part of STATS-152

## Proposed Changes

* Add a clarifying note to the Visitors tab tooltip explaining that totals are summed per-period, not unique overall
* The note only appears when viewing aggregated data (i.e., when the chart shows daily/weekly data and the total is a sum)

## Why are these changes being made?

Users are confused when comparing monthly visitors against the sum of daily visitors in the stats interface. Currently, the UI sums up daily visitor counts when viewing by day. This increases the total compared to monthly uniques (since visitors on multiple days are double-counted).

This change adds a tooltip note clarifying that daily visitors are summed by day, while monthly visitors represent unique visitors across the whole month—which will always be less than the daily totals added together.

## Testing Instructions

1. Go to Stats > Traffic for any site
2. View the chart in "Days" mode over a period (e.g., last 30 days)
3. Hover over the "Visitors" tab below the chart
4. Verify the tooltip now includes the note: "Totals are summed per-period, not unique overall."
5. Switch to "Months" view and verify the note still appears when hovering


<img width="1263" height="451" alt="Screenshot 2026-03-20 at 1 26 58 PM" src="https://github.com/user-attachments/assets/45983710-7b8a-432d-85b1-43da3dbbd106" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?