### PR TITLE
Image Studio: Add domain allowlist to error URL parser

### DIFF
--- a/packages/image-studio/src/hooks/use-error-notice.test.ts
+++ b/packages/image-studio/src/hooks/use-error-notice.test.ts
@@ -70,15 +70,18 @@ describe( 'useErrorNotice', () => {
 	} );
 
 	describe( 'errors with non-upgrade URLs', () => {
-		it( 'shows error snackbar with "Learn more" action', () => {
+		it( 'shows error snackbar with "Learn more" action for allowed domain', () => {
 			renderHook( () =>
-				useErrorNotice( 'Error occurred. See https://example.com/help for details.', mockAddNotice )
+				useErrorNotice(
+					'Error occurred. See https://wordpress.com/help for details.',
+					mockAddNotice
+				)
 			);
 
 			expect( mockAddNotice ).toHaveBeenCalledWith( 'Error occurred. See for details.', 'error', [
 				{
 					label: 'Learn more',
-					url: 'https://example.com/help',
+					url: 'https://wordpress.com/help',
 					openInNewTab: true,
 				},
 			] );
@@ -86,16 +89,24 @@ describe( 'useErrorNotice', () => {
 
 		it( 'extracts URL from middle of message', () => {
 			renderHook( () =>
-				useErrorNotice( 'Visit https://docs.example.com for help', mockAddNotice )
+				useErrorNotice( 'Visit https://jetpack.com/docs for help', mockAddNotice )
 			);
 
 			expect( mockAddNotice ).toHaveBeenCalledWith( 'Visit for help', 'error', [
 				{
 					label: 'Learn more',
-					url: 'https://docs.example.com',
+					url: 'https://jetpack.com/docs',
 					openInNewTab: true,
 				},
 			] );
+		} );
+
+		it( 'shows plain error when URL domain is not allowed', () => {
+			renderHook( () =>
+				useErrorNotice( 'Error occurred. See https://example.com/help for details.', mockAddNotice )
+			);
+
+			expect( mockAddNotice ).toHaveBeenCalledWith( 'Error occurred. See for details.', 'error' );
 		} );
 	} );
 
@@ -145,21 +156,34 @@ describe( 'useErrorNotice', () => {
 			] );
 		} );
 
-		it( 'shows warning notice with "Upgrade plan" for my-jetpack URL', () => {
-			renderHook( () =>
-				useErrorNotice(
-					'Please upgrade https://example.com/wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai',
-					mockAddNotice
-				)
-			);
+		it( 'shows warning notice with "Upgrade plan" for my-jetpack URL on current origin', () => {
+			const savedOrigin = window.location.origin;
+			Object.defineProperty( window, 'location', {
+				value: { origin: 'https://example.com' },
+				writable: true,
+			} );
 
-			expect( mockAddNotice ).toHaveBeenCalledWith( 'Please upgrade', 'warning', [
-				{
-					label: 'Upgrade plan',
-					url: 'https://example.com/wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai',
-					openInNewTab: true,
-				},
-			] );
+			try {
+				renderHook( () =>
+					useErrorNotice(
+						'Please upgrade https://example.com/wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai',
+						mockAddNotice
+					)
+				);
+
+				expect( mockAddNotice ).toHaveBeenCalledWith( 'Please upgrade', 'warning', [
+					{
+						label: 'Upgrade plan',
+						url: 'https://example.com/wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai',
+						openInNewTab: true,
+					},
+				] );
+			} finally {
+				Object.defineProperty( window, 'location', {
+					value: new URL( savedOrigin ),
+					writable: true,
+				} );
+			}
 		} );
 
 		it( 'handles real-world streaming error with upgrade URL', () => {

--- a/packages/image-studio/src/utils/parse-error-url.test.ts
+++ b/packages/image-studio/src/utils/parse-error-url.test.ts
@@ -52,42 +52,44 @@ describe( 'parseErrorUrl', () => {
 
 	describe( 'URL extraction', () => {
 		it( 'extracts http URL from message', () => {
-			const result = parseErrorUrl( 'Error occurred. See http://example.com for details.' );
-			expect( result.url ).toBe( 'http://example.com' );
+			const result = parseErrorUrl( 'Error occurred. See http://wordpress.com/help for details.' );
+			expect( result.url ).toBe( 'http://wordpress.com/help' );
 			expect( result.content ).toBe( 'Error occurred. See for details.' );
 		} );
 
 		it( 'extracts https URL from message', () => {
-			const result = parseErrorUrl( 'Error occurred. See https://example.com for details.' );
-			expect( result.url ).toBe( 'https://example.com' );
+			const result = parseErrorUrl( 'Error occurred. See https://wordpress.com/help for details.' );
+			expect( result.url ).toBe( 'https://wordpress.com/help' );
 			expect( result.content ).toBe( 'Error occurred. See for details.' );
 		} );
 
 		it( 'extracts URL with path and query params', () => {
-			const result = parseErrorUrl( 'Visit https://example.com/path?foo=bar&baz=qux' );
-			expect( result.url ).toBe( 'https://example.com/path?foo=bar&baz=qux' );
+			const result = parseErrorUrl( 'Visit https://wordpress.com/path?foo=bar&baz=qux' );
+			expect( result.url ).toBe( 'https://wordpress.com/path?foo=bar&baz=qux' );
 			expect( result.content ).toBe( 'Visit' );
 		} );
 
 		it( 'extracts first URL when multiple present', () => {
-			const result = parseErrorUrl( 'See https://first.com or https://second.com' );
-			expect( result.url ).toBe( 'https://first.com' );
+			const result = parseErrorUrl(
+				'See https://wordpress.com/first or https://jetpack.com/second'
+			);
+			expect( result.url ).toBe( 'https://wordpress.com/first' );
 		} );
 
 		it( 'trims content after URL removal', () => {
-			const result = parseErrorUrl( 'https://example.com' );
+			const result = parseErrorUrl( 'https://wordpress.com' );
 			expect( result.content ).toBe( '' );
 		} );
 
 		it( 'handles URL at start of message', () => {
-			const result = parseErrorUrl( 'https://example.com - click here for help' );
-			expect( result.url ).toBe( 'https://example.com' );
+			const result = parseErrorUrl( 'https://wordpress.com/help - click here for help' );
+			expect( result.url ).toBe( 'https://wordpress.com/help' );
 			expect( result.content ).toBe( '- click here for help' );
 		} );
 
 		it( 'handles URL at end of message', () => {
-			const result = parseErrorUrl( 'For more information visit https://example.com' );
-			expect( result.url ).toBe( 'https://example.com' );
+			const result = parseErrorUrl( 'For more information visit https://wordpress.com/help' );
+			expect( result.url ).toBe( 'https://wordpress.com/help' );
 			expect( result.content ).toBe( 'For more information visit' );
 		} );
 	} );
@@ -106,7 +108,7 @@ describe( 'parseErrorUrl', () => {
 		} );
 
 		it( 'identifies /upgrade/ with path as upgrade but not plans page', () => {
-			const result = parseErrorUrl( 'See https://example.com/upgrade/premium' );
+			const result = parseErrorUrl( 'See https://wordpress.com/upgrade/premium' );
 			expect( result.isUpgradeUrl ).toBe( true );
 			expect( result.isPlansPageUrl ).toBe( false );
 		} );
@@ -119,22 +121,39 @@ describe( 'parseErrorUrl', () => {
 			expect( result.isPlansPageUrl ).toBe( false );
 		} );
 
-		it( 'identifies my-jetpack URL as upgrade but not plans page', () => {
-			const result = parseErrorUrl(
-				'Upgrade required https://example.com/wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai'
-			);
-			expect( result.isUpgradeUrl ).toBe( true );
-			expect( result.isPlansPageUrl ).toBe( false );
+		it( 'identifies my-jetpack URL on current origin as upgrade but not plans page', () => {
+			// jsdom defaults to http://localhost — simulate a self-hosted site
+			const savedOrigin = window.location.origin;
+			Object.defineProperty( window, 'location', {
+				value: { origin: 'https://example.com' },
+				writable: true,
+			} );
+
+			try {
+				const result = parseErrorUrl(
+					'Upgrade required https://example.com/wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai'
+				);
+				expect( result.isUpgradeUrl ).toBe( true );
+				expect( result.isPlansPageUrl ).toBe( false );
+				expect( result.url ).toBe(
+					'https://example.com/wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai'
+				);
+			} finally {
+				Object.defineProperty( window, 'location', {
+					value: new URL( savedOrigin ),
+					writable: true,
+				} );
+			}
 		} );
 
-		it( 'returns false for non-upgrade URLs', () => {
-			const result = parseErrorUrl( 'See https://example.com/help' );
+		it( 'returns false for non-upgrade URLs on allowed domain', () => {
+			const result = parseErrorUrl( 'See https://wordpress.com/help' );
 			expect( result.isUpgradeUrl ).toBe( false );
 			expect( result.isPlansPageUrl ).toBe( false );
 		} );
 
 		it( 'returns false for URL with "plans" not in path', () => {
-			const result = parseErrorUrl( 'See https://example.com?plans=true' );
+			const result = parseErrorUrl( 'See https://wordpress.com?plans=true' );
 			expect( result.isUpgradeUrl ).toBe( false );
 			expect( result.isPlansPageUrl ).toBe( false );
 		} );
@@ -146,7 +165,7 @@ describe( 'parseErrorUrl', () => {
 		} );
 
 		it( 'returns false for URL with "jetpack.com/redirect" in path but different hostname', () => {
-			const result = parseErrorUrl( 'See https://evil.com/jetpack.com/redirect' );
+			const result = parseErrorUrl( 'See https://wordpress.com/jetpack.com/redirect' );
 			expect( result.isUpgradeUrl ).toBe( false );
 			expect( result.isPlansPageUrl ).toBe( false );
 		} );
@@ -165,47 +184,100 @@ describe( 'parseErrorUrl', () => {
 			expect( result.isPlansPageUrl ).toBe( false );
 		} );
 
-		it( 'returns false for my-jetpack URL', () => {
-			const result = parseErrorUrl(
-				'Upgrade required https://example.com/wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai'
-			);
-			expect( result.isPlansPageUrl ).toBe( false );
-		} );
-
 		it( 'returns false for /upgrade URL', () => {
 			const result = parseErrorUrl( 'Upgrade required https://wordpress.com/upgrade' );
 			expect( result.isPlansPageUrl ).toBe( false );
 		} );
 
 		it( 'returns false for non-upgrade URLs', () => {
-			const result = parseErrorUrl( 'See https://example.com/help' );
+			const result = parseErrorUrl( 'See https://wordpress.com/help' );
 			expect( result.isPlansPageUrl ).toBe( false );
+		} );
+	} );
+
+	describe( 'domain allowlist', () => {
+		it( 'allows wordpress.com URLs', () => {
+			const result = parseErrorUrl( 'See https://wordpress.com/help' );
+			expect( result.url ).toBe( 'https://wordpress.com/help' );
+		} );
+
+		it( 'allows jetpack.com URLs', () => {
+			const result = parseErrorUrl( 'See https://jetpack.com/help' );
+			expect( result.url ).toBe( 'https://jetpack.com/help' );
+		} );
+
+		it( 'rejects subdomains of trusted domains', () => {
+			const result = parseErrorUrl( 'See https://public-api.wordpress.com/help' );
+			expect( result.url ).toBeNull();
+		} );
+
+		it( 'allows URLs matching window.location.origin (self-hosted)', () => {
+			Object.defineProperty( window, 'location', {
+				value: { origin: 'https://my-selfhosted-site.org' },
+				writable: true,
+			} );
+
+			try {
+				const result = parseErrorUrl(
+					'See https://my-selfhosted-site.org/wp-admin/admin.php?page=my-jetpack'
+				);
+				expect( result.url ).toBe(
+					'https://my-selfhosted-site.org/wp-admin/admin.php?page=my-jetpack'
+				);
+			} finally {
+				Object.defineProperty( window, 'location', {
+					value: new URL( 'http://localhost' ),
+					writable: true,
+				} );
+			}
+		} );
+
+		it( 'rejects URLs from untrusted domains', () => {
+			const result = parseErrorUrl( 'See https://evil.com/phishing' );
+			expect( result.url ).toBeNull();
+			expect( result.content ).toBe( 'See' );
+		} );
+
+		it( 'rejects URLs that look like trusted domains but are not', () => {
+			const result = parseErrorUrl( 'See https://notwordpress.com/help' );
+			expect( result.url ).toBeNull();
+		} );
+
+		it( 'strips URL from content even when domain is rejected', () => {
+			const result = parseErrorUrl( 'Error occurred. See https://evil.com for details.' );
+			expect( result.url ).toBeNull();
+			expect( result.content ).toBe( 'Error occurred. See for details.' );
+		} );
+
+		it( 'handles hostname with port on allowed domain', () => {
+			const result = parseErrorUrl( 'See https://wordpress.com:8080/path' );
+			expect( result.url ).toBe( 'https://wordpress.com:8080/path' );
 		} );
 	} );
 
 	describe( 'edge cases', () => {
 		it( 'handles URL with fragment', () => {
-			const result = parseErrorUrl( 'See https://example.com/docs#section' );
-			expect( result.url ).toBe( 'https://example.com/docs#section' );
+			const result = parseErrorUrl( 'See https://wordpress.com/docs#section' );
+			expect( result.url ).toBe( 'https://wordpress.com/docs#section' );
 		} );
 
 		it( 'handles URL with port', () => {
-			const result = parseErrorUrl( 'See https://example.com:8080/path' );
-			expect( result.url ).toBe( 'https://example.com:8080/path' );
+			const result = parseErrorUrl( 'See https://wordpress.com:8080/path' );
+			expect( result.url ).toBe( 'https://wordpress.com:8080/path' );
 		} );
 
 		it( 'handles URL with encoded characters', () => {
-			const result = parseErrorUrl( 'See https://example.com/path%20with%20spaces' );
-			expect( result.url ).toBe( 'https://example.com/path%20with%20spaces' );
+			const result = parseErrorUrl( 'See https://wordpress.com/path%20with%20spaces' );
+			expect( result.url ).toBe( 'https://wordpress.com/path%20with%20spaces' );
 		} );
 
 		it( 'does not match ftp URLs', () => {
-			const result = parseErrorUrl( 'See ftp://example.com' );
+			const result = parseErrorUrl( 'See ftp://wordpress.com' );
 			expect( result.url ).toBeNull();
 		} );
 
 		it( 'does not match mailto links', () => {
-			const result = parseErrorUrl( 'Contact mailto:test@example.com' );
+			const result = parseErrorUrl( 'Contact mailto:test@wordpress.com' );
 			expect( result.url ).toBeNull();
 		} );
 	} );

--- a/packages/image-studio/src/utils/parse-error-url.ts
+++ b/packages/image-studio/src/utils/parse-error-url.ts
@@ -13,7 +13,34 @@ export interface ParsedErrorUrl {
 }
 
 /**
+ * Trusted domains whose URLs may be surfaced as clickable links in error notices.
+ */
+const ALLOWED_DOMAINS = [ 'wordpress.com', 'jetpack.com' ];
+
+function isAllowedDomain( hostname: string ): boolean {
+	const domain = hostname.replace( /:\d+$/, '' ).toLowerCase();
+
+	if ( ALLOWED_DOMAINS.includes( domain ) ) {
+		return true;
+	}
+
+	// Self-hosted Jetpack sites use their own admin URL for upgrade links.
+	// The current origin is always trusted — the user is already on that domain.
+	if ( typeof window !== 'undefined' ) {
+		try {
+			const currentHostname = new URL( window.location.origin ).hostname.toLowerCase();
+			return domain === currentHostname;
+		} catch {
+			// Invalid origin — fall through to reject.
+		}
+	}
+
+	return false;
+}
+
+/**
  * Parses an error message to extract a URL and determine if it's an upgrade URL.
+ * Only URLs from trusted domains are surfaced as clickable links.
  * @param errorMessage - The error message that may contain a URL
  * @returns Parsed result with content, url, and isUpgradeUrl flag
  */
@@ -39,6 +66,16 @@ export function parseErrorUrl( errorMessage: string ): ParsedErrorUrl {
 	const pathStart = urlWithoutProtocol.indexOf( '/' );
 	const pathAndQuery = pathStart >= 0 ? urlWithoutProtocol.slice( pathStart ) : '';
 	const hostname = pathStart >= 0 ? urlWithoutProtocol.slice( 0, pathStart ) : urlWithoutProtocol;
+
+	// Reject URLs from untrusted domains.
+	if ( ! isAllowedDomain( hostname ) ) {
+		return {
+			content,
+			url: null,
+			isUpgradeUrl: false,
+			isPlansPageUrl: false,
+		};
+	}
 
 	const isUpgradeUrl =
 		pathAndQuery.includes( '/plans/' ) ||


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of FORNO-258

## Proposed Changes

* Introduce domain allowlist to `parseErrorUrl()`. Restricts clickable links in error notices to wordpress.com, jetpack.com,
  and the current window origin (for self-hosted Jetpack admin URLs)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Prevents a compromised error source from injecting phishing links.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `install-plugin.sh am forno-258/error-url-domain-allowlist` on your sandbox
* Create a Jurassic Ninja site with sandbox access (or visit a test site which is out of Jetpack AI credits)
* Sandbox `widgets.wp.com` and `public-api.wordpress.com`
* Apply this patch to your sandbox. Pastebin: 3abc0-pb
* Ensure your site has 5 credits or less
* Launch image studio and generate an image
* Verify the upgrade notice does not render a clickable link
* Undo the sandbox patch and generate another image
* Verify the upgrade notice renders the clickable link

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
