### PR TITLE
MSD omnibar: fall back to slug when site name is empty

### DIFF
--- a/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
+++ b/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
@@ -67,7 +67,7 @@ export function InterimOmnibar( {
 				siteId={ siteId }
 				site={ site }
 				siteSlug={ siteSlug }
-				siteTitle={ site?.name ?? '' }
+				siteTitle={ site?.name?.trim() || site?.slug || '' }
 				siteUrl={ site?.URL ?? '' }
 				siteAdminUrl={ siteAdminUrl }
 				siteHomeUrl={ site?.URL ?? '' }

--- a/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
+++ b/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
@@ -5,6 +5,7 @@ import { Provider as ReduxProvider } from 'react-redux';
 import { MasterbarLoggedIn } from 'calypso/layout/masterbar/logged-in';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getLogoutUrl } from 'calypso/lib/user/shared-utils';
+import { getSiteDisplayName } from '../../utils/site-name';
 import type { User, Site } from '@automattic/api-core';
 
 const noop = () => {};
@@ -67,7 +68,7 @@ export function InterimOmnibar( {
 				siteId={ siteId }
 				site={ site }
 				siteSlug={ siteSlug }
-				siteTitle={ site?.name?.trim() || site?.slug || '' }
+				siteTitle={ site ? getSiteDisplayName( site ) : '' }
 				siteUrl={ site?.URL ?? '' }
 				siteAdminUrl={ siteAdminUrl }
 				siteHomeUrl={ site?.URL ?? '' }


### PR DESCRIPTION
## Summary
- The omnibar's site menu showed no title when the primary blog's `name` field was empty
- In v1 Calypso, the `getSiteTitle` Redux selector handles this by falling back to the site domain when `name` is falsy — but the `InterimOmnibar` wasn't replicating that fallback
- Apply the same logic: fall back to `site.slug` when `site.name` is empty/whitespace

## Test plan
- [ ] Log in with an account whose primary blog has an empty site name
- [ ] Verify the omnibar site menu shows the site slug instead of blank
- [ ] Verify accounts with a populated site name still show the name