### PR TITLE
Subscribers: simplify subscription type display for comps

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -46,7 +46,26 @@ type SubscriberDataViewsProps = {
 
 const SubscriptionTypeCell = ( { subscriber }: { subscriber: Subscriber } ) => {
 	const plans = useSubscriptionPlans( subscriber );
-	return plans.map( ( plan, index ) => <div key={ index }>{ plan.plan }</div> );
+
+	const freePlan = translate( 'Free' );
+	const compLabel = translate( 'Comp', {
+		comment: 'Short for "complimentary" — a free subscription granted by the site creator',
+	} );
+
+	// If there's a paid (non-gift, non-free) plan, show only that.
+	const paidPlans = plans.filter( ( p ) => ! p.is_gift && p.plan !== freePlan );
+	if ( paidPlans.length > 0 ) {
+		return paidPlans.map( ( plan, index ) => <div key={ index }>{ plan.plan }</div> );
+	}
+
+	// If there are any comps, show just "Comp" (no title details).
+	const hasComp = plans.some( ( p ) => p.is_gift );
+	if ( hasComp ) {
+		return <div>{ compLabel }</div>;
+	}
+
+	// Otherwise show "Free".
+	return <div>{ freePlan }</div>;
 };
 
 const SubscriberName = ( { displayName, email }: { displayName: string; email: string } ) => (

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -47,13 +47,8 @@ type SubscriberDataViewsProps = {
 const SubscriptionTypeCell = ( { subscriber }: { subscriber: Subscriber } ) => {
 	const plans = useSubscriptionPlans( subscriber );
 
-	const freePlan = translate( 'Free' );
-	const compLabel = translate( 'Comp', {
-		comment: 'Short for "complimentary" — a free subscription granted by the site creator',
-	} );
-
 	// If there's a paid (non-gift, non-free) plan, show only that.
-	const paidPlans = plans.filter( ( p ) => ! p.is_gift && p.plan !== freePlan );
+	const paidPlans = plans.filter( ( p ) => ! p.is_gift && ! p.is_free );
 	if ( paidPlans.length > 0 ) {
 		return paidPlans.map( ( plan, index ) => <div key={ index }>{ plan.plan }</div> );
 	}
@@ -61,11 +56,17 @@ const SubscriptionTypeCell = ( { subscriber }: { subscriber: Subscriber } ) => {
 	// If there are any comps, show just "Comp" (no title details).
 	const hasComp = plans.some( ( p ) => p.is_gift );
 	if ( hasComp ) {
-		return <div>{ compLabel }</div>;
+		return (
+			<div>
+				{ translate( 'Comp', {
+					comment: 'Short for "complimentary" — a free subscription granted by the site creator',
+				} ) }
+			</div>
+		);
 	}
 
 	// Otherwise show "Free".
-	return <div>{ freePlan }</div>;
+	return <div>{ translate( 'Free' ) }</div>;
 };
 
 const SubscriberName = ( { displayName, email }: { displayName: string; email: string } ) => (

--- a/client/my-sites/subscribers/hooks/use-subscription-plans.ts
+++ b/client/my-sites/subscribers/hooks/use-subscription-plans.ts
@@ -17,6 +17,7 @@ export type SubscriptionPlanData = {
 
 type PlanData = {
 	is_gift: boolean;
+	renewal_price: number;
 	renewalPrice: string;
 	when: string;
 	start_date: string;
@@ -57,6 +58,7 @@ const useSubscriptionPlans = ( subscriber: Subscriber ): SubscriptionPlanData[] 
 		const defaultSubscription = [
 			{
 				is_gift: false,
+				renewal_price: 0,
 				renewalPrice: freePlan,
 				when: '',
 				title: '',
@@ -78,7 +80,7 @@ const useSubscriptionPlans = ( subscriber: Subscriber ): SubscriptionPlanData[] 
 				const renewalPrice = formatRenewalPrice( renewal_price, currency );
 				const when = getPaymentInterval( renew_interval, inactive_renew_interval );
 
-				return { is_gift, renewalPrice, when, start_date, title };
+				return { is_gift, renewal_price, renewalPrice, when, start_date, title };
 			} );
 
 			return result || defaultSubscription;
@@ -109,7 +111,7 @@ const useSubscriptionPlans = ( subscriber: Subscriber ): SubscriptionPlanData[] 
 				startDate: plan.start_date,
 				title: plan.title,
 				is_gift: plan.is_gift,
-				is_free: ! plan.renewalPrice,
+				is_free: ! plan.renewal_price,
 			} ) );
 		}
 		return [];

--- a/client/my-sites/subscribers/hooks/use-subscription-plans.ts
+++ b/client/my-sites/subscribers/hooks/use-subscription-plans.ts
@@ -111,7 +111,7 @@ const useSubscriptionPlans = ( subscriber: Subscriber ): SubscriptionPlanData[] 
 				startDate: plan.start_date,
 				title: plan.title,
 				is_gift: plan.is_gift,
-				is_free: ! plan.renewal_price,
+				is_free: plan.renewal_price === 0,
 			} ) );
 		}
 		return [];

--- a/client/my-sites/subscribers/hooks/use-subscription-plans.ts
+++ b/client/my-sites/subscribers/hooks/use-subscription-plans.ts
@@ -12,6 +12,7 @@ export type SubscriptionPlanData = {
 	startDate?: string;
 	title?: string;
 	is_gift: boolean;
+	is_free: boolean;
 };
 
 type PlanData = {
@@ -108,6 +109,7 @@ const useSubscriptionPlans = ( subscriber: Subscriber ): SubscriptionPlanData[] 
 				startDate: plan.start_date,
 				title: plan.title,
 				is_gift: plan.is_gift,
+				is_free: ! plan.is_gift && ! plan.renewalPrice,
 			} ) );
 		}
 		return [];

--- a/client/my-sites/subscribers/hooks/use-subscription-plans.ts
+++ b/client/my-sites/subscribers/hooks/use-subscription-plans.ts
@@ -109,7 +109,7 @@ const useSubscriptionPlans = ( subscriber: Subscriber ): SubscriptionPlanData[] 
 				startDate: plan.start_date,
 				title: plan.title,
 				is_gift: plan.is_gift,
-				is_free: ! plan.is_gift && ! plan.renewalPrice,
+				is_free: ! plan.renewalPrice,
 			} ) );
 		}
 		return [];


### PR DESCRIPTION
Part of NL-549

## Proposed Changes

* In the subscribers list, comps now display as just "Comp" instead of listing every tier name (e.g., "Comp: Newsletter TierComp: Monthly Subscription").
* When a subscriber has both a comp and a paid plan, only the paid plan is shown — it's the more useful signal for site owners.
* The subscriber detail view is unchanged and continues to show full plan details.

<img width="291" height="336" alt="Screenshot 2026-03-24 at 11 57 04 AM" src="https://github.com/user-attachments/assets/834f0137-774e-402d-a20e-7ff0bb46346f" />


## Why are these changes being made?

When a subscriber has multiple comps, the subscription type column showed all tier names concatenated together, making the column hard to read. The tier name details aren't needed at a glance in the list view — "Comp" is sufficient.

## Testing Instructions

* Navigate to a site's Subscribers page (`/subscribers/:site`).
* Find a subscriber with one or more comped subscriptions — the Subscription Type column should show just "Comp".
* Find a subscriber with both a comp and a paid plan — only the paid plan (e.g., "Monthly ($5.00)") should display.
* Open a subscriber's detail view and confirm it still shows full plan information including tier names.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?