### PR TITLE
MSD: Restore hidden header to fix notifications/help center panels

### DIFF
--- a/client/dashboard/app/header/index.tsx
+++ b/client/dashboard/app/header/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useViewportMatch } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
 import HeaderBar from '../../components/header-bar';
@@ -12,8 +13,12 @@ function Header() {
 	const { Logo, name } = useAppContext();
 	const isDesktop = useViewportMatch( 'medium' );
 
+	const styles = isEnabled( 'dashboard/omnibar' )
+		? { style: { height: 0, position: 'absolute' as const } }
+		: {};
+
 	return (
-		<HeaderBar as="header">
+		<HeaderBar as="header" { ...styles }>
 			{ ! isDesktop && <PrimaryMenu /> }
 
 			{ Logo && (

--- a/client/dashboard/app/root/index.tsx
+++ b/client/dashboard/app/root/index.tsx
@@ -136,11 +136,7 @@ function Root() {
 			return null;
 		}
 
-		if ( ! isOmnibarEnabled ) {
-			return <Header />;
-		}
-
-		return null;
+		return <Header />;
 	};
 
 	const renderBody = () => {

--- a/client/dashboard/components/header-bar/index.tsx
+++ b/client/dashboard/components/header-bar/index.tsx
@@ -3,7 +3,15 @@ import { __experimentalHStack as HStack } from '@wordpress/components';
 import clsx from 'clsx';
 import './style.scss';
 
-function Header( { as = 'div', children }: { as?: 'div' | 'header'; children?: React.ReactNode } ) {
+function Header( {
+	as = 'div',
+	children,
+	style,
+}: {
+	as?: 'div' | 'header';
+	children?: React.ReactNode;
+	style?: React.CSSProperties;
+} ) {
 	return (
 		<HStack
 			as={ as }
@@ -16,6 +24,7 @@ function Header( { as = 'div', children }: { as?: 'div' | 'header'; children?: R
 			alignment="left"
 			spacing={ 0 }
 			justify="flex-start"
+			style={ style }
 		>
 			{ children }
 		</HStack>


### PR DESCRIPTION
Related: DOTMSD-1156

## Proposed Changes

Hack: instead of removing the header entirely when `dashboard/omnibar` is enabled (#109517), render it with `height: 0` and `position: absolute` so it's visually hidden but still in the DOM.

## Why are these changes being made?

Removing the header in #109517 broke the notifications and help center panels — they depend on the header being mounted in the DOM. This is definitely a hack; the proper fix is to decouple those panels from the header, but this unblocks things in the meantime.

## Testing Instructions

1. With `dashboard/omnibar` **enabled**:
   - Verify no visible header renders below the masterbar
   - Open notifications panel — it should work
   - Open help center panel — it should work
2. With `dashboard/omnibar` **disabled**: verify the standard dashboard header is unchanged

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?