### PR TITLE
MSD sidebar: don't show site menus for incoming migration

### DIFF
--- a/client/dashboard/sites/site-sidebar/index.tsx
+++ b/client/dashboard/sites/site-sidebar/index.tsx
@@ -34,6 +34,7 @@ import {
 	SidebarMenuItem,
 } from '../../components/sidebar';
 import { hasHostingFeature } from '../../utils/site-features';
+import { isSiteMigrationInProgress } from '../../utils/site-status';
 import { hasSiteTrialEnded } from '../../utils/site-trial';
 import { getSiteTypeFeatureSupports } from '../../utils/site-type-feature-support';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
@@ -61,7 +62,7 @@ export default function SiteSidebar() {
 					<SiteSwitcherItem site={ site } />
 					{ canSwitchEnvironment( site ) && <SidebarEnvironmentSwitcher site={ site } /> }
 				</SidebarMenu>
-				<SiteMenuSidebar site={ site } />
+				{ ! isSiteMigrationInProgress( site ) && <SiteMenuSidebar site={ site } /> }
 			</VStack>
 		</VStack>
 	);

--- a/client/dashboard/sites/site-sidebar/index.tsx
+++ b/client/dashboard/sites/site-sidebar/index.tsx
@@ -62,7 +62,7 @@ export default function SiteSidebar() {
 					<SiteSwitcherItem site={ site } />
 					{ canSwitchEnvironment( site ) && <SidebarEnvironmentSwitcher site={ site } /> }
 				</SidebarMenu>
-				{ ! isSiteMigrationInProgress( site ) && <SiteMenuSidebar site={ site } /> }
+				<SiteMenuSidebar site={ site } />
 			</VStack>
 		</VStack>
 	);
@@ -71,6 +71,10 @@ export default function SiteSidebar() {
 function SiteMenuSidebar( { site }: { site: Site } ) {
 	const siteSlug = site.slug;
 	const siteTypeSupports = getSiteTypeFeatureSupports( site );
+
+	if ( isSiteMigrationInProgress( site ) ) {
+		return null;
+	}
 
 	if ( hasSiteTrialEnded( site ) ) {
 		return (


### PR DESCRIPTION

## Proposed Changes

Missed case for "site migration in progress" case. Original logic:

https://github.com/Automattic/wp-calypso/blob/8e918907887562cf7c4252621ffb080198c1e090/client/dashboard/sites/site/index.tsx#L54

|Before|After|
|-|-|
|<img width="1228" height="591" alt="image" src="https://github.com/user-attachments/assets/d88b6c53-be64-4e3a-a60b-1fc0f5e30f40" />|<img width="1232" height="591" alt="image" src="https://github.com/user-attachments/assets/8e2aecef-3c3c-4145-97c4-e007404d8537" />


## Testing Instructions

1. Visit `/sites?flags=dashboard/omnibar`
2. Click a site in migration
3. Verify you don't see sidebar menus

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
