### PR TITLE
MCP: Clean up connect AI agent setup page

### DIFF
--- a/client/dashboard/me/mcp/setup/index.tsx
+++ b/client/dashboard/me/mcp/setup/index.tsx
@@ -236,7 +236,7 @@ function McpSetupComponent() {
 
 				<Card>
 					<CardBody style={ { padding: '16px' } }>
-						<VStack spacing={ 3 }>
+						<VStack spacing={ 2 }>
 							<VStack spacing={ 0 }>
 								<Text as="h3" weight="600" style={ { margin: 0 } }>
 									{ __( 'Manual setup' ) }

--- a/client/dashboard/me/mcp/setup/index.tsx
+++ b/client/dashboard/me/mcp/setup/index.tsx
@@ -151,7 +151,7 @@ function McpSetupComponent() {
 			<ComponentViewTracker eventName="calypso_dashboard_mcp_setup_view" />
 			<VStack spacing={ 2 }>
 				<Card>
-					<CardBody style={ { padding: '12px 16px' } }>
+					<CardBody style={ { padding: '8px 16px' } }>
 						<VStack spacing={ 2 }>
 							<SectionHeader level={ 3 } title={ __( 'Choose your AI agent' ) } />
 							<SelectControl
@@ -169,8 +169,8 @@ function McpSetupComponent() {
 					selectedMcpClient === 'claude-code' ||
 					selectedMcpClient === 'cursor' ) && (
 					<Card>
-						<CardBody style={ { padding: '12px 16px' } }>
-							<VStack spacing={ 3 }>
+						<CardBody style={ { padding: '8px 16px' } }>
+							<VStack spacing={ 2 }>
 								<SectionHeader level={ 3 } title={ __( 'Quick setup' ) } />
 
 								{ selectedMcpClient === 'claude' && (
@@ -207,8 +207,8 @@ function McpSetupComponent() {
 								) }
 
 								{ selectedMcpClient === 'cursor' && (
-									<VStack spacing={ 3 }>
-										<p>
+									<>
+										<p style={ { margin: 0 } }>
 											{ __(
 												'Use the one-click install to add the WordPress.com MCP server to Cursor.'
 											) }
@@ -221,7 +221,7 @@ function McpSetupComponent() {
 										>
 											{ __( 'Install in Cursor' ) }
 										</Button>
-									</VStack>
+									</>
 								) }
 							</VStack>
 						</CardBody>
@@ -229,7 +229,7 @@ function McpSetupComponent() {
 				) }
 
 				<Card>
-					<CardBody style={ { padding: '12px 16px' } }>
+					<CardBody style={ { padding: '8px 16px' } }>
 						<VStack spacing={ 2 }>
 							<HStack justify="space-between" alignment="center">
 								<SectionHeader level={ 3 } title={ __( 'Manual setup' ) } />

--- a/client/dashboard/me/mcp/setup/index.tsx
+++ b/client/dashboard/me/mcp/setup/index.tsx
@@ -173,8 +173,8 @@ function McpSetupComponent() {
 					selectedMcpClient === 'claude-code' ||
 					selectedMcpClient === 'cursor' ) && (
 					<Card>
-						<CardBody style={ { padding: '8px 16px' } }>
-							<VStack spacing={ 2 }>
+						<CardBody style={ { padding: '16px' } }>
+							<VStack spacing={ 3 }>
 								<Text as="h3" weight="600" style={ { margin: 0 } }>
 									{ __( 'Quick setup' ) }
 								</Text>
@@ -235,23 +235,28 @@ function McpSetupComponent() {
 				) }
 
 				<Card>
-					<CardBody style={ { padding: '8px 16px' } }>
-						<VStack spacing={ 2 }>
-							<HStack justify="space-between" alignment="center">
+					<CardBody style={ { padding: '16px' } }>
+						<VStack spacing={ 3 }>
+							<VStack spacing={ 0 }>
 								<Text as="h3" weight="600" style={ { margin: 0 } }>
 									{ __( 'Manual setup' ) }
 								</Text>
-								<Button
-									icon={ getCopyIcon() }
-									variant="tertiary"
-									iconSize={ 20 }
-									style={ {
-										color: copyStatus === 'error' ? 'var(--color-error)' : undefined,
-									} }
-									onClick={ copyToClipboard }
-									aria-label={ __( 'Copy configuration to clipboard' ) }
-								/>
-							</HStack>
+								<HStack justify="space-between" alignment="center">
+									<p style={ { margin: 0, fontSize: '13px', color: '#757575' } }>
+										{ __( "Copy this configuration into your client's MCP settings." ) }
+									</p>
+									<Button
+										icon={ getCopyIcon() }
+										variant="tertiary"
+										iconSize={ 20 }
+										style={ {
+											color: copyStatus === 'error' ? 'var(--color-error)' : undefined,
+										} }
+										onClick={ copyToClipboard }
+										aria-label={ __( 'Copy configuration to clipboard' ) }
+									/>
+								</HStack>
+							</VStack>
 							<TextareaControl
 								__nextHasNoMarginBottom
 								value={ JSON.stringify( generateMcpConfig( selectedMcpClient ), null, 2 ) }

--- a/client/dashboard/me/mcp/setup/index.tsx
+++ b/client/dashboard/me/mcp/setup/index.tsx
@@ -6,11 +6,9 @@ import {
 	TextareaControl,
 	SelectControl,
 	__experimentalVStack as VStack,
-	__experimentalText as Text,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { copy, check, error } from '@wordpress/icons';
 import { useState } from 'react';
 import { hasEnabledAccountTools } from '../../../../me/mcp/utils';
@@ -25,15 +23,11 @@ import { SectionHeader } from '../../../components/section-header';
 function McpSetupComponent() {
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 
-	// MCP client selection for configuration format
-	const [ selectedMcpClient, setSelectedMcpClient ] = useState< McpClient >( 'claude' );
-
-	// Copy button state
-	const [ copyStatus, setCopyStatus ] = useState( 'idle' );
-
 	type McpClient = 'claude' | 'claude-code' | 'cursor' | 'vscode' | 'continue' | 'default';
 
-	// MCP client options
+	const [ selectedMcpClient, setSelectedMcpClient ] = useState< McpClient >( 'claude' );
+	const [ copyStatus, setCopyStatus ] = useState( 'idle' );
+
 	const mcpClientOptions: Array< { label: string; value: McpClient } > = [
 		{ label: 'Claude', value: 'claude' },
 		{ label: 'Claude Code', value: 'claude-code' },
@@ -43,7 +37,6 @@ function McpSetupComponent() {
 		{ label: __( 'Other MCP client' ), value: 'default' },
 	];
 
-	// Documentation links for each client
 	const clientDocumentation: Record< McpClient, string > = {
 		claude: 'https://docs.claude.com/en/docs/mcp',
 		'claude-code': 'https://code.claude.com/docs/en/mcp',
@@ -53,9 +46,17 @@ function McpSetupComponent() {
 		default: 'https://modelcontextprotocol.io/docs/develop/connect-local-servers',
 	};
 
+	const clientDocumentationLabels: Record< McpClient, string > = {
+		claude: __( 'Claude documentation' ),
+		'claude-code': __( 'Claude Code documentation' ),
+		vscode: __( 'VS Code documentation' ),
+		cursor: __( 'Cursor documentation' ),
+		continue: __( 'Continue documentation' ),
+		default: __( 'MCP documentation' ),
+	};
+
 	const serverName = 'wpcom-mcp';
 
-	// Generate MCP configuration based on selected client
 	const generateMcpConfig = ( client: McpClient ) => {
 		const baseConfig = {
 			url: 'https://public-api.wordpress.com/wpcom/v2/mcp/v1',
@@ -63,54 +64,22 @@ function McpSetupComponent() {
 
 		switch ( client ) {
 			case 'claude':
-				return {
-					mcpServers: {
-						[ serverName ]: baseConfig,
-					},
-				};
+				return { mcpServers: { [ serverName ]: baseConfig } };
 			case 'claude-code':
-				return {
-					mcpServers: {
-						[ serverName ]: {
-							type: 'http',
-							url: baseConfig.url,
-						},
-					},
-				};
+				return { mcpServers: { [ serverName ]: { type: 'http', url: baseConfig.url } } };
 			case 'vscode':
-				return {
-					servers: {
-						[ serverName ]: baseConfig,
-					},
-				};
+				return { servers: { [ serverName ]: baseConfig } };
 			case 'cursor':
-				return {
-					mcpServers: {
-						[ serverName ]: baseConfig,
-					},
-				};
+				return { mcpServers: { [ serverName ]: baseConfig } };
 			case 'continue':
-				return {
-					mcpServers: [
-						{
-							name: serverName,
-							...baseConfig,
-						},
-					],
-				};
+				return { mcpServers: [ { name: serverName, ...baseConfig } ] };
 			default:
-				return {
-					mcpServers: {
-						[ serverName ]: baseConfig,
-					},
-				};
+				return { mcpServers: { [ serverName ]: baseConfig } };
 		}
 	};
 
-	// Copy MCP configuration to clipboard
 	const copyToClipboard = async () => {
 		const configText = JSON.stringify( generateMcpConfig( selectedMcpClient ), null, 2 );
-
 		try {
 			await navigator.clipboard.writeText( configText );
 			setCopyStatus( 'success' );
@@ -121,7 +90,6 @@ function McpSetupComponent() {
 		}
 	};
 
-	// Helper function to get the appropriate icon based on copy status
 	const getCopyIcon = () => {
 		switch ( copyStatus ) {
 			case 'success':
@@ -133,7 +101,6 @@ function McpSetupComponent() {
 		}
 	};
 
-	// Check if any account-level tools are enabled using the new nested structure
 	const hasEnabledTools = hasEnabledAccountTools( userSettings || {} );
 
 	if ( ! hasEnabledTools ) {
@@ -142,8 +109,8 @@ function McpSetupComponent() {
 				size="small"
 				header={
 					<PageHeader
-						title={ __( 'MCP Client Setup' ) }
-						description={ __( 'Configure your MCP client to connect to WordPress.com.' ) }
+						title={ __( 'Connect AI agent' ) }
+						description={ __( 'Get instructions for connecting your AI agent.' ) }
 						prefix={ <Breadcrumbs length={ 3 } /> }
 					/>
 				}
@@ -154,14 +121,7 @@ function McpSetupComponent() {
 						<VStack spacing={ 4 }>
 							<SectionHeader level={ 3 } title={ __( 'Setup Required' ) } />
 							<VStack spacing={ 4 }>
-								<Text as="p" variant="muted">
-									{ __( 'No MCP access is currently enabled for your account.' ) }
-								</Text>
-								<Text as="p" variant="muted">
-									{ __(
-										'MCP access defines what actions and data your MCP client can access on your account. You need to enable MCP access in the main MCP settings before configuring your client.'
-									) }
-								</Text>
+								<p>{ __( 'No MCP access is currently enabled for your account.' ) }</p>
 								<RouterLinkButton
 									to="/me/preferences/mcp"
 									variant="primary"
@@ -181,74 +141,26 @@ function McpSetupComponent() {
 		<PageLayout
 			size="small"
 			header={
-				<PageHeader title={ __( 'MCP Client Setup' ) } prefix={ <Breadcrumbs length={ 3 } /> } />
+				<PageHeader
+					title={ __( 'Connect AI agent' ) }
+					description={ __( 'Get instructions for connecting your AI agent.' ) }
+					prefix={ <Breadcrumbs length={ 3 } /> }
+				/>
 			}
 		>
 			<ComponentViewTracker eventName="calypso_dashboard_mcp_setup_view" />
-			<>
+			<VStack spacing={ 4 }>
 				<Card>
 					<CardBody>
 						<VStack spacing={ 4 }>
-							<SectionHeader
-								level={ 3 }
-								title={ __( 'Connect AI Assistant to WordPress.com (MCP)' ) }
+							<SectionHeader level={ 3 } title={ __( 'Choose your AI agent' ) } />
+							<SelectControl
+								__next40pxDefaultSize
+								__nextHasNoMarginBottom
+								value={ selectedMcpClient }
+								options={ mcpClientOptions }
+								onChange={ setSelectedMcpClient }
 							/>
-							<VStack spacing={ 4 }>
-								<Text as="p" variant="muted">
-									{ __(
-										'WordPress.com provides MCP (Model Context Protocol) support, which allows AI assistants to interact directly with your WordPress.com account.'
-									) }
-								</Text>
-								<Text as="p" variant="muted">
-									{ __(
-										'The JSON configuration below sets up a secure connection between your AI assistant and your WordPress.com account by:'
-									) }
-								</Text>
-								<VStack spacing={ 2 }>
-									<ul style={ { color: '#757575', paddingInlineStart: '20px', margin: '0' } }>
-										<li>
-											<Text as="p" variant="muted">
-												{ __( 'Connecting to the WordPress.com MCP endpoint' ) }
-											</Text>
-										</li>
-										<li>
-											<Text as="p" variant="muted">
-												{ __(
-													'Handling OAuth 2.1 authentication to securely connect to your WordPress.com account'
-												) }
-											</Text>
-										</li>
-										<li>
-											<Text as="p" variant="muted">
-												{ __(
-													'Providing real-time access to your account’s content and management features'
-												) }
-											</Text>
-										</li>
-									</ul>
-								</VStack>
-							</VStack>
-						</VStack>
-					</CardBody>
-				</Card>
-
-				<Card>
-					<CardBody>
-						<VStack spacing={ 4 }>
-							<SectionHeader level={ 3 } title={ __( 'MCP Client Configuration' ) } />
-							<VStack spacing={ 4 }>
-								<SelectControl
-									__next40pxDefaultSize
-									__nextHasNoMarginBottom
-									label={ __( 'MCP Client' ) }
-									value={ selectedMcpClient }
-									options={ mcpClientOptions }
-									onChange={ setSelectedMcpClient }
-									help={ __(
-										'Choose your MCP client to get the correct configuration format. Then, follow the instructions below.'
-									) }
-								/>
-							</VStack>
 						</VStack>
 					</CardBody>
 				</Card>
@@ -259,167 +171,48 @@ function McpSetupComponent() {
 					<Card>
 						<CardBody>
 							<VStack spacing={ 4 }>
-								<SectionHeader level={ 3 } title={ __( 'Quick Setup' ) } />
-								{ /* Quick Setup for Claude */ }
+								<SectionHeader level={ 3 } title={ __( 'Quick setup' ) } />
+
 								{ selectedMcpClient === 'claude' && (
-									<VStack spacing={ 4 }>
-										<Text as="p" variant="muted">
-											{ __( 'For Claude users, connect WordPress.com from Claude Connectors.' ) }
-										</Text>
-										<Text as="p" variant="muted">
-											{ __( 'Installation steps:' ) }
-										</Text>
-										<ol style={ { color: '#757575', paddingInlineStart: '20px', margin: '0' } }>
-											<li>
-												<Text as="p" variant="muted">
-													{ createInterpolateElement(
-														/* translators: %s is the link to the Claude settings page */
-														__( 'Open <ClaudeSettings/>.' ),
-														{
-															ClaudeSettings: (
-																<ExternalLink href="https://claude.ai/settings/connectors">
-																	{ __( 'Claude settings' ) }
-																</ExternalLink>
-															),
-														}
-													) }
-												</Text>
-											</li>
-											<li>
-												<Text as="p" variant="muted">
-													{ __( 'Click the "Browse connectors" button.' ) }
-												</Text>
-											</li>
-											<li>
-												<Text as="p" variant="muted">
-													{ __( 'Search for WordPress.com.' ) }
-												</Text>
-											</li>
-											<li>
-												<Text as="p" variant="muted">
-													{ __( 'Select WordPress.com and follow the prompts to connect.' ) }
-												</Text>
-											</li>
-										</ol>
-									</VStack>
+									<ol style={ { paddingInlineStart: '20px', margin: '0' } }>
+										<li>
+											<ExternalLink href="https://claude.ai/settings/connectors">
+												{ __( 'Open Claude settings' ) }
+											</ExternalLink>
+										</li>
+										<li>{ __( 'Click "Browse connectors" and search for WordPress.com' ) }</li>
+										<li>{ __( 'Select WordPress.com and follow the prompts' ) }</li>
+									</ol>
 								) }
 
-								{ /* Quick Setup for Claude Code */ }
 								{ selectedMcpClient === 'claude-code' && (
-									<VStack spacing={ 4 }>
-										<Text as="p" variant="muted">
-											{ __(
-												'Claude Code uses a different config format with type: "http". Use the CLI or copy the configuration below.'
-											) }
-										</Text>
-										<Text as="p" variant="muted">
-											{ __( 'Installation steps:' ) }
-										</Text>
-										<ol style={ { color: '#757575', paddingInlineStart: '20px', margin: '0' } }>
-											<li>
-												<Text as="p" variant="muted">
-													{ createInterpolateElement(
-														/* translators: %s is the CLI command to add the MCP server */
-														__( 'Run this command in your terminal: <code>%s</code>' ).replace(
-															'%s',
-															'claude mcp add --transport http wpcom-mcp https://public-api.wordpress.com/wpcom/v2/mcp/v1'
-														),
-														{
-															code: (
-																<code
-																	key="claude-code-cmd"
-																	style={ {
-																		backgroundColor: '#f0f0f1',
-																		padding: '2px 6px',
-																		borderRadius: '3px',
-																		fontFamily: 'monospace',
-																		fontSize: '13px',
-																	} }
-																>
-																	claude mcp add --transport http wpcom-mcp
-																	https://public-api.wordpress.com/wpcom/v2/mcp/v1
-																</code>
-															),
-														}
-													) }
-												</Text>
-											</li>
-											<li>
-												<Text as="p" variant="muted">
-													{ createInterpolateElement(
-														__(
-															'Or copy the configuration below and add it to your <mcpJson/> or <claudeJson/> file.'
-														),
-														{
-															mcpJson: (
-																<code
-																	key="mcp-json"
-																	style={ {
-																		backgroundColor: '#f0f0f1',
-																		padding: '2px 6px',
-																		borderRadius: '3px',
-																		fontFamily: 'monospace',
-																		fontSize: '13px',
-																	} }
-																>
-																	.mcp.json
-																</code>
-															),
-															claudeJson: (
-																<code
-																	key="claude-json"
-																	style={ {
-																		backgroundColor: '#f0f0f1',
-																		padding: '2px 6px',
-																		borderRadius: '3px',
-																		fontFamily: 'monospace',
-																		fontSize: '13px',
-																	} }
-																>
-																	~/.claude.json
-																</code>
-															),
-														}
-													) }
-												</Text>
-											</li>
-											<li>
-												<Text as="p" variant="muted">
-													{ createInterpolateElement(
-														__(
-															'In Claude Code, run <code/> to authenticate with your WordPress.com account.'
-														),
-														{
-															code: (
-																<code
-																	key="mcp-cmd"
-																	style={ {
-																		backgroundColor: '#f0f0f1',
-																		padding: '2px 6px',
-																		borderRadius: '3px',
-																		fontFamily: 'monospace',
-																		fontSize: '13px',
-																	} }
-																>
-																	/mcp
-																</code>
-															),
-														}
-													) }
-												</Text>
-											</li>
-										</ol>
-									</VStack>
+									<ol style={ { paddingInlineStart: '20px', margin: '0' } }>
+										<li>
+											{ __( 'Run in your terminal:' ) }{ ' ' }
+											<code
+												style={ {
+													backgroundColor: '#f0f0f1',
+													padding: '2px 6px',
+													borderRadius: '3px',
+													fontFamily: 'monospace',
+													fontSize: '13px',
+												} }
+											>
+												claude mcp add --transport http wpcom-mcp
+												https://public-api.wordpress.com/wpcom/v2/mcp/v1
+											</code>
+										</li>
+										<li>{ __( 'Run /mcp in Claude Code to authenticate' ) }</li>
+									</ol>
 								) }
 
-								{ /* Quick Setup for Cursor */ }
 								{ selectedMcpClient === 'cursor' && (
-									<VStack spacing={ 4 }>
-										<Text as="p" variant="muted">
+									<VStack spacing={ 3 }>
+										<p>
 											{ __(
-												'For Cursor users, use the one-click install to add the WordPress.com MCP app.'
+												'Use the one-click install to add the WordPress.com MCP server to Cursor.'
 											) }
-										</Text>
+										</p>
 										<Button
 											variant="primary"
 											href="cursor://anysphere.cursor-deeplink/mcp/install?name=WordPress.com&config=eyJjb21tYW5kIjoibnB4IC15IG1jcC1yZW1vdGUgaHR0cHM6Ly9wdWJsaWMtYXBpLndvcmRwcmVzcy5jb20vd3Bjb20vdjIvbWNwL3YxIn0%3D"
@@ -437,105 +230,36 @@ function McpSetupComponent() {
 
 				<Card>
 					<CardBody>
-						<VStack spacing={ 2 }>
-							<SectionHeader level={ 3 } title={ __( 'Manual Setup' ) } />
-							<VStack spacing={ 1 }>
-								<HStack justify="space-between" alignment="center">
-									{ clientDocumentation[ selectedMcpClient ] && (
-										<ExternalLink
-											href={ clientDocumentation[ selectedMcpClient ] }
-											style={ { fontSize: '11px', textTransform: 'uppercase' } }
-										>
-											{ selectedMcpClient === 'default'
-												? __( 'View setup instructions for other MCP client' )
-												: sprintf(
-														/* translators: %s is the name of the MCP client */
-														__( 'View setup instructions for %s' ),
-														mcpClientOptions.find( ( opt ) => opt.value === selectedMcpClient )
-															?.label || ''
-												  ) }
-										</ExternalLink>
-									) }
-									<Button
-										icon={ getCopyIcon() }
-										variant="tertiary"
-										iconSize={ 20 }
-										style={ {
-											color: copyStatus === 'error' ? 'var(--color-error)' : undefined,
-										} }
-										onClick={ copyToClipboard }
-										aria-label={ __( 'Copy configuration to clipboard' ) }
-									/>
-								</HStack>
-								<TextareaControl
-									__nextHasNoMarginBottom
-									value={ JSON.stringify( generateMcpConfig( selectedMcpClient ), null, 2 ) }
-									onChange={ () => {} } // Required prop for read-only textarea
-									readOnly
-									help={ __(
-										'Copy this configuration and paste it into your MCP client’s settings.'
-									) }
-									style={ { minHeight: '160px' } }
+						<VStack spacing={ 3 }>
+							<HStack justify="space-between" alignment="center">
+								<SectionHeader level={ 3 } title={ __( 'Manual setup' ) } />
+								<Button
+									icon={ getCopyIcon() }
+									variant="tertiary"
+									iconSize={ 20 }
+									style={ {
+										color: copyStatus === 'error' ? 'var(--color-error)' : undefined,
+									} }
+									onClick={ copyToClipboard }
+									aria-label={ __( 'Copy configuration to clipboard' ) }
 								/>
-								<VStack spacing={ 1 }>
-									<Text size="12px">
-										{ createInterpolateElement(
-											sprintf(
-												/* translators: %s is the server name identifier */
-												__(
-													'<code>%s</code> is a unique identifier for this WordPress.com account connection'
-												),
-												serverName
-											),
-											{
-												code: (
-													<code
-														key="server-name"
-														style={ {
-															backgroundColor: '#f0f0f1',
-															padding: '2px 6px',
-															borderRadius: '3px',
-															fontFamily: 'monospace',
-															fontSize: '13px',
-														} }
-													>
-														{ serverName }
-													</code>
-												),
-											}
-										) }
-									</Text>
-									<Text size="12px">
-										{ createInterpolateElement(
-											sprintf(
-												/* translators: %s is the package name */
-												__( '<code>%s</code> is the official WordPress.com MCP server endpoint' ),
-												'https://public-api.wordpress.com/wpcom/v2/mcp/v1'
-											),
-											{
-												code: (
-													<code
-														key="package-name"
-														style={ {
-															backgroundColor: '#f0f0f1',
-															padding: '2px 6px',
-															borderRadius: '3px',
-															fontFamily: 'monospace',
-															fontSize: '13px',
-														} }
-													>
-														https://public-api.wordpress.com/wpcom/v2/mcp/v1
-													</code>
-												),
-											}
-										) }
-									</Text>
-								</VStack>
-							</VStack>
+							</HStack>
+							<TextareaControl
+								__nextHasNoMarginBottom
+								value={ JSON.stringify( generateMcpConfig( selectedMcpClient ), null, 2 ) }
+								onChange={ () => {} }
+								readOnly
+								style={ { minHeight: '160px' } }
+							/>
+							{ clientDocumentation[ selectedMcpClient ] && (
+								<ExternalLink href={ clientDocumentation[ selectedMcpClient ] }>
+									{ clientDocumentationLabels[ selectedMcpClient ] }
+								</ExternalLink>
+							) }
 						</VStack>
 					</CardBody>
 				</Card>
-			</>
+			</VStack>
 		</PageLayout>
 	);
 }

--- a/client/dashboard/me/mcp/setup/index.tsx
+++ b/client/dashboard/me/mcp/setup/index.tsx
@@ -149,10 +149,10 @@ function McpSetupComponent() {
 			}
 		>
 			<ComponentViewTracker eventName="calypso_dashboard_mcp_setup_view" />
-			<VStack spacing={ 4 }>
+			<VStack spacing={ 2 }>
 				<Card>
-					<CardBody>
-						<VStack spacing={ 4 }>
+					<CardBody style={ { padding: '12px 16px' } }>
+						<VStack spacing={ 2 }>
 							<SectionHeader level={ 3 } title={ __( 'Choose your AI agent' ) } />
 							<SelectControl
 								__next40pxDefaultSize
@@ -169,8 +169,8 @@ function McpSetupComponent() {
 					selectedMcpClient === 'claude-code' ||
 					selectedMcpClient === 'cursor' ) && (
 					<Card>
-						<CardBody>
-							<VStack spacing={ 4 }>
+						<CardBody style={ { padding: '12px 16px' } }>
+							<VStack spacing={ 3 }>
 								<SectionHeader level={ 3 } title={ __( 'Quick setup' ) } />
 
 								{ selectedMcpClient === 'claude' && (
@@ -229,8 +229,8 @@ function McpSetupComponent() {
 				) }
 
 				<Card>
-					<CardBody>
-						<VStack spacing={ 3 }>
+					<CardBody style={ { padding: '12px 16px' } }>
+						<VStack spacing={ 2 }>
 							<HStack justify="space-between" alignment="center">
 								<SectionHeader level={ 3 } title={ __( 'Manual setup' ) } />
 								<Button

--- a/client/dashboard/me/mcp/setup/index.tsx
+++ b/client/dashboard/me/mcp/setup/index.tsx
@@ -7,6 +7,7 @@ import {
 	SelectControl,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
+	__experimentalText as Text,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { copy, check, error } from '@wordpress/icons';
@@ -18,7 +19,6 @@ import ComponentViewTracker from '../../../components/component-view-tracker';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
 import RouterLinkButton from '../../../components/router-link-button';
-import { SectionHeader } from '../../../components/section-header';
 
 function McpSetupComponent() {
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
@@ -119,7 +119,9 @@ function McpSetupComponent() {
 				<Card>
 					<CardBody>
 						<VStack spacing={ 4 }>
-							<SectionHeader level={ 3 } title={ __( 'Setup Required' ) } />
+							<Text as="h3" weight="600" style={ { margin: 0 } }>
+								{ __( 'Setup Required' ) }
+							</Text>
 							<VStack spacing={ 4 }>
 								<p>{ __( 'No MCP access is currently enabled for your account.' ) }</p>
 								<RouterLinkButton
@@ -153,7 +155,9 @@ function McpSetupComponent() {
 				<Card>
 					<CardBody style={ { padding: '8px 16px' } }>
 						<VStack spacing={ 2 }>
-							<SectionHeader level={ 3 } title={ __( 'Choose your AI agent' ) } />
+							<Text as="h3" weight="600" style={ { margin: 0 } }>
+								{ __( 'Choose your AI agent' ) }
+							</Text>
 							<SelectControl
 								__next40pxDefaultSize
 								__nextHasNoMarginBottom
@@ -171,7 +175,9 @@ function McpSetupComponent() {
 					<Card>
 						<CardBody style={ { padding: '8px 16px' } }>
 							<VStack spacing={ 2 }>
-								<SectionHeader level={ 3 } title={ __( 'Quick setup' ) } />
+								<Text as="h3" weight="600" style={ { margin: 0 } }>
+									{ __( 'Quick setup' ) }
+								</Text>
 
 								{ selectedMcpClient === 'claude' && (
 									<ol style={ { paddingInlineStart: '20px', margin: '0' } }>
@@ -232,7 +238,9 @@ function McpSetupComponent() {
 					<CardBody style={ { padding: '8px 16px' } }>
 						<VStack spacing={ 2 }>
 							<HStack justify="space-between" alignment="center">
-								<SectionHeader level={ 3 } title={ __( 'Manual setup' ) } />
+								<Text as="h3" weight="600" style={ { margin: 0 } }>
+									{ __( 'Manual setup' ) }
+								</Text>
 								<Button
 									icon={ getCopyIcon() }
 									variant="tertiary"

--- a/client/me/mcp/setup.jsx
+++ b/client/me/mcp/setup.jsx
@@ -6,18 +6,14 @@ import {
 	TextareaControl,
 	SelectControl,
 	__experimentalVStack as VStack,
-	__experimentalText as Text,
+	__experimentalHStack as HStack,
 	Card,
 	CardBody,
 } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
-import { sprintf } from '@wordpress/i18n';
 import { copy, check, error } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
-import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
-import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import SectionHeader from 'calypso/components/section-header';
@@ -38,29 +34,17 @@ function McpSetupComponent( { path } ) {
 		error: userSettingsError,
 	} = useQuery( userSettingsQuery() );
 
-	// MCP client selection for configuration format
 	const [ selectedMcpClient, setSelectedMcpClient ] = useState( 'claude' );
-
-	// Copy button state
 	const [ copyStatus, setCopyStatus ] = useState( 'idle' );
-
-	// Reauth state
 	const [ reauthRequired, setReauthRequired ] = useState( false );
 
-	// Monitor reauth status
 	useEffect( () => {
-		const checkReauth = () => {
-			const reauth = twoStepAuthorization.isReauthRequired();
-			setReauthRequired( reauth );
-		};
-
+		const checkReauth = () => setReauthRequired( twoStepAuthorization.isReauthRequired() );
 		twoStepAuthorization.on( 'change', checkReauth );
-		checkReauth(); // Initial check
-
+		checkReauth();
 		return () => twoStepAuthorization.off( 'change', checkReauth );
-	}, [] ); // Empty dependency array - only run once on mount
+	}, [] );
 
-	// MCP client options
 	const mcpClientOptions = [
 		{ label: 'Claude', value: 'claude' },
 		{ label: 'Claude Code', value: 'claude-code' },
@@ -70,7 +54,6 @@ function McpSetupComponent( { path } ) {
 		{ label: translate( 'Other MCP client' ), value: 'default' },
 	];
 
-	// Documentation links for each client
 	const clientDocumentation = {
 		claude: 'https://docs.claude.com/en/docs/mcp',
 		'claude-code': 'https://code.claude.com/docs/en/mcp',
@@ -80,9 +63,17 @@ function McpSetupComponent( { path } ) {
 		default: 'https://modelcontextprotocol.io/docs/develop/connect-local-servers',
 	};
 
+	const clientDocumentationLabels = {
+		claude: translate( 'Claude documentation' ),
+		'claude-code': translate( 'Claude Code documentation' ),
+		vscode: translate( 'VS Code documentation' ),
+		cursor: translate( 'Cursor documentation' ),
+		continue: translate( 'Continue documentation' ),
+		default: translate( 'MCP documentation' ),
+	};
+
 	const serverName = 'wpcom-mcp';
 
-	// Generate MCP configuration based on selected client
 	const generateMcpConfig = ( client ) => {
 		const baseConfig = {
 			url: 'https://public-api.wordpress.com/wpcom/v2/mcp/v1',
@@ -90,54 +81,22 @@ function McpSetupComponent( { path } ) {
 
 		switch ( client ) {
 			case 'claude':
-				return {
-					mcpServers: {
-						[ serverName ]: baseConfig,
-					},
-				};
+				return { mcpServers: { [ serverName ]: baseConfig } };
 			case 'claude-code':
-				return {
-					mcpServers: {
-						[ serverName ]: {
-							type: 'http',
-							url: baseConfig.url,
-						},
-					},
-				};
+				return { mcpServers: { [ serverName ]: { type: 'http', url: baseConfig.url } } };
 			case 'vscode':
-				return {
-					servers: {
-						[ serverName ]: baseConfig,
-					},
-				};
+				return { servers: { [ serverName ]: baseConfig } };
 			case 'cursor':
-				return {
-					mcpServers: {
-						[ serverName ]: baseConfig,
-					},
-				};
+				return { mcpServers: { [ serverName ]: baseConfig } };
 			case 'continue':
-				return {
-					mcpServers: [
-						{
-							name: serverName,
-							...baseConfig,
-						},
-					],
-				};
+				return { mcpServers: [ { name: serverName, ...baseConfig } ] };
 			default:
-				return {
-					mcpServers: {
-						[ serverName ]: baseConfig,
-					},
-				};
+				return { mcpServers: { [ serverName ]: baseConfig } };
 		}
 	};
 
-	// Copy MCP configuration to clipboard
 	const copyToClipboard = async () => {
 		const configText = JSON.stringify( generateMcpConfig( selectedMcpClient ), null, 2 );
-
 		try {
 			await navigator.clipboard.writeText( configText );
 			setCopyStatus( 'success' );
@@ -148,7 +107,6 @@ function McpSetupComponent( { path } ) {
 		}
 	};
 
-	// Helper function to get the appropriate icon based on copy status
 	const getCopyIcon = () => {
 		switch ( copyStatus ) {
 			case 'success':
@@ -160,15 +118,13 @@ function McpSetupComponent( { path } ) {
 		}
 	};
 
-	// Handle error states only - allow loading to continue so reauth can show
 	if ( userSettingsError ) {
 		return null;
 	}
 
-	// Common layout wrapper
 	const renderLayout = ( children ) => (
 		<Main wideLayout className="mcp mcp-setup">
-			<PageViewTracker path={ path } title="MCP Client Setup" />
+			<PageViewTracker path={ path } title="Connect AI agent" />
 			<DocumentHead title={ documentTitle } />
 			<NavigationHeader { ...navigationHeaderProps } />
 			<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
@@ -176,265 +132,91 @@ function McpSetupComponent( { path } ) {
 		</Main>
 	);
 
-	// Check if any account-level tools are enabled using the new nested structure
 	const hasEnabledTools = hasEnabledAccountTools( userSettings );
 
 	if ( ! hasEnabledTools ) {
 		return renderLayout(
-			<>
-				<SectionHeader label={ translate( 'Setup Required' ) } />
-				<Card isRounded={ false }>
-					<CardBody>
+			<Card isRounded={ false }>
+				<CardBody>
+					<VStack spacing={ 4 }>
+						<SectionHeader label={ translate( 'Setup Required' ) } />
 						<VStack spacing={ 4 }>
-							<Text as="p" size="medium">
-								{ translate( 'No MCP tools are currently enabled for your account.' ) }
-							</Text>
-							<Text as="p" size="medium">
-								{ translate(
-									'MCP tools define what actions and data your MCP client can access on your account. You need to enable at least one tool in the main MCP settings before configuring your client.'
-								) }
-							</Text>
+							<p>{ translate( 'No MCP access is currently enabled for your account.' ) }</p>
 							<Button variant="primary" href="/me/mcp" style={ { alignSelf: 'flex-start' } }>
 								{ translate( 'Go to MCP Settings' ) }
 							</Button>
 						</VStack>
-					</CardBody>
-				</Card>
-			</>
+					</VStack>
+				</CardBody>
+			</Card>
 		);
 	}
 
 	return renderLayout(
-		<>
-			<HeaderCake backText={ translate( 'Back' ) } backHref="/me/mcp">
-				{ translate( 'WordPress.com MCP Setup' ) }
-			</HeaderCake>
-
-			<Card style={ { borderRadius: '0' } }>
+		<VStack spacing={ 4 }>
+			<Card isRounded={ false }>
 				<CardBody>
 					<VStack spacing={ 4 }>
-						<Text as="p" size="medium">
-							{ translate(
-								'WordPress.com provides MCP (Model Context Protocol) support, which allows AI assistants to interact directly with your WordPress.com account.'
-							) }
-						</Text>
-						<Text as="p" size="medium">
-							{ translate(
-								'The JSON configuration below sets up a secure connection between your AI assistant and your WordPress.com account by:'
-							) }
-						</Text>
-						<VStack spacing={ 2 }>
-							<ul>
-								<li>{ translate( 'Connecting to the WordPress.com MCP endpoint' ) }</li>
-								<li>
-									{ translate(
-										'Handling OAuth 2.1 authentication to securely connect to your WordPress.com account'
-									) }
-								</li>
-								<li>
-									{ translate(
-										"Providing real-time access to your account's content and management features"
-									) }
-								</li>
-							</ul>
-						</VStack>
+						<SectionHeader label={ translate( 'Choose your AI agent' ) } />
+						<SelectControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							value={ selectedMcpClient }
+							options={ mcpClientOptions }
+							onChange={ setSelectedMcpClient }
+						/>
 					</VStack>
 				</CardBody>
 			</Card>
 
-			<div style={ { marginTop: '24px' } }>
-				<SectionHeader label={ translate( 'MCP Client Configuration' ) } />
+			{ ( selectedMcpClient === 'claude' ||
+				selectedMcpClient === 'claude-code' ||
+				selectedMcpClient === 'cursor' ) && (
 				<Card isRounded={ false }>
 					<CardBody>
-						<VStack spacing={ 6 }>
-							<SelectControl
-								__next40pxDefaultSize
-								__nextHasNoMarginBottom
-								label={ translate( 'MCP Client' ) }
-								value={ selectedMcpClient }
-								options={ mcpClientOptions }
-								onChange={ setSelectedMcpClient }
-								help={ translate(
-									'Choose your MCP client to get the correct configuration format.'
-								) }
-							/>
+						<VStack spacing={ 4 }>
+							<SectionHeader label={ translate( 'Quick setup' ) } />
 
-							{ /* Quick Setup for Claude */ }
 							{ selectedMcpClient === 'claude' && (
-								<VStack spacing={ 4 } style={ { borderBottom: '1px solid #e0e0e0' } }>
-									<CardHeading tagName="h1" size={ 16 } isBold>
-										{ translate( 'Quick Setup' ) }
-									</CardHeading>
-									<Text as="p" size="medium">
-										{ translate(
-											'For Claude users, connect WordPress.com from Claude Connectors.'
-										) }
-									</Text>
-									<Text as="p" size="medium">
-										{ translate( 'Installation steps:' ) }
-									</Text>
-									<ol>
-										<li>
-											<Text as="p" size="medium">
-												{ createInterpolateElement(
-													/* translators: %s is the link to the Claude settings page */
-													translate( 'Open <ClaudeSettings/>.' ),
-													{
-														ClaudeSettings: (
-															<ExternalLink href="https://claude.ai/settings/connectors">
-																{ translate( 'Claude settings' ) }
-															</ExternalLink>
-														),
-													}
-												) }
-											</Text>
-										</li>
-										<li>
-											<Text as="p" size="medium">
-												{ translate( 'Click the "Browse connectors" button.' ) }
-											</Text>
-										</li>
-										<li>
-											<Text as="p" size="medium">
-												{ translate( 'Search for WordPress.com.' ) }
-											</Text>
-										</li>
-										<li>
-											<Text as="p" size="medium">
-												{ translate( 'Select WordPress.com and follow the prompts to connect.' ) }
-											</Text>
-										</li>
-									</ol>
-								</VStack>
+								<ol style={ { paddingInlineStart: '20px', margin: '0' } }>
+									<li>
+										<ExternalLink href="https://claude.ai/settings/connectors">
+											{ translate( 'Open Claude settings' ) }
+										</ExternalLink>
+									</li>
+									<li>{ translate( 'Click "Browse connectors" and search for WordPress.com' ) }</li>
+									<li>{ translate( 'Select WordPress.com and follow the prompts' ) }</li>
+								</ol>
 							) }
 
-							{ /* Quick Setup for Claude Code */ }
 							{ selectedMcpClient === 'claude-code' && (
-								<VStack
-									spacing={ 4 }
-									style={ { borderBottom: '1px solid #e0e0e0', paddingBottom: '24px' } }
-								>
-									<CardHeading tagName="h1" size={ 16 } isBold>
-										{ translate( 'Quick Setup' ) }
-									</CardHeading>
-									<Text as="p" size="medium">
-										{ translate(
-											'Claude Code uses a different config format with type: "http". Use the CLI or copy the configuration below.'
-										) }
-									</Text>
-									<Text as="p" size="medium">
-										{ translate( 'Installation steps:' ) }
-									</Text>
-									<ol>
-										<li>
-											<Text as="p" size="medium">
-												{ createInterpolateElement(
-													translate( 'Run this command in your terminal: <code>%s</code>' ).replace(
-														'%s',
-														'claude mcp add --transport http wpcom-mcp https://public-api.wordpress.com/wpcom/v2/mcp/v1'
-													),
-													{
-														code: (
-															<code
-																key="claude-code-cmd"
-																style={ {
-																	backgroundColor: '#f0f0f1',
-																	padding: '2px 6px',
-																	borderRadius: '3px',
-																	fontFamily: 'monospace',
-																	fontSize: '13px',
-																} }
-															>
-																claude mcp add --transport http wpcom-mcp
-																https://public-api.wordpress.com/wpcom/v2/mcp/v1
-															</code>
-														),
-													}
-												) }
-											</Text>
-										</li>
-										<li>
-											<Text as="p" size="medium">
-												{ createInterpolateElement(
-													translate(
-														'Or copy the configuration below and add it to your <mcpJson/> or <claudeJson/> file.'
-													),
-													{
-														mcpJson: (
-															<code
-																key="mcp-json"
-																style={ {
-																	backgroundColor: '#f0f0f1',
-																	padding: '2px 6px',
-																	borderRadius: '3px',
-																	fontFamily: 'monospace',
-																	fontSize: '13px',
-																} }
-															>
-																.mcp.json
-															</code>
-														),
-														claudeJson: (
-															<code
-																key="claude-json"
-																style={ {
-																	backgroundColor: '#f0f0f1',
-																	padding: '2px 6px',
-																	borderRadius: '3px',
-																	fontFamily: 'monospace',
-																	fontSize: '13px',
-																} }
-															>
-																~/.claude.json
-															</code>
-														),
-													}
-												) }
-											</Text>
-										</li>
-										<li>
-											<Text as="p" size="medium">
-												{ createInterpolateElement(
-													translate(
-														'In Claude Code, run <code/> to authenticate with your WordPress.com account.'
-													),
-													{
-														code: (
-															<code
-																key="mcp-cmd"
-																style={ {
-																	backgroundColor: '#f0f0f1',
-																	padding: '2px 6px',
-																	borderRadius: '3px',
-																	fontFamily: 'monospace',
-																	fontSize: '13px',
-																} }
-															>
-																/mcp
-															</code>
-														),
-													}
-												) }
-											</Text>
-										</li>
-									</ol>
-								</VStack>
+								<ol style={ { paddingInlineStart: '20px', margin: '0' } }>
+									<li>
+										{ translate( 'Run in your terminal:' ) }{ ' ' }
+										<code
+											style={ {
+												backgroundColor: '#f0f0f1',
+												padding: '2px 6px',
+												borderRadius: '3px',
+												fontFamily: 'monospace',
+												fontSize: '13px',
+											} }
+										>
+											claude mcp add --transport http wpcom-mcp
+											https://public-api.wordpress.com/wpcom/v2/mcp/v1
+										</code>
+									</li>
+									<li>{ translate( 'Run /mcp in Claude Code to authenticate' ) }</li>
+								</ol>
 							) }
 
-							{ /* Quick Setup for Cursor */ }
 							{ selectedMcpClient === 'cursor' && (
-								<VStack
-									spacing={ 4 }
-									style={ { borderBottom: '1px solid #e0e0e0', paddingBottom: '24px' } }
-								>
-									<CardHeading tagName="h1" size={ 16 } isBold>
-										{ translate( 'Quick Setup' ) }
-									</CardHeading>
-									<Text as="p" size="medium">
+								<VStack spacing={ 3 }>
+									<p>
 										{ translate(
-											'For Cursor users, use the one-click install to add the WordPress.com MCP app.'
+											'Use the one-click install to add the WordPress.com MCP server to Cursor.'
 										) }
-									</Text>
+									</p>
 									<Button
 										variant="primary"
 										href="cursor://anysphere.cursor-deeplink/mcp/install?name=WordPress.com&config=eyJjb21tYW5kIjoibnB4IC15IG1jcC1yZW1vdGUgaHR0cHM6Ly9wdWJsaWMtYXBpLndvcmRwcmVzcy5jb20vd3Bjb20vdjIvbWNwL3YxIn0%3D"
@@ -445,114 +227,43 @@ function McpSetupComponent( { path } ) {
 									</Button>
 								</VStack>
 							) }
-
-							<VStack spacing={ 4 }>
-								<CardHeading tagName="h1" size={ 16 } isBold>
-									{ translate( 'Manual Setup' ) }
-								</CardHeading>
-
-								<VStack spacing={ 3 }>
-									<div
-										style={ {
-											display: 'flex',
-											justifyContent: 'space-between',
-											alignItems: 'center',
-										} }
-									>
-										{ clientDocumentation[ selectedMcpClient ] && (
-											<ExternalLink
-												href={ clientDocumentation[ selectedMcpClient ] }
-												target="_blank"
-												style={ { fontSize: 'inherit' } }
-											>
-												{ /* translators: %s is the name of the MCP client */ }
-												{ selectedMcpClient === 'default'
-													? translate( 'View setup instructions for other MCP client' )
-													: sprintf(
-															translate( 'View setup instructions for %s' ),
-															mcpClientOptions.find( ( opt ) => opt.value === selectedMcpClient )
-																?.label
-													  ) }
-											</ExternalLink>
-										) }
-										<Button
-											icon={ getCopyIcon() }
-											variant="tertiary"
-											size="small"
-											style={ {
-												color: copyStatus === 'error' ? 'var(--color-error)' : undefined,
-											} }
-											onClick={ copyToClipboard }
-											aria-label={ translate( 'Copy configuration to clipboard' ) }
-										/>
-									</div>
-									<TextareaControl
-										__nextHasNoMarginBottom
-										value={ JSON.stringify( generateMcpConfig( selectedMcpClient ), null, 2 ) }
-										onChange={ () => {} } // Required prop for read-only textarea
-										readOnly
-										help={ translate(
-											"Copy this configuration and paste it into your MCP client's settings."
-										) }
-										style={ { minHeight: '160px' } }
-									/>
-								</VStack>
-							</VStack>
-						</VStack>
-						<VStack spacing={ 3 }>
-							<ul style={ { listStyle: 'none', padding: '0', margin: '0' } }>
-								<li>
-									{ createInterpolateElement(
-										translate(
-											'<code>%s</code> is a unique identifier for this WordPress.com account connection'
-										).replace( '%s', serverName ),
-										{
-											code: (
-												<code
-													key="server-name"
-													style={ {
-														backgroundColor: '#f0f0f1',
-														padding: '2px 6px',
-														borderRadius: '3px',
-														fontFamily: 'monospace',
-														fontSize: '13px',
-													} }
-												>
-													{ serverName }
-												</code>
-											),
-										}
-									) }
-								</li>
-								<li>
-									{ createInterpolateElement(
-										translate(
-											'<code>%s</code> is the official WordPress.com MCP server endpoint'
-										).replace( '%s', 'https://public-api.wordpress.com/wpcom/v2/mcp/v1' ),
-										{
-											code: (
-												<code
-													key="package-name"
-													style={ {
-														backgroundColor: '#f0f0f1',
-														padding: '2px 6px',
-														borderRadius: '3px',
-														fontFamily: 'monospace',
-														fontSize: '13px',
-													} }
-												>
-													https://public-api.wordpress.com/wpcom/v2/mcp/v1
-												</code>
-											),
-										}
-									) }
-								</li>
-							</ul>
 						</VStack>
 					</CardBody>
 				</Card>
-			</div>
-		</>
+			) }
+
+			<Card isRounded={ false }>
+				<CardBody>
+					<VStack spacing={ 3 }>
+						<HStack justify="space-between" alignment="center">
+							<SectionHeader label={ translate( 'Manual setup' ) } />
+							<Button
+								icon={ getCopyIcon() }
+								variant="tertiary"
+								size="small"
+								style={ {
+									color: copyStatus === 'error' ? 'var(--color-error)' : undefined,
+								} }
+								onClick={ copyToClipboard }
+								aria-label={ translate( 'Copy configuration to clipboard' ) }
+							/>
+						</HStack>
+						<TextareaControl
+							__nextHasNoMarginBottom
+							value={ JSON.stringify( generateMcpConfig( selectedMcpClient ), null, 2 ) }
+							onChange={ () => {} }
+							readOnly
+							style={ { minHeight: '160px' } }
+						/>
+						{ clientDocumentation[ selectedMcpClient ] && (
+							<ExternalLink href={ clientDocumentation[ selectedMcpClient ] }>
+								{ clientDocumentationLabels[ selectedMcpClient ] }
+							</ExternalLink>
+						) }
+					</VStack>
+				</CardBody>
+			</Card>
+		</VStack>
 	);
 }
 

--- a/client/me/mcp/setup.jsx
+++ b/client/me/mcp/setup.jsx
@@ -140,12 +140,7 @@ function McpSetupComponent( { path } ) {
 			<Card isRounded={ false }>
 				<CardBody>
 					<VStack spacing={ 4 }>
-						<CardHeading
-							tagName="h2"
-							size={ 16 }
-							isBold
-							style={ { marginTop: 0, marginBottom: 0 } }
-						>
+						<CardHeading tagName="h2" size={ 16 } isBold>
 							{ translate( 'Setup Required' ) }
 						</CardHeading>
 						<VStack spacing={ 4 }>
@@ -185,12 +180,7 @@ function McpSetupComponent( { path } ) {
 					<Card isRounded={ false }>
 						<CardBody style={ { padding: '16px' } }>
 							<VStack spacing={ 3 }>
-								<CardHeading
-									tagName="h2"
-									size={ 16 }
-									isBold
-									style={ { marginTop: 0, marginBottom: 0 } }
-								>
+								<CardHeading tagName="h2" size={ 16 } isBold>
 									{ translate( 'Quick setup' ) }
 								</CardHeading>
 
@@ -256,12 +246,7 @@ function McpSetupComponent( { path } ) {
 						<VStack spacing={ 3 }>
 							<HStack justify="space-between" alignment="center">
 								<VStack spacing={ 0 }>
-									<CardHeading
-										tagName="h2"
-										size={ 16 }
-										isBold
-										style={ { marginTop: 0, marginBottom: 0 } }
-									>
+									<CardHeading tagName="h2" size={ 16 } isBold>
 										{ translate( 'Manual setup' ) }
 									</CardHeading>
 									<p style={ { margin: 0, fontSize: '13px', color: '#757575' } }>

--- a/client/me/mcp/setup.jsx
+++ b/client/me/mcp/setup.jsx
@@ -177,7 +177,7 @@ function McpSetupComponent( { path } ) {
 				selectedMcpClient === 'claude-code' ||
 				selectedMcpClient === 'cursor' ) && (
 				<Card isRounded={ false }>
-					<CardBody style={ { padding: '8px 16px' } }>
+					<CardBody style={ { padding: '16px' } }>
 						<VStack spacing={ 3 }>
 							<CardHeading tagName="h2" size={ 16 } isBold style={ { marginBottom: 0 } }>
 								{ translate( 'Quick setup' ) }
@@ -239,8 +239,8 @@ function McpSetupComponent( { path } ) {
 			) }
 
 			<Card isRounded={ false }>
-				<CardBody style={ { padding: '8px 16px' } }>
-					<VStack spacing={ 2 }>
+				<CardBody style={ { padding: '16px' } }>
+					<VStack spacing={ 3 }>
 						<HStack justify="space-between" alignment="center">
 							<VStack spacing={ 0 }>
 								<CardHeading tagName="h2" size={ 16 } isBold style={ { marginBottom: 0 } }>

--- a/client/me/mcp/setup.jsx
+++ b/client/me/mcp/setup.jsx
@@ -162,11 +162,11 @@ function McpSetupComponent( { path } ) {
 			</HeaderCake>
 			<VStack spacing={ 2 }>
 				<Card isRounded={ false }>
-					<CardBody style={ { padding: '8px 16px' } }>
+					<CardBody style={ { padding: '16px' } }>
 						<SelectControl
 							__next40pxDefaultSize
 							__nextHasNoMarginBottom
-							label={ translate( 'Choose your AI agent' ) }
+							label={ <strong>{ translate( 'Choose your AI agent' ) }</strong> }
 							value={ selectedMcpClient }
 							options={ mcpClientOptions }
 							onChange={ setSelectedMcpClient }

--- a/client/me/mcp/setup.jsx
+++ b/client/me/mcp/setup.jsx
@@ -244,26 +244,26 @@ function McpSetupComponent( { path } ) {
 				<Card isRounded={ false }>
 					<CardBody style={ { padding: '16px' } }>
 						<VStack spacing={ 3 }>
-							<HStack justify="space-between" alignment="center">
-								<VStack spacing={ 0 }>
-									<CardHeading tagName="h2" size={ 16 } isBold>
-										{ translate( 'Manual setup' ) }
-									</CardHeading>
+							<VStack spacing={ 0 }>
+								<CardHeading tagName="h2" size={ 16 } isBold>
+									{ translate( 'Manual setup' ) }
+								</CardHeading>
+								<HStack justify="space-between" alignment="center">
 									<p style={ { margin: 0, fontSize: '13px', color: '#757575' } }>
 										{ translate( "Copy this configuration into your client's MCP settings." ) }
 									</p>
-								</VStack>
-								<Button
-									icon={ getCopyIcon() }
-									variant="tertiary"
-									size="small"
-									style={ {
-										color: copyStatus === 'error' ? 'var(--color-error)' : undefined,
-									} }
-									onClick={ copyToClipboard }
-									aria-label={ translate( 'Copy configuration to clipboard' ) }
-								/>
-							</HStack>
+									<Button
+										icon={ getCopyIcon() }
+										variant="tertiary"
+										size="small"
+										style={ {
+											color: copyStatus === 'error' ? 'var(--color-error)' : undefined,
+										} }
+										onClick={ copyToClipboard }
+										aria-label={ translate( 'Copy configuration to clipboard' ) }
+									/>
+								</HStack>
+							</VStack>
 							<TextareaControl
 								__nextHasNoMarginBottom
 								value={ JSON.stringify( generateMcpConfig( selectedMcpClient ), null, 2 ) }

--- a/client/me/mcp/setup.jsx
+++ b/client/me/mcp/setup.jsx
@@ -15,6 +15,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
 import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
+import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -156,20 +157,19 @@ function McpSetupComponent( { path } ) {
 
 	return renderLayout(
 		<VStack spacing={ 2 }>
+			<HeaderCake backText={ translate( 'Back' ) } backHref="/me/mcp">
+				{ translate( 'Connect AI agent' ) }
+			</HeaderCake>
 			<Card isRounded={ false }>
 				<CardBody style={ { padding: '8px 16px' } }>
-					<VStack spacing={ 2 }>
-						<CardHeading tagName="h2" size={ 16 } isBold style={ { marginBottom: 0 } }>
-							{ translate( 'Choose your AI agent' ) }
-						</CardHeading>
-						<SelectControl
-							__next40pxDefaultSize
-							__nextHasNoMarginBottom
-							value={ selectedMcpClient }
-							options={ mcpClientOptions }
-							onChange={ setSelectedMcpClient }
-						/>
-					</VStack>
+					<SelectControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ translate( 'Choose your AI agent' ) }
+						value={ selectedMcpClient }
+						options={ mcpClientOptions }
+						onChange={ setSelectedMcpClient }
+					/>
 				</CardBody>
 			</Card>
 
@@ -242,9 +242,14 @@ function McpSetupComponent( { path } ) {
 				<CardBody style={ { padding: '8px 16px' } }>
 					<VStack spacing={ 2 }>
 						<HStack justify="space-between" alignment="center">
-							<CardHeading tagName="h2" size={ 16 } isBold style={ { marginBottom: 0 } }>
-								{ translate( 'Manual setup' ) }
-							</CardHeading>
+							<VStack spacing={ 0 }>
+								<CardHeading tagName="h2" size={ 16 } isBold style={ { marginBottom: 0 } }>
+									{ translate( 'Manual setup' ) }
+								</CardHeading>
+								<p style={ { margin: 0, fontSize: '13px', color: '#757575' } }>
+									{ translate( "Copy this configuration into your client's MCP settings." ) }
+								</p>
+							</VStack>
 							<Button
 								icon={ getCopyIcon() }
 								variant="tertiary"

--- a/client/me/mcp/setup.jsx
+++ b/client/me/mcp/setup.jsx
@@ -243,8 +243,8 @@ function McpSetupComponent( { path } ) {
 
 				<Card isRounded={ false }>
 					<CardBody style={ { padding: '16px' } }>
-						<VStack spacing={ 3 }>
-							<VStack spacing={ 0 }>
+						<VStack spacing={ 2 }>
+							<VStack spacing={ 2 }>
 								<CardHeading tagName="h2" size={ 16 } isBold>
 									{ translate( 'Manual setup' ) }
 								</CardHeading>

--- a/client/me/mcp/setup.jsx
+++ b/client/me/mcp/setup.jsx
@@ -139,7 +139,7 @@ function McpSetupComponent( { path } ) {
 			<Card isRounded={ false }>
 				<CardBody>
 					<VStack spacing={ 4 }>
-						<CardHeading tagName="h2" size={ 16 } isBold>
+						<CardHeading tagName="h2" size={ 16 } isBold style={ { marginBottom: 0 } }>
 							{ translate( 'Setup Required' ) }
 						</CardHeading>
 						<VStack spacing={ 4 }>
@@ -157,9 +157,9 @@ function McpSetupComponent( { path } ) {
 	return renderLayout(
 		<VStack spacing={ 2 }>
 			<Card isRounded={ false }>
-				<CardBody style={ { padding: '12px 16px' } }>
+				<CardBody style={ { padding: '8px 16px' } }>
 					<VStack spacing={ 2 }>
-						<CardHeading tagName="h2" size={ 16 } isBold>
+						<CardHeading tagName="h2" size={ 16 } isBold style={ { marginBottom: 0 } }>
 							{ translate( 'Choose your AI agent' ) }
 						</CardHeading>
 						<SelectControl
@@ -177,9 +177,9 @@ function McpSetupComponent( { path } ) {
 				selectedMcpClient === 'claude-code' ||
 				selectedMcpClient === 'cursor' ) && (
 				<Card isRounded={ false }>
-					<CardBody style={ { padding: '12px 16px' } }>
+					<CardBody style={ { padding: '8px 16px' } }>
 						<VStack spacing={ 3 }>
-							<CardHeading tagName="h2" size={ 16 } isBold>
+							<CardHeading tagName="h2" size={ 16 } isBold style={ { marginBottom: 0 } }>
 								{ translate( 'Quick setup' ) }
 							</CardHeading>
 
@@ -217,8 +217,8 @@ function McpSetupComponent( { path } ) {
 							) }
 
 							{ selectedMcpClient === 'cursor' && (
-								<VStack spacing={ 3 }>
-									<p>
+								<>
+									<p style={ { margin: 0 } }>
 										{ translate(
 											'Use the one-click install to add the WordPress.com MCP server to Cursor.'
 										) }
@@ -231,7 +231,7 @@ function McpSetupComponent( { path } ) {
 									>
 										{ translate( 'Install in Cursor' ) }
 									</Button>
-								</VStack>
+								</>
 							) }
 						</VStack>
 					</CardBody>
@@ -239,10 +239,10 @@ function McpSetupComponent( { path } ) {
 			) }
 
 			<Card isRounded={ false }>
-				<CardBody style={ { padding: '12px 16px' } }>
+				<CardBody style={ { padding: '8px 16px' } }>
 					<VStack spacing={ 2 }>
 						<HStack justify="space-between" alignment="center">
-							<CardHeading tagName="h2" size={ 16 } isBold>
+							<CardHeading tagName="h2" size={ 16 } isBold style={ { marginBottom: 0 } }>
 								{ translate( 'Manual setup' ) }
 							</CardHeading>
 							<Button

--- a/client/me/mcp/setup.jsx
+++ b/client/me/mcp/setup.jsx
@@ -140,7 +140,12 @@ function McpSetupComponent( { path } ) {
 			<Card isRounded={ false }>
 				<CardBody>
 					<VStack spacing={ 4 }>
-						<CardHeading tagName="h2" size={ 16 } isBold style={ { marginBottom: 0 } }>
+						<CardHeading
+							tagName="h2"
+							size={ 16 }
+							isBold
+							style={ { marginTop: 0, marginBottom: 0 } }
+						>
 							{ translate( 'Setup Required' ) }
 						</CardHeading>
 						<VStack spacing={ 4 }>
@@ -180,7 +185,12 @@ function McpSetupComponent( { path } ) {
 					<Card isRounded={ false }>
 						<CardBody style={ { padding: '16px' } }>
 							<VStack spacing={ 3 }>
-								<CardHeading tagName="h2" size={ 16 } isBold style={ { marginBottom: 0 } }>
+								<CardHeading
+									tagName="h2"
+									size={ 16 }
+									isBold
+									style={ { marginTop: 0, marginBottom: 0 } }
+								>
 									{ translate( 'Quick setup' ) }
 								</CardHeading>
 
@@ -246,7 +256,12 @@ function McpSetupComponent( { path } ) {
 						<VStack spacing={ 3 }>
 							<HStack justify="space-between" alignment="center">
 								<VStack spacing={ 0 }>
-									<CardHeading tagName="h2" size={ 16 } isBold style={ { marginBottom: 0 } }>
+									<CardHeading
+										tagName="h2"
+										size={ 16 }
+										isBold
+										style={ { marginTop: 0, marginBottom: 0 } }
+									>
 										{ translate( 'Manual setup' ) }
 									</CardHeading>
 									<p style={ { margin: 0, fontSize: '13px', color: '#757575' } }>

--- a/client/me/mcp/setup.jsx
+++ b/client/me/mcp/setup.jsx
@@ -13,10 +13,10 @@ import {
 import { copy, check, error } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
+import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
-import SectionHeader from 'calypso/components/section-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import ReauthRequired from 'calypso/me/reauth-required';
@@ -139,7 +139,9 @@ function McpSetupComponent( { path } ) {
 			<Card isRounded={ false }>
 				<CardBody>
 					<VStack spacing={ 4 }>
-						<SectionHeader label={ translate( 'Setup Required' ) } />
+						<CardHeading tagName="h2" size={ 16 } isBold>
+							{ translate( 'Setup Required' ) }
+						</CardHeading>
 						<VStack spacing={ 4 }>
 							<p>{ translate( 'No MCP access is currently enabled for your account.' ) }</p>
 							<Button variant="primary" href="/me/mcp" style={ { alignSelf: 'flex-start' } }>
@@ -157,7 +159,9 @@ function McpSetupComponent( { path } ) {
 			<Card isRounded={ false }>
 				<CardBody>
 					<VStack spacing={ 4 }>
-						<SectionHeader label={ translate( 'Choose your AI agent' ) } />
+						<CardHeading tagName="h2" size={ 16 } isBold>
+							{ translate( 'Choose your AI agent' ) }
+						</CardHeading>
 						<SelectControl
 							__next40pxDefaultSize
 							__nextHasNoMarginBottom
@@ -175,7 +179,9 @@ function McpSetupComponent( { path } ) {
 				<Card isRounded={ false }>
 					<CardBody>
 						<VStack spacing={ 4 }>
-							<SectionHeader label={ translate( 'Quick setup' ) } />
+							<CardHeading tagName="h2" size={ 16 } isBold>
+								{ translate( 'Quick setup' ) }
+							</CardHeading>
 
 							{ selectedMcpClient === 'claude' && (
 								<ol style={ { paddingInlineStart: '20px', margin: '0' } }>
@@ -236,7 +242,9 @@ function McpSetupComponent( { path } ) {
 				<CardBody>
 					<VStack spacing={ 3 }>
 						<HStack justify="space-between" alignment="center">
-							<SectionHeader label={ translate( 'Manual setup' ) } />
+							<CardHeading tagName="h2" size={ 16 } isBold>
+								{ translate( 'Manual setup' ) }
+							</CardHeading>
 							<Button
 								icon={ getCopyIcon() }
 								variant="tertiary"

--- a/client/me/mcp/setup.jsx
+++ b/client/me/mcp/setup.jsx
@@ -156,127 +156,131 @@ function McpSetupComponent( { path } ) {
 	}
 
 	return renderLayout(
-		<VStack spacing={ 2 }>
+		<>
 			<HeaderCake backText={ translate( 'Back' ) } backHref="/me/mcp">
 				{ translate( 'Connect AI agent' ) }
 			</HeaderCake>
-			<Card isRounded={ false }>
-				<CardBody style={ { padding: '8px 16px' } }>
-					<SelectControl
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-						label={ translate( 'Choose your AI agent' ) }
-						value={ selectedMcpClient }
-						options={ mcpClientOptions }
-						onChange={ setSelectedMcpClient }
-					/>
-				</CardBody>
-			</Card>
+			<VStack spacing={ 2 }>
+				<Card isRounded={ false }>
+					<CardBody style={ { padding: '8px 16px' } }>
+						<SelectControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							label={ translate( 'Choose your AI agent' ) }
+							value={ selectedMcpClient }
+							options={ mcpClientOptions }
+							onChange={ setSelectedMcpClient }
+						/>
+					</CardBody>
+				</Card>
 
-			{ ( selectedMcpClient === 'claude' ||
-				selectedMcpClient === 'claude-code' ||
-				selectedMcpClient === 'cursor' ) && (
+				{ ( selectedMcpClient === 'claude' ||
+					selectedMcpClient === 'claude-code' ||
+					selectedMcpClient === 'cursor' ) && (
+					<Card isRounded={ false }>
+						<CardBody style={ { padding: '16px' } }>
+							<VStack spacing={ 3 }>
+								<CardHeading tagName="h2" size={ 16 } isBold style={ { marginBottom: 0 } }>
+									{ translate( 'Quick setup' ) }
+								</CardHeading>
+
+								{ selectedMcpClient === 'claude' && (
+									<ol style={ { paddingInlineStart: '20px', margin: '0' } }>
+										<li>
+											<ExternalLink href="https://claude.ai/settings/connectors">
+												{ translate( 'Open Claude settings' ) }
+											</ExternalLink>
+										</li>
+										<li>
+											{ translate( 'Click "Browse connectors" and search for WordPress.com' ) }
+										</li>
+										<li>{ translate( 'Select WordPress.com and follow the prompts' ) }</li>
+									</ol>
+								) }
+
+								{ selectedMcpClient === 'claude-code' && (
+									<ol style={ { paddingInlineStart: '20px', margin: '0' } }>
+										<li>
+											{ translate( 'Run in your terminal:' ) }{ ' ' }
+											<code
+												style={ {
+													backgroundColor: '#f0f0f1',
+													padding: '2px 6px',
+													borderRadius: '3px',
+													fontFamily: 'monospace',
+													fontSize: '13px',
+												} }
+											>
+												claude mcp add --transport http wpcom-mcp
+												https://public-api.wordpress.com/wpcom/v2/mcp/v1
+											</code>
+										</li>
+										<li>{ translate( 'Run /mcp in Claude Code to authenticate' ) }</li>
+									</ol>
+								) }
+
+								{ selectedMcpClient === 'cursor' && (
+									<>
+										<p style={ { margin: 0 } }>
+											{ translate(
+												'Use the one-click install to add the WordPress.com MCP server to Cursor.'
+											) }
+										</p>
+										<Button
+											variant="primary"
+											href="cursor://anysphere.cursor-deeplink/mcp/install?name=WordPress.com&config=eyJjb21tYW5kIjoibnB4IC15IG1jcC1yZW1vdGUgaHR0cHM6Ly9wdWJsaWMtYXBpLndvcmRwcmVzcy5jb20vd3Bjb20vdjIvbWNwL3YxIn0%3D"
+											target="_blank"
+											style={ { alignSelf: 'flex-start' } }
+										>
+											{ translate( 'Install in Cursor' ) }
+										</Button>
+									</>
+								) }
+							</VStack>
+						</CardBody>
+					</Card>
+				) }
+
 				<Card isRounded={ false }>
 					<CardBody style={ { padding: '16px' } }>
 						<VStack spacing={ 3 }>
-							<CardHeading tagName="h2" size={ 16 } isBold style={ { marginBottom: 0 } }>
-								{ translate( 'Quick setup' ) }
-							</CardHeading>
-
-							{ selectedMcpClient === 'claude' && (
-								<ol style={ { paddingInlineStart: '20px', margin: '0' } }>
-									<li>
-										<ExternalLink href="https://claude.ai/settings/connectors">
-											{ translate( 'Open Claude settings' ) }
-										</ExternalLink>
-									</li>
-									<li>{ translate( 'Click "Browse connectors" and search for WordPress.com' ) }</li>
-									<li>{ translate( 'Select WordPress.com and follow the prompts' ) }</li>
-								</ol>
-							) }
-
-							{ selectedMcpClient === 'claude-code' && (
-								<ol style={ { paddingInlineStart: '20px', margin: '0' } }>
-									<li>
-										{ translate( 'Run in your terminal:' ) }{ ' ' }
-										<code
-											style={ {
-												backgroundColor: '#f0f0f1',
-												padding: '2px 6px',
-												borderRadius: '3px',
-												fontFamily: 'monospace',
-												fontSize: '13px',
-											} }
-										>
-											claude mcp add --transport http wpcom-mcp
-											https://public-api.wordpress.com/wpcom/v2/mcp/v1
-										</code>
-									</li>
-									<li>{ translate( 'Run /mcp in Claude Code to authenticate' ) }</li>
-								</ol>
-							) }
-
-							{ selectedMcpClient === 'cursor' && (
-								<>
-									<p style={ { margin: 0 } }>
-										{ translate(
-											'Use the one-click install to add the WordPress.com MCP server to Cursor.'
-										) }
+							<HStack justify="space-between" alignment="center">
+								<VStack spacing={ 0 }>
+									<CardHeading tagName="h2" size={ 16 } isBold style={ { marginBottom: 0 } }>
+										{ translate( 'Manual setup' ) }
+									</CardHeading>
+									<p style={ { margin: 0, fontSize: '13px', color: '#757575' } }>
+										{ translate( "Copy this configuration into your client's MCP settings." ) }
 									</p>
-									<Button
-										variant="primary"
-										href="cursor://anysphere.cursor-deeplink/mcp/install?name=WordPress.com&config=eyJjb21tYW5kIjoibnB4IC15IG1jcC1yZW1vdGUgaHR0cHM6Ly9wdWJsaWMtYXBpLndvcmRwcmVzcy5jb20vd3Bjb20vdjIvbWNwL3YxIn0%3D"
-										target="_blank"
-										style={ { alignSelf: 'flex-start' } }
-									>
-										{ translate( 'Install in Cursor' ) }
-									</Button>
-								</>
+								</VStack>
+								<Button
+									icon={ getCopyIcon() }
+									variant="tertiary"
+									size="small"
+									style={ {
+										color: copyStatus === 'error' ? 'var(--color-error)' : undefined,
+									} }
+									onClick={ copyToClipboard }
+									aria-label={ translate( 'Copy configuration to clipboard' ) }
+								/>
+							</HStack>
+							<TextareaControl
+								__nextHasNoMarginBottom
+								value={ JSON.stringify( generateMcpConfig( selectedMcpClient ), null, 2 ) }
+								onChange={ () => {} }
+								readOnly
+								style={ { minHeight: '160px' } }
+							/>
+							{ clientDocumentation[ selectedMcpClient ] && (
+								<ExternalLink href={ clientDocumentation[ selectedMcpClient ] }>
+									{ clientDocumentationLabels[ selectedMcpClient ] }
+								</ExternalLink>
 							) }
 						</VStack>
 					</CardBody>
 				</Card>
-			) }
-
-			<Card isRounded={ false }>
-				<CardBody style={ { padding: '16px' } }>
-					<VStack spacing={ 3 }>
-						<HStack justify="space-between" alignment="center">
-							<VStack spacing={ 0 }>
-								<CardHeading tagName="h2" size={ 16 } isBold style={ { marginBottom: 0 } }>
-									{ translate( 'Manual setup' ) }
-								</CardHeading>
-								<p style={ { margin: 0, fontSize: '13px', color: '#757575' } }>
-									{ translate( "Copy this configuration into your client's MCP settings." ) }
-								</p>
-							</VStack>
-							<Button
-								icon={ getCopyIcon() }
-								variant="tertiary"
-								size="small"
-								style={ {
-									color: copyStatus === 'error' ? 'var(--color-error)' : undefined,
-								} }
-								onClick={ copyToClipboard }
-								aria-label={ translate( 'Copy configuration to clipboard' ) }
-							/>
-						</HStack>
-						<TextareaControl
-							__nextHasNoMarginBottom
-							value={ JSON.stringify( generateMcpConfig( selectedMcpClient ), null, 2 ) }
-							onChange={ () => {} }
-							readOnly
-							style={ { minHeight: '160px' } }
-						/>
-						{ clientDocumentation[ selectedMcpClient ] && (
-							<ExternalLink href={ clientDocumentation[ selectedMcpClient ] }>
-								{ clientDocumentationLabels[ selectedMcpClient ] }
-							</ExternalLink>
-						) }
-					</VStack>
-				</CardBody>
-			</Card>
-		</VStack>
+			</VStack>
+		</>
 	);
 }
 

--- a/client/me/mcp/setup.jsx
+++ b/client/me/mcp/setup.jsx
@@ -155,10 +155,10 @@ function McpSetupComponent( { path } ) {
 	}
 
 	return renderLayout(
-		<VStack spacing={ 4 }>
+		<VStack spacing={ 2 }>
 			<Card isRounded={ false }>
-				<CardBody>
-					<VStack spacing={ 4 }>
+				<CardBody style={ { padding: '12px 16px' } }>
+					<VStack spacing={ 2 }>
 						<CardHeading tagName="h2" size={ 16 } isBold>
 							{ translate( 'Choose your AI agent' ) }
 						</CardHeading>
@@ -177,8 +177,8 @@ function McpSetupComponent( { path } ) {
 				selectedMcpClient === 'claude-code' ||
 				selectedMcpClient === 'cursor' ) && (
 				<Card isRounded={ false }>
-					<CardBody>
-						<VStack spacing={ 4 }>
+					<CardBody style={ { padding: '12px 16px' } }>
+						<VStack spacing={ 3 }>
 							<CardHeading tagName="h2" size={ 16 } isBold>
 								{ translate( 'Quick setup' ) }
 							</CardHeading>
@@ -239,8 +239,8 @@ function McpSetupComponent( { path } ) {
 			) }
 
 			<Card isRounded={ false }>
-				<CardBody>
-					<VStack spacing={ 3 }>
+				<CardBody style={ { padding: '12px 16px' } }>
+					<VStack spacing={ 2 }>
 						<HStack justify="space-between" alignment="center">
 							<CardHeading tagName="h2" size={ 16 } isBold>
 								{ translate( 'Manual setup' ) }

--- a/client/me/mcp/style.scss
+++ b/client/me/mcp/style.scss
@@ -139,6 +139,12 @@ body.is-section-me div.layout.is-global-sidebar-visible .layout__primary .main.m
 	}
 }
 
+// Setup page — zero out card-heading margins so CardBody padding is the only spacing
+.mcp-setup .card-heading {
+	margin-top: 0;
+	margin-bottom: 0;
+}
+
 // Site exceptions — flat `@wordpress/components` Cards only (same as hub / tools subpages)
 .mcp-sites {
 	min-width: 0;


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/AIINT-298/clean-up-the-mcp-connection-instructions-page

## Summary

Closes AIINT-298

- Rename page title from "MCP Client Setup" to "Connect AI agent"
- Remove verbose intro card explaining OAuth/endpoint internals
- Rename agent selector section to "Choose your AI agent"
- Simplify quick setup steps (Claude: 3 steps; Claude Code: 2 steps; Cursor: install button)
- Move copy button to Manual Setup card header (top-right)
- Move documentation link below textarea
- Remove technical notes about `wpcom-mcp` server name identifier

Applies to both the Dashboard (`client/dashboard/me/mcp/setup/index.tsx`) and classic Calypso (`client/me/mcp/setup.jsx`) pages.

| Before | After |
|--------|-------|
|<img width="883" height="837" alt="Screenshot 2026-03-24 at 14 38 06" src="https://github.com/user-attachments/assets/a44482c6-9ef0-4cbb-a1a8-e07a97cf8e42" />|<img width="884" height="792" alt="Screenshot 2026-03-24 at 14 37 27" src="https://github.com/user-attachments/assets/33d043ed-1bbf-45fd-b718-6bf06ff0798c" />|
|<img width="882" height="836" alt="Screenshot 2026-03-24 at 14 37 47" src="https://github.com/user-attachments/assets/7c2c7637-2aa3-4237-ba3c-09a9fdc3e51f" />|<img width="884" height="781" alt="Screenshot 2026-03-24 at 14 37 15" src="https://github.com/user-attachments/assets/a97f0886-384c-4c74-a970-786bdc7d117b" />|
|<img width="1451" height="840" alt="Screenshot 2026-03-24 at 14 38 50" src="https://github.com/user-attachments/assets/8b00e4a3-6190-4900-9e6c-a9af790a4877" />|<img width="1387" height="791" alt="Screenshot 2026-03-24 at 14 26 28" src="https://github.com/user-attachments/assets/7f20c595-44bf-4705-956e-950b6fc2cacc" />|
|<img width="1452" height="863" alt="Screenshot 2026-03-24 at 14 38 39" src="https://github.com/user-attachments/assets/c52ebf1d-892a-4e21-9396-6b937efdf18b" />|<img width="1381" height="795" alt="Screenshot 2026-03-24 at 14 26 10" src="https://github.com/user-attachments/assets/50372d7c-d92c-4062-b07e-49d054b51c57" />|

## Test plan

- [ ] Navigate to `/me/preferences/mcp/setup` (Dashboard) — confirm new title "Connect AI agent", simplified 3-card layout
- [ ] Navigate to `/me/mcp/setup` (classic Calypso) — confirm same simplified layout
- [ ] Switch between agent options in the selector — confirm quick setup shows for Claude/Claude Code/Cursor, not for others
- [ ] Click copy button in Manual Setup header — confirm JSON is copied
- [ ] Confirm documentation link appears below the textarea for each client
