### PR TITLE
Agents Manager show Sources component

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,7 @@
 	"dependencies": {
 		"@automattic/accessible-focus": "workspace:^",
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-ui": "^0.1.53",
+		"@automattic/agenttic-ui": "^0.1.55",
 		"@automattic/api-core": "workspace:^",
 		"@automattic/api-queries": "workspace:^",
 		"@automattic/block-renderer": "workspace:^",

--- a/packages/agents-manager/package.json
+++ b/packages/agents-manager/package.json
@@ -41,7 +41,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "file:/Users/jcheringer/projects/a8c/agenttic/packages/agenttic-client/automattic-agenttic-client-0.1.55.tgz",
+		"@automattic/agenttic-client": "^0.1.53",
 		"@automattic/agenttic-ui": "^0.1.53",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/components": "workspace:^",

--- a/packages/agents-manager/package.json
+++ b/packages/agents-manager/package.json
@@ -41,8 +41,8 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.53",
-		"@automattic/agenttic-ui": "^0.1.53",
+		"@automattic/agenttic-client": "^0.1.55",
+		"@automattic/agenttic-ui": "^0.1.55",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",

--- a/packages/agents-manager/package.json
+++ b/packages/agents-manager/package.json
@@ -41,9 +41,10 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.53",
+		"@automattic/agenttic-client": "file:/Users/jcheringer/projects/a8c/agenttic/packages/agenttic-client/automattic-agenttic-client-0.1.55.tgz",
 		"@automattic/agenttic-ui": "^0.1.53",
 		"@automattic/calypso-analytics": "workspace:^",
+		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/oauth-token": "workspace:^",

--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -451,7 +451,7 @@ body.post-new-php.agents-manager-sidebar-container {
 		}
 	}
 
-	// Prevent item picker content overflow (e.g., Patterns)
+	// Prevent content overflow
 	.Message-module_content {
 		width: 100%;
 	}

--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -451,6 +451,11 @@ body.post-new-php.agents-manager-sidebar-container {
 		}
 	}
 
+	// Prevent item picker content overflow (e.g., Patterns)
+	.Message-module_content {
+		width: 100%;
+	}
+
 	.big-sky__chat-actions {
 		width: 100%;
 		margin-top: auto;
@@ -656,11 +661,6 @@ body.post-new-php.agents-manager-sidebar-container {
 			.big-sky__item-picker__pager {
 				color: $gray-400;
 			}
-		}
-
-		// Prevent item picker content overflow (e.g., Patterns)
-		.Message-module_content {
-			width: 100%;
 		}
 	}
 }

--- a/packages/agents-manager/src/components/sources-display/index.tsx
+++ b/packages/agents-manager/src/components/sources-display/index.tsx
@@ -1,0 +1,77 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { FoldableCard } from '@automattic/components';
+import { isThisASupportArticleLink } from '@automattic/urls';
+import { decodeEntities } from '@wordpress/html-entities';
+import { __ } from '@wordpress/i18n';
+import { Icon, chevronRight, page } from '@wordpress/icons';
+import { useMemo } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useAgentsManagerContext } from '../../contexts';
+import './style.scss';
+
+interface Source {
+	title: string;
+	url: string;
+	content?: string;
+}
+
+export default function SourcesDisplay( { sources }: { sources: Source[] } ) {
+	const navigate = useNavigate();
+	const { pathname, state } = useLocation();
+	const { getActiveSessionId } = useAgentsManagerContext();
+
+	const uniqueSources = useMemo(
+		() => [ ...new Map( sources.map( ( source ) => [ source.url, source ] ) ).values() ],
+		[ sources ]
+	);
+
+	if ( uniqueSources.length === 0 ) {
+		return null;
+	}
+
+	const handleSourceClick = ( e: React.MouseEvent, url: string ) => {
+		const isSupportArticle = isThisASupportArticleLink( url );
+		const isFromOrchestrator = pathname === '/chat';
+
+		if ( isSupportArticle ) {
+			e.preventDefault();
+			navigate( `/post?link=${ encodeURIComponent( url ) }`, {
+				state: isFromOrchestrator ? { ...state, sessionId: getActiveSessionId() } : state,
+			} );
+		}
+
+		recordTracksEvent( 'calypso_agents_manager_link_click', {
+			href: url,
+			type: isSupportArticle ? 'support_article' : 'external',
+			source: isFromOrchestrator ? 'orchestrator' : 'zendesk',
+		} );
+	};
+
+	return (
+		<FoldableCard
+			className="agents-manager-sources-display"
+			summary={ __( 'Sources' ) }
+			expandedSummary={ __( 'Sources' ) }
+			screenReaderText="More"
+			iconSize={ 16 }
+			clickableHeader
+			smooth
+		>
+			<div className="agents-manager-sources-display__list">
+				{ uniqueSources.map( ( source, index ) => (
+					<a
+						key={ index }
+						className="agents-manager-sources-display__link"
+						href={ source.url }
+						rel="noopener noreferrer"
+						onClick={ ( e ) => handleSourceClick( e, source.url ) }
+					>
+						<Icon icon={ page } />
+						<span>{ decodeEntities( source.title ) }</span>
+						<Icon width={ 20 } height={ 20 } icon={ chevronRight } />
+					</a>
+				) ) }
+			</div>
+		</FoldableCard>
+	);
+}

