### PR TITLE
composite-checkout: Scroll next step into view when changing steps

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -715,7 +715,11 @@ export default function CheckoutMainContent( {
 						{ translate( 'Checkout' ) }
 					</WPCheckoutTitle>
 				) }
-				<CheckoutStepGroup loadingHeader={ loadingHeader } onStepChanged={ onStepChanged }>
+				<CheckoutStepGroup
+					loadingHeader={ loadingHeader }
+					onStepChanged={ onStepChanged }
+					scrollToStepOnForwardNavigation
+				>
 					<PerformanceTrackerStop />
 					{ infoMessage }
 

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -195,6 +195,7 @@ Available props:
 - `loadingContent?: ReactNode`. A component that will be displayed while checkout is loading. The default is [LoadingContent](#LoadingContent).
 - `loadingHeader?: ReactNode`. A component that will be displayed above the main content while checkout is loading.
 - `onStepChanged?: ({ stepNumber: number | null; previousStepNumber: number; paymentMethodId: string }) => void`. A function to call when the active checkout step is changed.
+- `scrollToStepOnForwardNavigation?: boolean`. When `true`, the newly active step will be scrolled into view whenever the user moves forward through the checkout steps. This is useful on mobile to correct the viewport position after the previous step's content collapses and causes the layout to shift. Defaults to `false`.
 - `store?: CheckoutStepGroupStore`. A way to inject a data store for the step group created by [createCheckoutStepGroupStore](#createCheckoutStepGroupStore). If not provided, a store will be created automatically.
 
 ### FormStatus

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -399,12 +399,14 @@ function CheckoutStepGroupWrapper( {
 	loadingContent,
 	loadingHeader,
 	onStepChanged,
+	scrollToStepOnForwardNavigation,
 	store,
 }: PropsWithChildren< {
 	className?: string;
 	loadingContent?: ReactNode;
 	loadingHeader?: ReactNode;
 	onStepChanged?: StepChangedCallback;
+	scrollToStepOnForwardNavigation?: boolean;
 	store: CheckoutStepGroupStore;
 } > ) {
 	const { isRTL } = useI18n();
@@ -435,12 +437,25 @@ function CheckoutStepGroupWrapper( {
 	// Call the `onStepChanged` callback when a step changes.
 	useEffect( () => {
 		if ( store.state.activeStepNumber !== previousStepNumber.current ) {
+			const prevStep = previousStepNumber.current;
+			const newStep = store.state.activeStepNumber;
 			onStepChanged?.( {
-				stepNumber: store.state.activeStepNumber,
-				previousStepNumber: previousStepNumber.current,
+				stepNumber: newStep,
+				previousStepNumber: prevStep,
 				paymentMethodId: activePaymentMethod?.id ?? '',
 			} );
-			previousStepNumber.current = store.state.activeStepNumber;
+			previousStepNumber.current = newStep;
+			// When moving forward through steps, scroll the newly active step into
+			// view. This corrects the viewport position on mobile after the previous
+			// step's content collapses and causes the layout to shift.
+			if ( scrollToStepOnForwardNavigation && newStep > prevStep ) {
+				const newStepId = Object.entries( store.state.stepIdMap ).find(
+					( [ , num ] ) => num === newStep
+				)?.[ 0 ];
+				if ( newStepId ) {
+					document.getElementById( newStepId )?.scrollIntoView?.( { block: 'start' } );
+				}
+			}
 		}
 		// We only want to run this when the step changes.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -851,7 +866,7 @@ export function CheckoutStepBody( {
 			errorMessage={ errorMessage || __( 'There was an error with this step.' ) }
 			onError={ onError }
 		>
-			<StepWrapper className={ className }>
+			<StepWrapper className={ className } id={ stepId }>
 				<CheckoutStepHeader
 					id={ stepId }
 					stepNumber={ stepNumber }
@@ -1221,6 +1236,7 @@ export function CheckoutStepGroup( {
 	stepAreaHeader,
 	store,
 	onStepChanged,
+	scrollToStepOnForwardNavigation,
 	loadingContent,
 	loadingHeader,
 }: PropsWithChildren< {
@@ -1228,6 +1244,7 @@ export function CheckoutStepGroup( {
 	stepAreaHeader?: ReactNode;
 	store?: CheckoutStepGroupStore;
 	onStepChanged?: StepChangedCallback;
+	scrollToStepOnForwardNavigation?: boolean;
 	loadingContent?: ReactNode;
 	loadingHeader?: ReactNode;
 } > ) {
@@ -1238,6 +1255,7 @@ export function CheckoutStepGroup( {
 			loadingContent={ loadingContent }
 			loadingHeader={ loadingHeader }
 			onStepChanged={ onStepChanged }
+			scrollToStepOnForwardNavigation={ scrollToStepOnForwardNavigation }
 		>
 			{ stepAreaHeader }
 			<CheckoutStepArea>


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-1824/

## Proposed changes

Fixes a mobile viewport issue in checkout where tapping "Continue to payment" would scroll the page to the bottom (coupon/TOS area) instead of showing the payment methods step.

* Add `id={stepId}` to the step wrapper `div` in `CheckoutStepBody` so each step's container element is addressable via `document.getElementById`
* Add a `scrollToStepOnForwardNavigation` prop to `CheckoutStepGroup` (and its internal `CheckoutStepGroupWrapper`) that, when enabled, scrolls the newly active step into view after any forward step transition
* Enable `scrollToStepOnForwardNavigation` on the WP.com checkout step group

## Why are these changes being made?

On mobile, the contact details form is long enough that the user must scroll down to reach the "Continue to payment" button. When the button is tapped, the contact step's content collapses (`display: none`) and the payment step expands (`display: block`). Because the browser (particularly iOS Safari) maintains scroll position in absolute pixels, the collapse of the contact form reduces the total page height — and the previously valid scroll offset now lands at or past the bottom of the page, showing the coupon field and terms-of-service text rather than the payment methods.

The fix scrolls the newly active step's wrapper element into view whenever the user moves forward through the checkout steps. The behavior is gated behind an opt-in `scrollToStepOnForwardNavigation` prop on `CheckoutStepGroup` so that other consumers of the `composite-checkout` package are unaffected.

## Testing instructions

Manual testing:
* Use a narrow viewport (≤ 480 px wide, or test on an iPhone)
* Add a product to cart and proceed to checkout
* On the contact details step, scroll down to the "Continue to payment" button and tap it
* Confirm the viewport scrolls to show the payment methods step header, not the bottom of the page
