### PR TITLE
MSD: Handle reauthorization_required in global error component

### DIFF
--- a/client/dashboard/app/500/index.tsx
+++ b/client/dashboard/app/500/index.tsx
@@ -1,9 +1,16 @@
+import { isWpError } from '@automattic/api-core';
 import { __ } from '@wordpress/i18n';
 import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import { reauthRequiredLink } from '../../utils/link';
 
 function UnknownError( { error }: { error: Error } ) {
+	if ( isWpError( error ) && error.error === 'reauthorization_required' ) {
+		window.location.href = reauthRequiredLink();
+		return null;
+	}
+
 	return (
 		<PageLayout
 			header={

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -1,4 +1,4 @@
-import { HostingFeatures, DotcomFeatures, LogType, isWpError } from '@automattic/api-core';
+import { HostingFeatures, DotcomFeatures, LogType } from '@automattic/api-core';
 import {
 	bigSkyPluginQuery,
 	codeDeploymentQuery,
@@ -35,7 +35,6 @@ import {
 	siteSshAccessStatusQuery,
 	siteStaticFile404SettingQuery,
 	siteWordPressVersionQuery,
-	userSettingsQuery,
 	queryClient,
 } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
@@ -54,7 +53,6 @@ import {
 	canViewHundredYearPlanSettings,
 	canViewWordPressSettings,
 } from '../../sites/features';
-import { reauthRequiredLink } from '../../utils/link';
 import {
 	getActivityLogHiddenGroups,
 	hasHostingFeature,
@@ -655,17 +653,6 @@ export const siteSettingsAIToolsRoute = createRoute( {
 
 		if ( ! isEnabled( 'wordpress-ai-tools' ) ) {
 			throw redirectAsNotAllowed( { to: siteSettingsRoute.fullPath, params: { siteSlug } } );
-		}
-
-		try {
-			await queryClient.ensureQueryData( userSettingsQuery() );
-		} catch ( error: unknown ) {
-			if ( isWpError( error ) && error.error === 'reauthorization_required' ) {
-				window.location.href = reauthRequiredLink();
-				return;
-			}
-
-			throw error;
 		}
 	},
 	loader: async ( { params: { siteSlug } } ) => {


### PR DESCRIPTION
Supersedes #109693

## Proposed Changes

* Handle `reauthorization_required` errors in the global 500 error component, redirecting to the reauth flow.

## Why are these changes being made?

* Instead of guarding individual routes, this handles the reauth redirect globally so all routes that trigger `reauthorization_required` are covered automatically.

## Testing Instructions

* Navigate to any dashboard page that triggers a `reauthorization_required` error.
* Verify you are redirected to the reauth flow instead of seeing the 500 error page.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)