### PR TITLE
Proof of concept changes for hiding CIAB sites in legacy Calypso.

### DIFF
--- a/client/sites/components/plan-pricing/index.tsx
+++ b/client/sites/components/plan-pricing/index.tsx
@@ -6,6 +6,7 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector, useDispatch } from 'react-redux';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { isSitePlanWooHosted } from 'calypso/dashboard/sites/plans';
 import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
@@ -21,6 +22,7 @@ export default function PlanPricing( { inline }: PlanPricingProps ) {
 	const dispatch = useDispatch();
 	const moment = useLocalizedMoment();
 	const site = useSelector( getSelectedSite );
+	const isWooHostedPlan = site ? isSitePlanWooHosted( site ) : false;
 	const planDetails = site?.plan;
 	const planSlug = ( planDetails?.product_slug || '' ) as PlanSlug;
 	const planData = useSelector( ( state ) => getCurrentPlan( state, site?.ID ) );
@@ -127,33 +129,35 @@ export default function PlanPricing( { inline }: PlanPricingProps ) {
 					} ) }
 				>
 					{ getExpireDetails() }
-					<div className="plan-price-cta">
-						{ isFreePlan && (
-							<Button
-								href={ `/plans/${ site?.slug }` }
-								onClick={ () =>
-									dispatch( recordTracksEvent( 'calypso_hosting_overview_upgrade_plan_click' ) )
-								}
-							>
-								{ translate( 'Upgrade your plan' ) }
-							</Button>
-						) }
-						{ site?.plan?.expired && (
-							<>
-								<Button compact href={ `/plans/${ site?.slug }` }>
-									{ translate( 'See all plans' ) }
-								</Button>
+					{ ! isWooHostedPlan && (
+						<div className="plan-price-cta">
+							{ isFreePlan && (
 								<Button
-									style={ { marginLeft: '8px' } }
-									primary
-									compact
-									href={ `/checkout/${ site?.slug }/${ planData.productSlug }` }
+									href={ `/plans/${ site?.slug }` }
+									onClick={ () =>
+										dispatch( recordTracksEvent( 'calypso_hosting_overview_upgrade_plan_click' ) )
+									}
 								>
-									{ translate( 'Renew plan' ) }
+									{ translate( 'Upgrade your plan' ) }
 								</Button>
-							</>
-						) }
-					</div>
+							) }
+							{ site?.plan?.expired && (
+								<>
+									<Button compact href={ `/plans/${ site?.slug }` }>
+										{ translate( 'See all plans' ) }
+									</Button>
+									<Button
+										style={ { marginLeft: '8px' } }
+										primary
+										compact
+										href={ `/checkout/${ site?.slug }/${ planData.productSlug }` }
+									>
+										{ translate( 'Renew plan' ) }
+									</Button>
+								</>
+							) }
+						</div>
+					) }
 				</div>
 			) }
 		</>

