### PR TITLE
@automattic/launchpad: bump version to 1.2.0

### DIFF
--- a/packages/launchpad/CHANGELOG.md
+++ b/packages/launchpad/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Changelog
 
+## 1.2.0
+
+- Extend `onTaskClick` to support returning `false` to cancel the default task action ([#109434](https://github.com/Automattic/wp-calypso/pull/109434))
+
 ## 1.0.0
 
 - Initial release

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/launchpad",
-	"version": "1.1.5",
+	"version": "1.2.0",
 	"description": "Launchpad components.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
Part of DATSCI-1165.

## Proposed Changes

- Bumps `@automattic/launchpad` version from `1.1.5` to `1.2.0`
- Updates CHANGELOG with the new version entry

## Why are these changes being made?

The `onTaskClick` callback was extended in #109434 to support returning `false` to cancel the default task action. This is a new backwards-compatible capability in the public API, warranting a minor version bump so external consumers (e.g. Jetpack) can depend on the new version.

## Testing Instructions

No functional changes — version and changelog only.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?