### PR TITLE
MSD: Move omnibar margin-top from JS to CSS

### DIFF
--- a/client/dashboard/app/interim-omnibar/index.tsx
+++ b/client/dashboard/app/interim-omnibar/index.tsx
@@ -14,11 +14,6 @@ export default async function loadOmnibar() {
 		queryClient.fetchQuery( { queryKey: AUTH_QUERY_KEY, queryFn: fetchUser } ),
 	] );
 
-	const wpcom = document.getElementById( 'wpcom' );
-	if ( wpcom ) {
-		wpcom.style.marginTop = 'var(--masterbar-height, 47px)';
-	}
-
 	// Hydrate the server-rendered omnibar with null props first to match SSR output,
 	// then immediately re-render with real data.
 	const root = hydrateRoot( container, <InterimOmnibar user={ null } site={ null } /> );

--- a/client/dashboard/app/interim-omnibar/style.scss
+++ b/client/dashboard/app/interim-omnibar/style.scss
@@ -1,5 +1,5 @@
 body:has(#wpcom-omnibar) #wpcom {
-	margin-top: var(--masterbar-height, 47px);
+	margin-block-start: var(--masterbar-height, 47px);
 }
 
 #wpcom-omnibar {

--- a/client/dashboard/app/interim-omnibar/style.scss
+++ b/client/dashboard/app/interim-omnibar/style.scss
@@ -1,3 +1,7 @@
+body:has(#wpcom-omnibar) #wpcom {
+	margin-top: var(--masterbar-height, 47px);
+}
+
 #wpcom-omnibar {
 	--color-masterbar-background: #1d2327;
 	--color-masterbar-text: #f0f0f1;


### PR DESCRIPTION
Part of DOTMSD-1170

## Proposed Changes

* Replace imperative JS `marginTop` assignment in `loadOmnibar()` with a CSS rule using `body:has(#wpcom-omnibar)`.

## Why are these changes being made?

* The old approach applied `margin-top` on `#wpcom` only after JS loaded and executed, causing a layout shift. Moving this to CSS ensures the margin is applied immediately since the stylesheet loads synchronously and `#wpcom-omnibar` is server-rendered.

## Testing Instructions

* Enable the `dashboard/omnibar` feature flag.
* Load the MSD dashboard.
* Verify the omnibar appears at the top and content below it has proper spacing with no layout shift on load.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?