### PR TITLE
Dashboard: Allow to change the WordPress version for sites with backup.

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -36,6 +36,7 @@ import {
 	siteStaticFile404SettingQuery,
 	siteWordPressVersionQuery,
 	queryClient,
+	wpOrgCoreVersionQuery,
 } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
 import { isSupportSession } from '@automattic/calypso-support-session';
@@ -53,6 +54,7 @@ import {
 	canViewHundredYearPlanSettings,
 	canViewWordPressSettings,
 } from '../../sites/features';
+import { shouldLoadWpVersionNotice } from '../../sites/overview/wp-version-notice';
 import {
 	getActivityLogHiddenGroups,
 	hasHostingFeature,
@@ -200,14 +202,19 @@ export const siteOverviewRoute = createRoute( {
 			}
 		}
 
-		await Promise.all( [
+		const [ preferences ] = await Promise.all( [
+			queryClient.ensureQueryData( rawUserPreferencesQuery() ),
+
 			// Ensure storage specifically is loaded because the warning notice can cause a layout shift
 			queryClient.ensureQueryData( siteMediaStorageQuery( site.ID ) ),
-			queryClient.ensureQueryData( rawUserPreferencesQuery() ),
-			// Ensure wp version specifically is loaded because the wp version notice can cause a layout shift
-			canViewWordPressSettings( site ) &&
-				queryClient.ensureQueryData( siteWordPressVersionQuery( site.ID ) ),
 		] );
+
+		if ( shouldLoadWpVersionNotice( site, preferences ) ) {
+			await Promise.all( [
+				queryClient.ensureQueryData( siteWordPressVersionQuery( site.ID ) ),
+				queryClient.ensureQueryData( wpOrgCoreVersionQuery( 'beta' ) ),
+			] );
+		}
 	},
 } ).lazy( () =>
 	import( '../../sites/overview' ).then( ( d ) =>

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -199,10 +199,14 @@ export const siteOverviewRoute = createRoute( {
 				queryClient.ensureQueryData( purchaseQuery( currentPlan.id ) );
 			}
 		}
-		// Ensure storage specifically is loaded because the warning notice can cause a layout shift
+
 		await Promise.all( [
+			// Ensure storage specifically is loaded because the warning notice can cause a layout shift
 			queryClient.ensureQueryData( siteMediaStorageQuery( site.ID ) ),
 			queryClient.ensureQueryData( rawUserPreferencesQuery() ),
+			// Ensure wp version specifically is loaded because the wp version notice can cause a layout shift
+			canViewWordPressSettings( site ) &&
+				queryClient.ensureQueryData( siteWordPressVersionQuery( site.ID ) ),
 		] );
 	},
 } ).lazy( () =>

--- a/client/dashboard/components/opt-in-survey/index.tsx
+++ b/client/dashboard/components/opt-in-survey/index.tsx
@@ -62,10 +62,8 @@ function checkEligible( welcomeNoticeDismissedAt: string | null ) {
 	return Date.now() >= lastDismissedDate.getTime() + RESHOW_AFTER_MS;
 }
 
-export default function OptInSurvey() {
+export function useShouldShowOptInSurvey() {
 	const { optIn } = useAppContext();
-	const { recordTracksEvent } = useAnalytics();
-	const [ isDismissed, setIsDismissed ] = useState( false );
 
 	const { data: dashboardOptIn } = useSuspenseQuery(
 		userPreferenceQuery( 'hosting-dashboard-opt-in' )
@@ -82,7 +80,22 @@ export default function OptInSurvey() {
 		)
 	);
 
-	if ( ! optIn || ! isEligible || isDismissed ) {
+	return optIn && isEligible;
+}
+
+export default function OptInSurvey() {
+	const shouldShow = useShouldShowOptInSurvey();
+	const { recordTracksEvent } = useAnalytics();
+	const [ isDismissed, setIsDismissed ] = useState( false );
+
+	const { data: dashboardOptIn } = useSuspenseQuery(
+		userPreferenceQuery( 'hosting-dashboard-opt-in' )
+	);
+	const { data: welcomeNoticeDismissedAt } = useSuspenseQuery(
+		userPreferenceQuery( 'hosting-dashboard-welcome-notice-dismissed' )
+	);
+
+	if ( ! shouldShow || isDismissed ) {
 		return null;
 	}
 

--- a/client/dashboard/sites/features.ts
+++ b/client/dashboard/sites/features.ts
@@ -40,8 +40,9 @@ export function canViewHundredYearPlanSettings( site: Site ) {
 
 // Settings -> Server
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function canViewWordPressSettings( site: Site ) {
-	return site.is_wpcom_staging_site;
+	return true;
 }
 
 // Settings -> Actions & danger zone

--- a/client/dashboard/sites/features.ts
+++ b/client/dashboard/sites/features.ts
@@ -41,7 +41,7 @@ export function canViewHundredYearPlanSettings( site: Site ) {
 // Settings -> Server
 
 export function canViewWordPressSettings( site: Site ) {
-	return hasPlanFeature( site, HostingFeatures.BACKUPS );
+	return hasHostingFeature( site, HostingFeatures.BACKUPS );
 }
 
 // Settings -> Actions & danger zone

--- a/client/dashboard/sites/features.ts
+++ b/client/dashboard/sites/features.ts
@@ -40,9 +40,8 @@ export function canViewHundredYearPlanSettings( site: Site ) {
 
 // Settings -> Server
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function canViewWordPressSettings( site: Site ) {
-	return true;
+	return hasPlanFeature( site, HostingFeatures.SFTP );
 }
 
 // Settings -> Actions & danger zone

--- a/client/dashboard/sites/features.ts
+++ b/client/dashboard/sites/features.ts
@@ -41,7 +41,7 @@ export function canViewHundredYearPlanSettings( site: Site ) {
 // Settings -> Server
 
 export function canViewWordPressSettings( site: Site ) {
-	return hasPlanFeature( site, HostingFeatures.SFTP );
+	return hasPlanFeature( site, HostingFeatures.BACKUPS );
 }
 
 // Settings -> Actions & danger zone

--- a/client/dashboard/sites/features.ts
+++ b/client/dashboard/sites/features.ts
@@ -1,4 +1,5 @@
 import { DotcomFeatures, HostingFeatures } from '@automattic/api-core';
+import { isEnabled } from '@automattic/calypso-config';
 import { isDashboardBackport } from '../utils/is-dashboard-backport';
 import { hasHostingFeature, hasPlanFeature } from '../utils/site-features';
 import { isSiteMigrationInProgress } from '../utils/site-status';
@@ -41,7 +42,10 @@ export function canViewHundredYearPlanSettings( site: Site ) {
 // Settings -> Server
 
 export function canViewWordPressSettings( site: Site ) {
-	return hasHostingFeature( site, HostingFeatures.BACKUPS );
+	if ( isEnabled( 'dashboard/wp-beta-program' ) ) {
+		return hasHostingFeature( site, HostingFeatures.BACKUPS );
+	}
+	return site.is_wpcom_staging_site;
 }
 
 // Settings -> Actions & danger zone

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -40,6 +40,7 @@ import VisibilityCardCiab from '../overview-visibility-card-ciab';
 import { InaccessibleJetpackNotice } from '../site/notices';
 import StagingSiteSyncDropdown from '../staging-site-sync-dropdown';
 import { StorageWarningBanner } from './storage-warning-banner';
+import { WpVersionNotice } from './wp-version-notice';
 import type { Site } from '@automattic/api-core';
 import type { WPBreakpoint } from '@wordpress/compose/build-types/hooks/use-viewport-match';
 import './style.scss';
@@ -242,6 +243,7 @@ function SiteOverview( {
 						<InaccessibleJetpackNotice error={ site.__inaccessible_jetpack_error } />
 					) }
 					{ ! isDashboardBackport() && <OptInSurvey /> }
+					<WpVersionNotice site={ site } />
 				</>
 			}
 		>

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -15,12 +15,13 @@ import { useRef } from 'react';
 import { useAppContext } from '../../app/context';
 import { PerformanceTrackerStop } from '../../app/performance-tracking';
 import { GuidedTourContextProvider, GuidedTourStep } from '../../components/guided-tour';
-import OptInSurvey from '../../components/opt-in-survey';
+import OptInSurvey, { useShouldShowOptInSurvey } from '../../components/opt-in-survey';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { isSelfHostedJetpackConnected, isCommerceGarden } from '../../utils/site-types';
+import { canViewWordPressSettings } from '../features';
 import AgencySiteShareCard from '../overview-agency-site-share-card';
 import BackupCard from '../overview-backup-card';
 import DIFMUpsellCard from '../overview-difm-upsell-card';
@@ -40,7 +41,7 @@ import VisibilityCardCiab from '../overview-visibility-card-ciab';
 import { InaccessibleJetpackNotice } from '../site/notices';
 import StagingSiteSyncDropdown from '../staging-site-sync-dropdown';
 import { StorageWarningBanner } from './storage-warning-banner';
-import { WpVersionNotice } from './wp-version-notice';
+import { WpVersionNotice, useShouldShowWpVersionNotice } from './wp-version-notice';
 import type { Site } from '@automattic/api-core';
 import type { WPBreakpoint } from '@wordpress/compose/build-types/hooks/use-viewport-match';
 import './style.scss';
@@ -194,6 +195,24 @@ function SiteOverview( {
 	} );
 
 	const wpAdminButtonRef = useRef( null );
+	const shouldShowOptInSurvey = useShouldShowOptInSurvey();
+	const shouldShowWpVersionNotice = useShouldShowWpVersionNotice( site );
+
+	const renderNotices = () => {
+		if ( site.__inaccessible_jetpack_error ) {
+			return <InaccessibleJetpackNotice error={ site.__inaccessible_jetpack_error } />;
+		}
+
+		if ( canViewWordPressSettings( site ) && shouldShowWpVersionNotice ) {
+			return <WpVersionNotice site={ site } />;
+		}
+
+		if ( ! isDashboardBackport() && shouldShowOptInSurvey ) {
+			return <OptInSurvey />;
+		}
+
+		return null;
+	};
 
 	const renderActions = () => {
 		if ( ! site.options?.admin_url ) {
@@ -237,15 +256,7 @@ function SiteOverview( {
 					actions={ renderActions() }
 				/>
 			}
-			notices={
-				<>
-					{ !! site.__inaccessible_jetpack_error && (
-						<InaccessibleJetpackNotice error={ site.__inaccessible_jetpack_error } />
-					) }
-					{ ! isDashboardBackport() && <OptInSurvey /> }
-					<WpVersionNotice site={ site } />
-				</>
-			}
+			notices={ renderNotices() }
 		>
 			<VStack alignment="stretch" spacing={ isSmallViewport ? 5 : 10 }>
 				<StorageWarningBanner site={ site } />

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -21,7 +21,6 @@ import PageLayout from '../../components/page-layout';
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { isSelfHostedJetpackConnected, isCommerceGarden } from '../../utils/site-types';
-import { canViewWordPressSettings } from '../features';
 import AgencySiteShareCard from '../overview-agency-site-share-card';
 import BackupCard from '../overview-backup-card';
 import DIFMUpsellCard from '../overview-difm-upsell-card';
@@ -203,7 +202,7 @@ function SiteOverview( {
 			return <InaccessibleJetpackNotice error={ site.__inaccessible_jetpack_error } />;
 		}
 
-		if ( canViewWordPressSettings( site ) && shouldShowWpVersionNotice ) {
+		if ( shouldShowWpVersionNotice ) {
 			return <WpVersionNotice site={ site } />;
 		}
 

--- a/client/dashboard/sites/overview/wp-version-notice.tsx
+++ b/client/dashboard/sites/overview/wp-version-notice.tsx
@@ -8,21 +8,26 @@ import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { __, sprintf } from '@wordpress/i18n';
 import Notice from '../../components/notice';
 import RouterLinkButton from '../../components/router-link-button';
+import { canViewWordPressSettings } from '../features';
 import type { Site } from '@automattic/api-core';
 
 const PREFERENCE_KEY = 'hosting-dashboard-wp-beta-notice-dismissed' as const;
 
 export function useShouldShowWpVersionNotice( site: Site ) {
+	const canView = canViewWordPressSettings( site );
 	const { data: isDismissed } = useSuspenseQuery(
 		userPreferenceQuery( `${ PREFERENCE_KEY }-${ site.ID }` )
 	);
 
-	const { data: currentVersionTag } = useSuspenseQuery( siteWordPressVersionQuery( site.ID ) );
+	const { data: currentVersionTag } = useSuspenseQuery( {
+		...siteWordPressVersionQuery( site.ID ),
+		...( canView ? {} : { queryFn: () => Promise.resolve( '' ) } ),
+	} );
 
 	const { data: betaVersion } = useSuspenseQuery( wpOrgCoreVersionQuery( 'beta' ) );
 
 	// Don't show if already dismissed, already on beta, or no beta version available.
-	return ! isDismissed && currentVersionTag !== 'beta' && betaVersion;
+	return canView && ! isDismissed && currentVersionTag !== 'beta' && betaVersion;
 }
 
 export function WpVersionNotice( { site }: { site: Site } ) {

--- a/client/dashboard/sites/overview/wp-version-notice.tsx
+++ b/client/dashboard/sites/overview/wp-version-notice.tsx
@@ -1,0 +1,54 @@
+import {
+	userPreferenceQuery,
+	userPreferenceMutation,
+	siteWordPressVersionQuery,
+	wpOrgCoreVersionQuery,
+} from '@automattic/api-queries';
+import { useSuspenseQuery, useQuery, useMutation } from '@tanstack/react-query';
+import { __, sprintf } from '@wordpress/i18n';
+import Notice from '../../components/notice';
+import RouterLinkButton from '../../components/router-link-button';
+import type { Site } from '@automattic/api-core';
+
+const PREFERENCE_KEY = 'hosting-dashboard-wp-beta-notice-dismissed';
+
+export function WpVersionNotice( { site }: { site: Site } ) {
+	const { data: isDismissedPersisted } = useSuspenseQuery(
+		userPreferenceQuery( `${ PREFERENCE_KEY }-${ site.ID }` )
+	);
+	const { mutate: dismiss, isPending: isDismissing } = useMutation(
+		userPreferenceMutation( `${ PREFERENCE_KEY }-${ site.ID }` )
+	);
+
+	const { data: currentVersionTag } = useQuery( siteWordPressVersionQuery( site.ID ) );
+	const { data: betaVersion } = useQuery( wpOrgCoreVersionQuery( 'beta' ) );
+
+	// Optimistically hide after dismiss click.
+	const isDismissed = isDismissedPersisted || isDismissing;
+
+	// Don't show if already dismissed, already on beta, or no beta version available.
+	if ( isDismissed || currentVersionTag === 'beta' || ! betaVersion ) {
+		return null;
+	}
+
+	return (
+		<Notice
+			variant="info"
+			title={ sprintf(
+				// translators: %s: WordPress version number, e.g. "7.0"
+				__( 'WordPress %s is available for early access' ),
+				betaVersion
+			) }
+			onClose={ () => dismiss( new Date().toISOString() ) }
+			actions={
+				<RouterLinkButton variant="primary" to={ `/sites/${ site.slug }/settings/wordpress` }>
+					{ __( 'Try it now' ) }
+				</RouterLinkButton>
+			}
+		>
+			{ __(
+				'You can switch your site to the latest beta version of WordPress from your site settings. A backup is created automatically before every switch.'
+			) }
+		</Notice>
+	);
+}

--- a/client/dashboard/sites/overview/wp-version-notice.tsx
+++ b/client/dashboard/sites/overview/wp-version-notice.tsx
@@ -12,19 +12,29 @@ import type { Site } from '@automattic/api-core';
 
 const PREFERENCE_KEY = 'hosting-dashboard-wp-beta-notice-dismissed' as const;
 
-export function WpVersionNotice( { site }: { site: Site } ) {
+export function useShouldShowWpVersionNotice( site: Site ) {
 	const { data: isDismissed } = useSuspenseQuery(
 		userPreferenceQuery( `${ PREFERENCE_KEY }-${ site.ID }` )
 	);
+
+	const { data: currentVersionTag } = useSuspenseQuery( siteWordPressVersionQuery( site.ID ) );
+
+	const { data: betaVersion } = useSuspenseQuery( wpOrgCoreVersionQuery( 'beta' ) );
+
+	// Don't show if already dismissed, already on beta, or no beta version available.
+	return ! isDismissed && currentVersionTag !== 'beta' && betaVersion;
+}
+
+export function WpVersionNotice( { site }: { site: Site } ) {
+	const shouldShow = useShouldShowWpVersionNotice( site );
+
 	const { mutate: dismiss } = useMutation(
 		userPreferenceOptimisticMutation( `${ PREFERENCE_KEY }-${ site.ID }` )
 	);
 
-	const { data: currentVersionTag } = useSuspenseQuery( siteWordPressVersionQuery( site.ID ) );
 	const { data: betaVersion } = useSuspenseQuery( wpOrgCoreVersionQuery( 'beta' ) );
 
-	// Don't show if already dismissed, already on beta, or no beta version available.
-	if ( isDismissed || currentVersionTag === 'beta' || ! betaVersion ) {
+	if ( ! shouldShow ) {
 		return null;
 	}
 

--- a/client/dashboard/sites/overview/wp-version-notice.tsx
+++ b/client/dashboard/sites/overview/wp-version-notice.tsx
@@ -4,7 +4,7 @@ import {
 	siteWordPressVersionQuery,
 	wpOrgCoreVersionQuery,
 } from '@automattic/api-queries';
-import { useSuspenseQuery, useQuery, useMutation } from '@tanstack/react-query';
+import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { __, sprintf } from '@wordpress/i18n';
 import Notice from '../../components/notice';
 import RouterLinkButton from '../../components/router-link-button';
@@ -20,8 +20,8 @@ export function WpVersionNotice( { site }: { site: Site } ) {
 		userPreferenceOptimisticMutation( `${ PREFERENCE_KEY }-${ site.ID }` )
 	);
 
-	const { data: currentVersionTag } = useQuery( siteWordPressVersionQuery( site.ID ) );
-	const { data: betaVersion } = useQuery( wpOrgCoreVersionQuery( 'beta' ) );
+	const { data: currentVersionTag } = useSuspenseQuery( siteWordPressVersionQuery( site.ID ) );
+	const { data: betaVersion } = useSuspenseQuery( wpOrgCoreVersionQuery( 'beta' ) );
 
 	// Don't show if already dismissed, already on beta, or no beta version available.
 	if ( isDismissed || currentVersionTag === 'beta' || ! betaVersion ) {

--- a/client/dashboard/sites/overview/wp-version-notice.tsx
+++ b/client/dashboard/sites/overview/wp-version-notice.tsx
@@ -1,36 +1,41 @@
 import {
-	userPreferenceQuery,
 	userPreferenceOptimisticMutation,
 	siteWordPressVersionQuery,
 	wpOrgCoreVersionQuery,
+	rawUserPreferencesQuery,
 } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { __, sprintf } from '@wordpress/i18n';
 import Notice from '../../components/notice';
 import RouterLinkButton from '../../components/router-link-button';
 import { canViewWordPressSettings } from '../features';
-import type { Site } from '@automattic/api-core';
+import type { Site, UserPreferences } from '@automattic/api-core';
 
 const PREFERENCE_KEY = 'hosting-dashboard-wp-beta-notice-dismissed' as const;
 
-export function useShouldShowWpVersionNotice( site: Site ) {
+export function shouldLoadWpVersionNotice( site: Site, preferences: UserPreferences ) {
 	const canView = canViewWordPressSettings( site );
-	const { data: isDismissed } = useSuspenseQuery(
-		userPreferenceQuery( `${ PREFERENCE_KEY }-${ site.ID }` )
-	);
+	const isDismissed = preferences[ `${ PREFERENCE_KEY }-${ site.ID }` ];
+
+	return canView && ! isDismissed;
+}
+
+export function useShouldShowWpVersionNotice( site: Site ) {
+	const { data: preferences } = useSuspenseQuery( rawUserPreferencesQuery() );
+	const shouldLoad = shouldLoadWpVersionNotice( site, preferences );
 
 	const { data: currentVersionTag } = useQuery( {
 		...siteWordPressVersionQuery( site.ID ),
-		enabled: canView,
+		enabled: shouldLoad,
 	} );
 
-	const { data: betaVersion } = useSuspenseQuery( {
+	const { data: betaVersion } = useQuery( {
 		...wpOrgCoreVersionQuery( 'beta' ),
-		...( canView ? {} : { queryFn: () => Promise.resolve( '' ) } ),
+		enabled: shouldLoad,
 	} );
 
-	// Don't show if already dismissed, already on beta, or no beta version available.
-	return canView && ! isDismissed && currentVersionTag !== 'beta' && betaVersion;
+	// Don't show if already already on beta, or no beta version available.
+	return shouldLoad && currentVersionTag !== 'beta' && betaVersion;
 }
 
 export function WpVersionNotice( { site }: { site: Site } ) {

--- a/client/dashboard/sites/overview/wp-version-notice.tsx
+++ b/client/dashboard/sites/overview/wp-version-notice.tsx
@@ -10,7 +10,7 @@ import Notice from '../../components/notice';
 import RouterLinkButton from '../../components/router-link-button';
 import type { Site } from '@automattic/api-core';
 
-const PREFERENCE_KEY = 'hosting-dashboard-wp-beta-notice-dismissed';
+const PREFERENCE_KEY = 'hosting-dashboard-wp-beta-notice-dismissed' as const;
 
 export function WpVersionNotice( { site }: { site: Site } ) {
 	const { data: isDismissed } = useSuspenseQuery(

--- a/client/dashboard/sites/overview/wp-version-notice.tsx
+++ b/client/dashboard/sites/overview/wp-version-notice.tsx
@@ -4,7 +4,7 @@ import {
 	siteWordPressVersionQuery,
 	wpOrgCoreVersionQuery,
 } from '@automattic/api-queries';
-import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
+import { useQuery, useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { __, sprintf } from '@wordpress/i18n';
 import Notice from '../../components/notice';
 import RouterLinkButton from '../../components/router-link-button';
@@ -19,9 +19,9 @@ export function useShouldShowWpVersionNotice( site: Site ) {
 		userPreferenceQuery( `${ PREFERENCE_KEY }-${ site.ID }` )
 	);
 
-	const { data: currentVersionTag } = useSuspenseQuery( {
+	const { data: currentVersionTag } = useQuery( {
 		...siteWordPressVersionQuery( site.ID ),
-		...( canView ? {} : { queryFn: () => Promise.resolve( '' ) } ),
+		enabled: canView,
 	} );
 
 	const { data: betaVersion } = useSuspenseQuery( {

--- a/client/dashboard/sites/overview/wp-version-notice.tsx
+++ b/client/dashboard/sites/overview/wp-version-notice.tsx
@@ -14,7 +14,7 @@ import type { Site, UserPreferences } from '@automattic/api-core';
 const PREFERENCE_KEY = 'hosting-dashboard-wp-beta-notice-dismissed' as const;
 
 export function shouldLoadWpVersionNotice( site: Site, preferences: UserPreferences ) {
-	const canView = canViewWordPressSettings( site );
+	const canView = canViewWordPressSettings( site ) && ! site.is_wpcom_staging_site;
 	const isDismissed = preferences[ `${ PREFERENCE_KEY }-${ site.ID }` ];
 
 	return canView && ! isDismissed;

--- a/client/dashboard/sites/overview/wp-version-notice.tsx
+++ b/client/dashboard/sites/overview/wp-version-notice.tsx
@@ -24,7 +24,10 @@ export function useShouldShowWpVersionNotice( site: Site ) {
 		...( canView ? {} : { queryFn: () => Promise.resolve( '' ) } ),
 	} );
 
-	const { data: betaVersion } = useSuspenseQuery( wpOrgCoreVersionQuery( 'beta' ) );
+	const { data: betaVersion } = useSuspenseQuery( {
+		...wpOrgCoreVersionQuery( 'beta' ),
+		...( canView ? {} : { queryFn: () => Promise.resolve( '' ) } ),
+	} );
 
 	// Don't show if already dismissed, already on beta, or no beta version available.
 	return canView && ! isDismissed && currentVersionTag !== 'beta' && betaVersion;

--- a/client/dashboard/sites/overview/wp-version-notice.tsx
+++ b/client/dashboard/sites/overview/wp-version-notice.tsx
@@ -1,6 +1,6 @@
 import {
 	userPreferenceQuery,
-	userPreferenceMutation,
+	userPreferenceOptimisticMutation,
 	siteWordPressVersionQuery,
 	wpOrgCoreVersionQuery,
 } from '@automattic/api-queries';
@@ -13,18 +13,15 @@ import type { Site } from '@automattic/api-core';
 const PREFERENCE_KEY = 'hosting-dashboard-wp-beta-notice-dismissed';
 
 export function WpVersionNotice( { site }: { site: Site } ) {
-	const { data: isDismissedPersisted } = useSuspenseQuery(
+	const { data: isDismissed } = useSuspenseQuery(
 		userPreferenceQuery( `${ PREFERENCE_KEY }-${ site.ID }` )
 	);
-	const { mutate: dismiss, isPending: isDismissing } = useMutation(
-		userPreferenceMutation( `${ PREFERENCE_KEY }-${ site.ID }` )
+	const { mutate: dismiss } = useMutation(
+		userPreferenceOptimisticMutation( `${ PREFERENCE_KEY }-${ site.ID }` )
 	);
 
 	const { data: currentVersionTag } = useQuery( siteWordPressVersionQuery( site.ID ) );
 	const { data: betaVersion } = useQuery( wpOrgCoreVersionQuery( 'beta' ) );
-
-	// Optimistically hide after dismiss click.
-	const isDismissed = isDismissedPersisted || isDismissing;
 
 	// Don't show if already dismissed, already on beta, or no beta version available.
 	if ( isDismissed || currentVersionTag === 'beta' || ! betaVersion ) {

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -1,3 +1,4 @@
+import { HostingFeatures } from '@automattic/api-core';
 import {
 	siteBySlugQuery,
 	siteWordPressVersionQuery,
@@ -15,15 +16,28 @@ import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import { hasHostingFeature } from '../../utils/site-features';
 import { formatWordPressVersion } from '../../utils/wp-version';
+import HostingFeatureGatedWithCallout from '../hosting-feature-gated-with-callout';
 import type { Field } from '@wordpress/dataviews';
 
 export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-	const { data: currentVersion } = useQuery( siteWordPressVersionQuery( site.ID ) );
+	const canView = hasHostingFeature( site, HostingFeatures.SFTP );
 
-	const { data: latestVersion } = useQuery( wpOrgCoreVersionQuery() );
-	const { data: betaVersion } = useQuery( wpOrgCoreVersionQuery( 'beta' ) );
+	const { data: currentVersion } = useQuery( {
+		...siteWordPressVersionQuery( site.ID ),
+		enabled: canView,
+	} );
+
+	const { data: latestVersion } = useQuery( {
+		...wpOrgCoreVersionQuery(),
+		enabled: canView,
+	} );
+	const { data: betaVersion } = useQuery( {
+		...wpOrgCoreVersionQuery( 'beta' ),
+		enabled: canView,
+	} );
 
 	const mutation = useMutation( {
 		...siteWordPressVersionMutation( site.ID ),
@@ -83,33 +97,39 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 				/>
 			}
 		>
-			<Card>
-				<CardBody>
-					<form onSubmit={ handleSubmit }>
-						<VStack spacing={ 4 }>
-							<NavigationBlocker shouldBlock={ isDirty } />
-							<DataForm< { version: string } >
-								data={ formData }
-								fields={ fields }
-								form={ form }
-								onChange={ ( edits: { version?: string } ) => {
-									setFormData( ( data ) => ( { ...data, ...edits } ) );
-								} }
-							/>
-							<ButtonStack justify="flex-start">
-								<Button
-									variant="primary"
-									type="submit"
-									isBusy={ isPending }
-									disabled={ isPending || ! isDirty }
-								>
-									{ __( 'Save' ) }
-								</Button>
-							</ButtonStack>
-						</VStack>
-					</form>
-				</CardBody>
-			</Card>
+			<HostingFeatureGatedWithCallout
+				site={ site }
+				feature={ HostingFeatures.SFTP }
+				upsellId="site-settings-wordpress"
+			>
+				<Card>
+					<CardBody>
+						<form onSubmit={ handleSubmit }>
+							<VStack spacing={ 4 }>
+								<NavigationBlocker shouldBlock={ isDirty } />
+								<DataForm< { version: string } >
+									data={ formData }
+									fields={ fields }
+									form={ form }
+									onChange={ ( edits: { version?: string } ) => {
+										setFormData( ( data ) => ( { ...data, ...edits } ) );
+									} }
+								/>
+								<ButtonStack justify="flex-start">
+									<Button
+										variant="primary"
+										type="submit"
+										isBusy={ isPending }
+										disabled={ isPending || ! isDirty }
+									>
+										{ __( 'Save' ) }
+									</Button>
+								</ButtonStack>
+							</VStack>
+						</form>
+					</CardBody>
+				</Card>
+			</HostingFeatureGatedWithCallout>
 		</PageLayout>
 	);
 }

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -5,44 +5,25 @@ import {
 	wpOrgCoreVersionQuery,
 } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery, useMutation } from '@tanstack/react-query';
-import {
-	__experimentalVStack as VStack,
-	__experimentalText as Text,
-	Button,
-} from '@wordpress/components';
+import { __experimentalVStack as VStack, Button } from '@wordpress/components';
 import { DataForm } from '@wordpress/dataviews';
-import { createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { NavigationBlocker } from '../../app/navigation-blocker';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
-import InlineSupportLink from '../../components/inline-support-link';
-import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import { formatWordPressVersion, getFormattedWordPressVersion } from '../../utils/wp-version';
-import { canViewWordPressSettings } from '../features';
+import { formatWordPressVersion } from '../../utils/wp-version';
 import type { Field } from '@wordpress/dataviews';
 
 export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-	const canView = canViewWordPressSettings( site );
+	const { data: currentVersion } = useQuery( siteWordPressVersionQuery( site.ID ) );
 
-	const { data: currentVersion } = useQuery( {
-		...siteWordPressVersionQuery( site.ID ),
-		enabled: canView,
-	} );
-
-	const { data: latestVersion } = useQuery( {
-		...wpOrgCoreVersionQuery(),
-		enabled: canView,
-	} );
-	const { data: betaVersion } = useQuery( {
-		...wpOrgCoreVersionQuery( 'beta' ),
-		enabled: canView,
-	} );
+	const { data: latestVersion } = useQuery( wpOrgCoreVersionQuery() );
+	const { data: betaVersion } = useQuery( wpOrgCoreVersionQuery( 'beta' ) );
 
 	const mutation = useMutation( {
 		...siteWordPressVersionMutation( site.ID ),
@@ -91,8 +72,17 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 		mutation.mutate( formData.version );
 	};
 
-	const renderForm = () => {
-		return (
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					prefix={ <Breadcrumbs length={ 2 } /> }
+					title="WordPress"
+					description={ __( 'Manage your WordPress version.' ) }
+				/>
+			}
+		>
 			<Card>
 				<CardBody>
 					<form onSubmit={ handleSubmit }>
@@ -120,49 +110,6 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 					</form>
 				</CardBody>
 			</Card>
-		);
-	};
-
-	const renderNotice = () => {
-		return (
-			<Notice>
-				<VStack>
-					<Text as="p">
-						{ sprintf(
-							// translators: %s: WordPress version, e.g. 6.8
-							__( 'Every WordPress.com site runs the latest WordPress version (%s).' ),
-							getFormattedWordPressVersion( site )
-						) }
-					</Text>
-					{ site.is_wpcom_atomic && (
-						<Text as="p">
-							{ createInterpolateElement(
-								__(
-									'Switch to a staging site to test a beta version of the next WordPress release. <learnMoreLink />'
-								),
-								{
-									learnMoreLink: <InlineSupportLink supportContext="switch-to-staging-site" />,
-								}
-							) }
-						</Text>
-					) }
-				</VStack>
-			</Notice>
-		);
-	};
-
-	return (
-		<PageLayout
-			size="small"
-			header={
-				<PageHeader
-					prefix={ <Breadcrumbs length={ 2 } /> }
-					title="WordPress"
-					description={ __( 'Manage your WordPress version.' ) }
-				/>
-			}
-		>
-			{ canView ? renderForm() : renderNotice() }
 		</PageLayout>
 	);
 }

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -6,17 +6,24 @@ import {
 	wpOrgCoreVersionQuery,
 } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery, useMutation } from '@tanstack/react-query';
-import { __experimentalVStack as VStack, Button } from '@wordpress/components';
+import {
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+	Button,
+} from '@wordpress/components';
 import { DataForm } from '@wordpress/dataviews';
-import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 import { useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { NavigationBlocker } from '../../app/navigation-blocker';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
+import InlineSupportLink from '../../components/inline-support-link';
+import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import { formatWordPressVersion } from '../../utils/wp-version';
+import { formatWordPressVersion, getFormattedWordPressVersion } from '../../utils/wp-version';
 import { canViewWordPressSettings } from '../features';
 import HostingFeatureGatedWithCallout from '../hosting-feature-gated-with-callout';
 import type { Field } from '@wordpress/dataviews';
@@ -85,6 +92,45 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 		e.preventDefault();
 		mutation.mutate( formData.version );
 	};
+
+	if ( ! canView ) {
+		return (
+			<PageLayout
+				size="small"
+				header={
+					<PageHeader
+						prefix={ <Breadcrumbs length={ 2 } /> }
+						title="WordPress"
+						description={ __( 'Manage your WordPress version.' ) }
+					/>
+				}
+			>
+				<Notice>
+					<VStack>
+						<Text as="p">
+							{ sprintf(
+								// translators: %s: WordPress version, e.g. 6.8
+								__( 'Every WordPress.com site runs the latest WordPress version (%s).' ),
+								getFormattedWordPressVersion( site )
+							) }
+						</Text>
+						{ site.is_wpcom_atomic && (
+							<Text as="p">
+								{ createInterpolateElement(
+									__(
+										'Switch to a staging site to test a beta version of the next WordPress release. <learnMoreLink />'
+									),
+									{
+										learnMoreLink: <InlineSupportLink supportContext="switch-to-staging-site" />,
+									}
+								) }
+							</Text>
+						) }
+					</VStack>
+				</Notice>
+			</PageLayout>
+		);
+	}
 
 	return (
 		<PageLayout

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -16,14 +16,14 @@ import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import { hasHostingFeature } from '../../utils/site-features';
 import { formatWordPressVersion } from '../../utils/wp-version';
+import { canViewWordPressSettings } from '../features';
 import HostingFeatureGatedWithCallout from '../hosting-feature-gated-with-callout';
 import type { Field } from '@wordpress/dataviews';
 
 export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-	const canView = hasHostingFeature( site, HostingFeatures.SFTP );
+	const canView = canViewWordPressSettings( site );
 
 	const { data: currentVersion } = useQuery( {
 		...siteWordPressVersionQuery( site.ID ),
@@ -99,7 +99,7 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 		>
 			<HostingFeatureGatedWithCallout
 				site={ site }
-				feature={ HostingFeatures.SFTP }
+				feature={ HostingFeatures.BACKUPS }
 				upsellId="site-settings-wordpress"
 			>
 				<Card>

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -17,7 +17,7 @@ import { Card, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { hasHostingFeature } from '../../utils/site-features';
-import { formatWordPressVersion } from '../../utils/wp-version';
+import { formatWordPressVersion, getWordPressVersionTagName } from '../../utils/wp-version';
 import HostingFeatureGatedWithCallout from '../hosting-feature-gated-with-callout';
 import type { Field } from '@wordpress/dataviews';
 
@@ -63,11 +63,15 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 			elements: [
 				{
 					value: 'latest',
-					label: formatWordPressVersion( latestVersion ?? currentWpVersion, 'latest' ),
+					label: `${
+						latestVersion ?? formatWordPressVersion( currentWpVersion )
+					} (${ getWordPressVersionTagName( 'latest' ) })`,
 				},
 				{
 					value: 'beta',
-					label: formatWordPressVersion( betaVersion ?? currentWpVersion, 'beta' ),
+					label: `${
+						betaVersion ?? formatWordPressVersion( currentWpVersion )
+					} (${ getWordPressVersionTagName( 'beta' ) })`,
 				},
 			],
 		},

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -1,4 +1,3 @@
-import { HostingFeatures } from '@automattic/api-core';
 import {
 	siteBySlugQuery,
 	siteWordPressVersionQuery,
@@ -25,7 +24,6 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { formatWordPressVersion, getFormattedWordPressVersion } from '../../utils/wp-version';
 import { canViewWordPressSettings } from '../features';
-import HostingFeatureGatedWithCallout from '../hosting-feature-gated-with-callout';
 import type { Field } from '@wordpress/dataviews';
 
 export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) {
@@ -143,39 +141,33 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 				/>
 			}
 		>
-			<HostingFeatureGatedWithCallout
-				site={ site }
-				feature={ HostingFeatures.BACKUPS }
-				upsellId="site-settings-wordpress"
-			>
-				<Card>
-					<CardBody>
-						<form onSubmit={ handleSubmit }>
-							<VStack spacing={ 4 }>
-								<NavigationBlocker shouldBlock={ isDirty } />
-								<DataForm< { version: string } >
-									data={ formData }
-									fields={ fields }
-									form={ form }
-									onChange={ ( edits: { version?: string } ) => {
-										setFormData( ( data ) => ( { ...data, ...edits } ) );
-									} }
-								/>
-								<ButtonStack justify="flex-start">
-									<Button
-										variant="primary"
-										type="submit"
-										isBusy={ isPending }
-										disabled={ isPending || ! isDirty }
-									>
-										{ __( 'Save' ) }
-									</Button>
-								</ButtonStack>
-							</VStack>
-						</form>
-					</CardBody>
-				</Card>
-			</HostingFeatureGatedWithCallout>
+			<Card>
+				<CardBody>
+					<form onSubmit={ handleSubmit }>
+						<VStack spacing={ 4 }>
+							<NavigationBlocker shouldBlock={ isDirty } />
+							<DataForm< { version: string } >
+								data={ formData }
+								fields={ fields }
+								form={ form }
+								onChange={ ( edits: { version?: string } ) => {
+									setFormData( ( data ) => ( { ...data, ...edits } ) );
+								} }
+							/>
+							<ButtonStack justify="flex-start">
+								<Button
+									variant="primary"
+									type="submit"
+									isBusy={ isPending }
+									disabled={ isPending || ! isDirty }
+								>
+									{ __( 'Save' ) }
+								</Button>
+							</ButtonStack>
+						</VStack>
+					</form>
+				</CardBody>
+			</Card>
 		</PageLayout>
 	);
 }

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -17,7 +17,7 @@ import { Card, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { hasHostingFeature } from '../../utils/site-features';
-import { formatWordPressVersion, getWordPressVersionTagName } from '../../utils/wp-version';
+import { formatWordPressVersion } from '../../utils/wp-version';
 import HostingFeatureGatedWithCallout from '../hosting-feature-gated-with-callout';
 import type { Field } from '@wordpress/dataviews';
 
@@ -63,15 +63,11 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 			elements: [
 				{
 					value: 'latest',
-					label: `${
-						latestVersion ?? formatWordPressVersion( currentWpVersion )
-					} (${ getWordPressVersionTagName( 'latest' ) })`,
+					label: formatWordPressVersion( latestVersion ?? currentWpVersion, 'latest', true ),
 				},
 				{
 					value: 'beta',
-					label: `${
-						betaVersion ?? formatWordPressVersion( currentWpVersion )
-					} (${ getWordPressVersionTagName( 'beta' ) })`,
+					label: formatWordPressVersion( betaVersion ?? currentWpVersion, 'beta', true ),
 				},
 			],
 		},

--- a/client/dashboard/sites/settings-wordpress/test/index.test.tsx
+++ b/client/dashboard/sites/settings-wordpress/test/index.test.tsx
@@ -64,29 +64,26 @@ describe( '<WordPressSettings>', () => {
 		} );
 	} );
 
-	test( 'renders notice for a non-staging site', async () => {
+	test( 'renders and saves the form for a non-staging site', async () => {
+		const user = userEvent.setup();
+
 		mockSite( { ...site, is_wpcom_staging_site: false } as Site );
+		mockWordPressVersion( 'latest' );
 
 		render( <WordPressSettings siteSlug={ site.slug } /> );
 		await screen.findByRole( 'heading', { name: 'WordPress' } );
 
-		expect(
-			screen.getByText( /Every WordPress.com site runs the latest WordPress version/ )
-		).toBeVisible();
-		expect( screen.queryByRole( 'button', { name: 'Save' } ) ).not.toBeInTheDocument();
-	} );
+		const versionSelect = await screen.findByRole( 'combobox', { name: 'WordPress version' } );
+		expect( versionSelect ).toHaveDisplayValue( '6.8.1 (Latest)' );
 
-	test( 'renders staging site suggestion for Atomic non-staging sites', async () => {
-		mockSite( {
-			...site,
-			is_wpcom_staging_site: false,
-			is_wpcom_atomic: true,
-		} as Site );
+		await user.selectOptions( versionSelect, '6.8.1 (Beta)' );
+		const scope = mockWordPressVersionSaved( 'beta' );
 
-		render( <WordPressSettings siteSlug={ site.slug } /> );
-		await screen.findByRole( 'heading', { name: 'WordPress' } );
+		const saveButton = screen.getByRole( 'button', { name: 'Save' } );
+		await user.click( saveButton );
 
-		expect( screen.getByText( /Switch to a staging site to test a beta version/ ) ).toBeVisible();
-		expect( screen.queryByRole( 'button', { name: 'Save' } ) ).not.toBeInTheDocument();
+		await waitFor( () => {
+			expect( scope.isDone() ).toBe( true );
+		} );
 	} );
 } );

--- a/client/dashboard/sites/settings-wordpress/test/index.test.tsx
+++ b/client/dashboard/sites/settings-wordpress/test/index.test.tsx
@@ -50,33 +50,10 @@ function mockWordPressVersionSaved( expectedVersion: string ) {
 }
 
 describe( '<WordPressSettings>', () => {
-	test( 'renders and saves the form for a staging site', async () => {
+	test( 'renders and saves the form for a Business+ site', async () => {
 		const user = userEvent.setup();
 
-		mockSite( { ...site, is_wpcom_staging_site: true } as Site );
-		mockWordPressVersion( 'latest' );
-
-		render( <WordPressSettings siteSlug={ site.slug } /> );
-		await screen.findByRole( 'heading', { name: 'WordPress' } );
-
-		const versionSelect = await screen.findByRole( 'combobox', { name: 'WordPress version' } );
-		expect( versionSelect ).toHaveDisplayValue( '6.8.1 (Latest)' );
-
-		await user.selectOptions( versionSelect, '6.8.1 (Beta)' );
-		const scope = mockWordPressVersionSaved( 'beta' );
-
-		const saveButton = screen.getByRole( 'button', { name: 'Save' } );
-		await user.click( saveButton );
-
-		await waitFor( () => {
-			expect( scope.isDone() ).toBe( true );
-		} );
-	} );
-
-	test( 'renders and saves the form for a non-staging site', async () => {
-		const user = userEvent.setup();
-
-		mockSite( { ...site, is_wpcom_staging_site: false } as Site );
+		mockSite( site );
 		mockWordPressVersion( 'latest' );
 
 		render( <WordPressSettings siteSlug={ site.slug } /> );

--- a/client/dashboard/sites/settings-wordpress/test/index.test.tsx
+++ b/client/dashboard/sites/settings-wordpress/test/index.test.tsx
@@ -12,6 +12,15 @@ import type { Site } from '@automattic/api-core';
 const site = {
 	ID: 123,
 	slug: 'test-site.wordpress.com',
+	is_wpcom_atomic: true,
+	plan: {
+		product_slug: 'business-bundle',
+		product_name_short: 'Business',
+		is_free: false,
+		features: {
+			active: [ 'atomic', 'sftp' ],
+		},
+	},
 	options: {
 		software_version: '6.8.1',
 	},

--- a/client/dashboard/sites/settings-wordpress/test/index.test.tsx
+++ b/client/dashboard/sites/settings-wordpress/test/index.test.tsx
@@ -13,12 +13,13 @@ const site = {
 	ID: 123,
 	slug: 'test-site.wordpress.com',
 	is_wpcom_atomic: true,
+	is_wpcom_staging_site: true,
 	plan: {
 		product_slug: 'business-bundle',
 		product_name_short: 'Business',
 		is_free: false,
 		features: {
-			active: [ 'atomic', 'sftp' ],
+			active: [ 'atomic', 'sftp', 'backups' ],
 		},
 	},
 	options: {

--- a/client/dashboard/utils/wp-version.ts
+++ b/client/dashboard/utils/wp-version.ts
@@ -3,7 +3,7 @@ import { __ } from '@wordpress/i18n';
 import { hasHostingFeature } from './site-features';
 import type { Site } from '@automattic/api-core';
 
-export function getWordPressVersionTagName( versionTag: string ) {
+function getWordPressVersionTagName( versionTag: string ) {
 	if ( versionTag === 'latest' ) {
 		return __( 'Latest' );
 	}

--- a/client/dashboard/utils/wp-version.ts
+++ b/client/dashboard/utils/wp-version.ts
@@ -1,4 +1,6 @@
+import { HostingFeatures } from '@automattic/api-core';
 import { __ } from '@wordpress/i18n';
+import { hasHostingFeature } from './site-features';
 import type { Site } from '@automattic/api-core';
 
 export function getWordPressVersionTagName( versionTag: string ) {
@@ -15,19 +17,31 @@ export function getFormattedWordPressVersion(
 	site: Site,
 	versionTag: string | undefined = undefined
 ) {
-	return formatWordPressVersion( site.options?.software_version ?? '', versionTag );
+	const canManageVersion = hasHostingFeature( site, HostingFeatures.SFTP );
+	return formatWordPressVersion(
+		site.options?.software_version ?? '',
+		versionTag,
+		canManageVersion
+	);
 }
 
 export function formatWordPressVersion(
 	wpVersion: string,
-	versionTag: string | undefined = undefined
+	versionTag: string | undefined = undefined,
+	preservePreRelease: boolean = false
 ) {
 	if ( ! wpVersion ) {
 		return '';
 	}
 
-	// The version string could have suffix like 6.8.1-alpha-60199, e.g. on Simple sites
-	wpVersion = wpVersion.split( '-' )[ 0 ];
+	if ( preservePreRelease ) {
+		// Strip only dev suffixes like "6.8.1-alpha-60199" but keep
+		// meaningful pre-release identifiers like "7.0-RC2" or "7.0-beta1".
+		wpVersion = wpVersion.replace( /-alpha-\d+$/, '' );
+	} else {
+		// The version string could have suffix like 6.8.1-alpha-60199, e.g. on Simple sites
+		wpVersion = wpVersion.split( '-' )[ 0 ];
+	}
 
 	if ( versionTag ) {
 		wpVersion = `${ wpVersion } (${ getWordPressVersionTagName( versionTag ) })`;

--- a/client/dashboard/utils/wp-version.ts
+++ b/client/dashboard/utils/wp-version.ts
@@ -17,7 +17,7 @@ export function getFormattedWordPressVersion(
 	site: Site,
 	versionTag: string | undefined = undefined
 ) {
-	const canManageVersion = hasHostingFeature( site, HostingFeatures.SFTP );
+	const canManageVersion = hasHostingFeature( site, HostingFeatures.BACKUPS );
 	return formatWordPressVersion(
 		site.options?.software_version ?? '',
 		versionTag,

--- a/client/dashboard/utils/wp-version.ts
+++ b/client/dashboard/utils/wp-version.ts
@@ -26,8 +26,9 @@ export function formatWordPressVersion(
 		return '';
 	}
 
-	// The version string could have suffix like 6.8.1-alpha-60199, e.g. on Simple sites
-	wpVersion = wpVersion.split( '-' )[ 0 ];
+	// Strip dev suffixes like "6.8.1-alpha-60199" (Simple sites) but keep
+	// meaningful pre-release identifiers like "7.0-RC2" or "7.0-beta1".
+	wpVersion = wpVersion.replace( /-alpha-\d+$/, '' );
 
 	if ( versionTag ) {
 		wpVersion = `${ wpVersion } (${ getWordPressVersionTagName( versionTag ) })`;

--- a/client/dashboard/utils/wp-version.ts
+++ b/client/dashboard/utils/wp-version.ts
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import type { Site } from '@automattic/api-core';
 
-function getWordPressVersionTagName( versionTag: string ) {
+export function getWordPressVersionTagName( versionTag: string ) {
 	if ( versionTag === 'latest' ) {
 		return __( 'Latest' );
 	}
@@ -26,9 +26,8 @@ export function formatWordPressVersion(
 		return '';
 	}
 
-	// Strip dev suffixes like "6.8.1-alpha-60199" (Simple sites) but keep
-	// meaningful pre-release identifiers like "7.0-RC2" or "7.0-beta1".
-	wpVersion = wpVersion.replace( /-alpha-\d+$/, '' );
+	// The version string could have suffix like 6.8.1-alpha-60199, e.g. on Simple sites
+	wpVersion = wpVersion.split( '-' )[ 0 ];
 
 	if ( versionTag ) {
 		wpVersion = `${ wpVersion } (${ getWordPressVersionTagName( versionTag ) })`;

--- a/client/sites/settings/server/server-configuration-form.tsx
+++ b/client/sites/settings/server/server-configuration-form.tsx
@@ -27,7 +27,8 @@ import { getAtomicHostingWpVersion } from 'calypso/state/selectors/get-atomic-ho
 import getRequest from 'calypso/state/selectors/get-request';
 import { isFetchingAtomicHostingGeoAffinity } from 'calypso/state/selectors/is-fetching-atomic-hosting-geo-affinity';
 import { isFetchingAtomicHostingWpVersion } from 'calypso/state/selectors/is-fetching-atomic-hosting-wp-version';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import type { DataCenterOption } from '@automattic/api-core';
 
 import './server-configuration-form.scss';
@@ -59,6 +60,9 @@ export default function ServerConfigurationForm( { disabled }: ServerConfigurati
 	const translate = useTranslate();
 
 	const siteId = useSelector( getSelectedSiteId );
+	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+
+	const isWpcomStagingSite = useSelector( ( state ) => isSiteWpcomStaging( state, siteId ) );
 	const geoAffinity = useSelector( ( state ) => getAtomicHostingGeoAffinity( state, siteId ) );
 	const phpVersion = useSelector( ( state ) => getAtomicHostingPhpVersion( state, siteId ) );
 	const wpVersion = useSelector( ( state ) => getAtomicHostingWpVersion( state, siteId ) );
@@ -95,6 +99,7 @@ export default function ServerConfigurationForm( { disabled }: ServerConfigurati
 
 	const wpVersionRef = useRef< HTMLLabelElement >( null );
 	const wpVersionDropdownRef = useRef< HTMLSelectElement >( null );
+	const wpVersionExplainerRef = useRef< HTMLParagraphElement >( null );
 
 	const phpVersionRef = useRef< HTMLLabelElement >( null );
 	const phpVersionDropdownRef = useRef< HTMLSelectElement >( null );
@@ -111,7 +116,7 @@ export default function ServerConfigurationForm( { disabled }: ServerConfigurati
 
 			if ( wpVersionRef.current && hash === '#wp' ) {
 				targetLabel = wpVersionRef.current;
-				targetControl = wpVersionDropdownRef.current;
+				targetControl = wpVersionDropdownRef.current || wpVersionExplainerRef.current;
 			} else if ( phpVersionRef.current && hash === '#php' ) {
 				targetLabel = phpVersionRef.current;
 				targetControl = phpVersionDropdownRef.current;
@@ -172,25 +177,42 @@ export default function ServerConfigurationForm( { disabled }: ServerConfigurati
 		return (
 			<FormFieldset>
 				<FormLabel ref={ wpVersionRef }>{ translate( 'WordPress version' ) }</FormLabel>
-				<FormSelect
-					disabled={ disabled || isUpdating }
-					className="web-server-settings-card__wp-version-select"
-					onChange={ ( event ) => setSelectedWpVersion( event.currentTarget.value ) }
-					inputRef={ wpVersionDropdownRef }
-					value={ selectedWpVersionValue }
-				>
-					{ getWpVersions().map( ( option ) => {
-						return (
-							<option
-								disabled={ option.value === wpVersion }
-								value={ option.value }
-								key={ option.label }
-							>
-								{ option.label }
-							</option>
-						);
-					} ) }
-				</FormSelect>
+				{ isWpcomStagingSite && (
+					<>
+						<FormSelect
+							disabled={ disabled || isUpdating }
+							className="web-server-settings-card__wp-version-select"
+							onChange={ ( event ) => setSelectedWpVersion( event.currentTarget.value ) }
+							inputRef={ wpVersionDropdownRef }
+							value={ selectedWpVersionValue }
+						>
+							{ getWpVersions().map( ( option ) => {
+								return (
+									<option
+										disabled={ option.value === wpVersion }
+										value={ option.value }
+										key={ option.label }
+									>
+										{ option.label }
+									</option>
+								);
+							} ) }
+						</FormSelect>
+					</>
+				) }
+				{ ! isWpcomStagingSite && (
+					<FormSettingExplanation ref={ wpVersionExplainerRef }>
+						{ translate(
+							'Every WordPress.com site runs the latest WordPress version. ' +
+								'For testing purposes, you can switch to the beta version of the next WordPress release on {{a}}your staging site{{/a}}.',
+							{
+								components: {
+									a: <a href={ `/staging-site/${ selectedSiteSlug }` } />,
+								},
+							}
+						) }
+					</FormSettingExplanation>
+				) }
 			</FormFieldset>
 		);
 	};

--- a/client/sites/settings/server/server-configuration-form.tsx
+++ b/client/sites/settings/server/server-configuration-form.tsx
@@ -27,8 +27,7 @@ import { getAtomicHostingWpVersion } from 'calypso/state/selectors/get-atomic-ho
 import getRequest from 'calypso/state/selectors/get-request';
 import { isFetchingAtomicHostingGeoAffinity } from 'calypso/state/selectors/is-fetching-atomic-hosting-geo-affinity';
 import { isFetchingAtomicHostingWpVersion } from 'calypso/state/selectors/is-fetching-atomic-hosting-wp-version';
-import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { DataCenterOption } from '@automattic/api-core';
 
 import './server-configuration-form.scss';
@@ -60,9 +59,6 @@ export default function ServerConfigurationForm( { disabled }: ServerConfigurati
 	const translate = useTranslate();
 
 	const siteId = useSelector( getSelectedSiteId );
-	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
-
-	const isWpcomStagingSite = useSelector( ( state ) => isSiteWpcomStaging( state, siteId ) );
 	const geoAffinity = useSelector( ( state ) => getAtomicHostingGeoAffinity( state, siteId ) );
 	const phpVersion = useSelector( ( state ) => getAtomicHostingPhpVersion( state, siteId ) );
 	const wpVersion = useSelector( ( state ) => getAtomicHostingWpVersion( state, siteId ) );
@@ -99,7 +95,6 @@ export default function ServerConfigurationForm( { disabled }: ServerConfigurati
 
 	const wpVersionRef = useRef< HTMLLabelElement >( null );
 	const wpVersionDropdownRef = useRef< HTMLSelectElement >( null );
-	const wpVersionExplainerRef = useRef< HTMLParagraphElement >( null );
 
 	const phpVersionRef = useRef< HTMLLabelElement >( null );
 	const phpVersionDropdownRef = useRef< HTMLSelectElement >( null );
@@ -116,7 +111,7 @@ export default function ServerConfigurationForm( { disabled }: ServerConfigurati
 
 			if ( wpVersionRef.current && hash === '#wp' ) {
 				targetLabel = wpVersionRef.current;
-				targetControl = wpVersionDropdownRef.current || wpVersionExplainerRef.current;
+				targetControl = wpVersionDropdownRef.current;
 			} else if ( phpVersionRef.current && hash === '#php' ) {
 				targetLabel = phpVersionRef.current;
 				targetControl = phpVersionDropdownRef.current;
@@ -177,42 +172,25 @@ export default function ServerConfigurationForm( { disabled }: ServerConfigurati
 		return (
 			<FormFieldset>
 				<FormLabel ref={ wpVersionRef }>{ translate( 'WordPress version' ) }</FormLabel>
-				{ isWpcomStagingSite && (
-					<>
-						<FormSelect
-							disabled={ disabled || isUpdating }
-							className="web-server-settings-card__wp-version-select"
-							onChange={ ( event ) => setSelectedWpVersion( event.currentTarget.value ) }
-							inputRef={ wpVersionDropdownRef }
-							value={ selectedWpVersionValue }
-						>
-							{ getWpVersions().map( ( option ) => {
-								return (
-									<option
-										disabled={ option.value === wpVersion }
-										value={ option.value }
-										key={ option.label }
-									>
-										{ option.label }
-									</option>
-								);
-							} ) }
-						</FormSelect>
-					</>
-				) }
-				{ ! isWpcomStagingSite && (
-					<FormSettingExplanation ref={ wpVersionExplainerRef }>
-						{ translate(
-							'Every WordPress.com site runs the latest WordPress version. ' +
-								'For testing purposes, you can switch to the beta version of the next WordPress release on {{a}}your staging site{{/a}}.',
-							{
-								components: {
-									a: <a href={ `/staging-site/${ selectedSiteSlug }` } />,
-								},
-							}
-						) }
-					</FormSettingExplanation>
-				) }
+				<FormSelect
+					disabled={ disabled || isUpdating }
+					className="web-server-settings-card__wp-version-select"
+					onChange={ ( event ) => setSelectedWpVersion( event.currentTarget.value ) }
+					inputRef={ wpVersionDropdownRef }
+					value={ selectedWpVersionValue }
+				>
+					{ getWpVersions().map( ( option ) => {
+						return (
+							<option
+								disabled={ option.value === wpVersion }
+								value={ option.value }
+								key={ option.label }
+							>
+								{ option.label }
+							</option>
+						);
+					} ) }
+				</FormSelect>
 			</FormFieldset>
 		);
 	};

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -29,6 +29,7 @@
 		"cookie-banner": false,
 		"rum-tracking/logstash": true,
 		"dashboard/omnibar": false,
+		"dashboard/wp-beta-program": true,
 		"dashboard/v2": false,
 		"dev/auth-helper": true,
 		"dev/preferences-helper": true,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -27,6 +27,7 @@
 		"cookie-banner": false,
 		"rum-tracking/logstash": true,
 		"dashboard/omnibar": false,
+		"dashboard/wp-beta-program": false,
 		"dashboard/v2": false,
 		"dev/auth-helper": true,
 		"dev/preferences-helper": true,

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -29,6 +29,7 @@
 		"bilmur-script": true,
 		"rum-tracking/logstash": true,
 		"dashboard/omnibar": false,
+		"dashboard/wp-beta-program": false,
 		"dashboard/v2": false,
 		"domain-transfer-redesign": true,
 		"marketplace-redesign": true,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -27,6 +27,7 @@
 		"cookie-banner": false,
 		"rum-tracking/logstash": true,
 		"dashboard/omnibar": false,
+		"dashboard/wp-beta-program": false,
 		"dashboard/v2": false,
 		"dev/store-sandbox-helper": true,
 		"domain-transfer-redesign": true,

--- a/config/development.json
+++ b/config/development.json
@@ -64,6 +64,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dashboard/omnibar": false,
+		"dashboard/wp-beta-program": true,
 		"dashboard/opt-in-banners": false,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -29,6 +29,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dashboard/omnibar": false,
+		"dashboard/wp-beta-program": false,
 		"dashboard/opt-in-banners": false,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,

--- a/config/production.json
+++ b/config/production.json
@@ -43,6 +43,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dashboard/omnibar": false,
+		"dashboard/wp-beta-program": false,
 		"dashboard/opt-in-banners": false,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -39,6 +39,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dashboard/omnibar": false,
+		"dashboard/wp-beta-program": false,
 		"dashboard/opt-in-banners": false,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -39,6 +39,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dashboard/omnibar": false,
+		"dashboard/wp-beta-program": false,
 		"dashboard/opt-in-banners": false,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,

--- a/packages/api-core/src/me-preferences/types.ts
+++ b/packages/api-core/src/me-preferences/types.ts
@@ -24,10 +24,10 @@ export interface UserPreferences {
 	[ key: `hosting-dashboard-overview-storage-notice-dismissed-${ number }` ]: string | undefined; // Timestamp when the user dismissed the notice
 	[ key: `hosting-dashboard-tours-${ string }` ]: string; // ISO date string when the user completed the tours
 	[ key: `hosting-dashboard-time-mismatch-warning-dismissed-${ number }` ]: string | undefined; // Timestamp when the user dismissed the notice
+	[ key: `hosting-dashboard-wp-beta-notice-dismissed-${ number }` ]: string | undefined; // ISO timestamp when the user dismissed the beta notice for a site
 	'hosting-dashboard-welcome-notice-dismissed'?: string; // Timestamp when the user dismissed the notice
 	'reader-landing-page'?: ReaderLandingPage;
 	'sites-landing-page'?: SitesLandingPage;
 	[ key: `cancel-purchase-survey-completed-${ string | number }` ]: string | undefined;
 	[ key: `cancellation-offer-accepted-notice-dismissed-${ string | number }` ]: string | undefined;
-	[ key: `hosting-dashboard-wp-beta-notice-dismissed-${ number }` ]: string | undefined; // ISO timestamp when the user dismissed the beta notice for a site
 }

--- a/packages/api-core/src/me-preferences/types.ts
+++ b/packages/api-core/src/me-preferences/types.ts
@@ -29,4 +29,5 @@ export interface UserPreferences {
 	'sites-landing-page'?: SitesLandingPage;
 	[ key: `cancel-purchase-survey-completed-${ string | number }` ]: string | undefined;
 	[ key: `cancellation-offer-accepted-notice-dismissed-${ string | number }` ]: string | undefined;
+	[ key: `hosting-dashboard-wp-beta-notice-dismissed-${ number }` ]: string | undefined; // ISO timestamp when the user dismissed the beta notice for a site
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of:
- https://linear.app/a8c/issue/DOTCOM-16564/wordpress-beta-program-on-wpcom-poc

## Proposed Changes

* We can now change the WordPress version for non-staging sites.
* Added a WordPress 7.0 RC beta notice so users can opt in.

https://github.com/user-attachments/assets/889b6071-00ca-4489-a746-ded8a44b6dec

Note: Changes are currently behind the `dashboard/wp-beta-program` feature flag.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is a PoC that shows what a trivial WordPress Beta program on WordPress.com could look like.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link and go to your site's settings screen.
* Apply these changes to your Sandbox: 210054-ghe-Automattic/wpcom
* Change the WordPress version
* It should work as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?