### PR TITLE
MSD: Load locale data for the interim omnibar

### DIFF
--- a/client/dashboard/app/interim-omnibar/use-interim-omnibar-data.ts
+++ b/client/dashboard/app/interim-omnibar/use-interim-omnibar-data.ts
@@ -16,18 +16,6 @@ function getUserLanguage( user: User | null | undefined ): string {
 	return user.localeVariant || user.localeSlug || user.locale_variant || user.language || 'en';
 }
 
-async function fetchAndApplyLocaleData( language: string ): Promise< null > {
-	try {
-		const response = await fetch(
-			`https://widgets.wp.com/languages/calypso/${ language }-v1.1.json`
-		);
-		defaultI18n.resetLocaleData( await response.json() );
-	} catch {
-		// Fall back to English if loading fails.
-	}
-	return null;
-}
-
 interface UseInterimOmnibarDataOptions {
 	initialUser: User | null;
 	events: OmnibarEvents;
@@ -44,8 +32,9 @@ export interface InterimOmnibarData {
 /**
  * Provides the props for `InterimOmnibar`. The first render mirrors the SSR
  * output exactly (`user = initialUser`, `site = null`, no callbacks) so
- * hydration succeeds; after hydration commits, the hook switches to
- * query-driven data.
+ * hydration succeeds. After hydration commits, the hook switches to
+ * query-driven data — but only once the user's locale data has also been
+ * loaded, so the user never sees real omnibar content in the wrong language.
  */
 export function useInterimOmnibarData( {
 	initialUser,
@@ -75,25 +64,54 @@ export function useInterimOmnibarData( {
 		enabled: hydrated && !! siteId,
 	} );
 
-	// Load translations for the omnibar after hydration. The interim omnibar
-	// hydrates independently from the main dashboard `Layout` (which provides
-	// the `I18nProvider`), so without this it would render in English even for
-	// non-English users. When the query resolves, React re-renders and the
-	// Masterbar picks up the new locale via `@wordpress/i18n`'s `__()`.
-	const language = getUserLanguage( user );
-	useQuery( {
-		queryKey: [ 'omnibar-locale', language ],
-		queryFn: () => fetchAndApplyLocaleData( language ),
-		enabled: hydrated && language !== 'en',
-		staleTime: Infinity,
-		refetchOnMount: false,
-		refetchOnWindowFocus: false,
-	} );
+	// Load the user's locale data into the global `defaultI18n` instance and
+	// gate the full render on it. The interim omnibar hydrates independently
+	// from the main dashboard `Layout` (which provides the `I18nProvider`), so
+	// without this it would render in English even for non-English users.
+	//
+	// `localeVersion` bumps every time a locale has been applied (or skipped
+	// because it's English, or abandoned after a fetch error). The full render
+	// is gated on `localeVersion > 0` so bootstrapped non-English users see the
+	// placeholder until their language is ready — no flash of English content.
+	const initialLanguage = getUserLanguage( initialUser );
+	const [ localeVersion, setLocaleVersion ] = useState( initialLanguage === 'en' ? 1 : 0 );
+	const currentLanguage = getUserLanguage( user ?? initialUser );
+
+	useEffect( () => {
+		if ( ! hydrated ) {
+			return;
+		}
+		if ( currentLanguage === 'en' ) {
+			setLocaleVersion( ( v ) => ( v === 0 ? 1 : v ) );
+			return;
+		}
+		let cancelled = false;
+		fetch( `https://widgets.wp.com/languages/calypso/${ currentLanguage }-v1.1.json` )
+			.then( ( response ) => response.json() )
+			.then( ( data ) => {
+				if ( cancelled ) {
+					return;
+				}
+				defaultI18n.resetLocaleData( data );
+				setLocaleVersion( ( v ) => v + 1 );
+			} )
+			.catch( () => {
+				if ( cancelled ) {
+					return;
+				}
+				// Fall back to whatever `defaultI18n` currently has (English by
+				// default) so the omnibar doesn't stay blocked forever.
+				setLocaleVersion( ( v ) => ( v === 0 ? 1 : v ) );
+			} );
+		return () => {
+			cancelled = true;
+		};
+	}, [ hydrated, currentLanguage ] );
 
 	const onToggleMenu = useCallback( () => events.mobileMenu.emit(), [ events ] );
 	const onToggleNotifications = useCallback( () => events.notifications.emit(), [ events ] );
 
-	if ( ! hydrated ) {
+	if ( ! hydrated || localeVersion === 0 ) {
 		return {
 			user: initialUser,
 			site: null,

--- a/client/dashboard/app/interim-omnibar/use-interim-omnibar-data.ts
+++ b/client/dashboard/app/interim-omnibar/use-interim-omnibar-data.ts
@@ -1,9 +1,32 @@
 import { siteByIdQuery, userPreferenceQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
+import { defaultI18n } from '@wordpress/i18n';
 import { useCallback, useEffect, useState } from 'react';
 import { AUTH_QUERY_KEY, initializeCurrentUser } from '../auth';
 import type { OmnibarEvents } from './click-handlers';
 import type { Site, User } from '@automattic/api-core';
+
+function getUserLanguage( user: User | null | undefined ): string {
+	if ( ! user ) {
+		return 'en';
+	}
+	// Prefer the bootstrap-provided locale fields (`localeVariant`/`localeSlug`)
+	// because they reflect the locale Calypso actually uses; fall back to the
+	// REST fields when bootstrap data isn't available.
+	return user.localeVariant || user.localeSlug || user.locale_variant || user.language || 'en';
+}
+
+async function fetchAndApplyLocaleData( language: string ): Promise< null > {
+	try {
+		const response = await fetch(
+			`https://widgets.wp.com/languages/calypso/${ language }-v1.1.json`
+		);
+		defaultI18n.resetLocaleData( await response.json() );
+	} catch {
+		// Fall back to English if loading fails.
+	}
+	return null;
+}
 
 interface UseInterimOmnibarDataOptions {
 	initialUser: User | null;
@@ -50,6 +73,21 @@ export function useInterimOmnibarData( {
 	const { data: site = null } = useQuery( {
 		...siteByIdQuery( siteId ?? 0 ),
 		enabled: hydrated && !! siteId,
+	} );
+
+	// Load translations for the omnibar after hydration. The interim omnibar
+	// hydrates independently from the main dashboard `Layout` (which provides
+	// the `I18nProvider`), so without this it would render in English even for
+	// non-English users. When the query resolves, React re-renders and the
+	// Masterbar picks up the new locale via `@wordpress/i18n`'s `__()`.
+	const language = getUserLanguage( user );
+	useQuery( {
+		queryKey: [ 'omnibar-locale', language ],
+		queryFn: () => fetchAndApplyLocaleData( language ),
+		enabled: hydrated && language !== 'en',
+		staleTime: Infinity,
+		refetchOnMount: false,
+		refetchOnWindowFocus: false,
 	} );
 
 	const onToggleMenu = useCallback( () => events.mobileMenu.emit(), [ events ] );


### PR DESCRIPTION
Part of DOTMSD-1199
Stacked on #109881

## Proposed Changes

- Fetch and apply the user's locale data via a dedicated query inside `useInterimOmnibarData`, so the Masterbar re-renders with translated strings after the locale JSON arrives.
- Ports #109762 onto the hooks-based data flow in #109881.

## Why are these changes being made?

The interim omnibar hydrates independently from the main dashboard `Layout` (which provides the `I18nProvider`), so without this it always renders in English — regardless of the user's language setting.

## Testing Instructions

1. Set your account language to a non-English locale (e.g. French, Arabic).
2. Enable the `dashboard/omnibar` feature flag and hard-reload a Dashboard page.
3. Confirm the omnibar text is translated (e.g. "My Sites", "Write", notifications tooltip).
4. For RTL languages, confirm the layout flips.
5. Switch back to English and confirm no regression.

Note: expect a brief English frame before the locale JSON resolves — the refactor uses incremental React renders rather than blocking on all data before a single render.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?