### PR TITLE
Plans: Update CIAB plan taglines and subheader copy

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -1,6 +1,10 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
-import { UrlFriendlyTermType, isDomainTransfer } from '@automattic/calypso-products';
+import {
+	UrlFriendlyTermType,
+	isDomainTransfer,
+	PLAN_WOO_HOSTED_FREE_TRIAL_MONTHLY,
+} from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { FREE_THEME } from '@automattic/design-picker';
 import {
@@ -18,8 +22,10 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import moment from 'moment';
 import { parse as parseQs } from 'qs';
 import AsyncLoad from 'calypso/components/async-load';
+import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import FormattedHeader from 'calypso/components/formatted-header';
 import MarketingMessage from 'calypso/components/marketing-message';
 import Notice from 'calypso/components/notice';
@@ -41,6 +47,7 @@ import {
 	submitSignupStep as submitSignupStepAction,
 } from 'calypso/state/signup/progress/actions';
 import { useSiteGlobalStylesOnPersonal } from 'calypso/state/sites/hooks/use-site-global-styles-on-personal';
+import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSiteBySlug } from 'calypso/state/sites/selectors';
 import { ONBOARD_STORE } from '../../../../stores';
 import { getIntervalType } from './util';
@@ -353,6 +360,12 @@ function UnifiedPlansStep( {
 		]
 	);
 
