### PR TITLE
A4A: add lead matching plumbing

### DIFF
--- a/client/a8c-for-agencies/AGENTS.md
+++ b/client/a8c-for-agencies/AGENTS.md
@@ -4,7 +4,7 @@
 
 - When creating forms, prefer `@wordpress/components` form controls and patterns directly, following the existing design system.
 - When adding new UI text (especially in new files or files that do not already use translations), use the `@wordpress/i18n` package for translation.
-- When wiring a new page into an existing A4A information architecture, keep breadcrumb ancestry aligned with the actual IA: sibling pages should inherit from the shared parent breadcrumb trail, not from another sibling page.
+- When wiring a new page into an existing A4A navigation structure, keep breadcrumbs aligned with the real page hierarchy: sibling pages should inherit from the shared parent breadcrumb trail, not from another sibling page.
 - When implementing non-trivial or complicated logic, add a minimal set of non-redundant tests that cover the key branches and edge cases.
 - When building tabular/list views or form workflows, prefer existing `DataViews` and `DataForm` abstractions where they fit, instead of creating bespoke implementations:
   - **DataViews** – display lists in a tabular, grid, or list format with sorting, filtering, and pagination.

--- a/client/a8c-for-agencies/AGENTS.md
+++ b/client/a8c-for-agencies/AGENTS.md
@@ -4,6 +4,7 @@
 
 - When creating forms, prefer `@wordpress/components` form controls and patterns directly, following the existing design system.
 - When adding new UI text (especially in new files or files that do not already use translations), use the `@wordpress/i18n` package for translation.
+- When wiring a new page into an existing A4A information architecture, keep breadcrumb ancestry aligned with the actual IA: sibling pages should inherit from the shared parent breadcrumb trail, not from another sibling page.
 - When implementing non-trivial or complicated logic, add a minimal set of non-redundant tests that cover the key branches and edge cases.
 - When building tabular/list views or form workflows, prefer existing `DataViews` and `DataForm` abstractions where they fit, instead of creating bespoke implementations:
   - **DataViews** – display lists in a tabular, grid, or list format with sorting, filtering, and pagination.

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-partner-directory-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-partner-directory-menu-items.ts
@@ -1,4 +1,4 @@
-import { category, cog } from '@wordpress/icons';
+import { category, cog, people } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { A4A_PARTNER_DIRECTORY_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
@@ -7,7 +7,9 @@ import {
 	PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG,
 	PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG,
 	PARTNER_DIRECTORY_DASHBOARD_SLUG,
+	PARTNER_DIRECTORY_LEAD_MATCHING_SLUG,
 } from 'calypso/a8c-for-agencies/sections/partner-directory/constants';
+import { isLeadMatchingSectionVisible } from 'calypso/a8c-for-agencies/sections/partner-directory/lib/lead-matching-visibility';
 import { useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 
@@ -22,6 +24,7 @@ const usePartnerDirectoryMenuItems = ( path: string ) => {
 	const hasDirectoryApproval = agency?.profile?.partner_directory_application?.directories.some(
 		( { status } ) => status === 'approved'
 	);
+	const canAccessLeadMatching = isLeadMatchingSectionVisible();
 
 	const menuItems = useMemo( () => {
 		return [
@@ -61,8 +64,27 @@ const usePartnerDirectoryMenuItems = ( path: string ) => {
 						),
 				  ]
 				: [] ),
+			...( canAccessLeadMatching
+				? [
+						createItem(
+							{
+								icon: people,
+								path: A4A_PARTNER_DIRECTORY_LINK,
+								link: `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_LEAD_MATCHING_SLUG }`,
+								title: translate( 'Lead matching' ),
+								trackEventProps: {
+									menu_item: 'Automattic for Agencies / Partner Directory / Lead matching',
+								},
+								isSelected: isSelected( path, [
+									`${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_LEAD_MATCHING_SLUG }`,
+								] ),
+							},
+							path
+						),
+				  ]
+				: [] ),
 		];
-	}, [ hasDirectoryApproval, path, translate ] );
+	}, [ canAccessLeadMatching, hasDirectoryApproval, path, translate ] );
 	return menuItems;
 };
 

