### PR TITLE
Add a skip to pending when purchase is marked confirmed

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-purchase-order.tsx
+++ b/client/my-sites/checkout/src/hooks/use-purchase-order.tsx
@@ -26,6 +26,7 @@ export type PurchaseOrderStatus =
 	| 'error'
 	| 'processing'
 	| 'async-pending'
+	| 'payment-confirmed'
 	| 'payment-failure'
 	| 'success';
 type OrderTransactionStatus =
@@ -52,6 +53,8 @@ function transformPurchaseOrderStatusToOrderTransactionStatus(
 		case 'processing':
 			return PROCESSING;
 		case 'async-pending':
+			return ASYNC_PENDING;
+		case 'payment-confirmed':
 			return ASYNC_PENDING;
 		case 'payment-failure':
 			return FAILURE;
@@ -122,6 +125,9 @@ function isOrderComplete( order: undefined | OrderTransaction ): boolean {
 		return false;
 	}
 	if ( order.processingStatus === PROCESSING ) {
+		return false;
+	}
+	if ( order.processingStatus === ASYNC_PENDING ) {
 		return false;
 	}
 	return true;

--- a/client/my-sites/checkout/src/lib/upi-processor.ts
+++ b/client/my-sites/checkout/src/lib/upi-processor.ts
@@ -1,4 +1,8 @@
-import { makeErrorResponse, makeSuccessResponse } from '@automattic/composite-checkout';
+import {
+	makeErrorResponse,
+	makeRedirectResponse,
+	makeSuccessResponse,
+} from '@automattic/composite-checkout';
 import { createElement } from 'react';
 import { Root, createRoot } from 'react-dom/client';
 import { PurchaseOrderStatus, fetchPurchaseOrder } from '../hooks/use-purchase-order';
@@ -114,6 +118,13 @@ export default async function upiProcessor(
 				throw new Error( genericErrorMessage );
 			}
 
+			const pendingPageUrl = addUrlToPendingPageRedirect( thankYouUrl, {
+				siteSlug,
+				fromSiteSlug,
+				orderId: response.order_id,
+				urlType: 'absolute',
+			} );
+
 			let isModalActive = true;
 			let explicitClosureMessage: string | undefined;
 			displayModal( {
@@ -134,6 +145,11 @@ export default async function upiProcessor(
 			let orderStatus = 'processing';
 			while ( isModalActive && [ 'processing', 'async-pending' ].includes( orderStatus ) ) {
 				orderStatus = await pollForOrderStatus( response.order_id, 2000, genericErrorMessage );
+			}
+			if ( orderStatus === 'payment-confirmed' ) {
+				safeDismissModal();
+				window.location.href = pendingPageUrl;
+				return makeRedirectResponse( pendingPageUrl );
 			}
 			if ( orderStatus !== 'success' ) {
 				throw new Error( explicitClosureMessage ?? genericFailureMessage );
@@ -164,7 +180,10 @@ async function pollForOrderStatus(
 		console.error( 'Order was not found.' );
 		throw new Error( genericErrorMessage );
 	}
-	if ( orderData.processing_status === 'success' ) {
+	if (
+		orderData.processing_status === 'success' ||
+		orderData.processing_status === 'payment-confirmed'
+	) {
 		return orderData.processing_status;
 	}
 	await new Promise( ( resolve ) => setTimeout( resolve, pollInterval ) );

--- a/client/my-sites/checkout/src/lib/upi-processor.ts
+++ b/client/my-sites/checkout/src/lib/upi-processor.ts
@@ -148,7 +148,6 @@ export default async function upiProcessor(
 			}
 			if ( orderStatus === 'payment-confirmed' ) {
 				safeDismissModal();
-				window.location.href = pendingPageUrl;
 				return makeRedirectResponse( pendingPageUrl );
 			}
 			if ( orderStatus !== 'success' ) {

--- a/client/my-sites/checkout/src/test/upi-processor.ts
+++ b/client/my-sites/checkout/src/test/upi-processor.ts
@@ -352,41 +352,47 @@ describe( 'upiProcessor', () => {
 			configurable: true,
 		} );
 
-		const orderId = 54321;
-		const mockOrderStatus = {
-			order_id: orderId,
-			user_id: 1234,
-			receipt_id: undefined,
-			processing_status: 'payment-confirmed',
-		};
-		mockOrderEndpoint( orderId, () => [ 200, mockOrderStatus ] );
-		mockTransactionsEndpoint( () => mockTransactionsRedirectResponse( orderId ) );
+		try {
+			const orderId = 54321;
+			const mockOrderStatus = {
+				order_id: orderId,
+				user_id: 1234,
+				receipt_id: undefined,
+				processing_status: 'payment-confirmed',
+			};
+			mockOrderEndpoint( orderId, () => [ 200, mockOrderStatus ] );
+			mockTransactionsEndpoint( () => mockTransactionsRedirectResponse( orderId ) );
 
-		const expectedPendingUrl =
-			'https://example.com/checkout/thank-you/no-site/pending/54321?redirect_to=%2Fthank-you&receiptId=%3AreceiptId';
-		const expected = {
-			payload: expectedPendingUrl,
-			type: 'REDIRECT',
-		};
+			const expectedPendingUrl =
+				'https://example.com/checkout/thank-you/no-site/pending/54321?redirect_to=%2Fthank-you&receiptId=%3AreceiptId';
+			const expected = {
+				payload: expectedPendingUrl,
+				type: 'REDIRECT',
+			};
 
-		await act( async () => {
-			await expect(
-				upiProcessor(
-					submitData,
-					{
-						...options,
-						contactDetails: {
-							countryCode,
-							postalCode,
+			await act( async () => {
+				await expect(
+					upiProcessor(
+						submitData,
+						{
+							...options,
+							contactDetails: {
+								countryCode,
+								postalCode,
+							},
 						},
-					},
-					translate
-				)
-			).resolves.toStrictEqual( expected );
-		} );
+						translate
+					)
+				).resolves.toStrictEqual( expected );
+			} );
 
-		expect( window.location.href ).toBe( expectedPendingUrl );
-		Object.defineProperty( window, 'location', { value: originalLocation, configurable: true } );
+			expect( window.location.href ).toBe( expectedPendingUrl );
+		} finally {
+			Object.defineProperty( window, 'location', {
+				value: originalLocation,
+				configurable: true,
+			} );
+		}
 	} );
 
 	it( 'returns a success response when the order succeeds', async () => {

--- a/client/my-sites/checkout/src/test/upi-processor.ts
+++ b/client/my-sites/checkout/src/test/upi-processor.ts
@@ -338,6 +338,57 @@ describe( 'upiProcessor', () => {
 		} );
 	} );
 
+	it( 'redirects to the pending page when payment is confirmed', async () => {
+		render( createElement( 'div', { className: 'upi-modal-target' } ) );
+
+		const originalLocation = window.location;
+		Object.defineProperty( window, 'location', {
+			value: {
+				origin: 'https://example.com',
+				pathname: '/',
+				search: '',
+				href: 'https://example.com/',
+			},
+			configurable: true,
+		} );
+
+		const orderId = 54321;
+		const mockOrderStatus = {
+			order_id: orderId,
+			user_id: 1234,
+			receipt_id: undefined,
+			processing_status: 'payment-confirmed',
+		};
+		mockOrderEndpoint( orderId, () => [ 200, mockOrderStatus ] );
+		mockTransactionsEndpoint( () => mockTransactionsRedirectResponse( orderId ) );
+
+		const expectedPendingUrl =
+			'https://example.com/checkout/thank-you/no-site/pending/54321?redirect_to=%2Fthank-you&receiptId=%3AreceiptId';
+		const expected = {
+			payload: expectedPendingUrl,
+			type: 'REDIRECT',
+		};
+
+		await act( async () => {
+			await expect(
+				upiProcessor(
+					submitData,
+					{
+						...options,
+						contactDetails: {
+							countryCode,
+							postalCode,
+						},
+					},
+					translate
+				)
+			).resolves.toStrictEqual( expected );
+		} );
+
+		expect( window.location.href ).toBe( expectedPendingUrl );
+		Object.defineProperty( window, 'location', { value: originalLocation, configurable: true } );
+	} );
+
 	it( 'returns a success response when the order succeeds', async () => {
 		render( createElement( 'div', { className: 'upi-modal-target' } ) );
 

--- a/client/my-sites/checkout/src/test/upi-processor.ts
+++ b/client/my-sites/checkout/src/test/upi-processor.ts
@@ -341,58 +341,38 @@ describe( 'upiProcessor', () => {
 	it( 'redirects to the pending page when payment is confirmed', async () => {
 		render( createElement( 'div', { className: 'upi-modal-target' } ) );
 
-		const originalLocation = window.location;
-		Object.defineProperty( window, 'location', {
-			value: {
-				origin: 'https://example.com',
-				pathname: '/',
-				search: '',
-				href: 'https://example.com/',
-			},
-			configurable: true,
-		} );
+		const orderId = 54321;
+		const mockOrderStatus = {
+			order_id: orderId,
+			user_id: 1234,
+			receipt_id: undefined,
+			processing_status: 'payment-confirmed',
+		};
+		mockOrderEndpoint( orderId, () => [ 200, mockOrderStatus ] );
+		mockTransactionsEndpoint( () => mockTransactionsRedirectResponse( orderId ) );
 
-		try {
-			const orderId = 54321;
-			const mockOrderStatus = {
-				order_id: orderId,
-				user_id: 1234,
-				receipt_id: undefined,
-				processing_status: 'payment-confirmed',
-			};
-			mockOrderEndpoint( orderId, () => [ 200, mockOrderStatus ] );
-			mockTransactionsEndpoint( () => mockTransactionsRedirectResponse( orderId ) );
+		const expectedPendingUrl =
+			'https://example.com/checkout/thank-you/no-site/pending/54321?redirect_to=%2Fthank-you&receiptId=%3AreceiptId';
+		const expected = {
+			payload: expectedPendingUrl,
+			type: 'REDIRECT',
+		};
 
-			const expectedPendingUrl =
-				'https://example.com/checkout/thank-you/no-site/pending/54321?redirect_to=%2Fthank-you&receiptId=%3AreceiptId';
-			const expected = {
-				payload: expectedPendingUrl,
-				type: 'REDIRECT',
-			};
-
-			await act( async () => {
-				await expect(
-					upiProcessor(
-						submitData,
-						{
-							...options,
-							contactDetails: {
-								countryCode,
-								postalCode,
-							},
+		await act( async () => {
+			await expect(
+				upiProcessor(
+					submitData,
+					{
+						...options,
+						contactDetails: {
+							countryCode,
+							postalCode,
 						},
-						translate
-					)
-				).resolves.toStrictEqual( expected );
-			} );
-
-			expect( window.location.href ).toBe( expectedPendingUrl );
-		} finally {
-			Object.defineProperty( window, 'location', {
-				value: originalLocation,
-				configurable: true,
-			} );
-		}
+					},
+					translate
+				)
+			).resolves.toStrictEqual( expected );
+		} );
 	} );
 
 	it( 'returns a success response when the order succeeds', async () => {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of  SHILL-1806

## Proposed Changes

* When the UPI polling endpoint returns `payment-confirmed`, close the Stripe confirmation modal and redirect to the pending page immediately, rather than continuing to poll until `success`
* Add `'payment-confirmed'` to the `PurchaseOrderStatus` type, mapped to `ASYNC_PENDING` so the pending page continues polling until the order completes
* Fix `isOrderComplete` in `usePurchaseOrder` to keep polling when status is `ASYNC_PENDING`, so the pending page doesn't stall on `payment-confirmed`
* `pollForOrderStatus` now returns immediately on `payment-confirmed` (same as `success`), avoiding an unnecessary 2-second delay before redirecting

## Why are these changes being made?

* Previously the UPI flow held the user in the modal for the entire duration of order processing, only dismissing it once the order reached `success`. This could mean the user sat in the modal while `process_order()` ran after the payment was already confirmed.
* The new `payment-confirmed` status signals that the Stripe webhook has fired and the payment is done — provisioning is the only remaining step. At that point it's better to move the user to the pending page, which is designed for this wait, rather than keeping them in the modal.

## Testing Instructions

* there's a test included, but I'm not really sure how to test this via the UI. The test Stripe method takes us away from the modal page, so it's not quite the same.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?