### PR TITLE
OAuth: Add state parameter and validate redirects across all clients

### DIFF
--- a/client/a8c-for-agencies/sections/auth/controller.tsx
+++ b/client/a8c-for-agencies/sections/auth/controller.tsx
@@ -13,12 +13,16 @@ export const connect: Callback = ( context, next ) => {
 	if ( config.isEnabled( 'oauth' ) && config( 'oauth_client_id' ) ) {
 		const redirectUri = new URL( '/connect/oauth/token', window.location.origin );
 
+		const state = crypto.randomUUID();
+		sessionStorage.setItem( 'wpcom_oauth_state', state );
+
 		const authUrl = new URL( WP_AUTHORIZE_ENDPOINT );
 		authUrl.search = new URLSearchParams( {
 			response_type: 'token',
 			client_id: config( 'oauth_client_id' ),
 			redirect_uri: redirectUri.toString(),
 			scope: 'global',
+			state,
 		} ).toString();
 
 		debug( `authUrl: ${ authUrl }` );
@@ -42,6 +46,15 @@ export const tokenRedirect: Callback = ( ctx, next ) => {
 	if ( context.hash?.error ) {
 		context.primary = <Connect authUrl="/connect/oauth/token" />;
 		return next();
+	}
+
+	// Validate the OAuth state parameter to prevent login CSRF / session fixation.
+	const returnedState = context.hash?.state;
+	const expectedState = sessionStorage.getItem( 'wpcom_oauth_state' );
+	sessionStorage.removeItem( 'wpcom_oauth_state' );
+	if ( ! returnedState || ! expectedState || returnedState !== expectedState ) {
+		document.location.replace( DEFAULT_NEXT_LOCATION );
+		return;
 	}
 
 	if ( context.hash?.access_token ) {

--- a/client/auth/controller.js
+++ b/client/auth/controller.js
@@ -2,6 +2,15 @@ import store from 'store';
 
 // Store token into local storage
 export function storeToken( context ) {
+	// Validate the OAuth state parameter to prevent login CSRF / session fixation.
+	const returnedState = context.hash?.state;
+	const expectedState = sessionStorage.getItem( 'wpcom_oauth_state' );
+	sessionStorage.removeItem( 'wpcom_oauth_state' );
+	if ( ! returnedState || ! expectedState || returnedState !== expectedState ) {
+		document.location.replace( '/' );
+		return;
+	}
+
 	if ( context.hash?.access_token ) {
 		store.set( 'wpcom_token', context.hash.access_token );
 	}
@@ -11,5 +20,8 @@ export function storeToken( context ) {
 	}
 
 	const { next = '/' } = context.query;
-	document.location.replace( next );
+
+	// Validate that next is a safe relative path to prevent DOM XSS and open redirect.
+	const isSafe = next.startsWith( '/' ) && ! next.startsWith( '//' );
+	document.location.replace( isSafe ? next : '/' );
 }

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -144,6 +144,9 @@ function authorizePath() {
 		next: window.location.pathname + window.location.search,
 	} ).toString();
 
+	const state = crypto.randomUUID();
+	sessionStorage.setItem( 'wpcom_oauth_state', state );
+
 	const authUri = new URL( 'https://public-api.wordpress.com/oauth2/authorize' );
 	authUri.search = new URLSearchParams( {
 		response_type: 'token',
@@ -151,6 +154,7 @@ function authorizePath() {
 		redirect_uri: redirectUri.toString(),
 		scope: 'global',
 		blog_id: 0,
+		state,
 	} ).toString();
 
 	return authUri.toString();

--- a/client/jetpack-cloud/sections/auth/controller.tsx
+++ b/client/jetpack-cloud/sections/auth/controller.tsx
@@ -13,12 +13,16 @@ export const connect: Callback = ( context, next ) => {
 	if ( config.isEnabled( 'oauth' ) && config( 'oauth_client_id' ) ) {
 		const redirectUri = new URL( '/connect/oauth/token', window.location.origin );
 
+		const state = crypto.randomUUID();
+		sessionStorage.setItem( 'wpcom_oauth_state', state );
+
 		const authUrl = new URL( WP_AUTHORIZE_ENDPOINT );
 		authUrl.search = new URLSearchParams( {
 			response_type: 'token',
 			client_id: config( 'oauth_client_id' ),
 			redirect_uri: redirectUri.toString(),
 			scope: 'global',
+			state,
 		} ).toString();
 
 		debug( `authUrl: ${ authUrl }` );
@@ -42,6 +46,15 @@ export const tokenRedirect: Callback = ( ctx, next ) => {
 	if ( context.hash?.error ) {
 		context.primary = <Connect authUrl="/connect/oauth/token" />;
 		return next();
+	}
+
+	// Validate the OAuth state parameter to prevent login CSRF / session fixation.
+	const returnedState = context.hash?.state;
+	const expectedState = sessionStorage.getItem( 'wpcom_oauth_state' );
+	sessionStorage.removeItem( 'wpcom_oauth_state' );
+	if ( ! returnedState || ! expectedState || returnedState !== expectedState ) {
+		document.location.replace( DEFAULT_NEXT_LOCATION );
+		return;
 	}
 
 	if ( context.hash?.access_token ) {


### PR DESCRIPTION
Part of DOTMSD-1145, DOTCOM-16408

## Proposed Changes

* Generate a cryptographic `state` parameter (`crypto.randomUUID()`) before redirecting to the WordPress.com OAuth authorize endpoint in Calypso, Jetpack Cloud, and A4A
* Validate the returned `state` on callback before storing the access token in all three clients
* Add redirect validation to Calypso's `auth/controller.js` which was passing the raw `next` query param directly to `document.location.replace()` — now rejects non-relative paths

## Why are these changes being made?

The Dashboard OAuth flow was fixed in #109411 and #109412, but the same vulnerabilities (login CSRF via missing `state` parameter, and unvalidated `next` redirect) exist in the Calypso, Jetpack Cloud, and A4A OAuth flows. This PR applies the same fixes to all remaining clients.

## Testing Instructions

* For each client (Calypso, Jetpack Cloud, A4A) that uses OAuth:
  * Trigger the OAuth login flow
  * Verify the authorize URL includes `&state=<uuid>`
  * Verify callback validates the state and stores the token on match
  * Verify callback rejects and redirects to `/` on state mismatch
* For Calypso specifically, verify that `next=javascript:alert(1)` in the callback URL redirects to `/` instead

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)