### PR TITLE
Reader: Fix stream error on user profile posts tab

### DIFF
--- a/client/reader/stream/error.tsx
+++ b/client/reader/stream/error.tsx
@@ -2,6 +2,8 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import EmptyContent from 'calypso/components/empty-content';
+import { useDispatch } from 'calypso/state';
+import { errorNotice } from 'calypso/state/notices/actions';
 
 /**
  * Props for the StreamError component.
@@ -11,10 +13,24 @@ import EmptyContent from 'calypso/components/empty-content';
 interface StreamErrorProps {
 	onTryAgain?: () => void;
 	streamKey: string;
+	error: {
+		message: string;
+	};
 }
 
-export const StreamError = ( { onTryAgain, streamKey }: StreamErrorProps ) => {
+export const StreamError = ( { onTryAgain, streamKey, error }: StreamErrorProps ) => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	useEffect( () => {
+		if ( ! error.message ) {
+			return;
+		}
+
+		dispatch(
+			errorNotice( translate( 'Stream error: %s', { args: error.message } ), { duration: 3000 } )
+		);
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	useEffect( () => {
 		recordTracksEvent( 'calypso_reader_stream_error', {

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -778,6 +778,7 @@ class ReaderStream extends Component {
 				<StreamError
 					onTryAgain={ this.tryAgain }
 					streamKey={ streamKey }
+					error={ this.props.error }
 					context={ this.state.selectedTab }
 				/>
 			);

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -356,6 +356,7 @@ const streamApis = {
 		path: ( { streamKey } ) => `/users/${ streamKeySuffix( streamKey ) }/posts`,
 		dateProperty: 'date',
 		apiVersion: '1',
+		pollQuery: () => getQueryStringForPoll( [], { number: 20 } ),
 	},
 };
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes: [READ-452](https://linear.app/a8c/issue/READ-452/user-profile-fix-something-went-wrong-on-posts-tab)

## Proposed Changes

- Override `number` param in data layer because our `v1/read/users/:id/posts` endpoint only support `number` param upto `20` but on polling we send `40` due to which API returns an error.
- Add a notification message in `StreamError` component that shows more detail about the error.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

User Profile > Posts tab were showing error message on its own after some time.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to /reader/users/mehmoodak
- Wait for 40s. The stream should be replaced with an error.
- Checkout this PR.
- Verify that the error isn't appearing now.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
