### PR TITLE
Masterbar: async-load launch button to prevent Explat warnings

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -62,7 +62,6 @@ import Item from './item';
 import Masterbar from './masterbar';
 import { AgentsManagerIcon } from './masterbar-agents-manager/agents-manager-icon';
 import { HelpCenterIcon } from './masterbar-help-center/help-center-icon';
-import { MasterbarLaunchButton } from './masterbar-launch-button';
 import Notifications from './masterbar-notifications/notifications-button';
 
 class MasterbarLoggedIn extends Component {
@@ -618,7 +617,7 @@ class MasterbarLoggedIn extends Component {
 			return null;
 		}
 
-		return <MasterbarLaunchButton siteId={ siteId } />;
+		return <AsyncLoad require="./masterbar-launch-button" placeholder={ null } siteId={ siteId } />;
 	}
 
 	renderProfileMenu() {

--- a/client/layout/masterbar/masterbar-launch-button.tsx
+++ b/client/layout/masterbar/masterbar-launch-button.tsx
@@ -14,7 +14,7 @@ import { launchSiteOrRedirectToLaunchSignupFlow } from 'calypso/state/sites/laun
 import { getSite } from 'calypso/state/sites/selectors';
 import Item from './item';
 
-export const MasterbarLaunchButton = ( { siteId }: { siteId: number } ) => {
+const MasterbarLaunchButton = ( { siteId }: { siteId: number } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const site = useSelector( ( state ) => getSite( state, siteId ) );
@@ -81,3 +81,5 @@ export const MasterbarLaunchButton = ( { siteId }: { siteId: number } ) => {
 		</>
 	);
 };
+
+export default MasterbarLaunchButton;


### PR DESCRIPTION
## Proposed Changes

- Load `MasterbarLaunchButton` with `AsyncLoad` in the logged-in masterbar instead of a static import.
- Switch `masterbar-launch-button.tsx` to a default export so the async chunk resolves correctly.

## Why are these changes being made?

The masterbar is loaded in SSR contexts and because the Launch Button contains experiment setup code and the explat code should only be run in the browser, it was giving us

```
ERROR calypso: 
    message: Trying to initialize anonId outside of a browser context.
    --
    properties: {
      "context": "explat",
      "explat_client": "calypso",
      "message": "Trying to initialize anonId outside of a browser context."
    }
```

## Testing Instructions

1. Log in to Calypso with a site that is not launched yet.
2. Confirm the launch button still appears and works (launch flow / navigation as before).
3. Check you don't see the error in the server logs.