### PR TITLE
DOTCOM-15915: Connection recovery for chat messages

### DIFF
--- a/packages/odie-client/src/components/notices/index.ts
+++ b/packages/odie-client/src/components/notices/index.ts
@@ -1,2 +1,1 @@
-export { default as useConnectionStatusNotice } from './use-connection-status-notice';
 export { default as useMessageSizeErrorNotice } from './use-message-size-error-notice';

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -1,6 +1,10 @@
 import '@automattic/agenttic-ui/index.css';
 import { useInput } from '@automattic/agenttic-ui';
+import { HelpCenterSelect } from '@automattic/data-stores';
 import { EmailFallbackNotice } from '@automattic/help-center/src/components/notices';
+import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
+import { useConnectionStatusNotice } from '@automattic/zendesk-client';
+import { useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useSearchParams } from 'react-router-dom';
@@ -8,7 +12,7 @@ import Smooch from 'smooch';
 import { useOdieAssistantContext } from '../../context';
 import { useSendChatMessage } from '../../hooks';
 import { AgentUIFooter } from '../chat-footer';
-import { useConnectionStatusNotice, useMessageSizeErrorNotice } from '../notices';
+import { useMessageSizeErrorNotice } from '../notices';
 import { useAttachmentHandler } from './use-attachment-handler';
 import { useSendMessageHandler } from './use-send-message-handler';
 
