### PR TITLE
Image Studio: Deduplicate notices by message content

### DIFF
--- a/packages/image-studio/src/store/index.test.ts
+++ b/packages/image-studio/src/store/index.test.ts
@@ -521,6 +521,34 @@ describe( 'Image Studio Store', () => {
 				expect( state.notices[ 0 ].content ).toBe( 'Message 2' );
 			} );
 
+			it( 'deduplicates notices with the same message content', () => {
+				let state = reducer( getInitialState(), actions.addNotice( 'Low credits', 'warning' ) );
+				expect( state.notices ).toHaveLength( 1 );
+
+				state = reducer( state, actions.addNotice( 'Low credits', 'warning' ) );
+				expect( state.notices ).toHaveLength( 1 );
+			} );
+
+			it( 'allows multiple warnings with different messages', () => {
+				let state = reducer( getInitialState(), actions.addNotice( 'Low credits', 'warning' ) );
+				state = reducer( state, actions.addNotice( 'Upgrade required', 'warning' ) );
+				expect( state.notices ).toHaveLength( 2 );
+			} );
+
+			it( 'deduplicates across notice types', () => {
+				let state = reducer( getInitialState(), actions.addNotice( 'Same message', 'error' ) );
+				state = reducer( state, actions.addNotice( 'Same message', 'warning' ) );
+				expect( state.notices ).toHaveLength( 1 );
+				expect( state.notices[ 0 ].type ).toBe( 'error' );
+			} );
+
+			it( 'allows multiple notices with different messages', () => {
+				let state = reducer( getInitialState(), actions.addNotice( 'Error 1', 'error' ) );
+				state = reducer( state, actions.addNotice( 'Error 2', 'error' ) );
+				state = reducer( state, actions.addNotice( 'Success 1', 'success' ) );
+				expect( state.notices ).toHaveLength( 3 );
+			} );
+
 			it( 'handles removing non-existent notice', () => {
 				const previousState: ImageStudioState = {
 					...getInitialState(),

--- a/packages/image-studio/src/store/index.ts
+++ b/packages/image-studio/src/store/index.ts
@@ -512,11 +512,18 @@ const reducer = (
 				isExitConfirmed: action.payload,
 			};
 
-		case 'ADD_NOTICE':
+		case 'ADD_NOTICE': {
+			// Deduplicate notices by message content: if a notice with the
+			// same text already exists, skip adding it again.
+			if ( state.notices.some( ( n ) => n.content === action.payload.content ) ) {
+				return state;
+			}
+
 			return {
 				...state,
 				notices: [ ...state.notices, action.payload ],
 			};
+		}
 
 		case 'REMOVE_NOTICE':
 			return {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of FORNO-262

## Proposed Changes

* Deduplicate Image Studio notices with identical messages

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Currently in Image Studio we show an upgrade notice when user is low on (or out of) credits. If the message is not dismissed the same error can be displayed again on the next request leading to a stack of duplicate notices.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `install-plugin.sh am dedupe-notice-messages` on your sandbox
* Sandbox `widgets.wp.com`
* While connected to the proxy, load a test site that is out of credits 
* Open Image Studio and then disconnect from the proxy
* In the Image Studio sidebar, attempt to regenerate alt text
* `You've reached your free AI limit. Unlock more generations with a paid plan.` notice should be displayed
* Attempt to regenerate alt text again
* Verify only one notice is displayed 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
