### PR TITLE
Woo Hosted Plans: allow changing to lower plan tiers from free plan

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -20,6 +20,7 @@ import {
 	getSimplifiedPlanFeaturesGroupedForFeaturesGrid,
 	getWordPressHostingFeaturesGroupedForFeaturesGrid,
 	isWooHostedPlan,
+	isWooHostedFreePlan,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, Spinner } from '@automattic/components';
@@ -310,7 +311,12 @@ const PlansFeaturesMain = ( {
 	// Users can only select interval types that are equal to or longer than their current plan's interval
 	// Only apply this fix in the plan-upgrade flow to avoid breaking other flows
 	const currentPlanTerm =
-		isStepperUpgradeFlow && sitePlanSlug ? getPlan( sitePlanSlug )?.term : null;
+		isStepperUpgradeFlow &&
+		sitePlanSlug &&
+		! isFreePlan( sitePlanSlug ) &&
+		! isWooHostedFreePlan( sitePlanSlug )
+			? getPlan( sitePlanSlug )?.term
+			: null;
 	const compatibleIntervalType = useMemo(
 		() => ensureCompatibleIntervalType( currentPlanTerm, intervalType ),
 		[ currentPlanTerm, intervalType ]


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-1805/

## Proposed changes

This fixes the monthly/yearly plan term selector in the Woo Hosted upgrade flow by exempting WooHosted free plans from a billing interval compatibility restriction that was blocking monthly plan selection.

* Add `isWooHostedFreePlan` to imports in `plans-features-main/index.tsx`
* Exclude WooHosted free plans from the `currentPlanTerm` computation, so `ensureCompatibleIntervalType` no longer forces the selector back to yearly for sites on these plans

## Why are these changes being made?

`PLAN_WOO_HOSTED_FREE` uses an annual timeframe internally, even though it's a free/trial plan. `ensureCompatibleIntervalType` prevents users in upgrade flows from selecting billing intervals shorter than their current plan's term. Because the free plan registers as annual, this caused the monthly selector to snap back to yearly immediately after being clicked — the option appeared visible but couldn't be selected.

`useFilteredDisplayedIntervals` already handles this correctly by exempting free plans and WooHosted free plans from its interval filtering (`! isFreePlan( productSlug ) && ! isWooHostedFreePlan( productSlug )`). This fix applies the same exemption to the `currentPlanTerm` guard that feeds `ensureCompatibleIntervalType`, making the two mechanisms consistent. The result: sites on WooHosted free/trial plans can freely toggle between monthly and yearly to compare pricing.

## Testing instructions

Manual testing:
* Open `/setup/woo-hosted-plans/plans?siteSlug=<woo-hosted-site>` on your sandbox
* Confirm both "Pay monthly" and "Pay yearly" appear in the plan term selector
* Click "Pay monthly" and confirm the selector stays on monthly and plan prices update accordingly
* Click "Pay yearly" and confirm it switches back
