### PR TITLE
MSD: Reorganize Preferences into sub-pages with summary cards

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -878,6 +878,27 @@ export const hostingDashboardRoute = createRoute( {
 	)
 );
 
+export const languageRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Language' ),
+			},
+		],
+	} ),
+	getParentRoute: () => preferencesRoute,
+	path: 'language',
+	loader: async () => {
+		await queryClient.ensureQueryData( userSettingsQuery() );
+	},
+} ).lazy( () =>
+	import( '../../me/language' ).then( ( d ) =>
+		createLazyRoute( 'language' )( {
+			component: d.default,
+		} )
+	)
+);
+
 export const appsRoute = createRoute( {
 	head: () => ( {
 		meta: [
@@ -1032,7 +1053,7 @@ export const createMeRoutes = ( config: AppConfig ) => {
 		return [];
 	}
 
-	const preferencesChildren: AnyRoute[] = [ preferencesIndexRoute, privacyRoute ];
+	const preferencesChildren: AnyRoute[] = [ preferencesIndexRoute, privacyRoute, languageRoute ];
 	if ( config.supports.reader ) {
 		preferencesChildren.push( blockedSitesRoute );
 	}

--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -899,6 +899,30 @@ export const languageRoute = createRoute( {
 	)
 );
 
+export const wordpressDefaultsRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'WordPress.com defaults' ),
+			},
+		],
+	} ),
+	getParentRoute: () => preferencesRoute,
+	path: 'defaults',
+	loader: async () => {
+		await Promise.all( [
+			queryClient.ensureQueryData( userSettingsQuery() ),
+			queryClient.ensureQueryData( rawUserPreferencesQuery() ),
+		] );
+	},
+} ).lazy( () =>
+	import( '../../me/wordpress-defaults' ).then( ( d ) =>
+		createLazyRoute( 'wordpress-defaults' )( {
+			component: d.default,
+		} )
+	)
+);
+
 export const appsRoute = createRoute( {
 	head: () => ( {
 		meta: [
@@ -1053,7 +1077,12 @@ export const createMeRoutes = ( config: AppConfig ) => {
 		return [];
 	}
 
-	const preferencesChildren: AnyRoute[] = [ preferencesIndexRoute, privacyRoute, languageRoute ];
+	const preferencesChildren: AnyRoute[] = [
+		preferencesIndexRoute,
+		privacyRoute,
+		languageRoute,
+		wordpressDefaultsRoute,
+	];
 	if ( config.supports.reader ) {
 		preferencesChildren.push( blockedSitesRoute );
 	}

--- a/client/dashboard/me/blocked-sites/index.tsx
+++ b/client/dashboard/me/blocked-sites/index.tsx
@@ -149,64 +149,67 @@ export default function BlockedSites() {
 				/>
 			}
 		>
-			<DataViewsCard ref={ ref }>
-				<DataViews< BlockedSite >
-					data={ filteredData }
-					fields={ fields }
-					view={ view }
-					actions={ [
-						{
-							id: 'unblock',
-							label: __( 'Unblock' ),
-							icon: <Icon icon={ closeSmall } />,
-							isPrimary: true,
-							disabled: unblockSite.isPending,
-							callback: ( items: BlockedSite[] ) => {
-								const item = items[ 0 ];
-								unblockSite.mutate( item.ID, {
-									onSuccess: () => {
-										createSuccessNotice(
-											sprintf(
-												/* translators: %s - the name of the unblocked site */
-												__( '%s was unblocked.' ),
-												item.name
-											),
-											{
-												type: 'snackbar',
-											}
-										);
-									},
-									onError: () => {
-										createErrorNotice(
-											sprintf(
-												/* translators: %s - the name of the unblocked site */
-												__( 'Failed to unblock %s.' ),
-												item.name
-											),
-											{
-												type: 'snackbar',
-											}
-										);
-									},
-								} );
+			{ ! isLoading && sites.length === 0 ? (
+				<p>{ __( "You haven't blocked any sites yet." ) }</p>
+			) : (
+				<DataViewsCard ref={ ref }>
+					<DataViews< BlockedSite >
+						data={ filteredData }
+						fields={ fields }
+						view={ view }
+						actions={ [
+							{
+								id: 'unblock',
+								label: __( 'Unblock' ),
+								icon: <Icon icon={ closeSmall } />,
+								isPrimary: true,
+								disabled: unblockSite.isPending,
+								callback: ( items: BlockedSite[] ) => {
+									const item = items[ 0 ];
+									unblockSite.mutate( item.ID, {
+										onSuccess: () => {
+											createSuccessNotice(
+												sprintf(
+													/* translators: %s - the name of the unblocked site */
+													__( '%s was unblocked.' ),
+													item.name
+												),
+												{
+													type: 'snackbar',
+												}
+											);
+										},
+										onError: () => {
+											createErrorNotice(
+												sprintf(
+													/* translators: %s - the name of the unblocked site */
+													__( 'Failed to unblock %s.' ),
+													item.name
+												),
+												{
+													type: 'snackbar',
+												}
+											);
+										},
+									} );
+								},
 							},
-						},
-					] }
-					getItemId={ ( item ) => item.ID.toString() }
-					defaultLayouts={ { table: {} } }
-					paginationInfo={ {
-						...paginationInfo,
-						infiniteScrollHandler,
-					} }
-					empty={ <p>{ __( 'You haven’t blocked any sites yet.' ) }</p> }
-					isLoading={ isLoading }
-					onChangeView={ setView }
-				>
-					<>
-						<DataViews.Layout />
-					</>
-				</DataViews>
-			</DataViewsCard>
+						] }
+						getItemId={ ( item ) => item.ID.toString() }
+						defaultLayouts={ { table: {} } }
+						paginationInfo={ {
+							...paginationInfo,
+							infiniteScrollHandler,
+						} }
+						isLoading={ isLoading }
+						onChangeView={ setView }
+					>
+						<>
+							<DataViews.Layout />
+						</>
+					</DataViews>
+				</DataViewsCard>
+			) }
 		</PageLayout>
 	);
 }

--- a/client/dashboard/me/language/index.tsx
+++ b/client/dashboard/me/language/index.tsx
@@ -1,0 +1,289 @@
+import { userSettingsMutation, userSettingsQuery } from '@automattic/api-queries';
+import config from '@automattic/calypso-config';
+import { getLanguage, isDefaultLocale, isTranslatedIncompletely } from '@automattic/i18n-utils';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
+import {
+	Notice,
+	Button,
+	__experimentalVStack as VStack,
+	ExternalLink,
+	ComboboxControl,
+	CheckboxControl,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { DataForm } from '@wordpress/dataviews';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useMemo, useState } from 'react';
+import Breadcrumbs from '../../app/breadcrumbs';
+import { NavigationBlocker } from '../../app/navigation-blocker';
+import { Card, CardBody } from '../../components/card';
+import FlashMessage, { reloadWithFlashMessage } from '../../components/flash-message';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import {
+	languagesAsOptions,
+	shouldDisplayCommunityTranslator,
+	getLocaleVariantOrLanguage,
+	CalypsoLanguage,
+} from '../preferences-language/languages';
+import type { UserSettings } from '@automattic/api-core';
+import type { Field, Form } from '@wordpress/dataviews';
+
+export default function Language() {
+	const { createErrorNotice } = useDispatch( noticesStore );
+	const { data: serverData } = useQuery( {
+		...userSettingsQuery(),
+		meta: { persist: false },
+	} );
+	const [ formData, setFormData ] = useState< Partial< UserSettings > | undefined >();
+	const mutation = useMutation( userSettingsMutation() );
+	const router = useRouter();
+
+	/**
+	 * When we save the language, in case we're using a locale_variant (a language without an official locale)
+	 * the API will return the parent language (example: es-cl will return 'es' in the 'language' field)
+	 * as such, we're overriding the language with the locale_variant, if present, this saves us from checking the data and allows us to
+	 * trust that the 'language' field contains a locale from the languages.
+	 */
+	if ( serverData?.locale_variant ) {
+		serverData.language = serverData.locale_variant;
+	}
+	const data = useMemo(
+		() => ( serverData ? { ...serverData, ...formData } : undefined ),
+		[ serverData, formData ]
+	);
+
+	if ( ! data ) {
+		return null;
+	}
+	// We need the CalypsoLanguage to show the % of translated content in the use_fallback_for_incomplete_languages
+	const selectedLanguage: CalypsoLanguage | undefined = data.language
+		? ( getLanguage( data.language ) as CalypsoLanguage )
+		: undefined;
+
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+		if ( ! formData ) {
+			return;
+		}
+		const mutationData = formData;
+		mutation.mutate( mutationData, {
+			onSuccess: () => {
+				router.history.destroy(); // Ignore any navigation blocker
+				reloadWithFlashMessage( 'language' );
+			},
+			onError: ( error ) => {
+				// Prepend previous attempted data back into local edits
+				setFormData( ( current ) => ( { ...mutationData, ...current } ) );
+				createErrorNotice( error.message ?? __( 'Language setting could not be saved.' ), {
+					type: 'snackbar',
+				} );
+			},
+		} );
+	};
+
+	const isDefaultLanguageSelected = !! data.language && isDefaultLocale( data.language );
+	const showIncompleteLocaleControl =
+		! isDefaultLanguageSelected && !! data.language && isTranslatedIncompletely( data.language );
+	const isSaving = mutation.isPending;
+
+	const isDirty =
+		!! formData &&
+		!! serverData &&
+		Object.entries( formData ).some( ( [ key, value ] ) => {
+			return serverData[ key as keyof UserSettings ] !== value;
+		} );
+
+	const hasValidLanguage = !! data?.language;
+	const canSubmit = ! isSaving && isDirty && hasValidLanguage;
+	const languageForm: Form = {
+		layout: {
+			type: 'regular' as const,
+			labelPosition: 'top' as const,
+		},
+		fields: [
+			{
+				id: 'interfaceLanguage',
+				children: [
+					'language',
+					'use_fallback_for_incomplete_languages',
+					'enable_translator',
+					'i18n_empathy_mode',
+				],
+			},
+		],
+	};
+
+	const languageFields: Field< UserSettings >[] = [
+		{
+			id: 'language',
+			label: __( 'Interface language' ),
+			type: 'text',
+			Edit: ( { field, data: fieldData, onChange } ) => {
+				const locale = fieldData?.language;
+				const lang =
+					locale && shouldDisplayCommunityTranslator( locale )
+						? getLocaleVariantOrLanguage( locale )
+						: undefined;
+
+				const helpText = lang
+					? createInterpolateElement(
+							sprintf(
+								/* translators: %s: selected interface language */
+								__(
+									'Thanks to all our <externalLink>community members who helped translate to %s</externalLink>'
+								),
+								lang.name
+							),
+							{
+								externalLink: (
+									<ExternalLink
+										href={ `https://translate.wordpress.com/translators/?contributor_locale=${ lang.langSlug }` }
+										children={ null }
+									/>
+								),
+							}
+					  )
+					: undefined;
+
+				return (
+					<ComboboxControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						value={ field.getValue( { item: fieldData } ) ?? '' }
+						label={ __( 'Interface language' ) }
+						onChange={ ( newValue ) => {
+							onChange( {
+								[ field.id ]: newValue,
+							} );
+						} }
+						placeholder={ __( 'Select a language' ) }
+						options={ field.elements || [] }
+						allowReset={ false } // a language is required so we're not allowing to reset it and have an empty state.
+						help={ helpText }
+					/>
+				);
+			},
+			elements: languagesAsOptions,
+		},
+		{
+			id: 'use_fallback_for_incomplete_languages',
+			label: __( 'Display interface in English' ),
+			description:
+				/* translators: %(languageName)s is a localized language name, %(percentTranslated)d%% is a percentage number (0-100), followed by an escaped percent sign %%. */
+				sprintf( __( '(%(languageName)s is only %(percentTranslated)d%% translated)' ), {
+					languageName: selectedLanguage?.name,
+					percentTranslated: selectedLanguage?.calypsoPercentTranslated,
+				} ),
+			type: 'boolean',
+			Edit: 'checkbox',
+			isVisible: () => showIncompleteLocaleControl,
+		},
+		{
+			id: 'i18n_empathy_mode',
+			label: 'Empathy mode (a8c-only)',
+			type: 'boolean',
+			isVisible: () => config.isEnabled( 'i18n/empathy-mode' ),
+			Edit: ( { field, data: fieldData, onChange } ) => {
+				const isEmpathyModeFieldDisabled =
+					! fieldData.language ||
+					fieldData.language === '' ||
+					!! isDefaultLocale( fieldData.language );
+				return (
+					<CheckboxControl
+						__nextHasNoMarginBottom
+						checked={ isEmpathyModeFieldDisabled ? false : field.getValue( { item: fieldData } ) }
+						label={ field.label }
+						disabled={ isEmpathyModeFieldDisabled }
+						onChange={ ( newValue ) => {
+							onChange( {
+								[ field.id ]: newValue,
+							} );
+						} }
+					/>
+				);
+			},
+		},
+		{
+			id: 'enable_translator',
+			label: __( 'Enable the in-page translator where available' ),
+			type: 'boolean',
+			isVisible: ( item ) => shouldDisplayCommunityTranslator( item.language ),
+			Edit: ( { field, data: fieldData, onChange } ) => {
+				return (
+					<CheckboxControl
+						__nextHasNoMarginBottom
+						checked={ field.getValue( { item: fieldData } ) }
+						label={ field.label }
+						onChange={ ( newValue ) => {
+							onChange( {
+								[ field.id ]: newValue,
+							} );
+						} }
+						help={ createInterpolateElement(
+							__( 'This allows you to help translate WordPress.com. <LearnMore/>' ),
+							{
+								LearnMore: (
+									<ExternalLink href="https://translate.wordpress.com/community-translator/">
+										{ __( 'Learn more' ) }
+									</ExternalLink>
+								),
+							}
+						) }
+					/>
+				);
+			},
+		},
+	];
+
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					prefix={ <Breadcrumbs length={ 2 } /> }
+					title={ __( 'Language' ) }
+					description={ __( 'Set the display language for WordPress.com.' ) }
+				/>
+			}
+		>
+			<form onSubmit={ handleSubmit }>
+				<FlashMessage id="language" message={ __( 'Language setting saved.' ) } />
+				<Card>
+					<CardBody>
+						<VStack spacing={ 4 }>
+							<NavigationBlocker shouldBlock={ isDirty } />
+							<DataForm< UserSettings >
+								data={ data }
+								fields={ languageFields }
+								form={ languageForm }
+								onChange={ ( edits: Partial< UserSettings > ) => {
+									setFormData( ( current ) => ( { ...current, ...edits } ) );
+								} }
+							/>
+							{ mutation.error && (
+								<Notice status="error" isDismissible={ false }>
+									{ mutation.error.message }
+								</Notice>
+							) }
+							<div>
+								<Button
+									variant="primary"
+									type="submit"
+									accessibleWhenDisabled
+									isBusy={ isSaving }
+									disabled={ ! canSubmit }
+								>
+									{ __( 'Save' ) }
+								</Button>
+							</div>
+						</VStack>
+					</CardBody>
+				</Card>
+			</form>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/me/language/index.tsx
+++ b/client/dashboard/me/language/index.tsx
@@ -78,7 +78,7 @@ export default function Language() {
 			onError: ( error ) => {
 				// Prepend previous attempted data back into local edits
 				setFormData( ( current ) => ( { ...mutationData, ...current } ) );
-				createErrorNotice( error.message ?? __( 'Language setting could not be saved.' ), {
+				createErrorNotice( error.message ?? __( 'Failed to save language.' ), {
 					type: 'snackbar',
 				} );
 			},

--- a/client/dashboard/me/language/test/index.test.tsx
+++ b/client/dashboard/me/language/test/index.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import '@testing-library/jest-dom';
+
+import { screen, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import Language from '../index';
+
+const renderWithUserData = ( userData = {} ) => {
+	nock( 'https://public-api.wordpress.com' ).get( '/rest/v1.1/me/settings' ).reply( 200, userData );
+
+	const result = render( <Language /> );
+
+	result.queryClient.setQueryData( [ 'user-settings-preferences' ], userData );
+
+	return result;
+};
+
+describe( '<Language />', () => {
+	describe( 'Field visibility logic', () => {
+		test( 'renders basic interface elements', async () => {
+			renderWithUserData( {
+				language: 'pt',
+				use_fallback_for_incomplete_languages: false,
+			} );
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Interface language' ) ).toBeVisible();
+			} );
+			expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeVisible();
+		} );
+
+		test( 'shows fallback field for incomplete language (Portuguese)', async () => {
+			renderWithUserData( {
+				language: 'pt',
+				use_fallback_for_incomplete_languages: false,
+			} );
+			await waitFor( () => {
+				expect( screen.getByText( 'Display interface in English' ) ).toBeVisible();
+			} );
+		} );
+
+		test( 'hides fallback field for complete language (English)', async () => {
+			renderWithUserData( {
+				language: 'en',
+				use_fallback_for_incomplete_languages: false,
+			} );
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Interface language' ) ).toBeVisible();
+			} );
+			expect( screen.queryByText( 'Display interface in English' ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'shows enable_translator field for translatable language (Spanish)', async () => {
+			renderWithUserData( {
+				language: 'es',
+			} );
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Enable the in-page translator where available' ) ).toBeVisible();
+			} );
+		} );
+
+		test( 'hides enable_translator field for non-translatable language (English)', async () => {
+			renderWithUserData( {
+				language: 'en',
+			} );
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Interface language' ) ).toBeVisible();
+			} );
+
+			expect(
+				screen.queryByText( 'Enable the in-page translator where available' )
+			).not.toBeInTheDocument();
+		} );
+	} );
+} );

--- a/client/dashboard/me/preferences-blocked-sites/index.tsx
+++ b/client/dashboard/me/preferences-blocked-sites/index.tsx
@@ -1,15 +1,36 @@
+import { blockedSitesInfiniteQuery } from '@automattic/api-queries';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import { Icon } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { notAllowed } from '@wordpress/icons';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
 
 export default function PreferencesBlockedSites() {
+	const { data } = useInfiniteQuery( blockedSitesInfiniteQuery( 1 ) );
+	const sites = ( data?.pages || [] ).flat();
+	const count = sites.length;
+
+	const badges =
+		count === 0
+			? [ { text: __( 'None' ) } ]
+			: [
+					{
+						text: sprintf(
+							/* translators: %d is the number of blocked sites */
+							__( '%d blocked' ),
+							count
+						),
+						intent: 'info' as const,
+					},
+			  ];
+
 	return (
 		<RouterLinkSummaryButton
 			to="/me/preferences/blocked-sites"
 			title={ __( 'Blocked sites' ) }
-			description={ __( 'Manage your list of blocked sites in the Reader.' ) }
+			description={ __( "Sites that won't appear in your Reader or recommendations." ) }
 			decoration={ <Icon icon={ notAllowed } size={ 24 } /> }
+			badges={ badges }
 		/>
 	);
 }

--- a/client/dashboard/me/preferences-defaults/index.tsx
+++ b/client/dashboard/me/preferences-defaults/index.tsx
@@ -1,5 +1,5 @@
 import { rawUserPreferencesQuery, userSettingsQuery } from '@automattic/api-queries';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
@@ -8,7 +8,7 @@ import { useAppContext } from '../../app/context';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
 
 function useLandingPageLabel() {
-	const { data: landingPage } = useSuspenseQuery( {
+	const { data: landingPage } = useQuery( {
 		...rawUserPreferencesQuery(),
 		select: ( preferences ) => {
 			if ( preferences[ 'sites-landing-page' ]?.useSitesAsLandingPage ) {
@@ -35,12 +35,12 @@ function usePrimarySiteName() {
 	const { queries } = useAppContext();
 	const { user } = useAuth();
 
-	const { data: primarySiteId } = useSuspenseQuery( {
+	const { data: primarySiteId } = useQuery( {
 		...userSettingsQuery(),
 		select: ( data ) => data.primary_site_ID,
 	} );
 
-	const { data: sites } = useSuspenseQuery(
+	const { data: sites } = useQuery(
 		queries.sitesQuery( { site_visibility: 'visible', include_a8c_owned: false } )
 	);
 

--- a/client/dashboard/me/preferences-defaults/index.tsx
+++ b/client/dashboard/me/preferences-defaults/index.tsx
@@ -1,0 +1,66 @@
+import { rawUserPreferencesQuery, userSettingsQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { wordpress } from '@wordpress/icons';
+import { useAuth } from '../../app/auth';
+import { useAppContext } from '../../app/context';
+import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+
+function useLandingPageLabel() {
+	const { data: landingPage } = useSuspenseQuery( {
+		...rawUserPreferencesQuery(),
+		select: ( preferences ) => {
+			if ( preferences[ 'sites-landing-page' ]?.useSitesAsLandingPage ) {
+				return 'sites';
+			}
+			if ( preferences[ 'reader-landing-page' ]?.useReaderAsLandingPage ) {
+				return 'reader';
+			}
+			return 'primary-site-dashboard';
+		},
+	} );
+
+	switch ( landingPage ) {
+		case 'sites':
+			return __( 'Sites list' );
+		case 'reader':
+			return __( 'Reader' );
+		default:
+			return __( 'Primary site' );
+	}
+}
+
+function usePrimarySiteName() {
+	const { queries } = useAppContext();
+	const { user } = useAuth();
+
+	const { data: primarySiteId } = useSuspenseQuery( {
+		...userSettingsQuery(),
+		select: ( data ) => data.primary_site_ID,
+	} );
+
+	const { data: sites } = useSuspenseQuery(
+		queries.sitesQuery( { site_visibility: 'visible', include_a8c_owned: false } )
+	);
+
+	const primarySite = sites?.find( ( site: { ID: number } ) => site.ID === primarySiteId );
+	return primarySite?.name ?? user.display_name;
+}
+
+export default function PreferencesDefaults() {
+	const landingPageLabel = useLandingPageLabel();
+	const primarySiteName = usePrimarySiteName();
+
+	const badges = [ { text: landingPageLabel }, { text: primarySiteName } ];
+
+	return (
+		<RouterLinkSummaryButton
+			to="/me/preferences/defaults"
+			title={ __( 'WordPress.com defaults' ) }
+			description={ __( 'Set your starting point after you log in and primary site.' ) }
+			decoration={ <Icon icon={ wordpress } size={ 24 } /> }
+			badges={ badges }
+		/>
+	);
+}

--- a/client/dashboard/me/preferences-language/index.tsx
+++ b/client/dashboard/me/preferences-language/index.tsx
@@ -1,279 +1,34 @@
-import { userSettingsMutation, userSettingsQuery } from '@automattic/api-queries';
-import config from '@automattic/calypso-config';
-import { getLanguage, isDefaultLocale, isTranslatedIncompletely } from '@automattic/i18n-utils';
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { useRouter } from '@tanstack/react-router';
-import {
-	Notice,
-	Button,
-	__experimentalVStack as VStack,
-	ExternalLink,
-	ComboboxControl,
-	CheckboxControl,
-} from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
-import { DataForm } from '@wordpress/dataviews';
-import { createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
-import { useMemo, useState } from 'react';
-import { NavigationBlocker } from '../../app/navigation-blocker';
-import { Card, CardBody } from '../../components/card';
-import FlashMessage, { reloadWithFlashMessage } from '../../components/flash-message';
-import { SectionHeader } from '../../components/section-header';
-import {
-	languagesAsOptions,
-	shouldDisplayCommunityTranslator,
-	getLocaleVariantOrLanguage,
-	CalypsoLanguage,
-} from './languages';
-import type { UserSettings } from '@automattic/api-core';
-import type { Field, Form } from '@wordpress/dataviews';
+import { userSettingsQuery } from '@automattic/api-queries';
+import { getLanguage } from '@automattic/i18n-utils';
+import { useQuery } from '@tanstack/react-query';
+import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { language } from '@wordpress/icons';
+import RouterLinkSummaryButton from '../../components/router-link-summary-button';
 
-export default function PreferencesLanguageForm() {
-	const { createErrorNotice } = useDispatch( noticesStore );
-	const { data: serverData } = useQuery( {
+export default function PreferencesLanguage() {
+	const { data: userSettings } = useQuery( {
 		...userSettingsQuery(),
 		meta: { persist: false },
 	} );
-	const [ formData, setFormData ] = useState< Partial< UserSettings > | undefined >();
-	const mutation = useMutation( userSettingsMutation() );
-	const router = useRouter();
 
-	/**
-	 * When we save the language, in case we're using a locale_variant (a language without an official locale)
-	 * the API will return the parent language (example: es-cl will return 'es' in the 'language' field)
-	 * as such, we're overriding the language with the locale_variant, if present, this saves us from checking the data and allows us to
-	 * trust that the 'language' field contains a locale from the languages.
-	 */
-	if ( serverData?.locale_variant ) {
-		serverData.language = serverData.locale_variant;
-	}
-	const data = useMemo(
-		() => ( serverData ? { ...serverData, ...formData } : undefined ),
-		[ serverData, formData ]
-	);
+	const locale = userSettings?.locale_variant || userSettings?.language;
+	const languageInfo = locale ? getLanguage( locale ) : undefined;
+	const languageName = languageInfo?.name ?? __( 'English' );
 
-	if ( ! data ) {
-		return null;
-	}
-	// We need the CalypsoLanguage to show the % of translated content in the use_fallback_for_incomplete_languages
-	const selectedLanguage: CalypsoLanguage | undefined = data.language
-		? ( getLanguage( data.language ) as CalypsoLanguage )
-		: undefined;
-
-	const handleSubmit = ( e: React.FormEvent ) => {
-		e.preventDefault();
-		if ( ! formData ) {
-			return;
-		}
-		const mutationData = formData;
-		mutation.mutate( mutationData, {
-			onSuccess: () => {
-				router.history.destroy(); // Ignore any navigation blocker
-				reloadWithFlashMessage( 'language' );
-			},
-			onError: ( error ) => {
-				// Prepend previous attempted data back into local edits
-				setFormData( ( current ) => ( { ...mutationData, ...current } ) );
-				createErrorNotice( error.message ?? __( 'Language setting could not be saved.' ), {
-					type: 'snackbar',
-				} );
-			},
-		} );
-	};
-
-	const isDefaultLanguageSelected = !! data.language && isDefaultLocale( data.language );
-	const showIncompleteLocaleControl =
-		! isDefaultLanguageSelected && !! data.language && isTranslatedIncompletely( data.language );
-	const isSaving = mutation.isPending;
-
-	const isDirty =
-		!! formData &&
-		!! serverData &&
-		Object.entries( formData ).some( ( [ key, value ] ) => {
-			return serverData[ key as keyof UserSettings ] !== value;
-		} );
-
-	const hasValidLanguage = !! data?.language;
-	const canSubmit = ! isSaving && isDirty && hasValidLanguage;
-	const languageForm: Form = {
-		layout: {
-			type: 'regular' as const,
-			labelPosition: 'top' as const,
-		},
-		fields: [
-			{
-				id: 'interfaceLanguage',
-				children: [
-					'language',
-					'use_fallback_for_incomplete_languages',
-					'enable_translator',
-					'i18n_empathy_mode',
-				],
-			},
-		],
-	};
-
-	const languageFields: Field< UserSettings >[] = [
+	const badges = [
 		{
-			id: 'language',
-			label: __( 'Interface language' ),
-			type: 'text',
-			Edit: ( { field, data, onChange } ) => {
-				const locale = data?.language;
-				const language =
-					locale && shouldDisplayCommunityTranslator( locale )
-						? getLocaleVariantOrLanguage( locale )
-						: undefined;
-
-				const helpText = language
-					? createInterpolateElement(
-							sprintf(
-								/* translators: %s: selected interface language */
-								__(
-									'Thanks to all our <externalLink>community members who helped translate to %s</externalLink>'
-								),
-								language.name
-							),
-							{
-								externalLink: (
-									<ExternalLink
-										href={ `https://translate.wordpress.com/translators/?contributor_locale=${ language.langSlug }` }
-										children={ null }
-									/>
-								),
-							}
-					  )
-					: undefined;
-
-				return (
-					<ComboboxControl
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-						value={ field.getValue( { item: data } ) ?? '' }
-						label={ __( 'Interface language' ) }
-						onChange={ ( newValue ) => {
-							onChange( {
-								[ field.id ]: newValue,
-							} );
-						} }
-						placeholder={ __( 'Select a language' ) }
-						options={ field.elements || [] }
-						allowReset={ false } // a language is required so we're not allowing to reset it and have an empty state.
-						help={ helpText }
-					/>
-				);
-			},
-			elements: languagesAsOptions,
-		},
-		{
-			id: 'use_fallback_for_incomplete_languages',
-			label: __( 'Display interface in English' ),
-			description:
-				/* translators: %(languageName)s is a localized language name, %(percentTranslated)d%% is a percentage number (0-100), followed by an escaped percent sign %%. */
-				sprintf( __( '(%(languageName)s is only %(percentTranslated)d%% translated)' ), {
-					languageName: selectedLanguage?.name,
-					percentTranslated: selectedLanguage?.calypsoPercentTranslated,
-				} ),
-			type: 'boolean',
-			Edit: 'checkbox',
-			isVisible: () => showIncompleteLocaleControl,
-		},
-		{
-			id: 'i18n_empathy_mode',
-			label: 'Empathy mode (a8c-only)',
-			type: 'boolean',
-			isVisible: () => config.isEnabled( 'i18n/empathy-mode' ),
-			Edit: ( { field, data, onChange } ) => {
-				const isEmpathyModeFieldDisabled =
-					! data.language || data.language === '' || !! isDefaultLocale( data.language );
-				return (
-					<CheckboxControl
-						__nextHasNoMarginBottom
-						checked={ isEmpathyModeFieldDisabled ? false : field.getValue( { item: data } ) }
-						label={ field.label }
-						disabled={ isEmpathyModeFieldDisabled }
-						onChange={ ( newValue ) => {
-							onChange( {
-								[ field.id ]: newValue,
-							} );
-						} }
-					/>
-				);
-			},
-		},
-		{
-			id: 'enable_translator',
-			label: __( 'Enable the in-page translator where available' ),
-			type: 'boolean',
-			isVisible: ( item ) => shouldDisplayCommunityTranslator( item.language ),
-			Edit: ( { field, data, onChange } ) => {
-				return (
-					<CheckboxControl
-						__nextHasNoMarginBottom
-						checked={ field.getValue( { item: data } ) }
-						label={ field.label }
-						onChange={ ( newValue ) => {
-							onChange( {
-								[ field.id ]: newValue,
-							} );
-						} }
-						help={ createInterpolateElement(
-							__( 'This allows you to help translate WordPress.com. <LearnMore/>' ),
-							{
-								LearnMore: (
-									<ExternalLink href="https://translate.wordpress.com/community-translator/">
-										{ __( 'Learn more' ) }
-									</ExternalLink>
-								),
-							}
-						) }
-					/>
-				);
-			},
+			text: languageName,
 		},
 	];
 
 	return (
-		<form onSubmit={ handleSubmit }>
-			<FlashMessage id="language" message={ __( 'Language setting saved.' ) } />
-			<Card>
-				<CardBody>
-					<VStack spacing={ 4 }>
-						<SectionHeader
-							level={ 3 }
-							title={ __( 'Language' ) }
-							description={ __( 'Use this to set the display language for WordPress.com.' ) }
-						/>
-						<NavigationBlocker shouldBlock={ isDirty } />
-						<DataForm< UserSettings >
-							data={ data }
-							fields={ languageFields }
-							form={ languageForm }
-							onChange={ ( edits: Partial< UserSettings > ) => {
-								setFormData( ( current ) => ( { ...current, ...edits } ) );
-							} }
-						/>
-						{ mutation.error && (
-							<Notice status="error" isDismissible={ false }>
-								{ mutation.error.message }
-							</Notice>
-						) }
-						<div>
-							<Button
-								variant="primary"
-								type="submit"
-								accessibleWhenDisabled
-								isBusy={ isSaving }
-								disabled={ ! canSubmit }
-							>
-								{ __( 'Save' ) }
-							</Button>
-						</div>
-					</VStack>
-				</CardBody>
-			</Card>
-		</form>
+		<RouterLinkSummaryButton
+			to="/me/preferences/language"
+			title={ __( 'Language' ) }
+			description={ __( 'Set the display language for WordPress.com.' ) }
+			decoration={ <Icon icon={ language } size={ 24 } /> }
+			badges={ badges }
+		/>
 	);
 }

--- a/client/dashboard/me/preferences-language/test/index.test.tsx
+++ b/client/dashboard/me/preferences-language/test/index.test.tsx
@@ -7,78 +7,42 @@ import '@testing-library/jest-dom';
 import { screen, waitFor } from '@testing-library/react';
 import nock from 'nock';
 import { render } from '../../../test-utils';
-import PreferencesLanguageForm from '../index';
+import PreferencesLanguage from '../index';
 
 const renderWithUserData = ( userData = {} ) => {
 	nock( 'https://public-api.wordpress.com' ).get( '/rest/v1.1/me/settings' ).reply( 200, userData );
 
-	const result = render( <PreferencesLanguageForm /> );
+	const result = render( <PreferencesLanguage /> );
 
-	// Mock the query data
 	result.queryClient.setQueryData( [ 'user-settings-preferences' ], userData );
 
 	return result;
 };
 
-describe( 'PreferencesLanguageForm', () => {
-	describe( 'Field visibility logic', () => {
-		it( 'renders basic interface elements', async () => {
-			renderWithUserData( {
-				language: 'pt', // Portuguese - incomplete language
-				use_fallback_for_incomplete_languages: false,
-			} );
+describe( '<PreferencesLanguage />', () => {
+	test( 'renders the language link card with title and description', async () => {
+		renderWithUserData( { language: 'en' } );
 
-			// Test that the component loads and shows basic elements
-			await waitFor( () => {
-				expect( screen.getByText( 'Interface language' ) ).toBeInTheDocument();
-			} );
-			expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeInTheDocument();
+		await waitFor( () => {
+			expect( screen.getByRole( 'link', { name: /Language/i } ) ).toBeVisible();
 		} );
+		expect( screen.getByText( 'Set the display language for WordPress.com.' ) ).toBeVisible();
+	} );
 
-		it( 'shows fallback field for incomplete language (Portuguese)', async () => {
-			renderWithUserData( {
-				language: 'pt', // Portuguese is marked as incomplete in real data
-				use_fallback_for_incomplete_languages: false,
-			} );
-			await waitFor( () => {
-				expect( screen.getByText( 'Display interface in English' ) ).toBeInTheDocument();
-			} );
+	test( 'shows the current language name as a badge', async () => {
+		renderWithUserData( { language: 'es' } );
+
+		await waitFor( () => {
+			expect( screen.getByText( 'Español' ) ).toBeVisible();
 		} );
+	} );
 
-		it( 'hides fallback field for complete language (Spanish)', async () => {
-			renderWithUserData( {
-				language: 'en', // Spanish is complete in real data
-				use_fallback_for_incomplete_languages: false,
-			} );
+	test( 'links to the language sub-page', async () => {
+		renderWithUserData( { language: 'en' } );
 
-			await waitFor( () => {
-				expect( screen.getByText( 'Interface language' ) ).toBeInTheDocument();
-			} );
-			expect( screen.queryByText( 'Display interface in English' ) ).toBe( null );
-		} );
-
-		it( 'shows enable_translator field for translatable language (Spanish)', async () => {
-			renderWithUserData( {
-				language: 'es',
-			} );
-
-			await waitFor( () => {
-				expect(
-					screen.getByText( 'Enable the in-page translator where available' )
-				).toBeInTheDocument();
-			} );
-		} );
-
-		it( 'hides enable_translator field for non-translatable language (English)', async () => {
-			renderWithUserData( {
-				language: 'en', // English is non-translatable in real data
-			} );
-
-			await waitFor( () => {
-				expect( screen.getByText( 'Interface language' ) ).toBeInTheDocument();
-			} );
-
-			expect( screen.queryByText( 'Enable the in-page translator where available' ) ).toBe( null );
+		await waitFor( () => {
+			const link = screen.getByRole( 'link', { name: /Language/i } );
+			expect( link ).toHaveAttribute( 'href', '/me/preferences/language' );
 		} );
 	} );
 } );

--- a/client/dashboard/me/preferences-privacy/index.tsx
+++ b/client/dashboard/me/preferences-privacy/index.tsx
@@ -1,15 +1,33 @@
+import { userSettingsQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { shield } from '@wordpress/icons';
+import { seen } from '@wordpress/icons';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
 
 export default function PreferencesPrivacy() {
+	const { data: userSettings } = useQuery( userSettingsQuery() );
+	const isSharingUsageInfo = userSettings ? ! userSettings.tracks_opt_out : undefined;
+
+	const badges =
+		isSharingUsageInfo !== undefined
+			? [
+					{
+						text: isSharingUsageInfo
+							? __( 'Sharing usage information' )
+							: __( 'Not sharing usage information' ),
+						intent: isSharingUsageInfo ? ( 'success' as const ) : undefined,
+					},
+			  ]
+			: undefined;
+
 	return (
 		<RouterLinkSummaryButton
 			to="/me/preferences/privacy"
 			title={ __( 'Privacy' ) }
 			description={ __( 'Manage your privacy settings and data sharing preferences.' ) }
-			decoration={ <Icon icon={ shield } size={ 24 } /> }
+			decoration={ <Icon icon={ seen } size={ 24 } /> }
+			badges={ badges }
 		/>
 	);
 }

--- a/client/dashboard/me/preferences/index.tsx
+++ b/client/dashboard/me/preferences/index.tsx
@@ -6,7 +6,7 @@ import PageLayout from '../../components/page-layout';
 import PreferencesAiMcp from '../preferences-ai-mcp';
 import PreferencesBlockedSites from '../preferences-blocked-sites';
 import PreferencesDefaultLanding from '../preferences-default-landing';
-import PreferencesLanguageForm from '../preferences-language';
+import PreferencesLanguage from '../preferences-language';
 import PreferencesNewHostingDashboard from '../preferences-new-hosting-dashboard';
 import PreferencesPrimarySite from '../preferences-primary-site';
 import PreferencesPrivacy from '../preferences-privacy';
@@ -26,9 +26,9 @@ export default function Preferences() {
 		>
 			{ optIn && <PreferencesNewHostingDashboard /> }
 			{ isEnabled( 'mcp-settings' ) && <PreferencesAiMcp /> }
+			<PreferencesLanguage />
 			{ supports.reader && <PreferencesBlockedSites /> }
 			<PreferencesPrivacy />
-			<PreferencesLanguageForm />
 			<PreferencesPrimarySite />
 			<PreferencesDefaultLanding />
 		</PageLayout>

--- a/client/dashboard/me/preferences/index.tsx
+++ b/client/dashboard/me/preferences/index.tsx
@@ -5,10 +5,9 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import PreferencesAiMcp from '../preferences-ai-mcp';
 import PreferencesBlockedSites from '../preferences-blocked-sites';
-import PreferencesDefaultLanding from '../preferences-default-landing';
+import PreferencesDefaults from '../preferences-defaults';
 import PreferencesLanguage from '../preferences-language';
 import PreferencesNewHostingDashboard from '../preferences-new-hosting-dashboard';
-import PreferencesPrimarySite from '../preferences-primary-site';
 import PreferencesPrivacy from '../preferences-privacy';
 
 export default function Preferences() {
@@ -27,10 +26,9 @@ export default function Preferences() {
 			{ optIn && <PreferencesNewHostingDashboard /> }
 			{ isEnabled( 'mcp-settings' ) && <PreferencesAiMcp /> }
 			<PreferencesLanguage />
+			<PreferencesDefaults />
 			{ supports.reader && <PreferencesBlockedSites /> }
 			<PreferencesPrivacy />
-			<PreferencesPrimarySite />
-			<PreferencesDefaultLanding />
 		</PageLayout>
 	);
 }

--- a/client/dashboard/me/preferences/index.tsx
+++ b/client/dashboard/me/preferences/index.tsx
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useAppContext } from '../../app/context';
 import { PageHeader } from '../../components/page-header';
@@ -23,12 +24,14 @@ export default function Preferences() {
 				/>
 			}
 		>
-			{ optIn && <PreferencesNewHostingDashboard /> }
-			{ isEnabled( 'mcp-settings' ) && <PreferencesAiMcp /> }
-			<PreferencesLanguage />
-			<PreferencesDefaults />
-			{ supports.reader && <PreferencesBlockedSites /> }
-			<PreferencesPrivacy />
+			<VStack spacing={ 4 }>
+				{ optIn && <PreferencesNewHostingDashboard /> }
+				{ isEnabled( 'mcp-settings' ) && <PreferencesAiMcp /> }
+				<PreferencesLanguage />
+				<PreferencesDefaults />
+				{ supports.reader && <PreferencesBlockedSites /> }
+				<PreferencesPrivacy />
+			</VStack>
 		</PageLayout>
 	);
 }

--- a/client/dashboard/me/preferences/index.tsx
+++ b/client/dashboard/me/preferences/index.tsx
@@ -29,8 +29,8 @@ export default function Preferences() {
 				{ isEnabled( 'mcp-settings' ) && <PreferencesAiMcp /> }
 				<PreferencesLanguage />
 				<PreferencesDefaults />
-				{ supports.reader && <PreferencesBlockedSites /> }
 				<PreferencesPrivacy />
+				{ supports.reader && <PreferencesBlockedSites /> }
 			</VStack>
 		</PageLayout>
 	);

--- a/client/dashboard/me/privacy/usage-information-card.tsx
+++ b/client/dashboard/me/privacy/usage-information-card.tsx
@@ -42,9 +42,7 @@ export default function UsageInformationCard() {
 	const fields: Field< { tracks_opt_out: boolean } >[] = [
 		{
 			id: 'tracks_opt_out',
-			label: __(
-				'Share information with our analytics tool about your use of services while logged in to your WordPress.com account.'
-			),
+			label: __( 'Enable usage information sharing' ),
 			Edit: ( { field, onChange, data, hideLabelFromVision } ) => {
 				const { id, label, getValue } = field;
 				return (

--- a/client/dashboard/me/security/index.tsx
+++ b/client/dashboard/me/security/index.tsx
@@ -29,7 +29,7 @@ function Security() {
 				/>
 			}
 		>
-			<VStack spacing={ 6 }>
+			<VStack spacing={ 4 }>
 				<SecurityPasswordSummary />
 				<SecurityAccountRecoverySummary />
 				<SecurityTwoStepAuthSummary />

--- a/client/dashboard/me/wordpress-defaults/index.tsx
+++ b/client/dashboard/me/wordpress-defaults/index.tsx
@@ -1,0 +1,264 @@
+import {
+	rawUserPreferencesQuery,
+	userPreferencesMutation,
+	userSettingsMutation,
+	userSettingsQuery,
+} from '@automattic/api-queries';
+import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { __experimentalVStack as VStack, Button } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { DataForm, Field } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useState } from 'react';
+import { useAuth } from '../../app/auth';
+import Breadcrumbs from '../../app/breadcrumbs';
+import { useAppContext } from '../../app/context';
+import { NavigationBlocker } from '../../app/navigation-blocker';
+import { ButtonStack } from '../../components/button-stack/';
+import { Card, CardBody } from '../../components/card';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import { SectionHeader } from '../../components/section-header';
+import PreferencesLoginSiteDropdown from '../preferences-primary-site/site-dropdown';
+
+type LandingPage = 'primary-site-dashboard' | 'sites' | 'reader';
+
+interface DefaultLandingFormData {
+	defaultLandingPage: LandingPage;
+}
+
+interface PrimarySiteFormData {
+	primarySiteId?: number;
+}
+
+function LandingPageCard() {
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	const { data: defaultLandingPage } = useSuspenseQuery( {
+		...rawUserPreferencesQuery(),
+		select: ( preferences ): LandingPage => {
+			if ( preferences[ 'sites-landing-page' ]?.useSitesAsLandingPage ) {
+				return 'sites';
+			}
+			if ( preferences[ 'reader-landing-page' ]?.useReaderAsLandingPage ) {
+				return 'reader';
+			}
+			return 'primary-site-dashboard';
+		},
+	} );
+
+	const { mutateAsync: saveUserPreferences, isPending } = useMutation( userPreferencesMutation() );
+
+	const [ formData, setFormData ] = useState< DefaultLandingFormData >( {
+		defaultLandingPage,
+	} );
+
+	const isDirty = defaultLandingPage !== formData.defaultLandingPage;
+
+	const fields: Field< DefaultLandingFormData >[] = [
+		{
+			id: 'defaultLandingPage',
+			label: __( 'Page' ),
+			Edit: 'radio',
+			elements: [
+				{ label: __( "Open your primary site's dashboard." ), value: 'primary-site-dashboard' },
+				{ label: __( 'See a list of all your sites.' ), value: 'sites' },
+				{ label: __( 'View posts from sites you follow.' ), value: 'reader' },
+			] satisfies { label: string; value: LandingPage }[],
+		},
+	];
+
+	const form = {
+		layout: { type: 'regular' as const },
+		fields: [ 'defaultLandingPage' ],
+	};
+
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+		const updatedAt = Date.now();
+		saveUserPreferences( {
+			'sites-landing-page': {
+				useSitesAsLandingPage: formData.defaultLandingPage === 'sites',
+				updatedAt,
+			},
+			'reader-landing-page': {
+				useReaderAsLandingPage: formData.defaultLandingPage === 'reader',
+				updatedAt,
+			},
+		} )
+			.then( () => {
+				createSuccessNotice( __( 'Default landing page saved.' ), {
+					type: 'snackbar',
+				} );
+			} )
+			.catch( () => {
+				createErrorNotice( __( 'Failed to save default landing page.' ), {
+					type: 'snackbar',
+				} );
+			} );
+	};
+
+	return (
+		<Card>
+			<CardBody>
+				<form onSubmit={ handleSubmit }>
+					<VStack spacing={ 4 }>
+						<SectionHeader
+							level={ 3 }
+							title={ __( 'Landing page' ) }
+							description={ __( 'Choose your destination after you log in.' ) }
+						/>
+						<NavigationBlocker shouldBlock={ isDirty } />
+						<DataForm< DefaultLandingFormData >
+							data={ formData }
+							fields={ fields }
+							form={ form }
+							onChange={ ( edits: Partial< DefaultLandingFormData > ) => {
+								setFormData( ( data ) => ( { ...data, ...edits } ) );
+							} }
+						/>
+						<ButtonStack>
+							<Button
+								__next40pxDefaultSize
+								variant="primary"
+								type="submit"
+								isBusy={ isPending }
+								disabled={ isPending || ! isDirty }
+							>
+								{ __( 'Save' ) }
+							</Button>
+						</ButtonStack>
+					</VStack>
+				</form>
+			</CardBody>
+		</Card>
+	);
+}
+
+function PrimarySiteCard() {
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const { user } = useAuth();
+	const { queries } = useAppContext();
+
+	const { data: primarySiteId } = useSuspenseQuery( {
+		...userSettingsQuery(),
+		select: ( data ) => data.primary_site_ID,
+	} );
+
+	const { data: sites, isLoading: isSiteListLoading } = useQuery(
+		queries.sitesQuery( { site_visibility: 'visible', include_a8c_owned: false } )
+	);
+
+	const { mutateAsync: saveUserSettings, isPending } = useMutation( userSettingsMutation() );
+
+	const [ formData, setFormData ] = useState< PrimarySiteFormData >( {
+		primarySiteId,
+	} );
+
+	const isDirty = primarySiteId !== formData.primarySiteId;
+
+	const fields: Field< PrimarySiteFormData >[] = [
+		{
+			id: 'primarySiteId',
+			label: __( 'Site' ),
+			isVisible: () => user.visible_site_count > 0,
+			Edit: ( { field, onChange, data, hideLabelFromVision } ) => {
+				const { id, getValue } = field;
+				const value = getValue( { item: data } )?.toString( 10 ) ?? '';
+				return (
+					<PreferencesLoginSiteDropdown
+						sites={ sites ?? [] }
+						isLoading={ isSiteListLoading }
+						value={ value }
+						onChange={ ( newValue ) => {
+							if ( newValue ) {
+								onChange( { [ id ]: parseInt( newValue, 10 ) } );
+							}
+						} }
+						label={ hideLabelFromVision ? '' : field.label }
+						hideLabelFromVision={ hideLabelFromVision }
+					/>
+				);
+			},
+		},
+	];
+
+	const form = {
+		layout: { type: 'regular' as const },
+		fields: [ 'primarySiteId' ],
+	};
+
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+		saveUserSettings( {
+			primary_site_ID: formData.primarySiteId,
+		} )
+			.then( () => {
+				createSuccessNotice( __( 'Primary site saved.' ), {
+					type: 'snackbar',
+				} );
+			} )
+			.catch( () => {
+				createErrorNotice( __( 'Failed to save primary site.' ), {
+					type: 'snackbar',
+				} );
+			} );
+	};
+
+	return (
+		<Card>
+			<CardBody>
+				<form onSubmit={ handleSubmit }>
+					<VStack spacing={ 4 }>
+						<SectionHeader
+							level={ 3 }
+							title={ __( 'Primary site' ) }
+							description={ __( 'Your go-to site, always within reach.' ) }
+						/>
+						<NavigationBlocker shouldBlock={ isDirty } />
+						<DataForm< PrimarySiteFormData >
+							data={ formData }
+							fields={ fields }
+							form={ form }
+							onChange={ ( edits: Partial< PrimarySiteFormData > ) => {
+								setFormData( ( data ) => ( { ...data, ...edits } ) );
+							} }
+						/>
+						<ButtonStack>
+							<Button
+								__next40pxDefaultSize
+								variant="primary"
+								type="submit"
+								isBusy={ isPending }
+								disabled={ isPending || ! isDirty }
+							>
+								{ __( 'Save' ) }
+							</Button>
+						</ButtonStack>
+					</VStack>
+				</form>
+			</CardBody>
+		</Card>
+	);
+}
+
+export default function WordPressDefaults() {
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					prefix={ <Breadcrumbs length={ 2 } /> }
+					title={ __( 'WordPress.com defaults' ) }
+					description={ __( 'Set your starting point after you log in and primary site.' ) }
+				/>
+			}
+		>
+			<VStack spacing={ 4 }>
+				<LandingPageCard />
+				<PrimarySiteCard />
+			</VStack>
+		</PageLayout>
+	);
+}


### PR DESCRIPTION
## Summary

This PR concludes some cleanup work on the new MSD preferences screen since introducing the AI + MCP settings. 

The updates include:

- **Language sub-page**: Extract the Language form into its own page at `/me/preferences/language` with a link card showing the current language as a badge
- **WordPress.com defaults sub-page**: Combine Primary Site and Default Landing Page into a single page at `/me/preferences/defaults` with badges showing current landing page and primary site name
- **Summary badges**: Add status badges to Privacy ("Sharing usage information") and Blocked Sites ("None" / "{count} blocked") link cards
- **UI polish**: Consolidate card spacing on Preferences and Security pages to match Billing (`spacing={4}`), reorder Blocked Sites to last, show plain text empty state for Blocked Sites instead of an empty table, shorten Privacy toggle label

**Before**

<img width="1789" height="1522" alt="image" src="https://github.com/user-attachments/assets/c782966c-0782-4e1b-96f9-f8473247d7d6" />

<img width="1789" height="1522" alt="image" src="https://github.com/user-attachments/assets/a5ba1fd5-8217-451d-b00a-b5c886044015" />

<img width="1789" height="1522" alt="image" src="https://github.com/user-attachments/assets/7c083971-22a5-4fe8-ada4-630d2599bed0" />

**After**
<img width="1789" height="1522" alt="image" src="https://github.com/user-attachments/assets/e24fc4d3-2e35-4e7d-86f0-da34df269f2f" />

<img width="1789" height="1522" alt="image" src="https://github.com/user-attachments/assets/bd0f794f-e2a1-470b-b8cd-72c966b39f49" />

<img width="1789" height="1522" alt="image" src="https://github.com/user-attachments/assets/baa528b3-73e2-4dfb-aef5-0b379ce9b470" />

<img width="1789" height="1522" alt="image" src="https://github.com/user-attachments/assets/b352bb1b-e868-4c5f-85a9-9353d54cdfbc" />

<img width="1789" height="1522" alt="image" src="https://github.com/user-attachments/assets/a7d9444a-dc84-4e66-becb-3b7be1293d4e" />



## Test plan

- [ ] Navigate to `my.localhost:3000/me/preferences`
  - [ ] Verify all 6 link cards render with correct icons, titles, descriptions, and badges
  - [ ] Verify card order: New hosting dashboard → AI and MCP → Language → WordPress.com defaults → Privacy → Blocked sites
  - [ ] Verify card gap matches `/me/billing` spacing
- [ ] Click **Language** card
  - [ ] Verify breadcrumbs show "Preferences / Language"
  - [ ] Verify language dropdown, empathy mode checkbox, and Save button work
  - [ ] Change language and save — verify page reloads with flash message
- [ ] Click **WordPress.com defaults** card
  - [ ] Verify breadcrumbs show "Preferences / WordPress.com defaults"
  - [ ] Verify Landing page card with radio buttons and Save
  - [ ] Verify Primary site card with site dropdown and Save
  - [ ] Change landing page and save — verify snackbar confirmation
- [ ] Click **Privacy** card
  - [ ] Verify toggle label reads "Enable usage information sharing"
  - [ ] Toggle and verify snackbar confirmation
- [ ] Click **Blocked sites** card
  - [ ] With no blocked sites: verify plain text "You haven't blocked any sites yet." (no empty table)
  - [ ] With blocked sites: verify table renders with unblock action
- [ ] Navigate to `/me/security` — verify card spacing matches Preferences/Billing


🤖 Generated with [Claude Code](https://claude.com/claude-code)