### PR TITLE
E2E: Use exact match for Jetpack menuitemcheckbox locator

### DIFF
--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -114,7 +114,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 			await editorPage.openEditorOptionsMenu();
 			const page = await editorPage.getEditorParent();
 
-			await page.getByRole( 'menuitemcheckbox', { name: 'Jetpack' } ).click();
+			await page.getByRole( 'menuitemcheckbox', { name: 'Jetpack', exact: true } ).click();
 		} );
 
 		skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )( 'Link preview', function () {


### PR DESCRIPTION
## Proposed Changes

* Add `exact: true` to the `getByRole( 'menuitemcheckbox', { name: 'Jetpack' } )` locator in the basic post flow E2E test.

## Why are these changes being made?

The locator was resolving to two elements — "Jetpack" and "Jetpack Newsletter" — causing a Playwright strict mode violation. Using `exact: true` ensures only the intended "Jetpack" menu item is matched.

## Testing Instructions

* Run the `editor__post-basic-flow` E2E test and confirm the "Open Jetpack settings" step no longer fails with a strict mode violation.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?