### PR TITLE
Traffic: Migrate header to admin-ui Page

### DIFF
--- a/client/my-sites/marketing/controller.js
+++ b/client/my-sites/marketing/controller.js
@@ -121,6 +121,7 @@ export const sharingButtons = ( context, next ) => {
 };
 
 export const traffic = ( context, next ) => {
+	context.section.name = 'marketing-traffic';
 	context.primary = createElement( Traffic );
 
 	next();

--- a/client/sites/marketing/traffic/style.scss
+++ b/client/sites/marketing/traffic/style.scss
@@ -1,3 +1,10 @@
+@import "calypso/components/jetpack-page-layout/admin-ui-page";
+
+body.is-section-marketing {
+	@include admin-ui-page-layout;
+	@include admin-ui-page-layout-constrained-content;
+}
+
 .site-settings {
 	font-size: $font-body-small;
 

--- a/client/sites/marketing/traffic/style.scss
+++ b/client/sites/marketing/traffic/style.scss
@@ -1,6 +1,6 @@
 @import "calypso/components/jetpack-page-layout/admin-ui-page";
 
-body.is-section-marketing {
+body.is-section-marketing-traffic {
 	@include admin-ui-page-layout;
 	@include admin-ui-page-layout-constrained-content;
 }

--- a/client/sites/marketing/traffic/style.scss
+++ b/client/sites/marketing/traffic/style.scss
@@ -5,7 +5,7 @@ body.is-section-marketing-traffic {
 	@include admin-ui-page-layout-constrained-content;
 }
 
-.site-settings {
+.settings-traffic.site-settings {
 	font-size: $font-body-small;
 
 	fieldset {
@@ -140,6 +140,9 @@ body.is-section-marketing-traffic {
 		}
 	}
 
+	.card.promo-card-block {
+		display: flex;
+	}
 
 	.promo-card .button {
 		float: none;

--- a/client/sites/marketing/traffic/traffic.js
+++ b/client/sites/marketing/traffic/traffic.js
@@ -1,3 +1,4 @@
+import { Page } from '@wordpress/admin-ui';
 import { localize } from 'i18n-calypso';
 import { pick } from 'lodash';
 import { useEffect } from 'react';
@@ -11,7 +12,6 @@ import EmptyContent from 'calypso/components/empty-content';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
-import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import useAdvertisingUrl from 'calypso/my-sites/advertising/useAdvertisingUrl';
 import AnalyticsSettings from 'calypso/my-sites/site-settings/analytics/form-google-analytics';
@@ -54,13 +54,14 @@ const SiteSettingsTraffic = ( {
 
 	return (
 		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-		<Main wideLayout className="sharing">
+		<Main fullWidthLayout className="sharing">
 			<DocumentHead title={ translate( 'Traffic' ) } />
 			{ siteId && <QueryJetpackModules siteId={ siteId } /> }
-			<NavigationHeader
-				navigationItems={ [] }
+			<Page
+				hasPadding
+				showSidebarToggle={ false }
 				title={ <JetpackTitle title={ translate( 'Traffic' ) } /> }
-				subtitle={ translate(
+				subTitle={ translate(
 					'Manage settings and tools related to the traffic your website receives. {{learnMoreLink/}}',
 					{
 						components: {
@@ -70,64 +71,67 @@ const SiteSettingsTraffic = ( {
 						},
 					}
 				) }
-			/>
-			<div className="settings-traffic site-settings">
-				<PageViewTracker path="/marketing/traffic/:site" title="Jetpack > Traffic" />
-				{ ! isAdmin && (
-					<EmptyContent title={ translate( 'You are not authorized to view this page' ) } />
-				) }
-				<JetpackDevModeNotice />
-				{ isAdmin && shouldShowAdvertisingOption && (
-					<PromoCardBlock
-						productSlug="blaze"
-						impressionEvent="calypso_marketing_traffic_blaze_banner_view"
-						clickEvent="calypso_marketing_traffic_blaze_banner_click"
-						headerText={ translate( 'Reach new readers and customers' ) }
-						contentText={ translate(
-							'Use WordPress Blaze to increase your reach by promoting your work to the larger WordPress.com community of blogs and sites. '
-						) }
-						ctaText={ translate( 'Get started' ) }
-						image={ blazeIllustration }
-						href={ advertisingUrl }
-					/>
-				) }
-				{ isAdmin && <SeoSettingsHelpCard disabled={ isRequestingSettings || isSavingSettings } /> }
-				{ isAdmin && (
-					<AsyncLoad
-						key={ siteId }
-						require="calypso/my-sites/site-settings/seo-settings/form"
-						placeholder={ null }
-					/>
-				) }
-				{ isJetpackAdmin && (
-					<JetpackSiteStats
-						handleAutosavingToggle={ handleAutosavingToggle }
-						setFieldValue={ setFieldValue }
-						isSavingSettings={ isSavingSettings }
-						isRequestingSettings={ isRequestingSettings }
-						fields={ fields }
-					/>
-				) }
-				{ isAdmin && <AnalyticsSettings /> }
-				{ isJetpackAdmin && (
-					<Shortlinks
-						handleAutosavingRadio={ handleAutosavingRadio }
-						handleAutosavingToggle={ handleAutosavingToggle }
-						isSavingSettings={ isSavingSettings }
-						isRequestingSettings={ isRequestingSettings }
-						fields={ fields }
-						onSubmitForm={ handleSubmitForm }
-					/>
-				) }
-				{ isAdmin && (
-					<Sitemaps
-						isSavingSettings={ isSavingSettings }
-						isRequestingSettings={ isRequestingSettings }
-						fields={ fields }
-					/>
-				) }
-				{ isAdmin && <SiteVerification /> }
-			</div>
+			>
+				<div className="settings-traffic site-settings">
+					<PageViewTracker path="/marketing/traffic/:site" title="Jetpack > Traffic" />
+					{ ! isAdmin && (
+						<EmptyContent title={ translate( 'You are not authorized to view this page' ) } />
+					) }
+					<JetpackDevModeNotice />
+					{ isAdmin && shouldShowAdvertisingOption && (
+						<PromoCardBlock
+							productSlug="blaze"
+							impressionEvent="calypso_marketing_traffic_blaze_banner_view"
+							clickEvent="calypso_marketing_traffic_blaze_banner_click"
+							headerText={ translate( 'Reach new readers and customers' ) }
+							contentText={ translate(
+								'Use WordPress Blaze to increase your reach by promoting your work to the larger WordPress.com community of blogs and sites. '
+							) }
+							ctaText={ translate( 'Get started' ) }
+							image={ blazeIllustration }
+							href={ advertisingUrl }
+						/>
+					) }
+					{ isAdmin && (
+						<SeoSettingsHelpCard disabled={ isRequestingSettings || isSavingSettings } />
+					) }
+					{ isAdmin && (
+						<AsyncLoad
+							key={ siteId }
+							require="calypso/my-sites/site-settings/seo-settings/form"
+							placeholder={ null }
+						/>
+					) }
+					{ isJetpackAdmin && (
+						<JetpackSiteStats
+							handleAutosavingToggle={ handleAutosavingToggle }
+							setFieldValue={ setFieldValue }
+							isSavingSettings={ isSavingSettings }
+							isRequestingSettings={ isRequestingSettings }
+							fields={ fields }
+						/>
+					) }
+					{ isAdmin && <AnalyticsSettings /> }
+					{ isJetpackAdmin && (
+						<Shortlinks
+							handleAutosavingRadio={ handleAutosavingRadio }
+							handleAutosavingToggle={ handleAutosavingToggle }
+							isSavingSettings={ isSavingSettings }
+							isRequestingSettings={ isRequestingSettings }
+							fields={ fields }
+							onSubmitForm={ handleSubmitForm }
+						/>
+					) }
+					{ isAdmin && (
+						<Sitemaps
+							isSavingSettings={ isSavingSettings }
+							isRequestingSettings={ isRequestingSettings }
+							fields={ fields }
+						/>
+					) }
+					{ isAdmin && <SiteVerification /> }
+				</div>
+			</Page>
 		</Main>
 	);
 };


### PR DESCRIPTION
Resolves JETPACK-1383

Migrate the Traffic settings page to the admin-ui Page component with constrained content width.

### Before:
<img width="1154" height="680" alt="image" src="https://github.com/user-attachments/assets/7dc999c1-9038-4da3-98bd-27f2b0089fce" />
<img width="454" height="878" alt="image" src="https://github.com/user-attachments/assets/6a635f13-e252-4623-b4a3-0dea0fd4490d" />


### After:
<img width="1154" height="638" alt="image" src="https://github.com/user-attachments/assets/1c0467d6-c373-458b-a5ef-7a41ad4c6e5c" />
<img width="429" height="870" alt="image" src="https://github.com/user-attachments/assets/a04adf00-98dd-427c-ad0b-dcf9e290b141" />

