### PR TITLE
MSD: wire up unseen notification dot icon logic in interim omnibar

### DIFF
--- a/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
+++ b/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
@@ -7,7 +7,7 @@ import { MasterbarLoggedIn } from 'calypso/layout/masterbar/logged-in';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { logout } from '../auth';
-import { omnibarEvents } from './omnibar-events';
+import { omnibarEvents, useOmnibarEvent } from './omnibar-events';
 import { createOmnibarStore } from './omnibar-store';
 import type { User, Site } from '@automattic/api-core';
 
@@ -55,6 +55,19 @@ export function InterimOmnibar( {
 		const container = document.getElementById( 'wpcom-omnibar' );
 		const bell = container?.querySelector< HTMLElement >( '.masterbar-notifications' ) ?? null;
 		omnibarEvents.notificationsAnchor.emit( bell );
+	} );
+
+	// Dispatch the user's unseen note count to the store so the unread marker appears.
+	useEffect( () => {
+		store.dispatch( {
+			type: 'NOTIFICATIONS_UNSEEN_COUNT_SET',
+			unseenCount: Number( !! user.has_unseen_notes ),
+		} );
+	}, [ store, user.has_unseen_notes ] );
+
+	// Also dispatch the emitted unseen note count from the notifications panel.
+	useOmnibarEvent( 'notificationsUnseenCount', ( unseenCount ) => {
+		store.dispatch( { type: 'NOTIFICATIONS_UNSEEN_COUNT_SET', unseenCount } );
 	} );
 
 	return (

--- a/client/dashboard/app/interim-omnibar/omnibar-events.ts
+++ b/client/dashboard/app/interim-omnibar/omnibar-events.ts
@@ -22,6 +22,7 @@ export const omnibarEvents = {
 	mobileMenu: createOmnibarEvent(),
 	notificationsAnchor: createOmnibarEvent< HTMLElement | null >(),
 	notifications: createOmnibarEvent(),
+	notificationsUnseenCount: createOmnibarEvent< number >(),
 	linkClick: createOmnibarEvent< { href: string; event: MouseEvent } >(),
 };
 

--- a/client/dashboard/app/interim-omnibar/omnibar-store.ts
+++ b/client/dashboard/app/interim-omnibar/omnibar-store.ts
@@ -5,14 +5,30 @@ type StoreType = Parameters< typeof ReduxProvider >[ 0 ][ 'store' ];
 // Fake Redux store so child components using connect() (e.g. Notifications) don't crash.
 // Intercepts specific actions so the dashboard can handle them.
 export function createOmnibarStore( onToggleNotifications?: () => void ): StoreType {
+	const listeners = new Set< () => void >();
+	let notificationsUnseenCount: number | undefined;
+
 	return {
-		getState: () => ( { ui: { section: false, isNotificationsOpen: false } } ),
-		dispatch: ( action: { type: string } ) => {
+		getState: () => ( {
+			ui: { section: false, isNotificationsOpen: false },
+			notificationsUnseenCount,
+		} ),
+		dispatch: ( action: { type: string; unseenCount?: number } ) => {
 			if ( action.type === 'NOTIFICATIONS_PANEL_TOGGLE' ) {
 				onToggleNotifications?.();
+
+				notificationsUnseenCount = 0;
+				listeners.forEach( ( listener ) => listener() );
+			}
+			if ( action.type === 'NOTIFICATIONS_UNSEEN_COUNT_SET' ) {
+				notificationsUnseenCount = action.unseenCount;
+				listeners.forEach( ( listener ) => listener() );
 			}
 			return action;
 		},
-		subscribe: () => () => {},
+		subscribe: ( listener: () => void ) => {
+			listeners.add( listener );
+			return () => listeners.delete( listener );
+		},
 	} as unknown as StoreType;
 }

--- a/client/dashboard/app/notifications/index.tsx
+++ b/client/dashboard/app/notifications/index.tsx
@@ -9,7 +9,7 @@ import { Suspense, lazy, useCallback, useEffect, useState } from 'react';
 import wpcom from 'calypso/lib/wp';
 import { useAuth } from '../auth';
 import { useHelpCenter } from '../help-center';
-import { useOmnibarEvent } from '../interim-omnibar/omnibar-events';
+import { omnibarEvents, useOmnibarEvent } from '../interim-omnibar/omnibar-events';
 import { useLocale } from '../locale';
 import './style.scss';
 
@@ -54,6 +54,7 @@ export default function Notifications( {
 		APP_RENDER_NOTES: [
 			( store: unknown, { newNoteCount }: { newNoteCount: number } ) => {
 				setHasUnseenNotifications( newNoteCount > 0 );
+				omnibarEvents.notificationsUnseenCount.emit( newNoteCount );
 			},
 		],
 		VIEW_SETTINGS: [


### PR DESCRIPTION
Fixes DOTMSD-1202

## Proposed Changes

This PR implements the unseen notification count logic in the fake interim omnibar's redux store.

## Testing Instructions

1. Checkout this PR.
2. With `dashboard/omnibar` flag on, visit Site List.
3. Trigger new notification, e.g. by commenting on a post by another user of yours.
4. Refresh the site list.
5. Verify you see the dot in the notification bell icon.
6. Click the bell icon.
7. Verify the dot is gone.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
