### PR TITLE
Consolidate SiteLaunchCelebrationModal trigger logic at site level

### DIFF
--- a/client/dashboard/sites/performance/index.tsx
+++ b/client/dashboard/sites/performance/index.tsx
@@ -173,17 +173,6 @@ function SitePerformanceContent( { site }: { site: Site } ) {
 function SitePerformance() {
 	const { siteSlug } = siteRoute.useParams();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-	const [ isCelebrationModalOpen, setIsCelebrationModalOpen ] = useState( false );
-
-	useEffect( () => {
-		const hasCelebrateLaunch = new URLSearchParams( window.location.search ).has(
-			'celebrateLaunch'
-		);
-		// Only open the modal if the param is present; closing is handled by onClose
-		if ( site.launch_status === 'launched' && hasCelebrateLaunch ) {
-			setIsCelebrationModalOpen( true );
-		}
-	}, [ site.launch_status ] );
 
 	return (
 		<HostingFeatureGatedWithCallout site={ site } fullPage { ...getPerformanceCalloutProps() }>
@@ -213,12 +202,7 @@ function SitePerformance() {
 				<SitePerformanceContent site={ site } />
 			) }
 			<PerformanceTrackerStop />
-			{ isCelebrationModalOpen && (
-				<SiteLaunchCelebrationModal
-					site={ site }
-					onClose={ () => setIsCelebrationModalOpen( false ) }
-				/>
-			) }
+			<SiteLaunchCelebrationModal site={ site } />
 		</HostingFeatureGatedWithCallout>
 	);
 }

