### PR TITLE
Revert "Docker Image: Publish refreshed cache-seed images inline from trunk app builds (#109590)"

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -260,7 +260,6 @@ object BuildDockerImage : BuildType({
 			--build-arg cache_mode=%cache_mode%
 			--build-arg base_image=%base_image%
 			--build-arg cache_seed_image=%cache_seed_image%
-			--build-arg cache_seed_key=%CACHE_SEED_KEY%
 			--build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber}
 			--build-arg profile=%PROFILE%
 			--build-arg manual_sentry_release=%MANUAL_SENTRY_RELEASE%
@@ -338,9 +337,10 @@ object BuildDockerImage : BuildType({
 			""".trimIndent()
 		}
 
-		// Base-image cache rebuilding remains disabled by default because it is slow
-		// enough to risk trunk timeouts. Seed-mode inline refresh is handled below,
-		// while the base flow stays available as a manual fallback.
+		// TODO: Cache rebuilding is currently disabled. It takes a long time and
+		// causes timeouts on trunk. It needs to run more quickly to be worth it.
+		// For now, the cache will be rebuilt a couple times a day by the dedicated
+		// cache build.
 
 		// Conditions don't seem to support and/or, so we do this in a separate step.
 		// Essentially, UPDATE_BASE_IMAGE_CACHE will remain false by default, but
@@ -395,49 +395,10 @@ object BuildDockerImage : BuildType({
 				namesAndTags = "registry.a8c.com/calypso/base:%base_image_publish_tag%"
 			}
 		}
-
-		dockerCommand {
-			name = "Rebuild cache-seed image"
-			conditions {
-				equals("cache_mode", "seed")
-				equals("UPDATE_CACHE_SEED", "true")
-				equals("teamcity.build.branch.is_default", "true")
-			}
-			commandType = build {
-				source = file {
-					path = "Dockerfile"
-				}
-				namesAndTags = """
-					registry.a8c.com/calypso/cache-seed:latest
-					registry.a8c.com/calypso/cache-seed:build-%build.number%
-				""".trimIndent()
-				commandArgs = """
-					--target update-cache-seed
-					--cache-from=registry.a8c.com/calypso/app:commit-${Settings.WpCalypso.paramRefs.buildVcsNumber},%cache_seed_image%
-					$commonArgs
-				""".trimIndent().replace("\n"," ")
-			}
-			param("dockerImage.platform", "linux")
-		}
-
-		dockerCommand {
-			name = "Push cache-seed image"
-			conditions {
-				equals("cache_mode", "seed")
-				equals("UPDATE_CACHE_SEED", "true")
-				equals("teamcity.build.branch.is_default", "true")
-			}
-			commandType = push {
-				namesAndTags = """
-					registry.a8c.com/calypso/cache-seed:latest
-					registry.a8c.com/calypso/cache-seed:build-%build.number%
-				""".trimIndent()
-			}
-		}
 	}
 
 	failureConditions {
-		executionTimeoutMin = 26
+		executionTimeoutMin = 20
 	}
 
 	features {

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ ARG cache_mode=base
 ARG node_version=22.9.0
 ARG base_image=registry.a8c.com/calypso/base:latest
 ARG cache_seed_image=registry.a8c.com/calypso/cache-seed:latest
-ARG cache_seed_key="(unknown)"
 
 ###################
 FROM node:${node_version}-bullseye-slim AS builder-cache-none
@@ -150,18 +149,6 @@ FROM ${base_image} AS update-base-cache
 # We only copy this part of the cache to make --push faster, and because webpack
 # is the main thing which will impact build performance when the cache invalidates.
 COPY --from=builder /calypso/.cache/evergreen/webpack /calypso/.cache/evergreen/webpack
-
-###################
-# A cache-only update can be generated with "docker build --target update-cache-seed"
-FROM scratch AS update-cache-seed
-ARG commit_sha
-ARG cache_seed_key
-
-LABEL org.opencontainers.image.revision=$commit_sha \
-	io.calypso.cache-seed-key=$cache_seed_key
-
-COPY --from=builder /calypso/.cache /calypso/.cache
-COPY --from=builder /calypso/.yarn /calypso/.yarn
 
 ###################
 FROM node:${node_version}-alpine AS app


### PR DESCRIPTION
I don't know if the revert is needed, but I am preparing it in case it is.


Part of #

## Proposed Changes

*

## Why are these changes being made?

*

## Testing Instructions


*

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
