### PR TITLE
Reader: Show notice on interaction with subscribe button

### DIFF
--- a/client/blocks/reader-feed-header/badge.tsx
+++ b/client/blocks/reader-feed-header/badge.tsx
@@ -1,7 +1,13 @@
+import { Site } from '@automattic/api-core';
 import { Gridicon } from '@automattic/components';
-import PropTypes from 'prop-types';
 
-const ReaderFeedHeaderSiteBadge = ( { site } ) => {
+interface ReaderFeedHeaderSiteBadgeProps {
+	site?: Site;
+}
+
+const ReaderFeedHeaderSiteBadge = ( {
+	site,
+}: ReaderFeedHeaderSiteBadgeProps ): JSX.Element | null => {
 	/* eslint-disable wpcalypso/jsx-gridicon-size */
 	if ( site && site.is_private ) {
 		return <Gridicon icon="lock" size={ 14 } />;
@@ -12,11 +18,6 @@ const ReaderFeedHeaderSiteBadge = ( { site } ) => {
 	}
 
 	return null;
-	/* eslint-enable wpcalypso/jsx-gridicon-size */
-};
-
-ReaderFeedHeaderSiteBadge.propTypes = {
-	site: PropTypes.object,
 };
 
 export default ReaderFeedHeaderSiteBadge;

--- a/client/blocks/reader-feed-header/follow.jsx
+++ b/client/blocks/reader-feed-header/follow.jsx
@@ -1,4 +1,5 @@
 import { Gridicon } from '@automattic/components';
+import { filterURLForDisplay } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
 import { useDispatch, shallowEqual } from 'react-redux';
@@ -10,6 +11,7 @@ import { getSiteUrl, isEligibleForUnseen } from 'calypso/reader/get-helpers';
 import { RecommendButton } from 'calypso/reader/recommend-button';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserName } from 'calypso/state/current-user/selectors';
+import { successNotice } from 'calypso/state/notices/actions';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import { getFeed } from 'calypso/state/reader/feeds/selectors';
 import { hasReaderFollowOrganization, isFollowing } from 'calypso/state/reader/follows/selectors';
@@ -81,6 +83,17 @@ export default function ReaderFeedHeaderFollow( props ) {
 	}, shallowEqual );
 
 	const openSuggestedFollowsModal = ( followClicked ) => {
+		const displayName = site.name || filterURLForDisplay( feed.feed_URL ?? '' );
+
+		dispatch(
+			successNotice(
+				following
+					? translate( 'Success! You are now unsubscribed from "%s".', { args: displayName } )
+					: translate( 'Success! You are now subscribed to "%s".', { args: displayName } ),
+				{ duration: 3000 }
+			)
+		);
+
 		setIsSuggestedFollowsModalOpen( followClicked );
 	};
 

--- a/client/blocks/reader-feed-header/follow.tsx
+++ b/client/blocks/reader-feed-header/follow.tsx
@@ -2,14 +2,14 @@ import { Gridicon } from '@automattic/components';
 import { filterURLForDisplay } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
-import { useDispatch, shallowEqual } from 'react-redux';
+import { shallowEqual } from 'react-redux';
 import ReaderSiteNotificationSettings from 'calypso/blocks/reader-site-notification-settings';
 import ReaderSuggestedFollowsDialog from 'calypso/blocks/reader-suggested-follows/dialog';
 import { useFeedRecommendationsMutation } from 'calypso/data/reader/use-feed-recommendations-mutation';
 import ReaderFollowButton from 'calypso/reader/follow-button';
 import { getSiteUrl, isEligibleForUnseen } from 'calypso/reader/get-helpers';
 import { RecommendButton } from 'calypso/reader/recommend-button';
-import { useSelector } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
 import { getCurrentUserName } from 'calypso/state/current-user/selectors';
 import { successNotice } from 'calypso/state/notices/actions';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
@@ -25,8 +25,32 @@ import { getSite } from 'calypso/state/reader/sites/selectors';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
 import isFeedWPForTeams from 'calypso/state/selectors/is-feed-wpforteams';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import type { AppState } from 'calypso/types';
 
