### PR TITLE
Masterbar: migrate from localize HOC to @wordpress/i18n

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -3,8 +3,9 @@ import { isEcommercePlan } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Badge } from '@automattic/ui';
 import { Button } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import clsx from 'clsx';
-import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { parse } from 'qs';
 import { Component } from 'react';
@@ -206,8 +207,6 @@ class MasterbarLoggedIn extends Component {
 	 * In nav unification, the menu is openned with the Sites button
 	 */
 	renderSidebarMobileMenu() {
-		const { translate } = this.props;
-
 		return (
 			<Item
 				tipTarget="mobile-menu"
@@ -215,7 +214,7 @@ class MasterbarLoggedIn extends Component {
 				onClick={ this.handleToggleMobileMenu }
 				isActive={ this.isSidebarOpen() }
 				className="masterbar__item-sidebar-menu"
-				tooltip={ translate( 'Menu' ) }
+				tooltip={ __( 'Menu' ) }
 			/>
 		);
 	}
@@ -225,7 +224,6 @@ class MasterbarLoggedIn extends Component {
 		const {
 			domainOnlySite,
 			siteSlug,
-			translate,
 			section,
 			currentRoute,
 			isGlobalSidebarVisible,
@@ -251,11 +249,11 @@ class MasterbarLoggedIn extends Component {
 			: [
 					[
 						{
-							label: translate( 'Sites' ),
+							label: __( 'Sites' ),
 							url: dashboardOptIn ? dashboardLink( '/sites' ) : '/sites',
 						},
 						{
-							label: translate( 'Domains' ),
+							label: __( 'Domains' ),
 							url: dashboardOptIn ? dashboardLink( '/domains' ) : '/domains/manage',
 						},
 					],
@@ -264,11 +262,11 @@ class MasterbarLoggedIn extends Component {
 						: [
 								[
 									{
-										label: translate( 'About WordPress' ),
+										label: __( 'About WordPress' ),
 										url: `${ siteAdminUrl }about.php`,
 									},
 									{
-										label: translate( 'Get Involved' ),
+										label: __( 'Get Involved' ),
 										url: `${ siteAdminUrl }contribute.php`,
 									},
 								],
@@ -284,7 +282,7 @@ class MasterbarLoggedIn extends Component {
 				subItems={ subItems }
 				onClick={ this.clickMySites }
 				isActive={ this.isMySitesActive() }
-				tooltip={ translate( 'Manage your sites' ) }
+				tooltip={ __( 'Manage your sites' ) }
 				preloadSection={ this.preloadMySites }
 				hasGlobalBorderStyle
 			/>
@@ -381,7 +379,6 @@ class MasterbarLoggedIn extends Component {
 	renderSiteBadges() {
 		const {
 			site,
-			translate,
 			isUnlaunchedSite,
 			isTrial,
 			isSiteP2,
@@ -415,12 +412,12 @@ class MasterbarLoggedIn extends Component {
 
 		// Staging Badge
 		if ( site?.is_wpcom_staging_site ) {
-			badges.push( translate( 'Staging' ) );
+			badges.push( __( 'Staging' ) );
 		}
 
 		// Trial Badge
 		if ( isTrial ) {
-			badges.push( translate( 'Trial' ) );
+			badges.push( __( 'Trial' ) );
 		}
 
 		// P2 Workspace Badge
@@ -431,30 +428,28 @@ class MasterbarLoggedIn extends Component {
 		// Private/Coming Soon Badge
 		if ( site.is_private ) {
 			badges.push(
-				shouldShowPrivateByDefaultComingSoonBadge
-					? translate( 'Coming Soon' )
-					: translate( 'Private' )
+				shouldShowPrivateByDefaultComingSoonBadge ? __( 'Coming Soon' ) : __( 'Private' )
 			);
 		}
 
 		// Express Service Badge
 		if ( site.options && site.options.is_difm_lite_in_progress ) {
-			badges.push( translate( 'Express Service' ) );
+			badges.push( __( 'Express Service' ) );
 		}
 
 		// Public Coming Soon Badge
 		if ( shouldShowPublicComingSoonSiteBadge ) {
-			badges.push( translate( 'Coming Soon' ) );
+			badges.push( __( 'Coming Soon' ) );
 		}
 
 		// Redirect Badge
 		if ( site.options && site.options.is_redirect ) {
-			badges.push( translate( 'Redirect' ) );
+			badges.push( __( 'Redirect' ) );
 		}
 
 		// Domain Badge
 		if ( site.options && site.options.is_domain_only ) {
-			badges.push( translate( 'Domain' ) );
+			badges.push( __( 'Domain' ) );
 		}
 
 		return badges.length > 0
@@ -469,7 +464,6 @@ class MasterbarLoggedIn extends Component {
 	renderSiteMenu() {
 		const {
 			siteSlug,
-			translate,
 			siteTitle,
 			siteUrl,
 			isClassicView,
@@ -485,19 +479,19 @@ class MasterbarLoggedIn extends Component {
 			return null;
 		}
 
-		const menuItems = [ { label: translate( 'Visit Site' ), url: siteUrl } ];
+		const menuItems = [ { label: __( 'Visit Site' ), url: siteUrl } ];
 
 		if ( isClassicView ) {
-			menuItems.push( { label: translate( 'Dashboard' ), url: siteAdminUrl } );
+			menuItems.push( { label: __( 'Dashboard' ), url: siteAdminUrl } );
 		} else {
-			menuItems.push( { label: translate( 'My Home' ), url: siteHomeUrl } );
+			menuItems.push( { label: __( 'My Home' ), url: siteHomeUrl } );
 		}
 
 		if ( ! site?.is_wpcom_staging_site ) {
 			menuItems.push( {
 				label: (
 					<div className="masterbar__site-info masterbar__site-plan">
-						<span className="masterbar__site-info-label">{ translate( 'Plan' ) }</span>
+						<span className="masterbar__site-info-label">{ __( 'Plan' ) }</span>
 						<div className="masterbar__info-badges">
 							<Badge className="masterbar__info-badge">{ sitePlanName }</Badge>
 						</div>
@@ -515,7 +509,7 @@ class MasterbarLoggedIn extends Component {
 			menuItems.push( {
 				label: (
 					<div className="masterbar__site-info masterbar__site-status">
-						<span className="masterbar__site-info-label">{ translate( 'Status' ) }</span>
+						<span className="masterbar__site-info-label">{ __( 'Status' ) }</span>
 						<div className="masterbar__info-badges">{ siteBadges }</div>
 					</div>
 				),
@@ -539,7 +533,6 @@ class MasterbarLoggedIn extends Component {
 		const {
 			siteSlug,
 			isClassicView,
-			translate,
 			siteAdminUrl,
 			newPostUrl,
 			newPageUrl,
@@ -560,38 +553,38 @@ class MasterbarLoggedIn extends Component {
 		if ( siteSlug ) {
 			siteActions = [
 				{
-					label: translate( 'Post' ),
+					label: __( 'Post' ),
 					url: newPostUrl,
 				},
 				{
-					label: translate( 'Media' ),
+					label: __( 'Media' ),
 					url: isClassicView ? `${ siteAdminUrl }media-new.php` : `/media/${ siteSlug }`,
 				},
 				{
-					label: translate( 'Page' ),
+					label: __( 'Page' ),
 					url: newPageUrl,
 				},
 				{
-					label: translate( 'User' ),
+					label: __( 'User' ),
 					url: isClassicView ? `${ siteAdminUrl }user-new.php` : `/people/new/${ siteSlug }`,
 				},
 			];
 		} else {
 			siteActions = [
 				{
-					label: translate( 'Post' ),
+					label: __( 'Post' ),
 					url: '/post',
 				},
 				{
-					label: translate( 'Media' ),
+					label: __( 'Media' ),
 					url: '/media',
 				},
 				{
-					label: translate( 'Page' ),
+					label: __( 'Page' ),
 					url: '/page',
 				},
 				{
-					label: translate( 'User' ),
+					label: __( 'User' ),
 					url: '/people/new',
 				},
 			];
@@ -602,17 +595,16 @@ class MasterbarLoggedIn extends Component {
 				url={ siteActions[ 0 ].url }
 				subItems={ [ siteActions ] }
 				icon={ <span className="dashicons-before dashicons-plus" /> }
-				tooltip={ translate( 'New', { context: 'admin bar menu group label' } ) }
+				tooltip={ _x( 'New', 'admin bar menu group label' ) }
 				tipTarget="new-menu"
 			>
-				{ translate( 'New', { context: 'admin bar menu group label' } ) }
+				{ _x( 'New', 'admin bar menu group label' ) }
 			</Item>
 		);
 	}
 
 	renderLaunchButton() {
-		const { isA4ADevSite, isUnlaunchedSite, siteId, translate, isManageSiteOptionsEnabled } =
-			this.props;
+		const { isA4ADevSite, isUnlaunchedSite, siteId, isManageSiteOptionsEnabled } = this.props;
 
 		if ( ! isUnlaunchedSite || ! isManageSiteOptionsEnabled || isA4ADevSite ) {
 			return null;
@@ -639,13 +631,13 @@ class MasterbarLoggedIn extends Component {
 					this.props.launchSiteOrRedirectToLaunchSignupFlow( siteId );
 				} }
 			>
-				{ translate( 'Launch site' ) }
+				{ __( 'Launch site' ) }
 			</Item>
 		);
 	}
 
 	renderProfileMenu() {
-		const { translate, user, isGlobalSidebarVisible, siteAdminUrl } = this.props;
+		const { user, isGlobalSidebarVisible, siteAdminUrl } = this.props;
 		const profileActions = [
 			{
 				label: (
@@ -664,7 +656,7 @@ class MasterbarLoggedIn extends Component {
 								{ user.username }
 							</span>
 							<span className="display-name edit-profile">
-								{ isGlobalSidebarVisible ? translate( 'My Profile' ) : translate( 'Edit Profile' ) }
+								{ isGlobalSidebarVisible ? __( 'My Profile' ) : __( 'Edit Profile' ) }
 							</span>
 						</div>
 					</div>
@@ -672,9 +664,9 @@ class MasterbarLoggedIn extends Component {
 				url: isGlobalSidebarVisible ? '/me' : `${ siteAdminUrl }profile.php`,
 			},
 			{
-				label: translate( 'Log Out' ),
+				label: __( 'Log Out' ),
 				onClick: () => this.props.redirectToLogout(),
-				tooltip: translate( 'Log out of WordPress.com' ),
+				tooltip: __( 'Log out of WordPress.com' ),
 				className: 'logout-link',
 			},
 		];
@@ -683,10 +675,8 @@ class MasterbarLoggedIn extends Component {
 			{
 				label: (
 					<span className="button wpcom-button">
-						{ translate( 'My {{wpcomIcon/}} WordPress.com Account', {
-							components: {
-								wpcomIcon: this.wordpressIcon(),
-							},
+						{ createInterpolateElement( __( 'My <wpcomIcon /> WordPress.com Account' ), {
+							wpcomIcon: this.wordpressIcon(),
 						} ) }
 					</span>
 				),
@@ -702,15 +692,17 @@ class MasterbarLoggedIn extends Component {
 				onClick={ this.clickMe }
 				isActive={ this.isActive( 'me', true ) }
 				className="masterbar__item-howdy"
-				tooltip={ translate( 'Update your profile, personal settings, and more' ) }
+				tooltip={ __( 'Update your profile, personal settings, and more' ) }
 				preloadSection={ this.preloadMe }
 				subItems={ [ profileActions, wpcomActions ] }
 				hasGlobalBorderStyle
 			>
 				<span className="masterbar__item-howdy-howdy">
-					{ translate( 'Howdy, %(display_name)s', {
-						args: { display_name: user.display_name },
-					} ) }
+					{ sprintf(
+						/* translators: %s is the user's display name */
+						__( 'Howdy, %s' ),
+						user.display_name
+					) }
 				</span>
 				<Gravatar
 					className="masterbar__item-howdy-gravatar"
@@ -723,7 +715,6 @@ class MasterbarLoggedIn extends Component {
 	}
 
 	renderReader() {
-		const { translate } = this.props;
 		return (
 			<Item
 				tipTarget="reader"
@@ -732,12 +723,12 @@ class MasterbarLoggedIn extends Component {
 				icon={ <ReaderIcon className="masterbar__menu-icon masterbar_svg-reader" /> }
 				onClick={ this.clickReader }
 				isActive={ this.isActive( 'reader', true ) }
-				tooltip={ translate( 'Read the blogs and topics you follow' ) }
+				tooltip={ __( 'Read the blogs and topics you follow' ) }
 				preloadSection={ this.preloadReader }
 				hasGlobalBorderStyle
 			>
 				<span className="masterbar__icon-label masterbar__item-reader-label">
-					{ translate( 'Reader' ) }
+					{ __( 'Reader' ) }
 				</span>
 			</Item>
 		);
@@ -770,32 +761,32 @@ class MasterbarLoggedIn extends Component {
 	}
 
 	renderNotifications() {
-		const { translate } = this.props;
 		return (
 			<Notifications
 				isShowing
 				isActive={ this.isActive( 'notifications' ) }
 				className="masterbar__item-notifications"
-				tooltip={ translate( 'Manage your notifications' ) }
+				tooltip={ __( 'Manage your notifications' ) }
 			>
 				<span className="masterbar__item-notifications-label">
-					{ translate( 'Notifications', {
-						comment: 'Toolbar, must be shorter than ~12 chars',
-					} ) }
+					{
+						/* translators: Toolbar, must be shorter than ~12 chars */
+						_x( 'Notifications', 'masterbar' )
+					}
 				</span>
 			</Notifications>
 		);
 	}
 
 	renderHelpCenter() {
-		const { siteId, translate, useUnifiedAgent } = this.props;
+		const { siteId, useUnifiedAgent } = this.props;
 
 		if ( useUnifiedAgent ) {
 			return (
 				<AsyncLoad
 					require="./masterbar-agents-manager"
 					siteId={ siteId }
-					tooltip={ translate( 'Help' ) }
+					tooltip={ __( 'Help' ) }
 					placeholder={ null }
 				/>
 			);
@@ -805,7 +796,7 @@ class MasterbarLoggedIn extends Component {
 			<AsyncLoad
 				require="./masterbar-help-center"
 				siteId={ siteId }
-				tooltip={ translate( 'Help' ) }
+				tooltip={ __( 'Help' ) }
 				placeholder={ null }
 			/>
 		);
@@ -910,4 +901,4 @@ export default connect(
 		redirectToLogout,
 		launchSiteOrRedirectToLaunchSignupFlow,
 	}
-)( localize( MasterbarLoggedIn ) );
+)( MasterbarLoggedIn );


### PR DESCRIPTION
## Summary
- Replace `i18n-calypso` `localize()` HOC with direct `@wordpress/i18n` imports (`__`, `_x`, `sprintf`) and `createInterpolateElement` from `@wordpress/element`
- Removes the `translate` prop dependency from `MasterbarLoggedIn`, making it usable without the `localize` wrapper
- Prerequisite for stacking Dashboard masterbar work (https://github.com/Automattic/wp-calypso/pull/109383) that wants to be able to use the old Calypso masterbar, but without the legacy localisation code.

## Test plan
- [ ] Verify masterbar renders correctly in Calypso (labels, tooltips, profile menu greeting)
- [ ] Verify translations still work (switch locale if possible)
- [ ] No console errors related to i18n