### PR TITLE
MSD: Fix Reader link on notifications/emails page

### DIFF
--- a/client/dashboard/me/notifications-emails/index.tsx
+++ b/client/dashboard/me/notifications-emails/index.tsx
@@ -4,6 +4,7 @@ import { __ } from '@wordpress/i18n';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import { wpcomLink } from '../../utils/link';
 import { PauseAllEmails } from './pause-all-emails';
 import { SubscriptionSettings } from './subscription-settings';
 
@@ -18,7 +19,9 @@ export default function NotificationsEmails() {
 					description={ createInterpolateElement(
 						__( 'To manage individual site subscriptions, <link>go to the Reader</link>.' ),
 						{
-							link: <ExternalLink href="/reader/subscriptions" children={ null } />,
+							link: (
+								<ExternalLink href={ wpcomLink( '/reader/subscriptions' ) } children={ null } />
+							),
 						}
 					) }
 				/>


### PR DESCRIPTION
## Proposed Changes

* Use `wpcomLink()` helper to generate the correct absolute URL for the "go to the Reader" link on the notifications/emails page.

## Why are these changes being made?

* The "go to the Reader" link on `me/notifications/emails` was using a relative path (`/reader/subscriptions`), which resolved to `my.wordpress.com/reader/subscriptions` instead of the correct `wordpress.com/reader/subscriptions`. Using the `wpcomLink()` helper ensures the link points to the right origin across all environments.

## Testing Instructions

* Navigate to the Dashboard → Me → Notifications → Emails page.
* Verify the "go to the Reader" link points to `wordpress.com/reader/subscriptions` (not `my.wordpress.com/reader/subscriptions`).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?