### PR TITLE
Add AGENTS.md and CLAUDE.md for Agents Manager

### DIFF
--- a/apps/agents-manager/AGENTS.md
+++ b/apps/agents-manager/AGENTS.md
@@ -1,58 +1,30 @@
 # Agents Manager App
 
-Build and deployment layer for the Agents Manager on Simple and Atomic sites. Most Agents Manager code lives in `packages/agents-manager/` — see `packages/agents-manager/AGENTS.md` for the primary spec.
+Build and deployment layer for the Agents Manager. Most code lives in `packages/agents-manager/` — see its `AGENTS.md` for architecture and conventions.
 
-## Overview
+This app bundles the package into 8 webpack entry points deployed to `widgets.wp.com/agents-manager/`. Jetpack enqueues these on Simple, Atomic, and CIAB sites.
 
-This app takes `@automattic/agents-manager` and bundles it into 8 separate webpack entry points deployed to `widgets.wp.com/agents-manager/`. Jetpack enqueues these bundles on various types of websites and pages (editor, wp-admin, CIAB).
-
-## Entry Points
-
-| Entry point                                 | Context                                           |
-| ------------------------------------------- | ------------------------------------------------- |
-| `agents-manager-gutenberg.js`               | Gutenberg editor (connected)                      |
-| `agents-manager-gutenberg-disconnected.js`  | Gutenberg editor (disconnected from Jetpack)      |
-| `agents-manager-wp-admin.js`                | wp-admin bar (connected, dual-mode: full/headless)|
-| `agents-manager-wp-admin-disconnected.js`   | wp-admin bar (disconnected from Jetpack)          |
-| `agents-manager-ciab.js`                    | CIAB admin (connected)                            |
-| `agents-manager-ciab-disconnected.js`       | CIAB admin (disconnected)                         |
-| `image-studio.js`                           | Standalone Image Studio integration               |
-| `block-notes.js`                            | Standalone Block Notes integration                |
-
-Each entry point is a standalone JS file in the app root that imports from `@automattic/agents-manager` (or `@automattic/image-studio` / `@automattic/block-notes`) and wires up environment-specific bootstrap logic.
-
-## Build & Sync Commands
+## Build & Sync
 
 ```bash
-# Dev build + sync to sandbox (use during development)
+# Dev build + sync to sandbox
 cd apps/agents-manager
 yarn dev --sync
 
-# Production build (for deployment)
-cd apps/agents-manager
+# Production build
 yarn build
 ```
 
-Both `dev` and `build` use `calypso-apps-builder` to compile webpack bundles. The `--sync` flag syncs them to `widgets.wp.com/agents-manager/` on your sandbox.
+The `--sync` flag syncs bundles to `widgets.wp.com/agents-manager/` on your sandbox.
 
 ## Sandbox Testing
 
 1. Sandbox `widgets.wp.com` (the sites themselves do not need sandboxing).
-2. Run `yarn dev --sync` from `apps/agents-manager/`.
+2. Run `yarn dev --sync` from this directory.
 3. Visit any Simple, Atomic, or CIAB site.
 4. Open the Agents Manager and verify your changes.
 
-## PR Guidelines
+## Pitfalls
 
-For PRs that **only** touch `apps/agents-manager/` (build config, entry point wiring):
-
-```markdown
-## Testing Instructions
-
-1. Sandbox `widgets.wp.com` (the sites themselves do not need sandboxing).
-2. Run `cd apps/agents-manager && yarn dev --sync`.
-3. Visit any Simple, Atomic, or CIAB site.
-4. Open the Agents Manager and verify it loads and functions correctly.
-```
-
-For PRs that also touch `packages/agents-manager/`, follow the PR guidelines in `packages/agents-manager/AGENTS.md` instead (which includes both Calypso and Simple/Atomic testing).
+- **`wp-admin` entry point is dual-mode**: It renders full UI when `#agents-manager-masterbar` exists, otherwise runs headless (for Image Studio shared use). This is not obvious from the filename.
+- **`image-studio` and `block-notes` are separate bundles**: They're built here but are independent features, not part of the main Agents Manager UI.

