### PR TITLE
[DRAFT] Reader: random fixes

### DIFF
--- a/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
+++ b/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
@@ -16,6 +16,7 @@ import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
 import { isConversationFollowable } from 'calypso/reader/post/capabilities';
 import * as stats from 'calypso/reader/stats';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { successNotice } from 'calypso/state/notices/actions';
 import * as PostUtils from 'calypso/state/posts/utils';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import { hasReaderFollowOrganization } from 'calypso/state/reader/follows/selectors';
@@ -65,9 +66,20 @@ class ReaderPostEllipsisMenu extends Component {
 		posts: [],
 	};
 
-	openSuggestedFollowsModal = ( shouldOpen ) => {
-		if ( shouldOpen ) {
-			this.props.openSuggestedFollows( shouldOpen );
+	onFollowToggle = ( isFollowing ) => {
+		const { post, translate } = this.props;
+		const displayName = post.site_name || post.feed_URL || post.site_URL;
+
+		this.props.successNotice(
+			isFollowing
+				? translate( 'Success! You are now subscribed to "%s".', { args: displayName } )
+				: translate( 'Success! You are now unsubscribed from "%s".', { args: displayName } ),
+			{ duration: 2000 }
+		);
+
+		if ( isFollowing ) {
+			this.props.openSuggestedFollows( isFollowing );
+			this.onMenuToggle();
 		}
 	};
 
@@ -298,12 +310,12 @@ class ReaderPostEllipsisMenu extends Component {
 					<ReaderFollowButton
 						tagName={ PopoverMenuItem }
 						feedId={ feedId }
-						siteId={ siteId }
+						siteId={ post.is_external ? null : siteId }
 						siteUrl={ post.feed_URL || post.site_URL }
 						followSource={ followSource }
 						iconSize={ 24 }
 						followingLabel={ translate( 'Subscribed' ) }
-						onFollowToggle={ this.openSuggestedFollowsModal }
+						onFollowToggle={ this.onFollowToggle }
 						railcar={ post.railcar }
 					/>
 				) }
@@ -413,5 +425,6 @@ export default connect(
 		requestMarkAsSeenBlog,
 		requestMarkAsUnseenBlog,
 		recordReaderTracksEvent,
+		successNotice,
 	}
 )( localize( ReaderPostEllipsisMenu ) );

--- a/client/blocks/reader-suggested-follows/index.jsx
+++ b/client/blocks/reader-suggested-follows/index.jsx
@@ -33,9 +33,6 @@ export const SuggestedFollowItem = ( { site, followSource } ) => {
 						className="reader-suggested-follow-item_link"
 						href={ streamUrl }
 						onClick={ () => onSiteClick( site ) }
-						aria-hidden="true"
-						target="_blank"
-						rel="noreferrer"
 					>
 						<span>
 							<SiteIcon iconUrl={ site.site_icon } size={ 48 } />

--- a/client/blocks/reader-suggested-follows/index.jsx
+++ b/client/blocks/reader-suggested-follows/index.jsx
@@ -1,4 +1,5 @@
 import './style.scss';
+import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { SiteIcon } from 'calypso/blocks/site-icon';
 import FollowButton from 'calypso/reader/follow-button';
@@ -6,10 +7,28 @@ import { formatUrlForDisplay } from 'calypso/reader/lib/feed-display-helper';
 import { getStreamUrl } from 'calypso/reader/route';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { useDispatch } from 'calypso/state';
+import { successNotice } from 'calypso/state/notices/actions';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 export const SuggestedFollowItem = ( { site, followSource } ) => {
 	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	const streamUrl = getStreamUrl( site?.feed_ID, site?.blog_ID );
+	const urlForDisplay = site && site.URL ? formatUrlForDisplay( site.URL ) : '';
+
+	const onFollowToggle = ( isFollowing ) => {
+		const displayName = site.name || urlForDisplay;
+
+		dispatch(
+			successNotice(
+				isFollowing
+					? translate( 'Success! You are now subscribed to %s.', { args: displayName } )
+					: translate( 'Success! You are now unsubscribed from "%s".', { args: displayName } ),
+				{ duration: 2000 }
+			)
+		);
+	};
 
 	const onSiteClick = ( selectedSite ) => {
 		recordAction( 'clicked_reader_suggested_following_item' );
@@ -20,9 +39,6 @@ export const SuggestedFollowItem = ( { site, followSource } ) => {
 			} )
 		);
 	};
