### PR TITLE
MCP settings: add Tracks events across all MCP settings surfaces

### DIFF
--- a/client/dashboard/me/mcp/index.tsx
+++ b/client/dashboard/me/mcp/index.tsx
@@ -109,7 +109,6 @@ function McpComponent() {
 	} );
 
 	const handleMcpToggle = ( enabled: boolean ) => {
-		recordTracksEvent( 'calypso_dashboard_mcp_account_toggled', { enabled } );
 		const accountAbilities: Record< string, boolean > = {};
 		Object.keys( mcpAbilities ).forEach( ( toolId ) => {
 			const tool = mcpAbilities[ toolId ] as McpAbility;
@@ -127,12 +126,19 @@ function McpComponent() {
 			...enabledSiteIds.map( ( id ) => ( { blog_id: id, site_level_enabled: false } ) ),
 		];
 
-		mutation.mutate( {
-			mcp_abilities: {
-				account: accountAbilities,
-				...( sitesToReset.length > 0 && { sites: sitesToReset } ),
-			},
-		} as any );
+		mutation.mutate(
+			{
+				mcp_abilities: {
+					account: accountAbilities,
+					...( sitesToReset.length > 0 && { sites: sitesToReset } ),
+				},
+			} as any,
+			{
+				onSuccess: () => {
+					recordTracksEvent( 'calypso_dashboard_mcp_account_toggled', { enabled } );
+				},
+			}
+		);
 	};
 
 	if ( ! config.isEnabled( 'mcp-settings' ) ) {

--- a/client/dashboard/me/mcp/index.tsx
+++ b/client/dashboard/me/mcp/index.tsx
@@ -9,6 +9,7 @@ import {
 	getDisabledSiteIds,
 	getEnabledSiteIds,
 } from '../../../me/mcp/utils';
+import { useAnalytics } from '../../app/analytics';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { Card, CardBody, CardDivider } from '../../components/card';
 import ComponentViewTracker from '../../components/component-view-tracker';
@@ -67,6 +68,7 @@ function getWriteBadge( tools: Array< [ string, McpAbility ] > ) {
 }
 
 function McpComponent() {
+	const { recordTracksEvent } = useAnalytics();
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 
 	const mcpAbilities = getAccountMcpAbilities( userSettings || {} );
@@ -107,6 +109,7 @@ function McpComponent() {
 	} );
 
 	const handleMcpToggle = ( enabled: boolean ) => {
+		recordTracksEvent( 'calypso_dashboard_mcp_account_toggled', { enabled } );
 		const accountAbilities: Record< string, boolean > = {};
 		Object.keys( mcpAbilities ).forEach( ( toolId ) => {
 			const tool = mcpAbilities[ toolId ] as McpAbility;

--- a/client/dashboard/me/mcp/mcp-sites/index.tsx
+++ b/client/dashboard/me/mcp/mcp-sites/index.tsx
@@ -8,6 +8,7 @@ import {
 	getDisabledSiteIds,
 	getEnabledSiteIds,
 } from '../../../../me/mcp/utils';
+import { useAnalytics } from '../../../app/analytics';
 import Breadcrumbs from '../../../app/breadcrumbs';
 import { useAppContext } from '../../../app/context';
 import { siteSettingsAIToolsRoute } from '../../../app/router/sites';
@@ -25,6 +26,7 @@ import PreferencesLoginSiteDropdown from '../../preferences-primary-site/site-dr
 import type { Site } from '@automattic/api-core';
 
 export default function McpMcpSites() {
+	const { recordTracksEvent } = useAnalytics();
 	const { queries } = useAppContext();
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 	const sitesQueryResult = useQuery(
@@ -71,6 +73,11 @@ export default function McpMcpSites() {
 	} );
 
 	const handleSiteAdd = ( siteId: number ) => {
+		if ( mcpEnabled ) {
+			recordTracksEvent( 'calypso_dashboard_mcp_site_exception_added', { site_id: siteId } );
+		} else {
+			recordTracksEvent( 'calypso_dashboard_mcp_site_added', { site_id: siteId } );
+		}
 		mutation.mutate( {
 			mcp_abilities: {
 				sites: [
@@ -84,6 +91,7 @@ export default function McpMcpSites() {
 	};
 
 	const handleSiteRemove = ( siteId: number ) => {
+		recordTracksEvent( 'calypso_dashboard_mcp_site_removed', { site_id: siteId } );
 		mutation.mutate( {
 			mcp_abilities: {
 				sites: [ { blog_id: siteId, site_level_enabled: null } ],

--- a/client/dashboard/me/mcp/mcp-sites/index.tsx
+++ b/client/dashboard/me/mcp/mcp-sites/index.tsx
@@ -73,30 +73,41 @@ export default function McpMcpSites() {
 	} );
 
 	const handleSiteAdd = ( siteId: number ) => {
-		if ( mcpEnabled ) {
-			recordTracksEvent( 'calypso_dashboard_mcp_site_exception_added', { site_id: siteId } );
-		} else {
-			recordTracksEvent( 'calypso_dashboard_mcp_site_added', { site_id: siteId } );
-		}
-		mutation.mutate( {
-			mcp_abilities: {
-				sites: [
-					{
-						blog_id: siteId,
-						site_level_enabled: mcpEnabled ? false : true,
-					},
-				],
-			},
-		} as any );
+		const eventName = mcpEnabled
+			? 'calypso_dashboard_mcp_site_exception_added'
+			: 'calypso_dashboard_mcp_site_added';
+		mutation.mutate(
+			{
+				mcp_abilities: {
+					sites: [
+						{
+							blog_id: siteId,
+							site_level_enabled: mcpEnabled ? false : true,
+						},
+					],
+				},
+			} as any,
+			{
+				onSuccess: () => {
+					recordTracksEvent( eventName, { site_id: siteId } );
+				},
+			}
+		);
 	};
 
 	const handleSiteRemove = ( siteId: number ) => {
-		recordTracksEvent( 'calypso_dashboard_mcp_site_removed', { site_id: siteId } );
-		mutation.mutate( {
-			mcp_abilities: {
-				sites: [ { blog_id: siteId, site_level_enabled: null } ],
-			},
-		} as any );
+		mutation.mutate(
+			{
+				mcp_abilities: {
+					sites: [ { blog_id: siteId, site_level_enabled: null } ],
+				},
+			} as any,
+			{
+				onSuccess: () => {
+					recordTracksEvent( 'calypso_dashboard_mcp_site_removed', { site_id: siteId } );
+				},
+			}
+		);
 	};
 
 	const handleSitePickerSelect = ( siteIdStr: string | null | undefined ) => {

--- a/client/dashboard/me/mcp/read/index.tsx
+++ b/client/dashboard/me/mcp/read/index.tsx
@@ -9,6 +9,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { Fragment } from 'react';
 import { getAccountMcpAbilities } from '../../../../me/mcp/utils';
+import { useAnalytics } from '../../../app/analytics';
 import Breadcrumbs from '../../../app/breadcrumbs';
 import { Card, CardBody, CardDivider } from '../../../components/card';
 import ComponentViewTracker from '../../../components/component-view-tracker';
@@ -36,6 +37,7 @@ interface McpAbility {
 }
 
 export default function McpRead() {
+	const { recordTracksEvent } = useAnalytics();
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 	const mcpAbilities = getAccountMcpAbilities( userSettings || {} );
 
@@ -57,6 +59,7 @@ export default function McpRead() {
 	} );
 
 	const handleToolChange = ( toolId: string, enabled: boolean ) => {
+		recordTracksEvent( 'calypso_dashboard_mcp_read_tool_toggled', { tool_id: toolId, enabled } );
 		mutation.mutate( {
 			mcp_abilities: {
 				account: {

--- a/client/dashboard/me/mcp/read/index.tsx
+++ b/client/dashboard/me/mcp/read/index.tsx
@@ -59,14 +59,23 @@ export default function McpRead() {
 	} );
 
 	const handleToolChange = ( toolId: string, enabled: boolean ) => {
-		recordTracksEvent( 'calypso_dashboard_mcp_read_tool_toggled', { tool_id: toolId, enabled } );
-		mutation.mutate( {
-			mcp_abilities: {
-				account: {
-					[ toolId ]: enabled,
+		mutation.mutate(
+			{
+				mcp_abilities: {
+					account: {
+						[ toolId ]: enabled,
+					},
 				},
-			},
-		} as any );
+			} as any,
+			{
+				onSuccess: () => {
+					recordTracksEvent( 'calypso_dashboard_mcp_read_tool_toggled', {
+						tool_id: toolId,
+						enabled,
+					} );
+				},
+			}
+		);
 	};
 
 	const handleEnableAll = ( categoryTools: Array< [ string, McpAbility ] >, enabled: boolean ) => {

--- a/client/dashboard/me/mcp/read/index.tsx
+++ b/client/dashboard/me/mcp/read/index.tsx
@@ -83,11 +83,23 @@ export default function McpRead() {
 		categoryTools.forEach( ( [ toolId ] ) => {
 			accountAbilities[ toolId ] = enabled;
 		} );
-		mutation.mutate( {
-			mcp_abilities: {
-				account: accountAbilities,
-			},
-		} as any );
+		mutation.mutate(
+			{
+				mcp_abilities: {
+					account: accountAbilities,
+				},
+			} as any,
+			{
+				onSuccess: () => {
+					categoryTools.forEach( ( [ toolId ] ) => {
+						recordTracksEvent( 'calypso_dashboard_mcp_read_tool_toggled', {
+							tool_id: toolId,
+							enabled,
+						} );
+					} );
+				},
+			}
+		);
 	};
 
 	// Group tools by display category

--- a/client/dashboard/me/mcp/read/index.tsx
+++ b/client/dashboard/me/mcp/read/index.tsx
@@ -78,7 +78,11 @@ export default function McpRead() {
 		);
 	};
 
-	const handleEnableAll = ( categoryTools: Array< [ string, McpAbility ] >, enabled: boolean ) => {
+	const handleEnableAll = (
+		categoryTools: Array< [ string, McpAbility ] >,
+		enabled: boolean,
+		category: string
+	) => {
 		const accountAbilities: Record< string, boolean > = {};
 		categoryTools.forEach( ( [ toolId ] ) => {
 			accountAbilities[ toolId ] = enabled;
@@ -91,11 +95,9 @@ export default function McpRead() {
 			} as any,
 			{
 				onSuccess: () => {
-					categoryTools.forEach( ( [ toolId ] ) => {
-						recordTracksEvent( 'calypso_dashboard_mcp_read_tool_toggled', {
-							tool_id: toolId,
-							enabled,
-						} );
+					recordTracksEvent( 'calypso_dashboard_mcp_read_enable_all_toggled', {
+						enabled,
+						category,
 					} );
 				},
 			}
@@ -195,7 +197,9 @@ export default function McpRead() {
 										checked={ allEnabled }
 										disabled={ mutation.isPending }
 										label={ __( 'Enable all' ) }
-										onChange={ ( checked ) => handleEnableAll( categoryTools, checked ) }
+										onChange={ ( checked ) =>
+											handleEnableAll( categoryTools, checked, categoryName )
+										}
 									/>
 								</HStack>
 							</CardBody>

--- a/client/dashboard/me/mcp/write/index.tsx
+++ b/client/dashboard/me/mcp/write/index.tsx
@@ -81,11 +81,23 @@ export default function McpWrite() {
 		categoryTools.forEach( ( [ toolId ] ) => {
 			accountAbilities[ toolId ] = enabled;
 		} );
-		mutation.mutate( {
-			mcp_abilities: {
-				account: accountAbilities,
-			},
-		} as any );
+		mutation.mutate(
+			{
+				mcp_abilities: {
+					account: accountAbilities,
+				},
+			} as any,
+			{
+				onSuccess: () => {
+					categoryTools.forEach( ( [ toolId ] ) => {
+						recordTracksEvent( 'calypso_dashboard_mcp_write_tool_toggled', {
+							tool_id: toolId,
+							enabled,
+						} );
+					} );
+				},
+			}
+		);
 	};
 
 	// Group tools by display category

--- a/client/dashboard/me/mcp/write/index.tsx
+++ b/client/dashboard/me/mcp/write/index.tsx
@@ -76,7 +76,11 @@ export default function McpWrite() {
 		);
 	};
 
-	const handleEnableAll = ( categoryTools: Array< [ string, McpAbility ] >, enabled: boolean ) => {
+	const handleEnableAll = (
+		categoryTools: Array< [ string, McpAbility ] >,
+		enabled: boolean,
+		category: string
+	) => {
 		const accountAbilities: Record< string, boolean > = {};
 		categoryTools.forEach( ( [ toolId ] ) => {
 			accountAbilities[ toolId ] = enabled;
@@ -89,11 +93,9 @@ export default function McpWrite() {
 			} as any,
 			{
 				onSuccess: () => {
-					categoryTools.forEach( ( [ toolId ] ) => {
-						recordTracksEvent( 'calypso_dashboard_mcp_write_tool_toggled', {
-							tool_id: toolId,
-							enabled,
-						} );
+					recordTracksEvent( 'calypso_dashboard_mcp_write_enable_all_toggled', {
+						enabled,
+						category,
 					} );
 				},
 			}
@@ -204,7 +206,9 @@ export default function McpWrite() {
 										checked={ allEnabled }
 										disabled={ mutation.isPending }
 										label={ __( 'Enable all' ) }
-										onChange={ ( checked ) => handleEnableAll( categoryTools, checked ) }
+										onChange={ ( checked ) =>
+											handleEnableAll( categoryTools, checked, categoryName )
+										}
 									/>
 								</HStack>
 							</CardBody>

--- a/client/dashboard/me/mcp/write/index.tsx
+++ b/client/dashboard/me/mcp/write/index.tsx
@@ -57,14 +57,23 @@ export default function McpWrite() {
 	} );
 
 	const handleToolChange = ( toolId: string, enabled: boolean ) => {
-		recordTracksEvent( 'calypso_dashboard_mcp_write_tool_toggled', { tool_id: toolId, enabled } );
-		mutation.mutate( {
-			mcp_abilities: {
-				account: {
-					[ toolId ]: enabled,
+		mutation.mutate(
+			{
+				mcp_abilities: {
+					account: {
+						[ toolId ]: enabled,
+					},
 				},
-			},
-		} as any );
+			} as any,
+			{
+				onSuccess: () => {
+					recordTracksEvent( 'calypso_dashboard_mcp_write_tool_toggled', {
+						tool_id: toolId,
+						enabled,
+					} );
+				},
+			}
+		);
 	};
 
 	const handleEnableAll = ( categoryTools: Array< [ string, McpAbility ] >, enabled: boolean ) => {

--- a/client/dashboard/me/mcp/write/index.tsx
+++ b/client/dashboard/me/mcp/write/index.tsx
@@ -9,6 +9,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { Fragment } from 'react';
 import { getAccountMcpAbilities } from '../../../../me/mcp/utils';
+import { useAnalytics } from '../../../app/analytics';
 import Breadcrumbs from '../../../app/breadcrumbs';
 import { Card, CardBody, CardDivider } from '../../../components/card';
 import ComponentViewTracker from '../../../components/component-view-tracker';
@@ -36,6 +37,7 @@ interface McpAbility {
 }
 
 export default function McpWrite() {
+	const { recordTracksEvent } = useAnalytics();
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 	const mcpAbilities = getAccountMcpAbilities( userSettings || {} );
 
@@ -55,6 +57,7 @@ export default function McpWrite() {
 	} );
 
 	const handleToolChange = ( toolId: string, enabled: boolean ) => {
+		recordTracksEvent( 'calypso_dashboard_mcp_write_tool_toggled', { tool_id: toolId, enabled } );
 		mutation.mutate( {
 			mcp_abilities: {
 				account: {

--- a/client/dashboard/sites/settings-ai-tools/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/index.tsx
@@ -159,6 +159,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 	} );
 
 	const handleMcpToggle = ( enabled: boolean ) => {
+		recordTracksEvent( 'calypso_dashboard_mcp_site_toggled', { enabled, site_id: site.ID } );
 		const abilities: Record< string, boolean > = {};
 		if ( enabled ) {
 			// Auto-enable all read tools; leave write tools unset (not explicitly disabled).

--- a/client/dashboard/sites/settings-ai-tools/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/index.tsx
@@ -159,7 +159,6 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 	} );
 
 	const handleMcpToggle = ( enabled: boolean ) => {
-		recordTracksEvent( 'calypso_dashboard_mcp_site_toggled', { enabled, site_id: site.ID } );
 		const abilities: Record< string, boolean > = {};
 		if ( enabled ) {
 			// Auto-enable all read tools; leave write tools unset (not explicitly disabled).
@@ -168,17 +167,27 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 			} );
 		}
 		// When disabling, send abilities: {} to clear all site-level tool access.
-		mcpMutation.mutate( {
-			mcp_abilities: {
-				sites: [
-					{
-						blog_id: site.ID,
-						site_level_enabled: enabled,
-						abilities,
-					},
-				],
+		mcpMutation.mutate(
+			{
+				mcp_abilities: {
+					sites: [
+						{
+							blog_id: site.ID,
+							site_level_enabled: enabled,
+							abilities,
+						},
+					],
+				},
 			},
-		} );
+			{
+				onSuccess: () => {
+					recordTracksEvent( 'calypso_dashboard_mcp_site_toggled', {
+						enabled,
+						site_id: site.ID,
+					} );
+				},
+			}
+		);
 	};
 
 	const mutation = useMutation( {

--- a/client/me/mcp/main.jsx
+++ b/client/me/mcp/main.jsx
@@ -1,4 +1,5 @@
 import { sitesQuery, userSettingsQuery, userSettingsMutation } from '@automattic/api-queries';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import SummaryButton from '@automattic/components/src/summary-button';
@@ -83,6 +84,7 @@ function McpComponent( { path } ) {
 	const anyToolsEnabled = hasTools && visibleTools.some( ( [ , tool ] ) => tool.enabled );
 
 	const handleToggleAll = ( enabled ) => {
+		recordTracksEvent( 'calypso_dashboard_mcp_account_toggled', { enabled } );
 		const accountAbilities = {};
 		Object.keys( mcpAbilities ).forEach( ( toolId ) => {
 			// When enabling, only turn on read tools by default — write tools must be opted in explicitly.

--- a/client/me/mcp/main.jsx
+++ b/client/me/mcp/main.jsx
@@ -84,18 +84,24 @@ function McpComponent( { path } ) {
 	const anyToolsEnabled = hasTools && visibleTools.some( ( [ , tool ] ) => tool.enabled );
 
 	const handleToggleAll = ( enabled ) => {
-		recordTracksEvent( 'calypso_dashboard_mcp_account_toggled', { enabled } );
 		const accountAbilities = {};
 		Object.keys( mcpAbilities ).forEach( ( toolId ) => {
 			// When enabling, only turn on read tools by default — write tools must be opted in explicitly.
 			accountAbilities[ toolId ] = enabled ? isReadTool( mcpAbilities[ toolId ] ) : false;
 		} );
 
-		mutation.mutate( {
-			mcp_abilities: {
-				account: accountAbilities,
+		mutation.mutate(
+			{
+				mcp_abilities: {
+					account: accountAbilities,
+				},
 			},
-		} );
+			{
+				onSuccess: () => {
+					recordTracksEvent( 'calypso_dashboard_mcp_account_toggled', { enabled } );
+				},
+			}
+		);
 	};
 
 	const disabledSiteCount = getDisabledSiteIds( userSettings || {} ).length;

--- a/client/me/mcp/read.jsx
+++ b/client/me/mcp/read.jsx
@@ -10,6 +10,7 @@ export default function McpReadToolsPage( props ) {
 			pageViewTitle="MCP Read Access"
 			headerTitle={ translate( 'Read' ) }
 			filterTool={ isReadTool }
+			toolCategory="read"
 			groupingMode="categories"
 		/>
 	);

--- a/client/me/mcp/tools-subpage.jsx
+++ b/client/me/mcp/tools-subpage.jsx
@@ -115,15 +115,15 @@ export default function McpToolsSubpage( {
 	 * @param {Array<[string, import('@automattic/api-core').McpAbility]>} groupTools
 	 * @param {boolean} enabled
 	 */
-	const handleGroupEnableAll = ( groupTools, enabled ) => {
+	const handleGroupEnableAll = ( groupTools, enabled, category ) => {
 		if ( groupTools.length === 0 ) {
 			return;
 		}
 		const account = Object.fromEntries( groupTools.map( ( [ toolId ] ) => [ toolId, enabled ] ) );
 		const eventName =
 			toolCategory === 'write'
-				? 'calypso_dashboard_mcp_write_tool_toggled'
-				: 'calypso_dashboard_mcp_read_tool_toggled';
+				? 'calypso_dashboard_mcp_write_enable_all_toggled'
+				: 'calypso_dashboard_mcp_read_enable_all_toggled';
 		mutation.mutate(
 			{
 				mcp_abilities: {
@@ -132,9 +132,7 @@ export default function McpToolsSubpage( {
 			},
 			{
 				onSuccess: () => {
-					groupTools.forEach( ( [ toolId ] ) => {
-						recordTracksEvent( eventName, { tool_id: toolId, enabled } );
-					} );
+					recordTracksEvent( eventName, { enabled, category } );
 				},
 			}
 		);
@@ -224,7 +222,9 @@ export default function McpToolsSubpage( {
 											checked={ allEnabled }
 											disabled={ mutation.isPending }
 											label={ translate( 'Enable all' ) }
-											onChange={ ( checked ) => handleGroupEnableAll( groupTools, checked ) }
+											onChange={ ( checked ) =>
+												handleGroupEnableAll( groupTools, checked, categoryName )
+											}
 										/>
 									</div>
 								</HStack>

--- a/client/me/mcp/tools-subpage.jsx
+++ b/client/me/mcp/tools-subpage.jsx
@@ -1,4 +1,5 @@
 import { sitesQuery, userSettingsQuery, userSettingsMutation } from '@automattic/api-queries';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
@@ -40,6 +41,7 @@ import './style.scss';
  * @param {string} props.pageViewTitle
  * @param {string} props.headerTitle
  * @param {(tool: import('@automattic/api-core').McpAbility) => boolean} props.filterTool
+ * @param {'read'|'write'} props.toolCategory
  * @param {'categories'|undefined} [props.groupingMode] When `"categories"`, tools are grouped by Dashboard MCP display category (`getDisplayCategory` + `CATEGORY_ORDER`).
  */
 export default function McpToolsSubpage( {
@@ -47,6 +49,7 @@ export default function McpToolsSubpage( {
 	pageViewTitle,
 	headerTitle,
 	filterTool,
+	toolCategory,
 	groupingMode,
 } ) {
 	const translate = useTranslate();
@@ -88,6 +91,11 @@ export default function McpToolsSubpage( {
 	);
 
 	const handleToolChange = ( toolId, enabled ) => {
+		const eventName =
+			toolCategory === 'write'
+				? 'calypso_dashboard_mcp_write_tool_toggled'
+				: 'calypso_dashboard_mcp_read_tool_toggled';
+		recordTracksEvent( eventName, { tool_id: toolId, enabled } );
 		mutation.mutate( {
 			mcp_abilities: {
 				account: {

--- a/client/me/mcp/tools-subpage.jsx
+++ b/client/me/mcp/tools-subpage.jsx
@@ -95,14 +95,20 @@ export default function McpToolsSubpage( {
 			toolCategory === 'write'
 				? 'calypso_dashboard_mcp_write_tool_toggled'
 				: 'calypso_dashboard_mcp_read_tool_toggled';
-		recordTracksEvent( eventName, { tool_id: toolId, enabled } );
-		mutation.mutate( {
-			mcp_abilities: {
-				account: {
-					[ toolId ]: enabled,
+		mutation.mutate(
+			{
+				mcp_abilities: {
+					account: {
+						[ toolId ]: enabled,
+					},
 				},
 			},
-		} );
+			{
+				onSuccess: () => {
+					recordTracksEvent( eventName, { tool_id: toolId, enabled } );
+				},
+			}
+		);
 	};
 
 	/**
@@ -114,11 +120,24 @@ export default function McpToolsSubpage( {
 			return;
 		}
 		const account = Object.fromEntries( groupTools.map( ( [ toolId ] ) => [ toolId, enabled ] ) );
-		mutation.mutate( {
-			mcp_abilities: {
-				account,
+		const eventName =
+			toolCategory === 'write'
+				? 'calypso_dashboard_mcp_write_tool_toggled'
+				: 'calypso_dashboard_mcp_read_tool_toggled';
+		mutation.mutate(
+			{
+				mcp_abilities: {
+					account,
+				},
 			},
-		} );
+			{
+				onSuccess: () => {
+					groupTools.forEach( ( [ toolId ] ) => {
+						recordTracksEvent( eventName, { tool_id: toolId, enabled } );
+					} );
+				},
+			}
+		);
 	};
 
 	if ( userSettingsError ) {

--- a/client/me/mcp/write.jsx
+++ b/client/me/mcp/write.jsx
@@ -10,6 +10,7 @@ export default function McpWriteToolsPage( props ) {
 			pageViewTitle="MCP Write Access"
 			headerTitle={ translate( 'Write' ) }
 			filterTool={ isWriteTool }
+			toolCategory="write"
 			groupingMode="categories"
 		/>
 	);


### PR DESCRIPTION
## Summary

- Fires `calypso_dashboard_mcp_account_toggled` (`{enabled}`) when the account-level MCP toggle is changed, on both `wordpress.com/me/mcp` (legacy) and `my.wordpress.com/me/preferences/mcp` (Dashboard)
- Fires `calypso_dashboard_mcp_site_toggled` (`{enabled, site_id}`) when the site-level MCP toggle is changed on the site AI Tools settings page
- Fires `calypso_dashboard_mcp_read_tool_toggled` / `calypso_dashboard_mcp_write_tool_toggled` (`{tool_id, enabled}`) per-tool on both legacy and Dashboard read/write pages
- Fires `calypso_dashboard_mcp_site_added`, `calypso_dashboard_mcp_site_exception_added`, and `calypso_dashboard_mcp_site_removed` (`{site_id}`) on the site picker page

Closes AI-930

## Files changed

- `client/dashboard/me/mcp/index.tsx` — account toggle (Dashboard)
- `client/dashboard/me/mcp/mcp-sites/index.tsx` — site add/exception/remove (Dashboard)
- `client/dashboard/me/mcp/read/index.tsx` — per-tool read toggle (Dashboard)
- `client/dashboard/me/mcp/write/index.tsx` — per-tool write toggle (Dashboard)
- `client/dashboard/sites/settings-ai-tools/index.tsx` — site-level MCP toggle
- `client/me/mcp/main.jsx` — account toggle (legacy)
- `client/me/mcp/tools-subpage.jsx` — per-tool read/write toggle (legacy); adds `toolCategory` prop
- `client/me/mcp/read.jsx` — passes `toolCategory="read"`
- `client/me/mcp/write.jsx` — passes `toolCategory="write"`

## Test plan

- [ ] Toggle account MCP on/off at `wordpress.com/me/mcp` and `my.wordpress.com/me/preferences/mcp` — verify `calypso_dashboard_mcp_account_toggled` fires with correct `enabled` value
- [ ] Toggle site-level MCP on/off at site AI Tools settings — verify `calypso_dashboard_mcp_site_toggled` fires with `enabled` and `site_id`
- [ ] Toggle individual read tools — verify `calypso_dashboard_mcp_read_tool_toggled` fires with `tool_id` and `enabled` on both legacy and Dashboard
- [ ] Toggle individual write tools — verify `calypso_dashboard_mcp_write_tool_toggled` fires on both legacy and Dashboard
- [ ] Add/remove a site on the site picker page — verify appropriate site event fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)