### PR TITLE
MSD: Bridge omnibar click handlers to dashboard app

### DIFF
--- a/client/dashboard/app/boot.tsx
+++ b/client/dashboard/app/boot.tsx
@@ -13,6 +13,7 @@ import wpcom from 'calypso/lib/wp';
 import isDashboardEnv from '../utils/is-dashboard-env';
 import { handleOAuthCallback } from './auth/oauth-callback';
 import { loadPreferencesHelper } from './dev-tools/preferences';
+import { createOmnibarEvents } from './interim-omnibar/click-handlers';
 import Layout from './layout';
 import limitTotalSnackbars from './snackbars/limit-total-snackbars';
 import type { AppConfig } from './context';
@@ -45,12 +46,16 @@ function boot( config: AppConfig ) {
 	}
 	const root = createRoot( rootElement );
 
-	if ( isEnabled( 'dashboard/omnibar' ) ) {
-		import( './interim-omnibar' ).then( ( m ) => m.default() ).catch( captureException );
+	const omnibarEvents = isEnabled( 'dashboard/omnibar' ) ? createOmnibarEvents() : null;
+
+	if ( omnibarEvents ) {
+		import( './interim-omnibar' )
+			.then( ( m ) => m.default( omnibarEvents ) )
+			.catch( captureException );
 	}
 
 	persistQueryClientPromise.then( () => {
-		root.render( <Layout config={ config } /> );
+		root.render( <Layout config={ config } omnibarEvents={ omnibarEvents } /> );
 	} );
 }
 

--- a/client/dashboard/app/boot.tsx
+++ b/client/dashboard/app/boot.tsx
@@ -13,7 +13,7 @@ import wpcom from 'calypso/lib/wp';
 import isDashboardEnv from '../utils/is-dashboard-env';
 import { handleOAuthCallback } from './auth/oauth-callback';
 import { loadPreferencesHelper } from './dev-tools/preferences';
-import { createOmnibarEvents } from './interim-omnibar/click-handlers';
+import { omnibarEvents } from './interim-omnibar/click-handlers';
 import Layout from './layout';
 import limitTotalSnackbars from './snackbars/limit-total-snackbars';
 import type { AppConfig } from './context';
@@ -46,16 +46,14 @@ function boot( config: AppConfig ) {
 	}
 	const root = createRoot( rootElement );
 
-	const omnibarEvents = isEnabled( 'dashboard/omnibar' ) ? createOmnibarEvents() : null;
-
-	if ( omnibarEvents ) {
+	if ( isEnabled( 'dashboard/omnibar' ) ) {
 		import( './interim-omnibar' )
 			.then( ( m ) => m.default( omnibarEvents ) )
 			.catch( captureException );
 	}
 
 	persistQueryClientPromise.then( () => {
-		root.render( <Layout config={ config } omnibarEvents={ omnibarEvents } /> );
+		root.render( <Layout config={ config } /> );
 	} );
 }
 

--- a/client/dashboard/app/interim-omnibar/click-handlers.ts
+++ b/client/dashboard/app/interim-omnibar/click-handlers.ts
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 type Listener< T = void > = ( payload: T ) => void;
 
@@ -18,25 +18,19 @@ function createOmnibarEvent< T = void >() {
 	};
 }
 
-export function createOmnibarEvents() {
-	return {
-		mobileMenu: createOmnibarEvent(),
-		notifications: createOmnibarEvent(),
-		linkClick: createOmnibarEvent< { href: string; event: MouseEvent } >(),
-	};
-}
+export const omnibarEvents = {
+	mobileMenu: createOmnibarEvent(),
+	notifications: createOmnibarEvent(),
+	linkClick: createOmnibarEvent< { href: string; event: MouseEvent } >(),
+};
 
-export type OmnibarEvents = ReturnType< typeof createOmnibarEvents >;
+export type OmnibarEvents = typeof omnibarEvents;
 
 type EventPayload< K extends keyof OmnibarEvents > = Parameters<
 	OmnibarEvents[ K ][ 'emit' ]
 > extends [ infer P ]
 	? P
 	: void;
-
-const OmnibarEventsContext = createContext< OmnibarEvents | null >( null );
-
-export const OmnibarEventsProvider = OmnibarEventsContext.Provider;
 
 /**
  * Subscribe to an omnibar event. The callback fires whenever the named event
@@ -46,19 +40,15 @@ export function useOmnibarEvent< K extends keyof OmnibarEvents >(
 	name: K,
 	callback: ( payload: EventPayload< K > ) => void
 ) {
-	const events = useContext( OmnibarEventsContext );
 	const callbackRef = useRef( callback );
 	useEffect( () => {
 		callbackRef.current = callback;
 	} );
 
 	useEffect( () => {
-		if ( ! events ) {
-			return;
-		}
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		return events[ name ].subscribe( ( payload: any ) => {
+		return omnibarEvents[ name ].subscribe( ( payload: any ) => {
 			callbackRef.current( payload );
 		} );
-	}, [ events, name ] );
+	}, [ name ] );
 }

--- a/client/dashboard/app/interim-omnibar/click-handlers.ts
+++ b/client/dashboard/app/interim-omnibar/click-handlers.ts
@@ -1,0 +1,54 @@
+import { createContext, useContext, useEffect, useRef } from 'react';
+
+type Listener = () => void;
+
+function createOmnibarEvent() {
+	const listeners = new Set< Listener >();
+	return {
+		emit() {
+			listeners.forEach( ( fn ) => fn() );
+		},
+		subscribe( fn: Listener ) {
+			listeners.add( fn );
+			return () => {
+				listeners.delete( fn );
+			};
+		},
+	};
+}
+
+export function createOmnibarEvents() {
+	return {
+		mobileMenu: createOmnibarEvent(),
+		notifications: createOmnibarEvent(),
+	};
+}
+
+export type OmnibarEvents = ReturnType< typeof createOmnibarEvents >;
+
+const OmnibarEventsContext = createContext< OmnibarEvents | null >( null );
+
+export const OmnibarEventsProvider = OmnibarEventsContext.Provider;
+
+/**
+ * Subscribe to an omnibar event. The callback fires whenever the named event
+ * is emitted from the interim omnibar. No-ops when the omnibar is disabled.
+ */
+export function useOmnibarEvent( name: keyof OmnibarEvents, callback: () => void ) {
+	const events = useContext( OmnibarEventsContext );
+	const callbackRef = useRef( callback );
+	callbackRef.current = callback;
+
+	useEffect( () => {
+		if ( ! events ) {
+			return;
+		}
+		// Defer to a microtask so the callback runs after the current click
+		// handler but before any macrotasks (e.g. Popover's setTimeout(0)
+		// blur-close). This prevents focus-outside handlers from racing
+		// with our toggle.
+		return events[ name ].subscribe( () => {
+			Promise.resolve().then( () => callbackRef.current() );
+		} );
+	}, [ events, name ] );
+}

