### PR TITLE
Subscribers: Fix layout shift when opening actions dropdown

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -9,6 +9,11 @@ $padding-standard: 16px;
 
 body.is-section-subscribers,
 .theme-jetpack-cloud.is-group-jetpack-cloud.is-section-jetpack-subscribers {
+	// Prevent layout shift when the DataViews actions dropdown opens.
+	// Ariakit's modal dropdown sets overflow:hidden on the body to lock
+	// scrolling, which hides the viewport scrollbar and jerks the content.
+	// This page uses a fixed viewport height with internal scrolling,
+	// so body-level scrolling is unnecessary.
 	overflow: hidden;
 
 	.layout:not( .has-no-sidebar ),

--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -92,6 +92,15 @@ body.is-section-subscribers,
 				display: flex;
 				flex-direction: column;
 
+				// DataViews' height: 100% doesn't resolve inside the
+				// Page content flex layout. Use flex to fill remaining
+				// space so the internal scroll container works.
+				.dataviews-wrapper {
+					height: auto;
+					flex-grow: 1;
+					min-height: 0;
+				}
+
 				.navigation-header {
 					padding: $padding-standard 24px;
 

--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -9,6 +9,8 @@ $padding-standard: 16px;
 
 body.is-section-subscribers,
 .theme-jetpack-cloud.is-group-jetpack-cloud.is-section-jetpack-subscribers {
+	overflow: hidden;
+
 	.layout:not( .has-no-sidebar ),
 	.has-no-masterbar {
 		.layout__content {
@@ -50,6 +52,7 @@ body.is-section-subscribers,
 			position: relative;
 			gap: 24px;
 			height: calc( 100vh - var( --masterbar-height ) - #{$padding-standard * 2} );
+			overflow: hidden;
 
 			@media ( max-width: $break-small ) {
 				padding: 0;

--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -52,7 +52,6 @@ body.is-section-subscribers,
 			position: relative;
 			gap: 24px;
 			height: calc( 100vh - var( --masterbar-height ) - #{$padding-standard * 2} );
-			overflow: hidden;
 
 			@media ( max-width: $break-small ) {
 				padding: 0;


### PR DESCRIPTION
## Proposed Changes

* Add `overflow: hidden` to the body on the subscribers page to prevent a viewport scrollbar from appearing.
* Override `.dataviews-wrapper` to use `flex-grow: 1; min-height: 0` instead of `height: 100%` so the DataViews internal scroll container works correctly within the admin-ui Page flex layout. The goal is to temporarily fix the brokenness until we find the correct upstream fix. Follow-up issue: NL-575

Before:

https://github.com/user-attachments/assets/794619d1-0ec4-4dd2-8bd5-05eb1883d48b

After:

https://github.com/user-attachments/assets/d07069f7-6eb0-4cc3-a825-5398a19ac5df


## Why are these changes being made?

**Scrollbar jerk:** When clicking the actions menu (three-dots button) on a subscriber row, the Ariakit modal dropdown sets `overflow: hidden` on the body to prevent background scrolling. This causes the viewport scrollbar to disappear, shifting the page content. Setting `overflow: hidden` on the body eliminates the scrollbar entirely since this page uses a fixed viewport height layout with internal scrolling.

**Table scroll clipping:** DataViews' `.dataviews-wrapper` uses `height: 100%` which doesn't resolve inside the admin-ui Page content flex layout. This causes the table to grow to full content height and get clipped by `overflow: hidden` on the list container, making the last rows unreachable.

## Testing Instructions

* Navigate to the Subscribers page on a site with subscribers.
* Click the three-dots actions button on any subscriber row.
* Verify the page does not jerk/shift when the dropdown opens.
* Click an action (e.g., "Comp a subscription" or "Remove") and verify no shift when the modal opens.
* Verify the table scrolls correctly and all rows are reachable, including the last one.
* Test at mobile screen sizes.

Note this adds some horizontal scrolling on specific screen sizes so that the columns are also reachable.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)