### PR TITLE
Checkout: Add Tracks event when contact validation fails

### DIFF
--- a/client/my-sites/checkout/src/lib/contact-validation.tsx
+++ b/client/my-sites/checkout/src/lib/contact-validation.tsx
@@ -161,7 +161,7 @@ export async function validateContactDetails(
 			reduxDispatch(
 				recordTracksEvent( 'calypso_checkout_contact_info_validation_failed', {
 					country: contactInfo.countryCode?.value,
-					messages: validationResult.messages_simple.join( ', ' ),
+					messages: validationResult.messages_simple?.join( ', ' ),
 				} )
 			);
 		}

--- a/client/my-sites/checkout/src/lib/contact-validation.tsx
+++ b/client/my-sites/checkout/src/lib/contact-validation.tsx
@@ -151,7 +151,21 @@ export async function validateContactDetails(
 				clearDomainContactErrorMessages,
 			} );
 		}
-		return isContactValidationResponseValid( validationResult );
+		const isValid = isContactValidationResponseValid( validationResult );
+		if (
+			! isValid &&
+			shouldDisplayErrors &&
+			isContactValidationResponse( validationResult ) &&
+			! validationResult.success
+		) {
+			reduxDispatch(
+				recordTracksEvent( 'calypso_checkout_contact_info_validation_failed', {
+					country: contactInfo.countryCode?.value,
+					messages: validationResult.messages_simple.join( ', ' ),
+				} )
+			);
+		}
+		return isValid;
 	};
 
 	if ( isLoggedOutCart ) {
@@ -171,6 +185,13 @@ export async function validateContactDetails(
 		}
 
 		if ( ! isContactValidationResponseValid( loggedOutValidationResult ) ) {
+			if ( shouldDisplayErrors ) {
+				reduxDispatch(
+					recordTracksEvent( 'calypso_checkout_contact_email_validation_failed', {
+						country: contactInfo.countryCode?.value,
+					} )
+				);
+			}
 			return false;
 		}
 	}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1814/checkout-add-tracks-event-when-contact-validation-fails

## Proposed Changes

This adds new Tracks events, `calypso_checkout_contact_info_validation_failed` and `calypso_checkout_contact_email_validation_failed`, for when a user clicks to complete the contact step of checkout and the validation fails.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This will help us track how people move through checkout. It was requested here: https://linear.app/a8c/issue/SHILL-1751/implement-checkout-ui-redesign-variant-changes#comment-708037d9

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Add a product to your cart and visit checkout.
- Open your browser's devtools to the console and type `localStorage.debug = 'calypso:analytics';` then press Enter. This will make analytics logs show up in your console when they happen.
- Reload the checkout page to make sure the debug setting takes effect.
- If necessary, click to edit the billing info/contact info step.
- Enter invalid contact details (eg: an invalid US postal code like `ABCD`) and click to continue to the next step.
- Verify you see an error displayed on the invalid field(s).
- Verify you see the Tracks event `calypso_checkout_contact_info_validation_failed` in the console (note that you'll see all events twice but this is normal; the logs are slightly different if you look closely).

<img width="1512" height="982" alt="Screenshot 2026-03-26 at 4 57 09 PM" src="https://github.com/user-attachments/assets/f32a7732-3951-4fa2-8884-89b56df80e88" />

