### PR TITLE
MCP: Default write permissions off when enabling MCP

### DIFF
--- a/client/me/mcp/main.jsx
+++ b/client/me/mcp/main.jsx
@@ -85,7 +85,8 @@ function McpComponent( { path } ) {
 	const handleToggleAll = ( enabled ) => {
 		const accountAbilities = {};
 		Object.keys( mcpAbilities ).forEach( ( toolId ) => {
-			accountAbilities[ toolId ] = enabled;
+			// When enabling, only turn on read tools by default — write tools must be opted in explicitly.
+			accountAbilities[ toolId ] = enabled ? isReadTool( mcpAbilities[ toolId ] ) : false;
 		} );
 
 		const disabledSiteIds = getDisabledSiteIds( userSettings || {} );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/AIINT-297/default-write-permissions-off-on-first-mcp-enable

## Summary

- When toggling MCP on, only enable read tools by default
- Write tools must be explicitly opted into by the user
- When toggling MCP off, all tools are disabled as before

Fixes AIINT-297.

## Test plan

- [ ] Navigate to `/me/mcp` with `mcp-settings` feature flag enabled
- [ ] With MCP currently disabled, toggle MCP on
- [ ] Verify Read tools are enabled and Write tools remain off
- [ ] Navigate to Write permissions page and confirm all write tools are off
- [ ] Toggle MCP off, then back on — verify same read-only default applies each time

🤖 Generated with [Claude Code](https://claude.com/claude-code)