### PR TITLE
MSD: Mobile sidebar improvements

### DIFF
--- a/client/dashboard/app/omnibar-header/index.tsx
+++ b/client/dashboard/app/omnibar-header/index.tsx
@@ -4,6 +4,7 @@ import { __ } from '@wordpress/i18n';
 import { menu } from '@wordpress/icons';
 import HeaderBar from '../../components/header-bar';
 import SecondaryMenu from '../secondary-menu';
+import './style.scss';
 
 function OmnibarHeader( { onToggleMenu }: { onToggleMenu?: () => void } ) {
 	const isDesktop = useViewportMatch( 'medium' );

--- a/client/dashboard/app/omnibar-header/style.scss
+++ b/client/dashboard/app/omnibar-header/style.scss
@@ -1,0 +1,3 @@
+:root {
+	--masterbar-height: 61px !important;
+}

--- a/client/dashboard/app/responsive-sidebar/_variables.scss
+++ b/client/dashboard/app/responsive-sidebar/_variables.scss
@@ -1,0 +1,1 @@
+$sidebar-width: 272px;

--- a/client/dashboard/app/responsive-sidebar/index.tsx
+++ b/client/dashboard/app/responsive-sidebar/index.tsx
@@ -1,5 +1,7 @@
+import { useRouter } from '@tanstack/react-router';
 import { useViewportMatch } from '@wordpress/compose';
 import clsx from 'clsx';
+import { useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import Sidebar from './sidebar';
 
@@ -12,6 +14,7 @@ export default function ResponsiveSidebar( {
 	isOpen: boolean;
 	onClose: () => void;
 } ) {
+	const router = useRouter();
 	const isDesktop = useViewportMatch( 'medium' );
 
 	const handleOverlayClick = () => {
@@ -23,6 +26,24 @@ export default function ResponsiveSidebar( {
 			onClose();
 		}
 	};
+
+	// Close sidebar after the navigation.
+	useEffect( () => {
+		if ( isDesktop ) {
+			return () => {};
+		}
+
+		const unsubscribe = router.subscribe( 'onLoad', () => {
+			onClose();
+			// Brief delay so the user sees the selected state before
+			// the sidebar slides closed.
+			// timeoutId = window.setTimeout( onClose, 0 );
+		} );
+
+		return () => {
+			unsubscribe();
+		};
+	}, [ isDesktop, router, onClose ] );
 
 	if ( isDesktop ) {
 		return <Sidebar />;
@@ -41,7 +62,7 @@ export default function ResponsiveSidebar( {
 					/>,
 					document.body
 				) }
-			<Sidebar onNavigate={ onClose } />
+			<Sidebar />
 		</div>
 	);
 }

--- a/client/dashboard/app/responsive-sidebar/sidebar.scss
+++ b/client/dashboard/app/responsive-sidebar/sidebar.scss
@@ -1,7 +1,7 @@
 @import '@wordpress/base-styles/variables';
 @import '@wordpress/base-styles/mixins';
 
-$sidebar-width: 272px;
+@import './variables';
 
 .dashboard-responsive-sidebar__sidebar {
 	display: flex;

--- a/client/dashboard/app/responsive-sidebar/sidebar.tsx
+++ b/client/dashboard/app/responsive-sidebar/sidebar.tsx
@@ -40,13 +40,19 @@ export default function Sidebar( { onNavigate }: { onNavigate?: () => void } ) {
 		if ( ! el ) {
 			return;
 		}
+		let timeoutId: NodeJS.Timeout;
 		const handler = ( event: MouseEvent ) => {
 			if ( ( event.target as HTMLElement ).closest( 'a' ) ) {
-				onNavigate();
+				// Brief delay so the user sees the selected state before
+				// the sidebar slides closed.
+				timeoutId = setTimeout( onNavigate, 150 );
 			}
 		};
 		el.addEventListener( 'click', handler );
-		return () => el.removeEventListener( 'click', handler );
+		return () => {
+			clearTimeout( timeoutId );
+			el.removeEventListener( 'click', handler );
+		};
 	}, [ onNavigate ] );
 
 	return (

--- a/client/dashboard/app/responsive-sidebar/sidebar.tsx
+++ b/client/dashboard/app/responsive-sidebar/sidebar.tsx
@@ -2,7 +2,7 @@ import { useRouterState } from '@tanstack/react-router';
 import { __experimentalHStack as HStack, Navigator } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { brush, copy, envelope, globe, plugins } from '@wordpress/icons';
-import { useEffect, useMemo, useRef } from 'react';
+import { useMemo } from 'react';
 import RouterLinkButton from '../../components/router-link-button';
 import { SidebarExpandableMenuItem, SidebarMenu, SidebarMenuItem } from '../../components/sidebar';
 import DomainSidebar from '../../domains/domain-sidebar';
@@ -16,7 +16,7 @@ import { getScreenPath, NavigatorRouteSync } from './navigator-route-sync';
 
 import './sidebar.scss';
 
-export default function Sidebar( { onNavigate }: { onNavigate?: () => void } ) {
+export default function Sidebar() {
 	const { Logo, name } = useAppContext();
 	const { recordTracksEvent } = useAnalytics();
 	const { resolvedPathname, hasError } = useRouterState( {
@@ -30,33 +30,8 @@ export default function Sidebar( { onNavigate }: { onNavigate?: () => void } ) {
 	const screenPath = getScreenPath( resolvedPathname, hasError );
 	const initialPath = useMemo( () => screenPath, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 
-	// Close responsive panel when a navigation link is clicked
-	const sidebarRef = useRef< HTMLDivElement >( null );
-	useEffect( () => {
-		if ( ! onNavigate ) {
-			return;
-		}
-		const el = sidebarRef.current;
-		if ( ! el ) {
-			return;
-		}
-		let timeoutId: NodeJS.Timeout;
-		const handler = ( event: MouseEvent ) => {
-			if ( ( event.target as HTMLElement ).closest( 'a' ) ) {
-				// Brief delay so the user sees the selected state before
-				// the sidebar slides closed.
-				timeoutId = setTimeout( onNavigate, 150 );
-			}
-		};
-		el.addEventListener( 'click', handler );
-		return () => {
-			clearTimeout( timeoutId );
-			el.removeEventListener( 'click', handler );
-		};
-	}, [ onNavigate ] );
-
 	return (
-		<div className="dashboard-responsive-sidebar__sidebar" ref={ sidebarRef }>
+		<div className="dashboard-responsive-sidebar__sidebar">
 			{ Logo && (
 				<div className="dashboard-responsive-sidebar__logo">
 					<RouterLinkButton

--- a/client/dashboard/app/responsive-sidebar/style.scss
+++ b/client/dashboard/app/responsive-sidebar/style.scss
@@ -8,7 +8,7 @@ $sidebar-width: 272px;
 	min-height: calc(100vh - var(--masterbar-height) );
 	width: $sidebar-width;
 	transform: translateX( -100% );
-	transition: transform 0.2s ease-out;
+	transition: transform 0.3s ease-in;
 	overflow: hidden;
 	z-index: 101; // Above content overlay
 

--- a/client/dashboard/app/responsive-sidebar/style.scss
+++ b/client/dashboard/app/responsive-sidebar/style.scss
@@ -15,6 +15,14 @@ $sidebar-width: 272px;
 	&.is-open {
 		transform: translateX( 0 );
 	}
+
+	[dir='rtl'] & {
+		transform: translateX( 100% );
+
+		&.is-open {
+			transform: translateX( 0 );
+		}
+	}
 }
 
 .dashboard-responsive-sidebar__overlay {

--- a/client/dashboard/app/responsive-sidebar/style.scss
+++ b/client/dashboard/app/responsive-sidebar/style.scss
@@ -1,4 +1,4 @@
-$sidebar-width: 272px;
+@import './variables';
 
 .dashboard-responsive-sidebar {
 	flex-shrink: 0;

--- a/client/dashboard/app/responsive-sidebar/style.scss
+++ b/client/dashboard/app/responsive-sidebar/style.scss
@@ -4,7 +4,7 @@ $sidebar-width: 272px;
 	flex-shrink: 0;
 	position: fixed;
 	top: var(--masterbar-height);
-	left: 0;
+	inset-inline-start: 0;
 	min-height: calc(100vh - var(--masterbar-height) );
 	width: $sidebar-width;
 	transform: translateX( -100% );
@@ -14,14 +14,6 @@ $sidebar-width: 272px;
 
 	&.is-open {
 		transform: translateX( 0 );
-	}
-
-	[dir='rtl'] & {
-		transform: translateX( 100% );
-
-		&.is-open {
-			transform: translateX( 0 );
-		}
 	}
 }
 

--- a/client/dashboard/app/responsive-sidebar/style.scss
+++ b/client/dashboard/app/responsive-sidebar/style.scss
@@ -3,7 +3,7 @@ $sidebar-width: 272px;
 .dashboard-responsive-sidebar {
 	flex-shrink: 0;
 	position: fixed;
-	top: 0;
+	top: var(--masterbar-height);
 	left: 0;
 	min-height: calc(100vh - var(--masterbar-height) );
 	width: $sidebar-width;

--- a/client/dashboard/app/responsive-sidebar/style.scss
+++ b/client/dashboard/app/responsive-sidebar/style.scss
@@ -1,14 +1,19 @@
+$sidebar-width: 272px;
+
 .dashboard-responsive-sidebar {
 	flex-shrink: 0;
-	position: sticky;
+	position: fixed;
 	top: 0;
+	left: 0;
 	min-height: calc(100vh - var(--masterbar-height) );
-	width: 0;
+	width: $sidebar-width;
+	transform: translateX( -100% );
+	transition: transform 0.2s ease-out;
 	overflow: hidden;
 	z-index: 101; // Above content overlay
 
 	&.is-open {
-		width: fit-content
+		transform: translateX( 0 );
 	}
 }
 

--- a/client/dashboard/app/root/index.tsx
+++ b/client/dashboard/app/root/index.tsx
@@ -2,7 +2,15 @@ import { isEnabled } from '@automattic/calypso-config';
 import { WordPressLogo } from '@automattic/components/src/logos/wordpress-logo';
 import { useQueryClient, useIsFetching } from '@tanstack/react-query';
 import { CatchNotFound, Outlet, useRouterState, useRouter } from '@tanstack/react-router';
-import { Suspense, lazy, useEffect, useState, useMemo, useSyncExternalStore } from 'react';
+import {
+	Suspense,
+	lazy,
+	useCallback,
+	useEffect,
+	useState,
+	useMemo,
+	useSyncExternalStore,
+} from 'react';
 import { LoadingLine } from '../../components/loading-line';
 import { PageViewTracker } from '../../components/page-view-tracker';
 import NotFound from '../404';
@@ -34,6 +42,7 @@ function Root() {
 	const queryClient = useQueryClient();
 	const queryCache = queryClient.getQueryCache();
 	const [ isSidebarOpen, setIsSidebarOpen ] = useState( false );
+	const closeSidebar = useCallback( () => setIsSidebarOpen( false ), [ setIsSidebarOpen ] );
 
 	const loadingQueryRequestedFullPageLoader = useSyncExternalStore(
 		( onStoreChange ) => queryCache.subscribe( onStoreChange ),
@@ -128,7 +137,7 @@ function Root() {
 
 		return (
 			<div className="dashboard-root__body">
-				<ResponsiveSidebar isOpen={ isSidebarOpen } onClose={ () => setIsSidebarOpen( false ) } />
+				<ResponsiveSidebar isOpen={ isSidebarOpen } onClose={ closeSidebar } />
 				<div className="dashboard-root__content">
 					<main>
 						<CatchNotFound fallback={ NotFound }>

--- a/client/dashboard/app/root/style.scss
+++ b/client/dashboard/app/root/style.scss
@@ -1,3 +1,5 @@
+@import '@wordpress/base-styles/variables';
+@import '@wordpress/base-styles/mixins';
 @import './omnibar-style';
 
 // Old layout (no sidebar): sticky header
@@ -20,6 +22,10 @@
 .dashboard-root__body {
 	display: flex;
 	min-height: calc(100vh - var(--masterbar-height) );
+
+	@media ( max-width: #{ ( $break-medium - 1 ) } ) {
+		overflow-x: hidden;
+	}
 }
 
 .dashboard-root__content {
@@ -28,4 +34,14 @@
 	flex-direction: column;
 	flex: 1;
 	min-width: 0;
+
+	@media ( max-width: #{ ( $break-medium - 1 ) } ) {
+		transition: transform 0.2s ease-out;
+
+		&.is-sidebar-open {
+			transform: translateX( 272px );
+			overflow: hidden;
+			height: 100vh;
+		}
+	}
 }

--- a/client/dashboard/app/root/style.scss
+++ b/client/dashboard/app/root/style.scss
@@ -39,9 +39,5 @@
 			transform: translateX( $sidebar-width );
 			overflow: hidden;
 			height: 100vh;
-
-			[dir='rtl'] & {
-				transform: translateX( -$sidebar-width );
-			}
 	}
 }

--- a/client/dashboard/app/root/style.scss
+++ b/client/dashboard/app/root/style.scss
@@ -1,5 +1,3 @@
-@import '@wordpress/base-styles/variables';
-@import '@wordpress/base-styles/mixins';
 @import '../responsive-sidebar/variables';
 @import './omnibar-style';
 
@@ -24,7 +22,7 @@
 	display: flex;
 	min-height: calc(100vh - var(--masterbar-height) );
 
-	@media ( max-width: #{ ( $break-medium - 1 ) } ) {
+	&:has(.dashboard-responsive-sidebar) {
 		overflow-x: hidden;
 	}
 }
@@ -35,11 +33,9 @@
 	flex-direction: column;
 	flex: 1;
 	min-width: 0;
+	transition: transform 0.2s ease-out;
 
-	@media ( max-width: #{ ( $break-medium - 1 ) } ) {
-		transition: transform 0.2s ease-out;
-
-		&.is-sidebar-open {
+	.dashboard-root__body:has(.dashboard-responsive-sidebar.is-open) & {
 			transform: translateX( $sidebar-width );
 			overflow: hidden;
 			height: 100vh;
@@ -47,6 +43,5 @@
 			[dir='rtl'] & {
 				transform: translateX( -$sidebar-width );
 			}
-		}
 	}
 }

--- a/client/dashboard/app/root/style.scss
+++ b/client/dashboard/app/root/style.scss
@@ -33,7 +33,7 @@
 	flex-direction: column;
 	flex: 1;
 	min-width: 0;
-	transition: transform 0.2s ease-out;
+	transition: transform 0.3s ease-in;
 
 	.dashboard-root__body:has(.dashboard-responsive-sidebar.is-open) & {
 			transform: translateX( $sidebar-width );

--- a/client/dashboard/app/root/style.scss
+++ b/client/dashboard/app/root/style.scss
@@ -1,5 +1,6 @@
 @import '@wordpress/base-styles/variables';
 @import '@wordpress/base-styles/mixins';
+@import '../responsive-sidebar/variables';
 @import './omnibar-style';
 
 // Old layout (no sidebar): sticky header
@@ -39,9 +40,13 @@
 		transition: transform 0.2s ease-out;
 
 		&.is-sidebar-open {
-			transform: translateX( 272px );
+			transform: translateX( $sidebar-width );
 			overflow: hidden;
 			height: 100vh;
+
+			[dir='rtl'] & {
+				transform: translateX( -$sidebar-width );
+			}
 		}
 	}
 }


### PR DESCRIPTION
Part of #109437

## Proposed Changes

* Changed the mobile sidebar from width-based animation to a fixed-position slide-in using CSS transforms.
* Content area now translates right by the sidebar width instead of resizing, preventing layout reflow.
* Scoped all mobile sidebar styles below the medium breakpoint so desktop layout is unaffected.
* Locked vertical scroll on the content area while the sidebar is open.
* Added a brief delay before closing the sidebar on nav click so the user sees the selected state.
* Extracted `$sidebar-width` into a shared SCSS partial (`sidebar/_variables.scss`) so the sidebar width is defined in one place.
* Added RTL support for the mobile sidebar — content and panel slide in the correct direction under `[dir="rtl"]`, and replaced `left: 0` with `inset-inline-start: 0`.

## Why are these changes being made?

Previously, opening the mobile sidebar caused the content area to resize as the sidebar grew from `width: 0` to `272px`. This triggered layout reflow and made the content visually shrink. The new approach uses `transform: translateX()` on both the sidebar and content, which is GPU-composited and keeps the content at full width — it simply slides off-screen to the right.

The sidebar width was also hardcoded in two places, which would silently break if the value changed. It is now a shared SCSS variable. Additionally, `translateX` is a physical (LTR-only) direction, so RTL overrides were added per the Dashboard's CSS logical properties convention.

## Testing Instructions

* Open the dashboard on a mobile viewport (below 782px).
* Tap the hamburger menu to open the sidebar.
* Verify the content slides to the right without resizing.
* Verify vertical scrolling is locked while the sidebar is open.
* Tap a nav link — verify the selected state is briefly visible before the sidebar closes.
* Tap the overlay to close the sidebar and confirm it slides back.
* Verify desktop layout is unchanged.
* Switch to an RTL locale and verify the sidebar slides in from the right and the content slides to the left.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?