### PR TITLE
Monetize: Migrate header to admin-ui Page

### DIFF
--- a/client/components/jetpack-page-layout/_admin-ui-page.scss
+++ b/client/components/jetpack-page-layout/_admin-ui-page.scss
@@ -16,15 +16,19 @@
 	.layout__primary .main {
 		padding-bottom: 0;
 	}
+}
 
-	// Temporarily here until constrained content width is implemented in Admin-UI
-	.admin-ui-page__content {
-		> * {
-			max-width: 660px;
-			width: 100%;
-			margin-left: auto;
-			margin-right: auto;
-			box-sizing: border-box;
+@mixin admin-ui-page-layout-constrained-content {
+	.layout:not(.has-no-sidebar) .layout__content {
+		// Temporarily here until constrained content width is implemented in Admin-UI
+		.admin-ui-page__content {
+			> * {
+				max-width: 660px;
+				width: 100%;
+				margin-left: auto;
+				margin-right: auto;
+				box-sizing: border-box;
+			}
 		}
 	}
 }

--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -2,6 +2,7 @@
 
 body.is-section-backup {
 	@include admin-ui-page-layout;
+	@include admin-ui-page-layout-constrained-content;
 }
 
 .backup__page {

--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -190,7 +190,7 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 
 	const getEarnSectionNav = () => {
 		return (
-			<div id="earn-navigation">
+			<div className="earn-navigation">
 				<SectionNav
 					selectedText={ getEarnSelectedText() }
 					variation={ ! isJetpackCloud() ? 'minimal' : '' }
@@ -246,8 +246,10 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 	const content = (
 		<>
 			{ showPageHeader && getEarnSectionNav() }
-			{ isAdSection( section ) && getAdsHeader() }
-			{ getComponent( section ) }
+			<div className="earn-content">
+				{ isAdSection( section ) && getAdsHeader() }
+				{ getComponent( section ) }
+			</div>
 		</>
 	);
 
@@ -262,7 +264,6 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 			/>
 			{ showPageHeader ? (
 				<Page
-					hasPadding
 					showSidebarToggle={ false }
 					title={ <JetpackTitle title={ translate( 'Monetize' ) } /> }
 					subTitle={ translate(

--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -1,11 +1,11 @@
 import { localizeUrl } from '@automattic/i18n-utils';
+import { Page } from '@wordpress/admin-ui';
 import { useTranslate } from 'i18n-calypso';
 import { capitalize, find } from 'lodash';
 import DocumentHead from 'calypso/components/data/document-head';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
-import NavigationHeader from 'calypso/components/navigation-header';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
@@ -241,8 +241,18 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 
 	const atomicLearnMoreLink = localizeUrl( 'https://wordpress.com/support/monetize-your-site/' );
 	const jetpackLearnMoreLink = localizeUrl( 'https://jetpack.com/support/monetize-your-site/' );
+	const showPageHeader = ! isSinglePaidSubscriptionSection( section );
+
+	const content = (
+		<>
+			{ showPageHeader && getEarnSectionNav() }
+			{ isAdSection( section ) && getAdsHeader() }
+			{ getComponent( section ) }
+		</>
+	);
+
 	return (
-		<Main wideLayout className="earn">
+		<Main fullWidthLayout={ showPageHeader } wideLayout={ ! showPageHeader } className="earn">
 			<PageViewTracker
 				path={ section ? `${ earnPath }/${ section }/:site` : `${ earnPath }/:site` }
 				title={ `${ adsProgramName } ${ capitalize( section ) }` }
@@ -250,33 +260,33 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 			<DocumentHead
 				title={ layoutTitles[ section as keyof typeof layoutTitles ] ?? translate( 'Monetize' ) }
 			/>
-			{ ! isSinglePaidSubscriptionSection( section ) && (
-				<>
-					<NavigationHeader
-						navigationItems={ [] }
-						title={ <JetpackTitle title={ translate( 'Monetize' ) } /> }
-						subtitle={ translate(
-							'Explore tools to earn money with your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-							{
-								components: {
-									learnMoreLink: isJetpackCloud() ? (
-										<a
-											href={ isJetpackNotAtomic ? jetpackLearnMoreLink : atomicLearnMoreLink }
-											target="_blank"
-											rel="noopener noreferrer"
-										/>
-									) : (
-										<InlineSupportLink supportContext="earn" showIcon={ false } />
-									),
-								},
-							}
-						) }
-					/>
-					{ getEarnSectionNav() }
-				</>
+			{ showPageHeader ? (
+				<Page
+					hasPadding
+					showSidebarToggle={ false }
+					title={ <JetpackTitle title={ translate( 'Monetize' ) } /> }
+					subTitle={ translate(
+						'Explore tools to earn money with your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						{
+							components: {
+								learnMoreLink: isJetpackCloud() ? (
+									<a
+										href={ isJetpackNotAtomic ? jetpackLearnMoreLink : atomicLearnMoreLink }
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								) : (
+									<InlineSupportLink supportContext="earn" showIcon={ false } />
+								),
+							},
+						}
+					) }
+				>
+					{ content }
+				</Page>
+			) : (
+				content
 			) }
-			{ isAdSection( section ) && getAdsHeader() }
-			{ getComponent( section ) }
 		</Main>
 	);
 };

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -5,17 +5,19 @@
 
 body.is-section-earn {
 	@include admin-ui-page-layout;
+}
 
-	// Override the default 660px max-width — Monetize content needs more room
-	.admin-ui-page__content {
-		> * {
-			max-width: none;
-		}
+.earn-navigation {
+	.section-nav {
+		padding: 0 var(--wpds-dimension-padding-2xl, 24px);
 	}
 }
 
-#earn-navigation {
-	margin-bottom: 30px;
+.earn-content {
+	margin: 0 auto;
+	max-width: 1040px;
+	padding: 24px;
+	width: 100%;
 }
 
 // Small override for card component headers

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -1,6 +1,18 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@automattic/components/src/styles/typography";
 @import "@wordpress/base-styles/mixins";
+@import "calypso/components/jetpack-page-layout/admin-ui-page";
+
+body.is-section-earn {
+	@include admin-ui-page-layout;
+
+	// Override the default 660px max-width — Monetize content needs more room
+	.admin-ui-page__content {
+		> * {
+			max-width: none;
+		}
+	}
+}
 
 #earn-navigation {
 	margin-bottom: 30px;

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -14,6 +14,7 @@ body.is-section-earn {
 }
 
 .earn-content {
+	box-sizing: border-box;
 	margin: 0 auto;
 	max-width: 1040px;
 	padding: 24px;
@@ -244,12 +245,5 @@ body:not(.theme-jetpack-cloud) {
 	max-width: 98%;
 	h1 {
 		margin-bottom: 1em;
-	}
-}
-
-/* Media Queries */
-@media (max-width: $break-large) {
-	.earn.main {
-		padding: 20px;
 	}
 }

--- a/client/my-sites/scan/style.scss
+++ b/client/my-sites/scan/style.scss
@@ -2,6 +2,7 @@
 
 body.is-section-scan {
 	@include admin-ui-page-layout;
+	@include admin-ui-page-layout-constrained-content;
 }
 
 .scan .formatted-header.is-left-align {

--- a/client/my-sites/site-settings/podcasting-details/style.scss
+++ b/client/my-sites/site-settings/podcasting-details/style.scss
@@ -2,6 +2,7 @@
 
 body.is-section-settings-podcasting {
 	@include admin-ui-page-layout;
+	@include admin-ui-page-layout-constrained-content;
 }
 
 .podcasting-details__publish-wrapper {


### PR DESCRIPTION
Part of JETPACK-1361
Depends on #109567

## Proposed Changes

* Migrates the Monetize page (`earn/main.tsx`) from `NavigationHeader` to `@wordpress/admin-ui` `Page` component
* Uses `JetpackTitle` component for the page title
* Page header conditionally hidden on single paid subscription sub-pages (same behavior as before — the sub-page has its own NavigationHeader with breadcrumbs, left unchanged)
* Adds admin-ui-page-layout mixin for the `earn` section
* **Overrides the shared mixin's `660px` max-width** for the earn section content — Monetize pages display cards, payment plans, and settings that need the full available width. The `660px` constraint works for settings-focused pages (Podcasting, Newsletter) but is too narrow for Monetize's content layout.

Follows the pattern established in the Subscribers migration (PR #109520).

Before:
<img width="1242" height="672" alt="image" src="https://github.com/user-attachments/assets/1015c740-51e5-4abd-8947-13b739ee2fd8" />

After:
<img width="1584" height="1299" alt="Screenshot 2026-03-26 at 17 16 54" src="https://github.com/user-attachments/assets/7172a880-8fc2-4c4a-abfc-d69ac0f38ff3" />


## Why are these changes being made?

* Aligning Jetpack pages in Calypso with the `@wordpress/admin-ui` Page component, consistent with the Jetpack monorepo header unification.

## Testing Instructions

* Navigate to `/earn/<site-slug>` — verify header with Jetpack logo + "Monetize" title
* Click through all tabs: Monetization Options, Paid Subscribers, Payment Settings, Ads
* Verify content width is consistent across tabs (should not be constrained to 660px)
* Click into a single paid subscription — verify the Page header disappears and the sub-page renders with its own NavigationHeader + breadcrumbs
* Test at different viewport widths (desktop and mobile)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
