### PR TITLE
E2E: Wait for Stripe iframe inputs to be visible before filling

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
@@ -125,7 +125,9 @@ export class CartCheckoutPage {
 				.waitFor( { state: 'visible' } );
 		}
 
-		await this.page.waitForSelector( selectors.cartItem( expectedCartItemName ) );
+		await this.page.waitForSelector( selectors.cartItem( expectedCartItemName ), {
+			timeout: 15000,
+		} );
 	}
 
 	/**
@@ -315,18 +317,24 @@ export class CartCheckoutPage {
 
 		const cardNumberFrameHandle = await this.page.waitForSelector( selectors.cardNumberFrame );
 		const cardNumberFrame = ( await cardNumberFrameHandle.contentFrame() ) as Frame;
-		const cardNumberInput = await cardNumberFrame.waitForSelector( selectors.cardNumberInput );
+		const cardNumberInput = await cardNumberFrame.waitForSelector( selectors.cardNumberInput, {
+			state: 'visible',
+		} );
 		await cardNumberInput.fill( paymentDetails.cardNumber );
 
 		const expiryFrameHandle = await this.page.waitForSelector( selectors.cardExpiryFrame );
 		const expiryFrame = ( await expiryFrameHandle.contentFrame() ) as Frame;
-		const expiryInput = await expiryFrame.waitForSelector( selectors.cardExpiryInput );
+		const expiryInput = await expiryFrame.waitForSelector( selectors.cardExpiryInput, {
+			state: 'visible',
+		} );
 		await expiryInput.fill( `${ paymentDetails.expiryMonth }${ paymentDetails.expiryYear }` );
 
 		const cvvFrame = ( await (
 			await this.page.waitForSelector( selectors.cardCVVFrame )
 		).contentFrame() ) as Frame;
-		const cvvInput = await cvvFrame.waitForSelector( selectors.cardCVVInput );
+		const cvvInput = await cvvFrame.waitForSelector( selectors.cardCVVInput, {
+			state: 'visible',
+		} );
 		await cvvInput.fill( paymentDetails.cvv );
 	}
 


### PR DESCRIPTION
## Proposed Changes

* Add `state: 'visible'` to `waitForSelector` calls for card number, expiry, and CVV inputs inside Stripe Elements iframes in `CartCheckoutPage.enterPaymentDetails()`

## Why are these changes being made?

The Stripe Elements iframes load asynchronously. After the iframe element is found in the DOM, the internal input fields may not yet be visible (Stripe is still rendering them). The `fill()` call fails with "element is not visible" because `waitForSelector` defaults to waiting for the element to be "attached" (present in DOM) rather than "visible" (rendered and not hidden).

This causes flaky failures in tests that enter payment details, including `setup-domain__flows.spec.ts` and `signup__with-theme-LOHP.spec.ts`.

## Testing Instructions

* This fix should reduce flakiness in all E2E tests that go through the checkout flow with card payment
* The affected tests run on CI against production — they can't be run locally

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)