### PR TITLE
Fix Resend email button on /me/account for unverified emails

### DIFF
--- a/client/me/email-verification-banner/index.tsx
+++ b/client/me/email-verification-banner/index.tsx
@@ -8,7 +8,7 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import isPendingEmailChange from 'calypso/state/selectors/is-pending-email-change';
-import { setUserSetting } from 'calypso/state/user-settings/actions';
+import { setUnsavedUserSetting } from 'calypso/state/user-settings/actions';
 import { saveUnsavedUserSettings } from 'calypso/state/user-settings/thunks';
 import './style.scss';
 
@@ -76,7 +76,9 @@ const EmailVerificationBannerV2: React.FC< Props > = ( { setIsBusy } ) => {
 		setIsBusy( true );
 		setIsSendingEmail( true );
 		try {
-			dispatch( setUserSetting( 'user_email', emailToVerify ) );
+			// Use setUnsavedUserSetting so the email is included even when it hasn't changed,
+			// e.g. when the original email was never confirmed.
+			dispatch( setUnsavedUserSetting( 'user_email', emailToVerify ) );
 			await dispatch( saveUnsavedUserSettings( [ 'user_email' ] ) );
 			dispatch(
 				successNotice(


### PR DESCRIPTION
## Proposed Changes

* Use `setUnsavedUserSetting` instead of `setUserSetting` in the email verification banner's resend handler.

## Why are these changes being made?

The "Resend email" button on `/me/account` fails with "No settings were provided to the endpoint to set." when the user's original email was never verified.

The `setUserSetting` thunk compares the new value against the already-saved value and drops it when they match. For unverified-but-unchanged emails, the values are always identical, so `saveUnsavedUserSettings` sends an empty payload to `PUT /me/settings` and the API rejects it.

Switching to `setUnsavedUserSetting` unconditionally includes the email in the payload, which triggers the verification email resend. This was broken since #103171.

## Testing Instructions

1. Log in as a user whose original email has never been verified (not a pending email change).
2. Go to `/me/account`.
3. Click "Resend email" on the verification banner.
4. Verify the success notice appears and no error is shown.
5. Also test with a pending email change to confirm that scenario still works.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)