### PR TITLE
MSD: remove "available until" messaging from plan removal flows

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
@@ -32,7 +32,11 @@ const CancelPurchaseFeatureList = ( {
 	const expirationDate = intlFormat( expiryDate, { dateStyle: 'medium' }, { locale: 'en-US' } );
 
 	const introCopy = ( () => {
-		if ( getPurchaseCancellationFlowType( purchase ) === CANCEL_FLOW_TYPE.REMOVE ) {
+		const flowType = getPurchaseCancellationFlowType( purchase );
+		if (
+			flowType === CANCEL_FLOW_TYPE.REMOVE ||
+			flowType === CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND
+		) {
 			return __( 'When you remove your plan, you will lose access to:' );
 		}
 		return sprintf(

--- a/client/dashboard/me/billing-purchases/cancel-purchase/time-remaining-notice.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/time-remaining-notice.tsx
@@ -2,7 +2,11 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { intlFormat, isToday, isBefore } from 'date-fns';
 import Notice from '../../../components/notice';
-import { isPartnerPurchase } from '../../../utils/purchase';
+import {
+	isPartnerPurchase,
+	getPurchaseCancellationFlowType,
+	CANCEL_FLOW_TYPE,
+} from '../../../utils/purchase';
 import type { Purchase } from '@automattic/api-core';
 
 interface TimeRemainingNoticeProps {
@@ -15,6 +19,13 @@ export default function TimeRemainingNotice( { purchase }: TimeRemainingNoticePr
 	const purchaseExpiryDate = new Date( purchase.expiry_date );
 	const now = new Date();
 	if ( isToday( purchaseExpiryDate ) || isBefore( purchaseExpiryDate, now ) ) {
+		return null;
+	}
+
+	// If the plan is being immediately removed (refund or explicit removal), don't show
+	// "available until [date]" — the plan won't be available, it's being removed now.
+	const flowType = getPurchaseCancellationFlowType( purchase );
+	if ( flowType === CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND || flowType === CANCEL_FLOW_TYPE.REMOVE ) {
 		return null;
 	}
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHE-462/
Related to https://linear.app/a8c/issue/SHILL-1773/

## Proposed changes

When cancelling a plan within the refund window, the plan will be immediately removed. This makes sure that both the "removal" and "cancel and refund" flows now correctly omit messaging that implies the subscription will remain active until a future date.

* `TimeRemainingNotice`: return null when the cancellation flow type is `CANCEL_WITH_REFUND` or `REMOVE`, so "Your plan features will be available until [date]" is no longer shown for plans being immediately removed
* `CancelPurchaseFeatureList`: extend the "When you remove your plan, you will lose access to:" heading to cover `CANCEL_WITH_REFUND` in addition to `REMOVE`, replacing the misleading "Your plan will expire on [date] and you'll lose access to:" copy

## Why are these changes being made?

The dashboard cancellation flow uses three distinct flow types: `CANCEL_AUTORENEW` (subscription stays active until expiry), `CANCEL_WITH_REFUND` (immediate removal with refund), and `REMOVE` (immediate removal, already expired or auto-renew off). Both `TimeRemainingNotice` and `CancelPurchaseFeatureList` were only checking for the `REMOVE` case, so plans cancelled within the refund window fell through to the `CANCEL_AUTORENEW` messaging path — telling users their plan features would be available until a specific future date, even though the plan was about to be removed immediately.

The fix gates the "available until" notice and the expiry-date heading on `CANCEL_AUTORENEW` only, which is the sole case where a plan genuinely remains active through the end of the billing period.

## Testing instructions
* Use a WordPress.com site with a plan purchased within the last 30 days (refund window)
* Navigate to Dashboard → Billing & Purchases → select the plan → Cancel
* Confirm that **no** "Your plan features will be available until [date]" notice appears in the cancellation flow
* Confirm the feature list heading reads "When you remove your plan, you will lose access to:" (not "Your plan will expire on [date]…")
* Verify that cancelling a plan **outside** the refund window still shows the expiry-date messaging correctly
