### PR TITLE
FORNO-281: Block notes tracking: Updates tracking events prefix

### DIFF
--- a/packages/block-notes/src/utils/tracking.test.ts
+++ b/packages/block-notes/src/utils/tracking.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for Block Notes tracking functions
  *
  * These tests validate that tracking functions call recordTracksEvent
- * with correct event names and essential properties.
+ * with the jetpack_ prefix and correct properties.
  */
 
 // Mock the tracks module
@@ -18,6 +18,10 @@ import {
 	trackBlockNoteAtMentionUsed,
 } from './tracking';
 
+const mockedRecordTracksEvent = recordTracksEvent as jest.MockedFunction<
+	typeof recordTracksEvent
+>;
+
 describe( 'Block Notes Tracking', () => {
 	const TEST_POST_ID = 123;
 	const TEST_NOTE_ID = 456;
@@ -28,14 +32,14 @@ describe( 'Block Notes Tracking', () => {
 	} );
 
 	describe( 'trackBlockNoteAtMentionUsed', () => {
-		it( 'should call recordTracksEvent with correct event name and required properties', () => {
+		it( 'should call recordTracksEvent with jetpack_ prefix and required properties', () => {
 			trackBlockNoteAtMentionUsed( {
 				postId: TEST_POST_ID,
 				noteId: TEST_NOTE_ID,
 			} );
 
-			expect( recordTracksEvent ).toHaveBeenCalledWith(
-				'block_note_at_mention_used',
+			expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+				'jetpack_big_sky_block_note_at_mention_used',
 				expect.objectContaining( {
 					post_id: TEST_POST_ID,
 					note_id: TEST_NOTE_ID,
@@ -50,8 +54,8 @@ describe( 'Block Notes Tracking', () => {
 				parentNoteId: TEST_PARENT_NOTE_ID,
 			} );
 
-			expect( recordTracksEvent ).toHaveBeenCalledWith(
-				'block_note_at_mention_used',
+			expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+				'jetpack_big_sky_block_note_at_mention_used',
 				expect.objectContaining( {
 					post_id: TEST_POST_ID,
 					note_id: TEST_NOTE_ID,
@@ -62,14 +66,14 @@ describe( 'Block Notes Tracking', () => {
 	} );
 
 	describe( 'trackBlockNoteAiReplyCreated', () => {
-		it( 'should call recordTracksEvent with correct event name and required properties', () => {
+		it( 'should call recordTracksEvent with jetpack_ prefix and required properties', () => {
 			trackBlockNoteAiReplyCreated( {
 				noteId: TEST_NOTE_ID,
 				postId: TEST_POST_ID,
 			} );
 
-			expect( recordTracksEvent ).toHaveBeenCalledWith(
-				'block_note_ai_reply_created',
+			expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+				'jetpack_big_sky_block_note_ai_reply_created',
 				expect.objectContaining( {
 					note_id: TEST_NOTE_ID,
 					post_id: TEST_POST_ID,
@@ -84,8 +88,8 @@ describe( 'Block Notes Tracking', () => {
 				parentNoteId: TEST_PARENT_NOTE_ID,
 			} );
 
-			expect( recordTracksEvent ).toHaveBeenCalledWith(
-				'block_note_ai_reply_created',
+			expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+				'jetpack_big_sky_block_note_ai_reply_created',
 				expect.objectContaining( {
 					note_id: TEST_NOTE_ID,
 					post_id: TEST_POST_ID,
@@ -96,14 +100,14 @@ describe( 'Block Notes Tracking', () => {
 	} );
 
 	describe( 'trackBlockNoteAiResponseFailed', () => {
-		it( 'should call recordTracksEvent with correct event name and required properties', () => {
+		it( 'should call recordTracksEvent with jetpack_ prefix and required properties', () => {
 			trackBlockNoteAiResponseFailed( {
 				noteId: TEST_NOTE_ID,
 				errorType: 'agent_response_failed',
 			} );
 
-			expect( recordTracksEvent ).toHaveBeenCalledWith(
-				'block_note_ai_response_failed',
+			expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+				'jetpack_big_sky_block_note_ai_response_failed',
 				expect.objectContaining( {
 					note_id: TEST_NOTE_ID,
 					error_type: 'agent_response_failed',
@@ -118,8 +122,8 @@ describe( 'Block Notes Tracking', () => {
 				errorType: 'agent_response_failed',
 			} );
 
-			expect( recordTracksEvent ).toHaveBeenCalledWith(
-				'block_note_ai_response_failed',
+			expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+				'jetpack_big_sky_block_note_ai_response_failed',
 				expect.objectContaining( {
 					note_id: TEST_NOTE_ID,
 					post_id: TEST_POST_ID,
@@ -136,8 +140,8 @@ describe( 'Block Notes Tracking', () => {
 				errorType: 'unknown',
 			} );
 
-			expect( recordTracksEvent ).toHaveBeenCalledWith(
-				'block_note_ai_response_failed',
+			expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+				'jetpack_big_sky_block_note_ai_response_failed',
 				expect.objectContaining( {
 					note_id: TEST_NOTE_ID,
 					post_id: TEST_POST_ID,
@@ -149,14 +153,14 @@ describe( 'Block Notes Tracking', () => {
 	} );
 
 	describe( 'trackBlockNoteAiReplyFailed', () => {
-		it( 'should call recordTracksEvent with correct event name and required properties', () => {
+		it( 'should call recordTracksEvent with jetpack_ prefix and required properties', () => {
 			trackBlockNoteAiReplyFailed( {
 				noteId: TEST_NOTE_ID,
 				errorType: 'ability_failed',
 			} );
 
-			expect( recordTracksEvent ).toHaveBeenCalledWith(
-				'block_note_ai_reply_failed',
+			expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+				'jetpack_big_sky_block_note_ai_reply_failed',
 				expect.objectContaining( {
 					note_id: TEST_NOTE_ID,
 					error_type: 'ability_failed',
@@ -171,8 +175,8 @@ describe( 'Block Notes Tracking', () => {
 				errorType: 'unknown',
 			} );
 
-			expect( recordTracksEvent ).toHaveBeenCalledWith(
-				'block_note_ai_reply_failed',
+			expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+				'jetpack_big_sky_block_note_ai_reply_failed',
 				expect.objectContaining( {
 					note_id: TEST_NOTE_ID,
 					post_id: TEST_POST_ID,

--- a/packages/block-notes/src/utils/tracking.ts
+++ b/packages/block-notes/src/utils/tracking.ts
@@ -4,7 +4,19 @@
  * Centralized tracking functions for Block Notes events.
  */
 
-import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { recordTracksEvent as recordTracksEventBase } from '@automattic/calypso-analytics';
+
+const TRACKS_PREFIX = 'jetpack';
+
+/**
+ * Record a tracks event with the jetpack_ prefix.
+ */
+function recordTracksEvent(
+	eventName: string,
+	properties: Record< string, string | number | boolean > = {}
+): void {
+	recordTracksEventBase( `${ TRACKS_PREFIX }_${ eventName }`, properties );
+}
 
 interface TrackBlockNoteAtMentionUsedOptions {
 	postId: number;
@@ -59,7 +71,7 @@ export function trackBlockNoteAtMentionUsed( {
 	if ( sessionId !== undefined ) {
 		properties.sessionid = sessionId;
 	}
-	recordTracksEvent( 'block_note_at_mention_used', properties );
+	recordTracksEvent( 'big_sky_block_note_at_mention_used', properties );
 }
 
 /**
@@ -86,7 +98,7 @@ export function trackBlockNoteAiReplyCreated( {
 	if ( sessionId !== undefined ) {
 		properties.sessionid = sessionId;
 	}
-	recordTracksEvent( 'block_note_ai_reply_created', properties );
+	recordTracksEvent( 'big_sky_block_note_ai_reply_created', properties );
 }
 
 /**
@@ -119,7 +131,7 @@ export function trackBlockNoteAiResponseFailed( {
 		properties.sessionid = sessionId;
 	}
 
-	recordTracksEvent( 'block_note_ai_response_failed', properties );
+	recordTracksEvent( 'big_sky_block_note_ai_response_failed', properties );
 }
 
 /**
@@ -149,5 +161,5 @@ export function trackBlockNoteAiReplyFailed( {
 		properties.sessionid = sessionId;
 	}
 
-	recordTracksEvent( 'block_note_ai_reply_failed', properties );
+	recordTracksEvent( 'big_sky_block_note_ai_reply_failed', properties );
 }


### PR DESCRIPTION
Part of [FORNO-281](https://linear.app/a8c/issue/FORNO-281/update-block-notes-tracking-events-prefix)

## Proposed Changes

- Add `jetpack_` prefix to Block Notes tracking events via a `recordTracksEvent` wrapper, and rename event names to include `big_sky_` (e.g., `jetpack_big_sky_block_note_at_mention_used`) to match the existing production event schema.
- Update unit tests to assert the prefixed event names.

## Why are these changes being made?

Block Notes tracking events were missing the required `jetpack_` source prefix, causing them to be silently dropped by the `calypso-analytics` validation (which requires events to start with an allowed source like `calypso`, `jetpack`, etc.). This PR fixes the prefix and maintains `jetpack_big_sky_` naming for parity with existing production event data.

## Testing Instructions

### Setup
1. Pull down the PR and run `cd apps/agents-manager && yarn dev --sync`
2. This should sync the Calypso to your sandbox
3. Sandbox `widgets.wp.com`
4. Sandbox site(s) that you will use for tests

### Simple site

1. Navigate to any Simple WordPress.com site, open a draft post in the editor.
5. Open the browser console and run:
   ```js
   localStorage.setItem('debug', 'dops:analytics');
   ```
6. Reload the page.
7. Select a block, click the three-dot options menu, and click **Add note**.
8. Type `@ai help me improve this block` and click **Add note**.
9. In the browser console, verify you see a log like:
   ```
   dops:analytics Record event "jetpack_big_sky_block_note_at_mention_used" called with props {…}
   ```

### Self-hosted Jetpack site

1. Navigate to any self-hosted WordPress site with Jetpack AI enabled, open a draft post in the editor.
2. Open the browser console and run:
   ```js
   localStorage.setItem('debug', 'calypso:analytics');
   ```
3. Reload the page.
4. Select a block, click the three-dot options menu, and click **Add note**.
5. Type `@ai help me improve this block` and click **Add note**.
6. In the browser console, verify you see a log like:
   ```
   calypso:analytics Record event "jetpack_big_sky_block_note_at_mention_used" called with props {…}
   ```

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?