### PR TITLE
A4A: highlight Pressable usage overages in the usage block

### DIFF
--- a/client/a8c-for-agencies/components/pressable-usage-details/index.tsx
+++ b/client/a8c-for-agencies/components/pressable-usage-details/index.tsx
@@ -1,9 +1,12 @@
 import { ProgressBar } from '@automattic/components';
 import { formatNumber, formatCurrency } from '@automattic/number-formatters';
+import { addQueryArgs } from '@wordpress/url';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
+import { A4A_MARKETPLACE_PRODUCTS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useFetchLicenses from 'calypso/a8c-for-agencies/data/purchases/use-fetch-licenses';
+import { PRODUCT_CATEGORY_PRESSABLE_ADDON } from 'calypso/a8c-for-agencies/sections/marketplace/constants';
 import getPressablePlan from 'calypso/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan';
 import {
 	LicenseFilter,
@@ -13,6 +16,7 @@ import {
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { TitanOrder } from 'calypso/state/a8c-for-agencies/types';
 import { calculateEffectiveCapacity } from './capacity';
+import { getPressableUsageWarning } from './usage-warnings';
 import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 import './style.scss';
@@ -64,6 +68,37 @@ export default function PressableUsageDetails( { existingPlan }: Props ) {
 	}
 
 	const effectiveCapacity = calculateEffectiveCapacity( planInfo, pressableLicensesData?.items );
+	const storageUsage = planUsage?.storage_gb ?? 0;
+	const visitsUsage = planUsage?.visits_count ?? 0;
+	const storageWarning = getPressableUsageWarning(
+		'storage',
+		storageUsage,
+		effectiveCapacity.storage
+	);
+	const visitsWarning = getPressableUsageWarning( 'visits', visitsUsage, effectiveCapacity.visits );
+	const getAddOnLabel = ( addOnLabelKey: 'storage' | 'visits' ) =>
+		addOnLabelKey === 'storage' ? translate( 'Storage' ) : translate( 'Visits' );
+	const pressableAddOnsHref = addQueryArgs( A4A_MARKETPLACE_PRODUCTS_LINK, {
+		category: PRODUCT_CATEGORY_PRESSABLE_ADDON,
+	} );
+	const renderWarningMessage = ( addOnLabelKey: 'storage' | 'visits' ) => (
+		<div className="pressable-usage-details__warning-message">
+			<div>
+				{ translate(
+					'Over the limit. Purchase Pressable %(addon_type)s add-ons to avoid issues with your agency sites.',
+					{
+						args: {
+							addon_type: getAddOnLabel( addOnLabelKey ),
+						},
+						comment: '%(addon_type)s is the Pressable add-on type the user should purchase.',
+					}
+				) }
+			</div>
+			<a className="pressable-usage-details__warning-link" href={ pressableAddOnsHref }>
+				{ translate( 'View Pressable add-ons' ) }
+			</a>
+		</div>
+	);
 
 	// Only render the Titan card if there are active orders
 	const shouldRenderTitanCard = titanUsage?.orders && activeOrders.length > 0;
@@ -80,7 +115,11 @@ export default function PressableUsageDetails( { existingPlan }: Props ) {
 				</div>
 			) }
 			<div className="pressable-usage-details__info">
-				<div className="pressable-usage-details__info-item">
+				<div
+					className={ clsx( 'pressable-usage-details__info-item', {
+						'is-warning': Boolean( storageWarning ),
+					} ) }
+				>
 					<div className="pressable-usage-details__info-header">
 						<div className="pressable-usage-details__info-label">
 							{ translate( 'Storage used' ) }
@@ -100,10 +139,12 @@ export default function PressableUsageDetails( { existingPlan }: Props ) {
 						<ProgressBar
 							className="pressable-usage-details__storage-bar"
 							compact
-							value={ planUsage ? planUsage.storage_gb : 0 }
+							color={ storageWarning ? 'var(--color-error)' : undefined }
+							value={ storageUsage }
 							total={ effectiveCapacity.storage }
 						/>
 					</div>
+					{ storageWarning && renderWarningMessage( storageWarning.addOnLabelKey ) }
 				</div>
 			</div>
 			<div className="pressable-usage-details__info">
@@ -133,7 +174,11 @@ export default function PressableUsageDetails( { existingPlan }: Props ) {
 					</div>
 				</div>
 
-				<div className="pressable-usage-details__info-item visits">
+				<div
+					className={ clsx( 'pressable-usage-details__info-item visits', {
+						'is-warning': Boolean( visitsWarning ),
+					} ) }
+				>
 					<div className="pressable-usage-details__info-header">
 						<div className="pressable-usage-details__info-label">
 							{ translate( 'Monthly visits' ) }
@@ -153,10 +198,12 @@ export default function PressableUsageDetails( { existingPlan }: Props ) {
 						<ProgressBar
 							className="pressable-usage-details__storage-bar"
 							compact
-							value={ planUsage ? planUsage.visits_count : 0 }
+							color={ visitsWarning ? 'var(--color-error)' : undefined }
+							value={ visitsUsage }
 							total={ effectiveCapacity.visits }
 						/>
 					</div>
+					{ visitsWarning && renderWarningMessage( visitsWarning.addOnLabelKey ) }
 				</div>
 			</div>
 			{ shouldRenderTitanCard && (

--- a/client/a8c-for-agencies/components/pressable-usage-details/style.scss
+++ b/client/a8c-for-agencies/components/pressable-usage-details/style.scss
@@ -53,6 +53,17 @@
 		@include break-large {
 			width: 100%;
 		}
+
+		&.is-warning {
+			background: var(--color-error-0);
+			box-shadow: inset 0 0 0 1px var(--color-error-10);
+
+			.pressable-usage-details__info-label,
+			.pressable-usage-details__info-top-right,
+			.pressable-usage-details__warning-message {
+				color: var(--color-error-80);
+			}
+		}
 	}
 
 	.pressable-usage-details__info-header {
@@ -85,6 +96,27 @@
 	.pressable-usage-details__info-value {
 		@include heading-large;
 		margin-top: 5px;
+	}
+
+	.pressable-usage-details__warning-message {
+		@include body-small;
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 8px;
+		margin-top: 12px;
+	}
+
+	.pressable-usage-details__warning-link {
+		@include body-small;
+		color: var(--color-error-80);
+		font-weight: 600;
+		text-decoration: underline;
+
+		&:hover,
+		&:focus {
+			color: var(--color-error-100);
+		}
 	}
 
 	/* Titan Email Addon styles */

--- a/client/a8c-for-agencies/components/pressable-usage-details/test/index.test.tsx
+++ b/client/a8c-for-agencies/components/pressable-usage-details/test/index.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import useFetchLicenses from 'calypso/a8c-for-agencies/data/purchases/use-fetch-licenses';
+import { APIProductFamilyProductBundlePrice } from 'calypso/a8c-for-agencies/types/products';
+import PressableUsageDetails from '../index';
+
+jest.mock( '@automattic/components', () => ( {
+	ProgressBar: ( { className }: { className?: string } ) => (
+		<div className={ className } data-testid="pressable-usage-progress-bar" />
+	),
+} ) );
+
+jest.mock( 'react-redux', () => ( {
+	useSelector: jest.fn(),
+} ) );
+
+jest.mock( 'i18n-calypso', () => ( {
+	useTranslate: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/a8c-for-agencies/data/purchases/use-fetch-licenses', () => jest.fn() );
+
+const mockUseSelector = jest.mocked( useSelector );
+const mockUseTranslate = jest.mocked( useTranslate );
+const mockUseFetchLicenses = jest.mocked( useFetchLicenses );
+
+const existingPlan = {
+	slug: 'pressable-wp-1',
+	name: 'Pressable WP 1',
+	product_id: 1,
+	currency: 'USD',
+	amount: '0',
+	interval: '1 year' as const,
+	bill_period: 'yearly' as const,
+	price_interval: 'yearly' as const,
+	family_slug: 'pressable-wp',
+	supported_bundles: [] as APIProductFamilyProductBundlePrice[],
+};
+
+function translateWithArgs(
+	text: string,
+	options?: { args?: Record< string, string | number > }
+): string {
+	if ( ! options?.args ) {
+		return text;
+	}
+
+	return Object.entries( options.args ).reduce(
+		( translatedText, [ key, value ] ) =>
+			translatedText.replaceAll( `%(${ key })s`, String( value ) ),
+		text
+	) as unknown as string;
+}
+
+function createState( agencyOverrides: Record< string, unknown > = {} ) {
+	return {
+		a8cForAgencies: {
+			agencies: {
+				activeAgency: {
+					third_party: {
+						pressable: {
+							usage: {
+								storage_gb: 0,
+								visits_count: 0,
+								sites_count: 0,
+							},
+							titan_usage: {
+								orders: [],
+							},
+						},
+					},
+					...agencyOverrides,
+				},
+			},
+		},
+	};
+}
+
+describe( 'PressableUsageDetails', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockUseTranslate.mockReturnValue(
+			translateWithArgs as unknown as ReturnType< typeof useTranslate >
+		);
+		mockUseFetchLicenses.mockReturnValue( {
+			data: {
+				items: [],
+			},
+		} as unknown as ReturnType< typeof useFetchLicenses > );
+	} );
+
+	it.each( [
+		{
+			name: 'storage',
+			usage: {
+				storage_gb: 21,
+				visits_count: 1000,
+				sites_count: 1,
+			},
+			expectedWarning:
+				'Over the limit. Purchase Pressable Storage add-ons to avoid issues with your agency sites.',
+		},
+		{
+			name: 'visits',
+			usage: {
+				storage_gb: 10,
+				visits_count: 50001,
+				sites_count: 1,
+			},
+			expectedWarning:
+				'Over the limit. Purchase Pressable Visits add-ons to avoid issues with your agency sites.',
+		},
+	] )( 'renders the add-ons CTA for $name overages', ( { usage, expectedWarning } ) => {
+		mockUseSelector.mockImplementation( ( selector: ( state: unknown ) => unknown ) =>
+			selector(
+				createState( {
+					third_party: {
+						pressable: {
+							usage,
+							titan_usage: {
+								orders: [],
+							},
+						},
+					},
+				} )
+			)
+		);
+
+		render( <PressableUsageDetails existingPlan={ existingPlan } /> );
+
+		expect( screen.getByText( expectedWarning ) ).toBeInTheDocument();
+
+		const cta = screen.getByRole( 'link', { name: 'View Pressable add-ons' } );
+		expect( cta ).toHaveAttribute( 'href', '/marketplace/products?category=pressable-addon' );
+	} );
+} );

--- a/client/a8c-for-agencies/components/pressable-usage-details/test/usage-warnings.test.ts
+++ b/client/a8c-for-agencies/components/pressable-usage-details/test/usage-warnings.test.ts
@@ -1,0 +1,25 @@
+import { getPressableUsageWarning } from '../usage-warnings';
+
+describe( 'getPressableUsageWarning', () => {
+	it( 'returns null when usage is within storage capacity', () => {
+		expect( getPressableUsageWarning( 'storage', 10, 10 ) ).toBeNull();
+	} );
+
+	it( 'returns storage warning details when storage exceeds capacity', () => {
+		expect( getPressableUsageWarning( 'storage', 11, 10 ) ).toEqual( {
+			metric: 'storage',
+			addOnLabelKey: 'storage',
+		} );
+	} );
+
+	it( 'returns visits warning details when visits exceed capacity', () => {
+		expect( getPressableUsageWarning( 'visits', 10001, 10000 ) ).toEqual( {
+			metric: 'visits',
+			addOnLabelKey: 'visits',
+		} );
+	} );
+
+	it( 'returns null when usage and capacity are both zero', () => {
+		expect( getPressableUsageWarning( 'visits', 0, 0 ) ).toBeNull();
+	} );
+} );

--- a/client/a8c-for-agencies/components/pressable-usage-details/usage-warnings.ts
+++ b/client/a8c-for-agencies/components/pressable-usage-details/usage-warnings.ts
@@ -1,0 +1,21 @@
+export type PressableUsageWarningMetric = 'storage' | 'visits';
+
+export type PressableUsageWarning = {
+	metric: PressableUsageWarningMetric;
+	addOnLabelKey: PressableUsageWarningMetric;
+};
+
+export function getPressableUsageWarning(
+	metric: PressableUsageWarningMetric,
+	used: number,
+	total: number
+): PressableUsageWarning | null {
+	if ( used <= total ) {
+		return null;
+	}
+
+	return {
+		metric,
+		addOnLabelKey: metric,
+	};
+}


### PR DESCRIPTION
**[ WIP ]**
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

<img width="2428" height="1376" alt="image" src="https://github.com/user-attachments/assets/9cb9d92e-1a5c-41dc-928c-dcee862cc8a8" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
