### PR TITLE
Dashboard performance: hide page and device selectors when site is not public

### DIFF
--- a/client/hosting/performance/components/MobileHeader.tsx
+++ b/client/hosting/performance/components/MobileHeader.tsx
@@ -24,14 +24,16 @@ export const MobileHeader = ( { pageTitle, pageSelector, subtitle }: MobileHeade
 				title={ <div className="navigation-header-title">{ translate( 'Performance' ) }</div> }
 				subtitle={ pageTitle }
 			>
-				<Button
-					variant="tertiary"
-					onClick={ togglePageSelector }
-					aria-expanded={ isPageSelectorVisible }
-				>
-					<ScreenReaderText>{ translate( 'toggle page selector' ) }</ScreenReaderText>
-					<Gridicon icon="cog" />
-				</Button>
+				{ pageSelector && (
+					<Button
+						variant="tertiary"
+						onClick={ togglePageSelector }
+						aria-expanded={ isPageSelectorVisible }
+					>
+						<ScreenReaderText>{ translate( 'toggle page selector' ) }</ScreenReaderText>
+						<Gridicon icon="cog" />
+					</Button>
+				) }
 			</NavigationHeader>
 
 			{ isPageSelectorVisible && pageSelector && (

--- a/client/hosting/performance/components/MobileHeader.tsx
+++ b/client/hosting/performance/components/MobileHeader.tsx
@@ -6,7 +6,7 @@ import NavigationHeader from 'calypso/components/navigation-header';
 
 type MobileHeaderProps = {
 	pageTitle: string;
-	pageSelector: JSX.Element;
+	pageSelector?: JSX.Element;
 	subtitle?: ReactNode;
 };
 
@@ -34,7 +34,7 @@ export const MobileHeader = ( { pageTitle, pageSelector, subtitle }: MobileHeade
 				</Button>
 			</NavigationHeader>
 
-			{ isPageSelectorVisible && (
+			{ isPageSelectorVisible && pageSelector && (
 				<div
 					css={ {
 						width: '100%',

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -299,7 +299,7 @@ const SitePerformanceContent = ( { path }: { path?: string } ) => {
 				{ isMobile ? (
 					<MobileHeader
 						pageTitle={ currentPage?.label ?? '' }
-						pageSelector={ isSitePublic ? pageSelector : null }
+						{ ...( isSitePublic && { pageSelector } ) }
 						subtitle={ subtitle }
 					/>
 				) : (

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -299,7 +299,7 @@ const SitePerformanceContent = ( { path }: { path?: string } ) => {
 				{ isMobile ? (
 					<MobileHeader
 						pageTitle={ currentPage?.label ?? '' }
-						pageSelector={ pageSelector }
+						pageSelector={ isSitePublic ? pageSelector : null }
 						subtitle={ subtitle }
 					/>
 				) : (
@@ -309,13 +309,15 @@ const SitePerformanceContent = ( { path }: { path?: string } ) => {
 						subtitle={ subtitle }
 					/>
 				) }
-				{ ! isMobile && pageSelector }
-				<DeviceTabControls
-					showTitle={ ! isMobile }
-					onDeviceTabChange={ handleDeviceTabChange }
-					disabled={ disableControls }
-					value={ activeTab }
-				/>
+				{ ! isMobile && isSitePublic && pageSelector }
+				{ isSitePublic && (
+					<DeviceTabControls
+						showTitle={ ! isMobile }
+						onDeviceTabChange={ handleDeviceTabChange }
+						disabled={ disableControls }
+						value={ activeTab }
+					/>
+				) }
 			</div>
 			{ isLoadingPages && isSitePublic ? (
 				<PerformanceReportLoading isLoadingPages />


### PR DESCRIPTION
When a site is not public, the Launch Site CTA is displayed instead of the performance report. The page selector and device selector controls are meaningless without a report to view, so hide them along with the launch screen for a cleaner UI.

## Proposed Changes

- Hide the page selector (`<PageSelector>`) when the site is not public (both mobile and desktop layouts)
- Hide the device selector (`<DeviceTabControls>` with Mobile/Desktop buttons) when the site is not public
- These controls only make sense when viewing performance reports, so they should not be visible when the launch screen is shown

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When a site is not public, users see a "Launch your site" CTA instead of performance data. Showing the page and device selectors above this CTA creates visual clutter and confusion since there's no report to interact with. This change provides a cleaner, more focused UI by hiding these controls until the site is launched.

## Before & After

**Before** — Page and Device selectors visible with launch CTA:
<img width="987" height="471" alt="Screenshot 2026-04-01 at 17 27 50 - before" src="https://github.com/user-attachments/assets/b922f77a-185e-40ef-9c8e-3cb23a3db898" />

**After** — Selectors hidden, focused on launch CTA:
<img width="981" height="453" alt="Screenshot 2026-04-01 at 17 38 55 - after" src="https://github.com/user-attachments/assets/ba681591-0368-455c-a36a-2551184c7560" />

## Testing Instructions

1. Open the Performance tab on a non-public/unpublished site
2. Verify that the page selector dropdown and device selector (Mobile/Desktop buttons) are **not visible**
3. The launch CTA should be the only control visible
4. Launch the site
5. Verify that the page and device selectors now **reappear** on the Performance tab
6. Test on both mobile and desktop viewports

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?