--- a/client/dashboard/sites/performance/index.tsx
+++ b/client/dashboard/sites/performance/index.tsx
@@ -187,7 +187,7 @@ function SitePerformance() {
 
 	return (
 		<HostingFeatureGatedWithCallout site={ site } fullPage { ...getPerformanceCalloutProps() }>
-			{ site.is_coming_soon || site.is_private ? (
+			{ site.is_coming_soon || site.is_private || site.launch_status ? (
 				<PageLayout
 					size="small"
 					header={

--- a/client/dashboard/sites/performance/index.tsx
+++ b/client/dashboard/sites/performance/index.tsx
@@ -187,7 +187,7 @@ function SitePerformance() {
 
 	return (
 		<HostingFeatureGatedWithCallout site={ site } fullPage { ...getPerformanceCalloutProps() }>
-			{ site.is_coming_soon || site.is_private || site.launch_status ? (
+			{ site.is_coming_soon || site.is_private ? (
 				<PageLayout
 					size="small"
 					header={

--- a/client/dashboard/sites/settings-site-visibility/index.tsx
+++ b/client/dashboard/sites/settings-site-visibility/index.tsx
@@ -3,7 +3,6 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { useSearch } from '@tanstack/react-router';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useEffect, useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { siteSettingsSiteVisibilityRoute } from '../../app/router/sites';
 import InlineSupportLink from '../../components/inline-support-link';
@@ -12,7 +11,6 @@ import PageLayout from '../../components/page-layout';
 import SnackbarBackButton, {
 	getSnackbarBackButtonText,
 } from '../../components/snackbar-back-button';
-import SiteLaunchCelebrationModal from '../site-launch-celebration-modal';
 import { LaunchAgencyDevelopmentSiteForm, LaunchForm } from './launch-form';
 import { PrivacyForm } from './privacy-form';
 import { ShareSiteForm } from './share-site-form';
@@ -23,18 +21,6 @@ export default function SiteVisibilitySettings( { siteSlug }: { siteSlug: string
 	const { back_to } = useSearch( {
 		from: siteSettingsSiteVisibilityRoute.fullPath,
 	} );
-
-	// Check if celebration modal should be shown based on URL param
-	const searchQueryParams = window.location.search;
-	const [ isCelebrationModalOpen, setIsCelebrationModalOpen ] = useState( false );
-
-	useEffect( () => {
-		const hasCelebrateLaunch = new URLSearchParams( searchQueryParams ).has( 'celebrateLaunch' );
-		// Only open the modal if the param is present; closing is handled by onClose
-		if ( hasCelebrateLaunch ) {
-			setIsCelebrationModalOpen( true );
-		}
-	}, [ searchQueryParams ] );
 
 	const renderContent = () => {
 		if ( site.launch_status === 'unlaunched' ) {
@@ -82,12 +68,6 @@ export default function SiteVisibilitySettings( { siteSlug }: { siteSlug: string
 				{ renderContent() }
 				{ renderBackButton() }
 			</PageLayout>
-			{ isCelebrationModalOpen && (
-				<SiteLaunchCelebrationModal
-					site={ site }
-					onClose={ () => setIsCelebrationModalOpen( false ) }
-				/>
-			) }
 		</>
 	);
 }

--- a/client/dashboard/sites/settings-site-visibility/index.tsx
+++ b/client/dashboard/sites/settings-site-visibility/index.tsx
@@ -49,25 +49,23 @@ export default function SiteVisibilitySettings( { siteSlug }: { siteSlug: string
 	};
 
 	return (
-		<>
-			<PageLayout
-				size="small"
-				header={
-					<PageHeader
-						prefix={ <Breadcrumbs length={ 2 } /> }
-						title={ __( 'Site visibility' ) }
-						description={ createInterpolateElement(
-							__( 'Control who can view your site. <learnMoreLink />' ),
-							{
-								learnMoreLink: <InlineSupportLink supportContext="privacy" />,
-							}
-						) }
-					/>
-				}
-			>
-				{ renderContent() }
-				{ renderBackButton() }
-			</PageLayout>
-		</>
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					prefix={ <Breadcrumbs length={ 2 } /> }
+					title={ __( 'Site visibility' ) }
+					description={ createInterpolateElement(
+						__( 'Control who can view your site. <learnMoreLink />' ),
+						{
+							learnMoreLink: <InlineSupportLink supportContext="privacy" />,
+						}
+					) }
+				/>
+			}
+		>
+			{ renderContent() }
+			{ renderBackButton() }
+		</PageLayout>
 	);
 }

--- a/client/dashboard/sites/site-launch-celebration-modal/index.tsx
+++ b/client/dashboard/sites/site-launch-celebration-modal/index.tsx
@@ -26,7 +26,7 @@ export default function SiteLaunchCelebrationModal( { site }: SiteLaunchCelebrat
 	const [ clipboardCopied, setClipboardCopied ] = useState( false );
 	const { recordTracksEvent } = useAnalytics();
 	const { queries } = useAppContext();
-	const { data: domains = [] } = useQuery( {
+	const { data: domains = [], isFetchedAfterMount: isDomainsFetched } = useQuery( {
 		...queries.domainsQuery(),
 		enabled: isOpen,
 		select: ( data ) => data.filter( ( domain ) => domain.blog_id === site.ID ),
@@ -62,7 +62,7 @@ export default function SiteLaunchCelebrationModal( { site }: SiteLaunchCelebrat
 		} );
 	}, [ isOpen, site?.plan?.product_slug, recordTracksEvent ] );
 
-	if ( ! isOpen ) {
+	if ( ! isOpen || ! isDomainsFetched ) {
 		return null;
 	}
 

--- a/client/dashboard/sites/site-launch-celebration-modal/index.tsx
+++ b/client/dashboard/sites/site-launch-celebration-modal/index.tsx
@@ -18,32 +18,37 @@ import type { Site } from '@automattic/api-core';
 import './styles.scss';
 
 interface SiteLaunchCelebrationModalProps {
-	site: Pick< Site, 'ID' | 'slug' | 'URL' > & {
-		plan?: Pick< Required< Site >[ 'plan' ], 'is_free' | 'product_slug' >;
-	};
-	onClose: () => void;
+	site: Site;
 }
 
-export default function SiteLaunchCelebrationModal( {
-	site,
-	onClose,
-}: SiteLaunchCelebrationModalProps ) {
+export default function SiteLaunchCelebrationModal( { site }: SiteLaunchCelebrationModalProps ) {
+	const [ isOpen, setIsOpen ] = useState( false );
+	const [ clipboardCopied, setClipboardCopied ] = useState( false );
 	const { recordTracksEvent } = useAnalytics();
 	const { queries } = useAppContext();
 	const { data: domains = [] } = useQuery( {
 		...queries.domainsQuery(),
+		enabled: isOpen,
 		select: ( data ) => data.filter( ( domain ) => domain.blog_id === site.ID ),
 	} );
-	const [ clipboardCopied, setClipboardCopied ] = useState( false );
 	const copyButtonRef = useRef< HTMLButtonElement >( null );
 
-	const isPaidPlan = ! site.plan?.is_free;
-	const isBilledMonthly = site.plan?.product_slug?.includes( 'monthly' );
-	const customDomains = domains.filter( ( domain ) => domain.subscription_id !== null );
-	const hasCustomDomain = customDomains.length > 0;
-	const siteDomain = hasCustomDomain ? customDomains[ 0 ].domain : site.slug;
+	// Check if celebration modal should be shown based on URL param and site launch status
+	useEffect( () => {
+		const hasCelebrateLaunch = new URLSearchParams( window.location.search ).has(
+			'celebrateLaunch'
+		);
+		if ( site.launch_status === 'launched' && hasCelebrateLaunch ) {
+			setIsOpen( true );
+		}
+	}, [ site.launch_status ] );
 
 	useEffect( () => {
+		// Only run cleanup and analytics when modal is open
+		if ( ! isOpen ) {
+			return;
+		}
+
 		// Remove the celebrateLaunch URL param without reloading the page
 		window.history.replaceState(
 			null,
@@ -55,7 +60,17 @@ export default function SiteLaunchCelebrationModal( {
 		recordTracksEvent( 'calypso_launchpad_celebration_modal_view', {
 			product_slug: site?.plan?.product_slug,
 		} );
-	}, [ site?.plan?.product_slug, recordTracksEvent ] );
+	}, [ isOpen, site?.plan?.product_slug, recordTracksEvent ] );
+
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	const isPaidPlan = ! site.plan?.is_free;
+	const isBilledMonthly = site.plan?.product_slug?.includes( 'monthly' );
+	const customDomains = domains.filter( ( domain ) => domain.subscription_id !== null );
+	const hasCustomDomain = customDomains.length > 0;
+	const siteDomain = hasCustomDomain ? customDomains[ 0 ].domain : site.slug;
 
 	const handleCopy = () => {
 		navigator.clipboard.writeText( siteDomain );
@@ -131,7 +146,7 @@ export default function SiteLaunchCelebrationModal( {
 			className="celebration-modal"
 			title={ __( 'Congrats, your site is live!' ) }
 			size="medium"
-			onRequestClose={ onClose }
+			onRequestClose={ () => setIsOpen( false ) }
 		>
 			<ConfettiAnimation />
 			<VStack spacing={ 6 }>

--- a/client/dashboard/sites/site-launch-celebration-modal/index.tsx
+++ b/client/dashboard/sites/site-launch-celebration-modal/index.tsx
@@ -18,7 +18,9 @@ import type { Site } from '@automattic/api-core';
 import './styles.scss';
 
 interface SiteLaunchCelebrationModalProps {
-	site: Site;
+	site: Pick< Site, 'ID' | 'slug' | 'URL' | 'launch_status' > & {
+		plan?: Pick< Required< Site >[ 'plan' ], 'is_free' | 'product_slug' >;
+	};
 }
 
 export default function SiteLaunchCelebrationModal( { site }: SiteLaunchCelebrationModalProps ) {

--- a/client/dashboard/sites/site-launch-celebration-modal/test/index.test.tsx
+++ b/client/dashboard/sites/site-launch-celebration-modal/test/index.test.tsx
@@ -14,6 +14,7 @@ const createMockSite = ( options: Partial< Site > = {} ): Site =>
 		ID: 1,
 		slug: 'test-site.wordpress.com',
 		URL: 'https://test-site.wordpress.com',
+		launch_status: 'launched' as const,
 		plan: {
 			is_free: false,
 			product_slug: 'business-monthly',
@@ -35,6 +36,13 @@ const mockDomainsApi = ( domains: DomainSummary[] = [] ) => {
 		.reply( 200, { domains } );
 };
 
+const setupCelebrateLaunchUrl = () => {
+	// Set the URL to include the celebrateLaunch param so the modal opens
+	const url = new URL( window.location.href );
+	url.searchParams.set( 'celebrateLaunch', 'true' );
+	window.history.pushState( {}, '', url.toString() );
+};
+
 describe( '<SiteLaunchCelebrationModal>', () => {
 	beforeEach( () => {
 		mockDomainsApi( [] );
@@ -45,18 +53,37 @@ describe( '<SiteLaunchCelebrationModal>', () => {
 	} );
 
 	describe( 'Modal Display', () => {
-		test( 'renders modal with proper structure', async () => {
+		test( 'renders modal with proper structure when conditions are met', async () => {
+			setupCelebrateLaunchUrl();
 			const mockSite = createMockSite();
-			render( <SiteLaunchCelebrationModal site={ mockSite } onClose={ jest.fn() } /> );
+			render( <SiteLaunchCelebrationModal site={ mockSite } /> );
 
-			expect( screen.getByRole( 'dialog' ) ).toBeVisible();
-			await screen.findByRole( 'button', { name: 'Copy URL' } );
+			expect( await screen.findByRole( 'dialog' ) ).toBeVisible();
+			expect( screen.getByRole( 'button', { name: 'Copy URL' } ) ).toBeVisible();
 			expect( screen.getByRole( 'link', { name: 'View site' } ) ).toBeVisible();
+		} );
+
+		test( 'does not render modal when celebrateLaunch param is missing', () => {
+			const mockSite = createMockSite();
+			render( <SiteLaunchCelebrationModal site={ mockSite } /> );
+
+			// Modal should not be rendered
+			expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'does not render modal when site launch_status is not launched', () => {
+			setupCelebrateLaunchUrl();
+			const mockSite = createMockSite( { launch_status: 'unlaunched' as const } );
+			render( <SiteLaunchCelebrationModal site={ mockSite } /> );
+
+			// Modal should not be rendered
+			expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
 		} );
 	} );
 
 	describe( 'Domain Selection Logic', () => {
 		test( 'copies custom domain to clipboard when available', async () => {
+			setupCelebrateLaunchUrl();
 			const user = userEvent.setup();
 			const mockSite = createMockSite();
 			const customDomain = createMockDomain( 'example.com', true );
@@ -64,7 +91,7 @@ describe( '<SiteLaunchCelebrationModal>', () => {
 
 			nock.cleanAll();
 			mockDomainsApi( [ customDomain ] );
-			render( <SiteLaunchCelebrationModal site={ mockSite } onClose={ jest.fn() } /> );
+			render( <SiteLaunchCelebrationModal site={ mockSite } /> );
 
 			await screen.findByText( 'example.com' );
 			const copyButton = screen.getByRole( 'button', { name: 'Copy URL' } );
@@ -74,6 +101,7 @@ describe( '<SiteLaunchCelebrationModal>', () => {
 		} );
 
 		test( 'copies first domain when multiple domains exist', async () => {
+			setupCelebrateLaunchUrl();
 			const user = userEvent.setup();
 			const mockSite = createMockSite();
 			const domain1 = createMockDomain( 'first.com', true );
@@ -82,7 +110,7 @@ describe( '<SiteLaunchCelebrationModal>', () => {
 
 			nock.cleanAll();
 			mockDomainsApi( [ domain1, domain2 ] );
-			render( <SiteLaunchCelebrationModal site={ mockSite } onClose={ jest.fn() } /> );
+			render( <SiteLaunchCelebrationModal site={ mockSite } /> );
 
 			await screen.findByText( 'first.com' );
 			const copyButton = screen.getByRole( 'button', { name: 'Copy URL' } );
@@ -93,6 +121,7 @@ describe( '<SiteLaunchCelebrationModal>', () => {
 		} );
 
 		test( 'skips domains without active subscription', async () => {
+			setupCelebrateLaunchUrl();
 			const user = userEvent.setup();
 			const mockSite = createMockSite();
 			const unsubscribedDomain = createMockDomain( 'unsubscribed.com', false );
@@ -101,7 +130,7 @@ describe( '<SiteLaunchCelebrationModal>', () => {
 
 			nock.cleanAll();
 			mockDomainsApi( [ unsubscribedDomain, activeDomain ] );
-			render( <SiteLaunchCelebrationModal site={ mockSite } onClose={ jest.fn() } /> );
+			render( <SiteLaunchCelebrationModal site={ mockSite } /> );
 
 			await screen.findByText( 'active.com' );
 			const copyButton = screen.getByRole( 'button', { name: 'Copy URL' } );
@@ -113,30 +142,28 @@ describe( '<SiteLaunchCelebrationModal>', () => {
 	} );
 
 	describe( 'Query Parameter Removal', () => {
-		test( 'removes celebrateLaunch query param on mount', () => {
-			// Store the original href to verify it changes
-			const originalHref = window.location.href;
-			window.history.pushState(
-				{},
-				'',
-				originalHref + ( originalHref.includes( '?' ) ? '&' : '?' ) + 'celebrateLaunch=true'
-			);
+		test( 'removes celebrateLaunch query param when modal opens', async () => {
+			setupCelebrateLaunchUrl();
 
 			const mockSite = createMockSite();
-			render( <SiteLaunchCelebrationModal site={ mockSite } onClose={ jest.fn() } /> );
+			render( <SiteLaunchCelebrationModal site={ mockSite } /> );
 
-			// After component mounts, the URL should not contain celebrateLaunch param
+			// Wait for modal to render
+			await screen.findByRole( 'dialog' );
+
+			// After component mounts and modal opens, the URL should not contain celebrateLaunch param
 			expect( window.location.href ).not.toContain( 'celebrateLaunch' );
 		} );
 	} );
 
 	describe( 'Copy Button Behavior', () => {
 		test( 'copies domain to clipboard and provides feedback', async () => {
+			setupCelebrateLaunchUrl();
 			const user = userEvent.setup();
 			const mockSite = createMockSite();
 			navigator.clipboard.writeText = jest.fn();
 
-			render( <SiteLaunchCelebrationModal site={ mockSite } onClose={ jest.fn() } /> );
+			render( <SiteLaunchCelebrationModal site={ mockSite } /> );
 
 			const copyButton = await screen.findByRole( 'button', { name: 'Copy URL' } );
 
@@ -155,9 +182,13 @@ describe( '<SiteLaunchCelebrationModal>', () => {
 	} );
 
 	describe( 'View Site Navigation', () => {
-		test( 'view site link uses site URL and opens in new tab', () => {
+		test( 'view site link uses site URL and opens in new tab', async () => {
+			setupCelebrateLaunchUrl();
 			const mockSite = createMockSite( { URL: 'https://mysite.wordpress.com' } );
-			render( <SiteLaunchCelebrationModal site={ mockSite } onClose={ jest.fn() } /> );
+			render( <SiteLaunchCelebrationModal site={ mockSite } /> );
+
+			// Wait for modal to render
+			await screen.findByRole( 'dialog' );
 
 			const viewLink = screen.getByRole( 'link', { name: 'View site' } );
 			expect( viewLink ).toHaveAttribute( 'href', 'https://mysite.wordpress.com' );
@@ -165,19 +196,26 @@ describe( '<SiteLaunchCelebrationModal>', () => {
 		} );
 
 		test( 'renders button instead of link when URL is missing', async () => {
+			setupCelebrateLaunchUrl();
 			const mockSite = createMockSite( { URL: undefined } );
-			render( <SiteLaunchCelebrationModal site={ mockSite } onClose={ jest.fn() } /> );
+			render( <SiteLaunchCelebrationModal site={ mockSite } /> );
 
 			// When href is undefined, WordPress Button renders as a button element, not a link
-			const viewButton = await screen.findByRole( 'button', { name: 'View site' } );
+			// Wait for the dialog to be sure the component rendered
+			await screen.findByRole( 'dialog' );
+			const viewButton = screen.getByRole( 'button', { name: 'View site' } );
 			expect( viewButton ).toBeVisible();
 		} );
 	} );
 
 	describe( 'Upsell Display Logic', () => {
 		test( 'shows upsell when no custom domain exists and plan is free', async () => {
+			setupCelebrateLaunchUrl();
 			const mockSite = createMockSite( { plan: { is_free: true } as any } );
-			render( <SiteLaunchCelebrationModal site={ mockSite } onClose={ jest.fn() } /> );
+			render( <SiteLaunchCelebrationModal site={ mockSite } /> );
+
+			// Wait for modal to render first
+			await screen.findByRole( 'dialog' );
 
 			// Upsell button should appear for free plan without custom domain
 			await screen.findByRole( 'link', { name: 'Get your domain' } );
@@ -188,12 +226,13 @@ describe( '<SiteLaunchCelebrationModal>', () => {
 		} );
 
 		test( 'does not show upsell when custom domain exists', async () => {
+			setupCelebrateLaunchUrl();
 			const mockSite = createMockSite( { plan: { is_free: true } as any } );
 			const customDomain = createMockDomain( 'example.com', true );
 
 			nock.cleanAll();
 			mockDomainsApi( [ customDomain ] );
-			render( <SiteLaunchCelebrationModal site={ mockSite } onClose={ jest.fn() } /> );
+			render( <SiteLaunchCelebrationModal site={ mockSite } /> );
 
 			// Wait for the domain to appear, confirming the API response is loaded
 			await screen.findByText( 'example.com' );
@@ -204,11 +243,13 @@ describe( '<SiteLaunchCelebrationModal>', () => {
 	} );
 
 	describe( 'Analytics Tracking', () => {
-		test( 'tracks celebration modal view on mount', () => {
+		test( 'tracks celebration modal view when modal opens', async () => {
+			setupCelebrateLaunchUrl();
 			const mockSite = createMockSite();
-			const { recordTracksEvent } = render(
-				<SiteLaunchCelebrationModal site={ mockSite } onClose={ jest.fn() } />
-			);
+			const { recordTracksEvent } = render( <SiteLaunchCelebrationModal site={ mockSite } /> );
+
+			// Wait for modal to render and analytics to fire
+			await screen.findByRole( 'dialog' );
 
 			expect( recordTracksEvent ).toHaveBeenCalledWith(
 				'calypso_launchpad_celebration_modal_view',
@@ -218,11 +259,13 @@ describe( '<SiteLaunchCelebrationModal>', () => {
 			);
 		} );
 
-		test( 'tracks event with undefined product_slug when plan is missing', () => {
+		test( 'tracks event with undefined product_slug when plan is missing', async () => {
+			setupCelebrateLaunchUrl();
 			const mockSite = createMockSite( { plan: undefined } );
-			const { recordTracksEvent } = render(
-				<SiteLaunchCelebrationModal site={ mockSite } onClose={ jest.fn() } />
-			);
+			const { recordTracksEvent } = render( <SiteLaunchCelebrationModal site={ mockSite } /> );
+
+			// Wait for modal to render and analytics to fire
+			await screen.findByRole( 'dialog' );
 
 			expect( recordTracksEvent ).toHaveBeenCalledWith(
 				'calypso_launchpad_celebration_modal_view',

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -14,8 +14,8 @@ import MenuDivider from '../../components/menu-divider';
 import { hasStagingSite } from '../../utils/site-staging-site';
 import { isSiteMigrationInProgress } from '../../utils/site-status';
 import { canManageSite, canSwitchEnvironment } from '../features';
-import SiteMenu from '../site-menu';
 import SiteLaunchCelebrationModal from '../site-launch-celebration-modal';
+import SiteMenu from '../site-menu';
 import EnvironmentSwitcher from './environment-switcher';
 import type { SiteSwitcherProps } from '../site-switcher/types';
 

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -15,6 +15,7 @@ import { hasStagingSite } from '../../utils/site-staging-site';
 import { isSiteMigrationInProgress } from '../../utils/site-status';
 import { canManageSite, canSwitchEnvironment } from '../features';
 import SiteMenu from '../site-menu';
+import SiteLaunchCelebrationModal from '../site-launch-celebration-modal';
 import EnvironmentSwitcher from './environment-switcher';
 import type { SiteSwitcherProps } from '../site-switcher/types';
 
@@ -62,6 +63,7 @@ function Site() {
 					type="error"
 					message={ __( 'You don’t have permission to view the requested page.' ) }
 				/>
+				<SiteLaunchCelebrationModal site={ site } />
 				<Outlet />
 			</Suspense>
 		</Suspense>

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -172,22 +172,6 @@ const SitePerformanceContent = ( { path }: { path?: string } ) => {
 		'calypso_standardized_site_launch_gating'
 	);
 	const experimentVariant = experimentData?.variationName;
-
-	const [ isCelebrationModalOpen, setIsCelebrationModalOpen ] = useState( false );
-
-	useEffect( () => {
-		if (
-			experimentVariant === 'gated_site_launch' &&
-			new URLSearchParams( window.location.search ).has( 'celebrateLaunch' )
-		) {
-			setIsCelebrationModalOpen( true );
-		}
-
-		if ( experimentVariant === 'ungated_site_launch' && siteIsLaunched && isSitePublic ) {
-			setIsCelebrationModalOpen( true );
-		}
-	}, [ siteIsLaunched, isSitePublic, experimentVariant ] );
-
 	const retestPage = () => {
 		recordTracksEvent( 'calypso_performance_profiler_test_again_click' );
 		performance.mark( 'test-started' );
@@ -228,8 +212,16 @@ const SitePerformanceContent = ( { path }: { path?: string } ) => {
 			return;
 		}
 
-		// For both ungated and control: use Redux action
-		// (ungated variant will show celebration modal via useEffect)
+		if ( experimentVariant === 'ungated_site_launch' ) {
+			// Add celebrateLaunch param immediately so it's ready when site status updates
+			const url = new URL( window.location.href );
+			url.searchParams.set( 'celebrateLaunch', 'true' );
+			window.history.replaceState( {}, '', url.toString() );
+			dispatch( launchSite( siteId! ) );
+			return;
+		}
+
+		// default / control variant
 		dispatch( launchSite( siteId! ) );
 	};
 
@@ -403,12 +395,9 @@ const SitePerformanceContent = ( { path }: { path?: string } ) => {
 					) }
 				</>
 			) }
-			{ isCelebrationModalOpen && site && isDomainsFetched && (
+			{ site && (
 				<AnalyticsProvider client={ analyticsClient }>
-					<SiteLaunchCelebrationModal
-						site={ site }
-						onClose={ () => setIsCelebrationModalOpen( false ) }
-					/>
+					<SiteLaunchCelebrationModal site={ site as unknown as DashboardSite } />
 				</AnalyticsProvider>
 			) }
 		</div>

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -40,7 +40,6 @@ import { ExpiredReportNotice } from './components/expired-report-notice/expired-
 import { usePerformanceReport } from './hooks/usePerformanceReport';
 import { useSitePerformancePageReports } from './hooks/useSitePerformancePageReports';
 import { getSupportLinkProps } from './utils';
-import type { Site } from '@automattic/api-core';
 
 import './style.scss';
 
@@ -394,7 +393,7 @@ const SitePerformanceContent = ( { path }: { path?: string } ) => {
 			) }
 			{ site && (
 				<AnalyticsProvider client={ analyticsClient }>
-					<SiteLaunchCelebrationModal site={ site as unknown as Site } />
+					<SiteLaunchCelebrationModal site={ site } />
 				</AnalyticsProvider>
 			) }
 		</div>

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -40,6 +40,7 @@ import { ExpiredReportNotice } from './components/expired-report-notice/expired-
 import { usePerformanceReport } from './hooks/usePerformanceReport';
 import { useSitePerformancePageReports } from './hooks/useSitePerformancePageReports';
 import { getSupportLinkProps } from './utils';
+import type { Site } from '@automattic/api-core';
 
 import './style.scss';
 
@@ -159,11 +160,7 @@ const SitePerformanceContent = ( { path }: { path?: string } ) => {
 		( state ) => getRequest( state, launchSite( siteId ) )?.isLoading ?? false
 	);
 
-	const siteIsLaunched = useSelector(
-		( state ) => getRequest( state, launchSite( siteId ) )?.hasLoaded ?? false
-	);
-
-	const { isFetchedAfterMount: isDomainsFetched } = useQuery( {
+	useQuery( {
 		...domainsQuery(),
 		select: ( data ) => data.filter( ( domain ) => domain.blog_id === site?.ID ),
 	} );
@@ -397,7 +394,7 @@ const SitePerformanceContent = ( { path }: { path?: string } ) => {
 			) }
 			{ site && (
 				<AnalyticsProvider client={ analyticsClient }>
-					<SiteLaunchCelebrationModal site={ site as unknown as DashboardSite } />
+					<SiteLaunchCelebrationModal site={ site as unknown as Site } />
 				</AnalyticsProvider>
 			) }
 		</div>


### PR DESCRIPTION
Closes DATSCI-1229

## Proposed Changes

### Dashboard (`client/dashboard/`)

* Moved the celebration modal open/close state and trigger logic from individual page components (`performance/index.tsx`, `settings-site-visibility/index.tsx`) into the `SiteLaunchCelebrationModal` component itself
* Rendered the modal once in `site/index.tsx` (the shared layout shell for all per-site pages) so it is available everywhere without duplication
* Added `enabled: isOpen` to the domains query inside the modal to prevent unnecessary API calls when the modal is not open
* Restructured hooks order to comply with React Rules of Hooks — all hooks called unconditionally, conditional logic moved inside effects
* Updated test suite to reflect new modal behavior: removed `onClose` prop, added tests for render conditions, ensured all 14 tests pass

### Calypso (`client/hosting/performance/`)

* Simplified modal integration: removed local `isCelebrationModalOpen` state management
* Added `celebrateLaunch` param synchronously when ungated launch is dispatched (avoids race conditions)
* Removed `onClose` prop from modal component call
* Render modal unconditionally (only guarded by site existence) — modal self-manages its visibility based on URL param and launch status

## Why are these changes being made?

The celebration modal was duplicated across multiple locations with inconsistent trigger logic:

- `settings-site-visibility/index.tsx` used a stale `searchQueryParams` variable (captured once on render, never re-evaluated) which made the trigger unreliable
- `performance/index.tsx` had the correct approach: using `site.launch_status` as the `useEffect` dependency, which fires reliably when the launch mutation completes
- `client/hosting/performance/site-performance.tsx` (Calypso) was using complex state tracking that suffered from race conditions

By consolidating the modal logic into the component itself and using consistent trigger mechanisms across both Dashboard and Calypso, we get a single source of truth that:

1. **Works universally**: Functions in both Dashboard (TanStack Router) and Calypso (Redux) applications
2. **Is reliable**: Reacts to the actual `site.launch_status` change which is the authoritative source
3. **Is defensive**: The modal only opens when **both** the URL param is present **and** `site.launch_status === 'launched'`
4. **Avoids race conditions**: In Calypso, the URL param is added synchronously at dispatch time, ensuring both conditions are ready when data updates
5. **Is testable**: Comprehensive test suite with 14 passing tests covering all scenarios

## Testing Instructions

**Pre-requisite:**

- Please test it in the local dev environment since we need to update the experiment name to `calypso_launch_button_experiment_test_20260319_4`, line: https://github.com/Automattic/wp-calypso/blob/datsci-1176-standardize-site-launch-msd-site-performance/client/dashboard/sites/site-launch-button/index.tsx#L53
- Make sure assigning`ungated_site_launch` experiment variant

**For Dashboard:**
* Navigate to a coming-soon or private site's Performance page — the "Launch your site" notice should appear
* Click "Launch your site" — after launch the celebration modal should appear
* Close the modal — it should not reappear on the same page
* The `?celebrateLaunch=true` query param should be stripped from the URL when the modal opens
* Navigate to Settings > Site Visibility for a coming-soon site, complete the launch flow, and confirm the modal appears on redirect

**For Calypso:**
* Navigate to an Atomic site's Performance page with a coming-soon status
* Click "Launch your site" 
* Celebrate modal should appear when launch completes
* Verify param is stripped when modal opens

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed?
- [x] Have you written new tests for your changes? (14 tests passing)
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?

## Files Changed

1. `client/dashboard/sites/site-launch-celebration-modal/index.tsx` — Added self-managed state and trigger logic
2. `client/dashboard/sites/site-launch-celebration-modal/test/index.test.tsx` — Updated tests (14 passing)
3. `client/dashboard/sites/site/index.tsx` — Render modal once at layout level
4. `client/dashboard/sites/performance/index.tsx` — Remove duplicate modal logic
5. `client/dashboard/sites/settings-site-visibility/index.tsx` — Remove duplicate modal logic
6. `client/hosting/performance/site-performance.tsx` — Simplify Calypso integration, add param at dispatch time