### PR TITLE
Reader: For external RSS feeds use site avatar as author avatar

### DIFF
--- a/client/blocks/reader-full-post/header-meta.jsx
+++ b/client/blocks/reader-full-post/header-meta.jsx
@@ -1,25 +1,29 @@
 import { TimeSince } from '@automattic/components';
 import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
 import ReaderAuthorLink from 'calypso/blocks/reader-author-link';
 import ReaderSiteStreamLink from 'calypso/blocks/reader-site-stream-link';
 import UserAvatar from 'calypso/blocks/user-avatar';
 import { areEqualIgnoringWhitespaceAndCase } from 'calypso/lib/string';
 import { getStreamUrl } from 'calypso/reader/route';
+import { getFeed } from 'calypso/state/reader/feeds/selectors';
 
 const ReaderFullPostHeaderMeta = ( { post, author, siteName, feedId, siteId } ) => {
 	const streamUrl = getStreamUrl( feedId, siteId );
-
+	const feed = useSelector( ( state ) => getFeed( state, feedId ) );
 	const hasAuthorName = author?.name;
 	const hasMatchingAuthorAndSiteNames =
 		hasAuthorName &&
 		areEqualIgnoringWhitespaceAndCase( String( siteName ), String( author?.name ) );
 	const showAuthorLink = hasAuthorName && ! hasMatchingAuthorAndSiteNames;
+	const avatarUrl =
+		! author.avatar_URL && post.is_external ? feed?.site_icon || feed?.image : author?.avatar_URL;
 
 	return (
 		<div className="reader-full-post__header-meta-wrapper">
 			<UserAvatar
 				className="reader-full-post__header-meta-avatars"
-				user={ author }
+				user={ { ...author, avatar_URL: avatarUrl } }
 				iconSize={ 40 }
 			/>
 			<div className="reader-full-post__header-meta-info">

--- a/client/blocks/reader-full-post/test/header-meta.jsx
+++ b/client/blocks/reader-full-post/test/header-meta.jsx
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+import UserAvatar from 'calypso/blocks/user-avatar';
+import { getFeed } from 'calypso/state/reader/feeds/selectors';
+import ReaderFullPostHeaderMeta from '../header-meta';
+
+jest.mock( '@automattic/components', () => ( {
+	TimeSince: () => null,
+} ) );
+
+jest.mock( 'calypso/blocks/user-avatar', () => jest.fn( () => null ) );
+
+jest.mock( 'calypso/state/reader/feeds/selectors', () => ( {
+	getFeed: jest.fn(),
+} ) );
+
+const createMockStore = () => {
+	const reducer = ( state = {} ) => state;
+	return createStore( reducer );
+};
+
+const renderHeaderMeta = ( { post, author, siteName, feedId, siteId } = {} ) => {
+	const store = createMockStore();
+	return render(
+		<Provider store={ store }>
+			<ReaderFullPostHeaderMeta
+				post={ post }
+				author={ author }
+				siteName={ siteName }
+				feedId={ feedId }
+				siteId={ siteId }
+			/>
+		</Provider>
+	);
+};
+
+describe( 'ReaderFullPostHeaderMeta avatar fallback', () => {
+	const testAuthor = { name: 'Test Author', avatar_URL: 'https://example.com/author-avatar.png' };
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		getFeed.mockReturnValue( undefined );
+	} );
+
+	it( 'keeps author avatar when one already exists', () => {
+		getFeed.mockReturnValue( {
+			site_icon: 'https://example.com/site-icon.png',
+		} );
+
+		renderHeaderMeta( {
+			author: testAuthor,
+			post: { is_external: true },
+		} );
+
+		const avatarProps = UserAvatar.mock.calls[ 0 ][ 0 ];
+		expect( avatarProps.user.avatar_URL ).toBe( 'https://example.com/author-avatar.png' );
+	} );
+
+	it( 'uses feed site_icon when author avatar is missing for external posts', () => {
+		getFeed.mockReturnValue( {
+			site_icon: 'https://example.com/site-icon.png',
+			image: 'https://example.com/feed-image.png',
+		} );
+
+		renderHeaderMeta( {
+			post: { is_external: true },
+			author: { ...testAuthor, avatar_URL: undefined },
+		} );
+
+		const avatarProps = UserAvatar.mock.calls[ 0 ][ 0 ];
+		expect( avatarProps.user.avatar_URL ).toBe( 'https://example.com/site-icon.png' );
+	} );
+
+	it( 'falls back to feed image when feed site_icon is unavailable', () => {
+		getFeed.mockReturnValue( {
+			image: 'https://example.com/feed-image.png',
+		} );
+
+		renderHeaderMeta( {
+			post: { is_external: true },
+			author: { ...testAuthor, avatar_URL: undefined },
+		} );
+
+		const avatarProps = UserAvatar.mock.calls[ 0 ][ 0 ];
+		expect( avatarProps.user.avatar_URL ).toBe( 'https://example.com/feed-image.png' );
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes: [READ-462](https://linear.app/a8c/issue/READ-462/reader-show-site-icon-as-author-image-for-rss-feeds)

## Proposed Changes

For external RSS feeds we don't have author avatars so for that use site avatars.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to RSS feeds (e.g. `/reader/feeds/114856417`)
- Verify full post view show site icon as author avatars.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