-export default function ReaderFeedHeaderFollow( props ) {
+interface ReaderFeedHeaderFollowProps {
+	feed?: ReaderFeed;
+	site?: ReaderSite;
+	streamKey?: string;
+}
+
+interface ReaderFeed {
+	feed_ID?: number;
+	feed_URL?: string;
+	blog_ID?: number;
+	URL?: string;
+	unseen_count?: number;
+	subscription_id?: number;
+	blog_owner?: string;
+	name?: string;
+}
+
+interface ReaderSite {
+	ID?: number;
+	feed_ID?: number;
+	name?: string;
+}
+
+export default function ReaderFeedHeaderFollow( props: ReaderFeedHeaderFollowProps ): JSX.Element {
 	const { feed, site, streamKey } = props;
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -34,12 +58,12 @@ export default function ReaderFeedHeaderFollow( props ) {
 	const siteId = site?.ID;
 	const siteUrl = getSiteUrl( { feed, site } );
 	const feedId = feed?.feed_ID;
-	const { isRecommended, toggleRecommended } = useFeedRecommendationsMutation( feedId );
+	const { isRecommended, toggleRecommended } = useFeedRecommendationsMutation( feedId as number );
 	const owner = useSelector( getCurrentUserName );
-	const isRequestingRecommendedBlogs = useSelector( ( state ) =>
+	const isRequestingRecommendedBlogs = useSelector( ( state: AppState ) =>
 		isRequestingUserRecommendedBlogs( state, owner )
 	);
-	const hasRequestedRecommendedBlogs = useSelector( ( state ) =>
+	const hasRequestedRecommendedBlogs = useSelector( ( state: AppState ) =>
 		hasRequestedUserRecommendedBlogs( state, owner )
 	);
 
@@ -56,20 +80,20 @@ export default function ReaderFeedHeaderFollow( props ) {
 		isWPForTeamsItem,
 		subscriptionId,
 		blogOwner,
-	} = useSelector( ( state ) => {
-		let _siteId = siteId;
-		let _feedId = feed?.feed_ID;
-		let _feed = _feedId ? getFeed( state, _feedId ) : undefined;
-		let _site = _siteId ? getSite( state, _siteId ) : undefined;
+	} = useSelector( ( state: AppState ) => {
+		let _siteId = siteId ?? 0;
+		let _feedId = feed?.feed_ID ?? 0;
+		let _feed: ReaderFeed | undefined = _feedId ? getFeed( state, _feedId ) : undefined;
+		let _site: ReaderSite | undefined = _siteId ? getSite( state, _siteId ) : undefined;
 
 		if ( _feed && ! _siteId ) {
-			_siteId = _feed.blog_ID || undefined;
-			_site = _siteId ? getSite( state, _feed.blog_ID ) : undefined;
+			_siteId = _feed.blog_ID || 0;
+			_site = _siteId ? getSite( state, _siteId ) : undefined;
 		}
 
 		if ( _site && ! _feedId ) {
-			_feedId = _site.feed_ID;
-			_feed = _feedId ? getFeed( state, _site.feed_ID ) : undefined;
+			_feedId = _site.feed_ID || 0;
+			_feed = _feedId ? getFeed( state, _feedId ) : undefined;
 		}
 
 		return {
@@ -82,8 +106,8 @@ export default function ReaderFeedHeaderFollow( props ) {
 		};
 	}, shallowEqual );
 
-	const openSuggestedFollowsModal = ( followClicked ) => {
-		const displayName = site.name || filterURLForDisplay( feed.feed_URL ?? '' );
+	const openSuggestedFollowsModal = ( followClicked: boolean ) => {
+		const displayName = site?.name || filterURLForDisplay( feed?.feed_URL ?? '' );
 
 		dispatch(
 			successNotice(
@@ -107,8 +131,8 @@ export default function ReaderFeedHeaderFollow( props ) {
 		dispatch(
 			requestMarkAllAsSeen( {
 				identifier: streamKey,
-				feedIds: [ feed.feed_ID ],
-				feedUrls: [ feed.URL ],
+				feedIds: [ feed?.feed_ID ],
+				feedUrls: [ feed?.URL ],
 			} )
 		);
 	};
@@ -126,7 +150,6 @@ export default function ReaderFeedHeaderFollow( props ) {
 								hasButtonStyle
 								iconSize={ 24 }
 								onFollowToggle={ openSuggestedFollowsModal }
-								followingLabel={ translate( 'Subscribed' ) }
 							/>
 
 							{ site && following && ! isEmailBlocked && (
@@ -168,6 +191,7 @@ export default function ReaderFeedHeaderFollow( props ) {
 			{ siteId && (
 				<ReaderSuggestedFollowsDialog
 					onClose={ onCloseSuggestedFollowModal }
+					postId={ null }
 					siteId={ +siteId }
 					isVisible={ isSuggestedFollowsModalOpen }
 					author={ blogOwner }

--- a/client/reader/get-helpers.ts
+++ b/client/reader/get-helpers.ts
@@ -39,7 +39,6 @@ export interface ReaderPost {
 }
 
 export interface ReaderFeed {
-	feed_ID?: number;
 	description: string;
 	feed_URL: string;
 	is_error: boolean;

--- a/client/reader/get-helpers.ts
+++ b/client/reader/get-helpers.ts
@@ -39,6 +39,7 @@ export interface ReaderPost {
 }
 
 export interface ReaderFeed {
+	feed_ID?: number;
 	description: string;
 	feed_URL: string;
 	is_error: boolean;
@@ -188,8 +189,8 @@ export const getSiteAuthorName = ( site: ReaderSite ): string => {
 
 interface isEligibleForUnseenArgs {
 	isWPForTeamsItem: boolean;
-	currentRoute: string | null;
-	hasOrganization: boolean | null;
+	currentRoute?: string | null;
+	hasOrganization?: boolean | null;
 }
 
 /**


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes: [READ-453](https://linear.app/a8c/issue/READ-453/reader-show-success-error-message-on-interacting-with-subscribe-button)

## Proposed Changes

- Show notification on interacting with "Subscribe" button present on Blog/Feed sidebar.
- Refactor `ReaderFeedHeaderSiteBadge` to TypeScript.
- Refactor `ReaderFeedHeaderFollow` to TypeScript.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Enhancements.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to any feeds page (example: reader/feeds/132345515)
- Click on Subscribe button and verify notice appears.
- Go to any blogs page (example: reader/blogs/241031857)
- Click on Subscribe button and verify notice appears.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