--- a/client/sites/components/plan-stats/index.tsx
+++ b/client/sites/components/plan-stats/index.tsx
@@ -3,6 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import PlanStorage, { useDisplayUpgradeLink } from 'calypso/blocks/plan-storage';
+import { isSitePlanWooHosted } from 'calypso/dashboard/sites/plans';
 import { isPlansPageUntangled } from 'calypso/lib/plans/untangling-plans-experiment';
 import { useStorageAddOnAvailable } from 'calypso/lib/plans/use-storage-add-on-available';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -55,6 +56,7 @@ type PlanStatsProps = {
 
 export default function PlanStats( { needMoreStorageTracksEventName }: PlanStatsProps ) {
 	const site = useSelector( getSelectedSite );
+	const isWooHostedPlan = site ? isSitePlanWooHosted( site ) : false;
 	const planDetails = site?.plan;
 	const planData = useSelector( ( state ) => getCurrentPlan( state, site?.ID ) );
 	const isFreePlan = planDetails?.is_free;
@@ -81,7 +83,7 @@ export default function PlanStats( { needMoreStorageTracksEventName }: PlanStats
 					siteId={ site?.ID }
 					storageBarComponent={ PlanStorageBar }
 				>
-					{ isStorageAddOnAvailable ? (
+					{ isStorageAddOnAvailable && ! isWooHostedPlan ? (
 						<div className="plan-storage-footer">
 							<NeedMoreStorage
 								noLink={ footerWrapperIsLink }

--- a/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -2,6 +2,7 @@ import { FEATURE_SITE_STAGING_SITES } from '@automattic/calypso-products';
 import { SiteExcerptData } from '@automattic/sites';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { useMemo } from 'react';
+import { isSitePlanWooHosted } from 'calypso/dashboard/sites/plans';
 import { isAtomicTransferredSite } from 'calypso/dashboard/utils/site-atomic-transfers';
 import { isMigrationInProgress } from 'calypso/data/site-migration';
 import ItemView from 'calypso/layout/hosting-dashboard/item-view';
@@ -62,6 +63,7 @@ const DotcomPreviewPane = ( {
 	const { __ } = useI18n();
 	const isInProgress = isMigrationInProgress( site );
 	const isA4ADevSite = !! site?.is_a4a_dev_site;
+	const isWooHostedSite = isSitePlanWooHosted( site );
 
 	const hasStagingSitesFeature = useSelector( ( state ) =>
 		siteHasFeature( state, site.ID, FEATURE_SITE_STAGING_SITES )
@@ -76,33 +78,33 @@ const DotcomPreviewPane = ( {
 			},
 			{
 				label: __( 'Deployments' ),
-				enabled: true,
+				enabled: ! isWooHostedSite,
 				featureIds: [ DEPLOYMENTS ],
 			},
 			{
 				label: __( 'Monitoring' ),
-				enabled: true,
+				enabled: ! isWooHostedSite,
 				featureIds: [ MONITORING ],
 			},
 			{
 				label: __( 'Performance' ),
-				enabled: true,
+				enabled: ! isWooHostedSite,
 				featureIds: [ PERFORMANCE ],
 			},
 			{
 				label: __( 'Logs' ),
-				enabled: true,
+				enabled: ! isWooHostedSite,
 				featureIds: [ LOGS_PHP, LOGS_WEB ],
 			},
 			{
 				label: __( 'Staging Site' ),
 				// We don't have the callout for the staging site tab since we'll retire the tab.
-				enabled: hasStagingSitesFeature && ! isA4ADevSite,
+				enabled: hasStagingSitesFeature && ! isA4ADevSite && ! isWooHostedSite,
 				featureIds: [ STAGING_SITE ],
 			},
 			{
 				label: __( 'Settings' ),
-				enabled: true,
+				enabled: ! isWooHostedSite,
 				featureIds: [
 					SETTINGS_SITE,
 					SETTINGS_ADMINISTRATION_RESET_SITE,
@@ -160,6 +162,7 @@ const DotcomPreviewPane = ( {
 		selectedSiteFeaturePreview,
 		hasStagingSitesFeature,
 		isA4ADevSite,
+		isWooHostedSite,
 	] );
 
 	const itemData: ItemData = {

--- a/client/sites/components/sites-dashboard.tsx
+++ b/client/sites/components/sites-dashboard.tsx
@@ -21,6 +21,7 @@ import GuidedTour from 'calypso/components/guided-tour';
 import { GuidedTourContextProvider } from 'calypso/components/guided-tour/data/guided-tour-context';
 import { useCurrentRoute } from 'calypso/components/route';
 import { DEFAULT_PER_PAGE } from 'calypso/dashboard/sites/dataviews';
+import { isSitePlanWooHosted } from 'calypso/dashboard/sites/plans';
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
 import Layout from 'calypso/layout/hosting-dashboard';
 import LayoutColumn from 'calypso/layout/hosting-dashboard/column';
@@ -153,6 +154,10 @@ const SitesDashboard = ( {
 
 		// Early return if the site is domain-only
 		if ( options?.is_domain_only ) {
+			return false;
+		}
+
+		if ( isSitePlanWooHosted( site ) ) {
 			return false;
 		}
 

--- a/client/sites/controller.tsx
+++ b/client/sites/controller.tsx
@@ -5,6 +5,7 @@ import { removeQueryArgs } from '@wordpress/url';
 import i18n from 'i18n-calypso';
 import AsyncLoad from 'calypso/components/async-load';
 import ResurrectedWelcomeModalGate from 'calypso/components/resurrected-welcome-modal';
+import { isSitePlanWooHosted } from 'calypso/dashboard/sites/plans';
 import { dashboardLink } from 'calypso/dashboard/utils/link';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors';
@@ -13,6 +14,7 @@ import { fetchPreferences } from 'calypso/state/preferences/actions';
 import { hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
 import { setAllSitesSelected } from 'calypso/state/ui/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { OVERVIEW } from './components/site-preview-pane/constants';
 import SitesDashboard from './components/sites-dashboard';
 import { areHostingFeaturesSupported } from './hosting/features';
 import type { Context, Context as PageJSContext } from '@automattic/calypso-router';
@@ -131,8 +133,18 @@ export function sitesDashboard( context: Context, next: () => void ) {
 	next();
 }
 
+function isWooHostedDashboardFeatureAllowed( feature: string | undefined ) {
+	return feature === undefined || feature === OVERVIEW;
+}
+
 export function siteDashboard( feature: string | undefined ) {
 	return ( context: Context, next: () => void ) => {
+		const site = getSelectedSite( context.store.getState() );
+		if ( site && isSitePlanWooHosted( site ) && ! isWooHostedDashboardFeatureAllowed( feature ) ) {
+			page.redirect( `/sites/${ site.slug }` );
+			return;
+		}
+
 		context.primary = (
 			<SitesDashboard
 				initialSiteFeature={ feature }

--- a/client/sites/overview/components/hosting-overview.tsx
+++ b/client/sites/overview/components/hosting-overview.tsx
@@ -1,6 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
 import NavigationHeader from 'calypso/components/navigation-header';
+import { isSitePlanWooHosted } from 'calypso/dashboard/sites/plans';
 import { isMigrationInProgress } from 'calypso/data/site-migration';
 import PlanNoticeUpgradeCredit from 'calypso/my-sites/plans-features-main/components/plan-notice-upgrade-credit';
 import { isNotAtomicJetpack } from 'calypso/sites-dashboard/utils';
@@ -20,6 +21,7 @@ import './style.scss';
 const HostingOverview: FC = () => {
 	const site = useSelector( getSelectedSite );
 	const translate = useTranslate();
+	const isWooHostedSite = site ? isSitePlanWooHosted( site ) : false;
 
 	if ( site ) {
 		const queryParams = new URLSearchParams( window.location.search );
@@ -48,7 +50,7 @@ const HostingOverview: FC = () => {
 				title={ translate( 'Overview' ) }
 				subtitle={ subtitle }
 			/>
-			{ site?.ID && (
+			{ site?.ID && ! isWooHostedSite && (
 				<PlanNoticeUpgradeCredit
 					className="hosting-overview__upgrade-credit-notice"
 					siteId={ site.ID }

--- a/client/sites/overview/components/plan-card.tsx
+++ b/client/sites/overview/components/plan-card.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import { HostingCard, HostingCardLinkButton } from 'calypso/components/hosting-card';
+import { isSitePlanWooHosted } from 'calypso/dashboard/sites/plans';
 import { isPlansPageUntangled } from 'calypso/lib/plans/untangling-plans-experiment';
 import { isPartnerPurchase, purchaseType } from 'calypso/lib/purchases';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
@@ -86,7 +87,14 @@ const PlanCard = () => {
 	const plansPageIsUntangled = useSelector( isPlansPageUntangled );
 
 	const renderManageButton = () => {
-		if ( isJetpack || ! site || isStaging || isAgencyPurchase || isDevelopmentSite ) {
+		if (
+			isJetpack ||
+			! site ||
+			isStaging ||
+			isAgencyPurchase ||
+			isDevelopmentSite ||
+			isSitePlanWooHosted( site )
+		) {
 			return false;
 		}
 		if ( isFreePlan ) {

--- a/client/sites/overview/controller.tsx
+++ b/client/sites/overview/controller.tsx
@@ -1,5 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
+import { isSitePlanWooHosted } from 'calypso/dashboard/sites/plans';
 import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { isMigrationInProgress } from 'calypso/data/site-migration';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -65,6 +66,10 @@ export async function dashboardBackportSiteOverview( context: PageJSContext, nex
 	if ( isMigrationInProgress( site ) || sshMigration ) {
 		// Temporarily show the v1 site migration overview page.
 		// @todo implement the page in v2.
+		return overview( context, next );
+	}
+
+	if ( site && isSitePlanWooHosted( site ) ) {
 		return overview( context, next );
 	}
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes ARC-1444

## Proposed Changes

* TODO

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* TODO

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* TODO

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
