### PR TITLE
ExPlat: Downgrade SSR anon-id messages to info

### DIFF
--- a/client/lib/explat/internals/anon-id.ts
+++ b/client/lib/explat/internals/anon-id.ts
@@ -4,7 +4,7 @@ import {
 	getTracksAnonymousUserId,
 	getTracksLoadPromise,
 } from '@automattic/calypso-analytics';
-import { logError } from './log-error';
+import { logError, logInfo } from './log-error';
 
 // SSR safety: Fail TypeScript compilation if `window` is used without an explicit undefined check
 declare const window: undefined | ( Window & typeof globalThis );
@@ -42,7 +42,7 @@ const anonIdPollingIntervalMaxAttempts = 100; // 50 * 100 = 5000 = 5 seconds
  */
 export const initializeAnonId = async (): Promise< string | null > => {
 	if ( typeof window === 'undefined' ) {
-		logError( { message: 'Trying to initialize anonId outside of a browser context.' } );
+		logInfo( { message: 'Skipping anonId initialization outside of a browser context.' } );
 		return null;
 	}
 
@@ -85,7 +85,7 @@ export const initializeAnonId = async (): Promise< string | null > => {
  */
 export const getAnonId = async (): Promise< string | null > => {
 	if ( typeof window === 'undefined' ) {
-		logError( { message: 'Trying to getAnonId in non browser context.' } );
+		logInfo( { message: 'Skipping getAnonId in non-browser context.' } );
 		return null;
 	}
 

--- a/client/lib/explat/internals/log-error.ts
+++ b/client/lib/explat/internals/log-error.ts
@@ -54,3 +54,16 @@ export const logError = ( error: Record< string, string > & { message: string } 
 		onError( e );
 	}
 };
+
+/**
+ * Log an info message.
+ * Works in SSR.
+ */
+export const logInfo = ( info: { message: string } ): void => {
+	if ( typeof window === 'undefined' ) {
+		getLogger().info( `[ExPlat] ${ info.message }` );
+	} else {
+		// eslint-disable-next-line no-console
+		console.log( '[ExPlat] ', info.message );
+	}
+};

--- a/client/lib/explat/internals/test/anon-id.ts
+++ b/client/lib/explat/internals/test/anon-id.ts
@@ -1,9 +1,9 @@
 // @ts-nocheck - TODO: Fix TypeScript issues
 import * as AnonId from '../anon-id';
 
-const mockLogError = jest.fn();
+const mockLogInfo = jest.fn();
 jest.mock( '../log-error', () => ( {
-	logError: ( ...args ) => mockLogError( ...args ),
+	logInfo: ( ...args ) => mockLogInfo( ...args ),
 } ) );
 
 jest.mock( 'calypso/lib/wp' );
@@ -37,14 +37,14 @@ beforeEach( () => {
 } );
 
 describe( 'initializeAnonId', () => {
-	it( 'should return null and log error when run under SSR', async () => {
+	it( 'should return null and log info when run under SSR', async () => {
 		setSsrContext();
 		await expect( AnonId.initializeAnonId() ).resolves.toBe( null );
-		expect( mockLogError.mock.calls ).toMatchInlineSnapshot( `
+		expect( mockLogInfo.mock.calls ).toMatchInlineSnapshot( `
 		Array [
 		  Array [
 		    Object {
-		      "message": "Trying to initialize anonId outside of a browser context.",
+		      "message": "Skipping anonId initialization outside of a browser context.",
 		    },
 		  ],
 		]
@@ -144,14 +144,14 @@ describe( 'initializeAnonId', () => {
 } );
 
 describe( 'getAnonId', () => {
-	it( 'should return null and log in SSR', async () => {
+	it( 'should return null and log info in SSR', async () => {
 		setSsrContext();
 		expect( await AnonId.getAnonId() ).toBeNull();
-		expect( mockLogError.mock.calls ).toMatchInlineSnapshot( `
+		expect( mockLogInfo.mock.calls ).toMatchInlineSnapshot( `
 		Array [
 		  Array [
 		    Object {
-		      "message": "Trying to getAnonId in non browser context.",
+		      "message": "Skipping getAnonId in non-browser context.",
 		    },
 		  ],
 		]


### PR DESCRIPTION
## Proposed Changes

- Add a `logInfo` helper alongside `logError` in `client/lib/explat/internals/log-error.ts`.
- Use `logInfo` for the SSR-context guards in `initializeAnonId` and `getAnonId` so they no longer surface as `ERROR` entries in server logs.

## Why are these changes being made?

When `calypso/lib/explat` is imported on the server, the SSR guards in `anon-id.ts` were calling `logError`, producing noisy server log lines like:

```
ERROR calypso:
    message: Trying to initialize anonId outside of a browser context.
```

But skipping anonId on the server is expected behaviour: callers safely receive `null`, and the anonId is set up client-side once the component hydrates. Nothing bad happens, so logging at `ERROR` level was misleading and was adding noise to server logs. Downgrading to an info message keeps the breadcrumb without polluting error dashboards.

This is a follow-up to the reverted #109841, which tried to fix the symptom by async-loading the masterbar launch button — that approach risked introducing other SSR issues, so addressing it at the source in the explat code is the simpler fix.

## Testing Instructions

1. Load any logged-in Calypso page that imports explat code via SSR (e.g. one with the masterbar launch button).
2. Confirm the `ERROR calypso: Trying to initialize anonId...` log no longer appears in the server logs.
3. Confirm explat continues to work client-side (anonId initialises after hydration).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?