### PR TITLE
MSD: Add dashboard/omnibar feature flag for sidebar

### DIFF
--- a/client/dashboard/app/header/index.tsx
+++ b/client/dashboard/app/header/index.tsx
@@ -1,20 +1,44 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { menu } from '@wordpress/icons';
 import HeaderBar from '../../components/header-bar';
+import RouterLinkButton from '../../components/router-link-button';
+import { useAnalytics } from '../analytics';
+import { useAppContext } from '../context';
+import PrimaryMenu from '../primary-menu';
 import SecondaryMenu from '../secondary-menu';
 
 function Header( { onOpenMenu, isMenuOpen }: { onOpenMenu?: () => void; isMenuOpen?: boolean } ) {
+	const isOmnibar = isEnabled( 'dashboard/omnibar' );
+	const { recordTracksEvent } = useAnalytics();
+	const { Logo, name } = useAppContext();
 	const isDesktop = useViewportMatch( 'medium' );
 
 	return (
 		<HeaderBar as="header">
-			{ ! isDesktop && ! isMenuOpen && (
+			{ isOmnibar && ! isDesktop && ! isMenuOpen && (
 				<Button icon={ menu } label={ __( 'Menu' ) } onClick={ onOpenMenu } />
 			) }
 
-			<div style={ { flexGrow: 1 } } />
+			{ ! isOmnibar && ! isDesktop && <PrimaryMenu /> }
+
+			{ ! isOmnibar && Logo && (
+				<div style={ { display: 'flex', alignItems: 'center' } }>
+					<RouterLinkButton
+						/* translators: Screen reader text for link to root of the hosting dashboard. "name" is the product of whose hosting dashboard this is: e.g. WordPress.com */
+						aria-label={ sprintf( __( '%(name)s home' ), { name } ) }
+						icon={ <Logo /> }
+						to="/"
+						onClick={ () => {
+							recordTracksEvent( 'calypso_dashboard_logo_click' );
+						} }
+					/>
+				</div>
+			) }
+
+			<div style={ { flexGrow: 1 } }>{ ! isOmnibar && isDesktop && <PrimaryMenu /> }</div>
 			<div style={ { flexShrink: 0 } }>
 				<SecondaryMenu />
 			</div>

--- a/client/dashboard/app/primary-menu/index.tsx
+++ b/client/dashboard/app/primary-menu/index.tsx
@@ -1,11 +1,12 @@
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { brush, copy, envelope, globe, plugins } from '@wordpress/icons';
+import ResponsiveMenu from '../../components/responsive-menu';
 import { SidebarExpandableMenuItem, SidebarMenu, SidebarMenuItem } from '../../components/sidebar';
 import { wpcomLink } from '../../utils/link';
 import { useAppContext } from '../context';
 
-function PrimaryMenu() {
+export function PrimaryMenuSidebar() {
 	const { supports } = useAppContext();
 
 	return (
@@ -57,6 +58,34 @@ function PrimaryMenu() {
 				</SidebarMenuItem>
 			) }
 		</SidebarMenu>
+	);
+}
+
+function PrimaryMenu() {
+	const { supports } = useAppContext();
+
+	return (
+		<ResponsiveMenu>
+			{ supports.sites && <ResponsiveMenu.Item to="/sites">{ __( 'Sites' ) }</ResponsiveMenu.Item> }
+			{ supports.domains && (
+				<ResponsiveMenu.Item to="/domains">{ __( 'Domains' ) }</ResponsiveMenu.Item>
+			) }
+			{ supports.emails && (
+				<ResponsiveMenu.Item to="/emails">{ __( 'Emails' ) }</ResponsiveMenu.Item>
+			) }
+			{ supports.plugins && (
+				<ResponsiveMenu.Item to="/plugins/manage">{ __( 'Plugins' ) }</ResponsiveMenu.Item>
+			) }
+			{ supports.themes && (
+				<ResponsiveMenu.Item
+					href={ wpcomLink( '/themes' ) }
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					{ __( 'Themes' ) }
+				</ResponsiveMenu.Item>
+			) }
+		</ResponsiveMenu>
 	);
 }
 

--- a/client/dashboard/app/root/index.tsx
+++ b/client/dashboard/app/root/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { WordPressLogo } from '@automattic/components/src/logos/wordpress-logo';
 import { useQueryClient, useIsFetching } from '@tanstack/react-query';
 import { CatchNotFound, Outlet, useRouterState, useRouter } from '@tanstack/react-router';
@@ -34,6 +35,7 @@ const SLOW_THRESHOLD_MS = 100;
 const VERY_SLOW_THRESHOLD_MS = 6000;
 
 function Root() {
+	const isOmnibar = isEnabled( 'dashboard/omnibar' );
 	const { name, supports, LoadingLogo = WordPressLogo } = useAppContext();
 	const isDesktop = useViewportMatch( 'medium' );
 	const [ isResponsiveSidebarOpen, setIsResponsiveSidebarOpen ] = useState( false );
@@ -123,7 +125,7 @@ function Root() {
 				/>
 			) }
 			{ ( isInitialLoad || isVerySlowNavigation ) && <LoadingLogo className="wpcom-site__logo" /> }
-			{ ! isVerySlowNavigation && (
+			{ ! isVerySlowNavigation && isOmnibar && (
 				<div className="dashboard-root__body">
 					{ isDesktop && <Sidebar /> }
 					{ ! isDesktop && (
@@ -148,6 +150,16 @@ function Root() {
 						</main>
 					</div>
 				</div>
+			) }
+			{ ! isVerySlowNavigation && ! isOmnibar && (
+				<>
+					<Header />
+					<main>
+						<CatchNotFound fallback={ NotFound }>
+							<Outlet />
+						</CatchNotFound>
+					</main>
+				</>
 			) }
 			{ supports.commandPalette && <CommandPalette /> }
 			<Snackbars />

--- a/client/dashboard/app/root/style.scss
+++ b/client/dashboard/app/root/style.scss
@@ -1,7 +1,19 @@
-.dashboard-root__content > .dashboard-header-bar {
+// Old layout (no sidebar): sticky header
+// For pages without sub menus, the first header is the sticky header
+// For pages with sub menus, the second header is the sticky header
+.dashboard-root__layout:not(:has(main > .dashboard-header-bar)) > .dashboard-header-bar,
+.dashboard-root__layout > main > .dashboard-header-bar {
 	position: sticky;
 	top: 0;
 	z-index: 3; // DataViews header seems to have z-index: 1; CalloutOverlay has z-index: 2
+}
+
+// Sidebar layout: sticky header in content area
+.dashboard-root__content > .dashboard-header-bar {
+	position: sticky;
+	top: 0;
+	z-index: 3;
+	height: 65px; // temporary to match Reader's header bar height
 }
 
 .dashboard-root__body {
@@ -21,4 +33,14 @@
 	position: absolute;
 	inset: 0;
 	z-index: 100;
+}
+
+// Sidebar layout: hide inner section headers and tab navigation
+// (sidebar handles navigation instead)
+.dashboard-root__body main .dashboard-header-bar {
+	display: none;
+}
+
+.dashboard-root__body .card__header:has([role="tablist"]) {
+	display: none;
 }

--- a/client/dashboard/app/sidebar/index.tsx
+++ b/client/dashboard/app/sidebar/index.tsx
@@ -9,7 +9,7 @@ import MeSidebar from '../../me/me-sidebar';
 import SiteSidebar from '../../sites/site-sidebar';
 import { useAnalytics } from '../analytics';
 import { useAppContext } from '../context';
-import PrimaryMenu from '../primary-menu';
+import { PrimaryMenuSidebar } from '../primary-menu';
 import RouteErrorBoundary from './error';
 import { getScreenPath, NavigatorRouteSync } from './navigator-route-sync';
 
@@ -75,7 +75,7 @@ export default function Sidebar( { onNavigate }: { onNavigate?: () => void } ) {
 				<NavigatorRouteSync screenPath={ screenPath } />
 
 				<Navigator.Screen path="/">
-					<PrimaryMenu />
+					<PrimaryMenuSidebar />
 				</Navigator.Screen>
 
 				<Navigator.Screen path="/sites/:siteSlug">

--- a/client/dashboard/components/header-bar/style.scss
+++ b/client/dashboard/components/header-bar/style.scss
@@ -22,8 +22,6 @@ $component-icon-padding: 6px;
 	&.is-support-user-session {
 		background-color: var( --dashboard-header__support-background-color );
 	}
-
-	height: 65px; // temporary to match Reader's header bar height
 }
 
 .dashboard-header-bar-title > span {

--- a/client/dashboard/components/switcher/index.tsx
+++ b/client/dashboard/components/switcher/index.tsx
@@ -69,7 +69,7 @@ export default function Switcher< T >( {
 					} }
 					aria-haspopup="true"
 					aria-expanded={ isOpen }
-					style={ { justifyContent: 'flex-start' } }
+					style={ { width: '100%', justifyContent: 'flex-start' } }
 				>
 					<HStack
 						alignment="center"

--- a/client/dashboard/domains/domain-menu/index.tsx
+++ b/client/dashboard/domains/domain-menu/index.tsx
@@ -3,9 +3,11 @@ import { __ } from '@wordpress/i18n';
 import { category, envelope } from '@wordpress/icons';
 import { useAppContext } from '../../app/context';
 import { emailsRoute } from '../../app/router/emails';
+import MenuDivider from '../../components/menu-divider';
+import ResponsiveMenu from '../../components/responsive-menu';
 import { SidebarMenu, SidebarMenuItem } from '../../components/sidebar';
 
-const DomainMenu = ( { domainName }: { domainName: string } ) => {
+export const DomainMenuSidebar = ( { domainName }: { domainName: string } ) => {
 	const { supports } = useAppContext();
 	const router = useRouter();
 
@@ -28,6 +30,26 @@ const DomainMenu = ( { domainName }: { domainName: string } ) => {
 				</SidebarMenuItem>
 			) }
 		</SidebarMenu>
+	);
+};
+
+const DomainMenu = ( { domainName }: { domainName: string } ) => {
+	const { supports } = useAppContext();
+	const router = useRouter();
+
+	return (
+		<ResponsiveMenu label={ __( 'Domain Menu' ) } prefix={ <MenuDivider /> }>
+			<ResponsiveMenu.Item to={ `/domains/${ domainName }` }>
+				{ __( 'Overview' ) }
+			</ResponsiveMenu.Item>
+			{ supports.emails && (
+				<ResponsiveMenu.Item
+					to={ router.buildLocation( { to: emailsRoute.fullPath, search: { domainName } } ).href }
+				>
+					{ __( 'Emails' ) }
+				</ResponsiveMenu.Item>
+			) }
+		</ResponsiveMenu>
 	);
 };
 

--- a/client/dashboard/domains/domain-sidebar/index.tsx
+++ b/client/dashboard/domains/domain-sidebar/index.tsx
@@ -4,7 +4,7 @@ import { __experimentalVStack as VStack, useNavigator } from '@wordpress/compone
 import { __ } from '@wordpress/i18n';
 import { Suspense } from 'react';
 import { SidebarBackButton } from '../../components/sidebar';
-import DomainMenu from '../domain-menu';
+import { DomainMenuSidebar } from '../domain-menu';
 import DomainSwitcher from '../domain-switcher';
 
 export default function DomainSidebar() {
@@ -24,7 +24,7 @@ export default function DomainSidebar() {
 				<Suspense fallback={ null }>
 					<DomainSwitcher domain={ domain } />
 				</Suspense>
-				<DomainMenu domainName={ domainName } />
+				<DomainMenuSidebar domainName={ domainName } />
 			</VStack>
 		</VStack>
 	);

--- a/client/dashboard/domains/domain/index.tsx
+++ b/client/dashboard/domains/domain/index.tsx
@@ -1,7 +1,75 @@
+import { DomainSubtype } from '@automattic/api-core';
+import { domainQuery } from '@automattic/api-queries';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { Outlet } from '@tanstack/react-router';
+import { __experimentalHStack as HStack, Icon } from '@wordpress/components';
+import { globe } from '@wordpress/icons';
+import { useAppContext } from '../../app/context';
+import useBuildCurrentRouteLink from '../../app/hooks/use-build-current-route-link';
+import { domainRoute } from '../../app/router/domains';
+import HeaderBar from '../../components/header-bar';
+import Switcher from '../../components/switcher';
+import DomainMenu from '../domain-menu';
+import type { DomainSummary } from '@automattic/api-core';
+import './style.scss';
 
 function Domain() {
-	return <Outlet />;
+	const { queries } = useAppContext();
+	const { domainName } = domainRoute.useParams();
+	const domains = useQuery( {
+		...queries.domainsQuery(),
+		select: ( data ) => {
+			return data.filter( ( domain ) => domain.subtype.id !== DomainSubtype.DEFAULT_ADDRESS );
+		},
+	} ).data;
+	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
+
+	const searchableFields = [
+		{
+			id: 'name',
+			getValue: ( { item }: { item: DomainSummary } ) => item.domain,
+			enableGlobalSearch: true,
+		},
+	];
+
+	const buildCurrentRouteLink = useBuildCurrentRouteLink();
+
+	return (
+		<>
+			<HeaderBar>
+				<HStack spacing={ 3 }>
+					<HeaderBar.Title>
+						<Switcher
+							items={ domains }
+							value={ domain }
+							searchableFields={ searchableFields }
+							getItemUrl={ ( domain ) =>
+								buildCurrentRouteLink( { params: { domainName: domain.domain } } )
+							}
+							renderItemMedia={ ( { context } ) =>
+								context === 'list' ? null : (
+									<Icon className="domain-icon" icon={ globe } size={ 24 } />
+								)
+							}
+							renderItemTitle={ ( { item } ) => (
+								<span
+									style={ {
+										overflow: 'hidden',
+										textOverflow: 'ellipsis',
+										whiteSpace: 'nowrap',
+									} }
+								>
+									{ item.domain }
+								</span>
+							) }
+						/>
+					</HeaderBar.Title>
+					<DomainMenu domainName={ domain.domain } />
+				</HStack>
+			</HeaderBar>
+			<Outlet />
+		</>
+	);
 }
 
 export default Domain;

--- a/client/dashboard/me/index.tsx
+++ b/client/dashboard/me/index.tsx
@@ -1,7 +1,23 @@
 import { Outlet } from '@tanstack/react-router';
+import { __experimentalHStack as HStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import HeaderBar from '../components/header-bar';
+import MeMenu from './me-menu';
 
 function Me() {
-	return <Outlet />;
+	return (
+		<>
+			<HeaderBar>
+				<HStack spacing={ 3 }>
+					<HeaderBar.Title>
+						<span>{ __( 'Account' ) }</span>
+					</HeaderBar.Title>
+					<MeMenu />
+				</HStack>
+			</HeaderBar>
+			<Outlet />
+		</>
+	);
 }
 
 export default Me;

--- a/client/dashboard/me/me-menu/index.tsx
+++ b/client/dashboard/me/me-menu/index.tsx
@@ -12,6 +12,8 @@ import {
 	starEmpty,
 } from '@wordpress/icons';
 import { useAppContext } from '../../app/context';
+import MenuDivider from '../../components/menu-divider';
+import ResponsiveMenu from '../../components/responsive-menu';
 import { SidebarMenu, SidebarMenuItem } from '../../components/sidebar';
 import type { AppConfig, MeSupports } from '../../app/context';
 
@@ -19,7 +21,7 @@ const hasAppSupport = ( supports: AppConfig[ 'supports' ], feature: keyof MeSupp
 	return supports.me && supports.me[ feature ];
 };
 
-const MeMenu = () => {
+export const MeMenuSidebar = () => {
 	const { supports } = useAppContext();
 
 	return (
@@ -62,6 +64,34 @@ const MeMenu = () => {
 				</SidebarMenuItem>
 			) }
 		</SidebarMenu>
+	);
+};
+
+const MeMenu = () => {
+	const { supports } = useAppContext();
+
+	return (
+		<ResponsiveMenu prefix={ <MenuDivider /> }>
+			<ResponsiveMenu.Item to="/me/profile">{ __( 'Profile' ) }</ResponsiveMenu.Item>
+			<ResponsiveMenu.Item to="/me/preferences">{ __( 'Preferences' ) }</ResponsiveMenu.Item>
+			<ResponsiveMenu.Item to="/me/billing">{ __( 'Billing' ) }</ResponsiveMenu.Item>
+			<ResponsiveMenu.Item to="/me/security">{ __( 'Security' ) }</ResponsiveMenu.Item>
+			{ hasAppSupport( supports, 'privacy' ) && (
+				<ResponsiveMenu.Item to="/me/privacy">{ __( 'Privacy' ) }</ResponsiveMenu.Item>
+			) }
+			{ supports.notifications && (
+				<ResponsiveMenu.Item to="/me/notifications">{ __( 'Notifications' ) }</ResponsiveMenu.Item>
+			) }
+			{ supports.reader && (
+				<ResponsiveMenu.Item to="/me/blocked-sites">{ __( 'Blocked sites' ) }</ResponsiveMenu.Item>
+			) }
+			{ isEnabled( 'mcp-settings' ) && (
+				<ResponsiveMenu.Item to="/me/mcp">{ __( 'MCP' ) }</ResponsiveMenu.Item>
+			) }
+			{ hasAppSupport( supports, 'apps' ) && (
+				<ResponsiveMenu.Item to="/me/apps">{ __( 'Apps' ) }</ResponsiveMenu.Item>
+			) }
+		</ResponsiveMenu>
 	);
 };
 

--- a/client/dashboard/me/me-sidebar/index.tsx
+++ b/client/dashboard/me/me-sidebar/index.tsx
@@ -6,7 +6,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import MeMenu from '../me-menu';
+import { MeMenuSidebar } from '../me-menu';
 
 import './style.scss';
 
@@ -34,7 +34,7 @@ export default function MeSidebar() {
 					</Text>
 				</VStack>
 			</HStack>
-			<MeMenu />
+			<MeMenuSidebar />
 		</VStack>
 	);
 }

--- a/client/dashboard/plugins/index.tsx
+++ b/client/dashboard/plugins/index.tsx
@@ -1,5 +1,21 @@
 import { Outlet } from '@tanstack/react-router';
+import { __experimentalHStack as HStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import HeaderBar from '../components/header-bar';
+import PluginsMenu from './plugins-menu';
 
 export default function Plugins() {
-	return <Outlet />;
+	return (
+		<>
+			<HeaderBar>
+				<HStack spacing={ 3 }>
+					<HeaderBar.Title>
+						<span>{ __( 'Plugins' ) }</span>
+					</HeaderBar.Title>
+					<PluginsMenu />
+				</HStack>
+			</HeaderBar>
+			<Outlet />
+		</>
+	);
 }

--- a/client/dashboard/plugins/plugins-menu/index.tsx
+++ b/client/dashboard/plugins/plugins-menu/index.tsx
@@ -1,0 +1,24 @@
+import { __ } from '@wordpress/i18n';
+import MenuDivider from '../../components/menu-divider';
+import ResponsiveMenu from '../../components/responsive-menu';
+import { wpcomLink } from '../../utils/link';
+
+const PluginsMenu = () => {
+	return (
+		<ResponsiveMenu prefix={ <MenuDivider /> }>
+			<ResponsiveMenu.Item to="/plugins/manage">{ __( 'Manage plugins' ) }</ResponsiveMenu.Item>
+			<ResponsiveMenu.Item to="/plugins/scheduled-updates">
+				{ __( 'Scheduled updates' ) }
+			</ResponsiveMenu.Item>
+			<ResponsiveMenu.Item
+				href={ wpcomLink( '/plugins' ) }
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				{ __( 'Browse plugins' ) }
+			</ResponsiveMenu.Item>
+		</ResponsiveMenu>
+	);
+};
+
+export default PluginsMenu;

--- a/client/dashboard/sites/logs/index.tsx
+++ b/client/dashboard/sites/logs/index.tsx
@@ -1,13 +1,15 @@
 import { HostingFeatures, LogType } from '@automattic/api-core';
 import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
+import { TabPanel } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from 'react';
 import { useDateRange } from '../../app/hooks/use-date-range';
 import { useLocale } from '../../app/locale';
 import { siteRoute } from '../../app/router/sites';
-import { Card, CardBody } from '../../components/card';
+import { Card, CardBody, CardHeader } from '../../components/card';
 import { DateRangePicker } from '../../components/date-range-picker';
 import { isLast7Days } from '../../components/date-range-picker/utils';
 import InlineSupportLink from '../../components/inline-support-link';
@@ -20,11 +22,13 @@ import HostingFeatureGatedWithCallout from '../hosting-feature-gated-with-callou
 import SiteActivityLogsDataViews from '../logs-activity/dataviews';
 import SiteLogsDataViews from './dataviews';
 import { getLogsCalloutProps } from './logs-callout';
+import { LOG_TABS } from './utils';
 import './style.scss';
 
 function SiteLogs( { logType }: { logType: LogType } ) {
 	const locale = useLocale();
 	const { siteSlug } = siteRoute.useParams();
+	const router = useRouter();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 
 	const settingsUrl = site.options?.admin_url
@@ -111,6 +115,19 @@ function SiteLogs( { logType }: { logType: LogType } ) {
 		return true;
 	};
 
+	const handleTabChange = ( tab: LogType ) => {
+		if ( logType === tab ) {
+			return;
+		}
+
+		if ( tab === LogType.PHP ) {
+			router.navigate( { to: `/sites/${ siteSlug }/logs/php` } );
+		} else if ( tab === LogType.ACTIVITY ) {
+			router.navigate( { to: `/sites/${ siteSlug }/logs/activity` } );
+		} else {
+			router.navigate( { to: `/sites/${ siteSlug }/logs/server` } );
+		}
+	};
 	const hasActivityLogAccess =
 		hasHostingFeature( site, HostingFeatures.ACTIVITY_LOG ) ||
 		hasPlanFeature( site, HostingFeatures.ACTIVITY_LOG );
@@ -157,6 +174,25 @@ function SiteLogs( { logType }: { logType: LogType } ) {
 			}
 		>
 			<Card className={ `site-logs-card site-logs-card--${ logType }` }>
+				<CardHeader style={ { paddingBottom: '0' } }>
+					<TabPanel
+						className="site-logs-tabs"
+						activeClass="is-active"
+						tabs={ LOG_TABS }
+						onSelect={ ( tabName ) => {
+							if (
+								tabName === LogType.PHP ||
+								tabName === LogType.SERVER ||
+								tabName === LogType.ACTIVITY
+							) {
+								handleTabChange( tabName );
+							}
+						} }
+						initialTabName={ logType }
+					>
+						{ () => null }
+					</TabPanel>
+				</CardHeader>
 				<CardBody>
 					{ logType === LogType.PHP || logType === LogType.SERVER ? (
 						<HostingFeatureGatedWithCallout site={ site } { ...getLogsCalloutProps() }>

--- a/client/dashboard/sites/logs/test/index.test.tsx
+++ b/client/dashboard/sites/logs/test/index.test.tsx
@@ -176,6 +176,26 @@ beforeEach( () => {
 } );
 
 describe( 'SiteLogs page', () => {
+	test.each( Object.entries( LogType ) )(
+		'on selecting tab %s, navigates to /%s',
+		async ( logType, logTypeName ) => {
+			// Different initial log type that the one under test
+			const initialLogType = logTypeName !== LogType.PHP ? LogType.PHP : LogType.SERVER;
+			render( <SiteLogs logType={ initialLogType } /> );
+
+			// Click another tab
+			await userEvent.click(
+				await screen.findByRole( 'button', { name: new RegExp( logTypeName, 'i' ) } )
+			);
+			const { __mocks: routerMocks } = jest.requireMock( '@tanstack/react-router' ) as {
+				__mocks: { navigate: jest.Mock };
+			};
+			expect( routerMocks.navigate ).toHaveBeenCalledWith( {
+				to: `/sites/test-site/logs/${ logTypeName }`,
+			} );
+		}
+	);
+
 	test( 'URL from/to params are normalized from ms to seconds', async () => {
 		const replaceSpy = jest.spyOn( window.history, 'replaceState' );
 		const msFrom = 1730000000000; // ms
@@ -188,17 +208,16 @@ describe( 'SiteLogs page', () => {
 
 		render( <SiteLogs logType={ LogType.PHP } /> );
 
-		await waitFor( () => {
-			const hrefArgs = replaceSpy.mock.calls
-				.map( ( call ) => call?.[ 2 ] )
-				.filter( ( v ): v is string => typeof v === 'string' );
-			expect(
-				hrefArgs.some( ( h ) => h.includes( `from=${ Math.floor( msFrom / 1000 ) }` ) )
-			).toBe( true );
-			expect( hrefArgs.some( ( h ) => h.includes( `to=${ Math.floor( msTo / 1000 ) }` ) ) ).toBe(
-				true
-			);
-		} );
+		await waitFor( () => expect( replaceSpy ).toHaveBeenCalled() );
+		const hrefArgs = replaceSpy.mock.calls
+			.map( ( call ) => call?.[ 2 ] )
+			.filter( ( v ): v is string => typeof v === 'string' );
+		expect( hrefArgs.some( ( h ) => h.includes( `from=${ Math.floor( msFrom / 1000 ) }` ) ) ).toBe(
+			true
+		);
+		expect( hrefArgs.some( ( h ) => h.includes( `to=${ Math.floor( msTo / 1000 ) }` ) ) ).toBe(
+			true
+		);
 
 		// restore
 		Object.defineProperty( window, 'location', { value: { href: originalHref } } );

--- a/client/dashboard/sites/scan/index.tsx
+++ b/client/dashboard/sites/scan/index.tsx
@@ -1,7 +1,8 @@
 import { HostingFeatures } from '@automattic/api-core';
 import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { Button, Modal } from '@wordpress/components';
+import { useRouter } from '@tanstack/react-router';
+import { Button, Modal, TabPanel } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { shield } from '@wordpress/icons';
 import { useState } from 'react';
@@ -9,7 +10,7 @@ import { useAnalytics } from '../../app/analytics';
 import { PerformanceTrackerStop } from '../../app/performance-tracking';
 import { siteRoute } from '../../app/router/sites';
 import { ButtonStack } from '../../components/button-stack';
-import { Card, CardBody } from '../../components/card';
+import { Card, CardHeader, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import TimeMismatchNotice from '../../components/time-mismatch-notice';
@@ -26,8 +27,14 @@ import { useScanState } from './use-scan-state';
 
 import './style.scss';
 
+const SCAN_TABS = [
+	{ name: 'active', title: __( 'Active threats' ) },
+	{ name: 'history', title: __( 'History' ) },
+];
+
 function SiteScan( { scanTab }: { scanTab: 'active' | 'history' } ) {
 	const { siteSlug } = siteRoute.useParams();
+	const router = useRouter();
 
 	const { recordTracksEvent } = useAnalytics();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
@@ -65,6 +72,18 @@ function SiteScan( { scanTab }: { scanTab: 'active' | 'history' } ) {
 		}
 
 		return null;
+	};
+
+	const handleTabChange = ( tab: 'active' | 'history' ) => {
+		if ( scanTab === tab ) {
+			return;
+		}
+
+		if ( tab === 'active' ) {
+			router.navigate( { to: `/sites/${ siteSlug }/scan/active` } );
+		} else {
+			router.navigate( { to: `/sites/${ siteSlug }/scan/history` } );
+		}
 	};
 
 	const renderActiveTab = () => {
@@ -147,6 +166,20 @@ function SiteScan( { scanTab }: { scanTab: 'active' | 'history' } ) {
 				}
 			>
 				<Card>
+					<CardHeader style={ { paddingBottom: '0' } }>
+						<TabPanel
+							activeClass="is-active"
+							tabs={ SCAN_TABS }
+							onSelect={ ( tabName ) => {
+								if ( tabName === 'active' || tabName === 'history' ) {
+									handleTabChange( tabName );
+								}
+							} }
+							initialTabName={ scanTab }
+						>
+							{ () => null }
+						</TabPanel>
+					</CardHeader>
 					<CardBody>
 						{ scanTab === 'active' && renderActiveTab() }
 						{ scanTab === 'history' && (

--- a/client/dashboard/sites/site-menu/index.tsx
+++ b/client/dashboard/sites/site-menu/index.tsx
@@ -23,6 +23,8 @@ import {
 	siteDomainsRoute,
 	siteSettingsRoute,
 } from '../../app/router/sites';
+import MenuDivider from '../../components/menu-divider';
+import ResponsiveMenu from '../../components/responsive-menu';
 import { SidebarExpandableMenuItem, SidebarMenu, SidebarMenuItem } from '../../components/sidebar';
 import { hasHostingFeature } from '../../utils/site-features';
 import { hasSiteTrialEnded } from '../../utils/site-trial';
@@ -31,7 +33,7 @@ import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import type { Site } from '@automattic/api-core';
 import type { AnyRoute } from '@tanstack/react-router';
 
-const SiteMenu = ( { site }: { site: Site } ) => {
+export const SiteMenuSidebar = ( { site }: { site: Site } ) => {
 	const siteSlug = site.slug;
 
 	const siteTypeSupports = getSiteTypeFeatureSupports( site );
@@ -150,6 +152,98 @@ const SiteMenu = ( { site }: { site: Site } ) => {
 					</SidebarMenuItem>
 				) }
 		</SidebarMenu>
+	);
+};
+
+const SiteMenu = ( { site }: { site: Site } ) => {
+	const siteSlug = site.slug;
+
+	const siteTypeSupports = getSiteTypeFeatureSupports( site );
+	if ( hasSiteTrialEnded( site ) ) {
+		return (
+			<ResponsiveMenu label={ __( 'Site Menu' ) } prefix={ <MenuDivider /> }>
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/trial-ended` }>
+					{ __( 'Trial ended' ) }
+				</ResponsiveMenu.Item>
+			</ResponsiveMenu>
+		);
+	}
+
+	if ( site.options?.is_difm_lite_in_progress && ! isSupportSession() ) {
+		return (
+			<ResponsiveMenu label={ __( 'Site Menu' ) } prefix={ <MenuDivider /> }>
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/site-building-in-progress` }>
+					{ __( 'Site building' ) }
+				</ResponsiveMenu.Item>
+				{ siteTypeSupports.domains && (
+					<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/domains` }>
+						{ __( 'Domains' ) }
+					</ResponsiveMenu.Item>
+				) }
+				{ siteTypeSupports.emails && (
+					<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/emails` }>
+						{ __( 'Emails' ) }
+					</ResponsiveMenu.Item>
+				) }
+			</ResponsiveMenu>
+		);
+	}
+
+	const isAvailable = ( route: AnyRoute ) =>
+		! site.__inaccessible_jetpack_error ||
+		route.options.staticData?.availableToInaccessibleJetpackSites;
+
+	return (
+		<ResponsiveMenu label={ __( 'Site Menu' ) } prefix={ <MenuDivider /> }>
+			{ isAvailable( siteOverviewRoute ) && (
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }` } activeOptions={ { exact: true } }>
+					{ __( 'Overview' ) }
+				</ResponsiveMenu.Item>
+			) }
+			{ isAvailable( siteDeploymentsRoute ) && siteTypeSupports.deployments && (
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/deployments` }>
+					{ __( 'Deployments' ) }
+				</ResponsiveMenu.Item>
+			) }
+			{ isAvailable( sitePerformanceRoute ) && siteTypeSupports.performance && (
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/performance` }>
+					{ __( 'Performance' ) }
+				</ResponsiveMenu.Item>
+			) }
+			{ isAvailable( siteMonitoringRoute ) && siteTypeSupports.monitoring && (
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/monitoring` }>
+					{ __( 'Monitoring' ) }
+				</ResponsiveMenu.Item>
+			) }
+			{ isAvailable( siteLogsRoute ) && siteTypeSupports.logs && (
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/logs` }>
+					{ __( 'Logs' ) }
+				</ResponsiveMenu.Item>
+			) }
+			{ isAvailable( siteScanRoute ) && siteTypeSupports.scan && (
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/scan` }>
+					{ __( 'Scan' ) }
+				</ResponsiveMenu.Item>
+			) }
+			{ isAvailable( siteBackupsRoute ) && siteTypeSupports.backups && (
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/backups` }>
+					{ __( 'Backups' ) }
+				</ResponsiveMenu.Item>
+			) }
+			{ isAvailable( siteDomainsRoute ) && siteTypeSupports.domains && (
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/domains` }>
+					{ __( 'Domains' ) }
+				</ResponsiveMenu.Item>
+			) }
+			{ isAvailable( siteSettingsRoute ) &&
+				siteTypeSupports.settings &&
+				site.capabilities?.manage_options &&
+				! isSelfHostedJetpackConnected( site ) && (
+					<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/settings` }>
+						{ __( 'Settings' ) }
+					</ResponsiveMenu.Item>
+				) }
+		</ResponsiveMenu>
 	);
 };
 

--- a/client/dashboard/sites/site-sidebar/index.tsx
+++ b/client/dashboard/sites/site-sidebar/index.tsx
@@ -7,7 +7,7 @@ import { useAppContext } from '../../app/context';
 import { SidebarBackButton, SidebarMenu } from '../../components/sidebar';
 import { canSwitchEnvironment } from '../features';
 import EnvironmentSwitcher from '../site/environment-switcher-v2';
-import SiteMenu from '../site-menu';
+import { SiteMenuSidebar } from '../site-menu';
 
 export default function SiteSidebar() {
 	const { params } = useNavigator();
@@ -32,7 +32,7 @@ export default function SiteSidebar() {
 						{ canSwitchEnvironment( site ) && <EnvironmentSwitcher site={ site } /> }
 					</SidebarMenu>
 				</Suspense>
-				<SiteMenu site={ site } />
+				<SiteMenuSidebar site={ site } />
 			</VStack>
 		</VStack>
 	);

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -1,17 +1,26 @@
 import { siteBySlugQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { notFound, Outlet } from '@tanstack/react-router';
+import { __experimentalHStack as HStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Suspense } from 'react';
+import { Suspense, useMemo, lazy } from 'react';
+import { useAppContext } from '../../app/context';
 import { siteRoute } from '../../app/router/sites';
 import StagingSiteSyncMonitor from '../../app/staging-site-sync-monitor';
 import FlashMessage from '../../components/flash-message';
+import HeaderBar from '../../components/header-bar';
+import MenuDivider from '../../components/menu-divider';
 import { hasStagingSite } from '../../utils/site-staging-site';
-import { canManageSite } from '../features';
+import { isSiteMigrationInProgress } from '../../utils/site-status';
+import { canManageSite, canSwitchEnvironment } from '../features';
+import SiteMenu from '../site-menu';
+import EnvironmentSwitcher from './environment-switcher';
 
 function Site() {
 	const { siteSlug } = siteRoute.useParams();
 	const { data: site, isError, error } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+	const { components } = useAppContext();
+	const SiteSwitcher = useMemo( () => lazy( components.siteSwitcher ), [ components ] );
 
 	if ( isError ) {
 		throw error;
@@ -24,6 +33,20 @@ function Site() {
 	return (
 		<Suspense fallback={ null }>
 			{ hasStagingSite( site ) && <StagingSiteSyncMonitor site={ site } /> }
+			<HeaderBar>
+				<HStack spacing={ 3 }>
+					<HeaderBar.Title>
+						<SiteSwitcher />
+						{ canSwitchEnvironment( site ) && (
+							<>
+								<MenuDivider />
+								<EnvironmentSwitcher site={ site } />
+							</>
+						) }
+					</HeaderBar.Title>
+					{ ! isSiteMigrationInProgress( site ) && <SiteMenu site={ site } /> }
+				</HStack>
+			</HeaderBar>
 			<Suspense fallback={ null }>
 				<FlashMessage
 					id="route-not-allowed"

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -28,6 +28,7 @@
 		"ciab/allow-domain-features": true,
 		"cookie-banner": false,
 		"rum-tracking/logstash": true,
+		"dashboard/omnibar": false,
 		"dashboard/v2": false,
 		"dev/auth-helper": true,
 		"dev/preferences-helper": true,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -26,6 +26,7 @@
 		"ciab/custom-branding": true,
 		"cookie-banner": false,
 		"rum-tracking/logstash": true,
+		"dashboard/omnibar": false,
 		"dashboard/v2": false,
 		"dev/auth-helper": true,
 		"dev/preferences-helper": true,

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -28,6 +28,7 @@
 		"cookie-banner": true,
 		"bilmur-script": true,
 		"rum-tracking/logstash": true,
+		"dashboard/omnibar": false,
 		"dashboard/v2": false,
 		"domain-transfer-redesign": true,
 		"marketplace-redesign": true,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -26,6 +26,7 @@
 		"ciab/custom-branding": true,
 		"cookie-banner": false,
 		"rum-tracking/logstash": true,
+		"dashboard/omnibar": false,
 		"dashboard/v2": false,
 		"dev/store-sandbox-helper": true,
 		"domain-transfer-redesign": true,


### PR DESCRIPTION
## Proposed Changes

- Add `dashboard/omnibar` feature flag (disabled by default in all environments)
- Gate the sidebar layout behind the flag in root and header components
- Menu components export both `ResponsiveMenu` (default) and `SidebarMenu` (named `*Sidebar` export) variants
- Revert section layouts (me, plugins, domain, site) and tab panels (logs, scan) to pre-sidebar behavior
- CSS hides inner HeaderBars and TabPanel headers when sidebar layout is active
- Restore deleted `plugins-menu` component

## Why are these changes being made?

The sidebar is a significant UI change that should be rolled out gradually. This feature flag allows enabling/disabling the sidebar independently, ensuring the app behaves identically to the pre-sidebar layout when the flag is OFF.

## Testing Instructions

1. With `dashboard/omnibar: false` (default): verify the dashboard looks identical to trunk — header-based navigation, section headers with switchers, tab panels in logs/scan
2. Set `dashboard/omnibar: true` in `config/dashboard-development.json`: verify the sidebar layout works correctly
3. Test both states on desktop and mobile viewports

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)