### PR TITLE
WP Beta Program: only allow Business plan or above

### DIFF
--- a/client/dashboard/sites/features.ts
+++ b/client/dashboard/sites/features.ts
@@ -43,7 +43,7 @@ export function canViewHundredYearPlanSettings( site: Site ) {
 
 export function canViewWordPressSettings( site: Site ) {
 	if ( isEnabled( 'dashboard/wp-beta-program' ) ) {
-		return hasHostingFeature( site, HostingFeatures.BACKUPS );
+		return hasHostingFeature( site, HostingFeatures.BACKUPS_SELF_SERVE );
 	}
 	return site.is_wpcom_staging_site;
 }

--- a/client/dashboard/utils/wp-version.ts
+++ b/client/dashboard/utils/wp-version.ts
@@ -1,6 +1,5 @@
-import { HostingFeatures } from '@automattic/api-core';
 import { __ } from '@wordpress/i18n';
-import { hasHostingFeature } from './site-features';
+import { canViewWordPressSettings } from '../sites/features';
 import type { Site } from '@automattic/api-core';
 
 function getWordPressVersionTagName( versionTag: string ) {
@@ -17,11 +16,10 @@ export function getFormattedWordPressVersion(
 	site: Site,
 	versionTag: string | undefined = undefined
 ) {
-	const canManageVersion = hasHostingFeature( site, HostingFeatures.BACKUPS );
 	return formatWordPressVersion(
 		site.options?.software_version ?? '',
 		versionTag,
-		canManageVersion
+		canViewWordPressSettings( site )
 	);
 }
 


### PR DESCRIPTION
Fixes DOTCOM-16602

## Proposed Changes

This PR allows the WP beta program on Business plan or above correctly.

Previously, we're checking for the `BACKUPS` feature. However, for the Summer Special, all paid plans now have that feature. The Summer Special "fix" was to add additional `BACKUPS_SELF_SERVE` feature for Business+ plan only. So, in this PR we also switch to that feature.


## Testing Instructions

Using the `dashboard/wp-beta-program` flag, verify that:
- You CAN change WP version in Business Atomic site.
- You CAN change WP version in staging site.
- You CANNOT change WP version in Premium Atomic site.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
