### PR TITLE
Migrate comment email subscription hooks to api-core/api-queries

### DIFF
--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -73,6 +73,7 @@ export * from './plugins';
 export * from './products';
 export * from './products';
 export * from './plans';
+export * from './read-comment-email-subscriptions';
 export * from './read-feeds';
 export * from './read-teams';
 export * from './site';

--- a/packages/api-core/src/read-comment-email-subscriptions/index.ts
+++ b/packages/api-core/src/read-comment-email-subscriptions/index.ts
@@ -1,0 +1,2 @@
+export * from './mutators';
+export * from './types';

--- a/packages/api-core/src/read-comment-email-subscriptions/mutators.ts
+++ b/packages/api-core/src/read-comment-email-subscriptions/mutators.ts
@@ -1,0 +1,47 @@
+import { wpcom } from '../wpcom-fetcher';
+import type {
+	UpdateSiteCommentEmailSubscriptionParams,
+	UpdateSiteCommentEmailSubscriptionResponse,
+	DeletePostCommentEmailSubscriptionParams,
+	DeletePostCommentEmailSubscriptionResponse,
+} from './types';
+
+export async function updateSiteCommentEmailSubscription(
+	params: UpdateSiteCommentEmailSubscriptionParams
+): Promise< UpdateSiteCommentEmailSubscriptionResponse > {
+	if ( ! params.blog_id || typeof params.send_comments !== 'boolean' ) {
+		throw new Error( 'Something went wrong while changing the "Email me new comments" setting.' );
+	}
+
+	const action = params.send_comments ? 'new' : 'delete';
+
+	const response = await wpcom.req.post( {
+		path: `/read/site/${ params.blog_id }/comment_email_subscriptions/${ action }`,
+		apiVersion: '1.2',
+	} );
+
+	if ( ! response.success ) {
+		throw new Error( 'Something went wrong while changing the "Email me comments posts" setting.' );
+	}
+
+	return response;
+}
+
+export async function deletePostCommentEmailSubscription(
+	params: DeletePostCommentEmailSubscriptionParams
+): Promise< DeletePostCommentEmailSubscriptionResponse > {
+	if ( ! params.blog_id ) {
+		throw new Error( 'Something went wrong while unsubscribing.' );
+	}
+
+	const response = await wpcom.req.post( {
+		path: `/read/site/${ params.blog_id }/comment_email_subscriptions/delete?post_id=${ params.post_id }`,
+		apiVersion: '1.2',
+	} );
+
+	if ( ! response.success ) {
+		throw new Error( 'Something went wrong while unsubscribing.' );
+	}
+
+	return response;
+}

--- a/packages/api-core/src/read-comment-email-subscriptions/types.ts
+++ b/packages/api-core/src/read-comment-email-subscriptions/types.ts
@@ -1,0 +1,20 @@
+export type UpdateSiteCommentEmailSubscriptionParams = {
+	send_comments: boolean;
+	blog_id: number | string;
+};
+
+export type UpdateSiteCommentEmailSubscriptionResponse = {
+	success: boolean;
+	subscribed: boolean;
+};
+
+export type DeletePostCommentEmailSubscriptionParams = {
+	blog_id: number | string;
+	post_id: number | string;
+};
+
+export type DeletePostCommentEmailSubscriptionResponse = {
+	success: boolean;
+	subscribed: boolean;
+	subscription: null;
+};

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -63,6 +63,7 @@ export * from './payment-methods';
 export * from './plans';
 export * from './plugin';
 export * from './products';
+export * from './read-comment-email-subscriptions';
 export * from './read-feed';
 export * from './site-activity-log';
 export * from './site-activity-log-backup';

--- a/packages/api-queries/src/read-comment-email-subscriptions.ts
+++ b/packages/api-queries/src/read-comment-email-subscriptions.ts
@@ -1,0 +1,29 @@
+import {
+	updateSiteCommentEmailSubscription,
+	deletePostCommentEmailSubscription,
+	type UpdateSiteCommentEmailSubscriptionParams,
+	type DeletePostCommentEmailSubscriptionParams,
+} from '@automattic/api-core';
+import { mutationOptions } from '@tanstack/react-query';
+import { queryClient } from './query-client';
+
+export const siteEmailMeNewCommentsMutation = () =>
+	mutationOptions( {
+		mutationFn: ( params: UpdateSiteCommentEmailSubscriptionParams & { subscriptionId: number } ) =>
+			updateSiteCommentEmailSubscription( params ),
+		onSettled: () => {
+			queryClient.invalidateQueries( { queryKey: [ 'read', 'site-subscriptions' ] } );
+			queryClient.invalidateQueries( { queryKey: [ 'read', 'site-subscription-details' ] } );
+			queryClient.invalidateQueries( { queryKey: [ 'read', 'subscriptions' ] } );
+		},
+	} );
+
+export const postCommentEmailUnsubscribeMutation = () =>
+	mutationOptions( {
+		mutationFn: ( params: DeletePostCommentEmailSubscriptionParams ) =>
+			deletePostCommentEmailSubscription( params ),
+		onSettled: () => {
+			queryClient.invalidateQueries( { queryKey: [ 'read', 'post-subscriptions' ] } );
+			queryClient.invalidateQueries( { queryKey: [ 'read', 'subscriptions-count' ] } );
+		},
+	} );