--- a/client/dashboard/app/interim-omnibar/click-handlers.ts
+++ b/client/dashboard/app/interim-omnibar/click-handlers.ts
@@ -48,7 +48,9 @@ export function useOmnibarEvent< K extends keyof OmnibarEvents >(
 ) {
 	const events = useContext( OmnibarEventsContext );
 	const callbackRef = useRef( callback );
-	callbackRef.current = callback;
+	useEffect( () => {
+		callbackRef.current = callback;
+	} );
 
 	useEffect( () => {
 		if ( ! events ) {

--- a/client/dashboard/app/interim-omnibar/click-handlers.ts
+++ b/client/dashboard/app/interim-omnibar/click-handlers.ts
@@ -1,14 +1,15 @@
 import { createContext, useContext, useEffect, useRef } from 'react';
 
-type Listener = () => void;
+type Listener< T = void > = ( payload: T ) => void;
 
-function createOmnibarEvent() {
-	const listeners = new Set< Listener >();
+function createOmnibarEvent< T = void >() {
+	const listeners = new Set< Listener< T > >();
 	return {
-		emit() {
-			listeners.forEach( ( fn ) => fn() );
+		emit( ...args: T extends void ? [] : [ T ] ) {
+			const payload = args[ 0 ] as T;
+			listeners.forEach( ( fn ) => fn( payload ) );
 		},
-		subscribe( fn: Listener ) {
+		subscribe( fn: Listener< T > ) {
 			listeners.add( fn );
 			return () => {
 				listeners.delete( fn );
@@ -21,10 +22,17 @@ export function createOmnibarEvents() {
 	return {
 		mobileMenu: createOmnibarEvent(),
 		notifications: createOmnibarEvent(),
+		linkClick: createOmnibarEvent< { href: string; event: MouseEvent } >(),
 	};
 }
 
 export type OmnibarEvents = ReturnType< typeof createOmnibarEvents >;
+
+type EventPayload< K extends keyof OmnibarEvents > = Parameters<
+	OmnibarEvents[ K ][ 'emit' ]
+> extends [ infer P ]
+	? P
+	: void;
 
 const OmnibarEventsContext = createContext< OmnibarEvents | null >( null );
 
@@ -34,7 +42,10 @@ export const OmnibarEventsProvider = OmnibarEventsContext.Provider;
  * Subscribe to an omnibar event. The callback fires whenever the named event
  * is emitted from the interim omnibar. No-ops when the omnibar is disabled.
  */
-export function useOmnibarEvent( name: keyof OmnibarEvents, callback: () => void ) {
+export function useOmnibarEvent< K extends keyof OmnibarEvents >(
+	name: K,
+	callback: ( payload: EventPayload< K > ) => void
+) {
 	const events = useContext( OmnibarEventsContext );
 	const callbackRef = useRef( callback );
 	callbackRef.current = callback;
@@ -43,12 +54,9 @@ export function useOmnibarEvent( name: keyof OmnibarEvents, callback: () => void
 		if ( ! events ) {
 			return;
 		}
-		// Defer to a microtask so the callback runs after the current click
-		// handler but before any macrotasks (e.g. Popover's setTimeout(0)
-		// blur-close). This prevents focus-outside handlers from racing
-		// with our toggle.
-		return events[ name ].subscribe( () => {
-			Promise.resolve().then( () => callbackRef.current() );
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		return events[ name ].subscribe( ( payload: any ) => {
+			callbackRef.current( payload );
 		} );
 	}, [ events, name ] );
 }

--- a/client/dashboard/app/interim-omnibar/index.tsx
+++ b/client/dashboard/app/interim-omnibar/index.tsx
@@ -33,9 +33,15 @@ export default async function loadOmnibar( events: OmnibarEvents ) {
 		queryClient.fetchQuery( { queryKey: AUTH_QUERY_KEY, queryFn: fetchUser } ),
 	] );
 
-	// Hydrate the server-rendered omnibar with null props first to match SSR output,
-	// then immediately re-render with real data.
-	const root = hydrateRoot( container, <InterimOmnibar user={ null } site={ null } /> );
+	// Hydrate the server-rendered omnibar with null props to match SSR output,
+	// then immediately re-render with real data.  Suppress recoverable hydration
+	// errors caused by Suspense boundaries inside MasterbarLoggedIn that
+	// renderToString cannot serialize (see logged-in.jsx for the proper fix).
+	const root = hydrateRoot(
+		container,
+		<InterimOmnibar user={ null } site={ null } currentRoute={ window.location.pathname } />,
+		{ onRecoverableError() {} }
+	);
 
 	const site = user.primary_blog
 		? await queryClient.fetchQuery( siteByIdQuery( user.primary_blog ) )
@@ -45,6 +51,7 @@ export default async function loadOmnibar( events: OmnibarEvents ) {
 		<InterimOmnibar
 			user={ user }
 			site={ site }
+			currentRoute={ window.location.pathname }
 			onToggleMenu={ () => events.mobileMenu.emit() }
 			onToggleNotifications={ () => events.notifications.emit() }
 		/>

--- a/client/dashboard/app/interim-omnibar/index.tsx
+++ b/client/dashboard/app/interim-omnibar/index.tsx
@@ -46,13 +46,7 @@ export default async function loadOmnibar( events: OmnibarEvents ) {
 			user={ user }
 			site={ site }
 			onToggleMenu={ () => events.mobileMenu.emit() }
-			onToggleNotifications={ () => {
-				// Defer to a microtask so the callback runs after the current
-				// click handler but before any macrotasks (e.g. Popover's
-				// setTimeout(0) blur-close). This prevents focus-outside
-				// handlers from racing with the toggle.
-				Promise.resolve().then( () => events.notifications.emit() );
-			} }
+			onToggleNotifications={ () => events.notifications.emit() }
 		/>
 	);
 }

--- a/client/dashboard/app/interim-omnibar/index.tsx
+++ b/client/dashboard/app/interim-omnibar/index.tsx
@@ -10,6 +10,24 @@ export default async function loadOmnibar( events: OmnibarEvents ) {
 		return;
 	}
 
+	container.addEventListener( 'click', ( event ) => {
+		if ( event.metaKey || event.ctrlKey || event.shiftKey || event.altKey ) {
+			return;
+		}
+
+		const anchor = ( event.target as Element ).closest< HTMLAnchorElement >( 'a[href]' );
+		if ( ! anchor || anchor.target === '_blank' ) {
+			return;
+		}
+
+		const href = anchor.getAttribute( 'href' );
+		if ( ! href ) {
+			return;
+		}
+
+		events.linkClick.emit( { href, event } );
+	} );
+
 	const [ { InterimOmnibar }, user ] = await Promise.all( [
 		import( './interim-omnibar' ),
 		queryClient.fetchQuery( { queryKey: AUTH_QUERY_KEY, queryFn: fetchUser } ),
@@ -28,7 +46,13 @@ export default async function loadOmnibar( events: OmnibarEvents ) {
 			user={ user }
 			site={ site }
 			onToggleMenu={ () => events.mobileMenu.emit() }
-			onToggleNotifications={ () => events.notifications.emit() }
+			onToggleNotifications={ () => {
+				// Defer to a microtask so the callback runs after the current
+				// click handler but before any macrotasks (e.g. Popover's
+				// setTimeout(0) blur-close). This prevents focus-outside
+				// handlers from racing with the toggle.
+				Promise.resolve().then( () => events.notifications.emit() );
+			} }
 		/>
 	);
 }

--- a/client/dashboard/app/interim-omnibar/index.tsx
+++ b/client/dashboard/app/interim-omnibar/index.tsx
@@ -2,8 +2,9 @@ import { fetchUser } from '@automattic/api-core';
 import { queryClient, siteByIdQuery } from '@automattic/api-queries';
 import { hydrateRoot } from 'react-dom/client';
 import { AUTH_QUERY_KEY } from '../auth';
+import type { OmnibarEvents } from './click-handlers';
 
-export default async function loadOmnibar() {
+export default async function loadOmnibar( events: OmnibarEvents ) {
 	const container = document.getElementById( 'wpcom-omnibar' );
 	if ( ! container ) {
 		return;
@@ -22,5 +23,12 @@ export default async function loadOmnibar() {
 		? await queryClient.fetchQuery( siteByIdQuery( user.primary_blog ) )
 		: null;
 
-	root.render( <InterimOmnibar user={ user } site={ site } /> );
+	root.render(
+		<InterimOmnibar
+			user={ user }
+			site={ site }
+			onToggleMenu={ () => events.mobileMenu.emit() }
+			onToggleNotifications={ () => events.notifications.emit() }
+		/>
+	);
 }

--- a/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
+++ b/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-restricted-imports */
 import { isEcommercePlan } from '@automattic/calypso-products';
+import { useMemo } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { MasterbarLoggedIn } from 'calypso/layout/masterbar/logged-in';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -8,13 +9,22 @@ import type { User, Site } from '@automattic/api-core';
 
 const noop = () => {};
 
+type StoreType = Parameters< typeof ReduxProvider >[ 0 ][ 'store' ];
+
 // Fake Redux store so child components using connect() (e.g. Notifications) don't crash.
-// Just the three methods react-redux's Provider needs.
-const noopStore = {
-	getState: () => ( {} ),
-	dispatch: () => ( {} ),
-	subscribe: () => () => {},
-} as unknown as Parameters< typeof ReduxProvider >[ 0 ][ 'store' ];
+// Intercepts specific actions so the dashboard can handle them.
+function createOmnibarStore( onToggleNotifications?: () => void ): StoreType {
+	return {
+		getState: () => ( {} ),
+		dispatch: ( action: { type: string } ) => {
+			if ( action.type === 'NOTIFICATIONS_PANEL_TOGGLE' ) {
+				onToggleNotifications?.();
+			}
+			return action;
+		},
+		subscribe: () => () => {},
+	} as unknown as StoreType;
+}
 
 // Minimal placeholder so MasterbarLoggedIn doesn't crash during SSR.
 const emptyUser = {
@@ -26,16 +36,27 @@ const emptyUser = {
 interface Props {
 	user: User | null;
 	site: Site | null;
+	onToggleMenu?: () => void;
+	onToggleNotifications?: () => void;
 }
 
-export function InterimOmnibar( { user: userProp, site }: Props ) {
+export function InterimOmnibar( {
+	user: userProp,
+	site,
+	onToggleMenu,
+	onToggleNotifications,
+}: Props ) {
 	const user = userProp ?? emptyUser;
 	const siteId = user.primary_blog ?? null;
 	const siteSlug = site?.slug ?? null;
 	const siteAdminUrl = site?.options?.admin_url ?? null;
+	const store = useMemo(
+		() => createOmnibarStore( onToggleNotifications ),
+		[ onToggleNotifications ]
+	);
 
 	return (
-		<ReduxProvider store={ noopStore }>
+		<ReduxProvider store={ store }>
 			<MasterbarLoggedIn
 				// User
 				user={ user }
@@ -89,7 +110,7 @@ export function InterimOmnibar( { user: userProp, site }: Props ) {
 				adminMenu={ null }
 				// Actions
 				setNextLayoutFocus={ noop }
-				activateNextLayoutFocus={ noop }
+				activateNextLayoutFocus={ () => onToggleMenu?.() }
 				recordTracksEvent={ recordTracksEvent }
 				updateSiteMigrationMeta={ noop }
 				savePreference={ noop }

--- a/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
+++ b/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
@@ -15,7 +15,7 @@ type StoreType = Parameters< typeof ReduxProvider >[ 0 ][ 'store' ];
 // Intercepts specific actions so the dashboard can handle them.
 function createOmnibarStore( onToggleNotifications?: () => void ): StoreType {
 	return {
-		getState: () => ( {} ),
+		getState: () => ( { ui: { section: false, isNotificationsOpen: false } } ),
 		dispatch: ( action: { type: string } ) => {
 			if ( action.type === 'NOTIFICATIONS_PANEL_TOGGLE' ) {
 				onToggleNotifications?.();
@@ -98,7 +98,7 @@ export function InterimOmnibar( {
 				isCheckout={ false }
 				isCheckoutPending={ false }
 				isCheckoutFailed={ false }
-				loadHelpCenterIcon={ false }
+				loadHelpCenterIcon
 				isGlobalSidebarVisible={ false }
 				isGravatarDomain={ false }
 				dashboardOptIn

--- a/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
+++ b/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
@@ -36,6 +36,7 @@ const emptyUser = {
 interface Props {
 	user: User | null;
 	site: Site | null;
+	currentRoute: string;
 	onToggleMenu?: () => void;
 	onToggleNotifications?: () => void;
 }
@@ -43,6 +44,7 @@ interface Props {
 export function InterimOmnibar( {
 	user: userProp,
 	site,
+	currentRoute,
 	onToggleMenu,
 	onToggleNotifications,
 }: Props ) {
@@ -90,7 +92,7 @@ export function InterimOmnibar( {
 				section=""
 				sectionGroup=""
 				currentLayoutFocus={ null }
-				currentRoute={ typeof window !== 'undefined' ? window.location.pathname : '/' }
+				currentRoute={ currentRoute }
 				previousPath=""
 				newPostUrl={ siteAdminUrl ? `${ siteAdminUrl }post-new.php` : '' }
 				newPageUrl={ siteAdminUrl ? `${ siteAdminUrl }post-new.php?post_type=page` : '' }

--- a/client/dashboard/app/interim-omnibar/style.scss
+++ b/client/dashboard/app/interim-omnibar/style.scss
@@ -12,4 +12,14 @@ body:has(#wpcom-omnibar) #wpcom {
 	--color-masterbar-item-active-background: #23282d;
 	--color-masterbar-unread-dot-background: var(--color-accent-20, #d54e21);
 	--color-masterbar-submenu-text: #c3c4c7;
+
+	button.masterbar__item {
+		background: transparent;
+		border: none;
+		cursor: pointer;
+
+		&:hover {
+			background: var(--color-masterbar-item-hover-background);
+		}
+	}
 }

--- a/client/dashboard/app/layout.tsx
+++ b/client/dashboard/app/layout.tsx
@@ -14,9 +14,11 @@ import { getNormalizedPath, getSuperProps } from './analytics/super-props';
 import { AuthProvider, useAuth } from './auth';
 import { AppProvider, useAppContext } from './context';
 import { I18nProvider } from './i18n';
+import { OmnibarEventsProvider } from './interim-omnibar/click-handlers';
 import { getRouter } from './router';
 import { useSurvicate } from './survicate';
 import type { AppConfig } from './context';
+import type { OmnibarEvents } from './interim-omnibar/click-handlers';
 
 function AnalyticsProviderWithClient( {
 	children,
@@ -69,21 +71,29 @@ function AnalyticsProviderWithClient( {
 	return <AnalyticsProvider client={ analyticsClient }>{ children }</AnalyticsProvider>;
 }
 
-function Layout( { config }: { config: AppConfig } ) {
+function Layout( {
+	config,
+	omnibarEvents,
+}: {
+	config: AppConfig;
+	omnibarEvents: OmnibarEvents | null;
+} ) {
 	const router = useMemo( () => getRouter( config ), [ config ] );
 
 	return (
-		<AppProvider config={ config }>
-			<QueryClientProvider client={ queryClient }>
-				<AuthProvider>
-					<I18nProvider>
-						<AnalyticsProviderWithClient router={ router }>
-							<RouterProvider router={ router } context={ { config } } />
-						</AnalyticsProviderWithClient>
-					</I18nProvider>
-				</AuthProvider>
-			</QueryClientProvider>
-		</AppProvider>
+		<OmnibarEventsProvider value={ omnibarEvents }>
+			<AppProvider config={ config }>
+				<QueryClientProvider client={ queryClient }>
+					<AuthProvider>
+						<I18nProvider>
+							<AnalyticsProviderWithClient router={ router }>
+								<RouterProvider router={ router } context={ { config } } />
+							</AnalyticsProviderWithClient>
+						</I18nProvider>
+					</AuthProvider>
+				</QueryClientProvider>
+			</AppProvider>
+		</OmnibarEventsProvider>
 	);
 }
 export default Layout;

--- a/client/dashboard/app/layout.tsx
+++ b/client/dashboard/app/layout.tsx
@@ -14,11 +14,9 @@ import { getNormalizedPath, getSuperProps } from './analytics/super-props';
 import { AuthProvider, useAuth } from './auth';
 import { AppProvider, useAppContext } from './context';
 import { I18nProvider } from './i18n';
-import { OmnibarEventsProvider } from './interim-omnibar/click-handlers';
 import { getRouter } from './router';
 import { useSurvicate } from './survicate';
 import type { AppConfig } from './context';
-import type { OmnibarEvents } from './interim-omnibar/click-handlers';
 
 function AnalyticsProviderWithClient( {
 	children,
@@ -71,29 +69,21 @@ function AnalyticsProviderWithClient( {
 	return <AnalyticsProvider client={ analyticsClient }>{ children }</AnalyticsProvider>;
 }
 
-function Layout( {
-	config,
-	omnibarEvents,
-}: {
-	config: AppConfig;
-	omnibarEvents: OmnibarEvents | null;
-} ) {
+function Layout( { config }: { config: AppConfig } ) {
 	const router = useMemo( () => getRouter( config ), [ config ] );
 
 	return (
-		<OmnibarEventsProvider value={ omnibarEvents }>
-			<AppProvider config={ config }>
-				<QueryClientProvider client={ queryClient }>
-					<AuthProvider>
-						<I18nProvider>
-							<AnalyticsProviderWithClient router={ router }>
-								<RouterProvider router={ router } context={ { config } } />
-							</AnalyticsProviderWithClient>
-						</I18nProvider>
-					</AuthProvider>
-				</QueryClientProvider>
-			</AppProvider>
-		</OmnibarEventsProvider>
+		<AppProvider config={ config }>
+			<QueryClientProvider client={ queryClient }>
+				<AuthProvider>
+					<I18nProvider>
+						<AnalyticsProviderWithClient router={ router }>
+							<RouterProvider router={ router } context={ { config } } />
+						</AnalyticsProviderWithClient>
+					</I18nProvider>
+				</AuthProvider>
+			</QueryClientProvider>
+		</AppProvider>
 	);
 }
 export default Layout;

--- a/client/dashboard/app/notifications/index.tsx
+++ b/client/dashboard/app/notifications/index.tsx
@@ -7,6 +7,7 @@ import clsx from 'clsx';
 import { Suspense, lazy, useEffect, useState } from 'react';
 import wpcom from 'calypso/lib/wp';
 import { useAuth } from '../auth';
+import { useOmnibarEvent } from '../interim-omnibar/click-handlers';
 import { useLocale } from '../locale';
 import './style.scss';
 
@@ -52,6 +53,8 @@ export default function Notifications( { className }: { className: string } ) {
 		],
 		CLOSE_PANEL: [ handleClose ],
 	};
+
+	useOmnibarEvent( 'notifications', () => setIsOpen( ( v ) => ! v ) );
 
 	useEffect( () => {
 		const handleKeyDown = ( event: KeyboardEvent ) => {

--- a/client/dashboard/app/notifications/index.tsx
+++ b/client/dashboard/app/notifications/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useNavigate } from '@tanstack/react-router';
 import { Button, Dropdown } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
@@ -84,6 +85,21 @@ export default function Notifications( { className }: { className: string } ) {
 				placement: 'bottom-end',
 				offset: 8,
 				focusOnMount: true,
+				...( isEnabled( 'dashboard/omnibar' ) && {
+					onFocusOutside: () => {
+						// When focus moves to the omnibar (e.g. clicking the
+						// omnibar notification bell), suppress the Popover's
+						// auto-close and let the omnibar event handle the toggle
+						// instead. Without this, the Popover's focus-outside close
+						// races with the omnibar's toggle event, causing the panel
+						// to close then immediately reopen.
+						const omnibar = document.getElementById( 'wpcom-omnibar' );
+						if ( omnibar?.contains( document.activeElement ) ) {
+							return;
+						}
+						setIsOpen( false );
+					},
+				} ),
 			} }
 			open={ isOpen }
 			expandOnMobile={ isMobileViewport }

--- a/client/dashboard/app/root/index.tsx
+++ b/client/dashboard/app/root/index.tsx
@@ -45,6 +45,28 @@ function Root() {
 	const [ isSidebarOpen, setIsSidebarOpen ] = useState( false );
 	const closeSidebar = useCallback( () => setIsSidebarOpen( false ), [ setIsSidebarOpen ] );
 	useOmnibarEvent( 'mobileMenu', () => setIsSidebarOpen( ( v ) => ! v ) );
+	useOmnibarEvent( 'linkClick', ( { href, event } ) => {
+		const url = new URL( href, window.location.origin );
+
+		if ( url.origin !== window.location.origin ) {
+			return;
+		}
+
+		const path = url.pathname + url.search + url.hash;
+		const parsedLocation = router.parseLocation( undefined, {
+			pathname: url.pathname,
+			search: url.search,
+			hash: url.hash,
+			href: path,
+			state: { __TSR_index: 0 },
+		} );
+		const { foundRoute } = router.getMatchedRoutes( parsedLocation );
+
+		if ( foundRoute ) {
+			event.preventDefault();
+			router.navigate( { to: path } );
+		}
+	} );
 
 	const loadingQueryRequestedFullPageLoader = useSyncExternalStore(
 		( onStoreChange ) => queryCache.subscribe( onStoreChange ),

--- a/client/dashboard/app/root/index.tsx
+++ b/client/dashboard/app/root/index.tsx
@@ -18,6 +18,7 @@ import { bumpStat } from '../analytics';
 import CommandPalette from '../command-palette';
 import { useAppContext } from '../context';
 import Header from '../header';
+import { useOmnibarEvent } from '../interim-omnibar/click-handlers';
 import { NavigationBlockerRegistry } from '../navigation-blocker';
 import OmnibarHeader from '../omnibar-header';
 import ResponsiveSidebar from '../responsive-sidebar';
@@ -43,6 +44,7 @@ function Root() {
 	const queryCache = queryClient.getQueryCache();
 	const [ isSidebarOpen, setIsSidebarOpen ] = useState( false );
 	const closeSidebar = useCallback( () => setIsSidebarOpen( false ), [ setIsSidebarOpen ] );
+	useOmnibarEvent( 'mobileMenu', () => setIsSidebarOpen( ( v ) => ! v ) );
 
 	const loadingQueryRequestedFullPageLoader = useSyncExternalStore(
 		( onStoreChange ) => queryCache.subscribe( onStoreChange ),

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -166,7 +166,7 @@ class Document extends Component {
 					{ /* eslint-disable wpcalypso/jsx-classname-namespace, react/no-danger */ }
 					{ dashboard && config.isEnabled( 'dashboard/omnibar' ) && (
 						<div id="wpcom-omnibar">
-							<InterimOmnibar user={ null } site={ null } />
+							<InterimOmnibar user={ null } site={ null } currentRoute={ this.props.path ?? '/' } />
 						</div>
 					) }
 					{ renderedLayout ? (


### PR DESCRIPTION
Fixes DOTMSD-1164

## Proposed Changes

* Enable the Help Center icon in the omnibar by setting `loadHelpCenterIcon` to true
  * Add `ui` state (`section`, `isNotificationsOpen`) to the fake Redux store so `MasterbarHelpCenter`'s `getSection` selector doesn't crash
  * Reset `<button>` default styles (background, border) inside `#wpcom-omnibar` so button-based masterbar items (e.g. Help) blend into the dark bar, including hover background
* Add an event bridge between the interim omnibar (separate React root) and the dashboard app so click interactions in the omnibar can be handled by the dashboard
* Intercept `<a>` clicks in the omnibar via DOM delegation and MSD checks whether they match a route in TanStack
* Bridge `mobileMenu` and `notifications` toggle events from MasterbarLoggedIn to the dashboard via a fake Redux store that intercepts dispatched actions
* Fix a race condition between the Popover's focus-outside detection and the omnibar notification toggle by overriding `onFocusOutside` to suppress the close when focus moves to the omnibar

## What this PR does NOT do

- Fix every link in the masterbar — some links still navigate to the wrong place

## Why are these changes being made?

The interim omnibar renders MasterbarLoggedIn in a separate React root outside the dashboard tree. Without this bridge, all omnibar link clicks trigger full-page browser navigation (bypassing TanStack Router), and toggle interactions (mobile menu, notifications) have no way to communicate with the dashboard's state.

## Testing Instructions

* Enable the `dashboard/omnibar` feature flag in `config/dashboard-development.json`
* Run `yarn start-dashboard`
* Click omnibar links that correspond to dashboard routes (e.g. `/sites`) — verify SPA navigation without full reload
* Click omnibar links that are NOT dashboard routes (e.g. `/reader`, wp-admin links) — verify full-page navigation
  * Links like this need to update to use `wpcomLink()` so they go to the right domain
* Click the omnibar notification bell — verify the panel toggles correctly (open/close) without flickering
  * confirm keyboard in notification panel still works
  * Esc dismisses panel
* Click the Help Center icon — verify it opens the Help Center panel without console errors
  * confirm keyboard in help panel still works
  * Esc dismisses panel
* Test mobile menu — verify sidebar toggles
* Ctrl/Cmd+click omnibar links — verify they open in a new tab

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?