### PR TITLE
Add a `/start-store` route

### DIFF
--- a/client/dashboard/app-ciab/index.tsx
+++ b/client/dashboard/app-ciab/index.tsx
@@ -43,6 +43,7 @@ boot( {
 		plugins: false,
 		commandPalette: false,
 		domainOnlySites: false,
+		startStoreRoute: true,
 	},
 	optIn: false,
 	components: {

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -46,6 +46,7 @@ export type AppConfig = {
 		me: MeSupports | false;
 		commandPalette: boolean;
 		domainOnlySites: boolean;
+		startStoreRoute: boolean;
 	};
 	posthog?: string;
 	optIn: boolean;
@@ -80,6 +81,7 @@ export const APP_CONTEXT_DEFAULT_CONFIG: AppConfig = {
 		me: false,
 		commandPalette: false,
 		domainOnlySites: false,
+		startStoreRoute: false,
 	},
 	optIn: false,
 	components: {},

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -46,7 +46,7 @@ export type AppConfig = {
 		me: MeSupports | false;
 		commandPalette: boolean;
 		domainOnlySites: boolean;
-		startStoreRoute: boolean;
+		startStoreRoute?: boolean;
 	};
 	posthog?: string;
 	optIn: boolean;

--- a/client/dashboard/app/router/index.tsx
+++ b/client/dashboard/app/router/index.tsx
@@ -10,6 +10,7 @@ import { createMeRoutes } from './me';
 import { createPluginsRoutes } from './plugins';
 import { rootRoute } from './root';
 import { createSitesRoutes } from './sites';
+import { startStoreRoute } from './start-store';
 import type { SiteTypeFeature } from '../../utils/site-type-feature-support';
 import type { AppConfig } from '../context';
 import type { ErrorInfo } from 'react';
@@ -65,6 +66,10 @@ const createRouteTree = ( config: AppConfig ) => {
 
 	if ( config.supports.me ) {
 		children.push( ...createMeRoutes( config ) );
+	}
+
+	if ( config.supports.startStoreRoute ) {
+		children.push( startStoreRoute );
 	}
 
 	return rootRoute.addChildren( children );

--- a/client/dashboard/app/router/start-store.ts
+++ b/client/dashboard/app/router/start-store.ts
@@ -1,0 +1,28 @@
+import { queryClient } from '@automattic/api-queries';
+import { createRoute, redirect } from '@tanstack/react-router';
+import { addQueryArgs } from '@wordpress/url';
+import { wpcomLink } from '../../utils/link';
+import { AUTH_QUERY_KEY } from '../auth';
+import { rootRoute } from './root';
+import type { User } from '@automattic/api-core';
+
+export const startStoreRoute = createRoute( {
+	getParentRoute: () => rootRoute,
+	path: '/start-store',
+	beforeLoad: () => {
+		const user = queryClient.getQueryData< User >( AUTH_QUERY_KEY );
+
+		if ( user && user.garden_site_count > 0 ) {
+			throw redirect( { to: '/sites', replace: true } );
+		}
+
+		// The site builder flow is served by a separate entry point (stepper),
+		// so we need a full page navigation rather than a TanStack redirect.
+		window.location.replace(
+			addQueryArgs( wpcomLink( '/setup/ai-site-builder-spec/site-spec' ), {
+				source: 'ciab-sites-dashboard',
+				ref: 'start-store',
+			} )
+		);
+	},
+} );

--- a/client/lib/site-spec/utils.ts
+++ b/client/lib/site-spec/utils.ts
@@ -200,7 +200,7 @@ export function getCiabSiteSpecConfig(): SiteSpecConfig {
 	return {
 		buildSiteUrl: '/setup/ai-site-builder/?create_garden_site=1&trigger_backend_build=0&spec_id=',
 		backButton: {
-			enabled: ref === 'new-site-popover',
+			enabled: ref === 'new-site-popover' || ref === 'start-store',
 			url: '/sites',
 		},
 		exitButton: {

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -1128,6 +1128,12 @@ export default function pages() {
 				( req ) => isAllowedCiabDashboardHostname( req.hostname )
 			);
 		} );
+		handleSectionPath(
+			CIAB_DASHBOARD_SECTION_DEFINITION,
+			'/start-store',
+			'entry-dashboard-ciab',
+			( req ) => isAllowedCiabDashboardHostname( req.hostname )
+		);
 	}
 
 	sections


### PR DESCRIPTION
ARC-1636

Adds a lightweight `/start-store` route that provides a simple entry point. For new users with no stores, they'll get sent into the creation flow. If the user already has stores, they'll land on `/sites`.

This is more or less a stopgap while there's no official entry point to this app other than marketing links.

## Testing

- Log into `my.woo.localhost:3000/start-store` on a new account (one with no stores), land in the site builder flow.
- Log into `my.woo.localhost:3000/start-store` on an account where you already have stores, land on `/sites`.