### PR TITLE
A4A: Fix gray border around plugin avatars on A4A plugins page

### DIFF
--- a/client/my-sites/plugins/plugins-dashboard/style.scss
+++ b/client/my-sites/plugins/plugins-dashboard/style.scss
@@ -348,6 +348,13 @@
 		margin-top: 16px;
 	}
 
+	.dataviews-column-primary__media {
+		background-color: transparent;
+		&::after {
+			display: none;
+		}
+	}
+
 	.dataviews-view-list {
 		.dataviews-view-list__media-wrapper {
 			background-color: transparent;
@@ -375,7 +382,8 @@
 }
 
 body.is-section-plugins .hosting-dashboard-layout,
-.is-section-jetpack-cloud-plugin-management .hosting-dashboard-layout {
+.is-section-jetpack-cloud-plugin-management .hosting-dashboard-layout,
+.is-section-a8c-for-agencies-plugins .hosting-dashboard-layout {
 	.hosting-dashboard-layout-with-columns__container {
 		background-color: var( --color-main-background );
 	}


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/A4A-1494/plugin-ui-plugin-avatar-border-can-be-removed 

## Proposed Changes

* Fix Bug on the A4A Plugins Management page where the plugin icon has a weird border.

Styling improvements:

* Added a rule to `.dataviews-column-primary__media` to set its background to transparent and hide its pseudo-element, ensuring a cleaner look in the plugins dashboard.

Section-specific layout updates:

* Extended the background color styling for `.hosting-dashboard-layout-with-columns__container` to the `.is-section-a8c-for-agencies-plugins` section, in addition to the existing sections, for consistent theming.

## Why are these changes being made?

* Patches UI bug.

## Testing Instructions

* Use the A4A live link and navigate to `/plugins/manage/sites` page.
* Confirm that the plugins icon no longer has a weird border bug.

| Before | After |
|--------|--------|
| <img width="403" height="246" alt="Screenshot 2026-03-30 at 7 53 03 PM" src="https://github.com/user-attachments/assets/21d325be-0514-406d-9038-a0854b417748" /> | <img width="418" height="189" alt="Screenshot 2026-03-30 at 7 52 55 PM" src="https://github.com/user-attachments/assets/8832d09b-4c9d-4849-b96e-a62a21bba9d9" /> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
