### PR TITLE
prevent overwriting post details with empty values

### DIFF
--- a/client/state/reader/posts/reducer.js
+++ b/client/state/reader/posts/reducer.js
@@ -17,7 +17,57 @@ const MEDIA_FIELDS_TO_PRESERVE = [
 	'post_thumbnail',
 ];
 
-function isIncomingMediaFieldEmpty( value ) {
+/**
+ * Stream-normalized posts may carry canonical_media objects with keys but no usable src;
+ * treat those as empty so we do not clobber a good full-post canonical_media.
+ */
+function isEmptyCanonicalMedia( value ) {
+	if ( value == null || value === '' ) {
+		return true;
+	}
+	if (
+		typeof value !== 'object' ||
+		value === null ||
+		Array.isArray( value ) ||
+		Object.keys( value ).length === 0
+	) {
+		return true;
+	}
+	const { mediaType, src, autoplayIframe } = value;
+	if ( mediaType === 'video' ) {
+		if ( autoplayIframe ) {
+			return false;
+		}
+		const srcStr = typeof src === 'string' ? src.trim() : '';
+		return srcStr === '';
+	}
+	const srcStr = typeof src === 'string' ? src.trim() : '';
+	return srcStr === '';
+}
+
+function isEmptyCanonicalImage( value ) {
+	if ( value == null || value === '' ) {
+		return true;
+	}
+	if (
+		typeof value !== 'object' ||
+		value === null ||
+		Array.isArray( value ) ||
+		Object.keys( value ).length === 0
+	) {
+		return true;
+	}
+	const uri = typeof value.uri === 'string' ? value.uri.trim() : '';
+	return uri === '';
+}
+
+function isIncomingMediaFieldEmpty( fieldName, value ) {
+	if ( fieldName === 'canonical_media' ) {
+		return isEmptyCanonicalMedia( value );
+	}
+	if ( fieldName === 'canonical_image' ) {
+		return isEmptyCanonicalImage( value );
+	}
 	if ( value == null || value === '' ) {
 		return true;
 	}
@@ -32,7 +82,13 @@ function isIncomingMediaFieldEmpty( value ) {
 	return false;
 }
 
-function existingMediaFieldHasValue( value ) {
+function existingMediaFieldHasValue( fieldName, value ) {
+	if ( fieldName === 'canonical_media' ) {
+		return ! isEmptyCanonicalMedia( value );
+	}
+	if ( fieldName === 'canonical_image' ) {
+		return ! isEmptyCanonicalImage( value );
+	}
 	if ( value == null || value === '' ) {
 		return false;
 	}
@@ -45,6 +101,77 @@ function existingMediaFieldHasValue( value ) {
 		return false;
 	}
 	return true;
+}
+
+/**
+ * True when two posts are the same Reader item but may have different global_ID
+ * (e.g. single-post vs feed list responses). getPostByKey maps by feed/site keys, so
+ * duplicates must share merged media or the wrong copy wins in the selector.
+ */
+function postsMatchSameReaderItem( a, b ) {
+	if ( ! a || ! b || a.global_ID === b.global_ID ) {
+		return false;
+	}
+	const sameBlog =
+		a.site_ID && b.site_ID && a.ID && b.ID && a.site_ID === b.site_ID && a.ID === b.ID;
+	if ( sameBlog ) {
+		return true;
+	}
+	if ( ! a.feed_ID || ! b.feed_ID || a.feed_ID !== b.feed_ID ) {
+		return false;
+	}
+	const aItem = a.feed_item_ID;
+	const bItem = b.feed_item_ID;
+	if ( aItem && bItem && aItem === bItem ) {
+		return true;
+	}
+	const bIds = b.feed_item_IDs || [];
+	const aIds = a.feed_item_IDs || [];
+	if ( aItem && bIds.length && bIds.includes( aItem ) ) {
+		return true;
+	}
+	if ( bItem && aIds.length && aIds.includes( bItem ) ) {
+		return true;
+	}
+	return false;
+}
+
+function findSiblingPost( state, post ) {
+	if ( ! post?.global_ID ) {
+		return undefined;
+	}
+	for ( const candidate of Object.values( state ) ) {
+		if ( postsMatchSameReaderItem( post, candidate ) ) {
+			return candidate;
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Combine two store entries for the same logical post so spread(incoming) does not drop
+ * media that only exists on the sibling (different global_ID).
+ */
+function mergeDirectAndSiblingForMedia( direct, sibling ) {
+	const merged = { ...sibling, ...direct };
+	for ( const field of MEDIA_FIELDS_TO_PRESERVE ) {
+		if (
+			isIncomingMediaFieldEmpty( field, direct[ field ] ) &&
+			existingMediaFieldHasValue( field, sibling[ field ] )
+		) {
+			merged[ field ] = sibling[ field ];
+		}
+	}
+	return merged;
+}
+
+function resolveExistingPostForMerge( state, post ) {
+	const direct = state[ post.global_ID ];
+	const sibling = findSiblingPost( state, post );
+	if ( direct && sibling ) {
+		return mergeDirectAndSiblingForMedia( direct, sibling );
+	}
+	return direct || sibling;
 }
 
 /**
@@ -62,7 +189,7 @@ export function items( state = {}, action ) {
 			// Keep track of all the feed_item_ID that have the same global_ID.
 			// See: https://github.com/Automattic/wp-calypso/pull/88408
 			posts.forEach( ( post ) => {
-				const existing = state[ post.global_ID ];
+				const existing = resolveExistingPostForMerge( state, post );
 				const { feed_item_IDs = [] } = existing ?? {};
 				const { feed_item_ID, global_ID } = post;
 
@@ -71,8 +198,8 @@ export function items( state = {}, action ) {
 					merged = { ...existing, ...post };
 					for ( const field of MEDIA_FIELDS_TO_PRESERVE ) {
 						if (
-							isIncomingMediaFieldEmpty( post[ field ] ) &&
-							existingMediaFieldHasValue( existing[ field ] )
+							isIncomingMediaFieldEmpty( field, post[ field ] ) &&
+							existingMediaFieldHasValue( field, existing[ field ] )
 						) {
 							merged[ field ] = existing[ field ];
 						}

--- a/client/state/reader/posts/reducer.js
+++ b/client/state/reader/posts/reducer.js
@@ -10,6 +10,43 @@ import {
 } from 'calypso/state/reader/action-types';
 import { combineReducers } from 'calypso/state/utils';
 
+const MEDIA_FIELDS_TO_PRESERVE = [
+	'featured_image',
+	'canonical_media',
+	'canonical_image',
+	'post_thumbnail',
+];
+
+function isIncomingMediaFieldEmpty( value ) {
+	if ( value == null || value === '' ) {
+		return true;
+	}
+	if (
+		typeof value === 'object' &&
+		value !== null &&
+		! Array.isArray( value ) &&
+		Object.keys( value ).length === 0
+	) {
+		return true;
+	}
+	return false;
+}
+
+function existingMediaFieldHasValue( value ) {
+	if ( value == null || value === '' ) {
+		return false;
+	}
+	if (
+		typeof value === 'object' &&
+		value !== null &&
+		! Array.isArray( value ) &&
+		Object.keys( value ).length === 0
+	) {
+		return false;
+	}
+	return true;
+}
+
 /**
  * Tracks all known post objects, indexed by post ID.
  * @param  {Object} state  Current state
@@ -25,11 +62,25 @@ export function items( state = {}, action ) {
 			// Keep track of all the feed_item_ID that have the same global_ID.
 			// See: https://github.com/Automattic/wp-calypso/pull/88408
 			posts.forEach( ( post ) => {
-				const { feed_item_IDs = [] } = state[ post.global_ID ] ?? {};
+				const existing = state[ post.global_ID ];
+				const { feed_item_IDs = [] } = existing ?? {};
 				const { feed_item_ID, global_ID } = post;
 
+				let merged = { ...post };
+				if ( existing ) {
+					merged = { ...existing, ...post };
+					for ( const field of MEDIA_FIELDS_TO_PRESERVE ) {
+						if (
+							isIncomingMediaFieldEmpty( post[ field ] ) &&
+							existingMediaFieldHasValue( existing[ field ] )
+						) {
+							merged[ field ] = existing[ field ];
+						}
+					}
+				}
+
 				postsByKey[ global_ID ] = {
-					...post,
+					...merged,
 					...( feed_item_ID && {
 						feed_item_IDs: feed_item_IDs.length
 							? [ ...new Set( [ ...feed_item_IDs, feed_item_ID ] ) ]

--- a/client/state/reader/posts/test/reducer.js
+++ b/client/state/reader/posts/test/reducer.js
@@ -48,6 +48,74 @@ describe( 'reducer', () => {
 
 			expect( nextState.b.canonical_media ).toEqual( canonical );
 		} );
+
+		test( 'should preserve canonical_media when incoming has empty src', () => {
+			const good = {
+				mediaType: 'image',
+				src: 'https://good.example/img.jpg',
+				width: 100,
+				height: 100,
+			};
+			const posts = [ { global_ID: 'c', canonical_media: { mediaType: 'image', src: '' } } ];
+			const prevState = { c: { global_ID: 'c', canonical_media: good } };
+			const nextState = items( prevState, receivePosts( posts ) );
+
+			expect( nextState.c.canonical_media ).toEqual( good );
+		} );
+
+		test( 'should preserve canonical_media when incoming image omits src', () => {
+			const good = {
+				mediaType: 'image',
+				src: 'https://good.example/img.jpg',
+				width: 200,
+				height: 150,
+			};
+			const posts = [ { global_ID: 'd', canonical_media: { mediaType: 'image' } } ];
+			const prevState = { d: { global_ID: 'd', canonical_media: good } };
+			const nextState = items( prevState, receivePosts( posts ) );
+
+			expect( nextState.d.canonical_media ).toEqual( good );
+		} );
+
+		test( 'should preserve canonical_image when incoming has empty uri', () => {
+			const good = { uri: 'https://good.example/thumb.jpg', width: 50, height: 50 };
+			const posts = [ { global_ID: 'e', canonical_image: { uri: '', width: 0, height: 0 } } ];
+			const prevState = { e: { global_ID: 'e', canonical_image: good } };
+			const nextState = items( prevState, receivePosts( posts ) );
+
+			expect( nextState.e.canonical_image ).toEqual( good );
+		} );
+
+		test( 'should pull media from sibling post with different global_ID for same feed item', () => {
+			const fullFromSingle = {
+				global_ID: 'aaa',
+				feed_ID: 1,
+				feed_item_ID: 99,
+				site_ID: 2,
+				ID: 3,
+				featured_image: 'https://example.com/hero.jpg',
+				canonical_media: {
+					mediaType: 'image',
+					src: 'https://example.com/hero.jpg',
+					width: 100,
+					height: 100,
+				},
+			};
+			const thinFromStream = {
+				global_ID: 'bbb',
+				feed_ID: 1,
+				feed_item_ID: 99,
+				site_ID: 2,
+				ID: 3,
+				featured_image: '',
+				canonical_media: { mediaType: 'image', src: '' },
+			};
+			const prevState = { aaa: fullFromSingle };
+			const nextState = items( prevState, receivePosts( [ thinFromStream ] ) );
+
+			expect( nextState.bbb.featured_image ).toBe( 'https://example.com/hero.jpg' );
+			expect( nextState.bbb.canonical_media ).toEqual( fullFromSingle.canonical_media );
+		} );
 	} );
 
 	describe( '#seen()', () => {

--- a/client/state/reader/posts/test/reducer.js
+++ b/client/state/reader/posts/test/reducer.js
@@ -22,12 +22,31 @@ describe( 'reducer', () => {
 			} );
 		} );
 
-		test( 'should overwrite already existing post with a new one', () => {
-			const posts = [ { global_ID: 1 } ];
-			const prevState = { [ 1 ]: {} };
+		test( 'should merge incoming post with existing when global_ID matches', () => {
+			const posts = [ { global_ID: 1, title: 'Updated' } ];
+			const prevState = { 1: { global_ID: 1, title: 'Old' } };
 			const nextState = items( prevState, receivePosts( posts ) );
 
-			expect( nextState ).toEqual( { 1: posts[ 0 ] } );
+			expect( nextState ).toEqual( { 1: { global_ID: 1, title: 'Updated' } } );
+		} );
+
+		test( 'should preserve featured_image when incoming post has empty string', () => {
+			const posts = [ { global_ID: 'a', featured_image: '' } ];
+			const prevState = {
+				a: { global_ID: 'a', featured_image: 'https://example.com/hero.jpg' },
+			};
+			const nextState = items( prevState, receivePosts( posts ) );
+
+			expect( nextState.a.featured_image ).toBe( 'https://example.com/hero.jpg' );
+		} );
+
+		test( 'should preserve canonical_media when incoming omits it', () => {
+			const canonical = { mediaType: 'image', src: 'https://example.com/hero.jpg' };
+			const posts = [ { global_ID: 'b' } ];
+			const prevState = { b: { global_ID: 'b', canonical_media: canonical } };
+			const nextState = items( prevState, receivePosts( posts ) );
+
+			expect( nextState.b.canonical_media ).toEqual( canonical );
 		} );
 	} );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* client/state/reader/posts/reducer.js: On READER_POSTS_RECEIVE, merge incoming posts so media fields (featured_image, canonical_media, canonical_image, post_thumbnail) are not replaced when the payload’s value is effectively empty but an existing store entry (or a sibling entry for the same feed item / same site post under a different global_ID) already has usable media. Helpers distinguish empty canonical media/image objects from real ones so stream-normalized posts do not clobber richer single-post data.
* Tests: client/state/reader/posts/test/reducer.js updated for the new merge behavior.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The feed response overwrites details that are set from the full post response. Instead of overwriting existing values with empty values, we can merge and retain existing media fields.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to */reader/feeds/135089632/posts/5836212907
* Verify the featured image is present.
* Click the site name link at the top to navigate to the feed page (my staging website)
* On the feed page, scroll down until you find the same post ("Happy Day 2nd")
* Verify there is an image shown in the card. (before this change there wasn't)
* Click the post card to load full post again.
* Verify the featured image is still present. (before this change it wasn't).

Note - Obviously this surfaces a larger issue with the feed response not returning the expected images. That will be resolved separately on the backend. While that can resolve the flow on its own, this PR still may serve as a potential fallback and prevent overwriting existing data with empty fields in other potential scenarios.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
