### PR TITLE
Fix Resend email on /me/account by using send-verification-email endpoint

### DIFF
--- a/client/me/email-verification-banner/index.tsx
+++ b/client/me/email-verification-banner/index.tsx
@@ -9,8 +9,6 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import isPendingEmailChange from 'calypso/state/selectors/is-pending-email-change';
-import { setUserSetting } from 'calypso/state/user-settings/actions';
-import { saveUnsavedUserSettings } from 'calypso/state/user-settings/thunks';
 import './style.scss';
 
 const EmailVerificationBanner: React.FC< {
@@ -67,7 +65,6 @@ const EmailVerificationBannerV2: React.FC< Props > = ( { setIsBusy } ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const emailToVerify = useGetEmailToVerify();
-	const isEmailChangePending = useSelector( isPendingEmailChange );
 	const sendVerificationEmail = useSendEmailVerification();
 	const [ isSendingEmail, setIsSendingEmail ] = useState( false );
 
@@ -79,15 +76,7 @@ const EmailVerificationBannerV2: React.FC< Props > = ( { setIsBusy } ) => {
 		setIsBusy( true );
 		setIsSendingEmail( true );
 		try {
-			if ( isEmailChangePending ) {
-				// For pending email changes, re-submit the new email via PUT /me/settings.
-				dispatch( setUserSetting( 'user_email', emailToVerify ) );
-				await dispatch( saveUnsavedUserSettings( [ 'user_email' ] ) );
-			} else {
-				// For unverified original emails, use the dedicated endpoint since
-				// PUT /me/settings won't resend when the email hasn't changed.
-				await sendVerificationEmail();
-			}
+			await sendVerificationEmail();
 			dispatch(
 				successNotice(
 					translate(
@@ -110,14 +99,7 @@ const EmailVerificationBannerV2: React.FC< Props > = ( { setIsBusy } ) => {
 			setIsBusy( false );
 			setIsSendingEmail( false );
 		}
-	}, [
-		dispatch,
-		emailToVerify,
-		isEmailChangePending,
-		sendVerificationEmail,
-		setIsBusy,
-		translate,
-	] );
+	}, [ dispatch, emailToVerify, sendVerificationEmail, setIsBusy, translate ] );
 
 	if ( ! emailToVerify ) {
 		return null;


### PR DESCRIPTION
Part of #109723, #109724

## Proposed Changes

* Use `POST /me/send-verification-email` instead of `PUT /me/settings` to resend verification emails in the account settings banner.

## Why are these changes being made?

`PUT /me/settings` won't resend a verification email when the email hasn't changed server-side. This breaks "Resend email" for both unverified original emails and pending email changes. `POST /me/send-verification-email` is the dedicated endpoint that always resends, and is already used elsewhere in the codebase (stepper flows, follow buttons, etc.).

## Testing Instructions

1. Log in as a user whose original email has never been verified.
2. Go to `/me/account`.
3. Click "Resend email" on the verification banner.
4. Verify the success notice appears and a verification email is received.
5. Also test with a user who has a pending email change — click "Resend email" and verify it works.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)