--- a/packages/data-stores/src/reader/mutations/use-post-unsubscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-post-unsubscribe-mutation.ts
@@ -1,5 +1,5 @@
+import { deletePostCommentEmailSubscription } from '@automattic/api-core';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { callApi } from '../helpers';
 import { useCacheKey, useIsLoggedIn } from '../hooks';
 import { PostSubscription, SubscriptionManagerSubscriptionsCount } from '../types';
 
@@ -7,12 +7,6 @@ type UnsubscribeParams = {
 	id: number | string;
 	blog_id: number | string;
 	post_id: number | string;
-};
-
-type UnsubscribeResponse = {
-	success: boolean;
-	subscribed: boolean;
-	subscription: null;
 };
 
 type PostSubscriptions = {
@@ -33,28 +27,10 @@ const usePostUnsubscribeMutation = () => {
 
 	return useMutation( {
 		mutationFn: async ( params: UnsubscribeParams ) => {
-			if ( ! params.blog_id ) {
-				throw new Error(
-					// reminder: translate this string when we add it to the UI
-					'Something went wrong while unsubscribing.'
-				);
-			}
-
-			const response = await callApi< UnsubscribeResponse >( {
-				path: `/read/site/${ params.blog_id }/comment_email_subscriptions/delete?post_id=${ params.post_id }`,
-				method: 'POST',
-				isLoggedIn,
-				apiVersion: '1.2',
+			return deletePostCommentEmailSubscription( {
+				blog_id: params.blog_id,
+				post_id: params.post_id,
 			} );
-
-			if ( ! response.success ) {
-				throw new Error(
-					// reminder: translate this string when we add it to the UI
-					'Something went wrong while unsubscribing.'
-				);
-			}
-
-			return response;
 		},
 		onMutate: async ( params ) => {
 			await queryClient.cancelQueries( { queryKey: postSubscriptionsCacheKey } );

--- a/packages/data-stores/src/reader/mutations/use-site-email-me-new-comments-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-email-me-new-comments-mutation.ts
@@ -1,5 +1,6 @@
+import { updateSiteCommentEmailSubscription } from '@automattic/api-core';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { buildQueryKey, callApi } from '../helpers';
+import { buildQueryKey } from '../helpers';
 import {
 	alterSiteSubscriptionDetails,
 	invalidateSiteSubscriptionDetails,
@@ -13,41 +14,16 @@ type SiteSubscriptionEmailMeNewCommentsParams = {
 	subscriptionId: number;
 };
 
-type SiteSubscriptionEmailMeNewCommentsResponse = {
-	success: boolean;
-	subscribed: boolean;
-};
-
 const useSiteEmailMeNewCommentsMutation = () => {
 	const { id, isLoggedIn } = useIsLoggedIn();
 	const queryClient = useQueryClient();
 
 	return useMutation( {
 		mutationFn: async ( params: SiteSubscriptionEmailMeNewCommentsParams ) => {
-			if ( ! params.blog_id || typeof params.send_comments !== 'boolean' ) {
-				throw new Error(
-					// reminder: translate this string when we add it to the UI
-					'Something went wrong while changing the "Email me new comments" setting.'
-				);
-			}
-
-			const action = params.send_comments ? 'new' : 'delete';
-
-			const response = await callApi< SiteSubscriptionEmailMeNewCommentsResponse >( {
-				path: `/read/site/${ params.blog_id }/comment_email_subscriptions/${ action }`,
-				method: 'POST',
-				body: {},
-				isLoggedIn,
-				apiVersion: '1.2',
+			return updateSiteCommentEmailSubscription( {
+				send_comments: params.send_comments,
+				blog_id: params.blog_id,
 			} );
-			if ( ! response.success ) {
-				throw new Error(
-					// reminder: translate this string when we add it to the UI
-					'Something went wrong while changing the "Email me comments posts" setting.'
-				);
-			}
-
-			return response;
 		},
 		onMutate: async ( { blog_id, send_comments, subscriptionId } ) => {
 			const siteSubscriptionsQueryKey = buildQueryKey(


### PR DESCRIPTION
Part of READ-408

## Proposed Changes

* Extract pure mutator functions (`updateSiteCommentEmailSubscription`, `deletePostCommentEmailSubscription`) into `@automattic/api-core` under `read-comment-email-subscriptions/`.
* Create `mutationOptions()` wrappers (`siteEmailMeNewCommentsMutation`, `postCommentEmailUnsubscribeMutation`) in `@automattic/api-queries`.
* Update `data-stores` hooks (`useSiteEmailMeNewCommentsMutation`, `usePostUnsubscribeMutation`) to use the new api-core mutators instead of the custom `callApi()` helper, while preserving existing optimistic update logic.

## Why are these changes being made?

This is part of an ongoing migration (Phase 3) to move Reader query/mutation logic from `data-stores` to the standardized `api-core`/`api-queries` pattern. Centralizing API calls in `api-core` with `wpcom-fetcher` and exposing `mutationOptions` from `api-queries` improves reusability, testability, and consistency across clients.

## Testing Instructions

* Verify "Email me new comments" toggle works on a site subscription row (Subscriptions > Sites).
* Verify unsubscribing from a comment subscription works (Subscriptions > Comments).
* Verify the Reader site subscription settings panel toggles comments email correctly.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?