### PR TITLE
Disable Reader MSD when dashboard omnibar is enabled

### DIFF
--- a/client/state/reader-ui/selectors.js
+++ b/client/state/reader-ui/selectors.js
@@ -41,5 +41,9 @@ export function getPersistedLastActionPriorToLogin( state ) {
  * @returns {boolean} Whether the user is enabled for the reader multi-site dashboard
  */
 export function isReaderMSDEnabled( state ) {
-	return isEnabled( 'reader/msd-enabled' ) && hasDashboardOptIn( state );
+	return (
+		isEnabled( 'reader/msd-enabled' ) &&
+		hasDashboardOptIn( state ) &&
+		! isEnabled( 'dashboard/omnibar' )
+	);
 }

--- a/config/development.json
+++ b/config/development.json
@@ -63,6 +63,7 @@
 		"cookie-banner": false,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
+		"dashboard/omnibar": false,
 		"dashboard/opt-in-banners": false,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -28,6 +28,7 @@
 		"cookie-banner": true,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
+		"dashboard/omnibar": false,
 		"dashboard/opt-in-banners": false,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,

--- a/config/production.json
+++ b/config/production.json
@@ -42,6 +42,7 @@
 		"cookie-banner": true,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
+		"dashboard/omnibar": false,
 		"dashboard/opt-in-banners": false,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -38,6 +38,7 @@
 		"cookie-banner": false,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
+		"dashboard/omnibar": false,
 		"dashboard/opt-in-banners": false,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -38,6 +38,7 @@
 		"checkout/stripe-upi": true,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
+		"dashboard/omnibar": false,
 		"dashboard/opt-in-banners": false,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,


### PR DESCRIPTION
## Proposed Changes

* Add `dashboard/omnibar` feature flag (defaulting to `false`) across all config environments.
* Gate Reader MSD behind the omnibar being disabled to avoid conflicts between the two features.

## Why are these changes being made?

* When the dashboard omnibar is enabled, it conflicts with Reader MSD. This ensures only one is active at a time.

## Testing Instructions

* With `dashboard/omnibar` set to `false` (default), verify Reader MSD works as before for opted-in users.
* With `dashboard/omnibar` set to `true`, verify Reader MSD is disabled.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)