### PR TITLE
Image Studio: Fix block editor crash when AMP plugin is active

### DIFF
--- a/packages/image-studio/src/extensions/generate-button-extension.test.tsx
+++ b/packages/image-studio/src/extensions/generate-button-extension.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// eslint-disable-next-line import/order
+import React from 'react';
+
+// Webpack global injected at build time, used at render time by __().
+( globalThis as Record< string, unknown > ).__i18n_text_domain__ = 'default';
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	useBlockEditContext: jest.fn( () => ( { name: 'core/image' } ) ),
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	Button: ( { children }: { children: React.ReactNode } ) => <button>{ children }</button>,
+} ) );
+
+jest.mock( '@wordpress/compose', () => ( {
+	createHigherOrderComponent: ( fn: ( component: React.ComponentType ) => React.ComponentType ) =>
+		fn,
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	dispatch: jest.fn( () => ( { openImageStudio: jest.fn() } ) ),
+} ) );
+
+jest.mock( '@wordpress/element', () => ( {
+	...jest.requireActual( '@wordpress/element' ),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text: string ) => text,
+} ) );
+
+jest.mock( '../store', () => ( {
+	store: 'image-studio',
+	ImageStudioEntryPoint: { EditorBlock: 'editor-block' },
+} ) );
+
+jest.mock( '../types', () => ( {
+	ImageStudioMode: { Edit: 'edit' },
+} ) );
+
+jest.mock( '../utils/get-image-data', () => ( {} ) );
+
+jest.mock( '../utils/tracking', () => ( {
+	trackImageStudioOpened: jest.fn(),
+} ) );
+
+jest.mock( './utils', () => ( {
+	handleImageSelection: jest.fn(),
+} ) );
+
+// Must import after jest.mock() calls to receive the mocked dependencies.
+import { withImageStudioGenerateButton } from './generate-button-extension';
+
+describe( 'withImageStudioGenerateButton', () => {
+	it( 'should return a component compatible with class extends', () => {
+		const OriginalComponent = () => <div />;
+		const Wrapped = withImageStudioGenerateButton( OriginalComponent );
+
+		// This must not throw — AMP and similar plugins use `class extends`
+		// on the editor.MediaUpload filter result.
+		expect( () => {
+			class TestExtend extends ( Wrapped as any ) {}
+			return TestExtend;
+		} ).not.toThrow();
+	} );
+} );

--- a/packages/image-studio/src/extensions/generate-button-extension.tsx
+++ b/packages/image-studio/src/extensions/generate-button-extension.tsx
@@ -2,7 +2,7 @@ import { useBlockEditContext } from '@wordpress/block-editor';
 import { Button } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { dispatch } from '@wordpress/data';
