### PR TITLE
Fix double underline in stats usage meter

### DIFF
--- a/client/my-sites/stats/stats-plan-usage/style.scss
+++ b/client/my-sites/stats/stats-plan-usage/style.scss
@@ -75,6 +75,5 @@
 	a {
 		font-weight: 500;
 		color: inherit;
-		border-bottom: 1px solid var(--studio-gray-60);
 	}
 }


### PR DESCRIPTION
Fixes STATS-123

## Proposed Changes

* Removes double underline from upgrade prompt in "Your Stats plan usage" panel.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fixes a visual inconsistency with how the upgrade link is displayed.

## Testing Instructions

1. Add a Stats plan to a site and go to http://calypso.localhost:3000/stats/day/example.com
2. Scroll down to the "Your Stats plan usage" panel and see that the "Upgrade now" link has a double underline.
3. Apply the PR and see that the link has the proper single underline.

**Before**

![SCR-20260330-haiy](https://github.com/user-attachments/assets/3bcce25e-0791-4f6c-9251-e35210cb3614)

**After**

![SCR-20260330-hayz](https://github.com/user-attachments/assets/4c22bdf6-658b-4081-b3f7-533a2b52a6c6)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
