### PR TITLE
Cookie banner: Enable the Decline non-essential button

### DIFF
--- a/client/blocks/cookie-banner/use-cookie-banner-content.tsx
+++ b/client/blocks/cookie-banner/use-cookie-banner-content.tsx
@@ -31,6 +31,7 @@ export const useCookieBannerContent = (): CookieBannerProps[ 'content' ] => {
 			),
 			acceptAllButton: translate( 'Accept all' ),
 			customizeButton: translate( 'Customize' ),
+			declineNonEssentialButton: translate( 'Decline non-essential cookies' ),
 		},
 		customizedConsent: {
 			description: translate(


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of M4R73CH-1681

## Proposed Changes

* Enable the `Decline non-essential button` introduced in https://github.com/Automattic/wp-calypso/pull/109701.

The button is now enabled by default, as we should show it in all the countries we show the cookie banner in.

Before:
<img width="956" height="244" alt="image" src="https://github.com/user-attachments/assets/28a36c48-1ea8-4361-b13d-3f56a89a7a51" />


After: 

<img width="930" height="258" alt="image" src="https://github.com/user-attachments/assets/b24d5b47-3fc2-4c05-8b09-99cb90df7f8e" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To comply with legal requirements.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/themes?flags=ad-tracking,cookie-banner` and confirm the cookie banner is displayed and works as expected.

Confirm the `` cookie contains:

```
{"ok":true,"buckets":{"essential":true,"analytics":false,"advertising":false}}
```
after declining non-essential cookies.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
