### PR TITLE
Dashboard: harden GitHub/PayPal social-login OAuth state handling

### DIFF
--- a/client/dashboard/me/security-social-logins/github-login.tsx
+++ b/client/dashboard/me/security-social-logins/github-login.tsx
@@ -8,12 +8,13 @@ export default function GitHubLogin( { ...rest }: Props ) {
 		<OAuth2Login
 			service="github"
 			label="GitHub"
-			onClick={ ( e, redirectUri ) => {
+			onClick={ ( e, redirectUri, state ) => {
 				window.location.href = addQueryArgs(
 					'https://public-api.wordpress.com/wpcom/v2/hosting/github/app-authorize',
 					{
 						redirect_uri: redirectUri,
 						scope: encodeURIComponent( 'read:user,user:email' ),
+						state,
 						ux_mode: 'redirect',
 					}
 				);

--- a/client/dashboard/me/security-social-logins/oauth2-login.tsx
+++ b/client/dashboard/me/security-social-logins/oauth2-login.tsx
@@ -1,3 +1,4 @@
+import { fetchGenerateAuthorizationNonce, type ConnectSocialUserArgs } from '@automattic/api-core';
 import { postLoginRequestMutation } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import { useMutation } from '@tanstack/react-query';
@@ -9,12 +10,11 @@ import { getQueryArg } from '@wordpress/url';
 import { MouseEvent, useCallback, useEffect, useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import type { SocialLoginButtonProps } from './types';
-import type { ConnectSocialUserArgs } from '@automattic/api-core';
 
 export type OAuth2LoginProps = SocialLoginButtonProps & {
 	service: 'github' | 'paypal';
 	label: string;
-	onClick?: ( event: MouseEvent< HTMLButtonElement >, redirectUri: string ) => void;
+	onClick?: ( event: MouseEvent< HTMLButtonElement >, redirectUri: string, state: string ) => void;
 };
 
 // This component supports typical OAuth2 Social Login.
@@ -38,6 +38,7 @@ export default function OAuth2Login( {
 
 	const code = ( getQueryArg( window.location.search, 'code' ) || '' ) as string;
 	const requestService = ( getQueryArg( window.location.search, 'service' ) || '' ) as string;
+	const state = ( getQueryArg( window.location.search, 'state' ) || '' ) as string;
 	const error = ( getQueryArg( window.location.search, 'error' ) || '' ) as string;
 
 	const [ showLoading, setShowLoading ] = useState< boolean >( false );
@@ -58,7 +59,7 @@ export default function OAuth2Login( {
 	}, [ createErrorNotice, label ] );
 
 	const exchangeCodeForToken = useCallback(
-		async ( auth_code: string ) => {
+		async ( auth_code: string, requestState: string ) => {
 			postLoginRequest(
 				{
 					action: 'exchange-social-auth-code',
@@ -67,11 +68,17 @@ export default function OAuth2Login( {
 						auth_code,
 						client_id: config( 'wpcom_signup_id' ),
 						client_secret: config( 'wpcom_signup_key' ),
+						state: requestState,
 					},
 				},
 				{
 					onSuccess: ( response ) => {
-						const { access_token } = response?.body?.data as ConnectSocialUserArgs;
+						const { access_token, exchange_token } = response?.body?.data as ConnectSocialUserArgs;
+						if ( exchange_token ) {
+							responseHandler( { exchange_token, service } );
+							return;
+						}
+
 						responseHandler( { access_token, service } );
 					},
 					onError: () => {
@@ -89,9 +96,9 @@ export default function OAuth2Login( {
 	useEffect( () => {
 		if ( code && requestService === service && ! isConnected ) {
 			setShowLoading( true );
-			exchangeCodeForToken( code );
+			exchangeCodeForToken( code, state );
 		}
-	}, [ code, requestService, service, isConnected, exchangeCodeForToken ] );
+	}, [ code, state, requestService, service, isConnected, exchangeCodeForToken ] );
 
 	useEffect( () => {
 		if ( requestService === service && error ) {
@@ -104,12 +111,32 @@ export default function OAuth2Login( {
 		return urlParts[ 0 ];
 	};
 
-	const handleClick = ( e: MouseEvent< HTMLButtonElement > ) => {
+	const handleClick = async ( e: MouseEvent< HTMLButtonElement > ) => {
 		e.preventDefault();
 		setShowLoading( true );
 		recordTracksEvent( 'calypso_dashboard_security_social_logins_' + service + '_login_click' );
 
-		onClick?.( e, stripQueryString( redirectUri ?? '' ) );
+		let nonce: string;
+		try {
+			nonce = await fetchGenerateAuthorizationNonce();
+		} catch {
+			setShowLoading( false );
+			createErrorNotice(
+				sprintf(
+					// Translators: %(service)s is the name of a third-party authentication provider, e.g. "Google", "Facebook", "Apple" ...
+					__( 'Error fetching authorization state for %(service)s. Please try again.' ),
+					{
+						service: label,
+					}
+				),
+				{
+					type: 'snackbar',
+				}
+			);
+			return;
+		}
+
+		onClick?.( e, stripQueryString( redirectUri ?? '' ), nonce );
 	};
 
 	return (

--- a/client/dashboard/me/security-social-logins/paypal-login.tsx
+++ b/client/dashboard/me/security-social-logins/paypal-login.tsx
@@ -8,11 +8,12 @@ export default function PayPalLogin( { ...rest }: Props ) {
 		<OAuth2Login
 			service="paypal"
 			label="PayPal"
-			onClick={ ( e, redirectUri ) => {
+			onClick={ ( e, redirectUri, state ) => {
 				window.location.href = addQueryArgs(
 					'https://public-api.wordpress.com/wpcom/v2/hosting/paypal/app-authorize',
 					{
 						redirect_uri: redirectUri,
+						state,
 						ux_mode: 'redirect',
 					}
 				);

--- a/packages/api-core/src/me-social-logins/types.ts
+++ b/packages/api-core/src/me-social-logins/types.ts
@@ -14,6 +14,7 @@ export interface DisconnectSocialUserArgs {
 export interface ConnectSocialUserArgs {
 	service: string;
 	access_token?: string;
+	exchange_token?: string;
 	id_token?: string;
 	user_name?: string;
 	user_email?: string;


### PR DESCRIPTION
Part of #LIN-XXXX

## Proposed Changes

* Generate and pass OAuth state nonces for Dashboard GitHub and PayPal social-login authorization redirects.
* Include the returned OAuth state in auth-code exchange requests, and support `exchange_token` responses before falling back to `access_token`.
* Extend social-login API typing to include `exchange_token` for hardened OAuth exchange handling.

## Why are these changes being made?

* This hardens the OAuth flow against state tampering and aligns Dashboard social-login handling with server-side validation expectations for GitHub and PayPal.

## Testing Instructions

* Go to Dashboard security social logins and start the GitHub and PayPal connect flows.
* Confirm each provider redirect URL includes a `state` query parameter.
* Complete each flow and verify social login connection still succeeds.
* Simulate a failed nonce fetch (for example, by failing the nonce request) and verify the UI shows an error notice.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?