### PR TITLE
Restrict PNG and JPG imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -376,6 +376,12 @@ module.exports = {
 		'no-restricted-imports': [
 			2,
 			{
+				patterns: [
+					{
+						group: [ '**/*.png', '**/*.jpg', '**/*.jpeg' ],
+						message: "Please use 'webp' files instead.",
+					},
+				],
 				paths: [
 					// Prevent naked import of gridicons module. Use 'components/gridicon' instead.
 					{

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -379,7 +379,8 @@ module.exports = {
 				patterns: [
 					{
 						group: [ '**/*.png', '**/*.jpg', '**/*.jpeg' ],
-						message: "Please use 'webp' files instead.",
+						message:
+							"Please use 'webp' files instead. You can convert using `brew install webp && cwebp -q 90 -alpha_q 85 -m 6 <input>.png -o <output>.webp`",
 					},
 				],
 				paths: [

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -43,6 +43,14 @@
 				"units": [ "px" ]
 			}
 		],
+		"declaration-property-value-disallowed-list": [
+			{
+				"/./": [ "/\\.(?:png|jpe?g)/i" ]
+			},
+			{
+				"message": "Please use 'webp' files instead."
+			}
+		],
 		"unit-allowed-list": [
 			"%",
 			"deg",

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -43,14 +43,6 @@
 				"units": [ "px" ]
 			}
 		],
-		"declaration-property-value-disallowed-list": [
-			{
-				"/./": [ "/\\.(?:png|jpe?g)/i" ]
-			},
-			{
-				"message": "Please use 'webp' files instead."
-			}
-		],
 		"unit-allowed-list": [
 			"%",
 			"deg",

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -19,7 +19,8 @@ module.exports = {
 				patterns: [
 					{
 						group: [ '**/*.png', '**/*.jpg', '**/*.jpeg' ],
-						message: "Please use 'webp' files instead.",
+						message:
+							"Please use 'webp' files instead. You can convert using `brew install webp && cwebp -q 90 -alpha_q 85 -m 6 <input>.png -o <output>.webp`",
 					},
 					{
 						group: [ '@testing-library/jest-dom*' ],

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -18,6 +18,10 @@ module.exports = {
 			{
 				patterns: [
 					{
+						group: [ '**/*.png', '**/*.jpg', '**/*.jpeg' ],
+						message: "Please use 'webp' files instead.",
+					},
+					{
 						group: [ '@testing-library/jest-dom*' ],
 						message:
 							'@testing-library/jest-dom is already globally provided by our test setup framework.',


### PR DESCRIPTION
Fixes DOTCOM-16558

## Proposed Changes
- Error out when png and jpg are used.

## Why are these changes being made?
- WebP's only historical downside was browser support. Now it's widely supported and we should avoid using inefficient fomats like PNG and JPG.

## Testing Instructions
- Edit a JS file to use a PNG file.
- You should get an error.
