### PR TITLE
Reader: Add collapsible sidebar toggle

### DIFF
--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -282,15 +282,17 @@ export class ReaderSidebar extends Component {
 
 	render() {
 		return (
-			<GlobalSidebar
-				path={ this.props.path }
-				onClick={ this.handleClick }
-				siteTitle={ i18n.translate( 'Reader' ) }
-			>
+			<>
 				<ReaderSidebarCollapseToggle />
-				<ReaderSidebarNudges />
-				{ this.renderSidebarMenu() }
-			</GlobalSidebar>
+				<GlobalSidebar
+					path={ this.props.path }
+					onClick={ this.handleClick }
+					siteTitle={ i18n.translate( 'Reader' ) }
+				>
+					<ReaderSidebarNudges />
+					{ this.renderSidebarMenu() }
+				</GlobalSidebar>
+			</>
 		);
 	}
 }

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -282,17 +282,15 @@ export class ReaderSidebar extends Component {
 
 	render() {
 		return (
-			<>
+			<GlobalSidebar
+				path={ this.props.path }
+				onClick={ this.handleClick }
+				siteTitle={ i18n.translate( 'Reader' ) }
+			>
 				<ReaderSidebarCollapseToggle />
-				<GlobalSidebar
-					path={ this.props.path }
-					onClick={ this.handleClick }
-					siteTitle={ i18n.translate( 'Reader' ) }
-				>
-					<ReaderSidebarNudges />
-					{ this.renderSidebarMenu() }
-				</GlobalSidebar>
-			</>
+				<ReaderSidebarNudges />
+				{ this.renderSidebarMenu() }
+			</GlobalSidebar>
 		);
 	}
 }

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -44,6 +44,7 @@ import {
 import { getReaderTeams } from 'calypso/state/teams/selectors';
 import { setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import ReaderSidebarHelper from './helper';
+import ReaderSidebarCollapseToggle from './reader-sidebar-collapse-toggle';
 import ReaderSidebarLists from './reader-sidebar-lists';
 import ReaderSidebarNudges from './reader-sidebar-nudges';
 import ReaderSidebarOrganizations from './reader-sidebar-organizations';
@@ -286,6 +287,7 @@ export class ReaderSidebar extends Component {
 				onClick={ this.handleClick }
 				siteTitle={ i18n.translate( 'Reader' ) }
 			>
+				<ReaderSidebarCollapseToggle />
 				<ReaderSidebarNudges />
 				{ this.renderSidebarMenu() }
 			</GlobalSidebar>

--- a/client/reader/sidebar/reader-sidebar-collapse-toggle.jsx
+++ b/client/reader/sidebar/reader-sidebar-collapse-toggle.jsx
@@ -1,7 +1,7 @@
-import { Button } from '@wordpress/components';
-import { chevronLeft, chevronRight } from '@wordpress/icons';
+import { chevronLeft, chevronRight, Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import { useSelector, useDispatch } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
@@ -26,13 +26,14 @@ export default function ReaderSidebarCollapseToggle() {
 		dispatch( savePreference( 'readerSidebarCollapsed', ! isCollapsed ) );
 	};
 
-	return (
-		<Button
+	return createPortal(
+		<button
 			className="reader-sidebar-collapse-toggle"
 			onClick={ handleToggle }
-			icon={ isCollapsed ? chevronRight : chevronLeft }
-			label={ isCollapsed ? translate( 'Expand sidebar' ) : translate( 'Collapse sidebar' ) }
-			size="compact"
-		/>
+			aria-label={ isCollapsed ? translate( 'Expand sidebar' ) : translate( 'Collapse sidebar' ) }
+		>
+			<Icon icon={ isCollapsed ? chevronRight : chevronLeft } size={ 16 } />
+		</button>,
+		document.body
 	);
 }

--- a/client/reader/sidebar/reader-sidebar-collapse-toggle.jsx
+++ b/client/reader/sidebar/reader-sidebar-collapse-toggle.jsx
@@ -1,0 +1,38 @@
+import { Button } from '@wordpress/components';
+import { chevronLeft, chevronRight } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { getPreference } from 'calypso/state/preferences/selectors';
+
+import './reader-sidebar-collapse-toggle.scss';
+
+export default function ReaderSidebarCollapseToggle() {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const isCollapsed = useSelector( ( state ) => getPreference( state, 'readerSidebarCollapsed' ) );
+
+	useEffect( () => {
+		document.body.classList.toggle( 'is-reader-sidebar-collapsed', !! isCollapsed );
+		return () => {
+			document.body.classList.remove( 'is-reader-sidebar-collapsed' );
+		};
+	}, [ isCollapsed ] );
+
+	const handleToggle = () => {
+		dispatch( recordTracksEvent( 'calypso_reader_sidebar_toggle', { collapsed: ! isCollapsed } ) );
+		dispatch( savePreference( 'readerSidebarCollapsed', ! isCollapsed ) );
+	};
+
+	return (
+		<Button
+			className="reader-sidebar-collapse-toggle"
+			onClick={ handleToggle }
+			icon={ isCollapsed ? chevronRight : chevronLeft }
+			label={ isCollapsed ? translate( 'Expand sidebar' ) : translate( 'Collapse sidebar' ) }
+			size="compact"
+		/>
+	);
+}

--- a/client/reader/sidebar/reader-sidebar-collapse-toggle.scss
+++ b/client/reader/sidebar/reader-sidebar-collapse-toggle.scss
@@ -1,0 +1,64 @@
+.reader-sidebar-collapse-toggle {
+	position: fixed;
+	top: 50%;
+	transform: translateY( -50% );
+	z-index: 100;
+	width: 24px;
+	height: 24px;
+	min-width: 24px !important;
+	padding: 0 !important;
+	border-radius: 50%;
+	background: var( --color-surface );
+	border: 1px solid var( --color-border-subtle );
+	box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.1 );
+	cursor: pointer;
+	display: none;
+
+	&:hover {
+		background: var( --color-neutral-0 );
+		border-color: var( --color-border );
+	}
+
+	svg {
+		fill: var( --color-text-subtle );
+	}
+
+	@media ( min-width: 782px ) {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+}
+
+// When sidebar is visible: button at the right edge of sidebar
+body.is-section-reader:not( .is-reader-sidebar-collapsed ) {
+	.reader-sidebar-collapse-toggle {
+		left: calc( var( --sidebar-width-max ) - 12px );
+	}
+}
+
+// When sidebar is collapsed
+body.is-section-reader.is-reader-sidebar-collapsed {
+	// Move toggle to left edge
+	.reader-sidebar-collapse-toggle {
+		left: 8px;
+	}
+
+	// Hide sidebar and reclaim space
+	.layout__secondary {
+		/* stylelint-disable length-zero-no-unit */
+		width: 0px;
+		/* stylelint-enable length-zero-no-unit */
+		border: none;
+	}
+
+	.layout__secondary .global-sidebar {
+		visibility: hidden;
+		opacity: 0;
+	}
+
+	// Shift content to fill full width
+	.layout__content {
+		padding-inline-start: 32px !important;
+	}
+}

--- a/client/reader/sidebar/reader-sidebar-collapse-toggle.scss
+++ b/client/reader/sidebar/reader-sidebar-collapse-toggle.scss
@@ -49,12 +49,12 @@ body.is-section-reader.is-reader-sidebar-collapsed {
 		/* stylelint-disable length-zero-no-unit */
 		width: 0px;
 		/* stylelint-enable length-zero-no-unit */
+		overflow: visible;
 		border: none;
 	}
 
 	.layout__secondary .global-sidebar {
 		visibility: hidden;
-		opacity: 0;
 	}
 
 	// Shift content to fill full width

--- a/client/reader/sidebar/reader-sidebar-collapse-toggle.scss
+++ b/client/reader/sidebar/reader-sidebar-collapse-toggle.scss
@@ -33,7 +33,7 @@
 // When sidebar is visible: button at the right edge of sidebar
 body.is-section-reader:not( .is-reader-sidebar-collapsed ) {
 	.reader-sidebar-collapse-toggle {
-		left: calc( var( --sidebar-width-max ) - 12px );
+		inset-inline-start: calc( var( --sidebar-width-max ) - 12px );
 	}
 }
 
@@ -41,7 +41,7 @@ body.is-section-reader:not( .is-reader-sidebar-collapsed ) {
 body.is-section-reader.is-reader-sidebar-collapsed {
 	// Move toggle to left edge
 	.reader-sidebar-collapse-toggle {
-		left: 8px;
+		inset-inline-start: 8px;
 	}
 
 	// Hide sidebar and reclaim space

--- a/client/reader/sidebar/reader-sidebar-collapse-toggle.scss
+++ b/client/reader/sidebar/reader-sidebar-collapse-toggle.scss
@@ -49,16 +49,13 @@ body.is-section-reader.is-reader-sidebar-collapsed {
 		/* stylelint-disable length-zero-no-unit */
 		width: 0px;
 		/* stylelint-enable length-zero-no-unit */
-		overflow: visible;
 		border: none;
 	}
 
-	.layout__secondary .global-sidebar {
-		visibility: hidden;
-	}
-
-	// Shift content to fill full width
+	// Shift content to fill full width — use padding shorthand to
+	// reliably override the Reader's existing padding shorthand.
 	.layout__content {
-		padding-inline-start: 32px !important;
+		padding: calc( var( --masterbar-height ) + var( --content-padding-top ) ) 16px
+			var( --content-padding-bottom ) 32px !important;
 	}
 }


### PR DESCRIPTION
Part of READ-444

## Proposed Changes

* Add a small chevron button at the Reader sidebar edge that fully hides/shows the sidebar
* Persist collapsed state via user preferences (`readerSidebarCollapsed`)
* Track toggle events via `calypso_reader_sidebar_toggle`

## Why are these changes being made?

The Reader sidebar takes up significant horizontal space. Users who want to focus on reading content should be able to fully collapse the sidebar with a single click, similar to the P2 sidebar collapse pattern. Unlike the existing Calypso sidebar collapse (which shows an icon strip), this fully hides the sidebar to 0px width.

## Testing Instructions

1. Navigate to `/read` in Calypso
2. Look for a small circular chevron button at the right edge of the sidebar, vertically centered
3. Click the button — the sidebar should fully disappear, content fills the width, and the button moves to the left edge
4. Click again — sidebar should reappear
5. Reload the page — collapsed/expanded state should persist
6. Navigate away from Reader and back — body class should be cleaned up and re-applied correctly
7. On mobile (< 782px viewport), the toggle button should be hidden

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?