### PR TITLE
Docker Image: Add cache-seed key computation and staleness detection to builds

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -125,6 +125,9 @@ object BuildDockerImage : BuildType({
 			checked = "true",
 			unchecked = "false"
 		)
+		param("CACHE_SEED_KEY", "")
+		param("UPDATE_CACHE_SEED", "false")
+		param("GENERATE_CACHE_IMAGE", "false")
 		param("env.WEBPACK_CACHE_INVALIDATED", "false")
 	}
 
@@ -203,6 +206,52 @@ object BuildDockerImage : BuildType({
 			dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
 		}
 
+		script {
+			name = "Resolve cache-seed state"
+			scriptContent = """
+				#!/usr/bin/env bash
+				set -euo pipefail
+
+				cache_seed_key=$(bash ./bin/print-cache-seed-key.sh)
+				echo "Computed cache-seed key: ${'$'}cache_seed_key"
+				echo "##teamcity[setParameter name='CACHE_SEED_KEY' value='${'$'}cache_seed_key']"
+
+				update_cache_seed=false
+				generate_cache_image=false
+
+				if [[ "%cache_mode%" == "seed" && "%teamcity.build.branch.is_default%" == "true" ]]; then
+					docker pull "%cache_seed_image%" >/dev/null 2>&1 || true
+
+					existing_cache_seed_key=$(
+						docker image inspect "%cache_seed_image%" \
+							--format '{{with index .Config.Labels "io.calypso.cache-seed-key"}}{{.}}{{end}}' \
+							2>/dev/null || true
+					)
+
+					echo "Existing cache-seed key: ${'$'}{existing_cache_seed_key:-<missing>}"
+
+					if [[ -z "${'$'}existing_cache_seed_key" || "${'$'}existing_cache_seed_key" != "${'$'}cache_seed_key" ]]; then
+						echo "Cache-seed image is stale or unlabeled; enabling inline cache regeneration."
+						update_cache_seed=true
+						generate_cache_image=true
+					else
+						echo "Cache-seed image is current."
+					fi
+				elif [[ "%cache_mode%" == "base" && "%UPDATE_BASE_IMAGE_CACHE%" == "true" ]]; then
+					echo "Base mode selected with UPDATE_BASE_IMAGE_CACHE=true; enabling writable cache."
+					generate_cache_image=true
+				else
+					echo "No inline cache refresh required for this build."
+				fi
+
+				echo "UPDATE_CACHE_SEED=${'$'}update_cache_seed"
+				echo "GENERATE_CACHE_IMAGE=${'$'}generate_cache_image"
+
+				echo "##teamcity[setParameter name='UPDATE_CACHE_SEED' value='${'$'}update_cache_seed']"
+				echo "##teamcity[setParameter name='GENERATE_CACHE_IMAGE' value='${'$'}generate_cache_image']"
+			""".trimIndent()
+		}
+
 		val commonArgs = """
 			--label com.a8c.image-builder=teamcity
 			--label com.a8c.build-id=%teamcity.build.id%
@@ -216,7 +265,7 @@ object BuildDockerImage : BuildType({
 			--build-arg manual_sentry_release=%MANUAL_SENTRY_RELEASE%
 			--build-arg is_default_branch=%teamcity.build.branch.is_default%
 			--build-arg sentry_auth_token=%SENTRY_AUTH_TOKEN%
-			--build-arg generate_cache_image=%UPDATE_BASE_IMAGE_CACHE%
+			--build-arg generate_cache_image=%GENERATE_CACHE_IMAGE%
 		""".trimIndent().replace("\n"," ")
 
 		dockerCommand {

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -468,6 +468,7 @@ object BuildCacheSeedImages : BuildType({
 	params {
 		param("build.prefix", "1.0")
 		param("image_tag", "latest")
+		param("CACHE_SEED_KEY", "")
 		checkbox(
 			name = "PROFILE",
 			value = "false",
@@ -484,7 +485,19 @@ object BuildCacheSeedImages : BuildType({
 	}
 
 	steps {
-		val commonArgs = "--pull --build-arg workers=32 --build-arg node_memory=16384 --build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber} --build-arg profile=%PROFILE%"
+		script {
+			name = "Compute cache-seed key"
+			scriptContent = """
+				#!/usr/bin/env bash
+				set -euo pipefail
+
+				cache_seed_key=$(bash ./bin/print-cache-seed-key.sh)
+				echo "Computed cache-seed key: ${'$'}cache_seed_key"
+				echo "##teamcity[setParameter name='CACHE_SEED_KEY' value='${'$'}cache_seed_key']"
+			""".trimIndent()
+		}
+
+		val commonArgs = "--pull --build-arg workers=32 --build-arg node_memory=16384 --build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber} --build-arg profile=%PROFILE% --build-arg cache_seed_key=%CACHE_SEED_KEY%"
 
 		dockerCommand {
 			name = "Build cache-seed image"
@@ -585,6 +598,7 @@ object BuildCacheSeedPreviewImage : BuildType({
 
 	params {
 		param("build.prefix", "preview")
+		param("CACHE_SEED_KEY", "")
 		checkbox(
 			name = "PROFILE",
 			value = "false",
@@ -601,7 +615,19 @@ object BuildCacheSeedPreviewImage : BuildType({
 	}
 
 	steps {
-		val commonArgs = "--pull --build-arg workers=32 --build-arg node_memory=16384 --build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber} --build-arg profile=%PROFILE%"
+		script {
+			name = "Compute cache-seed key"
+			scriptContent = """
+				#!/usr/bin/env bash
+				set -euo pipefail
+
+				cache_seed_key=$(bash ./bin/print-cache-seed-key.sh)
+				echo "Computed cache-seed key: ${'$'}cache_seed_key"
+				echo "##teamcity[setParameter name='CACHE_SEED_KEY' value='${'$'}cache_seed_key']"
+			""".trimIndent()
+		}
+
+		val commonArgs = "--pull --build-arg workers=32 --build-arg node_memory=16384 --build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber} --build-arg profile=%PROFILE% --build-arg cache_seed_key=%CACHE_SEED_KEY%"
 
 		dockerCommand {
 			name = "Build cache-seed preview image"

--- a/bin/print-cache-seed-key.sh
+++ b/bin/print-cache-seed-key.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+hash_cmd() {
+	if command -v sha256sum >/dev/null 2>&1; then
+		sha256sum | awk '{ print $1 }'
+	elif command -v shasum >/dev/null 2>&1; then
+		shasum -a 256 | awk '{ print $1 }'
+	else
+		echo "Neither sha256sum nor shasum is available." >&2
+		exit 1
+	fi
+}
+
+# This key is intentionally build-system centric, not source centric.
+# Changing regular application code should not force a cache-seed refresh.
+paths=(
+	.nvmrc
+	.dockerignore
+	.yarnrc.yml
+	package.json
+	yarn.lock
+	env-config.sh
+	Dockerfile
+	Dockerfile.cache-seed
+	babel.config.js
+	bin/postinstall.sh
+	bin/build-packages-web.sh
+	bin/build-languages.js
+	client/webpack.config.js
+	client/webpack.config.node.js
+	client/webpack.common.js
+	client/server/config
+	build-tools/babel/babel-loader-cache-identifier/index.js
+	build-tools/webpack
+	.yarn/patches
+	.yarn/releases
+	# Workspace manifests copied into the deps stage
+	":(glob)apps/*/package.json"
+	":(glob)packages/*/package.json"
+	client/package.json
+	desktop/package.json
+	test/e2e/package.json
+	# Build-tool / prebuild workspaces that materially affect cache usefulness
+	packages/calypso-build
+	packages/calypso-babel-config
+	packages/babel-plugin-i18n-calypso
+	packages/wp-babel-makepot
+	packages/calypso-color-schemes
+	packages/create-calypso-config
+	packages/languages
+)
+
+{
+	printf 'cache-seed-key:v1\0'
+
+	git ls-files -- "${paths[@]}" \
+		| LC_ALL=C sort \
+		| while IFS= read -r file; do
+			[ -f "$file" ] || continue
+			printf '%s\0' "$file"
+			cat "$file"
+			printf '\0'
+		done
+} | hash_cmd | cut -c1-20


### PR DESCRIPTION
This adds a system that lets the "Docker Image" build determine if it's out of date. The previous system, which has been disabled for years, grepped for output from the build file and could only know if it failed *after* the build runs.  It used `if grep "resolving of build dependencies is invalid" $build_file ; then`.  Instead, we're using a shell script to hash a bunch of files to figure out *before* a build runs, if the webpack cache is out of date.


The moving parts:
* `bin/print-cache-seed-key.sh` - hashes a bunch of build related files into a single key.
* Cache-seed build jobs now add the key as a Docker label (`io.calypso.cache-seed-key`) to published images.
* `BuildDockerImage` now computes the key before the Docker build, looks at the current seed image's label, and sets `GENERATE_CACHE_IMAGE=true` when they differ. This will let build run with a writable cache so the work isn't wasted.

Note that we're not actually pushing the updated seed image from the app build, yet. That can be a followup if this works. 

## Proposed Changes

*

## Why are these changes being made?


* Previously there was no way to know whether the seed image was still useful for the current state of the repo. The old base-image path relied on a 6-hour schedule, which can be both wasteful and too late. Instead, if we can figure out right when the cache went stale, we can run one "slow" build and immediately refresh it.

## Testing Instructions

* Run `bin/print-cache-seed-key.sh` locally and confirm it produces a stable 20-character hex key
* Change a file in the key (like `babel.config.js`) and confirm the key changes
* Change an app source file and confirm the key doesn't change
* Trigger a trunk app build and check the "Resolve cache-seed state" step output: it should log both keys and whether the seed is current or stale
* Trigger a cache-seed build and confirm the published image has the `io.calypso.cache-seed-key` label (via `docker inspect`)
* Use maven to validate the teamcity config

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
