### PR TITLE
A4A: Enable checkout/stripe-upi on A4A production

### DIFF
--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -42,7 +42,7 @@
 		"jetpack/crm-downloads": true,
 		"upgrades/redirect-payments": true,
 		"a4a-bd-term-pricing": true,
-		"checkout/stripe-upi": false
+		"checkout/stripe-upi": true
 	},
 	"enable_all_sections": false,
 	"sections": {


### PR DESCRIPTION
Resolves A4A-2335 (https://linear.app/a8c/issue/A4A-2335/enable-the-feature-flag-on-production)

## Proposed Changes

- Enable the `checkout/stripe-upi` feature flag in `config/a8c-for-agencies-production.json` so A4A production matches stage, horizon, development, and main Calypso production.

## Why are these changes being made?

UPI (Stripe) support for A4A checkout was added behind this flag; lower A4A environments already have it enabled. Turning it on in production completes the rollout for agencies.automattic.com.

## Testing Instructions

1. After deploy, open A4A checkout in production with a cart that qualifies for UPI (e.g. INR / India context as defined by existing checkout rules).
2. Confirm **UPI** is listed as a payment method and that a test transaction can be completed using the team’s standard payment QA process.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g. browsers), interfaces (e.g. keyboard navigation), and assistive technologies (e.g. screen readers) (PCYsg-S3g-p2)
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
