### PR TITLE
Reader full post - show entire featured image.

### DIFF
--- a/client/blocks/reader-featured-image/index.jsx
+++ b/client/blocks/reader-featured-image/index.jsx
@@ -1,3 +1,8 @@
+/**
+ * Fixed-size featured thumbnails for Reader compact UIs: post cards, related cards,
+ * Recent stream rows, and video overlays (reader-featured-video). For the full post
+ * article column, use ReaderFullPostFeaturedImage from reader-full-post/featured-image instead.
+ */
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';

--- a/client/blocks/reader-featured-image/style.scss
+++ b/client/blocks/reader-featured-image/style.scss
@@ -13,19 +13,3 @@
 		object-fit: contain;
 	}
 }
-
-.reader-full-post__content .reader-featured-image {
-	margin-bottom: 24px;
-	position: relative;
-	&::after {
-		content: "";
-		position: absolute;
-		pointer-events: none;
-		top: 0;
-		left: 0;
-		bottom: 0;
-		right: 0;
-		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
-		border-radius: 6px; /* stylelint-disable-line scales/radii */
-	}
-}

--- a/client/blocks/reader-full-post/featured-image.jsx
+++ b/client/blocks/reader-full-post/featured-image.jsx
@@ -1,18 +1,36 @@
 import PropTypes from 'prop-types';
+import cssSafeUrl from 'calypso/lib/css-safe-url';
+import resizeImageUrl from 'calypso/lib/resize-image-url';
+import { getFeaturedImageAlt } from 'calypso/reader/get-helpers';
 
 const hideImageOnError = ( event ) => {
 	event.target.parentNode.style.display = 'none';
 };
 
