### PR TITLE
Grid: add AI agent context

### DIFF
--- a/packages/grid/AGENTS.md
+++ b/packages/grid/AGENTS.md
@@ -2,10 +2,6 @@
 
 `@automattic/grid` — data-driven CSS Grid layout component for React. See `README.md` for API and usage.
 
-## Linear Project
-
-Tracked in [Grid Package](https://linear.app/a8c/project/grid-package-aabf867f10a9) — Teams: Design System (DS), Architecture (ARC).
-
 ## Commands
 
 ```bash

--- a/packages/grid/AGENTS.md
+++ b/packages/grid/AGENTS.md
@@ -12,7 +12,7 @@ yarn workspace @automattic/grid prepack
 yarn workspace @automattic/grid tsc --build --dry
 
 # Run tests
-yarn test-client packages/grid
+yarn jest packages/grid --config packages/grid/jest.config.js
 
 # Storybook
 yarn workspace @automattic/grid storybook:start

--- a/packages/grid/AGENTS.md
+++ b/packages/grid/AGENTS.md
@@ -12,7 +12,7 @@ yarn workspace @automattic/grid prepack
 yarn workspace @automattic/grid tsc --build --dry
 
 # Run tests
-yarn jest packages/grid --config packages/grid/jest.config.js
+yarn workspace @automattic/grid test
 
 # Storybook
 yarn workspace @automattic/grid storybook:start

--- a/packages/grid/AGENTS.md
+++ b/packages/grid/AGENTS.md
@@ -1,0 +1,53 @@
+# Grid
+
+`@automattic/grid` — data-driven CSS Grid layout component for React. See `README.md` for API and usage.
+
+## Linear Project
+
+Tracked in [Grid Package](https://linear.app/a8c/project/grid-package-aabf867f10a9) — Teams: Design System (DS), Architecture (ARC).
+
+## Commands
+
+```bash
+# Build (ESM + CJS)
+yarn workspace @automattic/grid prepack
+
+# Type check
+yarn workspace @automattic/grid tsc --build --dry
+
+# Run tests
+yarn test-client packages/grid
+
+# Storybook
+yarn workspace @automattic/grid storybook:start
+
+# Lint
+yarn eslint packages/grid/src/<file>
+```
+
+## Conventions
+
+- **Types**: All shared types live in `src/types.ts`.
+- **Peer deps**: React 18+.
+
+## Release Process
+
+Published to npm as `@automattic/grid`. Steps:
+
+1. **Prepare PR**
+   - Update version in `package.json`
+   - Update `CHANGELOG.md` (Keep a Changelog format)
+   - Merge PR to trunk
+
+2. **Publish to npm**
+   - Checkout `trunk` at the merged commit
+   - Log in with your personal npm account (must be a member of the `@automattic` org): `yarn npm login --scope @automattic`
+   - Verify: `yarn npm whoami --scope @automattic`
+   - Publish: `cd packages/grid && yarn npm publish`
+   - Enter 2FA code when prompted
+   - Verify on [npmjs.com](https://www.npmjs.com/package/@automattic/grid)
+
+3. **Create git tag**
+   - `git tag "@automattic/grid@<version>"`
+   - `git push origin "@automattic/grid@<version>"`
+   - Verify tag on GitHub

--- a/packages/grid/CHANGELOG.md
+++ b/packages/grid/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Add `fillWidth` layout property — items fill remaining columns in their row
+- Add AI agent context (`CLAUDE.md`, `AGENTS.md`)
 
 ## 0.1.3
 

--- a/packages/grid/CLAUDE.md
+++ b/packages/grid/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -27,7 +27,8 @@
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch",
-		"storybook:start": "storybook dev -p 56834"
+		"storybook:start": "storybook dev -p 56834",
+		"test": "cd ../.. && yarn test-packages packages/grid"
 	},
 	"devDependencies": {
 		"@automattic/calypso-build": "workspace:^",


### PR DESCRIPTION
## What?

Adds `CLAUDE.md` and `AGENTS.md` to the `@automattic/grid` package to provide context for AI agents working on this codebase.

Closes DS-460

## Why?

AI agents lack package-specific context (Linear project, commands, conventions, release process). This makes it harder for them to contribute effectively.

## How?

- `CLAUDE.md` references `AGENTS.md` (same pattern as `block-notes`, `help-center`, `image-studio`)
- `AGENTS.md` includes: Linear project reference, build/test/lint commands, conventions, and the full npm release process

## Testing

- [ ] Verify `AGENTS.md` content is accurate
- [ ] Confirm `CLAUDE.md` correctly references `AGENTS.md`