### PR TITLE
Mailing List: Add AI Tips to Notifications Extras Dashboard

### DIFF
--- a/client/dashboard/me/notifications-extras/extras-config.ts
+++ b/client/dashboard/me/notifications-extras/extras-config.ts
@@ -10,6 +10,7 @@ export const WPCOM_OPTION_KEYS = [
 	'digest',
 	'reports',
 	'news_developer',
+	'ai_tips',
 	'scheduled_updates',
 ] as const;
 
@@ -27,6 +28,7 @@ export const WPCOM_TITLES: Record< WpcomOptionKey, string > = {
 	digest: __( 'Digests' ),
 	reports: __( 'Reports' ),
 	news_developer: __( 'Developer Newsletter' ),
+	ai_tips: __( 'AI Tips' ),
 	scheduled_updates: __( 'Scheduled updates' ),
 };
 
@@ -39,6 +41,7 @@ export const WPCOM_DESCRIPTIONS: Record< WpcomOptionKey, string > = {
 	digest: __( 'Popular content from the blogs you follow.' ),
 	reports: __( 'Complimentary reports and updates regarding site performance and traffic.' ),
 	news_developer: __( 'A once-monthly roundup of notable news for WordPress developers.' ),
+	ai_tips: __( 'AI insights, breakthroughs, tips, and new feature highlights.' ),
 	scheduled_updates: __( 'Complimentary reports regarding scheduled plugin updates.' ),
 };
 

--- a/client/dashboard/me/notifications-extras/extras-toggle-card/test/index.test.tsx
+++ b/client/dashboard/me/notifications-extras/extras-toggle-card/test/index.test.tsx
@@ -23,6 +23,7 @@ const defaultExtraSettings: Partial< WpcomNotificationSettings > = {
 	digest: false,
 	reports: false,
 	news_developer: false,
+	ai_tips: false,
 	scheduled_updates: false,
 };
 
@@ -72,6 +73,7 @@ describe( 'ExtrasToggleCard', () => {
 		expect( screen.getByLabelText( 'Digests' ) ).toBeVisible();
 		expect( screen.getByLabelText( 'Reports' ) ).toBeVisible();
 		expect( screen.getByLabelText( 'Developer Newsletter' ) ).toBeVisible();
+		expect( screen.getByLabelText( 'AI Tips' ) ).toBeVisible();
 		expect( screen.getByLabelText( 'Scheduled updates' ) ).toBeVisible();
 	} );
 
@@ -140,6 +142,7 @@ describe( 'ExtrasToggleCard', () => {
 				digest: true,
 				reports: true,
 				news_developer: true,
+				ai_tips: true,
 				scheduled_updates: true,
 			},
 			'subscribe-all'

--- a/client/dashboard/me/notifications-extras/test/index.test.tsx
+++ b/client/dashboard/me/notifications-extras/test/index.test.tsx
@@ -33,6 +33,7 @@ const defaultWpcomSettings: WpcomNotificationSettings = {
 	akismet_marketing: false,
 	woopay_marketing: false,
 	gravatar_onboarding: false,
+	ai_tips: false,
 };
 
 const defaultUserSettings: UserNotificationSettings = {
@@ -132,6 +133,7 @@ describe( 'NotificationsExtras', () => {
 		expect( wpcomSectionQueries.getByLabelText( 'Digests' ) ).toBeVisible();
 		expect( wpcomSectionQueries.getByLabelText( 'Reports' ) ).toBeVisible();
 		expect( wpcomSectionQueries.getByLabelText( 'Developer Newsletter' ) ).toBeVisible();
+		expect( wpcomSectionQueries.getByLabelText( 'AI Tips' ) ).toBeVisible();
 		expect( wpcomSectionQueries.getByLabelText( 'Scheduled updates' ) ).toBeVisible();
 	} );
 
@@ -204,6 +206,7 @@ describe( 'NotificationsExtras', () => {
 		expect( screen.getByLabelText( 'Digests' ) ).not.toBeChecked();
 		expect( screen.getAllByLabelText( 'Reports' )[ 0 ] ).not.toBeChecked();
 		expect( screen.getByLabelText( 'Developer Newsletter' ) ).not.toBeChecked();
+		expect( screen.getByLabelText( 'AI Tips' ) ).not.toBeChecked();
 		expect( screen.getByLabelText( 'Scheduled updates' ) ).not.toBeChecked();
 
 		// Jetpack toggles - verify enabled ones are checked
@@ -256,6 +259,7 @@ describe( 'NotificationsExtras', () => {
 			digest: true,
 			reports: true,
 			news_developer: true,
+			ai_tips: true,
 			scheduled_updates: true,
 		} );
 

--- a/packages/api-core/src/me-notification-settings/types.ts
+++ b/packages/api-core/src/me-notification-settings/types.ts
@@ -22,6 +22,7 @@ export interface WpcomNotificationSettings {
 	akismet_marketing: boolean;
 	woopay_marketing: boolean;
 	gravatar_onboarding: boolean;
+	ai_tips: boolean;
 }
 
 export interface NotificationSettings {


### PR DESCRIPTION
Add `AI Tips` as a new email category option in the WPCOM Notification Extras Dashboard.

## Testing instructions
Visit [Notification settings](http://my.localhost:3000/me/notifications/extras). Confirm that the subscribe and resubscribe actions work, and that the title and description of the message are correctly displayed.

<img width="500" height="1708" alt="CleanShot 2026-03-20 at 09 32 49@2x" src="https://github.com/user-attachments/assets/5b6c25ef-21f4-4344-ac44-e37012695ca5" />

<img width="500" height="1722" alt="CleanShot 2026-03-20 at 09 33 17@2x" src="https://github.com/user-attachments/assets/b2b4a6a9-603c-42c2-b016-e273a67e29a3" />

