### PR TITLE
Checkout: Filter malformed subscription renewal IDs

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
@@ -485,7 +485,21 @@ function useAddRenewalBySubscriptionId( {
 			} );
 			return;
 		}
-		const subscriptionIds = String( originalPurchaseId ).split( ',' );
+		const subscriptionIds = String( originalPurchaseId )
+			.split( ',' )
+			.map( ( id ) => id.trim() )
+			.filter( Boolean );
+		if ( subscriptionIds.length === 0 ) {
+			dispatch( {
+				type: 'RENEWALS_ADD_ERROR',
+				message: String(
+					translate( 'A valid subscription ID is required to add a renewal to the cart.', {
+						textOnly: true,
+					} )
+				),
+			} );
+			return;
+		}
 		const cartItems = subscriptionIds.map( ( subscriptionId ) =>
 			createRequestCartProduct( {
 				product_slug: '',


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHE-459/

## Proposed changes

This fixes a crash in `useAddRenewalBySubscriptionId` when the checkout renewal URL contains a trailing comma or consecutive commas (e.g. `/checkout/renew/123456,` or `/checkout/renew/123,,456`).

* Filter empty strings from the comma-split subscription ID list by trimming whitespace and removing blank entries
* Dispatch a `RENEWALS_ADD_ERROR` with a user-facing message if no valid IDs remain after filtering

## Why are these changes being made?

`useAddRenewalBySubscriptionId` splits the `originalPurchaseId` URL parameter on commas to support multi-renewal URLs. Previously it passed all resulting tokens — including empty strings from trailing or consecutive commas — directly into `createRequestCartProduct`. An empty `purchaseId` cannot produce a valid `product_slug`, so `createRequestCartProduct` throws, crashing the checkout effect and leaving the route unusable with no error shown to the user.

The fix mirrors how `useAddRenewalItems` already handles the same input: filter out empty entries before mapping, and redirect to an error state if nothing valid remains.

## Testing instructions

* Navigate to `/checkout/renew/123456,` (trailing comma) on a logged-in WordPress.com account
* Confirm checkout does not crash — it should display an error message rather than an unhandled exception
* Repeat with `/checkout/renew/123,,456` (consecutive commas) — only the valid ID `123` and `456` should be added to the cart
* Confirm a well-formed URL like `/checkout/renew/123456` still works as expected
