### PR TITLE
FORNO-304: Add @automattic/jetpack-ai-sidebar package

### DIFF
--- a/apps/agents-manager/jetpack-ai-sidebar.js
+++ b/apps/agents-manager/jetpack-ai-sidebar.js
@@ -17,6 +17,7 @@ import {
 	getChatComponent,
 	getEmptyViewSuggestions,
 	useSuggestions,
+	useCheckpoint,
 } from '@automattic/jetpack-ai-sidebar';
 
 // Expose on window for the ESM wrapper to re-export
@@ -27,4 +28,5 @@ window.__JetpackAIProvider = {
 	getChatComponent,
 	getEmptyViewSuggestions,
 	useSuggestions,
+	useCheckpoint,
 };

--- a/apps/agents-manager/jetpack-ai-sidebar.js
+++ b/apps/agents-manager/jetpack-ai-sidebar.js
@@ -3,7 +3,7 @@
  *
  * Entry point for the standalone Jetpack AI sidebar provider bundle.
  * This is built as an IIFE and loaded by the PHP loader in Jetpack.
- * The ESM wrapper (jetpack-ai-provider-esm.mjs) re-exports from
+ * The ESM wrapper (jetpack-ai-sidebar.provider.mjs) re-exports from
  * window.__JetpackAIProvider for Agents Manager to consume.
  */
 

--- a/apps/agents-manager/jetpack-ai-sidebar.js
+++ b/apps/agents-manager/jetpack-ai-sidebar.js
@@ -1,0 +1,30 @@
+/**
+ * Jetpack AI Sidebar Entry Point
+ *
+ * Entry point for the standalone Jetpack AI sidebar provider bundle.
+ * This is built as an IIFE and loaded by the PHP loader in Jetpack.
+ * The ESM wrapper (jetpack-ai-provider-esm.mjs) re-exports from
+ * window.__JetpackAIProvider for Agents Manager to consume.
+ */
+
+/**
+ * External dependencies
+ */
+import {
+	useAbilitiesSetup,
+	toolProvider,
+	contextProvider,
+	getChatComponent,
+	getEmptyViewSuggestions,
+	useSuggestions,
+} from '@automattic/jetpack-ai-sidebar';
+
+// Expose on window for the ESM wrapper to re-export
+window.__JetpackAIProvider = {
+	useAbilitiesSetup,
+	toolProvider,
+	contextProvider,
+	getChatComponent,
+	getEmptyViewSuggestions,
+	useSuggestions,
+};

--- a/apps/agents-manager/jetpack-ai-sidebar.provider.mjs
+++ b/apps/agents-manager/jetpack-ai-sidebar.provider.mjs
@@ -18,6 +18,7 @@ export const getChatComponent = lazy( 'getChatComponent' );
 export const getEmptyViewSuggestions = lazy( 'getEmptyViewSuggestions' );
 export const useSuggestions = lazy( 'useSuggestions' );
 export const useAbilitiesSetup = lazy( 'useAbilitiesSetup' );
