### PR TITLE
Dashboard: Disable view transitions on all redirects

### DIFF
--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -124,6 +124,12 @@ module.exports = {
 						message: 'Use local components exported from client/dashboard/components/card instead.',
 					},
 					{
+						name: '@tanstack/react-router',
+						importNames: [ 'redirect' ],
+						message:
+							'Use dashboardRedirect from client/dashboard/app/router/redirect instead. It disables view transitions on redirects.',
+					},
+					{
 						name: '@automattic/api-queries',
 						importNames: [ 'sitesQuery', 'dashboardSiteListQuery', 'dashboardSiteFiltersQuery' ],
 						message: 'Use local queries exported from either context or useAppContext instead.',

--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -24,7 +24,6 @@ import {
 	createRoute,
 	createLazyRoute,
 	notFound,
-	redirect,
 	lazyRouteComponent,
 	Outlet,
 } from '@tanstack/react-router';
@@ -39,6 +38,7 @@ import {
 	checkDomainContactVerificationPermissions,
 } from '../../utils/domain-permissions';
 import { queryParamToArray } from '../../utils/url';
+import { dashboardRedirect } from './redirect';
 import { rootRoute } from './root';
 
 const domainsRoute = createRoute( {
@@ -86,7 +86,7 @@ export const domainsContactInfoRoute = createRoute( {
 		const selected = queryParamToArray( ( search as { selected: unknown } ).selected );
 
 		if ( selected.length === 0 ) {
-			throw redirect( { to: '/domains' } );
+			throw dashboardRedirect( { to: '/domains' } );
 		}
 	},
 	loaderDeps: ( { search } ) => {
@@ -148,7 +148,7 @@ export const domainRoute = createRoute( {
 					__( 'You do not have permission to transfer this domain.' ),
 					{ type: 'snackbar' }
 				);
-				throw redirect( {
+				throw dashboardRedirect( {
 					to: '/domains/$domainName',
 					params: { domainName },
 				} );
@@ -257,7 +257,7 @@ export const domainDnsEditRoute = createRoute( {
 		const dnsRecords = await queryClient.ensureQueryData( domainDnsQuery( domainName ) );
 		const record = dnsRecords?.records.find( ( record ) => record.id === recordId );
 		if ( ! record ) {
-			throw redirect( { to: '/domains/$domainName/dns', params: { domainName } } );
+			throw dashboardRedirect( { to: '/domains/$domainName/dns', params: { domainName } } );
 		}
 	},
 	loader: ( { params: { domainName } } ) => {
@@ -592,7 +592,10 @@ export const domainTransferIndexRoute = createRoute( {
 
 		if ( domain.transfer_status === DomainTransferStatus.PENDING_START ) {
 			if ( ! domain.last_transfer_error ) {
-				throw redirect( { to: domainTransferSetupRoute.fullPath, params: { domainName } } );
+				throw dashboardRedirect( {
+					to: domainTransferSetupRoute.fullPath,
+					params: { domainName },
+				} );
 			}
 			// If there was a transfer error, the user should see the transfer failed page
 			return domain;
@@ -602,7 +605,7 @@ export const domainTransferIndexRoute = createRoute( {
 			DomainTransferStatus.PENDING_REGISTRY !== domain.transfer_status &&
 			DomainTransferStatus.CANCELLED !== domain.transfer_status
 		) {
-			throw redirect( { to: domainOverviewRoute.fullPath, params: { domainName } } );
+			throw dashboardRedirect( { to: domainOverviewRoute.fullPath, params: { domainName } } );
 		}
 
 		return domain;

--- a/client/dashboard/app/router/emails.tsx
+++ b/client/dashboard/app/router/emails.tsx
@@ -8,10 +8,11 @@ import {
 	siteByIdQuery,
 	userMailboxesQuery,
 } from '@automattic/api-queries';
-import { createLazyRoute, createRoute, redirect, Outlet } from '@tanstack/react-router';
+import { createLazyRoute, createRoute, Outlet } from '@tanstack/react-router';
 import { __, _n } from '@wordpress/i18n';
 import { IntervalLength, MailboxProvider } from '../../emails/types';
 import { accountHasWarningWithSlug } from '../../utils/email-utils';
+import { dashboardRedirect } from './redirect';
 import { rootRoute } from './root';
 
 export const emailsRoute = createRoute( {
@@ -64,7 +65,7 @@ const redirectIfInvalidDomain = async ( domainName: string ) => {
 				( [ code, errorType ] ) => error.statusCode === code && error.error === errorType
 			)
 		) {
-			throw redirect( {
+			throw dashboardRedirect( {
 				to: emailsRoute.fullPath,
 				search: {
 					domainName,
@@ -146,7 +147,7 @@ export const addMailboxRoute = createRoute( {
 			// @ts-expect-error The interval param can be anything.
 			! Object.values( IntervalLength ).includes( interval )
 		) {
-			throw redirect( {
+			throw dashboardRedirect( {
 				to: chooseEmailSolutionRoute.to,
 				params: { domain: domainName },
 			} );
@@ -199,7 +200,7 @@ export const setUpMailboxRoute = createRoute( {
 		const hasUnusedMailbox = !! unusedMailboxesCount;
 
 		if ( ! hasUnusedMailbox ) {
-			throw redirect( {
+			throw dashboardRedirect( {
 				to: emailsRoute.fullPath,
 				search: {
 					domainName,

--- a/client/dashboard/app/router/index.tsx
+++ b/client/dashboard/app/router/index.tsx
@@ -1,5 +1,5 @@
 import calypsoConfig from '@automattic/calypso-config';
-import { createRouter, createRoute, redirect } from '@tanstack/react-router';
+import { createRouter, createRoute } from '@tanstack/react-router';
 import NotFound from '../404';
 import UnknownError from '../500';
 import { handleOnCatch } from '../logger';
@@ -8,6 +8,7 @@ import { createDomainsRoutes } from './domains';
 import { createEmailsRoutes } from './emails';
 import { createMeRoutes } from './me';
 import { createPluginsRoutes } from './plugins';
+import { dashboardRedirect } from './redirect';
 import { rootRoute } from './root';
 import { createSitesRoutes } from './sites';
 import { startStoreRoute } from './start-store';
@@ -38,7 +39,7 @@ const indexRoute = createRoute( {
 	path: '/',
 	beforeLoad: ( { context }: { context: RouteContext } ) => {
 		if ( context.config ) {
-			throw redirect( { to: context.config.mainRoute } );
+			throw dashboardRedirect( { to: context.config.mainRoute } );
 		}
 	},
 } );

--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -970,7 +970,7 @@ export const profileLegacyRedirectRoute = createRoute( {
 	getParentRoute: () => meRoute,
 	path: 'profile',
 	beforeLoad: () => {
-		throw redirect( { to: '/me/account' } );
+		throw dashboardRedirect( { to: '/me/account' } );
 	},
 } );
 

--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -32,7 +32,7 @@ import {
 	userTransferredPurchasesQuery,
 } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
-import { createRoute, createLazyRoute, redirect } from '@tanstack/react-router';
+import { createRoute, createLazyRoute } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import { getMonetizeSubscriptionsPageTitle } from '../../me/billing-monetize-subscriptions/title';
 import { reauthRequiredLink } from '../../utils/link';
@@ -43,6 +43,7 @@ import {
 	isDotcomPlan,
 	CANCEL_FLOW_TYPE,
 } from '../../utils/purchase';
+import { dashboardRedirect } from './redirect';
 import { rootRoute } from './root';
 import type { AppConfig } from '../context';
 import type { Purchase } from '@automattic/api-core';
@@ -80,7 +81,7 @@ export const meIndexRoute = createRoute( {
 	getParentRoute: () => meRoute,
 	path: '/',
 	beforeLoad: () => {
-		throw redirect( { to: '/me/account' } );
+		throw dashboardRedirect( { to: '/me/account' } );
 	},
 } );
 
@@ -945,7 +946,7 @@ export const mcpLegacyRedirectRoute = createRoute( {
 	getParentRoute: () => meRoute,
 	path: 'mcp',
 	beforeLoad: () => {
-		throw redirect( { to: '/me/preferences/mcp' } );
+		throw dashboardRedirect( { to: '/me/preferences/mcp' } );
 	},
 } );
 
@@ -953,7 +954,7 @@ export const privacyLegacyRedirectRoute = createRoute( {
 	getParentRoute: () => meRoute,
 	path: 'privacy',
 	beforeLoad: () => {
-		throw redirect( { to: '/me/preferences/privacy' } );
+		throw dashboardRedirect( { to: '/me/preferences/privacy' } );
 	},
 } );
 
@@ -961,7 +962,7 @@ export const blockedSitesLegacyRedirectRoute = createRoute( {
 	getParentRoute: () => meRoute,
 	path: 'blocked-sites',
 	beforeLoad: () => {
-		throw redirect( { to: '/me/preferences/blocked-sites' } );
+		throw dashboardRedirect( { to: '/me/preferences/blocked-sites' } );
 	},
 } );
 

--- a/client/dashboard/app/router/plugins.tsx
+++ b/client/dashboard/app/router/plugins.tsx
@@ -4,8 +4,9 @@ import {
 	rawUserPreferencesQuery,
 	marketplacePluginsQuery,
 } from '@automattic/api-queries';
-import { createRoute, createLazyRoute, redirect } from '@tanstack/react-router';
+import { createRoute, createLazyRoute } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
+import { dashboardRedirect } from './redirect';
 import { rootRoute } from './root';
 import type { AnyRoute } from '@tanstack/react-router';
 
@@ -38,7 +39,7 @@ export const pluginsIndexRoute = createRoute( {
 	getParentRoute: () => pluginsRoute,
 	path: '/',
 	beforeLoad: () => {
-		throw redirect( { to: '/plugins/manage' } );
+		throw dashboardRedirect( { to: '/plugins/manage' } );
 	},
 } );
 

--- a/client/dashboard/app/router/redirect.ts
+++ b/client/dashboard/app/router/redirect.ts
@@ -7,8 +7,7 @@ import { redirect } from '@tanstack/react-router';
  * should not trigger a view transition animation.
  */
 export function dashboardRedirect(
-	...args: Parameters< typeof redirect >
+	options: Parameters< typeof redirect >[ 0 ]
 ): ReturnType< typeof redirect > {
-	const [ options ] = args;
 	return redirect( { ...options, viewTransition: false } );
 }

--- a/client/dashboard/app/router/redirect.ts
+++ b/client/dashboard/app/router/redirect.ts
@@ -1,0 +1,14 @@
+// eslint-disable-next-line no-restricted-imports
+import { redirect } from '@tanstack/react-router';
+
+/**
+ * A wrapper around TanStack Router's `redirect()` that disables view transitions.
+ * Redirects are automatic reroutes, not user-initiated navigations, so they
+ * should not trigger a view transition animation.
+ */
+export function dashboardRedirect(
+	...args: Parameters< typeof redirect >
+): ReturnType< typeof redirect > {
+	const [ options ] = args;
+	return redirect( { ...options, viewTransition: false } );
+}

--- a/client/dashboard/app/router/redirect.ts
+++ b/client/dashboard/app/router/redirect.ts
@@ -5,9 +5,9 @@ import { redirect } from '@tanstack/react-router';
  * A wrapper around TanStack Router's `redirect()` that disables view transitions.
  * Redirects are automatic reroutes, not user-initiated navigations, so they
  * should not trigger a view transition animation.
+ *
+ * Typed as `typeof redirect` so callers get the same generic inference for
+ * `to`, `params`, and `search` as the underlying function.
  */
-export function dashboardRedirect(
-	options: Parameters< typeof redirect >[ 0 ]
-): ReturnType< typeof redirect > {
-	return redirect( { ...options, viewTransition: false } );
-}
+export const dashboardRedirect: typeof redirect = ( options ) =>
+	redirect( { ...options, viewTransition: false } );

--- a/client/dashboard/app/router/root.tsx
+++ b/client/dashboard/app/router/root.tsx
@@ -4,11 +4,12 @@ import {
 	queryClient,
 } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
-import { createRootRouteWithContext, redirect } from '@tanstack/react-router';
+import { createRootRouteWithContext } from '@tanstack/react-router';
 import { wpcomLink } from '../../utils/link';
 import { AUTH_QUERY_KEY } from '../auth';
 import Root from '../root';
 import NotFoundRoot from '../root/error';
+import { dashboardRedirect } from './redirect';
 import type { AppConfig } from '../context';
 import type { User } from '@automattic/api-core';
 
@@ -46,6 +47,6 @@ export const rootRoute = createRootRouteWithContext< RootRouterContext >()( {
 			return;
 		}
 
-		throw redirect( { href: wpcomLink( '/' ), replace: true } );
+		throw dashboardRedirect( { href: wpcomLink( '/' ), replace: true } );
 	},
 } );

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -43,13 +43,7 @@ import {
 import { isEnabled } from '@automattic/calypso-config';
 import { isSupportSession } from '@automattic/calypso-support-session';
 import { MutationObserver } from '@tanstack/react-query';
-import {
-	createLazyRoute,
-	createRoute,
-	lazyRouteComponent,
-	notFound,
-	redirect,
-} from '@tanstack/react-router';
+import { createLazyRoute, createRoute, lazyRouteComponent, notFound } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import {
 	canManageSite,
@@ -69,6 +63,7 @@ import { hasSiteTrialEnded } from '../../utils/site-trial';
 import { getSiteTypeFeatureSupports } from '../../utils/site-type-feature-support';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import { AUTH_QUERY_KEY } from '../auth';
+import { dashboardRedirect } from './redirect';
 import { rootRoute } from './root';
 import type { AppConfig } from '../context';
 import type { DifmWebsiteContentResponse, Site, User } from '@automattic/api-core';
@@ -128,12 +123,12 @@ export const siteRoute = createRoute( {
 			site.__inaccessible_jetpack_error &&
 			! matches.some( ( match ) => match.staticData?.availableToInaccessibleJetpackSites )
 		) {
-			throw redirect( { to: overviewUrl } );
+			throw dashboardRedirect( { to: overviewUrl } );
 		}
 
 		const trialExpiredUrl = `/sites/${ siteSlug }/trial-ended`;
 		if ( hasSiteTrialEnded( site ) && ! location.pathname.includes( trialExpiredUrl ) ) {
-			throw redirect( { to: trialExpiredUrl } );
+			throw dashboardRedirect( { to: trialExpiredUrl } );
 		}
 
 		const difmUrl = `/sites/${ siteSlug }/site-building-in-progress`;
@@ -143,12 +138,12 @@ export const siteRoute = createRoute( {
 			! isSupportSession() &&
 			! matches.some( ( match ) => difmAllowedRoutes.includes( match.routeId ) )
 		) {
-			throw redirect( { to: difmUrl } );
+			throw dashboardRedirect( { to: difmUrl } );
 		}
 
 		const migrationUrl = `/sites/${ siteSlug }/migration-overview`;
 		if ( isSiteMigrationInProgress( site ) && ! location.pathname.includes( migrationUrl ) ) {
-			throw redirect( { to: migrationUrl } );
+			throw dashboardRedirect( { to: migrationUrl } );
 		}
 
 		// Check site type support for matched routes
@@ -311,7 +306,7 @@ export const siteLogsIndexRoute = createRoute( {
 	getParentRoute: () => siteLogsRoute,
 	path: '/',
 	beforeLoad: ( { params } ) => {
-		throw redirect( { to: `/sites/${ params.siteSlug }/logs/${ LogType.ACTIVITY }` } );
+		throw dashboardRedirect( { to: `/sites/${ params.siteSlug }/logs/${ LogType.ACTIVITY }` } );
 	},
 } );
 
@@ -406,7 +401,7 @@ export const siteScanIndexRoute = createRoute( {
 	getParentRoute: () => siteScanRoute,
 	path: '/',
 	beforeLoad: ( { params } ) => {
-		throw redirect( { to: `/sites/${ params.siteSlug }/scan/active` } );
+		throw dashboardRedirect( { to: `/sites/${ params.siteSlug }/scan/active` } );
 	},
 } );
 
@@ -714,7 +709,7 @@ function redirectSiteAiToolsSubpageToHub( {
 		return;
 	}
 	if ( ! isEnabled( 'mcp-settings' ) ) {
-		throw redirect( {
+		throw dashboardRedirect( {
 			to: siteSettingsAIToolsIndexRoute.fullPath,
 			params: { siteSlug },
 		} );
@@ -1404,7 +1399,7 @@ export const siteTrialEndedRoute = createRoute( {
 
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		if ( ! hasSiteTrialEnded( site ) ) {
-			throw redirect( { to: siteOverviewRoute.fullPath, params: { siteSlug } } );
+			throw dashboardRedirect( { to: siteOverviewRoute.fullPath, params: { siteSlug } } );
 		}
 	},
 } ).lazy( () =>
@@ -1434,7 +1429,7 @@ export const siteDifmLiteInProgressRoute = createRoute( {
 
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		if ( ! site.options?.is_difm_lite_in_progress ) {
-			throw redirect( { to: siteOverviewRoute.fullPath, params: { siteSlug } } );
+			throw dashboardRedirect( { to: siteOverviewRoute.fullPath, params: { siteSlug } } );
 		}
 	},
 	loader: async ( { params: { siteSlug } } ) => {
@@ -1488,7 +1483,7 @@ export const siteMigrationOverviewRoute = createRoute( {
 
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		if ( ! isSiteMigrationInProgress( site ) ) {
-			throw redirect( { to: siteOverviewRoute.fullPath, params: { siteSlug } } );
+			throw dashboardRedirect( { to: siteOverviewRoute.fullPath, params: { siteSlug } } );
 		}
 
 		return {
@@ -1643,7 +1638,7 @@ function redirectAsNotAllowed( options: {
 	params?: Record< string, string >;
 	search?: Record< string, unknown >;
 } ) {
-	return redirect( {
+	return dashboardRedirect( {
 		...options,
 		search: {
 			...options.search,

--- a/client/dashboard/app/router/start-store.ts
+++ b/client/dashboard/app/router/start-store.ts
@@ -1,8 +1,9 @@
 import { queryClient } from '@automattic/api-queries';
-import { createRoute, redirect } from '@tanstack/react-router';
+import { createRoute } from '@tanstack/react-router';
 import { addQueryArgs } from '@wordpress/url';
 import { wpcomLink } from '../../utils/link';
 import { AUTH_QUERY_KEY } from '../auth';
+import { dashboardRedirect } from './redirect';
 import { rootRoute } from './root';
 import type { User } from '@automattic/api-core';
 
@@ -13,7 +14,7 @@ export const startStoreRoute = createRoute( {
 		const user = queryClient.getQueryData< User >( AUTH_QUERY_KEY );
 
 		if ( user && user.garden_site_count > 0 ) {
-			throw redirect( { to: '/sites', replace: true } );
+			throw dashboardRedirect( { to: '/sites', replace: true } );
 		}
 
 		// The site builder flow is served by a separate entry point (stepper),


### PR DESCRIPTION
Alternative to #109685

## Proposed Changes

- Introduce a `dashboardRedirect()` wrapper around TanStack Router's `redirect()` that forces `viewTransition: false`
- Replace all 26 direct `redirect()` calls across the dashboard router files with `dashboardRedirect()`
- Add an ESLint `no-restricted-imports` rule to enforce using `dashboardRedirect` over the direct import

## Why are these changes being made?

#109685 fixed an `AbortError` caused by view transitions firing on the root route redirect. The same issue can occur on any redirect — redirects are automatic reroutes, not user-initiated navigations, so they should not trigger view transition animations.

Rather than adding `viewTransition: false` to each redirect individually (easy to forget), this introduces a single wrapper function and an ESLint rule to enforce its use.

## Testing Instructions

- Navigate to `/` in the dashboard — should redirect to the main route without a view transition animation
- Navigate to `/plugins` — should redirect to `/plugins/manage` without animation
- Navigate to `/me` — should redirect to `/me/profile` without animation
- Normal link clicks (e.g., clicking sidebar items) should still animate with view transitions

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?