### PR TITLE
Telegram/Dolly: route tweaks

### DIFF
--- a/client/me/index.js
+++ b/client/me/index.js
@@ -6,6 +6,7 @@ import {
 	maybeRedirectToMultiSiteDashboard,
 } from 'calypso/controller';
 import { setupPreferences } from 'calypso/controller/preferences';
+import { TELEGRAM_CONNECT_PATH, telegramConnect } from 'calypso/telegram-connect/controller';
 import * as controller from './controller';
 
 import './style.scss';
@@ -30,6 +31,8 @@ export default function () {
 	// Redirect legacy URLs
 	page( '/me/trophies', controller.profileRedirect, makeLayout, clientRender );
 	page( '/me/find-friends', controller.profileRedirect, makeLayout, clientRender );
+
+	page( TELEGRAM_CONNECT_PATH, setupPreferences, telegramConnect, makeLayout, clientRender );
 
 	page(
 		'/me/get-apps',

--- a/client/me/telegram/use-telegram-bot-widget.tsx
+++ b/client/me/telegram/use-telegram-bot-widget.tsx
@@ -6,7 +6,7 @@ import wpcom from 'calypso/lib/wp';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { DEFAULT_NOTICE_DURATION } from 'calypso/state/notices/constants';
 
-/** Auto-dismiss options for Telegram connect/disconnect global notices (shared with `/telegram-connect`). */
+/** Auto-dismiss options for Telegram connect/disconnect global notices (shared with `/me/get-apps/telegram-connect`). */
 export const TELEGRAM_TRANSIENT_NOTICE = { duration: DEFAULT_NOTICE_DURATION };
 
 export type TelegramAuthPayload = {

--- a/client/telegram-connect/controller.js
+++ b/client/telegram-connect/controller.js
@@ -6,6 +6,17 @@ import { login } from 'calypso/lib/paths';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import TelegramConnectPage from './main';
 
+export const LEGACY_TELEGRAM_CONNECT_PATH = '/telegram-connect';
+export const TELEGRAM_CONNECT_PATH = '/me/get-apps/telegram-connect';
+
+export function redirectLegacyTelegramConnect( context ) {
+	const queryString = context.path.includes( '?' )
+		? context.path.slice( context.path.indexOf( '?' ) )
+		: '';
+
+	page.redirect( `${ TELEGRAM_CONNECT_PATH }${ queryString }` );
+}
+
 export function telegramConnect( context, next ) {
 	if ( ! config.isEnabled( 'dolly/telegram' ) ) {
 		context.primary = createElement( EmptyContent, {

--- a/client/telegram-connect/index.js
+++ b/client/telegram-connect/index.js
@@ -1,7 +1,6 @@
 import page from '@automattic/calypso-router';
-import { makeLayout, render as clientRender } from 'calypso/controller';
-import { telegramConnect } from './controller';
+import { LEGACY_TELEGRAM_CONNECT_PATH, redirectLegacyTelegramConnect } from './controller';
 
 export default function () {
-	page( '/telegram-connect', telegramConnect, makeLayout, clientRender );
+	page( `${ LEGACY_TELEGRAM_CONNECT_PATH }*`, redirectLegacyTelegramConnect );
 }


### PR DESCRIPTION
This PR is changing the route for telegram connection from a top-level route (`telegram-connect`) to a nested one in  `/me/get-apps/telegram-connect`.
This is to avoid having to rewrite nginx routing for logged-out access per BSKY-1868
This is also introducing a fallback for legacy connections

## Testing instructions

- Message bot on telegram
- Copy url
- Replace domain with `http://calypso.localhost:3000/me/get-apps/telegram-connect`
- Observe connection succeeding