### PR TITLE
MSD Sidebar: Reduce back arrow icon size

### DIFF
--- a/client/dashboard/components/sidebar/sidebar-back-button.tsx
+++ b/client/dashboard/components/sidebar/sidebar-back-button.tsx
@@ -10,6 +10,7 @@ export function SidebarBackButton( { to, children }: { to: string; children: Rea
 			<RouterLinkButton
 				className="dashboard-sidebar__back-button"
 				icon={ arrowLeft }
+				iconSize={ 18 }
 				size="small"
 				to={ to }
 			>


### PR DESCRIPTION
## Proposed Changes

* Reduce the sidebar back arrow icon from the default 24px to 18px by adding `iconSize={ 18 }` to the `RouterLinkButton` in the `SidebarBackButton` component.

I couldn't find the exact design to reference but this looks closer.

| Before | After |
|--------|--------|
| <img width="270" height="381" alt="Screenshot 2026-03-26 at 1 52 01 PM" src="https://github.com/user-attachments/assets/b850421d-3716-480f-b1be-e07f81794e2a" /> | <img width="263" height="282" alt="Screenshot 2026-03-26 at 1 51 35 PM" src="https://github.com/user-attachments/assets/9ca9b536-70e6-4ddc-aa28-25867d766a36" /> | 


## Why are these changes being made?

* The back arrow icon in the dashboard sidebar was visually too large relative to the surrounding UI elements. This reduces it for better visual proportion.

## Testing Instructions

* Navigate to a site detail page in the Dashboard (e.g., `/sites/<site-slug>`) and observe the "Back to Sites" button in the sidebar.
* Navigate to a domain detail page and observe the "Back to Domains" button.
* Confirm the arrow icon appears smaller and visually balanced.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)