### PR TITLE
Try Dolly as agent

### DIFF
--- a/packages/agents-manager/src/constants.ts
+++ b/packages/agents-manager/src/constants.ts
@@ -2,6 +2,6 @@ export const API_BASE_URL = 'https://public-api.wordpress.com';
 
 export const ORCHESTRATOR_AGENT_URL = `${ API_BASE_URL }/wpcom/v2/ai/agent`;
 export const ORCHESTRATOR_AGENT_ID = 'wp-orchestrator';
-export const UNIFIED_CHAT_AGENT_ID = 'wpcom-workflow-unified_chat';
+export const UNIFIED_CHAT_AGENT_ID = 'dolly';
 
 export const LOCAL_TOOL_RUNNING_MESSAGE = 'local_tool_running';

--- a/packages/agents-manager/src/utils/create-agent-config.ts
+++ b/packages/agents-manager/src/utils/create-agent-config.ts
@@ -107,6 +107,7 @@ async function createWrappedContextProvider(
 				constructorArguments: {
 					...( resolvedContext.constructorArguments || {} ),
 					...( version && { version } ),
+					client: 'agents-manager',
 				},
 			};
 		},
@@ -134,7 +135,10 @@ async function createDefaultContextProvider(
 			currentScreen: { url: window.location.href },
 			...( siteId && { selectedSiteId: siteId } ),
 			// TODO: Remove once agenttic-client supports top-level constructorArguments
-			...( version && { constructorArguments: { version } } ),
+			constructorArguments: {
+				...( version && { version } ),
+				client: 'agents-manager',
+			},
 		} ),
 	};
 }
@@ -166,6 +170,7 @@ export async function createAgentConfig(
 		sessionIdStorageKey: getSessionStorageKey( agentId ),
 		authProvider: createCalypsoAuthProvider( siteId ),
 		enableStreaming: true,
+		fetchCallback: fetch,
 	};
 
 	if ( toolProvider ) {


### PR DESCRIPTION
## Proposed Changes

* Try Dolly in Agents Manager

## Testing Instructions

* Requires
  * 313-ghe-Automattic/agenttic
  * 5904-gh-Automattic/big-sky-plugin
  * 209661-ghe-Automattic/wpcom
* Sync the agents manager app with your sandbox: `cd apps/agents-manager &&  yarn dev --sync`
* Make sure the Unified Experience is enabled: https://wordpress.com/wp-admin/profile.php
* Open the site editor and try talking with the agent

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?