### PR TITLE
MSD: Dot indicators for expandable sidebar sub-items

### DIFF
--- a/client/dashboard/app/primary-menu/index.tsx
+++ b/client/dashboard/app/primary-menu/index.tsx
@@ -26,12 +26,7 @@ function PrimaryMenu() {
 				</SidebarMenuItem>
 			) }
 			{ supports.plugins && (
-				<SidebarExpandableMenuItem
-					label={ __( 'Plugins' ) }
-					icon={ plugins }
-					to="/plugins"
-					defaultTo="/plugins/manage"
-				>
+				<SidebarExpandableMenuItem label={ __( 'Plugins' ) } icon={ plugins } to="/plugins">
 					<SidebarMenuItem to="/plugins/manage">{ __( 'Manage plugins' ) }</SidebarMenuItem>
 					<SidebarMenuItem to="/plugins/scheduled-updates">
 						{ __( 'Scheduled updates' ) }

--- a/client/dashboard/components/sidebar/sidebar-expandable-menu-item.scss
+++ b/client/dashboard/components/sidebar/sidebar-expandable-menu-item.scss
@@ -11,3 +11,7 @@
 	}
 }
 
+.dashboard-sidebar__menu-item.active .dashboard-sidebar__dot {
+	fill: var( --wp-admin-theme-color );
+}
+

--- a/client/dashboard/components/sidebar/sidebar-expandable-menu-item.scss
+++ b/client/dashboard/components/sidebar/sidebar-expandable-menu-item.scss
@@ -11,7 +11,3 @@
 	}
 }
 
-.dashboard-sidebar__menu-item.active .dashboard-sidebar__dot {
-	fill: var( --wp-admin-theme-color );
-}
-

--- a/client/dashboard/components/sidebar/sidebar-expandable-menu-item.scss
+++ b/client/dashboard/components/sidebar/sidebar-expandable-menu-item.scss
@@ -4,7 +4,6 @@
 
 .dashboard-sidebar__expandable-trigger.dashboard-sidebar__expandable-trigger {
 	width: 100%;
-	padding: $grid-unit-10 $grid-unit-15;
 	border-radius: $radius-small;
 
 	.components-flex {
@@ -12,6 +11,3 @@
 	}
 }
 
-.dashboard-sidebar__expandable-children {
-	padding-inline-start: $grid-unit-20;
-}

--- a/client/dashboard/components/sidebar/sidebar-expandable-menu-item.tsx
+++ b/client/dashboard/components/sidebar/sidebar-expandable-menu-item.tsx
@@ -45,9 +45,10 @@ export function SidebarExpandableMenuItem( {
 	}, [ isActive ] );
 
 	return (
-		<div className="dashboard-sidebar__expandable">
+		<VStack className="dashboard-sidebar__expandable" spacing={ 1 }>
 			<RouterLinkButton
 				className="dashboard-sidebar__menu-item dashboard-sidebar__expandable-trigger"
+				variant="tertiary"
 				activeProps={ {
 					className: 'dashboard-sidebar__menu-item dashboard-sidebar__expandable-trigger',
 				} }
@@ -81,6 +82,6 @@ export function SidebarExpandableMenuItem( {
 					} ) }
 				</VStack>
 			) }
-		</div>
+		</VStack>
 	);
 }

