### PR TITLE
Dashboard MCP: show 'Add to specific sites' when account MCP is disabled

### DIFF
--- a/client/dashboard/components/icon-list/icon-list-item.tsx
+++ b/client/dashboard/components/icon-list/icon-list-item.tsx
@@ -58,9 +58,8 @@ function UnforwardedIconListItem(
 	const layoutConfig = LAYOUT_CONFIG[ layout ];
 	const { Component: LayoutComponent } = layoutConfig;
 
-	// Description forces top alignment in stacked layout; inline stays centered.
-	const outerAlignment =
-		layout === 'stacked' && description ? 'flex-start' : layoutConfig.outerAlignment;
+	// Description forces top alignment regardless of layout
+	const outerAlignment = description ? 'flex-start' : layoutConfig.outerAlignment;
 
 	return (
 		<VStack className={ clsx( 'icon-list-item', className ) } ref={ ref } as="span">

--- a/client/dashboard/components/icon-list/icon-list-item.tsx
+++ b/client/dashboard/components/icon-list/icon-list-item.tsx
@@ -58,8 +58,9 @@ function UnforwardedIconListItem(
 	const layoutConfig = LAYOUT_CONFIG[ layout ];
 	const { Component: LayoutComponent } = layoutConfig;
 
-	// Description forces top alignment regardless of layout
-	const outerAlignment = description ? 'flex-start' : layoutConfig.outerAlignment;
+	// Description forces top alignment in stacked layout; inline stays centered.
+	const outerAlignment =
+		layout === 'stacked' && description ? 'flex-start' : layoutConfig.outerAlignment;
 
 	return (
 		<VStack className={ clsx( 'icon-list-item', className ) } ref={ ref } as="span">

--- a/client/dashboard/me/mcp/index.tsx
+++ b/client/dashboard/me/mcp/index.tsx
@@ -3,7 +3,7 @@ import config from '@automattic/calypso-config';
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { Icon, __experimentalVStack as VStack, ToggleControl } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { seen, pencil, notAllowed, connection } from '@wordpress/icons';
+import { seen, pencil, notAllowed, connection, globe } from '@wordpress/icons';
 import {
 	getAccountMcpAbilities,
 	getDisabledSiteIds,
@@ -87,6 +87,11 @@ function McpComponent() {
 		exceptionCount > 0
 			? { text: `${ exceptionCount } exceptions`, intent: 'warning' as const }
 			: { text: __( 'No exceptions' ) };
+
+	const addSiteBadge =
+		enabledSiteIds.length > 0
+			? { text: `${ enabledSiteIds.length } sites`, intent: 'success' as const }
+			: { text: __( 'No sites added' ) };
 
 	const readBadge = getReadBadge( readTools );
 	const writeBadge = getWriteBadge( writeTools );
@@ -189,6 +194,18 @@ function McpComponent() {
 								title={ __( 'Site exceptions' ) }
 								decoration={ <Icon icon={ notAllowed } size={ 24 } /> }
 								badges={ [ exceptionBadge ] }
+							/>
+						</>
+					) }
+					{ ! mcpEnabled && (
+						<>
+							<CardDivider />
+							<RouterLinkSummaryButton
+								to="/me/preferences/mcp/mcp-sites"
+								density="medium"
+								title={ __( 'Add to specific sites' ) }
+								decoration={ <Icon icon={ globe } size={ 24 } /> }
+								badges={ [ addSiteBadge ] }
 							/>
 						</>
 					) }

--- a/client/dashboard/me/mcp/mcp-sites/index.tsx
+++ b/client/dashboard/me/mcp/mcp-sites/index.tsx
@@ -10,11 +10,13 @@ import {
 } from '../../../../me/mcp/utils';
 import Breadcrumbs from '../../../app/breadcrumbs';
 import { useAppContext } from '../../../app/context';
+import { siteSettingsAIToolsRoute } from '../../../app/router/sites';
 import { ActionList } from '../../../components/action-list';
 import { Card, CardBody } from '../../../components/card';
 import ComponentViewTracker from '../../../components/component-view-tracker';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
+import RouterLinkButton from '../../../components/router-link-button';
 import { SectionHeader } from '../../../components/section-header';
 import SiteIcon from '../../../components/site-icon';
 import { getSiteDisplayName } from '../../../utils/site-name';
@@ -163,13 +165,14 @@ export default function McpMcpSites() {
 									actions={
 										<>
 											{ site.slug && (
-												<Button
+												<RouterLinkButton
 													variant="tertiary"
 													size="compact"
-													href={ `/sites/${ site.slug }/settings/ai-tools` }
+													to={ siteSettingsAIToolsRoute.fullPath }
+													params={ { siteSlug: site.slug } }
 												>
 													{ __( 'Manage' ) }
-												</Button>
+												</RouterLinkButton>
 											) }
 											<Button
 												variant="secondary"

--- a/client/dashboard/me/mcp/mcp-sites/index.tsx
+++ b/client/dashboard/me/mcp/mcp-sites/index.tsx
@@ -47,6 +47,7 @@ export default function McpMcpSites() {
 			id: siteId,
 			name: site ? getSiteDisplayName( site ) : String( siteId ),
 			displayUrl: site ? getSiteDisplayUrl( site ) : '',
+			slug: site?.slug ?? null,
 			site: site ?? null,
 		};
 	};
@@ -158,9 +159,18 @@ export default function McpMcpSites() {
 									key={ site.id }
 									title={ site.name }
 									description={ site.displayUrl || undefined }
-									decoration={ site.site ? <SiteIcon site={ site.site } size={ 32 } /> : undefined }
+									decoration={ site.site ? <SiteIcon site={ site.site } size={ 40 } /> : undefined }
 									actions={
 										<>
+											{ site.slug && (
+												<Button
+													variant="tertiary"
+													size="compact"
+													href={ `/sites/${ site.slug }/settings/ai-tools` }
+												>
+													{ __( 'Manage' ) }
+												</Button>
+											) }
 											<Button
 												variant="secondary"
 												size="compact"

--- a/client/dashboard/me/mcp/mcp-sites/index.tsx
+++ b/client/dashboard/me/mcp/mcp-sites/index.tsx
@@ -67,13 +67,25 @@ export default function McpMcpSites() {
 		},
 	} );
 
-	const handleSiteToggle = ( siteId: number, enabled: boolean ) => {
+	const handleSiteAdd = ( siteId: number ) => {
 		mutation.mutate( {
 			mcp_abilities: {
 				sites: [
-					enabled
-						? { blog_id: siteId, account_tools_enabled: true }
-						: { blog_id: siteId, site_level_enabled: null },
+					mcpEnabled
+						? { blog_id: siteId, account_tools_enabled: false } // add exception: disable this site
+						: { blog_id: siteId, site_level_enabled: true }, // add site: enable this site
+				],
+			},
+		} as any );
+	};
+
+	const handleSiteRemove = ( siteId: number ) => {
+		mutation.mutate( {
+			mcp_abilities: {
+				sites: [
+					mcpEnabled
+						? { blog_id: siteId, account_tools_enabled: true } // remove exception: re-enable this site
+						: { blog_id: siteId, site_level_enabled: null }, // remove site: clear override
 				],
 			},
 		} as any );
@@ -82,9 +94,7 @@ export default function McpMcpSites() {
 	const handleSitePickerSelect = ( siteIdStr: string | null | undefined ) => {
 		if ( siteIdStr ) {
 			const siteId = parseInt( siteIdStr, 10 );
-			// When account MCP is ON: disable for specific site (add exception)
-			// When account MCP is OFF: enable for specific site
-			handleSiteToggle( siteId, ! mcpEnabled );
+			handleSiteAdd( siteId );
 			setSelectedSiteId( null );
 		}
 	};
@@ -158,7 +168,7 @@ export default function McpMcpSites() {
 												variant="secondary"
 												size="compact"
 												disabled={ mutation.isPending }
-												onClick={ () => handleSiteToggle( site.id, mcpEnabled ) }
+												onClick={ () => handleSiteRemove( site.id ) }
 											>
 												{ __( 'Remove' ) }
 											</Button>

--- a/client/dashboard/me/mcp/mcp-sites/index.tsx
+++ b/client/dashboard/me/mcp/mcp-sites/index.tsx
@@ -71,9 +71,10 @@ export default function McpMcpSites() {
 		mutation.mutate( {
 			mcp_abilities: {
 				sites: [
-					mcpEnabled
-						? { blog_id: siteId, account_tools_enabled: false } // add exception: disable this site
-						: { blog_id: siteId, site_level_enabled: true }, // add site: enable this site
+					{
+						blog_id: siteId,
+						site_level_enabled: mcpEnabled ? false : true,
+					},
 				],
 			},
 		} as any );
@@ -82,11 +83,7 @@ export default function McpMcpSites() {
 	const handleSiteRemove = ( siteId: number ) => {
 		mutation.mutate( {
 			mcp_abilities: {
-				sites: [
-					mcpEnabled
-						? { blog_id: siteId, account_tools_enabled: true } // remove exception: re-enable this site
-						: { blog_id: siteId, site_level_enabled: null }, // remove site: clear override
-				],
+				sites: [ { blog_id: siteId, site_level_enabled: null } ],
 			},
 		} as any );
 	};

--- a/client/dashboard/me/mcp/mcp-sites/index.tsx
+++ b/client/dashboard/me/mcp/mcp-sites/index.tsx
@@ -71,10 +71,9 @@ export default function McpMcpSites() {
 		mutation.mutate( {
 			mcp_abilities: {
 				sites: [
-					{
-						blog_id: siteId,
-						account_tools_enabled: enabled,
-					},
+					enabled
+						? { blog_id: siteId, account_tools_enabled: true }
+						: { blog_id: siteId, site_level_enabled: null },
 				],
 			},
 		} as any );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/AIINT-350/msd-mcp-site-level-settings-parity-add-to-specific-sites-in-account

## Proposed Changes

* When account-level MCP is disabled at `my.wordpress.com/me/preferences/mcp`, a new **"Add to specific sites"** button is shown in the card linking to the existing `/me/preferences/mcp/mcp-sites` page.
* The badge shows how many sites already have MCP explicitly enabled (e.g. "2 sites") or "No sites added" when none.
* When MCP is enabled the existing behaviour is unchanged ("Site exceptions" row remains).

| Before | After |
|--------|-------|
| <img width="826" height="532" alt="Screenshot 2026-04-03 at 21 32 13" src="https://github.com/user-attachments/assets/ea1c9840-c0fa-48f5-8b6c-a1fcfaf8b052" /> | <img width="818" height="542" alt="Screenshot 2026-04-03 at 21 41 33" src="https://github.com/user-attachments/assets/99c508d5-5573-4bf7-af56-7dfd8949e719" /> |

## Why are these changes being made?

The `mcp-sites` sub-page already handles both states correctly ("Add MCP to specific sites" when account MCP is off, "Site exceptions" when on), and the route was already registered — but there was no navigation entry point when MCP was disabled. This brings the MSD hub to parity with the legacy `wordpress.com/me/mcp` hub.

## Testing Instructions

1. Go to `my.wordpress.com/me/preferences/mcp`
2. Disable account-level MCP (or open the page while it is already disabled)
3. Confirm an **"Add to specific sites"** row appears below the toggle
4. Click it — confirm it navigates to the mcp-sites page showing "Add MCP to specific sites" UI with a site picker
5. Add a site — confirm the badge on the hub updates to "1 site"
6. Re-enable account-level MCP — confirm the "Add to specific sites" row disappears and "Read", "Write", "Site exceptions" rows appear instead

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?