### PR TITLE
Update Akismet quantity display in Billing History

### DIFF
--- a/client/dashboard/me/billing-history/dataviews.tsx
+++ b/client/dashboard/me/billing-history/dataviews.tsx
@@ -5,6 +5,7 @@ import { __experimentalText as Text, __experimentalVStack as VStack } from '@wor
 import { __, sprintf } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import { receiptRoute } from '../../app/router/me';
+import { isAkismetPro500Plan } from '../../utils/akismet';
 import {
 	formatReceiptAmount,
 	formatReceiptTaxAmount,
@@ -318,11 +319,21 @@ function renderServiceNameDescription( receipt: Receipt ) {
 
 	const receiptItem = receiptItems[ 0 ];
 	const termLabel = getTransactionTermLabel( receiptItem );
+	const isAkismet =
+		receiptItem.licensed_quantity && isAkismetPro500Plan( receiptItem.wpcom_product_slug );
+	const displayLabel = isAkismet
+		? sprintf(
+				/* translators: 1: product name like "Akismet Pro", 2: number of requests per month */
+				__( '%1$s (%2$d requests/month)' ),
+				label.replace( /\s*\(.*$/, '' ).trim(),
+				500 * parseInt( String( receiptItem.licensed_quantity ) )
+		  )
+		: label;
 
 	return (
 		<VStack spacing={ 1 }>
 			<Text isBlock weight={ 500 } size="13">
-				{ label }
+				{ displayLabel }
 			</Text>
 			{ receiptItem.domain && (
 				<Text isBlock variant="muted" size="12">

--- a/client/dashboard/me/billing-history/receipt.tsx
+++ b/client/dashboard/me/billing-history/receipt.tsx
@@ -24,6 +24,7 @@ import { receiptRoute, taxDetailsRoute } from '../../app/router/me';
 import { Card, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import { isAkismetPro500Plan } from '../../utils/akismet';
 import {
 	formatReceiptAmount,
 	formatReceiptTaxAmount,
@@ -362,6 +363,15 @@ function ReceiptLineItems( { receipt }: { receipt: Receipt } ) {
 
 function ReceiptLineItem( { item, receipt }: { item: ReceiptItem; receipt: Receipt } ) {
 	const termLabel = getTransactionTermLabel( item );
+	const isAkismet = item.licensed_quantity && isAkismetPro500Plan( item.wpcom_product_slug );
+	const variationDisplay = isAkismet
+		? sprintf(
+				/* translators: 1: product name like "Akismet Pro", 2: number of requests per month */
+				__( '%1$s (%2$d requests/month)' ),
+				item.variation.replace( /\s*\(.*$/, '' ).trim(),
+				500 * parseInt( String( item.licensed_quantity ) )
+		  )
+		: item.variation;
 	const shouldShowDiscount = areReceiptItemDiscountsAccurate( receipt.date );
 	const subtotalInteger = shouldShowDiscount
 		? getReceiptItemOriginalCost( item )
@@ -377,7 +387,7 @@ function ReceiptLineItem( { item, receipt }: { item: ReceiptItem; receipt: Recei
 				<VStack className="receipt-line-item-cell">
 					<VStack spacing={ 1 } alignment="flex-start">
 						<Text weight={ 500 }>
-							{ item.variation } ({ item.type_localized.toLowerCase() })
+							{ variationDisplay } ({ item.type_localized.toLowerCase() })
 						</Text>
 						<VStack spacing={ 0 }>
 							{ termLabel && <Text>{ termLabel }</Text> }

--- a/client/dashboard/me/billing-history/utils.tsx
+++ b/client/dashboard/me/billing-history/utils.tsx
@@ -1,5 +1,6 @@
 import { formatCurrency, formatNumber } from '@automattic/number-formatters';
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { isAkismetPro500Plan } from '../../utils/akismet';
 import {
 	isDIFMProduct,
 	isGoogleWorkspace,
@@ -186,6 +187,30 @@ function renderSpaceAddOnquantitySummary( licensedQuantity: number, isRenewal: b
 	);
 }
 
+function renderAkismetTransactionQuantitySummary( licensedQuantity: number, isRenewal: boolean ) {
+	if ( isRenewal ) {
+		return sprintf(
+			/* translators: %d: number of 500 API call licenses */
+			_n(
+				'Renewal for %d 500 API call license',
+				'Renewal for %d 500 API call licenses',
+				licensedQuantity
+			),
+			licensedQuantity
+		);
+	}
+
+	return sprintf(
+		/* translators: %d: number of 500 API call licenses */
+		_n(
+			'Purchase of %d 500 API call license',
+			'Purchase of %d 500 API call licenses',
+			licensedQuantity
+		),
+		licensedQuantity
+	);
+}
+
 export function DomainTransactionVolumeSummary( { item }: { item: ReceiptItem } ) {
 	if ( ! item.volume ) {
 		return null;
@@ -260,6 +285,10 @@ export function renderTransactionQuantitySummary( {
 
 	if ( isTieredVolumeSpaceAddon( product ) ) {
 		return renderSpaceAddOnquantitySummary( licensedQuantity, isRenewal );
+	}
+
+	if ( isAkismetPro500Plan( wpcom_product_slug ) ) {
+		return renderAkismetTransactionQuantitySummary( licensedQuantity, isRenewal );
 	}
 
 	if ( isRenewal ) {

--- a/client/me/purchases/billing-history/field-definitions.tsx
+++ b/client/me/purchases/billing-history/field-definitions.tsx
@@ -1,3 +1,4 @@
+import { isAkismetPro500, getAkismetPro500ProductDisplayName } from '@automattic/calypso-products';
 import { type Fields, type Operator } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
 import { capitalPDangit } from 'calypso/lib/formatting';
@@ -19,7 +20,13 @@ function renderServiceNameDescription(
 	transaction: BillingTransactionItem,
 	translate: ReturnType< typeof useTranslate >
 ) {
-	const plan = capitalPDangit( transaction.variation );
+	const isAkismet = isAkismetPro500( { product_slug: transaction.wpcom_product_slug } );
+	const planName = isAkismet
+		? String(
+				getAkismetPro500ProductDisplayName( transaction.variation, transaction.licensed_quantity )
+		  )
+		: transaction.variation;
+	const plan = capitalPDangit( planName );
 	const termLabel = getTransactionTermLabel( transaction, translate );
 
 	return (
@@ -159,7 +166,16 @@ export function getFieldDefinitions(
 				if ( transactionItem.product === transactionItem.variation ) {
 					return String( transactionItem.product );
 				}
-				return capitalPDangit( transactionItem.variation );
+				const isAkismet = isAkismetPro500( { product_slug: transactionItem.wpcom_product_slug } );
+				const name = isAkismet
+					? String(
+							getAkismetPro500ProductDisplayName(
+								transactionItem.variation,
+								transactionItem.licensed_quantity
+							)
+					  )
+					: transactionItem.variation;
+				return capitalPDangit( name );
 			},
 		},
 		{

--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -1,3 +1,4 @@
+import { isAkismetPro500, getAkismetPro500ProductDisplayName } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, Card, FormLabel } from '@automattic/components';
 import { formatCurrency } from '@automattic/number-formatters';
@@ -578,7 +579,11 @@ function ReceiptLineItem( {
 		<>
 			<tr>
 				<td className="billing-history__receipt-item-name">
-					<span>{ item.variation }</span>
+					<span>
+						{ isAkismetPro500( { product_slug: item.wpcom_product_slug } )
+							? getAkismetPro500ProductDisplayName( item.variation, item.licensed_quantity )
+							: item.variation }
+					</span>
 					<small>({ item.type_localized })</small>
 					{ termLabel && <em>{ termLabel }</em> }
 					{ item.domain && <em>{ item.domain }</em> }

--- a/client/me/purchases/billing-history/utils.tsx
+++ b/client/me/purchases/billing-history/utils.tsx
@@ -1,6 +1,7 @@
 import {
 	getPlanTermLabel,
 	isDIFMProduct,
+	isAkismetPro500,
 	isGoogleWorkspace,
 	isTitanMail,
 	isTieredVolumeSpaceAddon,
@@ -312,6 +313,32 @@ export function DomainTransactionVolumeSummary( { item }: { item: BillingTransac
 	);
 }
 
+function renderAkismetTransactionQuantitySummary(
+	licensed_quantity: number,
+	isRenewal: boolean,
+	translate: LocalizeProps[ 'translate' ]
+) {
+	if ( isRenewal ) {
+		return translate(
+			'Renewal for %(quantity)d 500 API call license',
+			'Renewal for %(quantity)d 500 API call licenses',
+			{
+				args: { quantity: licensed_quantity },
+				count: licensed_quantity,
+			}
+		);
+	}
+
+	return translate(
+		'Purchase of %(quantity)d 500 API call license',
+		'Purchase of %(quantity)d 500 API call licenses',
+		{
+			args: { quantity: licensed_quantity },
+			count: licensed_quantity,
+		}
+	);
+}
+
 export function renderTransactionQuantitySummary(
 	{ licensed_quantity, new_quantity, type, wpcom_product_slug }: BillingTransactionItem,
 	translate: LocalizeProps[ 'translate' ]
@@ -350,6 +377,10 @@ export function renderTransactionQuantitySummary(
 
 	if ( isTieredVolumeSpaceAddon( product ) ) {
 		return renderSpaceAddOnquantitySummary( licensed_quantity, isRenewal, translate );
+	}
+
+	if ( isAkismetPro500( product ) ) {
+		return renderAkismetTransactionQuantitySummary( licensed_quantity, isRenewal, translate );
 	}
 
 	if ( isRenewal ) {


### PR DESCRIPTION
Fixes CHE-444 and NOSPAM-393

## Proposed Changes

* This adjusts the way Akismet Pro 500 plans display in "Billing History" and "Receipts" . The fix calculates the total API call limit (matching how it displays on the "Active Upgrades" page) and improves the display of "items" to indicate each quantity is an instance of a 500 API license.


## Why are these changes being made?

* This fixes an issue where the "Billing History" and "Receipts" for Akismet Pro subscriptions don't match what is displayed on the "Active Upgrades" section of Calypso

## Testing Instructions

1. Add an Akismet 500 license (2 site variation)
2. View on WordPress.com and see that it shows in Billing History as "Akismet Pro (500 requests/month)" and "Purchase of 2 items"
3. View this PR on local environment and see that the same license shows "Akismet Pro (1000 requests/month" and "Purchase of 2 500 API call licenses"


### Before:

Upgrade display:

![SCR-20260327-onrq](https://github.com/user-attachments/assets/e907cf45-ced8-4a6b-8e50-10042ad04109)

Billing History display:

<img width="1592" height="753" alt="image" src="https://github.com/user-attachments/assets/dfad38e1-55bb-4bf9-94c7-b7224f972a9b" />

Receipt display:

<img width="1391" height="834" alt="image" src="https://github.com/user-attachments/assets/f2ff1dcf-62c3-4d61-ad78-c1ee02147c14" />


### After

Billing History:

<img width="1585" height="770" alt="image" src="https://github.com/user-attachments/assets/7025ff17-35c3-4f98-b5de-28c5cd63d065" />


Receipt:

<img width="1278" height="888" alt="image" src="https://github.com/user-attachments/assets/1c6a5949-9f3f-4427-889d-568bd6add95f" />




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
