### PR TITLE
MSD: Add focus-visible styles to omnibar

### DIFF
--- a/client/dashboard/app/interim-omnibar/style.scss
+++ b/client/dashboard/app/interim-omnibar/style.scss
@@ -22,4 +22,14 @@ body:has(#wpcom-omnibar) #wpcom {
 			background: var(--color-masterbar-item-hover-background);
 		}
 	}
+
+	.masterbar__item:focus-visible {
+		box-shadow: inset 0 0 0 2px var(--color-masterbar-highlight);
+		outline: none;
+	}
+
+	.masterbar__item-subitems a:focus-visible,
+	.masterbar__item-subitems button:focus-visible {
+		outline: thin dotted;
+	}
 }


### PR DESCRIPTION
Fixes DOTMSD-1177

![CleanShot 2026-03-27 at 12 25 10](https://github.com/user-attachments/assets/07bd367c-448f-4639-9e94-30243b6cfa27)


## Proposed Changes

* Add `:focus-visible` styles to top-level omnibar items (inset box-shadow ring)
* Add `outline: thin dotted` to submenu links/buttons

Mimics the existing focus ring design from the Calypso masterbar. For comparison, navigate to a site-specific Calypso view (e.g. My Home) and tab through the masterbar to see the expected behavior.

## Why are these changes being made?

PR #109537 review flagged missing focus styles on interactive elements in the MSD omnibar. The existing masterbar focus styles are gated behind `.accessible-focus` (JS), which the dashboard doesn't load. This adds equivalent styles using native `:focus-visible` CSS.

## Testing Instructions

1. Enable the `dashboard/omnibar` feature flag
2. Load the MSD dashboard
3. Tab through omnibar items — each should show a 2px inset blue ring
4. Open a submenu and tab through items — should show a thin dotted outline
5. Mouse clicks should NOT show focus rings

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?