### PR TITLE
Dashboard: Site Performance: Standardize site launch

### DIFF
--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -1,17 +1,21 @@
 import page from '@automattic/calypso-router';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { Button } from '@wordpress/components';
+import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import moment from 'moment';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSiteSettings } from 'calypso/blocks/plugins-scheduled-updates/hooks/use-site-settings';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import NavigationHeader from 'calypso/components/navigation-header';
+import { AnalyticsProvider } from 'calypso/dashboard/app/analytics';
+import SiteLaunchCelebrationModal from 'calypso/dashboard/sites/site-launch-celebration-modal';
 import {
 	DeviceTabProvider,
 	useDeviceTab,
 } from 'calypso/hosting/performance/contexts/device-tab-context';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useExperiment } from 'calypso/lib/explat';
 import { TabType } from 'calypso/performance-profiler/components/header';
 import { profilerVersion } from 'calypso/performance-profiler/utils/profiler-version';
 import { trackReportCompletedEvent } from 'calypso/performance-profiler/utils/track-report-events';
@@ -34,8 +38,14 @@ import { ExpiredReportNotice } from './components/expired-report-notice/expired-
 import { usePerformanceReport } from './hooks/usePerformanceReport';
 import { useSitePerformancePageReports } from './hooks/useSitePerformancePageReports';
 import { getSupportLinkProps } from './utils';
+import type { Site as DashboardSite } from '@automattic/api-core';
 
 import './style.scss';
+
+const analyticsClient = {
+	recordTracksEvent,
+	recordPageView: () => {}, // Required by AnalyticsClient interface; unused by SiteLaunchCelebrationModal
+};
 
 const statType = 'statsTopPosts';
 const statsQuery = {
@@ -148,6 +158,31 @@ const SitePerformanceContent = ( { path }: { path?: string } ) => {
 		( state ) => getRequest( state, launchSite( siteId ) )?.isLoading ?? false
 	);
 
+	const [ isExperimentLoading, experimentData ] = useExperiment(
+		'calypso_standardized_site_launch_gating'
+	);
+	const experimentVariant = experimentData?.variationName;
+
+	const [ isCelebrationModalOpen, setIsCelebrationModalOpen ] = useState( false );
+	const prevSiteIsLaunchingRef = useRef( siteIsLaunching );
+
+	// calypso_standardized_site_launch_gating experiment: ungated_site_launch variant
+	// Show celebration modal when site launch completes
+	useEffect( () => {
+		const wasLaunching = prevSiteIsLaunchingRef.current;
+		prevSiteIsLaunchingRef.current = siteIsLaunching;
+
+		// Only show modal when launch completes (transitions from launching to not launching)
+		if (
+			experimentVariant === 'ungated_site_launch' &&
+			wasLaunching &&
+			! siteIsLaunching &&
+			isSitePublic
+		) {
+			setIsCelebrationModalOpen( true );
+		}
+	}, [ siteIsLaunching, isSitePublic, experimentVariant ] );
+
 	const retestPage = () => {
 		recordTracksEvent( 'calypso_performance_profiler_test_again_click' );
 		performance.mark( 'test-started' );
@@ -169,7 +204,6 @@ const SitePerformanceContent = ( { path }: { path?: string } ) => {
 			return;
 		}
 
-		dispatch( launchSite( siteId! ) );
 		recordTracksEvent( 'calypso_performance_profiler_launch_site_cta_click' );
 
 		// Additional event to align analysis across dashboards.
@@ -178,6 +212,20 @@ const SitePerformanceContent = ( { path }: { path?: string } ) => {
 			context: 'site_performance',
 			path,
 		} );
+
+		if ( experimentVariant === 'gated_site_launch' ) {
+			window.location.assign(
+				addQueryArgs( '/start/launch-site', {
+					siteSlug: site?.slug,
+					back_to: `/sites/performance/${ site?.slug }`,
+				} )
+			);
+			return;
+		}
+
+		// For both ungated and control: use Redux action
+		// (ungated variant will show celebration modal via useEffect)
+		dispatch( launchSite( siteId! ) );
 	};
 
 	const isMobile = useMobileBreakpoint();
