### PR TITLE
MSD Sidebar: Fix expandable menu item overflow clipping focus outlines

### DIFF
--- a/client/dashboard/components/sidebar/sidebar-expandable-menu-item.scss
+++ b/client/dashboard/components/sidebar/sidebar-expandable-menu-item.scss
@@ -12,8 +12,9 @@
 	opacity 0.2s ease-out;
 
 	&.is-open {
-		overflow: visible;
 		block-size: auto;
 		opacity: 1;
+		overflow: clip;
+		overflow-clip-margin: 2px;
 	}
 }


### PR DESCRIPTION
## Proposed Changes

* Replace `overflow: visible` with `overflow: clip` + `overflow-clip-margin: 2px` on the expandable sidebar menu panel's open state

## Why are these changes being made?

The expandable sidebar menu items (e.g., Plugins, Logs) use a CSS `block-size` transition for the expand/collapse animation. The open state previously used `overflow: visible` which caused the sidebar container to show a scrollbar because the content exceeded the container bounds.

Using `overflow: clip` prevents the scrollbar, while `overflow-clip-margin: 2px` ensures that focus outlines on menu items inside the panel remain visible and are not clipped.

## Testing Instructions

* Open the dashboard sidebar
* Expand a menu item with sub-items (e.g., Plugins or Logs)
* Verify no horizontal scrollbar appears on the sidebar
* Tab through the sub-items — focus outlines should be fully visible, not clipped

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)