### PR TITLE
Checkout pending: Refetch user in unified flow

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -17,6 +17,7 @@ import { getRedirectFromPendingPage } from 'calypso/my-sites/checkout/src/lib/pe
 import { sendMessageToOpener } from 'calypso/my-sites/checkout/src/lib/popup';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { useSelector, useDispatch } from 'calypso/state';
+import { fetchCurrentUser } from 'calypso/state/current-user/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { SUCCESS } from 'calypso/state/order-transactions/constants';
 import { fetchReceipt } from 'calypso/state/receipts/actions';
@@ -211,6 +212,26 @@ function useRedirectOnTransactionSuccess( {
 		searchParams.size &&
 		searchParams.get( 'from' ) === 'connect-after-checkout' &&
 		searchParams.get( 'connect_url_redirect' ) === 'true';
+	const isUnifiedCheckout = searchParams.get( 'checkout_type' ) === 'unified';
+
+	// For unified checkout (logged-out flow where a new account + site are
+	// created before the transaction), we re-fetch the current user once the
+	// receipt is available. By the time the pending page has finished polling
+	// for the transaction, enough time has passed for the server to propagate
+	// the new site, so a fresh fetch reliably returns site_count >= 1. Without
+	// this, siteSelection receives a stale site_count = 0 and renders "You
+	// don't have any sites yet" instead of the thank-you page.
+	const didRefreshUserForUnified = useRef( false );
+	const [ isUserRefreshedForUnified, setIsUserRefreshedForUnified ] = useState( false );
+	useEffect( () => {
+		if ( ! isUnifiedCheckout || ! blogId || didRefreshUserForUnified.current ) {
+			return;
+		}
+		didRefreshUserForUnified.current = true;
+		( reduxDispatch( fetchCurrentUser() ) as Promise< unknown > )
+			.catch( () => {} )
+			.finally( () => setIsUserRefreshedForUnified( true ) );
+	}, [ isUnifiedCheckout, blogId, reduxDispatch ] );
 
 	const defaultPendingText = translate( 'Almost there—we’re currently finalizing your order.' );
 	const connectingJetpackText = translate(
@@ -290,6 +311,14 @@ function useRedirectOnTransactionSuccess( {
 			return;
 		}
 
+		// For unified checkout, wait for the current user to be re-fetched
+		// (triggered by the useEffect above) before proceeding. This ensures
+		// site_count is up-to-date in Redux so siteSelection doesn't incorrectly
+		// bail with "You don't have any sites yet" on the thank-you page.
+		if ( isUnifiedCheckout && blogId && ! isUserRefreshedForUnified ) {
+			return;
+		}
+
 		didRedirect.current = true;
 		if ( ! redirectInstructions.isError && ! redirectInstructions.isUnknown ) {
 			invokeSurvicateEvent( 'purchaseCompleted' );
@@ -307,8 +336,7 @@ function useRedirectOnTransactionSuccess( {
 		} );
 
 		// Pre-populate the Redux sites store with the newly-purchased site so
-		// that the thank-you page does not briefly show "You don't have any
-		// sites yet" while siteSelection fetches it asynchronously.
+		// that the thank-you page can use it immediately on arrival.
 		if ( blogId ) {
 			reduxDispatch( requestSite( blogId ) );
 		}
@@ -318,6 +346,8 @@ function useRedirectOnTransactionSuccess( {
 		isLoadingOrder,
 		saasRedirectUrl,
 		isConnectAfterCheckoutFlow,
+		isUnifiedCheckout,
+		isUserRefreshedForUnified,
 		connectingJetpackText,
 		error,
 		finalReceiptId,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/SHILL-1820/unified-siteless-checkout-flow-with-paypal-does-not-show-created-site

## Proposed Changes

This PR refetches the current user into Redux when the post-checkout "pending" page finds a successful order. This way if the site was created during the order process, it should be available when the post-checkout thank-you page is shown.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When a user uses siteless checkout to create a site during the transaction order flow, it's possible that the calypso Redux store will not have it available when the pending page loads (because it hasn't been created yet). The pending page polls the order until it completes, and then redirects the user to the final post-checkout destination. However, if that destination relies on the Redux store having site data for the user, it will fail since the site count was 0 when the Redux store last updated.

We need to update the site count (part of the user data) when the checkout completes.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit https://wordpress.com/checkout/unified/personal while logged out of wordpress.com.
- Fill in the checkout form (you must use a new email address that does not have a wordpress.com account and it cannot be an automattic email address).
- At the payment step, select PayPal and complete the payment (the bug does not appear to happen with credit cards).
- Confirm you are redirected to the onboarding post-checkout page (not a "no sites" or log-in page) and that the new site is available.