### PR TITLE
Add missing site error to my-sites controller onSelectedSiteAvailable

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -194,6 +194,22 @@ export function renderNoVisibleSites( context ) {
 	clientRender( context );
 }
 
+function renderSelectedSiteNotFound( context ) {
+	setSectionMiddleware( { group: 'sites' } )( context );
+
+	context.primary = createElement( EmptyContentComponent, {
+		title: i18n.translate( "You don't have access to that site" ),
+		line: i18n.translate(
+			'You might not have permission to view this site, or it may not exist. Select a different site to continue.'
+		),
+		action: i18n.translate( 'Select a different site' ),
+		actionURL: '/sites',
+	} );
+
+	makeLayout( context, noop );
+	clientRender( context );
+}
+
 function renderSelectedSiteIsDIFMLiteInProgress( reactContext, selectedSite ) {
 	reactContext.primary = <DIFMLiteInProgress siteId={ selectedSite.ID } />;
 
@@ -315,6 +331,12 @@ function isPathAllowedForDIFMInProgressSite( path, slug, domains, contextParams 
 function onSelectedSiteAvailable( context ) {
 	const state = context.store.getState();
 	const selectedSite = getSelectedSite( state );
+
+	if ( ! selectedSite ) {
+		renderSelectedSiteNotFound( context );
+		return false;
+	}
+
 	// Use getSitePlanSlug() as it ignores expired plans.
 	const currentPlanSlug = getSitePlanSlug( state, selectedSite.ID );
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-1825/

## Proposed changes

Adds an error page when checkout (or any My Sites route) loads for a site that cannot be accessed, replacing an infinite loading spinner and a console crash.

* Add `renderSelectedSiteNotFound()` helper that renders an `EmptyContentComponent` with the message "You don't have access to that site" and a "Select a different site" CTA pointing to `/sites`
* Add a null guard at the top of `onSelectedSiteAvailable()` that calls the new helper and returns `false` when `getSelectedSite()` returns null

Before             |  After
:-------------------------:|:-------------------------:
<img width="1509" height="757" alt="Screenshot 2026-03-31 at 4 49 47 PM" src="https://github.com/user-attachments/assets/0aa6bf0f-2db4-4291-b9b1-697256e532d6" /> | <img width="1509" height="815" alt="Screenshot 2026-03-31 at 4 49 36 PM" src="https://github.com/user-attachments/assets/a081b7d6-ce2e-4737-9c60-00ced9e1daaf" />


## Why are these changes being made?

`onSelectedSiteAvailable()` is called by `siteSelection` middleware whenever a site fragment is found in the URL. It immediately reads `selectedSite.ID` on the first line after fetching `getSelectedSite(state)`. When the site cannot be loaded — because it doesn't exist, the user lacks permission, or the API request failed — `getSelectedSite()` returns `null`, causing an uncaught `TypeError: Cannot read properties of null (reading 'ID')`. This crash prevents `next()` from ever being called, leaving the checkout page (and any other My Sites route) stuck showing a loading indicator indefinitely.

The fix adds an early-return null guard consistent with every other early-exit path in `onSelectedSiteAvailable()`: render something useful and return `false`. The new `renderSelectedSiteNotFound()` function follows the same pattern as the existing `renderNoVisibleSites()` and `renderEmptySites()` helpers — it sets the section, assigns `context.primary`, and calls `makeLayout`/`clientRender` directly without needing `next()`.

## Testing instructions

No automated test coverage exists for this middleware today.

Manual testing:
* Visit `/checkout/12345/personal` (or any My Sites URL with a site ID that either doesn't exist or you don't have access to)
* **Before:** infinite loading spinner; console shows `TypeError: Cannot read properties of null (reading 'ID')`
* **After:** an error page reading "You don't have access to that site" with a "Select a different site" button

