### PR TITLE
MSD: Add sidebar top padding when no logo

### DIFF
--- a/client/dashboard/app/responsive-sidebar/sidebar.scss
+++ b/client/dashboard/app/responsive-sidebar/sidebar.scss
@@ -20,6 +20,10 @@
 	overflow-y: auto;
 }
 
+.dashboard-responsive-sidebar__sidebar:not( :has( > .dashboard-responsive-sidebar__logo ) ) {
+	padding-block-start: $grid-unit-30;
+}
+
 .dashboard-responsive-sidebar__logo {
 	padding: 14px $grid-unit-30 + 2px;
 	border-block-end: 1px solid var( --dashboard-header__border-color );


### PR DESCRIPTION
Fixes DOTMSD-1206

<img width="442" alt="CleanShot 2026-04-08 at 15 01 51@2x" src="https://github.com/user-attachments/assets/8494a1f6-cdab-4157-842d-37d4a8bd8cac" />


## Proposed Changes

* Add `padding-block-start: 24px` to `.dashboard-responsive-sidebar__sidebar` when it has no `__logo` child, via `:not(:has(...))`.

## Why are these changes being made?

CIAB (`my.woo.ai`) boots the dashboard w/ `Logo: null`. With `dashboard/omnibar` on, the dashboard's own `<Header>` is also skipped, so the first sidebar menu item rendered flush under the external omnibar — no breathing room. Dotcom is unaffected (always has a Logo).

CIAB may or may not eventually have a logo here, but while MSD supports it we should have some sort of way to handle having no logo.

## Testing Instructions

* Enable `dashboard/omnibar` in `config/dashboard-development.json`.
* Load CIAB w/ omnibar on — confirm ~24px padding above "Stores" item.
* Load dotcom — confirm logo block still renders, no extra top padding stacked.
* Toggle omnibar off on CIAB — confirm no regression under own header.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?