### PR TITLE
Add taglines to experiment

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
@@ -39,6 +39,11 @@ type PlanDifferentiatorsExperimentResult = {
 	 */
 	useVar42NoAiFeatures: boolean;
 	/**
+	 * When true, use focused_new_copy taglines for plan headers.
+	 * Applies to: focused_new_copy only.
+	 */
+	useFocusedNewCopyTaglines: boolean;
+	/**
 	 * When true, the user is eligible for the experiment (any arm, including control).
 	 */
 	isExperimentVariant: boolean;
@@ -94,6 +99,7 @@ function usePlanDifferentiatorsExperiment( {
 			variant === 'focused_more_premium' ||
 			variant === 'focused_new_copy' ||
 			variant === 'focused_no_ai',
+		useFocusedNewCopyTaglines: variant === 'focused_new_copy',
 		isExperimentVariant,
 	};
 }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -400,6 +400,7 @@ const PlansFeaturesMain = ( {
 		useVar41MorePremiumFeatures,
 		useVar42NoAiFeatures,
 		showPricingDifferentiationFeaturePills,
+		useFocusedNewCopyTaglines,
 		isExperimentVariant,
 	} = usePlanDifferentiatorsExperiment( { flowName, isInSignup, siteId } );
 
@@ -483,6 +484,7 @@ const PlansFeaturesMain = ( {
 		useVar41MorePremiumFeatures,
 		useVar42NoAiFeatures,
 		showPricingDifferentiationFeaturePills,
+		useFocusedNewCopyTaglines,
 		isExperimentVariant,
 	} );
 
@@ -511,6 +513,7 @@ const PlansFeaturesMain = ( {
 		useVar41MorePremiumFeatures,
 		useVar42NoAiFeatures,
 		showPricingDifferentiationFeaturePills,
+		useFocusedNewCopyTaglines,
 		isExperimentVariant,
 	} );
 

--- a/packages/calypso-products/src/features-list.tsx
+++ b/packages/calypso-products/src/features-list.tsx
@@ -3193,7 +3193,15 @@ const FEATURES_LIST: FeatureList = {
 	// AI features for plan differentiators experiment
 	[ FEATURE_AI_WEBSITE_BUILDER ]: {
 		getSlug: () => FEATURE_AI_WEBSITE_BUILDER,
-		getTitle: () => i18n.translate( 'AI Website Builder' ),
+		getTitle: () => {
+			if (
+				i18n.getLocaleSlug()?.startsWith( 'en' ) ||
+				i18n.hasTranslation( 'AI website builder' )
+			) {
+				return i18n.translate( 'AI website builder' );
+			}
+			return i18n.translate( 'AI Website Builder' );
+		},
 		getDescription: ( params ) =>
 			params?.isExperimentVariant
 				? i18n.translate( 'Use the latest AI models in the AI website builder.' )

--- a/packages/plans-grid-next/src/hooks/data-store/types.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/types.ts
@@ -54,6 +54,11 @@ export interface UseGridPlansParams {
 	 */
 	showPricingDifferentiationFeaturePills?: boolean;
 	/**
+	 * When true, use the focused_new_copy taglines for plan headers.
+	 * Applies to: focused_new_copy only.
+	 */
+	useFocusedNewCopyTaglines?: boolean;
+	/**
 	 * When true, the user is in an experiment variant (not control).
 	 */
 	isExperimentVariant?: boolean;

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-comparison-grid.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-comparison-grid.ts
@@ -32,6 +32,7 @@ const useGridPlansForComparisonGrid = ( {
 	useVar41MorePremiumFeatures,
 	useVar42NoAiFeatures,
 	showPricingDifferentiationFeaturePills,
+	useFocusedNewCopyTaglines,
 	isExperimentVariant,
 }: UseGridPlansParams ): GridPlan[] | null => {
 	const gridPlans = useGridPlans( {
@@ -51,6 +52,7 @@ const useGridPlansForComparisonGrid = ( {
 		useFreeTrialPlanSlugs,
 		isDomainOnlySite,
 		reflectStorageSelectionInPlanPrices,
+		useFocusedNewCopyTaglines,
 		isExperimentVariant,
 	} );
 

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-features-grid.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-features-grid.ts
@@ -29,6 +29,7 @@ const useGridPlansForFeaturesGrid = ( {
 	useVar41MorePremiumFeatures,
 	useVar42NoAiFeatures,
 	showPricingDifferentiationFeaturePills,
+	useFocusedNewCopyTaglines,
 	isExperimentVariant,
 }: UseGridPlansParams ): GridPlan[] | null => {
 	const gridPlans = useGridPlans( {
@@ -50,6 +51,7 @@ const useGridPlansForFeaturesGrid = ( {
 		highlightLabelOverrides,
 		isDomainOnlySite,
 		reflectStorageSelectionInPlanPrices,
+		useFocusedNewCopyTaglines,
 		isExperimentVariant,
 	} );
 

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -29,6 +29,7 @@ import {
 	getPlanClass,
 } from '@automattic/calypso-products';
 import { Plans } from '@automattic/data-stores';
+import i18n, { useTranslate } from 'i18n-calypso';
 import { isSamePlan } from '../../lib/is-same-plan';
 import { UseGridPlansParams, UseGridPlansType } from './types';
 import useHighlightLabels from './use-highlight-labels';
@@ -309,8 +310,10 @@ const useGridPlans: UseGridPlansType = ( {
 	highlightLabelOverrides,
 	isDomainOnlySite,
 	reflectStorageSelectionInPlanPrices,
+	useFocusedNewCopyTaglines,
 	isExperimentVariant,
 } ) => {
+	const translate = useTranslate();
 	const freeTrialPlanSlugs = useFreeTrialPlanSlugs?.( {
 		intent: intent ?? 'default',
 		eligibleForFreeHostingTrial,
@@ -393,6 +396,47 @@ const useGridPlans: UseGridPlansType = ( {
 			tagline = planConstantObj.getBlogOnboardingTagLine?.() ?? '';
 		} else {
 			tagline = planConstantObj.getPlanTagline?.() ?? '';
+		}
+
+		if ( useFocusedNewCopyTaglines ) {
+			const existingTagline = tagline;
+			if ( isFreePlan( planSlug ) ) {
+				tagline =
+					i18n.getLocaleSlug()?.startsWith( 'en' ) ||
+					i18n.hasTranslation( 'Start your WordPress journey.' )
+						? translate( 'Start your WordPress journey.' )
+						: existingTagline;
+			} else if ( isPersonalPlan( planSlug ) ) {
+				tagline =
+					i18n.getLocaleSlug()?.startsWith( 'en' ) ||
+					i18n.hasTranslation( 'Build your presence with a site you can customize.' )
+						? translate( 'Build your presence with a site you can customize.' )
+						: existingTagline;
+			} else if ( isPremiumPlan( planSlug ) ) {
+				tagline =
+					i18n.getLocaleSlug()?.startsWith( 'en' ) ||
+					i18n.hasTranslation( 'Accept payments on your site and reach more people.' )
+						? translate( 'Accept payments on your site and reach more people.' )
+						: existingTagline;
+			} else if ( isBusinessPlan( planSlug ) ) {
+				tagline =
+					i18n.getLocaleSlug()?.startsWith( 'en' ) ||
+					i18n.hasTranslation( 'Grow your business with powerful tools and priority support.' )
+						? translate( 'Grow your business with powerful tools and priority support.' )
+						: existingTagline;
+			} else if ( isEcommercePlan( planSlug ) ) {
+				tagline =
+					i18n.getLocaleSlug()?.startsWith( 'en' ) ||
+					i18n.hasTranslation( 'Run an online store and keep more of what you earn.' )
+						? translate( 'Run an online store and keep more of what you earn.' )
+						: existingTagline;
+			} else if ( isWpcomEnterpriseGridPlan( planSlug ) ) {
+				tagline =
+					i18n.getLocaleSlug()?.startsWith( 'en' ) ||
+					i18n.hasTranslation( 'Publish securely at enterprise scale.' )
+						? translate( 'Publish securely at enterprise scale.' )
+						: existingTagline;
+			}
 		}
 
 		const productNameShort =


### PR DESCRIPTION
Part of DOTCOM-16384

## Proposed Changes

* Variant focused_new_copy needs new taglines
* Lowercase one of the features per request

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

* Assign a test user to the focused_new_copy variant of the 
* Start the setup/onboarding flow
* Notice new taglines and lowercase AI website builder

<img width="1438" height="744" alt="Screenshot 2026-04-01 at 10 29 10" src="https://github.com/user-attachments/assets/4352608a-c56b-4e48-afc9-4e4c75fa79ea" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
