### PR TITLE
Freshly Pressed: update the tab's name

### DIFF
--- a/client/reader/discover/components/header-and-navigation/index.tsx
+++ b/client/reader/discover/components/header-and-navigation/index.tsx
@@ -59,7 +59,7 @@ export default function DiscoverHeaderAndNavigation(
 			break;
 
 		case FRESHLY_PRESSED_TAB:
-			subHeaderText = translate( "Our team's favorite blog posts." );
+			subHeaderText = translate( "Freshly Pressed highlights our team's favorite blog posts." );
 			break;
 	}
 


### PR DESCRIPTION
Fixes READ-418

## Proposed Changes

Update the tab's name to be more descriptive.

**Before**

<img width="693" height="145" alt="image" src="https://github.com/user-attachments/assets/1363f3cf-2989-4e88-b8e6-e4d7fb58ac01" />


**After**

<img width="657" height="165" alt="Screenshot 2026-03-23 at 11 42 38" src="https://github.com/user-attachments/assets/89e4a908-6cbb-4176-9d00-379d915e9998" />


## Testing Instructions

* Check out this branch
* Go to http://calypso.localhost:3000/discover
    * See screenshots above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
