### PR TITLE
MSD: Show version switch progress when changing WordPress version

### DIFF
--- a/client/dashboard/sites/settings-wordpress/beta-program-notice.tsx
+++ b/client/dashboard/sites/settings-wordpress/beta-program-notice.tsx
@@ -24,22 +24,22 @@ export function BetaProgramNotice( { site, wpVersion }: BetaProgramNoticeProps )
 				wpVersion
 			) }
 		>
-			{ backupUrl
+			{ site.is_wpcom_staging_site
 				? createInterpolateElement(
+						__(
+							'If you notice anything unexpected, <support>let us know</support>. Your feedback helps shape WordPress. You can switch back to the stable release anytime.'
+						),
+						{
+							support: <Button variant="link" onClick={ () => setShowHelpCenter( true ) } />,
+						}
+				  )
+				: createInterpolateElement(
 						__(
 							'If you notice anything unexpected, <support>let us know</support>. Your feedback helps shape WordPress. You can switch back to the stable release anytime. A <backup>backup of your site</backup> is available if you ever need it.'
 						),
 						{
 							support: <Button variant="link" onClick={ () => setShowHelpCenter( true ) } />,
 							backup: <a href={ backupUrl } />,
-						}
-				  )
-				: createInterpolateElement(
-						__(
-							'If you notice anything unexpected, <support>let us know</support>. Your feedback helps shape WordPress. You can switch back to the stable release anytime.'
-						),
-						{
-							support: <Button variant="link" onClick={ () => setShowHelpCenter( true ) } />,
 						}
 				  ) }
 		</Notice>

--- a/client/dashboard/sites/settings-wordpress/beta-program-notice.tsx
+++ b/client/dashboard/sites/settings-wordpress/beta-program-notice.tsx
@@ -1,0 +1,47 @@
+import { Button } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { useHelpCenter } from '../../app/help-center';
+import { Notice } from '../../components/notice';
+import { getBackupUrl } from '../../utils/site-backup';
+import type { Site } from '@automattic/api-core';
+
+interface BetaProgramNoticeProps {
+	site: Site;
+	wpVersion: string;
+}
+
+export function BetaProgramNotice( { site, wpVersion }: BetaProgramNoticeProps ) {
+	const backupUrl = getBackupUrl( site );
+	const { setShowHelpCenter } = useHelpCenter();
+
+	return (
+		<Notice
+			variant="info"
+			title={ sprintf(
+				/* translators: %s is the WordPress version string e.g. "6.8 beta" */
+				__( 'Your site is running WordPress %s' ),
+				wpVersion
+			) }
+		>
+			{ backupUrl
+				? createInterpolateElement(
+						__(
+							'If you notice anything unexpected, <support>let us know</support>. Your feedback helps shape WordPress. You can switch back to the stable release anytime. A <backup>backup of your site</backup> is available if you ever need it.'
+						),
+						{
+							support: <Button variant="link" onClick={ () => setShowHelpCenter( true ) } />,
+							backup: <a href={ backupUrl } />,
+						}
+				  )
+				: createInterpolateElement(
+						__(
+							'If you notice anything unexpected, <support>let us know</support>. Your feedback helps shape WordPress. You can switch back to the stable release anytime.'
+						),
+						{
+							support: <Button variant="link" onClick={ () => setShowHelpCenter( true ) } />,
+						}
+				  ) }
+		</Notice>
+	);
+}

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -1,34 +1,16 @@
-import {
-	queryClient,
-	siteBackupsQuery,
-	siteBySlugQuery,
-	siteWordPressVersionQuery,
-	siteWordPressVersionMutation,
-	wpOrgCoreVersionQuery,
-} from '@automattic/api-queries';
-import { useQuery, useSuspenseQuery, useMutation } from '@tanstack/react-query';
-import {
-	__experimentalVStack as VStack,
-	__experimentalText as Text,
-	Button,
-} from '@wordpress/components';
-import { DataForm } from '@wordpress/dataviews';
+import { siteBySlugQuery, siteWordPressVersionQuery } from '@automattic/api-queries';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { __experimentalVStack as VStack, __experimentalText as Text } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { useEffect, useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
-import { NavigationBlocker } from '../../app/navigation-blocker';
-import { ButtonStack } from '../../components/button-stack';
-import { Card, CardBody } from '../../components/card';
 import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import { formatWordPressVersion, getFormattedWordPressVersion } from '../../utils/wp-version';
-import { useBackupState } from '../backups/use-backup-state';
+import { getFormattedWordPressVersion } from '../../utils/wp-version';
 import { canViewWordPressSettings } from '../features';
-import { VersionSwitchNotice } from './version-switch-notice';
-import type { Field } from '@wordpress/dataviews';
+import { VersionForm } from './version-form';
 
 export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
@@ -38,93 +20,6 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 		...siteWordPressVersionQuery( site.ID ),
 		enabled: canView,
 	} );
-
-	const { data: latestVersion } = useQuery( {
-		...wpOrgCoreVersionQuery(),
-		enabled: canView,
-	} );
-	const { data: betaVersion } = useQuery( {
-		...wpOrgCoreVersionQuery( 'beta' ),
-		enabled: canView,
-	} );
-
-	const backupState = useBackupState( site.ID );
-	const [ switchTarget, setSwitchTarget ] = useState< string | null >( null );
-
-	// The version has changed when the current version matches what we requested.
-	const isVersionChanged = !! switchTarget && currentVersion === switchTarget;
-	const isSwitching = !! switchTarget && ! isVersionChanged;
-
-	// Poll backups while a version switch is in progress.
-	useQuery( {
-		...siteBackupsQuery( site.ID ),
-		refetchInterval: isSwitching ? 3000 : false,
-		enabled: canView && isSwitching,
-	} );
-
-	// After backup completes, poll WP version until it changes.
-	useQuery( {
-		...siteWordPressVersionQuery( site.ID ),
-		refetchInterval: isSwitching && backupState.hasRecentlyCompleted ? 5000 : false,
-		enabled: canView,
-	} );
-
-	// After backup completes, also invalidate immediately to get a quick first check.
-	useEffect( () => {
-		if ( backupState.hasRecentlyCompleted ) {
-			queryClient.invalidateQueries( siteWordPressVersionQuery( site.ID ) );
-		}
-	}, [ backupState.hasRecentlyCompleted, site.ID ] );
-
-	const mutation = useMutation( {
-		...siteWordPressVersionMutation( site.ID ),
-		onSuccess: () => {
-			backupState.setEnqueued( true );
-		},
-		meta: {
-			snackbar: {
-				error: __( 'Failed to save WordPress version.' ),
-			},
-		},
-	} );
-
-	const [ formData, setFormData ] = useState< { version: string } >( {
-		version: currentVersion ?? '',
-	} );
-
-	const currentWpVersion = site.options?.software_version ?? '';
-
-	const fields: Field< { version: string } >[] = [
-		{
-			id: 'version',
-			label: __( 'WordPress version' ),
-			Edit: 'select',
-			elements: [
-				{
-					value: 'latest',
-					label: formatWordPressVersion( latestVersion ?? currentWpVersion, 'latest', true ),
-				},
-				{
-					value: 'beta',
-					label: formatWordPressVersion( betaVersion ?? currentWpVersion, 'beta', true ),
-				},
-			],
-		},
-	];
-
-	const form = {
-		layout: { type: 'regular' as const },
-		fields: [ 'version' ],
-	};
-
-	const isDirty = formData.version !== currentVersion;
-	const { isPending } = mutation;
-
-	const handleSubmit = ( e: React.FormEvent ) => {
-		e.preventDefault();
-		setSwitchTarget( formData.version );
-		mutation.mutate( formData.version );
-	};
 
 	if ( ! canView ) {
 		return (
@@ -175,49 +70,8 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 					description={ __( 'Manage your WordPress version.' ) }
 				/>
 			}
-			notices={
-				isSwitching || isVersionChanged ? (
-					<VersionSwitchNotice
-						backupState={ backupState }
-						targetVersion={
-							switchTarget === 'beta'
-								? betaVersion ?? currentWpVersion
-								: latestVersion ?? currentWpVersion
-						}
-						isVersionChanged={ isVersionChanged }
-					/>
-				) : undefined
-			}
 		>
-			<Card>
-				<CardBody>
-					<form onSubmit={ handleSubmit }>
-						<fieldset disabled={ isSwitching } style={ { border: 0, margin: 0, padding: 0 } }>
-							<VStack spacing={ 4 }>
-								<NavigationBlocker shouldBlock={ isDirty } />
-								<DataForm< { version: string } >
-									data={ formData }
-									fields={ fields }
-									form={ form }
-									onChange={ ( edits: { version?: string } ) => {
-										setFormData( ( data ) => ( { ...data, ...edits } ) );
-									} }
-								/>
-								<ButtonStack justify="flex-start">
-									<Button
-										variant="primary"
-										type="submit"
-										isBusy={ isPending }
-										disabled={ isPending || ! isDirty || isSwitching }
-									>
-										{ __( 'Save' ) }
-									</Button>
-								</ButtonStack>
-							</VStack>
-						</fieldset>
-					</form>
-				</CardBody>
-			</Card>
+			<VersionForm site={ site } currentVersion={ currentVersion } />
 		</PageLayout>
 	);
 }

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -1,4 +1,6 @@
 import {
+	queryClient,
+	siteBackupsQuery,
 	siteBySlugQuery,
 	siteWordPressVersionQuery,
 	siteWordPressVersionMutation,
@@ -13,7 +15,7 @@ import {
 import { DataForm } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { NavigationBlocker } from '../../app/navigation-blocker';
 import { ButtonStack } from '../../components/button-stack';
@@ -23,7 +25,9 @@ import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { formatWordPressVersion, getFormattedWordPressVersion } from '../../utils/wp-version';
+import { useBackupState } from '../backups/use-backup-state';
 import { canViewWordPressSettings } from '../features';
+import { VersionSwitchNotice } from './version-switch-notice';
 import type { Field } from '@wordpress/dataviews';
 
 export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) {
@@ -44,11 +48,42 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 		enabled: canView,
 	} );
 
