### PR TITLE
MSD: Use SidebarMenuSwitcherItem for domain sidebar

### DIFF
--- a/client/dashboard/domains/domain-sidebar/domain-switcher-item.tsx
+++ b/client/dashboard/domains/domain-sidebar/domain-switcher-item.tsx
@@ -1,0 +1,43 @@
+import { __experimentalHStack as HStack, Button, Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { chevronUpDown, globe } from '@wordpress/icons';
+import { SidebarMenuSwitcherItem } from '../../components/sidebar';
+import { Text } from '../../components/text';
+import DomainSwitcher from '../domain-switcher';
+import type { Domain } from '@automattic/api-core';
+
+export default function DomainSwitcherItem( { domain }: { domain: Domain } ) {
+	return (
+		<SidebarMenuSwitcherItem
+			switcher={
+				<DomainSwitcher
+					domain={ domain }
+					renderToggle={ ( { isOpen, onToggle } ) => (
+						<Button
+							variant="tertiary"
+							onClick={ onToggle }
+							onKeyDown={ ( event: React.KeyboardEvent ) => {
+								if ( ! isOpen && event.code === 'ArrowDown' ) {
+									event.preventDefault();
+									onToggle();
+								}
+							} }
+							aria-haspopup="true"
+							aria-expanded={ isOpen }
+							label={ __( 'Switch domain' ) }
+							icon={ chevronUpDown }
+							size="small"
+						/>
+					) }
+				/>
+			}
+		>
+			<HStack justify="flex-start" alignment="center">
+				<Icon className="domain-icon" icon={ globe } size={ 24 } />
+				<Text weight={ 500 } truncate numberOfLines={ 1 }>
+					{ domain.domain }
+				</Text>
+			</HStack>
+		</SidebarMenuSwitcherItem>
+	);
+}

--- a/client/dashboard/domains/domain-sidebar/index.tsx
+++ b/client/dashboard/domains/domain-sidebar/index.tsx
@@ -7,7 +7,7 @@ import { category, envelope } from '@wordpress/icons';
 import { useAppContext } from '../../app/context';
 import { emailsRoute } from '../../app/router/emails';
 import { SidebarBackButton, SidebarMenu, SidebarMenuItem } from '../../components/sidebar';
-import DomainSwitcher from '../domain-switcher';
+import DomainSwitcherItem from './domain-switcher-item';
 
 export default function DomainSidebar() {
 	const { params } = useNavigator();
@@ -23,7 +23,7 @@ export default function DomainSidebar() {
 		<VStack spacing={ 2 }>
 			<SidebarBackButton to="/domains">{ __( 'Back to Domains' ) }</SidebarBackButton>
 			<VStack spacing={ 4 }>
-				<DomainSwitcher domain={ domain } />
+				<DomainSwitcherItem domain={ domain } />
 				<DomainMenuSidebar domainName={ domainName } />
 			</VStack>
 		</VStack>

--- a/client/dashboard/domains/domain-switcher/index.tsx
+++ b/client/dashboard/domains/domain-switcher/index.tsx
@@ -6,6 +6,7 @@ import { useAppContext } from '../../app/context';
 import useBuildCurrentRouteLink from '../../app/hooks/use-build-current-route-link';
 import Switcher from '../../components/switcher';
 import { Text } from '../../components/text';
+import type { SwitcherProps } from '../../components/switcher';
 import type { Domain, DomainSummary } from '@automattic/api-core';
 
 import './style.scss';
@@ -18,7 +19,13 @@ const searchableFields = [
 	},
 ];
 
-export default function DomainSwitcher( { domain }: { domain: Domain } ) {
+export default function DomainSwitcher( {
+	domain,
+	renderToggle,
+}: {
+	domain: Domain;
+	renderToggle?: SwitcherProps< DomainSummary >[ 'renderToggle' ];
+} ) {
 	const { queries } = useAppContext();
 	const domains = useQuery( {
 		...queries.domainsQuery(),
@@ -35,6 +42,7 @@ export default function DomainSwitcher( { domain }: { domain: Domain } ) {
 			value={ domain }
 			searchableFields={ searchableFields }
 			getItemUrl={ ( d ) => buildCurrentRouteLink( { params: { domainName: d.domain } } ) }
+			renderToggle={ renderToggle }
 			renderItem={ ( { item, context } ) => (
 				<Switcher.Item
 					media={

--- a/client/dashboard/domains/domain-switcher/style.scss
+++ b/client/dashboard/domains/domain-switcher/style.scss
@@ -2,4 +2,5 @@
 
 .domain-icon {
 	color: #{$gray-700};
+	fill: currentColor;
 }

--- a/client/dashboard/domains/domain/index.tsx
+++ b/client/dashboard/domains/domain/index.tsx
@@ -1,40 +1,16 @@
-import { DomainSubtype } from '@automattic/api-core';
 import { domainQuery } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { Outlet } from '@tanstack/react-router';
-import { __experimentalHStack as HStack, Icon } from '@wordpress/components';
-import { globe } from '@wordpress/icons';
-import { useAppContext } from '../../app/context';
-import useBuildCurrentRouteLink from '../../app/hooks/use-build-current-route-link';
+import { __experimentalHStack as HStack } from '@wordpress/components';
 import { domainRoute } from '../../app/router/domains';
 import HeaderBar from '../../components/header-bar';
-import Switcher from '../../components/switcher';
-import { Text } from '../../components/text';
 import DomainMenu from '../domain-menu';
-import type { DomainSummary } from '@automattic/api-core';
-import './style.scss';
+import DomainSwitcher from '../domain-switcher';
 
 function Domain() {
-	const { queries } = useAppContext();
 	const { domainName } = domainRoute.useParams();
-	const domains = useQuery( {
-		...queries.domainsQuery(),
-		select: ( data ) => {
-			return data.filter( ( domain ) => domain.subtype.id !== DomainSubtype.DEFAULT_ADDRESS );
-		},
-	} ).data;
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
-
-	const searchableFields = [
-		{
-			id: 'name',
-			getValue: ( { item }: { item: DomainSummary } ) => item.domain,
-			enableGlobalSearch: true,
-		},
-	];
-
-	const buildCurrentRouteLink = useBuildCurrentRouteLink();
 
 	return (
 		<>
@@ -42,28 +18,7 @@ function Domain() {
 				<HeaderBar>
 					<HStack spacing={ 3 }>
 						<HeaderBar.Title>
-							<Switcher
-								items={ domains }
-								value={ domain }
-								searchableFields={ searchableFields }
-								getItemUrl={ ( domain ) =>
-									buildCurrentRouteLink( { params: { domainName: domain.domain } } )
-								}
-								renderItem={ ( { item, context } ) => (
-									<Switcher.Item
-										media={
-											context !== 'list' ? (
-												<Icon className="domain-icon" icon={ globe } size={ 24 } />
-											) : undefined
-										}
-										title={
-											<Text truncate numberOfLines={ 1 } style={ { color: 'inherit' } }>
-												{ item.domain }
-											</Text>
-										}
-									/>
-								) }
-							/>
+							<DomainSwitcher domain={ domain } />
 						</HeaderBar.Title>
 						<DomainMenu domainName={ domain.domain } />
 					</HStack>

--- a/client/dashboard/domains/domain/style.scss
+++ b/client/dashboard/domains/domain/style.scss
@@ -1,5 +1,0 @@
-@import '@wordpress/base-styles/colors';
-
-.domain-icon {
-	color: #{$gray-700};
-}


### PR DESCRIPTION
## Summary
- Extract `DomainSwitcherItem` into its own file under `domain-sidebar/`
- Wrap `DomainSwitcher` with `SidebarMenuSwitcherItem`, using a custom `renderToggle` that renders a compact chevron icon button — matching the site sidebar pattern
- Reuse `DomainSwitcher` in `domain/index.tsx` instead of duplicating inline `Switcher` usage
- Add `renderToggle` prop passthrough to `DomainSwitcher`

| Before | After |
| - | - |
|<img width="245" height="156" alt="image" src="https://github.com/user-attachments/assets/f7e2afc5-33c1-4554-9ec2-d3ce215736f5" />|<img width="242" height="148" alt="image" src="https://github.com/user-attachments/assets/5c524347-0bca-4707-8d18-f7828bd4c67b" />|

## Test plan
- [ ] Open the domain sidebar and verify the domain switcher renders with the icon button
- [ ] Click the switcher button and verify the dropdown opens
- [ ] Verify the domain header bar still works when omnibar is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)