### PR TITLE
Connect Screen: add reusable notice component

### DIFF
--- a/client/components/connect-screen/notice/index.tsx
+++ b/client/components/connect-screen/notice/index.tsx
@@ -1,0 +1,168 @@
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Icon, check, closeSmall, info, warning } from '@wordpress/icons';
+import clsx from 'clsx';
+import {
+	Children,
+	isValidElement,
+	type AnchorHTMLAttributes,
+	type HTMLAttributes,
+	type ReactNode,
+} from 'react';
+import type { ButtonAsButtonProps } from '@wordpress/components/build-types/button/types';
+
+import './style.scss';
+
+export type NoticeIntent = 'neutral' | 'info' | 'warning' | 'success' | 'error';
+
+interface NoticeRootProps extends HTMLAttributes< HTMLDivElement > {
+	intent?: NoticeIntent;
+	icon?: ReactNode | null;
+}
+
+interface NoticeTitleProps extends HTMLAttributes< HTMLHeadingElement > {
+	as?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+}
+
+type NoticeActionButtonProps = Omit< ButtonAsButtonProps, 'size' | 'variant' > & {
+	className?: string;
+};
+type NoticeCloseIconProps = Omit< ButtonAsButtonProps, 'size' | 'variant' > & {
+	className?: string;
+};
+
+const DEFAULT_NOTICE_ICONS: Record< NoticeIntent, ReactNode | null > = {
+	neutral: null,
+	info: <Icon icon={ info } size={ 20 } />,
+	warning: <Icon icon={ warning } size={ 20 } />,
+	success: <Icon icon={ check } size={ 20 } />,
+	error: <Icon icon={ closeSmall } size={ 20 } />,
+};
+
+export function NoticeRoot( {
+	children,
+	className,
+	icon,
+	intent = 'neutral',
+	...props
+}: NoticeRootProps ): JSX.Element {
+	const renderedIcon = icon === undefined ? DEFAULT_NOTICE_ICONS[ intent ] : icon;
+	const contentChildren: ReactNode[] = [];
+	let closeIconSlot: ReactNode = null;
+
+	Children.forEach( children, ( child ) => {
+		if ( ! closeIconSlot && isValidElement( child ) && child.type === NoticeCloseIcon ) {
+			closeIconSlot = child;
+			return;
+		}
+
+		contentChildren.push( child );
+	} );
+
+	return (
+		<div
+			className={ clsx(
+				'connect-screen-notice',
+				`is-intent-${ intent }`,
+				renderedIcon && 'has-icon',
+				className
+			) }
+			{ ...props }
+		>
+			{ renderedIcon && (
+				<span className="connect-screen-notice-icon" aria-hidden="true">
+					{ renderedIcon }
+				</span>
+			) }
+			<div className="connect-screen-notice-content">{ contentChildren }</div>
+			{ closeIconSlot }
+		</div>
+	);
+}
+
+export function NoticeTitle( {
+	as: Tag = 'h3',
+	children,
+	className,
+	...props
+}: NoticeTitleProps ): JSX.Element {
+	return (
+		<Tag className={ clsx( 'connect-screen-notice-title', className ) } { ...props }>
+			{ children }
+		</Tag>
+	);
+}
+
+export function NoticeDescription( {
+	children,
+	className,
+	...props
+}: HTMLAttributes< HTMLDivElement > ): JSX.Element {
+	return (
+		<div className={ clsx( 'connect-screen-notice-description', className ) } { ...props }>
+			{ children }
+		</div>
+	);
+}
+
+export function NoticeActions( {
+	children,
+	className,
+	...props
+}: HTMLAttributes< HTMLDivElement > ): JSX.Element {
+	return (
+		<div className={ clsx( 'connect-screen-notice-actions', className ) } { ...props }>
+			{ children }
+		</div>
+	);
+}
+
+export function NoticeActionButton( {
+	children,
+	className,
+	...props
+}: NoticeActionButtonProps ): JSX.Element {
+	return (
+		<Button
+			size="small"
+			variant="secondary"
+			className={ clsx( 'connect-screen-notice-action-button', className ) }
+			{ ...props }
+		>
+			{ children }
+		</Button>
+	);
+}
+
+export function NoticeCloseIcon( {
+	className,
+	children,
+	icon = closeSmall,
+	label,
+	...props
+}: NoticeCloseIconProps ): JSX.Element {
+	return (
+		<Button
+			size="small"
+			variant="tertiary"
+			icon={ icon }
+			label={ label ?? __( 'Dismiss', 'calypso' ) }
+			className={ clsx( 'connect-screen-notice-close-icon', className ) }
+			{ ...props }
+		>
+			{ children }
+		</Button>
+	);
+}
+
+export function NoticeActionLink( {
+	children,
+	className,
+	...props
+}: AnchorHTMLAttributes< HTMLAnchorElement > ): JSX.Element {
+	return (
+		<a className={ clsx( 'connect-screen-notice-action-link', className ) } { ...props }>
+			{ children }
+		</a>
+	);
+}

