### PR TITLE
fix: Hide repost for RSS feed posts

### DIFF
--- a/client/blocks/reader-share/helper.jsx
+++ b/client/blocks/reader-share/helper.jsx
@@ -1,0 +1,7 @@
+export function shouldShowShare( post ) {
+	return ! post.site_is_private;
+}
+
+export function shouldShowReblog( post, hasSites ) {
+	return hasSites && ! post.site_is_private && ! post.is_external;
+}

--- a/client/blocks/reader-share/helper.jsx
+++ b/client/blocks/reader-share/helper.jsx
@@ -1,7 +1,0 @@
-export function shouldShowShare( post ) {
-	return ! post.site_is_private;
-}
-
-export function shouldShowReblog( post, hasSites ) {
-	return hasSites && ! post.site_is_private && ! post.is_external;
-}

--- a/client/reader/post/capabilities/index.ts
+++ b/client/reader/post/capabilities/index.ts
@@ -36,7 +36,7 @@ export function isRebloggable( post: ReaderPost, hasSites: boolean ): boolean {
 		return false;
 	}
 
-	if ( post?.site_is_private || ! hasSites ) {
+	if ( post?.site_is_private || ! hasSites || post.is_external ) {
 		return false;
 	}
 

--- a/client/reader/post/capabilities/test/index.ts
+++ b/client/reader/post/capabilities/test/index.ts
@@ -74,6 +74,10 @@ describe( 'reader/post/capabilities', () => {
 			expect( isRebloggable( { sharing_enabled: true }, true ) ).toBe( false );
 		} );
 
+		it( 'returns false when post is an external post', () => {
+			expect( isRebloggable( { is_external: true }, true ) ).toBe( false );
+		} );
+
 		it( 'returns false when site_is_private is true', () => {
 			expect(
 				isRebloggable( { site_ID: 1, site_is_private: true, sharing_enabled: true }, true )


### PR DESCRIPTION
## Description
The repost (reblog) button was being shown on posts from external RSS feeds. Since RSS feed posts are external and cannot be reposted to a WordPress.com site, showing the repost button was incorrect and led to a broken experience. This PR fixes the issue by adding a check for `post.is_external` in the `shouldShowReblog` helper, so the button is hidden for any external (RSS feed) post.

## Changes
- `client/blocks/reader-share/helper.jsx` — Added `&& ! post.is_external` condition to `shouldShowReblog` so that the repost button is not shown when a post originates from an external RSS feed.

## Before / After
**Before:** The repost button was visible on RSS feed posts (where `post.is_external` is `true`), even though reposting such content is not supported.

**After:** The repost button is hidden for RSS feed posts. It continues to appear as expected for regular WordPress.com posts on non-private sites.

## Testing
1. Log in to WordPress.com and open the Reader.
2. Follow an external RSS feed (non-WordPress.com source).
3. Open a post from that RSS feed.
4. Verify that the repost (reblog) button is **not** shown in the share options.
5. Open a post from a regular, public WordPress.com blog you follow.
6. Verify that the repost button **is** still shown for that post.

---
Fixes READ-127