### PR TITLE
Refactor partner branding detector naming across auth flows

### DIFF
--- a/client/components/connect-screen/stories/index.stories.tsx
+++ b/client/components/connect-screen/stories/index.stories.tsx
@@ -5,7 +5,7 @@ import { seen, edit, cog, check, chartBar, postList, commentAuthorAvatar } from 
 import { useState } from 'react';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';
-import { CIAB_PARTNERS } from 'calypso/lib/partner-branding';
+import { PARTNERS } from 'calypso/lib/partner-branding';
 import {
 	AppleLoginButton,
 	GithubSocialButton,
@@ -324,14 +324,14 @@ export const LoginPageWrapperPartnerBranded: StoryObj< typeof LoginPageWrapper >
 		<LoginPageWrapper
 			title="Log in to Woo"
 			branding={ {
-				logo: CIAB_PARTNERS.woo.logo.src,
-				logoAlt: CIAB_PARTNERS.woo.logo.alt,
-				logoWidth: CIAB_PARTNERS.woo.logo.width,
-				logoHeight: CIAB_PARTNERS.woo.logo.height,
-				topBarLogo: CIAB_PARTNERS.woo.compactLogo?.src,
-				topBarLogoAlt: CIAB_PARTNERS.woo.compactLogo?.alt,
-				topBarLogoWidth: CIAB_PARTNERS.woo.compactLogo?.width,
-				topBarLogoHeight: CIAB_PARTNERS.woo.compactLogo?.height,
+				logo: PARTNERS.woo.logo.src,
+				logoAlt: PARTNERS.woo.logo.alt,
+				logoWidth: PARTNERS.woo.logo.width,
+				logoHeight: PARTNERS.woo.logo.height,
+				topBarLogo: PARTNERS.woo.compactLogo?.src,
+				topBarLogoAlt: PARTNERS.woo.compactLogo?.alt,
+				topBarLogoWidth: PARTNERS.woo.compactLogo?.width,
+				topBarLogoHeight: PARTNERS.woo.compactLogo?.height,
 			} }
 			primaryNavLink={ { label: 'Create an account', href: '/start/account' } }
 			secondaryNavLink={ { label: 'No thanks', href: '/no-thanks' } }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -47,7 +47,7 @@ const UserStepComponent: StepType = function UserStep( {
 	const { handleSocialResponse, notice, accountCreateResponse } = useHandleSocialResponse( flow );
 	const [ wpAccountCreateResponse, setWpAccountCreateResponse ] = useState< AccountCreateReturn >();
 	const { socialServiceResponse } = useSocialService();
-	const { topBarLogo, ciabConfig, signupTosElement } = usePartnerBranding();
+	const { topBarLogo, partnerConfig, signupTosElement } = usePartnerBranding();
 
 	const {
 		isExperimentVariant,
@@ -82,7 +82,7 @@ const UserStepComponent: StepType = function UserStep( {
 		signupUrl,
 		redirectTo,
 		locale,
-		from: ciabConfig?.id ?? queryArgs.get( 'from' ) ?? undefined,
+		from: partnerConfig?.id ?? queryArgs.get( 'from' ) ?? undefined,
 	} );
 
 	const shouldRenderLocaleSuggestions = ! isLoggedIn; // For logged-in users, we respect the user language settings
@@ -126,7 +126,7 @@ const UserStepComponent: StepType = function UserStep( {
 				isEmailVariation={ isEmailVariation }
 				isMessagingVariation={ isMessagingVariation }
 				isSliderVariation={ isSliderVariation }
-				allowedSocialServices={ ciabConfig?.ssoProviders }
+				allowedSocialServices={ partnerConfig?.ssoProviders }
 				customTosElement={ signupTosElement }
 			/>
 			{ accountCreateResponse && 'bearer_token' in accountCreateResponse && (
@@ -143,9 +143,9 @@ const UserStepComponent: StepType = function UserStep( {
 		let headingText = translate( 'Create your account' );
 		if ( isMessagingVariation ) {
 			headingText = translate( 'Welcome to WordPress.com' );
-		} else if ( ciabConfig ) {
+		} else if ( partnerConfig ) {
 			headingText = translate( 'Create an account for %(partner)s', {
-				args: { partner: ciabConfig.displayName },
+				args: { partner: partnerConfig.displayName },
 				textOnly: true,
 			} );
 		}

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -92,7 +92,7 @@ const LayoutLoggedOut = ( {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const currentRoute = useSelector( getCurrentRoute );
 	const loggedInAction = useSelector( getLastActionRequiresLogin );
-	const { ciabConfig } = usePartnerBranding();
+	const { partnerConfig } = usePartnerBranding();
 
 	const dashboard =
 		typeof window !== 'undefined' && getDashboardFromHostname( window.location.hostname );
@@ -169,7 +169,7 @@ const LayoutLoggedOut = ( {
 		'is-wpcom-magic-login': isWpcomMagicLogin,
 		'is-woo-passwordless': isWoo,
 		'is-blaze-pro': isBlazePro,
-		'is-ciab-font-system': ciabConfig?.fontStyle === 'system',
+		'is-ciab-font-system': partnerConfig?.fontStyle === 'system',
 		'two-factor-auth-enabled': twoFactorEnabled,
 		'is-woo-com-oauth': isWooOAuth2Client( oauth2Client ),
 		woo: isWoo,

--- a/client/lib/partner-branding.tsx
+++ b/client/lib/partner-branding.tsx
@@ -332,8 +332,6 @@ export function detectPartnerConfig(
 	return null;
 }
 
-export const detectCiabConfig = detectPartnerConfig;
-
 /**
  * Get allowed social services for a partner.
  * Detects partner from globally available values (see detectPartnerConfig).

--- a/client/lib/partner-branding.tsx
+++ b/client/lib/partner-branding.tsx
@@ -289,7 +289,7 @@ function getSearchParam( name: string ): string | null {
 }
 
 /**
- * Detect CIAB partner config from globally available values.
+ * Detect partner config from globally available values.
  *
  * The oauth2Client parameter comes from Redux (getCurrentOAuth2Client).
  * Other detection sources read from window.location internally.
@@ -301,7 +301,9 @@ function getSearchParam( name: string ): string | null {
  *   4. redirect_to        — hostname inside ?redirect_to= URL
  *   5. session storage    — persisted partner from a previous detection in this session
  */
-export function detectCiabConfig( oauth2Client?: { id: number } | null ): CiabPartnerConfig | null {
+export function detectPartnerConfig(
+	oauth2Client?: { id: number } | null
+): CiabPartnerConfig | null {
 	const detected =
 		getCiabConfigFromCurrentDomain() ??
 		getCiabConfigFromBrandingCode() ??
@@ -330,16 +332,18 @@ export function detectCiabConfig( oauth2Client?: { id: number } | null ): CiabPa
 	return null;
 }
 
+export const detectCiabConfig = detectPartnerConfig;
+
 /**
  * Get allowed social services for a partner.
- * Detects partner from globally available values (see detectCiabConfig).
+ * Detects partner from globally available values (see detectPartnerConfig).
  * Returns the array of allowed SSO providers or null if no restrictions apply.
  * @returns Array of allowed service names (e.g., ['paypal', 'google', 'apple']) or null
  */
 export function getPartnerAllowedSocialServices(
 	oauth2Client?: { id: number } | null
 ): AllowedSocialService[] | null {
-	const ciabConfig = detectCiabConfig( oauth2Client );
+	const ciabConfig = detectPartnerConfig( oauth2Client );
 	return ciabConfig?.ssoProviders ?? null;
 }
 
@@ -359,7 +363,7 @@ export interface UsePartnerBrandingResult {
 
 /**
  * Hook to get current partner branding based on URL params and feature flags.
- * Internally calls detectCiabConfig() — callers do not need to pass any values.
+ * Internally calls detectPartnerConfig() — callers do not need to pass any values.
  *
  * @example
  * const { topBarLogo, ciabConfig, signupTosElement } = usePartnerBranding();
@@ -381,7 +385,7 @@ export function usePartnerBranding(): UsePartnerBrandingResult {
 	const translate = useTranslate();
 
 	// Redux selectors are used only as memo-invalidation triggers.
-	// The actual detection reads from window.location via detectCiabConfig().
+	// The actual detection reads from window.location via detectPartnerConfig().
 	const currentQuery = useSelector( getCurrentQueryArguments );
 	const initialQuery = useSelector( getInitialQueryArguments );
 	const from = currentQuery?.from || initialQuery?.from;
@@ -389,7 +393,7 @@ export function usePartnerBranding(): UsePartnerBrandingResult {
 	const oauth2Client = useSelector( getCurrentOAuth2Client );
 
 	return useMemo( () => {
-		const ciabConfig = detectCiabConfig( oauth2Client );
+		const ciabConfig = detectPartnerConfig( oauth2Client );
 		const hasCustomBranding = ciabConfig !== null;
 
 		// Build logo element for TopBar

--- a/client/lib/partner-branding.tsx
+++ b/client/lib/partner-branding.tsx
@@ -26,10 +26,10 @@ interface LogoConfig {
 }
 
 /**
- * CIAB Partner configuration
+ * Partner configuration
  * All partner-specific settings are centralized here
  */
-export interface CiabPartnerConfig {
+export interface PartnerConfig {
 	/** Partner identifier */
 	id: string;
 	/** Display name shown in UI (e.g., "Woo") */
@@ -53,15 +53,15 @@ export interface CiabPartnerConfig {
 }
 
 /**
- * CIAB Partners Configuration
+ * Partner configuration
  *
  * To add a new partner:
- * 1. Add entry here with all config
- * 2. Add the translated ToS text in getPartnerSignupTosElement() below (required for i18n extraction)
- * 3. Add feature flag to config/_shared.json and config/development.json
- * 4. Done! No other code changes needed.
+ * 1. Add entry here with all config.
+ * 2. Add translated ToS text in getPartnerSignupTosElement() below (required for i18n extraction).
+ * 3. Add the feature flag to config/_shared.json and config/development.json.
+ * 4. Done. No other code changes are needed.
  */
-export const CIAB_PARTNERS: Record< string, CiabPartnerConfig > = {
+export const PARTNERS: Record< string, PartnerConfig > = {
 	woo: {
 		id: 'woo',
 		displayName: 'Woo',
@@ -86,24 +86,25 @@ export const CIAB_PARTNERS: Record< string, CiabPartnerConfig > = {
 	},
 };
 
-export function getPartnerWindowTitleSuffix( ciabConfig: CiabPartnerConfig | null ): string {
-	return ciabConfig?.windowTitleSuffix || config( 'site_name' );
+export function getPartnerWindowTitleSuffix( partnerConfig: PartnerConfig | null ): string {
+	return partnerConfig?.windowTitleSuffix || config( 'site_name' );
 }
 
 export function getPartnerFormattedWindowTitle(
 	title: string | null | undefined,
-	ciabConfig: CiabPartnerConfig | null
+	partnerConfig: PartnerConfig | null
 ): string {
 	const titlePrefix = title ? `${ title } — ` : '';
 
-	return titlePrefix + getPartnerWindowTitleSuffix( ciabConfig );
+	return titlePrefix + getPartnerWindowTitleSuffix( partnerConfig );
 }
 
-function isPartnerEnabled( partnerConfig: CiabPartnerConfig ): boolean {
+function isPartnerEnabled( partnerConfig: PartnerConfig ): boolean {
 	return ! partnerConfig.featureFlag || config.isEnabled( partnerConfig.featureFlag );
 }
 
-const CIAB_PARTNER_SESSION_KEY = 'calypso.ciab.partner-id';
+const PARTNER_SESSION_KEY = 'calypso.partner.partner-id';
+const LEGACY_PARTNER_SESSION_KEY = 'calypso.ciab.partner-id';
 
 function getSessionStorage(): Storage | null {
 	if ( typeof window === 'undefined' ) {
@@ -117,7 +118,7 @@ function getSessionStorage(): Storage | null {
 	}
 }
 
-export function readPersistedCiabPartnerId(): string | null {
+export function readPersistedPartnerId(): string | null {
 	const sessionStorage = getSessionStorage();
 
 	if ( ! sessionStorage ) {
@@ -125,13 +126,30 @@ export function readPersistedCiabPartnerId(): string | null {
 	}
 
 	try {
-		return sessionStorage.getItem( CIAB_PARTNER_SESSION_KEY );
+		const partnerId = sessionStorage.getItem( PARTNER_SESSION_KEY );
+
+		if ( partnerId ) {
+			return partnerId;
+		}
+
+		const legacyPartnerId = sessionStorage.getItem( LEGACY_PARTNER_SESSION_KEY );
+
+		if ( ! legacyPartnerId ) {
+			return null;
+		}
+
+		// One-time migration: read from the legacy CIAB key and immediately
+		// re-persist using the partner-generic key.
+		sessionStorage.setItem( PARTNER_SESSION_KEY, legacyPartnerId );
+		sessionStorage.removeItem( LEGACY_PARTNER_SESSION_KEY );
+
+		return legacyPartnerId;
 	} catch {
 		return null;
 	}
 }
 
-export function persistCiabPartnerId( partnerId: string ): void {
+export function persistPartnerId( partnerId: string ): void {
 	const sessionStorage = getSessionStorage();
 
 	if ( ! sessionStorage || ! partnerId ) {
@@ -139,13 +157,13 @@ export function persistCiabPartnerId( partnerId: string ): void {
 	}
 
 	try {
-		sessionStorage.setItem( CIAB_PARTNER_SESSION_KEY, partnerId );
+		sessionStorage.setItem( PARTNER_SESSION_KEY, partnerId );
 	} catch {
 		// Ignore storage write failures.
 	}
 }
 
-export function clearPersistedCiabPartnerId(): void {
+export function clearPersistedPartnerId(): void {
 	const sessionStorage = getSessionStorage();
 
 	if ( ! sessionStorage ) {
@@ -153,45 +171,46 @@ export function clearPersistedCiabPartnerId(): void {
 	}
 
 	try {
-		sessionStorage.removeItem( CIAB_PARTNER_SESSION_KEY );
+		sessionStorage.removeItem( PARTNER_SESSION_KEY );
+		sessionStorage.removeItem( LEGACY_PARTNER_SESSION_KEY );
 	} catch {
 		// Ignore storage clear failures.
 	}
 }
 
 /**
- * Get CIAB partner config from garden info
- * Maps garden partner/name combinations to CIAB branding configs
+ * Get partner config from Garden info.
+ * Maps Garden partner/name combinations to branding configs.
  */
-export function getCiabConfigFromGarden(
+export function getPartnerConfigFromGarden(
 	gardenPartner?: string,
 	gardenName?: string,
 	options: { persistToSession?: boolean } = {}
-): CiabPartnerConfig | null {
+): PartnerConfig | null {
 	if ( ! gardenPartner || ! gardenName ) {
 		return null;
 	}
 
-	let ciabConfig: CiabPartnerConfig | null = null;
+	let partnerConfig: PartnerConfig | null = null;
 
 	// Map garden partners to branding configs
 	if ( gardenPartner === 'woo' && gardenName === 'commerce' ) {
-		ciabConfig = CIAB_PARTNERS.woo ?? null;
+		partnerConfig = PARTNERS.woo ?? null;
 	}
 
-	if ( ciabConfig && options.persistToSession ) {
-		persistCiabPartnerId( ciabConfig.id );
+	if ( partnerConfig && options.persistToSession ) {
+		persistPartnerId( partnerConfig.id );
 	}
 
 	// Future: add mappings for other partners like "paypal"
-	return ciabConfig;
+	return partnerConfig;
 }
 
 /**
- * Get CIAB partner config by matching a hostname against partner domains.
+ * Get partner config by matching a hostname against partner domains.
  */
-function getCiabConfigByHostname( hostname: string ): CiabPartnerConfig | null {
-	for ( const partnerConfig of Object.values( CIAB_PARTNERS ) ) {
+function getPartnerConfigByHostname( hostname: string ): PartnerConfig | null {
+	for ( const partnerConfig of Object.values( PARTNERS ) ) {
 		if ( partnerConfig.domains?.includes( hostname ) ) {
 			if ( isPartnerEnabled( partnerConfig ) ) {
 				return partnerConfig;
@@ -202,23 +221,23 @@ function getCiabConfigByHostname( hostname: string ): CiabPartnerConfig | null {
 }
 
 /**
- * Get CIAB partner config by matching the current page's hostname against partner domains.
+ * Get partner config by matching the current page's hostname against partner domains.
  */
-export function getCiabConfigFromCurrentDomain(): CiabPartnerConfig | null {
+export function getPartnerConfigFromCurrentDomain(): PartnerConfig | null {
 	if ( typeof window === 'undefined' ) {
 		return null;
 	}
-	return getCiabConfigByHostname( window.location.hostname );
+	return getPartnerConfigByHostname( window.location.hostname );
 }
 
 /**
- * Get CIAB partner config from the branding code query parameter.
+ * Get partner config from the branding code query parameter.
  *
- * TODO: The `from` parameter is transitional — it provides backward compatibility
- * with existing flows (e.g. ?from=woo). In a follow-up, replace it with a dedicated
- * global branding-code parameter (e.g. ?branding=woo) and remove this fallback.
+ * TODO: The `from` parameter is transitional. It provides backward compatibility
+ * with existing flows (for example, ?from=woo). In a follow-up, replace it with a
+ * dedicated branding-code query parameter (for example, ?branding=woo).
  */
-export function getCiabConfigFromBrandingCode(): CiabPartnerConfig | null {
+export function getPartnerConfigFromBrandingCode(): PartnerConfig | null {
 	if ( typeof window === 'undefined' ) {
 		return null;
 	}
@@ -226,8 +245,8 @@ export function getCiabConfigFromBrandingCode(): CiabPartnerConfig | null {
 	const params = new URLSearchParams( window.location.search );
 	const from = params.get( 'from' );
 
-	if ( from && CIAB_PARTNERS[ from ] ) {
-		const partnerConfig = CIAB_PARTNERS[ from ];
+	if ( from && PARTNERS[ from ] ) {
+		const partnerConfig = PARTNERS[ from ];
 		if ( isPartnerEnabled( partnerConfig ) ) {
 			return partnerConfig;
 		}
@@ -237,11 +256,11 @@ export function getCiabConfigFromBrandingCode(): CiabPartnerConfig | null {
 }
 
 /**
- * Get CIAB partner config by matching a redirect URL's hostname against partner domains.
+ * Get partner config by matching a redirect URL hostname against partner domains.
  */
-export function getCiabConfigFromRedirectUrl(
+export function getPartnerConfigFromRedirectUrl(
 	redirectUrl: string | string[] | undefined | null
-): CiabPartnerConfig | null {
+): PartnerConfig | null {
 	const urlValue = Array.isArray( redirectUrl ) ? redirectUrl[ 0 ] : redirectUrl;
 
 	if ( ! urlValue ) {
@@ -249,7 +268,7 @@ export function getCiabConfigFromRedirectUrl(
 	}
 
 	try {
-		return getCiabConfigByHostname( new URL( urlValue ).hostname );
+		return getPartnerConfigByHostname( new URL( urlValue ).hostname );
 	} catch {
 		// Invalid URL, ignore
 	}
@@ -258,16 +277,16 @@ export function getCiabConfigFromRedirectUrl(
 }
 
 /**
- * Get CIAB partner config by matching an OAuth2 client (from Redux store) against partner configs.
+ * Get partner config by matching an OAuth2 client against partner configs.
  */
-export function getCiabConfigFromOAuth2Client(
+export function getPartnerConfigFromOAuth2Client(
 	oauth2Client: { id: number } | null | undefined
-): CiabPartnerConfig | null {
+): PartnerConfig | null {
 	if ( ! oauth2Client ) {
 		return null;
 	}
 
-	for ( const partnerConfig of Object.values( CIAB_PARTNERS ) ) {
+	for ( const partnerConfig of Object.values( PARTNERS ) ) {
 		if ( partnerConfig.isOAuth2Client?.( oauth2Client ) ) {
 			if ( isPartnerEnabled( partnerConfig ) ) {
 				return partnerConfig;
@@ -296,37 +315,35 @@ function getSearchParam( name: string ): string | null {
  *
  * Detection precedence (first match wins):
  *   1. hostname           — window.location.hostname against partner domains
- *   2. branding code      — ?from= query param (transitional, see getCiabConfigFromBrandingCode)
+ *   2. branding code      — ?from= query param (transitional, see getPartnerConfigFromBrandingCode)
  *   3. OAuth2 client      — current OAuth2 client from Redux store matched against partner configs
  *   4. redirect_to        — hostname inside ?redirect_to= URL
  *   5. session storage    — persisted partner from a previous detection in this session
  */
-export function detectPartnerConfig(
-	oauth2Client?: { id: number } | null
-): CiabPartnerConfig | null {
+export function detectPartnerConfig( oauth2Client?: { id: number } | null ): PartnerConfig | null {
 	const detected =
-		getCiabConfigFromCurrentDomain() ??
-		getCiabConfigFromBrandingCode() ??
-		getCiabConfigFromOAuth2Client( oauth2Client ) ??
-		getCiabConfigFromRedirectUrl( getSearchParam( 'redirect_to' ) );
+		getPartnerConfigFromCurrentDomain() ??
+		getPartnerConfigFromBrandingCode() ??
+		getPartnerConfigFromOAuth2Client( oauth2Client ) ??
+		getPartnerConfigFromRedirectUrl( getSearchParam( 'redirect_to' ) );
 
 	if ( detected ) {
-		persistCiabPartnerId( detected.id );
+		persistPartnerId( detected.id );
 		return detected;
 	}
 
 	// Session persistence fallback: if no detection source matches,
 	// check if a partner was previously detected in this session.
-	const persistedPartnerId = readPersistedCiabPartnerId();
+	const persistedPartnerId = readPersistedPartnerId();
 
 	if ( persistedPartnerId ) {
-		const persistedConfig = CIAB_PARTNERS[ persistedPartnerId ];
+		const persistedConfig = PARTNERS[ persistedPartnerId ];
 
 		if ( persistedConfig && isPartnerEnabled( persistedConfig ) ) {
 			return persistedConfig;
 		}
 
-		clearPersistedCiabPartnerId();
+		clearPersistedPartnerId();
 	}
 
 	return null;
@@ -341,8 +358,8 @@ export function detectPartnerConfig(
 export function getPartnerAllowedSocialServices(
 	oauth2Client?: { id: number } | null
 ): AllowedSocialService[] | null {
-	const ciabConfig = detectPartnerConfig( oauth2Client );
-	return ciabConfig?.ssoProviders ?? null;
+	const partnerConfig = detectPartnerConfig( oauth2Client );
+	return partnerConfig?.ssoProviders ?? null;
 }
 
 /**
@@ -351,8 +368,8 @@ export function getPartnerAllowedSocialServices(
 export interface UsePartnerBrandingResult {
 	/** Whether custom branding is active */
 	hasCustomBranding: boolean;
-	/** CIAB partner config (null if not a CIAB partner or feature flag disabled) */
-	ciabConfig: CiabPartnerConfig | null;
+	/** Partner config (null if no partner is detected or the feature flag is disabled) */
+	partnerConfig: PartnerConfig | null;
 	/** Ready-to-use logo element for TopBar, or undefined to use default */
 	topBarLogo: JSX.Element | undefined;
 	/** Ready-to-use ToS element for signup, or undefined to use default */
@@ -364,14 +381,14 @@ export interface UsePartnerBrandingResult {
  * Internally calls detectPartnerConfig() — callers do not need to pass any values.
  *
  * @example
- * const { topBarLogo, ciabConfig, signupTosElement } = usePartnerBranding();
+ * const { topBarLogo, partnerConfig, signupTosElement } = usePartnerBranding();
  *
  * // In TopBar:
  * <Step.TopBar logo={topBarLogo} ... />
  *
  * // For SSO filtering:
- * if (ciabConfig) {
- *   const allowedProviders = ciabConfig.ssoProviders;
+ * if (partnerConfig) {
+ *   const allowedProviders = partnerConfig.ssoProviders;
  * }
  *
  * // For signup ToS:
@@ -391,11 +408,11 @@ export function usePartnerBranding(): UsePartnerBrandingResult {
 	const oauth2Client = useSelector( getCurrentOAuth2Client );
 
 	return useMemo( () => {
-		const ciabConfig = detectPartnerConfig( oauth2Client );
-		const hasCustomBranding = ciabConfig !== null;
+		const partnerConfig = detectPartnerConfig( oauth2Client );
+		const hasCustomBranding = partnerConfig !== null;
 
 		// Build logo element for TopBar
-		const logoConfig = ciabConfig?.compactLogo ?? ciabConfig?.logo;
+		const logoConfig = partnerConfig?.compactLogo ?? partnerConfig?.logo;
 		const topBarLogo =
 			hasCustomBranding && logoConfig?.src ? (
 				<img
@@ -407,11 +424,11 @@ export function usePartnerBranding(): UsePartnerBrandingResult {
 			) : undefined;
 
 		// Build ToS element for signup
-		const signupTosElement = getPartnerSignupTosElement( ciabConfig, translate );
+		const signupTosElement = getPartnerSignupTosElement( partnerConfig, translate );
 
 		return {
 			hasCustomBranding,
-			ciabConfig,
+			partnerConfig,
 			topBarLogo,
 			signupTosElement,
 		};
@@ -423,10 +440,10 @@ export function usePartnerBranding(): UsePartnerBrandingResult {
  * Each partner's ToS text must be a string literal for i18n extraction.
  */
 export function getPartnerSignupTosElement(
-	ciabConfig: CiabPartnerConfig | null,
+	partnerConfig: PartnerConfig | null,
 	translate: ReturnType< typeof useTranslate >
 ): JSX.Element | undefined {
-	if ( ! ciabConfig ) {
+	if ( ! partnerConfig ) {
 		return undefined;
 	}
 
@@ -450,7 +467,7 @@ export function getPartnerSignupTosElement(
 	};
 
 	// Each partner's ToS text - must be string literals for i18n
-	switch ( ciabConfig.id ) {
+	switch ( partnerConfig.id ) {
 		case 'woo':
 			return createInterpolateElement(
 				translate(

--- a/client/lib/test/partner-branding.tsx
+++ b/client/lib/test/partner-branding.tsx
@@ -4,22 +4,22 @@
 import config from '@automattic/calypso-config';
 import { render, screen } from '@testing-library/react';
 import {
-	getCiabConfigFromCurrentDomain,
-	getCiabConfigFromBrandingCode,
-	getCiabConfigFromOAuth2Client,
-	getCiabConfigFromRedirectUrl,
-	getCiabConfigFromGarden,
+	getPartnerConfigFromCurrentDomain,
+	getPartnerConfigFromBrandingCode,
+	getPartnerConfigFromOAuth2Client,
+	getPartnerConfigFromRedirectUrl,
+	getPartnerConfigFromGarden,
 	detectPartnerConfig,
 	getPartnerAllowedSocialServices,
 	getPartnerSignupTosElement,
 	getPartnerWindowTitleSuffix,
 	getPartnerFormattedWindowTitle,
-	persistCiabPartnerId,
-	readPersistedCiabPartnerId,
-	clearPersistedCiabPartnerId,
-	CIAB_PARTNERS,
+	persistPartnerId,
+	readPersistedPartnerId,
+	clearPersistedPartnerId,
+	PARTNERS,
 } from '../partner-branding';
-import type { CiabPartnerConfig } from '../partner-branding';
+import type { PartnerConfig } from '../partner-branding';
 import type { useTranslate } from 'i18n-calypso';
 
 // Mock the config module
@@ -51,7 +51,7 @@ describe( 'partner-branding', () => {
 	}
 
 	beforeEach( () => {
-		clearPersistedCiabPartnerId();
+		clearPersistedPartnerId();
 		( config.isEnabled as jest.Mock ).mockImplementation( ( feature: string ) => {
 			if ( feature === 'ciab/custom-branding' ) {
 				return true;
@@ -68,11 +68,11 @@ describe( 'partner-branding', () => {
 		} );
 	} );
 
-	describe( 'getCiabConfigFromCurrentDomain', () => {
+	describe( 'getPartnerConfigFromCurrentDomain', () => {
 		test( 'returns partner config when current domain matches', () => {
 			setLocation( 'my.woo.ai' );
 
-			const result = getCiabConfigFromCurrentDomain();
+			const result = getPartnerConfigFromCurrentDomain();
 
 			expect( result ).not.toBeNull();
 			expect( result?.id ).toBe( 'woo' );
@@ -81,17 +81,17 @@ describe( 'partner-branding', () => {
 		test( 'returns null when current domain does not match any partner', () => {
 			setLocation( 'wordpress.com' );
 
-			const result = getCiabConfigFromCurrentDomain();
+			const result = getPartnerConfigFromCurrentDomain();
 
 			expect( result ).toBeNull();
 		} );
 	} );
 
-	describe( 'getCiabConfigFromBrandingCode', () => {
+	describe( 'getPartnerConfigFromBrandingCode', () => {
 		test( 'returns partner config when from param matches a valid partner', () => {
 			setLocation( 'wordpress.com', '?from=woo' );
 
-			const result = getCiabConfigFromBrandingCode();
+			const result = getPartnerConfigFromBrandingCode();
 
 			expect( result ).not.toBeNull();
 			expect( result?.id ).toBe( 'woo' );
@@ -100,7 +100,7 @@ describe( 'partner-branding', () => {
 		test( 'returns null when from param does not match any partner', () => {
 			setLocation( 'wordpress.com', '?from=unknown' );
 
-			const result = getCiabConfigFromBrandingCode();
+			const result = getPartnerConfigFromBrandingCode();
 
 			expect( result ).toBeNull();
 		} );
@@ -108,47 +108,47 @@ describe( 'partner-branding', () => {
 		test( 'returns null when from param is absent', () => {
 			setLocation( 'wordpress.com' );
 
-			const result = getCiabConfigFromBrandingCode();
+			const result = getPartnerConfigFromBrandingCode();
 
 			expect( result ).toBeNull();
 		} );
 	} );
 
-	describe( 'getCiabConfigFromRedirectUrl', () => {
+	describe( 'getPartnerConfigFromRedirectUrl', () => {
 		test( 'returns partner config when redirect URL hostname matches a partner domain', () => {
-			const result = getCiabConfigFromRedirectUrl( 'https://my.woo.ai/dashboard' );
+			const result = getPartnerConfigFromRedirectUrl( 'https://my.woo.ai/dashboard' );
 
 			expect( result ).not.toBeNull();
 			expect( result?.id ).toBe( 'woo' );
 		} );
 
 		test( 'returns partner config when redirect URL has path and query params', () => {
-			const result = getCiabConfigFromRedirectUrl( 'https://my.woo.ai/some/path?foo=bar&baz=1' );
+			const result = getPartnerConfigFromRedirectUrl( 'https://my.woo.ai/some/path?foo=bar&baz=1' );
 
 			expect( result ).not.toBeNull();
 			expect( result?.id ).toBe( 'woo' );
 		} );
 
 		test( 'returns null when redirect URL hostname does not match any partner', () => {
-			const result = getCiabConfigFromRedirectUrl( 'https://example.com/dashboard' );
+			const result = getPartnerConfigFromRedirectUrl( 'https://example.com/dashboard' );
 
 			expect( result ).toBeNull();
 		} );
 
 		test( 'returns null when redirect URL is undefined', () => {
-			const result = getCiabConfigFromRedirectUrl( undefined );
+			const result = getPartnerConfigFromRedirectUrl( undefined );
 
 			expect( result ).toBeNull();
 		} );
 
 		test( 'returns null when redirect URL is an invalid URL', () => {
-			const result = getCiabConfigFromRedirectUrl( 'not-a-url' );
+			const result = getPartnerConfigFromRedirectUrl( 'not-a-url' );
 
 			expect( result ).toBeNull();
 		} );
 
 		test( 'handles array of redirect URLs by using first value', () => {
-			const result = getCiabConfigFromRedirectUrl( [
+			const result = getPartnerConfigFromRedirectUrl( [
 				'https://my.woo.ai/dashboard',
 				'https://example.com',
 			] );
@@ -158,41 +158,41 @@ describe( 'partner-branding', () => {
 		} );
 
 		test( 'does not match subdomains of partner domains', () => {
-			const result = getCiabConfigFromRedirectUrl( 'https://sub.my.woo.ai/dashboard' );
+			const result = getPartnerConfigFromRedirectUrl( 'https://sub.my.woo.ai/dashboard' );
 
 			expect( result ).toBeNull();
 		} );
 	} );
 
-	describe( 'getCiabConfigFromOAuth2Client', () => {
+	describe( 'getPartnerConfigFromOAuth2Client', () => {
 		test( 'returns partner config when oauth2Client matches dev ID', () => {
-			const result = getCiabConfigFromOAuth2Client( { id: 134404 } );
+			const result = getPartnerConfigFromOAuth2Client( { id: 134404 } );
 
 			expect( result ).not.toBeNull();
 			expect( result?.id ).toBe( 'woo' );
 		} );
 
 		test( 'returns partner config when oauth2Client matches production ID', () => {
-			const result = getCiabConfigFromOAuth2Client( { id: 134405 } );
+			const result = getPartnerConfigFromOAuth2Client( { id: 134405 } );
 
 			expect( result ).not.toBeNull();
 			expect( result?.id ).toBe( 'woo' );
 		} );
 
 		test( 'returns null when oauth2Client does not match any partner', () => {
-			const result = getCiabConfigFromOAuth2Client( { id: 99999 } );
+			const result = getPartnerConfigFromOAuth2Client( { id: 99999 } );
 
 			expect( result ).toBeNull();
 		} );
 
 		test( 'returns null when oauth2Client is null', () => {
-			const result = getCiabConfigFromOAuth2Client( null );
+			const result = getPartnerConfigFromOAuth2Client( null );
 
 			expect( result ).toBeNull();
 		} );
 
 		test( 'returns null when oauth2Client is undefined', () => {
-			const result = getCiabConfigFromOAuth2Client( undefined );
+			const result = getPartnerConfigFromOAuth2Client( undefined );
 
 			expect( result ).toBeNull();
 		} );
@@ -200,7 +200,7 @@ describe( 'partner-branding', () => {
 		test( 'returns null when feature flag is disabled', () => {
 			( config.isEnabled as jest.Mock ).mockReturnValue( false );
 
-			const result = getCiabConfigFromOAuth2Client( { id: 134404 } );
+			const result = getPartnerConfigFromOAuth2Client( { id: 134404 } );
 
 			expect( result ).toBeNull();
 		} );
@@ -298,9 +298,9 @@ describe( 'partner-branding', () => {
 
 	describe( 'session persistence', () => {
 		test( 'persists and reads partner id', () => {
-			persistCiabPartnerId( 'woo' );
+			persistPartnerId( 'woo' );
 
-			expect( readPersistedCiabPartnerId() ).toBe( 'woo' );
+			expect( readPersistedPartnerId() ).toBe( 'woo' );
 		} );
 
 		test( 'detectPartnerConfig persists partner when detected', () => {
@@ -308,11 +308,11 @@ describe( 'partner-branding', () => {
 
 			detectPartnerConfig();
 
-			expect( readPersistedCiabPartnerId() ).toBe( 'woo' );
+			expect( readPersistedPartnerId() ).toBe( 'woo' );
 		} );
 
 		test( 'detectPartnerConfig uses persisted partner when nothing else matches', () => {
-			persistCiabPartnerId( 'woo' );
+			persistPartnerId( 'woo' );
 			setLocation( 'wordpress.com' );
 
 			const result = detectPartnerConfig();
@@ -321,14 +321,22 @@ describe( 'partner-branding', () => {
 		} );
 
 		test( 'detectPartnerConfig clears persisted partner when feature flag is disabled', () => {
-			persistCiabPartnerId( 'woo' );
+			persistPartnerId( 'woo' );
 			( config.isEnabled as jest.Mock ).mockReturnValue( false );
 			setLocation( 'wordpress.com' );
 
 			const result = detectPartnerConfig();
 
 			expect( result ).toBeNull();
-			expect( readPersistedCiabPartnerId() ).toBeNull();
+			expect( readPersistedPartnerId() ).toBeNull();
+		} );
+
+		test( 'reads legacy session key once and migrates to the partner key', () => {
+			window.sessionStorage.setItem( 'calypso.ciab.partner-id', 'woo' );
+
+			expect( readPersistedPartnerId() ).toBe( 'woo' );
+			expect( window.sessionStorage.getItem( 'calypso.partner.partner-id' ) ).toBe( 'woo' );
+			expect( window.sessionStorage.getItem( 'calypso.ciab.partner-id' ) ).toBeNull();
 		} );
 	} );
 
@@ -338,7 +346,7 @@ describe( 'partner-branding', () => {
 
 			const services = getPartnerAllowedSocialServices();
 
-			expect( services ).toEqual( CIAB_PARTNERS.woo.ssoProviders );
+			expect( services ).toEqual( PARTNERS.woo.ssoProviders );
 		} );
 
 		test( 'returns ssoProviders array when redirect URL matches partner', () => {
@@ -346,7 +354,7 @@ describe( 'partner-branding', () => {
 
 			const services = getPartnerAllowedSocialServices();
 
-			expect( services ).toEqual( CIAB_PARTNERS.woo.ssoProviders );
+			expect( services ).toEqual( PARTNERS.woo.ssoProviders );
 		} );
 
 		test( 'returns null when nothing matches', () => {
@@ -366,23 +374,23 @@ describe( 'partner-branding', () => {
 		} );
 	} );
 
-	describe( 'getCiabConfigFromGarden', () => {
+	describe( 'getPartnerConfigFromGarden', () => {
 		test( 'returns woo config for commerce garden partner mapping', () => {
-			const result = getCiabConfigFromGarden( 'woo', 'commerce' );
+			const result = getPartnerConfigFromGarden( 'woo', 'commerce' );
 
-			expect( result ).toEqual( CIAB_PARTNERS.woo );
+			expect( result ).toEqual( PARTNERS.woo );
 		} );
 
 		test( 'returns null for unsupported garden mapping', () => {
-			const result = getCiabConfigFromGarden( 'woo', 'unknown' );
+			const result = getPartnerConfigFromGarden( 'woo', 'unknown' );
 
 			expect( result ).toBeNull();
 		} );
 
 		test( 'persists partner id when requested', () => {
-			getCiabConfigFromGarden( 'woo', 'commerce', { persistToSession: true } );
+			getPartnerConfigFromGarden( 'woo', 'commerce', { persistToSession: true } );
 
-			expect( readPersistedCiabPartnerId() ).toBe( 'woo' );
+			expect( readPersistedPartnerId() ).toBe( 'woo' );
 		} );
 	} );
 
@@ -390,7 +398,7 @@ describe( 'partner-branding', () => {
 		const mockTranslate = ( ( original: string ) => original ) as ReturnType< typeof useTranslate >;
 
 		test( 'returns a ToS element for supported partners', () => {
-			const tosElement = getPartnerSignupTosElement( CIAB_PARTNERS.woo, mockTranslate );
+			const tosElement = getPartnerSignupTosElement( PARTNERS.woo, mockTranslate );
 
 			expect( tosElement ).toBeDefined();
 			render( <>{ tosElement }</> );
@@ -405,7 +413,7 @@ describe( 'partner-branding', () => {
 	} );
 
 	describe( 'partner without featureFlag is always active', () => {
-		const testPartner: CiabPartnerConfig = {
+		const testPartner: PartnerConfig = {
 			id: 'test-no-flag',
 			displayName: 'Test',
 			logo: { src: 'test.svg', alt: 'Test' },
@@ -414,37 +422,37 @@ describe( 'partner-branding', () => {
 		};
 
 		beforeEach( () => {
-			( CIAB_PARTNERS as Record< string, CiabPartnerConfig > )[ 'test-no-flag' ] = testPartner;
+			( PARTNERS as Record< string, PartnerConfig > )[ 'test-no-flag' ] = testPartner;
 		} );
 
 		afterEach( () => {
-			delete ( CIAB_PARTNERS as Record< string, CiabPartnerConfig > )[ 'test-no-flag' ];
+			delete ( PARTNERS as Record< string, PartnerConfig > )[ 'test-no-flag' ];
 		} );
 
-		test( 'getCiabConfigFromCurrentDomain returns partner even when all feature flags are disabled', () => {
+		test( 'getPartnerConfigFromCurrentDomain returns partner even when all feature flags are disabled', () => {
 			( config.isEnabled as jest.Mock ).mockReturnValue( false );
 			setLocation( 'test.example.com' );
 
-			const result = getCiabConfigFromCurrentDomain();
+			const result = getPartnerConfigFromCurrentDomain();
 
 			expect( result ).not.toBeNull();
 			expect( result?.id ).toBe( 'test-no-flag' );
 		} );
 
-		test( 'getCiabConfigFromBrandingCode returns partner even when all feature flags are disabled', () => {
+		test( 'getPartnerConfigFromBrandingCode returns partner even when all feature flags are disabled', () => {
 			( config.isEnabled as jest.Mock ).mockReturnValue( false );
 			setLocation( 'wordpress.com', '?from=test-no-flag' );
 
-			const result = getCiabConfigFromBrandingCode();
+			const result = getPartnerConfigFromBrandingCode();
 
 			expect( result ).not.toBeNull();
 			expect( result?.id ).toBe( 'test-no-flag' );
 		} );
 	} );
 
-	describe( 'CIAB_PARTNERS', () => {
+	describe( 'PARTNERS', () => {
 		test( 'woo partner has required configuration', () => {
-			const wooConfig = CIAB_PARTNERS.woo;
+			const wooConfig = PARTNERS.woo;
 
 			expect( wooConfig ).toBeDefined();
 			expect( wooConfig.id ).toBe( 'woo' );
@@ -461,7 +469,7 @@ describe( 'partner-branding', () => {
 
 	describe( 'window title helpers', () => {
 		test( 'returns partner-specific suffix when available', () => {
-			expect( getPartnerWindowTitleSuffix( CIAB_PARTNERS.woo ) ).toBe( 'Woo' );
+			expect( getPartnerWindowTitleSuffix( PARTNERS.woo ) ).toBe( 'Woo' );
 		} );
 
 		test( 'falls back to site_name when partner suffix is unavailable', () => {
@@ -469,7 +477,7 @@ describe( 'partner-branding', () => {
 		} );
 
 		test( 'formats title with partner-aware suffix', () => {
-			expect( getPartnerFormattedWindowTitle( 'Accept Invite', CIAB_PARTNERS.woo ) ).toBe(
+			expect( getPartnerFormattedWindowTitle( 'Accept Invite', PARTNERS.woo ) ).toBe(
 				'Accept Invite — Woo'
 			);
 		} );

--- a/client/lib/test/partner-branding.tsx
+++ b/client/lib/test/partner-branding.tsx
@@ -9,7 +9,7 @@ import {
 	getCiabConfigFromOAuth2Client,
 	getCiabConfigFromRedirectUrl,
 	getCiabConfigFromGarden,
-	detectCiabConfig,
+	detectPartnerConfig,
 	getPartnerAllowedSocialServices,
 	getPartnerSignupTosElement,
 	getPartnerWindowTitleSuffix,
@@ -206,11 +206,11 @@ describe( 'partner-branding', () => {
 		} );
 	} );
 
-	describe( 'detectCiabConfig — precedence', () => {
+	describe( 'detectPartnerConfig — precedence', () => {
 		test( 'hostname wins over conflicting from query param', () => {
 			setLocation( 'my.woo.ai', '?from=other' );
 
-			const result = detectCiabConfig();
+			const result = detectPartnerConfig();
 
 			expect( result ).not.toBeNull();
 			expect( result?.id ).toBe( 'woo' );
@@ -219,7 +219,7 @@ describe( 'partner-branding', () => {
 		test( 'hostname wins over conflicting redirect_to', () => {
 			setLocation( 'my.woo.ai', '?redirect_to=https://example.com' );
 
-			const result = detectCiabConfig();
+			const result = detectPartnerConfig();
 
 			expect( result ).not.toBeNull();
 			expect( result?.id ).toBe( 'woo' );
@@ -228,7 +228,7 @@ describe( 'partner-branding', () => {
 		test( 'from=woo still works when hostname does not match', () => {
 			setLocation( 'wordpress.com', '?from=woo' );
 
-			const result = detectCiabConfig();
+			const result = detectPartnerConfig();
 
 			expect( result ).not.toBeNull();
 			expect( result?.id ).toBe( 'woo' );
@@ -237,7 +237,7 @@ describe( 'partner-branding', () => {
 		test( 'from wins over redirect_to when conflicting', () => {
 			setLocation( 'wordpress.com', '?from=woo&redirect_to=https://example.com' );
 
-			const result = detectCiabConfig();
+			const result = detectPartnerConfig();
 
 			expect( result ).not.toBeNull();
 			expect( result?.id ).toBe( 'woo' );
@@ -246,7 +246,7 @@ describe( 'partner-branding', () => {
 		test( 'from wins over oauth2Client when conflicting', () => {
 			setLocation( 'wordpress.com', '?from=woo' );
 
-			const result = detectCiabConfig( { id: 99999 } );
+			const result = detectPartnerConfig( { id: 99999 } );
 
 			expect( result ).not.toBeNull();
 			expect( result?.id ).toBe( 'woo' );
@@ -255,7 +255,7 @@ describe( 'partner-branding', () => {
 		test( 'oauth2Client matching still works when no hostname or from match', () => {
 			setLocation( 'wordpress.com' );
 
-			const result = detectCiabConfig( { id: 134404 } );
+			const result = detectPartnerConfig( { id: 134404 } );
 
 			expect( result ).not.toBeNull();
 			expect( result?.id ).toBe( 'woo' );
@@ -264,7 +264,7 @@ describe( 'partner-branding', () => {
 		test( 'oauth2Client wins over redirect_to when conflicting', () => {
 			setLocation( 'wordpress.com', '?redirect_to=https://example.com' );
 
-			const result = detectCiabConfig( { id: 134405 } );
+			const result = detectPartnerConfig( { id: 134405 } );
 
 			expect( result ).not.toBeNull();
 			expect( result?.id ).toBe( 'woo' );
@@ -273,7 +273,7 @@ describe( 'partner-branding', () => {
 		test( 'redirect_to matching still works when no hostname or from match', () => {
 			setLocation( 'wordpress.com', '?redirect_to=https://my.woo.ai/dashboard' );
 
-			const result = detectCiabConfig();
+			const result = detectPartnerConfig();
 
 			expect( result ).not.toBeNull();
 			expect( result?.id ).toBe( 'woo' );
@@ -282,7 +282,7 @@ describe( 'partner-branding', () => {
 		test( 'returns null when nothing matches', () => {
 			setLocation( 'wordpress.com', '?redirect_to=https://example.com' );
 
-			const result = detectCiabConfig();
+			const result = detectPartnerConfig();
 
 			expect( result ).toBeNull();
 		} );
@@ -290,7 +290,7 @@ describe( 'partner-branding', () => {
 		test( 'returns null when no query params are present', () => {
 			setLocation( 'wordpress.com' );
 
-			const result = detectCiabConfig();
+			const result = detectPartnerConfig();
 
 			expect( result ).toBeNull();
 		} );
@@ -303,29 +303,29 @@ describe( 'partner-branding', () => {
 			expect( readPersistedCiabPartnerId() ).toBe( 'woo' );
 		} );
 
-		test( 'detectCiabConfig persists partner when detected', () => {
+		test( 'detectPartnerConfig persists partner when detected', () => {
 			setLocation( 'wordpress.com', '?from=woo' );
 
-			detectCiabConfig();
+			detectPartnerConfig();
 
 			expect( readPersistedCiabPartnerId() ).toBe( 'woo' );
 		} );
 
-		test( 'detectCiabConfig uses persisted partner when nothing else matches', () => {
+		test( 'detectPartnerConfig uses persisted partner when nothing else matches', () => {
 			persistCiabPartnerId( 'woo' );
 			setLocation( 'wordpress.com' );
 
-			const result = detectCiabConfig();
+			const result = detectPartnerConfig();
 
 			expect( result?.id ).toBe( 'woo' );
 		} );
 
-		test( 'detectCiabConfig clears persisted partner when feature flag is disabled', () => {
+		test( 'detectPartnerConfig clears persisted partner when feature flag is disabled', () => {
 			persistCiabPartnerId( 'woo' );
 			( config.isEnabled as jest.Mock ).mockReturnValue( false );
 			setLocation( 'wordpress.com' );
 
-			const result = detectCiabConfig();
+			const result = detectPartnerConfig();
 
 			expect( result ).toBeNull();
 			expect( readPersistedCiabPartnerId() ).toBeNull();

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -14,7 +14,7 @@ import {
 	isIosOAuth2Client,
 	isStudioAppOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
-import { detectCiabConfig, getPartnerSignupTosElement } from 'calypso/lib/partner-branding';
+import { detectPartnerConfig, getPartnerSignupTosElement } from 'calypso/lib/partner-branding';
 import { login } from 'calypso/lib/paths';
 import OneLoginFooter from 'calypso/login/wp-login/components/one-login-footer';
 import OneLoginLayout from 'calypso/login/wp-login/components/one-login-layout';
@@ -399,7 +399,7 @@ const mapState = ( state ) => {
 			'jetpack-onboarding',
 		isWooJPC: isWooJPCFlow( state ),
 		publicToken: getMagicLoginPublicToken( state ),
-		ciabConfig: detectCiabConfig( getCurrentOAuth2Client( state ) ),
+		ciabConfig: detectPartnerConfig( getCurrentOAuth2Client( state ) ),
 	};
 };
 

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -112,7 +112,7 @@ export class MagicLogin extends Component {
 		// From `localize`
 		translate: PropTypes.func.isRequired,
 		isWooJPC: PropTypes.bool,
-		ciabConfig: PropTypes.object,
+		partnerConfig: PropTypes.object,
 	};
 
 	state = {
@@ -167,7 +167,7 @@ export class MagicLogin extends Component {
 
 		const isA4A = query?.redirect_to?.includes( 'agencies.automattic.com/client' ) ?? false;
 		const isMobileApp = isIosOAuth2Client( oauth2Client ) || isAndroidOAuth2Client( oauth2Client );
-		const hasPartnerBranding = Boolean( this.props.ciabConfig );
+		const hasPartnerBranding = Boolean( this.props.partnerConfig );
 
 		if ( showCheckYourEmail ) {
 			if ( isA4A || isMobileApp || hasPartnerBranding ) {
@@ -232,8 +232,8 @@ export class MagicLogin extends Component {
 	}
 
 	renderTos = () => {
-		const { ciabConfig, translate } = this.props;
-		const partnerTosElement = getPartnerSignupTosElement( ciabConfig, translate );
+		const { partnerConfig, translate } = this.props;
+		const partnerTosElement = getPartnerSignupTosElement( partnerConfig, translate );
 
 		if ( partnerTosElement ) {
 			return partnerTosElement;
@@ -351,10 +351,10 @@ export const getMagicLoginInitialHeaders = ( props, translate ) => {
 		return getCheckYourEmailHeaders( translate, { emailAddress } );
 	}
 
-	const headingOverride = props.ciabConfig?.displayName
+	const headingOverride = props.partnerConfig?.displayName
 		? translate( 'Log in to %(partnerName)s', {
 				args: {
-					partnerName: props.ciabConfig.displayName,
+					partnerName: props.partnerConfig.displayName,
 				},
 		  } )
 		: undefined;
@@ -399,7 +399,7 @@ const mapState = ( state ) => {
 			'jetpack-onboarding',
 		isWooJPC: isWooJPCFlow( state ),
 		publicToken: getMagicLoginPublicToken( state ),
-		ciabConfig: detectPartnerConfig( getCurrentOAuth2Client( state ) ),
+		partnerConfig: detectPartnerConfig( getCurrentOAuth2Client( state ) ),
 	};
 };
 

--- a/client/login/magic-login/test/index.test.jsx
+++ b/client/login/magic-login/test/index.test.jsx
@@ -4,7 +4,7 @@ import { getPartnerSignupTosElement } from 'calypso/lib/partner-branding';
 import { getMagicLoginInitialHeaders, MagicLogin } from '../index';
 
 jest.mock( 'calypso/lib/partner-branding', () => ( {
-	detectCiabConfig: jest.fn(),
+	detectPartnerConfig: jest.fn(),
 	getPartnerSignupTosElement: jest.fn(),
 } ) );
 

--- a/client/login/magic-login/test/index.test.jsx
+++ b/client/login/magic-login/test/index.test.jsx
@@ -22,7 +22,7 @@ describe( 'magic-login branding behavior', () => {
 		translate: ( text ) => text,
 		oauth2Client: null,
 		isWooJPC: false,
-		ciabConfig: null,
+		partnerConfig: null,
 	};
 
 	beforeEach( () => {
@@ -41,7 +41,7 @@ describe( 'magic-login branding behavior', () => {
 		const { heading } = getMagicLoginInitialHeaders(
 			{
 				...baseProps,
-				ciabConfig: {
+				partnerConfig: {
 					displayName: 'Woo',
 				},
 			},
@@ -70,7 +70,7 @@ describe( 'magic-login branding behavior', () => {
 
 		const instance = new MagicLogin( {
 			...baseProps,
-			ciabConfig: { id: 'woo', displayName: 'Woo' },
+			partnerConfig: { id: 'woo', displayName: 'Woo' },
 		} );
 
 		expect( instance.renderTos() ).toBe( partnerTosElement );
@@ -103,7 +103,7 @@ describe( 'magic-login branding behavior', () => {
 		const instance = new MagicLogin( {
 			...baseProps,
 			showCheckYourEmail: true,
-			ciabConfig: { id: 'woo', displayName: 'Woo' },
+			partnerConfig: { id: 'woo', displayName: 'Woo' },
 		} );
 
 		expect( instance.renderLinks() ).toBeNull();
@@ -113,7 +113,7 @@ describe( 'magic-login branding behavior', () => {
 		const instance = new MagicLogin( {
 			...baseProps,
 			showCheckYourEmail: true,
-			ciabConfig: null,
+			partnerConfig: null,
 		} );
 
 		expect( instance.renderLinks() ).toEqual(

--- a/client/login/wp-login/hooks/get-header-text.tsx
+++ b/client/login/wp-login/hooks/get-header-text.tsx
@@ -9,7 +9,7 @@ import {
 } from 'calypso/lib/oauth2-clients';
 import { getOAuth2Client } from 'calypso/state/oauth2-clients/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
-import type { CiabPartnerConfig } from 'calypso/lib/partner-branding';
+import type { PartnerConfig } from 'calypso/lib/partner-branding';
 
 interface Props {
 	twoFactorAuthType: string | null;
@@ -29,7 +29,7 @@ interface Props {
 	isFromAkismet?: boolean;
 	isFromPassport?: boolean;
 	isFromAutomatticForAgenciesPlugin?: boolean;
-	ciabConfig?: CiabPartnerConfig | null;
+	partnerConfig?: PartnerConfig | null;
 	isGravPoweredClient?: boolean;
 	isUserLoggedIn?: boolean;
 }
@@ -72,7 +72,7 @@ export function getHeaderText( {
 	isFromAkismet,
 	isFromPassport,
 	isFromAutomatticForAgenciesPlugin,
-	ciabConfig,
+	partnerConfig,
 	isGravPoweredClient,
 	currentQuery,
 	translate,
@@ -96,9 +96,9 @@ export function getHeaderText( {
 
 	if ( isSocialFirst ) {
 		// CIAB partners have custom headers without "with WordPress.com"
-		if ( ciabConfig ) {
+		if ( partnerConfig ) {
 			headerText = translate( 'Log in to %(partner)s', {
-				args: { partner: ciabConfig.displayName },
+				args: { partner: partnerConfig.displayName },
 			} );
 		} else {
 			let clientName = oauth2Client?.name;

--- a/client/login/wp-login/hooks/get-heading-subtext.tsx
+++ b/client/login/wp-login/hooks/get-heading-subtext.tsx
@@ -1,13 +1,13 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { type LocalizeProps } from 'i18n-calypso';
-import type { CiabPartnerConfig } from 'calypso/lib/partner-branding';
+import type { PartnerConfig } from 'calypso/lib/partner-branding';
 
 interface Props {
 	isSocialFirst: boolean;
 	twoFactorAuthType: string;
 	action?: string;
 	isWooJPC?: boolean;
-	ciabConfig?: CiabPartnerConfig | null;
+	partnerConfig?: PartnerConfig | null;
 	translate: LocalizeProps[ 'translate' ];
 }
 
@@ -20,7 +20,7 @@ const getHeadingSubText = ( {
 	action,
 	translate,
 	isWooJPC,
-	ciabConfig,
+	partnerConfig,
 }: Props ) => {
 	if ( ! isSocialFirst || twoFactorAuthType ) {
 		return null;
@@ -28,7 +28,7 @@ const getHeadingSubText = ( {
 
 	const tos = (
 		<span className="wp-login__one-login-layout-tos">
-			{ ciabConfig
+			{ partnerConfig
 				? translate(
 						'By continuing with any of the options below, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}. WordPress.com is used to manage your account.',
 						{

--- a/client/login/wp-login/hooks/test/get-heading-subtext.test.tsx
+++ b/client/login/wp-login/hooks/test/get-heading-subtext.test.tsx
@@ -16,7 +16,7 @@ describe( 'getHeadingSubText', () => {
 			action: 'login',
 			translate,
 			isWooJPC: false,
-			ciabConfig: {
+			partnerConfig: {
 				id: 'woo',
 				displayName: 'Woo',
 				featureFlag: 'ciab/custom-branding',
@@ -37,7 +37,7 @@ describe( 'getHeadingSubText', () => {
 			action: 'login',
 			translate,
 			isWooJPC: true,
-			ciabConfig: {
+			partnerConfig: {
 				id: 'woo',
 				displayName: 'Woo',
 				featureFlag: 'ciab/custom-branding',

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -114,7 +114,7 @@ export class Login extends Component {
 			'isFromAkismet',
 			'isFromPassport',
 			'isFromAutomatticForAgenciesPlugin',
-			'ciabConfig',
+			'partnerConfig',
 			'isGravPoweredClient',
 			'currentQuery',
 			'translate',
@@ -322,7 +322,7 @@ export class Login extends Component {
 			isGravPoweredClient,
 			isJetpack,
 			action,
-			ciabConfig,
+			partnerConfig,
 		} = this.props;
 
 		const canonicalUrl = localizeUrl( 'https://wordpress.com/log-in', locale );
@@ -343,7 +343,7 @@ export class Login extends Component {
 				<DocumentHead
 					title={ getPartnerFormattedWindowTitle(
 						translate( 'Log In', { textOnly: true } ),
-						ciabConfig
+						partnerConfig
 					) }
 					skipTitleFormatting
 					link={ [ { rel: 'canonical', href: canonicalUrl } ] }
@@ -398,7 +398,7 @@ function getInitialHeadingState( props, translate ) {
 		isFromAkismet,
 		isFromPassport,
 		isFromAutomatticForAgenciesPlugin,
-		ciabConfig,
+		partnerConfig,
 		isGravPoweredClient,
 		currentQuery,
 		isUserLoggedIn: isLoggedIn,
@@ -421,7 +421,7 @@ function getInitialHeadingState( props, translate ) {
 		isFromAkismet,
 		isFromPassport,
 		isFromAutomatticForAgenciesPlugin,
-		ciabConfig,
+		partnerConfig,
 		isGravPoweredClient,
 		currentQuery,
 		translate,
@@ -434,7 +434,7 @@ function getInitialHeadingState( props, translate ) {
 		action,
 		translate,
 		isWooJPC,
-		ciabConfig,
+		partnerConfig,
 	} );
 
 	return {
@@ -506,7 +506,7 @@ export default connect(
 				'automattic-for-agencies-client' === get( getCurrentQueryArguments( state ), 'from' ) ||
 				'automattic-for-agencies-client' ===
 					new URLSearchParams( getRedirectToOriginal( state )?.split( '?' )[ 1 ] ).get( 'from' ),
-			ciabConfig: detectPartnerConfig( oauth2Client ),
+			partnerConfig: detectPartnerConfig( oauth2Client ),
 			isManualRenewalImmediateLoginAttempt: wasManualRenewalImmediateLoginAttempted( state ),
 			isUserLoggedIn: isUserLoggedIn( state ),
 			isWooPaymentsFlow: isWooCommercePaymentsOnboardingFlow( state ),

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -21,7 +21,7 @@ import {
 	isCrowdsignalOAuth2Client,
 	isVIPOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
-import { detectCiabConfig, getPartnerFormattedWindowTitle } from 'calypso/lib/partner-branding';
+import { detectPartnerConfig, getPartnerFormattedWindowTitle } from 'calypso/lib/partner-branding';
 import isPassportRedirect from 'calypso/lib/passport/is-passport-redirect';
 import { login } from 'calypso/lib/paths';
 import { getHeaderText } from 'calypso/login/wp-login/hooks/get-header-text';
@@ -506,7 +506,7 @@ export default connect(
 				'automattic-for-agencies-client' === get( getCurrentQueryArguments( state ), 'from' ) ||
 				'automattic-for-agencies-client' ===
 					new URLSearchParams( getRedirectToOriginal( state )?.split( '?' )[ 1 ] ).get( 'from' ),
-			ciabConfig: detectCiabConfig( oauth2Client ),
+			ciabConfig: detectPartnerConfig( oauth2Client ),
 			isManualRenewalImmediateLoginAttempt: wasManualRenewalImmediateLoginAttempted( state ),
 			isUserLoggedIn: isUserLoggedIn( state ),
 			isWooPaymentsFlow: isWooCommercePaymentsOnboardingFlow( state ),

--- a/client/my-sites/invites-unified/index.tsx
+++ b/client/my-sites/invites-unified/index.tsx
@@ -1,7 +1,7 @@
 import { Step } from '@automattic/onboarding';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { getCiabConfigFromGarden } from 'calypso/lib/partner-branding';
+import { getPartnerConfigFromGarden } from 'calypso/lib/partner-branding';
 import normalizeInvite from 'calypso/my-sites/invites/invite-accept/utils/normalize-invite';
 import LoggedOutInviteAccept from 'calypso/my-sites/invites/invite-accept-logged-out';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -44,7 +44,7 @@ export function UnifiedInviteAccept( {
 	const blogDetails = ( inviteData as { blog_details?: InviteBlogDetails } )?.blog_details;
 	const branding =
 		blogDetails?.is_garden_site && blogDetails.garden
-			? getCiabConfigFromGarden( blogDetails.garden.partner, blogDetails.garden.name, {
+			? getPartnerConfigFromGarden( blogDetails.garden.partner, blogDetails.garden.name, {
 					persistToSession: true,
 			  } )
 			: null;

--- a/client/my-sites/invites-unified/screens/accept-invite-screen.tsx
+++ b/client/my-sites/invites-unified/screens/accept-invite-screen.tsx
@@ -13,9 +13,9 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { navigate } from 'calypso/lib/navigate';
 import {
 	detectPartnerConfig,
-	getCiabConfigFromGarden,
+	getPartnerConfigFromGarden,
 	getPartnerFormattedWindowTitle,
-	type CiabPartnerConfig,
+	type PartnerConfig,
 } from 'calypso/lib/partner-branding';
 import { login } from 'calypso/lib/paths';
 import { getRedirectAfterAccept } from 'calypso/my-sites/invites/utils';
@@ -56,12 +56,12 @@ function toLegacyInvite( invite: Invite ) {
 /**
  * Get CIAB branding config from blog details
  */
-function getBrandingFromBlogDetails( blogDetails?: InviteBlogDetails ): CiabPartnerConfig | null {
+function getBrandingFromBlogDetails( blogDetails?: InviteBlogDetails ): PartnerConfig | null {
 	if ( ! blogDetails?.is_garden_site || ! blogDetails?.garden ) {
 		return null;
 	}
 
-	return getCiabConfigFromGarden( blogDetails.garden.partner, blogDetails.garden.name, {
+	return getPartnerConfigFromGarden( blogDetails.garden.partner, blogDetails.garden.name, {
 		persistToSession: true,
 	} );
 }
@@ -257,7 +257,7 @@ export function AcceptInviteScreen( { invite }: AcceptInviteScreenProps ) {
 				inviteSentTo={ inviteSentTo }
 				isKnownUser={ isKnownUser }
 				topBarLogo={ topBarLogo }
-				ciabConfig={ titleBranding }
+				partnerConfig={ titleBranding }
 				trackingProps={ trackingProps }
 			/>
 		);

--- a/client/my-sites/invites-unified/screens/accept-invite-screen.tsx
+++ b/client/my-sites/invites-unified/screens/accept-invite-screen.tsx
@@ -12,7 +12,7 @@ import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { navigate } from 'calypso/lib/navigate';
 import {
-	detectCiabConfig,
+	detectPartnerConfig,
 	getCiabConfigFromGarden,
 	getPartnerFormattedWindowTitle,
 	type CiabPartnerConfig,
@@ -169,7 +169,7 @@ export function AcceptInviteScreen( { invite }: AcceptInviteScreenProps ) {
 
 	// Get branding from blog_details garden info
 	const branding = getBrandingFromBlogDetails( invite?.blog_details );
-	const titleBranding = branding ?? detectCiabConfig();
+	const titleBranding = branding ?? detectPartnerConfig();
 	const gardenName = invite?.blog_details?.garden?.name || null;
 	const gardenPartner = invite?.blog_details?.garden?.partner || null;
 

--- a/client/my-sites/invites-unified/screens/email-mismatch-screen.tsx
+++ b/client/my-sites/invites-unified/screens/email-mismatch-screen.tsx
@@ -7,10 +7,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { navigate } from 'calypso/lib/navigate';
-import {
-	getPartnerFormattedWindowTitle,
-	type CiabPartnerConfig,
-} from 'calypso/lib/partner-branding';
+import { getPartnerFormattedWindowTitle, type PartnerConfig } from 'calypso/lib/partner-branding';
 import { login } from 'calypso/lib/paths';
 
 import './style.scss';
@@ -19,7 +16,7 @@ interface EmailMismatchScreenProps {
 	inviteSentTo: string;
 	isKnownUser: boolean;
 	topBarLogo?: React.ReactNode;
-	ciabConfig: CiabPartnerConfig | null;
+	partnerConfig: PartnerConfig | null;
 	trackingProps: Record< string, unknown >;
 }
 
@@ -27,7 +24,7 @@ export function EmailMismatchScreen( {
 	inviteSentTo,
 	isKnownUser,
 	topBarLogo,
-	ciabConfig,
+	partnerConfig,
 	trackingProps,
 }: EmailMismatchScreenProps ) {
 	const translate = useTranslate();
@@ -69,7 +66,7 @@ export function EmailMismatchScreen( {
 			<DocumentHead
 				title={ getPartnerFormattedWindowTitle(
 					translate( 'Accept Invite', { textOnly: true } ),
-					ciabConfig
+					partnerConfig
 				) }
 				skipTitleFormatting
 			/>

--- a/client/my-sites/invites-unified/screens/invite-screen-layout.tsx
+++ b/client/my-sites/invites-unified/screens/invite-screen-layout.tsx
@@ -9,7 +9,7 @@ import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { navigate } from 'calypso/lib/navigate';
 import {
-	detectCiabConfig,
+	detectPartnerConfig,
 	getCiabConfigFromGarden,
 	getPartnerFormattedWindowTitle,
 } from 'calypso/lib/partner-branding';
@@ -79,7 +79,7 @@ export function InviteScreenLayout( {
 				persistToSession: true,
 		  } )
 		: null;
-	const titleBranding = branding ?? detectCiabConfig();
+	const titleBranding = branding ?? detectPartnerConfig();
 
 	const topBarLogoConfig = branding?.compactLogo ?? branding?.logo;
 	const topBarLogo = topBarLogoConfig?.src ? (

--- a/client/my-sites/invites-unified/screens/invite-screen-layout.tsx
+++ b/client/my-sites/invites-unified/screens/invite-screen-layout.tsx
@@ -10,7 +10,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { navigate } from 'calypso/lib/navigate';
 import {
 	detectPartnerConfig,
-	getCiabConfigFromGarden,
+	getPartnerConfigFromGarden,
 	getPartnerFormattedWindowTitle,
 } from 'calypso/lib/partner-branding';
 import { login } from 'calypso/lib/paths';
@@ -75,7 +75,7 @@ export function InviteScreenLayout( {
 	};
 
 	const branding = blogDetails?.garden
-		? getCiabConfigFromGarden( blogDetails.garden.partner, blogDetails.garden.name, {
+		? getPartnerConfigFromGarden( blogDetails.garden.partner, blogDetails.garden.name, {
 				persistToSession: true,
 		  } )
 		: null;

--- a/client/my-sites/invites-unified/screens/test/accept-invite-screen.test.tsx
+++ b/client/my-sites/invites-unified/screens/test/accept-invite-screen.test.tsx
@@ -153,7 +153,7 @@ const mockWooBranding = {
 };
 
 jest.mock( 'calypso/lib/partner-branding', () => ( {
-	detectCiabConfig: () => null,
+	detectPartnerConfig: () => null,
 	getCiabConfigFromGarden: ( partner: string, name: string ) => {
 		if ( partner === 'woo' && name === 'commerce' ) {
 			return mockWooBranding;

--- a/client/my-sites/invites-unified/screens/test/accept-invite-screen.test.tsx
+++ b/client/my-sites/invites-unified/screens/test/accept-invite-screen.test.tsx
@@ -154,7 +154,7 @@ const mockWooBranding = {
 
 jest.mock( 'calypso/lib/partner-branding', () => ( {
 	detectPartnerConfig: () => null,
-	getCiabConfigFromGarden: ( partner: string, name: string ) => {
+	getPartnerConfigFromGarden: ( partner: string, name: string ) => {
 		if ( partner === 'woo' && name === 'commerce' ) {
 			return mockWooBranding;
 		}
@@ -162,8 +162,8 @@ jest.mock( 'calypso/lib/partner-branding', () => ( {
 	},
 	getPartnerFormattedWindowTitle: (
 		title: string,
-		ciabConfig: { windowTitleSuffix?: string } | null
-	) => `${ title } — ${ ciabConfig?.windowTitleSuffix || 'WordPress.com' }`,
+		partnerConfig: { windowTitleSuffix?: string } | null
+	) => `${ title } — ${ partnerConfig?.windowTitleSuffix || 'WordPress.com' }`,
 } ) );
 
 jest.mock( 'calypso/lib/paths', () => ( {

--- a/client/my-sites/invites-unified/screens/test/already-member-screen.test.tsx
+++ b/client/my-sites/invites-unified/screens/test/already-member-screen.test.tsx
@@ -98,7 +98,7 @@ jest.mock( 'calypso/lib/navigate', () => ( {
 
 jest.mock( 'calypso/lib/partner-branding', () => ( {
 	detectPartnerConfig: () => null,
-	getCiabConfigFromGarden: ( partner: string, name: string ) => {
+	getPartnerConfigFromGarden: ( partner: string, name: string ) => {
 		if ( partner === 'woo' && name === 'commerce' ) {
 			return {
 				windowTitleSuffix: 'Woo',
@@ -120,8 +120,8 @@ jest.mock( 'calypso/lib/partner-branding', () => ( {
 	},
 	getPartnerFormattedWindowTitle: (
 		title: string,
-		ciabConfig: { windowTitleSuffix?: string } | null
-	) => `${ title } — ${ ciabConfig?.windowTitleSuffix || 'WordPress.com' }`,
+		partnerConfig: { windowTitleSuffix?: string } | null
+	) => `${ title } — ${ partnerConfig?.windowTitleSuffix || 'WordPress.com' }`,
 } ) );
 
 jest.mock( 'calypso/lib/paths', () => ( {

--- a/client/my-sites/invites-unified/screens/test/already-member-screen.test.tsx
+++ b/client/my-sites/invites-unified/screens/test/already-member-screen.test.tsx
@@ -97,7 +97,7 @@ jest.mock( 'calypso/lib/navigate', () => ( {
 } ) );
 
 jest.mock( 'calypso/lib/partner-branding', () => ( {
-	detectCiabConfig: () => null,
+	detectPartnerConfig: () => null,
 	getCiabConfigFromGarden: ( partner: string, name: string ) => {
 		if ( partner === 'woo' && name === 'commerce' ) {
 			return {

--- a/client/my-sites/invites-unified/screens/test/email-mismatch-screen.test.tsx
+++ b/client/my-sites/invites-unified/screens/test/email-mismatch-screen.test.tsx
@@ -102,7 +102,7 @@ describe( 'EmailMismatchScreen', () => {
 			<EmailMismatchScreen
 				inviteSentTo="invited@example.com"
 				isKnownUser
-				ciabConfig={ null }
+				partnerConfig={ null }
 				trackingProps={ { unified: true } }
 			/>
 		);
@@ -121,7 +121,7 @@ describe( 'EmailMismatchScreen', () => {
 			<EmailMismatchScreen
 				inviteSentTo="invited@example.com"
 				isKnownUser
-				ciabConfig={ null }
+				partnerConfig={ null }
 				trackingProps={ { unified: true } }
 			/>
 		);
@@ -134,7 +134,7 @@ describe( 'EmailMismatchScreen', () => {
 			<EmailMismatchScreen
 				inviteSentTo="invited@example.com"
 				isKnownUser={ false }
-				ciabConfig={ null }
+				partnerConfig={ null }
 				trackingProps={ { unified: true } }
 			/>
 		);
@@ -148,7 +148,7 @@ describe( 'EmailMismatchScreen', () => {
 			<EmailMismatchScreen
 				inviteSentTo="invited@example.com"
 				isKnownUser
-				ciabConfig={ null }
+				partnerConfig={ null }
 				trackingProps={ { role: 'administrator', unified: true } }
 			/>
 		);

--- a/client/my-sites/invites-unified/test/index.test.tsx
+++ b/client/my-sites/invites-unified/test/index.test.tsx
@@ -24,7 +24,7 @@ jest.mock( '@automattic/onboarding', () => ( {
 } ) );
 
 jest.mock( 'calypso/lib/partner-branding', () => ( {
-	detectCiabConfig: () => null,
+	detectPartnerConfig: () => null,
 	getCiabConfigFromGarden: () => ( {
 		windowTitleSuffix: 'Woo',
 		compactLogo: {

--- a/client/my-sites/invites-unified/test/index.test.tsx
+++ b/client/my-sites/invites-unified/test/index.test.tsx
@@ -25,7 +25,7 @@ jest.mock( '@automattic/onboarding', () => ( {
 
 jest.mock( 'calypso/lib/partner-branding', () => ( {
 	detectPartnerConfig: () => null,
-	getCiabConfigFromGarden: () => ( {
+	getPartnerConfigFromGarden: () => ( {
 		windowTitleSuffix: 'Woo',
 		compactLogo: {
 			src: 'https://example.com/compact-logo.svg',
@@ -42,8 +42,8 @@ jest.mock( 'calypso/lib/partner-branding', () => ( {
 	} ),
 	getPartnerFormattedWindowTitle: (
 		title: string,
-		ciabConfig: { windowTitleSuffix?: string } | null
-	) => `${ title } — ${ ciabConfig?.windowTitleSuffix || 'WordPress.com' }`,
+		partnerConfig: { windowTitleSuffix?: string } | null
+	) => `${ title } — ${ partnerConfig?.windowTitleSuffix || 'WordPress.com' }`,
 } ) );
 
 jest.mock( 'calypso/my-sites/invites/invite-accept/utils/normalize-invite', () => ( {

--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -7,7 +7,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import { navigate } from 'calypso/lib/navigate';
 import {
 	detectPartnerConfig,
-	getCiabConfigFromGarden,
+	getPartnerConfigFromGarden,
 	getPartnerFormattedWindowTitle,
 } from 'calypso/lib/partner-branding';
 import InviteAccept from 'calypso/my-sites/invites/invite-accept';
@@ -66,9 +66,9 @@ export function acceptInvite( context, next ) {
 	const AcceptInviteTitle = () => {
 		const translate = useTranslate();
 		const blogDetails = context.inviteData?.blog_details;
-		const ciabConfig =
+		const partnerConfig =
 			blogDetails?.is_garden_site && blogDetails.garden
-				? getCiabConfigFromGarden( blogDetails.garden.partner, blogDetails.garden.name, {
+				? getPartnerConfigFromGarden( blogDetails.garden.partner, blogDetails.garden.name, {
 						persistToSession: true,
 				  } )
 				: detectPartnerConfig();
@@ -77,7 +77,7 @@ export function acceptInvite( context, next ) {
 			<DocumentHead
 				title={ getPartnerFormattedWindowTitle(
 					translate( 'Accept Invite', { textOnly: true } ),
-					ciabConfig
+					partnerConfig
 				) }
 				skipTitleFormatting
 			/>

--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -6,7 +6,7 @@ import store from 'store';
 import DocumentHead from 'calypso/components/data/document-head';
 import { navigate } from 'calypso/lib/navigate';
 import {
-	detectCiabConfig,
+	detectPartnerConfig,
 	getCiabConfigFromGarden,
 	getPartnerFormattedWindowTitle,
 } from 'calypso/lib/partner-branding';
@@ -71,7 +71,7 @@ export function acceptInvite( context, next ) {
 				? getCiabConfigFromGarden( blogDetails.garden.partner, blogDetails.garden.name, {
 						persistToSession: true,
 				  } )
-				: detectCiabConfig();
+				: detectPartnerConfig();
 
 		return (
 			<DocumentHead

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -11,7 +11,7 @@ import LoggedOutFormLinkItem from 'calypso/components/logged-out-form/link-item'
 import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { getCiabConfigFromGarden } from 'calypso/lib/partner-branding';
+import { getPartnerConfigFromGarden } from 'calypso/lib/partner-branding';
 import { login } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/route';
 import InviteFormHeaderLoggedOut from 'calypso/my-sites/invites/invite-form-header-logged-out';
@@ -129,7 +129,7 @@ class InviteAcceptLoggedOut extends Component {
 		return (
 			<InviteFormHeaderLoggedOut
 				site={ this.props.invite?.site }
-				ciabConfig={ this.getCiabConfig() }
+				partnerConfig={ this.getCiabConfig() }
 			/>
 		);
 	};
@@ -139,7 +139,7 @@ class InviteAcceptLoggedOut extends Component {
 		const gardenName = site?.garden?.name;
 		const gardenPartner = site?.garden?.partner;
 
-		return getCiabConfigFromGarden( gardenPartner, gardenName, { persistToSession: true } );
+		return getPartnerConfigFromGarden( gardenPartner, gardenName, { persistToSession: true } );
 	};
 
 	loginUser = () => {
@@ -215,15 +215,15 @@ class InviteAcceptLoggedOut extends Component {
 	};
 
 	render() {
-		const ciabConfig = this.getCiabConfig();
+		const partnerConfig = this.getCiabConfig();
 
 		if ( this.props.forceMatchingEmail && this.props.invite.knownUser ) {
 			return (
 				<>
 					<BodySectionCssClass
-						bodyClass={ ciabConfig?.fontStyle === 'system' ? [ 'is-ciab-font-system' ] : [] }
+						bodyClass={ partnerConfig?.fontStyle === 'system' ? [ 'is-ciab-font-system' ] : [] }
 					/>
-					<WpLoggedOutInviteLogo ciabConfig={ ciabConfig } />
+					<WpLoggedOutInviteLogo partnerConfig={ partnerConfig } />
 					{ this.renderSignInLinkOnly() }
 				</>
 			);
@@ -244,9 +244,9 @@ class InviteAcceptLoggedOut extends Component {
 		return (
 			<>
 				<BodySectionCssClass
-					bodyClass={ ciabConfig?.fontStyle === 'system' ? [ 'is-ciab-font-system' ] : [] }
+					bodyClass={ partnerConfig?.fontStyle === 'system' ? [ 'is-ciab-font-system' ] : [] }
 				/>
-				<WpLoggedOutInviteLogo ciabConfig={ ciabConfig } />
+				<WpLoggedOutInviteLogo partnerConfig={ partnerConfig } />
 				<div className="invite-accept-logged-out-wrapper">
 					{ this.renderFormHeader() }
 					<SignupForm

--- a/client/my-sites/invites/invite-accept-logged-out/wp-logo.tsx
+++ b/client/my-sites/invites/invite-accept-logged-out/wp-logo.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
-import type { CiabPartnerConfig } from 'calypso/lib/partner-branding';
+import type { PartnerConfig } from 'calypso/lib/partner-branding';
 
 interface WpLoggedOutInviteLogoProps {
-	ciabConfig?: CiabPartnerConfig | null;
+	partnerConfig?: PartnerConfig | null;
 }
 
-export const WpLoggedOutInviteLogo: React.FC< WpLoggedOutInviteLogoProps > = ( { ciabConfig } ) => {
-	const logo = ciabConfig?.logo;
+export const WpLoggedOutInviteLogo: React.FC< WpLoggedOutInviteLogoProps > = ( {
+	partnerConfig,
+} ) => {
+	const logo = partnerConfig?.logo;
 
 	if ( logo?.src ) {
 		return (

--- a/client/my-sites/invites/invite-form-header-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-form-header-logged-out/index.jsx
@@ -5,7 +5,7 @@ import { useTranslate } from 'i18n-calypso';
 import { BrandHeader } from 'calypso/components/connect-screen/brand-header';
 import { getPartnerSignupTosElement } from 'calypso/lib/partner-branding';
 
-function InviteFormHeaderLoggedOut( { site, ciabConfig } ) {
+function InviteFormHeaderLoggedOut( { site, partnerConfig } ) {
 	const translate = useTranslate();
 	const siteName = site?.title || site?.domain || translate( 'this site' );
 	const siteUrl = site?.URL;
@@ -27,7 +27,7 @@ function InviteFormHeaderLoggedOut( { site, ciabConfig } ) {
 	);
 
 	const description =
-		getPartnerSignupTosElement( ciabConfig, translate ) ||
+		getPartnerSignupTosElement( partnerConfig, translate ) ||
 		createInterpolateElement(
 			translate(
 				'Just a little reminder that by continuing with any of the options below, you agree to our <tosLink>Terms of Service</tosLink> and <privacyLink>Privacy Policy</privacyLink>.'

--- a/client/my-sites/invites/test/invite-accept-logged-out.jsx
+++ b/client/my-sites/invites/test/invite-accept-logged-out.jsx
@@ -47,7 +47,7 @@ jest.mock( 'calypso/lib/analytics/tracks', () => ( {
 } ) );
 
 jest.mock( 'calypso/lib/partner-branding', () => ( {
-	getCiabConfigFromGarden: ( ...args ) => mockGetCiabConfigFromGarden( ...args ),
+	getPartnerConfigFromGarden: ( ...args ) => mockGetCiabConfigFromGarden( ...args ),
 } ) );
 
 jest.mock( 'calypso/lib/paths', () => ( {

--- a/client/my-sites/invites/test/invite-form-header-logged-out.jsx
+++ b/client/my-sites/invites/test/invite-form-header-logged-out.jsx
@@ -62,7 +62,7 @@ describe( 'InviteFormHeaderLoggedOut', () => {
 					title: 'Woo Store',
 					URL: 'https://woo.store',
 				} }
-				ciabConfig={ { id: 'woo' } }
+				partnerConfig={ { id: 'woo' } }
 			/>
 		);
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -128,7 +128,7 @@ class Signup extends Component {
 		flowName: PropTypes.string,
 		stepName: PropTypes.string,
 		pageTitle: PropTypes.string,
-		ciabConfig: PropTypes.object,
+		partnerConfig: PropTypes.object,
 		stepSectionName: PropTypes.string,
 		hostingFlow: PropTypes.bool.isRequired,
 	};
@@ -873,7 +873,10 @@ class Signup extends Component {
 			<>
 				<div className={ `signup is-${ kebabCase( this.props.flowName ) }` }>
 					<DocumentHead
-						title={ getPartnerFormattedWindowTitle( this.props.pageTitle, this.props.ciabConfig ) }
+						title={ getPartnerFormattedWindowTitle(
+							this.props.pageTitle,
+							this.props.partnerConfig
+						) }
 						skipTitleFormatting
 					/>
 					{ showPageHeader && (
@@ -940,7 +943,7 @@ export default connect(
 			siteId,
 			localeSlug: getCurrentLocaleSlug( state ),
 			oauth2Client,
-			ciabConfig: detectPartnerConfig( oauth2Client ),
+			partnerConfig: detectPartnerConfig( oauth2Client ),
 			isGravatar: isGravatarOAuth2Client( oauth2Client ),
 			wccomFrom: getWccomFrom( state ),
 			hostingFlow,

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -46,7 +46,7 @@ import {
 	isGravatarOAuth2Client,
 	isPartnerPortalOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
-import { detectCiabConfig, getPartnerFormattedWindowTitle } from 'calypso/lib/partner-branding';
+import { detectPartnerConfig, getPartnerFormattedWindowTitle } from 'calypso/lib/partner-branding';
 import SignupFlowController from 'calypso/lib/signup/flow-controller';
 import FlowProgressIndicator from 'calypso/signup/flow-progress-indicator';
 import SignupHeader from 'calypso/signup/signup-header';
@@ -940,7 +940,7 @@ export default connect(
 			siteId,
 			localeSlug: getCurrentLocaleSlug( state ),
 			oauth2Client,
-			ciabConfig: detectCiabConfig( oauth2Client ),
+			ciabConfig: detectPartnerConfig( oauth2Client ),
 			isGravatar: isGravatarOAuth2Client( oauth2Client ),
 			wccomFrom: getWccomFrom( state ),
 			hostingFlow,


### PR DESCRIPTION
## Proposed Changes

* Complete the CIAB -> partner naming migration in `client/lib/partner-branding.tsx`:
  * `CiabPartnerConfig` -> `PartnerConfig`
  * `CIAB_PARTNERS` -> `PARTNERS`
  * `getCiabConfigFrom*` helpers -> `getPartnerConfigFrom*`
  * hook result key renamed to `partnerConfig`
* Migrate all consumer code (login, signup, invites, layout, and stepper flows) to the new type/helper/property names and remove remaining `ciabConfig` object keys/variables.
* Migrate related tests/mocks/stories to the new naming.
* Keep behavior unchanged, including Woo branding suffix (`Woo`).
* Keep `detectCiabConfig` fully removed (no compatibility alias reintroduced).
* Preserve session continuity for partner detection:
  * read from the new session key first
  * if absent, do a one-time fallback read from the legacy CIAB key
  * immediately write back using the new key and clear the old key

## Why are these changes being made?

* This finishes the partner-branding naming refactor so the domain is consistently partner-generic and no longer CIAB-specific.
* The one-time legacy session-key read avoids breaking in-flight user sessions while still moving persistence to the new naming immediately.

## Testing Instructions

* Run:
  * `yarn test-client client/lib/test/partner-branding.tsx client/login/magic-login/test/index.test.jsx client/my-sites/invites-unified/screens/test/accept-invite-screen.test.tsx client/my-sites/invites-unified/screens/test/already-member-screen.test.tsx client/my-sites/invites-unified/test/index.test.tsx`
* Verify all five suites pass.
* Confirm these grep checks return zero matches in `*.{js,jsx,ts,tsx}`:
  * `CiabPartnerConfig`
  * `getCiabConfigFrom`
  * `CIAB_PARTNERS`
  * `ciabConfig`
  * `detectCiabConfig`
* Run `yarn typecheck-client` (currently fails due existing unrelated type errors in other areas).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the \"[Status] String Freeze\" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the \"[Status] Needs Privacy Updates\" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?