### PR TITLE
MSD: Load locale data for the interim omnibar

### DIFF
--- a/client/dashboard/app/interim-omnibar/index.tsx
+++ b/client/dashboard/app/interim-omnibar/index.tsx
@@ -1,7 +1,31 @@
 import { queryClient, siteByIdQuery } from '@automattic/api-queries';
+import { defaultI18n } from '@wordpress/i18n';
 import { hydrateRoot } from 'react-dom/client';
 import { AUTH_QUERY_KEY, initializeCurrentUser } from '../auth';
 import type { OmnibarEvents } from './click-handlers';
+import type { User } from '@automattic/api-core';
+
+async function loadLocaleData( user: User ) {
+	const language =
+		( user as User & { localeVariant?: string; localeSlug?: string } ).localeVariant ||
+		( user as User & { localeVariant?: string; localeSlug?: string } ).localeSlug ||
+		user.locale_variant ||
+		user.language ||
+		'en';
+
+	if ( language === 'en' ) {
+		return;
+	}
+
+	try {
+		const response = await fetch(
+			`https://widgets.wp.com/languages/calypso/${ language }-v1.1.json`
+		);
+		defaultI18n.resetLocaleData( await response.json() );
+	} catch {
+		// Fall back to English if loading fails.
+	}
+}
 
 export default async function loadOmnibar( events: OmnibarEvents ) {
 	const container = document.getElementById( 'wpcom-omnibar' );
@@ -46,9 +70,10 @@ export default async function loadOmnibar( events: OmnibarEvents ) {
 		{ onRecoverableError() {} }
 	);
 
-	const site = user.primary_blog
-		? await queryClient.fetchQuery( siteByIdQuery( user.primary_blog ) )
-		: null;
+	const [ site ] = await Promise.all( [
+		user.primary_blog ? queryClient.fetchQuery( siteByIdQuery( user.primary_blog ) ) : null,
+		loadLocaleData( user ),
+	] );
 
 	root.render(
 		<InterimOmnibar


### PR DESCRIPTION
## Summary

- The interim omnibar was always rendering in English because it hydrates independently from the main dashboard `Layout`, which provides the `I18nProvider`.
- Fix by fetching the user's locale data and calling `defaultI18n.resetLocaleData()` before re-rendering the omnibar with full user/site data.
- The locale fetch runs in parallel with the site data fetch, so no additional latency.

Fixes: DOTMSD-1199

## Test plan

- [ ] Set your account language to a non-English locale (e.g. Arabic, French)
- [ ] Navigate to the MSD dashboard (`/sites`)
- [ ] Verify the omnibar text is translated (e.g. "My Sites", "Write", notifications tooltip)
- [ ] Verify RTL layout works correctly for RTL languages
- [ ] Verify English locale still works (no regression)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)