### PR TITLE
MSD Omnibar: implement last selected site

### DIFF
--- a/client/dashboard/app/interim-omnibar/index.tsx
+++ b/client/dashboard/app/interim-omnibar/index.tsx
@@ -1,4 +1,10 @@
-import { queryClient, siteByIdQuery } from '@automattic/api-queries';
+import {
+	queryClient,
+	rawUserPreferencesQuery,
+	siteByIdQuery,
+	userPreferenceQuery,
+} from '@automattic/api-queries';
+import { QueryObserver } from '@tanstack/react-query';
 import { hydrateRoot } from 'react-dom/client';
 import { AUTH_QUERY_KEY, initializeCurrentUser } from '../auth';
 import type { OmnibarEvents } from './click-handlers';
@@ -42,21 +48,37 @@ export default async function loadOmnibar( events: OmnibarEvents ) {
 		/>
 	);
 
-	const site = user.primary_blog
-		? await queryClient.fetchQuery( siteByIdQuery( user.primary_blog ) )
-		: null;
+	const handleToggleMenu = () => events.mobileMenu.emit();
+	const handleToggleNotifications = () =>
+		events.notifications.emit(
+			container.querySelector< HTMLElement >( '.masterbar-notifications' )
+		);
 
-	root.render(
-		<InterimOmnibar
-			user={ user }
-			site={ site }
-			currentRoute={ window.location.pathname }
-			onToggleMenu={ () => events.mobileMenu.emit() }
-			onToggleNotifications={ () =>
-				events.notifications.emit(
-					container.querySelector< HTMLElement >( '.masterbar-notifications' )
-				)
-			}
-		/>
-	);
+	async function renderWithSiteId( siteId: number | undefined ) {
+		const site = siteId ? await queryClient.ensureQueryData( siteByIdQuery( siteId ) ) : null;
+		root.render(
+			<InterimOmnibar
+				user={ user }
+				site={ site }
+				currentRoute={ window.location.pathname }
+				onToggleMenu={ handleToggleMenu }
+				onToggleNotifications={ handleToggleNotifications }
+			/>
+		);
+	}
+
+	// Render with the initial recent site (or primary blog as fallback).
+	const recentSites = queryClient.getQueryData( rawUserPreferencesQuery().queryKey )?.recentSites;
+	const initialSiteId = recentSites?.[ 0 ] || user.primary_blog;
+	renderWithSiteId( initialSiteId );
+
+	// Re-render whenever recentSites changes (e.g. user navigates to a different site).
+	let currentSiteId = initialSiteId;
+	new QueryObserver( queryClient, userPreferenceQuery( 'recentSites' ) ).subscribe( ( result ) => {
+		const siteId = result.data?.[ 0 ] || user.primary_blog;
+		if ( siteId !== currentSiteId ) {
+			currentSiteId = siteId;
+			renderWithSiteId( siteId );
+		}
+	} );
 }

--- a/client/dashboard/app/interim-omnibar/index.tsx
+++ b/client/dashboard/app/interim-omnibar/index.tsx
@@ -8,6 +8,7 @@ import { QueryObserver } from '@tanstack/react-query';
 import { hydrateRoot } from 'react-dom/client';
 import { AUTH_QUERY_KEY, initializeCurrentUser } from '../auth';
 import type { OmnibarEvents } from './click-handlers';
+import type { UserPreferences } from '@automattic/api-core';
 
 export default async function loadOmnibar( events: OmnibarEvents ) {
 	const container = document.getElementById( 'wpcom-omnibar' );
@@ -68,7 +69,9 @@ export default async function loadOmnibar( events: OmnibarEvents ) {
 	}
 
 	// Render with the initial recent site (or primary blog as fallback).
-	const recentSites = queryClient.getQueryData( rawUserPreferencesQuery().queryKey )?.recentSites;
+	const recentSites = queryClient.getQueryData< UserPreferences >(
+		rawUserPreferencesQuery().queryKey
+	)?.recentSites;
 	const initialSiteId = recentSites?.[ 0 ] || user.primary_blog;
 	renderWithSiteId( initialSiteId );
 

--- a/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
+++ b/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-restricted-imports */
 import { isEcommercePlan } from '@automattic/calypso-products';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { MasterbarLoggedIn } from 'calypso/layout/masterbar/logged-in';
@@ -26,6 +27,10 @@ function createOmnibarStore( onToggleNotifications?: () => void ): StoreType {
 		subscribe: () => () => {},
 	} as unknown as StoreType;
 }
