### PR TITLE
fix: Guard against empty messages array in `convertOdieChatToOdieConversation`

### DIFF
--- a/packages/odie-client/src/utils/chat-utils.ts
+++ b/packages/odie-client/src/utils/chat-utils.ts
@@ -44,13 +44,14 @@ export const convertOdieChatToOdieConversation = (
 	sessionId: string,
 	botSlug: string
 ): LoggedOutOdieConversation => {
+	const createdAt = odieChat.messages[ 0 ]?.ts ?? 0;
 	return {
 		id: odieChat.odieId?.toString() || '',
 		messages: odieChat.messages.map( ( message ) => convertMessageToOdieMessage( message ) ),
-		createdAt: odieChat.messages[ 0 ].ts || 0,
+		createdAt,
 		metadata: {
 			odieChatId: odieChat.odieId || 0,
-			createdAt: odieChat.messages[ 0 ].ts || 0,
+			createdAt,
 			supportInteractionId: '',
 			status: 'open',
 			botSlug,

--- a/packages/odie-client/src/utils/test/chat-utils.test.ts
+++ b/packages/odie-client/src/utils/test/chat-utils.test.ts
@@ -106,17 +106,21 @@ describe( 'convertOdieChatToOdieConversation', () => {
 	const sessionId = 'test-session-id';
 	const botSlug = 'wpcom-support-chat';
 
-	it( 'throws a TypeError when messages array is empty (demonstrates the bug)', () => {
+	it( 'does not throw and falls back to createdAt 0 when messages array is empty', () => {
 		// An OdieChat with an empty messages array — e.g. a chat created but never messaged,
-		// or a truncated API response — triggers the bug: messages[0].ts is accessed on undefined.
+		// or a truncated API response — previously crashed with a TypeError because
+		// messages[0].ts was accessed on undefined.
 		const emptyChatLoggedOut: OdieChat = {
 			odieId: 42,
 			messages: [],
 		};
 
-		expect( () =>
-			convertOdieChatToOdieConversation( emptyChatLoggedOut, sessionId, botSlug )
-		).toThrow( TypeError );
+		const result = convertOdieChatToOdieConversation( emptyChatLoggedOut, sessionId, botSlug );
+
+		expect( result.id ).toBe( '42' );
+		expect( result.createdAt ).toBe( 0 );
+		expect( result.metadata.createdAt ).toBe( 0 );
+		expect( result.messages ).toHaveLength( 0 );
 	} );
 
 	it( 'converts an OdieChat with messages correctly', () => {

--- a/packages/odie-client/src/utils/test/chat-utils.test.ts
+++ b/packages/odie-client/src/utils/test/chat-utils.test.ts
@@ -1,5 +1,5 @@
-import { Chat } from '../../types';
-import { hasRecentEscalationAttempt } from '../chat-utils';
+import { Chat, OdieChat } from '../../types';
+import { convertOdieChatToOdieConversation, hasRecentEscalationAttempt } from '../chat-utils';
 
 // Helper to create a date string in the format 'YYYY-MM-DD HH:MM:SS'
 const formatDate = ( date: Date ): string => {
@@ -99,5 +99,45 @@ describe( 'hasRecentEscalationAttempt', () => {
 		};
 
 		expect( hasRecentEscalationAttempt( chat ) ).toBe( false );
+	} );
+} );
+
+describe( 'convertOdieChatToOdieConversation', () => {
+	const sessionId = 'test-session-id';
+	const botSlug = 'wpcom-support-chat';
+
+	it( 'throws a TypeError when messages array is empty (demonstrates the bug)', () => {
+		// An OdieChat with an empty messages array — e.g. a chat created but never messaged,
+		// or a truncated API response — triggers the bug: messages[0].ts is accessed on undefined.
+		const emptyChatLoggedOut: OdieChat = {
+			odieId: 42,
+			messages: [],
+		};
+
+		expect( () =>
+			convertOdieChatToOdieConversation( emptyChatLoggedOut, sessionId, botSlug )
+		).toThrow( TypeError );
+	} );
+
+	it( 'converts an OdieChat with messages correctly', () => {
+		const ts = 1700000000;
+		const chatWithMessages: OdieChat = {
+			odieId: 7,
+			messages: [
+				{ role: 'user', type: 'message', content: 'Hello', ts },
+				{ role: 'bot', type: 'message', content: 'Hi there', ts: ts + 10 },
+			],
+		};
+
+		const result = convertOdieChatToOdieConversation( chatWithMessages, sessionId, botSlug );
+
+		expect( result.id ).toBe( '7' );
+		expect( result.createdAt ).toBe( ts );
+		expect( result.metadata.odieChatId ).toBe( 7 );
+		expect( result.metadata.createdAt ).toBe( ts );
+		expect( result.metadata.sessionId ).toBe( sessionId );
+		expect( result.metadata.botSlug ).toBe( botSlug );
+		expect( result.messages ).toHaveLength( 2 );
+		expect( result.messages[ 0 ] ).toEqual( { received: ts, role: 'user', text: 'Hello' } );
 	} );
 } );

--- a/packages/odie-client/src/utils/test/chat-utils.test.ts
+++ b/packages/odie-client/src/utils/test/chat-utils.test.ts
@@ -107,9 +107,6 @@ describe( 'convertOdieChatToOdieConversation', () => {
 	const botSlug = 'wpcom-support-chat';
 
 	it( 'does not throw and falls back to createdAt 0 when messages array is empty', () => {
-		// An OdieChat with an empty messages array — e.g. a chat created but never messaged,
-		// or a truncated API response — previously crashed with a TypeError because
-		// messages[0].ts was accessed on undefined.
 		const emptyChatLoggedOut: OdieChat = {
 			odieId: 42,
 			messages: [],


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTSUP-452

## Proposed Changes

* Guard the `messages[0]` access with optional chaining and a nullish-coalescing fallback:

```
const createdAt = odieChat.messages?.[0]?.ts ?? 0;
```

This makes the converter safe for empty message lists while preserving existing behaviour for non-empty ones.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* `convertOdieChatToOdieConversation` unconditionally accessed `odieChat.messages[0].ts` to populate the `createdAt` field of the returned conversation. When a logged-out ODIE session existed but had an empty message list (e.g. a chat created before any message was sent, or a truncated API response), `messages[0]` resolved to `undefined`, causing .ts to throw a `TypeError`.

`useGetHistoryChats` calls this converter whenever `loggedOutSession && loggedOutChat.data` is truthy, so any user whose logged-out session returned an empty message list would see the help-center history view crash entirely.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check the code.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
