### PR TITLE
Plans page: fix display of current plan price when an introductory offer is active

### DIFF
--- a/packages/api-core/src/upgrades/types.ts
+++ b/packages/api-core/src/upgrades/types.ts
@@ -8,6 +8,7 @@ export interface RefundOptions {
 
 export interface RawPurchaseIntroductoryOffer {
 	cost_per_interval: number;
+	cost_per_interval_integer: number;
 	end_date: string;
 	interval_count: number;
 	interval_unit: string;

--- a/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
@@ -117,6 +117,7 @@ const usePricingMetaForGridPlans = ( {
 					discountedPrice: Plans.PlanPricing[ 'discountedPrice' ];
 					currencyCode: Plans.PlanPricing[ 'currencyCode' ];
 					introOffer: Plans.PlanPricing[ 'introOffer' ];
+					renewalPrice?: Plans.PlanPricing[ 'originalPrice' ];
 				};
 		  }
 		| null = null;
@@ -186,17 +187,35 @@ const usePricingMetaForGridPlans = ( {
 
 					/**
 					 * Ensure the spotlight (current) plan shows the price with which the plan was purchased.
+					 * When the purchase has an active intro offer, use the intro offer price (what the
+					 * user is actually paying this billing term) instead of the renewal price.
 					 */
+					let renewalPrice: Plans.PlanPricing[ 'originalPrice' ] | undefined;
+
 					if ( purchasedPlan ) {
+						const hasActiveIntroOffer = purchasedPlan.introductoryOffer?.isWithinPeriod;
+						const currentTermPrice = hasActiveIntroOffer
+							? purchasedPlan.introductoryOffer!.costPerIntervalInteger
+							: purchasedPlan.priceInteger;
 						const isMonthly = purchasedPlan.billPeriodDays === PLAN_MONTHLY_PERIOD;
 
-						if ( isMonthly && monthlyPrice !== purchasedPlan.priceInteger ) {
-							monthlyPrice = purchasedPlan.priceInteger;
-							fullPrice = parseFloat( ( purchasedPlan.priceInteger * 12 ).toFixed( 2 ) );
-						} else if ( fullPrice !== purchasedPlan.priceInteger ) {
+						if ( isMonthly && monthlyPrice !== currentTermPrice ) {
+							monthlyPrice = currentTermPrice;
+							fullPrice = parseFloat( ( currentTermPrice * 12 ).toFixed( 2 ) );
+						} else if ( fullPrice !== currentTermPrice ) {
 							const term = getTermFromDuration( purchasedPlan.billPeriodDays ) || '';
-							monthlyPrice = calculateMonthlyPrice( term, purchasedPlan.priceInteger );
-							fullPrice = purchasedPlan.priceInteger;
+							monthlyPrice = calculateMonthlyPrice( term, currentTermPrice );
+							fullPrice = currentTermPrice;
+						}
+
+						if ( hasActiveIntroOffer ) {
+							const renewalTerm = getTermFromDuration( purchasedPlan.billPeriodDays ) || '';
+							renewalPrice = {
+								monthly: isMonthly
+									? purchasedPlan.priceInteger
+									: calculateMonthlyPrice( renewalTerm, purchasedPlan.priceInteger ),
+								full: purchasedPlan.priceInteger,
+							};
 						}
 					}
 
@@ -214,6 +233,7 @@ const usePricingMetaForGridPlans = ( {
 							currencyCode: purchasedPlan
 								? purchasedPlan?.currencyCode
 								: plan?.pricing?.currencyCode,
+							...( renewalPrice && { renewalPrice } ),
 						},
 					];
 				}
@@ -366,6 +386,7 @@ const usePricingMetaForGridPlans = ( {
 					currencyCode: planPrices?.[ planSlug ]?.currencyCode,
 					expiry: sitePlans.data?.[ planSlug ]?.expiry,
 					introOffer: planPrices?.[ planSlug ]?.introOffer,
+					renewalPrice: planPrices?.[ planSlug ]?.renewalPrice,
 				},
 			} ),
 			{} as { [ planSlug in PlanSlug ]?: Plans.PricingMetaForGridPlan }

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -146,6 +146,12 @@ export interface PricingMetaForGridPlan {
 	 */
 	introOffer?: PlanPricing[ 'introOffer' ];
 	expiry?: SitePlan[ 'expiry' ];
+	/**
+	 * The renewal price for the current plan when it differs from originalPrice
+	 * (e.g. when the current billing term has an active intro offer).
+	 * Used by renewal pricing text to show what the plan will cost after the offer ends.
+	 */
+	renewalPrice?: PlanPricing[ 'originalPrice' ];
 }
 
 export interface SitePlan {

--- a/packages/data-stores/src/purchases/lib/assembler.ts
+++ b/packages/data-stores/src/purchases/lib/assembler.ts
@@ -31,6 +31,7 @@ export function createPurchaseObject( purchase: RawPurchase ): Purchase {
 		introductoryOffer: purchase.introductory_offer
 			? {
 					costPerInterval: Number( purchase.introductory_offer.cost_per_interval ),
+					costPerIntervalInteger: Number( purchase.introductory_offer.cost_per_interval_integer ),
 					endDate: String( purchase.introductory_offer.end_date ),
 					intervalCount: Number( purchase.introductory_offer.interval_count ),
 					intervalUnit: String( purchase.introductory_offer.interval_unit ),

--- a/packages/data-stores/src/purchases/types.ts
+++ b/packages/data-stores/src/purchases/types.ts
@@ -219,6 +219,7 @@ export interface RefundOptions {
 
 export interface RawPurchaseIntroductoryOffer {
 	cost_per_interval: number;
+	cost_per_interval_integer: number;
 	end_date: string;
 	interval_count: number;
 	interval_unit: string;
@@ -232,6 +233,7 @@ export interface RawPurchaseIntroductoryOffer {
 
 export interface PurchaseIntroductoryOffer {
 	costPerInterval: number;
+	costPerIntervalInteger: number;
 	endDate: string;
 	intervalCount: number;
 	intervalUnit: string;

--- a/packages/plans-grid-next/src/hooks/data-store/get-renewal-pricing-text.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/get-renewal-pricing-text.ts
@@ -22,9 +22,10 @@ export function getRenewalPricingText( {
 	showBillingDescriptionForIncreasedRenewalPrice,
 	translate,
 }: GetRenewalPricingTextParams ): TranslateResult | null {
-	const { currencyCode, discountedPrice, originalPrice, billingPeriod, introOffer } = pricing;
+	const { currencyCode, discountedPrice, originalPrice, billingPeriod, introOffer, renewalPrice } =
+		pricing;
 
-	const monthlyPrice = originalPrice?.monthly;
+	const monthlyPrice = renewalPrice?.monthly ?? originalPrice?.monthly;
 	// Use the discounted price before the intro offer price since the discount is applied on top of it.
 	const currentFullPrice =
 		discountedPrice?.full || introOffer?.rawPrice?.full || originalPrice?.full;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [M4R73CH-1665](https://linear.app/a8c/issue/M4R73CH-1665)

## Proposed Changes

* Adjust the logic for displaying the current plan monthly price to display the introductory price if the current plan has an active introductory offer.

Before:
<img width="1288" height="359" alt="Screenshot 2026-03-24 at 20 38 54" src="https://github.com/user-attachments/assets/9a9442fc-9a38-4296-a312-4e41c7ed3c7f" />
After:
<img width="1288" height="359" alt="Screenshot 2026-03-24 at 20 39 43" src="https://github.com/user-attachments/assets/aab02051-9fa0-4dae-a484-cb914c4d087a" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To present correct information to the users.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the testing instructions from 209176-ghe-Automattic/wpcom

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
