### PR TITLE
Fix Resend email on /me/account for pending email changes

### DIFF
--- a/client/me/email-verification-banner/index.tsx
+++ b/client/me/email-verification-banner/index.tsx
@@ -9,7 +9,7 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import isPendingEmailChange from 'calypso/state/selectors/is-pending-email-change';
-import { setUserSetting } from 'calypso/state/user-settings/actions';
+import { setUnsavedUserSetting } from 'calypso/state/user-settings/actions';
 import { saveUnsavedUserSettings } from 'calypso/state/user-settings/thunks';
 import './style.scss';
 
@@ -82,7 +82,7 @@ const EmailVerificationBannerV2: React.FC< Props > = ( { setIsBusy } ) => {
 			if ( isEmailChangePending ) {
 				// For pending email changes, re-submit the new email via PUT /me/settings
 				// since POST /me/send-verification-email only works for the original email.
-				dispatch( setUserSetting( 'user_email', emailToVerify ) );
+				dispatch( setUnsavedUserSetting( 'user_email', emailToVerify ) );
 				await dispatch( saveUnsavedUserSettings( [ 'user_email' ] ) );
 			} else {
 				// For unverified original emails, use the dedicated endpoint since

--- a/client/me/email-verification-banner/index.tsx
+++ b/client/me/email-verification-banner/index.tsx
@@ -9,6 +9,8 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import isPendingEmailChange from 'calypso/state/selectors/is-pending-email-change';
+import { setUserSetting } from 'calypso/state/user-settings/actions';
+import { saveUnsavedUserSettings } from 'calypso/state/user-settings/thunks';
 import './style.scss';
 
 const EmailVerificationBanner: React.FC< {
@@ -65,6 +67,7 @@ const EmailVerificationBannerV2: React.FC< Props > = ( { setIsBusy } ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const emailToVerify = useGetEmailToVerify();
+	const isEmailChangePending = useSelector( isPendingEmailChange );
 	const sendVerificationEmail = useSendEmailVerification();
 	const [ isSendingEmail, setIsSendingEmail ] = useState( false );
 
@@ -76,7 +79,16 @@ const EmailVerificationBannerV2: React.FC< Props > = ( { setIsBusy } ) => {
 		setIsBusy( true );
 		setIsSendingEmail( true );
 		try {
-			await sendVerificationEmail();
+			if ( isEmailChangePending ) {
+				// For pending email changes, re-submit the new email via PUT /me/settings
+				// since POST /me/send-verification-email only works for the original email.
+				dispatch( setUserSetting( 'user_email', emailToVerify ) );
+				await dispatch( saveUnsavedUserSettings( [ 'user_email' ] ) );
+			} else {
+				// For unverified original emails, use the dedicated endpoint since
+				// PUT /me/settings won't resend when the email hasn't changed.
+				await sendVerificationEmail();
+			}
 			dispatch(
 				successNotice(
 					translate(
@@ -99,7 +111,14 @@ const EmailVerificationBannerV2: React.FC< Props > = ( { setIsBusy } ) => {
 			setIsBusy( false );
 			setIsSendingEmail( false );
 		}
-	}, [ dispatch, emailToVerify, sendVerificationEmail, setIsBusy, translate ] );
+	}, [
+		dispatch,
+		emailToVerify,
+		isEmailChangePending,
+		sendVerificationEmail,
+		setIsBusy,
+		translate,
+	] );
 
 	if ( ! emailToVerify ) {
 		return null;


### PR DESCRIPTION
Part of #109725

## Proposed Changes

* For pending email changes, use `PUT /me/settings` to resend verification instead of `POST /me/send-verification-email`, which only works for the original email.

## Why are these changes being made?

#109725 switched to `POST /me/send-verification-email` to fix resend for unverified original emails, but that endpoint doesn't support pending email changes. This adds branching so each scenario uses the correct endpoint:

- **Unverified original email**: `POST /me/send-verification-email`
- **Pending email change**: `PUT /me/settings` with the pending email

## Testing Instructions

1. Log in as a user whose original email has never been verified. Go to `/me/account`, click "Resend email" — verify success.
2. Log in as a user with a verified email, change the email address to trigger a pending change. Click "Resend email" — verify success.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)