### PR TITLE
Stepper: Preload current step chunk during boot

### DIFF
--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -177,6 +177,19 @@ async function main() {
 
 	let flowSteps = 'initialize' in flow ? await flow.initialize( reduxStore ) : null;
 
+	// Eagerly preload the current step's chunk so it's ready before React mounts.
+	// usePreloadSteps only preloads *next* steps; the current step would otherwise
+	// wait for React.lazy + Suspense to trigger the download. We only fire the
+	// import here (no lazyCache write) because the webpack module cache ensures
+	// React.lazy's subsequent call resolves instantly from the already-loaded module.
+	if ( flowSteps && flowSteps.length > 0 ) {
+		const stepSlug = window.location.pathname.split( '/' )[ 3 ]; // /setup/<flow>/<step>
+		const currentStep = flowSteps.find( ( s ) => s.slug === stepSlug );
+		if ( currentStep && 'asyncComponent' in currentStep ) {
+			currentStep.asyncComponent();
+		}
+	}
+
 	if ( '__experimentalUseSessions' in flow ) {
 		const sessionId = getSessionId() || createSessionId();
 		history.replaceState( null, '', addQueryArgs( { sessionId }, window.location.href ) );

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -180,7 +180,7 @@ async function main() {
 
 	// Warm the webpack module cache for the current step's chunk so React.lazy
 	// resolves instantly. See preload-current-step.ts for details.
-	if ( flowSteps && flowSteps.length > 0 ) {
+	if ( flowSteps ) {
 		preloadCurrentStep( flowSteps, window.location.pathname );
 	}
 

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -51,6 +51,7 @@ import { enhanceFlowWithAuth, injectUserStepInSteps } from './utils/enhanceFlowW
 import redirectPathIfNecessary from './utils/flow-redirect-handler';
 import { DEFAULT_FLOW, getFlowFromURL } from './utils/get-flow-from-url';
 import { startStepperPerformanceTracking } from './utils/performance-tracking';
+import { preloadCurrentStep } from './utils/preload-current-step';
 import { getSessionId } from './utils/use-session-id';
 import { WindowLocaleEffectManager } from './utils/window-locale-effect-manager';
 import type { CurrentUser } from '@automattic/data-stores';
@@ -177,17 +178,10 @@ async function main() {
 
 	let flowSteps = 'initialize' in flow ? await flow.initialize( reduxStore ) : null;
 
-	// Eagerly preload the current step's chunk so it's ready before React mounts.
-	// usePreloadSteps only preloads *next* steps; the current step would otherwise
-	// wait for React.lazy + Suspense to trigger the download. We only fire the
-	// import here (no lazyCache write) because the webpack module cache ensures
-	// React.lazy's subsequent call resolves instantly from the already-loaded module.
+	// Warm the webpack module cache for the current step's chunk so React.lazy
+	// resolves instantly. See preload-current-step.ts for details.
 	if ( flowSteps && flowSteps.length > 0 ) {
-		const stepSlug = window.location.pathname.split( '/' )[ 3 ]; // /setup/<flow>/<step>
-		const currentStep = flowSteps.find( ( s ) => s.slug === stepSlug );
-		if ( currentStep && 'asyncComponent' in currentStep ) {
-			currentStep.asyncComponent();
-		}
+		preloadCurrentStep( flowSteps, window.location.pathname );
 	}
 
 	if ( '__experimentalUseSessions' in flow ) {

--- a/client/landing/stepper/utils/get-flow-from-url.ts
+++ b/client/landing/stepper/utils/get-flow-from-url.ts
@@ -17,6 +17,7 @@ export const getFlowFromURL = ( pathname?: string, search?: string ) => {
 export const getStepFromURL = (
 	pathname = typeof window !== 'undefined' ? window.location.pathname : ''
 ) => {
-	const fromPath = matchPath( { path: '/setup/:flow/:step' }, pathname ?? '' )?.params?.step;
+	const fromPath = matchPath( { path: '/setup/:flow/:step', end: false }, pathname ?? '' )?.params
+		?.step;
 	return fromPath;
 };

--- a/client/landing/stepper/utils/preload-current-step.ts
+++ b/client/landing/stepper/utils/preload-current-step.ts
@@ -1,0 +1,29 @@
+import type { StepperStep } from '../declarative-flow/internals/types';
+
+/**
+ * Eagerly fires the asyncComponent import for the step that matches the current
+ * URL so the webpack module cache is warm by the time React.lazy requests it.
+ *
+ * This complements usePreloadSteps (which only preloads *future* steps) by
+ * covering the current step on initial page load.
+ *
+ * We intentionally do NOT write to lazyCache here. Writing the raw component
+ * would race with flowStepComponent() which stores a React.lazy wrapper in the
+ * same cache slot — overwriting it would change the element type and force a
+ * remount. The webpack module cache is sufficient: once the dynamic import
+ * resolves, any subsequent call to the same asyncComponent returns instantly.
+ */
+export function preloadCurrentStep( flowSteps: readonly StepperStep[], pathname: string ): void {
+	// URL shape: /setup/<flow>/<step>/<lang?>
+	const stepSlug = pathname.split( '/' )[ 3 ];
+
+	if ( ! stepSlug ) {
+		return;
+	}
+
+	const currentStep = flowSteps.find( ( s ) => s.slug === stepSlug );
+
+	if ( currentStep && 'asyncComponent' in currentStep ) {
+		currentStep.asyncComponent();
+	}
+}

--- a/client/landing/stepper/utils/preload-current-step.ts
+++ b/client/landing/stepper/utils/preload-current-step.ts
@@ -1,21 +1,12 @@
+import { getStepFromURL } from './get-flow-from-url';
 import type { StepperStep } from '../declarative-flow/internals/types';
 
 /**
- * Eagerly fires the asyncComponent import for the step that matches the current
- * URL so the webpack module cache is warm by the time React.lazy requests it.
- *
- * This complements usePreloadSteps (which only preloads *future* steps) by
- * covering the current step on initial page load.
- *
- * We intentionally do NOT write to lazyCache here. Writing the raw component
- * would race with flowStepComponent() which stores a React.lazy wrapper in the
- * same cache slot — overwriting it would change the element type and force a
- * remount. The webpack module cache is sufficient: once the dynamic import
- * resolves, any subsequent call to the same asyncComponent returns instantly.
+ * Warms the webpack module cache for the current step's chunk so React.lazy
+ * resolves instantly. Complements usePreloadSteps which only covers future steps.
  */
 export function preloadCurrentStep( flowSteps: readonly StepperStep[], pathname: string ): void {
-	// URL shape: /setup/<flow>/<step>/<lang?>
-	const stepSlug = pathname.split( '/' )[ 3 ];
+	const stepSlug = getStepFromURL( pathname );
 
 	if ( ! stepSlug ) {
 		return;
@@ -23,7 +14,7 @@ export function preloadCurrentStep( flowSteps: readonly StepperStep[], pathname:
 
 	const currentStep = flowSteps.find( ( s ) => s.slug === stepSlug );
 
-	if ( currentStep && 'asyncComponent' in currentStep ) {
+	if ( currentStep ) {
 		currentStep.asyncComponent();
 	}
 }

--- a/client/landing/stepper/utils/test/preload-current-step.ts
+++ b/client/landing/stepper/utils/test/preload-current-step.ts
@@ -36,7 +36,6 @@ describe( 'preloadCurrentStep', () => {
 	} );
 
 	it( 'does nothing for an empty steps array', () => {
-		// Should not throw.
 		expect( () => preloadCurrentStep( [], '/setup/onboarding/domains' ) ).not.toThrow();
 	} );
 
@@ -53,7 +52,6 @@ describe( 'preloadCurrentStep', () => {
 	it( 'handles a URL with a trailing locale segment', () => {
 		const domainStep = makeStep( 'domains' );
 
-		// /setup/<flow>/<step>/<lang>
 		preloadCurrentStep( [ domainStep ], '/setup/onboarding/domains/es' );
 
 		expect( domainStep.asyncComponent ).toHaveBeenCalledTimes( 1 );

--- a/client/landing/stepper/utils/test/preload-current-step.ts
+++ b/client/landing/stepper/utils/test/preload-current-step.ts
@@ -1,0 +1,61 @@
+import { preloadCurrentStep } from '../preload-current-step';
+import type { StepperStep } from '../../declarative-flow/internals/types';
+
+function makeStep( slug: string, asyncComponent?: jest.Mock ): StepperStep {
+	return {
+		slug,
+		asyncComponent: asyncComponent ?? jest.fn( () => Promise.resolve( { default: () => null } ) ),
+	};
+}
+
+describe( 'preloadCurrentStep', () => {
+	it( 'calls asyncComponent for the step matching the URL slug', () => {
+		const domainStep = makeStep( 'domains' );
+		const plansStep = makeStep( 'plans' );
+
+		preloadCurrentStep( [ domainStep, plansStep ], '/setup/onboarding/domains' );
+
+		expect( domainStep.asyncComponent ).toHaveBeenCalledTimes( 1 );
+		expect( plansStep.asyncComponent ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does nothing when the URL has no step segment', () => {
+		const step = makeStep( 'domains' );
+
+		preloadCurrentStep( [ step ], '/setup/onboarding' );
+
+		expect( step.asyncComponent ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does nothing when no step matches the URL slug', () => {
+		const step = makeStep( 'domains' );
+
+		preloadCurrentStep( [ step ], '/setup/onboarding/plans' );
+
+		expect( step.asyncComponent ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does nothing for an empty steps array', () => {
+		// Should not throw.
+		expect( () => preloadCurrentStep( [], '/setup/onboarding/domains' ) ).not.toThrow();
+	} );
+
+	it( 'does not preload the injected user step that is not yet in the array', () => {
+		// flow.initialize() returns steps before injectUserStepInSteps runs,
+		// so the "user" step is absent — preload should be a no-op.
+		const domainStep = makeStep( 'domains' );
+
+		preloadCurrentStep( [ domainStep ], '/setup/onboarding/user' );
+
+		expect( domainStep.asyncComponent ).not.toHaveBeenCalled();
+	} );
+
+	it( 'handles a URL with a trailing locale segment', () => {
+		const domainStep = makeStep( 'domains' );
+
+		// /setup/<flow>/<step>/<lang>
+		preloadCurrentStep( [ domainStep ], '/setup/onboarding/domains/es' );
+
+		expect( domainStep.asyncComponent ).toHaveBeenCalledTimes( 1 );
+	} );
+} );


### PR DESCRIPTION
## Summary

- Eagerly fires the current step's `asyncComponent()` import right after `flow.initialize()` resolves, so the webpack module cache is warm by the time `React.lazy` requests it
- `usePreloadSteps` only preloads *future* steps — the current step previously had to wait for the Suspense boundary to trigger the download
- Also fixes `getStepFromURL` to match URLs with a trailing locale segment (e.g. `/setup/onboarding/domains/es`)

## Test plan

- [ ] Load `/setup/onboarding/domains` in incognito — confirm the step chunk request starts before React mount in DevTools Network tab
- [ ] Check Performance tab — Suspense fallback duration should be reduced or eliminated
- [ ] Navigate through the full onboarding flow to confirm no regressions
- [ ] `yarn test-client client/landing/stepper/utils/test/preload-current-step.ts` — 6 tests pass
- [ ] `yarn test-client client/landing/stepper/utils/test/get-flow-from-url.ts` — 4 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)