### PR TITLE
Image Studio: Remove grid view click override

### DIFF
--- a/packages/image-studio/src/index.tsx
+++ b/packages/image-studio/src/index.tsx
@@ -10,7 +10,7 @@ import { registerBlockEditorFilters } from './extensions';
 import { useDraftCleanup } from './hooks/use-draft-cleanup';
 import { useImageFileNavigation } from './hooks/use-image-file-navigation';
 import { type ImageStudioActions, ImageStudioEntryPoint, store as imageStudioStore } from './store';
-import { IMAGE_STUDIO_SUPPORTED_MIME_TYPES, ImageStudioMode } from './types';
+import { ImageStudioMode } from './types';
 import { getImageData, type ImageData } from './utils/get-image-data';
 import {
 	trackImageStudioClosed,
@@ -137,51 +137,6 @@ function ImageStudioIntegration(): JSX.Element | null {
 					openImageStudio( undefined, undefined, ImageStudioEntryPoint.MediaLibrary );
 				}
 				return;
-			}
-
-			// Supported MIME types for Image Studio
-			const supportedMimeTypes: readonly string[] = IMAGE_STUDIO_SUPPORTED_MIME_TYPES;
-
-			// Only apply overrides on the Media Library page (upload.php), not in post editor
-			const isMediaLibraryPage = window.location.pathname.includes( 'upload.php' );
-
-			if ( ! isMediaLibraryPage ) {
-				return;
-			}
-
-			// Override thumbnail clicks in media library grid view to open Image Studio (images only)
-			// Skip if bulk select mode is active (user is selecting items, not opening them)
-			// WordPress adds 'media-toolbar-mode-select' class to the media toolbar in bulk select mode
-			const mediaToolbar = document.querySelector( '.media-toolbar' );
-			const isBulkSelectMode = mediaToolbar?.classList.contains( 'media-toolbar-mode-select' );
-			const attachment = target.closest( '.attachment' );
-			if ( attachment && attachment.classList.contains( 'save-ready' ) && ! isBulkSelectMode ) {
-				// Get attachment ID from the element
-				const id = attachment.getAttribute( 'data-id' );
-				if ( ! id ) {
-					return;
-				}
-
-				// Check if this is a supported image by querying WordPress media library
-				const wpMedia = window.wp?.media;
-				if ( wpMedia?.attachment ) {
-					const attachmentModel = wpMedia.attachment( parseInt( id, 10 ) );
-					const mimeType = attachmentModel?.get( 'mime' );
-
-					// Only override if this is a supported image type
-					if ( ! mimeType || ! supportedMimeTypes.includes( mimeType ) ) {
-						return; // Let legacy flow handle unsupported types
-					}
-				}
-
-				event.preventDefault();
-				event.stopPropagation();
-				trackImageStudioOpened( {
-					mode: ImageStudioMode.Edit,
-					attachmentId: parseInt( id, 10 ),
-					entryPoint: ImageStudioEntryPoint.MediaLibrary,
-				} );
-				openImageStudio( parseInt( id, 10 ), undefined, ImageStudioEntryPoint.MediaLibrary );
 			}
 		};
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* Removes the click override that handled thumbnail clicks in the media library grid view to open Image Studio instead of the core attachment modal

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We should provide a way to opt out of this behaviour, and better handle cases where customers do not have AI credits

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `install-plugin.sh am update/skip-core-modal-override` on your sandbox
* Sandbox `widgets.wp.com`
* Load media library in simple site, Jurassic Ninja site, Atomic site
* Verify that `Edit with AI` in media library list mode launched image studio, while clicking the attachment in grid mode launches the core attachment modal

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