+	const siteId = selectedSite?.ID ?? signupDependencies.siteId;
+
+	const currentPlan = useSelector( ( state ) =>
+		siteId ? getCurrentPlan( state, siteId ) : null
+	);
+
 	const handleRemovePaidDomain = useCallback( () => {
 		const domainItem = undefined;
 
@@ -464,7 +477,28 @@ function UnifiedPlansStep( {
 		}
 
 		if ( intent === 'plans-woo-hosted' ) {
-			return translate( 'Your free trial ends soon — select a plan to keep your online store.' );
+			if ( ! currentPlan && ! selectedSite?.plan ) {
+				return null;
+			}
+			const isOnTrial =
+				currentPlan?.productSlug === PLAN_WOO_HOSTED_FREE_TRIAL_MONTHLY ||
+				selectedSite?.plan?.product_slug === PLAN_WOO_HOSTED_FREE_TRIAL_MONTHLY;
+
+			if ( isOnTrial ) {
+				const daysLeft = currentPlan?.expiryDate
+					? Math.ceil( moment.utc( currentPlan.expiryDate ).diff( moment().utc(), 'days', true ) )
+					: null;
+
+				if ( daysLeft !== null && daysLeft >= 1 ) {
+					return translate(
+						'Your free trial ends in %(daysLeft)d day — select a plan to keep your online store.',
+						'Your free trial ends in %(daysLeft)d days — select a plan to keep your online store.',
+						{ count: daysLeft, args: { daysLeft } }
+					);
+				}
+				return translate( 'Your free trial ends soon — select a plan to keep your online store.' );
+			}
+			return translate( 'Choose the plan that fits your business.' );
 		}
 
 		if ( useEmailOnboardingSubheader ) {
@@ -532,6 +566,7 @@ function UnifiedPlansStep( {
 					intent === 'plans-wordpress-hosting' || intent === 'plans-website-builder',
 			} ) }
 		>
+			{ intent === 'plans-woo-hosted' && siteId && <QuerySitePlans siteId={ siteId } /> }
 			{ 'invalid' === step?.status && (
 				<div>
 					<Notice status="is-error" showDismiss={ false }>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -6,6 +6,7 @@ import {
 	PLAN_WOO_HOSTED_FREE_TRIAL_MONTHLY,
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
+import { Plans } from '@automattic/data-stores';
 import { FREE_THEME } from '@automattic/design-picker';
 import {
 	DOMAIN_FLOW,
@@ -25,7 +26,6 @@ import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
 import { parse as parseQs } from 'qs';
 import AsyncLoad from 'calypso/components/async-load';
-import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import FormattedHeader from 'calypso/components/formatted-header';
 import MarketingMessage from 'calypso/components/marketing-message';
 import Notice from 'calypso/components/notice';
@@ -47,7 +47,6 @@ import {
 	submitSignupStep as submitSignupStepAction,
 } from 'calypso/state/signup/progress/actions';
 import { useSiteGlobalStylesOnPersonal } from 'calypso/state/sites/hooks/use-site-global-styles-on-personal';
-import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSiteBySlug } from 'calypso/state/sites/selectors';
 import { ONBOARD_STORE } from '../../../../stores';
 import { getIntervalType } from './util';
@@ -361,10 +360,7 @@ function UnifiedPlansStep( {
 	);
 
 	const siteId = selectedSite?.ID ?? signupDependencies.siteId;
-
-	const currentPlan = useSelector( ( state ) =>
-		siteId ? getCurrentPlan( state, siteId ) : null
-	);
+	const currentPlan = Plans.useCurrentPlan( { siteId } );
 
 	const handleRemovePaidDomain = useCallback( () => {
 		const domainItem = undefined;
@@ -485,8 +481,8 @@ function UnifiedPlansStep( {
 				selectedSite?.plan?.product_slug === PLAN_WOO_HOSTED_FREE_TRIAL_MONTHLY;
 
 			if ( isOnTrial ) {
-				const daysLeft = currentPlan?.expiryDate
-					? Math.ceil( moment.utc( currentPlan.expiryDate ).diff( moment().utc(), 'days', true ) )
+				const daysLeft = currentPlan?.expiry
+					? Math.ceil( moment.utc( currentPlan.expiry ).diff( moment().utc(), 'days', true ) )
 					: null;
 
 				if ( daysLeft !== null && daysLeft >= 1 ) {
@@ -566,7 +562,6 @@ function UnifiedPlansStep( {
 					intent === 'plans-wordpress-hosting' || intent === 'plans-website-builder',
 			} ) }
 		>
-			{ intent === 'plans-woo-hosted' && siteId && <QuerySitePlans siteId={ siteId } /> }
 			{ 'invalid' === step?.status && (
 				<div>
 					<Notice status="is-error" showDismiss={ false }>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -17,7 +17,7 @@ import { isDesktop as isDesktopViewport, subscribeIsDesktop } from '@automattic/
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import clsx from 'clsx';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { parse as parseQs } from 'qs';
 import AsyncLoad from 'calypso/components/async-load';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -464,15 +464,7 @@ function UnifiedPlansStep( {
 		}
 
 		if ( intent === 'plans-woo-hosted' ) {
-			return i18n.fixMe( {
-				text: 'Your free trial ends soon. Select a plan to keep access to your store admin.',
-				newCopy: translate(
-					'Your free trial ends soon. Select a plan to keep access to your store admin.'
-				),
-				oldCopy: translate(
-					'Your free trial ends soon - select a plan to keep your online store.'
-				),
-			} );
+			return translate( 'Your free trial ends soon — select a plan to keep your online store.' );
 		}
 
 		if ( useEmailOnboardingSubheader ) {

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1671,8 +1671,7 @@ const getPlanWooHostedBasicDetails = (): IncompleteWPcomPlan => ( {
 	],
 	getStorageFeature: () => FEATURE_50GB_STORAGE,
 	getTitle: () => i18n.translate( 'Basic' ),
-	getPlanTagline: () =>
-		i18n.translate( 'Everything you need to set up your store and start selling your products.' ),
+	getPlanTagline: () => i18n.translate( 'Everything you need to build and run your online store.' ),
 	getTagline: () =>
 		i18n.translate(
 			'Learn more about everything included with Woo Basic and take advantage of its powerful marketplace features.'
@@ -1709,7 +1708,8 @@ const getPlanWooHostedProDetails = (): IncompleteWPcomPlan => ( {
 	],
 	getStorageFeature: () => FEATURE_100GB_STORAGE,
 	getTitle: () => i18n.translate( 'Pro' ),
-	getPlanTagline: () => i18n.translate( 'Accelerate your growth with advanced features.' ),
+	getPlanTagline: () =>
+		i18n.translate( 'For businesses selling anywhere, reaching more customers, and growing fast.' ),
 	getTagline: () =>
 		i18n.translate(
 			'Learn more about everything included with Woo Pro and take advantage of its powerful marketplace features.'


### PR DESCRIPTION
Resolves SHILL-1834

## Proposed Changes

* Update WooHosted Basic plan tagline to "Everything you need to build and run your online store."
* Update WooHosted Pro plan tagline to "For businesses selling anywhere, reaching more customers, and growing fast."
* Add dynamic trial-aware subheader messaging to the CIAB plans page:
  - Trial users with >= 1 day remaining: "Your free trial ends in X days"
  - Trial users with < 1 day remaining: "Your free trial ends soon"
  - Non-trial users (paid plans, expired, free): "Choose the plan that fits your business."
* Fetch site plans detail data via `<QuerySitePlans>` (gated to woo-hosted intent only) to access trial expiry date

## Why are these changes being made?

Updating CIAB plans page to match current Figma designs. The subheader previously showed static "Your free trial ends soon" text to all users regardless of plan state. Now it dynamically detects whether the user is on a Woo Hosted free trial (`woo_hosted_free_trial_plan_monthly`) and shows a countdown or appropriate messaging based on their actual plan. 
Tagline changes are scoped to WooHosted (Basic/Pro) only - WooExpress (Essential/Performance) taglines are unchanged.

| Scenario | Before | After |
|----------|--------|-------|
| On trial, 5 days left | "Your free trial ends soon" | "Your free trial ends in 5 days" |
| On trial, < 1 day left | "Your free trial ends soon" | "Your free trial ends soon" |
| On paid plan (Pro) | "Your free trial ends soon" | "Choose the plan that fits your business." |
| On free/expired plan | "Your free trial ends soon" | "Choose the plan that fits your business." |
| Basic tagline | "Everything you need to set up your store and start selling your products." | "Everything you need to build and run your online store." |
| Pro tagline | "Accelerate your growth with advanced features." | "For businesses selling anywhere, reaching more customers, and growing fast." |


## Screenshots

Trial ends in multiple days:
<img width="724" height="663" alt="Screenshot 2026-03-31 at 5 38 53 PM" src="https://github.com/user-attachments/assets/01cc3073-2fc0-4678-82d9-84e9c9fab67c" />

Tiral ends in 1 day:
<img width="724" height="663" alt="Screenshot 2026-03-31 at 5 39 28 PM" src="https://github.com/user-attachments/assets/d69dad23-97b3-46e0-a0d8-9f4ef01218aa" />

Trial end soon:
<img width="724" height="663" alt="Screenshot 2026-03-31 at 5 40 02 PM" src="https://github.com/user-attachments/assets/f939884a-7d30-4d1b-a63f-7b30bb75a82c" />

Non-trial:
<img width="724" height="663" alt="Screenshot 2026-03-31 at 5 40 22 PM" src="https://github.com/user-attachments/assets/ea537a65-69ae-4ba3-ac39-3f31e15e4d4f" />



## Testing Instructions

**Steps:**
1. Navigate to `http://calypso.localhost:3000/setup/woo-hosted-plans?siteSlug=YOUR_SITE.wpcomstaging.com`
2. **With a trial site**: Verify the subheader shows "Your free trial ends in X days" with the correct day count
3. **With a paid plan site**: Verify the subheader shows "Choose the plan that fits your business."
4. **With an expired/free site**: Verify the subheader shows "Choose the plan that fits your business."
5. Verify the Basic plan card tagline reads "Everything you need to build and run your online store."
6. Verify the Pro plan card tagline reads "For businesses selling anywhere, reaching more customers, and growing fast."
7. Switch between Monthly and Annual billing - verify subheader and taglines remain correct

**Calypso Live:**
- `https://update-SHILL-1834-plans-page-subheading-description.calypso.live/setup/woo-hosted-plans?siteSlug=YOUR_SITE.wpcomstaging.com`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
