### PR TITLE
MSD Sidebar: Fall back to root screen on 404/500 routes

### DIFF
--- a/client/dashboard/app/404/index.tsx
+++ b/client/dashboard/app/404/index.tsx
@@ -1,32 +1,14 @@
-import { useRouter } from '@tanstack/react-router';
-import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import { sitesRoute } from '../router/sites';
 
 function NotFound() {
-	const router = useRouter();
-
 	return (
 		<PageLayout
 			header={
 				<PageHeader
 					title={ __( '404 Not Found' ) }
 					description={ __( 'The page you are looking for does not exist.' ) }
-					actions={
-						<Button
-							variant="primary"
-							__next40pxDefaultSize
-							href={
-								router.buildLocation( {
-									to: sitesRoute.fullPath,
-								} ).href
-							}
-						>
-							{ __( 'Go to Sites' ) }
-						</Button>
-					}
 				/>
 			}
 		/>

--- a/client/dashboard/app/500/index.tsx
+++ b/client/dashboard/app/500/index.tsx
@@ -2,21 +2,12 @@ import { __ } from '@wordpress/i18n';
 import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import RouterLinkButton from '../../components/router-link-button';
 
 function UnknownError( { error }: { error: Error } ) {
 	return (
 		<PageLayout
 			header={
-				<PageHeader
-					title={ __( '500 Error' ) }
-					description={ __( 'Something wrong happened.' ) }
-					actions={
-						<RouterLinkButton to="/sites" variant="primary" __next40pxDefaultSize>
-							{ __( 'Go to Sites' ) }
-						</RouterLinkButton>
-					}
-				/>
+				<PageHeader title={ __( '500 Error' ) } description={ __( 'Something wrong happened.' ) } />
 			}
 			notices={ <Notice variant="error">{ error.message }</Notice> }
 		></PageLayout>

--- a/client/dashboard/app/sidebar/index.tsx
+++ b/client/dashboard/app/sidebar/index.tsx
@@ -26,10 +26,15 @@ export function ResponsiveSidebar( { isOpen, onClose }: { isOpen: boolean; onClo
 export default function Sidebar( { onNavigate }: { onNavigate?: () => void } ) {
 	const { Logo, name } = useAppContext();
 	const { recordTracksEvent } = useAnalytics();
-	const resolvedPathname = useRouterState( {
-		select: ( state ) => state.resolvedLocation?.pathname ?? state.location.pathname,
+	const { resolvedPathname, hasError } = useRouterState( {
+		select: ( state ) => ( {
+			resolvedPathname: state.resolvedLocation?.pathname ?? state.location.pathname,
+			hasError: state.matches.some(
+				( match ) => match.status === 'error' || match.status === 'notFound'
+			),
+		} ),
 	} );
-	const screenPath = getScreenPath( resolvedPathname );
+	const screenPath = getScreenPath( resolvedPathname, hasError );
 	const initialPath = useMemo( () => screenPath, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	// Close responsive panel when a navigation link is clicked

--- a/client/dashboard/app/sidebar/navigator-route-sync.tsx
+++ b/client/dashboard/app/sidebar/navigator-route-sync.tsx
@@ -6,10 +6,12 @@ import { useEffect, useRef } from 'react';
  */
 export function getScreenPath( pathname: string ): string {
 	if ( pathname.startsWith( '/sites/' ) ) {
-		return '/sites/' + pathname.split( '/' )[ 2 ];
+		const siteSlug = pathname.split( '/' )[ 2 ];
+		return siteSlug ? '/sites/' + siteSlug : '/';
 	}
 	if ( pathname.startsWith( '/domains/' ) ) {
-		return '/domains/' + pathname.split( '/' )[ 2 ];
+		const domainSlug = pathname.split( '/' )[ 2 ];
+		return domainSlug ? '/domains/' + domainSlug : '/';
 	}
 	if ( pathname.startsWith( '/me' ) ) {
 		return '/me';

--- a/client/dashboard/app/sidebar/navigator-route-sync.tsx
+++ b/client/dashboard/app/sidebar/navigator-route-sync.tsx
@@ -4,10 +4,7 @@ import { useEffect, useRef } from 'react';
 /**
  * Maps the route pathname to a Navigator screen.
  *
- * When `hasError` is true the screen falls back to the parent:
- *   /sites/slug  → /
- *   /domains/slug → /
- *   /me          → /
+ * When `hasError` is true the screen falls back to the parent.
  */
 export function getScreenPath( pathname: string, hasError = false ): string {
 	if ( pathname.startsWith( '/sites/' ) ) {

--- a/client/dashboard/app/sidebar/navigator-route-sync.tsx
+++ b/client/dashboard/app/sidebar/navigator-route-sync.tsx
@@ -3,18 +3,29 @@ import { useEffect, useRef } from 'react';
 
 /**
  * Maps the route pathname to a Navigator screen.
+ *
+ * When `hasError` is true the screen falls back to the parent:
+ *   /sites/slug  → /
+ *   /domains/slug → /
+ *   /me          → /
  */
-export function getScreenPath( pathname: string ): string {
+export function getScreenPath( pathname: string, hasError = false ): string {
 	if ( pathname.startsWith( '/sites/' ) ) {
 		const siteSlug = pathname.split( '/' )[ 2 ];
-		return siteSlug ? '/sites/' + siteSlug : '/';
+		if ( ! siteSlug || hasError ) {
+			return '/';
+		}
+		return '/sites/' + siteSlug;
 	}
 	if ( pathname.startsWith( '/domains/' ) ) {
 		const domainSlug = pathname.split( '/' )[ 2 ];
-		return domainSlug ? '/domains/' + domainSlug : '/';
+		if ( ! domainSlug || hasError ) {
+			return '/';
+		}
+		return '/domains/' + domainSlug;
 	}
 	if ( pathname.startsWith( '/me' ) ) {
-		return '/me';
+		return hasError ? '/' : '/me';
 	}
 	return '/';
 }

--- a/client/dashboard/app/sidebar/test/navigator-route-sync.test.ts
+++ b/client/dashboard/app/sidebar/test/navigator-route-sync.test.ts
@@ -44,4 +44,26 @@ describe( 'getScreenPath', () => {
 	it( 'returns "/" for unknown paths', () => {
 		expect( getScreenPath( '/unknown/path' ) ).toBe( '/' );
 	} );
+
+	describe( 'with error context', () => {
+		it( 'returns "/" for a site path when hasError is true', () => {
+			expect( getScreenPath( '/sites/example.wordpress.com', true ) ).toBe( '/' );
+		} );
+
+		it( 'returns "/" for a site sub-path when hasError is true', () => {
+			expect( getScreenPath( '/sites/example.wordpress.com/settings', true ) ).toBe( '/' );
+		} );
+
+		it( 'returns "/" for a domain path when hasError is true', () => {
+			expect( getScreenPath( '/domains/example.com', true ) ).toBe( '/' );
+		} );
+
+		it( 'returns "/" for "/me" when hasError is true', () => {
+			expect( getScreenPath( '/me', true ) ).toBe( '/' );
+		} );
+
+		it( 'returns "/" for root path when hasError is true', () => {
+			expect( getScreenPath( '/', true ) ).toBe( '/' );
+		} );
+	} );
 } );

--- a/client/dashboard/app/sidebar/test/navigator-route-sync.test.ts
+++ b/client/dashboard/app/sidebar/test/navigator-route-sync.test.ts
@@ -1,0 +1,47 @@
+import { getScreenPath } from '../navigator-route-sync';
+
+describe( 'getScreenPath', () => {
+	it( 'returns "/" for the root path', () => {
+		expect( getScreenPath( '/' ) ).toBe( '/' );
+	} );
+
+	it( 'returns "/" for "/sites/" with no site slug', () => {
+		expect( getScreenPath( '/sites/' ) ).toBe( '/' );
+	} );
+
+	it( 'returns the site screen for a site slug', () => {
+		expect( getScreenPath( '/sites/example.wordpress.com' ) ).toBe(
+			'/sites/example.wordpress.com'
+		);
+	} );
+
+	it( 'returns the site screen and strips sub-paths', () => {
+		expect( getScreenPath( '/sites/example.wordpress.com/settings/general' ) ).toBe(
+			'/sites/example.wordpress.com'
+		);
+	} );
+
+	it( 'returns "/" for "/domains/" with no domain', () => {
+		expect( getScreenPath( '/domains/' ) ).toBe( '/' );
+	} );
+
+	it( 'returns the domain screen for a domain slug', () => {
+		expect( getScreenPath( '/domains/example.com' ) ).toBe( '/domains/example.com' );
+	} );
+
+	it( 'returns the domain screen and strips sub-paths', () => {
+		expect( getScreenPath( '/domains/example.com/manage' ) ).toBe( '/domains/example.com' );
+	} );
+
+	it( 'returns "/me" for "/me"', () => {
+		expect( getScreenPath( '/me' ) ).toBe( '/me' );
+	} );
+
+	it( 'returns "/me" for "/me/" sub-paths', () => {
+		expect( getScreenPath( '/me/billing' ) ).toBe( '/me' );
+	} );
+
+	it( 'returns "/" for unknown paths', () => {
+		expect( getScreenPath( '/unknown/path' ) ).toBe( '/' );
+	} );
+} );


### PR DESCRIPTION
Part of #109437

## Proposed Changes

* Fix `getScreenPath` to return `"/"` instead of `"/sites/undefined"` or `"/domains/undefined"` when the pathname is `/sites/` or `/domains/` with no slug.
* When a route match has an `error` or `notFound` status, the sidebar falls back to the root screen (`"/"`) instead of showing an empty site/domain sidebar.
* Remove the "Go to Sites" button from 404 and 500 pages — the sidebar now shows the primary menu on error routes, so users can navigate from there.
* Add unit tests for `getScreenPath` covering all branches including error context.

## Screenshots

### Before
<img width="1185" height="773" alt="Screenshot 2026-03-23 at 2 29 51 PM" src="https://github.com/user-attachments/assets/d9c529ca-5ba6-484a-a068-00a8edeaecf7" />


### After
#### Parent
<img width="2370" height="1858" alt="my localhost_3000_sites_asdfasf" src="https://github.com/user-attachments/assets/97d6fd9d-8226-4f2f-9719-7dcf4715d185" />
<img width="1184" height="962" alt="Screenshot 2026-03-23 at 2 29 03 PM" src="https://github.com/user-attachments/assets/e0e994ce-c143-4159-b238-cceddb657d27" />


#### Nested Child
<img width="1183" height="1007" alt="Screenshot 2026-03-23 at 2 27 04 PM" src="https://github.com/user-attachments/assets/5c2d5deb-4c70-4de2-92dd-f3f4f104ec90" />





## Why are these changes being made?

Two issues with the sidebar navigator:
1. Navigating to `/sites/` (no slug) produced an invalid screen path `/sites/undefined`.
2. Navigating to `/sites/nonexistent-slug` triggered a route error, but the sidebar still tried to render the site sidebar — resulting in an empty sidebar panel. Now it falls back to the primary menu, making the redundant "Go to Sites" button unnecessary.

## Testing Instructions

* Run `yarn test-client client/dashboard/app/sidebar/test/navigator-route-sync.test.ts` — all 15 tests should pass.
* Navigate to `/sites/nonexistent-slug` — the sidebar should show the primary menu, not an empty site sidebar. No "Go to Sites" button should appear.
* Navigate to `/sites/` — should not break the sidebar.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)