### PR TITLE
Change Claude action restrictions from 'automattor' to 'matticbot'

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,7 +18,7 @@ jobs:
     if: |
       (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment') &&
       contains(github.event.comment.body, '@claude') &&
-      github.event.comment.user.login == 'automattor'
+      github.event.comment.user.login == 'matticbot'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

The actual bot in Calypso is @matticbot. This PR fixes that mistake.

## Proposed Changes

* Change Claude action restrictions from 'automattor' to 'matticbot'
