### PR TITLE
Reader sidebar: Move upsell nudge below navigation menu

### DIFF
--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -286,8 +286,8 @@ export class ReaderSidebar extends Component {
 				onClick={ this.handleClick }
 				siteTitle={ i18n.translate( 'Reader' ) }
 			>
-				<ReaderSidebarNudges />
 				{ this.renderSidebarMenu() }
+				<ReaderSidebarNudges />
 			</GlobalSidebar>
 		);
 	}

--- a/client/reader/sidebar/reader-sidebar-nudges/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-nudges/index.jsx
@@ -27,6 +27,8 @@ function renderFreeToPaidPlanNudge( { siteId, siteSlug, translate }, dispatch ) 
 			onClick={ () => dispatch( clickUpgradeNudge( siteId ) ) }
 			tracksClickName="calypso_upgrade_nudge_cta_click"
 			tracksImpressionName="calypso_upgrade_nudge_impression"
+			dismissPreferenceName="reader-sidebar-free-to-paid-nudge"
+			tracksDismissName="calypso_reader_sidebar_nudge_dismiss"
 		/>
 	);
 }


### PR DESCRIPTION
Closes DOMENG-495

## Proposed Changes

* Move `ReaderSidebarNudges` to render after the sidebar menu content instead of before it.
* Make the "Free domain with an annual plan" upsell nudge permanently dismissable via the user preferences API.


|![Screenshot 2026-03-24 at 15 31 58](https://github.com/user-attachments/assets/610f412b-7bd4-4722-aafc-063efa8847cd)|![Screenshot 2026-03-24 at 15 48 36](https://github.com/user-attachments/assets/a69c766d-8658-4c02-b602-930e423216a1)|
|:---:|:---:|
|**BEFORE**|**AFTER**|

## Why are these changes being made?

The upsell nudge ("Free domain with an annual plan") was rendering above the Reader sidebar navigation menu, pushing primary navigation items (Discover, Recent, Tags, Lists, etc.) down. This degrades the sidebar experience since users have to scroll past a promotional banner before reaching actual navigation. Moving the nudge below the menu ensures navigation items are immediately accessible.

Additionally, the nudge had no dismiss option, so users who were not interested in upgrading had no way to hide it. Adding permanent dismissal via `dismissPreferenceName` allows users to close the banner once and never see it again.

## Testing Instructions

* Open the Reader sidebar while logged in with a single free site (to trigger the upsell nudge eligibility).
* Verify the "Free domain with an annual plan" nudge appears **below** the sidebar navigation menu, not above it.
* Verify all sidebar navigation items render correctly and are accessible without scrolling past the nudge.
* Verify the nudge now shows a dismiss (close) button.
* Click the dismiss button and confirm the nudge disappears.
* Reload the page and confirm the nudge remains dismissed.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in Memoizing with create-selector and Using memoizing selectors and Our Approach to Data
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)