### PR TITLE
MSD: Extract shared staging site logic into useStagingSite hook

### DIFF
--- a/client/dashboard/components/environment/index.tsx
+++ b/client/dashboard/components/environment/index.tsx
@@ -1,4 +1,8 @@
-import { Icon, __experimentalHStack as HStack } from '@wordpress/components';
+import {
+	Icon,
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { staging, production } from '../icons';
 
@@ -9,19 +13,13 @@ interface EnvironmentProps {
 }
 
 const Environment = ( { environmentType }: EnvironmentProps ) => {
-	if ( environmentType === 'staging' ) {
-		return (
-			<HStack justify="flex-start" spacing={ 1 } expanded={ false } style={ { flexShrink: 0 } }>
-				<Icon icon={ staging } />
-				<span>{ __( 'Staging' ) }</span>
-			</HStack>
-		);
-	}
+	const icon = environmentType === 'staging' ? staging : production;
+	const label = environmentType === 'staging' ? __( 'Staging' ) : __( 'Production' );
 
 	return (
-		<HStack justify="flex-start" spacing={ 1 } expanded={ false } style={ { flexShrink: 0 } }>
-			<Icon icon={ production } />
-			<span>{ __( 'Production' ) }</span>
+		<HStack justify="flex-start" spacing={ 2 } expanded={ false } style={ { flexShrink: 0 } }>
+			<Icon icon={ icon } size={ 20 } />
+			<Text weight={ 500 }>{ label }</Text>
 		</HStack>
 	);
 };

--- a/client/dashboard/sites/site-sidebar/index.tsx
+++ b/client/dashboard/sites/site-sidebar/index.tsx
@@ -38,7 +38,7 @@ import { hasSiteTrialEnded } from '../../utils/site-trial';
 import { getSiteTypeFeatureSupports } from '../../utils/site-type-feature-support';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import { canSwitchEnvironment } from '../features';
-import EnvironmentSwitcher from '../site/environment-switcher-v2';
+import SidebarEnvironmentSwitcher from '../site/sidebar-environment-switcher';
 import SiteSwitcherItem from './site-switcher-item';
 import type { Site } from '@automattic/api-core';
 import type { AnyRoute } from '@tanstack/react-router';
@@ -59,7 +59,7 @@ export default function SiteSidebar() {
 			<VStack spacing={ 4 }>
 				<SidebarMenu>
 					<SiteSwitcherItem site={ site } />
-					{ canSwitchEnvironment( site ) && <EnvironmentSwitcher site={ site } /> }
+					{ canSwitchEnvironment( site ) && <SidebarEnvironmentSwitcher site={ site } /> }
 				</SidebarMenu>
 				<SiteMenuSidebar site={ site } />
 			</VStack>

--- a/client/dashboard/sites/site/environment-switcher-dropdown.tsx
+++ b/client/dashboard/sites/site/environment-switcher-dropdown.tsx
@@ -25,7 +25,7 @@ const StagingSiteActionButton = ( {
 		return (
 			<>
 				<Spinner style={ spinnerStyle } />
-				<span>{ __( 'Adding staging site\u2026' ) }</span>
+				<span>{ __( 'Adding staging site…' ) }</span>
 			</>
 		);
 	}
@@ -34,7 +34,7 @@ const StagingSiteActionButton = ( {
 		return (
 			<>
 				<Spinner style={ spinnerStyle } />
-				<span>{ __( 'Deleting staging site\u2026' ) }</span>
+				<span>{ __( 'Deleting staging site…' ) }</span>
 			</>
 		);
 	}

--- a/client/dashboard/sites/site/environment-switcher-dropdown.tsx
+++ b/client/dashboard/sites/site/environment-switcher-dropdown.tsx
@@ -1,0 +1,123 @@
+import {
+	__experimentalHStack as HStack,
+	MenuGroup,
+	MenuItem,
+	NavigableMenu,
+	Spinner,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Icon, plus } from '@wordpress/icons';
+import useBuildCurrentRouteLink from '../../app/hooks/use-build-current-route-link';
+import Environment from '../../components/environment';
+import RouterLinkMenuItem from '../../components/router-link-menu-item';
+import { canManageSite, canCreateStagingSite } from '../features';
+import type { Site } from '@automattic/api-core';
+
+const StagingSiteActionButton = ( {
+	isStagingSiteDeleting,
+	isStagingSiteCreating,
+}: {
+	isStagingSiteDeleting: boolean;
+	isStagingSiteCreating: boolean;
+} ) => {
+	const spinnerStyle = { width: '24px', height: '24px', padding: '4px', margin: 0 };
+	if ( isStagingSiteCreating ) {
+		return (
+			<>
+				<Spinner style={ spinnerStyle } />
+				<span>{ __( 'Adding staging site\u2026' ) }</span>
+			</>
+		);
+	}
+
+	if ( isStagingSiteDeleting ) {
+		return (
+			<>
+				<Spinner style={ spinnerStyle } />
+				<span>{ __( 'Deleting staging site\u2026' ) }</span>
+			</>
+		);
+	}
+	return (
+		<>
+			<Icon icon={ plus } />
+			<span>{ __( 'Add staging site' ) }</span>
+		</>
+	);
+};
+
+const EnvironmentSwitcherDropdown = ( {
+	currentSite,
+	productionSite,
+	stagingSite,
+	onClose,
+	onAddStagingSite,
+	isStagingSiteDeleting,
+	isStagingSiteCreating,
+}: {
+	currentSite: Site;
+	productionSite: Site | undefined;
+	stagingSite: Site | undefined;
+	onClose: () => void;
+	onAddStagingSite: () => void;
+	isStagingSiteDeleting: boolean;
+	isStagingSiteCreating: boolean;
+} ) => {
+	const buildCurrentRouteLink = useBuildCurrentRouteLink();
+
+	// TODO: Handle upsell.
+	const handleUpsell = () => {};
+
+	const showStagingSite =
+		stagingSite &&
+		canManageSite( stagingSite ) &&
+		! isStagingSiteDeleting &&
+		! isStagingSiteCreating;
+
+	const showActionButton =
+		( ! currentSite.is_wpcom_staging_site && productionSite && ! stagingSite ) ||
+		isStagingSiteCreating ||
+		isStagingSiteDeleting;
+
+	return (
+		<NavigableMenu>
+			<MenuGroup>
+				{ productionSite && canManageSite( productionSite ) && (
+					<RouterLinkMenuItem
+						to={ buildCurrentRouteLink( { params: { siteSlug: productionSite.slug } } ) }
+						onClick={ onClose }
+					>
+						<Environment environmentType="production" />
+					</RouterLinkMenuItem>
+				) }
+				{ showStagingSite && (
+					<RouterLinkMenuItem
+						to={ buildCurrentRouteLink( { params: { siteSlug: stagingSite.slug } } ) }
+						onClick={ onClose }
+					>
+						<Environment environmentType="staging" />
+					</RouterLinkMenuItem>
+				) }
+				{ showActionButton && (
+					<MenuItem
+						onClick={
+							productionSite && canCreateStagingSite( productionSite )
+								? onAddStagingSite
+								: handleUpsell
+						}
+						disabled={ isStagingSiteCreating || isStagingSiteDeleting }
+					>
+						<HStack justify="flex-start" spacing={ 1 }>
+							<StagingSiteActionButton
+								isStagingSiteDeleting={ isStagingSiteDeleting }
+								isStagingSiteCreating={ isStagingSiteCreating }
+							/>
+						</HStack>
+					</MenuItem>
+				) }
+			</MenuGroup>
+		</NavigableMenu>
+	);
+};
+
+export default EnvironmentSwitcherDropdown;

--- a/client/dashboard/sites/site/environment-switcher-v2.tsx
+++ b/client/dashboard/sites/site/environment-switcher-v2.tsx
@@ -1,16 +1,4 @@
 import {
-	siteByIdQuery,
-	stagingSiteCreateMutation,
-	isDeletingStagingSiteQuery,
-	hasStagingSiteQuery,
-	hasValidQuotaQuery,
-	jetpackConnectionHealthQuery,
-	siteLatestAtomicTransferQuery,
-	isCreatingStagingSiteQuery,
-	siteBySlugQuery,
-} from '@automattic/api-queries';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import {
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
 	Button,
@@ -20,23 +8,14 @@ import {
 	NavigableMenu,
 	Spinner,
 } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
-import { sprintf, __ } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Icon, chevronUpDown, plus } from '@wordpress/icons';
-import { store as noticesStore } from '@wordpress/notices';
-import { useEffect } from 'react';
-import { useAnalytics } from '../../app/analytics';
-import { useHelpCenter } from '../../app/help-center';
 import useBuildCurrentRouteLink from '../../app/hooks/use-build-current-route-link';
 import Environment from '../../components/environment';
 import { staging, production } from '../../components/icons';
 import RouterLinkMenuItem from '../../components/router-link-menu-item';
-import {
-	isAtomicTransferInProgress,
-	isAtomicTransferredSite,
-} from '../../utils/site-atomic-transfers';
-import { getProductionSiteId, getStagingSiteId } from '../../utils/site-staging-site';
 import { canManageSite, canCreateStagingSite } from '../features';
+import useStagingSite from './use-staging-site';
 import type { Site } from '@automattic/api-core';
 
 import './environment-switcher-v2.scss';
@@ -161,218 +140,13 @@ const EnvironmentSwitcherDropdown = ( {
 };
 
 const EnvironmentSwitcher = ( { site }: { site: Site } ) => {
-	const { recordTracksEvent } = useAnalytics();
-	const queryClient = useQueryClient();
-
-	const productionSiteId = getProductionSiteId( site );
-
-	const { data: productionSite } = useQuery( {
-		...siteByIdQuery( productionSiteId ?? 0 ),
-		enabled: !! productionSiteId,
-	} );
-
-	const stagingSiteId = getStagingSiteId( productionSite ?? site );
-
-	const { data: isStagingSiteCreating } = useQuery( {
-		...isCreatingStagingSiteQuery( productionSiteId ?? 0 ),
-		enabled: !! productionSiteId,
-	} );
-
-	const { data: atomicTransfer } = useQuery( {
-		...siteLatestAtomicTransferQuery( stagingSiteId ?? 0 ),
-		refetchInterval: ( query ) => {
-			return isAtomicTransferInProgress( query.state.data?.status ?? 'pending' ) ? 2000 : false;
-		},
-		enabled: isStagingSiteCreating && !! stagingSiteId,
-	} );
-	const transferStatus = atomicTransfer?.status;
-
-	const { data: stagingSite } = useQuery( {
-		...siteByIdQuery( stagingSiteId ?? 0 ),
-		refetchInterval: ( query ) => {
-			if ( ! query.state.data ) {
-				return 0;
-			}
-
-			return isAtomicTransferredSite( query.state.data ) ? false : 2000;
-		},
-		enabled: !! stagingSiteId && transferStatus === 'completed',
-	} );
-
-	const { data: isStagingSiteDeleting } = useQuery( {
-		...isDeletingStagingSiteQuery( stagingSiteId ?? 0 ),
-		enabled: !! stagingSiteId,
-	} );
-
-	// Staging site deletion process runs via async job. We need to keep on polling for the staging site deletion before we start displaying the button to add a staging site again
-	const { data: stagingSiteExistsFromQuery } = useQuery( {
-		...hasStagingSiteQuery( productionSiteId ?? 0 ),
-		refetchInterval: isStagingSiteDeleting ? 3000 : false,
-		enabled: !! productionSiteId && isStagingSiteDeleting,
-	} );
-
-	const { createSuccessNotice, createNotice, createErrorNotice } = useDispatch( noticesStore );
-
-	// Clean up deletion flag when staging site no longer exists
-	useEffect( () => {
-		const invalidateQueries = async (
-			productionSiteId: number,
-			productionSiteSlug: string,
-			stagingSiteId: number
-		) => {
-			// Ensure the new site is retrieved before invalidating the deletion flag
-			await queryClient.invalidateQueries( siteByIdQuery( productionSiteId ) );
-			await queryClient.invalidateQueries( siteBySlugQuery( productionSiteSlug ) );
-			await queryClient.invalidateQueries( isDeletingStagingSiteQuery( stagingSiteId ) );
-		};
-		if (
-			isStagingSiteDeleting &&
-			stagingSiteExistsFromQuery === false &&
-			productionSiteId &&
-			productionSite &&
-			stagingSiteId
-		) {
-			createSuccessNotice( __( 'Staging site deleted.' ), {
-				type: 'snackbar',
-			} );
-			invalidateQueries( productionSiteId, productionSite?.slug, stagingSiteId );
-		}
-	}, [
-		isStagingSiteDeleting,
-		stagingSiteExistsFromQuery,
-		queryClient,
-		stagingSiteId,
-		productionSiteId,
+	const {
 		productionSite,
-		createSuccessNotice,
-	] );
-
-	const { setShowHelpCenter, setNavigateToRoute } = useHelpCenter();
-
-	const isStagingSiteReady =
-		isStagingSiteCreating && stagingSite && isAtomicTransferredSite( stagingSite );
-
-	useEffect( () => {
-		if ( ! stagingSite ) {
-			return;
-		}
-		if ( isStagingSiteReady ) {
-			createSuccessNotice( __( 'Staging site added.' ), {
-				type: 'snackbar',
-				explicitDismiss: true,
-			} );
-			productionSite && queryClient.invalidateQueries( siteBySlugQuery( productionSite.slug ) );
-			queryClient.setQueryData(
-				isCreatingStagingSiteQuery( productionSiteId ?? 0 ).queryKey,
-				false
-			);
-		}
-	}, [
-		queryClient,
-		isStagingSiteReady,
 		stagingSite,
-		createSuccessNotice,
-		productionSiteId,
-		productionSite,
-	] );
-
-	const mutation = useMutation( stagingSiteCreateMutation( productionSite?.ID ?? 0 ) );
-
-	const { data: hasValidQuota, error: isErrorValidQuota } = useQuery( {
-		...hasValidQuotaQuery( productionSite?.ID ?? 0 ),
-		enabled: !! productionSite?.ID && ! stagingSite && ! isStagingSiteCreating,
-		meta: {
-			persist: false,
-		},
-	} );
-
-	const { data: connectionHealth } = useQuery( {
-		...jetpackConnectionHealthQuery( productionSite?.ID ?? 0 ),
-		enabled: !! productionSite?.ID && ! stagingSite && ! isStagingSiteCreating,
-	} );
-
-	const handleAddStagingSite = () => {
-		recordTracksEvent( 'calypso_hosting_configuration_staging_site_add_click' );
-
-		if ( isErrorValidQuota ) {
-			createNotice(
-				'error',
-				__( 'Cannot add a staging site due to site quota validation issue.' ),
-				{
-					type: 'snackbar',
-					actions: [
-						{
-							label: __( 'Contact support' ),
-							url: null,
-							onClick: () => {
-								setNavigateToRoute( '/odie' );
-								setShowHelpCenter( true );
-							},
-						},
-					],
-				}
-			);
-			return;
-		}
-
-		if ( ! hasValidQuota ) {
-			createErrorNotice(
-				__(
-					'Your available storage space is below 50%, which is insufficient for creating a staging site.'
-				),
-				{
-					type: 'snackbar',
-				}
-			);
-			return;
-		}
-
-		if ( ! connectionHealth?.is_healthy ) {
-			createNotice( 'error', __( 'Cannot add a staging site due to a Jetpack connection issue.' ), {
-				type: 'snackbar',
-				actions: [
-					{
-						label: __( 'Contact support' ),
-						url: null,
-						onClick: () => {
-							setNavigateToRoute( '/odie' );
-							setShowHelpCenter( true );
-						},
-					},
-				],
-			} );
-			return;
-		}
-
-		createSuccessNotice(
-			__(
-				'Setting up your staging site — this may take a few minutes. We’ll email you when it’s ready.'
-			),
-			{
-				type: 'snackbar',
-			}
-		);
-
-		mutation.mutate( undefined, {
-			onSuccess: () => {
-				queryClient.invalidateQueries( siteByIdQuery( productionSiteId ?? 0 ) );
-				queryClient.invalidateQueries( hasStagingSiteQuery( productionSiteId ?? 0 ) );
-			},
-			onError: ( error: Error ) => {
-				recordTracksEvent( 'calypso_hosting_configuration_staging_site_add_failure' );
-				createErrorNotice(
-					sprintf(
-						// translators: "reason" is why adding the staging site failed.
-						__( 'Failed to create staging site: %(reason)s' ),
-						{ reason: error.message }
-					),
-					{
-						type: 'snackbar',
-					}
-				);
-			},
-		} );
-	};
+		isStagingSiteCreating,
+		isStagingSiteDeleting,
+		handleAddStagingSite,
+	} = useStagingSite( site );
 
 	// TODO: Let's make sure to revise these conditions and simplify them once we have the design and the full understanding of how the
 	// deletion in progress should look like and if it should have a loading state during deletion.
@@ -410,8 +184,8 @@ const EnvironmentSwitcher = ( { site }: { site: Site } ) => {
 							stagingSite={ stagingSite }
 							onClose={ onClose }
 							onAddStagingSite={ handleAddStagingSite }
-							isStagingSiteDeleting={ !! isStagingSiteDeleting }
-							isStagingSiteCreating={ !! isStagingSiteCreating }
+							isStagingSiteDeleting={ isStagingSiteDeleting }
+							isStagingSiteCreating={ isStagingSiteCreating }
 						/>
 					) }
 				/>

--- a/client/dashboard/sites/site/environment-switcher-v2.tsx
+++ b/client/dashboard/sites/site/environment-switcher-v2.tsx
@@ -3,18 +3,12 @@ import {
 	__experimentalText as Text,
 	Button,
 	Dropdown,
-	MenuGroup,
-	MenuItem,
-	NavigableMenu,
-	Spinner,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Icon, chevronUpDown, plus } from '@wordpress/icons';
-import useBuildCurrentRouteLink from '../../app/hooks/use-build-current-route-link';
-import Environment from '../../components/environment';
+import { Icon, chevronUpDown } from '@wordpress/icons';
 import { staging, production } from '../../components/icons';
-import RouterLinkMenuItem from '../../components/router-link-menu-item';
-import { canManageSite, canCreateStagingSite } from '../features';
+import { canManageSite } from '../features';
+import EnvironmentSwitcherDropdown from './environment-switcher-dropdown';
 import useStagingSite from './use-staging-site';
 import type { Site } from '@automattic/api-core';
 
@@ -29,113 +23,6 @@ const CurrentEnvironment = ( { site }: { site: Site } ) => {
 			<Icon icon={ icon } size={ 20 } />
 			<Text weight={ 500 }>{ label }</Text>
 		</HStack>
-	);
-};
-
-const StagingSiteActionButton = ( {
-	isStagingSiteDeleting,
-	isStagingSiteCreating,
-}: {
-	isStagingSiteDeleting: boolean;
-	isStagingSiteCreating: boolean;
-} ) => {
-	const spinnerStyle = { width: '24px', height: '24px', padding: '4px', margin: 0 };
-	if ( isStagingSiteCreating ) {
-		return (
-			<>
-				<Spinner style={ spinnerStyle } />
-				<span>{ __( 'Adding staging site…' ) }</span>
-			</>
-		);
-	}
-
-	if ( isStagingSiteDeleting ) {
-		return (
-			<>
-				<Spinner style={ spinnerStyle } />
-				<span>{ __( 'Deleting staging site…' ) }</span>
-			</>
-		);
-	}
-	return (
-		<>
-			<Icon icon={ plus } />
-			<span>{ __( 'Add staging site' ) }</span>
-		</>
-	);
-};
-
-const EnvironmentSwitcherDropdown = ( {
-	currentSite,
-	productionSite,
-	stagingSite,
-	onClose,
-	onAddStagingSite,
-	isStagingSiteDeleting,
-	isStagingSiteCreating,
-}: {
-	currentSite: Site;
-	productionSite: Site | undefined;
-	stagingSite: Site | undefined;
-	onClose: () => void;
-	onAddStagingSite: () => void;
-	isStagingSiteDeleting: boolean;
-	isStagingSiteCreating: boolean;
-} ) => {
-	const buildCurrentRouteLink = useBuildCurrentRouteLink();
-
-	// TODO: Handle upsell.
-	const handleUpsell = () => {};
-
-	const showStagingSite =
-		stagingSite &&
-		canManageSite( stagingSite ) &&
-		! isStagingSiteDeleting &&
-		! isStagingSiteCreating;
-
-	const showActionButton =
-		( ! currentSite.is_wpcom_staging_site && productionSite && ! stagingSite ) ||
-		isStagingSiteCreating ||
-		isStagingSiteDeleting;
-
-	return (
-		<NavigableMenu>
-			<MenuGroup>
-				{ productionSite && canManageSite( productionSite ) && (
-					<RouterLinkMenuItem
-						to={ buildCurrentRouteLink( { params: { siteSlug: productionSite.slug } } ) }
-						onClick={ onClose }
-					>
-						<Environment environmentType="production" />
-					</RouterLinkMenuItem>
-				) }
-				{ showStagingSite && (
-					<RouterLinkMenuItem
-						to={ buildCurrentRouteLink( { params: { siteSlug: stagingSite.slug } } ) }
-						onClick={ onClose }
-					>
-						<Environment environmentType="staging" />
-					</RouterLinkMenuItem>
-				) }
-				{ showActionButton && (
-					<MenuItem
-						onClick={
-							productionSite && canCreateStagingSite( productionSite )
-								? onAddStagingSite
-								: handleUpsell
-						}
-						disabled={ isStagingSiteCreating || isStagingSiteDeleting }
-					>
-						<HStack justify="flex-start" spacing={ 1 }>
-							<StagingSiteActionButton
-								isStagingSiteDeleting={ isStagingSiteDeleting }
-								isStagingSiteCreating={ isStagingSiteCreating }
-							/>
-						</HStack>
-					</MenuItem>
-				) }
-			</MenuGroup>
-		</NavigableMenu>
 	);
 };
 

--- a/client/dashboard/sites/site/environment-switcher.tsx
+++ b/client/dashboard/sites/site/environment-switcher.tsx
@@ -6,15 +6,8 @@ import EnvironmentSwitcherDropdown from './environment-switcher-dropdown';
 import useStagingSite from './use-staging-site';
 import type { Site } from '@automattic/api-core';
 
-const CurrentEnvironment = ( { site }: { site: Site } ) => {
-	if ( site.is_wpcom_staging_site ) {
-		return <Environment environmentType="staging" />;
-	}
-
-	return <Environment environmentType="production" />;
-};
-
 const EnvironmentSwitcher = ( { site }: { site: Site } ) => {
+	const environmentType = site.is_wpcom_staging_site ? 'staging' : 'production';
 	const {
 		productionSite,
 		stagingSite,
@@ -49,7 +42,7 @@ const EnvironmentSwitcher = ( { site }: { site: Site } ) => {
 							aria-haspopup="true"
 							aria-expanded={ isOpen }
 						>
-							<CurrentEnvironment site={ site } />
+							<Environment environmentType={ environmentType } />
 						</Button>
 					);
 				} }

--- a/client/dashboard/sites/site/environment-switcher.tsx
+++ b/client/dashboard/sites/site/environment-switcher.tsx
@@ -7,13 +7,13 @@ import useStagingSite from './use-staging-site';
 import type { Site } from '@automattic/api-core';
 
 const EnvironmentSwitcher = ( { site }: { site: Site } ) => {
-	const environmentType = site.is_wpcom_staging_site ? 'staging' : 'production';
 	const {
 		productionSite,
 		stagingSite,
 		isStagingSiteCreating,
 		isStagingSiteDeleting,
 		handleAddStagingSite,
+		environmentType,
 	} = useStagingSite( site );
 
 	return (

--- a/client/dashboard/sites/site/environment-switcher.tsx
+++ b/client/dashboard/sites/site/environment-switcher.tsx
@@ -1,16 +1,4 @@
 import {
-	siteByIdQuery,
-	stagingSiteCreateMutation,
-	isDeletingStagingSiteQuery,
-	hasStagingSiteQuery,
-	hasValidQuotaQuery,
-	jetpackConnectionHealthQuery,
-	siteLatestAtomicTransferQuery,
-	isCreatingStagingSiteQuery,
-	siteBySlugQuery,
-} from '@automattic/api-queries';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import {
 	__experimentalHStack as HStack,
 	Button,
 	Dropdown,
@@ -19,22 +7,13 @@ import {
 	NavigableMenu,
 	Spinner,
 } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
-import { sprintf, __ } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Icon, chevronDownSmall, plus } from '@wordpress/icons';
-import { store as noticesStore } from '@wordpress/notices';
-import { useEffect } from 'react';
-import { useAnalytics } from '../../app/analytics';
-import { useHelpCenter } from '../../app/help-center';
 import useBuildCurrentRouteLink from '../../app/hooks/use-build-current-route-link';
 import Environment from '../../components/environment';
 import RouterLinkMenuItem from '../../components/router-link-menu-item';
-import {
-	isAtomicTransferInProgress,
-	isAtomicTransferredSite,
-} from '../../utils/site-atomic-transfers';
-import { getProductionSiteId, getStagingSiteId } from '../../utils/site-staging-site';
 import { canManageSite, canCreateStagingSite } from '../features';
+import useStagingSite from './use-staging-site';
 import type { Site } from '@automattic/api-core';
 
 const CurrentEnvironment = ( { site }: { site: Site } ) => {
@@ -153,218 +132,13 @@ const EnvironmentSwitcherDropdown = ( {
 };
 
 const EnvironmentSwitcher = ( { site }: { site: Site } ) => {
-	const { recordTracksEvent } = useAnalytics();
-	const queryClient = useQueryClient();
-
-	const productionSiteId = getProductionSiteId( site );
-
-	const { data: productionSite } = useQuery( {
-		...siteByIdQuery( productionSiteId ?? 0 ),
-		enabled: !! productionSiteId,
-	} );
-
-	const stagingSiteId = getStagingSiteId( productionSite ?? site );
-
-	const { data: isStagingSiteCreating } = useQuery( {
-		...isCreatingStagingSiteQuery( productionSiteId ?? 0 ),
-		enabled: !! productionSiteId,
-	} );
-
-	const { data: atomicTransfer } = useQuery( {
-		...siteLatestAtomicTransferQuery( stagingSiteId ?? 0 ),
-		refetchInterval: ( query ) => {
-			return isAtomicTransferInProgress( query.state.data?.status ?? 'pending' ) ? 2000 : false;
-		},
-		enabled: isStagingSiteCreating && !! stagingSiteId,
-	} );
-	const transferStatus = atomicTransfer?.status;
-
-	const { data: stagingSite } = useQuery( {
-		...siteByIdQuery( stagingSiteId ?? 0 ),
-		refetchInterval: ( query ) => {
-			if ( ! query.state.data ) {
-				return 0;
-			}
-
-			return isAtomicTransferredSite( query.state.data ) ? false : 2000;
-		},
-		enabled: !! stagingSiteId && transferStatus === 'completed',
-	} );
-
-	const { data: isStagingSiteDeleting } = useQuery( {
-		...isDeletingStagingSiteQuery( stagingSiteId ?? 0 ),
-		enabled: !! stagingSiteId,
-	} );
-
-	// Staging site deletion process runs via async job. We need to keep on polling for the staging site deletion before we start displaying the button to add a staging site again
-	const { data: stagingSiteExistsFromQuery } = useQuery( {
-		...hasStagingSiteQuery( productionSiteId ?? 0 ),
-		refetchInterval: isStagingSiteDeleting ? 3000 : false,
-		enabled: !! productionSiteId && isStagingSiteDeleting,
-	} );
-
-	const { createSuccessNotice, createNotice, createErrorNotice } = useDispatch( noticesStore );
-
-	// Clean up deletion flag when staging site no longer exists
-	useEffect( () => {
-		const invalidateQueries = async (
-			productionSiteId: number,
-			productionSiteSlug: string,
-			stagingSiteId: number
-		) => {
-			// Ensure the new site is retrieved before invalidating the deletion flag
-			await queryClient.invalidateQueries( siteByIdQuery( productionSiteId ) );
-			await queryClient.invalidateQueries( siteBySlugQuery( productionSiteSlug ) );
-			await queryClient.invalidateQueries( isDeletingStagingSiteQuery( stagingSiteId ) );
-		};
-		if (
-			isStagingSiteDeleting &&
-			stagingSiteExistsFromQuery === false &&
-			productionSiteId &&
-			productionSite &&
-			stagingSiteId
-		) {
-			createSuccessNotice( __( 'Staging site deleted.' ), {
-				type: 'snackbar',
-			} );
-			invalidateQueries( productionSiteId, productionSite?.slug, stagingSiteId );
-		}
-	}, [
-		isStagingSiteDeleting,
-		stagingSiteExistsFromQuery,
-		queryClient,
-		stagingSiteId,
-		productionSiteId,
+	const {
 		productionSite,
-		createSuccessNotice,
-	] );
-
-	const { setShowHelpCenter, setNavigateToRoute } = useHelpCenter();
-
-	const isStagingSiteReady =
-		isStagingSiteCreating && stagingSite && isAtomicTransferredSite( stagingSite );
-
-	useEffect( () => {
-		if ( ! stagingSite ) {
-			return;
-		}
-		if ( isStagingSiteReady ) {
-			createSuccessNotice( __( 'Staging site added.' ), {
-				type: 'snackbar',
-				explicitDismiss: true,
-			} );
-			productionSite && queryClient.invalidateQueries( siteBySlugQuery( productionSite.slug ) );
-			queryClient.setQueryData(
-				isCreatingStagingSiteQuery( productionSiteId ?? 0 ).queryKey,
-				false
-			);
-		}
-	}, [
-		queryClient,
-		isStagingSiteReady,
 		stagingSite,
-		createSuccessNotice,
-		productionSiteId,
-		productionSite,
-	] );
-
-	const mutation = useMutation( stagingSiteCreateMutation( productionSite?.ID ?? 0 ) );
-
-	const { data: hasValidQuota, error: isErrorValidQuota } = useQuery( {
-		...hasValidQuotaQuery( productionSite?.ID ?? 0 ),
-		enabled: !! productionSite?.ID && ! stagingSite && ! isStagingSiteCreating,
-		meta: {
-			persist: false,
-		},
-	} );
-
-	const { data: connectionHealth } = useQuery( {
-		...jetpackConnectionHealthQuery( productionSite?.ID ?? 0 ),
-		enabled: !! productionSite?.ID && ! stagingSite && ! isStagingSiteCreating,
-	} );
-
-	const handleAddStagingSite = () => {
-		recordTracksEvent( 'calypso_hosting_configuration_staging_site_add_click' );
-
-		if ( isErrorValidQuota ) {
-			createNotice(
-				'error',
-				__( 'Cannot add a staging site due to site quota validation issue.' ),
-				{
-					type: 'snackbar',
-					actions: [
-						{
-							label: __( 'Contact support' ),
-							url: null,
-							onClick: () => {
-								setNavigateToRoute( '/odie' );
-								setShowHelpCenter( true );
-							},
-						},
-					],
-				}
-			);
-			return;
-		}
-
-		if ( ! hasValidQuota ) {
-			createErrorNotice(
-				__(
-					'Your available storage space is below 50%, which is insufficient for creating a staging site.'
-				),
-				{
-					type: 'snackbar',
-				}
-			);
-			return;
-		}
-
-		if ( ! connectionHealth?.is_healthy ) {
-			createNotice( 'error', __( 'Cannot add a staging site due to a Jetpack connection issue.' ), {
-				type: 'snackbar',
-				actions: [
-					{
-						label: __( 'Contact support' ),
-						url: null,
-						onClick: () => {
-							setNavigateToRoute( '/odie' );
-							setShowHelpCenter( true );
-						},
-					},
-				],
-			} );
-			return;
-		}
-
-		createSuccessNotice(
-			__(
-				'Setting up your staging site — this may take a few minutes. We’ll email you when it’s ready.'
-			),
-			{
-				type: 'snackbar',
-			}
-		);
-
-		mutation.mutate( undefined, {
-			onSuccess: () => {
-				queryClient.invalidateQueries( siteByIdQuery( productionSiteId ?? 0 ) );
-				queryClient.invalidateQueries( hasStagingSiteQuery( productionSiteId ?? 0 ) );
-			},
-			onError: ( error: Error ) => {
-				recordTracksEvent( 'calypso_hosting_configuration_staging_site_add_failure' );
-				createErrorNotice(
-					sprintf(
-						// translators: "reason" is why adding the staging site failed.
-						__( 'Failed to create staging site: %(reason)s' ),
-						{ reason: error.message }
-					),
-					{
-						type: 'snackbar',
-					}
-				);
-			},
-		} );
-	};
+		isStagingSiteCreating,
+		isStagingSiteDeleting,
+		handleAddStagingSite,
+	} = useStagingSite( site );
 
 	return (
 		<HStack expanded={ false } style={ { flexShrink: 0 } }>
@@ -403,8 +177,8 @@ const EnvironmentSwitcher = ( { site }: { site: Site } ) => {
 						stagingSite={ stagingSite }
 						onClose={ onClose }
 						onAddStagingSite={ handleAddStagingSite }
-						isStagingSiteDeleting={ !! isStagingSiteDeleting }
-						isStagingSiteCreating={ !! isStagingSiteCreating }
+						isStagingSiteDeleting={ isStagingSiteDeleting }
+						isStagingSiteCreating={ isStagingSiteCreating }
 					/>
 				) }
 			/>

--- a/client/dashboard/sites/site/environment-switcher.tsx
+++ b/client/dashboard/sites/site/environment-switcher.tsx
@@ -1,18 +1,8 @@
-import {
-	__experimentalHStack as HStack,
-	Button,
-	Dropdown,
-	MenuGroup,
-	MenuItem,
-	NavigableMenu,
-	Spinner,
-} from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { Icon, chevronDownSmall, plus } from '@wordpress/icons';
-import useBuildCurrentRouteLink from '../../app/hooks/use-build-current-route-link';
+import { __experimentalHStack as HStack, Button, Dropdown } from '@wordpress/components';
+import { chevronDownSmall } from '@wordpress/icons';
 import Environment from '../../components/environment';
-import RouterLinkMenuItem from '../../components/router-link-menu-item';
-import { canManageSite, canCreateStagingSite } from '../features';
+import { canManageSite } from '../features';
+import EnvironmentSwitcherDropdown from './environment-switcher-dropdown';
 import useStagingSite from './use-staging-site';
 import type { Site } from '@automattic/api-core';
 
@@ -22,113 +12,6 @@ const CurrentEnvironment = ( { site }: { site: Site } ) => {
 	}
 
 	return <Environment environmentType="production" />;
-};
-
-const StagingSiteActionButton = ( {
-	isStagingSiteDeleting,
-	isStagingSiteCreating,
-}: {
-	isStagingSiteDeleting: boolean;
-	isStagingSiteCreating: boolean;
-} ) => {
-	const spinnerStyle = { width: '24px', height: '24px', padding: '4px', margin: 0 };
-	if ( isStagingSiteCreating ) {
-		return (
-			<>
-				<Spinner style={ spinnerStyle } />
-				<span>{ __( 'Adding staging site…' ) }</span>
-			</>
-		);
-	}
-
-	if ( isStagingSiteDeleting ) {
-		return (
-			<>
-				<Spinner style={ spinnerStyle } />
-				<span>{ __( 'Deleting staging site…' ) }</span>
-			</>
-		);
-	}
-	return (
-		<>
-			<Icon icon={ plus } />
-			<span>{ __( 'Add staging site' ) }</span>
-		</>
-	);
-};
-
-const EnvironmentSwitcherDropdown = ( {
-	currentSite,
-	productionSite,
-	stagingSite,
-	onClose,
-	onAddStagingSite,
-	isStagingSiteDeleting,
-	isStagingSiteCreating,
-}: {
-	currentSite: Site;
-	productionSite: Site | undefined;
-	stagingSite: Site | undefined;
-	onClose: () => void;
-	onAddStagingSite: () => void;
-	isStagingSiteDeleting: boolean;
-	isStagingSiteCreating: boolean;
-} ) => {
-	const buildCurrentRouteLink = useBuildCurrentRouteLink();
-
-	// TODO: Handle upsell.
-	const handleUpsell = () => {};
-
-	const showStagingSite =
-		stagingSite &&
-		canManageSite( stagingSite ) &&
-		! isStagingSiteDeleting &&
-		! isStagingSiteCreating;
-
-	const showActionButton =
-		( ! currentSite.is_wpcom_staging_site && productionSite && ! stagingSite ) ||
-		isStagingSiteCreating ||
-		isStagingSiteDeleting;
-
-	return (
-		<NavigableMenu>
-			<MenuGroup>
-				{ productionSite && canManageSite( productionSite ) && (
-					<RouterLinkMenuItem
-						to={ buildCurrentRouteLink( { params: { siteSlug: productionSite.slug } } ) }
-						onClick={ onClose }
-					>
-						<Environment environmentType="production" />
-					</RouterLinkMenuItem>
-				) }
-				{ showStagingSite && (
-					<RouterLinkMenuItem
-						to={ buildCurrentRouteLink( { params: { siteSlug: stagingSite.slug } } ) }
-						onClick={ onClose }
-					>
-						<Environment environmentType="staging" />
-					</RouterLinkMenuItem>
-				) }
-				{ showActionButton && (
-					<MenuItem
-						onClick={
-							productionSite && canCreateStagingSite( productionSite )
-								? onAddStagingSite
-								: handleUpsell
-						}
-						disabled={ isStagingSiteCreating || isStagingSiteDeleting }
-					>
-						<HStack justify="flex-start" spacing={ 1 }>
-							<StagingSiteActionButton
-								isStagingSiteDeleting={ isStagingSiteDeleting }
-								isStagingSiteCreating={ isStagingSiteCreating }
-							/>
-						</HStack>
-					</MenuItem>
-				) }
-			</MenuGroup>
-		</NavigableMenu>
-	);
 };
 
 const EnvironmentSwitcher = ( { site }: { site: Site } ) => {

--- a/client/dashboard/sites/site/sidebar-environment-switcher.scss
+++ b/client/dashboard/sites/site/sidebar-environment-switcher.scss
@@ -1,12 +1,12 @@
 @import '@wordpress/base-styles/variables';
 
-.environment-switcher-v2 {
+.sidebar-environment-switcher {
 	height: 40px;
 	padding-inline-start: $grid-unit-15;
 	// This makes it align with toggle caret's in the sidebar.
 	padding-inline-end: calc( #{$grid-unit-15} - 3px );
 
-	.environment-switcher-v2__toggle {
+	.sidebar-environment-switcher__toggle {
 		color: var( --dashboard-menu-item__color );
 		min-width: 0;
 		padding: 0;

--- a/client/dashboard/sites/site/sidebar-environment-switcher.tsx
+++ b/client/dashboard/sites/site/sidebar-environment-switcher.tsx
@@ -12,7 +12,7 @@ import EnvironmentSwitcherDropdown from './environment-switcher-dropdown';
 import useStagingSite from './use-staging-site';
 import type { Site } from '@automattic/api-core';
 
-import './environment-switcher-v2.scss';
+import './sidebar-environment-switcher.scss';
 
 const CurrentEnvironment = ( { site }: { site: Site } ) => {
 	const icon = site.is_wpcom_staging_site ? staging : production;
@@ -26,7 +26,7 @@ const CurrentEnvironment = ( { site }: { site: Site } ) => {
 	);
 };
 
-const EnvironmentSwitcher = ( { site }: { site: Site } ) => {
+const SidebarEnvironmentSwitcher = ( { site }: { site: Site } ) => {
 	const {
 		productionSite,
 		stagingSite,
@@ -42,13 +42,13 @@ const EnvironmentSwitcher = ( { site }: { site: Site } ) => {
 		( stagingSite && canManageSite( stagingSite ) );
 
 	return (
-		<HStack expanded={ false } style={ { flexShrink: 0 } } className="environment-switcher-v2">
+		<HStack expanded={ false } style={ { flexShrink: 0 } } className="sidebar-environment-switcher">
 			<CurrentEnvironment site={ site } />
 			{ canToggle && (
 				<Dropdown
 					renderToggle={ ( { isOpen, onToggle } ) => (
 						<Button
-							className="environment-switcher-v2__toggle"
+							className="sidebar-environment-switcher__toggle"
 							variant="tertiary"
 							onClick={ onToggle }
 							onKeyDown={ ( event: React.KeyboardEvent ) => {
@@ -81,4 +81,4 @@ const EnvironmentSwitcher = ( { site }: { site: Site } ) => {
 	);
 };
 
-export default EnvironmentSwitcher;
+export default SidebarEnvironmentSwitcher;

--- a/client/dashboard/sites/site/sidebar-environment-switcher.tsx
+++ b/client/dashboard/sites/site/sidebar-environment-switcher.tsx
@@ -1,30 +1,13 @@
-import {
-	__experimentalHStack as HStack,
-	__experimentalText as Text,
-	Button,
-	Dropdown,
-} from '@wordpress/components';
+import { __experimentalHStack as HStack, Button, Dropdown } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Icon, chevronUpDown } from '@wordpress/icons';
-import { staging, production } from '../../components/icons';
+import { chevronUpDown } from '@wordpress/icons';
+import Environment from '../../components/environment';
 import { canManageSite } from '../features';
 import EnvironmentSwitcherDropdown from './environment-switcher-dropdown';
 import useStagingSite from './use-staging-site';
 import type { Site } from '@automattic/api-core';
 
 import './sidebar-environment-switcher.scss';
-
-const CurrentEnvironment = ( { site }: { site: Site } ) => {
-	const icon = site.is_wpcom_staging_site ? staging : production;
-	const label = site.is_wpcom_staging_site ? __( 'Staging' ) : __( 'Production' );
-
-	return (
-		<HStack justify="flex-start" spacing={ 2 } expanded={ false } style={ { flexShrink: 0 } }>
-			<Icon icon={ icon } size={ 20 } />
-			<Text weight={ 500 }>{ label }</Text>
-		</HStack>
-	);
-};
 
 const SidebarEnvironmentSwitcher = ( { site }: { site: Site } ) => {
 	const {
@@ -41,9 +24,11 @@ const SidebarEnvironmentSwitcher = ( { site }: { site: Site } ) => {
 		( productionSite && canManageSite( productionSite ) ) ||
 		( stagingSite && canManageSite( stagingSite ) );
 
+	const environmentType = site.is_wpcom_staging_site ? 'staging' : 'production';
+
 	return (
 		<HStack expanded={ false } style={ { flexShrink: 0 } } className="sidebar-environment-switcher">
-			<CurrentEnvironment site={ site } />
+			<Environment environmentType={ environmentType } />
 			{ canToggle && (
 				<Dropdown
 					renderToggle={ ( { isOpen, onToggle } ) => (

--- a/client/dashboard/sites/site/sidebar-environment-switcher.tsx
+++ b/client/dashboard/sites/site/sidebar-environment-switcher.tsx
@@ -16,6 +16,7 @@ const SidebarEnvironmentSwitcher = ( { site }: { site: Site } ) => {
 		isStagingSiteCreating,
 		isStagingSiteDeleting,
 		handleAddStagingSite,
+		environmentType,
 	} = useStagingSite( site );
 
 	// TODO: Let's make sure to revise these conditions and simplify them once we have the design and the full understanding of how the
@@ -23,8 +24,6 @@ const SidebarEnvironmentSwitcher = ( { site }: { site: Site } ) => {
 	const canToggle =
 		( productionSite && canManageSite( productionSite ) ) ||
 		( stagingSite && canManageSite( stagingSite ) );
-
-	const environmentType = site.is_wpcom_staging_site ? 'staging' : 'production';
 
 	return (
 		<HStack expanded={ false } style={ { flexShrink: 0 } } className="sidebar-environment-switcher">

--- a/client/dashboard/sites/site/use-staging-site.ts
+++ b/client/dashboard/sites/site/use-staging-site.ts
@@ -239,11 +239,14 @@ export default function useStagingSite( site: Site ) {
 		} );
 	};
 
+	const environmentType = site.is_wpcom_staging_site ? 'staging' : 'production';
+
 	return {
 		productionSite,
 		stagingSite,
 		isStagingSiteCreating: !! isStagingSiteCreating,
 		isStagingSiteDeleting: !! isStagingSiteDeleting,
 		handleAddStagingSite,
+		environmentType,
 	};
 }

--- a/client/dashboard/sites/site/use-staging-site.ts
+++ b/client/dashboard/sites/site/use-staging-site.ts
@@ -97,6 +97,7 @@ export default function useStagingSite( site: Site ) {
 		) {
 			createSuccessNotice( __( 'Staging site deleted.' ), {
 				type: 'snackbar',
+				id: 'staging-site-deleted',
 			} );
 			invalidateQueries( productionSiteId, productionSite?.slug, stagingSiteId );
 		}
@@ -123,6 +124,7 @@ export default function useStagingSite( site: Site ) {
 			createSuccessNotice( __( 'Staging site added.' ), {
 				type: 'snackbar',
 				explicitDismiss: true,
+				id: 'staging-site-added',
 			} );
 			productionSite && queryClient.invalidateQueries( siteBySlugQuery( productionSite.slug ) );
 			queryClient.setQueryData(

--- a/client/dashboard/sites/site/use-staging-site.ts
+++ b/client/dashboard/sites/site/use-staging-site.ts
@@ -21,6 +21,7 @@ import {
 	isAtomicTransferredSite,
 } from '../../utils/site-atomic-transfers';
 import { getProductionSiteId, getStagingSiteId } from '../../utils/site-staging-site';
+import type { EnvironmentType } from '../../components/environment';
 import type { Site } from '@automattic/api-core';
 
 export default function useStagingSite( site: Site ) {
@@ -239,7 +240,7 @@ export default function useStagingSite( site: Site ) {
 		} );
 	};
 
-	const environmentType = site.is_wpcom_staging_site ? 'staging' : 'production';
+	const environmentType: EnvironmentType = site.is_wpcom_staging_site ? 'staging' : 'production';
 
 	return {
 		productionSite,

--- a/client/dashboard/sites/site/use-staging-site.ts
+++ b/client/dashboard/sites/site/use-staging-site.ts
@@ -211,7 +211,7 @@ export default function useStagingSite( site: Site ) {
 
 		createSuccessNotice(
 			__(
-				'Setting up your staging site — this may take a few minutes. We\u2019ll email you when it\u2019s ready.'
+				'Setting up your staging site — this may take a few minutes. We’ll email you when it’s ready.'
 			),
 			{
 				type: 'snackbar',

--- a/client/dashboard/sites/site/use-staging-site.ts
+++ b/client/dashboard/sites/site/use-staging-site.ts
@@ -1,0 +1,247 @@
+import {
+	siteByIdQuery,
+	stagingSiteCreateMutation,
+	isDeletingStagingSiteQuery,
+	hasStagingSiteQuery,
+	hasValidQuotaQuery,
+	jetpackConnectionHealthQuery,
+	siteLatestAtomicTransferQuery,
+	isCreatingStagingSiteQuery,
+	siteBySlugQuery,
+} from '@automattic/api-queries';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useDispatch } from '@wordpress/data';
+import { sprintf, __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useEffect } from 'react';
+import { useAnalytics } from '../../app/analytics';
+import { useHelpCenter } from '../../app/help-center';
+import {
+	isAtomicTransferInProgress,
+	isAtomicTransferredSite,
+} from '../../utils/site-atomic-transfers';
+import { getProductionSiteId, getStagingSiteId } from '../../utils/site-staging-site';
+import type { Site } from '@automattic/api-core';
+
+export default function useStagingSite( site: Site ) {
+	const { recordTracksEvent } = useAnalytics();
+	const queryClient = useQueryClient();
+
+	const productionSiteId = getProductionSiteId( site );
+
+	const { data: productionSite } = useQuery( {
+		...siteByIdQuery( productionSiteId ?? 0 ),
+		enabled: !! productionSiteId,
+	} );
+
+	const stagingSiteId = getStagingSiteId( productionSite ?? site );
+
+	const { data: isStagingSiteCreating } = useQuery( {
+		...isCreatingStagingSiteQuery( productionSiteId ?? 0 ),
+		enabled: !! productionSiteId,
+	} );
+
+	const { data: atomicTransfer } = useQuery( {
+		...siteLatestAtomicTransferQuery( stagingSiteId ?? 0 ),
+		refetchInterval: ( query ) => {
+			return isAtomicTransferInProgress( query.state.data?.status ?? 'pending' ) ? 2000 : false;
+		},
+		enabled: isStagingSiteCreating && !! stagingSiteId,
+	} );
+	const transferStatus = atomicTransfer?.status;
+
+	const { data: stagingSite } = useQuery( {
+		...siteByIdQuery( stagingSiteId ?? 0 ),
+		refetchInterval: ( query ) => {
+			if ( ! query.state.data ) {
+				return 0;
+			}
+
+			return isAtomicTransferredSite( query.state.data ) ? false : 2000;
+		},
+		enabled: !! stagingSiteId && transferStatus === 'completed',
+	} );
+
+	const { data: isStagingSiteDeleting } = useQuery( {
+		...isDeletingStagingSiteQuery( stagingSiteId ?? 0 ),
+		enabled: !! stagingSiteId,
+	} );
+
+	// Staging site deletion process runs via async job. We need to keep on polling for the staging site deletion before we start displaying the button to add a staging site again
+	const { data: stagingSiteExistsFromQuery } = useQuery( {
+		...hasStagingSiteQuery( productionSiteId ?? 0 ),
+		refetchInterval: isStagingSiteDeleting ? 3000 : false,
+		enabled: !! productionSiteId && isStagingSiteDeleting,
+	} );
+
+	const { createSuccessNotice, createNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	// Clean up deletion flag when staging site no longer exists
+	useEffect( () => {
+		const invalidateQueries = async (
+			productionSiteId: number,
+			productionSiteSlug: string,
+			stagingSiteId: number
+		) => {
+			// Ensure the new site is retrieved before invalidating the deletion flag
+			await queryClient.invalidateQueries( siteByIdQuery( productionSiteId ) );
+			await queryClient.invalidateQueries( siteBySlugQuery( productionSiteSlug ) );
+			await queryClient.invalidateQueries( isDeletingStagingSiteQuery( stagingSiteId ) );
+		};
+		if (
+			isStagingSiteDeleting &&
+			stagingSiteExistsFromQuery === false &&
+			productionSiteId &&
+			productionSite &&
+			stagingSiteId
+		) {
+			createSuccessNotice( __( 'Staging site deleted.' ), {
+				type: 'snackbar',
+			} );
+			invalidateQueries( productionSiteId, productionSite?.slug, stagingSiteId );
+		}
+	}, [
+		isStagingSiteDeleting,
+		stagingSiteExistsFromQuery,
+		queryClient,
+		stagingSiteId,
+		productionSiteId,
+		productionSite,
+		createSuccessNotice,
+	] );
+
+	const { setShowHelpCenter, setNavigateToRoute } = useHelpCenter();
+
+	const isStagingSiteReady =
+		isStagingSiteCreating && stagingSite && isAtomicTransferredSite( stagingSite );
+
+	useEffect( () => {
+		if ( ! stagingSite ) {
+			return;
+		}
+		if ( isStagingSiteReady ) {
+			createSuccessNotice( __( 'Staging site added.' ), {
+				type: 'snackbar',
+				explicitDismiss: true,
+			} );
+			productionSite && queryClient.invalidateQueries( siteBySlugQuery( productionSite.slug ) );
+			queryClient.setQueryData(
+				isCreatingStagingSiteQuery( productionSiteId ?? 0 ).queryKey,
+				false
+			);
+		}
+	}, [
+		queryClient,
+		isStagingSiteReady,
+		stagingSite,
+		createSuccessNotice,
+		productionSiteId,
+		productionSite,
+	] );
+
+	const mutation = useMutation( stagingSiteCreateMutation( productionSite?.ID ?? 0 ) );
+
+	const { data: hasValidQuota, error: isErrorValidQuota } = useQuery( {
+		...hasValidQuotaQuery( productionSite?.ID ?? 0 ),
+		enabled: !! productionSite?.ID && ! stagingSite && ! isStagingSiteCreating,
+		meta: {
+			persist: false,
+		},
+	} );
+
+	const { data: connectionHealth } = useQuery( {
+		...jetpackConnectionHealthQuery( productionSite?.ID ?? 0 ),
+		enabled: !! productionSite?.ID && ! stagingSite && ! isStagingSiteCreating,
+	} );
+
+	const handleAddStagingSite = () => {
+		recordTracksEvent( 'calypso_hosting_configuration_staging_site_add_click' );
+
+		if ( isErrorValidQuota ) {
+			createNotice(
+				'error',
+				__( 'Cannot add a staging site due to site quota validation issue.' ),
+				{
+					type: 'snackbar',
+					actions: [
+						{
+							label: __( 'Contact support' ),
+							url: null,
+							onClick: () => {
+								setNavigateToRoute( '/odie' );
+								setShowHelpCenter( true );
+							},
+						},
+					],
+				}
+			);
+			return;
+		}
+
+		if ( ! hasValidQuota ) {
+			createErrorNotice(
+				__(
+					'Your available storage space is below 50%, which is insufficient for creating a staging site.'
+				),
+				{
+					type: 'snackbar',
+				}
+			);
+			return;
+		}
+
+		if ( ! connectionHealth?.is_healthy ) {
+			createNotice( 'error', __( 'Cannot add a staging site due to a Jetpack connection issue.' ), {
+				type: 'snackbar',
+				actions: [
+					{
+						label: __( 'Contact support' ),
+						url: null,
+						onClick: () => {
+							setNavigateToRoute( '/odie' );
+							setShowHelpCenter( true );
+						},
+					},
+				],
+			} );
+			return;
+		}
+
+		createSuccessNotice(
+			__(
+				'Setting up your staging site — this may take a few minutes. We\u2019ll email you when it\u2019s ready.'
+			),
+			{
+				type: 'snackbar',
+			}
+		);
+
+		mutation.mutate( undefined, {
+			onSuccess: () => {
+				queryClient.invalidateQueries( siteByIdQuery( productionSiteId ?? 0 ) );
+				queryClient.invalidateQueries( hasStagingSiteQuery( productionSiteId ?? 0 ) );
+			},
+			onError: ( error: Error ) => {
+				recordTracksEvent( 'calypso_hosting_configuration_staging_site_add_failure' );
+				createErrorNotice(
+					sprintf(
+						// translators: "reason" is why adding the staging site failed.
+						__( 'Failed to create staging site: %(reason)s' ),
+						{ reason: error.message }
+					),
+					{
+						type: 'snackbar',
+					}
+				);
+			},
+		} );
+	};
+
+	return {
+		productionSite,
+		stagingSite,
+		isStagingSiteCreating: !! isStagingSiteCreating,
+		isStagingSiteDeleting: !! isStagingSiteDeleting,
+		handleAddStagingSite,
+	};
+}

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -192,11 +192,8 @@ if ( isDevelopment ) {
 	outputChunkFilename = '[name].js';
 }
 
-const cssFilename = cssNameFromFilename( outputFilename ).replace( '[contenthash]', '[chunkhash]' );
-const cssChunkFilename = cssNameFromFilename( outputChunkFilename ).replace(
-	'[contenthash]',
-	'[chunkhash]'
-);
+const cssFilename = cssNameFromFilename( outputFilename );
+const cssChunkFilename = cssNameFromFilename( outputChunkFilename );
 
 const outputDir = path.resolve( '.' );
 


### PR DESCRIPTION
Closes DOTMSD-1155

## Proposed Changes

* Extract shared staging site logic (queries, mutations, effects, handler) into a `useStagingSite` hook
* Extract shared dropdown into `EnvironmentSwitcherDropdown` component
* Rename `environment-switcher-v2` to `SidebarEnvironmentSwitcher`
* Update the shared `Environment` component and remove redundant `CurrentEnvironment` wrappers
* Add stable IDs to staging site notices to prevent duplicate snackbars

## Why are these changes being made?

PR #109437 introduced `environment-switcher-v2.tsx` as a near-complete fork of `environment-switcher.tsx` to support the sidebar. The two files shared almost all their staging site logic, meaning bug fixes would need to be applied in both places.

## Testing Instructions

* Verify the environment switcher in the header bar works as before (production/staging toggle, add staging site flow)
* Verify the environment switcher in the sidebar works as before
* Verify staging site creation only shows one "Staging site added." snackbar

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)