### PR TITLE
MSD: Remove ScrollLock from Switcher dropdown

### DIFF
--- a/client/dashboard/components/switcher/index.tsx
+++ b/client/dashboard/components/switcher/index.tsx
@@ -1,4 +1,4 @@
-import { Dropdown, Button, ScrollLock } from '@wordpress/components';
+import { Dropdown, Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { chevronDownSmall } from '@wordpress/icons';
 import { useState, type ComponentProps } from 'react';
@@ -86,21 +86,18 @@ function Switcher< T >( {
 			defaultOpen={ defaultOpen }
 			renderToggle={ renderDropdownToggle }
 			renderContent={ ( { onClose } ) => (
-				<>
-					<ScrollLock />
-					<SwitcherContent
-						items={ items }
-						searchableFields={ searchableFields }
-						getItemUrl={ getItemUrl }
-						renderItem={ renderItem }
-						view={ view }
-						onChangeView={ setView }
-						onClose={ onClose }
-						onItemClick={ onItemClick }
-					>
-						{ children?.( { onClose } ) }
-					</SwitcherContent>
-				</>
+				<SwitcherContent
+					items={ items }
+					searchableFields={ searchableFields }
+					getItemUrl={ getItemUrl }
+					renderItem={ renderItem }
+					view={ view }
+					onChangeView={ setView }
+					onClose={ onClose }
+					onItemClick={ onItemClick }
+				>
+					{ children?.( { onClose } ) }
+				</SwitcherContent>
 			) }
 		/>
 	);


### PR DESCRIPTION
## Summary
- Remove `ScrollLock` from the Switcher dropdown to test if this triggers the undefined CSS contenthash bug in `mini-css-extract-plugin` v1
- This is a test PR to isolate the issue — removing `ScrollLock` changes the `@wordpress/components` chunk graph

## Test plan
- [ ] Check if the calypso.live build produces `*.undefined.min.css` filenames
- [ ] If it does, this confirms `ScrollLock` removal is the trigger for the webpack chunk splitting bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)