### PR TITLE
Fix width of developer cards at certain breakpoints

### DIFF
--- a/client/me/developer/features/style.scss
+++ b/client/me/developer/features/style.scss
@@ -28,6 +28,7 @@
 		display: flex;
 		flex-direction: column;
 		margin-bottom: 0;
+		width: 100%;
 
 		a {
 			font-size: rem(13px);
@@ -77,6 +78,7 @@
 
 		.developer-features-list__item {
 			margin: 0 32px 24px 32px;
+			width: auto;
 
 			.developer-features-list__item-learn-more {
 				padding-top: 30px;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

Fix the width of the Dolly card by setting width to 100% when breakpoint is > large
For smaller viewports set width to auto

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When a developer card doesn't have enough content, the width of the card is shorter than the rest

before
<img width="1184" height="726" alt="image" src="https://github.com/user-attachments/assets/1452f43d-b799-4c87-a80c-310bf3f59e40" />

after
<img width="1221" height="583" alt="Screenshot 2026-03-20 at 9 43 28 AM" src="https://github.com/user-attachments/assets/c7001819-1f8c-44d4-bad7-0fa80d0c0c1e" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

http://calypso.localhost:3000/me/developer

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
