### PR TITLE
Disable building Calypso apps unless a label is added

### DIFF
--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -179,8 +179,7 @@ object CalypsoApps: BuildType({
 					exit 0
 				fi
 
-				# Non-PR topic branches: keep previous behavior (build without label).
-				exit 0
+				cancel "Skipped Calypso apps build - branch is not a PR and not trunk"
 			"""
 		}
 		mergeTrunk()

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -9,10 +9,11 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.ScriptBuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.perfmon
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.PullRequests
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.pullRequests
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.commitStatusPublisher
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
 private const val CALYPSO_APPS_PR_LABEL = "Build Calypso apps"
+private const val GITHUB_STATUS_CONTEXT = "Build Calypso Apps"
 
 object WPComPlugins : Project({
 	id("WPComPlugins")
@@ -59,10 +60,9 @@ object CalypsoApps: BuildType({
 	uuid = "8453b8fe-226f-4e91-b5cc-8bdad15e0814"
 	name = "Build Calypso Apps"
 	description = """
-		Builds all Calypso apps and saves release artifacts for each. This replaces the separate build configurations for each app.
-		On pull request branches, runs only when the GitHub label "${CALYPSO_APPS_PR_LABEL}" is present (otherwise the build is canceled).
-		On the default branch, runs only when the commit is associated with a merged PR that had that label (otherwise canceled).
-		Other branch pushes are unchanged.
+		Builds all Calypso apps and saves release artifacts for each.
+		Gated by the "${CALYPSO_APPS_PR_LABEL}" GitHub label: only runs on labeled PRs and trunk merges from labeled PRs.
+		Build status is published to GitHub manually (no commit status publisher) so unlabeled builds stay invisible.
 	""".trimIndent()
 
 	buildNumberPattern = "%build.prefix%.%build.counter%"
@@ -89,15 +89,6 @@ object CalypsoApps: BuildType({
 					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
 				}
 				filterAuthorRole = PullRequests.GitHubRoleFilter.EVERYBODY
-			}
-		}
-		commitStatusPublisher {
-			vcsRootExtId = "${Settings.WpCalypso.id}"
-			publisher = github {
-				githubUrl = "https://api.github.com"
-				authType = personalToken {
-					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
-				}
 			}
 		}
 	}
@@ -134,7 +125,7 @@ object CalypsoApps: BuildType({
 
 	steps {
 		bashNodeScript {
-			name = "Require \"$CALYPSO_APPS_PR_LABEL\" label (PR or labeled merge to trunk)"
+			name = "Check for required \"$CALYPSO_APPS_PR_LABEL\" label"
 			scriptContent = """
 				LABEL='$CALYPSO_APPS_PR_LABEL'
 				REPO='Automattic/wp-calypso'
@@ -143,16 +134,34 @@ object CalypsoApps: BuildType({
 				BRANCH_RAW='%teamcity.build.branch%'
 				COMMIT_SHA='%build.vcs.number%'
 				BRANCH="${'$'}{BRANCH_RAW#refs/heads/}"
+				BUILD_URL='%teamcity.serverUrl%/viewLog.html?buildId=%teamcity.build.id%'
+				CONTEXT='$GITHUB_STATUS_CONTEXT'
 
 				cancel() {
 					echo "##teamcity[buildStop comment='${'$'}1' readdToQueue='false']"
+				}
+
+				post_status() {
+					local json
+					json=${'$'}(jq -n --arg s "${'$'}1" --arg u "${'$'}BUILD_URL" --arg d "${'$'}2" --arg c "${'$'}CONTEXT" \
+						'{state: ${'$'}s, target_url: ${'$'}u, description: ${'$'}d, context: ${'$'}c}')
+					curl -fsS -X POST \
+						-H "Authorization: token ${'$'}GH_TOKEN" \
+						-H "Accept: application/vnd.github+json" \
+						"https://api.github.com/repos/${'$'}REPO/statuses/${'$'}COMMIT_SHA" \
+						-d "${'$'}json" || true
 				}
 
 				pr_json_has_label() {
 					echo "${'$'}1" | jq -e --arg want "${'$'}LABEL" '(.labels // []) | map(.name) | index(${'$'}want) != null' >/dev/null 2>&1
 				}
 
-				# Default branch (trunk): only if this commit is linked to a merged PR that has the label.
+				label_found() {
+					echo "##teamcity[setParameter name='env.CALYPSO_APPS_LABEL_FOUND' value='true']"
+					post_status "pending" "Build started"
+				}
+
+				# Default branch (trunk): only build if this commit came from a merged PR with the label.
 				if [ "${'$'}IS_DEFAULT" = "true" ]; then
 					PULLS_JSON="${'$'}(curl -fsS -H "Authorization: token ${'$'}GH_TOKEN" -H "Accept: application/vnd.github.groot-preview+json" "https://api.github.com/repos/${'$'}REPO/commits/${'$'}COMMIT_SHA/pulls")"
 					FOUND='false'
@@ -164,22 +173,26 @@ object CalypsoApps: BuildType({
 						fi
 					done < <(echo "${'$'}PULLS_JSON" | jq -c '.[]')
 					if [ "${'$'}FOUND" != "true" ]; then
-						cancel "Skipped Calypso apps build - trunk commit is not linked to a PR with the required label"
+						cancel "Skipped - trunk commit has no linked PR with the ${'$'}LABEL label"
+						exit 0
 					fi
+					label_found
 					exit 0
 				fi
 
-				# GitHub pull request branch in TeamCity (pull/<n>/head or pull/<n>/merge).
+				# Pull request branch (pull/<n>/head or pull/<n>/merge).
 				if [[ "${'$'}BRANCH" =~ ^pull/([0-9]+)/(head|merge)${'$'} ]]; then
 					PR="${'$'}{BASH_REMATCH[1]}"
 					PR_JSON="${'$'}(curl -fsS -H "Authorization: token ${'$'}GH_TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/${'$'}REPO/pulls/${'$'}PR")"
 					if ! pr_json_has_label "${'$'}PR_JSON"; then
-						cancel "Skipped Calypso apps build - add the required label to this pull request"
+						cancel "Skipped - add the ${'$'}LABEL label to PR #${'$'}PR"
+						exit 0
 					fi
+					label_found
 					exit 0
 				fi
 
-				cancel "Skipped Calypso apps build - branch is not a PR and not trunk"
+				cancel "Skipped - branch is not a PR and not trunk"
 			"""
 		}
 		mergeTrunk()
@@ -239,6 +252,45 @@ object CalypsoApps: BuildType({
 				export skip_build_diff="%skip_release_diff%"
 
 				node ./bin/process-calypso-app-artifacts.mjs
+			"""
+		}
+
+		bashNodeScript {
+			name = "Mark build successful"
+			scriptContent = """
+				echo "##teamcity[setParameter name='env.CALYPSO_APPS_BUILD_OK' value='true']"
+			"""
+		}
+
+		bashNodeScript {
+			name = "Report build status to GitHub"
+			executionMode = BuildStep.ExecutionMode.ALWAYS
+			scriptContent = """
+				if [ "${'$'}{CALYPSO_APPS_LABEL_FOUND:-}" != "true" ]; then
+					exit 0
+				fi
+
+				export GH_TOKEN='%matticbot_oauth_token%'
+				COMMIT_SHA='%build.vcs.number%'
+				BUILD_URL='%teamcity.serverUrl%/viewLog.html?buildId=%teamcity.build.id%'
+				CONTEXT='$GITHUB_STATUS_CONTEXT'
+				REPO='Automattic/wp-calypso'
+
+				if [ "${'$'}{CALYPSO_APPS_BUILD_OK:-}" = "true" ]; then
+					STATE='success'
+					DESC='Build finished successfully'
+				else
+					STATE='failure'
+					DESC='Build failed'
+				fi
+
+				json=${'$'}(jq -n --arg s "${'$'}STATE" --arg u "${'$'}BUILD_URL" --arg d "${'$'}DESC" --arg c "${'$'}CONTEXT" \
+					'{state: ${'$'}s, target_url: ${'$'}u, description: ${'$'}d, context: ${'$'}c}')
+				curl -fsS -X POST \
+					-H "Authorization: token ${'$'}GH_TOKEN" \
+					-H "Accept: application/vnd.github+json" \
+					"https://api.github.com/repos/${'$'}REPO/statuses/${'$'}COMMIT_SHA" \
+					-d "${'$'}json" || true
 			"""
 		}
 	}

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -12,6 +12,8 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.pullRequests
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.commitStatusPublisher
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
+private const val CALYPSO_APPS_PR_LABEL = "Build Calypso apps"
+
 object WPComPlugins : Project({
 	id("WPComPlugins")
 	name = "WPCom Plugins"
@@ -56,7 +58,12 @@ object CalypsoApps: BuildType({
 	id("calypso_WPComPlugins_Build_Plugins")
 	uuid = "8453b8fe-226f-4e91-b5cc-8bdad15e0814"
 	name = "Build Calypso Apps"
-	description = "Builds all Calypso apps and saves release artifacts for each. This replaces the separate build configurations for each app."
+	description = """
+		Builds all Calypso apps and saves release artifacts for each. This replaces the separate build configurations for each app.
+		On pull request branches, runs only when the GitHub label "${CALYPSO_APPS_PR_LABEL}" is present (otherwise the build is canceled).
+		On the default branch, runs only when the commit is associated with a merged PR that had that label (otherwise canceled).
+		Other branch pushes are unchanged.
+	""".trimIndent()
 
 	buildNumberPattern = "%build.prefix%.%build.counter%"
 	params {
@@ -97,10 +104,8 @@ object CalypsoApps: BuildType({
 
 	triggers {
 		vcs {
-			branchFilter = """
-				+:*
-				-:pull*
-			""".trimIndent()
+			// Include refs like pull/<id>/head so PRs are built; gating is done in the first build step (label + trunk merge rules).
+			branchFilter = "+:*"
 			triggerRules = """
 				-:test/e2e/**
 				-:docs/**.md
@@ -128,6 +133,56 @@ object CalypsoApps: BuildType({
 	""".trimIndent()
 
 	steps {
+		bashNodeScript {
+			name = "Require \"$CALYPSO_APPS_PR_LABEL\" label (PR or labeled merge to trunk)"
+			scriptContent = """
+				LABEL='$CALYPSO_APPS_PR_LABEL'
+				REPO='Automattic/wp-calypso'
+				export GH_TOKEN='%matticbot_oauth_token%'
+				IS_DEFAULT='%teamcity.build.branch.is_default%'
+				BRANCH_RAW='%teamcity.build.branch%'
+				COMMIT_SHA='%build.vcs.number%'
+				BRANCH="${'$'}{BRANCH_RAW#refs/heads/}"
+
+				cancel() {
+					echo "##teamcity[buildStop comment='${'$'}1' readdToQueue='false']"
+				}
+
+				pr_json_has_label() {
+					echo "${'$'}1" | jq -e --arg want "${'$'}LABEL" '(.labels // []) | map(.name) | index(${'$'}want) != null' >/dev/null 2>&1
+				}
+
+				# Default branch (trunk): only if this commit is linked to a merged PR that has the label.
+				if [ "${'$'}IS_DEFAULT" = "true" ]; then
+					PULLS_JSON="${'$'}(curl -fsS -H "Authorization: token ${'$'}GH_TOKEN" -H "Accept: application/vnd.github.groot-preview+json" "https://api.github.com/repos/${'$'}REPO/commits/${'$'}COMMIT_SHA/pulls")"
+					FOUND='false'
+					while read -r pr_json; do
+						[ -z "${'$'}pr_json" ] && continue
+						if pr_json_has_label "${'$'}pr_json"; then
+							FOUND='true'
+							break
+						fi
+					done < <(echo "${'$'}PULLS_JSON" | jq -c '.[]')
+					if [ "${'$'}FOUND" != "true" ]; then
+						cancel "Skipped Calypso apps build - trunk commit is not linked to a PR with the required label"
+					fi
+					exit 0
+				fi
+
+				# GitHub pull request branch in TeamCity (pull/<n>/head or pull/<n>/merge).
+				if [[ "${'$'}BRANCH" =~ ^pull/([0-9]+)/(head|merge)${'$'} ]]; then
+					PR="${'$'}{BASH_REMATCH[1]}"
+					PR_JSON="${'$'}(curl -fsS -H "Authorization: token ${'$'}GH_TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/${'$'}REPO/pulls/${'$'}PR")"
+					if ! pr_json_has_label "${'$'}PR_JSON"; then
+						cancel "Skipped Calypso apps build - add the required label to this pull request"
+					fi
+					exit 0
+				fi
+
+				# Non-PR topic branches: keep previous behavior (build without label).
+				exit 0
+			"""
+		}
 		mergeTrunk()
 		bashNodeScript {
 			name = "Install dependencies"


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
