### PR TITLE
Purchases: fix dataviews sticky footer

### DIFF
--- a/client/me/style.scss
+++ b/client/me/style.scss
@@ -53,16 +53,25 @@ body.is-section-me {
 	div.layout.is-global-sidebar-visible {
 		.layout__primary {
 			.main {
-				padding: 24px;
+				// Bottom padding is 0 because .main will act as the scroll
+				// container. Any sticky items within it (e.g. DataView footers)
+				// will be influenced by the padding.
+				padding: 24px 24px 0;
 				background: var( --color-surface );
 				border-radius: 8px;
 				overflow-y: auto;
 				overflow-x: hidden;
 				max-width: none;
+
 				& > * {
 					max-width: 1040px;
 					margin-left: auto;
 					margin-right: auto;
+				}
+
+				// Make sure that there's space beneath the last child (see above).
+				& > *:last-child {
+					margin-bottom:24px;
 				}
 
 				@include break-small {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHE-464/

## Proposed Changes

This fixes the bottom padding of the DataView's sticky footer on "Me" section purchase management pages.

## Why are these changes being made?

In the "Me" section, the layout sets `padding: 24px` on `.main` (which is also the scroll container). Thus, any sticky positioned elements within the container (e.g. the DataViews pagination footer) will have their positioning constrained by the padding edge of the scroll container. In other words, the footer was pinned 24px above the actual bottom border of the card, leaving a gap where product rows were visible underneath.

The best way to fix this is to set the bottom padding of the scroll container (`.main` in this case) to `0` and let the elements contained within handle their own bottom padding/margin. I've done that by using the `> *:last-child` selector.

## Testing Instructions

Manual testing:
* Navigate to `/me/purchases` and scroll the purchases list — confirm the pagination footer sits flush at the bottom of the card with no gap
* Verify content rows no longer appear below/behind the sticky footer
* Scroll to the bottom of the container and make sure that you see a 24px gap between the last element and the bottom.
* Click through to other Me screens and verify that the bottom gap remains
