### PR TITLE
Scan & Backup: Migrate all headers to admin-ui Page

### DIFF
--- a/client/components/jetpack/wpcom-business-at/index.tsx
+++ b/client/components/jetpack/wpcom-business-at/index.tsx
@@ -2,6 +2,7 @@ import { WPCOM_FEATURES_BACKUPS_SELF_SERVE } from '@automattic/calypso-products'
 import page from '@automattic/calypso-router';
 import { CompactCard, Dialog } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { Page } from '@wordpress/admin-ui';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import { useCallback, useEffect, useState } from 'react';
@@ -16,8 +17,8 @@ import WarningList from 'calypso/blocks/eligibility-warnings/warning-list';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryAutomatedTransferEligibility from 'calypso/components/data/query-atat-eligibility';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
-import FormattedHeader from 'calypso/components/formatted-header';
 import WhatIsJetpack from 'calypso/components/jetpack/what-is-jetpack';
+import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
@@ -72,6 +73,7 @@ interface TransferFailureNoticeProps {
 export interface AtomicContentSwitch {
 	documentHeadTitle: string;
 	header: string;
+	subTitle?: string;
 	primaryPromo: {
 		image: { path: string };
 		promoCTA: { loadingText: string; text: string };
@@ -85,7 +87,8 @@ export interface AtomicContentSwitch {
 
 const vaultpressContent: AtomicContentSwitch = {
 	documentHeadTitle: translate( 'Activate Jetpack VaultPress Backup now' ) as string,
-	header: translate( 'Jetpack VaultPress Backup' ) as string,
+	header: translate( 'Backup' ) as string,
+	subTitle: translate( 'Save changes and restore quickly with one-click recovery.' ) as string,
 	primaryPromo: {
 		title: translate( 'Get time travel for your site with Jetpack VaultPress Backup' ),
 		image: { path: JetpackBackupSVG },
@@ -280,19 +283,19 @@ export default function WPCOMBusinessAT( {
 	// If features are not loaded yet, show loading state
 	if ( featuresNotLoaded ) {
 		return (
-			<Main wideLayout className="wpcom-business-at">
+			<Main fullWidthLayout className="wpcom-business-at">
 				<QuerySiteFeatures siteIds={ [ siteId ] } />
 				<DocumentHead title={ content.documentHeadTitle } />
-				<FormattedHeader
-					id="wpcom-business-at-header"
-					className="wpcom-business-at__header"
-					headerText={ content.header }
-					align="left"
-					brandFont
-				/>
-				<div className="wpcom-business-at__loading">
-					<p>{ translate( 'Loading…' ) }</p>
-				</div>
+				<Page
+					hasPadding
+					showSidebarToggle={ false }
+					title={ <JetpackTitle title={ content.header } /> }
+					subTitle={ content.subTitle }
+				>
+					<div className="wpcom-business-at__loading">
+						<p>{ translate( 'Loading…' ) }</p>
+					</div>
+				</Page>
 			</Main>
 		);
 	}
@@ -303,59 +306,59 @@ export default function WPCOMBusinessAT( {
 	}
 
 	return (
-		<Main wideLayout className="wpcom-business-at">
+		<Main fullWidthLayout className="wpcom-business-at">
 			<QueryAutomatedTransferEligibility siteId={ siteId } />
 			<DocumentHead title={ content.documentHeadTitle } />
 			<PageViewTracker path="/backup/:site" title="Business Plan Automated Transfer" />
 
-			<FormattedHeader
-				id="wpcom-business-at-header"
-				className="wpcom-business-at__header"
-				headerText={ content.header }
-				align="left"
-				brandFont
-			/>
-			<BlockingHoldNotice
-				siteId={ siteId }
-				productName={ content.header }
-				suppressInstallNotice={ rewindAtomicDeactivated }
-			/>
-			<TransferFailureNotice
-				transferStatus={ automatedTransferStatus as TransferStatus }
-				productName={ content.header }
-			/>
-			<PromoCard
-				title={ content.primaryPromo.title }
-				image={ content.primaryPromo.image }
-				isPrimary
+			<Page
+				hasPadding
+				showSidebarToggle={ false }
+				title={ <JetpackTitle title={ content.header } /> }
+				subTitle={ content.subTitle }
 			>
-				<p>{ content.primaryPromo.content }</p>
-				<div className="wpcom-business-at__cta">
-					<SpinnerButton
-						text={ content.primaryPromo.promoCTA.text }
-						loadingText={ content.primaryPromo.promoCTA.loadingText }
-						loading={
-							automatedTransferStatus === START ||
-							( automatedTransferStatus === COMPLETE && ! isJetpack ) ||
-							isRewindActivating
-						}
-						onClick={ () => {
-							if ( rewindAtomicDeactivated ) {
-								setIsRewindActivating( true );
-								dispatch( autoConfigCredentials( siteId ) );
-								page( content.getProductUrl( siteSlug ) );
-								return;
+				<BlockingHoldNotice
+					siteId={ siteId }
+					productName={ content.header }
+					suppressInstallNotice={ rewindAtomicDeactivated }
+				/>
+				<TransferFailureNotice
+					transferStatus={ automatedTransferStatus as TransferStatus }
+					productName={ content.header }
+				/>
+				<PromoCard
+					title={ content.primaryPromo.title }
+					image={ content.primaryPromo.image }
+					isPrimary
+				>
+					<p>{ content.primaryPromo.content }</p>
+					<div className="wpcom-business-at__cta">
+						<SpinnerButton
+							text={ content.primaryPromo.promoCTA.text }
+							loadingText={ content.primaryPromo.promoCTA.loadingText }
+							loading={
+								automatedTransferStatus === START ||
+								( automatedTransferStatus === COMPLETE && ! isJetpack ) ||
+								isRewindActivating
 							}
-							initiateATOrShowWarnings();
-						} }
-						disabled={
-							( cannotInitiateTransfer && ! rewindAtomicDeactivated ) || isRewindActivating
-						}
-					/>
-				</div>
-			</PromoCard>
+							onClick={ () => {
+								if ( rewindAtomicDeactivated ) {
+									setIsRewindActivating( true );
+									dispatch( autoConfigCredentials( siteId ) );
+									page( content.getProductUrl( siteSlug ) );
+									return;
+								}
+								initiateATOrShowWarnings();
+							} }
+							disabled={
+								( cannotInitiateTransfer && ! rewindAtomicDeactivated ) || isRewindActivating
+							}
+						/>
+					</div>
+				</PromoCard>
 
-			{ ! isJetpackCloud() && <WhatIsJetpack className="wpcom-business-at__footer" /> }
+				{ ! isJetpackCloud() && <WhatIsJetpack className="wpcom-business-at__footer" /> }
+			</Page>
 
 			<Dialog
 				isVisible={ showDialog }

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -1,5 +1,6 @@
 import { WPCOM_FEATURES_REAL_TIME_BACKUPS } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
+import { Page } from '@wordpress/admin-ui';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
@@ -20,7 +21,6 @@ import BackupPlaceholder from 'calypso/components/jetpack/backup-placeholder';
 import JetpackTitle from 'calypso/components/jetpack-title';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
-import NavigationHeader from 'calypso/components/navigation-header';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -64,31 +64,36 @@ const BackupPage = ( { queryDate } ) => {
 		keepLocalTime: !! queryDate,
 	} );
 
+	const isWpcom = ! ( isJetpackCloud() || isA8CForAgencies() );
+
 	return (
 		<div
 			className={ clsx( 'backup__page', {
-				wordpressdotcom: ! ( isJetpackCloud() || isA8CForAgencies() ),
+				wordpressdotcom: isWpcom,
 			} ) }
 		>
 			<Main
-				wideLayout
+				fullWidthLayout={ isWpcom }
+				wideLayout={ ! isWpcom }
 				className={ clsx( {
 					is_jetpackcom: isJetpackCloud(),
 				} ) }
 			>
 				{ isJetpackCloud() && <SidebarNavigation /> }
 				<TimeMismatchWarning siteId={ siteId } settingsUrl={ siteSettingsUrl } />
-				{ ! ( isJetpackCloud() || isA8CForAgencies() ) && (
-					<NavigationHeader
-						navigationItems={ [] }
+				{ isWpcom ? (
+					<Page
+						hasPadding
+						showSidebarToggle={ false }
 						title={ <JetpackTitle title={ translate( 'Backup' ) } /> }
-						subtitle={ translate( 'Save changes and restore quickly with one-click recovery.' ) }
+						subTitle={ translate( 'Save changes and restore quickly with one-click recovery.' ) }
+						actions={ <BackupActionsToolbar siteId={ siteId } /> }
 					>
-						<BackupActionsToolbar siteId={ siteId } />
-					</NavigationHeader>
+						<AdminContent selectedDate={ selectedDate } />
+					</Page>
+				) : (
+					<AdminContent selectedDate={ selectedDate } />
 				) }
-
-				<AdminContent selectedDate={ selectedDate } />
 			</Main>
 		</div>
 	);

--- a/client/my-sites/scan/history/index.tsx
+++ b/client/my-sites/scan/history/index.tsx
@@ -1,10 +1,10 @@
+import { Page } from '@wordpress/admin-ui';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import ThreatHistoryList from 'calypso/components/jetpack/threat-history-list';
 import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
-import NavigationHeader from 'calypso/components/navigation-header';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -21,25 +21,10 @@ interface Props {
 export default function ScanHistoryPage( { filter }: Props ) {
 	const translate = useTranslate();
 	const isJetpackPlatform = isJetpackCloud();
+	const isWpcom = ! ( isJetpackPlatform || isA8CForAgencies() );
 
-	return (
-		<Main
-			wideLayout
-			className={ clsx( 'scan history', {
-				is_jetpackcom: isJetpackPlatform,
-			} ) }
-		>
-			<DocumentHead title={ translate( 'Scan' ) } />
-			{ isJetpackPlatform && <SidebarNavigation /> }
-			<PageViewTracker path="/scan/history/:site" title="Scan History" />
-			{ ! ( isJetpackPlatform || isA8CForAgencies() ) && (
-				<NavigationHeader
-					navigationItems={ [] }
-					title={ <JetpackTitle title={ translate( 'Scan' ) } /> }
-					subtitle={ translate( 'Automated malware scanning and firewall protection.' ) }
-				/>
-			) }
-
+	const content = (
+		<>
 			<ScanNavigation section="history" />
 			<section className="history__body">
 				<p className="history__description">
@@ -49,6 +34,32 @@ export default function ScanHistoryPage( { filter }: Props ) {
 				</p>
 				<ThreatHistoryList filter={ filter } />
 			</section>
+		</>
+	);
+
+	return (
+		<Main
+			fullWidthLayout={ isWpcom }
+			wideLayout={ ! isWpcom }
+			className={ clsx( 'scan history', {
+				is_jetpackcom: isJetpackPlatform,
+			} ) }
+		>
+			<DocumentHead title={ translate( 'Scan' ) } />
+			{ isJetpackPlatform && <SidebarNavigation /> }
+			<PageViewTracker path="/scan/history/:site" title="Scan History" />
+			{ isWpcom ? (
+				<Page
+					hasPadding
+					showSidebarToggle={ false }
+					title={ <JetpackTitle title={ translate( 'Scan' ) } /> }
+					subTitle={ translate( 'Automated malware scanning and firewall protection.' ) }
+				>
+					{ content }
+				</Page>
+			) : (
+				content
+			) }
 		</Main>
 	);
 }

--- a/client/my-sites/scan/main.tsx
+++ b/client/my-sites/scan/main.tsx
@@ -1,5 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Button, ProgressBar, Gridicon, Card } from '@automattic/components';
+import { Page } from '@wordpress/admin-ui';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import { Component } from 'react';
@@ -14,7 +15,6 @@ import SecurityIcon from 'calypso/components/jetpack/security-icon';
 import JetpackTitle from 'calypso/components/jetpack-title';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
-import NavigationHeader from 'calypso/components/navigation-header';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import { withApplySiteOffset, applySiteOffsetType } from 'calypso/components/site-offset';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
@@ -326,6 +326,7 @@ class ScanPage extends Component< Props > {
 	render() {
 		const { siteId, siteSettingsUrl } = this.props;
 		const isJetpackPlatform = isJetpackCloud();
+		const isWpcom = ! ( isJetpackPlatform || isA8CForAgencies() );
 		let mainClass = 'scan';
 
 		if ( ! siteId ) {
@@ -336,9 +337,19 @@ class ScanPage extends Component< Props > {
 			mainClass = 'scan-new';
 		}
 
+		const content = (
+			<>
+				<QueryJetpackScan siteId={ siteId } />
+				<ScanNavigation section="scanner" />
+				<div className="scan__content">{ this.renderScanState() }</div>
+				{ this.renderJetpackReviewPrompt() }
+			</>
+		);
+
 		return (
 			<Main
-				wideLayout
+				fullWidthLayout={ isWpcom }
+				wideLayout={ ! isWpcom }
 				className={ clsx( mainClass, {
 					is_jetpackcom: isJetpackPlatform,
 				} ) }
@@ -347,18 +358,18 @@ class ScanPage extends Component< Props > {
 				{ isJetpackPlatform && <SidebarNavigation /> }
 				<PageViewTracker path="/scan/:site" title="Scanner" />
 				<TimeMismatchWarning siteId={ siteId } settingsUrl={ siteSettingsUrl } />
-				{ ! ( isJetpackPlatform || isA8CForAgencies() ) && (
-					<NavigationHeader
-						navigationItems={ [] }
+				{ isWpcom ? (
+					<Page
+						hasPadding
+						showSidebarToggle={ false }
 						title={ <JetpackTitle title={ translate( 'Scan' ) } /> }
-						subtitle={ translate( 'Automated malware scanning and firewall protection.' ) }
-					/>
+						subTitle={ translate( 'Automated malware scanning and firewall protection.' ) }
+					>
+						{ content }
+					</Page>
+				) : (
+					content
 				) }
-
-				<QueryJetpackScan siteId={ siteId } />
-				<ScanNavigation section="scanner" />
-				<div className="scan__content">{ this.renderScanState() }</div>
-				{ this.renderJetpackReviewPrompt() }
 			</Main>
 		);
 	}

--- a/client/my-sites/scan/wpcom-atomic-transfer.tsx
+++ b/client/my-sites/scan/wpcom-atomic-transfer.tsx
@@ -1,12 +1,13 @@
 import { WPCOM_FEATURES_SCAN_SELF_SERVE } from '@automattic/calypso-products';
+import { Page } from '@wordpress/admin-ui';
 import { translate } from 'i18n-calypso';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import JetpackScanSVG from 'calypso/assets/images/illustrations/jetpack-scan.svg';
 import QueryJetpackScan from 'calypso/components/data/query-jetpack-scan';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
-import FormattedHeader from 'calypso/components/formatted-header';
 import WPCOMBusinessAT from 'calypso/components/jetpack/wpcom-business-at';
+import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
@@ -27,16 +28,16 @@ const ScanLoadingPlaceholder = () => {
 	const siteId = useSelector( getSelectedSiteId ) as number;
 
 	return (
-		<Main className="business-at-switch__loading">
+		<Main fullWidthLayout className="business-at-switch__loading">
 			<QuerySiteFeatures siteIds={ [ siteId ] } />
 			<QueryJetpackScan siteId={ siteId } />
-			<FormattedHeader
-				id="wpcom-scan-loading"
-				className="business-at-switch placeholder__header"
-				headerText={ translate( 'Loading…' ) }
-				align="left"
-			/>
-			<div className="business-at-switch placeholder__primary-promo"></div>
+			<Page
+				hasPadding
+				showSidebarToggle={ false }
+				title={ <JetpackTitle title={ translate( 'Scan' ) } /> }
+			>
+				<div className="business-at-switch placeholder__primary-promo"></div>
+			</Page>
 		</Main>
 	);
 };
@@ -86,7 +87,8 @@ const ScanAtomicTransferWrapper = () => {
 	// If scan state is 'unavailable' and site has scan feature, show atomic transfer activation
 	const content = {
 		documentHeadTitle: translate( 'Activate Jetpack Scan now' ) as string,
-		header: translate( 'Jetpack Scan' ) as string,
+		header: translate( 'Scan' ) as string,
+		subTitle: translate( 'Automated malware scanning and firewall protection.' ) as string,
 		primaryPromo: {
 			title: translate( 'We guard your site. You run your business.' ),
 			image: { path: JetpackScanSVG },

--- a/client/my-sites/scan/wpcom-scan-upsell-placeholder.tsx
+++ b/client/my-sites/scan/wpcom-scan-upsell-placeholder.tsx
@@ -1,13 +1,18 @@
+import { Page } from '@wordpress/admin-ui';
 import { useTranslate } from 'i18n-calypso';
-import FormattedHeader from 'calypso/components/formatted-header';
 import WpcomUpsellPlaceholder from 'calypso/components/jetpack/wpcom-upsell-placeholder';
+import JetpackTitle from 'calypso/components/jetpack-title';
 
 export default function WpcomScanUpsellPlaceholder() {
 	const translate = useTranslate();
 	return (
-		<>
-			<FormattedHeader brandFont headerText={ translate( 'Jetpack Scan' ) } align="left" />
+		<Page
+			hasPadding
+			showSidebarToggle={ false }
+			title={ <JetpackTitle title={ translate( 'Scan' ) } /> }
+			subTitle={ translate( 'Automated malware scanning and firewall protection.' ) }
+		>
 			<WpcomUpsellPlaceholder />
-		</>
+		</Page>
 	);
 }


### PR DESCRIPTION
Part of JETPACK-1361
Depends on #109567

## Proposed Changes

* Migrates **Scan main page** (`scan/main.tsx`), **Scan history** (`scan/history/index.tsx`), and **Backup main page** (`backup/main.jsx`) from `NavigationHeader` to `@wordpress/admin-ui` `Page` component
* Migrates **atomic transfer activation** (`wpcom-business-at/index.tsx`, `wpcom-atomic-transfer.tsx`) and **Scan upsell placeholder** from `FormattedHeader` to `Page`
* Environment-conditional rendering preserved: `Page` only renders on WP.com; Jetpack Cloud and A8C for Agencies paths are unchanged
* Backup's `BackupActionsToolbar` moves from NavigationHeader children to the `Page` `actions` prop
* Shortens product names in atomic transfer headers: "Jetpack VaultPress Backup" -> "Backup", "Jetpack Scan" -> "Scan" (JetpackTitle component provides the Jetpack logo)
* Adds `subTitle` prop to `AtomicContentSwitch` interface for consistent subtitles

Follows the pattern established in the Subscribers migration (PR #109520).

Before:

<img width="1153" height="678" alt="image" src="https://github.com/user-attachments/assets/5549610f-d3c6-4390-ac14-3977449ad8fa" />

<img width="1153" height="730" alt="image" src="https://github.com/user-attachments/assets/087901c9-9f36-47df-a9f1-a723b1a10da1" />


After:

<img width="1152" height="625" alt="image" src="https://github.com/user-attachments/assets/497c2068-c4dc-4c74-ada3-3b79b656e729" />
<img width="1152" height="682" alt="image" src="https://github.com/user-attachments/assets/b4b0c155-8c85-4db5-b424-996516f3898e" />


## Why are these changes being made?

* Aligning Jetpack pages in Calypso with the `@wordpress/admin-ui` Page component, consistent with the Jetpack monorepo header unification.

## Testing Instructions

### Scan (site without Scan active, e.g. Business plan with Scan unavailable)
* Navigate to `/scan/<site-slug>` — should show atomic transfer activation with admin-ui Page header
* Verify "Scan" title with Jetpack logo and subtitle

### Scan (site with Scan active)
* Navigate to `/scan/<site-slug>` — should show Scan dashboard with admin-ui Page header
* Navigate to `/scan/history/<site-slug>` — same header on history page

### Backup (site without Backup active)
* Navigate to `/backup/<site-slug>` — should show atomic transfer activation with admin-ui Page header
* Verify "Backup" title with Jetpack logo and subtitle

### Backup (site with Backup active)
* Navigate to `/backup/<site-slug>` — should show Backup dashboard with admin-ui Page header and BackupActionsToolbar in actions area

### All pages
* Test at different viewport widths (desktop and mobile)
* Verify Jetpack Cloud does NOT show the admin-ui Page header (env-conditional)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
