### PR TITLE
MSD: Add dashboard/omnibar feature flag for sidebar

### DIFF
--- a/client/dashboard/app/omnibar-header/index.tsx
+++ b/client/dashboard/app/omnibar-header/index.tsx
@@ -1,0 +1,23 @@
+import { Button } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+import { menu } from '@wordpress/icons';
+import HeaderBar from '../../components/header-bar';
+import SecondaryMenu from '../secondary-menu';
+
+function OmnibarHeader( { onToggleMenu }: { onToggleMenu?: () => void } ) {
+	const isDesktop = useViewportMatch( 'medium' );
+
+	return (
+		<HeaderBar as="header">
+			{ ! isDesktop && <Button icon={ menu } label={ __( 'Menu' ) } onClick={ onToggleMenu } /> }
+
+			<div style={ { flexGrow: 1 } } />
+			<div style={ { flexShrink: 0 } }>
+				<SecondaryMenu />
+			</div>
+		</HeaderBar>
+	);
+}
+
+export default OmnibarHeader;

--- a/client/dashboard/app/responsive-sidebar/index.tsx
+++ b/client/dashboard/app/responsive-sidebar/index.tsx
@@ -1,0 +1,46 @@
+import { useViewportMatch } from '@wordpress/compose';
+import clsx from 'clsx';
+import { createPortal } from 'react-dom';
+import Sidebar from './sidebar';
+
+import './style.scss';
+
+export default function ResponsiveSidebar( {
+	isOpen,
+	onClose,
+}: {
+	isOpen: boolean;
+	onClose: () => void;
+} ) {
+	const isDesktop = useViewportMatch( 'medium' );
+
+	const handleOverlayClick = () => {
+		onClose();
+	};
+
+	const handleOverlayKeyDown = ( event: React.KeyboardEvent ) => {
+		if ( event.key === 'Escape' ) {
+			onClose();
+		}
+	};
+
+	if ( isDesktop ) {
+		return <Sidebar />;
+	}
+
+	return (
+		<div className={ clsx( 'dashboard-responsive-sidebar', { 'is-open': isOpen } ) }>
+			{ isOpen &&
+				createPortal(
+					// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+					<div
+						className="dashboard-responsive-sidebar__overlay"
+						onClick={ handleOverlayClick }
+						onKeyDown={ handleOverlayKeyDown }
+					/>,
+					document.body
+				) }
+			<Sidebar />
+		</div>
+	);
+}

