### PR TITLE
MSD: Use paste instead of type for long string in profile test

### DIFF
--- a/client/dashboard/me/profile-gravatar/test/index.test.tsx
+++ b/client/dashboard/me/profile-gravatar/test/index.test.tsx
@@ -79,7 +79,7 @@ describe( '<GravatarProfileSection>', () => {
 
 			const displayNameInput = screen.getByRole( 'textbox', { name: 'Display name' } );
 			await user.clear( displayNameInput );
-			await user.type( displayNameInput, 'a'.repeat( 251 ) );
+			await user.paste( 'a'.repeat( 251 ) );
 			await user.tab();
 
 			expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeDisabled();


### PR DESCRIPTION
## Summary
- Replace `user.type('a'.repeat(251))` with `user.paste()` in the Gravatar profile test
- `user.type` simulates 251 individual keystrokes, making the test unnecessarily slow
- `user.paste` fires a single clipboard event

### Benchmark

| Test | Before (`type`) | After (`paste`) | Speedup |
|------|---------|---------|---------|
| display name 250 chars | 1216ms | 108ms | ~11x faster |
| Total suite | 3.25s | 2.07s | ~1.6x faster |

## Test plan
- [x] `yarn test-client client/dashboard/me/profile-gravatar/test/index.test.tsx` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)