### PR TITLE
MSD: Update Sites sidebar icon from copy to layout

### DIFF
--- a/client/dashboard/app/responsive-sidebar/sidebar.tsx
+++ b/client/dashboard/app/responsive-sidebar/sidebar.tsx
@@ -1,7 +1,7 @@
 import { useRouterState } from '@tanstack/react-router';
 import { __experimentalHStack as HStack, Navigator } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { brush, copy, envelope, globe, plugins } from '@wordpress/icons';
+import { brush, envelope, globe, layout, plugins } from '@wordpress/icons';
 import { useRef } from 'react';
 import { menuDot } from '../../components/icons';
 import RouterLinkButton from '../../components/router-link-button';
@@ -81,7 +81,7 @@ function PrimaryMenuSidebar() {
 	return (
 		<SidebarMenu>
 			{ supports.sites && (
-				<SidebarMenuItem icon={ copy } to="/sites">
+				<SidebarMenuItem icon={ layout } to="/sites">
 					{ __( 'Sites' ) }
 				</SidebarMenuItem>
 			) }


### PR DESCRIPTION
Part of DOTMSD-1172

## Proposed Changes

* Replace the `copy` icon with the `layout` icon for the "Sites" item in the dashboard sidebar.

| Before | After |
| - | - |
| <img width="246" height="54" alt="image" src="https://github.com/user-attachments/assets/93a25517-4036-4266-ad4a-0cab876b8e3a" />| <img width="242" height="46" alt="image" src="https://github.com/user-attachments/assets/d7fe9db8-5673-4930-9d88-3f5281e77dbc" />|

## Why are these changes being made?

* The `copy` icon was confusing as it resembled the "copy" action. The `layout` icon better represents "Sites" and was chosen per design feedback.

## Testing Instructions

* Open the multi-site dashboard sidebar and verify the "Sites" menu item displays the layout icon instead of the old copy icon.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)