### PR TITLE
Analytics: Add source field to calypso_masterbar_launch_site event

### DIFF
--- a/client/layout/masterbar/masterbar-launch-button.tsx
+++ b/client/layout/masterbar/masterbar-launch-button.tsx
@@ -10,13 +10,14 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { launchSiteOrRedirectToLaunchSignupFlow } from 'calypso/state/sites/launch/actions';
 import { getSite } from 'calypso/state/sites/selectors';
+import { getSectionName } from 'calypso/state/ui/selectors';
 import Item from './item';
 
 export const MasterbarLaunchButton = ( { siteId }: { siteId: number } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const site = useSelector( ( state ) => getSite( state, siteId ) );
-
+	const sectionName = useSelector( getSectionName );
 	const launchSiteMutation = useMutation( siteLaunchMutation( siteId ) );
 
 	const { onSiteLaunched } = useCelebrateLaunchModalSideEffects( siteId );
@@ -24,7 +25,7 @@ export const MasterbarLaunchButton = ( { siteId }: { siteId: number } ) => {
 	const [ isLoading, data ] = useExperiment( 'calypso_standardized_site_launch_gating' );
 
 	const onLaunchSiteClick = () => {
-		dispatch( recordTracksEvent( 'calypso_masterbar_launch_site' ) );
+		dispatch( recordTracksEvent( 'calypso_masterbar_launch_site', { source: sectionName } ) );
 
 		if ( data?.variationName === 'gated_site_launch' ) {
 			window.location.assign(


### PR DESCRIPTION
## Summary

Add a source field to the calypso_masterbar_launch_site Tracks event to capture which Calypso section (e.g., reader, my-sites, checkout) the user was in when launching their site from the masterbar. This enables better attribution and insights into launch patterns across different areas of the application.

## Changes

- Import getSectionName selector from calypso/state/ui/selectors
- Use the selector to get the current section name
- Pass { source: sectionName } to the recordTracksEvent call

## Test plan

- Navigate to different Calypso sections (Reader, My Sites, Checkout, etc.)
- Click the "Launch site" button in the masterbar
- Verify in the browser's network tab that the calypso_masterbar_launch_site event includes the correct source property matching the section

<img width="849" height="24" alt="Screenshot 2026-04-06 at 19 31 21" src="https://github.com/user-attachments/assets/da01b413-1426-42af-9ee6-ad06923a0b25" />

## Related issue

DATSCI-1227