### PR TITLE
A4A: Display agency name in sidebar header

### DIFF
--- a/client/a8c-for-agencies/components/sidebar/header/index.tsx
+++ b/client/a8c-for-agencies/components/sidebar/header/index.tsx
@@ -1,4 +1,7 @@
+import { HStack } from '@wordpress/components';
 import { SidebarV2Header as SidebarHeader } from 'calypso/layout/sidebar-v2';
+import { useSelector } from 'calypso/state';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import A4ALogo, { LOGO_COLOR_SECONDARY_ALT } from '../../a4a-logo';
 import ProfileDropdown from './profile-dropdown';
 
@@ -15,9 +18,14 @@ const AllSitesIcon = () => (
 );
 
 const Header = ( { withProfileDropdown }: Props ) => {
+	const agency = useSelector( getActiveAgency );
+
 	return (
 		<SidebarHeader className="a4a-sidebar__header">
-			<AllSitesIcon />
+			<HStack spacing={ 3 } alignment="center" justify="flex-start">
+				<AllSitesIcon />
+				{ agency?.name && <span className="a4a-sidebar__agency-name">{ agency.name }</span> }
+			</HStack>
 			{ withProfileDropdown && <ProfileDropdown /> }
 		</SidebarHeader>
 	);

--- a/client/a8c-for-agencies/components/sidebar/header/style.scss
+++ b/client/a8c-for-agencies/components/sidebar/header/style.scss
@@ -10,6 +10,16 @@ $profile-dropdown-menu-height: 250px;
 	display: flex;
 	justify-content: space-between;
 }
+
+.a4a-sidebar__agency-name {
+	color: var(--color-sidebar-text);
+	font-size: 0.875rem;
+	font-weight: 500;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	max-width: 140px;
+}
 .components-button .help-center__icon {
 	fill: var(--color-sidebar-text);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Part of A4A-1996

## Proposed Changes

* Display the agency name in the A4A sidebar header next to the logo
* Add styling for the agency name with text truncation for long names

## Why are these changes being made?

Agencies reported being unsure if they were logged in with the correct account. By displaying the agency name in the sidebar header, users can quickly identify which agency account they are viewing, improving the portal experience and reducing confusion.

## Testing Instructions

1. Log in to the A4A portal with an agency account
2. Verify the agency name appears in the sidebar header next to the A4A logo
3. If the agency name is long, verify it truncates with an ellipsis
4. Test on narrow viewports to ensure the layout remains correct

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [A4A-1996](https://linear.app/a8c/issue/A4A-1996/add-display-of-agency-name-to-portal)

<div><a href="https://cursor.com/agents/bc-fef7752e-3b9e-4f99-9302-455ddbaf78bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fef7752e-3b9e-4f99-9302-455ddbaf78bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