+	const backupState = useBackupState( site.ID );
+	const isBackupInProgress = backupState.status === 'enqueued' || backupState.status === 'running';
+	const [ switchTarget, setSwitchTarget ] = useState< string | null >( null );
+
+	// The version has changed when the current version matches what we requested.
+	const isVersionChanged = !! switchTarget && currentVersion === switchTarget;
+	const isSwitching = !! switchTarget && ! isVersionChanged;
+
+	// Poll backups while a version switch is in progress.
+	useQuery( {
+		...siteBackupsQuery( site.ID ),
+		refetchInterval: isBackupInProgress ? 3000 : false,
+		enabled: canView && isBackupInProgress,
+	} );
+
+	// After backup completes, poll WP version until it changes.
+	useQuery( {
+		...siteWordPressVersionQuery( site.ID ),
+		refetchInterval: isSwitching && backupState.hasRecentlyCompleted ? 5000 : false,
+		enabled: canView,
+	} );
+
+	// After backup completes, also invalidate immediately to get a quick first check.
+	useEffect( () => {
+		if ( backupState.hasRecentlyCompleted ) {
+			queryClient.invalidateQueries( siteWordPressVersionQuery( site.ID ) );
+		}
+	}, [ backupState.hasRecentlyCompleted, site.ID ] );
+
 	const mutation = useMutation( {
 		...siteWordPressVersionMutation( site.ID ),
+		onSuccess: () => {
+			backupState.setEnqueued( true );
+		},
 		meta: {
 			snackbar: {
-				success: __( 'WordPress version saved.' ),
 				error: __( 'Failed to save WordPress version.' ),
 			},
 		},
@@ -88,6 +123,7 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
+		setSwitchTarget( formData.version );
 		mutation.mutate( formData.version );
 	};
 
@@ -140,6 +176,19 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 					description={ __( 'Manage your WordPress version.' ) }
 				/>
 			}
+			notices={
+				isSwitching || isVersionChanged ? (
+					<VersionSwitchNotice
+						backupState={ backupState }
+						targetVersion={
+							switchTarget === 'beta'
+								? betaVersion ?? currentWpVersion
+								: latestVersion ?? currentWpVersion
+						}
+						isVersionChanged={ isVersionChanged }
+					/>
+				) : undefined
+			}
 		>
 			<Card>
 				<CardBody>
@@ -158,8 +207,8 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 								<Button
 									variant="primary"
 									type="submit"
-									isBusy={ isPending }
-									disabled={ isPending || ! isDirty }
+									isBusy={ isPending || isSwitching }
+									disabled={ isPending || ! isDirty || isSwitching }
 								>
 									{ __( 'Save' ) }
 								</Button>

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -1,4 +1,8 @@
-import { siteBySlugQuery, siteWordPressVersionQuery } from '@automattic/api-queries';
+import {
+	siteBySlugQuery,
+	siteWordPressVersionQuery,
+	wpOrgCoreVersionQuery,
+} from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack, __experimentalText as Text } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
@@ -10,54 +14,55 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { getFormattedWordPressVersion } from '../../utils/wp-version';
 import { canViewWordPressSettings } from '../features';
+import { useVersionSwitch } from './use-version-switch';
 import { VersionForm } from './version-form';
+import { VersionSwitchNotice } from './version-switch-notice';
+
+function WordPressSettingsForm( { siteSlug }: { siteSlug: string } ) {
+	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+	const { data: currentVersion } = useQuery( siteWordPressVersionQuery( site.ID ) );
+	const versionSwitch = useVersionSwitch( site );
+	const { isSwitching, isSwitched, backupState, targetVersion } = versionSwitch;
+
+	// Resolve the target version tag (e.g. "beta") to a display string (e.g. "7.0-RC2").
+	const { data: latestVersion = '' } = useQuery( wpOrgCoreVersionQuery() );
+	const { data: betaVersion = '' } = useQuery( wpOrgCoreVersionQuery( 'beta' ) );
+
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					prefix={ <Breadcrumbs length={ 2 } /> }
+					title="WordPress"
+					description={ __( 'Manage your WordPress version.' ) }
+				/>
+			}
+			notices={
+				isSwitching || isSwitched ? (
+					<VersionSwitchNotice
+						backupState={ backupState }
+						targetVersion={ targetVersion === 'beta' ? betaVersion : latestVersion }
+						currentWpVersion={ site.options?.software_version ?? '' }
+						isVersionSwitched={ isSwitched }
+					/>
+				) : undefined
+			}
+		>
+			<VersionForm
+				site={ site }
+				currentVersion={ currentVersion }
+				versionSwitch={ versionSwitch }
+			/>
+		</PageLayout>
+	);
+}
 
 export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-	const canView = canViewWordPressSettings( site );
 
-	const { data: currentVersion } = useQuery( {
-		...siteWordPressVersionQuery( site.ID ),
-		enabled: canView,
-	} );
-
-	if ( ! canView ) {
-		return (
-			<PageLayout
-				size="small"
-				header={
-					<PageHeader
-						prefix={ <Breadcrumbs length={ 2 } /> }
-						title="WordPress"
-						description={ __( 'Manage your WordPress version.' ) }
-					/>
-				}
-			>
-				<Notice>
-					<VStack>
-						<Text as="p">
-							{ sprintf(
-								// translators: %s: WordPress version, e.g. 6.8
-								__( 'Every WordPress.com site runs the latest WordPress version (%s).' ),
-								getFormattedWordPressVersion( site )
-							) }
-						</Text>
-						{ site.is_wpcom_atomic && (
-							<Text as="p">
-								{ createInterpolateElement(
-									__(
-										'Switch to a staging site to test a beta version of the next WordPress release. <learnMoreLink />'
-									),
-									{
-										learnMoreLink: <InlineSupportLink supportContext="switch-to-staging-site" />,
-									}
-								) }
-							</Text>
-						) }
-					</VStack>
-				</Notice>
-			</PageLayout>
-		);
+	if ( canViewWordPressSettings( site ) ) {
+		return <WordPressSettingsForm siteSlug={ siteSlug } />;
 	}
 
 	return (
@@ -71,7 +76,29 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 				/>
 			}
 		>
-			<VersionForm site={ site } currentVersion={ currentVersion } />
+			<Notice>
+				<VStack>
+					<Text as="p">
+						{ sprintf(
+							// translators: %s: WordPress version, e.g. 6.8
+							__( 'Every WordPress.com site runs the latest WordPress version (%s).' ),
+							getFormattedWordPressVersion( site )
+						) }
+					</Text>
+					{ site.is_wpcom_atomic && (
+						<Text as="p">
+							{ createInterpolateElement(
+								__(
+									'Switch to a staging site to test a beta version of the next WordPress release. <learnMoreLink />'
+								),
+								{
+									learnMoreLink: <InlineSupportLink supportContext="switch-to-staging-site" />,
+								}
+							) }
+						</Text>
+					) }
+				</VStack>
+			</Notice>
 		</PageLayout>
 	);
 }

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -49,7 +49,6 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 	} );
 
 	const backupState = useBackupState( site.ID );
