### PR TITLE
FORNO-261: Image Studio > Fix Aspect Ratio

### DIFF
--- a/packages/image-studio/src/utils/client-context.ts
+++ b/packages/image-studio/src/utils/client-context.ts
@@ -21,6 +21,7 @@ export interface ImageStudioData {
 	isOpen: boolean;
 	id: number | null;
 	style?: string;
+	aspect_ratio?: string;
 	metadata: ImageStudioMetadata;
 }
 
@@ -192,6 +193,7 @@ function detectImageEntity(): ImageStudioData | null {
 		const attachmentId = storeSelect.getImageStudioAttachmentId?.();
 		const isOpen = storeSelect.getIsImageStudioOpen?.() || false;
 		const selectedStyle = storeSelect.getSelectedStyle?.() || null;
+		const selectedAspectRatio = storeSelect.getSelectedAspectRatio?.() || null;
 		const originalAttachmentId = storeSelect.getOriginalAttachmentId?.() || null;
 
 		// Generate mode = opened without an existing image
@@ -203,9 +205,15 @@ function detectImageEntity(): ImageStudioData | null {
 			metadata: {},
 		};
 
-		// Only include style for generate mode
+		// Style only applies in generate mode (no existing image).
 		if ( selectedStyle && isGenerateMode ) {
 			imageStudio.style = selectedStyle;
+		}
+
+		// Always send aspect_ratio — the backend decides applicability via isEdit,
+		// so the client should not gate it on generate-only mode.
+		if ( selectedAspectRatio ) {
+			imageStudio.aspect_ratio = selectedAspectRatio;
 		}
 
 		// Try to get attachment metadata from core store

--- a/packages/image-studio/src/utils/client-context.ts
+++ b/packages/image-studio/src/utils/client-context.ts
@@ -194,10 +194,6 @@ function detectImageEntity(): ImageStudioData | null {
 		const isOpen = storeSelect.getIsImageStudioOpen?.() || false;
 		const selectedStyle = storeSelect.getSelectedStyle?.() || null;
 		const selectedAspectRatio = storeSelect.getSelectedAspectRatio?.() || null;
-		const originalAttachmentId = storeSelect.getOriginalAttachmentId?.() || null;
-
-		// Generate mode = opened without an existing image
-		const isGenerateMode = originalAttachmentId === null;
 
 		const imageStudio: ImageStudioData = {
 			isOpen,
@@ -205,13 +201,10 @@ function detectImageEntity(): ImageStudioData | null {
 			metadata: {},
 		};
 
-		// Style only applies in generate mode (no existing image).
-		if ( selectedStyle && isGenerateMode ) {
+		if ( selectedStyle ) {
 			imageStudio.style = selectedStyle;
 		}
 
-		// Always send aspect_ratio — the backend decides applicability via isEdit,
-		// so the client should not gate it on generate-only mode.
 		if ( selectedAspectRatio ) {
 			imageStudio.aspect_ratio = selectedAspectRatio;
 		}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Always send Aspect Ratio and Style to backed

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Aspect Ratio selection is not taking effect on generated images

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Install this on your sandbox `install-plugin.sh am forno-261/image-studio-aspect-ratio`
* Sandbox `widgets.wp.com`
* Verify that aspect ratio and style is respected on image generation / style for editing

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
