### PR TITLE
MSD Sidebar: Add expand/collapse animation to sidebar menu

### DIFF
--- a/client/dashboard/components/sidebar/sidebar-expandable-menu-item.scss
+++ b/client/dashboard/components/sidebar/sidebar-expandable-menu-item.scss
@@ -1,3 +1,18 @@
 .dashboard-sidebar__expandable {
 	width: 100%;
 }
+
+.dashboard-sidebar__expandable-panel {
+	interpolate-size: allow-keywords;
+	height: 0;
+	overflow: hidden;
+	opacity: 0;
+	transition:
+	height 0.2s ease-out,
+	opacity 0.2s ease-out;
+
+	&.is-open {
+		height: auto;
+		opacity: 1;
+	}
+}

--- a/client/dashboard/components/sidebar/sidebar-expandable-menu-item.scss
+++ b/client/dashboard/components/sidebar/sidebar-expandable-menu-item.scss
@@ -4,15 +4,15 @@
 
 .dashboard-sidebar__expandable-panel {
 	interpolate-size: allow-keywords;
-	height: 0;
+	block-size: 0;
 	overflow: hidden;
 	opacity: 0;
 	transition:
-	height 0.2s ease-out,
-	opacity 0.2s ease-out;
+		block-size 0.2s ease-out,
+		opacity 0.2s ease-out;
 
 	&.is-open {
-		height: auto;
+		block-size: auto;
 		opacity: 1;
 	}
 }

--- a/client/dashboard/components/sidebar/sidebar-expandable-menu-item.scss
+++ b/client/dashboard/components/sidebar/sidebar-expandable-menu-item.scss
@@ -8,8 +8,8 @@
 	overflow: hidden;
 	opacity: 0;
 	transition:
-		block-size 0.2s ease-out,
-		opacity 0.2s ease-out;
+	block-size 0.2s ease-out,
+	opacity 0.2s ease-out;
 
 	&.is-open {
 		overflow: visible;

--- a/client/dashboard/components/sidebar/sidebar-expandable-menu-item.scss
+++ b/client/dashboard/components/sidebar/sidebar-expandable-menu-item.scss
@@ -12,6 +12,7 @@
 		opacity 0.2s ease-out;
 
 	&.is-open {
+		overflow: visible;
 		block-size: auto;
 		opacity: 1;
 	}

--- a/client/dashboard/components/sidebar/sidebar-expandable-menu-item.tsx
+++ b/client/dashboard/components/sidebar/sidebar-expandable-menu-item.tsx
@@ -70,7 +70,8 @@ export function SidebarExpandableMenuItem( {
 				className={ clsx( 'dashboard-sidebar__expandable-panel', {
 					'is-open': isOpen,
 				} ) }
-				inert={ ! isOpen ? true : undefined }
+				// @ts-expect-error For some reason there's no inert type.
+				inert={ ! isOpen ? 'true' : undefined }
 			>
 				<VStack id={ panelId } spacing={ 1 }>
 					{ Children.map( children, ( child ) => {

--- a/client/dashboard/components/sidebar/sidebar-expandable-menu-item.tsx
+++ b/client/dashboard/components/sidebar/sidebar-expandable-menu-item.tsx
@@ -5,6 +5,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
+import clsx from 'clsx';
 import { Children, cloneElement, isValidElement, useId, useState, useEffect } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { SidebarMenuItem } from './sidebar-menu-item';
@@ -64,7 +65,12 @@ export function SidebarExpandableMenuItem( {
 					<Icon icon={ isOpen ? chevronUp : chevronDown } size={ 18 } />
 				</HStack>
 			</Button>
-			{ isOpen && (
+			{ /* Wrapper div is needed because VStack's flex layout interferes with the CSS height animation. */ }
+			<div
+				className={ clsx( 'dashboard-sidebar__expandable-panel', {
+					'is-open': isOpen,
+				} ) }
+			>
 				<VStack id={ panelId } spacing={ 1 }>
 					{ Children.map( children, ( child ) => {
 						if ( isValidElement( child ) && child.type === SidebarMenuItem && ! child.props.icon ) {
@@ -73,7 +79,7 @@ export function SidebarExpandableMenuItem( {
 						return child;
 					} ) }
 				</VStack>
-			) }
+			</div>
 		</VStack>
 	);
 }

--- a/client/dashboard/components/sidebar/sidebar-expandable-menu-item.tsx
+++ b/client/dashboard/components/sidebar/sidebar-expandable-menu-item.tsx
@@ -70,6 +70,7 @@ export function SidebarExpandableMenuItem( {
 				className={ clsx( 'dashboard-sidebar__expandable-panel', {
 					'is-open': isOpen,
 				} ) }
+				inert={ ! isOpen ? true : undefined }
 			>
 				<VStack id={ panelId } spacing={ 1 }>
 					{ Children.map( children, ( child ) => {


### PR DESCRIPTION
## Summary
- Add CSS-based expand/collapse animation to sidebar expandable menu items
- Use `interpolate-size: allow-keywords` to animate height from 0 to auto with an opacity fade
- No JS animation library needed — pure CSS transitions
- Browser support: Chrome 129+, Safari 18.2+, Firefox 135+ ([MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/interpolate-size)). Falls back gracefully to instant toggle in older browsers.
- We can consider to use `motion.div` if we want as Framer Motion (the motion library) has special handling for `height: 'auto'`

#### Animation on div
https://github.com/user-attachments/assets/9334c173-5b09-4a8a-8e75-3b36c9a17344

#### Animation on VStack
https://github.com/user-attachments/assets/4f2eb0de-e6f2-455e-bd8b-0939fd50773e

## Test plan
- [ ] Open the dashboard sidebar
- [ ] Click an expandable menu item and verify it animates open smoothly
- [ ] Click again to collapse and verify the closing animation
- [ ] Verify no layout shift or flicker during transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)