### PR TITLE
A4A: Fix Partner Directory form not able to save Language spoken.

### DIFF
--- a/client/a8c-for-agencies/data/partner-directory/use-submit-agency-details.ts
+++ b/client/a8c-for-agencies/data/partner-directory/use-submit-agency-details.ts
@@ -1,5 +1,4 @@
 import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
-import { findIsoCodeByLanguage } from 'calypso/a8c-for-agencies/sections/partner-directory/lib/available-languages';
 import { AgencyDetails } from 'calypso/a8c-for-agencies/sections/partner-directory/types';
 import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
@@ -21,14 +20,6 @@ function mutationSubmitAgencyDetails(
 		throw new Error( 'Agency ID is required to update the profile' );
 	}
 
-	const languages = agencyDetails?.languagesSpoken?.reduce( ( acc: string[], language ) => {
-		const code = findIsoCodeByLanguage( language );
-		if ( code !== null ) {
-			acc.push( code );
-		}
-		return acc;
-	}, [] );
-
 	return wpcom.req.put( {
 		apiNamespace: 'wpcom/v2',
 		path: `/agency/${ agencyId }/profile`,
@@ -44,7 +35,7 @@ function mutationSubmitAgencyDetails(
 			profile_listing_is_global: agencyDetails.isGlobal,
 			profile_listing_is_available: agencyDetails.isAvailable,
 			profile_listing_industries: agencyDetails.industries,
-			profile_listing_languages_spoken: languages,
+			profile_listing_languages_spoken: agencyDetails?.languagesSpoken ?? [],
 			profile_listing_services: agencyDetails.services,
 			profile_listing_products: agencyDetails.products,
 			profile_budget_budget_lower_range: agencyDetails.budgetLowerRange,

--- a/client/a8c-for-agencies/sections/partner-directory/utils/map-application-form-data.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/utils/map-application-form-data.ts
@@ -1,5 +1,4 @@
 import { Agency } from 'calypso/state/a8c-for-agencies/types';
-import { availableLanguages } from '../lib/available-languages';
 import {
 	AgencyDetails,
 	AgencyDirectoryApplication,
@@ -113,18 +112,6 @@ export function mapAgencyDetailsFormData( agency: Agency | null ): AgencyDetails
 		return null;
 	}
 
-	const languages = agency.profile.listing_details.languages_spoken?.reduce(
-		( acc: string[], val ) => {
-			if ( availableLanguages[ val ] ) {
-				acc.push( availableLanguages[ val ] );
-			} else {
-				acc.push( val );
-			}
-			return acc;
-		},
-		[]
-	);
-
 	return {
 		name: agency.profile.company_details.name,
 		email: agency.profile.company_details.email,
@@ -138,7 +125,7 @@ export function mapAgencyDetailsFormData( agency: Agency | null ): AgencyDetails
 		industries: agency.profile.listing_details.industries,
 		services: agency.profile.listing_details.services,
 		products: agency.profile.listing_details.products,
-		languagesSpoken: languages,
+		languagesSpoken: agency.profile.listing_details.languages_spoken ?? [],
 		budgetLowerRange: agency.profile.budget_details.budget_lower_range,
 	};
 }


### PR DESCRIPTION
Closes  https://linear.app/a8c/issue/A4A-2348/language-spoken-field-does-not-persist
Related to https://github.com/Automattic/wp-calypso/pull/109568

## Proposed Changes

This pull request simplifies how languages spoken by agencies are handled in the partner directory feature. The main change is the removal of language code mapping logic, so the system now directly uses the language values as provided, both when submitting and displaying agency details.

**Partner Directory Language Handling Simplification:**

* Removed the mapping of spoken languages to ISO codes in `use-submit-agency-details.ts`. The `profile_listing_languages_spoken` field now directly uses the `languagesSpoken` array from `agencyDetails`, defaulting to an empty array if not present. [[1]](diffhunk://#diff-b9cf5a820aeeaf38e7460aaa3f9e7fb74eb9f7d11113e4c30d75ab20e84c2f83L24-L31) [[2]](diffhunk://#diff-b9cf5a820aeeaf38e7460aaa3f9e7fb74eb9f7d11113e4c30d75ab20e84c2f83L47-R38)
* In `map-application-form-data.ts`, eliminated the transformation of language values using the `availableLanguages` mapping. The `languagesSpoken` field now directly reflects the `languages_spoken` data from the agency profile, defaulting to an empty array if absent. [[1]](diffhunk://#diff-8b05fe4876e06a40193abe55e010d7607262a3a7f574641c03a13f1d599d86bcL116-L127) [[2]](diffhunk://#diff-8b05fe4876e06a40193abe55e010d7607262a3a7f574641c03a13f1d599d86bcL141-R128)

**Code Cleanup:**

* Removed unused imports related to language mapping from both `use-submit-agency-details.ts` and `map-application-form-data.ts`. [[1]](diffhunk://#diff-b9cf5a820aeeaf38e7460aaa3f9e7fb74eb9f7d11113e4c30d75ab20e84c2f83L2) [[2]](diffhunk://#diff-8b05fe4876e06a40193abe55e010d7607262a3a7f574641c03a13f1d599d86bcL2)

## Why are these changes being made?

* Fixes a regression in the PD form.

<img width="887" height="326" alt="Screenshot 2026-03-31 at 7 21 42 PM" src="https://github.com/user-attachments/assets/eb6dd88b-cbf1-406f-ae16-ee81aa2692db" />

## Testing Instructions

* Use the A4A live link and navigate to the `/partner-directory/dashboard` page.
* Fill up some form and have 1 directory approved. Make sure this is hidden.
* This should allow you to access the Agency Details form where the bug is. `/partner-directory/agency-details`
* Submit the language spoken. Confirm you see the language properly saved.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
