### PR TITLE
Backup: add Jetpack footer to the WP.com page

### DIFF
--- a/client/components/jetpack/wpcom-business-at/index.tsx
+++ b/client/components/jetpack/wpcom-business-at/index.tsx
@@ -17,6 +17,7 @@ import WarningList from 'calypso/blocks/eligibility-warnings/warning-list';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryAutomatedTransferEligibility from 'calypso/components/data/query-atat-eligibility';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
+import JetpackFooter from 'calypso/components/jetpack/jetpack-footer';
 import WhatIsJetpack from 'calypso/components/jetpack/what-is-jetpack';
 import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
@@ -296,6 +297,7 @@ export default function WPCOMBusinessAT( {
 						<p>{ translate( 'Loading…' ) }</p>
 					</div>
 				</Page>
+				{ ! isJetpackCloud() && <JetpackFooter /> }
 			</Main>
 		);
 	}
@@ -359,6 +361,7 @@ export default function WPCOMBusinessAT( {
 
 				{ ! isJetpackCloud() && <WhatIsJetpack className="wpcom-business-at__footer" /> }
 			</Page>
+			{ ! isJetpackCloud() && <JetpackFooter /> }
 
 			<Dialog
 				isVisible={ showDialog }

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -18,6 +18,7 @@ import QuerySiteProducts from 'calypso/components/data/query-site-products';
 import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import BackupActionsToolbar from 'calypso/components/jetpack/backup-actions-toolbar';
 import BackupPlaceholder from 'calypso/components/jetpack/backup-placeholder';
+import JetpackFooter from 'calypso/components/jetpack/jetpack-footer';
 import JetpackTitle from 'calypso/components/jetpack-title';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
@@ -97,6 +98,7 @@ const BackupPage = ( { queryDate } ) => {
 						<AdminContent selectedDate={ selectedDate } />
 					</>
 				) }
+				{ isWpcom && <JetpackFooter /> }
 			</Main>
 		</div>
 	);

--- a/client/my-sites/backup/wpcom-backup-upsell.tsx
+++ b/client/my-sites/backup/wpcom-backup-upsell.tsx
@@ -12,6 +12,7 @@ import JetpackBackupSVG from 'calypso/assets/images/illustrations/jetpack-backup
 import VaultPressLogo from 'calypso/assets/images/jetpack/vaultpress-logo.svg';
 import DocumentHead from 'calypso/components/data/document-head';
 import JetpackDisconnectedWPCOM from 'calypso/components/jetpack/jetpack-disconnected-wpcom';
+import JetpackFooter from 'calypso/components/jetpack/jetpack-footer';
 import WhatIsJetpack from 'calypso/components/jetpack/what-is-jetpack';
 import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
@@ -291,6 +292,7 @@ export default function WPCOMUpsellPage( { reason }: { reason: string } ) {
 			>
 				{ body }
 			</Page>
+			<JetpackFooter />
 		</Main>
 	);
 }

--- a/client/my-sites/backup/wpcom-upsell.tsx
+++ b/client/my-sites/backup/wpcom-upsell.tsx
@@ -8,6 +8,7 @@ import { Page } from '@wordpress/admin-ui';
 import { useTranslate } from 'i18n-calypso';
 import JetpackBackupSVG from 'calypso/assets/images/illustrations/jetpack-backup.svg';
 import DocumentHead from 'calypso/components/data/document-head';
+import JetpackFooter from 'calypso/components/jetpack/jetpack-footer';
 import WhatIsJetpack from 'calypso/components/jetpack/what-is-jetpack';
 import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
@@ -114,6 +115,7 @@ export default function WPCOMUpsellPage() {
 
 				<WhatIsJetpack />
 			</Page>
+			<JetpackFooter />
 		</Main>
 	);
 }


### PR DESCRIPTION
Part of JETPACK-1504

## Proposed Changes

#109765 added the simplified Jetpack footer to four Calypso pages (Activity Log, Monetize, Traffic, Podcasting) but explicitly left Backup and Scan out due to the additional complexity of testing them. This PR closes the Backup half across **all** WP.com render paths reachable from `/backup/<site-slug>`.

