### PR TITLE
TeamCity: BuildCacheSeedImages: Auto rebuild on lock file changes

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -20,6 +20,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.projectFeatures.dockerRegist
 import jetbrains.buildServer.configs.kotlin.v2019_2.projectFeatures.githubConnection
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.schedule
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
 import jetbrains.buildServer.configs.kotlin.v2019_2.version
 
@@ -245,8 +246,8 @@ object BuildBaseImages : BuildType({
 
 	triggers {
 		schedule {
-			schedulingPolicy = cron {
-				hours = "*/6"
+			schedulingPolicy = daily {
+				hour = 3
 			}
 			branchFilter = """
 				+:trunk
@@ -462,6 +463,7 @@ object BuildToolchainPreviewImages : BuildType({
 object BuildCacheSeedImages : BuildType({
 	name = "Build cache-seed images"
 	description = "Builds and publishes scheduled cache-seed images from Dockerfile.cache-seed."
+	maxRunningBuilds = 1
 
 	buildNumberPattern = "%build.prefix%.%build.counter%"
 
@@ -552,6 +554,17 @@ object BuildCacheSeedImages : BuildType({
 	}
 
 	triggers {
+		vcs {
+			branchFilter = "+:trunk"
+			triggerRules = """
+				+:yarn.lock
+				+:package.json
+				+:composer.lock
+				+:.nvmrc
+			""".trimIndent()
+			quietPeriodMode = VcsTrigger.QuietPeriodMode.USE_CUSTOM
+			quietPeriod = 600  // 10 minutes in seconds
+		}
 		schedule {
 			schedulingPolicy = cron {
 				hours = "3,9,15,21"


### PR DESCRIPTION
OK, after I worked on rube goldberg machines to rebuild the cache seed image, the easiest way is really just to use a VCS trigger to auto rebuild it on lockfile changes. This should get us out of the "Build is slow" pattern quicker.

## Proposed Changes

*

## Why are these changes being made?

*

## Testing Instructions


*

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
