### PR TITLE
MSD: Refactor Switcher to use renderItem and add Switcher.Item

### DIFF
--- a/client/dashboard/components/switcher/index.tsx
+++ b/client/dashboard/components/switcher/index.tsx
@@ -1,14 +1,10 @@
-import {
-	__experimentalHStack as HStack,
-	Dropdown,
-	Button,
-	ScrollLock,
-} from '@wordpress/components';
+import { Dropdown, Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { chevronDownSmall } from '@wordpress/icons';
 import { useState, type ComponentProps } from 'react';
 import SwitcherContent from './switcher-content';
-import { RenderItemTitle, RenderItemMedia, RenderItemDescription } from './types';
+import SwitcherItem from './switcher-item';
+import { RenderItem } from './types';
 import type { Field, View } from '@wordpress/dataviews';
 
 interface RenderCallbackProps {
@@ -23,12 +19,11 @@ export type SwitcherProps< T > = {
 	searchableFields: Field< T >[];
 	children?: ( props: RenderCallbackProps ) => React.ReactNode;
 	getItemUrl: ( item: T ) => string;
-	renderItemMedia: RenderItemMedia< T >;
-	renderItemTitle: RenderItemTitle< T >;
-	renderItemDescription?: RenderItemDescription< T >;
+	renderItem: RenderItem< T >;
+	icon?: React.JSX.Element;
 	onItemClick?: () => void;
 	renderToggle?: RenderToggle;
-} & Pick< ComponentProps< typeof Dropdown >, 'open' | 'onToggle' | 'defaultOpen' >; // For controlled usage of the switcher
+} & Pick< ComponentProps< typeof Dropdown >, 'open' | 'onToggle' | 'defaultOpen' >;
 
 const DEFAULT_VIEW: View = {
 	type: 'list',
@@ -37,15 +32,14 @@ const DEFAULT_VIEW: View = {
 	sort: { field: 'name', direction: 'asc' },
 };
 
-export default function Switcher< T >( {
+function Switcher< T >( {
 	items,
 	value,
 	searchableFields,
 	children,
 	getItemUrl,
-	renderItemMedia,
-	renderItemTitle,
-	renderItemDescription,
+	renderItem,
+	icon = chevronDownSmall,
 	onItemClick,
 	open,
 	onToggle,
@@ -62,7 +56,7 @@ export default function Switcher< T >( {
 		return (
 			<Button
 				className="dashboard-menu__item active"
-				icon={ chevronDownSmall }
+				icon={ icon }
 				iconPosition="right"
 				onClick={ () => onToggle() }
 				onKeyDown={ ( event: React.KeyboardEvent ) => {
@@ -73,15 +67,14 @@ export default function Switcher< T >( {
 				} }
 				aria-haspopup="true"
 				aria-expanded={ isOpen }
-				style={ { width: '100%', justifyContent: 'flex-start' } }
+				style={ {
+					width: '100%',
+					justifyContent: 'flex-start',
+					overflow: 'hidden',
+					maxWidth: isDesktop ? 'calc(30vw)' : '100%',
+				} }
 			>
-				<HStack
-					alignment="center"
-					style={ { overflow: 'hidden', maxWidth: isDesktop ? 'calc(30vw)' : '100%' } }
-				>
-					{ renderItemMedia( { item: value, context: 'dropdown', size: 16 } ) }
-					{ renderItemTitle( { item: value, context: 'dropdown' } ) }
-				</HStack>
+				{ renderItem( { item: value, context: 'dropdown' } ) }
 			</Button>
 		);
 	};
@@ -93,24 +86,23 @@ export default function Switcher< T >( {
 			defaultOpen={ defaultOpen }
 			renderToggle={ renderDropdownToggle }
 			renderContent={ ( { onClose } ) => (
-				<>
-					<ScrollLock />
-					<SwitcherContent
-						items={ items }
-						searchableFields={ searchableFields }
-						getItemUrl={ getItemUrl }
-						renderItemMedia={ renderItemMedia }
-						renderItemTitle={ renderItemTitle }
-						renderItemDescription={ renderItemDescription }
-						view={ view }
-						onChangeView={ setView }
-						onClose={ onClose }
-						onItemClick={ onItemClick }
-					>
-						{ children?.( { onClose } ) }
-					</SwitcherContent>
-				</>
+				<SwitcherContent
+					items={ items }
+					searchableFields={ searchableFields }
+					getItemUrl={ getItemUrl }
+					renderItem={ renderItem }
+					view={ view }
+					onChangeView={ setView }
+					onClose={ onClose }
+					onItemClick={ onItemClick }
+				>
+					{ children?.( { onClose } ) }
+				</SwitcherContent>
 			) }
 		/>
 	);
 }
+
+Switcher.Item = SwitcherItem;
+
+export default Switcher;

--- a/client/dashboard/components/switcher/switcher-content.tsx
+++ b/client/dashboard/components/switcher/switcher-content.tsx
@@ -1,6 +1,5 @@
 import {
 	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
 	MenuGroup,
 	NavigableMenu,
 	SearchControl,
@@ -9,14 +8,12 @@ import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import RouterLinkMenuItem from '../router-link-menu-item';
-import { RenderItemTitle, RenderItemMedia, RenderItemDescription } from './types';
+import { RenderItem } from './types';
 import type { View, Field } from '@wordpress/dataviews';
 import type { PropsWithChildren } from 'react';
 
 export default function SwitcherContent< T >( {
-	itemAlignment,
 	itemClassName,
-	itemSpacing,
 	items,
 	searchableFields,
 	searchClassName,
@@ -24,9 +21,7 @@ export default function SwitcherContent< T >( {
 	onChangeView,
 	width = '280px',
 	getItemUrl,
-	renderItemMedia,
-	renderItemTitle,
-	renderItemDescription,
+	renderItem,
 	resetScroll = true,
 	children,
 	onClose,
@@ -34,9 +29,7 @@ export default function SwitcherContent< T >( {
 	filter,
 	filterField,
 }: PropsWithChildren< {
-	itemAlignment?: string;
 	itemClassName?: string | ( ( item: T ) => string );
-	itemSpacing?: number;
 	items?: T[];
 	searchClassName?: string;
 	searchableFields: Field< T >[];
@@ -44,9 +37,7 @@ export default function SwitcherContent< T >( {
 	onChangeView: ( newView: View ) => void;
 	width?: string;
 	getItemUrl: ( item: T ) => string;
-	renderItemMedia: RenderItemMedia< T >;
-	renderItemTitle: RenderItemTitle< T >;
-	renderItemDescription?: RenderItemDescription< T >;
+	renderItem: RenderItem< T >;
 	resetScroll?: boolean;
 	onClose: () => void;
 	onItemClick?: () => void;
@@ -115,18 +106,7 @@ export default function SwitcherContent< T >( {
 							} }
 							resetScroll={ resetScroll }
 						>
-							<HStack
-								justify="flex-start"
-								alignment={ itemAlignment || 'center' }
-								expanded
-								{ ...( itemSpacing ? { spacing: itemSpacing } : {} ) }
-							>
-								{ renderItemMedia( { item, context: 'list', size: 32 } ) }
-								<VStack spacing={ 0 }>
-									{ renderItemTitle( { item, context: 'list' } ) }
-									{ renderItemDescription?.( { item, context: 'list' } ) }
-								</VStack>
-							</HStack>
+							{ renderItem( { item, context: 'list' } ) }
 						</RouterLinkMenuItem>
 					);
 				} ) }

--- a/client/dashboard/components/switcher/switcher-item.tsx
+++ b/client/dashboard/components/switcher/switcher-item.tsx
@@ -1,0 +1,30 @@
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+
+interface SwitcherItemProps {
+	media?: React.ReactNode;
+	title: React.ReactNode;
+	description?: React.ReactNode;
+	spacing?: number;
+	alignment?: string;
+}
+
+export default function SwitcherItem( {
+	media,
+	title,
+	description,
+	spacing,
+	alignment = 'center',
+}: SwitcherItemProps ) {
+	return (
+		<HStack justify="flex-start" alignment={ alignment } expanded spacing={ spacing }>
+			{ media }
+			<VStack spacing={ 0 }>
+				{ title }
+				{ description }
+			</VStack>
+		</HStack>
+	);
+}

--- a/client/dashboard/components/switcher/switcher-item.tsx
+++ b/client/dashboard/components/switcher/switcher-item.tsx
@@ -18,6 +18,10 @@ export default function SwitcherItem( {
 	spacing,
 	alignment = 'center',
 }: SwitcherItemProps ) {
+	if ( ! media && ! description ) {
+		return <>{ title }</>;
+	}
+
 	return (
 		<HStack justify="flex-start" alignment={ alignment } expanded spacing={ spacing }>
 			{ media }

--- a/client/dashboard/components/switcher/types.ts
+++ b/client/dashboard/components/switcher/types.ts
@@ -1,12 +1,8 @@
 import type { ReactNode } from 'react';
 
-type RenderItemProps< T > = {
+export type RenderItemProps< T > = {
 	item: T;
 	context: 'dropdown' | 'list';
 };
 
-export type RenderItemMedia< T > = ( props: RenderItemProps< T > & { size?: number } ) => ReactNode;
-
-export type RenderItemTitle< T > = ( props: RenderItemProps< T > ) => ReactNode;
-
-export type RenderItemDescription< T > = ( props: RenderItemProps< T > ) => ReactNode;
+export type RenderItem< T > = ( props: RenderItemProps< T > ) => ReactNode;

--- a/client/dashboard/domains/domain-switcher/index.tsx
+++ b/client/dashboard/domains/domain-switcher/index.tsx
@@ -5,6 +5,7 @@ import { globe } from '@wordpress/icons';
 import { useAppContext } from '../../app/context';
 import useBuildCurrentRouteLink from '../../app/hooks/use-build-current-route-link';
 import Switcher from '../../components/switcher';
+import { Text } from '../../components/text';
 import type { Domain, DomainSummary } from '@automattic/api-core';
 
 import './style.scss';
@@ -34,19 +35,19 @@ export default function DomainSwitcher( { domain }: { domain: Domain } ) {
 			value={ domain }
 			searchableFields={ searchableFields }
 			getItemUrl={ ( d ) => buildCurrentRouteLink( { params: { domainName: d.domain } } ) }
-			renderItemMedia={ ( { context } ) =>
-				context === 'list' ? null : <Icon className="domain-icon" icon={ globe } size={ 24 } />
-			}
-			renderItemTitle={ ( { item } ) => (
-				<span
-					style={ {
-						overflow: 'hidden',
-						textOverflow: 'ellipsis',
-						whiteSpace: 'nowrap',
-					} }
-				>
-					{ item.domain }
-				</span>
+			renderItem={ ( { item, context } ) => (
+				<Switcher.Item
+					media={
+						context !== 'list' ? (
+							<Icon className="domain-icon" icon={ globe } size={ 24 } />
+						) : undefined
+					}
+					title={
+						<Text truncate numberOfLines={ 1 }>
+							{ item.domain }
+						</Text>
+					}
+				/>
 			) }
 		/>
 	);

--- a/client/dashboard/domains/domain-switcher/index.tsx
+++ b/client/dashboard/domains/domain-switcher/index.tsx
@@ -43,7 +43,7 @@ export default function DomainSwitcher( { domain }: { domain: Domain } ) {
 						) : undefined
 					}
 					title={
-						<Text truncate numberOfLines={ 1 }>
+						<Text truncate numberOfLines={ 1 } style={ { color: 'inherit' } }>
 							{ item.domain }
 						</Text>
 					}

--- a/client/dashboard/domains/domain/index.tsx
+++ b/client/dashboard/domains/domain/index.tsx
@@ -10,6 +10,7 @@ import useBuildCurrentRouteLink from '../../app/hooks/use-build-current-route-li
 import { domainRoute } from '../../app/router/domains';
 import HeaderBar from '../../components/header-bar';
 import Switcher from '../../components/switcher';
+import { Text } from '../../components/text';
 import DomainMenu from '../domain-menu';
 import type { DomainSummary } from '@automattic/api-core';
 import './style.scss';
@@ -48,21 +49,19 @@ function Domain() {
 								getItemUrl={ ( domain ) =>
 									buildCurrentRouteLink( { params: { domainName: domain.domain } } )
 								}
-								renderItemMedia={ ( { context } ) =>
-									context === 'list' ? null : (
-										<Icon className="domain-icon" icon={ globe } size={ 24 } />
-									)
-								}
-								renderItemTitle={ ( { item } ) => (
-									<span
-										style={ {
-											overflow: 'hidden',
-											textOverflow: 'ellipsis',
-											whiteSpace: 'nowrap',
-										} }
-									>
-										{ item.domain }
-									</span>
+								renderItem={ ( { item, context } ) => (
+									<Switcher.Item
+										media={
+											context !== 'list' ? (
+												<Icon className="domain-icon" icon={ globe } size={ 24 } />
+											) : undefined
+										}
+										title={
+											<Text truncate numberOfLines={ 1 }>
+												{ item.domain }
+											</Text>
+										}
+									/>
 								) }
 							/>
 						</HeaderBar.Title>

--- a/client/dashboard/plugins/manage/components/plugin-switcher.tsx
+++ b/client/dashboard/plugins/manage/components/plugin-switcher.tsx
@@ -1,4 +1,3 @@
-import { __experimentalVStack as VStack } from '@wordpress/components';
 import { throttle } from '@wordpress/compose';
 import { Field, View } from '@wordpress/dataviews';
 import { __, _n, sprintf } from '@wordpress/i18n';
@@ -7,6 +6,7 @@ import { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useRef, useS
 import { pluginRoute } from '../../../app/router/plugins';
 import { Card, CardBody } from '../../../components/card';
 import SwitcherContent from '../../../components/switcher/switcher-content';
+import SwitcherItem from '../../../components/switcher/switcher-item';
 import { Text } from '../../../components/text';
 import { PluginListRow } from '../types';
 import { PluginIcon } from './plugin-icon';
@@ -80,11 +80,7 @@ export const PluginSwitcher = ( {
 		[ selectedPluginSlug ]
 	);
 
-	const renderItemMedia = useCallback( ( { item }: { item: PluginListRow } ) => {
-		return <PluginIcon item={ item } />;
-	}, [] );
-
-	const renderItemTitle = useCallback( ( { item }: { item: PluginListRow } ) => {
+	const renderItem = useCallback( ( { item }: { item: PluginListRow } ) => {
 		const sitesText = sprintf(
 			// translators: %(siteCount)d is the number of sites the plugin is installed on.
 			_n( '%(siteCount)d site', '%(siteCount)d sites', item.sitesCount ),
@@ -104,17 +100,24 @@ export const PluginSwitcher = ( {
 			: '';
 
 		return (
-			<VStack spacing={ 1 }>
-				{ /* @ts-expect-error: Can only set one of `children` or `props.dangerouslySetInnerHTML`. */ }
-				<Text
-					className="plugin-switcher-item-name"
-					dangerouslySetInnerHTML={ { __html: item.name } }
-					title={ item.name }
-				/>
-				<Text className="plugin-switcher-item-site-count" variant="muted">
-					{ updatesText ? `${ sitesText }, ${ updatesText }` : sitesText }
-				</Text>
-			</VStack>
+			<SwitcherItem
+				alignment="start"
+				spacing={ 3 }
+				media={ <PluginIcon item={ item } /> }
+				title={
+					// @ts-expect-error: Can only set one of `children` or `props.dangerouslySetInnerHTML`.
+					<Text
+						className="plugin-switcher-item-name"
+						dangerouslySetInnerHTML={ { __html: item.name } }
+						title={ item.name }
+					/>
+				}
+				description={
+					<Text className="plugin-switcher-item-site-count" variant="muted">
+						{ updatesText ? `${ sitesText }, ${ updatesText }` : sitesText }
+					</Text>
+				}
+			/>
 		);
 	}, [] );
 
@@ -135,17 +138,14 @@ export const PluginSwitcher = ( {
 		<Card>
 			<CardBody className="plugin-switcher-card-body" ref={ scrollRef }>
 				<SwitcherContent
-					itemAlignment="start"
 					itemClassName={ itemClassName }
-					itemSpacing={ 3 }
 					searchClassName="plugin-switcher-search"
 					view={ view }
 					onChangeView={ onChangeView }
 					items={ pluginsWithIcon }
 					resetScroll={ false }
 					getItemUrl={ ( item ) => pluginRoute.to.replace( '$pluginId', item.slug ) }
-					renderItemMedia={ renderItemMedia }
-					renderItemTitle={ renderItemTitle }
+					renderItem={ renderItem }
 					searchableFields={ searchableFields }
 					onClose={ () => {} }
 					width="auto"

--- a/client/dashboard/sites/site-switcher-v2/base.tsx
+++ b/client/dashboard/sites/site-switcher-v2/base.tsx
@@ -46,30 +46,14 @@ export const SiteSwitcherBase = (
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const buildCurrentRouteLink = useBuildCurrentRouteLink();
 
-	const renderItemMedia: SwitcherProps< Site >[ 'renderItemMedia' ] = ( { item, size } ) => (
-		<SiteIcon site={ item } size={ size } />
-	);
-
-	const renderItemTitle: SwitcherProps< Site >[ 'renderItemTitle' ] = ( { item } ) => (
-		<span
-			style={ {
-				color: 'var(--dashboard__text-color)',
-				fontWeight: 500,
-				overflow: 'hidden',
-				textOverflow: 'ellipsis',
-				whiteSpace: 'nowrap',
-			} }
-		>
-			{ getSiteDisplayName( item ) }
-		</span>
-	);
-
 	return (
 		<HStack className="site-switcher" spacing={ 0 } expanded={ false } style={ { flexShrink: 0 } }>
 			<HStack justify="flex-start" alignment="center" style={ { maxWidth: '85%' } }>
-				{ renderItemMedia( { item: site, context: 'dropdown', size: 32 } ) }
+				<SiteIcon site={ site } size={ 32 } />
 				<VStack spacing={ 0 }>
-					{ renderItemTitle( { item: site, context: 'dropdown' } ) }
+					<Text weight={ 500 } truncate numberOfLines={ 1 }>
+						{ getSiteDisplayName( site ) }
+					</Text>
 					<ExternalLink
 						href={ site.URL }
 						style={ { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }
@@ -89,12 +73,22 @@ export const SiteSwitcherBase = (
 					}
 					return site.options?.admin_url ?? '';
 				} }
-				renderItemMedia={ renderItemMedia }
-				renderItemTitle={ renderItemTitle }
-				renderItemDescription={ ( { item } ) => (
-					<Text variant="muted" truncate numberOfLines={ 1 }>
-						{ getSiteDisplayUrl( item ) }
-					</Text>
+				renderItem={ ( { item, context } ) => (
+					<Switcher.Item
+						media={ <SiteIcon site={ item } size={ context === 'list' ? 32 : 16 } /> }
+						title={
+							<Text weight={ 500 } truncate numberOfLines={ 1 }>
+								{ getSiteDisplayName( item ) }
+							</Text>
+						}
+						description={
+							context === 'list' ? (
+								<Text variant="muted" truncate numberOfLines={ 1 }>
+									{ getSiteDisplayUrl( item ) }
+								</Text>
+							) : undefined
+						}
+					/>
 				) }
 				open={ isSwitcherOpen }
 				onToggle={ ( willOpen: boolean ) => {

--- a/client/dashboard/sites/site-switcher-v2/base.tsx
+++ b/client/dashboard/sites/site-switcher-v2/base.tsx
@@ -77,7 +77,7 @@ export const SiteSwitcherBase = (
 					<Switcher.Item
 						media={ <SiteIcon site={ item } size={ context === 'list' ? 32 : 16 } /> }
 						title={
-							<Text weight={ 500 } truncate numberOfLines={ 1 }>
+							<Text weight={ 500 } truncate numberOfLines={ 1 } style={ { color: 'inherit' } }>
 								{ getSiteDisplayName( item ) }
 							</Text>
 						}

--- a/client/dashboard/sites/site-switcher/base.tsx
+++ b/client/dashboard/sites/site-switcher/base.tsx
@@ -50,7 +50,7 @@ export const SiteSwitcherBase = ( props: Pick< SwitcherProps< Site >, 'children'
 				<Switcher.Item
 					media={ <SiteIcon site={ item } size={ context === 'list' ? 32 : 16 } /> }
 					title={
-						<Text weight={ 500 } truncate numberOfLines={ 1 }>
+						<Text weight={ 500 } truncate numberOfLines={ 1 } style={ { color: 'inherit' } }>
 							{ getSiteDisplayName( item ) }
 						</Text>
 					}

--- a/client/dashboard/sites/site-switcher/base.tsx
+++ b/client/dashboard/sites/site-switcher/base.tsx
@@ -46,23 +46,22 @@ export const SiteSwitcherBase = ( props: Pick< SwitcherProps< Site >, 'children'
 				}
 				return site.options?.admin_url ?? '';
 			} }
-			renderItemMedia={ ( { item, size } ) => <SiteIcon site={ item } size={ size } /> }
-			renderItemTitle={ ( { item } ) => (
-				<span
-					style={ {
-						fontWeight: 500,
-						overflow: 'hidden',
-						textOverflow: 'ellipsis',
-						whiteSpace: 'nowrap',
-					} }
-				>
-					{ getSiteDisplayName( item ) }
-				</span>
-			) }
-			renderItemDescription={ ( { item } ) => (
-				<Text variant="muted" truncate numberOfLines={ 1 }>
-					{ getSiteDisplayUrl( item ) }
-				</Text>
+			renderItem={ ( { item, context } ) => (
+				<Switcher.Item
+					media={ <SiteIcon site={ item } size={ context === 'list' ? 32 : 16 } /> }
+					title={
+						<Text weight={ 500 } truncate numberOfLines={ 1 }>
+							{ getSiteDisplayName( item ) }
+						</Text>
+					}
+					description={
+						context === 'list' ? (
+							<Text variant="muted" truncate numberOfLines={ 1 }>
+								{ getSiteDisplayUrl( item ) }
+							</Text>
+						) : undefined
+					}
+				/>
 			) }
 			open={ isSwitcherOpen }
 			onToggle={ ( willOpen: boolean ) => {


### PR DESCRIPTION
## Proposed Changes

- Replace `renderItemMedia`/`renderItemTitle`/`renderItemDescription` with a single `renderItem` prop that receives `{ item, context }`
- Add `Switcher.Item` layout component (`media` + `title` + `description` + `spacing` + `alignment`) for the default item layout
- Add `icon` prop to `Switcher` (defaults to `chevronDownSmall`)
- Replace inline `<span style={...}>` with `<Text>` component for truncation
- Remove `ScrollLock` from Switcher
- Update all consumers (`site-switcher`, `site-switcher-v2`, `domain-switcher`, `domain/index`, `plugin-switcher`) to use `renderItem` + `Switcher.Item`

## Why are these changes being made?

The Switcher had three separate render props (`renderItemMedia`, `renderItemTitle`, `renderItemDescription`) plus `itemAlignment`/`itemSpacing` that forced a rigid HStack+VStack layout. A single `renderItem` gives consumers full control over item rendering, while `Switcher.Item` provides the default layout as an opt-in convenience.

## Testing Instructions

1. Verify site switcher works in the header (dropdown toggle + list items render correctly)
2. Verify site switcher v2 works in the sidebar (current item + toggle + dropdown)
3. Verify domain switcher renders correctly
4. Verify plugin switcher on the plugins manage page renders correctly with aligned items
5. Check text truncation works on long site/domain names

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)