### PR TITLE
Revert: Upgrade mini-css-extract-plugin from v1.6.2 to v2.10.2

### DIFF
--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -50,7 +50,7 @@
 		"css-minimizer-webpack-plugin": "^3.4.1",
 		"duplicate-package-checker-webpack-plugin": "^3.0.0",
 		"lodash": "^4.17.21",
-		"mini-css-extract-plugin": "^2.10.2",
+		"mini-css-extract-plugin": "^1.6.2",
 		"postcss-custom-properties": "^12.1.11",
 		"postcss-loader": "^6.2.1",
 		"recursive-copy": "^2.0.14",

--- a/packages/calypso-build/webpack/sass.js
+++ b/packages/calypso-build/webpack/sass.js
@@ -64,12 +64,6 @@ module.exports.plugins = ( { chunkFilename, filename } ) => [
 		attributes: {
 			'data-webpack': true,
 		},
-		// v2 auto-enables importModule on webpack 5.33.2+, but CSS extraction
-		// fails with "window is not defined" because DefinePlugin replaces
-		// `global` with `window` which doesn't exist in the Node.js execution
-		// context used by importModule. Falling back to the child compiler
-		// approach used by v1.
-		experimentalUseImportModule: false,
 	} ),
 	new MiniCSSWithRTLPlugin(),
 	new WebpackRTLPlugin(),

--- a/packages/webpack-rtl-plugin/package.json
+++ b/packages/webpack-rtl-plugin/package.json
@@ -26,7 +26,7 @@
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"css-loader": "^6.11.0",
-		"mini-css-extract-plugin": "^2.10.2",
+		"mini-css-extract-plugin": "^1.6.2",
 		"webpack": "^5.99.8"
 	},
 	"peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -486,7 +486,7 @@ __metadata:
     duplicate-package-checker-webpack-plugin: "npm:^3.0.0"
     gettext-parser: "npm:^6.0.0"
     lodash: "npm:^4.17.21"
-    mini-css-extract-plugin: "npm:^2.10.2"
+    mini-css-extract-plugin: "npm:^1.6.2"
     postcss-custom-properties: "npm:^12.1.11"
     postcss-loader: "npm:^6.2.1"
     recursive-copy: "npm:^2.0.14"
@@ -2373,7 +2373,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
     css-loader: "npm:^6.11.0"
-    mini-css-extract-plugin: "npm:^2.10.2"
+    mini-css-extract-plugin: "npm:^1.6.2"
     rtlcss: "npm:^3.1.2"
     webpack: "npm:^5.99.8"
   peerDependencies:
@@ -24014,15 +24014,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mini-css-extract-plugin@npm:^2.10.2":
-  version: 2.10.2
-  resolution: "mini-css-extract-plugin@npm:2.10.2"
+"mini-css-extract-plugin@npm:^1.6.2":
+  version: 1.6.2
+  resolution: "mini-css-extract-plugin@npm:1.6.2"
   dependencies:
-    schema-utils: "npm:^4.0.0"
-    tapable: "npm:^2.2.1"
+    loader-utils: "npm:^2.0.0"
+    schema-utils: "npm:^3.0.0"
+    webpack-sources: "npm:^1.1.0"
   peerDependencies:
-    webpack: ^5.0.0
-  checksum: ba58afb1c090be144b423a3621c4e0d09a9f8f4875410d3bc108915dfcf8e2fd6e550a7f3ba129eb07fd76599157650f86186b09f3ae2c34ccc5b50e82da0aa3
+    webpack: ^4.4.0 || ^5.0.0
+  checksum: 138c008f8a510012266d2834227e75181feeffd09e89e9cde0a63f17be3d64ea3ddbba01036aac9c8a969462c0142285659a20c294e8d01ba948aa1124affdc2
   languageName: node
   linkType: hard
 
@@ -30105,6 +30106,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-list-map@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "source-list-map@npm:2.0.1"
+  checksum: 2e5e421b185dcd857f46c3c70e2e711a65d717b78c5f795e2e248c9d67757882ea989b80ebc08cf164eeeda5f4be8aa95d3b990225070b2daaaf3257c5958149
+  languageName: node
+  linkType: hard
+
 "source-map-js@npm:>=0.6.2 <2.0.0, source-map-js@npm:^1.0.1, source-map-js@npm:^1.2.1":
   version: 1.2.1
   resolution: "source-map-js@npm:1.2.1"
@@ -33093,6 +33101,16 @@ __metadata:
   version: 3.0.0
   resolution: "webpack-node-externals@npm:3.0.0"
   checksum: 9f645a4dc8e122dac43cdc8c1367d4b44af20c79632438b633acc1b4fe64ea7ba1ad6ab61bd0fc46e1b873158c48d8c7a25a489cdab1f31299f00eb3b81cfc61
+  languageName: node
+  linkType: hard
+
+"webpack-sources@npm:^1.1.0":
+  version: 1.4.3
+  resolution: "webpack-sources@npm:1.4.3"
+  dependencies:
+    source-list-map: "npm:^2.0.0"
+    source-map: "npm:~0.6.1"
+  checksum: 78dafb3e1e297d3f4eb6204311e8c64d28cd028f82887ba33aaf03fffc82482d8e1fdf6de25a60f4dde621d3565f4c3b1bfb350f09add8f4e54e00279ff3db5e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reverts #109687

## Proposed Changes

* Reverts the mini-css-extract-plugin upgrade from v2.10.2 back to v1.6.2.

## Why are these changes being made?

* Just in case.

## Testing Instructions

* Verify the build completes successfully.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?