### PR TITLE
Monetize: Migrate header to admin-ui Page

### DIFF
--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -1,11 +1,11 @@
 import { localizeUrl } from '@automattic/i18n-utils';
+import { Page } from '@wordpress/admin-ui';
 import { useTranslate } from 'i18n-calypso';
 import { capitalize, find } from 'lodash';
 import DocumentHead from 'calypso/components/data/document-head';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
-import NavigationHeader from 'calypso/components/navigation-header';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
@@ -190,7 +190,7 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 
 	const getEarnSectionNav = () => {
 		return (
-			<div id="earn-navigation">
+			<div className="earn-navigation">
 				<SectionNav
 					selectedText={ getEarnSelectedText() }
 					variation={ ! isJetpackCloud() ? 'minimal' : '' }
@@ -241,8 +241,20 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 
 	const atomicLearnMoreLink = localizeUrl( 'https://wordpress.com/support/monetize-your-site/' );
 	const jetpackLearnMoreLink = localizeUrl( 'https://jetpack.com/support/monetize-your-site/' );
+	const showPageHeader = ! isSinglePaidSubscriptionSection( section );
+
+	const content = (
+		<>
+			{ showPageHeader && getEarnSectionNav() }
+			<div className="earn-content">
+				{ isAdSection( section ) && getAdsHeader() }
+				{ getComponent( section ) }
+			</div>
+		</>
+	);
+
 	return (
-		<Main wideLayout className="earn">
+		<Main fullWidthLayout={ showPageHeader } wideLayout={ ! showPageHeader } className="earn">
 			<PageViewTracker
 				path={ section ? `${ earnPath }/${ section }/:site` : `${ earnPath }/:site` }
 				title={ `${ adsProgramName } ${ capitalize( section ) }` }
@@ -250,33 +262,32 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 			<DocumentHead
 				title={ layoutTitles[ section as keyof typeof layoutTitles ] ?? translate( 'Monetize' ) }
 			/>
-			{ ! isSinglePaidSubscriptionSection( section ) && (
-				<>
-					<NavigationHeader
-						navigationItems={ [] }
-						title={ <JetpackTitle title={ translate( 'Monetize' ) } /> }
-						subtitle={ translate(
-							'Explore tools to earn money with your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-							{
-								components: {
-									learnMoreLink: isJetpackCloud() ? (
-										<a
-											href={ isJetpackNotAtomic ? jetpackLearnMoreLink : atomicLearnMoreLink }
-											target="_blank"
-											rel="noopener noreferrer"
-										/>
-									) : (
-										<InlineSupportLink supportContext="earn" showIcon={ false } />
-									),
-								},
-							}
-						) }
-					/>
-					{ getEarnSectionNav() }
-				</>
+			{ showPageHeader ? (
+				<Page
+					showSidebarToggle={ false }
+					title={ <JetpackTitle title={ translate( 'Monetize' ) } /> }
+					subTitle={ translate(
+						'Explore tools to earn money with your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						{
+							components: {
+								learnMoreLink: isJetpackCloud() ? (
+									<a
+										href={ isJetpackNotAtomic ? jetpackLearnMoreLink : atomicLearnMoreLink }
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								) : (
+									<InlineSupportLink supportContext="earn" showIcon={ false } />
+								),
+							},
+						}
+					) }
+				>
+					{ content }
+				</Page>
+			) : (
+				content
 			) }
-			{ isAdSection( section ) && getAdsHeader() }
-			{ getComponent( section ) }
 		</Main>
 	);
 };

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -9,7 +9,10 @@ body.is-section-earn {
 
 .earn-navigation {
 	.section-nav {
+		background: none;
+		box-shadow: none;
 		padding: 0 var(--wpds-dimension-padding-2xl, 24px);
+		border-bottom: var(--wpds-border-width-xs, 1px) solid var(--wpds-color-stroke-surface-neutral-weak, #e0e0e0);
 	}
 }
 

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -1,9 +1,24 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@automattic/components/src/styles/typography";
 @import "@wordpress/base-styles/mixins";
+@import "calypso/components/jetpack-page-layout/admin-ui-page";
 
-#earn-navigation {
-	margin-bottom: 30px;
+body.is-section-earn {
+	@include admin-ui-page-layout;
+}
+
+.earn-navigation {
+	.section-nav {
+		padding: 0 var(--wpds-dimension-padding-2xl, 24px);
+	}
+}
+
+.earn-content {
+	box-sizing: border-box;
+	margin: 0 auto;
+	max-width: 1040px;
+	padding: 24px;
+	width: 100%;
 }
 
 // Small override for card component headers
@@ -230,12 +245,5 @@ body:not(.theme-jetpack-cloud) {
 	max-width: 98%;
 	h1 {
 		margin-bottom: 1em;
-	}
-}
-
-/* Media Queries */
-@media (max-width: $break-large) {
-	.earn.main {
-		padding: 20px;
 	}
 }


### PR DESCRIPTION
Resolves JETPACK-1362

- Migrate the Monetise page to the admin-ui Page component. Content max-width overridden for full-width layout.
- Visually adjusts the tabs component to fit under the header.

### Before:
<img width="1242" height="672" alt="image" src="https://github.com/user-attachments/assets/1015c740-51e5-4abd-8947-13b739ee2fd8" />
<img width="1249" height="1205" alt="image" src="https://github.com/user-attachments/assets/68c40276-3261-4b87-baac-6a8944563eed" />



### After:
<img width="1473" height="1210" alt="Screenshot 2026-03-27 at 11 16 04" src="https://github.com/user-attachments/assets/20f3ad9a-ff66-4c8e-8cc2-af80c08e101b" />
<img width="1246" height="551" alt="Screenshot 2026-03-27 at 11 09 21" src="https://github.com/user-attachments/assets/420411ae-dc2a-46d3-914e-da150f70f60b" />
<img width="457" height="860" alt="image" src="https://github.com/user-attachments/assets/d2f57ba1-8486-4232-bd7d-fcf4b42ea03c" />

### Testing

- Test both WP.com and Jetpack Cloud versions
- Contents should not change visually (width, style)
