### PR TITLE
Podcasting: set Page component height to 100%

### DIFF
--- a/client/my-sites/site-settings/podcasting-details/style.scss
+++ b/client/my-sites/site-settings/podcasting-details/style.scss
@@ -4,14 +4,31 @@ body.is-section-settings-podcasting {
 	@include admin-ui-page-layout;
 	@include admin-ui-page-layout-constrained-content;
 
-	.layout,
-	.layout__content,
-	.layout__primary {
-		height: 100%;
-	}
+	.layout__content {
+		display: flex;
 
-	.layout__primary .main {
-		height: 100%;
+		.layout__primary {
+			flex: 1;
+			display: flex;
+
+			.main {
+				margin: 0;
+				flex-grow: 1;
+				position: relative;
+				padding-bottom: 65px;
+
+				.jetpack-footer {
+					position: fixed;
+					z-index: 1;
+					bottom: 0;
+					background-color: var( --wpds-color-bg-surface-neutral );
+
+					@include break-medium {
+						max-width: calc( 100% - var( --sidebar-width-max ) );
+					}
+				}
+			}
+		}
 	}
 }
 

--- a/client/my-sites/site-settings/podcasting-details/style.scss
+++ b/client/my-sites/site-settings/podcasting-details/style.scss
@@ -3,6 +3,16 @@
 body.is-section-settings-podcasting {
 	@include admin-ui-page-layout;
 	@include admin-ui-page-layout-constrained-content;
+
+	.layout,
+	.layout__content,
+	.layout__primary {
+		height: 100%;
+	}
+
+	.layout__primary .main {
+		height: 100%;
+	}
 }
 
 .podcasting-details__publish-wrapper {

--- a/client/my-sites/site-settings/podcasting-details/style.scss
+++ b/client/my-sites/site-settings/podcasting-details/style.scss
@@ -64,6 +64,11 @@ body.is-section-settings-podcasting {
 	display: flex;
 	gap: 24px;
 	margin-bottom: 16px;
+	flex-direction: column;
+
+	@include break-medium {
+		flex-direction: row;
+	}
 
 	.podcast-cover-image-setting {
 		flex-shrink: 0;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Follow-up to JETPACK-1365
Follow-up to https://github.com/Automattic/wp-calypso/pull/108878
Related to JETPACK-1475


## Proposed Changes

* Sets page heights to take full space to fill the background with the Page component, and to accommodate future footer addition.

### Before
<img width="1260" height="1139" alt="Screenshot 2026-03-26 at 18 28 23" src="https://github.com/user-attachments/assets/688b392b-6d0b-46bb-a8f1-8e8168bfbc61" />


### After
<img width="1259" height="1142" alt="Screenshot 2026-03-26 at 18 27 48" src="https://github.com/user-attachments/assets/f2f64c38-3ba7-48a2-88a4-71d9315d2dac" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
