### PR TITLE
MSD: read origin_site_id param and set as current omnibar site

### DIFF
--- a/client/dashboard/app/interim-omnibar/index.tsx
+++ b/client/dashboard/app/interim-omnibar/index.tsx
@@ -75,7 +75,7 @@ export default async function loadOmnibar( events: OmnibarEvents ) {
 	const originSiteId = Number(
 		new URLSearchParams( window.location.search ).get( 'origin_site_id' )
 	);
-	if ( originSiteId ) {
+	if ( originSiteId > 0 ) {
 		setCurrentOmnibarSite( originSiteId );
 		window.history.replaceState(
 			null,

--- a/client/dashboard/app/interim-omnibar/index.tsx
+++ b/client/dashboard/app/interim-omnibar/index.tsx
@@ -7,8 +7,8 @@ import {
 import { QueryObserver } from '@tanstack/react-query';
 import { removeQueryArgs } from '@wordpress/url';
 import { hydrateRoot } from 'react-dom/client';
-import { setCurrentOmnibarSite } from '../../utils/omnibar';
 import { AUTH_QUERY_KEY, initializeCurrentUser } from '../auth';
+import { getCurrentOmnibarSiteId, setCurrentOmnibarSiteId } from '../omnibar/current-site';
 import type { OmnibarEvents } from './click-handlers';
 import type { UserPreferences } from '@automattic/api-core';
 
@@ -76,7 +76,7 @@ export default async function loadOmnibar( events: OmnibarEvents ) {
 		new URLSearchParams( window.location.search ).get( 'origin_site_id' )
 	);
 	if ( originSiteId > 0 ) {
-		setCurrentOmnibarSite( originSiteId );
+		setCurrentOmnibarSiteId( originSiteId );
 		window.history.replaceState(
 			null,
 			'',
@@ -88,16 +88,14 @@ export default async function loadOmnibar( events: OmnibarEvents ) {
 		rawUserPreferencesQuery().queryKey
 	)?.recentSites;
 
-	// Render with the origin site, or the most recent site, or primary blog as fallback.
-	const initialSiteId = originSiteId || recentSites?.[ 0 ] || user.primary_blog;
+	// Render with the origin site as higher priority.
+	const initialSiteId = originSiteId || getCurrentOmnibarSiteId( user, recentSites );
 	renderWithSiteId( initialSiteId );
 
 	// Re-render whenever recentSites changes (e.g. user navigates to a different site).
-	let currentSiteId = initialSiteId;
 	new QueryObserver( queryClient, userPreferenceQuery( 'recentSites' ) ).subscribe( ( result ) => {
-		const siteId = result.data?.[ 0 ] || user.primary_blog;
-		if ( siteId !== currentSiteId ) {
-			currentSiteId = siteId;
+		const siteId = getCurrentOmnibarSiteId( user, result.data );
+		if ( siteId !== initialSiteId ) {
 			renderWithSiteId( siteId );
 		}
 	} );

--- a/client/dashboard/app/interim-omnibar/index.tsx
+++ b/client/dashboard/app/interim-omnibar/index.tsx
@@ -5,7 +5,9 @@ import {
 	userPreferenceQuery,
 } from '@automattic/api-queries';
 import { QueryObserver } from '@tanstack/react-query';
+import { removeQueryArgs } from '@wordpress/url';
 import { hydrateRoot } from 'react-dom/client';
+import { setCurrentOmnibarSite } from '../../utils/omnibar';
 import { AUTH_QUERY_KEY, initializeCurrentUser } from '../auth';
 import type { OmnibarEvents } from './click-handlers';
 import type { UserPreferences } from '@automattic/api-core';
@@ -56,7 +58,9 @@ export default async function loadOmnibar( events: OmnibarEvents ) {
 		);
 
 	async function renderWithSiteId( siteId: number | undefined ) {
-		const site = siteId ? await queryClient.ensureQueryData( siteByIdQuery( siteId ) ) : null;
+		const site = siteId
+			? await queryClient.ensureQueryData( siteByIdQuery( siteId ) ).catch( () => null )
+			: null;
 		root.render(
 			<InterimOmnibar
 				user={ user }
@@ -68,11 +72,24 @@ export default async function loadOmnibar( events: OmnibarEvents ) {
 		);
 	}
 
-	// Render with the initial recent site (or primary blog as fallback).
+	const originSiteId = Number(
+		new URLSearchParams( window.location.search ).get( 'origin_site_id' )
+	);
+	if ( originSiteId ) {
+		setCurrentOmnibarSite( originSiteId );
+		window.history.replaceState(
+			null,
+			'',
+			removeQueryArgs( window.location.pathname + window.location.search, 'origin_site_id' )
+		);
+	}
+
 	const recentSites = queryClient.getQueryData< UserPreferences >(
 		rawUserPreferencesQuery().queryKey
 	)?.recentSites;
-	const initialSiteId = recentSites?.[ 0 ] || user.primary_blog;
+
+	// Render with the origin site, or the most recent site, or primary blog as fallback.
+	const initialSiteId = originSiteId || recentSites?.[ 0 ] || user.primary_blog;
 	renderWithSiteId( initialSiteId );
 
 	// Re-render whenever recentSites changes (e.g. user navigates to a different site).

--- a/client/dashboard/app/omnibar/current-site.ts
+++ b/client/dashboard/app/omnibar/current-site.ts
@@ -4,12 +4,21 @@ import {
 	userPreferenceOptimisticMutation,
 } from '@automattic/api-queries';
 import { MutationObserver } from '@tanstack/react-query';
+import type { User } from '@automattic/api-core';
+
+/**
+ * Returns the current site ID to be displayed in the omnibar,
+ * based on the user's recent sites and primary blog.
+ */
+export function getCurrentOmnibarSiteId( user: User, recentSites?: number[] ) {
+	return recentSites?.[ 0 ] || user.primary_blog;
+}
 
 /**
  * Sets the current site to be displayed in the omnibar,
- * by pushing the site ID to the front of the recentSites user preferences.
+ * by pushing the site to the front of the user's recent sites preferences.
  */
-export async function setCurrentOmnibarSite( siteId: number ) {
+export async function setCurrentOmnibarSiteId( siteId: number ) {
 	const prefs = await queryClient.ensureQueryData( rawUserPreferencesQuery() );
 	const recentSites = prefs?.recentSites ?? [];
 	if ( siteId === recentSites[ 0 ] ) {

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -56,7 +56,6 @@ import {
 	canViewWordPressSettings,
 } from '../../sites/features';
 import { shouldLoadWpVersionNotice } from '../../sites/overview/wp-version-notice';
-import { setCurrentOmnibarSite } from '../../utils/omnibar';
 import {
 	getActivityLogHiddenGroups,
 	hasHostingFeature,
@@ -68,6 +67,7 @@ import { hasSiteTrialEnded } from '../../utils/site-trial';
 import { getSiteTypeFeatureSupports } from '../../utils/site-type-feature-support';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import { AUTH_QUERY_KEY } from '../auth';
+import { setCurrentOmnibarSiteId } from '../omnibar/current-site';
 import { rootRoute } from './root';
 import type { AppConfig } from '../context';
 import type { DifmWebsiteContentResponse, Site, User } from '@automattic/api-core';
@@ -173,7 +173,7 @@ export const siteRoute = createRoute( {
 	onEnter: async ( { loaderData } ) => {
 		const siteId = loaderData?.site?.ID;
 		if ( siteId ) {
-			setCurrentOmnibarSite( siteId );
+			setCurrentOmnibarSiteId( siteId );
 		}
 	},
 	errorComponent: lazyRouteComponent( () => import( '../../sites/site/error' ) ),

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -36,13 +36,11 @@ import {
 	siteSshAccessStatusQuery,
 	siteStaticFile404SettingQuery,
 	siteWordPressVersionQuery,
-	userPreferenceOptimisticMutation,
 	queryClient,
 	wpOrgCoreVersionQuery,
 } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
 import { isSupportSession } from '@automattic/calypso-support-session';
-import { MutationObserver } from '@tanstack/react-query';
 import {
 	createLazyRoute,
 	createRoute,
@@ -58,6 +56,7 @@ import {
 	canViewWordPressSettings,
 } from '../../sites/features';
 import { shouldLoadWpVersionNotice } from '../../sites/overview/wp-version-notice';
+import { setCurrentOmnibarSite } from '../../utils/omnibar';
 import {
 	getActivityLogHiddenGroups,
 	hasHostingFeature,
@@ -173,16 +172,8 @@ export const siteRoute = createRoute( {
 	},
 	onEnter: async ( { loaderData } ) => {
 		const siteId = loaderData?.site?.ID;
-		if ( ! siteId ) {
-			return;
-		}
-		const prefs = await queryClient.ensureQueryData( rawUserPreferencesQuery() );
-		const recentSites = prefs?.recentSites ?? [];
-		if ( siteId !== recentSites[ 0 ] ) {
-			const updated = [ ...new Set( [ siteId, ...recentSites ] ) ].slice( 0, 5 );
-			new MutationObserver( queryClient, userPreferenceOptimisticMutation( 'recentSites' ) ).mutate(
-				updated
-			);
+		if ( siteId ) {
+			setCurrentOmnibarSite( siteId );
 		}
 	},
 	errorComponent: lazyRouteComponent( () => import( '../../sites/site/error' ) ),

--- a/client/dashboard/utils/omnibar.ts
+++ b/client/dashboard/utils/omnibar.ts
@@ -1,0 +1,22 @@
+import {
+	queryClient,
+	rawUserPreferencesQuery,
+	userPreferenceOptimisticMutation,
+} from '@automattic/api-queries';
+import { MutationObserver } from '@tanstack/react-query';
+
+/**
+ * Sets the current site to be displayed in the omnibar,
+ * by pushing the site ID to the front of the recentSites user preferences.
+ */
+export async function setCurrentOmnibarSite( siteId: number ) {
+	const prefs = await queryClient.ensureQueryData( rawUserPreferencesQuery() );
+	const recentSites = prefs?.recentSites ?? [];
+	if ( siteId === recentSites[ 0 ] ) {
+		return;
+	}
+	const updated = [ ...new Set( [ siteId, ...recentSites ] ) ].slice( 0, 5 );
+	new MutationObserver( queryClient, userPreferenceOptimisticMutation( 'recentSites' ) ).mutate(
+		updated
+	);
+}


### PR DESCRIPTION
Fixes DOTMSD-1204

## Proposed Changes

The W logo from wp-admin's admin bar points to `wordpress.com/sites?origin_site_id=<blog_id>`. This is used to set the current site in the admin bar.

This PR applies the same logic to the interim omnibar.

## Testing Instructions

1. Check out this PR.
1. Visit the Site List while `dashboard/omnibar` flag is true.
2. Click any site.
3. Visit another site's wp-admin.
4. Right-click on the wp-admin W logo and select Copy Link.
5. Paste the URL to the Site List, but replace `https://wordpress.com` with `my.localhost:3000`. 
6. Verify that site is still the current site displayed in the interim omnibar.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
