### PR TITLE
Agents Manager: Remove SILENT_TOOL_IDS workaround for set-processing-state

### DIFF
--- a/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
+++ b/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
@@ -5,9 +5,6 @@ import { isEditorPage } from './is-editor-page';
 import type { GetChatComponent } from './load-external-providers';
 import type { UIMessage } from '@automattic/agenttic-client';
 
-// Tool IDs that are silently dropped without a console warning.
-const SILENT_TOOL_IDS = [ 'big_sky__set_processing_state' ];
-
 /**
  * Scans message content blocks for JSON-encoded sources data and replaces
  * those blocks with a SourcesDisplay component. Text blocks that don't parse
@@ -223,10 +220,8 @@ export default function convertToolMessagesToComponents( {
 		}
 
 		// Remove unhandled tool messages to avoid displaying raw JSON to the user.
-		if ( ! SILENT_TOOL_IDS.includes( textData.tool_id ) ) {
-			// eslint-disable-next-line no-console
-			console.warn( `[AgentsManager] Unhandled tool message with tool_id: ${ textData.tool_id }` );
-		}
+		// eslint-disable-next-line no-console
+		console.warn( `[AgentsManager] Unhandled tool message with tool_id: ${ textData.tool_id }` );
 		return [];
 	} );
 }


### PR DESCRIPTION
## Summary
- Remove `SILENT_TOOL_IDS` allowlist from `convertToolMessagesToComponents`
- `big_sky__set_processing_state` now sends `localToolRunningMessage` as `agentMessage`, so orchestrator-chat filters it out before reaching this function
- Unhandled tool messages now always log a warning, with no silent exceptions

**Depends on:** Big Sky PR `5931-gh-Automattic/big-sky-plugin` (set-processing-state `agentMessage` change)

## Test plan
- [ ] Verify set-processing-state tool messages are hidden from the chat UI
- [ ] Verify unhandled tool messages log a console warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)