### PR TITLE
Attempt at implementing the stripe upi checkout using an iframe.

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -57,6 +57,7 @@ import { payPalJsProcessor } from '../lib/paypal-js-processor';
 import { pixProcessor } from '../lib/pix-processor';
 import razorpayProcessor from '../lib/razorpay-processor';
 import { translateResponseCartToWPCOMCart } from '../lib/translate-cart';
+import upiProcessor from '../lib/upi-processor';
 import weChatProcessor from '../lib/we-chat-processor';
 import webPayProcessor from '../lib/web-pay-processor';
 import { CHECKOUT_STORE } from '../lib/wpcom-store';
@@ -586,7 +587,7 @@ export default function CheckoutMain( {
 			eps: ( transactionData: unknown ) =>
 				genericRedirectProcessor( 'eps', transactionData, dataForProcessor ),
 			'stripe-upi': ( transactionData: unknown ) =>
-				genericRedirectProcessor( 'stripe-upi', transactionData, dataForProcessor ),
+				upiProcessor( transactionData, dataForProcessor, translate ),
 			'existing-card': ( transactionData: unknown ) =>
 				existingCardProcessor( transactionData, dataForProcessor ),
 			'existing-card-ebanx': ( transactionData: unknown ) =>

--- a/client/my-sites/checkout/src/lib/upi-confirmation.tsx
+++ b/client/my-sites/checkout/src/lib/upi-confirmation.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 
 const ConfirmationDialog = styled.dialog`
-	width: 420px;
+	width: 475px;
 	max-width: 95vw;
 	padding: 0;
 	border: none;
@@ -30,7 +30,7 @@ const ConfirmationDialog = styled.dialog`
 const UpiIframe = styled.iframe`
 	display: block;
 	width: 100%;
-	height: 520px;
+	height: 700px;
 	border: none;
 `;
 

--- a/client/my-sites/checkout/src/lib/upi-confirmation.tsx
+++ b/client/my-sites/checkout/src/lib/upi-confirmation.tsx
@@ -1,0 +1,54 @@
+import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
+
+const ConfirmationDialog = styled.dialog`
+	width: 420px;
+	max-width: 95vw;
+	padding: 0;
+	border: none;
+	border-radius: 8px;
+	overflow: hidden;
+	margin: auto;
+
+	.upi-confirmation__cancel {
+		display: block;
+		width: 100%;
+		padding: 8px;
+		background: none;
+		border: none;
+		border-top: 1px solid var( --color-neutral-10 );
+		cursor: pointer;
+		font-size: 14px;
+		color: var( --color-text-subtle );
+
+		&:hover {
+			background: var( --color-neutral-0 );
+		}
+	}
+`;
+
+const UpiIframe = styled.iframe`
+	display: block;
+	width: 100%;
+	height: 520px;
+	border: none;
+`;
+
+export function UpiConfirmation( {
+	redirectUrl,
+	cancel,
+}: {
+	redirectUrl: string;
+	cancel: () => void;
+} ) {
+	const translate = useTranslate();
+
+	return (
+		<ConfirmationDialog className="upi-confirmation">
+			<UpiIframe src={ redirectUrl } title={ translate( 'Authorize UPI payment' ) as string } />
+			<button className="upi-confirmation__cancel" onClick={ () => cancel() }>
+				{ translate( 'Cancel payment' ) }
+			</button>
+		</ConfirmationDialog>
+	);
+}

--- a/client/my-sites/checkout/src/lib/upi-processor.ts
+++ b/client/my-sites/checkout/src/lib/upi-processor.ts
@@ -132,6 +132,8 @@ export default async function upiProcessor(
 				throw new Error( explicitClosureMessage ?? genericFailureMessage );
 			}
 
+			hideModal( root );
+
 			const responseData: Partial< WPCOMTransactionEndpointResponseSuccess > = {
 				success: true,
 				order_id: response.order_id,

--- a/client/my-sites/checkout/src/lib/upi-processor.ts
+++ b/client/my-sites/checkout/src/lib/upi-processor.ts
@@ -92,6 +92,13 @@ export default async function upiProcessor(
 	);
 
 	const root = getRenderRoot( genericErrorMessage );
+	let rootUnmounted = false;
+	const safeDismissModal = () => {
+		if ( ! rootUnmounted ) {
+			rootUnmounted = true;
+			hideModal( root );
+		}
+	};
 
 	return submitWpcomTransaction( formattedTransactionData, options )
 		.then( async ( response?: WPCOMTransactionEndpointResponse ) => {
@@ -113,12 +120,12 @@ export default async function upiProcessor(
 				root,
 				redirectUrl: response.redirect_url,
 				cancel: () => {
-					hideModal( root );
+					safeDismissModal();
 					isModalActive = false;
 					explicitClosureMessage = translate( 'Payment cancelled.' );
 				},
 				error: () => {
-					hideModal( root );
+					safeDismissModal();
 					isModalActive = false;
 					explicitClosureMessage = genericErrorMessage;
 				},
@@ -132,7 +139,7 @@ export default async function upiProcessor(
 				throw new Error( explicitClosureMessage ?? genericFailureMessage );
 			}
 
-			hideModal( root );
+			safeDismissModal();
 
 			const responseData: Partial< WPCOMTransactionEndpointResponseSuccess > = {
 				success: true,
@@ -141,7 +148,7 @@ export default async function upiProcessor(
 			return makeSuccessResponse( responseData );
 		} )
 		.catch( ( error ) => {
-			hideModal( root );
+			safeDismissModal();
 			return makeErrorResponse( error.message );
 		} );
 }

--- a/client/my-sites/checkout/src/lib/upi-processor.ts
+++ b/client/my-sites/checkout/src/lib/upi-processor.ts
@@ -1,0 +1,222 @@
+import { makeErrorResponse, makeSuccessResponse } from '@automattic/composite-checkout';
+import { createElement } from 'react';
+import { Root, createRoot } from 'react-dom/client';
+import { PurchaseOrderStatus, fetchPurchaseOrder } from '../hooks/use-purchase-order';
+import { recordTransactionBeginAnalytics } from '../lib/analytics';
+import getDomainDetails from '../lib/get-domain-details';
+import getPostalCode from '../lib/get-postal-code';
+import prepareRedirectTransaction from '../lib/prepare-redirect-transaction';
+import { addUrlToPendingPageRedirect } from './pending-page';
+import submitWpcomTransaction from './submit-wpcom-transaction';
+import { UpiConfirmation } from './upi-confirmation';
+import type { PaymentProcessorOptions } from '../types/payment-processors';
+import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
+import type {
+	WPCOMTransactionEndpointResponse,
+	WPCOMTransactionEndpointResponseSuccess,
+} from '@automattic/wpcom-checkout';
+import type { LocalizeProps } from 'i18n-calypso';
+
+type StripeUpiTransactionRequest = {
+	name: string;
+	address: string;
+	streetNumber: string;
+	city: string;
+	state: string;
+	postalCode: string;
+	country: string;
+};
+
+export default async function upiProcessor(
+	submitData: unknown,
+	options: PaymentProcessorOptions,
+	translate: LocalizeProps[ 'translate' ]
+): Promise< PaymentProcessorResponse > {
+	if ( ! isValidTransactionData( submitData ) ) {
+		throw new Error( 'Required purchase data is missing' );
+	}
+
+	const {
+		getThankYouUrl,
+		siteSlug,
+		siteId,
+		includeDomainDetails,
+		includeGSuiteDetails,
+		reduxDispatch,
+		responseCart,
+		contactDetails,
+		fromSiteSlug,
+	} = options;
+	const paymentMethodId = 'stripe-upi';
+
+	reduxDispatch( recordTransactionBeginAnalytics( { paymentMethodId } ) );
+
+	const {
+		origin = 'https://wordpress.com',
+		pathname = '/',
+		search = '',
+	} = typeof window !== 'undefined' ? window.location : {};
+	const thankYouUrl = getThankYouUrl() || 'https://wordpress.com';
+	const successUrl = addUrlToPendingPageRedirect( thankYouUrl, {
+		siteSlug,
+		fromSiteSlug,
+		urlType: 'absolute',
+	} );
+	const cancelUrl = `${ origin }${ pathname }${ search }`;
+
+	const formattedTransactionData = prepareRedirectTransaction(
+		paymentMethodId,
+		{
+			...submitData,
+			name: submitData.name ?? '',
+			successUrl,
+			cancelUrl,
+			couponId: responseCart.coupon,
+			country: contactDetails?.countryCode?.value ?? '',
+			postalCode: getPostalCode( contactDetails ),
+			subdivisionCode: contactDetails?.state?.value,
+			siteId: siteId ? String( siteId ) : '',
+			domainDetails: getDomainDetails( contactDetails, {
+				includeDomainDetails,
+				includeGSuiteDetails,
+			} ),
+		},
+		options
+	);
+
+	const genericErrorMessage = translate(
+		"Sorry, we couldn't process your payment. Please try again later."
+	);
+	const genericFailureMessage = translate(
+		'Payment failed. Please check your account and try again.'
+	);
+
+	return submitWpcomTransaction( formattedTransactionData, options )
+		.then( async ( response?: WPCOMTransactionEndpointResponse ) => {
+			if ( ! response?.redirect_url ) {
+				// eslint-disable-next-line no-console
+				console.error( 'Transaction response was missing required redirect url' );
+				throw new Error( genericErrorMessage );
+			}
+
+			if ( ! response.order_id ) {
+				// eslint-disable-next-line no-console
+				console.error( 'Transaction response was missing required order ID' );
+				throw new Error( genericErrorMessage );
+			}
+
+			const root = getRenderRoot( genericErrorMessage );
+
+			let isModalActive = true;
+			let explicitClosureMessage: string | undefined;
+			displayModal( {
+				root,
+				redirectUrl: response.redirect_url,
+				cancel: () => {
+					hideModal( root );
+					isModalActive = false;
+					explicitClosureMessage = translate( 'Payment cancelled.' );
+				},
+				error: () => {
+					hideModal( root );
+					isModalActive = false;
+					explicitClosureMessage = genericErrorMessage;
+				},
+			} );
+
+			let orderStatus = 'processing';
+			while ( isModalActive && [ 'processing', 'async-pending' ].includes( orderStatus ) ) {
+				orderStatus = await pollForOrderStatus( response.order_id, 2000, genericErrorMessage );
+			}
+			if ( orderStatus !== 'success' ) {
+				throw new Error( explicitClosureMessage ?? genericFailureMessage );
+			}
+
+			const responseData: Partial< WPCOMTransactionEndpointResponseSuccess > = {
+				success: true,
+				order_id: response.order_id,
+			};
+			return makeSuccessResponse( responseData );
+		} )
+		.catch( ( error ) => {
+			return makeErrorResponse( error.message );
+		} );
+}
+
+async function pollForOrderStatus(
+	orderId: number,
+	pollInterval: number,
+	genericErrorMessage: string
+): Promise< PurchaseOrderStatus > {
+	const orderData = await fetchPurchaseOrder( orderId );
+	if ( ! orderData ) {
+		// eslint-disable-next-line no-console
+		console.error( 'Order was not found.' );
+		throw new Error( genericErrorMessage );
+	}
+	if ( orderData.processing_status === 'success' ) {
+		return orderData.processing_status;
+	}
+	await new Promise( ( resolve ) => setTimeout( resolve, pollInterval ) );
+	return orderData.processing_status;
+}
+
+function getRenderRoot( genericErrorMessage: string ) {
+	const dialogTarget = document.querySelector( '.upi-modal-target' );
+	if ( ! dialogTarget ) {
+		// eslint-disable-next-line no-console
+		console.error( 'Dialog target was not found.' );
+		throw new Error( genericErrorMessage );
+	}
+	return createRoot( dialogTarget );
+}
+
+function hideModal( root: Root ): void {
+	root.unmount();
+}
+
+function displayModal( {
+	root,
+	redirectUrl,
+	cancel,
+	error,
+}: {
+	root: Root;
+	redirectUrl: string;
+	cancel: () => void;
+	error: () => void;
+} ) {
+	root.render(
+		createElement( UpiConfirmation, {
+			redirectUrl,
+			cancel,
+		} )
+	);
+
+	// We have to activate the `<dialog>` element after a moment because we
+	// need to give React a chance to render it.
+	setTimeout( () => {
+		const dialogElement = document.querySelector( 'dialog.upi-confirmation' );
+		if ( ! dialogElement || ! ( 'showModal' in dialogElement ) ) {
+			// eslint-disable-next-line no-console
+			console.error( 'Dialog was not found or browser does not support dialogs.' );
+			error();
+			return;
+		}
+
+		// dialog elements are a new addition to HTML but should be
+		// supported by all the browsers that calypso supports.
+		// Nevertheless, TypeScript does not know about it.
+		( dialogElement.showModal as () => void )();
+		dialogElement.addEventListener( 'close', () => cancel() );
+	} );
+	return root;
+}
+
+function isValidTransactionData( submitData: unknown ): submitData is StripeUpiTransactionRequest {
+	const data = submitData as StripeUpiTransactionRequest;
+	if ( ! data ) {
+		throw new Error( 'Transaction requires data and none was provided' );
+	}
+	return true;
+}

--- a/client/my-sites/checkout/src/lib/upi-processor.ts
+++ b/client/my-sites/checkout/src/lib/upi-processor.ts
@@ -91,6 +91,8 @@ export default async function upiProcessor(
 		'Payment failed. Please check your account and try again.'
 	);
 
+	const root = getRenderRoot( genericErrorMessage );
+
 	return submitWpcomTransaction( formattedTransactionData, options )
 		.then( async ( response?: WPCOMTransactionEndpointResponse ) => {
 			if ( ! response?.redirect_url ) {
@@ -104,8 +106,6 @@ export default async function upiProcessor(
 				console.error( 'Transaction response was missing required order ID' );
 				throw new Error( genericErrorMessage );
 			}
-
-			const root = getRenderRoot( genericErrorMessage );
 
 			let isModalActive = true;
 			let explicitClosureMessage: string | undefined;
@@ -139,6 +139,7 @@ export default async function upiProcessor(
 			return makeSuccessResponse( responseData );
 		} )
 		.catch( ( error ) => {
+			hideModal( root );
 			return makeErrorResponse( error.message );
 		} );
 }

--- a/client/my-sites/checkout/src/test/upi-processor.ts
+++ b/client/my-sites/checkout/src/test/upi-processor.ts
@@ -337,4 +337,38 @@ describe( 'upiProcessor', () => {
 			},
 		} );
 	} );
+
+	it( 'returns a success response when the order succeeds', async () => {
+		render( createElement( 'div', { className: 'upi-modal-target' } ) );
+
+		const orderId = 54321;
+		const mockOrderStatus = {
+			order_id: orderId,
+			user_id: 1234,
+			receipt_id: undefined,
+			processing_status: 'success',
+		};
+		mockOrderEndpoint( orderId, () => [ 200, mockOrderStatus ] );
+		mockTransactionsEndpoint( () => mockTransactionsRedirectResponse( orderId ) );
+		const expected = {
+			payload: { success: true, order_id: orderId },
+			type: 'SUCCESS',
+		};
+
+		await act( async () => {
+			await expect(
+				upiProcessor(
+					submitData,
+					{
+						...options,
+						contactDetails: {
+							countryCode,
+							postalCode,
+						},
+					},
+					translate
+				)
+			).resolves.toStrictEqual( expected );
+		} );
+	} );
 } );

--- a/client/my-sites/checkout/src/test/upi-processor.ts
+++ b/client/my-sites/checkout/src/test/upi-processor.ts
@@ -1,0 +1,340 @@
+/**
+ * @jest-environment jsdom
+ */
+// @ts-nocheck - TODO: Fix TypeScript issues
+
+import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
+import { act, render } from '@testing-library/react';
+import { translate } from 'i18n-calypso';
+import { createElement } from 'react';
+import upiProcessor from '../lib/upi-processor';
+import {
+	mockTransactionsEndpoint,
+	mockTransactionsRedirectResponse,
+	processorOptions,
+	basicExpectedDomainDetails,
+	countryCode,
+	postalCode,
+	contactDetailsForDomain,
+	mockOrderEndpoint,
+} from './util';
+
+describe( 'upiProcessor', () => {
+	const product = getEmptyResponseCartProduct();
+	const domainProduct = {
+		...getEmptyResponseCartProduct(),
+		meta: 'example.com',
+		is_domain_registration: true,
+	};
+	const cart = { ...getEmptyResponseCart(), products: [ product ] };
+	const options = {
+		...processorOptions,
+		responseCart: cart,
+	};
+
+	const submitData = {
+		name: 'test name',
+		address: '100 Test St',
+		streetNumber: '',
+		city: 'Test City',
+		state: 'CA',
+		postalCode: '99999',
+		country: 'XX',
+	};
+
+	const basicExpectedStripeRequest = {
+		cart: {
+			blog_id: 0,
+			cart_key: 'no-site',
+			coupon: '',
+			products: [ product ],
+			tax: {
+				location: {},
+			},
+			temporary: false,
+		},
+		payment: {
+			address: '100 Test St',
+			cancel_url: 'https://example.com/',
+			city: 'Test City',
+			country: 'US',
+			country_code: 'US',
+			name: 'test name',
+			payment_method: 'WPCOM_Billing_Stripe_Upi',
+			payment_partner: 'IE',
+			postal_code: '10001',
+			state: 'CA',
+			street_number: '',
+			success_url:
+				'https://example.com/checkout/thank-you/no-site/pending/:orderId?redirect_to=%2Fthank-you&receiptId=%3AreceiptId',
+			zip: '10001',
+		},
+		tos: {
+			locale: 'en',
+			path: '/',
+			viewport: '0x0',
+		},
+		ad_conversion: {
+			ad_details: '',
+			sensitive_pixel_options: '',
+		},
+	};
+
+	it( 'sends the correct data to the endpoint with no site and one product', async () => {
+		// The processor renders the dialog into a div so that div must be
+		// present to avoid errors.
+		render( createElement( 'div', { className: 'upi-modal-target' } ) );
+
+		const orderId = 54321;
+		const mockOrderStatus = {
+			order_id: orderId,
+			user_id: 1234,
+			receipt_id: undefined,
+			processing_status: 'payment-failure',
+		};
+		mockOrderEndpoint( orderId, () => [ 200, mockOrderStatus ] );
+		const transactionsEndpoint = mockTransactionsEndpoint( () =>
+			mockTransactionsRedirectResponse( orderId )
+		);
+		const expected = {
+			payload: "Sorry, we couldn't process your payment. Please try again later.",
+			type: 'ERROR',
+		};
+
+		// We have to use `act()` because this changes the DOM async and
+		// otherwise we get a bunch of warnings.
+		await act( async () => {
+			await expect(
+				upiProcessor(
+					submitData,
+					{
+						...options,
+						contactDetails: {
+							countryCode,
+							postalCode,
+						},
+					},
+					translate
+				)
+			).resolves.toStrictEqual( expected );
+		} );
+
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( basicExpectedStripeRequest );
+	} );
+
+	it( 'returns an explicit error response if the transaction fails', async () => {
+		// The processor renders the dialog into a div so that div must be
+		// present to avoid errors.
+		render( createElement( 'div', { className: 'upi-modal-target' } ) );
+
+		mockTransactionsEndpoint( () => [
+			400,
+			{
+				error: 'test_error',
+				message: 'test error',
+			},
+		] );
+		const expected = { payload: 'test error', type: 'ERROR' };
+
+		// We have to use `act()` because this changes the DOM async and
+		// otherwise we get a bunch of warnings.
+		await act( async () => {
+			await expect(
+				upiProcessor(
+					submitData,
+					{
+						...options,
+						contactDetails: {
+							countryCode,
+							postalCode,
+						},
+					},
+					translate
+				)
+			).resolves.toStrictEqual( expected );
+		} );
+	} );
+
+	it( 'sends the correct data to the endpoint with a site and one product', async () => {
+		// The processor renders the dialog into a div so that div must be
+		// present to avoid errors.
+		render( createElement( 'div', { className: 'upi-modal-target' } ) );
+
+		const orderId = 54321;
+		const mockOrderStatus = {
+			order_id: orderId,
+			user_id: 1234,
+			receipt_id: undefined,
+			processing_status: 'payment-failure',
+		};
+		mockOrderEndpoint( orderId, () => [ 200, mockOrderStatus ] );
+		const transactionsEndpoint = mockTransactionsEndpoint( () =>
+			mockTransactionsRedirectResponse( orderId )
+		);
+		const expected = {
+			payload: "Sorry, we couldn't process your payment. Please try again later.",
+			type: 'ERROR',
+		};
+
+		// We have to use `act()` because this changes the DOM async and
+		// otherwise we get a bunch of warnings.
+		await act( async () => {
+			await expect(
+				upiProcessor(
+					submitData,
+					{
+						...options,
+						siteSlug: 'example.wordpress.com',
+						siteId: 1234567,
+						contactDetails: {
+							countryCode,
+							postalCode,
+						},
+					},
+					translate
+				)
+			).resolves.toStrictEqual( expected );
+		} );
+
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+			...basicExpectedStripeRequest,
+			cart: {
+				...basicExpectedStripeRequest.cart,
+				blog_id: 1234567,
+				cart_key: 1234567,
+				coupon: '',
+			},
+			payment: {
+				...basicExpectedStripeRequest.payment,
+				success_url:
+					'https://example.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirect_to=%2Fthank-you&receiptId=%3AreceiptId',
+			},
+		} );
+	} );
+
+	it( 'sends the correct data to the endpoint with tax information', async () => {
+		// The processor renders the dialog into a div so that div must be
+		// present to avoid errors.
+		render( createElement( 'div', { className: 'upi-modal-target' } ) );
+
+		const orderId = 54321;
+		const mockOrderStatus = {
+			order_id: orderId,
+			user_id: 1234,
+			receipt_id: undefined,
+			processing_status: 'payment-failure',
+		};
+		mockOrderEndpoint( orderId, () => [ 200, mockOrderStatus ] );
+		const transactionsEndpoint = mockTransactionsEndpoint( () =>
+			mockTransactionsRedirectResponse( orderId )
+		);
+		const expected = {
+			payload: "Sorry, we couldn't process your payment. Please try again later.",
+			type: 'ERROR',
+		};
+
+		// We have to use `act()` because this changes the DOM async and
+		// otherwise we get a bunch of warnings.
+		await act( async () => {
+			await expect(
+				upiProcessor(
+					submitData,
+					{
+						...options,
+						siteSlug: 'example.wordpress.com',
+						siteId: 1234567,
+						contactDetails: {
+							countryCode,
+							postalCode,
+						},
+						responseCart: {
+							...options.responseCart,
+							tax: {
+								display_taxes: true,
+								location: {
+									postal_code: 'pr267ry',
+									country_code: 'GB',
+								},
+							},
+						},
+					},
+					translate
+				)
+			).resolves.toStrictEqual( expected );
+		} );
+
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+			...basicExpectedStripeRequest,
+			cart: {
+				...basicExpectedStripeRequest.cart,
+				blog_id: 1234567,
+				cart_key: 1234567,
+				coupon: '',
+				tax: { location: { postal_code: 'pr267ry', country_code: 'GB' } },
+			},
+			payment: {
+				...basicExpectedStripeRequest.payment,
+				success_url:
+					'https://example.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirect_to=%2Fthank-you&receiptId=%3AreceiptId',
+			},
+		} );
+	} );
+
+	it( 'sends the correct data to the endpoint with a site and one domain product', async () => {
+		// The processor renders the dialog into a div so that div must be
+		// present to avoid errors.
+		render( createElement( 'div', { className: 'upi-modal-target' } ) );
+
+		const orderId = 54321;
+		const mockOrderStatus = {
+			order_id: orderId,
+			user_id: 1234,
+			receipt_id: undefined,
+			processing_status: 'payment-failure',
+		};
+		mockOrderEndpoint( orderId, () => [ 200, mockOrderStatus ] );
+		const transactionsEndpoint = mockTransactionsEndpoint( () =>
+			mockTransactionsRedirectResponse( orderId )
+		);
+		const expected = {
+			payload: "Sorry, we couldn't process your payment. Please try again later.",
+			type: 'ERROR',
+		};
+
+		// We have to use `act()` because this changes the DOM async and
+		// otherwise we get a bunch of warnings.
+		await act( async () => {
+			await expect(
+				upiProcessor(
+					submitData,
+					{
+						...options,
+						siteSlug: 'example.wordpress.com',
+						siteId: 1234567,
+						contactDetails: contactDetailsForDomain,
+						responseCart: { ...cart, products: [ domainProduct ] },
+						includeDomainDetails: true,
+					},
+					translate
+				)
+			).resolves.toStrictEqual( expected );
+		} );
+
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+			...basicExpectedStripeRequest,
+			cart: {
+				...basicExpectedStripeRequest.cart,
+				blog_id: 1234567,
+				cart_key: 1234567,
+				coupon: '',
+				products: [ domainProduct ],
+			},
+			domain_details: basicExpectedDomainDetails,
+			payment: {
+				...basicExpectedStripeRequest.payment,
+				success_url:
+					'https://example.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirect_to=%2Fthank-you&receiptId=%3AreceiptId',
+			},
+		} );
+	} );
+} );

