### PR TITLE
MSD: Fix mobile sidebar scroll-to-top issue

### DIFF
--- a/client/dashboard/app/interim-omnibar/style.scss
+++ b/client/dashboard/app/interim-omnibar/style.scss
@@ -1,5 +1,7 @@
 body:has(#wpcom-omnibar) #wpcom {
-	margin-block-start: var(--masterbar-height, 47px);
+	padding-block-start: var(--masterbar-height, 47px);
+	height: auto;
+	min-height: calc(100vh - var(--masterbar-height, 47px) );
 }
 
 #wpcom-omnibar {

--- a/client/dashboard/app/responsive-sidebar/sidebar.scss
+++ b/client/dashboard/app/responsive-sidebar/sidebar.scss
@@ -9,9 +9,9 @@
 	flex-shrink: 0;
 	gap: $grid-unit-30;
 	position: sticky;
-	top: 0;
+	top: var(--masterbar-height, 0);
 	width: $sidebar-width;
-	min-height: calc(100vh - var(--masterbar-height) );
+	min-height: calc(100vh - var(--masterbar-height, 0) );
 	padding: 0 $grid-unit-20;
 	border-inline-end: $border-width solid var( --dashboard-header__border-color );
 	box-sizing: border-box;

--- a/client/dashboard/app/responsive-sidebar/style.scss
+++ b/client/dashboard/app/responsive-sidebar/style.scss
@@ -5,7 +5,7 @@
 	position: fixed;
 	top: var(--masterbar-height);
 	inset-inline-start: 0;
-	min-height: calc(100vh - var(--masterbar-height) );
+	height: calc(100vh - var(--masterbar-height) );
 	width: $sidebar-width;
 	transform: translateX( -100% );
 	transition: transform 0.3s ease-in;
@@ -14,6 +14,7 @@
 
 	&.is-open {
 		transform: translateX( 0 );
+		overflow-y: auto;
 	}
 }
 

--- a/client/dashboard/app/root/style.scss
+++ b/client/dashboard/app/root/style.scss
@@ -10,7 +10,6 @@
 }
 
 .dashboard-root__body {
-	--masterbar-height: 61px;
 	display: flex;
 	min-height: calc(100vh - var(--masterbar-height) );
 
@@ -30,6 +29,5 @@
 	.dashboard-root__body:has(.dashboard-responsive-sidebar.is-open) & {
 			transform: translateX( $sidebar-width );
 			overflow: hidden;
-			height: 100vh;
 	}
 }


### PR DESCRIPTION
## Proposed Changes

* Remove `height: 100vh` from `.dashboard-root__content` when the mobile sidebar is open
* Change `min-height` to `height` on `.dashboard-responsive-sidebar` (mobile) so the sidebar is constrained to the viewport
* Add `overflow-y: auto` to the mobile sidebar when open so it scrolls when content exceeds viewport
* Fix desktop sidebar sticky positioning: use `top: var(--masterbar-height, 0)` so it sticks below the masterbar
* Remove hardcoded `--masterbar-height: 61px` from `.dashboard-root__body` — it's now provided by the masterbar itself
* Fix omnibar body offset: use `padding-block-start` instead of `margin-block-start` to prevent layout collapse

## Why are these changes being made?

Three sidebar layout issues:

1. **Mobile: content scrolls to top when sidebar opens** — `height: 100vh` on `.dashboard-root__content` capped the document height, causing the browser to clamp scroll position to `maxScroll = viewportHeight - 812 = 46px`.

2. **Mobile: sidebar not scrollable** — `min-height` allowed the sidebar to grow beyond the viewport, but `overflow: hidden` prevented scrolling. Changing to `height` constrains the sidebar to the viewport, and `overflow-y: auto` enables scrolling.

3. **Desktop: sidebar not sticky** — `top: 0` made the sidebar stick to the very top of the page, but with the masterbar present, `top: var(--masterbar-height, 0)` positions it correctly below the masterbar.

A follow-up could add `ScrollLock` when the sidebar is open on mobile to fully prevent the user from scrolling the background content.

## Testing Instructions

### Mobile (< 782px viewport)
1. Navigate to a site overview page
2. Scroll down the content
3. Open the sidebar — content should stay at scrolled position (not reset to top)
4. Sidebar should be scrollable if menu items exceed viewport height
5. Close sidebar — scroll position preserved

### Desktop
1. Navigate to a site overview page with many cards
2. Scroll down — sidebar should stay sticky, pinned below the masterbar
3. If sidebar content exceeds viewport, it should scroll internally

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?

🤖 Generated with [Claude Code](https://claude.com/claude-code)