### PR TITLE
Checkout: Revert using generic renewal route for all renewals

### DIFF
--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -18,7 +18,6 @@ import {
 	checkoutUnifiedSiteless,
 	checkoutA4ASiteless,
 	checkoutRenewalBySubscriptionId,
-	redirectToRenewalBySubscriptionId,
 	checkoutThankYou,
 	licensingPendingAsyncActivation,
 	licensingThankYouManualActivationInstructions,
@@ -396,9 +395,23 @@ export default function () {
 		clientRender
 	);
 
-	page( '/checkout/:product/renew/:purchaseId', redirectToRenewalBySubscriptionId );
+	page(
+		'/checkout/:product/renew/:purchaseId',
+		redirectLoggedOut,
+		noSite,
+		checkout,
+		makeLayout,
+		clientRender
+	);
 
-	page( '/checkout/:product/renew/:purchaseId/:domain', redirectToRenewalBySubscriptionId );
+	page(
+		'/checkout/:product/renew/:purchaseId/:domain',
+		redirectLoggedOut,
+		siteSelection,
+		checkout,
+		makeLayout,
+		clientRender
+	);
 
 	// Gift purchases work without a site, so do not include the `siteSelection`
 	// middleware.


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/SHILL-1829/regression-legacy-jetpack-social-advanced-beta-renewal-fails-with-not

## Proposed Changes

This PR reverts the effects of https://github.com/Automattic/wp-calypso/pull/109026. As a result, regular checkout renewal URLs will not redirect to the siteless checkout renewal format.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

There seems to be some problem with Jetpack renewal URLs using the siteless checkout flow. It seems safer while debugging the issue to restore the original checkout URLs from before https://github.com/Automattic/wp-calypso/pull/109026 was merged.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit a full renewal URL (including the product slug, site, and subscription ID) for a product you own and verify that checkout loads correctly and that the URL does not change. Probably the easiest way to do this is to visit the purchase settings page for your subscription (start at http://my.wordpress.com/me/billing/purchases/, click on a subscription), and click "Renew now".

As an example, prior to this PR, http://calypso.localhost:3000/checkout/value_bundle/renew/2275782/qingbingcha.org would have been transformed into http://calypso.localhost:3000/checkout/renew/2275782
