### PR TITLE
Reader cards - stop cropping featured images.

### DIFF
--- a/client/blocks/reader-featured-image/index.jsx
+++ b/client/blocks/reader-featured-image/index.jsx
@@ -7,6 +7,7 @@ import {
 	READER_COMPACT_POST_FEATURED_MAX_IMAGE_HEIGHT,
 	READER_COMPACT_POST_FEATURED_MAX_IMAGE_WIDTH,
 	READER_COMPACT_POST_NO_EXCERPT_FEATURED_MAX_IMAGE_WIDTH,
+	READER_CONTENT_WIDTH,
 	READER_FEATURED_MAX_IMAGE_HEIGHT,
 } from 'calypso/state/reader/posts/sizes';
 import './style.scss';
@@ -69,6 +70,7 @@ const ReaderFeaturedImage = ( {
 	imageHeight,
 	isCompactPost,
 	hasExcerpt,
+	useStreamAspectFit = false,
 } ) => {
 	// No featured image, so don't render anything
 	if ( imageUrl === undefined ) {
@@ -136,40 +138,86 @@ const ReaderFeaturedImage = ( {
 			containerHeight = READER_COMPACT_POST_FEATURED_MAX_IMAGE_HEIGHT;
 	}
 
-	const resizedImageUrl = fetched
-		? imageUrl
-		: resizeImageUrl( imageUrl, { w: containerWidth }, containerHeight );
+	let resizedImageUrl = imageUrl;
+	if ( ! fetched ) {
+		if ( useStreamAspectFit ) {
+			resizedImageUrl = resizeImageUrl(
+				imageUrl,
+				READER_CONTENT_WIDTH,
+				READER_FEATURED_MAX_IMAGE_HEIGHT
+			);
+		} else {
+			resizedImageUrl = resizeImageUrl( imageUrl, { w: containerWidth }, containerHeight );
+		}
+	}
 	const safeCssUrl = cssSafeUrl( resizedImageUrl );
 	if ( ! safeCssUrl ) {
 		return null;
 	}
 
-	// Set default style to no background
-	let featuredImageStyle = {
-		background: 'none',
-		height: containerHeight,
-	};
+	const isPortrait =
+		typeof imageWidth === 'number' && typeof imageHeight === 'number' && imageHeight > imageWidth;
 
-	const isPortrait = imageHeight > imageWidth;
+	// `false` from `{ cond && <Node /> }` is a valid React child but means "no overlay" (e.g. video thumbnail).
+	const hasChildContent = children != null && children !== false;
 
-	if ( children ) {
+	let featuredImageStyle;
+	let renderedChildren = children;
+
+	if ( useStreamAspectFit && hasChildContent ) {
+		featuredImageStyle = {
+			backgroundColor: 'var(--studio-gray-0)',
+			backgroundImage: 'url(' + safeCssUrl + ')',
+			backgroundPosition: '50% 50%',
+			backgroundRepeat: 'no-repeat',
+			backgroundSize: 'contain',
+			height: containerHeight,
+			maxWidth: '100%',
+			width: '100%',
+		};
+	} else if ( useStreamAspectFit && ! hasChildContent ) {
+		featuredImageStyle = {
+			backgroundColor: 'var(--studio-gray-0)',
+			maxWidth: '100%',
+			width: '100%',
+		};
+		renderedChildren = (
+			<img
+				src={ safeCssUrl }
+				alt="Featured"
+				style={ {
+					display: 'block',
+					height: 'auto',
+					maxHeight: READER_FEATURED_MAX_IMAGE_HEIGHT,
+					maxWidth: '100%',
+					objectFit: 'contain',
+					width: 'auto',
+				} }
+			/>
+		);
+	} else if ( hasChildContent ) {
 		// If there are children, then we are rendering an image tag inside the anchor tag
 		// In this case we will need to anchor tag will need specific styling to show the image(s)
 		featuredImageStyle = {
 			backgroundImage: 'url(' + safeCssUrl + ')',
 			backgroundPosition: '50% 50%',
+			backgroundRepeat: 'no-repeat',
+			backgroundSize: 'cover',
 			height: containerHeight,
 			width: 'auto',
-			backgroundSize: 'cover',
-			backgroundRepeat: 'no-repeat',
 		};
 	} else {
+		featuredImageStyle = {
+			background: 'none',
+			height: containerHeight,
+		};
+
 		if ( isPortrait ) {
 			featuredImageStyle.background = 'var(--studio-gray-0)';
 		}
 
 		// Since there is no children in props, we need to create a new image tag to ensure the correct size is rendered
-		children = (
+		renderedChildren = (
 			<img
 				src={ safeCssUrl }
 				alt="Featured"
@@ -178,11 +226,13 @@ const ReaderFeaturedImage = ( {
 		);
 	}
 
-	const classNames = clsx( className, 'reader-featured-image' );
+	const classNames = clsx( className, 'reader-featured-image', {
+		'reader-featured-image--stream-aspect-fit': useStreamAspectFit,
+	} );
 
 	return (
 		<a className={ classNames } href={ href } style={ featuredImageStyle } onClick={ onClick }>
-			{ children }
+			{ renderedChildren }
 		</a>
 	);
 };
@@ -191,6 +241,7 @@ ReaderFeaturedImage.propTypes = {
 	canonicalMedia: PropTypes.object,
 	href: PropTypes.string,
 	onClick: PropTypes.func,
+	useStreamAspectFit: PropTypes.bool,
 };
 
 const mapStateToProps = ( state, ownProps ) => {

--- a/client/blocks/reader-featured-image/style.scss
+++ b/client/blocks/reader-featured-image/style.scss
@@ -8,9 +8,28 @@
 	max-height: 300px;
 	overflow-y: hidden;
 	img {
-		/* stylelint-disable-next-line scales/radii */
-		border-radius: 6px;
 		object-fit: contain;
+	}
+}
+
+.reader-featured-image.reader-featured-image--stream-aspect-fit {
+	box-sizing: border-box;
+	height: auto;
+	max-height: 300px;
+	min-height: 0;
+	position: relative;
+	width: 100%;
+
+	&::after {
+		border-radius: 6px; /* stylelint-disable-line scales/radii */
+		bottom: 0;
+		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+		content: "";
+		left: 0;
+		pointer-events: none;
+		position: absolute;
+		right: 0;
+		top: 0;
 	}
 }
 

--- a/client/blocks/reader-featured-video/index.jsx
+++ b/client/blocks/reader-featured-video/index.jsx
@@ -34,6 +34,7 @@ class ReaderFeaturedVideo extends Component {
 		isCompactPost: PropTypes.bool,
 		expandCard: PropTypes.func,
 		hasExcerpt: PropTypes.bool,
+		useStreamAspectFit: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -111,6 +112,7 @@ class ReaderFeaturedVideo extends Component {
 			isExpanded,
 			isCompactPost,
 			hasExcerpt,
+			useStreamAspectFit,
 		} = this.props;
 
 		const classNames = clsx( className, 'reader-featured-video', {
@@ -130,6 +132,7 @@ class ReaderFeaturedVideo extends Component {
 					hasExcerpt={ hasExcerpt }
 					imageWidth={ imageWidth }
 					imageHeight={ imageHeight }
+					useStreamAspectFit={ useStreamAspectFit }
 				>
 					{ allowPlaying && (
 						<img

--- a/client/blocks/reader-post-card/featured-asset.jsx
+++ b/client/blocks/reader-post-card/featured-asset.jsx
@@ -16,6 +16,8 @@ const FeaturedAsset = ( {
 		return null;
 	}
 
+	const useStreamAspectFit = ! isCompactPost;
+
 	if ( canonicalMedia.mediaType === 'video' ) {
 		return (
 			<ReaderFeaturedVideo
@@ -26,6 +28,7 @@ const FeaturedAsset = ( {
 				isExpanded={ isVideoExpanded }
 				isCompactPost={ isCompactPost }
 				hasExcerpt={ hasExcerpt }
+				useStreamAspectFit={ useStreamAspectFit }
 			/>
 		);
 	}
@@ -37,6 +40,7 @@ const FeaturedAsset = ( {
 			canonicalMedia={ canonicalMedia }
 			isCompactPost={ isCompactPost }
 			hasExcerpt={ hasExcerpt }
+			useStreamAspectFit={ useStreamAspectFit }
 		/>
 	);
 };

--- a/client/blocks/reader-post-card/featured-images.jsx
+++ b/client/blocks/reader-post-card/featured-images.jsx
@@ -7,7 +7,14 @@ import {
 	READER_COMPACT_POST_FEATURED_MAX_IMAGE_HEIGHT,
 } from 'calypso/state/reader/posts/sizes';
 
-const ReaderFeaturedImages = ( { post, postUrl, canonicalMedia, isCompactPost, hasExcerpt } ) => {
+const ReaderFeaturedImages = ( {
+	post,
+	postUrl,
+	canonicalMedia,
+	isCompactPost,
+	hasExcerpt,
+	useStreamAspectFit = false,
+} ) => {
 	const numImages = isCompactPost ? 1 : 4;
 	const imagesToDisplay = post.featured_image ? [] : getImagesFromPostToDisplay( post, numImages );
 	if ( imagesToDisplay.length === 0 ) {
@@ -18,14 +25,15 @@ const ReaderFeaturedImages = ( { post, postUrl, canonicalMedia, isCompactPost, h
 				fetched={ canonicalMedia.fetched }
 				isCompactPost={ isCompactPost }
 				hasExcerpt={ hasExcerpt }
+				useStreamAspectFit={ useStreamAspectFit }
 			/>
 		);
 	}
 
 	let classNames = 'reader-post-card__featured-images';
-	const listItems = imagesToDisplay.map( ( image, index, [ imageWidth, imageHeight ] ) => {
-		imageWidth = null;
-		imageHeight =
+	const listItems = imagesToDisplay.map( ( image, index ) => {
+		const imageWidth = null;
+		let imageHeight =
 			isCompactPost && hasExcerpt
 				? READER_COMPACT_POST_FEATURED_MAX_IMAGE_HEIGHT
 				: READER_FEATURED_MAX_IMAGE_HEIGHT;
@@ -33,7 +41,6 @@ const ReaderFeaturedImages = ( { post, postUrl, canonicalMedia, isCompactPost, h
 		let width = '50%';
 
 		if ( imagesToDisplay.length === 4 ) {
-			imageWidth = imageWidth / 2;
 			imageHeight = imageHeight / 2;
 			classNames = clsx( 'reader-post-card__featured-images', 'four-images' );
 		} else if ( imagesToDisplay.length === 3 ) {
@@ -59,6 +66,7 @@ const ReaderFeaturedImages = ( { post, postUrl, canonicalMedia, isCompactPost, h
 				children={ <div style={ { width: width } } /> }
 				isCompactPost={ isCompactPost }
 				hasExcerpt={ hasExcerpt }
+				useStreamAspectFit={ useStreamAspectFit }
 			/>
 		);
 

--- a/client/blocks/reader-post-card/gallery.jsx
+++ b/client/blocks/reader-post-card/gallery.jsx
@@ -26,9 +26,9 @@ function PostGallery( { post, children } ) {
 		if ( safeCssUrl ) {
 			imageStyle = {
 				backgroundImage: 'url(' + safeCssUrl + ')',
-				backgroundSize: 'cover',
 				backgroundPosition: '50% 50%',
 				backgroundRepeat: 'no-repeat',
+				backgroundSize: 'contain',
 			};
 		}
 		return (

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -84,6 +84,23 @@
 			box-sizing: border-box;
 		}
 
+		// Inset frame when not using stream aspect-fit (stream: .reader-featured-image--stream-aspect-fit in reader-featured-image/style.scss).
+		.reader-featured-image:not(.reader-featured-image--stream-aspect-fit) {
+			position: relative;
+
+			&::after {
+				border-radius: 6px; /* stylelint-disable-line scales/radii */
+				bottom: 0;
+				box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+				content: "";
+				left: 0;
+				pointer-events: none;
+				position: absolute;
+				right: 0;
+				top: 0;
+			}
+		}
+
 		&.is-photo {
 			.reader-post-card__post {
 				flex-direction: column;
@@ -705,6 +722,7 @@
 }
 
 .reader-post-card__gallery-image {
+	background-color: var(--studio-gray-0);
 	border-radius: 4px;
 	box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
 	height: 300px;
@@ -757,36 +775,33 @@
 			max-height: 150px;
 			overflow: hidden;
 		}
-		.reader-featured-image img,
 		.reader-featured-image::after {
 			border-radius: 0;
+		}
+		.reader-featured-image img {
 			object-fit: cover;
 		}
 		.reader-post-card__featured-images-item:first-child {
 			.reader-featured-image,
-			.reader-featured-image::after,
-			img {
+			.reader-featured-image::after {
 				border-top-left-radius: 6px; /* stylelint-disable-line scales/radii */
 			}
 		}
 		.reader-post-card__featured-images-item:nth-child(2) {
 			.reader-featured-image,
-			.reader-featured-image::after,
-			img {
+			.reader-featured-image::after {
 				border-top-right-radius: 6px; /* stylelint-disable-line scales/radii */
 			}
 		}
 		.reader-post-card__featured-images-item:nth-child(3) {
 			.reader-featured-image,
-			.reader-featured-image::after,
-			img {
+			.reader-featured-image::after {
 				border-bottom-left-radius: 6px; /* stylelint-disable-line scales/radii */
 			}
 		}
 		.reader-post-card__featured-images-item:last-child {
 			.reader-featured-image,
-			.reader-featured-image::after,
-			img {
+			.reader-featured-image::after {
 				border-bottom-right-radius: 6px; /* stylelint-disable-line scales/radii */
 			}
 		}
@@ -800,9 +815,10 @@
 			height: 302px;
 			max-height: 302px;
 		}
-		.reader-featured-image img,
 		.reader-featured-image::after {
 			border-radius: 0;
+		}
+		.reader-featured-image img {
 			object-fit: cover;
 		}
 		/* First image */
@@ -818,8 +834,6 @@
 			}
 		}
 		.reader-post-card__featured-images-item:first-child img {
-			border-bottom-left-radius: 6px; /* stylelint-disable-line scales/radii */
-			border-top-left-radius: 6px; /* stylelint-disable-line scales/radii */
 			height: 100%;
 			max-width: none;
 			object-fit: cover;
@@ -842,8 +856,6 @@
 				border-radius: 0;
 
 				img {
-					border-radius: 0;
-					border-top-right-radius: 6px; /* stylelint-disable-line scales/radii */
 					object-fit: cover;
 				}
 				.reader-featured-image {
@@ -861,8 +873,6 @@
 				border-radius: 0;
 
 				img {
-					border-radius: 0;
-					border-bottom-right-radius: 6px; /* stylelint-disable-line scales/radii */
 					object-fit: cover;
 				}
 				.reader-featured-image {
@@ -890,9 +900,10 @@
 			height: 300px;
 			max-height: 300px;
 		}
-		.reader-featured-image img,
 		.reader-featured-image::after {
 			border-radius: 0;
+		}
+		.reader-featured-image img {
 			height: 100%;
 			max-width: none;
 			object-fit: cover;
@@ -901,16 +912,14 @@
 		}
 		.reader-post-card__featured-images-item:first-child {
 			.reader-featured-image,
-			.reader-featured-image::after,
-			img {
+			.reader-featured-image::after {
 				border-bottom-left-radius: 6px; /* stylelint-disable-line scales/radii */
 				border-top-left-radius: 6px; /* stylelint-disable-line scales/radii */
 			}
 		}
 		.reader-post-card__featured-images-item:last-child {
 			.reader-featured-image,
-			.reader-featured-image::after,
-			img {
+			.reader-featured-image::after {
 				border-bottom-right-radius: 6px; /* stylelint-disable-line scales/radii */
 				border-top-right-radius: 6px; /* stylelint-disable-line scales/radii */
 			}
@@ -924,18 +933,75 @@
 			object-fit: contain;
 		}
 	}
-	.reader-featured-image {
-		position: relative;
-		&::after {
-			content: "";
-			position: absolute;
-			pointer-events: none;
-			top: 0;
-			left: 0;
-			bottom: 0;
-			right: 0;
-			box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
-			border-radius: 6px; /* stylelint-disable-line scales/radii */
+}
+
+.reader-post-card.card:not(.is-compact) .reader-post-card__featured-images {
+	&.four-images {
+		.reader-post-card__featured-images-item {
+			align-items: center;
+			display: flex;
+			justify-content: center;
+		}
+
+		.reader-featured-image img {
+			height: auto;
+			max-height: 100%;
+			max-width: 100%;
+			object-fit: contain;
+			object-position: center;
+			width: auto;
+		}
+	}
+
+	&.three-images {
+		.reader-post-card__featured-images-item:first-child {
+			align-items: center;
+			display: flex;
+			justify-content: center;
+		}
+
+		.reader-post-card__featured-images-item:first-child img {
+			height: auto;
+			max-height: 100%;
+			max-width: 100%;
+			object-fit: contain;
+			object-position: center;
+			width: auto;
+		}
+
+		.reader-post-card__featured-images-item.column-two .reader-post-card__featured-images.column {
+			.reader-post-card__featured-images-item {
+				align-items: center;
+				display: flex;
+				justify-content: center;
+			}
+
+			.reader-post-card__featured-images-item:first-child img,
+			.reader-post-card__featured-images-item:last-child img {
+				height: auto;
+				max-height: 100%;
+				max-width: 100%;
+				object-fit: contain;
+				object-position: center;
+				width: auto;
+			}
+		}
+	}
+
+	&.two-images {
+		.reader-post-card__featured-images-item {
+			align-items: center;
+			display: flex;
+			justify-content: center;
+		}
+
+		.reader-featured-image img {
+			height: auto;
+			max-height: 100%;
+			max-width: 100%;
+			object-fit: contain;
+			object-position: center;
+			width: auto;
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

noting some of the examples on the p2 discussion about this - pg9MHR-1go-p2#comment-2380, to see how much we may want to go forward here or not.
*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?