### PR TITLE
The AI feature has no line break on mobile

### DIFF
--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -356,6 +356,12 @@
 	flex: 1 0 0;
 	width: 100%;
 
+	.plan-features-2023-grid__ai-website-builder-break {
+		@media ( max-width: 480px ) {
+			display: none;
+		}
+	}
+
 	.plan-features-2023-grid__item-title {
 		color: var(--studio-gray-80);
 		font-size: $font-body-small;

--- a/packages/plans-grid-next/src/components/features.tsx
+++ b/packages/plans-grid-next/src/components/features.tsx
@@ -203,7 +203,11 @@ const PlanFeatures2023GridFeatures: React.FC< {
 														<FeatureBadge>{ currentFeature.badgeText }</FeatureBadge>
 													) }
 												</span>
-												{ shouldBreakAfterAiWebsiteBuilderTitle && <div>{ '\u00A0' }</div> }
+												{ shouldBreakAfterAiWebsiteBuilderTitle && (
+													<div className="plan-features-2023-grid__ai-website-builder-break">
+														{ '\u00A0' }
+													</div>
+												) }
 												{ currentFeature?.getSubFeatureObjects?.()?.length ? (
 													<ul className="plan-features-2023-grid__item-sub-feature-list">
 														{ currentFeature.getSubFeatureObjects().map( ( subFeature ) => (


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* We inserted an empty line on mobile after the AI website builder because the Personal feature is longer

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*



## Testing Instructions

1. Assign yourself to the focused_new_copy of the experiment and switch to mobile
2. No break after AI website builder
<img width="357" height="612" alt="Screenshot 2026-04-01 at 12 25 48" src="https://github.com/user-attachments/assets/dc6d75b4-bd8c-4249-a95a-f65f01ffc2c8" />


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
