### PR TITLE
Add /setup/artpromo flow for promotional domain checkout

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/artpromo/artpromo.ts
+++ b/client/landing/stepper/declarative-flow/flows/artpromo/artpromo.ts
@@ -1,0 +1,58 @@
+import { DomainAvailabilityStatus, fetchDomainAvailability } from '@automattic/api-core';
+import { ART_PROMO_FLOW, addProductsToCart } from '@automattic/onboarding';
+import { useQuery } from '../../../hooks/use-query';
+import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
+import { STEPS } from '../../internals/steps';
+import type { FlowV2 } from '../../internals/types';
+
+function initialize() {
+	return stepsWithRequiredLogin( [ STEPS.PROCESSING ] );
+}
+
+const artPromoFlow: FlowV2< typeof initialize > = {
+	name: ART_PROMO_FLOW,
+	isSignupFlow: false,
+	__experimentalUseBuiltinAuth: true,
+	initialize,
+
+	useStepNavigation() {
+		const flowName = this.name;
+		const queryParams = useQuery();
+		const domain = queryParams.get( 'new' ) || '';
+
+		const submit = async () => {
+			if ( ! domain ) {
+				return window.location.assign( '/' );
+			}
+
+			const availability = await fetchDomainAvailability( domain, {
+				is_cart_pre_check: true,
+			} );
+
+			if (
+				availability.status !== DomainAvailabilityStatus.AVAILABLE ||
+				! availability.product_slug
+			) {
+				return window.location.assign( '/domains' );
+			}
+
+			await addProductsToCart( 'no-site', flowName, [
+				{
+					product_slug: availability.product_slug,
+					meta: domain,
+					extra: {
+						art_promo: 'wpcom2026',
+						privacy_available: availability.supports_privacy,
+						privacy: availability.supports_privacy,
+					},
+				},
+			] );
+
+			return window.location.replace( '/checkout/no-site?signup=0&isDomainOnly=1' );
+		};
+
+		return { submit };
+	},
+};
+
+export default artPromoFlow;

--- a/client/landing/stepper/declarative-flow/flows/artpromo/artpromo.ts
+++ b/client/landing/stepper/declarative-flow/flows/artpromo/artpromo.ts
@@ -41,7 +41,7 @@ const artPromoFlow: FlowV2< typeof initialize > = {
 					product_slug: availability.product_slug,
 					meta: domain,
 					extra: {
-						art_promo: 'wpcom2026',
+						is_art_promo: true,
 						privacy_available: availability.supports_privacy,
 						privacy: availability.supports_privacy,
 					},

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -20,6 +20,7 @@ import {
 	PLAN_UPGRADE_FLOW,
 	FLEX_SITE_FLOW,
 	WOO_HOSTED_PLANS_FLOW,
+	ART_PROMO_FLOW,
 } from '@automattic/onboarding';
 import type { Flow, FlowV2 } from '../declarative-flow/internals/types';
 
@@ -62,6 +63,9 @@ const availableFlows: Record< string, () => Promise< { default: FlowV2< any > } 
 		import(
 			/* webpackChunkName: "woo-hosted-plans" */ './flows/woo-hosted-plans/woo-hosted-plans'
 		),
+
+	[ ART_PROMO_FLOW ]: () =>
+		import( /* webpackChunkName: "artpromo-flow" */ './flows/artpromo/artpromo' ),
 };
 
 /**

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -40,7 +40,7 @@ export const PLAYGROUND_FLOW = 'playground';
 export const PLAN_UPGRADE_FLOW = 'plan-upgrade';
 export const FLEX_SITE_FLOW = 'flex-site';
 export const WOO_HOSTED_PLANS_FLOW = 'woo-hosted-plans';
-export const ART_PROMO_FLOW = 'artpromo';
+export const ART_PROMO_FLOW = 'art-domain';
 
 export const isNewsletterFlow = ( flowName: string | null | undefined ) => {
 	return Boolean( flowName && NEWSLETTER_FLOW === flowName );

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -40,6 +40,7 @@ export const PLAYGROUND_FLOW = 'playground';
 export const PLAN_UPGRADE_FLOW = 'plan-upgrade';
 export const FLEX_SITE_FLOW = 'flex-site';
 export const WOO_HOSTED_PLANS_FLOW = 'woo-hosted-plans';
+export const ART_PROMO_FLOW = 'artpromo';
 
 export const isNewsletterFlow = ( flowName: string | null | undefined ) => {
 	return Boolean( flowName && NEWSLETTER_FLOW === flowName );

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -875,6 +875,7 @@ export interface ResponseCartProductExtra {
 	legal_agreements?: never[] | DomainLegalAgreements;
 	is_gravatar_domain?: boolean;
 	is_hundred_year_domain?: boolean;
+	art_promo?: string;
 
 	/**
 	 * Set to 'renewal' if requesting a renewal.

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -875,7 +875,7 @@ export interface ResponseCartProductExtra {
 	legal_agreements?: never[] | DomainLegalAgreements;
 	is_gravatar_domain?: boolean;
 	is_hundred_year_domain?: boolean;
-	art_promo?: string;
+	is_art_promo?: boolean;
 
 	/**
 	 * Set to 'renewal' if requesting a renewal.


### PR DESCRIPTION
Part of [DOMENG-431: 100% discount applied using URL parameter in Domain search](https://linear.app/a8c/issue/DOMENG-431/100percent-discount-applied-using-url-parameter-in-domain-search)

## Proposed Changes

* Add a new stepper flow at `/setup/artpromo` that accepts a domain via the `new` query parameter
* The flow requires login (`__experimentalUseBuiltinAuth` + `stepsWithRequiredLogin`)
* Runs a pre-checkout domain availability check via `fetchDomainAvailability`
* Adds the domain to the shopping cart with an extra property `is_art_promo: true`
* Redirects to `/checkout/no-site` for domain-only purchase

## Why are these changes being made?

This flow supports a promotional domain registration experience where domains can be offered with a 100% discount applied via a URL parameter. The `is_art_promo` cart extra allows the backend to identify and apply the appropriate pricing.

## Testing Instructions

1. Start the dev server: `yarn start`
2. Navigate to `/setup/artpromo?new=some-available-domain.com`
3. Verify you are prompted to log in if not already logged in
4. After login, verify the processing screen appears briefly
5. Verify you are redirected to checkout with the domain in your cart
6. Inspect the cart (via browser devtools / network tab) to confirm the `is_art_promo: true` extra property is present
7. Test with an unavailable domain — should redirect to `/domains`
8. Test without the `new` param — should redirect to `/`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?