### PR TITLE
Dockerfile: Switch default cache mode from base to seed

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -97,7 +97,7 @@ object BuildDockerImage : BuildType({
     }
 
 	params {
-		text("cache_mode", "base", label = "Docker build cache mode", description = "How the main Docker build sources warm caches. Allowed values: base, seed, none.", allowEmpty = false)
+		text("cache_mode", "seed", label = "Docker build cache mode", description = "How the main Docker build sources warm caches. Allowed values: base, seed, none.", allowEmpty = false)
 		text("base_image", "registry.a8c.com/calypso/base:latest", label = "Base docker image", description = "Base docker image", allowEmpty = false)
 		text("cache_seed_image", "registry.a8c.com/calypso/cache-seed:latest", label = "Cache seed image", description = "Cache-only image used when cache_mode=seed", allowEmpty = false)
 		text("base_image_publish_tag", "latest", label = "Tag to use for the published base image", description = "Base docker image tag", allowEmpty = false)


### PR DESCRIPTION


Part of #

## Proposed Changes

* Flips the default `cache_mode` for the main app Docker build from `base` to `seed`. The `base` and `none` modes still work as manual overrides.


This is the next step in splitting the old base image into toolchain + cache-seed. The cache-seed image is already being published and validated in CI, so this just makes it the default path. Rolling back is easy, if we set `cache_mode=base` on the build, we're back to normal.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run builds in TeamCity comparing the two different modes.

### A. Build a preview seed

Custom run:

* Build type: `Build cache-seed preview image`
* Branch: PR branch
* leave defaults alone

Record the preview build number, for example `preview.123`.

### B. Run the control app build

Custom run:

* Build type: `Web app / Docker image`
* Branch: same branch
* Parameters:
  * `cache_mode=base`

Record the TeamCity build number, say `173500`.

### C. Run the seed app build

Custom run:

* Build type: `Web app / Docker image`
* Branch: same branch
* Parameters:
  * `cache_mode=seed`
  * `cache_seed_image=registry.a8c.com/calypso/cache-seed:preview.123`

Record the TeamCity build number, say `173501`.

### D. Compare the two produced app images locally

Pull the two images:

```bash
docker pull registry.a8c.com/calypso/app:build-173500
docker pull registry.a8c.com/calypso/app:build-173501

docker tag registry.a8c.com/calypso/app:build-173500 calypso-app-base-tc
docker tag registry.a8c.com/calypso/app:build-173501 calypso-app-seed-tc
```

Then compare final runtime image contents, excluding the two known ordering-prone JSON files first:

```bash
for mode in base-tc seed-tc; do
  docker run --rm --entrypoint "" calypso-app-$mode \
    sh -c 'find /calypso -type f \
      ! -path /calypso/build/modules.json \
      ! -path /calypso/public/chunks-map.json \
      | sort | xargs sha256sum' > /tmp/hashes-$mode.txt
done

diff -u /tmp/hashes-base-tc.txt /tmp/hashes-seed-tc.txt
```

Then compare the two JSON files canonically:

```bash
for mode in base-tc seed-tc; do
  mkdir -p /tmp/$mode
  docker run --rm --entrypoint "" calypso-app-$mode \
    sh -c 'cat /calypso/build/modules.json' > /tmp/$mode/modules.json
  docker run --rm --entrypoint "" calypso-app-$mode \
    sh -c 'cat /calypso/public/chunks-map.json' > /tmp/$mode/chunks-map.json
done

canon_jq='def norm:
  if type=="object" then to_entries|sort_by(.key)|map(.value |= norm)|from_entries
  elif type=="array" then map(norm)|sort_by(tostring)
  else .
  end;
  norm'

jq "$canon_jq" /tmp/base-tc/modules.json > /tmp/base-tc/modules.norm.json
jq "$canon_jq" /tmp/seed-tc/modules.json > /tmp/seed-tc/modules.norm.json
diff -u /tmp/base-tc/modules.norm.json /tmp/seed-tc/modules.norm.json

jq "$canon_jq" /tmp/base-tc/chunks-map.json > /tmp/base-tc/chunks-map.norm.json
jq "$canon_jq" /tmp/seed-tc/chunks-map.json > /tmp/seed-tc/chunks-map.norm.json
diff -u /tmp/base-tc/chunks-map.norm.json /tmp/seed-tc/chunks-map.norm.json
```

I have done extensive local and CI comparison testing between the base and seed paths. The resulting app images are functionally identical.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
