### PR TITLE
Redirect existing users to /sites after logging in from onboarding

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { Step, StepContainer } from '@automattic/onboarding';
+import { ONBOARDING_FLOW, Step, StepContainer } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { createInterpolateElement, useEffect, useState } from '@wordpress/element';
@@ -78,9 +78,13 @@ const UserStepComponent: StepType = function UserStep( {
 
 	const locale = useFlowLocale();
 
+	// When existing users click "Get started" on the logged-out homepage and then choose
+	// "Log in", redirect them to /sites instead of continuing through onboarding.
+	const loginRedirectTo = flow === ONBOARDING_FLOW ? '/sites' : redirectTo;
+
 	const loginLink = login( {
 		signupUrl,
-		redirectTo,
+		redirectTo: loginRedirectTo,
 		locale,
 		from: ciabConfig?.id ?? queryArgs.get( 'from' ) ?? undefined,
 	} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/index.tsx
@@ -8,23 +8,56 @@ import routeReducer from 'calypso/state/route/reducer';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import UserStep from '..';
 
-describe( 'User email signup step', () => {
-	const renderUserStep = ( url = '/onboarding/user?user_email=test@example.com' ) => {
-		return renderWithProvider(
-			<MemoryRouter initialEntries={ [ url ] }>
-				<UserStep flow="onboarding" stepName="user" navigation={ { submit: jest.fn() } } />
-			</MemoryRouter>,
-			{ reducers: { login: loginReducer, route: routeReducer } }
-		);
-	};
+const renderUserStep = ( {
+	flow = 'onboarding',
+	url = '/onboarding/user',
+	redirectTo,
+}: { flow?: string; url?: string; redirectTo?: string } = {} ) => {
+	return renderWithProvider(
+		<MemoryRouter initialEntries={ [ url ] }>
+			<UserStep
+				flow={ flow }
+				stepName="user"
+				navigation={ { submit: jest.fn() } }
+				{ ...( redirectTo !== undefined && { redirectTo } ) }
+			/>
+		</MemoryRouter>,
+		{ reducers: { login: loginReducer, route: routeReducer } }
+	);
+};
 
+describe( 'User email signup step', () => {
 	it( 'passes userEmail from user_email query param to SignupFormSocialFirst', () => {
-		renderUserStep( '/onboarding/user?user_email=hello@wp.com' );
+		renderUserStep( { url: '/onboarding/user?user_email=hello@wp.com' } );
 		expect( screen.getByLabelText( 'Enter your email' ) ).toHaveValue( 'hello@wp.com' );
 	} );
 
 	it( 'defaults userEmail to empty string when user_email is missing', () => {
-		renderUserStep( '/onboarding/user' );
+		renderUserStep();
 		expect( screen.getByLabelText( 'Enter your email' ) ).toHaveValue( '' );
+	} );
+} );
+
+describe( 'Login redirect', () => {
+	it( 'redirects to /sites when flow is onboarding', () => {
+		renderUserStep( { redirectTo: '/setup/onboarding/domains' } );
+		const loginLink = screen.getByRole( 'link', { name: 'Log in' } );
+		expect( loginLink ).toHaveAttribute(
+			'href',
+			expect.stringContaining( 'redirect_to=%2Fsites' )
+		);
+	} );
+
+	it( 'uses the provided redirectTo when flow is not onboarding', () => {
+		renderUserStep( {
+			flow: 'site-setup',
+			url: '/site-setup/user',
+			redirectTo: '/setup/site-setup/goals',
+		} );
+		const loginLink = screen.getByRole( 'link', { name: 'Log in' } );
+		expect( loginLink ).toHaveAttribute(
+			'href',
+			expect.stringContaining( 'redirect_to=%2Fsetup%2Fsite-setup%2Fgoals' )
+		);
 	} );
 } );


### PR DESCRIPTION
Related to: pet6gk-2MS-p2


## Proposed Changes

* When existing users click "Get started" on the logged-out homepage and then choose "Log in", redirect them to `/sites` instead of continuing through the onboarding flow.

## Why are these changes being made?

Today, the logged-out homepage has two entry points:

- **Log in** → `/sites`
- **Get started** → Log in → `/setup/onboarding` (domain search)

"Get started" is a broad term — not explicitly "Sign up." An existing user may reasonably click it, then choose to log in. When they do, they are treated as a new user and dropped into onboarding/domain search.

This is an intent mismatch: by choosing "Log in", the user has identified themselves as an existing account holder, but the product continues the new-user path.

This change overrides the login redirect in the user step specifically for the onboarding flow, so:

- **Existing users** who click "Get started" → "Log in" → land on `/sites`
- **New users** who click "Get started" → sign up → continue through onboarding (unchanged)
- **All other flows** are unaffected

## Testing Instructions

1. Simulate a "Get started" click locally, by accessing this link: http://calypso.localhost:3000/setup/onboarding/pt-br?ref=logged-out-homepage-lp
3. On the account screen, click "Log in" in the top right
4. Verify the login URL contains `redirect_to=%2Fsites` (not `/setup/onboarding/...`)
5. Log in with an existing account
6. Verify you land on `/sites` instead of the onboarding domain search

Also verify the signup path is unaffected:
1. Access [Get Started locally](http://calypso.localhost:3000/setup/onboarding/pt-br?ref=logged-out-homepage-lp) while logged out
3. Create a new account
4. Verify you continue through the onboarding flow as before:


<img width="1438" height="713" alt="Screenshot 2026-03-20 at 10 38 12" src="https://github.com/user-attachments/assets/1745a8cc-7624-4dde-8844-6061229b2a4d" />

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)