### PR TITLE
Fix READ-313: Reader Recommended blogs on subscribe action: subscribed blog recommended

### DIFF
--- a/client/blocks/reader-suggested-follows/hooks/use-recommend-or-related-sites-query/index.ts
+++ b/client/blocks/reader-suggested-follows/hooks/use-recommend-or-related-sites-query/index.ts
@@ -61,7 +61,15 @@ export const useRecommendOrRelatedSitesQuery = ( query: QueryParams, options?: Q
 		enabled: shouldLoadRelatedSites && enabled,
 	} );
 
-	const data = recommendedFeeds?.length > 0 ? recommendedFeeds : relatedSites;
+	// Filter out the current site from recommendations so the user doesn't see
+	// the blog they just subscribed to in the suggested follows dialog.
+	const filteredRecommendedFeeds = recommendedFeeds?.filter(
+		( feed ) => String( feed.siteId ) !== String( siteId )
+	);
+	const filteredRelatedSites = relatedSites?.filter( ( site ) => site.site_ID !== siteId );
+
+	const data =
+		filteredRecommendedFeeds?.length > 0 ? filteredRecommendedFeeds : filteredRelatedSites;
 	const isLoading = isLoadingRecommendedFeeds || isLoadingRelatedSites;
 	const isFetched = isFetchedRecommendedFeeds || isFetchedRelatedSites;
 
@@ -69,6 +77,6 @@ export const useRecommendOrRelatedSitesQuery = ( query: QueryParams, options?: Q
 		data: isFetched ? data : [],
 		isLoading,
 		isFetched,
-		resourceType: getResourceType( recommendedFeeds, relatedSites ),
+		resourceType: getResourceType( filteredRecommendedFeeds, filteredRelatedSites ),
 	};
 };

--- a/client/blocks/reader-suggested-follows/hooks/use-recommend-or-related-sites-query/test/index.test.ts
+++ b/client/blocks/reader-suggested-follows/hooks/use-recommend-or-related-sites-query/test/index.test.ts
@@ -181,6 +181,75 @@ describe( 'useRecommendOrRelatedSitesQuery', () => {
 		} );
 	} );
 
+	it( 'filters out the current site from recommended feeds', () => {
+		const mockRecommendedFeeds = [
+			{ ID: '1', name: 'Other Blog', feedId: '10', siteId: '999' },
+			{ ID: '2', name: 'Current Blog', feedId: '20', siteId: '123' },
+		];
+
+		( useFeedRecommendationsQuery as jest.Mock ).mockReturnValue( {
+			data: mockRecommendedFeeds,
+			isLoading: false,
+			isFetched: true,
+		} );
+
+		const { result } = renderHook( () =>
+			useRecommendOrRelatedSitesQuery( { author: fakeAuthor, siteId: 123, postId: 456 } )
+		);
+
+		expect( result.current.data ).toEqual( [
+			{ ID: '1', name: 'Other Blog', feedId: '10', siteId: '999' },
+		] );
+		expect( result.current.resourceType ).toBe( 'recommended' );
+	} );
+
+	it( 'filters out the current site from related sites', () => {
+		( useFeedRecommendationsQuery as jest.Mock ).mockReturnValue( {
+			data: [],
+			isLoading: false,
+			isFetched: true,
+		} );
+
+		( useRelatedSites as jest.Mock ).mockReturnValue( {
+			data: [
+				{ global_ID: 'a', site_ID: 999, name: 'Other Site' },
+				{ global_ID: 'b', site_ID: 123, name: 'Current Site' },
+			],
+			isLoading: false,
+			isFetched: true,
+		} );
+
+		const { result } = renderHook( () =>
+			useRecommendOrRelatedSitesQuery( { siteId: 123, postId: 456 } )
+		);
+
+		expect( result.current.data ).toEqual( [
+			{ global_ID: 'a', site_ID: 999, name: 'Other Site' },
+		] );
+		expect( result.current.resourceType ).toBe( 'related' );
+	} );
+
+	it( 'returns empty when all recommended feeds match the current site', () => {
+		( useFeedRecommendationsQuery as jest.Mock ).mockReturnValue( {
+			data: [ { ID: '1', name: 'Current Blog', feedId: '10', siteId: '123' } ],
+			isLoading: false,
+			isFetched: true,
+		} );
+
+		( useRelatedSites as jest.Mock ).mockReturnValue( {
+			data: [],
+			isLoading: false,
+			isFetched: true,
+		} );
+
+		const { result } = renderHook( () =>
+			useRecommendOrRelatedSitesQuery( { author: fakeAuthor, siteId: 123, postId: 456 } )
+		);
+
+		expect( result.current.data ).toEqual( [] );
+		expect( result.current.resourceType ).toBeNull();
+	} );
+
 	it( 'returns an empty array when there is no recommended or related sites', () => {
 		( useFeedRecommendationsQuery as jest.Mock ).mockReturnValue( {
 			data: [],


### PR DESCRIPTION
## Summary
- Filters the currently subscribed blog from the recommended/related sites shown in the suggested follows dialog
- When a user subscribes to a blog and the recommended blogs modal appears, the blog they just subscribed to is no longer included in the list
- Filtering is applied in `useRecommendOrRelatedSitesQuery` hook for both recommended feeds (`siteId`) and related sites (`site_ID`)

Fixes: READ-313

## Test plan
- [ ] Go to a blog feed page (e.g., `/reader/feeds/<id>`)
- [ ] Subscribe to the blog
- [ ] Verify the recommended blogs modal does not include the blog just subscribed to
- [ ] Verify other recommended/related blogs still appear correctly
- [ ] Verify modal auto-closes if filtering removes all results

🤖 Generated with [Claude Code](https://claude.com/claude-code)