### PR TITLE
MSD: Use omnibar-aware viewport breakpoints for Backups, Plugins, and Performance

### DIFF
--- a/client/dashboard/plugins/manage/index.tsx
+++ b/client/dashboard/plugins/manage/index.tsx
@@ -4,6 +4,7 @@ import {
 	marketplaceSearchQuery,
 	pluginsQuery,
 } from '@automattic/api-queries';
+import { isEnabled } from '@automattic/calypso-config';
 import { useQueries, useQuery } from '@tanstack/react-query';
 import { useParams } from '@tanstack/react-router';
 import { __experimentalGrid as Grid } from '@wordpress/components';
@@ -44,7 +45,8 @@ const searchableFields = [
 
 export default function PluginsList() {
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
-	const isSmallViewport = useViewportMatch( 'medium', '<' );
+	const isOmnibarEnabled = isEnabled( 'dashboard/omnibar' );
+	const isSmallViewport = useViewportMatch( isOmnibarEnabled ? 'xlarge' : 'medium', '<' );
 	const { data: sitesPlugins, isLoading: sitesPluginsLoading } = useQuery( pluginsQuery() );
 	const { sitesById } = useSitesById();
 	const { pluginId: pluginSlug } = useParams( { strict: false } );

--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -1,5 +1,6 @@
 import { HostingFeatures } from '@automattic/api-core';
 import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
+import { isEnabled } from '@automattic/calypso-config';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Outlet, useParams, useRouter } from '@tanstack/react-router';
 import { __experimentalGrid as Grid } from '@wordpress/components';
@@ -100,7 +101,8 @@ export function BackupsListPage() {
 		[ router, siteSlug ]
 	);
 
-	const isSmallViewport = useViewportMatch( 'medium', '<' );
+	const isOmnibarEnabled = isEnabled( 'dashboard/omnibar' );
+	const isSmallViewport = useViewportMatch( isOmnibarEnabled ? 'xlarge' : 'medium', '<' );
 
 	// Auto-select backup based on rewindId parameter
 	useEffect( () => {

--- a/client/dashboard/sites/performance/constants.ts
+++ b/client/dashboard/sites/performance/constants.ts
@@ -1,0 +1,21 @@
+import { isEnabled } from '@automattic/calypso-config';
+import type { WPBreakpoint } from '@wordpress/compose/build-types/hooks/use-viewport-match';
+
+const isOmnibarEnabled = isEnabled( 'dashboard/omnibar' );
+
+/**
+ * The sidebar added by the omnibar takes up space, so layouts need wider
+ * breakpoints to avoid feeling cramped. When the omnibar is enabled, shift
+ * breakpoints up:
+ *   - medium → xlarge
+ *   - small  → large
+ */
+export const VIEWPORT_BREAKPOINTS: Record<
+	'desktop' | 'medium' | 'small' | 'mobile',
+	WPBreakpoint
+> = {
+	desktop: isOmnibarEnabled ? 'xlarge' : 'medium',
+	medium: isOmnibarEnabled ? 'xlarge' : 'medium',
+	small: isOmnibarEnabled ? 'large' : 'small',
+	mobile: 'mobile',
+};

--- a/client/dashboard/sites/performance/core-metrics-chart.tsx
+++ b/client/dashboard/sites/performance/core-metrics-chart.tsx
@@ -14,6 +14,7 @@ import {
 	getStatusText,
 	mapThresholdsToStatus,
 } from '../../utils/site-performance';
+import { VIEWPORT_BREAKPOINTS } from './constants';
 import type { SitePerformanceReport, SitePerformanceHistory, Metrics } from '@automattic/api-core';
 import '@automattic/charts/line-chart/style.css';
 
@@ -152,7 +153,7 @@ export default function CoreMetricsChart( {
 	metricsThresholds: Record< Metrics, { good: number; needsImprovement: number; bad: number } >;
 } ) {
 	const { good, needsImprovement } = metricsThresholds[ metric ];
-	const isDesktop = useViewportMatch( 'medium' );
+	const isDesktop = useViewportMatch( VIEWPORT_BREAKPOINTS.desktop );
 	const lineChartData = useLineChartData( metric, report.history );
 
 	const formatThresholdValue = ( valuation: Valuation ) => {

--- a/client/dashboard/sites/performance/core-metrics-tabs.tsx
+++ b/client/dashboard/sites/performance/core-metrics-tabs.tsx
@@ -7,6 +7,7 @@ import {
 	mapThresholdsToStatus,
 	getAvailableMetrics,
 } from '../../utils/site-performance';
+import { VIEWPORT_BREAKPOINTS } from './constants';
 import { MetricScore } from './core-metrics-score';
 import type { SitePerformanceReport } from '@automattic/api-core';
 
@@ -18,7 +19,7 @@ const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
 const { Tabs } = unlock( privateApis );
 
 const Tab = ( { children, tabId }: { children: React.ReactNode; tabId: string } ) => {
-	const isDesktop = useViewportMatch( 'medium' );
+	const isDesktop = useViewportMatch( VIEWPORT_BREAKPOINTS.desktop );
 
 	return (
 		<Tabs.Tab tabId={ tabId } style={ { height: '100%' } }>
@@ -36,7 +37,7 @@ const CoreMetricsTabs = ( {
 	report: SitePerformanceReport;
 	compact?: boolean;
 } ) => {
-	const isSmall = useViewportMatch( 'small' );
+	const isSmall = useViewportMatch( VIEWPORT_BREAKPOINTS.small );
 
 	const availableMetrics = getAvailableMetrics( report );
 

--- a/client/dashboard/sites/performance/core-metrics.tsx
+++ b/client/dashboard/sites/performance/core-metrics.tsx
@@ -5,6 +5,7 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 import { useState } from 'react';
 import { Card, CardBody } from '../../components/card';
 import { getAvailableMetrics } from '../../utils/site-performance';
+import { VIEWPORT_BREAKPOINTS } from './constants';
 import CoreMetricsContent from './core-metrics-content';
 import CoreMetricsTabs from './core-metrics-tabs';
 import type { SitePerformanceReport } from '@automattic/api-core';
@@ -34,7 +35,7 @@ export default function CoreMetrics( {
 } ) {
 	const firstAvailableTab = getFirstAvailableTab( report );
 	const [ activeTab, setActiveTab ] = useState< Metrics | null >( firstAvailableTab );
-	const isDesktop = useViewportMatch( 'medium' );
+	const isDesktop = useViewportMatch( VIEWPORT_BREAKPOINTS.desktop );
 
 	if ( ! activeTab ) {
 		return null;

--- a/client/dashboard/sites/performance/device-toggle.tsx
+++ b/client/dashboard/sites/performance/device-toggle.tsx
@@ -7,6 +7,7 @@ import {
 import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { mobile, desktop } from '@wordpress/icons';
+import { VIEWPORT_BREAKPOINTS } from './constants';
 import type { DeviceToggleType } from './types';
 
 type DeviceToggleProps = {
@@ -16,7 +17,7 @@ type DeviceToggleProps = {
 };
 
 export default function DeviceToggle( { value, onChange, disabled }: DeviceToggleProps ) {
-	const isMobileViewPort = useViewportMatch( 'mobile', '<' );
+	const isMobileViewPort = useViewportMatch( VIEWPORT_BREAKPOINTS.mobile, '<' );
 	const options: { value: DeviceToggleType; label: string; icon: React.ReactElement }[] = [
 		{
 			value: 'mobile',

--- a/client/dashboard/sites/performance/llm-notice.tsx
+++ b/client/dashboard/sites/performance/llm-notice.tsx
@@ -7,6 +7,7 @@ import AILoadingIcon from 'calypso/assets/images/performance-profiler/ai-loading
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import { Text } from '../../components/text';
+import { VIEWPORT_BREAKPOINTS } from './constants';
 import type { ReactNode } from 'react';
 
 const LLMNotice = ( {
@@ -18,7 +19,7 @@ const LLMNotice = ( {
 	isLoading?: boolean;
 	actions?: ReactNode;
 } ) => {
-	const isMediumScreen = useViewportMatch( 'medium', '<' );
+	const isMediumScreen = useViewportMatch( VIEWPORT_BREAKPOINTS.medium, '<' );
 
 	return (
 		<Card

--- a/client/dashboard/sites/performance/page-selector.tsx
+++ b/client/dashboard/sites/performance/page-selector.tsx
@@ -2,6 +2,7 @@ import { CustomSelectControl } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
+import { VIEWPORT_BREAKPOINTS } from './constants';
 import type { SitePerformancePage } from '@automattic/api-core';
 import type { CSSProperties } from 'react';
 import './page-selector.scss';
@@ -41,7 +42,7 @@ export default function PageSelector( {
 	currentPage: SitePerformancePage | undefined;
 	onChange: ( page_id: string | null | undefined ) => void;
 } ) {
-	const isDesktop = useViewportMatch( 'medium' );
+	const isDesktop = useViewportMatch( VIEWPORT_BREAKPOINTS.desktop );
 	const pageOptions = useMemo( () => {
 		if ( ! pages ) {
 			return [];

--- a/client/dashboard/sites/performance/performance-insight.tsx
+++ b/client/dashboard/sites/performance/performance-insight.tsx
@@ -20,6 +20,7 @@ import { useLocale } from '../../app/locale';
 import { ButtonStack } from '../../components/button-stack';
 import { Notice } from '../../components/notice';
 import { Text } from '../../components/text';
+import { VIEWPORT_BREAKPOINTS } from './constants';
 import LLMNotice from './llm-notice';
 import PerformanceInsightTable from './performance-insight-table';
 import useLoadingSteps from './use-loading-steps';
@@ -40,8 +41,8 @@ export const PerformanceInsightTitle = ( {
 	index: number;
 	isHightImpact: boolean;
 } ) => {
-	const isMediumScreen = useViewportMatch( 'medium', '<' );
-	const isSmallScreen = useViewportMatch( 'small', '<' );
+	const isMediumScreen = useViewportMatch( VIEWPORT_BREAKPOINTS.medium, '<' );
+	const isSmallScreen = useViewportMatch( VIEWPORT_BREAKPOINTS.small, '<' );
 	const intent = insight.type === 'fail' ? 'error' : 'warning';
 
 	return (
@@ -254,7 +255,7 @@ export const PerformanceInsight = ( {
 	showTip: boolean;
 } ) => {
 	const locale = useLocale();
-	const isDesktop = useViewportMatch( 'medium' );
+	const isDesktop = useViewportMatch( VIEWPORT_BREAKPOINTS.desktop );
 	const { data: llmAnswer, isError } = useQuery( {
 		...odieAssistantPerformanceProfilerQuery( {
 			hash,

--- a/client/dashboard/sites/performance/performance-insights.tsx
+++ b/client/dashboard/sites/performance/performance-insights.tsx
@@ -12,6 +12,7 @@ import { useCallback, useMemo } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { Text } from '../../components/text';
 import { metricsNames } from '../../utils/site-performance';
+import { VIEWPORT_BREAKPOINTS } from './constants';
 import { PerformanceInsightTitle, PerformanceInsight } from './performance-insight';
 import type { DeviceToggleType } from './types';
 import type { SitePerformanceReport, PerformanceMetricAudit } from '@automattic/api-core';
@@ -111,7 +112,7 @@ export default function PerformanceInsights( {
 	onFilterChange: ( filter: Metrics ) => void;
 } ) {
 	const { recordTracksEvent } = useAnalytics();
-	const isDesktop = useViewportMatch( 'medium' );
+	const isDesktop = useViewportMatch( VIEWPORT_BREAKPOINTS.desktop );
 	const { audits, fullPageScreenshot, is_wpcom } = report;
 
 	const options: CustomSelectControlOption[] = Object.keys( metricsNames ).map( ( key: string ) => {


### PR DESCRIPTION
## Summary
- When `dashboard/omnibar` is enabled, shift viewport breakpoints up (`medium` → `xlarge`, `small` → `large`) so layouts don't feel cramped with the extra sidebar
- Update Backups and Plugins pages to use `xlarge` breakpoint instead of `medium`
- Update Performance page: extract breakpoint constants into `constants.ts` and apply them across all viewport-dependent components (core metrics, charts, tabs, insights, page selector, device toggle, LLM notice)

## Test plan
- [ ] Enable `dashboard/omnibar` feature flag
- [ ] Open Backups page — verify two-column layout only shows on xlarge viewports
- [ ] Open Plugins page — verify two-column layout only shows on xlarge viewports
- [ ] Open Performance page — verify all responsive layouts shift to wider breakpoints
- [ ] Disable `dashboard/omnibar` — verify all pages still use original breakpoints as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)