### PR TITLE
A4A: Pass external-checkout flag to UPI pending redirect

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -588,7 +588,12 @@ export default function CheckoutMain( {
 			eps: ( transactionData: unknown ) =>
 				genericRedirectProcessor( 'eps', transactionData, dataForProcessor ),
 			'stripe-upi': ( transactionData: unknown ) =>
-				upiProcessor( transactionData, dataForProcessor, translate ),
+				upiProcessor(
+					transactionData,
+					dataForProcessor,
+					translate,
+					sitelessCheckoutType === 'a4a'
+				),
 			'existing-card': ( transactionData: unknown ) =>
 				existingCardProcessor( transactionData, dataForProcessor ),
 			'existing-card-ebanx': ( transactionData: unknown ) =>
@@ -601,7 +606,7 @@ export default function CheckoutMain( {
 			razorpay: ( transactionData: unknown ) =>
 				razorpayProcessor( transactionData, dataForProcessor, translate ),
 		} ),
-		[ dataForProcessor, translate ]
+		[ dataForProcessor, sitelessCheckoutType, translate ]
 	);
 
 	// Gravatar Theme

--- a/client/my-sites/checkout/src/lib/upi-processor.ts
+++ b/client/my-sites/checkout/src/lib/upi-processor.ts
@@ -34,7 +34,8 @@ type StripeUpiTransactionRequest = {
 export default async function upiProcessor(
 	submitData: unknown,
 	options: PaymentProcessorOptions,
-	translate: LocalizeProps[ 'translate' ]
+	translate: LocalizeProps[ 'translate' ],
+	fromExternalCheckout?: boolean
 ): Promise< PaymentProcessorResponse > {
 	if ( ! isValidTransactionData( submitData ) ) {
 		throw new Error( 'Required purchase data is missing' );
@@ -64,6 +65,7 @@ export default async function upiProcessor(
 	const successUrl = addUrlToPendingPageRedirect( thankYouUrl, {
 		siteSlug,
 		fromSiteSlug,
+		fromExternalCheckout,
 		urlType: 'absolute',
 	} );
 	const cancelUrl = `${ origin }${ pathname }${ search }`;
@@ -121,6 +123,7 @@ export default async function upiProcessor(
 			const pendingPageUrl = addUrlToPendingPageRedirect( thankYouUrl, {
 				siteSlug,
 				fromSiteSlug,
+				fromExternalCheckout,
 				orderId: response.order_id,
 				urlType: 'absolute',
 			} );


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/A4A-2330/enable-upi-payments-on-a4a-checkout

## Proposed Changes
- Pass a UPI-only `fromExternalCheckout` boolean into `upiProcessor` and thread it into `addUrlToPendingPageRedirect`.
- Derive `fromExternalCheckout` from `sitelessCheckoutType === 'a4a'` at the UPI processor call site.

## Why are these changes being made?
UPI requires forcing the pending-page origin to wordpress.com when checkout is initiated from an external (A4A) checkout context.

## Testing Instructions
- In an A4A siteless checkout flow, select UPI and confirm the generated pending-page URL uses a wordpress.com origin.
- In non-A4A checkout flows, confirm UPI continues to use the current origin for pending-page URLs.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?