### PR TITLE
Fix READ-443: Reader sidebar click tracking handlers no longer fire

### DIFF
--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -141,12 +141,11 @@ export class ReaderSidebar extends Component {
 		} );
 	};
 
-	handleSidebarMenuClick = ( key ) => ( event, path ) => {
-		const handler = TrackingKeys[ key ];
-		if ( handler ) {
-			recordAction( handler.action );
-			recordGaEvent( handler.gaEvent );
-			this.props.recordReaderTracksEvent( handler.tracksEvent );
+	handleSidebarMenuClick = ( trackingData ) => ( event, path ) => {
+		if ( trackingData ) {
+			recordAction( trackingData.action );
+			recordGaEvent( trackingData.gaEvent );
+			this.props.recordReaderTracksEvent( trackingData.tracksEvent );
 			this.handleGlobalSidebarMenuItemClick( path );
 		}
 	};


### PR DESCRIPTION
Fixes READ-443

## Proposed Changes

* Refactored `handleSidebarMenuClick` in `client/reader/sidebar/index.jsx` to accept the tracking metadata object directly instead of a string key.

## Why are these changes being made?

The refactor in commit a988d6ff531f introduced a `handleSidebarMenuClick` helper that expects a string key and uses `TrackingKeys[key]` to retrieve analytics metadata. However, all call sites pass `TrackingKeys.search` (and similar objects) instead of the string `"search"`. In JavaScript, using an object as a property key coerces it to `"[object Object]"`, which doesn't exist in `TrackingKeys`, so the handler resolves to `undefined` and no analytics events are fired. This silently breaks all Reader sidebar click tracking.

The fix changes `handleSidebarMenuClick` to use the passed object directly as the tracking data, which matches how every call site already invokes it.

## Testing Instructions

1. Click any item in the Reader sidebar (Search, Discover, Likes, Conversations, Manage Subscriptions).
2. Verify that the corresponding analytics events fire (check browser console or network requests for tracking calls).
3. Confirm `recordAction`, `recordGaEvent`, and `recordReaderTracksEvent` are called with the correct values.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?