### PR TITLE
Upgrade mini-css-extract-plugin from v1 to v2

### DIFF
--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -50,7 +50,7 @@
 		"css-minimizer-webpack-plugin": "^3.4.1",
 		"duplicate-package-checker-webpack-plugin": "^3.0.0",
 		"lodash": "^4.17.21",
-		"mini-css-extract-plugin": "^1.6.2",
+		"mini-css-extract-plugin": "^2.10.1",
 		"postcss-custom-properties": "^12.1.11",
 		"postcss-loader": "^6.2.1",
 		"recursive-copy": "^2.0.14",

--- a/packages/webpack-rtl-plugin/package.json
+++ b/packages/webpack-rtl-plugin/package.json
@@ -26,7 +26,7 @@
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"css-loader": "^6.11.0",
-		"mini-css-extract-plugin": "^1.6.2",
+		"mini-css-extract-plugin": "^2.10.1",
 		"webpack": "^5.99.8"
 	},
 	"peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -486,7 +486,7 @@ __metadata:
     duplicate-package-checker-webpack-plugin: "npm:^3.0.0"
     gettext-parser: "npm:^6.0.0"
     lodash: "npm:^4.17.21"
-    mini-css-extract-plugin: "npm:^1.6.2"
+    mini-css-extract-plugin: "npm:^2.10.1"
     postcss-custom-properties: "npm:^12.1.11"
     postcss-loader: "npm:^6.2.1"
     recursive-copy: "npm:^2.0.14"
@@ -2373,7 +2373,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
     css-loader: "npm:^6.11.0"
-    mini-css-extract-plugin: "npm:^1.6.2"
+    mini-css-extract-plugin: "npm:^2.10.1"
     rtlcss: "npm:^3.1.2"
     webpack: "npm:^5.99.8"
   peerDependencies:
@@ -23983,16 +23983,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mini-css-extract-plugin@npm:^1.6.2":
-  version: 1.6.2
-  resolution: "mini-css-extract-plugin@npm:1.6.2"
+"mini-css-extract-plugin@npm:^2.10.1":
+  version: 2.10.1
+  resolution: "mini-css-extract-plugin@npm:2.10.1"
   dependencies:
-    loader-utils: "npm:^2.0.0"
-    schema-utils: "npm:^3.0.0"
-    webpack-sources: "npm:^1.1.0"
+    schema-utils: "npm:^4.0.0"
+    tapable: "npm:^2.2.1"
   peerDependencies:
-    webpack: ^4.4.0 || ^5.0.0
-  checksum: 138c008f8a510012266d2834227e75181feeffd09e89e9cde0a63f17be3d64ea3ddbba01036aac9c8a969462c0142285659a20c294e8d01ba948aa1124affdc2
+    webpack: ^5.0.0
+  checksum: 2e90dacdca5bc35862e601e6b3989673e498217c789c4bb270a35bbd22b4d6e85f091795d0324d5cda5a9e2aa2a8f1f3340b6db5a96d66ec208c627659bebb08
   languageName: node
   linkType: hard
 
@@ -30075,13 +30074,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-list-map@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "source-list-map@npm:2.0.1"
-  checksum: 2e5e421b185dcd857f46c3c70e2e711a65d717b78c5f795e2e248c9d67757882ea989b80ebc08cf164eeeda5f4be8aa95d3b990225070b2daaaf3257c5958149
-  languageName: node
-  linkType: hard
-
 "source-map-js@npm:>=0.6.2 <2.0.0, source-map-js@npm:^1.0.1, source-map-js@npm:^1.2.1":
   version: 1.2.1
   resolution: "source-map-js@npm:1.2.1"
@@ -33070,16 +33062,6 @@ __metadata:
   version: 3.0.0
   resolution: "webpack-node-externals@npm:3.0.0"
   checksum: 9f645a4dc8e122dac43cdc8c1367d4b44af20c79632438b633acc1b4fe64ea7ba1ad6ab61bd0fc46e1b873158c48d8c7a25a489cdab1f31299f00eb3b81cfc61
-  languageName: node
-  linkType: hard
-
-"webpack-sources@npm:^1.1.0":
-  version: 1.4.3
-  resolution: "webpack-sources@npm:1.4.3"
-  dependencies:
-    source-list-map: "npm:^2.0.0"
-    source-map: "npm:~0.6.1"
-  checksum: 78dafb3e1e297d3f4eb6204311e8c64d28cd028f82887ba33aaf03fffc82482d8e1fdf6de25a60f4dde621d3565f4c3b1bfb350f09add8f4e54e00279ff3db5e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Upgrade `mini-css-extract-plugin` from ^1.6.2 to ^2.10.1 in both `@automattic/calypso-build` and `@automattic/webpack-rtl-plugin`
- v1.6.2 has a known issue where CSS-only chunks get `undefined` as their content hash, producing broken URLs like `48421.undefined.min.css` in production
- v2 properly computes content hashes for all CSS chunks
- The plugin API (`MiniCssExtractPlugin.loader`, constructor options, `miniCssF` runtime global) is unchanged between v1 and v2

## Test plan
- [ ] Verify CI build passes
- [ ] Verify production build has no `undefined` in CSS chunk filenames
- [ ] Spot-check RTL CSS chunks are still generated correctly
- [ ] Verify no visual regressions on a few key pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)