-	const isBackupInProgress = backupState.status === 'enqueued' || backupState.status === 'running';
 	const [ switchTarget, setSwitchTarget ] = useState< string | null >( null );
 
 	// The version has changed when the current version matches what we requested.
@@ -59,8 +58,8 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 	// Poll backups while a version switch is in progress.
 	useQuery( {
 		...siteBackupsQuery( site.ID ),
-		refetchInterval: isBackupInProgress ? 3000 : false,
-		enabled: canView && isBackupInProgress,
+		refetchInterval: isSwitching ? 3000 : false,
+		enabled: canView && isSwitching,
 	} );
 
 	// After backup completes, poll WP version until it changes.
@@ -193,27 +192,29 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 			<Card>
 				<CardBody>
 					<form onSubmit={ handleSubmit }>
-						<VStack spacing={ 4 }>
-							<NavigationBlocker shouldBlock={ isDirty } />
-							<DataForm< { version: string } >
-								data={ formData }
-								fields={ fields }
-								form={ form }
-								onChange={ ( edits: { version?: string } ) => {
-									setFormData( ( data ) => ( { ...data, ...edits } ) );
-								} }
-							/>
-							<ButtonStack justify="flex-start">
-								<Button
-									variant="primary"
-									type="submit"
-									isBusy={ isPending || isSwitching }
-									disabled={ isPending || ! isDirty || isSwitching }
-								>
-									{ __( 'Save' ) }
-								</Button>
-							</ButtonStack>
-						</VStack>
+						<fieldset disabled={ isSwitching } style={ { border: 0, margin: 0, padding: 0 } }>
+							<VStack spacing={ 4 }>
+								<NavigationBlocker shouldBlock={ isDirty } />
+								<DataForm< { version: string } >
+									data={ formData }
+									fields={ fields }
+									form={ form }
+									onChange={ ( edits: { version?: string } ) => {
+										setFormData( ( data ) => ( { ...data, ...edits } ) );
+									} }
+								/>
+								<ButtonStack justify="flex-start">
+									<Button
+										variant="primary"
+										type="submit"
+										isBusy={ isPending }
+										disabled={ isPending || ! isDirty || isSwitching }
+									>
+										{ __( 'Save' ) }
+									</Button>
+								</ButtonStack>
+							</VStack>
+						</fieldset>
 					</form>
 				</CardBody>
 			</Card>

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -14,6 +14,8 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { getFormattedWordPressVersion } from '../../utils/wp-version';
 import { canViewWordPressSettings } from '../features';
+import { BetaProgramNotice } from './beta-program-notice';
+import { LatestVersionNotice } from './latest-version-notice';
 import { useVersionSwitch } from './use-version-switch';
 import { VersionForm } from './version-form';
 import { VersionSwitchNotice } from './version-switch-notice';
@@ -22,11 +24,29 @@ function WordPressSettingsForm( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: currentVersion } = useQuery( siteWordPressVersionQuery( site.ID ) );
 	const versionSwitch = useVersionSwitch( site );
-	const { isSwitching, isSwitched, backupState, targetVersion } = versionSwitch;
+	const { isSwitching, switchedToBeta, switchedToLatest, backupState, targetVersion } =
+		versionSwitch;
 
 	// Resolve the target version tag (e.g. "beta") to a display string (e.g. "7.0-RC2").
 	const { data: latestVersion = '' } = useQuery( wpOrgCoreVersionQuery() );
 	const { data: betaVersion = '' } = useQuery( wpOrgCoreVersionQuery( 'beta' ) );
