### PR TITLE
Stepper: Drop blocking experiment fetch from onboarding initialize()

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -34,7 +34,7 @@ import { ProcessingResult } from '../../internals/steps-repository/processing-st
 import { type FlowV2, type ProvidedDependencies, type SubmitHandler } from '../../internals/types';
 import type { DomainSuggestion } from '@automattic/api-core';
 
-async function initialize() {
+function initialize() {
 	const steps = [
 		STEPS.DOMAIN_SEARCH,
 		STEPS.USE_MY_DOMAIN,
@@ -45,7 +45,8 @@ async function initialize() {
 		STEPS.SETUP_YOUR_SITE_AI,
 	];
 
-	await loadExperimentAssignment( 'calypso_account_step_improvement_202601' );
+	// Prefetch so the assignment is cached before the account step renders.
+	loadExperimentAssignment( 'calypso_account_step_improvement_202601' );
 
 	return [ ...stepsWithRequiredLogin( steps ), STEPS.PLAYGROUND, STEPS.BLUEPRINT ];
 }


### PR DESCRIPTION
## Proposed Changes

* Make the `loadExperimentAssignment` call in the onboarding flow's `initialize()` fire-and-forget instead of awaited, removing it from the critical rendering path.
* Drop the `async` keyword from `initialize()` since it no longer awaits anything.

## Why are these changes being made?

The onboarding flow's `initialize()` awaits `loadExperimentAssignment('calypso_account_step_improvement_202601')` before returning the step list, blocking the entire boot sequence for 100-300ms on a network fetch. This experiment only affects the account step (rendered much later), and its consumer (`useAccountCreationExperiment`) already handles its own loading state via the `useExperiment()` hook.

Making this fire-and-forget is an established pattern in this codebase. The ExPlat client caches assignments in localStorage and deduplicates concurrent requests, so the prefetch will populate the cache well before the account step renders.

**Existing fire-and-forget precedents:**

Same file, `useSideEffect` (line 337-339):
```ts
useEffect( () => {
    loadExperimentAssignment( 'calypso_plans_page_visual_separation_2025_09_v2' );
}, [] );
```

`goals.tsx` (line 11):
```ts
export const useGoals = (): Goal[] => {
    loadExperimentAssignment( 'calypso_design_picker_image_optimization_202406' );
    // ...
};
```

No other stepper flow awaits experiments in `initialize()` — onboarding was the only one.

## Testing Instructions

* Navigate to `/setup/onboarding/` — the domain search step should render without additional delay.
* Proceed through the flow to the user/account creation step — experiment variations should still apply correctly (the `useExperiment()` hook handles loading state).
* In DevTools Performance tab, `initialize()` should no longer show a blocking network request.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)