### PR TITLE
Stats: Replace newsletter empty state CTA with settings deep link

### DIFF
--- a/client/my-sites/stats/const.js
+++ b/client/my-sites/stats/const.js
@@ -7,8 +7,6 @@ export const JETPACK_SUPPORT_URL_TRAFFIC =
 
 // eslint-disable-next-line wpcalypso/i18n-unlocalized-url
 export const SUBSCRIBERS_SUPPORT_URL = 'https://wordpress.com/support/subscribers/';
-// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
-export const NEWSLETTER_SUPPORT_URL = 'https://wordpress.com/support/newsletter/';
 export const INSIGHTS_SUPPORT_URL =
 	// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
 	'https://wordpress.com/support/stats/learn-insights-about-your-website/';

--- a/client/my-sites/stats/features/modules/shared/stats-empty-action-email.tsx
+++ b/client/my-sites/stats/features/modules/shared/stats-empty-action-email.tsx
@@ -1,52 +1,38 @@
+import config from '@automattic/calypso-config';
 import { mail } from '@automattic/components/src/icons';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { useSelector } from 'react-redux';
-import useSupportDocData from 'calypso/components/inline-support-link/use-support-doc-data';
 import EmptyStateAction from 'calypso/my-sites/stats/components/empty-state-action';
-import {
-	JETPACK_SUPPORT_NEWSLETTER_URL,
-	NEWSLETTER_SUPPORT_URL,
-} from 'calypso/my-sites/stats/const';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { JETPACK_SUPPORT_NEWSLETTER_URL } from 'calypso/my-sites/stats/const';
+import { isJetpackSite, getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { StatsEmptyActionProps } from './';
 
 const StatsEmptyActionEmail: React.FC< StatsEmptyActionProps > = ( { from } ) => {
 	const translate = useTranslate();
+	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const siteId = useSelector( getSelectedSiteId );
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 	const isJetpack = useSelector( ( state ) =>
 		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
 	);
 
-	const supportLink = localizeUrl(
-		isJetpack ? JETPACK_SUPPORT_NEWSLETTER_URL : NEWSLETTER_SUPPORT_URL
-	);
-
-	const { openSupportDoc } = useSupportDocData( {
-		supportLink,
-	} );
-
 	return (
 		<EmptyStateAction
 			icon={ mail }
-			text={ translate( 'Send emails with Newsletter' ) }
+			text={ translate( 'Set up your newsletter' ) }
 			analyticsDetails={ {
 				from: from,
 				feature: 'newsletter',
 			} }
 			onClick={ () => {
-				// analytics event tracting handled in EmptyStateAction component
-
-				// If the site is a Jetpack site, use the Jetpack links.
-				// Otherwise, use the WordPress.com links.
-
-				if ( isJetpack ) {
-					// open in new tab
+				if ( isJetpack || isOdysseyStats || ! siteSlug ) {
+					const supportLink = localizeUrl( JETPACK_SUPPORT_NEWSLETTER_URL );
 					setTimeout( () => window.open( supportLink, '_blank' ), 250 );
 				} else {
-					openSupportDoc();
+					setTimeout( () => ( window.location.href = `/settings/newsletter/${ siteSlug }` ), 250 );
 				}
 			} }
 		/>


### PR DESCRIPTION
Part of NL-533

## Proposed Changes

* Replace the newsletter empty state CTA deep link: instead of opening external support docs, navigate to `/settings/newsletter/:siteSlug` for WordPress.com sites
* Jetpack and Odyssey Stats contexts continue to open Jetpack support docs in a new tab (fallback)
* Update CTA text from "Send emails with Newsletter" to "Set up your newsletter"
* Add null-safety fallback: if `siteSlug` is unavailable, fall back to external docs

## Why are these changes being made?

The current empty state CTA for the newsletter module in Stats links to external documentation, which is a dead end for users who want to activate their newsletter. By deep-linking to `/settings/newsletter/:siteSlug`, users land directly on the newsletter activation page where they can take action.

## Testing Instructions

1. Go to Stats > Subscribers on a WordPress.com site that has subscribers but has never sent a newsletter email
2. The emails module empty state should show "Set up your newsletter" with a mail icon
3. Click it — should navigate to `/settings/newsletter/{your-site-slug}`
4. Repeat on a Jetpack self-hosted site or Odyssey Stats (wp-admin) — clicking should open `https://jetpack.com/support/newsletter` in a new tab
5. Check browser console for the `calypso_empty_state_interaction` analytics event firing with `feature: newsletter, from: module_emails`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?