### PR TITLE
TeamCity: Point default docker_image to toolchain

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -72,7 +72,7 @@ project {
 		text("JEST_E2E_WORKERS", "50%", label = "Jest max workers", description = "Number or percent of cores to use when running E2E tests.", allowEmpty = true)
 		password("matticbot_oauth_token", "credentialsJSON:34cb38a5-9124-41c4-8497-74ed6289d751", display = ParameterDisplay.HIDDEN)
 		text("env.CHILD_CONCURRENCY", "15", label = "Yarn child concurrency", description = "How many packages yarn builds in parallel", allowEmpty = true)
-		text("docker_image", "registry.a8c.com/calypso/base:latest", label = "Docker image", description = "Default Docker image used to run builds", allowEmpty = true)
+		text("docker_image", "registry.a8c.com/calypso/toolchain:latest", label = "Docker image", description = "Default Docker image used to run builds", allowEmpty = true)
 		text("docker_image_e2e", "registry.a8c.com/calypso/ci-e2e:latest", label = "Docker e2e image", description = "Docker image used to run e2e tests", allowEmpty = true)
 		text("env.DOCKER_BUILDKIT", "1", label = "Enable Docker BuildKit", description = "Enables BuildKit (faster image generation). Values 0 or 1", allowEmpty = true)
 		password("mc_post_root", "credentialsJSON:2f764583-d399-4d5f-8ee1-06f68ef2e2a6", display = ParameterDisplay.HIDDEN )


### PR DESCRIPTION
## What

Changes the root `docker_image` parameter from `registry.a8c.com/calypso/base:latest` to `registry.a8c.com/calypso/toolchain:latest`. This is the image used by generic `bashNodeScript` steps (unit tests, linting, smart build launcher, `mergeTrunk()`, etc).


## Why

This is the last consumer of `base:latest` outside of the app build's `cache_mode=base` fallback. Once this lands, generic CI jobs no longer depend on `Dockerfile.base` at all, which clears the path to retire `BuildBaseImages` and its 6-hour cron.

## Rollout plan

This is step 2 of 3:

1. Publish canonical `ci-e2e` / `ci-wpcom` from `Dockerfile.toolchain` ( #109534 )
2. **This PR** — point generic CI at `toolchain`
3. Remove `cache_mode=base`, `update-base-cache`, and `BuildBaseImages`

If anything breaks, reverting this one line restores the old behavior. You can also manually retag `base:latest` as `toolchain:latest` via the registry if needed before a revert lands.

## Testing

- Confirm `docker_image` points to `registry.a8c.com/calypso/toolchain:latest` in the diff
- Confirm `docker_image_e2e` is unchanged
- After merge, watch a round of these generic CI consumers:
  - `Check code style`
  - `Smart Build Launcher`
  - `Web app / Unit tests`
  - `Web app / Code style`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
