### PR TITLE
Comp modal: hide already-comped plan options

### DIFF
--- a/client/my-sites/earn/components/add-edit-coupon-modal/products-selector.tsx
+++ b/client/my-sites/earn/components/add-edit-coupon-modal/products-selector.tsx
@@ -18,6 +18,7 @@ type ProductsSelectorProps = {
 	initialSelectedList: number[];
 	allowMultiple: boolean;
 	showLabel?: boolean;
+	excludeTitles?: string[];
 };
 
 const ProductsSelector = ( {
@@ -25,14 +26,19 @@ const ProductsSelector = ( {
 	initialSelectedList,
 	allowMultiple,
 	showLabel = true,
+	excludeTitles,
 }: ProductsSelectorProps ) => {
 	const [ selectedPlanIds, setSelectedPlanIds ] = useState( initialSelectedList ?? [] );
 
 	const selectedSiteId = useSelector( getSelectedSiteId );
 
-	const products: Product[] = useSelector( ( state ) =>
+	const allProducts: Product[] = useSelector( ( state ) =>
 		getProductsForSiteId( state, selectedSiteId )
 	);
+
+	const products = excludeTitles?.length
+		? allProducts.filter( ( product ) => ! excludeTitles.includes( product.title ?? '' ) )
+		: allProducts;
 
 	const onSelectProduct = ( event: ChangeEvent< HTMLInputElement > ) => {
 		const productId =

--- a/client/my-sites/earn/components/add-edit-coupon-modal/products-selector.tsx
+++ b/client/my-sites/earn/components/add-edit-coupon-modal/products-selector.tsx
@@ -18,7 +18,7 @@ type ProductsSelectorProps = {
 	initialSelectedList: number[];
 	allowMultiple: boolean;
 	showLabel?: boolean;
-	excludeTitles?: string[];
+	excludeProductIds?: number[];
 };
 
 const ProductsSelector = ( {
@@ -26,7 +26,7 @@ const ProductsSelector = ( {
 	initialSelectedList,
 	allowMultiple,
 	showLabel = true,
-	excludeTitles,
+	excludeProductIds,
 }: ProductsSelectorProps ) => {
 	const [ selectedPlanIds, setSelectedPlanIds ] = useState( initialSelectedList ?? [] );
 
@@ -36,8 +36,8 @@ const ProductsSelector = ( {
 		getProductsForSiteId( state, selectedSiteId )
 	);
 
-	const products = excludeTitles?.length
-		? allProducts.filter( ( product ) => ! excludeTitles.includes( product.title ?? '' ) )
+	const products = excludeProductIds?.length
+		? allProducts.filter( ( product ) => ! excludeProductIds.includes( product.ID ?? 0 ) )
 		: allProducts;
 
 	const onSelectProduct = ( event: ChangeEvent< HTMLInputElement > ) => {

--- a/client/my-sites/earn/components/add-edit-coupon-modal/test/products-selector.tsx
+++ b/client/my-sites/earn/components/add-edit-coupon-modal/test/products-selector.tsx
@@ -154,7 +154,7 @@ describe( 'ProductsSelector', () => {
 		expect( getDropdownButton( '2 products selected.' ) ).not.toBeNull();
 	} );
 
-	test( 'should not render products matching excludeTitles', async () => {
+	test( 'should not render products matching excludeProductIds', async () => {
 		const render = ( el, options ) =>
 			renderWithProvider( el, {
 				...options,
@@ -171,7 +171,7 @@ describe( 'ProductsSelector', () => {
 				onSelectedPlanIdsChange={ () => {} }
 				initialSelectedList={ [] }
 				allowMultiple={ false }
-				excludeTitles={ [ 'Monthly Subscription' ] }
+				excludeProductIds={ [ testProduct1.ID ] }
 			/>
 		);
 

--- a/client/my-sites/earn/components/add-edit-coupon-modal/test/products-selector.tsx
+++ b/client/my-sites/earn/components/add-edit-coupon-modal/test/products-selector.tsx
@@ -154,6 +154,36 @@ describe( 'ProductsSelector', () => {
 		expect( getDropdownButton( '2 products selected.' ) ).not.toBeNull();
 	} );
 
+	test( 'should not render products matching excludeTitles', async () => {
+		const render = ( el, options ) =>
+			renderWithProvider( el, {
+				...options,
+				initialState,
+				reducers: {
+					ui: uiReducer,
+					memberships: membershipsReducer,
+					siteSettings: siteSettingsReducer,
+				},
+			} );
+		const user = userEvent.setup();
+		render(
+			<ProductsSelector
+				onSelectedPlanIdsChange={ () => {} }
+				initialSelectedList={ [] }
+				allowMultiple={ false }
+				excludeTitles={ [ 'Monthly Subscription' ] }
+			/>
+		);
+
+		await user.click( getDropdownButton( 'No product selected' ) );
+		expect( getYearlyProductCheckbox() ).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'menuitemcheckbox', {
+				name: 'Monthly Subscription : $5.00 / month',
+			} )
+		).not.toBeInTheDocument();
+	} );
+
 	test( 'clicking the button should show a dropdown with selected items selected', async () => {
 		const render = ( el, options ) =>
 			renderWithProvider( el, {

--- a/client/my-sites/subscribers/components/comp-modal/comp-modal.tsx
+++ b/client/my-sites/subscribers/components/comp-modal/comp-modal.tsx
@@ -1,10 +1,12 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Modal, Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import ProductsSelector from 'calypso/my-sites/earn/components/add-edit-coupon-modal/products-selector';
-import { useDispatch } from 'calypso/state';
+import { Product } from 'calypso/my-sites/earn/types';
+import { useDispatch, useSelector } from 'calypso/state';
 import { requestAddComp } from 'calypso/state/memberships/comps/actions';
+import { getProductsForSiteId } from 'calypso/state/memberships/product-list/selectors';
 
 import './style.scss';
 
@@ -12,6 +14,7 @@ type CompSubscriptionModalProps = {
 	userId: number | string;
 	siteId: number;
 	username: string;
+	compedPlanTitles?: string[];
 	onClose: () => void;
 	onConfirm: () => void;
 };
@@ -25,6 +28,7 @@ const CompSubscriptionModal = ( {
 	siteId,
 	userId,
 	username,
+	compedPlanTitles,
 	onClose,
 	onConfirm,
 }: CompSubscriptionModalProps ) => {
@@ -34,6 +38,15 @@ const CompSubscriptionModal = ( {
 
 	const [ planId, setPlanId ] = useState( 0 );
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
+
+	const products: Product[] = useSelector( ( state ) => getProductsForSiteId( state, siteId ) );
+	const allPlansComped = useMemo( () => {
+		if ( ! compedPlanTitles?.length || ! products?.length ) {
+			return false;
+		}
+		const compedSet = new Set( compedPlanTitles );
+		return products.every( ( product ) => compedSet.has( product.title ?? '' ) );
+	}, [ compedPlanTitles, products ] );
 
 	useEffect( () => {
 		recordTracksEvent( 'calypso_subscribers_comp_modal_open', {
@@ -79,26 +92,40 @@ const CompSubscriptionModal = ( {
 			title={ translate( 'Complimentary subscription' ) }
 			onRequestClose={ onClose }
 		>
-			<p>{ translate( 'Select a plan to give complimentary access to this user:' ) }</p>
-			<ProductsSelector
-				onSelectedPlanIdsChange={ ( list ) => setPlanId( list[ 0 ] ?? 0 ) }
-				initialSelectedList={ [] }
-				allowMultiple={ false }
-				showLabel={ false }
-			/>
-			<div className="complimentary-subscription-modal__buttons">
-				<Button onClick={ onClose } variant="tertiary">
-					{ translate( 'Cancel' ) }
-				</Button>
-				<Button
-					variant="primary"
-					isBusy={ isSubmitting }
-					onClick={ () => addCompSubscription( planId, userId, username ) }
-					disabled={ planId === 0 || isSubmitting }
-				>
-					{ translate( 'Confirm' ) }
-				</Button>
-			</div>
+			{ allPlansComped ? (
+				<>
+					<p>{ translate( 'This subscriber already has complimentary access to all plans.' ) }</p>
+					<div className="complimentary-subscription-modal__buttons">
+						<Button onClick={ onClose } variant="primary">
+							{ translate( 'Close' ) }
+						</Button>
+					</div>
+				</>
+			) : (
+				<>
+					<p>{ translate( 'Select a plan to give complimentary access to this user:' ) }</p>
+					<ProductsSelector
+						onSelectedPlanIdsChange={ ( list ) => setPlanId( list[ 0 ] ?? 0 ) }
+						initialSelectedList={ [] }
+						allowMultiple={ false }
+						showLabel={ false }
+						excludeTitles={ compedPlanTitles }
+					/>
+					<div className="complimentary-subscription-modal__buttons">
+						<Button onClick={ onClose } variant="tertiary">
+							{ translate( 'Cancel' ) }
+						</Button>
+						<Button
+							variant="primary"
+							isBusy={ isSubmitting }
+							onClick={ () => addCompSubscription( planId, userId, username ) }
+							disabled={ planId === 0 || isSubmitting }
+						>
+							{ translate( 'Confirm' ) }
+						</Button>
+					</div>
+				</>
+			) }
 		</Modal>
 	);
 };

--- a/client/my-sites/subscribers/components/comp-modal/comp-modal.tsx
+++ b/client/my-sites/subscribers/components/comp-modal/comp-modal.tsx
@@ -44,8 +44,7 @@ const CompSubscriptionModal = ( {
 		if ( ! compedPlanTitles?.length || ! products?.length ) {
 			return false;
 		}
-		const compedSet = new Set( compedPlanTitles );
-		return products.every( ( product ) => compedSet.has( product.title ?? '' ) );
+		return products.every( ( product ) => compedPlanTitles.includes( product.title ?? '' ) );
 	}, [ compedPlanTitles, products ] );
 
 	useEffect( () => {

--- a/client/my-sites/subscribers/components/comp-modal/comp-modal.tsx
+++ b/client/my-sites/subscribers/components/comp-modal/comp-modal.tsx
@@ -14,7 +14,7 @@ type CompSubscriptionModalProps = {
 	userId: number | string;
 	siteId: number;
 	username: string;
-	compedPlanTitles?: string[];
+	compedPlanIds?: number[];
 	onClose: () => void;
 	onConfirm: () => void;
 };
@@ -28,7 +28,7 @@ const CompSubscriptionModal = ( {
 	siteId,
 	userId,
 	username,
-	compedPlanTitles,
+	compedPlanIds,
 	onClose,
 	onConfirm,
 }: CompSubscriptionModalProps ) => {
@@ -41,11 +41,11 @@ const CompSubscriptionModal = ( {
 
 	const products: Product[] = useSelector( ( state ) => getProductsForSiteId( state, siteId ) );
 	const allPlansComped = useMemo( () => {
-		if ( ! compedPlanTitles?.length || ! products?.length ) {
+		if ( ! compedPlanIds?.length || ! products?.length ) {
 			return false;
 		}
-		return products.every( ( product ) => compedPlanTitles.includes( product.title ?? '' ) );
-	}, [ compedPlanTitles, products ] );
+		return products.every( ( product ) => compedPlanIds.includes( product.ID ?? 0 ) );
+	}, [ compedPlanIds, products ] );
 
 	useEffect( () => {
 		recordTracksEvent( 'calypso_subscribers_comp_modal_open', {
@@ -108,7 +108,7 @@ const CompSubscriptionModal = ( {
 						initialSelectedList={ [] }
 						allowMultiple={ false }
 						showLabel={ false }
-						excludeTitles={ compedPlanTitles }
+						excludeProductIds={ compedPlanIds }
 					/>
 					<div className="complimentary-subscription-modal__buttons">
 						<Button onClick={ onClose } variant="tertiary">

--- a/client/my-sites/subscribers/components/comp-modal/test/comp-modal.test.tsx
+++ b/client/my-sites/subscribers/components/comp-modal/test/comp-modal.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import membershipsReducer from 'calypso/state/memberships/reducer';
+import uiReducer from 'calypso/state/ui/reducer';
+import { renderWithProvider } from '../../../../../test-helpers/testing-library';
+import CompSubscriptionModal from '../comp-modal';
+
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/state/memberships/comps/actions', () => ( {
+	requestAddComp: jest.fn( () => () => Promise.resolve() ),
+} ) );
+
+const products = [
+	{
+		ID: 100,
+		title: 'Monthly Subscription',
+		price: 5,
+		currency: 'USD',
+		renewal_schedule: '1 month',
+	},
+	{
+		ID: 200,
+		title: 'Yearly Subscription',
+		price: 40,
+		currency: 'USD',
+		renewal_schedule: '1 year',
+	},
+];
+
+const siteId = 1;
+
+const initialState = {
+	sites: { items: {} },
+	ui: { selectedSiteId: siteId },
+	memberships: {
+		productList: {
+			items: {
+				[ siteId ]: products,
+			},
+		},
+	},
+};
+
+function renderModal( props = {} ) {
+	const defaultProps = {
+		siteId,
+		userId: 123,
+		username: 'testuser',
+		onClose: jest.fn(),
+		onConfirm: jest.fn(),
+	};
+
+	return {
+		...renderWithProvider( <CompSubscriptionModal { ...defaultProps } { ...props } />, {
+			initialState,
+			reducers: {
+				ui: uiReducer,
+				memberships: membershipsReducer,
+			},
+		} ),
+		props: { ...defaultProps, ...props },
+	};
+}
+
+describe( 'CompSubscriptionModal', () => {
+	it( 'renders the plan selection UI by default', () => {
+		renderModal();
+
+		expect(
+			screen.getByText( 'Select a plan to give complimentary access to this user:' )
+		).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Confirm' } ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Cancel' } ) ).toBeVisible();
+	} );
+
+	it( 'hides already-comped plans from the dropdown', async () => {
+		const user = userEvent.setup();
+		renderModal( { compedPlanTitles: [ 'Monthly Subscription' ] } );
+
+		await user.click( screen.getByRole( 'button', { name: 'No product selected' } ) );
+
+		expect(
+			screen.getByRole( 'menuitemcheckbox', { name: 'Yearly Subscription : $40.00 / year' } )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'menuitemcheckbox', {
+				name: 'Monthly Subscription : $5.00 / month',
+			} )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'shows all-comped message when all plans are comped', () => {
+		renderModal( {
+			compedPlanTitles: [ 'Monthly Subscription', 'Yearly Subscription' ],
+		} );
+
+		expect(
+			screen.getByText( 'This subscriber already has complimentary access to all plans.' )
+		).toBeVisible();
+		expect( screen.queryByRole( 'button', { name: 'Confirm' } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Cancel' } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'calls onClose when Close is clicked in all-comped state', async () => {
+		const user = userEvent.setup();
+		const { props } = renderModal( {
+			compedPlanTitles: [ 'Monthly Subscription', 'Yearly Subscription' ],
+		} );
+
+		const closeButtons = screen.getAllByRole( 'button', { name: 'Close' } );
+		// Click the modal body Close button (not the modal X button)
+		await user.click( closeButtons[ closeButtons.length - 1 ] );
+
+		expect( props.onClose ).toHaveBeenCalled();
+	} );
+
+	it( 'disables Confirm button when no plan is selected', () => {
+		renderModal();
+
+		expect( screen.getByRole( 'button', { name: 'Confirm' } ) ).toBeDisabled();
+	} );
+} );

--- a/client/my-sites/subscribers/components/comp-modal/test/comp-modal.test.tsx
+++ b/client/my-sites/subscribers/components/comp-modal/test/comp-modal.test.tsx
@@ -81,7 +81,7 @@ describe( 'CompSubscriptionModal', () => {
 
 	it( 'hides already-comped plans from the dropdown', async () => {
 		const user = userEvent.setup();
-		renderModal( { compedPlanTitles: [ 'Monthly Subscription' ] } );
+		renderModal( { compedPlanIds: [ 100 ] } );
 
 		await user.click( screen.getByRole( 'button', { name: 'No product selected' } ) );
 
@@ -97,7 +97,7 @@ describe( 'CompSubscriptionModal', () => {
 
 	it( 'shows all-comped message when all plans are comped', () => {
 		renderModal( {
-			compedPlanTitles: [ 'Monthly Subscription', 'Yearly Subscription' ],
+			compedPlanIds: [ 100, 200 ],
 		} );
 
 		expect(
@@ -110,7 +110,7 @@ describe( 'CompSubscriptionModal', () => {
 	it( 'calls onClose when Close is clicked in all-comped state', async () => {
 		const user = userEvent.setup();
 		const { props } = renderModal( {
-			compedPlanTitles: [ 'Monthly Subscription', 'Yearly Subscription' ],
+			compedPlanIds: [ 100, 200 ],
 		} );
 
 		const closeButtons = screen.getAllByRole( 'button', { name: 'Close' } );

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -13,8 +13,10 @@ import { translate } from 'i18n-calypso';
 import JetpackTitle from 'calypso/components/jetpack-title';
 import { useSubscribedNewsletterCategories } from 'calypso/data/newsletter-categories';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { Product } from 'calypso/my-sites/earn/types';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import { getProductsForSiteId } from 'calypso/state/memberships/product-list/selectors';
 import { getCouponsAndGiftsEnabledForSiteId } from 'calypso/state/memberships/settings/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
@@ -164,6 +166,21 @@ export default function SubscriberDataViews( {
 
 	const couponsAndGiftsEnabled = useSelector( ( state ) =>
 		getCouponsAndGiftsEnabledForSiteId( state, siteId )
+	);
+
+	const products: Product[] = useSelector( ( state ) => getProductsForSiteId( state, siteId ) );
+
+	const hasUncompedPlans = useCallback(
+		( subscriber: Subscriber ) => {
+			if ( ! products?.length ) {
+				return true;
+			}
+			const compedTitles = new Set(
+				( subscriber.plans ?? [] ).filter( ( p ) => p.is_comp ).map( ( p ) => p.title )
+			);
+			return products.some( ( product ) => ! compedTitles.has( product.title ?? '' ) );
+		},
+		[ products ]
 	);
 
 	const [ currentView, setCurrentView ] = useState< View >( {
@@ -513,7 +530,7 @@ export default function SubscriberDataViews( {
 						'"Comp" is short for "complimentary" — granting a free subscription to a subscriber',
 				} ),
 				isEligible: ( subscriber: Subscriber ) =>
-					!! ( subscriber.user_id || subscriber.email_address ),
+					!! ( subscriber.user_id || subscriber.email_address ) && hasUncompedPlans( subscriber ),
 				callback: ( items: Subscriber[] ) => {
 					const subscriber = items[ 0 ];
 					if ( ! subscriber ) {
@@ -533,6 +550,7 @@ export default function SubscriberDataViews( {
 		handleUnsubscribe,
 		onCompSubscription,
 		couponsAndGiftsEnabled,
+		hasUncompedPlans,
 	] );
 
 	const handleViewChange = useCallback(

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -175,10 +175,10 @@ export default function SubscriberDataViews( {
 			if ( ! products?.length ) {
 				return true;
 			}
-			const compedTitles = ( subscriber.plans ?? [] )
-				.filter( ( p ) => p.is_comp )
-				.map( ( p ) => p.title );
-			return products.some( ( product ) => ! compedTitles.includes( product.title ?? '' ) );
+			const compedIds = ( subscriber.plans ?? [] )
+				.filter( ( p ) => p.is_comp && p.subscription_id )
+				.map( ( p ) => p.subscription_id );
+			return products.some( ( product ) => ! compedIds.includes( product.ID ?? 0 ) );
 		},
 		[ products ]
 	);

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -175,10 +175,10 @@ export default function SubscriberDataViews( {
 			if ( ! products?.length ) {
 				return true;
 			}
-			const compedTitles = new Set(
-				( subscriber.plans ?? [] ).filter( ( p ) => p.is_comp ).map( ( p ) => p.title )
-			);
-			return products.some( ( product ) => ! compedTitles.has( product.title ?? '' ) );
+			const compedTitles = ( subscriber.plans ?? [] )
+				.filter( ( p ) => p.is_comp )
+				.map( ( p ) => p.title );
+			return products.some( ( product ) => ! compedTitles.includes( product.title ?? '' ) );
 		},
 		[ products ]
 	);

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -62,9 +62,13 @@ const SubscribersPage = ( { subscriberId }: Props ) => {
 
 	const [ compUserId, setCompUserId ] = useState< number | string | null >( null );
 	const [ compUsername, setCompUsername ] = useState( '' );
-	const onCompSubscription = ( { user_id, email_address, display_name }: Subscriber ) => {
+	const [ compedPlanTitles, setCompedPlanTitles ] = useState< string[] >( [] );
+	const onCompSubscription = ( { user_id, email_address, display_name, plans }: Subscriber ) => {
 		setCompUserId( user_id || email_address || null );
 		setCompUsername( display_name );
+		setCompedPlanTitles(
+			( plans ?? [] ).filter( ( plan ) => plan.is_comp ).map( ( plan ) => plan.title )
+		);
 	};
 
 	const [ removeComp, setRemoveComp ] = useState< {
@@ -92,6 +96,7 @@ const SubscribersPage = ( { subscriberId }: Props ) => {
 							siteId={ siteId ?? 0 }
 							userId={ compUserId }
 							username={ compUsername }
+							compedPlanTitles={ compedPlanTitles }
 							onClose={ () => setCompUserId( null ) }
 							onConfirm={ () => setCompUserId( null ) }
 						/>

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -4,6 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
+import QueryMemberships from 'calypso/components/data/query-memberships';
 import QueryMembershipsSettings from 'calypso/components/data/query-memberships-settings';
 import Main from 'calypso/components/main';
 import SubscriberValidationGate from 'calypso/components/subscribers-validation-gate';
@@ -79,6 +80,7 @@ const SubscribersPage = ( { subscriberId }: Props ) => {
 
 	return (
 		<>
+			<QueryMemberships siteId={ siteId ?? 0 } />
 			<QueryMembershipsSettings siteId={ siteId ?? 0 } source="calypso" />
 			<Main wideLayout className="subscribers">
 				<DocumentHead title={ translate( 'Subscribers' ) } />

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -63,12 +63,14 @@ const SubscribersPage = ( { subscriberId }: Props ) => {
 
 	const [ compUserId, setCompUserId ] = useState< number | string | null >( null );
 	const [ compUsername, setCompUsername ] = useState( '' );
-	const [ compedPlanTitles, setCompedPlanTitles ] = useState< string[] >( [] );
+	const [ compedPlanIds, setCompedPlanIds ] = useState< number[] >( [] );
 	const onCompSubscription = ( { user_id, email_address, display_name, plans }: Subscriber ) => {
 		setCompUserId( user_id || email_address || null );
 		setCompUsername( display_name );
-		setCompedPlanTitles(
-			( plans ?? [] ).filter( ( plan ) => plan.is_comp ).map( ( plan ) => plan.title )
+		setCompedPlanIds(
+			( plans ?? [] )
+				.filter( ( plan ) => plan.is_comp && plan.subscription_id )
+				.map( ( plan ) => plan.subscription_id as number )
 		);
 	};
 
@@ -98,7 +100,7 @@ const SubscribersPage = ( { subscriberId }: Props ) => {
 							siteId={ siteId ?? 0 }
 							userId={ compUserId }
 							username={ compUsername }
-							compedPlanTitles={ compedPlanTitles }
+							compedPlanIds={ compedPlanIds }
 							onClose={ () => setCompUserId( null ) }
 							onConfirm={ () => setCompUserId( null ) }
 						/>

--- a/client/my-sites/subscribers/types/index.ts
+++ b/client/my-sites/subscribers/types/index.ts
@@ -10,6 +10,7 @@ export type SubscriberEndpointResponse = {
 };
 
 export type SubscriptionPlan = {
+	subscription_id?: number;
 	is_comp: boolean;
 	comp_id?: number;
 	/** @deprecated Legacy field from the API — plans with is_gift are filtered out. */


### PR DESCRIPTION
Part of NL-555

## Proposed Changes

* Filter out plans the subscriber has already been comped to from the complimentary subscription modal dropdown, matching by `subscription_id` → `Product.ID`
* When all plans are already comped, show an informational message ("This subscriber already has complimentary access to all plans.") instead of an empty dropdown
* Hide the "Comp a subscription" row action in the subscriber list when all plans are already comped
* Prefetch membership products on the subscribers page so filtering data is available immediately (no flash)
* Add `subscription_id` to the `SubscriptionPlan` TypeScript type (now returned by the individual subscriber endpoint)

<img width="497" height="336" alt="Screenshot 2026-03-30 at 3 47 09 PM" src="https://github.com/user-attachments/assets/e33dd8f0-4fed-4afd-a8a0-a8ab4d6be528" />
<img width="533" height="212" alt="Screenshot 2026-03-30 at 3 46 52 PM" src="https://github.com/user-attachments/assets/f353376a-a371-48f4-a116-69613bf6d7f5" />


## Why are these changes being made?

After comping a subscriber, the modal still shows all options including the one already granted. The user has to guess which plan they've already comped. This change hides already-comped plans so creators don't accidentally try to comp the same plan twice.

## Testing Instructions

1. Navigate to the Subscribers page for a site with multiple paid plans
2. Comp a subscriber to one of the plans
3. Open the comp modal again for the same subscriber — the comped plan should no longer appear in the dropdown
4. Comp the subscriber to all remaining plans
5. Open the comp modal again — it should show "This subscriber already has complimentary access to all plans." with a Close button
6. In the subscriber list, the "Comp a subscription" row action should no longer appear for that fully-comped subscriber

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?