### PR TITLE
Update /me sidebar profile: smaller avatar and left-aligned layout

### DIFF
--- a/client/me/profile-gravatar/index.jsx
+++ b/client/me/profile-gravatar/index.jsx
@@ -22,7 +22,7 @@ export default function ProfileGravatar( { user, inSidebar } ) {
 		<div className={ clsx( 'profile-gravatar', { 'is-in-sidebar': inSidebar } ) }>
 			<div role="presentation" onClick={ recordGravatarMisclick }>
 				<Animate type="appear">
-					<Gravatar user={ user } size={ 150 } imgSize={ GRAVATAR_IMG_SIZE } />
+					<Gravatar user={ user } size={ 80 } imgSize={ GRAVATAR_IMG_SIZE } />
 				</Animate>
 			</div>
 			<h2 className="profile-gravatar__user-display-name">{ user.display_name }</h2>

--- a/client/me/profile-gravatar/style.scss
+++ b/client/me/profile-gravatar/style.scss
@@ -1,13 +1,15 @@
 .profile-gravatar {
+	padding-inline-start: 20px;
+
 	.gravatar {
 		display: block;
-		margin: 0 auto;
+		margin: 0;
 	}
 }
 
 .profile-gravatar__user-secondary-info {
 	margin-bottom: 30px;
-	text-align: center;
+	text-align: start;
 	font-size: $font-body-small;
 
 	.profile-gravatar.is-in-sidebar & {
@@ -19,8 +21,8 @@
 	font-size: $font-title-small;
 	font-weight: 600;
 	line-height: 1.1;
-	margin: 16px 16px 4px;
-	text-align: center;
+	margin: 16px 0 4px;
+	text-align: start;
 	word-break: break-word;
 	word-wrap: break-word;
 }

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -135,18 +135,6 @@ class MeSidebar extends Component {
 			<>
 				<ProfileGravatar inSidebar user={ this.props.currentUser } />
 
-				<div className="sidebar__me-signout">
-					<Button
-						compact
-						className="sidebar__me-signout-button"
-						onClick={ this.onSignOut }
-						title={ translate( 'Log out of WordPress.com' ) }
-					>
-						<span className="sidebar__me-signout-text">{ translate( 'Log out' ) }</span>
-						<Gridicon icon="popout" size={ 16 } />
-					</Button>
-				</div>
-
 				<SidebarMenu>
 					<SidebarItem
 						selected={ itemLinkMatches( '', path ) }
@@ -248,6 +236,18 @@ class MeSidebar extends Component {
 						onNavigate={ this.onNavigate }
 					/>
 				</SidebarMenu>
+
+				<div className="sidebar__me-signout">
+					<Button
+						compact
+						className="sidebar__me-signout-button"
+						onClick={ this.onSignOut }
+						title={ translate( 'Log out of WordPress.com' ) }
+					>
+						<span className="sidebar__me-signout-text">{ translate( 'Log out' ) }</span>
+						<Gridicon icon="popout" size={ 16 } />
+					</Button>
+				</div>
 			</>
 		);
 

--- a/client/me/sidebar/style.scss
+++ b/client/me/sidebar/style.scss
@@ -1,7 +1,8 @@
 .sidebar__me-signout {
 	flex-shrink: 0;	// these are required for the flexed sidebar to not implode in Safari
 	display: flex;
-	justify-content: center;
+	justify-content: flex-start;
+	padding-inline-start: 20px;
 	margin: 0 0 16px;
 }
 

--- a/client/me/sidebar/style.scss
+++ b/client/me/sidebar/style.scss
@@ -3,7 +3,7 @@
 	display: flex;
 	justify-content: flex-start;
 	padding-inline-start: 20px;
-	margin: 0 0 16px;
+	margin: 16px 0;
 }
 
 .sidebar .profile-gravatar {


### PR DESCRIPTION
## Proposed Changes

- Reduce profile avatar size from 150px to 80px for a more compact sidebar header
- Left-align avatar, display name, username, and logout button
- Align all profile elements to the sidebar menu items' 20px left padding for visual consistency

## Why are these changes being made?

The centered, large avatar takes up excessive vertical space in the /me sidebar. Left-aligning the profile section and reducing the avatar size creates a more compact, consistent layout that matches the alignment of the sidebar menu items below it.

## Testing Instructions

1. Navigate to `http://calypso.localhost:3000/me`
2. Verify the profile avatar is smaller (~80px)
3. Verify the avatar, "Lucas Mendes", "@lucasmdo", and "Log out" button are all left-aligned
4. Verify they align with the left edge of sidebar menu items (My Profile, Account Settings, etc.)
5. Test with sidebar collapsed — collapsed behavior should be unchanged

## Pre-merge Checklist

- [x] Has the general commit checklist been followed?
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?