### PR TITLE
Checkout: Switch pending page to use receiptQuery for receipt

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -1,3 +1,4 @@
+import { receiptQuery } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
 import { getUrlParts } from '@automattic/calypso-url';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
@@ -6,6 +7,7 @@ import { Step } from '@automattic/onboarding';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { invokeSurvicateEvent } from '@automattic/survicate';
 import { AUTO_RENEWAL } from '@automattic/urls';
+import { useQuery } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
 import React, { useState, useEffect, useRef } from 'react';
 import Loading from 'calypso/components/loading';
@@ -20,14 +22,11 @@ import { useSelector, useDispatch } from 'calypso/state';
 import { fetchCurrentUser } from 'calypso/state/current-user/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { SUCCESS } from 'calypso/state/order-transactions/constants';
-import { fetchReceipt } from 'calypso/state/receipts/actions';
-import { getReceiptById } from 'calypso/state/receipts/selectors';
 import getOrderTransactionError from 'calypso/state/selectors/get-order-transaction-error';
 import { requestSite } from 'calypso/state/sites/actions';
 import usePurchaseOrder from '../../src/hooks/use-purchase-order';
 import { logStashLoadErrorEvent } from '../../src/lib/analytics';
 import type { RedirectInstructions } from 'calypso/my-sites/checkout/src/lib/pending-page';
-import type { ReceiptState } from 'calypso/state/receipts/types';
 import type {
 	OrderTransaction,
 	OrderTransactionSuccess,
@@ -151,18 +150,6 @@ function notifyAndPerformRedirect(
 	performRedirect( url );
 }
 
-function getSaaSProductRedirectUrl( receipt: ReceiptState ) {
-	let saasRedirectUrl;
-
-	( receipt?.data?.purchases || [] ).forEach( ( purchase ) => {
-		if ( purchase.saasRedirectUrl ) {
-			saasRedirectUrl = purchase.saasRedirectUrl;
-		}
-	} );
-
-	return saasRedirectUrl;
-}
-
 function useRedirectOnTransactionSuccess( {
 	orderId,
 	receiptId,
@@ -191,8 +178,15 @@ function useRedirectOnTransactionSuccess( {
 		? transaction.receiptId
 		: undefined;
 	const finalReceiptId = receiptId ?? transactionReceiptId;
-	const receipt = useSelector( ( state ) => getReceiptById( state, finalReceiptId ) );
-	const isReceiptLoaded = receipt.hasLoadedFromServer;
+	const {
+		data: receipt,
+		isSuccess: isReceiptSuccess,
+		isError: isReceiptError,
+	} = useQuery( {
+		...receiptQuery( finalReceiptId ?? 0 ),
+		enabled: !! finalReceiptId,
+	} );
+	const isReceiptLoaded = isReceiptSuccess || isReceiptError;
 	const error: Error | null = useSelector( ( state ) =>
 		orderId ? getOrderTransactionError( state, orderId ) : null
 	);
@@ -200,12 +194,15 @@ function useRedirectOnTransactionSuccess( {
 	const cartKey = useCartKey();
 	const { reloadFromServer: reloadCart } = useShoppingCart( cartKey );
 
-	const firstPurchase = receipt.data?.purchases[ 0 ];
-	const isRenewal = firstPurchase?.isRenewal ?? false;
-	const productName = firstPurchase?.productName ?? '';
-	const willAutoRenew = firstPurchase?.willAutoRenew ?? false;
-	const blogId = firstPurchase?.blogId;
-	const saasRedirectUrl = getSaaSProductRedirectUrl( receipt );
+	const firstItem = receipt?.items[ 0 ];
+	const isRenewal = receipt?.items.some( ( item ) => item.type === 'renewal' ) ?? false;
+	const productName = firstItem?.variation || firstItem?.product || '';
+	const willAutoRenew = firstItem?.will_auto_renew ?? false;
+	const blogId = firstItem?.site_id;
+	const saasRedirectUrl = receipt?.items.reduce< string | undefined >(
+		( url, item ) => url ?? ( item.saas_redirect_url || undefined ),
+		undefined
+	);
 
 	const { searchParams } = getUrlParts( redirectTo || '/' );
 	const isConnectAfterCheckoutFlow =
@@ -239,18 +236,6 @@ function useRedirectOnTransactionSuccess( {
 	);
 
 	const [ headingText, setHeadingText ] = useState( defaultPendingText );
-
-	// Fetch receipt data once we have a receipt Id.
-	const didFetchReceipt = useRef( false );
-	useEffect( () => {
-		if ( didFetchReceipt.current ) {
-			return;
-		}
-		if ( ! isReceiptLoaded && finalReceiptId ) {
-			didFetchReceipt.current = true;
-			reduxDispatch( fetchReceipt( finalReceiptId ) );
-		}
-	}, [ finalReceiptId, isReceiptLoaded, reduxDispatch ] );
 
 	// Redirect and display notices.
 	const didRedirect = useRef( false );

--- a/packages/api-core/src/me-billing-history/types.ts
+++ b/packages/api-core/src/me-billing-history/types.ts
@@ -62,6 +62,8 @@ export interface ReceiptItem {
 	credits_used: number | null;
 	introductory_offer_terms: IntroductoryOfferTerms | null;
 	price_tier_slug: string;
+	will_auto_renew: boolean;
+	saas_redirect_url: string;
 }
 
 export interface Receipt {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-1843/

## Proposed changes

Migrates the checkout pending page's receipt fetching from Redux (v1.1 endpoint) to TanStack Query with the v1.2 receipt endpoint, and extends the `ReceiptItem` type with two fields that restore parity with the old endpoint.

Depends on 210195-ghe-Automattic/wpcom

## Why are these changes being made?

The v1.1 receipt endpoint (`/rest/v1.1/me/billing-history/receipt/:id`) returns a `purchases[]` array closely mirroring the transaction endpoint's structure — camelCased, with fields like `isRenewal`, `willAutoRenew`, `saasRedirectUrl`, and `blogId`. The v1.2 endpoint returns a cleaner `items[]` structure with different field names. Using the newer version is the right direction as the API evolves.

Switching to TanStack Query here is consistent with the broader effort to move away from Redux for data fetching in this area. The `receiptQuery` definition already exists in `@automattic/api-queries` and is used by the Dashboard billing history — reusing it means the pending page benefits from the same caching, deduplication, and retry behaviour.

This is needed by https://github.com/Automattic/wp-calypso/pull/109721 which requires a property from the new endpoint to be available on the pending page.

## Testing instructions

Manual testing:
* Complete a purchase through checkout.
* Confirm the pending page redirects to the correct thank-you page in each case.

You can actually visit a pending page URL directly to see the same effect for any previous purchase that you own. For example, `/checkout/thank-you/paytontest17197.wordpress.com/pending/776303` is a valid pending page for my site. The number at the end is the Order ID. You can find that on the backend when examining the receipt data for any purchase.