### PR TITLE
Launch Site Flow Standardization: Add Calypso Launchpad variations

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -7,16 +7,15 @@ import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { useMyHomeCardLaunchpad } from './use-my-home-card-launchpad';
 import './style.scss';
+import type { EventHandlers } from '@automattic/launchpad';
 
-interface CustomerHomeLaunchpadProps {
+interface CustomerHomeLaunchpadProps
+	extends Pick< EventHandlers, 'onSiteLaunched' | 'onTaskClick' > {
 	checklistSlug: string;
-	onSiteLaunched?: () => void;
 }
 
-const CustomerHomeLaunchpad: FC< CustomerHomeLaunchpadProps > = ( {
-	checklistSlug,
-	onSiteLaunched,
-}: CustomerHomeLaunchpadProps ) => {
+const CustomerHomeLaunchpad: FC< CustomerHomeLaunchpadProps > = ( props ) => {
+	const { checklistSlug, onSiteLaunched, onTaskClick } = props;
 	const launchpadContext = 'customer-home';
 	const translate = useTranslate();
 
@@ -86,6 +85,7 @@ const CustomerHomeLaunchpad: FC< CustomerHomeLaunchpadProps > = ( {
 				siteSlug={ siteSlug }
 				checklistSlug={ checklistSlug }
 				launchpadContext={ launchpadContext }
+				onTaskClick={ onTaskClick }
 				onSiteLaunched={ onSiteLaunched }
 			/>
 		</div>

--- a/client/my-sites/customer-home/cards/launchpad/pre-launch.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/pre-launch.tsx
@@ -1,11 +1,13 @@
 import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
 import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
+import { useExperiment } from 'calypso/lib/explat';
 import { useSelector } from 'calypso/state';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CelebrateLaunchModal from '../../components/celebrate-launch-modal';
 import { useCelebrateLaunchModal } from './use-celebrate-launch-modal';
 import CustomerHomeLaunchpad from '.';
+import type { Task } from '@automattic/launchpad';
 import type { AppState } from 'calypso/types';
 
 type LaunchpadPreLaunchProps = {
@@ -16,20 +18,43 @@ const LaunchpadPreLaunch = ( props: LaunchpadPreLaunchProps ): JSX.Element => {
 	const siteId = useSelector( getSelectedSiteId ) || 0;
 	const site = useSelector( ( state: AppState ) => getSite( state, siteId ) );
 	const checklistSlug = site?.options?.site_intent ?? '';
-	const { data: allDomains = [] } = useGetDomainsQuery( site?.ID ?? null, {
+	const { data: allDomains = [], isFetchedAfterMount } = useGetDomainsQuery( site?.ID ?? null, {
 		retry: false,
 	} );
 
 	const layout = useHomeLayoutQuery( siteId || null );
 	const { isOpen, setModalIsOpen, handleSiteLaunched } = useCelebrateLaunchModal( siteId, layout );
 
+	const [ , experimentData ] = useExperiment( 'calypso_standardized_site_launch_gating' );
+	const experimentAssignment = experimentData?.variationName;
+
+	const handleTaskClick = ( task: Task ) => {
+		// No experiment assignment (i.e., control) or not the site launch task
+		if ( task.id !== 'site_launched' || ! experimentAssignment ) {
+			return;
+		}
+
+		// Ungated site launch. When the action is completed, handleSiteLaunched will be called.
+		if ( experimentAssignment === 'ungated_site_launch' ) {
+			return;
+		}
+
+		if ( experimentAssignment === 'gated_site_launch' ) {
+			window.location.assign( `/start/launch-site?siteSlug=${ site?.slug }` );
+			return false;
+		}
+
+		throw new Error( 'Invalid experiment assignment' );
+	};
+
 	return (
 		<>
 			<CustomerHomeLaunchpad
 				checklistSlug={ props.checklistSlug ?? checklistSlug }
+				onTaskClick={ handleTaskClick }
 				onSiteLaunched={ () => handleSiteLaunched( !! site?.is_wpcom_atomic ) }
 			/>
-			{ isOpen && (
+			{ isOpen && isFetchedAfterMount && (
 				<CelebrateLaunchModal
 					setModalIsOpen={ setModalIsOpen }
 					site={ site }

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -163,7 +163,10 @@ export const setUpActionsForTasks = ( {
 		}
 
 		const actionDispatch = () => {
-			onTaskClick?.( task );
+			const result = onTaskClick?.( task );
+			if ( result === false ) {
+				return;
+			}
 			action?.();
 		};
 

--- a/packages/launchpad/src/types.ts
+++ b/packages/launchpad/src/types.ts
@@ -65,7 +65,10 @@ export interface PermittedActions {
 
 export type EventHandlers = {
 	onSiteLaunched?: () => void;
-	onTaskClick?: ( task: Task ) => void;
+	/**
+	 * If the function returns false, the default task will not be executed.
+	 */
+	onTaskClick?: ( task: Task ) => void | boolean;
 };
 
 export interface LaunchpadTaskActionsProps {


### PR DESCRIPTION
Closes DATSCI-1165.

## Proposed Changes

- Integrates the `calypso_standardized_site_launch_gating` ExplAt experiment into the Launchpad "Launch site" task in the Customer Home
- Adds an `onTaskClick` handler in `LaunchpadPreLaunch` that intercepts the task click and routes based on experiment variation:
  - `gated_site_launch`: redirects to `/start/launch-site` (the new standardized launch signup flow)
  - `ungated_site_launch`: lets the default task action proceed, triggering `handleSiteLaunched` and showing the `CelebrateLaunchModal`
  - Control (no variation): no interception, existing behavior preserved
- Fixes `CelebrateLaunchModal` to only render after domains are fetched (`isFetchedAfterMount`)
- Adds `onTaskClick` prop to `CustomerHomeLaunchpad`, forwarding it to the underlying launchpad component
- Extends `onTaskClick` in `packages/launchpad` to support returning `false` to cancel the default task action

## Why are these changes being made?

As part of the Launch Site Flow Standardization initiative, we need to A/B test different site launch paths from the Calypso Launchpad task. The `onTaskClick` callback in the launchpad package previously had no way to prevent the default task action from executing. This PR adds that capability (return `false` to cancel) and uses it to redirect users in the `gated_site_launch` experiment variation to the new standardized launch flow, while keeping the existing behavior intact for the control group.

## Testing Instructions

1. Visit a site with an unlaunched/staging status in Calypso and navigate to the Customer Home
2. Verify the Launchpad "Launch site" task is visible
3. Test with the `calypso_standardized_site_launch_gating` experiment:
   - `gated_site_launch` variation: clicking the task should redirect to `/start/launch-site?siteSlug=<slug>`
   - `ungated_site_launch` variation: clicking the task should launch the site directly and show the `CelebrateLaunchModal`
   - Control (no variation assigned): existing behavior should be preserved
4. Verify the `CelebrateLaunchModal` does not flash before domains are loaded

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?