### PR TITLE
MSD: Prevent protocol-relative redirects in dashboard link builders

### DIFF
--- a/client/dashboard/app-ciab/routing.ts
+++ b/client/dashboard/app-ciab/routing.ts
@@ -35,8 +35,9 @@ export function isAllowedCiabLegacyRoute( path: string = '' ): boolean {
 }
 
 export function buildCiabDashboardLink( path: string = '' ) {
+	const safePath = path.replace( /^\/\/+/, '/' );
 	if ( config( 'env' ) === 'development' ) {
-		return new URL( path, 'http://my.woo.localhost:3000' ).href;
+		return new URL( safePath, 'http://my.woo.localhost:3000' ).href;
 	}
-	return new URL( path, 'https://my.woo.ai' ).href;
+	return new URL( safePath, 'https://my.woo.ai' ).href;
 }

--- a/client/dashboard/app-ciab/test/routing.ts
+++ b/client/dashboard/app-ciab/test/routing.ts
@@ -1,0 +1,34 @@
+import { buildCiabDashboardLink } from '../routing';
+
+jest.mock( '@automattic/calypso-config', () => {
+	const config = ( key: string ) => {
+		const values: Record< string, string > = { env: 'production' };
+		return values[ key ];
+	};
+	config.isEnabled = () => false;
+	return { __esModule: true, default: config };
+} );
+
+describe( 'buildCiabDashboardLink', () => {
+	test( 'should build a URL with the CIAB origin', () => {
+		expect( buildCiabDashboardLink( '/sites' ) ).toBe( 'https://my.woo.ai/sites' );
+	} );
+
+	test( 'should reject protocol-relative paths', () => {
+		expect( buildCiabDashboardLink( '//evil.com' ) ).toBe( 'https://my.woo.ai/evil.com' );
+	} );
+
+	test( 'should reject multiple leading slashes', () => {
+		expect( buildCiabDashboardLink( '///evil.com' ) ).toBe( 'https://my.woo.ai/evil.com' );
+	} );
+
+	test( 'should handle empty path', () => {
+		expect( buildCiabDashboardLink() ).toBe( 'https://my.woo.ai/' );
+	} );
+
+	test( 'should preserve valid paths', () => {
+		expect( buildCiabDashboardLink( '/checkout/site.com' ) ).toBe(
+			'https://my.woo.ai/checkout/site.com'
+		);
+	} );
+} );

--- a/client/dashboard/app-dotcom/routing.ts
+++ b/client/dashboard/app-dotcom/routing.ts
@@ -12,8 +12,9 @@ export function isAllowedDotcomDashboardHostname( hostname?: string ): boolean {
 }
 
 export function buildDotcomDashboardLink( path: string = '' ) {
+	const safePath = path.replace( /^\/\/+/, '/' );
 	if ( config( 'env' ) === 'development' ) {
-		return new URL( path, 'http://my.localhost:3000' ).href;
+		return new URL( safePath, 'http://my.localhost:3000' ).href;
 	}
-	return new URL( path, 'https://my.wordpress.com' ).href;
+	return new URL( safePath, 'https://my.wordpress.com' ).href;
 }

--- a/client/dashboard/app-dotcom/test/routing.ts
+++ b/client/dashboard/app-dotcom/test/routing.ts
@@ -1,0 +1,34 @@
+import { buildDotcomDashboardLink } from '../routing';
+
+jest.mock( '@automattic/calypso-config', () => {
+	const config = ( key: string ) => {
+		const values: Record< string, string > = { env: 'production' };
+		return values[ key ];
+	};
+	config.isEnabled = () => false;
+	return { __esModule: true, default: config };
+} );
+
+describe( 'buildDotcomDashboardLink', () => {
+	test( 'should build a URL with the dotcom origin', () => {
+		expect( buildDotcomDashboardLink( '/sites' ) ).toBe( 'https://my.wordpress.com/sites' );
+	} );
+
+	test( 'should reject protocol-relative paths', () => {
+		expect( buildDotcomDashboardLink( '//evil.com' ) ).toBe( 'https://my.wordpress.com/evil.com' );
+	} );
+
+	test( 'should reject multiple leading slashes', () => {
+		expect( buildDotcomDashboardLink( '///evil.com' ) ).toBe( 'https://my.wordpress.com/evil.com' );
+	} );
+
+	test( 'should handle empty path', () => {
+		expect( buildDotcomDashboardLink() ).toBe( 'https://my.wordpress.com/' );
+	} );
+
+	test( 'should preserve valid paths with query params', () => {
+		expect( buildDotcomDashboardLink( '/sites?foo=bar' ) ).toBe(
+			'https://my.wordpress.com/sites?foo=bar'
+		);
+	} );
+} );

--- a/client/dashboard/utils/link.ts
+++ b/client/dashboard/utils/link.ts
@@ -37,18 +37,19 @@ export function wpcomLink( path: string ) {
 			return path;
 		}
 	}
