### PR TITLE
Reader: Show login-required message when comments need registration

### DIFF
--- a/client/blocks/comments/comment-actions.jsx
+++ b/client/blocks/comments/comment-actions.jsx
@@ -2,11 +2,7 @@ import { Gridicon } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import ShareButton from 'calypso/blocks/reader-share';
-import {
-	isCommentsOpen,
-	isLoginRequiredToComment,
-	isRebloggable,
-} from 'calypso/reader/post/capabilities';
+import { isCommentsOpen, isRebloggable } from 'calypso/reader/post/capabilities';
 import { useSelector } from 'calypso/state';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import CommentLikeButtonContainer from './comment-likes';
@@ -26,7 +22,7 @@ const CommentActions = ( {
 	onLikeToggle,
 } ) => {
 	const translate = useTranslate();
-	const showReplyButton = isCommentsOpen( post ) && ! isLoginRequiredToComment( post );
+	const showReplyButton = isCommentsOpen( post );
 	const showCancelReplyButton = activeReplyCommentId === commentId;
 	const hasSites = !! useSelector( getPrimarySiteId );
 	const showReblogButton = isRebloggable( post, hasSites );

--- a/client/blocks/comments/comment-actions.jsx
+++ b/client/blocks/comments/comment-actions.jsx
@@ -2,7 +2,11 @@ import { Gridicon } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import ShareButton from 'calypso/blocks/reader-share';
-import { isLoginRequiredToComment, isRebloggable } from 'calypso/reader/post/capabilities';
+import {
+	isCommentsOpen,
+	isLoginRequiredToComment,
+	isRebloggable,
+} from 'calypso/reader/post/capabilities';
 import { useSelector } from 'calypso/state';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import CommentLikeButtonContainer from './comment-likes';
@@ -22,11 +26,7 @@ const CommentActions = ( {
 	onLikeToggle,
 } ) => {
 	const translate = useTranslate();
-	const showReplyButton =
-		post &&
-		post.discussion &&
-		post.discussion.comments_open === true &&
-		! isLoginRequiredToComment( post );
+	const showReplyButton = isCommentsOpen( post ) && ! isLoginRequiredToComment( post );
 	const showCancelReplyButton = activeReplyCommentId === commentId;
 	const hasSites = !! useSelector( getPrimarySiteId );
 	const showReblogButton = isRebloggable( post, hasSites );

--- a/client/blocks/comments/comment-actions.jsx
+++ b/client/blocks/comments/comment-actions.jsx
@@ -2,7 +2,7 @@ import { Gridicon } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import ShareButton from 'calypso/blocks/reader-share';
-import { isRebloggable } from 'calypso/reader/post/capabilities';
+import { isLoginRequiredToComment, isRebloggable } from 'calypso/reader/post/capabilities';
 import { useSelector } from 'calypso/state';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import CommentLikeButtonContainer from './comment-likes';
@@ -22,7 +22,11 @@ const CommentActions = ( {
 	onLikeToggle,
 } ) => {
 	const translate = useTranslate();
-	const showReplyButton = post && post.discussion && post.discussion.comments_open === true;
+	const showReplyButton =
+		post &&
+		post.discussion &&
+		post.discussion.comments_open === true &&
+		! isLoginRequiredToComment( post );
 	const showCancelReplyButton = activeReplyCommentId === commentId;
 	const hasSites = !! useSelector( getPrimarySiteId );
 	const showReblogButton = isRebloggable( post, hasSites );

--- a/client/blocks/comments/form.jsx
+++ b/client/blocks/comments/form.jsx
@@ -152,6 +152,16 @@ class PostCommentForm extends Component {
 	render() {
 		const { post, error, errorType, translate } = this.props;
 
+		// Don't display the form if comments are closed
+		if ( post && ! isCommentsOpen( post ) ) {
+			// If we already have some comments, show a 'comments closed message'
+			if ( post.discussion?.comment_count > 0 ) {
+				return <p className="comments__form-closed">{ translate( 'Comments closed.' ) }</p>;
+			}
+
+			return null;
+		}
+
 		// If comments require registration, show a prompt to visit the post instead of the form
 		if ( post && isLoginRequiredToComment( post ) ) {
 			return (
@@ -166,16 +176,6 @@ class PostCommentForm extends Component {
 					) }
 				</p>
 			);
-		}
-
-		// Don't display the form if comments are closed
-		if ( post && ! isCommentsOpen( post ) ) {
-			// If we already have some comments, show a 'comments closed message'
-			if ( post.discussion?.comment_count > 0 ) {
-				return <p className="comments__form-closed">{ translate( 'Comments closed.' ) }</p>;
-			}
-
-			return null;
 		}
 
 		const buttonClasses = clsx( {

--- a/client/blocks/comments/form.jsx
+++ b/client/blocks/comments/form.jsx
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import GravatarWithHovercards from 'calypso/components/gravatar-with-hovercards';
 import { ProtectFormGuard } from 'calypso/lib/protect-form';
+import { isLoginRequiredToComment } from 'calypso/reader/post/capabilities';
 import { recordAction, recordGaEvent, recordTrackForPost, getLocation } from 'calypso/reader/stats';
 import { writeComment, deleteComment, replyComment } from 'calypso/state/comments/actions';
 import { getCurrentUser, isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -150,6 +151,22 @@ class PostCommentForm extends Component {
 
 	render() {
 		const { post, error, errorType, translate } = this.props;
+
+		// If comments require registration, show a prompt to visit the post instead of the form
+		if ( post && isLoginRequiredToComment( post ) ) {
+			return (
+				<p className="comments__form-closed">
+					{ translate(
+						'This site requires registration to comment. {{a}}Visit the original post{{/a}} to log in or create an account and join the conversation.',
+						{
+							components: {
+								a: <a href={ post.URL } target="_blank" rel="noopener noreferrer" />,
+							},
+						}
+					) }
+				</p>
+			);
+		}
 
 		// Don't display the form if comments are closed
 		if ( post && post.discussion && post.discussion.comments_open === false ) {

--- a/client/blocks/comments/form.jsx
+++ b/client/blocks/comments/form.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import GravatarWithHovercards from 'calypso/components/gravatar-with-hovercards';
 import { ProtectFormGuard } from 'calypso/lib/protect-form';
-import { isLoginRequiredToComment } from 'calypso/reader/post/capabilities';
+import { isCommentsOpen, isLoginRequiredToComment } from 'calypso/reader/post/capabilities';
 import { recordAction, recordGaEvent, recordTrackForPost, getLocation } from 'calypso/reader/stats';
 import { writeComment, deleteComment, replyComment } from 'calypso/state/comments/actions';
 import { getCurrentUser, isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -169,9 +169,9 @@ class PostCommentForm extends Component {
 		}
 
 		// Don't display the form if comments are closed
-		if ( post && post.discussion && post.discussion.comments_open === false ) {
+		if ( post && ! isCommentsOpen( post ) ) {
 			// If we already have some comments, show a 'comments closed message'
-			if ( post.discussion.comment_count && post.discussion.comment_count > 0 ) {
+			if ( post.discussion?.comment_count > 0 ) {
 				return <p className="comments__form-closed">{ translate( 'Comments closed.' ) }</p>;
 			}
 

--- a/client/blocks/comments/test/form.jsx
+++ b/client/blocks/comments/test/form.jsx
@@ -1,0 +1,117 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import PostCommentForm from '../form';
+
+jest.mock( 'calypso/components/gravatar-with-hovercards', () => () => (
+	<div data-testid="gravatar" />
+) );
+jest.mock( 'calypso/blocks/user-mentions', () => ( {
+	__esModule: true,
+	default: ( Component ) => Component,
+	withUserMentions: ( Component ) => Component,
+} ) );
+
+const defaultPost = {
+	ID: 123,
+	site_ID: 456,
+	URL: 'https://example.com/post',
+	discussion: {
+		comments_open: true,
+		comment_count: 5,
+	},
+};
+
+const defaultProps = {
+	post: defaultPost,
+	onUpdateCommentText: jest.fn(),
+	onCommentSubmit: jest.fn(),
+};
+
+const renderForm = ( props = {} ) => {
+	return renderWithProvider( <PostCommentForm { ...defaultProps } { ...props } />, {
+		initialState: {
+			currentUser: {
+				id: 1,
+				user: { ID: 1, display_name: 'Test User' },
+			},
+		},
+	} );
+};
+
+describe( 'PostCommentForm', () => {
+	describe( 'when comments are open', () => {
+		it( 'renders the comment form', () => {
+			renderForm();
+			expect( screen.getByPlaceholderText( 'Add a comment…' ) ).toBeVisible();
+		} );
+	} );
+
+	describe( 'when comments are closed', () => {
+		it( 'shows "Comments closed." when there are existing comments', () => {
+			renderForm( {
+				post: {
+					...defaultPost,
+					discussion: { comments_open: false, comment_count: 3 },
+				},
+			} );
+			expect( screen.getByText( 'Comments closed.' ) ).toBeVisible();
+		} );
+
+		it( 'renders nothing when there are no comments', () => {
+			const { container } = renderForm( {
+				post: {
+					...defaultPost,
+					discussion: { comments_open: false, comment_count: 0 },
+				},
+			} );
+			expect( container ).toBeEmptyDOMElement();
+		} );
+	} );
+
+	describe( 'when login is required to comment', () => {
+		it( 'shows the registration required message', () => {
+			renderForm( {
+				post: {
+					...defaultPost,
+					discussion: {
+						comments_open: false,
+						comment_count: 5,
+						comments_require_registration: true,
+					},
+				},
+			} );
+			expect( screen.getByText( /This site requires registration to comment/ ) ).toBeVisible();
+		} );
+
+		it( 'links to the original post', () => {
+			renderForm( {
+				post: {
+					...defaultPost,
+					discussion: {
+						comments_open: false,
+						comments_require_registration: true,
+					},
+				},
+			} );
+			const link = screen.getByRole( 'link', { name: /Visit the original post/ } );
+			expect( link ).toHaveAttribute( 'href', 'https://example.com/post' );
+			expect( link ).toHaveAttribute( 'target', '_blank' );
+		} );
+
+		it( 'does not render the comment textarea', () => {
+			renderForm( {
+				post: {
+					...defaultPost,
+					discussion: {
+						comments_open: true,
+						comments_require_registration: true,
+					},
+				},
+			} );
+			expect( screen.queryByPlaceholderText( 'Add a comment…' ) ).not.toBeInTheDocument();
+		} );
+	} );
+} );

--- a/client/blocks/comments/test/form.jsx
+++ b/client/blocks/comments/test/form.jsx
@@ -72,13 +72,12 @@ describe( 'PostCommentForm', () => {
 	} );
 
 	describe( 'when login is required to comment', () => {
-		it( 'shows the registration required message', () => {
+		it( 'shows the registration required message when comments are open', () => {
 			renderForm( {
 				post: {
 					...defaultPost,
 					discussion: {
-						comments_open: false,
-						comment_count: 5,
+						comments_open: true,
 						comments_require_registration: true,
 					},
 				},
@@ -91,7 +90,7 @@ describe( 'PostCommentForm', () => {
 				post: {
 					...defaultPost,
 					discussion: {
-						comments_open: false,
+						comments_open: true,
 						comments_require_registration: true,
 					},
 				},
@@ -112,6 +111,20 @@ describe( 'PostCommentForm', () => {
 				},
 			} );
 			expect( screen.queryByPlaceholderText( 'Add a comment…' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'shows comments closed when comments_open is false even with registration required', () => {
+			renderForm( {
+				post: {
+					...defaultPost,
+					discussion: {
+						comments_open: false,
+						comment_count: 5,
+						comments_require_registration: true,
+					},
+				},
+			} );
+			expect( screen.getByText( 'Comments closed.' ) ).toBeVisible();
 		} );
 	} );
 } );

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -31,7 +31,7 @@ import ReaderBackButton from 'calypso/reader/components/back-button';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import { canBeMarkedAsSeen, getSiteName, isEligibleForUnseen } from 'calypso/reader/get-helpers';
 import readerContentWidth from 'calypso/reader/lib/content-width';
-import { isCommentable } from 'calypso/reader/post/capabilities';
+import { isCommentable, isLoginRequiredToComment } from 'calypso/reader/post/capabilities';
 import PostExcerptLink from 'calypso/reader/post-excerpt-link';
 import { keyForPost } from 'calypso/reader/post-key';
 import { ReaderPerformanceTrackerStop } from 'calypso/reader/reader-performance-tracker';
@@ -805,7 +805,7 @@ export class FullPostView extends Component {
 									onCommentClick={ this.handleCommentClick }
 									onEditClick={ this.onEditClick }
 									commentsApiDisabled={ commentsApiDisabled }
-									showComments={ isCommentable( post ) }
+									showComments={ isCommentable( post ) || isLoginRequiredToComment( post ) }
 									renderMarkAsSeenButton={
 										shouldShowMarkAsSeen ? this.renderMarkAsSenButton : null
 									}
@@ -847,21 +847,22 @@ export class FullPostView extends Component {
 							{ ! isLoading && <ReaderPerformanceTrackerStop /> }
 
 							<div className="reader-full-post__comments-wrapper" ref={ this.commentsWrapper }>
-								{ ! commentsApiDisabled && isCommentable( post ) && (
-									<Comments
-										showNestingReplyArrow
-										post={ post }
-										initialSize={ startingCommentId ? commentCount : 10 }
-										pageSize={ 25 }
-										startingCommentId={ startingCommentId }
-										commentCount={ commentCount }
-										maxDepth={ 1 }
-										commentsFilterDisplay={ COMMENTS_FILTER_ALL }
-										showConversationFollowButton
-										shouldPollForNewComments={ config.isEnabled( 'reader/comment-polling' ) }
-										shouldHighlightNew
-									/>
-								) }
+								{ ! commentsApiDisabled &&
+									( isCommentable( post ) || isLoginRequiredToComment( post ) ) && (
+										<Comments
+											showNestingReplyArrow
+											post={ post }
+											initialSize={ startingCommentId ? commentCount : 10 }
+											pageSize={ 25 }
+											startingCommentId={ startingCommentId }
+											commentCount={ commentCount }
+											maxDepth={ 1 }
+											commentsFilterDisplay={ COMMENTS_FILTER_ALL }
+											showConversationFollowButton
+											shouldPollForNewComments={ config.isEnabled( 'reader/comment-polling' ) }
+											shouldHighlightNew
+										/>
+									) }
 							</div>
 
 							{ isDefaultLayout && (

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -31,7 +31,7 @@ import ReaderBackButton from 'calypso/reader/components/back-button';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import { canBeMarkedAsSeen, getSiteName, isEligibleForUnseen } from 'calypso/reader/get-helpers';
 import readerContentWidth from 'calypso/reader/lib/content-width';
-import { isCommentable, isLoginRequiredToComment } from 'calypso/reader/post/capabilities';
+import { isCommentsOpen, isLoginRequiredToComment } from 'calypso/reader/post/capabilities';
 import PostExcerptLink from 'calypso/reader/post-excerpt-link';
 import { keyForPost } from 'calypso/reader/post-key';
 import { ReaderPerformanceTrackerStop } from 'calypso/reader/reader-performance-tracker';
@@ -805,7 +805,11 @@ export class FullPostView extends Component {
 									onCommentClick={ this.handleCommentClick }
 									onEditClick={ this.onEditClick }
 									commentsApiDisabled={ commentsApiDisabled }
-									showComments={ isCommentable( post ) || isLoginRequiredToComment( post ) }
+									showComments={
+										isCommentsOpen( post ) ||
+										isLoginRequiredToComment( post ) ||
+										post.discussion?.comment_count > 0
+									}
 									renderMarkAsSeenButton={
 										shouldShowMarkAsSeen ? this.renderMarkAsSenButton : null
 									}
@@ -848,7 +852,9 @@ export class FullPostView extends Component {
 
 							<div className="reader-full-post__comments-wrapper" ref={ this.commentsWrapper }>
 								{ ! commentsApiDisabled &&
-									( isCommentable( post ) || isLoginRequiredToComment( post ) ) && (
+									( isCommentsOpen( post ) ||
+										isLoginRequiredToComment( post ) ||
+										post.discussion?.comment_count > 0 ) && (
 										<Comments
 											showNestingReplyArrow
 											post={ post }

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -7,6 +7,7 @@ import ReaderCommentIcon from 'calypso/reader/components/icons/comment-icon';
 import LikeButton from 'calypso/reader/like-button';
 import {
 	isCommentable,
+	isLoginRequiredToComment,
 	isSharable,
 	isRebloggable,
 	isLikeable,
@@ -30,7 +31,7 @@ const ReaderPostActions = ( {
 	const hasSites = !! useSelector( getPrimarySiteId );
 	const showShare = isSharable( post );
 	const showReblog = isRebloggable( post, hasSites );
-	const showComments = isCommentable( post );
+	const showComments = isCommentable( post ) || isLoginRequiredToComment( post );
 	const showLikes = isLikeable( post );
 	const listClassnames = clsx( 'reader-post-actions', className );
 	const isAutomattician = useSelector( isA8cTeamMember );

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -6,8 +6,7 @@ import ShareButton from 'calypso/blocks/reader-share';
 import ReaderCommentIcon from 'calypso/reader/components/icons/comment-icon';
 import LikeButton from 'calypso/reader/like-button';
 import {
-	isCommentable,
-	isLoginRequiredToComment,
+	isCommentsOpen,
 	isSharable,
 	isRebloggable,
 	isLikeable,
@@ -31,7 +30,7 @@ const ReaderPostActions = ( {
 	const hasSites = !! useSelector( getPrimarySiteId );
 	const showShare = isSharable( post );
 	const showReblog = isRebloggable( post, hasSites );
-	const showComments = isCommentable( post ) || isLoginRequiredToComment( post );
+	const showComments = isCommentsOpen( post ) || post.discussion?.comment_count > 0;
 	const showLikes = isLikeable( post );
 	const listClassnames = clsx( 'reader-post-actions', className );
 	const isAutomattician = useSelector( isA8cTeamMember );

--- a/client/blocks/reader-post-card/post-card-comments.jsx
+++ b/client/blocks/reader-post-card/post-card-comments.jsx
@@ -2,6 +2,7 @@ import config from '@automattic/calypso-config';
 import { useEffect } from 'react';
 import PostComments from 'calypso/blocks/comments';
 import { COMMENTS_FILTER_ALL } from 'calypso/blocks/comments/comments-filters';
+import { isCommentsOpen } from 'calypso/reader/post/capabilities';
 import { recordAction, recordGaEvent, recordTrackForPost } from 'calypso/reader/stats';
 import { useDispatch, useSelector } from 'calypso/state';
 import { requestPostComments } from 'calypso/state/comments/actions';
@@ -16,8 +17,7 @@ const PostCardComments = ( { post, handleClick, fixedHeaderHeight, streamKey } )
 
 	// If the user is unable to comment and the comment count is zero, there is no reason to fetch
 	// and show comments.
-	const shouldHideComments =
-		! post.discussion?.comments_open && post.discussion?.comment_count === 0;
+	const shouldHideComments = ! isCommentsOpen( post ) && post.discussion?.comment_count === 0;
 
 	useEffect( () => {
 		// Request comments if they have not been set in state.

--- a/client/reader/post/capabilities/index.ts
+++ b/client/reader/post/capabilities/index.ts
@@ -12,15 +12,8 @@ interface ReaderPost {
 	};
 }
 
-export function isCommentable( post: ReaderPost ): boolean {
-	if (
-		post.discussion &&
-		( post.discussion.comments_open || ( post.discussion.comment_count ?? 0 ) > 0 )
-	) {
-		return true;
-	}
-
-	return false;
+export function isCommentsOpen( post: ReaderPost ): boolean {
+	return !! post.discussion?.comments_open;
 }
 
 export function isLoginRequiredToComment( post: ReaderPost ): boolean {
@@ -62,5 +55,5 @@ export function isLikeable( post: ReaderPost ): boolean {
 }
 
 export function isConversationFollowable( post: ReaderPost ): boolean {
-	return !! post?.site_ID && ! post?.is_external && isCommentable( post );
+	return !! post?.site_ID && ! post?.is_external && isCommentsOpen( post );
 }

--- a/client/reader/post/capabilities/index.ts
+++ b/client/reader/post/capabilities/index.ts
@@ -8,6 +8,7 @@ interface ReaderPost {
 	discussion?: {
 		comments_open?: boolean;
 		comment_count?: number;
+		comments_require_registration?: boolean;
 	};
 }
 
@@ -20,6 +21,10 @@ export function isCommentable( post: ReaderPost ): boolean {
 	}
 
 	return false;
+}
+
+export function isLoginRequiredToComment( post: ReaderPost ): boolean {
+	return !! post.discussion?.comments_require_registration;
 }
 
 export function isSharable( post: ReaderPost ): boolean {

--- a/client/reader/post/capabilities/test/index.ts
+++ b/client/reader/post/capabilities/test/index.ts
@@ -1,5 +1,5 @@
 import {
-	isCommentable,
+	isCommentsOpen,
 	isLoginRequiredToComment,
 	isSharable,
 	isRebloggable,
@@ -8,29 +8,21 @@ import {
 } from '../index';
 
 describe( 'reader/post/capabilities', () => {
-	describe( 'isCommentable', () => {
+	describe( 'isCommentsOpen', () => {
 		it( 'returns true when comments_open is true', () => {
-			expect( isCommentable( { discussion: { comments_open: true } } ) ).toBe( true );
+			expect( isCommentsOpen( { discussion: { comments_open: true } } ) ).toBe( true );
 		} );
 
-		it( 'returns true when comments_open is false but comment_count > 0', () => {
-			expect( isCommentable( { discussion: { comments_open: false, comment_count: 3 } } ) ).toBe(
-				true
-			);
-		} );
-
-		it( 'returns false when comments_open is false and comment_count is 0', () => {
-			expect( isCommentable( { discussion: { comments_open: false, comment_count: 0 } } ) ).toBe(
-				false
-			);
+		it( 'returns false when comments_open is false', () => {
+			expect( isCommentsOpen( { discussion: { comments_open: false } } ) ).toBe( false );
 		} );
 
 		it( 'returns false when discussion is undefined', () => {
-			expect( isCommentable( {} ) ).toBe( false );
+			expect( isCommentsOpen( {} ) ).toBe( false );
 		} );
 
 		it( 'returns false when discussion exists but has no properties', () => {
-			expect( isCommentable( { discussion: {} } ) ).toBe( false );
+			expect( isCommentsOpen( { discussion: {} } ) ).toBe( false );
 		} );
 	} );
 
@@ -147,11 +139,11 @@ describe( 'reader/post/capabilities', () => {
 			).toBe( false );
 		} );
 
-		it( 'returns false when post is not commentable', () => {
+		it( 'returns false when comments are not open', () => {
 			expect(
 				isConversationFollowable( {
 					site_ID: 1,
-					discussion: { comments_open: false, comment_count: 0 },
+					discussion: { comments_open: false },
 				} )
 			).toBe( false );
 		} );

--- a/client/reader/post/capabilities/test/index.ts
+++ b/client/reader/post/capabilities/test/index.ts
@@ -1,5 +1,6 @@
 import {
 	isCommentable,
+	isLoginRequiredToComment,
 	isSharable,
 	isRebloggable,
 	isLikeable,
@@ -30,6 +31,28 @@ describe( 'reader/post/capabilities', () => {
 
 		it( 'returns false when discussion exists but has no properties', () => {
 			expect( isCommentable( { discussion: {} } ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'isLoginRequiredToComment', () => {
+		it( 'returns true when comments_require_registration is true', () => {
+			expect(
+				isLoginRequiredToComment( {
+					discussion: { comments_require_registration: true },
+				} )
+			).toBe( true );
+		} );
+
+		it( 'returns false when comments_require_registration is false', () => {
+			expect(
+				isLoginRequiredToComment( {
+					discussion: { comments_require_registration: false },
+				} )
+			).toBe( false );
+		} );
+
+		it( 'returns false when discussion is undefined', () => {
+			expect( isLoginRequiredToComment( {} ) ).toBe( false );
 		} );
 	} );
 


### PR DESCRIPTION
Part of READ-343

## Proposed Changes
- Shows a message saying "This blog requires you to be logged in to comment" on blogs that require registration

| before | after |
|--------|--------|
| <img width="1640" height="1566" alt="CleanShot 2026-03-27 at 14 02 39@2x" src="https://github.com/user-attachments/assets/d3f844b8-e4f8-4962-b4c4-59e812b441c3" /> | <img width="1642" height="1662" alt="CleanShot 2026-03-27 at 14 03 56@2x" src="https://github.com/user-attachments/assets/6bb7e125-1177-44fd-9437-7fcbe3cea1c8" /> |


## Why are these changes being made?

The Reader UI only checked `comments_open` to decide whether to show the comment form, ignoring if the blog requires registration and doesn't support wpcom login, but the UI was showing "comments closed" — which is misleading. Comments aren't closed; the user just needs to log in on the original site.

Check the liner issue for more details 


## Testing Instructions
## NOTE YOU NEED TO SANDBOX THE PUBLIC API USING THE BRANCH Automattic/wpcom/pull/209611


Scenario 1: (Atomic + Require registration)
* Sandbox the API using the PR Automattic/wpcom/pull/209611
* Go to /reader 
* Subscribe https://make.wordpress.org/core/
* Check if you can't see the comment form
* Click on reply and check the same message.

Scenario 2: (Free + Require registration)
- Create a free site
- Go to /wp-admin/options-discussion.php
- Turn ON "Users must be registered and logged in to comment."
- Turn OFF "Let visitors use a WordPress.com or Facebook account to comment" (Verbum)
- Check if you can't see the comment form
- Click on reply and check the same message.

~Scenario 3: (Free + Require registration + Verbum ON)~
~- Create a free site~
~- Go to /wp-admin/options-discussion.php~
~- Turn ON "Users must be registered and logged in to comment."~
~- Turn ON "Let visitors use a WordPress.com or Facebook account to comment" (Verbum)~
~- Check if you can submit comments and replays~



## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?