### PR TITLE
MSD: Dismiss notifications panel when help center opens and vice versa

### DIFF
--- a/client/dashboard/app/notifications/index.tsx
+++ b/client/dashboard/app/notifications/index.tsx
@@ -8,6 +8,7 @@ import clsx from 'clsx';
 import { Suspense, lazy, useCallback, useEffect, useState } from 'react';
 import wpcom from 'calypso/lib/wp';
 import { useAuth } from '../auth';
+import { useHelpCenter } from '../help-center';
 import { useOmnibarEvent } from '../interim-omnibar/click-handlers';
 import { useLocale } from '../locale';
 import './style.scss';
@@ -26,13 +27,24 @@ export default function Notifications( {
 	const { user } = useAuth();
 	const locale = useLocale();
 	const isMobileViewport = useViewportMatch( 'small', '<' );
+	const { isShown: isHelpCenterShown, setShowHelpCenter } = useHelpCenter();
 	const [ isOpen, setIsOpen ] = useState( false );
 	const [ hasUnseenNotifications, setHasUnseenNotifications ] = useState( user.has_unseen_notes );
 	const [ anchorEl, setAnchorEl ] = useState< HTMLElement | null >( null );
 
 	const handleToggle = ( willOpen: boolean ) => {
+		if ( willOpen ) {
+			setShowHelpCenter( false, undefined, true );
+		}
 		setIsOpen( willOpen );
 	};
+
+	// Close notifications when help center opens.
+	useEffect( () => {
+		if ( isHelpCenterShown && isOpen ) {
+			setIsOpen( false );
+		}
+	}, [ isHelpCenterShown ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	const handleClose = () => {
 		handleToggle( false );
@@ -63,10 +75,18 @@ export default function Notifications( {
 		CLOSE_PANEL: [ handleClose ],
 	};
 
-	const handleOmnibarToggle = useCallback( ( element: HTMLElement | null ) => {
-		setAnchorEl( element );
-		setIsOpen( ( v ) => ! v );
-	}, [] );
+	const handleOmnibarToggle = useCallback(
+		( element: HTMLElement | null ) => {
+			setAnchorEl( element );
+			setIsOpen( ( prev ) => {
+				if ( ! prev ) {
+					setShowHelpCenter( false, undefined, true );
+				}
+				return ! prev;
+			} );
+		},
+		[ setShowHelpCenter ]
+	);
 
 	useOmnibarEvent( 'notifications', handleOmnibarToggle );
 

--- a/client/dashboard/app/notifications/index.tsx
+++ b/client/dashboard/app/notifications/index.tsx
@@ -41,10 +41,10 @@ export default function Notifications( {
 
 	// Close notifications when help center opens.
 	useEffect( () => {
-		if ( isHelpCenterShown && isOpen ) {
+		if ( isHelpCenterShown ) {
 			setIsOpen( false );
 		}
-	}, [ isHelpCenterShown ] ); // eslint-disable-line react-hooks/exhaustive-deps
+	}, [ isHelpCenterShown ] );
 
 	const handleClose = () => {
 		handleToggle( false );


### PR DESCRIPTION
Part of DOTMSD-1179

## Proposed Changes

* When the notifications panel opens, close the help center.
* When the help center opens, close the notifications panel.

## Why are these changes being made?

* Both panels occupy similar screen space and shouldn't be open simultaneously. This provides a cleaner UX by ensuring only one panel is visible at a time.

## Testing Instructions

* Enable the dashboard omnibar feature flag.
* Open the notifications panel, then click the help center button — notifications should close.
* Open the help center, then click the notifications bell — help center should close.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)