### PR TITLE
MSD: Hide duplicate site URL in overview when omnibar is enabled

### DIFF
--- a/client/dashboard/sites/overview-site-fields/index.tsx
+++ b/client/dashboard/sites/overview-site-fields/index.tsx
@@ -1,5 +1,6 @@
 import { HostingFeatures } from '@automattic/api-core';
 import { siteAgencyBlogQuery } from '@automattic/api-queries';
+import { isEnabled } from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { __experimentalText as Text, ExternalLink } from '@wordpress/components';
@@ -70,7 +71,7 @@ const SiteOverviewFields = ( { site }: { site: Site } ) => {
 				</Text>
 			</MetadataItem>
 		);
-	} else {
+	} else if ( ! isEnabled( 'dashboard/omnibar' ) ) {
 		fields.push(
 			<MetadataItem key="url">
 				<ExternalLink href={ url } style={ { overflowWrap: 'anywhere' } }>


### PR DESCRIPTION
## Proposed Changes

- Conditionally hide the site URL field in the overview when `dashboard/omnibar` is enabled

## Why are these changes being made?

When the sidebar is active, the site URL is already displayed in the `SiteSwitcherItem` in the sidebar. Showing it again in the overview fields is redundant.

## Testing Instructions

1. With `dashboard/omnibar` disabled: verify site URL still appears in overview fields
2. With `dashboard/omnibar` enabled: verify site URL is hidden from overview (shown in sidebar instead)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)