### PR TITLE
Revert "Masterbar: async-load launch button to prevent Explat warnings"

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -62,6 +62,7 @@ import Item from './item';
 import Masterbar from './masterbar';
 import { AgentsManagerIcon } from './masterbar-agents-manager/agents-manager-icon';
 import { HelpCenterIcon } from './masterbar-help-center/help-center-icon';
+import { MasterbarLaunchButton } from './masterbar-launch-button';
 import Notifications from './masterbar-notifications/notifications-button';
 
 class MasterbarLoggedIn extends Component {
@@ -617,7 +618,7 @@ class MasterbarLoggedIn extends Component {
 			return null;
 		}
 
-		return <AsyncLoad require="./masterbar-launch-button" placeholder={ null } siteId={ siteId } />;
+		return <MasterbarLaunchButton siteId={ siteId } />;
 	}
 
 	renderProfileMenu() {

--- a/client/layout/masterbar/masterbar-launch-button.tsx
+++ b/client/layout/masterbar/masterbar-launch-button.tsx
@@ -14,7 +14,7 @@ import { launchSiteOrRedirectToLaunchSignupFlow } from 'calypso/state/sites/laun
 import { getSite } from 'calypso/state/sites/selectors';
 import Item from './item';
 
-const MasterbarLaunchButton = ( { siteId }: { siteId: number } ) => {
+export const MasterbarLaunchButton = ( { siteId }: { siteId: number } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const site = useSelector( ( state ) => getSite( state, siteId ) );
@@ -81,5 +81,3 @@ const MasterbarLaunchButton = ( { siteId }: { siteId: number } ) => {
 		</>
 	);
 };
-
-export default MasterbarLaunchButton;


### PR DESCRIPTION
Reverts Automattic/wp-calypso#109841

I don't think this is the right way to deal with SSR warnings coming from the masterbar launch button https://github.com/Automattic/wp-calypso/pull/109841#pullrequestreview-4065053888