### PR TITLE
Do not load the Help Center for no reason

### DIFF
--- a/client/components/help-center/async-help-center-app.tsx
+++ b/client/components/help-center/async-help-center-app.tsx
@@ -2,6 +2,9 @@ import AsyncLoad from 'calypso/components/async-load';
 import type { HelpCenterAppProps } from './help-center-app';
 
 const AsyncHelpCenterApp = ( props: HelpCenterAppProps ) => {
+	if ( props.requireLogin && ! props.currentUser ) {
+		return null;
+	}
 	return (
 		<AsyncLoad
 			require="./help-center-app"

--- a/client/components/help-center/help-center-app.tsx
+++ b/client/components/help-center/help-center-app.tsx
@@ -12,7 +12,9 @@ import './help-center-app.scss';
 export type HelpCenterAppProps = Omit<
 	React.ComponentProps< typeof HelpCenter >,
 	'onboardingUrl' | 'handleClose'
->;
+> & {
+	requireLogin?: boolean;
+};
 
 const HELP_CENTER_STORE = HelpCenterStore.register();
 

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -226,6 +226,7 @@ async function main() {
 					</BrowserRouter>
 					{ ! FLOWS_WITHOUT_HELP_CENTER.has( flowName ) && (
 						<AsyncHelpCenterApp
+							requireLogin
 							currentUser={ user as UserStore.CurrentUser }
 							sectionName="stepper"
 						/>


### PR DESCRIPTION
Fixes DOTCOM-16518

## Proposed Changes

* Delay loading the Help Center until the user logs in.

## Why are these changes being made?
Performance improvements.


