### PR TITLE
Enable PostHog tracking in stage environment

### DIFF
--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -24,6 +24,7 @@
 		"catch-js-errors": true,
 		"ciab/allow-domain-features": true,
 		"ciab/custom-branding": true,
+		"posthog-tracking": true,
 		"cookie-banner": false,
 		"rum-tracking/logstash": true,
 		"dashboard/omnibar": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -31,6 +31,7 @@
 		"checkout/checkout-version": true,
 		"ciab/allow-domain-features": true,
 		"ciab/custom-branding": true,
+		"posthog-tracking": true,
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/razorpay": true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes WOOPRD-3232.

## Proposed Changes

This PR enables PostHog tracking in the staging environment as requested in pgzWbf-5ex-p2. This allows proxied access to trigger PostHog functionality, which is useful for confirming things are working as intended.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

PostHog is currently only enabled on production. Enabling on staging allows verification of tracking events and helps debug instrumentation during development.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Verify that `"posthog-tracking": true` is now present in both `config/stage.json` and `config/dashboard-stage.json`.
1. Verify that `"posthog-tracking": true` is still present in both `config/production.json` and `config/dashboard-production.json` (no regression).
1. Optionally, to confirm PostHog fires correctly:
   1. Temporarily add `"posthog-tracking": true` to the `features` object in `config/dashboard-development.json`.
   1. Run `yarn start-dashboard`.
   1. Open the DevTools Network tab and filter by posthog.com.
   1. Open `http://my.woo.localhost:3000/sites` and confirm PostHog requests are being made.
   1. Click **Add New store** (ai-site-builder-spec) and confirm PostHog requests are being made as well.
   1. Revert the change to config/dashboard-development.json.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?