### PR TITLE
Traffic: Migrate header to admin-ui Page

### DIFF
--- a/client/sites/marketing/traffic/style.scss
+++ b/client/sites/marketing/traffic/style.scss
@@ -2,6 +2,7 @@
 
 body.is-section-marketing {
 	@include admin-ui-page-layout;
+	@include admin-ui-page-layout-constrained-content;
 }
 
 .site-settings {

--- a/client/sites/marketing/traffic/style.scss
+++ b/client/sites/marketing/traffic/style.scss
@@ -1,3 +1,9 @@
+@import "calypso/components/jetpack-page-layout/admin-ui-page";
+
+body.is-section-marketing {
+	@include admin-ui-page-layout;
+}
+
 .site-settings {
 	font-size: $font-body-small;
 

--- a/client/sites/marketing/traffic/traffic.js
+++ b/client/sites/marketing/traffic/traffic.js
@@ -1,3 +1,4 @@
+import { Page } from '@wordpress/admin-ui';
 import { localize } from 'i18n-calypso';
 import { pick } from 'lodash';
 import { useEffect } from 'react';
@@ -11,7 +12,6 @@ import EmptyContent from 'calypso/components/empty-content';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
-import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import useAdvertisingUrl from 'calypso/my-sites/advertising/useAdvertisingUrl';
 import AnalyticsSettings from 'calypso/my-sites/site-settings/analytics/form-google-analytics';
@@ -54,13 +54,14 @@ const SiteSettingsTraffic = ( {
 
 	return (
 		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-		<Main wideLayout className="sharing">
+		<Main fullWidthLayout className="sharing">
 			<DocumentHead title={ translate( 'Traffic' ) } />
 			{ siteId && <QueryJetpackModules siteId={ siteId } /> }
-			<NavigationHeader
-				navigationItems={ [] }
+			<Page
+				hasPadding
+				showSidebarToggle={ false }
 				title={ <JetpackTitle title={ translate( 'Traffic' ) } /> }
-				subtitle={ translate(
+				subTitle={ translate(
 					'Manage settings and tools related to the traffic your website receives. {{learnMoreLink/}}',
 					{
 						components: {
@@ -70,64 +71,67 @@ const SiteSettingsTraffic = ( {
 						},
 					}
 				) }
-			/>
-			<div className="settings-traffic site-settings">
-				<PageViewTracker path="/marketing/traffic/:site" title="Jetpack > Traffic" />
-				{ ! isAdmin && (
-					<EmptyContent title={ translate( 'You are not authorized to view this page' ) } />
-				) }
-				<JetpackDevModeNotice />
-				{ isAdmin && shouldShowAdvertisingOption && (
-					<PromoCardBlock
-						productSlug="blaze"
-						impressionEvent="calypso_marketing_traffic_blaze_banner_view"
-						clickEvent="calypso_marketing_traffic_blaze_banner_click"
-						headerText={ translate( 'Reach new readers and customers' ) }
-						contentText={ translate(
-							'Use WordPress Blaze to increase your reach by promoting your work to the larger WordPress.com community of blogs and sites. '
-						) }
-						ctaText={ translate( 'Get started' ) }
-						image={ blazeIllustration }
-						href={ advertisingUrl }
-					/>
-				) }
-				{ isAdmin && <SeoSettingsHelpCard disabled={ isRequestingSettings || isSavingSettings } /> }
-				{ isAdmin && (
-					<AsyncLoad
-						key={ siteId }
-						require="calypso/my-sites/site-settings/seo-settings/form"
-						placeholder={ null }
-					/>
-				) }
-				{ isJetpackAdmin && (
-					<JetpackSiteStats
-						handleAutosavingToggle={ handleAutosavingToggle }
-						setFieldValue={ setFieldValue }
-						isSavingSettings={ isSavingSettings }
-						isRequestingSettings={ isRequestingSettings }
-						fields={ fields }
-					/>
-				) }
-				{ isAdmin && <AnalyticsSettings /> }
-				{ isJetpackAdmin && (
-					<Shortlinks
-						handleAutosavingRadio={ handleAutosavingRadio }
-						handleAutosavingToggle={ handleAutosavingToggle }
-						isSavingSettings={ isSavingSettings }
-						isRequestingSettings={ isRequestingSettings }
-						fields={ fields }
-						onSubmitForm={ handleSubmitForm }
-					/>
-				) }
-				{ isAdmin && (
-					<Sitemaps
-						isSavingSettings={ isSavingSettings }
-						isRequestingSettings={ isRequestingSettings }
-						fields={ fields }
-					/>
-				) }
-				{ isAdmin && <SiteVerification /> }
-			</div>
+			>
+				<div className="settings-traffic site-settings">
+					<PageViewTracker path="/marketing/traffic/:site" title="Jetpack > Traffic" />
+					{ ! isAdmin && (
+						<EmptyContent title={ translate( 'You are not authorized to view this page' ) } />
+					) }
+					<JetpackDevModeNotice />
+					{ isAdmin && shouldShowAdvertisingOption && (
+						<PromoCardBlock
+							productSlug="blaze"
+							impressionEvent="calypso_marketing_traffic_blaze_banner_view"
+							clickEvent="calypso_marketing_traffic_blaze_banner_click"
+							headerText={ translate( 'Reach new readers and customers' ) }
+							contentText={ translate(
+								'Use WordPress Blaze to increase your reach by promoting your work to the larger WordPress.com community of blogs and sites. '
+							) }
+							ctaText={ translate( 'Get started' ) }
+							image={ blazeIllustration }
+							href={ advertisingUrl }
+						/>
+					) }
+					{ isAdmin && (
+						<SeoSettingsHelpCard disabled={ isRequestingSettings || isSavingSettings } />
+					) }
+					{ isAdmin && (
+						<AsyncLoad
+							key={ siteId }
+							require="calypso/my-sites/site-settings/seo-settings/form"
+							placeholder={ null }
+						/>
+					) }
+					{ isJetpackAdmin && (
+						<JetpackSiteStats
+							handleAutosavingToggle={ handleAutosavingToggle }
+							setFieldValue={ setFieldValue }
+							isSavingSettings={ isSavingSettings }
+							isRequestingSettings={ isRequestingSettings }
+							fields={ fields }
+						/>
+					) }
+					{ isAdmin && <AnalyticsSettings /> }
+					{ isJetpackAdmin && (
+						<Shortlinks
+							handleAutosavingRadio={ handleAutosavingRadio }
+							handleAutosavingToggle={ handleAutosavingToggle }
+							isSavingSettings={ isSavingSettings }
+							isRequestingSettings={ isRequestingSettings }
+							fields={ fields }
+							onSubmitForm={ handleSubmitForm }
+						/>
+					) }
+					{ isAdmin && (
+						<Sitemaps
+							isSavingSettings={ isSavingSettings }
+							isRequestingSettings={ isRequestingSettings }
+							fields={ fields }
+						/>
+					) }
+					{ isAdmin && <SiteVerification /> }
+				</div>
+			</Page>
 		</Main>
 	);
 };


### PR DESCRIPTION
Part of JETPACK-1361
Depends on #109567

## Proposed Changes

* Migrates the Traffic settings page from `NavigationHeader` to `@wordpress/admin-ui` `Page` component
* Uses `JetpackTitle` component for the page title (already present from PR #108987)
* Adds admin-ui-page-layout mixin for the `marketing` section
* Switches `Main` from `wideLayout` to `fullWidthLayout`

Follows the pattern established in the Subscribers migration (PR #109520).

Before:
<img width="1154" height="680" alt="image" src="https://github.com/user-attachments/assets/7dc999c1-9038-4da3-98bd-27f2b0089fce" />

After:
<img width="1154" height="638" alt="image" src="https://github.com/user-attachments/assets/1c0467d6-c373-458b-a5ef-7a41ad4c6e5c" />

## Why are these changes being made?

* Aligning Jetpack pages in Calypso with the `@wordpress/admin-ui` Page component, consistent with the Jetpack monorepo header unification.

## Testing Instructions

* Navigate to `/marketing/traffic/<site-slug>`
* Verify the Jetpack logo appears next to "Traffic" in the header
* Verify the subtitle with "Learn more" link displays correctly
* Verify page content (Blaze promo, SEO, analytics settings, etc.) renders properly
* Test at different viewport widths (desktop and mobile)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
