### PR TITLE
Dockerfile: Add cache_mode=base|seed|none to the main app Docker build

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -97,7 +97,9 @@ object BuildDockerImage : BuildType({
     }
 
 	params {
+		text("cache_mode", "base", label = "Docker build cache mode", description = "How the main Docker build sources warm caches. Allowed values: base, seed, none.", allowEmpty = false)
 		text("base_image", "registry.a8c.com/calypso/base:latest", label = "Base docker image", description = "Base docker image", allowEmpty = false)
+		text("cache_seed_image", "registry.a8c.com/calypso/cache-seed:latest", label = "Cache seed image", description = "Cache-only image used when cache_mode=seed", allowEmpty = false)
 		text("base_image_publish_tag", "latest", label = "Tag to use for the published base image", description = "Base docker image tag", allowEmpty = false)
 		checkbox(
 			name = "MANUAL_SENTRY_RELEASE",
@@ -111,7 +113,7 @@ object BuildDockerImage : BuildType({
 			name = "UPDATE_BASE_IMAGE_CACHE",
 			value = "false",
 			label = "Update the base image from the cache.",
-			description = "Updates the base image by copying .cache files from the current build. Runs on trunk by default if the cache invalidates during the build.",
+			description = "Updates the base image by copying .cache files from the current build. This applies only when cache_mode=base.",
 			checked = "true",
 			unchecked = "false"
 		)
@@ -206,8 +208,9 @@ object BuildDockerImage : BuildType({
 			--label com.a8c.build-id=%teamcity.build.id%
 			--build-arg workers=32
 			--build-arg node_memory=16384
-			--build-arg use_cache=true
+			--build-arg cache_mode=%cache_mode%
 			--build-arg base_image=%base_image%
+			--build-arg cache_seed_image=%cache_seed_image%
 			--build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber}
 			--build-arg profile=%PROFILE%
 			--build-arg manual_sentry_release=%MANUAL_SENTRY_RELEASE%
@@ -314,6 +317,7 @@ object BuildDockerImage : BuildType({
 		dockerCommand {
 			name = "Rebuild cache image"
 			conditions {
+				equals("cache_mode", "base")
 				equals("UPDATE_BASE_IMAGE_CACHE", "true")
 				equals("teamcity.build.branch.is_default", "true")
 			}
@@ -334,6 +338,7 @@ object BuildDockerImage : BuildType({
 		dockerCommand {
 			name = "Push cache image"
 			conditions {
+				equals("cache_mode", "base")
 				equals("UPDATE_BASE_IMAGE_CACHE", "true")
 				equals("teamcity.build.branch.is_default", "true")
 			}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,48 @@
 # syntax=docker/dockerfile:1.20
 
-ARG use_cache=false
+ARG cache_mode=base
 ARG node_version=22.9.0
 ARG base_image=registry.a8c.com/calypso/base:latest
+ARG cache_seed_image=registry.a8c.com/calypso/cache-seed:latest
 
 ###################
-FROM node:${node_version}-bullseye-slim AS builder-cache-false
+FROM node:${node_version}-bullseye-slim AS builder-cache-none
+
+WORKDIR /calypso
+ENV HOME=/calypso
+ENV NPM_CONFIG_CACHE=/calypso/.cache
+ENV PERSISTENT_CACHE=true
+
+RUN mkdir -p /calypso/.cache /calypso/.yarn
 
 
 ###################
 # This image contains a directory /calypso/.cache which includes caches
 # for yarn, terser, css-loader and babel.
-FROM ${base_image} AS builder-cache-true
+FROM ${base_image} AS builder-cache-base
 
 ENV NPM_CONFIG_CACHE=/calypso/.cache
 ENV PERSISTENT_CACHE=true
 
 ###################
+FROM ${cache_seed_image} AS cache-seed-source
+
+###################
+FROM node:${node_version}-bullseye-slim AS builder-cache-seed
+
+WORKDIR /calypso
+ENV HOME=/calypso
+ENV NPM_CONFIG_CACHE=/calypso/.cache
+ENV PERSISTENT_CACHE=true
+
+COPY --from=cache-seed-source /calypso/.cache /calypso/.cache
+COPY --from=cache-seed-source /calypso/.yarn /calypso/.yarn
+
+###################
 # Dedicated dependency-install stage.
 # By copying only manifests and the lockfile first, we can cache
 # the slow yarn install and skip it when only source files change.
-FROM builder-cache-${use_cache} AS deps
+FROM builder-cache-${cache_mode} AS deps
 
 WORKDIR /calypso
 ENV PLAYWRIGHT_SKIP_DOWNLOAD=true

--- a/Dockerfile.cache-seed
+++ b/Dockerfile.cache-seed
@@ -74,7 +74,7 @@ ENV CALYPSO_ENV=production
 ENV BUILD_TRANSLATION_CHUNKS=true
 ENV WORKERS=$workers
 ENV NODE_OPTIONS=--max-old-space-size=$node_memory
-ENV COMMIT_SHA $commit_sha
+ENV COMMIT_SHA=$commit_sha
 
 COPY --link . /calypso/
 

--- a/Dockerfile.toolchain
+++ b/Dockerfile.toolchain
@@ -53,7 +53,6 @@ ARG cache_seed_key
 
 LABEL org.opencontainers.image.revision=$commit_sha \
 	io.calypso.cache-seed-key=$cache_seed_key
-ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=
 ENV DISPLAY=:99
 
 RUN apt-get update \

--- a/client/my-sites/customer-home/components/home-content/index.jsx
+++ b/client/my-sites/customer-home/components/home-content/index.jsx
@@ -212,7 +212,7 @@ const HomeContent = ( {
 				navigationItems={ [] }
 				mobileItem={ null }
 				title={ translate( 'My Home' ) }
-				subtitle={ translate( 'Your hub for next steps, support center, and quick links.' ) }
+				subtitle={ translate( 'Your hub2 for next steps, support center, and quick links.' ) }
 			>
 				{ headerActions }
 			</NavigationHeader>

--- a/client/my-sites/customer-home/components/home-content/index.jsx
+++ b/client/my-sites/customer-home/components/home-content/index.jsx
@@ -212,7 +212,7 @@ const HomeContent = ( {
 				navigationItems={ [] }
 				mobileItem={ null }
 				title={ translate( 'My Home' ) }
-				subtitle={ translate( 'Your hub2 for next steps, support center, and quick links.' ) }
+				subtitle={ translate( 'Your hub for next steps, support center, and quick links.' ) }
 			>
 				{ headerActions }
 			</NavigationHeader>


### PR DESCRIPTION
The toolchain and cache-seed preview images landed in #109478 and are building successfully in TeamCity. This PR wires up the main app Dockerfile so it can actually use them.

The main build now supports three cache modes via a cache_mode build arg:
 
- base (default) — the current behavior, unchanged
- seed - copies .cache/ and .yarn/ from a dedicated cache-seed image into a clean Node builder
- none - same clean builder, but with no imported cache (for testing correctness or as a fallback)

No defaults are changed. Existing builds behave exactly as before.

## Proposed Changes

*

## Why are these changes being made?

*

## Testing Instructions

The existing production path should be the same as before when running with the defaults (since cache_mode defaults to `base`).
To try the new modes, run a custom build of `Docker image` with:


* Seed mode:
  * cache_mode=seed
  * cache_seed_image=registry.a8c.com/calypso/cache-seed:preview.TAG
  * UPDATE_BASE_IMAGE_CACHE=false
* None mode:
  * cache_mode=none

### Local validation (before → base-after → seed)

I built all three app images from the same trunk checkout and compared file hashes. Note, if building on mac you will need to add `RUN apt-get update && apt-get install -y python3 make g++ bzip2 && rm -rf /var/lib/apt/lists/*` to the images where necessary.

```
docker build -t calypso-base-before \
    --target base --no-cache \
    --build-arg workers=16 --build-arg node_memory=12000 \
    -f Dockerfile.base . 2>&1 | tee build-base-before.log


docker build -t calypso-app-before \
    --build-arg cache_mode=base \
    --build-arg base_image=calypso-base-before \
    --build-arg workers=16 --build-arg node_memory=12000 \
    --no-cache . 2>&1 | tee build-app-before.log

# -- 

docker build -t calypso-cache-seed \
    --target cache-seed --no-cache \
    --build-arg workers=16 --build-arg node_memory=12000 \
    -f Dockerfile.cache-seed . 2>&1 | tee build-cache-seed.log
	
# Old path
docker build -t calypso-app-base-after \
    --build-arg cache_mode=base \
    --build-arg base_image=calypso-base-before \
    --build-arg workers=16 --build-arg node_memory=12000 \
    --no-cache . 2>&1 | tee build-app-base-after.log

# New path
docker build -t calypso-app-seed \
    --build-arg cache_mode=seed \
    --build-arg cache_seed_image=calypso-cache-seed \
    --build-arg workers=16 --build-arg node_memory=12000 \
    --no-cache . 2>&1 | tee build-app-seed.log
```

There is more info about using local docker builds to test here: #109303.

Results:

- **before** to  **base-after** (same `cache_mode=base`, only the Dockerfile changes): This is mostly the same, except for differences: one minor webpack tree-shaking difference in a Sentry vendor chunk (99038). Then its hash is cascading into the runtime chunk and manifest files. There's also translation chunk key ordering. And a dtrace-provider build artifact from HOME changing.
- **base-after** to **seed**: only `modules.json` and `server.js` differ (chunk hash references). No functional changes.


## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
