### PR TITLE
MSD: Restyle environment switcher toggle

### DIFF
--- a/client/dashboard/components/environment/index.tsx
+++ b/client/dashboard/components/environment/index.tsx
@@ -6,21 +6,28 @@ export type EnvironmentType = 'production' | 'staging';
 
 interface EnvironmentProps {
 	environmentType: EnvironmentType;
+	spacing?: number;
+	iconSize?: number;
 }
 
-const Environment = ( { environmentType }: EnvironmentProps ) => {
+const Environment = ( { environmentType, spacing = 1, iconSize }: EnvironmentProps ) => {
 	if ( environmentType === 'staging' ) {
 		return (
-			<HStack justify="flex-start" spacing={ 1 } expanded={ false } style={ { flexShrink: 0 } }>
-				<Icon icon={ staging } />
+			<HStack
+				justify="flex-start"
+				spacing={ spacing }
+				expanded={ false }
+				style={ { flexShrink: 0 } }
+			>
+				<Icon icon={ staging } size={ iconSize } />
 				<span>{ __( 'Staging' ) }</span>
 			</HStack>
 		);
 	}
 
 	return (
-		<HStack justify="flex-start" spacing={ 1 } expanded={ false } style={ { flexShrink: 0 } }>
-			<Icon icon={ production } />
+		<HStack justify="flex-start" spacing={ spacing } expanded={ false } style={ { flexShrink: 0 } }>
+			<Icon icon={ production } size={ iconSize } />
 			<span>{ __( 'Production' ) }</span>
 		</HStack>
 	);

--- a/client/dashboard/components/environment/index.tsx
+++ b/client/dashboard/components/environment/index.tsx
@@ -1,4 +1,8 @@
-import { Icon, __experimentalHStack as HStack } from '@wordpress/components';
+import {
+	Icon,
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { staging, production } from '../icons';
 
@@ -20,7 +24,7 @@ const Environment = ( { environmentType, spacing = 1, iconSize }: EnvironmentPro
 				style={ { flexShrink: 0 } }
 			>
 				<Icon icon={ staging } size={ iconSize } />
-				<span>{ __( 'Staging' ) }</span>
+				<Text>{ __( 'Staging' ) }</Text>
 			</HStack>
 		);
 	}
@@ -28,7 +32,7 @@ const Environment = ( { environmentType, spacing = 1, iconSize }: EnvironmentPro
 	return (
 		<HStack justify="flex-start" spacing={ spacing } expanded={ false } style={ { flexShrink: 0 } }>
 			<Icon icon={ production } size={ iconSize } />
-			<span>{ __( 'Production' ) }</span>
+			<Text>{ __( 'Production' ) }</Text>
 		</HStack>
 	);
 };

--- a/client/dashboard/components/environment/index.tsx
+++ b/client/dashboard/components/environment/index.tsx
@@ -1,8 +1,4 @@
-import {
-	Icon,
-	__experimentalHStack as HStack,
-	__experimentalText as Text,
-} from '@wordpress/components';
+import { Icon, __experimentalHStack as HStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { staging, production } from '../icons';
 
@@ -10,30 +6,22 @@ export type EnvironmentType = 'production' | 'staging';
 
 interface EnvironmentProps {
 	environmentType: EnvironmentType;
-	spacing?: number;
-	iconSize?: number;
-	weight?: React.CSSProperties[ 'fontWeight' ];
 }
 
-const Environment = ( { environmentType, spacing = 1, iconSize, weight }: EnvironmentProps ) => {
+const Environment = ( { environmentType }: EnvironmentProps ) => {
 	if ( environmentType === 'staging' ) {
 		return (
-			<HStack
-				justify="flex-start"
-				spacing={ spacing }
-				expanded={ false }
-				style={ { flexShrink: 0 } }
-			>
-				<Icon icon={ staging } size={ iconSize } />
-				<Text weight={ weight }>{ __( 'Staging' ) }</Text>
+			<HStack justify="flex-start" spacing={ 1 } expanded={ false } style={ { flexShrink: 0 } }>
+				<Icon icon={ staging } />
+				<span>{ __( 'Staging' ) }</span>
 			</HStack>
 		);
 	}
 
 	return (
-		<HStack justify="flex-start" spacing={ spacing } expanded={ false } style={ { flexShrink: 0 } }>
-			<Icon icon={ production } size={ iconSize } />
-			<Text weight={ weight }>{ __( 'Production' ) }</Text>
+		<HStack justify="flex-start" spacing={ 1 } expanded={ false } style={ { flexShrink: 0 } }>
+			<Icon icon={ production } />
+			<span>{ __( 'Production' ) }</span>
 		</HStack>
 	);
 };

--- a/client/dashboard/components/environment/index.tsx
+++ b/client/dashboard/components/environment/index.tsx
@@ -12,9 +12,10 @@ interface EnvironmentProps {
 	environmentType: EnvironmentType;
 	spacing?: number;
 	iconSize?: number;
+	weight?: React.CSSProperties[ 'fontWeight' ];
 }
 
-const Environment = ( { environmentType, spacing = 1, iconSize }: EnvironmentProps ) => {
+const Environment = ( { environmentType, spacing = 1, iconSize, weight }: EnvironmentProps ) => {
 	if ( environmentType === 'staging' ) {
 		return (
 			<HStack
@@ -24,7 +25,7 @@ const Environment = ( { environmentType, spacing = 1, iconSize }: EnvironmentPro
 				style={ { flexShrink: 0 } }
 			>
 				<Icon icon={ staging } size={ iconSize } />
-				<Text>{ __( 'Staging' ) }</Text>
+				<Text weight={ weight }>{ __( 'Staging' ) }</Text>
 			</HStack>
 		);
 	}
@@ -32,7 +33,7 @@ const Environment = ( { environmentType, spacing = 1, iconSize }: EnvironmentPro
 	return (
 		<HStack justify="flex-start" spacing={ spacing } expanded={ false } style={ { flexShrink: 0 } }>
 			<Icon icon={ production } size={ iconSize } />
-			<Text>{ __( 'Production' ) }</Text>
+			<Text weight={ weight }>{ __( 'Production' ) }</Text>
 		</HStack>
 	);
 };

--- a/client/dashboard/sites/site-sidebar/index.tsx
+++ b/client/dashboard/sites/site-sidebar/index.tsx
@@ -6,7 +6,7 @@ import { Suspense, lazy, useMemo } from 'react';
 import { useAppContext } from '../../app/context';
 import { SidebarBackButton, SidebarMenu } from '../../components/sidebar';
 import { canSwitchEnvironment } from '../features';
-import EnvironmentSwitcher from '../site/environment-switcher';
+import EnvironmentSwitcher from '../site/environment-switcher-v2';
 import SiteMenu from '../site-menu';
 
 export default function SiteSidebar() {

--- a/client/dashboard/sites/site/environment-switcher-v2.scss
+++ b/client/dashboard/sites/site/environment-switcher-v2.scss
@@ -1,0 +1,21 @@
+@import '@wordpress/base-styles/variables';
+
+.environment-switcher-v2 {
+	height: 40px;
+	padding-inline: $grid-unit-15;
+
+	span {
+		color: var( --dashboard__text-color );
+	}
+
+	.environment-switcher-v2__toggle {
+		color: var( --dashboard-menu-item__color );
+		min-width: 0;
+		padding: 0;
+
+		svg {
+			width: 18px;
+			height: 18px;
+		}
+	}
+}

--- a/client/dashboard/sites/site/environment-switcher-v2.scss
+++ b/client/dashboard/sites/site/environment-switcher-v2.scss
@@ -8,6 +8,7 @@
 
 	span {
 		color: var( --dashboard__text-color );
+		font-weight: 500;
 	}
 
 	.environment-switcher-v2__toggle {

--- a/client/dashboard/sites/site/environment-switcher-v2.scss
+++ b/client/dashboard/sites/site/environment-switcher-v2.scss
@@ -6,11 +6,6 @@
 	// This makes it align with toggle caret's in the side.
 	padding-inline-end: calc( #{$grid-unit-15} - 3px );
 
-	span {
-		color: var( --dashboard__text-color );
-		font-weight: 500;
-	}
-
 	.environment-switcher-v2__toggle {
 		color: var( --dashboard-menu-item__color );
 		min-width: 0;

--- a/client/dashboard/sites/site/environment-switcher-v2.scss
+++ b/client/dashboard/sites/site/environment-switcher-v2.scss
@@ -3,7 +3,7 @@
 .environment-switcher-v2 {
 	height: 40px;
 	padding-inline-start: $grid-unit-15;
-	// This makes it aligh with toggle caret's in the side.
+	// This makes it align with toggle caret's in the side.
 	padding-inline-end: calc( #{$grid-unit-15} - 3px );
 
 	span {

--- a/client/dashboard/sites/site/environment-switcher-v2.scss
+++ b/client/dashboard/sites/site/environment-switcher-v2.scss
@@ -2,7 +2,9 @@
 
 .environment-switcher-v2 {
 	height: 40px;
-	padding-inline: $grid-unit-15;
+	padding-inline-start: $grid-unit-15;
+	// This makes it aligh with toggle caret's in the side.
+	padding-inline-end: calc( #{$grid-unit-15} - 3px );
 
 	span {
 		color: var( --dashboard__text-color );

--- a/client/dashboard/sites/site/environment-switcher-v2.scss
+++ b/client/dashboard/sites/site/environment-switcher-v2.scss
@@ -3,7 +3,7 @@
 .environment-switcher-v2 {
 	height: 40px;
 	padding-inline-start: $grid-unit-15;
-	// This makes it align with toggle caret's in the side.
+	// This makes it align with toggle caret's in the sidebar.
 	padding-inline-end: calc( #{$grid-unit-15} - 3px );
 
 	.environment-switcher-v2__toggle {

--- a/client/dashboard/sites/site/environment-switcher-v2.tsx
+++ b/client/dashboard/sites/site/environment-switcher-v2.tsx
@@ -12,6 +12,7 @@ import {
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
 	__experimentalHStack as HStack,
+	__experimentalText as Text,
 	Button,
 	Dropdown,
 	MenuGroup,
@@ -28,6 +29,7 @@ import { useAnalytics } from '../../app/analytics';
 import { useHelpCenter } from '../../app/help-center';
 import useBuildCurrentRouteLink from '../../app/hooks/use-build-current-route-link';
 import Environment from '../../components/environment';
+import { staging, production } from '../../components/icons';
 import './environment-switcher-v2.scss';
 import RouterLinkMenuItem from '../../components/router-link-menu-item';
 import {
@@ -39,9 +41,14 @@ import { canManageSite, canCreateStagingSite } from '../features';
 import type { Site } from '@automattic/api-core';
 
 const CurrentEnvironment = ( { site }: { site: Site } ) => {
-	const environmentType = site.is_wpcom_staging_site ? 'staging' : 'production';
+	const icon = site.is_wpcom_staging_site ? staging : production;
+	const label = site.is_wpcom_staging_site ? __( 'Staging' ) : __( 'Production' );
+
 	return (
-		<Environment environmentType={ environmentType } spacing={ 2 } iconSize={ 20 } weight={ 500 } />
+		<HStack justify="flex-start" spacing={ 2 } expanded={ false } style={ { flexShrink: 0 } }>
+			<Icon icon={ icon } size={ 20 } />
+			<Text weight={ 500 }>{ label }</Text>
+		</HStack>
 	);
 };
 

--- a/client/dashboard/sites/site/environment-switcher-v2.tsx
+++ b/client/dashboard/sites/site/environment-switcher-v2.tsx
@@ -30,7 +30,6 @@ import { useHelpCenter } from '../../app/help-center';
 import useBuildCurrentRouteLink from '../../app/hooks/use-build-current-route-link';
 import Environment from '../../components/environment';
 import { staging, production } from '../../components/icons';
-import './environment-switcher-v2.scss';
 import RouterLinkMenuItem from '../../components/router-link-menu-item';
 import {
 	isAtomicTransferInProgress,
@@ -39,6 +38,8 @@ import {
 import { getProductionSiteId, getStagingSiteId } from '../../utils/site-staging-site';
 import { canManageSite, canCreateStagingSite } from '../features';
 import type { Site } from '@automattic/api-core';
+
+import './environment-switcher-v2.scss';
 
 const CurrentEnvironment = ( { site }: { site: Site } ) => {
 	const icon = site.is_wpcom_staging_site ? staging : production;

--- a/client/dashboard/sites/site/environment-switcher-v2.tsx
+++ b/client/dashboard/sites/site/environment-switcher-v2.tsx
@@ -1,0 +1,413 @@
+import {
+	siteByIdQuery,
+	stagingSiteCreateMutation,
+	isDeletingStagingSiteQuery,
+	hasStagingSiteQuery,
+	hasValidQuotaQuery,
+	jetpackConnectionHealthQuery,
+	siteLatestAtomicTransferQuery,
+	isCreatingStagingSiteQuery,
+	siteBySlugQuery,
+} from '@automattic/api-queries';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+	__experimentalHStack as HStack,
+	Button,
+	Dropdown,
+	MenuGroup,
+	MenuItem,
+	NavigableMenu,
+	Spinner,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { sprintf, __ } from '@wordpress/i18n';
+import { Icon, chevronUpDown, plus } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
+import { useEffect } from 'react';
+import { useAnalytics } from '../../app/analytics';
+import { useHelpCenter } from '../../app/help-center';
+import useBuildCurrentRouteLink from '../../app/hooks/use-build-current-route-link';
+import Environment from '../../components/environment';
+import './environment-switcher-v2.scss';
+import RouterLinkMenuItem from '../../components/router-link-menu-item';
+import {
+	isAtomicTransferInProgress,
+	isAtomicTransferredSite,
+} from '../../utils/site-atomic-transfers';
+import { getProductionSiteId, getStagingSiteId } from '../../utils/site-staging-site';
+import { canManageSite, canCreateStagingSite } from '../features';
+import type { Site } from '@automattic/api-core';
+
+const CurrentEnvironment = ( { site }: { site: Site } ) => {
+	const environmentType = site.is_wpcom_staging_site ? 'staging' : 'production';
+	return <Environment environmentType={ environmentType } spacing={ 2 } iconSize={ 20 } />;
+};
+
+const StagingSiteActionButton = ( {
+	isStagingSiteDeleting,
+	isStagingSiteCreating,
+}: {
+	isStagingSiteDeleting: boolean;
+	isStagingSiteCreating: boolean;
+} ) => {
+	const spinnerStyle = { width: '24px', height: '24px', padding: '4px', margin: 0 };
+	if ( isStagingSiteCreating ) {
+		return (
+			<>
+				<Spinner style={ spinnerStyle } />
+				<span>{ __( 'Adding staging site…' ) }</span>
+			</>
+		);
+	}
+
+	if ( isStagingSiteDeleting ) {
+		return (
+			<>
+				<Spinner style={ spinnerStyle } />
+				<span>{ __( 'Deleting staging site…' ) }</span>
+			</>
+		);
+	}
+	return (
+		<>
+			<Icon icon={ plus } />
+			<span>{ __( 'Add staging site' ) }</span>
+		</>
+	);
+};
+
+const EnvironmentSwitcherDropdown = ( {
+	currentSite,
+	productionSite,
+	stagingSite,
+	onClose,
+	onAddStagingSite,
+	isStagingSiteDeleting,
+	isStagingSiteCreating,
+}: {
+	currentSite: Site;
+	productionSite: Site | undefined;
+	stagingSite: Site | undefined;
+	onClose: () => void;
+	onAddStagingSite: () => void;
+	isStagingSiteDeleting: boolean;
+	isStagingSiteCreating: boolean;
+} ) => {
+	const buildCurrentRouteLink = useBuildCurrentRouteLink();
+
+	// TODO: Handle upsell.
+	const handleUpsell = () => {};
+
+	const showStagingSite =
+		stagingSite &&
+		canManageSite( stagingSite ) &&
+		! isStagingSiteDeleting &&
+		! isStagingSiteCreating;
+
+	const showActionButton =
+		( ! currentSite.is_wpcom_staging_site && productionSite && ! stagingSite ) ||
+		isStagingSiteCreating ||
+		isStagingSiteDeleting;
+
+	return (
+		<NavigableMenu>
+			<MenuGroup>
+				{ productionSite && canManageSite( productionSite ) && (
+					<RouterLinkMenuItem
+						to={ buildCurrentRouteLink( { params: { siteSlug: productionSite.slug } } ) }
+						onClick={ onClose }
+					>
+						<Environment environmentType="production" />
+					</RouterLinkMenuItem>
+				) }
+				{ showStagingSite && (
+					<RouterLinkMenuItem
+						to={ buildCurrentRouteLink( { params: { siteSlug: stagingSite.slug } } ) }
+						onClick={ onClose }
+					>
+						<Environment environmentType="staging" />
+					</RouterLinkMenuItem>
+				) }
+				{ showActionButton && (
+					<MenuItem
+						onClick={
+							productionSite && canCreateStagingSite( productionSite )
+								? onAddStagingSite
+								: handleUpsell
+						}
+						disabled={ isStagingSiteCreating || isStagingSiteDeleting }
+					>
+						<HStack justify="flex-start" spacing={ 1 }>
+							<StagingSiteActionButton
+								isStagingSiteDeleting={ isStagingSiteDeleting }
+								isStagingSiteCreating={ isStagingSiteCreating }
+							/>
+						</HStack>
+					</MenuItem>
+				) }
+			</MenuGroup>
+		</NavigableMenu>
+	);
+};
+
+const EnvironmentSwitcher = ( { site }: { site: Site } ) => {
+	const { recordTracksEvent } = useAnalytics();
+	const queryClient = useQueryClient();
+
+	const productionSiteId = getProductionSiteId( site );
+
+	const { data: productionSite } = useQuery( {
+		...siteByIdQuery( productionSiteId ?? 0 ),
+		enabled: !! productionSiteId,
+	} );
+
+	const stagingSiteId = getStagingSiteId( productionSite ?? site );
+
+	const { data: isStagingSiteCreating } = useQuery( {
+		...isCreatingStagingSiteQuery( productionSiteId ?? 0 ),
+		enabled: !! productionSiteId,
+	} );
+
+	const { data: atomicTransfer } = useQuery( {
+		...siteLatestAtomicTransferQuery( stagingSiteId ?? 0 ),
+		refetchInterval: ( query ) => {
+			return isAtomicTransferInProgress( query.state.data?.status ?? 'pending' ) ? 2000 : false;
+		},
+		enabled: isStagingSiteCreating && !! stagingSiteId,
+	} );
+	const transferStatus = atomicTransfer?.status;
+
+	const { data: stagingSite } = useQuery( {
+		...siteByIdQuery( stagingSiteId ?? 0 ),
+		refetchInterval: ( query ) => {
+			if ( ! query.state.data ) {
+				return 0;
+			}
+
+			return isAtomicTransferredSite( query.state.data ) ? false : 2000;
+		},
+		enabled: !! stagingSiteId && transferStatus === 'completed',
+	} );
+
+	const { data: isStagingSiteDeleting } = useQuery( {
+		...isDeletingStagingSiteQuery( stagingSiteId ?? 0 ),
+		enabled: !! stagingSiteId,
+	} );
+
+	// Staging site deletion process runs via async job. We need to keep on polling for the staging site deletion before we start displaying the button to add a staging site again
+	const { data: stagingSiteExistsFromQuery } = useQuery( {
+		...hasStagingSiteQuery( productionSiteId ?? 0 ),
+		refetchInterval: isStagingSiteDeleting ? 3000 : false,
+		enabled: !! productionSiteId && isStagingSiteDeleting,
+	} );
+
+	const { createSuccessNotice, createNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	// Clean up deletion flag when staging site no longer exists
+	useEffect( () => {
+		const invalidateQueries = async (
+			productionSiteId: number,
+			productionSiteSlug: string,
+			stagingSiteId: number
+		) => {
+			// Ensure the new site is retrieved before invalidating the deletion flag
+			await queryClient.invalidateQueries( siteByIdQuery( productionSiteId ) );
+			await queryClient.invalidateQueries( siteBySlugQuery( productionSiteSlug ) );
+			await queryClient.invalidateQueries( isDeletingStagingSiteQuery( stagingSiteId ) );
+		};
+		if (
+			isStagingSiteDeleting &&
+			stagingSiteExistsFromQuery === false &&
+			productionSiteId &&
+			productionSite &&
+			stagingSiteId
+		) {
+			createSuccessNotice( __( 'Staging site deleted.' ), {
+				type: 'snackbar',
+			} );
+			invalidateQueries( productionSiteId, productionSite?.slug, stagingSiteId );
+		}
+	}, [
+		isStagingSiteDeleting,
+		stagingSiteExistsFromQuery,
+		queryClient,
+		stagingSiteId,
+		productionSiteId,
+		productionSite,
+		createSuccessNotice,
+	] );
+
+	const { setShowHelpCenter, setNavigateToRoute } = useHelpCenter();
+
+	const isStagingSiteReady =
+		isStagingSiteCreating && stagingSite && isAtomicTransferredSite( stagingSite );
+
+	useEffect( () => {
+		if ( ! stagingSite ) {
+			return;
+		}
+		if ( isStagingSiteReady ) {
+			createSuccessNotice( __( 'Staging site added.' ), {
+				type: 'snackbar',
+				explicitDismiss: true,
+			} );
+			productionSite && queryClient.invalidateQueries( siteBySlugQuery( productionSite.slug ) );
+			queryClient.setQueryData(
+				isCreatingStagingSiteQuery( productionSiteId ?? 0 ).queryKey,
+				false
+			);
+		}
+	}, [
+		queryClient,
+		isStagingSiteReady,
+		stagingSite,
+		createSuccessNotice,
+		productionSiteId,
+		productionSite,
+	] );
+
+	const mutation = useMutation( stagingSiteCreateMutation( productionSite?.ID ?? 0 ) );
+
+	const { data: hasValidQuota, error: isErrorValidQuota } = useQuery( {
+		...hasValidQuotaQuery( productionSite?.ID ?? 0 ),
+		enabled: !! productionSite?.ID && ! stagingSite && ! isStagingSiteCreating,
+		meta: {
+			persist: false,
+		},
+	} );
+
+	const { data: connectionHealth } = useQuery( {
+		...jetpackConnectionHealthQuery( productionSite?.ID ?? 0 ),
+		enabled: !! productionSite?.ID && ! stagingSite && ! isStagingSiteCreating,
+	} );
+
+	const handleAddStagingSite = () => {
+		recordTracksEvent( 'calypso_hosting_configuration_staging_site_add_click' );
+
+		if ( isErrorValidQuota ) {
+			createNotice(
+				'error',
+				__( 'Cannot add a staging site due to site quota validation issue.' ),
+				{
+					type: 'snackbar',
+					actions: [
+						{
+							label: __( 'Contact support' ),
+							url: null,
+							onClick: () => {
+								setNavigateToRoute( '/odie' );
+								setShowHelpCenter( true );
+							},
+						},
+					],
+				}
+			);
+			return;
+		}
+
+		if ( ! hasValidQuota ) {
+			createErrorNotice(
+				__(
+					'Your available storage space is below 50%, which is insufficient for creating a staging site.'
+				),
+				{
+					type: 'snackbar',
+				}
+			);
+			return;
+		}
+
+		if ( ! connectionHealth?.is_healthy ) {
+			createNotice( 'error', __( 'Cannot add a staging site due to a Jetpack connection issue.' ), {
+				type: 'snackbar',
+				actions: [
+					{
+						label: __( 'Contact support' ),
+						url: null,
+						onClick: () => {
+							setNavigateToRoute( '/odie' );
+							setShowHelpCenter( true );
+						},
+					},
+				],
+			} );
+			return;
+		}
+
+		createSuccessNotice(
+			__(
+				'Setting up your staging site — this may take a few minutes. We’ll email you when it’s ready.'
+			),
+			{
+				type: 'snackbar',
+			}
+		);
+
+		mutation.mutate( undefined, {
+			onSuccess: () => {
+				queryClient.invalidateQueries( siteByIdQuery( productionSiteId ?? 0 ) );
+				queryClient.invalidateQueries( hasStagingSiteQuery( productionSiteId ?? 0 ) );
+			},
+			onError: ( error: Error ) => {
+				recordTracksEvent( 'calypso_hosting_configuration_staging_site_add_failure' );
+				createErrorNotice(
+					sprintf(
+						// translators: "reason" is why adding the staging site failed.
+						__( 'Failed to create staging site: %(reason)s' ),
+						{ reason: error.message }
+					),
+					{
+						type: 'snackbar',
+					}
+				);
+			},
+		} );
+	};
+
+	// TODO: Let's make sure to revise these conditions and simplify them once we have the design and the full understanding of how the
+	// deletion in progress should look like and if it should have a loading state during deletion.
+	const canToggle =
+		( productionSite && canManageSite( productionSite ) ) ||
+		( stagingSite && canManageSite( stagingSite ) );
+
+	return (
+		<HStack expanded={ false } style={ { flexShrink: 0 } } className="environment-switcher-v2">
+			<CurrentEnvironment site={ site } />
+			{ canToggle && (
+				<Dropdown
+					renderToggle={ ( { isOpen, onToggle } ) => (
+						<Button
+							className="environment-switcher-v2__toggle"
+							variant="tertiary"
+							onClick={ onToggle }
+							onKeyDown={ ( event: React.KeyboardEvent ) => {
+								if ( ! isOpen && event.code === 'ArrowDown' ) {
+									event.preventDefault();
+									onToggle();
+								}
+							} }
+							aria-haspopup="true"
+							aria-expanded={ isOpen }
+							label={ __( 'Switch environment' ) }
+							icon={ chevronUpDown }
+							size="small"
+						/>
+					) }
+					renderContent={ ( { onClose } ) => (
+						<EnvironmentSwitcherDropdown
+							currentSite={ site }
+							productionSite={ productionSite }
+							stagingSite={ stagingSite }
+							onClose={ onClose }
+							onAddStagingSite={ handleAddStagingSite }
+							isStagingSiteDeleting={ !! isStagingSiteDeleting }
+							isStagingSiteCreating={ !! isStagingSiteCreating }
+						/>
+					) }
+				/>
+			) }
+		</HStack>
+	);
+};
+
+export default EnvironmentSwitcher;

--- a/client/dashboard/sites/site/environment-switcher-v2.tsx
+++ b/client/dashboard/sites/site/environment-switcher-v2.tsx
@@ -40,7 +40,9 @@ import type { Site } from '@automattic/api-core';
 
 const CurrentEnvironment = ( { site }: { site: Site } ) => {
 	const environmentType = site.is_wpcom_staging_site ? 'staging' : 'production';
-	return <Environment environmentType={ environmentType } spacing={ 2 } iconSize={ 20 } />;
+	return (
+		<Environment environmentType={ environmentType } spacing={ 2 } iconSize={ 20 } weight={ 500 } />
+	);
 };
 
 const StagingSiteActionButton = ( {


### PR DESCRIPTION
Part of #109437

## Proposed Changes

* Duplicated `environment-switcher.tsx` into `environment-switcher-v2.tsx` to iterate on the design without affecting the current component.

### Differences from the original `environment-switcher.tsx`

* **Toggle is a separate button**: The environment label is now a static display element. A separate icon-only `Button` with the `chevronUpDown` icon opens the dropdown, instead of the entire label being clickable with `chevronDownSmall`.
* **Button styling**: The toggle uses `variant="tertiary"` and `size="small"` to match sidebar nav button hover/focus/active states.
* **Environment label**: Uses `spacing={2}` (8px gap) and `iconSize={20}` on the `Environment` component, instead of the default `spacing={1}` and 24px icon size.
* **Stylesheet**: Added `environment-switcher-v2.scss` with 40px height, dark text color (`--dashboard__text-color`), toggle button color (`--dashboard-menu-item__color`) at 18px, and adjusted `padding-inline-end` to align the toggle caret with the expandable menu carets.
* **Conditional rendering**: The `canToggle` check now conditionally renders the dropdown button rather than disabling it, so users without toggle permission only see the label.

## Screenshots

<img width="500" src="https://github.com/user-attachments/assets/c90de35e-ea79-4b44-ad10-d04dbe006cfc" >

## Why are these changes being made?

The environment switcher design is being updated to visually separate the environment label from the action of switching environments, improving clarity and aligning with updated design specs.

## Testing Instructions

* Open the dashboard on a site that has a staging site.
* Verify the environment switcher shows the environment label with a small up/down arrow button to its right.
* Click the up/down arrow — verify the dropdown opens with production/staging options.
* Verify clicking the label text does not open the dropdown.
* Verify the toggle button hover/focus states match the sidebar nav buttons.
* Verify the up/down arrow aligns horizontally with the expand/collapse chevrons on the menu items below.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?