### PR TITLE
Subscribers: add comp filter for subscription type

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -432,11 +432,20 @@ export default function SubscriberDataViews( {
 			{
 				id: 'plan',
 				label: translate( 'Subscription type' ),
-				getValue: ( { item }: { item: Subscriber } ) =>
-					item.plans?.length ? SubscribersFilterBy.Paid : SubscribersFilterBy.Free,
+				getValue: ( { item }: { item: Subscriber } ) => {
+					const hasNonCompPlan = item.plans?.some( ( plan ) => ! plan.is_comp );
+					if ( hasNonCompPlan ) {
+						return SubscribersFilterBy.Paid;
+					}
+					if ( item.plans?.length ) {
+						return SubscribersFilterBy.Comp;
+					}
+					return SubscribersFilterBy.Free;
+				},
 				render: ( { item }: { item: Subscriber } ) => <SubscriptionTypeCell subscriber={ item } />,
 				elements: [
 					{ label: translate( 'Paid' ), value: SubscribersFilterBy.Paid },
+					{ label: translate( 'Comp' ), value: SubscribersFilterBy.Comp },
 					{ label: translate( 'Free' ), value: SubscribersFilterBy.Free },
 				],
 				filterBy: {

--- a/client/my-sites/subscribers/constants.ts
+++ b/client/my-sites/subscribers/constants.ts
@@ -13,6 +13,7 @@ export enum SubscribersFilterBy {
 	WPCOM = 'wpcom',
 	Free = 'free',
 	Paid = 'paid',
+	Comp = 'comp',
 	ReaderSubscriber = 'reader_subscriber',
 	UnconfirmedSubscriber = 'unconfirmed_subscriber',
 	EmailSubscriber = 'email_subscriber',


### PR DESCRIPTION
## Summary
- Adds a Comp option to the subscription type filter in the subscribers list, allowing site owners to filter subscribers by complimentary subscriptions
- Updates the plan getValue to correctly categorize subscribers as Paid, Comp, or Free (previously comp subscribers were grouped under Paid)
- Frontend implementation for 210960-ghe-Automattic/wpcom

## Test plan
- [x] Navigate to Subscribers page
- [x] Open the Subscription type filter
- [x] Verify Comp appears as a filter option between Paid and Free
- [x] Select Comp filter and verify only comp subscribers are shown
- [x] Verify Paid filter no longer includes comp subscribers