### PR TITLE
Stepper: Eager-fire first step chunk download before React renders

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/hooks/use-preload-steps/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-preload-steps/index.ts
@@ -12,7 +12,7 @@ export const lazyCache = new WeakMap<
 	Awaited< ReturnType< StepperStep[ 'asyncComponent' ] > >[ 'default' ]
 >();
 
-async function tryPreload( step?: StepperStep, followingStep?: StepperStep ) {
+export async function tryPreload( step?: StepperStep, followingStep?: StepperStep ) {
 	if ( step && 'asyncComponent' in step ) {
 		debug( 'Preloading step:', step.slug );
 		const { default: component } = await step.asyncComponent();

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -41,6 +41,7 @@ import { setStore } from 'calypso/state/redux-store';
 import { setCurrentFlowName } from 'calypso/state/signup/flow/actions';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { FlowRenderer } from './declarative-flow/internals';
+import { tryPreload } from './declarative-flow/internals/hooks/use-preload-steps';
 import 'calypso/assets/stylesheets/style.scss';
 import { createSessionId } from './declarative-flow/internals/state-manager/create-session-id';
 import availableFlows from './declarative-flow/registered-flows';
@@ -204,16 +205,14 @@ async function main() {
 
 		// Warm the initial step's chunk so it's ready by the time React.lazy
 		// hits the Suspense boundary.
-		const warm = ( slug?: string ) =>
-			flowSteps
-				.find( ( s: { slug: string } ) => s.slug === slug )
-				?.asyncComponent()
-				?.catch( () => {} );
-		warm( getStepFromURL() || flowSteps[ 0 ]?.slug );
+		const findStep = ( slug?: string ) =>
+			flowSteps.find( ( s: { slug: string } ) => s.slug === slug );
+
+		tryPreload( findStep( getStepFromURL() || flowSteps[ 0 ]?.slug ) );
 
 		// Logged-out users get redirected to the auth step first; warm it too.
 		if ( ! user ) {
-			warm( 'user' );
+			tryPreload( findStep( 'user' ) );
 		}
 	} else if ( 'useSteps' in flow ) {
 		// V1 flows have to be enhanced by changing their `useSteps` hook.

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -49,7 +49,7 @@ import { setupWpDataDebug } from './utils/devtools';
 import { enhanceFlowWithUtilityFunctions } from './utils/enhance-flow-with-utils';
 import { enhanceFlowWithAuth, injectUserStepInSteps } from './utils/enhanceFlowWithAuth';
 import redirectPathIfNecessary from './utils/flow-redirect-handler';
-import { DEFAULT_FLOW, getFlowFromURL } from './utils/get-flow-from-url';
+import { DEFAULT_FLOW, getFlowFromURL, getStepFromURL } from './utils/get-flow-from-url';
 import { startStepperPerformanceTracking } from './utils/performance-tracking';
 import { getSessionId } from './utils/use-session-id';
 import { WindowLocaleEffectManager } from './utils/window-locale-effect-manager';
@@ -201,6 +201,20 @@ async function main() {
 		flowSteps = injectUserStepInSteps( flowSteps ) as typeof flowSteps;
 		flow.__flowSteps = flowSteps;
 		enhanceFlowWithUtilityFunctions( flow );
+
+		// Warm the initial step's chunk so it's ready by the time React.lazy
+		// hits the Suspense boundary.
+		const warm = ( slug?: string ) =>
+			flowSteps
+				.find( ( s: { slug: string } ) => s.slug === slug )
+				?.asyncComponent()
+				?.catch( () => {} );
+		warm( getStepFromURL() || flowSteps[ 0 ]?.slug );
+
+		// Logged-out users get redirected to the auth step first; warm it too.
+		if ( ! user ) {
+			warm( 'user' );
+		}
 	} else if ( 'useSteps' in flow ) {
 		// V1 flows have to be enhanced by changing their `useSteps` hook.
 		flow = enhanceFlowWithAuth( flow );


### PR DESCRIPTION
## Proposed Changes

* After `flow.initialize()` resolves and the step list is known, immediately call `tryPreload()` on the step matching the current URL so its webpack chunk starts downloading in parallel with `createQueryClient`'s IndexedDB I/O and React bootstrap — instead of waiting for `React.lazy` to hit the Suspense boundary.
* Reuses the existing `tryPreload` helper (exported from `use-preload-steps`) so the preloaded chunk is stored in `lazyCache` and `React.lazy` can pick it up synchronously.
* Falls back to the first step for bare `/setup/:flow` visits.
* For logged-out users, also preloads the user (auth) step chunk.

## Why are these changes being made?

* The landing step's webpack chunk currently doesn't start downloading until React mounts and `React.lazy` hits the `Suspense` boundary. By that point, `createQueryClient` has already finished its IDB work and React has bootstrapped — wasting an opportunity to overlap the chunk download with that work. This change shaves ~100-300ms off LCP by starting the download earlier.

## Testing Instructions

* Navigate to `/setup/onboarding/` while logged in — verify the domain search step renders without regressions.
* Navigate to `/setup/onboarding/` while logged out (incognito) — verify the auth step renders without regressions.
* Deep-link to `/setup/onboarding/plans` — verify the plans step renders correctly (the preloaded chunk should match the URL step).
* In DevTools Network tab, confirm the landing step chunk download starts before React mounts.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?