### PR TITLE
print-cache-seed-key.sh: Temporarily re-add

### DIFF
--- a/bin/print-cache-seed-key.sh
+++ b/bin/print-cache-seed-key.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+hash_cmd() {
+	if command -v sha256sum >/dev/null 2>&1; then
+		sha256sum | awk '{ print $1 }'
+	elif command -v shasum >/dev/null 2>&1; then
+		shasum -a 256 | awk '{ print $1 }'
+	else
+		echo "Neither sha256sum nor shasum is available." >&2
+		exit 1
+	fi
+}
+
+# This key is intentionally build-system centric, not source centric.
+# Changing regular application code should not force a cache-seed refresh.
+paths=(
+	.nvmrc
+	.dockerignore
+	.yarnrc.yml
+	package.json
+	yarn.lock
+	env-config.sh
+	Dockerfile
+	Dockerfile.cache-seed
+	babel.config.js
+	bin/postinstall.sh
+	bin/build-packages-web.sh
+	bin/build-languages.js
+	client/webpack.config.js
+	client/webpack.config.node.js
+	client/webpack.common.js
+	client/server/config
+	build-tools/babel/babel-loader-cache-identifier/index.js
+	build-tools/webpack
+	.yarn/patches
+	.yarn/releases
+	# Workspace manifests copied into the deps stage
+	":(glob)apps/*/package.json"
+	":(glob)packages/*/package.json"
+	client/package.json
+	desktop/package.json
+	test/e2e/package.json
+	# Build-tool / prebuild workspaces that materially affect cache usefulness
+	packages/calypso-build
+	packages/calypso-babel-config
+	packages/babel-plugin-i18n-calypso
+	packages/wp-babel-makepot
+	packages/calypso-color-schemes
+	packages/create-calypso-config
+	packages/languages
+)
+
+{
+	printf 'cache-seed-key:v1\0'
+
+	git ls-files -- "${paths[@]}" \
+		| LC_ALL=C sort \
+		| while IFS= read -r file; do
+			[ -f "$file" ] || continue
+			printf '%s\0' "$file"
+			cat "$file"
+			printf '\0'
+		done
+} | hash_cmd | cut -c1-20


### PR DESCRIPTION
This file is gone after the revert of the inline refresh in #109675, but I need to temporarily add it for people who have un-rebased PRs. That's because they'll be running the (old) TeamCity config on their branch, combined with a git-merge-head of applying trunk to their branch, which removes this file.

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
