### PR TITLE
MSD: SSR omnibar user profile from bootstrapped data

### DIFF
--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -51,7 +51,7 @@ interface AuthContextType {
 }
 export const AuthContext = createContext< AuthContextType | undefined >( undefined );
 
-async function initializeCurrentUser(): Promise< User > {
+export async function initializeCurrentUser(): Promise< User > {
 	// In support user session the `currentUser` refers to the wrong person so we should request
 	// the user object. Note we do not check `isSupportNextSession()` because in "next" support
 	// sessions the server does bootstrap the correct `currentUser`.

--- a/client/dashboard/app/interim-omnibar/index.tsx
+++ b/client/dashboard/app/interim-omnibar/index.tsx
@@ -28,18 +28,21 @@ export default async function loadOmnibar( events: OmnibarEvents ) {
 		events.linkClick.emit( { href, event } );
 	} );
 
+	// When wpcom-user-bootstrap is enabled, the user is already in window.currentUser —
+	// use it directly to avoid a redundant API fetch. Otherwise, fetch from the API.
+	const ssrUser = window.currentUser ?? null;
+
 	const [ { InterimOmnibar }, user ] = await Promise.all( [
 		import( './interim-omnibar' ),
-		queryClient.fetchQuery( { queryKey: AUTH_QUERY_KEY, queryFn: fetchUser } ),
+		ssrUser ?? queryClient.fetchQuery( { queryKey: AUTH_QUERY_KEY, queryFn: fetchUser } ),
 	] );
 
-	// Hydrate the server-rendered omnibar with null props to match SSR output,
-	// then immediately re-render with real data.  Suppress recoverable hydration
-	// errors caused by Suspense boundaries inside MasterbarLoggedIn that
-	// renderToString cannot serialize (see logged-in.jsx for the proper fix).
+	// Hydrate matching the SSR output: user when bootstrapped, null when not.
+	// Suppress recoverable hydration errors caused by Suspense boundaries inside
+	// MasterbarLoggedIn that renderToString cannot serialize.
 	const root = hydrateRoot(
 		container,
-		<InterimOmnibar user={ null } site={ null } currentRoute={ window.location.pathname } />,
+		<InterimOmnibar user={ ssrUser } site={ null } currentRoute={ window.location.pathname } />,
 		{ onRecoverableError() {} }
 	);
 

--- a/client/dashboard/app/interim-omnibar/index.tsx
+++ b/client/dashboard/app/interim-omnibar/index.tsx
@@ -1,7 +1,6 @@
-import { fetchUser } from '@automattic/api-core';
 import { queryClient, siteByIdQuery } from '@automattic/api-queries';
 import { hydrateRoot } from 'react-dom/client';
-import { AUTH_QUERY_KEY } from '../auth';
+import { AUTH_QUERY_KEY, initializeCurrentUser } from '../auth';
 import type { OmnibarEvents } from './click-handlers';
 
 export default async function loadOmnibar( events: OmnibarEvents ) {
@@ -28,13 +27,9 @@ export default async function loadOmnibar( events: OmnibarEvents ) {
 		events.linkClick.emit( { href, event } );
 	} );
 
-	// When wpcom-user-bootstrap is enabled, the user is already in window.currentUser —
-	// use it directly to avoid a redundant API fetch. Otherwise, fetch from the API.
-	const ssrUser = window.currentUser ?? null;
-
 	const [ { InterimOmnibar }, user ] = await Promise.all( [
 		import( './interim-omnibar' ),
-		ssrUser ?? queryClient.fetchQuery( { queryKey: AUTH_QUERY_KEY, queryFn: fetchUser } ),
+		queryClient.fetchQuery( { queryKey: AUTH_QUERY_KEY, queryFn: initializeCurrentUser } ),
 	] );
 
 	// Hydrate matching the SSR output: user when bootstrapped, null when not.
@@ -42,7 +37,12 @@ export default async function loadOmnibar( events: OmnibarEvents ) {
 	// MasterbarLoggedIn that renderToString cannot serialize.
 	const root = hydrateRoot(
 		container,
-		<InterimOmnibar user={ ssrUser } site={ null } currentRoute={ window.location.pathname } />,
+		<InterimOmnibar
+			user={ window.currentUser ?? null }
+			site={ null }
+			currentRoute={ window.location.pathname }
+		/>,
+
 		{ onRecoverableError() {} }
 	);
 

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -166,7 +166,11 @@ class Document extends Component {
 					{ /* eslint-disable wpcalypso/jsx-classname-namespace, react/no-danger */ }
 					{ dashboard && config.isEnabled( 'dashboard/omnibar' ) && (
 						<div id="wpcom-omnibar">
-							<InterimOmnibar user={ null } site={ null } currentRoute={ this.props.path ?? '/' } />
+							<InterimOmnibar
+								user={ user || null }
+								site={ null }
+								currentRoute={ this.props.path ?? '/' }
+							/>
 						</div>
 					) }
 					{ renderedLayout ? (

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -672,13 +672,15 @@ class MasterbarLoggedIn extends Component {
 				subItems={ [ profileActions, wpcomActions ] }
 				hasGlobalBorderStyle
 			>
-				<span className="masterbar__item-howdy-howdy">
-					{ sprintf(
-						/* translators: %s is the user's display name */
-						__( 'Howdy, %s' ),
-						user.display_name
-					) }
-				</span>
+				{ user.display_name && (
+					<span className="masterbar__item-howdy-howdy">
+						{ sprintf(
+							/* translators: %s is the user's display name */
+							__( 'Howdy, %s' ),
+							user.display_name
+						) }
+					</span>
+				) }
 				<Gravatar
 					className="masterbar__item-howdy-gravatar"
 					role="presentation"


### PR DESCRIPTION
Fixes DOTMSD-1166

## Proposed Changes

- Pass the bootstrapped `user` to the SSR'd `InterimOmnibar` so the profile/gravatar renders server-side
- On the client, reuse `window.currentUser` (when available) instead of re-fetching from the API
- Skip rendering the "Howdy, " fragment when `display_name` is empty (affects all masterbar instances, not just MSD)

## Why are these changes being made?

When `wpcom-user-bootstrap` is enabled the user object is already available at SSR time, but the omnibar was always rendering with `user={null}` and fetching the user client-side. This caused a flash of empty profile state. By threading the bootstrapped user through SSR and hydration we eliminate that flash and save a redundant API call.

## Testing Instructions

1. Copy `config/empty-secrets.json` to `config/secrets.json` and follow the FG instructions to enable `wpcom-user-bootstrap` locally
    - PCYsg-5YE-p2 
2. Enable the `wpcom-user-bootstrap` and `dashboard/omnibar` feature flags in `config/dashboard-development.json`
3. `yarn start-dashboard`
4. Load any MSD page — the omnibar profile/gravatar should render immediately without a flash
5. Verify hydration completes without React mismatch warnings in the console
6. `yarn start`
7. Verify the "Howdy" change hasn't broken any existing masterbar's in Calypso

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?