### PR TITLE
Agents Manager: Bump agenttic packages to v0.1.58

### DIFF
--- a/packages/agents-manager/package.json
+++ b/packages/agents-manager/package.json
@@ -41,8 +41,8 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.57",
-		"@automattic/agenttic-ui": "^0.1.57",
+		"@automattic/agenttic-client": "^0.1.58",
+		"@automattic/agenttic-ui": "^0.1.58",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",

--- a/packages/block-notes/package.json
+++ b/packages/block-notes/package.json
@@ -41,7 +41,7 @@
 	},
 	"dependencies": {
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-client": "^0.1.57",
+		"@automattic/agenttic-client": "^0.1.58",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@wordpress/abilities": "^0.4.0",
 		"@wordpress/api-fetch": "^7.23.0",

--- a/packages/image-studio/package.json
+++ b/packages/image-studio/package.json
@@ -51,8 +51,8 @@
 	},
 	"dependencies": {
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-client": "^0.1.57",
-		"@automattic/agenttic-ui": "^0.1.57",
+		"@automattic/agenttic-client": "^0.1.58",
+		"@automattic/agenttic-ui": "^0.1.58",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/oauth-token": "workspace:^",
 		"@wordpress/abilities": "^0.4.0",

--- a/packages/odie-client/package.json
+++ b/packages/odie-client/package.json
@@ -41,7 +41,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-ui": "^0.1.57",
+		"@automattic/agenttic-ui": "^0.1.58",
 		"@automattic/components": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/zendesk-client": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -141,8 +141,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/agents-manager@workspace:packages/agents-manager"
   dependencies:
-    "@automattic/agenttic-client": "npm:^0.1.57"
-    "@automattic/agenttic-ui": "npm:^0.1.57"
+    "@automattic/agenttic-client": "npm:^0.1.58"
+    "@automattic/agenttic-ui": "npm:^0.1.58"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
@@ -174,9 +174,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/agenttic-client@npm:^0.1.57":
-  version: 0.1.57
-  resolution: "@automattic/agenttic-client@npm:0.1.57"
+"@automattic/agenttic-client@npm:^0.1.58":
+  version: 0.1.58
+  resolution: "@automattic/agenttic-client@npm:0.1.58"
   dependencies:
     "@types/react": "npm:^18.0.0"
     marked: "npm:^16.2.1"
@@ -190,7 +190,7 @@ __metadata:
   peerDependenciesMeta:
     "@wordpress/api-fetch":
       optional: true
-  checksum: edfa220594eb3dd34f64d1d5d65d8a7dbae9b1e527db56eff92dfe7ae973231497f675d8688e592db7449e3457640306eb02ef4348c939887e314ac512cd7c5b
+  checksum: 56f7c576329369a8c3e827112ea2f930b333c0e1eae4c4f80b2d3064a93ea9671317b5a90c2d91dfa2eb2bcb93bff8e6ffc24c72b7de5ed031d3f68346586e90
   languageName: node
   linkType: hard
 
@@ -223,6 +223,38 @@ __metadata:
     marked:
       optional: true
   checksum: 6cdd969d79263bc10d73fe647416c5f72dbb9bc061e149f8063d369a4b7a4806ff61dac3605bb2dd501bfb4361cb0b9c03d2874a3671466c73e31ea88ad1087d
+  languageName: node
+  linkType: hard
+
+"@automattic/agenttic-ui@npm:^0.1.58":
+  version: 0.1.58
+  resolution: "@automattic/agenttic-ui@npm:0.1.58"
+  dependencies:
+    "@automattic/charts": "npm:>=0.58.0 <1.0.0"
+    "@floating-ui/react-dom": "npm:^2.1.6"
+    "@radix-ui/react-scroll-area": "npm:^1.2.9"
+    "@radix-ui/react-slot": "npm:^1.2.3"
+    "@visx/xychart": "npm:^3.12.0"
+    "@wordpress/i18n": "npm:^6.1.0"
+    class-variance-authority: "npm:^0.7.1"
+    clsx: "npm:^2.1.1"
+    framer-motion: "npm:^12.23.0"
+    lucide-react: "npm:^0.525.0"
+    marked: "npm:^16.2.1"
+    react: "npm:^18.0.0"
+    react-dom: "npm:^18.0.0"
+    react-markdown: "npm:^10.1.0"
+    react-textarea-autosize: "npm:^8.5.9"
+    remark-gfm: "npm:^4.0.1"
+    unified: "npm:^11.0.5"
+    use-debounce: "npm:^10.0.6"
+  peerDependencies:
+    react: ^18.0.0
+    react-dom: ^18.0.0
+  dependenciesMeta:
+    marked:
+      optional: true
+  checksum: 0488aace57988ef5cd260dad10edce3f1404f11d66acd0136fac8008065fc7c2654c685ade6733fc202cc36e705215502ca04cc4808814682a69e9a104624877
   languageName: node
   linkType: hard
 
@@ -346,7 +378,7 @@ __metadata:
   resolution: "@automattic/block-notes@workspace:packages/block-notes"
   dependencies:
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-client": "npm:^0.1.57"
+    "@automattic/agenttic-client": "npm:^0.1.58"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@testing-library/react": "npm:^15.0.0"
@@ -1443,8 +1475,8 @@ __metadata:
   resolution: "@automattic/image-studio@workspace:packages/image-studio"
   dependencies:
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-client": "npm:^0.1.57"
-    "@automattic/agenttic-ui": "npm:^0.1.57"
+    "@automattic/agenttic-client": "npm:^0.1.58"
+    "@automattic/agenttic-ui": "npm:^0.1.58"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/oauth-token": "workspace:^"
@@ -1777,7 +1809,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/odie-client@workspace:packages/odie-client"
   dependencies:
-    "@automattic/agenttic-ui": "npm:^0.1.57"
+    "@automattic/agenttic-ui": "npm:^0.1.58"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -194,39 +194,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@automattic/agenttic-ui@npm:^0.1.57":
-  version: 0.1.57
-  resolution: "@automattic/agenttic-ui@npm:0.1.57"
-  dependencies:
-    "@automattic/charts": "npm:>=0.58.0 <1.0.0"
-    "@floating-ui/react-dom": "npm:^2.1.6"
-    "@radix-ui/react-scroll-area": "npm:^1.2.9"
-    "@radix-ui/react-slot": "npm:^1.2.3"
-    "@visx/xychart": "npm:^3.12.0"
-    "@wordpress/i18n": "npm:^6.1.0"
-    class-variance-authority: "npm:^0.7.1"
-    clsx: "npm:^2.1.1"
-    framer-motion: "npm:^12.23.0"
-    lucide-react: "npm:^0.525.0"
-    marked: "npm:^16.2.1"
-    react: "npm:^18.0.0"
-    react-dom: "npm:^18.0.0"
-    react-markdown: "npm:^10.1.0"
-    react-textarea-autosize: "npm:^8.5.9"
-    remark-gfm: "npm:^4.0.1"
-    unified: "npm:^11.0.5"
-    use-debounce: "npm:^10.0.6"
-  peerDependencies:
-    react: ^18.0.0
-    react-dom: ^18.0.0
-  dependenciesMeta:
-    marked:
-      optional: true
-  checksum: 6cdd969d79263bc10d73fe647416c5f72dbb9bc061e149f8063d369a4b7a4806ff61dac3605bb2dd501bfb4361cb0b9c03d2874a3671466c73e31ea88ad1087d
-  languageName: node
-  linkType: hard
-
-"@automattic/agenttic-ui@npm:^0.1.58":
+"@automattic/agenttic-ui@npm:^0.1.57, @automattic/agenttic-ui@npm:^0.1.58":
   version: 0.1.58
   resolution: "@automattic/agenttic-ui@npm:0.1.58"
   dependencies:


### PR DESCRIPTION
## Summary
- Bump `@automattic/agenttic-client` and `@automattic/agenttic-ui` to `^0.1.58` across all consuming packages

### Key fix in v0.1.58
- Fix `continueTaskStreamed` argument order (`313-gh-Automattic/agenttic`) — `fetchCallback`, `toolProvider`, and `contextProvider` were passed in the wrong order, causing streaming errors when abilities returned to agents

### Packages updated
- `@automattic/agents-manager`
- `@automattic/block-notes`
- `@automattic/image-studio`
- `@automattic/odie-client`

## Test plan
- [ ] Verify site builder ability flow (e.g., set-processing-state) completes without streaming errors
- [ ] Verify Help Center agent chat works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)