### PR TITLE
Fix TimeMismatchWarning placement on Activity Log pages

### DIFF
--- a/client/my-sites/activity/activity-log-v2/index.tsx
+++ b/client/my-sites/activity/activity-log-v2/index.tsx
@@ -143,7 +143,6 @@ const ActivityLogV2: FunctionComponent = () => {
 			<DocumentHead title={ translate( 'Activity Log' ) } />
 			{ isJetpackCloud() && <SidebarNavigation /> }
 			<PageViewTracker path="/activity-log/:site" title="Activity Log" />
-			{ settingsUrl && <TimeMismatchWarning siteId={ siteId } settingsUrl={ settingsUrl } /> }
 			{ isWpcom ? (
 				<Page
 					hasPadding
@@ -153,11 +152,13 @@ const ActivityLogV2: FunctionComponent = () => {
 						'This is the complete event history for your site. Filter by date range and/or activity type.'
 					) }
 				>
+					{ settingsUrl && <TimeMismatchWarning siteId={ siteId } settingsUrl={ settingsUrl } /> }
 					{ content }
 				</Page>
 			) : (
 				<>
 					{ jetpackCloudHeader }
+					{ settingsUrl && <TimeMismatchWarning siteId={ siteId } settingsUrl={ settingsUrl } /> }
 					{ content }
 				</>
 			) }

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -496,6 +496,9 @@ class ActivityLog extends Component {
 						"Keep tabs on all your site's activity — plugin and theme updates, user logins, setting modifications, and more."
 					) }
 				>
+					{ siteId && (
+						<TimeMismatchWarning siteId={ siteId } settingsUrl={ this.props.siteSettingsUrl } />
+					) }
 					{ siteId && isJetpack && ! isAtomic && <RewindAlerts siteId={ siteId } /> }
 					{ siteId && 'unavailable' === rewindState.state && (
 						<RewindUnavailabilityNotice siteId={ siteId } />
@@ -594,7 +597,7 @@ class ActivityLog extends Component {
 	render() {
 		const { siteId, translate } = this.props;
 
-		const { context, rewindState, siteSettingsUrl } = this.props;
+		const { context, rewindState } = this.props;
 
 		const rewindNoThanks = get( context, 'query.rewind-redirect', '' );
 		const rewindIsNotReady =
@@ -609,7 +612,6 @@ class ActivityLog extends Component {
 				{ siteId && <QueryRewindPolicies siteId={ siteId } /> }
 				{ siteId && <QueryRewindState siteId={ siteId } /> }
 				{ siteId && <QueryJetpackPlugins siteIds={ [ siteId ] } /> }
-				{ siteId && <TimeMismatchWarning siteId={ siteId } settingsUrl={ siteSettingsUrl } /> }
 				{ '' !== rewindNoThanks && rewindIsNotReady
 					? siteId && <ActivityLogSwitch siteId={ siteId } redirect={ rewindNoThanks } />
 					: this.getActivityLog() }

--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -52,9 +52,6 @@ body.is-section-backup {
 	display: flex;
 	flex-direction: column;
 	height: calc(100vh - 120px);
-	margin-left: -16px;
-	margin-right: -16px;
-
 	@include breakpoint-deprecated( ">660px" ) {
 		height: auto;
 	}


### PR DESCRIPTION
Fixes JETPACK-1512

## Proposed Changes

- Move `TimeMismatchWarning` inside the `<Page>` component on Activity Log v1 and v2
- Remove obsolete negative margins from `.backup__main-wrap`


Before:
Calypso
<img width="1257" height="346" alt="image" src="https://github.com/user-attachments/assets/deb0c1d8-e6bf-4bcc-a2a4-b879b2093e6f" />

Jetpack Cloud
<img width="1253" height="483" alt="image" src="https://github.com/user-attachments/assets/83195e33-ae96-412d-98a8-854c4380df78" />

After:
Calypso
<img width="2480" height="1162" alt="backup-calypso-after" src="https://github.com/user-attachments/assets/b26e4b62-1a71-4548-81ab-850b57f2c06f" />

Jetpack Cloud
<img width="2480" height="949" alt="backup-jpc-after" src="https://github.com/user-attachments/assets/a84e032b-7081-4efa-9f35-2bafb96b2d88" />


It also addresses an issue with backup page on JPC, where negative margins (now unused) would make the main wrapper look out of line:

Before:
<img width="1176" height="489" alt="image" src="https://github.com/user-attachments/assets/df1f6521-4d73-4beb-981f-59ece45f2fce" />


After:
<img width="2480" height="2042" alt="backup-jpc-after" src="https://github.com/user-attachments/assets/66f9d914-9229-48ea-86bb-cd408162a73a" />


## Why are these changes being made?

After migrating Jetpack page headers to `@wordpress/admin-ui` `Page`, the timezone mismatch notice on Activity Log pages ended up rendering outside the `Page` component — above the page header instead of within the page content area.

This was already fixed for Scan (#109625) and Backup (#109626). A search for all `TimeMismatchWarning` usages confirmed Activity Log v1 and v2 were the last remaining instances with this placement issue.

The negative margins on `.backup__main-wrap` were a bleed-out hack to counteract parent padding that is no longer needed after the Page migration.

## Testing Instructions

- Navigate to `/activity-log/:site` on a WP.com site
- If the timezone mismatch notice appears (site timezone ≠ browser timezone), verify it renders inside the page content area, below the header
- Check Jetpack Cloud activity log as well — the notice should still appear there
- Navigate to `/backup/:site` — verify layout is not affected by the margin removal

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?