### PR TITLE
Fix: Set find_available_url to false for free .blog subdomains

### DIFF
--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
 import { NewSiteSuccessResponse, Site } from '@automattic/data-stores';
 import { SiteGoal } from '@automattic/data-stores/src/onboard';
-import { getTld } from '@automattic/domain-search';
+import { getTld, isFreeSubdomainQuery } from '@automattic/domain-search';
 import { guessTimezone, getLanguage } from '@automattic/i18n-utils';
 import debugFactory from 'debug';
 import { getLocaleSlug } from 'i18n-calypso';
@@ -69,8 +69,9 @@ const getBlogNameGenerationParams = ( {
 
 		return {
 			blog_name: blogName,
-			// If there is a TLD we need to find an underlying free subdomain in case the user wants to skip checkout.
-			find_available_url: !! getTld( blogName ),
+			// Free subdomains (.wordpress.com and .blog) should use the exact URL.
+			// Only paid domains need find_available_url to generate a fallback free subdomain.
+			find_available_url: ! isFreeSubdomainQuery( siteUrl ) && !! getTld( blogName ),
 		};
 	}
 

--- a/packages/onboarding/src/cart/test/index.ts
+++ b/packages/onboarding/src/cart/test/index.ts
@@ -152,4 +152,21 @@ describe( 'getNewSiteParams', () => {
 			} )
 		);
 	} );
+
+	test( 'find_available_url is false when siteUrl is a free .blog subdomain', () => {
+		expect(
+			getNewSiteParams(
+				testParams( {
+					siteUrl: 'mysite.tech.blog',
+					siteTitle: 'Testing Inc.',
+					username: 'janedoe',
+				} )
+			)
+		).toEqual(
+			expect.objectContaining( {
+				blog_name: 'mysite.tech.blog',
+				find_available_url: false,
+			} )
+		);
+	} );
 } );


### PR DESCRIPTION
Fixes DOMAINS-2052

## Proposed Changes

- Check `isFreeSubdomainQuery()` before setting `find_available_url` in `getBlogNameGenerationParams()`
- Free subdomains (`.wordpress.com` and `.blog` like `mysite.tech.blog`) now set `find_available_url: false` so the exact subdomain is used
- Only paid/custom domains (e.g. `example.com`) set `find_available_url: true`
- Add test case for free `.blog` subdomain

## Why are these changes being made?

When creating a site with a free `.blog` subdomain (e.g. `mysite.tech.blog`), `getTld()` detected `"blog"` as a TLD and set `find_available_url: true`. This caused the `/sites/new` API to generate a new `*.wordpress.com` subdomain instead of using the requested `.blog` subdomain.

## Testing Instructions

1. Start the site creation flow with a free `.blog` subdomain (e.g. `mysite.tech.blog`)
2. Verify the created site uses the `.blog` subdomain, not a `.wordpress.com` fallback
3. Verify custom domains (e.g. `example.com`) still set `find_available_url: true`
4. Run `yarn test-packages --testPathPattern='packages/onboarding/src/cart/test'`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)