### PR TITLE
Fix free-trial disable confirmation modal in AI tools settings

### DIFF
--- a/client/dashboard/sites/settings-ai-tools/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/index.tsx
@@ -68,6 +68,11 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 		: undefined;
 
 	const handleToggle = ( enable: boolean ) => {
+		if ( ! enable && isFreeTrial && ! isConfirmModalOpen ) {
+			setIsConfirmModalOpen( true );
+			return;
+		}
+
 		if ( enable ) {
 			recordTracksEvent( 'calypso_dashboard_ai_tool_ai_assistant_enabled' );
 		} else {


### PR DESCRIPTION
Fixes DOTMSD-1149

## Proposed Changes

* Fix `handleToggle` to open the confirmation modal when a free-trial user tries to disable the AI assistant, instead of executing the mutation directly.

## Why are these changes being made?

* The `ConfirmModal` warning free-trial users that disabling the AI assistant is irreversible without a paid plan was unreachable — `isConfirmModalOpen` was never set to `true`. Users could disable the AI assistant without seeing the warning.

## Testing Instructions

* Have a site on a free trial plan (e.g. after starting at wordpress.com/ai and declining to pay).
* Navigate to the AI tools settings page.
* Click the toggle to disable the AI assistant.
* **Expected:** A confirmation modal appears warning that the action is irreversible without a paid plan.
* Click "Disable AI assistant" in the modal to confirm, or cancel to keep it enabled.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)