### PR TITLE
Configure session recording in PostHog package

### DIFF
--- a/client/dashboard/app-ciab/index.tsx
+++ b/client/dashboard/app-ciab/index.tsx
@@ -6,8 +6,8 @@ import {
 	domainsQuery,
 } from '@automattic/api-queries';
 /* eslint-enable no-restricted-imports */
-import config from '@automattic/calypso-config';
 import boot from '../app/boot';
+import { getPostHogConfig } from './posthog';
 import './translations';
 import type {
 	FetchSitesOptions,
@@ -18,7 +18,7 @@ import './style.scss';
 
 boot( {
 	name: 'CIAB',
-	posthog: config.isEnabled( 'posthog-tracking' ) ? config( 'ciab_posthog_api_key' ) : undefined,
+	posthog: getPostHogConfig(),
 	basePath: '/',
 	mainRoute: '/sites',
 	Logo: null,

--- a/client/dashboard/app-ciab/posthog.ts
+++ b/client/dashboard/app-ciab/posthog.ts
@@ -28,6 +28,7 @@ export function getPostHogConfig(): AppConfig[ 'posthog' ] {
 	return {
 		apiKey: config( 'ciab_posthog_api_key' ) as string,
 		overrides: {
+			debug: config( 'env' ) === 'development',
 			session_recording: {
 				maskTextFn: maskText,
 				blockSelector: BLOCK_SELECTOR,

--- a/client/dashboard/app-ciab/posthog.ts
+++ b/client/dashboard/app-ciab/posthog.ts
@@ -28,7 +28,6 @@ export function getPostHogConfig(): AppConfig[ 'posthog' ] {
 	return {
 		apiKey: config( 'ciab_posthog_api_key' ) as string,
 		overrides: {
-			debug: config( 'env' ) === 'development',
 			session_recording: {
 				maskTextFn: maskText,
 				blockSelector: BLOCK_SELECTOR,

--- a/client/dashboard/app-ciab/posthog.ts
+++ b/client/dashboard/app-ciab/posthog.ts
@@ -1,0 +1,51 @@
+/**
+ * PostHog configuration for the CIAB dashboard.
+ */
+
+import config from '@automattic/calypso-config';
+import type { AppConfig } from '../app/context';
+
+/** CSS selectors for elements whose text is safe to show. */
+const UNMASK_SELECTORS = [
+	'.dashboard-header-bar',
+	'.dashboard-section-header',
+	'.environment-badge',
+	'h1',
+	'h2',
+	'h3',
+	'h4',
+	'h5',
+	'h6',
+	'label',
+	'th',
+	'button',
+];
+
+/** CSS selector for elements to block entirely from session recordings. */
+const BLOCK_SELECTOR =
+	'img[src*="gravatar.com"], img[src*="githubusercontent.com"], .site-activity-logs__actor-icon-avatar';
+
+function maskText( text: string, element?: HTMLElement ): string {
+	if ( element ) {
+		for ( const selector of UNMASK_SELECTORS ) {
+			if ( element.closest( selector ) ) {
+				return text;
+			}
+		}
+	}
+	return '*'.repeat( text.trim().length );
+}
+
+export function getPostHogConfig(): AppConfig[ 'posthog' ] {
+	if ( ! config.isEnabled( 'posthog-tracking' ) ) {
+		return undefined;
+	}
+
+	return {
+		apiKey: config( 'ciab_posthog_api_key' ) as string,
+		masking: {
+			maskTextFn: maskText,
+			blockSelector: BLOCK_SELECTOR,
+		},
+	};
+}

--- a/client/dashboard/app-ciab/posthog.ts
+++ b/client/dashboard/app-ciab/posthog.ts
@@ -17,7 +17,7 @@ function maskText( text: string, element?: HTMLElement ): string {
 	if ( element?.closest( UNMASK_SELECTOR ) ) {
 		return text;
 	}
-	return '*'.repeat( text.trim().length );
+	return '*'.repeat( text.length );
 }
 
 export function getPostHogConfig(): AppConfig[ 'posthog' ] {

--- a/client/dashboard/app-ciab/posthog.ts
+++ b/client/dashboard/app-ciab/posthog.ts
@@ -5,33 +5,17 @@
 import config from '@automattic/calypso-config';
 import type { AppConfig } from '../app/context';
 
-/** CSS selectors for elements whose text is safe to show. */
-const UNMASK_SELECTORS = [
-	'.dashboard-header-bar',
-	'.dashboard-section-header',
-	'.environment-badge',
-	'h1',
-	'h2',
-	'h3',
-	'h4',
-	'h5',
-	'h6',
-	'label',
-	'th',
-	'button',
-];
+/** CSS selector for elements whose text is safe to show. */
+const UNMASK_SELECTOR =
+	'.dashboard-header-bar, .dashboard-section-header, .environment-badge, h1, h2, h3, h4, h5, h6, label, th, button';
 
 /** CSS selector for elements to block entirely from session recordings. */
 const BLOCK_SELECTOR =
 	'img[src*="gravatar.com"], img[src*="githubusercontent.com"], .site-activity-logs__actor-icon-avatar';
 
 function maskText( text: string, element?: HTMLElement ): string {
-	if ( element ) {
-		for ( const selector of UNMASK_SELECTORS ) {
-			if ( element.closest( selector ) ) {
-				return text;
-			}
-		}
+	if ( element?.closest( UNMASK_SELECTOR ) ) {
+		return text;
 	}
 	return '*'.repeat( text.trim().length );
 }
@@ -43,9 +27,11 @@ export function getPostHogConfig(): AppConfig[ 'posthog' ] {
 
 	return {
 		apiKey: config( 'ciab_posthog_api_key' ) as string,
-		masking: {
-			maskTextFn: maskText,
-			blockSelector: BLOCK_SELECTOR,
+		overrides: {
+			session_recording: {
+				maskTextFn: maskText,
+				blockSelector: BLOCK_SELECTOR,
+			},
 		},
 	};
 }

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -47,7 +47,13 @@ export type AppConfig = {
 		commandPalette: boolean;
 		domainOnlySites: boolean;
 	};
-	posthog?: string;
+	posthog?: {
+		apiKey: string;
+		masking?: {
+			maskTextFn?: ( text: string, element?: HTMLElement ) => string;
+			blockSelector?: string;
+		};
+	};
 	optIn: boolean;
 	components: Record< string, () => Promise< { default: React.FC } > >;
 	queries: {

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -12,6 +12,7 @@ import type {
 	FetchPaginatedSitesOptions,
 	FetchDashboardSiteFiltersParams,
 } from '@automattic/api-core';
+import type { PostHogOverrides } from '@automattic/posthog';
 
 export type MeBillingSupports = {
 	monetizeSubscriptions: boolean;
@@ -49,10 +50,7 @@ export type AppConfig = {
 	};
 	posthog?: {
 		apiKey: string;
-		masking?: {
-			maskTextFn?: ( text: string, element?: HTMLElement ) => string;
-			blockSelector?: string;
-		};
+		overrides?: PostHogOverrides;
 	};
 	optIn: boolean;
 	components: Record< string, () => Promise< { default: React.FC } > >;

--- a/client/dashboard/app/layout.tsx
+++ b/client/dashboard/app/layout.tsx
@@ -37,7 +37,7 @@ function AnalyticsProviderWithClient( {
 	useEffect( () => {
 		if ( posthog ) {
 			import( '@automattic/posthog' ).then( ( { init } ) =>
-				init( posthog, user ? { ID: user.ID } : undefined )
+				init( posthog.apiKey, user ? { ID: user.ID } : undefined, posthog.masking )
 			);
 		}
 	}, [ user, posthog ] );

--- a/client/dashboard/app/layout.tsx
+++ b/client/dashboard/app/layout.tsx
@@ -37,7 +37,7 @@ function AnalyticsProviderWithClient( {
 	useEffect( () => {
 		if ( posthog ) {
 			import( '@automattic/posthog' ).then( ( { init } ) =>
-				init( posthog.apiKey, user ? { ID: user.ID } : undefined, posthog.masking )
+				init( posthog.apiKey, user ? { ID: user.ID } : undefined, posthog.overrides )
 			);
 		}
 	}, [ user, posthog ] );

--- a/client/landing/stepper/declarative-flow/flows/ai-site-builder-spec/ai-site-builder-spec.ts
+++ b/client/landing/stepper/declarative-flow/flows/ai-site-builder-spec/ai-site-builder-spec.ts
@@ -45,7 +45,10 @@ const aiSiteBuilderSpec: FlowV2< typeof initialize > = {
 				initPostHog(
 					config( 'ciab_posthog_api_key' ),
 					currentUser ? { ID: currentUser.ID } : undefined,
-					{ session_recording: { maskAllInputs: false, maskTextSelector: '' } }
+					{
+						debug: config( 'env' ) === 'development',
+						session_recording: { maskAllInputs: false, maskTextSelector: '' },
+					}
 				);
 			}
 		}, [ source, currentUser ] );

--- a/client/landing/stepper/declarative-flow/flows/ai-site-builder-spec/ai-site-builder-spec.ts
+++ b/client/landing/stepper/declarative-flow/flows/ai-site-builder-spec/ai-site-builder-spec.ts
@@ -44,7 +44,8 @@ const aiSiteBuilderSpec: FlowV2< typeof initialize > = {
 			if ( source?.startsWith( 'ciab-' ) && config.isEnabled( 'posthog-tracking' ) ) {
 				initPostHog(
 					config( 'ciab_posthog_api_key' ),
-					currentUser ? { ID: currentUser.ID } : undefined
+					currentUser ? { ID: currentUser.ID } : undefined,
+					{ session_recording: { maskAllInputs: false, maskTextSelector: '' } }
 				);
 			}
 		}, [ source, currentUser ] );

--- a/client/landing/stepper/declarative-flow/flows/ai-site-builder-spec/ai-site-builder-spec.ts
+++ b/client/landing/stepper/declarative-flow/flows/ai-site-builder-spec/ai-site-builder-spec.ts
@@ -46,7 +46,6 @@ const aiSiteBuilderSpec: FlowV2< typeof initialize > = {
 					config( 'ciab_posthog_api_key' ),
 					currentUser ? { ID: currentUser.ID } : undefined,
 					{
-						debug: config( 'env' ) === 'development',
 						session_recording: { maskAllInputs: false, maskTextSelector: '' },
 					}
 				);

--- a/packages/posthog/README.md
+++ b/packages/posthog/README.md
@@ -16,6 +16,23 @@ init( 'your-api-key', {
 
 The `init` function is safe to call multiple times; it will only initialize PostHog once.
 
+### Session recording overrides
+
+Pass an optional third argument to customize session recording masking. By default, all inputs are masked and all text is replaced via `maskTextSelector: '*'`.
+
+```js
+import { init } from '@automattic/posthog';
+
+init( 'your-api-key', { ID: 12345 }, {
+	session_recording: {
+		maskAllInputs: true,
+		maskTextSelector: '*',
+		maskTextFn: ( text, element ) => '*'.repeat( text.length ),
+		blockSelector: 'img[src*="gravatar.com"]',
+	},
+} );
+```
+
 ### Retrieving the session ID
 
 ```js

--- a/packages/posthog/README.md
+++ b/packages/posthog/README.md
@@ -24,6 +24,7 @@ Pass an optional third argument to customize session recording masking. By defau
 import { init } from '@automattic/posthog';
 
 init( 'your-api-key', { ID: 12345 }, {
+	debug: true, // enables PostHog console logging and exposes config on window.__posthogConfig
 	session_recording: {
 		maskAllInputs: true,
 		maskTextSelector: '*',

--- a/packages/posthog/src/index.ts
+++ b/packages/posthog/src/index.ts
@@ -9,6 +9,13 @@ export interface PostHogUser {
 	username?: string;
 }
 
+export interface PostHogMasking {
+	maskTextFn?: ( text: string, element?: HTMLElement ) => string;
+	blockSelector?: string;
+}
+
+const defaultMaskTextFn = ( text: string ) => '*'.repeat( text.trim().length );
+
 export function getSessionId(): string | undefined {
 	return posthog.get_session_id?.();
 }
@@ -18,7 +25,7 @@ export function reset() {
 	initialized = false;
 }
 
-export function init( apiKey: string, user?: PostHogUser ) {
+export function init( apiKey: string, user?: PostHogUser, masking?: PostHogMasking ) {
 	if ( initialized || ! apiKey ) {
 		return;
 	}
@@ -30,12 +37,27 @@ export function init( apiKey: string, user?: PostHogUser ) {
 
 	initialized = true;
 
+	const maskTextFn = masking?.maskTextFn ?? defaultMaskTextFn;
+
+	// Expose masking config for debugging in the browser console.
+	// Usage: __posthogMasking.maskTextFn(text, element)
+	( window as Record< string, unknown > ).__posthogMasking = {
+		maskTextFn,
+		blockSelector: masking?.blockSelector,
+	};
+
 	posthog.init( apiKey, {
 		api_host: 'https://us.i.posthog.com',
 		autocapture: true,
 		defaults: '2026-01-30',
 		capture_pageleave: true,
 		debug: false,
+		session_recording: {
+			maskAllInputs: true,
+			maskTextSelector: '*',
+			maskTextFn,
+			...( masking?.blockSelector && { blockSelector: masking.blockSelector } ),
+		},
 		...( user?.ID && {
 			bootstrap: {
 				distinctID: String( user.ID ),

--- a/packages/posthog/src/index.ts
+++ b/packages/posthog/src/index.ts
@@ -9,12 +9,14 @@ export interface PostHogUser {
 	username?: string;
 }
 
-export interface PostHogMasking {
-	maskTextFn?: ( text: string, element?: HTMLElement ) => string;
-	blockSelector?: string;
+export interface PostHogOverrides {
+	session_recording?: {
+		maskAllInputs?: boolean;
+		maskTextSelector?: string;
+		maskTextFn?: ( text: string, element?: HTMLElement ) => string;
+		blockSelector?: string;
+	};
 }
-
-const defaultMaskTextFn = ( text: string ) => '*'.repeat( text.trim().length );
 
 export function getSessionId(): string | undefined {
 	return posthog.get_session_id?.();
@@ -25,7 +27,7 @@ export function reset() {
 	initialized = false;
 }
 
-export function init( apiKey: string, user?: PostHogUser, masking?: PostHogMasking ) {
+export function init( apiKey: string, user?: PostHogUser, overrides?: PostHogOverrides ) {
 	if ( initialized || ! apiKey ) {
 		return;
 	}
@@ -37,13 +39,12 @@ export function init( apiKey: string, user?: PostHogUser, masking?: PostHogMaski
 
 	initialized = true;
 
-	const maskTextFn = masking?.maskTextFn ?? defaultMaskTextFn;
+	const sessionRecording = overrides?.session_recording;
 
 	// Expose masking config for debugging in the browser console.
-	// Usage: __posthogMasking.maskTextFn(text, element)
 	( window as unknown as Record< string, unknown > ).__posthogMasking = {
-		maskTextFn,
-		blockSelector: masking?.blockSelector,
+		maskTextFn: sessionRecording?.maskTextFn,
+		blockSelector: sessionRecording?.blockSelector,
 	};
 
 	posthog.init( apiKey, {
@@ -53,10 +54,12 @@ export function init( apiKey: string, user?: PostHogUser, masking?: PostHogMaski
 		capture_pageleave: true,
 		debug: false,
 		session_recording: {
-			maskAllInputs: true,
-			maskTextSelector: '*',
-			maskTextFn,
-			...( masking?.blockSelector && { blockSelector: masking.blockSelector } ),
+			maskAllInputs: sessionRecording?.maskAllInputs ?? true,
+			maskTextSelector: sessionRecording?.maskTextSelector ?? '*',
+			...( sessionRecording?.maskTextFn && { maskTextFn: sessionRecording.maskTextFn } ),
+			...( sessionRecording?.blockSelector && {
+				blockSelector: sessionRecording.blockSelector,
+			} ),
 		},
 		...( user?.ID && {
 			bootstrap: {

--- a/packages/posthog/src/index.ts
+++ b/packages/posthog/src/index.ts
@@ -41,7 +41,7 @@ export function init( apiKey: string, user?: PostHogUser, masking?: PostHogMaski
 
 	// Expose masking config for debugging in the browser console.
 	// Usage: __posthogMasking.maskTextFn(text, element)
-	( window as Record< string, unknown > ).__posthogMasking = {
+	( window as unknown as Record< string, unknown > ).__posthogMasking = {
 		maskTextFn,
 		blockSelector: masking?.blockSelector,
 	};

--- a/packages/posthog/src/index.ts
+++ b/packages/posthog/src/index.ts
@@ -45,7 +45,7 @@ export function init( apiKey: string, user?: PostHogUser, overrides?: PostHogOve
 	const posthogConfig = {
 		api_host: 'https://us.i.posthog.com',
 		autocapture: true,
-		defaults: '2026-01-30',
+		defaults: '2026-01-30' as const,
 		capture_pageleave: true,
 		debug: overrides?.debug ?? false,
 		session_recording: {

--- a/packages/posthog/src/index.ts
+++ b/packages/posthog/src/index.ts
@@ -40,8 +40,6 @@ export function init( apiKey: string, user?: PostHogUser, overrides?: PostHogOve
 
 	initialized = true;
 
-	const sessionRecording = overrides?.session_recording;
-
 	const posthogConfig = {
 		api_host: 'https://us.i.posthog.com',
 		autocapture: true,
@@ -49,12 +47,9 @@ export function init( apiKey: string, user?: PostHogUser, overrides?: PostHogOve
 		capture_pageleave: true,
 		debug: overrides?.debug ?? false,
 		session_recording: {
-			maskAllInputs: sessionRecording?.maskAllInputs ?? true,
-			maskTextSelector: sessionRecording?.maskTextSelector ?? '*',
-			...( sessionRecording?.maskTextFn && { maskTextFn: sessionRecording.maskTextFn } ),
-			...( sessionRecording?.blockSelector && {
-				blockSelector: sessionRecording.blockSelector,
-			} ),
+			maskAllInputs: true,
+			maskTextSelector: '*',
+			...overrides?.session_recording,
 		},
 		...( user?.ID && {
 			bootstrap: {
@@ -64,7 +59,9 @@ export function init( apiKey: string, user?: PostHogUser, overrides?: PostHogOve
 		} ),
 	};
 
-	if ( overrides?.debug ) {
+	const urlDebug =
+		new URLSearchParams( window.location.search ).get( '__posthog_debug' ) === 'true';
+	if ( overrides?.debug || urlDebug ) {
 		( window as unknown as Record< string, unknown > ).__posthogConfig = posthogConfig;
 	}
 

--- a/packages/posthog/src/index.ts
+++ b/packages/posthog/src/index.ts
@@ -10,6 +10,7 @@ export interface PostHogUser {
 }
 
 export interface PostHogOverrides {
+	debug?: boolean;
 	session_recording?: {
 		maskAllInputs?: boolean;
 		maskTextSelector?: string;
@@ -41,18 +42,12 @@ export function init( apiKey: string, user?: PostHogUser, overrides?: PostHogOve
 
 	const sessionRecording = overrides?.session_recording;
 
-	// Expose masking config for debugging in the browser console.
-	( window as unknown as Record< string, unknown > ).__posthogMasking = {
-		maskTextFn: sessionRecording?.maskTextFn,
-		blockSelector: sessionRecording?.blockSelector,
-	};
-
-	posthog.init( apiKey, {
+	const posthogConfig = {
 		api_host: 'https://us.i.posthog.com',
 		autocapture: true,
 		defaults: '2026-01-30',
 		capture_pageleave: true,
-		debug: false,
+		debug: overrides?.debug ?? false,
 		session_recording: {
 			maskAllInputs: sessionRecording?.maskAllInputs ?? true,
 			maskTextSelector: sessionRecording?.maskTextSelector ?? '*',
@@ -67,7 +62,13 @@ export function init( apiKey: string, user?: PostHogUser, overrides?: PostHogOve
 				isIdentifiedID: true,
 			},
 		} ),
-	} );
+	};
+
+	if ( overrides?.debug ) {
+		( window as unknown as Record< string, unknown > ).__posthogConfig = posthogConfig;
+	}
+
+	posthog.init( apiKey, posthogConfig );
 
 	if ( user?.ID ) {
 		posthog.identify( String( user.ID ), {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [WOOPRD-2313](https://linear.app/a8c/issue/WOOPRD-2313/configure-pii-masking-for-posthog-ciab-implementation).

## Proposed Changes

Configures PostHog session recording privacy masking for the CIAB dashboard, with all inputs and most text (except some structural UI chrome) masked by default. Avatar images are also blocked entirely.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Session recordings can capture PII (names, emails, addresses) rendered across MSD pages. Masking text and inputs client-side ensures this data is never transmitted to PostHog while still allowing us to observe user behavior through the unmasked app chrome.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run `yarn start-dashboard` and open `my.woo.localhost:3000/sites?flags=posthog-tracking` so that PostHog is enabled.
   Depending on your location (GDPR), it might be necessary to ensure the cookies are correctly set so the `advertising` bucket is not opted-out. Run this in the JS console and reload:
   ```
   document.cookie = 'sensitive_pixel_options=' + JSON.stringify({ok:true,buckets:{essential:true,analytics:true,advertising:true}}) + '; path=/';
   ```
1. Check for requests to `posthog.com` in the Network tab of dev tools to confirm that PostHog is working.
1. To preview what masking looks like, paste this in the console:
   ```js
   (function() {
       const { maskTextFn } = window.__posthogConfig.session_recording;
       const w = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
       while (w.nextNode()) {
         const n = w.currentNode, t = n.textContent?.trim(), p = n.parentElement;
         if (t && p) {
           const masked = maskTextFn(t, p);
           if (masked !== t) n.textContent = masked;
         }
       }
       document.querySelectorAll('input,textarea').forEach(i => { if (i.value) i.value = '*'.repeat(i.value.length); });
     })();
     ```

   This isn't an exact match of what PostHog does, but given the same callbacks and selectors are involved, it should make it clear what text is masked.
1. Navigate to some sections of the dashboard (don't forget the `?flags=posthog-tracking` query arg and confirm that sensitive text is masked.
   <img width="716" height="598" alt="Screenshot 2026-03-23 at 22 53 38" src="https://github.com/user-attachments/assets/c86aadac-0463-4a91-b792-396c87e8c1eb" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
