### PR TITLE
MCP: Fix badge icons on dashboard hub to match classic Calypso (AIINT-301)

### DIFF
--- a/client/dashboard/me/mcp/index.tsx
+++ b/client/dashboard/me/mcp/index.tsx
@@ -32,30 +32,30 @@ interface McpAbility {
 
 function getReadBadge( tools: Array< [ string, McpAbility ] > ) {
 	if ( tools.length === 0 ) {
-		return { text: __( 'All enabled' ), intent: 'info' as const };
+		return { text: __( 'All enabled' ), intent: 'success' as const };
 	}
 	const enabledCount = tools.filter( ( [ , tool ] ) => tool.enabled ).length;
 	if ( enabledCount === tools.length ) {
-		return { text: __( 'All enabled' ), intent: 'info' as const };
+		return { text: __( 'All enabled' ), intent: 'success' as const };
 	}
 	if ( enabledCount === 0 ) {
-		return { text: __( 'None enabled' ) };
+		return { text: __( 'None enabled' ), intent: 'warning' as const };
 	}
-	return { text: `${ enabledCount } of ${ tools.length }`, intent: 'info' as const };
+	return { text: `${ enabledCount } of ${ tools.length }` };
 }
 
 function getWriteBadge( tools: Array< [ string, McpAbility ] > ) {
 	if ( tools.length === 0 ) {
-		return { text: __( 'All enabled' ), intent: 'info' as const };
+		return { text: __( 'All enabled' ), intent: 'success' as const };
 	}
 	const enabledCount = tools.filter( ( [ , tool ] ) => tool.enabled ).length;
 	if ( enabledCount === tools.length ) {
-		return { text: __( 'All enabled' ), intent: 'info' as const };
+		return { text: __( 'All enabled' ), intent: 'success' as const };
 	}
 	if ( enabledCount === 0 ) {
 		return { text: __( 'Disabled' ) };
 	}
-	return { text: `${ enabledCount } of ${ tools.length }`, intent: 'info' as const };
+	return { text: `${ enabledCount } of ${ tools.length }` };
 }
 
 function McpComponent() {


### PR DESCRIPTION
Fixes [AIINT-301.](https://linear.app/a8c/issue/AIINT-301/fix-icons-on-calypso-mcp-settings)

## Summary

- Fixes the badge icons on the \`me/preferences/mcp\` dashboard hub to match the \`me/mcp\` classic Calypso hub
- **"All enabled"** now shows a check icon (\`intent: 'success'\`) instead of the info circle icon (\`intent: 'info'\`)
- **"None enabled"** now shows a caution icon (\`intent: 'warning'\`) instead of no icon
- **Partial counts** (e.g. "5 of 10") now show no icon instead of the info circle icon

The \`Badge\` component maps intents to icons: \`success\` → check, \`info\` → info circle, \`warning\` → caution. The classic Calypso hub (\`me/mcp\`) was already using the correct intents via \`hub-helpers.js\`; this aligns the dashboard hub to match.

## Test plan

- [ ] Visit \`/me/preferences/mcp\` with some read tools enabled and some disabled — partial count badge should have no icon
- [ ] Enable all tools — badge should show "All enabled" with a check icon
- [ ] Disable all tools — Read badge shows "None enabled" with a caution icon; Write badge shows "Disabled" with no icon
- [ ] Compare with \`/me/mcp\` — badges should look consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)