### PR TITLE
A4A: Fix bug with WPCOM owned sites count.

### DIFF
--- a/client/a8c-for-agencies/hooks/use-wpcom-owned-sites.ts
+++ b/client/a8c-for-agencies/hooks/use-wpcom-owned-sites.ts
@@ -51,7 +51,9 @@ export default function useWPCOMOwnedSites() {
 		count: isReady
 			? licenses.filter(
 					( license ) =>
-						license.productId === creatorPlan?.product_id &&
+						( license.productId === creatorPlan?.product_id ||
+							license.productId === creatorPlan?.monthly_product_id ||
+							license.productId === creatorPlan?.yearly_product_id ) &&
 						! license.referral && // We make sure we do not count referrals
 						! license.meta?.isDevSite // And also a dev site
 			  ).length


### PR DESCRIPTION
Context: p1775553952413269-slack-C091P0A65U5

## Proposed Changes

This pull request updates the logic for counting owned sites in the `useWPCOMOwnedSites` hook to ensure all relevant product IDs are included. Now, the filter checks for matches against the main, monthly, and yearly product IDs, rather than only the main one.

**Enhancements to owned site counting logic:**

* [`client/a8c-for-agencies/hooks/use-wpcom-owned-sites.ts`](diffhunk://#diff-0714d517266a02ca299b6cce00d1c243f6db80f94add113aee9450c63a6bc4c1L54-R56): Updated the filter to count licenses matching any of `creatorPlan.product_id`, `creatorPlan.monthly_product_id`, or `creatorPlan.yearly_product_id`, ensuring all associated products are considered.

## Why are these changes being made?

* Fixes the bug with WPCOM sites' owner count and prevents some confusion.

## Testing Instructions

* Use the A4A live link and go to the `/marketplace/hosting` page.
* Purchase a WPCOM plan (on a monthly basis).
* Keep an eye on the current site count.
* Ensure that after the purchase, the number of owned sites increases.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?