### PR TITLE
MSD: Redirect to reauth when AI tools settings require it

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -1,4 +1,4 @@
-import { HostingFeatures, DotcomFeatures, LogType } from '@automattic/api-core';
+import { HostingFeatures, DotcomFeatures, LogType, isWpError } from '@automattic/api-core';
 import {
 	bigSkyPluginQuery,
 	codeDeploymentQuery,
@@ -35,6 +35,7 @@ import {
 	siteSshAccessStatusQuery,
 	siteStaticFile404SettingQuery,
 	siteWordPressVersionQuery,
+	userSettingsQuery,
 	queryClient,
 } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
@@ -53,6 +54,7 @@ import {
 	canViewHundredYearPlanSettings,
 	canViewWordPressSettings,
 } from '../../sites/features';
+import { reauthRequiredLink } from '../../utils/link';
 import {
 	getActivityLogHiddenGroups,
 	hasHostingFeature,
@@ -653,6 +655,15 @@ export const siteSettingsAIToolsRoute = createRoute( {
 
 		if ( ! isEnabled( 'wordpress-ai-tools' ) ) {
 			throw redirectAsNotAllowed( { to: siteSettingsRoute.fullPath, params: { siteSlug } } );
+		}
+
+		try {
+			await queryClient.ensureQueryData( userSettingsQuery() );
+		} catch ( error: unknown ) {
+			if ( isWpError( error ) && error.error === 'reauthorization_required' ) {
+				window.location.href = reauthRequiredLink();
+				return;
+			}
 		}
 	},
 	loader: async ( { params: { siteSlug } } ) => {

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -664,6 +664,8 @@ export const siteSettingsAIToolsRoute = createRoute( {
 				window.location.href = reauthRequiredLink();
 				return;
 			}
+
+			throw error;
 		}
 	},
 	loader: async ( { params: { siteSlug } } ) => {


### PR DESCRIPTION
## Proposed Changes

* When loading the AI tools settings page, pre-fetch user settings and check for `reauthorization_required` error.
* If reauth is needed, redirect to the reauth flow instead of showing an error page.

## Why are these changes being made?

* The AI tools settings page fetches user settings which can fail with `reauthorization_required` for users who need to re-authenticate. Without handling this, users see a broken error state instead of being redirected to complete reauth.

## Testing Instructions

* Navigate to a site's AI tools settings page while in a state that requires reauthorization.
* Verify you are redirected to the reauth flow instead of seeing an error.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)