### PR TITLE
Dashboard: Anchor notifications popover when toggled via 'n' shortcut

### DIFF
--- a/client/dashboard/app/interim-omnibar/click-handlers.ts
+++ b/client/dashboard/app/interim-omnibar/click-handlers.ts
@@ -20,9 +20,7 @@ function createOmnibarEvent< T = void >() {
 
 export const omnibarEvents = {
 	mobileMenu: createOmnibarEvent(),
-	/** Announces the omnibar's notifications bell element so consumers can use it as a popover anchor. */
 	notificationsAnchor: createOmnibarEvent< HTMLElement | null >(),
-	/** Requests the notifications panel to toggle (e.g. user clicked the bell). */
 	notifications: createOmnibarEvent(),
 	linkClick: createOmnibarEvent< { href: string; event: MouseEvent } >(),
 };

--- a/client/dashboard/app/interim-omnibar/click-handlers.ts
+++ b/client/dashboard/app/interim-omnibar/click-handlers.ts
@@ -20,7 +20,10 @@ function createOmnibarEvent< T = void >() {
 
 export const omnibarEvents = {
 	mobileMenu: createOmnibarEvent(),
-	notifications: createOmnibarEvent< HTMLElement | null >(),
+	/** Announces the omnibar's notifications bell element so consumers can use it as a popover anchor. */
+	notificationsAnchor: createOmnibarEvent< HTMLElement | null >(),
+	/** Requests the notifications panel to toggle (e.g. user clicked the bell). */
+	notifications: createOmnibarEvent(),
 	linkClick: createOmnibarEvent< { href: string; event: MouseEvent } >(),
 };
 

--- a/client/dashboard/app/interim-omnibar/index.tsx
+++ b/client/dashboard/app/interim-omnibar/index.tsx
@@ -50,10 +50,7 @@ export default async function loadOmnibar( events: OmnibarEvents ) {
 	);
 
 	const handleToggleMenu = () => events.mobileMenu.emit();
-	const handleToggleNotifications = () =>
-		events.notifications.emit(
-			container.querySelector< HTMLElement >( '.masterbar-notifications' )
-		);
+	const handleToggleNotifications = () => events.notifications.emit();
 
 	async function renderWithSiteId( siteId: number | undefined ) {
 		const site = siteId ? await queryClient.ensureQueryData( siteByIdQuery( siteId ) ) : null;

--- a/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
+++ b/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
@@ -1,12 +1,13 @@
 /* eslint-disable no-restricted-imports */
 import { isEcommercePlan } from '@automattic/calypso-products';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { MasterbarLoggedIn } from 'calypso/layout/masterbar/logged-in';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getLogoutUrl } from 'calypso/lib/user/shared-utils';
 import { getSiteDisplayName } from '../../utils/site-name';
+import { omnibarEvents } from './click-handlers';
 import type { User, Site } from '@automattic/api-core';
 
 const noop = () => {};
@@ -62,6 +63,15 @@ export function InterimOmnibar( {
 		() => createOmnibarStore( onToggleNotifications ),
 		[ onToggleNotifications ]
 	);
+
+	// Announce the bell button element to subscribers (e.g. the Notifications
+	// component) so they can anchor a popover to it. Re-runs on every commit so
+	// it stays correct if MasterbarLoggedIn re-renders and replaces the node.
+	useEffect( () => {
+		const container = document.getElementById( 'wpcom-omnibar' );
+		const bell = container?.querySelector< HTMLElement >( '.masterbar-notifications' ) ?? null;
+		omnibarEvents.notificationsAnchor.emit( bell );
+	} );
 
 	return (
 		<QueryClientProvider client={ omnibarQueryClient }>

--- a/client/dashboard/app/notifications/index.tsx
+++ b/client/dashboard/app/notifications/index.tsx
@@ -75,19 +75,16 @@ export default function Notifications( {
 		CLOSE_PANEL: [ handleClose ],
 	};
 
-	const handleOmnibarToggle = useCallback(
-		( element: HTMLElement | null ) => {
-			setAnchorEl( element );
-			setIsOpen( ( prev ) => {
-				if ( ! prev ) {
-					setShowHelpCenter( false, undefined, true );
-				}
-				return ! prev;
-			} );
-		},
-		[ setShowHelpCenter ]
-	);
+	const handleOmnibarToggle = useCallback( () => {
+		setIsOpen( ( prev ) => {
+			if ( ! prev ) {
+				setShowHelpCenter( false, undefined, true );
+			}
+			return ! prev;
+		} );
+	}, [ setShowHelpCenter ] );
 
+	useOmnibarEvent( 'notificationsAnchor', setAnchorEl );
 	useOmnibarEvent( 'notifications', handleOmnibarToggle );
 
 	useEffect( () => {
@@ -101,7 +98,7 @@ export default function Notifications( {
 			if ( event.key === 'n' ) {
 				event.stopPropagation();
 				event.preventDefault();
-				handleToggle( true );
+				handleOmnibarToggle();
 			}
 		};
 
@@ -109,7 +106,7 @@ export default function Notifications( {
 		return () => {
 			window.removeEventListener( 'keydown', handleKeyDown, false );
 		};
-	}, [] );
+	}, [ handleOmnibarToggle ] );
 
 	return (
 		<Dropdown


### PR DESCRIPTION
Part of DOTMSD-1196

## Proposed Changes

* Split `omnibarEvents.notifications` into two events: `notificationsAnchor` (carries the bell `HTMLElement`) and `notifications` (payload-less toggle request).
* `InterimOmnibar` now emits `notificationsAnchor` from a `useEffect` after every commit, so the bell element is always known to subscribers — including before the user has interacted with it.
* The `Notifications` component subscribes to both events and continues to own the `n` keyboard shortcut. Because `anchorEl` is populated at hydration time, pressing `n` on first load now anchors the popover under the bell.
* The `.masterbar-notifications` selector now lives in exactly one place (`InterimOmnibar`).

## Why are these changes being made?

In the MSD omnibar, pressing `n` after page load opened the notifications panel at the bottom-left of the screen instead of under the bell button. The keyboard shortcut handler called `handleToggle( true )` directly, which only flipped `isOpen`. The popover's `anchor` was only ever set as a side effect of clicking the bell, so on first key press `anchorEl` was `null` and the `Popover` fell back to its default origin.

## Testing Instructions

1. Enable the \`dashboard/omnibar\` feature flag locally.
2. Load the sites list (or any dashboard route).
3. Without clicking anywhere, press \`n\`. Expected: the notifications panel opens anchored under the bell button in the omnibar.
4. Press \`n\` again. Expected: the panel closes.
5. Click the bell button. Expected: panel opens anchored under the bell (regression check on the click path).
6. With the omnibar flag disabled (default), repeat steps 2–4. Expected: pressing \`n\` toggles the panel anchored under the secondary-menu bell, as before.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?