### PR TITLE
e2e: Disable email notifications on form blocks during tests

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/all-form-fields.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/all-form-fields.ts
@@ -1,5 +1,6 @@
 import { OpenInlineInserter } from '../../pages';
 import {
+	disableFormEmailNotifications,
 	labelFormFieldBlock,
 	makeSelectorFromBlockName,
 	validatePublishedFormFields,
@@ -36,6 +37,8 @@ export class AllFormFieldsFlow implements BlockFlow {
 	 * @param {EditorContext} context The current context for the editor at the point of test execution
 	 */
 	async configure( context: EditorContext ): Promise< void > {
+		await disableFormEmailNotifications( context.page, context.addedBlockLocator );
+
 		// Determine if we are working with the refactored form fields (released June 2025)
 		const editorCanvas = await context.editorPage.getEditorCanvas();
 		const initailBlock = editorCanvas.locator( makeSelectorFromBlockName( 'Text input field' ) );

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/contact-form.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/contact-form.ts
@@ -1,4 +1,5 @@
 import {
+	disableFormEmailNotifications,
 	labelFormFieldBlock,
 	makeSelectorFromBlockName,
 	validatePublishedFormFields,
@@ -33,6 +34,8 @@ export class ContactFormFlow implements BlockFlow {
 	 * @param {EditorContext} context The current context for the editor at the point of test execution
 	 */
 	async configure( context: EditorContext ): Promise< void > {
+		await disableFormEmailNotifications( context.page, context.addedBlockLocator );
+
 		// Name and Email are common fields shared amongst all Form patterns.
 		// So let's make them unique here!
 		await labelFormFieldBlock( context.addedBlockLocator, {

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/form-ai.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/form-ai.ts
@@ -1,4 +1,8 @@
-import { makeSelectorFromBlockName, validatePublishedFormFields } from './shared';
+import {
+	disableFormEmailNotifications,
+	makeSelectorFromBlockName,
+	validatePublishedFormFields,
+} from './shared';
 import { BlockFlow, EditorContext, PublishedPostContext } from '.';
 
 interface ConfigurationData {
@@ -73,6 +77,8 @@ export class FormAiFlow implements BlockFlow {
 		await aiInputReadyLocator.fill( this.configurationData.prompt );
 		await sendButtonLocator.click();
 		await aiInputBusyLocator.waitFor( { state: 'detached' } );
+		await disableFormEmailNotifications( context.page, context.addedBlockLocator );
+
 		// Grab a first sample input label and submit button text to use for validation.
 		this.validationData = {
 			sampleInputLabel: await this.getFirstTextFieldLabel( context ),

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts
@@ -1,5 +1,6 @@
 import {
 	ExpectedFormField,
+	disableFormEmailNotifications,
 	labelFormFieldBlock,
 	makeSelectorFromBlockName,
 	validatePublishedFormFields,
@@ -54,6 +55,8 @@ export class FormPatternsFlow implements BlockFlow {
 			)
 			.getAttribute( 'id' );
 		const newParentBlockLocator = editorCanvas.locator( `#${ newParentBlockId }` );
+
+		await disableFormEmailNotifications( context.page, newParentBlockLocator );
 
 		// We now have to double-click to edit the pattern-added form.
 		// (or click an "Edit section" sidebar button, but this is easier)

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/shared/block-helpers.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/shared/block-helpers.ts
@@ -1,4 +1,4 @@
-import { Locator, Page } from 'playwright';
+import { Frame, Locator, Page } from 'playwright';
 
 export interface ExpectedFormField {
 	type: 'textbox' | 'checkbox' | 'radio' | 'combobox' | 'button';
@@ -36,6 +36,26 @@ export async function validatePublishedFormFields(
 		const { type, accessibleName } = expectedField;
 		await publishedPage.getByRole( type, { name: accessibleName } ).first().waitFor();
 	}
+}
+
+/**
+ * Disables email notifications on a form block by updating its attributes
+ * via the WordPress block editor data store.
+ *
+ * @param {Frame | Page} editorFrame The editor frame or page to evaluate in.
+ * @param {Locator} blockLocator Locator for the form block.
+ */
+export async function disableFormEmailNotifications(
+	editorFrame: Frame | Page,
+	blockLocator: Locator
+) {
+	const domId = await blockLocator.getAttribute( 'id' );
+	const clientId = domId?.replace( /^block-/, '' );
+	await editorFrame.evaluate( ( cid ) => {
+		( window as any ).wp.data
+			.dispatch( 'core/block-editor' )
+			.updateBlockAttributes( cid, { emailNotifications: false } );
+	}, clientId );
 }
 
 /**


### PR DESCRIPTION
## Proposed Changes

* Add a shared `disableFormEmailNotifications` helper that uses the block editor data store (`wp.data.dispatch('core/block-editor').updateBlockAttributes`) to set `emailNotifications: false` on `jetpack/contact-form` blocks after insertion.
* Call the helper from all four form block flows: `ContactFormFlow`, `AllFormFieldsFlow`, `FormPatternsFlow`, and `FormAiFlow`.

## Why are these changes being made?

When e2e tests insert and publish form blocks, form submissions can trigger email notifications. This is unnecessary noise — the `forms__submissions.ts` spec already disables it via raw block markup, but the block flows in `blocks__jetpack-forms.ts` did not. This change ensures all form block test flows consistently disable email notifications.

## Testing Instructions

* Run the Jetpack Forms block smoke tests:
  ```
  yarn workspace wp-e2e-tests build &&   CALYPSO_BASE_URL=https://wordpress.com   VIEWPORT_NAME="mobile"   JETPACK_TARGET="wpcom-deployment"   yarn workspace wp-e2e-tests test test/e2e/specs/blocks/blocks__jetpack-forms.ts
  ```
* All 19 tests should pass.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?