### PR TITLE
A4A: Add missing Pressable 64GB  storage addon plan data.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
@@ -559,6 +559,13 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		storage: 32,
 		category: PRODUCT_CATEGORY_PRESSABLE_ADDON,
 	},
+	'pressable-addon-storage-64gb': {
+		slug: 'pressable-addon-storage-64gb',
+		install: 0,
+		visits: 0,
+		storage: 64,
+		category: PRODUCT_CATEGORY_PRESSABLE_ADDON,
+	},
 };
 
 export default function getPressablePlan( slug: string ) {


### PR DESCRIPTION
Context: p1774543485253759/1774537425.088089-slack-C047ACYM8UQ

## Proposed Changes
This pull request adds a new 64GB storage add-on option to the available Pressable plans. This allows users to select a plan with increased storage capacity.

New plan addition:

* Added a new entry for the `pressable-addon-storage-64gb` plan with 64GB storage to the `PLAN_DATA` record in `get-pressable-plan.ts`.

## Why are these changes being made?

* This is needed for the UI to calculate Pressable usage coverage that includes the addon.

## Testing Instructions

* Use the A4A live link and go to the Marketplace products section.
* Purchase a Pressable 64GB addon.
* Confirm that the addon is added to your Max Storage.

e.g.

| Before | After |
|--------|--------|
| <img width="1158" height="330" alt="Screenshot 2026-03-27 at 12 56 38 AM" src="https://github.com/user-attachments/assets/8c95512d-cdaa-4eff-bf66-f9f75e606187" /> | <img width="1093" height="318" alt="Screenshot 2026-03-27 at 12 56 54 AM" src="https://github.com/user-attachments/assets/9649d886-21b4-4df7-ae1f-3b08ea69db9b" /> | 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?