### PR TITLE
Launch Site Flow: Add more permissive WP Admin redirects

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -109,10 +109,13 @@ function getLaunchDestination( dependencies ) {
 		return addQueryArgs( { celebrateLaunch: 'true' }, dependencies.back_to );
 	}
 
-	if ( dependencies.refParameter === 'wp-admin' ) {
+	const ref = dependencies.refParameter?.trim() ?? '';
+	const isWpAdminPath = ref === 'wp-admin' || ref.startsWith( 'wp-admin/' );
+
+	if ( isWpAdminPath ) {
 		return addQueryArgs(
 			{ 'celebrate-launch': 'true' },
-			`https://${ dependencies.siteSlug }/wp-admin`
+			`https://${ dependencies.siteSlug }/${ ref }`
 		);
 	}
 


### PR DESCRIPTION
Part of DATSCI-1180.

## Proposed Changes

Allow redirecting to other WP Admin pages when launching a site.

## Why are these changes being made?

There are other entry points where the user can launch a site, and it's not always the home page. For example, you can launch the site from the Reading settings.

Launching from there should send the user back to the same place where they started, not necessarily the home page. This also applies to launching from the masterbar.

## Testing Instructions

`%s` is always a site slug.

Visit the flow using these URLs:
- `http://calypso.localhost:3000/start/launch-site?siteSlug=%s&ref=wp-admin`
- `http://calypso.localhost:3000/start/launch-site?siteSlug=%s&ref=wp-admin%2Foptions-reading.php`

And you should be sent back to the URL in the ref, with `celebrate-launch=true` attached to the query parameters.

Run `http://calypso.localhost:3000/start/launch-site?siteSlug=%s` and you should end up at `/home/%s`.