### PR TITLE
Scan & Backup upsell pages: Migrate headers to admin-ui Page

### DIFF
--- a/client/components/jetpack-page-layout/_admin-ui-page.scss
+++ b/client/components/jetpack-page-layout/_admin-ui-page.scss
@@ -16,15 +16,19 @@
 	.layout__primary .main {
 		padding-bottom: 0;
 	}
+}
 
-	// Temporarily here until constrained content width is implemented in Admin-UI
-	.admin-ui-page__content {
-		> * {
-			max-width: 660px;
-			width: 100%;
-			margin-left: auto;
-			margin-right: auto;
-			box-sizing: border-box;
+@mixin admin-ui-page-layout-constrained-content {
+	.layout:not(.has-no-sidebar) .layout__content {
+		// Temporarily here until constrained content width is implemented in Admin-UI
+		.admin-ui-page__content {
+			> * {
+				max-width: 660px;
+				width: 100%;
+				margin-left: auto;
+				margin-right: auto;
+				box-sizing: border-box;
+			}
 		}
 	}
 }

--- a/client/components/jetpack-page-layout/_admin-ui-page.scss
+++ b/client/components/jetpack-page-layout/_admin-ui-page.scss
@@ -1,0 +1,29 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/admin-ui/build-style/style.css";
+
+// Shared layout overrides for pages using @wordpress/admin-ui Page component.
+// Usage: @include admin-ui-page-layout;
+// Must be called inside a `body.is-section-<name>` selector.
+@mixin admin-ui-page-layout {
+	.layout:not(.has-no-sidebar) .layout__content {
+		padding: calc(var(--masterbar-height)) 0 0 calc(var(--sidebar-width-max));
+
+		@media (max-width: $break-medium) {
+			padding-left: 0;
+		}
+	}
+
+	.layout__primary .main {
+		padding-bottom: 0;
+	}
+
+	// Temporarily here until constrained content width is implemented in Admin-UI
+	.admin-ui-page__content {
+		> * {
+			max-width: 660px;
+			width: 100%;
+			margin: 0 auto;
+			box-sizing: border-box;
+		}
+	}
+}

--- a/client/components/jetpack-page-layout/_admin-ui-page.scss
+++ b/client/components/jetpack-page-layout/_admin-ui-page.scss
@@ -18,17 +18,22 @@
 	}
 }
 
