### PR TITLE
Do not load Noto unless it's needed

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/style.scss
+++ b/client/blocks/importer/wordpress/upgrade-plan/style.scss
@@ -2,6 +2,7 @@
 @import "@automattic/onboarding/styles/mixins";
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap";
 
 $business-plan-color: #7f54b3;
 

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -1,3 +1,5 @@
+@import "https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap";
+
 .is-site-stream.is-two-columns {
 	.reader-feed-header__site {
 		align-items: center;

--- a/client/components/bloganuary-header/style.scss
+++ b/client/components/bloganuary-header/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap";
 
 .bloganuary-header {
 	background-color: var(--color-sidebar-background);

--- a/client/components/empty-content/no-sites-message/style.scss
+++ b/client/components/empty-content/no-sites-message/style.scss
@@ -1,4 +1,5 @@
 @import "@automattic/typography/styles/variables";
+@import "https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap";
 
 .no-sites-message {
 	display: flex;

--- a/client/components/head/index.jsx
+++ b/client/components/head/index.jsx
@@ -2,13 +2,7 @@ import config from '@automattic/calypso-config';
 import PropTypes from 'prop-types';
 import Favicons from './favicons';
 
-const Head = ( {
-	title = 'WordPress.com',
-	children,
-	branchName,
-	inlineScriptNonce,
-	faviconUrl,
-} ) => {
+const Head = ( { title = 'WordPress.com', children, branchName, faviconUrl } ) => {
 	return (
 		<head>
 			<title>{ title }</title>
@@ -40,34 +34,6 @@ const Head = ( {
 					href={ '/calypso/manifest.json?branch=' + encodeURIComponent( branchName ) }
 				/>
 			) }
-			<link
-				rel="preload"
-				href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap"
-				as="style"
-			/>
-			<noscript>
-				<link
-					rel="stylesheet"
-					href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap"
-				/>
-			</noscript>
-			{ /* eslint-disable react/no-danger */ }
-			<script
-				type="text/javascript"
-				nonce={ inlineScriptNonce }
-				dangerouslySetInnerHTML={ {
-					// eslint-disable
-					__html: `
-			(function() {
-				var m = document.createElement( "link" );
-				m.rel = "stylesheet";
-				m.href = "https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap";
-				document.head.insertBefore( m, document.head.childNodes[ document.head.childNodes.length - 1 ].nextSibling );
-			})()
-			`,
-				} }
-			/>
-			{ /* eslint-enable react/no-danger */ }
 			{ children }
 		</head>
 	);

--- a/client/components/jetpack/wpcom-upsell-placeholder/style.scss
+++ b/client/components/jetpack/wpcom-upsell-placeholder/style.scss
@@ -1,5 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap";
+
 
 .wpcom-upsell-placeholder {
 	display: flex;

--- a/client/hosting/server-settings/style.scss
+++ b/client/hosting/server-settings/style.scss
@@ -1,4 +1,6 @@
 @import "calypso/assets/stylesheets/shared/mixins/breakpoints";
+@import "https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap";
+
 
 .page-server-settings {
 	/* Rely on the standard spacing for the underlying elements. */

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
@@ -1,5 +1,6 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@automattic/onboarding/styles/mixins';
+@import "https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap";
 
 .plans {
 	.step-container {

--- a/client/my-sites/customer-home/components/celebrate-launch-modal.scss
+++ b/client/my-sites/customer-home/components/celebrate-launch-modal.scss
@@ -1,3 +1,5 @@
+@import "https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap";
+
 $breakpoint-mobile: 782px; //Mobile size.
 
 .launched__modal {

--- a/client/my-sites/stats/videopress-stats-module/style.scss
+++ b/client/my-sites/stats/videopress-stats-module/style.scss
@@ -1,6 +1,7 @@
 @import "@automattic/typography/styles/variables";
 @import "@wordpress/base-styles/breakpoints";
 @import "@automattic/components/src/styles/typography";
+@import "https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap";
 
 .stats-module__date-picker-header {
 	margin: 20px 0;

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -2,6 +2,7 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 @import '@wordpress/base-styles/variables';
+@import "https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap";
 
 .is-section-themes {
 	&.theme-default.color-scheme {

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -1,6 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/variables";
+@import "https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap";
 
 .is-two-columns.tag-stream__main {
 	.reader__content,

--- a/client/reader/tags/style.scss
+++ b/client/reader/tags/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap";
 
 .layout.has-header-section.is-section-reader .layout__header-section-content {
 	box-sizing: border-box;

--- a/client/site-profiler/components/domain-analyzer/styles.scss
+++ b/client/site-profiler/components/domain-analyzer/styles.scss
@@ -1,4 +1,5 @@
 @import '@wordpress/base-styles/breakpoints';
+@import 'https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap';
 
 @mixin input-style {
 	background: #fff;
@@ -26,7 +27,7 @@
 	display: flex;
 	position: relative;
 
-	@media ( min-width: $break-small + 1px ) {
+	@media ( min-width: #{$break-small + 1px} ) {
 		@include input-style;
 		gap: 1rem;
 
@@ -80,7 +81,7 @@
 
 .domain-analyzer--form {
 	&.is-error {
-		@media ( min-width: $break-small + 1px ) {
+		@media ( min-width: #{$break-small + 1px} ) {
 			.domain-analyzer--form-container {
 				border: 1px solid var( --studio-red-50 );
 			}
@@ -97,7 +98,7 @@
 .domain-analyzer--msg {
 	margin-top: 0.5rem;
 
-	@media ( min-width: $break-small + 1px ) {
+	@media ( min-width: #{$break-small + 1px} ) {
 		position: absolute;
 		left: 0;
 		margin-top: 1.5rem;

--- a/client/site-profiler/components/styles.scss
+++ b/client/site-profiler/components/styles.scss
@@ -1,4 +1,5 @@
 @import "@wordpress/base-styles/breakpoints";
+@import "https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap";
 
 html[dir="rtl"] {
 	.is-section-site-profiler .main .hosting-intro-block.globe-bg {


### PR DESCRIPTION
Fixes DOTCOM-16521

## Proposed Changes

After some investigation, turns out the font Noto is used in 28 places but it's loaded for the entire app. This loads the font in the places it is used only.

## Why are these changes being made?
Better performance.

## Testing Instructions

1. Open DevTools > Network.
2. Go to /setup.
3. Make sure Noto is not loaded.

### Regression testing

1. Keep DevTools open.
2. Go to /themes.
3. Noto should load.