### PR TITLE
Fix recovery SMS rejecting valid 350 area code numbers

### DIFF
--- a/client/dashboard/utils/test/phone-number.ts
+++ b/client/dashboard/utils/test/phone-number.ts
@@ -60,14 +60,6 @@ describe( 'validatePhone', () => {
 			} );
 		} );
 
-		it( 'should return success for valid US 350 area code number', () => {
-			const result = validatePhone( '+13502197449' );
-			expect( result ).toEqual( {
-				info: 'phone_number_valid',
-				message: 'Valid phone number',
-			} );
-		} );
-
 		it( 'should return success for valid international phone number', () => {
 			const result = validatePhone( '+447911123456' );
 			expect( result ).toEqual( {

--- a/client/dashboard/utils/test/phone-number.ts
+++ b/client/dashboard/utils/test/phone-number.ts
@@ -60,6 +60,14 @@ describe( 'validatePhone', () => {
 			} );
 		} );
 
+		it( 'should return success for valid US 350 area code number', () => {
+			const result = validatePhone( '+13502197449' );
+			expect( result ).toEqual( {
+				info: 'phone_number_valid',
+				message: 'Valid phone number',
+			} );
+		} );
+
 		it( 'should return success for valid international phone number', () => {
 			const result = validatePhone( '+447911123456' );
 			expect( result ).toEqual( {

--- a/client/lib/phone-validation/test/index.jsx
+++ b/client/lib/phone-validation/test/index.jsx
@@ -17,6 +17,7 @@ describe( 'Phone Validation Library', () => {
 	test.each( [
 		{ country: 'UK', input: '+447941952721' }, // Valid United Kingdom number
 		{ country: 'US', input: '+14631234567' }, // Valid United States number
+		{ country: 'US', input: '+13502197449' }, // Valid United States 350 area code (CA, assigned 2022)
 		{ country: 'AR', input: '+542231234567' }, // Valid Argentina without leading 9
 		{ country: 'AR', input: '+5492231234567' }, // Valid Argentina with leading 9
 		{ country: 'HR', input: '+38598123456' }, // Valid Croatian number

--- a/client/package.json
+++ b/client/package.json
@@ -192,7 +192,7 @@
 		"nock": "^13.5.6",
 		"path-browserify": "^1.0.1",
 		"percentage-regex": "^3.0.0",
-		"phone": "^3.1.59",
+		"phone": "^3.1.71",
 		"photon": "workspace:^",
 		"phpunserialize": "^1.1.0",
 		"postcss": "^8.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13590,7 +13590,7 @@ __metadata:
     nock: "npm:^13.5.6"
     path-browserify: "npm:^1.0.1"
     percentage-regex: "npm:^3.0.0"
-    phone: "npm:^3.1.59"
+    phone: "npm:^3.1.71"
     photon: "workspace:^"
     phpunserialize: "npm:^1.1.0"
     pkg-dir: "npm:^5.0.0"
@@ -25636,10 +25636,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"phone@npm:^3.1.59":
-  version: 3.1.59
-  resolution: "phone@npm:3.1.59"
-  checksum: 8abc5c2ed5ff292f39484340906ab1f49414a54812dba72bba47da06790957eaf8c844965d04b8f9d540bb03ca5b4f304de00157c665caa31b6d3d80c775e322
+"phone@npm:^3.1.71":
+  version: 3.1.71
+  resolution: "phone@npm:3.1.71"
+  checksum: 8f4ac65b82e64d7d73fb4c6e50ab36ebeea7697327c224b3586fc8b23b1e8220c0d08bdb131c4d6abe2955404bb9df8140fe8d8e3c8cb6702b5a9b58b46a2269
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes DOTOBRD-423

## Proposed Changes

* Bump the `phone` npm package from 3.1.59 to 3.1.71, which adds support for the 350 area code (assigned by NANPA in 2022 for California).
* Add test coverage for 350 area code validation in both the Dashboard (`client/dashboard/utils/phone-number.ts`) and classic Calypso (`client/lib/phone-validation/index.jsx`) phone validation paths.

## Why are these changes being made?

A site owner reported being unable to add a valid US phone number with the 350 area code as their recovery SMS number. The `phone` npm package v3.1.59 did not include data for this area code, causing `phone()` to return `isValid: false`. The latest version (3.1.71) recognizes 350 as a valid US area code.

## Testing Instructions

1. Go to https://wordpress.com/me/security/account-recovery
2. Try adding a recovery SMS number with the 350 area code (e.g., country +1, number `3502197449`)
3. Verify the number is accepted and no "invalid phone number" error is shown
4. Verify other phone numbers (US and international) continue to work as expected

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?