### PR TITLE
DO NOT REVIEW: Docker sandbox template for Claude Code

### DIFF
--- a/Dockerfile.claude-sandbox
+++ b/Dockerfile.claude-sandbox
@@ -1,0 +1,24 @@
+FROM docker/sandbox-templates:claude-code
+
+USER root
+
+# Install Node.js 22.9.0 (replace base image's Node)
+RUN ARCH=$(dpkg --print-architecture) && \
+    if [ "$ARCH" = "amd64" ]; then NARCH="x64"; else NARCH="arm64"; fi && \
+    curl -fsSL "https://nodejs.org/dist/v22.9.0/node-v22.9.0-linux-${NARCH}.tar.gz" -o /tmp/node.tar.gz && \
+    tar -xzf /tmp/node.tar.gz -C /usr/local --strip-components=1 && \
+    rm /tmp/node.tar.gz
+
+# Enable corepack
+RUN corepack enable
+
+# Install system deps useful for Calypso development
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+USER agent
+
+# Pre-download Yarn 4.0.2 as the agent user
+RUN corepack prepare yarn@4.0.2 --activate

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -115,3 +115,19 @@ One such tool is [AnyBar](https://github.com/tonsky/AnyBar) (_macOS only_), a ve
 ### Other platforms
 
 `anybar-calypso` communicates with AnyBar by sending simple strings via UDP to a local port. This means that it can trivially be adapted to work with any other notification system, either by listening to UDP traffic or by altering `anybar-calypso` directly.
+
+## Docker Sandbox (Claude Code)
+
+You can run Claude Code in a Docker sandbox with the correct Node and Yarn versions pre-installed. The sandbox is fully isolated, so all tools run without permission gating — no approval prompts for file edits, shell commands, etc.
+
+Build the image:
+
+```bash
+docker build -f Dockerfile.claude-sandbox -t my-calypso-sandbox .
+```
+
+Launch a sandbox:
+
+```bash
+docker sandbox run -t my-calypso-sandbox claude
+```


### PR DESCRIPTION
## Proposed Changes

* Add `Dockerfile.claude-sandbox` with Node 22.9.0 and Yarn 4.0.2 for running Claude Code in a Docker sandbox
* Document sandbox build/run commands in `docs/development-workflow.md`

## Why are these changes being made?

* Enables running Claude Code in a fully isolated Docker sandbox with no permission gating

## Testing Instructions

* Build: `docker build -f Dockerfile.claude-sandbox -t my-calypso-sandbox .`
* Run: `docker sandbox run -t my-calypso-sandbox claude`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?