### PR TITLE
Cancel flow: hide 'cancel bundled domain' option when domain is past its refund window

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
@@ -43,7 +43,8 @@ const willShowDomainOptionsRadioButtons = (
 	return (
 		includedDomainPurchase.is_domain_registration &&
 		purchase.is_refundable &&
-		!! includedDomainPurchase.cost_to_unbundle_display
+		!! includedDomainPurchase.cost_to_unbundle_display &&
+		includedDomainPurchase.is_within_initial_refund_window
 	);
 };
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/domain-options.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/domain-options.tsx
@@ -236,7 +236,8 @@ const CancelPurchaseDomainOptions = ( {
 	if (
 		'domain_transfer' === includedDomainPurchase.product_slug ||
 		! purchase.is_refundable ||
-		! includedDomainPurchase.cost_to_unbundle_display
+		! includedDomainPurchase.cost_to_unbundle_display ||
+		! includedDomainPurchase.is_within_initial_refund_window
 	) {
 		return (
 			<CancelPlanWithoutCancellingDomainMessage

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -102,7 +102,8 @@ const willShowDomainOptionsRadioButtons = (
 	return (
 		includedDomainPurchase.is_domain_registration &&
 		purchase.is_refundable &&
-		!! includedDomainPurchase.cost_to_unbundle_display
+		!! includedDomainPurchase.cost_to_unbundle_display &&
+		includedDomainPurchase.is_within_initial_refund_window
 	);
 };
 

--- a/client/me/purchases/cancel-purchase/domain-options.tsx
+++ b/client/me/purchases/cancel-purchase/domain-options.tsx
@@ -25,7 +25,8 @@ export const willShowDomainOptionsRadioButtons = (
 	return (
 		isDomainRegistration( includedDomainPurchase ) &&
 		isRefundable( purchase ) &&
-		!! includedDomainPurchase.costToUnbundleText
+		!! includedDomainPurchase.costToUnbundleText &&
+		includedDomainPurchase.isWithinInitialRefundWindow
 	);
 };
 
@@ -253,7 +254,8 @@ const CancelPurchaseDomainOptions = ( {
 	if (
 		isDomainTransfer( includedDomainPurchase ) ||
 		! isRefundable( purchase ) ||
-		! includedDomainPurchase.costToUnbundleText
+		! includedDomainPurchase.costToUnbundleText ||
+		! includedDomainPurchase.isWithinInitialRefundWindow
 	) {
 		return (
 			<CancelPlanWithoutCancellingDomainMessage

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -107,6 +107,7 @@ describe( 'selectors', () => {
 				isInAppPurchase: false,
 				isRechargeable: true,
 				isRefundable: false,
+				isWithinInitialRefundWindow: false,
 				isRenewable: false,
 				isRenewal: false,
 				isWooExpressTrial: false,

--- a/packages/api-core/src/upgrades/types.ts
+++ b/packages/api-core/src/upgrades/types.ts
@@ -135,6 +135,13 @@ export interface Purchase {
 	 */
 	cost_to_unbundle_display: undefined | string;
 
+	/**
+	 * True if this subscription is within the refund window of its initial
+	 * purchase (i.e. not a renewal). Used to determine whether a bundled domain
+	 * can be cancelled together with its plan for a full refund.
+	 */
+	is_within_initial_refund_window: boolean;
+
 	price_text: string;
 	price_tier_list: Array< PriceTierEntry >;
 	currency_code: string;

--- a/packages/data-stores/src/purchases/lib/assembler.ts
+++ b/packages/data-stores/src/purchases/lib/assembler.ts
@@ -58,6 +58,7 @@ export function createPurchaseObject( purchase: RawPurchase ): Purchase {
 		isInAppPurchase: Boolean( purchase.is_iap_purchase ),
 		isRechargeable: Boolean( purchase.is_rechargeable ),
 		isRefundable: Boolean( purchase.is_refundable ),
+		isWithinInitialRefundWindow: Boolean( purchase.is_within_initial_refund_window ),
 		isRenewable: Boolean( purchase.is_renewable ),
 		isRenewal: Boolean( purchase.is_renewal ),
 		isWooExpressTrial: Boolean( purchase.is_woo_express_trial ),

--- a/packages/data-stores/src/purchases/types.ts
+++ b/packages/data-stores/src/purchases/types.ts
@@ -66,6 +66,7 @@ export interface Purchase {
 	isLocked: boolean;
 	isRechargeable: boolean;
 	isRefundable: boolean;
+	isWithinInitialRefundWindow: boolean;
 	isRenewable: boolean;
 	isRenewal: boolean;
 	isWooExpressTrial: boolean;


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/SHILL-1789/regression-cancelling-a-plan-outside-the-domain-refund-window-allows

## Proposed changes

This PR adds a new `is_within_initial_refund_window` boolean field to the purchase API type and uses it to gate the "cancel plan and domain together" option in the plan cancellation flow. (209178-ghe-Automattic/wpcom will also make the refund itself impossible)

Before             |  After
:-------------------------:|:-------------------------:
<img width="690" height="505" alt="Screenshot 2026-03-25 at 1 25 18 PM" src="https://github.com/user-attachments/assets/4cfbd58b-8a0a-45ad-82b7-9429745d148f" /> | <img width="682" height="618" alt="Screenshot 2026-03-25 at 1 24 59 PM" src="https://github.com/user-attachments/assets/2b432e28-008b-46f9-bcd8-6ff705987131" />
<img width="686" height="481" alt="Screenshot 2026-03-25 at 1 24 16 PM" src="https://github.com/user-attachments/assets/3abd9772-565e-49c1-aa93-d8f7d2f9573c" /> | <img width="698" height="530" alt="Screenshot 2026-03-25 at 1 24 41 PM" src="https://github.com/user-attachments/assets/dcc892cd-580d-435d-bf8c-807f080d205f" />


## Why are these changes being made?

When cancelling a refundable plan that includes a bundled domain, the cancel flow offers two choices: keep the domain (partial refund with the domain cost withheld) or cancel both together (full refund). The second option is only valid while the bundled domain is still within its registry refund window — after that point, WP.com can no longer recover the registration fee, so the withholding from the plan refund must be mandatory.

Previously the frontend had no way to distinguish this case. It used `cost_to_unbundle_display` as a proxy, but that field is set based on the _plan's_ refund eligibility, not the domain's. This meant the "cancel both" radio button could appear even after the domain's refund window had closed, which is incorrect — the user could select an option that either shouldn't apply or would produce the wrong refund amount.

The fix adds `is_within_initial_refund_window` (provided by the backend in 209357-ghe-Automattic/wpcom) to all four places that gate the radio-button choice, in both the Classic (`client/me/purchases/cancel-purchase/`) and Dashboard (`client/dashboard/me/billing-purchases/cancel-purchase/`) cancel flows. When the domain is past its window, all paths fall through to `CancelPlanWithoutCancellingDomainMessage`, which already correctly renders the mandatory partial-refund message.

## Testing instructions

1. Purchase a plan that includes a bundled domain.
2. **Within the domain's refund window:** navigate to cancel the plan. The "What would you like to do with the domain?" prompt with two radio options should appear.
3. **After the domain's refund window has expired, while the plan is still refundable:** navigate to cancel the plan. The radio buttons should not appear; instead only the partial-refund message ("the domain will not be removed… you will receive a partial refund of X") should be shown.