### PR TITLE
MSD OAuth: Support sending users straight to signup for some flows

### DIFF
--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -20,10 +20,12 @@ function getOAuthAuthorizeUrl( {
 	state,
 	next = '',
 	isLogout = false,
+	isNewUser = false,
 }: {
 	state: string;
 	next?: string;
 	isLogout?: boolean;
+	isNewUser?: boolean;
 } ): string {
 	const redirectUri = new URL( OAUTH_CALLBACK_PATH, window.location.origin );
 
@@ -40,6 +42,7 @@ function getOAuthAuthorizeUrl( {
 		blog_id: '0',
 		state,
 		...( isLogout === true ? { implicit: 'false' } : {} ),
+		...( isNewUser === true ? { 'new-user': '1' } : {} ),
 	} ).toString();
 
 	return authUri.toString();
@@ -114,9 +117,14 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 			const state = crypto.randomUUID();
 			sessionStorage.setItem( 'wpcom_oauth_state', state );
 
+			// Default to the signup screen rather than the login screen for certain paths.
+			const newUserPaths = [ '/start-store' ];
+			const isNewUser = newUserPaths.includes( window.location.pathname );
+
 			window.location.replace(
 				getOAuthAuthorizeUrl( {
 					state,
+					isNewUser,
 					next: window.location.pathname + window.location.search,
 				} )
 			);

--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -11,6 +11,7 @@ import {
 	type MutationCacheNotifyEvent,
 } from '@tanstack/react-query';
 import { createContext, useContext, useMemo, useEffect, useRef, useCallback } from 'react';
+import { useAppContext } from '../context';
 import { OAUTH_CALLBACK_PATH } from './oauth-callback';
 import type { WPError } from '@automattic/api-core';
 
@@ -79,6 +80,7 @@ async function initializeCurrentUser(): Promise< User > {
  */
 export function AuthProvider( { children }: { children: React.ReactNode } ) {
 	const authErrorHandled = useRef( false );
+	const { supports } = useAppContext();
 	const queryClient = useQueryClient();
 	const {
 		data: user,
@@ -117,9 +119,9 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 			const state = crypto.randomUUID();
 			sessionStorage.setItem( 'wpcom_oauth_state', state );
 
-			// Default to the signup screen rather than the login screen for certain paths.
-			const newUserPaths = [ '/start-store' ];
-			const isNewUser = newUserPaths.includes( window.location.pathname );
+			// Default to the signup screen rather than the login screen for certain routes.
+			const isNewUser =
+				supports.startStoreRoute === true && window.location.pathname === '/start-store';
 
 			window.location.replace(
 				getOAuthAuthorizeUrl( {

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -53,8 +53,6 @@ export function pathWithLeadingSlash( path ) {
 
 export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, pathname ) {
 	const redirectTo = get( currentQuery, 'redirect_to', '' );
-	const ciabSetupRedirectTo =
-		'/setup/ai-site-builder-spec?source=ciab-sites-dashboard&ref=new-site-popover';
 
 	if (
 		// Match locales like `/log-in/jetpack/es`
@@ -139,23 +137,6 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 			oauth2_redirect: redirectTo,
 		} );
 		return `/start/wpcc?${ oauth2Params.toString() }`;
-	}
-
-	let hasCiabRedirectHost = false;
-	if ( redirectTo ) {
-		try {
-			const redirectToUrl = new URL( redirectTo );
-			hasCiabRedirectHost = [ 'my.woo.ai', 'my.woo.localhost' ].includes( redirectToUrl.hostname );
-		} catch {
-			// no-op
-		}
-	}
-
-	if ( get( currentQuery, 'from' ) === 'woo' || hasCiabRedirectHost ) {
-		const params = new URLSearchParams( {
-			redirect_to: ciabSetupRedirectTo,
-		} );
-		return `/start/account?${ params.toString() }`;
 	}
 
 	const signupFlow = get( currentQuery, 'signup_flow' );

--- a/client/lib/login/test/index.js
+++ b/client/lib/login/test/index.js
@@ -216,45 +216,6 @@ describe( 'getSignupUrl', () => {
 			'/start/account?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Fpublic.api%2Fconnect%2F%3Faction%3Dverify'
 		);
 	} );
-
-	test( 'from=woo uses the CIAB AI setup redirect', () => {
-		expect( getSignupUrl( { from: 'woo' }, '/log-in', null, 'en', '' ) ).toEqual(
-			'/start/account?redirect_to=%2Fsetup%2Fai-site-builder-spec%3Fsource%3Dciab-sites-dashboard%26ref%3Dnew-site-popover'
-		);
-	} );
-
-	test( 'CIAB redirect host in redirect_to uses the CIAB AI setup redirect', () => {
-		expect(
-			getSignupUrl( { redirect_to: 'https://my.woo.ai/sites' }, '/log-in', null, 'en', '' )
-		).toEqual(
-			'/start/account?redirect_to=%2Fsetup%2Fai-site-builder-spec%3Fsource%3Dciab-sites-dashboard%26ref%3Dnew-site-popover'
-		);
-	} );
-
-	test( 'non-CIAB from keeps existing behavior', () => {
-		expect( getSignupUrl( { from: 'reader' }, '/log-in', null, 'en', '' ) ).toEqual( '/start' );
-	} );
-
-	test( 'generic OAuth2 client keeps existing behavior in CIAB context', () => {
-		const oauth2Client = {
-			id: 123,
-			name: 'example',
-			title: 'Example',
-			url: 'https://example.com',
-		};
-
-		expect(
-			getSignupUrl(
-				{ from: 'woo', redirect_to: 'https://example.com/oauth' },
-				'/log-in',
-				oauth2Client,
-				'en',
-				''
-			)
-		).toEqual(
-			'/start/wpcc?oauth2_client_id=123&oauth2_redirect=https%3A%2F%2Fexample.com%2Foauth'
-		);
-	} );
 } );
 
 describe( 'getPluginTitle', () => {


### PR DESCRIPTION
DOTMSD-1176

For `/start-store` we want to assume it's a new user experience. So rather than landing them on the log-in page (friction from the start while trying to create an account), this passes `new-user=1` to the OAuth flow which will default to the sign up page instead.

## Testing

Visit `http://my.woo.localhost:3000/start-store` while logged out (incognito)