### PR TITLE
MSD: Fix Help Center hydration mismatch in masterbar

### DIFF
--- a/client/dashboard/app/interim-omnibar/index.tsx
+++ b/client/dashboard/app/interim-omnibar/index.tsx
@@ -33,17 +33,13 @@ export default async function loadOmnibar( events: OmnibarEvents ) {
 	] );
 
 	// Hydrate matching the SSR output: user when bootstrapped, null when not.
-	// Suppress recoverable hydration errors caused by Suspense boundaries inside
-	// MasterbarLoggedIn that renderToString cannot serialize.
 	const root = hydrateRoot(
 		container,
 		<InterimOmnibar
 			user={ window.currentUser ?? null }
 			site={ null }
 			currentRoute={ window.location.pathname }
-		/>,
-
-		{ onRecoverableError() {} }
+		/>
 	);
 
 	const site = user.primary_blog

--- a/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
+++ b/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
@@ -79,10 +79,11 @@ export function InterimOmnibar( {
 				isEcommerce={ isEcommercePlan( site?.plan?.product_slug ?? '' ) }
 				// isClassicView={ !! site && siteUsesWpAdminInterface( site ) }
 				isClassicView
-				isSimpleSite={ !! site && ! site.jetpack }
+				// TODO: Causes hydration mismatch unless client and server both have the same site object
+				isSimpleSite={ false }
 				isJetpackNotAtomic={ !! site && site.jetpack && ! site.is_wpcom_atomic }
 				domainOnlySite={ !! site?.options?.is_domain_only }
-				isUnlaunchedSite={ site?.launch_status === 'unlaunched' }
+				isUnlaunchedSite={ false }
 				isTrial={ false }
 				isSiteP2={ !! site?.options?.is_wpforteams_site }
 				isP2Hub={ !! site?.options?.p2_hub_blog_id && site.options.p2_hub_blog_id === site.ID }

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -60,6 +60,8 @@ import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 import { getMostRecentlySelectedSiteId, getSectionGroup } from 'calypso/state/ui/selectors';
 import Item from './item';
 import Masterbar from './masterbar';
+import { AgentsManagerIcon } from './masterbar-agents-manager/agents-manager-icon';
+import { HelpCenterIcon } from './masterbar-help-center/help-center-icon';
 import { MasterbarLaunchButton } from './masterbar-launch-button';
 import Notifications from './masterbar-notifications/notifications-button';
 
@@ -82,6 +84,8 @@ class MasterbarLoggedIn extends Component {
 		useUnifiedAgent: PropTypes.bool,
 	};
 
+	state = { mounted: false };
+
 	handleLayoutFocus = ( currentSection ) => {
 		if ( currentSection !== this.props.section ) {
 			// When current section is not focused then open the sidebar.
@@ -95,6 +99,12 @@ class MasterbarLoggedIn extends Component {
 	};
 
 	componentDidMount() {
+		// We really do want to re-render after mounting. When the masterbar is rendered on the server we
+		// need the first client-side render to match the server-rendered elements. And then we can
+		// kick off another render with client-side-only features (like the async loaded help menu).
+		// eslint-disable-next-line react/no-did-mount-set-state
+		this.setState( { mounted: true } );
+
 		// Give a chance to direct URLs to open the sidebar on page load ( eg by clicking 'me' in wp-admin ).
 		const qryString = parse( document.location.search.replace( /^\?/, '' ) );
 		if ( qryString?.openSidebar === 'true' ) {
@@ -759,14 +769,38 @@ class MasterbarLoggedIn extends Component {
 		const { siteId, useUnifiedAgent } = this.props;
 
 		if ( useUnifiedAgent ) {
+			const placeholder = (
+				<Item
+					className="masterbar__item-agents-manager"
+					tooltip={ __( 'Help' ) }
+					icon={ <AgentsManagerIcon hasUnread={ false } /> }
+				/>
+			);
+
+			if ( ! this.state.mounted ) {
+				return placeholder;
+			}
+
 			return (
 				<AsyncLoad
 					require="./masterbar-agents-manager"
 					siteId={ siteId }
 					tooltip={ __( 'Help' ) }
-					placeholder={ null }
+					placeholder={ placeholder }
 				/>
 			);
+		}
+
+		const placeholder = (
+			<Item
+				className="masterbar__item-help"
+				tooltip={ __( 'Help' ) }
+				icon={ <HelpCenterIcon hasUnread={ false } /> }
+			/>
+		);
+
+		if ( ! this.state.mounted ) {
+			return placeholder;
 		}
 
 		return (
@@ -774,7 +808,7 @@ class MasterbarLoggedIn extends Component {
 				require="./masterbar-help-center"
 				siteId={ siteId }
 				tooltip={ __( 'Help' ) }
-				placeholder={ null }
+				placeholder={ placeholder }
 			/>
 		);
 	}


### PR DESCRIPTION
Mainly about fixing hydration errors, but also fixes DOTMSD-1189
Closes DOTMSD-1164

## Proposed Changes

* Render static icon placeholders during SSR and first client render
* Defer `AsyncLoad` of the Help Center and Agents Manager until after mount using a `mounted` state flag, so the first client render matches SSR output
* On the client, use the same static icon as the Suspense fallback so we get the exact same icon while the async load happens
* Hardcode `isSimpleSite` and `isUnlaunchedSite` to `false` in the omnibar to avoid mismatches when the site object differs between server and client
  * The W dropdown menu has different menu items depending on whether a site is atomic or not. Deferring this work until we try server rendering the site info DOTMSD-1167
* Remove the `onRecoverableError` suppression in the omnibar loader now that the root causes are fixed

## Why are these changes being made?

`renderToString` cannot serialize `Suspense` boundaries. The previous `AsyncLoad` approach wrapped the Help Center in `Suspense` which caused hydration mismatches between SSR and client rendering. This fix avoids the Suspense boundary during SSR entirely while preserving the icon in the SSR HTML to prevent layout shift.

## Testing Instructions

* Enable the `dashboard/omnibar` feature flag
* Run `yarn start-dashboard` and open a site page
* Verify the Help icon is visible immediately on page load (no pop-in)
* Verify clicking the Help icon opens the Help Center
* Verify no hydration errors in the console

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?