### PR TITLE
fix(e2e): opt Jest tests into Mailosaur for reliable cleanup

### DIFF
--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
@@ -36,6 +36,7 @@ declare const browser: Browser;
 describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function () {
 	const planName = 'Personal';
 	const testUser = DataHelper.getNewTestUser( {
+		useMailosaur: true,
 		usernamePrefix: 'ftmepersonal',
 	} );
 

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site.ts
@@ -29,7 +29,7 @@ describe(
 		jest.setTimeout( 240 * 1000 );
 
 		const planName = 'Business';
-		const testUser = DataHelper.getNewTestUser();
+		const testUser = DataHelper.getNewTestUser( { useMailosaur: true } );
 
 		let newUserDetails: NewUserResponse;
 		let siteSlug: string;

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection.ts
@@ -21,7 +21,7 @@ describe(
 	function () {
 		const planName = 'Business';
 		const blogName = DataHelper.getBlogName();
-		const testUser = DataHelper.getNewTestUser();
+		const testUser = DataHelper.getNewTestUser( { useMailosaur: true } );
 
 		let newUserDetails: NewUserResponse;
 		let plansPage: PlansPage;

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection__pre-selected-plan.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection__pre-selected-plan.ts
@@ -27,7 +27,7 @@ describe(
 		const planSlug = 'business-bundle';
 		const planName = 'Business';
 		const blogName = DataHelper.getBlogName();
-		const testUser = DataHelper.getNewTestUser();
+		const testUser = DataHelper.getNewTestUser( { useMailosaur: true } );
 
 		let newUserDetails: NewUserResponse;
 		let cartCheckoutPage: CartCheckoutPage;

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site__pre-selected-plan.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site__pre-selected-plan.ts
@@ -19,7 +19,7 @@ describe(
 	function () {
 		const planSlug = 'business-bundle';
 		const planName = 'Business';
-		const testUser = DataHelper.getNewTestUser();
+		const testUser = DataHelper.getNewTestUser( { useMailosaur: true } );
 
 		let newUserDetails: NewUserResponse;
 		let cartCheckoutPage: CartCheckoutPage;

--- a/test/e2e/specs/onboarding/onboarding__write.ts
+++ b/test/e2e/specs/onboarding/onboarding__write.ts
@@ -21,6 +21,7 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () {
 	const blogName = DataHelper.getBlogName();
 	const testUser = DataHelper.getNewTestUser( {
+		useMailosaur: true,
 		usernamePrefix: 'signupfree',
 	} );
 

--- a/test/e2e/specs/onboarding/signup__with-theme-premium.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-premium.ts
@@ -36,6 +36,7 @@ describe( 'Lifecyle: Premium theme signup, onboard, launch and cancel subscripti
 	let themeSlug: string | null = null;
 
 	const testUser = DataHelper.getNewTestUser( {
+		useMailosaur: true,
 		usernamePrefix: 'ftmepremium',
 	} );
 


### PR DESCRIPTION
## Summary

- Opts all Jest onboarding tests into Mailosaur (`useMailosaur: true`) to fix silent account cleanup failures
- Follow-up to #109692 which introduced Gmail+ aliasing as the default for `getNewTestUser()`

## Context

When signing up with a Gmail+ alias (e.g. `a8c.e2e+e2eflowtesting123@gmail.com`), WP.com assigns a username derived from the full local part (`a8ce2ee2eflowtesting123`), which differs from the username we generate locally (`e2eflowtesting123`). This mismatch causes `closeAccount` to fail silently with `invalid_username`, leaving orphaned accounts on WP.com.

Playwright tests are unaffected because their cleanup uses the bearer token from the signup response. Jest tests fall back to username/password auth when the bearer token isn't available (e.g. when the test fails before signup completes).

## Test plan

- [ ] Verify Jest `calypso-release` tests pass with Mailosaur
- [ ] Verify account cleanup succeeds (no `invalid_username` or `incorrect_password` errors)
- [ ] Verify Playwright tests still use Gmail aliasing (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)