### PR TITLE
Store Sandbox: persist ticket in localStorage for OAuth environments

### DIFF
--- a/client/lib/store-sandbox-helper/index.tsx
+++ b/client/lib/store-sandbox-helper/index.tsx
@@ -1,15 +1,19 @@
+import config from '@automattic/calypso-config';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ToggleControl } from '@wordpress/components';
 import { useState, useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
+import store from 'store';
 import useStoreSandboxStatusQuery from 'calypso/data/store-sandbox/use-store-sandbox-status';
 import wp from 'calypso/lib/wp';
+import { GUEST_TICKET_LOCALFORAGE_KEY } from 'calypso/lib/wp/handlers/guest-sandbox-ticket';
 
 import './style.scss';
 
 interface StoreSandboxQueryResponse {
 	store_sandbox_cookie_name: string | undefined;
 	store_sandbox_expiration_time: number | undefined;
+	store_sandbox_ticket_value: string | undefined;
 	is_disabled: boolean | undefined;
 }
 
@@ -42,6 +46,16 @@ export function StoreSandboxHelper() {
 				}
 
 				if ( ! error && data ) {
+					if ( config.isEnabled( 'oauth' ) ) {
+						if ( data?.store_sandbox_ticket_value ) {
+							store.set( GUEST_TICKET_LOCALFORAGE_KEY, {
+								createdDate: Date.now(),
+								value: data.store_sandbox_ticket_value,
+							} );
+						} else if ( data?.is_disabled ) {
+							store.remove( GUEST_TICKET_LOCALFORAGE_KEY );
+						}
+					}
 					setIsStoreSandboxed( !! data?.store_sandbox_cookie_name );
 					window.location.reload();
 				}


### PR DESCRIPTION
Part of SHILL-1804

Requires 209203-ghe-Automattic/wpcom

## Proposed Changes

* On OAuth environments, store the sandbox ticket value from the enable API response in localStorage under the existing `GUEST_TICKET_LOCALFORAGE_KEY`
* On disable, clear the ticket from localStorage
* The existing `injectGuestSandboxTicketHandler` middleware automatically picks up the ticket and injects it as a `store_sandbox_ticket` query param on all API requests

## Why are these changes being made?

The Store Sandbox toggle does not work on OAuth environments (`my.woo.ai`, `my.woo.localhost`). The toggle relies on a `Set-Cookie` response with `domain=.wordpress.com`, which fails on non-wordpress.com OAuth environments because:

1. The browser blocks the cookie as third-party (page origin is `woo.ai`)
2. OAuth environments use bearer tokens via XHR, not the proxy iframe that carries `.wordpress.com` cookies


The infrastructure to solve this already exists — the `guest-sandbox-ticket` handler in `client/lib/wp/handlers/guest-sandbox-ticket.js` reads a ticket from localStorage and injects it as a query param on every API request. This PR wires the toggle to store/clear the ticket there on OAuth environments. Non-OAuth environments continue to use the cookie path.

| Environment | Auth mode | Before | After |
|---|---|---|---|
| `my.localhost:3000` | Proxy (cookie) | Works | Works (no change) |
| `my.woo.localhost:3000` | OAuth | Broken | Works via localStorage |
| `my.wordpress.com` | Proxy (cookie) | Works | Works (no change) |
| `my.woo.ai` | OAuth | Broken | Works via localStorage |

## Testing Instructions

see: 209203-ghe-Automattic/wpcom

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?