### PR TITLE
composite-checkout: Add editButtonElement to CheckoutStep

### DIFF
--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -150,6 +150,7 @@ This component's props are:
 - `nextStepButtonAriaLabel?: string`. Used to fill in the `aria-label` attribute for the "Continue" button if one exists.
 - `canEditStep?: boolean`. If false, the step will never show an "Edit" button. Defaults to true.
 - `editButtonText?: string`. Used in place of "Edit" on the edit step button.
+- `editButtonElement?: React.ReactNode`. Used in place of the "Edit" button contents on the edit step button (overrides `editButtonText`).
 - `nextStepButtonText?: string`. Used in place of "Continue" on the next step button.
 - `validatingButtonText?: string`. Used in place of "Please wait…" on the next step button when `isCompleteCallback` returns an unresolved Promise.
 - `validatingButtonAriaLabel:? string`. Used for the `aria-label` attribute on the next step button when `isCompleteCallback` returns an unresolved Promise.
@@ -168,6 +169,7 @@ This component's props are:
 - `errorMessage?: string`. The error message to display in the React error boundary if there is an error thrown by any component in this step.
 - `onError?: (error: Error) => void`. A callback to be called from the React error boundary if there is an error thrown by any component in this step.
 - `editButtonText?: string`. The text to display instead of "Edit" for the edit step button.
+- `editButtonElement?: React.ReactNode`. Used in place of the "Edit" button contents on the edit step button (overrides `editButtonText`).
 - `editButtonAriaLabel?: string`. The text to display for `aria-label` instead of "Edit" for the edit step button.
 - `nextStepButtonText?: string`. Like `editButtonText` but for the "Continue" button.
 - `nextStepButtonAriaLabel?: string`. Like `editButtonAriaLabel` but for the "Continue" button.

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -486,6 +486,7 @@ export const CheckoutStep = ( {
 	isCompleteCallback,
 	canEditStep = true,
 	editButtonText,
+	editButtonElement,
 	editButtonAriaLabel,
 	nextStepButtonText,
 	nextStepButtonAriaLabel,
@@ -543,6 +544,7 @@ export const CheckoutStep = ( {
 		<CheckoutStepBody
 			onError={ onError }
 			editButtonText={ editButtonText || __( 'Edit' ) }
+			editButtonElement={ editButtonElement }
 			editButtonAriaLabel={ editButtonAriaLabel || __( 'Edit this step' ) }
 			nextStepButtonText={ nextStepButtonText || __( 'Continue' ) }
 			nextStepButtonAriaLabel={ nextStepButtonAriaLabel || __( 'Continue to the next step' ) }
@@ -815,6 +817,7 @@ const StepSummaryWrapper = styled.div< StepContentWrapperProps & HTMLAttributes<
 export function CheckoutStepBody( {
 	errorMessage,
 	editButtonText,
+	editButtonElement,
 	editButtonAriaLabel,
 	nextStepButtonText,
 	validatingButtonText,
@@ -862,6 +865,7 @@ export function CheckoutStepBody( {
 							: undefined
 					}
 					editButtonText={ editButtonText || __( 'Edit' ) }
+					editButtonElement={ editButtonElement }
 					editButtonAriaLabel={ editButtonAriaLabel || __( 'Edit this step' ) }
 				/>
 				<StepContentWrapper
@@ -908,6 +912,7 @@ interface CheckoutStepBodyProps {
 	onError?: ( error: Error ) => void;
 	editButtonAriaLabel?: string;
 	editButtonText?: string;
+	editButtonElement?: ReactNode;
 	nextStepButtonText?: string;
 	nextStepButtonAriaLabel?: string;
 	isStepActive: boolean;
@@ -931,6 +936,7 @@ CheckoutStepBody.propTypes = {
 	onError: PropTypes.func,
 	editButtonAriaLabel: PropTypes.string,
 	editButtonText: PropTypes.string,
+	editButtonElement: PropTypes.node,
 	nextStepButtonText: PropTypes.string,
 	nextStepButtonAriaLabel: PropTypes.string,
 	isStepActive: PropTypes.bool.isRequired,
@@ -1027,6 +1033,7 @@ function CheckoutStepHeader( {
 	canEditStep,
 	onEdit,
 	editButtonText,
+	editButtonElement,
 	editButtonAriaLabel,
 }: {
 	id: string;
@@ -1038,6 +1045,7 @@ function CheckoutStepHeader( {
 	canEditStep?: boolean;
 	onEdit?: () => void;
 	editButtonText?: string;
+	editButtonElement?: ReactNode;
 	editButtonAriaLabel?: string;
 } ) {
 	const { __ } = useI18n();
@@ -1064,7 +1072,7 @@ function CheckoutStepHeader( {
 					onClick={ onEdit }
 					aria-label={ editButtonAriaLabel || __( 'Edit this step' ) }
 				>
-					{ editButtonText || __( 'Edit' ) }
+					{ editButtonElement ?? editButtonText ?? __( 'Edit' ) }
 				</HeaderEditButton>
 			) }
 		</StepHeaderWrapper>
@@ -1166,6 +1174,7 @@ CheckoutStepHeader.propTypes = {
 	isActive: PropTypes.bool,
 	isComplete: PropTypes.bool,
 	editButtonText: PropTypes.string,
+	editButtonElement: PropTypes.node,
 	editButtonAriaLabel: PropTypes.string,
 	onEdit: PropTypes.func,
 };

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -19,6 +19,7 @@ export interface CheckoutStepProps {
 	className?: string;
 	canEditStep?: boolean;
 	editButtonText?: string;
+	editButtonElement?: React.ReactNode;
 	editButtonAriaLabel?: string;
 	nextStepButtonText?: string;
 	nextStepButtonAriaLabel?: string;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/SHILL-1751/implement-checkout-ui-redesign-variant-changes

## Proposed Changes

This PR adds a new prop to the `CheckoutStep` component in the `@automattic/composite-checkout` package. This allows replacing the "Edit step" button entirely (eg: with an icon) rather than just changing its text.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

See https://github.com/Automattic/wp-calypso/pull/109253