+
+	let notice;
+	if ( isSwitching ) {
+		// Switching in progress — show backup/progress notices.
+		notice = (
+			<VersionSwitchNotice
+				backupState={ backupState }
+				targetVersion={ targetVersion === 'beta' ? betaVersion : latestVersion }
+			/>
+		);
+	} else if ( switchedToLatest ) {
+		// Just switched back to stable.
+		notice = <LatestVersionNotice wpVersion={ latestVersion } />;
+	} else if ( switchedToBeta || currentVersion === 'beta' ) {
+		// Enrolled in beta — show program notice.
+		notice = <BetaProgramNotice site={ site } wpVersion={ betaVersion } />;
+	}
 
 	return (
 		<PageLayout
@@ -38,16 +58,7 @@ function WordPressSettingsForm( { siteSlug }: { siteSlug: string } ) {
 					description={ __( 'Manage your WordPress version.' ) }
 				/>
 			}
-			notices={
-				isSwitching || isSwitched ? (
-					<VersionSwitchNotice
-						backupState={ backupState }
-						targetVersion={ targetVersion === 'beta' ? betaVersion : latestVersion }
-						currentWpVersion={ site.options?.software_version ?? '' }
-						isVersionSwitched={ isSwitched }
-					/>
-				) : undefined
-			}
+			notices={ notice }
 		>
 			<VersionForm
 				site={ site }

--- a/client/dashboard/sites/settings-wordpress/latest-version-notice.tsx
+++ b/client/dashboard/sites/settings-wordpress/latest-version-notice.tsx
@@ -1,0 +1,18 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { Notice } from '../../components/notice';
+
+interface LatestVersionNoticeProps {
+	wpVersion: string;
+}
+
+export function LatestVersionNotice( { wpVersion }: LatestVersionNoticeProps ) {
+	return (
+		<Notice variant="success" title={ __( 'WordPress version updated' ) }>
+			{ sprintf(
+				// translators: %s: WordPress version, e.g. "7.0-RC2"
+				__( 'Your site is now running WordPress %s.' ),
+				wpVersion
+			) }
+		</Notice>
+	);
+}

--- a/client/dashboard/sites/settings-wordpress/test/index.test.tsx
+++ b/client/dashboard/sites/settings-wordpress/test/index.test.tsx
@@ -42,7 +42,7 @@ function mockApi() {
 		.persist()
 		.get( `/wpcom/v2/sites/${ site.ID }/hosting/wp-version/pending` )
 		.query( true )
-		.reply( 200, null );
+		.reply( 200 );
 
 	nock( 'https://public-api.wordpress.com' )
 		.persist()

--- a/client/dashboard/sites/settings-wordpress/test/index.test.tsx
+++ b/client/dashboard/sites/settings-wordpress/test/index.test.tsx
@@ -27,24 +27,34 @@ const site = {
 	},
 } as Site;
 
-function mockSite( mockedSite: Site ) {
+function mockApi() {
 	nock( 'https://public-api.wordpress.com' )
-		.get( `/rest/v1.1/sites/${ mockedSite.slug }` )
+		.get( `/rest/v1.1/sites/${ site.slug }` )
 		.query( true )
-		.reply( 200, mockedSite );
-}
+		.reply( 200, site );
 
-function mockWordPressVersion( version: string ) {
 	nock( 'https://public-api.wordpress.com' )
 		.get( `/wpcom/v2/sites/${ site.ID }/hosting/wp-version` )
 		.query( true )
-		.reply( 200, version );
+		.reply( 200, 'latest' );
+
+	nock( 'https://public-api.wordpress.com' )
+		.persist()
+		.get( `/wpcom/v2/sites/${ site.ID }/hosting/wp-version/pending` )
+		.query( true )
+		.reply( 200, null );
+
+	nock( 'https://public-api.wordpress.com' )
+		.persist()
+		.get( `/wpcom/v2/sites/${ site.ID }/rewind/backups` )
+		.query( true )
+		.reply( 200, [] );
 }
 
 function mockWordPressVersionSaved( expectedVersion: string ) {
 	return nock( 'https://public-api.wordpress.com' )
 		.post( `/wpcom/v2/sites/${ site.ID }/hosting/wp-version`, ( body ) => {
-			expect( body ).toEqual( { version: expectedVersion } );
+			expect( body ).toMatchObject( { version: expectedVersion } );
 			return true;
 		} )
 		.reply( 200 );
@@ -54,8 +64,7 @@ describe( '<WordPressSettings>', () => {
 	test( 'renders and saves the form for a Business+ site', async () => {
 		const user = userEvent.setup();
 
-		mockSite( site );
-		mockWordPressVersion( 'latest' );
+		mockApi();
 
 		render( <WordPressSettings siteSlug={ site.slug } /> );
 		await screen.findByRole( 'heading', { name: 'WordPress' } );

--- a/client/dashboard/sites/settings-wordpress/test/index.test.tsx
+++ b/client/dashboard/sites/settings-wordpress/test/index.test.tsx
@@ -42,7 +42,7 @@ function mockApi() {
 		.persist()
 		.get( `/wpcom/v2/sites/${ site.ID }/hosting/wp-version/pending` )
 		.query( true )
-		.reply( 200 );
+		.reply( 200, null );
 
 	nock( 'https://public-api.wordpress.com' )
 		.persist()

--- a/client/dashboard/sites/settings-wordpress/test/index.test.tsx
+++ b/client/dashboard/sites/settings-wordpress/test/index.test.tsx
@@ -42,7 +42,7 @@ function mockApi() {
 		.persist()
 		.get( `/wpcom/v2/sites/${ site.ID }/hosting/wp-version/pending` )
 		.query( true )
-		.reply( 200, null );
+		.reply( 200, null as unknown as nock.Body );
 
 	nock( 'https://public-api.wordpress.com' )
 		.persist()

--- a/client/dashboard/sites/settings-wordpress/use-version-switch.ts
+++ b/client/dashboard/sites/settings-wordpress/use-version-switch.ts
@@ -55,12 +55,18 @@ export interface VersionSwitchState {
 }
 
 export function useVersionSwitch( site: Site ): VersionSwitchState {
+	const deferUntilBackupComplete =
+		isEnabled( 'dashboard/wp-beta-program' ) && ! site.is_wpcom_staging_site;
+
 	const backupState = useBackupState( site.ID );
 	const [ phase, dispatch ] = useReducer( reducer, { status: 'idle' } );
 
 	// Check if there's a pending version switch.
-	const { data: pendingVersion } = useQuery( sitePendingWordPressVersionQuery( site.ID ) );
-	const hasPendingVersion = !! pendingVersion;
+	const { data: pendingVersion } = useQuery( {
+		...sitePendingWordPressVersionQuery( site.ID ),
+		enabled: deferUntilBackupComplete,
+	} );
+	const hasPendingVersion = deferUntilBackupComplete && !! pendingVersion;
 	const hadPendingVersion = usePrevious( hasPendingVersion );
 
 	// Pending version appeared → switching. Also start backup tracking.
@@ -97,19 +103,20 @@ export function useVersionSwitch( site: Site ): VersionSwitchState {
 		refetchInterval: hasPendingVersion && backupState.hasRecentlyCompleted ? 5000 : false,
 	} );
 
-	const deferUntilBackupComplete = isEnabled( 'dashboard/wp-beta-program' );
-
 	const mutation = useMutation( {
 		...siteWordPressVersionMutation( site.ID, { deferUntilBackupComplete } ),
 		meta: {
 			snackbar: {
+				...( ! deferUntilBackupComplete && { success: __( 'WordPress version saved.' ) } ),
 				error: __( 'Failed to save WordPress version.' ),
 			},
 		},
 	} );
 
 	const switchVersion = ( version: string ) => {
-		dispatch( { type: 'VERSION_CHANGE_REQUESTED', targetVersion: version } );
+		if ( deferUntilBackupComplete ) {
+			dispatch( { type: 'VERSION_CHANGE_REQUESTED', targetVersion: version } );
+		}
 		mutation.mutate( version );
 	};
 

--- a/client/dashboard/sites/settings-wordpress/use-version-switch.ts
+++ b/client/dashboard/sites/settings-wordpress/use-version-switch.ts
@@ -77,6 +77,9 @@ export function useVersionSwitch( site: Site ): VersionSwitchState {
 			dispatch( { type: 'SWITCH_COMPLETED' } );
 			queryClient.invalidateQueries( siteWordPressVersionQuery( site.ID ) );
 			queryClient.invalidateQueries( siteBySlugQuery( site.slug ) );
+			queryClient.invalidateQueries( {
+				queryKey: [ 'site', site.ID, 'backup-activity-log' ],
+			} );
 		}
 	}, [ hadPendingVersion, hasPendingVersion, site.ID, site.slug ] );
 

--- a/client/dashboard/sites/settings-wordpress/use-version-switch.ts
+++ b/client/dashboard/sites/settings-wordpress/use-version-switch.ts
@@ -6,69 +6,98 @@ import {
 	siteWordPressVersionQuery,
 	siteWordPressVersionMutation,
 } from '@automattic/api-queries';
+import { isEnabled } from '@automattic/calypso-config';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { usePrevious } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { useEffect, useState } from 'react';
+import { useEffect, useReducer } from 'react';
 import { useBackupState } from '../backups/use-backup-state';
 import type { BackupState } from '../backups/use-backup-state';
 import type { Site } from '@automattic/api-core';
 
+export type Phase =
+	| { status: 'idle' }
+	| { status: 'submitting'; targetVersion: string }
+	| { status: 'switching'; targetVersion: string }
+	| { status: 'switched'; targetVersion: string };
+
+type Action =
+	| { type: 'VERSION_CHANGE_REQUESTED'; targetVersion: string }
+	| { type: 'SWITCH_STARTED'; targetVersion: string }
+	| { type: 'SWITCH_COMPLETED' };
+
+export function reducer( state: Phase, action: Action ): Phase {
+	switch ( action.type ) {
+		case 'VERSION_CHANGE_REQUESTED':
+			return { status: 'submitting', targetVersion: action.targetVersion };
+		case 'SWITCH_STARTED':
+			return { status: 'switching', targetVersion: action.targetVersion };
+		case 'SWITCH_COMPLETED':
+			if ( state.status !== 'switching' ) {
+				return state;
+			}
+			return { status: 'switched', targetVersion: state.targetVersion };
+		default:
+			return state;
+	}
+}
+
 export interface VersionSwitchState {
 	backupState: BackupState;
-	/** The pending version tag while switching, or the last one after switch completes. */
 	targetVersion: string;
+	pendingVersion: string | null | undefined;
 	isSwitching: boolean;
 	isSwitched: boolean;
-	mutation: ReturnType< typeof useMutation< void, Error, string > >;
+	switchedToBeta: boolean;
+	switchedToLatest: boolean;
+	switchVersion: ( version: string ) => void;
+	isSaving: boolean;
 }
 
 export function useVersionSwitch( site: Site ): VersionSwitchState {
 	const backupState = useBackupState( site.ID );
+	const [ phase, dispatch ] = useReducer( reducer, { status: 'idle' } );
 
 	// Check if there's a pending version switch.
 	const { data: pendingVersion } = useQuery( sitePendingWordPressVersionQuery( site.ID ) );
-	const isSwitching = !! pendingVersion;
-	const wasSwitching = usePrevious( isSwitching );
-	const [ isSwitched, setIsSwitched ] = useState( false );
-	const [ targetVersion, setTargetVersion ] = useState( '' );
+	const hasPendingVersion = !! pendingVersion;
+	const hadPendingVersion = usePrevious( hasPendingVersion );
 
-	// Remember the pending version so we can show it in the success notice.
+	// Pending version appeared → switching. Also start backup tracking.
 	useEffect( () => {
 		if ( pendingVersion ) {
-			setTargetVersion( pendingVersion );
+			backupState.setEnqueued( true );
+			dispatch( { type: 'SWITCH_STARTED', targetVersion: pendingVersion } );
 		}
-	}, [ pendingVersion ] );
+	}, [ pendingVersion ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
-	// Track the transition from switching to not switching.
+	// Pending version cleared → switched.
 	useEffect( () => {
-		if ( wasSwitching && ! isSwitching ) {
-			setIsSwitched( true );
+		if ( hadPendingVersion && ! hasPendingVersion ) {
+			dispatch( { type: 'SWITCH_COMPLETED' } );
 			queryClient.invalidateQueries( siteWordPressVersionQuery( site.ID ) );
 			queryClient.invalidateQueries( siteBySlugQuery( site.slug ) );
 		}
-	}, [ wasSwitching, isSwitching, site.ID, site.slug ] );
+	}, [ hadPendingVersion, hasPendingVersion, site.ID, site.slug ] );
 
-	// Poll backups while a version switch is in progress.
+	// Poll backups while a version switch is in progress (including right after mutation fires).
+	const shouldPollBackups = phase.status === 'submitting' || hasPendingVersion;
 	useQuery( {
 		...siteBackupsQuery( site.ID ),
-		refetchInterval: isSwitching ? 3000 : false,
-		enabled: isSwitching,
+		refetchInterval: shouldPollBackups ? 3000 : false,
+		enabled: shouldPollBackups,
 	} );
 
 	// After backup completes, poll pending version until it clears.
 	useQuery( {
 		...sitePendingWordPressVersionQuery( site.ID ),
-		refetchInterval: isSwitching && backupState.hasRecentlyCompleted ? 5000 : false,
+		refetchInterval: hasPendingVersion && backupState.hasRecentlyCompleted ? 5000 : false,
 	} );
 
+	const deferUntilBackupComplete = isEnabled( 'dashboard/wp-beta-program' );
+
 	const mutation = useMutation( {
-		...siteWordPressVersionMutation( site.ID ),
-		onSuccess: () => {
-			backupState.setEnqueued( true );
-			setIsSwitched( false );
-			queryClient.invalidateQueries( sitePendingWordPressVersionQuery( site.ID ) );
-		},
+		...siteWordPressVersionMutation( site.ID, { deferUntilBackupComplete } ),
 		meta: {
 			snackbar: {
 				error: __( 'Failed to save WordPress version.' ),
@@ -76,11 +105,23 @@ export function useVersionSwitch( site: Site ): VersionSwitchState {
 		},
 	} );
 
+	const switchVersion = ( version: string ) => {
+		dispatch( { type: 'VERSION_CHANGE_REQUESTED', targetVersion: version } );
+		mutation.mutate( version );
+	};
+
+	const targetVersion = phase.status !== 'idle' ? phase.targetVersion : '';
+	const isSwitched = phase.status === 'switched';
+
 	return {
 		backupState,
 		targetVersion,
-		isSwitching,
+		pendingVersion,
+		isSwitching: phase.status === 'submitting' || phase.status === 'switching',
 		isSwitched,
-		mutation,
+		switchedToBeta: isSwitched && phase.targetVersion === 'beta',
+		switchedToLatest: isSwitched && phase.targetVersion === 'latest',
+		switchVersion,
+		isSaving: mutation.isPending,
 	};
 }

--- a/client/dashboard/sites/settings-wordpress/use-version-switch.ts
+++ b/client/dashboard/sites/settings-wordpress/use-version-switch.ts
@@ -1,0 +1,86 @@
+import {
+	queryClient,
+	siteBackupsQuery,
+	siteBySlugQuery,
+	sitePendingWordPressVersionQuery,
+	siteWordPressVersionQuery,
+	siteWordPressVersionMutation,
+} from '@automattic/api-queries';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { usePrevious } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+import { useEffect, useState } from 'react';
+import { useBackupState } from '../backups/use-backup-state';
+import type { BackupState } from '../backups/use-backup-state';
+import type { Site } from '@automattic/api-core';
+
+export interface VersionSwitchState {
+	backupState: BackupState;
+	/** The pending version tag while switching, or the last one after switch completes. */
+	targetVersion: string;
+	isSwitching: boolean;
+	isSwitched: boolean;
+	mutation: ReturnType< typeof useMutation< void, Error, string > >;
+}
+
+export function useVersionSwitch( site: Site ): VersionSwitchState {
+	const backupState = useBackupState( site.ID );
+
+	// Check if there's a pending version switch.
+	const { data: pendingVersion } = useQuery( sitePendingWordPressVersionQuery( site.ID ) );
+	const isSwitching = !! pendingVersion;
+	const wasSwitching = usePrevious( isSwitching );
+	const [ isSwitched, setIsSwitched ] = useState( false );
+	const [ targetVersion, setTargetVersion ] = useState( '' );
+
+	// Remember the pending version so we can show it in the success notice.
+	useEffect( () => {
+		if ( pendingVersion ) {
+			setTargetVersion( pendingVersion );
+		}
+	}, [ pendingVersion ] );
+
+	// Track the transition from switching to not switching.
+	useEffect( () => {
+		if ( wasSwitching && ! isSwitching ) {
+			setIsSwitched( true );
+			queryClient.invalidateQueries( siteWordPressVersionQuery( site.ID ) );
+			queryClient.invalidateQueries( siteBySlugQuery( site.slug ) );
+		}
+	}, [ wasSwitching, isSwitching, site.ID, site.slug ] );
+
+	// Poll backups while a version switch is in progress.
+	useQuery( {
+		...siteBackupsQuery( site.ID ),
+		refetchInterval: isSwitching ? 3000 : false,
+		enabled: isSwitching,
+	} );
+
+	// After backup completes, poll pending version until it clears.
+	useQuery( {
+		...sitePendingWordPressVersionQuery( site.ID ),
+		refetchInterval: isSwitching && backupState.hasRecentlyCompleted ? 5000 : false,
+	} );
+
+	const mutation = useMutation( {
+		...siteWordPressVersionMutation( site.ID ),
+		onSuccess: () => {
+			backupState.setEnqueued( true );
+			setIsSwitched( false );
+			queryClient.invalidateQueries( sitePendingWordPressVersionQuery( site.ID ) );
+		},
+		meta: {
+			snackbar: {
+				error: __( 'Failed to save WordPress version.' ),
+			},
+		},
+	} );
+
+	return {
+		backupState,
+		targetVersion,
+		isSwitching,
+		isSwitched,
+		mutation,
+	};
+}

--- a/client/dashboard/sites/settings-wordpress/version-form.tsx
+++ b/client/dashboard/sites/settings-wordpress/version-form.tsx
@@ -1,77 +1,28 @@
-import {
-	queryClient,
-	siteBackupsQuery,
-	sitePendingWordPressVersionQuery,
-	siteWordPressVersionQuery,
-	siteWordPressVersionMutation,
-	wpOrgCoreVersionQuery,
-} from '@automattic/api-queries';
-import { useQuery, useMutation } from '@tanstack/react-query';
+import { wpOrgCoreVersionQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack, Button } from '@wordpress/components';
 import { DataForm } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import { NavigationBlocker } from '../../app/navigation-blocker';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import { formatWordPressVersion } from '../../utils/wp-version';
-import { useBackupState } from '../backups/use-backup-state';
-import { VersionSwitchNotice } from './version-switch-notice';
+import type { VersionSwitchState } from './use-version-switch';
 import type { Site } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
 
 interface VersionFormProps {
 	site: Site;
 	currentVersion: string | undefined;
+	versionSwitch: VersionSwitchState;
 }
 
-export function VersionForm( { site, currentVersion }: VersionFormProps ) {
+export function VersionForm( { site, currentVersion, versionSwitch }: VersionFormProps ) {
 	const { data: latestVersion } = useQuery( wpOrgCoreVersionQuery() );
 	const { data: betaVersion } = useQuery( wpOrgCoreVersionQuery( 'beta' ) );
 
-	const backupState = useBackupState( site.ID );
-
-	// Check if there's a pending version switch.
-	const { data: pendingVersion } = useQuery( sitePendingWordPressVersionQuery( site.ID ) );
-	const isSwitching = !! pendingVersion;
-	const wasSwitchingRef = useRef( false );
-	const [ isSwitched, setIsSwitched ] = useState( false );
-
-	// Track the transition from switching to not switching.
-	useEffect( () => {
-		if ( wasSwitchingRef.current && ! isSwitching ) {
-			setIsSwitched( true );
-			queryClient.invalidateQueries( siteWordPressVersionQuery( site.ID ) );
-		}
-		wasSwitchingRef.current = isSwitching;
-	}, [ isSwitching, site.ID ] );
-
-	// Poll backups while a version switch is in progress.
-	useQuery( {
-		...siteBackupsQuery( site.ID ),
-		refetchInterval: isSwitching ? 3000 : false,
-		enabled: isSwitching,
-	} );
-
-	// After backup completes, poll pending version until it clears.
-	useQuery( {
-		...sitePendingWordPressVersionQuery( site.ID ),
-		refetchInterval: isSwitching && backupState.hasRecentlyCompleted ? 5000 : false,
-	} );
-
-	const mutation = useMutation( {
-		...siteWordPressVersionMutation( site.ID ),
-		onSuccess: () => {
-			backupState.setEnqueued( true );
-			setIsSwitched( false );
-			queryClient.invalidateQueries( sitePendingWordPressVersionQuery( site.ID ) );
-		},
-		meta: {
-			snackbar: {
-				error: __( 'Failed to save WordPress version.' ),
-			},
-		},
-	} );
+	const { isSwitching, mutation } = versionSwitch;
 
 	const [ formData, setFormData ] = useState< { version: string } >( {
 		version: currentVersion ?? '',
@@ -111,43 +62,34 @@ export function VersionForm( { site, currentVersion }: VersionFormProps ) {
 	};
 
 	return (
-		<>
-			{ ( isSwitching || isSwitched ) && (
-				<VersionSwitchNotice
-					backupState={ backupState }
-					targetVersion={ pendingVersion ?? '' }
-					isVersionSwitched={ isSwitched }
-				/>
-			) }
-			<Card>
-				<CardBody>
-					<form onSubmit={ handleSubmit }>
-						<fieldset disabled={ isSwitching } style={ { border: 0, margin: 0, padding: 0 } }>
-							<VStack spacing={ 4 }>
-								<NavigationBlocker shouldBlock={ isDirty } />
-								<DataForm< { version: string } >
-									data={ formData }
-									fields={ fields }
-									form={ form }
-									onChange={ ( edits: { version?: string } ) => {
-										setFormData( ( data ) => ( { ...data, ...edits } ) );
-									} }
-								/>
-								<ButtonStack justify="flex-start">
-									<Button
-										variant="primary"
-										type="submit"
-										isBusy={ isPending }
-										disabled={ isPending || ! isDirty || isSwitching }
-									>
-										{ __( 'Save' ) }
-									</Button>
-								</ButtonStack>
-							</VStack>
-						</fieldset>
-					</form>
-				</CardBody>
-			</Card>
-		</>
+		<Card>
+			<CardBody>
+				<form onSubmit={ handleSubmit }>
+					<fieldset disabled={ isSwitching } style={ { border: 0, margin: 0, padding: 0 } }>
+						<VStack spacing={ 4 }>
+							<NavigationBlocker shouldBlock={ isDirty } />
+							<DataForm< { version: string } >
+								data={ formData }
+								fields={ fields }
+								form={ form }
+								onChange={ ( edits: { version?: string } ) => {
+									setFormData( ( data ) => ( { ...data, ...edits } ) );
+								} }
+							/>
+							<ButtonStack justify="flex-start">
+								<Button
+									variant="primary"
+									type="submit"
+									isBusy={ isPending }
+									disabled={ isPending || ! isDirty || isSwitching }
+								>
+									{ __( 'Save' ) }
+								</Button>
+							</ButtonStack>
+						</VStack>
+					</fieldset>
+				</form>
+			</CardBody>
+		</Card>
 	);
 }

--- a/client/dashboard/sites/settings-wordpress/version-form.tsx
+++ b/client/dashboard/sites/settings-wordpress/version-form.tsx
@@ -22,11 +22,15 @@ export function VersionForm( { site, currentVersion, versionSwitch }: VersionFor
 	const { data: latestVersion } = useQuery( wpOrgCoreVersionQuery() );
 	const { data: betaVersion } = useQuery( wpOrgCoreVersionQuery( 'beta' ) );
 
-	const { isSwitching, mutation } = versionSwitch;
+	const { isSwitching, pendingVersion, switchVersion, isSaving } = versionSwitch;
 
-	const [ formData, setFormData ] = useState< { version: string } >( {
-		version: currentVersion ?? '',
+	const [ formEdits, setFormEdits ] = useState< { version: string } >( {
+		version: '',
 	} );
+
+	const formData = {
+		version: formEdits.version || pendingVersion || currentVersion || '',
+	};
 
 	const currentWpVersion = site.options?.software_version ?? '';
 
@@ -54,11 +58,10 @@ export function VersionForm( { site, currentVersion, versionSwitch }: VersionFor
 	};
 
 	const isDirty = formData.version !== currentVersion;
-	const { isPending } = mutation;
 
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
-		mutation.mutate( formData.version );
+		switchVersion( formData.version );
 	};
 
 	return (
@@ -73,15 +76,15 @@ export function VersionForm( { site, currentVersion, versionSwitch }: VersionFor
 								fields={ fields }
 								form={ form }
 								onChange={ ( edits: { version?: string } ) => {
-									setFormData( ( data ) => ( { ...data, ...edits } ) );
+									setFormEdits( ( data ) => ( { ...data, ...edits } ) );
 								} }
 							/>
 							<ButtonStack justify="flex-start">
 								<Button
 									variant="primary"
 									type="submit"
-									isBusy={ isPending }
-									disabled={ isPending || ! isDirty || isSwitching }
+									isBusy={ isSaving }
+									disabled={ isSaving || ! isDirty || isSwitching }
 								>
 									{ __( 'Save' ) }
 								</Button>

--- a/client/dashboard/sites/settings-wordpress/version-form.tsx
+++ b/client/dashboard/sites/settings-wordpress/version-form.tsx
@@ -1,0 +1,153 @@
+import {
+	queryClient,
+	siteBackupsQuery,
+	sitePendingWordPressVersionQuery,
+	siteWordPressVersionQuery,
+	siteWordPressVersionMutation,
+	wpOrgCoreVersionQuery,
+} from '@automattic/api-queries';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { __experimentalVStack as VStack, Button } from '@wordpress/components';
+import { DataForm } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { useEffect, useRef, useState } from 'react';
+import { NavigationBlocker } from '../../app/navigation-blocker';
+import { ButtonStack } from '../../components/button-stack';
+import { Card, CardBody } from '../../components/card';
+import { formatWordPressVersion } from '../../utils/wp-version';
+import { useBackupState } from '../backups/use-backup-state';
+import { VersionSwitchNotice } from './version-switch-notice';
+import type { Site } from '@automattic/api-core';
+import type { Field } from '@wordpress/dataviews';
+
+interface VersionFormProps {
+	site: Site;
+	currentVersion: string | undefined;
+}
+
+export function VersionForm( { site, currentVersion }: VersionFormProps ) {
+	const { data: latestVersion } = useQuery( wpOrgCoreVersionQuery() );
+	const { data: betaVersion } = useQuery( wpOrgCoreVersionQuery( 'beta' ) );
+
+	const backupState = useBackupState( site.ID );
+
+	// Check if there's a pending version switch.
+	const { data: pendingVersion } = useQuery( sitePendingWordPressVersionQuery( site.ID ) );
+	const isSwitching = !! pendingVersion;
+	const wasSwitchingRef = useRef( false );
+	const [ isSwitched, setIsSwitched ] = useState( false );
+
+	// Track the transition from switching to not switching.
+	useEffect( () => {
+		if ( wasSwitchingRef.current && ! isSwitching ) {
+			setIsSwitched( true );
+			queryClient.invalidateQueries( siteWordPressVersionQuery( site.ID ) );
+		}
+		wasSwitchingRef.current = isSwitching;
+	}, [ isSwitching, site.ID ] );
+
+	// Poll backups while a version switch is in progress.
+	useQuery( {
+		...siteBackupsQuery( site.ID ),
+		refetchInterval: isSwitching ? 3000 : false,
+		enabled: isSwitching,
+	} );
+
+	// After backup completes, poll pending version until it clears.
+	useQuery( {
+		...sitePendingWordPressVersionQuery( site.ID ),
+		refetchInterval: isSwitching && backupState.hasRecentlyCompleted ? 5000 : false,
+	} );
+
+	const mutation = useMutation( {
+		...siteWordPressVersionMutation( site.ID ),
+		onSuccess: () => {
+			backupState.setEnqueued( true );
+			setIsSwitched( false );
+			queryClient.invalidateQueries( sitePendingWordPressVersionQuery( site.ID ) );
+		},
+		meta: {
+			snackbar: {
+				error: __( 'Failed to save WordPress version.' ),
+			},
+		},
+	} );
+
+	const [ formData, setFormData ] = useState< { version: string } >( {
+		version: currentVersion ?? '',
+	} );
+
+	const currentWpVersion = site.options?.software_version ?? '';
+
+	const fields: Field< { version: string } >[] = [
+		{
+			id: 'version',
+			label: __( 'WordPress version' ),
+			Edit: 'select',
+			elements: [
+				{
+					value: 'latest',
+					label: formatWordPressVersion( latestVersion ?? currentWpVersion, 'latest', true ),
+				},
+				{
+					value: 'beta',
+					label: formatWordPressVersion( betaVersion ?? currentWpVersion, 'beta', true ),
+				},
+			],
+		},
+	];
+
+	const form = {
+		layout: { type: 'regular' as const },
+		fields: [ 'version' ],
+	};
+
+	const isDirty = formData.version !== currentVersion;
+	const { isPending } = mutation;
+
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+		mutation.mutate( formData.version );
+	};
+
+	return (
+		<>
+			{ ( isSwitching || isSwitched ) && (
+				<VersionSwitchNotice
+					backupState={ backupState }
+					targetVersion={ pendingVersion ?? '' }
+					isVersionSwitched={ isSwitched }
+				/>
+			) }
+			<Card>
+				<CardBody>
+					<form onSubmit={ handleSubmit }>
+						<fieldset disabled={ isSwitching } style={ { border: 0, margin: 0, padding: 0 } }>
+							<VStack spacing={ 4 }>
+								<NavigationBlocker shouldBlock={ isDirty } />
+								<DataForm< { version: string } >
+									data={ formData }
+									fields={ fields }
+									form={ form }
+									onChange={ ( edits: { version?: string } ) => {
+										setFormData( ( data ) => ( { ...data, ...edits } ) );
+									} }
+								/>
+								<ButtonStack justify="flex-start">
+									<Button
+										variant="primary"
+										type="submit"
+										isBusy={ isPending }
+										disabled={ isPending || ! isDirty || isSwitching }
+									>
+										{ __( 'Save' ) }
+									</Button>
+								</ButtonStack>
+							</VStack>
+						</fieldset>
+					</form>
+				</CardBody>
+			</Card>
+		</>
+	);
+}

--- a/client/dashboard/sites/settings-wordpress/version-form.tsx
+++ b/client/dashboard/sites/settings-wordpress/version-form.tsx
@@ -83,7 +83,7 @@ export function VersionForm( { site, currentVersion, versionSwitch }: VersionFor
 								<Button
 									variant="primary"
 									type="submit"
-									isBusy={ isSaving }
+									isBusy={ isSaving || isSwitching }
 									disabled={ isSaving || ! isDirty || isSwitching }
 								>
 									{ __( 'Save' ) }

--- a/client/dashboard/sites/settings-wordpress/version-switch-notice.tsx
+++ b/client/dashboard/sites/settings-wordpress/version-switch-notice.tsx
@@ -1,0 +1,85 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { Notice } from '../../components/notice';
+import type { BackupState } from '../backups/use-backup-state';
+
+interface VersionSwitchNoticeProps {
+	backupState: BackupState;
+	targetVersion: string;
+	isVersionChanged: boolean;
+}
+
+export function VersionSwitchNotice( {
+	backupState,
+	targetVersion,
+	isVersionChanged,
+}: VersionSwitchNoticeProps ) {
+	const { status, backup } = backupState;
+
+	if ( isVersionChanged ) {
+		return (
+			<Notice variant="success" title={ __( 'WordPress version updated' ) }>
+				{ sprintf(
+					// translators: %s: WordPress version, e.g. "7.0-RC2"
+					__( 'Your site is now running WordPress %s.' ),
+					targetVersion
+				) }
+			</Notice>
+		);
+	}
+
+	if ( status === 'enqueued' ) {
+		return (
+			<Notice
+				variant="info"
+				title={ sprintf(
+					// translators: %s: WordPress version, e.g. "7.0-RC2"
+					__( 'Switching to WordPress %s…' ),
+					targetVersion
+				) }
+			>
+				{ __( 'Creating a backup of your site before switching.' ) }
+			</Notice>
+		);
+	}
+
+	if ( status === 'running' ) {
+		return (
+			<Notice
+				variant="info"
+				title={ sprintf(
+					// translators: %1$s: WordPress version, %2$s: backup progress percentage
+					__( 'Switching to WordPress %1$s… (%2$s%% backup progress)' ),
+					targetVersion,
+					backup?.percent ?? '0'
+				) }
+			>
+				{ __( 'A backup is being created before switching. This may take a few minutes.' ) }
+			</Notice>
+		);
+	}
+
+	if ( status === 'success' ) {
+		return (
+			<Notice
+				variant="info"
+				title={ sprintf(
+					// translators: %s: WordPress version, e.g. "7.0-RC2"
+					__( 'Switching to WordPress %s…' ),
+					targetVersion
+				) }
+			>
+				{ __( 'Backup completed. Now switching WordPress version…' ) }
+			</Notice>
+		);
+	}
+
+	if ( status === 'error' ) {
+		return (
+			<Notice variant="error" title={ __( 'Version switch failed' ) }>
+				{ __( 'The backup could not be completed. Please try again or contact support.' ) }
+			</Notice>
+		);
+	}
+
+	return null;
+}

--- a/client/dashboard/sites/settings-wordpress/version-switch-notice.tsx
+++ b/client/dashboard/sites/settings-wordpress/version-switch-notice.tsx
@@ -5,17 +5,17 @@ import type { BackupState } from '../backups/use-backup-state';
 interface VersionSwitchNoticeProps {
 	backupState: BackupState;
 	targetVersion: string;
-	isVersionChanged: boolean;
+	isVersionSwitched: boolean;
 }
 
 export function VersionSwitchNotice( {
 	backupState,
 	targetVersion,
-	isVersionChanged,
+	isVersionSwitched,
 }: VersionSwitchNoticeProps ) {
 	const { status, backup } = backupState;
 
-	if ( isVersionChanged ) {
+	if ( isVersionSwitched ) {
 		return (
 			<Notice variant="success" title={ __( 'WordPress version updated' ) }>
 				{ sprintf(

--- a/client/dashboard/sites/settings-wordpress/version-switch-notice.tsx
+++ b/client/dashboard/sites/settings-wordpress/version-switch-notice.tsx
@@ -47,13 +47,18 @@ export function VersionSwitchNotice( {
 			<Notice
 				variant="info"
 				title={ sprintf(
-					// translators: %1$s: WordPress version, %2$s: backup progress percentage
-					__( 'Switching to WordPress %1$s… (%2$s%% backup progress)' ),
-					targetVersion,
-					backup?.percent ?? '0'
+					// translators: %s: WordPress version, e.g. "7.0-RC2"
+					__( 'Switching to WordPress %s…' ),
+					targetVersion
 				) }
 			>
-				{ __( 'A backup is being created before switching. This may take a few minutes.' ) }
+				{ sprintf(
+					// translators: %s: backup progress percentage
+					__(
+						'Generating backup… (%s%% progress). A backup is being created before switching. This may take a few minutes.'
+					),
+					backup?.percent ?? '0'
+				) }
 			</Notice>
 		);
 	}

--- a/client/dashboard/sites/settings-wordpress/version-switch-notice.tsx
+++ b/client/dashboard/sites/settings-wordpress/version-switch-notice.tsx
@@ -5,29 +5,10 @@ import type { BackupState } from '../backups/use-backup-state';
 interface VersionSwitchNoticeProps {
 	backupState: BackupState;
 	targetVersion: string;
-	currentWpVersion: string;
-	isVersionSwitched: boolean;
 }
 
-export function VersionSwitchNotice( {
-	backupState,
-	targetVersion,
-	currentWpVersion,
-	isVersionSwitched,
-}: VersionSwitchNoticeProps ) {
+export function VersionSwitchNotice( { backupState, targetVersion }: VersionSwitchNoticeProps ) {
 	const { status, backup } = backupState;
-
-	if ( isVersionSwitched ) {
-		return (
-			<Notice variant="success" title={ __( 'WordPress version updated' ) }>
-				{ sprintf(
-					// translators: %s: WordPress version, e.g. "7.0-RC2"
-					__( 'Your site is now running WordPress %s.' ),
-					currentWpVersion
-				) }
-			</Notice>
-		);
-	}
 
 	if ( status === 'enqueued' ) {
 		return (

--- a/client/dashboard/sites/settings-wordpress/version-switch-notice.tsx
+++ b/client/dashboard/sites/settings-wordpress/version-switch-notice.tsx
@@ -5,12 +5,14 @@ import type { BackupState } from '../backups/use-backup-state';
 interface VersionSwitchNoticeProps {
 	backupState: BackupState;
 	targetVersion: string;
+	currentWpVersion: string;
 	isVersionSwitched: boolean;
 }
 
 export function VersionSwitchNotice( {
 	backupState,
 	targetVersion,
+	currentWpVersion,
 	isVersionSwitched,
 }: VersionSwitchNoticeProps ) {
 	const { status, backup } = backupState;
@@ -21,7 +23,7 @@ export function VersionSwitchNotice( {
 				{ sprintf(
 					// translators: %s: WordPress version, e.g. "7.0-RC2"
 					__( 'Your site is now running WordPress %s.' ),
-					targetVersion
+					currentWpVersion
 				) }
 			</Notice>
 		);
@@ -86,5 +88,17 @@ export function VersionSwitchNotice( {
 		);
 	}
 
-	return null;
+	// Fallback for 'idle' state — pending version exists but backup hasn't started yet.
+	return (
+		<Notice
+			variant="info"
+			title={ sprintf(
+				// translators: %s: WordPress version, e.g. "7.0-RC2"
+				__( 'Switching to WordPress %s…' ),
+				targetVersion
+			) }
+		>
+			{ __( 'Preparing to switch WordPress version…' ) }
+		</Notice>
+	);
 }

--- a/packages/api-core/src/site-hosting/fetchers.ts
+++ b/packages/api-core/src/site-hosting/fetchers.ts
@@ -8,6 +8,13 @@ export async function fetchWordPressVersion( siteId: number ): Promise< string >
 	} );
 }
 
+export async function fetchPendingWordPressVersion( siteId: number ): Promise< string | null > {
+	return wpcom.req.get( {
+		path: `/sites/${ siteId }/hosting/wp-version/pending`,
+		apiNamespace: 'wpcom/v2',
+	} );
+}
+
 export async function fetchPHPVersion( siteId: number ): Promise< string > {
 	return wpcom.req.get( {
 		path: `/sites/${ siteId }/hosting/php-version`,

--- a/packages/api-core/src/site-hosting/mutators.ts
+++ b/packages/api-core/src/site-hosting/mutators.ts
@@ -34,13 +34,20 @@ export async function restoreSitePlanSoftware( siteId: number ) {
 	} );
 }
 
-export async function updateWordPressVersion( siteId: number, version: string ) {
+export async function updateWordPressVersion(
+	siteId: number,
+	version: string,
+	deferUntilBackupComplete?: boolean
+) {
 	return wpcom.req.post(
 		{
 			path: `/sites/${ siteId }/hosting/wp-version`,
 			apiNamespace: 'wpcom/v2',
 		},
-		{ version }
+		{
+			version,
+			...( deferUntilBackupComplete && { defer_until_backup_complete: true } ),
+		}
 	);
 }
 

--- a/packages/api-queries/src/site-wordpress-version.ts
+++ b/packages/api-queries/src/site-wordpress-version.ts
@@ -1,4 +1,8 @@
-import { fetchWordPressVersion, updateWordPressVersion } from '@automattic/api-core';
+import {
+	fetchWordPressVersion,
+	fetchPendingWordPressVersion,
+	updateWordPressVersion,
+} from '@automattic/api-core';
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { queryClient } from './query-client';
 
@@ -8,10 +12,17 @@ export const siteWordPressVersionQuery = ( siteId: number ) =>
 		queryFn: () => fetchWordPressVersion( siteId ),
 	} );
 
+export const sitePendingWordPressVersionQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'wp-version', 'pending' ],
+		queryFn: () => fetchPendingWordPressVersion( siteId ),
+	} );
+
 export const siteWordPressVersionMutation = ( siteId: number ) =>
 	mutationOptions( {
 		mutationFn: ( version: string ) => updateWordPressVersion( siteId, version ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( siteWordPressVersionQuery( siteId ) );
+			queryClient.invalidateQueries( sitePendingWordPressVersionQuery( siteId ) );
 		},
 	} );

--- a/packages/api-queries/src/site-wordpress-version.ts
+++ b/packages/api-queries/src/site-wordpress-version.ts
@@ -18,9 +18,13 @@ export const sitePendingWordPressVersionQuery = ( siteId: number ) =>
 		queryFn: () => fetchPendingWordPressVersion( siteId ),
 	} );
 
-export const siteWordPressVersionMutation = ( siteId: number ) =>
+export const siteWordPressVersionMutation = (
+	siteId: number,
+	options?: { deferUntilBackupComplete?: boolean }
+) =>
 	mutationOptions( {
-		mutationFn: ( version: string ) => updateWordPressVersion( siteId, version ),
+		mutationFn: ( version: string ) =>
+			updateWordPressVersion( siteId, version, options?.deferUntilBackupComplete ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( siteWordPressVersionQuery( siteId ) );
 			queryClient.invalidateQueries( sitePendingWordPressVersionQuery( siteId ) );


### PR DESCRIPTION
Fixes DOTCOM-16577


## Summary

- When switching WordPress version, show contextual notices tracking the full lifecycle: backup queuing → backup progress → switching version → success/error
- Keep the Save button disabled throughout the switch
- After backup completes, poll the WP version endpoint until the switch is confirmed
- Reuses existing `useBackupState` hook for backup lifecycle tracking

Depends on: #109747

Demo

https://github.com/user-attachments/assets/d1760ce8-becb-43c2-b1b4-7bc09017947e

## Test plan

- [ ] Apply 210270-ghe-Automattic/wpcom to your sandbox, and sandbox your API
- [ ] Navigate to a staging site's WordPress settings
- [ ] Change the version from Latest to Beta (or vice versa) and click Save
- [ ] Verify "Switching to WordPress X..." notice appears while backup queues
- [ ] Verify progress percentage updates as backup runs
- [ ] Verify "Backup completed. Now switching..." appears after backup finishes
- [ ] Follow instructions on 210270-ghe-Automattic/wpcom to trigger the action
- [ ] Verify "Your site is now running WordPress X." appears once version changes
- [ ] Verify the Save button is disabled throughout the switch
- [ ] Verify error notice appears if backup fails

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)