### PR TITLE
Docker Image: Inline refresh: Fix race conditions

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -223,36 +223,67 @@ object BuildDockerImage : BuildType({
 					docker pull "${'$'}ref" >/dev/null 2>&1 || return 1
 
 					docker image inspect "${'$'}ref" \
-						--format '{{range .RepoDigests}}{{println .}}{{end}}' \
-						| grep '^registry\.a8c\.com/calypso/cache-seed@sha256:' \
-						| head -n1
+						--format '{{if .RepoDigests}}{{index .RepoDigests 0}}{{end}}'
 				}
 
+				read_cache_seed_key() {
+					local ref="${'$'}1"
+
+					docker image inspect "${'$'}ref" \
+						--format '{{with index .Config.Labels "io.calypso.cache-seed-key"}}{{.}}{{end}}' \
+						2>/dev/null || true
+				}
+
+				default_cache_seed_image="registry.a8c.com/calypso/cache-seed:latest"
 				update_cache_seed=false
 				generate_cache_image=false
 				resolved_cache_seed_image="%cache_seed_image%"
 
 				if [[ "%cache_mode%" == "seed" ]]; then
-					key_ref="registry.a8c.com/calypso/cache-seed:key-${'$'}cache_seed_key"
+					if [[ "%cache_seed_image%" == "${'$'}default_cache_seed_image" ]]; then
+						key_ref="registry.a8c.com/calypso/cache-seed:key-${'$'}cache_seed_key"
 
-					if resolved_cache_seed_image=$(resolve_cache_seed_digest "${'$'}key_ref"); then
-						echo "Using cache-seed image for current key: ${'$'}resolved_cache_seed_image"
+						if resolved_cache_seed_image=$(resolve_cache_seed_digest "${'$'}key_ref"); then
+							echo "Using cache-seed image for current key: ${'$'}resolved_cache_seed_image"
+						else
+							echo "No exact cache-seed image found for key ${'$'}cache_seed_key; falling back to %cache_seed_image%."
+
+							if resolved_cache_seed_image=$(resolve_cache_seed_digest "%cache_seed_image%"); then
+								echo "Resolved cache-seed input: ${'$'}resolved_cache_seed_image"
+							else
+								echo "Could not resolve %cache_seed_image% to a digest; falling back to tag."
+								resolved_cache_seed_image="%cache_seed_image%"
+							fi
+
+							if [[ "%teamcity.build.branch.is_default%" == "true" ]]; then
+								echo "Cache-seed key is missing; enabling inline cache regeneration."
+								update_cache_seed=true
+								generate_cache_image=true
+							else
+								echo "Cache-seed key is missing, but this is not the default branch."
+							fi
+						fi
 					else
-						echo "No exact cache-seed image found for key ${'$'}cache_seed_key; falling back to %cache_seed_image%."
+						echo "Explicit cache-seed image override detected (%cache_seed_image%); bypassing canonical key lookup."
 
 						if resolved_cache_seed_image=$(resolve_cache_seed_digest "%cache_seed_image%"); then
-							echo "Resolved cache-seed input: ${'$'}resolved_cache_seed_image"
+							echo "Resolved explicit cache-seed input: ${'$'}resolved_cache_seed_image"
 						else
 							echo "Could not resolve %cache_seed_image% to a digest; falling back to tag."
 							resolved_cache_seed_image="%cache_seed_image%"
 						fi
 
 						if [[ "%teamcity.build.branch.is_default%" == "true" ]]; then
-							echo "Cache-seed key is missing; enabling inline cache regeneration."
-							update_cache_seed=true
-							generate_cache_image=true
-						else
-							echo "Cache-seed key is missing, but this is not the default branch."
+							existing_cache_seed_key=$(read_cache_seed_key "${'$'}resolved_cache_seed_image")
+							echo "Explicit cache-seed key: ${'$'}{existing_cache_seed_key:-<missing>}"
+
+							if [[ -z "${'$'}existing_cache_seed_key" || "${'$'}existing_cache_seed_key" != "${'$'}cache_seed_key" ]]; then
+								echo "Explicit cache-seed image does not match the current key; enabling inline cache regeneration."
+								update_cache_seed=true
+								generate_cache_image=true
+							else
+								echo "Explicit cache-seed image already matches the current key."
+							fi
 						fi
 					fi
 				elif [[ "%cache_mode%" == "base" && "%UPDATE_BASE_IMAGE_CACHE%" == "true" ]]; then
@@ -450,6 +481,7 @@ object BuildDockerImage : BuildType({
 					path = "Dockerfile"
 				}
 				namesAndTags = """
+					registry.a8c.com/calypso/cache-seed:latest
 					registry.a8c.com/calypso/cache-seed:key-%CACHE_SEED_KEY%
 					registry.a8c.com/calypso/cache-seed:build-%build.number%
 				""".trimIndent()

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -126,6 +126,7 @@ object BuildDockerImage : BuildType({
 			unchecked = "false"
 		)
 		param("CACHE_SEED_KEY", "")
+		param("RESOLVED_CACHE_SEED_IMAGE", "%cache_seed_image%")
 		param("UPDATE_CACHE_SEED", "false")
 		param("GENERATE_CACHE_IMAGE", "false")
 		param("env.WEBPACK_CACHE_INVALIDATED", "false")
@@ -216,26 +217,43 @@ object BuildDockerImage : BuildType({
 				echo "Computed cache-seed key: ${'$'}cache_seed_key"
 				echo "##teamcity[setParameter name='CACHE_SEED_KEY' value='${'$'}cache_seed_key']"
 
+				resolve_cache_seed_digest() {
+					local ref="${'$'}1"
+
+					docker pull "${'$'}ref" >/dev/null 2>&1 || return 1
+
+					docker image inspect "${'$'}ref" \
+						--format '{{range .RepoDigests}}{{println .}}{{end}}' \
+						| grep '^registry\.a8c\.com/calypso/cache-seed@sha256:' \
+						| head -n1
+				}
+
 				update_cache_seed=false
 				generate_cache_image=false
+				resolved_cache_seed_image="%cache_seed_image%"
 
-				if [[ "%cache_mode%" == "seed" && "%teamcity.build.branch.is_default%" == "true" ]]; then
-					docker pull "%cache_seed_image%" >/dev/null 2>&1 || true
+				if [[ "%cache_mode%" == "seed" ]]; then
+					key_ref="registry.a8c.com/calypso/cache-seed:key-${'$'}cache_seed_key"
 
-					existing_cache_seed_key=$(
-						docker image inspect "%cache_seed_image%" \
-							--format '{{with index .Config.Labels "io.calypso.cache-seed-key"}}{{.}}{{end}}' \
-							2>/dev/null || true
-					)
-
-					echo "Existing cache-seed key: ${'$'}{existing_cache_seed_key:-<missing>}"
-
-					if [[ -z "${'$'}existing_cache_seed_key" || "${'$'}existing_cache_seed_key" != "${'$'}cache_seed_key" ]]; then
-						echo "Cache-seed image is stale or unlabeled; enabling inline cache regeneration."
-						update_cache_seed=true
-						generate_cache_image=true
+					if resolved_cache_seed_image=$(resolve_cache_seed_digest "${'$'}key_ref"); then
+						echo "Using cache-seed image for current key: ${'$'}resolved_cache_seed_image"
 					else
-						echo "Cache-seed image is current."
+						echo "No exact cache-seed image found for key ${'$'}cache_seed_key; falling back to %cache_seed_image%."
+
+						if resolved_cache_seed_image=$(resolve_cache_seed_digest "%cache_seed_image%"); then
+							echo "Resolved cache-seed input: ${'$'}resolved_cache_seed_image"
+						else
+							echo "Could not resolve %cache_seed_image% to a digest; falling back to tag."
+							resolved_cache_seed_image="%cache_seed_image%"
+						fi
+
+						if [[ "%teamcity.build.branch.is_default%" == "true" ]]; then
+							echo "Cache-seed key is missing; enabling inline cache regeneration."
+							update_cache_seed=true
+							generate_cache_image=true
+						else
+							echo "Cache-seed key is missing, but this is not the default branch."
+						fi
 					fi
 				elif [[ "%cache_mode%" == "base" && "%UPDATE_BASE_IMAGE_CACHE%" == "true" ]]; then
 					echo "Base mode selected with UPDATE_BASE_IMAGE_CACHE=true; enabling writable cache."
@@ -244,9 +262,11 @@ object BuildDockerImage : BuildType({
 					echo "No inline cache refresh required for this build."
 				fi
 
+				echo "RESOLVED_CACHE_SEED_IMAGE=${'$'}resolved_cache_seed_image"
 				echo "UPDATE_CACHE_SEED=${'$'}update_cache_seed"
 				echo "GENERATE_CACHE_IMAGE=${'$'}generate_cache_image"
 
+				echo "##teamcity[setParameter name='RESOLVED_CACHE_SEED_IMAGE' value='${'$'}resolved_cache_seed_image']"
 				echo "##teamcity[setParameter name='UPDATE_CACHE_SEED' value='${'$'}update_cache_seed']"
 				echo "##teamcity[setParameter name='GENERATE_CACHE_IMAGE' value='${'$'}generate_cache_image']"
 			""".trimIndent()
@@ -259,7 +279,7 @@ object BuildDockerImage : BuildType({
 			--build-arg node_memory=16384
 			--build-arg cache_mode=%cache_mode%
 			--build-arg base_image=%base_image%
-			--build-arg cache_seed_image=%cache_seed_image%
+			--build-arg cache_seed_image=%RESOLVED_CACHE_SEED_IMAGE%
 			--build-arg cache_seed_key=%CACHE_SEED_KEY%
 			--build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber}
 			--build-arg profile=%PROFILE%
@@ -396,6 +416,28 @@ object BuildDockerImage : BuildType({
 			}
 		}
 
+		script {
+			name = "Skip cache refresh if key already exists"
+			conditions {
+				equals("cache_mode", "seed")
+				equals("UPDATE_CACHE_SEED", "true")
+				equals("teamcity.build.branch.is_default", "true")
+			}
+			scriptContent = """
+				#!/usr/bin/env bash
+				set -euo pipefail
+
+				key_ref="registry.a8c.com/calypso/cache-seed:key-%CACHE_SEED_KEY%"
+
+				if docker pull "${'$'}key_ref" >/dev/null 2>&1; then
+					echo "Exact cache-seed key already published by another build; skipping refresh."
+					echo "##teamcity[setParameter name='UPDATE_CACHE_SEED' value='false']"
+				else
+					echo "Exact cache-seed key still missing; proceeding with inline refresh."
+				fi
+			""".trimIndent()
+		}
+
 		dockerCommand {
 			name = "Rebuild cache-seed image"
 			conditions {
@@ -408,12 +450,12 @@ object BuildDockerImage : BuildType({
 					path = "Dockerfile"
 				}
 				namesAndTags = """
-					registry.a8c.com/calypso/cache-seed:latest
+					registry.a8c.com/calypso/cache-seed:key-%CACHE_SEED_KEY%
 					registry.a8c.com/calypso/cache-seed:build-%build.number%
 				""".trimIndent()
 				commandArgs = """
 					--target update-cache-seed
-					--cache-from=registry.a8c.com/calypso/app:commit-${Settings.WpCalypso.paramRefs.buildVcsNumber},%cache_seed_image%
+					--cache-from=registry.a8c.com/calypso/app:commit-${Settings.WpCalypso.paramRefs.buildVcsNumber},%RESOLVED_CACHE_SEED_IMAGE%
 					$commonArgs
 				""".trimIndent().replace("\n"," ")
 			}
@@ -430,6 +472,7 @@ object BuildDockerImage : BuildType({
 			commandType = push {
 				namesAndTags = """
 					registry.a8c.com/calypso/cache-seed:latest
+					registry.a8c.com/calypso/cache-seed:key-%CACHE_SEED_KEY%
 					registry.a8c.com/calypso/cache-seed:build-%build.number%
 				""".trimIndent()
 			}

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -540,14 +540,17 @@ object BuildCacheSeedImages : BuildType({
 				set -euo pipefail
 
 				docker tag "registry.a8c.com/calypso/cache-seed:%build.number%" "registry.a8c.com/calypso/cache-seed:%image_tag%"
+				docker tag "registry.a8c.com/calypso/cache-seed:%build.number%" "registry.a8c.com/calypso/cache-seed:key-%CACHE_SEED_KEY%"
 
 				numbered_id=$(docker image inspect "registry.a8c.com/calypso/cache-seed:%build.number%" --format '{{.Id}}')
 				publish_id=$(docker image inspect "registry.a8c.com/calypso/cache-seed:%image_tag%" --format '{{.Id}}')
+				key_id=$(docker image inspect "registry.a8c.com/calypso/cache-seed:key-%CACHE_SEED_KEY%" --format '{{.Id}}')
 
 				echo "registry.a8c.com/calypso/cache-seed:%build.number% id=${'$'}numbered_id"
 				echo "registry.a8c.com/calypso/cache-seed:%image_tag% id=${'$'}publish_id"
+				echo "registry.a8c.com/calypso/cache-seed:key-%CACHE_SEED_KEY% id=${'$'}key_id"
 
-				if [[ "${'$'}numbered_id" != "${'$'}publish_id" ]]; then
+				if [[ "${'$'}numbered_id" != "${'$'}publish_id" || "${'$'}numbered_id" != "${'$'}key_id" ]]; then
 					echo "Tag mismatch for registry.a8c.com/calypso/cache-seed"
 					exit 1
 				fi
@@ -558,6 +561,7 @@ object BuildCacheSeedImages : BuildType({
 			commandType = push {
 				namesAndTags = """
 					registry.a8c.com/calypso/cache-seed:%image_tag%
+					registry.a8c.com/calypso/cache-seed:key-%CACHE_SEED_KEY%
 					registry.a8c.com/calypso/cache-seed:%build.number%
 				""".trimIndent()
 			}


### PR DESCRIPTION
## What is Inline Refresh?

The docker builds use a webpack persistent cache to speed themselves up most of the time. This is in registry.a8c.com/calypso/cache-seed. After some repo changes, like upgrading packages, it can no longer be used. We used to have slow builds when this happened until the every-6-hour-scheduled job refreshed the cache seed.

Enter inline refresh: In #109585+#109590, I added "inline refresh". If when building trunk, we cannot use the cache, we detect this case and do a few extra steps after the build to push the work we've already done to the cache seed.

This works, but there was a race case when commits are "stacked" on trunk and it's out of date.

## The race condition

The way it reuses work is with:
```
###################
# A cache-only update can be generated with "docker build --target update-cache-seed"
FROM scratch AS update-cache-seed
ARG commit_sha
ARG cache_seed_key

LABEL org.opencontainers.image.revision=$commit_sha \
	io.calypso.cache-seed-key=$cache_seed_key

COPY --from=builder /calypso/.cache /calypso/.cache
COPY --from=builder /calypso/.yarn /calypso/.yarn
```

Then it re-executes all the builder steps it just did, but since nothing changed they're all layer `CACHED`, so it doesn't have to do anything. The issue is that this is a moving target: `ARG cache_seed_image=registry.a8c.com/calypso/cache-seed:latest`.  If someone has pushed to cache-seed:latest while the build was running, then when it goes to "reuse the work", the layer caches never hit, and it tries doing a second build after. Which isn't ideal.

## The fix

Use an additional step to resolve the tag name to a specific digest, then pass that in.

## Proposed Changes

*

## Why are these changes being made?

*

## Testing Instructions


*

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
