### PR TITLE
CIAB: Use Woo suffix in partner-branded auth titles

### DIFF
--- a/client/lib/partner-branding.tsx
+++ b/client/lib/partner-branding.tsx
@@ -48,6 +48,8 @@ export interface CiabPartnerConfig {
 	domains?: string[];
 	/** Callback to check if an OAuth2 client belongs to this partner */
 	isOAuth2Client?: ( oauth2Client: { id: number } | null ) => boolean;
+	/** Window title suffix used on branded auth flows */
+	windowTitleSuffix?: string;
 }
 
 /**
@@ -78,10 +80,24 @@ export const CIAB_PARTNERS: Record< string, CiabPartnerConfig > = {
 		},
 		ssoProviders: [ 'paypal', 'google', 'apple', 'magic-login' ],
 		fontStyle: 'system',
+		windowTitleSuffix: 'Woo',
 		domains: [ 'my.woo.ai', 'my.woo.localhost' ],
 		isOAuth2Client: isCiabOAuth2Client,
 	},
 };
+
+export function getPartnerWindowTitleSuffix( ciabConfig: CiabPartnerConfig | null ): string {
+	return ciabConfig?.windowTitleSuffix || config( 'site_name' );
+}
+
+export function getPartnerFormattedWindowTitle(
+	title: string | null | undefined,
+	ciabConfig: CiabPartnerConfig | null
+): string {
+	const titlePrefix = title ? `${ title } — ` : '';
+
+	return titlePrefix + getPartnerWindowTitleSuffix( ciabConfig );
+}
 
 function isPartnerEnabled( partnerConfig: CiabPartnerConfig ): boolean {
 	return ! partnerConfig.featureFlag || config.isEnabled( partnerConfig.featureFlag );

--- a/client/lib/test/partner-branding.tsx
+++ b/client/lib/test/partner-branding.tsx
@@ -12,6 +12,8 @@ import {
 	detectCiabConfig,
 	getPartnerAllowedSocialServices,
 	getPartnerSignupTosElement,
+	getPartnerWindowTitleSuffix,
+	getPartnerFormattedWindowTitle,
 	persistCiabPartnerId,
 	readPersistedCiabPartnerId,
 	clearPersistedCiabPartnerId,
@@ -22,7 +24,13 @@ import type { useTranslate } from 'i18n-calypso';
 
 // Mock the config module
 jest.mock( '@automattic/calypso-config', () => {
-	const config = () => null;
+	const config = ( key: string ) => {
+		if ( key === 'site_name' ) {
+			return 'WordPress.com';
+		}
+
+		return null;
+	};
 	config.isEnabled = jest.fn( ( feature: string ) => {
 		if ( feature === 'ciab/custom-branding' ) {
 			return true;
@@ -446,7 +454,30 @@ describe( 'partner-branding', () => {
 			expect( wooConfig.logo.src ).toBeDefined();
 			expect( wooConfig.ssoProviders ).toBeInstanceOf( Array );
 			expect( wooConfig.ssoProviders.length ).toBeGreaterThan( 0 );
+			expect( wooConfig.windowTitleSuffix ).toBe( 'Woo' );
 			expect( wooConfig.domains ).toContain( 'my.woo.ai' );
+		} );
+	} );
+
+	describe( 'window title helpers', () => {
+		test( 'returns partner-specific suffix when available', () => {
+			expect( getPartnerWindowTitleSuffix( CIAB_PARTNERS.woo ) ).toBe( 'Woo' );
+		} );
+
+		test( 'falls back to site_name when partner suffix is unavailable', () => {
+			expect( getPartnerWindowTitleSuffix( null ) ).toBe( 'WordPress.com' );
+		} );
+
+		test( 'formats title with partner-aware suffix', () => {
+			expect( getPartnerFormattedWindowTitle( 'Accept Invite', CIAB_PARTNERS.woo ) ).toBe(
+				'Accept Invite — Woo'
+			);
+		} );
+
+		test( 'formats title with default suffix when no partner is detected', () => {
+			expect( getPartnerFormattedWindowTitle( 'Accept Invite', null ) ).toBe(
+				'Accept Invite — WordPress.com'
+			);
 		} );
 	} );
 } );

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -21,7 +21,7 @@ import {
 	isCrowdsignalOAuth2Client,
 	isVIPOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
-import { detectCiabConfig } from 'calypso/lib/partner-branding';
+import { detectCiabConfig, getPartnerFormattedWindowTitle } from 'calypso/lib/partner-branding';
 import isPassportRedirect from 'calypso/lib/passport/is-passport-redirect';
 import { login } from 'calypso/lib/paths';
 import { getHeaderText } from 'calypso/login/wp-login/hooks/get-header-text';
@@ -315,8 +315,15 @@ export class Login extends Component {
 	}
 
 	render() {
-		const { locale, translate, isGenericOauth, isGravPoweredClient, isJetpack, action } =
-			this.props;
+		const {
+			locale,
+			translate,
+			isGenericOauth,
+			isGravPoweredClient,
+			isJetpack,
+			action,
+			ciabConfig,
+		} = this.props;
 
 		const canonicalUrl = localizeUrl( 'https://wordpress.com/log-in', locale );
 
@@ -334,7 +341,11 @@ export class Login extends Component {
 				{ isGravPoweredClient && this.renderI18nSuggestions() }
 
 				<DocumentHead
-					title={ translate( 'Log In' ) }
+					title={ getPartnerFormattedWindowTitle(
+						translate( 'Log In', { textOnly: true } ),
+						ciabConfig
+					) }
+					skipTitleFormatting
 					link={ [ { rel: 'canonical', href: canonicalUrl } ] }
 					meta={ [
 						{

--- a/client/my-sites/invites-unified/screens/accept-invite-screen.tsx
+++ b/client/my-sites/invites-unified/screens/accept-invite-screen.tsx
@@ -11,7 +11,12 @@ import DocumentHead from 'calypso/components/data/document-head';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { navigate } from 'calypso/lib/navigate';
-import { getCiabConfigFromGarden, type CiabPartnerConfig } from 'calypso/lib/partner-branding';
+import {
+	detectCiabConfig,
+	getCiabConfigFromGarden,
+	getPartnerFormattedWindowTitle,
+	type CiabPartnerConfig,
+} from 'calypso/lib/partner-branding';
 import { login } from 'calypso/lib/paths';
 import { getRedirectAfterAccept } from 'calypso/my-sites/invites/utils';
 import { useDispatch } from 'calypso/state';
@@ -163,6 +168,7 @@ export function AcceptInviteScreen( { invite }: AcceptInviteScreenProps ) {
 
 	// Get branding from blog_details garden info
 	const branding = getBrandingFromBlogDetails( invite?.blog_details );
+	const titleBranding = branding ?? detectCiabConfig();
 	const gardenName = invite?.blog_details?.garden?.name || null;
 	const gardenPartner = invite?.blog_details?.garden?.partner || null;
 
@@ -250,6 +256,7 @@ export function AcceptInviteScreen( { invite }: AcceptInviteScreenProps ) {
 				inviteSentTo={ inviteSentTo }
 				isKnownUser={ isKnownUser }
 				topBarLogo={ topBarLogo }
+				ciabConfig={ titleBranding }
 				trackingProps={ trackingProps }
 			/>
 		);
@@ -257,7 +264,13 @@ export function AcceptInviteScreen( { invite }: AcceptInviteScreenProps ) {
 
 	return (
 		<>
-			<DocumentHead title={ translate( 'Accept Invite', { textOnly: true } ) } />
+			<DocumentHead
+				title={ getPartnerFormattedWindowTitle(
+					translate( 'Accept Invite', { textOnly: true } ),
+					titleBranding
+				) }
+				skipTitleFormatting
+			/>
 			<BodySectionCssClass
 				bodyClass={ [
 					'is-section-accept-invite-unified',

--- a/client/my-sites/invites-unified/screens/email-mismatch-screen.tsx
+++ b/client/my-sites/invites-unified/screens/email-mismatch-screen.tsx
@@ -7,6 +7,10 @@ import DocumentHead from 'calypso/components/data/document-head';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { navigate } from 'calypso/lib/navigate';
+import {
+	getPartnerFormattedWindowTitle,
+	type CiabPartnerConfig,
+} from 'calypso/lib/partner-branding';
 import { login } from 'calypso/lib/paths';
 
 import './style.scss';
@@ -15,6 +19,7 @@ interface EmailMismatchScreenProps {
 	inviteSentTo: string;
 	isKnownUser: boolean;
 	topBarLogo?: React.ReactNode;
+	ciabConfig: CiabPartnerConfig | null;
 	trackingProps: Record< string, unknown >;
 }
 
@@ -22,6 +27,7 @@ export function EmailMismatchScreen( {
 	inviteSentTo,
 	isKnownUser,
 	topBarLogo,
+	ciabConfig,
 	trackingProps,
 }: EmailMismatchScreenProps ) {
 	const translate = useTranslate();
@@ -60,7 +66,13 @@ export function EmailMismatchScreen( {
 
 	return (
 		<>
-			<DocumentHead title={ translate( 'Accept Invite', { textOnly: true } ) } />
+			<DocumentHead
+				title={ getPartnerFormattedWindowTitle(
+					translate( 'Accept Invite', { textOnly: true } ),
+					ciabConfig
+				) }
+				skipTitleFormatting
+			/>
 			<BodySectionCssClass bodyClass={ [ 'is-section-accept-invite-unified' ] } />
 			<Step.CenteredColumnLayout
 				columnWidth={ 4 }

--- a/client/my-sites/invites-unified/screens/invite-screen-layout.tsx
+++ b/client/my-sites/invites-unified/screens/invite-screen-layout.tsx
@@ -8,7 +8,11 @@ import DocumentHead from 'calypso/components/data/document-head';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { navigate } from 'calypso/lib/navigate';
-import { getCiabConfigFromGarden } from 'calypso/lib/partner-branding';
+import {
+	detectCiabConfig,
+	getCiabConfigFromGarden,
+	getPartnerFormattedWindowTitle,
+} from 'calypso/lib/partner-branding';
 import { login } from 'calypso/lib/paths';
 import { useDispatch } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
@@ -75,6 +79,7 @@ export function InviteScreenLayout( {
 				persistToSession: true,
 		  } )
 		: null;
+	const titleBranding = branding ?? detectCiabConfig();
 
 	const topBarLogoConfig = branding?.compactLogo ?? branding?.logo;
 	const topBarLogo = topBarLogoConfig?.src ? (
@@ -91,7 +96,13 @@ export function InviteScreenLayout( {
 
 	return (
 		<>
-			<DocumentHead title={ translate( 'Accept Invite', { textOnly: true } ) } />
+			<DocumentHead
+				title={ getPartnerFormattedWindowTitle(
+					translate( 'Accept Invite', { textOnly: true } ),
+					titleBranding
+				) }
+				skipTitleFormatting
+			/>
 			<BodySectionCssClass
 				bodyClass={ [
 					'is-section-accept-invite-unified',

--- a/client/my-sites/invites-unified/screens/test/accept-invite-screen.test.tsx
+++ b/client/my-sites/invites-unified/screens/test/accept-invite-screen.test.tsx
@@ -137,6 +137,7 @@ jest.mock( 'calypso/lib/navigate', () => ( {
 } ) );
 
 const mockWooBranding = {
+	windowTitleSuffix: 'Woo',
 	logo: {
 		src: 'https://example.com/woo-logo.png',
 		alt: 'Woo',
@@ -152,12 +153,17 @@ const mockWooBranding = {
 };
 
 jest.mock( 'calypso/lib/partner-branding', () => ( {
+	detectCiabConfig: () => null,
 	getCiabConfigFromGarden: ( partner: string, name: string ) => {
 		if ( partner === 'woo' && name === 'commerce' ) {
 			return mockWooBranding;
 		}
 		return null;
 	},
+	getPartnerFormattedWindowTitle: (
+		title: string,
+		ciabConfig: { windowTitleSuffix?: string } | null
+	) => `${ title } — ${ ciabConfig?.windowTitleSuffix || 'WordPress.com' }`,
 } ) );
 
 jest.mock( 'calypso/lib/paths', () => ( {

--- a/client/my-sites/invites-unified/screens/test/already-member-screen.test.tsx
+++ b/client/my-sites/invites-unified/screens/test/already-member-screen.test.tsx
@@ -97,9 +97,11 @@ jest.mock( 'calypso/lib/navigate', () => ( {
 } ) );
 
 jest.mock( 'calypso/lib/partner-branding', () => ( {
+	detectCiabConfig: () => null,
 	getCiabConfigFromGarden: ( partner: string, name: string ) => {
 		if ( partner === 'woo' && name === 'commerce' ) {
 			return {
+				windowTitleSuffix: 'Woo',
 				logo: {
 					src: 'https://example.com/woo-logo.png',
 					alt: 'Woo',
@@ -116,6 +118,10 @@ jest.mock( 'calypso/lib/partner-branding', () => ( {
 		}
 		return null;
 	},
+	getPartnerFormattedWindowTitle: (
+		title: string,
+		ciabConfig: { windowTitleSuffix?: string } | null
+	) => `${ title } — ${ ciabConfig?.windowTitleSuffix || 'WordPress.com' }`,
 } ) );
 
 jest.mock( 'calypso/lib/paths', () => ( {

--- a/client/my-sites/invites-unified/screens/test/email-mismatch-screen.test.tsx
+++ b/client/my-sites/invites-unified/screens/test/email-mismatch-screen.test.tsx
@@ -102,6 +102,7 @@ describe( 'EmailMismatchScreen', () => {
 			<EmailMismatchScreen
 				inviteSentTo="invited@example.com"
 				isKnownUser
+				ciabConfig={ null }
 				trackingProps={ { unified: true } }
 			/>
 		);
@@ -120,6 +121,7 @@ describe( 'EmailMismatchScreen', () => {
 			<EmailMismatchScreen
 				inviteSentTo="invited@example.com"
 				isKnownUser
+				ciabConfig={ null }
 				trackingProps={ { unified: true } }
 			/>
 		);
@@ -132,6 +134,7 @@ describe( 'EmailMismatchScreen', () => {
 			<EmailMismatchScreen
 				inviteSentTo="invited@example.com"
 				isKnownUser={ false }
+				ciabConfig={ null }
 				trackingProps={ { unified: true } }
 			/>
 		);
@@ -145,6 +148,7 @@ describe( 'EmailMismatchScreen', () => {
 			<EmailMismatchScreen
 				inviteSentTo="invited@example.com"
 				isKnownUser
+				ciabConfig={ null }
 				trackingProps={ { role: 'administrator', unified: true } }
 			/>
 		);

--- a/client/my-sites/invites-unified/test/index.test.tsx
+++ b/client/my-sites/invites-unified/test/index.test.tsx
@@ -24,7 +24,9 @@ jest.mock( '@automattic/onboarding', () => ( {
 } ) );
 
 jest.mock( 'calypso/lib/partner-branding', () => ( {
+	detectCiabConfig: () => null,
 	getCiabConfigFromGarden: () => ( {
+		windowTitleSuffix: 'Woo',
 		compactLogo: {
 			src: 'https://example.com/compact-logo.svg',
 			alt: 'Compact Logo',
@@ -38,6 +40,10 @@ jest.mock( 'calypso/lib/partner-branding', () => ( {
 			height: 32,
 		},
 	} ),
+	getPartnerFormattedWindowTitle: (
+		title: string,
+		ciabConfig: { windowTitleSuffix?: string } | null
+	) => `${ title } — ${ ciabConfig?.windowTitleSuffix || 'WordPress.com' }`,
 } ) );
 
 jest.mock( 'calypso/my-sites/invites/invite-accept/utils/normalize-invite', () => ( {

--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -5,6 +5,11 @@ import { useTranslate } from 'i18n-calypso';
 import store from 'store';
 import DocumentHead from 'calypso/components/data/document-head';
 import { navigate } from 'calypso/lib/navigate';
+import {
+	detectCiabConfig,
+	getCiabConfigFromGarden,
+	getPartnerFormattedWindowTitle,
+} from 'calypso/lib/partner-branding';
 import InviteAccept from 'calypso/my-sites/invites/invite-accept';
 import { getRedirectAfterAccept } from 'calypso/my-sites/invites/utils';
 import { setUserEmailVerified } from 'calypso/state/current-user/actions';
@@ -60,8 +65,23 @@ export function acceptInvite( context, next ) {
 
 	const AcceptInviteTitle = () => {
 		const translate = useTranslate();
+		const blogDetails = context.inviteData?.blog_details;
+		const ciabConfig =
+			blogDetails?.is_garden_site && blogDetails.garden
+				? getCiabConfigFromGarden( blogDetails.garden.partner, blogDetails.garden.name, {
+						persistToSession: true,
+				  } )
+				: detectCiabConfig();
 
-		return <DocumentHead title={ translate( 'Accept Invite', { textOnly: true } ) } />;
+		return (
+			<DocumentHead
+				title={ getPartnerFormattedWindowTitle(
+					translate( 'Accept Invite', { textOnly: true } ),
+					ciabConfig
+				) }
+				skipTitleFormatting
+			/>
+		);
 	};
 
 	context.primary = (

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -46,6 +46,7 @@ import {
 	isGravatarOAuth2Client,
 	isPartnerPortalOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
+import { detectCiabConfig, getPartnerFormattedWindowTitle } from 'calypso/lib/partner-branding';
 import SignupFlowController from 'calypso/lib/signup/flow-controller';
 import FlowProgressIndicator from 'calypso/signup/flow-progress-indicator';
 import SignupHeader from 'calypso/signup/signup-header';
@@ -127,6 +128,7 @@ class Signup extends Component {
 		flowName: PropTypes.string,
 		stepName: PropTypes.string,
 		pageTitle: PropTypes.string,
+		ciabConfig: PropTypes.object,
 		stepSectionName: PropTypes.string,
 		hostingFlow: PropTypes.bool.isRequired,
 	};
@@ -870,7 +872,10 @@ class Signup extends Component {
 		return (
 			<>
 				<div className={ `signup is-${ kebabCase( this.props.flowName ) }` }>
-					<DocumentHead title={ this.props.pageTitle } />
+					<DocumentHead
+						title={ getPartnerFormattedWindowTitle( this.props.pageTitle, this.props.ciabConfig ) }
+						skipTitleFormatting
+					/>
 					{ showPageHeader && (
 						<SignupHeader
 							progressBar={ {
@@ -935,6 +940,7 @@ export default connect(
 			siteId,
 			localeSlug: getCurrentLocaleSlug( state ),
 			oauth2Client,
+			ciabConfig: detectCiabConfig( oauth2Client ),
 			isGravatar: isGravatarOAuth2Client( oauth2Client ),
 			wccomFrom: getWccomFrom( state ),
 			hostingFlow,


### PR DESCRIPTION
Part of ARC-1586

## Proposed Changes

- Add partner branding support for a dedicated `windowTitleSuffix`, including Woo config and helper utilities to build auth page titles.
- Update auth title rendering in `/log-in`, `/start`, and accept-invite flows to use partner-aware titles and skip default title formatting.
- Update invite flow tests to cover the new partner title helper usage and required props/mocks.

## Why are these changes being made?

- Partner-branded auth experiences should consistently use partner-specific title suffixes instead of always showing the default site suffix.
- This aligns browser window titles with Woo branding across login, signup, and invite acceptance entry points.

## Testing Instructions

- Run `yarn test-client client/lib/test/partner-branding.tsx`.
- Run `yarn test-client client/my-sites/invites-unified/screens/test`.
- Verify `/log-in`, `/start`, and `/accept-invite` show Woo-branded title suffix when partner branding is detected, and default suffix otherwise.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?