### PR TITLE
Reader: Adds caller param to users/sites endpoint

### DIFF
--- a/client/reader/user-profile/queries/use-user-sites-query.ts
+++ b/client/reader/user-profile/queries/use-user-sites-query.ts
@@ -1,5 +1,10 @@
 import { callApi } from '@automattic/data-stores/src/reader';
 import { UseQueryResult, useQuery } from '@tanstack/react-query';
+import { addQueryArgs } from '@wordpress/url';
+
+interface UserSitesQueryParams {
+	caller: string; // To identify the caller of the API which filter the sites accordingly.
+}
 
 export interface UserSitesResponse {
 	total: number;
@@ -31,7 +36,9 @@ export default function useUserSitesQuery(
 		queryFn: () =>
 			callApi< UserSitesResponse >( {
 				apiNamespace: 'wpcom/v2',
-				path: `/users/${ userId }/sites`,
+				path: addQueryArgs( `/users/${ userId }/sites`, {
+					caller: 'reader',
+				} as UserSitesQueryParams ),
 				method: 'GET',
 				isLoggedIn: true,
 				apiVersion: '2',

--- a/client/reader/user-profile/queries/use-user-sites-query.ts
+++ b/client/reader/user-profile/queries/use-user-sites-query.ts
@@ -2,10 +2,6 @@ import { callApi } from '@automattic/data-stores/src/reader';
 import { UseQueryResult, useQuery } from '@tanstack/react-query';
 import { addQueryArgs } from '@wordpress/url';
 
-interface UserSitesQueryParams {
-	caller: string; // To identify the caller of the API which filter the sites accordingly.
-}
-
 export interface UserSitesResponse {
 	total: number;
 	primary_site_id: number;
@@ -37,8 +33,8 @@ export default function useUserSitesQuery(
 			callApi< UserSitesResponse >( {
 				apiNamespace: 'wpcom/v2',
 				path: addQueryArgs( `/users/${ userId }/sites`, {
-					caller: 'reader',
-				} as UserSitesQueryParams ),
+					caller: 'reader', // To identify the caller of the API which filter the sites accordingly.
+				} ),
 				method: 'GET',
 				isLoggedIn: true,
 				apiVersion: '2',


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes: [READ-470](https://linear.app/a8c/issue/READ-470/user-profile-filter-sites-based-on-stickers)
BE PR: 210992-ghe-Automattic/wpcom

## Proposed Changes

Add `caller` query param to the `users/sites` endpoint which filters the sites for the Reader.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to any user profile page.
- Verify `users/:id/sites` endpoint is called with `caller=reader` param.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?