### PR TITLE
fix: Reader: Fix setState during render warning in ReaderOnboarding

### DIFF
--- a/client/reader/onboarding/index.tsx
+++ b/client/reader/onboarding/index.tsx
@@ -147,7 +147,10 @@ const ReaderOnboarding = ( {
 	}, [ dispatch ] );
 
 	// Notify the parent component if onboarding will render.
-	onRender?.( shouldShowOnboarding );
+	// Use useEffect to avoid calling setState during render (React anti-pattern).
+	useEffect( () => {
+		onRender?.( shouldShowOnboarding );
+	}, [ onRender, shouldShowOnboarding ] );
 
 	if ( ! shouldRenderOnboarding ) {
 		return null;


### PR DESCRIPTION
## Description
The `ReaderOnboarding` component was calling `onRender?.( shouldShowOnboarding )` directly during the render phase. When the parent component used this callback to call `setState`, React would throw a warning about updating state during an existing state transition (setState during render). This is a React anti-pattern because it can cause cascading renders and unpredictable behavior.

This PR wraps the `onRender` callback in a `useEffect` so it is invoked after the render is committed, following React's rules for side effects.

## Changes
- `client/reader/onboarding/index.tsx`: Wrapped the `onRender?.( shouldShowOnboarding )` call in a `useEffect` hook with `onRender` and `shouldShowOnboarding` as dependencies, preventing the setState-during-render React warning.

## Before / After
**Before:** `onRender` was called inline during render. If the parent responded by setting state, React would emit a warning: "Cannot update a component (`X`) while rendering a different component (`ReaderOnboarding`)."

**After:** `onRender` is called inside a `useEffect`, which runs after the component has finished rendering and been committed to the DOM. This eliminates the warning and follows React's recommended pattern for communicating side effects to parent components.

## Testing
1. Navigate to the Reader section of WordPress.com as a user who would see the onboarding flow.
2. Open the browser console and confirm there are no "Cannot update a component while rendering a different component" warnings.
3. Verify the onboarding UI renders correctly and the parent component receives the `onRender` callback as expected.
4. Dismiss or complete onboarding and confirm the parent state updates correctly without console warnings.

---
Fixes READ-339