### PR TITLE
Agents Manager: emit ready event when actions API is populated

### DIFF
--- a/packages/agents-manager/src/global.d.ts
+++ b/packages/agents-manager/src/global.d.ts
@@ -60,6 +60,12 @@ interface AgentsManagerActions {
 	isCompactMode?: boolean;
 	isChatEnabled?: boolean;
 	desktopMediaQuery?: string;
+	/**
+	 * Set to `true` once the actions API is fully populated and safe to call.
+	 * Hosts that load after Agents Manager can check this flag synchronously
+	 * instead of waiting for the `agents-manager-ready` event.
+	 */
+	isReady?: boolean;
 }
 
 /**

--- a/packages/agents-manager/src/hooks/__tests__/use-setup-custom-actions.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-setup-custom-actions.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import useSetupCustomActions from '../use-setup-custom-actions';
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn( () => ( {
+		hasLoaded: true,
+		isOpen: false,
+		isDocked: false,
+		floatingPosition: '',
+	} ) ),
+	useDispatch: jest.fn( () => ( {
+		setIsOpen: jest.fn(),
+		setIsDocked: jest.fn(),
+	} ) ),
+} ) );
+
+jest.mock( 'react-router-dom', () => ( {
+	useNavigate: jest.fn( () => jest.fn() ),
+} ) );
+
+jest.mock( '../../contexts', () => ( {
+	useAgentsManagerContext: jest.fn( () => ( {
+		getActiveSessionId: jest.fn( () => 'session-123' ),
+	} ) ),
+} ) );
+
+jest.mock( '../../stores', () => ( {
+	AGENTS_MANAGER_STORE: 'agents-manager-store',
+} ) );
+
+const baseProps = {
+	dock: jest.fn(),
+	undock: jest.fn(),
+	openSidebar: jest.fn(),
+	closeSidebar: jest.fn(),
+	canDock: true,
+	setIsCompactMode: jest.fn(),
+	setShouldRenderChat: jest.fn(),
+	setDesktopMediaQuery: jest.fn(),
+};
+
+describe( 'useSetupCustomActions — ready signal', () => {
+	beforeEach( () => {
+		delete window.__agentsManagerActions;
+	} );
+
+	it( 'sets isReady on the global after mount', () => {
+		renderHook( () => useSetupCustomActions( baseProps ) );
+
+		expect( window.__agentsManagerActions?.isReady ).toBe( true );
+	} );
+
+	it( 'dispatches agents-manager-ready event after mount', () => {
+		const listener = jest.fn();
+		window.addEventListener( 'agents-manager-ready', listener );
+
+		renderHook( () => useSetupCustomActions( baseProps ) );
+
+		expect( listener ).toHaveBeenCalledTimes( 1 );
+
+		window.removeEventListener( 'agents-manager-ready', listener );
+	} );
+
+	it( 'fires the ready event only once across re-renders', () => {
+		const listener = jest.fn();
+		window.addEventListener( 'agents-manager-ready', listener );
+
+		const { rerender } = renderHook( () => useSetupCustomActions( baseProps ) );
+		rerender();
+		rerender();
+
+		expect( listener ).toHaveBeenCalledTimes( 1 );
+
+		window.removeEventListener( 'agents-manager-ready', listener );
+	} );
+
+	it( 'populates the actions API before firing the ready event', () => {
+		let snapshot: AgentsManagerActions | undefined;
+		window.addEventListener( 'agents-manager-ready', () => {
+			snapshot = window.__agentsManagerActions;
+		} );
+
+		renderHook( () => useSetupCustomActions( baseProps ) );
+
+		expect( snapshot?.setChatOpen ).toBeInstanceOf( Function );
+		expect( snapshot?.setChatDocked ).toBeInstanceOf( Function );
+		expect( snapshot?.isReady ).toBe( true );
+	} );
+} );

--- a/packages/agents-manager/src/hooks/use-setup-custom-actions/README.md
+++ b/packages/agents-manager/src/hooks/use-setup-custom-actions/README.md
@@ -18,6 +18,25 @@ Once the hook is mounted, `window.__agentsManagerActions` provides:
 | `setChatCompactMode`       | `(isCompact: boolean) => void`                          | Toggles compact mode (undocked only).                                                            |
 | `setChatDesktopMediaQuery` | `(query: string) => void`                               | Sets the media query used to determine whether the chat can dock into the sidebar.               |
 | `chatNavigate`             | `NavigateFunction`                                      | The `react-router-dom` navigate function. Accepts a path string with options or a numeric delta. |
+| `isReady`                  | `boolean`                                               | `true` once the actions API is fully populated and safe to call.                                 |
+
+## Ready signal
+
+Agents Manager dispatches a `agents-manager-ready` event on `window` once the actions API is fully populated. Hosts that need to invoke actions on initial load (e.g. `setChatOpen( true )`) should listen for this event instead of polling.
+
+For hosts that may load **after** Agents Manager has already mounted, check `window.__agentsManagerActions?.isReady` synchronously before subscribing — the event has already fired and won't fire again.
+
+```js
+function openChat() {
+	window.__agentsManagerActions?.setChatOpen( true );
+}
+
+if ( window.__agentsManagerActions?.isReady ) {
+	openChat();
+} else {
+	window.addEventListener( 'agents-manager-ready', openChat, { once: true } );
+}
+```
 
 ### Initial values
 

--- a/packages/agents-manager/src/hooks/use-setup-custom-actions/index.ts
+++ b/packages/agents-manager/src/hooks/use-setup-custom-actions/index.ts
@@ -34,6 +34,7 @@ export default function useSetupCustomActions( {
 	const { getActiveSessionId } = useAgentsManagerContext();
 	const navigate = useNavigate();
 	const resolveRef = useRef< ( ( state: AgentsManagerChatState ) => void ) | null >( null );
+	const hasFiredReadyRef = useRef( false );
 
 	const setChatOpen = useCallback(
 		( shouldOpen: boolean ) => {
@@ -137,7 +138,16 @@ export default function useSetupCustomActions( {
 			setChatCompactMode,
 			setChatDesktopMediaQuery,
 			chatNavigate: navigate,
+			isReady: true,
 		};
+
+		// Fire the ready event exactly once per mount, after the global has
+		// been fully populated. Hosts (e.g. CIAB) listen for this to safely
+		// invoke actions like `setChatOpen` without polling.
+		if ( ! hasFiredReadyRef.current ) {
+			hasFiredReadyRef.current = true;
+			window.dispatchEvent( new CustomEvent( 'agents-manager-ready' ) );
+		}
 
 		return () => {
 			delete window.__agentsManagerActions;


### PR DESCRIPTION
## Summary

Fires a `agents-manager-ready` `CustomEvent` on `window` once `useSetupCustomActions` has populated `window.__agentsManagerActions`. Also adds an `isReady` flag on the actions object so hosts loading after Agents Manager can check synchronously.

This gives host apps (CIAB, future integrations) a clean signal to invoke actions like `setChatOpen( true )` without polling for the global to appear.

Closes AI-926.

## Why

Today, hosts that want to call `window.__agentsManagerActions.setChatOpen(true)` on initial page load have to poll because they don't know when the global is populated. CIAB onboarding currently uses `setInterval` with up to 10 seconds of retries, and there are reports of inconsistent behavior where the chat fails to open on first visit (LIN ref WOOAI-437).

## Implementation

- `useSetupCustomActions` now sets `isReady: true` on the actions object after wiring all setters.
- After the actions are populated, dispatches `new CustomEvent('agents-manager-ready')` on `window`.
- Uses a ref to ensure the event fires exactly once per mount, even though the effect re-runs on dependency changes.

## Test plan

- [x] New unit tests in `packages/agents-manager/src/hooks/__tests__/use-setup-custom-actions.test.ts` cover:
  - `isReady` is `true` after mount
  - `agents-manager-ready` event fires after mount
  - Event fires only once across re-renders
  - Actions API is fully populated before the event fires
- [x] All 96 existing tests in `packages/agents-manager` still pass.
- [ ] Sandbox: visit a CIAB site, paste in browser console:
  ```js
  window.addEventListener('agents-manager-ready', () => console.log('ready', window.__agentsManagerActions));
  ```
  Reload — should see the log with the populated actions object.

## Related

- Companion follow-ups (separate PRs):
  1. CIAB: replace polling in `woocommerce-next/routes/onboarding/stage.tsx` with the ready event listener
  2. Use the same `__agentsManagerActions` extension surface to add a host-injectable `trackingHandler` for telemetry routing in CIAB

🤖 Generated with [Claude Code](https://claude.com/claude-code)