### PR TITLE
MSD: Account sidebar profile header

### DIFF
--- a/client/dashboard/me/me-menu/index.tsx
+++ b/client/dashboard/me/me-menu/index.tsx
@@ -25,7 +25,7 @@ const MeMenu = () => {
 	return (
 		<SidebarMenu>
 			<SidebarMenuItem icon={ commentAuthorAvatar } to="/me/profile">
-				{ __( 'Profile' ) }
+				{ __( 'Account' ) }
 			</SidebarMenuItem>
 			<SidebarMenuItem icon={ settings } to="/me/preferences">
 				{ __( 'Preferences' ) }

--- a/client/dashboard/me/me-menu/index.tsx
+++ b/client/dashboard/me/me-menu/index.tsx
@@ -25,7 +25,7 @@ const MeMenu = () => {
 	return (
 		<SidebarMenu>
 			<SidebarMenuItem icon={ commentAuthorAvatar } to="/me/profile">
-				{ __( 'Account' ) }
+				{ __( 'Profile' ) }
 			</SidebarMenuItem>
 			<SidebarMenuItem icon={ settings } to="/me/preferences">
 				{ __( 'Preferences' ) }

--- a/client/dashboard/me/me-sidebar/index.tsx
+++ b/client/dashboard/me/me-sidebar/index.tsx
@@ -1,12 +1,35 @@
-import { __experimentalVStack as VStack } from '@wordpress/components';
+import { userSettingsQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import {
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { SidebarBackButton } from '../../components/sidebar';
 import MeMenu from '../me-menu';
 
+import './style.scss';
+
 export default function MeSidebar() {
+	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
+
 	return (
-		<VStack spacing={ 2 }>
-			<SidebarBackButton to="/">{ __( 'Back' ) }</SidebarBackButton>
+		<VStack spacing={ 4 }>
+			<HStack justify="flex-start" alignment="center" spacing={ 3 }>
+				<div className="me-sidebar__avatar-wrapper">
+					<div className="me-sidebar__avatar">
+						<img src={ userSettings.avatar_URL } alt={ __( 'Profile photo' ) } />
+					</div>
+				</div>
+				<VStack spacing={ 0 } style={ { minWidth: 0 } }>
+					<Text weight={ 500 } size="13px" truncate>
+						{ userSettings.display_name }
+					</Text>
+					<Text variant="muted" size="12px" truncate>
+						@{ userSettings.user_login }
+					</Text>
+				</VStack>
+			</HStack>
 			<MeMenu />
 		</VStack>
 	);

--- a/client/dashboard/me/me-sidebar/index.tsx
+++ b/client/dashboard/me/me-sidebar/index.tsx
@@ -1,5 +1,5 @@
 import { userSettingsQuery } from '@automattic/api-queries';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import {
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
@@ -11,7 +11,11 @@ import MeMenu from '../me-menu';
 import './style.scss';
 
 export default function MeSidebar() {
-	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
+	const { data: userSettings } = useQuery( userSettingsQuery() );
+
+	if ( ! userSettings ) {
+		return null;
+	}
 
 	return (
 		<VStack spacing={ 4 }>

--- a/client/dashboard/me/me-sidebar/style.scss
+++ b/client/dashboard/me/me-sidebar/style.scss
@@ -1,0 +1,27 @@
+.me-sidebar__avatar-wrapper {
+	margin-inline-start: $grid-unit-15;
+}
+
+.me-sidebar__avatar {
+	position: relative;
+	width: 52px;
+	height: 52px;
+	flex-shrink: 0;
+
+	img {
+		width: 52px;
+		height: 52px;
+		border-radius: 50%;
+		object-fit: cover;
+		display: block;
+	}
+
+	&::after {
+		content: '';
+		position: absolute;
+		inset: 0;
+		border-radius: 50%;
+		box-shadow: inset 0 0 0 1.393px rgba( 0, 0, 0, 0.15 );
+		pointer-events: none;
+	}
+}


### PR DESCRIPTION
Part of #109437

## Proposed Changes

* Added user profile header (avatar, display name, username) to the top of the account sidebar.
* Renamed "Profile" menu item to "Account".
* Avatar is 52x52 with an inset ring overlay.

| Before | After |
|--------|--------|
| <img width="269" height="533" alt="Screenshot 2026-03-23 at 11 43 14 AM" src="https://github.com/user-attachments/assets/9a31736c-a4d4-431e-8289-a64eb762427d" /> | <img width="270" height="569" alt="Screenshot 2026-03-23 at 11 43 01 AM" src="https://github.com/user-attachments/assets/2dd2d8bd-7d88-4de8-966a-c426d149bcbd" /> | 


## Why are these changes being made?

The account sidebar should show who is logged in at a glance, matching the design where the user's avatar and identity appear above the navigation menu items.

## Testing Instructions

* Navigate to `/me` in the dashboard.
* Verify the sidebar shows the user's avatar, display name, and @username above the menu items.
* Verify the avatar has a subtle dark inset ring.
* Verify the first menu item reads "Account" instead of "Profile".
* Verify text truncates properly for long display names or usernames.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?