### PR TITLE
Newsletter: Add publish celebration modal

### DIFF
--- a/apps/wpcom-block-editor/package.json
+++ b/apps/wpcom-block-editor/package.json
@@ -23,6 +23,7 @@
 	},
 	"dependencies": {
 		"@automattic/calypso-url": "workspace:^",
+		"canvas-confetti": "^1.6.0",
 		"@automattic/typography": "workspace:^",
 		"@babel/runtime": "^7.27.1",
 		"@wordpress/api-fetch": "^7.23.0",

--- a/apps/wpcom-block-editor/src/wpcom/features/celebrate-first-post-modal/confetti.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/celebrate-first-post-modal/confetti.js
@@ -1,0 +1,37 @@
+import confetti from 'canvas-confetti';
+
+const COLORS = [ '#31CC9F', '#618DF2', '#6AB3D0', '#B35EB1', '#F2D76B', '#FAA754', '#E34C84' ];
+
+export function fireConfetti() {
+	if ( window.matchMedia?.( '(prefers-reduced-motion: reduce)' ).matches ) {
+		return;
+	}
+
+	const count = 60;
+	const scale = 2;
+	const defaults = {
+		origin: { y: 0.4 },
+		colors: COLORS,
+		scalar: scale,
+		spread: 180,
+		gravity: 6,
+	};
+
+	function fire( particleRatio, opts ) {
+		confetti(
+			Object.assign( {}, defaults, opts, {
+				particleCount: Math.floor( count * particleRatio ),
+				startVelocity: opts.startVelocity ? scale * opts.startVelocity : undefined,
+				spread: scale * opts.spread,
+				scalar: opts.scalar ? scale * opts.scalar : scale,
+				zIndex: 1000000,
+			} )
+		);
+	}
+
+	fire( 0.25, { spread: 26, startVelocity: 55 } );
+	fire( 0.2, { spread: 60 } );
+	fire( 0.35, { spread: 100, decay: 0.91, scalar: 0.8 } );
+	fire( 0.1, { spread: 120, startVelocity: 25, decay: 0.92, scalar: 1.2 } );
+	fire( 0.1, { spread: 120, startVelocity: 45 } );
+}

--- a/apps/wpcom-block-editor/src/wpcom/features/celebrate-first-post-modal/index.jsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/celebrate-first-post-modal/index.jsx
@@ -1,0 +1,61 @@
+import { Button, Modal } from '@wordpress/components';
+import { select } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { useEffect } from 'react';
+import tracksRecordEvent from '../tracking/track-record-event';
+import { fireConfetti } from './confetti';
+
+import './style.scss';
+
+export function CelebrateFirstPostModal( { onClose } ) {
+	const siteSlug = window.location.hostname;
+	const postUrl = select( 'core/editor' ).getPermalink();
+
+	useEffect( () => {
+		fireConfetti();
+		tracksRecordEvent( 'calypso_newsletter_first_publish_celebration_shown' );
+	}, [] );
+
+	const handleCtaClick = ( cta ) => {
+		tracksRecordEvent( 'calypso_newsletter_first_publish_celebration_cta_click', { cta } );
+	};
+
+	return (
+		<Modal
+			onRequestClose={ () => {
+				handleCtaClick( 'dismiss' );
+				onClose();
+			} }
+			className="celebrate-first-post-modal"
+			shouldCloseOnClickOutside={ false }
+		>
+			<h1 className="celebrate-first-post-modal__heading">
+				{ __( 'Your first post is published!' ) }
+			</h1>
+			<p className="celebrate-first-post-modal__body">
+				{ __( 'Your subscribers will receive it shortly. Keep the momentum going.' ) }
+			</p>
+			<div className="celebrate-first-post-modal__actions">
+				<Button
+					variant="primary"
+					href={ `https://wordpress.com/post/${ siteSlug }` }
+					target="_top"
+					onClick={ () => handleCtaClick( 'next_post' ) }
+				>
+					{ __( 'Write your next post' ) }
+				</Button>
+				{ postUrl && (
+					<Button
+						variant="secondary"
+						href={ postUrl }
+						target="_blank"
+						rel="noopener noreferrer"
+						onClick={ () => handleCtaClick( 'view_post' ) }
+					>
+						{ __( 'View your post' ) }
+					</Button>
+				) }
+			</div>
+		</Modal>
+	);
+}

--- a/apps/wpcom-block-editor/src/wpcom/features/celebrate-first-post-modal/style.scss
+++ b/apps/wpcom-block-editor/src/wpcom/features/celebrate-first-post-modal/style.scss
@@ -1,0 +1,51 @@
+$breakpoint-mobile: 782px;
+
+.celebrate-first-post-modal {
+	max-inline-size: 480px;
+
+	.components-modal__header {
+		padding-block-start: 40px;
+		padding-block-end: 0;
+		padding-inline: 40px;
+	}
+
+	.components-modal__content {
+		margin: 0;
+		padding-block-start: 0;
+		padding-block-end: 40px;
+		padding-inline: 40px;
+		display: flex;
+		flex-direction: column;
+		gap: 24px;
+	}
+
+	.celebrate-first-post-modal__heading {
+		color: var(--studio-gray-100);
+		font-size: 1.5rem;
+		line-height: 32px;
+		font-weight: 600;
+		margin: 0;
+	}
+
+	.celebrate-first-post-modal__body {
+		color: var(--studio-gray-60);
+		font-size: 0.875rem;
+		line-height: 22px;
+		margin: 0;
+	}
+
+	.celebrate-first-post-modal__actions {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+
+		@media ( min-width: $breakpoint-mobile ) {
+			flex-direction: row;
+			flex-wrap: wrap;
+		}
+
+		.components-button {
+			justify-content: center;
+		}
+	}
+}

--- a/apps/wpcom-block-editor/src/wpcom/features/onboarding-next-step-after-publishing-post.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/onboarding-next-step-after-publishing-post.js
@@ -1,72 +1,105 @@
+import apiFetch from '@wordpress/api-fetch';
 import { dispatch, select, subscribe, useSelect } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
-import { Icon, pending } from '@wordpress/icons';
-import { getQueryArg } from '@wordpress/url';
+import { useState, useEffect, useRef } from 'react';
+import { CelebrateFirstPostModal } from './celebrate-first-post-modal';
+import useSiteIntent from './use-site-intent';
 
 export function OnboardingNextStepAfterPublishingPost() {
+	const [ showCelebration, setShowCelebration ] = useState( false );
+	const firstPostAlreadyPublishedRef = useRef( null );
+	const launchpadFetchPromiseRef = useRef( null );
+	const unmountedRef = useRef( false );
+
+	const { siteIntent } = useSiteIntent();
 	const currentPostType = useSelect(
 		( localSelect ) => localSelect( 'core/editor' ).getCurrentPostType(),
 		[]
 	);
 
-	const hasPublishFirstPostTaskQueryArg = window.location.hash === '#publish-first-post';
+	const isNewsletterPost = siteIntent === 'newsletter' && currentPostType === 'post';
 
-	if ( ! hasPublishFirstPostTaskQueryArg || currentPostType !== 'post' ) {
-		return false;
-	}
+	// Fetch launchpad status on mount for newsletter posts.
+	useEffect( () => {
+		if ( ! isNewsletterPost ) {
+			return;
+		}
 
-	// Save site origin in session storage to be used in editor refresh.
-	const siteOriginParam = getQueryArg( window.location.search, 'origin' );
-	if ( siteOriginParam ) {
-		window.sessionStorage.setItem( 'site-origin', siteOriginParam );
-	}
+		const promise = apiFetch( { path: '/wpcom/v2/launchpad' } )
+			.then( ( response ) => {
+				firstPostAlreadyPublishedRef.current =
+					response?.checklist_statuses?.first_post_published ?? false;
+			} )
+			.catch( () => {
+				// On failure, default to false so a first-publish can still celebrate.
+				firstPostAlreadyPublishedRef.current = false;
+			} );
 
-	const siteOrigin = window.sessionStorage.getItem( 'site-origin' ) || 'https://wordpress.com';
-	const siteSlug = window.location.hostname;
+		launchpadFetchPromiseRef.current = promise;
+	}, [ isNewsletterPost ] );
 
-	const unsubscribe = subscribe( () => {
-		const isSavingPost = select( 'core/editor' ).isSavingPost();
-		const getCurrentPostRevisionsCount = select( 'core/editor' ).getCurrentPostRevisionsCount();
+	// Watch for publish transitions using a persistent subscriber.
+	useEffect( () => {
+		if ( ! isNewsletterPost ) {
+			return;
+		}
 
-		if ( isSavingPost ) {
-			const unsubscribeFromSavingPost = subscribe( () => {
-				const postStatus = select( 'core/editor' ).getEditedPostAttribute( 'status' );
-				if (
-					( postStatus === 'publish' || postStatus === 'future' ) &&
-					getCurrentPostRevisionsCount >= 1
-				) {
-					unsubscribeFromSavingPost();
-					unsubscribe();
-					dispatch( 'core/edit-post' ).closePublishSidebar();
+		unmountedRef.current = false;
+		let prevIsSaving = select( 'core/editor' ).isSavingPost();
+		let wasPublishedBeforeSave = select( 'core/editor' ).isCurrentPostPublished();
+		let didCelebrate = false;
 
-					const unsubscribeFromNotices = subscribe( () => {
-						const notices = select( 'core/notices' ).getNotices();
-						if ( notices.some( ( notice ) => notice.id === 'editor-save' ) ) {
-							dispatch( 'core/notices' ).removeNotice( 'editor-save' );
+		const unsubscribe = subscribe( () => {
+			if ( didCelebrate ) {
+				return;
+			}
 
-							// Show success notice with Next steps link
-							dispatch( 'core/notices' ).createSuccessNotice(
-								__( 'Well done publishing your first post!' ),
-								{
-									actions: [
-										{
-											label: __( 'Next steps' ),
-											url: `${ siteOrigin }/home/${ siteSlug }`,
-										},
-									],
-									type: 'snackbar',
-									isDismissible: true,
-									explicitDismiss: true,
-									icon: <Icon icon={ pending } fill="white" size={ 24 } />,
-									id: 'NEXT_STEPS_NOTICE_ID',
-								}
-							);
+			const isSaving = select( 'core/editor' ).isSavingPost();
 
-							unsubscribeFromNotices();
+			if ( ! prevIsSaving && isSaving ) {
+				// Snapshot the pre-save published state when a save cycle starts.
+				wasPublishedBeforeSave = select( 'core/editor' ).isCurrentPostPublished();
+			}
+
+			if ( prevIsSaving && ! isSaving ) {
+				const isNowPublished = select( 'core/editor' ).isCurrentPostPublished();
+
+				if ( isNowPublished && ! wasPublishedBeforeSave ) {
+					const fetchPromise = launchpadFetchPromiseRef.current || Promise.resolve();
+
+					fetchPromise.then( () => {
+						if ( unmountedRef.current || didCelebrate ) {
+							return;
+						}
+
+						if ( firstPostAlreadyPublishedRef.current === false ) {
+							didCelebrate = true;
+
+							dispatch( 'core/edit-post' ).closePublishSidebar();
+
+							// Best-effort removal of the save notice so it doesn't overlap the modal.
+							const notices = select( 'core/notices' ).getNotices();
+							if ( notices.some( ( notice ) => notice.id === 'editor-save' ) ) {
+								dispatch( 'core/notices' ).removeNotice( 'editor-save' );
+							}
+
+							setShowCelebration( true );
 						}
 					} );
 				}
-			} );
-		}
-	} );
+			}
+
+			prevIsSaving = isSaving;
+		} );
+
+		return () => {
+			unmountedRef.current = true;
+			unsubscribe();
+		};
+	}, [ isNewsletterPost ] );
+
+	if ( ! showCelebration ) {
+		return null;
+	}
+
+	return <CelebrateFirstPostModal onClose={ () => setShowCelebration( false ) } />;
 }

--- a/apps/wpcom-block-editor/src/wpcom/features/test/onboarding-next-step-after-publishing-post.test.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/test/onboarding-next-step-after-publishing-post.test.js
@@ -1,0 +1,352 @@
+/**
+ * @jest-environment jsdom
+ */
+import { OnboardingNextStepAfterPublishingPost } from '../onboarding-next-step-after-publishing-post';
+
+const mockClosePublishSidebar = jest.fn();
+const mockRemoveNotice = jest.fn();
+const mockSubscribeCallbacks = [];
+const mockUseEffectFunctions = {};
+let mockFunctionDescriptor = '';
+let mockIsSaving = false;
+let mockPostType = 'post';
+let mockIsCurrentPostPublished = false;
+let mockNotices = [];
+let mockSiteIntent = 'newsletter';
+
+// Shared ref objects so tests can control state.
+const mockFirstPostRef = { current: null };
+const mockFetchPromiseRef = { current: null };
+const mockUnmountedRef = { current: false };
+
+let mockApiFetchResult = Promise.resolve( {
+	checklist_statuses: { first_post_published: false },
+} );
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn( () => mockApiFetchResult ),
+} ) );
+
+const refOrder = [];
+jest.mock( 'react', () => ( {
+	...jest.requireActual( 'react' ),
+	useState: ( initial ) => [ initial, jest.fn() ],
+	useEffect: ( fn ) => {
+		if ( ! mockUseEffectFunctions[ mockFunctionDescriptor ] ) {
+			mockUseEffectFunctions[ mockFunctionDescriptor ] = [];
+		}
+		mockUseEffectFunctions[ mockFunctionDescriptor ].push( fn );
+	},
+	useRef: () => {
+		// Return refs in creation order: firstPostAlreadyPublished, launchpadFetchPromise, unmounted.
+		const ref = refOrder.shift();
+		return ref;
+	},
+} ) );
+
+jest.mock( 'canvas-confetti', () => jest.fn() );
+
+jest.mock( '../celebrate-first-post-modal', () => ( {
+	CelebrateFirstPostModal: () => null,
+} ) );
+
+jest.mock( '../tracking/track-record-event', () => jest.fn() );
+
+jest.mock( '../use-site-intent', () => ( {
+	__esModule: true,
+	default: () => ( { siteIntent: mockSiteIntent, siteIntentFetched: true } ),
+} ) );
+
+const stubSelect = ( store ) => {
+	if ( store === 'core/editor' ) {
+		return {
+			isSavingPost: () => mockIsSaving,
+			getCurrentPostType: () => mockPostType,
+			isCurrentPostPublished: () => mockIsCurrentPostPublished,
+			getPermalink: () => 'https://example.wordpress.com/?p=1',
+		};
+	}
+
+	if ( store === 'core/notices' ) {
+		return {
+			getNotices: () => mockNotices,
+		};
+	}
+};
+
+jest.mock( '@wordpress/data', () => ( {
+	subscribe: ( callback ) => {
+		mockSubscribeCallbacks.push( callback );
+		const unsubscribe = jest.fn( () => {
+			const idx = mockSubscribeCallbacks.indexOf( callback );
+			if ( idx !== -1 ) {
+				mockSubscribeCallbacks.splice( idx, 1 );
+			}
+		} );
+		return unsubscribe;
+	},
+	select: stubSelect,
+	dispatch: ( store ) => {
+		if ( store === 'core/edit-post' ) {
+			return { closePublishSidebar: mockClosePublishSidebar };
+		}
+		if ( store === 'core/notices' ) {
+			return { removeNotice: mockRemoveNotice };
+		}
+		return {};
+	},
+	useSelect: ( selector ) => selector( stubSelect ),
+} ) );
+
+function setupRefs() {
+	refOrder.length = 0;
+	refOrder.push( mockFirstPostRef, mockFetchPromiseRef, mockUnmountedRef );
+}
+
+function simulateSaveCycle( { publishAfterSave = false } = {} ) {
+	mockIsSaving = true;
+	mockSubscribeCallbacks.forEach( ( cb ) => cb() );
+
+	mockIsSaving = false;
+	if ( publishAfterSave ) {
+		mockIsCurrentPostPublished = true;
+	}
+	mockSubscribeCallbacks.forEach( ( cb ) => cb() );
+}
+
+describe( 'OnboardingNextStepAfterPublishingPost', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockSubscribeCallbacks.length = 0;
+		mockIsSaving = false;
+		mockPostType = 'post';
+		mockIsCurrentPostPublished = false;
+		mockNotices = [];
+		mockSiteIntent = 'newsletter';
+		mockFirstPostRef.current = null;
+		mockFetchPromiseRef.current = null;
+		mockUnmountedRef.current = false;
+		mockApiFetchResult = Promise.resolve( {
+			checklist_statuses: { first_post_published: false },
+		} );
+		Object.keys( mockUseEffectFunctions ).forEach( ( k ) => delete mockUseEffectFunctions[ k ] );
+	} );
+
+	it( 'should return null for non-newsletter sites', () => {
+		mockFunctionDescriptor = 'non_newsletter';
+		mockSiteIntent = 'build';
+		setupRefs();
+
+		const result = OnboardingNextStepAfterPublishingPost();
+
+		expect( result ).toBeNull();
+	} );
+
+	it( 'should return null when post type is not post', () => {
+		mockFunctionDescriptor = 'wrong_post_type';
+		mockPostType = 'page';
+		setupRefs();
+
+		const result = OnboardingNextStepAfterPublishingPost();
+
+		expect( result ).toBeNull();
+	} );
+
+	it( 'should fetch launchpad status on mount for newsletter posts', () => {
+		mockFunctionDescriptor = 'fetch_launchpad';
+		setupRefs();
+
+		OnboardingNextStepAfterPublishingPost();
+
+		const effects = mockUseEffectFunctions[ mockFunctionDescriptor ];
+		expect( effects.length ).toBeGreaterThanOrEqual( 2 );
+		effects[ 0 ]();
+
+		const apiFetch = require( '@wordpress/api-fetch' ).default;
+		expect( apiFetch ).toHaveBeenCalledWith( { path: '/wpcom/v2/launchpad' } );
+	} );
+
+	it( 'should not fetch launchpad for non-newsletter sites', () => {
+		mockFunctionDescriptor = 'no_fetch';
+		mockSiteIntent = 'build';
+		setupRefs();
+
+		OnboardingNextStepAfterPublishingPost();
+
+		const effects = mockUseEffectFunctions[ mockFunctionDescriptor ];
+		effects?.forEach( ( fn ) => fn() );
+
+		const apiFetch = require( '@wordpress/api-fetch' ).default;
+		expect( apiFetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should show celebration when first newsletter post is published', async () => {
+		mockFunctionDescriptor = 'first_publish';
+		mockFirstPostRef.current = false;
+		mockFetchPromiseRef.current = Promise.resolve();
+		mockNotices = [ { id: 'editor-save' } ];
+		setupRefs();
+
+		OnboardingNextStepAfterPublishingPost();
+
+		const effects = mockUseEffectFunctions[ mockFunctionDescriptor ];
+		effects[ 1 ]();
+
+		simulateSaveCycle( { publishAfterSave: true } );
+
+		await Promise.resolve();
+
+		expect( mockClosePublishSidebar ).toHaveBeenCalledTimes( 1 );
+		expect( mockRemoveNotice ).toHaveBeenCalledWith( 'editor-save' );
+	} );
+
+	it( 'should not show celebration when first_post_published is already true', async () => {
+		mockFunctionDescriptor = 'already_published';
+		mockFirstPostRef.current = true;
+		mockFetchPromiseRef.current = Promise.resolve();
+		setupRefs();
+
+		OnboardingNextStepAfterPublishingPost();
+
+		const effects = mockUseEffectFunctions[ mockFunctionDescriptor ];
+		effects[ 1 ]();
+
+		simulateSaveCycle( { publishAfterSave: true } );
+
+		await Promise.resolve();
+
+		expect( mockClosePublishSidebar ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should not show celebration when updating an already-published post', async () => {
+		mockFunctionDescriptor = 'update_existing';
+		mockFirstPostRef.current = false;
+		mockFetchPromiseRef.current = Promise.resolve();
+		mockIsCurrentPostPublished = true;
+		setupRefs();
+
+		OnboardingNextStepAfterPublishingPost();
+
+		const effects = mockUseEffectFunctions[ mockFunctionDescriptor ];
+		effects[ 1 ]();
+
+		simulateSaveCycle();
+
+		await Promise.resolve();
+
+		expect( mockClosePublishSidebar ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should still detect publish after a non-publish save cycle', async () => {
+		mockFunctionDescriptor = 'retry_after_draft';
+		mockFirstPostRef.current = false;
+		mockFetchPromiseRef.current = Promise.resolve();
+		setupRefs();
+
+		OnboardingNextStepAfterPublishingPost();
+
+		const effects = mockUseEffectFunctions[ mockFunctionDescriptor ];
+		effects[ 1 ]();
+
+		simulateSaveCycle( { publishAfterSave: false } );
+
+		await Promise.resolve();
+		expect( mockClosePublishSidebar ).not.toHaveBeenCalled();
+
+		simulateSaveCycle( { publishAfterSave: true } );
+
+		await Promise.resolve();
+		expect( mockClosePublishSidebar ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should wait for launchpad fetch before showing celebration', async () => {
+		mockFunctionDescriptor = 'slow_fetch';
+
+		let resolveFetch;
+		const slowPromise = new Promise( ( resolve ) => {
+			resolveFetch = resolve;
+		} );
+		mockFetchPromiseRef.current = slowPromise;
+		mockFirstPostRef.current = null;
+		setupRefs();
+
+		OnboardingNextStepAfterPublishingPost();
+
+		const effects = mockUseEffectFunctions[ mockFunctionDescriptor ];
+		effects[ 1 ]();
+
+		simulateSaveCycle( { publishAfterSave: true } );
+
+		await Promise.resolve();
+		expect( mockClosePublishSidebar ).not.toHaveBeenCalled();
+
+		mockFirstPostRef.current = false;
+		resolveFetch();
+		await Promise.resolve();
+
+		expect( mockClosePublishSidebar ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should handle launchpad fetch failure gracefully', async () => {
+		mockFunctionDescriptor = 'fetch_error';
+		mockApiFetchResult = Promise.reject( new Error( 'Network error' ) );
+		setupRefs();
+
+		OnboardingNextStepAfterPublishingPost();
+
+		const effects = mockUseEffectFunctions[ mockFunctionDescriptor ];
+		effects[ 0 ]();
+
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect( mockFirstPostRef.current ).toBe( false );
+	} );
+
+	it( 'should not show celebration when launchpad fetch is still pending', async () => {
+		mockFunctionDescriptor = 'fetch_pending';
+		mockFirstPostRef.current = null;
+		mockFetchPromiseRef.current = null;
+		setupRefs();
+
+		OnboardingNextStepAfterPublishingPost();
+
+		const effects = mockUseEffectFunctions[ mockFunctionDescriptor ];
+		effects[ 1 ]();
+
+		simulateSaveCycle( { publishAfterSave: true } );
+
+		await Promise.resolve();
+
+		expect( mockClosePublishSidebar ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should not fire celebration after unmount', async () => {
+		mockFunctionDescriptor = 'unmount_guard';
+
+		let resolveFetch;
+		const slowPromise = new Promise( ( resolve ) => {
+			resolveFetch = resolve;
+		} );
+		mockFetchPromiseRef.current = slowPromise;
+		mockFirstPostRef.current = null;
+		setupRefs();
+
+		OnboardingNextStepAfterPublishingPost();
+
+		const effects = mockUseEffectFunctions[ mockFunctionDescriptor ];
+		const cleanup = effects[ 1 ]();
+
+		simulateSaveCycle( { publishAfterSave: true } );
+
+		// Unmount before fetch resolves.
+		cleanup();
+
+		mockFirstPostRef.current = false;
+		resolveFetch();
+		await Promise.resolve();
+
+		expect( mockClosePublishSidebar ).not.toHaveBeenCalled();
+	} );
+} );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2450,6 +2450,7 @@ __metadata:
     "@wordpress/rich-text": "npm:^7.23.0"
     "@wordpress/router": "npm:^1.23.0"
     "@wordpress/url": "npm:^4.23.0"
+    canvas-confetti: "npm:^1.6.0"
     clsx: "npm:^2.1.1"
     debug: "npm:^4.4.1"
     lodash: "npm:^4.17.21"


### PR DESCRIPTION
## Summary

- **Replaces** the dead first-publish snackbar (triggered by a URL hash nothing sets — zero users hit it in Q1 2026) with a confetti celebration modal for newsletter authors
- **New trigger**: checks the launchpad API `first_post_published` status on editor mount, scoped to newsletter sites only via `siteIntentOption`. No dependency on onboarding flow URL parameters.
- **Adds a "Write your next post" CTA** to close the loop between first and second publish — funnel data shows 76% of first-time newsletter emailers don't send again within a week, but retention flattens at 34% for second-post senders
- **New Tracks events**: `calypso_newsletter_first_publish_celebration_shown` and `calypso_newsletter_first_publish_celebration_cta_click`

Part of #77090

## Test plan

- [ ] Create a new newsletter site and publish the first post — verify the confetti modal appears
- [ ] Click "Write your next post" CTA — verify it navigates to a new post editor and fires the CTA click event
- [ ] Close the modal via the X button — verify it dismisses cleanly
- [ ] Publish a second post on the same site — verify the celebration modal does NOT appear again
- [ ] Create a non-newsletter (blog) site and publish the first post — verify no modal appears
- [ ] Verify both Tracks events fire correctly in the console
- [ ] Block editor app — test after CI deploys to widgets.wp.com, not locally

Generated with [Claude Code](https://claude.com/claude-code)