### PR TITLE
Dashboard: Keep Help Center mounted after first open

### DIFF
--- a/client/dashboard/app/interim-omnibar/omnibar-help-center.tsx
+++ b/client/dashboard/app/interim-omnibar/omnibar-help-center.tsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { Suspense, lazy, useCallback, useRef } from 'react';
+import { Suspense, lazy, useCallback, useState } from 'react';
 import { useAuth } from '../auth';
 import { useHelpCenter } from '../help-center';
 
@@ -18,18 +18,20 @@ const AsyncHelpCenterApp = lazy( () => import( '../help-center/help-center-app' 
 export default function OmnibarHelpCenter() {
 	const { user } = useAuth();
 	const { isShown, setShowHelpCenter } = useHelpCenter();
-	const hasBeenShownRef = useRef( false );
+	const [ hasBeenShown, setHasBeenShown ] = useState( false );
 
 	const handleClose = useCallback( () => {
 		setShowHelpCenter( false, undefined, true );
 	}, [ setShowHelpCenter ] );
 
-	if ( isShown ) {
-		hasBeenShownRef.current = true;
+	// Latch to true the first time the panel is shown. React will re-render
+	// immediately and discard this render's output.
+	if ( isShown && ! hasBeenShown ) {
+		setHasBeenShown( true );
 	}
 
 	// Defer the lazy chunk download until the first time the panel is opened.
-	if ( ! hasBeenShownRef.current ) {
+	if ( ! hasBeenShown ) {
 		return null;
 	}
 

--- a/client/dashboard/app/interim-omnibar/omnibar-help-center.tsx
+++ b/client/dashboard/app/interim-omnibar/omnibar-help-center.tsx
@@ -12,8 +12,7 @@ const AsyncHelpCenterApp = lazy( () => import( '../help-center/help-center-app' 
  * Once the panel has been opened for the first time, the inner `HelpCenter`
  * component is kept mounted and manages its own visibility via the help center
  * store. Unmounting it on close would tear down the Zendesk Smooch iframe
- * mid-request and surface "TypeError: Failed to fetch" in the console
- * (see DOTMSD-1197).
+ * mid-request and surface "TypeError: Failed to fetch" in the console.
  */
 export default function OmnibarHelpCenter() {
 	const { user } = useAuth();

--- a/client/dashboard/app/interim-omnibar/omnibar-help-center.tsx
+++ b/client/dashboard/app/interim-omnibar/omnibar-help-center.tsx
@@ -12,7 +12,7 @@ const AsyncHelpCenterApp = lazy( () => import( '../help-center/help-center-app' 
  * Once the panel has been opened for the first time, the inner `HelpCenter`
  * component is kept mounted and manages its own visibility via the help center
  * store. Unmounting it on close would tear down the Zendesk Smooch iframe
- * mid-request and surface "TypeError: Failed to fetch" in the console.
+ * mid-request and surface errors in the console.
  */
 export default function OmnibarHelpCenter() {
 	const { user } = useAuth();

--- a/client/dashboard/app/interim-omnibar/omnibar-help-center.tsx
+++ b/client/dashboard/app/interim-omnibar/omnibar-help-center.tsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { Suspense, lazy, useCallback } from 'react';
+import { Suspense, lazy, useCallback, useRef } from 'react';
 import { useAuth } from '../auth';
 import { useHelpCenter } from '../help-center';
 
@@ -8,16 +8,28 @@ const AsyncHelpCenterApp = lazy( () => import( '../help-center/help-center-app' 
 /**
  * Renders the floating Help Center panel when the omnibar is enabled.
  * The masterbar's help button handles toggling via the shared help center store.
+ *
+ * Once the panel has been opened for the first time, the inner `HelpCenter`
+ * component is kept mounted and manages its own visibility via the help center
+ * store. Unmounting it on close would tear down the Zendesk Smooch iframe
+ * mid-request and surface "TypeError: Failed to fetch" in the console
+ * (see DOTMSD-1197).
  */
 export default function OmnibarHelpCenter() {
 	const { user } = useAuth();
 	const { isShown, setShowHelpCenter } = useHelpCenter();
+	const hasBeenShownRef = useRef( false );
 
 	const handleClose = useCallback( () => {
 		setShowHelpCenter( false, undefined, true );
 	}, [ setShowHelpCenter ] );
 
-	if ( ! isShown ) {
+	if ( isShown ) {
+		hasBeenShownRef.current = true;
+	}
+
+	// Defer the lazy chunk download until the first time the panel is opened.
+	if ( ! hasBeenShownRef.current ) {
 		return null;
 	}
 


### PR DESCRIPTION
Part of DOTMSD-1197

## Proposed Changes

* In `OmnibarHelpCenter`, track whether the panel has ever been opened and, after the first open, keep the inner `<HelpCenter />` mounted instead of conditionally rendering `null` when it's closed.
* The lazy `help-center-app` chunk is still deferred until the first open, so users who never click the help button pay no cost.

## Why are these changes being made?

Closing the Help Center in the dashboard (with the `dashboard/omnibar` flag on) produced Uncaught exceptions originating from Zendesk's `frame.x.x.x.min.js`.

Root cause: `OmnibarHelpCenter` returned `null` whenever `isHelpCenterShown` was false, which unmounted the entire `HelpCenter` subtree — including `HelpCenterSmooch`. Its cleanup calls `Smooch.destroy()`, which removes the Zendesk iframe from the DOM. Any fetch in flight inside that iframe (Smooch's internal init/poll calls) then rejects with `TypeError: Failed to fetch`, which Smooch's promise chain doesn't catch.

Classic Calypso doesn't hit this because `client/components/help-center/help-center-app.tsx` keeps `<HelpCenter />` mounted unconditionally and lets `HelpCenterContainer` toggle visibility via its own `isHelpCenterShown` selector. This change brings the omnibar in line with that pattern.


## Testing Instructions

1. Enable the `dashboard/omnibar` feature flag.
2. Navigate to your sites list in the dashboard.
3. Open the browser DevTools console.
4. Click the help center button to open the Help Center, then click it again to close it. Repeat a few times, also alternating with the notifications panel.
5. **Before this change:** an `Uncaught` exception was thrown.
6. **After this change:** no such error appears, and the Help Center still opens, closes, and toggles correctly.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?