### PR TITLE
Minor fix to not break word-break in advertising action buttons

### DIFF
--- a/apps/blaze-dashboard/src/app.scss
+++ b/apps/blaze-dashboard/src/app.scss
@@ -111,6 +111,7 @@
 			font-weight: 600;
 			font-size: 0.75rem;
 			background-color: var(--color-surface);
+			word-break: normal;
 
 			&:hover {
 				text-decoration: underline;

--- a/client/my-sites/promote-post-i2/components/campaign-item/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item/style.scss
@@ -26,6 +26,7 @@
 		color: var(--color-accent);
 		background-color: var(--color-surface);
 		box-shadow: none;
+		word-break: normal;
 	}
 
 	.campaign-item__post-details-button:hover {

--- a/client/my-sites/promote-post-i2/components/payments-list/style.scss
+++ b/client/my-sites/promote-post-i2/components/payments-list/style.scss
@@ -64,6 +64,7 @@
 				margin: 0;
 				text-decoration: underline;
 				padding: 8px;
+				word-break: normal;
 			}
 		}
 		@media (max-width: $break-medium) {


### PR DESCRIPTION
Part of #
No linear ticket. just a quick hot fix


## Proposed Changes
Add word-break normal in promote buttons

## Why are these changes being made?
I noticed that in blaze (using jetpack) there is a breaking word on this button

<img width="302" height="373" alt="Screenshot 2026-03-20 at 10 48 08" src="https://github.com/user-attachments/assets/3e45e925-1229-4373-81fe-79ff9f56bb40" />

also appears here (when the browser width is narrow)

 
<img width="194" height="205" alt="Screenshot 2026-03-20 at 10 49 02" src="https://github.com/user-attachments/assets/d9a3d930-5b23-41c8-a165-6736fd224613" />


this PR will fix the issue


## Testing Instructions

CR is enough i think. But in order to test it out

I cant spot this in normal calypso.. only jetpack seems to have the bug, 

You can just checkout the branch and sync to your sandbox using

`
yarn dev --sync
`

check a jetpack connected site (add hosts to widgets.wp.com)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
