### PR TITLE
Dockerfile.toolchain: Make sure ci-e2e downloads playwright browsers

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -357,7 +357,6 @@ object BuildToolchainPreviewImages : BuildType({
 				set -euo pipefail
 
 				docker run --rm --entrypoint /bin/bash registry.a8c.com/calypso/ci-e2e:%build.number% -lc '
-					test "${PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD:-}" = "0" &&
 					xvfb-run --help >/dev/null &&
 					aws --version &&
 					dpkg -s fonts-noto-cjk fonts-noto-core libgtk-3-0 libgbm1 libnss3 >/dev/null

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -357,6 +357,7 @@ object BuildToolchainPreviewImages : BuildType({
 				set -euo pipefail
 
 				docker run --rm --entrypoint /bin/bash registry.a8c.com/calypso/ci-e2e:%build.number% -lc '
+					test "${PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD:-}" = "0" &&
 					xvfb-run --help >/dev/null &&
 					aws --version &&
 					dpkg -s fonts-noto-cjk fonts-noto-core libgtk-3-0 libgbm1 libnss3 >/dev/null

--- a/Dockerfile.toolchain
+++ b/Dockerfile.toolchain
@@ -53,6 +53,7 @@ ARG cache_seed_key
 
 LABEL org.opencontainers.image.revision=$commit_sha \
 	io.calypso.cache-seed-key=$cache_seed_key
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=0
 ENV DISPLAY=:99
 
 RUN apt-get update \


### PR DESCRIPTION
I was so concerned with efficiency by removing unneeded playwright browser downloads where they weren't needed, that the actual new ci-e2e image doesn't downloading playwright. Oops. Fixing..

## Proposed Changes

*

## Why are these changes being made?

*

## Testing Instructions


*

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