--- a/client/dashboard/app/responsive-sidebar/index.tsx
+++ b/client/dashboard/app/responsive-sidebar/index.tsx
@@ -32,8 +32,9 @@ export default function ResponsiveSidebar( {
 		<div className={ clsx( 'dashboard-responsive-sidebar', { 'is-open': isOpen } ) }>
 			{ isOpen &&
 				createPortal(
-					// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+					// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 					<div
+						role="presentation"
 						className="dashboard-responsive-sidebar__overlay"
 						onClick={ handleOverlayClick }
 						onKeyDown={ handleOverlayKeyDown }

--- a/client/dashboard/app/responsive-sidebar/sidebar.scss
+++ b/client/dashboard/app/responsive-sidebar/sidebar.scss
@@ -1,0 +1,25 @@
+@import '@wordpress/base-styles/variables';
+@import '@wordpress/base-styles/mixins';
+
+$sidebar-width: 272px;
+
+.dashboard-responsive-sidebar__sidebar {
+	display: flex;
+	flex-direction: column;
+	flex-shrink: 0;
+	gap: $grid-unit-30;
+	position: sticky;
+	width: $sidebar-width;
+	min-height: calc(100vh - var(--masterbar-height) );
+	padding: 0 $grid-unit-20;
+	border-inline-end: $border-width solid var( --dashboard-header__border-color );
+	box-sizing: border-box;
+	color: var( --dashboard-menu-item__color );
+	background-color: var( --dashboard-header__background-color );
+	overflow-y: auto;
+}
+
+.dashboard-responsive-sidebar__logo {
+	padding: 14px 2px; // temporary to match Reader's layout
+	border-block-end: 1px solid var( --dashboard-header__border-color );
+}

--- a/client/dashboard/app/responsive-sidebar/sidebar.tsx
+++ b/client/dashboard/app/responsive-sidebar/sidebar.tsx
@@ -1,0 +1,29 @@
+import { __, sprintf } from '@wordpress/i18n';
+import RouterLinkButton from '../../components/router-link-button';
+import { useAnalytics } from '../analytics';
+import { useAppContext } from '../context';
+
+import './sidebar.scss';
+
+export default function Sidebar() {
+	const { Logo, name } = useAppContext();
+	const { recordTracksEvent } = useAnalytics();
+
+	return (
+		<div className="dashboard-responsive-sidebar__sidebar">
+			{ Logo && (
+				<div className="dashboard-responsive-sidebar__logo">
+					<RouterLinkButton
+						/* translators: Screen reader text for link to root of the hosting dashboard. "name" is the product of whose hosting dashboard this is: e.g. WordPress.com */
+						aria-label={ sprintf( __( '%(name)s home' ), { name } ) }
+						icon={ <Logo /> }
+						to="/"
+						onClick={ () => {
+							recordTracksEvent( 'calypso_dashboard_logo_click' );
+						} }
+					/>
+				</div>
+			) }
+		</div>
+	);
+}

--- a/client/dashboard/app/responsive-sidebar/style.scss
+++ b/client/dashboard/app/responsive-sidebar/style.scss
@@ -1,0 +1,19 @@
+.dashboard-responsive-sidebar {
+	flex-shrink: 0;
+	position: sticky;
+	top: 0;
+	min-height: calc(100vh - var(--masterbar-height) );
+	width: 0;
+	overflow: hidden;
+	z-index: 101; // Above content overlay
+
+	&.is-open {
+		width: fit-content
+	}
+}
+
+.dashboard-responsive-sidebar__overlay {
+	position: absolute;
+	inset: 0;
+	z-index: 100;
+}

--- a/client/dashboard/app/root/index.tsx
+++ b/client/dashboard/app/root/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { WordPressLogo } from '@automattic/components/src/logos/wordpress-logo';
 import { useQueryClient, useIsFetching } from '@tanstack/react-query';
 import { CatchNotFound, Outlet, useRouterState, useRouter } from '@tanstack/react-router';
@@ -10,6 +11,8 @@ import CommandPalette from '../command-palette';
 import { useAppContext } from '../context';
 import Header from '../header';
 import { NavigationBlockerRegistry } from '../navigation-blocker';
+import OmnibarHeader from '../omnibar-header';
+import ResponsiveSidebar from '../responsive-sidebar';
 import Snackbars from '../snackbars';
 import './style.scss';
 
@@ -24,11 +27,13 @@ const SLOW_THRESHOLD_MS = 100;
 const VERY_SLOW_THRESHOLD_MS = 6000;
 
 function Root() {
+	const isOmnibarEnabled = isEnabled( 'dashboard/omnibar' );
 	const { name, supports, LoadingLogo = WordPressLogo } = useAppContext();
 	const isFetching = useIsFetching();
 	const router = useRouter();
 	const queryClient = useQueryClient();
 	const queryCache = queryClient.getQueryCache();
+	const [ isSidebarOpen, setIsSidebarOpen ] = useState( false );
 
 	const loadingQueryRequestedFullPageLoader = useSyncExternalStore(
 		( onStoreChange ) => queryCache.subscribe( onStoreChange ),
@@ -94,6 +99,47 @@ function Root() {
 			.join( ' ‹ ' );
 	}, [ routeMeta ] );
 
+	const renderHeader = () => {
+		if ( isInitialLoad ) {
+			return null;
+		}
+
+		if ( ! isOmnibarEnabled ) {
+			return <Header />;
+		}
+
+		return <OmnibarHeader onToggleMenu={ () => setIsSidebarOpen( ( value ) => ! value ) } />;
+	};
+
+	const renderBody = () => {
+		if ( isVerySlowNavigation ) {
+			return null;
+		}
+
+		if ( ! isOmnibarEnabled ) {
+			return (
+				<main>
+					<CatchNotFound fallback={ NotFound }>
+						<Outlet />
+					</CatchNotFound>
+				</main>
+			);
+		}
+
+		return (
+			<div className="dashboard-root__body">
+				<ResponsiveSidebar isOpen={ isSidebarOpen } onClose={ () => setIsSidebarOpen( false ) } />
+				<div className="dashboard-root__content">
+					<main>
+						<CatchNotFound fallback={ NotFound }>
+							<Outlet />
+						</CatchNotFound>
+					</main>
+				</div>
+			</div>
+		);
+	};
+
 	useEffect( () => {
 		document.title = title ? `${ title } – ${ name }` : name;
 	}, [ name, title ] );
@@ -109,14 +155,8 @@ function Root() {
 				/>
 			) }
 			{ ( isInitialLoad || isVerySlowNavigation ) && <LoadingLogo className="wpcom-site__logo" /> }
-			{ ! isInitialLoad && <Header /> }
-			{ ! isVerySlowNavigation && (
-				<main>
-					<CatchNotFound fallback={ NotFound }>
-						<Outlet />
-					</CatchNotFound>
-				</main>
-			) }
+			{ renderHeader() }
+			{ renderBody() }
 			{ supports.commandPalette && <CommandPalette /> }
 			<Snackbars />
 			<PageViewTracker />

--- a/client/dashboard/app/root/style.scss
+++ b/client/dashboard/app/root/style.scss
@@ -6,3 +6,8 @@
 	top: 0;
 	z-index: 3; // DataViews header seems to have z-index: 1; CalloutOverlay has z-index: 2
 }
+
+.dashboard-root__body {
+	display: flex;
+	min-height: calc(100vh - var(--masterbar-height) );
+}

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -28,6 +28,7 @@
 		"ciab/allow-domain-features": true,
 		"cookie-banner": false,
 		"rum-tracking/logstash": true,
+		"dashboard/omnibar": false,
 		"dashboard/v2": false,
 		"dev/auth-helper": true,
 		"dev/preferences-helper": true,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -26,6 +26,7 @@
 		"ciab/custom-branding": true,
 		"cookie-banner": false,
 		"rum-tracking/logstash": true,
+		"dashboard/omnibar": false,
 		"dashboard/v2": false,
 		"dev/auth-helper": true,
 		"dev/preferences-helper": true,

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -28,6 +28,7 @@
 		"cookie-banner": true,
 		"bilmur-script": true,
 		"rum-tracking/logstash": true,
+		"dashboard/omnibar": false,
 		"dashboard/v2": false,
 		"domain-transfer-redesign": true,
 		"marketplace-redesign": true,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -26,6 +26,7 @@
 		"ciab/custom-branding": true,
 		"cookie-banner": false,
 		"rum-tracking/logstash": true,
+		"dashboard/omnibar": false,
 		"dashboard/v2": false,
 		"dev/store-sandbox-helper": true,
 		"domain-transfer-redesign": true,


### PR DESCRIPTION
## Proposed Changes

- Add `dashboard/omnibar` feature flag (disabled by default in all environments)
- Gate the sidebar layout behind the flag in the root component
- Add `OmnibarHeader` and `ResponsiveSidebar` components, rendered only when the flag is ON
- When flag is OFF, the existing `Header` is used unchanged

| Desktop | Mobile | Mobile with sidebar |
| - | - | - |
|<img width="1235" height="932" alt="image" src="https://github.com/user-attachments/assets/dbc1499a-35c9-482c-96d5-f3efc18785f5" />|<img width="429" height="931" alt="image" src="https://github.com/user-attachments/assets/f257921f-189e-4767-84b9-1ce262084a16" />|<img width="429" height="930" alt="image" src="https://github.com/user-attachments/assets/e682af81-1690-458a-949a-4ff6930b82ac" />|

## Why are these changes being made?

The sidebar is a significant UI change to the multi-site dashboard. This feature flag allows the sidebar to be rolled out gradually and toggled off if issues arise, without affecting the existing header-based navigation.

## Testing Instructions

1. With `dashboard/omnibar: false` (default): verify the dashboard looks and behaves identically to trunk
2. Set `dashboard/omnibar: true` in `config/dashboard-development.json` and restart: verify the sidebar layout renders correctly

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)