### PR TITLE
Onboarding E2E: Fix visibility settings launch redirect URL

### DIFF
--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
@@ -216,7 +216,7 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 		} );
 
 		it( 'Navigated to Home dashboard', async function () {
-			await page.waitForURL( /home/ );
+			await page.waitForURL( /site-visibility/ );
 			const myHomePage = new MyHomePage( page );
 			await new Promise( ( r ) => setTimeout( r, 2000 ) );
 			await page.reload();

--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
@@ -215,7 +215,7 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 			await domainSearchComponent.skipPurchase();
 		} );
 
-		it( 'Navigated to Home dashboard', async function () {
+		it( 'Navigated back to site visibility page', async function () {
 			await page.waitForURL( /site-visibility/ );
 			const myHomePage = new MyHomePage( page );
 			await new Promise( ( r ) => setTimeout( r, 2000 ) );


### PR DESCRIPTION
Fixes the E2E failures introduced by https://github.com/Automattic/wp-calypso/pull/109829.

## Proposed Changes

With our last PR, we exposed a bug in our E2E tests: launching a site from the dashboard's visibility settings redirected users to the home page instead of the page they were on before starting the launch site flow.

What we're observing right now is expected behavior (send them back to the visibility settings page), so we need to update the tests to reflect that.

## Testing Instructions

None. Watch the Jest E2E tests pass.
