### PR TITLE
MCP: Clear site lists when toggling MCP on or off

### DIFF
--- a/client/me/mcp/main.jsx
+++ b/client/me/mcp/main.jsx
@@ -88,10 +88,17 @@ function McpComponent( { path } ) {
 			accountAbilities[ toolId ] = enabled;
 		} );
 
+		const disabledSiteIds = getDisabledSiteIds( userSettings || {} );
+		const enabledSiteIds = getEnabledSiteIds( userSettings || {} );
+		const sitesToReset = [
+			...disabledSiteIds.map( ( id ) => ( { blog_id: id, account_tools_enabled: true } ) ),
+			...enabledSiteIds.map( ( id ) => ( { blog_id: id, site_level_enabled: false } ) ),
+		];
+
 		mutation.mutate( {
 			mcp_abilities: {
 				account: accountAbilities,
-				sites: [],
+				...( sitesToReset.length > 0 && { sites: sitesToReset } ),
 			},
 		} );
 	};

--- a/client/me/mcp/main.jsx
+++ b/client/me/mcp/main.jsx
@@ -91,6 +91,7 @@ function McpComponent( { path } ) {
 		mutation.mutate( {
 			mcp_abilities: {
 				account: accountAbilities,
+				sites: [],
 			},
 		} );
 	};


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/AIINT-296/clear-site-lists-when-toggling-mcp-on-or-off

## Proposed Changes

* When toggling MCP access on or off, include `sites: []` in the mutation payload to reset both the specific-sites allowlist (`site_level_enabled`) and the exceptions list (`account_tools_enabled: false`) alongside the account-level tool toggles.

## Why are these changes being made?

Toggling MCP on should reset to "all sites enabled, no exceptions" — a clean slate. Toggling off should similarly clear any site-level exceptions. Previously the site lists were left untouched when the main MCP toggle was flipped.

## Testing Instructions

* Enable MCP access, add some site exceptions via `/me/mcp/mcp-sites`.
* Toggle MCP off — verify the exceptions list is cleared.
* Add some site exceptions again, then toggle MCP on — verify both the allowlist and exceptions list are cleared and all sites default to enabled.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)