### PR TITLE
Stats: Add multi-level breadcrumb trail for detail pages

### DIFF
--- a/client/my-sites/stats/components/stats-main/index.tsx
+++ b/client/my-sites/stats/components/stats-main/index.tsx
@@ -36,20 +36,31 @@ interface StatsMainProps extends MainProps {
 function StatsBreadcrumbs( { items }: { items: BreadcrumbItem[] } ) {
 	const translate = useTranslate();
 
+	// First item is always "Stats" with Jetpack logo, using the first item's URL.
+	const rootUrl = items[ 0 ]?.to;
+	const restItems = items.slice( 1 );
+
 	return (
 		<nav className="stats-breadcrumbs" aria-label={ translate( 'Breadcrumbs' ) }>
 			<JetpackLogo size={ 20 } monochrome={ false } />
-			{ items.flatMap( ( item, index ) => {
-				const elements: ReactNode[] = [];
-				if ( index > 0 ) {
-					elements.push(
-						<span key={ `sep-${ index }` } className="stats-breadcrumbs__separator">
-							{ ' / ' }
-						</span>
-					);
-				}
-				if ( item.to ) {
-					elements.push(
+			{ rootUrl ? (
+				<a
+					className="stats-breadcrumbs__link"
+					href={ rootUrl }
+					onClick={ ( e ) => {
+						e.preventDefault();
+						page( rootUrl );
+					} }
+				>
+					{ STATS_HEADER_TITLE }
+				</a>
+			) : (
+				<span className="stats-breadcrumbs__current">{ STATS_HEADER_TITLE }</span>
+			) }
+			{ restItems.map( ( item, index ) => (
+				<span key={ index }>
+					<span className="stats-breadcrumbs__separator"> / </span>
+					{ item.to ? (
 						<a
 							key={ `item-${ index }` }
 							className="stats-breadcrumbs__link"
@@ -72,20 +83,11 @@ function StatsBreadcrumbs( { items }: { items: BreadcrumbItem[] } ) {
 						>
 							{ item.label }
 						</a>
-					);
-				} else {
-					elements.push(
-						<span
-							key={ `item-${ index }` }
-							className="stats-breadcrumbs__current"
-							aria-current="page"
-						>
-							{ item.label }
-						</span>
-					);
-				}
-				return elements;
-			} ) }
+					) : (
+						<span className="stats-breadcrumbs__current">{ item.label }</span>
+					) }
+				</span>
+			) ) }
 		</nav>
 	);
 }

--- a/client/my-sites/stats/hooks/use-stats-navigation-history.ts
+++ b/client/my-sites/stats/hooks/use-stats-navigation-history.ts
@@ -186,6 +186,100 @@ export const useStatsNavigationHistory = (): { text: string; url: string | null 
 };
 
 /**
+ * Hook that returns the full navigation trail as breadcrumb items.
+ * Excludes the current screen (last item in history).
+ * Each item has a label and URL for building breadcrumb navigation.
+ */
+export const useStatsBreadcrumbTrail = (): Array< { label: string; url: string | null } > => {
+	const localizedTabNames: { [ key: string ]: string | null } = useMemo(
+		() => ( {
+			traffic: translate( 'Traffic' ),
+			insights: translate( 'Insights' ),
+			store: translate( 'Store' ),
+			realtime: translate( 'Realtime' ),
+			ads: translate( 'Ads' ),
+			subscribers: translate( 'Subscribers' ),
+			posts: translate( 'Most viewed' ),
+			authors: translate( 'Authors' ),
+			filedownloads: translate( 'File Downloads' ),
+			referrers: translate( 'Referrers' ),
+			locations: translate( 'Locations' ),
+			countryviews: translate( 'Countries' ),
+			utm: translate( 'UTM' ),
+			clicks: translate( 'Clicks' ),
+			searchterms: translate( 'Search Terms' ),
+			videoplays: translate( 'Videos' ),
+			annualstats: translate( 'Annual insights' ),
+			postList: translate( 'Post List' ),
+			emailsummary: translate( 'Emails' ),
+			postDetails: null,
+		} ),
+		[]
+	);
+
+	const siteId = useSelector( getSelectedSiteId );
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
+	const adminBaseUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
+
+	const [ trail, setTrail ] = useState< Array< { label: string; url: string | null } > >( [] );
+
+	useEffect( () => {
+		try {
+			const navState = JSON.parse( sessionStorage.getItem( STORAGE_KEY ) || '[]' );
+			if ( ! Array.isArray( navState ) || navState.length < 2 ) {
+				setTrail( [] );
+				return;
+			}
+
+			// Exclude the last item (current screen).
+			const items = navState.slice( 0, -1 );
+
+			const breadcrumbs = items
+				.map( ( entry: { screen: string; queryParams: QueryArgs; period: string | null } ) => {
+					const label = localizedTabNames[ entry.screen ];
+					if ( ! label ) {
+						return null;
+					}
+
+					let link = possibleBackLinks[ entry.screen ];
+					if ( ! link ) {
+						return null;
+					}
+
+					if ( link.includes( '{period}' ) && entry.period ) {
+						link = link.replace( '{period}', entry.period );
+					}
+
+					if ( link.includes( '{adminUrl}' ) ) {
+						if ( ! adminBaseUrl ) {
+							return null;
+						}
+						link = link.replace( '{adminUrl}', adminBaseUrl );
+						return {
+							label,
+							url: addQueryArgs( link, prepareAdminQueryParams( entry.queryParams ) ),
+						};
+					}
+
+					return {
+						label,
+						url: siteSlug
+							? addQueryArgs( link + siteSlug, getFilteredQueryParams( entry.queryParams ) )
+							: null,
+					};
+				} )
+				.filter( Boolean ) as Array< { label: string; url: string | null } >;
+
+			setTrail( breadcrumbs );
+		} catch ( e ) {
+			setTrail( [] );
+		}
+	}, [ localizedTabNames, siteSlug, adminBaseUrl ] );
+
+	return trail;
+};
+
+/**
  * Utility to record the current screen for back navigation
  * @param {string} screen - Current screen identifier
  * @param {Object} args - Arguments for the screen

--- a/client/my-sites/stats/stats-email-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-detail/index.jsx
@@ -22,9 +22,9 @@ import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
 import memoizeLast from 'calypso/lib/memoize-last';
 import { isHttps } from 'calypso/lib/url';
 import Main from 'calypso/my-sites/stats/components/stats-main';
-import { STATS_HEADER_TITLE, STATS_PRODUCT_NAME } from 'calypso/my-sites/stats/constants';
+import { STATS_PRODUCT_NAME } from 'calypso/my-sites/stats/constants';
 import {
-	useStatsNavigationHistory,
+	useStatsBreadcrumbTrail,
 	recordCurrentScreen,
 } from 'calypso/my-sites/stats/hooks/use-stats-navigation-history';
 import StatsEmailModule from 'calypso/my-sites/stats/stats-email-module';
@@ -232,7 +232,7 @@ class StatsEmailDetail extends Component {
 			showViewLink,
 			previewUrl,
 			siteSlug,
-			lastScreen,
+			breadcrumbTrail,
 		} = this.props;
 		const { maxBars } = this.state;
 
@@ -266,7 +266,7 @@ class StatsEmailDetail extends Component {
 					fullWidthLayout
 					className={ clsx( 'stats__email-detail' ) }
 					breadcrumbs={ [
-						{ label: STATS_HEADER_TITLE, to: lastScreen?.url },
+						...breadcrumbTrail.map( ( item ) => ( { label: item.label, to: item.url } ) ),
 						{ label: navigationItems[ 1 ].label },
 					] }
 					pageActions={
@@ -442,8 +442,8 @@ class StatsEmailDetail extends Component {
 }
 
 const StatsEmailDetailWrapper = ( props ) => {
-	const lastScreen = useStatsNavigationHistory();
-	return <StatsEmailDetail { ...props } lastScreen={ lastScreen } />;
+	const breadcrumbTrail = useStatsBreadcrumbTrail();
+	return <StatsEmailDetail { ...props } breadcrumbTrail={ breadcrumbTrail } />;
 };
 
 const connectComponent = connect(

--- a/client/my-sites/stats/stats-email-summary/index.jsx
+++ b/client/my-sites/stats/stats-email-summary/index.jsx
@@ -4,12 +4,15 @@ import { useMemo, useEffect } from 'react';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/my-sites/stats/components/stats-main';
 import { useShouldGateStats } from 'calypso/my-sites/stats/hooks/use-should-gate-stats';
-import { recordCurrentScreen } from 'calypso/my-sites/stats/hooks/use-stats-navigation-history';
+import {
+	useStatsBreadcrumbTrail,
+	recordCurrentScreen,
+} from 'calypso/my-sites/stats/hooks/use-stats-navigation-history';
 import DownloadCsv from 'calypso/my-sites/stats/stats-download-csv';
 import DownloadCsvUpsell from 'calypso/my-sites/stats/stats-download-csv-upsell';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import { STATS_FEATURE_DOWNLOAD_CSV, STATS_HEADER_TITLE } from '../constants';
+import { STATS_FEATURE_DOWNLOAD_CSV } from '../constants';
 import {
 	TooltipWrapper,
 	OpensTooltipContent,
@@ -23,6 +26,7 @@ import '../stats-module/summary-nav.scss';
 
 // TODO: `query` was never passed from outside or defined in scope. Adding it to avoid a lint error.
 const StatsEmailSummary = ( { period, query, context } ) => {
+	const breadcrumbTrail = useStatsBreadcrumbTrail();
 	const StatsStrings = useStatsStrings();
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
@@ -91,7 +95,7 @@ const StatsEmailSummary = ( { period, query, context } ) => {
 		<Main
 			fullWidthLayout
 			breadcrumbs={ [
-				{ label: STATS_HEADER_TITLE, to: navigationItems[ 0 ].href },
+				...breadcrumbTrail.map( ( item ) => ( { label: item.label, to: item.url } ) ),
 				{ label: navigationItems[ 1 ].label },
 			] }
 			pageActions={ <div className="stats-module__header-nav-button">{ downloadCsvElement }</div> }

--- a/client/my-sites/stats/stats-email-summary/index.jsx
+++ b/client/my-sites/stats/stats-email-summary/index.jsx
@@ -1,6 +1,6 @@
 import { formatNumber } from '@automattic/number-formatters';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo, useEffect } from 'react';
+import { useMemo, useLayoutEffect } from 'react';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/my-sites/stats/components/stats-main';
 import { useShouldGateStats } from 'calypso/my-sites/stats/hooks/use-should-gate-stats';
@@ -24,9 +24,10 @@ import PageViewTracker from '../stats-page-view-tracker';
 import '../summary/style.scss';
 import '../stats-module/summary-nav.scss';
 
-// TODO: `query` was never passed from outside or defined in scope. Adding it to avoid a lint error.
-const StatsEmailSummary = ( { period, query, context } ) => {
-	const breadcrumbTrail = useStatsBreadcrumbTrail();
+// Inner component that records the current screen before the wrapper reads breadcrumb trail.
+// useLayoutEffect fires before the parent wrapper's useEffect in useStatsBreadcrumbTrail,
+// ensuring the navigation history is updated before the breadcrumb trail is read.
+const StatsEmailSummaryInner = ( { period, query, context, breadcrumbTrail } ) => {
 	const StatsStrings = useStatsStrings();
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
@@ -64,7 +65,7 @@ const StatsEmailSummary = ( { period, query, context } ) => {
 		return [ { label: backLabel, href: backLink }, { label: title } ];
 	}, [ translate, siteSlug ] );
 
-	useEffect( () => {
+	useLayoutEffect( () => {
 		recordCurrentScreen( 'emailsummary', {
 			queryParams: context.query,
 			period: period.period,
@@ -180,6 +181,13 @@ const StatsEmailSummary = ( { period, query, context } ) => {
 			</div>
 		</Main>
 	);
+};
+
+// TODO: `query` was never passed from outside or defined in scope. Adding it to avoid a lint error.
+const StatsEmailSummary = ( props ) => {
+	const breadcrumbTrail = useStatsBreadcrumbTrail();
+
+	return <StatsEmailSummaryInner { ...props } breadcrumbTrail={ breadcrumbTrail } />;
 };
 
 export default StatsEmailSummary;

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -19,9 +19,8 @@ import WebPreview from 'calypso/components/web-preview';
 import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
 import { isHttps } from 'calypso/lib/url';
 import Main from 'calypso/my-sites/stats/components/stats-main';
-import { STATS_HEADER_TITLE } from 'calypso/my-sites/stats/constants';
 import {
-	useStatsNavigationHistory,
+	useStatsBreadcrumbTrail,
 	recordCurrentScreen,
 } from 'calypso/my-sites/stats/hooks/use-stats-navigation-history';
 import StatsDetailsNavigation from 'calypso/my-sites/stats/stats-details-navigation';
@@ -211,7 +210,7 @@ class StatsPostDetail extends Component {
 			isSubscriptionsModuleActive,
 			supportsEmailStats,
 			isSimple,
-			lastScreen,
+			breadcrumbTrail,
 		} = this.props;
 
 		const isLoading = isRequestingStats && ! countViews;
@@ -255,7 +254,7 @@ class StatsPostDetail extends Component {
 			<Main
 				fullWidthLayout
 				breadcrumbs={ [
-					{ label: STATS_HEADER_TITLE, to: lastScreen.url },
+					...breadcrumbTrail.map( ( item ) => ( { label: item.label, to: item.url } ) ),
 					{ label: navigationItems[ 1 ].label },
 				] }
 				pageTabs={
@@ -333,7 +332,7 @@ class StatsPostDetail extends Component {
 }
 
 const StatsPostDetailWrapper = ( props ) => {
-	const lastScreen = useStatsNavigationHistory();
+	const breadcrumbTrail = useStatsBreadcrumbTrail();
 
 	const supportLink = localizeUrl(
 		'https://wordpress.com/support/getting-more-views-and-traffic/'
@@ -357,7 +356,9 @@ const StatsPostDetailWrapper = ( props ) => {
 		}
 	};
 
-	return <StatsPostDetail { ...props } lastScreen={ lastScreen } openSupportDoc={ openDoc } />;
+	return (
+		<StatsPostDetail { ...props } breadcrumbTrail={ breadcrumbTrail } openSupportDoc={ openDoc } />
+	);
 };
 
 const connectComponent = connect( ( state, { postId } ) => {

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -16,13 +16,13 @@ import StatsModuleReferrers from 'calypso/my-sites/stats/features/modules/stats-
 import StatsModuleSearch from 'calypso/my-sites/stats/features/modules/stats-search';
 import StatsModuleTopPosts from 'calypso/my-sites/stats/features/modules/stats-top-posts';
 import {
-	useStatsNavigationHistory,
+	useStatsBreadcrumbTrail,
 	recordCurrentScreen,
 } from 'calypso/my-sites/stats/hooks/use-stats-navigation-history';
 import getMediaItem from 'calypso/state/selectors/get-media-item';
 import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import { STATS_FEATURE_DOWNLOAD_CSV, STATS_HEADER_TITLE } from '../constants';
+import { STATS_FEATURE_DOWNLOAD_CSV } from '../constants';
 import StatsModuleLocations from '../features/modules/stats-locations';
 import LocationsNavTabs from '../features/modules/stats-locations/locations-nav-tabs';
 import { GEO_MODES } from '../features/modules/stats-locations/types';
@@ -130,7 +130,7 @@ class StatsSummary extends Component {
 			supportsUTMStats,
 			supportsArchiveStats,
 			shouldGateStatsCsvDownload,
-			lastScreen,
+			breadcrumbTrail,
 			statsStrings,
 		} = this.props;
 
@@ -444,7 +444,10 @@ class StatsSummary extends Component {
 		return (
 			<Main
 				fullWidthLayout
-				breadcrumbs={ [ { label: STATS_HEADER_TITLE, to: lastScreen.url }, { label: title } ] }
+				breadcrumbs={ [
+					...breadcrumbTrail.map( ( item ) => ( { label: item.label, to: item.url } ) ),
+					{ label: title },
+				] }
 				pageTabs={ tabs }
 				pageActions={
 					<div className="stats-module__header-nav-button">
@@ -502,10 +505,12 @@ class StatsSummary extends Component {
 }
 
 const StatsSummaryWrapper = ( props ) => {
-	const lastScreen = useStatsNavigationHistory();
+	const breadcrumbTrail = useStatsBreadcrumbTrail();
 	const statsStrings = useStatsStrings( { supportsArchiveStats: props.supportsArchiveStats } );
 
-	return <StatsSummary { ...props } lastScreen={ lastScreen } statsStrings={ statsStrings } />;
+	return (
+		<StatsSummary { ...props } breadcrumbTrail={ breadcrumbTrail } statsStrings={ statsStrings } />
+	);
 };
 
 export default connect( ( state, { context, postId } ) => {


### PR DESCRIPTION
Part of #109786

## Proposed Changes

- Add `useStatsBreadcrumbTrail` hook that reads the full navigation history from sessionStorage and converts it to breadcrumb items.
- Detail pages now show dynamic multi-level breadcrumb trails based on actual navigation path (e.g. "Stats / Most viewed / Post name" when navigating Traffic → Summary → Post detail).
- First breadcrumb item is always "Stats" with Jetpack logo, linking back to the parent page.
- Fix breadcrumb label: "Posts & pages" → "Most viewed" to match the summary page title.
- Breadcrumb styling: inline-flex alignment, underline on links.
- Fix email summary breadcrumb trail: split into wrapper + inner component pattern so `recordCurrentScreen` (via `useLayoutEffect`) fires before `useStatsBreadcrumbTrail` reads the navigation history.

## Testing Instructions

- Navigate to `/stats/day/<site-slug>` → click "View more" on Most viewed → click a post title
  - Breadcrumb should show: "Stats / Most viewed / Post name"
- Navigate directly to a post detail from the traffic page
  - Breadcrumb should show: "Stats / Post name" (two levels)
- Navigate to the Emails summary page from traffic
  - Breadcrumb should show: "Stats / Traffic / Emails" (not just "Emails")
- Verify each breadcrumb link navigates to the correct page
- Test the same flow for Referrers, Clicks, Locations, etc.

https://github.com/user-attachments/assets/f2577c89-0e17-4866-a5c8-a5fb706f19bb

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)