@@ -42,7 +46,13 @@ export const OdieSendMessageButton = () => {
 	const [ initialQuery, setInitialQuery ] = useState( queryForNewChat );
 	const [ inputValue, setInputValue ] = useState( initialQuery );
 	const messageSizeNotice = useMessageSizeErrorNotice( inputValue.trim().length );
-	const connectionNotice = useConnectionStatusNotice( isLiveChat );
+
+	const connectionStatus = useSelect( ( select ) => {
+		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
+		return helpCenterSelect.getZendeskConnectionStatus();
+	}, [] );
+
+	const connectionNotice = useConnectionStatusNotice( connectionStatus, isLiveChat );
 
 	useEffect( () => {
 		// Only process query param for new conversations (no chatId)

--- a/packages/odie-client/src/components/send-message-input/use-attachment-handler.tsx
+++ b/packages/odie-client/src/components/send-message-input/use-attachment-handler.tsx
@@ -29,7 +29,7 @@ function isSupportedImageType( type: string ) {
 
 const getFileType = ( file: File ) => {
 	if ( file.type.startsWith( 'image/' ) ) {
-		return 'image';
+		return 'image-placeholder';
 	}
 	return 'text';
 };

--- a/packages/odie-client/src/components/send-message-input/use-attachment-handler.tsx
+++ b/packages/odie-client/src/components/send-message-input/use-attachment-handler.tsx
@@ -29,20 +29,20 @@ function isSupportedImageType( type: string ) {
 
 const getFileType = ( file: File ) => {
 	if ( file.type.startsWith( 'image/' ) ) {
-		return 'image-placeholder';
+		return 'image';
 	}
 	return 'text';
 };
 
 const getPlaceholderAttachmentMessage = ( file: File ) => {
 	return zendeskMessageConverter( {
+		id: String( new Date().getTime() ),
 		role: 'user',
 		type: getFileType( file ),
 		text: '',
-		id: String( new Date().getTime() ),
 		received: new Date().getTime(),
 		metadata: {
-			temporary_id: crypto.randomUUID(),
+			temporary_id: crypto.randomUUID() as string,
 			local_timestamp: Date.now() / 1000,
 		},
 		source: { type: 'web', id: '', integrationId: '' },

--- a/packages/zendesk-client/src/index.ts
+++ b/packages/zendesk-client/src/index.ts
@@ -25,6 +25,7 @@ export {
 export type * from './types';
 export { zendeskMessageConverter } from './zendesk-message-converter';
 export { useManagedZendeskChat } from './use-managed-zendesk-chat';
+export { useConnectionStatusNotice } from './use-connection-status-notice';
 export { useGetZendeskConversations } from './use-managed-zendesk-chat';
 export { CSATForm } from './components/csat-form';
 export type { CSATFormProps } from './components/csat-form';

--- a/packages/zendesk-client/src/types.ts
+++ b/packages/zendesk-client/src/types.ts
@@ -188,3 +188,7 @@ export type ConversationData = {
 		id: string;
 	};
 };
+
+export type QueuedMessage = {
+	text: string;
+};

--- a/packages/zendesk-client/src/types.ts
+++ b/packages/zendesk-client/src/types.ts
@@ -93,6 +93,7 @@ export type ZendeskMessage = {
 	text: string;
 	altText?: string;
 	avatarUrl?: string;
+	sendStatus?: 'sending';
 	id: string;
 	actions?: MessageAction[];
 	source?: {

--- a/packages/zendesk-client/src/use-connection-status-notice.tsx
+++ b/packages/zendesk-client/src/use-connection-status-notice.tsx
@@ -1,21 +1,16 @@
-import { HelpCenterSelect } from '@automattic/data-stores';
-import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
-import { useSelect } from '@wordpress/data';
 import { Icon, check, info } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, useState } from 'react';
 
 const WARNING_THRESHOLD = 15; // seconds
 
-export default function useConnectionStatusNotice( isLiveChat: boolean = false ) {
+export function useConnectionStatusNotice(
+	connectionStatus: 'connected' | 'disconnected' | 'reconnecting' | undefined,
+	isLiveChat: boolean = false
+) {
 	const [ shouldWarn, setShouldWarn ] = useState( false );
 	const [ secondsSinceDisconnected, setSecondsSinceDisconnected ] = useState( 0 );
 	const { __ } = useI18n();
-
-	const connectionStatus = useSelect(
-		( select ) => ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).getZendeskConnectionStatus(),
-		[]
-	);
 
 	useEffect( () => {
 		if ( connectionStatus === 'disconnected' ) {

--- a/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
+++ b/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
@@ -32,6 +32,7 @@ import {
 	useAuthenticateZendeskMessaging,
 	fetchMessagingAuth,
 } from './use-authenticate-zendesk-messaging';
+import { useConnectionStatusNotice } from './use-connection-status-notice';
 import {
 	convertZendeskMessageToAgentticFormat,
 	getSmoochContainer,
@@ -169,7 +170,7 @@ function sendMessage(
  * - sendMessage: A function to send a message to the conversation.
  */
 export const useManagedZendeskChat = () => {
-	const [ notice, setNotice ] = useState< NoticeConfig | undefined >();
+	const [ attachmentsNotice, setAttachmentNotice ] = useState< NoticeConfig | undefined >();
 	const { state } = useLocation();
 	const conversationId = state?.conversationId;
 	const startedFromChatId = state?.startedFromChatId;
@@ -184,6 +185,8 @@ export const useManagedZendeskChat = () => {
 	const connectionStatusRef = useRef( connectionStatus );
 	connectionStatusRef.current = connectionStatus;
 	const hadDisconnectRef = useRef( false );
+
+	const connectionNotice = useConnectionStatusNotice( connectionStatus, true );
 
 	const { data: authData } = useAuthenticateZendeskMessaging( true, 'zendesk', false );
 	const { data: Smooch, isLoading: isSettingUpSmooch } = useSmooch();
@@ -201,7 +204,9 @@ export const useManagedZendeskChat = () => {
 	const getUnreadListener = useCallback(
 		( message: ZendeskMessage, data: { conversation: { id: string } } ) => {
 			if ( data.conversation.id === conversation?.id ) {
-				playNotificationSound();
+				if ( message.sendStatus !== 'sending' ) {
+					playNotificationSound();
+				}
 				//Smooch?.getConversationById( data.conversation.id ).then( setConversation );
 				//Smooch?.loadConversation( data.conversation.id );
 				setConversation( ( prev ) =>
@@ -499,7 +504,7 @@ export const useManagedZendeskChat = () => {
 	] );
 
 	const handleFilesSelected = useCallback( async ( files: File[] ) => {
-		setNotice( undefined );
+		setAttachmentNotice( undefined );
 
 		setPendingImages( ( prev ) => {
 			const uploadedImages = files.filter( ( f ) => isSupportedImageType( f.type ) );
@@ -507,7 +512,7 @@ export const useManagedZendeskChat = () => {
 			const shouldWarnAboutMaxAttachments = uploadedImages.length + prev.length > MAX_ATTACHMENTS;
 
 			if ( shouldWarnAboutMaxAttachments ) {
-				setNotice( {
+				setAttachmentNotice( {
 					status: 'warning',
 					message: __( 'Only five images can be added at a time.', '__i18n_text_domain__' ),
 				} );
@@ -533,7 +538,7 @@ export const useManagedZendeskChat = () => {
 	}, [] );
 
 	const handleRemoveImage = useCallback( ( image: { id: string } ) => {
-		setNotice( undefined );
+		setAttachmentNotice( undefined );
 		setPendingImages( ( prev ) => {
 			const item = prev.find( ( p ) => p.id === image.id );
 			if ( item?.url ) {
@@ -562,7 +567,7 @@ export const useManagedZendeskChat = () => {
 		( message: string ) => {
 			const toUpload = pendingImages;
 			setPendingImages( [] );
-			setNotice( undefined );
+			setAttachmentNotice( undefined );
 
 			const isDisconnected =
 				connectionStatusRef.current === 'disconnected' ||
@@ -684,7 +689,7 @@ export const useManagedZendeskChat = () => {
 		isProcessing: isSettingUpSmooch,
 		conversation,
 		connectionStatus,
-		notice,
+		notice: connectionNotice || attachmentsNotice,
 		agentticMessages,
 		isLoadingConversation: isSettingUpSmooch || ! conversation,
 		hasInteractionEnded: hasCSAT,

--- a/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
+++ b/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
@@ -25,6 +25,7 @@ import {
 	ZendeskConversation,
 	ZendeskImagePreview,
 	ZendeskUploadingImage,
+	QueuedMessage,
 } from './types';
 import { useAttachFileToConversation } from './use-attach-file';
 import {
@@ -40,7 +41,18 @@ import {
 	playNotificationSound,
 	SUPPORTED_IMAGE_TYPES,
 } from './util';
-import type { AgentticMessage, ZendeskMessage } from './types';
+import type { AgentticMessage, ZendeskMessage, ZendeskContentType } from './types';
+
+function sortMessagesByTimestamp( messages: ZendeskMessage[] ) {
+	return messages.slice( 0 ).sort( ( a, b ) => {
+		// Give precedence to the local timestamp, if it exists.
+		// It's more accurate than the server timestamp because it's independent of connection status.
+		const aTimestamp = a.metadata?.local_timestamp || a.received;
+		const bTimestamp = b.metadata?.local_timestamp || b.received;
+
+		return aTimestamp - bTimestamp;
+	} );
+}
 
 function useSmooch( enabled = true ) {
 	const queryClient = useQueryClient();
@@ -93,6 +105,59 @@ function useSmooch( enabled = true ) {
 
 	return { ...smoochQuery, isLoading: isAuthenticatingZendeskMessaging || smoochQuery.isFetching };
 }
+
+type UserMessageContent = {
+	type: ZendeskContentType;
+	text: string;
+	payload?: string;
+	metadata?: Record< string, unknown >;
+};
+
+function createUserMessage( content: UserMessageContent ): ZendeskMessage {
+	return {
+		...content,
+		id: crypto.randomUUID(),
+		role: 'user',
+		received: Date.now() / 1000,
+		metadata: {
+			...content.metadata,
+			local_timestamp: Date.now() / 1000,
+			temporary_id: crypto.randomUUID(),
+		},
+	} as ZendeskMessage;
+}
+
+/**
+ * Creates an enhanced ZendeskMessage from the given content and sends it via Smooch.
+ * Automatically adds id, role, received timestamp, and temporary_id metadata.
+ * @returns The enhanced message (for optimistic updates) and a `sent` promise that
+ *          resolves when the server acknowledges the message, or rejects after 5 s.
+ */
+function sendMessage(
+	content: UserMessageContent,
+	conversationId: string,
+	Smooch: typeof SmoochLibrary
+) {
+	const messageToSend = createUserMessage( content );
+
+	const sent = new Promise< ZendeskMessage >( ( resolve, reject ) => {
+		Smooch?.sendMessage( messageToSend, conversationId );
+		const timeout = setTimeout( () => {
+			reject( new Error( 'Message not sent' ) );
+		}, 5000 );
+		function onMessageSent( message: ZendeskMessage ) {
+			if ( message.metadata?.temporary_id === messageToSend.metadata?.temporary_id ) {
+				Smooch.off( 'message:sent', onMessageSent );
+				resolve( message );
+				clearTimeout( timeout );
+			}
+		}
+		Smooch?.on( 'message:sent', onMessageSent as any );
+	} );
+
+	return { message: messageToSend, sent };
+}
+
 /**
  * Returns a complete API for managing a Zendesk chat.
  * @returns An object with the following properties:
@@ -115,6 +180,10 @@ export const useManagedZendeskChat = () => {
 	>( undefined );
 	const [ pendingImages, setPendingImages ] = useState< ZendeskImagePreview[] >( [] );
 	const refetchTimeoutRef = useRef< ReturnType< typeof setTimeout > | null >( null );
+	const messageQueueRef = useRef< QueuedMessage[] >( [] );
+	const connectionStatusRef = useRef( connectionStatus );
+	connectionStatusRef.current = connectionStatus;
+	const hadDisconnectRef = useRef( false );
 
 	const { data: authData } = useAuthenticateZendeskMessaging( true, 'zendesk', false );
 	const { data: Smooch, isLoading: isSettingUpSmooch } = useSmooch();
@@ -133,11 +202,14 @@ export const useManagedZendeskChat = () => {
 		( message: ZendeskMessage, data: { conversation: { id: string } } ) => {
 			if ( data.conversation.id === conversation?.id ) {
 				playNotificationSound();
-				Smooch?.getConversationById( data.conversation.id ).then( setConversation );
+				//Smooch?.getConversationById( data.conversation.id ).then( setConversation );
 				//Smooch?.loadConversation( data.conversation.id );
+				setConversation( ( prev ) =>
+					prev ? { ...prev, messages: [ ...prev.messages, message ] } : prev
+				);
 			}
 		},
-		[ Smooch, setConversation, conversation?.id ]
+		[ setConversation, conversation?.id ]
 	);
 
 	const hasCSAT = useMemo( () => {
@@ -146,6 +218,7 @@ export const useManagedZendeskChat = () => {
 	}, [ conversation?.messages ] );
 
 	const disconnectedListener = useCallback( () => {
+		hadDisconnectRef.current = true;
 		setConnectionStatus( 'disconnected' );
 		recordTracksEvent( 'calypso_smooch_messenger_disconnected' );
 	}, [ setConnectionStatus ] );
@@ -215,22 +288,22 @@ export const useManagedZendeskChat = () => {
 					? __( 'Good 👍', '__i18n_text_domain__' )
 					: __( 'Needs improvement 👎', '__i18n_text_domain__' );
 
-			const messageToSend = {
-				type: 'text',
-				text,
-				payload: JSON.stringify( { csat_rating: score.toUpperCase() } ),
-				metadata: {
-					rated: true,
+			sendMessage(
+				{
+					type: 'text',
+					text,
+					payload: JSON.stringify( { csat_rating: score.toUpperCase() } ),
+					metadata: { rated: true },
 				},
-			};
-
-			Smooch.sendMessage( messageToSend, conversation.id );
+				conversation.id,
+				Smooch
+			);
 		},
-		[ Smooch, conversation?.id ]
+		[ conversation?.id, Smooch ]
 	);
 
 	const agentticMessages = useMemo( () => {
-		const rawMessages = conversation?.messages ?? [];
+		const rawMessages = sortMessagesByTimestamp( conversation?.messages ?? [] );
 		const ratingMessage = rawMessages.find( ( msg ) => msg.metadata?.rated === true );
 		const hasRated = ratingMessage !== undefined;
 		let score: 'GOOD' | 'BAD' | null = null;
@@ -310,10 +383,7 @@ export const useManagedZendeskChat = () => {
 			}
 
 			const isAttachment =
-				( message.type === 'file' ||
-					message.type === 'image' ||
-					message.type === 'image-placeholder' ) &&
-				message.mediaUrl;
+				( message.type === 'file' || message.type === 'image' ) && message.mediaUrl;
 
 			if ( isAttachment && message.mediaUrl ) {
 				const mediaUrl = message.mediaUrl;
@@ -473,8 +543,11 @@ export const useManagedZendeskChat = () => {
 		} );
 	}, [] );
 
+	const isDisconnectedStatus =
+		connectionStatus === 'disconnected' || connectionStatus === 'reconnecting';
+
 	const imageUpload =
-		conversation?.id && clientId && authData?.jwt
+		conversation?.id && clientId && authData?.jwt && ! isDisconnectedStatus
 			? {
 					pendingImages,
 					uploadingImages: [] as ZendeskUploadingImage[],
@@ -490,6 +563,20 @@ export const useManagedZendeskChat = () => {
 			const toUpload = pendingImages;
 			setPendingImages( [] );
 			setNotice( undefined );
+
+			const isDisconnected =
+				connectionStatusRef.current === 'disconnected' ||
+				connectionStatusRef.current === 'reconnecting';
+
+			if ( isDisconnected && conversation?.id && message.trim().length > 0 ) {
+				messageQueueRef.current.push( { text: message.trim() } );
+				const messageToSend = createUserMessage( { type: 'text', text: message.trim() } );
+				setConversation( ( prev ) =>
+					prev ? { ...prev, messages: [ ...prev.messages, messageToSend ] } : prev
+				);
+				return;
+			}
+
 			if ( toUpload.length > 0 && conversation?.id && authData?.jwt && clientId && Smooch ) {
 				const conversationId = conversation.id;
 				Promise.all(
@@ -530,14 +617,7 @@ export const useManagedZendeskChat = () => {
 			}
 			const hasText = message.trim().length > 0;
 			if ( conversation?.id && Smooch && hasText ) {
-				const messageToSend = {
-					type: 'text',
-					text: message.trim(),
-				};
-				setConversation( ( prev ) =>
-					prev ? { ...prev, messages: [ ...prev.messages, messageToSend as ZendeskMessage ] } : prev
-				);
-				Smooch.sendMessage( messageToSend, conversation.id );
+				sendMessage( { type: 'text', text: message.trim() }, conversation.id, Smooch );
 			}
 		},
 		[
@@ -550,6 +630,45 @@ export const useManagedZendeskChat = () => {
 			attachFileToConversation,
 		]
 	);
+
+	useEffect( () => {
+		if (
+			connectionStatus !== 'connected' ||
+			! hadDisconnectRef.current ||
+			! Smooch ||
+			! conversation?.id
+		) {
+			return;
+		}
+
+		hadDisconnectRef.current = false;
+		const conversationId = conversation.id;
+		const queue = [ ...messageQueueRef.current ];
+		messageQueueRef.current = [];
+
+		const flushAndResync = async () => {
+			for ( const entry of queue ) {
+				if ( entry.text.length > 0 ) {
+					try {
+						await sendMessage( { type: 'text', text: entry.text }, conversationId, Smooch ).sent;
+					} catch {
+						// Message failed to send — it was already shown optimistically, and the
+						// resync below will reconcile the conversation state with the server.
+					}
+				}
+			}
+
+			if ( queue.length > 0 ) {
+				recordTracksEvent( 'calypso_smooch_messenger_queue_flushed', {
+					queued_messages: queue.length,
+				} );
+			}
+
+			return Smooch.getConversationById( conversationId ).then( setConversation );
+		};
+
+		flushAndResync();
+	}, [ connectionStatus, Smooch, conversation?.id ] );
 
 	useEffect( () => {
 		return () => {


### PR DESCRIPTION
Part of #dotcom-15915

## Proposed Changes
* `useManagedZendeskChat`: add optimistic, temporary-id-based message sending, deduplicate Zendesk messages, and queue user messages while `disconnected/reconnecting` then flush + resync after reconnect.
* `use-attachment-handler` (ODIE): adjust image placeholder conversion so images are treated as `image` and ensure `temporary_id` typing is consistent.

## Why are these changes being made?
* Prevent duplicated/out-of-order chat messages during Zendesk connection recovery and keep image attachment handling consistent across reconnect states.

## Testing Instructions

### Recovery
1. Sandbox `widgets.wp.com` (the sites themselves do not need sandboxing).
2. Run `cd apps/agents-manger && yarn dev --sync`.
3. Visit any Simple, Atomic, or CIAB site.
4. Open the Help Center and simulate Zendesk chat disconnect/reconnect (using DevTools > Network offline).
5. Send messages in order like (1,2,3,4,5).
6. Come back online. They should be sent in the same order you queued them.
7. Login to Zendesk staging and respond to your chat.
8. Go offline on the Agents Manager tab. 
9. Send messages from Zendesk in order.
10. Come back online, and they should be resynced in the right order.

### Notice
1. Go offline for 15 seconds.
2. A notice should appear.
3. Come back online. It should let you know you're back and go away.