-	return new URL( path, config( 'wpcom_url' ) ).href;
+	return new URL( path.replace( /^\/\/+/, '/' ), config( 'wpcom_url' ) ).href;
 }
 
 /**
  * This function returns a link to the A4A (Automattic for Agencies) domain.
  */
 export function a4aLink( path: string ) {
+	const safePath = path.replace( /^\/\/+/, '/' );
 	if ( config( 'env' ) === 'development' ) {
-		return new URL( path, 'http://agencies.localhost:3000' ).href;
+		return new URL( safePath, 'http://agencies.localhost:3000' ).href;
 	}
 
-	return new URL( path, 'https://agencies.automattic.com' ).href;
+	return new URL( safePath, 'https://agencies.automattic.com' ).href;
 }
 
 /**

--- a/client/dashboard/utils/test/link.ts
+++ b/client/dashboard/utils/test/link.ts
@@ -1,0 +1,96 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { wpcomLink, a4aLink, redirectToDashboardLink } from '../link';
+
+jest.mock( '@automattic/calypso-config', () => {
+	const config = ( key: string ) => {
+		const values: Record< string, string > = {
+			wpcom_url: 'https://wordpress.com',
+			env: 'production',
+		};
+		return values[ key ];
+	};
+	config.isEnabled = () => false;
+	return { __esModule: true, default: config };
+} );
+
+jest.mock( '../../app/routing', () => ( {
+	getCurrentDashboard: () => 'dotcom',
+	getDashboardFromQuery: () => undefined,
+	buildDashboardLink: ( _dashboard: string, path: string ) =>
+		new URL( path.replace( /^\/\/+/, '/' ), 'https://my.wordpress.com' ).href,
+} ) );
+
+describe( 'wpcomLink', () => {
+	test( 'should build a URL with the configured origin', () => {
+		expect( wpcomLink( '/sites' ) ).toBe( 'https://wordpress.com/sites' );
+	} );
+
+	test( 'should reject protocol-relative paths', () => {
+		expect( wpcomLink( '//evil.com' ) ).toBe( 'https://wordpress.com/evil.com' );
+	} );
+
+	test( 'should reject multiple leading slashes', () => {
+		expect( wpcomLink( '///evil.com' ) ).toBe( 'https://wordpress.com/evil.com' );
+	} );
+
+	test( 'should handle empty path', () => {
+		expect( wpcomLink( '' ) ).toBe( 'https://wordpress.com/' );
+	} );
+
+	test( 'should preserve valid paths with query params', () => {
+		expect( wpcomLink( '/sites?foo=bar' ) ).toBe( 'https://wordpress.com/sites?foo=bar' );
+	} );
+} );
+
+describe( 'a4aLink', () => {
+	test( 'should build a URL with the agencies origin', () => {
+		expect( a4aLink( '/sites' ) ).toBe( 'https://agencies.automattic.com/sites' );
+	} );
+
+	test( 'should reject protocol-relative paths', () => {
+		expect( a4aLink( '//evil.com' ) ).toBe( 'https://agencies.automattic.com/evil.com' );
+	} );
+
+	test( 'should reject multiple leading slashes', () => {
+		expect( a4aLink( '///evil.com' ) ).toBe( 'https://agencies.automattic.com/evil.com' );
+	} );
+} );
+
+describe( 'redirectToDashboardLink', () => {
+	const originalLocation = window.location;
+
+	beforeEach( () => {
+		Object.defineProperty( window, 'location', {
+			value: {
+				href: 'https://wordpress.com/sites',
+				origin: 'https://wordpress.com',
+			},
+			writable: true,
+		} );
+	} );
+
+	afterEach( () => {
+		Object.defineProperty( window, 'location', {
+			value: originalLocation,
+			writable: true,
+		} );
+	} );
+
+	test( 'should build a redirect link from the current path', () => {
+		expect( redirectToDashboardLink() ).toBe( 'https://my.wordpress.com/sites' );
+	} );
+
+	test( 'should prevent protocol-relative redirect when URL contains double slashes', () => {
+		window.location = {
+			href: 'https://wordpress.com//evil.com/path',
+			origin: 'https://wordpress.com',
+		} as Location;
+
+		const result = redirectToDashboardLink();
+		const parsed = new URL( result );
+		expect( parsed.hostname ).toBe( 'my.wordpress.com' );
+	} );
+} );

--- a/client/dashboard/utils/test/link.ts
+++ b/client/dashboard/utils/test/link.ts
@@ -84,10 +84,13 @@ describe( 'redirectToDashboardLink', () => {
 	} );
 
 	test( 'should prevent protocol-relative redirect when URL contains double slashes', () => {
-		window.location = {
-			href: 'https://wordpress.com//evil.com/path',
-			origin: 'https://wordpress.com',
-		} as Location;
+		Object.defineProperty( window, 'location', {
+			value: {
+				href: 'https://wordpress.com//evil.com/path',
+				origin: 'https://wordpress.com',
+			},
+			writable: true,
+		} );
 
 		const result = redirectToDashboardLink();
 		const parsed = new URL( result );


### PR DESCRIPTION
Part of DOTMSD-1146

## Proposed Changes

* Sanitize paths in `buildCiabDashboardLink`, `buildDotcomDashboardLink`, `wpcomLink`, and `a4aLink` by collapsing leading `//` into `/`.
* Add tests for all affected link builder functions covering the protocol-relative attack vector.

## Why are these changes being made?

* `new URL('//evil.com', 'https://my.woo.ai')` resolves to `https://evil.com`, enabling open redirects. A crafted URL like `https://my.wordpress.com//evil.com` would strip the origin and pass `//evil.com` as the path to the link builder, redirecting to the attacker's domain.

## Testing Instructions

* `yarn test-client client/dashboard/app-ciab/test/routing.ts client/dashboard/app-dotcom/test/routing.ts client/dashboard/utils/test/link.ts`
* Verify that navigating to `https://my.wordpress.com//evil.com` does not redirect to `evil.com`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)