### PR TITLE
Reader: Use updated fields from rest/v1.1/users endpoint

### DIFF
--- a/client/lib/user/user.d.ts
+++ b/client/lib/user/user.d.ts
@@ -9,9 +9,21 @@ export type UserData = User;
 export type UserProfileData = {
 	ID: number;
 	avatar_URL: string;
-	bio?: string;
+	first_name: string;
+	last_name: string;
+	description: string;
 	display_name: string;
-	primary_blog?: number;
-	profile_URL?: string;
+	profile_URL: string;
 	user_login: string;
+	primary_blog?: UserProfilePrimaryBlog | null;
+	recommended_blogs_count: number;
 };
+
+interface UserProfilePrimaryBlog {
+	ID: number;
+	feed_ID: number;
+	URL: string;
+	title: string;
+	description: string;
+	avatar_URL: string;
+}

--- a/client/lib/user/user.d.ts
+++ b/client/lib/user/user.d.ts
@@ -25,5 +25,5 @@ interface UserProfilePrimaryBlog {
 	URL: string;
 	title: string;
 	description: string;
-	avatar_URL: string;
+	avatar_URL: string | null;
 }

--- a/client/lib/user/user.d.ts
+++ b/client/lib/user/user.d.ts
@@ -16,7 +16,7 @@ export type UserProfileData = {
 	profile_URL: string;
 	user_login: string;
 	primary_blog?: UserProfilePrimaryBlog | null;
-	recommended_blogs_count: number;
+	recommended_blogs_count?: number;
 };
 
 interface UserProfilePrimaryBlog {

--- a/client/reader/user-profile/components/user-profile-header/index.tsx
+++ b/client/reader/user-profile/components/user-profile-header/index.tsx
@@ -29,7 +29,7 @@ const UserProfileHeader = ( { user, view }: UserProfileHeaderProps ): JSX.Elemen
 			const isOverflowing = bioElement.scrollHeight > bioElement.clientHeight;
 			setShowMoreToggle( isOverflowing );
 		}
