### PR TITLE
Site AI Tools: add Read/Write/Setup MCP sub-pages

### DIFF
--- a/client/dashboard/app/breadcrumbs/index.tsx
+++ b/client/dashboard/app/breadcrumbs/index.tsx
@@ -24,7 +24,11 @@ export default function Breadcrumbs( { length, onItemClick }: BreadcrumbsProps )
 	const items: BreadcrumbItemProps[] = matches
 		.map( ( match ) => {
 			const title = match.meta?.find( ( meta ) => meta?.title )?.title;
-			const breadcrumbHref = match.meta?.find( ( meta ) => meta?.breadcrumbHref )?.breadcrumbHref;
+			const breadcrumbHref = (
+				match.meta?.find( ( meta ) => ( meta as Record< string, unknown > )?.breadcrumbHref ) as
+					| Record< string, string >
+					| undefined
+			 )?.breadcrumbHref;
 			const href = breadcrumbHref ?? match.pathname;
 			return {
 				label: title || '',

--- a/client/dashboard/app/breadcrumbs/index.tsx
+++ b/client/dashboard/app/breadcrumbs/index.tsx
@@ -24,9 +24,11 @@ export default function Breadcrumbs( { length, onItemClick }: BreadcrumbsProps )
 	const items: BreadcrumbItemProps[] = matches
 		.map( ( match ) => {
 			const title = match.meta?.find( ( meta ) => meta?.title )?.title;
+			const breadcrumbHref = match.meta?.find( ( meta ) => meta?.breadcrumbHref )?.breadcrumbHref;
+			const href = breadcrumbHref ?? match.pathname;
 			return {
 				label: title || '',
-				href: match.pathname,
+				href,
 			};
 		} )
 		.filter( ( { label } ) => Boolean( label ) )

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -760,8 +760,11 @@ export const siteSettingsAIToolsSetupRoute = createRoute( {
 	getParentRoute: () => siteSettingsAIToolsRoute,
 	path: 'ai-tools/setup',
 	beforeLoad: redirectSiteAiToolsSubpageToHub,
-	loader: async () => {
-		await queryClient.ensureQueryData( userSettingsQuery() );
+	loader: async ( { params: { siteSlug } } ) => {
+		await Promise.all( [
+			queryClient.ensureQueryData( userSettingsQuery() ),
+			queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) ),
+		] );
 	},
 } ).lazy( () =>
 	import( '../../sites/settings-ai-tools/setup' ).then( ( d ) =>

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -639,19 +639,16 @@ export const siteSettingsSiteVisibilityRoute = createRoute( {
 // Pathless layout: a route with path `ai-tools` in flatRoutes fuzzy-matches `ai-tools/read` and
 // breaks matching (leftover `**` segment). Children use full paths under `settings` instead.
 export const siteSettingsAIToolsRoute = createRoute( {
-	id: 'siteSettingsAiTools',
 	staticData: { requiresSiteTypeSupport: 'settingsGeneralAITools' },
-	head: ( { params: { siteSlug } } ) => ( {
+	head: () => ( {
 		meta: [
 			{
 				title: __( 'AI tools' ),
 			},
-			{
-				breadcrumbHref: `/sites/${ siteSlug }/settings/ai-tools`,
-			},
 		],
 	} ),
 	getParentRoute: () => siteSettingsRoute,
+	path: 'ai-tools',
 	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
 		if ( cause === 'preload' ) {
 			return;
@@ -672,7 +669,7 @@ export const siteSettingsAIToolsRoute = createRoute( {
 
 export const siteSettingsAIToolsIndexRoute = createRoute( {
 	getParentRoute: () => siteSettingsAIToolsRoute,
-	path: 'ai-tools',
+	path: '/',
 } ).lazy( () =>
 	import( '../../sites/settings-ai-tools' ).then( ( d ) =>
 		createLazyRoute( 'site-settings-ai-tools' )( {
@@ -708,7 +705,7 @@ export const siteSettingsAIToolsReadRoute = createRoute( {
 		],
 	} ),
 	getParentRoute: () => siteSettingsAIToolsRoute,
-	path: 'ai-tools/read',
+	path: 'read',
 	beforeLoad: redirectSiteAiToolsSubpageToHub,
 	loader: async ( { params: { siteSlug } } ) => {
 		await Promise.all( [
@@ -733,7 +730,7 @@ export const siteSettingsAIToolsWriteRoute = createRoute( {
 		],
 	} ),
 	getParentRoute: () => siteSettingsAIToolsRoute,
-	path: 'ai-tools/write',
+	path: 'write',
 	beforeLoad: redirectSiteAiToolsSubpageToHub,
 	loader: async ( { params: { siteSlug } } ) => {
 		await Promise.all( [
@@ -758,7 +755,7 @@ export const siteSettingsAIToolsSetupRoute = createRoute( {
 		],
 	} ),
 	getParentRoute: () => siteSettingsAIToolsRoute,
-	path: 'ai-tools/setup',
+	path: 'setup',
 	beforeLoad: redirectSiteAiToolsSubpageToHub,
 	loader: async ( { params: { siteSlug } } ) => {
 		await Promise.all( [

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -636,8 +636,6 @@ export const siteSettingsSiteVisibilityRoute = createRoute( {
 	)
 );
 
-// Pathless layout: a route with path `ai-tools` in flatRoutes fuzzy-matches `ai-tools/read` and
-// breaks matching (leftover `**` segment). Children use full paths under `settings` instead.
 export const siteSettingsAIToolsRoute = createRoute( {
 	staticData: { requiresSiteTypeSupport: 'settingsGeneralAITools' },
 	head: () => ( {

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -636,17 +636,22 @@ export const siteSettingsSiteVisibilityRoute = createRoute( {
 	)
 );
 
+// Pathless layout: a route with path `ai-tools` in flatRoutes fuzzy-matches `ai-tools/read` and
+// breaks matching (leftover `**` segment). Children use full paths under `settings` instead.
 export const siteSettingsAIToolsRoute = createRoute( {
+	id: 'siteSettingsAiTools',
 	staticData: { requiresSiteTypeSupport: 'settingsGeneralAITools' },
-	head: () => ( {
+	head: ( { params: { siteSlug } } ) => ( {
 		meta: [
 			{
 				title: __( 'AI tools' ),
 			},
+			{
+				breadcrumbHref: `/sites/${ siteSlug }/settings/ai-tools`,
+			},
 		],
 	} ),
 	getParentRoute: () => siteSettingsRoute,
-	path: 'ai-tools',
 	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
 		if ( cause === 'preload' ) {
 			return;
@@ -663,17 +668,11 @@ export const siteSettingsAIToolsRoute = createRoute( {
 			queryClient.ensureQueryData( userSettingsQuery() ),
 		] );
 	},
-} ).lazy( () =>
-	import( '../../sites/settings-ai-tools/layout' ).then( ( d ) =>
-		createLazyRoute( 'site-settings-ai-tools-layout' )( {
-			component: d.default,
-		} )
-	)
-);
+} );
 
 export const siteSettingsAIToolsIndexRoute = createRoute( {
 	getParentRoute: () => siteSettingsAIToolsRoute,
-	path: '/',
+	path: 'ai-tools',
 } ).lazy( () =>
 	import( '../../sites/settings-ai-tools' ).then( ( d ) =>
 		createLazyRoute( 'site-settings-ai-tools' )( {
@@ -681,6 +680,24 @@ export const siteSettingsAIToolsIndexRoute = createRoute( {
 		} )
 	)
 );
+
+function redirectSiteAiToolsSubpageToHub( {
+	cause,
+	params: { siteSlug },
+}: {
+	cause: string;
+	params: { siteSlug: string };
+} ) {
+	if ( cause === 'preload' ) {
+		return;
+	}
+	if ( ! isEnabled( 'mcp-settings' ) ) {
+		throw redirect( {
+			to: siteSettingsAIToolsIndexRoute.fullPath,
+			params: { siteSlug },
+		} );
+	}
+}
 
 export const siteSettingsAIToolsReadRoute = createRoute( {
 	head: () => ( {
@@ -691,9 +708,13 @@ export const siteSettingsAIToolsReadRoute = createRoute( {
 		],
 	} ),
 	getParentRoute: () => siteSettingsAIToolsRoute,
-	path: 'read',
-	loader: async () => {
-		await queryClient.ensureQueryData( userSettingsQuery() );
+	path: 'ai-tools/read',
+	beforeLoad: redirectSiteAiToolsSubpageToHub,
+	loader: async ( { params: { siteSlug } } ) => {
+		await Promise.all( [
+			queryClient.ensureQueryData( userSettingsQuery() ),
+			queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) ),
+		] );
 	},
 } ).lazy( () =>
 	import( '../../sites/settings-ai-tools/read' ).then( ( d ) =>
@@ -712,9 +733,13 @@ export const siteSettingsAIToolsWriteRoute = createRoute( {
 		],
 	} ),
 	getParentRoute: () => siteSettingsAIToolsRoute,
-	path: 'write',
-	loader: async () => {
-		await queryClient.ensureQueryData( userSettingsQuery() );
+	path: 'ai-tools/write',
+	beforeLoad: redirectSiteAiToolsSubpageToHub,
+	loader: async ( { params: { siteSlug } } ) => {
+		await Promise.all( [
+			queryClient.ensureQueryData( userSettingsQuery() ),
+			queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) ),
+		] );
 	},
 } ).lazy( () =>
 	import( '../../sites/settings-ai-tools/write' ).then( ( d ) =>
@@ -733,7 +758,8 @@ export const siteSettingsAIToolsSetupRoute = createRoute( {
 		],
 	} ),
 	getParentRoute: () => siteSettingsAIToolsRoute,
-	path: 'setup',
+	path: 'ai-tools/setup',
+	beforeLoad: redirectSiteAiToolsSubpageToHub,
 	loader: async () => {
 		await queryClient.ensureQueryData( userSettingsQuery() );
 	},
@@ -1531,14 +1557,12 @@ export const createSitesRoutes = ( config: AppConfig ) => {
 
 		// General
 		siteSettingsSiteVisibilityRoute,
-		isEnabled( 'mcp-settings' )
-			? siteSettingsAIToolsRoute.addChildren( [
-					siteSettingsAIToolsIndexRoute,
-					siteSettingsAIToolsReadRoute,
-					siteSettingsAIToolsWriteRoute,
-					siteSettingsAIToolsSetupRoute,
-			  ] )
-			: siteSettingsAIToolsRoute.addChildren( [ siteSettingsAIToolsIndexRoute ] ),
+		siteSettingsAIToolsRoute.addChildren( [
+			siteSettingsAIToolsIndexRoute,
+			siteSettingsAIToolsReadRoute,
+			siteSettingsAIToolsWriteRoute,
+			siteSettingsAIToolsSetupRoute,
+		] ),
 		siteSettingsSubscriptionGiftingRoute,
 		siteSettingsAgencyRoute,
 		siteSettingsHundredYearPlanRoute,

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -677,7 +677,6 @@ export const siteSettingsAIToolsIndexRoute = createRoute( {
 );
 
 export const siteSettingsAIToolsReadRoute = createRoute( {
-	staticData: { requiresSiteTypeSupport: 'settingsGeneralAITools' },
 	head: () => ( {
 		meta: [
 			{
@@ -687,14 +686,6 @@ export const siteSettingsAIToolsReadRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteSettingsAIToolsRoute,
 	path: 'read',
-	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
-		if ( cause === 'preload' ) {
-			return;
-		}
-		if ( ! isEnabled( 'mcp-settings' ) ) {
-			throw redirectAsNotAllowed( { to: siteSettingsAIToolsRoute.fullPath, params: { siteSlug } } );
-		}
-	},
 	loader: async () => {
 		await queryClient.ensureQueryData( userSettingsQuery() );
 	},
@@ -707,7 +698,6 @@ export const siteSettingsAIToolsReadRoute = createRoute( {
 );
 
 export const siteSettingsAIToolsWriteRoute = createRoute( {
-	staticData: { requiresSiteTypeSupport: 'settingsGeneralAITools' },
 	head: () => ( {
 		meta: [
 			{
@@ -717,14 +707,6 @@ export const siteSettingsAIToolsWriteRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteSettingsAIToolsRoute,
 	path: 'write',
-	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
-		if ( cause === 'preload' ) {
-			return;
-		}
-		if ( ! isEnabled( 'mcp-settings' ) ) {
-			throw redirectAsNotAllowed( { to: siteSettingsAIToolsRoute.fullPath, params: { siteSlug } } );
-		}
-	},
 	loader: async () => {
 		await queryClient.ensureQueryData( userSettingsQuery() );
 	},
@@ -737,7 +719,6 @@ export const siteSettingsAIToolsWriteRoute = createRoute( {
 );
 
 export const siteSettingsAIToolsSetupRoute = createRoute( {
-	staticData: { requiresSiteTypeSupport: 'settingsGeneralAITools' },
 	head: () => ( {
 		meta: [
 			{
@@ -747,14 +728,6 @@ export const siteSettingsAIToolsSetupRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteSettingsAIToolsRoute,
 	path: 'setup',
-	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
-		if ( cause === 'preload' ) {
-			return;
-		}
-		if ( ! isEnabled( 'mcp-settings' ) ) {
-			throw redirectAsNotAllowed( { to: siteSettingsAIToolsRoute.fullPath, params: { siteSlug } } );
-		}
-	},
 	loader: async () => {
 		await queryClient.ensureQueryData( userSettingsQuery() );
 	},
@@ -1552,12 +1525,14 @@ export const createSitesRoutes = ( config: AppConfig ) => {
 
 		// General
 		siteSettingsSiteVisibilityRoute,
-		siteSettingsAIToolsRoute.addChildren( [
-			siteSettingsAIToolsIndexRoute,
-			siteSettingsAIToolsReadRoute,
-			siteSettingsAIToolsWriteRoute,
-			siteSettingsAIToolsSetupRoute,
-		] ),
+		isEnabled( 'mcp-settings' )
+			? siteSettingsAIToolsRoute.addChildren( [
+					siteSettingsAIToolsIndexRoute,
+					siteSettingsAIToolsReadRoute,
+					siteSettingsAIToolsWriteRoute,
+					siteSettingsAIToolsSetupRoute,
+			  ] )
+			: siteSettingsAIToolsRoute.addChildren( [ siteSettingsAIToolsIndexRoute ] ),
 		siteSettingsSubscriptionGiftingRoute,
 		siteSettingsAgencyRoute,
 		siteSettingsHundredYearPlanRoute,

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -663,7 +663,13 @@ export const siteSettingsAIToolsRoute = createRoute( {
 			queryClient.ensureQueryData( userSettingsQuery() ),
 		] );
 	},
-} );
+} ).lazy( () =>
+	import( '../../sites/settings-ai-tools/layout' ).then( ( d ) =>
+		createLazyRoute( 'site-settings-ai-tools-layout' )( {
+			component: d.default,
+		} )
+	)
+);
 
 export const siteSettingsAIToolsIndexRoute = createRoute( {
 	getParentRoute: () => siteSettingsAIToolsRoute,

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -1,6 +1,7 @@
 import { HostingFeatures, DotcomFeatures, LogType } from '@automattic/api-core';
 import {
 	bigSkyPluginQuery,
+	userSettingsQuery,
 	codeDeploymentQuery,
 	codeDeploymentsQuery,
 	githubInstallationsQuery,
@@ -657,12 +658,110 @@ export const siteSettingsAIToolsRoute = createRoute( {
 	},
 	loader: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		await queryClient.ensureQueryData( bigSkyPluginQuery( site.ID ) );
+		await Promise.all( [
+			queryClient.ensureQueryData( bigSkyPluginQuery( site.ID ) ),
+			queryClient.ensureQueryData( userSettingsQuery() ),
+		] );
 	},
+} );
+
+export const siteSettingsAIToolsIndexRoute = createRoute( {
+	getParentRoute: () => siteSettingsAIToolsRoute,
+	path: '/',
 } ).lazy( () =>
 	import( '../../sites/settings-ai-tools' ).then( ( d ) =>
 		createLazyRoute( 'site-settings-ai-tools' )( {
 			component: () => <d.default siteSlug={ siteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
+export const siteSettingsAIToolsReadRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsGeneralAITools' },
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Read' ),
+			},
+		],
+	} ),
+	getParentRoute: () => siteSettingsAIToolsRoute,
+	path: 'read',
+	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
+		if ( cause === 'preload' ) {
+			return;
+		}
+		if ( ! isEnabled( 'mcp-settings' ) ) {
+			throw redirectAsNotAllowed( { to: siteSettingsAIToolsRoute.fullPath, params: { siteSlug } } );
+		}
+	},
+	loader: async () => {
+		await queryClient.ensureQueryData( userSettingsQuery() );
+	},
+} ).lazy( () =>
+	import( '../../sites/settings-ai-tools/read' ).then( ( d ) =>
+		createLazyRoute( 'site-settings-ai-tools-read' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const siteSettingsAIToolsWriteRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsGeneralAITools' },
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Write' ),
+			},
+		],
+	} ),
+	getParentRoute: () => siteSettingsAIToolsRoute,
+	path: 'write',
+	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
+		if ( cause === 'preload' ) {
+			return;
+		}
+		if ( ! isEnabled( 'mcp-settings' ) ) {
+			throw redirectAsNotAllowed( { to: siteSettingsAIToolsRoute.fullPath, params: { siteSlug } } );
+		}
+	},
+	loader: async () => {
+		await queryClient.ensureQueryData( userSettingsQuery() );
+	},
+} ).lazy( () =>
+	import( '../../sites/settings-ai-tools/write' ).then( ( d ) =>
+		createLazyRoute( 'site-settings-ai-tools-write' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const siteSettingsAIToolsSetupRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsGeneralAITools' },
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Connect AI agent' ),
+			},
+		],
+	} ),
+	getParentRoute: () => siteSettingsAIToolsRoute,
+	path: 'setup',
+	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
+		if ( cause === 'preload' ) {
+			return;
+		}
+		if ( ! isEnabled( 'mcp-settings' ) ) {
+			throw redirectAsNotAllowed( { to: siteSettingsAIToolsRoute.fullPath, params: { siteSlug } } );
+		}
+	},
+	loader: async () => {
+		await queryClient.ensureQueryData( userSettingsQuery() );
+	},
+} ).lazy( () =>
+	import( '../../sites/settings-ai-tools/setup' ).then( ( d ) =>
+		createLazyRoute( 'site-settings-ai-tools-setup' )( {
+			component: d.default,
 		} )
 	)
 );
@@ -1453,7 +1552,12 @@ export const createSitesRoutes = ( config: AppConfig ) => {
 
 		// General
 		siteSettingsSiteVisibilityRoute,
-		siteSettingsAIToolsRoute,
+		siteSettingsAIToolsRoute.addChildren( [
+			siteSettingsAIToolsIndexRoute,
+			siteSettingsAIToolsReadRoute,
+			siteSettingsAIToolsWriteRoute,
+			siteSettingsAIToolsSetupRoute,
+		] ),
 		siteSettingsSubscriptionGiftingRoute,
 		siteSettingsAgencyRoute,
 		siteSettingsHundredYearPlanRoute,

--- a/client/dashboard/sites/settings-ai-tools/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/index.tsx
@@ -153,12 +153,12 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 	const handleMcpToggle = ( enabled: boolean ) => {
 		const abilities: Record< string, boolean > = {};
 		if ( enabled ) {
-			// Auto-enable all read tools and disable all write tools.
-			availableTools.forEach( ( [ toolId, tool ] ) => {
-				abilities[ toolId ] = ! isWriteTool( toolId, tool );
+			// Auto-enable all read tools; leave write tools unset (not explicitly disabled).
+			readTools.forEach( ( [ toolId ] ) => {
+				abilities[ toolId ] = true;
 			} );
 		}
-		// When disabling, send abilities: {} to clear all site-level overrides.
+		// When disabling, send abilities: {} to clear all site-level tool access.
 		mcpMutation.mutate( {
 			mcp_abilities: {
 				sites: [

--- a/client/dashboard/sites/settings-ai-tools/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/index.tsx
@@ -287,25 +287,21 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 									/>
 								</VStack>
 							</CardBody>
-							{ isMcpEnabled && (
-								<>
-									<CardDivider className="mcp-settings__sub-divider" />
-									<RouterLinkSummaryButton
-										to={ `/sites/${ siteSlug }/settings/ai-tools/read` }
-										density="medium"
-										title={ __( 'Read' ) }
-										decoration={ <Icon icon={ seen } size={ 24 } /> }
-										badges={ [ readBadge ] }
-									/>
-									<RouterLinkSummaryButton
-										to={ `/sites/${ siteSlug }/settings/ai-tools/write` }
-										density="medium"
-										title={ __( 'Write' ) }
-										decoration={ <Icon icon={ pencil } size={ 24 } /> }
-										badges={ [ writeBadge ] }
-									/>
-								</>
-							) }
+							<CardDivider className="mcp-settings__sub-divider" />
+							<RouterLinkSummaryButton
+								to={ `/sites/${ siteSlug }/settings/ai-tools/read` }
+								density="medium"
+								title={ __( 'Read' ) }
+								decoration={ <Icon icon={ seen } size={ 24 } /> }
+								badges={ [ readBadge ] }
+							/>
+							<RouterLinkSummaryButton
+								to={ `/sites/${ siteSlug }/settings/ai-tools/write` }
+								density="medium"
+								title={ __( 'Write' ) }
+								decoration={ <Icon icon={ pencil } size={ 24 } /> }
+								badges={ [ writeBadge ] }
+							/>
 						</Card>
 						{ isMcpEnabled && (
 							<RouterLinkSummaryButton

--- a/client/dashboard/sites/settings-ai-tools/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/index.tsx
@@ -288,21 +288,25 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 									/>
 								</VStack>
 							</CardBody>
-							<CardDivider className="mcp-settings__sub-divider" />
-							<RouterLinkSummaryButton
-								to={ `/sites/${ siteSlug }/settings/ai-tools/read` }
-								density="medium"
-								title={ __( 'Read' ) }
-								decoration={ <Icon icon={ seen } size={ 24 } /> }
-								badges={ [ readBadge ] }
-							/>
-							<RouterLinkSummaryButton
-								to={ `/sites/${ siteSlug }/settings/ai-tools/write` }
-								density="medium"
-								title={ __( 'Write' ) }
-								decoration={ <Icon icon={ pencil } size={ 24 } /> }
-								badges={ [ writeBadge ] }
-							/>
+							{ isMcpEnabled && (
+								<>
+									<CardDivider className="mcp-settings__sub-divider" />
+									<RouterLinkSummaryButton
+										to={ `/sites/${ siteSlug }/settings/ai-tools/read` }
+										density="medium"
+										title={ __( 'Read' ) }
+										decoration={ <Icon icon={ seen } size={ 24 } /> }
+										badges={ [ readBadge ] }
+									/>
+									<RouterLinkSummaryButton
+										to={ `/sites/${ siteSlug }/settings/ai-tools/write` }
+										density="medium"
+										title={ __( 'Write' ) }
+										decoration={ <Icon icon={ pencil } size={ 24 } /> }
+										badges={ [ writeBadge ] }
+									/>
+								</>
+							) }
 						</Card>
 						{ isMcpEnabled && (
 							<RouterLinkSummaryButton

--- a/client/dashboard/sites/settings-ai-tools/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/index.tsx
@@ -136,8 +136,9 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 	 ).filter( ( [ , tool ] ) => tool.visible !== false );
 	const readTools = availableTools.filter( ( [ toolId, tool ] ) => ! isWriteTool( toolId, tool ) );
 	const writeTools = availableTools.filter( ( [ toolId, tool ] ) => isWriteTool( toolId, tool ) );
-	const readBadge = getReadBadge( readTools );
-	const writeBadge = getWriteBadge( writeTools );
+	const disabledBadge = { text: __( 'Disabled' ) };
+	const readBadge = isMcpEnabled ? getReadBadge( readTools ) : disabledBadge;
+	const writeBadge = isMcpEnabled ? getWriteBadge( writeTools ) : disabledBadge;
 	const mcpMutation = useMutation( {
 		...userSettingsMutation(),
 		meta: {

--- a/client/dashboard/sites/settings-ai-tools/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/index.tsx
@@ -71,7 +71,7 @@ function getReadBadge( tools: Array< [ string, McpAbility ] > ) {
 		return { text: __( 'All enabled' ), intent: 'success' as const };
 	}
 	if ( enabledCount === 0 ) {
-		return { text: __( 'None enabled' ) };
+		return { text: __( 'Disabled' ) };
 	}
 	return {
 		/* translators: %1$d is the number of enabled tools, %2$d is the total number of tools */
@@ -151,12 +151,21 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 	} );
 
 	const handleMcpToggle = ( enabled: boolean ) => {
+		const abilities: Record< string, boolean > = {};
+		if ( enabled ) {
+			// Auto-enable all read tools and disable all write tools.
+			availableTools.forEach( ( [ toolId, tool ] ) => {
+				abilities[ toolId ] = ! isWriteTool( toolId, tool );
+			} );
+		}
+		// When disabling, send abilities: {} to clear all site-level overrides.
 		mcpMutation.mutate( {
 			mcp_abilities: {
 				sites: [
 					{
 						blog_id: site.ID,
 						site_level_enabled: enabled,
+						abilities,
 					},
 				],
 			},

--- a/client/dashboard/sites/settings-ai-tools/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/index.tsx
@@ -1,3 +1,5 @@
+import './style.scss';
+
 import { HostingFeatures } from '@automattic/api-core';
 import {
 	bigSkyPluginMutation,
@@ -29,7 +31,13 @@ import {
 	termDescription,
 } from '@wordpress/icons';
 import { useState } from 'react';
-import { getAccountMcpAbilities, getSiteAccountToolsEnabled } from '../../../me/mcp/utils';
+import {
+	getAccountMcpAbilities,
+	getSiteContextToolIds,
+	getSiteLevelEnabled,
+	getSiteMcpAbilities,
+	mergeSiteMcpAbilities,
+} from '../../../me/mcp/utils';
 import { useAnalytics } from '../../app/analytics';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { useHelpCenter } from '../../app/help-center';
@@ -112,9 +120,17 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 
 	// MCP settings for this site
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
-	const isMcpEnabled = getSiteAccountToolsEnabled( userSettings || {}, site.ID );
+	const isMcpEnabled = getSiteLevelEnabled( userSettings || {}, site.ID );
 
-	const mcpAbilities = getAccountMcpAbilities( userSettings || {} );
+	const accountAbilities = getAccountMcpAbilities( userSettings || {} );
+	const siteContextToolIds = getSiteContextToolIds( userSettings || {} );
+	const siteAbilities = getSiteMcpAbilities( userSettings || {}, site.ID );
+	const siteAccountAbilities = siteContextToolIds.size
+		? Object.fromEntries(
+				Object.entries( accountAbilities ).filter( ( [ id ] ) => siteContextToolIds.has( id ) )
+		  )
+		: accountAbilities;
+	const mcpAbilities = mergeSiteMcpAbilities( siteAccountAbilities, siteAbilities );
 	const availableTools = (
 		Object.entries( mcpAbilities ) as Array< [ string, McpAbility ] >
 	 ).filter( ( [ , tool ] ) => tool.visible !== false );
@@ -140,11 +156,11 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 				sites: [
 					{
 						blog_id: site.ID,
-						account_tools_enabled: enabled,
+						site_level_enabled: enabled,
 					},
 				],
 			},
-		} as any );
+		} );
 	};
 
 	const mutation = useMutation( {
@@ -264,16 +280,16 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 							</CardBody>
 							{ isMcpEnabled && (
 								<>
-									<CardDivider />
+									<CardDivider className="mcp-settings__sub-divider" />
 									<RouterLinkSummaryButton
-										to="./read"
+										to={ `/sites/${ siteSlug }/settings/ai-tools/read` }
 										density="medium"
 										title={ __( 'Read' ) }
 										decoration={ <Icon icon={ seen } size={ 24 } /> }
 										badges={ [ readBadge ] }
 									/>
 									<RouterLinkSummaryButton
-										to="./write"
+										to={ `/sites/${ siteSlug }/settings/ai-tools/write` }
 										density="medium"
 										title={ __( 'Write' ) }
 										decoration={ <Icon icon={ pencil } size={ 24 } /> }
@@ -284,7 +300,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 						</Card>
 						{ isMcpEnabled && (
 							<RouterLinkSummaryButton
-								to="./setup"
+								to={ `/sites/${ siteSlug }/settings/ai-tools/setup` }
 								title={ __( 'Connect external AI agent' ) }
 								description={ __( 'Get instructions for connecting your external AI assistant.' ) }
 								decoration={ <Icon icon={ connection } size={ 24 } /> }

--- a/client/dashboard/sites/settings-ai-tools/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/index.tsx
@@ -16,10 +16,20 @@ import {
 	ToggleControl,
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
-import { brush, check, comment, help, image, termDescription } from '@wordpress/icons';
+import { __, sprintf } from '@wordpress/i18n';
+import {
+	brush,
+	check,
+	comment,
+	connection,
+	help,
+	image,
+	pencil,
+	seen,
+	termDescription,
+} from '@wordpress/icons';
 import { useState } from 'react';
-import { getSiteAccountToolsEnabled } from '../../../me/mcp/utils';
+import { getAccountMcpAbilities, getSiteAccountToolsEnabled } from '../../../me/mcp/utils';
 import { useAnalytics } from '../../app/analytics';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { useHelpCenter } from '../../app/help-center';
@@ -32,8 +42,53 @@ import RouterLinkSummaryButton from '../../components/router-link-summary-button
 import { SectionHeader } from '../../components/section-header';
 import SummaryButton from '../../components/summary-button';
 import { SummaryButtonList } from '../../components/summary-button-list';
+import { isWriteTool } from '../../me/mcp/categories';
 import UpsellCallout from '../hosting-feature-gated-with-callout/upsell';
 import upsellIllustrationUrl from './upsell-illustration.svg';
+
+interface McpAbility {
+	title: string;
+	description: string;
+	enabled: boolean;
+	readonly?: boolean;
+	visible?: boolean;
+}
+
+function getReadBadge( tools: Array< [ string, McpAbility ] > ) {
+	if ( tools.length === 0 ) {
+		return { text: __( 'All enabled' ), intent: 'success' as const };
+	}
+	const enabledCount = tools.filter( ( [ , tool ] ) => tool.enabled ).length;
+	if ( enabledCount === tools.length ) {
+		return { text: __( 'All enabled' ), intent: 'success' as const };
+	}
+	if ( enabledCount === 0 ) {
+		return { text: __( 'None enabled' ) };
+	}
+	return {
+		/* translators: %1$d is the number of enabled tools, %2$d is the total number of tools */
+		text: sprintf( __( '%1$d of %2$d enabled' ), enabledCount, tools.length ),
+		intent: 'info' as const,
+	};
+}
+
+function getWriteBadge( tools: Array< [ string, McpAbility ] > ) {
+	if ( tools.length === 0 ) {
+		return { text: __( 'All enabled' ), intent: 'success' as const };
+	}
+	const enabledCount = tools.filter( ( [ , tool ] ) => tool.enabled ).length;
+	if ( enabledCount === tools.length ) {
+		return { text: __( 'All enabled' ), intent: 'success' as const };
+	}
+	if ( enabledCount === 0 ) {
+		return { text: __( 'Disabled' ) };
+	}
+	return {
+		/* translators: %1$d is the number of enabled tools, %2$d is the total number of tools */
+		text: sprintf( __( '%1$d of %2$d enabled' ), enabledCount, tools.length ),
+		intent: 'info' as const,
+	};
+}
 
 const features = [
 	__( 'Get answers where you work so you‘re unstuck faster' ),
@@ -58,6 +113,15 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 	// MCP settings for this site
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 	const isMcpEnabled = getSiteAccountToolsEnabled( userSettings || {}, site.ID );
+
+	const mcpAbilities = getAccountMcpAbilities( userSettings || {} );
+	const availableTools = (
+		Object.entries( mcpAbilities ) as Array< [ string, McpAbility ] >
+	 ).filter( ( [ , tool ] ) => tool.visible !== false );
+	const readTools = availableTools.filter( ( [ toolId, tool ] ) => ! isWriteTool( toolId, tool ) );
+	const writeTools = availableTools.filter( ( [ toolId, tool ] ) => isWriteTool( toolId, tool ) );
+	const readBadge = getReadBadge( readTools );
+	const writeBadge = getWriteBadge( writeTools );
 	const mcpMutation = useMutation( {
 		...userSettingsMutation(),
 		meta: {
@@ -180,32 +244,53 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 					) }
 				</Card>
 				{ config.isEnabled( 'mcp-settings' ) && (
-					<Card>
-						<CardBody>
-							<VStack spacing={ 4 }>
-								<SectionHeader
-									title={ __( 'MCP access' ) }
-									description={ __(
-										'Control whether AI assistants can access this site via MCP (Model Context Protocol).'
-									) }
-									level={ 3 }
-								/>
-								<ToggleControl
-									__nextHasNoMarginBottom
-									checked={ isMcpEnabled }
-									disabled={ mcpMutation.isPending }
-									label={ __( 'Enable MCP access for this site' ) }
-									onChange={ handleMcpToggle }
-								/>
-							</VStack>
-						</CardBody>
-						<CardDivider />
-						<RouterLinkSummaryButton
-							to="/me/preferences/mcp"
-							density="medium"
-							title={ __( 'Manage at account level' ) }
-						/>
-					</Card>
+					<>
+						<Card>
+							<CardBody>
+								<VStack spacing={ 4 }>
+									<SectionHeader
+										title={ __( 'External AI agent access' ) }
+										description={ __( 'Allow external AI agents to access this site via MCP.' ) }
+										level={ 3 }
+									/>
+									<ToggleControl
+										__nextHasNoMarginBottom
+										checked={ isMcpEnabled }
+										disabled={ mcpMutation.isPending }
+										label={ __( 'Enable MCP access for this site' ) }
+										onChange={ handleMcpToggle }
+									/>
+								</VStack>
+							</CardBody>
+							{ isMcpEnabled && (
+								<>
+									<CardDivider />
+									<RouterLinkSummaryButton
+										to="./read"
+										density="medium"
+										title={ __( 'Read' ) }
+										decoration={ <Icon icon={ seen } size={ 24 } /> }
+										badges={ [ readBadge ] }
+									/>
+									<RouterLinkSummaryButton
+										to="./write"
+										density="medium"
+										title={ __( 'Write' ) }
+										decoration={ <Icon icon={ pencil } size={ 24 } /> }
+										badges={ [ writeBadge ] }
+									/>
+								</>
+							) }
+						</Card>
+						{ isMcpEnabled && (
+							<RouterLinkSummaryButton
+								to="./setup"
+								title={ __( 'Connect external AI agent' ) }
+								description={ __( 'Get instructions for connecting your external AI assistant.' ) }
+								decoration={ <Icon icon={ connection } size={ 24 } /> }
+							/>
+						) }
+					</>
 				) }
 				{ isFreeTrial && (
 					<ConfirmModal

--- a/client/dashboard/sites/settings-ai-tools/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/index.tsx
@@ -136,9 +136,8 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 	 ).filter( ( [ , tool ] ) => tool.visible !== false );
 	const readTools = availableTools.filter( ( [ toolId, tool ] ) => ! isWriteTool( toolId, tool ) );
 	const writeTools = availableTools.filter( ( [ toolId, tool ] ) => isWriteTool( toolId, tool ) );
-	const disabledBadge = { text: __( 'Disabled' ) };
-	const readBadge = isMcpEnabled ? getReadBadge( readTools ) : disabledBadge;
-	const writeBadge = isMcpEnabled ? getWriteBadge( writeTools ) : disabledBadge;
+	const readBadge = getReadBadge( readTools );
+	const writeBadge = getWriteBadge( writeTools );
 	const mcpMutation = useMutation( {
 		...userSettingsMutation(),
 		meta: {

--- a/client/dashboard/sites/settings-ai-tools/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/index.tsx
@@ -136,8 +136,16 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 	 ).filter( ( [ , tool ] ) => tool.visible !== false );
 	const readTools = availableTools.filter( ( [ toolId, tool ] ) => ! isWriteTool( toolId, tool ) );
 	const writeTools = availableTools.filter( ( [ toolId, tool ] ) => isWriteTool( toolId, tool ) );
-	const readBadge = getReadBadge( readTools );
-	const writeBadge = getWriteBadge( writeTools );
+	// When there are no site-specific overrides, use site_level_enabled_default as the effective
+	// state. True when account MCP is on for sites, false when disabled.
+	const hasSiteAbilityOverrides = Object.keys( siteAbilities ).length > 0;
+	const defaultToolEnabled =
+		( userSettings as any )?.mcp_abilities?.site_level_enabled_default ?? false;
+	const defaultBadge = defaultToolEnabled
+		? { text: __( 'All enabled' ), intent: 'success' as const }
+		: { text: __( 'Disabled' ) };
+	const readBadge = hasSiteAbilityOverrides ? getReadBadge( readTools ) : defaultBadge;
+	const writeBadge = hasSiteAbilityOverrides ? getWriteBadge( writeTools ) : defaultBadge;
 	const mcpMutation = useMutation( {
 		...userSettingsMutation(),
 		meta: {
@@ -270,7 +278,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 				</Card>
 				{ config.isEnabled( 'mcp-settings' ) && (
 					<>
-						<Card>
+						<Card className="mcp-settings__access-card">
 							<CardBody>
 								<VStack spacing={ 4 }>
 									<SectionHeader

--- a/client/dashboard/sites/settings-ai-tools/layout.tsx
+++ b/client/dashboard/sites/settings-ai-tools/layout.tsx
@@ -1,0 +1,5 @@
+import { Outlet } from '@tanstack/react-router';
+
+export default function AIToolsLayout() {
+	return <Outlet />;
+}

--- a/client/dashboard/sites/settings-ai-tools/layout.tsx
+++ b/client/dashboard/sites/settings-ai-tools/layout.tsx
@@ -1,5 +1,0 @@
-import { Outlet } from '@tanstack/react-router';
-
-export default function AIToolsLayout() {
-	return <Outlet />;
-}

--- a/client/dashboard/sites/settings-ai-tools/read/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/read/index.tsx
@@ -1,4 +1,6 @@
-import { userSettingsQuery, userSettingsMutation } from '@automattic/api-queries';
+import '../style.scss';
+
+import { userSettingsQuery, userSettingsMutation, siteBySlugQuery } from '@automattic/api-queries';
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import {
 	__experimentalVStack as VStack,
@@ -8,9 +10,15 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Fragment } from 'react';
-import { getAccountMcpAbilities } from '../../../../me/mcp/utils';
+import {
+	getAccountMcpAbilities,
+	getSiteContextToolIds,
+	getSiteMcpAbilities,
+	mergeSiteMcpAbilities,
+} from '../../../../me/mcp/utils';
 import Breadcrumbs from '../../../app/breadcrumbs';
-import { Card, CardBody, CardDivider } from '../../../components/card';
+import { siteRoute } from '../../../app/router/sites';
+import { Card, CardBody, CardDivider, CardHeader } from '../../../components/card';
 import ComponentViewTracker from '../../../components/component-view-tracker';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
@@ -36,8 +44,19 @@ interface McpAbility {
 }
 
 export default function SiteAIToolsRead() {
+	const { siteSlug } = siteRoute.useParams();
+	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
-	const mcpAbilities = getAccountMcpAbilities( userSettings || {} );
+
+	const accountAbilities = getAccountMcpAbilities( userSettings || {} );
+	const siteContextToolIds = getSiteContextToolIds( userSettings || {} );
+	const siteAbilities = getSiteMcpAbilities( userSettings || {}, site.ID );
+	const siteAccountAbilities = siteContextToolIds.size
+		? Object.fromEntries(
+				Object.entries( accountAbilities ).filter( ( [ id ] ) => siteContextToolIds.has( id ) )
+		  )
+		: accountAbilities;
+	const mcpAbilities = mergeSiteMcpAbilities( siteAccountAbilities, siteAbilities );
 
 	const allTools = ( Object.entries( mcpAbilities ) as Array< [ string, McpAbility ] > ).filter(
 		( [ , tool ] ) => tool.visible !== false
@@ -57,23 +76,33 @@ export default function SiteAIToolsRead() {
 	const handleToolChange = ( toolId: string, enabled: boolean ) => {
 		mutation.mutate( {
 			mcp_abilities: {
-				account: {
-					[ toolId ]: enabled,
-				},
+				sites: [
+					{
+						blog_id: site.ID,
+						abilities: {
+							[ toolId ]: enabled,
+						},
+					},
+				],
 			},
-		} as any );
+		} );
 	};
 
 	const handleEnableAll = ( categoryTools: Array< [ string, McpAbility ] >, enabled: boolean ) => {
-		const accountAbilities: Record< string, boolean > = {};
+		const abilities: Record< string, boolean > = {};
 		categoryTools.forEach( ( [ toolId ] ) => {
-			accountAbilities[ toolId ] = enabled;
+			abilities[ toolId ] = enabled;
 		} );
 		mutation.mutate( {
 			mcp_abilities: {
-				account: accountAbilities,
+				sites: [
+					{
+						blog_id: site.ID,
+						abilities,
+					},
+				],
 			},
-		} as any );
+		} );
 	};
 
 	// Group tools by display category
@@ -117,17 +146,7 @@ export default function SiteAIToolsRead() {
 
 		return subGroups.map( ( subName, index ) => (
 			<Fragment key={ subName }>
-				{ index > 0 && (
-					<CardBody style={ { padding: 'calc(4px * 2) calc(4px * 6)' } }>
-						<hr
-							style={ {
-								border: 'none',
-								borderTop: '1px solid var(--color-border-subtle, #dcdcde)',
-								margin: 0,
-							} }
-						/>
-					</CardBody>
-				) }
+				{ index > 0 && <CardDivider className="mcp-settings__sub-divider" /> }
 				<CardBody>
 					<VStack spacing={ 4 }>{ renderToolToggles( sortTools( subGrouped[ subName ] ) ) }</VStack>
 				</CardBody>
@@ -159,7 +178,7 @@ export default function SiteAIToolsRead() {
 
 					return (
 						<Card key={ categoryName }>
-							<CardBody>
+							<CardHeader>
 								<HStack justify="space-between" alignment="center">
 									<Text as="h3" weight={ 600 } size={ 14 }>
 										{ categoryName }
@@ -172,8 +191,7 @@ export default function SiteAIToolsRead() {
 										onChange={ ( checked ) => handleEnableAll( categoryTools, checked ) }
 									/>
 								</HStack>
-							</CardBody>
-							<CardDivider />
+							</CardHeader>
 							{ subOrder ? (
 								renderSubGroupedTools( categoryTools, categoryName )
 							) : (

--- a/client/dashboard/sites/settings-ai-tools/read/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/read/index.tsx
@@ -146,7 +146,7 @@ export default function SiteAIToolsRead() {
 
 		return subGroups.map( ( subName, index ) => (
 			<Fragment key={ subName }>
-				{ index > 0 && <CardDivider /> }
+				{ index > 0 && <CardDivider className="mcp-settings__tool-group-divider" /> }
 				<CardBody>
 					<VStack spacing={ 4 }>{ renderToolToggles( sortTools( subGrouped[ subName ] ) ) }</VStack>
 				</CardBody>

--- a/client/dashboard/sites/settings-ai-tools/read/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/read/index.tsx
@@ -1,0 +1,190 @@
+import { userSettingsQuery, userSettingsMutation } from '@automattic/api-queries';
+import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
+import {
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+	ToggleControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Fragment } from 'react';
+import { getAccountMcpAbilities } from '../../../../me/mcp/utils';
+import Breadcrumbs from '../../../app/breadcrumbs';
+import { Card, CardBody, CardDivider } from '../../../components/card';
+import ComponentViewTracker from '../../../components/component-view-tracker';
+import { PageHeader } from '../../../components/page-header';
+import PageLayout from '../../../components/page-layout';
+import {
+	CATEGORY_ORDER,
+	SUB_CATEGORY_ORDER,
+	getDisplayCategory,
+	getSubCategory,
+	isWriteTool,
+	sortTools,
+} from '../../../me/mcp/categories';
+
+interface McpAbility {
+	title: string;
+	description: string;
+	enabled: boolean;
+	category?: string;
+	category_label?: string;
+	type?: string;
+	readonly?: boolean;
+	visible?: boolean;
+	annotations?: Record< string, unknown >;
+}
+
+export default function SiteAIToolsRead() {
+	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
+	const mcpAbilities = getAccountMcpAbilities( userSettings || {} );
+
+	const allTools = ( Object.entries( mcpAbilities ) as Array< [ string, McpAbility ] > ).filter(
+		( [ , tool ] ) => tool.visible !== false
+	);
+	const readTools = allTools.filter( ( [ toolId, tool ] ) => ! isWriteTool( toolId, tool ) );
+
+	const mutation = useMutation( {
+		...userSettingsMutation(),
+		meta: {
+			snackbar: {
+				success: __( 'MCP settings saved.' ),
+				error: __( 'Failed to save MCP settings.' ),
+			},
+		},
+	} );
+
+	const handleToolChange = ( toolId: string, enabled: boolean ) => {
+		mutation.mutate( {
+			mcp_abilities: {
+				account: {
+					[ toolId ]: enabled,
+				},
+			},
+		} as any );
+	};
+
+	const handleEnableAll = ( categoryTools: Array< [ string, McpAbility ] >, enabled: boolean ) => {
+		const accountAbilities: Record< string, boolean > = {};
+		categoryTools.forEach( ( [ toolId ] ) => {
+			accountAbilities[ toolId ] = enabled;
+		} );
+		mutation.mutate( {
+			mcp_abilities: {
+				account: accountAbilities,
+			},
+		} as any );
+	};
+
+	// Group tools by display category
+	const grouped: Record< string, Array< [ string, McpAbility ] > > = {};
+	readTools.forEach( ( [ toolId, tool ] ) => {
+		const category = getDisplayCategory( toolId, tool );
+		if ( ! grouped[ category ] ) {
+			grouped[ category ] = [];
+		}
+		grouped[ category ].push( [ toolId, tool ] );
+	} );
+
+	const renderToolToggles = ( tools: Array< [ string, McpAbility ] > ) =>
+		tools.map( ( [ toolId, tool ] ) => (
+			<ToggleControl
+				key={ toolId }
+				__nextHasNoMarginBottom
+				checked={ tool.enabled }
+				disabled={ mutation.isPending }
+				label={ tool.title }
+				help={ tool.description }
+				onChange={ ( checked ) => handleToolChange( toolId, checked ) }
+			/>
+		) );
+
+	const renderSubGroupedTools = (
+		categoryTools: Array< [ string, McpAbility ] >,
+		categoryName: string
+	) => {
+		const subGrouped: Record< string, Array< [ string, McpAbility ] > > = {};
+		categoryTools.forEach( ( [ toolId, tool ] ) => {
+			const sub = getSubCategory( toolId, tool ) ?? '';
+			if ( ! subGrouped[ sub ] ) {
+				subGrouped[ sub ] = [];
+			}
+			subGrouped[ sub ].push( [ toolId, tool ] );
+		} );
+
+		const order = SUB_CATEGORY_ORDER[ categoryName ] ?? [];
+		const subGroups = order.filter( ( sub ) => subGrouped[ sub ] && subGrouped[ sub ].length > 0 );
+
+		return subGroups.map( ( subName, index ) => (
+			<Fragment key={ subName }>
+				{ index > 0 && (
+					<CardBody style={ { padding: 'calc(4px * 2) calc(4px * 6)' } }>
+						<hr
+							style={ {
+								border: 'none',
+								borderTop: '1px solid var(--color-border-subtle, #dcdcde)',
+								margin: 0,
+							} }
+						/>
+					</CardBody>
+				) }
+				<CardBody>
+					<VStack spacing={ 4 }>{ renderToolToggles( sortTools( subGrouped[ subName ] ) ) }</VStack>
+				</CardBody>
+			</Fragment>
+		) );
+	};
+
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					prefix={ <Breadcrumbs length={ 3 } /> }
+					title={ __( 'Read' ) }
+					description={ __( 'View your sites, posts, and account info.' ) }
+				/>
+			}
+		>
+			<ComponentViewTracker eventName="calypso_dashboard_site_ai_tools_read_view" />
+			<VStack spacing={ 4 }>
+				{ CATEGORY_ORDER.map( ( categoryName ) => {
+					const categoryTools = grouped[ categoryName ];
+					if ( ! categoryTools || categoryTools.length === 0 ) {
+						return null;
+					}
+
+					const allEnabled = categoryTools.every( ( [ , tool ] ) => tool.enabled );
+					const subOrder = SUB_CATEGORY_ORDER[ categoryName ];
+
+					return (
+						<Card key={ categoryName }>
+							<CardBody>
+								<HStack justify="space-between" alignment="center">
+									<Text as="h3" weight={ 600 } size={ 14 }>
+										{ categoryName }
+									</Text>
+									<ToggleControl
+										__nextHasNoMarginBottom
+										checked={ allEnabled }
+										disabled={ mutation.isPending }
+										label={ __( 'Enable all' ) }
+										onChange={ ( checked ) => handleEnableAll( categoryTools, checked ) }
+									/>
+								</HStack>
+							</CardBody>
+							<CardDivider />
+							{ subOrder ? (
+								renderSubGroupedTools( categoryTools, categoryName )
+							) : (
+								<CardBody>
+									<VStack spacing={ 4 }>{ renderToolToggles( categoryTools ) }</VStack>
+								</CardBody>
+							) }
+						</Card>
+					);
+				} ) }
+			</VStack>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/sites/settings-ai-tools/read/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/read/index.tsx
@@ -146,7 +146,7 @@ export default function SiteAIToolsRead() {
 
 		return subGroups.map( ( subName, index ) => (
 			<Fragment key={ subName }>
-				{ index > 0 && <CardDivider className="mcp-settings__sub-divider" /> }
+				{ index > 0 && <CardDivider /> }
 				<CardBody>
 					<VStack spacing={ 4 }>{ renderToolToggles( sortTools( subGrouped[ subName ] ) ) }</VStack>
 				</CardBody>

--- a/client/dashboard/sites/settings-ai-tools/read/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/read/index.tsx
@@ -56,7 +56,21 @@ export default function SiteAIToolsRead() {
 				Object.entries( accountAbilities ).filter( ( [ id ] ) => siteContextToolIds.has( id ) )
 		  )
 		: accountAbilities;
-	const mcpAbilities = mergeSiteMcpAbilities( siteAccountAbilities, siteAbilities );
+	const mergedAbilities = mergeSiteMcpAbilities( siteAccountAbilities, siteAbilities );
+
+	// When there are no site-specific overrides, use site_level_enabled_default as the effective
+	// enabled state for every tool. True when account MCP is on, false when it's disabled for sites.
+	const hasSiteAbilityOverrides = Object.keys( siteAbilities ).length > 0;
+	const defaultToolEnabled =
+		( userSettings as any )?.mcp_abilities?.site_level_enabled_default ?? false;
+	const mcpAbilities = hasSiteAbilityOverrides
+		? mergedAbilities
+		: Object.fromEntries(
+				Object.entries( mergedAbilities ).map( ( [ id, tool ] ) => [
+					id,
+					{ ...tool, enabled: defaultToolEnabled },
+				] )
+		  );
 
 	const allTools = ( Object.entries( mcpAbilities ) as Array< [ string, McpAbility ] > ).filter(
 		( [ , tool ] ) => tool.visible !== false
@@ -73,15 +87,26 @@ export default function SiteAIToolsRead() {
 		},
 	} );
 
+	// When there are no existing overrides, materialize the implicit default alongside the change
+	// so subsequent edits have a full baseline to work from.
+	const buildAbilities = ( overrides: Record< string, boolean > ): Record< string, boolean > => {
+		if ( hasSiteAbilityOverrides ) {
+			return overrides;
+		}
+		const defaults: Record< string, boolean > = {};
+		allTools.forEach( ( [ id ] ) => {
+			defaults[ id ] = defaultToolEnabled;
+		} );
+		return { ...defaults, ...overrides };
+	};
+
 	const handleToolChange = ( toolId: string, enabled: boolean ) => {
 		mutation.mutate( {
 			mcp_abilities: {
 				sites: [
 					{
 						blog_id: site.ID,
-						abilities: {
-							[ toolId ]: enabled,
-						},
+						abilities: buildAbilities( { [ toolId ]: enabled } ),
 					},
 				],
 			},
@@ -89,16 +114,16 @@ export default function SiteAIToolsRead() {
 	};
 
 	const handleEnableAll = ( categoryTools: Array< [ string, McpAbility ] >, enabled: boolean ) => {
-		const abilities: Record< string, boolean > = {};
+		const overrides: Record< string, boolean > = {};
 		categoryTools.forEach( ( [ toolId ] ) => {
-			abilities[ toolId ] = enabled;
+			overrides[ toolId ] = enabled;
 		} );
 		mutation.mutate( {
 			mcp_abilities: {
 				sites: [
 					{
 						blog_id: site.ID,
-						abilities,
+						abilities: buildAbilities( overrides ),
 					},
 				],
 			},
@@ -161,7 +186,7 @@ export default function SiteAIToolsRead() {
 				<PageHeader
 					prefix={ <Breadcrumbs length={ 3 } /> }
 					title={ __( 'Read' ) }
-					description={ __( 'View your sites, posts, and account info.' ) }
+					description={ __( 'View your sites content.' ) }
 				/>
 			}
 		>

--- a/client/dashboard/sites/settings-ai-tools/setup/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/setup/index.tsx
@@ -149,7 +149,7 @@ function SiteAIToolsSetup() {
 		>
 			<ComponentViewTracker eventName="calypso_dashboard_site_ai_tools_setup_view" />
 			<>
-				<Card>
+				<Card className="mcp-setup__choose-agent-card">
 					<CardBody>
 						<SelectControl
 							__next40pxDefaultSize
@@ -167,62 +167,22 @@ function SiteAIToolsSetup() {
 					selectedMcpClient === 'cursor' ) && (
 					<Card>
 						<CardBody>
-							<VStack spacing={ 4 }>
+							<VStack spacing={ 2 }>
 								<SectionHeader level={ 3 } title={ __( 'Quick setup' ) } />
-								{ /* Quick Setup for Claude */ }
-								{ selectedMcpClient === 'claude' && (
-									<ol className="mcp-setup__steps">
-										<li>
-											<Text as="p" variant="muted">
-												{ createInterpolateElement(
-													/* translators: <ClaudeSettings/> is a link to the Claude settings page */
-													__( 'Open <ClaudeSettings/>.' ),
-													{
-														ClaudeSettings: (
-															<ExternalLink href="https://claude.ai/settings/connectors">
-																{ __( 'Claude settings' ) }
-															</ExternalLink>
-														),
-													}
-												) }
-											</Text>
-										</li>
-										<li>
-											<Text as="p" variant="muted">
-												{ __( 'Click "Browse connectors" and search for WordPress.com.' ) }
-											</Text>
-										</li>
-										<li>
-											<Text as="p" variant="muted">
-												{ __( 'Select WordPress.com and follow the prompts.' ) }
-											</Text>
-										</li>
-									</ol>
-								) }
-
-								{ /* Quick Setup for Claude Code */ }
-								{ selectedMcpClient === 'claude-code' && (
-									<VStack spacing={ 4 }>
-										<Text as="p" variant="muted">
-											{ __(
-												'Claude Code uses a different config format with type: "http". Use the CLI or copy the configuration below.'
-											) }
-										</Text>
+								<VStack spacing={ 4 }>
+									{ /* Quick Setup for Claude */ }
+									{ selectedMcpClient === 'claude' && (
 										<ol className="mcp-setup__steps">
 											<li>
 												<Text as="p" variant="muted">
 													{ createInterpolateElement(
-														/* translators: %s is the CLI command to add the MCP server */
-														__( 'Run this command in your terminal: <code>%s</code>' ).replace(
-															'%s',
-															'claude mcp add --transport http wpcom-mcp https://public-api.wordpress.com/wpcom/v2/mcp/v1'
-														),
+														/* translators: <ClaudeSettings/> is a link to the Claude settings page */
+														__( 'Open <ClaudeSettings/>.' ),
 														{
-															code: (
-																<code className="mcp-setup__code" key="claude-code-cmd">
-																	claude mcp add --transport http wpcom-mcp
-																	https://public-api.wordpress.com/wpcom/v2/mcp/v1
-																</code>
+															ClaudeSettings: (
+																<ExternalLink href="https://claude.ai/settings/connectors">
+																	{ __( 'Claude settings' ) }
+																</ExternalLink>
 															),
 														}
 													) }
@@ -230,63 +190,102 @@ function SiteAIToolsSetup() {
 											</li>
 											<li>
 												<Text as="p" variant="muted">
-													{ createInterpolateElement(
-														__(
-															'Or copy the configuration below and add it to your <mcpJson/> or <claudeJson/> file.'
-														),
-														{
-															mcpJson: (
-																<code className="mcp-setup__code" key="mcp-json">
-																	.mcp.json
-																</code>
-															),
-															claudeJson: (
-																<code className="mcp-setup__code" key="claude-json">
-																	~/.claude.json
-																</code>
-															),
-														}
-													) }
+													{ __( 'Click "Browse connectors" and search for WordPress.com.' ) }
 												</Text>
 											</li>
 											<li>
 												<Text as="p" variant="muted">
-													{ createInterpolateElement(
-														__(
-															'In Claude Code, run <code/> to authenticate with your WordPress.com account.'
-														),
-														{
-															code: (
-																<code className="mcp-setup__code" key="mcp-cmd">
-																	/mcp
-																</code>
-															),
-														}
-													) }
+													{ __( 'Select WordPress.com and follow the prompts.' ) }
 												</Text>
 											</li>
 										</ol>
-									</VStack>
-								) }
+									) }
 
-								{ /* Quick Setup for Cursor */ }
-								{ selectedMcpClient === 'cursor' && (
-									<VStack spacing={ 4 }>
-										<Text as="p" variant="muted">
-											{ __(
-												'For Cursor users, use the one-click install to add the WordPress.com MCP app.'
-											) }
-										</Text>
-										<Button
-											variant="primary"
-											href="cursor://anysphere.cursor-deeplink/mcp/install?name=WordPress.com&config=eyJjb21tYW5kIjoibnB4IC15IG1jcC1yZW1vdGUgaHR0cHM6Ly9wdWJsaWMtYXBpLndvcmRwcmVzcy5jb20vd3Bjb20vdjIvbWNwL3YxIn0%3D"
-											target="_blank"
-											className="mcp-setup__action-button"
-										>
-											{ __( 'Install in Cursor' ) }
-										</Button>
-									</VStack>
-								) }
+									{ /* Quick Setup for Claude Code */ }
+									{ selectedMcpClient === 'claude-code' && (
+										<VStack spacing={ 4 }>
+											<Text as="p" variant="muted">
+												{ __(
+													'Claude Code uses a different config format with type: "http". Use the CLI or copy the configuration below.'
+												) }
+											</Text>
+											<ol className="mcp-setup__steps">
+												<li>
+													<Text as="p" variant="muted">
+														{ createInterpolateElement(
+															/* translators: <code/> is replaced with the CLI command to add the MCP server */
+															__( 'Run this command in your terminal: <code/>' ),
+															{
+																code: (
+																	<code className="mcp-setup__code" key="claude-code-cmd">
+																		claude mcp add --transport http wpcom-mcp
+																		https://public-api.wordpress.com/wpcom/v2/mcp/v1
+																	</code>
+																),
+															}
+														) }
+													</Text>
+												</li>
+												<li>
+													<Text as="p" variant="muted">
+														{ createInterpolateElement(
+															__(
+																'Or copy the configuration below and add it to your <mcpJson/> or <claudeJson/> file.'
+															),
+															{
+																mcpJson: (
+																	<code className="mcp-setup__code" key="mcp-json">
+																		.mcp.json
+																	</code>
+																),
+																claudeJson: (
+																	<code className="mcp-setup__code" key="claude-json">
+																		~/.claude.json
+																	</code>
+																),
+															}
+														) }
+													</Text>
+												</li>
+												<li>
+													<Text as="p" variant="muted">
+														{ createInterpolateElement(
+															__(
+																'In Claude Code, run <code/> to authenticate with your WordPress.com account.'
+															),
+															{
+																code: (
+																	<code className="mcp-setup__code" key="mcp-cmd">
+																		/mcp
+																	</code>
+																),
+															}
+														) }
+													</Text>
+												</li>
+											</ol>
+										</VStack>
+									) }
+
+									{ /* Quick Setup for Cursor */ }
+									{ selectedMcpClient === 'cursor' && (
+										<VStack spacing={ 4 }>
+											<Text as="p" variant="muted">
+												{ __(
+													'For Cursor users, use the one-click install to add the WordPress.com MCP app.'
+												) }
+											</Text>
+											<Button
+												variant="primary"
+												href="cursor://anysphere.cursor-deeplink/mcp/install?name=WordPress.com&config=eyJjb21tYW5kIjoibnB4IC15IG1jcC1yZW1vdGUgaHR0cHM6Ly9wdWJsaWMtYXBpLndvcmRwcmVzcy5jb20vd3Bjb20vdjIvbWNwL3YxIn0%3D"
+												target="_blank"
+												className="mcp-setup__action-button"
+											>
+												{ __( 'Install in Cursor' ) }
+											</Button>
+										</VStack>
+									) }
+								</VStack>
 							</VStack>
 						</CardBody>
 					</Card>
@@ -294,7 +293,7 @@ function SiteAIToolsSetup() {
 
 				<Card>
 					<CardBody>
-						<VStack spacing={ 2 }>
+						<VStack spacing={ 1 }>
 							<HStack justify="space-between" alignment="center">
 								<SectionHeader level={ 3 } title={ __( 'Manual setup' ) } />
 								<Button
@@ -305,21 +304,23 @@ function SiteAIToolsSetup() {
 									aria-label={ __( 'Copy configuration to clipboard' ) }
 								/>
 							</HStack>
-							<Text as="p" variant="muted">
-								{ __( 'Copy this configuration into your client\u2019s MCP settings.' ) }
-							</Text>
-							<TextareaControl
-								className="mcp-setup__config-textarea"
-								__nextHasNoMarginBottom
-								value={ JSON.stringify( generateMcpConfig( selectedMcpClient ), null, 2 ) }
-								onChange={ () => {} }
-								readOnly
-							/>
-							{ clientDocumentation[ selectedMcpClient ] && (
-								<ExternalLink href={ clientDocumentation[ selectedMcpClient ] }>
-									{ clientDocumentationLabels[ selectedMcpClient ] }
-								</ExternalLink>
-							) }
+							<VStack spacing={ 2 }>
+								<Text as="p" variant="muted">
+									{ __( 'Copy this configuration into your client\u2019s MCP settings.' ) }
+								</Text>
+								<TextareaControl
+									className="mcp-setup__config-textarea"
+									__nextHasNoMarginBottom
+									value={ JSON.stringify( generateMcpConfig( selectedMcpClient ), null, 2 ) }
+									onChange={ () => {} }
+									readOnly
+								/>
+								{ clientDocumentation[ selectedMcpClient ] && (
+									<ExternalLink href={ clientDocumentation[ selectedMcpClient ] }>
+										{ clientDocumentationLabels[ selectedMcpClient ] }
+									</ExternalLink>
+								) }
+							</VStack>
 						</VStack>
 					</CardBody>
 				</Card>

--- a/client/dashboard/sites/settings-ai-tools/setup/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/setup/index.tsx
@@ -15,6 +15,7 @@ import { copy, check } from '@wordpress/icons';
 import { useState } from 'react';
 import { hasEnabledAccountTools } from '../../../../me/mcp/utils';
 import Breadcrumbs from '../../../app/breadcrumbs';
+import { siteRoute } from '../../../app/router/sites';
 import { Card, CardBody } from '../../../components/card';
 import ComponentViewTracker from '../../../components/component-view-tracker';
 import { PageHeader } from '../../../components/page-header';
@@ -25,6 +26,7 @@ import { SectionHeader } from '../../../components/section-header';
 import '../../../me/mcp/setup/style.scss';
 
 function SiteAIToolsSetup() {
+	const { siteSlug } = siteRoute.useParams();
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 
 	type McpClient = 'claude' | 'claude-code' | 'cursor' | 'vscode' | 'continue' | 'default';
@@ -122,11 +124,11 @@ function SiteAIToolsSetup() {
 									) }
 								</Text>
 								<RouterLinkButton
-									to="/me/preferences/mcp"
+									to={ `/sites/${ siteSlug }/settings/ai-tools` }
 									variant="primary"
 									className="mcp-setup__action-button"
 								>
-									{ __( 'Go to MCP Settings' ) }
+									{ __( 'Go to AI tools settings' ) }
 								</RouterLinkButton>
 							</VStack>
 						</VStack>

--- a/client/dashboard/sites/settings-ai-tools/setup/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/setup/index.tsx
@@ -1,4 +1,4 @@
-import { userSettingsQuery } from '@automattic/api-queries';
+import { userSettingsQuery, siteBySlugQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import {
 	Button,
@@ -13,7 +13,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { copy, check } from '@wordpress/icons';
 import { useState } from 'react';
-import { hasEnabledAccountTools } from '../../../../me/mcp/utils';
+import { getSiteLevelEnabled } from '../../../../me/mcp/utils';
 import Breadcrumbs from '../../../app/breadcrumbs';
 import { siteRoute } from '../../../app/router/sites';
 import { Card, CardBody } from '../../../components/card';
@@ -27,6 +27,7 @@ import '../../../me/mcp/setup/style.scss';
 
 function SiteAIToolsSetup() {
 	const { siteSlug } = siteRoute.useParams();
+	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 
 	type McpClient = 'claude' | 'claude-code' | 'cursor' | 'vscode' | 'continue' | 'default';
@@ -95,9 +96,9 @@ function SiteAIToolsSetup() {
 		}
 	};
 
-	const hasEnabledTools = hasEnabledAccountTools( userSettings || {} );
+	const isSiteMcpEnabled = getSiteLevelEnabled( userSettings || {}, site.ID );
 
-	if ( ! hasEnabledTools ) {
+	if ( ! isSiteMcpEnabled ) {
 		return (
 			<PageLayout
 				size="small"
@@ -116,19 +117,17 @@ function SiteAIToolsSetup() {
 							<SectionHeader level={ 3 } title={ __( 'Setup Required' ) } />
 							<VStack spacing={ 4 }>
 								<Text as="p" variant="muted">
-									{ __( 'No MCP access is currently enabled for your account.' ) }
+									{ __( 'MCP access is not enabled for this site.' ) }
 								</Text>
 								<Text as="p" variant="muted">
-									{ __(
-										'MCP access defines what actions and data your MCP client can access on your account. You need to enable MCP access in the main MCP settings before configuring your client.'
-									) }
+									{ __( 'Enable MCP access for this site before connecting your AI agent.' ) }
 								</Text>
 								<RouterLinkButton
 									to={ `/sites/${ siteSlug }/settings/ai-tools` }
 									variant="primary"
 									className="mcp-setup__action-button"
 								>
-									{ __( 'Go to AI tools settings' ) }
+									{ __( 'Go to Site MCP settings' ) }
 								</RouterLinkButton>
 							</VStack>
 						</VStack>

--- a/client/dashboard/sites/settings-ai-tools/setup/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/setup/index.tsx
@@ -1,0 +1,331 @@
+import { userSettingsQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import {
+	Button,
+	ExternalLink,
+	TextareaControl,
+	SelectControl,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+} from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { copy, check } from '@wordpress/icons';
+import { useState } from 'react';
+import { hasEnabledAccountTools } from '../../../../me/mcp/utils';
+import Breadcrumbs from '../../../app/breadcrumbs';
+import { Card, CardBody } from '../../../components/card';
+import ComponentViewTracker from '../../../components/component-view-tracker';
+import { PageHeader } from '../../../components/page-header';
+import PageLayout from '../../../components/page-layout';
+import RouterLinkButton from '../../../components/router-link-button';
+import { SectionHeader } from '../../../components/section-header';
+
+import '../../../me/mcp/setup/style.scss';
+
+function SiteAIToolsSetup() {
+	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
+
+	type McpClient = 'claude' | 'claude-code' | 'cursor' | 'vscode' | 'continue' | 'default';
+
+	const [ selectedMcpClient, setSelectedMcpClient ] = useState< McpClient >( 'claude' );
+	const [ copyStatus, setCopyStatus ] = useState( 'idle' );
+
+	const mcpClientOptions: Array< { label: string; value: McpClient } > = [
+		{ label: 'Claude', value: 'claude' },
+		{ label: 'Claude Code', value: 'claude-code' },
+		{ label: 'Cursor', value: 'cursor' },
+		{ label: 'VS Code', value: 'vscode' },
+		{ label: 'Continue', value: 'continue' },
+		{ label: __( 'Other MCP client' ), value: 'default' },
+	];
+
+	const clientDocumentation: Record< McpClient, string > = {
+		claude: 'https://docs.claude.com/en/docs/mcp',
+		'claude-code': 'https://code.claude.com/docs/en/mcp',
+		vscode: 'https://code.visualstudio.com/docs/copilot/customization/mcp-servers',
+		cursor: 'https://docs.cursor.com/en/context/mcp',
+		continue: 'https://docs.continue.dev/customize/deep-dives/mcp',
+		default: 'https://modelcontextprotocol.io/docs/develop/connect-local-servers',
+	};
+
+	const clientDocumentationLabels: Record< McpClient, string > = {
+		claude: __( 'Claude documentation' ),
+		'claude-code': __( 'Claude Code documentation' ),
+		vscode: __( 'VS Code documentation' ),
+		cursor: __( 'Cursor documentation' ),
+		continue: __( 'Continue documentation' ),
+		default: __( 'MCP documentation' ),
+	};
+
+	const serverName = 'wpcom-mcp';
+
+	const generateMcpConfig = ( client: McpClient ) => {
+		const baseConfig = {
+			url: 'https://public-api.wordpress.com/wpcom/v2/mcp/v1',
+		};
+
+		switch ( client ) {
+			case 'claude':
+				return { mcpServers: { [ serverName ]: baseConfig } };
+			case 'claude-code':
+				return { mcpServers: { [ serverName ]: { type: 'http', url: baseConfig.url } } };
+			case 'vscode':
+				return { servers: { [ serverName ]: baseConfig } };
+			case 'cursor':
+				return { mcpServers: { [ serverName ]: baseConfig } };
+			case 'continue':
+				return { mcpServers: [ { name: serverName, ...baseConfig } ] };
+			default:
+				return { mcpServers: { [ serverName ]: baseConfig } };
+		}
+	};
+
+	const copyToClipboard = async () => {
+		const configText = JSON.stringify( generateMcpConfig( selectedMcpClient ), null, 2 );
+		try {
+			await navigator.clipboard.writeText( configText );
+			setCopyStatus( 'success' );
+			setTimeout( () => setCopyStatus( 'idle' ), 2000 );
+		} catch {
+			// Silently fail — clipboard access may be blocked
+		}
+	};
+
+	const hasEnabledTools = hasEnabledAccountTools( userSettings || {} );
+
+	if ( ! hasEnabledTools ) {
+		return (
+			<PageLayout
+				size="small"
+				header={
+					<PageHeader
+						title={ __( 'Connect AI agent' ) }
+						description={ __( 'Get instructions for connecting your AI agent.' ) }
+						prefix={ <Breadcrumbs length={ 3 } /> }
+					/>
+				}
+			>
+				<ComponentViewTracker eventName="calypso_dashboard_site_ai_tools_setup_view" />
+				<Card>
+					<CardBody>
+						<VStack spacing={ 4 }>
+							<SectionHeader level={ 3 } title={ __( 'Setup Required' ) } />
+							<VStack spacing={ 4 }>
+								<Text as="p" variant="muted">
+									{ __( 'No MCP access is currently enabled for your account.' ) }
+								</Text>
+								<Text as="p" variant="muted">
+									{ __(
+										'MCP access defines what actions and data your MCP client can access on your account. You need to enable MCP access in the main MCP settings before configuring your client.'
+									) }
+								</Text>
+								<RouterLinkButton
+									to="/me/preferences/mcp"
+									variant="primary"
+									className="mcp-setup__action-button"
+								>
+									{ __( 'Go to MCP Settings' ) }
+								</RouterLinkButton>
+							</VStack>
+						</VStack>
+					</CardBody>
+				</Card>
+			</PageLayout>
+		);
+	}
+
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					title={ __( 'Connect AI agent' ) }
+					description={ __( 'Get instructions for connecting your AI agent.' ) }
+					prefix={ <Breadcrumbs length={ 3 } /> }
+				/>
+			}
+		>
+			<ComponentViewTracker eventName="calypso_dashboard_site_ai_tools_setup_view" />
+			<>
+				<Card>
+					<CardBody>
+						<SelectControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							label={ __( 'Choose your AI agent' ) }
+							value={ selectedMcpClient }
+							options={ mcpClientOptions }
+							onChange={ setSelectedMcpClient }
+						/>
+					</CardBody>
+				</Card>
+
+				{ ( selectedMcpClient === 'claude' ||
+					selectedMcpClient === 'claude-code' ||
+					selectedMcpClient === 'cursor' ) && (
+					<Card>
+						<CardBody>
+							<VStack spacing={ 4 }>
+								<SectionHeader level={ 3 } title={ __( 'Quick setup' ) } />
+								{ /* Quick Setup for Claude */ }
+								{ selectedMcpClient === 'claude' && (
+									<ol className="mcp-setup__steps">
+										<li>
+											<Text as="p" variant="muted">
+												{ createInterpolateElement(
+													/* translators: <ClaudeSettings/> is a link to the Claude settings page */
+													__( 'Open <ClaudeSettings/>.' ),
+													{
+														ClaudeSettings: (
+															<ExternalLink href="https://claude.ai/settings/connectors">
+																{ __( 'Claude settings' ) }
+															</ExternalLink>
+														),
+													}
+												) }
+											</Text>
+										</li>
+										<li>
+											<Text as="p" variant="muted">
+												{ __( 'Click "Browse connectors" and search for WordPress.com.' ) }
+											</Text>
+										</li>
+										<li>
+											<Text as="p" variant="muted">
+												{ __( 'Select WordPress.com and follow the prompts.' ) }
+											</Text>
+										</li>
+									</ol>
+								) }
+
+								{ /* Quick Setup for Claude Code */ }
+								{ selectedMcpClient === 'claude-code' && (
+									<VStack spacing={ 4 }>
+										<Text as="p" variant="muted">
+											{ __(
+												'Claude Code uses a different config format with type: "http". Use the CLI or copy the configuration below.'
+											) }
+										</Text>
+										<ol className="mcp-setup__steps">
+											<li>
+												<Text as="p" variant="muted">
+													{ createInterpolateElement(
+														/* translators: %s is the CLI command to add the MCP server */
+														__( 'Run this command in your terminal: <code>%s</code>' ).replace(
+															'%s',
+															'claude mcp add --transport http wpcom-mcp https://public-api.wordpress.com/wpcom/v2/mcp/v1'
+														),
+														{
+															code: (
+																<code className="mcp-setup__code" key="claude-code-cmd">
+																	claude mcp add --transport http wpcom-mcp
+																	https://public-api.wordpress.com/wpcom/v2/mcp/v1
+																</code>
+															),
+														}
+													) }
+												</Text>
+											</li>
+											<li>
+												<Text as="p" variant="muted">
+													{ createInterpolateElement(
+														__(
+															'Or copy the configuration below and add it to your <mcpJson/> or <claudeJson/> file.'
+														),
+														{
+															mcpJson: (
+																<code className="mcp-setup__code" key="mcp-json">
+																	.mcp.json
+																</code>
+															),
+															claudeJson: (
+																<code className="mcp-setup__code" key="claude-json">
+																	~/.claude.json
+																</code>
+															),
+														}
+													) }
+												</Text>
+											</li>
+											<li>
+												<Text as="p" variant="muted">
+													{ createInterpolateElement(
+														__(
+															'In Claude Code, run <code/> to authenticate with your WordPress.com account.'
+														),
+														{
+															code: (
+																<code className="mcp-setup__code" key="mcp-cmd">
+																	/mcp
+																</code>
+															),
+														}
+													) }
+												</Text>
+											</li>
+										</ol>
+									</VStack>
+								) }
+
+								{ /* Quick Setup for Cursor */ }
+								{ selectedMcpClient === 'cursor' && (
+									<VStack spacing={ 4 }>
+										<Text as="p" variant="muted">
+											{ __(
+												'For Cursor users, use the one-click install to add the WordPress.com MCP app.'
+											) }
+										</Text>
+										<Button
+											variant="primary"
+											href="cursor://anysphere.cursor-deeplink/mcp/install?name=WordPress.com&config=eyJjb21tYW5kIjoibnB4IC15IG1jcC1yZW1vdGUgaHR0cHM6Ly9wdWJsaWMtYXBpLndvcmRwcmVzcy5jb20vd3Bjb20vdjIvbWNwL3YxIn0%3D"
+											target="_blank"
+											className="mcp-setup__action-button"
+										>
+											{ __( 'Install in Cursor' ) }
+										</Button>
+									</VStack>
+								) }
+							</VStack>
+						</CardBody>
+					</Card>
+				) }
+
+				<Card>
+					<CardBody>
+						<VStack spacing={ 2 }>
+							<HStack justify="space-between" alignment="center">
+								<SectionHeader level={ 3 } title={ __( 'Manual setup' ) } />
+								<Button
+									icon={ copyStatus === 'success' ? check : copy }
+									variant="tertiary"
+									iconSize={ 20 }
+									onClick={ copyToClipboard }
+									aria-label={ __( 'Copy configuration to clipboard' ) }
+								/>
+							</HStack>
+							<Text as="p" variant="muted">
+								{ __( 'Copy this configuration into your client\u2019s MCP settings.' ) }
+							</Text>
+							<TextareaControl
+								className="mcp-setup__config-textarea"
+								__nextHasNoMarginBottom
+								value={ JSON.stringify( generateMcpConfig( selectedMcpClient ), null, 2 ) }
+								onChange={ () => {} }
+								readOnly
+							/>
+							{ clientDocumentation[ selectedMcpClient ] && (
+								<ExternalLink href={ clientDocumentation[ selectedMcpClient ] }>
+									{ clientDocumentationLabels[ selectedMcpClient ] }
+								</ExternalLink>
+							) }
+						</VStack>
+					</CardBody>
+				</Card>
+			</>
+		</PageLayout>
+	);
+}
+
+export default SiteAIToolsSetup;

--- a/client/dashboard/sites/settings-ai-tools/style.scss
+++ b/client/dashboard/sites/settings-ai-tools/style.scss
@@ -7,15 +7,25 @@
 	margin: 0;
 }
 
-// Remove the bottom border from the last summary button inside a card to avoid a double border.
-.components-card > .summary-button:last-child {
-	border-bottom: 0;
+// Clip children (summary button hover highlights) to the card's rounded corners,
+// and remove the double bottom border on the last summary button.
+.mcp-settings__access-card {
+	overflow: hidden;
 }
 
-// Inset sub-group dividers on the Read/Write tool pages to align with CardBody content.
-// width: auto overrides the emotion-injected width: 100% so margin-inline takes effect.
+.mcp-settings__access-card .summary-button:last-child {
+	border-bottom: 0 !important;
+}
+
+// Inset sub-group dividers on the Read/Write tool pages to match preferences/mcp/read appearance.
+// Clears the default CardDivider box-shadow in favour of a plain border-top (same as account-level
+// mcp-tools-subpage__sub-divider). width: auto + margin-inline overrides emotion's width: 100%.
 // 24px matches the horizontal padding of a medium-sized CardBody (space(6)).
 hr.mcp-settings__tool-group-divider {
+	background: transparent;
+	border: 0;
+	border-top: 1px solid var( --color-border-subtle );
+	height: 0;
 	width: auto;
 	margin-inline: 24px;
 }

--- a/client/dashboard/sites/settings-ai-tools/style.scss
+++ b/client/dashboard/sites/settings-ai-tools/style.scss
@@ -11,3 +11,8 @@
 .components-card > .summary-button:last-child {
 	border-bottom: 0;
 }
+
+// Inset sub-group dividers on the Read/Write tool pages to align with CardBody content.
+.mcp-settings__tool-group-divider {
+	margin-inline: 16px;
+}

--- a/client/dashboard/sites/settings-ai-tools/style.scss
+++ b/client/dashboard/sites/settings-ai-tools/style.scss
@@ -6,3 +6,8 @@
 	height: 0;
 	margin: 0;
 }
+
+// Remove the bottom border from the last summary button inside a card to avoid a double border.
+.components-card > .summary-button:last-child {
+	border-bottom: 0;
+}

--- a/client/dashboard/sites/settings-ai-tools/style.scss
+++ b/client/dashboard/sites/settings-ai-tools/style.scss
@@ -13,6 +13,9 @@
 }
 
 // Inset sub-group dividers on the Read/Write tool pages to align with CardBody content.
-.mcp-settings__tool-group-divider {
-	margin-inline: 16px;
+// width: auto overrides the emotion-injected width: 100% so margin-inline takes effect.
+// 24px matches the horizontal padding of a medium-sized CardBody (space(6)).
+hr.mcp-settings__tool-group-divider {
+	width: auto;
+	margin-inline: 24px;
 }

--- a/client/dashboard/sites/settings-ai-tools/style.scss
+++ b/client/dashboard/sites/settings-ai-tools/style.scss
@@ -1,0 +1,8 @@
+// Override box-shadow-based hr divider which renders invisibly at zero height.
+.mcp-settings__sub-divider {
+	background: transparent;
+	border: 0;
+	border-top: 1px solid rgba( 0, 0, 0, 0.1 );
+	height: 0;
+	margin: 0;
+}

--- a/client/dashboard/sites/settings-ai-tools/summary.tsx
+++ b/client/dashboard/sites/settings-ai-tools/summary.tsx
@@ -1,7 +1,8 @@
-import { bigSkyPluginQuery } from '@automattic/api-queries';
+import { bigSkyPluginQuery, userSettingsQuery } from '@automattic/api-queries';
 import { BigSkyLogo } from '@automattic/components/src/logos/big-sky-logo';
 import { useQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
+import { getSiteLevelEnabled } from '../../../me/mcp/utils';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
 import type { Site } from '@automattic/api-core';
 import type { Density } from '@automattic/components/src/summary-button/types';
@@ -14,15 +15,17 @@ export default function AISiteToolsSettingsSummary( {
 	density?: Density;
 } ) {
 	const { data: pluginStatus, isLoading } = useQuery( bigSkyPluginQuery( site.ID ) );
+	const { data: userSettings } = useQuery( userSettingsQuery() );
 	const isEnabled = pluginStatus?.enabled ?? false;
 	const isAvailable = pluginStatus?.available ?? false;
+	const isMcpEnabled = getSiteLevelEnabled( userSettings || {}, site.ID );
 
 	const getBadge = () => {
 		if ( isLoading || ! isAvailable ) {
 			return [];
 		}
 
-		if ( isEnabled ) {
+		if ( isEnabled || isMcpEnabled ) {
 			return [
 				{
 					text: __( 'Enabled' ),

--- a/client/dashboard/sites/settings-ai-tools/write/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/write/index.tsx
@@ -56,7 +56,21 @@ export default function SiteAIToolsWrite() {
 				Object.entries( accountAbilities ).filter( ( [ id ] ) => siteContextToolIds.has( id ) )
 		  )
 		: accountAbilities;
-	const mcpAbilities = mergeSiteMcpAbilities( siteAccountAbilities, siteAbilities );
+	const mergedAbilities = mergeSiteMcpAbilities( siteAccountAbilities, siteAbilities );
+
+	// When there are no site-specific overrides, use site_level_enabled_default as the effective
+	// enabled state for every tool. True when account MCP is on, false when it's disabled for sites.
+	const hasSiteAbilityOverrides = Object.keys( siteAbilities ).length > 0;
+	const defaultToolEnabled =
+		( userSettings as any )?.mcp_abilities?.site_level_enabled_default ?? false;
+	const mcpAbilities = hasSiteAbilityOverrides
+		? mergedAbilities
+		: Object.fromEntries(
+				Object.entries( mergedAbilities ).map( ( [ id, tool ] ) => [
+					id,
+					{ ...tool, enabled: defaultToolEnabled },
+				] )
+		  );
 
 	const allTools = ( Object.entries( mcpAbilities ) as Array< [ string, McpAbility ] > ).filter(
 		( [ , tool ] ) => tool.visible !== false
@@ -73,15 +87,26 @@ export default function SiteAIToolsWrite() {
 		},
 	} );
 
+	// When there are no existing overrides, materialize the implicit default alongside the change
+	// so subsequent edits have a full baseline to work from.
+	const buildAbilities = ( overrides: Record< string, boolean > ): Record< string, boolean > => {
+		if ( hasSiteAbilityOverrides ) {
+			return overrides;
+		}
+		const defaults: Record< string, boolean > = {};
+		allTools.forEach( ( [ id ] ) => {
+			defaults[ id ] = defaultToolEnabled;
+		} );
+		return { ...defaults, ...overrides };
+	};
+
 	const handleToolChange = ( toolId: string, enabled: boolean ) => {
 		mutation.mutate( {
 			mcp_abilities: {
 				sites: [
 					{
 						blog_id: site.ID,
-						abilities: {
-							[ toolId ]: enabled,
-						},
+						abilities: buildAbilities( { [ toolId ]: enabled } ),
 					},
 				],
 			},
@@ -89,16 +114,16 @@ export default function SiteAIToolsWrite() {
 	};
 
 	const handleEnableAll = ( categoryTools: Array< [ string, McpAbility ] >, enabled: boolean ) => {
-		const abilities: Record< string, boolean > = {};
+		const overrides: Record< string, boolean > = {};
 		categoryTools.forEach( ( [ toolId ] ) => {
-			abilities[ toolId ] = enabled;
+			overrides[ toolId ] = enabled;
 		} );
 		mutation.mutate( {
 			mcp_abilities: {
 				sites: [
 					{
 						blog_id: site.ID,
-						abilities,
+						abilities: buildAbilities( overrides ),
 					},
 				],
 			},

--- a/client/dashboard/sites/settings-ai-tools/write/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/write/index.tsx
@@ -1,4 +1,6 @@
-import { userSettingsQuery, userSettingsMutation } from '@automattic/api-queries';
+import '../style.scss';
+
+import { userSettingsQuery, userSettingsMutation, siteBySlugQuery } from '@automattic/api-queries';
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import {
 	__experimentalVStack as VStack,
@@ -8,9 +10,15 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Fragment } from 'react';
-import { getAccountMcpAbilities } from '../../../../me/mcp/utils';
+import {
+	getAccountMcpAbilities,
+	getSiteContextToolIds,
+	getSiteMcpAbilities,
+	mergeSiteMcpAbilities,
+} from '../../../../me/mcp/utils';
 import Breadcrumbs from '../../../app/breadcrumbs';
-import { Card, CardBody, CardDivider } from '../../../components/card';
+import { siteRoute } from '../../../app/router/sites';
+import { Card, CardBody, CardDivider, CardHeader } from '../../../components/card';
 import ComponentViewTracker from '../../../components/component-view-tracker';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
@@ -36,8 +44,19 @@ interface McpAbility {
 }
 
 export default function SiteAIToolsWrite() {
+	const { siteSlug } = siteRoute.useParams();
+	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
-	const mcpAbilities = getAccountMcpAbilities( userSettings || {} );
+
+	const accountAbilities = getAccountMcpAbilities( userSettings || {} );
+	const siteContextToolIds = getSiteContextToolIds( userSettings || {} );
+	const siteAbilities = getSiteMcpAbilities( userSettings || {}, site.ID );
+	const siteAccountAbilities = siteContextToolIds.size
+		? Object.fromEntries(
+				Object.entries( accountAbilities ).filter( ( [ id ] ) => siteContextToolIds.has( id ) )
+		  )
+		: accountAbilities;
+	const mcpAbilities = mergeSiteMcpAbilities( siteAccountAbilities, siteAbilities );
 
 	const allTools = ( Object.entries( mcpAbilities ) as Array< [ string, McpAbility ] > ).filter(
 		( [ , tool ] ) => tool.visible !== false
@@ -57,23 +76,33 @@ export default function SiteAIToolsWrite() {
 	const handleToolChange = ( toolId: string, enabled: boolean ) => {
 		mutation.mutate( {
 			mcp_abilities: {
-				account: {
-					[ toolId ]: enabled,
-				},
+				sites: [
+					{
+						blog_id: site.ID,
+						abilities: {
+							[ toolId ]: enabled,
+						},
+					},
+				],
 			},
-		} as any );
+		} );
 	};
 
 	const handleEnableAll = ( categoryTools: Array< [ string, McpAbility ] >, enabled: boolean ) => {
-		const accountAbilities: Record< string, boolean > = {};
+		const abilities: Record< string, boolean > = {};
 		categoryTools.forEach( ( [ toolId ] ) => {
-			accountAbilities[ toolId ] = enabled;
+			abilities[ toolId ] = enabled;
 		} );
 		mutation.mutate( {
 			mcp_abilities: {
-				account: accountAbilities,
+				sites: [
+					{
+						blog_id: site.ID,
+						abilities,
+					},
+				],
 			},
-		} as any );
+		} );
 	};
 
 	// Group tools by display category
@@ -119,17 +148,7 @@ export default function SiteAIToolsWrite() {
 
 		return subGroups.map( ( subName, index ) => (
 			<Fragment key={ subName }>
-				{ index > 0 && (
-					<CardBody style={ { padding: 'calc(4px * 2) calc(4px * 6)' } }>
-						<hr
-							style={ {
-								border: 'none',
-								borderTop: '1px solid var(--color-border-subtle, #dcdcde)',
-								margin: 0,
-							} }
-						/>
-					</CardBody>
-				) }
+				{ index > 0 && <CardDivider className="mcp-settings__sub-divider" /> }
 				<CardBody>
 					<VStack spacing={ 4 }>{ renderToolToggles( sortTools( subGrouped[ subName ] ) ) }</VStack>
 				</CardBody>
@@ -170,7 +189,7 @@ export default function SiteAIToolsWrite() {
 
 					return (
 						<Card key={ categoryName }>
-							<CardBody>
+							<CardHeader>
 								<HStack justify="space-between" alignment="center">
 									<Text as="h3" weight={ 600 } size={ 14 }>
 										{ categoryName }
@@ -183,8 +202,7 @@ export default function SiteAIToolsWrite() {
 										onChange={ ( checked ) => handleEnableAll( categoryTools, checked ) }
 									/>
 								</HStack>
-							</CardBody>
-							<CardDivider />
+							</CardHeader>
 							{ subOrder ? (
 								renderSubGroupedTools( categoryTools, categoryName )
 							) : (

--- a/client/dashboard/sites/settings-ai-tools/write/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/write/index.tsx
@@ -1,0 +1,201 @@
+import { userSettingsQuery, userSettingsMutation } from '@automattic/api-queries';
+import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
+import {
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+	ToggleControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Fragment } from 'react';
+import { getAccountMcpAbilities } from '../../../../me/mcp/utils';
+import Breadcrumbs from '../../../app/breadcrumbs';
+import { Card, CardBody, CardDivider } from '../../../components/card';
+import ComponentViewTracker from '../../../components/component-view-tracker';
+import { PageHeader } from '../../../components/page-header';
+import PageLayout from '../../../components/page-layout';
+import {
+	CATEGORY_ORDER,
+	SUB_CATEGORY_ORDER,
+	getDisplayCategory,
+	getSubCategory,
+	isWriteTool,
+	sortTools,
+} from '../../../me/mcp/categories';
+
+interface McpAbility {
+	title: string;
+	description: string;
+	enabled: boolean;
+	category?: string;
+	category_label?: string;
+	type?: string;
+	readonly?: boolean;
+	visible?: boolean;
+	annotations?: Record< string, unknown >;
+}
+
+export default function SiteAIToolsWrite() {
+	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
+	const mcpAbilities = getAccountMcpAbilities( userSettings || {} );
+
+	const allTools = ( Object.entries( mcpAbilities ) as Array< [ string, McpAbility ] > ).filter(
+		( [ , tool ] ) => tool.visible !== false
+	);
+	const writeTools = allTools.filter( ( [ toolId, tool ] ) => isWriteTool( toolId, tool ) );
+
+	const mutation = useMutation( {
+		...userSettingsMutation(),
+		meta: {
+			snackbar: {
+				success: __( 'MCP settings saved.' ),
+				error: __( 'Failed to save MCP settings.' ),
+			},
+		},
+	} );
+
+	const handleToolChange = ( toolId: string, enabled: boolean ) => {
+		mutation.mutate( {
+			mcp_abilities: {
+				account: {
+					[ toolId ]: enabled,
+				},
+			},
+		} as any );
+	};
+
+	const handleEnableAll = ( categoryTools: Array< [ string, McpAbility ] >, enabled: boolean ) => {
+		const accountAbilities: Record< string, boolean > = {};
+		categoryTools.forEach( ( [ toolId ] ) => {
+			accountAbilities[ toolId ] = enabled;
+		} );
+		mutation.mutate( {
+			mcp_abilities: {
+				account: accountAbilities,
+			},
+		} as any );
+	};
+
+	// Group tools by display category
+	const grouped: Record< string, Array< [ string, McpAbility ] > > = {};
+	writeTools.forEach( ( [ toolId, tool ] ) => {
+		const category = getDisplayCategory( toolId, tool );
+		if ( ! grouped[ category ] ) {
+			grouped[ category ] = [];
+		}
+		grouped[ category ].push( [ toolId, tool ] );
+	} );
+
+	const hasWriteTools = writeTools.length > 0;
+
+	const renderToolToggles = ( tools: Array< [ string, McpAbility ] > ) =>
+		tools.map( ( [ toolId, tool ] ) => (
+			<ToggleControl
+				key={ toolId }
+				__nextHasNoMarginBottom
+				checked={ tool.enabled }
+				disabled={ mutation.isPending }
+				label={ tool.title }
+				help={ tool.description }
+				onChange={ ( checked ) => handleToolChange( toolId, checked ) }
+			/>
+		) );
+
+	const renderSubGroupedTools = (
+		categoryTools: Array< [ string, McpAbility ] >,
+		categoryName: string
+	) => {
+		const subGrouped: Record< string, Array< [ string, McpAbility ] > > = {};
+		categoryTools.forEach( ( [ toolId, tool ] ) => {
+			const sub = getSubCategory( toolId, tool ) ?? '';
+			if ( ! subGrouped[ sub ] ) {
+				subGrouped[ sub ] = [];
+			}
+			subGrouped[ sub ].push( [ toolId, tool ] );
+		} );
+
+		const order = SUB_CATEGORY_ORDER[ categoryName ] ?? [];
+		const subGroups = order.filter( ( sub ) => subGrouped[ sub ] && subGrouped[ sub ].length > 0 );
+
+		return subGroups.map( ( subName, index ) => (
+			<Fragment key={ subName }>
+				{ index > 0 && (
+					<CardBody style={ { padding: 'calc(4px * 2) calc(4px * 6)' } }>
+						<hr
+							style={ {
+								border: 'none',
+								borderTop: '1px solid var(--color-border-subtle, #dcdcde)',
+								margin: 0,
+							} }
+						/>
+					</CardBody>
+				) }
+				<CardBody>
+					<VStack spacing={ 4 }>{ renderToolToggles( sortTools( subGrouped[ subName ] ) ) }</VStack>
+				</CardBody>
+			</Fragment>
+		) );
+	};
+
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					prefix={ <Breadcrumbs length={ 3 } /> }
+					title={ __( 'Write' ) }
+					description={ __( 'Create, update, and manage content on your sites.' ) }
+				/>
+			}
+		>
+			<ComponentViewTracker eventName="calypso_dashboard_site_ai_tools_write_view" />
+			<VStack spacing={ 4 }>
+				{ ! hasWriteTools && (
+					<Card>
+						<CardBody>
+							<Text variant="muted">
+								{ __( 'No write tools are available for your account.' ) }
+							</Text>
+						</CardBody>
+					</Card>
+				) }
+				{ CATEGORY_ORDER.map( ( categoryName ) => {
+					const categoryTools = grouped[ categoryName ];
+					if ( ! categoryTools || categoryTools.length === 0 ) {
+						return null;
+					}
+
+					const allEnabled = categoryTools.every( ( [ , tool ] ) => tool.enabled );
+					const subOrder = SUB_CATEGORY_ORDER[ categoryName ];
+
+					return (
+						<Card key={ categoryName }>
+							<CardBody>
+								<HStack justify="space-between" alignment="center">
+									<Text as="h3" weight={ 600 } size={ 14 }>
+										{ categoryName }
+									</Text>
+									<ToggleControl
+										__nextHasNoMarginBottom
+										checked={ allEnabled }
+										disabled={ mutation.isPending }
+										label={ __( 'Enable all' ) }
+										onChange={ ( checked ) => handleEnableAll( categoryTools, checked ) }
+									/>
+								</HStack>
+							</CardBody>
+							<CardDivider />
+							{ subOrder ? (
+								renderSubGroupedTools( categoryTools, categoryName )
+							) : (
+								<CardBody>
+									<VStack spacing={ 4 }>{ renderToolToggles( categoryTools ) }</VStack>
+								</CardBody>
+							) }
+						</Card>
+					);
+				} ) }
+			</VStack>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/sites/settings-ai-tools/write/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/write/index.tsx
@@ -148,7 +148,7 @@ export default function SiteAIToolsWrite() {
 
 		return subGroups.map( ( subName, index ) => (
 			<Fragment key={ subName }>
-				{ index > 0 && <CardDivider /> }
+				{ index > 0 && <CardDivider className="mcp-settings__tool-group-divider" /> }
 				<CardBody>
 					<VStack spacing={ 4 }>{ renderToolToggles( sortTools( subGrouped[ subName ] ) ) }</VStack>
 				</CardBody>

--- a/client/dashboard/sites/settings-ai-tools/write/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/write/index.tsx
@@ -148,7 +148,7 @@ export default function SiteAIToolsWrite() {
 
 		return subGroups.map( ( subName, index ) => (
 			<Fragment key={ subName }>
-				{ index > 0 && <CardDivider className="mcp-settings__sub-divider" /> }
+				{ index > 0 && <CardDivider /> }
 				<CardBody>
 					<VStack spacing={ 4 }>{ renderToolToggles( sortTools( subGrouped[ subName ] ) ) }</VStack>
 				</CardBody>

--- a/client/me/mcp/main.jsx
+++ b/client/me/mcp/main.jsx
@@ -92,7 +92,7 @@ function McpComponent( { path } ) {
 		const disabledSiteIds = getDisabledSiteIds( userSettings || {} );
 		const enabledSiteIds = getEnabledSiteIds( userSettings || {} );
 		const sitesToReset = [
-			...disabledSiteIds.map( ( id ) => ( { blog_id: id, account_tools_enabled: true } ) ),
+			...disabledSiteIds.map( ( id ) => ( { blog_id: id, site_level_enabled: true } ) ),
 			...enabledSiteIds.map( ( id ) => ( { blog_id: id, site_level_enabled: false } ) ),
 		];
 

--- a/client/me/mcp/main.jsx
+++ b/client/me/mcp/main.jsx
@@ -162,7 +162,7 @@ function McpComponent( { path } ) {
 					</VStack>
 
 					{ /* TODO: Restore when site-level MCP PRs land */ }
-					{ false && hasTools && ! anyToolsEnabled && (
+					{ hasTools && ! anyToolsEnabled && (
 						<VStack spacing={ 0 } className="mcp-hub__panel-rows">
 							{ ! isLoadingSites && (
 								<SummaryButton

--- a/client/me/mcp/main.jsx
+++ b/client/me/mcp/main.jsx
@@ -89,17 +89,9 @@ function McpComponent( { path } ) {
 			accountAbilities[ toolId ] = enabled ? isReadTool( mcpAbilities[ toolId ] ) : false;
 		} );
 
-		const disabledSiteIds = getDisabledSiteIds( userSettings || {} );
-		const enabledSiteIds = getEnabledSiteIds( userSettings || {} );
-		const sitesToReset = [
-			...disabledSiteIds.map( ( id ) => ( { blog_id: id, site_level_enabled: true } ) ),
-			...enabledSiteIds.map( ( id ) => ( { blog_id: id, site_level_enabled: false } ) ),
-		];
-
 		mutation.mutate( {
 			mcp_abilities: {
 				account: accountAbilities,
-				...( sitesToReset.length > 0 && { sites: sitesToReset } ),
 			},
 		} );
 	};

--- a/client/me/mcp/mcp-add-site.jsx
+++ b/client/me/mcp/mcp-add-site.jsx
@@ -258,7 +258,7 @@ export default function McpAddSitePage( { path } ) {
 														<HStack spacing={ 4 } justify="flex-end" expanded={ false }>
 															{ slug && (
 																<Button
-																	variant="link"
+																	variant="tertiary"
 																	size="compact"
 																	href={ `/sites/${ slug }/settings/ai-tools` }
 																>

--- a/client/me/mcp/mcp-add-site.jsx
+++ b/client/me/mcp/mcp-add-site.jsx
@@ -138,7 +138,7 @@ export default function McpAddSitePage( { path } ) {
 				sites: [
 					{
 						blog_id: siteId,
-						site_level_enabled: false,
+						site_level_enabled: null,
 					},
 				],
 			},

--- a/client/me/mcp/mcp-sites.jsx
+++ b/client/me/mcp/mcp-sites.jsx
@@ -120,7 +120,7 @@ export default function McpSitesPage( { path } ) {
 				sites: [
 					{
 						blog_id: blogId,
-						account_tools_enabled: false,
+						site_level_enabled: false,
 					},
 				],
 			},
@@ -133,7 +133,7 @@ export default function McpSitesPage( { path } ) {
 				sites: [
 					{
 						blog_id: siteId,
-						account_tools_enabled: true,
+						site_level_enabled: true,
 					},
 				],
 			},

--- a/client/me/mcp/mcp-sites.jsx
+++ b/client/me/mcp/mcp-sites.jsx
@@ -133,7 +133,7 @@ export default function McpSitesPage( { path } ) {
 				sites: [
 					{
 						blog_id: siteId,
-						site_level_enabled: true,
+						site_level_enabled: null,
 					},
 				],
 			},

--- a/client/me/mcp/utils.js
+++ b/client/me/mcp/utils.js
@@ -133,22 +133,22 @@ export function getDisabledSiteIds( userSettings ) {
 
 /**
  * Check if the site-level MCP server is enabled for a specific site.
- * Absent means off (default); only true when site_level_enabled is explicitly true.
+ * Uses site_level_enabled from the site's entry if present, otherwise
+ * falls back to mcp_abilities.site_level_enabled_default.
  * @param {Object} userSettings - The user settings object
  * @param {string|number} siteId - The site ID
  * @returns {boolean}
  */
 export function getSiteLevelEnabled( userSettings, siteId ) {
-	if ( userSettings?.sites ) {
-		const siteEntry = userSettings.sites.find( ( site ) => site.blog_id === parseInt( siteId ) );
-		if ( siteEntry ) {
-			return siteEntry.site_level_enabled === true;
-		}
+	const mcpAbilities = userSettings?.mcp_abilities;
+	const mcpSites = mcpAbilities?.sites || [];
+	const siteEntry = mcpSites.find( ( site ) => site.blog_id === parseInt( siteId ) );
+
+	if ( siteEntry ) {
+		return siteEntry.site_level_enabled === true;
 	}
 
-	const mcpSites = userSettings?.mcp_abilities?.sites || [];
-	const siteEntry = mcpSites.find( ( site ) => site.blog_id === parseInt( siteId ) );
-	return siteEntry?.site_level_enabled === true;
+	return mcpAbilities?.site_level_enabled_default === true;
 }
 
 /**

--- a/client/me/mcp/utils.js
+++ b/client/me/mcp/utils.js
@@ -73,6 +73,47 @@ export function getSiteAccountToolsEnabled( userSettings, siteId ) {
 }
 
 /**
+ * Get the set of tool IDs that are relevant in a site context.
+ * Uses mcp_abilities.site as the authoritative list of site-applicable tools.
+ * @param {Object} userSettings - The user settings object
+ * @returns {Set<string>} Tool IDs relevant at the site level
+ */
+export function getSiteContextToolIds( userSettings ) {
+	const siteTools = userSettings?.mcp_abilities?.site || {};
+	return new Set( Object.keys( siteTools ) );
+}
+
+/**
+ * Get site-level MCP ability overrides for a specific site
+ * @param {Object} userSettings - The user settings object
+ * @param {string|number} siteId - The site ID
+ * @returns {Record<string, boolean>} Site-level ability overrides (toolId -> enabled)
+ */
+export function getSiteMcpAbilities( userSettings, siteId ) {
+	const mcpSites = userSettings?.mcp_abilities?.sites || [];
+	const siteEntry = mcpSites.find( ( site ) => site.blog_id === parseInt( siteId ) );
+	return siteEntry?.abilities || {};
+}
+
+/**
+ * Merge account-level MCP abilities with site-level overrides
+ * @param {Record<string, Object>} accountAbilities - Account-level abilities from getAccountMcpAbilities
+ * @param {Record<string, boolean>} siteAbilities - Site-level overrides from getSiteMcpAbilities
+ * @returns {Record<string, Object>} Merged abilities with site overrides taking precedence
+ */
+export function mergeSiteMcpAbilities( accountAbilities, siteAbilities ) {
+	return Object.fromEntries(
+		Object.entries( accountAbilities ).map( ( [ toolId, tool ] ) => [
+			toolId,
+			{
+				...tool,
+				enabled: toolId in siteAbilities ? siteAbilities[ toolId ] : tool.enabled,
+			},
+		] )
+	);
+}
+
+/**
  * Get site IDs where MCP access is disabled at the site level
  * @param {Object} userSettings - The user settings object
  * @returns {number[]} Site IDs with account tools disabled
@@ -88,6 +129,26 @@ export function getDisabledSiteIds( userSettings ) {
 	return mcpSites
 		.filter( ( site ) => site.account_tools_enabled === false )
 		.map( ( site ) => site.blog_id );
+}
+
+/**
+ * Check if the site-level MCP server is enabled for a specific site.
+ * Absent means off (default); only true when site_level_enabled is explicitly true.
+ * @param {Object} userSettings - The user settings object
+ * @param {string|number} siteId - The site ID
+ * @returns {boolean}
+ */
+export function getSiteLevelEnabled( userSettings, siteId ) {
+	if ( userSettings?.sites ) {
+		const siteEntry = userSettings.sites.find( ( site ) => site.blog_id === parseInt( siteId ) );
+		if ( siteEntry ) {
+			return siteEntry.site_level_enabled === true;
+		}
+	}
+
+	const mcpSites = userSettings?.mcp_abilities?.sites || [];
+	const siteEntry = mcpSites.find( ( site ) => site.blog_id === parseInt( siteId ) );
+	return siteEntry?.site_level_enabled === true;
 }
 
 /**

--- a/client/me/mcp/utils.js
+++ b/client/me/mcp/utils.js
@@ -114,20 +114,15 @@ export function mergeSiteMcpAbilities( accountAbilities, siteAbilities ) {
 }
 
 /**
- * Get site IDs where MCP access is disabled at the site level
+ * Get site IDs where site-level MCP access is explicitly disabled.
+ * These appear as exceptions when the account default is enabled.
  * @param {Object} userSettings - The user settings object
- * @returns {number[]} Site IDs with account tools disabled
+ * @returns {number[]} Site IDs with site_level_enabled set to false
  */
 export function getDisabledSiteIds( userSettings ) {
-	if ( userSettings?.sites ) {
-		return userSettings.sites
-			.filter( ( site ) => site.account_tools_enabled === false )
-			.map( ( site ) => site.blog_id );
-	}
-
 	const mcpSites = userSettings?.mcp_abilities?.sites || [];
 	return mcpSites
-		.filter( ( site ) => site.account_tools_enabled === false )
+		.filter( ( site ) => site.site_level_enabled === false )
 		.map( ( site ) => site.blog_id );
 }
 

--- a/client/sites/index.tsx
+++ b/client/sites/index.tsx
@@ -25,6 +25,22 @@ export default function () {
 		return page.redirect( `/sites/${ context.params.site }/settings` );
 	} );
 
+	// `/:feature?` is a single segment; nested paths like `ai-tools/read` must be registered explicitly
+	// or page.js will not match after TanStack sync calls `page.show()` → embed unmounts (blank screen).
+	const dashboardBackportSiteSettingsStack = [
+		siteSelection,
+		setupPreferences,
+		maybeRedirectToMultiSiteDashboard(),
+		navigation,
+		dashboardBackportSiteSettings,
+		siteDashboard( SETTINGS_SITE ),
+		makeLayout,
+		clientRender,
+	];
+	page( '/sites/:site/settings/ai-tools/read', ...dashboardBackportSiteSettingsStack );
+	page( '/sites/:site/settings/ai-tools/write', ...dashboardBackportSiteSettingsStack );
+	page( '/sites/:site/settings/ai-tools/setup', ...dashboardBackportSiteSettingsStack );
+
 	page(
 		'/sites/:site/settings/:feature?',
 		siteSelection,

--- a/client/sites/v2/site-settings/router.tsx
+++ b/client/sites/v2/site-settings/router.tsx
@@ -37,7 +37,8 @@ const siteVisibilityRoute = createRoute( {
 
 const aiToolsLayoutRoute = createRoute( {
 	// Bypass type issue by omitting the loader and head (both are typed against the dashboard router context).
-	...Object.assign( appRouterSites.siteSettingsAIToolsRoute.options, {
+	// Use an empty object as the first arg to avoid mutating the shared options object.
+	...Object.assign( {}, appRouterSites.siteSettingsAIToolsRoute.options, {
 		loader: undefined,
 		head: undefined,
 	} ),
@@ -151,7 +152,7 @@ const phpRoute = createRoute( {
 
 const databaseRoute = createRoute( {
 	// Bypass type issue by omitting the loader.
-	...Object.assign( appRouterSites.siteSettingsDatabaseRoute.options, { loader: undefined } ),
+	...Object.assign( {}, appRouterSites.siteSettingsDatabaseRoute.options, { loader: undefined } ),
 	getParentRoute: () => settingsRoute,
 } ).lazy( () =>
 	import( 'calypso/dashboard/sites/settings-database' ).then( ( d ) =>
@@ -240,7 +241,9 @@ const sftpSshRoute = createRoute( {
 
 const transferSiteRoute = createRoute( {
 	// Bypass type issue by omitting the loader.
-	...Object.assign( appRouterSites.siteSettingsTransferSiteRoute.options, { loader: undefined } ),
+	...Object.assign( {}, appRouterSites.siteSettingsTransferSiteRoute.options, {
+		loader: undefined,
+	} ),
 	getParentRoute: () => settingsRoute,
 } ).lazy( () =>
 	import( 'calypso/dashboard/sites/settings-transfer-site' ).then( ( d ) =>

--- a/client/sites/v2/site-settings/router.tsx
+++ b/client/sites/v2/site-settings/router.tsx
@@ -37,21 +37,13 @@ const siteVisibilityRoute = createRoute( {
 );
 
 const aiToolsLayoutRoute = createRoute( {
-	// Bypass type issue by omitting the loader and head (both are typed against the dashboard router context).
-	// Use an empty object as the first arg to avoid mutating the shared options object.
-	...Object.assign( {}, appRouterSites.siteSettingsAIToolsRoute.options, {
-		loader: undefined,
-		head: undefined,
-	} ),
+	path: 'ai-tools',
 	getParentRoute: () => settingsRoute,
 	head: () => ( { meta: [ { title: __( 'AI tools' ) } ] } ),
 } );
 
-const { getParentRoute: _aiToolsIndexParent, ...aiToolsIndexRouteOptions } =
-	appRouterSites.siteSettingsAIToolsIndexRoute.options;
-
 const aiToolsIndexRoute = createRoute( {
-	...aiToolsIndexRouteOptions,
+	path: '/',
 	getParentRoute: () => aiToolsLayoutRoute,
 } ).lazy( () =>
 	import( 'calypso/dashboard/sites/settings-ai-tools' ).then( ( d ) =>
@@ -61,15 +53,8 @@ const aiToolsIndexRoute = createRoute( {
 	)
 );
 
-const {
-	getParentRoute: _aiToolsReadParent,
-	loader: _aiToolsReadLoader,
-	head: _aiToolsReadHead,
-	...aiToolsReadRouteOptions
-} = appRouterSites.siteSettingsAIToolsReadRoute.options;
-
 const aiToolsReadRoute = createRoute( {
-	...aiToolsReadRouteOptions,
+	path: 'read',
 	getParentRoute: () => aiToolsLayoutRoute,
 	head: () => ( { meta: [ { title: __( 'Read' ) } ] } ),
 } ).lazy( () =>
@@ -80,15 +65,8 @@ const aiToolsReadRoute = createRoute( {
 	)
 );
 
-const {
-	getParentRoute: _aiToolsWriteParent,
-	loader: _aiToolsWriteLoader,
-	head: _aiToolsWriteHead,
-	...aiToolsWriteRouteOptions
-} = appRouterSites.siteSettingsAIToolsWriteRoute.options;
-
 const aiToolsWriteRoute = createRoute( {
-	...aiToolsWriteRouteOptions,
+	path: 'write',
 	getParentRoute: () => aiToolsLayoutRoute,
 	head: () => ( { meta: [ { title: __( 'Write' ) } ] } ),
 } ).lazy( () =>
@@ -99,15 +77,8 @@ const aiToolsWriteRoute = createRoute( {
 	)
 );
 
-const {
-	getParentRoute: _aiToolsSetupParent,
-	loader: _aiToolsSetupLoader,
-	head: _aiToolsSetupHead,
-	...aiToolsSetupRouteOptions
-} = appRouterSites.siteSettingsAIToolsSetupRoute.options;
-
 const aiToolsSetupRoute = createRoute( {
-	...aiToolsSetupRouteOptions,
+	path: 'setup',
 	getParentRoute: () => aiToolsLayoutRoute,
 	head: () => ( { meta: [ { title: __( 'Connect AI agent' ) } ] } ),
 } ).lazy( () =>

--- a/client/sites/v2/site-settings/router.tsx
+++ b/client/sites/v2/site-settings/router.tsx
@@ -51,7 +51,6 @@ const { getParentRoute: _aiToolsIndexParent, ...aiToolsIndexRouteOptions } =
 const aiToolsIndexRoute = createRoute( {
 	...aiToolsIndexRouteOptions,
 	getParentRoute: () => aiToolsLayoutRoute,
-	path: 'ai-tools',
 } ).lazy( () =>
 	import( 'calypso/dashboard/sites/settings-ai-tools' ).then( ( d ) =>
 		createLazyRoute( 'ai-tools' )( {
@@ -70,7 +69,6 @@ const {
 const aiToolsReadRoute = createRoute( {
 	...aiToolsReadRouteOptions,
 	getParentRoute: () => aiToolsLayoutRoute,
-	path: 'ai-tools/read',
 } ).lazy( () =>
 	import( 'calypso/dashboard/sites/settings-ai-tools/read' ).then( ( d ) =>
 		createLazyRoute( 'site-settings-ai-tools-read-v2' )( {
@@ -89,7 +87,6 @@ const {
 const aiToolsWriteRoute = createRoute( {
 	...aiToolsWriteRouteOptions,
 	getParentRoute: () => aiToolsLayoutRoute,
-	path: 'ai-tools/write',
 } ).lazy( () =>
 	import( 'calypso/dashboard/sites/settings-ai-tools/write' ).then( ( d ) =>
 		createLazyRoute( 'site-settings-ai-tools-write-v2' )( {
@@ -108,7 +105,6 @@ const {
 const aiToolsSetupRoute = createRoute( {
 	...aiToolsSetupRouteOptions,
 	getParentRoute: () => aiToolsLayoutRoute,
-	path: 'ai-tools/setup',
 } ).lazy( () =>
 	import( 'calypso/dashboard/sites/settings-ai-tools/setup' ).then( ( d ) =>
 		createLazyRoute( 'site-settings-ai-tools-setup-v2' )( {

--- a/client/sites/v2/site-settings/router.tsx
+++ b/client/sites/v2/site-settings/router.tsx
@@ -36,7 +36,11 @@ const siteVisibilityRoute = createRoute( {
 );
 
 const aiToolsLayoutRoute = createRoute( {
-	...appRouterSites.siteSettingsAIToolsRoute.options,
+	// Bypass type issue by omitting the loader and head (both are typed against the dashboard router context).
+	...Object.assign( appRouterSites.siteSettingsAIToolsRoute.options, {
+		loader: undefined,
+		head: undefined,
+	} ),
 	getParentRoute: () => settingsRoute,
 } );
 
@@ -55,8 +59,12 @@ const aiToolsIndexRoute = createRoute( {
 	)
 );
 
-const { getParentRoute: _aiToolsReadParent, ...aiToolsReadRouteOptions } =
-	appRouterSites.siteSettingsAIToolsReadRoute.options;
+const {
+	getParentRoute: _aiToolsReadParent,
+	loader: _aiToolsReadLoader,
+	head: _aiToolsReadHead,
+	...aiToolsReadRouteOptions
+} = appRouterSites.siteSettingsAIToolsReadRoute.options;
 
 const aiToolsReadRoute = createRoute( {
 	...aiToolsReadRouteOptions,
@@ -70,8 +78,12 @@ const aiToolsReadRoute = createRoute( {
 	)
 );
 
-const { getParentRoute: _aiToolsWriteParent, ...aiToolsWriteRouteOptions } =
-	appRouterSites.siteSettingsAIToolsWriteRoute.options;
+const {
+	getParentRoute: _aiToolsWriteParent,
+	loader: _aiToolsWriteLoader,
+	head: _aiToolsWriteHead,
+	...aiToolsWriteRouteOptions
+} = appRouterSites.siteSettingsAIToolsWriteRoute.options;
 
 const aiToolsWriteRoute = createRoute( {
 	...aiToolsWriteRouteOptions,
@@ -85,8 +97,12 @@ const aiToolsWriteRoute = createRoute( {
 	)
 );
 
-const { getParentRoute: _aiToolsSetupParent, ...aiToolsSetupRouteOptions } =
-	appRouterSites.siteSettingsAIToolsSetupRoute.options;
+const {
+	getParentRoute: _aiToolsSetupParent,
+	loader: _aiToolsSetupLoader,
+	head: _aiToolsSetupHead,
+	...aiToolsSetupRouteOptions
+} = appRouterSites.siteSettingsAIToolsSetupRoute.options;
 
 const aiToolsSetupRoute = createRoute( {
 	...aiToolsSetupRouteOptions,

--- a/client/sites/v2/site-settings/router.tsx
+++ b/client/sites/v2/site-settings/router.tsx
@@ -35,13 +35,67 @@ const siteVisibilityRoute = createRoute( {
 	)
 );
 
-const aiToolsRoute = createRoute( {
+const aiToolsLayoutRoute = createRoute( {
 	...appRouterSites.siteSettingsAIToolsRoute.options,
 	getParentRoute: () => settingsRoute,
+} );
+
+const { getParentRoute: _aiToolsIndexParent, ...aiToolsIndexRouteOptions } =
+	appRouterSites.siteSettingsAIToolsIndexRoute.options;
+
+const aiToolsIndexRoute = createRoute( {
+	...aiToolsIndexRouteOptions,
+	getParentRoute: () => aiToolsLayoutRoute,
+	path: 'ai-tools',
 } ).lazy( () =>
 	import( 'calypso/dashboard/sites/settings-ai-tools' ).then( ( d ) =>
 		createLazyRoute( 'ai-tools' )( {
 			component: () => <d.default siteSlug={ siteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
+const { getParentRoute: _aiToolsReadParent, ...aiToolsReadRouteOptions } =
+	appRouterSites.siteSettingsAIToolsReadRoute.options;
+
+const aiToolsReadRoute = createRoute( {
+	...aiToolsReadRouteOptions,
+	getParentRoute: () => aiToolsLayoutRoute,
+	path: 'ai-tools/read',
+} ).lazy( () =>
+	import( 'calypso/dashboard/sites/settings-ai-tools/read' ).then( ( d ) =>
+		createLazyRoute( 'site-settings-ai-tools-read-v2' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const { getParentRoute: _aiToolsWriteParent, ...aiToolsWriteRouteOptions } =
+	appRouterSites.siteSettingsAIToolsWriteRoute.options;
+
+const aiToolsWriteRoute = createRoute( {
+	...aiToolsWriteRouteOptions,
+	getParentRoute: () => aiToolsLayoutRoute,
+	path: 'ai-tools/write',
+} ).lazy( () =>
+	import( 'calypso/dashboard/sites/settings-ai-tools/write' ).then( ( d ) =>
+		createLazyRoute( 'site-settings-ai-tools-write-v2' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const { getParentRoute: _aiToolsSetupParent, ...aiToolsSetupRouteOptions } =
+	appRouterSites.siteSettingsAIToolsSetupRoute.options;
+
+const aiToolsSetupRoute = createRoute( {
+	...aiToolsSetupRouteOptions,
+	getParentRoute: () => aiToolsLayoutRoute,
+	path: 'ai-tools/setup',
+} ).lazy( () =>
+	import( 'calypso/dashboard/sites/settings-ai-tools/setup' ).then( ( d ) =>
+		createLazyRoute( 'site-settings-ai-tools-setup-v2' )( {
+			component: d.default,
 		} )
 	)
 );
@@ -208,7 +262,12 @@ const createRouteTree = () =>
 			settingsRoute.addChildren( [
 				settingsIndexRoute,
 				siteVisibilityRoute,
-				aiToolsRoute,
+				aiToolsLayoutRoute.addChildren( [
+					aiToolsIndexRoute,
+					aiToolsReadRoute,
+					aiToolsWriteRoute,
+					aiToolsSetupRoute,
+				] ),
 				subscriptionGiftingRoute,
 				wordpressRoute,
 				phpRoute,

--- a/client/sites/v2/site-settings/router.tsx
+++ b/client/sites/v2/site-settings/router.tsx
@@ -1,5 +1,6 @@
 import calypsoConfig from '@automattic/calypso-config';
 import { Router, createLazyRoute, createRoute } from '@tanstack/react-router';
+import { __ } from '@wordpress/i18n';
 import { APP_CONTEXT_DEFAULT_CONFIG } from 'calypso/dashboard/app/context';
 import { handleOnCatch } from 'calypso/dashboard/app/logger';
 import * as appRouterSites from 'calypso/dashboard/app/router/sites';
@@ -43,6 +44,7 @@ const aiToolsLayoutRoute = createRoute( {
 		head: undefined,
 	} ),
 	getParentRoute: () => settingsRoute,
+	head: () => ( { meta: [ { title: __( 'AI tools' ) } ] } ),
 } );
 
 const { getParentRoute: _aiToolsIndexParent, ...aiToolsIndexRouteOptions } =
@@ -69,6 +71,7 @@ const {
 const aiToolsReadRoute = createRoute( {
 	...aiToolsReadRouteOptions,
 	getParentRoute: () => aiToolsLayoutRoute,
+	head: () => ( { meta: [ { title: __( 'Read' ) } ] } ),
 } ).lazy( () =>
 	import( 'calypso/dashboard/sites/settings-ai-tools/read' ).then( ( d ) =>
 		createLazyRoute( 'site-settings-ai-tools-read-v2' )( {
@@ -87,6 +90,7 @@ const {
 const aiToolsWriteRoute = createRoute( {
 	...aiToolsWriteRouteOptions,
 	getParentRoute: () => aiToolsLayoutRoute,
+	head: () => ( { meta: [ { title: __( 'Write' ) } ] } ),
 } ).lazy( () =>
 	import( 'calypso/dashboard/sites/settings-ai-tools/write' ).then( ( d ) =>
 		createLazyRoute( 'site-settings-ai-tools-write-v2' )( {
@@ -105,6 +109,7 @@ const {
 const aiToolsSetupRoute = createRoute( {
 	...aiToolsSetupRouteOptions,
 	getParentRoute: () => aiToolsLayoutRoute,
+	head: () => ( { meta: [ { title: __( 'Connect AI agent' ) } ] } ),
 } ).lazy( () =>
 	import( 'calypso/dashboard/sites/settings-ai-tools/setup' ).then( ( d ) =>
 		createLazyRoute( 'site-settings-ai-tools-setup-v2' )( {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/AIINT-324/site-ai-tools-add-readwrite-mcp-sub-pages-to-site-settings

## Proposed Changes

### New sub-pages under `client/dashboard/sites/settings-ai-tools/`
* **Read** (`ai-tools/read`) — per-tool toggles for read-access tools, grouped by category with "Enable all" per group
* **Write** (`ai-tools/write`) — same pattern for write tools
* **Setup** (`ai-tools/setup`) — MCP client connection instructions (agent selector, quick-setup steps, manual config copy block)

### Site AI tools hub (`ai-tools/`)
* Shows **Read** and **Write** navigation rows (with enabled/disabled badges and icons) when MCP is enabled for a site, plus a **Connect external AI agent** button
* Badges reflect real per-tool state when site-level ability overrides exist, or fall back to `site_level_enabled_default` when the site is in its default state
* Gating: Read/Write/Setup rows only visible when `isMcpEnabled` is true for the site

### Site-level MCP toggle behaviour
* **Enable** → sets `site_level_enabled: true` and auto-enables all read tools; write tools left unset
* **Disable** → sets `site_level_enabled: false` and clears all site-level tool overrides (`abilities: {}`)
* Read/Write rows hidden when site MCP is disabled

### Default state handling (no site-level overrides)
* When a site has no explicit ability overrides, tool enabled states are derived from `site_level_enabled_default` (`true` = all enabled, `false` = all disabled)
* First edit on a site without overrides **materialises the implicit default** — sends all tools at their default state plus the specific change, establishing a full baseline for subsequent edits

### Account-level MCP (`me/mcp`) fixes
* Removed `sitesToReset` from `handleToggleAll` — site-level state is now fully managed by the backend when toggling account-level access
* Remove buttons on `/me/mcp/mcp-sites` and `/me/mcp/add-site` now send `site_level_enabled: null` to clear the explicit override and fall back to `site_level_enabled_default`, rather than setting to `true`/`false`

### `me/mcp/utils.js`
* `getSiteLevelEnabled` reads `site_level_enabled` from the site entry, falling back to `mcp_abilities.site_level_enabled_default`
* `getDisabledSiteIds` checks `site_level_enabled === false`
* `getEnabledSiteIds` checks `site_level_enabled === true`

### Router & breadcrumbs
* `siteSettingsAIToolsRoute` uses `path: 'ai-tools'` (not pathless) with child routes for `/`, `read`, `write`, `setup`
* Calypso v2 router (`client/sites/v2/site-settings/router.tsx`) has explicit `head()` on each AI tools route so breadcrumb meta is populated via `useMatches()`
* Breadcrumbs component uses `breadcrumbHref` from route `head()` meta

### Styling
* Sub-group dividers on Read/Write pages use `border-top: 1px solid var(--color-border-subtle)` to match the account-level `preferences/mcp/read` appearance
* Last summary button inside the MCP access card has its bottom border removed and the card uses `overflow: hidden` to clip hover highlights to rounded corners

## Demo


https://github.com/user-attachments/assets/89ff8b01-442c-40f0-944c-be0cce94decc



## Testing Instructions

**Needs 210093-ghe-Automattic/wpcom and `public-api.wordpress.com` sandboxed**

1. Enable the `mcp-settings` and `wordpress-ai-tools` feature flags
2. Navigate to `/sites/:siteSlug/settings/ai-tools`
   - MCP toggle **off** → no Read/Write rows visible
   - MCP toggle **on** → Read row (with badge), Write row (with badge), Connect button appear
   - With no prior tool overrides, badges show "All enabled" (when `site_level_enabled_default: true`)
3. Click **Read** → shows tool toggles grouped by category; all enabled by default; breadcrumb navigates back
4. Click **Write** → same for write tools
5. Toggle a tool off on the Read page → snackbar confirms save; all other tools remain enabled; toggling back restores state
6. Click **Connect external AI agent** → setup page with agent selector and MCP config copy block
7. Disable site MCP toggle → Read/Write/Setup rows disappear; re-enabling restores them
8. On `/me/mcp`, disable account MCP → site pages reflect disabled state; re-enabling restores correctly
9. On `/me/mcp/mcp-sites`, click Remove → clears the override rather than setting `site_level_enabled: true`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?