### PR TITLE
Checkout: Add user email to header under domain

### DIFF
--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -157,7 +157,7 @@ export default function WPCheckoutOrderReview( {
 			getCurrentUser( state ) && currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )
 	);
 	const currentUserEmail = useSelector( getCurrentUserEmail ) as string | undefined;
-	const isGiftPurchase = responseCart.gift_details?.receiver_blog_slug;
+	const isGiftPurchase = Boolean( responseCart.gift_details?.receiver_blog_slug );
 
 	return (
 		<>
@@ -174,7 +174,11 @@ export default function WPCheckoutOrderReview( {
 					</SiteSummary>
 				) }
 				{ currentUserEmail && ! isGiftPurchase && (
-					<EmailSummary className="checkout-review-order__email">{ currentUserEmail }</EmailSummary>
+					<EmailSummary className="checkout-review-order__email">
+						{ isCheckoutUiRedesignV1
+							? currentUserEmail
+							: translate( 'Account: %s', { args: currentUserEmail } ) }
+					</EmailSummary>
 				) }
 				{ planIsP2Plus && selectedSiteData?.name && (
 					<SiteSummary className="checkout-review-order__site">

--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -13,7 +13,11 @@ import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
-import { currentUserHasFlag, getCurrentUser } from 'calypso/state/current-user/selectors';
+import {
+	currentUserHasFlag,
+	getCurrentUser,
+	getCurrentUserEmail,
+} from 'calypso/state/current-user/selectors';
 import {
 	getIsOnboardingAffiliateFlow,
 	getIsOnboardingUnifiedFlow,
@@ -47,6 +51,12 @@ const SiteSummary = styled.div`
 
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
 		margin-top: -8px;
+	}
+`;
+
+const EmailSummary = styled( SiteSummary )`
+	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
+		margin-top: 0;
 	}
 `;
 
@@ -146,6 +156,8 @@ export default function WPCheckoutOrderReview( {
 		( state ) =>
 			getCurrentUser( state ) && currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )
 	);
+	const currentUserEmail = useSelector( getCurrentUserEmail ) as string | undefined;
+	const isGiftPurchase = responseCart.gift_details?.receiver_blog_slug;
 
 	return (
 		<>
@@ -160,6 +172,9 @@ export default function WPCheckoutOrderReview( {
 					<SiteSummary className="checkout-review-order__site">
 						{ isCheckoutUiRedesignV1 ? domainUrl : translate( 'Site: %s', { args: domainUrl } ) }
 					</SiteSummary>
+				) }
+				{ currentUserEmail && ! isGiftPurchase && (
+					<EmailSummary className="checkout-review-order__email">{ currentUserEmail }</EmailSummary>
 				) }
 				{ planIsP2Plus && selectedSiteData?.name && (
 					<SiteSummary className="checkout-review-order__site">


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHE-463/checkout-show-current-account-information

## Proposed changes

Displays the logged-in user's email address in the "Your order" summary column, just below the site URL.

<img width="1178" height="461" alt="Screenshot 2026-03-31 at 2 54 45 PM" src="https://github.com/user-attachments/assets/ca8371e4-46b6-4670-8132-a929a1d0d0b0" />

> [!NOTE]
> This sort of conflicts with the checkout redesign experiment adjustments in https://github.com/Automattic/wp-calypso/pull/109710. It should be altered once that is merged to account for this new row..

## Why are these changes being made?

During checkout, the order summary already shows the site being upgraded. Showing the account email alongside it gives users a quick confirmation that they're purchasing under the right account — useful when someone manages multiple WordPress.com accounts or is on a shared device. The email is omitted for gift purchases since the order is for a different recipient's site and showing the buyer's email there could be confusing.

## Testing instructions

Manual testing:
* Log in to a WordPress.com account and navigate to checkout with any product
* Confirm the account email appears below the "Site:" line in the order summary column

