### PR TITLE
Add server controlled plans page to Multi Site Dashboard

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -1545,6 +1545,14 @@ export const sitePlansRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteRoute,
 	path: 'plans',
+	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
+		if ( cause === 'preload' ) {
+			return;
+		}
+		if ( ! isEnabled( 'dashboard/plans' ) ) {
+			throw redirectAsNotAllowed( { to: siteRoute.fullPath, params: { siteSlug } } );
+		}
+	},
 	loader: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		await queryClient.ensureQueryData( sitePlansQuery( site.ID ) );

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -1547,10 +1547,7 @@ export const sitePlansRoute = createRoute( {
 	path: 'plans',
 	loader: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		await Promise.all( [
-			queryClient.ensureQueryData( sitePlansQuery( site.ID ) ),
-			queryClient.prefetchQuery( sitePurchasesQuery( site.ID ) ),
-		] );
+		await queryClient.ensureQueryData( sitePlansQuery( site.ID ) );
 	},
 } ).lazy( () =>
 	import( '../../sites/site-plans' ).then( ( d ) =>

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -23,7 +23,6 @@ import {
 	sitePHPVersionQuery,
 	siteCurrentPlanQuery,
 	sitePlansQuery,
-	plansQuery,
 	siteBySlugQuery,
 	siteByIdQuery,
 	siteCrontabsQuery,
@@ -1550,7 +1549,6 @@ export const sitePlansRoute = createRoute( {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		await Promise.all( [
 			queryClient.ensureQueryData( sitePlansQuery( site.ID ) ),
-			queryClient.prefetchQuery( plansQuery() ),
 			queryClient.prefetchQuery( sitePurchasesQuery( site.ID ) ),
 		] );
 	},

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -22,6 +22,8 @@ import {
 	siteMediaStorageQuery,
 	sitePHPVersionQuery,
 	siteCurrentPlanQuery,
+	sitePlansQuery,
+	plansQuery,
 	siteBySlugQuery,
 	siteByIdQuery,
 	siteCrontabsQuery,
@@ -1534,6 +1536,32 @@ export const siteSSHMigrationCompleteRoute = createRoute( {
 	)
 );
 
+export const sitePlansRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Plans' ),
+			},
+		],
+	} ),
+	getParentRoute: () => siteRoute,
+	path: 'plans',
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		await Promise.all( [
+			queryClient.ensureQueryData( sitePlansQuery( site.ID ) ),
+			queryClient.prefetchQuery( plansQuery() ),
+			queryClient.prefetchQuery( sitePurchasesQuery( site.ID ) ),
+		] );
+	},
+} ).lazy( () =>
+	import( '../../sites/site-plans' ).then( ( d ) =>
+		createLazyRoute( 'site-plans' )( {
+			component: d.default,
+		} )
+	)
+);
+
 export const createSitesRoutes = ( config: AppConfig ) => {
 	if ( ! config.supports.sites ) {
 		return [];
@@ -1569,6 +1597,7 @@ export const createSitesRoutes = ( config: AppConfig ) => {
 			siteScanHistoryRoute,
 		] ),
 		siteDomainsRoute,
+		sitePlansRoute,
 	];
 
 	const settingsRoutes: AnyRoute[] = [

--- a/client/dashboard/sites/overview/test/index.test.tsx
+++ b/client/dashboard/sites/overview/test/index.test.tsx
@@ -93,20 +93,22 @@ describe( '<SiteOverview>', () => {
 			.reply( 200, { max_storage_bytes: 1073741824, storage_used_bytes: 100000000 } );
 
 		nock( 'https://public-api.wordpress.com' )
-			.get( `/rest/v1.3/sites/${ site.ID }/plans` )
+			.get( `/rest/v1.4/sites/${ site.ID }/plans` )
 			.query( true )
 			.reply( 200, {
-				1: {
-					product_id: 1,
-					product_slug: 'business-bundle',
-					product_name_short: 'Business',
-					current_plan: true,
-					original_price: { amount: 0 },
-					raw_price: 0,
-					raw_price_integer: 0,
-					raw_discount: 0,
-					raw_discount_integer: 0,
-					cost_overrides: [],
+				plans: {
+					1: {
+						product_id: 1,
+						product_slug: 'business-bundle',
+						product_name_short: 'Business',
+						current_plan: true,
+						original_price: { amount: 0 },
+						raw_price: 0,
+						raw_price_integer: 0,
+						raw_discount: 0,
+						raw_discount_integer: 0,
+						cost_overrides: [],
+					},
 				},
 			} );
 

--- a/client/dashboard/sites/site-plans/index.tsx
+++ b/client/dashboard/sites/site-plans/index.tsx
@@ -609,20 +609,21 @@ export default function SitePlans() {
 	return (
 		<PageLayout
 			header={
-				<PageHeader
-					actions={
+				<div className="site-plans__header-wrap">
+					<PageHeader title={ pageContext?.page_title } />
+					{ pageContext?.header_message && (
+						<Text className="site-plans__subheader">{ pageContext.header_message }</Text>
+					) }
+					<div className="site-plans__interval-selector-wrap">
 						<BillingIntervalSelector
 							billingInterval={ billingInterval }
 							availableBillPeriods={ availableBillPeriods }
 							onChange={ setBillingInterval }
 						/>
-					}
-				/>
+					</div>
+				</div>
 			}
 		>
-			{ pageContext?.header_message && (
-				<Text className="site-plans__subheader">{ pageContext.header_message }</Text>
-			) }
 			<div
 				className="site-plans__grid"
 				style={ { '--plan-count': shownPlans.length } as React.CSSProperties }

--- a/client/dashboard/sites/site-plans/index.tsx
+++ b/client/dashboard/sites/site-plans/index.tsx
@@ -315,9 +315,16 @@ function PlanCard( {
 				</div>
 				<VStack spacing={ 4 }>
 					<VStack spacing={ 1 }>
-						<Text className="site-plans__plan-name" size={ 20 } weight={ 600 }>
-							{ sitePlan.plan_card_name ?? sitePlan.product_name }
-						</Text>
+						<div className="site-plans__plan-header">
+							<Text className="site-plans__plan-name" size={ 20 } weight={ 600 }>
+								{ sitePlan.plan_card_name ?? sitePlan.product_name }
+							</Text>
+							{ sitePlan.badges?.map( ( badge ) => (
+								<span key={ badge } className="site-plans__plan-badge">
+									{ badge }
+								</span>
+							) ) }
+						</div>
 						{ sitePlan.tagline && (
 							<Text className="site-plans__tagline" variant="muted">
 								{ sitePlan.tagline }

--- a/client/dashboard/sites/site-plans/index.tsx
+++ b/client/dashboard/sites/site-plans/index.tsx
@@ -361,7 +361,7 @@ function PlanCard( {
 						) ) }
 				</div>
 				<VStack spacing={ 4 }>
-					<VStack spacing={ 1 }>
+					<VStack spacing={ 1 } className="site-plans__plan-info">
 						<div className="site-plans__plan-header">
 							<Text className="site-plans__plan-name" size={ 20 } weight={ 600 }>
 								{ sitePlan.plan_card_name ?? sitePlan.product_name }

--- a/client/dashboard/sites/site-plans/index.tsx
+++ b/client/dashboard/sites/site-plans/index.tsx
@@ -333,7 +333,7 @@ function PlanCard( {
 					</VStack>
 
 					<VStack spacing={ 1 }>
-						{ ! isCurrentPlan && sitePlan.introductory_offer_formatted_price && (
+						{ sitePlan.introductory_offer_formatted_price && (
 							<span className="site-plans__special-offer-badge">{ __( 'Special Offer' ) }</span>
 						) }
 						<PlanPrice

--- a/client/dashboard/sites/site-plans/index.tsx
+++ b/client/dashboard/sites/site-plans/index.tsx
@@ -324,6 +324,7 @@ function PlanCard( {
 	tierRank,
 	currentTierRank,
 	redirectAfterPurchase,
+	totalPlanCount,
 }: {
 	site: Site;
 	sitePlan: SiteContextualPlan;
@@ -332,9 +333,17 @@ function PlanCard( {
 	tierRank: number;
 	currentTierRank: number;
 	redirectAfterPurchase: string;
+	totalPlanCount: number;
 } ) {
 	const isCurrentPlan =
 		sitePlan.current_plan === true || ( currentTierRank >= 0 && tierRank === currentTierRank );
+
+	// When displaying more than 2 plan cards side-by-side, the card width will
+	// be small enough that badges are unlikely to fit next to the plan title,
+	// causing them to wrap to the next line, which pushes the card layout off
+	// compared to its neighbors. To help prevent that, we move the badge to
+	// the top.
+	const showBadgesAtTop = totalPlanCount > 2;
 
 	return (
 		<Card className={ `site-plans__card${ isCurrentPlan ? ' site-plans__card--current' : '' }` }>
@@ -343,6 +352,13 @@ function PlanCard( {
 					{ isCurrentPlan && (
 						<span className="site-plans__current-badge">{ __( 'Your plan' ) }</span>
 					) }
+					{ showBadgesAtTop &&
+						! isCurrentPlan &&
+						sitePlan.badges?.map( ( badge ) => (
+							<span key={ badge } className="site-plans__plan-badge">
+								{ badge }
+							</span>
+						) ) }
 				</div>
 				<VStack spacing={ 4 }>
 					<VStack spacing={ 1 }>
@@ -350,11 +366,12 @@ function PlanCard( {
 							<Text className="site-plans__plan-name" size={ 20 } weight={ 600 }>
 								{ sitePlan.plan_card_name ?? sitePlan.product_name }
 							</Text>
-							{ sitePlan.badges?.map( ( badge ) => (
-								<span key={ badge } className="site-plans__plan-badge">
-									{ badge }
-								</span>
-							) ) }
+							{ ! showBadgesAtTop &&
+								sitePlan.badges?.map( ( badge ) => (
+									<span key={ badge } className="site-plans__plan-badge">
+										{ badge }
+									</span>
+								) ) }
 						</div>
 						{ sitePlan.tagline && (
 							<Text className="site-plans__tagline" variant="muted">
@@ -676,6 +693,7 @@ export default function SitePlans() {
 						tierRank={ ap.tierRank }
 						currentTierRank={ currentTierRank }
 						redirectAfterPurchase={ redirectAfterPurchase }
+						totalPlanCount={ shownPlans.length }
 					/>
 				) ) }
 			</div>

--- a/client/dashboard/sites/site-plans/index.tsx
+++ b/client/dashboard/sites/site-plans/index.tsx
@@ -1,0 +1,664 @@
+import { SubscriptionBillPeriod } from '@automattic/api-core';
+import { plansQuery, sitePlansQuery, siteBySlugQuery } from '@automattic/api-queries';
+import { formatCurrency, getCurrencyObject } from '@automattic/number-formatters';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import {
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+	Button,
+	Icon,
+	SelectControl,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { check, lineSolid } from '@wordpress/icons';
+import React, { Fragment, useState } from 'react';
+import { siteRoute } from '../../app/router/sites';
+import { Card, CardBody } from '../../components/card';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import { wpcomLink } from '../../utils/link';
+import type {
+	PlanProduct,
+	PlanProductComparisonGroup,
+	SiteContextualPlan,
+	Site,
+	SubscriptionBillPeriodValue,
+} from '@automattic/api-core';
+import './style.scss';
+
+function getBillingPeriodMonths( billPeriod: SubscriptionBillPeriodValue ): number {
+	if ( billPeriod === SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD ) {
+		return 1;
+	}
+	return Math.round( billPeriod / 365 ) * 12;
+}
+
+function getBillingPeriodLabel( billPeriod: SubscriptionBillPeriodValue ): string {
+	switch ( billPeriod ) {
+		case SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD:
+			return __( 'Monthly' );
+		case SubscriptionBillPeriod.PLAN_ANNUAL_PERIOD:
+			return __( 'Yearly' );
+		default: {
+			const years = Math.round( billPeriod / 365 );
+			if ( years <= 0 ) {
+				return String( billPeriod );
+			}
+			return sprintf(
+				/* translators: %d is the number of years, e.g. "2" */
+				__( '%d Years' ),
+				years
+			);
+		}
+	}
+}
+
+function PlanPrice( {
+	sitePlan,
+	billingInterval,
+	annualSitePlan,
+}: {
+	sitePlan: SiteContextualPlan;
+	billingInterval: SubscriptionBillPeriodValue;
+	annualSitePlan?: SiteContextualPlan;
+} ) {
+	const isMonthly = billingInterval === SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD;
+	const billingMonths = getBillingPeriodMonths( billingInterval );
+
+	if ( sitePlan.introductory_offer_formatted_price ) {
+		const introPriceObj = getCurrencyObject(
+			sitePlan.introductory_offer_raw_price ?? sitePlan.raw_price,
+			sitePlan.currency_code
+		);
+
+		const originalPrice = sitePlan.raw_price + sitePlan.raw_discount;
+		const regularPrice = isMonthly
+			? originalPrice
+			: Math.round( ( originalPrice / billingMonths ) * 100 ) / 100;
+		const regularPriceObj = getCurrencyObject( regularPrice, sitePlan.currency_code );
+
+		const intervalUnit = sitePlan.introductory_offer_interval_unit ?? 'month';
+		const intervalCount = sitePlan.introductory_offer_interval_count ?? 1;
+		let introPeriod: string;
+		if ( intervalUnit === 'year' ) {
+			introPeriod =
+				intervalCount === 1
+					? __( 'your first year' )
+					: sprintf(
+							/* translators: %d is the number of years, e.g. "3" */
+							__( 'your first %d years' ),
+							intervalCount
+					  );
+		} else {
+			introPeriod =
+				intervalCount === 1
+					? __( 'your first month' )
+					: sprintf(
+							/* translators: %d is the number of months, e.g. "3" */
+							__( 'your first %d months' ),
+							intervalCount
+					  );
+		}
+
+		const formattedOriginalPrice = formatCurrency( originalPrice, sitePlan.currency_code, {
+			stripZeros: true,
+		} );
+		let renewalNote: string;
+		if ( isMonthly ) {
+			renewalNote = sprintf(
+				/* translators: 1: intro period (e.g. "your first month"), 2: monthly price (e.g. "$49") */
+				__( 'for %1$s, then %2$s/month, excl. taxes' ),
+				introPeriod,
+				formattedOriginalPrice
+			);
+		} else if ( billingInterval === SubscriptionBillPeriod.PLAN_ANNUAL_PERIOD ) {
+			renewalNote = sprintf(
+				/* translators: 1: intro period (e.g. "your first month"), 2: annual price (e.g. "$588") */
+				__( 'for %1$s, then %2$s billed annually, excl. taxes' ),
+				introPeriod,
+				formattedOriginalPrice
+			);
+		} else {
+			const years = Math.round( billingInterval / 365 );
+			renewalNote = sprintf(
+				/* translators: 1: intro period (e.g. "your first month"), 2: price (e.g. "$588"), 3: number of years (e.g. "2") */
+				__( 'for %1$s, then %2$s billed every %3$d years, excl. taxes' ),
+				introPeriod,
+				formattedOriginalPrice,
+				years
+			);
+		}
+
+		return (
+			<VStack spacing={ 1 }>
+				<div className="site-plans__price-display">
+					{ introPriceObj.symbolPosition === 'before' && (
+						<sup className="site-plans__price-currency">{ introPriceObj.symbol }</sup>
+					) }
+					<span className="site-plans__price-number">
+						{ introPriceObj.integer }
+						{ introPriceObj.hasNonZeroFraction && introPriceObj.fraction }
+					</span>
+					{ introPriceObj.symbolPosition === 'after' && (
+						<sup className="site-plans__price-currency">{ introPriceObj.symbol }</sup>
+					) }
+					<div className="site-plans__price-original">
+						{ regularPriceObj.symbolPosition === 'before' && (
+							<sup className="site-plans__price-currency site-plans__price-currency--original">
+								{ regularPriceObj.symbol }
+							</sup>
+						) }
+						<span className="site-plans__price-number site-plans__price-number--original">
+							{ regularPriceObj.integer }
+							{ regularPriceObj.hasNonZeroFraction && regularPriceObj.fraction }
+						</span>
+						{ regularPriceObj.symbolPosition === 'after' && (
+							<sup className="site-plans__price-currency site-plans__price-currency--original">
+								{ regularPriceObj.symbol }
+							</sup>
+						) }
+					</div>
+				</div>
+				<Text className="site-plans__price-note" variant="muted">
+					{ renewalNote }
+				</Text>
+			</VStack>
+		);
+	}
+
+	// Use original (pre-proration) price for display throughout
+	const originalPrice = sitePlan.raw_price + sitePlan.raw_discount;
+
+	if ( ! isMonthly ) {
+		const perMonthRaw = Math.round( ( originalPrice / billingMonths ) * 100 ) / 100;
+		const perMonthObj = getCurrencyObject( perMonthRaw, sitePlan.currency_code );
+		let billingNote: string;
+		if ( billingInterval === SubscriptionBillPeriod.PLAN_ANNUAL_PERIOD ) {
+			billingNote = sprintf(
+				/* translators: %s is the annual price, e.g. "€251" */
+				__( 'per month, %s billed annually, excl. taxes' ),
+				formatCurrency( originalPrice, sitePlan.currency_code, { stripZeros: true } )
+			);
+		} else {
+			const years = Math.round( billingInterval / 365 );
+			billingNote = sprintf(
+				/* translators: 1: total price (e.g. "$588"), 2: number of years (e.g. "2") */
+				__( 'per month, %1$s billed every %2$d years, excl. taxes' ),
+				formatCurrency( originalPrice, sitePlan.currency_code, { stripZeros: true } ),
+				years
+			);
+		}
+		return (
+			<VStack spacing={ 1 }>
+				<div className="site-plans__price-display">
+					{ perMonthObj.symbolPosition === 'before' && (
+						<sup className="site-plans__price-currency">{ perMonthObj.symbol }</sup>
+					) }
+					<span className="site-plans__price-number">
+						{ perMonthObj.integer }
+						{ perMonthObj.hasNonZeroFraction && perMonthObj.fraction }
+					</span>
+					{ perMonthObj.symbolPosition === 'after' && (
+						<sup className="site-plans__price-currency">{ perMonthObj.symbol }</sup>
+					) }
+				</div>
+				<Text className="site-plans__price-note" variant="muted">
+					{ billingNote }
+				</Text>
+			</VStack>
+		);
+	}
+
+	const monthlyObj = getCurrencyObject( originalPrice, sitePlan.currency_code );
+	const savingsPercent =
+		annualSitePlan && originalPrice > 0
+			? Math.round(
+					( 1 - ( annualSitePlan.raw_price + annualSitePlan.raw_discount ) / 12 / originalPrice ) *
+						100
+			  )
+			: 0;
+
+	return (
+		<VStack spacing={ 1 }>
+			<div className="site-plans__price-display">
+				{ monthlyObj.symbolPosition === 'before' && (
+					<sup className="site-plans__price-currency">{ monthlyObj.symbol }</sup>
+				) }
+				<span className="site-plans__price-number">
+					{ monthlyObj.integer }
+					{ monthlyObj.hasNonZeroFraction && monthlyObj.fraction }
+				</span>
+				{ monthlyObj.symbolPosition === 'after' && (
+					<sup className="site-plans__price-currency">{ monthlyObj.symbol }</sup>
+				) }
+			</div>
+			{ savingsPercent > 0 && (
+				<Text className="site-plans__price-note" variant="muted">
+					{ sprintf(
+						/* translators: %d is the savings percentage, e.g. "25" */
+						__( 'Save %d%% by paying annually' ),
+						savingsPercent
+					) }
+				</Text>
+			) }
+		</VStack>
+	);
+}
+
+function PlanCardCTA( {
+	site,
+	sitePlan,
+	planCardName,
+	tierRank,
+	currentTierRank,
+}: {
+	site: Site;
+	sitePlan: SiteContextualPlan;
+	planCardName: string;
+	tierRank: number;
+	currentTierRank: number;
+} ) {
+	const isCurrentPlan =
+		sitePlan.current_plan === true || ( currentTierRank >= 0 && tierRank === currentTierRank );
+
+	if ( isCurrentPlan ) {
+		return (
+			<Button variant="secondary" disabled className="site-plans__cta-button">
+				{ __( 'Your plan' ) }
+			</Button>
+		);
+	}
+
+	if ( tierRank > currentTierRank ) {
+		const checkoutURL = wpcomLink( `/checkout/${ site.slug }/${ sitePlan.product_slug }` );
+		return (
+			<Button variant="primary" href={ checkoutURL } className="site-plans__cta-button">
+				{ sprintf(
+					/* translators: %s is the plan name, e.g. "Pro" */
+					__( 'Get %s' ),
+					planCardName
+				) }
+			</Button>
+		);
+	}
+
+	// Higher-tier plan is current; downgrade not offered
+	return null;
+}
+
+function PlanCard( {
+	site,
+	sitePlan,
+	planProduct,
+	billingInterval,
+	annualSitePlan,
+	tierRank,
+	currentTierRank,
+}: {
+	site: Site;
+	sitePlan: SiteContextualPlan;
+	planProduct?: PlanProduct;
+	billingInterval: SubscriptionBillPeriodValue;
+	annualSitePlan?: SiteContextualPlan;
+	tierRank: number;
+	currentTierRank: number;
+} ) {
+	const isCurrentPlan =
+		sitePlan.current_plan === true || ( currentTierRank >= 0 && tierRank === currentTierRank );
+
+	return (
+		<Card className={ `site-plans__card${ isCurrentPlan ? ' site-plans__card--current' : '' }` }>
+			<CardBody>
+				<div className="site-plans__badge-slot">
+					{ isCurrentPlan && (
+						<span className="site-plans__current-badge">{ __( 'Your plan' ) }</span>
+					) }
+					{ ! isCurrentPlan && sitePlan.introductory_offer_formatted_price && (
+						<span className="site-plans__special-offer-badge">{ __( 'Special Offer' ) }</span>
+					) }
+				</div>
+				<VStack spacing={ 4 }>
+					<VStack spacing={ 1 }>
+						<Text className="site-plans__plan-name" size={ 20 } weight={ 600 }>
+							{ planProduct?.plan_card_name ?? sitePlan.product_name }
+						</Text>
+						{ planProduct?.tagline && (
+							<Text className="site-plans__tagline" variant="muted">
+								{ planProduct.tagline }
+							</Text>
+						) }
+						{ ! planProduct?.tagline && planProduct?.description && (
+							<Text className="site-plans__tagline" variant="muted">
+								{ planProduct.description }
+							</Text>
+						) }
+					</VStack>
+
+					<PlanPrice
+						sitePlan={ sitePlan }
+						billingInterval={ billingInterval }
+						annualSitePlan={ annualSitePlan }
+					/>
+
+					<PlanCardCTA
+						site={ site }
+						sitePlan={ sitePlan }
+						planCardName={ planProduct?.plan_card_name ?? sitePlan.product_name }
+						tierRank={ tierRank }
+						currentTierRank={ currentTierRank }
+					/>
+
+					{ planProduct?.plan_card_features && planProduct.plan_card_features.length > 0 && (
+						<ul className="site-plans__features">
+							{ planProduct.plan_card_features.map( ( feature ) => (
+								<li
+									key={ feature.text }
+									className={ `site-plans__feature-item${
+										feature.available === false ? ' site-plans__feature-item--unavailable' : ''
+									}` }
+								>
+									{ feature.text }
+								</li>
+							) ) }
+						</ul>
+					) }
+				</VStack>
+			</CardBody>
+		</Card>
+	);
+}
+
+function TierCell( {
+	tier,
+	tiers,
+	tierValues,
+	isUnavailableOnMonthly,
+}: {
+	tier: number;
+	tiers?: number[];
+	tierValues?: Record< string, string >;
+	isUnavailableOnMonthly: boolean;
+} ) {
+	const isAvailable = ! isUnavailableOnMonthly && tiers?.includes( tier );
+	if ( ! isAvailable ) {
+		return <Icon icon={ lineSolid } size={ 20 } className="site-plans__comparison-dash-icon" />;
+	}
+	const tierValue = tierValues?.[ String( tier ) ];
+	if ( tierValue ) {
+		return tierValue;
+	}
+	return <Icon icon={ check } size={ 20 } className="site-plans__comparison-check-icon" />;
+}
+
+function BillingIntervalSelector( {
+	billingInterval,
+	availableBillPeriods,
+	onChange,
+}: {
+	billingInterval: SubscriptionBillPeriodValue;
+	availableBillPeriods: SubscriptionBillPeriodValue[];
+	onChange: ( value: SubscriptionBillPeriodValue ) => void;
+} ) {
+	const handleChange = ( value: string | number | undefined ) => {
+		const numeric = Number( value );
+		if ( ! isNaN( numeric ) && numeric !== 0 ) {
+			onChange( numeric as SubscriptionBillPeriodValue );
+		}
+	};
+
+	if ( availableBillPeriods.length > 2 ) {
+		return (
+			<SelectControl
+				value={ String( billingInterval ) }
+				options={ availableBillPeriods.map( ( period ) => ( {
+					value: String( period ),
+					label: getBillingPeriodLabel( period ),
+				} ) ) }
+				onChange={ ( value ) => handleChange( value ) }
+				__nextHasNoMarginBottom
+				label={ __( 'Billing interval' ) }
+				hideLabelFromVision
+			/>
+		);
+	}
+
+	return (
+		<ToggleGroupControl
+			value={ String( billingInterval ) }
+			isBlock
+			__nextHasNoMarginBottom
+			__next40pxDefaultSize
+			onChange={ handleChange }
+			label={ __( 'Billing interval' ) }
+			hideLabelFromVision
+		>
+			{ availableBillPeriods.map( ( period ) => (
+				<ToggleGroupControlOption
+					key={ period }
+					value={ String( period ) }
+					label={ getBillingPeriodLabel( period ) }
+				/>
+			) ) }
+		</ToggleGroupControl>
+	);
+}
+
+function PlanComparisonSection( {
+	comparisonGroups,
+	planColumns,
+	billPeriod,
+	billingInterval,
+	availableBillPeriods,
+	onBillingIntervalChange,
+}: {
+	comparisonGroups: PlanProductComparisonGroup[];
+	planColumns: Array< { tierKey: number; planCardName: string | undefined } >;
+	billPeriod: SubscriptionBillPeriodValue | undefined;
+	billingInterval: SubscriptionBillPeriodValue;
+	availableBillPeriods: SubscriptionBillPeriodValue[];
+	onBillingIntervalChange: ( value: SubscriptionBillPeriodValue ) => void;
+} ) {
+	return (
+		<section className="site-plans__comparison">
+			<div className="site-plans__comparison-header">
+				<Text size={ 24 } weight={ 600 } className="site-plans__comparison-title">
+					{ __( 'Compare our plans and find yours' ) }
+				</Text>
+				<BillingIntervalSelector
+					billingInterval={ billingInterval }
+					availableBillPeriods={ availableBillPeriods }
+					onChange={ onBillingIntervalChange }
+				/>
+			</div>
+			<Card className="site-plans__comparison-card">
+				<table className="site-plans__comparison-table">
+					<thead>
+						<tr>
+							<th />
+							{ planColumns.map( ( col ) => (
+								<th key={ col.tierKey } className="site-plans__comparison-plan-header">
+									{ col.planCardName }
+								</th>
+							) ) }
+						</tr>
+					</thead>
+					<tbody>
+						{ comparisonGroups.map( ( group ) => (
+							<Fragment key={ group.group }>
+								<tr className="site-plans__comparison-group-row">
+									<th colSpan={ planColumns.length + 1 }>{ group.group }</th>
+								</tr>
+								{ group.features.map( ( feature ) => {
+									const isUnavailableOnMonthly =
+										!! feature.billing_periods &&
+										billPeriod !== undefined &&
+										! feature.billing_periods.includes( billPeriod );
+									return (
+										<tr key={ feature.key }>
+											<td>{ feature.title }</td>
+											{ planColumns.map( ( col ) => (
+												<td key={ col.tierKey } className="site-plans__comparison-check-cell">
+													<TierCell
+														tier={ col.tierKey }
+														tiers={ feature.tiers }
+														tierValues={ feature.tier_values }
+														isUnavailableOnMonthly={ isUnavailableOnMonthly }
+													/>
+												</td>
+											) ) }
+										</tr>
+									);
+								} ) }
+							</Fragment>
+						) ) }
+					</tbody>
+				</table>
+			</Card>
+		</section>
+	);
+}
+
+export default function SitePlans() {
+	const { siteSlug } = siteRoute.useParams();
+	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+
+	const [ billingInterval, setBillingInterval ] = useState< SubscriptionBillPeriodValue >(
+		SubscriptionBillPeriod.PLAN_ANNUAL_PERIOD
+	);
+
+	const { data: sitePlans } = useQuery( {
+		...sitePlansQuery( site.ID ),
+		enabled: !! site.ID,
+	} );
+	const { data: planProducts } = useQuery( plansQuery() );
+
+	const planProductMap = new Map< string, PlanProduct >(
+		( planProducts ?? [] ).map( ( p ) => [ p.product_slug, p ] )
+	);
+
+	// Index sitePlans by product_id for O(1) sibling lookups
+	const plansByProductId = new Map< number, SiteContextualPlan >(
+		( sitePlans ?? [] ).map( ( p ) => [ p.product_id, p ] )
+	);
+
+	// Plans to show, sorted by plan_card_order — one entry per plan family (deduplicated by
+	// product_tier_id in case multiple billing-period variants carry a plan_card_order).
+	const shownPlans = ( sitePlans ?? [] )
+		.filter( ( p ) => typeof p.plan_card_order === 'number' )
+		.filter(
+			( p, index, arr ) =>
+				arr.findIndex( ( q ) => q.product_tier_id === p.product_tier_id ) === index
+		)
+		.sort( ( a, b ) => ( a.plan_card_order ?? 0 ) - ( b.plan_card_order ?? 0 ) );
+
+	// Collect all billing periods available across all shown plan families, sorted ascending.
+	const availableBillPeriods = Array.from(
+		new Set(
+			shownPlans.flatMap( ( p ) =>
+				( p.product_tier_product_ids ?? [] ).flatMap( ( id ) => {
+					const sp = plansByProductId.get( id );
+					if ( ! sp ) {
+						return [];
+					}
+					const pp = planProductMap.get( sp.product_slug );
+					if ( ! pp || pp.bill_period <= 0 ) {
+						return [];
+					}
+					return [ pp.bill_period ];
+				} )
+			)
+		)
+	).sort( ( a, b ) => a - b ) as SubscriptionBillPeriodValue[];
+
+	const activePlans = shownPlans.map( ( canonicalPlan, tierRank ) => {
+		const siblings = ( canonicalPlan.product_tier_product_ids ?? [] )
+			.map( ( id ) => plansByProductId.get( id ) )
+			.filter( Boolean ) as SiteContextualPlan[];
+
+		const sitePlan =
+			siblings.find(
+				( p ) => planProductMap.get( p.product_slug )?.bill_period === billingInterval
+			) ?? canonicalPlan;
+
+		const annualSitePlan =
+			billingInterval === SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD
+				? siblings.find(
+						( p ) =>
+							planProductMap.get( p.product_slug )?.bill_period ===
+							SubscriptionBillPeriod.PLAN_ANNUAL_PERIOD
+				  )
+				: undefined;
+
+		return { canonicalPlan, sitePlan, annualSitePlan, tierRank };
+	} );
+
+	// Tier rank of the current plan (by product_tier_id)
+	const currentPlanSlug =
+		sitePlans?.find( ( p ) => p.current_plan )?.product_slug ?? site.plan?.product_slug;
+	const currentTierRank = shownPlans.findIndex( ( p ) =>
+		( p.product_tier_product_ids ?? [] )
+			.map( ( id ) => plansByProductId.get( id )?.product_slug )
+			.includes( currentPlanSlug ?? '' )
+	);
+
+	const comparisonGroups = activePlans
+		.map( ( ap ) => planProductMap.get( ap.sitePlan.product_slug )?.features_comparison )
+		.find( Boolean );
+
+	// Comparison table columns keyed by product_tier_id, matching tiers[] in features_comparison
+	const planColumns = activePlans.map( ( ap ) => ( {
+		tierKey: ap.canonicalPlan.product_tier_id ?? 0,
+		planCardName:
+			planProductMap.get( ap.sitePlan.product_slug )?.plan_card_name ?? ap.sitePlan.product_name,
+	} ) );
+
+	const billPeriod = activePlans
+		.map( ( ap ) => planProductMap.get( ap.sitePlan.product_slug )?.bill_period )
+		.find( ( v ) => v !== undefined );
+
+	return (
+		<PageLayout
+			header={
+				<PageHeader
+					actions={
+						<BillingIntervalSelector
+							billingInterval={ billingInterval }
+							availableBillPeriods={ availableBillPeriods }
+							onChange={ setBillingInterval }
+						/>
+					}
+				/>
+			}
+		>
+			<div
+				className="site-plans__grid"
+				style={ { '--plan-count': shownPlans.length } as React.CSSProperties }
+			>
+				{ activePlans.map( ( ap ) => (
+					<PlanCard
+						key={ String( ap.canonicalPlan.product_tier_id ) }
+						site={ site }
+						sitePlan={ ap.sitePlan }
+						planProduct={ planProductMap.get( ap.sitePlan.product_slug ) }
+						billingInterval={ billingInterval }
+						annualSitePlan={ ap.annualSitePlan }
+						tierRank={ ap.tierRank }
+						currentTierRank={ currentTierRank }
+					/>
+				) ) }
+			</div>
+			{ comparisonGroups && (
+				<PlanComparisonSection
+					comparisonGroups={ comparisonGroups }
+					planColumns={ planColumns }
+					billPeriod={ billPeriod }
+					billingInterval={ billingInterval }
+					availableBillPeriods={ availableBillPeriods }
+					onBillingIntervalChange={ setBillingInterval }
+				/>
+			) }
+		</PageLayout>
+	);
+}

--- a/client/dashboard/sites/site-plans/index.tsx
+++ b/client/dashboard/sites/site-plans/index.tsx
@@ -2,6 +2,7 @@ import { SubscriptionBillPeriod } from '@automattic/api-core';
 import { sitePlansQuery, siteBySlugQuery } from '@automattic/api-queries';
 import { formatCurrency, getCurrencyObject } from '@automattic/number-formatters';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { useSearch } from '@tanstack/react-router';
 import {
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
@@ -12,14 +13,16 @@ import {
 	SelectControl,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { check, lineSolid } from '@wordpress/icons';
+import { check, chevronLeft, lineSolid } from '@wordpress/icons';
+import { addQueryArgs } from '@wordpress/url';
 import React, { Fragment, useState } from 'react';
 import { useHelpCenter } from '../../app/help-center';
-import { siteRoute } from '../../app/router/sites';
+import { siteRoute, sitePlansRoute } from '../../app/router/sites';
 import { Card, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import { wpcomLink } from '../../utils/link';
+import { dashboardLink, wpcomLink } from '../../utils/link';
+import { isRelativeUrl } from '../../utils/url';
 import type {
 	PlanProductComparisonGroup,
 	SiteContextualPlan,
@@ -253,12 +256,14 @@ function PlanCardCTA( {
 	planCardName,
 	tierRank,
 	currentTierRank,
+	redirectAfterPurchase,
 }: {
 	site: Site;
 	sitePlan: SiteContextualPlan;
 	planCardName: string;
 	tierRank: number;
 	currentTierRank: number;
+	redirectAfterPurchase: string;
 } ) {
 	const { setNewMessagingChat } = useHelpCenter();
 	const isCurrentPlan =
@@ -273,7 +278,11 @@ function PlanCardCTA( {
 	}
 
 	if ( tierRank > currentTierRank ) {
-		const checkoutURL = wpcomLink( `/checkout/${ site.slug }/${ sitePlan.product_slug }` );
+		const cancelTo = window.location.pathname + window.location.search;
+		const checkoutURL = addQueryArgs(
+			wpcomLink( `/checkout/${ site.slug }/${ sitePlan.product_slug }` ),
+			{ redirect_to: redirectAfterPurchase, cancel_to: cancelTo }
+		);
 		return (
 			<Button variant="primary" href={ checkoutURL } className="site-plans__cta-button">
 				{ sprintf(
@@ -314,6 +323,7 @@ function PlanCard( {
 	annualSitePlan,
 	tierRank,
 	currentTierRank,
+	redirectAfterPurchase,
 }: {
 	site: Site;
 	sitePlan: SiteContextualPlan;
@@ -321,6 +331,7 @@ function PlanCard( {
 	annualSitePlan?: SiteContextualPlan;
 	tierRank: number;
 	currentTierRank: number;
+	redirectAfterPurchase: string;
 } ) {
 	const isCurrentPlan =
 		sitePlan.current_plan === true || ( currentTierRank >= 0 && tierRank === currentTierRank );
@@ -352,7 +363,7 @@ function PlanCard( {
 						) }
 					</VStack>
 
-					<VStack spacing={ 1 }>
+					<VStack spacing={ 1 } className="site-plans__price-area">
 						{ sitePlan.introductory_offer_formatted_price && (
 							<span className="site-plans__special-offer-badge">{ __( 'Special Offer' ) }</span>
 						) }
@@ -369,6 +380,7 @@ function PlanCard( {
 						planCardName={ sitePlan.plan_card_name ?? sitePlan.product_name }
 						tierRank={ tierRank }
 						currentTierRank={ currentTierRank }
+						redirectAfterPurchase={ redirectAfterPurchase }
 					/>
 
 					{ sitePlan.plan_card_features && sitePlan.plan_card_features.length > 0 && (
@@ -469,14 +481,12 @@ function BillingIntervalSelector( {
 function PlanComparisonSection( {
 	comparisonGroups,
 	planColumns,
-	billPeriod,
 	billingInterval,
 	availableBillPeriods,
 	onBillingIntervalChange,
 }: {
 	comparisonGroups: PlanProductComparisonGroup[];
 	planColumns: Array< { tierKey: number; planCardName: string | undefined } >;
-	billPeriod: SubscriptionBillPeriodValue | undefined;
 	billingInterval: SubscriptionBillPeriodValue;
 	availableBillPeriods: SubscriptionBillPeriodValue[];
 	onBillingIntervalChange: ( value: SubscriptionBillPeriodValue ) => void;
@@ -514,8 +524,7 @@ function PlanComparisonSection( {
 								{ group.features.map( ( feature ) => {
 									const isUnavailableOnMonthly =
 										!! feature.billing_periods &&
-										billPeriod !== undefined &&
-										! feature.billing_periods.includes( billPeriod );
+										! feature.billing_periods.includes( billingInterval );
 									return (
 										<tr key={ feature.key }>
 											<td className="site-plans__comparison-feature-title">{ feature.title }</td>
@@ -543,11 +552,15 @@ function PlanComparisonSection( {
 
 export default function SitePlans() {
 	const { siteSlug } = siteRoute.useParams();
+	const { redirect_to } = useSearch( { from: sitePlansRoute.fullPath } );
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 
 	const [ billingInterval, setBillingInterval ] = useState< SubscriptionBillPeriodValue >(
 		SubscriptionBillPeriod.PLAN_ANNUAL_PERIOD
 	);
+
+	const backUrl = redirect_to && isRelativeUrl( redirect_to ) ? redirect_to : undefined;
+	const redirectAfterPurchase = backUrl ?? dashboardLink( '/sites' );
 
 	const { data: sitePlansData } = useQuery( {
 		...sitePlansQuery( site.ID ),
@@ -622,15 +635,20 @@ export default function SitePlans() {
 		planCardName: ap.sitePlan.plan_card_name ?? ap.sitePlan.product_name,
 	} ) );
 
-	const billPeriod = activePlans
-		.map( ( ap ) => ap.sitePlan.interval as SubscriptionBillPeriodValue | undefined )
-		.find( ( v ) => v !== undefined );
-
 	return (
 		<PageLayout
 			header={
 				<div className="site-plans__header-wrap">
-					<PageHeader title={ pageContext?.page_title } />
+					<PageHeader
+						title={ pageContext?.page_title }
+						prefix={
+							backUrl ? (
+								<Button variant="tertiary" icon={ chevronLeft } href={ backUrl } size="compact">
+									{ __( 'Back' ) }
+								</Button>
+							) : undefined
+						}
+					/>
 					{ pageContext?.header_message && (
 						<Text className="site-plans__subheader">{ pageContext.header_message }</Text>
 					) }
@@ -657,6 +675,7 @@ export default function SitePlans() {
 						annualSitePlan={ ap.annualSitePlan }
 						tierRank={ ap.tierRank }
 						currentTierRank={ currentTierRank }
+						redirectAfterPurchase={ redirectAfterPurchase }
 					/>
 				) ) }
 			</div>
@@ -664,7 +683,6 @@ export default function SitePlans() {
 				<PlanComparisonSection
 					comparisonGroups={ comparisonGroups }
 					planColumns={ planColumns }
-					billPeriod={ billPeriod }
 					billingInterval={ billingInterval }
 					availableBillPeriods={ availableBillPeriods }
 					onBillingIntervalChange={ setBillingInterval }

--- a/client/dashboard/sites/site-plans/index.tsx
+++ b/client/dashboard/sites/site-plans/index.tsx
@@ -12,6 +12,7 @@ import {
 	Icon,
 	SelectControl,
 } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { check, chevronLeft, lineSolid } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
@@ -19,6 +20,8 @@ import React, { Fragment, useState } from 'react';
 import { useHelpCenter } from '../../app/help-center';
 import { siteRoute, sitePlansRoute } from '../../app/router/sites';
 import { Card, CardBody } from '../../components/card';
+import InlineSupportLink from '../../components/inline-support-link';
+import { Notice } from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { dashboardLink, wpcomLink } from '../../utils/link';
@@ -30,6 +33,137 @@ import type {
 	SubscriptionBillPeriodValue,
 } from '@automattic/api-core';
 import './style.scss';
+
+type UpgradeCreditsSource = 'plan' | 'domain' | 'other-upgrades' | 'domain-and-other-upgrades';
+
+type UpgradeCredit = { amount: number; currencyCode: string; source: UpgradeCreditsSource };
+
+/**
+ * Computes the upgrade credit to display in the notice banner, or null if none applies.
+ *
+ * A plan has upgrade credits when its raw_discount > 0 (proration from a current plan,
+ * domain, or other upgrade). Returns the maximum credit across all upgradeable plans and
+ * infers the source label from cost_overrides for the message text.
+ */
+function getUpgradeCredit(
+	activePlans: Array< { sitePlan: SiteContextualPlan; tierRank: number } >,
+	currentTierRank: number
+): UpgradeCredit | null {
+	let amount = 0;
+	let currencyCode = '';
+	let hasDomainProration = false;
+	let hasOtherProration = false;
+
+	for ( const ap of activePlans ) {
+		if ( ap.tierRank <= currentTierRank ) {
+			continue;
+		}
+		const plan = ap.sitePlan;
+		if ( ! plan.has_sale_coupon && plan.raw_discount > amount ) {
+			amount = plan.raw_discount;
+			currencyCode = plan.currency_code;
+		}
+		for ( const override of plan.cost_overrides ) {
+			if ( override.override_code === 'recent-domain-proration' ) {
+				hasDomainProration = true;
+			}
+			if ( override.override_code === 'recent-plan-proration' ) {
+				hasOtherProration = true;
+			}
+		}
+	}
+
+	if ( amount <= 0 ) {
+		return null;
+	}
+
+	let source: UpgradeCreditsSource;
+	if ( hasDomainProration && hasOtherProration ) {
+		source = 'domain-and-other-upgrades';
+	} else if ( hasDomainProration ) {
+		source = 'domain';
+	} else if ( hasOtherProration ) {
+		source = 'other-upgrades';
+	} else {
+		// No explicit override code: infer from whether the user has a shown plan.
+		// If they do (currentTierRank >= 0), this is likely a paid-plan upgrade credit.
+		source = currentTierRank >= 0 ? 'plan' : 'other-upgrades';
+	}
+
+	return { amount, currencyCode, source };
+}
+
+function UpgradeCreditsNotice( {
+	amount,
+	currencyCode,
+	source,
+}: {
+	amount: number;
+	currencyCode: string;
+	source: UpgradeCreditsSource;
+} ) {
+	const formattedAmount = formatCurrency( amount, currencyCode );
+	const linkMap = { a: <InlineSupportLink supportContext="plans-upgrade-credit" /> };
+
+	let message: React.ReactNode;
+	switch ( source ) {
+		case 'plan':
+			message = createInterpolateElement(
+				sprintf(
+					/* translators: %s is a formatted currency amount, e.g. "$0.08". The <a> tags wrap a link to the upgrade credits support article. */
+					__(
+						'You have %s in <a>upgrade credits</a> available from your current plan. This credit will be applied to the pricing below at checkout if you upgrade today!'
+					),
+					formattedAmount
+				),
+				linkMap
+			);
+			break;
+		case 'domain':
+			message = createInterpolateElement(
+				sprintf(
+					/* translators: %s is a formatted currency amount, e.g. "$0.08". The <a> tags wrap a link to the upgrade credits support article. */
+					__(
+						'You have %s in <a>upgrade credits</a> available from your current domain. This credit will be applied to the pricing below at checkout if you purchase a plan today!'
+					),
+					formattedAmount
+				),
+				linkMap
+			);
+			break;
+		case 'domain-and-other-upgrades':
+			message = createInterpolateElement(
+				sprintf(
+					/* translators: %s is a formatted currency amount, e.g. "$0.08". The <a> tags wrap a link to the upgrade credits support article. */
+					__(
+						'You have %s in <a>upgrade credits</a> available from your current domain and other upgrades. This credit will be applied to the pricing below at checkout if you purchase a plan today!'
+					),
+					formattedAmount
+				),
+				linkMap
+			);
+			break;
+		default: // 'other-upgrades'
+			message = createInterpolateElement(
+				sprintf(
+					/* translators: %s is a formatted currency amount, e.g. "$0.08". The <a> tags wrap a link to the upgrade credits support article. */
+					__(
+						'You have %s in <a>upgrade credits</a> available from other upgrades. This credit will be applied to the pricing below at checkout if you purchase a plan today!'
+					),
+					formattedAmount
+				),
+				linkMap
+			);
+	}
+
+	return (
+		<div className="site-plans__upgrade-credit-notice">
+			<Notice variant="success" density="high">
+				{ message }
+			</Notice>
+		</div>
+	);
+}
 
 function getBillingPeriodMonths( billPeriod: SubscriptionBillPeriodValue ): number {
 	if ( billPeriod === SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD ) {
@@ -652,6 +786,8 @@ export default function SitePlans() {
 		planCardName: ap.sitePlan.plan_card_name ?? ap.sitePlan.product_name,
 	} ) );
 
+	const upgradeCredit = getUpgradeCredit( activePlans, currentTierRank );
+
 	return (
 		<PageLayout
 			header={
@@ -679,6 +815,13 @@ export default function SitePlans() {
 				</div>
 			}
 		>
+			{ upgradeCredit && (
+				<UpgradeCreditsNotice
+					amount={ upgradeCredit.amount }
+					currencyCode={ upgradeCredit.currencyCode }
+					source={ upgradeCredit.source }
+				/>
+			) }
 			<div
 				className="site-plans__grid"
 				style={ { '--plan-count': shownPlans.length } as React.CSSProperties }

--- a/client/dashboard/sites/site-plans/index.tsx
+++ b/client/dashboard/sites/site-plans/index.tsx
@@ -805,6 +805,13 @@ export default function SitePlans() {
 					{ pageContext?.header_message && (
 						<Text className="site-plans__subheader">{ pageContext.header_message }</Text>
 					) }
+					{ upgradeCredit && (
+						<UpgradeCreditsNotice
+							amount={ upgradeCredit.amount }
+							currencyCode={ upgradeCredit.currencyCode }
+							source={ upgradeCredit.source }
+						/>
+					) }
 					<div className="site-plans__interval-selector-wrap">
 						<BillingIntervalSelector
 							billingInterval={ billingInterval }
@@ -815,13 +822,6 @@ export default function SitePlans() {
 				</div>
 			}
 		>
-			{ upgradeCredit && (
-				<UpgradeCreditsNotice
-					amount={ upgradeCredit.amount }
-					currencyCode={ upgradeCredit.currencyCode }
-					source={ upgradeCredit.source }
-				/>
-			) }
 			<div
 				className="site-plans__grid"
 				style={ { '--plan-count': shownPlans.length } as React.CSSProperties }

--- a/client/dashboard/sites/site-plans/index.tsx
+++ b/client/dashboard/sites/site-plans/index.tsx
@@ -1,5 +1,5 @@
 import { SubscriptionBillPeriod } from '@automattic/api-core';
-import { plansQuery, sitePlansQuery, siteBySlugQuery } from '@automattic/api-queries';
+import { sitePlansQuery, siteBySlugQuery } from '@automattic/api-queries';
 import { formatCurrency, getCurrencyObject } from '@automattic/number-formatters';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import {
@@ -20,7 +20,6 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { wpcomLink } from '../../utils/link';
 import type {
-	PlanProduct,
 	PlanProductComparisonGroup,
 	SiteContextualPlan,
 	Site,
@@ -291,7 +290,6 @@ function PlanCardCTA( {
 function PlanCard( {
 	site,
 	sitePlan,
-	planProduct,
 	billingInterval,
 	annualSitePlan,
 	tierRank,
@@ -299,7 +297,6 @@ function PlanCard( {
 }: {
 	site: Site;
 	sitePlan: SiteContextualPlan;
-	planProduct?: PlanProduct;
 	billingInterval: SubscriptionBillPeriodValue;
 	annualSitePlan?: SiteContextualPlan;
 	tierRank: number;
@@ -322,16 +319,11 @@ function PlanCard( {
 				<VStack spacing={ 4 }>
 					<VStack spacing={ 1 }>
 						<Text className="site-plans__plan-name" size={ 20 } weight={ 600 }>
-							{ planProduct?.plan_card_name ?? sitePlan.product_name }
+							{ sitePlan.plan_card_name ?? sitePlan.product_name }
 						</Text>
-						{ planProduct?.tagline && (
+						{ sitePlan.tagline && (
 							<Text className="site-plans__tagline" variant="muted">
-								{ planProduct.tagline }
-							</Text>
-						) }
-						{ ! planProduct?.tagline && planProduct?.description && (
-							<Text className="site-plans__tagline" variant="muted">
-								{ planProduct.description }
+								{ sitePlan.tagline }
 							</Text>
 						) }
 					</VStack>
@@ -345,14 +337,14 @@ function PlanCard( {
 					<PlanCardCTA
 						site={ site }
 						sitePlan={ sitePlan }
-						planCardName={ planProduct?.plan_card_name ?? sitePlan.product_name }
+						planCardName={ sitePlan.plan_card_name ?? sitePlan.product_name }
 						tierRank={ tierRank }
 						currentTierRank={ currentTierRank }
 					/>
 
-					{ planProduct?.plan_card_features && planProduct.plan_card_features.length > 0 && (
+					{ sitePlan.plan_card_features && sitePlan.plan_card_features.length > 0 && (
 						<ul className="site-plans__features">
-							{ planProduct.plan_card_features.map( ( feature ) => (
+							{ sitePlan.plan_card_features.map( ( feature ) => (
 								<li
 									key={ feature.text }
 									className={ `site-plans__feature-item${
@@ -532,12 +524,6 @@ export default function SitePlans() {
 		...sitePlansQuery( site.ID ),
 		enabled: !! site.ID,
 	} );
-	const { data: planProducts } = useQuery( plansQuery() );
-
-	const planProductMap = new Map< string, PlanProduct >(
-		( planProducts ?? [] ).map( ( p ) => [ p.product_slug, p ] )
-	);
-
 	// Index sitePlans by product_id for O(1) sibling lookups
 	const plansByProductId = new Map< number, SiteContextualPlan >(
 		( sitePlans ?? [] ).map( ( p ) => [ p.product_id, p ] )
@@ -562,11 +548,10 @@ export default function SitePlans() {
 					if ( ! sp ) {
 						return [];
 					}
-					const pp = planProductMap.get( sp.product_slug );
-					if ( ! pp || pp.bill_period <= 0 ) {
+					if ( ! sp.interval || sp.interval <= 0 ) {
 						return [];
 					}
-					return [ pp.bill_period ];
+					return [ sp.interval ];
 				} )
 			)
 		)
@@ -577,18 +562,11 @@ export default function SitePlans() {
 			.map( ( id ) => plansByProductId.get( id ) )
 			.filter( Boolean ) as SiteContextualPlan[];
 
-		const sitePlan =
-			siblings.find(
-				( p ) => planProductMap.get( p.product_slug )?.bill_period === billingInterval
-			) ?? canonicalPlan;
+		const sitePlan = siblings.find( ( p ) => p.interval === billingInterval ) ?? canonicalPlan;
 
 		const annualSitePlan =
 			billingInterval === SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD
-				? siblings.find(
-						( p ) =>
-							planProductMap.get( p.product_slug )?.bill_period ===
-							SubscriptionBillPeriod.PLAN_ANNUAL_PERIOD
-				  )
+				? siblings.find( ( p ) => p.interval === SubscriptionBillPeriod.PLAN_ANNUAL_PERIOD )
 				: undefined;
 
 		return { canonicalPlan, sitePlan, annualSitePlan, tierRank };
@@ -604,18 +582,17 @@ export default function SitePlans() {
 	);
 
 	const comparisonGroups = activePlans
-		.map( ( ap ) => planProductMap.get( ap.sitePlan.product_slug )?.features_comparison )
+		.map( ( ap ) => ap.sitePlan.features_comparison )
 		.find( Boolean );
 
 	// Comparison table columns keyed by product_tier_id, matching tiers[] in features_comparison
 	const planColumns = activePlans.map( ( ap ) => ( {
 		tierKey: ap.canonicalPlan.product_tier_id ?? 0,
-		planCardName:
-			planProductMap.get( ap.sitePlan.product_slug )?.plan_card_name ?? ap.sitePlan.product_name,
+		planCardName: ap.sitePlan.plan_card_name ?? ap.sitePlan.product_name,
 	} ) );
 
 	const billPeriod = activePlans
-		.map( ( ap ) => planProductMap.get( ap.sitePlan.product_slug )?.bill_period )
+		.map( ( ap ) => ap.sitePlan.interval as SubscriptionBillPeriodValue | undefined )
 		.find( ( v ) => v !== undefined );
 
 	return (
@@ -641,7 +618,6 @@ export default function SitePlans() {
 						key={ String( ap.canonicalPlan.product_tier_id ) }
 						site={ site }
 						sitePlan={ ap.sitePlan }
-						planProduct={ planProductMap.get( ap.sitePlan.product_slug ) }
 						billingInterval={ billingInterval }
 						annualSitePlan={ ap.annualSitePlan }
 						tierRank={ ap.tierRank }

--- a/client/dashboard/sites/site-plans/index.tsx
+++ b/client/dashboard/sites/site-plans/index.tsx
@@ -498,7 +498,7 @@ function PlanComparisonSection( {
 										! feature.billing_periods.includes( billPeriod );
 									return (
 										<tr key={ feature.key }>
-											<td>{ feature.title }</td>
+											<td className="site-plans__comparison-feature-title">{ feature.title }</td>
 											{ planColumns.map( ( col ) => (
 												<td key={ col.tierKey } className="site-plans__comparison-check-cell">
 													<TierCell

--- a/client/dashboard/sites/site-plans/index.tsx
+++ b/client/dashboard/sites/site-plans/index.tsx
@@ -312,9 +312,6 @@ function PlanCard( {
 					{ isCurrentPlan && (
 						<span className="site-plans__current-badge">{ __( 'Your plan' ) }</span>
 					) }
-					{ ! isCurrentPlan && sitePlan.introductory_offer_formatted_price && (
-						<span className="site-plans__special-offer-badge">{ __( 'Special Offer' ) }</span>
-					) }
 				</div>
 				<VStack spacing={ 4 }>
 					<VStack spacing={ 1 }>
@@ -328,11 +325,16 @@ function PlanCard( {
 						) }
 					</VStack>
 
-					<PlanPrice
-						sitePlan={ sitePlan }
-						billingInterval={ billingInterval }
-						annualSitePlan={ annualSitePlan }
-					/>
+					<VStack spacing={ 1 }>
+						{ ! isCurrentPlan && sitePlan.introductory_offer_formatted_price && (
+							<span className="site-plans__special-offer-badge">{ __( 'Special Offer' ) }</span>
+						) }
+						<PlanPrice
+							sitePlan={ sitePlan }
+							billingInterval={ billingInterval }
+							annualSitePlan={ annualSitePlan }
+						/>
+					</VStack>
 
 					<PlanCardCTA
 						site={ site }

--- a/client/dashboard/sites/site-plans/index.tsx
+++ b/client/dashboard/sites/site-plans/index.tsx
@@ -529,10 +529,12 @@ export default function SitePlans() {
 		SubscriptionBillPeriod.PLAN_ANNUAL_PERIOD
 	);
 
-	const { data: sitePlans } = useQuery( {
+	const { data: sitePlansData } = useQuery( {
 		...sitePlansQuery( site.ID ),
 		enabled: !! site.ID,
 	} );
+	const sitePlans = sitePlansData?.plans;
+	const pageContext = sitePlansData?.pageContext;
 	// Index sitePlans by product_id for O(1) sibling lookups
 	const plansByProductId = new Map< number, SiteContextualPlan >(
 		( sitePlans ?? [] ).map( ( p ) => [ p.product_id, p ] )
@@ -618,6 +620,9 @@ export default function SitePlans() {
 				/>
 			}
 		>
+			{ pageContext?.header_message && (
+				<Text className="site-plans__subheader">{ pageContext.header_message }</Text>
+			) }
 			<div
 				className="site-plans__grid"
 				style={ { '--plan-count': shownPlans.length } as React.CSSProperties }

--- a/client/dashboard/sites/site-plans/index.tsx
+++ b/client/dashboard/sites/site-plans/index.tsx
@@ -14,6 +14,7 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { check, lineSolid } from '@wordpress/icons';
 import React, { Fragment, useState } from 'react';
+import { useHelpCenter } from '../../app/help-center';
 import { siteRoute } from '../../app/router/sites';
 import { Card, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
@@ -259,6 +260,7 @@ function PlanCardCTA( {
 	tierRank: number;
 	currentTierRank: number;
 } ) {
+	const { setNewMessagingChat } = useHelpCenter();
 	const isCurrentPlan =
 		sitePlan.current_plan === true || ( currentTierRank >= 0 && tierRank === currentTierRank );
 
@@ -283,8 +285,26 @@ function PlanCardCTA( {
 		);
 	}
 
-	// Higher-tier plan is current; downgrade not offered
-	return null;
+	return (
+		<Button
+			variant="secondary"
+			className="site-plans__cta-button"
+			onClick={ () =>
+				setNewMessagingChat( {
+					initialMessage: sprintf(
+						/* translators: %s is the plan name, e.g. "Starter" */
+						__( 'I would like to downgrade my plan to %s.' ),
+						planCardName
+					),
+					section: 'plans',
+					siteUrl: site.URL,
+					siteId: String( site.ID ),
+				} )
+			}
+		>
+			{ __( 'Downgrade' ) }
+		</Button>
+	);
 }
 
 function PlanCard( {

--- a/client/dashboard/sites/site-plans/style.scss
+++ b/client/dashboard/sites/site-plans/style.scss
@@ -1,10 +1,21 @@
+.site-plans__header-wrap {
+	max-width: 660px;
+	margin-inline: auto;
+	width: 100%;
+}
+
 .site-plans__subheader {
 	display: block;
-	margin-block-end: 24px;
+	margin-block-start: 8px;
 	color: var( --wp-components-color-gray-600, #757575 );
 }
 
+.site-plans__interval-selector-wrap {
+	margin-block-start: 48px;
+}
+
 .site-plans__grid {
+	margin-block-start: 16px;
 	display: grid;
 	grid-template-columns: repeat( auto-fit, minmax( 240px, 1fr ) );
 	gap: 0;

--- a/client/dashboard/sites/site-plans/style.scss
+++ b/client/dashboard/sites/site-plans/style.scss
@@ -204,6 +204,10 @@
 	color: var( --wp-components-color-gray-600, #757575 );
 }
 
+.site-plans__comparison-feature-title {
+	max-width: 450px;
+}
+
 .site-plans__comparison-check-cell {
 	width: 100px;
 	text-align: center;

--- a/client/dashboard/sites/site-plans/style.scss
+++ b/client/dashboard/sites/site-plans/style.scss
@@ -1,3 +1,9 @@
+.site-plans__subheader {
+	display: block;
+	margin-block-end: 24px;
+	color: var( --wp-components-color-gray-600, #757575 );
+}
+
 .site-plans__grid {
 	display: grid;
 	grid-template-columns: repeat( auto-fit, minmax( 240px, 1fr ) );

--- a/client/dashboard/sites/site-plans/style.scss
+++ b/client/dashboard/sites/site-plans/style.scss
@@ -126,6 +126,10 @@
 	font-size: 12px;
 }
 
+.site-plans__plan-info {
+	min-height: 100px;
+}
+
 .site-plans__tagline {
 	font-size: 14px;
 }

--- a/client/dashboard/sites/site-plans/style.scss
+++ b/client/dashboard/sites/site-plans/style.scss
@@ -44,10 +44,30 @@
 	line-height: 21px;
 }
 
+.site-plans__plan-header {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
+.site-plans__plan-badge {
+	display: inline-block;
+	align-self: center;
+	margin-block-start: 4px;
+	background: var( --studio-gray-5, #f0f0f0 );
+	color: var( --studio-gray-70, #3c434a );
+	font-size: 12px;
+	font-weight: 500;
+	padding: 3px 10px;
+	border-radius: 4px;
+	line-height: 1.5;
+}
+
 .site-plans__plan-name {
 	font-size: 32px;
 	font-weight: 600;
-	line-height: 1.1;
+	line-height: 1;
 }
 
 .site-plans__price-display {

--- a/client/dashboard/sites/site-plans/style.scss
+++ b/client/dashboard/sites/site-plans/style.scss
@@ -131,6 +131,20 @@
 	font-size: 14px;
 }
 
+.site-plans__card.components-card {
+	height: 100%;
+}
+
+.site-plans__card .components-card__body {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+}
+
+.site-plans__price-area.components-v-stack {
+	flex: 1;
+}
+
 .site-plans__cta-button.components-button {
 	width: 100%;
 	justify-content: center;

--- a/client/dashboard/sites/site-plans/style.scss
+++ b/client/dashboard/sites/site-plans/style.scss
@@ -34,6 +34,7 @@
 
 .site-plans__special-offer-badge {
 	display: inline-block;
+	align-self: flex-start;
 	background-color: var( --studio-green-5, #d8f1e8 );
 	color: var( --studio-green-80, #1a5c3a );
 	font-size: 12px;

--- a/client/dashboard/sites/site-plans/style.scss
+++ b/client/dashboard/sites/site-plans/style.scss
@@ -1,0 +1,197 @@
+.site-plans__grid {
+	display: grid;
+	grid-template-columns: repeat( auto-fit, minmax( 240px, 1fr ) );
+	gap: 0;
+	max-width: calc( 344px * var( --plan-count, 2 ) );
+	margin-inline: auto;
+
+	@media ( max-width: 600px ) {
+		grid-template-columns: 1fr;
+		max-width: 344px;
+	}
+}
+
+.site-plans__card {
+	position: relative;
+}
+
+.site-plans__badge-slot {
+	min-height: 22px;
+	margin-block-end: 4px;
+}
+
+.site-plans__current-badge {
+	display: inline-block;
+	background: var( --wp-admin-theme-color, #007cba );
+	color: #fff;
+	font-size: 11px;
+	font-weight: 600;
+	padding: 2px 8px;
+	border-radius: 2px;
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+}
+
+.site-plans__special-offer-badge {
+	display: inline-block;
+	background-color: var( --studio-green-5, #d8f1e8 );
+	color: var( --studio-green-80, #1a5c3a );
+	font-size: 12px;
+	font-weight: 500;
+	padding: 0 12px;
+	border-radius: 4px;
+	line-height: 21px;
+}
+
+.site-plans__plan-name {
+	font-size: 32px;
+	font-weight: 600;
+	line-height: 1.1;
+}
+
+.site-plans__price-display {
+	display: flex;
+	align-items: flex-start;
+	line-height: 1;
+}
+
+.site-plans__price-currency {
+	font-size: 20px;
+	font-weight: 600;
+	margin-block-start: 4px;
+}
+
+.site-plans__price-number {
+	font-size: 48px;
+	font-weight: 700;
+	line-height: 1;
+}
+
+.site-plans__price-original {
+	display: flex;
+	align-items: flex-start;
+	margin-inline-start: 8px;
+	color: var( --wp-components-color-gray-400, #949494 );
+}
+
+.site-plans__price-number--original {
+	font-size: 28px;
+	font-weight: 600;
+	text-decoration: line-through;
+}
+
+.site-plans__price-currency--original {
+	font-size: 14px;
+	margin-block-start: 4px;
+}
+
+.site-plans__price-note {
+	font-size: 12px;
+}
+
+.site-plans__tagline {
+	font-size: 14px;
+}
+
+.site-plans__cta-button.components-button {
+	width: 100%;
+	justify-content: center;
+
+	&:disabled {
+		opacity: 1;
+		cursor: default;
+	}
+}
+
+.site-plans__features {
+	margin: 0;
+	padding-inline-start: 0;
+	list-style: none;
+}
+
+.site-plans__feature-item {
+	font-size: 13px;
+	padding-block: 4px;
+}
+
+.site-plans__feature-item--unavailable {
+	text-decoration: line-through;
+	color: var( --wp-components-color-gray-400, #949494 );
+}
+
+.site-plans__comparison {
+	margin-block-start: 48px;
+	margin-inline: auto;
+}
+
+.site-plans__comparison-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-block-end: 24px;
+}
+
+.site-plans__comparison-title {
+	display: block;
+}
+
+.site-plans__comparison-card.components-card {
+	overflow: hidden;
+	padding: 0;
+}
+
+.site-plans__comparison-table {
+	width: 100%;
+	border-collapse: collapse;
+	font-size: 13px;
+
+	th,
+	td {
+		padding: 12px 16px;
+		text-align: start;
+		vertical-align: middle;
+	}
+
+	thead tr {
+		border-block-end: 1px solid #e0e0e0;
+
+		th {
+			font-weight: 600;
+		}
+	}
+
+	tbody tr {
+		border-block-end: 1px solid #e0e0e0;
+
+		&:last-child {
+			border-block-end: none;
+		}
+	}
+}
+
+.site-plans__comparison-plan-header {
+	width: 100px;
+	text-align: center;
+}
+
+.site-plans__comparison-group-row th {
+	font-weight: 600;
+	background: #f6f7f7;
+	font-size: 11px;
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+	color: var( --wp-components-color-gray-600, #757575 );
+}
+
+.site-plans__comparison-check-cell {
+	width: 100px;
+	text-align: center;
+}
+
+.site-plans__comparison-check-icon {
+	fill: var( --wp-admin-theme-color, #007cba );
+}
+
+.site-plans__comparison-dash-icon {
+	fill: var( --wp-components-color-gray-400, #949494 );
+}

--- a/client/dashboard/sites/site-plans/style.scss
+++ b/client/dashboard/sites/site-plans/style.scss
@@ -14,6 +14,10 @@
 	margin-block-start: 48px;
 }
 
+.site-plans__upgrade-credit-notice {
+	margin-block-end: 16px;
+}
+
 .site-plans__grid {
 	margin-block-start: 16px;
 	display: grid;

--- a/client/dashboard/sites/site-plans/style.scss
+++ b/client/dashboard/sites/site-plans/style.scss
@@ -15,7 +15,7 @@
 }
 
 .site-plans__upgrade-credit-notice {
-	margin-block-end: 16px;
+	margin-block-start: 16px;
 }
 
 .site-plans__grid {

--- a/client/dashboard/sites/site-plans/style.scss
+++ b/client/dashboard/sites/site-plans/style.scss
@@ -71,7 +71,6 @@
 .site-plans__plan-badge {
 	display: inline-block;
 	align-self: center;
-	margin-block-start: 4px;
 	background: var( --studio-gray-5, #f0f0f0 );
 	color: var( --studio-gray-70, #3c434a );
 	font-size: 12px;

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -28,6 +28,7 @@
 		"dashboard/omnibar": true,
 		"dashboard/wp-beta-program": true,
 		"dashboard/v2": false,
+		"dashboard/plans": true,
 		"dev/auth-helper": true,
 		"dev/preferences-helper": true,
 		"dev/store-sandbox-helper": true,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -28,6 +28,7 @@
 		"dashboard/omnibar": true,
 		"dashboard/wp-beta-program": true,
 		"dashboard/v2": false,
+		"dashboard/plans": true,
 		"dev/auth-helper": true,
 		"dev/preferences-helper": true,
 		"dev/store-sandbox-helper": true,

--- a/config/development.json
+++ b/config/development.json
@@ -68,6 +68,7 @@
 		"dashboard/opt-in-banners": false,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,
+		"dashboard/plans": true,
 		"design-picker/use-assembler-styles": true,
 		"dev/account-settings-helper": true,
 		"dev/auth-helper": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -33,6 +33,7 @@
 		"dashboard/opt-in-banners": false,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,
+		"dashboard/plans": true,
 		"design-picker/use-assembler-styles": true,
 		"devdocs": false,
 		"domain-transfer-redesign": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -43,6 +43,7 @@
 		"dashboard/opt-in-banners": false,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,
+		"dashboard/plans": true,
 		"design-picker/use-assembler-styles": true,
 		"dev/auth-helper": true,
 		"dev/account-settings-helper": true,

--- a/packages/api-core/src/constants.ts
+++ b/packages/api-core/src/constants.ts
@@ -222,6 +222,8 @@ export const SubscriptionBillPeriod = {
 	PLAN_DECENNIAL_PERIOD: 3650,
 	PLAN_CENTENNIAL_PERIOD: 36500,
 } as const;
+export type SubscriptionBillPeriodValue =
+	( typeof SubscriptionBillPeriod )[ keyof typeof SubscriptionBillPeriod ];
 
 export const WPCOM_DIFM_LITE = 'wp_difm_lite';
 

--- a/packages/api-core/src/plans/fetchers.ts
+++ b/packages/api-core/src/plans/fetchers.ts
@@ -27,19 +27,8 @@ function normalizePlanProduct( plan: PlanProduct ): PlanProduct {
 		...( plan.introductory_offer_interval_count !== undefined && {
 			introductory_offer_interval_count: toNumber( plan.introductory_offer_interval_count ),
 		} ),
-		...( plan.product_tier_id !== undefined && {
+		...( Boolean( plan.product_tier_id ) === true && {
 			product_tier_id: toNumber( plan.product_tier_id ),
-		} ),
-		...( plan.features_comparison !== undefined && {
-			features_comparison: plan.features_comparison.map( ( group ) => ( {
-				...group,
-				features: group.features.map( ( feature ) => ( {
-					...feature,
-					...( feature.tiers !== undefined && {
-						tiers: feature.tiers.map( toNumber ),
-					} ),
-				} ) ),
-			} ) ),
 		} ),
 	};
 }

--- a/packages/api-core/src/plans/fetchers.ts
+++ b/packages/api-core/src/plans/fetchers.ts
@@ -27,6 +27,20 @@ function normalizePlanProduct( plan: PlanProduct ): PlanProduct {
 		...( plan.introductory_offer_interval_count !== undefined && {
 			introductory_offer_interval_count: toNumber( plan.introductory_offer_interval_count ),
 		} ),
+		...( plan.product_tier_id !== undefined && {
+			product_tier_id: toNumber( plan.product_tier_id ),
+		} ),
+		...( plan.features_comparison !== undefined && {
+			features_comparison: plan.features_comparison.map( ( group ) => ( {
+				...group,
+				features: group.features.map( ( feature ) => ( {
+					...feature,
+					...( feature.tiers !== undefined && {
+						tiers: feature.tiers.map( toNumber ),
+					} ),
+				} ) ),
+			} ) ),
+		} ),
 	};
 }
 

--- a/packages/api-core/src/plans/types.ts
+++ b/packages/api-core/src/plans/types.ts
@@ -1,6 +1,61 @@
+import type { SubscriptionBillPeriodValue } from '../constants';
+
 export interface PlanProductFeatureHighlight {
 	title?: string;
 	items: string[];
+}
+
+export interface PlanCardFeature {
+	text: string;
+	available: boolean;
+}
+
+/**
+ * A feature to display in the plans page comparison grid for this product.
+ */
+export interface PlanProductComparisonFeature {
+	/**
+	 * The unique ID of this feature.
+	 */
+	key: string;
+
+	/**
+	 * The feature description shown in the first column of the comparison grid
+	 * (eg: "Accept all major card brands automatically").
+	 */
+	title: string;
+
+	/**
+	 * For products which have different tiers that have differing features,
+	 * this list is the tiers where this feature should be shown. Each entry
+	 * is the product_tier_id for that plan family (e.g. 1180 for Woo Basic,
+	 * 1181 for Woo Pro). This is stable across all billing-period variants
+	 * of a plan.
+	 */
+	tiers?: number[];
+
+	/**
+	 * If set, this feature will only be shown for versions of this product
+	 * with the matching billing periods. The billing periods are numbers of
+	 * days but are not literal renewal periods; they are numeric constants
+	 * that represent each period. For example, `31` means "monthly" although
+	 * the expiry date may be fewer than 31 days from the last renewal.
+	 */
+	billing_periods?: SubscriptionBillPeriodValue[];
+
+	/**
+	 * Per-tier display values shown in the comparison grid instead of a check
+	 * mark. The key is the string form of product_tier_id (JSON object keys are
+	 * always strings, e.g. "1180") and the value is a translated string shown in
+	 * that tier's column (e.g. "10 GB" for tier 1180, "50 GB" for tier 1181).
+	 * Tiers omitted from this map still show the default check mark.
+	 */
+	tier_values?: Record< string, string >;
+}
+
+export interface PlanProductComparisonGroup {
+	group: string;
+	features: PlanProductComparisonFeature[];
 }
 
 export interface PlanProductDowngrade {
@@ -25,7 +80,7 @@ export interface PlanProduct {
 	bundle_product_ids: number[];
 
 	// Billing/pricing properties
-	bill_period: number;
+	bill_period: SubscriptionBillPeriodValue;
 	bill_period_label?: string;
 	orig_cost_integer: number;
 	orig_cost: number | null;
@@ -40,7 +95,15 @@ export interface PlanProduct {
 	// Descriptive properties
 	description: string;
 	tagline: string | null;
+	plan_card_name: string | null;
 	features_highlight?: PlanProductFeatureHighlight[];
+	plan_card_features?: PlanCardFeature[];
+	features_comparison?: PlanProductComparisonGroup[];
+
+	/** Numeric ID shared by all billing-period variants of the same plan family.
+	 *  Matches product_tier_id on SiteContextualPlan. Used as the column identifier
+	 *  in features_comparison (tiers[] and tier_values keys). */
+	product_tier_id?: number;
 
 	// Downgrade options
 	downgrade_paths: PlanProductDowngrade[];

--- a/packages/api-core/src/plans/types.ts
+++ b/packages/api-core/src/plans/types.ts
@@ -5,59 +5,6 @@ export interface PlanProductFeatureHighlight {
 	items: string[];
 }
 
-export interface PlanCardFeature {
-	text: string;
-	available: boolean;
-}
-
-/**
- * A feature to display in the plans page comparison grid for this product.
- */
-export interface PlanProductComparisonFeature {
-	/**
-	 * The unique ID of this feature.
-	 */
-	key: string;
-
-	/**
-	 * The feature description shown in the first column of the comparison grid
-	 * (eg: "Accept all major card brands automatically").
-	 */
-	title: string;
-
-	/**
-	 * For products which have different tiers that have differing features,
-	 * this list is the tiers where this feature should be shown. Each entry
-	 * is the product_tier_id for that plan family (e.g. 1180 for Woo Basic,
-	 * 1181 for Woo Pro). This is stable across all billing-period variants
-	 * of a plan.
-	 */
-	tiers?: number[];
-
-	/**
-	 * If set, this feature will only be shown for versions of this product
-	 * with the matching billing periods. The billing periods are numbers of
-	 * days but are not literal renewal periods; they are numeric constants
-	 * that represent each period. For example, `31` means "monthly" although
-	 * the expiry date may be fewer than 31 days from the last renewal.
-	 */
-	billing_periods?: SubscriptionBillPeriodValue[];
-
-	/**
-	 * Per-tier display values shown in the comparison grid instead of a check
-	 * mark. The key is the string form of product_tier_id (JSON object keys are
-	 * always strings, e.g. "1180") and the value is a translated string shown in
-	 * that tier's column (e.g. "10 GB" for tier 1180, "50 GB" for tier 1181).
-	 * Tiers omitted from this map still show the default check mark.
-	 */
-	tier_values?: Record< string, string >;
-}
-
-export interface PlanProductComparisonGroup {
-	group: string;
-	features: PlanProductComparisonFeature[];
-}
-
 export interface PlanProductDowngrade {
 	product_id: number;
 	bill_period: number;
@@ -95,14 +42,16 @@ export interface PlanProduct {
 	// Descriptive properties
 	description: string;
 	tagline: string | null;
-	plan_card_name: string | null;
 	features_highlight?: PlanProductFeatureHighlight[];
-	plan_card_features?: PlanCardFeature[];
-	features_comparison?: PlanProductComparisonGroup[];
 
-	/** Numeric ID shared by all billing-period variants of the same plan family.
-	 *  Matches product_tier_id on SiteContextualPlan. Used as the column identifier
-	 *  in features_comparison (tiers[] and tier_values keys). */
+	/**
+	 * Numeric ID shared by all billing-period variants of the same plan
+	 * family. A product tier is one plan for a service which offers multiple
+	 * levels of that plan. For example, on WPCOM we offer Personal, Premium,
+	 * Business, and Commerce, which are each tiers. Within the Personal plan
+	 * is Personal Monthly, Personal Annual, Personal Biennial, and Personal
+	 * Triennial.
+	 */
 	product_tier_id?: number;
 
 	// Downgrade options

--- a/packages/api-core/src/site-plans/fetchers.ts
+++ b/packages/api-core/src/site-plans/fetchers.ts
@@ -39,10 +39,10 @@ function normalizeSitePlan( plan: SiteContextualPlan ): SiteContextualPlan {
 		...( plan.id !== undefined && {
 			id: toNumber( plan.id ),
 		} ),
-		...( plan.plan_card_order != null && {
+		...( Boolean( plan.plan_card_order ) === true && {
 			plan_card_order: toNumber( plan.plan_card_order ),
 		} ),
-		...( plan.product_tier_id !== undefined && {
+		...( Boolean( plan.product_tier_id ) === true && {
 			product_tier_id: toNumber( plan.product_tier_id ),
 		} ),
 		...( plan.product_tier_product_ids !== undefined && {

--- a/packages/api-core/src/site-plans/fetchers.ts
+++ b/packages/api-core/src/site-plans/fetchers.ts
@@ -1,7 +1,7 @@
 import { toNumber } from '../normalize-utils';
 import { wpcom } from '../wpcom-fetcher';
 import type { SubscriptionBillPeriodValue } from '../constants';
-import type { SiteContextualPlan } from './types';
+import type { SiteContextualPlan, SitePlansPageContext } from './types';
 
 /**
  * Normalizes a product object to ensure all number fields are actual numbers.
@@ -54,13 +54,19 @@ function normalizeSitePlan( plan: SiteContextualPlan ): SiteContextualPlan {
 export async function fetchSitePlans(
 	siteId: number,
 	coupon?: string
-): Promise< SiteContextualPlan[] > {
+): Promise< { plans: SiteContextualPlan[]; pageContext?: SitePlansPageContext } > {
 	const params = new URLSearchParams();
 	coupon && params.append( 'coupon_code', coupon );
-	const plansByProductId: Record< string, SiteContextualPlan > = await wpcom.req.get( {
+	const response: {
+		plans: Record< string, SiteContextualPlan >;
+		page_context?: SitePlansPageContext;
+	} = await wpcom.req.get( {
 		path: `/sites/${ siteId }/plans`,
-		apiVersion: '1.3',
+		apiVersion: '1.4',
 		query: params.toString(),
 	} );
-	return Object.values( plansByProductId ).map( normalizeSitePlan );
+	return {
+		plans: Object.values( response.plans ).map( normalizeSitePlan ),
+		pageContext: response.page_context,
+	};
 }

--- a/packages/api-core/src/site-plans/fetchers.ts
+++ b/packages/api-core/src/site-plans/fetchers.ts
@@ -38,6 +38,15 @@ function normalizeSitePlan( plan: SiteContextualPlan ): SiteContextualPlan {
 		...( plan.id !== undefined && {
 			id: toNumber( plan.id ),
 		} ),
+		...( plan.plan_card_order != null && {
+			plan_card_order: toNumber( plan.plan_card_order ),
+		} ),
+		...( plan.product_tier_id !== undefined && {
+			product_tier_id: toNumber( plan.product_tier_id ),
+		} ),
+		...( plan.product_tier_product_ids !== undefined && {
+			product_tier_product_ids: plan.product_tier_product_ids.map( toNumber ),
+		} ),
 	};
 }
 

--- a/packages/api-core/src/site-plans/fetchers.ts
+++ b/packages/api-core/src/site-plans/fetchers.ts
@@ -1,5 +1,6 @@
 import { toNumber } from '../normalize-utils';
 import { wpcom } from '../wpcom-fetcher';
+import type { SubscriptionBillPeriodValue } from '../constants';
 import type { SiteContextualPlan } from './types';
 
 /**
@@ -18,7 +19,7 @@ function normalizeSitePlan( plan: SiteContextualPlan ): SiteContextualPlan {
 		raw_discount_integer: toNumber( plan.raw_discount_integer ),
 		product_id: toNumber( plan.product_id ),
 		...( plan.interval !== undefined && {
-			interval: toNumber( plan.interval ),
+			interval: toNumber( plan.interval ) as SubscriptionBillPeriodValue,
 		} ),
 		cost_overrides: plan.cost_overrides.map( ( override ) => ( {
 			...override,

--- a/packages/api-core/src/site-plans/types.ts
+++ b/packages/api-core/src/site-plans/types.ts
@@ -1,3 +1,6 @@
+import type { SubscriptionBillPeriodValue } from '../constants';
+import type { PlanCardFeature, PlanProductComparisonGroup } from '../plans/types';
+
 export interface SiteContextualPlanCostOverride {
 	old_price: number;
 	new_price: number;
@@ -34,7 +37,7 @@ export interface SiteContextualPlan {
 	is_domain_upgrade: boolean;
 
 	// Billing interval (conditional - if bill_period is set)
-	interval?: number;
+	interval?: SubscriptionBillPeriodValue;
 
 	// Coupon-related fields (conditional - when coupon is applied)
 	has_sale_coupon?: boolean;
@@ -76,4 +79,10 @@ export interface SiteContextualPlan {
 	/** product_id values for every billing-period variant of this plan family (inclusive).
 	 *  Use these to navigate between monthly / annual / biennial / triennial variants. */
 	product_tier_product_ids?: number[];
+
+	// Display/marketing content (conditional - only present when plan_card_order is set)
+	plan_card_name?: string | null;
+	tagline?: string | null;
+	plan_card_features?: PlanCardFeature[];
+	features_comparison?: PlanProductComparisonGroup[];
 }

--- a/packages/api-core/src/site-plans/types.ts
+++ b/packages/api-core/src/site-plans/types.ts
@@ -1,5 +1,57 @@
 import type { SubscriptionBillPeriodValue } from '../constants';
-import type { PlanCardFeature, PlanProductComparisonGroup } from '../plans/types';
+
+export interface PlanCardFeature {
+	text: string;
+	available: boolean;
+}
+
+export interface PlanProductComparisonGroup {
+	group: string;
+	features: PlanProductComparisonFeature[];
+}
+
+/**
+ * A feature to display in the plans page comparison grid for this product.
+ */
+export interface PlanProductComparisonFeature {
+	/**
+	 * The unique ID of this feature.
+	 */
+	key: string;
+
+	/**
+	 * The feature description shown in the first column of the comparison grid
+	 * (eg: "Accept all major card brands automatically").
+	 */
+	title: string;
+
+	/**
+	 * For products which have different tiers that have differing features,
+	 * this list is the tiers where this feature should be shown. Each entry
+	 * is the product_tier_id for that plan family (e.g. 1180 for Woo Basic,
+	 * 1181 for Woo Pro). This is stable across all billing-period variants
+	 * of a plan.
+	 */
+	tiers?: number[];
+
+	/**
+	 * If set, this feature will only be shown for versions of this product
+	 * with the matching billing periods. The billing periods are numbers of
+	 * days but are not literal renewal periods; they are numeric constants
+	 * that represent each period. For example, `31` means "monthly" although
+	 * the expiry date may be fewer than 31 days from the last renewal.
+	 */
+	billing_periods?: SubscriptionBillPeriodValue[];
+
+	/**
+	 * Per-tier display values shown in the comparison grid instead of a check
+	 * mark. The key is the string form of product_tier_id (JSON object keys are
+	 * always strings, e.g. "1180") and the value is a translated string shown in
+	 * that tier's column (e.g. "10 GB" for tier 1180, "50 GB" for tier 1181).
+	 * Tiers omitted from this map still show the default check mark.
+	 */
+	tier_values?: Record< string, string >;
+}
 
 export interface SiteContextualPlanCostOverride {
 	old_price: number;
@@ -69,15 +121,26 @@ export interface SiteContextualPlan {
 	// Trial availability (conditional - when !is_current_plan && !is_free)
 	can_start_trial?: boolean;
 
-	/** Display order for plan cards on the comparison page. Lower values appear first.
-	 *  Only present on plans that should be shown; absence means the plan is not displayed. */
+	/**
+	 * Display order for plan cards on the comparison page. Lower values appear first.
+	 * Only present on plans that should be shown; absence means the plan is not displayed.
+	 */
 	plan_card_order?: number;
 
-	/** Numeric ID shared by all billing-period variants of the same plan family (e.g. 1180 for Woo Basic). */
+	/**
+	 * Numeric ID shared by all billing-period variants of the same plan
+	 * family. A product tier is one plan for a service which offers multiple
+	 * levels of that plan. For example, on WPCOM we offer Personal, Premium,
+	 * Business, and Commerce, which are each tiers. Within the Personal plan
+	 * is Personal Monthly, Personal Annual, Personal Biennial, and Personal
+	 * Triennial.
+	 */
 	product_tier_id?: number;
 
-	/** product_id values for every billing-period variant of this plan family (inclusive).
-	 *  Use these to navigate between monthly / annual / biennial / triennial variants. */
+	/**
+	 * product_id values for every billing-period variant of this plan family (inclusive).
+	 * Use these to navigate between monthly / annual / biennial / triennial variants.
+	 */
 	product_tier_product_ids?: number[];
 
 	// Display/marketing content (conditional - only present when plan_card_order is set)

--- a/packages/api-core/src/site-plans/types.ts
+++ b/packages/api-core/src/site-plans/types.ts
@@ -65,4 +65,15 @@ export interface SiteContextualPlan {
 
 	// Trial availability (conditional - when !is_current_plan && !is_free)
 	can_start_trial?: boolean;
+
+	/** Display order for plan cards on the comparison page. Lower values appear first.
+	 *  Only present on plans that should be shown; absence means the plan is not displayed. */
+	plan_card_order?: number;
+
+	/** Numeric ID shared by all billing-period variants of the same plan family (e.g. 1180 for Woo Basic). */
+	product_tier_id?: number;
+
+	/** product_id values for every billing-period variant of this plan family (inclusive).
+	 *  Use these to navigate between monthly / annual / biennial / triennial variants. */
+	product_tier_product_ids?: number[];
 }

--- a/packages/api-core/src/site-plans/types.ts
+++ b/packages/api-core/src/site-plans/types.ts
@@ -2,6 +2,7 @@ import type { SubscriptionBillPeriodValue } from '../constants';
 
 export interface SitePlansPageContext {
 	header_message?: string;
+	page_title?: string;
 }
 
 export interface PlanCardFeature {

--- a/packages/api-core/src/site-plans/types.ts
+++ b/packages/api-core/src/site-plans/types.ts
@@ -1,5 +1,9 @@
 import type { SubscriptionBillPeriodValue } from '../constants';
 
+export interface SitePlansPageContext {
+	header_message?: string;
+}
+
 export interface PlanCardFeature {
 	text: string;
 	available: boolean;

--- a/packages/api-core/src/site-plans/types.ts
+++ b/packages/api-core/src/site-plans/types.ts
@@ -148,4 +148,5 @@ export interface SiteContextualPlan {
 	tagline?: string | null;
 	plan_card_features?: PlanCardFeature[];
 	features_comparison?: PlanProductComparisonGroup[];
+	badges?: string[];
 }

--- a/packages/api-core/src/upgrades/types.ts
+++ b/packages/api-core/src/upgrades/types.ts
@@ -1,4 +1,4 @@
-import { SubscriptionBillPeriod } from '../constants';
+import type { SubscriptionBillPeriodValue } from '../constants';
 
 export interface RefundOptions {
 	to_product_id: number;
@@ -97,20 +97,7 @@ export interface Purchase {
 	 * `31` means "monthly" although the expiry date may be fewer than 31 days
 	 * from the last renewal. `-1` means that it does not expire.
 	 */
-	bill_period_days:
-		| typeof SubscriptionBillPeriod.PLAN_ONE_TIME_PERIOD
-		| typeof SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD
-		| typeof SubscriptionBillPeriod.PLAN_ANNUAL_PERIOD
-		| typeof SubscriptionBillPeriod.PLAN_BIENNIAL_PERIOD
-		| typeof SubscriptionBillPeriod.PLAN_TRIENNIAL_PERIOD
-		| typeof SubscriptionBillPeriod.PLAN_QUADRENNIAL_PERIOD
-		| typeof SubscriptionBillPeriod.PLAN_QUINQUENNIAL_PERIOD
-		| typeof SubscriptionBillPeriod.PLAN_SEXENNIAL_PERIOD
-		| typeof SubscriptionBillPeriod.PLAN_SEPTENNIAL_PERIOD
-		| typeof SubscriptionBillPeriod.PLAN_OCTENNIAL_PERIOD
-		| typeof SubscriptionBillPeriod.PLAN_NOVENNIAL_PERIOD
-		| typeof SubscriptionBillPeriod.PLAN_DECENNIAL_PERIOD
-		| typeof SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD;
+	bill_period_days: SubscriptionBillPeriodValue;
 
 	bill_period_label: string;
 	most_recent_renew_date: string;

--- a/packages/api-queries/src/site-plans.ts
+++ b/packages/api-queries/src/site-plans.ts
@@ -12,7 +12,7 @@ export const siteCurrentPlanQuery = ( siteId: number ) =>
 	queryOptions( {
 		queryKey: [ 'site', siteId, 'plans', 'current' ],
 		queryFn: async () => {
-			const plans = await fetchSitePlans( siteId );
+			const { plans } = await fetchSitePlans( siteId );
 			const plan = plans.find( ( plan ) => plan.current_plan );
 			if ( ! plan ) {
 				throw new Error( 'No current plan found' );
@@ -25,7 +25,7 @@ export const sitePlanBySlugQuery = ( siteId: number, productSlug: string ) =>
 	queryOptions( {
 		queryKey: [ 'site', siteId, 'plans', productSlug ],
 		queryFn: async () => {
-			const plans = await fetchSitePlans( siteId );
+			const { plans } = await fetchSitePlans( siteId );
 			const plan = plans.find( ( plan ) => plan.product_slug === productSlug );
 			if ( ! plan ) {
 				throw new Error( `The plan ${ productSlug } cannot be found` );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/SHILL-1861/make-plans-page-fully-controlled-by-server-data

## Proposed Changes

This PR is a follow-up to the proof-of-concept of the MSD native plans page for CIAB plans (https://github.com/Automattic/wp-calypso/pull/109131). In this version, the plans page is entirely controlled by the server and so should work for any site (provided the server has been given the features lists for those plans).

Currently the data is filled for Woo Hosted plans and WordPress.com plans. Data for additional plans should be just a matter of adding it to the backend of the site plans endpoint.

This creates a new plans page at `/sites/:siteSlug/plans` in the dashboard. It does not replace the existing dashboard plans page at `/setup/woo-hosted-plans/plans?siteSlug=:siteSlug` yet. Nor does it replace the calypso plans page yet at `/plans/:siteSlug`.

> [!NOTE]
> This is currently only available in development, horizon, and wpcalypso environments. We need to do more testing before launching it anywhere.

Depends on 210824-ghe-Automattic/wpcom (**merged**)
Depends on 211175-ghe-Automattic/wpcom (**merged**)

CIAB             |  WPCOM
:-------------------------:|:-------------------------:
<img width="1508" height="761" alt="Screenshot 2026-04-09 at 4 29 22 PM" src="https://github.com/user-attachments/assets/5f4a2671-48b5-405f-84b2-718a72b31bc9" /> | <img width="1511" height="780" alt="Screenshot 2026-04-09 at 4 29 43 PM" src="https://github.com/user-attachments/assets/c3239db1-3beb-4149-a25c-50bdcf388a1b" />
<img width="1509" height="800" alt="Screenshot 2026-04-09 at 4 29 33 PM" src="https://github.com/user-attachments/assets/b856ea0a-3e18-4e60-b00d-06de4c9170af" /> | <img width="1512" height="787" alt="Screenshot 2026-04-09 at 4 29 59 PM" src="https://github.com/user-attachments/assets/ee1d4d06-a900-43b6-8c6f-b2310b1a5e66" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We are developing a plans page that can operate entirely off of server-side data instead of needing a ton of hard-coded data on the frontend.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!NOTE]
> If you want to see introductory offers for CIAB sites, make sure your currency is set to USD and you have no currently active plan.

1. Open the Dashboard client for a Woo Hosted (CIAB) site and navigate to `/sites/:siteSlug/plans`.
2. Verify both Monthly and Yearly tabs render plan cards for Basic and Pro.
3. Confirm the displayed prices match the plan list prices (not the prorated checkout price). For example, if you hold a Basic monthly plan with an upgrade credit, the Pro card should still show the full Pro price.
4. Confirm the "Save X%" badge appears on yearly plan cards and the percentage is calculated correctly against the monthly price.
5. Confirm the active plan tier shows a "Current plan" badge and a disabled "Your plan" button regardless of which billing tab is active.
6. Confirm the inactive plan shows a "Get [Plan Name]" button that links to checkout.
7. Scroll below the plan cards and verify the feature comparison table is present and organized into the expected groups.
8. Repeat the above for a wpcom site.
9. Verify that you see Free, Personal, Premium, Business, and Commerce. 
10. Verify that there are options for Monthly, Annual, Biennial, and Triennial.