### PR TITLE
Expand Linear Release path filters for Creators

### DIFF
--- a/.github/workflows/linear-release-creators.yml
+++ b/.github/workflows/linear-release-creators.yml
@@ -8,6 +8,7 @@ on:
       - 'client/reader/**'
       - 'client/blocks/reader-*/**'
       - 'client/blocks/conversation-*/**'
+      - 'client/blocks/conversations/**'
       - 'client/blocks/follow-button/**'
       - 'client/data/reader/**'
       - 'client/state/reader/**'
@@ -22,11 +23,11 @@ on:
       - 'client/my-sites/site-settings/settings-newsletter/**'
       - 'client/my-sites/importer/newsletter/**'
       - 'client/landing/stepper/declarative-flow/flows/newsletter/**'
+      - 'packages/data-stores/src/newsletter-categories/**'
       # Subscriptions
       - 'client/landing/subscriptions/**'
       - 'packages/subscriber/**'
       - 'packages/data-stores/src/subscriber/**'
-      - 'packages/data-stores/src/newsletter-categories/**'
 
 permissions:
   contents: read

--- a/.github/workflows/linear-release-creators.yml
+++ b/.github/workflows/linear-release-creators.yml
@@ -4,15 +4,30 @@ on:
   push:
     branches: [trunk]
     paths:
-      # Reader
+      # Reader - UI, state, data, utilities
       - 'client/reader/**'
       - 'client/blocks/reader-*/**'
-      # Newsletter
+      - 'client/blocks/conversation-*/**'
+      - 'client/blocks/follow-button/**'
+      - 'client/data/reader/**'
+      - 'client/state/reader/**'
+      - 'client/state/reader-ui/**'
+      - 'client/lib/reader/**'
+      - 'packages/data-stores/src/reader/**'
+      # Newsletter - settings, onboarding, import
       - 'client/data/newsletter-categories/**'
       - 'client/data/paid-newsletter/**'
       - 'client/mailing-lists/**'
       - 'client/my-sites/email/**'
       - 'client/my-sites/subscribers/**'
+      - 'client/my-sites/site-settings/settings-newsletter/**'
+      - 'client/my-sites/importer/newsletter/**'
+      - 'client/landing/stepper/declarative-flow/flows/newsletter/**'
+      # Subscriptions
+      - 'client/landing/subscriptions/**'
+      - 'packages/subscriber/**'
+      - 'packages/data-stores/src/subscriber/**'
+      - 'packages/data-stores/src/newsletter-categories/**'
 
 permissions:
   contents: read

--- a/.github/workflows/linear-release-creators.yml
+++ b/.github/workflows/linear-release-creators.yml
@@ -18,7 +18,6 @@ on:
       - 'client/data/newsletter-categories/**'
       - 'client/data/paid-newsletter/**'
       - 'client/mailing-lists/**'
-      - 'client/my-sites/email/**'
       - 'client/my-sites/subscribers/**'
       - 'client/my-sites/site-settings/settings-newsletter/**'
       - 'client/my-sites/importer/newsletter/**'


### PR DESCRIPTION
Part of #109467

## Proposed Changes

* Adds missing path filters to the Linear Release workflow so it triggers on all Creators-owned code:
  - **Reader**: state, data stores, lib, conversation/follow blocks
  - **Newsletter**: settings page, onboarding flow, importer
  - **Subscriptions**: landing page, subscriber package, data stores

## Why are these changes being made?

The initial workflow in #109467 only covered top-level Reader and Newsletter directories. Changes to Reader Redux state (`client/state/reader/`), the subscriptions landing page (`client/landing/subscriptions/`), newsletter settings (`client/my-sites/site-settings/settings-newsletter/`), and other Creators-owned paths were not triggering releases.

Intentionally excluded paths owned by other teams (stats, memberships/payments, Titan email, notification settings).

## Testing Instructions

* Merge a PR touching one of the newly added paths with a linked Linear issue. Verify it appears in the [Creators release pipeline](https://linear.app/a8c/pipeline/apps-metrics/releases).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>