### PR TITLE
MSD Sidebar: Add site switcher v2 for sidebar

### DIFF
--- a/client/dashboard/app-ciab/index.tsx
+++ b/client/dashboard/app-ciab/index.tsx
@@ -48,6 +48,7 @@ boot( {
 	components: {
 		sites: () => import( '../sites-ciab' ),
 		siteSwitcher: () => import( '../sites-ciab/site-switcher' ),
+		siteSwitcherV2: () => import( '../sites-ciab/site-switcher-v2' ),
 	},
 	queries: {
 		sitesQuery: ( fetchSitesOptions?: FetchSitesOptions ) =>

--- a/client/dashboard/app-dotcom/index.tsx
+++ b/client/dashboard/app-dotcom/index.tsx
@@ -46,6 +46,7 @@ boot( {
 	components: {
 		sites: () => import( '../sites' ),
 		siteSwitcher: () => import( '../sites/site-switcher' ),
+		siteSwitcherV2: () => import( '../sites/site-switcher-v2' ),
 	},
 	queries: {
 		sitesQuery: ( fetchSiteOptions?: FetchSitesOptions ) => sitesQuery( 'all', fetchSiteOptions ),

--- a/client/dashboard/components/switcher/index.tsx
+++ b/client/dashboard/components/switcher/index.tsx
@@ -15,6 +15,8 @@ interface RenderCallbackProps {
 	onClose: () => void;
 }
 
+type RenderToggle = ComponentProps< typeof Dropdown >[ 'renderToggle' ];
+
 export type SwitcherProps< T > = {
 	items?: T[];
 	value: T;
@@ -25,6 +27,7 @@ export type SwitcherProps< T > = {
 	renderItemTitle: RenderItemTitle< T >;
 	renderItemDescription?: RenderItemDescription< T >;
 	onItemClick?: () => void;
+	renderToggle?: RenderToggle;
 } & Pick< ComponentProps< typeof Dropdown >, 'open' | 'onToggle' | 'defaultOpen' >; // For controlled usage of the switcher
 
 const DEFAULT_VIEW: View = {
@@ -47,39 +50,48 @@ export default function Switcher< T >( {
 	open,
 	onToggle,
 	defaultOpen,
+	renderToggle,
 }: SwitcherProps< T > ) {
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
 	const isDesktop = useViewportMatch( 'medium' );
+	const renderDropdownToggle: RenderToggle = ( { isOpen, onToggle, ...props } ) => {
+		if ( renderToggle ) {
+			return renderToggle( { isOpen, onToggle, ...props } );
+		}
+
+		return (
+			<Button
+				className="dashboard-menu__item active"
+				icon={ chevronDownSmall }
+				iconPosition="right"
+				onClick={ () => onToggle() }
+				onKeyDown={ ( event: React.KeyboardEvent ) => {
+					if ( ! isOpen && event.code === 'ArrowDown' ) {
+						event.preventDefault();
+						onToggle();
+					}
+				} }
+				aria-haspopup="true"
+				aria-expanded={ isOpen }
+				style={ { width: '100%', justifyContent: 'flex-start' } }
+			>
+				<HStack
+					alignment="center"
+					style={ { overflow: 'hidden', maxWidth: isDesktop ? 'calc(30vw)' : '100%' } }
+				>
+					{ renderItemMedia( { item: value, context: 'dropdown', size: 16 } ) }
+					{ renderItemTitle( { item: value, context: 'dropdown' } ) }
+				</HStack>
+			</Button>
+		);
+	};
+
 	return (
 		<Dropdown
 			open={ open }
 			onToggle={ onToggle }
 			defaultOpen={ defaultOpen }
-			renderToggle={ ( { onToggle, isOpen } ) => (
-				<Button
-					className="dashboard-menu__item active"
-					icon={ chevronDownSmall }
-					iconPosition="right"
-					onClick={ () => onToggle() }
-					onKeyDown={ ( event: React.KeyboardEvent ) => {
-						if ( ! isOpen && event.code === 'ArrowDown' ) {
-							event.preventDefault();
-							onToggle();
-						}
-					} }
-					aria-haspopup="true"
-					aria-expanded={ isOpen }
-					style={ { width: '100%', justifyContent: 'flex-start' } }
-				>
-					<HStack
-						alignment="center"
-						style={ { overflow: 'hidden', maxWidth: isDesktop ? 'calc(30vw)' : '100%' } }
-					>
-						{ renderItemMedia( { item: value, context: 'dropdown', size: 16 } ) }
-						{ renderItemTitle( { item: value, context: 'dropdown' } ) }
-					</HStack>
-				</Button>
-			) }
+			renderToggle={ renderDropdownToggle }
 			renderContent={ ( { onClose } ) => (
 				<>
 					<ScrollLock />

--- a/client/dashboard/sites-ciab/site-switcher-v2/index.tsx
+++ b/client/dashboard/sites-ciab/site-switcher-v2/index.tsx
@@ -1,0 +1,41 @@
+import { __experimentalHStack as HStack, MenuGroup, MenuItem, Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { plus } from '@wordpress/icons';
+import { addQueryArgs } from '@wordpress/url';
+import { useAnalytics } from '../../app/analytics';
+import { SiteSwitcherBase } from '../../sites/site-switcher-v2/base';
+import { wpcomLink } from '../../utils/link';
+
+const CIABSiteSwitcher = () => {
+	const { recordTracksEvent } = useAnalytics();
+	const handleAddNewStore = () => {
+		recordTracksEvent( 'calypso_dashboard_site_switcher_new_site_button_click', {
+			action: 'big-sky',
+			context: 'ciab-sites-dashboard',
+		} );
+
+		const addNewStoreUrl = addQueryArgs( wpcomLink( '/setup/ai-site-builder-spec' ), {
+			source: 'ciab-sites-dashboard',
+			ref: 'new-site-popover',
+		} );
+
+		window.location.href = addNewStoreUrl;
+	};
+
+	return (
+		<SiteSwitcherBase>
+			{ () => (
+				<MenuGroup>
+					<MenuItem onClick={ handleAddNewStore }>
+						<HStack justify="flex-start" alignment="center">
+							<Icon icon={ plus } />
+							<span>{ __( 'Add new store', 'Commerce in a box' ) }</span>
+						</HStack>
+					</MenuItem>
+				</MenuGroup>
+			) }
+		</SiteSwitcherBase>
+	);
+};
+
+export default CIABSiteSwitcher;

--- a/client/dashboard/sites/site-sidebar/index.tsx
+++ b/client/dashboard/sites/site-sidebar/index.tsx
@@ -50,7 +50,7 @@ export default function SiteSidebar() {
 	const { data: site } = useQuery( siteBySlugQuery( siteSlug ) );
 
 	const { components } = useAppContext();
-	const SiteSwitcher = useMemo( () => lazy( components.siteSwitcher ), [ components ] );
+	const SiteSwitcherV2 = useMemo( () => lazy( components.siteSwitcherV2 ), [ components ] );
 
 	if ( ! site ) {
 		return null;
@@ -62,7 +62,7 @@ export default function SiteSidebar() {
 			<VStack spacing={ 4 }>
 				<Suspense fallback={ null }>
 					<SidebarMenu>
-						<SiteSwitcher />
+						<SiteSwitcherV2 />
 						{ canSwitchEnvironment( site ) && <EnvironmentSwitcher site={ site } /> }
 					</SidebarMenu>
 				</Suspense>

--- a/client/dashboard/sites/site-switcher-v2/base.scss
+++ b/client/dashboard/sites/site-switcher-v2/base.scss
@@ -1,0 +1,19 @@
+@import '@wordpress/base-styles/variables';
+
+.site-switcher {
+	height: 40px;
+	padding-inline-start: $grid-unit-15;
+	// This makes it align with toggle caret's in the sidebar.
+	padding-inline-end: calc( #{$grid-unit-15} - 3px );
+
+	.site-switcher__toggle {
+		color: var( --dashboard-menu-item__color );
+		min-width: 0;
+		padding: 0;
+
+		svg {
+			width: 18px;
+			height: 18px;
+		}
+	}
+}

--- a/client/dashboard/sites/site-switcher-v2/base.tsx
+++ b/client/dashboard/sites/site-switcher-v2/base.tsx
@@ -1,0 +1,130 @@
+import { siteBySlugQuery } from '@automattic/api-queries';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Button,
+	ExternalLink,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { chevronUpDown } from '@wordpress/icons';
+import { useState } from 'react';
+import { useAnalytics } from '../../app/analytics';
+import { useAppContext } from '../../app/context';
+import useBuildCurrentRouteLink from '../../app/hooks/use-build-current-route-link';
+import { siteRoute } from '../../app/router/sites';
+import SiteIcon from '../../components/site-icon';
+import Switcher from '../../components/switcher';
+import { Text } from '../../components/text';
+import { getSiteDisplayName } from '../../utils/site-name';
+import { getSiteDisplayUrl } from '../../utils/site-url';
+import { canManageSite } from '../features';
+import type { SwitcherProps } from '../../components/switcher';
+import type { Site } from '@automattic/api-core';
+
+import './base.scss';
+
+const searchableFields = [
+	{
+		id: 'name',
+		getValue: ( { item }: { item: Site } ) => getSiteDisplayName( item ),
+	},
+	{
+		id: 'URL',
+		getValue: ( { item }: { item: Site } ) => getSiteDisplayUrl( item ),
+	},
+];
+
+export const SiteSwitcherBase = (
+	props: Pick< SwitcherProps< Site >, 'children' | 'renderToggle' >
+) => {
+	const { recordTracksEvent } = useAnalytics();
+	const { queries } = useAppContext();
+	const [ isSwitcherOpen, setIsSwitcherOpen ] = useState( false );
+	const { data: sites } = useQuery( { ...queries.sitesQuery(), enabled: isSwitcherOpen } );
+	const { siteSlug } = siteRoute.useParams();
+	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+	const buildCurrentRouteLink = useBuildCurrentRouteLink();
+
+	const renderItemMedia: SwitcherProps< Site >[ 'renderItemMedia' ] = ( { item, size } ) => (
+		<SiteIcon site={ item } size={ size } />
+	);
+
+	const renderItemTitle: SwitcherProps< Site >[ 'renderItemTitle' ] = ( { item } ) => (
+		<span
+			style={ {
+				color: 'var(--dashboard__text-color)',
+				fontWeight: 500,
+				overflow: 'hidden',
+				textOverflow: 'ellipsis',
+				whiteSpace: 'nowrap',
+			} }
+		>
+			{ getSiteDisplayName( item ) }
+		</span>
+	);
+
+	return (
+		<HStack className="site-switcher" spacing={ 0 } expanded={ false } style={ { flexShrink: 0 } }>
+			<HStack justify="flex-start" alignment="center" style={ { maxWidth: '85%' } }>
+				{ renderItemMedia( { item: site, context: 'dropdown', size: 32 } ) }
+				<VStack spacing={ 0 }>
+					{ renderItemTitle( { item: site, context: 'dropdown' } ) }
+					<ExternalLink
+						href={ site.URL }
+						style={ { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }
+					>
+						{ getSiteDisplayUrl( site ) }
+					</ExternalLink>
+				</VStack>
+			</HStack>
+			<Switcher< Site >
+				{ ...props }
+				items={ sites }
+				value={ site }
+				searchableFields={ searchableFields }
+				getItemUrl={ ( site ) => {
+					if ( canManageSite( site ) ) {
+						return buildCurrentRouteLink( { params: { siteSlug: site.slug } } );
+					}
+					return site.options?.admin_url ?? '';
+				} }
+				renderItemMedia={ renderItemMedia }
+				renderItemTitle={ renderItemTitle }
+				renderItemDescription={ ( { item } ) => (
+					<Text variant="muted" truncate numberOfLines={ 1 }>
+						{ getSiteDisplayUrl( item ) }
+					</Text>
+				) }
+				open={ isSwitcherOpen }
+				onToggle={ ( willOpen: boolean ) => {
+					setIsSwitcherOpen( willOpen );
+					recordTracksEvent( 'calypso_dashboard_site_switcher_toggle', {
+						is_open: willOpen,
+					} );
+				} }
+				onItemClick={ () => {
+					recordTracksEvent( 'calypso_dashboard_site_switcher_item_click' );
+				} }
+				renderToggle={ ( { isOpen, onToggle } ) => (
+					<Button
+						className="site-switcher__toggle"
+						variant="tertiary"
+						onClick={ onToggle }
+						onKeyDown={ ( event: React.KeyboardEvent ) => {
+							if ( ! isOpen && event.code === 'ArrowDown' ) {
+								event.preventDefault();
+								onToggle();
+							}
+						} }
+						aria-haspopup="true"
+						aria-expanded={ isOpen }
+						label={ __( 'Switch site' ) }
+						icon={ chevronUpDown }
+						size="small"
+					/>
+				) }
+			/>
+		</HStack>
+	);
+};

--- a/client/dashboard/sites/site-switcher-v2/index.tsx
+++ b/client/dashboard/sites/site-switcher-v2/index.tsx
@@ -1,0 +1,51 @@
+import {
+	__experimentalHStack as HStack,
+	MenuGroup,
+	MenuItem,
+	Icon,
+	Modal,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { plus } from '@wordpress/icons';
+import { useState } from 'react';
+import { useAnalytics } from '../../app/analytics';
+import AddNewSite from '../add-new-site';
+import { SiteSwitcherBase } from './base';
+
+const SiteSwitcher = () => {
+	const { recordTracksEvent } = useAnalytics();
+	const [ isAddSiteModalOpen, setIsAddSiteModalOpen ] = useState( false );
+
+	return (
+		<>
+			<SiteSwitcherBase>
+				{ ( { onClose } ) => (
+					<MenuGroup>
+						<MenuItem
+							onClick={ () => {
+								recordTracksEvent( 'calypso_dashboard_site_switcher_add_new_site_click' );
+								onClose();
+								setIsAddSiteModalOpen( true );
+							} }
+						>
+							<HStack justify="flex-start" alignment="center">
+								<Icon icon={ plus } />
+								<span>{ __( 'Add new site' ) }</span>
+							</HStack>
+						</MenuItem>
+					</MenuGroup>
+				) }
+			</SiteSwitcherBase>
+			{ isAddSiteModalOpen && (
+				<Modal
+					title={ __( 'Add new site' ) }
+					onRequestClose={ () => setIsAddSiteModalOpen( false ) }
+				>
+					<AddNewSite context="sites-dashboard" />
+				</Modal>
+			) }
+		</>
+	);
+};
+
+export default SiteSwitcher;


### PR DESCRIPTION
## Proposed Changes

- Add site switcher v2 component for the sidebar layout
- Update switcher component
- Wire up in site-sidebar and app configs

<img width="269" height="633" alt="image" src="https://github.com/user-attachments/assets/ef3fa0e8-f5f1-4c85-840e-c095f090f663" />

## Why are these changes being made?

The sidebar needs a dedicated site switcher variant that works within the sidebar's Navigator-based layout.

## Testing Instructions

1. Verify site switcher renders correctly in the sidebar
2. Test switching between sites

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)