### PR TITLE
Theme Showcase: Launch modern logged-out redesign

### DIFF
--- a/client/my-sites/themes/hero-modern/index.tsx
+++ b/client/my-sites/themes/hero-modern/index.tsx
@@ -25,7 +25,7 @@ const HeroModern = ( {
 	return (
 		<FullWidthSection enabled className="hero-modern">
 			<div className="hero-modern__content">
-				<h1 className="hero-modern__title">{ preventWidows( header ) }</h1>
+				<h1 className="hero-modern__title">{ header }</h1>
 				<p className="hero-modern__description">{ preventWidows( description ) }</p>
 				<div className="hero-modern__search">
 					<SearchThemes

--- a/client/my-sites/themes/hero-modern/style.scss
+++ b/client/my-sites/themes/hero-modern/style.scss
@@ -30,7 +30,7 @@ $hero-modern-navbar-height: 57px; // UniversalHeaderNavigation
 
 .hero-modern__content {
 	flex: 1;
-	max-width: 700px;
+	max-width: 800px;
 	padding: 0 24px;
 
 	@media ( min-width: $break-wide ) {

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -123,7 +123,7 @@
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,
-		"themes/showcase-modern": false,
+		"themes/showcase-modern": true,
 		"themes/subscription-purchases": false,
 		"themes/universal-header": true,
 		"plugins/universal-header": true,

--- a/config/production.json
+++ b/config/production.json
@@ -162,7 +162,7 @@
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,
-		"themes/showcase-modern": false,
+		"themes/showcase-modern": true,
 		"themes/subscription-purchases": false,
 		"themes/universal-header": true,
 		"plugins/universal-header": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -157,7 +157,7 @@
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,
-		"themes/showcase-modern": false,
+		"themes/showcase-modern": true,
 		"themes/subscription-purchases": false,
 		"themes/universal-header": true,
 		"plugins/universal-header": true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTTHEM-344

## Proposed Changes

* Launch the modern redesign of the logged-out Theme Showcase.

| Old logged-out | Old logged-in<br>(unchanged) | Modern logged-out |
|--------|--------|--------|
| <img width="500" alt="Screenshot 2026-03-26 at 10 27 09" src="https://github.com/user-attachments/assets/31386b08-988f-482b-8bd6-b908114c9b9b" /> | <img width="500" alt="Screenshot 2026-03-26 at 10 27 37" src="https://github.com/user-attachments/assets/403f57c6-0ef3-4676-a20d-7f26362c9e4d" /> | <img width="500" alt="Screenshot 2026-03-26 at 10 27 18" src="https://github.com/user-attachments/assets/af266eaa-c8b8-47eb-a5bb-d1422db48235" /> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the logged-out Theme Showcase.
* Ensure you get the modern showcase design.
* Visit the logged-in Theme Showcase.
* Ensure you get the classic showcase design.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
