### PR TITLE
MSD: Add version switch notices and beta program enrollment UI

### DIFF
--- a/client/dashboard/components/empty-state/index.tsx
+++ b/client/dashboard/components/empty-state/index.tsx
@@ -17,11 +17,9 @@ function EmptyState( { children }: { children?: ReactNode } ) {
 }
 
 function EmptyStateWrapper( {
-	expand = true,
 	isBorderless = false,
 	children,
 }: {
-	expand?: boolean;
 	isBorderless?: boolean;
 	children: ReactNode;
 } ) {
@@ -31,12 +29,12 @@ function EmptyStateWrapper( {
 	// This keeps the visual layout stable between view transitions. It's fine if
 	// the wrapper expands beyond this initial calculation after layout changes.
 	useLayoutEffect( () => {
-		if ( ! cardRef.current || ! expand ) {
+		if ( ! cardRef.current ) {
 			return;
 		}
 		const rect = cardRef.current.getBoundingClientRect();
 		cardRef.current.style.setProperty( '--dashboard-empty-state-offset', `${ rect.top }px` );
-	}, [ expand ] );
+	}, [] );
 
 	return (
 		<Card ref={ cardRef } className="dashboard-empty-state__wrapper" isBorderless={ isBorderless }>

--- a/client/dashboard/components/empty-state/index.tsx
+++ b/client/dashboard/components/empty-state/index.tsx
@@ -17,9 +17,11 @@ function EmptyState( { children }: { children?: ReactNode } ) {
 }
 
 function EmptyStateWrapper( {
+	expand = true,
 	isBorderless = false,
 	children,
 }: {
+	expand?: boolean;
 	isBorderless?: boolean;
 	children: ReactNode;
 } ) {
@@ -29,12 +31,12 @@ function EmptyStateWrapper( {
 	// This keeps the visual layout stable between view transitions. It's fine if
 	// the wrapper expands beyond this initial calculation after layout changes.
 	useLayoutEffect( () => {
-		if ( ! cardRef.current ) {
+		if ( ! cardRef.current || ! expand ) {
 			return;
 		}
 		const rect = cardRef.current.getBoundingClientRect();
 		cardRef.current.style.setProperty( '--dashboard-empty-state-offset', `${ rect.top }px` );
-	}, [] );
+	}, [ expand ] );
 
 	return (
 		<Card ref={ cardRef } className="dashboard-empty-state__wrapper" isBorderless={ isBorderless }>

--- a/client/dashboard/sites/settings-wordpress/beta-program-notice.tsx
+++ b/client/dashboard/sites/settings-wordpress/beta-program-notice.tsx
@@ -9,29 +9,20 @@ import type { Site } from '@automattic/api-core';
 interface BetaProgramNoticeProps {
 	site: Site;
 	wpVersion: string;
-	isJustEnrolled: boolean;
 }
 
-export function BetaProgramNotice( { site, wpVersion, isJustEnrolled }: BetaProgramNoticeProps ) {
+export function BetaProgramNotice( { site, wpVersion }: BetaProgramNoticeProps ) {
 	const backupUrl = getBackupUrl( site );
 	const { setShowHelpCenter } = useHelpCenter();
 
 	return (
 		<Notice
-			variant={ isJustEnrolled ? 'success' : 'info' }
-			title={
-				isJustEnrolled
-					? sprintf(
-							/* translators: %s is the WordPress version string e.g. "6.8 beta" */
-							__( 'Your site is now running WordPress %s' ),
-							wpVersion
-					  )
-					: sprintf(
-							/* translators: %s is the WordPress version string e.g. "6.8 beta" */
-							__( 'Your site is running WordPress %s' ),
-							wpVersion
-					  )
-			}
+			variant="info"
+			title={ sprintf(
+				/* translators: %s is the WordPress version string e.g. "6.8 beta" */
+				__( 'Your site is running WordPress %s' ),
+				wpVersion
+			) }
 		>
 			{ backupUrl
 				? createInterpolateElement(

--- a/client/dashboard/sites/settings-wordpress/beta-program-notice.tsx
+++ b/client/dashboard/sites/settings-wordpress/beta-program-notice.tsx
@@ -1,0 +1,56 @@
+import { Button } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { useHelpCenter } from '../../app/help-center';
+import { Notice } from '../../components/notice';
+import { getBackupUrl } from '../../utils/site-backup';
+import type { Site } from '@automattic/api-core';
+
+interface BetaProgramNoticeProps {
+	site: Site;
+	wpVersion: string;
+	isJustEnrolled: boolean;
+}
+
+export function BetaProgramNotice( { site, wpVersion, isJustEnrolled }: BetaProgramNoticeProps ) {
+	const backupUrl = getBackupUrl( site );
+	const { setShowHelpCenter } = useHelpCenter();
+
+	return (
+		<Notice
+			variant={ isJustEnrolled ? 'success' : 'info' }
+			title={
+				isJustEnrolled
+					? sprintf(
+							/* translators: %s is the WordPress version string e.g. "6.8 beta" */
+							__( 'Your site is now running WordPress %s' ),
+							wpVersion
+					  )
+					: sprintf(
+							/* translators: %s is the WordPress version string e.g. "6.8 beta" */
+							__( 'Your site is running WordPress %s' ),
+							wpVersion
+					  )
+			}
+		>
+			{ backupUrl
+				? createInterpolateElement(
+						__(
+							'If you notice anything unexpected, <support>let us know</support>. Your feedback helps shape WordPress. You can switch back to the stable release anytime. A <backup>backup of your site</backup> is available if you ever need it.'
+						),
+						{
+							support: <Button variant="link" onClick={ () => setShowHelpCenter( true ) } />,
+							backup: <a href={ backupUrl } />,
+						}
+				  )
+				: createInterpolateElement(
+						__(
+							'If you notice anything unexpected, <support>let us know</support>. Your feedback helps shape WordPress. You can switch back to the stable release anytime.'
+						),
+						{
+							support: <Button variant="link" onClick={ () => setShowHelpCenter( true ) } />,
+						}
+				  ) }
+		</Notice>
+	);
+}

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -61,7 +61,6 @@ function WordPressSettingsForm( { siteSlug }: { siteSlug: string } ) {
 			notices={ notice }
 		>
 			<VersionForm
-				key={ currentVersion }
 				site={ site }
 				currentVersion={ currentVersion }
 				versionSwitch={ versionSwitch }

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -41,14 +41,8 @@ function WordPressSettingsForm( { siteSlug }: { siteSlug: string } ) {
 			/>
 		);
 	} else if ( switchedToBeta || currentVersion === 'beta' ) {
-		// Just enrolled, or returning visit while on beta.
-		notice = (
-			<BetaProgramNotice
-				site={ site }
-				wpVersion={ betaVersion }
-				isJustEnrolled={ switchedToBeta }
-			/>
-		);
+		// Enrolled in beta — show program notice.
+		notice = <BetaProgramNotice site={ site } wpVersion={ betaVersion } />;
 	} else if ( switchedToLatest ) {
 		// Just switched back to stable.
 		notice = <LatestVersionNotice wpVersion={ latestVersion } />;

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -22,11 +22,14 @@ function WordPressSettingsForm( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: currentVersion } = useQuery( siteWordPressVersionQuery( site.ID ) );
 	const versionSwitch = useVersionSwitch( site );
-	const { isSwitching, isSwitched, backupState, targetVersion } = versionSwitch;
+	const { phase, backupState } = versionSwitch;
+	const showNotice = phase.status !== 'idle';
 
 	// Resolve the target version tag (e.g. "beta") to a display string (e.g. "7.0-RC2").
 	const { data: latestVersion = '' } = useQuery( wpOrgCoreVersionQuery() );
 	const { data: betaVersion = '' } = useQuery( wpOrgCoreVersionQuery( 'beta' ) );
+
+	const targetVersion = phase.status !== 'idle' ? phase.targetVersion : '';
 
 	return (
 		<PageLayout
@@ -39,12 +42,12 @@ function WordPressSettingsForm( { siteSlug }: { siteSlug: string } ) {
 				/>
 			}
 			notices={
-				isSwitching || isSwitched ? (
+				showNotice ? (
 					<VersionSwitchNotice
 						backupState={ backupState }
 						targetVersion={ targetVersion === 'beta' ? betaVersion : latestVersion }
 						currentWpVersion={ site.options?.software_version ?? '' }
-						isVersionSwitched={ isSwitched }
+						isVersionSwitched={ phase.status === 'switched' }
 					/>
 				) : undefined
 			}

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -14,6 +14,8 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { getFormattedWordPressVersion } from '../../utils/wp-version';
 import { canViewWordPressSettings } from '../features';
+import { BetaProgramNotice } from './beta-program-notice';
+import { LatestVersionNotice } from './latest-version-notice';
 import { useVersionSwitch } from './use-version-switch';
 import { VersionForm } from './version-form';
 import { VersionSwitchNotice } from './version-switch-notice';
@@ -23,13 +25,39 @@ function WordPressSettingsForm( { siteSlug }: { siteSlug: string } ) {
 	const { data: currentVersion } = useQuery( siteWordPressVersionQuery( site.ID ) );
 	const versionSwitch = useVersionSwitch( site );
 	const { phase, backupState } = versionSwitch;
-	const showNotice = phase.status !== 'idle';
+	const isInProgress = phase.status === 'submitting' || phase.status === 'switching';
+	const isSwitched = phase.status === 'switched';
+	const switchedToBeta = isSwitched && phase.targetVersion === 'beta';
+	const switchedToLatest = isSwitched && phase.targetVersion === 'latest';
 
 	// Resolve the target version tag (e.g. "beta") to a display string (e.g. "7.0-RC2").
 	const { data: latestVersion = '' } = useQuery( wpOrgCoreVersionQuery() );
 	const { data: betaVersion = '' } = useQuery( wpOrgCoreVersionQuery( 'beta' ) );
 
 	const targetVersion = phase.status !== 'idle' ? phase.targetVersion : '';
+
+	let notice;
+	if ( isInProgress ) {
+		// Switching in progress — show backup/progress notices.
+		notice = (
+			<VersionSwitchNotice
+				backupState={ backupState }
+				targetVersion={ targetVersion === 'beta' ? betaVersion : latestVersion }
+			/>
+		);
+	} else if ( switchedToBeta || currentVersion === 'beta' ) {
+		// Just enrolled, or returning visit while on beta.
+		notice = (
+			<BetaProgramNotice
+				site={ site }
+				wpVersion={ betaVersion }
+				isJustEnrolled={ switchedToBeta }
+			/>
+		);
+	} else if ( switchedToLatest ) {
+		// Just switched back to stable.
+		notice = <LatestVersionNotice wpVersion={ latestVersion } />;
+	}
 
 	return (
 		<PageLayout
@@ -41,15 +69,7 @@ function WordPressSettingsForm( { siteSlug }: { siteSlug: string } ) {
 					description={ __( 'Manage your WordPress version.' ) }
 				/>
 			}
-			notices={
-				showNotice ? (
-					<VersionSwitchNotice
-						backupState={ backupState }
-						targetVersion={ targetVersion === 'beta' ? betaVersion : latestVersion }
-						isVersionSwitched={ phase.status === 'switched' }
-					/>
-				) : undefined
-			}
+			notices={ notice }
 		>
 			<VersionForm
 				key={ currentVersion }

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -40,12 +40,12 @@ function WordPressSettingsForm( { siteSlug }: { siteSlug: string } ) {
 				targetVersion={ targetVersion === 'beta' ? betaVersion : latestVersion }
 			/>
 		);
-	} else if ( switchedToBeta || currentVersion === 'beta' ) {
-		// Enrolled in beta — show program notice.
-		notice = <BetaProgramNotice site={ site } wpVersion={ betaVersion } />;
 	} else if ( switchedToLatest ) {
 		// Just switched back to stable.
 		notice = <LatestVersionNotice wpVersion={ latestVersion } />;
+	} else if ( switchedToBeta || currentVersion === 'beta' ) {
+		// Enrolled in beta — show program notice.
+		notice = <BetaProgramNotice site={ site } wpVersion={ betaVersion } />;
 	}
 
 	return (

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -46,13 +46,13 @@ function WordPressSettingsForm( { siteSlug }: { siteSlug: string } ) {
 					<VersionSwitchNotice
 						backupState={ backupState }
 						targetVersion={ targetVersion === 'beta' ? betaVersion : latestVersion }
-						currentWpVersion={ site.options?.software_version ?? '' }
 						isVersionSwitched={ phase.status === 'switched' }
 					/>
 				) : undefined
 			}
 		>
 			<VersionForm
+				key={ currentVersion }
 				site={ site }
 				currentVersion={ currentVersion }
 				versionSwitch={ versionSwitch }

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -24,20 +24,15 @@ function WordPressSettingsForm( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: currentVersion } = useQuery( siteWordPressVersionQuery( site.ID ) );
 	const versionSwitch = useVersionSwitch( site );
-	const { phase, backupState } = versionSwitch;
-	const isInProgress = phase.status === 'submitting' || phase.status === 'switching';
-	const isSwitched = phase.status === 'switched';
-	const switchedToBeta = isSwitched && phase.targetVersion === 'beta';
-	const switchedToLatest = isSwitched && phase.targetVersion === 'latest';
+	const { isSwitching, switchedToBeta, switchedToLatest, backupState, targetVersion } =
+		versionSwitch;
 
 	// Resolve the target version tag (e.g. "beta") to a display string (e.g. "7.0-RC2").
 	const { data: latestVersion = '' } = useQuery( wpOrgCoreVersionQuery() );
 	const { data: betaVersion = '' } = useQuery( wpOrgCoreVersionQuery( 'beta' ) );
 
-	const targetVersion = phase.status !== 'idle' ? phase.targetVersion : '';
-
 	let notice;
-	if ( isInProgress ) {
+	if ( isSwitching ) {
 		// Switching in progress — show backup/progress notices.
 		notice = (
 			<VersionSwitchNotice

--- a/client/dashboard/sites/settings-wordpress/latest-version-notice.tsx
+++ b/client/dashboard/sites/settings-wordpress/latest-version-notice.tsx
@@ -1,0 +1,18 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { Notice } from '../../components/notice';
+
+interface LatestVersionNoticeProps {
+	wpVersion: string;
+}
+
+export function LatestVersionNotice( { wpVersion }: LatestVersionNoticeProps ) {
+	return (
+		<Notice variant="success" title={ __( 'WordPress version updated' ) }>
+			{ sprintf(
+				// translators: %s: WordPress version, e.g. "7.0-RC2"
+				__( 'Your site is now running WordPress %s.' ),
+				wpVersion
+			) }
+		</Notice>
+	);
+}

--- a/client/dashboard/sites/settings-wordpress/test/index.test.tsx
+++ b/client/dashboard/sites/settings-wordpress/test/index.test.tsx
@@ -27,24 +27,34 @@ const site = {
 	},
 } as Site;
 
-function mockSite( mockedSite: Site ) {
+function mockApi() {
 	nock( 'https://public-api.wordpress.com' )
-		.get( `/rest/v1.1/sites/${ mockedSite.slug }` )
+		.get( `/rest/v1.1/sites/${ site.slug }` )
 		.query( true )
-		.reply( 200, mockedSite );
-}
+		.reply( 200, site );
 
-function mockWordPressVersion( version: string ) {
 	nock( 'https://public-api.wordpress.com' )
 		.get( `/wpcom/v2/sites/${ site.ID }/hosting/wp-version` )
 		.query( true )
-		.reply( 200, version );
+		.reply( 200, 'latest' );
+
+	nock( 'https://public-api.wordpress.com' )
+		.persist()
+		.get( `/wpcom/v2/sites/${ site.ID }/hosting/wp-version/pending` )
+		.query( true )
+		.reply( 200, null );
+
+	nock( 'https://public-api.wordpress.com' )
+		.persist()
+		.get( `/wpcom/v2/sites/${ site.ID }/rewind/backups` )
+		.query( true )
+		.reply( 200, [] );
 }
 
 function mockWordPressVersionSaved( expectedVersion: string ) {
 	return nock( 'https://public-api.wordpress.com' )
 		.post( `/wpcom/v2/sites/${ site.ID }/hosting/wp-version`, ( body ) => {
-			expect( body ).toEqual( { version: expectedVersion } );
+			expect( body ).toMatchObject( { version: expectedVersion } );
 			return true;
 		} )
 		.reply( 200 );
@@ -54,8 +64,7 @@ describe( '<WordPressSettings>', () => {
 	test( 'renders and saves the form for a Business+ site', async () => {
 		const user = userEvent.setup();
 
-		mockSite( site );
-		mockWordPressVersion( 'latest' );
+		mockApi();
 
 		render( <WordPressSettings siteSlug={ site.slug } /> );
 		await screen.findByRole( 'heading', { name: 'WordPress' } );

--- a/client/dashboard/sites/settings-wordpress/use-version-switch.ts
+++ b/client/dashboard/sites/settings-wordpress/use-version-switch.ts
@@ -44,11 +44,13 @@ export function reducer( state: Phase, action: Action ): Phase {
 	}
 }
 
-// --- Public interface ---
-
 export interface VersionSwitchState {
 	backupState: BackupState;
-	phase: Phase;
+	targetVersion: string;
+	isSwitching: boolean;
+	isSwitched: boolean;
+	switchedToBeta: boolean;
+	switchedToLatest: boolean;
 	mutation: ReturnType< typeof useMutation< void, Error, string > >;
 }
 
@@ -106,5 +108,16 @@ export function useVersionSwitch( site: Site ): VersionSwitchState {
 		},
 	} );
 
-	return { backupState, phase, mutation };
+	const targetVersion = phase.status !== 'idle' ? phase.targetVersion : '';
+	const isSwitched = phase.status === 'switched';
+
+	return {
+		backupState,
+		targetVersion,
+		isSwitching: phase.status === 'submitting' || phase.status === 'switching',
+		isSwitched,
+		switchedToBeta: isSwitched && phase.targetVersion === 'beta',
+		switchedToLatest: isSwitched && phase.targetVersion === 'latest',
+		mutation,
+	};
 }

--- a/client/dashboard/sites/settings-wordpress/use-version-switch.ts
+++ b/client/dashboard/sites/settings-wordpress/use-version-switch.ts
@@ -58,8 +58,8 @@ export function useVersionSwitch( site: Site ): VersionSwitchState {
 
 	// Check if there's a pending version switch.
 	const { data: pendingVersion } = useQuery( sitePendingWordPressVersionQuery( site.ID ) );
-	const isSwitching = !! pendingVersion;
-	const wasSwitching = usePrevious( isSwitching );
+	const hasPendingVersion = !! pendingVersion;
+	const hadPendingVersion = usePrevious( hasPendingVersion );
 
 	// Pending version appeared → switching.
 	useEffect( () => {
@@ -70,15 +70,15 @@ export function useVersionSwitch( site: Site ): VersionSwitchState {
 
 	// Pending version cleared → switched.
 	useEffect( () => {
-		if ( wasSwitching && ! isSwitching ) {
+		if ( hadPendingVersion && ! hasPendingVersion ) {
 			dispatch( { type: 'SWITCH_COMPLETED' } );
 			queryClient.invalidateQueries( siteWordPressVersionQuery( site.ID ) );
 			queryClient.invalidateQueries( siteBySlugQuery( site.slug ) );
 		}
-	}, [ wasSwitching, isSwitching, site.ID, site.slug ] );
+	}, [ hadPendingVersion, hasPendingVersion, site.ID, site.slug ] );
 
 	// Poll backups while a version switch is in progress (including right after mutation fires).
-	const shouldPollBackups = phase.status === 'submitting' || isSwitching;
+	const shouldPollBackups = phase.status === 'submitting' || hasPendingVersion;
 	useQuery( {
 		...siteBackupsQuery( site.ID ),
 		refetchInterval: shouldPollBackups ? 3000 : false,
@@ -88,7 +88,7 @@ export function useVersionSwitch( site: Site ): VersionSwitchState {
 	// After backup completes, poll pending version until it clears.
 	useQuery( {
 		...sitePendingWordPressVersionQuery( site.ID ),
-		refetchInterval: isSwitching && backupState.hasRecentlyCompleted ? 5000 : false,
+		refetchInterval: hasPendingVersion && backupState.hasRecentlyCompleted ? 5000 : false,
 	} );
 
 	const deferUntilBackupComplete = isEnabled( 'dashboard/wp-beta-program' );

--- a/client/dashboard/sites/settings-wordpress/use-version-switch.ts
+++ b/client/dashboard/sites/settings-wordpress/use-version-switch.ts
@@ -24,13 +24,13 @@ export type Phase =
 	| { status: 'switched'; targetVersion: string };
 
 type Action =
-	| { type: 'MUTATION_FIRED'; targetVersion: string }
+	| { type: 'VERSION_CHANGE_REQUESTED'; targetVersion: string }
 	| { type: 'SWITCH_STARTED'; targetVersion: string }
 	| { type: 'SWITCH_COMPLETED' };
 
 export function reducer( state: Phase, action: Action ): Phase {
 	switch ( action.type ) {
-		case 'MUTATION_FIRED':
+		case 'VERSION_CHANGE_REQUESTED':
 			return { status: 'submitting', targetVersion: action.targetVersion };
 		case 'SWITCH_STARTED':
 			return { status: 'switching', targetVersion: action.targetVersion };
@@ -96,7 +96,7 @@ export function useVersionSwitch( site: Site ): VersionSwitchState {
 		...siteWordPressVersionMutation( site.ID, { deferUntilBackupComplete } ),
 		onSuccess: ( _data, version ) => {
 			backupState.setEnqueued( true );
-			dispatch( { type: 'MUTATION_FIRED', targetVersion: version } );
+			dispatch( { type: 'VERSION_CHANGE_REQUESTED', targetVersion: version } );
 			queryClient.invalidateQueries( sitePendingWordPressVersionQuery( site.ID ) );
 		},
 		meta: {

--- a/client/dashboard/sites/settings-wordpress/use-version-switch.ts
+++ b/client/dashboard/sites/settings-wordpress/use-version-switch.ts
@@ -15,8 +15,6 @@ import { useBackupState } from '../backups/use-backup-state';
 import type { BackupState } from '../backups/use-backup-state';
 import type { Site } from '@automattic/api-core';
 
-// --- Explicit state machine ---
-
 export type Phase =
 	| { status: 'idle' }
 	| { status: 'submitting'; targetVersion: string }
@@ -79,11 +77,12 @@ export function useVersionSwitch( site: Site ): VersionSwitchState {
 		}
 	}, [ wasSwitching, isSwitching, site.ID, site.slug ] );
 
-	// Poll backups while switching.
+	// Poll backups while a version switch is in progress (including right after mutation fires).
+	const shouldPollBackups = phase.status === 'submitting' || isSwitching;
 	useQuery( {
 		...siteBackupsQuery( site.ID ),
-		refetchInterval: isSwitching ? 3000 : false,
-		enabled: isSwitching,
+		refetchInterval: shouldPollBackups ? 3000 : false,
+		enabled: shouldPollBackups,
 	} );
 
 	// After backup completes, poll pending version until it clears.

--- a/client/dashboard/sites/settings-wordpress/use-version-switch.ts
+++ b/client/dashboard/sites/settings-wordpress/use-version-switch.ts
@@ -49,7 +49,8 @@ export interface VersionSwitchState {
 	isSwitched: boolean;
 	switchedToBeta: boolean;
 	switchedToLatest: boolean;
-	mutation: ReturnType< typeof useMutation< void, Error, string > >;
+	switchVersion: ( version: string ) => void;
+	isSaving: boolean;
 }
 
 export function useVersionSwitch( site: Site ): VersionSwitchState {
@@ -61,12 +62,13 @@ export function useVersionSwitch( site: Site ): VersionSwitchState {
 	const hasPendingVersion = !! pendingVersion;
 	const hadPendingVersion = usePrevious( hasPendingVersion );
 
-	// Pending version appeared → switching.
+	// Pending version appeared → switching. Also start backup tracking.
 	useEffect( () => {
 		if ( pendingVersion ) {
+			backupState.setEnqueued( true );
 			dispatch( { type: 'SWITCH_STARTED', targetVersion: pendingVersion } );
 		}
-	}, [ pendingVersion ] );
+	}, [ pendingVersion ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	// Pending version cleared → switched.
 	useEffect( () => {
@@ -95,17 +97,17 @@ export function useVersionSwitch( site: Site ): VersionSwitchState {
 
 	const mutation = useMutation( {
 		...siteWordPressVersionMutation( site.ID, { deferUntilBackupComplete } ),
-		onSuccess: ( _data, version ) => {
-			backupState.setEnqueued( true );
-			dispatch( { type: 'VERSION_CHANGE_REQUESTED', targetVersion: version } );
-			queryClient.invalidateQueries( sitePendingWordPressVersionQuery( site.ID ) );
-		},
 		meta: {
 			snackbar: {
 				error: __( 'Failed to save WordPress version.' ),
 			},
 		},
 	} );
+
+	const switchVersion = ( version: string ) => {
+		dispatch( { type: 'VERSION_CHANGE_REQUESTED', targetVersion: version } );
+		mutation.mutate( version );
+	};
 
 	const targetVersion = phase.status !== 'idle' ? phase.targetVersion : '';
 	const isSwitched = phase.status === 'switched';
@@ -117,6 +119,7 @@ export function useVersionSwitch( site: Site ): VersionSwitchState {
 		isSwitched,
 		switchedToBeta: isSwitched && phase.targetVersion === 'beta',
 		switchedToLatest: isSwitched && phase.targetVersion === 'latest',
-		mutation,
+		switchVersion,
+		isSaving: mutation.isPending,
 	};
 }

--- a/client/dashboard/sites/settings-wordpress/use-version-switch.ts
+++ b/client/dashboard/sites/settings-wordpress/use-version-switch.ts
@@ -9,47 +9,74 @@ import {
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { usePrevious } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { useEffect, useState } from 'react';
+import { useEffect, useReducer } from 'react';
 import { useBackupState } from '../backups/use-backup-state';
 import type { BackupState } from '../backups/use-backup-state';
 import type { Site } from '@automattic/api-core';
 
+// --- Explicit state machine ---
+
+export type Phase =
+	| { status: 'idle' }
+	| { status: 'submitting'; targetVersion: string }
+	| { status: 'switching'; targetVersion: string }
+	| { status: 'switched'; targetVersion: string };
+
+type Action =
+	| { type: 'MUTATION_FIRED'; targetVersion: string }
+	| { type: 'SWITCH_STARTED'; targetVersion: string }
+	| { type: 'SWITCH_COMPLETED' };
+
+export function reducer( state: Phase, action: Action ): Phase {
+	switch ( action.type ) {
+		case 'MUTATION_FIRED':
+			return { status: 'submitting', targetVersion: action.targetVersion };
+		case 'SWITCH_STARTED':
+			return { status: 'switching', targetVersion: action.targetVersion };
+		case 'SWITCH_COMPLETED':
+			if ( state.status !== 'switching' ) {
+				return state;
+			}
+			return { status: 'switched', targetVersion: state.targetVersion };
+		default:
+			return state;
+	}
+}
+
+// --- Public interface ---
+
 export interface VersionSwitchState {
 	backupState: BackupState;
-	/** The pending version tag while switching, or the last one after switch completes. */
-	targetVersion: string;
-	isSwitching: boolean;
-	isSwitched: boolean;
+	phase: Phase;
 	mutation: ReturnType< typeof useMutation< void, Error, string > >;
 }
 
 export function useVersionSwitch( site: Site ): VersionSwitchState {
 	const backupState = useBackupState( site.ID );
+	const [ phase, dispatch ] = useReducer( reducer, { status: 'idle' } );
 
 	// Check if there's a pending version switch.
 	const { data: pendingVersion } = useQuery( sitePendingWordPressVersionQuery( site.ID ) );
 	const isSwitching = !! pendingVersion;
 	const wasSwitching = usePrevious( isSwitching );
-	const [ isSwitched, setIsSwitched ] = useState( false );
-	const [ targetVersion, setTargetVersion ] = useState( '' );
 
-	// Remember the pending version so we can show it in the success notice.
+	// Pending version appeared → switching.
 	useEffect( () => {
 		if ( pendingVersion ) {
-			setTargetVersion( pendingVersion );
+			dispatch( { type: 'SWITCH_STARTED', targetVersion: pendingVersion } );
 		}
 	}, [ pendingVersion ] );
 
-	// Track the transition from switching to not switching.
+	// Pending version cleared → switched.
 	useEffect( () => {
 		if ( wasSwitching && ! isSwitching ) {
-			setIsSwitched( true );
+			dispatch( { type: 'SWITCH_COMPLETED' } );
 			queryClient.invalidateQueries( siteWordPressVersionQuery( site.ID ) );
 			queryClient.invalidateQueries( siteBySlugQuery( site.slug ) );
 		}
 	}, [ wasSwitching, isSwitching, site.ID, site.slug ] );
 
-	// Poll backups while a version switch is in progress.
+	// Poll backups while switching.
 	useQuery( {
 		...siteBackupsQuery( site.ID ),
 		refetchInterval: isSwitching ? 3000 : false,
@@ -64,9 +91,9 @@ export function useVersionSwitch( site: Site ): VersionSwitchState {
 
 	const mutation = useMutation( {
 		...siteWordPressVersionMutation( site.ID ),
-		onSuccess: () => {
+		onSuccess: ( _data, version ) => {
 			backupState.setEnqueued( true );
-			setIsSwitched( false );
+			dispatch( { type: 'MUTATION_FIRED', targetVersion: version } );
 			queryClient.invalidateQueries( sitePendingWordPressVersionQuery( site.ID ) );
 		},
 		meta: {
@@ -76,11 +103,5 @@ export function useVersionSwitch( site: Site ): VersionSwitchState {
 		},
 	} );
 
-	return {
-		backupState,
-		targetVersion,
-		isSwitching,
-		isSwitched,
-		mutation,
-	};
+	return { backupState, phase, mutation };
 }

--- a/client/dashboard/sites/settings-wordpress/use-version-switch.ts
+++ b/client/dashboard/sites/settings-wordpress/use-version-switch.ts
@@ -6,6 +6,7 @@ import {
 	siteWordPressVersionQuery,
 	siteWordPressVersionMutation,
 } from '@automattic/api-queries';
+import { isEnabled } from '@automattic/calypso-config';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { usePrevious } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
@@ -89,8 +90,10 @@ export function useVersionSwitch( site: Site ): VersionSwitchState {
 		refetchInterval: isSwitching && backupState.hasRecentlyCompleted ? 5000 : false,
 	} );
 
+	const deferUntilBackupComplete = isEnabled( 'dashboard/wp-beta-program' );
+
 	const mutation = useMutation( {
-		...siteWordPressVersionMutation( site.ID ),
+		...siteWordPressVersionMutation( site.ID, { deferUntilBackupComplete } ),
 		onSuccess: ( _data, version ) => {
 			backupState.setEnqueued( true );
 			dispatch( { type: 'MUTATION_FIRED', targetVersion: version } );

--- a/client/dashboard/sites/settings-wordpress/use-version-switch.ts
+++ b/client/dashboard/sites/settings-wordpress/use-version-switch.ts
@@ -45,6 +45,7 @@ export function reducer( state: Phase, action: Action ): Phase {
 export interface VersionSwitchState {
 	backupState: BackupState;
 	targetVersion: string;
+	pendingVersion: string | null | undefined;
 	isSwitching: boolean;
 	isSwitched: boolean;
 	switchedToBeta: boolean;
@@ -115,6 +116,7 @@ export function useVersionSwitch( site: Site ): VersionSwitchState {
 	return {
 		backupState,
 		targetVersion,
+		pendingVersion,
 		isSwitching: phase.status === 'submitting' || phase.status === 'switching',
 		isSwitched,
 		switchedToBeta: isSwitched && phase.targetVersion === 'beta',

--- a/client/dashboard/sites/settings-wordpress/version-form.tsx
+++ b/client/dashboard/sites/settings-wordpress/version-form.tsx
@@ -22,7 +22,8 @@ export function VersionForm( { site, currentVersion, versionSwitch }: VersionFor
 	const { data: latestVersion } = useQuery( wpOrgCoreVersionQuery() );
 	const { data: betaVersion } = useQuery( wpOrgCoreVersionQuery( 'beta' ) );
 
-	const { isSwitching, mutation } = versionSwitch;
+	const { phase, mutation } = versionSwitch;
+	const isSwitching = phase.status === 'switching' || phase.status === 'submitting';
 
 	const [ formData, setFormData ] = useState< { version: string } >( {
 		version: currentVersion ?? '',

--- a/client/dashboard/sites/settings-wordpress/version-form.tsx
+++ b/client/dashboard/sites/settings-wordpress/version-form.tsx
@@ -28,12 +28,19 @@ export function VersionForm( { site, currentVersion, versionSwitch }: VersionFor
 		version: pendingVersion ?? currentVersion ?? '',
 	} );
 
-	// Sync form state when the current version changes (e.g. after a version switch).
+	// Sync form state when the pending version or current version changes.
+	// Pending version always takes priority over current version.
 	useEffect( () => {
-		if ( currentVersion ) {
+		if ( pendingVersion ) {
+			setFormData( { version: pendingVersion } );
+		}
+	}, [ pendingVersion ] );
+
+	useEffect( () => {
+		if ( currentVersion && ! pendingVersion ) {
 			setFormData( { version: currentVersion } );
 		}
-	}, [ currentVersion ] );
+	}, [ currentVersion, pendingVersion ] );
 
 	const currentWpVersion = site.options?.software_version ?? '';
 

--- a/client/dashboard/sites/settings-wordpress/version-form.tsx
+++ b/client/dashboard/sites/settings-wordpress/version-form.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack, Button } from '@wordpress/components';
 import { DataForm } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { NavigationBlocker } from '../../app/navigation-blocker';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
@@ -24,23 +24,13 @@ export function VersionForm( { site, currentVersion, versionSwitch }: VersionFor
 
 	const { isSwitching, pendingVersion, switchVersion, isSaving } = versionSwitch;
 
-	const [ formData, setFormData ] = useState< { version: string } >( {
-		version: pendingVersion ?? currentVersion ?? '',
+	const [ formEdits, setFormEdits ] = useState< { version: string } >( {
+		version: '',
 	} );
 
-	// Sync form state when the pending version or current version changes.
-	// Pending version always takes priority over current version.
-	useEffect( () => {
-		if ( pendingVersion ) {
-			setFormData( { version: pendingVersion } );
-		}
-	}, [ pendingVersion ] );
-
-	useEffect( () => {
-		if ( currentVersion && ! pendingVersion ) {
-			setFormData( { version: currentVersion } );
-		}
-	}, [ currentVersion, pendingVersion ] );
+	const formData = {
+		version: formEdits.version || pendingVersion || currentVersion || '',
+	};
 
 	const currentWpVersion = site.options?.software_version ?? '';
 
@@ -86,7 +76,7 @@ export function VersionForm( { site, currentVersion, versionSwitch }: VersionFor
 								fields={ fields }
 								form={ form }
 								onChange={ ( edits: { version?: string } ) => {
-									setFormData( ( data ) => ( { ...data, ...edits } ) );
+									setFormEdits( ( data ) => ( { ...data, ...edits } ) );
 								} }
 							/>
 							<ButtonStack justify="flex-start">

--- a/client/dashboard/sites/settings-wordpress/version-form.tsx
+++ b/client/dashboard/sites/settings-wordpress/version-form.tsx
@@ -22,8 +22,7 @@ export function VersionForm( { site, currentVersion, versionSwitch }: VersionFor
 	const { data: latestVersion } = useQuery( wpOrgCoreVersionQuery() );
 	const { data: betaVersion } = useQuery( wpOrgCoreVersionQuery( 'beta' ) );
 
-	const { phase, mutation } = versionSwitch;
-	const isSwitching = phase.status === 'switching' || phase.status === 'submitting';
+	const { isSwitching, mutation } = versionSwitch;
 
 	const [ formData, setFormData ] = useState< { version: string } >( {
 		version: currentVersion ?? '',

--- a/client/dashboard/sites/settings-wordpress/version-form.tsx
+++ b/client/dashboard/sites/settings-wordpress/version-form.tsx
@@ -22,10 +22,10 @@ export function VersionForm( { site, currentVersion, versionSwitch }: VersionFor
 	const { data: latestVersion } = useQuery( wpOrgCoreVersionQuery() );
 	const { data: betaVersion } = useQuery( wpOrgCoreVersionQuery( 'beta' ) );
 
-	const { isSwitching, targetVersion, switchVersion, isSaving } = versionSwitch;
+	const { isSwitching, pendingVersion, switchVersion, isSaving } = versionSwitch;
 
 	const [ formData, setFormData ] = useState< { version: string } >( {
-		version: isSwitching ? targetVersion : currentVersion ?? '',
+		version: pendingVersion ?? currentVersion ?? '',
 	} );
 
 	// Sync form state when the current version changes (e.g. after a version switch).

--- a/client/dashboard/sites/settings-wordpress/version-form.tsx
+++ b/client/dashboard/sites/settings-wordpress/version-form.tsx
@@ -22,10 +22,10 @@ export function VersionForm( { site, currentVersion, versionSwitch }: VersionFor
 	const { data: latestVersion } = useQuery( wpOrgCoreVersionQuery() );
 	const { data: betaVersion } = useQuery( wpOrgCoreVersionQuery( 'beta' ) );
 
-	const { isSwitching, mutation } = versionSwitch;
+	const { isSwitching, targetVersion, switchVersion, isSaving } = versionSwitch;
 
 	const [ formData, setFormData ] = useState< { version: string } >( {
-		version: currentVersion ?? '',
+		version: isSwitching ? targetVersion : currentVersion ?? '',
 	} );
 
 	// Sync form state when the current version changes (e.g. after a version switch).
@@ -61,11 +61,10 @@ export function VersionForm( { site, currentVersion, versionSwitch }: VersionFor
 	};
 
 	const isDirty = formData.version !== currentVersion;
-	const { isPending } = mutation;
 
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
-		mutation.mutate( formData.version );
+		switchVersion( formData.version );
 	};
 
 	return (
@@ -87,8 +86,8 @@ export function VersionForm( { site, currentVersion, versionSwitch }: VersionFor
 								<Button
 									variant="primary"
 									type="submit"
-									isBusy={ isPending }
-									disabled={ isPending || ! isDirty || isSwitching }
+									isBusy={ isSaving }
+									disabled={ isSaving || ! isDirty || isSwitching }
 								>
 									{ __( 'Save' ) }
 								</Button>

--- a/client/dashboard/sites/settings-wordpress/version-form.tsx
+++ b/client/dashboard/sites/settings-wordpress/version-form.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack, Button } from '@wordpress/components';
 import { DataForm } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { NavigationBlocker } from '../../app/navigation-blocker';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
@@ -27,6 +27,13 @@ export function VersionForm( { site, currentVersion, versionSwitch }: VersionFor
 	const [ formData, setFormData ] = useState< { version: string } >( {
 		version: currentVersion ?? '',
 	} );
+
+	// Sync form state when the current version changes (e.g. after a version switch).
+	useEffect( () => {
+		if ( currentVersion ) {
+			setFormData( { version: currentVersion } );
+		}
+	}, [ currentVersion ] );
 
 	const currentWpVersion = site.options?.software_version ?? '';
 

--- a/client/dashboard/sites/settings-wordpress/version-switch-notice.tsx
+++ b/client/dashboard/sites/settings-wordpress/version-switch-notice.tsx
@@ -5,14 +5,12 @@ import type { BackupState } from '../backups/use-backup-state';
 interface VersionSwitchNoticeProps {
 	backupState: BackupState;
 	targetVersion: string;
-	currentWpVersion: string;
 	isVersionSwitched: boolean;
 }
 
 export function VersionSwitchNotice( {
 	backupState,
 	targetVersion,
-	currentWpVersion,
 	isVersionSwitched,
 }: VersionSwitchNoticeProps ) {
 	const { status, backup } = backupState;
@@ -23,7 +21,7 @@ export function VersionSwitchNotice( {
 				{ sprintf(
 					// translators: %s: WordPress version, e.g. "7.0-RC2"
 					__( 'Your site is now running WordPress %s.' ),
-					currentWpVersion
+					targetVersion
 				) }
 			</Notice>
 		);

--- a/client/dashboard/sites/settings-wordpress/version-switch-notice.tsx
+++ b/client/dashboard/sites/settings-wordpress/version-switch-notice.tsx
@@ -5,27 +5,10 @@ import type { BackupState } from '../backups/use-backup-state';
 interface VersionSwitchNoticeProps {
 	backupState: BackupState;
 	targetVersion: string;
-	isVersionSwitched: boolean;
 }
 
-export function VersionSwitchNotice( {
-	backupState,
-	targetVersion,
-	isVersionSwitched,
-}: VersionSwitchNoticeProps ) {
+export function VersionSwitchNotice( { backupState, targetVersion }: VersionSwitchNoticeProps ) {
 	const { status, backup } = backupState;
-
-	if ( isVersionSwitched ) {
-		return (
-			<Notice variant="success" title={ __( 'WordPress version updated' ) }>
-				{ sprintf(
-					// translators: %s: WordPress version, e.g. "7.0-RC2"
-					__( 'Your site is now running WordPress %s.' ),
-					targetVersion
-				) }
-			</Notice>
-		);
-	}
 
 	if ( status === 'enqueued' ) {
 		return (

--- a/packages/api-core/src/site-hosting/mutators.ts
+++ b/packages/api-core/src/site-hosting/mutators.ts
@@ -34,13 +34,20 @@ export async function restoreSitePlanSoftware( siteId: number ) {
 	} );
 }
 
-export async function updateWordPressVersion( siteId: number, version: string ) {
+export async function updateWordPressVersion(
+	siteId: number,
+	version: string,
+	deferUntilBackupComplete?: boolean
+) {
 	return wpcom.req.post(
 		{
 			path: `/sites/${ siteId }/hosting/wp-version`,
 			apiNamespace: 'wpcom/v2',
 		},
-		{ version }
+		{
+			version,
+			...( deferUntilBackupComplete && { defer_until_backup_complete: true } ),
+		}
 	);
 }
 

--- a/packages/api-queries/src/site-wordpress-version.ts
+++ b/packages/api-queries/src/site-wordpress-version.ts
@@ -18,9 +18,13 @@ export const sitePendingWordPressVersionQuery = ( siteId: number ) =>
 		queryFn: () => fetchPendingWordPressVersion( siteId ),
 	} );
 
-export const siteWordPressVersionMutation = ( siteId: number ) =>
+export const siteWordPressVersionMutation = (
+	siteId: number,
+	options?: { deferUntilBackupComplete?: boolean }
+) =>
 	mutationOptions( {
-		mutationFn: ( version: string ) => updateWordPressVersion( siteId, version ),
+		mutationFn: ( version: string ) =>
+			updateWordPressVersion( siteId, version, options?.deferUntilBackupComplete ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( siteWordPressVersionQuery( siteId ) );
 			queryClient.invalidateQueries( sitePendingWordPressVersionQuery( siteId ) );


### PR DESCRIPTION
Built on top of #109795

## Proposed Changes

* Add explicit reducer state machine for version switch lifecycle (idle → submitting → switching → switched)
* Add permanent beta program notice when enrolled in beta, with Help Center support link and backup link
* Add transient confirmation notice when switching back to latest stable release
* Fix stale form state after version switch by keying VersionForm on currentVersion
* Defer version switch until backup completes (behind `dashboard/wp-beta-program` flag)
* Split WordPress settings into separate components (VersionForm, VersionSwitchNotice, BetaProgramNotice, LatestVersionNotice)


**Screenshot**

<img width="748" height="517" alt="Screenshot 2026-04-03 at 2 54 14 PM" src="https://github.com/user-attachments/assets/6c093995-3365-4e12-9c7c-23f0b085663f" />

<img width="757" height="520" alt="Screenshot 2026-04-03 at 3 04 45 PM" src="https://github.com/user-attachments/assets/a775b8f8-f07e-4a2c-8c59-906d7b722994" />



## Why are these changes being made?

Builds on #109795 to provide clear user feedback throughout the WordPress version switch lifecycle. Users enrolled in the beta program now see a persistent notice explaining the program with links to support and backups. The reducer refactor eliminates impossible state combinations and makes the switch lifecycle explicit and testable.

## Testing Instructions

* Enable the `dashboard/wp-beta-program` feature flag
* Navigate to Sites > Settings > WordPress
* Switch to beta version — verify progress notices show during backup and switch
* After switch completes, verify the beta program notice appears with support and backup links
* Refresh the page — verify the beta program notice persists
* Switch back to latest — verify the "WordPress version updated" confirmation appears
* Verify the form resets correctly after each switch (no stale dirty state)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?