### PR TITLE
Grid: bump @automattic/grid to 0.2.0

### DIFF
--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/grid",
-	"version": "0.1.3",
+	"version": "0.2.0",
 	"description": "Grid component for Automattic projects.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
## What

Bump `@automattic/grid` package version to `0.2.0` for npm release.

Closes DS-461

## Why

Prepare the package for publishing to npm with the latest changes:
- `fillWidth` layout property (ARC-1614)
- AI agent context (DS-460)

## How

- Update version in `package.json` from `0.1.3` to `0.2.0`
- CHANGELOG already up to date with 0.2.0 entries

## Testing

1. Verify `package.json` shows version `0.2.0`
2. Verify CHANGELOG has matching `0.2.0` section
3. After merge, publish from trunk: `cd packages/grid && yarn npm publish`
4. Create git tag: `git tag "@automattic/grid@0.2.0"`