-	}, [ user.bio ] );
+	}, [ user.description ] );
 
 	const handleShowMoreToggle = () => {
 		setIsExpanded( ! isExpanded );
@@ -90,7 +90,7 @@ const UserProfileHeader = ( { user, view }: UserProfileHeaderProps ): JSX.Elemen
 					</div>
 				</div>
 
-				{ user.bio && (
+				{ user.description && (
 					<AutoDirection>
 						<div className="user-profile-header__bio">
 							<p
@@ -100,7 +100,7 @@ const UserProfileHeader = ( { user, view }: UserProfileHeaderProps ): JSX.Elemen
 									'is-expanded': isExpanded,
 								} ) }
 							>
-								{ user.bio }
+								{ user.description }
 							</p>
 							{ showMoreToggle && (
 								<button

--- a/client/reader/user-profile/components/user-profile-header/test/index.tsx
+++ b/client/reader/user-profile/components/user-profile-header/test/index.tsx
@@ -33,10 +33,14 @@ describe( 'UserProfileHeader', () => {
 	const defaultUser: UserProfileData = {
 		ID: 123,
 		user_login: 'testuser',
+		first_name: 'First',
+		last_name: 'Last',
 		display_name: 'Test User',
 		avatar_URL: 'https://example.com/avatar.jpg',
 		profile_URL: 'https://wordpress.com/testuser',
-		bio: undefined,
+		description: 'This is a test user biography.',
+		primary_blog: null,
+		recommended_blogs_count: 0,
 	};
 
 	jest.mocked( useUserSitesQuery ).mockReturnValue( {
@@ -120,15 +124,15 @@ describe( 'UserProfileHeader', () => {
 	} );
 
 	test( 'should render bio section when user has a bio', () => {
-		const userWithBio = {
+		const userWithBio: UserProfileData = {
 			...defaultUser,
-			bio: 'This is my test biography that describes me as a test user.',
+			description: 'This is my test biography that describes me as a test user.',
 		};
 
 		render( <UserProfileHeader user={ userWithBio } view="posts" /> );
 
 		// Bio section should be present
-		const bioText = screen.getByText( userWithBio.bio );
+		const bioText = screen.getByText( userWithBio.description );
 		expect( bioText ).toBeVisible();
 	} );
 
@@ -144,9 +148,9 @@ describe( 'UserProfileHeader', () => {
 	} );
 
 	test( 'should not render Gravatar badge when user does not have profile_URL', () => {
-		const userWithoutGravatarProfile = {
+		const userWithoutGravatarProfile: UserProfileData = {
 			...defaultUser,
-			profile_URL: undefined,
+			profile_URL: '',
 		};
 
 		render( <UserProfileHeader user={ userWithoutGravatarProfile } view="posts" /> );
@@ -156,7 +160,7 @@ describe( 'UserProfileHeader', () => {
 
 	test( 'should show "Show more" button for long bio and expand on click', async () => {
 		const longBio = 'This is a very long biography that spans multiple lines. '.repeat( 10 ).trim();
-		const userWithLongBio = { ...defaultUser, bio: longBio };
+		const userWithLongBio: UserProfileData = { ...defaultUser, description: longBio };
 
 		const { rerender } = render( <UserProfileHeader user={ userWithLongBio } view="posts" /> );
 
@@ -169,7 +173,7 @@ describe( 'UserProfileHeader', () => {
 		Object.defineProperty( bioDesc, 'clientHeight', { value: 60, configurable: true } );
 		// Re-render with slightly different bio to trigger useLayoutEffect
 		rerender(
-			<UserProfileHeader user={ { ...userWithLongBio, bio: longBio + '.' } } view="posts" />
+			<UserProfileHeader user={ { ...userWithLongBio, description: longBio + '.' } } view="posts" />
 		);
 
 		const showMoreButton = screen.getByText( /show more/i );

--- a/client/reader/user-profile/test/index.tsx
+++ b/client/reader/user-profile/test/index.tsx
@@ -5,6 +5,7 @@
 import page from '@automattic/calypso-router';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { UserProfileData } from 'calypso/lib/user/user';
 import { UserProfile, UserProfileProps } from '../index';
 
 jest.mock( '@automattic/calypso-router', () => ( {
@@ -64,6 +65,16 @@ describe( 'UserProfile', () => {
 		isLoading: false,
 		view: 'posts',
 	};
+	const defaultUser: UserProfileData = {
+		ID: 123,
+		user_login: 'testuser',
+		display_name: 'Test User',
+		avatar_URL: 'https://example.com/avatar.jpg',
+		first_name: '',
+		last_name: '',
+		description: '',
+		profile_URL: '',
+	};
 
 	beforeEach( () => {
 		// Reset mock function calls between tests
@@ -78,31 +89,17 @@ describe( 'UserProfile', () => {
 	} );
 
 	test( 'should render user profile when user is available', () => {
-		const user = {
-			ID: 123,
-			user_login: 'testuser',
-			display_name: 'Test User',
-			avatar_URL: 'https://example.com/avatar.jpg',
-		};
-
-		render( <UserProfile { ...defaultProps } user={ user } /> );
+		render( <UserProfile { ...defaultProps } user={ defaultUser } /> );
 
 		expect( screen.getByTestId( 'user-profile-header' ) ).toBeInTheDocument();
 		expect( screen.getByTestId( 'user-posts' ) ).toBeInTheDocument();
 	} );
 
 	test( 'should render lists view when view is lists', () => {
-		const user = {
-			ID: 123,
-			user_login: 'testuser',
-			display_name: 'Test User',
-			avatar_URL: 'https://example.com/avatar.jpg',
-		};
-
 		render(
 			<UserProfile
 				{ ...defaultProps }
-				user={ user }
+				user={ defaultUser }
 				view="lists"
 				path="/reader/users/testuser/lists"
 			/>
@@ -113,17 +110,10 @@ describe( 'UserProfile', () => {
 	} );
 
 	test( 'should render recommended-blogs view when view is recommended-blogs', () => {
-		const user = {
-			ID: 123,
-			user_login: 'testuser',
-			display_name: 'Test User',
-			avatar_URL: 'https://example.com/avatar.jpg',
-		};
-
 		render(
 			<UserProfile
 				{ ...defaultProps }
-				user={ user }
+				user={ defaultUser }
 				view="recommended-blogs"
 				path="/reader/users/testuser/recommended-blogs"
 			/>
@@ -141,14 +131,7 @@ describe( 'UserProfile', () => {
 	} );
 
 	test( 'should redirect from user ID path to user login path when user is loaded', () => {
-		const user = {
-			ID: 123,
-			user_login: 'testuser',
-			display_name: 'Test User',
-			avatar_URL: 'https://example.com/avatar.jpg',
-		};
-
-		render( <UserProfile { ...defaultProps } user={ user } path="/reader/users/id/123" /> );
+		render( <UserProfile { ...defaultProps } user={ defaultUser } path="/reader/users/id/123" /> );
 
 		// Verify the redirect was called with the correct path
 		expect( page.replace ).toHaveBeenCalledWith( '/reader/users/testuser' );

--- a/client/reader/user-profile/views/sites/test/sites.test.tsx
+++ b/client/reader/user-profile/views/sites/test/sites.test.tsx
@@ -36,6 +36,10 @@ describe( 'UserSites', () => {
 		user_login: 'test_user',
 		display_name: 'Test User',
 		avatar_URL: 'https://example.com/avatar.jpg',
+		first_name: '',
+		last_name: '',
+		description: '',
+		profile_URL: '',
 	};
 
 	beforeEach( () => {

--- a/client/reader/user-profile/views/test/recommended-blogs.tsx
+++ b/client/reader/user-profile/views/test/recommended-blogs.tsx
@@ -45,9 +45,13 @@ describe( 'UserRecommendedBlogs', () => {
 
 	const defaultUser: UserProfileData = {
 		ID: 123,
-		user_login: 'testuser',
+		user_login: 'test_user',
 		display_name: 'Test User',
 		avatar_URL: 'https://example.com/avatar.jpg',
+		first_name: '',
+		last_name: '',
+		description: '',
+		profile_URL: '',
 	};
 
 	const mockDispatch = jest.fn();


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes: [READ-467](https://linear.app/a8c/issue/READ-467/reader-update-restv11users-endpoint-to-add-info-needed-for-hovercard)
Review this PR first: 210646-ghe-Automattic/wpcom

## Proposed Changes

- Using updated fields from `rest/v1.1/users` endpoint.
- A lot of change in tests due to new schema.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

On BE we have updated `/rest/v1.1/users` endpoint as following and now we need to make updates on FE.
1. Added fields `first_name, last_name, nice_name, recommended_blogs_count`
1. Updated `primary_blog` from `number` to `object` that returns `ID, feedID, URL, title, description, avatar_URL`
1. Updated `bio` to `description` as it matches with the BE name.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Checkout BE PR on sandbox.
- Go to any user profile page and verify you can view the profile description.
- View some gravatar hovercards and verify correct primary blog is being shown.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?