### PR TITLE
Subscribers: Fix comp subscribers redirecting to /earn on removal

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -430,7 +430,9 @@ export default function SubscriberDataViews( {
 				id: 'plan',
 				label: translate( 'Subscription type' ),
 				getValue: ( { item }: { item: Subscriber } ) =>
-					item.plans?.length ? SubscribersFilterBy.Paid : SubscribersFilterBy.Free,
+					item.plans?.some( ( plan ) => ! plan.is_comp )
+						? SubscribersFilterBy.Paid
+						: SubscribersFilterBy.Free,
 				render: ( { item }: { item: Subscriber } ) => <SubscriptionTypeCell subscriber={ item } />,
 				elements: [
 					{ label: translate( 'Paid' ), value: SubscribersFilterBy.Paid },

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -430,9 +430,7 @@ export default function SubscriberDataViews( {
 				id: 'plan',
 				label: translate( 'Subscription type' ),
 				getValue: ( { item }: { item: Subscriber } ) =>
-					item.plans?.some( ( plan ) => ! plan.is_comp )
-						? SubscribersFilterBy.Paid
-						: SubscribersFilterBy.Free,
+					item.plans?.length ? SubscribersFilterBy.Paid : SubscribersFilterBy.Free,
 				render: ( { item }: { item: Subscriber } ) => <SubscriptionTypeCell subscriber={ item } />,
 				elements: [
 					{ label: translate( 'Paid' ), value: SubscribersFilterBy.Paid },

--- a/client/my-sites/subscribers/components/unsubscribe-modal/unsubscribe-modal.tsx
+++ b/client/my-sites/subscribers/components/unsubscribe-modal/unsubscribe-modal.tsx
@@ -18,7 +18,9 @@ type UnsubscribeModalProps = {
 const UnsubscribeModal = ( { subscribers, onCancel, onConfirm }: UnsubscribeModalProps ) => {
 	const translate = useTranslate();
 	const subscriber = subscribers?.[ 0 ];
-	const someSubscriberHasPlans = !! subscribers?.some( ( subscriber ) => subscriber.plans?.length );
+	const someSubscriberHasPlans = !! subscribers?.some(
+		( subscriber ) => subscriber.plans?.some( ( plan ) => ! plan.is_comp )
+	);
 	const recordRemoveModal = useRecordRemoveModal();
 
 	useEffect( () => {

--- a/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
+++ b/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
@@ -83,14 +83,16 @@ const useSubscriberRemoveMutation = (
 			const subscriberPromises = subscribers.map( async ( subscriber ) => {
 				if ( subscriber.plans?.length ) {
 					// unsubscribe this user from all plans
-					const promises = subscriber.plans.map( ( plan ) =>
-						wpcom.req.post(
-							`/sites/${ siteId }/memberships/subscriptions/${ plan.paid_subscription_id }/cancel`,
-							{
-								user_id: subscriber.user_id,
-							}
-						)
-					);
+					const promises = subscriber.plans
+						.filter( ( plan ) => ! plan.is_comp )
+						.map( ( plan ) =>
+							wpcom.req.post(
+								`/sites/${ siteId }/memberships/subscriptions/${ plan.paid_subscription_id }/cancel`,
+								{
+									user_id: subscriber.user_id,
+								}
+							)
+						);
 
 					await Promise.all( promises );
 				}


### PR DESCRIPTION
## Proposed Changes

* Exclude complimentary (comp) plans from the paid subscriber check in the unsubscribe modal

## Why are these changes being made?

When removing a subscriber with a complimentary subscription, the unsubscribe modal was treating them as a paid subscriber. This caused a redirect to /earn/paid-subscriptions/ instead of allowing direct removal. The check subscriber.plans?.length did not distinguish between paid and comp plans. Now it filters out comp plans with ! plan.is_comp.

## Testing Instructions

* Navigate to Subscribers for a site that has complimentary subscribers
* Select a comp subscriber and click Remove
* Verify the modal shows the "Remove subscriber" prompt (not "Manage paid subscriber")
* Confirm the subscriber is removed successfully without redirecting to /earn
* Also verify that removing an actual paid subscriber still shows the "Manage paid subscriber" modal and redirects to /earn

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
