### PR TITLE
Stepper: delay preloading steps by five seconds

### DIFF
--- a/client/components/help-center/async-help-center-app.tsx
+++ b/client/components/help-center/async-help-center-app.tsx
@@ -2,6 +2,9 @@ import AsyncLoad from 'calypso/components/async-load';
 import type { HelpCenterAppProps } from './help-center-app';
 
 const AsyncHelpCenterApp = ( props: HelpCenterAppProps ) => {
+	if ( props.requireLogin && ! props.currentUser ) {
+		return null;
+	}
 	return (
 		<AsyncLoad
 			require="./help-center-app"

--- a/client/components/help-center/help-center-app.tsx
+++ b/client/components/help-center/help-center-app.tsx
@@ -12,7 +12,9 @@ import './help-center-app.scss';
 export type HelpCenterAppProps = Omit<
 	React.ComponentProps< typeof HelpCenter >,
 	'onboardingUrl' | 'handleClose'
->;
+> & {
+	requireLogin?: boolean;
+};
 
 const HELP_CENTER_STORE = HelpCenterStore.register();
 

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-preload-steps/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-preload-steps/index.ts
@@ -1,6 +1,6 @@
 import { SiteDetails } from '@automattic/data-stores';
 import debugFactory from 'debug';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import type { Flow, FlowV2, StepperStep } from '../../types';
@@ -24,6 +24,17 @@ async function tryPreload( step?: StepperStep, followingStep?: StepperStep ) {
 	}
 }
 
+function useHasItBeenASecond() {
+	const [ hasItBeenASecond, setHasItBeenASecond ] = useState( false );
+
+	useEffect( () => {
+		const intervalId = setTimeout( () => setHasItBeenASecond( true ), 1000 );
+		return () => clearTimeout( intervalId );
+	}, [] );
+
+	return hasItBeenASecond;
+}
+
 /**
  * Preload the next step in the flow, if it's an async component.
  * @param siteSlugOrId The site slug or ID.
@@ -40,8 +51,14 @@ export function usePreloadSteps(
 	flow: Flow | FlowV2< any >
 ) {
 	const isLoggedIn = useSelector( isUserLoggedIn );
+	// Wait a second before preloading. Gives priority to what's on the screen.
+	const activate = useHasItBeenASecond();
 
 	useEffect( () => {
+		if ( ! activate ) {
+			debug( 'Not preloading steps yet. Too early.' );
+			return;
+		}
 		if ( siteSlugOrId && ! selectedSite ) {
 			// If this step depends on a selected site, only preload after we have the data.
 			// Otherwise, we're still waiting to render something meaningful, and we don't want to
@@ -80,5 +97,5 @@ export function usePreloadSteps(
 		// different points. But even if they do, worst case scenario we only fail to preload
 		// some steps, and they'll simply be loaded later.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ siteSlugOrId, selectedSite, currentStepRoute, flow ] );
+	}, [ siteSlugOrId, selectedSite, currentStepRoute, flow, activate ] );
 }

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-preload-steps/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-preload-steps/index.ts
@@ -24,15 +24,15 @@ async function tryPreload( step?: StepperStep, followingStep?: StepperStep ) {
 	}
 }
 
-function useHasItBeenASecond() {
-	const [ hasItBeenASecond, setHasItBeenASecond ] = useState( false );
+function useHasItBeenFiveSeconds() {
+	const [ hasItBeenFiveSeconds, setHasItBeenFiveSeconds ] = useState( false );
 
 	useEffect( () => {
-		const intervalId = setTimeout( () => setHasItBeenASecond( true ), 1000 );
+		const intervalId = setTimeout( () => setHasItBeenFiveSeconds( true ), 5000 );
 		return () => clearTimeout( intervalId );
 	}, [] );
 
-	return hasItBeenASecond;
+	return hasItBeenFiveSeconds;
 }
 
 /**
@@ -52,7 +52,7 @@ export function usePreloadSteps(
 ) {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	// Wait a second before preloading. Gives priority to what's on the screen.
-	const activate = useHasItBeenASecond();
+	const activate = useHasItBeenFiveSeconds();
 
 	useEffect( () => {
 		if ( ! activate ) {

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-preload-steps/test/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-preload-steps/test/index.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import { SiteDetails } from '@automattic/data-stores';
-import { renderHook } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { usePreloadSteps } from '../../use-preload-steps';
@@ -18,6 +18,8 @@ jest.mock( 'calypso/state/current-user/selectors', () => ( {
 } ) );
 
 jest.mock( 'debug', () => () => jest.fn() );
+
+const PRELOAD_DELAY_MS = 5000;
 
 describe( 'usePreloadSteps', () => {
 	// Mock step components
@@ -44,6 +46,7 @@ describe( 'usePreloadSteps', () => {
 
 	beforeEach( () => {
 		jest.clearAllMocks();
+		jest.useFakeTimers();
 		( useSelector as jest.Mock ).mockImplementation( ( selector ) => {
 			if ( selector === isUserLoggedIn ) {
 				return false;
@@ -52,10 +55,27 @@ describe( 'usePreloadSteps', () => {
 		} );
 	} );
 
-	it( 'should not preload anything if siteSlugOrId is provided but selectedSite is not', () => {
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	it( 'should not preload anything if siteSlugOrId is provided but selectedSite is not', async () => {
 		renderHook( () => usePreloadSteps( 'site-slug', null, 'step1', mockFlowSteps, mockFlow ) );
 
+		await act( () => jest.advanceTimersByTime( PRELOAD_DELAY_MS ) );
+
 		expect( mockAsyncComponent1 ).not.toHaveBeenCalled();
+		expect( mockAsyncComponent2 ).not.toHaveBeenCalled();
+		expect( mockAsyncComponent3 ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should not preload before the delay elapses', () => {
+		renderHook( () =>
+			usePreloadSteps( 'site-slug', mockSiteDetails, 'step1', mockFlowSteps, mockFlow )
+		);
+
+		jest.advanceTimersByTime( PRELOAD_DELAY_MS - 1 );
+
 		expect( mockAsyncComponent2 ).not.toHaveBeenCalled();
 		expect( mockAsyncComponent3 ).not.toHaveBeenCalled();
 	} );
@@ -65,8 +85,7 @@ describe( 'usePreloadSteps', () => {
 			usePreloadSteps( 'site-slug', mockSiteDetails, 'step1', mockFlowSteps, mockFlow )
 		);
 
-		// Wait for async operations
-		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+		await act( () => jest.advanceTimersByTime( PRELOAD_DELAY_MS ) );
 
 		expect( mockAsyncComponent2 ).toHaveBeenCalled();
 		expect( mockAsyncComponent3 ).toHaveBeenCalled();
@@ -77,8 +96,7 @@ describe( 'usePreloadSteps', () => {
 			usePreloadSteps( 'site-slug', mockSiteDetails, 'step1', mockFlowSteps, mockFlow )
 		);
 
-		// Wait for async operations
-		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+		await act( () => jest.advanceTimersByTime( PRELOAD_DELAY_MS ) );
 
 		expect( mockUserAsyncComponent ).toHaveBeenCalled();
 	} );
@@ -95,8 +113,7 @@ describe( 'usePreloadSteps', () => {
 			usePreloadSteps( 'site-slug', mockSiteDetails, 'step1', mockFlowSteps, mockFlow )
 		);
 
-		// Wait for async operations
-		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+		await act( () => jest.advanceTimersByTime( PRELOAD_DELAY_MS ) );
 
 		expect( mockUserAsyncComponent ).not.toHaveBeenCalled();
 	} );
@@ -106,8 +123,7 @@ describe( 'usePreloadSteps', () => {
 			usePreloadSteps( 'site-slug', mockSiteDetails, 'user', mockFlowSteps, mockFlow )
 		);
 
-		// Wait for async operations
-		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+		await act( () => jest.advanceTimersByTime( PRELOAD_DELAY_MS ) );
 
 		expect( mockAsyncComponent2 ).toHaveBeenCalled(); // First step requiring authentication
 		expect( mockAsyncComponent3 ).toHaveBeenCalled(); // Next step after that
@@ -118,8 +134,7 @@ describe( 'usePreloadSteps', () => {
 			usePreloadSteps( 'site-slug', mockSiteDetails, 'non-existent-step', mockFlowSteps, mockFlow )
 		);
 
-		// Wait for async operations
-		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+		await act( () => jest.advanceTimersByTime( PRELOAD_DELAY_MS ) );
 
 		expect( mockAsyncComponent1 ).not.toHaveBeenCalled();
 		expect( mockAsyncComponent2 ).not.toHaveBeenCalled();
@@ -131,12 +146,23 @@ describe( 'usePreloadSteps', () => {
 			usePreloadSteps( 'site-slug', mockSiteDetails, 'step3', mockFlowSteps, mockFlow )
 		);
 
-		// Wait for async operations
-		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+		await act( () => jest.advanceTimersByTime( PRELOAD_DELAY_MS ) );
 
 		// No error should be thrown
 		expect( mockAsyncComponent1 ).not.toHaveBeenCalled();
 		expect( mockAsyncComponent2 ).not.toHaveBeenCalled();
 		expect( mockAsyncComponent3 ).not.toHaveBeenCalled(); // Current step, not preloaded
+	} );
+
+	it( 'should cancel preloading on unmount', async () => {
+		const { unmount } = renderHook( () =>
+			usePreloadSteps( 'site-slug', mockSiteDetails, 'step1', mockFlowSteps, mockFlow )
+		);
+
+		unmount();
+		await act( () => jest.advanceTimersByTime( PRELOAD_DELAY_MS ) );
+
+		expect( mockAsyncComponent2 ).not.toHaveBeenCalled();
+		expect( mockAsyncComponent3 ).not.toHaveBeenCalled();
 	} );
 } );

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -226,6 +226,8 @@ async function main() {
 					</BrowserRouter>
 					{ ! FLOWS_WITHOUT_HELP_CENTER.has( flowName ) && (
 						<AsyncHelpCenterApp
+							// Only load the Help Center for logged in users.
+							requireLogin
 							currentUser={ user as UserStore.CurrentUser }
 							sectionName="stepper"
 						/>


### PR DESCRIPTION
Fixes DOTCOM-16515

## Proposed Changes

Currently, Stepper preloads the next steps to prevent showing the dreaded fading WordPress logo between steps. But it's too aggressive and can slow the first step. Delay preloading by 1-2 seconds to make sure the first step is done loading.

## Why are these changes being made?
Improve Web Vitals scores.

## Testing Instructions

1. While incognito, open DevTools > Network.
2. Go to /setup and watch the downloaded bytes counter.
3. It should settle for 5 seconds then load a bunch of bytes.