### Files touched

* **`client/my-sites/backup/main.jsx`** — happy-path `BackupPage` (when the site has the backup product). Footer gated on `isWpcom`. Pattern matches Podcasting (`client/my-sites/site-settings/podcasting-details/index.jsx`) which uses the same `<Page>` from `@wordpress/admin-ui` and renders `<JetpackFooter />` after `</Page>` but inside `<Main>`.
* **`client/my-sites/backup/wpcom-backup-upsell.tsx`** — `WPCOMUpsellPage` reached via the `showUpsellIfNoBackup` / `showUpsellIfNoBackupRestoreFeature` middlewares (`client/my-sites/backup/index.js`) when the site has no backup product or feature. File is wpcom-only by construction (Jetpack Cloud uses a separate `backup-upsell` component) so no `isJetpackCloud()` gate is needed.
* **`client/my-sites/backup/wpcom-upsell.tsx`** — `WPCOMUpsellPage` reached via `WPCOMBusinessAT` on Business-plan WP.com sites that lack `WPCOM_FEATURES_BACKUPS_SELF_SERVE`. Same wpcom-only construction.
* **`client/components/jetpack/wpcom-business-at/index.tsx`** — shared Atomic-transfer component used by both Backup and Scan. Footer added on **both** `<Main>` branches (the `featuresNotLoaded` placeholder and the transfer CTA), gated on `! isJetpackCloud()` because the same component is also rendered by Jetpack Cloud paths. **Side effect**: this fix also benefits Scan's atomic-transfer flow as a free side-effect, since the component is shared.

Total diff is 9 added lines across 4 files (one import + one render line per file, with the wpcom-business-at file getting two render lines for its two `<Main>` branches).

### Render path coverage

Backup's route middleware chain (`client/my-sites/backup/index.js` line 97-114) means `/backup/<site>` can resolve to one of several components depending on the site's plan/features and whether it's WP.com Simple, WP.com Atomic, or Jetpack Cloud:

| Render path | Component | Covered |
|---|---|---|
| Has backup product (happy path) | `main.jsx::BackupPage` | ✅ this PR |
| No backup product / feature | `wpcom-backup-upsell.tsx::WPCOMUpsellPage` | ✅ this PR |
| Business-plan, no backup feature, via `WPCOMBusinessAT` | `wpcom-upsell.tsx::WPCOMUpsellPage` | ✅ this PR |
| Atomic transfer flow, `featuresNotLoaded` | `wpcom-business-at/index.tsx` (Main #1) | ✅ this PR |
| Atomic transfer flow, transfer CTA | `wpcom-business-at/index.tsx` (Main #2) | ✅ this PR |
| Brief loading-state flash inside `UpsellSwitch` | `upsell-switch/index.tsx` | ❌ intentional — see below |
| Jetpack Cloud variant | `backup-upsell` (separate component) | N/A (gated, has its own chrome) |

### Out of scope: `UpsellSwitch` loading flash

`client/components/jetpack/upsell-switch/index.tsx` wraps its placeholder children in a `<Main className="upsell-switch__loading">` during the brief moment between mount and the "do we have a backup product?" data load. This `<Main>` has no footer, so there's a momentary flash before the loaded state takes over.

This PR **intentionally does not modify `UpsellSwitch`** because it's generic Jetpack-feature shared infrastructure used beyond Backup (Anti-Spam, Search, etc.). Adding a footer there would change loading-state appearance for every feature using it, which is a much broader discussion than HEADER-008's scope. Worth its own ticket if we want loading-state footers everywhere.

## Why are these changes being made?

#109765 added the simplified Jetpack footer to four Calypso pages (Activity Log, Monetize, Traffic, Podcasting) but explicitly left Backup and Scan out — quoting that PR's description:

> Using the footer at Scan & Backup I'm also leaving for another PR due to a bit more complexity of testing those pages, so this is easier to merge sooner.

This PR closes the Backup half. Scan will follow in a sibling PR (#109888). After both land, JETPACK-1504's checklist will be complete and the parent issue (JETPACK-1391) can tick its remaining Calypso boxes.

## Testing Instructions

### Before / After (happy path, `main.jsx`)

<img width="2294" height="1345" alt="Screenshot 2026-04-08 at 12 39 42" src="https://github.com/user-attachments/assets/8888fbae-24af-431f-bc6c-e238801d495d" />

**Before**: Backup page ends right at the bottom of the "More backups from today" card with empty white space below it — no footer chrome.

<img width="2296" height="1354" alt="Screenshot 2026-04-08 at 12 39 10" src="https://github.com/user-attachments/assets/a3ecb5e4-ecef-4ae9-8b87-5edacc93d8a5" />

**After**: Same content with a new row at the bottom showing the green Jetpack pill on the left and the "An Automattic airline" byline on the right, matching the existing footer on Activity Log / Monetize / Traffic / Podcasting.

### Steps to verify

1. **Happy path**: On a WP.com site with Jetpack Backup active, navigate to `/backup/<site-slug>`. Expected: footer renders at the bottom of the page.
2. **Upsell path (Simple)**: On a WP.com Simple site without Backup, navigate to `/backup/<site-slug>`. The page renders the upsell (`WPCOMUpsellPage` from either `wpcom-backup-upsell.tsx` or `wpcom-upsell.tsx` depending on the plan/feature combo). Expected: footer renders at the bottom.
3. **Atomic transfer path**: On a Business-plan WP.com site that triggers the Atomic transfer flow, navigate to `/backup/<site-slug>`. Expected: footer renders below both the loading placeholder and the transfer CTA.
4. **Jetpack Cloud variant** (if available): Navigate to the same Backup page from the Jetpack Cloud variant and confirm the footer does **not** render — Jetpack Cloud has its own chrome and the `isWpcom` / `isJetpackCloud()` gates suppress the new footer for that platform.
5. Switch to a narrow viewport (≤460px) and confirm the footer wraps cleanly.

### DOM check

Quickly verifiable from the browser console:

```js
document.querySelector( 'footer.jetpack-footer' )
// → <footer class="... jetpack-footer" aria-label="Jetpack" role="contentinfo">…</footer>
```

To confirm there's no duplicate footer rendering:

```js
document.querySelectorAll( 'footer.jetpack-footer' ).length
// → 1
```

### Local validation already performed

**Desktop:**
- ✅ **willstestdotblog.wordpress.com** (Simple, no backup → upsell render path via `WPCOMBusinessAT` → `wpcom-upsell.tsx`): footer present after fix; absent before
- ✅ **curlingforbeginners9.wpcomstaging.com** (Atomic with backup → `main.jsx` happy path): footer present, `footerCount === 1` (no duplicate from the upsell-switch `display` prop chain)

**Mobile viewport (390×844, ≤460px breakpoint):**
- ✅ **Simple upsell path** on willstestdotblog.wordpress.com: footer renders below the "What is Jetpack?" section at the bottom of the page, wraps cleanly, single instance
- ✅ **Atomic happy path** on curlingforbeginners9.wpcomstaging.com: footer renders below the backup activity cards, wraps cleanly, single instance

<!--
Mobile screenshots saved locally at:
- /tmp/calypso-backup-mobile-upsell-simple.png (Simple upsell path, 390x844)
- /tmp/calypso-backup-mobile-happypath-atomic.png (Atomic happy path, 390x844)
Drag-drop these into the GitHub PR description when convenient.
-->

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? — N/A, wiring change with no logic to test
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)? — Simple verified on willstestdotblog.wordpress.com, Atomic verified on curlingforbeginners9.wpcomstaging.com. Self-hosted Jetpack n/a (this code path is wpcom-only by construction).
- [x] Have you checked for TypeScript, React or other console errors? — none in local build; pre-commit Prettier ran clean
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2). — `<footer role="contentinfo" aria-label="Jetpack">` inherits the same a11y as the existing `JetpackFooter` usages
- [x] Have you used memoizing on expensive computations? — N/A, no new computations
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? — no new strings; the footer's "Jetpack" / "An Automattic airline" labels live in `JetpackFooter` itself and are already translated
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? — N/A, no new strings
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)? — no, no tracking or data changes