+export const useCheckpoint = lazy( 'useCheckpoint' );
 
 // toolProvider and contextProvider are objects, not functions — use getters.
 export const toolProvider = new Proxy(

--- a/apps/agents-manager/jetpack-ai-sidebar.provider.mjs
+++ b/apps/agents-manager/jetpack-ai-sidebar.provider.mjs
@@ -1,0 +1,14 @@
+/**
+ * ESM provider wrapper for the Jetpack AI sidebar.
+ *
+ * The IIFE bundle (jetpack-ai-sidebar.min.js) assigns exports to
+ * window.__JetpackAIProvider. This thin ESM re-exports them so
+ * Agents Manager can load the provider via dynamic import().
+ */
+const p = window.__JetpackAIProvider || {};
+export const getChatComponent = p.getChatComponent;
+export const getEmptyViewSuggestions = p.getEmptyViewSuggestions;
+export const useSuggestions = p.useSuggestions;
+export const toolProvider = p.toolProvider;
+export const contextProvider = p.contextProvider;
+export const useAbilitiesSetup = p.useAbilitiesSetup;

--- a/apps/agents-manager/jetpack-ai-sidebar.provider.mjs
+++ b/apps/agents-manager/jetpack-ai-sidebar.provider.mjs
@@ -4,11 +4,27 @@
  * The IIFE bundle (jetpack-ai-sidebar.min.js) assigns exports to
  * window.__JetpackAIProvider. This thin ESM re-exports them so
  * Agents Manager can load the provider via dynamic import().
+ *
+ * Uses a lazy proxy so exports resolve at access time, not at module
+ * evaluation time. This avoids a race if AM imports this module
+ * before the IIFE has executed.
  */
-const p = window.__JetpackAIProvider || {};
-export const getChatComponent = p.getChatComponent;
-export const getEmptyViewSuggestions = p.getEmptyViewSuggestions;
-export const useSuggestions = p.useSuggestions;
-export const toolProvider = p.toolProvider;
-export const contextProvider = p.contextProvider;
-export const useAbilitiesSetup = p.useAbilitiesSetup;
+const lazy = ( key ) => ( ...args ) => {
+	const fn = window.__JetpackAIProvider?.[ key ];
+	return typeof fn === 'function' ? fn( ...args ) : undefined;
+};
+
+export const getChatComponent = lazy( 'getChatComponent' );
+export const getEmptyViewSuggestions = lazy( 'getEmptyViewSuggestions' );
+export const useSuggestions = lazy( 'useSuggestions' );
+export const useAbilitiesSetup = lazy( 'useAbilitiesSetup' );
+
+// toolProvider and contextProvider are objects, not functions — use getters.
+export const toolProvider = new Proxy(
+	{},
+	{ get: ( _, prop ) => window.__JetpackAIProvider?.toolProvider?.[ prop ] }
+);
+export const contextProvider = new Proxy(
+	{},
+	{ get: ( _, prop ) => window.__JetpackAIProvider?.contextProvider?.[ prop ] }
+);

--- a/apps/agents-manager/package.json
+++ b/apps/agents-manager/package.json
@@ -48,6 +48,7 @@
 		"@automattic/wp-babel-makepot": "workspace:^",
 		"@wordpress/dependency-extraction-webpack-plugin": "^6.24.0",
 		"@wordpress/readable-js-assets-webpack-plugin": "^3.24.0",
+		"copy-webpack-plugin": "^10.2.4",
 		"webpack": "^5.99.8"
 	},
 	"peerDependencies": {

--- a/apps/agents-manager/package.json
+++ b/apps/agents-manager/package.json
@@ -34,6 +34,7 @@
 		"@automattic/block-notes": "workspace:^",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/image-studio": "workspace:^",
+		"@automattic/jetpack-ai-sidebar": "workspace:^",
 		"@tanstack/react-query": "^5.83.0",
 		"@wordpress/components": "^28.23.0",
 		"@wordpress/compose": "^7.23.0",

--- a/apps/agents-manager/webpack.config.js
+++ b/apps/agents-manager/webpack.config.js
@@ -79,7 +79,9 @@ function getIndividualConfig( options = {} ) {
 					// Bundle @wordpress/abilities into image-studio so it works on
 					// self-hosted sites where the package isn't registered as a script.
 					if (
-						( name === 'image-studio' || name === 'block-notes' ) &&
+						( name === 'image-studio' ||
+							name === 'block-notes' ||
+							name === 'jetpack-ai-sidebar' ) &&
 						request === '@wordpress/abilities'
 					) {
 						return null;
@@ -108,6 +110,7 @@ function getWebpackConfig( env = { source: '' }, argv = {} ) {
 		getIndividualConfig( { env, argv, name: 'agents-manager-gutenberg' } ),
 		getIndividualConfig( { env, argv, name: 'agents-manager-wp-admin' } ),
 		getIndividualConfig( { env, argv, name: 'image-studio' } ),
+		getIndividualConfig( { env, argv, name: 'jetpack-ai-sidebar' } ),
 		getIndividualConfig( { env, argv, name: 'agents-manager-gutenberg-disconnected' } ),
 		getIndividualConfig( { env, argv, name: 'agents-manager-wp-admin-disconnected' } ),
 		getIndividualConfig( { env, argv, name: 'agents-manager-ciab-disconnected' } ),

--- a/apps/agents-manager/webpack.config.js
+++ b/apps/agents-manager/webpack.config.js
@@ -2,6 +2,7 @@ const path = require( 'path' );
 const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );
 const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
 const ReadableJsAssetsWebpackPlugin = require( '@wordpress/readable-js-assets-webpack-plugin' );
+const CopyPlugin = require( 'copy-webpack-plugin' );
 const webpack = require( 'webpack' );
 const GenerateChunksMapPlugin = require( '../../build-tools/webpack/generate-chunks-map-plugin' );
 
@@ -106,7 +107,19 @@ function getIndividualConfig( options = {} ) {
 function getWebpackConfig( env = { source: '' }, argv = {} ) {
 	env.WP = true;
 
-	return [
+	// Copy the ESM provider wrapper for jetpack-ai-sidebar to dist.
+	// This file is pure ESM and doesn't need webpack processing — AM
+	// loads it via dynamic import() at runtime.
+	const copyEsmProviders = new CopyPlugin( {
+		patterns: [
+			{
+				from: path.join( __dirname, 'jetpack-ai-sidebar.provider.mjs' ),
+				to: path.join( __dirname, 'dist', 'jetpack-ai-sidebar.provider.mjs' ),
+			},
+		],
+	} );
+
+	const configs = [
 		getIndividualConfig( { env, argv, name: 'agents-manager-gutenberg' } ),
 		getIndividualConfig( { env, argv, name: 'agents-manager-wp-admin' } ),
 		getIndividualConfig( { env, argv, name: 'image-studio' } ),
@@ -118,6 +131,11 @@ function getWebpackConfig( env = { source: '' }, argv = {} ) {
 		getIndividualConfig( { env, argv, name: 'agents-manager-ciab' } ),
 		getIndividualConfig( { env, argv, name: 'agents-manager-wooai' } ),
 	];
+
+	// Attach the copy plugin to the first config.
+	configs[ 0 ].plugins.push( copyEsmProviders );
+
+	return configs;
 }
 
 module.exports = getWebpackConfig;

--- a/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
+++ b/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
@@ -83,6 +83,11 @@ export function useEmptyViewSuggestions( {
 			const suggestions = loadedProviders.getEmptyViewSuggestions?.();
 			if ( suggestions && suggestions.length > 0 ) {
 				setEmptyViewSuggestions( suggestions );
+			} else {
+				// Provider exists but returned empty/undefined (e.g. lazy proxy
+				// race where the IIFE hasn't set window globals yet). Fall back
+				// to defaults so the AM still renders.
+				setEmptyViewSuggestions( defaultSuggestions );
 			}
 		}
 	}, [

--- a/packages/agents-manager/src/hooks/use-zoom-action.ts
+++ b/packages/agents-manager/src/hooks/use-zoom-action.ts
@@ -17,11 +17,17 @@ export default function useZoomAction( registerMessageActions: RegisterMessageAc
 					return [];
 				}
 
-				// Only show zoom on `show_component` tool messages.
+				// Only show zoom on `show_component` tool messages, and let
+				// individual component types opt out via `data.hideZoomAction`
+				// (e.g. title-picker doesn't need canvas zoom — it edits the
+				// post title, not block content).
 				const firstPartText = message.content?.[ 0 ]?.text ?? '';
 				try {
 					const parsed = JSON.parse( firstPartText );
 					if ( parsed.tool_id !== 'big_sky__show_component' ) {
+						return [];
+					}
+					if ( parsed.data?.hideZoomAction ) {
 						return [];
 					}
 				} catch {

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -210,57 +210,68 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 	const allUseSuggestions: UseSuggestionsHook[] = [];
 	const allGetEmptyViewSuggestions: ( () => Suggestion[] )[] = [];
 
-	for ( const moduleId of agentProviders ) {
-		try {
-			// Dynamic import of registered script module
-			// The webpackIgnore comment tells webpack not to bundle this - it's loaded at runtime
-			const module = await import( /* webpackIgnore: true */ moduleId );
+	// Load all providers in parallel to avoid serializing network/module fetches.
+	// Results are processed in registration order to preserve first-write-wins semantics.
+	const loadedModules = await Promise.all(
+		agentProviders.map( async ( moduleId ) => {
+			try {
+				// Dynamic import of registered script module
+				// The webpackIgnore comment tells webpack not to bundle this - it's loaded at runtime
+				const module = await import( /* webpackIgnore: true */ moduleId );
+				// eslint-disable-next-line no-console
+				console.log( `[AgentsManager] Loaded provider "${ moduleId }"` );
+				return module;
+			} catch ( error ) {
+				// eslint-disable-next-line no-console
+				console.warn( `[AgentsManager] Failed to load provider "${ moduleId }":`, error );
+				return null;
+			}
+		} )
+	);
 
-			// These exports are merged across all providers.
-			if ( module.toolProvider ) {
-				allToolProviders.push( module.toolProvider );
-			}
-			if ( module.getChatComponent ) {
-				allGetChatComponents.push( module.getChatComponent );
-			}
-			if ( module.useAbilitiesSetup ) {
-				allAbilitiesSetups.push( module.useAbilitiesSetup );
-			}
-			if ( module.useSuggestions ) {
-				allUseSuggestions.push( module.useSuggestions );
-			}
-			if ( module.getEmptyViewSuggestions ) {
-				allGetEmptyViewSuggestions.push( module.getEmptyViewSuggestions );
-			}
+	for ( const module of loadedModules ) {
+		if ( ! module ) {
+			continue;
+		}
 
-			// First-write-wins for singleton exports.
-			if ( module.contextProvider && ! mergedContextProvider ) {
-				mergedContextProvider = module.contextProvider;
-			}
-			if ( module.markdownComponents && ! mergedMarkdownComponents ) {
-				mergedMarkdownComponents = module.markdownComponents;
-			}
-			if ( module.markdownExtensions && ! mergedMarkdownExtensions ) {
-				mergedMarkdownExtensions = module.markdownExtensions;
-			}
-			if ( module.useNavigationContinuation && ! mergedNavigationContinuation ) {
-				mergedNavigationContinuation = module.useNavigationContinuation;
-			}
-			if ( module.siteBuildUtils && ! mergedSiteBuildUtils ) {
-				mergedSiteBuildUtils = module.siteBuildUtils;
-			}
-			if ( module.useImageUpload && ! mergedImageUpload ) {
-				mergedImageUpload = module.useImageUpload;
-			}
-			if ( module.useCheckpoint && ! mergedUseCheckpoint ) {
-				mergedUseCheckpoint = module.useCheckpoint;
-			}
+		// These exports are merged across all providers.
+		if ( module.toolProvider ) {
+			allToolProviders.push( module.toolProvider );
+		}
+		if ( module.getChatComponent ) {
+			allGetChatComponents.push( module.getChatComponent );
+		}
+		if ( module.useAbilitiesSetup ) {
+			allAbilitiesSetups.push( module.useAbilitiesSetup );
+		}
+		if ( module.useSuggestions ) {
+			allUseSuggestions.push( module.useSuggestions );
+		}
+		if ( module.getEmptyViewSuggestions ) {
+			allGetEmptyViewSuggestions.push( module.getEmptyViewSuggestions );
+		}
 
-			// eslint-disable-next-line no-console
-			console.log( `[AgentsManager] Loaded provider "${ moduleId }"` );
-		} catch ( error ) {
-			// eslint-disable-next-line no-console
-			console.warn( `[AgentsManager] Failed to load provider "${ moduleId }":`, error );
+		// First-write-wins for singleton exports.
+		if ( module.contextProvider && ! mergedContextProvider ) {
+			mergedContextProvider = module.contextProvider;
+		}
+		if ( module.markdownComponents && ! mergedMarkdownComponents ) {
+			mergedMarkdownComponents = module.markdownComponents;
+		}
+		if ( module.markdownExtensions && ! mergedMarkdownExtensions ) {
+			mergedMarkdownExtensions = module.markdownExtensions;
+		}
+		if ( module.useNavigationContinuation && ! mergedNavigationContinuation ) {
+			mergedNavigationContinuation = module.useNavigationContinuation;
+		}
+		if ( module.siteBuildUtils && ! mergedSiteBuildUtils ) {
+			mergedSiteBuildUtils = module.siteBuildUtils;
+		}
+		if ( module.useImageUpload && ! mergedImageUpload ) {
+			mergedImageUpload = module.useImageUpload;
+		}
+		if ( module.useCheckpoint && ! mergedUseCheckpoint ) {
+			mergedUseCheckpoint = module.useCheckpoint;
 		}
 	}
 
@@ -268,36 +279,39 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 	// resolution order of every other merged provider export (contextProvider,
 	// getChatComponent, useSuggestions, etc). Providers are processed in the
 	// order they were registered; earlier providers win on ability-name
-	// collisions, and executeAbility tries earlier providers first.
+	// collisions.
 	if ( allToolProviders.length === 1 ) {
 		mergedToolProvider = allToolProviders[ 0 ];
 	} else if ( allToolProviders.length > 1 ) {
-		mergedToolProvider = {
-			getAbilities: async () => {
-				const results = await Promise.all( allToolProviders.map( ( tp ) => tp.getAbilities() ) );
-				const seen = new Map< string, unknown >();
-				for ( const abilities of results ) {
-					for ( const ability of abilities ) {
-						if ( ! seen.has( ability.name ) ) {
-							seen.set( ability.name, ability );
-						}
-					}
+		// Fetch all abilities once and build a name→provider map so that
+		// executeAbility can look up the owning provider in O(1) instead of
+		// re-querying getAbilities() on every call.
+		const allAbilityResults = await Promise.all(
+			allToolProviders.map( ( tp ) => tp.getAbilities() )
+		);
+		const abilityProviderMap = new Map< string, ToolProvider >();
+		const seenAbilities = new Map< string, unknown >();
+		for ( let i = 0; i < allToolProviders.length; i++ ) {
+			for ( const ability of allAbilityResults[ i ] ) {
+				if ( ! abilityProviderMap.has( ability.name ) ) {
+					abilityProviderMap.set( ability.name, allToolProviders[ i ] );
+					seenAbilities.set( ability.name, ability );
 				}
-				return [ ...seen.values() ] as Awaited< ReturnType< ToolProvider[ 'getAbilities' ] > >;
-			},
+			}
+		}
+		const cachedAbilities = [ ...seenAbilities.values() ] as Awaited<
+			ReturnType< ToolProvider[ 'getAbilities' ] >
+		>;
+
+		mergedToolProvider = {
+			getAbilities: async () => cachedAbilities,
 			executeAbility: async ( name: string, args: unknown ) => {
-				// Identify the owning provider by walking `getAbilities` in the
-				// same order as the dedupe above (first-write-wins), then
-				// delegate to that single provider. This avoids the older
-				// approach of iterating with `try/catch { /* try next */ }`,
-				// which silently swallowed real errors from a provider that
-				// DID own the ability but genuinely failed.
-				for ( const provider of allToolProviders ) {
-					const abilities = await provider.getAbilities();
-					const owns = abilities.some( ( a: { name?: string } ) => a?.name === name );
-					if ( owns ) {
-						return provider.executeAbility( name, args );
-					}
+				// Use the pre-built map — avoids re-querying getAbilities() on
+				// every call and surfaces real errors from the owning provider
+				// instead of silently swallowing them.
+				const provider = abilityProviderMap.get( name );
+				if ( provider ) {
+					return provider.executeAbility( name, args );
 				}
 				throw new Error( `No provider handled ability: ${ name }` );
 			},

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -264,7 +264,11 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 		}
 	}
 
-	// Merge toolProviders: chain getAbilities (dedupe by name), chain executeAbility.
+	// Merge toolProviders: first-write-wins by ability name, matching the
+	// resolution order of every other merged provider export (contextProvider,
+	// getChatComponent, useSuggestions, etc). Providers are processed in the
+	// order they were registered; earlier providers win on ability-name
+	// collisions, and executeAbility tries earlier providers first.
 	if ( allToolProviders.length === 1 ) {
 		mergedToolProvider = allToolProviders[ 0 ];
 	} else if ( allToolProviders.length > 1 ) {
@@ -274,17 +278,25 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 				const seen = new Map< string, unknown >();
 				for ( const abilities of results ) {
 					for ( const ability of abilities ) {
-						seen.set( ability.name, ability );
+						if ( ! seen.has( ability.name ) ) {
+							seen.set( ability.name, ability );
+						}
 					}
 				}
 				return [ ...seen.values() ] as Awaited< ReturnType< ToolProvider[ 'getAbilities' ] > >;
 			},
 			executeAbility: async ( name: string, args: unknown ) => {
-				for ( let i = allToolProviders.length - 1; i >= 0; i-- ) {
-					try {
-						return await allToolProviders[ i ].executeAbility( name, args );
-					} catch {
-						// Try next provider
+				// Identify the owning provider by walking `getAbilities` in the
+				// same order as the dedupe above (first-write-wins), then
+				// delegate to that single provider. This avoids the older
+				// approach of iterating with `try/catch { /* try next */ }`,
+				// which silently swallowed real errors from a provider that
+				// DID own the ability but genuinely failed.
+				for ( const provider of allToolProviders ) {
+					const abilities = await provider.getAbilities();
+					const owns = abilities.some( ( a: { name?: string } ) => a?.name === name );
+					if ( owns ) {
+						return provider.executeAbility( name, args );
 					}
 				}
 				throw new Error( `No provider handled ability: ${ name }` );

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -203,46 +203,56 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 	let mergedImageUpload: ImageUploadHook | undefined;
 	let mergedUseCheckpoint: UseCheckpointHook | undefined;
 
+	// Collect exports that need to be merged across all providers.
+	const allToolProviders: ToolProvider[] = [];
+	const allGetChatComponents: GetChatComponent[] = [];
+	const allAbilitiesSetups: AbilitiesSetupHook[] = [];
+	const allUseSuggestions: UseSuggestionsHook[] = [];
+	const allGetEmptyViewSuggestions: ( () => Suggestion[] )[] = [];
+
 	for ( const moduleId of agentProviders ) {
 		try {
 			// Dynamic import of registered script module
 			// The webpackIgnore comment tells webpack not to bundle this - it's loaded at runtime
 			const module = await import( /* webpackIgnore: true */ moduleId );
 
+			// These exports are merged across all providers.
 			if ( module.toolProvider ) {
-				mergedToolProvider = module.toolProvider;
-			}
-			if ( module.contextProvider ) {
-				mergedContextProvider = module.contextProvider;
-			}
-			if ( module.getEmptyViewSuggestions ) {
-				mergedGetEmptyViewSuggestions = module.getEmptyViewSuggestions;
-			}
-			if ( module.markdownComponents ) {
-				mergedMarkdownComponents = module.markdownComponents;
-			}
-			if ( module.markdownExtensions ) {
-				mergedMarkdownExtensions = module.markdownExtensions;
-			}
-			if ( module.useNavigationContinuation ) {
-				mergedNavigationContinuation = module.useNavigationContinuation;
-			}
-			if ( module.useAbilitiesSetup ) {
-				mergedAbilitiesSetup = module.useAbilitiesSetup;
-			}
-			if ( module.useSuggestions ) {
-				mergedUseSuggestions = module.useSuggestions;
+				allToolProviders.push( module.toolProvider );
 			}
 			if ( module.getChatComponent ) {
-				mergedGetChatComponent = module.getChatComponent;
+				allGetChatComponents.push( module.getChatComponent );
 			}
-			if ( module.siteBuildUtils ) {
+			if ( module.useAbilitiesSetup ) {
+				allAbilitiesSetups.push( module.useAbilitiesSetup );
+			}
+			if ( module.useSuggestions ) {
+				allUseSuggestions.push( module.useSuggestions );
+			}
+			if ( module.getEmptyViewSuggestions ) {
+				allGetEmptyViewSuggestions.push( module.getEmptyViewSuggestions );
+			}
+
+			// First-write-wins for singleton exports.
+			if ( module.contextProvider && ! mergedContextProvider ) {
+				mergedContextProvider = module.contextProvider;
+			}
+			if ( module.markdownComponents && ! mergedMarkdownComponents ) {
+				mergedMarkdownComponents = module.markdownComponents;
+			}
+			if ( module.markdownExtensions && ! mergedMarkdownExtensions ) {
+				mergedMarkdownExtensions = module.markdownExtensions;
+			}
+			if ( module.useNavigationContinuation && ! mergedNavigationContinuation ) {
+				mergedNavigationContinuation = module.useNavigationContinuation;
+			}
+			if ( module.siteBuildUtils && ! mergedSiteBuildUtils ) {
 				mergedSiteBuildUtils = module.siteBuildUtils;
 			}
-			if ( module.useImageUpload ) {
+			if ( module.useImageUpload && ! mergedImageUpload ) {
 				mergedImageUpload = module.useImageUpload;
 			}
-			if ( module.useCheckpoint ) {
+			if ( module.useCheckpoint && ! mergedUseCheckpoint ) {
 				mergedUseCheckpoint = module.useCheckpoint;
 			}
 
@@ -252,6 +262,99 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 			// eslint-disable-next-line no-console
 			console.warn( `[AgentsManager] Failed to load provider "${ moduleId }":`, error );
 		}
+	}
+
+	// Merge toolProviders: chain getAbilities (dedupe by name), chain executeAbility.
+	if ( allToolProviders.length === 1 ) {
+		mergedToolProvider = allToolProviders[ 0 ];
+	} else if ( allToolProviders.length > 1 ) {
+		mergedToolProvider = {
+			getAbilities: async () => {
+				const results = await Promise.all( allToolProviders.map( ( tp ) => tp.getAbilities() ) );
+				const seen = new Map< string, unknown >();
+				for ( const abilities of results ) {
+					for ( const ability of abilities ) {
+						seen.set( ability.name, ability );
+					}
+				}
+				return [ ...seen.values() ] as Awaited< ReturnType< ToolProvider[ 'getAbilities' ] > >;
+			},
+			executeAbility: async ( name: string, args: unknown ) => {
+				for ( let i = allToolProviders.length - 1; i >= 0; i-- ) {
+					try {
+						return await allToolProviders[ i ].executeAbility( name, args );
+					} catch {
+						// Try next provider
+					}
+				}
+				throw new Error( `No provider handled ability: ${ name }` );
+			},
+		};
+	}
+
+	// Merge getChatComponent: try each provider, return first non-null.
+	if ( allGetChatComponents.length === 1 ) {
+		mergedGetChatComponent = allGetChatComponents[ 0 ];
+	} else if ( allGetChatComponents.length > 1 ) {
+		mergedGetChatComponent = ( ( type: string ) => {
+			for ( const fn of allGetChatComponents ) {
+				const result = fn( type as ChatComponentType );
+				if ( result ) {
+					return result;
+				}
+			}
+			return null;
+		} ) as GetChatComponent;
+	}
+
+	// Merge useAbilitiesSetup: call ALL providers' hooks.
+	if ( allAbilitiesSetups.length === 1 ) {
+		mergedAbilitiesSetup = allAbilitiesSetups[ 0 ];
+	} else if ( allAbilitiesSetups.length > 1 ) {
+		mergedAbilitiesSetup = ( ( actions ) => {
+			for ( const fn of allAbilitiesSetups ) {
+				fn( actions );
+			}
+		} ) as AbilitiesSetupHook;
+	}
+
+	// Merge useSuggestions: combine from all providers, dedupe by id.
+	if ( allUseSuggestions.length === 1 ) {
+		mergedUseSuggestions = allUseSuggestions[ 0 ];
+	} else if ( allUseSuggestions.length > 1 ) {
+		mergedUseSuggestions = ( ( maxSuggestions?: number ) => {
+			const combined: Suggestion[] = [];
+			const seenIds = new Set< string >();
+			for ( const hook of allUseSuggestions ) {
+				const { suggestions } = hook( maxSuggestions );
+				for ( const s of suggestions ) {
+					if ( ! seenIds.has( s.id ) ) {
+						seenIds.add( s.id );
+						combined.push( s );
+					}
+				}
+			}
+			return { suggestions: combined };
+		} ) as UseSuggestionsHook;
+	}
+
+	// Merge getEmptyViewSuggestions: combine from all providers, dedupe by id.
+	if ( allGetEmptyViewSuggestions.length === 1 ) {
+		mergedGetEmptyViewSuggestions = allGetEmptyViewSuggestions[ 0 ];
+	} else if ( allGetEmptyViewSuggestions.length > 1 ) {
+		mergedGetEmptyViewSuggestions = () => {
+			const combined: Suggestion[] = [];
+			const seenIds = new Set< string >();
+			for ( const fn of allGetEmptyViewSuggestions ) {
+				for ( const s of fn() ) {
+					if ( ! seenIds.has( s.id ) ) {
+						seenIds.add( s.id );
+						combined.push( s );
+					}
+				}
+			}
+			return combined;
+		};
 	}
 
 	return {

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -287,14 +287,30 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 		// executeAbility can look up the owning provider in O(1) instead of
 		// re-querying getAbilities() on every call.
 		const allAbilityResults = await Promise.all(
-			allToolProviders.map( ( tp ) => tp.getAbilities() )
+			allToolProviders.map( async ( tp ) => {
+				try {
+					return await tp.getAbilities();
+				} catch ( error ) {
+					// eslint-disable-next-line no-console
+					console.warn( '[AgentsManager] Failed to load abilities from provider:', error );
+					return [];
+				}
+			} )
 		);
 		const abilityProviderMap = new Map< string, ToolProvider >();
 		const seenAbilities = new Map< string, unknown >();
+		// Normalize ability names: AM converts `/` → `__` and `-` → `_`
+		// when routing tool calls. Index both raw and normalized forms
+		// so executeAbility matches regardless of which form the caller uses.
+		const normalize = ( name: string ) => name.replace( /\//g, '__' ).replace( /-/g, '_' );
 		for ( let i = 0; i < allToolProviders.length; i++ ) {
 			for ( const ability of allAbilityResults[ i ] ) {
 				if ( ! abilityProviderMap.has( ability.name ) ) {
 					abilityProviderMap.set( ability.name, allToolProviders[ i ] );
+					const normalized = normalize( ability.name );
+					if ( normalized !== ability.name ) {
+						abilityProviderMap.set( normalized, allToolProviders[ i ] );
+					}
 					seenAbilities.set( ability.name, ability );
 				}
 			}

--- a/packages/jetpack-ai-sidebar/AGENTS.md
+++ b/packages/jetpack-ai-sidebar/AGENTS.md
@@ -1,0 +1,102 @@
+# Jetpack AI Sidebar
+
+Agents Manager (AM) provider for the Jetpack AI sidebar in Gutenberg. Bridges the WordPress block editor with the AM chat interface via tools, context, and suggestions.
+
+## File Guide (Read the Right File)
+
+| File                    | Purpose                                         | When to read                          |
+| ----------------------- | ----------------------------------------------- | ------------------------------------- |
+| **AGENTS.md** (this)    | Critical patterns, pitfalls, conventions         | Always read first for any code change |
+| [package.json](package.json) | Dependencies, build scripts                 | When modifying deps or build config   |
+
+## Architecture
+
+This package exports the **AM provider contract** — a set of functions the Agents Manager calls to wire up a sidebar provider:
+
+| Export                   | Role                                                        |
+| ------------------------ | ----------------------------------------------------------- |
+| `useAbilitiesSetup`      | Captures AM's `addMessage` callback; registers WP abilities |
+| `toolProvider`           | Wraps `@wordpress/abilities` + Jetpack AI tool definitions  |
+| `contextProvider`        | Sends Gutenberg editor state to the orchestrator            |
+| `getChatComponent`       | Maps tool IDs → React components for in-chat rendering      |
+| `getEmptyViewSuggestions` | Static suggestions shown before conversation starts        |
+| `useSuggestions`         | Block-aware dynamic suggestions during conversation         |
+
+All exports live in `src/index.ts`. This is intentionally a single-file provider — keep it that way unless the file exceeds ~800 lines.
+
+## Critical Patterns (Don't Break These)
+
+- **Module-level state**: `addMessageFn` and `clearSuggestionsFn` are captured once via `useAbilitiesSetup`. These are module singletons — do NOT move them into React state or a store.
+- **`returnToAgent: false`**: Both tool handlers (`handleSelectTitle`, `handleUpdateBlockContent`) return `{ returnToAgent: false }`. This prevents the AM orchestrator from continuing automatically after the tool executes. Removing this breaks the UX flow.
+- **Ability registration guard**: `isAbilityRegistered` prevents duplicate `@wordpress/abilities` registration. The guard is set *before* the async `registerAbility` call to handle concurrent invocations. Don't move it after the await.
+- **Tool ID normalization**: AM normalizes tool IDs (`wpcom/select-title` → `wpcom__select_title`). The `isSelectTitleTool` and `isUpdateBlockContentTool` helpers handle both forms. Any new tool must follow this pattern.
+- **Processing shimmer**: The shimmer effect uses `Flow Block` font + CSS animations injected into the block's owning document (which may be an iframe). The `ensureProcessingStyles` function is idempotent — don't duplicate style injection.
+
+## Tools
+
+| Tool ID                      | Handler                    | UI Component   | Description                              |
+| ---------------------------- | -------------------------- | -------------- | ---------------------------------------- |
+| `wpcom/select-title`        | `handleSelectTitle`        | `TitlePicker`  | Renders title suggestions in chat        |
+| `wpcom/update-block-content` | `handleUpdateBlockContent` | *(chat text)*  | Updates block content with shimmer effect |
+
+### Adding a New Tool
+
+1. Define the tool ID and ability schema in `src/utils/tool-provider.ts`
+2. Add an `is<ToolName>Tool` helper that matches both raw and normalized IDs
+3. Add the handler function in `src/index.ts`
+4. Register the ability in `toolProvider.getAbilities()` with a callback
+5. Add a fallback case in `toolProvider.executeAbility()`
+6. If the tool needs a chat component, add mapping in `getChatComponent()`
+
+## Context Provider
+
+`contextProvider.getClientContext()` builds the context object sent to the orchestrator with each message. It includes:
+
+- Current page URL/pathname
+- Serialized block tree (`currentPageContent`)
+- Selected block's `clientId` and resolved text content
+- Environment identifier (`'gutenberg'`)
+
+Changes here affect AI response quality. The orchestrator uses `selectedBlockClientId` to target block operations and `currentPageContent` for whole-page understanding.
+
+## Suggestions
+
+- **Empty view**: `getEmptyViewSuggestions()` returns static suggestions (currently just "Optimize Title")
+- **Dynamic**: `useSuggestions()` returns block-type-aware suggestions:
+  - Text blocks → translate, change tone, check grammar, simplify
+  - Image blocks → generate alt text
+  - No selection → optimize title
+- Suggestions hide permanently once clicked (via `big-sky-inline-suggestion-click` event), then re-show on block selection change
+
+## Cross-Bundle / iframe
+
+The block editor may run inside an iframe (`editor-canvas`). `findBlockElement` checks both the main document and the iframe's `contentDocument`. The `clientId` is validated against `/^[0-9a-f-]+$/i` to prevent selector injection.
+
+## Conventions
+
+- **`any` types**: Used at WordPress API boundaries (`wp.data`, `wp.abilities`) where no upstream types exist. This is intentional — don't add `@ts-ignore` or overly specific types for untyped APIs.
+- **`@wordpress/i18n`**: All user-facing strings use `__()` with `'jetpack'` text domain.
+- **`@wordpress/components`**: Use for standard UI (Button, etc.).
+- **Styling**: Component styles in `.scss` files alongside the component.
+- **Tests must be TypeScript**: `.test.ts` / `.test.tsx`.
+
+## Build & Test
+
+```bash
+yarn workspace @automattic/jetpack-ai-sidebar build      # Build ESM + CJS
+yarn workspace @automattic/jetpack-ai-sidebar clean       # Clean dist/
+yarn workspace @automattic/jetpack-ai-sidebar typecheck   # Type check
+yarn workspace @automattic/jetpack-ai-sidebar lint        # Lint
+```
+
+Test files go alongside source: `foo.ts` → `foo.test.ts`.
+
+**Coverage**: This package currently has **0% test coverage**. All changes need manual testing in the Gutenberg editor with the AM sidebar enabled.
+
+## PR Guidelines
+
+- Reference Linear issue ID in title
+- Before/after screenshots for UI changes (especially TitlePicker or shimmer effects)
+- Test with both block selected and no block selected states
+
+**Last updated**: 2026-03-22

--- a/packages/jetpack-ai-sidebar/AGENTS.md
+++ b/packages/jetpack-ai-sidebar/AGENTS.md
@@ -130,7 +130,7 @@ The IIFE bundle actually served to widgets.wp.com is built from `apps/agents-man
 
 Test files go alongside source: `foo.ts` → `foo.test.ts`.
 
-**Coverage**: This package currently has **0% test coverage**. All changes need manual testing in the Gutenberg editor with the AM sidebar enabled.
+**Coverage**: Unit tests exist in `src/index.test.ts` covering tool provider abilities, show-component handling, and checkpoint logic. Coverage is still partial — changes outside tested paths need manual testing in the Gutenberg editor with the AM sidebar enabled.
 
 ## PR Guidelines
 

--- a/packages/jetpack-ai-sidebar/AGENTS.md
+++ b/packages/jetpack-ai-sidebar/AGENTS.md
@@ -4,23 +4,23 @@ Agents Manager (AM) provider for the Jetpack AI sidebar in Gutenberg. Bridges th
 
 ## File Guide (Read the Right File)
 
-| File                    | Purpose                                         | When to read                          |
-| ----------------------- | ----------------------------------------------- | ------------------------------------- |
-| **AGENTS.md** (this)    | Critical patterns, pitfalls, conventions         | Always read first for any code change |
-| [package.json](package.json) | Dependencies, build scripts                 | When modifying deps or build config   |
+| File                         | Purpose                                  | When to read                          |
+| ---------------------------- | ---------------------------------------- | ------------------------------------- |
+| **AGENTS.md** (this)         | Critical patterns, pitfalls, conventions | Always read first for any code change |
+| [package.json](package.json) | Dependencies, build scripts              | When modifying deps or build config   |
 
 ## Architecture
 
 This package exports the **AM provider contract** — a set of functions the Agents Manager calls to wire up a sidebar provider:
 
-| Export                   | Role                                                        |
-| ------------------------ | ----------------------------------------------------------- |
-| `useAbilitiesSetup`      | Captures AM's `addMessage` callback; registers WP abilities |
-| `toolProvider`           | Wraps `@wordpress/abilities` + Jetpack AI tool definitions  |
-| `contextProvider`        | Sends Gutenberg editor state to the orchestrator            |
-| `getChatComponent`       | Maps tool IDs → React components for in-chat rendering      |
-| `getEmptyViewSuggestions` | Static suggestions shown before conversation starts        |
-| `useSuggestions`         | Block-aware dynamic suggestions during conversation         |
+| Export                    | Role                                                        |
+| ------------------------- | ----------------------------------------------------------- |
+| `useAbilitiesSetup`       | Captures AM's `addMessage` callback; registers WP abilities |
+| `toolProvider`            | Wraps `@wordpress/abilities` + Jetpack AI tool definitions  |
+| `contextProvider`         | Sends Gutenberg editor state to the orchestrator            |
+| `getChatComponent`        | Maps tool IDs → React components for in-chat rendering      |
+| `getEmptyViewSuggestions` | Static suggestions shown before conversation starts         |
+| `useSuggestions`          | Block-aware dynamic suggestions during conversation         |
 
 All exports live in `src/index.ts`. This is intentionally a single-file provider — keep it that way unless the file exceeds ~800 lines.
 
@@ -28,16 +28,16 @@ All exports live in `src/index.ts`. This is intentionally a single-file provider
 
 - **Module-level state**: `addMessageFn` and `clearSuggestionsFn` are captured once via `useAbilitiesSetup`. These are module singletons — do NOT move them into React state or a store.
 - **`returnToAgent: false`**: Both tool handlers (`handleSelectTitle`, `handleUpdateBlockContent`) return `{ returnToAgent: false }`. This prevents the AM orchestrator from continuing automatically after the tool executes. Removing this breaks the UX flow.
-- **Ability registration guard**: `isAbilityRegistered` prevents duplicate `@wordpress/abilities` registration. The guard is set *before* the async `registerAbility` call to handle concurrent invocations. Don't move it after the await.
+- **Ability registration guard**: `isAbilityRegistered` prevents duplicate `@wordpress/abilities` registration. The guard is set _before_ the async `registerAbility` call to handle concurrent invocations. Don't move it after the await.
 - **Tool ID normalization**: AM normalizes tool IDs (`wpcom/select-title` → `wpcom__select_title`). The `isSelectTitleTool` and `isUpdateBlockContentTool` helpers handle both forms. Any new tool must follow this pattern.
 - **Processing shimmer**: The shimmer effect uses `Flow Block` font + CSS animations injected into the block's owning document (which may be an iframe). The `ensureProcessingStyles` function is idempotent — don't duplicate style injection.
 
 ## Tools
 
-| Tool ID                      | Handler                    | UI Component   | Description                              |
-| ---------------------------- | -------------------------- | -------------- | ---------------------------------------- |
-| `wpcom/select-title`        | `handleSelectTitle`        | `TitlePicker`  | Renders title suggestions in chat        |
-| `wpcom/update-block-content` | `handleUpdateBlockContent` | *(chat text)*  | Updates block content with shimmer effect |
+| Tool ID                      | Handler                    | UI Component  | Description                               |
+| ---------------------------- | -------------------------- | ------------- | ----------------------------------------- |
+| `wpcom/select-title`         | `handleSelectTitle`        | `TitlePicker` | Renders title suggestions in chat         |
+| `wpcom/update-block-content` | `handleUpdateBlockContent` | _(chat text)_ | Updates block content with shimmer effect |
 
 ### Adding a New Tool
 

--- a/packages/jetpack-ai-sidebar/AGENTS.md
+++ b/packages/jetpack-ai-sidebar/AGENTS.md
@@ -7,6 +7,7 @@ Agents Manager (AM) provider for the Jetpack AI sidebar in Gutenberg. Bridges th
 | File                         | Purpose                                  | When to read                          |
 | ---------------------------- | ---------------------------------------- | ------------------------------------- |
 | **AGENTS.md** (this)         | Critical patterns, pitfalls, conventions | Always read first for any code change |
+| [README.md](README.md)       | Overview, install, usage                 | When onboarding or linking externally |
 | [package.json](package.json) | Dependencies, build scripts              | When modifying deps or build config   |
 
 ## Architecture
@@ -15,10 +16,11 @@ This package exports the **AM provider contract** — a set of functions the Age
 
 | Export                    | Role                                                        |
 | ------------------------- | ----------------------------------------------------------- |
-| `useAbilitiesSetup`       | Captures AM's `addMessage` callback; registers WP abilities |
-| `toolProvider`            | Wraps `@wordpress/abilities` + Jetpack AI tool definitions  |
+| `useAbilitiesSetup`       | Captures AM's `addMessage`/`clearSuggestions` callbacks     |
+| `toolProvider`            | Surfaces Jetpack AI's client-side abilities to AM           |
 | `contextProvider`         | Sends Gutenberg editor state to the orchestrator            |
-| `getChatComponent`        | Maps tool IDs → React components for in-chat rendering      |
+| `getChatComponent`        | Maps `type` strings → React components for show-component   |
+| `useCheckpoint`           | Post-title snapshots for AM's native Undo action            |
 | `getEmptyViewSuggestions` | Static suggestions shown before conversation starts         |
 | `useSuggestions`          | Block-aware dynamic suggestions during conversation         |
 
@@ -26,27 +28,59 @@ All exports live in `src/index.ts`. This is intentionally a single-file provider
 
 ## Critical Patterns (Don't Break These)
 
-- **Module-level state**: `addMessageFn` and `clearSuggestionsFn` are captured once via `useAbilitiesSetup`. These are module singletons — do NOT move them into React state or a store.
-- **`returnToAgent: false`**: Both tool handlers (`handleSelectTitle`, `handleUpdateBlockContent`) return `{ returnToAgent: false }`. This prevents the AM orchestrator from continuing automatically after the tool executes. Removing this breaks the UX flow.
-- **Ability registration guard**: `isAbilityRegistered` prevents duplicate `@wordpress/abilities` registration. The guard is set _before_ the async `registerAbility` call to handle concurrent invocations. Don't move it after the await.
-- **Tool ID normalization**: AM normalizes tool IDs (`wpcom/select-title` → `wpcom__select_title`). The `isSelectTitleTool` and `isUpdateBlockContentTool` helpers handle both forms. Any new tool must follow this pattern.
-- **Processing shimmer**: The shimmer effect uses `Flow Block` font + CSS animations injected into the block's owning document (which may be an iframe). The `ensureProcessingStyles` function is idempotent — don't duplicate style injection.
+- **Module-level state**: `addMessageFn`, `clearSuggestionsFn`, and `moduleCheckpointApi` are captured once via their respective hooks. These are module singletons — do NOT move them into React state or a store.
+- **`returnToAgent: false`**: The `handleUpdateBlockContent` and `handleShowComponent` handlers return `{ returnToAgent: false }`. This prevents the AM orchestrator from continuing automatically after the tool executes. Removing this breaks the UX flow.
+- **Tool ID normalization**: AM normalizes tool IDs (`wpcom/update-block-content` → `wpcom__update_block_content`). The `isUpdateBlockContentTool` / `isShowComponentTool` helpers handle both forms. Any new tool must follow this pattern.
+- **Show-component via `agentMessage` escape hatch**: `handleShowComponent` returns `{ agentMessage: JSON }` — it does NOT call `addMessageFn` directly. agenttic-client wraps the JSON in an `{ role: 'agent', parts: [text] }` message, AM's `convert-tool-messages-to-components` resolves the component via `getChatComponent`, and AgentChat's action bar (thumbs/Undo) attaches because the original message had a text content part. See "Show-component pattern" below.
+- **Role transformation**: AM's `useAbilitiesSetup` handler maps `role: 'assistant'` → `'agent'` and everything else → `'user'`. When injecting messages directly via `addMessageFn`, always use `'assistant'` — passing `'agent'` would make the message render as user content and get filtered out of the agent message list.
+- **Processing shimmer**: The block editing shimmer uses `Flow Block` font + CSS animations injected into the block's owning document (which may be an iframe). The `ensureProcessingStyles` function is idempotent — don't duplicate style injection.
 
 ## Tools
 
-| Tool ID                      | Handler                    | UI Component  | Description                               |
-| ---------------------------- | -------------------------- | ------------- | ----------------------------------------- |
-| `wpcom/select-title`         | `handleSelectTitle`        | `TitlePicker` | Renders title suggestions in chat         |
-| `wpcom/update-block-content` | `handleUpdateBlockContent` | _(chat text)_ | Updates block content with shimmer effect |
+| Tool ID                      | Handler                    | UI Component  | Description                                     |
+| ---------------------------- | -------------------------- | ------------- | ----------------------------------------------- |
+| `big_sky__show_component`    | `handleShowComponent`      | via `getChatComponent` | Renders interactive pickers (currently title-picker) |
+| `wpcom/update-block-content` | `handleUpdateBlockContent` | _(chat text)_ | Updates block content with shimmer effect       |
 
-### Adding a New Tool
+### Show-component pattern
+
+Used for any interactive picker (title, font, color, etc.). The wpcom ability returns an `Input_Required_Result` with `tool_id: 'big_sky__show_component'` and a data envelope shaped like:
+
+```
+{
+  type: '<component-type>',
+  props: { ... },
+  calypsoCheckpointId: '<id>',
+  isCurrent: true,
+  hideZoomAction: <optional boolean>
+}
+```
+
+On the client, `handleShowComponent`:
+
+1. Looks up the component via `getChatComponent(type)` to verify the type is supported.
+2. Snapshots state via the module-level `moduleCheckpointApi.setCheckpoint()` so AM's native Undo action can restore it later.
+3. Returns `{ agentMessage: JSON.stringify({ tool_id, data }) }`. agenttic-client re-emits this as an `{ role: 'agent', parts: [text] }` message.
+4. AM's `convert-tool-messages-to-components` matches the tool_id, calls `getChatComponent(data.type)`, and replaces the text content with a component render. Because the original message had text content, AgentChat renders its action bar (thumbs, Undo) on the resulting bubble.
+
+`hideZoomAction: true` opts out of AM's zoom action button — set it for component types that don't edit block content (e.g. title-picker, which edits the post title).
+
+### Adding a new picker type
+
+1. Add a case in `getChatComponent()` mapping your `type` string to a React component.
+2. Create the component under `src/components/` with a `scss` sibling.
+3. Update the wpcom ability (or add a new one) to return `tool_id: 'big_sky__show_component'` with `data: { type: '<your-type>', props: { ... } }`.
+4. No changes to `toolProvider`, `useCheckpoint`, or the action bar wiring.
+
+### Adding a non-rendering client tool
+
+For tools that perform an editor action (like `update-block-content`):
 
 1. Define the tool ID and ability schema in `src/utils/tool-provider.ts`
 2. Add an `is<ToolName>Tool` helper that matches both raw and normalized IDs
 3. Add the handler function in `src/index.ts`
 4. Register the ability in `toolProvider.getAbilities()` with a callback
 5. Add a fallback case in `toolProvider.executeAbility()`
-6. If the tool needs a chat component, add mapping in `getChatComponent()`
 
 ## Context Provider
 
@@ -58,6 +92,10 @@ All exports live in `src/index.ts`. This is intentionally a single-file provider
 - Environment identifier (`'gutenberg'`)
 
 Changes here affect AI response quality. The orchestrator uses `selectedBlockClientId` to target block operations and `currentPageContent` for whole-page understanding.
+
+## Checkpoint / Undo
+
+`useCheckpoint` exposes a minimal subset of AM's `UseCheckpointReturn` interface — only `setCheckpoint` / `hasCheckpoint` / `restoreCheckpoint` are implemented; the Big Sky page/navigation stubs are no-ops. Snapshots are stored in a module-level `titleSnapshots` map keyed by checkpoint id (the tool call id), so the sync `handleShowComponent` callback and the async React restore path share state.
 
 ## Suggestions
 
@@ -89,6 +127,8 @@ yarn workspace @automattic/jetpack-ai-sidebar typecheck   # Type check
 yarn workspace @automattic/jetpack-ai-sidebar lint        # Lint
 ```
 
+The IIFE bundle actually served to widgets.wp.com is built from `apps/agents-manager` — rebuilding this package alone does NOT update the deployed asset. Use `yarn workspace @automattic/agents-manager-app dev` to rebuild + sync to a widgets sandbox.
+
 Test files go alongside source: `foo.ts` → `foo.test.ts`.
 
 **Coverage**: This package currently has **0% test coverage**. All changes need manual testing in the Gutenberg editor with the AM sidebar enabled.
@@ -99,4 +139,4 @@ Test files go alongside source: `foo.ts` → `foo.test.ts`.
 - Before/after screenshots for UI changes (especially TitlePicker or shimmer effects)
 - Test with both block selected and no block selected states
 
-**Last updated**: 2026-03-22
+**Last updated**: 2026-04-10

--- a/packages/jetpack-ai-sidebar/AGENTS.md
+++ b/packages/jetpack-ai-sidebar/AGENTS.md
@@ -7,7 +7,6 @@ Agents Manager (AM) provider for the Jetpack AI sidebar in Gutenberg. Bridges th
 | File                         | Purpose                                  | When to read                          |
 | ---------------------------- | ---------------------------------------- | ------------------------------------- |
 | **AGENTS.md** (this)         | Critical patterns, pitfalls, conventions | Always read first for any code change |
-| [README.md](README.md)       | Overview, install, usage                 | When onboarding or linking externally |
 | [package.json](package.json) | Dependencies, build scripts              | When modifying deps or build config   |
 
 ## Architecture
@@ -37,10 +36,10 @@ All exports live in `src/index.ts`. This is intentionally a single-file provider
 
 ## Tools
 
-| Tool ID                      | Handler                    | UI Component  | Description                                     |
-| ---------------------------- | -------------------------- | ------------- | ----------------------------------------------- |
-| `big_sky__show_component`    | `handleShowComponent`      | via `getChatComponent` | Renders interactive pickers (currently title-picker) |
-| `wpcom/update-block-content` | `handleUpdateBlockContent` | _(chat text)_ | Updates block content with shimmer effect       |
+| Tool ID                      | Handler                    | UI Component             | Description                                          |
+| ---------------------------- | -------------------------- | ------------------------ | ---------------------------------------------------- |
+| `big_sky__show_component`    | `handleShowComponent`      | via `getChatComponent`   | Renders interactive pickers (currently title-picker) |
+| `wpcom/update-block-content` | `handleUpdateBlockContent` | _(chat text)_            | Updates block content with shimmer effect            |
 
 ### Show-component pattern
 

--- a/packages/jetpack-ai-sidebar/CLAUDE.md
+++ b/packages/jetpack-ai-sidebar/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/jetpack-ai-sidebar/jest.config.js
+++ b/packages/jetpack-ai-sidebar/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	preset: '../../test/packages/jest-preset.js',
+	roots: [ '<rootDir>/src' ],
+	testMatch: [ '<rootDir>/src/**/*.test.{js,ts,tsx}' ],
+	modulePathIgnorePatterns: [ '<rootDir>/dist' ],
+	testEnvironment: 'jsdom',
+};

--- a/packages/jetpack-ai-sidebar/package.json
+++ b/packages/jetpack-ai-sidebar/package.json
@@ -1,0 +1,64 @@
+{
+	"name": "@automattic/jetpack-ai-sidebar",
+	"version": "1.0.0",
+	"description": "Jetpack AI sidebar provider for Agents Manager.",
+	"homepage": "https://github.com/Automattic/wp-calypso",
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic Inc.",
+	"main": "dist/cjs/index.js",
+	"module": "dist/esm/index.js",
+	"calypso:src": "src/index.ts",
+	"exports": {
+		".": {
+			"calypso:src": "./src/index.ts",
+			"types": "./dist/types/index.d.ts",
+			"import": "./dist/esm/index.js",
+			"require": "./dist/cjs/index.js"
+		},
+		"./src/*": {
+			"calypso:src": "./src/*"
+		}
+	},
+	"sideEffects": [
+		"*.css",
+		"*.scss"
+	],
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/jetpack-ai-sidebar"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"bugs": "https://github.com/Automattic/wp-calypso/issues",
+	"types": "dist/types",
+	"scripts": {
+		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && run -T copy-assets",
+		"prepack": "yarn run clean && yarn run build",
+		"watch": "tsc --build ./tsconfig.json --watch",
+		"lint": "run -T eslint src/",
+		"lint:fix": "run -T eslint src/ --fix",
+		"typecheck": "tsc --build --dry"
+	},
+	"dependencies": {
+		"@automattic/agenttic-client": "^0.1.53",
+		"@wordpress/abilities": "^0.4.0",
+		"@wordpress/components": "^30.9.0",
+		"@wordpress/i18n": "^5.23.0"
+	},
+	"devDependencies": {
+		"@automattic/calypso-typescript-config": "workspace:^",
+		"@types/react": "^18.3.1",
+		"@types/react-dom": "^18.3.1",
+		"typescript": "^5.8.3"
+	},
+	"peerDependencies": {
+		"@wordpress/data": "^10.23.0",
+		"@wordpress/element": "^6.23.0",
+		"react": "^18.3.1",
+		"react-dom": "^18.3.1"
+	},
+	"private": true
+}

--- a/packages/jetpack-ai-sidebar/package.json
+++ b/packages/jetpack-ai-sidebar/package.json
@@ -38,6 +38,7 @@
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && run -T copy-assets",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch",
+		"test": "cd ../.. && yarn test-packages packages/jetpack-ai-sidebar",
 		"lint": "run -T eslint src/",
 		"lint:fix": "run -T eslint src/ --fix",
 		"typecheck": "tsc --build --dry"

--- a/packages/jetpack-ai-sidebar/package.json
+++ b/packages/jetpack-ai-sidebar/package.json
@@ -43,7 +43,7 @@
 		"typecheck": "tsc --build --dry"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.53",
+		"@automattic/agenttic-client": "^0.1.58",
 		"@wordpress/abilities": "^0.4.0",
 		"@wordpress/components": "^30.9.0",
 		"@wordpress/i18n": "^5.23.0"

--- a/packages/jetpack-ai-sidebar/src/auto-scroll-fix.scss
+++ b/packages/jetpack-ai-sidebar/src/auto-scroll-fix.scss
@@ -1,0 +1,6 @@
+// Override the AM's bottomMessages CSS so messages start from the top
+// instead of being pinned to the bottom via margin-top: auto.
+// This makes the chat push content upward when new messages arrive.
+[data-slot="messages"] > *:first-child {
+	margin-top: 0 !important;
+}

--- a/packages/jetpack-ai-sidebar/src/components/title-picker.scss
+++ b/packages/jetpack-ai-sidebar/src/components/title-picker.scss
@@ -1,0 +1,112 @@
+.jetpack-ai-title-picker {
+	padding: 8px 0;
+
+	&__intro {
+		margin: 0 0 12px;
+		font-size: 14px;
+	}
+
+	&__applied {
+		margin: 0;
+		font-size: 14px;
+		color: #00a32a;
+		font-weight: 600;
+	}
+
+	&__options {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	&__card {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		padding: 12px;
+		border: 1px solid rgba(255, 255, 255, 0.12);
+		border-radius: 8px;
+		background: transparent;
+		cursor: pointer;
+		text-align: left;
+		transition: border-color 0.15s ease, background 0.15s ease;
+		width: 100%;
+		color: inherit;
+		font-family: inherit;
+
+		&:hover {
+			border-color: rgba(255, 255, 255, 0.3);
+			background: rgba(255, 255, 255, 0.04);
+		}
+
+		&.is-selected {
+			border-color: var(--wp-admin-theme-color, #3858e9);
+			background: rgba(56, 88, 233, 0.08);
+		}
+
+		&-title {
+			font-size: 14px;
+			font-weight: 600;
+			line-height: 20px;
+		}
+
+		&-explanation {
+			font-size: 12px;
+			font-weight: 400;
+			line-height: 18px;
+			opacity: 0.7;
+		}
+	}
+
+	&__actions {
+		display: flex;
+		justify-content: flex-end;
+		margin-top: 12px;
+	}
+}
+
+// Block update transition effects
+@keyframes jetpack-ai-shimmer {
+
+	0% {
+		background-position: -200% 0;
+	}
+
+	100% {
+		background-position: 200% 0;
+	}
+}
+
+.jetpack-ai-block-updating {
+	position: relative;
+	opacity: 0.6;
+	transition: opacity 0.3s ease;
+
+	&::after {
+		content: "";
+		position: absolute;
+		inset: 0;
+		border-radius: 4px;
+		background: linear-gradient(90deg, transparent 0%, rgba(56, 88, 233, 0.12) 50%, transparent 100%);
+		background-size: 200% 100%;
+		animation: jetpack-ai-shimmer 1.2s ease-in-out infinite;
+		pointer-events: none;
+	}
+}
+
+.jetpack-ai-block-updated {
+	animation: jetpack-ai-highlight 1s ease-out;
+}
+
+@keyframes jetpack-ai-highlight {
+
+	0% {
+		outline: 2px solid rgba(56, 88, 233, 0.6);
+		outline-offset: 2px;
+	}
+
+	100% {
+		outline: 2px solid transparent;
+		outline-offset: 2px;
+	}
+}

--- a/packages/jetpack-ai-sidebar/src/components/title-picker.scss
+++ b/packages/jetpack-ai-sidebar/src/components/title-picker.scss
@@ -24,24 +24,26 @@
 		flex-direction: column;
 		gap: 4px;
 		padding: 12px;
-		border: 1px solid rgba(255, 255, 255, 0.12);
+		border: 1px solid rgba( 255, 255, 255, 0.12 );
 		border-radius: 8px;
 		background: transparent;
 		cursor: pointer;
 		text-align: left;
-		transition: border-color 0.15s ease, background 0.15s ease;
+		transition:
+			border-color 0.15s ease,
+			background 0.15s ease;
 		width: 100%;
 		color: inherit;
 		font-family: inherit;
 
 		&:hover {
-			border-color: rgba(255, 255, 255, 0.3);
-			background: rgba(255, 255, 255, 0.04);
+			border-color: rgba( 255, 255, 255, 0.3 );
+			background: rgba( 255, 255, 255, 0.04 );
 		}
 
 		&.is-selected {
-			border-color: var(--wp-admin-theme-color, #3858e9);
-			background: rgba(56, 88, 233, 0.08);
+			border-color: var( --wp-admin-theme-color, #3858e9 );
+			background: rgba( 56, 88, 233, 0.08 );
 		}
 
 		&-title {
@@ -62,51 +64,5 @@
 		display: flex;
 		justify-content: flex-end;
 		margin-top: 12px;
-	}
-}
-
-// Block update transition effects
-@keyframes jetpack-ai-shimmer {
-
-	0% {
-		background-position: -200% 0;
-	}
-
-	100% {
-		background-position: 200% 0;
-	}
-}
-
-.jetpack-ai-block-updating {
-	position: relative;
-	opacity: 0.6;
-	transition: opacity 0.3s ease;
-
-	&::after {
-		content: "";
-		position: absolute;
-		inset: 0;
-		border-radius: 4px;
-		background: linear-gradient(90deg, transparent 0%, rgba(56, 88, 233, 0.12) 50%, transparent 100%);
-		background-size: 200% 100%;
-		animation: jetpack-ai-shimmer 1.2s ease-in-out infinite;
-		pointer-events: none;
-	}
-}
-
-.jetpack-ai-block-updated {
-	animation: jetpack-ai-highlight 1s ease-out;
-}
-
-@keyframes jetpack-ai-highlight {
-
-	0% {
-		outline: 2px solid rgba(56, 88, 233, 0.6);
-		outline-offset: 2px;
-	}
-
-	100% {
-		outline: 2px solid transparent;
-		outline-offset: 2px;
 	}
 }

--- a/packages/jetpack-ai-sidebar/src/components/title-picker.scss
+++ b/packages/jetpack-ai-sidebar/src/components/title-picker.scss
@@ -6,13 +6,6 @@
 		font-size: 14px;
 	}
 
-	&__applied {
-		margin: 0;
-		font-size: 14px;
-		color: #00a32a;
-		font-weight: 600;
-	}
-
 	&__options {
 		display: flex;
 		flex-direction: column;
@@ -22,7 +15,6 @@
 	&__card {
 		display: flex;
 		flex-direction: column;
-		gap: 4px;
 		padding: 12px;
 		border: 1px solid rgba( 255, 255, 255, 0.12 );
 		border-radius: 8px;
@@ -41,9 +33,9 @@
 			background: rgba( 255, 255, 255, 0.04 );
 		}
 
-		&.is-selected {
+		&.is-applied {
 			border-color: var( --wp-admin-theme-color, #3858e9 );
-			background: rgba( 56, 88, 233, 0.08 );
+			background: rgba( 56, 88, 233, 0.12 );
 		}
 
 		&-title {
@@ -51,18 +43,5 @@
 			font-weight: 600;
 			line-height: 20px;
 		}
-
-		&-explanation {
-			font-size: 12px;
-			font-weight: 400;
-			line-height: 18px;
-			opacity: 0.7;
-		}
-	}
-
-	&__actions {
-		display: flex;
-		justify-content: flex-end;
-		margin-top: 12px;
 	}
 }

--- a/packages/jetpack-ai-sidebar/src/components/title-picker.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/title-picker.tsx
@@ -31,7 +31,6 @@ interface TitlePickerProps {
  *
  * Renders title suggestions as clickable cards. Clicking a card selects it,
  * then the user confirms with "Use this title" to update the post.
- *
  * @param {TitlePickerProps} props - Component props.
  * @returns {import('react').ReactElement} The rendered component.
  */

--- a/packages/jetpack-ai-sidebar/src/components/title-picker.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/title-picker.tsx
@@ -1,10 +1,11 @@
 /**
  * TitlePicker — renders title suggestions in the chat sidebar.
  *
- * Displayed when the backend ability returns a Tool_Call_Result with
- * tool_id 'wpcom__select_title'. Clicking a title card applies it to the
- * post immediately. The picker stays visible so users can try different
- * titles in real time; the currently-applied option is highlighted.
+ * Displayed when the orchestrator renders a show-component response via
+ * 'big_sky__show_component' with data.type set to 'title-picker'.
+ * Clicking a title card applies it to the post immediately. The picker
+ * stays visible so users can try different titles in real time; the
+ * currently-applied option is highlighted.
  *
  * Response feedback (thumbs up/down) is provided by Agents Manager's
  * native feedback action bar, which attaches to the orchestrator's
@@ -59,11 +60,11 @@ export default function TitlePicker( { titles, onComplete }: TitlePickerProps ) 
 				{ __( 'Choose a title for your post:', 'jetpack' ) }
 			</p>
 			<div className="jetpack-ai-title-picker__options">
-				{ titles.map( ( option ) => {
+				{ titles.map( ( option, index ) => {
 					const isApplied = option.title === appliedTitle;
 					return (
 						<button
-							key={ option.title }
+							key={ `${ option.title }-${ index }` }
 							type="button"
 							className={ `jetpack-ai-title-picker__card${ isApplied ? ' is-applied' : '' }` }
 							onClick={ () => handleApply( option.title ) }

--- a/packages/jetpack-ai-sidebar/src/components/title-picker.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/title-picker.tsx
@@ -1,0 +1,93 @@
+/**
+ * TitlePicker — renders title suggestions in the chat sidebar.
+ *
+ * Displayed when the backend ability returns a Tool_Call_Result with
+ * tool_id 'wpcom__select_title'. The user clicks a title card to apply it.
+ */
+
+/**
+ * External dependencies
+ */
+import { Button } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { useState, useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Props for the TitlePicker component.
+ */
+interface TitleOption {
+	title: string;
+	explanation?: string;
+}
+
+interface TitlePickerProps {
+	titles: TitleOption[];
+	onComplete?: () => void;
+}
+
+/**
+ * TitlePicker component for the chat sidebar.
+ *
+ * Renders title suggestions as clickable cards. Clicking a card selects it,
+ * then the user confirms with "Use this title" to update the post.
+ *
+ * @param {TitlePickerProps} props - Component props.
+ * @returns {import('react').ReactElement} The rendered component.
+ */
+export default function TitlePicker( { titles, onComplete }: TitlePickerProps ) {
+	const [ selected, setSelected ] = useState< string | null >( null );
+	const [ applied, setApplied ] = useState( false );
+	const { editPost } = useDispatch( 'core/editor' );
+
+	const handleApply = useCallback( () => {
+		if ( ! selected ) {
+			return;
+		}
+		editPost( { title: selected } );
+		setApplied( true );
+		onComplete?.();
+	}, [ editPost, selected, onComplete ] );
+
+	if ( applied ) {
+		return (
+			<div className="jetpack-ai-title-picker">
+				<p className="jetpack-ai-title-picker__applied">{ __( 'Title updated!', 'jetpack' ) }</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="jetpack-ai-title-picker">
+			<p className="jetpack-ai-title-picker__intro">
+				{ __( 'Choose a title for your post:', 'jetpack' ) }
+			</p>
+			<div className="jetpack-ai-title-picker__options">
+				{ titles.map( ( option ) => (
+					<button
+						key={ option.title }
+						type="button"
+						className={ `jetpack-ai-title-picker__card${
+							option.title === selected ? ' is-selected' : ''
+						}` }
+						onClick={ () => setSelected( option.title ) }
+					>
+						<span className="jetpack-ai-title-picker__card-title">{ option.title }</span>
+						{ option.explanation && (
+							<span className="jetpack-ai-title-picker__card-explanation">
+								{ option.explanation }
+							</span>
+						) }
+					</button>
+				) ) }
+			</div>
+			{ selected && (
+				<div className="jetpack-ai-title-picker__actions">
+					<Button variant="primary" onClick={ handleApply }>
+						{ __( 'Use this title', 'jetpack' ) }
+					</Button>
+				</div>
+			) }
+		</div>
+	);
+}

--- a/packages/jetpack-ai-sidebar/src/components/title-picker.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/title-picker.tsx
@@ -2,13 +2,18 @@
  * TitlePicker — renders title suggestions in the chat sidebar.
  *
  * Displayed when the backend ability returns a Tool_Call_Result with
- * tool_id 'wpcom__select_title'. The user clicks a title card to apply it.
+ * tool_id 'wpcom__select_title'. Clicking a title card applies it to the
+ * post immediately. The picker stays visible so users can try different
+ * titles in real time; the currently-applied option is highlighted.
+ *
+ * Response feedback (thumbs up/down) is provided by Agents Manager's
+ * native feedback action bar, which attaches to the orchestrator's
+ * intro text message (not to the picker itself).
  */
 
 /**
  * External dependencies
  */
-import { Button } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { useState, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -29,32 +34,24 @@ interface TitlePickerProps {
 /**
  * TitlePicker component for the chat sidebar.
  *
- * Renders title suggestions as clickable cards. Clicking a card selects it,
- * then the user confirms with "Use this title" to update the post.
+ * Renders title suggestions as clickable cards. Clicking a card updates the
+ * post title immediately; the picker stays visible so the user can click
+ * through options to try them. The currently-applied title is highlighted.
  * @param {TitlePickerProps} props - Component props.
  * @returns {import('react').ReactElement} The rendered component.
  */
 export default function TitlePicker( { titles, onComplete }: TitlePickerProps ) {
-	const [ selected, setSelected ] = useState< string | null >( null );
-	const [ applied, setApplied ] = useState( false );
+	const [ appliedTitle, setAppliedTitle ] = useState< string | null >( null );
 	const { editPost } = useDispatch( 'core/editor' );
 
-	const handleApply = useCallback( () => {
-		if ( ! selected ) {
-			return;
-		}
-		editPost( { title: selected } );
-		setApplied( true );
-		onComplete?.();
-	}, [ editPost, selected, onComplete ] );
-
-	if ( applied ) {
-		return (
-			<div className="jetpack-ai-title-picker">
-				<p className="jetpack-ai-title-picker__applied">{ __( 'Title updated!', 'jetpack' ) }</p>
-			</div>
-		);
-	}
+	const handleApply = useCallback(
+		( title: string ) => {
+			editPost( { title } );
+			setAppliedTitle( title );
+			onComplete?.();
+		},
+		[ editPost, onComplete ]
+	);
 
 	return (
 		<div className="jetpack-ai-title-picker">
@@ -62,31 +59,21 @@ export default function TitlePicker( { titles, onComplete }: TitlePickerProps ) 
 				{ __( 'Choose a title for your post:', 'jetpack' ) }
 			</p>
 			<div className="jetpack-ai-title-picker__options">
-				{ titles.map( ( option ) => (
-					<button
-						key={ option.title }
-						type="button"
-						className={ `jetpack-ai-title-picker__card${
-							option.title === selected ? ' is-selected' : ''
-						}` }
-						onClick={ () => setSelected( option.title ) }
-					>
-						<span className="jetpack-ai-title-picker__card-title">{ option.title }</span>
-						{ option.explanation && (
-							<span className="jetpack-ai-title-picker__card-explanation">
-								{ option.explanation }
-							</span>
-						) }
-					</button>
-				) ) }
+				{ titles.map( ( option ) => {
+					const isApplied = option.title === appliedTitle;
+					return (
+						<button
+							key={ option.title }
+							type="button"
+							className={ `jetpack-ai-title-picker__card${ isApplied ? ' is-applied' : '' }` }
+							onClick={ () => handleApply( option.title ) }
+							aria-pressed={ isApplied }
+						>
+							<span className="jetpack-ai-title-picker__card-title">{ option.title }</span>
+						</button>
+					);
+				} ) }
 			</div>
-			{ selected && (
-				<div className="jetpack-ai-title-picker__actions">
-					<Button variant="primary" onClick={ handleApply }>
-						{ __( 'Use this title', 'jetpack' ) }
-					</Button>
-				</div>
-			) }
 		</div>
 	);
 }

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Tests for the Jetpack AI Sidebar provider.
+ *
+ * Focused on the show-component flow, the checkpoint hook, and the
+ * getChatComponent resolver — these are the pieces AM wires into its chat.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import TitlePicker from './components/title-picker';
+import { getChatComponent, toolProvider, useCheckpoint } from './index';
+
+// Stub @wordpress/data on window so useCheckpoint / handleShowComponent
+// can read/write the post title via the core/editor store.
+function installWpDataMock( initialTitle: string ) {
+	const state = { title: initialTitle };
+	( window as any ).wp = {
+		data: {
+			select: ( store: string ) => {
+				if ( store === 'core/editor' ) {
+					return {
+						getEditedPostAttribute: ( attr: string ) =>
+							attr === 'title' ? state.title : undefined,
+					};
+				}
+				return undefined;
+			},
+			dispatch: ( store: string ) => {
+				if ( store === 'core/editor' ) {
+					return {
+						editPost: ( attrs: { title?: string } ) => {
+							if ( typeof attrs.title === 'string' ) {
+								state.title = attrs.title;
+							}
+						},
+					};
+				}
+				return undefined;
+			},
+		},
+	};
+	return state;
+}
+
+describe( 'getChatComponent', () => {
+	it( 'returns TitlePicker for type "title-picker"', () => {
+		expect( getChatComponent( 'title-picker' ) ).toBe( TitlePicker );
+	} );
+
+	it( 'returns null for an unknown type', () => {
+		expect( getChatComponent( 'font-picker' ) ).toBeNull();
+		expect( getChatComponent( '' ) ).toBeNull();
+		expect( getChatComponent( 'anything-else' ) ).toBeNull();
+	} );
+} );
+
+describe( 'toolProvider', () => {
+	beforeEach( () => {
+		// Ensure wp.abilities is undefined so getAbilities falls into the
+		// empty-base case and only includes the provider's own definitions.
+		( window as any ).wp = {};
+	} );
+
+	describe( 'getAbilities', () => {
+		it( 'includes update-block-content and big_sky__show_component', async () => {
+			const abilities = await toolProvider.getAbilities();
+			const names = abilities.map( ( a: any ) => a.name );
+
+			expect( names ).toContain( 'wpcom/update-block-content' );
+			expect( names ).toContain( 'big_sky__show_component' );
+		} );
+
+		it( 'wires a callback on each provided ability', async () => {
+			const abilities = await toolProvider.getAbilities();
+			const showComponent = abilities.find( ( a: any ) => a.name === 'big_sky__show_component' );
+			const updateBlock = abilities.find( ( a: any ) => a.name === 'wpcom/update-block-content' );
+
+			expect( typeof showComponent?.callback ).toBe( 'function' );
+			expect( typeof updateBlock?.callback ).toBe( 'function' );
+		} );
+	} );
+
+	describe( 'executeAbility for big_sky__show_component', () => {
+		beforeEach( () => {
+			installWpDataMock( 'Original Title' );
+		} );
+
+		it( 'returns an error when type is missing', async () => {
+			const { result } = await toolProvider.executeAbility( 'big_sky__show_component', {} );
+			expect( result ).toMatchObject( { success: false } );
+			expect( ( result as any ).error ).toMatch( /missing type/ );
+		} );
+
+		it( 'returns an error for an unknown component type', async () => {
+			const { result } = await toolProvider.executeAbility( 'big_sky__show_component', {
+				type: 'nonexistent-picker',
+				props: {},
+			} );
+			expect( result ).toMatchObject( { success: false } );
+			expect( ( result as any ).error ).toMatch( /no component registered/ );
+		} );
+
+		it( 'returns an agentMessage envelope for a valid title-picker call', async () => {
+			const titles = [
+				{ title: 'Title 1', explanation: 'a' },
+				{ title: 'Title 2', explanation: 'b' },
+				{ title: 'Title 3', explanation: 'c' },
+			];
+			const { result, returnToAgent } = ( await toolProvider.executeAbility(
+				'big_sky__show_component',
+				{
+					type: 'title-picker',
+					props: { titles },
+					toolCallId: 'call_test_123',
+				}
+			) ) as any;
+
+			expect( returnToAgent ).toBe( false );
+			expect( result.returnToAgent ).toBe( false );
+			expect( typeof result.agentMessage ).toBe( 'string' );
+
+			const parsed = JSON.parse( result.agentMessage );
+			expect( parsed.tool_id ).toBe( 'big_sky__show_component' );
+			expect( parsed.data.type ).toBe( 'title-picker' );
+			expect( parsed.data.props ).toEqual( { titles } );
+			expect( parsed.data.calypsoCheckpointId ).toBe( 'call_test_123' );
+			expect( parsed.data.isCurrent ).toBe( true );
+			expect( parsed.data.hideZoomAction ).toBe( true );
+		} );
+
+		it( 'generates a checkpointId fallback when toolCallId is missing', async () => {
+			const { result } = ( await toolProvider.executeAbility( 'big_sky__show_component', {
+				type: 'title-picker',
+				props: { titles: [ { title: 'x' } ] },
+			} ) ) as any;
+
+			const parsed = JSON.parse( result.agentMessage );
+			expect( typeof parsed.data.calypsoCheckpointId ).toBe( 'string' );
+			expect( parsed.data.calypsoCheckpointId.length ).toBeGreaterThan( 0 );
+		} );
+	} );
+} );
+
+describe( 'useCheckpoint', () => {
+	beforeEach( () => {
+		installWpDataMock( 'Original Title' );
+	} );
+
+	it( 'snapshots the post title on setCheckpoint and restores it on restoreCheckpoint', async () => {
+		const api = useCheckpoint();
+
+		// Snapshot original.
+		api.setCheckpoint( 'cp-1' );
+		expect( api.hasCheckpoint( 'cp-1' ) ).toBe( true );
+
+		// Change title.
+		( window as any ).wp.data.dispatch( 'core/editor' ).editPost( { title: 'New Title' } );
+		expect(
+			( window as any ).wp.data.select( 'core/editor' ).getEditedPostAttribute( 'title' )
+		).toBe( 'New Title' );
+
+		// Restore.
+		await api.restoreCheckpoint( 'cp-1' );
+		expect(
+			( window as any ).wp.data.select( 'core/editor' ).getEditedPostAttribute( 'title' )
+		).toBe( 'Original Title' );
+	} );
+
+	it( 'keeps the checkpoint after restore so Undo can be used repeatedly', async () => {
+		const api = useCheckpoint();
+		api.setCheckpoint( 'cp-2' );
+
+		( window as any ).wp.data.dispatch( 'core/editor' ).editPost( { title: 'Try 1' } );
+		await api.restoreCheckpoint( 'cp-2' );
+		expect( api.hasCheckpoint( 'cp-2' ) ).toBe( true );
+
+		( window as any ).wp.data.dispatch( 'core/editor' ).editPost( { title: 'Try 2' } );
+		await api.restoreCheckpoint( 'cp-2' );
+		expect(
+			( window as any ).wp.data.select( 'core/editor' ).getEditedPostAttribute( 'title' )
+		).toBe( 'Original Title' );
+	} );
+
+	it( 'removes the checkpoint when clearCheckpoint is called', () => {
+		const api = useCheckpoint();
+		api.setCheckpoint( 'cp-3' );
+		expect( api.hasCheckpoint( 'cp-3' ) ).toBe( true );
+		api.clearCheckpoint( 'cp-3' );
+		expect( api.hasCheckpoint( 'cp-3' ) ).toBe( false );
+	} );
+
+	it( 'hasCheckpoint returns false for unknown ids', () => {
+		const api = useCheckpoint();
+		expect( api.hasCheckpoint( 'never-set' ) ).toBe( false );
+	} );
+} );

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -50,7 +50,6 @@ const OPTIMIZE_TITLE_SUGGESTION = {
 
 /**
  * Find a block element by clientId in the main document or editor iframe.
- *
  * @param {string} clientId - The block's clientId.
  * @returns The block element, or null.
  */
@@ -123,7 +122,6 @@ function ensureProcessingStyles( doc: Document ): void {
 
 /**
  * Apply processing effect to a block element.
- *
  * @param el - The block element.
  */
 function applyProcessingEffect( el: HTMLElement ): void {
@@ -133,7 +131,6 @@ function applyProcessingEffect( el: HTMLElement ): void {
 
 /**
  * Remove processing effect and show a brief highlight.
- *
  * @param el - The block element.
  */
 function removeProcessingEffect( el: HTMLElement ): void {
@@ -165,7 +162,6 @@ function startBlockShimmer(): void {
 
 /**
  * Handle the select-title tool call: render TitlePicker in chat.
- *
  * @param {any} input - Tool input with titles array.
  * @returns {Object} Result with returnToAgent: false.
  */
@@ -221,7 +217,6 @@ function handleSelectTitle( input: any ): any {
 
 /**
  * Handle the update-block-content tool call: apply text changes to a block.
- *
  * @param {any} input - Tool input with clientId, content, and optional summary.
  * @returns {Object} Result with returnToAgent: false.
  */
@@ -276,7 +271,6 @@ function handleUpdateBlockContent( input: any ): any {
 
 /**
  * Check whether the `@wordpress/abilities` API is available.
- *
  * @returns {boolean} True when window.wp.abilities.getAbilities exists.
  */
 function hasAbilitiesApi(): boolean {
@@ -306,7 +300,7 @@ async function registerSelectTitleAbility(): Promise< void > {
 			category: 'jetpack-ai',
 			description: SELECT_TITLE_ABILITY.description,
 			input_schema: SELECT_TITLE_ABILITY.input_schema,
-			callback: async ( input: any ) => handleSelectTitle( input ),
+			callback: handleSelectTitle,
 		} );
 	} catch ( e: any ) {
 		if ( ! e?.message?.includes?.( 'already registered' ) ) {
@@ -325,10 +319,6 @@ registerSelectTitleAbility();
 
 /**
  * Captures AM's addMessage/clearSuggestions callbacks and registers abilities.
- *
- * @param {Object} actions                  - The actions object provided by AM.
- * @param          actions.addMessage
- * @param          actions.clearSuggestions
  */
 export function useAbilitiesSetup( actions: {
 	addMessage: ( message: any ) => void;
@@ -368,7 +358,6 @@ function setupAutoScrollFix(): void {
 
 /**
  * Normalize an ability name to the format used by agenttic-client for matching.
- *
  * @param {string} name - Ability name (e.g., 'wpcom/select-title').
  * @returns {string} Normalized name (e.g., 'wpcom__select_title').
  */
@@ -378,7 +367,6 @@ function normalizeAbilityName( name: string ): string {
 
 /**
  * Filter out an ability by name from a list.
- *
  * @param {any[]}  abilities - List of abilities.
  * @param {string} toolId    - Tool ID to remove.
  * @returns {any[]} Filtered list.
@@ -398,7 +386,6 @@ export const toolProvider = {
 	 * with versions that have callbacks returning returnToAgent: false.
 	 * This is necessary because agenttic-client's executeAbility path
 	 * hardcodes returnToAgent: true, but the callback path respects it.
-	 *
 	 * @returns {Promise<any[]>} Array of ability descriptors.
 	 */
 	async getAbilities(): Promise< any[] > {
@@ -424,11 +411,11 @@ export const toolProvider = {
 		abilities.unshift(
 			{
 				...SELECT_TITLE_ABILITY,
-				callback: async ( input: any ) => handleSelectTitle( input ),
+				callback: handleSelectTitle,
 			},
 			{
 				...UPDATE_BLOCK_CONTENT_ABILITY,
-				callback: async ( input: any ) => handleUpdateBlockContent( input ),
+				callback: handleUpdateBlockContent,
 			}
 		);
 
@@ -437,7 +424,6 @@ export const toolProvider = {
 
 	/**
 	 * Execute an ability by name (fallback when callback path is not used).
-	 *
 	 * @param {string} name - The ability identifier.
 	 * @param {any}    args - Arguments to pass to the ability.
 	 * @returns {Promise<{result: Record<string, unknown>, returnToAgent?: boolean}>} Execution result.
@@ -468,7 +454,6 @@ export const toolProvider = {
 
 /**
  * Serialize a block for the orchestrator's Page context class.
- *
  * @param {any} block - The block to serialize.
  * @returns {any} Serialized block with name, clientId, attributes, innerBlocks.
  */
@@ -484,7 +469,6 @@ function serializeBlock( block: any ): any {
 /**
  * Extract the full text content from a block's content attribute.
  * Handles both plain strings and RichTextData objects.
- *
  * @param {any} rawContent - The block's content attribute value.
  * @returns {string} The resolved HTML string.
  */
@@ -504,7 +488,6 @@ function resolveBlockContent( rawContent: any ): string {
 export const contextProvider = {
 	/**
 	 * Build the client context object sent with each message.
-	 *
 	 * @returns {any} Context with page content, selected block, and block content.
 	 */
 	getClientContext(): any {
@@ -552,7 +535,6 @@ export const contextProvider = {
 
 /**
  * Map component type strings to React components for rendering in the chat.
- *
  * @param {string} type - The component type identifier.
  * @returns {ComponentType|null} The matching component, or null.
  */
@@ -567,7 +549,6 @@ export function getChatComponent( type: string ): ComponentType | null {
 
 /**
  * Suggestions shown in the AM empty view (before any messages).
- *
  * @returns {Array} Array of suggestion objects.
  */
 export function getEmptyViewSuggestions(): Array< {
@@ -636,7 +617,6 @@ const BLOCK_SUGGESTIONS = [
  *
  * Returns contextual suggestions based on the selected block type.
  * Hides permanently once the conversation becomes active.
- *
  * @returns {Object} Object containing a suggestions array.
  */
 export function useSuggestions(): {

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -25,6 +25,7 @@ import { __ } from '@wordpress/i18n';
  */
 import TitlePicker from './components/title-picker';
 import './components/title-picker.scss';
+import './auto-scroll-fix.scss';
 import {
 	UPDATE_BLOCK_CONTENT_TOOL_ID,
 	UPDATE_BLOCK_CONTENT_ABILITY,
@@ -338,28 +339,6 @@ export function useAbilitiesSetup( actions: {
 	if ( actions.clearSuggestions ) {
 		clearSuggestionsFn = actions.clearSuggestions;
 	}
-	setupAutoScrollFix();
-}
-
-/**
- * Override the AM's bottomMessages CSS so messages start from the top
- * instead of being pinned to the bottom via margin-top: auto.
- * This makes the chat push content upward when new messages arrive.
- */
-function setupAutoScrollFix(): void {
-	if ( ( window as any ).__jetpackAiScrollFixActive ) {
-		return;
-	}
-	( window as any ).__jetpackAiScrollFixActive = true;
-
-	const style = document.createElement( 'style' );
-	style.id = 'jetpack-ai-scroll-fix';
-	style.textContent = `
-		[data-slot="messages"] > *:first-child {
-			margin-top: 0 !important;
-		}
-	`;
-	document.head.appendChild( style );
 }
 
 // ---------- toolProvider ----------

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -178,7 +178,7 @@ function startBlockShimmer(): void {
  */
 function handleUpdateBlockContent( input: any ): any {
 	const { clientId, content, summary } = input;
-	if ( ! clientId || ! content ) {
+	if ( ! clientId || content === undefined || content === null ) {
 		return { success: false, error: 'clientId and content are required', returnToAgent: false };
 	}
 

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -310,6 +310,28 @@ export function useAbilitiesSetup( actions: {
 		clearSuggestionsFn = actions.clearSuggestions;
 	}
 	registerSelectTitleAbility();
+	setupAutoScrollFix();
+}
+
+/**
+ * Override the AM's bottomMessages CSS so messages start from the top
+ * instead of being pinned to the bottom via margin-top: auto.
+ * This makes the chat push content upward when new messages arrive.
+ */
+function setupAutoScrollFix(): void {
+	if ( ( window as any ).__jetpackAiScrollFixActive ) {
+		return;
+	}
+	( window as any ).__jetpackAiScrollFixActive = true;
+
+	const style = document.createElement( 'style' );
+	style.id = 'jetpack-ai-scroll-fix';
+	style.textContent = `
+		[data-slot="messages"] > *:first-child {
+			margin-top: 0 !important;
+		}
+	`;
+	document.head.appendChild( style );
 }
 
 // ---------- toolProvider ----------

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -170,27 +170,53 @@ function startBlockShimmer(): void {
  * @returns {Object} Result with returnToAgent: false.
  */
 function handleSelectTitle( input: any ): any {
-	if ( ! addMessageFn ) {
-		return { success: false, error: 'Provider not initialized', returnToAgent: false };
-	}
 	const titles = input?.titles;
 	if ( ! titles?.length ) {
 		return { success: false, error: 'No titles provided', returnToAgent: false };
 	}
-	addMessageFn( {
-		id: `title-picker-${ Date.now() }`,
-		role: 'assistant',
-		content: [
-			{
-				type: 'component',
-				component: TitlePicker,
-				componentProps: { titles },
-			},
-		],
-		created_at: Math.floor( Date.now() / 1000 ),
-		showIcon: true,
-	} );
-	return { success: true, returnToAgent: false };
+
+	// When running as an AM provider, addMessageFn is set by useAbilitiesSetup
+	// and we inject the TitlePicker component directly into the chat.
+	if ( addMessageFn ) {
+		addMessageFn( {
+			id: `title-picker-${ Date.now() }`,
+			role: 'assistant',
+			content: [
+				{
+					type: 'component',
+					component: TitlePicker,
+					componentProps: { titles },
+				},
+			],
+			created_at: Math.floor( Date.now() / 1000 ),
+			showIcon: true,
+		} );
+		return { success: true, returnToAgent: false };
+	}
+
+	// When running alongside Big Sky standalone (no AM provider setup),
+	// use Big Sky's AI store to inject the TitlePicker into the chat.
+	try {
+		const wpData = ( window as any ).wp?.data;
+		const aiStore = wpData?.dispatch?.( 'ai-assembler' );
+		if ( aiStore?.addMessage ) {
+			aiStore.addMessage( {
+				role: 'assistant',
+				content: [
+					{
+						type: 'component',
+						component: TitlePicker,
+						componentProps: { titles },
+					},
+				],
+			} );
+			return { success: true, returnToAgent: false, followUpTasks: false };
+		}
+	} catch {
+		// ignore
+	}
+
+	return { success: false, error: 'No chat interface available', returnToAgent: false };
 }
 
 /**
@@ -290,6 +316,10 @@ async function registerSelectTitleAbility(): Promise< void > {
 		}
 	}
 }
+
+// Register on module load so standalone integrations (without AM setup hooks)
+// still have the Jetpack AI abilities available.
+registerSelectTitleAbility();
 
 // ---------- useAbilitiesSetup ----------
 

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -3,9 +3,11 @@
  *
  * Exports the full AM provider contract:
  * - useAbilitiesSetup: captures AM's addMessage callback
- * - toolProvider: wraps `@wordpress/abilities` and adds Jetpack AI abilities
- * - contextProvider: sends gutenberg editor state to the orchestrator
- * - getChatComponent: maps tool IDs to React components
+ * - toolProvider: surfaces Jetpack AI's client-side abilities to AM
+ * - contextProvider: sends Gutenberg editor state to the orchestrator
+ * - getChatComponent: resolves `title-picker` to the TitlePicker component
+ *   for AM's show-component pipeline
+ * - useCheckpoint: post-title snapshots for AM's native Undo action
  * - getEmptyViewSuggestions: initial suggestions before conversation starts
  * - useSuggestions: block-aware dynamic suggestions during conversation
  */
@@ -24,9 +26,6 @@ import { __ } from '@wordpress/i18n';
 import TitlePicker from './components/title-picker';
 import './components/title-picker.scss';
 import {
-	SELECT_TITLE_TOOL_ID,
-	SELECT_TITLE_ABILITY,
-	isSelectTitleTool,
 	UPDATE_BLOCK_CONTENT_TOOL_ID,
 	UPDATE_BLOCK_CONTENT_ABILITY,
 	isUpdateBlockContentTool,
@@ -37,7 +36,18 @@ import type { ComponentType } from 'react';
 
 let addMessageFn: ( ( message: any ) => void ) | null = null;
 let clearSuggestionsFn: ( () => void ) | null = null;
-let isAbilityRegistered = false;
+
+/**
+ * Checkpoint API shared between the React `useCheckpoint` hook (which AM
+ * calls) and the synchronous `handleShowComponent` callback (which needs to
+ * snapshot state before the picker renders).
+ */
+interface CheckpointApi {
+	setCheckpoint: ( id: string ) => void;
+	hasCheckpoint: ( id: string ) => boolean;
+	restoreCheckpoint: ( id: string ) => Promise< void >;
+}
+let moduleCheckpointApi: CheckpointApi | null = null;
 
 /** Default suggestion shown when no block is selected. */
 const OPTIMIZE_TITLE_SUGGESTION = {
@@ -161,61 +171,6 @@ function startBlockShimmer(): void {
 // ---------- Ability callbacks ----------
 
 /**
- * Handle the select-title tool call: render TitlePicker in chat.
- * @param {any} input - Tool input with titles array.
- * @returns {Object} Result with returnToAgent: false.
- */
-function handleSelectTitle( input: any ): any {
-	const titles = input?.titles;
-	if ( ! titles?.length ) {
-		return { success: false, error: 'No titles provided', returnToAgent: false };
-	}
-
-	// When running as an AM provider, addMessageFn is set by useAbilitiesSetup
-	// and we inject the TitlePicker component directly into the chat.
-	if ( addMessageFn ) {
-		addMessageFn( {
-			id: `title-picker-${ Date.now() }`,
-			role: 'assistant',
-			content: [
-				{
-					type: 'component',
-					component: TitlePicker,
-					componentProps: { titles },
-				},
-			],
-			created_at: Math.floor( Date.now() / 1000 ),
-			showIcon: true,
-		} );
-		return { success: true, returnToAgent: false };
-	}
-
-	// When running alongside Big Sky standalone (no AM provider setup),
-	// use Big Sky's AI store to inject the TitlePicker into the chat.
-	try {
-		const wpData = ( window as any ).wp?.data;
-		const aiStore = wpData?.dispatch?.( 'ai-assembler' );
-		if ( aiStore?.addMessage ) {
-			aiStore.addMessage( {
-				role: 'assistant',
-				content: [
-					{
-						type: 'component',
-						component: TitlePicker,
-						componentProps: { titles },
-					},
-				],
-			} );
-			return { success: true, returnToAgent: false, followUpTasks: false };
-		}
-	} catch {
-		// ignore
-	}
-
-	return { success: false, error: 'No chat interface available', returnToAgent: false };
-}
-
-/**
  * Handle the update-block-content tool call: apply text changes to a block.
  * @param {any} input - Tool input with clientId, content, and optional summary.
  * @returns {Object} Result with returnToAgent: false.
@@ -267,7 +222,94 @@ function handleUpdateBlockContent( input: any ): any {
 	} );
 }
 
-// ---------- WP Abilities registration ----------
+// ---------- Show-component ability ----------
+
+const SHOW_COMPONENT_TOOL_ID = 'big_sky__show_component';
+
+/**
+ * Client-side ability definition for `big_sky__show_component`.
+ *
+ * Surfaced to AM via `toolProvider.getAbilities()` so the orchestrator
+ * recognizes the tool_id on self-hosted Jetpack sites where Big Sky's own
+ * registration isn't present. Same pattern as update-block-content.
+ */
+const SHOW_COMPONENT_ABILITY: any = {
+	id: SHOW_COMPONENT_TOOL_ID,
+	name: SHOW_COMPONENT_TOOL_ID,
+	label: 'Show component',
+	category: 'jetpack-ai',
+	description: 'Render an interactive component in the chat.',
+	input_schema: {
+		type: 'object',
+		properties: {
+			type: { type: 'string' },
+			props: { type: 'object' },
+		},
+		required: [ 'type' ],
+	},
+};
+
+/**
+ * Handles `big_sky__show_component` tool calls from the wpcom ability.
+ *
+ * Follows the Big Sky unified-experience pattern: instead of injecting the
+ * picker directly via `addMessage`, we return an `agentMessage` envelope.
+ * agenttic-client wraps it as an `{ role: 'agent', parts: [text] }` message,
+ * AM's `convert-tool-messages-to-components` transforms it into a component
+ * message via `getChatComponent(type)`, and AgentChat's action bar (thumbs,
+ * Undo) attaches because the original message had a text content part.
+ *
+ * Before returning, we snapshot the current post title via the shared
+ * checkpoint API so AM's native `use-checkpoint-action` can restore it when
+ * the user clicks Undo. The picker disables canvas zoom since title edits
+ * don't change block content.
+ * @param {any} input - Tool call arguments: `{ type, props, toolCallId, ... }`.
+ * @returns {Object} Result containing the `agentMessage` to re-emit.
+ */
+function handleShowComponent( input: any ): any {
+	const { type, props } = input || {};
+
+	if ( ! type ) {
+		return { success: false, error: 'show-component: missing type', returnToAgent: false };
+	}
+
+	if ( ! getChatComponent( type ) ) {
+		return {
+			success: false,
+			error: `show-component: no component registered for type "${ type }"`,
+			returnToAgent: false,
+		};
+	}
+
+	// Snapshot state for Undo. Tool call id doubles as the checkpoint id so
+	// it matches the identifier AM reads from the rendered message.
+	const checkpointId: string =
+		input?.toolCallId || input?.calypsoCheckpointId || `show-component-${ type }-${ Date.now() }`;
+	if ( moduleCheckpointApi && ! moduleCheckpointApi.hasCheckpoint( checkpointId ) ) {
+		try {
+			moduleCheckpointApi.setCheckpoint( checkpointId );
+		} catch {
+			// Non-fatal — Undo just won't attach if the snapshot fails.
+		}
+	}
+
+	const agentMessage = JSON.stringify( {
+		tool_id: SHOW_COMPONENT_TOOL_ID,
+		data: {
+			type,
+			props: props ?? {},
+			calypsoCheckpointId: checkpointId,
+			isCurrent: true,
+			hideZoomAction: true,
+		},
+	} );
+
+	return {
+		result: 'Component displayed successfully',
+		returnToAgent: false,
+		agentMessage,
+	};
+}
 
 /**
  * Check whether the `@wordpress/abilities` API is available.
@@ -281,44 +323,11 @@ function hasAbilitiesApi(): boolean {
 	}
 }
 
-/**
- * Register wpcom/select-title as a client-side ability via `@wordpress/abilities`.
- */
-async function registerSelectTitleAbility(): Promise< void > {
-	if ( isAbilityRegistered || ! hasAbilitiesApi() ) {
-		return;
-	}
-
-	// Set guard before await to prevent concurrent registration attempts.
-	isAbilityRegistered = true;
-
-	try {
-		const { registerAbility } = ( window as any ).wp.abilities;
-		await registerAbility( {
-			name: SELECT_TITLE_TOOL_ID,
-			label: 'Select title',
-			category: 'jetpack-ai',
-			description: SELECT_TITLE_ABILITY.description,
-			input_schema: SELECT_TITLE_ABILITY.input_schema,
-			callback: handleSelectTitle,
-		} );
-	} catch ( e: any ) {
-		if ( ! e?.message?.includes?.( 'already registered' ) ) {
-			isAbilityRegistered = false; // Reset on genuine failure.
-			// eslint-disable-next-line no-console
-			console.warn( '[Jetpack AI] Failed to register select-title ability:', e );
-		}
-	}
-}
-
-// Register on module load so standalone integrations (without AM setup hooks)
-// still have the Jetpack AI abilities available.
-registerSelectTitleAbility();
-
 // ---------- useAbilitiesSetup ----------
 
 /**
- * Captures AM's addMessage/clearSuggestions callbacks and registers abilities.
+ * Captures AM's addMessage/clearSuggestions callbacks so the
+ * update-block-content handler can post a summary line after applying edits.
  */
 export function useAbilitiesSetup( actions: {
 	addMessage: ( message: any ) => void;
@@ -329,7 +338,6 @@ export function useAbilitiesSetup( actions: {
 	if ( actions.clearSuggestions ) {
 		clearSuggestionsFn = actions.clearSuggestions;
 	}
-	registerSelectTitleAbility();
 	setupAutoScrollFix();
 }
 
@@ -358,8 +366,8 @@ function setupAutoScrollFix(): void {
 
 /**
  * Normalize an ability name to the format used by agenttic-client for matching.
- * @param {string} name - Ability name (e.g., 'wpcom/select-title').
- * @returns {string} Normalized name (e.g., 'wpcom__select_title').
+ * @param {string} name - Ability name (e.g., 'wpcom/update-block-content').
+ * @returns {string} Normalized name (e.g., 'wpcom__update_block_content').
  */
 function normalizeAbilityName( name: string ): string {
 	return name.replace( /\//g, '__' ).replace( /-/g, '_' );
@@ -378,14 +386,18 @@ function filterAbility( abilities: any[], toolId: string ): any[] {
 	);
 }
 
+function isShowComponentTool( toolId: string ): boolean {
+	return toolId === SHOW_COMPONENT_TOOL_ID || toolId === 'big_sky__show_component';
+}
+
 export const toolProvider = {
 	/**
-	 * Return all available abilities with Jetpack AI callbacks.
-	 *
-	 * Replaces any existing select-title and update-block-content abilities
-	 * with versions that have callbacks returning returnToAgent: false.
-	 * This is necessary because agenttic-client's executeAbility path
-	 * hardcodes returnToAgent: true, but the callback path respects it.
+	 * Return the client-side abilities this provider handles:
+	 * - `wpcom/update-block-content`: applies block edits and posts a summary.
+	 * - `big_sky__show_component`: renders interactive pickers (title-picker)
+	 *   via `handleShowComponent`. Registered here so the tool_id is known
+	 *   to the orchestrator on self-hosted Jetpack sites where Big Sky's
+	 *   own registration is unavailable.
 	 * @returns {Promise<any[]>} Array of ability descriptors.
 	 */
 	async getAbilities(): Promise< any[] > {
@@ -404,18 +416,16 @@ export const toolProvider = {
 			}
 		}
 
-		// Remove existing versions and add ours with callbacks
-		abilities = filterAbility( abilities, SELECT_TITLE_TOOL_ID );
 		abilities = filterAbility( abilities, UPDATE_BLOCK_CONTENT_TOOL_ID );
-
+		abilities = filterAbility( abilities, SHOW_COMPONENT_TOOL_ID );
 		abilities.unshift(
-			{
-				...SELECT_TITLE_ABILITY,
-				callback: handleSelectTitle,
-			},
 			{
 				...UPDATE_BLOCK_CONTENT_ABILITY,
 				callback: handleUpdateBlockContent,
+			},
+			{
+				...SHOW_COMPONENT_ABILITY,
+				callback: handleShowComponent,
 			}
 		);
 
@@ -432,13 +442,13 @@ export const toolProvider = {
 		name: string,
 		args: any
 	): Promise< { result: Record< string, unknown >; returnToAgent?: boolean } > {
-		if ( isSelectTitleTool( name ) ) {
-			return { result: handleSelectTitle( args ), returnToAgent: false };
-		}
-
 		if ( isUpdateBlockContentTool( name ) ) {
 			const result = await handleUpdateBlockContent( args );
 			return { result, returnToAgent: false };
+		}
+
+		if ( isShowComponentTool( name ) ) {
+			return { result: handleShowComponent( args ), returnToAgent: false };
 		}
 
 		if ( hasAbilitiesApi() ) {
@@ -539,10 +549,65 @@ export const contextProvider = {
  * @returns {ComponentType|null} The matching component, or null.
  */
 export function getChatComponent( type: string ): ComponentType | null {
-	if ( type === 'title-picker' || isSelectTitleTool( type ) ) {
+	if ( type === 'title-picker' ) {
 		return TitlePicker as ComponentType;
 	}
 	return null;
+}
+
+// ---------- useCheckpoint ----------
+
+/**
+ * Provider hook consumed by AM's `use-checkpoint-action` so Undo buttons
+ * can attach to show-component messages. Snapshots the post title on
+ * `setCheckpoint(id)` and restores it on `restoreCheckpoint(id)` via
+ * `core/editor` dispatch. Stubs the rest of AM's `UseCheckpointReturn`
+ * interface — only the three methods above are used on this path.
+ * @returns {Object} The checkpoint API AM consumes.
+ */
+const titleSnapshots: Map< string, string > = new Map();
+
+export function useCheckpoint(): any {
+	const api: CheckpointApi = {
+		setCheckpoint( id: string ) {
+			const wpData = ( window as any ).wp?.data;
+			const current =
+				( wpData?.select?.( 'core/editor' )?.getEditedPostAttribute?.( 'title' ) as string ) ?? '';
+			titleSnapshots.set( id, current );
+		},
+		hasCheckpoint( id: string ): boolean {
+			return titleSnapshots.has( id );
+		},
+		async restoreCheckpoint( id: string ): Promise< void > {
+			const previous = titleSnapshots.get( id );
+			if ( previous === undefined ) {
+				return;
+			}
+			const wpData = ( window as any ).wp?.data;
+			wpData?.dispatch?.( 'core/editor' )?.editPost?.( { title: previous } );
+			// Intentionally NOT deleting the snapshot here — the user can keep
+			// clicking titles in the picker and use Undo again to revert back
+			// to the original title (the state before the picker appeared).
+			// clearCheckpoint() removes the snapshot when AM resets the session.
+		},
+	};
+	moduleCheckpointApi = api;
+
+	// Return the full shape AM's UseCheckpointReturn expects. Methods we
+	// don't implement are safe no-op stubs — AM only calls the three above
+	// for the show-component / title-picker flow.
+	return {
+		...api,
+		getLastEditorState: () => null,
+		addCheckpointKeys: () => undefined,
+		addNewPageToCheckpoint: () => undefined,
+		addPageRenameToCheckpoint: () => undefined,
+		addPageRemovalToCheckpoint: () => undefined,
+		getLatestUserMessageId: () => undefined,
+		clearCheckpoint: ( id: string ) => {
+			titleSnapshots.delete( id );
+		},
+	};
 }
 
 // ---------- getEmptyViewSuggestions ----------

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -562,18 +562,7 @@ export function getEmptyViewSuggestions(): Array< {
 // ---------- useSuggestions ----------
 
 /** Block types that support text editing suggestions. */
-const TEXT_BLOCK_TYPES = [
-	'core/paragraph',
-	'core/heading',
-	'core/list',
-	'core/quote',
-	'core/pullquote',
-	'core/verse',
-	'core/preformatted',
-	'core/freeform',
-	'core/list-item',
-	'core/table',
-];
+const TEXT_BLOCK_TYPES = [ 'core/paragraph', 'core/heading' ];
 
 /** Block types that support image-related suggestions. */
 const IMAGE_BLOCK_TYPES = [ 'core/image', 'core/media-text', 'core/cover', 'core/gallery' ];

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -1,0 +1,630 @@
+/**
+ * Jetpack AI provider module for Agents Manager.
+ *
+ * Exports the full AM provider contract:
+ * - useAbilitiesSetup: captures AM's addMessage callback
+ * - toolProvider: wraps `@wordpress/abilities` and adds Jetpack AI abilities
+ * - contextProvider: sends gutenberg editor state to the orchestrator
+ * - getChatComponent: maps tool IDs to React components
+ * - getEmptyViewSuggestions: initial suggestions before conversation starts
+ * - useSuggestions: block-aware dynamic suggestions during conversation
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { useState, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import TitlePicker from './components/title-picker';
+import './components/title-picker.scss';
+import {
+	SELECT_TITLE_TOOL_ID,
+	SELECT_TITLE_ABILITY,
+	isSelectTitleTool,
+	UPDATE_BLOCK_CONTENT_TOOL_ID,
+	UPDATE_BLOCK_CONTENT_ABILITY,
+	isUpdateBlockContentTool,
+} from './utils/tool-provider';
+import type { ComponentType } from 'react';
+
+// ---------- Module state ----------
+
+let addMessageFn: ( ( message: any ) => void ) | null = null;
+let clearSuggestionsFn: ( () => void ) | null = null;
+let isAbilityRegistered = false;
+
+/** Default suggestion shown when no block is selected. */
+const OPTIMIZE_TITLE_SUGGESTION = {
+	id: 'optimize-title',
+	label: __( 'Optimize Title', 'jetpack' ),
+	prompt: __( 'Optimize the title of this post', 'jetpack' ),
+};
+
+// ---------- Block element helpers ----------
+
+/**
+ * Find a block element by clientId in the main document or editor iframe.
+ *
+ * @param {string} clientId - The block's clientId.
+ * @returns The block element, or null.
+ */
+function findBlockElement( clientId: string ): HTMLElement | null {
+	// Validate clientId format to prevent selector injection.
+	if ( ! /^[0-9a-f-]+$/i.test( clientId ) ) {
+		return null;
+	}
+
+	try {
+		const el = document.querySelector( `[data-block="${ clientId }"]` ) as HTMLElement | null;
+		if ( el ) {
+			return el;
+		}
+		const iframe = document.querySelector(
+			'iframe[name="editor-canvas"]'
+		) as HTMLIFrameElement | null;
+		return iframe?.contentDocument?.querySelector(
+			`[data-block="${ clientId }"]`
+		) as HTMLElement | null;
+	} catch {
+		return null;
+	}
+}
+
+// ---------- Processing effect (Flow Block shimmer) ----------
+
+/**
+ * Inject processing styles into the document containing the block.
+ * Uses Flow Block font + flash animation matching Big Sky's effect.
+ * @param doc
+ */
+function ensureProcessingStyles( doc: Document ): void {
+	if ( doc.getElementById( 'jetpack-ai-processing-styles' ) ) {
+		return;
+	}
+	const style = doc.createElement( 'style' );
+	style.id = 'jetpack-ai-processing-styles';
+	style.textContent = `
+		@import url("https://fonts.googleapis.com/css2?family=Flow+Block&display=swap");
+		@keyframes jetpack-ai-flash-text {
+			0% { opacity: 0.4; }
+			50% { opacity: 0.8; }
+			100% { opacity: 0.4; }
+		}
+		@keyframes jetpack-ai-highlight-fade {
+			0% { outline-color: rgba(56, 88, 233, 0.8); }
+			100% { outline-color: transparent; }
+		}
+		.jetpack-ai-is-processing,
+		.jetpack-ai-is-processing .wp-block-heading,
+		.jetpack-ai-is-processing .wp-block-paragraph {
+			font-family: "Flow Block", system-ui !important;
+			font-style: normal;
+			font-weight: 200;
+			transition: transform 1s;
+		}
+		.jetpack-ai-is-processing:not(:has(img)) {
+			animation: jetpack-ai-flash-text 2s infinite;
+		}
+		.jetpack-ai-has-processed {
+			outline: 2px solid rgba(56, 88, 233, 0.8);
+			outline-offset: 2px;
+			border-radius: 4px;
+			animation: jetpack-ai-highlight-fade 1s ease-out forwards;
+		}
+	`;
+	doc.head.appendChild( style );
+}
+
+/**
+ * Apply processing effect to a block element.
+ *
+ * @param el - The block element.
+ */
+function applyProcessingEffect( el: HTMLElement ): void {
+	ensureProcessingStyles( el.ownerDocument );
+	el.classList.add( 'jetpack-ai-is-processing' );
+}
+
+/**
+ * Remove processing effect and show a brief highlight.
+ *
+ * @param el - The block element.
+ */
+function removeProcessingEffect( el: HTMLElement ): void {
+	el.classList.remove( 'jetpack-ai-is-processing' );
+	el.classList.add( 'jetpack-ai-has-processed' );
+	setTimeout( () => {
+		el.classList.remove( 'jetpack-ai-has-processed' );
+	}, 1000 );
+}
+
+/**
+ * Start shimmer on the currently selected block (if any).
+ */
+function startBlockShimmer(): void {
+	const wpData = ( window as any ).wp?.data;
+	if ( ! wpData ) {
+		return;
+	}
+	const block = wpData.select( 'core/block-editor' ).getSelectedBlock();
+	if ( block?.clientId ) {
+		const blockEl = findBlockElement( block.clientId );
+		if ( blockEl ) {
+			applyProcessingEffect( blockEl );
+		}
+	}
+}
+
+// ---------- Ability callbacks ----------
+
+/**
+ * Handle the select-title tool call: render TitlePicker in chat.
+ *
+ * @param {any} input - Tool input with titles array.
+ * @returns {Object} Result with returnToAgent: false.
+ */
+function handleSelectTitle( input: any ): any {
+	if ( ! addMessageFn ) {
+		return { success: false, error: 'Provider not initialized', returnToAgent: false };
+	}
+	const titles = input?.titles;
+	if ( ! titles?.length ) {
+		return { success: false, error: 'No titles provided', returnToAgent: false };
+	}
+	addMessageFn( {
+		id: `title-picker-${ Date.now() }`,
+		role: 'assistant',
+		content: [
+			{
+				type: 'component',
+				component: TitlePicker,
+				componentProps: { titles },
+			},
+		],
+		created_at: Math.floor( Date.now() / 1000 ),
+		showIcon: true,
+	} );
+	return { success: true, returnToAgent: false };
+}
+
+/**
+ * Handle the update-block-content tool call: apply text changes to a block.
+ *
+ * @param {any} input - Tool input with clientId, content, and optional summary.
+ * @returns {Object} Result with returnToAgent: false.
+ */
+function handleUpdateBlockContent( input: any ): any {
+	const { clientId, content, summary } = input;
+	if ( ! clientId || ! content ) {
+		return { success: false, error: 'clientId and content are required', returnToAgent: false };
+	}
+
+	const wpData = ( window as any ).wp?.data;
+	if ( ! wpData ) {
+		return { success: false, error: 'WordPress data not available', returnToAgent: false };
+	}
+
+	const blockEditor = wpData.dispatch( 'core/block-editor' );
+	if ( ! blockEditor ) {
+		return { success: false, error: 'Block editor not available', returnToAgent: false };
+	}
+
+	// Apply shimmer briefly, then update content and show highlight
+	const blockEl = findBlockElement( clientId );
+	if ( blockEl ) {
+		applyProcessingEffect( blockEl );
+	}
+
+	// Short delay so the shimmer is visible before content swaps
+	return new Promise< any >( ( resolve ) => {
+		setTimeout( () => {
+			blockEditor.updateBlockAttributes( clientId, { content } );
+
+			if ( blockEl ) {
+				removeProcessingEffect( blockEl );
+			}
+
+			// Show summary in chat
+			if ( addMessageFn && summary ) {
+				addMessageFn( {
+					id: `block-update-${ Date.now() }`,
+					role: 'assistant',
+					content: [ { type: 'text', text: summary } ],
+					created_at: Math.floor( Date.now() / 1000 ),
+					showIcon: true,
+				} );
+			}
+
+			resolve( { success: true, returnToAgent: false } );
+		}, 800 );
+	} );
+}
+
+// ---------- WP Abilities registration ----------
+
+/**
+ * Check whether the `@wordpress/abilities` API is available.
+ *
+ * @returns {boolean} True when window.wp.abilities.getAbilities exists.
+ */
+function hasAbilitiesApi(): boolean {
+	try {
+		return !! ( window as any ).wp?.abilities?.getAbilities;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Register wpcom/select-title as a client-side ability via `@wordpress/abilities`.
+ */
+async function registerSelectTitleAbility(): Promise< void > {
+	if ( isAbilityRegistered || ! hasAbilitiesApi() ) {
+		return;
+	}
+
+	// Set guard before await to prevent concurrent registration attempts.
+	isAbilityRegistered = true;
+
+	try {
+		const { registerAbility } = ( window as any ).wp.abilities;
+		await registerAbility( {
+			name: SELECT_TITLE_TOOL_ID,
+			label: 'Select title',
+			category: 'jetpack-ai',
+			description: SELECT_TITLE_ABILITY.description,
+			input_schema: SELECT_TITLE_ABILITY.input_schema,
+			callback: async ( input: any ) => handleSelectTitle( input ),
+		} );
+	} catch ( e: any ) {
+		if ( ! e?.message?.includes?.( 'already registered' ) ) {
+			isAbilityRegistered = false; // Reset on genuine failure.
+			// eslint-disable-next-line no-console
+			console.warn( '[Jetpack AI] Failed to register select-title ability:', e );
+		}
+	}
+}
+
+// ---------- useAbilitiesSetup ----------
+
+/**
+ * Captures AM's addMessage/clearSuggestions callbacks and registers abilities.
+ *
+ * @param {Object} actions                  - The actions object provided by AM.
+ * @param          actions.addMessage
+ * @param          actions.clearSuggestions
+ */
+export function useAbilitiesSetup( actions: {
+	addMessage: ( message: any ) => void;
+	clearSuggestions?: () => void;
+	[ key: string ]: unknown;
+} ): void {
+	addMessageFn = actions.addMessage;
+	if ( actions.clearSuggestions ) {
+		clearSuggestionsFn = actions.clearSuggestions;
+	}
+	registerSelectTitleAbility();
+}
+
+// ---------- toolProvider ----------
+
+/**
+ * Normalize an ability name to the format used by agenttic-client for matching.
+ *
+ * @param {string} name - Ability name (e.g., 'wpcom/select-title').
+ * @returns {string} Normalized name (e.g., 'wpcom__select_title').
+ */
+function normalizeAbilityName( name: string ): string {
+	return name.replace( /\//g, '__' ).replace( /-/g, '_' );
+}
+
+/**
+ * Filter out an ability by name from a list.
+ *
+ * @param {any[]}  abilities - List of abilities.
+ * @param {string} toolId    - Tool ID to remove.
+ * @returns {any[]} Filtered list.
+ */
+function filterAbility( abilities: any[], toolId: string ): any[] {
+	const normalized = normalizeAbilityName( toolId );
+	return abilities.filter(
+		( a: any ) => normalizeAbilityName( a.name ?? '' ) !== normalized && a.name !== toolId
+	);
+}
+
+export const toolProvider = {
+	/**
+	 * Return all available abilities with Jetpack AI callbacks.
+	 *
+	 * Replaces any existing select-title and update-block-content abilities
+	 * with versions that have callbacks returning returnToAgent: false.
+	 * This is necessary because agenttic-client's executeAbility path
+	 * hardcodes returnToAgent: true, but the callback path respects it.
+	 *
+	 * @returns {Promise<any[]>} Array of ability descriptors.
+	 */
+	async getAbilities(): Promise< any[] > {
+		let abilities: any[] = [];
+
+		if ( hasAbilitiesApi() ) {
+			try {
+				const { getAbilities } = ( window as any ).wp.abilities;
+				const wpAbilities = await getAbilities();
+				if ( Array.isArray( wpAbilities ) ) {
+					abilities = wpAbilities;
+				}
+			} catch ( e ) {
+				// eslint-disable-next-line no-console
+				console.warn( '[Jetpack AI] Failed to load WP abilities:', e );
+			}
+		}
+
+		// Remove existing versions and add ours with callbacks
+		abilities = filterAbility( abilities, SELECT_TITLE_TOOL_ID );
+		abilities = filterAbility( abilities, UPDATE_BLOCK_CONTENT_TOOL_ID );
+
+		abilities.unshift(
+			{
+				...SELECT_TITLE_ABILITY,
+				callback: async ( input: any ) => handleSelectTitle( input ),
+			},
+			{
+				...UPDATE_BLOCK_CONTENT_ABILITY,
+				callback: async ( input: any ) => handleUpdateBlockContent( input ),
+			}
+		);
+
+		return abilities;
+	},
+
+	/**
+	 * Execute an ability by name (fallback when callback path is not used).
+	 *
+	 * @param {string} name - The ability identifier.
+	 * @param {any}    args - Arguments to pass to the ability.
+	 * @returns {Promise<{result: Record<string, unknown>, returnToAgent?: boolean}>} Execution result.
+	 */
+	async executeAbility(
+		name: string,
+		args: any
+	): Promise< { result: Record< string, unknown >; returnToAgent?: boolean } > {
+		if ( isSelectTitleTool( name ) ) {
+			return { result: handleSelectTitle( args ), returnToAgent: false };
+		}
+
+		if ( isUpdateBlockContentTool( name ) ) {
+			const result = await handleUpdateBlockContent( args );
+			return { result, returnToAgent: false };
+		}
+
+		if ( hasAbilitiesApi() ) {
+			const { executeAbility } = ( window as any ).wp.abilities;
+			return executeAbility( name, args );
+		}
+
+		return { result: { error: `Unknown ability: ${ name }` } };
+	},
+};
+
+// ---------- contextProvider ----------
+
+/**
+ * Serialize a block for the orchestrator's Page context class.
+ *
+ * @param {any} block - The block to serialize.
+ * @returns {any} Serialized block with name, clientId, attributes, innerBlocks.
+ */
+function serializeBlock( block: any ): any {
+	return {
+		name: block.name,
+		clientId: block.clientId,
+		attributes: block.attributes,
+		innerBlocks: ( block.innerBlocks || [] ).map( serializeBlock ),
+	};
+}
+
+/**
+ * Extract the full text content from a block's content attribute.
+ * Handles both plain strings and RichTextData objects.
+ *
+ * @param {any} rawContent - The block's content attribute value.
+ * @returns {string} The resolved HTML string.
+ */
+function resolveBlockContent( rawContent: any ): string {
+	if ( typeof rawContent === 'string' ) {
+		return rawContent;
+	}
+	if ( rawContent?.toHTMLString ) {
+		return rawContent.toHTMLString();
+	}
+	return '';
+}
+
+/**
+ * Provides gutenberg editor state to the orchestrator via client context.
+ */
+export const contextProvider = {
+	/**
+	 * Build the client context object sent with each message.
+	 *
+	 * @returns {any} Context with page content, selected block, and block content.
+	 */
+	getClientContext(): any {
+		const wpData = ( window as any ).wp?.data;
+		let currentPageContent: any[] = [];
+		let selectedBlockClientId = '';
+		let selectedBlockContent = '';
+
+		if ( wpData ) {
+			const blockEditor = wpData.select( 'core/block-editor' );
+			if ( blockEditor ) {
+				const blocks = blockEditor.getBlocks?.() ?? [];
+				currentPageContent = blocks.map( serializeBlock );
+				selectedBlockClientId = blockEditor.getSelectedBlockClientId?.() ?? '';
+
+				if ( selectedBlockClientId ) {
+					const selectedBlock = blockEditor.getSelectedBlock?.();
+					if ( selectedBlock?.attributes?.content ) {
+						selectedBlockContent = resolveBlockContent( selectedBlock.attributes.content );
+					}
+				}
+			}
+		}
+
+		return {
+			url: window.location.href,
+			pathname: window.location.pathname,
+			search: window.location.search,
+			environment: 'gutenberg',
+			titleSuggestionCount: 3,
+			currentPageContent,
+			selectedBlockClientId,
+			contextEntries: [
+				{
+					id: 'selected-block-content',
+					type: 'selected-block-content',
+					data: selectedBlockContent ? { content: selectedBlockContent } : null,
+				},
+			],
+		};
+	},
+};
+
+// ---------- getChatComponent ----------
+
+/**
+ * Map component type strings to React components for rendering in the chat.
+ *
+ * @param {string} type - The component type identifier.
+ * @returns {ComponentType|null} The matching component, or null.
+ */
+export function getChatComponent( type: string ): ComponentType | null {
+	if ( type === 'title-picker' || isSelectTitleTool( type ) ) {
+		return TitlePicker as ComponentType;
+	}
+	return null;
+}
+
+// ---------- getEmptyViewSuggestions ----------
+
+/**
+ * Suggestions shown in the AM empty view (before any messages).
+ *
+ * @returns {Array} Array of suggestion objects.
+ */
+export function getEmptyViewSuggestions(): Array< {
+	id: string;
+	label: string;
+	prompt?: string;
+} > {
+	return [ OPTIMIZE_TITLE_SUGGESTION ];
+}
+
+// ---------- useSuggestions ----------
+
+/** Block types that support text editing suggestions. */
+const TEXT_BLOCK_TYPES = [
+	'core/paragraph',
+	'core/heading',
+	'core/list',
+	'core/quote',
+	'core/pullquote',
+	'core/verse',
+	'core/preformatted',
+	'core/freeform',
+	'core/list-item',
+	'core/table',
+];
+
+/** Block types that support image-related suggestions. */
+const IMAGE_BLOCK_TYPES = [ 'core/image', 'core/media-text', 'core/cover', 'core/gallery' ];
+
+/** Block-aware suggestion definitions with optional condition per block type. */
+const BLOCK_SUGGESTIONS = [
+	{
+		id: 'translate-content',
+		label: __( 'Translate content', 'jetpack' ),
+		prompt: __( 'Translate this block content to:', 'jetpack' ),
+		condition: ( block: any ) => TEXT_BLOCK_TYPES.includes( block?.name ),
+	},
+	{
+		id: 'change-tone',
+		label: __( 'Change tone', 'jetpack' ),
+		prompt: __( 'Change the tone of this text to be more:', 'jetpack' ),
+		condition: ( block: any ) => TEXT_BLOCK_TYPES.includes( block?.name ),
+	},
+	{
+		id: 'check-grammar',
+		label: __( 'Check grammar', 'jetpack' ),
+		prompt: __( 'Check the grammar and spelling of this text', 'jetpack' ),
+		condition: ( block: any ) => TEXT_BLOCK_TYPES.includes( block?.name ),
+	},
+	{
+		id: 'simplify-text',
+		label: __( 'Simplify text', 'jetpack' ),
+		prompt: __( 'Simplify this text to make it easier to read', 'jetpack' ),
+		condition: ( block: any ) => TEXT_BLOCK_TYPES.includes( block?.name ),
+	},
+	{
+		id: 'generate-alt-text',
+		label: __( 'Generate alt text', 'jetpack' ),
+		prompt: __( 'Generate descriptive alt text for this image', 'jetpack' ),
+		condition: ( block: any ) => IMAGE_BLOCK_TYPES.includes( block?.name ),
+	},
+];
+
+/**
+ * Block-aware dynamic suggestions for the AM sidebar.
+ *
+ * Returns contextual suggestions based on the selected block type.
+ * Hides permanently once the conversation becomes active.
+ *
+ * @returns {Object} Object containing a suggestions array.
+ */
+export function useSuggestions(): {
+	suggestions: Array< { id: string; label: string; prompt?: string } >;
+} {
+	const [ hidden, setHidden ] = useState( false );
+
+	useEffect( () => {
+		const handleSuggestionClick = () => {
+			setHidden( true );
+			clearSuggestionsFn?.();
+			startBlockShimmer();
+		};
+		window.addEventListener( 'big-sky-inline-suggestion-click', handleSuggestionClick );
+		return () => {
+			window.removeEventListener( 'big-sky-inline-suggestion-click', handleSuggestionClick );
+		};
+	}, [] );
+
+	const selectedBlock = useSelect(
+		( select ) =>
+			( select( 'core/block-editor' ) as { getSelectedBlock: () => any } ).getSelectedBlock(),
+		[]
+	);
+
+	// Re-show suggestions when block selection changes (unless conversation is active)
+	useEffect( () => {
+		setHidden( false );
+	}, [ selectedBlock?.clientId ] );
+
+	if ( hidden ) {
+		return { suggestions: [] };
+	}
+
+	if ( ! selectedBlock ) {
+		return { suggestions: [ OPTIMIZE_TITLE_SUGGESTION ] };
+	}
+
+	const applicable = BLOCK_SUGGESTIONS.filter( ( s ) => s.condition( selectedBlock ) );
+	return {
+		suggestions: applicable.map( ( { id, label, prompt } ) => ( { id, label, prompt } ) ),
+	};
+}

--- a/packages/jetpack-ai-sidebar/src/utils/tool-provider.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/tool-provider.ts
@@ -1,0 +1,74 @@
+/**
+ * Title optimization tool provider — ability definition and helpers.
+ *
+ * Used by jetpack-ai-provider.ts (Agents Manager provider module).
+ */
+
+import type { Tool } from '@automattic/agenttic-client';
+
+export const SELECT_TITLE_TOOL_ID = 'wpcom/select-title';
+
+export const SELECT_TITLE_ABILITY: Tool = {
+	id: SELECT_TITLE_TOOL_ID,
+	name: SELECT_TITLE_TOOL_ID,
+	...( { label: 'Select title', category: 'jetpack-ai' } as any ), // eslint-disable-line @typescript-eslint/no-explicit-any
+	description:
+		'Present title suggestions to the user for selection. Call this after generating optimized title options. The user will see a picker UI and can choose one to apply to their post.',
+	input_schema: {
+		type: 'object',
+		properties: {
+			titles: {
+				type: 'array',
+				description: 'Array of title suggestions with explanations',
+				items: {
+					type: 'object',
+					properties: {
+						title: { type: 'string', description: 'The suggested title' },
+						explanation: {
+							type: 'string',
+							description: 'Why this title is effective',
+						},
+					},
+					required: [ 'title' ],
+				},
+			},
+		},
+		required: [ 'titles' ],
+	},
+};
+
+export function isSelectTitleTool( toolId: string ): boolean {
+	return toolId === SELECT_TITLE_TOOL_ID || toolId === 'wpcom__select_title';
+}
+
+export const UPDATE_BLOCK_CONTENT_TOOL_ID = 'wpcom/update-block-content';
+
+export const UPDATE_BLOCK_CONTENT_ABILITY: Tool = {
+	id: UPDATE_BLOCK_CONTENT_TOOL_ID,
+	name: UPDATE_BLOCK_CONTENT_TOOL_ID,
+	...( { label: 'Update block content', category: 'jetpack-ai' } as any ), // eslint-disable-line @typescript-eslint/no-explicit-any
+	description:
+		'Update the text content of a specific block in the editor. Use this after translating, changing tone, checking grammar, or any other text transformation. The block will be updated directly in the editor.',
+	input_schema: {
+		type: 'object',
+		properties: {
+			clientId: {
+				type: 'string',
+				description: 'The clientId of the block to update (from selected_block_client_id).',
+			},
+			content: {
+				type: 'string',
+				description: 'The new HTML content for the block.',
+			},
+			summary: {
+				type: 'string',
+				description: 'A brief user-friendly description of what was changed.',
+			},
+		},
+		required: [ 'clientId', 'content' ],
+	},
+};
+
+export function isUpdateBlockContentTool( toolId: string ): boolean {
+	return toolId === UPDATE_BLOCK_CONTENT_TOOL_ID || toolId === 'wpcom__update_block_content';
+}

--- a/packages/jetpack-ai-sidebar/src/utils/tool-provider.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/tool-provider.ts
@@ -1,45 +1,15 @@
 /**
- * Title optimization tool provider — ability definition and helpers.
+ * Tool provider — client-side ability definitions and helpers.
  *
  * Used by jetpack-ai-provider.ts (Agents Manager provider module).
+ *
+ * Title optimization is routed through AM's native `big_sky__show_component`
+ * pipeline, so no client-side `wpcom/select-title` ability is registered here;
+ * the TitlePicker component is resolved via `getChatComponent('title-picker')`
+ * at render time.
  */
 
 import type { Tool } from '@automattic/agenttic-client';
-
-export const SELECT_TITLE_TOOL_ID = 'wpcom/select-title';
-
-export const SELECT_TITLE_ABILITY: Tool = {
-	id: SELECT_TITLE_TOOL_ID,
-	name: SELECT_TITLE_TOOL_ID,
-	...( { label: 'Select title', category: 'jetpack-ai' } as any ), // eslint-disable-line @typescript-eslint/no-explicit-any
-	description:
-		'Present title suggestions to the user for selection. Call this after generating optimized title options. The user will see a picker UI and can choose one to apply to their post.',
-	input_schema: {
-		type: 'object',
-		properties: {
-			titles: {
-				type: 'array',
-				description: 'Array of title suggestions with explanations',
-				items: {
-					type: 'object',
-					properties: {
-						title: { type: 'string', description: 'The suggested title' },
-						explanation: {
-							type: 'string',
-							description: 'Why this title is effective',
-						},
-					},
-					required: [ 'title' ],
-				},
-			},
-		},
-		required: [ 'titles' ],
-	},
-};
-
-export function isSelectTitleTool( toolId: string ): boolean {
-	return toolId === SELECT_TITLE_TOOL_ID || toolId === 'wpcom__select_title';
-}
 
 export const UPDATE_BLOCK_CONTENT_TOOL_ID = 'wpcom/update-block-content';
 

--- a/packages/jetpack-ai-sidebar/tsconfig-cjs.json
+++ b/packages/jetpack-ai-sidebar/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig",
+	"compilerOptions": {
+		"module": "commonjs",
+		"outDir": "dist/cjs"
+	}
+}

--- a/packages/jetpack-ai-sidebar/tsconfig.json
+++ b/packages/jetpack-ai-sidebar/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"extends": "@automattic/calypso-typescript-config/ts-package.json",
+	"compilerOptions": {
+		"allowJs": true,
+		"checkJs": false,
+		"declarationDir": "dist/types",
+		"outDir": "dist/esm",
+		"rootDir": "src"
+	},
+	"include": [ "src", "src/*.json" ],
+	"exclude": [ "**/test/*", "**/*.test.ts", "**/*.test.tsx", "**/*.test.js", "**/__mocks__/**" ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -116,6 +116,7 @@ __metadata:
     "@automattic/calypso-apps-builder": "workspace:^"
     "@automattic/calypso-build": "workspace:^"
     "@automattic/image-studio": "workspace:^"
+    "@automattic/jetpack-ai-sidebar": "workspace:^"
     "@automattic/wp-babel-makepot": "workspace:^"
     "@tanstack/react-query": "npm:^5.83.0"
     "@wordpress/components": "npm:^28.23.0"
@@ -1541,6 +1542,26 @@ __metadata:
   peerDependenciesMeta:
     "@babel/runtime":
       optional: true
+  languageName: unknown
+  linkType: soft
+
+"@automattic/jetpack-ai-sidebar@workspace:^, @automattic/jetpack-ai-sidebar@workspace:packages/jetpack-ai-sidebar":
+  version: 0.0.0-use.local
+  resolution: "@automattic/jetpack-ai-sidebar@workspace:packages/jetpack-ai-sidebar"
+  dependencies:
+    "@automattic/agenttic-client": "npm:^0.1.53"
+    "@automattic/calypso-typescript-config": "workspace:^"
+    "@types/react": "npm:^18.3.1"
+    "@types/react-dom": "npm:^18.3.1"
+    "@wordpress/abilities": "npm:^0.4.0"
+    "@wordpress/components": "npm:^30.9.0"
+    "@wordpress/i18n": "npm:^5.23.0"
+    typescript: "npm:^5.8.3"
+  peerDependencies:
+    "@wordpress/data": ^10.23.0
+    "@wordpress/element": ^6.23.0
+    react: ^18.3.1
+    react-dom: ^18.3.1
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1549,7 +1549,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/jetpack-ai-sidebar@workspace:packages/jetpack-ai-sidebar"
   dependencies:
-    "@automattic/agenttic-client": "npm:^0.1.53"
+    "@automattic/agenttic-client": "npm:^0.1.58"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@types/react": "npm:^18.3.1"
     "@types/react-dom": "npm:^18.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -126,6 +126,7 @@ __metadata:
     "@wordpress/i18n": "npm:^6.13.0"
     "@wordpress/plugins": "npm:^7.23.0"
     "@wordpress/readable-js-assets-webpack-plugin": "npm:^3.24.0"
+    copy-webpack-plugin: "npm:^10.2.4"
     webpack: "npm:^5.99.8"
   peerDependencies:
     "@automattic/calypso-router": "workspace:^"


### PR DESCRIPTION
## Summary

Add the `@automattic/jetpack-ai-sidebar` package and its CDN build, plus the Agents Manager changes needed to host it as an external provider. This is the client half of the Jetpack AI sidebar: title optimization via the show-component pattern, TitlePicker UI, and provider merge support so Jetpack can coexist with Big Sky.

## What this does

### Jetpack AI sidebar package (`packages/jetpack-ai-sidebar`)

- **AM provider contract**: `useAbilitiesSetup`, `toolProvider`, `contextProvider`, `getChatComponent`, `useCheckpoint`, `getEmptyViewSuggestions`, `useSuggestions`
- **Title optimization via show-component**: `handleShowComponent` snapshots the current title with `moduleCheckpointApi.setCheckpoint(id)` and returns `{ agentMessage: JSON.stringify(payload) }`. The server-side `wpcom/optimize-title` ability emits `tool_id: 'big_sky__show_component'` with `data.type: 'title-picker'`, and AM's convert pipeline resolves the component via `getChatComponent`.
- **TitlePicker component**: auto-apply on click, keep picker visible after apply, highlight the applied title. No inline feedback/undo — AM's native action bar hooks (`use-feedback-action`, `use-checkpoint-action`) attach because the message has `role: 'agent'` with a text content part.
- **Auto-register abilities on load**, with an `ai-assembler` store fallback so the provider works in environments where the wp-abilities store isn't pre-populated.
- **Text block suggestions** limited to `core/paragraph` and `core/heading` (blocks that use `attributes.content`).
- **AGENTS.md** package-level agent guide documenting the show-component flow and how to add new pickers.
- **Unit tests** covering show-component, checkpoint set/restore, and role-transformer behavior.

### Agents Manager changes (`packages/agents-manager`)

- **First-write-wins provider merge** (`utils/load-external-providers.ts`): merges `toolProvider.getAbilities`, `executeAbility`, `executeTool`, and other exports across multiple providers in priority order. Earlier providers in the list win on collisions. Errors during execution now surface instead of being swallowed.
- **`use-zoom-action` opt-out**: respects `data.hideZoomAction: true` on show-component payloads so components like TitlePicker (which don't edit block content) don't get a canvas-zoom button.
- **Auto-scroll fix** pinning chat messages to the top.

### CDN build (`apps/agents-manager`)

- **IIFE entry** (`jetpack-ai-sidebar.js`): imports all provider exports and assigns them to `window.__JetpackAIProvider`
- **ESM wrapper** (`jetpack-ai-sidebar.provider.mjs`): lazy re-export using proxies to avoid race conditions when AM dynamically imports the provider before the IIFE has finished evaluating
- **webpack.config.js**: builds both artifacts into `apps/agents-manager/dist/`, which rsyncs to the widgets.wp.com sandbox via `calypso-apps-builder`

### Other

- Bump `@automattic/agenttic-client` to `^0.1.58` (needed for the show-component `agentMessage` escape hatch)

## Dependencies

- Jetpack: [Automattic/jetpack#47730](https://github.com/Automattic/jetpack/pull/47730) — PHP loader + provider registration

## Steps to Test

See WPCOM PR 210965.