### PR TITLE
Login: Fix redirect_to handling for WordPress.com subdomains

### DIFF
--- a/client/login/redirect-logged-in/index.web.js
+++ b/client/login/redirect-logged-in/index.web.js
@@ -20,7 +20,16 @@ function isExternalUrl( url ) {
 			'agencies.automattic.com',
 		];
 
-		if ( allowedHostname.includes( urlObject.hostname ) && urlObject.protocol === 'https:' ) {
+		if ( urlObject.protocol !== 'https:' ) {
+			return true;
+		}
+
+		if ( allowedHostname.includes( urlObject.hostname ) ) {
+			return false;
+		}
+
+		// Allow *.wordpress.com subdomains (e.g., P2 sites like testp2020a8c.wordpress.com).
+		if ( urlObject.hostname.endsWith( '.wordpress.com' ) ) {
 			return false;
 		}
 	} catch {

--- a/client/login/redirect-logged-in/index.web.js
+++ b/client/login/redirect-logged-in/index.web.js
@@ -28,7 +28,7 @@ function isExternalUrl( url ) {
 			return false;
 		}
 
-		// Allow *.wordpress.com subdomains (e.g., P2 sites like testp2020a8c.wordpress.com).
+		// Allow *.wordpress.com subdomains (e.g., P2 sites like myteamp2.wordpress.com).
 		if ( urlObject.hostname.endsWith( '.wordpress.com' ) ) {
 			return false;
 		}

--- a/client/login/test/redirect-to-login.js
+++ b/client/login/test/redirect-to-login.js
@@ -79,11 +79,11 @@ describe( 'redirectLoggedIn', () => {
 			redirectLoggedIn(
 				{
 					...context,
-					query: { redirect_to: 'https://testp2020a8c.wordpress.com/' },
+					query: { redirect_to: 'https://testp2p2.wordpress.com/' },
 				},
 				next
 			);
-			expect( window.location ).toBe( 'https://testp2020a8c.wordpress.com/' );
+			expect( window.location ).toBe( 'https://testp2p2.wordpress.com/' );
 		} );
 
 		test( 'should redirect to wordpress.com subdomain with path', () => {
@@ -92,12 +92,12 @@ describe( 'redirectLoggedIn', () => {
 				{
 					...context,
 					query: {
-						redirect_to: 'https://testp2020a8c.wordpress.com/author/wrightcj03',
+						redirect_to: 'https://testp2p2.wordpress.com/author/janedoe',
 					},
 				},
 				next
 			);
-			expect( window.location ).toBe( 'https://testp2020a8c.wordpress.com/author/wrightcj03' );
+			expect( window.location ).toBe( 'https://testp2p2.wordpress.com/author/janedoe' );
 		} );
 
 		test( 'should reject non-https wordpress.com subdomain', () => {
@@ -105,7 +105,7 @@ describe( 'redirectLoggedIn', () => {
 			redirectLoggedIn(
 				{
 					...context,
-					query: { redirect_to: 'http://testp2020a8c.wordpress.com/' },
+					query: { redirect_to: 'http://testp2p2.wordpress.com/' },
 				},
 				next
 			);

--- a/client/login/test/redirect-to-login.js
+++ b/client/login/test/redirect-to-login.js
@@ -73,5 +73,43 @@ describe( 'redirectLoggedIn', () => {
 			redirectLoggedIn( { ...context, query: { redirect_to: 'https://test.com' } }, next );
 			expect( window.location ).toBe( '/' );
 		} );
+
+		test( 'should redirect to wordpress.com subdomain (P2 site)', () => {
+			isUserLoggedIn.mockReturnValue( true );
+			redirectLoggedIn(
+				{
+					...context,
+					query: { redirect_to: 'https://testp2020a8c.wordpress.com/' },
+				},
+				next
+			);
+			expect( window.location ).toBe( 'https://testp2020a8c.wordpress.com/' );
+		} );
+
+		test( 'should redirect to wordpress.com subdomain with path', () => {
+			isUserLoggedIn.mockReturnValue( true );
+			redirectLoggedIn(
+				{
+					...context,
+					query: {
+						redirect_to: 'https://testp2020a8c.wordpress.com/author/wrightcj03',
+					},
+				},
+				next
+			);
+			expect( window.location ).toBe( 'https://testp2020a8c.wordpress.com/author/wrightcj03' );
+		} );
+
+		test( 'should reject non-https wordpress.com subdomain', () => {
+			isUserLoggedIn.mockReturnValue( true );
+			redirectLoggedIn(
+				{
+					...context,
+					query: { redirect_to: 'http://testp2020a8c.wordpress.com/' },
+				},
+				next
+			);
+			expect( window.location ).toBe( '/' );
+		} );
 	} );
 } );

--- a/client/state/login/actions/reboot-after-login.ts
+++ b/client/state/login/actions/reboot-after-login.ts
@@ -1,6 +1,10 @@
 import { clearStore, getStoredUserId } from 'calypso/lib/user/store';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getRedirectToSanitized, isTwoFactorEnabled } from 'calypso/state/login/selectors';
+import {
+	getRedirectToOriginal,
+	getRedirectToSanitized,
+	isTwoFactorEnabled,
+} from 'calypso/state/login/selectors';
 import type { CalypsoDispatch } from 'calypso/state/types';
 
 export const rebootAfterLogin =
@@ -13,8 +17,9 @@ export const rebootAfterLogin =
 			} )
 		);
 
