### PR TITLE
Stats: Add percentage-based Y-axis baseline for subscriber chart

### DIFF
--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -23,6 +23,7 @@ function StatsLineChart( {
 	),
 	zeroBaseline = true,
 	fixedDomain = false,
+	smartBaseline = false,
 	curveType = 'monotone',
 }: {
 	chartData: Array< {
@@ -37,6 +38,8 @@ function StatsLineChart( {
 	emptyState: JSX.Element;
 	zeroBaseline?: boolean;
 	fixedDomain?: boolean;
+	/** When true, calculates Y-axis baseline so data occupies ~50% of chart height, capped at 20% below min. */
+	smartBaseline?: boolean;
 	curveType?: 'smooth' | 'linear' | 'monotone';
 	onClick?: ( item: { data: { period: string } } ) => void;
 } ) {
@@ -60,15 +63,12 @@ function StatsLineChart( {
 
 	const isEmpty = ( chartData?.[ 0 ]?.data || [] ).length === 0;
 
-	const maxValue = useMemo(
-		() =>
-			Math.max(
-				...chartData.map( ( series ) =>
-					Math.max( ...series.data.map( ( d ) => d.value as number ) )
-				)
-			),
-		[ chartData ]
-	);
+	const [ minValue, maxValue ] = useMemo( () => {
+		const allValues = chartData.flatMap( ( series ) =>
+			series.data.map( ( d ) => d.value as number )
+		);
+		return [ Math.min( ...allValues ), Math.max( ...allValues ) ];
+	}, [ chartData ] );
 
 	const yNumTicks = useMemo( () => {
 		const uniqueValues = [
@@ -88,6 +88,26 @@ function StatsLineChart( {
 
 		return maxTicks - 1;
 	}, [ chartData, fixedDomain ] );
+
+	const yScaleDomain = useMemo( () => {
+		if ( fixedDomain ) {
+			return [ 0, maxValue ] as [ number, number ];
+		}
+		if ( smartBaseline && minValue > 0 ) {
+			const range = maxValue - minValue;
+			// Two padding strategies:
+			// 1. Range-based: padding = range, so data occupies ~50% of chart
+			// 2. Max 20% of min value to avoid excessive empty space
+			// Use the smaller of the two.
+			const rangePadding = range;
+			const maxPadding = minValue * 0.2;
+			const padding = Math.min( rangePadding, maxPadding );
+			const baseline = Math.max( 0, Math.floor( minValue - padding ) );
+
+			return [ baseline, maxValue ] as [ number, number ];
+		}
+		return undefined;
+	}, [ fixedDomain, smartBaseline, minValue, maxValue ] );
 
 	const yScaleType = useMemo( () => {
 		if ( chartData.length <= 1 ) {
@@ -206,8 +226,8 @@ function StatsLineChart( {
 					options={ {
 						yScale: {
 							type: yScaleType,
-							...( fixedDomain && { domain: [ 0, maxValue ] } ),
-							zero: zeroBaseline,
+							...( yScaleDomain && { domain: yScaleDomain } ),
+							zero: ! smartBaseline && zeroBaseline,
 						},
 						axis: {
 							x: {

--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -283,6 +283,7 @@ export default function SubscribersChartSection( {
 							curveType="monotone" // can use smooth, linear, monotone
 							EmptyState={ () => null }
 							zeroBaseline={ lineChartData.length > 1 }
+							smartBaseline={ lineChartData.length === 1 }
 							formatTimeTick={ formatTimeTick }
 							placeholder={ <StatsModulePlaceholder className="is-chart" isLoading /> }
 						/>


### PR DESCRIPTION
Part of STATS-229

## Proposed Changes

* Add a new `smartBaseline` prop to `StatsLineChart` component
* When enabled, calculates Y-axis baseline so data occupies ~50% of chart height, capped at 20% below min value
* Apply `smartBaseline` to the subscriber chart for single-series data

## Why are these changes being made?

The subscriber count chart was auto-scaling the Y-axis to min/max of actual data, making tiny fluctuations appear dramatic. For example, a variance of 4 subscribers out of ~140 would fill the entire chart height, visually suggesting catastrophic drops/gains when the actual change was negligible.

This provides a "happy medium" between:
- Starting from 0 (which makes small changes nearly invisible)
- Auto-scaling to min/max (which makes small changes look dramatic)

**Algorithm:**
```typescript
const padding = Math.min(range, minValue * 0.2);
const baseline = Math.max(0, minValue - padding);
```

| Scenario | min | max | range | padding | baseline | Data occupies |
|----------|-----|-----|-------|---------|----------|---------------|
| Tiny change | 140 | 144 | 4 | 4 | 136 | 50% |
| Small change | 1000 | 1010 | 10 | 10 | 990 | 50% |
| Large change | 100 | 150 | 50 | 20 | 80 | 71% |

## Testing Instructions

1. Go to Stats > Subscribers on a site with subscriber data
3. Verify the Y-axis no longer starts at the minimum subscriber count
4. Small fluctuations should appear proportional, not dramatic

| Before | After |
|-------|-------|
| <img width="400" height="393" alt="Screenshot 2026-03-24 at 11 37 32 AM" src="https://github.com/user-attachments/assets/75c1ab68-f4e9-4133-b1c9-60dc707698c5" /> | <img width="400" height="397" alt="Screenshot 2026-03-24 at 11 37 46 AM" src="https://github.com/user-attachments/assets/1dd58e8c-ac81-437f-a607-c5ce22dc4e5b" /> |

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?