--- a/packages/wpcom-checkout/src/payment-methods/stripe-upi.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/stripe-upi.tsx
@@ -366,6 +366,7 @@ export function StripeUpiSubmitButton( {
 			fullWidth
 		>
 			{ submitButtonContent }
+			<div className="upi-modal-target" />
 		</Button>
 	);
 }

--- a/packages/wpcom-checkout/src/payment-methods/stripe-upi.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/stripe-upi.tsx
@@ -344,30 +344,32 @@ export function StripeUpiSubmitButton( {
 	}
 
 	return (
-		<Button
-			disabled={ disabled }
-			onClick={ ( ev ) => {
-				ev.preventDefault();
-				if ( state.isValid() ) {
-					debug( 'Initiate Stripe UPI payment' );
-					onClick( {
-						name: state.data.customerName,
-						address: state.data.address,
-						streetNumber: state.data.streetNumber,
-						city: state.data.city,
-						state: state.data.state,
-						postalCode: state.data.postalCode,
-						country: state.data.country,
-					} );
-				}
-			} }
-			buttonType="primary"
-			isBusy={ FormStatus.SUBMITTING === formStatus }
-			fullWidth
-		>
-			{ submitButtonContent }
+		<>
+			<Button
+				disabled={ disabled }
+				onClick={ ( ev ) => {
+					ev.preventDefault();
+					if ( state.isValid() ) {
+						debug( 'Initiate Stripe UPI payment' );
+						onClick( {
+							name: state.data.customerName,
+							address: state.data.address,
+							streetNumber: state.data.streetNumber,
+							city: state.data.city,
+							state: state.data.state,
+							postalCode: state.data.postalCode,
+							country: state.data.country,
+						} );
+					}
+				} }
+				buttonType="primary"
+				isBusy={ FormStatus.SUBMITTING === formStatus }
+				fullWidth
+			>
+				{ submitButtonContent }
+			</Button>
 			<div className="upi-modal-target" />
-		</Button>
+		</>
 	);
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->
Fixes SHILL-1782

## Proposed Changes

 - Adds a custom upiProcessor for the stripe-upi payment method, replacing the generic redirect processor
 - Displays Stripe's hosted UPI instructions page (hosted_instructions_url, mapped to redirect_url) in an iframe modal on the checkout page, keeping the user in-context rather
  than redirecting them away
 - Polls the backend for order status while the modal is open, and resolves the checkout flow (success or error) based on the result

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

 - UPI payments via Stripe use a `hosted_instructions_url` next action, which Stripe recommends rendering in-context on the checkout page rather than as a full-page redirect. The previous implementation used genericRedirectProcessor, which redirected the user away from checkout and did not support the in-context experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Change your currency to INR and go to checkout
* Use India as your country (you can ask claude for an Indian address, or use https://www.browserstack.com/free-tools/random-address-generator). 
* Select UPI from the payment options.
* Complete the form, and checkout. The stripe checkout options should appear in a modal. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
