### PR TITLE
Switch MSD OAuth to cookie-based storage

### DIFF
--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -65,6 +65,7 @@ module.exports = {
 							'!@automattic/languages',
 							'!@automattic/load-script',
 							'!@automattic/number-formatters',
+							'!@automattic/oauth-token',
 							'!@automattic/search',
 							'!@automattic/calypso-razorpay',
 							'!@automattic/calypso-stripe',

--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -4,6 +4,7 @@ import config from '@automattic/calypso-config';
 import { setUser } from '@automattic/calypso-sentry';
 import { isSupportUserSession } from '@automattic/calypso-support-session';
 import { magnificentNonEnLocales } from '@automattic/i18n-utils';
+import { clearToken } from '@automattic/oauth-token';
 import {
 	useQuery,
 	useQueryClient,
@@ -227,6 +228,7 @@ export async function logout( user: User ): Promise< void > {
 
 	disablePersistQueryClient();
 	clearQueryClient();
+	clearToken( '/' );
 
 	// Dynamically import Calypso v1 cleanup code because it includes a number
 	// of dependencies we don't want included in the Hosting Dashboard bundle.

--- a/client/dashboard/app/auth/oauth-callback.ts
+++ b/client/dashboard/app/auth/oauth-callback.ts
@@ -1,4 +1,4 @@
-import store from 'store';
+import { setToken } from '@automattic/oauth-token';
 import { isRelativeUrl } from '../../utils/url';
 
 export const OAUTH_CALLBACK_PATH = '/oauth/token';
@@ -27,12 +27,13 @@ export function handleOAuthCallback(): boolean {
 
 	const accessToken = hash.get( 'access_token' );
 	if ( accessToken ) {
-		store.set( 'wpcom_token', accessToken );
-	}
-
-	const expiresIn = hash.get( 'expires_in' );
-	if ( expiresIn ) {
-		store.set( 'wpcom_token_expires_in', expiresIn );
+		const expiresIn = hash.get( 'expires_in' );
+		setToken( accessToken, {
+			path: '/',
+			sameSite: 'lax',
+			secure: process.env.NODE_ENV !== 'development',
+			...( expiresIn ? { maxAge: Number( expiresIn ) } : {} ),
+		} );
 	}
 
 	const next = params.get( 'next' ) || '/';

--- a/packages/oauth-token/src/index.js
+++ b/packages/oauth-token/src/index.js
@@ -5,6 +5,8 @@ import store from 'store';
  * Module variables
  */
 const TOKEN_NAME = 'wpcom_token';
+
+// Note: Cookies expect seconds for maxAge, not milliseconds. Leaving this as the existing default behavior for now though.
 const MAX_AGE = 365 * 24 * 60 * 60 * 1000; // How long to store the OAuth cookie
 
 export function getToken() {
@@ -23,15 +25,17 @@ export function getToken() {
 	return false;
 }
 
-export function setToken( token ) {
-	// TODO: Support secure cookies if this is ever used outside of the desktop app
-	document.cookie = cookie.serialize( TOKEN_NAME, token, { maxAge: MAX_AGE } );
+export function setToken( token, options = {} ) {
+	document.cookie = cookie.serialize( TOKEN_NAME, token, { maxAge: MAX_AGE, ...options } );
 }
 
-export function clearToken() {
+export function clearToken( path ) {
 	const cookies = cookie.parse( document.cookie );
 
 	if ( typeof cookies[ TOKEN_NAME ] !== 'undefined' ) {
-		document.cookie = cookie.serialize( TOKEN_NAME, false, { maxAge: -1 } );
+		document.cookie = cookie.serialize( TOKEN_NAME, '', {
+			maxAge: -1,
+			...( path ? { path } : {} ),
+		} );
 	}
 }

--- a/packages/oauth-token/types.d.ts
+++ b/packages/oauth-token/types.d.ts
@@ -1,7 +1,13 @@
 declare module '@automattic/oauth-token' {
 	const getToken: () => string | boolean;
-	const setToken: ( token: string ) => void;
-	const clearToken: () => void;
+	interface SetTokenOptions {
+		maxAge?: number;
+		path?: string;
+		sameSite?: 'strict' | 'lax' | 'none';
+		secure?: boolean;
+	}
+	const setToken: ( token: string, options?: SetTokenOptions ) => void;
+	const clearToken: ( path?: string ) => void;
 
 	export { getToken, setToken, clearToken };
 }


### PR DESCRIPTION
Follows up https://github.com/Automattic/wp-calypso/pull/109135 and switches to using cookies for the OAuth token rather than localstorage. This is primarily to make a way for server-side SSO functionality, but could also be followed up in the future with:

- Enabling `wpcom-user-bootstrap` features for OAuth-based MSD dashboards, pre-hydrating the user object during SSR (I started down that road, but there's some lurking complexity that felt best to handle separately).
- Switching the OAuth callback handling to be server-side, getting the token via POST response instead and setting the cookie on the server. We still couldn't do httpOnly on the cookie though, because the frontend is making various api requests still. We'd have to proxy them all through the server, which I'm not sure if we want.

This PR is extra careful to only affect the OAuth MSD dashboard flows (only my.woo.ai right now), as it's not super clear to me where all the other usages of this shared oauth-token library are currently in play. So I've purposely left all the existing defaults alone.