--- a/apps/agents-manager/AGENTS.md
+++ b/apps/agents-manager/AGENTS.md
@@ -42,23 +42,6 @@ Both `dev` and `build` use `calypso-apps-builder` to compile webpack bundles. Th
 3. Visit any Simple, Atomic, or CIAB site.
 4. Open the Agents Manager and verify your changes.
 
-## Deployment
-
-1. Connect to your sandbox and run: `install-plugin.sh am --release`
-2. When prompted where to push the branch, select the WPCOM repository.
-3. This will create a PR on the WPCOM repository.
-4. Once checks pass, merge the PR.
-5. Deploy wpcom: `deploy wpcom`
-
-This deploys the Agents Manager bundles and language files for Jetpack consumption (served via `widgets.wp.com`).
-
-## Translations
-
-Translations are uploaded to `widgets.wp.com/agents-manager/languages`. They're downloaded in Jetpack during the build process.
-
-> [!IMPORTANT]
-> If you add new phrases to the Agents Manager, they will only be translated on Atomic sites after `jetpack-mu-plugin` is released, which happens twice a day.
-
 ## PR Guidelines
 
 For PRs that **only** touch `apps/agents-manager/` (build config, entry point wiring):

--- a/apps/agents-manager/AGENTS.md
+++ b/apps/agents-manager/AGENTS.md
@@ -1,0 +1,75 @@
+# Agents Manager App
+
+Build and deployment layer for the Agents Manager on Simple and Atomic sites. Most Agents Manager code lives in `packages/agents-manager/` — see `packages/agents-manager/AGENTS.md` for the primary spec.
+
+## Overview
+
+This app takes `@automattic/agents-manager` and bundles it into 8 separate webpack entry points deployed to `widgets.wp.com/agents-manager/`. Jetpack enqueues these bundles on various types of websites and pages (editor, wp-admin, CIAB).
+
+## Entry Points
+
+| Entry point                                 | Context                                           |
+| ------------------------------------------- | ------------------------------------------------- |
+| `agents-manager-gutenberg.js`               | Gutenberg editor (connected)                      |
+| `agents-manager-gutenberg-disconnected.js`  | Gutenberg editor (disconnected from Jetpack)      |
+| `agents-manager-wp-admin.js`                | wp-admin bar (connected, dual-mode: full/headless)|
+| `agents-manager-wp-admin-disconnected.js`   | wp-admin bar (disconnected from Jetpack)          |
+| `agents-manager-ciab.js`                    | CIAB admin (connected)                            |
+| `agents-manager-ciab-disconnected.js`       | CIAB admin (disconnected)                         |
+| `image-studio.js`                           | Standalone Image Studio integration               |
+| `block-notes.js`                            | Standalone Block Notes integration                |
+
+Each entry point is a standalone JS file in the app root that imports from `@automattic/agents-manager` (or `@automattic/image-studio` / `@automattic/block-notes`) and wires up environment-specific bootstrap logic.
+
+## Build & Sync Commands
+
+```bash
+# Dev build + sync to sandbox (use during development)
+cd apps/agents-manager
+yarn dev --sync
+
+# Production build (for deployment)
+cd apps/agents-manager
+yarn build
+```
+
+Both `dev` and `build` use `calypso-apps-builder` to compile webpack bundles. The `--sync` flag syncs them to `widgets.wp.com/agents-manager/` on your sandbox.
+
+## Sandbox Testing
+
+1. Sandbox `widgets.wp.com` (the sites themselves do not need sandboxing).
+2. Run `yarn dev --sync` from `apps/agents-manager/`.
+3. Visit any Simple, Atomic, or CIAB site.
+4. Open the Agents Manager and verify your changes.
+
+## Deployment
+
+1. Connect to your sandbox and run: `install-plugin.sh am --release`
+2. When prompted where to push the branch, select the WPCOM repository.
+3. This will create a PR on the WPCOM repository.
+4. Once checks pass, merge the PR.
+5. Deploy wpcom: `deploy wpcom`
+
+This deploys the Agents Manager bundles and language files for Jetpack consumption (served via `widgets.wp.com`).
+
+## Translations
+
+Translations are uploaded to `widgets.wp.com/agents-manager/languages`. They're downloaded in Jetpack during the build process.
+
+> [!IMPORTANT]
+> If you add new phrases to the Agents Manager, they will only be translated on Atomic sites after `jetpack-mu-plugin` is released, which happens twice a day.
+
+## PR Guidelines
+
+For PRs that **only** touch `apps/agents-manager/` (build config, entry point wiring):
+
+```markdown
+## Testing Instructions
+
+1. Sandbox `widgets.wp.com` (the sites themselves do not need sandboxing).
+2. Run `cd apps/agents-manager && yarn dev --sync`.
+3. Visit any Simple, Atomic, or CIAB site.
+4. Open the Agents Manager and verify it loads and functions correctly.
+```
+
+For PRs that also touch `packages/agents-manager/`, follow the PR guidelines in `packages/agents-manager/AGENTS.md` instead (which includes both Calypso and Simple/Atomic testing).

