### PR TITLE
Increase theme showcase hero content width

### DIFF
--- a/client/my-sites/themes/hero-modern/style.scss
+++ b/client/my-sites/themes/hero-modern/style.scss
@@ -30,7 +30,7 @@ $hero-modern-navbar-height: 57px; // UniversalHeaderNavigation
 
 .hero-modern__content {
 	flex: 1;
-	max-width: 700px;
+	max-width: 800px;
 	padding: 0 24px;
 
 	@media ( min-width: $break-wide ) {


### PR DESCRIPTION
## Proposed Changes

- Increase `.hero-modern__content` max-width from 700px to 800px

## Why are these changes being made?

The logged-out theme showcase hero heading wraps awkwardly for longer category names (e.g., "Find the perfect theme for your entertainment website"). Increasing the content area width from 700px to 800px allows more words per line, reducing unnecessary line breaks while still leaving room for the illustration on the right.

## Testing Instructions

1. Open an **incognito/private window** (logged-out view required)
2. Navigate to `http://calypso.localhost:3000/themes/filter/entertainment`
3. Verify the hero heading has more horizontal space and fewer line breaks
4. Check other categories (blog, business, portfolio) for balanced wrapping
5. Test at various viewport widths to ensure the illustration isn't clipped

## Pre-merge Checklist

- [x] Has the general commit checklist been followed?
- [ ] Have you written new tests for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes?