### PR TITLE
Stripe UPI: enable in production

### DIFF
--- a/client/dashboard/me/billing-purchases/payment-methods/translate-payment-method-names.ts
+++ b/client/dashboard/me/billing-purchases/payment-methods/translate-payment-method-names.ts
@@ -44,6 +44,8 @@ export function translateWpcomPaymentMethodToCheckoutPaymentMethod(
 			return 'existingCard';
 		case 'WPCOM_Billing_Razorpay':
 			return 'razorpay';
+		case 'WPCOM_Billing_Stripe_Upi':
+			return 'stripe-upi';
 		default:
 			throw new Error( `Unknown payment method '${ paymentMethod }'` );
 	}
@@ -96,6 +98,8 @@ export function translateCheckoutPaymentMethodToWpcomPaymentMethod(
 			return 'WPCOM_Billing_WPCOM';
 		case 'razorpay':
 			return 'WPCOM_Billing_Razorpay';
+		case 'stripe-upi':
+			return 'WPCOM_Billing_Stripe_Upi';
 	}
 	return null;
 }
@@ -118,6 +122,7 @@ export function readWPCOMPaymentMethodClass( slug: string ): WPCOMPaymentMethod 
 		case 'WPCOM_Billing_Stripe_Wechat_Pay':
 		case 'WPCOM_Billing_Web_Payment':
 		case 'WPCOM_Billing_Razorpay':
+		case 'WPCOM_Billing_Stripe_Upi':
 			return slug;
 	}
 	return null;
@@ -152,6 +157,7 @@ export function readCheckoutPaymentMethodSlug( slug: string ): CheckoutPaymentMe
 		case 'web-pay':
 		case 'free-purchase':
 		case 'razorpay':
+		case 'stripe-upi':
 			return slug;
 		case 'apple-pay':
 		case 'google-pay':
@@ -169,6 +175,7 @@ export function isRedirectPaymentMethod( slug: CheckoutPaymentMethodSlug ): bool
 		'paypal-express',
 		'paypal-js',
 		'p24',
+		'stripe-upi',
 		'wechat',
 	];
 	return redirectPaymentMethods.includes( slug );

--- a/config/production.json
+++ b/config/production.json
@@ -38,7 +38,7 @@
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/razorpay": false,
-		"checkout/stripe-upi": false,
+		"checkout/stripe-upi": true,
 		"cookie-banner": true,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of SHILL-1688

## Proposed Changes

* Update the translations used for the Stripe UPI payment method in places outside of checkout
* Allow UPI in production (still being gated by the backend code!)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is part of go-live. The other pages haven't been an issue so far, but probably will be once this is in production.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
--> 

* I think visual inspection should be fine.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
