### PR TITLE
MSD: Use Modern color scheme for the interim omnibar

### DIFF
--- a/client/dashboard/app/interim-omnibar/style.scss
+++ b/client/dashboard/app/interim-omnibar/style.scss
@@ -5,15 +5,15 @@ body:has(#wpcom-omnibar) #wpcom {
 }
 
 #wpcom-omnibar {
-	--color-masterbar-background: #1d2327;
-	--color-masterbar-text: #f0f0f1;
-	--color-masterbar-icon: rgba(240, 246, 252, 0.6);
-	--color-masterbar-highlight: #72aee6;
-	--color-masterbar-border: #8c8f94;
-	--color-masterbar-item-hover-background: #2c3338;
-	--color-masterbar-item-active-background: #23282d;
-	--color-masterbar-unread-dot-background: var(--color-accent-20, #d54e21);
-	--color-masterbar-submenu-text: #c3c4c7;
+	--color-masterbar-background: #1e1e1e;
+	--color-masterbar-text: #fff;
+	--color-masterbar-icon: #f3f1f1;
+	--color-masterbar-highlight: #7b90ff;
+	--color-masterbar-border: #303030;
+	--color-masterbar-item-hover-background: #0c0c0c;
+	--color-masterbar-item-active-background: #0c0c0c;
+	--color-masterbar-unread-dot-background: var(--studio-wordpress-blue-20, #3858e9);
+	--color-masterbar-submenu-text: #bcbcbc;
 
 	button.masterbar__item {
 		background: transparent;


### PR DESCRIPTION
Fixes DOTMSD-1186

## Proposed Changes

This PR proposes to update the color scheme of the omnibar to Modern.

It's the default color for WP 7.0's wp-admin, including frontend. So for most single-site users, the color is now consistent.

I'd actually love for the omnibar to have distinct color scheme when rendered in MSD, but maybe that's for another story. For now, this change is better than the existing (wrong) color scheme.

The CSS colors are copied from https://github.com/Automattic/wp-calypso/blob/71c215e53ec809ed8919fc6258f1697cc81471d4/packages/calypso-color-schemes/src/shared/color-schemes/_modern.scss.

## Testing Instructions

Verify the omnibar is rendered with the Modern color scheme. You can check with your site's wp-admin using Modern color and verify no difference.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
