### PR TITLE
 Renewal pricing: update the rollout date

### DIFF
--- a/client/my-sites/plans-features-main/hooks/test/use-renewal-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-renewal-price-experiment.ts
@@ -134,7 +134,7 @@ describe( 'useRenewalPricingExperiment', () => {
 
 	describe( 'registration date cutoff', () => {
 		it( 'qualifies users registered on the cutoff date', () => {
-			mockUserDate( '2026-03-26T00:00:00Z' );
+			mockUserDate( '2026-03-27T00:00:00Z' );
 			const { result } = renderHook( () => useRenewalPricingExperiment() );
 			expect( result.current[ 1 ] ).toBe( 'crossed_price' );
 		} );

--- a/client/my-sites/plans-features-main/hooks/use-renewal-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-renewal-price-experiment.ts
@@ -47,7 +47,7 @@ export function useRenewalPricingExperiment(
 	return [ false, 'crossed_price' ];
 }
 
-const REGISTRATION_DATE_CUTOFF = new Date( '2026-03-26T00:00:00Z' );
+const REGISTRATION_DATE_CUTOFF = new Date( '2026-03-27T00:00:00Z' );
 
 function isNewUserOrLoggedOut( registrationDate: string | null | undefined ): boolean {
 	if ( ! registrationDate ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to [DOTMART-116](https://linear.app/a8c/issue/DOTMART-116)

## Proposed Changes

* Update the date.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To allow more time for coordination.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