--- a/apps/agents-manager/CLAUDE.md
+++ b/apps/agents-manager/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/apps/agents-manager/README.md
+++ b/apps/agents-manager/README.md
@@ -1,21 +1,35 @@
-# Agents Manager App
+# Agents Manager
 
-The Agents Manager app provides a standalone application for loading the Unified AI Agent component.
+The Agents Manager is the unified AI agent experience for WordPress.com users, providing chat, support guides, and AI-powered tools across multiple environments.
 
 ## Development
 
-### In Calypso
+The Agents Manager runs in multiple different environments:
+
+1. In Calypso.
+2. In Simple sites
+   - as a plugin to Gutenberg editor.
+   - as a wpadminbar menu item.
+3. In Atomic sites
+   - as a plugin to Gutenberg editor.
+   - as a wpadminbar menu item.
+4. In CIAB (Commerce in a Box)
+   - as a Next Admin SPA integration.
+
+### How to develop the Agents Manager
+
+#### In Calypso
 
 Follow the classic Calypso development setup. Run `yarn start` and edit away. Nothing else should be needed.
 
-### In Simple sites
+#### In Simple sites
 
 1. cd into `apps/agents-manager`.
 2. run `yarn dev --sync`.
 3. Sandbox your site and `widgets.wp.com`.
 4. Your changes should be reflected on the site live.
 
-### In Atomic sites
+#### In Atomic sites
 
 If you only interested in making JS and CSS changes, you're in luck; you don't need to worry about running Jetpack. You can follow the same instructions of simple sites.
 
@@ -24,19 +38,19 @@ If you only interested in making JS and CSS changes, you're in luck; you don't n
 
 If you do want to modify PHP files. Please follow the development process of [`jetpack-mu-plugin`](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/jetpack-mu-wpcom/README.md).
 
-## Translations
+### Translations
 
 Translations are uploaded to widgets.wp.com/agents-manager/languages. They're then downloaded in Jetpack during the build process.
 
-## Deployment
+### Deployment
 
 After every change to the Agents Manager, the development process is two parts:
 
-### Deploy Calypso
+#### Deploy Calypso
 
 This simply means deploying Calypso as you normally would.
 
-### Deploy the Agents Manager for Jetpack consumption
+#### Deploy the Agents Manager for Jetpack consumption
 1. Connect to your sandbox and run: `install-plugin.sh am --release`
 2. When prompted where to push the branch, select the WPCOM repository.
 3. This will create a PR on the WPCOM repository.
@@ -47,4 +61,3 @@ This will deploy the Agents Manager app for Jetpack consumption. Along with the 
 
 > [!IMPORTANT]
 > If you add new phrases to the Agents Manager. They will only be translated in Atomic sites after `jetpack-mu-plugin` is released. Which happens twice a day.
-

