### PR TITLE
fix: Tweak spacing for DIFM content form

### DIFF
--- a/client/signup/accordion-form/form-components.tsx
+++ b/client/signup/accordion-form/form-components.tsx
@@ -117,7 +117,7 @@ const FlexFormFieldset = styled( FormFieldset )`
 const StyledFormFieldset = styled( FormFieldset, {
 	shouldForwardProp: ( prop ) => prop !== 'hasFillerContentCheckbox',
 } )( ( props ) => ( {
-	marginBottom: props.hasFillerContentCheckbox ? '12px' : '20px',
+	marginBottom: props.hasFillerContentCheckbox ? '4px' : '20px',
 } ) );
 
 const StyledFormCheckbox = styled( FormCheckbox )`


### PR DESCRIPTION
## Description
The `StyledFormFieldset` component in the DIFM (Do It For Me) content form was applying too much bottom margin (`12px`) when the filler content checkbox was present. This caused the spacing between the form field and the checkbox to appear visually loose and inconsistent. This PR reduces that margin to `4px` to tighten the layout and improve visual alignment.

## Changes
- `client/signup/accordion-form/form-components.tsx` — Updated `marginBottom` value in `StyledFormFieldset` from `12px` to `4px` when `hasFillerContentCheckbox` prop is `true`, to reduce excess spacing between the form fieldset and the filler content checkbox.

## Before / After
**Before:** When `hasFillerContentCheckbox` was `true`, the form fieldset had a `12px` bottom margin, creating noticeable extra space between the field and the checkbox below it.

**After:** The bottom margin is reduced to `4px` when `hasFillerContentCheckbox` is `true`, resulting in tighter, more visually consistent spacing between the fieldset and the checkbox.

## Testing
1. Navigate to the DIFM (Do It For Me) signup flow in Calypso.
2. Reach the content form step that includes the filler content checkbox.
3. Verify that the spacing between the form fieldset and the filler content checkbox appears tighter and more compact than before.
4. Confirm that form fields without `hasFillerContentCheckbox` still retain the standard `20px` bottom margin.
5. Check across different screen sizes to ensure the spacing looks correct responsively.

---
Fixes GH-102042