### PR TITLE
Agents Manager: Fix admin bar menu not working in docked mode

### DIFF
--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -102,12 +102,7 @@ export default function AgentDock( {
 			defaultDocked: isPersistedDocked,
 			defaultOpen: isPersistedOpen,
 			desktopMediaQuery,
-			onOpenSidebar: () => {
-				setIsOpen( true );
-				if ( pathname === '/history' ) {
-					navigate( '/' );
-				}
-			},
+			onOpenSidebar: () => setIsOpen( true ),
 			onCloseSidebar: () => setIsOpen( false ),
 		} );
 
@@ -115,7 +110,7 @@ export default function AgentDock( {
 	useAdminBarIntegration( {
 		isOpen: isPersistedOpen,
 		sectionName,
-		setIsOpen,
+		openChat: () => ( isDocked ? openSidebar() : setIsOpen( true ) ),
 		navigate,
 	} );
 

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -111,7 +111,11 @@ export default function AgentDock( {
 	useAdminBarIntegration( {
 		isOpen: isPersistedOpen,
 		sectionName,
-		openChat: () => ( isDocked ? openSidebar() : setIsOpen( true ) ),
+		maybeOpenChat: () => {
+			if ( ! isPersistedOpen ) {
+				isDocked ? openSidebar() : setIsOpen( true );
+			}
+		},
 		navigate,
 	} );
 

--- a/packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx
+++ b/packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx
@@ -20,7 +20,7 @@ const DESTINATION_GUIDES = 'agents-manager-support-guides';
 interface UseAdminBarIntegrationOptions {
 	isOpen: boolean;
 	sectionName: string;
-	openChat: () => void;
+	maybeOpenChat: () => void;
 	navigate: ( route: string, options?: { state?: object } ) => void;
 }
 
@@ -36,12 +36,12 @@ interface UseAdminBarIntegrationOptions {
 export default function useAdminBarIntegration( {
 	isOpen,
 	sectionName,
-	openChat,
+	maybeOpenChat,
 	navigate,
 }: UseAdminBarIntegrationOptions ) {
-	// Ref to avoid re-attaching DOM event listeners when the caller passes a new openChat reference.
-	const openChatRef = useRef( openChat );
-	openChatRef.current = openChat;
+	// Ref to avoid re-attaching DOM event listeners when the caller passes a new maybeOpenChat reference.
+	const maybeOpenChatRef = useRef( maybeOpenChat );
+	maybeOpenChatRef.current = maybeOpenChat;
 
 	// Update admin bar button active state based on isOpen
 	useEffect( () => {
@@ -117,7 +117,7 @@ export default function useAdminBarIntegration( {
 					destination,
 				} );
 				navigate( route );
-				openChatRef.current();
+				maybeOpenChatRef.current();
 			};
 		};
 

--- a/packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx
+++ b/packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx
@@ -39,7 +39,7 @@ export default function useAdminBarIntegration( {
 	maybeOpenChat,
 	navigate,
 }: UseAdminBarIntegrationOptions ) {
-	// Ref to avoid re-attaching DOM event listeners when the caller passes a new maybeOpenChat reference.
+	// Ref to avoid re-attaching DOM event listeners when the caller passes a new `maybeOpenChat` reference.
 	const maybeOpenChatRef = useRef( maybeOpenChat );
 	maybeOpenChatRef.current = maybeOpenChat;
 

--- a/packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx
+++ b/packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx
@@ -1,5 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import './style.scss';
 
 // Admin bar element selectors
@@ -20,7 +20,7 @@ const DESTINATION_GUIDES = 'agents-manager-support-guides';
 interface UseAdminBarIntegrationOptions {
 	isOpen: boolean;
 	sectionName: string;
-	setIsOpen: ( isOpen: boolean ) => void;
+	openChat: () => void;
 	navigate: ( route: string, options?: { state?: object } ) => void;
 }
 
@@ -36,9 +36,13 @@ interface UseAdminBarIntegrationOptions {
 export default function useAdminBarIntegration( {
 	isOpen,
 	sectionName,
-	setIsOpen,
+	openChat,
 	navigate,
 }: UseAdminBarIntegrationOptions ) {
+	// Ref to avoid re-attaching DOM event listeners when the caller passes a new openChat reference.
+	const openChatRef = useRef( openChat );
+	openChatRef.current = openChat;
+
 	// Update admin bar button active state based on isOpen
 	useEffect( () => {
 		const button = document.getElementById( ADMIN_BAR_BUTTON_ID );
@@ -106,14 +110,14 @@ export default function useAdminBarIntegration( {
 		const historyItem = document.getElementById( ADMIN_BAR_HISTORY_ITEM_ID );
 		const guidesItem = document.getElementById( ADMIN_BAR_GUIDES_ITEM_ID );
 
-		const createMenuItemHandler = ( destination: string, route: string, routeState?: object ) => {
+		const createMenuItemHandler = ( destination: string, route: string ) => {
 			return () => {
 				recordTracksEvent( 'calypso_dashboard_help_center_menu_panel_click', {
 					section: sectionName || 'wp-admin',
 					destination,
 				} );
-				navigate( route, { state: routeState } );
-				setIsOpen( true );
+				navigate( route );
+				openChatRef.current();
 			};
 		};
 
@@ -130,5 +134,5 @@ export default function useAdminBarIntegration( {
 			historyItem?.removeEventListener( 'click', handleHistoryClick );
 			guidesItem?.removeEventListener( 'click', handleGuidesClick );
 		};
-	}, [ navigate, setIsOpen, sectionName ] );
+	}, [ navigate, sectionName ] );
 }


### PR DESCRIPTION
## Proposed Changes

Linear task: AI-922

* Refactor `useAdminBarIntegration` to accept a `maybeOpenChat` callback instead of `setIsOpen`, so the hook is agnostic to docked vs undocked mode.
* Guard `maybeOpenChat` so it only opens the chat when it's not already open, avoiding redundant re-renders.
* Use a `useRef` for `maybeOpenChat` to keep the effect's dependency array stable and avoid re-attaching DOM event listeners on every render.
* Remove the `onOpenSidebar` redirect that navigated away from `/history`, which conflicted with admin bar menu item navigation in docked mode.
* Remove unused `routeState` parameter from `createMenuItemHandler`.

## Why are these changes being made?

In docked mode, clicking admin bar menu items (e.g., History, Support Guides) didn't work correctly. The `onOpenSidebar` callback contained a redirect (`pathname === '/history'` → `navigate('/')`) that immediately overrode the navigation triggered by the menu item handler. This caused the chat to always land on `/` instead of the intended route.

Additionally, the hook previously received `setIsOpen` directly, which didn't account for the docked mode requiring `openSidebar()` instead. The new `maybeOpenChat` callback lets the caller handle the correct open behavior for both modes, and skips the open action entirely when the chat is already open.

## Testing Instructions

* Open the agents manager in **docked (sidebar) mode**.
* Click the admin bar menu items: **Chat**, **History**, and **Support Guides**.
* Verify each navigates to the correct route and the sidebar opens/stays open.
* Click the **History** menu item a second time — confirm it stays on `/history` (previously it redirected to `/`).
* Repeat the above in **undocked (popover) mode** and verify the behavior is unchanged.

https://github.com/user-attachments/assets/df9c9f80-54b2-4782-af08-dffe98f97672

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)