### PR TITLE
Dashboard: Add OAuth state parameter to prevent login CSRF

### DIFF
--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -87,6 +87,9 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 				next: window.location.pathname + window.location.search,
 			} ).toString();
 
+			const state = crypto.randomUUID();
+			sessionStorage.setItem( 'wpcom_oauth_state', state );
+
 			const authUri = new URL( 'https://public-api.wordpress.com/oauth2/authorize' );
 			authUri.search = new URLSearchParams( {
 				response_type: 'token',
@@ -94,6 +97,7 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 				redirect_uri: redirectUri.toString(),
 				scope: 'global',
 				blog_id: '0',
+				state,
 			} ).toString();
 
 			window.location.replace( authUri.toString() );

--- a/client/dashboard/app/auth/oauth-callback.ts
+++ b/client/dashboard/app/auth/oauth-callback.ts
@@ -13,6 +13,16 @@ export function handleOAuthCallback(): boolean {
 	}
 
 	const hash = new URLSearchParams( window.location.hash.substring( 1 ) );
+	const params = new URLSearchParams( window.location.search );
+
+	// Validate the OAuth state parameter to prevent login CSRF / session fixation.
+	const returnedState = hash.get( 'state' ) || params.get( 'state' );
+	const expectedState = sessionStorage.getItem( 'wpcom_oauth_state' );
+	sessionStorage.removeItem( 'wpcom_oauth_state' );
+	if ( ! returnedState || ! expectedState || returnedState !== expectedState ) {
+		document.location.replace( '/' );
+		return true;
+	}
 
 	const accessToken = hash.get( 'access_token' );
 	if ( accessToken ) {
@@ -24,7 +34,6 @@ export function handleOAuthCallback(): boolean {
 		store.set( 'wpcom_token_expires_in', expiresIn );
 	}
 
-	const params = new URLSearchParams( window.location.search );
 	const next = params.get( 'next' ) || '/';
 	document.location.replace( next );
 


### PR DESCRIPTION
Part of DOTMSD-1145

## Proposed Changes

* Generate a cryptographic `state` parameter (`crypto.randomUUID()`) before redirecting to the WordPress.com OAuth authorize endpoint
* Validate the returned `state` on callback before storing the access token
* Reject the callback and redirect to `/` if the state is missing or mismatched

## Why are these changes being made?

The Dashboard OAuth flow constructs the authorization URL without a `state` parameter. This allows an attacker to craft a callback URL with their own access token and trick a victim into visiting it, causing the victim to be logged into the attacker's account (session fixation / login CSRF). The `state` parameter binds the OAuth callback to the session that initiated it, preventing this attack.

## Testing Instructions

* Use the OAuth flow locally at `http://my.woo.localhost:3000`
* Trigger an auth error or log out to initiate the OAuth redirect
* Verify the authorize URL includes `&state=<uuid>`
* Verify callback validates the state and stores the token on match
* Verify callback rejects and redirects to `/` on state mismatch (e.g., manually alter the state param in the callback URL)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)