### PR TITLE
Dockerfile.toolchain: Automate builds on relevant trunk changes and weekly schedule

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -290,7 +290,7 @@ object BuildBaseImages : BuildType({
 
 object BuildToolchainPreviewImages : BuildType({
 	name = "Build toolchain images"
-	description = "Builds manual-only toolchain, ci-e2e, and ci-wpcom images from Dockerfile.toolchain and publishes the canonical ci image tags."
+	description = "Builds toolchain, ci-e2e, and ci-wpcom images from Dockerfile.toolchain and publishes the canonical ci image tags."
 
 	buildNumberPattern = "%build.prefix%.%build.counter%"
 
@@ -417,6 +417,32 @@ object BuildToolchainPreviewImages : BuildType({
 					registry.a8c.com/calypso/ci-wpcom:%build.number%
 				""".trimIndent()
 			}
+		}
+	}
+
+	triggers {
+		vcs {
+			branchFilter = """
+				+:trunk
+			""".trimIndent()
+			triggerRules = """
+				+:.nvmrc
+				+:.dockerignore
+				+:Dockerfile.toolchain
+				+:composer.json
+				+:composer.lock
+			""".trimIndent()
+		}
+		schedule {
+			schedulingPolicy = cron {
+				hours = "1"
+				dayOfWeek = "Sun"
+			}
+			branchFilter = """
+				+:trunk
+			""".trimIndent()
+			triggerBuild = always()
+			withPendingChangesOnly = false
 		}
 	}
 


### PR DESCRIPTION
## Proposed Changes

* The `Build toolchain images` job will now automatically run when:
  * Files touched on trunk: (`.nvmrc`, `Dockerfile.toolchain`, `.dockerignore`, `composer.json`, `composer.lock`)
  * Weekly schedule - Sunday at 1am. Backup plan and any changes from upstream apt or node changes.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Now that `ci-e2e:latest` and `ci-wpcom:latest` are published from this job, it needs to run automatically. Previously this was manual because we were still validating the toolchain path. The old `Build base images` job ran on a 6-hour cron - a weekly schedule plus file change triggers should be fine since the toolchain image changes much less frequently than the cache.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
