### PR TITLE
Checkout: Make sure siteId query param is set when creating new site

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -251,17 +251,27 @@ function useRedirectOnTransactionSuccess( {
 			return;
 		}
 
-		// For siteless purchases where the pre-transaction redirect URL defaults to '/'
-		// (because the new site's ID was unknown before the transaction), use the
-		// receipt's blogId to redirect to the new site's thank-you page instead.
-		// Preserve any query params from the original redirectTo (e.g., ?flow=unified).
+		// For siteless purchases where the new site's ID was unknown at the time the
+		// redirect URL was generated (e.g. redirect payment methods like PayPal that
+		// build the thank-you URL before the transaction begins), resolve the site using
+		// the blogId from the receipt. Two cases are handled:
+		//
+		// 1. redirectTo is '/' or empty: construct the full thank-you URL from blogId
+		//    and receiptId, preserving any query params (e.g. ?checkout_type=unified).
+		// 2. redirectTo contains a ':siteId' placeholder: replace it with the real blogId.
+		//    This covers the onboarding cookie URL and ecommerce plan thank-you URL paths.
 		const { pathname, search } = redirectTo
 			? getUrlParts( redirectTo )
 			: { pathname: undefined, search: '' };
-		const effectiveRedirectTo =
-			( ! redirectTo || pathname === '/' ) && blogId && finalReceiptId
-				? `/checkout/thank-you/${ blogId }/${ finalReceiptId }${ search }`
-				: redirectTo;
+		const effectiveRedirectTo = ( () => {
+			if ( ( ! redirectTo || pathname === '/' ) && blogId && finalReceiptId ) {
+				return `/checkout/thank-you/${ blogId }/${ finalReceiptId }${ search }`;
+			}
+			if ( blogId && redirectTo?.includes( ':siteId' ) ) {
+				return redirectTo.replaceAll( ':siteId', String( blogId ) );
+			}
+			return redirectTo;
+		} )();
 
 		const redirectInstructions = getRedirectFromPendingPage( {
 			isLoadingOrder,

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -318,10 +318,13 @@ export default function getThankYouPageUrl( {
 
 	// Unified affiliate + paid media siteless checkout - handles post-checkout site creation flow
 	if ( sitelessCheckoutType === 'unified' ) {
-		// If there is an ecommerce plan in cart, redirect to checkout thank you page
+		// If there is an ecommerce plan in cart, redirect to checkout thank you page.
+		// Use ':siteId' as a placeholder when siteId is not yet known (redirect payment methods
+		// like PayPal generate this URL before the new site is created). The pending page will
+		// replace ':siteId' with the actual blogId from the receipt.
 		if ( cart && hasEcommercePlan( cart ) ) {
 			debug( 'redirecting to Commerce thank you' );
-			return `/checkout/thank-you/${ siteId }/${ receiptIdOrPlaceholder }`;
+			return `/checkout/thank-you/${ siteId ?? ':siteId' }/${ receiptIdOrPlaceholder }`;
 		}
 
 		// Get the post-checkout destination URL from cookie (set during onboarding-unified plans step)
@@ -332,7 +335,15 @@ export default function getThankYouPageUrl( {
 			urlFromCookie.includes( '/setup/onboarding-unified/post-checkout-onboarding' )
 		) {
 			debug( 'redirecting to the saved post-checkout destination' );
-			return addQueryArgs( { siteId }, urlFromCookie );
+			if ( siteId ) {
+				return addQueryArgs( { siteId }, urlFromCookie );
+			}
+			// siteId is not yet known (redirect payment methods like PayPal generate this URL
+			// before the new site is created). Append ':siteId' as a literal placeholder
+			// rather than using addQueryArgs, which would percent-encode the colon and prevent
+			// the pending page from detecting and replacing it.
+			const separator = urlFromCookie.includes( '?' ) ? '&' : '?';
+			return `${ urlFromCookie }${ separator }siteId=:siteId`;
 		}
 
 		// Fallback for unified checkout - let the pending page construct the URL

--- a/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
@@ -2089,5 +2089,64 @@ describe( 'getThankYouPageUrl', () => {
 
 			expect( url ).toBe( '/setup/onboarding-unified/post-checkout-onboarding?siteId=12345' );
 		} );
+
+		it( 'should append :siteId placeholder when cookie URL contains post-checkout-onboarding path but siteId is undefined', () => {
+			const getUrlFromCookie = jest.fn(
+				() => '/setup/onboarding-unified/post-checkout-onboarding'
+			);
+
+			const url = getThankYouPageUrl( {
+				...defaultArgs,
+				sitelessCheckoutType: 'unified',
+				siteId: undefined,
+				getUrlFromCookie,
+			} );
+
+			expect( url ).toBe( '/setup/onboarding-unified/post-checkout-onboarding?siteId=:siteId' );
+		} );
+
+		it( 'should append :siteId placeholder after existing query params when siteId is undefined', () => {
+			const getUrlFromCookie = jest.fn(
+				() => '/setup/onboarding-unified/post-checkout-onboarding?existing=param'
+			);
+
+			const url = getThankYouPageUrl( {
+				...defaultArgs,
+				sitelessCheckoutType: 'unified',
+				siteId: undefined,
+				getUrlFromCookie,
+			} );
+
+			expect( url ).toBe(
+				'/setup/onboarding-unified/post-checkout-onboarding?existing=param&siteId=:siteId'
+			);
+		} );
+
+		it( 'should use :siteId placeholder in ecommerce thank-you URL when siteId is undefined', () => {
+			const getUrlFromCookie = jest.fn(
+				() => '/setup/onboarding-unified/post-checkout-onboarding'
+			);
+			const receiptId = 67890;
+			const cart = {
+				...getMockCart(),
+				products: [
+					{
+						...getEmptyResponseCartProduct(),
+						product_slug: PLAN_ECOMMERCE,
+					},
+				],
+			};
+
+			const url = getThankYouPageUrl( {
+				...defaultArgs,
+				sitelessCheckoutType: 'unified',
+				siteId: undefined,
+				receiptId,
+				cart,
+				getUrlFromCookie,
+			} );
+
+			expect( url ).toBe( '/checkout/thank-you/:siteId/67890' );
+		} );
 	} );
 } );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-1820/

## Proposed changes

Fixes a redirect failure in the unified siteless checkout flow where completing payment via any redirect-based payment method would land the user on a "no sites" page instead of their newly created site.

* In `get-thank-you-page-url`, emit a `:siteId` placeholder in the post-checkout URL when `siteId` is not yet known — covering both the onboarding cookie URL path (`/setup/onboarding-unified/post-checkout-onboarding?siteId=:siteId`) and the ecommerce plan thank-you URL path (`/checkout/thank-you/:siteId/:receiptId`)
* In the pending page's `effectiveRedirectTo` logic, add a second resolution path: if `blogId` is available from the receipt and the redirect URL contains a `:siteId` placeholder, replace it with the real blog ID

## Why are these changes being made?

Sometimes `getThankYouPageUrl()` (used to generate the post-checkout destination page) would call `addQueryArgs({ siteId: undefined }, cookieUrl)`, which silently drops the `siteId` param entirely. This can happen when we don't yet know the site (eg: in siteless checkout since the post-checkout URL is often generated before the transaction is even submitted).

Regardless of the final post-checkout URL, the user will be redirected to the "pending" page to wait for the order to be complete. The pending page's existing `blogId`-based recovery logic only fired when `redirectTo` was `'/'` or empty, so it never kicked in for post-checkout URLs that are not empty. The user would be sent to `/setup/onboarding-unified/post-checkout-onboarding` with no site context, resulting in a view that reads "You don't have any sites yet".

## Testing instructions

* Start the logged-out unified siteless checkout (e.g. via the affiliate/paid media landing page - https://wordpress.com/ppc/optimized-wp-hosting/) with a non-ecommerce plan.
* At the payment step, select PayPal and complete the payment (the bug does not appear to happen with credit cards).
* Confirm you are redirected to the onboarding post-checkout page (not a "no sites" or generic page) and that the new site is available.

