### PR TITLE
Newsletter importer: import comps as complimentary subscriptions

### DIFF
--- a/client/data/paid-newsletter/use-paid-newsletter-query.ts
+++ b/client/data/paid-newsletter/use-paid-newsletter-query.ts
@@ -33,12 +33,14 @@ export interface SubscribersStepContent {
 	connect_url?: string;
 	is_connected_stripe: boolean;
 	map_plans?: Record< string, string >;
+	comp_stripe_plan_id?: string;
 	account_display?: string;
 	plans?: Plan[];
 	meta?: {
 		email_count: string;
 		id: number;
 		paid_subscribers_count: string;
+		comp_count?: number;
 		platform: string;
 		scheduled_at: string;
 		status: string;
@@ -48,6 +50,9 @@ export interface SubscribersStepContent {
 		paid_subscribed_count: string | null;
 		paid_already_subscribed_count: string | null;
 		paid_failed_subscribed_count: string | null;
+		comp_subscribed_count: string | null;
+		comp_already_subscribed_count: string | null;
+		comp_failed_subscribed_count: string | null;
 		timestamp: string;
 	};
 }

--- a/client/data/paid-newsletter/use-set-comp-plan-mutation.ts
+++ b/client/data/paid-newsletter/use-set-comp-plan-mutation.ts
@@ -1,0 +1,70 @@
+import {
+	DefaultError,
+	useMutation,
+	UseMutationOptions,
+	useQueryClient,
+} from '@tanstack/react-query';
+import { useCallback } from 'react';
+import wp from 'calypso/lib/wp';
+
+interface MutationVariables {
+	siteId: number;
+	engine: string;
+	currentStep: string;
+	stripePlanId: string;
+}
+
+export const useSetCompPlanMutation = (
+	options: UseMutationOptions< unknown, DefaultError, MutationVariables > = {}
+) => {
+	const queryClient = useQueryClient();
+	const mutation = useMutation( {
+		mutationFn: async ( { siteId, engine, currentStep, stripePlanId }: MutationVariables ) => {
+			// Optimistically set the value.
+			queryClient.setQueryData(
+				[ 'paid-newsletter-importer', siteId, engine ],
+				( previous: any ) => {
+					if ( ! previous ) {
+						return previous;
+					}
+					previous.steps[ 'subscribers' ].content.comp_stripe_plan_id = stripePlanId;
+					return previous;
+				}
+			);
+
+			const response = await wp.req.post(
+				{
+					path: `/sites/${ siteId }/site-importer/paid-newsletter/set-comp-plan`,
+					apiNamespace: 'wpcom/v2',
+				},
+				{
+					engine: engine,
+					current_step: currentStep,
+					stripe_plan_id: stripePlanId,
+				}
+			);
+
+			if ( ! response.current_step ) {
+				throw new Error( 'failed to set comp plan' );
+			}
+
+			return response;
+		},
+		...options,
+		onSuccess( ...args ) {
+			const [ data, { siteId, engine } ] = args;
+			queryClient.setQueryData( [ 'paid-newsletter-importer', siteId, engine ], data );
+			options.onSuccess?.( ...args );
+		},
+	} );
+
+	const { mutate } = mutation;
+
+	const setCompPlan = useCallback(
+		( siteId: number, engine: string, currentStep: string, stripePlanId: string ) =>
+			mutate( { siteId, engine, currentStep, stripePlanId } ),
+		[ mutate ]
+	);
+
+	return { setCompPlan, ...mutation };
+};

--- a/client/data/paid-newsletter/use-set-comp-plan-mutation.ts
+++ b/client/data/paid-newsletter/use-set-comp-plan-mutation.ts
@@ -40,7 +40,7 @@ export const useSetCompPlanMutation = (
 				{
 					engine: engine,
 					current_step: currentStep,
-					stripe_plan_id: stripePlanId,
+					comp_stripe_plan_id: stripePlanId,
 				}
 			);
 

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-comp-plan.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-comp-plan.tsx
@@ -1,0 +1,107 @@
+import { formatCurrency } from '@automattic/number-formatters';
+import { DropdownMenu, MenuGroup, MenuItemsChoice, Button } from '@wordpress/components';
+import { sprintf } from '@wordpress/i18n';
+import { chevronDown, Icon, arrowRight } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
+import { useState, KeyboardEvent } from 'react';
+import { Plan } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
+
+type MapCompPlanProps = {
+	compCount: number;
+	plans: Plan[];
+	selectedStripePlanId: string;
+	onCompPlanSelect: ( stripePlanId: string ) => void;
+};
+
+function displayPlan( plan?: Plan, fallback?: string ) {
+	if ( ! plan ) {
+		return fallback;
+	}
+
+	return (
+		<div>
+			<strong>{ plan.name }</strong>
+			<p>
+				{ formatCurrency( plan.plan_amount_decimal, plan.plan_currency, {
+					isSmallestUnit: true,
+					stripZeros: true,
+				} ) }
+				/{ plan.plan_interval }
+			</p>
+		</div>
+	);
+}
+
+export function MapCompPlan( {
+	compCount,
+	plans,
+	selectedStripePlanId,
+	onCompPlanSelect,
+}: MapCompPlanProps ) {
+	const { __, _n } = useI18n();
+	const [ isOpen, setIsOpen ] = useState( false );
+
+	const selectedPlan = plans.find( ( plan ) => plan.product_id === selectedStripePlanId );
+
+	const choices = plans.map( ( plan ) => ( {
+		info: `${ formatCurrency( plan.plan_amount_decimal, plan.plan_currency, {
+			isSmallestUnit: true,
+			stripZeros: true,
+		} ) } / ${ plan.plan_interval }`,
+		label: plan.name,
+		value: plan.product_id,
+	} ) );
+
+	return (
+		<div className="map-plan">
+			<div className="map-plan__info">
+				<strong>{ __( 'Comped subscribers' ) }</strong>
+				<p>
+					{ sprintf(
+						// Translators: %d is number of complimentary subscribers
+						_n( '%d complimentary subscriber', '%d complimentary subscribers', compCount ),
+						compCount
+					) }
+				</p>
+			</div>
+			<div className="map-plan__arrow">
+				<Icon icon={ arrowRight } />
+			</div>
+			<div className="map-plan__select-product">
+				<Button
+					aria-haspopup="true"
+					tabIndex={ 0 }
+					className="map-plan__selected"
+					onClick={ () => setIsOpen( ! isOpen ) }
+					onKeyDown={ ( event: KeyboardEvent ) => {
+						if ( event.key === 'Enter' || event.key === ' ' ) {
+							setIsOpen( ! isOpen );
+						}
+					} }
+				>
+					{ displayPlan( selectedPlan, __( 'Select a plan' ) ) }
+				</Button>
+				<DropdownMenu
+					onToggle={ ( openState: boolean ) => setIsOpen( openState ) }
+					icon={ chevronDown }
+					label={ __( 'Choose a plan for comped subscribers' ) }
+					open={ isOpen }
+				>
+					{ ( { onClose }: { onClose: () => void } ) => (
+						<MenuGroup label={ __( 'Grant complimentary access to' ) }>
+							<MenuItemsChoice
+								choices={ choices }
+								onSelect={ ( stripePlanId ) => {
+									onCompPlanSelect( stripePlanId );
+									onClose();
+								} }
+								onHover={ () => {} }
+								value={ selectedStripePlanId }
+							/>
+						</MenuGroup>
+					) }
+				</DropdownMenu>
+			</div>
+		</div>
+	);
+}

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-comp-plan.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-comp-plan.tsx
@@ -3,7 +3,7 @@ import { DropdownMenu, MenuGroup, MenuItemsChoice, Button } from '@wordpress/com
 import { sprintf } from '@wordpress/i18n';
 import { chevronDown, Icon, arrowRight } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { useState, KeyboardEvent } from 'react';
+import { useState } from 'react';
 import { Plan } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
 
 type MapCompPlanProps = {
@@ -19,16 +19,16 @@ function displayPlan( plan?: Plan, fallback?: string ) {
 	}
 
 	return (
-		<div>
-			<strong>{ plan.name }</strong>
-			<p>
+		<span>
+			<strong>{ plan.name }</strong>{ ' ' }
+			<span>
 				{ formatCurrency( plan.plan_amount_decimal, plan.plan_currency, {
 					isSmallestUnit: true,
 					stripZeros: true,
 				} ) }
 				/{ plan.plan_interval }
-			</p>
-		</div>
+			</span>
+		</span>
 	);
 }
 
@@ -70,14 +70,8 @@ export function MapCompPlan( {
 			<div className="map-plan__select-product">
 				<Button
 					aria-haspopup="true"
-					tabIndex={ 0 }
 					className="map-plan__selected"
 					onClick={ () => setIsOpen( ! isOpen ) }
-					onKeyDown={ ( event: KeyboardEvent ) => {
-						if ( event.key === 'Enter' || event.key === ' ' ) {
-							setIsOpen( ! isOpen );
-						}
-					} }
 				>
 					{ displayPlan( selectedPlan, __( 'Select a plan' ) ) }
 				</Button>

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-plans.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-plans.tsx
@@ -4,6 +4,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, useState, useRef } from 'react';
 import { useMapStripePlanToProductMutation } from 'calypso/data/paid-newsletter/use-map-stripe-plan-to-product-mutation';
+import { useSetCompPlanMutation } from 'calypso/data/paid-newsletter/use-set-comp-plan-mutation';
 import RecurringPaymentsPlanAddEditModal from 'calypso/my-sites/earn/components/add-edit-plan-modal';
 import {
 	PLAN_YEARLY_FREQUENCY,
@@ -15,6 +16,7 @@ import { useSelector } from 'calypso/state';
 import { getProductsForSiteId } from 'calypso/state/memberships/product-list/selectors';
 import { SubscribersStepProps } from '../../types';
 import StartImportButton from './../start-import-button';
+import { MapCompPlan } from './map-comp-plan';
 import { MapPlan, TierToAdd } from './map-plan';
 import NoPlans from './no-plans';
 import SuccessNotice from './success-notice';
@@ -36,10 +38,20 @@ function shouldEnableImporting( cardData: any ) {
 	const plans = cardData?.plans ?? [];
 	const map_plans = cardData?.map_plans ?? {};
 
-	// Check if all items in the map array have a value for each key
-	return Object.values( plans ).every(
+	const allPlansMapped = Object.values( plans ).every(
 		( item: any ) => map_plans[ item?.product_id ] !== undefined
 	);
+	if ( ! allPlansMapped ) {
+		return false;
+	}
+
+	// If there are comped subscribers, require a comp plan selection.
+	const compCount = parseInt( cardData?.meta?.comp_count || '0' );
+	if ( compCount > 0 && ! cardData?.comp_stripe_plan_id ) {
+		return false;
+	}
+
+	return true;
 }
 
 function findNewProduct( currentProducts: Array< Product >, previousProducts: Array< Product > ) {
@@ -74,6 +86,7 @@ export default function MapPlans( {
 	);
 	const { mapStripePlanToProduct, isPending: isSavingPlanMapping } =
 		useMapStripePlanToProductMutation();
+	const { setCompPlan, isPending: isSavingCompPlan } = useSetCompPlanMutation();
 	const newsletterTiersRef = useRef( newsletterTiers );
 	const stripePlanRef = useRef( '' );
 
@@ -153,7 +166,13 @@ export default function MapPlans( {
 		},
 	};
 
-	const isImportButtonDisabled = ! shouldEnableImporting( cardData ) || isSavingPlanMapping;
+	const isImportButtonDisabled =
+		! shouldEnableImporting( cardData ) || isSavingPlanMapping || isSavingCompPlan;
+
+	const compCount = parseInt( cardData?.meta?.comp_count || '0' );
+	const onCompPlanSelect = ( stripePlanId: string ) => {
+		setCompPlan( selectedSite.ID, engine, currentStep, stripePlanId );
+	};
 
 	const onProductSelect = ( stripePlanId: string, productId: string ) => {
 		mapStripePlanToProduct( selectedSite.ID, engine, currentStep, stripePlanId, productId );
@@ -202,6 +221,14 @@ export default function MapPlans( {
 						/>
 					);
 				} ) }
+				{ compCount > 0 && (
+					<MapCompPlan
+						compCount={ compCount }
+						plans={ cardData.plans }
+						selectedStripePlanId={ cardData.comp_stripe_plan_id ?? '' }
+						onCompPlanSelect={ onCompPlanSelect }
+					/>
+				) }
 			</div>
 
 			<StartImportButton

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-plans.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-plans.tsx
@@ -45,10 +45,21 @@ function shouldEnableImporting( cardData: any ) {
 		return false;
 	}
 
-	// If there are comped subscribers, require a comp plan selection.
+	// If there are comped subscribers, require a comp plan selection that still
+	// resolves to a known Stripe plan (guards against stale selections after a
+	// Stripe account reconnect or plan deletion).
 	const compCount = parseInt( cardData?.meta?.comp_count || '0' );
-	if ( compCount > 0 && ! cardData?.comp_stripe_plan_id ) {
-		return false;
+	if ( compCount > 0 ) {
+		const compStripePlanId = cardData?.comp_stripe_plan_id;
+		if ( ! compStripePlanId ) {
+			return false;
+		}
+		const compPlanExists = ( plans as any[] ).some(
+			( item: any ) => item?.product_id === compStripePlanId
+		);
+		if ( ! compPlanExists ) {
+			return false;
+		}
 	}
 
 	return true;
@@ -138,8 +149,7 @@ export default function MapPlans( {
 	const monthyPlan = cardData.plans.find( ( plan: any ) => plan.plan_interval === 'month' );
 	const annualPlan = cardData.plans.find( ( plan: any ) => plan.plan_interval === 'year' );
 
-	// TODO what if those plans are undefined?
-	if ( ! monthyPlan || ! annualPlan ) {
+	if ( ! cardData.plans.length ) {
 		return (
 			<NoPlans
 				cardData={ cardData }
@@ -151,16 +161,20 @@ export default function MapPlans( {
 		);
 	}
 
+	// Fall back to whichever interval is present so the add-tier modal still has sane defaults.
+	const referenceMonth = monthyPlan ?? annualPlan;
+	const referenceYear = annualPlan ?? monthyPlan;
+
 	const tierToAdd = {
 		via: '',
-		currency: monthyPlan.plan_currency,
-		price: formatCurrencyFloat( monthyPlan.plan_amount_decimal, monthyPlan.plan_currency ),
+		currency: referenceMonth.plan_currency,
+		price: formatCurrencyFloat( referenceMonth.plan_amount_decimal, referenceMonth.plan_currency ),
 		type: TYPE_TIER,
 		title: __( 'Newsletter tier' ),
 		interval: PLAN_MONTHLY_FREQUENCY,
 		annualProduct: {
-			currency: annualPlan.plan_currency,
-			price: formatCurrencyFloat( annualPlan.plan_amount_decimal, annualPlan.plan_currency ),
+			currency: referenceYear.plan_currency,
+			price: formatCurrencyFloat( referenceYear.plan_amount_decimal, referenceYear.plan_currency ),
 			type: TYPE_TIER,
 			interval: PLAN_YEARLY_FREQUENCY,
 		},

--- a/client/my-sites/importer/newsletter/summary/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/subscribers.tsx
@@ -34,12 +34,16 @@ export default function SubscriberSummary( { stepContent, status }: SubscriberSu
 		const subscribedCount = parseInt( stepContent.meta?.email_count || '0' );
 		const addedFree = parseInt( stepContent.meta?.subscribed_count || '0' );
 		const addedPaid = parseInt( stepContent.meta?.paid_subscribed_count || '0' );
+		const compCount = stepContent.meta?.comp_count ?? 0;
+		const addedComp = parseInt( stepContent.meta?.comp_subscribed_count || '0' );
 		const existingTotal =
 			parseInt( stepContent.meta?.already_subscribed_count || '0' ) +
-			parseInt( stepContent.meta?.paid_already_subscribed_count || '0' );
+			parseInt( stepContent.meta?.paid_already_subscribed_count || '0' ) +
+			parseInt( stepContent.meta?.comp_already_subscribed_count || '0' );
 		const failedTotal =
 			parseInt( stepContent.meta?.failed_subscribed_count || '0' ) +
-			parseInt( stepContent.meta?.paid_failed_subscribed_count || '0' );
+			parseInt( stepContent.meta?.paid_failed_subscribed_count || '0' ) +
+			parseInt( stepContent.meta?.comp_failed_subscribed_count || '0' );
 
 		return (
 			<div className="summary__content-stats">
@@ -52,6 +56,9 @@ export default function SubscriberSummary( { stepContent, status }: SubscriberSu
 				) }
 				{ addedFree > 0 && <SummaryStat count={ addedFree } label={ __( 'Free Subscribers' ) } /> }
 				{ addedPaid > 0 && <SummaryStat count={ addedPaid } label={ __( 'Paid Subscribers' ) } /> }
+				{ compCount > 0 && (
+					<SummaryStat count={ addedComp } label={ __( 'Comped Subscribers' ) } />
+				) }
 				{ existingTotal > 0 && (
 					<SummaryStat count={ existingTotal } label={ __( 'Skipped (duplicate)' ) } />
 				) }


### PR DESCRIPTION
Fixes NL-509
Fixes NL-581

## Proposed Changes

* Add a "Comped subscribers" row to the paid newsletter map-plans step, rendered when `meta.comp_count > 0` is present in the state response.
* Let users pick which Stripe plan comped subscribers should be granted complimentary access to, persisted as `comp_stripe_plan_id` via a new `set-comp-plan` mutation.
* Require a comp plan selection before enabling the Start Import button when comps are present, and guard against stale selections if the persisted plan id no longer resolves to a known Stripe plan (e.g. after a Stripe reconnect).
* Show a "Comped Subscribers" line in the summary step, sourced from the new `comp_subscribed_count` / `comp_already_subscribed_count` / `comp_failed_subscribed_count` meta fields.
* Loosen the `NoPlans` gate in `map-plans.tsx` (NL-581): previously required *both* a monthly *and* an annual Stripe plan to proceed, which blocked publishers with only one interval. Now only an empty `plans` array falls through to `NoPlans`, and the add-tier modal uses whichever interval is present as the reference. This is needed by the comps feature too — single-interval publishers with comped subscribers would otherwise never reach the comps row.

<img width="852" height="727" alt="Screenshot 2026-04-07 at 9 04 32 AM" src="https://github.com/user-attachments/assets/9d8bf01c-7ddf-4564-a725-d18ba27f7a53" />

<img width="805" height="761" alt="Screenshot 2026-04-07 at 10 50 19 AM" src="https://github.com/user-attachments/assets/1c58f0cb-0d9d-41bd-acaa-69678c479062" />


## Why are these changes being made?

Publishers migrating a newsletter with comped subscribers previously lost those subscribers' paid-tier access — they were imported as free subscribers. This PR lets the publisher choose which Stripe plan the comps should land on, and the backend grants matching complimentary subscriptions during the same import job. Pairs with the backend PR in wpcom.

Separately (NL-581), publishers with a single-interval Stripe account (monthly-only or annual-only) were blocked at the paid subscribers step with a "We couldn't find any plans in your connected Stripe account" warning even though plans existed. The gate has been loosened to only fire when zero plans are present.

## Testing Instructions

**Comped subscriber import:**

* Create a new site.
* Start a newsletter import from Tools > Import or the dashboard.
* Proceed to the Subscribers step and import a csv with comped subscribers.
* Connect Stripe.
* After Stripe is connected, switch back to the version of Calypso with these changes (Live or local).
* Select a plan for comps and click to import.
* Run the import and verify the Summary step shows a "Comped Subscribers" line with the correct granted count.
* Check that your comps were correctly imported.

**Single-interval Stripe account (NL-581):**

* Connect a Stripe account that has only a monthly plan (or only an annual plan).
* Proceed to the paid subscribers step and verify the mapping UI renders instead of the "no plans found" warning.
* Verify the add-tier modal opens with sane defaults derived from the available interval.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
