### PR TITLE
MCP: Use BigSkyLogo icon on me/preferences/mcp to match AI tools settings

### DIFF
--- a/client/dashboard/me/preferences-ai-mcp/index.tsx
+++ b/client/dashboard/me/preferences-ai-mcp/index.tsx
@@ -1,8 +1,7 @@
 import { userSettingsQuery } from '@automattic/api-queries';
+import { BigSkyLogo } from '@automattic/components/src/logos/big-sky-logo';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { connection } from '@wordpress/icons';
 import { hasEnabledAccountTools } from '../../../me/mcp/utils';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
 
@@ -22,7 +21,7 @@ export default function PreferencesAiMcp() {
 			to="/me/preferences/mcp"
 			title={ __( 'AI and MCP' ) }
 			description={ __( 'Configure how AI agents access your WordPress.com data.' ) }
-			decoration={ <Icon icon={ connection } size={ 24 } /> }
+			decoration={ <BigSkyLogo.CentralLogo heartless size={ 24 } /> }
 			badges={ badges }
 		/>
 	);


### PR DESCRIPTION
Fixes [AIINT-301.](https://linear.app/a8c/issue/AIINT-301/fix-icons-on-calypso-mcp-settings)

## Summary

Replaces the `connection` icon on the AI & MCP summary row (account preferences page) with `BigSkyLogo.CentralLogo` — the same icon used by the AI tools row on the site settings page — so the two are visually consistent.

## Test plan

- [ ] Visit a site settings page (e.g. `/sites/example.com/settings`) and note the icon on the "AI tools" row
- [ ] Visit `/me/preferences` and confirm the "AI and MCP" row now uses the same BigSky logo icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)