### PR TITLE
MSD: Slide content off-screen when mobile sidebar opens

### DIFF
--- a/client/dashboard/app/root/index.tsx
+++ b/client/dashboard/app/root/index.tsx
@@ -2,6 +2,7 @@ import { WordPressLogo } from '@automattic/components/src/logos/wordpress-logo';
 import { useQueryClient, useIsFetching } from '@tanstack/react-query';
 import { CatchNotFound, Outlet, useRouterState, useRouter } from '@tanstack/react-router';
 import { useViewportMatch } from '@wordpress/compose';
+import clsx from 'clsx';
 import {
 	Suspense,
 	lazy,
@@ -132,7 +133,11 @@ function Root() {
 							onClose={ closeResponsiveSidebar }
 						/>
 					) }
-					<div className="dashboard-root__content">
+					<div
+						className={ clsx( 'dashboard-root__content', {
+							'is-sidebar-open': ! isDesktop && isResponsiveSidebarOpen,
+						} ) }
+					>
 						{ ! isDesktop && isResponsiveSidebarOpen && (
 							<div
 								className="dashboard-root__content-overlay"

--- a/client/dashboard/app/root/style.scss
+++ b/client/dashboard/app/root/style.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/variables';
+@import '@wordpress/base-styles/mixins';
+
 .dashboard-root__content > .dashboard-header-bar {
 	position: sticky;
 	top: 0;
@@ -7,6 +10,10 @@
 .dashboard-root__body {
 	display: flex;
 	min-height: 100vh;
+
+	@media ( max-width: #{ ( $break-medium - 1 ) } ) {
+		overflow-x: hidden;
+	}
 }
 
 .dashboard-root__content {
@@ -15,6 +22,16 @@
 	flex-direction: column;
 	flex: 1;
 	min-width: 0;
+
+	@media ( max-width: #{ ( $break-medium - 1 ) } ) {
+		transition: transform 0.2s ease-out;
+
+		&.is-sidebar-open {
+			transform: translateX( 272px );
+			overflow: hidden;
+			height: 100vh;
+		}
+	}
 }
 
 .dashboard-root__content-overlay {

--- a/client/dashboard/app/sidebar/style.scss
+++ b/client/dashboard/app/sidebar/style.scss
@@ -26,15 +26,17 @@ $sidebar-width: 272px;
 }
 
 .dashboard-sidebar-responsive__panel {
-	width: 0;
-	flex-shrink: 0;
-	overflow: hidden;
-	transition: width 0.2s ease-out;
-	position: sticky;
+	position: fixed;
 	top: 0;
+	left: 0;
+	width: $sidebar-width;
 	height: 100vh;
+	transform: translateX( -100% );
+	transition: transform 0.2s ease-out;
+	z-index: 101; // Above content overlay
+	overflow-y: auto;
 
 	&.is-open {
-		width: $sidebar-width;
+		transform: translateX( 0 );
 	}
 }


### PR DESCRIPTION
## Proposed Changes

* Changed the mobile sidebar from width-based animation to a fixed-position slide-in using CSS transforms.
* Content area now translates right by the sidebar width instead of resizing, preventing layout reflow.
* Scoped all mobile sidebar styles below the medium breakpoint so desktop layout is unaffected.
* Locked vertical scroll on the content area while the sidebar is open.

## Why are these changes being made?

Previously, opening the mobile sidebar caused the content area to resize as the sidebar grew from `width: 0` to `272px`. This triggered layout reflow and made the content visually shrink. The new approach uses `transform: translateX()` on both the sidebar and content, which is GPU-composited and keeps the content at full width — it simply slides off-screen to the right.

## Testing Instructions

* Open the dashboard on a mobile viewport (below 782px).
* Tap the hamburger menu to open the sidebar.
* Verify the content slides to the right without resizing.
* Verify vertical scrolling is locked while the sidebar is open.
* Tap the overlay or a nav link to close the sidebar and confirm it slides back.
* Verify desktop layout is unchanged.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?