+
+// Separate query client for the legacy masterbar so its internal queries
+// (e.g. useGetDomainsQuery in MasterbarLaunchButton) don't pollute the Dashboard cache.
+const omnibarQueryClient = new QueryClient();
 
 // Minimal placeholder so MasterbarLoggedIn doesn't crash during SSR.
 const emptyUser = {
@@ -59,74 +64,76 @@ export function InterimOmnibar( {
 	);
 
 	return (
-		<ReduxProvider store={ store }>
-			<MasterbarLoggedIn
-				// User
-				user={ user }
-				hasNoSites={ user.site_count === 0 }
-				// Site identity
-				siteId={ siteId }
-				site={ site }
-				siteSlug={ siteSlug }
-				siteTitle={ site ? getSiteDisplayName( site ) : '' }
-				siteUrl={ site?.URL ?? '' }
-				siteAdminUrl={ siteAdminUrl }
-				siteHomeUrl={ site?.URL ?? '' }
-				sitePlanName={ site?.plan?.product_name_short ?? '' }
-				currentSelectedSiteSlug={ siteSlug }
-				// TODO: Audit site-specific flags to see which we need to handle in the interim omnibar, and which can be hardcoded to false.
-				// Site flags
-				isEcommerce={ isEcommercePlan( site?.plan?.product_slug ?? '' ) }
-				// isClassicView={ !! site && siteUsesWpAdminInterface( site ) }
-				isClassicView
-				// TODO: Causes hydration mismatch unless client and server both have the same site object
-				isSimpleSite={ false }
-				isJetpackNotAtomic={ !! site && site.jetpack && ! site.is_wpcom_atomic }
-				domainOnlySite={ !! site?.options?.is_domain_only }
-				isUnlaunchedSite={ false }
-				isTrial={ false }
-				isSiteP2={ !! site?.options?.is_wpforteams_site }
-				isP2Hub={ !! site?.options?.p2_hub_blog_id && site.options.p2_hub_blog_id === site.ID }
-				isManageSiteOptionsEnabled={ !! site?.capabilities?.manage_options }
-				isA4ADevSite={ !! site?.is_a4a_dev_site }
-				isAtomicAndEditingToolkitDeactivated={ false }
-				// Navigation / layout
-				section=""
-				sectionGroup=""
-				currentLayoutFocus={ null }
-				currentRoute={ currentRoute }
-				previousPath=""
-				newPostUrl={ siteAdminUrl ? `${ siteAdminUrl }post-new.php` : '' }
-				newPageUrl={ siteAdminUrl ? `${ siteAdminUrl }post-new.php?post_type=page` : '' }
-				// Feature flags
-				isCheckout={ false }
-				isCheckoutPending={ false }
-				isCheckoutFailed={ false }
-				loadHelpCenterIcon
-				isGlobalSidebarVisible={ false }
-				isGravatarDomain={ false }
-				dashboardOptIn
-				useUnifiedAgent={ false }
-				isSupportSession={ false }
-				isNotificationsShowing={ false }
-				isMigrationInProgress={ false }
-				migrationStatus={ null }
-				adminMenu={ null }
-				// Actions
-				setNextLayoutFocus={ noop }
-				activateNextLayoutFocus={ () => onToggleMenu?.() }
-				recordTracksEvent={ recordTracksEvent }
-				updateSiteMigrationMeta={ noop }
-				savePreference={ noop }
-				requestAdminMenu={ noop }
-				redirectToLogout={ () => {
-					if ( userProp ) {
-						const logoutUrl = getLogoutUrl( userProp );
-						window.location.href = logoutUrl;
-					}
-				} }
-				launchSiteOrRedirectToLaunchSignupFlow={ noop }
-			/>
-		</ReduxProvider>
+		<QueryClientProvider client={ omnibarQueryClient }>
+			<ReduxProvider store={ store }>
+				<MasterbarLoggedIn
+					// User
+					user={ user }
+					hasNoSites={ user.site_count === 0 }
+					// Site identity
+					siteId={ siteId }
+					site={ site }
+					siteSlug={ siteSlug }
+					siteTitle={ site ? getSiteDisplayName( site ) : '' }
+					siteUrl={ site?.URL ?? '' }
+					siteAdminUrl={ siteAdminUrl }
+					siteHomeUrl={ site?.URL ?? '' }
+					sitePlanName={ site?.plan?.product_name_short ?? '' }
+					currentSelectedSiteSlug={ siteSlug }
+					// TODO: Audit site-specific flags to see which we need to handle in the interim omnibar, and which can be hardcoded to false.
+					// Site flags
+					isEcommerce={ isEcommercePlan( site?.plan?.product_slug ?? '' ) }
+					// isClassicView={ !! site && siteUsesWpAdminInterface( site ) }
+					isClassicView
+					// TODO: Causes hydration mismatch unless client and server both have the same site object
+					isSimpleSite={ false }
+					isJetpackNotAtomic={ !! site && site.jetpack && ! site.is_wpcom_atomic }
+					domainOnlySite={ !! site?.options?.is_domain_only }
+					isUnlaunchedSite={ false }
+					isTrial={ false }
+					isSiteP2={ !! site?.options?.is_wpforteams_site }
+					isP2Hub={ !! site?.options?.p2_hub_blog_id && site.options.p2_hub_blog_id === site.ID }
+					isManageSiteOptionsEnabled={ !! site?.capabilities?.manage_options }
+					isA4ADevSite={ !! site?.is_a4a_dev_site }
+					isAtomicAndEditingToolkitDeactivated={ false }
+					// Navigation / layout
+					section=""
+					sectionGroup=""
+					currentLayoutFocus={ null }
+					currentRoute={ currentRoute }
+					previousPath=""
+					newPostUrl={ siteAdminUrl ? `${ siteAdminUrl }post-new.php` : '' }
+					newPageUrl={ siteAdminUrl ? `${ siteAdminUrl }post-new.php?post_type=page` : '' }
+					// Feature flags
+					isCheckout={ false }
+					isCheckoutPending={ false }
+					isCheckoutFailed={ false }
+					loadHelpCenterIcon
+					isGlobalSidebarVisible={ false }
+					isGravatarDomain={ false }
+					dashboardOptIn
+					useUnifiedAgent={ false }
+					isSupportSession={ false }
+					isNotificationsShowing={ false }
+					isMigrationInProgress={ false }
+					migrationStatus={ null }
+					adminMenu={ null }
+					// Actions
+					setNextLayoutFocus={ noop }
+					activateNextLayoutFocus={ () => onToggleMenu?.() }
+					recordTracksEvent={ recordTracksEvent }
+					updateSiteMigrationMeta={ noop }
+					savePreference={ noop }
+					requestAdminMenu={ noop }
+					redirectToLogout={ () => {
+						if ( userProp ) {
+							const logoutUrl = getLogoutUrl( userProp );
+							window.location.href = logoutUrl;
+						}
+					} }
+					launchSiteOrRedirectToLaunchSignupFlow={ noop }
+				/>
+			</ReduxProvider>
+		</QueryClientProvider>
 	);
 }

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -36,11 +36,13 @@ import {
 	siteSshAccessStatusQuery,
 	siteStaticFile404SettingQuery,
 	siteWordPressVersionQuery,
+	userPreferenceOptimisticMutation,
 	queryClient,
 	wpOrgCoreVersionQuery,
 } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
 import { isSupportSession } from '@automattic/calypso-support-session';
+import { MutationObserver } from '@tanstack/react-query';
 import {
 	createLazyRoute,
 	createRoute,
@@ -168,6 +170,20 @@ export const siteRoute = createRoute( {
 		}
 
 		return { site };
+	},
+	onEnter: async ( { loaderData } ) => {
+		const siteId = loaderData?.site?.ID;
+		if ( ! siteId ) {
+			return;
+		}
+		const prefs = await queryClient.ensureQueryData( rawUserPreferencesQuery() );
+		const recentSites = prefs?.recentSites ?? [];
+		if ( siteId !== recentSites[ 0 ] ) {
+			const updated = [ ...new Set( [ siteId, ...recentSites ] ) ].slice( 0, 5 );
+			new MutationObserver( queryClient, userPreferenceOptimisticMutation( 'recentSites' ) ).mutate(
+				updated
+			);
+		}
 	},
 	errorComponent: lazyRouteComponent( () => import( '../../sites/site/error' ) ),
 } ).lazy( () =>

--- a/packages/api-core/src/me-preferences/types.ts
+++ b/packages/api-core/src/me-preferences/types.ts
@@ -18,6 +18,7 @@ export interface ReaderLandingPage extends LandingPagePreference {
 }
 
 export interface UserPreferences {
+	recentSites?: number[];
 	'hosting-dashboard-opt-in'?: HostingDashboardOptIn;
 	'hosting-dashboard-opt-in-welcome-modal-dismissed'?: string; // Timestamp when the user dismissed the modal
 	[ key: `hosting-dashboard-dataviews-view-${ string }` ]: View | undefined;

--- a/packages/api-queries/src/me-preferences.ts
+++ b/packages/api-queries/src/me-preferences.ts
@@ -4,6 +4,7 @@ import { queryClient } from './query-client';
 import type { UserPreferences } from '@automattic/api-core';
 
 const defaultValues: Required< UserPreferences > = {
+	recentSites: [],
 	'hosting-dashboard-opt-in': { value: 'unset', updated_at: '' },
 	'hosting-dashboard-opt-in-welcome-modal-dismissed': '',
 	'hosting-dashboard-welcome-notice-dismissed': '',


### PR DESCRIPTION
Part of DOTMSD-1168

## Proposed Changes

- Add `recentSites` to the `UserPreferences` type and defaults in `@automattic/api-core` / `@automattic/api-queries`
- Update `recentSites` preference via `onEnter` callback on `siteRoute` — fires on every site navigation, uses `MutationObserver` with `userPreferenceOptimisticMutation` for proper optimistic updates and rollback
- Subscribe to `recentSites` changes in the omnibar via `QueryObserver` so it reactively updates when the user navigates to a different site
- Add a separate `QueryClientProvider` for the legacy masterbar to prevent its internal queries from polluting the Dashboard cache
	- Now that I could easily test different selected site types in the OmniBar, I found that some site types caused the OmniBar to crash because of the missing `QueryClientProvider`

Note: by including the `QueryClientProvider` the launch button appeared. It's correctly on appears on unlaunched sites, but click handler doesn't do anything yet. That should be a follow up DOTMSD-1188

<img width="398" alt="CleanShot 2026-03-31 at 21 19 27@2x" src="https://github.com/user-attachments/assets/f98d9ad4-9267-4b59-9e03-d225ccef2e3c" />


## Why are these changes being made?

The omnibar always showed the user's `primary_blog`. It should reflect whichever site the user most recently interacted with. The `recentSites` calypso preference (stored server-side via `/me/preferences`) is the right mechanism — it's cross-domain (REST API, not localStorage) and already used by Calypso v1 and server-side PHP for redirects.

Note: wp-admin does not currently write to `recentSites` — but the jetpack-masterbar already reads/writes other `calypso_preferences` keys, so a follow-up could add `recentSites` writing there.

## Testing Instructions

1. `yarn start-dashboard`, navigate to `/sites/foo.com` — omnibar should show foo.com
2. Switch to a different site — omnibar updates to new site
4. Reload page — omnibar should show the last visited site (not primary blog)
6. Visit site in Calypso v1 → return to MSD → omnibar should show that site
7. Try clicking various different "types" of site, Jetpack sites, atomic sites, CIAB sites. Make sure nothing is crashing.

You may notice that different site types show different number of menu items. This is simply Calypso V1 behaviour 🤷‍♂️ 

| Atomic | Simple |
| --- | --- |
| <img width="306" alt="CleanShot 2026-03-31 at 21 20 26@2x" src="https://github.com/user-attachments/assets/daeb1c96-5129-4786-a747-2e69b62f7e1d" /> | <img width="268" alt="CleanShot 2026-03-31 at 21 19 57@2x" src="https://github.com/user-attachments/assets/968a9fe7-343f-473b-a857-c0f55cc7f1f7" /> |

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?