### PR TITLE
MSD Sidebar: Remove MCP item from sidebar

### DIFF
--- a/client/dashboard/me/me-sidebar/index.tsx
+++ b/client/dashboard/me/me-sidebar/index.tsx
@@ -1,5 +1,4 @@
 import { userSettingsQuery } from '@automattic/api-queries';
-import { isEnabled } from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
 import {
 	__experimentalHStack as HStack,
@@ -15,7 +14,6 @@ import {
 	notAllowed,
 	payment,
 	settings,
-	starEmpty,
 } from '@wordpress/icons';
 import { useAppContext } from '../../app/context';
 import { SidebarMenu, SidebarMenuItem } from '../../components/sidebar';
@@ -81,11 +79,6 @@ function MeMenuSidebar() {
 			{ supports.reader && (
 				<SidebarMenuItem icon={ notAllowed } to="/me/blocked-sites">
 					{ __( 'Blocked sites' ) }
-				</SidebarMenuItem>
-			) }
-			{ isEnabled( 'mcp-settings' ) && (
-				<SidebarMenuItem icon={ starEmpty } to="/me/mcp">
-					{ __( 'MCP' ) }
 				</SidebarMenuItem>
 			) }
 			{ hasAppSupport( supports, 'apps' ) && (


### PR DESCRIPTION
Fixes DOTMSD-1192

## Proposed Changes

* Remove the MCP sidebar menu item from the Me sidebar
* Clean up unused `isEnabled` and `starEmpty` imports

**Screenshots**

| Before | After |
|--------|--------|
| <img width="271" height="524" alt="Screenshot 2026-03-31 at 10 08 15 AM" src="https://github.com/user-attachments/assets/e237d92e-6ab3-4efc-b2c2-db1019cd4014" /> | <img width="271" height="467" alt="Screenshot 2026-03-31 at 10 08 10 AM" src="https://github.com/user-attachments/assets/9d79fbaf-ab61-4c66-898d-890418475e58" /> | 


## Why are these changes being made?

The MCP settings are now nested under the Preferences page, so the dedicated sidebar link is no longer needed. A redirect from `/me/mcp` to `/me/preferences/mcp` is already in place for old links.

Similar to #109686.

## Testing Instructions

* Navigate to the Me section in the Dashboard
* Verify the MCP item no longer appears in the sidebar
* Verify MCP settings are still accessible via the Preferences page
* Verify navigating to `/me/mcp` redirects to `/me/preferences/mcp`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?