### PR TITLE
E2E: Use exact match in EditorToolbarComponent openSettings

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -317,7 +317,10 @@ export class EditorToolbarComponent {
 		if ( target !== 'Settings' ) {
 			await this.openMoreOptionsMenu();
 
-			button = editorParent.getByRole( 'menuitemcheckbox', { name: translatedTargetName } );
+			button = editorParent.getByRole( 'menuitemcheckbox', {
+				name: translatedTargetName,
+				exact: true,
+			} );
 		}
 
 		if ( await this.targetIsOpen( button ) ) {


### PR DESCRIPTION
## Proposed Changes

* Add `exact: true` to the `getByRole( 'menuitemcheckbox' )` locator in the shared `EditorToolbarComponent.openSettings` method.

## Why are these changes being made?

Follow-up to #109736. The shared `openSettings` method resolves "Jetpack" to both the "Jetpack" and "Jetpack Newsletter" menu items, causing Playwright strict mode violations in specs like `social__editor-features`. Adding `exact: true` ensures only the intended item is matched.

## Testing Instructions

* Run E2E specs that call `editorPage.openSettings( 'Jetpack' )` (e.g. `social__editor-features`, `social__editor-smoke`) and confirm they no longer fail with a strict mode violation.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?