-import { useCallback } from '@wordpress/element';
+import { Component, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { ImageStudioEntryPoint, store as imageStudioStore } from '../store';
 import { ImageStudioMode } from '../types';
@@ -25,7 +25,7 @@ export const withImageStudioGenerateButton = createHigherOrderComponent(
 			return allowedBlocks.includes( name );
 		};
 
-		const ImageStudioGenerateButton = ( props: any ) => {
+		const ImageStudioGenerateButtonInner = ( props: any ) => {
 			const { name } = useBlockEditContext();
 			const { render: originalRenderProp, ...rest } = props;
 			const { onSelect, multiple } = rest;
@@ -82,7 +82,14 @@ export const withImageStudioGenerateButton = createHigherOrderComponent(
 			return <OriginalComponent { ...rest } render={ render } />;
 		};
 
-		ImageStudioGenerateButton.displayName = 'ImageStudioGenerateButton';
+		// Class wrapper ensures compatibility with plugins that use
+		// `class extends` on the editor.MediaUpload filter result (e.g. AMP).
+		// Arrow functions have no [[Construct]], so `class extends arrowFn` throws.
+		class ImageStudioGenerateButton extends Component< any > {
+			render() {
+				return <ImageStudioGenerateButtonInner { ...this.props } />;
+			}
+		}
 
 		return ImageStudioGenerateButton;
 	},

--- a/packages/image-studio/src/extensions/image-toolbar-extension.test.tsx
+++ b/packages/image-studio/src/extensions/image-toolbar-extension.test.tsx
@@ -116,6 +116,17 @@ describe( 'withImageStudioToolbarButton', () => {
 		jest.clearAllMocks();
 	} );
 
+	it( 'should return a component compatible with class extends', () => {
+		const Wrapped = withImageStudioToolbarButton( BlockEdit );
+
+		// This must not throw — plugins like AMP use `class extends`
+		// on editor filter results.
+		expect( () => {
+			class TestExtend extends ( Wrapped as any ) {}
+			return TestExtend;
+		} ).not.toThrow();
+	} );
+
 	it( 'should always render BlockEdit regardless of button visibility', () => {
 		renderToolbar( { name: 'core/paragraph' } );
 		expect( screen.getByTestId( 'block-edit' ) ).toBeInTheDocument();

--- a/packages/image-studio/src/extensions/image-toolbar-extension.tsx
+++ b/packages/image-studio/src/extensions/image-toolbar-extension.tsx
@@ -3,7 +3,7 @@ import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
 import { dispatch, useSelect } from '@wordpress/data';
-import { useCallback } from '@wordpress/element';
+import { Component, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { ImageStudioEntryPoint, store as imageStudioStore } from '../store/index';
 import { type BlockEditProps, IMAGE_STUDIO_SUPPORTED_MIME_TYPES, ImageStudioMode } from '../types';
@@ -15,7 +15,7 @@ import { trackImageStudioOpened } from '../utils/tracking';
  */
 export const withImageStudioToolbarButton = createHigherOrderComponent(
 	( BlockEdit: React.ComponentType< BlockEditProps > ) => {
-		const ImageStudioToolbarButton = ( props: BlockEditProps ) => {
+		const ImageStudioToolbarButtonInner = ( props: BlockEditProps ) => {
 			const { openImageStudio } = dispatch( imageStudioStore );
 			const { attributes, setAttributes } = props;
 
@@ -133,7 +133,14 @@ export const withImageStudioToolbarButton = createHigherOrderComponent(
 			);
 		};
 
-		ImageStudioToolbarButton.displayName = 'ImageStudioToolbarButton';
+		// Class wrapper ensures compatibility with plugins that use
+		// `class extends` on editor filter results (e.g. AMP plugin).
+		// Arrow functions have no [[Construct]], so `class extends arrowFn` throws.
+		class ImageStudioToolbarButton extends Component< BlockEditProps > {
+			render() {
+				return <ImageStudioToolbarButtonInner { ...this.props } />;
+			}
+		}
 
 		return ImageStudioToolbarButton;
 	},


### PR DESCRIPTION
## Proposed Changes

- Wrap Image Studio's `editor.MediaUpload` and `editor.BlockEdit` filter HOCs in class component shells instead of returning arrow functions
- Add regression tests verifying the returned components are compatible with `class extends`

## Why are these changes being made?

The AMP plugin's `amp-block-editor.js` hooks into editor components using `class extends` to wrap them. Image Studio's HOCs (`withImageStudioGenerateButton` and `withImageStudioToolbarButton`) return arrow function components from the filter. Arrow functions cannot be used as a base class — they have no `prototype` and no `[[Construct]]` internal method. When AMP attempts `class extends <arrow function>`, it throws an unrecoverable `TypeError` that crashes React's rendering tree, making the editor completely unusable:

```
TypeError: Class extends value l=>{let{name:c}=(0,o.useBlockEditContext)(),...}
is not a constructor or null
```

The fix wraps each inner functional component (which uses hooks) in a thin class component shell. This preserves all existing behavior while making the HOC output a valid class that can be extended via `class extends`.

## Testing Instructions

1. On any WordPress.com Atomic site, install and activate the **AMP** plugin
2. Open any post or page in the block editor
3. **Before fix**: All blocks show "This block has encountered an error and cannot be previewed"; browser console shows `TypeError: Class extends value ... is not a constructor or null`
4. As an Automattician, go to your sandbox and use the `am` plugin installer to load this branch. Route requests to `widgets.wp.com` to your sandbox.
5. Repeat steps 1 & 2
6. **After fix**: Editor loads normally, all blocks render correctly
7. Verify Image Studio features still work:
   - Insert an Image block → the "Generate Image" button appears in the placeholder
   - Select an existing Image block → the "Edit with AI" toolbar button appears

### Automated tests

```bash
yarn jest packages/image-studio/src/extensions/ --no-coverage
```

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)