### PR TITLE
MSD Sidebar: Revert menus to ResponsiveMenu

### DIFF
--- a/client/dashboard/app/primary-menu/index.tsx
+++ b/client/dashboard/app/primary-menu/index.tsx
@@ -1,7 +1,5 @@
-import { __experimentalHStack as HStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { brush, copy, envelope, globe, plugins } from '@wordpress/icons';
-import { SidebarExpandableMenuItem, SidebarMenu, SidebarMenuItem } from '../../components/sidebar';
+import ResponsiveMenu from '../../components/responsive-menu';
 import { wpcomLink } from '../../utils/link';
 import { useAppContext } from '../context';
 
@@ -9,54 +7,27 @@ function PrimaryMenu() {
 	const { supports } = useAppContext();
 
 	return (
-		<SidebarMenu>
-			{ supports.sites && (
-				<SidebarMenuItem icon={ copy } to="/sites">
-					{ __( 'Sites' ) }
-				</SidebarMenuItem>
-			) }
+		<ResponsiveMenu>
+			{ supports.sites && <ResponsiveMenu.Item to="/sites">{ __( 'Sites' ) }</ResponsiveMenu.Item> }
 			{ supports.domains && (
-				<SidebarMenuItem icon={ globe } to="/domains">
-					{ __( 'Domains' ) }
-				</SidebarMenuItem>
+				<ResponsiveMenu.Item to="/domains">{ __( 'Domains' ) }</ResponsiveMenu.Item>
 			) }
 			{ supports.emails && (
-				<SidebarMenuItem icon={ envelope } to="/emails">
-					{ __( 'Emails' ) }
-				</SidebarMenuItem>
+				<ResponsiveMenu.Item to="/emails">{ __( 'Emails' ) }</ResponsiveMenu.Item>
 			) }
 			{ supports.plugins && (
-				<SidebarExpandableMenuItem label={ __( 'Plugins' ) } icon={ plugins } to="/plugins">
-					<SidebarMenuItem to="/plugins/manage">{ __( 'Manage plugins' ) }</SidebarMenuItem>
-					<SidebarMenuItem to="/plugins/scheduled-updates">
-						{ __( 'Scheduled updates' ) }
-					</SidebarMenuItem>
-					<SidebarMenuItem
-						href={ wpcomLink( '/plugins' ) }
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						<HStack justify="flex-start" spacing={ 1 }>
-							<span>{ __( 'Browse plugins' ) }</span>
-							<span aria-label={ __( '(opens in a new tab)' ) }>&#8599;</span>
-						</HStack>
-					</SidebarMenuItem>
-				</SidebarExpandableMenuItem>
+				<ResponsiveMenu.Item to="/plugins/manage">{ __( 'Plugins' ) }</ResponsiveMenu.Item>
 			) }
 			{ supports.themes && (
-				<SidebarMenuItem
-					icon={ brush }
+				<ResponsiveMenu.Item
 					href={ wpcomLink( '/themes' ) }
 					target="_blank"
 					rel="noopener noreferrer"
 				>
-					<HStack justify="flex-start" spacing={ 1 }>
-						<span>{ __( 'Themes' ) }</span>
-						<span aria-label={ __( '(opens in a new tab)' ) }>&#8599;</span>
-					</HStack>
-				</SidebarMenuItem>
+					{ __( 'Themes' ) }
+				</ResponsiveMenu.Item>
 			) }
-		</SidebarMenu>
+		</ResponsiveMenu>
 	);
 }
 

--- a/client/dashboard/app/root/omnibar-style.scss
+++ b/client/dashboard/app/root/omnibar-style.scss
@@ -1,0 +1,16 @@
+/**
+ * Omnibar overrides
+ *
+ * When the dashboard/omnibar feature flag is enabled, the sidebar handles
+ * navigation (site/domain switchers, section menus, log/scan tab switching).
+ * These styles hide the redundant navigation UI that section components
+ * still render for the non-sidebar (flag OFF) layout.
+ */
+
+.dashboard-root__body main .dashboard-header-bar {
+	display: none;
+}
+
+.dashboard-root__body .card__header:has([role="tablist"]) {
+	display: none;
+}

--- a/client/dashboard/app/root/style.scss
+++ b/client/dashboard/app/root/style.scss
@@ -1,7 +1,20 @@
-.dashboard-root__content > .dashboard-header-bar {
+@import './omnibar-style';
+
+// Old layout (no sidebar): sticky header
+// For pages without sub menus, the first header is the sticky header
+// For pages with sub menus, the second header is the sticky header
+.dashboard-root__layout:not(:has(main > .dashboard-header-bar)) > .dashboard-header-bar,
+.dashboard-root__layout > main > .dashboard-header-bar {
 	position: sticky;
 	top: 0;
 	z-index: 3; // DataViews header seems to have z-index: 1; CalloutOverlay has z-index: 2
+}
+
+// Sidebar layout: sticky header in content area
+.dashboard-root__content > .dashboard-header-bar {
+	position: sticky;
+	top: 0;
+	z-index: 3;
 }
 
 .dashboard-root__body {

--- a/client/dashboard/app/sidebar/index.tsx
+++ b/client/dashboard/app/sidebar/index.tsx
@@ -1,15 +1,17 @@
 import { useRouterState } from '@tanstack/react-router';
-import { Navigator } from '@wordpress/components';
+import { __experimentalHStack as HStack, Navigator } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import { brush, copy, envelope, globe, plugins } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useEffect, useMemo, useRef } from 'react';
 import RouterLinkButton from '../../components/router-link-button';
+import { SidebarExpandableMenuItem, SidebarMenu, SidebarMenuItem } from '../../components/sidebar';
 import DomainSidebar from '../../domains/domain-sidebar';
 import MeSidebar from '../../me/me-sidebar';
 import SiteSidebar from '../../sites/site-sidebar';
+import { wpcomLink } from '../../utils/link';
 import { useAnalytics } from '../analytics';
 import { useAppContext } from '../context';
-import PrimaryMenu from '../primary-menu';
 import RouteErrorBoundary from './error';
 import { getScreenPath, NavigatorRouteSync } from './navigator-route-sync';
 
@@ -75,7 +77,7 @@ export default function Sidebar( { onNavigate }: { onNavigate?: () => void } ) {
 				<NavigatorRouteSync screenPath={ screenPath } />
 
 				<Navigator.Screen path="/">
-					<PrimaryMenu />
+					<PrimaryMenuSidebar />
 				</Navigator.Screen>
 
 				<Navigator.Screen path="/sites/:siteSlug">
@@ -97,5 +99,60 @@ export default function Sidebar( { onNavigate }: { onNavigate?: () => void } ) {
 				</Navigator.Screen>
 			</Navigator>
 		</div>
+	);
+}
+
+function PrimaryMenuSidebar() {
+	const { supports } = useAppContext();
+
+	return (
+		<SidebarMenu>
+			{ supports.sites && (
+				<SidebarMenuItem icon={ copy } to="/sites">
+					{ __( 'Sites' ) }
+				</SidebarMenuItem>
+			) }
+			{ supports.domains && (
+				<SidebarMenuItem icon={ globe } to="/domains">
+					{ __( 'Domains' ) }
+				</SidebarMenuItem>
+			) }
+			{ supports.emails && (
+				<SidebarMenuItem icon={ envelope } to="/emails">
+					{ __( 'Emails' ) }
+				</SidebarMenuItem>
+			) }
+			{ supports.plugins && (
+				<SidebarExpandableMenuItem label={ __( 'Plugins' ) } icon={ plugins } to="/plugins">
+					<SidebarMenuItem to="/plugins/manage">{ __( 'Manage plugins' ) }</SidebarMenuItem>
+					<SidebarMenuItem to="/plugins/scheduled-updates">
+						{ __( 'Scheduled updates' ) }
+					</SidebarMenuItem>
+					<SidebarMenuItem
+						href={ wpcomLink( '/plugins' ) }
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						<HStack justify="flex-start" spacing={ 1 }>
+							<span>{ __( 'Browse plugins' ) }</span>
+							<span aria-label={ __( '(opens in a new tab)' ) }>&#8599;</span>
+						</HStack>
+					</SidebarMenuItem>
+				</SidebarExpandableMenuItem>
+			) }
+			{ supports.themes && (
+				<SidebarMenuItem
+					icon={ brush }
+					href={ wpcomLink( '/themes' ) }
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					<HStack justify="flex-start" spacing={ 1 }>
+						<span>{ __( 'Themes' ) }</span>
+						<span aria-label={ __( '(opens in a new tab)' ) }>&#8599;</span>
+					</HStack>
+				</SidebarMenuItem>
+			) }
+		</SidebarMenu>
 	);
 }

--- a/client/dashboard/components/header-bar/style.scss
+++ b/client/dashboard/components/header-bar/style.scss
@@ -22,8 +22,6 @@ $component-icon-padding: 6px;
 	&.is-support-user-session {
 		background-color: var( --dashboard-header__support-background-color );
 	}
-
-	height: 65px; // temporary to match Reader's header bar height
 }
 
 .dashboard-header-bar-title > span {

--- a/client/dashboard/components/sidebar/sidebar-expandable-menu-item.tsx
+++ b/client/dashboard/components/sidebar/sidebar-expandable-menu-item.tsx
@@ -68,7 +68,7 @@ export function SidebarExpandableMenuItem( {
 				<VStack id={ panelId } spacing={ 1 }>
 					{ Children.map( children, ( child ) => {
 						if ( isValidElement( child ) && child.type === SidebarMenuItem && ! child.props.icon ) {
-							return cloneElement( child, { icon: dotIcon } );
+							return cloneElement( child as React.ReactElement, { icon: dotIcon } );
 						}
 						return child;
 					} ) }

--- a/client/dashboard/components/switcher/index.tsx
+++ b/client/dashboard/components/switcher/index.tsx
@@ -69,7 +69,7 @@ export default function Switcher< T >( {
 					} }
 					aria-haspopup="true"
 					aria-expanded={ isOpen }
-					style={ { justifyContent: 'flex-start' } }
+					style={ { width: '100%', justifyContent: 'flex-start' } }
 				>
 					<HStack
 						alignment="center"

--- a/client/dashboard/domains/domain-menu/index.tsx
+++ b/client/dashboard/domains/domain-menu/index.tsx
@@ -1,33 +1,27 @@
 import { useRouter } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
-import { category, envelope } from '@wordpress/icons';
 import { useAppContext } from '../../app/context';
 import { emailsRoute } from '../../app/router/emails';
-import { SidebarMenu, SidebarMenuItem } from '../../components/sidebar';
+import MenuDivider from '../../components/menu-divider';
+import ResponsiveMenu from '../../components/responsive-menu';
 
 const DomainMenu = ( { domainName }: { domainName: string } ) => {
 	const { supports } = useAppContext();
 	const router = useRouter();
 
 	return (
-		<SidebarMenu>
-			<SidebarMenuItem icon={ category } to={ `/domains/${ domainName }` }>
+		<ResponsiveMenu label={ __( 'Domain Menu' ) } prefix={ <MenuDivider /> }>
+			<ResponsiveMenu.Item to={ `/domains/${ domainName }` }>
 				{ __( 'Overview' ) }
-			</SidebarMenuItem>
+			</ResponsiveMenu.Item>
 			{ supports.emails && (
-				<SidebarMenuItem
-					icon={ envelope }
-					to={
-						router.buildLocation( {
-							to: emailsRoute.fullPath,
-							search: { domainName },
-						} ).href
-					}
+				<ResponsiveMenu.Item
+					to={ router.buildLocation( { to: emailsRoute.fullPath, search: { domainName } } ).href }
 				>
 					{ __( 'Emails' ) }
-				</SidebarMenuItem>
+				</ResponsiveMenu.Item>
 			) }
-		</SidebarMenu>
+		</ResponsiveMenu>
 	);
 };
 

--- a/client/dashboard/domains/domain-sidebar/index.tsx
+++ b/client/dashboard/domains/domain-sidebar/index.tsx
@@ -1,10 +1,13 @@
 import { domainQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
 import { __experimentalVStack as VStack, useNavigator } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { category, envelope } from '@wordpress/icons';
 import { Suspense } from 'react';
-import { SidebarBackButton } from '../../components/sidebar';
-import DomainMenu from '../domain-menu';
+import { useAppContext } from '../../app/context';
+import { emailsRoute } from '../../app/router/emails';
+import { SidebarBackButton, SidebarMenu, SidebarMenuItem } from '../../components/sidebar';
 import DomainSwitcher from '../domain-switcher';
 
 export default function DomainSidebar() {
@@ -24,8 +27,34 @@ export default function DomainSidebar() {
 				<Suspense fallback={ null }>
 					<DomainSwitcher domain={ domain } />
 				</Suspense>
-				<DomainMenu domainName={ domainName } />
+				<DomainMenuSidebar domainName={ domainName } />
 			</VStack>
 		</VStack>
+	);
+}
+
+function DomainMenuSidebar( { domainName }: { domainName: string } ) {
+	const { supports } = useAppContext();
+	const router = useRouter();
+
+	return (
+		<SidebarMenu>
+			<SidebarMenuItem icon={ category } to={ `/domains/${ domainName }` }>
+				{ __( 'Overview' ) }
+			</SidebarMenuItem>
+			{ supports.emails && (
+				<SidebarMenuItem
+					icon={ envelope }
+					to={
+						router.buildLocation( {
+							to: emailsRoute.fullPath,
+							search: { domainName },
+						} ).href
+					}
+				>
+					{ __( 'Emails' ) }
+				</SidebarMenuItem>
+			) }
+		</SidebarMenu>
 	);
 }

--- a/client/dashboard/domains/domain/index.tsx
+++ b/client/dashboard/domains/domain/index.tsx
@@ -1,7 +1,75 @@
+import { DomainSubtype } from '@automattic/api-core';
+import { domainQuery } from '@automattic/api-queries';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { Outlet } from '@tanstack/react-router';
+import { __experimentalHStack as HStack, Icon } from '@wordpress/components';
+import { globe } from '@wordpress/icons';
+import { useAppContext } from '../../app/context';
+import useBuildCurrentRouteLink from '../../app/hooks/use-build-current-route-link';
+import { domainRoute } from '../../app/router/domains';
+import HeaderBar from '../../components/header-bar';
+import Switcher from '../../components/switcher';
+import DomainMenu from '../domain-menu';
+import type { DomainSummary } from '@automattic/api-core';
+import './style.scss';
 
 function Domain() {
-	return <Outlet />;
+	const { queries } = useAppContext();
+	const { domainName } = domainRoute.useParams();
+	const domains = useQuery( {
+		...queries.domainsQuery(),
+		select: ( data ) => {
+			return data.filter( ( domain ) => domain.subtype.id !== DomainSubtype.DEFAULT_ADDRESS );
+		},
+	} ).data;
+	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
+
+	const searchableFields = [
+		{
+			id: 'name',
+			getValue: ( { item }: { item: DomainSummary } ) => item.domain,
+			enableGlobalSearch: true,
+		},
+	];
+
+	const buildCurrentRouteLink = useBuildCurrentRouteLink();
+
+	return (
+		<>
+			<HeaderBar>
+				<HStack spacing={ 3 }>
+					<HeaderBar.Title>
+						<Switcher
+							items={ domains }
+							value={ domain }
+							searchableFields={ searchableFields }
+							getItemUrl={ ( domain ) =>
+								buildCurrentRouteLink( { params: { domainName: domain.domain } } )
+							}
+							renderItemMedia={ ( { context } ) =>
+								context === 'list' ? null : (
+									<Icon className="domain-icon" icon={ globe } size={ 24 } />
+								)
+							}
+							renderItemTitle={ ( { item } ) => (
+								<span
+									style={ {
+										overflow: 'hidden',
+										textOverflow: 'ellipsis',
+										whiteSpace: 'nowrap',
+									} }
+								>
+									{ item.domain }
+								</span>
+							) }
+						/>
+					</HeaderBar.Title>
+					<DomainMenu domainName={ domain.domain } />
+				</HStack>
+			</HeaderBar>
+			<Outlet />
+		</>
+	);
 }
 
 export default Domain;

--- a/client/dashboard/me/index.tsx
+++ b/client/dashboard/me/index.tsx
@@ -1,7 +1,23 @@
 import { Outlet } from '@tanstack/react-router';
+import { __experimentalHStack as HStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import HeaderBar from '../components/header-bar';
+import MeMenu from './me-menu';
 
 function Me() {
-	return <Outlet />;
+	return (
+		<>
+			<HeaderBar>
+				<HStack spacing={ 3 }>
+					<HeaderBar.Title>
+						<span>{ __( 'Account' ) }</span>
+					</HeaderBar.Title>
+					<MeMenu />
+				</HStack>
+			</HeaderBar>
+			<Outlet />
+		</>
+	);
 }
 
 export default Me;

--- a/client/dashboard/me/me-menu/index.tsx
+++ b/client/dashboard/me/me-menu/index.tsx
@@ -1,18 +1,8 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { __ } from '@wordpress/i18n';
-import {
-	bell,
-	buttons,
-	commentAuthorAvatar,
-	lock,
-	notAllowed,
-	payment,
-	seen,
-	settings,
-	starEmpty,
-} from '@wordpress/icons';
 import { useAppContext } from '../../app/context';
-import { SidebarMenu, SidebarMenuItem } from '../../components/sidebar';
+import MenuDivider from '../../components/menu-divider';
+import ResponsiveMenu from '../../components/responsive-menu';
 import type { AppConfig, MeSupports } from '../../app/context';
 
 const hasAppSupport = ( supports: AppConfig[ 'supports' ], feature: keyof MeSupports ) => {
@@ -23,45 +13,27 @@ const MeMenu = () => {
 	const { supports } = useAppContext();
 
 	return (
-		<SidebarMenu>
-			<SidebarMenuItem icon={ commentAuthorAvatar } to="/me/profile">
-				{ __( 'Profile' ) }
-			</SidebarMenuItem>
-			<SidebarMenuItem icon={ settings } to="/me/preferences">
-				{ __( 'Preferences' ) }
-			</SidebarMenuItem>
-			<SidebarMenuItem icon={ payment } to="/me/billing">
-				{ __( 'Billing' ) }
-			</SidebarMenuItem>
-			<SidebarMenuItem icon={ lock } to="/me/security">
-				{ __( 'Security' ) }
-			</SidebarMenuItem>
+		<ResponsiveMenu prefix={ <MenuDivider /> }>
+			<ResponsiveMenu.Item to="/me/profile">{ __( 'Profile' ) }</ResponsiveMenu.Item>
+			<ResponsiveMenu.Item to="/me/preferences">{ __( 'Preferences' ) }</ResponsiveMenu.Item>
+			<ResponsiveMenu.Item to="/me/billing">{ __( 'Billing' ) }</ResponsiveMenu.Item>
+			<ResponsiveMenu.Item to="/me/security">{ __( 'Security' ) }</ResponsiveMenu.Item>
 			{ hasAppSupport( supports, 'privacy' ) && (
-				<SidebarMenuItem icon={ seen } to="/me/privacy">
-					{ __( 'Privacy' ) }
-				</SidebarMenuItem>
+				<ResponsiveMenu.Item to="/me/privacy">{ __( 'Privacy' ) }</ResponsiveMenu.Item>
 			) }
 			{ supports.notifications && (
-				<SidebarMenuItem icon={ bell } to="/me/notifications">
-					{ __( 'Notifications' ) }
-				</SidebarMenuItem>
+				<ResponsiveMenu.Item to="/me/notifications">{ __( 'Notifications' ) }</ResponsiveMenu.Item>
 			) }
 			{ supports.reader && (
-				<SidebarMenuItem icon={ notAllowed } to="/me/blocked-sites">
-					{ __( 'Blocked sites' ) }
-				</SidebarMenuItem>
+				<ResponsiveMenu.Item to="/me/blocked-sites">{ __( 'Blocked sites' ) }</ResponsiveMenu.Item>
 			) }
 			{ isEnabled( 'mcp-settings' ) && (
-				<SidebarMenuItem icon={ starEmpty } to="/me/mcp">
-					{ __( 'MCP' ) }
-				</SidebarMenuItem>
+				<ResponsiveMenu.Item to="/me/mcp">{ __( 'MCP' ) }</ResponsiveMenu.Item>
 			) }
 			{ hasAppSupport( supports, 'apps' ) && (
-				<SidebarMenuItem icon={ buttons } to="/me/apps">
-					{ __( 'Apps' ) }
-				</SidebarMenuItem>
+				<ResponsiveMenu.Item to="/me/apps">{ __( 'Apps' ) }</ResponsiveMenu.Item>
 			) }
-		</SidebarMenu>
+		</ResponsiveMenu>
 	);
 };
 

--- a/client/dashboard/me/me-sidebar/index.tsx
+++ b/client/dashboard/me/me-sidebar/index.tsx
@@ -1,4 +1,5 @@
 import { userSettingsQuery } from '@automattic/api-queries';
+import { isEnabled } from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
 import {
 	__experimentalHStack as HStack,
@@ -6,9 +7,26 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import MeMenu from '../me-menu';
+import {
+	bell,
+	buttons,
+	commentAuthorAvatar,
+	lock,
+	notAllowed,
+	payment,
+	seen,
+	settings,
+	starEmpty,
+} from '@wordpress/icons';
+import { useAppContext } from '../../app/context';
+import { SidebarMenu, SidebarMenuItem } from '../../components/sidebar';
+import type { AppConfig, MeSupports } from '../../app/context';
 
 import './style.scss';
+
+const hasAppSupport = ( supports: AppConfig[ 'supports' ], feature: keyof MeSupports ) => {
+	return supports.me && supports.me[ feature ];
+};
 
 export default function MeSidebar() {
 	const { data: userSettings } = useQuery( userSettingsQuery() );
@@ -34,7 +52,53 @@ export default function MeSidebar() {
 					</Text>
 				</VStack>
 			</HStack>
-			<MeMenu />
+			<MeMenuSidebar />
 		</VStack>
+	);
+}
+
+function MeMenuSidebar() {
+	const { supports } = useAppContext();
+
+	return (
+		<SidebarMenu>
+			<SidebarMenuItem icon={ commentAuthorAvatar } to="/me/profile">
+				{ __( 'Profile' ) }
+			</SidebarMenuItem>
+			<SidebarMenuItem icon={ settings } to="/me/preferences">
+				{ __( 'Preferences' ) }
+			</SidebarMenuItem>
+			<SidebarMenuItem icon={ payment } to="/me/billing">
+				{ __( 'Billing' ) }
+			</SidebarMenuItem>
+			<SidebarMenuItem icon={ lock } to="/me/security">
+				{ __( 'Security' ) }
+			</SidebarMenuItem>
+			{ hasAppSupport( supports, 'privacy' ) && (
+				<SidebarMenuItem icon={ seen } to="/me/privacy">
+					{ __( 'Privacy' ) }
+				</SidebarMenuItem>
+			) }
+			{ supports.notifications && (
+				<SidebarMenuItem icon={ bell } to="/me/notifications">
+					{ __( 'Notifications' ) }
+				</SidebarMenuItem>
+			) }
+			{ supports.reader && (
+				<SidebarMenuItem icon={ notAllowed } to="/me/blocked-sites">
+					{ __( 'Blocked sites' ) }
+				</SidebarMenuItem>
+			) }
+			{ isEnabled( 'mcp-settings' ) && (
+				<SidebarMenuItem icon={ starEmpty } to="/me/mcp">
+					{ __( 'MCP' ) }
+				</SidebarMenuItem>
+			) }
+			{ hasAppSupport( supports, 'apps' ) && (
+				<SidebarMenuItem icon={ buttons } to="/me/apps">
+					{ __( 'Apps' ) }
+				</SidebarMenuItem>
+			) }
+		</SidebarMenu>
 	);
 }

--- a/client/dashboard/plugins/index.tsx
+++ b/client/dashboard/plugins/index.tsx
@@ -1,5 +1,21 @@
 import { Outlet } from '@tanstack/react-router';
+import { __experimentalHStack as HStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import HeaderBar from '../components/header-bar';
+import PluginsMenu from './plugins-menu';
 
 export default function Plugins() {
-	return <Outlet />;
+	return (
+		<>
+			<HeaderBar>
+				<HStack spacing={ 3 }>
+					<HeaderBar.Title>
+						<span>{ __( 'Plugins' ) }</span>
+					</HeaderBar.Title>
+					<PluginsMenu />
+				</HStack>
+			</HeaderBar>
+			<Outlet />
+		</>
+	);
 }

--- a/client/dashboard/plugins/plugins-menu/index.tsx
+++ b/client/dashboard/plugins/plugins-menu/index.tsx
@@ -1,0 +1,24 @@
+import { __ } from '@wordpress/i18n';
+import MenuDivider from '../../components/menu-divider';
+import ResponsiveMenu from '../../components/responsive-menu';
+import { wpcomLink } from '../../utils/link';
+
+const PluginsMenu = () => {
+	return (
+		<ResponsiveMenu prefix={ <MenuDivider /> }>
+			<ResponsiveMenu.Item to="/plugins/manage">{ __( 'Manage plugins' ) }</ResponsiveMenu.Item>
+			<ResponsiveMenu.Item to="/plugins/scheduled-updates">
+				{ __( 'Scheduled updates' ) }
+			</ResponsiveMenu.Item>
+			<ResponsiveMenu.Item
+				href={ wpcomLink( '/plugins' ) }
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				{ __( 'Browse plugins' ) }
+			</ResponsiveMenu.Item>
+		</ResponsiveMenu>
+	);
+};
+
+export default PluginsMenu;

--- a/client/dashboard/sites/logs/index.tsx
+++ b/client/dashboard/sites/logs/index.tsx
@@ -1,13 +1,15 @@
 import { HostingFeatures, LogType } from '@automattic/api-core';
 import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
+import { TabPanel } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from 'react';
 import { useDateRange } from '../../app/hooks/use-date-range';
 import { useLocale } from '../../app/locale';
 import { siteRoute } from '../../app/router/sites';
-import { Card, CardBody } from '../../components/card';
+import { Card, CardBody, CardHeader } from '../../components/card';
 import { DateRangePicker } from '../../components/date-range-picker';
 import { isLast7Days } from '../../components/date-range-picker/utils';
 import InlineSupportLink from '../../components/inline-support-link';
@@ -20,11 +22,13 @@ import HostingFeatureGatedWithCallout from '../hosting-feature-gated-with-callou
 import SiteActivityLogsDataViews from '../logs-activity/dataviews';
 import SiteLogsDataViews from './dataviews';
 import { getLogsCalloutProps } from './logs-callout';
+import { LOG_TABS } from './utils';
 import './style.scss';
 
 function SiteLogs( { logType }: { logType: LogType } ) {
 	const locale = useLocale();
 	const { siteSlug } = siteRoute.useParams();
+	const router = useRouter();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 
 	const settingsUrl = site.options?.admin_url
@@ -111,6 +115,19 @@ function SiteLogs( { logType }: { logType: LogType } ) {
 		return true;
 	};
 
+	const handleTabChange = ( tab: LogType ) => {
+		if ( logType === tab ) {
+			return;
+		}
+
+		if ( tab === LogType.PHP ) {
+			router.navigate( { to: `/sites/${ siteSlug }/logs/php` } );
+		} else if ( tab === LogType.ACTIVITY ) {
+			router.navigate( { to: `/sites/${ siteSlug }/logs/activity` } );
+		} else {
+			router.navigate( { to: `/sites/${ siteSlug }/logs/server` } );
+		}
+	};
 	const hasActivityLogAccess =
 		hasHostingFeature( site, HostingFeatures.ACTIVITY_LOG ) ||
 		hasPlanFeature( site, HostingFeatures.ACTIVITY_LOG );
@@ -157,6 +174,25 @@ function SiteLogs( { logType }: { logType: LogType } ) {
 			}
 		>
 			<Card className={ `site-logs-card site-logs-card--${ logType }` }>
+				<CardHeader style={ { paddingBottom: '0' } }>
+					<TabPanel
+						className="site-logs-tabs"
+						activeClass="is-active"
+						tabs={ LOG_TABS }
+						onSelect={ ( tabName ) => {
+							if (
+								tabName === LogType.PHP ||
+								tabName === LogType.SERVER ||
+								tabName === LogType.ACTIVITY
+							) {
+								handleTabChange( tabName );
+							}
+						} }
+						initialTabName={ logType }
+					>
+						{ () => null }
+					</TabPanel>
+				</CardHeader>
 				<CardBody>
 					{ logType === LogType.PHP || logType === LogType.SERVER ? (
 						<HostingFeatureGatedWithCallout site={ site } { ...getLogsCalloutProps() }>

--- a/client/dashboard/sites/logs/test/index.test.tsx
+++ b/client/dashboard/sites/logs/test/index.test.tsx
@@ -176,6 +176,26 @@ beforeEach( () => {
 } );
 
 describe( 'SiteLogs page', () => {
+	test.each( Object.entries( LogType ) )(
+		'on selecting tab %s, navigates to /%s',
+		async ( logType, logTypeName ) => {
+			// Different initial log type that the one under test
+			const initialLogType = logTypeName !== LogType.PHP ? LogType.PHP : LogType.SERVER;
+			render( <SiteLogs logType={ initialLogType } /> );
+
+			// Click another tab
+			await userEvent.click(
+				await screen.findByRole( 'button', { name: new RegExp( logTypeName, 'i' ) } )
+			);
+			const { __mocks: routerMocks } = jest.requireMock( '@tanstack/react-router' ) as {
+				__mocks: { navigate: jest.Mock };
+			};
+			expect( routerMocks.navigate ).toHaveBeenCalledWith( {
+				to: `/sites/test-site/logs/${ logTypeName }`,
+			} );
+		}
+	);
+
 	test( 'URL from/to params are normalized from ms to seconds', async () => {
 		const replaceSpy = jest.spyOn( window.history, 'replaceState' );
 		const msFrom = 1730000000000; // ms
@@ -188,17 +208,16 @@ describe( 'SiteLogs page', () => {
 
 		render( <SiteLogs logType={ LogType.PHP } /> );
 
-		await waitFor( () => {
-			const hrefArgs = replaceSpy.mock.calls
-				.map( ( call ) => call?.[ 2 ] )
-				.filter( ( v ): v is string => typeof v === 'string' );
-			expect(
-				hrefArgs.some( ( h ) => h.includes( `from=${ Math.floor( msFrom / 1000 ) }` ) )
-			).toBe( true );
-			expect( hrefArgs.some( ( h ) => h.includes( `to=${ Math.floor( msTo / 1000 ) }` ) ) ).toBe(
-				true
-			);
-		} );
+		await waitFor( () => expect( replaceSpy ).toHaveBeenCalled() );
+		const hrefArgs = replaceSpy.mock.calls
+			.map( ( call ) => call?.[ 2 ] )
+			.filter( ( v ): v is string => typeof v === 'string' );
+		expect( hrefArgs.some( ( h ) => h.includes( `from=${ Math.floor( msFrom / 1000 ) }` ) ) ).toBe(
+			true
+		);
+		expect( hrefArgs.some( ( h ) => h.includes( `to=${ Math.floor( msTo / 1000 ) }` ) ) ).toBe(
+			true
+		);
 
 		// restore
 		Object.defineProperty( window, 'location', { value: { href: originalHref } } );

--- a/client/dashboard/sites/scan/index.tsx
+++ b/client/dashboard/sites/scan/index.tsx
@@ -1,7 +1,8 @@
 import { HostingFeatures } from '@automattic/api-core';
 import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { Button, Modal } from '@wordpress/components';
+import { useRouter } from '@tanstack/react-router';
+import { Button, Modal, TabPanel } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { shield } from '@wordpress/icons';
 import { useState } from 'react';
@@ -9,7 +10,7 @@ import { useAnalytics } from '../../app/analytics';
 import { PerformanceTrackerStop } from '../../app/performance-tracking';
 import { siteRoute } from '../../app/router/sites';
 import { ButtonStack } from '../../components/button-stack';
-import { Card, CardBody } from '../../components/card';
+import { Card, CardHeader, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import TimeMismatchNotice from '../../components/time-mismatch-notice';
@@ -26,8 +27,14 @@ import { useScanState } from './use-scan-state';
 
 import './style.scss';
 
+const SCAN_TABS = [
+	{ name: 'active', title: __( 'Active threats' ) },
+	{ name: 'history', title: __( 'History' ) },
+];
+
 function SiteScan( { scanTab }: { scanTab: 'active' | 'history' } ) {
 	const { siteSlug } = siteRoute.useParams();
+	const router = useRouter();
 
 	const { recordTracksEvent } = useAnalytics();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
@@ -65,6 +72,18 @@ function SiteScan( { scanTab }: { scanTab: 'active' | 'history' } ) {
 		}
 
 		return null;
+	};
+
+	const handleTabChange = ( tab: 'active' | 'history' ) => {
+		if ( scanTab === tab ) {
+			return;
+		}
+
+		if ( tab === 'active' ) {
+			router.navigate( { to: `/sites/${ siteSlug }/scan/active` } );
+		} else {
+			router.navigate( { to: `/sites/${ siteSlug }/scan/history` } );
+		}
 	};
 
 	const renderActiveTab = () => {
@@ -147,6 +166,20 @@ function SiteScan( { scanTab }: { scanTab: 'active' | 'history' } ) {
 				}
 			>
 				<Card>
+					<CardHeader style={ { paddingBottom: '0' } }>
+						<TabPanel
+							activeClass="is-active"
+							tabs={ SCAN_TABS }
+							onSelect={ ( tabName ) => {
+								if ( tabName === 'active' || tabName === 'history' ) {
+									handleTabChange( tabName );
+								}
+							} }
+							initialTabName={ scanTab }
+						>
+							{ () => null }
+						</TabPanel>
+					</CardHeader>
 					<CardBody>
 						{ scanTab === 'active' && renderActiveTab() }
 						{ scanTab === 'history' && (

--- a/client/dashboard/sites/site-menu/index.tsx
+++ b/client/dashboard/sites/site-menu/index.tsx
@@ -1,17 +1,5 @@
-import { HostingFeatures } from '@automattic/api-core';
 import { isSupportSession } from '@automattic/calypso-support-session';
 import { __ } from '@wordpress/i18n';
-import {
-	backup,
-	category,
-	chartBar,
-	code,
-	formatListBullets,
-	globe,
-	pending,
-	settings,
-	shield,
-} from '@wordpress/icons';
 import {
 	siteOverviewRoute,
 	siteDeploymentsRoute,
@@ -23,8 +11,8 @@ import {
 	siteDomainsRoute,
 	siteSettingsRoute,
 } from '../../app/router/sites';
-import { SidebarExpandableMenuItem, SidebarMenu, SidebarMenuItem } from '../../components/sidebar';
-import { hasHostingFeature } from '../../utils/site-features';
+import MenuDivider from '../../components/menu-divider';
+import ResponsiveMenu from '../../components/responsive-menu';
 import { hasSiteTrialEnded } from '../../utils/site-trial';
 import { getSiteTypeFeatureSupports } from '../../utils/site-type-feature-support';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
@@ -35,32 +23,33 @@ const SiteMenu = ( { site }: { site: Site } ) => {
 	const siteSlug = site.slug;
 
 	const siteTypeSupports = getSiteTypeFeatureSupports( site );
-
 	if ( hasSiteTrialEnded( site ) ) {
 		return (
-			<SidebarMenu>
-				<SidebarMenuItem to={ `/sites/${ siteSlug }/trial-ended` }>
+			<ResponsiveMenu label={ __( 'Site Menu' ) } prefix={ <MenuDivider /> }>
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/trial-ended` }>
 					{ __( 'Trial ended' ) }
-				</SidebarMenuItem>
-			</SidebarMenu>
+				</ResponsiveMenu.Item>
+			</ResponsiveMenu>
 		);
 	}
 
 	if ( site.options?.is_difm_lite_in_progress && ! isSupportSession() ) {
 		return (
-			<SidebarMenu>
-				<SidebarMenuItem to={ `/sites/${ siteSlug }/site-building-in-progress` }>
+			<ResponsiveMenu label={ __( 'Site Menu' ) } prefix={ <MenuDivider /> }>
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/site-building-in-progress` }>
 					{ __( 'Site building' ) }
-				</SidebarMenuItem>
+				</ResponsiveMenu.Item>
 				{ siteTypeSupports.domains && (
-					<SidebarMenuItem to={ `/sites/${ siteSlug }/domains` }>
+					<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/domains` }>
 						{ __( 'Domains' ) }
-					</SidebarMenuItem>
+					</ResponsiveMenu.Item>
 				) }
 				{ siteTypeSupports.emails && (
-					<SidebarMenuItem to={ `/sites/${ siteSlug }/emails` }>{ __( 'Emails' ) }</SidebarMenuItem>
+					<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/emails` }>
+						{ __( 'Emails' ) }
+					</ResponsiveMenu.Item>
 				) }
-			</SidebarMenu>
+			</ResponsiveMenu>
 		);
 	}
 
@@ -69,87 +58,56 @@ const SiteMenu = ( { site }: { site: Site } ) => {
 		route.options.staticData?.availableToInaccessibleJetpackSites;
 
 	return (
-		<SidebarMenu>
+		<ResponsiveMenu label={ __( 'Site Menu' ) } prefix={ <MenuDivider /> }>
 			{ isAvailable( siteOverviewRoute ) && (
-				<SidebarMenuItem
-					icon={ category }
-					to={ `/sites/${ siteSlug }` }
-					activeOptions={ { exact: true } }
-				>
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }` } activeOptions={ { exact: true } }>
 					{ __( 'Overview' ) }
-				</SidebarMenuItem>
+				</ResponsiveMenu.Item>
 			) }
 			{ isAvailable( siteDeploymentsRoute ) && siteTypeSupports.deployments && (
-				<SidebarMenuItem icon={ code } to={ `/sites/${ siteSlug }/deployments` }>
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/deployments` }>
 					{ __( 'Deployments' ) }
-				</SidebarMenuItem>
+				</ResponsiveMenu.Item>
 			) }
 			{ isAvailable( sitePerformanceRoute ) && siteTypeSupports.performance && (
-				<SidebarMenuItem icon={ chartBar } to={ `/sites/${ siteSlug }/performance` }>
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/performance` }>
 					{ __( 'Performance' ) }
-				</SidebarMenuItem>
+				</ResponsiveMenu.Item>
 			) }
 			{ isAvailable( siteMonitoringRoute ) && siteTypeSupports.monitoring && (
-				<SidebarMenuItem icon={ pending } to={ `/sites/${ siteSlug }/monitoring` }>
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/monitoring` }>
 					{ __( 'Monitoring' ) }
-				</SidebarMenuItem>
+				</ResponsiveMenu.Item>
 			) }
 			{ isAvailable( siteLogsRoute ) && siteTypeSupports.logs && (
-				<SidebarExpandableMenuItem
-					label={ __( 'Logs' ) }
-					icon={ formatListBullets }
-					to={ `/sites/${ siteSlug }/logs` }
-				>
-					<SidebarMenuItem to={ `/sites/${ siteSlug }/logs/activity` }>
-						{ __( 'Activity' ) }
-					</SidebarMenuItem>
-					<SidebarMenuItem to={ `/sites/${ siteSlug }/logs/php` }>
-						{ __( 'PHP errors' ) }
-					</SidebarMenuItem>
-					<SidebarMenuItem to={ `/sites/${ siteSlug }/logs/server` }>
-						{ __( 'Web server' ) }
-					</SidebarMenuItem>
-				</SidebarExpandableMenuItem>
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/logs` }>
+					{ __( 'Logs' ) }
+				</ResponsiveMenu.Item>
 			) }
-			{ isAvailable( siteScanRoute ) &&
-				siteTypeSupports.scan &&
-				( hasHostingFeature( site, HostingFeatures.SCAN_SELF_SERVE ) ? (
-					<SidebarExpandableMenuItem
-						label={ __( 'Scan' ) }
-						icon={ shield }
-						to={ `/sites/${ siteSlug }/scan` }
-					>
-						<SidebarMenuItem to={ `/sites/${ siteSlug }/scan/active` }>
-							{ __( 'Active threats' ) }
-						</SidebarMenuItem>
-						<SidebarMenuItem to={ `/sites/${ siteSlug }/scan/history` }>
-							{ __( 'History' ) }
-						</SidebarMenuItem>
-					</SidebarExpandableMenuItem>
-				) : (
-					<SidebarMenuItem icon={ shield } to={ `/sites/${ siteSlug }/scan` }>
-						{ __( 'Scan' ) }
-					</SidebarMenuItem>
-				) ) }
+			{ isAvailable( siteScanRoute ) && siteTypeSupports.scan && (
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/scan` }>
+					{ __( 'Scan' ) }
+				</ResponsiveMenu.Item>
+			) }
 			{ isAvailable( siteBackupsRoute ) && siteTypeSupports.backups && (
-				<SidebarMenuItem icon={ backup } to={ `/sites/${ siteSlug }/backups` }>
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/backups` }>
 					{ __( 'Backups' ) }
-				</SidebarMenuItem>
+				</ResponsiveMenu.Item>
 			) }
 			{ isAvailable( siteDomainsRoute ) && siteTypeSupports.domains && (
-				<SidebarMenuItem icon={ globe } to={ `/sites/${ siteSlug }/domains` }>
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/domains` }>
 					{ __( 'Domains' ) }
-				</SidebarMenuItem>
+				</ResponsiveMenu.Item>
 			) }
 			{ isAvailable( siteSettingsRoute ) &&
 				siteTypeSupports.settings &&
 				site.capabilities?.manage_options &&
 				! isSelfHostedJetpackConnected( site ) && (
-					<SidebarMenuItem icon={ settings } to={ `/sites/${ siteSlug }/settings` }>
+					<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/settings` }>
 						{ __( 'Settings' ) }
-					</SidebarMenuItem>
+					</ResponsiveMenu.Item>
 				) }
-		</SidebarMenu>
+		</ResponsiveMenu>
 	);
 };
 

--- a/client/dashboard/sites/site-sidebar/index.tsx
+++ b/client/dashboard/sites/site-sidebar/index.tsx
@@ -1,13 +1,47 @@
+import { HostingFeatures } from '@automattic/api-core';
 import { siteBySlugQuery } from '@automattic/api-queries';
+import { isSupportSession } from '@automattic/calypso-support-session';
 import { useQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack, useNavigator } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import {
+	backup,
+	category,
+	chartBar,
+	code,
+	formatListBullets,
+	globe,
+	pending,
+	settings,
+	shield,
+} from '@wordpress/icons';
 import { Suspense, lazy, useMemo } from 'react';
 import { useAppContext } from '../../app/context';
-import { SidebarBackButton, SidebarMenu } from '../../components/sidebar';
+import {
+	siteOverviewRoute,
+	siteDeploymentsRoute,
+	sitePerformanceRoute,
+	siteMonitoringRoute,
+	siteLogsRoute,
+	siteScanRoute,
+	siteBackupsRoute,
+	siteDomainsRoute,
+	siteSettingsRoute,
+} from '../../app/router/sites';
+import {
+	SidebarBackButton,
+	SidebarExpandableMenuItem,
+	SidebarMenu,
+	SidebarMenuItem,
+} from '../../components/sidebar';
+import { hasHostingFeature } from '../../utils/site-features';
+import { hasSiteTrialEnded } from '../../utils/site-trial';
+import { getSiteTypeFeatureSupports } from '../../utils/site-type-feature-support';
+import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import { canSwitchEnvironment } from '../features';
 import EnvironmentSwitcher from '../site/environment-switcher-v2';
-import SiteMenu from '../site-menu';
+import type { Site } from '@automattic/api-core';
+import type { AnyRoute } from '@tanstack/react-router';
 
 export default function SiteSidebar() {
 	const { params } = useNavigator();
@@ -32,8 +66,129 @@ export default function SiteSidebar() {
 						{ canSwitchEnvironment( site ) && <EnvironmentSwitcher site={ site } /> }
 					</SidebarMenu>
 				</Suspense>
-				<SiteMenu site={ site } />
+				<SiteMenuSidebar site={ site } />
 			</VStack>
 		</VStack>
+	);
+}
+
+function SiteMenuSidebar( { site }: { site: Site } ) {
+	const siteSlug = site.slug;
+	const siteTypeSupports = getSiteTypeFeatureSupports( site );
+
+	if ( hasSiteTrialEnded( site ) ) {
+		return (
+			<SidebarMenu>
+				<SidebarMenuItem to={ `/sites/${ siteSlug }/trial-ended` }>
+					{ __( 'Trial ended' ) }
+				</SidebarMenuItem>
+			</SidebarMenu>
+		);
+	}
+
+	if ( site.options?.is_difm_lite_in_progress && ! isSupportSession() ) {
+		return (
+			<SidebarMenu>
+				<SidebarMenuItem to={ `/sites/${ siteSlug }/site-building-in-progress` }>
+					{ __( 'Site building' ) }
+				</SidebarMenuItem>
+				{ siteTypeSupports.domains && (
+					<SidebarMenuItem to={ `/sites/${ siteSlug }/domains` }>
+						{ __( 'Domains' ) }
+					</SidebarMenuItem>
+				) }
+				{ siteTypeSupports.emails && (
+					<SidebarMenuItem to={ `/sites/${ siteSlug }/emails` }>{ __( 'Emails' ) }</SidebarMenuItem>
+				) }
+			</SidebarMenu>
+		);
+	}
+
+	const isAvailable = ( route: AnyRoute ) =>
+		! site.__inaccessible_jetpack_error ||
+		route.options.staticData?.availableToInaccessibleJetpackSites;
+
+	return (
+		<SidebarMenu>
+			{ isAvailable( siteOverviewRoute ) && (
+				<SidebarMenuItem
+					icon={ category }
+					to={ `/sites/${ siteSlug }` }
+					activeOptions={ { exact: true } }
+				>
+					{ __( 'Overview' ) }
+				</SidebarMenuItem>
+			) }
+			{ isAvailable( siteDeploymentsRoute ) && siteTypeSupports.deployments && (
+				<SidebarMenuItem icon={ code } to={ `/sites/${ siteSlug }/deployments` }>
+					{ __( 'Deployments' ) }
+				</SidebarMenuItem>
+			) }
+			{ isAvailable( sitePerformanceRoute ) && siteTypeSupports.performance && (
+				<SidebarMenuItem icon={ chartBar } to={ `/sites/${ siteSlug }/performance` }>
+					{ __( 'Performance' ) }
+				</SidebarMenuItem>
+			) }
+			{ isAvailable( siteMonitoringRoute ) && siteTypeSupports.monitoring && (
+				<SidebarMenuItem icon={ pending } to={ `/sites/${ siteSlug }/monitoring` }>
+					{ __( 'Monitoring' ) }
+				</SidebarMenuItem>
+			) }
+			{ isAvailable( siteLogsRoute ) && siteTypeSupports.logs && (
+				<SidebarExpandableMenuItem
+					label={ __( 'Logs' ) }
+					icon={ formatListBullets }
+					to={ `/sites/${ siteSlug }/logs` }
+				>
+					<SidebarMenuItem to={ `/sites/${ siteSlug }/logs/activity` }>
+						{ __( 'Activity' ) }
+					</SidebarMenuItem>
+					<SidebarMenuItem to={ `/sites/${ siteSlug }/logs/php` }>
+						{ __( 'PHP errors' ) }
+					</SidebarMenuItem>
+					<SidebarMenuItem to={ `/sites/${ siteSlug }/logs/server` }>
+						{ __( 'Web server' ) }
+					</SidebarMenuItem>
+				</SidebarExpandableMenuItem>
+			) }
+			{ isAvailable( siteScanRoute ) &&
+				siteTypeSupports.scan &&
+				( hasHostingFeature( site, HostingFeatures.SCAN_SELF_SERVE ) ? (
+					<SidebarExpandableMenuItem
+						label={ __( 'Scan' ) }
+						icon={ shield }
+						to={ `/sites/${ siteSlug }/scan` }
+					>
+						<SidebarMenuItem to={ `/sites/${ siteSlug }/scan/active` }>
+							{ __( 'Active threats' ) }
+						</SidebarMenuItem>
+						<SidebarMenuItem to={ `/sites/${ siteSlug }/scan/history` }>
+							{ __( 'History' ) }
+						</SidebarMenuItem>
+					</SidebarExpandableMenuItem>
+				) : (
+					<SidebarMenuItem icon={ shield } to={ `/sites/${ siteSlug }/scan` }>
+						{ __( 'Scan' ) }
+					</SidebarMenuItem>
+				) ) }
+			{ isAvailable( siteBackupsRoute ) && siteTypeSupports.backups && (
+				<SidebarMenuItem icon={ backup } to={ `/sites/${ siteSlug }/backups` }>
+					{ __( 'Backups' ) }
+				</SidebarMenuItem>
+			) }
+			{ isAvailable( siteDomainsRoute ) && siteTypeSupports.domains && (
+				<SidebarMenuItem icon={ globe } to={ `/sites/${ siteSlug }/domains` }>
+					{ __( 'Domains' ) }
+				</SidebarMenuItem>
+			) }
+			{ isAvailable( siteSettingsRoute ) &&
+				siteTypeSupports.settings &&
+				site.capabilities?.manage_options &&
+				! isSelfHostedJetpackConnected( site ) && (
+					<SidebarMenuItem icon={ settings } to={ `/sites/${ siteSlug }/settings` }>
+						{ __( 'Settings' ) }
+					</SidebarMenuItem>
+				) }
+		</SidebarMenu>
 	);
 }

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -1,17 +1,26 @@
 import { siteBySlugQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { notFound, Outlet } from '@tanstack/react-router';
+import { __experimentalHStack as HStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Suspense } from 'react';
+import { Suspense, useMemo, lazy } from 'react';
+import { useAppContext } from '../../app/context';
 import { siteRoute } from '../../app/router/sites';
 import StagingSiteSyncMonitor from '../../app/staging-site-sync-monitor';
 import FlashMessage from '../../components/flash-message';
+import HeaderBar from '../../components/header-bar';
+import MenuDivider from '../../components/menu-divider';
 import { hasStagingSite } from '../../utils/site-staging-site';
-import { canManageSite } from '../features';
+import { isSiteMigrationInProgress } from '../../utils/site-status';
+import { canManageSite, canSwitchEnvironment } from '../features';
+import SiteMenu from '../site-menu';
+import EnvironmentSwitcher from './environment-switcher';
 
 function Site() {
 	const { siteSlug } = siteRoute.useParams();
 	const { data: site, isError, error } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+	const { components } = useAppContext();
+	const SiteSwitcher = useMemo( () => lazy( components.siteSwitcher ), [ components ] );
 
 	if ( isError ) {
 		throw error;
@@ -24,6 +33,20 @@ function Site() {
 	return (
 		<Suspense fallback={ null }>
 			{ hasStagingSite( site ) && <StagingSiteSyncMonitor site={ site } /> }
+			<HeaderBar>
+				<HStack spacing={ 3 }>
+					<HeaderBar.Title>
+						<SiteSwitcher />
+						{ canSwitchEnvironment( site ) && (
+							<>
+								<MenuDivider />
+								<EnvironmentSwitcher site={ site } />
+							</>
+						) }
+					</HeaderBar.Title>
+					{ ! isSiteMigrationInProgress( site ) && <SiteMenu site={ site } /> }
+				</HStack>
+			</HeaderBar>
 			<Suspense fallback={ null }>
 				<FlashMessage
 					id="route-not-allowed"


### PR DESCRIPTION
## Proposed Changes

- Revert `*-menu` files (`primary-menu`, `site-menu`, `me-menu`, `domain-menu`) back to trunk's `ResponsiveMenu` so they are unaffected by the sidebar feature
- Inline `SidebarMenu` rendering directly in `*-sidebar` files (`site-sidebar`, `domain-sidebar`, `me-sidebar`, `app/sidebar`), making them self-contained
- Revert section layouts (`domain`, `site`, `me`, `plugins`) to restore their original `HeaderBar` components
- Revert `logs` and `scan` to restore `TabPanel` UI
- Add `omnibar-style.scss` with CSS that hides redundant inner `HeaderBar`s and tab navigation when the sidebar layout is active (`.dashboard-root__body` only exists when sidebar is ON)
- Restore old sticky header selectors for the non-sidebar layout
- Restore deleted `plugins-menu` component

## Why are these changes being made?

Separates sidebar-specific menu rendering from the shared menu components. Menu files stay as `ResponsiveMenu` (used by the header), while sidebar files contain their own `SidebarMenu` items. This enables the `dashboard/omnibar` feature flag to gate the sidebar without modifying shared menu components.

## Testing Instructions

1. Verify the sidebar layout still works correctly (site menu, domain menu, me menu, primary menu all render in the sidebar)
2. Verify the inner `HeaderBar`s and `TabPanel` tabs are hidden when sidebar is active (CSS hiding via `.dashboard-root__body`)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)