### PR TITLE
[Fraud] Defer loading fingerprintjs

### DIFF
--- a/client/lib/wp/handlers/fingerprint.js
+++ b/client/lib/wp/handlers/fingerprint.js
@@ -1,15 +1,14 @@
-import { load } from '@fingerprintjs/fingerprintjs';
+let fingerprintPromise;
 
-let fingerprint;
-export async function loadFingerprint() {
-	const agent = await load( { monitoring: false } );
-	const result = await agent.get();
-	fingerprint = result.visitorId;
-}
-if ( document.readyState !== 'loading' ) {
-	loadFingerprint();
-} else {
-	document.addEventListener( 'DOMContentLoaded', loadFingerprint );
+function loadFingerprint() {
+	if ( ! fingerprintPromise ) {
+		fingerprintPromise = import( '@fingerprintjs/fingerprintjs' ).then( async ( { load } ) => {
+			const agent = await load( { monitoring: false } );
+			const result = await agent.get();
+			return result.visitorId;
+		} );
+	}
+	return fingerprintPromise;
 }
 
 /**
@@ -20,14 +19,17 @@ export function injectFingerprint( wpcom ) {
 	const request = wpcom.request.bind( wpcom );
 
 	wpcom.request = function ( params, callback ) {
-		if ( fingerprint && params?.path === '/me/transactions' ) {
-			params = {
-				...params,
-				headers: {
-					...( params.headers || {} ),
-					'X-Fingerprint': fingerprint,
-				},
-			};
+		if ( params?.path === '/me/transactions' ) {
+			return loadFingerprint().then( ( fingerprint ) => {
+				params = {
+					...params,
+					headers: {
+						...( params.headers || {} ),
+						'X-Fingerprint': fingerprint,
+					},
+				};
+				return request( params, callback );
+			} );
 		}
 		return request( params, callback );
 	};

--- a/client/lib/wp/handlers/test/fingerprint.test.ts
+++ b/client/lib/wp/handlers/test/fingerprint.test.ts
@@ -2,84 +2,69 @@
  * @jest-environment jsdom
  */
 
-import {
-	type loadFingerprint as loadFingerprintType,
-	type injectFingerprint as injectFingerprintType,
-} from '../fingerprint';
+const MOCK_VISITOR_ID = 'mock-visitor-id-123';
+
+jest.mock( '@fingerprintjs/fingerprintjs', () => ( {
+	load: jest.fn( () =>
+		Promise.resolve( {
+			get: jest.fn( () => Promise.resolve( { visitorId: MOCK_VISITOR_ID } ) ),
+		} )
+	),
+} ) );
+
+import { injectFingerprint } from '../fingerprint';
 
 describe( '#injectFingerprint', () => {
-	let loadFingerprint: typeof loadFingerprintType;
-	let injectFingerprint: typeof injectFingerprintType;
 	let wpcom: { request: jest.Mock };
 	let originalRequest: jest.Mock;
 	const callback = jest.fn();
-
-	beforeAll( async () => {
-		jest.spyOn( document, 'readyState', 'get' ).mockReturnValue( 'loading' );
-		jest.spyOn( document, 'addEventListener' ).mockImplementation( () => {} );
-		( { loadFingerprint, injectFingerprint } = await import( '../fingerprint' ) );
-	} );
 
 	beforeEach( () => {
 		originalRequest = jest.fn();
 		wpcom = { request: originalRequest };
 	} );
 
-	test( 'should not inject X-Fingerprint header when fingerprint is not available', async () => {
+	test( 'should inject fingerprint header for transactions path', async () => {
 		injectFingerprint( wpcom );
 
-		wpcom.request( { path: '/me/transactions' }, callback );
+		await wpcom.request( { path: '/me/transactions' }, callback );
 
-		expect( originalRequest ).toHaveBeenCalledWith( { path: '/me/transactions' }, callback );
+		expect( originalRequest ).toHaveBeenCalledWith(
+			{
+				path: '/me/transactions',
+				headers: {
+					'X-Fingerprint': MOCK_VISITOR_ID,
+				},
+			},
+			callback
+		);
 	} );
 
-	describe( 'when fingerprint is loaded', () => {
-		beforeAll( async () => {
-			await loadFingerprint();
-		} );
+	test( 'should not inject header for other paths', () => {
+		injectFingerprint( wpcom );
 
-		test( 'should inject fingerprint header for transactions path', () => {
-			injectFingerprint( wpcom );
+		wpcom.request( { path: '/me/settings' }, callback );
 
-			wpcom.request( { path: '/me/transactions' }, callback );
+		expect( originalRequest ).toHaveBeenCalledWith( { path: '/me/settings' }, callback );
+	} );
 
-			expect( originalRequest ).toHaveBeenCalledWith(
-				{
-					path: '/me/transactions',
-					headers: {
-						'X-Fingerprint': expect.any( String ),
-					},
+	test( 'should merge with existing headers if present', async () => {
+		injectFingerprint( wpcom );
+
+		await wpcom.request(
+			{ path: '/me/transactions', headers: { 'Content-Type': 'application/json' } },
+			callback
+		);
+
+		expect( originalRequest ).toHaveBeenCalledWith(
+			{
+				path: '/me/transactions',
+				headers: {
+					'Content-Type': 'application/json',
+					'X-Fingerprint': MOCK_VISITOR_ID,
 				},
-				callback
-			);
-		} );
-
-		test( 'should not inject header for other paths', () => {
-			injectFingerprint( wpcom );
-
-			wpcom.request( { path: '/me/settings' }, callback );
-
-			expect( originalRequest ).toHaveBeenCalledWith( { path: '/me/settings' }, callback );
-		} );
-
-		test( 'should merge with existing headers if present', () => {
-			injectFingerprint( wpcom );
-
-			wpcom.request(
-				{ path: '/me/transactions', headers: { 'Content-Type': 'application/json' } },
-				callback
-			);
-
-			expect( originalRequest ).toHaveBeenCalledWith(
-				{
-					path: '/me/transactions',
-					headers: {
-						'Content-Type': 'application/json',
-						'X-Fingerprint': expect.any( String ),
-					},
-				},
-				callback
-			);
-		} );
+			},
+			callback
+		);
 	} );
 } );


### PR DESCRIPTION
Fixes DOTCOM-16514

## Proposed Changes

Fingerprint.js is a significant library, and now it's loaded everywhere even though it's used in a very narrow single case. This loads it only when it's needed.

## Why are these changes being made?
Performance.

## Testing Instructions

1. Add a plan to checkout.
2. Open DevTools > Network and filter by "/me/transactions".
3. Pay with anything besides PayPal (credits work).
4. The request to transactions should contain a X-Fingerprint header.