### PR TITLE
Dashboard: Fix AbortError on root route view transition

### DIFF
--- a/client/dashboard/app/router/index.tsx
+++ b/client/dashboard/app/router/index.tsx
@@ -38,7 +38,7 @@ const indexRoute = createRoute( {
 	path: '/',
 	beforeLoad: ( { context }: { context: RouteContext } ) => {
 		if ( context.config ) {
-			throw redirect( { to: context.config.mainRoute } );
+			throw redirect( { to: context.config.mainRoute, viewTransition: false } );
 		}
 	},
 } );


### PR DESCRIPTION
## Proposed Changes

* Disable view transition for the index route's redirect from `/` to `mainRoute` by passing `viewTransition: false` to the redirect call.

## Why are these changes being made?

When loading the Dashboard at `/`, the index route's `beforeLoad` immediately redirects to `mainRoute`. With `defaultViewTransition: true` on the router, the browser's View Transition API starts a transition for the initial navigation, which is then immediately aborted by the redirect. This surfaces as `Uncaught (in promise) AbortError: Transition was skipped` in the console.

Since users never see the `/` route (it's an instant redirect), there's no visible content to animate from, making the view transition unnecessary.

## Testing Instructions

* Navigate to the Dashboard root URL (`/`)
* Verify the redirect to the main route works as before
* Confirm the `AbortError` no longer appears in the browser console
* Verify view transitions still work for normal page-to-page navigations

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)