### PR TITLE
Dockerfile: Simplify, only support seed and none modes, remove base mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 # syntax=docker/dockerfile:1.20
 
-ARG cache_mode=base
+ARG cache_mode=seed
 ARG node_version=22.9.0
-ARG base_image=registry.a8c.com/calypso/base:latest
 ARG cache_seed_image=registry.a8c.com/calypso/cache-seed:latest
 
 ###################
@@ -14,15 +13,6 @@ ENV NPM_CONFIG_CACHE=/calypso/.cache
 ENV PERSISTENT_CACHE=true
 
 RUN mkdir -p /calypso/.cache /calypso/.yarn
-
-
-###################
-# This image contains a directory /calypso/.cache which includes caches
-# for yarn, terser, css-loader and babel.
-FROM ${base_image} AS builder-cache-base
-
-ENV NPM_CONFIG_CACHE=/calypso/.cache
-ENV PERSISTENT_CACHE=true
 
 ###################
 FROM ${cache_seed_image} AS cache-seed-source
@@ -134,23 +124,13 @@ RUN yarn run build-packages:web
 # This contains built environments of Calypso. It will
 # change any time any of the Calypso source-code changes.
 ENV NODE_ENV production
-ARG generate_cache_image=false
 # Delete sourcemaps in the same layer as the build so trunk's hidden-source-map
 # artifacts do not have to be committed and then whiteouted in a later snapshot.
-RUN GENERATE_CACHE_IMAGE=$generate_cache_image yarn run build 2>&1 | tee /tmp/build_log.txt \
-	&& find /calypso/build /calypso/public -name "*.*.map" -delete
+RUN yarn run build 2>&1 | tee /tmp/build_log.txt \
+     && find /calypso/build /calypso/public -name "*.*.map" -delete
 
 # This will output a service message to TeamCity if the build cache was invalidated as seen in the build_log file.
 RUN ./bin/check-log-for-cache-invalidation.sh /tmp/build_log.txt
-
-###################
-# A cache-only update can be generated with "docker build --target update-base-cache"
-FROM ${base_image} AS update-base-cache
-
-# Update webpack cache in the base image so that it can be re-used in future builds.
-# We only copy this part of the cache to make --push faster, and because webpack
-# is the main thing which will impact build performance when the cache invalidates.
-COPY --from=builder /calypso/.cache/evergreen/webpack /calypso/.cache/evergreen/webpack
 
 ###################
 FROM node:${node_version}-alpine AS app


### PR DESCRIPTION
## Proposed Changes

* In the main Dockerfile, remove support for the `cache_mode=base` and passing in a `base_image`. 
  * The base_image, which combined a `.cache` folder with tooling like npm and git, has been separated out into the toolchain + cache_seed images.  The "seed" mode uses the new cache_seed image with only a `.cache` folder in it, and has been working for two weeks.
  * This is one part of several of simplification.

## Why are these changes being made?

*

## Testing Instructions


*

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
