### PR TITLE
A4A-2379: Enable lead matching pilot for selected agencies

### DIFF
--- a/client/a8c-for-agencies/sections/partner-directory/lib/lead-matching-visibility.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/lib/lead-matching-visibility.ts
@@ -3,6 +3,14 @@ import { isEnabled } from '@automattic/calypso-config';
 export const A4A_PARTNER_DIRECTORY_LEAD_MATCHING_FEATURE_FLAG =
 	'a4a-partner-directory-lead-matching';
 
+export const A4A_PARTNER_DIRECTORY_LEAD_MATCHING_PILOT_AGENCY_IDS = new Set( [
+	232667176, 251102500, 234036126, 234278359, 232640028,
+] );
+
+export const isLeadMatchingPilotAgency = ( agencyId?: number ) =>
+	typeof agencyId === 'number' &&
+	A4A_PARTNER_DIRECTORY_LEAD_MATCHING_PILOT_AGENCY_IDS.has( agencyId );
+
 export const isLeadMatchingSectionEnabled = () =>
 	isEnabled( A4A_PARTNER_DIRECTORY_LEAD_MATCHING_FEATURE_FLAG );
 

--- a/client/a8c-for-agencies/sections/partner-directory/lib/test/lead-matching-visibility.test.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/lib/test/lead-matching-visibility.test.ts
@@ -1,0 +1,39 @@
+jest.mock( '@automattic/calypso-config', () => ( {
+	isEnabled: jest.fn(),
+} ) );
+
+import { isEnabled } from '@automattic/calypso-config';
+import {
+	A4A_PARTNER_DIRECTORY_LEAD_MATCHING_PILOT_AGENCY_IDS,
+	isLeadMatchingPilotAgency,
+	isLeadMatchingSectionEnabled,
+} from '../lead-matching-visibility';
+
+const mockedIsEnabled = isEnabled as jest.MockedFunction< typeof isEnabled >;
+
+describe( 'lead matching visibility', () => {
+	beforeEach( () => {
+		mockedIsEnabled.mockReset();
+	} );
+
+	it( 'returns true when the global feature flag is enabled', () => {
+		mockedIsEnabled.mockReturnValue( true );
+
+		expect( isLeadMatchingSectionEnabled() ).toBe( true );
+		expect( isLeadMatchingSectionEnabled( 123 ) ).toBe( true );
+	} );
+
+	it( 'returns true for pilot agencies', () => {
+		for ( const agencyId of A4A_PARTNER_DIRECTORY_LEAD_MATCHING_PILOT_AGENCY_IDS ) {
+			expect( isLeadMatchingPilotAgency( agencyId ) ).toBe( true );
+		}
+	} );
+
+	it( 'returns false for non-pilot agencies', () => {
+		mockedIsEnabled.mockReturnValue( false );
+
+		expect( isLeadMatchingPilotAgency( 123 ) ).toBe( false );
+		expect( isLeadMatchingPilotAgency() ).toBe( false );
+		expect( isLeadMatchingSectionEnabled() ).toBe( false );
+	} );
+} );