-
-	const streamUrl = getStreamUrl( site?.feed_ID, site?.blog_ID );
-	const urlForDisplay = site && site.URL ? formatUrlForDisplay( site.URL ) : '';
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
@@ -49,7 +65,11 @@ export const SuggestedFollowItem = ( { site, followSource } ) => {
 						</span>
 					</a>
 					<span className="reader-suggested-follow-button">
-						<FollowButton siteUrl={ site.URL } followSource={ followSource } />
+						<FollowButton
+							siteUrl={ site.URL }
+							followSource={ followSource }
+							onFollowToggle={ onFollowToggle }
+						/>
 					</span>
 				</>
 			) }

--- a/client/blocks/reader-suggested-follows/style.scss
+++ b/client/blocks/reader-suggested-follows/style.scss
@@ -118,18 +118,6 @@
 		.reader-suggested-follow-item_nameurl {
 			margin-bottom: 3px;
 		}
-		.reader-suggested-follow-item_nameurl::after {
-			content: "";
-			background-image: url("data:image/svg+xml,%3Csvg fill='none' height='20' viewBox='0 0 20 20' width='20' xmlns='http://www.w3.org/2000/svg'%3E%3Cg stroke='%23101517' stroke-linecap='square' stroke-width='1.5'%3E%3Cpath d='m5.8335 14.1666 7.3333-7.33335' stroke-linejoin='round'/%3E%3Cpath d='m6.8335 5.83325h7.3333v7.33335'/%3E%3C/g%3E%3C/svg%3E"); /* stylelint-disable function-url-quotes */
-			background-repeat: no-repeat;
-			background-size: 20px 20px;
-			display: inline-block;
-			height: 20px;
-			margin-left: 3px;
-			position: relative;
-			top: 5px;
-			width: 20px;
-		}
 	}
 
 	.reader-recommended-follows-dialog__follow-item {

--- a/client/reader/site-subscriptions-manager/unsubscribed-feeds-search-list/index.tsx
+++ b/client/reader/site-subscriptions-manager/unsubscribed-feeds-search-list/index.tsx
@@ -4,6 +4,7 @@ import { Reader, SubscriptionManager } from '@automattic/data-stores';
 import { useQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack, Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { useDebounce } from 'use-debounce';
 import ReaderFeedItem from 'calypso/blocks/reader-feed-item';
 import FeedPreview from 'calypso/landing/subscriptions/components/feed-preview';
 import { SOURCE_SUBSCRIPTIONS_SEARCH_RECOMMENDATION_LIST } from 'calypso/landing/subscriptions/tracks';
@@ -17,6 +18,7 @@ interface Props {
 export const UnsubscribedFeedsSearchList = ( props: Props ) => {
 	const { hideTitle = false } = props;
 	const { searchTerm } = useSiteSubscriptionsQueryProps();
+	const [ debouncedSearchTerm ] = useDebounce( searchTerm, 500 );
 	const { isPending: isUnsubscribing } = useSiteUnsubscribeMutation();
 	const translate = useTranslate();
 	const {
@@ -30,7 +32,7 @@ export const UnsubscribedFeedsSearchList = ( props: Props ) => {
 		error: searchError,
 	} = useQuery(
 		readFeedSearchQuery( {
-			query: searchTerm,
+			query: debouncedSearchTerm,
 			excludeFollowed: true,
 		} )
 	);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