--- a/packages/agents-manager/src/components/sources-display/index.tsx
+++ b/packages/agents-manager/src/components/sources-display/index.tsx
@@ -15,7 +15,11 @@ interface Source {
 	content?: string;
 }
 
-export default function SourcesDisplay( { sources }: { sources: Source[] } ) {
+interface Props {
+	sources: Source[];
+}
+
+export default function SourcesDisplay( { sources }: Props ) {
 	const navigate = useNavigate();
 	const { pathname, state } = useLocation();
 	const { getActiveSessionId } = useAgentsManagerContext();
@@ -50,9 +54,9 @@ export default function SourcesDisplay( { sources }: { sources: Source[] } ) {
 	return (
 		<FoldableCard
 			className="agents-manager-sources-display"
-			summary={ __( 'Sources' ) }
-			expandedSummary={ __( 'Sources' ) }
-			screenReaderText="More"
+			summary={ __( 'Sources', '__i18n_text_domain__' ) }
+			expandedSummary={ __( 'Sources', '__i18n_text_domain__' ) }
+			screenReaderText={ __( 'More', '__i18n_text_domain__' ) }
 			iconSize={ 16 }
 			clickableHeader
 			smooth

--- a/packages/agents-manager/src/components/sources-display/style.scss
+++ b/packages/agents-manager/src/components/sources-display/style.scss
@@ -1,5 +1,3 @@
-@import "@automattic/typography/styles/variables";
-
 .Message-module_content:has(.agents-manager-sources-display) {
 	position: relative;
 }

--- a/packages/agents-manager/src/components/sources-display/style.scss
+++ b/packages/agents-manager/src/components/sources-display/style.scss
@@ -1,0 +1,115 @@
+@import "@automattic/typography/styles/variables";
+
+.Message-module_content:has(.agents-manager-sources-display) {
+	position: relative;
+}
+
+.agents-manager-sources-display {
+	&.card {
+		position: absolute;
+		width: 100%;
+		display: flex;
+		flex-direction: column;
+		align-items: flex-end;
+		background-color: transparent;
+		box-shadow: none;
+		margin-bottom: 0;
+		pointer-events: none;
+	}
+
+	.foldable-card__header {
+		width: auto;
+		height: 32px;
+		min-height: unset;
+		flex-direction: row-reverse;
+		justify-content: end;
+		gap: 4px;
+		padding: 0;
+		pointer-events: initial;
+	}
+
+	.foldable-card__content {
+		width: 100%;
+		pointer-events: initial;
+		margin: 8px 0 24px;
+	}
+
+	.foldable-card__main,
+	.foldable-card__secondary {
+		flex: unset;
+		margin: 0;
+	}
+
+	.foldable-card__action {
+		position: relative;
+		width: 16px;
+
+		svg.gridicon {
+			fill: var(--color-muted-foreground);
+		}
+	}
+
+	.foldable-card__summary,
+	.foldable-card__summary-expanded {
+		color: var(--color-muted-foreground);
+		margin: 0;
+	}
+
+	&.is-expanded {
+		.foldable-card__header {
+			height: 32px;
+			min-height: unset;
+		}
+
+		.foldable-card__content {
+			border: none;
+		}
+	}
+
+	.agents-manager-sources-display__link {
+		width: 100%;
+		min-width: 0;
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 4px;
+		border: 1px solid var(--color-muted);
+
+		& + .agents-manager-sources-display__link {
+			margin-top: -1px;
+		}
+
+		&:first-of-type:not(:only-of-type) {
+			border-radius: 8px 8px 0 0;
+		}
+
+		&:last-of-type:not(:only-of-type) {
+			border-radius: 0 0 8px 8px;
+		}
+
+		&:hover {
+			background-color: color-mix(in srgb, var(--color-background) 50%, var(--color-muted));
+		}
+
+		&:focus {
+			box-shadow: none;
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--color-ring);
+			outline-offset: -3px;
+		}
+
+		span {
+			flex: 1;
+			font-size: var(--text-xs);
+			white-space: nowrap;
+			overflow: hidden;
+			text-overflow: ellipsis;
+		}
+
+		svg path {
+			fill: var(--color-muted-foreground)
+		}
+	}
+}

--- a/packages/agents-manager/src/utils/__tests__/process-tool-messages.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/process-tool-messages.test.ts
@@ -1,4 +1,5 @@
 import { EscalationButton } from '../../components/escalation-button';
+import SourcesDisplay from '../../components/sources-display';
 import UnavailableToolMessage from '../../components/unavailable-tool-message';
 import { isEditorPage } from '../is-editor-page';
 import { convertToolMessagesToComponents, deactivateStaleMessages } from '../process-tool-messages';
@@ -8,10 +9,15 @@ jest.mock(
 	'@automattic/components',
 	() => ( {
 		SummaryButton: () => null,
+		FoldableCard: () => null,
 	} ),
 	{ virtual: true }
 );
 jest.mock( '../is-editor-page' );
+jest.mock( '../../components/sources-display', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
 
 const MockComponent = jest.fn();
 const MockNextStepButton = jest.fn();
@@ -180,6 +186,62 @@ describe( 'convertToolMessagesToComponents', () => {
 			type: 'component',
 			component: EscalationButton,
 		} );
+	} );
+
+	it( 'replaces data blocks with sources into SourcesDisplay components', () => {
+		const sources = [
+			{ title: 'Article 1', url: 'https://example.com/1' },
+			{ title: 'Article 2', url: 'https://example.com/2' },
+		];
+		const message = createMessage( {
+			content: [
+				{ type: 'text', text: 'Here is your answer.' },
+				{ type: 'data', data: { sources } },
+			],
+		} );
+
+		const result = convertToolMessagesToComponents( { messages: [ message ] } );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].content ).toHaveLength( 2 );
+		expect( result[ 0 ].content[ 0 ] ).toMatchObject( {
+			type: 'text',
+			text: 'Here is your answer.',
+		} );
+		expect( result[ 0 ].content[ 1 ] ).toMatchObject( {
+			type: 'component',
+			component: SourcesDisplay,
+			componentProps: { sources },
+		} );
+	} );
+
+	it( 'does not modify messages without sources data blocks', () => {
+		const message = createMessage( {
+			content: [
+				{ type: 'text', text: 'Just a normal message.' },
+				{ type: 'data', data: { flags: null } },
+			],
+		} );
+
+		const result = convertToolMessagesToComponents( { messages: [ message ] } );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].content ).toHaveLength( 2 );
+		expect( result[ 0 ].content[ 1 ] ).toMatchObject( { type: 'data', data: { flags: null } } );
+	} );
+
+	it( 'ignores sources data blocks with an empty array', () => {
+		const message = createMessage( {
+			content: [
+				{ type: 'text', text: 'Answer text.' },
+				{ type: 'data', data: { sources: [] } },
+			],
+		} );
+
+		const result = convertToolMessagesToComponents( { messages: [ message ] } );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].content[ 1 ] ).toMatchObject( { type: 'data', data: { sources: [] } } );
 	} );
 
 	it( 'filters out unhandled tool messages', () => {

--- a/packages/agents-manager/src/utils/process-tool-messages.ts
+++ b/packages/agents-manager/src/utils/process-tool-messages.ts
@@ -16,8 +16,7 @@ const SILENT_TOOL_IDS = [ 'big_sky__set_processing_state' ];
  */
 function extractSourcesFromContent( messages: UIMessage[] ): UIMessage[] {
 	return messages.map( ( message ) => {
-		// @ts-expect-error -- `assistant` comes from Big Sky messages
-		if ( message.role !== 'agent' && message.role !== 'assistant' ) {
+		if ( message.role !== 'agent' ) {
 			return message;
 		}
 

--- a/packages/agents-manager/src/utils/process-tool-messages.ts
+++ b/packages/agents-manager/src/utils/process-tool-messages.ts
@@ -1,4 +1,5 @@
 import { EscalationButton } from '../components/escalation-button';
+import SourcesDisplay from '../components/sources-display';
 import UnavailableToolMessage from '../components/unavailable-tool-message';
 import { CHECKPOINT_ACTION_ID } from '../hooks/use-checkpoint-action';
 import { isEditorPage } from './is-editor-page';
@@ -7,6 +8,44 @@ import type { UIMessage } from '@automattic/agenttic-client';
 
 // Tool IDs that are silently dropped without a console warning.
 const SILENT_TOOL_IDS = [ 'big_sky__set_processing_state' ];
+
+/**
+ * Scans message content blocks for JSON-encoded sources data and replaces
+ * those blocks with a SourcesDisplay component. Text blocks that don't parse
+ * as JSON (i.e. the actual answer text) are left untouched.
+ */
+function extractSourcesFromContent( messages: UIMessage[] ): UIMessage[] {
+	return messages.map( ( message ) => {
+		// @ts-expect-error -- `assistant` comes from Big Sky messages
+		if ( message.role !== 'agent' && message.role !== 'assistant' ) {
+			return message;
+		}
+
+		let hasSourcesBlock = false;
+		const updatedContent = message.content.map( ( block ) => {
+			if (
+				block.type !== 'data' ||
+				! Array.isArray( block.data?.sources ) ||
+				block.data.sources.length === 0
+			) {
+				return block;
+			}
+
+			hasSourcesBlock = true;
+			return {
+				type: 'component' as const,
+				component: SourcesDisplay as React.ComponentType,
+				componentProps: { sources: block.data.sources },
+			};
+		} );
+
+		if ( ! hasSourcesBlock ) {
+			return message;
+		}
+
+		return { ...message, content: updatedContent };
+	} );
+}
 
 interface Options {
 	messages: UIMessage[];
@@ -22,7 +61,10 @@ export function convertToolMessagesToComponents( {
 	getChatComponent,
 	currentPostId,
 }: Options ): UIMessage[] {
-	return messages.flatMap( ( message, index, array ) => {
+	// First pass: extract sources data blocks into SourcesDisplay components.
+	const messagesWithSources = extractSourcesFromContent( messages );
+
+	return messagesWithSources.flatMap( ( message, index, array ) => {
 		const firstContentText = message.content?.[ 0 ]?.text;
 
 		// @ts-expect-error -- `assistant` comes from Big Sky messages

--- a/packages/block-notes/package.json
+++ b/packages/block-notes/package.json
@@ -41,7 +41,7 @@
 	},
 	"dependencies": {
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-client": "^0.1.50",
+		"@automattic/agenttic-client": "^0.1.55",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@wordpress/abilities": "^0.4.0",
 		"@wordpress/api-fetch": "^7.23.0",

--- a/packages/image-studio/package.json
+++ b/packages/image-studio/package.json
@@ -51,8 +51,8 @@
 	},
 	"dependencies": {
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-client": "^0.1.53",
-		"@automattic/agenttic-ui": "^0.1.53",
+		"@automattic/agenttic-client": "^0.1.55",
+		"@automattic/agenttic-ui": "^0.1.55",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/oauth-token": "workspace:^",
 		"@wordpress/abilities": "^0.4.0",

--- a/packages/odie-client/package.json
+++ b/packages/odie-client/package.json
@@ -41,7 +41,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-ui": "^0.1.53",
+		"@automattic/agenttic-ui": "^0.1.55",
 		"@automattic/components": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/zendesk-client": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -141,8 +141,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/agents-manager@workspace:packages/agents-manager"
   dependencies:
-    "@automattic/agenttic-client": "npm:^0.1.53"
-    "@automattic/agenttic-ui": "npm:^0.1.53"
+    "@automattic/agenttic-client": "npm:^0.1.55"
+    "@automattic/agenttic-ui": "npm:^0.1.55"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
@@ -174,9 +174,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/agenttic-client@npm:^0.1.50, @automattic/agenttic-client@npm:^0.1.53":
-  version: 0.1.53
-  resolution: "@automattic/agenttic-client@npm:0.1.53"
+"@automattic/agenttic-client@npm:^0.1.55":
+  version: 0.1.55
+  resolution: "@automattic/agenttic-client@npm:0.1.55"
   dependencies:
     "@types/react": "npm:^18.0.0"
     marked: "npm:^16.2.1"
@@ -190,15 +190,15 @@ __metadata:
   peerDependenciesMeta:
     "@wordpress/api-fetch":
       optional: true
-  checksum: 09dbbdb387f0b2b052f1b3cd7c08a6d62e5abeb808234cd20ada788f8d940038b6494ae3be095e1655acf1be547fc19f89f339a47be87ecc6f8d1b8fed9bcf07
+  checksum: 3821a9e28680e38b6e820d268974074dd2cb01060c94b04aa0bb91ff1d9313855b60024536df3db007c78a96c5008cf27b6bfcb3bce0af35a2595e9bb0ee24be
   languageName: node
   linkType: hard
 
-"@automattic/agenttic-ui@npm:^0.1.53":
-  version: 0.1.53
-  resolution: "@automattic/agenttic-ui@npm:0.1.53"
+"@automattic/agenttic-ui@npm:^0.1.55":
+  version: 0.1.55
+  resolution: "@automattic/agenttic-ui@npm:0.1.55"
   dependencies:
-    "@automattic/charts": "npm:>=0.14.0 <1.0.0"
+    "@automattic/charts": "npm:>=0.58.0 <1.0.0"
     "@floating-ui/react-dom": "npm:^2.1.6"
     "@radix-ui/react-scroll-area": "npm:^1.2.9"
     "@radix-ui/react-slot": "npm:^1.2.3"
@@ -222,7 +222,7 @@ __metadata:
   dependenciesMeta:
     marked:
       optional: true
-  checksum: ce9c723149cc688b83b96c49468bbf1fb507c35a53ca281a2a56d59242f0d8f587b690d5e7c4afe5ab4869655563711ed61075072819d96c237fbc93e3f15178
+  checksum: 65505a80e4f4784bb6e5d7c950e945c7338dcf4f364b4e72d6b92374b6ad23985715d6671d195e244c3b84b582fadb3de1905911056b464b7437e20182867a1c
   languageName: node
   linkType: hard
 
@@ -346,7 +346,7 @@ __metadata:
   resolution: "@automattic/block-notes@workspace:packages/block-notes"
   dependencies:
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-client": "npm:^0.1.50"
+    "@automattic/agenttic-client": "npm:^0.1.55"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@testing-library/react": "npm:^15.0.0"
@@ -768,12 +768,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/charts@npm:>=0.14.0 <1.0.0, @automattic/charts@npm:^0.50.0":
-  version: 0.50.2
-  resolution: "@automattic/charts@npm:0.50.2"
+"@automattic/charts@npm:>=0.58.0 <1.0.0":
+  version: 0.58.0
+  resolution: "@automattic/charts@npm:0.58.0"
   dependencies:
-    "@automattic/number-formatters": "npm:^1.0.15"
-    "@babel/runtime": "npm:7.28.4"
+    "@automattic/number-formatters": "npm:^1.1.2"
+    "@babel/runtime": "npm:7.28.6"
     "@react-spring/web": "npm:9.7.5"
     "@visx/annotation": "npm:^3.12.0"
     "@visx/axis": "npm:^3.12.0"
@@ -789,18 +789,22 @@ __metadata:
     "@visx/shape": "npm:^3.12.0"
     "@visx/text": "npm:^3.12.0"
     "@visx/tooltip": "npm:^3.12.0"
+    "@visx/vendor": "npm:^3.12.0"
     "@visx/xychart": "npm:^3.12.0"
     "@wordpress/i18n": "npm:^6.0.0"
+    "@wordpress/theme": "npm:0.8.0"
+    "@wordpress/ui": "npm:0.8.0"
     clsx: "npm:2.1.1"
     date-fns: "npm:^4.1.0"
     deepmerge: "npm:4.3.1"
     fast-deep-equal: "npm:3.1.3"
     gridicons: "npm:3.4.2"
+    react-google-charts: "npm:^5.2.1"
     tslib: "npm:2.8.1"
   peerDependencies:
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-  checksum: e0bdce896e10910973c422eb9626e86375731abd53223f06f77daa717da30fb04457d5ed71d54d51c323a037518c722d947d8b50b869cc65a3bcd4c0c690d76d
+  checksum: f273d5f37be2e8da517f3a550fb4f3c2c984b6c8e8ea228cf638a13a382542f3139e0f4edfc4aaa5b0aa31a28e6ce463ae9498e6ac5ea03292911d5ccfafe42a
   languageName: node
   linkType: hard
 
@@ -837,6 +841,42 @@ __metadata:
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
   checksum: 0c986843d1ce366fe6bd0556f097ed278b39f6bdd1bd5e70ac665aac4ef4c3b5a5823f4ba9ecab6c277fe0e4ba5a6e6179664e05d933eb517fa91d24000f66bd
+  languageName: node
+  linkType: hard
+
+"@automattic/charts@npm:^0.50.0":
+  version: 0.50.2
+  resolution: "@automattic/charts@npm:0.50.2"
+  dependencies:
+    "@automattic/number-formatters": "npm:^1.0.15"
+    "@babel/runtime": "npm:7.28.4"
+    "@react-spring/web": "npm:9.7.5"
+    "@visx/annotation": "npm:^3.12.0"
+    "@visx/axis": "npm:^3.12.0"
+    "@visx/curve": "npm:^3.12.0"
+    "@visx/event": "npm:^3.12.0"
+    "@visx/gradient": "npm:^3.12.0"
+    "@visx/grid": "npm:^3.12.0"
+    "@visx/group": "npm:^3.12.0"
+    "@visx/legend": "npm:^3.12.0"
+    "@visx/pattern": "npm:^3.12.0"
+    "@visx/responsive": "npm:^3.12.0"
+    "@visx/scale": "npm:^3.12.0"
+    "@visx/shape": "npm:^3.12.0"
+    "@visx/text": "npm:^3.12.0"
+    "@visx/tooltip": "npm:^3.12.0"
+    "@visx/xychart": "npm:^3.12.0"
+    "@wordpress/i18n": "npm:^6.0.0"
+    clsx: "npm:2.1.1"
+    date-fns: "npm:^4.1.0"
+    deepmerge: "npm:4.3.1"
+    fast-deep-equal: "npm:3.1.3"
+    gridicons: "npm:3.4.2"
+    tslib: "npm:2.8.1"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+  checksum: e0bdce896e10910973c422eb9626e86375731abd53223f06f77daa717da30fb04457d5ed71d54d51c323a037518c722d947d8b50b869cc65a3bcd4c0c690d76d
   languageName: node
   linkType: hard
 
@@ -1403,8 +1443,8 @@ __metadata:
   resolution: "@automattic/image-studio@workspace:packages/image-studio"
   dependencies:
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-client": "npm:^0.1.53"
-    "@automattic/agenttic-ui": "npm:^0.1.53"
+    "@automattic/agenttic-client": "npm:^0.1.55"
+    "@automattic/agenttic-ui": "npm:^0.1.55"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/oauth-token": "workspace:^"
@@ -1690,6 +1730,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@automattic/number-formatters@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@automattic/number-formatters@npm:1.1.2"
+  dependencies:
+    "@wordpress/date": "npm:^5.19.0"
+    debug: "npm:^4.4.0"
+    tslib: "npm:^2.5.0"
+  checksum: bd83f99d1d53a81ccc9879c7062f66b6c9e1b1b0103ae5943189fd546fcb20d1a27d20f2d55f20c80164b64cf0bee5dbc72e533123e9b3f873b4e3670a6d67da
+  languageName: node
+  linkType: hard
+
 "@automattic/o2-blocks@workspace:apps/o2-blocks":
   version: 0.0.0-use.local
   resolution: "@automattic/o2-blocks@workspace:apps/o2-blocks"
@@ -1737,7 +1788,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/odie-client@workspace:packages/odie-client"
   dependencies:
-    "@automattic/agenttic-ui": "npm:^0.1.53"
+    "@automattic/agenttic-ui": "npm:^0.1.55"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
@@ -4116,6 +4167,13 @@ __metadata:
   version: 7.28.4
   resolution: "@babel/runtime@npm:7.28.4"
   checksum: 792ce7af9750fb9b93879cc9d1db175701c4689da890e6ced242ea0207c9da411ccf16dc04e689cc01158b28d7898c40d75598f4559109f761c12ce01e959bf7
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:7.28.6":
+  version: 7.28.6
+  resolution: "@babel/runtime@npm:7.28.6"
+  checksum: 358cf2429992ac1c466df1a21c1601d595c46930a13c1d4662fde908d44ee78ec3c183aaff513ecb01ef8c55c3624afe0309eeeb34715672dbfadb7feedb2c0d
   languageName: node
   linkType: hard
 
@@ -9858,7 +9916,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@visx/vendor@npm:3.12.0":
+"@visx/vendor@npm:3.12.0, @visx/vendor@npm:^3.12.0":
   version: 3.12.0
   resolution: "@visx/vendor@npm:3.12.0"
   dependencies:
@@ -11433,6 +11491,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wordpress/theme@npm:0.8.0, @wordpress/theme@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "@wordpress/theme@npm:0.8.0"
+  dependencies:
+    "@wordpress/element": "npm:^6.41.0"
+    "@wordpress/private-apis": "npm:^1.41.0"
+    colorjs.io: "npm:^0.6.0"
+    memize: "npm:^2.1.0"
+  peerDependencies:
+    react: ^18.0.0
+    react-dom: ^18.0.0
+    stylelint: ^16.8.2
+  peerDependenciesMeta:
+    stylelint:
+      optional: true
+  checksum: e342733d1f31703cc9c2d3670d5b0a14423299a2ffbb57fe465107d8c3c4e24a61d13a1415d87fe44052a8aaec0674559df65a9be7cd6639ef8796ce9a4b7b7d
+  languageName: node
+  linkType: hard
+
 "@wordpress/theme@npm:^0.9.0":
   version: 0.9.0
   resolution: "@wordpress/theme@npm:0.9.0"
@@ -11458,6 +11535,28 @@ __metadata:
   dependencies:
     "@babel/runtime": "npm:7.25.7"
   checksum: e2a8f53b871f9fa0774dab021c7fec1e35040d15d744bd49c61b67867d8863046c93200a3387355d519c0016ffb4d5d989c7c70688062302ae8857c09a6ea5ac
+  languageName: node
+  linkType: hard
+
+"@wordpress/ui@npm:0.8.0":
+  version: 0.8.0
+  resolution: "@wordpress/ui@npm:0.8.0"
+  dependencies:
+    "@base-ui/react": "npm:^1.2.0"
+    "@wordpress/a11y": "npm:^4.41.0"
+    "@wordpress/compose": "npm:^7.41.0"
+    "@wordpress/element": "npm:^6.41.0"
+    "@wordpress/i18n": "npm:^6.14.0"
+    "@wordpress/icons": "npm:^11.8.0"
+    "@wordpress/keycodes": "npm:^4.41.0"
+    "@wordpress/primitives": "npm:^4.41.0"
+    "@wordpress/private-apis": "npm:^1.41.0"
+    "@wordpress/theme": "npm:^0.8.0"
+    clsx: "npm:^2.1.1"
+  peerDependencies:
+    react: ^18.0.0
+    react-dom: ^18.0.0
+  checksum: bdd15df091f0891704ff1e12735b5250a92e7b87f4d4b79128addf9ad876eadcd71dcce960215bdb2a182a29707c11ef25ab4abe76bd1b9634ac4317a2ad45cc
   languageName: node
   linkType: hard
 
@@ -13278,7 +13377,7 @@ __metadata:
   dependencies:
     "@automattic/accessible-focus": "workspace:^"
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-ui": "npm:^0.1.53"
+    "@automattic/agenttic-ui": "npm:^0.1.55"
     "@automattic/api-core": "workspace:^"
     "@automattic/api-queries": "workspace:^"
     "@automattic/block-renderer": "workspace:^"
@@ -27014,6 +27113,16 @@ __metadata:
   version: 3.2.2
   resolution: "react-fast-compare@npm:3.2.2"
   checksum: 0bbd2f3eb41ab2ff7380daaa55105db698d965c396df73e6874831dbafec8c4b5b08ba36ff09df01526caa3c61595247e3269558c284e37646241cba2b90a367
+  languageName: node
+  linkType: hard
+
+"react-google-charts@npm:^5.2.1":
+  version: 5.2.1
+  resolution: "react-google-charts@npm:5.2.1"
+  peerDependencies:
+    react: ">=16.3.0"
+    react-dom: ">=16.3.0"
+  checksum: de9e4a685a7f0db37a2b89fc91e88a702b56819d59f1f2a9f02b8fa94604964cf1e7f59223332220548ebfd04f5e27e3a4b8f4a8842c87f5d5634eb23da1ff2a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1719,18 +1719,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/number-formatters@npm:^1.0.14, @automattic/number-formatters@npm:^1.0.15, @automattic/number-formatters@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@automattic/number-formatters@npm:1.1.0"
-  dependencies:
-    "@wordpress/date": "npm:^5.19.0"
-    debug: "npm:^4.4.0"
-    tslib: "npm:^2.5.0"
-  checksum: 277a5dd990141795cf11efcad0a0a5e072c92cb91915f6ce3cc0d834527744bf518977da0ea48566480da845e901d28969783236ed1ebd582265aec714b5a1a8
-  languageName: node
-  linkType: hard
-
-"@automattic/number-formatters@npm:^1.1.2":
+"@automattic/number-formatters@npm:^1.0.14, @automattic/number-formatters@npm:^1.0.15, @automattic/number-formatters@npm:^1.1.0, @automattic/number-formatters@npm:^1.1.2":
   version: 1.1.2
   resolution: "@automattic/number-formatters@npm:1.1.2"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -141,7 +141,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/agents-manager@workspace:packages/agents-manager"
   dependencies:
-    "@automattic/agenttic-client": "file:/Users/jcheringer/projects/a8c/agenttic/packages/agenttic-client/automattic-agenttic-client-0.1.55.tgz"
+    "@automattic/agenttic-client": "npm:^0.1.53"
     "@automattic/agenttic-ui": "npm:^0.1.53"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
@@ -173,26 +173,6 @@ __metadata:
     react-dom: ^18.3.1
   languageName: unknown
   linkType: soft
-
-"@automattic/agenttic-client@file:/Users/jcheringer/projects/a8c/agenttic/packages/agenttic-client/automattic-agenttic-client-0.1.55.tgz::locator=%40automattic%2Fagents-manager%40workspace%3Apackages%2Fagents-manager":
-  version: 0.1.55
-  resolution: "@automattic/agenttic-client@file:/Users/jcheringer/projects/a8c/agenttic/packages/agenttic-client/automattic-agenttic-client-0.1.55.tgz#/Users/jcheringer/projects/a8c/agenttic/packages/agenttic-client/automattic-agenttic-client-0.1.55.tgz::hash=2cef1a&locator=%40automattic%2Fagents-manager%40workspace%3Apackages%2Fagents-manager"
-  dependencies:
-    "@types/react": "npm:^18.0.0"
-    marked: "npm:^16.2.1"
-    react: "npm:^18.0.0"
-  peerDependencies:
-    "@wordpress/api-fetch": ^6.0.0 || ^7.0.0
-    react: ^18.0.0
-  dependenciesMeta:
-    marked:
-      optional: true
-  peerDependenciesMeta:
-    "@wordpress/api-fetch":
-      optional: true
-  checksum: ea3e5ec7e743fc682a9b682ace6acbf80134c4cb53d10518f7beec657686145104a8a76ccf33f14a6f90b02d3817062e92ea896106ec2f441507d40ed7973aa3
-  languageName: node
-  linkType: hard
 
 "@automattic/agenttic-client@npm:^0.1.50, @automattic/agenttic-client@npm:^0.1.53":
   version: 0.1.53

--- a/yarn.lock
+++ b/yarn.lock
@@ -141,10 +141,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/agents-manager@workspace:packages/agents-manager"
   dependencies:
-    "@automattic/agenttic-client": "npm:^0.1.53"
+    "@automattic/agenttic-client": "file:/Users/jcheringer/projects/a8c/agenttic/packages/agenttic-client/automattic-agenttic-client-0.1.55.tgz"
     "@automattic/agenttic-ui": "npm:^0.1.53"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
+    "@automattic/components": "workspace:^"
     "@automattic/data-stores": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
     "@automattic/oauth-token": "workspace:^"
@@ -172,6 +173,26 @@ __metadata:
     react-dom: ^18.3.1
   languageName: unknown
   linkType: soft
+
+"@automattic/agenttic-client@file:/Users/jcheringer/projects/a8c/agenttic/packages/agenttic-client/automattic-agenttic-client-0.1.55.tgz::locator=%40automattic%2Fagents-manager%40workspace%3Apackages%2Fagents-manager":
+  version: 0.1.55
+  resolution: "@automattic/agenttic-client@file:/Users/jcheringer/projects/a8c/agenttic/packages/agenttic-client/automattic-agenttic-client-0.1.55.tgz#/Users/jcheringer/projects/a8c/agenttic/packages/agenttic-client/automattic-agenttic-client-0.1.55.tgz::hash=2cef1a&locator=%40automattic%2Fagents-manager%40workspace%3Apackages%2Fagents-manager"
+  dependencies:
+    "@types/react": "npm:^18.0.0"
+    marked: "npm:^16.2.1"
+    react: "npm:^18.0.0"
+  peerDependencies:
+    "@wordpress/api-fetch": ^6.0.0 || ^7.0.0
+    react: ^18.0.0
+  dependenciesMeta:
+    marked:
+      optional: true
+  peerDependenciesMeta:
+    "@wordpress/api-fetch":
+      optional: true
+  checksum: ea3e5ec7e743fc682a9b682ace6acbf80134c4cb53d10518f7beec657686145104a8a76ccf33f14a6f90b02d3817062e92ea896106ec2f441507d40ed7973aa3
+  languageName: node
+  linkType: hard
 
 "@automattic/agenttic-client@npm:^0.1.50, @automattic/agenttic-client@npm:^0.1.53":
   version: 0.1.53


### PR DESCRIPTION

Fixes BSKY-1582

Depends on 305-ghe-Automattic/agenttic

## Summary
- Add `SourcesDisplay` component that renders a collapsible FoldableCard with deduplicated source links (page icon + title + chevron)
- Intercept `data` content blocks with a `sources` array in `process-tool-messages.ts` and replace them with the `SourcesDisplay` component
- Handle source link clicks with the same support-article detection logic as `CustomALink` (navigates to `/post?link=...` for support articles, records Tracks events)
- Add `@automattic/components` as an explicit dependency (was already used implicitly via `SummaryButton`)

## Context

The workflow agent (`wpcom-workflow-support_chat`) returns support article sources alongside its text responses. After agenttic-client normalizes these into `{ type: 'data', data: { sources } }` content blocks, this PR picks them up and renders a proper collapsible sources card instead of raw JSON.

## Test plan

### Setup (until the agenttic-client dependency is published)

This PR depends on unreleased changes in `@automattic/agenttic-client`. To test locally:

1. Clone the agenttic repo and checkout 305-ghe-Automattic/agenttic
2. Build and pack the client package:
   ```bash
   cd agenttic/packages/agenttic-client
   pnpm build
   pnpm pack
   ```
3. In Calypso, temporarily point the dependency to the packed tarball:
   ```diff
   # Replace all agenttic-client references
   - "@automattic/agenttic-client": "^0.1.54",
   + "@automattic/agenttic-client": "/path/to/agenttic/packages/agenttic-client/automattic-agenttic-client-0.1.54.tgz",
   ```
4. Run `yarn install` in Calypso root
5. Sync the agents manager app with your sandbox

### Testing

- [ ] Make sure the Unified Experience is enabled - https://wordpress.com/wp-admin/profile.php
- [ ] Navigate to a page where the AI Chat is available and add `?agent=wpcom-workflow-support_chat` to the URL
- [ ] Ask a question that triggers sources (e.g. "How to add a domain?")
- [ ] Verify the text answer renders normally and a collapsed "Sources" card appears
- [ ] Expand the sources card and verify source links are listed with page icon + title + chevron
- [ ] Click a source link — support articles should open in the post view, external links should open normally
- [ ] Reload the page and verify sources still appear correctly on the reloaded conversation
- [ ] Verify the sources card does not interfere with feedback action buttons (thumbs up/down)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?