-export default function FeaturedImage( { src, alt } ) {
+function featuredImageAltString( post ) {
+	const alt = getFeaturedImageAlt( post );
+	return typeof alt === 'string' ? alt : '';
+}
+
+export default function FeaturedImage( { post, maxWidth } ) {
+	if ( ! post?.featured_image ) {
+		return null;
+	}
+
+	const resizedUrl = resizeImageUrl( post.featured_image, maxWidth );
+	const safeSrc = cssSafeUrl( resizedUrl );
+	if ( ! safeSrc ) {
+		return null;
+	}
+
 	return (
 		<div className="reader-full-post__featured-image">
-			<img src={ src } alt={ alt } onError={ hideImageOnError } />
+			<img src={ safeSrc } alt={ featuredImageAltString( post ) } onError={ hideImageOnError } />
 		</div>
 	);
 }
 
 FeaturedImage.propTypes = {
-	src: PropTypes.string,
-	alt: PropTypes.string,
+	post: PropTypes.object.isRequired,
+	maxWidth: PropTypes.number.isRequired,
 };

--- a/client/blocks/reader-full-post/featured-image.jsx
+++ b/client/blocks/reader-full-post/featured-image.jsx
@@ -12,7 +12,7 @@ function featuredImageAltString( post ) {
 	return typeof alt === 'string' ? alt : '';
 }
 
-export default function FeaturedImage( { post, maxWidth } ) {
+export default function ReaderFullPostFeaturedImage( { post, maxWidth } ) {
 	if ( ! post?.featured_image ) {
 		return null;
 	}
@@ -30,7 +30,7 @@ export default function FeaturedImage( { post, maxWidth } ) {
 	);
 }
 
-FeaturedImage.propTypes = {
+ReaderFullPostFeaturedImage.propTypes = {
 	post: PropTypes.object.isRequired,
 	maxWidth: PropTypes.number.isRequired,
 };

--- a/client/blocks/reader-full-post/featured-image.jsx
+++ b/client/blocks/reader-full-post/featured-image.jsx
@@ -6,11 +6,6 @@ const hideImageOnError = ( event ) => {
 	event.target.parentNode.style.display = 'none';
 };
 
-function featuredImageAltString( post ) {
-	const alt = getFeaturedImageAlt( post );
-	return typeof alt === 'string' ? alt : '';
-}
-
 export default function ReaderFullPostFeaturedImage( { post, maxWidth } ) {
 	if ( ! post?.featured_image ) {
 		return null;
@@ -23,7 +18,7 @@ export default function ReaderFullPostFeaturedImage( { post, maxWidth } ) {
 
 	return (
 		<div className="reader-full-post__featured-image">
-			<img src={ resizedUrl } alt={ featuredImageAltString( post ) } onError={ hideImageOnError } />
+			<img src={ resizedUrl } alt={ getFeaturedImageAlt( post ) } onError={ hideImageOnError } />
 		</div>
 	);
 }

--- a/client/blocks/reader-full-post/featured-image.jsx
+++ b/client/blocks/reader-full-post/featured-image.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import cssSafeUrl from 'calypso/lib/css-safe-url';
 import resizeImageUrl from 'calypso/lib/resize-image-url';
 import { getFeaturedImageAlt } from 'calypso/reader/get-helpers';
 
@@ -18,14 +17,13 @@ export default function ReaderFullPostFeaturedImage( { post, maxWidth } ) {
 	}
 
 	const resizedUrl = resizeImageUrl( post.featured_image, maxWidth );
-	const safeSrc = cssSafeUrl( resizedUrl );
-	if ( ! safeSrc ) {
+	if ( ! resizedUrl ) {
 		return null;
 	}
 
 	return (
 		<div className="reader-full-post__featured-image">
-			<img src={ safeSrc } alt={ featuredImageAltString( post ) } onError={ hideImageOnError } />
+			<img src={ resizedUrl } alt={ featuredImageAltString( post ) } onError={ hideImageOnError } />
 		</div>
 	);
 }

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 import Comments from 'calypso/blocks/comments';
 import { COMMENTS_FILTER_ALL } from 'calypso/blocks/comments/comments-filters';
 import { shouldShowComments } from 'calypso/blocks/comments/helper';
-import ReaderFeaturedImage from 'calypso/blocks/reader-featured-image';
+import FeaturedImage from 'calypso/blocks/reader-full-post/featured-image';
 import { scrollToComments } from 'calypso/blocks/reader-full-post/scroll-to-comments';
 import WPiFrameResize from 'calypso/blocks/reader-full-post/wp-iframe-resize';
 import ReaderPostActions from 'calypso/blocks/reader-post-actions';
@@ -816,13 +816,7 @@ export class FullPostView extends Component {
 							) }
 
 							{ post.featured_image && ! isFeaturedImageInContent( post ) && (
-								<ReaderFeaturedImage
-									canonicalMedia={ null }
-									imageUrl={ post.featured_image }
-									href={ getStreamUrlFromPost( post ) }
-									imageWidth={ contentWidth }
-									children={ <div style={ { width: contentWidth } } /> }
-								/>
+								<FeaturedImage post={ post } maxWidth={ contentWidth } />
 							) }
 							{ isLoading && <ReaderFullPostContentPlaceholder /> }
 							{ post.use_excerpt ? (

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 import Comments from 'calypso/blocks/comments';
 import { COMMENTS_FILTER_ALL } from 'calypso/blocks/comments/comments-filters';
 import { shouldShowComments } from 'calypso/blocks/comments/helper';
-import FeaturedImage from 'calypso/blocks/reader-full-post/featured-image';
+import ReaderFullPostFeaturedImage from 'calypso/blocks/reader-full-post/featured-image';
 import { scrollToComments } from 'calypso/blocks/reader-full-post/scroll-to-comments';
 import WPiFrameResize from 'calypso/blocks/reader-full-post/wp-iframe-resize';
 import ReaderPostActions from 'calypso/blocks/reader-post-actions';
@@ -816,7 +816,7 @@ export class FullPostView extends Component {
 							) }
 
 							{ post.featured_image && ! isFeaturedImageInContent( post ) && (
-								<FeaturedImage post={ post } maxWidth={ contentWidth } />
+								<ReaderFullPostFeaturedImage post={ post } maxWidth={ contentWidth } />
 							) }
 							{ isLoading && <ReaderFullPostContentPlaceholder /> }
 							{ post.use_excerpt ? (

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -777,9 +777,10 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 		z-index: 1;
 	}
 	img {
-		display: block;
-		max-inline-size: 100%;
 		block-size: auto;
+		display: block;
+		inline-size: 100%;
+		max-inline-size: 100%;
 	}
 }
 

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -759,24 +759,27 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 }
 
 .reader-full-post__featured-image {
-	display: inline-flex;
-	margin: 28px 0 26px;
+	display: block;
+	margin-block: 28px 26px;
+	margin-inline: 0;
+	max-inline-size: 100%;
+	overflow: hidden;
 	position: relative;
+	/* stylelint-disable-next-line scales/radii */
+	border-radius: 5px;
 	&::after {
 		content: '';
 		position: absolute;
 		pointer-events: none;
-		top: 0;
-		left: 0;
-		bottom: 0;
-		right: 0;
+		inset: 0;
 		box-shadow: inset 0 0 0 1px rgba( 0, 0, 0, 0.1 );
 		border-radius: 5px; /* stylelint-disable-line scales/radii */
+		z-index: 1;
 	}
 	img {
-		box-shadow: inset 0 0 0 1px rgba( 0, 0, 0, 0.1 );
-		border-radius: 4px;
-		position: relative;
+		display: block;
+		max-inline-size: 100%;
+		block-size: auto;
 	}
 }
 

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -760,27 +760,24 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 
 .reader-full-post__featured-image {
 	display: block;
-	margin-block: 28px 26px;
-	margin-inline: 0;
-	max-inline-size: 100%;
-	overflow: hidden;
+	margin: 28px 0 26px;
 	position: relative;
-	/* stylelint-disable-next-line scales/radii */
-	border-radius: 5px;
 	&::after {
 		content: '';
 		position: absolute;
 		pointer-events: none;
-		inset: 0;
+		top: 0;
+		left: 0;
+		bottom: 0;
+		right: 0;
 		box-shadow: inset 0 0 0 1px rgba( 0, 0, 0, 0.1 );
 		border-radius: 5px; /* stylelint-disable-line scales/radii */
-		z-index: 1;
 	}
 	img {
-		block-size: auto;
+		border-radius: 4px;
+		position: relative;
 		display: block;
 		inline-size: 100%;
-		max-inline-size: 100%;
 	}
 }
 

--- a/client/blocks/reader-full-post/test/featured-image.jsx
+++ b/client/blocks/reader-full-post/test/featured-image.jsx
@@ -7,7 +7,9 @@ import FeaturedImage from '../featured-image';
 describe( 'FeaturedImage', () => {
 	test( 'sets the source to an empty string if the image fails to load', () => {
 		const nonExistentImage = 'http://sketchy-feed.com/missing-image-2.jpg';
-		const { container } = render( <FeaturedImage src={ nonExistentImage } /> );
+		const { container } = render(
+			<FeaturedImage post={ { featured_image: nonExistentImage } } maxWidth={ 600 } />
+		);
 		const div = container.getElementsByClassName( 'reader-full-post__featured-image' )[ 0 ];
 
 		fireEvent.error( div.getElementsByTagName( 'img' )[ 0 ] );

--- a/client/blocks/reader-full-post/test/featured-image.jsx
+++ b/client/blocks/reader-full-post/test/featured-image.jsx
@@ -2,13 +2,13 @@
  * @jest-environment jsdom
  */
 import { fireEvent, render } from '@testing-library/react';
-import FeaturedImage from '../featured-image';
+import ReaderFullPostFeaturedImage from '../featured-image';
 
-describe( 'FeaturedImage', () => {
+describe( 'ReaderFullPostFeaturedImage', () => {
 	test( 'sets the source to an empty string if the image fails to load', () => {
 		const nonExistentImage = 'http://sketchy-feed.com/missing-image-2.jpg';
 		const { container } = render(
-			<FeaturedImage post={ { featured_image: nonExistentImage } } maxWidth={ 600 } />
+			<ReaderFullPostFeaturedImage post={ { featured_image: nonExistentImage } } maxWidth={ 600 } />
 		);
 		const div = container.getElementsByClassName( 'reader-full-post__featured-image' )[ 0 ];
 

--- a/client/blocks/reader-full-post/test/featured-image.jsx
+++ b/client/blocks/reader-full-post/test/featured-image.jsx
@@ -2,10 +2,39 @@
  * @jest-environment jsdom
  */
 import { fireEvent, render } from '@testing-library/react';
+import resizeImageUrl from 'calypso/lib/resize-image-url';
 import ReaderFullPostFeaturedImage from '../featured-image';
 
+jest.mock( 'calypso/lib/resize-image-url', () => jest.fn( ( url ) => url ) );
+
 describe( 'ReaderFullPostFeaturedImage', () => {
-	test( 'sets the source to an empty string if the image fails to load', () => {
+	beforeEach( () => {
+		resizeImageUrl.mockImplementation( ( url ) => url );
+	} );
+
+	test( 'returns null when the post has no featured_image', () => {
+		const { container } = render(
+			<ReaderFullPostFeaturedImage post={ { title: 'Hello' } } maxWidth={ 600 } />
+		);
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	test( 'renders an image with the resized URL when the post has a featured_image', () => {
+		const featuredImage = 'https://example.com/featured.jpg';
+		resizeImageUrl.mockReturnValue( 'https://example.com/featured.jpg?w=1200' );
+
+		const { container } = render(
+			<ReaderFullPostFeaturedImage post={ { featured_image: featuredImage } } maxWidth={ 600 } />
+		);
+
+		const img = container.querySelector( '.reader-full-post__featured-image img' );
+		expect( img ).toBeTruthy();
+		expect( img ).toHaveAttribute( 'src', 'https://example.com/featured.jpg?w=1200' );
+		expect( resizeImageUrl ).toHaveBeenCalledWith( featuredImage, 600 );
+	} );
+
+	test( 'hides the wrapper when the image fails to load', () => {
 		const nonExistentImage = 'http://sketchy-feed.com/missing-image-2.jpg';
 		const { container } = render(
 			<ReaderFullPostFeaturedImage post={ { featured_image: nonExistentImage } } maxWidth={ 600 } />


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # https://linear.app/a8c/issue/READ-415/featured-images-forced-to-fixed-aspect-ratio-crop-on-web

## Proposed Changes

Show non-cropped featured image in the reader full post screen.
* Uses existing `*/reader-full-post/featured-image` component.  Previously this was using the reader-featured-image component which is setup for cards and thumbnails.
* Removes unused css for using the reader-featured-image component in the full post content.
* Updates the full post featured image component to use resizeImageUrl with contentWidth. Updates styles slightly so images fit as expected.
* Adds tests.
* Adds a comment to the reader-featured-image component used in cards/thumbnails to hopefully prevent this from invading the full-post screen again.
* Adds some test cases.
* Functionally this removes the link to the feed page when clicking the featured image from here, this is intended as discussed in slack.  p1774290544828479-slack-C03NLNTPZ2T


BEFORE | AFTERs
<img width="932" height="790" alt="Screenshot 2026-03-24 at 9 33 39 AM" src="https://github.com/user-attachments/assets/b0223bdc-903c-4243-b21a-b76357433678" />
<img width="877" height="1146" alt="Screenshot 2026-03-24 at 9 33 51 AM" src="https://github.com/user-attachments/assets/97bb6ce9-f105-4e21-bfff-6a0ee03aaf3a" />
<img width="887" height="718" alt="Screenshot 2026-03-24 at 9 34 58 AM" src="https://github.com/user-attachments/assets/98cf1af0-363d-4d0a-ab96-8f6d84c916fd" />
<img width="838" height="1025" alt="Screenshot 2026-03-24 at 9 35 11 AM" src="https://github.com/user-attachments/assets/db28e564-ded8-4099-82d5-a8ac45e68754" />
<img width="817" height="758" alt="Screenshot 2026-03-24 at 9 36 02 AM" src="https://github.com/user-attachments/assets/09c2bcd3-521b-4537-bc83-44db172553b2" />
<img width="827" height="960" alt="Screenshot 2026-03-24 at 9 36 26 AM" src="https://github.com/user-attachments/assets/90977975-c131-4b8b-966e-e33f8faa41a3" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Featured images in full post page are way too heavily cropped. Turns out they were using the component for cards and thumbnails instead of an existing component for showing the full image on the full post page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check how the featured image is displayed on the full post page for a variety of posts and image sizes/ratios. Verify it shows the full aspect ratios of the image and is not cropped, fits the content width, and works well across mobile viewport widths as well.
* Some examples:
    * `*/reader/feeds/68236971/posts/6004410310` 
    * `*/reader/feeds/157262415/posts/5989935985`
    * `*/reader/blogs/185584613/posts/20813`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?