### PR TITLE
MSD: Update Logs/Scan page titles to match sidebar with omnibar

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -291,7 +291,7 @@ export const siteLogsPhpRoute = createRoute( {
 	head: () => ( {
 		meta: [
 			{
-				title: __( 'PHP errors' ),
+				title: isEnabled( 'dashboard/omnibar' ) ? __( 'PHP errors' ) : undefined,
 			},
 		],
 	} ),
@@ -313,7 +313,7 @@ export const siteLogsServerRoute = createRoute( {
 	head: () => ( {
 		meta: [
 			{
-				title: __( 'Web server' ),
+				title: isEnabled( 'dashboard/omnibar' ) ? __( 'Web server' ) : undefined,
 			},
 		],
 	} ),
@@ -335,7 +335,7 @@ export const siteLogsActivityRoute = createRoute( {
 	head: () => ( {
 		meta: [
 			{
-				title: __( 'Activity' ),
+				title: isEnabled( 'dashboard/omnibar' ) ? __( 'Activity' ) : undefined,
 			},
 		],
 	} ),
@@ -386,7 +386,7 @@ export const siteScanActiveThreatsRoute = createRoute( {
 	head: () => ( {
 		meta: [
 			{
-				title: __( 'Active threats' ),
+				title: isEnabled( 'dashboard/omnibar' ) ? __( 'Active threats' ) : undefined,
 			},
 		],
 	} ),
@@ -404,7 +404,7 @@ export const siteScanHistoryRoute = createRoute( {
 	head: () => ( {
 		meta: [
 			{
-				title: __( 'History' ),
+				title: isEnabled( 'dashboard/omnibar' ) ? __( 'History' ) : undefined,
 			},
 		],
 	} ),

--- a/client/dashboard/sites/logs/index.tsx
+++ b/client/dashboard/sites/logs/index.tsx
@@ -140,7 +140,6 @@ function SiteLogs( { logType }: { logType: LogType } ) {
 		<PageLayout
 			header={
 				<PageHeader
-					title={ __( 'Logs' ) }
 					description={ createInterpolateElement(
 						__( 'View and download various server logs. <learnMoreLink />' ),
 						{

--- a/client/dashboard/sites/scan/index.tsx
+++ b/client/dashboard/sites/scan/index.tsx
@@ -122,7 +122,6 @@ function SiteScan( { scanTab }: { scanTab: 'active' | 'history' } ) {
 			<PageLayout
 				header={
 					<PageHeader
-						title={ __( 'Scan' ) }
 						description={ getPageDescription() }
 						actions={
 							<ButtonStack>


### PR DESCRIPTION
Closes DOTMSD-1183

## Proposed Changes

* Remove hardcoded `title` prop from Logs and Scan `PageHeader` components, letting them derive the title from route `head()` meta via the existing `PageTitle` fallback.
* Conditionally set child route titles based on the `dashboard/omnibar` flag: when enabled, child routes return their specific title (e.g., "Activity", "PHP errors", "Active threats"); when disabled, they return `undefined` so the parent route's generic title ("Logs" / "Scan") is used.

## Why are these changes being made?

* When the omnibar is enabled, the tab navigation inside Logs/Scan pages is hidden and the sidebar provides sub-page navigation instead. The page header title should reflect the current sub-page (matching the sidebar label) rather than always showing the generic parent title.

## Testing Instructions

* Enable the `dashboard/omnibar` feature flag.
* Navigate to Logs sub-pages (Activity, PHP errors, Web server) and Scan sub-pages (Active threats, History) via the sidebar.
* Verify the page header title matches the sidebar label for each sub-page.
* Disable the flag and verify the titles still show "Logs" and "Scan" as before.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?