### PR TITLE
Stripe UPI: Make available for free trials

### DIFF
--- a/client/my-sites/checkout/src/lib/upi-processor.ts
+++ b/client/my-sites/checkout/src/lib/upi-processor.ts
@@ -22,7 +22,9 @@ import type {
 import type { Stripe } from '@stripe/stripe-js';
 import type { LocalizeProps } from 'i18n-calypso';
 
-// stripe.confirmUpiSetup is not yet included in the installed @stripe/stripe-js types.
+// stripe.confirmUpiSetup is not yet included in the installed @stripe/stripe-js types (v1.54.2).
+// TODO: Remove this local type once @stripe/stripe-js is upgraded to a version that includes it,
+// and verify the real signature matches before removing.
 type StripeWithUpiSetup = Stripe & {
 	confirmUpiSetup: (
 		clientSecret: string,
@@ -34,7 +36,7 @@ type StripeWithUpiSetup = Stripe & {
 			mandate_data: {
 				customer_acceptance: {
 					type: 'online';
-					online: { ip_address: string; user_agent: string };
+					online: { infer_from_client: boolean };
 				};
 			};
 		}
@@ -253,8 +255,10 @@ async function confirmUpiSetupIntent(
 			customer_acceptance: {
 				type: 'online',
 				online: {
-					ip_address: '',
-					user_agent: typeof navigator !== 'undefined' ? navigator.userAgent : '',
+					// infer_from_client tells Stripe to collect the customer's IP and
+					// user agent directly from the network request, which is the correct
+					// approach for browser-initiated mandate acceptance.
+					infer_from_client: true,
 				},
 			},
 		},

--- a/client/my-sites/checkout/src/lib/upi-processor.ts
+++ b/client/my-sites/checkout/src/lib/upi-processor.ts
@@ -19,7 +19,34 @@ import type {
 	WPCOMTransactionEndpointResponse,
 	WPCOMTransactionEndpointResponseSuccess,
 } from '@automattic/wpcom-checkout';
+import type { Stripe } from '@stripe/stripe-js';
 import type { LocalizeProps } from 'i18n-calypso';
+
+// stripe.confirmUpiSetup is not yet included in the installed @stripe/stripe-js types.
+type StripeWithUpiSetup = Stripe & {
+	confirmUpiSetup: (
+		clientSecret: string,
+		data: {
+			payment_method: {
+				upi: Record< string, never >;
+				billing_details?: { name?: string };
+			};
+			mandate_data: {
+				customer_acceptance: {
+					type: 'online';
+					online: { ip_address: string; user_agent: string };
+				};
+			};
+		}
+	) => Promise< {
+		setupIntent?: {
+			next_action?: {
+				upi_qr_code?: { hosted_instructions_url: string };
+			};
+		};
+		error?: { message?: string };
+	} >;
+};
 
 type StripeUpiTransactionRequest = {
 	name: string;
@@ -108,17 +135,18 @@ export default async function upiProcessor(
 
 	return submitWpcomTransaction( formattedTransactionData, options )
 		.then( async ( response?: WPCOMTransactionEndpointResponse ) => {
-			if ( ! response?.redirect_url ) {
-				// eslint-disable-next-line no-console
-				console.error( 'Transaction response was missing required redirect url' );
-				throw new Error( genericErrorMessage );
-			}
-
-			if ( ! response.order_id ) {
+			if ( ! response?.order_id ) {
 				// eslint-disable-next-line no-console
 				console.error( 'Transaction response was missing required order ID' );
 				throw new Error( genericErrorMessage );
 			}
+
+			const redirectUrl = await getRedirectUrl(
+				response,
+				submitData,
+				options,
+				genericErrorMessage
+			);
 
 			const pendingPageUrl = addUrlToPendingPageRedirect( thankYouUrl, {
 				siteSlug,
@@ -132,7 +160,7 @@ export default async function upiProcessor(
 			let explicitClosureMessage: string | undefined;
 			displayModal( {
 				root,
-				redirectUrl: response.redirect_url,
+				redirectUrl,
 				cancel: () => {
 					safeDismissModal();
 					isModalActive = false;
@@ -169,6 +197,74 @@ export default async function upiProcessor(
 			safeDismissModal();
 			return makeErrorResponse( error.message );
 		} );
+}
+
+/**
+ * Determines the hosted instructions URL for the UPI iframe.
+ *
+ * For a regular payment (PaymentIntent), the backend confirms the Stripe intent
+ * server-side and returns the hosted_instructions_url directly as redirect_url.
+ *
+ * For a free trial (SetupIntent), the backend returns a setup_intent_client_secret
+ * that must be confirmed client-side via stripe.confirmUpiSetup(), which returns
+ * the hosted_instructions_url for the iframe.
+ */
+async function getRedirectUrl(
+	response: WPCOMTransactionEndpointResponse,
+	submitData: StripeUpiTransactionRequest,
+	options: PaymentProcessorOptions,
+	genericErrorMessage: string
+): Promise< string > {
+	const message = ( response as { message?: unknown } ).message;
+	if ( message && typeof message === 'object' && 'setup_intent_client_secret' in message ) {
+		return confirmUpiSetupIntent(
+			String( ( message as { setup_intent_client_secret: string } ).setup_intent_client_secret ),
+			submitData.name ?? '',
+			options,
+			genericErrorMessage
+		);
+	}
+
+	const redirectUrl = ( response as { redirect_url?: string } ).redirect_url;
+	if ( ! redirectUrl ) {
+		// eslint-disable-next-line no-console
+		console.error( 'Transaction response was missing required redirect url' );
+		throw new Error( genericErrorMessage );
+	}
+	return redirectUrl;
+}
+
+async function confirmUpiSetupIntent(
+	clientSecret: string,
+	name: string,
+	options: PaymentProcessorOptions,
+	genericErrorMessage: string
+): Promise< string > {
+	if ( ! options.stripe ) {
+		throw new Error( genericErrorMessage );
+	}
+	const stripe = options.stripe as unknown as StripeWithUpiSetup;
+	const { setupIntent, error } = await stripe.confirmUpiSetup( clientSecret, {
+		payment_method: {
+			upi: {},
+			billing_details: { name },
+		},
+		mandate_data: {
+			customer_acceptance: {
+				type: 'online',
+				online: {
+					ip_address: '',
+					user_agent: typeof navigator !== 'undefined' ? navigator.userAgent : '',
+				},
+			},
+		},
+	} );
+	if ( error || ! setupIntent?.next_action?.upi_qr_code?.hosted_instructions_url ) {
+		// eslint-disable-next-line no-console
+		console.error( 'Failed to confirm UPI setup intent', error );
+		throw new Error( genericErrorMessage );
+	}
+	return setupIntent.next_action.upi_qr_code.hosted_instructions_url;
 }
 
 async function pollForOrderStatus(

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -38,7 +38,7 @@ export type WPCOMTransactionEndpointResponseFailed = {
 };
 
 export type WPCOMTransactionEndpointResponseRedirect = {
-	message: { payment_intent_client_secret: string } | '';
+	message: { payment_intent_client_secret: string } | { setup_intent_client_secret: string } | '';
 	order_id: number | '';
 	redirect_url: string;
 	qr_code?: string;


### PR DESCRIPTION
Part of SHILL-1767
Requires backend PR before launch.

## Proposed Changes

* Adds support for UPI as a payment method when the purchase involves a free trial (SetupIntent flow).
* When the backend returns a `setup_intent_client_secret` instead of a `redirect_url`, the client now confirms the UPI SetupIntent via `stripe.confirmUpiSetup()` and retrieves the hosted instructions URL from the result.
* Extends `WPCOMTransactionEndpointResponseRedirect` to allow `setup_intent_client_secret` in the `message` field alongside the existing `payment_intent_client_secret`.

## Why are these changes being made?

* UPI was not appearing as a payment method option during free trial purchases (e.g. Professional Email subscriptions). Because UPI payment methods are rechargeable, they are eligible for use with SetupIntents, which is the mechanism Stripe uses for free trials. Previously only the PaymentIntent (non-free-trial) flow was handled, so UPI was excluded from free trial checkout.

## Testing Instructions

* Start a free trial purchase (e.g. Professional Email) with a UPI-eligible account.
* Confirm UPI appears as a payment method option at checkout.
* Complete the UPI flow and verify the QR code / hosted instructions page is displayed correctly.
* Also verify that the non-free-trial UPI flow (PaymentIntent) still works as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?