### PR TITLE
Docs: Update agents-manager build command to include --sync flag

### DIFF
--- a/apps/agents-manager/AGENTS.md
+++ b/apps/agents-manager/AGENTS.md
@@ -11,8 +11,9 @@ This app bundles the package into 8 webpack entry points deployed to `widgets.wp
 cd apps/agents-manager
 yarn dev --sync
 
-# Production build
-yarn build
+# Production build + sync (use before deploying)
+cd apps/agents-manager
+yarn build --sync
 ```
 
 The `--sync` flag syncs bundles to `widgets.wp.com/agents-manager/` on your sandbox.


### PR DESCRIPTION
## Summary
- Update the `apps/agents-manager/AGENTS.md` build command from `yarn build` to `yarn build --sync` so built files are synced to the sandbox before running `install-plugin.sh am --release`.

## Test plan
- [ ] Verify `yarn build --sync` works correctly for agents-manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Testing Instructions (for QA)
This PR only changes documentation (AGENTS.md). No functional testing required.

### Checklist
- [ ] I have read [CONTRIBUTING.md](https://github.com/Automattic/wp-calypso/blob/HEAD/docs/CONTRIBUTING.md).
- [ ] This change doesn't need tests (documentation only).