### PR TITLE
Podcasting: fix gap between masterbar and header

### DIFF
--- a/client/my-sites/site-settings/podcasting-details/style.scss
+++ b/client/my-sites/site-settings/podcasting-details/style.scss
@@ -2,8 +2,15 @@
 @import '@wordpress/admin-ui/build-style/style.css';
 
 body.is-section-settings-podcasting {
+
+	@media screen and (max-width: breakpoints.$break-small) {
+		.focus-content:not(.has-no-sidebar):not(.has-no-masterbar) .layout__content {
+			padding-top: var(--masterbar-height);
+		}
+	}
+
 	.layout:not(.has-no-sidebar) .layout__content {
-		padding: calc(var(--masterbar-height)) 0 0 calc(var(--sidebar-width-max));
+		padding: var(--masterbar-height) 0 0 var(--sidebar-width-max);
 
 		// Full width when sidebar is collapsed
 		@media ( max-width: breakpoints.$break-medium ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Follow-up to JETPACK-1365
Follow-up to https://github.com/Automattic/wp-calypso/pull/108878


## Proposed Changes

* Fix gap below masterbar on mobile

### Before
<img width="437" height="377" alt="Screenshot 2026-03-26 at 18 44 32" src="https://github.com/user-attachments/assets/9938ef5c-3169-4f9e-b1e4-0f05a3043895" />


### After
<img width="425" height="881" alt="Screenshot 2026-03-26 at 18 40 54" src="https://github.com/user-attachments/assets/85cae80c-2c3d-4a0a-9261-15680da2eabd" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* See podcasting page on different screen widths

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
