### PR TITLE
Fix Sentry sourcemap uploads broken by webpack cache collision with seed builds

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -437,7 +437,7 @@ object BuildDockerImage : BuildType({
 	}
 
 	failureConditions {
-		executionTimeoutMin = 26
+		executionTimeoutMin = 31
 	}
 
 	features {

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -102,7 +102,15 @@ const webpackCacheBuildDependencies = [
 	path.resolve( __dirname, '../.yarnrc.yml' ),
 ];
 
-const cacheFlavorParts = [ `mode=${ bundleEnv }`, `devtool=${ sourceMapType || 'none' }` ];
+// Sentry release mode mutates the client compilation by injecting release code
+// into the entrypoints. It must not share a filesystem cache flavor with
+// hidden-source-map builds that run without the Sentry plugin, such as
+// cache-seed priming.
+const cacheFlavorParts = [
+	`mode=${ bundleEnv }`,
+	`devtool=${ sourceMapType || 'none' }`,
+	`release=${ shouldCreateSentryRelease ? 'on' : 'off' }`,
+];
 const webpackCacheName = `client-${ cacheFlavorParts.join( '__' ) }`;
 
 // Inputs that should invalidate a cache flavor.
@@ -110,6 +118,8 @@ const webpackCacheVersion = JSON.stringify( {
 	bundleEnv,
 	nodeEnv: process.env.NODE_ENV || null,
 	calypsoEnv: process.env.CALYPSO_ENV || null,
+	sourceMapType: sourceMapType || null,
+	sentryRelease: shouldCreateSentryRelease,
 	buildChunksMap: shouldBuildChunksMap,
 	minify: shouldMinify,
 	entryLimit: process.env.ENTRY_LIMIT || null,


### PR DESCRIPTION
When we switched cache modes from base to seed (#109528). Sentry source map uploads stopped working.

I think what's happening is that sentry release=on is sharing a cache bucket with =off, and the cache priming runs are populating it with data, preventing the sentry plugin from running when we want it to. If this doesn't work, can revert and try something else.

## Proposed Changes

*

## Why are these changes being made?

*

## Testing Instructions


* After pushing to prod, check the build log for:
```
[20:42:52]W:	 [Step 5/10] #25 100.9 Source Map Upload Report
[20:42:52]W:	 [Step 5/10] #25 100.9   Minified Scripts
[20:42:52]W:	 [Step 5/10] #25 100.9     ~/calypso/evergreen/1006.a31eb5b9918138f7e6f9.min.js (sourcemap at 1006.a31eb5b9918138f7e6f9.min.js.map)
...
```

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
