### PR TITLE
Split Base CI Images: Fix entrypoint error in Teamcity settings

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -349,7 +349,7 @@ object BuildToolchainPreviewImages : BuildType({
 				#!/usr/bin/env bash
 				set -euo pipefail
 
-				docker run --rm registry.a8c.com/calypso/toolchain:%build.number% bash -lc \
+				docker run --rm --entrypoint /bin/bash registry.a8c.com/calypso/toolchain:%build.number% -lc \
 					'node --version && yarn --version && git --version && jq --version'
 			""".trimIndent()
 		}
@@ -359,7 +359,7 @@ object BuildToolchainPreviewImages : BuildType({
 				#!/usr/bin/env bash
 				set -euo pipefail
 
-				docker run --rm registry.a8c.com/calypso/ci-e2e-toolchain:%build.number% bash -lc '
+				docker run --rm --entrypoint /bin/bash registry.a8c.com/calypso/ci-e2e-toolchain:%build.number% -lc '
 					xvfb-run --help >/dev/null &&
 					aws --version &&
 					dpkg -s fonts-noto-cjk fonts-noto-core libgtk-3-0 libgbm1 libnss3 >/dev/null
@@ -372,7 +372,7 @@ object BuildToolchainPreviewImages : BuildType({
 				#!/usr/bin/env bash
 				set -euo pipefail
 
-				docker run --rm registry.a8c.com/calypso/ci-wpcom-toolchain:%build.number% bash -lc \
+				docker run --rm --entrypoint /bin/bash registry.a8c.com/calypso/ci-wpcom-toolchain:%build.number% -lc \
 					'php -v && composer --version && docker-compose version && sentry-cli --version'
 			""".trimIndent()
 		}
@@ -493,7 +493,8 @@ object BuildCacheSeedPreviewImage : BuildType({
 
 				trap 'docker image rm -f calypso/cache-seed-smoke:%build.number% >/dev/null 2>&1 || true' EXIT
 
-				docker run --rm calypso/cache-seed-smoke:%build.number% bash -lc 'du -sh /calypso/.cache /calypso/.yarn'
+				docker run --rm --entrypoint /bin/bash calypso/cache-seed-smoke:%build.number% -lc \
+					'du -sh /calypso/.cache /calypso/.yarn'
 			""".trimIndent()
 		}
 		script {


### PR DESCRIPTION

## Proposed Changes

* See also #109478.
* Try to fix this error

<img width="393" height="75" alt="Screenshot 2026-03-23 at 4 55 23 PM" src="https://github.com/user-attachments/assets/c8308e80-b270-4677-a9a9-44eb72a3a7be" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Will have to try on TC. This does not affect production at all

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