--- a/packages/agents-manager/AGENTS.md
+++ b/packages/agents-manager/AGENTS.md
@@ -1,0 +1,155 @@
+# Agents Manager Package
+
+## Package Overview
+
+`@automattic/agents-manager` is the shared component library for WordPress.com's unified AI agent experience. It runs in multiple environments:
+
+1. **Calypso** — embedded directly as a React component in the WordPress.com dashboard.
+2. **Simple sites** — loaded via `widgets.wp.com` as a Gutenberg editor plugin and wp-admin bar menu item.
+3. **Atomic sites** — same as Simple when connected to Jetpack. Falls back to a disconnected variant when not connected.
+4. **CIAB (Commerce in a Box)** — loaded via `widgets.wp.com` through Next Admin, not through Calypso.
+
+Most code lives here in `packages/agents-manager/`. The `apps/agents-manager/` app handles building and deploying the webpack bundles that serve Simple, Atomic, and CIAB sites.
+
+## Backend
+
+The Agents Manager backend lives in `jetpack-mu-wpcom` (in the Jetpack monorepo). It is responsible for:
+
+1. **Loading the Agents Manager** in wp-admin, the block editor, and CIAB — it enqueues the webpack bundles built by `apps/agents-manager/` from `widgets.wp.com`.
+2. **Registering the `/agents-manager/open-state` REST API endpoint** for persisting UI state (open/docked/position) via user preferences.
+
+Any change that requires new API endpoints, different API behavior, or loading the Agents Manager in a new context requires work in `jetpack-mu-wpcom`, not in this repo.
+
+## Architecture
+
+### State Management
+
+Uses WordPress `@wordpress/data` stores and TanStack Query for server state.
+
+- **`AGENTS_MANAGER_STORE`** (`src/stores.ts`) — UI state (isOpen, isDocked, floatingPosition, routerHistory).
+- **`AgentsManagerContext`** (`src/contexts/AgentsManagerContext.tsx`) — React context for currentUser, site, sectionName, agentConfig, sessionId.
+
+### Key Directories
+
+```
+src/
+├── index.ts              # Entry point & exports
+├── constants.ts          # API URLs and agent IDs
+├── types.ts              # TypeScript type definitions
+├── stores.ts             # WordPress data store registration
+├── extension-types.ts    # Plugin extension interfaces (ToolProvider, ContextProvider, Ability)
+├── auth/                 # Authentication providers (Calypso auth)
+├── components/           # React UI components
+│   ├── agents-manager.tsx          # Main component wrapper
+│   ├── agent-chat/                 # Chat UI (messages, input, suggestions)
+│   ├── agent-dock/                 # Dock/sidebar with routing
+│   ├── agent-history/              # Conversation history view
+│   ├── headless-agent-initializer.tsx  # Headless agent setup (no UI)
+│   ├── chat-header/                # Header with menu
+│   ├── feedback-input/             # Feedback form after thumbs down
+│   ├── escalation-button/          # Support escalation
+│   ├── support-guides/             # Support articles list
+│   └── ...                         # 23 component directories total
+├── contexts/             # React context providers
+├── hooks/                # Custom React hooks
+│   ├── use-agent-config.ts         # Agent ID/version resolution
+│   ├── use-agent-layout-manager/   # Layout management with store
+│   ├── use-conversation.ts         # Individual conversation state
+│   ├── use-conversation-list.ts    # Conversation history
+│   ├── use-feedback-action.ts      # Rating/feedback submission
+│   ├── use-persisted-history.ts    # Conversation persistence
+│   ├── use-setup-custom-actions/   # Window API for cross-app integration
+│   ├── use-should-use-unified-agent.ts  # Unified experience flag
+│   └── ...
+├── utils/                # Utilities
+│   ├── load-external-providers.ts  # Dynamic extension loading
+│   └── ...
+└── styles/               # Global SCSS (variables, mixins, animations)
+```
+
+### Extension System
+
+The Agents Manager supports plugin extensions via a dynamic provider system. Providers are registered by PHP filters and loaded at runtime.
+
+**Loading flow:**
+1. PHP filter `agents_manager_agent_providers` registers provider module URLs, injected as `agentsManagerData.agentProviders`.
+2. `loadExternalProviders()` (`src/utils/load-external-providers.ts`) dynamically imports each module.
+3. Each module can export: `toolProvider`, `contextProvider`, `useAbilitiesSetup`, `getEmptyViewSuggestions`, `markdownComponents`, `markdownExtensions`, and more.
+
+**Key interfaces** (defined in `src/extension-types.ts`):
+- **`ToolProvider`**: `getAbilities()` and `executeAbility(name, args)`
+- **`Ability`**: name, label, description, category, input_schema, output_schema, callback, permissionCallback, meta.annotations
+- **`ContextProvider`**: `getClientContext()` returning URL, pathname, environment, contextEntries
+
+### Agenttic Integration
+
+The package uses `@automattic/agenttic-client` and `@automattic/agenttic-ui` for the core chat runtime:
+
+- **agenttic-client**: `getAgentManager()`, `useAgentChat()`, message types, auth providers
+- **agenttic-ui**: `AgentUI`, `createMessageRenderer()`, `EmptyView`, `ImageUploader`, suggestion/markdown types
+
+### How Changes Flow to Simple/Atomic
+
+Changes in `packages/agents-manager/src/` are consumed by `apps/agents-manager/` via its webpack entry points. The app bundles the package into 8 separate JS files deployed to `widgets.wp.com/agents-manager/`. Jetpack enqueues these bundles on WordPress.com Simple and Atomic sites.
+
+## Testing
+
+### Unit Tests
+
+```bash
+# Run from repo root
+yarn jest packages/agents-manager
+```
+
+Test files live in `src/components/__tests__/`, `src/hooks/__tests__/`, `src/contexts/__tests__/`, and `src/utils/__tests__/`.
+
+### Sandbox Testing (Simple/Atomic/CIAB)
+
+To verify changes on Simple, Atomic, and CIAB sites you only need to sandbox `widgets.wp.com` — the sites themselves do not need sandboxing:
+
+1. Sandbox `widgets.wp.com`.
+2. Run `cd apps/agents-manager && yarn dev --sync` — this builds the webpack bundles and syncs them to your sandbox.
+3. Visit any Simple, Atomic, or CIAB site and verify the Agents Manager works correctly.
+
+See `apps/agents-manager/AGENTS.md` for more details on the build/sync layer.
+
+## PR Guidelines
+
+**Every PR touching `packages/agents-manager/`** must include testing instructions for both Calypso and Simple/Atomic/CIAB environments:
+
+### Testing Instructions Template
+
+```markdown
+## Testing Instructions
+
+### Calypso
+
+1. Run `yarn start`.
+2. Open the Agents Manager and verify [describe expected behavior].
+
+### Simple/Atomic/CIAB
+
+1. Sandbox `widgets.wp.com`.
+2. Run `cd apps/agents-manager && yarn dev --sync`.
+3. Visit any Simple, Atomic, or CIAB site (the site itself does not need sandboxing).
+4. Open the Agents Manager and verify [describe expected behavior].
+```
+
+This "always include both" rule exists because nearly everything in `packages/agents-manager/src/` flows through to the Simple/Atomic/CIAB bundles. Missing sandbox testing steps is costly; including them when not strictly needed is cheap.
+
+## Conventions
+
+- **i18n**: Use `@wordpress/i18n` with text domain `'__i18n_text_domain__'` for all user-facing strings. New strings won't be translated on Atomic until the next `jetpack-mu-plugin` release (twice daily).
+- **Components**: Use `@wordpress/components` and `@automattic/components` where appropriate.
+- **Data fetching**: Use TanStack Query for server state. Follow existing patterns in `src/hooks/`.
+- **Styling**: Component-scoped SCSS files (`style.scss`). Global styles and variables in `src/styles/`.
+- **Store**: Use `AGENTS_MANAGER_STORE` via `@wordpress/data` for UI state. Use `AgentsManagerContext` for session/user/site data.
+
+## Common Pitfalls
+
+- **Two deployment targets**: Changes must work in both Calypso (SPA) and Simple/Atomic/CIAB (via `widgets.wp.com`). Always test both.
+- **Multiple entry points**: `apps/agents-manager/` has 8 webpack entry points for different contexts. A change may behave differently across entry points.
+- **asset.json sync limitation**: If you add or remove `@wordpress/*` dependencies, the `.asset.json` files won't sync to the sandbox because Jetpack fetches them from production. You must deploy for dependency changes to take effect on Atomic.
+- **Disconnected variants**: Some entry points have "disconnected" versions that show minimal UI (help icon link only). Make sure changes don't break these variants.
+- **Help Center replacement**: On Gutenberg pages, the Agents Manager dequeues Help Center scripts. Be aware of this interaction when debugging.
+- **Extension provider changes**: If modifying the extension system interfaces in `extension-types.ts`, coordinate with Big Sky and any other provider plugins.

