### PR TITLE
Reader: Hide not permitted actions for password protected posts

### DIFF
--- a/client/blocks/comments/comment-actions.jsx
+++ b/client/blocks/comments/comment-actions.jsx
@@ -2,7 +2,7 @@ import { Gridicon } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import ShareButton from 'calypso/blocks/reader-share';
-import { shouldShowReblog } from 'calypso/blocks/reader-share/helper';
+import { isRebloggable } from 'calypso/reader/post/capabilities';
 import { useSelector } from 'calypso/state';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import CommentLikeButtonContainer from './comment-likes';
@@ -25,7 +25,7 @@ const CommentActions = ( {
 	const showReplyButton = post && post.discussion && post.discussion.comments_open === true;
 	const showCancelReplyButton = activeReplyCommentId === commentId;
 	const hasSites = !! useSelector( getPrimarySiteId );
-	const showReblogButton = shouldShowReblog( post, hasSites );
+	const showReblogButton = isRebloggable( post, hasSites );
 
 	// Only render actions for non placeholders
 	if ( isPlaceholder ) {

--- a/client/blocks/comments/helper.jsx
+++ b/client/blocks/comments/helper.jsx
@@ -1,7 +1,0 @@
-export function shouldShowComments( post ) {
-	if ( post.discussion && ( post.discussion.comments_open || post.discussion.comment_count > 0 ) ) {
-		return true;
-	}
-
-	return false;
-}

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -7,8 +7,8 @@ import PropTypes from 'prop-types';
 import { Component, createRef } from 'react';
 import { connect } from 'react-redux';
 import ConversationFollowButton from 'calypso/blocks/conversation-follow-button';
-import { shouldShowConversationFollowButton } from 'calypso/blocks/conversation-follow-button/helper';
 import ReaderFollowConversationIcon from 'calypso/reader/components/icons/follow-conversation-icon';
+import { isConversationFollowable } from 'calypso/reader/post/capabilities';
 import { recordAction, recordGaEvent, recordTrackForPost } from 'calypso/reader/stats';
 import {
 	requestPostComments,
@@ -649,8 +649,7 @@ class PostCommentList extends Component {
 				  this.getCommentsCount( this.props.commentsTree.children );
 
 		const showConversationFollowButton =
-			this.props.showConversationFollowButton &&
-			shouldShowConversationFollowButton( this.props.post );
+			this.props.showConversationFollowButton && isConversationFollowable( this.props.post );
 
 		const showManageCommentsButton =
 			! expandableView && this.props.canUserModerateComments && commentCount > 0;

--- a/client/blocks/conversation-follow-button/helper.js
+++ b/client/blocks/conversation-follow-button/helper.js
@@ -1,5 +1,0 @@
-import { shouldShowComments } from 'calypso/blocks/comments/helper';
-
-export function shouldShowConversationFollowButton( post ) {
-	return post.site_ID && ! post.is_external && shouldShowComments( post );
-}

--- a/client/blocks/reader-full-post/action-bar.jsx
+++ b/client/blocks/reader-full-post/action-bar.jsx
@@ -6,7 +6,7 @@ import PostEditButton from 'calypso/blocks/post-edit-button';
 import ReaderCommentIcon from 'calypso/reader/components/icons/comment-icon';
 import ReaderFollowButton from 'calypso/reader/follow-button';
 import LikeButton from 'calypso/reader/like-button';
-import { shouldShowLikes } from 'calypso/reader/like-helper';
+import { isLikeable } from 'calypso/reader/post/capabilities';
 import { recordAction, recordPermalinkClick } from 'calypso/reader/stats';
 import { userCan } from 'calypso/state/posts/utils';
 
@@ -25,7 +25,7 @@ const ReaderFullPostActionBar = ( {
 } ) => {
 	const translate = useTranslate();
 	const canEdit = site && userCan( 'edit_post', post );
-	const showLikes = shouldShowLikes( post );
+	const showLikes = isLikeable( post );
 	const followUrl = feedUrl || siteUrl;
 	const feedId = post.feed_ID ? Number( post.feed_ID ) : undefined;
 	const siteId = post.site_ID ? Number( post.site_ID ) : undefined;

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -9,7 +9,6 @@ import { createRef, Component } from 'react';
 import { connect } from 'react-redux';
 import Comments from 'calypso/blocks/comments';
 import { COMMENTS_FILTER_ALL } from 'calypso/blocks/comments/comments-filters';
-import { shouldShowComments } from 'calypso/blocks/comments/helper';
 import ReaderFullPostFeaturedImage from 'calypso/blocks/reader-full-post/featured-image';
 import { scrollToComments } from 'calypso/blocks/reader-full-post/scroll-to-comments';
 import WPiFrameResize from 'calypso/blocks/reader-full-post/wp-iframe-resize';
@@ -32,6 +31,7 @@ import ReaderBackButton from 'calypso/reader/components/back-button';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import { canBeMarkedAsSeen, getSiteName, isEligibleForUnseen } from 'calypso/reader/get-helpers';
 import readerContentWidth from 'calypso/reader/lib/content-width';
+import { isCommentable } from 'calypso/reader/post/capabilities';
 import PostExcerptLink from 'calypso/reader/post-excerpt-link';
 import { keyForPost } from 'calypso/reader/post-key';
 import { ReaderPerformanceTrackerStop } from 'calypso/reader/reader-performance-tracker';
@@ -805,7 +805,7 @@ export class FullPostView extends Component {
 									onCommentClick={ this.handleCommentClick }
 									onEditClick={ this.onEditClick }
 									commentsApiDisabled={ commentsApiDisabled }
-									showComments={ shouldShowComments( post ) }
+									showComments={ isCommentable( post ) }
 									renderMarkAsSeenButton={
 										shouldShowMarkAsSeen ? this.renderMarkAsSenButton : null
 									}
@@ -847,7 +847,7 @@ export class FullPostView extends Component {
 							{ ! isLoading && <ReaderPerformanceTrackerStop /> }
 
 							<div className="reader-full-post__comments-wrapper" ref={ this.commentsWrapper }>
-								{ ! commentsApiDisabled && shouldShowComments( post ) && (
+								{ ! commentsApiDisabled && isCommentable( post ) && (
 									<Comments
 										showNestingReplyArrow
 										post={ post }

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -2,12 +2,15 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import CommentButton from 'calypso/blocks/comment-button';
-import { shouldShowComments } from 'calypso/blocks/comments/helper';
 import ShareButton from 'calypso/blocks/reader-share';
-import { shouldShowShare, shouldShowReblog } from 'calypso/blocks/reader-share/helper';
 import ReaderCommentIcon from 'calypso/reader/components/icons/comment-icon';
 import LikeButton from 'calypso/reader/like-button';
-import { shouldShowLikes } from 'calypso/reader/like-helper';
+import {
+	isCommentable,
+	isSharable,
+	isRebloggable,
+	isLikeable,
+} from 'calypso/reader/post/capabilities';
 import { useSelector } from 'calypso/state';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import { isA8cTeamMember } from 'calypso/state/teams/selectors';
@@ -25,13 +28,13 @@ const ReaderPostActions = ( {
 } ) => {
 	const translate = useTranslate();
 	const hasSites = !! useSelector( getPrimarySiteId );
-	const showShare = shouldShowShare( post );
-	const showReblog = shouldShowReblog( post, hasSites );
-	const showComments = shouldShowComments( post );
-	const showLikes = shouldShowLikes( post );
+	const showShare = isSharable( post );
+	const showReblog = isRebloggable( post, hasSites );
+	const showComments = isCommentable( post );
+	const showLikes = isLikeable( post );
 	const listClassnames = clsx( 'reader-post-actions', className );
 	const isAutomattician = useSelector( isA8cTeamMember );
-	const shouldShowFreshlyPressed = fullPost && isAutomattician;
+	const shouldShowFreshlyPressed = fullPost && isAutomattician && showShare;
 
 	return (
 		<ul className={ listClassnames }>

--- a/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
+++ b/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import ConversationFollowButton from 'calypso/blocks/conversation-follow-button';
-import { shouldShowConversationFollowButton } from 'calypso/blocks/conversation-follow-button/helper';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import ReaderFollowConversationIcon from 'calypso/reader/components/icons/follow-conversation-icon';
@@ -14,6 +13,7 @@ import ReaderFollowButton from 'calypso/reader/follow-button';
 import { READER_POST_OPTIONS_MENU } from 'calypso/reader/follow-sources';
 import { canBeMarkedAsSeen, isEligibleForUnseen } from 'calypso/reader/get-helpers';
 import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
+import { isConversationFollowable } from 'calypso/reader/post/capabilities';
 import * as stats from 'calypso/reader/stats';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import * as PostUtils from 'calypso/state/posts/utils';
@@ -284,7 +284,7 @@ class ReaderPostEllipsisMenu extends Component {
 
 		const isTeamMember = isAutomatticTeamMember( teams );
 		const showConversationFollowButton =
-			this.props.showConversationFollow && shouldShowConversationFollowButton( post );
+			this.props.showConversationFollow && isConversationFollowable( post );
 
 		return (
 			<EllipsisMenu

--- a/client/blocks/reader-share/helper.jsx
+++ b/client/blocks/reader-share/helper.jsx
@@ -1,7 +1,0 @@
-export function shouldShowShare( post ) {
-	return ! post.site_is_private;
-}
-
-export function shouldShowReblog( post, hasSites ) {
-	return hasSites && ! post.site_is_private;
-}

--- a/client/reader/like-helper.jsx
+++ b/client/reader/like-helper.jsx
@@ -1,7 +1,0 @@
-export function shouldShowLikes( post ) {
-	if ( post && post.site_ID && ! post.is_external ) {
-		return true;
-	}
-
-	return false;
-}

--- a/client/reader/post/capabilities/index.ts
+++ b/client/reader/post/capabilities/index.ts
@@ -52,7 +52,8 @@ export function isLikeable( post: ReaderPost ): boolean {
 		return false;
 	}
 
-	return post?.likes_enabled ?? false;
+	// Default to likes enabled unless explicitly disabled
+	return post?.likes_enabled !== false;
 }
 
 export function isConversationFollowable( post: ReaderPost ): boolean {

--- a/client/reader/post/capabilities/index.ts
+++ b/client/reader/post/capabilities/index.ts
@@ -1,0 +1,63 @@
+// TODO: Unify with ReaderPost interfaces in reader/get-helpers.ts and reader/recent/types.ts
+interface ReaderPost {
+	site_ID?: number;
+	site_is_private?: boolean;
+	is_external?: boolean;
+	sharing_enabled?: boolean;
+	likes_enabled?: boolean;
+	discussion?: {
+		comments_open?: boolean;
+		comment_count?: number;
+	};
+}
+
+export function isCommentable( post: ReaderPost ): boolean {
+	if (
+		post.discussion &&
+		( post.discussion.comments_open || ( post.discussion.comment_count ?? 0 ) > 0 )
+	) {
+		return true;
+	}
+
+	return false;
+}
+
+export function isSharable( post: ReaderPost ): boolean {
+	if ( ! post?.site_ID ) {
+		return false;
+	}
+
+	if ( post?.site_is_private ) {
+		return false;
+	}
+
+	return post?.sharing_enabled ?? false;
+}
+
+export function isRebloggable( post: ReaderPost, hasSites: boolean ): boolean {
+	if ( ! post?.site_ID ) {
+		return false;
+	}
+
+	if ( post?.site_is_private || ! hasSites ) {
+		return false;
+	}
+
+	return post?.sharing_enabled ?? false;
+}
+
+export function isLikeable( post: ReaderPost ): boolean {
+	if ( ! post?.site_ID ) {
+		return false;
+	}
+
+	if ( post.is_external ) {
+		return false;
+	}
+
+	return post?.likes_enabled ?? false;
+}
+
+export function isConversationFollowable( post: ReaderPost ): boolean {
+	return !! post?.site_ID && ! post?.is_external && isCommentable( post );
+}

--- a/client/reader/post/capabilities/index.ts
+++ b/client/reader/post/capabilities/index.ts
@@ -23,15 +23,12 @@ export function isCommentable( post: ReaderPost ): boolean {
 }
 
 export function isSharable( post: ReaderPost ): boolean {
-	if ( ! post?.site_ID ) {
-		return false;
-	}
-
 	if ( post?.site_is_private ) {
 		return false;
 	}
 
-	return post?.sharing_enabled ?? false;
+	// Treat sharing as enabled by default; only disable when explicitly set to false.
+	return post?.sharing_enabled !== false;
 }
 
 export function isRebloggable( post: ReaderPost, hasSites: boolean ): boolean {

--- a/client/reader/post/capabilities/index.ts
+++ b/client/reader/post/capabilities/index.ts
@@ -40,7 +40,7 @@ export function isRebloggable( post: ReaderPost, hasSites: boolean ): boolean {
 		return false;
 	}
 
-	return post?.sharing_enabled ?? false;
+	return post?.sharing_enabled !== false;
 }
 
 export function isLikeable( post: ReaderPost ): boolean {

--- a/client/reader/post/capabilities/test/index.ts
+++ b/client/reader/post/capabilities/test/index.ts
@@ -1,0 +1,136 @@
+import {
+	isCommentable,
+	isSharable,
+	isRebloggable,
+	isLikeable,
+	isConversationFollowable,
+} from '../index';
+
+describe( 'reader/post/capabilities', () => {
+	describe( 'isCommentable', () => {
+		it( 'returns true when comments_open is true', () => {
+			expect( isCommentable( { discussion: { comments_open: true } } ) ).toBe( true );
+		} );
+
+		it( 'returns true when comments_open is false but comment_count > 0', () => {
+			expect( isCommentable( { discussion: { comments_open: false, comment_count: 3 } } ) ).toBe(
+				true
+			);
+		} );
+
+		it( 'returns false when comments_open is false and comment_count is 0', () => {
+			expect( isCommentable( { discussion: { comments_open: false, comment_count: 0 } } ) ).toBe(
+				false
+			);
+		} );
+
+		it( 'returns false when discussion is undefined', () => {
+			expect( isCommentable( {} ) ).toBe( false );
+		} );
+
+		it( 'returns false when discussion exists but has no properties', () => {
+			expect( isCommentable( { discussion: {} } ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'isSharable', () => {
+		it( 'returns true when site_ID exists and sharing_enabled is true', () => {
+			expect( isSharable( { site_ID: 1, sharing_enabled: true } ) ).toBe( true );
+		} );
+
+		it( 'returns false when sharing_enabled is false', () => {
+			expect( isSharable( { site_ID: 1, sharing_enabled: false } ) ).toBe( false );
+		} );
+
+		it( 'returns false when site_ID is missing', () => {
+			expect( isSharable( { sharing_enabled: true } ) ).toBe( false );
+		} );
+
+		it( 'returns false when site_is_private is true', () => {
+			expect( isSharable( { site_ID: 1, site_is_private: true, sharing_enabled: true } ) ).toBe(
+				false
+			);
+		} );
+
+		it( 'returns false when sharing_enabled is undefined', () => {
+			expect( isSharable( { site_ID: 1 } ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'isRebloggable', () => {
+		it( 'returns true when site_ID exists, sharing_enabled is true, and user has sites', () => {
+			expect( isRebloggable( { site_ID: 1, sharing_enabled: true }, true ) ).toBe( true );
+		} );
+
+		it( 'returns false when sharing_enabled is false', () => {
+			expect( isRebloggable( { site_ID: 1, sharing_enabled: false }, true ) ).toBe( false );
+		} );
+
+		it( 'returns false when user has no sites', () => {
+			expect( isRebloggable( { site_ID: 1, sharing_enabled: true }, false ) ).toBe( false );
+		} );
+
+		it( 'returns false when site_ID is missing', () => {
+			expect( isRebloggable( { sharing_enabled: true }, true ) ).toBe( false );
+		} );
+
+		it( 'returns false when site_is_private is true', () => {
+			expect(
+				isRebloggable( { site_ID: 1, site_is_private: true, sharing_enabled: true }, true )
+			).toBe( false );
+		} );
+	} );
+
+	describe( 'isLikeable', () => {
+		it( 'returns true when site_ID exists and likes_enabled is true', () => {
+			expect( isLikeable( { site_ID: 1, likes_enabled: true } ) ).toBe( true );
+		} );
+
+		it( 'returns false when likes_enabled is false', () => {
+			expect( isLikeable( { site_ID: 1, likes_enabled: false } ) ).toBe( false );
+		} );
+
+		it( 'returns false when site_ID is missing', () => {
+			expect( isLikeable( { likes_enabled: true } ) ).toBe( false );
+		} );
+
+		it( 'returns false when post is external', () => {
+			expect( isLikeable( { site_ID: 1, is_external: true, likes_enabled: true } ) ).toBe( false );
+		} );
+
+		it( 'returns false when likes_enabled is undefined', () => {
+			expect( isLikeable( { site_ID: 1 } ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'isConversationFollowable', () => {
+		it( 'returns true when site_ID exists, not external, and commentable', () => {
+			expect(
+				isConversationFollowable( { site_ID: 1, discussion: { comments_open: true } } )
+			).toBe( true );
+		} );
+
+		it( 'returns false when site_ID is missing', () => {
+			expect( isConversationFollowable( { discussion: { comments_open: true } } ) ).toBe( false );
+		} );
+
+		it( 'returns false when post is external', () => {
+			expect(
+				isConversationFollowable( {
+					site_ID: 1,
+					is_external: true,
+					discussion: { comments_open: true },
+				} )
+			).toBe( false );
+		} );
+
+		it( 'returns false when post is not commentable', () => {
+			expect(
+				isConversationFollowable( {
+					site_ID: 1,
+					discussion: { comments_open: false, comment_count: 0 },
+				} )
+			).toBe( false );
+		} );
+	} );
+} );

--- a/client/reader/post/capabilities/test/index.ts
+++ b/client/reader/post/capabilities/test/index.ts
@@ -42,8 +42,8 @@ describe( 'reader/post/capabilities', () => {
 			expect( isSharable( { site_ID: 1, sharing_enabled: false } ) ).toBe( false );
 		} );
 
-		it( 'returns false when site_ID is missing', () => {
-			expect( isSharable( { sharing_enabled: true } ) ).toBe( false );
+		it( 'returns true when site_ID is missing but sharing_enabled is true', () => {
+			expect( isSharable( { sharing_enabled: true } ) ).toBe( true );
 		} );
 
 		it( 'returns false when site_is_private is true', () => {
@@ -52,8 +52,8 @@ describe( 'reader/post/capabilities', () => {
 			);
 		} );
 
-		it( 'returns false when sharing_enabled is undefined', () => {
-			expect( isSharable( { site_ID: 1 } ) ).toBe( false );
+		it( 'defaults to true when sharing_enabled is undefined', () => {
+			expect( isSharable( { site_ID: 1 } ) ).toBe( true );
 		} );
 	} );
 
@@ -98,8 +98,8 @@ describe( 'reader/post/capabilities', () => {
 			expect( isLikeable( { site_ID: 1, is_external: true, likes_enabled: true } ) ).toBe( false );
 		} );
 
-		it( 'returns false when likes_enabled is undefined', () => {
-			expect( isLikeable( { site_ID: 1 } ) ).toBe( false );
+		it( 'defaults to true when likes_enabled is undefined', () => {
+			expect( isLikeable( { site_ID: 1 } ) ).toBe( true );
 		} );
 	} );
 

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -19,7 +19,7 @@ import scrollTo from 'calypso/lib/scroll-to';
 import withDimensions from 'calypso/lib/with-dimensions';
 import { isEditorIframeFocused } from 'calypso/reader/components/quick-post/utils';
 import ReaderMain from 'calypso/reader/components/reader-main';
-import { shouldShowLikes } from 'calypso/reader/like-helper';
+import { isLikeable } from 'calypso/reader/post/capabilities';
 import { keysAreEqual, keyToString } from 'calypso/reader/post-key';
 import { MAX_POSTS_FOR_LOGGED_OUT_USERS } from 'calypso/reader/reader.const';
 import ReaderStreamLoginPrompt from 'calypso/reader/stream/login-prompt';
@@ -368,7 +368,7 @@ class ReaderStream extends Component {
 			return;
 		}
 
-		if ( shouldShowLikes( selectedPost ) ) {
+		if ( isLikeable( selectedPost ) ) {
 			this.toggleLikeAction();
 		}
 	};


### PR DESCRIPTION
Close READ-342

Depends on the  wpcom/pull/208104

## Proposed Changes

- Hide comments, share, reblog, like, and freshly pressed actions from post-protected posts. 
- Create `client/reader/post/capabilities` module with functions that determine what actions a post supports: `isCommentable`, `isSharable`, `isRebloggable`, `isLikeable`, and `isConversationFollowable`
- Migrate all consumers to use the new centralized module
- Remove scattered helper files: `blocks/comments/helper.jsx`, `blocks/reader-share/helper.jsx`, `blocks/conversation-follow-button/helper.js`, `reader/like-helper.jsx`

## Why are these changes being made?
Currently, we show the comments, like, share, and reblog buttons regardless of whether the user can actually use them. Password-protected posts can't perform these actions, so this update focuses on hiding the buttons. 


The Post action visibility logic was duplicated across multiple helper files with inconsistent naming. Centralizing into a single `post/capabilities` module with a clear naming convention (`is*` pattern) makes the codebase easier to maintain and extend when new post capability checks are needed.

## Testing Instructions

- Publish a password protected post in a free site
- Follow the free site
- Go to the feeds page or the post page
- Check you can't see "Like",  "Comments", "Share", 


<img width="2852" height="1948" alt="CleanShot 2026-03-23 at 19 27 09@2x" src="https://github.com/user-attachments/assets/64737c06-215a-4d54-8e02-2570b4e11631" />

<img width="2852" height="1950" alt="CleanShot 2026-03-23 at 19 27 19@2x" src="https://github.com/user-attachments/assets/e79556db-fd76-4375-a6a8-e36db40a0128" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?