### PR TITLE
MSD: Increase card density on account settings pages

### DIFF
--- a/client/dashboard/me/billing/index.tsx
+++ b/client/dashboard/me/billing/index.tsx
@@ -49,14 +49,14 @@ function Billing() {
 					decoration={ <Icon icon={ backup } /> }
 					to={ billingHistoryRoute.to }
 				/>
-				{ supportsBilling.monetizeSubscriptions && (
+				{ supportsBilling.monetizeSubscriptions ? (
 					<RouterLinkSummaryButton
 						title={ getMonetizeSubscriptionsPageTitle() }
 						description={ __( 'Manage Monetize subscriptions.' ) }
 						decoration={ <Icon icon={ currencyDollar } /> }
 						to={ monetizeSubscriptionsRoute.to }
 					/>
-				) }
+				) : null }
 				<RouterLinkSummaryButton
 					title={ __( 'Payment methods' ) }
 					description={ __( 'Manage credit cards saved to your account.' ) }

--- a/client/dashboard/me/billing/index.tsx
+++ b/client/dashboard/me/billing/index.tsx
@@ -1,4 +1,4 @@
-import { __experimentalVStack as VStack, Icon } from '@wordpress/components';
+import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { backup, payment, receipt, institution, currencyDollar } from '@wordpress/icons';
 import { useAppContext } from '../../app/context';
@@ -13,6 +13,7 @@ import {
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import { SummaryButtonList } from '../../components/summary-button-list';
 import { getMonetizeSubscriptionsPageTitle } from '../billing-monetize-subscriptions/title';
 
 function Billing() {
@@ -33,7 +34,7 @@ function Billing() {
 				/>
 			}
 		>
-			<VStack spacing={ 4 }>
+			<SummaryButtonList>
 				<RouterLinkSummaryButton
 					title={ __( 'Active upgrades' ) }
 					description={ __(
@@ -68,7 +69,7 @@ function Billing() {
 					decoration={ <Icon icon={ institution } /> }
 					to={ taxDetailsRoute.to }
 				/>
-			</VStack>
+			</SummaryButtonList>
 			<PerformanceTrackerStop />
 		</PageLayout>
 	);

--- a/client/dashboard/me/notifications-comments/summary.tsx
+++ b/client/dashboard/me/notifications-comments/summary.tsx
@@ -3,10 +3,12 @@ import { __ } from '@wordpress/i18n';
 import { comment } from '@wordpress/icons';
 import { notificationsCommentsRoute } from '../../app/router/me';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import type { Density } from '@automattic/components/src/summary-button/types';
 
-export const NotificationsCommentsSummary = () => {
+export const NotificationsCommentsSummary = ( { density }: { density?: Density } ) => {
 	return (
 		<RouterLinkSummaryButton
+			density={ density }
 			to={ notificationsCommentsRoute.fullPath }
 			title={ __( 'Comments' ) }
 			description={ __(

--- a/client/dashboard/me/notifications-emails/summary.tsx
+++ b/client/dashboard/me/notifications-emails/summary.tsx
@@ -1,5 +1,5 @@
 import { userSettingsQuery } from '@automattic/api-queries';
-import { SummaryButtonBadgeProps } from '@automattic/components/src/summary-button/types';
+import { Density, SummaryButtonBadgeProps } from '@automattic/components/src/summary-button/types';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -8,7 +8,7 @@ import { useMemo } from 'react';
 import { notificationsEmailsRoute } from '../../app/router/me';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
 
-export const NotificationsEmailsSummary = () => {
+export const NotificationsEmailsSummary = ( { density }: { density?: Density } ) => {
 	const { data: settings } = useSuspenseQuery( userSettingsQuery() );
 	const isAllWpcomEmailsDisabled = settings.subscription_delivery_email_blocked;
 
@@ -22,6 +22,7 @@ export const NotificationsEmailsSummary = () => {
 
 	return (
 		<RouterLinkSummaryButton
+			density={ density }
 			to={ notificationsEmailsRoute.fullPath }
 			title={ __( 'Emails' ) }
 			description={ __(

--- a/client/dashboard/me/notifications-extras/summary.tsx
+++ b/client/dashboard/me/notifications-extras/summary.tsx
@@ -3,10 +3,12 @@ import { __ } from '@wordpress/i18n';
 import { starEmpty } from '@wordpress/icons';
 import { notificationsExtrasRoute } from '../../app/router/me';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import type { Density } from '@automattic/components/src/summary-button/types';
 
-export const NotificationsExtrasSummary = () => {
+export const NotificationsExtrasSummary = ( { density }: { density?: Density } ) => {
 	return (
 		<RouterLinkSummaryButton
+			density={ density }
 			to={ notificationsExtrasRoute.fullPath }
 			title={ __( 'Extras' ) }
 			description={ __(

--- a/client/dashboard/me/notifications-sites/summary.tsx
+++ b/client/dashboard/me/notifications-sites/summary.tsx
@@ -3,10 +3,12 @@ import { __ } from '@wordpress/i18n';
 import { layout } from '@wordpress/icons';
 import { notificationsSitesRoute } from '../../app/router/me';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import type { Density } from '@automattic/components/src/summary-button/types';
 
-export const NotificationsSitesSummary = () => {
+export const NotificationsSitesSummary = ( { density }: { density?: Density } ) => {
 	return (
 		<RouterLinkSummaryButton
+			density={ density }
 			to={ notificationsSitesRoute.fullPath }
 			title={ __( 'Sites' ) }
 			description={ __(

--- a/client/dashboard/me/notifications/index.tsx
+++ b/client/dashboard/me/notifications/index.tsx
@@ -1,7 +1,7 @@
-import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import { SummaryButtonList } from '../../components/summary-button-list';
 import { NotificationsCommentsSummary } from '../notifications-comments/summary';
 import { NotificationsEmailsSummary } from '../notifications-emails/summary';
 import { NotificationsExtrasSummary } from '../notifications-extras/summary';
@@ -20,12 +20,12 @@ function Notifications() {
 				/>
 			}
 		>
-			<VStack spacing={ 4 }>
+			<SummaryButtonList>
 				<NotificationsSitesSummary />
 				<NotificationsCommentsSummary />
 				<NotificationsEmailsSummary />
 				<NotificationsExtrasSummary />
-			</VStack>
+			</SummaryButtonList>
 		</PageLayout>
 	);
 }

--- a/client/dashboard/me/preferences-ai-mcp/index.tsx
+++ b/client/dashboard/me/preferences-ai-mcp/index.tsx
@@ -4,8 +4,9 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 import { hasEnabledAccountTools } from '../../../me/mcp/utils';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import type { Density } from '@automattic/components/src/summary-button/types';
 
-export default function PreferencesAiMcp() {
+export default function PreferencesAiMcp( { density }: { density?: Density } ) {
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 	const isEnabled = hasEnabledAccountTools( userSettings || {} );
 
@@ -18,6 +19,7 @@ export default function PreferencesAiMcp() {
 
 	return (
 		<RouterLinkSummaryButton
+			density={ density }
 			to="/me/preferences/mcp"
 			title={ __( 'AI and MCP' ) }
 			description={ __( 'Configure how AI agents access your WordPress.com data.' ) }

--- a/client/dashboard/me/preferences-blocked-sites/index.tsx
+++ b/client/dashboard/me/preferences-blocked-sites/index.tsx
@@ -4,8 +4,9 @@ import { Icon } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { notAllowed } from '@wordpress/icons';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import type { Density } from '@automattic/components/src/summary-button/types';
 
-export default function PreferencesBlockedSites() {
+export default function PreferencesBlockedSites( { density }: { density?: Density } ) {
 	const { data } = useInfiniteQuery( blockedSitesInfiniteQuery( 1 ) );
 	const sites = ( data?.pages || [] ).flat();
 	const count = sites.length;
@@ -26,6 +27,7 @@ export default function PreferencesBlockedSites() {
 
 	return (
 		<RouterLinkSummaryButton
+			density={ density }
 			to="/me/preferences/blocked-sites"
 			title={ __( 'Blocked sites' ) }
 			description={ __( "Sites that won't appear in your Reader or recommendations." ) }

--- a/client/dashboard/me/preferences-defaults/index.tsx
+++ b/client/dashboard/me/preferences-defaults/index.tsx
@@ -6,6 +6,7 @@ import { wordpress } from '@wordpress/icons';
 import { useAuth } from '../../app/auth';
 import { useAppContext } from '../../app/context';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import type { Density } from '@automattic/components/src/summary-button/types';
 
 function useLandingPageLabel() {
 	const { data: landingPage } = useQuery( {
@@ -48,7 +49,7 @@ function usePrimarySiteName() {
 	return primarySite?.name ?? user.display_name;
 }
 
-export default function PreferencesDefaults() {
+export default function PreferencesDefaults( { density }: { density?: Density } ) {
 	const landingPageLabel = useLandingPageLabel();
 	const primarySiteName = usePrimarySiteName();
 
@@ -56,6 +57,7 @@ export default function PreferencesDefaults() {
 
 	return (
 		<RouterLinkSummaryButton
+			density={ density }
 			to="/me/preferences/defaults"
 			title={ __( 'WordPress.com defaults' ) }
 			description={ __( 'Set your starting point after you log in and primary site.' ) }

--- a/client/dashboard/me/preferences-language/index.tsx
+++ b/client/dashboard/me/preferences-language/index.tsx
@@ -5,8 +5,9 @@ import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { language } from '@wordpress/icons';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import type { Density } from '@automattic/components/src/summary-button/types';
 
-export default function PreferencesLanguage() {
+export default function PreferencesLanguage( { density }: { density?: Density } ) {
 	const { data: userSettings } = useQuery( {
 		...userSettingsQuery(),
 		meta: { persist: false },
@@ -24,6 +25,7 @@ export default function PreferencesLanguage() {
 
 	return (
 		<RouterLinkSummaryButton
+			density={ density }
 			to="/me/preferences/language"
 			title={ __( 'Language' ) }
 			description={ __( 'Set the display language for WordPress.com.' ) }

--- a/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
+++ b/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
@@ -6,10 +6,11 @@ import { __ } from '@wordpress/i18n';
 import { grid } from '@wordpress/icons';
 import { useAuth } from '../../app/auth';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import type { Density } from '@automattic/components/src/summary-button/types';
 
 const OLDEST_ELIGIBLE_USER: number = config( 'dashboard_opt_in_oldest_eligible_user' );
 
-export default function PreferencesNewHostingDashboard() {
+export default function PreferencesNewHostingDashboard( { density }: { density?: Density } ) {
 	const { user } = useAuth();
 	const { data: optIn } = useSuspenseQuery( userPreferenceQuery( 'hosting-dashboard-opt-in' ) );
 	const isOptedIn = optIn.value === 'opt-in';
@@ -28,6 +29,7 @@ export default function PreferencesNewHostingDashboard() {
 
 	return (
 		<RouterLinkSummaryButton
+			density={ density }
 			to="/me/preferences/hosting-dashboard"
 			title={ __( 'New hosting dashboard' ) }
 			description={ __(

--- a/client/dashboard/me/preferences-privacy/index.tsx
+++ b/client/dashboard/me/preferences-privacy/index.tsx
@@ -4,8 +4,9 @@ import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { seen } from '@wordpress/icons';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import type { Density } from '@automattic/components/src/summary-button/types';
 
-export default function PreferencesPrivacy() {
+export default function PreferencesPrivacy( { density }: { density?: Density } ) {
 	const { data: userSettings } = useQuery( userSettingsQuery() );
 	const isSharingUsageInfo = userSettings ? ! userSettings.tracks_opt_out : undefined;
 
@@ -23,6 +24,7 @@ export default function PreferencesPrivacy() {
 
 	return (
 		<RouterLinkSummaryButton
+			density={ density }
 			to="/me/preferences/privacy"
 			title={ __( 'Privacy' ) }
 			description={ __( 'Manage your privacy settings and data sharing preferences.' ) }

--- a/client/dashboard/me/preferences/index.tsx
+++ b/client/dashboard/me/preferences/index.tsx
@@ -30,7 +30,7 @@ export default function Preferences() {
 				<PreferencesLanguage />
 				<PreferencesDefaults />
 				<PreferencesPrivacy />
-				{ supports.reader && <PreferencesBlockedSites /> }
+				{ supports.reader ? <PreferencesBlockedSites /> : null }
 			</SummaryButtonList>
 		</PageLayout>
 	);

--- a/client/dashboard/me/preferences/index.tsx
+++ b/client/dashboard/me/preferences/index.tsx
@@ -1,9 +1,9 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useAppContext } from '../../app/context';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import { SummaryButtonList } from '../../components/summary-button-list';
 import PreferencesAiMcp from '../preferences-ai-mcp';
 import PreferencesBlockedSites from '../preferences-blocked-sites';
 import PreferencesDefaults from '../preferences-defaults';
@@ -24,14 +24,14 @@ export default function Preferences() {
 				/>
 			}
 		>
-			<VStack spacing={ 4 }>
+			<SummaryButtonList>
 				{ optIn && <PreferencesNewHostingDashboard /> }
 				{ isEnabled( 'mcp-settings' ) && <PreferencesAiMcp /> }
 				<PreferencesLanguage />
 				<PreferencesDefaults />
 				<PreferencesPrivacy />
 				{ supports.reader && <PreferencesBlockedSites /> }
-			</VStack>
+			</SummaryButtonList>
 		</PageLayout>
 	);
 }

--- a/client/dashboard/me/preferences/index.tsx
+++ b/client/dashboard/me/preferences/index.tsx
@@ -25,7 +25,7 @@ export default function Preferences() {
 			}
 		>
 			<SummaryButtonList>
-				{ optIn && <PreferencesNewHostingDashboard /> }
+				{ optIn ? <PreferencesNewHostingDashboard /> : null }
 				{ isEnabled( 'mcp-settings' ) && <PreferencesAiMcp /> }
 				<PreferencesLanguage />
 				<PreferencesDefaults />

--- a/client/dashboard/me/preferences/index.tsx
+++ b/client/dashboard/me/preferences/index.tsx
@@ -26,7 +26,7 @@ export default function Preferences() {
 		>
 			<SummaryButtonList>
 				{ optIn ? <PreferencesNewHostingDashboard /> : null }
-				{ isEnabled( 'mcp-settings' ) && <PreferencesAiMcp /> }
+				{ isEnabled( 'mcp-settings' ) ? <PreferencesAiMcp /> : null }
 				<PreferencesLanguage />
 				<PreferencesDefaults />
 				<PreferencesPrivacy />

--- a/client/dashboard/me/security-account-recovery/summary.tsx
+++ b/client/dashboard/me/security-account-recovery/summary.tsx
@@ -4,9 +4,12 @@ import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { lifesaver } from '@wordpress/icons';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
-import type { SummaryButtonBadgeProps } from '@automattic/components/src/summary-button/types';
+import type {
+	Density,
+	SummaryButtonBadgeProps,
+} from '@automattic/components/src/summary-button/types';
 
-export default function SecurityAccountRecoverySummary() {
+export default function SecurityAccountRecoverySummary( { density }: { density?: Density } ) {
 	const { data: accountRecovery } = useSuspenseQuery( accountRecoveryQuery() );
 
 	const { email, email_validated, phone, phone_validated } = accountRecovery;
@@ -39,6 +42,7 @@ export default function SecurityAccountRecoverySummary() {
 
 	return (
 		<RouterLinkSummaryButton
+			density={ density }
 			to="/me/security/account-recovery"
 			title={ __( 'Account recovery' ) }
 			description={ __( 'Set up recovery email & SMS number.' ) }

--- a/client/dashboard/me/security-connected-apps/summary.tsx
+++ b/client/dashboard/me/security-connected-apps/summary.tsx
@@ -4,9 +4,12 @@ import { Icon } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { connection } from '@wordpress/icons';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
-import type { SummaryButtonBadgeProps } from '@automattic/components/src/summary-button/types';
+import type {
+	Density,
+	SummaryButtonBadgeProps,
+} from '@automattic/components/src/summary-button/types';
 
-export default function SecurityConnectedAppsSummary() {
+export default function SecurityConnectedAppsSummary( { density }: { density?: Density } ) {
 	const { data: connectedApplications } = useSuspenseQuery( connectedApplicationsQuery() );
 
 	const connectedApplicationsCount = connectedApplications.length;
@@ -30,6 +33,7 @@ export default function SecurityConnectedAppsSummary() {
 
 	return (
 		<RouterLinkSummaryButton
+			density={ density }
 			to="/me/security/connected-apps"
 			title={ __( 'Connected applications' ) }
 			description={ __( 'Manage applications connected to your WordPress.com account.' ) }

--- a/client/dashboard/me/security-password/summary.tsx
+++ b/client/dashboard/me/security-password/summary.tsx
@@ -4,9 +4,12 @@ import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { lockOutline } from '@wordpress/icons';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
-import type { SummaryButtonBadgeProps } from '@automattic/components/src/summary-button/types';
+import type {
+	Density,
+	SummaryButtonBadgeProps,
+} from '@automattic/components/src/summary-button/types';
 
-export default function SecurityAccountRecoverySummary() {
+export default function SecurityAccountRecoverySummary( { density }: { density?: Density } ) {
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 
 	const { is_passwordless_user } = userSettings;
@@ -22,6 +25,7 @@ export default function SecurityAccountRecoverySummary() {
 
 	return (
 		<RouterLinkSummaryButton
+			density={ density }
 			to="/me/security/password"
 			title={ __( 'Password' ) }
 			description={ __( 'Strengthen your account by ensuring your password is strong.' ) }

--- a/client/dashboard/me/security-social-logins/summary.tsx
+++ b/client/dashboard/me/security-social-logins/summary.tsx
@@ -3,9 +3,12 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { commentAuthorAvatar } from '@wordpress/icons';
 import { useAuth } from '../../app/auth';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
-import type { SummaryButtonBadgeProps } from '@automattic/components/src/summary-button/types';
+import type {
+	Density,
+	SummaryButtonBadgeProps,
+} from '@automattic/components/src/summary-button/types';
 
-export default function SecuritySocialLoginsSummary() {
+export default function SecuritySocialLoginsSummary( { density }: { density?: Density } ) {
 	const { user } = useAuth();
 
 	const socialLoginCount = user.social_login_connections?.length ?? 0;
@@ -25,6 +28,7 @@ export default function SecuritySocialLoginsSummary() {
 
 	return (
 		<RouterLinkSummaryButton
+			density={ density }
 			to="/me/security/social-logins"
 			title={ __( 'Social logins' ) }
 			description={ __( 'Log in faster with the accounts you already use.' ) }

--- a/client/dashboard/me/security-ssh-key/summary.tsx
+++ b/client/dashboard/me/security-ssh-key/summary.tsx
@@ -4,9 +4,12 @@ import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { key } from '@wordpress/icons';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
-import type { SummaryButtonBadgeProps } from '@automattic/components/src/summary-button/types';
+import type {
+	Density,
+	SummaryButtonBadgeProps,
+} from '@automattic/components/src/summary-button/types';
 
-export default function SecuritySshKeySummary() {
+export default function SecuritySshKeySummary( { density }: { density?: Density } ) {
 	const { data: sshKeys } = useSuspenseQuery( sshKeysQuery() );
 
 	const badges: SummaryButtonBadgeProps[] = [
@@ -18,6 +21,7 @@ export default function SecuritySshKeySummary() {
 
 	return (
 		<RouterLinkSummaryButton
+			density={ density }
 			to="/me/security/ssh-key"
 			title={ __( 'SSH key' ) }
 			description={ __(

--- a/client/dashboard/me/security-two-step-auth/summary.tsx
+++ b/client/dashboard/me/security-two-step-auth/summary.tsx
@@ -5,9 +5,12 @@ import { __ } from '@wordpress/i18n';
 import { mobile } from '@wordpress/icons';
 import { useAuth } from '../../app/auth';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
-import type { SummaryButtonBadgeProps } from '@automattic/components/src/summary-button/types';
+import type {
+	Density,
+	SummaryButtonBadgeProps,
+} from '@automattic/components/src/summary-button/types';
 
-export default function SecurityTwoStepAuthSummary() {
+export default function SecurityTwoStepAuthSummary( { density }: { density?: Density } ) {
 	const { user } = useAuth();
 	const isEmailVerified = user?.email_verified;
 
@@ -31,6 +34,7 @@ export default function SecurityTwoStepAuthSummary() {
 
 	return (
 		<RouterLinkSummaryButton
+			density={ density }
 			disabled={ ! isEmailVerified }
 			to="/me/security/two-step-auth"
 			title={ __( 'Two-step authentication' ) }

--- a/client/dashboard/me/security/index.tsx
+++ b/client/dashboard/me/security/index.tsx
@@ -33,7 +33,7 @@ function Security() {
 				<SecurityPasswordSummary />
 				<SecurityAccountRecoverySummary />
 				<SecurityTwoStepAuthSummary />
-				{ supportsSecurity.sshKey && <SecuritySshKeySummary /> }
+				{ supportsSecurity.sshKey ? <SecuritySshKeySummary /> : null }
 				<SecurityConnectedAppsSummary />
 				<SecuritySocialLoginsSummary />
 			</SummaryButtonList>

--- a/client/dashboard/me/security/index.tsx
+++ b/client/dashboard/me/security/index.tsx
@@ -1,9 +1,9 @@
-import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useAppContext } from '../../app/context';
 import { PerformanceTrackerStop } from '../../app/performance-tracking';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import { SummaryButtonList } from '../../components/summary-button-list';
 import SecurityAccountRecoverySummary from '../security-account-recovery/summary';
 import SecurityConnectedAppsSummary from '../security-connected-apps/summary';
 import SecurityPasswordSummary from '../security-password/summary';
@@ -29,14 +29,14 @@ function Security() {
 				/>
 			}
 		>
-			<VStack spacing={ 4 }>
+			<SummaryButtonList>
 				<SecurityPasswordSummary />
 				<SecurityAccountRecoverySummary />
 				<SecurityTwoStepAuthSummary />
 				{ supportsSecurity.sshKey && <SecuritySshKeySummary /> }
 				<SecurityConnectedAppsSummary />
 				<SecuritySocialLoginsSummary />
-			</VStack>
+			</SummaryButtonList>
 			<PerformanceTrackerStop />
 		</PageLayout>
 	);


### PR DESCRIPTION
## Summary

This PR addresses some internal feedback that some of our account settings screens are getting too long (p1775041728104749-slack-C9EJ7KSGH). The PR updates the density of the summary buttons on the Preferences, Billing, Security, and Notifications screens to make them more compact.

**Before**
<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/3c944c08-1b06-4e32-a5bf-1fbd33641dc8" />

<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/a5f5609a-1c77-4e79-bc24-ba8fe7b7a13e" />

<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/c96e1732-a255-4cc8-9142-79df32d73ea6" />

<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/ead4bb23-4b79-454b-829b-291870322676" />


**After**
<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/589d7f42-d301-496d-9e0d-a8f7450e384a" />

<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/ff81afec-010a-4cfa-85d1-aab3b31bf7b7" />

<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/18fa8c38-c1c9-4fe4-91af-a088e9aa0a6e" />

<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/a277c06c-e9e2-4642-b849-0b714fbd25f9" />



## Test plan

- [ ] Navigate to `my.localhost:3000/me/preferences` — items should be grouped in a single card with dividers (not separate cards)
- [ ] Navigate to `my.localhost:3000/me/billing` — same dense layout
- [ ] Navigate to `my.localhost:3000/me/security` — same dense layout
- [ ] Navigate to `my.localhost:3000/me/notifications` — same dense layout
- [ ] Compare with site Settings at `my.localhost:3000/sites/{slug}/settings` — density should match
- [ ] Click through each card item on all 4 pages — navigation should still work correctly
- [ ] Verify badges still render on Preferences cards (Enabled/Disabled, English, Sites list, etc.)


🤖 Generated with [Claude Code](https://claude.com/claude-code)