### PR TITLE
Remove `calypso_account_step_improvement_202601` experiment code

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -45,7 +45,7 @@ async function initialize() {
 		STEPS.SETUP_YOUR_SITE_AI,
 	];
 
-	await loadExperimentAssignment( 'calypso_account_step_improvement_202601' );
+	// await loadExperimentAssignment( 'calypso_account_step_improvement_202601' );
 
 	return [ ...stepsWithRequiredLogin( steps ), STEPS.PLAYGROUND, STEPS.BLUEPRINT ];
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -55,7 +55,7 @@ const UserStepComponent: StepType = function UserStep( {
 		isMessagingVariation,
 		isSliderVariation,
 		isSimpleSliderVariation,
-	} = useAccountCreationExperiment( { flow } );
+	} = useAccountCreationExperiment();
 
 	useEffect( () => {
 		if ( wpAccountCreateResponse && 'bearer_token' in wpAccountCreateResponse ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-account-creation-experiment.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-account-creation-experiment.ts
@@ -1,6 +1,3 @@
-import { isOnboardingFlow } from '@automattic/onboarding';
-import { useExperiment } from 'calypso/lib/explat';
-
 type AccountCreationExperimentVariant =
 	| 'control'
 	| 'treatment_email'
@@ -18,10 +15,6 @@ type AccountCreationExperimentResult = {
 	isSliderVariation: boolean;
 	isSimpleSliderVariation: boolean;
 };
-
-interface UseAccountCreationExperimentParams {
-	flow: string;
-}
 
 const EMAIL_VARIATIONS: AccountCreationExperimentVariant[] = [
 	'treatment_email',
@@ -47,19 +40,15 @@ const SIMPLE_SLIDER_VARIATIONS: AccountCreationExperimentVariant[] = [
 	'treatment_email_messaging_slider_simplified',
 ];
 
-function useAccountCreationExperiment( {
-	flow,
-}: UseAccountCreationExperimentParams ): AccountCreationExperimentResult {
-	const [ isLoading, assignment ] = useExperiment( 'calypso_account_step_improvement_202601', {
-		isEligible: isOnboardingFlow( flow ),
-	} );
+function useAccountCreationExperiment(): AccountCreationExperimentResult {
+	// const [ isLoading, assignment ] = useExperiment( 'calypso_account_step_improvement_202601', {
+	// 	isEligible: isOnboardingFlow( flow ),
+	// } );
 
-	const variationName = (
-		isLoading ? 'control' : assignment?.variationName ?? 'control'
-	) as AccountCreationExperimentVariant;
+	const variationName = 'control';
 
 	return {
-		isLoading,
+		isLoading: false,
 		variationName,
 		isExperimentVariant: variationName !== 'control',
 		isEmailVariation: EMAIL_VARIATIONS.includes( variationName ),


### PR DESCRIPTION
Fixes DOTCOM-16593

## Proposed Changes

The experiment has concluded, and loading it slows down onboarding.

## Testing
1. Go to /setup while incognito.
2. The user step should render in the center without images.