-		// Redirects to / if no redirect url is available
-		const url = getRedirectToSanitized( getState() ) || '/';
+		// Redirects to / if no redirect url is available.
+		// Fall back to the original redirect_to from the URL query if the API didn't return one.
+		const url = getRedirectToSanitized( getState() ) || getRedirectToOriginal( getState() ) || '/';
 
 		// user ID is persisted in localstorage
 		// therefore we need to reset it before we redirect, otherwise we'll get

--- a/client/state/login/actions/test/reboot-after-login.ts
+++ b/client/state/login/actions/test/reboot-after-login.ts
@@ -1,0 +1,84 @@
+/**
+ * @jest-environment jsdom
+ */
+import { rebootAfterLogin } from 'calypso/state/login/actions/reboot-after-login';
+
+const originalLocation = window.location;
+
+jest.mock( 'calypso/lib/user/store', () => ( {
+	clearStore: jest.fn().mockResolvedValue( undefined ),
+	getStoredUserId: jest.fn().mockReturnValue( null ),
+} ) );
+
+jest.mock( 'calypso/state/analytics/actions', () => ( {
+	recordTracksEventWithClientId: () => () => {},
+} ) );
+
+describe( 'rebootAfterLogin', () => {
+	beforeEach( () => {
+		Object.defineProperty( window, 'location', {
+			value: { href: '' },
+			writable: true,
+		} );
+	} );
+
+	afterEach( () => {
+		Object.defineProperty( window, 'location', {
+			value: originalLocation,
+			writable: true,
+		} );
+	} );
+
+	function makeGetState( {
+		sanitized = null,
+		original = null,
+	}: {
+		sanitized?: string | null;
+		original?: string | null;
+	} ) {
+		return () => ( {
+			login: {
+				twoFactorAuth: {},
+				redirectTo: { sanitized, original },
+			},
+		} );
+	}
+
+	test( 'redirects to sanitized URL when available', async () => {
+		const dispatch = jest.fn();
+		const getState = makeGetState( { sanitized: 'https://wordpress.com/home' } );
+
+		await rebootAfterLogin( {} )( dispatch, getState );
+		expect( window.location.href ).toBe( 'https://wordpress.com/home' );
+	} );
+
+	test( 'falls back to original redirect_to when sanitized is null', async () => {
+		const dispatch = jest.fn();
+		const getState = makeGetState( {
+			sanitized: null,
+			original: 'https://testp2020a8c.wordpress.com/',
+		} );
+
+		await rebootAfterLogin( {} )( dispatch, getState );
+		expect( window.location.href ).toBe( 'https://testp2020a8c.wordpress.com/' );
+	} );
+
+	test( 'redirects to / when both sanitized and original are null', async () => {
+		const dispatch = jest.fn();
+		const getState = makeGetState( { sanitized: null, original: null } );
+
+		await rebootAfterLogin( {} )( dispatch, getState );
+		expect( window.location.href ).toBe( '/' );
+	} );
+
+	test( 'prefers sanitized over original when both are set', async () => {
+		const dispatch = jest.fn();
+		const getState = makeGetState( {
+			sanitized: 'https://wordpress.com/home',
+			original: 'https://testp2020a8c.wordpress.com/',
+		} );
+
+		await rebootAfterLogin( {} )( dispatch, getState );
+		expect( window.location.href ).toBe( 'https://wordpress.com/home' );
+	} );
+} );