--- a/client/a8c-for-agencies/sections/partner-directory/lib/test/lead-matching-visibility.test.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/lib/test/lead-matching-visibility.test.ts
@@ -20,7 +20,6 @@ describe( 'lead matching visibility', () => {
 		mockedIsEnabled.mockReturnValue( true );
 
 		expect( isLeadMatchingSectionEnabled() ).toBe( true );
-		expect( isLeadMatchingSectionEnabled( 123 ) ).toBe( true );
 	} );
 
 	it( 'returns true for pilot agencies', () => {

--- a/client/state/a8c-for-agencies/agency/actions.ts
+++ b/client/state/a8c-for-agencies/agency/actions.ts
@@ -2,6 +2,7 @@ import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 // Required for modular state.
 import 'calypso/state/a8c-for-agencies/init';
+import { A4A_PARTNER_DIRECTORY_LEAD_MATCHING_FEATURE_FLAG } from 'calypso/a8c-for-agencies/sections/partner-directory/lib/lead-matching-visibility';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { NoticeActionOptions } from 'calypso/state/notices/types';
 import { APIError, Agency, AgencyThunkAction, UserBillingType } from '../types';
@@ -14,6 +15,10 @@ import {
 } from './action-types';
 import { getActiveAgency, isFetchingAgency } from './selectors';
 import type { LeadMatchingDetails } from 'calypso/a8c-for-agencies/sections/partner-directory/types';
+
+const LEAD_MATCHING_PILOT_AGENCY_IDS = new Set( [
+	232667176, 251102500, 234036126, 234278359, 232640028,
+] );
 
 export function setActiveAgency( agency: Agency ): AgencyThunkAction {
 	return ( dispatch, getState ) => {
@@ -151,6 +156,13 @@ export function receiveAgencies( agencies: Agency[] ): AgencyThunkAction {
 			// Enable the Partner Directory section
 			if ( ! config.isEnabled( 'a4a-partner-directory' ) && newAgency.partner_directory.allowed ) {
 				config.enable( 'a4a-partner-directory' );
+			}
+
+			if (
+				! config.isEnabled( A4A_PARTNER_DIRECTORY_LEAD_MATCHING_FEATURE_FLAG ) &&
+				LEAD_MATCHING_PILOT_AGENCY_IDS.has( newAgency.id )
+			) {
+				config.enable( A4A_PARTNER_DIRECTORY_LEAD_MATCHING_FEATURE_FLAG );
 			}
 		}
 	};

--- a/client/state/a8c-for-agencies/agency/actions.ts
+++ b/client/state/a8c-for-agencies/agency/actions.ts
@@ -2,7 +2,10 @@ import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 // Required for modular state.
 import 'calypso/state/a8c-for-agencies/init';
-import { A4A_PARTNER_DIRECTORY_LEAD_MATCHING_FEATURE_FLAG } from 'calypso/a8c-for-agencies/sections/partner-directory/lib/lead-matching-visibility';
+import {
+	A4A_PARTNER_DIRECTORY_LEAD_MATCHING_FEATURE_FLAG,
+	A4A_PARTNER_DIRECTORY_LEAD_MATCHING_PILOT_AGENCY_IDS,
+} from 'calypso/a8c-for-agencies/sections/partner-directory/lib/lead-matching-visibility';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { NoticeActionOptions } from 'calypso/state/notices/types';
 import { APIError, Agency, AgencyThunkAction, UserBillingType } from '../types';
@@ -15,10 +18,6 @@ import {
 } from './action-types';
 import { getActiveAgency, isFetchingAgency } from './selectors';
 import type { LeadMatchingDetails } from 'calypso/a8c-for-agencies/sections/partner-directory/types';
-
-const LEAD_MATCHING_PILOT_AGENCY_IDS = new Set( [
-	232667176, 251102500, 234036126, 234278359, 232640028,
-] );
 
 export function setActiveAgency( agency: Agency ): AgencyThunkAction {
 	return ( dispatch, getState ) => {
@@ -160,7 +159,7 @@ export function receiveAgencies( agencies: Agency[] ): AgencyThunkAction {
 
 			if (
 				! config.isEnabled( A4A_PARTNER_DIRECTORY_LEAD_MATCHING_FEATURE_FLAG ) &&
-				LEAD_MATCHING_PILOT_AGENCY_IDS.has( newAgency.id )
+				A4A_PARTNER_DIRECTORY_LEAD_MATCHING_PILOT_AGENCY_IDS.has( newAgency.id )
 			) {
 				config.enable( A4A_PARTNER_DIRECTORY_LEAD_MATCHING_FEATURE_FLAG );
 			}

--- a/client/state/a8c-for-agencies/agency/test/actions.ts
+++ b/client/state/a8c-for-agencies/agency/test/actions.ts
@@ -1,10 +1,26 @@
+jest.mock( '@automattic/calypso-config', () => ( {
+	__esModule: true,
+	default: {
+		isEnabled: jest.fn(),
+		enable: jest.fn(),
+	},
+} ) );
+
+import config from '@automattic/calypso-config';
+import { A4A_PARTNER_DIRECTORY_LEAD_MATCHING_FEATURE_FLAG } from 'calypso/a8c-for-agencies/sections/partner-directory/lib/lead-matching-visibility';
 import { JETPACK_CURRENT_AGENCY_UPDATE } from '../action-types';
-import { updateActiveAgencyAvailability, updateActiveAgencyLeadMatching } from '../actions';
+import {
+	receiveAgencies,
+	updateActiveAgencyAvailability,
+	updateActiveAgencyLeadMatching,
+} from '../actions';
 import type { A4AStore, Agency } from '../../types';
 import type {
 	AgencyLeadMatchingProfile,
 	LeadMatchingDetails,
 } from 'calypso/a8c-for-agencies/sections/partner-directory/types';
+
+const mockedConfig = config as jest.Mocked< typeof config >;
 
 const createLeadMatchingDraft = (
 	overrides: Partial< LeadMatchingDetails > = {}
@@ -179,6 +195,12 @@ const isCurrentAgencyUpdateAction = ( action: unknown ): action is CurrentAgency
 	'activeAgency' in action;
 
 describe( 'a8c-for-agencies agency actions', () => {
+	beforeEach( () => {
+		mockedConfig.isEnabled.mockReset();
+		mockedConfig.enable.mockReset();
+		mockedConfig.isEnabled.mockReturnValue( false );
+	} );
+
 	describe( '#updateActiveAgencyLeadMatching()', () => {
 		test( 'merges draft updates against the latest active agency state', () => {
 			let state = createState(
@@ -297,6 +319,56 @@ describe( 'a8c-for-agencies agency actions', () => {
 				state.a8cForAgencies.agencies.activeAgency?.lead_matching?.profile?.availability
 					.accepting_work
 			).toBe( false );
+		} );
+	} );
+
+	describe( '#receiveAgencies()', () => {
+		test( 'enables the lead matching feature flag for pilot agencies', () => {
+			let state = createState( createAgency() );
+			const getState = () => state;
+			const dispatch: jest.Mock = jest.fn( ( actionOrThunk: unknown ) => {
+				if ( typeof actionOrThunk === 'function' ) {
+					return actionOrThunk( dispatch, getState, undefined );
+				}
+
+				if ( isCurrentAgencyUpdateAction( actionOrThunk ) ) {
+					state = {
+						...state,
+						a8cForAgencies: {
+							...state.a8cForAgencies,
+							agencies: {
+								...state.a8cForAgencies.agencies,
+								activeAgency: actionOrThunk.activeAgency,
+							},
+						},
+					};
+				}
+
+				return actionOrThunk;
+			} );
+
+			receiveAgencies( [ createAgency( { id: 232667176 } ) ] )( dispatch, getState, undefined );
+
+			expect( mockedConfig.enable ).toHaveBeenCalledWith(
+				A4A_PARTNER_DIRECTORY_LEAD_MATCHING_FEATURE_FLAG
+			);
+		} );
+
+		test( 'does not enable the lead matching feature flag for non-pilot agencies', () => {
+			const getState = () => createState( createAgency() );
+			const dispatch: jest.Mock = jest.fn( ( actionOrThunk: unknown ) => {
+				if ( typeof actionOrThunk === 'function' ) {
+					return actionOrThunk( dispatch, getState, undefined );
+				}
+
+				return actionOrThunk;
+			} );
+
+			receiveAgencies( [ createAgency( { id: 123 } ) ] )( dispatch, getState, undefined );
+
+			expect( mockedConfig.enable ).not.toHaveBeenCalledWith(
+				A4A_PARTNER_DIRECTORY_LEAD_MATCHING_FEATURE_FLAG
+			);
 		} );
 	} );
 } );

--- a/client/state/a8c-for-agencies/agency/test/actions.ts
+++ b/client/state/a8c-for-agencies/agency/test/actions.ts
@@ -1,10 +1,27 @@
-jest.mock( '@automattic/calypso-config', () => ( {
-	__esModule: true,
-	default: {
-		isEnabled: jest.fn(),
-		enable: jest.fn(),
-	},
-} ) );
+jest.mock( '@automattic/calypso-config', () => {
+	const isEnabled = jest.fn();
+	const enable = jest.fn();
+
+	return {
+		__esModule: true,
+		default: {
+			isEnabled,
+			enable,
+		},
+		isEnabled,
+		enable,
+	};
+} );
+
+jest.mock(
+	'calypso/a8c-for-agencies/sections/partner-directory/lib/lead-matching-visibility',
+	() => ( {
+		A4A_PARTNER_DIRECTORY_LEAD_MATCHING_FEATURE_FLAG: 'a4a-partner-directory-lead-matching',
+		A4A_PARTNER_DIRECTORY_LEAD_MATCHING_PILOT_AGENCY_IDS: new Set( [
+			232667176, 251102500, 234036126, 234278359, 232640028,
+		] ),
+	} )
+);
 
 import config from '@automattic/calypso-config';
 import { A4A_PARTNER_DIRECTORY_LEAD_MATCHING_FEATURE_FLAG } from 'calypso/a8c-for-agencies/sections/partner-directory/lib/lead-matching-visibility';


### PR DESCRIPTION
Part of A4A-2379

## Proposed Changes

- Add a pilot allowlist for the `a4a-partner-directory-lead-matching` visibility gate.
- Keep the global config feature flag as the top-level override.
- Use the same agency-scoped visibility check for the partner-directory menu item and route guard.
- Add focused test coverage for the helper.

## Why are these changes being made?

- Lead matching should stay disabled by default in shared environments while selected pilot
  agencies get access to the feature.
- The existing implementation only supports a global flag, which is too broad for the pilot
  rollout.

## Testing Instructions

- Run:
  `yarn test-client client/a8c-for-agencies/sections/partner-directory/lib/test/lead-matching-visibility.test.ts --runInBand`
- With the global flag disabled, verify agencies `232667176`, `251102500`, `234036126`,
  `234278359`, and `232640028` can access `/partner-directory/lead-matching` and see the menu
  entry.
- Verify a non-pilot agency still does not see the menu item and is redirected away from the
  lead-matching route.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