--- a/packages/agents-manager/AGENTS.md
+++ b/packages/agents-manager/AGENTS.md
@@ -1,155 +1,36 @@
 # Agents Manager Package
 
-## Package Overview
+`@automattic/agents-manager` is the shared component library for WordPress.com's unified AI agent experience. It runs in Calypso, Simple sites, Atomic sites, and CIAB — all from the same source.
 
-`@automattic/agents-manager` is the shared component library for WordPress.com's unified AI agent experience. It runs in multiple environments:
+## Cross-Repo Boundaries
 
-1. **Calypso** — embedded directly as a React component in the WordPress.com dashboard.
-2. **Simple sites** — loaded via `widgets.wp.com` as a Gutenberg editor plugin and wp-admin bar menu item.
-3. **Atomic sites** — same as Simple when connected to Jetpack. Falls back to a disconnected variant when not connected.
-4. **CIAB (Commerce in a Box)** — loaded via `widgets.wp.com` through Next Admin, not through Calypso.
-
-Most code lives here in `packages/agents-manager/`. The `apps/agents-manager/` app handles building and deploying the webpack bundles that serve Simple, Atomic, and CIAB sites.
-
-## Backend
-
-The Agents Manager backend lives in `jetpack-mu-wpcom` (in the Jetpack monorepo). It is responsible for:
-
-1. **Loading the Agents Manager** in wp-admin, the block editor, and CIAB — it enqueues the webpack bundles built by `apps/agents-manager/` from `widgets.wp.com`.
-2. **Registering the `/agents-manager/open-state` REST API endpoint** for persisting UI state (open/docked/position) via user preferences.
-
-Any change that requires new API endpoints, different API behavior, or loading the Agents Manager in a new context requires work in `jetpack-mu-wpcom`, not in this repo.
-
-## Architecture
-
-### State Management
-
-Uses WordPress `@wordpress/data` stores and TanStack Query for server state.
-
-- **`AGENTS_MANAGER_STORE`** (`src/stores.ts`) — UI state (isOpen, isDocked, floatingPosition, routerHistory).
-- **`AgentsManagerContext`** (`src/contexts/AgentsManagerContext.tsx`) — React context for currentUser, site, sectionName, agentConfig, sessionId.
-
-### Key Directories
-
-```
-src/
-├── index.ts              # Entry point & exports
-├── constants.ts          # API URLs and agent IDs
-├── types.ts              # TypeScript type definitions
-├── stores.ts             # WordPress data store registration
-├── extension-types.ts    # Plugin extension interfaces (ToolProvider, ContextProvider, Ability)
-├── auth/                 # Authentication providers (Calypso auth)
-├── components/           # React UI components
-│   ├── agents-manager.tsx          # Main component wrapper
-│   ├── agent-chat/                 # Chat UI (messages, input, suggestions)
-│   ├── agent-dock/                 # Dock/sidebar with routing
-│   ├── agent-history/              # Conversation history view
-│   ├── headless-agent-initializer.tsx  # Headless agent setup (no UI)
-│   ├── chat-header/                # Header with menu
-│   ├── feedback-input/             # Feedback form after thumbs down
-│   ├── escalation-button/          # Support escalation
-│   ├── support-guides/             # Support articles list
-│   └── ...                         # 23 component directories total
-├── contexts/             # React context providers
-├── hooks/                # Custom React hooks
-│   ├── use-agent-config.ts         # Agent ID/version resolution
-│   ├── use-agent-layout-manager/   # Layout management with store
-│   ├── use-conversation.ts         # Individual conversation state
-│   ├── use-conversation-list.ts    # Conversation history
-│   ├── use-feedback-action.ts      # Rating/feedback submission
-│   ├── use-persisted-history.ts    # Conversation persistence
-│   ├── use-setup-custom-actions/   # Window API for cross-app integration
-│   ├── use-should-use-unified-agent.ts  # Unified experience flag
-│   └── ...
-├── utils/                # Utilities
-│   ├── load-external-providers.ts  # Dynamic extension loading
-│   └── ...
-└── styles/               # Global SCSS (variables, mixins, animations)
-```
-
-### Extension System
-
-The Agents Manager supports plugin extensions via a dynamic provider system. Providers are registered by PHP filters and loaded at runtime.
-
-**Loading flow:**
-1. PHP filter `agents_manager_agent_providers` registers provider module URLs, injected as `agentsManagerData.agentProviders`.
-2. `loadExternalProviders()` (`src/utils/load-external-providers.ts`) dynamically imports each module.
-3. Each module can export: `toolProvider`, `contextProvider`, `useAbilitiesSetup`, `getEmptyViewSuggestions`, `markdownComponents`, `markdownExtensions`, and more.
-
-**Key interfaces** (defined in `src/extension-types.ts`):
-- **`ToolProvider`**: `getAbilities()` and `executeAbility(name, args)`
-- **`Ability`**: name, label, description, category, input_schema, output_schema, callback, permissionCallback, meta.annotations
-- **`ContextProvider`**: `getClientContext()` returning URL, pathname, environment, contextEntries
-
-### Agenttic Integration
-
-The package uses `@automattic/agenttic-client` and `@automattic/agenttic-ui` for the core chat runtime:
-
-- **agenttic-client**: `getAgentManager()`, `useAgentChat()`, message types, auth providers
-- **agenttic-ui**: `AgentUI`, `createMessageRenderer()`, `EmptyView`, `ImageUploader`, suggestion/markdown types
-
-### How Changes Flow to Simple/Atomic
-
-Changes in `packages/agents-manager/src/` are consumed by `apps/agents-manager/` via its webpack entry points. The app bundles the package into 8 separate JS files deployed to `widgets.wp.com/agents-manager/`. Jetpack enqueues these bundles on WordPress.com Simple and Atomic sites.
+- **Frontend** lives here (`packages/agents-manager/`) and is bundled by `apps/agents-manager/`.
+- **Backend** lives in the Jetpack monorepo at `jetpack-mu-wpcom/src/features/agents-manager/`. New API endpoints or loading contexts require changes there, not here.
+- **Extension providers** (like Big Sky) register via the PHP filter `agents_manager_agent_providers`. The loading flow crosses repos: PHP injects provider URLs → `loadExternalProviders()` dynamically imports them → they export `toolProvider`, `contextProvider`, etc. See `src/extension-types.ts` for the provider contract.
+- **Chat runtime** comes from `@automattic/agenttic-client` (hooks, auth, message types) and `@automattic/agenttic-ui` (UI components, renderers). These are external NPM packages, not in this repo.
 
 ## Testing
 
