### PR TITLE
CIAB: Use partner branding config for the loading logo

### DIFF
--- a/client/dashboard/app-ciab/index.tsx
+++ b/client/dashboard/app-ciab/index.tsx
@@ -7,6 +7,8 @@ import {
 } from '@automattic/api-queries';
 /* eslint-enable no-restricted-imports */
 import config from '@automattic/calypso-config';
+// eslint-disable-next-line no-restricted-imports
+import { detectCiabConfig } from 'calypso/lib/partner-branding';
 import boot from '../app/boot';
 import './translations';
 import type {
@@ -22,6 +24,7 @@ boot( {
 	basePath: '/',
 	mainRoute: '/sites',
 	Logo: null,
+	LoadingLogo: detectCiabConfig()?.loadingLogo,
 	supports: {
 		sites: true,
 		domains: true,

--- a/client/dashboard/app-ciab/index.tsx
+++ b/client/dashboard/app-ciab/index.tsx
@@ -8,7 +8,7 @@ import {
 /* eslint-enable no-restricted-imports */
 import config from '@automattic/calypso-config';
 // eslint-disable-next-line no-restricted-imports
-import { detectCiabConfig } from 'calypso/lib/partner-branding';
+import WooCommerceLogo from 'calypso/components/woocommerce-logo';
 import boot from '../app/boot';
 import './translations';
 import type {
@@ -24,7 +24,7 @@ boot( {
 	basePath: '/',
 	mainRoute: '/sites',
 	Logo: null,
-	LoadingLogo: detectCiabConfig()?.loadingLogo,
+	LoadingLogo: WooCommerceLogo,
 	supports: {
 		sites: true,
 		domains: true,

--- a/client/dashboard/app/root/index.tsx
+++ b/client/dashboard/app/root/index.tsx
@@ -11,8 +11,6 @@ import {
 	useMemo,
 	useSyncExternalStore,
 } from 'react';
-// eslint-disable-next-line no-restricted-imports
-import { detectCiabConfig } from 'calypso/lib/partner-branding';
 import { LoadingLine } from '../../components/loading-line';
 import { PageViewTracker } from '../../components/page-view-tracker';
 import NotFound from '../404';
@@ -26,11 +24,6 @@ import ResponsiveSidebar from '../responsive-sidebar';
 import Snackbars from '../snackbars';
 import './style.scss';
 
-function getDefaultLoadingLogo() {
-	const ciabConfig = detectCiabConfig();
-	return ciabConfig?.loadingLogo ?? WordPressLogo;
-}
-
 const WebpackBuildMonitor = lazy(
 	() =>
 		import(
@@ -43,7 +36,7 @@ const VERY_SLOW_THRESHOLD_MS = 6000;
 
 function Root() {
 	const isOmnibarEnabled = isEnabled( 'dashboard/omnibar' );
-	const { name, supports, LoadingLogo = getDefaultLoadingLogo() } = useAppContext();
+	const { name, supports, LoadingLogo = WordPressLogo } = useAppContext();
 	const isFetching = useIsFetching();
 	const router = useRouter();
 	const queryClient = useQueryClient();

--- a/client/dashboard/app/root/index.tsx
+++ b/client/dashboard/app/root/index.tsx
@@ -11,6 +11,8 @@ import {
 	useMemo,
 	useSyncExternalStore,
 } from 'react';
+// eslint-disable-next-line no-restricted-imports
+import { detectCiabConfig } from 'calypso/lib/partner-branding';
 import { LoadingLine } from '../../components/loading-line';
 import { PageViewTracker } from '../../components/page-view-tracker';
 import NotFound from '../404';
@@ -24,6 +26,11 @@ import ResponsiveSidebar from '../responsive-sidebar';
 import Snackbars from '../snackbars';
 import './style.scss';
 
+function getDefaultLoadingLogo() {
+	const ciabConfig = detectCiabConfig();
+	return ciabConfig?.loadingLogo ?? WordPressLogo;
+}
+
 const WebpackBuildMonitor = lazy(
 	() =>
 		import(
@@ -36,7 +43,7 @@ const VERY_SLOW_THRESHOLD_MS = 6000;
 
 function Root() {
 	const isOmnibarEnabled = isEnabled( 'dashboard/omnibar' );
-	const { name, supports, LoadingLogo = WordPressLogo } = useAppContext();
+	const { name, supports, LoadingLogo = getDefaultLoadingLogo() } = useAppContext();
 	const isFetching = useIsFetching();
 	const router = useRouter();
 	const queryClient = useQueryClient();

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -23,6 +23,7 @@ import WooCommerceLogo from 'calypso/components/woocommerce-logo';
 import { getDashboardStepperLogo } from 'calypso/dashboard/app/stepper-logo';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { isGravPoweredOAuth2Client, isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
+import { getPartnerConfigFromDashboardType } from 'calypso/lib/partner-branding';
 import { jsonStringifyForHtml } from 'calypso/server/sanitize';
 import { initialClientsData, gravatarClientData } from 'calypso/state/oauth2-clients/reducer';
 import { isBilmurEnabled, getBilmurUrl } from './utils/bilmur';
@@ -353,13 +354,19 @@ function LoadingPlaceholder( {
 		isWpMobileApp: app?.isWpMobileApp,
 		isWcMobileApp: app?.isWcMobileApp,
 		isWCCOM,
+		dashboard,
 	} );
 	return <LoadingLogo size={ 72 } className="wpcom-site__logo" />;
 }
 
-function chooseLoadingLogo( { isWpMobileApp, isWcMobileApp, isWCCOM } ) {
+function chooseLoadingLogo( { isWpMobileApp, isWcMobileApp, isWCCOM, dashboard } ) {
 	if ( isWcMobileApp || isWCCOM ) {
 		return WooCommerceLogo;
+	}
+
+	const ciabConfig = getPartnerConfigFromDashboardType( dashboard );
+	if ( ciabConfig?.loadingLogo ) {
+		return ciabConfig.loadingLogo;
 	}
 
 	if ( config.isEnabled( 'jetpack-cloud' ) || isWpMobileApp ) {

--- a/client/lib/partner-branding.tsx
+++ b/client/lib/partner-branding.tsx
@@ -5,6 +5,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import wooLogo from 'calypso/assets/images/icons/Woo_logo_color.svg';
+import WooCommerceLogo from 'calypso/components/woocommerce-logo';
 import { isCiabOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { useSelector } from 'calypso/state';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
@@ -48,6 +49,8 @@ export interface CiabPartnerConfig {
 	domains?: string[];
 	/** Callback to check if an OAuth2 client belongs to this partner */
 	isOAuth2Client?: ( oauth2Client: { id: number } | null ) => boolean;
+	/** Loading logo component (inline SVG) shown during page load */
+	loadingLogo?: React.FC< { className?: string; size?: number } >;
 }
 
 /**
@@ -80,6 +83,7 @@ export const CIAB_PARTNERS: Record< string, CiabPartnerConfig > = {
 		fontStyle: 'system',
 		domains: [ 'my.woo.ai', 'my.woo.localhost' ],
 		isOAuth2Client: isCiabOAuth2Client,
+		loadingLogo: WooCommerceLogo,
 	},
 };
 
@@ -169,6 +173,20 @@ export function getCiabConfigFromGarden(
 
 	// Future: add mappings for other partners like "paypal"
 	return ciabConfig;
+}
+
+/**
+ * Get CIAB partner config from a dashboard type identifier.
+ * Server-safe: no window or DOM access needed.
+ */
+export function getPartnerConfigFromDashboardType( dashboard?: string ): CiabPartnerConfig | null {
+	if ( dashboard === 'ciab' ) {
+		const partnerConfig = CIAB_PARTNERS.woo;
+		if ( partnerConfig && isPartnerEnabled( partnerConfig ) ) {
+			return partnerConfig;
+		}
+	}
+	return null;
 }
 
 /**


### PR DESCRIPTION
## Proposed Changes

- Add `loadingLogo` field to the partner branding config (`CiabPartnerConfig`) pointing to `WooCommerceLogo`
- Add `getPartnerConfigFromDashboardType()` server-safe helper to resolve partner config from dashboard type
- Use partner branding config to determine the loading logo in the server-rendered HTML (`client/document/index.jsx`), the Dashboard root component (`client/dashboard/app/root/index.tsx`), and the CIAB app entry (`client/dashboard/app-ciab/index.tsx`)

## Why are these changes being made?

CIAB sites (`my.woo.ai`, `my.woo.localhost`) were showing the WordPress logo during page load. This change uses the partner branding system to show the Woo logo instead, keeping the loading logo consistent with the rest of the CIAB branding. The approach is scalable — adding a new partner only requires setting `loadingLogo` in their `CIAB_PARTNERS` config entry.

## Testing Instructions

- Visit `my.woo.localhost:3000` (CIAB dashboard)
- Observe the Woo logo during page load instead of the WordPress logo
- Verify `calypso.localhost:3000` still shows the WordPress logo

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?