### PR TITLE
Docker Image: Publish refreshed cache-seed images inline from trunk app builds

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -260,6 +260,7 @@ object BuildDockerImage : BuildType({
 			--build-arg cache_mode=%cache_mode%
 			--build-arg base_image=%base_image%
 			--build-arg cache_seed_image=%cache_seed_image%
+			--build-arg cache_seed_key=%CACHE_SEED_KEY%
 			--build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber}
 			--build-arg profile=%PROFILE%
 			--build-arg manual_sentry_release=%MANUAL_SENTRY_RELEASE%
@@ -337,10 +338,9 @@ object BuildDockerImage : BuildType({
 			""".trimIndent()
 		}
 
-		// TODO: Cache rebuilding is currently disabled. It takes a long time and
-		// causes timeouts on trunk. It needs to run more quickly to be worth it.
-		// For now, the cache will be rebuilt a couple times a day by the dedicated
-		// cache build.
+		// Base-image cache rebuilding remains disabled by default because it is slow
+		// enough to risk trunk timeouts. Seed-mode inline refresh is handled below,
+		// while the base flow stays available as a manual fallback.
 
 		// Conditions don't seem to support and/or, so we do this in a separate step.
 		// Essentially, UPDATE_BASE_IMAGE_CACHE will remain false by default, but
@@ -395,10 +395,49 @@ object BuildDockerImage : BuildType({
 				namesAndTags = "registry.a8c.com/calypso/base:%base_image_publish_tag%"
 			}
 		}
+
+		dockerCommand {
+			name = "Rebuild cache-seed image"
+			conditions {
+				equals("cache_mode", "seed")
+				equals("UPDATE_CACHE_SEED", "true")
+				equals("teamcity.build.branch.is_default", "true")
+			}
+			commandType = build {
+				source = file {
+					path = "Dockerfile"
+				}
+				namesAndTags = """
+					registry.a8c.com/calypso/cache-seed:latest
+					registry.a8c.com/calypso/cache-seed:build-%build.number%
+				""".trimIndent()
+				commandArgs = """
+					--target update-cache-seed
+					--cache-from=registry.a8c.com/calypso/app:commit-${Settings.WpCalypso.paramRefs.buildVcsNumber},%cache_seed_image%
+					$commonArgs
+				""".trimIndent().replace("\n"," ")
+			}
+			param("dockerImage.platform", "linux")
+		}
+
+		dockerCommand {
+			name = "Push cache-seed image"
+			conditions {
+				equals("cache_mode", "seed")
+				equals("UPDATE_CACHE_SEED", "true")
+				equals("teamcity.build.branch.is_default", "true")
+			}
+			commandType = push {
+				namesAndTags = """
+					registry.a8c.com/calypso/cache-seed:latest
+					registry.a8c.com/calypso/cache-seed:build-%build.number%
+				""".trimIndent()
+			}
+		}
 	}
 
 	failureConditions {
-		executionTimeoutMin = 20
+		executionTimeoutMin = 26
 	}
 
 	features {

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ARG cache_mode=base
 ARG node_version=22.9.0
 ARG base_image=registry.a8c.com/calypso/base:latest
 ARG cache_seed_image=registry.a8c.com/calypso/cache-seed:latest
+ARG cache_seed_key="(unknown)"
 
 ###################
 FROM node:${node_version}-bullseye-slim AS builder-cache-none
@@ -149,6 +150,18 @@ FROM ${base_image} AS update-base-cache
 # We only copy this part of the cache to make --push faster, and because webpack
 # is the main thing which will impact build performance when the cache invalidates.
 COPY --from=builder /calypso/.cache/evergreen/webpack /calypso/.cache/evergreen/webpack
+
+###################
+# A cache-only update can be generated with "docker build --target update-cache-seed"
+FROM scratch AS update-cache-seed
+ARG commit_sha
+ARG cache_seed_key
+
+LABEL org.opencontainers.image.revision=$commit_sha \
+	io.calypso.cache-seed-key=$cache_seed_key
+
+COPY --from=builder /calypso/.cache /calypso/.cache
+COPY --from=builder /calypso/.yarn /calypso/.yarn
 
 ###################
 FROM node:${node_version}-alpine AS app


### PR DESCRIPTION
## Proposed Changes

Followup to #109585. When a trunk build runs and the cache seed key has changed, it's forced to not use the webpack cache and make a new one. In the PR, when it's made, we now directly publish the updated cache-seed image from the trunk build. This means we won't be reliant on the 6 hour cron to build a refreshed webpack cache, but as soon as it goes stale, we make a new one.

Adds:
- `update-cache-seed` target in the Dockerfile: This is an image that only copies `.cache` and `.yarn` from the builder, and attaches the current `cache-seed-key` label.
- TeamCity steps to build and push the seed image after a successful trunk app build, gated on `UPDATE_CACHE_SEED=true`, `cache_mode=seed`, and default branch.




## Why are these changes being made?

* The dedicated `BuildCacheSeedImages` job starts cold and takes ~23 minutes because it re-runs `yarn install` and `build-client` from scratch. This inline path reuses the layers the app build already produced, so the seed refresh cost is just the image assembly and push. (Plus the cost of turning off readonly webpack cache).

## Testing Instructions


* Trigger a build where the cache key has changed (for example yarn up -R caniuse-lite). Look for:
  * "Resolve cache-seed state" discovers there is a cache key mismatch
  * "Rebuild cache-seed image" runs and finishes quickly (it should reuse the work already done)
  * "Push cache-seed image" pushes both `latest` and `build-N` tags
  * `docker inspect registry.a8c.com/calypso/cache-seed:latest` shows the
    updated `io.calypso.cache-seed-key` label
* On builds where the cache key doesn't change, the steps above should be skipped
* Branch builds should always skip these steps

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
