### PR TITLE
Dashboard: move site preview visibility to AppConfig

### DIFF
--- a/client/dashboard/app-ciab/index.tsx
+++ b/client/dashboard/app-ciab/index.tsx
@@ -44,7 +44,7 @@ boot( {
 		commandPalette: false,
 		domainOnlySites: false,
 		startStoreRoute: true,
-		sitePreview: true,
+		siteOverviewPreview: true,
 	},
 	optIn: false,
 	components: {

--- a/client/dashboard/app-ciab/index.tsx
+++ b/client/dashboard/app-ciab/index.tsx
@@ -44,6 +44,7 @@ boot( {
 		commandPalette: false,
 		domainOnlySites: false,
 		startStoreRoute: true,
+		sitePreview: true,
 	},
 	optIn: false,
 	components: {

--- a/client/dashboard/app-ciab/index.tsx
+++ b/client/dashboard/app-ciab/index.tsx
@@ -44,7 +44,9 @@ boot( {
 		commandPalette: false,
 		domainOnlySites: false,
 		startStoreRoute: true,
-		siteOverviewPreview: true,
+		siteOverview: {
+			preview: true,
+		},
 	},
 	optIn: false,
 	components: {

--- a/client/dashboard/app-dotcom/index.tsx
+++ b/client/dashboard/app-dotcom/index.tsx
@@ -6,6 +6,7 @@ import {
 	domainsQuery,
 } from '@automattic/api-queries';
 /* eslint-enable no-restricted-imports */
+import { isEnabled } from '@automattic/calypso-config';
 import boot from '../app/boot';
 import Logo from './logo';
 import type {
@@ -41,6 +42,7 @@ boot( {
 		plugins: true,
 		commandPalette: false,
 		domainOnlySites: true,
+		sitePreview: ! isEnabled( 'dashboard/omnibar' ),
 	},
 	optIn: true,
 	components: {

--- a/client/dashboard/app-dotcom/index.tsx
+++ b/client/dashboard/app-dotcom/index.tsx
@@ -42,7 +42,7 @@ boot( {
 		plugins: true,
 		commandPalette: false,
 		domainOnlySites: true,
-		sitePreview: ! isEnabled( 'dashboard/omnibar' ),
+		siteOverviewPreview: ! isEnabled( 'dashboard/omnibar' ),
 	},
 	optIn: true,
 	components: {

--- a/client/dashboard/app-dotcom/index.tsx
+++ b/client/dashboard/app-dotcom/index.tsx
@@ -42,7 +42,9 @@ boot( {
 		plugins: true,
 		commandPalette: false,
 		domainOnlySites: true,
-		siteOverviewPreview: ! isEnabled( 'dashboard/omnibar' ),
+		siteOverview: {
+			preview: ! isEnabled( 'dashboard/omnibar' ),
+		},
 	},
 	optIn: true,
 	components: {

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -28,6 +28,10 @@ export type MeSupports = {
 	apps: boolean;
 };
 
+export type SiteOverviewSupports = {
+	preview: boolean;
+};
+
 export type AppConfig = {
 	name: string;
 	basePath: string;
@@ -47,7 +51,7 @@ export type AppConfig = {
 		commandPalette: boolean;
 		domainOnlySites: boolean;
 		startStoreRoute?: boolean;
-		siteOverviewPreview: boolean;
+		siteOverview: SiteOverviewSupports;
 	};
 	posthog?: string;
 	optIn: boolean;
@@ -83,7 +87,9 @@ export const APP_CONTEXT_DEFAULT_CONFIG: AppConfig = {
 		commandPalette: false,
 		domainOnlySites: false,
 		startStoreRoute: false,
-		siteOverviewPreview: false,
+		siteOverview: {
+			preview: false,
+		},
 	},
 	optIn: false,
 	components: {},

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -47,6 +47,7 @@ export type AppConfig = {
 		commandPalette: boolean;
 		domainOnlySites: boolean;
 		startStoreRoute?: boolean;
+		sitePreview: boolean;
 	};
 	posthog?: string;
 	optIn: boolean;
@@ -82,6 +83,7 @@ export const APP_CONTEXT_DEFAULT_CONFIG: AppConfig = {
 		commandPalette: false,
 		domainOnlySites: false,
 		startStoreRoute: false,
+		sitePreview: false,
 	},
 	optIn: false,
 	components: {},

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -47,7 +47,7 @@ export type AppConfig = {
 		commandPalette: boolean;
 		domainOnlySites: boolean;
 		startStoreRoute?: boolean;
-		sitePreview: boolean;
+		siteOverviewPreview: boolean;
 	};
 	posthog?: string;
 	optIn: boolean;
@@ -83,7 +83,7 @@ export const APP_CONTEXT_DEFAULT_CONFIG: AppConfig = {
 		commandPalette: false,
 		domainOnlySites: false,
 		startStoreRoute: false,
-		sitePreview: false,
+		siteOverviewPreview: false,
 	},
 	optIn: false,
 	components: {},

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -208,12 +208,7 @@ export const siteOverviewRoute = createRoute( {
 } ).lazy( () =>
 	import( '../../sites/overview' ).then( ( d ) =>
 		createLazyRoute( 'site-overview' )( {
-			component: () => (
-				<d.default
-					siteSlug={ siteRoute.useParams().siteSlug }
-					hideSitePreview={ isEnabled( 'dashboard/omnibar' ) }
-				/>
-			),
+			component: () => <d.default siteSlug={ siteRoute.useParams().siteSlug } />,
 		} )
 	)
 );

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -208,7 +208,12 @@ export const siteOverviewRoute = createRoute( {
 } ).lazy( () =>
 	import( '../../sites/overview' ).then( ( d ) =>
 		createLazyRoute( 'site-overview' )( {
-			component: () => <d.default siteSlug={ siteRoute.useParams().siteSlug } />,
+			component: () => (
+				<d.default
+					siteSlug={ siteRoute.useParams().siteSlug }
+					hideSitePreview={ isEnabled( 'dashboard/omnibar' ) }
+				/>
+			),
 		} )
 	)
 );

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -183,7 +183,7 @@ function SiteOverview( {
 	const { supports } = useAppContext();
 	const isLargeViewport = useViewportMatch( breakpoints?.large ?? 'xlarge' );
 	const isSmallViewport = useViewportMatch( breakpoints?.small ?? 'medium', '<' );
-	const showSitePreview = ! isSmallViewport && supports.siteOverviewPreview;
+	const showSitePreview = ! isSmallViewport && supports.siteOverview.preview;
 	const spacing = isSmallViewport ? SPACING.SMALL : SPACING.DEFAULT;
 	const isCommerceGardenSite = isCommerceGarden( site );
 	const gridLayout = getGridLayout( {

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -183,7 +183,7 @@ function SiteOverview( {
 	const { supports } = useAppContext();
 	const isLargeViewport = useViewportMatch( breakpoints?.large ?? 'xlarge' );
 	const isSmallViewport = useViewportMatch( breakpoints?.small ?? 'medium', '<' );
-	const showSitePreview = ! isSmallViewport && supports.sitePreview;
+	const showSitePreview = ! isSmallViewport && supports.siteOverviewPreview;
 	const spacing = isSmallViewport ? SPACING.SMALL : SPACING.DEFAULT;
 	const isCommerceGardenSite = isCommerceGarden( site );
 	const gridLayout = getGridLayout( {

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -184,8 +184,8 @@ function SiteOverview( {
 	const isLargeViewport = useViewportMatch( breakpoints?.large ?? 'xlarge' );
 	const isSmallViewport = useViewportMatch( breakpoints?.small ?? 'medium', '<' );
 	const showSitePreview = ! isSmallViewport && supports.sitePreview;
-	const isCommerceGardenSite = isCommerceGarden( site );
 	const spacing = isSmallViewport ? SPACING.SMALL : SPACING.DEFAULT;
+	const isCommerceGardenSite = isCommerceGarden( site );
 	const gridLayout = getGridLayout( {
 		count: ( isCommerceGardenSite ? 1 : 3 ) + Number( showSitePreview ),
 		isLargeViewport,

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -12,6 +12,7 @@ import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useRef } from 'react';
+import { useAppContext } from '../../app/context';
 import { PerformanceTrackerStop } from '../../app/performance-tracking';
 import { GuidedTourContextProvider, GuidedTourStep } from '../../components/guided-tour';
 import OptInSurvey from '../../components/opt-in-survey';
@@ -173,19 +174,18 @@ function SiteOverviewSecondaryCards( {
 
 function SiteOverview( {
 	siteSlug,
-	hideSitePreview = false,
 	breakpoints,
 }: {
 	siteSlug: string;
-	hideSitePreview?: boolean;
 	breakpoints?: { large: WPBreakpoint; small: WPBreakpoint };
 } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+	const { supports } = useAppContext();
 	const isLargeViewport = useViewportMatch( breakpoints?.large ?? 'xlarge' );
 	const isSmallViewport = useViewportMatch( breakpoints?.small ?? 'medium', '<' );
-	const showSitePreview = ! ( hideSitePreview || isSmallViewport );
-	const spacing = isSmallViewport ? SPACING.SMALL : SPACING.DEFAULT;
+	const showSitePreview = ! isSmallViewport && supports.sitePreview;
 	const isCommerceGardenSite = isCommerceGarden( site );
+	const spacing = isSmallViewport ? SPACING.SMALL : SPACING.DEFAULT;
 	const gridLayout = getGridLayout( {
 		count: ( isCommerceGardenSite ? 1 : 3 ) + Number( showSitePreview ),
 		isLargeViewport,

--- a/client/sites/v2/site-overview/router.tsx
+++ b/client/sites/v2/site-overview/router.tsx
@@ -24,11 +24,7 @@ const siteOverviewRoute = createRoute( {
 					? { large: 'wide' as WPBreakpoint, small: 'wide' as WPBreakpoint }
 					: { large: 'medium' as WPBreakpoint, small: 'medium' as WPBreakpoint };
 				return (
-					<d.default
-						siteSlug={ siteRoute.useParams().siteSlug }
-						hideSitePreview
-						breakpoints={ breakpoints }
-					/>
+					<d.default siteSlug={ siteRoute.useParams().siteSlug } breakpoints={ breakpoints } />
 				);
 			},
 		} )


### PR DESCRIPTION
## Summary
- Add `siteOverviewPreview` to `AppConfig.supports` to control site preview card visibility on the site overview page
- CIAB always shows the site preview card (`siteOverviewPreview: true`)
- Dotcom hides the site preview card when the omnibar flag is on (`siteOverviewPreview: ! isEnabled( 'dashboard/omnibar' )`)
- Remove `hideSitePreview` prop from overview component in favor of reading from app context

DOTMSD-1138

## Test plan
- [ ] Verify site preview card is hidden on the overview page on dotcom when `dashboard/omnibar` flag is on
- [ ] Verify site preview card is shown on the overview page on dotcom when `dashboard/omnibar` flag is off
- [ ] Verify site preview card is always shown on CIAB
- [ ] Verify site preview card is still hidden on small viewports


🤖 Generated with [Claude Code](https://claude.com/claude-code)