### PR TITLE
Reader: Add last published time on Recent menu

### DIFF
--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -305,10 +305,6 @@ $brand-text: "SF Pro Text", $sans;
 		}
 	}
 
-	.is-section-reader & .sidebar__menu-item-siteicon {
-		margin-inline-end: 12px;
-	}
-
 	.sidebar__menu .sidebar__heading {
 		outline: none;
 	}

--- a/client/reader/sidebar/reader-sidebar-organizations/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-organizations/list-item.jsx
@@ -40,7 +40,7 @@ export class ReaderSidebarOrganizationsListItem extends Component {
 					href={ `/reader/feeds/${ site.feed_ID }` }
 					onClick={ this.handleSidebarClick }
 				>
-					<Favicon site={ site } className="sidebar__menu-item-siteicon" size={ 16 } />
+					<Favicon site={ site } className="sidebar__menu-item-site-icon" size={ 22 } />
 
 					<span className="sidebar__menu-item-sitename">
 						<AutoDirection>

--- a/client/reader/sidebar/reader-sidebar-organizations/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-organizations/list.jsx
@@ -1,5 +1,6 @@
 import page from '@automattic/calypso-router';
 import { Count } from '@automattic/components';
+import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { map } from 'lodash';
 import PropTypes from 'prop-types';
@@ -95,11 +96,11 @@ export class ReaderSidebarOrganizationsList extends Component {
 				expandableIconClick={ this.toggleMenu }
 				customIcon={ this.renderIcon() }
 				disableFlyout
-				className={
-					( '/reader/' + organization.slug === path ||
-						sites.some( ( site ) => `/reader/feeds/${ site.feed_ID }` === path ) ) &&
-					'sidebar__menu--selected'
-				}
+				className={ clsx( 'has-counts', {
+					'sidebar__menu--selected':
+						'/reader/' + organization.slug === path ||
+						sites.some( ( site ) => `/reader/feeds/${ site.feed_ID }` === path ),
+				} ) }
 			>
 				{ this.renderAll() }
 				{ this.renderSites() }

--- a/client/reader/sidebar/reader-sidebar-recent/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-recent/index.tsx
@@ -6,6 +6,7 @@ import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import ReaderIcon from 'calypso/assets/icons/reader/reader-icon';
 import AutoDirection from 'calypso/components/auto-direction';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
 import Favicon from 'calypso/reader/components/favicon';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
@@ -52,6 +53,7 @@ const ReaderSidebarRecent = ( {
 	const [ showAllSites, setShowAllSites ] = useState( false );
 	const sites = useSelector< AppState, Site[] >( getReaderFollowedSites );
 	const selectedSiteFeedId = useSelector< AppState, number | null >( getSelectedRecentFeedId );
+	const moment = useLocalizedMoment();
 	const recordReaderTracksEvent = useRecordReaderTracksEvent();
 	const isRecentStream = RECENT_PATH_REGEX.test( path );
 
@@ -131,9 +133,14 @@ const ReaderSidebarRecent = ( {
 							className={ clsx( 'reader-sidebar-recent__item sidebar__menu-link' ) }
 							onClick={ () => trackMenuClick( site.feed_ID ) }
 						>
-							<Favicon site={ site } className="reader-sidebar-recent__site-icon" size={ 24 } />
+							<Favicon site={ site } className="sidebar__menu-item-site-icon" size={ 22 } />
 							<span title={ site.name } className="reader-sidebar-recent__site-name">
-								{ site.name }
+								<span>{ site.name }</span>
+								{ site.last_updated > 0 && (
+									<span className="sidebar__menu-item-last-updated">
+										{ moment( new Date( site.last_updated ) ).fromNow() }
+									</span>
+								) }
 							</span>
 						</MenuItemLink>
 					</AutoDirection>

--- a/client/reader/sidebar/reader-sidebar-recent/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-recent/index.tsx
@@ -134,7 +134,7 @@ const ReaderSidebarRecent = ( {
 							onClick={ () => trackMenuClick( site.feed_ID ) }
 						>
 							<Favicon site={ site } className="sidebar__menu-item-site-icon" size={ 22 } />
-							<span title={ site.name } className="reader-sidebar-recent__site-name">
+							<span title={ site.name } className="sidebar__menu-item-sitename">
 								<span>{ site.name }</span>
 								{ site.last_updated > 0 && (
 									<span className="sidebar__menu-item-last-updated">

--- a/client/reader/sidebar/reader-sidebar-recent/style.scss
+++ b/client/reader/sidebar/reader-sidebar-recent/style.scss
@@ -1,19 +1,9 @@
 .reader-sidebar-recent {
-	$recent-item-padding-x: 18px;
-	$recent-site-icon-size: 16px;
-	$recent-item-gap: 8px;
-
 	&__site {
 		&-name {
 			overflow: hidden;
 			white-space: nowrap;
 			text-overflow: ellipsis;
-		}
-
-		&-icon {
-			border-radius: 50%;
-			width: $recent-site-icon-size;
-			height: $recent-site-icon-size;
 		}
 
 		&-count {

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -205,6 +205,7 @@ body.is-section-reader {
 		outline-color: currentColor;
 		color: currentColor;
 		margin: 0 auto;
+		align-self: self-start;
 	}
 
 	.sidebar__menu-link:hover .count {
@@ -228,7 +229,6 @@ body.is-section-reader {
 		font-size: 0.67rem; /* stylelint-disable-line scales/font-sizes */
 		font-style: italic;
 		color: var( --color-sidebar-text-alternative );
-		line-height: 14px;
 	}
 
 	.sidebar__separator {
@@ -237,11 +237,9 @@ body.is-section-reader {
 
 	.sidebar__menu-item-sitename {
 		line-height: 14px;
-		max-width: 80%;
 		text-overflow: ellipsis;
 		white-space: nowrap;
 		overflow: hidden;
-		margin-right: 8px;
 
 		// If the site name is marked with ltr or rtl, ensure we use that directionality.
 		&:has( span[direction='ltr'] ) {

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -24,7 +24,7 @@
 			font-size: 32px;
 			font-style: normal;
 			font-weight: 400;
-			line-height: normal;;
+			line-height: normal;
 		}
 		p {
 			display: none;
@@ -219,10 +219,7 @@ body.is-section-reader {
 		color: var( --color-sidebar-menu-selected-text );
 	}
 
-	.sidebar__menu-item-siteicon {
-		margin-right: 15px;
-		position: relative;
-		flex-shrink: 0;
+	.sidebar__menu-item-site-icon {
 		border-radius: 4px;
 	}
 
@@ -231,6 +228,7 @@ body.is-section-reader {
 		font-size: 0.67rem; /* stylelint-disable-line scales/font-sizes */
 		font-style: italic;
 		color: var( --color-sidebar-text-alternative );
+		line-height: 14px;
 	}
 
 	.sidebar__separator {
@@ -291,11 +289,16 @@ body.is-section-reader {
 			}
 			margin-bottom: 16px;
 		}
+
+		&.has-counts .sidebar__menu-link {
+			grid-template-columns: 24px 1fr 36px;
+		}
+
 		.sidebar__menu-link {
 			display: grid;
-			grid-template-columns: 24px 1fr 36px;
+			grid-template-columns: 24px 1fr;
 			align-items: center;
-			gap: 4px;
+			gap: 6px;
 			line-height: 1.5;
 			padding: 12px 10px 12px 18px;
 			box-sizing: content-box;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes: [READ-362](https://linear.app/a8c/issue/READ-362/reader-improve-ordering-of-recent-dropdown-in-discussion)

## Proposed Changes

- Add last_updated time on Recent menu.
- Increase size of site icon on sidebar from `16px` to `22px`.
- Improve spacing of menu items i.e. different spacing on menu items with counts and without counts.

| Before | After |
| -------|------| 
| <img width="250" height="357" alt="image" src="https://github.com/user-attachments/assets/e298720a-b440-465c-a3eb-0d41de361118" /> | <img width="251" height="399" alt="image" src="https://github.com/user-attachments/assets/04807c8a-2cc9-490c-9177-cef59aaad5b8" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The discussion started from how can we improve ordering on Recent menu and then we decided to just show how the list is ordered.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to /reader
1. Verify you can see the last_updated time
1. Verify style tweaks looks good (large icon, better spacings)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
