### PR TITLE
Checkout: tweak UI for redesign experiment

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -2096,7 +2096,7 @@ const WPCheckoutWrapper = styled.div< {
 			.wp-checkout-order-summary__subtotal,
 			.wp-checkout-order-summary__total {
 				color: ${ colorStudio.colors[ 'Gray 90' ] };
-				font-size: 14px;
+				font-size: 16px;
 				line-height: 20px;
 				margin-bottom: 0;
 			}

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -1942,14 +1942,14 @@ const WPCheckoutWrapper = styled.div< {
 			.item-variation-picker > li > div:hover::before {
 				border: none;
 			}
-			.item-variation-picker > li > div > label {                                                                                                                    
+			.item-variation-picker > li > div > label {
 					min-height: 64px;
 					padding-top: 2px;
-					padding-bottom: 0;                                                                                                                                       
-				@media ( ${ props.theme.breakpoints.desktopUp } ) {                                                                                                        
-					min-height: 72px;                                                                                                                                     
-				}                                                                                                                                                          
-			}   
+					padding-bottom: 0;
+				@media ( ${ props.theme.breakpoints.desktopUp } ) {
+					min-height: 72px;
+				}
+			}
 			.checkout-step__stepper > div > div:first-child {
 				border: 1px solid ${ colorStudio.colors[ 'Gray 90' ] };
 				color: ${ colorStudio.colors[ 'Gray 90' ] };
@@ -2025,11 +2025,11 @@ const WPCheckoutWrapper = styled.div< {
 			.checkout-step__header h2 > span {
 				color: ${ colorStudio.colors[ 'Gray 100' ] };
 				font-size: 18px;
-					@media ( ${ props.theme.breakpoints.desktopUp } ) {                                                                                                                                                                  
-						font-size: 20px;                                                                                                                                                                                                 
-					}                                                                                                                                                                                                                    
-				}  
-				
+					@media ( ${ props.theme.breakpoints.desktopUp } ) {
+						font-size: 20px;
+					}
+				}
+
 			.checkout-step__header {
 				margin-bottom: 16px;
 			}
@@ -2042,7 +2042,7 @@ const WPCheckoutWrapper = styled.div< {
 				padding-top: 24px;
 				padding-bottom: 0;
 			}
-				
+
 			.wp-checkout__review-order-step .checkout-step__header h2 > span {
 				font-weight: 500;
 			}

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -2161,6 +2161,9 @@ const WPCheckoutWrapper = styled.div< {
 		props.isCheckoutUiRedesignV1 &&
 		props.isLargeViewport &&
 		css`
+			.checkout__summary-area {
+				padding-top: 50px;
+			}
 			div:has( > div > .wp-checkout-order-review__show-coupon-field-button ) {
 				padding-block-start: 24px;
 			}

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -2022,13 +2022,14 @@ const WPCheckoutWrapper = styled.div< {
 				align-items: center;
 				line-height: 1;
 			}
-			.checkout-step__header h2 {
-				font-size: 15px;
-			}
+
 			.checkout-step__header h2 > span {
-				font-weight: 590;
 				color: ${ colorStudio.colors[ 'Gray 100' ] };
-			}
+				font-size: 18px;
+					@media ( ${ props.theme.breakpoints.desktopUp } ) {                                                                                                                                                                  
+						font-size: 20px;                                                                                                                                                                                                 
+					}                                                                                                                                                                                                                    
+				}  
 				
 			.checkout-step__header {
 				margin-bottom: 16px;

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -2023,10 +2023,20 @@ const WPCheckoutWrapper = styled.div< {
 				font-weight: 590;
 				color: ${ colorStudio.colors[ 'Gray 100' ] };
 			}
-			.checkout-step--active .checkout-step__header,
-			.checkout-step--complete .checkout-step__header {
-				margin-block-end: 24px;
+				
+			.checkout-step__header {
+				margin-bottom: 16px;
 			}
+
+			.wp-checkout__review-order-step .checkout-step__header {
+				margin-bottom: 0;
+			}
+
+			.checkout-line-item {
+				padding-top: 24px;
+				padding-bottom: 0;
+			}
+				
 			.wp-checkout__review-order-step .checkout-step__header h2 > span {
 				font-weight: 500;
 			}
@@ -2052,9 +2062,9 @@ const WPCheckoutWrapper = styled.div< {
 				margin-top: 0;
 			}
 			.wp-checkout__review-order-step .checkout-review-order__site {
-				font-size: 13px;
+				font-size: 14px;
 				font-weight: 400;
-				color: ${ colorStudio.colors[ 'Gray 40' ] };
+				color: ${ colorStudio.colors[ 'Gray 50' ] };
 				@media ( ${ props.theme.breakpoints.tabletUp } ) {
 					margin-inline-start: -40px;
 					margin-top: 0;

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -1328,7 +1328,9 @@ const StepContainerV2CheckoutFixer = styled.div< {
 				padding-block-start: 0;
 			}
 			.wp-checkout__review-order-step .checkout-step__stepper {
-				display: none;
+				@media ( max-width: 699px ) {
+					display: none;
+				}
 			}
 			.wp-checkout__review-order-step .checkout-step__header h2 {
 				font-size: 20px;
@@ -1344,7 +1346,6 @@ const StepContainerV2CheckoutFixer = styled.div< {
 				font-weight: 400;
 				color: ${ colorStudio.colors[ 'Gray 40' ] };
 				@media ( ${ props.theme.breakpoints.tabletUp } ) {
-					margin-inline-start: -40px;
 					margin-top: 0;
 				}
 			}
@@ -2055,7 +2056,9 @@ const WPCheckoutWrapper = styled.div< {
 				padding-block-start: 0;
 			}
 			.wp-checkout__review-order-step .checkout-step__stepper {
-				display: none;
+				@media ( max-width: 699px ) {
+					display: none;
+				}
 			}
 			.wp-checkout__review-order-step .checkout-step__header h2 {
 				font-size: 20px;
@@ -2071,7 +2074,6 @@ const WPCheckoutWrapper = styled.div< {
 				font-weight: 400;
 				color: ${ colorStudio.colors[ 'Gray 50' ] };
 				@media ( ${ props.theme.breakpoints.tabletUp } ) {
-					margin-inline-start: -40px;
 					margin-top: 0;
 				}
 			}

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -1902,6 +1902,14 @@ const WPCheckoutWrapper = styled.div< {
 				padding: 0;
 				margin-bottom: 0;
 			}
+			@media ( ${ props.theme.breakpoints.desktopUp } ) {
+				.checkout__summary-card {
+					background: ${ colorStudio.colors[ 'White' ] };
+					border: 1px solid ${ colorStudio.colors[ 'Gray 5' ] };
+					border-radius: 8px;
+					padding: 24px;
+				}
+			}
 			.promo-card.checkout-sidebar-plan-upsell {
 				background: linear-gradient( 135deg, rgba( 255, 255, 255, 0 ) 0%, #fff 50%, #e6f1ff 100% );
 				border-radius: 8px;
@@ -2103,16 +2111,17 @@ const WPCheckoutWrapper = styled.div< {
 				display: none;
 			}
 			.wp-checkout-order-summary__amount-wrapper {
-				border-top: 1px dashed ${ colorStudio.colors[ 'Gray 10' ] };
+				border-top: 1px dashed ${ colorStudio.colors[ 'Gray 5' ] };
 			}
 			.wp-checkout-order-summary__subtotal-section {
-				border-bottom: 1px dashed ${ colorStudio.colors[ 'Gray 10' ] };
+				border-top: 0;
+				border-bottom: 1px dashed ${ colorStudio.colors[ 'Gray 5' ] };S
 			}
 			.checkout-terms-and-checkboxes {
 				padding-block-start: 24px;
 			}
 			.checkout-terms-and-checkboxes > *:first-child {
-				border-top: 1px dashed ${ colorStudio.colors[ 'Gray 10' ] };
+				border-top: 1px dashed ${ colorStudio.colors[ 'Gray 5' ] };
 			}
 			.checkout-steps__submit-footer-wrapper > div {
 				margin-top: 8px;

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -1941,9 +1941,14 @@ const WPCheckoutWrapper = styled.div< {
 			.item-variation-picker > li > div:hover::before {
 				border: none;
 			}
-			.item-variation-picker > li > div > label {
-				min-height: 52px;
-			}
+			.item-variation-picker > li > div > label {                                                                                                                    
+					min-height: 64px;
+					padding-top: 2px;
+					padding-bottom: 0;                                                                                                                                       
+				@media ( ${ props.theme.breakpoints.desktopUp } ) {                                                                                                        
+					min-height: 72px;                                                                                                                                     
+				}                                                                                                                                                          
+			}   
 			.checkout-step__stepper > div > div:first-child {
 				border: 1px solid ${ colorStudio.colors[ 'Gray 90' ] };
 				color: ${ colorStudio.colors[ 'Gray 90' ] };

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -1981,7 +1981,6 @@ const WPCheckoutWrapper = styled.div< {
 				border: none;
 			}
 			.checkout-payment-methods .has-highlight > label {
-				min-height: 52px;
 				font-size: 13px;
 				font-weight: 400;
 			}

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -2096,11 +2096,16 @@ const WPCheckoutWrapper = styled.div< {
 			.wp-checkout-order-summary__subtotal,
 			.wp-checkout-order-summary__total {
 				color: ${ colorStudio.colors[ 'Gray 90' ] };
-				font-size: 13px;
+				font-size: 14px;
 				line-height: 20px;
+				margin-bottom: 0;
+			}
+			.wp-checkout-order-summary__subtotal:first-child,
+			.wp-checkout-order-summary__total:first-child {
+				margin-bottom: 4px;
 			}
 			.wp-checkout-order-summary__subtotal .wp-checkout-order-summary__subtotal-price {
-				font-size: 13px;
+				font-size: 14px;
 			}
 			.wp-checkout-order-summary__line-item,
 			.wp-checkout-order-summary__tax-not-calculated {

--- a/client/my-sites/checkout/src/components/item-variation-picker/variant-radio-price.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/variant-radio-price.tsx
@@ -1,7 +1,7 @@
 import colorStudio from '@automattic/color-studio';
 import { formatCurrency } from '@automattic/number-formatters';
 import { styled } from '@automattic/wpcom-checkout';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import { useCheckoutUiRedesignExperiment } from 'calypso/my-sites/checkout/src/hooks/use-checkout-ui-redesign-experiment';
 import { getItemVariantDiscount } from './util';
@@ -97,6 +97,21 @@ export const ItemVariantRadioPrice: FunctionComponent< {
 	} );
 
 	const priceDisplay = ( () => {
+		if ( isCheckoutUiRedesignV1 ) {
+			return i18n.fixMe( {
+				text: '%(pricePerMonth)s/mo',
+				newCopy: translate( '%(pricePerMonth)s/mo', {
+					args: {
+						pricePerMonth: pricePerMonthFormatted,
+					},
+				} ),
+				oldCopy: translate( '%(pricePerMonth)s /mo', {
+					args: {
+						pricePerMonth: pricePerMonthFormatted,
+					},
+				} ),
+			} );
+		}
 		return translate( '%(pricePerMonth)s /mo', {
 			args: {
 				pricePerMonth: pricePerMonthFormatted,

--- a/client/my-sites/checkout/src/components/item-variation-picker/variant-radio-price.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/variant-radio-price.tsx
@@ -24,8 +24,9 @@ const Discount = styled.span`
 	}
 `;
 
-const Price = styled.span`
+const Price = styled.span< { isCheckoutUiRedesignV1?: boolean } >`
 	color: ${ colorStudio.colors[ 'Black' ] };
+	${ ( props ) => props.isCheckoutUiRedesignV1 && 'padding-right: 6px;' }
 `;
 
 const Variant = styled.div`
@@ -45,14 +46,14 @@ const VariantTermLabel = styled.span< { isCheckoutUiRedesignV1?: boolean } >`
 	gap: 2px;
 `;
 
-const PriceArea = styled.span< { inlineDiscount?: boolean } >`
+const PriceArea = styled.span< { inlineDiscount?: boolean; isCheckoutUiRedesignV1?: boolean } >`
 	text-align: right;
 	display: flex;
 	flex-direction: ${ ( props ) => ( props.inlineDiscount ? 'row' : 'column' ) };
 	gap: ${ ( props ) => ( props.inlineDiscount ? '8px' : '2px' ) };
 	align-items: ${ ( props ) => ( props.inlineDiscount ? 'center' : 'flex-end' ) };
 	${ ( props ) =>
-		props.inlineDiscount &&
+		props.isCheckoutUiRedesignV1 &&
 		`
 		> span:last-child {
 			min-width: 80px;
@@ -109,11 +110,14 @@ export const ItemVariantRadioPrice: FunctionComponent< {
 			<VariantTermLabel isCheckoutUiRedesignV1={ isCheckoutUiRedesignV1 }>
 				{ label }
 			</VariantTermLabel>
-			<PriceArea inlineDiscount={ isCheckoutUiRedesignV1 && discountPercentage > 0 }>
+			<PriceArea
+				inlineDiscount={ isCheckoutUiRedesignV1 && discountPercentage > 0 }
+				isCheckoutUiRedesignV1={ isCheckoutUiRedesignV1 }
+			>
 				{ isCheckoutUiRedesignV1 && discountPercentage > 0 && (
 					<DiscountPercentage percent={ discountPercentage } />
 				) }
-				<Price>{ priceDisplay }</Price>
+				<Price isCheckoutUiRedesignV1={ isCheckoutUiRedesignV1 }>{ priceDisplay }</Price>
 				{ ! isCheckoutUiRedesignV1 && discountPercentage > 0 && (
 					<DiscountPercentage percent={ discountPercentage } />
 				) }

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -33,7 +33,7 @@ import {
 	getTotalLineItemFromCart,
 	getCreditsLineItemFromCart,
 } from '@automattic/wpcom-checkout';
-import { keyframes } from '@emotion/react';
+import { css, keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 import { Icon, reusableBlock } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -46,6 +46,7 @@ import useEquivalentMonthlyTotals, {
 } from 'calypso/my-sites/checkout/utils/use-equivalent-monthly-totals';
 import { useSelector } from 'calypso/state';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
+import { useCheckoutUiRedesignExperiment } from '../hooks/use-checkout-ui-redesign-experiment';
 import getAkismetProductFeatures from '../lib/get-akismet-product-features';
 import getJetpackProductFeatures from '../lib/get-jetpack-product-features';
 import getPlanFeatures from '../lib/get-plan-features';
@@ -166,6 +167,7 @@ function CheckoutSummaryPriceList() {
 	const totalLineItem = getTotalLineItemFromCart( responseCart );
 	const translate = useTranslate();
 	const monthlyPrices = useEquivalentMonthlyTotals( responseCart.products );
+	const [ , isCheckoutUiRedesignV1 ] = useCheckoutUiRedesignExperiment();
 
 	const subtotalBeforeDiscounts = responseCart.products.reduce( ( subtotal, product ) => {
 		const originalAmountInteger = getOriginalAmountIntegerForDisplay( product, monthlyPrices );
@@ -185,6 +187,7 @@ function CheckoutSummaryPriceList() {
 					<CheckoutSummarySubtotal
 						key="checkout-summary-line-item-subtotal"
 						className="wp-checkout-order-summary__subtotal"
+						isCheckoutUiRedesignV1={ isCheckoutUiRedesignV1 }
 					>
 						<span>{ translate( 'Subtotal' ) }</span>
 						<span className="wp-checkout-order-summary__subtotal-price">
@@ -920,12 +923,21 @@ const CheckoutSummaryLineItem = styled.div< { isDiscount?: boolean } >`
 	}
 `;
 
-const CheckoutSummarySubtotal = styled( CheckoutSummaryLineItem )`
+const CheckoutSummarySubtotal = styled( CheckoutSummaryLineItem )< {
+	isCheckoutUiRedesignV1?: boolean;
+} >`
 	color: ${ ( props ) => props.theme.colors.textColorDark };
 	font-weight: ${ ( props ) => props.theme.weights.bold };
 	line-height: 26px;
 	margin-bottom: 0px;
 	font-size: 20px;
+	${ ( { isCheckoutUiRedesignV1 } ) =>
+		isCheckoutUiRedesignV1 &&
+		css`
+			& > span:first-child {
+				font-size: 14px;
+			}
+		` }
 	& .wp-checkout-order-summary__subtotal-price {
 		font-size: 14px;
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Follow-up https://github.com/Automattic/wp-calypso/pull/109253
Also fixes https://linear.app/a8c/issue/SHILL-1751/implement-checkout-ui-redesign-variant-changes


## Proposed Changes
This PR implements new styles for checkout based on an updated design. The updated design is only activated when the associated experiment is active.

Fixes are both in mobile and desktop versions: font sizes, margins, and paddings to improve legibility and consistency.

## Screenshots
Compared to https://github.com/Automattic/wp-calypso/pull/109253 (left):

| Before | After |
| --- | --- |
| ![image 1714](https://github.com/user-attachments/assets/2bcea86c-2c7b-4cda-ad0d-4cf36b14428a) | ![calypso-ahir](https://github.com/user-attachments/assets/517bef05-44b4-49d4-93f9-9bfdef03d165) |
| ![image 1715](https://github.com/user-attachments/assets/80ed1fa3-c8f7-40e8-ba35-5c8ed5e24996) | ![calypso localhost_3000_checkout_desdahir wordpress com_checkout_ui_redesign=1(iPhone 12 Pro) (1) 1](https://github.com/user-attachments/assets/d2c22de7-e63e-4f03-89ef-8ec434b05ab1) |
| ![image 1716](https://github.com/user-attachments/assets/e4ce2f1f-ea9a-4e11-8a5a-dc1181925feb) | ![calypso localhost_3000_checkout_desdahir wordpress com_checkout_ui_redesign=1(iPhone 12 Pro) 1](https://github.com/user-attachments/assets/af0dee54-c898-463c-8f72-e7c20a388037) |


## Testing Instructions
* Add a product to your cart and visit checkout on this branch.
* Add ?checkout_ui_redesign=1 to the checkout URL to see the updated design.
* Verify it looks ok at different widths/states.