### PR TITLE
Odyssey Stats: Fix wp-admin layout padding and sticky header

### DIFF
--- a/apps/odyssey-stats/src/styles/wp-admin.scss
+++ b/apps/odyssey-stats/src/styles/wp-admin.scss
@@ -58,9 +58,11 @@
 	--sidebar-width-max: 160px;
 	--sidebar-width-min: 36px;
 
+	// Remove top padding — the admin-ui Page header is inside .admin-ui-page,
+	// so .layout__content no longer needs extra space above it.
 	& .layout__content,
 	&.theme-default .focus-content .layout__content {
-		padding-top: 32px;
+		padding-top: 0;
 		padding-left: 1px;
 	}
 	// Fixed header doesn't work well for WP-Admin, as the masterbar isn't fixed.

--- a/apps/odyssey-stats/src/styles/wp-admin.scss
+++ b/apps/odyssey-stats/src/styles/wp-admin.scss
@@ -76,6 +76,12 @@
 	& .is-section-stats .has-fixed-nav {
 		padding-top: 64px;
 	}
+	// Disable sticky header — in wp-admin the admin-ui-page forms its own
+	// scroll container, causing the header to stick and overlap content.
+	& .admin-ui-page__header {
+		position: static;
+	}
+
 	& .highlight-cards.has-odyssey-stats-bg-color,
 	& .inner-notice-container.has-odyssey-stats-bg-color {
 		background-color: var(--jetpack-white-off);


### PR DESCRIPTION
Part of #109786

Fixes STATS-247.

## Proposed Changes

- Remove `padding-top: 32px` from `.layout__content` in wp-admin — the admin-ui Page header now renders inside `.admin-ui-page`, so the extra top padding is no longer needed.
- Disable `position: sticky` on the Page header in wp-admin — the `.admin-ui-page` container forms its own scroll context in wp-admin, causing the header to incorrectly stick and overlap content.

## Testing Instructions

- Open Odyssey Stats in wp-admin (`/wp-admin/admin.php?page=stats`)
- Verify the Page header does not stick when scrolling
- Verify there is no extra blank space above the header
- Compare with WordPress.com Stats to ensure consistent behavior

### Before
https://github.com/user-attachments/assets/ed00ea9e-85e6-4451-9070-f25a5cb0f53c

### After
https://github.com/user-attachments/assets/868834e9-5736-41cd-90ed-a41200bb51ed

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)