### PR TITLE
Fix tax label in dashboard billing history to show VAT/GST instead of Tax

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -199,6 +199,7 @@ export const receiptRoute = createRoute( {
 		await Promise.all( [
 			queryClient.ensureQueryData( receiptQuery( parseInt( receiptId ) ) ),
 			queryClient.ensureQueryData( userTaxDetailsQuery() ),
+			queryClient.ensureQueryData( countryListQuery() ),
 		] );
 	},
 	path: '$receiptId',

--- a/client/dashboard/me/billing-history/dataviews.tsx
+++ b/client/dashboard/me/billing-history/dataviews.tsx
@@ -392,10 +392,9 @@ function renderReceiptAmount( receipt: Receipt, taxName?: string ) {
 	const taxAmount = formatReceiptTaxAmount( receipt );
 	const includesTaxString = taxName
 		? sprintf(
-				/* translators: 1: a localized price like $12.34, 2: a tax name like VAT or GST */
-				__( '(includes %1$s %2$s)' ),
-				taxAmount,
-				taxName
+				/* translators: taxAmount is a localized price like $12.34, taxName is a tax name like VAT or GST */
+				__( '(includes %(taxAmount)s %(taxName)s)' ),
+				{ taxAmount, taxName }
 		  )
 		: sprintf(
 				/* translators: %s is a localized price, like $12.34 */

--- a/client/dashboard/me/billing-history/dataviews.tsx
+++ b/client/dashboard/me/billing-history/dataviews.tsx
@@ -6,6 +6,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import { receiptRoute } from '../../app/router/me';
 import { isAkismetPro500Plan } from '../../utils/akismet';
+import { getTaxName } from '../../utils/tax';
 import {
 	formatReceiptAmount,
 	formatReceiptTaxAmount,
@@ -15,7 +16,7 @@ import {
 	summarizeReceiptItems,
 	transactionIncludesTax,
 } from './utils';
-import type { Receipt } from '@automattic/api-core';
+import type { CountryListItem, Receipt } from '@automattic/api-core';
 import type { Fields, Operator, SortDirection, View } from '@wordpress/dataviews';
 
 import './styles.scss';
@@ -94,7 +95,10 @@ export function useActions() {
 	);
 }
 
-export function getFields( receipts: Receipt[] ): Fields< Receipt > {
+export function getFields(
+	receipts: Receipt[],
+	countryList: CountryListItem[] = []
+): Fields< Receipt > {
 	return [
 		{
 			id: 'date',
@@ -205,7 +209,8 @@ export function getFields( receipts: Receipt[] ): Fields< Receipt > {
 				}
 				return search_data;
 			},
-			render: ( { item }: { item: Receipt } ) => renderReceiptAmount( item ),
+			render: ( { item }: { item: Receipt } ) =>
+				renderReceiptAmount( item, getTaxName( countryList, item.tax_country_code ) ),
 		},
 		{
 			id: 'extra_receipt_data_for_search',
@@ -373,7 +378,7 @@ function getReceiptItemTypeForDisplay( receipt: Receipt ): string {
 	return String( receiptItem.type_localized || receiptItem.type || '' );
 }
 
-function renderReceiptAmount( receipt: Receipt ) {
+function renderReceiptAmount( receipt: Receipt, taxName?: string ) {
 	if ( ! transactionIncludesTax( receipt ) ) {
 		return (
 			<VStack spacing={ 1 }>
@@ -384,11 +389,19 @@ function renderReceiptAmount( receipt: Receipt ) {
 		);
 	}
 
-	const includesTaxString = sprintf(
-		/* translators: %s is a localized price, like $12.34 */
-		__( '(includes %s tax)' ),
-		formatReceiptTaxAmount( receipt )
-	);
+	const taxAmount = formatReceiptTaxAmount( receipt );
+	const includesTaxString = taxName
+		? sprintf(
+				/* translators: 1: a localized price like $12.34, 2: a tax name like VAT or GST */
+				__( '(includes %1$s %2$s)' ),
+				taxAmount,
+				taxName
+		  )
+		: sprintf(
+				/* translators: %s is a localized price, like $12.34 */
+				__( '(includes %s tax)' ),
+				taxAmount
+		  );
 
 	return (
 		<VStack spacing={ 1 }>

--- a/client/dashboard/me/billing-history/index.tsx
+++ b/client/dashboard/me/billing-history/index.tsx
@@ -1,4 +1,4 @@
-import { userReceiptsQuery } from '@automattic/api-queries';
+import { countryListQuery, userReceiptsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { useResizeObserver } from '@wordpress/compose';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
@@ -26,6 +26,7 @@ const emptyReceipts: Receipt[] = [];
 
 export default function BillingHistory() {
 	const { data: receipts = emptyReceipts, isLoading } = useQuery( userReceiptsQuery() );
+	const { data: countryList = [] } = useQuery( countryListQuery() );
 
 	const searchParams = billingHistoryRoute.useSearch();
 	const [ defaultView, setDefaultView ] = useState( DEFAULT_VIEW );
@@ -48,7 +49,7 @@ export default function BillingHistory() {
 		}
 	} );
 
-	const fields = getFields( receipts );
+	const fields = getFields( receipts, countryList );
 
 	const { data: filteredReceipts, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( receipts, view, fields );

--- a/client/dashboard/me/billing-history/index.tsx
+++ b/client/dashboard/me/billing-history/index.tsx
@@ -49,7 +49,7 @@ export default function BillingHistory() {
 		}
 	} );
 
-	const fields = getFields( receipts, countryList );
+	const fields = useMemo( () => getFields( receipts, countryList ), [ receipts, countryList ] );
 
 	const { data: filteredReceipts, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( receipts, view, fields );

--- a/client/dashboard/me/billing-history/receipt.tsx
+++ b/client/dashboard/me/billing-history/receipt.tsx
@@ -1,5 +1,6 @@
 import { PaymentPartners } from '@automattic/api-core';
 import {
+	countryListQuery,
 	receiptQuery,
 	sendReceiptEmailMutation,
 	userTaxDetailsQuery,
@@ -25,6 +26,7 @@ import { Card, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { isAkismetPro500Plan } from '../../utils/akismet';
+import { getTaxName } from '../../utils/tax';
 import {
 	formatReceiptAmount,
 	formatReceiptTaxAmount,
@@ -318,6 +320,8 @@ function getPaymentMethodText( receipt: Receipt ): string | null {
 
 function ReceiptLineItems( { receipt }: { receipt: Receipt } ) {
 	const groupedItems = groupDomainProducts( receipt.items );
+	const { data: countryList } = useSuspenseQuery( countryListQuery() );
+	const taxName = getTaxName( countryList, receipt.tax_country_code );
 
 	return (
 		<VStack spacing={ 4 } alignment="flex-start">
@@ -343,7 +347,7 @@ function ReceiptLineItems( { receipt }: { receipt: Receipt } ) {
 					{ transactionIncludesTax( receipt ) && (
 						<VStack className="receipt-tax-row">
 							<HStack justify="space-between">
-								<span>{ __( 'Tax' ) }</span>
+								<span>{ taxName ?? __( 'Tax' ) }</span>
 								<span>{ formatReceiptTaxAmount( receipt ) }</span>
 							</HStack>
 						</VStack>


### PR DESCRIPTION
Resolves [CHE-269](https://linear.app/a8c/issue/CHE-269/hosting-dashboard-billing-history-and-receipt-pages-dont-use-the)

## Proposed Changes

* Updated the receipt page (`client/dashboard/me/billing-history/receipt.tsx`) to look up the correct tax label (VAT, GST, etc.) using `getTaxName` from `client/dashboard/utils/tax.ts` instead of hardcoding "Tax"
* Updated the billing history list view (`client/dashboard/me/billing-history/dataviews.tsx`) to display the correct tax name in the "(includes $X VAT)" string, with fallback to "(includes $X tax)" when the country is unknown
* Added `countryListQuery` fetch in `index.tsx` and passed it through `getFields` to make country data available to the list view

## Why are these changes being made?

The new hosting dashboard billing history and receipt pages always display "Tax" as the tax label, regardless of the customer's country. The classic Calypso pages (`client/me/purchases/billing-history/`) correctly show country-specific labels like "VAT" for EU countries and "GST" for Australia.

The fix uses `getTaxName` + `countryListQuery` - the same pattern already established in the dashboard's tax details form (`client/dashboard/me/billing-tax-details/user-tax-form.tsx`).

| Country | Before | After |
|---------|--------|-------|
| DE (Germany) | Tax | VAT |
| GB (United Kingdom) | Tax | VAT |
| AU (Australia) | Tax | GST |
| FR (France) | Tax | VAT |
| Unknown / empty | Tax | Tax (fallback) |

## Testing Instructions

**Environment:**
- Enable Store Sandbox mode
- `public-api.wordpress.com` sandboxed

**Steps:**
1. Navigate to `http://calypso.localhost:3000/me/purchases/billing`
2. Find a receipt with tax from an EU country (e.g., buy something with a French or German address)
3. In the list view, verify that the amount column shows "(includes $X.XX VAT)" instead of "(includes $X.XX tax)"
4. Click into that receipt
5. Verify that the tax row in the order summary shows "VAT" instead of "Tax"
6. Navigate to an Australian receipt if available - verify it shows "GST"
7. Check a receipt with no tax (e.g., US) - verify no tax row appears and page renders normally
8. Cross-check with the classic billing page at `https://wordpress.com/me/purchases/billing` - tax labels should now match between classic and dashboard

**Verify:**
- Receipt page shows "VAT", "GST", etc. based on country, with "Tax" as fallback
- List view shows "(includes $X.XX VAT)", "(includes $X.XX GST)", etc., with "(includes $X.XX tax)" as fallback

## Screenshots
<img width="1334" height="1169" alt="Screenshot 2026-04-06 at 12 12 42 PM" src="https://github.com/user-attachments/assets/05ae6e10-a9dc-4e1a-b651-df2fdc22d4d1" />

<img width="1334" height="1169" alt="Screenshot 2026-04-06 at 12 12 48 PM" src="https://github.com/user-attachments/assets/e10375bd-330b-4875-8932-d0dfb3664b51" />

<img width="1334" height="1169" alt="Screenshot 2026-04-06 at 12 14 24 PM" src="https://github.com/user-attachments/assets/eed8f18c-68c0-4b3b-893f-e124bbb10525" />




## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
