### PR TITLE
Reader: Move Jetpack app promotion from inline feed to sidebar

### DIFF
--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -44,6 +44,7 @@ import {
 import { getReaderTeams } from 'calypso/state/teams/selectors';
 import { setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import ReaderSidebarHelper from './helper';
+import ReaderSidebarAppPromo from './reader-sidebar-app-promo';
 import ReaderSidebarLists from './reader-sidebar-lists';
 import ReaderSidebarNudges from './reader-sidebar-nudges';
 import ReaderSidebarOrganizations from './reader-sidebar-organizations';
@@ -288,6 +289,7 @@ export class ReaderSidebar extends Component {
 			>
 				<ReaderSidebarNudges />
 				{ this.renderSidebarMenu() }
+				<ReaderSidebarAppPromo />
 			</GlobalSidebar>
 		);
 	}

--- a/client/reader/sidebar/reader-sidebar-app-promo/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-app-promo/index.tsx
@@ -1,0 +1,51 @@
+import { useRtl, useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import wpToJpImageRtl from 'calypso/assets/images/jetpack/wp-to-jp-rtl.svg';
+import wpToJpImage from 'calypso/assets/images/jetpack/wp-to-jp.svg';
+import QrCode from 'calypso/blocks/app-promo/qr-code';
+import AppsBadge from 'calypso/blocks/get-apps/apps-badge';
+import userAgent from 'calypso/lib/user-agent';
+import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRecordReaderTracksEvent';
+
+import './style.scss';
+
+const CAMPAIGN = 'calypso-reader-sidebar';
+
+export default function ReaderSidebarAppPromo() {
+	const isRtl = useRtl();
+	const translate = useTranslate();
+	const recordReaderTracksEvent = useRecordReaderTracksEvent();
+
+	useEffect( () => {
+		recordReaderTracksEvent( 'calypso_reader_sidebar_app_promo_impression' );
+	}, [ recordReaderTracksEvent ] );
+
+	const { isiPad, isiPod, isiPhone, isAndroid } = userAgent;
+	const isMobile = isiPad || isiPod || isiPhone || isAndroid;
+	const showIosBadge = isiPad || isiPod || isiPhone;
+
+	return (
+		<div className="reader-sidebar-app-promo">
+			<img
+				className="reader-sidebar-app-promo__icon"
+				src={ isRtl ? wpToJpImageRtl : wpToJpImage }
+				width={ 50 }
+				height={ 30 }
+				alt=""
+			/>
+			<h3 className="reader-sidebar-app-promo__heading">{ translate( 'Jetpack Mobile App' ) }</h3>
+			{ isMobile ? (
+				<AppsBadge
+					storeName={ showIosBadge ? 'ios' : 'android' }
+					utm_campaign={ CAMPAIGN }
+					utm_source="calypso"
+				/>
+			) : (
+				<>
+					<QrCode campaign={ CAMPAIGN } size={ 80 } />
+					<p className="reader-sidebar-app-promo__helper">{ translate( 'Scan to download' ) }</p>
+				</>
+			) }
+		</div>
+	);
+}

--- a/client/reader/sidebar/reader-sidebar-app-promo/style.scss
+++ b/client/reader/sidebar/reader-sidebar-app-promo/style.scss
@@ -1,0 +1,35 @@
+.reader-sidebar-app-promo {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	padding: 24px 16px;
+	text-align: center;
+
+	.reader-sidebar-app-promo__icon {
+		margin-block-end: 8px;
+	}
+
+	.reader-sidebar-app-promo__heading {
+		font-size: 0.875rem;
+		font-weight: 600;
+		margin-block-end: 12px;
+		color: var(--color-text);
+	}
+
+	// Override the QR code block's large margins for sidebar context.
+	.app-promo__qr-code {
+		margin-block: 0;
+		flex-direction: column;
+		align-items: center;
+
+		.get-apps__card-text {
+			display: none;
+		}
+	}
+
+	.reader-sidebar-app-promo__helper {
+		font-size: 0.75rem;
+		color: var(--color-text-subtle);
+		margin-block-start: 8px;
+	}
+}

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -8,7 +8,6 @@ import { createRef, Component, Fragment } from 'react';
 import * as React from 'react';
 import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
-import AppPromo from 'calypso/blocks/app-promo';
 import InfiniteList from 'calypso/components/infinite-list';
 import ListEnd from 'calypso/components/list-end';
 import SectionNav from 'calypso/components/section-nav';
@@ -535,26 +534,6 @@ class ReaderStream extends Component {
 		} );
 	};
 
-	renderAppPromo = ( index ) => {
-		const { isDiscoverStream } = this.props;
-		// Only show it once in the 4th position.
-		if ( index !== 3 ) {
-			return;
-		}
-
-		return (
-			isDiscoverStream && (
-				<AppPromo
-					iconSize={ 40 }
-					campaign="calypso-reader-stream"
-					title={ this.props.translate( 'Read on the go with the Jetpack Mobile App' ) }
-					hasQRCode
-					hasGetAppButton={ false }
-				/>
-			)
-		);
-	};
-
 	getPostRef = ( postKey ) => {
 		return keyToString( postKey );
 	};
@@ -583,7 +562,6 @@ class ReaderStream extends Component {
 
 		return (
 			<Fragment key={ itemKey }>
-				{ this.renderAppPromo( index ) }
 				<PostLifecycle
 					ref={ itemKey /* The ref is stored into `InfiniteList`'s `this.ref` map */ }
 					isSelected={ isSelected }


### PR DESCRIPTION
Part of READ-424

## Proposed Changes

- Remove the inline Jetpack app promotion card from the Discover feed (was at position 4)
- Add a compact app promotion widget to the bottom of the Reader sidebar
- Desktop: shows wp-to-jp icon, heading, and 80px QR code with "Scan to download" helper text
- Mobile: shows native App Store / Play Store badge instead of QR code

## Why are these changes being made?

The inline ad card cheapens the Jetpack mobile app by making it look like a cheap advertisement competing with content. Moving it to the sidebar positions it as a persistent value-add rather than an interruptive ad. Feedback from Product Compass walkthrough — consensus was to move it, not duplicate it.

## Testing Instructions

1. Visit `/discover` — confirm the inline app promo card at position 4 is gone
2. Visit any Reader page — confirm the sidebar shows the app promotion at the bottom, below all navigation items
3. Verify the QR code renders and is scannable (should link to `apps.wordpress.com/get?campaign=calypso-reader-sidebar-qrcode`)
4. Use Chrome DevTools mobile emulation — confirm an app store badge renders instead of the QR code

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?

---
Generated with [Claude Code](https://claude.com/claude-code)