### PR TITLE
Fix link style in stats upgrade notice

### DIFF
--- a/client/my-sites/stats/stats-notices/style.scss
+++ b/client/my-sites/stats/stats-notices/style.scss
@@ -40,7 +40,6 @@
 
 		.notice-banner__action-link > span {
 			border-bottom: 0;
-			vertical-align: middle;
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes STATS-240

## Proposed Changes

* Removes the `vertical-align` property from the link style applied to "Learn More" so that the link displays the proper underline.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This fixes a small visual polish issue. 

## Testing Instructions

1. On a Jetpack site without a Stats plan and without Complete, use the debugger to set the site as commercial
2. Go to WordPress.com dashboard and see the stats upgrade nudge: https://wordpress.com/stats/day/example.com
3. Observe that the link style for “Learn More” has a strange style where the underline doesn’t display properly.
4. Apply PR and see issue is resolved.

**Before:**

<img width="2088" height="929" alt="image" src="https://github.com/user-attachments/assets/f86eb2b5-e33b-45c1-b7bb-fe52e03c6d5d" />


**After:**

<img width="1337" height="833" alt="image" src="https://github.com/user-attachments/assets/e0bccbc2-5dbd-4bdb-9fc3-633a425c6238" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ x ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
