### PR TITLE
Subscribers: add Remove comp action to actions menu

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -123,6 +123,9 @@ const getSubscriptionIdString = ( subscriber: Subscriber ): string => {
 	return String( getSubscriptionIdFromSubscriber( subscriber ) );
 };
 
+const findRemovableComp = ( subscriber: Subscriber ) =>
+	( subscriber.plans ?? [] ).find( ( p ) => p.is_comp && p.comp_id );
+
 const defaultView: ViewTable = {
 	type: 'table',
 	titleField: 'name',
@@ -508,13 +511,11 @@ export default function SubscriberDataViews( {
 			},
 			{
 				id: 'remove',
-				label: String(
-					fixMe( {
-						text: 'Remove subscriber',
-						newCopy: translate( 'Remove subscriber' ),
-						oldCopy: translate( 'Remove' ),
-					} ) ?? translate( 'Remove' )
-				),
+				label: fixMe( {
+					text: 'Remove subscriber',
+					newCopy: translate( 'Remove subscriber' ),
+					oldCopy: translate( 'Remove' ),
+				} ) as string,
 				callback: handleUnsubscribe,
 				isPrimary: false,
 				supportsBulk: true,
@@ -549,14 +550,13 @@ export default function SubscriberDataViews( {
 				comment:
 					'"Comp" is short for "complimentary" — revoking a free subscription previously granted to a subscriber',
 			} ),
-			isEligible: ( subscriber: Subscriber ) =>
-				( subscriber.plans ?? [] ).some( ( p ) => p.is_comp && p.comp_id ),
+			isEligible: ( subscriber: Subscriber ) => !! findRemovableComp( subscriber ),
 			callback: ( items: Subscriber[] ) => {
 				const subscriber = items[ 0 ];
 				if ( ! subscriber ) {
 					return;
 				}
-				const compPlan = ( subscriber.plans ?? [] ).find( ( p ) => p.is_comp && p.comp_id );
+				const compPlan = findRemovableComp( subscriber );
 				if ( ! compPlan ) {
 					return;
 				}

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -536,12 +536,40 @@ export default function SubscriberDataViews( {
 			isPrimary: false,
 		} );
 
+		baseActions.push( {
+			id: 'remove-comp',
+			label: translate( 'Remove comp', {
+				textOnly: true,
+				comment:
+					'"Comp" is short for "complimentary" — revoking a free subscription previously granted to a subscriber',
+			} ),
+			isEligible: ( subscriber: Subscriber ) =>
+				( subscriber.plans ?? [] ).some( ( p ) => p.is_comp && p.comp_id ),
+			callback: ( items: Subscriber[] ) => {
+				const subscriber = items[ 0 ];
+				if ( ! subscriber ) {
+					return;
+				}
+				const compPlan = ( subscriber.plans ?? [] ).find( ( p ) => p.is_comp && p.comp_id );
+				if ( ! compPlan ) {
+					return;
+				}
+				onRemoveComp( {
+					planName: compPlan.title ?? '',
+					username: subscriber.display_name,
+					compId: compPlan.comp_id,
+				} );
+			},
+			isPrimary: false,
+		} );
+
 		return baseActions;
 	}, [
 		selectedSubscriber,
 		handleSubscriberSelection,
 		handleUnsubscribe,
 		onCompSubscription,
+		onRemoveComp,
 		hasUncompedPlans,
 	] );
 

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -9,7 +9,7 @@ import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { DataViews, type View, type ViewTable, type Action, Operator } from '@wordpress/dataviews';
 import { useMemo, useState, useCallback, useEffect } from '@wordpress/element';
 import { plus, trash } from '@wordpress/icons';
-import { translate } from 'i18n-calypso';
+import { fixMe, translate } from 'i18n-calypso';
 import JetpackTitle from 'calypso/components/jetpack-title';
 import { useSubscribedNewsletterCategories } from 'calypso/data/newsletter-categories';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
@@ -508,7 +508,13 @@ export default function SubscriberDataViews( {
 			},
 			{
 				id: 'remove',
-				label: translate( 'Remove' ),
+				label: String(
+					fixMe( {
+						text: 'Remove subscriber',
+						newCopy: translate( 'Remove subscriber' ),
+						oldCopy: translate( 'Remove' ),
+					} ) ?? translate( 'Remove' )
+				),
 				callback: handleUnsubscribe,
 				isPrimary: false,
 				supportsBulk: true,


### PR DESCRIPTION
Part of NL-29

## Proposed Changes

* Add a conditional **Remove comp** action to the subscribers DataViews row actions menu, shown when a subscriber has an active complimentary subscription with a `comp_id`.
* The new action sits alongside the existing **Comp a subscription** action; both have independent eligibility so subscribers with multi-tier plans can both comp a new plan and remove an existing comp.
* Rename the existing **Remove** row action to **Remove subscriber** to disambiguate it from **Remove comp**. Uses `fixMe()` from `i18n-calypso` so the existing "Remove" translation is shown until the new string is translated.
* Reuses the existing `RemoveCompModal` and `requestDeleteComp` Redux action already wired up for the subscriber detail view — no backend work required.

<img width="231" height="167" alt="Screenshot 2026-04-07 at 4 32 54 PM" src="https://github.com/user-attachments/assets/54b08cef-fb23-43cd-9c91-8590a1b65c79" />
<img width="181" height="156" alt="Screenshot 2026-04-07 at 4 31 02 PM" src="https://github.com/user-attachments/assets/ee6ef026-0fb6-4d45-898d-d7a4edb4c730" />
<img width="573" height="268" alt="Screenshot 2026-04-07 at 4 13 30 PM" src="https://github.com/user-attachments/assets/f7531f3c-d9e0-455f-a252-951aa50bdc41" />


## Why are these changes being made?

Creators need a way to revoke a complimentary subscription once granted. The DELETE endpoint and modal already exist and are hooked into the subscriber detail panel, but there was no way to trigger removal from the main subscribers list without drilling into the detail view. This fills the UI gap.

For subscribers with multiple comps, the action removes the first comp plan found; the detail view continues to support per-plan removal for finer control.

## Testing Instructions

* On a site with paid newsletter plans, comp a subscriber and confirm the **Remove comp** action appears in that row's actions menu.
* Click **Remove comp** and confirm the existing confirmation modal opens with the correct plan name and username.
* Confirm removal succeeds and the **Remove comp** action disappears from the menu for that subscriber afterward.
* Confirm subscribers with no comp do not see **Remove comp**.
* Confirm subscribers that still have uncomped paid plans continue to see **Comp a subscription**.
* Confirm the existing destructive row action now reads **Remove subscriber** (falling back to the existing "Remove" translation in non-English locales until the new string is translated).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?