### PR TITLE
MCP: Fix connect panel hover border appearing bolder

### DIFF
--- a/client/me/mcp/main.jsx
+++ b/client/me/mcp/main.jsx
@@ -199,25 +199,20 @@ function McpComponent( { path } ) {
 							}
 							density="medium"
 						/>
+						<SummaryButton
+							href="/me/mcp/setup"
+							title={ translate( 'Connect external AI assistant' ) }
+							description={ translate(
+								'Get instructions for connecting your external AI assistant.'
+							) }
+							decoration={
+								<Icon className="mcp-hub__summary-icon" icon={ connection } size={ 24 } />
+							}
+							density="medium-low"
+						/>
 					</VStack>
 				) }
 			</Card>
-
-			{ hasTools && anyToolsEnabled && (
-				<Card className="mcp-hub__panel mcp-hub__panel--connect">
-					<SummaryButton
-						href="/me/mcp/setup"
-						title={ translate( 'Connect external AI assistant' ) }
-						description={ translate(
-							'Get instructions for connecting your external AI assistant.'
-						) }
-						decoration={
-							<Icon className="mcp-hub__summary-icon" icon={ connection } size={ 24 } />
-						}
-						density="low"
-					/>
-				</Card>
-			) }
 		</VStack>
 	);
 

--- a/client/me/mcp/main.jsx
+++ b/client/me/mcp/main.jsx
@@ -199,20 +199,20 @@ function McpComponent( { path } ) {
 							}
 							density="medium"
 						/>
-						<SummaryButton
-							href="/me/mcp/setup"
-							title={ translate( 'Connect external AI assistant' ) }
-							description={ translate(
-								'Get instructions for connecting your external AI assistant.'
-							) }
-							decoration={
-								<Icon className="mcp-hub__summary-icon" icon={ connection } size={ 24 } />
-							}
-							density="medium-low"
-						/>
 					</VStack>
 				) }
 			</Card>
+
+			{ hasTools && anyToolsEnabled && (
+				<SummaryButton
+					className="mcp-hub__panel"
+					href="/me/mcp/setup"
+					title={ translate( 'Connect external AI assistant' ) }
+					description={ translate( 'Get instructions for connecting your external AI assistant.' ) }
+					decoration={ <Icon className="mcp-hub__summary-icon" icon={ connection } size={ 24 } /> }
+					density="low"
+				/>
+			) }
 		</VStack>
 	);
 

--- a/client/me/mcp/style.scss
+++ b/client/me/mcp/style.scss
@@ -76,13 +76,9 @@ body.is-section-me div.layout.is-global-sidebar-visible .layout__primary .main.m
 		}
 
 		.summary-button.components-button.has-density-low {
-			border: 1px solid transparent;
+			border: none;
 			border-radius: 0;
 			margin: 0;
-
-			&:hover:not(:disabled, [aria-disabled="true"]):not(:focus-visible) {
-				border-color: transparent;
-			}
 		}
 	}
 }

--- a/client/me/mcp/style.scss
+++ b/client/me/mcp/style.scss
@@ -60,26 +60,9 @@ body.is-section-me div.layout.is-global-sidebar-visible .layout__primary .main.m
 	}
 
 	// Last summary row: drop duplicate bottom rule (card already has an edge)
-	.mcp-hub__panel-rows .summary-button.components-button.has-density-medium:last-child {
+	.mcp-hub__panel-rows .summary-button.components-button.has-density-medium:last-child,
+	.mcp-hub__panel-rows .summary-button.components-button.has-density-medium-low:last-child {
 		border-bottom: none;
-	}
-
-	// Connect panel (MCP on): single SummaryButton, full width
-	.mcp-hub__panel--connect {
-		padding: 0;
-		overflow: hidden;
-
-		.summary-button.components-button {
-			width: 100%;
-			max-width: 100%;
-			box-sizing: border-box;
-		}
-
-		.summary-button.components-button.has-density-low {
-			border: none;
-			border-radius: 0;
-			margin: 0;
-		}
 	}
 }
 

--- a/client/me/mcp/style.scss
+++ b/client/me/mcp/style.scss
@@ -74,6 +74,7 @@ body.is-section-me div.layout.is-global-sidebar-visible .layout__primary .main.m
 		&:hover:not(:disabled, [aria-disabled="true"]):not(:focus-visible) {
 			border: none;
 			box-shadow: 0 0 0 1px var(--color-border-subtle);
+			background: color-mix(in srgb, #fff 98%, var(--wp-admin-theme-color, #3858e9));
 		}
 	}
 }

--- a/client/me/mcp/style.scss
+++ b/client/me/mcp/style.scss
@@ -79,6 +79,10 @@ body.is-section-me div.layout.is-global-sidebar-visible .layout__primary .main.m
 			border: 1px solid transparent;
 			border-radius: 0;
 			margin: 0;
+
+			&:hover:not(:disabled, [aria-disabled="true"]):not(:focus-visible) {
+				border-color: transparent;
+			}
 		}
 	}
 }

--- a/client/me/mcp/style.scss
+++ b/client/me/mcp/style.scss
@@ -60,8 +60,7 @@ body.is-section-me div.layout.is-global-sidebar-visible .layout__primary .main.m
 	}
 
 	// Last summary row: drop duplicate bottom rule (card already has an edge)
-	.mcp-hub__panel-rows .summary-button.components-button.has-density-medium:last-child,
-	.mcp-hub__panel-rows .summary-button.components-button.has-density-medium-low:last-child {
+	.mcp-hub__panel-rows .summary-button.components-button.has-density-medium:last-child {
 		border-bottom: none;
 	}
 }

--- a/client/me/mcp/style.scss
+++ b/client/me/mcp/style.scss
@@ -63,6 +63,19 @@ body.is-section-me div.layout.is-global-sidebar-visible .layout__primary .main.m
 	.mcp-hub__panel-rows .summary-button.components-button.has-density-medium:last-child {
 		border-bottom: none;
 	}
+
+	// Connect button: match Card appearance (box-shadow border, surface background, flat corners)
+	.summary-button.components-button.mcp-hub__panel {
+		border: none;
+		border-radius: 0;
+		background: var(--color-surface);
+		box-shadow: 0 0 0 1px var(--color-border-subtle);
+
+		&:hover:not(:disabled, [aria-disabled="true"]):not(:focus-visible) {
+			border: none;
+			box-shadow: 0 0 0 1px var(--color-border-subtle);
+		}
+	}
 }
 
 // Hub summary row icons (Read / Write / Site exceptions / Connect)


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/AIINT-300/fix-connect-panel-hover-border-appearing-bolder

## Proposed Changes

* Keep the connect panel SummaryButton border transparent on hover so it does not visually thicken the surrounding card border.

## Why are these changes being made?

The SummaryButton component applies a tinted 1px solid border on hover for has-density-low buttons. In the connect panel the button sits flush inside a card with padding: 0, so this hover border was overriding the transparent border override and making the card edge appear to get bolder on hover. The fix keeps the border transparent on hover so the card edge stays consistent.

## Testing Instructions

* Enable MCP access on /me/mcp so the Connect external AI assistant panel is visible.
* Hover over the panel — the card border should remain the same width/colour throughout.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the String Freeze label as soon as any new strings were ready for translation?
- [ ] For changes affecting Jetpack: Have we added the Needs Privacy Updates label if this PR changes what data or activity we track or use?

Generated with [Claude Code](https://claude.com/claude-code)