### PR TITLE
Dashboard: Remove Privacy sidebar link and me.privacy config flag

### DIFF
--- a/client/dashboard/app-ciab/index.tsx
+++ b/client/dashboard/app-ciab/index.tsx
@@ -37,7 +37,6 @@ boot( {
 			security: {
 				sshKey: false,
 			},
-			privacy: true,
 			apps: false,
 		},
 		plugins: false,

--- a/client/dashboard/app-dotcom/index.tsx
+++ b/client/dashboard/app-dotcom/index.tsx
@@ -36,7 +36,6 @@ boot( {
 			security: {
 				sshKey: true,
 			},
-			privacy: true,
 			apps: true,
 		},
 		plugins: true,

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -23,7 +23,6 @@ export type MeSecuritySupports = {
 
 export type MeSupports = {
 	billing: MeBillingSupports | false;
-	privacy: boolean;
 	security: MeSecuritySupports | false;
 	apps: boolean;
 };

--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -1032,10 +1032,7 @@ export const createMeRoutes = ( config: AppConfig ) => {
 		return [];
 	}
 
-	const preferencesChildren: AnyRoute[] = [ preferencesIndexRoute ];
-	if ( config.supports.me.privacy ) {
-		preferencesChildren.push( privacyRoute );
-	}
+	const preferencesChildren: AnyRoute[] = [ preferencesIndexRoute, privacyRoute ];
 	if ( config.supports.reader ) {
 		preferencesChildren.push( blockedSitesRoute );
 	}

--- a/client/dashboard/me/me-sidebar/index.tsx
+++ b/client/dashboard/me/me-sidebar/index.tsx
@@ -14,7 +14,6 @@ import {
 	lock,
 	notAllowed,
 	payment,
-	seen,
 	settings,
 	starEmpty,
 } from '@wordpress/icons';
@@ -74,11 +73,6 @@ function MeMenuSidebar() {
 			<SidebarMenuItem icon={ lock } to="/me/security">
 				{ __( 'Security' ) }
 			</SidebarMenuItem>
-			{ hasAppSupport( supports, 'privacy' ) && (
-				<SidebarMenuItem icon={ seen } to="/me/privacy">
-					{ __( 'Privacy' ) }
-				</SidebarMenuItem>
-			) }
 			{ supports.notifications && (
 				<SidebarMenuItem icon={ bell } to="/me/notifications">
 					{ __( 'Notifications' ) }

--- a/client/dashboard/me/preferences/index.tsx
+++ b/client/dashboard/me/preferences/index.tsx
@@ -27,7 +27,7 @@ export default function Preferences() {
 			{ optIn && <PreferencesNewHostingDashboard /> }
 			{ isEnabled( 'mcp-settings' ) && <PreferencesAiMcp /> }
 			{ supports.reader && <PreferencesBlockedSites /> }
-			{ !! supports.me && supports.me.privacy && <PreferencesPrivacy /> }
+			<PreferencesPrivacy />
 			<PreferencesLanguageForm />
 			<PreferencesPrimarySite />
 			<PreferencesDefaultLanding />


### PR DESCRIPTION
## Proposed Changes

* Remove the Privacy sidebar link from the Dashboard Me sidebar.
* Remove the `me.privacy` config flag from `MeSupports` type and both app configs (dotcom, ciab).
* Remove feature gating — the privacy route and `<PreferencesPrivacy />` component are now always available.
* Remove the unused `seen` icon import.

## Why are these changes being made?

Privacy was moved under Preferences in #109317. The commit `e2a5c2af081` noted:

> *Move Privacy under Preferences, add per-card Save buttons to WordPress.com defaults*
> - Privacy page: moved from top-level `/me/privacy` to `/me/preferences/privacy`
> - Removed Privacy from top navigation menu

The sidebar link was not removed at that time, so it remains as a stale top-level entry. Since privacy is always available under preferences, the `me.privacy` config flag is no longer needed.

## Testing Instructions

* Open the Dashboard at `/me` and confirm the Privacy link is no longer shown in the sidebar.
* Verify `/me/preferences/privacy` still works via the Preferences page.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)