### PR TITLE
MSD Sidebar: Add border-radius to external link menu items

### DIFF
--- a/client/dashboard/components/sidebar/sidebar-menu-item.scss
+++ b/client/dashboard/components/sidebar/sidebar-menu-item.scss
@@ -1,5 +1,9 @@
 @import '@wordpress/base-styles/variables';
 
+.dashboard-sidebar__menu-item {
+	border-radius: $radius-small;
+}
+
 .components-button.dashboard-sidebar__menu-item {
 	justify-content: flex-start;
 	width: 100%;
@@ -9,8 +13,4 @@
 		background: color-mix( in srgb, var( --wp-admin-theme-color ) 8%, transparent );
 		color: var( --wp-admin-theme-color );
 	}
-}
-
-a.dashboard-sidebar__menu-item {
-	border-radius: $radius-small;
 }

--- a/client/dashboard/components/sidebar/sidebar-menu-item.scss
+++ b/client/dashboard/components/sidebar/sidebar-menu-item.scss
@@ -1,3 +1,5 @@
+@import '@wordpress/base-styles/variables';
+
 .components-button.dashboard-sidebar__menu-item {
 	justify-content: flex-start;
 	width: 100%;
@@ -7,4 +9,8 @@
 		background: color-mix( in srgb, var( --wp-admin-theme-color ) 8%, transparent );
 		color: var( --wp-admin-theme-color );
 	}
+}
+
+a.dashboard-sidebar__menu-item {
+	border-radius: $radius-small;
 }


### PR DESCRIPTION
Closes DOTMSD-1178

## Proposed Changes

* Add `border-radius` to anchor-based sidebar menu items so their focus ring matches the rounded style of Button-based menu items.

## Why are these changes being made?

When `SidebarMenuItem` renders with an `href` prop, it uses the WordPress `Item` component as an `<a>` tag. This component applies a `box-shadow` focus ring but has no `border-radius`, resulting in a square focus outline. Button-based menu items already have `border-radius: 2px` built in, so their focus rings appear rounded. Adding `border-radius: $radius-small` to the anchor variant makes them consistent.

This is a bit heavy-handed, but I couldn't find a more predictable way to ensure the border-radius for the `<a`> tag.

## Testing Instructions

* Navigate to a site sidebar that has external link menu items
* Tab through the sidebar items
* Verify the focus ring on external link items is rounded, matching the other menu items

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)