### PR TITLE
Fix domain search mini cart showing wrong price for plan users

### DIFF
--- a/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
@@ -14,18 +14,15 @@ import {
 } from '@automattic/shopping-cart';
 import { ComponentProps, useMemo } from 'react';
 
-const wpcomCartToDomainSearchCart = (
-	domain: ResponseCartProduct,
-	isFirstDomainFreeForFirstYear: boolean
-) => {
+const wpcomCartToDomainSearchCart = ( domain: ResponseCartProduct, isEffectivelyFree: boolean ) => {
 	const [ domainName, ...tld ] = domain.meta.split( '.' );
 
 	const hasPromotion =
-		isFirstDomainFreeForFirstYear ||
+		isEffectivelyFree ||
 		domain.cost_overrides?.some( ( override ) => ! override.does_override_original_cost );
 
 	const currentPrice = formatCurrency(
-		isFirstDomainFreeForFirstYear ? 0 : domain.item_subtotal_integer,
+		isEffectivelyFree ? 0 : domain.item_subtotal_integer,
 		domain.currency,
 		{
 			isSmallestUnit: true,
@@ -99,22 +96,29 @@ export const useWPCOMDomainSearchCart = ( {
 			? firstNonPremiumDomain?.meta
 			: undefined;
 
-		const total = formatCurrency(
-			domainItems.reduce(
-				( acc, item ) => acc + ( freeDomainName === item.meta ? 0 : item.item_subtotal_integer ),
-				0
-			),
-			responseCart.currency ?? 'USD',
-			{
-				isSmallestUnit: true,
-				stripZeros: true,
-			}
+		const rawTotal = domainItems.reduce(
+			( acc, item ) => acc + ( freeDomainName === item.meta ? 0 : item.item_subtotal_integer ),
+			0
 		);
+		const creditsInteger = responseCart.credits_integer ?? 0;
+		const totalAfterCredits = Math.max( 0, rawTotal - creditsInteger );
+
+		const total = formatCurrency( totalAfterCredits, responseCart.currency ?? 'USD', {
+			isSmallestUnit: true,
+			stripZeros: true,
+		} );
 
 		const cart: ComponentProps< typeof DomainSearch >[ 'cart' ] = {
-			items: domainItems.map( ( domainItem ) =>
-				wpcomCartToDomainSearchCart( domainItem, freeDomainName === domainItem.meta )
-			),
+			items: domainItems.map( ( domainItem ) => {
+				const isCoveredByCredits =
+					! forceFirstNonPremiumDomainToBeFree &&
+					creditsInteger >= domainItem.item_subtotal_integer &&
+					domainItem === firstNonPremiumDomain;
+				return wpcomCartToDomainSearchCart(
+					domainItem,
+					freeDomainName === domainItem.meta || isCoveredByCredits
+				);
+			} ),
 			total,
 			hasItem: ( domain ) => !! domainItems.find( ( item ) => item.meta === domain ),
 			onAddItem: async ( { domain_name, product_slug, supports_privacy } ) => {

--- a/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
@@ -113,7 +113,7 @@ export const useWPCOMDomainSearchCart = ( {
 				const isCoveredByCredits =
 					! forceFirstNonPremiumDomainToBeFree &&
 					creditsInteger >= domainItem.item_subtotal_integer &&
-					domainItem === firstNonPremiumDomain;
+					domainItem.meta === firstNonPremiumDomain?.meta;
 				return wpcomCartToDomainSearchCart(
 					domainItem,
 					freeDomainName === domainItem.meta || isCoveredByCredits


### PR DESCRIPTION
Part of DOMENG-524

## Proposed Changes

- Subtract `credits_integer` from the mini cart total so it reflects the server's actual `total_cost_integer`
- Mark the first non-premium domain as effectively free in the per-item display when credits cover its cost
- Show `$0` on the search **result card** when the domain is in the cart and effectively free (free-domain promo or account credits), so the card stays in sync with the mini cart and checkout
- Use `meta` comparison instead of reference equality for more robust domain matching

## Why are these changes being made?

When a user with an existing paid plan adds a domain, the free domain is covered by account credit. The server-side cart correctly computes a `$0` total (`total_cost_integer: 0`) and checkout shows `$0`, but the client showed a price in two places:

1. The **mini cart** summed `item_subtotal_integer` and ignored `credits_integer`, so it showed the full price.
2. The **search result card** kept showing the catalog/sale price after the domain was added, because the suggestion-pricing path had no notion of cart credits.

Both made it look like the user would be charged for a domain that's actually free. This change makes the result card, the mini cart, and checkout all agree on `$0`.

## Testing Instructions

The free domain requires a **yearly** paid plan (monthly plans don't include a free domain).

1. On a site with a yearly paid plan, add a domain via either **Upgrades → Email** or **Upgrades → Domains**.
2. Search for and add a domain to the cart.
3. (Optional) In DevTools → Network, confirm the `shopping-cart` response covers the domain with credit — `credits_integer` ≥ the domain's `item_subtotal_integer`, and `total_cost_integer: 0`.
4. **Before fix:** the result card and the mini cart show the domain's price.
5. **After fix:** the result card and the mini cart both show `$0`, matching the server total.
6. Continue to checkout and confirm it still shows `$0`.

Also verify:
- On a site with **no paid plan** (or a monthly plan), the domain still shows its full price.
- In **onboarding flows** (free-domain-for-first-year promo), the first non-premium domain still shows `$0` and the existing `forceFirstNonPremiumDomainToBeFree` path is unchanged.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

Co-Authored-By: Claude <noreply@anthropic.com>