-@mixin admin-ui-page-layout-constrained-content {
-	.layout:not(.has-no-sidebar) .layout__content {
-		// Temporarily here until constrained content width is implemented in Admin-UI
-		.admin-ui-page__content {
-			> * {
-				max-width: 660px;
-				width: 100%;
-				margin-left: auto;
-				margin-right: auto;
-				box-sizing: border-box;
-			}
+// Constrain admin-ui Page content to 660px centered.
+// Pass a $scope selector to limit to specific page variants (e.g. upsell pages).
+// Usage:
+//   @include admin-ui-page-layout-constrained-content;           // always constrained
+//   @include admin-ui-page-layout-constrained-content('.my-upsell'); // only within .my-upsell
+@mixin admin-ui-page-layout-constrained-content($scope: null) {
+	$parent: if($scope, "#{$scope} .admin-ui-page__content", ".admin-ui-page__content");
+
+	// Temporarily here until constrained content width is implemented in Admin-UI
+	#{$parent} {
+		> * {
+			max-width: 660px;
+			width: 100%;
+			margin-left: auto;
+			margin-right: auto;
+			box-sizing: border-box;
 		}
 	}
 }

--- a/client/components/jetpack-page-layout/_admin-ui-page.scss
+++ b/client/components/jetpack-page-layout/_admin-ui-page.scss
@@ -22,7 +22,8 @@
 		> * {
 			max-width: 660px;
 			width: 100%;
-			margin: 0 auto;
+			margin-left: auto;
+			margin-right: auto;
 			box-sizing: border-box;
 		}
 	}

--- a/client/components/jetpack-page-layout/_admin-ui-page.scss
+++ b/client/components/jetpack-page-layout/_admin-ui-page.scss
@@ -5,8 +5,14 @@
 // Usage: @include admin-ui-page-layout;
 // Must be called inside a `body.is-section-<name>` selector.
 @mixin admin-ui-page-layout {
+	@media screen and (max-width: $break-small) {
+		.focus-content:not(.has-no-sidebar):not(.has-no-masterbar) .layout__content {
+			padding-top: var(--masterbar-height);
+		}
+	}
+
 	.layout:not(.has-no-sidebar) .layout__content {
-		padding: calc(var(--masterbar-height)) 0 0 calc(var(--sidebar-width-max));
+		padding: var(--masterbar-height) 0 0 var(--sidebar-width-max);
 
 		@media (max-width: $break-medium) {
 			padding-left: 0;

--- a/client/components/jetpack/backup-getting-started/style.scss
+++ b/client/components/jetpack/backup-getting-started/style.scss
@@ -11,7 +11,6 @@ $content-max-width: 210px;
 	background-color: #f9f9f6;
 
 	@include break-medium {
-		height: $card-height-desktop;
 		background-image: url(calypso/assets/images/jetpack/getting-started-backup-bg.svg);
 		grid-template-columns: minmax(0, $preview-max-width) minmax($content-max-width, 1fr);
 		grid-column-gap: 1.5rem;

--- a/client/components/jetpack/wpcom-business-at/index.tsx
+++ b/client/components/jetpack/wpcom-business-at/index.tsx
@@ -2,6 +2,7 @@ import { WPCOM_FEATURES_BACKUPS_SELF_SERVE } from '@automattic/calypso-products'
 import page from '@automattic/calypso-router';
 import { CompactCard, Dialog } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { Page } from '@wordpress/admin-ui';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import { useCallback, useEffect, useState } from 'react';
@@ -16,8 +17,8 @@ import WarningList from 'calypso/blocks/eligibility-warnings/warning-list';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryAutomatedTransferEligibility from 'calypso/components/data/query-atat-eligibility';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
-import FormattedHeader from 'calypso/components/formatted-header';
 import WhatIsJetpack from 'calypso/components/jetpack/what-is-jetpack';
+import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
@@ -72,6 +73,7 @@ interface TransferFailureNoticeProps {
 export interface AtomicContentSwitch {
 	documentHeadTitle: string;
 	header: string;
+	subTitle?: string;
 	primaryPromo: {
 		image: { path: string };
 		promoCTA: { loadingText: string; text: string };
@@ -85,7 +87,8 @@ export interface AtomicContentSwitch {
 
 const vaultpressContent: AtomicContentSwitch = {
 	documentHeadTitle: translate( 'Activate Jetpack VaultPress Backup now' ) as string,
-	header: translate( 'Jetpack VaultPress Backup' ) as string,
+	header: translate( 'Backup' ) as string,
+	subTitle: translate( 'Save changes and restore quickly with one-click recovery.' ) as string,
 	primaryPromo: {
 		title: translate( 'Get time travel for your site with Jetpack VaultPress Backup' ),
 		image: { path: JetpackBackupSVG },
@@ -280,19 +283,19 @@ export default function WPCOMBusinessAT( {
 	// If features are not loaded yet, show loading state
 	if ( featuresNotLoaded ) {
 		return (
-			<Main wideLayout className="wpcom-business-at">
+			<Main fullWidthLayout className="wpcom-business-at">
 				<QuerySiteFeatures siteIds={ [ siteId ] } />
 				<DocumentHead title={ content.documentHeadTitle } />
-				<FormattedHeader
-					id="wpcom-business-at-header"
-					className="wpcom-business-at__header"
-					headerText={ content.header }
-					align="left"
-					brandFont
-				/>
-				<div className="wpcom-business-at__loading">
-					<p>{ translate( 'Loading…' ) }</p>
-				</div>
+				<Page
+					hasPadding
+					showSidebarToggle={ false }
+					title={ <JetpackTitle title={ content.header } /> }
+					subTitle={ content.subTitle }
+				>
+					<div className="wpcom-business-at__loading">
+						<p>{ translate( 'Loading…' ) }</p>
+					</div>
+				</Page>
 			</Main>
 		);
 	}
@@ -303,59 +306,59 @@ export default function WPCOMBusinessAT( {
 	}
 
 	return (
-		<Main wideLayout className="wpcom-business-at">
+		<Main fullWidthLayout className="wpcom-business-at">
 			<QueryAutomatedTransferEligibility siteId={ siteId } />
 			<DocumentHead title={ content.documentHeadTitle } />
 			<PageViewTracker path="/backup/:site" title="Business Plan Automated Transfer" />
 
-			<FormattedHeader
-				id="wpcom-business-at-header"
-				className="wpcom-business-at__header"
-				headerText={ content.header }
-				align="left"
-				brandFont
-			/>
-			<BlockingHoldNotice
-				siteId={ siteId }
-				productName={ content.header }
-				suppressInstallNotice={ rewindAtomicDeactivated }
-			/>
-			<TransferFailureNotice
-				transferStatus={ automatedTransferStatus as TransferStatus }
-				productName={ content.header }
-			/>
-			<PromoCard
-				title={ content.primaryPromo.title }
-				image={ content.primaryPromo.image }
-				isPrimary
+			<Page
+				hasPadding
+				showSidebarToggle={ false }
+				title={ <JetpackTitle title={ content.header } /> }
+				subTitle={ content.subTitle }
 			>
-				<p>{ content.primaryPromo.content }</p>
-				<div className="wpcom-business-at__cta">
-					<SpinnerButton
-						text={ content.primaryPromo.promoCTA.text }
-						loadingText={ content.primaryPromo.promoCTA.loadingText }
-						loading={
-							automatedTransferStatus === START ||
-							( automatedTransferStatus === COMPLETE && ! isJetpack ) ||
-							isRewindActivating
-						}
-						onClick={ () => {
-							if ( rewindAtomicDeactivated ) {
-								setIsRewindActivating( true );
-								dispatch( autoConfigCredentials( siteId ) );
-								page( content.getProductUrl( siteSlug ) );
-								return;
+				<BlockingHoldNotice
+					siteId={ siteId }
+					productName={ content.header }
+					suppressInstallNotice={ rewindAtomicDeactivated }
+				/>
+				<TransferFailureNotice
+					transferStatus={ automatedTransferStatus as TransferStatus }
+					productName={ content.header }
+				/>
+				<PromoCard
+					title={ content.primaryPromo.title }
+					image={ content.primaryPromo.image }
+					isPrimary
+				>
+					<p>{ content.primaryPromo.content }</p>
+					<div className="wpcom-business-at__cta">
+						<SpinnerButton
+							text={ content.primaryPromo.promoCTA.text }
+							loadingText={ content.primaryPromo.promoCTA.loadingText }
+							loading={
+								automatedTransferStatus === START ||
+								( automatedTransferStatus === COMPLETE && ! isJetpack ) ||
+								isRewindActivating
 							}
-							initiateATOrShowWarnings();
-						} }
-						disabled={
-							( cannotInitiateTransfer && ! rewindAtomicDeactivated ) || isRewindActivating
-						}
-					/>
-				</div>
-			</PromoCard>
+							onClick={ () => {
+								if ( rewindAtomicDeactivated ) {
+									setIsRewindActivating( true );
+									dispatch( autoConfigCredentials( siteId ) );
+									page( content.getProductUrl( siteSlug ) );
+									return;
+								}
+								initiateATOrShowWarnings();
+							} }
+							disabled={
+								( cannotInitiateTransfer && ! rewindAtomicDeactivated ) || isRewindActivating
+							}
+						/>
+					</div>
+				</PromoCard>
 
-			{ ! isJetpackCloud() && <WhatIsJetpack className="wpcom-business-at__footer" /> }
+				{ ! isJetpackCloud() && <WhatIsJetpack className="wpcom-business-at__footer" /> }
+			</Page>
 
 			<Dialog
 				isVisible={ showDialog }

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -80,7 +80,6 @@ const BackupPage = ( { queryDate } ) => {
 				} ) }
 			>
 				{ isJetpackCloud() && <SidebarNavigation /> }
-				<TimeMismatchWarning siteId={ siteId } settingsUrl={ siteSettingsUrl } />
 				{ isWpcom ? (
 					<Page
 						hasPadding
@@ -89,10 +88,14 @@ const BackupPage = ( { queryDate } ) => {
 						subTitle={ translate( 'Save changes and restore quickly with one-click recovery.' ) }
 						actions={ <BackupActionsToolbar siteId={ siteId } /> }
 					>
+						<TimeMismatchWarning siteId={ siteId } settingsUrl={ siteSettingsUrl } />
 						<AdminContent selectedDate={ selectedDate } />
 					</Page>
 				) : (
-					<AdminContent selectedDate={ selectedDate } />
+					<>
+						<TimeMismatchWarning siteId={ siteId } settingsUrl={ siteSettingsUrl } />
+						<AdminContent selectedDate={ selectedDate } />
+					</>
 				) }
 			</Main>
 		</div>

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -1,5 +1,6 @@
 import { WPCOM_FEATURES_REAL_TIME_BACKUPS } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
+import { Page } from '@wordpress/admin-ui';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
@@ -20,7 +21,6 @@ import BackupPlaceholder from 'calypso/components/jetpack/backup-placeholder';
 import JetpackTitle from 'calypso/components/jetpack-title';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
-import NavigationHeader from 'calypso/components/navigation-header';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -64,31 +64,36 @@ const BackupPage = ( { queryDate } ) => {
 		keepLocalTime: !! queryDate,
 	} );
 
+	const isWpcom = ! ( isJetpackCloud() || isA8CForAgencies() );
+
 	return (
 		<div
 			className={ clsx( 'backup__page', {
-				wordpressdotcom: ! ( isJetpackCloud() || isA8CForAgencies() ),
+				wordpressdotcom: isWpcom,
 			} ) }
 		>
 			<Main
-				wideLayout
+				fullWidthLayout={ isWpcom }
+				wideLayout={ ! isWpcom }
 				className={ clsx( {
 					is_jetpackcom: isJetpackCloud(),
 				} ) }
 			>
 				{ isJetpackCloud() && <SidebarNavigation /> }
 				<TimeMismatchWarning siteId={ siteId } settingsUrl={ siteSettingsUrl } />
-				{ ! ( isJetpackCloud() || isA8CForAgencies() ) && (
-					<NavigationHeader
-						navigationItems={ [] }
+				{ isWpcom ? (
+					<Page
+						hasPadding
+						showSidebarToggle={ false }
 						title={ <JetpackTitle title={ translate( 'Backup' ) } /> }
-						subtitle={ translate( 'Save changes and restore quickly with one-click recovery.' ) }
+						subTitle={ translate( 'Save changes and restore quickly with one-click recovery.' ) }
+						actions={ <BackupActionsToolbar siteId={ siteId } /> }
 					>
-						<BackupActionsToolbar siteId={ siteId } />
-					</NavigationHeader>
+						<AdminContent selectedDate={ selectedDate } />
+					</Page>
+				) : (
+					<AdminContent selectedDate={ selectedDate } />
 				) }
-
-				<AdminContent selectedDate={ selectedDate } />
 			</Main>
 		</div>
 	);

--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -2,17 +2,7 @@
 
 body.is-section-backup {
 	@include admin-ui-page-layout;
-
-	// Constrain content width on upsell pages only
-	.backup__wpcom-upsell .admin-ui-page__content {
-		> * {
-			max-width: 660px;
-			width: 100%;
-			margin-left: auto;
-			margin-right: auto;
-			box-sizing: border-box;
-		}
-	}
+	@include admin-ui-page-layout-constrained-content(".backup__wpcom-upsell");
 }
 
 .backup__page {

--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -1,3 +1,30 @@
+@import '@wordpress/admin-ui/build-style/style.css';
+
+body.is-section-backup {
+	.layout:not(.has-no-sidebar) .layout__content {
+		padding: calc(var(--masterbar-height)) 0 0 calc(var(--sidebar-width-max));
+
+		@media (max-width: 782px) {
+			padding-left: 0;
+			padding-right: 0;
+		}
+	}
+
+	.layout__primary .main {
+		padding-bottom: 0;
+	}
+
+	// Temporarily here until constrained content width is implemented in Admin-UI
+	.admin-ui-page__content {
+		> * {
+			max-width: 660px;
+			width: 100%;
+			margin: 0 auto;
+			box-sizing: border-box;
+		}
+	}
+}
+
 .backup__page {
 	.filterbar .filterbar__wrap.card {
 		display: flex;

--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -1,12 +1,12 @@
+@import "@wordpress/base-styles/breakpoints";
 @import '@wordpress/admin-ui/build-style/style.css';
 
 body.is-section-backup {
 	.layout:not(.has-no-sidebar) .layout__content {
 		padding: calc(var(--masterbar-height)) 0 0 calc(var(--sidebar-width-max));
 
-		@media (max-width: 782px) {
+		@media (max-width: $break-medium) {
 			padding-left: 0;
-			padding-right: 0;
 		}
 	}
 

--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -122,8 +122,8 @@ body.is-section-backup {
 /* WordPress.com-only styles */
 .wordpressdotcom.backup__page {
 	.backup__main-wrap {
-		margin-left: initial;
-		margin-right: initial;
+		margin-left: auto;
+		margin-right: auto;
 	}
 
 	.backup__last-backup-status {

--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -2,6 +2,7 @@
 
 body.is-section-backup {
 	@include admin-ui-page-layout;
+	@include admin-ui-page-layout-constrained-content;
 }
 
 .backup__page {

--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -1,28 +1,7 @@
-@import "@wordpress/base-styles/breakpoints";
-@import '@wordpress/admin-ui/build-style/style.css';
+@import "calypso/components/jetpack-page-layout/admin-ui-page";
 
 body.is-section-backup {
-	.layout:not(.has-no-sidebar) .layout__content {
-		padding: calc(var(--masterbar-height)) 0 0 calc(var(--sidebar-width-max));
-
-		@media (max-width: $break-medium) {
-			padding-left: 0;
-		}
-	}
-
-	.layout__primary .main {
-		padding-bottom: 0;
-	}
-
-	// Temporarily here until constrained content width is implemented in Admin-UI
-	.admin-ui-page__content {
-		> * {
-			max-width: 660px;
-			width: 100%;
-			margin: 0 auto;
-			box-sizing: border-box;
-		}
-	}
+	@include admin-ui-page-layout;
 }
 
 .backup__page {

--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -2,7 +2,17 @@
 
 body.is-section-backup {
 	@include admin-ui-page-layout;
-	@include admin-ui-page-layout-constrained-content;
+
+	// Constrain content width on upsell pages only
+	.backup__wpcom-upsell .admin-ui-page__content {
+		> * {
+			max-width: 660px;
+			width: 100%;
+			margin-left: auto;
+			margin-right: auto;
+			box-sizing: border-box;
+		}
+	}
 }
 
 .backup__page {

--- a/client/my-sites/backup/wpcom-backup-upsell-placeholder.tsx
+++ b/client/my-sites/backup/wpcom-backup-upsell-placeholder.tsx
@@ -1,18 +1,18 @@
+import { Page } from '@wordpress/admin-ui';
 import { useTranslate } from 'i18n-calypso';
 import WpcomUpsellPlaceholder from 'calypso/components/jetpack/wpcom-upsell-placeholder';
 import JetpackTitle from 'calypso/components/jetpack-title';
-import NavigationHeader from 'calypso/components/navigation-header';
 
 export default function WpcomBackupUpsellPlaceholder() {
 	const translate = useTranslate();
 	return (
-		<>
-			<NavigationHeader
-				navigationItems={ [] }
-				title={ <JetpackTitle title={ translate( 'Backup' ) } /> }
-				subtitle={ translate( 'Save changes and restore quickly with one-click recovery.' ) }
-			/>
+		<Page
+			hasPadding
+			showSidebarToggle={ false }
+			title={ <JetpackTitle title={ translate( 'Backup' ) } /> }
+			subTitle={ translate( 'Save changes and restore quickly with one-click recovery.' ) }
+		>
 			<WpcomUpsellPlaceholder />
-		</>
+		</Page>
 	);
 }

--- a/client/my-sites/backup/wpcom-backup-upsell.tsx
+++ b/client/my-sites/backup/wpcom-backup-upsell.tsx
@@ -4,6 +4,7 @@ import {
 	getPlan,
 } from '@automattic/calypso-products';
 import { Button, Gridicon } from '@automattic/components';
+import { Page } from '@wordpress/admin-ui';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect, useCallback } from 'react';
@@ -14,7 +15,6 @@ import JetpackDisconnectedWPCOM from 'calypso/components/jetpack/jetpack-disconn
 import WhatIsJetpack from 'calypso/components/jetpack/what-is-jetpack';
 import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
-import NavigationHeader from 'calypso/components/navigation-header';
 import Notice from 'calypso/components/notice';
 import PromoSection, { Props as PromoSectionProps } from 'calypso/components/promo-section';
 import PromoCard from 'calypso/components/promo-section/promo-card';
@@ -279,16 +279,18 @@ export default function WPCOMUpsellPage( { reason }: { reason: string } ) {
 			body = <BackupUpsellBody />;
 	}
 	return (
-		<Main wideLayout className="backup__main backup__wpcom-upsell">
+		<Main fullWidthLayout className="backup__main backup__wpcom-upsell">
 			<DocumentHead title="Jetpack VaultPress Backup" />
 			<PageViewTracker path="/backup/:site" title="VaultPress Backup" />
-			<NavigationHeader
-				navigationItems={ [] }
-				title={ <JetpackTitle title={ translate( 'Backup' ) } /> }
-				subtitle={ translate( 'Save changes and restore quickly with one-click recovery.' ) }
-			/>
 
-			{ body }
+			<Page
+				hasPadding
+				showSidebarToggle={ false }
+				title={ <JetpackTitle title={ translate( 'Backup' ) } /> }
+				subTitle={ translate( 'Save changes and restore quickly with one-click recovery.' ) }
+			>
+				{ body }
+			</Page>
 		</Main>
 	);
 }

--- a/client/my-sites/backup/wpcom-upsell.tsx
+++ b/client/my-sites/backup/wpcom-upsell.tsx
@@ -4,13 +4,13 @@ import {
 	getPlan,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
+import { Page } from '@wordpress/admin-ui';
 import { useTranslate } from 'i18n-calypso';
 import JetpackBackupSVG from 'calypso/assets/images/illustrations/jetpack-backup.svg';
 import DocumentHead from 'calypso/components/data/document-head';
 import WhatIsJetpack from 'calypso/components/jetpack/what-is-jetpack';
 import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
-import NavigationHeader from 'calypso/components/navigation-header';
 import Notice from 'calypso/components/notice';
 import PromoSection, { Props as PromoSectionProps } from 'calypso/components/promo-section';
 import PromoCard from 'calypso/components/promo-section/promo-card';
@@ -50,69 +50,70 @@ export default function WPCOMUpsellPage() {
 	};
 
 	return (
-		<Main wideLayout className="backup__main backup__wpcom-upsell">
+		<Main fullWidthLayout className="backup__main backup__wpcom-upsell">
 			<DocumentHead title="Jetpack VaultPress Backup" />
 			<PageViewTracker path="/backup/:site" title="VaultPress Backup" />
 
-			<NavigationHeader
-				navigationItems={ [] }
+			<Page
+				hasPadding
+				showSidebarToggle={ false }
 				title={ <JetpackTitle title={ translate( 'Backup' ) } /> }
-				subtitle={ translate( 'Save changes and restore quickly with one-click recovery.' ) }
-			/>
-
-			<PromoCard
-				title={ preventWidows(
-					translate( 'Get time travel for your site with Jetpack VaultPress Backup' )
-				) }
-				image={ { path: JetpackBackupSVG } }
-				isPrimary
+				subTitle={ translate( 'Save changes and restore quickly with one-click recovery.' ) }
 			>
-				<p>
-					{ preventWidows(
-						translate(
-							'VaultPress Backup gives you granular control over your site, with the ability to restore it to any previous state, and export it at any time.'
-						)
+				<PromoCard
+					title={ preventWidows(
+						translate( 'Get time travel for your site with Jetpack VaultPress Backup' )
 					) }
-				</p>
-				{ ! isAdmin && (
-					<Notice
-						status="is-warning"
-						text={ translate(
-							'Only site administrators can upgrade to the %(businessPlanName)s plan.',
-							{ args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' } }
+					image={ { path: JetpackBackupSVG } }
+					isPrimary
+				>
+					<p>
+						{ preventWidows(
+							translate(
+								'VaultPress Backup gives you granular control over your site, with the ability to restore it to any previous state, and export it at any time.'
+							)
 						) }
-						showDismiss={ false }
-					/>
-				) }
-				{ isAdmin && (
-					<PromoCardCTA
-						cta={ {
-							text: translate( 'Upgrade to %(planName)s Plan', {
+					</p>
+					{ ! isAdmin && (
+						<Notice
+							status="is-warning"
+							text={ translate(
+								'Only site administrators can upgrade to the %(businessPlanName)s plan.',
+								{ args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' } }
+							) }
+							showDismiss={ false }
+						/>
+					) }
+					{ isAdmin && (
+						<PromoCardCTA
+							cta={ {
+								text: translate( 'Upgrade to %(planName)s Plan', {
+									args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+								} ),
+								action: {
+									url: `/checkout/${ siteSlug }/business`,
+									onClick: onUpgradeClick,
+									selfTarget: true,
+								},
+							} }
+						/>
+					) }
+				</PromoCard>
+
+				{ ! hasFullActivityLogFeature && (
+					<>
+						<h2 className="backup__subheader">
+							{ translate( 'Also included in the %(planName)s Plan', {
 								args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
-							} ),
-							action: {
-								url: `/checkout/${ siteSlug }/business`,
-								onClick: onUpgradeClick,
-								selfTarget: true,
-							},
-						} }
-					/>
+							} ) }
+						</h2>
+
+						<PromoSection { ...promos } />
+					</>
 				) }
-			</PromoCard>
 
-			{ ! hasFullActivityLogFeature && (
-				<>
-					<h2 className="backup__subheader">
-						{ translate( 'Also included in the %(planName)s Plan', {
-							args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
-						} ) }
-					</h2>
-
-					<PromoSection { ...promos } />
-				</>
-			) }
-
-			<WhatIsJetpack />
+				<WhatIsJetpack />
+			</Page>
 		</Main>
 	);
 }

--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -1,11 +1,11 @@
 import { localizeUrl } from '@automattic/i18n-utils';
+import { Page } from '@wordpress/admin-ui';
 import { useTranslate } from 'i18n-calypso';
 import { capitalize, find } from 'lodash';
 import DocumentHead from 'calypso/components/data/document-head';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
-import NavigationHeader from 'calypso/components/navigation-header';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
@@ -190,7 +190,7 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 
 	const getEarnSectionNav = () => {
 		return (
-			<div id="earn-navigation">
+			<div className="earn-navigation">
 				<SectionNav
 					selectedText={ getEarnSelectedText() }
 					variation={ ! isJetpackCloud() ? 'minimal' : '' }
@@ -241,8 +241,20 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 
 	const atomicLearnMoreLink = localizeUrl( 'https://wordpress.com/support/monetize-your-site/' );
 	const jetpackLearnMoreLink = localizeUrl( 'https://jetpack.com/support/monetize-your-site/' );
+	const showPageHeader = ! isSinglePaidSubscriptionSection( section );
+
+	const content = (
+		<>
+			{ showPageHeader && getEarnSectionNav() }
+			<div className="earn-content">
+				{ isAdSection( section ) && getAdsHeader() }
+				{ getComponent( section ) }
+			</div>
+		</>
+	);
+
 	return (
-		<Main wideLayout className="earn">
+		<Main fullWidthLayout={ showPageHeader } wideLayout={ ! showPageHeader } className="earn">
 			<PageViewTracker
 				path={ section ? `${ earnPath }/${ section }/:site` : `${ earnPath }/:site` }
 				title={ `${ adsProgramName } ${ capitalize( section ) }` }
@@ -250,33 +262,32 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 			<DocumentHead
 				title={ layoutTitles[ section as keyof typeof layoutTitles ] ?? translate( 'Monetize' ) }
 			/>
-			{ ! isSinglePaidSubscriptionSection( section ) && (
-				<>
-					<NavigationHeader
-						navigationItems={ [] }
-						title={ <JetpackTitle title={ translate( 'Monetize' ) } /> }
-						subtitle={ translate(
-							'Explore tools to earn money with your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-							{
-								components: {
-									learnMoreLink: isJetpackCloud() ? (
-										<a
-											href={ isJetpackNotAtomic ? jetpackLearnMoreLink : atomicLearnMoreLink }
-											target="_blank"
-											rel="noopener noreferrer"
-										/>
-									) : (
-										<InlineSupportLink supportContext="earn" showIcon={ false } />
-									),
-								},
-							}
-						) }
-					/>
-					{ getEarnSectionNav() }
-				</>
+			{ showPageHeader ? (
+				<Page
+					showSidebarToggle={ false }
+					title={ <JetpackTitle title={ translate( 'Monetize' ) } /> }
+					subTitle={ translate(
+						'Explore tools to earn money with your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						{
+							components: {
+								learnMoreLink: isJetpackCloud() ? (
+									<a
+										href={ isJetpackNotAtomic ? jetpackLearnMoreLink : atomicLearnMoreLink }
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								) : (
+									<InlineSupportLink supportContext="earn" showIcon={ false } />
+								),
+							},
+						}
+					) }
+				>
+					{ content }
+				</Page>
+			) : (
+				content
 			) }
-			{ isAdSection( section ) && getAdsHeader() }
-			{ getComponent( section ) }
 		</Main>
 	);
 };

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -1,9 +1,24 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@automattic/components/src/styles/typography";
 @import "@wordpress/base-styles/mixins";
+@import "calypso/components/jetpack-page-layout/admin-ui-page";
 
-#earn-navigation {
-	margin-bottom: 30px;
+body.is-section-earn {
+	@include admin-ui-page-layout;
+}
+
+.earn-navigation {
+	.section-nav {
+		padding: 0 var(--wpds-dimension-padding-2xl, 24px);
+	}
+}
+
+.earn-content {
+	box-sizing: border-box;
+	margin: 0 auto;
+	max-width: 1040px;
+	padding: 24px;
+	width: 100%;
 }
 
 // Small override for card component headers
@@ -230,12 +245,5 @@ body:not(.theme-jetpack-cloud) {
 	max-width: 98%;
 	h1 {
 		margin-bottom: 1em;
-	}
-}
-
-/* Media Queries */
-@media (max-width: $break-large) {
-	.earn.main {
-		padding: 20px;
 	}
 }

--- a/client/my-sites/scan/history/index.tsx
+++ b/client/my-sites/scan/history/index.tsx
@@ -1,10 +1,10 @@
+import { Page } from '@wordpress/admin-ui';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import ThreatHistoryList from 'calypso/components/jetpack/threat-history-list';
 import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
-import NavigationHeader from 'calypso/components/navigation-header';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -21,25 +21,10 @@ interface Props {
 export default function ScanHistoryPage( { filter }: Props ) {
 	const translate = useTranslate();
 	const isJetpackPlatform = isJetpackCloud();
+	const isWpcom = ! ( isJetpackPlatform || isA8CForAgencies() );
 
-	return (
-		<Main
-			wideLayout
-			className={ clsx( 'scan history', {
-				is_jetpackcom: isJetpackPlatform,
-			} ) }
-		>
-			<DocumentHead title={ translate( 'Scan' ) } />
-			{ isJetpackPlatform && <SidebarNavigation /> }
-			<PageViewTracker path="/scan/history/:site" title="Scan History" />
-			{ ! ( isJetpackPlatform || isA8CForAgencies() ) && (
-				<NavigationHeader
-					navigationItems={ [] }
-					title={ <JetpackTitle title={ translate( 'Scan' ) } /> }
-					subtitle={ translate( 'Automated malware scanning and firewall protection.' ) }
-				/>
-			) }
-
+	const content = (
+		<>
 			<ScanNavigation section="history" />
 			<section className="history__body">
 				<p className="history__description">
@@ -49,6 +34,32 @@ export default function ScanHistoryPage( { filter }: Props ) {
 				</p>
 				<ThreatHistoryList filter={ filter } />
 			</section>
+		</>
+	);
+
+	return (
+		<Main
+			fullWidthLayout={ isWpcom }
+			wideLayout={ ! isWpcom }
+			className={ clsx( 'scan history', {
+				is_jetpackcom: isJetpackPlatform,
+			} ) }
+		>
+			<DocumentHead title={ translate( 'Scan' ) } />
+			{ isJetpackPlatform && <SidebarNavigation /> }
+			<PageViewTracker path="/scan/history/:site" title="Scan History" />
+			{ isWpcom ? (
+				<Page
+					hasPadding
+					showSidebarToggle={ false }
+					title={ <JetpackTitle title={ translate( 'Scan' ) } /> }
+					subTitle={ translate( 'Automated malware scanning and firewall protection.' ) }
+				>
+					{ content }
+				</Page>
+			) : (
+				content
+			) }
 		</Main>
 	);
 }

--- a/client/my-sites/scan/main.tsx
+++ b/client/my-sites/scan/main.tsx
@@ -1,5 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Button, ProgressBar, Gridicon, Card } from '@automattic/components';
+import { Page } from '@wordpress/admin-ui';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import { Component } from 'react';
@@ -14,7 +15,6 @@ import SecurityIcon from 'calypso/components/jetpack/security-icon';
 import JetpackTitle from 'calypso/components/jetpack-title';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
-import NavigationHeader from 'calypso/components/navigation-header';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import { withApplySiteOffset, applySiteOffsetType } from 'calypso/components/site-offset';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
@@ -326,6 +326,7 @@ class ScanPage extends Component< Props > {
 	render() {
 		const { siteId, siteSettingsUrl } = this.props;
 		const isJetpackPlatform = isJetpackCloud();
+		const isWpcom = ! ( isJetpackPlatform || isA8CForAgencies() );
 		let mainClass = 'scan';
 
 		if ( ! siteId ) {
@@ -336,9 +337,19 @@ class ScanPage extends Component< Props > {
 			mainClass = 'scan-new';
 		}
 
+		const content = (
+			<>
+				<QueryJetpackScan siteId={ siteId } />
+				<ScanNavigation section="scanner" />
+				<div className="scan__content">{ this.renderScanState() }</div>
+				{ this.renderJetpackReviewPrompt() }
+			</>
+		);
+
 		return (
 			<Main
-				wideLayout
+				fullWidthLayout={ isWpcom }
+				wideLayout={ ! isWpcom }
 				className={ clsx( mainClass, {
 					is_jetpackcom: isJetpackPlatform,
 				} ) }
@@ -347,18 +358,18 @@ class ScanPage extends Component< Props > {
 				{ isJetpackPlatform && <SidebarNavigation /> }
 				<PageViewTracker path="/scan/:site" title="Scanner" />
 				<TimeMismatchWarning siteId={ siteId } settingsUrl={ siteSettingsUrl } />
-				{ ! ( isJetpackPlatform || isA8CForAgencies() ) && (
-					<NavigationHeader
-						navigationItems={ [] }
+				{ isWpcom ? (
+					<Page
+						hasPadding
+						showSidebarToggle={ false }
 						title={ <JetpackTitle title={ translate( 'Scan' ) } /> }
-						subtitle={ translate( 'Automated malware scanning and firewall protection.' ) }
-					/>
+						subTitle={ translate( 'Automated malware scanning and firewall protection.' ) }
+					>
+						{ content }
+					</Page>
+				) : (
+					content
 				) }
-
-				<QueryJetpackScan siteId={ siteId } />
-				<ScanNavigation section="scanner" />
-				<div className="scan__content">{ this.renderScanState() }</div>
-				{ this.renderJetpackReviewPrompt() }
 			</Main>
 		);
 	}

--- a/client/my-sites/scan/style.scss
+++ b/client/my-sites/scan/style.scss
@@ -2,17 +2,7 @@
 
 body.is-section-scan {
 	@include admin-ui-page-layout;
-
-	// Constrain content width on upsell pages only
-	.scan__wpcom-upsell .admin-ui-page__content {
-		> * {
-			max-width: 660px;
-			width: 100%;
-			margin-left: auto;
-			margin-right: auto;
-			box-sizing: border-box;
-		}
-	}
+	@include admin-ui-page-layout-constrained-content(".scan__wpcom-upsell");
 }
 
 .scan .formatted-header.is-left-align {

--- a/client/my-sites/scan/style.scss
+++ b/client/my-sites/scan/style.scss
@@ -1,3 +1,30 @@
+@import '@wordpress/admin-ui/build-style/style.css';
+
+body.is-section-scan {
+	.layout:not(.has-no-sidebar) .layout__content {
+		padding: calc(var(--masterbar-height)) 0 0 calc(var(--sidebar-width-max));
+
+		@media (max-width: 782px) {
+			padding-left: 0;
+			padding-right: 0;
+		}
+	}
+
+	.layout__primary .main {
+		padding-bottom: 0;
+	}
+
+	// Temporarily here until constrained content width is implemented in Admin-UI
+	.admin-ui-page__content {
+		> * {
+			max-width: 660px;
+			width: 100%;
+			margin: 0 auto;
+			box-sizing: border-box;
+		}
+	}
+}
+
 .scan .formatted-header.is-left-align {
 	margin-top: 20px;
 

--- a/client/my-sites/scan/style.scss
+++ b/client/my-sites/scan/style.scss
@@ -1,28 +1,7 @@
-@import "@wordpress/base-styles/breakpoints";
-@import '@wordpress/admin-ui/build-style/style.css';
+@import "calypso/components/jetpack-page-layout/admin-ui-page";
 
 body.is-section-scan {
-	.layout:not(.has-no-sidebar) .layout__content {
-		padding: calc(var(--masterbar-height)) 0 0 calc(var(--sidebar-width-max));
-
-		@media (max-width: $break-medium) {
-			padding-left: 0;
-		}
-	}
-
-	.layout__primary .main {
-		padding-bottom: 0;
-	}
-
-	// Temporarily here until constrained content width is implemented in Admin-UI
-	.admin-ui-page__content {
-		> * {
-			max-width: 660px;
-			width: 100%;
-			margin: 0 auto;
-			box-sizing: border-box;
-		}
-	}
+	@include admin-ui-page-layout;
 }
 
 .scan .formatted-header.is-left-align {

--- a/client/my-sites/scan/style.scss
+++ b/client/my-sites/scan/style.scss
@@ -2,7 +2,17 @@
 
 body.is-section-scan {
 	@include admin-ui-page-layout;
-	@include admin-ui-page-layout-constrained-content;
+
+	// Constrain content width on upsell pages only
+	.scan__wpcom-upsell .admin-ui-page__content {
+		> * {
+			max-width: 660px;
+			width: 100%;
+			margin-left: auto;
+			margin-right: auto;
+			box-sizing: border-box;
+		}
+	}
 }
 
 .scan .formatted-header.is-left-align {

--- a/client/my-sites/scan/style.scss
+++ b/client/my-sites/scan/style.scss
@@ -2,6 +2,7 @@
 
 body.is-section-scan {
 	@include admin-ui-page-layout;
+	@include admin-ui-page-layout-constrained-content;
 }
 
 .scan .formatted-header.is-left-align {

--- a/client/my-sites/scan/style.scss
+++ b/client/my-sites/scan/style.scss
@@ -1,12 +1,12 @@
+@import "@wordpress/base-styles/breakpoints";
 @import '@wordpress/admin-ui/build-style/style.css';
 
 body.is-section-scan {
 	.layout:not(.has-no-sidebar) .layout__content {
 		padding: calc(var(--masterbar-height)) 0 0 calc(var(--sidebar-width-max));
 
-		@media (max-width: 782px) {
+		@media (max-width: $break-medium) {
 			padding-left: 0;
-			padding-right: 0;
 		}
 	}
 

--- a/client/my-sites/scan/wpcom-atomic-transfer.tsx
+++ b/client/my-sites/scan/wpcom-atomic-transfer.tsx
@@ -1,12 +1,13 @@
 import { WPCOM_FEATURES_SCAN_SELF_SERVE } from '@automattic/calypso-products';
+import { Page } from '@wordpress/admin-ui';
 import { translate } from 'i18n-calypso';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import JetpackScanSVG from 'calypso/assets/images/illustrations/jetpack-scan.svg';
 import QueryJetpackScan from 'calypso/components/data/query-jetpack-scan';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
-import FormattedHeader from 'calypso/components/formatted-header';
 import WPCOMBusinessAT from 'calypso/components/jetpack/wpcom-business-at';
+import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
@@ -27,16 +28,16 @@ const ScanLoadingPlaceholder = () => {
 	const siteId = useSelector( getSelectedSiteId ) as number;
 
 	return (
-		<Main className="business-at-switch__loading">
+		<Main fullWidthLayout className="business-at-switch__loading">
 			<QuerySiteFeatures siteIds={ [ siteId ] } />
 			<QueryJetpackScan siteId={ siteId } />
-			<FormattedHeader
-				id="wpcom-scan-loading"
-				className="business-at-switch placeholder__header"
-				headerText={ translate( 'Loading…' ) }
-				align="left"
-			/>
-			<div className="business-at-switch placeholder__primary-promo"></div>
+			<Page
+				hasPadding
+				showSidebarToggle={ false }
+				title={ <JetpackTitle title={ translate( 'Scan' ) } /> }
+			>
+				<div className="business-at-switch placeholder__primary-promo"></div>
+			</Page>
 		</Main>
 	);
 };
@@ -86,7 +87,8 @@ const ScanAtomicTransferWrapper = () => {
 	// If scan state is 'unavailable' and site has scan feature, show atomic transfer activation
 	const content = {
 		documentHeadTitle: translate( 'Activate Jetpack Scan now' ) as string,
-		header: translate( 'Jetpack Scan' ) as string,
+		header: translate( 'Scan' ) as string,
+		subTitle: translate( 'Automated malware scanning and firewall protection.' ) as string,
 		primaryPromo: {
 			title: translate( 'We guard your site. You run your business.' ),
 			image: { path: JetpackScanSVG },

--- a/client/my-sites/scan/wpcom-scan-upsell-placeholder.tsx
+++ b/client/my-sites/scan/wpcom-scan-upsell-placeholder.tsx
@@ -1,13 +1,18 @@
+import { Page } from '@wordpress/admin-ui';
 import { useTranslate } from 'i18n-calypso';
-import FormattedHeader from 'calypso/components/formatted-header';
 import WpcomUpsellPlaceholder from 'calypso/components/jetpack/wpcom-upsell-placeholder';
+import JetpackTitle from 'calypso/components/jetpack-title';
 
 export default function WpcomScanUpsellPlaceholder() {
 	const translate = useTranslate();
 	return (
-		<>
-			<FormattedHeader brandFont headerText={ translate( 'Jetpack Scan' ) } align="left" />
+		<Page
+			hasPadding
+			showSidebarToggle={ false }
+			title={ <JetpackTitle title={ translate( 'Scan' ) } /> }
+			subTitle={ translate( 'Automated malware scanning and firewall protection.' ) }
+		>
 			<WpcomUpsellPlaceholder />
-		</>
+		</Page>
 	);
 }

--- a/client/my-sites/scan/wpcom-scan-upsell.tsx
+++ b/client/my-sites/scan/wpcom-scan-upsell.tsx
@@ -4,6 +4,7 @@ import {
 	getPlan,
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
+import { Page } from '@wordpress/admin-ui';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import JetpackScanSVG from 'calypso/assets/images/illustrations/jetpack-scan.svg';
@@ -13,7 +14,6 @@ import JetpackDisconnectedWPCOM from 'calypso/components/jetpack/jetpack-disconn
 import SecurityIcon from 'calypso/components/jetpack/security-icon';
 import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
-import NavigationHeader from 'calypso/components/navigation-header';
 import Notice from 'calypso/components/notice';
 import PromoCard from 'calypso/components/promo-section/promo-card';
 import PromoCardCTA from 'calypso/components/promo-section/promo-card/cta';
@@ -193,17 +193,18 @@ export default function WPCOMScanUpsellPage( { reason }: { reason?: string } ) {
 			body = <ScanUpsellBody />;
 	}
 	return (
-		<Main className="scan scan__wpcom-upsell">
+		<Main fullWidthLayout className="scan scan__wpcom-upsell">
 			<DocumentHead title="Scanner" />
 			<PageViewTracker path="/scan/:site" title="Scanner" />
 
-			<NavigationHeader
-				navigationItems={ [] }
+			<Page
+				hasPadding
+				showSidebarToggle={ false }
 				title={ <JetpackTitle title={ translate( 'Scan' ) } /> }
-				subtitle={ translate( 'Automated malware scanning and firewall protection.' ) }
-			/>
-
-			{ body }
+				subTitle={ translate( 'Automated malware scanning and firewall protection.' ) }
+			>
+				{ body }
+			</Page>
 		</Main>
 	);
 }

--- a/client/my-sites/scan/wpcom-upsell.tsx
+++ b/client/my-sites/scan/wpcom-upsell.tsx
@@ -1,11 +1,11 @@
 import { PLAN_BUSINESS, getPlan } from '@automattic/calypso-products';
+import { Page } from '@wordpress/admin-ui';
 import { useTranslate } from 'i18n-calypso';
 import JetpackScanSVG from 'calypso/assets/images/illustrations/jetpack-scan.svg';
 import DocumentHead from 'calypso/components/data/document-head';
 import WhatIsJetpack from 'calypso/components/jetpack/what-is-jetpack';
 import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
-import NavigationHeader from 'calypso/components/navigation-header';
 import PromoCard from 'calypso/components/promo-section/promo-card';
 import PromoCardCTA from 'calypso/components/promo-section/promo-card/cta';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -23,44 +23,45 @@ export default function WPCOMScanUpsellPage() {
 	const businessPlanName = getPlan( PLAN_BUSINESS )?.getTitle() ?? '';
 
 	return (
-		<Main wideLayout className="scan scan__wpcom-upsell">
+		<Main fullWidthLayout className="scan scan__wpcom-upsell">
 			<DocumentHead title="Scanner" />
 			<PageViewTracker path="/scan/:site" title="Scanner" />
 
-			<NavigationHeader
-				navigationItems={ [] }
+			<Page
+				hasPadding
+				showSidebarToggle={ false }
 				title={ <JetpackTitle title={ translate( 'Scan' ) } /> }
-				subtitle={ translate( 'Automated malware scanning and firewall protection.' ) }
-			/>
-
-			<PromoCard
-				title={ translate( 'We guard your site. You run your business.' ) }
-				image={ { path: JetpackScanSVG } }
-				isPrimary
+				subTitle={ translate( 'Automated malware scanning and firewall protection.' ) }
 			>
-				<p>
-					{ translate(
-						'Scan gives you automated scanning and one-click fixes ' +
-							'to keep your site ahead of security threats.'
-					) }
-				</p>
-				<PromoCardCTA
-					cta={ {
-						text: translate( 'Upgrade to %(planName)s Plan', {
-							args: {
-								planName: businessPlanName,
+				<PromoCard
+					title={ translate( 'We guard your site. You run your business.' ) }
+					image={ { path: JetpackScanSVG } }
+					isPrimary
+				>
+					<p>
+						{ translate(
+							'Scan gives you automated scanning and one-click fixes ' +
+								'to keep your site ahead of security threats.'
+						) }
+					</p>
+					<PromoCardCTA
+						cta={ {
+							text: translate( 'Upgrade to %(planName)s Plan', {
+								args: {
+									planName: businessPlanName,
+								},
+							} ),
+							action: {
+								url: `/checkout/${ siteSlug }/${ PLAN_BUSINESS }`,
+								onClick: onUpgradeClick,
+								selfTarget: true,
 							},
-						} ),
-						action: {
-							url: `/checkout/${ siteSlug }/${ PLAN_BUSINESS }`,
-							onClick: onUpgradeClick,
-							selfTarget: true,
-						},
-					} }
-				/>
-			</PromoCard>
+						} }
+					/>
+				</PromoCard>
 
-			<WhatIsJetpack />
+				<WhatIsJetpack />
+			</Page>
 		</Main>
 	);
 }

--- a/client/my-sites/site-settings/podcasting-details/style.scss
+++ b/client/my-sites/site-settings/podcasting-details/style.scss
@@ -1,29 +1,7 @@
-@use '@wordpress/base-styles/breakpoints' as breakpoints;
-@import '@wordpress/admin-ui/build-style/style.css';
+@import "calypso/components/jetpack-page-layout/admin-ui-page";
 
 body.is-section-settings-podcasting {
-	.layout:not(.has-no-sidebar) .layout__content {
-		padding: calc(var(--masterbar-height)) 0 0 calc(var(--sidebar-width-max));
-
-		// Full width when sidebar is collapsed
-		@media ( max-width: breakpoints.$break-medium ) {
-			padding-left: 0;
-		}
-	}
-
-	.layout__primary .main {
-		padding-bottom: 0;
-	}
-
-	// Tempoarily here until constrained content width is implemented in Admin-UI
-	.admin-ui-page__content {
-		> * {
-			max-width: 660px;
-			width: 100%;
-			margin: 0 auto;
-			box-sizing: border-box;
-		}
-	}
+	@include admin-ui-page-layout;
 }
 
 .podcasting-details__publish-wrapper {

--- a/client/my-sites/site-settings/podcasting-details/style.scss
+++ b/client/my-sites/site-settings/podcasting-details/style.scss
@@ -2,6 +2,7 @@
 
 body.is-section-settings-podcasting {
 	@include admin-ui-page-layout;
+	@include admin-ui-page-layout-constrained-content;
 }
 
 .podcasting-details__publish-wrapper {

--- a/client/sites/marketing/traffic/style.scss
+++ b/client/sites/marketing/traffic/style.scss
@@ -1,3 +1,10 @@
+@import "calypso/components/jetpack-page-layout/admin-ui-page";
+
+body.is-section-marketing {
+	@include admin-ui-page-layout;
+	@include admin-ui-page-layout-constrained-content;
+}
+
 .site-settings {
 	font-size: $font-body-small;
 

--- a/client/sites/marketing/traffic/traffic.js
+++ b/client/sites/marketing/traffic/traffic.js
@@ -1,3 +1,4 @@
+import { Page } from '@wordpress/admin-ui';
 import { localize } from 'i18n-calypso';
 import { pick } from 'lodash';
 import { useEffect } from 'react';
@@ -11,7 +12,6 @@ import EmptyContent from 'calypso/components/empty-content';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
-import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import useAdvertisingUrl from 'calypso/my-sites/advertising/useAdvertisingUrl';
 import AnalyticsSettings from 'calypso/my-sites/site-settings/analytics/form-google-analytics';
@@ -54,13 +54,14 @@ const SiteSettingsTraffic = ( {
 
 	return (
 		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-		<Main wideLayout className="sharing">
+		<Main fullWidthLayout className="sharing">
 			<DocumentHead title={ translate( 'Traffic' ) } />
 			{ siteId && <QueryJetpackModules siteId={ siteId } /> }
-			<NavigationHeader
-				navigationItems={ [] }
+			<Page
+				hasPadding
+				showSidebarToggle={ false }
 				title={ <JetpackTitle title={ translate( 'Traffic' ) } /> }
-				subtitle={ translate(
+				subTitle={ translate(
 					'Manage settings and tools related to the traffic your website receives. {{learnMoreLink/}}',
 					{
 						components: {
@@ -70,64 +71,67 @@ const SiteSettingsTraffic = ( {
 						},
 					}
 				) }
-			/>
-			<div className="settings-traffic site-settings">
-				<PageViewTracker path="/marketing/traffic/:site" title="Jetpack > Traffic" />
-				{ ! isAdmin && (
-					<EmptyContent title={ translate( 'You are not authorized to view this page' ) } />
-				) }
-				<JetpackDevModeNotice />
-				{ isAdmin && shouldShowAdvertisingOption && (
-					<PromoCardBlock
-						productSlug="blaze"
-						impressionEvent="calypso_marketing_traffic_blaze_banner_view"
-						clickEvent="calypso_marketing_traffic_blaze_banner_click"
-						headerText={ translate( 'Reach new readers and customers' ) }
-						contentText={ translate(
-							'Use WordPress Blaze to increase your reach by promoting your work to the larger WordPress.com community of blogs and sites. '
-						) }
-						ctaText={ translate( 'Get started' ) }
-						image={ blazeIllustration }
-						href={ advertisingUrl }
-					/>
-				) }
-				{ isAdmin && <SeoSettingsHelpCard disabled={ isRequestingSettings || isSavingSettings } /> }
-				{ isAdmin && (
-					<AsyncLoad
-						key={ siteId }
-						require="calypso/my-sites/site-settings/seo-settings/form"
-						placeholder={ null }
-					/>
-				) }
-				{ isJetpackAdmin && (
-					<JetpackSiteStats
-						handleAutosavingToggle={ handleAutosavingToggle }
-						setFieldValue={ setFieldValue }
-						isSavingSettings={ isSavingSettings }
-						isRequestingSettings={ isRequestingSettings }
-						fields={ fields }
-					/>
-				) }
-				{ isAdmin && <AnalyticsSettings /> }
-				{ isJetpackAdmin && (
-					<Shortlinks
-						handleAutosavingRadio={ handleAutosavingRadio }
-						handleAutosavingToggle={ handleAutosavingToggle }
-						isSavingSettings={ isSavingSettings }
-						isRequestingSettings={ isRequestingSettings }
-						fields={ fields }
-						onSubmitForm={ handleSubmitForm }
-					/>
-				) }
-				{ isAdmin && (
-					<Sitemaps
-						isSavingSettings={ isSavingSettings }
-						isRequestingSettings={ isRequestingSettings }
-						fields={ fields }
-					/>
-				) }
-				{ isAdmin && <SiteVerification /> }
-			</div>
+			>
+				<div className="settings-traffic site-settings">
+					<PageViewTracker path="/marketing/traffic/:site" title="Jetpack > Traffic" />
+					{ ! isAdmin && (
+						<EmptyContent title={ translate( 'You are not authorized to view this page' ) } />
+					) }
+					<JetpackDevModeNotice />
+					{ isAdmin && shouldShowAdvertisingOption && (
+						<PromoCardBlock
+							productSlug="blaze"
+							impressionEvent="calypso_marketing_traffic_blaze_banner_view"
+							clickEvent="calypso_marketing_traffic_blaze_banner_click"
+							headerText={ translate( 'Reach new readers and customers' ) }
+							contentText={ translate(
+								'Use WordPress Blaze to increase your reach by promoting your work to the larger WordPress.com community of blogs and sites. '
+							) }
+							ctaText={ translate( 'Get started' ) }
+							image={ blazeIllustration }
+							href={ advertisingUrl }
+						/>
+					) }
+					{ isAdmin && (
+						<SeoSettingsHelpCard disabled={ isRequestingSettings || isSavingSettings } />
+					) }
+					{ isAdmin && (
+						<AsyncLoad
+							key={ siteId }
+							require="calypso/my-sites/site-settings/seo-settings/form"
+							placeholder={ null }
+						/>
+					) }
+					{ isJetpackAdmin && (
+						<JetpackSiteStats
+							handleAutosavingToggle={ handleAutosavingToggle }
+							setFieldValue={ setFieldValue }
+							isSavingSettings={ isSavingSettings }
+							isRequestingSettings={ isRequestingSettings }
+							fields={ fields }
+						/>
+					) }
+					{ isAdmin && <AnalyticsSettings /> }
+					{ isJetpackAdmin && (
+						<Shortlinks
+							handleAutosavingRadio={ handleAutosavingRadio }
+							handleAutosavingToggle={ handleAutosavingToggle }
+							isSavingSettings={ isSavingSettings }
+							isRequestingSettings={ isRequestingSettings }
+							fields={ fields }
+							onSubmitForm={ handleSubmitForm }
+						/>
+					) }
+					{ isAdmin && (
+						<Sitemaps
+							isSavingSettings={ isSavingSettings }
+							isRequestingSettings={ isRequestingSettings }
+							fields={ fields }
+						/>
+					) }
+					{ isAdmin && <SiteVerification /> }
+				</div>
+			</Page>
 		</Main>
 	);
 };


### PR DESCRIPTION
Part of JETPACK-1361

## Proposed Changes

* Migrates Scan upsell pages (`wpcom-upsell.tsx` and `wpcom-scan-upsell.tsx`) from `NavigationHeader` to `@wordpress/admin-ui` `Page` component
* Migrates Backup upsell pages (`wpcom-upsell.tsx`, `wpcom-backup-upsell.tsx`, and `wpcom-backup-upsell-placeholder.tsx`) from `NavigationHeader` to `Page`
* Uses `JetpackTitle` component for the page title on all pages
* Adds admin-ui CSS import and responsive layout overrides for both `scan` and `backup` sections
* Switches `Main` from `wideLayout` to `fullWidthLayout` to let admin-ui handle content width

Follows the pattern established in the Subscribers migration (PR #109520).

### Scan

Before:
<img width="1155" height="685" alt="image" src="https://github.com/user-attachments/assets/44a47b35-af2f-4a09-999f-dda2d0840048" />


After:

<img width="1153" height="550" alt="image" src="https://github.com/user-attachments/assets/96045120-294d-4fe2-a2f0-2630426bea59" />
<img width="347" height="638" alt="image" src="https://github.com/user-attachments/assets/6bbfb004-6a1f-4b50-bf2f-c01fba6fec41" />


### Backup
Before:
<img width="1157" height="676" alt="image" src="https://github.com/user-attachments/assets/b5b2eede-00fd-4733-b304-697f03763c59" />

After:

<img width="1150" height="680" alt="image" src="https://github.com/user-attachments/assets/046b4767-ecb0-4dc7-9e28-6ccd26d3db6b" />

<img width="348" height="654" alt="image" src="https://github.com/user-attachments/assets/c7b8e6ad-d1ea-4a46-81e6-aad62086465b" />

## Why are these changes being made?

* Aligning Jetpack pages in Calypso with the `@wordpress/admin-ui` Page component, consistent with the Jetpack monorepo header unification.

## Testing Instructions

### Scan
* Navigate to `/scan/<site-slug>` on a WP.com site **without** Scan (should show the upsell page)
* Verify the Jetpack logo appears next to "Scan" in the header
* Verify the subtitle and upsell content display correctly
* Test at different viewport widths (desktop and mobile)

### Backup
* Navigate to `/backup/<site-slug>` on a WP.com site **without** Backup (should show the upsell page)
* Verify the Jetpack logo appears next to "Backup" in the header
* Verify the subtitle and upsell content display correctly
* Test at different viewport widths (desktop and mobile)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
