### PR TITLE
Switch CSS chunk filenames from contenthash to chunkhash

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -192,8 +192,11 @@ if ( isDevelopment ) {
 	outputChunkFilename = '[name].js';
 }
 
-const cssFilename = cssNameFromFilename( outputFilename );
-const cssChunkFilename = cssNameFromFilename( outputChunkFilename );
+const cssFilename = cssNameFromFilename( outputFilename ).replace( '[contenthash]', '[chunkhash]' );
+const cssChunkFilename = cssNameFromFilename( outputChunkFilename ).replace(
+	'[contenthash]',
+	'[chunkhash]'
+);
 
 const outputDir = path.resolve( '.' );
 


### PR DESCRIPTION
Part of #

## Proposed Changes

* Changes the CSS output filename hashing from `[contenthash]` to `[chunkhash]` for both `cssFilename` and `cssChunkFilename` in the webpack config.


## Why are these changes being made?

* We're seeing intermittent white screens caused by CSS chunks failing to load. We think the root cause might be that webpack's persistent filesystem cache can have a stale contenthash value when we add or remove imports. When this happens, the `miniCssF` function returns undefined for the chunk, and the CSS file never loads.  It might also be a bug in the old version of the mini CSS extract plugin we have.

The tradeoff is that CSS URLs change when JS in the same chunk changes, even if the CSS didn't. That means slightly worse performance because browser caches don't last as long. That's worth it because it's better than random white screens.

See also p1774444429064819-slack-CRWCHQGUB

The long term plan is to do more investigation, fix the underlying bug, and switch back to contenthash. But this should be a short term mitigation.

## Testing Instructions


*

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?