### PR TITLE
Dashboard: Pass app id as site transfer context

### DIFF
--- a/client/dashboard/app-ciab/index.tsx
+++ b/client/dashboard/app-ciab/index.tsx
@@ -17,6 +17,7 @@ import type {
 import './style.scss';
 
 boot( {
+	id: 'ciab',
 	name: 'CIAB',
 	posthog: config.isEnabled( 'posthog-tracking' ) ? config( 'ciab_posthog_api_key' ) : undefined,
 	basePath: '/',

--- a/client/dashboard/app-dotcom/index.tsx
+++ b/client/dashboard/app-dotcom/index.tsx
@@ -16,6 +16,7 @@ import type {
 import './style.scss';
 
 boot( {
+	id: 'dotcom',
 	name: 'WordPress.com',
 	basePath: '/',
 	mainRoute: '/sites',

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -28,7 +28,10 @@ export type MeSupports = {
 	apps: boolean;
 };
 
+export type AppId = 'dotcom' | 'ciab';
+
 export type AppConfig = {
+	id: AppId;
 	name: string;
 	basePath: string;
 	mainRoute: string;
@@ -63,6 +66,7 @@ export type AppConfig = {
 };
 
 export const APP_CONTEXT_DEFAULT_CONFIG: AppConfig = {
+	id: 'dotcom',
 	name: '',
 	basePath: '',
 	mainRoute: '',

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -64,8 +64,8 @@ import { hasSiteTrialEnded } from '../../utils/site-trial';
 import { getSiteTypeFeatureSupports } from '../../utils/site-type-feature-support';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import { AUTH_QUERY_KEY } from '../auth';
+import { useAppContext, type AppConfig } from '../context';
 import { rootRoute } from './root';
-import type { AppConfig } from '../context';
 import type { DifmWebsiteContentResponse, Site, User } from '@automattic/api-core';
 import type { AnyRoute } from '@tanstack/react-router';
 
@@ -1110,9 +1110,10 @@ export const siteSettingsTransferSiteRoute = createRoute( {
 } ).lazy( () =>
 	import( '../../sites/settings-transfer-site' ).then( ( d ) =>
 		createLazyRoute( 'site-settings-transfer-site' )( {
-			component: () => (
-				<d.default siteSlug={ siteRoute.useParams().siteSlug } context="dashboard_v2" />
-			),
+			component: function TransferSite() {
+				const { id } = useAppContext();
+				return <d.default siteSlug={ siteRoute.useParams().siteSlug } context={ id } />;
+			},
 		} )
 	)
 );

--- a/client/dashboard/sites/settings-transfer-site/index.tsx
+++ b/client/dashboard/sites/settings-transfer-site/index.tsx
@@ -14,7 +14,7 @@ import { ConfirmNewOwnerForm, ConfirmNewOwnerFormData } from './confirm-new-owne
 import { EmailConfirmation } from './email-confirmation';
 import { InvitationEmailSent } from './invitation-email-sent';
 import { StartSiteTransferForm } from './start-site-transfer-form';
-import type { SiteOwnerTransferContext } from '@automattic/api-core';
+import type { AppId } from '../../app/context';
 
 const MIN_STEP = 0;
 
@@ -50,7 +50,7 @@ export default function SettingsTransferSite( {
 	context,
 }: {
 	siteSlug: string;
-	context?: SiteOwnerTransferContext;
+	context?: AppId;
 } ) {
 	const { user } = useAuth();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );

--- a/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
@@ -14,7 +14,8 @@ import React, { useState } from 'react';
 import { ButtonStack } from '../../components/button-stack';
 import Notice from '../../components/notice';
 import { SectionHeader } from '../../components/section-header';
-import type { Site, SiteOwnerTransferContext } from '@automattic/api-core';
+import type { AppId } from '../../app/context';
+import type { Site } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
 
 export type StartSiteTransferFormData = {
@@ -69,7 +70,7 @@ export function StartSiteTransferForm( {
 }: {
 	site: Site;
 	newOwnerEmail: string;
-	context?: SiteOwnerTransferContext;
+	context?: AppId;
 	onSubmit: () => void;
 	onBack: () => void;
 } ) {

--- a/packages/api-core/src/site-owner-transfer/mutators.ts
+++ b/packages/api-core/src/site-owner-transfer/mutators.ts
@@ -1,9 +1,9 @@
 import { wpcom } from '../wpcom-fetcher';
-import type { SiteOwnerTransferContext, SiteOwnerTransferConfirmation } from './types';
+import type { SiteOwnerTransferConfirmation } from './types';
 
 export async function startSiteOwnerTransfer(
 	siteId: number,
-	data: { new_site_owner: string; context?: SiteOwnerTransferContext }
+	data: { new_site_owner: string; context?: string }
 ) {
 	return wpcom.req.post(
 		{

--- a/packages/api-core/src/site-owner-transfer/types.ts
+++ b/packages/api-core/src/site-owner-transfer/types.ts
@@ -1,5 +1,3 @@
-export type SiteOwnerTransferContext = 'dashboard_v2';
-
 export interface SiteOwnerTransferConfirmation {
 	transfer: boolean;
 	email_sent: boolean;

--- a/packages/api-queries/src/site-owner-transfer.ts
+++ b/packages/api-queries/src/site-owner-transfer.ts
@@ -6,11 +6,10 @@ import {
 import { mutationOptions } from '@tanstack/react-query';
 import { queryClient } from './query-client';
 import { siteQueryFilter } from './site';
-import type { SiteOwnerTransferContext } from '@automattic/api-core';
 
 export const siteOwnerTransferMutation = ( siteId: number ) =>
 	mutationOptions( {
-		mutationFn: ( data: { new_site_owner: string; context?: SiteOwnerTransferContext } ) =>
+		mutationFn: ( data: { new_site_owner: string; context?: string } ) =>
 			startSiteOwnerTransfer( siteId, data ),
 	} );
 


### PR DESCRIPTION
Part of DOTMSD-1093

## Proposed Changes

- Add an `id` field (`'dotcom' | 'ciab'`) to the Dashboard `AppConfig`, giving each app variant a stable identifier.
- Pass the app `id` as the `context` parameter when calling `POST /wpcom/v2/sites/{site_id}/site-owner-transfer`, replacing the hardcoded `"dashboard_v2"` value.
- Remove the `SiteOwnerTransferContext` type from `@automattic/api-core` — the API layer now accepts a plain `string`, and the app layer (`AppId`) is the single source of truth for valid values.

## Why are these changes being made?

When a user initiates a site ownership transfer from `my.woo.ai`, the confirmation email currently links back to `wordpress.com` instead of `my.woo.ai`. The backend (wpcom PR #204885) adds support for mapping context values to the correct origin, but the frontend needs to identify which app it is.

Rather than adding yet another hardcoded context string (`"mywooai"`), this change introduces a general-purpose app identifier on the Dashboard config. Each dashboard variant declares its own `id`, and that `id` flows through to the transfer API. The backend maps it to the correct confirmation email origin:

- `dotcom` → `https://my.wordpress.com`
- `ciab` → `https://my.woo.ai`
- `dashboard_v2` → `https://my.wordpress.com` (backward compat, to be removed)

## Testing Instructions

1. On `my.wordpress.com` (or local dotcom dashboard), navigate to a site's Settings → Transfer site.
2. Initiate a transfer — verify the API call includes `context: "dotcom"` in the request body.
3. On `my.woo.ai` (or local CIAB dashboard), repeat — verify the API call includes `context: "ciab"`.
4. Confirm that the backend (once wpcom PR #204885 lands) generates the correct confirmation email links for each context.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?