### PR TITLE
Activity Log v1 & v2: Migrate headers to admin-ui Page

### DIFF
--- a/client/my-sites/activity/activity-log-v2/index.tsx
+++ b/client/my-sites/activity/activity-log-v2/index.tsx
@@ -1,5 +1,6 @@
 import { WPCOM_FEATURES_FULL_ACTIVITY_LOG } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
+import { Page } from '@wordpress/admin-ui';
 import { Tooltip } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -10,8 +11,8 @@ import QuerySiteCredentials from 'calypso/components/data/query-site-credentials
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import Upsell from 'calypso/components/jetpack/upsell';
+import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
-import NavigationHeader from 'calypso/components/navigation-header';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import useActivityLogQuery from 'calypso/data/activity-log/use-activity-log-query';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
@@ -115,12 +116,26 @@ const ActivityLogV2: FunctionComponent = () => {
 		/>
 	);
 
+	const isWpcom = ! ( ( isJetpackCloud() || isA8CForAgencies() ) && ! isWPCOMSite );
+
+	const content = (
+		<div className="activity-log-v2__content">
+			<ActivityCardList
+				logs={ logs }
+				pageSize={ 10 }
+				showFilter={ siteHasFullActivityLog }
+				siteId={ siteId }
+			/>
+		</div>
+	);
+
 	return (
 		<Main
 			className={ clsx( 'activity-log-v2', {
-				wordpressdotcom: ! ( isJetpackCloud() || isA8CForAgencies() ),
+				wordpressdotcom: isWpcom,
 			} ) }
-			wideLayout={ ! isA8CForAgencies() }
+			fullWidthLayout={ isWpcom }
+			wideLayout={ ! isWpcom && ! isA8CForAgencies() }
 		>
 			{ siteId && <QuerySitePlans siteId={ siteId } /> }
 			{ siteId && <QuerySitePurchases siteId={ siteId } /> }
@@ -129,24 +144,23 @@ const ActivityLogV2: FunctionComponent = () => {
 			{ isJetpackCloud() && <SidebarNavigation /> }
 			<PageViewTracker path="/activity-log/:site" title="Activity Log" />
 			{ settingsUrl && <TimeMismatchWarning siteId={ siteId } settingsUrl={ settingsUrl } /> }
-			{ ( isJetpackCloud() || isA8CForAgencies() ) && ! isWPCOMSite ? (
-				jetpackCloudHeader
-			) : (
-				<NavigationHeader
-					title={ translate( 'Activity' ) }
-					subtitle={ translate(
+			{ isWpcom ? (
+				<Page
+					hasPadding
+					showSidebarToggle={ false }
+					title={ <JetpackTitle title={ translate( 'Activity' ) } /> }
+					subTitle={ translate(
 						'This is the complete event history for your site. Filter by date range and/or activity type.'
 					) }
-				/>
+				>
+					{ content }
+				</Page>
+			) : (
+				<>
+					{ jetpackCloudHeader }
+					{ content }
+				</>
 			) }
-			<div className="activity-log-v2__content">
-				<ActivityCardList
-					logs={ logs }
-					pageSize={ 10 }
-					showFilter={ siteHasFullActivityLog }
-					siteId={ siteId }
-				/>
-			</div>
 		</Main>
 	);
 };

--- a/client/my-sites/activity/activity-log-v2/style.scss
+++ b/client/my-sites/activity/activity-log-v2/style.scss
@@ -1,3 +1,16 @@
+@import "calypso/components/jetpack-page-layout/admin-ui-page";
+
+body.is-section-activity {
+	@include admin-ui-page-layout;
+
+	// Override max-width — Activity Log content needs full width
+	.admin-ui-page__content {
+		> * {
+			max-width: none;
+		}
+	}
+}
+
 main.activity-log-v2 {
 	&:not(.wordpressdotcom) {
 		.activity-log-v2__header {

--- a/client/my-sites/activity/activity-log-v2/style.scss
+++ b/client/my-sites/activity/activity-log-v2/style.scss
@@ -2,13 +2,7 @@
 
 body.is-section-activity {
 	@include admin-ui-page-layout;
-
-	// Override max-width — Activity Log content needs full width
-	.admin-ui-page__content {
-		> * {
-			max-width: none;
-		}
-	}
+	@include admin-ui-page-layout-constrained-content;
 }
 
 main.activity-log-v2 {

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -4,6 +4,7 @@ import { siteByIdQuery, stagingSiteSyncStateQuery } from '@automattic/api-querie
 import { WPCOM_FEATURES_FULL_ACTIVITY_LOG } from '@automattic/calypso-products';
 import { isMobile } from '@automattic/viewport';
 import { useQuery } from '@tanstack/react-query';
+import { Page } from '@wordpress/admin-ui';
 import { localize } from 'i18n-calypso';
 import { get, isEmpty, isEqual } from 'lodash';
 import PropTypes from 'prop-types';
@@ -25,7 +26,6 @@ import JetpackColophon from 'calypso/components/jetpack-colophon';
 import JetpackTitle from 'calypso/components/jetpack-title';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
-import NavigationHeader from 'calypso/components/navigation-header';
 import Pagination from 'calypso/components/pagination';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import { getProductionSiteId } from 'calypso/dashboard/utils/site-staging-site';
@@ -488,83 +488,84 @@ class ActivityLog extends Component {
 
 				{ isJetpackCloud() && <SidebarNavigation /> }
 
-				<NavigationHeader
-					navigationItems={ [] }
+				<Page
+					hasPadding
+					showSidebarToggle={ false }
 					title={ <JetpackTitle title={ translate( 'Activity Log' ) } /> }
-					subtitle={ translate(
+					subTitle={ translate(
 						"Keep tabs on all your site's activity — plugin and theme updates, user logins, setting modifications, and more."
 					) }
-				/>
-
-				{ siteId && isJetpack && ! isAtomic && <RewindAlerts siteId={ siteId } /> }
-				{ siteId && 'unavailable' === rewindState.state && (
-					<RewindUnavailabilityNotice siteId={ siteId } />
-				) }
-				{ ! hasFullActivityLog && ! isMultisite && <UpgradeBanner siteId={ siteId } /> }
-				{ siteId && isJetpack && <ActivityLogTasklist siteId={ siteId } /> }
-				{ this.renderErrorMessage() }
-				{ this.renderActionProgress() }
-				{ this.renderFilterbar() }
-				{ isEmpty( logs ) ? (
-					this.renderNoLogsContent()
-				) : (
-					<div>
-						<Pagination
-							compact={ isMobile() }
-							className="activity-log__pagination is-top-pagination"
-							key="activity-list-pagination-top"
-							nextLabel={ translate( 'Older' ) }
-							page={ actualPage }
-							pageClick={ this.changePage }
-							perPage={ PAGE_SIZE }
-							prevLabel={ translate( 'Newer' ) }
-							total={ logs.length }
-						/>
-						<section className="activity-log__wrapper">
-							{ ! hasFullActivityLog && <div className="activity-log__fader" /> }
-							{ theseLogs.map( ( log ) =>
-								log.isAggregate ? (
-									<Fragment key={ log.activityId }>
-										{ timePeriod( log ) }
-										<ActivityLogAggregatedItem
-											key={ log.activityId }
-											activity={ log }
-											disableRestore={ disableRestore }
-											disableBackup={ disableBackup }
-											siteId={ siteId }
-											rewindState={ rewindState.state }
-										/>
-									</Fragment>
-								) : (
-									<Fragment key={ log.activityId }>
-										{ timePeriod( log ) }
-										<ActivityLogItem
-											key={ log.activityId }
-											activity={ log }
-											disableRestore={ disableRestore }
-											disableBackup={ disableBackup }
-											siteId={ siteId }
-										/>
-									</Fragment>
-								)
+				>
+					{ siteId && isJetpack && ! isAtomic && <RewindAlerts siteId={ siteId } /> }
+					{ siteId && 'unavailable' === rewindState.state && (
+						<RewindUnavailabilityNotice siteId={ siteId } />
+					) }
+					{ ! hasFullActivityLog && ! isMultisite && <UpgradeBanner siteId={ siteId } /> }
+					{ siteId && isJetpack && <ActivityLogTasklist siteId={ siteId } /> }
+					{ this.renderErrorMessage() }
+					{ this.renderActionProgress() }
+					{ this.renderFilterbar() }
+					{ isEmpty( logs ) ? (
+						this.renderNoLogsContent()
+					) : (
+						<div>
+							<Pagination
+								compact={ isMobile() }
+								className="activity-log__pagination is-top-pagination"
+								key="activity-list-pagination-top"
+								nextLabel={ translate( 'Older' ) }
+								page={ actualPage }
+								pageClick={ this.changePage }
+								perPage={ PAGE_SIZE }
+								prevLabel={ translate( 'Newer' ) }
+								total={ logs.length }
+							/>
+							<section className="activity-log__wrapper">
+								{ ! hasFullActivityLog && <div className="activity-log__fader" /> }
+								{ theseLogs.map( ( log ) =>
+									log.isAggregate ? (
+										<Fragment key={ log.activityId }>
+											{ timePeriod( log ) }
+											<ActivityLogAggregatedItem
+												key={ log.activityId }
+												activity={ log }
+												disableRestore={ disableRestore }
+												disableBackup={ disableBackup }
+												siteId={ siteId }
+												rewindState={ rewindState.state }
+											/>
+										</Fragment>
+									) : (
+										<Fragment key={ log.activityId }>
+											{ timePeriod( log ) }
+											<ActivityLogItem
+												key={ log.activityId }
+												activity={ log }
+												disableRestore={ disableRestore }
+												disableBackup={ disableBackup }
+												siteId={ siteId }
+											/>
+										</Fragment>
+									)
+								) }
+							</section>
+							{ showVisibleDaysLimitUpsell && (
+								<VisibleDaysLimitUpsell cardClassName="activity-log-item__card" />
 							) }
-						</section>
-						{ showVisibleDaysLimitUpsell && (
-							<VisibleDaysLimitUpsell cardClassName="activity-log-item__card" />
-						) }
-						<Pagination
-							compact={ isMobile() }
-							className="activity-log__pagination is-bottom-pagination"
-							key="activity-list-pagination-bottom"
-							nextLabel={ translate( 'Older' ) }
-							page={ actualPage }
-							pageClick={ this.changePage }
-							perPage={ PAGE_SIZE }
-							prevLabel={ translate( 'Newer' ) }
-							total={ logs.length }
-						/>
-					</div>
-				) }
+							<Pagination
+								compact={ isMobile() }
+								className="activity-log__pagination is-bottom-pagination"
+								key="activity-list-pagination-bottom"
+								nextLabel={ translate( 'Older' ) }
+								page={ actualPage }
+								pageClick={ this.changePage }
+								perPage={ PAGE_SIZE }
+								prevLabel={ translate( 'Newer' ) }
+								total={ logs.length }
+							/>
+						</div>
+					) }
+				</Page>
 			</>
 		);
 	}
@@ -601,7 +602,7 @@ class ActivityLog extends Component {
 			'vp_can_transfer' === rewindState.reason;
 
 		return (
-			<Main wideLayout>
+			<Main fullWidthLayout>
 				<QuerySiteFeatures siteIds={ [ siteId ] } />
 				<PageViewTracker path="/activity-log/:site" title="Activity" />
 				<DocumentHead title={ translate( 'Activity' ) } />


### PR DESCRIPTION
Part of JETPACK-1364
Depends on #109567

## Proposed Changes

* Migrates **Activity Log v2** (`activity-log-v2/index.tsx`) from `NavigationHeader` to `@wordpress/admin-ui` `Page` component
  - Env-conditional: Page renders on WP.com; JPC/A4A keeps its custom div header unchanged
  - Adds `JetpackTitle` component (was missing from v2)
  - Note: v2 is behind the `activity-log/v2` feature flag (only enabled on Jetpack Cloud)

* Migrates **Activity Log v1** (`activity-log/index.jsx`) from `NavigationHeader` to `Page`
  - Class component with `connect()` + `localize()` + `withLocalizedMoment()`
  - Page wraps all content inside `getActivityLog()` method
  - Query components and SidebarNavigation remain outside Page

* Adds admin-ui-page-layout mixin for the `activity` section with `max-width: none` override (Activity Log content needs full width)

Follows the pattern established in the Subscribers migration (PR #109520).

Before:
<img width="1245" height="723" alt="image" src="https://github.com/user-attachments/assets/9cc07b9e-6569-493e-a8e8-bd1d7efcf58b" />

After:
<img width="1244" height="647" alt="image" src="https://github.com/user-attachments/assets/baf4d8fd-7a93-4244-848e-4a4ae83cfec5" />


## Why are these changes being made?

* Aligning Jetpack pages in Calypso with the `@wordpress/admin-ui` Page component, consistent with the Jetpack monorepo header unification.

## Testing Instructions

### Activity Log v1 (default on WP.com)
* Navigate to `/activity-log/<site-slug>`
* Verify the Jetpack logo appears next to "Activity Log" in the header
* Verify subtitle displays correctly
* Verify activity items, pagination, filterbar all render properly
* Test at different viewport widths

### Activity Log v2 (Jetpack Cloud only, or enable locally)
* To test on WP.com: add `"activity-log/v2": true` to `config/development.json`
* Navigate to `/activity-log/<site-slug>`
* Verify the admin-ui Page header renders on WP.com
* Verify JPC/A4A still shows the custom div header (not Page)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