-### Unit Tests
-
 ```bash
-# Run from repo root
+# Unit tests (from repo root)
 yarn jest packages/agents-manager
+
+# Sandbox testing (Simple/Atomic/CIAB)
+cd apps/agents-manager && yarn dev --sync
+# Then visit any site — only widgets.wp.com needs sandboxing, not the site itself
 ```
 
-Test files live in `src/components/__tests__/`, `src/hooks/__tests__/`, `src/contexts/__tests__/`, and `src/utils/__tests__/`.
-
-### Sandbox Testing (Simple/Atomic/CIAB)
-
-To verify changes on Simple, Atomic, and CIAB sites you only need to sandbox `widgets.wp.com` — the sites themselves do not need sandboxing:
-
-1. Sandbox `widgets.wp.com`.
-2. Run `cd apps/agents-manager && yarn dev --sync` — this builds the webpack bundles and syncs them to your sandbox.
-3. Visit any Simple, Atomic, or CIAB site and verify the Agents Manager works correctly.
-
-See `apps/agents-manager/AGENTS.md` for more details on the build/sync layer.
-
-## PR Guidelines
-
-**Every PR touching `packages/agents-manager/`** must include testing instructions for both Calypso and Simple/Atomic/CIAB environments:
-
-### Testing Instructions Template
-
-```markdown
-## Testing Instructions
-
-### Calypso
-
-1. Run `yarn start`.
-2. Open the Agents Manager and verify [describe expected behavior].
-
-### Simple/Atomic/CIAB
-
-1. Sandbox `widgets.wp.com`.
-2. Run `cd apps/agents-manager && yarn dev --sync`.
-3. Visit any Simple, Atomic, or CIAB site (the site itself does not need sandboxing).
-4. Open the Agents Manager and verify [describe expected behavior].
-```
-
-This "always include both" rule exists because nearly everything in `packages/agents-manager/src/` flows through to the Simple/Atomic/CIAB bundles. Missing sandbox testing steps is costly; including them when not strictly needed is cheap.
+**Every PR** must include testing instructions for both Calypso (`yarn start`) and sandbox environments. See the PR template in `packages/help-center/AGENTS.md` for the pattern.
 
 ## Conventions
 
