### PR TITLE
Extract shared admin-ui page layout mixin

### DIFF
--- a/client/components/jetpack-page-layout/_admin-ui-page.scss
+++ b/client/components/jetpack-page-layout/_admin-ui-page.scss
@@ -1,0 +1,45 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/admin-ui/build-style/style.css";
+
+// Shared layout overrides for pages using @wordpress/admin-ui Page component.
+// Usage: @include admin-ui-page-layout;
+// Must be called inside a `body.is-section-<name>` selector.
+@mixin admin-ui-page-layout {
+	@media screen and (max-width: $break-small) {
+		.focus-content:not(.has-no-sidebar):not(.has-no-masterbar) .layout__content {
+			padding-top: var(--masterbar-height);
+		}
+	}
+
+	.layout:not(.has-no-sidebar) .layout__content {
+		padding: var(--masterbar-height) 0 0 var(--sidebar-width-max);
+
+		@media (max-width: $break-medium) {
+			padding-left: 0;
+		}
+	}
+
+	.layout__primary .main {
+		padding-bottom: 0;
+	}
+}
+
+// Constrain admin-ui Page content to 660px centered.
+// Pass a $scope selector to limit to specific page variants (e.g. upsell pages).
+// Usage:
+//   @include admin-ui-page-layout-constrained-content;           // always constrained
+//   @include admin-ui-page-layout-constrained-content('.my-upsell'); // only within .my-upsell
+@mixin admin-ui-page-layout-constrained-content($scope: null) {
+	$parent: if($scope, "#{$scope} .admin-ui-page__content", ".admin-ui-page__content");
+
+	// Temporarily here until constrained content width is implemented in Admin-UI
+	#{$parent} {
+		> * {
+			max-width: 660px;
+			width: 100%;
+			margin-left: auto;
+			margin-right: auto;
+			box-sizing: border-box;
+		}
+	}
+}

--- a/client/my-sites/site-settings/podcasting-details/style.scss
+++ b/client/my-sites/site-settings/podcasting-details/style.scss
@@ -1,36 +1,8 @@
-@use '@wordpress/base-styles/breakpoints' as breakpoints;
-@import '@wordpress/admin-ui/build-style/style.css';
+@import "calypso/components/jetpack-page-layout/admin-ui-page";
 
 body.is-section-settings-podcasting {
-
-	@media screen and (max-width: breakpoints.$break-small) {
-		.focus-content:not(.has-no-sidebar):not(.has-no-masterbar) .layout__content {
-			padding-top: var(--masterbar-height);
-		}
-	}
-
-	.layout:not(.has-no-sidebar) .layout__content {
-		padding: var(--masterbar-height) 0 0 var(--sidebar-width-max);
-
-		// Full width when sidebar is collapsed
-		@media ( max-width: breakpoints.$break-medium ) {
-			padding-left: 0;
-		}
-	}
-
-	.layout__primary .main {
-		padding-bottom: 0;
-	}
-
-	// Tempoarily here until constrained content width is implemented in Admin-UI
-	.admin-ui-page__content {
-		> * {
-			max-width: 660px;
-			width: 100%;
-			margin: 0 auto;
-			box-sizing: border-box;
-		}
-	}
+	@include admin-ui-page-layout;
+	@include admin-ui-page-layout-constrained-content;
 }
 
 .podcasting-details__publish-wrapper {


### PR DESCRIPTION
Part of JETPACK-1361

## Proposed Changes

* Creates shared SCSS mixins at `client/components/jetpack-page-layout/_admin-ui-page.scss` for pages migrating to `@wordpress/admin-ui` Page component
* `admin-ui-page-layout` mixin: layout padding overrides, mobile sidebar collapse handling, masterbar padding fix for focus-content on small screens
* `admin-ui-page-layout-constrained-content($scope)` mixin: optional 660px max-width content constraint with scope parameter for targeting specific page variants (e.g. upsell pages only)
* Refactors Podcasting page to use the shared mixin, replacing inline CSS

## Why are these changes being made?

* All Jetpack pages migrating to admin-ui Page need the same layout CSS overrides. This mixin avoids duplicating ~30 lines of CSS per page.

## Testing Instructions

* Navigate to `/settings/podcasting/<site-slug>` — verify layout looks the same as before (header, content width, mobile responsiveness)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