--- a/client/components/connect-screen/notice/style.scss
+++ b/client/components/connect-screen/notice/style.scss
@@ -1,0 +1,196 @@
+.connect-screen-notice {
+	--connect-screen-notice-icon-size: 24px;
+	--connect-screen-notice-text-line-height: 20px;
+	--connect-screen-notice-text-vertical-padding: calc(
+		( var( --connect-screen-notice-icon-size ) - var( --connect-screen-notice-text-line-height ) ) /
+			2
+	);
+	--connect-screen-notice-background-color: var( --studio-white, #fff );
+	--connect-screen-notice-border-color: var( --studio-gray-5, #dcdcde );
+	--connect-screen-notice-text-color: var( --color-text, #1e1e1e );
+	--connect-screen-notice-icon-color: var( --color-text-subtle, #50575e );
+
+	display: grid;
+	align-items: start;
+	grid-template-columns: auto minmax( 0, 1fr ) auto;
+	width: 100%;
+	margin-bottom: 1rem;
+	padding: 0.75rem;
+	border: 1px solid var( --connect-screen-notice-border-color );
+	border-radius: 8px;
+	background: var( --connect-screen-notice-background-color );
+	color: var( --connect-screen-notice-text-color );
+}
+
+.connect-screen-notice.is-intent-neutral {
+	--connect-screen-notice-background-color: var( --studio-white, #fff );
+	--connect-screen-notice-border-color: var( --studio-gray-5, #dcdcde );
+	--connect-screen-notice-text-color: var( --color-text, #1e1e1e );
+	--connect-screen-notice-icon-color: var( --color-text-subtle, #50575e );
+}
+
+.connect-screen-notice.is-intent-info {
+	--connect-screen-notice-background-color: color-mix(
+		in srgb,
+		var( --color-accent, #0675c4 ) 8%,
+		var( --studio-white, #fff )
+	);
+	--connect-screen-notice-border-color: color-mix(
+		in srgb,
+		var( --color-accent, #0675c4 ) 30%,
+		var( --studio-gray-5, #dcdcde )
+	);
+	--connect-screen-notice-text-color: var( --color-accent-70, #005f96 );
+	--connect-screen-notice-icon-color: color-mix(
+		in srgb,
+		var( --color-accent, #0675c4 ) 78%,
+		var( --studio-white, #fff )
+	);
+}
+
+.connect-screen-notice.is-intent-warning {
+	--connect-screen-notice-background-color: color-mix(
+		in srgb,
+		var( --color-warning, #b26200 ) 12%,
+		var( --studio-white, #fff )
+	);
+	--connect-screen-notice-border-color: color-mix(
+		in srgb,
+		var( --color-warning, #b26200 ) 36%,
+		var( --studio-gray-5, #dcdcde )
+	);
+	--connect-screen-notice-text-color: var( --color-warning-70, #7a3d00 );
+	--connect-screen-notice-icon-color: color-mix(
+		in srgb,
+		var( --color-warning, #b26200 ) 78%,
+		var( --studio-white, #fff )
+	);
+}
+
+.connect-screen-notice.is-intent-success {
+	--connect-screen-notice-background-color: color-mix(
+		in srgb,
+		var( --color-success, #008a20 ) 11%,
+		var( --studio-white, #fff )
+	);
+	--connect-screen-notice-border-color: color-mix(
+		in srgb,
+		var( --color-success, #008a20 ) 34%,
+		var( --studio-gray-5, #dcdcde )
+	);
+	--connect-screen-notice-text-color: var( --color-success-70, #005f1c );
+	--connect-screen-notice-icon-color: color-mix(
+		in srgb,
+		var( --color-success, #008a20 ) 80%,
+		var( --studio-white, #fff )
+	);
+}
+
+.connect-screen-notice.is-intent-error {
+	--connect-screen-notice-background-color: color-mix(
+		in srgb,
+		var( --color-error, #c9352d ) 11%,
+		var( --studio-white, #fff )
+	);
+	--connect-screen-notice-border-color: color-mix(
+		in srgb,
+		var( --color-error, #c9352d ) 34%,
+		var( --studio-gray-5, #dcdcde )
+	);
+	--connect-screen-notice-text-color: var( --color-error-70, #8c201c );
+	--connect-screen-notice-icon-color: color-mix(
+		in srgb,
+		var( --color-error, #c9352d ) 80%,
+		var( --studio-white, #fff )
+	);
+}
+
+.connect-screen-notice-icon {
+	grid-row: 1;
+	grid-column: 1;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	margin-inline-end: 0.5rem;
+	color: var( --connect-screen-notice-icon-color );
+}
+
+.connect-screen-notice-content {
+	grid-column: 2;
+	min-width: 0;
+}
+
+.connect-screen-notice-title {
+	margin: 0;
+	padding-block: var( --connect-screen-notice-text-vertical-padding );
+	font-size: 0.875rem;
+	font-weight: 500;
+	line-height: var( --connect-screen-notice-text-line-height );
+	color: var( --connect-screen-notice-text-color );
+}
+
+.connect-screen-notice-description {
+	margin: 0;
+	padding-block: var( --connect-screen-notice-text-vertical-padding );
+	font-size: 0.875rem;
+	line-height: var( --connect-screen-notice-text-line-height );
+	color: var( --connect-screen-notice-text-color );
+}
+
+.connect-screen-notice-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.75rem;
+}
+
+.connect-screen-notice-content:has( .connect-screen-notice-title ) .connect-screen-notice-actions,
+.connect-screen-notice-content:has( .connect-screen-notice-description )
+	.connect-screen-notice-actions {
+	margin-block-start: 0.5rem;
+}
+
+.connect-screen-notice-action-button.components-button {
+	flex-shrink: 0;
+	min-height: 30px;
+	padding: 0 0.75rem;
+	font-size: 0.75rem;
+	font-weight: 500;
+}
+
+.connect-screen-notice-action-link {
+	display: inline-flex;
+	align-items: center;
+	flex-shrink: 0;
+	font-size: 0.875rem;
+	line-height: var( --connect-screen-notice-text-line-height );
+	color: var( --connect-screen-notice-text-color );
+	text-decoration: underline;
+	margin-block: auto;
+}
+
+.connect-screen-notice-action-link:not( :first-child ) {
+	margin-inline-start: 0.25rem;
+}
+
+.connect-screen-notice-action-link:not( :last-child ) {
+	margin-inline-end: 0.25rem;
+}
+
+.connect-screen-notice-action-link:hover,
+.connect-screen-notice-action-link:focus {
+	color: var( --connect-screen-notice-text-color );
+}
+
+.connect-screen-notice-close-icon.components-button {
+	grid-row: 1;
+	grid-column: 3;
+	margin-inline-start: 0.5rem;
+	color: var( --connect-screen-notice-text-color );
+	opacity: 0.8;
+}
+
+.connect-screen-notice-close-icon.components-button:hover,
+.connect-screen-notice-close-icon.components-button:focus {
+	opacity: 1;
+	background: color-mix( in srgb, transparent 50%, var( --studio-gray-5, #dcdcde ) );
+}

--- a/client/components/connect-screen/stories/index.stories.tsx
+++ b/client/components/connect-screen/stories/index.stories.tsx
@@ -20,6 +20,15 @@ import { BrandHeader } from '../brand-header';
 import { ConsentText } from '../consent-text';
 import { LoadingScreen } from '../loading-screen';
 import { LoginPageWrapper } from '../login-page-wrapper';
+import {
+	NoticeActionButton,
+	NoticeActionLink,
+	NoticeActions,
+	NoticeCloseIcon,
+	NoticeDescription,
+	NoticeRoot,
+	NoticeTitle,
+} from '../notice';
 import { PermissionsList } from '../permissions-list';
 import { ScreenLayout } from '../screen-layout';
 import { UserCard } from '../user-card';
@@ -254,6 +263,55 @@ export const ConsentTextVariants: StoryObj< typeof ConsentText > = {
 					</a>
 					.
 				</ConsentText>
+			</VariantSection>
+		</div>
+	),
+};
+
+// Notice - All intent variants
+export const NoticeVariants: StoryObj = {
+	render: () => (
+		<div>
+			<VariantSection title="Info with title, description, and actions">
+				<NoticeRoot intent="info">
+					<NoticeTitle>Complete your setup</NoticeTitle>
+					<NoticeDescription>
+						You are one step away from connecting your account to this site.
+					</NoticeDescription>
+					<NoticeActions>
+						<NoticeActionLink href="https://wordpress.com/help" target="_blank" rel="noreferrer">
+							Read guide
+						</NoticeActionLink>
+						<NoticeActionButton>Try again</NoticeActionButton>
+					</NoticeActions>
+				</NoticeRoot>
+			</VariantSection>
+			<VariantSection title="Warning">
+				<NoticeRoot intent="warning">
+					<NoticeTitle>Review requested permissions</NoticeTitle>
+					<NoticeDescription>
+						This app requests access to additional site settings.
+					</NoticeDescription>
+				</NoticeRoot>
+			</VariantSection>
+			<VariantSection title="Success">
+				<NoticeRoot intent="success">
+					<NoticeTitle>Connection successful</NoticeTitle>
+					<NoticeDescription>Your account is now connected.</NoticeDescription>
+				</NoticeRoot>
+			</VariantSection>
+			<VariantSection title="Error">
+				<NoticeRoot intent="error">
+					<NoticeTitle>We could not connect your account</NoticeTitle>
+					<NoticeDescription>Please check your permissions and try again.</NoticeDescription>
+				</NoticeRoot>
+			</VariantSection>
+			<VariantSection title="Neutral with close icon slot">
+				<NoticeRoot intent="neutral">
+					<NoticeTitle>Heads up</NoticeTitle>
+					<NoticeDescription>You can dismiss this notice and continue later.</NoticeDescription>
+					<NoticeCloseIcon />
+				</NoticeRoot>
 			</VariantSection>
 		</div>
 	),


### PR DESCRIPTION
## Summary
- Add a reusable Connect Screen notice component under `client/components/connect-screen/notice`.
- Include component implementation and scoped styles.
- Add a Storybook showcase for notice variants in `client/components/connect-screen/stories/index.stories.tsx`.
- Intentionally scoped to notice component work only; excludes Jetpack Connect SSO changes.

## Storybook
- Start Storybook from the repo root with: `yarn storybook:start`.
- Open `http://localhost:6006` and navigate to `client/components/ConnectScreen`.
- The notice examples are in the `NoticeVariants` story within `client/components/connect-screen/stories/index.stories.tsx`.

## Testing
- `yarn eslint client/components/connect-screen/notice/index.tsx`
- `yarn stylelint client/components/connect-screen/notice/style.scss`
- `yarn eslint client/components/connect-screen/stories/index.stories.tsx`