### PR TITLE
Image Studio: Skip grid view override when free AI credits exhausted

### DIFF
--- a/packages/image-studio/src/index.tsx
+++ b/packages/image-studio/src/index.tsx
@@ -1,10 +1,9 @@
 /**
  * WordPress dependencies
  */
-import apiFetch from '@wordpress/api-fetch';
 import { store as coreStore } from '@wordpress/core-data';
 import { select, useDispatch, useSelect } from '@wordpress/data';
-import { createRoot, useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import { createRoot, useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import ImageStudio from './components';
 import { registerBlockEditorFilters } from './extensions';
@@ -92,26 +91,9 @@ function ImageStudioIntegration(): JSX.Element | null {
 
 	const [ image, setImage ] = useState< ImageData | null >( null );
 
-	// Track whether the user has exhausted free Jetpack AI credits (free tier only).
-	// Uses a ref so the click handler always reads the latest value without needing
-	// to re-register the document click listener on every credit check.
-	const requireUpgradeRef = useRef( false );
-
-	useEffect( () => {
-		apiFetch< {
-			'site-require-upgrade': boolean;
-			'current-tier': { value: number };
-		} >( { path: '/wpcom/v2/jetpack-ai/ai-assistant-feature' } )
-			.then( ( response ) => {
-				const siteRequiresUpgrade = response?.[ 'site-require-upgrade' ] === true;
-				const isFreeTier = response?.[ 'current-tier' ]?.value === 0;
-				requireUpgradeRef.current = siteRequiresUpgrade && isFreeTier;
-			} )
-			.catch( () => {
-				// If the API call fails, default to allowing Image Studio.
-				requireUpgradeRef.current = false;
-			} );
-	}, [] );
+	// Big Sky (WordPress.com AI Assistant) sets window.bigSkyInitialState when its
+	// plugin is active. The grid-view override should only apply for Big Sky subscribers.
+	const isBigSkyEnabled = typeof ( window as any ).bigSkyInitialState !== 'undefined';
 
 	// Check for unsaved changes
 	const hasUnsavedChanges = useSelect(
@@ -196,9 +178,9 @@ function ImageStudioIntegration(): JSX.Element | null {
 					}
 				}
 
-				// Don't override grid clicks when free AI credits are exhausted.
-				// Let the legacy media editor handle it instead.
-				if ( requireUpgradeRef.current ) {
+				// Only override grid clicks for Big Sky subscribers.
+				// Non-subscribers fall through to the legacy media editor.
+				if ( ! isBigSkyEnabled ) {
 					return;
 				}
 

--- a/packages/image-studio/src/index.tsx
+++ b/packages/image-studio/src/index.tsx
@@ -1,9 +1,10 @@
 /**
  * WordPress dependencies
  */
+import apiFetch from '@wordpress/api-fetch';
 import { store as coreStore } from '@wordpress/core-data';
 import { select, useDispatch, useSelect } from '@wordpress/data';
-import { createRoot, useCallback, useEffect, useState } from '@wordpress/element';
+import { createRoot, useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import ImageStudio from './components';
 import { registerBlockEditorFilters } from './extensions';
@@ -91,6 +92,27 @@ function ImageStudioIntegration(): JSX.Element | null {
 
 	const [ image, setImage ] = useState< ImageData | null >( null );
 
+	// Track whether the user has exhausted free Jetpack AI credits (free tier only).
+	// Uses a ref so the click handler always reads the latest value without needing
+	// to re-register the document click listener on every credit check.
+	const requireUpgradeRef = useRef( false );
+
+	useEffect( () => {
+		apiFetch< {
+			'site-require-upgrade': boolean;
+			'current-tier': { value: number };
+		} >( { path: '/wpcom/v2/jetpack-ai/ai-assistant-feature' } )
+			.then( ( response ) => {
+				const siteRequiresUpgrade = response?.[ 'site-require-upgrade' ] === true;
+				const isFreeTier = response?.[ 'current-tier' ]?.value === 0;
+				requireUpgradeRef.current = siteRequiresUpgrade && isFreeTier;
+			} )
+			.catch( () => {
+				// If the API call fails, default to allowing Image Studio.
+				requireUpgradeRef.current = false;
+			} );
+	}, [] );
+
 	// Check for unsaved changes
 	const hasUnsavedChanges = useSelect(
 		( selectStore ) =>
@@ -172,6 +194,12 @@ function ImageStudioIntegration(): JSX.Element | null {
 					if ( ! mimeType || ! supportedMimeTypes.includes( mimeType ) ) {
 						return; // Let legacy flow handle unsupported types
 					}
+				}
+
+				// Don't override grid clicks when free AI credits are exhausted.
+				// Let the legacy media editor handle it instead.
+				if ( requireUpgradeRef.current ) {
+					return;
 				}
 
 				event.preventDefault();


### PR DESCRIPTION
## Proposed Changes

* When a free-tier user has exhausted their 20 Jetpack AI credits, stop intercepting media library grid thumbnail clicks so the legacy media editor handles them instead.
* Adds a one-time `apiFetch` call to `/wpcom/v2/jetpack-ai/ai-assistant-feature` on mount to check credit status.
* Only gates free-tier users (`current-tier.value === 0`) who are over their limit (`site-require-upgrade === true`). Paid-tier users are unaffected.
* Fails open — if the API call errors, Image Studio remains available.

## Why are these changes being made?

Image Studio currently overrides media library grid view thumbnail clicks unconditionally. When free-tier users exhaust their 20 Jetpack AI credits, Image Studio cannot function but still prevents access to the legacy media editor. This is a regression — users lose the ability to edit images entirely once credits run out.

This is a targeted fix for the grid view override only. A holistic solution covering all Image Studio entry points (block editor toolbar, "Edit with AI" row actions, extension disabling) across both the Jetpack and Calypso repos is tracked separately.

## Testing Instructions

1. Use a site on the Jetpack AI free tier with all 20 credits exhausted
2. Navigate to the Media Library grid view (`/wp-admin/upload.php`)
3. Click on an image thumbnail
4. **Before this fix:** Image Studio opens (non-functional)
5. **After this fix:** The legacy WordPress media editor opens
6. Verify that explicit "Edit with AI" row action links still open Image Studio
7. Verify that on a site with remaining free credits OR a paid Jetpack AI plan, grid clicks still open Image Studio as expected

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)