--- a/client/dashboard/components/sidebar/sidebar-expandable-menu-item.tsx
+++ b/client/dashboard/components/sidebar/sidebar-expandable-menu-item.tsx
@@ -1,12 +1,12 @@
 import { useRouterState } from '@tanstack/react-router';
 import {
+	Button,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
-import { Children, cloneElement, isValidElement, useState, useEffect } from 'react';
+import { Children, cloneElement, isValidElement, useId, useState, useEffect } from 'react';
 import { useAnalytics } from '../../app/analytics';
-import RouterLinkButton from '../../components/router-link-button';
 import { SidebarMenuItem } from './sidebar-menu-item';
 
 import './sidebar-expandable-menu-item.scss';
@@ -21,7 +21,6 @@ interface SidebarExpandableMenuItemProps {
 	label: string;
 	icon?: React.JSX.Element;
 	to: string;
-	defaultTo: string;
 	children: React.ReactNode;
 }
 
@@ -29,7 +28,6 @@ export function SidebarExpandableMenuItem( {
 	label,
 	icon,
 	to,
-	defaultTo,
 	children,
 }: SidebarExpandableMenuItemProps ) {
 	const { recordTracksEvent } = useAnalytics();
@@ -38,6 +36,7 @@ export function SidebarExpandableMenuItem( {
 	} );
 	const isActive = pathname.startsWith( to );
 	const [ isOpen, setIsOpen ] = useState( isActive );
+	const panelId = useId();
 
 	// Sync open state with active state when navigating
 	useEffect( () => {
@@ -46,22 +45,15 @@ export function SidebarExpandableMenuItem( {
 
 	return (
 		<VStack className="dashboard-sidebar__expandable" spacing={ 1 }>
-			<RouterLinkButton
+			<Button
 				className="dashboard-sidebar__menu-item dashboard-sidebar__expandable-trigger"
 				variant="tertiary"
-				activeProps={ {
-					className: 'dashboard-sidebar__menu-item dashboard-sidebar__expandable-trigger',
+				onClick={ () => {
+					setIsOpen( ( prev ) => ! prev );
+					recordTracksEvent( 'calypso_dashboard_menu_item_click', { to } );
 				} }
-				to={ defaultTo }
-				onClick={ ( e: React.MouseEvent ) => {
-					if ( isActive ) {
-						e.preventDefault();
-						setIsOpen( ( prev ) => ! prev );
-					} else {
-						setIsOpen( true );
-						recordTracksEvent( 'calypso_dashboard_menu_item_click', { to: defaultTo } );
-					}
-				} }
+				aria-expanded={ isOpen }
+				aria-controls={ panelId }
 				__next40pxDefaultSize
 			>
 				<HStack justify="space-between">
@@ -71,9 +63,9 @@ export function SidebarExpandableMenuItem( {
 					</HStack>
 					<Icon icon={ isOpen ? chevronUp : chevronDown } size={ 18 } />
 				</HStack>
-			</RouterLinkButton>
+			</Button>
 			{ isOpen && (
-				<VStack className="dashboard-sidebar__expandable-children" spacing={ 1 }>
+				<VStack id={ panelId } className="dashboard-sidebar__expandable-children" spacing={ 1 }>
 					{ Children.map( children, ( child ) => {
 						if ( isValidElement( child ) && child.type === SidebarMenuItem && ! child.props.icon ) {
 							return cloneElement( child, { icon: dotIcon } );

--- a/client/dashboard/components/sidebar/sidebar-expandable-menu-item.tsx
+++ b/client/dashboard/components/sidebar/sidebar-expandable-menu-item.tsx
@@ -1,11 +1,21 @@
 import { useRouterState } from '@tanstack/react-router';
-import { __experimentalHStack as HStack } from '@wordpress/components';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
 import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
-import { useState, useEffect } from 'react';
+import { Children, cloneElement, isValidElement, useState, useEffect } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import RouterLinkButton from '../../components/router-link-button';
+import { SidebarMenuItem } from './sidebar-menu-item';
 
 import './sidebar-expandable-menu-item.scss';
+
+const dotIcon = (
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+		<circle cx="12" cy="12" r="3" fill="currentColor" />
+	</svg>
+);
 
 interface SidebarExpandableMenuItemProps {
 	label: string;
@@ -61,7 +71,16 @@ export function SidebarExpandableMenuItem( {
 					<Icon icon={ isOpen ? chevronUp : chevronDown } size={ 18 } />
 				</HStack>
 			</RouterLinkButton>
-			{ isOpen && <div className="dashboard-sidebar__expandable-children">{ children }</div> }
+			{ isOpen && (
+				<VStack className="dashboard-sidebar__expandable-children" spacing={ 1 }>
+					{ Children.map( children, ( child ) => {
+						if ( isValidElement( child ) && child.type === SidebarMenuItem && ! child.props.icon ) {
+							return cloneElement( child, { icon: dotIcon } );
+						}
+						return child;
+					} ) }
+				</VStack>
+			) }
 		</div>
 	);
 }

--- a/client/dashboard/components/sidebar/sidebar-expandable-menu-item.tsx
+++ b/client/dashboard/components/sidebar/sidebar-expandable-menu-item.tsx
@@ -13,7 +13,7 @@ import './sidebar-expandable-menu-item.scss';
 
 const dotIcon = (
 	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
-		<circle cx="12" cy="12" r="3" fill="currentColor" />
+		<circle cx="12" cy="12" r="2" fill="#ccc" className="dashboard-sidebar__dot" />
 	</svg>
 );
 

--- a/client/dashboard/components/sidebar/sidebar-expandable-menu-item.tsx
+++ b/client/dashboard/components/sidebar/sidebar-expandable-menu-item.tsx
@@ -65,7 +65,7 @@ export function SidebarExpandableMenuItem( {
 				</HStack>
 			</Button>
 			{ isOpen && (
-				<VStack id={ panelId } className="dashboard-sidebar__expandable-children" spacing={ 1 }>
+				<VStack id={ panelId } spacing={ 1 }>
 					{ Children.map( children, ( child ) => {
 						if ( isValidElement( child ) && child.type === SidebarMenuItem && ! child.props.icon ) {
 							return cloneElement( child, { icon: dotIcon } );

--- a/client/dashboard/components/sidebar/sidebar-expandable-menu-item.tsx
+++ b/client/dashboard/components/sidebar/sidebar-expandable-menu-item.tsx
@@ -13,7 +13,7 @@ import './sidebar-expandable-menu-item.scss';
 
 const dotIcon = (
 	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
-		<circle cx="12" cy="12" r="2" fill="#ccc" className="dashboard-sidebar__dot" />
+		<circle cx="12" cy="12" r="2" fill="currentColor" />
 	</svg>
 );
 

--- a/client/dashboard/sites/site-menu/index.tsx
+++ b/client/dashboard/sites/site-menu/index.tsx
@@ -99,7 +99,6 @@ const SiteMenu = ( { site }: { site: Site } ) => {
 					label={ __( 'Logs' ) }
 					icon={ formatListBullets }
 					to={ `/sites/${ siteSlug }/logs` }
-					defaultTo={ `/sites/${ siteSlug }/logs/activity` }
 				>
 					<SidebarMenuItem to={ `/sites/${ siteSlug }/logs/activity` }>
 						{ __( 'Activity' ) }
@@ -119,7 +118,6 @@ const SiteMenu = ( { site }: { site: Site } ) => {
 						label={ __( 'Scan' ) }
 						icon={ shield }
 						to={ `/sites/${ siteSlug }/scan` }
-						defaultTo={ `/sites/${ siteSlug }/scan/active` }
 					>
 						<SidebarMenuItem to={ `/sites/${ siteSlug }/scan/active` }>
 							{ __( 'Active threats' ) }


### PR DESCRIPTION
Part of #109437

## Proposed Changes

* Added dot SVG icon to sub-items inside expandable sidebar menus (Plugins, Logs, Scan), auto-injected via `React.Children.map`.
* Dot uses `fill="currentColor"` to inherit the menu item's text color — gray when inactive, theme color when active — with no extra CSS needed.
* Replaced `RouterLinkButton` with `Button` on the expandable trigger, following the WAI-ARIA disclosure pattern (`aria-expanded`, `aria-controls`). Clicking only toggles sub-items, no navigation.
* Removed `defaultTo` prop — trigger no longer navigates.
* Added `variant="tertiary"` for hover styles and `VStack spacing={1}` for consistent 4px gap between trigger and sub-items.

| Before | After |
|--------|--------|
| <img width="271" height="745" alt="Screenshot 2026-03-23 at 11 39 10 AM" src="https://github.com/user-attachments/assets/bf32d203-924f-431b-a8c7-e73ca1258d80" /> | <img width="272" height="758" alt="Screenshot 2026-03-23 at 11 40 50 AM" src="https://github.com/user-attachments/assets/bcd9ac61-7d0d-416c-9387-5ed380a22c36" /> | 

## Why are these changes being made?

Sub-navigation items had no visual indicator, and the expandable trigger navigated on click which was confusing. The disclosure pattern is the accessible standard for toggle-only controls, and the dot icons provide a clear visual hierarchy.

## Testing Instructions

* Navigate to a site and expand "Logs" or "Scan" in the sidebar.
* Expand "Plugins" in the main sidebar.
* Verify clicking the parent item only toggles sub-items (no navigation).
* Verify sub-items show a dot icon — matches text color when inactive, blue when active.
* Verify the trigger has hover styles and a 4px gap before sub-items.
* Verify screen reader announces "expanded/collapsed" on the trigger.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?