--- a/client/a8c-for-agencies/lib/permission.ts
+++ b/client/a8c-for-agencies/lib/permission.ts
@@ -2,6 +2,7 @@ import {
 	PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG,
 	PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG,
 	PARTNER_DIRECTORY_DASHBOARD_SLUG,
+	PARTNER_DIRECTORY_LEAD_MATCHING_SLUG,
 } from 'calypso/a8c-for-agencies/sections/partner-directory/constants';
 import {
 	A4A_REPORTS_LINK,
@@ -63,6 +64,7 @@ import type { Agency } from 'calypso/state/a8c-for-agencies/types';
 const A4A_PARTNER_DIRECTORY_DASHBOARD_LINK = `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_DASHBOARD_SLUG }`;
 const A4A_PARTNER_DIRECTORY_AGENCY_DETAILS_LINK = `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG }`;
 const A4A_PARTNER_DIRECTORY_AGENCY_EXPERTISE_LINK = `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG }`;
+const A4A_PARTNER_DIRECTORY_LEAD_MATCHING_LINK = `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_LEAD_MATCHING_SLUG }`;
 
 const MEMBER_ACCESSIBLE_PATHS: Record< string, string[] > = {
 	[ A4A_SITES_LINK ]: [ 'a4a_read_managed_sites' ],
@@ -93,6 +95,7 @@ const MEMBER_ACCESSIBLE_PATHS: Record< string, string[] > = {
 	[ A4A_PARTNER_DIRECTORY_DASHBOARD_LINK ]: [ 'a4a_read_partner_directory' ],
 	[ A4A_PARTNER_DIRECTORY_AGENCY_DETAILS_LINK ]: [ 'a4a_read_partner_directory' ],
 	[ A4A_PARTNER_DIRECTORY_AGENCY_EXPERTISE_LINK ]: [ 'a4a_read_partner_directory' ],
+	[ A4A_PARTNER_DIRECTORY_LEAD_MATCHING_LINK ]: [ 'a4a_read_partner_directory' ],
 	[ A4A_PURCHASES_LINK ]: [ 'a4a_jetpack_licensing' ],
 	[ A4A_BILLING_LINK ]: [ 'a4a_jetpack_licensing' ],
 	[ A4A_INVOICES_LINK ]: [ 'a4a_jetpack_licensing' ],
@@ -173,6 +176,7 @@ const MEMBER_TIER_ACCESSIBLE_PATHS: Record< string, string[] > = {
 	[ A4A_PARTNER_DIRECTORY_DASHBOARD_LINK ]: [ 'a4a_feature_partner_directory' ],
 	[ A4A_PARTNER_DIRECTORY_AGENCY_DETAILS_LINK ]: [ 'a4a_feature_partner_directory' ],
 	[ A4A_PARTNER_DIRECTORY_AGENCY_EXPERTISE_LINK ]: [ 'a4a_feature_partner_directory' ],
+	[ A4A_PARTNER_DIRECTORY_LEAD_MATCHING_LINK ]: [ 'a4a_feature_partner_directory' ],
 };
 
 export const isPathAllowedForTier = ( pathname: string, agency: Agency | null ) => {

--- a/client/a8c-for-agencies/sections/partner-directory/constants.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/constants.ts
@@ -1,3 +1,4 @@
 export const PARTNER_DIRECTORY_DASHBOARD_SLUG = 'dashboard';
 export const PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG = 'agency-details';
 export const PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG = 'agency-expertise';
+export const PARTNER_DIRECTORY_LEAD_MATCHING_SLUG = 'lead-matching';

--- a/client/a8c-for-agencies/sections/partner-directory/controller.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/controller.tsx
@@ -8,7 +8,9 @@ import {
 	PARTNER_DIRECTORY_DASHBOARD_SLUG,
 	PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG,
 	PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG,
+	PARTNER_DIRECTORY_LEAD_MATCHING_SLUG,
 } from './constants';
+import { isLeadMatchingSectionVisible } from './lib/lead-matching-visibility';
 import PartnerDirectory from './partner-directory';
 
 export const partnerDirectoryDashboardContext: Callback = ( context, next ) => {
@@ -17,12 +19,14 @@ export const partnerDirectoryDashboardContext: Callback = ( context, next ) => {
 	const hasDirectoryApproval = agency?.profile?.partner_directory_application?.directories.some(
 		( { status } ) => status === 'approved'
 	);
+	const canAccessLeadMatching = isLeadMatchingSectionVisible();
 
 	const validSections = [
 		PARTNER_DIRECTORY_DASHBOARD_SLUG,
 		// Agency details is hidden if the agency has no directories approved
 		...( hasDirectoryApproval ? [ PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG ] : [] ),
 		PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG,
+		...( canAccessLeadMatching ? [ PARTNER_DIRECTORY_LEAD_MATCHING_SLUG ] : [] ),
 	];
 
 	const selectedSection = context.params.section ?? PARTNER_DIRECTORY_DASHBOARD_SLUG;
@@ -34,7 +38,14 @@ export const partnerDirectoryDashboardContext: Callback = ( context, next ) => {
 
 	context.primary = (
 		<>
-			<PageViewTracker title="Partner Directory > Dashboard" path={ context.path } />
+			<PageViewTracker
+				title={
+					selectedSection === PARTNER_DIRECTORY_LEAD_MATCHING_SLUG
+						? 'Partner Directory > Lead Matching'
+						: 'Partner Directory > Dashboard'
+				}
+				path={ context.path }
+			/>
 			<PartnerDirectory selectedSection={ selectedSection } />
 		</>
 	);

--- a/client/a8c-for-agencies/sections/partner-directory/lead-matching/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/lead-matching/index.tsx
@@ -1,0 +1,16 @@
+import { useTranslate } from 'i18n-calypso';
+
+export default function LeadMatchingPlaceholder() {
+	const translate = useTranslate();
+
+	return (
+		<div className="partner-directory-lead-matching-placeholder">
+			<h2>{ translate( 'Lead matching' ) }</h2>
+			<p>
+				{ translate(
+					'This section is now wired for rollout. The final lead matching form will land in a follow-up PR.'
+				) }
+			</p>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/partner-directory/lead-matching/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/lead-matching/index.tsx
@@ -1,16 +1,15 @@
-import { useTranslate } from 'i18n-calypso';
+import { Text, VStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 export default function LeadMatchingPlaceholder() {
-	const translate = useTranslate();
-
 	return (
-		<div className="partner-directory-lead-matching-placeholder">
-			<h2>{ translate( 'Lead matching' ) }</h2>
-			<p>
-				{ translate(
+		<VStack className="partner-directory-lead-matching-placeholder">
+			<Text as="h2">{ __( 'Lead matching' ) }</Text>
+			<Text>
+				{ __(
 					'This section is now wired for rollout. The final lead matching form will land in a follow-up PR.'
 				) }
-			</p>
-		</div>
+			</Text>
+		</VStack>
 	);
 }

--- a/client/a8c-for-agencies/sections/partner-directory/lead-matching/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/lead-matching/index.tsx
@@ -1,4 +1,4 @@
-import { Text, VStack } from '@wordpress/components';
+import { __experimentalText as Text, __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 export default function LeadMatchingPlaceholder() {

--- a/client/a8c-for-agencies/sections/partner-directory/lib/lead-matching-visibility.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/lib/lead-matching-visibility.ts
@@ -1,0 +1,9 @@
+import { isEnabled } from '@automattic/calypso-config';
+
+export const A4A_PARTNER_DIRECTORY_LEAD_MATCHING_FEATURE_FLAG =
+	'a4a-partner-directory-lead-matching';
+
+export const isLeadMatchingSectionEnabled = () =>
+	isEnabled( A4A_PARTNER_DIRECTORY_LEAD_MATCHING_FEATURE_FLAG );
+
+export const isLeadMatchingSectionVisible = () => isLeadMatchingSectionEnabled();

--- a/client/a8c-for-agencies/sections/partner-directory/partner-directory.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/partner-directory.tsx
@@ -95,7 +95,7 @@ export default function PartnerDirectory( { selectedSection }: Props ) {
 		sections[ PARTNER_DIRECTORY_LEAD_MATCHING_SLUG ] = {
 			content: <LeadMatchingPlaceholder />,
 			breadcrumbItems: [
-				...sections[ PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG ].breadcrumbItems,
+				...sections[ PARTNER_DIRECTORY_DASHBOARD_SLUG ].breadcrumbItems,
 				{
 					label: translate( 'Lead matching' ),
 					href: `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_LEAD_MATCHING_SLUG }`,

--- a/client/a8c-for-agencies/sections/partner-directory/partner-directory.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/partner-directory.tsx
@@ -23,8 +23,10 @@ import {
 	PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG,
 	PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG,
 	PARTNER_DIRECTORY_DASHBOARD_SLUG,
+	PARTNER_DIRECTORY_LEAD_MATCHING_SLUG,
 } from './constants';
 import Dashboard from './dashboard';
+import LeadMatchingPlaceholder from './lead-matching';
 import {
 	mapAgencyDetailsFormData,
 	mapApplicationFormData,
@@ -86,6 +88,17 @@ export default function PartnerDirectory( { selectedSection }: Props ) {
 				{
 					label: translate( 'Agency Expertise' ),
 					href: `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG }`,
+				},
+			],
+		};
+
+		sections[ PARTNER_DIRECTORY_LEAD_MATCHING_SLUG ] = {
+			content: <LeadMatchingPlaceholder />,
+			breadcrumbItems: [
+				...sections[ PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG ].breadcrumbItems,
+				{
+					label: translate( 'Lead matching' ),
+					href: `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_LEAD_MATCHING_SLUG }`,
 				},
 			],
 		};

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -91,6 +91,9 @@ export interface Agency {
 		allowed: boolean;
 		directories: DirectoryApplicationType[];
 	};
+	lead_matching?: {
+		allowed?: boolean;
+	};
 	user: {
 		role: 'a4a_administrator' | 'a4a_manager';
 		capabilities: string[];

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -39,6 +39,7 @@
 		"a4a/site-details-pane": true,
 		"a4a/site-migration": true,
 		"a4a-partner-directory": false,
+		"a4a-partner-directory-lead-matching": true,
 		"a4a-pressable-referrals": true,
 		"a4a-pressable-premium-plans": true,
 		"a4a-updated-add-new-site": true,

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -32,6 +32,7 @@
 		"a4a/site-details-pane": true,
 		"a4a/site-migration": true,
 		"a4a-partner-directory": false,
+		"a4a-partner-directory-lead-matching": false,
 		"a4a-pressable-referrals": true,
 		"a4a-pressable-premium-plans": true,
 		"a4a-updated-add-new-site": true,

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -32,6 +32,7 @@
 		"cookie-banner": true,
 		"oauth": true,
 		"a4a-partner-directory": false,
+		"a4a-partner-directory-lead-matching": false,
 		"a4a-pressable-referrals": true,
 		"a4a-pressable-premium-plans": true,
 		"a4a-updated-add-new-site": true,

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -34,6 +34,7 @@
 		"oauth": true,
 		"a4a/site-migration": false,
 		"a4a-partner-directory": false,
+		"a4a-partner-directory-lead-matching": false,
 		"a4a-pressable-referrals": true,
 		"a4a-pressable-premium-plans": true,
 		"a4a-updated-add-new-site": true,


### PR DESCRIPTION
Part of A4A-2100/lead-routing-design-partner-directory-ia-and-form-improvements

## Proposed Changes

* Add gated route and menu plumbing for the new Partner Directory lead-matching section
* Add a global Calypso feature flag for the section
* Keep the first slice flag-only so the section can be exercised locally before the agency gate lands

## Why are these changes being made?

* This is PR 1 of the Lead Machine Engine Calypso rollout.
* It lands the rollout skeleton first, before the grouped form contract and API integration work.
* Keeping the plumbing isolated reduces review risk and keeps the later form PR focused.
* The agency-level `lead_matching.allowed` rollout gate is deferred to a follow-up PR.

## Testing Instructions

* Verify the new section is hidden when the feature flag is off.
* Verify `?flags=a4a-partner-directory-lead-matching` shows the `Lead matching` menu item.
* Verify direct navigation to `/partner-directory/lead-matching?flags=a4a-partner-directory-lead-matching` stays on the lead-matching route.
* Verify existing Partner Directory routes still behave the same.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in Memoizing with create-selector and Our Approach to Data
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?
