### PR TITLE
Add Recommended badge to CIAB Basic plan card

### DIFF
--- a/packages/plans-grid-next/src/components/features-grid/plan-headers.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/plan-headers.tsx
@@ -13,7 +13,7 @@ type PlanHeadersProps = {
 };
 
 const PlanHeaders = ( { options, renderedGridPlans }: PlanHeadersProps ) => {
-	return renderedGridPlans.map( ( { planSlug, planTitle } ) => {
+	return renderedGridPlans.map( ( { planSlug, planTitle, titleBadge } ) => {
 		const headerClasses = clsx( 'plan-features-2023-grid__header', getPlanClass( planSlug ) );
 
 		return (
@@ -26,6 +26,9 @@ const PlanHeaders = ( { options, renderedGridPlans }: PlanHeadersProps ) => {
 			>
 				<div role="columnheader" className={ headerClasses }>
 					<h4 className="plan-features-2023-grid__header-title">{ planTitle }</h4>
+					{ titleBadge && (
+						<span className="plan-features-2023-grid__header-badge">{ titleBadge }</span>
+					) }
 				</div>
 			</PlanDivOrTdContainer>
 		);

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -9,6 +9,11 @@
 	background-color: var(--color-surface);
 	justify-content: flex-start;
 	font-weight: 400;
+
+	&.is-woo-hosted-basic-plan {
+		align-items: center;
+		gap: 12px;
+	}
 }
 
 .plan-features-2023-grid__header-logo {
@@ -203,6 +208,18 @@
 	font-weight: 400;
 	@include onboarding-font-recoleta;
 	letter-spacing: 0;
+}
+
+.plan-features-2023-grid__header-badge {
+	background-color: var(--studio-blue-5);
+	color: var(--studio-blue-50);
+	border-radius: 3px;
+	display: inline-block;
+	font-size: $font-body-extra-small;
+	font-weight: 500;
+	line-height: 20px;
+	padding: 0 8px;
+	white-space: nowrap;
 }
 
 .plan-features-2023-grid__header-tagline {

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -33,6 +33,7 @@ import { isSamePlan } from '../../lib/is-same-plan';
 import { UseGridPlansParams, UseGridPlansType } from './types';
 import useHighlightLabels from './use-highlight-labels';
 import usePlansFromTypes from './use-plans-from-types';
+import useTitleBadges from './use-title-badges';
 import type { HiddenPlans, PlansIntent } from '../../types';
 import type { TranslateResult } from 'i18n-calypso';
 
@@ -359,6 +360,11 @@ const useGridPlans: UseGridPlansType = ( {
 		isExperimentVariant,
 	} );
 
+	const titleBadges = useTitleBadges( {
+		intent,
+		planSlugs: planSlugsForIntent,
+	} );
+
 	// TODO: pricedAPIPlans to be queried from data-store package
 	const pricedAPIPlans = Plans.usePlans( { coupon } );
 	const pricingMeta = Plans.usePricingMetaForGridPlans( {
@@ -432,6 +438,7 @@ const useGridPlans: UseGridPlansType = ( {
 			isMonthlyPlan,
 			cartItemForPlan,
 			highlightLabel: highlightLabels[ planSlug ],
+			titleBadge: titleBadges[ planSlug ],
 			pricing: pricingMeta[ planSlug ],
 		};
 	} );

--- a/packages/plans-grid-next/src/hooks/data-store/use-title-badges.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-title-badges.ts
@@ -1,0 +1,31 @@
+import { isWooHostedBasicPlan, type PlanSlug } from '@automattic/calypso-products';
+import { useTranslate } from 'i18n-calypso';
+import type { PlansIntent } from '../../types';
+import type { TranslateResult } from 'i18n-calypso';
+
+interface Props {
+	intent?: PlansIntent;
+	planSlugs: PlanSlug[];
+}
+
+const useTitleBadges = ( { intent, planSlugs }: Props ) => {
+	const translate = useTranslate();
+
+	return planSlugs.reduce(
+		( acc, planSlug ) => {
+			let label;
+
+			if ( 'plans-woo-hosted' === intent && isWooHostedBasicPlan( planSlug ) ) {
+				label = translate( 'Recommended' );
+			}
+
+			return {
+				...acc,
+				[ planSlug ]: label ?? null,
+			};
+		},
+		{} as Record< PlanSlug, TranslateResult | null >
+	);
+};
+
+export default useTitleBadges;

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -53,6 +53,7 @@ export interface GridPlan {
 		product_slug: string;
 	} | null;
 	highlightLabel?: React.ReactNode | null;
+	titleBadge?: React.ReactNode | null;
 }
 
 /***********************


### PR DESCRIPTION
Resolves SHILL-1833

## Proposed Changes

* Add a new `titleBadge` field to the `GridPlan` type for rendering inline badges next to plan titles
* Add `useTitleBadges` hook that returns "Recommended" for the Basic plan in the `plans-woo-hosted` intent
* Render the badge as a sibling to the `<h4>` title inside the existing flex container in `PlanHeaders`
* Style the badge with a light blue background and blue text, matching the Figma design system

This is separate from the existing `highlightLabel`/`PopularBadge` system, which renders a positioned pill above the card.

## Why are these changes being made?

The CIAB plans page should show a "Recommended" badge inline next to the "Basic" plan title to help guide users toward the recommended plan. The existing badge system (`PopularBadge`/`PlanPill`) renders above the card header and serves a different purpose ("Your plan", "Popular", etc.), so a new `titleBadge` field keeps the two concerns independent.

## Screenshots
<img width="724" height="663" alt="image" src="https://github.com/user-attachments/assets/533af3bd-05cb-49ec-9202-7a0f4a0b1845" />


## Testing Instructions

**Steps:**
1. Navigate to a CIAB Woo Hosted plans page at `/setup/woo-hosted-plans/plans?siteSlug=<your-woo-trial-site>`
2. Verify that the Basic plan card shows a "Recommended" badge inline next to the "Basic" title
3. Verify the badge has a light blue background with blue text
4. Verify the Pro plan card does not show a "Recommended" badge
5. Verify the existing "Your plan" pill still appears correctly when viewing as a user with an active plan
6. Resize the browser to a narrow viewport and verify the badge wraps gracefully

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
