### PR TITLE
Dashboard: Show expired plan banner and disable Manage store for CIAB sites

### DIFF
--- a/client/dashboard/sites/overview/ciab-plan-expired-banner.tsx
+++ b/client/dashboard/sites/overview/ciab-plan-expired-banner.tsx
@@ -2,13 +2,11 @@ import { siteCurrentPlanQuery, purchaseQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
-import { addQueryArgs } from '@wordpress/url';
 import { useLocale } from '../../app/locale';
-import { getCurrentDashboard } from '../../app/routing';
 import Notice from '../../components/notice';
 import { formatDate } from '../../utils/datetime';
-import { wpcomLink } from '../../utils/link';
 import { isCommerceGarden, isCommerceGardenPlanExpired } from '../../utils/site-types';
+import { getSitePlanUpgradeUrl } from '../../utils/site-url';
 import type { Site } from '@automattic/api-core';
 
 export function CiabPlanExpiredBanner( { site }: { site: Site } ) {
@@ -28,10 +26,7 @@ export function CiabPlanExpiredBanner( { site }: { site: Site } ) {
 		return null;
 	}
 
-	const plansUrl = addQueryArgs( wpcomLink( '/setup/woo-hosted-plans' ), {
-		siteSlug: site.slug,
-		dashboard: getCurrentDashboard(),
-	} );
+	const plansUrl = getSitePlanUpgradeUrl( site );
 
 	const gracePeriodDate = purchase?.expiry_date
 		? new Date( new Date( purchase.expiry_date ).getTime() + 30 * 24 * 60 * 60 * 1000 )

--- a/client/dashboard/sites/overview/ciab-plan-expired-banner.tsx
+++ b/client/dashboard/sites/overview/ciab-plan-expired-banner.tsx
@@ -1,0 +1,66 @@
+import { siteCurrentPlanQuery, purchaseQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { Button } from '@wordpress/components';
+import { sprintf, __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+import { useLocale } from '../../app/locale';
+import { getCurrentDashboard } from '../../app/routing';
+import Notice from '../../components/notice';
+import { formatDate } from '../../utils/datetime';
+import { wpcomLink } from '../../utils/link';
+import { isCommerceGarden } from '../../utils/site-types';
+import type { Site } from '@automattic/api-core';
+
+export function CiabPlanExpiredBanner( { site }: { site: Site } ) {
+	const locale = useLocale();
+	const isExpired = isCommerceGarden( site ) && site.plan?.expired;
+
+	const { data: plan } = useQuery( {
+		...siteCurrentPlanQuery( site.ID ),
+		enabled: !! isExpired,
+	} );
+	const { data: purchase } = useQuery( {
+		...purchaseQuery( plan?.id ?? 0 ),
+		enabled: !! isExpired && !! plan?.id,
+	} );
+
+	if ( ! isExpired ) {
+		return null;
+	}
+
+	const plansUrl = addQueryArgs( wpcomLink( '/setup/woo-hosted-plans' ), {
+		siteSlug: site.slug,
+		dashboard: getCurrentDashboard(),
+	} );
+
+	const gracePeriodDate = purchase?.expiry_date
+		? new Date( new Date( purchase.expiry_date ).getTime() + 30 * 24 * 60 * 60 * 1000 )
+		: null;
+	const formattedDate = gracePeriodDate
+		? formatDate( gracePeriodDate, locale, { dateStyle: 'long' } )
+		: null;
+
+	return (
+		<Notice
+			variant="warning"
+			title={ __( 'Plan expired' ) }
+			actions={
+				<Button variant="primary" href={ plansUrl }>
+					{ __( 'Get a plan' ) }
+				</Button>
+			}
+		>
+			{ formattedDate
+				? sprintf(
+						/* translators: %s is the date by which the user must purchase a plan */
+						__(
+							'The store is no longer active since the plan has expired. Purchase a plan before %s to keep your store or it will be permanently deleted.'
+						),
+						formattedDate
+				  )
+				: __(
+						'The store is no longer active since the plan has expired. Purchase a plan to keep your store or it will be permanently deleted.'
+				  ) }
+		</Notice>
+	);
+}

--- a/client/dashboard/sites/overview/ciab-plan-expired-banner.tsx
+++ b/client/dashboard/sites/overview/ciab-plan-expired-banner.tsx
@@ -1,9 +1,9 @@
 import { siteCurrentPlanQuery, purchaseQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
-import { Button } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
 import { useLocale } from '../../app/locale';
 import Notice from '../../components/notice';
+import UpsellCTAButton from '../../components/upsell-cta-button';
 import { formatDate } from '../../utils/datetime';
 import { isCommerceGarden, isCommerceGardenPlanExpired } from '../../utils/site-types';
 import { getSitePlanUpgradeUrl } from '../../utils/site-url';
@@ -40,9 +40,9 @@ export function CiabPlanExpiredBanner( { site }: { site: Site } ) {
 			variant="warning"
 			title={ __( 'Plan expired' ) }
 			actions={
-				<Button variant="primary" href={ plansUrl }>
+				<UpsellCTAButton upsellId="site-overview-plan-expired" variant="primary" href={ plansUrl }>
 					{ __( 'Get a plan' ) }
-				</Button>
+				</UpsellCTAButton>
 			}
 		>
 			{ formattedDate

--- a/client/dashboard/sites/overview/ciab-plan-expired-banner.tsx
+++ b/client/dashboard/sites/overview/ciab-plan-expired-banner.tsx
@@ -8,12 +8,12 @@ import { getCurrentDashboard } from '../../app/routing';
 import Notice from '../../components/notice';
 import { formatDate } from '../../utils/datetime';
 import { wpcomLink } from '../../utils/link';
-import { isCommerceGarden } from '../../utils/site-types';
+import { isCommerceGarden, isCommerceGardenPlanExpired } from '../../utils/site-types';
 import type { Site } from '@automattic/api-core';
 
 export function CiabPlanExpiredBanner( { site }: { site: Site } ) {
 	const locale = useLocale();
-	const isExpired = isCommerceGarden( site ) && site.plan?.expired;
+	const isExpired = isCommerceGarden( site ) && isCommerceGardenPlanExpired( site );
 
 	const { data: plan } = useQuery( {
 		...siteCurrentPlanQuery( site.ID ),

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -39,6 +39,7 @@ import VisibilityCard from '../overview-visibility-card';
 import VisibilityCardCiab from '../overview-visibility-card-ciab';
 import { InaccessibleJetpackNotice } from '../site/notices';
 import StagingSiteSyncDropdown from '../staging-site-sync-dropdown';
+import { CiabPlanExpiredBanner } from './ciab-plan-expired-banner';
 import { StorageWarningBanner } from './storage-warning-banner';
 import type { Site } from '@automattic/api-core';
 import type { WPBreakpoint } from '@wordpress/compose/build-types/hooks/use-viewport-match';
@@ -201,7 +202,12 @@ function SiteOverview( {
 
 		if ( isCommerceGardenSite ) {
 			return (
-				<Button __next40pxDefaultSize variant="primary" href={ site.options.admin_url }>
+				<Button
+					__next40pxDefaultSize
+					variant="primary"
+					href={ site.options.admin_url }
+					disabled={ !! site.plan?.expired }
+				>
 					{ __( 'Manage store' ) }
 				</Button>
 			);
@@ -247,6 +253,7 @@ function SiteOverview( {
 		>
 			<VStack alignment="stretch" spacing={ isSmallViewport ? 5 : 10 }>
 				<StorageWarningBanner site={ site } />
+				<CiabPlanExpiredBanner site={ site } />
 				<Grid { ...gridLayout } gap={ spacing }>
 					{ showSitePreview && <SitePreviewCard site={ site } /> }
 					<SiteOverviewPrimaryCards site={ site } spacing={ spacing } />

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -20,7 +20,11 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { getSiteDisplayName } from '../../utils/site-name';
-import { isSelfHostedJetpackConnected, isCommerceGarden } from '../../utils/site-types';
+import {
+	isSelfHostedJetpackConnected,
+	isCommerceGarden,
+	isCommerceGardenPlanExpired,
+} from '../../utils/site-types';
 import AgencySiteShareCard from '../overview-agency-site-share-card';
 import BackupCard from '../overview-backup-card';
 import DIFMUpsellCard from '../overview-difm-upsell-card';
@@ -206,7 +210,7 @@ function SiteOverview( {
 					__next40pxDefaultSize
 					variant="primary"
 					href={ site.options.admin_url }
-					disabled={ !! site.plan?.expired }
+					disabled={ isCommerceGardenPlanExpired( site ) }
 				>
 					{ __( 'Manage store' ) }
 				</Button>

--- a/client/dashboard/utils/site-types.ts
+++ b/client/dashboard/utils/site-types.ts
@@ -18,6 +18,10 @@ export function isCommerceGarden( site: Site ) {
 	return site.is_garden && site.garden_name === 'commerce';
 }
 
+export function isCommerceGardenPlanExpired( site: Site ) {
+	return !! site.plan?.expired || !! site.plan?.is_free;
+}
+
 export function isStagingSite( site: Site ) {
 	return site.is_wpcom_staging_site;
 }


### PR DESCRIPTION
## Proposed Changes

* Add a warning banner on the CIAB site overview when the plan has expired, showing the grace period deadline (expiry date + 30 days) and a "Get a plan" CTA linking to the Woo hosted plans page.
* Disable the "Manage store" button when the CIAB plan is expired.

<img width="736" height="626" alt="Captura de Tela 2026-03-26 às 17 43 11" src="https://github.com/user-attachments/assets/3b68565a-84cd-464a-b7a0-f3dfc8b2d4fc" />

## Why are these changes being made?

When a CIAB site's plan expires, users need a clear indication that their store is no longer active and a path to reactivate it before permanent deletion. The disabled button prevents navigating to a non-functional store admin.

## Testing Instructions

* Navigate to a CIAB site overview with an expired plan (e.g., `/sites/<slug>`).
* Verify the yellow warning banner appears with the title "Plan expired" and the message includes a date 30 days after the plan's expiry date.
* Verify the "Get a plan" button in the banner links to `/setup/woo-hosted-plans`.
* Verify the "Manage store" header button is disabled.
* Verify that CIAB sites with active plans still show the enabled "Manage store" button and no banner.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?