### PR TITLE
Dashboard: Add compact variant to EmptyState.Wrapper

### DIFF
--- a/client/dashboard/components/empty-state/index.stories.tsx
+++ b/client/dashboard/components/empty-state/index.stories.tsx
@@ -189,6 +189,26 @@ export const WithoutContentWrapper: Story = {
 	},
 };
 
+export const CompactWrapper: Story = {
+	render: ( args ) => (
+		<EmptyState.Wrapper isCompact>
+			<EmptyState { ...args } />
+		</EmptyState.Wrapper>
+	),
+	args: {
+		children: (
+			<>
+				<EmptyState.Header>
+					<EmptyState.Title>Site blocked</EmptyState.Title>
+					<EmptyState.Description>
+						This site has been blocked and is no longer accessible.
+					</EmptyState.Description>
+				</EmptyState.Header>
+			</>
+		),
+	},
+};
+
 export const WithContainerAndCallout: Story = {
 	render: ( args ) => (
 		<EmptyState.Wrapper>

--- a/client/dashboard/components/empty-state/index.tsx
+++ b/client/dashboard/components/empty-state/index.tsx
@@ -1,5 +1,6 @@
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
+import clsx from 'clsx';
 import { useLayoutEffect, useRef, type ReactNode } from 'react';
 import { ActionList } from '../action-list';
 import { Card, CardBody } from '../card';
@@ -18,9 +19,11 @@ function EmptyState( { children }: { children?: ReactNode } ) {
 
 function EmptyStateWrapper( {
 	isBorderless = false,
+	isCompact = false,
 	children,
 }: {
 	isBorderless?: boolean;
+	isCompact?: boolean;
 	children: ReactNode;
 } ) {
 	const cardRef = useRef< HTMLElement >( null );
@@ -29,15 +32,19 @@ function EmptyStateWrapper( {
 	// This keeps the visual layout stable between view transitions. It's fine if
 	// the wrapper expands beyond this initial calculation after layout changes.
 	useLayoutEffect( () => {
-		if ( ! cardRef.current ) {
+		if ( isCompact || ! cardRef.current ) {
 			return;
 		}
 		const rect = cardRef.current.getBoundingClientRect();
 		cardRef.current.style.setProperty( '--dashboard-empty-state-offset', `${ rect.top }px` );
-	}, [] );
+	}, [ isCompact ] );
+
+	const className = clsx( 'dashboard-empty-state__wrapper', {
+		'is-compact': isCompact,
+	} );
 
 	return (
-		<Card ref={ cardRef } className="dashboard-empty-state__wrapper" isBorderless={ isBorderless }>
+		<Card ref={ cardRef } className={ className } isBorderless={ isBorderless }>
 			<CardBody>
 				<VStack spacing={ 8 } alignment="center" className="dashboard-empty-state__wrapper-content">
 					{ children }

--- a/client/dashboard/components/empty-state/style.scss
+++ b/client/dashboard/components/empty-state/style.scss
@@ -20,16 +20,18 @@
 	&.is-compact {
 		min-height: 0;
 		justify-content: flex-start;
-
-		.dashboard-empty-state__wrapper-content {
-			padding-block: 0;
-		}
 	}
 }
 
 .dashboard-empty-state__wrapper-content {
 	@include break-medium {
 		padding-block: $grid-unit-40;
+	}
+}
+
+.is-compact .dashboard-empty-state__wrapper-content {
+	@include break-medium {
+		padding-block: 0;
 	}
 }
 

--- a/client/dashboard/components/empty-state/style.scss
+++ b/client/dashboard/components/empty-state/style.scss
@@ -16,22 +16,22 @@
 		justify-content: center;
 		min-height: calc(100dvh - var(--dashboard-empty-state-offset, 30dvh) - var(--page-layout-block-padding, #{$grid-unit-40}));
 	}
-
-	&.is-compact {
-		min-height: 0;
-		justify-content: flex-start;
-	}
 }
+
+.dashboard-empty-state__wrapper.is-compact {
+	min-height: 0;
+	justify-content: flex-start;
+}
+
+.dashboard-empty-state__wrapper.is-compact .dashboard-empty-state__wrapper-content {
+	@include break-medium {
+			padding-block: 0;
+		}
+	}
 
 .dashboard-empty-state__wrapper-content {
 	@include break-medium {
 		padding-block: $grid-unit-40;
-	}
-}
-
-.is-compact .dashboard-empty-state__wrapper-content {
-	@include break-medium {
-		padding-block: 0;
 	}
 }
 

--- a/client/dashboard/components/empty-state/style.scss
+++ b/client/dashboard/components/empty-state/style.scss
@@ -16,6 +16,15 @@
 		justify-content: center;
 		min-height: calc(100dvh - var(--dashboard-empty-state-offset, 30dvh) - var(--page-layout-block-padding, #{$grid-unit-40}));
 	}
+
+	&.is-compact {
+		min-height: 0;
+		justify-content: flex-start;
+
+		.dashboard-empty-state__wrapper-content {
+			padding-block: 0;
+		}
+	}
 }
 
 .dashboard-empty-state__wrapper-content {

--- a/client/dashboard/components/empty-state/style.scss
+++ b/client/dashboard/components/empty-state/style.scss
@@ -25,9 +25,9 @@
 
 .dashboard-empty-state__wrapper.is-compact .dashboard-empty-state__wrapper-content {
 	@include break-medium {
-			padding-block: 0;
-		}
+		padding-block: 0;
 	}
+}
 
 .dashboard-empty-state__wrapper-content {
 	@include break-medium {

--- a/client/dashboard/me/blocked-sites/index.tsx
+++ b/client/dashboard/me/blocked-sites/index.tsx
@@ -11,6 +11,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { DataViewsCard } from '../../components/dataviews';
+import EmptyState from '../../components/empty-state';
 import InlineSupportLink from '../../components/inline-support-link';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
@@ -150,7 +151,13 @@ export default function BlockedSites() {
 			}
 		>
 			{ ! isLoading && sites.length === 0 ? (
-				<p>{ __( "You haven't blocked any sites yet." ) }</p>
+				<EmptyState.Wrapper isCompact>
+					<EmptyState>
+						<EmptyState.Description>
+							{ __( "You haven't blocked any sites yet." ) }
+						</EmptyState.Description>
+					</EmptyState>
+				</EmptyState.Wrapper>
 			) : (
 				<DataViewsCard ref={ ref }>
 					<DataViews< BlockedSite >


### PR DESCRIPTION
Part of #109805

## Proposed Changes

- Add `isCompact` prop to `EmptyState.Wrapper` that sizes the wrapper to its content instead of filling the remaining viewport height.
- Use compact `EmptyState.Wrapper` for the blocked sites empty state.
- Add `CompactWrapper` Storybook story.


| Header | Header |
|--------|--------|
| <img width="671" height="305" alt="Screenshot 2026-04-03 at 9 22 03 AM" src="https://github.com/user-attachments/assets/371744e0-12b3-4ace-a7cc-31e76f7d01d4" /> | <img width="719" height="330" alt="Screenshot 2026-04-03 at 9 22 13 AM" src="https://github.com/user-attachments/assets/85fc69c3-4cf2-4457-94ec-4b41c9e51290" /> | 

## Why are these changes being made?

The existing `EmptyState.Wrapper` always expands to fill the viewport, which doesn't suit all contexts. For example, the blocked sites page just needs a simple card-sized empty state. The `isCompact` variant removes the `min-height` calculation and extra padding so the wrapper shrinks to fit its content.

This is an alternative approach to #109805, which addresses the same blocked sites empty state.

## Testing Instructions

- Visit the blocked sites page in the Dashboard with no blocked sites — the empty state should render as a compact card.
- Check Storybook: `client/dashboard/EmptyState` → `CompactWrapper` story.
- Verify existing `EmptyState.Wrapper` usage (e.g., empty sites state) is unaffected.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)