### PR TITLE
e2e: Fix intermittent slideshow block test crash

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/slideshow.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/slideshow.ts
@@ -49,7 +49,10 @@ export class SlideshowBlockFlow implements BlockFlow {
 			await Promise.all( [
 				fileInputLocator.setInputFiles( testFile.fullpath ),
 				context.page.waitForResponse(
-					( response ) => response.url().includes( 'media?' ) && response.ok()
+					( response ) =>
+						response.request().method() === 'POST' &&
+						response.url().includes( 'media?' ) &&
+						response.ok()
 				),
 			] );
 			const uploadingIndicatorLocator = editorCanvas.locator( selectors.uploadingIndicator ).last();


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

Fix SlideshowBlockFlow's `waitForResponse()` to not match the wrong response.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Since Gutenberg 22.6.0, we've been seeing an intermittent editor crash related to the slideshow block test. What seems to be happening, roughly, is:

1. There's a bug somewhere in Gutenberg that causes an editor crash. Claude thinks it's when core-data gets updated mid-render.
2. SlideshowBlockFlow occasionally terminates early by matching a wrong response in a `waitForResponse()`, leaving some requests in-flight.
3. The test moves on to ImageCompareFlow, and an in-flight request comes in when `addBlockFromSidebar` is mid-render, updating core-data and triggering the race. 💥

This fixes SlideshowBlockFlow's `waitForResponse()` to not match the wrong response, so the Gutenberg race won't be triggered anymore.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* 🤷 This hacky E2E test seems to reliably reproduce the crash on trunk, and no longer reproduces with this PR: [test.ts](https://github.com/user-attachments/files/26519848/test.ts.txt)
  * Save it to `test/e2e/specs/editor/test.ts`, then run it something like `yarn workspace wp-e2e-tests build && CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME="desktop" TEST_ON_ATOMIC="true" yarn workspace wp-e2e-tests test test/e2e/specs/editor/test.ts`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