@@ -325,7 +373,7 @@ const SitePerformanceContent = ( { path }: { path?: string } ) => {
 				<>
 					{ ! isSitePublic ? (
 						<ReportUnavailable
-							isLaunching={ siteIsLaunching }
+							isLaunching={ siteIsLaunching || isExperimentLoading }
 							onLaunchSiteClick={ onLaunchSiteClick }
 							ctaText={
 								site?.is_a4a_dev_site
@@ -349,6 +397,14 @@ const SitePerformanceContent = ( { path }: { path?: string } ) => {
 						</>
 					) }
 				</>
+			) }
+			{ isCelebrationModalOpen && site && (
+				<AnalyticsProvider client={ analyticsClient }>
+					<SiteLaunchCelebrationModal
+						site={ site as unknown as DashboardSite }
+						onClose={ () => setIsCelebrationModalOpen( false ) }
+					/>
+				</AnalyticsProvider>
 			) }
 		</div>
 	);

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -305,6 +305,7 @@ export function generateFlows( {
 			destination: getLaunchDestination,
 			description: 'A flow to launch a private site.',
 			providesDependenciesInQuery: [ 'siteSlug' ],
+			optionalDependenciesInQuery: [ 'back_to' ],
 			hideProgressIndicator: true,
 			lastModified: '2019-11-22',
 			excludeFromManageSiteFlows: true,

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -104,6 +104,11 @@ function getSignupDestination( { siteSlug, redirect_to, localeSlug, flowName } )
 }
 
 function getLaunchDestination( dependencies ) {
+	// If back_to is provided, redirect to that destination instead
+	if ( dependencies.back_to ) {
+		return dependencies.back_to;
+	}
+
 	if ( dependencies.refParameter === 'wp-admin' ) {
 		return addQueryArgs(
 			{ 'celebrate-launch': 'true' },

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -637,8 +637,10 @@ class Signup extends Component {
 	getDependenciesInQuery = () => {
 		const flow = flows.getFlow( this.props.flowName, this.props.isLoggedIn );
 		const requiredDependenciesInQuery = flow?.providesDependenciesInQuery ?? [];
+		const optionalDependenciesInQuery = flow?.optionalDependenciesInQuery ?? [];
+		const allDependencies = [ ...requiredDependenciesInQuery, ...optionalDependenciesInQuery ];
 
-		return this.extractFlowDependenciesFromQuery( requiredDependenciesInQuery );
+		return this.extractFlowDependenciesFromQuery( allDependencies );
 	};
 
 	getCurrentFlowSupportedQueryParams = () => {


### PR DESCRIPTION
Fixes DATSCI-1181

Implement the standardized site launch flow experiment for the Calypso Hosting Site Performance page with three variants:

- **Control**: Preserve existing Redux launch behavior
- **Gated**: Redirect to /start/launch-site stepper with back_to parameter
- **Ungated**: Use Redux launch + show SiteLaunchCelebrationModal from dashboard

The ungated variant detects launch completion via state transition (siteIsLaunching false + isSitePublic true) and displays the celebration modal, providing feedback to users without page refresh.

<img width="462" height="477" alt="Screenshot 2026-04-01 at 16 40 39" src="https://github.com/user-attachments/assets/86b0dd89-37ad-41a2-aa06-af7ee8b0d14f" />

## Proposed Changes

- Added experiment hook integration (`useExperiment('calypso_standardized_site_launch_gating')`)
- Implemented three variant flows in `onLaunchSiteClick` handler
- Created modal state management with smart detection of launch completion
- Integrated `SiteLaunchCelebrationModal` from dashboard with `AnalyticsProvider` bridge

## Why are these changes being made?

We are standardizing the site launch flow across WordPress.com surfaces (Calypso, Dashboard, Masterbar) to provide a consistent user experience. This experiment tests different launch approaches:
- **Control**: Baseline behavior
- **Gated**: Funnels users through structured onboarding stepper
- **Ungated**: Immediate launch with celebration feedback

This helps us measure which approach best drives site engagement while maintaining backward compatibility.

## Testing Instructions

**Prerequisites**: Test site must be **Atomic** (AT) and currently **not launched** (blog_public: 0)

### Reset Site Between Tests

To test multiple variants on the same site, SSH into the site and run:
```bash
wp option update launch-status unlaunched && wp option update blog_public 0
```
Then refresh the dashboard to clear the in-memory cache.

### Testing Each Variant

#### 1. Control Variant (null/no assignment)
- Navigate to `/sites/performance/:site` on an unlaunched atomic site
- Click "Launch your site" button
- **Expected**:
  - Success notice appears ("Your site has been launched...")
  - Banner disappears, Performance Report shows instead
  - No celebration modal
  - Same behavior as before the experiment

#### 2. Gated Variant (gated_site_launch)
- Manually assign variant via Explat or using browser dev tools
- Navigate to `/sites/performance/:site` on unlaunched atomic site
- Click "Launch your site" button
- **Expected**:
  - Redirect to `/start/launch-site?siteSlug=...&back_to=/sites/performance/:site`
  - Complete launch stepper flow
  - After launching, redirect back to the performance page
  - Banner is gone, Performance Report visible

#### 3. Ungated Variant (ungated_site_launch)
- Manually assign variant via Explat or using browser dev tools
- Navigate to `/sites/performance/:site` on unlaunched atomic site
- Click "Launch your site" button
- **Expected**:
  - Button enters loading state
  - API call launches the site
  - Banner transitions to Performance Report (no refresh needed)
  - Celebration modal appears with confetti animation
  - Modal shows site domain and domain upsell options
  - Close button dismisses modal without side effects
  - Track events: `calypso_dashboard_site_launch_button_click`, `calypso_launchpad_celebration_modal_view` recorded

### Verification Checklist
- [ ] All three variants tested end-to-end
- [ ] No console errors in any variant
- [ ] Celebration modal only shows once per launch (not on every page refresh)
- [ ] Modal closes cleanly and doesn't break page state
- [ ] Track events fire correctly for each variant
- [ ] Site appears as public/launched in subsequent navigation
