### PR TITLE
MSD: Implement logout in interim omnibar

### DIFF
--- a/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
+++ b/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
@@ -5,8 +5,8 @@ import { useEffect, useMemo } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { MasterbarLoggedIn } from 'calypso/layout/masterbar/logged-in';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { getLogoutUrl } from 'calypso/lib/user/shared-utils';
 import { getSiteDisplayName } from '../../utils/site-name';
+import { logout } from '../auth';
 import { omnibarEvents } from './click-handlers';
 import type { User, Site } from '@automattic/api-core';
 
@@ -137,8 +137,7 @@ export function InterimOmnibar( {
 					requestAdminMenu={ noop }
 					redirectToLogout={ () => {
 						if ( userProp ) {
-							const logoutUrl = getLogoutUrl( userProp );
-							window.location.href = logoutUrl;
+							logout( userProp );
 						}
 					} }
 					launchSiteOrRedirectToLaunchSignupFlow={ noop }

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -22,7 +22,6 @@
 	"wpcom_login_url": "https://wordpress.com/log-in",
 	"logout_url": "https://|subdomain|wordpress.com",
 	"features": {
-		"always_use_logout_url": true,
 		"calypso/ai-site-builder-flow": true,
 		"cancel-flow/solutions-cards-upsell": false,
 		"ciab/allow-domain-features": true,

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -10,7 +10,6 @@
 		"my.woo.localhost": {
 			"oauth_client_id": 134404,
 			"wpcom_login_url": false,
-			"logout_url": false,
 			"features": { "oauth": true }
 		}
 	},
@@ -20,7 +19,6 @@
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
 	"wpcom_url": "http://calypso.localhost:3000",
 	"wpcom_login_url": "https://wordpress.com/log-in",
-	"logout_url": "https://|subdomain|wordpress.com",
 	"features": {
 		"calypso/ai-site-builder-flow": true,
 		"cancel-flow/solutions-cards-upsell": false,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -10,7 +10,6 @@
 		"my.woo.ai": {
 			"oauth_client_id": 134405,
 			"wpcom_login_url": false,
-			"logout_url": false,
 			"features": { "oauth": true, "wpcom-user-bootstrap": false }
 		}
 	},

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -10,7 +10,6 @@
 		"my.woo.ai": {
 			"oauth_client_id": 134405,
 			"wpcom_login_url": false,
-			"logout_url": false,
 			"features": { "oauth": true, "wpcom-user-bootstrap": false }
 		}
 	},

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -10,7 +10,6 @@
 		"my.woo.ai": {
 			"oauth_client_id": 134405,
 			"wpcom_login_url": false,
-			"logout_url": false,
 			"features": { "oauth": true, "wpcom-user-bootstrap": false }
 		}
 	},


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTMSD-1190

## Proposed Changes

<img width="471" height="220" alt="image" src="https://github.com/user-attachments/assets/eddadc0a-389a-4caf-8b1c-c5c56f8987ff" />


This PR fixes the interim omnibar logout mechanism to use dashboard's `logout()` method.


## Testing Instructions

1. Load the dashboard with `dashboard/omnibar` flag set to true.
2. Hover the `Howdy, <username>` and click Log Out.
3. Verify you get logged out correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