-- **i18n**: Use `@wordpress/i18n` with text domain `'__i18n_text_domain__'` for all user-facing strings. New strings won't be translated on Atomic until the next `jetpack-mu-plugin` release (twice daily).
-- **Components**: Use `@wordpress/components` and `@automattic/components` where appropriate.
-- **Data fetching**: Use TanStack Query for server state. Follow existing patterns in `src/hooks/`.
-- **Styling**: Component-scoped SCSS files (`style.scss`). Global styles and variables in `src/styles/`.
-- **Store**: Use `AGENTS_MANAGER_STORE` via `@wordpress/data` for UI state. Use `AgentsManagerContext` for session/user/site data.
+- **i18n**: Use `@wordpress/i18n` with text domain `'__i18n_text_domain__'`. This placeholder is replaced at build time.
+- **Curly quotes**: Preserve `""` `''` exactly as they appear. Do not convert to unicode escapes or ASCII equivalents.
 
-## Common Pitfalls
+## Pitfalls
 
-- **Two deployment targets**: Changes must work in both Calypso (SPA) and Simple/Atomic/CIAB (via `widgets.wp.com`). Always test both.
-- **Multiple entry points**: `apps/agents-manager/` has 8 webpack entry points for different contexts. A change may behave differently across entry points.
-- **asset.json sync limitation**: If you add or remove `@wordpress/*` dependencies, the `.asset.json` files won't sync to the sandbox because Jetpack fetches them from production. You must deploy for dependency changes to take effect on Atomic.
-- **Disconnected variants**: Some entry points have "disconnected" versions that show minimal UI (help icon link only). Make sure changes don't break these variants.
-- **Help Center replacement**: On Gutenberg pages, the Agents Manager dequeues Help Center scripts. Be aware of this interaction when debugging.
-- **Extension provider changes**: If modifying the extension system interfaces in `extension-types.ts`, coordinate with Big Sky and any other provider plugins.
+- **Two deployment targets**: Every change must work in both Calypso (SPA) and Simple/Atomic/CIAB (via `widgets.wp.com` bundles). They use different bootstrap paths.
+- **asset.json sync gap**: Adding/removing `@wordpress/*` dependencies changes `.asset.json` files, which Jetpack fetches from production — not your sandbox. Dependency changes require a deploy to take effect on Atomic.
+- **Disconnected variants**: Several entry points have `-disconnected` versions showing minimal UI. Changes to shared code can silently break these.
+- **Help Center dequeue**: On Gutenberg pages, the Agents Manager dequeues Help Center scripts to prevent duplicate UI. If debugging missing Help Center behavior, check this interaction.
+- **Extension interface changes**: Modifying `extension-types.ts` affects all provider plugins (Big Sky, etc.) across repos.

--- a/packages/agents-manager/CLAUDE.md
+++ b/packages/agents-manager/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` and `CLAUDE.md` to `packages/agents-manager/` with architecture, extension system, testing patterns, and conventions
- Add `AGENTS.md` and `CLAUDE.md` to `apps/agents-manager/` with entry points, build/deploy workflow, and sandbox testing
- Update `apps/agents-manager/README.md` with environment details (matching Help Center pattern)

These files provide AI coding agent context so tools like Claude Code and Cursor can understand the Agents Manager codebase when working on changes.

## Test plan

- [ ] Verify AGENTS.md content is accurate against current codebase
- [ ] Verify CLAUDE.md files reference AGENTS.md correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)