### PR TITLE
Subscribers: Remove comp feature gate

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -17,7 +17,6 @@ import { Product } from 'calypso/my-sites/earn/types';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { getProductsForSiteId } from 'calypso/state/memberships/product-list/selectors';
-import { getCouponsAndGiftsEnabledForSiteId } from 'calypso/state/memberships/settings/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
@@ -164,16 +163,12 @@ export default function SubscriberDataViews( {
 	const [ filters, setFilters ] = useState< SubscribersFilterBy[] >( [ SubscribersFilterBy.All ] );
 	const [ selectedSubscriber, setSelectedSubscriber ] = useState< Subscriber | null >( null );
 
-	const couponsAndGiftsEnabled = useSelector( ( state ) =>
-		getCouponsAndGiftsEnabledForSiteId( state, siteId )
-	);
-
 	const products: Product[] = useSelector( ( state ) => getProductsForSiteId( state, siteId ) );
 
 	const hasUncompedPlans = useCallback(
 		( subscriber: Subscriber ) => {
 			if ( ! products?.length ) {
-				return true;
+				return false;
 			}
 			const compedIds = ( subscriber.plans ?? [] )
 				.filter( ( p ) => p.is_comp && p.subscription_id )
@@ -521,27 +516,25 @@ export default function SubscriberDataViews( {
 			},
 		];
 
-		if ( couponsAndGiftsEnabled ) {
-			baseActions.push( {
-				id: 'comp',
-				label: translate( 'Comp a subscription', {
-					textOnly: true,
-					comment:
-						'"Comp" is short for "complimentary" — granting a free subscription to a subscriber',
-				} ),
-				isEligible: ( subscriber: Subscriber ) =>
-					!! ( subscriber.user_id || subscriber.email_address ) && hasUncompedPlans( subscriber ),
-				callback: ( items: Subscriber[] ) => {
-					const subscriber = items[ 0 ];
-					if ( ! subscriber ) {
-						return;
-					}
+		baseActions.push( {
+			id: 'comp',
+			label: translate( 'Comp a subscription', {
+				textOnly: true,
+				comment:
+					'"Comp" is short for "complimentary" — granting a free subscription to a subscriber',
+			} ),
+			isEligible: ( subscriber: Subscriber ) =>
+				!! ( subscriber.user_id || subscriber.email_address ) && hasUncompedPlans( subscriber ),
+			callback: ( items: Subscriber[] ) => {
+				const subscriber = items[ 0 ];
+				if ( ! subscriber ) {
+					return;
+				}
 
-					onCompSubscription( subscriber );
-				},
-				isPrimary: false,
-			} );
-		}
+				onCompSubscription( subscriber );
+			},
+			isPrimary: false,
+		} );
 
 		return baseActions;
 	}, [
@@ -549,7 +542,6 @@ export default function SubscriberDataViews( {
 		handleSubscriberSelection,
 		handleUnsubscribe,
 		onCompSubscription,
-		couponsAndGiftsEnabled,
 		hasUncompedPlans,
 	] );
 
@@ -787,16 +779,13 @@ export default function SubscriberDataViews( {
 							subscriptionId={ getSubscriptionId( subscriberDetails ) }
 							onClose={ handleClose }
 							onUnsubscribe={ ( subscriber ) => handleUnsubscribe( [ subscriber ] ) }
-							onCompSubscription={ couponsAndGiftsEnabled ? onCompSubscription : undefined }
-							onRemoveComp={
-								couponsAndGiftsEnabled
-									? ( { planName, compId } ) =>
-											onRemoveComp( {
-												planName,
-												username: subscriberDetails.display_name,
-												compId,
-											} )
-									: undefined
+							onCompSubscription={ onCompSubscription }
+							onRemoveComp={ ( { planName, compId } ) =>
+								onRemoveComp( {
+									planName,
+									username: subscriberDetails.display_name,
+									compId,
+								} )
 							}
 							newsletterCategoriesEnabled={ subscribedNewsletterCategoriesData?.enabled }
 							newsletterCategories={ subscribedNewsletterCategoriesData?.newsletterCategories }


### PR DESCRIPTION
## Proposed Changes

* Remove the `couponsAndGiftsEnabled` blog sticker gate from the subscriber data views
* Comp actions are now always available when the site has paid plans
* Changed `hasUncompedPlans` to return `false` when no products exist, so the comp action only appears on sites with paid newsletter plans

## Why are these changes being made?

The complimentary memberships feature is ready for general availability. The server-side blog sticker gate (`coupons_and_gifts_enabled`) is no longer needed — the only condition for showing the comp option should be whether the site has paid plans.

## Testing Instructions

* Navigate to Subscribers on a site **with** paid newsletter plans → "Comp a subscription" action should appear
* Navigate to Subscribers on a site **without** paid plans → "Comp a subscription" action should not appear
* Open subscriber details → comp/remove-comp actions should work without needing the blog sticker

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?