### PR TITLE
Fix Sources component click overlap

### DIFF
--- a/packages/agents-manager/src/components/sources-display/index.tsx
+++ b/packages/agents-manager/src/components/sources-display/index.tsx
@@ -59,6 +59,7 @@ export default function SourcesDisplay( { sources }: Props ) {
 			screenReaderText={ __( 'More', '__i18n_text_domain__' ) }
 			iconSize={ 16 }
 			clickableHeader
+			useInert
 			smooth
 		>
 			<div className="agents-manager-sources-display__list">

--- a/packages/agents-manager/src/components/sources-display/style.scss
+++ b/packages/agents-manager/src/components/sources-display/style.scss
@@ -23,6 +23,13 @@
 		gap: 4px;
 		padding: 0;
 		pointer-events: initial;
+		border-radius: 4px;
+
+		&:has(:focus-visible) {
+			padding-left: 4px;
+			outline: 2px solid var(--color-ring);
+			outline-offset: -1px;
+		}
 	}
 
 	.foldable-card__content {
@@ -39,6 +46,10 @@
 	.foldable-card__action {
 		position: relative;
 		width: 16px;
+
+		&:focus-visible {
+			outline: none;
+		}
 
 		svg.gridicon {
 			fill: var(--color-muted-foreground);

--- a/packages/agents-manager/src/components/sources-display/style.scss
+++ b/packages/agents-manager/src/components/sources-display/style.scss
@@ -10,6 +10,7 @@
 		background-color: transparent;
 		box-shadow: none;
 		margin: -32px 0 0;
+		pointer-events: none;
 	}
 
 	.foldable-card__header {
@@ -18,12 +19,15 @@
 		min-height: unset;
 		flex-direction: row-reverse;
 		justify-content: end;
+		align-self: flex-end;
 		gap: 4px;
 		padding: 0;
+		pointer-events: initial;
 	}
 
 	.foldable-card__content {
 		width: 100%;
+		pointer-events: initial;
 	}
 
 	.foldable-card__main,


### PR DESCRIPTION
## Proposed Changes

Fix an issue in the Agents Manager chat where the Sources container was above other actions, such as Thumbs Up/Down or the Copy button. (Context: p1775481265083219-slack-C9UMZ71QD)

## Testing Instructions

* Sync the Agents Manager app with your sandbox - `cd apps/agents-manager && yarn dev --sync`
* Ask a question like `How to register a domain?`
* The agent response should include the Sources and you should be able to open/close it
* The other buttons should also be clickable

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?