### PR TITLE
Image Studio: Include attachment url in client context

### DIFF
--- a/packages/image-studio/src/utils/client-context.ts
+++ b/packages/image-studio/src/utils/client-context.ts
@@ -11,6 +11,7 @@ import type { BlockEditorSelectors, CoreDataSelectors, WPBlock } from '../types/
 
 export interface ImageStudioMetadata {
 	id?: number;
+	url?: string;
 	title?: string;
 	alt?: string;
 	width?: number;
@@ -229,6 +230,7 @@ function detectImageEntity(): ImageStudioData | null {
 		if ( attachment ) {
 			imageStudio.metadata = {
 				id: attachment.id,
+				url: attachment.source_url,
 				title: getRenderedText( attachment.title ),
 				alt: attachment.alt_text,
 				width: attachment.media_details?.width,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of FORNO-263

## Proposed Changes

* Send attachment URL in client context

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Currently we get the attachment URL in the backend from the ID. This may not always work for self-hosted sites (e.g. if the attachment has not synced correctly) which means we cannot fetch the image to be edited. Sending the attachment URL via context solves this.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow testing steps in 209054-ghe-Automattic/wpcom

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
