### PR TITLE
Fix comp modal product dropdown rendering reversed

### DIFF
--- a/client/my-sites/subscribers/components/comp-modal/style.scss
+++ b/client/my-sites/subscribers/components/comp-modal/style.scss
@@ -10,9 +10,12 @@
 
 		.components-button.has-icon.has-text {
 			justify-content: space-between;
-			flex-direction: row-reverse;
 			width: 100%;
 			border: 1px solid var(--wp-components-color-gray-600, #949494);
+
+			svg {
+				order: 1;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Part of NL-579

## Proposed Changes

* Replace `flex-direction: row-reverse` on the comp modal product dropdown trigger with an explicit `svg { order: 1; }` rule, so the chevron is always rendered after the label.

Sometimes before | Always after
---- | -----
<img width="523" height="302" alt="Screenshot 2026-04-06 at 1 33 34 PM" src="https://github.com/user-attachments/assets/ebee3ec3-1d90-488c-9c6d-89f619aa7482" /> | <img width="472" height="283" alt="Screenshot 2026-04-07 at 3 44 37 PM" src="https://github.com/user-attachments/assets/c9bcbe0a-c8ca-4c4c-8588-ce69bc2df26d" />


## Why are these changes being made?

The product dropdown inside the complimentary subscription modal sometimes rendered with the chevron icon and label on swapped sides. The previous styling relied on `flex-direction: row-reverse`, which depends on the child render order produced by `@wordpress/components` Button and also flips the wrong way under RTL. Using `order` on the SVG is direction-independent and deterministic.

## Testing Instructions

* Open a site's Subscribers screen, pick a subscriber, and open the "Add complimentary subscription" modal.
* Confirm the product dropdown trigger consistently shows the label on the inline-start side and the chevron on the inline-end side.
* Re-open the modal several times / try different selected products to confirm the order does not flip.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?