### PR TITLE
Billing: Tweak active upgrades table column widths

### DIFF
--- a/client/me/purchases/purchases-list-in-dataviews/style.scss
+++ b/client/me/purchases/purchases-list-in-dataviews/style.scss
@@ -96,7 +96,7 @@
 
 	.dataviews-view-table__cell-content-wrapper .purchase-item__status {
 		margin-right: 16px;
-		width: 250px;
+		width: 230px;
 		white-space: break-spaces;
 	}
 
@@ -104,7 +104,7 @@
 		display: flex;
 		align-items: center;
 		flex-wrap: wrap;
-		min-width: 175px;
+		min-width: 160px;
 
 		.purchase-item__payment-method-card {
 			margin-right: 8px;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes
This is a tiny tweak to the column widths slightly so that there's no horizontal scrollbar when a product name is long.

It isn't perfect (other languages could still result in overflow), but it shouldn't break anything.

Even better would be to increase the breakpoint from 1040px to something a bit larger so we actually use the space on the page, but that's out of scope here, as it would impact many screens and should have design input.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Discovered while working with an HE and figured I'd do a bit of polish.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Add `Jetpack VaultPress Backup Add-on Storage (100GB)` to a site.
2. Go here: `http://calypso.localhost:3001/me/purchases`

On `trunk`, there'll be a horizontal scroll bar. In this branch, that scroll bar is gone.

Before:
<img width="2756" height="1790" alt="image" src="https://github.com/user-attachments/assets/430b0bc2-fb7d-40ad-92f7-8e62dee5a9a3" />

After:
<img width="2728" height="1788" alt="image" src="https://github.com/user-attachments/assets/d03889d3-6877-446c-8f5e-5b52e2217aea" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?