### PR TITLE
A4A: Restore back the AgencyTierCelebrationModal.

### DIFF
--- a/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/index.tsx
@@ -3,6 +3,7 @@ import getAgencyTierInfo from 'calypso/a8c-for-agencies/sections/agency-tier/lib
 import AgencyTierProgressCard from 'calypso/a8c-for-agencies/sections/agency-tier/progress-card';
 import { useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import AgencyTierCelebrationModal from './celebration-modal';
 
 import './style.scss';
 
@@ -21,10 +22,16 @@ export default function OverviewSidebarAgencyTier() {
 	}
 
 	return (
-		<AgencyTierProgressCard
-			currentAgencyTierId={ currentAgencyTierId }
-			influencedRevenue={ influencedRevenue ?? 0 }
-			tierStatus={ tierStatus }
-		/>
+		<>
+			<AgencyTierCelebrationModal
+				agencyTierInfo={ currentAgencyTierInfo }
+				currentAgencyTier={ currentAgencyTierId }
+			/>
+			<AgencyTierProgressCard
+				currentAgencyTierId={ currentAgencyTierId }
+				influencedRevenue={ influencedRevenue ?? 0 }
+				tierStatus={ tierStatus }
+			/>
+		</>
 	);
 }


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/A4A-1917/tier-congratulations-modal-not-working

## Proposed Changes
This pull request introduces the `AgencyTierCelebrationModal` component into the agency tier sidebar overview. The modal is rendered alongside the existing progress card, and is provided with the current agency tier information and ID.

UI enhancements:

* Added the `AgencyTierCelebrationModal` component to the `OverviewSidebarAgencyTier` component, passing in `currentAgencyTierInfo` and `currentAgencyTierId` as props, and wrapped the sidebar content in a React fragment to support multiple elements. [[1]](diffhunk://#diff-41a88d2c49b337c29ddb4d0f8ab4509568a21f943160c7867cace2be875beaefR6) [[2]](diffhunk://#diff-41a88d2c49b337c29ddb4d0f8ab4509568a21f943160c7867cace2be875beaefR25-R35)

## Why are these changes being made?

* Ensure we add feedback when the agency reaches a new tier.

## Testing Instructions

* Use the A4A live link and navigate to `/overview` page.
* Simulate some Tier progression (via MC tool).
* Refresh the page and confirm you see the Celebration modal. If in case it did not show up, clear `a4a-agency-tier-celebration-modal-dismissed-type` preference first.

<img width="817" height="526" alt="Screenshot 2026-03-30 at 8 57 32 PM" src="https://github.com/user-attachments/assets/9ad9adbc-b8e9-46c3-bb65-4bb379aa158c" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
