### PR TITLE
Checkout: Fetch site for new purchase on pending page after transaction complete

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -22,6 +22,7 @@ import { SUCCESS } from 'calypso/state/order-transactions/constants';
 import { fetchReceipt } from 'calypso/state/receipts/actions';
 import { getReceiptById } from 'calypso/state/receipts/selectors';
 import getOrderTransactionError from 'calypso/state/selectors/get-order-transaction-error';
+import { requestSite } from 'calypso/state/sites/actions';
 import usePurchaseOrder from '../../src/hooks/use-purchase-order';
 import { logStashLoadErrorEvent } from '../../src/lib/analytics';
 import type { RedirectInstructions } from 'calypso/my-sites/checkout/src/lib/pending-page';
@@ -304,6 +305,13 @@ function useRedirectOnTransactionSuccess( {
 			translate,
 			reduxDispatch,
 		} );
+
+		// Pre-populate the Redux sites store with the newly-purchased site so
+		// that the thank-you page does not briefly show "You don't have any
+		// sites yet" while siteSelection fetches it asynchronously.
+		if ( blogId ) {
+			reduxDispatch( requestSite( blogId ) );
+		}
 
 		notifyAndPerformRedirect( siteSlug, redirectInstructions );
 	}, [


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1820/unified-siteless-checkout-flow-with-paypal-does-not-show-created-site

## Proposed Changes

This PR fetches the current site into Redux when the post-checkout "pending" page finds a successful order. This way if the site was created during the order process, it should be available when the post-checkout thank-you page is shown.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When a user uses siteless checkout to create a site during the transaction order flow, it's possible that the calypso Redux store will not have it available when the pending page loads (because it hasn't been created yet). The pending page polls the order until it completes, and then redirects the user to the final post-checkout destination. However, if that destination relies on the Redux store having site data for the user, it will fail since the site count was 0 when the Redux store last updated.

It would be better to refresh the Redux store _after_ the order is complete.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Start the logged-out unified siteless checkout (e.g. via the affiliate/paid media landing page - https://wordpress.com/ppc/optimized-wp-hosting/) with a non-ecommerce plan.
- At the payment step, select PayPal and complete the payment (the bug does not appear to happen with credit cards).
- Confirm you are redirected to the onboarding post-checkout page (not a "no sites" or generic page) and that the new site is available.

