### PR TITLE
Fix Resend email for unverified original emails on /me/account

### DIFF
--- a/client/me/email-verification-banner/index.tsx
+++ b/client/me/email-verification-banner/index.tsx
@@ -3,12 +3,13 @@ import React, { useCallback, useState } from 'react';
 import Banner from 'calypso/components/banner';
 import EmailVerificationDialog from 'calypso/components/email-verification/email-verification-dialog';
 import useGetEmailToVerify from 'calypso/components/email-verification/hooks/use-get-email-to-verify';
+import { useSendEmailVerification } from 'calypso/landing/stepper/hooks/use-send-email-verification';
 import { emailFormEventEmitter } from 'calypso/me/account/account-email-field';
 import { useDispatch, useSelector } from 'calypso/state';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import isPendingEmailChange from 'calypso/state/selectors/is-pending-email-change';
-import { setUnsavedUserSetting } from 'calypso/state/user-settings/actions';
+import { setUserSetting } from 'calypso/state/user-settings/actions';
 import { saveUnsavedUserSettings } from 'calypso/state/user-settings/thunks';
 import './style.scss';
 
@@ -66,6 +67,8 @@ const EmailVerificationBannerV2: React.FC< Props > = ( { setIsBusy } ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const emailToVerify = useGetEmailToVerify();
+	const isEmailChangePending = useSelector( isPendingEmailChange );
+	const sendVerificationEmail = useSendEmailVerification();
 	const [ isSendingEmail, setIsSendingEmail ] = useState( false );
 
 	const highlightEmailInput = useCallback( () => {
@@ -76,10 +79,15 @@ const EmailVerificationBannerV2: React.FC< Props > = ( { setIsBusy } ) => {
 		setIsBusy( true );
 		setIsSendingEmail( true );
 		try {
-			// Use setUnsavedUserSetting so the email is included even when it hasn't changed,
-			// e.g. when the original email was never confirmed.
-			dispatch( setUnsavedUserSetting( 'user_email', emailToVerify ) );
-			await dispatch( saveUnsavedUserSettings( [ 'user_email' ] ) );
+			if ( isEmailChangePending ) {
+				// For pending email changes, re-submit the new email via PUT /me/settings.
+				dispatch( setUserSetting( 'user_email', emailToVerify ) );
+				await dispatch( saveUnsavedUserSettings( [ 'user_email' ] ) );
+			} else {
+				// For unverified original emails, use the dedicated endpoint since
+				// PUT /me/settings won't resend when the email hasn't changed.
+				await sendVerificationEmail();
+			}
 			dispatch(
 				successNotice(
 					translate(
@@ -102,7 +110,14 @@ const EmailVerificationBannerV2: React.FC< Props > = ( { setIsBusy } ) => {
 			setIsBusy( false );
 			setIsSendingEmail( false );
 		}
-	}, [ dispatch, emailToVerify, setIsBusy, translate ] );
+	}, [
+		dispatch,
+		emailToVerify,
+		isEmailChangePending,
+		sendVerificationEmail,
+		setIsBusy,
+		translate,
+	] );
 
 	if ( ! emailToVerify ) {
 		return null;


### PR DESCRIPTION
Part of #109723

## Proposed Changes

* For unverified original emails, use `POST /me/send-verification-email` instead of `PUT /me/settings`.
* For pending email changes, keep the existing `PUT /me/settings` flow.

## Why are these changes being made?

The previous fix (#109723) addressed the client-side issue where `setUserSetting` dropped unchanged values, but `PUT /me/settings` still won't resend verification when the email hasn't changed server-side. This meant "Resend email" still didn't work for users whose original email was never verified.

This fix uses `POST /me/send-verification-email` — the dedicated endpoint for resending verification — for unverified original emails. The `PUT /me/settings` path is kept for pending email changes, where the new email differs from the saved one.

## Testing Instructions

1. Log in as a user whose original email has never been verified (not a pending email change).
2. Go to `/me/account`.
3. Click "Resend email" on the verification banner.
4. Verify the success notice appears and a verification email is received.
5. Also test with a user who has a pending email change — click "Resend email" and verify that flow still works.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)