### PR TITLE
Subscribers: hide comp button in detail view when site has no paid plans

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -779,7 +779,9 @@ export default function SubscriberDataViews( {
 							subscriptionId={ getSubscriptionId( subscriberDetails ) }
 							onClose={ handleClose }
 							onUnsubscribe={ ( subscriber ) => handleUnsubscribe( [ subscriber ] ) }
-							onCompSubscription={ onCompSubscription }
+							onCompSubscription={
+								hasUncompedPlans( subscriberDetails ) ? onCompSubscription : undefined
+							}
 							onRemoveComp={ ( { planName, compId } ) =>
 								onRemoveComp( {
 									planName,

--- a/client/my-sites/subscribers/components/subscriber-details/test/subscriber-details.test.tsx
+++ b/client/my-sites/subscribers/components/subscriber-details/test/subscriber-details.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import uiReducer from 'calypso/state/ui/reducer';
+import { renderWithProvider } from '../../../../../test-helpers/testing-library';
+import SubscriberDetails from '../subscriber-details';
+
+jest.mock( '../../../hooks', () => ( {
+	useSubscriptionPlans: () => [
+		{ title: 'Free', plan: 'Free Plan', is_free: true, is_complimentary: false },
+	],
+} ) );
+
+const siteId = 1;
+
+const initialState = {
+	sites: { items: {} },
+	ui: { selectedSiteId: siteId },
+};
+
+const baseSubscriber = {
+	user_id: 123,
+	subscription_id: 456,
+	subscription_status: 'active',
+	email_address: 'test@example.com',
+	avatar: '',
+	display_name: 'Test User',
+	date_subscribed: '2026-01-01T00:00:00Z',
+	plans: [],
+};
+
+function renderDetails( props = {} ) {
+	return renderWithProvider(
+		<SubscriberDetails subscriber={ baseSubscriber } siteId={ siteId } { ...props } />,
+		{
+			initialState,
+			reducers: { ui: uiReducer },
+		}
+	);
+}
+
+describe( 'SubscriberDetails', () => {
+	it( 'shows the comp button when onCompSubscription is provided', () => {
+		renderDetails( { onCompSubscription: jest.fn() } );
+
+		expect( screen.getByRole( 'button', { name: 'Comp a subscription' } ) ).toBeVisible();
+	} );
+
+	it( 'hides the comp button when onCompSubscription is undefined', () => {
+		renderDetails();
+
+		expect(
+			screen.queryByRole( 'button', { name: 'Comp a subscription' } )
+		).not.toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
Fixes [NL-580](https://linear.app/a8c/issue/NL-580/hide-comp-button-in-subscriber-detail-view-when-site-has-no-paid-plans). Part of the [Complimentary Subscriptions](https://linear.app/a8c/project/complimentary-subscriptions-d7e366b3b98c) project.

## Proposed Changes

* Gate the "Comp a subscription" button in the subscriber detail view behind `hasUncompedPlans()`, matching the existing gating on the kebab menu action in the list view.

## Why are these changes being made?

The subscriber detail view passed `onCompSubscription` unconditionally, so the "Comp a subscription" button appeared for all sites — even those without paid newsletter plans. The kebab menu in the list view was already correctly gated. This aligns both code paths.

## Testing Instructions

1. Navigate to `/subscribers/{site-without-paid-plans}`, click View on a subscriber. The "Comp a subscription" button should **not** appear in the detail panel footer.
2. Navigate to `/subscribers/{site-with-paid-plans}`, click View on a subscriber. The button **should** appear.
3. On the site with paid plans, confirm the kebab menu "Comp a subscription" action still works as before.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?