### PR TITLE
Activity Log v2: Add Jetpack logo to header

### DIFF
--- a/client/my-sites/activity/activity-log-v2/index.tsx
+++ b/client/my-sites/activity/activity-log-v2/index.tsx
@@ -10,6 +10,7 @@ import QuerySiteCredentials from 'calypso/components/data/query-site-credentials
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import Upsell from 'calypso/components/jetpack/upsell';
+import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
@@ -133,7 +134,7 @@ const ActivityLogV2: FunctionComponent = () => {
 				jetpackCloudHeader
 			) : (
 				<NavigationHeader
-					title={ translate( 'Activity' ) }
+					title={ <JetpackTitle title={ translate( 'Activity' ) } /> }
 					subtitle={ translate(
 						'This is the complete event history for your site. Filter by date range and/or activity type.'
 					) }


### PR DESCRIPTION
Part of JETPACK-1361

## Proposed Changes

* Add `JetpackTitle` component to the Activity Log v2 `NavigationHeader`, showing the Jetpack logo next to the page title.
* Consistent with other Jetpack pages (Scan, Backup, Monetize, etc.) updated in #108987.

## Why are these changes being made?

* Part of the "Standardize the Jetpack Header" project. All Jetpack product pages should show the Jetpack logo in their header for consistent branding.

## Testing Instructions

Activity Log v2 is currently only enabled in Jetpack Cloud environments (via the `activity-log/v2` feature flag). In Jetpack Cloud, the JPC/A4A header path renders instead of `NavigationHeader`, so this change applies to the WP.com path.

To test locally in WP.com Calypso:
1. Add `"activity-log/v2": true` to `config/development.json` features
2. Run `yarn start`
3. Navigate to `/activity-log/<site-slug>`
4. Verify the Jetpack logo appears next to "Activity" in the header
5. Verify the subtitle text remains unchanged

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?