### PR TITLE
Fix line item price showing wrong amount with stacked cost overrides

### DIFF
--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -20,6 +20,7 @@ import {
 	doesIntroductoryOfferHavePriceIncrease,
 	filterCostOverridesForLineItem,
 	getLabel,
+	getSubtotalWithoutDiscountsForProduct,
 	isOverrideCodeIntroductoryOffer,
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
@@ -381,23 +382,6 @@ const WPCheckoutCheckIcon = styled( CheckIcon )`
 	}
 `;
 
-/**
- * Walk the cost overrides chain and return the `old_subtotal_integer` of the
- * first override that reduces the price. This gives us the "peak" price after
- * any price-increasing overrides (e.g. premium domain intro offer) but before
- * any discounts (e.g. sale coupon).
- *
- * Falls back to `item_subtotal_integer` when no price-reducing override exists.
- */
-function getPriceBeforeDiscountsFromOverrides( product: ResponseCartProduct ): number {
-	for ( const override of product.cost_overrides ?? [] ) {
-		if ( override.new_subtotal_integer < override.old_subtotal_integer ) {
-			return override.old_subtotal_integer;
-		}
-	}
-	return product.item_subtotal_integer;
-}
-
 function SingleProductAndCostOverridesList( { product }: { product: ResponseCartProduct } ) {
 	const translate = useTranslate();
 	const costOverridesList = filterCostOverridesForLineItem( product, translate );
@@ -420,7 +404,7 @@ function SingleProductAndCostOverridesList( { product }: { product: ResponseCart
 	// with a price-increasing intro offer followed by a sale coupon (e.g.
 	// premium domains: $80 → $1,100 → $275), this gives us the peak price
 	// ($1,100) to use as the crossed-out "full price".
-	const priceBeforeDiscountsInteger = getPriceBeforeDiscountsFromOverrides( product );
+	const priceBeforeDiscountsInteger = getSubtotalWithoutDiscountsForProduct( product );
 	const hasStackedPriceIncrease =
 		! isDiscounted &&
 		priceBeforeDiscountsInteger > originalAmountInteger &&

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -381,6 +381,23 @@ const WPCheckoutCheckIcon = styled( CheckIcon )`
 	}
 `;
 
+/**
+ * Walk the cost overrides chain and return the `old_subtotal_integer` of the
+ * first override that reduces the price. This gives us the "peak" price after
+ * any price-increasing overrides (e.g. premium domain intro offer) but before
+ * any discounts (e.g. sale coupon).
+ *
+ * Falls back to `item_subtotal_integer` when no price-reducing override exists.
+ */
+function getPriceBeforeDiscountsFromOverrides( product: ResponseCartProduct ): number {
+	for ( const override of product.cost_overrides ?? [] ) {
+		if ( override.new_subtotal_integer < override.old_subtotal_integer ) {
+			return override.old_subtotal_integer;
+		}
+	}
+	return product.item_subtotal_integer;
+}
+
 function SingleProductAndCostOverridesList( { product }: { product: ResponseCartProduct } ) {
 	const translate = useTranslate();
 	const costOverridesList = filterCostOverridesForLineItem( product, translate );
@@ -399,12 +416,21 @@ function SingleProductAndCostOverridesList( { product }: { product: ResponseCart
 		itemSubtotalInteger < originalAmountInteger && originalAmountDisplay
 	);
 
+	// Find the price before any price-reducing cost overrides. For products
+	// with a price-increasing intro offer followed by a sale coupon (e.g.
+	// premium domains: $80 → $1,100 → $275), this gives us the peak price
+	// ($1,100) to use as the crossed-out "full price".
+	const priceBeforeDiscountsInteger = getPriceBeforeDiscountsFromOverrides( product );
+	const hasStackedPriceIncrease =
+		! isDiscounted &&
+		priceBeforeDiscountsInteger > originalAmountInteger &&
+		product.item_subtotal_integer < priceBeforeDiscountsInteger;
+
 	// For WPCOM plans always show the renewal amount for legal reasons.
 	// Introductory offer discount would be shown in LineItemCostOverrides.
-	// For other products (e.g. domains), show the pre-coupon subtotal so
-	// that stacked cost overrides (price-increasing intro offer + sale
-	// coupon) display the correct amount instead of the renewal price.
 	let actualAmountDisplay;
+	let crossedOutAmountDisplay: string | undefined;
+
 	if ( isWpComPlan( product.product_slug ) ) {
 		actualAmountDisplay = formatCurrency(
 			product.item_original_subtotal_integer,
@@ -414,11 +440,25 @@ function SingleProductAndCostOverridesList( { product }: { product: ResponseCart
 				stripZeros: true,
 			}
 		);
+		crossedOutAmountDisplay = isDiscounted ? originalAmountDisplay : undefined;
+	} else if ( hasStackedPriceIncrease ) {
+		// Stacked cost overrides: a price-increasing intro offer raised the
+		// price above the original, then a sale coupon discounted it. Show
+		// the pre-discount price crossed out with the final price.
+		actualAmountDisplay = formatCurrency( product.item_subtotal_integer, product.currency, {
+			isSmallestUnit: true,
+			stripZeros: true,
+		} );
+		crossedOutAmountDisplay = formatCurrency( priceBeforeDiscountsInteger, product.currency, {
+			isSmallestUnit: true,
+			stripZeros: true,
+		} );
 	} else {
 		actualAmountDisplay = formatCurrency( itemSubtotalInteger, product.currency, {
 			isSmallestUnit: true,
 			stripZeros: true,
 		} );
+		crossedOutAmountDisplay = isDiscounted ? originalAmountDisplay : undefined;
 	}
 
 	return (
@@ -428,7 +468,7 @@ function SingleProductAndCostOverridesList( { product }: { product: ResponseCart
 				<span className="cost-overrides-list-product__title">{ label }</span>
 				<SimplifiedLineItemPrice
 					actualAmount={ actualAmountDisplay }
-					crossedOutAmount={ isDiscounted ? originalAmountDisplay : undefined }
+					crossedOutAmount={ crossedOutAmountDisplay }
 				/>
 			</ProductTitleAreaForCostOverridesList>
 			<LineItemCostOverrides product={ product } costOverridesList={ costOverridesList } />

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -382,6 +382,48 @@ const WPCheckoutCheckIcon = styled( CheckIcon )`
 	}
 `;
 
+function getLineItemPriceDisplay(
+	product: ResponseCartProduct,
+	monthlyPrices: Record< string, number >
+): { actualAmountDisplay: string; crossedOutAmountDisplay: string | undefined } {
+	const fmt = ( amount: number ) =>
+		formatCurrency( amount, product.currency, { isSmallestUnit: true, stripZeros: true } );
+	const originalAmountInteger = getOriginalAmountIntegerForDisplay( product, monthlyPrices );
+	const itemSubtotalInteger =
+		product.item_subtotal_integer + ( product.coupon_savings_integer ?? 0 );
+	const isDiscounted = itemSubtotalInteger < originalAmountInteger;
+
+	// For WPCOM plans always show the renewal amount for legal reasons.
+	// Introductory offer discount would be shown in LineItemCostOverrides.
+	if ( isWpComPlan( product.product_slug ) ) {
+		return {
+			actualAmountDisplay: fmt( product.item_original_subtotal_integer ),
+			crossedOutAmountDisplay: isDiscounted ? fmt( originalAmountInteger ) : undefined,
+		};
+	}
+
+	// For products with a price-increasing intro offer followed by a sale
+	// coupon (e.g. premium domains: $80 → $1,100 → $275), show the peak
+	// price crossed out with the final price.
+	const priceBeforeDiscountsInteger = getSubtotalWithoutDiscountsForProduct( product );
+	if (
+		priceBeforeDiscountsInteger > originalAmountInteger &&
+		product.item_subtotal_integer < priceBeforeDiscountsInteger
+	) {
+		return {
+			actualAmountDisplay: fmt( product.item_subtotal_integer ),
+			crossedOutAmountDisplay: fmt( priceBeforeDiscountsInteger ),
+		};
+	}
+
+	// Default: show the pre-coupon subtotal, with the original crossed out
+	// when the product is discounted.
+	return {
+		actualAmountDisplay: fmt( itemSubtotalInteger ),
+		crossedOutAmountDisplay: isDiscounted ? fmt( originalAmountInteger ) : undefined,
+	};
+}
+
 function SingleProductAndCostOverridesList( { product }: { product: ResponseCartProduct } ) {
 	const translate = useTranslate();
 	const costOverridesList = filterCostOverridesForLineItem( product, translate );
@@ -389,61 +431,10 @@ function SingleProductAndCostOverridesList( { product }: { product: ResponseCart
 
 	const monthlyPrices = useEquivalentMonthlyTotals( [ product ] );
 
-	const originalAmountInteger = getOriginalAmountIntegerForDisplay( product, monthlyPrices );
-	const originalAmountDisplay = formatCurrency( originalAmountInteger, product.currency, {
-		isSmallestUnit: true,
-		stripZeros: true,
-	} );
-	const itemSubtotalInteger =
-		product.item_subtotal_integer + ( product.coupon_savings_integer ?? 0 );
-	const isDiscounted = Boolean(
-		itemSubtotalInteger < originalAmountInteger && originalAmountDisplay
+	const { actualAmountDisplay, crossedOutAmountDisplay } = getLineItemPriceDisplay(
+		product,
+		monthlyPrices
 	);
-
-	// Find the price before any price-reducing cost overrides. For products
-	// with a price-increasing intro offer followed by a sale coupon (e.g.
-	// premium domains: $80 → $1,100 → $275), this gives us the peak price
-	// ($1,100) to use as the crossed-out "full price".
-	const priceBeforeDiscountsInteger = getSubtotalWithoutDiscountsForProduct( product );
-	const hasStackedPriceIncrease =
-		! isDiscounted &&
-		priceBeforeDiscountsInteger > originalAmountInteger &&
-		product.item_subtotal_integer < priceBeforeDiscountsInteger;
-
-	// For WPCOM plans always show the renewal amount for legal reasons.
-	// Introductory offer discount would be shown in LineItemCostOverrides.
-	let actualAmountDisplay;
-	let crossedOutAmountDisplay: string | undefined;
-
-	if ( isWpComPlan( product.product_slug ) ) {
-		actualAmountDisplay = formatCurrency(
-			product.item_original_subtotal_integer,
-			product.currency,
-			{
-				isSmallestUnit: true,
-				stripZeros: true,
-			}
-		);
-		crossedOutAmountDisplay = isDiscounted ? originalAmountDisplay : undefined;
-	} else if ( hasStackedPriceIncrease ) {
-		// Stacked cost overrides: a price-increasing intro offer raised the
-		// price above the original, then a sale coupon discounted it. Show
-		// the pre-discount price crossed out with the final price.
-		actualAmountDisplay = formatCurrency( product.item_subtotal_integer, product.currency, {
-			isSmallestUnit: true,
-			stripZeros: true,
-		} );
-		crossedOutAmountDisplay = formatCurrency( priceBeforeDiscountsInteger, product.currency, {
-			isSmallestUnit: true,
-			stripZeros: true,
-		} );
-	} else {
-		actualAmountDisplay = formatCurrency( itemSubtotalInteger, product.currency, {
-			isSmallestUnit: true,
-			stripZeros: true,
-		} );
-		crossedOutAmountDisplay = isDiscounted ? originalAmountDisplay : undefined;
-	}
 
 	return (
 		<SimplifiedSingleProductAndCostOverridesListWrapper>

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -393,15 +393,6 @@ function getLineItemPriceDisplay(
 		product.item_subtotal_integer + ( product.coupon_savings_integer ?? 0 );
 	const isDiscounted = itemSubtotalInteger < originalAmountInteger;
 
-	// For WPCOM plans always show the renewal amount for legal reasons.
-	// Introductory offer discount would be shown in LineItemCostOverrides.
-	if ( isWpComPlan( product.product_slug ) ) {
-		return {
-			actualAmountDisplay: fmt( product.item_original_subtotal_integer ),
-			crossedOutAmountDisplay: isDiscounted ? fmt( originalAmountInteger ) : undefined,
-		};
-	}
-
 	// For products with a price-increasing intro offer followed by a sale
 	// coupon (e.g. premium domains: $80 → $1,100 → $275), show the peak
 	// price crossed out with the final price.

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -401,8 +401,11 @@ function SingleProductAndCostOverridesList( { product }: { product: ResponseCart
 
 	// For WPCOM plans always show the renewal amount for legal reasons.
 	// Introductory offer discount would be shown in LineItemCostOverrides.
+	// For other products (e.g. domains), show the pre-coupon subtotal so
+	// that stacked cost overrides (price-increasing intro offer + sale
+	// coupon) display the correct amount instead of the renewal price.
 	let actualAmountDisplay;
-	if ( ! isDiscounted || isWpComPlan( product.product_slug ) ) {
+	if ( isWpComPlan( product.product_slug ) ) {
 		actualAmountDisplay = formatCurrency(
 			product.item_original_subtotal_integer,
 			product.currency,

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -41,6 +41,7 @@ import { joinClasses } from './join-classes';
 import { LoadingCard, LoadingCopy, LoadingRow } from './loading-card';
 import { getPartnerCoupon } from './partner-coupon';
 import IonosLogo from './partner-logo-ionos';
+import { getSubtotalWithoutDiscountsForProduct } from './transformations';
 import type { LineItemType } from './types';
 import type {
 	GSuiteProductUser,
@@ -1481,6 +1482,21 @@ function CheckoutLineItem( {
 		itemSubtotalInteger < originalAmountInteger && originalAmountDisplay
 	);
 
+	// For products with stacked cost overrides (e.g. premium domains with a
+	// price-increasing intro offer + sale coupon: $80 → $1,100 → $275), show
+	// the pre-discount price ($1,100) crossed out next to the final price.
+	const priceBeforeDiscountsInteger = getSubtotalWithoutDiscountsForProduct( product );
+	const hasStackedPriceIncrease =
+		! isDiscounted &&
+		priceBeforeDiscountsInteger > originalAmountInteger &&
+		itemSubtotalInteger < priceBeforeDiscountsInteger;
+	const stackedCrossedOutDisplay = hasStackedPriceIncrease
+		? formatCurrency( priceBeforeDiscountsInteger, product.currency, {
+				isSmallestUnit: true,
+				stripZeros: true,
+		  } )
+		: undefined;
+
 	const isEmail =
 		isGoogleWorkspaceProductSlug( productSlug ) ||
 		isGSuiteOrExtraLicenseProductSlug( productSlug ) ||
@@ -1570,7 +1586,9 @@ function CheckoutLineItem( {
 					<>
 						<LineItemPrice
 							actualAmount={ actualAmountDisplay }
-							crossedOutAmount={ isDiscounted ? originalAmountDisplay : undefined }
+							crossedOutAmount={
+								stackedCrossedOutDisplay ?? ( isDiscounted ? originalAmountDisplay : undefined )
+							}
 						/>
 					</>
 				) }

--- a/packages/wpcom-checkout/test/transformations.ts
+++ b/packages/wpcom-checkout/test/transformations.ts
@@ -1,6 +1,7 @@
 import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
 import {
 	getCreditsLineItemFromCart,
+	getSubtotalWithoutDiscountsForProduct,
 	getTaxLineItemFromCart,
 	getTaxBreakdownLineItemsFromCart,
 	getCouponLineItemFromCart,
@@ -244,5 +245,109 @@ describe( 'getCreditsLineItemFromCart', function () {
 		};
 
 		expect( getCreditsLineItemFromCart( cartWithCredits ) ).toStrictEqual( expected );
+	} );
+} );
+
+describe( 'getSubtotalWithoutDiscountsForProduct', function () {
+	it( 'returns item_subtotal_integer when there are no cost overrides', () => {
+		const product = {
+			...getEmptyResponseCartProduct(),
+			item_subtotal_integer: 8000,
+			item_original_subtotal_integer: 8000,
+		};
+
+		expect( getSubtotalWithoutDiscountsForProduct( product ) ).toBe( 8000 );
+	} );
+
+	it( 'returns the intro offer new_subtotal for a premium domain with a price-increasing intro offer', () => {
+		const product = {
+			...getEmptyResponseCartProduct(),
+			product_slug: 'dotart_domain',
+			item_subtotal_integer: 110000,
+			item_original_subtotal_integer: 8000,
+			introductory_offer_terms: {
+				enabled: true,
+				interval_unit: 'year' as const,
+				interval_count: 1,
+				transition_after_renewal_count: 0,
+				should_prorate_when_offer_ends: false,
+				do_not_use_offer: false,
+				reason: null,
+			},
+			cost_overrides: [
+				{
+					human_readable_reason: 'Introductory offer',
+					old_subtotal_integer: 8000,
+					new_subtotal_integer: 110000,
+					override_code: 'introductory-offer',
+					does_override_original_cost: false,
+					percentage: 0,
+					first_unit_only: false,
+				},
+			],
+		};
+
+		expect( getSubtotalWithoutDiscountsForProduct( product ) ).toBe( 110000 );
+	} );
+
+	it( 'returns the peak price for a premium domain with stacked overrides (intro offer + sale coupon)', () => {
+		const product = {
+			...getEmptyResponseCartProduct(),
+			product_slug: 'dotart_domain',
+			item_subtotal_integer: 27500,
+			item_original_subtotal_integer: 8000,
+			introductory_offer_terms: {
+				enabled: true,
+				interval_unit: 'year' as const,
+				interval_count: 1,
+				transition_after_renewal_count: 0,
+				should_prorate_when_offer_ends: false,
+				do_not_use_offer: false,
+				reason: null,
+			},
+			cost_overrides: [
+				{
+					human_readable_reason: 'Introductory offer',
+					old_subtotal_integer: 8000,
+					new_subtotal_integer: 110000,
+					override_code: 'introductory-offer',
+					does_override_original_cost: false,
+					percentage: 0,
+					first_unit_only: false,
+				},
+				{
+					human_readable_reason: 'Item on sale',
+					old_subtotal_integer: 110000,
+					new_subtotal_integer: 27500,
+					override_code: 'sale-coupon-discount-1',
+					does_override_original_cost: false,
+					percentage: 75,
+					first_unit_only: true,
+				},
+			],
+		};
+
+		expect( getSubtotalWithoutDiscountsForProduct( product ) ).toBe( 110000 );
+	} );
+
+	it( 'returns the first override old_subtotal for a product with only a discount override', () => {
+		const product = {
+			...getEmptyResponseCartProduct(),
+			item_subtotal_integer: 6000,
+			item_original_subtotal_integer: 8000,
+			cost_overrides: [
+				{
+					human_readable_reason: 'Introductory offer',
+					old_subtotal_integer: 8000,
+					new_subtotal_integer: 6000,
+					override_code: 'introductory-offer',
+					does_override_original_cost: false,
+					percentage: 0,
+					first_unit_only: false,
+				},
+			],
+		};
+
+		expect( getSubtotalWithoutDiscountsForProduct( product ) ).toBe( 8000 );
 	} );
 } );


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/DOMENG-512/checkout-shows-wrong-price-for-premium-domains-with-stacked-cost

## Proposed Changes

* For premium domains with stacked cost overrides (price-increasing intro offer + sale coupon), show the pre-discount price crossed out next to the final price (e.g. ~~$1,100~~ $275) in both the main checkout line item and the sidebar summary.
* Reuse the existing `getSubtotalWithoutDiscountsForProduct()` helper from `transformations.ts` to find the "peak" price before any price-reducing overrides (e.g. $1,100 after the intro offer but before the sale coupon).
* WPCOM plans continue showing the renewal price (`item_original_subtotal_integer`) for legal reasons — no change there.

|<img width="820" height="1292" alt="checkout before" src="https://github.com/user-attachments/assets/66b2539a-97bd-42e7-a527-dbaf7a866656" />|<img width="810" height="1284" alt="checkout-after" src="https://github.com/user-attachments/assets/c86681b4-44de-4054-924d-056f10aa7b08" />|
|:---:|:---:|
|**BEFORE**|**AFTER**|

|![Screenshot 2026-03-24 at 10 39 49](https://github.com/user-attachments/assets/3589f57b-b7c4-4438-909c-c5f9ce4c3279)|![Screenshot 2026-03-24 at 10 57 10](https://github.com/user-attachments/assets/7ca11cca-df84-45b2-8bae-21a6772b74f6)|
|:---:|:---:|
|**BEFORE**|**AFTER**|

|![Screenshot 2026-03-24 at 11 13 01](https://github.com/user-attachments/assets/5210bf8d-b249-475f-98be-3b6e6f71d916)|
|:---:|
|**2 YEARS REGISTRATION**|

## Why are these changes being made?
In checkout, the price displayed next to an H/L premium domain name with an additional discount (e.g. `ronald.art`) showed the base/renewal price ($80) instead of the actual charge. For a premium `.art` domain with stacked cost overrides:

1. `introductory-offer`: $80 → $1,100 (first-year premium price)
2. `sale-coupon-discount-1`: $1,100 → $275 (75% sale discount)

The sale discount is applied as a cost override (`sale-coupon-discount-1`), not a user coupon, so `coupon_savings_integer` is 0. This meant the `isDiscounted` check compared $275 < $80 (false), and the code fell back to displaying the renewal price ($80) with no strikethrough.

The fix uses `getSubtotalWithoutDiscountsForProduct()` to find the pre-discount price ($1,100), then shows it crossed out next to the final price ($275). The `hasStackedPriceIncrease` condition only triggers when all three hold:
- The item is not already marked as discounted (`!isDiscounted`)
- A price-increasing override pushed the price above the original (`priceBeforeDiscountsInteger > originalAmountInteger`)
- A subsequent discount brought it back down (`itemSubtotalInteger < priceBeforeDiscountsInteger`)

This limits the change to premium domains with stacked overrides — no other product types are affected.

## Testing Instructions

* Add a premium `.art` domain (e.g. `ronald.art`) to the cart that has both a price-increasing introductory offer and a sale coupon discount.
* Verify the main checkout line item price next to the domain name shows ~~$1,100~~ $275.
* Verify the sidebar summary also shows ~~$1,100~~ $275.
* Verify WPCOM plan line items still show the renewal/original price.
* Verify domains without stacked overrides (no overrides, coupon-only, or discount-only intro offers) still display correctly.
* Verify other product types (Google Workspace, Jetpack, etc.) are unaffected.

|![Screenshot 2026-03-24 at 11 12 12](https://github.com/user-attachments/assets/0db097fb-afd6-4aa0-bc43-6d59fd63b42a)|
|:---:|
|**Titan email 3 months offer - no regression**|

|![Screenshot 2026-03-24 at 11 12 28](https://github.com/user-attachments/assets/885d39b7-1541-4934-ac48-97a426437dff)|
|:---:|
|**H/L Domain not on sale**|

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)