### PR TITLE
Dockerfile.toolchain: Publish ci-e2e and ci-wpcom under their canonical names

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -238,10 +238,6 @@ object BuildBaseImages : BuildType({
 				namesAndTags = """
 					registry.a8c.com/calypso/base:%image_tag%
 					registry.a8c.com/calypso/base:%build.number%
-					registry.a8c.com/calypso/ci-e2e:%image_tag%
-					registry.a8c.com/calypso/ci-e2e:%build.number%
-					registry.a8c.com/calypso/ci-wpcom:%image_tag%
-					registry.a8c.com/calypso/ci-wpcom:%build.number%
 				""".trimIndent()
 			}
 		}
@@ -293,13 +289,13 @@ object BuildBaseImages : BuildType({
 })
 
 object BuildToolchainPreviewImages : BuildType({
-	name = "Build toolchain preview images"
-	description = "Builds manual-only preview images for toolchain, ci-e2e, and ci-wpcom from Dockerfile.toolchain."
+	name = "Build toolchain images"
+	description = "Builds manual-only toolchain, ci-e2e, and ci-wpcom images from Dockerfile.toolchain and publishes the canonical ci image tags."
 
 	buildNumberPattern = "%build.prefix%.%build.counter%"
 
 	params {
-		param("build.prefix", "preview")
+		param("build.prefix", "1.0")
 		param("image_tag", "latest")
 	}
 
@@ -323,23 +319,23 @@ object BuildToolchainPreviewImages : BuildType({
 			param("dockerImage.platform", "linux")
 		}
 		dockerCommand {
-			name = "Build CI e2e preview image"
+			name = "Build CI e2e image"
 			commandType = build {
 				source = file {
 					path = "Dockerfile.toolchain"
 				}
-				namesAndTags = "registry.a8c.com/calypso/ci-e2e-toolchain:%build.number%"
+				namesAndTags = "registry.a8c.com/calypso/ci-e2e:%build.number%"
 				commandArgs = "--target ci-e2e $commonArgs"
 			}
 			param("dockerImage.platform", "linux")
 		}
 		dockerCommand {
-			name = "Build CI wpcom preview image"
+			name = "Build CI wpcom image"
 			commandType = build {
 				source = file {
 					path = "Dockerfile.toolchain"
 				}
-				namesAndTags = "registry.a8c.com/calypso/ci-wpcom-toolchain:%build.number%"
+				namesAndTags = "registry.a8c.com/calypso/ci-wpcom:%build.number%"
 				commandArgs = "--target ci-wpcom $commonArgs"
 			}
 			param("dockerImage.platform", "linux")
@@ -355,12 +351,12 @@ object BuildToolchainPreviewImages : BuildType({
 			""".trimIndent()
 		}
 		script {
-			name = "Smoke test CI e2e preview image"
+			name = "Smoke test CI e2e image"
 			scriptContent = """
 				#!/usr/bin/env bash
 				set -euo pipefail
 
-				docker run --rm --entrypoint /bin/bash registry.a8c.com/calypso/ci-e2e-toolchain:%build.number% -lc '
+				docker run --rm --entrypoint /bin/bash registry.a8c.com/calypso/ci-e2e:%build.number% -lc '
 					xvfb-run --help >/dev/null &&
 					aws --version &&
 					dpkg -s fonts-noto-cjk fonts-noto-core libgtk-3-0 libgbm1 libnss3 >/dev/null
@@ -368,17 +364,17 @@ object BuildToolchainPreviewImages : BuildType({
 			""".trimIndent()
 		}
 		script {
-			name = "Smoke test CI wpcom preview image"
+			name = "Smoke test CI wpcom image"
 			scriptContent = """
 				#!/usr/bin/env bash
 				set -euo pipefail
 
-				docker run --rm --entrypoint /bin/bash registry.a8c.com/calypso/ci-wpcom-toolchain:%build.number% -lc \
+				docker run --rm --entrypoint /bin/bash registry.a8c.com/calypso/ci-wpcom:%build.number% -lc \
 					'php -v && composer --version && docker-compose version && sentry-cli --version'
 			""".trimIndent()
 		}
 		script {
-			name = "Retag preview images for publish"
+			name = "Retag images for publish"
 			scriptContent = """
 				#!/usr/bin/env bash
 				set -euo pipefail
@@ -405,20 +401,20 @@ object BuildToolchainPreviewImages : BuildType({
 				}
 
 				retag_image registry.a8c.com/calypso/toolchain
-				retag_image registry.a8c.com/calypso/ci-e2e-toolchain
-				retag_image registry.a8c.com/calypso/ci-wpcom-toolchain
+				retag_image registry.a8c.com/calypso/ci-e2e
+				retag_image registry.a8c.com/calypso/ci-wpcom
 			""".trimIndent()
 		}
 		dockerCommand {
-			name = "Push preview images"
+			name = "Push images"
 			commandType = push {
 				namesAndTags = """
 					registry.a8c.com/calypso/toolchain:%image_tag%
 					registry.a8c.com/calypso/toolchain:%build.number%
-					registry.a8c.com/calypso/ci-e2e-toolchain:%image_tag%
-					registry.a8c.com/calypso/ci-e2e-toolchain:%build.number%
-					registry.a8c.com/calypso/ci-wpcom-toolchain:%image_tag%
-					registry.a8c.com/calypso/ci-wpcom-toolchain:%build.number%
+					registry.a8c.com/calypso/ci-e2e:%image_tag%
+					registry.a8c.com/calypso/ci-e2e:%build.number%
+					registry.a8c.com/calypso/ci-wpcom:%image_tag%
+					registry.a8c.com/calypso/ci-wpcom:%build.number%
 				""".trimIndent()
 			}
 		}

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -295,7 +295,7 @@ object BuildToolchainPreviewImages : BuildType({
 	buildNumberPattern = "%build.prefix%.%build.counter%"
 
 	params {
-		param("build.prefix", "1.0")
+		param("build.prefix", "2.0")
 		param("image_tag", "latest")
 	}
 


### PR DESCRIPTION
Switch the manual toolchain image publisher to push `ci-e2e` and `ci-wpcom` under their existing canonical registry names instead of the temporary `ci-e2e-toolchain` and `ci-wpcom-toolchain` names.

After this lands, a manual run of `Build toolchain images` publishes:

- `registry.a8c.com/calypso/toolchain:{build,latest}`
- `registry.a8c.com/calypso/ci-e2e:{build,latest}`
- `registry.a8c.com/calypso/ci-wpcom:{build,latest}`

###  Why

This is the next step in moving away from "Build Base Images" after flipping the app build to `cache_mode=seed`. The toolchain-based CI images have been validated in TeamCity under the temporary `*-toolchain` tags. Publishing under the standard names lets consumers use the images without needed to be customized.

## Proposed Changes

*

## Why are these changes being made?

*

## Testing Instructions

Run some TC builds with the new images

*  E2E Tests (Playwright Test) - Overrode both docker_image=registry.a8c.com/calypso/toolchain:preview.3 docker_image_e2e=registry.a8c.com/calypso/ci-e2e-toolchain:preview.3, worked fine
* Build Calypso Apps - overrode docker_image to `registry.a8c.com/calypso/ci-wpcom-toolchain:preview.3`, worked fine
* Check code style - override docker_image to `registry.a8c.com/calypso/toolchain:preview.3`, worked fine

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