--- a/client/state/login/actions/test/reboot-after-login.ts
+++ b/client/state/login/actions/test/reboot-after-login.ts
@@ -56,11 +56,11 @@ describe( 'rebootAfterLogin', () => {
 		const dispatch = jest.fn();
 		const getState = makeGetState( {
 			sanitized: null,
-			original: 'https://testp2020a8c.wordpress.com/',
+			original: 'https://testp2p2.wordpress.com/',
 		} );
 
 		await rebootAfterLogin( {} )( dispatch, getState );
-		expect( window.location.href ).toBe( 'https://testp2020a8c.wordpress.com/' );
+		expect( window.location.href ).toBe( 'https://testp2p2.wordpress.com/' );
 	} );
 
 	test( 'redirects to / when both sanitized and original are null', async () => {
@@ -75,7 +75,7 @@ describe( 'rebootAfterLogin', () => {
 		const dispatch = jest.fn();
 		const getState = makeGetState( {
 			sanitized: 'https://wordpress.com/home',
-			original: 'https://testp2020a8c.wordpress.com/',
+			original: 'https://testp2p2.wordpress.com/',
 		} );
 
 		await rebootAfterLogin( {} )( dispatch, getState );


### PR DESCRIPTION
## Proposed Changes

- Allow `*.wordpress.com` subdomains in the login redirect URL allowlist
- Fall back to the original `redirect_to` URL parameter when the API doesn't return one

## Why are these changes being made?

See P2HQ-55

When users visit a private P2 site while logged out, P2 correctly sets `redirect_to` to the original URL. After logging in, two issues prevent the redirect from working:

1. `isExternalUrl()` in `redirect-logged-in` treats `*.wordpress.com` subdomains (e.g., `myteamp2.wordpress.com`) as external URLs because the allowlist only matches exact hostnames. The `redirect_to` is silently dropped.

2. `rebootAfterLogin` relies solely on the API-sanitized `redirect_to`. If the API doesn't echo it back, the original URL parameter from the login page is ignored entirely, defaulting to `/`.

Users end up at `wordpress.com/p2/` instead of the P2 they were trying to visit.

## Testing Instructions

1. Open an incognito/private browser window (must be logged out of WordPress.com)
2. Navigate to a private P2 URL, e.g., `cAFMY-p2`
3. Click "Log in" on the private landing page
4. Verify the login URL contains `redirect_to=https%3A%2F%2Fmyteamp2.wordpress.com%2F`
5. Complete the login flow (enter credentials)
6. **Expected:** Redirected back to `myteamp2.wordpress.com`
7. **Before fix:** Redirected to `wordpress.com/p2/`

Also test the "already logged in" path:
1. While logged in, navigate to `https://wordpress.com/log-in?redirect_to=https%3A%2F%2Fmyteamp2.wordpress.com%2F`
2. Click "Continue"
3. **Expected:** Redirected to `myteamp2.wordpress.com`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?