### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,3 +80,34 @@ yarn reformat-files # Fix formatting with Prettier
   - Avoid mentioning people's names.
   - Do not link to wordpress.com URLs.
   - Include all checklist items from .github/PULL_REQUEST_TEMPLATE.md. Only mark items as completed (`[x]`) if they actually apply; leave inapplicable items unchecked (`[ ]`).
+
+## Cursor Cloud specific instructions
+
+### Hosts file entries
+
+The dev server requires these `/etc/hosts` entries (already configured in the VM snapshot):
+
+```
+127.0.0.1 calypso.localhost
+127.0.0.1 my.localhost
+127.0.0.1 my.woo.localhost
+```
+
+If missing, add them before starting any dev server.
+
+### Starting the dev server
+
+- `yarn start` — full Calypso (all clients). Builds packages, compiles webpack, and starts Express on port 3000. First build takes ~2-3 minutes.
+- `yarn start-dashboard` — Dashboard client only (faster, limits webpack entries). Served at `http://my.localhost:3000/`.
+- The Dashboard environment config uses hostname `my.localhost` (not `calypso.localhost`). The root URL `/` redirects to the WordPress.com login page when unauthenticated — this is expected.
+- Webpack hot-reloading is enabled; after the initial build completes ("Ready! All assets are re-compiled"), incremental rebuilds take ~5-10 seconds.
+
+### Running tests
+
+- Use scoped test commands for faster feedback: `yarn test-client <path>` or `yarn test-packages <path>`.
+- Full `yarn lint` runs all linters sequentially (`lint:config-defaults`, `lint:css`, `lint:js`, `lint:mixedindent`, `lint:unused-state-action-types`). For quick checks, run `yarn lint:js` or `yarn lint:css` directly.
+- The `.env` file does not exist and the "Failed to load ./.env" warning on startup is benign.
+
+### Node.js version
+
+This project requires Node.js 22.9.0 (pinned in `.nvmrc`). The update script handles version switching via nvm.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Proposed Changes

* Add a `## Cursor Cloud specific instructions` section to `AGENTS.md` with dev environment guidance for cloud agents, including hosts file entries, dev server startup caveats, test commands, and Node.js version details.

## Why are these changes being made?

This provides durable, non-obvious context for future Cursor Cloud agents working in this repository, so they can correctly start the dev server, run tests, and avoid common pitfalls (e.g., using `my.localhost` instead of `calypso.localhost` for the Dashboard client, ignoring the benign `.env` warning).

## Testing Instructions

* Verify the AGENTS.md additions are accurate by reviewing against the existing development documentation and `config/dashboard-development.json`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43280144-c249-4682-bb1e-99acec33680c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43280144-c249-4682-bb1e-99acec33680c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

