### PR TITLE
Global expansion: Test adding a separate handling for the thank you page of the site-less paid media flow

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -119,7 +119,7 @@ export interface CheckoutThankYouProps {
 	upgradeIntent: string;
 	redirectTo?: string;
 	displayMode?: string;
-	flow?: string;
+	checkoutType?: string;
 }
 
 export interface CheckoutThankYouConnectedProps {
@@ -656,7 +656,7 @@ export class CheckoutThankYou extends Component<
 						primaryPurchase={ purchases[ 0 ] }
 						isEmailVerified={ this.props.isEmailVerified }
 						transferComplete={ this.props.transferComplete }
-						flow={ this.props.flow }
+						checkoutType={ this.props.checkoutType }
 					/>
 				);
 			} else if ( purchases.length === 1 && isSearch( purchases[ 0 ] ) ) {

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -655,6 +655,7 @@ export class CheckoutThankYou extends Component<
 						primaryPurchase={ purchases[ 0 ] }
 						isEmailVerified={ this.props.isEmailVerified }
 						transferComplete={ this.props.transferComplete }
+						flow={ this.props.flow }
 					/>
 				);
 			} else if ( purchases.length === 1 && isSearch( purchases[ 0 ] ) ) {

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -119,6 +119,7 @@ export interface CheckoutThankYouProps {
 	upgradeIntent: string;
 	redirectTo?: string;
 	displayMode?: string;
+	flow?: string;
 }
 
 export interface CheckoutThankYouConnectedProps {

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -254,9 +254,14 @@ function useRedirectOnTransactionSuccess( {
 		// For siteless purchases where the pre-transaction redirect URL defaults to '/'
 		// (because the new site's ID was unknown before the transaction), use the
 		// receipt's blogId to redirect to the new site's thank-you page instead.
+		// Preserve any query params from the original redirectTo (e.g., ?flow=unified).
+		const redirectToPath = redirectTo?.split( '?' )[ 0 ];
+		const redirectToParams = redirectTo?.includes( '?' ) ? redirectTo.split( '?' )[ 1 ] : '';
 		const effectiveRedirectTo =
-			( ! redirectTo || redirectTo === '/' ) && blogId && finalReceiptId
-				? `/checkout/thank-you/${ blogId }/${ finalReceiptId }`
+			( ! redirectTo || redirectToPath === '/' ) && blogId && finalReceiptId
+				? `/checkout/thank-you/${ blogId }/${ finalReceiptId }${
+						redirectToParams ? '?' + redirectToParams : ''
+				  }`
 				: redirectTo;
 
 		const redirectInstructions = getRedirectFromPendingPage( {

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -255,13 +255,12 @@ function useRedirectOnTransactionSuccess( {
 		// (because the new site's ID was unknown before the transaction), use the
 		// receipt's blogId to redirect to the new site's thank-you page instead.
 		// Preserve any query params from the original redirectTo (e.g., ?flow=unified).
-		const redirectToPath = redirectTo?.split( '?' )[ 0 ];
-		const redirectToParams = redirectTo?.includes( '?' ) ? redirectTo.split( '?' )[ 1 ] : '';
+		const { pathname, search } = redirectTo
+			? getUrlParts( redirectTo )
+			: { pathname: undefined, search: '' };
 		const effectiveRedirectTo =
-			( ! redirectTo || redirectToPath === '/' ) && blogId && finalReceiptId
-				? `/checkout/thank-you/${ blogId }/${ finalReceiptId }${
-						redirectToParams ? '?' + redirectToParams : ''
-				  }`
+			( ! redirectTo || pathname === '/' ) && blogId && finalReceiptId
+				? `/checkout/thank-you/${ blogId }/${ finalReceiptId }${ search }`
 				: redirectTo;
 
 		const redirectInstructions = getRedirectFromPendingPage( {

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
@@ -12,6 +12,7 @@ import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
 import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
+import { hasDomainCredit } from 'calypso/state/sites/plans/selectors';
 import { getSiteOptions, getSiteUrl, getSiteWooCommerceUrl } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import ThankYouPlanProduct from '../products/plan-product';
@@ -29,6 +30,7 @@ interface PlanOnlyThankYouProps {
 	removeNotice: ( noticeId: string ) => void;
 	successNotice: ( text: string, noticeOptions?: object ) => void;
 	transferComplete?: boolean;
+	flow?: string;
 }
 
 const isMonthsOld = ( months: number, rawDate?: string ) => {
@@ -47,6 +49,7 @@ const PlanOnlyThankYou = ( {
 	removeNotice,
 	successNotice,
 	transferComplete,
+	flow,
 }: PlanOnlyThankYouProps ) => {
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
@@ -95,7 +98,9 @@ const PlanOnlyThankYou = ( {
 	// we can be confident that `siteId` is a number and not `null`
 	const siteAdminUrl = useSelector( ( state ) => getSiteWooCommerceUrl( state, siteId as number ) );
 	const emailAddress = useSelector( getCurrentUserEmail );
+	const siteDomainCredit = useSelector( ( state ) => hasDomainCredit( state, siteId ) );
 
+	let title;
 	let subtitle;
 	let headerButtons;
 
@@ -133,6 +138,15 @@ const PlanOnlyThankYou = ( {
 				</Button>
 			);
 		}
+	} else if ( flow === 'unified' ) {
+		title = translate( 'Thank you for your purchase!' );
+		subtitle = siteDomainCredit
+			? translate(
+					"You're one step away from building your WordPress site. Click below to get started. You also have a free domain credit to redeem anytime in your dashboard."
+			  )
+			: translate(
+					"You're one step away from building your WordPress site. Click below to get started."
+			  );
 	} else {
 		subtitle = translate(
 			'All set! Start exploring the features included with your {{strong}}%(productName)s{{/strong}} plan',
@@ -192,7 +206,7 @@ const PlanOnlyThankYou = ( {
 					isEmailVerified && <WpAdminAutoLogin site={ { URL: siteUrl } } delay={ 0 } />
 			}
 			<ThankYouV2
-				title={ translate( 'Get the best out of your site' ) }
+				title={ title ?? translate( 'Get the best out of your site' ) }
 				subtitle={ preventWidows( subtitle ) }
 				headerButtons={ headerButtons }
 				products={

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
@@ -12,7 +12,6 @@ import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
 import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
-import { hasDomainCredit } from 'calypso/state/sites/plans/selectors';
 import { getSiteOptions, getSiteUrl, getSiteWooCommerceUrl } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import ThankYouPlanProduct from '../products/plan-product';
@@ -98,7 +97,7 @@ const PlanOnlyThankYou = ( {
 	// we can be confident that `siteId` is a number and not `null`
 	const siteAdminUrl = useSelector( ( state ) => getSiteWooCommerceUrl( state, siteId as number ) );
 	const emailAddress = useSelector( getCurrentUserEmail );
-	const siteDomainCredit = useSelector( ( state ) => hasDomainCredit( state, siteId ) );
+	const siteUrl = useSelector( ( state ) => getSiteUrl( state, siteId as number ) );
 
 	let title;
 	let subtitle;
@@ -139,14 +138,10 @@ const PlanOnlyThankYou = ( {
 			);
 		}
 	} else if ( checkoutType === 'unified' ) {
-		title = translate( 'Thank you for your purchase!' );
-		subtitle = siteDomainCredit
-			? translate(
-					"You're one step away from building your WordPress site. Click below to get started. You also have a free domain credit to redeem anytime in your dashboard."
-			  )
-			: translate(
-					"You're one step away from building your WordPress site. Click below to get started."
-			  );
+		title = translate( 'Purchase successful' );
+		subtitle = translate(
+			"You're all set to start building your WordPress site. Jump into your dashboard to create and customize your site."
+		);
 	} else {
 		subtitle = translate(
 			'All set! Start exploring the features included with your {{strong}}%(productName)s{{/strong}} plan',
@@ -194,8 +189,6 @@ const PlanOnlyThankYou = ( {
 		} );
 	}
 
-	const siteUrl = useSelector( ( state ) => getSiteUrl( state, siteId as number ) );
-
 	return (
 		<>
 			{
@@ -214,6 +207,7 @@ const PlanOnlyThankYou = ( {
 						purchase={ primaryPurchase }
 						siteSlug={ siteSlug }
 						siteId={ siteId }
+						checkoutType={ checkoutType }
 					/>
 				}
 				footerDetails={ footerDetails }

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
@@ -30,7 +30,7 @@ interface PlanOnlyThankYouProps {
 	removeNotice: ( noticeId: string ) => void;
 	successNotice: ( text: string, noticeOptions?: object ) => void;
 	transferComplete?: boolean;
-	flow?: string;
+	checkoutType?: string;
 }
 
 const isMonthsOld = ( months: number, rawDate?: string ) => {
@@ -49,7 +49,7 @@ const PlanOnlyThankYou = ( {
 	removeNotice,
 	successNotice,
 	transferComplete,
-	flow,
+	checkoutType,
 }: PlanOnlyThankYouProps ) => {
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
@@ -138,7 +138,7 @@ const PlanOnlyThankYou = ( {
 				</Button>
 			);
 		}
-	} else if ( flow === 'unified' ) {
+	} else if ( checkoutType === 'unified' ) {
 		title = translate( 'Thank you for your purchase!' );
 		subtitle = siteDomainCredit
 			? translate(

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/plan-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/plan-product.tsx
@@ -20,12 +20,14 @@ export type ThankYouPlanProductProps = {
 	purchase: ReceiptPurchase;
 	siteSlug: string | null;
 	siteId: number | null;
+	checkoutType?: string;
 };
 
 export default function ThankYouPlanProduct( {
 	purchase,
 	siteSlug,
 	siteId,
+	checkoutType,
 }: ThankYouPlanProductProps ) {
 	const isLoadingPurchases = useSelector(
 		( state ) => isFetchingSitePurchases( state ) || ! hasLoadedSitePurchasesFromServer( state )
@@ -117,7 +119,9 @@ export default function ThankYouPlanProduct( {
 							href={ letsWorkHref }
 							onClick={ letsWorkButtonOnClick }
 						>
-							{ translate( 'Let’s work on the site' ) }
+							{ checkoutType === 'unified'
+								? translate( 'Go to dashboard' )
+								: translate( 'Let’s work on the site' ) }
 						</Button>
 					) }
 					<Button variant="secondary" href={ `/plans/my-plan/${ siteSlug }` }>

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -448,7 +448,7 @@ export function checkoutThankYou( context, next ) {
 				displayMode={ displayMode }
 				domainOnlySiteFlow={ ! context.params.site }
 				email={ context.query.email }
-				flow={ context.query.flow }
+				checkoutType={ context.query.checkout_type }
 				gsuiteReceiptId={ gsuiteReceiptId }
 				receiptId={ receiptId }
 				redirectTo={ context.query.redirect_to }

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -448,6 +448,7 @@ export function checkoutThankYou( context, next ) {
 				displayMode={ displayMode }
 				domainOnlySiteFlow={ ! context.params.site }
 				email={ context.query.email }
+				flow={ context.query.flow }
 				gsuiteReceiptId={ gsuiteReceiptId }
 				receiptId={ receiptId }
 				redirectTo={ context.query.redirect_to }

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -334,6 +334,11 @@ export default function getThankYouPageUrl( {
 			debug( 'redirecting to the saved post-checkout destination' );
 			return addQueryArgs( { siteId }, urlFromCookie );
 		}
+
+		// Fallback for unified checkout - let the pending page construct the URL
+		// using the blogId from the receipt, and preserve the flow param
+		debug( 'unified checkout fallback, letting pending page construct URL' );
+		return '/?flow=unified';
 	}
 
 	// If there is no purchase, then send the user to a generic page (not

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -336,9 +336,9 @@ export default function getThankYouPageUrl( {
 		}
 
 		// Fallback for unified checkout - let the pending page construct the URL
-		// using the blogId from the receipt, and preserve the flow param
+		// using the blogId from the receipt, and preserve the checkout_type param
 		debug( 'unified checkout fallback, letting pending page construct URL' );
-		return addQueryArgs( { flow: 'unified' }, '/' );
+		return addQueryArgs( { checkout_type: 'unified' }, '/' );
 	}
 
 	// If there is no purchase, then send the user to a generic page (not

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -338,7 +338,7 @@ export default function getThankYouPageUrl( {
 		// Fallback for unified checkout - let the pending page construct the URL
 		// using the blogId from the receipt, and preserve the flow param
 		debug( 'unified checkout fallback, letting pending page construct URL' );
-		return '/?flow=unified';
+		return addQueryArgs( { flow: 'unified' }, '/' );
 	}
 
 	// If there is no purchase, then send the user to a generic page (not

--- a/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
@@ -1991,7 +1991,7 @@ describe( 'getThankYouPageUrl', () => {
 			);
 		} );
 
-		it( 'should return /?flow=unified fallback when cookie URL does not contain post-checkout-onboarding path even if siteSlug is provided', () => {
+		it( 'should return /?checkout_type=unified fallback when cookie URL does not contain post-checkout-onboarding path even if siteSlug is provided', () => {
 			const getUrlFromCookie = jest.fn( () => '/some/other/path' );
 			const siteId = 12345;
 
@@ -2003,10 +2003,10 @@ describe( 'getThankYouPageUrl', () => {
 				getUrlFromCookie,
 			} );
 
-			expect( url ).toBe( '/?flow=unified' );
+			expect( url ).toBe( '/?checkout_type=unified' );
 		} );
 
-		it( 'should return /?flow=unified fallback when no cookie URL is available even if siteSlug is provided', () => {
+		it( 'should return /?checkout_type=unified fallback when no cookie URL is available even if siteSlug is provided', () => {
 			const getUrlFromCookie = jest.fn( () => undefined );
 			const siteId = 12345;
 
@@ -2018,10 +2018,10 @@ describe( 'getThankYouPageUrl', () => {
 				getUrlFromCookie,
 			} );
 
-			expect( url ).toBe( '/?flow=unified' );
+			expect( url ).toBe( '/?checkout_type=unified' );
 		} );
 
-		it( 'should return /?flow=unified fallback when cookie URL is empty string even if siteSlug is provided', () => {
+		it( 'should return /?checkout_type=unified fallback when cookie URL is empty string even if siteSlug is provided', () => {
 			const getUrlFromCookie = jest.fn( () => '' );
 			const siteId = 12345;
 
@@ -2033,7 +2033,7 @@ describe( 'getThankYouPageUrl', () => {
 				getUrlFromCookie,
 			} );
 
-			expect( url ).toBe( '/?flow=unified' );
+			expect( url ).toBe( '/?checkout_type=unified' );
 		} );
 
 		it( 'should redirect to checkout thank you page when cart has ecommerce plan', () => {

--- a/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
@@ -1991,7 +1991,7 @@ describe( 'getThankYouPageUrl', () => {
 			);
 		} );
 
-		it( 'should fall through to other logic when cookie URL does not contain post-checkout-onboarding path', () => {
+		it( 'should return /?flow=unified fallback when cookie URL does not contain post-checkout-onboarding path even if siteSlug is provided', () => {
 			const getUrlFromCookie = jest.fn( () => '/some/other/path' );
 			const siteId = 12345;
 
@@ -2003,10 +2003,10 @@ describe( 'getThankYouPageUrl', () => {
 				getUrlFromCookie,
 			} );
 
-			expect( url ).toBe( '/checkout/thank-you/foo.bar/:receiptId' );
+			expect( url ).toBe( '/?flow=unified' );
 		} );
 
-		it( 'should fall through to other logic when no cookie URL is available', () => {
+		it( 'should return /?flow=unified fallback when no cookie URL is available even if siteSlug is provided', () => {
 			const getUrlFromCookie = jest.fn( () => undefined );
 			const siteId = 12345;
 
@@ -2018,10 +2018,10 @@ describe( 'getThankYouPageUrl', () => {
 				getUrlFromCookie,
 			} );
 
-			expect( url ).toBe( '/checkout/thank-you/foo.bar/:receiptId' );
+			expect( url ).toBe( '/?flow=unified' );
 		} );
 
-		it( 'should fall through to other logic when cookie URL is empty string', () => {
+		it( 'should return /?flow=unified fallback when cookie URL is empty string even if siteSlug is provided', () => {
 			const getUrlFromCookie = jest.fn( () => '' );
 			const siteId = 12345;
 
@@ -2033,7 +2033,7 @@ describe( 'getThankYouPageUrl', () => {
 				getUrlFromCookie,
 			} );
 
-			expect( url ).toBe( '/checkout/thank-you/foo.bar/:receiptId' );
+			expect( url ).toBe( '/?flow=unified' );
 		} );
 
 		it( 'should redirect to checkout thank you page when cart has ecommerce plan', () => {

--- a/client/my-sites/checkout/src/test/pending-page.ts
+++ b/client/my-sites/checkout/src/test/pending-page.ts
@@ -473,16 +473,16 @@ describe( 'getRedirectFromPendingPage', () => {
 	it( 'returns a url with preserved query params if there is a receipt', () => {
 		const actual = getRedirectFromPendingPage( {
 			isLoadingOrder: false,
-			redirectTo: '/checkout/thank-you/12345/67890?flow=unified',
+			redirectTo: '/checkout/thank-you/12345/67890?checkout_type=unified',
 			receiptId: 67890,
 		} );
-		expect( actual ).toEqual( { url: '/checkout/thank-you/12345/67890?flow=unified' } );
+		expect( actual ).toEqual( { url: '/checkout/thank-you/12345/67890?checkout_type=unified' } );
 	} );
 
 	it( 'returns a url with preserved query params if the transaction is successful', () => {
 		const actual = getRedirectFromPendingPage( {
 			isLoadingOrder: false,
-			redirectTo: '/checkout/thank-you/12345/:receiptId?flow=unified',
+			redirectTo: '/checkout/thank-you/12345/:receiptId?checkout_type=unified',
 			siteSlug: 'example.com',
 			transaction: {
 				orderId: 1,
@@ -491,17 +491,17 @@ describe( 'getRedirectFromPendingPage', () => {
 				processingStatus: SUCCESS,
 			},
 		} );
-		expect( actual ).toEqual( { url: '/checkout/thank-you/12345/67890?flow=unified' } );
+		expect( actual ).toEqual( { url: '/checkout/thank-you/12345/67890?checkout_type=unified' } );
 	} );
 
 	it( 'returns a url with multiple preserved query params if there is a receipt', () => {
 		const actual = getRedirectFromPendingPage( {
 			isLoadingOrder: false,
-			redirectTo: '/checkout/thank-you/12345/67890?flow=unified&source=paid-media',
+			redirectTo: '/checkout/thank-you/12345/67890?checkout_type=unified&source=paid-media',
 			receiptId: 67890,
 		} );
 		expect( actual ).toEqual( {
-			url: '/checkout/thank-you/12345/67890?flow=unified&source=paid-media',
+			url: '/checkout/thank-you/12345/67890?checkout_type=unified&source=paid-media',
 		} );
 	} );
 } );

--- a/client/my-sites/checkout/src/test/pending-page.ts
+++ b/client/my-sites/checkout/src/test/pending-page.ts
@@ -469,4 +469,39 @@ describe( 'getRedirectFromPendingPage', () => {
 		} );
 		expect( actual ).toBeUndefined();
 	} );
+
+	it( 'returns a url with preserved query params if there is a receipt', () => {
+		const actual = getRedirectFromPendingPage( {
+			isLoadingOrder: false,
+			redirectTo: '/checkout/thank-you/12345/67890?flow=unified',
+			receiptId: 67890,
+		} );
+		expect( actual ).toEqual( { url: '/checkout/thank-you/12345/67890?flow=unified' } );
+	} );
+
+	it( 'returns a url with preserved query params if the transaction is successful', () => {
+		const actual = getRedirectFromPendingPage( {
+			isLoadingOrder: false,
+			redirectTo: '/checkout/thank-you/12345/:receiptId?flow=unified',
+			siteSlug: 'example.com',
+			transaction: {
+				orderId: 1,
+				userId: 1,
+				receiptId: 67890,
+				processingStatus: SUCCESS,
+			},
+		} );
+		expect( actual ).toEqual( { url: '/checkout/thank-you/12345/67890?flow=unified' } );
+	} );
+
+	it( 'returns a url with multiple preserved query params if there is a receipt', () => {
+		const actual = getRedirectFromPendingPage( {
+			isLoadingOrder: false,
+			redirectTo: '/checkout/thank-you/12345/67890?flow=unified&source=paid-media',
+			receiptId: 67890,
+		} );
+		expect( actual ).toEqual( {
+			url: '/checkout/thank-you/12345/67890?flow=unified&source=paid-media',
+		} );
+	} );
 } );


### PR DESCRIPTION

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of GE-53

## Proposed Changes

* Detect the flow on the thank you page, by passing it as a query parameter, so that we can show a different message on the plan "thank you" page for users coming through the site-less/unified paid media flow.
* Needs more testing of the new condition, i.e. if there are cases where the unified (site-less) flow _should_ fall through, and be handled in another conditional.
* I'm also wondering if there are better ways of handling this.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* On request from Global Expansion

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Go to https://calypso.localhost:3000/checkout/unified/personal
* Purchase a plan
* You should be redirected to the thank you page post-purchase, but with a different message, per the unified value in checkout_type. This parameter is carried via the pending route, and we return early with the `/` path, as there's a special handling for this in the pending component (while it now also handles and forwards URL parameters).
* You can remove this parameter from the URL and refresh the page, and you'll see the original default page.
* Commerce plans will not reach this new thank you page, as they have a different conditional handling.

With the parameter:
<img width="1721" height="435" alt="Screenshot 2026-03-25 at 13 52 27" src="https://github.com/user-attachments/assets/8fab4605-2051-48be-8b74-46ecaeacd75d" />


Without the parameter:
<img width="1719" height="515" alt="Screenshot 2026-03-25 at 13 59 47" src="https://github.com/user-attachments/assets/3c59d668-4479-409e-a2db-2b5fe58f4dbd" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
