### PR TITLE
MSD: Replace React.Children manipulation with render prop in sidebar

### DIFF
--- a/client/dashboard/app/responsive-sidebar/sidebar.tsx
+++ b/client/dashboard/app/responsive-sidebar/sidebar.tsx
@@ -104,6 +104,7 @@ function PrimaryMenuSidebar() {
 						{ __( 'Scheduled updates' ) }
 					</SidebarMenuItem>
 					<SidebarMenuItem
+						icon={ menuDot }
 						href={ wpcomLink( '/plugins' ) }
 						target="_blank"
 						rel="noopener noreferrer"

--- a/client/dashboard/app/responsive-sidebar/sidebar.tsx
+++ b/client/dashboard/app/responsive-sidebar/sidebar.tsx
@@ -96,20 +96,26 @@ function PrimaryMenuSidebar() {
 			) }
 			{ supports.plugins && (
 				<SidebarExpandableMenuItem label={ __( 'Plugins' ) } icon={ plugins } to="/plugins">
-					<SidebarMenuItem to="/plugins/manage">{ __( 'Manage plugins' ) }</SidebarMenuItem>
-					<SidebarMenuItem to="/plugins/scheduled-updates">
-						{ __( 'Scheduled updates' ) }
-					</SidebarMenuItem>
-					<SidebarMenuItem
-						href={ wpcomLink( '/plugins' ) }
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						<HStack justify="flex-start" spacing={ 1 }>
-							<span>{ __( 'Browse plugins' ) }</span>
-							<span aria-label={ __( '(opens in a new tab)' ) }>&#8599;</span>
-						</HStack>
-					</SidebarMenuItem>
+					{ ( dotIcon ) => (
+						<>
+							<SidebarMenuItem icon={ dotIcon } to="/plugins/manage">
+								{ __( 'Manage plugins' ) }
+							</SidebarMenuItem>
+							<SidebarMenuItem icon={ dotIcon } to="/plugins/scheduled-updates">
+								{ __( 'Scheduled updates' ) }
+							</SidebarMenuItem>
+							<SidebarMenuItem
+								href={ wpcomLink( '/plugins' ) }
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								<HStack justify="flex-start" spacing={ 1 }>
+									<span>{ __( 'Browse plugins' ) }</span>
+									<span aria-label={ __( '(opens in a new tab)' ) }>&#8599;</span>
+								</HStack>
+							</SidebarMenuItem>
+						</>
+					) }
 				</SidebarExpandableMenuItem>
 			) }
 			{ supports.themes && (

--- a/client/dashboard/app/responsive-sidebar/sidebar.tsx
+++ b/client/dashboard/app/responsive-sidebar/sidebar.tsx
@@ -3,6 +3,7 @@ import { __experimentalHStack as HStack, Navigator } from '@wordpress/components
 import { __, sprintf } from '@wordpress/i18n';
 import { brush, copy, envelope, globe, plugins } from '@wordpress/icons';
 import { useRef } from 'react';
+import { menuDot } from '../../components/icons';
 import RouterLinkButton from '../../components/router-link-button';
 import { SidebarExpandableMenuItem, SidebarMenu, SidebarMenuItem } from '../../components/sidebar';
 import DomainSidebar from '../../domains/domain-sidebar';
@@ -96,26 +97,22 @@ function PrimaryMenuSidebar() {
 			) }
 			{ supports.plugins && (
 				<SidebarExpandableMenuItem label={ __( 'Plugins' ) } icon={ plugins } to="/plugins">
-					{ ( dotIcon ) => (
-						<>
-							<SidebarMenuItem icon={ dotIcon } to="/plugins/manage">
-								{ __( 'Manage plugins' ) }
-							</SidebarMenuItem>
-							<SidebarMenuItem icon={ dotIcon } to="/plugins/scheduled-updates">
-								{ __( 'Scheduled updates' ) }
-							</SidebarMenuItem>
-							<SidebarMenuItem
-								href={ wpcomLink( '/plugins' ) }
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								<HStack justify="flex-start" spacing={ 1 }>
-									<span>{ __( 'Browse plugins' ) }</span>
-									<span aria-label={ __( '(opens in a new tab)' ) }>&#8599;</span>
-								</HStack>
-							</SidebarMenuItem>
-						</>
-					) }
+					<SidebarMenuItem icon={ menuDot } to="/plugins/manage">
+						{ __( 'Manage plugins' ) }
+					</SidebarMenuItem>
+					<SidebarMenuItem icon={ menuDot } to="/plugins/scheduled-updates">
+						{ __( 'Scheduled updates' ) }
+					</SidebarMenuItem>
+					<SidebarMenuItem
+						href={ wpcomLink( '/plugins' ) }
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						<HStack justify="flex-start" spacing={ 1 }>
+							<span>{ __( 'Browse plugins' ) }</span>
+							<span aria-label={ __( '(opens in a new tab)' ) }>&#8599;</span>
+						</HStack>
+					</SidebarMenuItem>
 				</SidebarExpandableMenuItem>
 			) }
 			{ supports.themes && (

--- a/client/dashboard/components/icons/index.tsx
+++ b/client/dashboard/components/icons/index.tsx
@@ -1,4 +1,10 @@
-import { SVG, Path } from '@wordpress/primitives';
+import { SVG, Path, Circle } from '@wordpress/primitives';
+
+export const menuDot = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+		<Circle cx="12" cy="12" r="2" fill="currentColor" />
+	</SVG>
+);
 
 export const production = (
 	<SVG width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/client/dashboard/components/sidebar/sidebar-expandable-menu-item.tsx
+++ b/client/dashboard/components/sidebar/sidebar-expandable-menu-item.tsx
@@ -11,17 +11,11 @@ import { useAnalytics } from '../../app/analytics';
 
 import './sidebar-expandable-menu-item.scss';
 
-const dotIcon = (
-	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
-		<circle cx="12" cy="12" r="2" fill="currentColor" />
-	</svg>
-);
-
 interface SidebarExpandableMenuItemProps {
 	label: string;
 	icon?: React.JSX.Element;
 	to: string;
-	children: ( icon: React.JSX.Element ) => React.ReactNode;
+	children: React.ReactNode;
 }
 
 export function SidebarExpandableMenuItem( {
@@ -73,7 +67,7 @@ export function SidebarExpandableMenuItem( {
 				inert={ ! isOpen ? 'true' : undefined }
 			>
 				<VStack id={ panelId } spacing={ 1 }>
-					{ children( dotIcon ) }
+					{ children }
 				</VStack>
 			</div>
 		</VStack>

--- a/client/dashboard/components/sidebar/sidebar-expandable-menu-item.tsx
+++ b/client/dashboard/components/sidebar/sidebar-expandable-menu-item.tsx
@@ -6,9 +6,8 @@ import {
 } from '@wordpress/components';
 import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
 import clsx from 'clsx';
-import { Children, cloneElement, isValidElement, useId, useState, useEffect } from 'react';
+import { useId, useState, useEffect } from 'react';
 import { useAnalytics } from '../../app/analytics';
-import { SidebarMenuItem } from './sidebar-menu-item';
 
 import './sidebar-expandable-menu-item.scss';
 
@@ -22,7 +21,7 @@ interface SidebarExpandableMenuItemProps {
 	label: string;
 	icon?: React.JSX.Element;
 	to: string;
-	children: React.ReactNode;
+	children: ( icon: React.JSX.Element ) => React.ReactNode;
 }
 
 export function SidebarExpandableMenuItem( {
@@ -74,12 +73,7 @@ export function SidebarExpandableMenuItem( {
 				inert={ ! isOpen ? 'true' : undefined }
 			>
 				<VStack id={ panelId } spacing={ 1 }>
-					{ Children.map( children, ( child ) => {
-						if ( isValidElement( child ) && child.type === SidebarMenuItem && ! child.props.icon ) {
-							return cloneElement( child as React.ReactElement, { icon: dotIcon } );
-						}
-						return child;
-					} ) }
+					{ children( dotIcon ) }
 				</VStack>
 			</div>
 		</VStack>

--- a/client/dashboard/sites/site-sidebar/index.tsx
+++ b/client/dashboard/sites/site-sidebar/index.tsx
@@ -28,6 +28,7 @@ import {
 	siteDomainsRoute,
 	siteSettingsRoute,
 } from '../../app/router/sites';
+import { menuDot } from '../../components/icons';
 import {
 	SidebarBackButton,
 	SidebarExpandableMenuItem,
@@ -140,19 +141,15 @@ function SiteMenuSidebar( { site }: { site: Site } ) {
 					icon={ formatListBullets }
 					to={ `/sites/${ siteSlug }/logs` }
 				>
-					{ ( dotIcon ) => (
-						<>
-							<SidebarMenuItem icon={ dotIcon } to={ `/sites/${ siteSlug }/logs/activity` }>
-								{ __( 'Activity' ) }
-							</SidebarMenuItem>
-							<SidebarMenuItem icon={ dotIcon } to={ `/sites/${ siteSlug }/logs/php` }>
-								{ __( 'PHP errors' ) }
-							</SidebarMenuItem>
-							<SidebarMenuItem icon={ dotIcon } to={ `/sites/${ siteSlug }/logs/server` }>
-								{ __( 'Web server' ) }
-							</SidebarMenuItem>
-						</>
-					) }
+					<SidebarMenuItem icon={ menuDot } to={ `/sites/${ siteSlug }/logs/activity` }>
+						{ __( 'Activity' ) }
+					</SidebarMenuItem>
+					<SidebarMenuItem icon={ menuDot } to={ `/sites/${ siteSlug }/logs/php` }>
+						{ __( 'PHP errors' ) }
+					</SidebarMenuItem>
+					<SidebarMenuItem icon={ menuDot } to={ `/sites/${ siteSlug }/logs/server` }>
+						{ __( 'Web server' ) }
+					</SidebarMenuItem>
 				</SidebarExpandableMenuItem>
 			) }
 			{ isAvailable( siteScanRoute ) &&
@@ -163,16 +160,12 @@ function SiteMenuSidebar( { site }: { site: Site } ) {
 						icon={ shield }
 						to={ `/sites/${ siteSlug }/scan` }
 					>
-						{ ( dotIcon ) => (
-							<>
-								<SidebarMenuItem icon={ dotIcon } to={ `/sites/${ siteSlug }/scan/active` }>
-									{ __( 'Active threats' ) }
-								</SidebarMenuItem>
-								<SidebarMenuItem icon={ dotIcon } to={ `/sites/${ siteSlug }/scan/history` }>
-									{ __( 'History' ) }
-								</SidebarMenuItem>
-							</>
-						) }
+						<SidebarMenuItem icon={ menuDot } to={ `/sites/${ siteSlug }/scan/active` }>
+							{ __( 'Active threats' ) }
+						</SidebarMenuItem>
+						<SidebarMenuItem icon={ menuDot } to={ `/sites/${ siteSlug }/scan/history` }>
+							{ __( 'History' ) }
+						</SidebarMenuItem>
 					</SidebarExpandableMenuItem>
 				) : (
 					<SidebarMenuItem icon={ shield } to={ `/sites/${ siteSlug }/scan` }>

--- a/client/dashboard/sites/site-sidebar/index.tsx
+++ b/client/dashboard/sites/site-sidebar/index.tsx
@@ -140,15 +140,19 @@ function SiteMenuSidebar( { site }: { site: Site } ) {
 					icon={ formatListBullets }
 					to={ `/sites/${ siteSlug }/logs` }
 				>
-					<SidebarMenuItem to={ `/sites/${ siteSlug }/logs/activity` }>
-						{ __( 'Activity' ) }
-					</SidebarMenuItem>
-					<SidebarMenuItem to={ `/sites/${ siteSlug }/logs/php` }>
-						{ __( 'PHP errors' ) }
-					</SidebarMenuItem>
-					<SidebarMenuItem to={ `/sites/${ siteSlug }/logs/server` }>
-						{ __( 'Web server' ) }
-					</SidebarMenuItem>
+					{ ( dotIcon ) => (
+						<>
+							<SidebarMenuItem icon={ dotIcon } to={ `/sites/${ siteSlug }/logs/activity` }>
+								{ __( 'Activity' ) }
+							</SidebarMenuItem>
+							<SidebarMenuItem icon={ dotIcon } to={ `/sites/${ siteSlug }/logs/php` }>
+								{ __( 'PHP errors' ) }
+							</SidebarMenuItem>
+							<SidebarMenuItem icon={ dotIcon } to={ `/sites/${ siteSlug }/logs/server` }>
+								{ __( 'Web server' ) }
+							</SidebarMenuItem>
+						</>
+					) }
 				</SidebarExpandableMenuItem>
 			) }
 			{ isAvailable( siteScanRoute ) &&
@@ -159,12 +163,16 @@ function SiteMenuSidebar( { site }: { site: Site } ) {
 						icon={ shield }
 						to={ `/sites/${ siteSlug }/scan` }
 					>
-						<SidebarMenuItem to={ `/sites/${ siteSlug }/scan/active` }>
-							{ __( 'Active threats' ) }
-						</SidebarMenuItem>
-						<SidebarMenuItem to={ `/sites/${ siteSlug }/scan/history` }>
-							{ __( 'History' ) }
-						</SidebarMenuItem>
+						{ ( dotIcon ) => (
+							<>
+								<SidebarMenuItem icon={ dotIcon } to={ `/sites/${ siteSlug }/scan/active` }>
+									{ __( 'Active threats' ) }
+								</SidebarMenuItem>
+								<SidebarMenuItem icon={ dotIcon } to={ `/sites/${ siteSlug }/scan/history` }>
+									{ __( 'History' ) }
+								</SidebarMenuItem>
+							</>
+						) }
 					</SidebarExpandableMenuItem>
 				) : (
 					<SidebarMenuItem icon={ shield } to={ `/sites/${ siteSlug }/scan` }>


### PR DESCRIPTION
Fixes DOTMSD-1161

## Proposed Changes

* Remove `React.Children.map`/`cloneElement` from `SidebarExpandableMenuItem` — accept plain `children` instead.
* Extract a shared `menuDot` icon to `components/icons` and use it directly at call sites (`sidebar.tsx`, `site-sidebar/index.tsx`) instead of passing it via render prop or cloneElement.

## Why are these changes being made?

* `cloneElement` is a [legacy API](https://react.dev/reference/react/cloneElement) — the React docs recommend alternatives. Using plain children with an explicit icon import is simpler, more explicit, and type-safe.

## Testing Instructions

* Open the MSD sidebar with the `dashboard/omnibar` feature flag **enabled**, expand "Plugins" and "Logs" / "Scan" sub-menus, verify dot icons still render on child items.
* Repeat with the `dashboard/omnibar` feature flag **disabled**.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?