### PR TITLE
Sticky Jetpack footer + fixed primary layout across admin pages

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/jetpack/style.scss
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/style.scss
@@ -3,11 +3,6 @@
 		display: none !important;
 	}
 
-	.backup__last-backup-status {
-		padding: initial;
-		background: initial;
-	}
-
 	.dataviews-view-table__row {
 		cursor: pointer;
 	}

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -145,12 +145,6 @@
 
 		.hosting-dashboard-item-view__content {
 			padding: 10px 10px 88px; /* 88px matches the padding from PR #39201. */
-
-			.backup__page .main {
-				/* Prevents the backup page from overriding our padding and overflow settings. */
-				padding-bottom: 88px; /* 88px matches the padding from PR #39201. */
-				overflow: hidden;
-			}
 		}
 	}
 

--- a/client/components/jetpack-page-layout/_admin-ui-page.scss
+++ b/client/components/jetpack-page-layout/_admin-ui-page.scss
@@ -50,7 +50,14 @@
 				margin: 0;
 				flex-grow: 1;
 				position: relative;
-				padding-bottom: 65px;
+
+				// Only reserve bottom space when a Jetpack footer is actually
+				// rendered. Pages without a footer (e.g. Jetpack Cloud views)
+				// get the fixed-primary structural hack without the wasted
+				// padding.
+				&:has(> .jetpack-footer) {
+					padding-bottom: 65px;
+				}
 
 				.jetpack-footer {
 					position: fixed;

--- a/client/components/jetpack-page-layout/_admin-ui-page.scss
+++ b/client/components/jetpack-page-layout/_admin-ui-page.scss
@@ -24,6 +24,41 @@
 	}
 }
 
+// Stick the Jetpack footer to the viewport bottom while letting the page
+// body absorb remaining vertical space. Flex chain runs
+// .layout__content → .layout__primary → .main, with the footer pinned via
+// `position: fixed` and width-matched to the content column on desktop.
+// Usage: @include admin-ui-page-sticky-footer;
+// Must be called inside a `body.is-section-<name>` selector.
+@mixin admin-ui-page-sticky-footer {
+	.layout__content {
+		display: flex;
+
+		.layout__primary {
+			flex: 1;
+			display: flex;
+
+			.main {
+				margin: 0;
+				flex-grow: 1;
+				position: relative;
+				padding-bottom: 65px;
+
+				.jetpack-footer {
+					position: fixed;
+					z-index: 1;
+					bottom: 0;
+					background-color: var(--wpds-color-bg-surface-neutral);
+
+					@include break-medium {
+						max-width: calc(100% - var(--sidebar-width-max));
+					}
+				}
+			}
+		}
+	}
+}
+
 // Constrain admin-ui Page content width, centered.
 // Pass a $scope selector to limit to specific page variants (e.g. upsell pages).
 // Pass $max-width to override the default 660px (e.g. 1040px for wider content).

--- a/client/components/jetpack-page-layout/_admin-ui-page.scss
+++ b/client/components/jetpack-page-layout/_admin-ui-page.scss
@@ -55,6 +55,12 @@
 			}
 
 			.main {
+
+				margin-block: 0;
+
+				@include break-medium {	
+					margin-block: var(--wpds-dimension-padding-2xl);
+				}
 				// Only fill the fixed-primary column when the page renders an
 				// admin-ui <Page> inside <Main>. Pages that render content
 				// directly in <Main> (e.g. wideLayout views without a <Page>
@@ -62,7 +68,6 @@
 				// JP Cloud code paths of Scan/Backup/AL v2) keep .main's
 				// default `margin: auto` + `max-width` centering.
 				&:has(> .admin-ui-page) {
-					margin: 0;
 					flex-grow: 1;
 					position: relative;
 				}
@@ -75,7 +80,6 @@
 				// horizontal `margin: auto` still handles wideLayout
 				// centering.
 				&:not(:has(> .admin-ui-page)) {
-					margin-block: 0;
 					margin-inline: auto;
 					flex-grow: 1;
 				}

--- a/client/components/jetpack-page-layout/_admin-ui-page.scss
+++ b/client/components/jetpack-page-layout/_admin-ui-page.scss
@@ -37,6 +37,14 @@
 		.layout__primary {
 			flex: 1;
 			display: flex;
+			position: fixed;
+			top: var( --masterbar-height );
+			height: calc(100vh - var(--masterbar-height));
+			width: 100vw;
+
+			@include break-medium {
+				width: calc(100vw - var(--sidebar-width-max));
+			}
 
 			.main {
 				margin: 0;

--- a/client/components/jetpack-page-layout/_admin-ui-page.scss
+++ b/client/components/jetpack-page-layout/_admin-ui-page.scss
@@ -67,6 +67,19 @@
 					position: relative;
 				}
 
+				// Pages without an admin-ui <Page> wrapper inherit the base
+				// `.main { margin: auto }` rule. In the now-flex
+				// .layout__primary that turns into vertical auto-margin
+				// absorption, centering short content in the viewport. Kill
+				// the vertical auto margins so content top-aligns normally;
+				// horizontal `margin: auto` still handles wideLayout
+				// centering.
+				&:not(:has(> .admin-ui-page)) {
+					margin-block: 0;
+					margin-inline: auto;
+					flex-grow: 1;
+				}
+
 				// Only reserve bottom space when a Jetpack footer is actually
 				// rendered. Pages without a footer (e.g. Jetpack Cloud views)
 				// get the fixed-primary structural hack without the wasted

--- a/client/components/jetpack-page-layout/_admin-ui-page.scss
+++ b/client/components/jetpack-page-layout/_admin-ui-page.scss
@@ -42,6 +42,14 @@
 			height: calc(100vh - var(--masterbar-height));
 			width: 100vw;
 
+			// Jetpack Cloud uses 100vh except on mobile where it shows a sidebar navigation on top (73px)
+			&:has(header.current-section) {
+				height: calc(100vh - 73px);
+				@include break-medium {
+					height: 100vh;
+				}
+			}
+
 			@include break-medium {
 				width: calc(100vw - var(--sidebar-width-max));
 			}
@@ -51,7 +59,7 @@
 			// AL v2, which render content directly inside <Main>), make the
 			// fixed-primary itself scrollable so content isn't clipped.
 			&:not(:has(.admin-ui-page)) {
-				overflow-y: auto;
+				overflow: hidden auto;
 			}
 
 			.main {
@@ -59,7 +67,10 @@
 				margin-block: 0;
 
 				@include break-medium {	
-					margin-block: var(--wpds-dimension-padding-2xl);
+					body.theme-jetpack-cloud &,
+					body.theme-a8c-for-agencies & {
+						margin-block: var(--wpds-dimension-padding-2xl);
+					}
 				}
 				// Only fill the fixed-primary column when the page renders an
 				// admin-ui <Page> inside <Main>. Pages that render content

--- a/client/components/jetpack-page-layout/_admin-ui-page.scss
+++ b/client/components/jetpack-page-layout/_admin-ui-page.scss
@@ -47,9 +47,17 @@
 			}
 
 			.main {
-				margin: 0;
-				flex-grow: 1;
-				position: relative;
+				// Only fill the fixed-primary column when the page renders an
+				// admin-ui <Page> inside <Main>. Pages that render content
+				// directly in <Main> (e.g. wideLayout views without a <Page>
+				// wrapper like Earn's paid-subscription detail screen, or the
+				// JP Cloud code paths of Scan/Backup/AL v2) keep .main's
+				// default `margin: auto` + `max-width` centering.
+				&:has(> .admin-ui-page) {
+					margin: 0;
+					flex-grow: 1;
+					position: relative;
+				}
 
 				// Only reserve bottom space when a Jetpack footer is actually
 				// rendered. Pages without a footer (e.g. Jetpack Cloud views)

--- a/client/components/jetpack-page-layout/_admin-ui-page.scss
+++ b/client/components/jetpack-page-layout/_admin-ui-page.scss
@@ -54,45 +54,16 @@
 				width: calc(100vw - var(--sidebar-width-max));
 			}
 
-			// When no admin-ui <Page> provides a .admin-ui-page__content
-			// scroll container (e.g. Jetpack Cloud views of Scan / Backup /
-			// AL v2, which render content directly inside <Main>), make the
-			// fixed-primary itself scrollable so content isn't clipped.
-			&:not(:has(.admin-ui-page)) {
-				overflow: hidden auto;
-			}
-
 			.main {
-
+				flex-grow: 1;
+				position: relative;
 				margin-block: 0;
 
-				@include break-medium {	
+				@include break-medium {
 					body.theme-jetpack-cloud &,
 					body.theme-a8c-for-agencies & {
 						margin-block: var(--wpds-dimension-padding-2xl);
 					}
-				}
-				// Only fill the fixed-primary column when the page renders an
-				// admin-ui <Page> inside <Main>. Pages that render content
-				// directly in <Main> (e.g. wideLayout views without a <Page>
-				// wrapper like Earn's paid-subscription detail screen, or the
-				// JP Cloud code paths of Scan/Backup/AL v2) keep .main's
-				// default `margin: auto` + `max-width` centering.
-				&:has(> .admin-ui-page) {
-					flex-grow: 1;
-					position: relative;
-				}
-
-				// Pages without an admin-ui <Page> wrapper inherit the base
-				// `.main { margin: auto }` rule. In the now-flex
-				// .layout__primary that turns into vertical auto-margin
-				// absorption, centering short content in the viewport. Kill
-				// the vertical auto margins so content top-aligns normally;
-				// horizontal `margin: auto` still handles wideLayout
-				// centering.
-				&:not(:has(> .admin-ui-page)) {
-					margin-inline: auto;
-					flex-grow: 1;
 				}
 
 				// Only reserve bottom space when a Jetpack footer is actually

--- a/client/components/jetpack-page-layout/_admin-ui-page.scss
+++ b/client/components/jetpack-page-layout/_admin-ui-page.scss
@@ -46,6 +46,14 @@
 				width: calc(100vw - var(--sidebar-width-max));
 			}
 
+			// When no admin-ui <Page> provides a .admin-ui-page__content
+			// scroll container (e.g. Jetpack Cloud views of Scan / Backup /
+			// AL v2, which render content directly inside <Main>), make the
+			// fixed-primary itself scrollable so content isn't clipped.
+			&:not(:has(.admin-ui-page)) {
+				overflow-y: auto;
+			}
+
 			.main {
 				// Only fill the fixed-primary column when the page renders an
 				// admin-ui <Page> inside <Main>. Pages that render content

--- a/client/components/sidebar-navigation/style.scss
+++ b/client/components/sidebar-navigation/style.scss
@@ -3,7 +3,6 @@
  */
 .current-section {
 	position: relative;
-	margin: 0 -16px;
 
 	@include breakpoint-deprecated( ">660px" ) {
 		display: none;

--- a/client/jetpack-cloud/sections/jetpack-social/promo.jsx
+++ b/client/jetpack-cloud/sections/jetpack-social/promo.jsx
@@ -5,6 +5,7 @@ import {
 } from '@automattic/calypso-products';
 import { format as formatUrl, getUrlParts, getUrlFromParts } from '@automattic/calypso-url';
 import { Gridicon } from '@automattic/components';
+import { Page } from '@wordpress/admin-ui';
 import { localize } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { connect, useDispatch } from 'react-redux';
@@ -16,6 +17,7 @@ import QuerySiteProducts from 'calypso/components/data/query-site-products';
 import JetpackRnaActionCard from 'calypso/components/jetpack/card/jetpack-rna-action-card';
 import UpsellProductCard from 'calypso/components/jetpack/upsell-product-card';
 import Main from 'calypso/components/main';
+import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import { preventWidows } from 'calypso/lib/formatting';
 import slugToSelectorProduct from 'calypso/my-sites/plans/jetpack-plans/slug-to-selector-product';
 import { useSelector } from 'calypso/state';
@@ -58,43 +60,46 @@ export const Promo = ( { adminUrl, pluginInstallUrl, translate, siteId } ) => {
 		: translate( 'Get Started' );
 
 	return (
-		<Main wideLayout className="jetpack-social__promo">
+		<Main fullWidthLayout className="jetpack-social__promo">
 			<DocumentHead title={ titleHeader } />
+			<SidebarNavigation />
 			<QueryProductsList type="jetpack" />
 			{ siteId && <QueryIntroOffers siteId={ siteId } /> }
 			{ siteId && <QuerySiteProducts siteId={ siteId } /> }
-			<div className="jetpack-social__promo-content">
-				{
-					// If the site already has a paid plan active, show the publicize activation card.
-					hasPaidFeatures || isLoadingFeatures ? (
-						<JetpackRnaActionCard
-							headerText={ product.displayName }
-							subHeaderText={ product.description }
-							cardImage={ SocialImage }
-							cardImageAlt={ ctaButtonLabel }
-							// Disable the button while we're loading the features.
-							ctaButtonURL={ isLoadingFeatures ? '' : ctaButtonURL }
-							ctaButtonLabel={ ctaButtonLabel }
-							ctaButtonExternal
-						>
-							<ul className="jetpack-social__features">
-								{ product.features.items.map( ( feature ) => (
-									<li className="jetpack-social__feature" key={ feature.slug }>
-										<Gridicon size={ 18 } icon="checkmark" /> { preventWidows( feature.text ) }
-									</li>
-								) ) }
-							</ul>
-						</JetpackRnaActionCard>
-					) : (
-						<UpsellProductCard
-							featureType={ FEATURE_TYPE_JETPACK_SOCIAL }
-							nonManageProductSlug={ PRODUCT_JETPACK_SOCIAL_V1_YEARLY }
-							siteId={ siteId }
-							onCtaButtonClick={ onClick }
-						/>
-					)
-				}
-			</div>
+			<Page hasPadding showSidebarToggle={ false }>
+				<div className="jetpack-social__promo-content">
+					{
+						// If the site already has a paid plan active, show the publicize activation card.
+						hasPaidFeatures || isLoadingFeatures ? (
+							<JetpackRnaActionCard
+								headerText={ product.displayName }
+								subHeaderText={ product.description }
+								cardImage={ SocialImage }
+								cardImageAlt={ ctaButtonLabel }
+								// Disable the button while we're loading the features.
+								ctaButtonURL={ isLoadingFeatures ? '' : ctaButtonURL }
+								ctaButtonLabel={ ctaButtonLabel }
+								ctaButtonExternal
+							>
+								<ul className="jetpack-social__features">
+									{ product.features.items.map( ( feature ) => (
+										<li className="jetpack-social__feature" key={ feature.slug }>
+											<Gridicon size={ 18 } icon="checkmark" /> { preventWidows( feature.text ) }
+										</li>
+									) ) }
+								</ul>
+							</JetpackRnaActionCard>
+						) : (
+							<UpsellProductCard
+								featureType={ FEATURE_TYPE_JETPACK_SOCIAL }
+								nonManageProductSlug={ PRODUCT_JETPACK_SOCIAL_V1_YEARLY }
+								siteId={ siteId }
+								onCtaButtonClick={ onClick }
+							/>
+						)
+					}
+				</div>
+			</Page>
 		</Main>
 	);
 };

--- a/client/jetpack-cloud/sections/jetpack-social/promo.scss
+++ b/client/jetpack-cloud/sections/jetpack-social/promo.scss
@@ -1,3 +1,10 @@
+@import "calypso/components/jetpack-page-layout/admin-ui-page";
+
+body.is-section-jetpack-social {
+	@include admin-ui-page-layout;
+	@include admin-ui-page-sticky-footer;
+}
+
 .jetpack-social__features {
 	list-style: none;
 	margin: 0 0 24px;

--- a/client/jetpack-cloud/style.scss
+++ b/client/jetpack-cloud/style.scss
@@ -14,8 +14,6 @@
 
 	.main:not(.is-wide-layout) {
 		box-sizing: border-box;
-		padding-left: 16px;
-		padding-right: 16px;
 	}
 
 	input::placeholder {

--- a/client/my-sites/activity/activity-log-v2/index.tsx
+++ b/client/my-sites/activity/activity-log-v2/index.tsx
@@ -1,8 +1,5 @@
 import { WPCOM_FEATURES_FULL_ACTIVITY_LOG } from '@automattic/calypso-products';
-import { Button } from '@automattic/components';
 import { Page } from '@wordpress/admin-ui';
-import { Tooltip } from '@wordpress/components';
-import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import TimeMismatchWarning from 'calypso/blocks/time-mismatch-warning';
 import ActivityCardList from 'calypso/components/activity-card-list';
@@ -19,7 +16,6 @@ import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { preventWidows } from 'calypso/lib/formatting';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import { backupClonePath } from 'calypso/my-sites/backup/paths';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { hasJetpackPartnerAccess as hasJetpackPartnerAccessSelector } from 'calypso/state/partner-portal/partner/selectors';
@@ -27,7 +23,6 @@ import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filte
 import getActivityLogHiddenGroups from 'calypso/state/selectors/get-activity-log-hidden-groups';
 import getSettingsUrl from 'calypso/state/selectors/get-settings-url';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
-import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import type { FunctionComponent } from 'react';
@@ -39,7 +34,6 @@ const ActivityLogV2: FunctionComponent = () => {
 	const dispatch = useDispatch();
 
 	const siteId = useSelector( getSelectedSiteId );
-	const isAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, siteId as number ) );
 	const isWPCOMSite = useSelector( ( state ) => getIsSiteWPCOM( state, siteId ) );
 	const filter = useSelector( ( state ) => getActivityLogFilter( state, siteId ) );
 	const notGroup = useSelector( ( state ) => getActivityLogHiddenGroups( state, siteId ) );
@@ -53,6 +47,10 @@ const ActivityLogV2: FunctionComponent = () => {
 	);
 	const settingsUrl = useSelector( ( state ) => getSettingsUrl( state, siteId, 'general' ) );
 
+	const isJetpackPlatform = isJetpackCloud() || isA8CForAgencies();
+	const showHeader = ! isJetpackPlatform;
+	const showUpsell = isJetpackPlatform && ! isWPCOMSite && ! siteHasFullActivityLog;
+
 	let upsellURL;
 	if ( hasJetpackPartnerAccess && ! isA8CForAgencies() ) {
 		upsellURL = `/partner-portal/issue-license?site_id=${ siteId }`;
@@ -62,106 +60,55 @@ const ActivityLogV2: FunctionComponent = () => {
 		upsellURL = `/pricing/${ selectedSiteSlug }`;
 	}
 
-	const isAtomicA4AEnabled = isA8CForAgencies() && isAtomic;
-
-	const jetpackCloudHeader = siteHasFullActivityLog ? (
-		<div className="activity-log-v2__header">
-			<div className="activity-log-v2__header-left">
-				<div className="activity-log-v2__header-title">{ translate( 'Activity Log' ) }</div>
-				<div className="activity-log-v2__header-text">
-					{ translate( 'This is the complete event history for your site' ) }
-				</div>
-			</div>
-			<div className="activity-log-v2__header-right">
-				{ isJetpackCloud() && selectedSiteSlug && (
-					<Tooltip
-						text={ translate(
-							'To test your site changes, migrate or keep your data safe in another site'
-						) }
-					>
-						<Button
-							className="activity-log-v2__clone-button"
-							href={
-								isAtomicA4AEnabled
-									? `https://wordpress.com/backup/${ selectedSiteSlug }/clone`
-									: backupClonePath( selectedSiteSlug )
-							}
-							onClick={ () =>
-								dispatch( recordTracksEvent( 'calypso_jetpack_activity_log_copy_site' ) )
-							}
-						>
-							{ translate( 'Copy site' ) }
-						</Button>
-					</Tooltip>
-				) }
-			</div>
-		</div>
-	) : (
-		<Upsell
-			headerText={ translate( 'Activity Log' ) }
-			bodyText={ preventWidows(
-				translate(
-					'You currently have access to the 20 most recent events. Upgrade to Jetpack ' +
-						'VaultPress Backup or Jetpack Security to unlock more powerful features. ' +
-						'You can access all site activity for the last 30 days and filter events ' +
-						'by type and date range to quickly find the information you need.'
-				)
-			) }
-			buttonLink={ upsellURL }
-			buttonText={ translate( 'Upgrade now' ) }
-			onClick={ () =>
-				dispatch( recordTracksEvent( 'calypso_jetpack_activity_log_upgrade_click' ) )
-			}
-			openButtonLinkOnNewTab={ false }
-		/>
-	);
-
-	const isWpcom = ! ( ( isJetpackCloud() || isA8CForAgencies() ) && ! isWPCOMSite );
-
-	const content = (
-		<div className="activity-log-v2__content">
-			<ActivityCardList
-				logs={ logs }
-				pageSize={ 10 }
-				showFilter={ siteHasFullActivityLog }
-				siteId={ siteId }
-			/>
-		</div>
-	);
-
 	return (
-		<Main
-			className={ clsx( 'activity-log-v2', {
-				wordpressdotcom: isWpcom,
-			} ) }
-			fullWidthLayout={ isWpcom }
-			wideLayout={ ! isWpcom && ! isA8CForAgencies() }
-		>
+		<Main fullWidthLayout className="activity-log-v2">
 			{ siteId && <QuerySitePlans siteId={ siteId } /> }
 			{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 			{ siteId && <QuerySiteCredentials siteId={ siteId } /> }
 			<DocumentHead title={ translate( 'Activity Log' ) } />
 			{ isJetpackCloud() && <SidebarNavigation /> }
 			<PageViewTracker path="/activity-log/:site" title="Activity Log" />
-			{ isWpcom ? (
-				<Page
-					hasPadding
-					showSidebarToggle={ false }
-					title={ <JetpackTitle title={ translate( 'Activity' ) } /> }
-					subTitle={ translate(
-						'This is the complete event history for your site. Filter by date range and/or activity type.'
-					) }
-				>
-					{ settingsUrl && <TimeMismatchWarning siteId={ siteId } settingsUrl={ settingsUrl } /> }
-					{ content }
-				</Page>
-			) : (
-				<>
-					{ jetpackCloudHeader }
-					{ settingsUrl && <TimeMismatchWarning siteId={ siteId } settingsUrl={ settingsUrl } /> }
-					{ content }
-				</>
-			) }
+			<Page
+				hasPadding
+				showSidebarToggle={ false }
+				title={ showHeader ? <JetpackTitle title={ translate( 'Activity' ) } /> : undefined }
+				subTitle={
+					showHeader
+						? translate(
+								'This is the complete event history for your site. Filter by date range and/or activity type.'
+						  )
+						: undefined
+				}
+			>
+				{ showUpsell && (
+					<Upsell
+						headerText={ translate( 'Activity Log' ) }
+						bodyText={ preventWidows(
+							translate(
+								'You currently have access to the 20 most recent events. Upgrade to Jetpack ' +
+									'VaultPress Backup or Jetpack Security to unlock more powerful features. ' +
+									'You can access all site activity for the last 30 days and filter events ' +
+									'by type and date range to quickly find the information you need.'
+							)
+						) }
+						buttonLink={ upsellURL }
+						buttonText={ translate( 'Upgrade now' ) }
+						onClick={ () =>
+							dispatch( recordTracksEvent( 'calypso_jetpack_activity_log_upgrade_click' ) )
+						}
+						openButtonLinkOnNewTab={ false }
+					/>
+				) }
+				{ settingsUrl && <TimeMismatchWarning siteId={ siteId } settingsUrl={ settingsUrl } /> }
+				<div className="activity-log-v2__content">
+					<ActivityCardList
+						logs={ logs }
+						pageSize={ 10 }
+						showFilter={ siteHasFullActivityLog }
+						siteId={ siteId }
+					/>
+				</div>
+			</Page>
 		</Main>
 	);
 };

--- a/client/my-sites/activity/activity-log-v2/style.scss
+++ b/client/my-sites/activity/activity-log-v2/style.scss
@@ -3,13 +3,10 @@
 body.is-section-activity {
 	@include admin-ui-page-layout;
 	@include admin-ui-page-layout-constrained-content($max-width: 1040px);
+	@include admin-ui-page-sticky-footer;
 
 	.admin-ui-page {
 		background: var(--color-surface-backdrop);
-	}
-
-	.jetpack-colophon {
-		padding-bottom: 24px;
 	}
 }
 

--- a/client/my-sites/activity/activity-log-v2/style.scss
+++ b/client/my-sites/activity/activity-log-v2/style.scss
@@ -11,16 +11,6 @@ body.is-section-activity {
 }
 
 main.activity-log-v2 {
-	&:not(.wordpressdotcom) {
-		.activity-log-v2__header {
-			margin-top: 32px;
-		}
-		.activity-log-v2__content {
-			margin-top: 32px;
-			margin-bottom: 32px;
-		}
-	}
-
 	.filterbar {
 		margin-left: 0;
 		margin-right: 0;
@@ -39,36 +29,4 @@ main.activity-log-v2 {
 			}
 		}
 	}
-}
-
-.activity-log-v2__header {
-	display: flex;
-	margin-bottom: 32px;
-}
-
-.activity-log-v2__header-left {
-	text-align: left;
-	flex-grow: 1;
-}
-
-.activity-log-v2__header-right {
-	text-align: right;
-	margin-top: 8px;
-}
-
-.activity-log-v2__header-title {
-	font-size: $font-title-large;
-	font-weight: 600;
-	margin-bottom: 8px;
-}
-
-.activity-log-v2__clone-button .components-tooltip .components-popover__content {
-	background-color: #50575e;
-	width: 168px;
-	white-space: normal;
-	text-align: left;
-}
-
-.activity-log-v2__clone-button {
-	white-space: nowrap;
 }

--- a/client/my-sites/activity/activity-log/style.scss
+++ b/client/my-sites/activity/activity-log/style.scss
@@ -1,6 +1,13 @@
 @import "@automattic/typography/styles/variables";
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "calypso/components/jetpack-page-layout/admin-ui-page";
+
+body.is-section-activity {
+	@include admin-ui-page-layout;
+	@include admin-ui-page-layout-constrained-content($max-width: 1040px);
+	@include admin-ui-page-sticky-footer;
+}
 
 // Activity Log
 

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -177,32 +177,30 @@ function BackupStatus( { selectedDate, needCredentials, onDateChange } ) {
 
 	return (
 		<div className="backup__main-wrap">
-			<div className="backup__last-backup-status">
-				{ ( isJetpackCloud() || isA8CForAgencies() ) && (
-					<div className="backup__header">
-						<div className="backup__header-left">
-							<div className="backup__header-title">{ translate( 'Latest Backups' ) }</div>
-							<div className="backup__header-text">
-								{ translate( 'This is a list of your latest generated backups' ) }
-							</div>
-						</div>
-						<div className="backup__header-right">
-							<BackupActionsToolbar siteId={ siteId } />
+			{ ( isJetpackCloud() || isA8CForAgencies() ) && (
+				<div className="backup__header">
+					<div className="backup__header-left">
+						<div className="backup__header-title">{ translate( 'Latest Backups' ) }</div>
+						<div className="backup__header-text">
+							{ translate( 'This is a list of your latest generated backups' ) }
 						</div>
 					</div>
-				) }
+					<div className="backup__header-right">
+						<BackupActionsToolbar siteId={ siteId } />
+					</div>
+				</div>
+			) }
 
-				{ needCredentials && <EnableRestoresBanner /> }
-				{ ! needCredentials && hasRealtimeBackups && <BackupsMadeRealtimeBanner /> }
+			{ needCredentials && <EnableRestoresBanner /> }
+			{ ! needCredentials && hasRealtimeBackups && <BackupsMadeRealtimeBanner /> }
 
-				<BackupDatePicker onDateChange={ onDateChange } selectedDate={ selectedDate } />
-				<BackupStorageSpace />
-				{ hasRealtimeBackups ? (
-					<RealtimeStatus selectedDate={ selectedDate } />
-				) : (
-					<DailyStatus selectedDate={ selectedDate } />
-				) }
-			</div>
+			<BackupDatePicker onDateChange={ onDateChange } selectedDate={ selectedDate } />
+			<BackupStorageSpace />
+			{ hasRealtimeBackups ? (
+				<RealtimeStatus selectedDate={ selectedDate } />
+			) : (
+				<DailyStatus selectedDate={ selectedDate } />
+			) }
 		</div>
 	);
 }

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -65,36 +65,33 @@ const BackupPage = ( { queryDate } ) => {
 		keepLocalTime: !! queryDate,
 	} );
 
-	const isWpcom = ! ( isJetpackCloud() || isA8CForAgencies() );
+	const isJetpackPlatform = isJetpackCloud() || isA8CForAgencies();
+	const showHeader = ! isJetpackPlatform;
 
 	return (
 		<Main
-			fullWidthLayout={ isWpcom }
-			wideLayout={ ! isWpcom }
+			fullWidthLayout
 			className={ clsx( 'backup__page', {
-				wordpressdotcom: isWpcom,
+				wordpressdotcom: showHeader,
 				is_jetpackcom: isJetpackCloud(),
 			} ) }
 		>
 			{ isJetpackCloud() && <SidebarNavigation /> }
-			{ isWpcom ? (
-				<Page
-					hasPadding
-					showSidebarToggle={ false }
-					title={ <JetpackTitle title={ translate( 'Backup' ) } /> }
-					subTitle={ translate( 'Save changes and restore quickly with one-click recovery.' ) }
-					actions={ <BackupActionsToolbar siteId={ siteId } /> }
-				>
-					<TimeMismatchWarning siteId={ siteId } settingsUrl={ siteSettingsUrl } />
-					<AdminContent selectedDate={ selectedDate } />
-				</Page>
-			) : (
-				<>
-					<TimeMismatchWarning siteId={ siteId } settingsUrl={ siteSettingsUrl } />
-					<AdminContent selectedDate={ selectedDate } />
-				</>
-			) }
-			{ isWpcom && <JetpackFooter /> }
+			<Page
+				hasPadding
+				showSidebarToggle={ false }
+				title={ showHeader ? <JetpackTitle title={ translate( 'Backup' ) } /> : undefined }
+				subTitle={
+					showHeader
+						? translate( 'Save changes and restore quickly with one-click recovery.' )
+						: undefined
+				}
+				actions={ showHeader ? <BackupActionsToolbar siteId={ siteId } /> : undefined }
+			>
+				<TimeMismatchWarning siteId={ siteId } settingsUrl={ siteSettingsUrl } />
+				<AdminContent selectedDate={ selectedDate } />
+			</Page>
+			{ showHeader && <JetpackFooter /> }
 		</Main>
 	);
 };

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -68,39 +68,34 @@ const BackupPage = ( { queryDate } ) => {
 	const isWpcom = ! ( isJetpackCloud() || isA8CForAgencies() );
 
 	return (
-		<div
+		<Main
+			fullWidthLayout={ isWpcom }
+			wideLayout={ ! isWpcom }
 			className={ clsx( 'backup__page', {
 				wordpressdotcom: isWpcom,
+				is_jetpackcom: isJetpackCloud(),
 			} ) }
 		>
-			<Main
-				fullWidthLayout={ isWpcom }
-				wideLayout={ ! isWpcom }
-				className={ clsx( {
-					is_jetpackcom: isJetpackCloud(),
-				} ) }
-			>
-				{ isJetpackCloud() && <SidebarNavigation /> }
-				{ isWpcom ? (
-					<Page
-						hasPadding
-						showSidebarToggle={ false }
-						title={ <JetpackTitle title={ translate( 'Backup' ) } /> }
-						subTitle={ translate( 'Save changes and restore quickly with one-click recovery.' ) }
-						actions={ <BackupActionsToolbar siteId={ siteId } /> }
-					>
-						<TimeMismatchWarning siteId={ siteId } settingsUrl={ siteSettingsUrl } />
-						<AdminContent selectedDate={ selectedDate } />
-					</Page>
-				) : (
-					<>
-						<TimeMismatchWarning siteId={ siteId } settingsUrl={ siteSettingsUrl } />
-						<AdminContent selectedDate={ selectedDate } />
-					</>
-				) }
-				{ isWpcom && <JetpackFooter /> }
-			</Main>
-		</div>
+			{ isJetpackCloud() && <SidebarNavigation /> }
+			{ isWpcom ? (
+				<Page
+					hasPadding
+					showSidebarToggle={ false }
+					title={ <JetpackTitle title={ translate( 'Backup' ) } /> }
+					subTitle={ translate( 'Save changes and restore quickly with one-click recovery.' ) }
+					actions={ <BackupActionsToolbar siteId={ siteId } /> }
+				>
+					<TimeMismatchWarning siteId={ siteId } settingsUrl={ siteSettingsUrl } />
+					<AdminContent selectedDate={ selectedDate } />
+				</Page>
+			) : (
+				<>
+					<TimeMismatchWarning siteId={ siteId } settingsUrl={ siteSettingsUrl } />
+					<AdminContent selectedDate={ selectedDate } />
+				</>
+			) }
+			{ isWpcom && <JetpackFooter /> }
+		</Main>
 	);
 };
 

--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -21,16 +21,6 @@ body.is-section-backup {
 	--color-accent-60: var(--studio-jetpack-green-70);
 }
 
-.backup__last-backup-status {
-	background: var(--studio-white);
-	padding: 16px 16px 0;
-
-	@include breakpoint-deprecated( ">660px" ) {
-		background: var(--color-surface-backdrop);
-		padding: 0;
-		margin: 0;
-	}
-}
 .backup__main .formatted-header.is-left-align {
 	margin-top: 20px;
 
@@ -41,8 +31,11 @@ body.is-section-backup {
 }
 
 .backup__main-wrap {
-	display: flex;
-	flex-direction: column;
+	// Plain block layout (not flex). Cards inside have `margin: 0 auto` from
+	// `.card`, which is harmless on block children (computes to 0) but in a
+	// flex column container would override `align-items: stretch` and shrink
+	// each card to its content width.
+	display: block;
 }
 
 .backup__search {
@@ -114,11 +107,6 @@ body.is-section-backup {
 	.backup__main-wrap {
 		margin-left: auto;
 		margin-right: auto;
-	}
-
-	.backup__last-backup-status {
-		padding: initial;
-		background: initial;
 	}
 
 	.button {

--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -3,6 +3,7 @@
 body.is-section-backup {
 	@include admin-ui-page-layout;
 	@include admin-ui-page-layout-constrained-content($max-width: 1040px);
+	@include admin-ui-page-sticky-footer;
 
 	.backup__wpcom-upsell .promo-card {
 		display: flex;
@@ -30,15 +31,6 @@ body.is-section-backup {
 		margin: 0;
 	}
 }
-.backup__page .main {
-	overflow-y: auto;
-	padding-bottom: 0;
-
-	@include breakpoint-deprecated( ">660px" ) {
-		overflow-y: visible;
-	}
-}
-
 .backup__main .formatted-header.is-left-align {
 	margin-top: 20px;
 
@@ -51,10 +43,6 @@ body.is-section-backup {
 .backup__main-wrap {
 	display: flex;
 	flex-direction: column;
-	height: calc(100vh - 120px);
-	@include breakpoint-deprecated( ">660px" ) {
-		height: auto;
-	}
 }
 
 .backup__search {

--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -256,7 +256,7 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 	);
 
 	return (
-		<Main fullWidthLayout={ showPageHeader } wideLayout={ ! showPageHeader } className="earn">
+		<Main fullWidthLayout className="earn">
 			<PageViewTracker
 				path={ section ? `${ earnPath }/${ section }/:site` : `${ earnPath }/:site` }
 				title={ `${ adsProgramName } ${ capitalize( section ) }` }
@@ -264,32 +264,33 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 			<DocumentHead
 				title={ layoutTitles[ section as keyof typeof layoutTitles ] ?? translate( 'Monetize' ) }
 			/>
-			{ showPageHeader ? (
-				<Page
-					showSidebarToggle={ false }
-					title={ <JetpackTitle title={ translate( 'Monetize' ) } /> }
-					subTitle={ translate(
-						'Explore tools to earn money with your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-						{
-							components: {
-								learnMoreLink: isJetpackPlatform ? (
-									<a
-										href={ isJetpackNotAtomic ? jetpackLearnMoreLink : atomicLearnMoreLink }
-										target="_blank"
-										rel="noopener noreferrer"
-									/>
-								) : (
-									<InlineSupportLink supportContext="earn" showIcon={ false } />
-								),
-							},
-						}
-					) }
-				>
-					{ content }
-				</Page>
-			) : (
-				content
-			) }
+			<Page
+				hasPadding
+				showSidebarToggle={ false }
+				title={ showPageHeader ? <JetpackTitle title={ translate( 'Monetize' ) } /> : undefined }
+				subTitle={
+					showPageHeader
+						? translate(
+								'Explore tools to earn money with your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+								{
+									components: {
+										learnMoreLink: isJetpackPlatform ? (
+											<a
+												href={ isJetpackNotAtomic ? jetpackLearnMoreLink : atomicLearnMoreLink }
+												target="_blank"
+												rel="noopener noreferrer"
+											/>
+										) : (
+											<InlineSupportLink supportContext="earn" showIcon={ false } />
+										),
+									},
+								}
+						  )
+						: undefined
+				}
+			>
+				{ content }
+			</Page>
 			{ ! isJetpackPlatform && <JetpackFooter /> }
 		</Main>
 	);

--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -269,9 +269,13 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 			<Page
 				hasPadding
 				showSidebarToggle={ false }
-				title={ showPageHeader ? <JetpackTitle title={ translate( 'Monetize' ) } /> : undefined }
+				title={
+					showPageHeader && ! isJetpackPlatform ? (
+						<JetpackTitle title={ translate( 'Monetize' ) } />
+					) : undefined
+				}
 				subTitle={
-					showPageHeader
+					showPageHeader && ! isJetpackPlatform
 						? translate(
 								'Explore tools to earn money with your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 								{

--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -1,4 +1,3 @@
-import { localizeUrl } from '@automattic/i18n-utils';
 import { Page } from '@wordpress/admin-ui';
 import { useTranslate } from 'i18n-calypso';
 import { capitalize, find } from 'lodash';
@@ -18,7 +17,6 @@ import WordAdsPayments from 'calypso/my-sites/earn/ads/payments';
 import WordAdsEarnings from 'calypso/my-sites/stats/wordads/earnings';
 import WordAdsHighlightsSection from 'calypso/my-sites/stats/wordads/highlights-section';
 import { useSelector } from 'calypso/state';
-import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { canAccessWordAds, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import AdsWrapper from './ads/wrapper';
@@ -48,8 +46,7 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, site?.ID ) );
 	const adsProgramName = isJetpack ? 'Ads' : 'WordAds';
 	const paidSubscriptionId = query?.paid_susbcription;
-	const isAtomicSite = useSelector( ( state ) => isSiteAutomatedTransfer( state, site?.ID ) );
-	const isJetpackNotAtomic = isJetpack && ! isAtomicSite;
+
 	const isJetpackPlatform = isJetpackCloud();
 
 	const layoutTitles = {
@@ -242,8 +239,6 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 		);
 	};
 
-	const atomicLearnMoreLink = localizeUrl( 'https://wordpress.com/support/monetize-your-site/' );
-	const jetpackLearnMoreLink = localizeUrl( 'https://jetpack.com/support/monetize-your-site/' );
 	const showPageHeader = ! isSinglePaidSubscriptionSection( section );
 
 	const content = (
@@ -280,15 +275,7 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 								'Explore tools to earn money with your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 								{
 									components: {
-										learnMoreLink: isJetpackPlatform ? (
-											<a
-												href={ isJetpackNotAtomic ? jetpackLearnMoreLink : atomicLearnMoreLink }
-												target="_blank"
-												rel="noopener noreferrer"
-											/>
-										) : (
-											<InlineSupportLink supportContext="earn" showIcon={ false } />
-										),
+										learnMoreLink: <InlineSupportLink supportContext="earn" showIcon={ false } />,
 									},
 								}
 						  )

--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -10,6 +10,7 @@ import Main from 'calypso/components/main';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
+import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import AdsSettings from 'calypso/my-sites/earn/ads/form-settings';
@@ -264,6 +265,7 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 			<DocumentHead
 				title={ layoutTitles[ section as keyof typeof layoutTitles ] ?? translate( 'Monetize' ) }
 			/>
+			{ isJetpackPlatform && <SidebarNavigation /> }
 			<Page
 				hasPadding
 				showSidebarToggle={ false }

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -21,7 +21,6 @@ body.is-section-earn {
 	box-sizing: border-box;
 	margin: 0 auto;
 	max-width: 1040px;
-	padding: 24px;
 	width: 100%;
 }
 

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -5,6 +5,7 @@
 
 body.is-section-earn {
 	@include admin-ui-page-layout;
+	@include admin-ui-page-sticky-footer;
 }
 
 .earn-navigation {

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -3,9 +3,16 @@
 @import "@wordpress/base-styles/mixins";
 @import "calypso/components/jetpack-page-layout/admin-ui-page";
 
-body.is-section-earn {
+// The same `calypso/my-sites/earn` module is registered under two section
+// names: `earn` on Calypso (route `/earn`) and `jetpack-monetize` on Jetpack
+// Cloud (route `/monetize`) — see `client/sections.js`. The body class
+// follows the section name, so the layout mixin must be applied to both
+// to cover every environment that renders this page.
+body.is-section-earn,
+body.is-section-jetpack-monetize {
 	@include admin-ui-page-layout;
 	@include admin-ui-page-sticky-footer;
+	@include admin-ui-page-layout-constrained-content($max-width: 1040px);
 }
 
 .earn-navigation {
@@ -15,13 +22,6 @@ body.is-section-earn {
 		padding: 0 var(--wpds-dimension-padding-2xl, 24px);
 		border-bottom: var(--wpds-border-width-xs, 1px) solid var(--wpds-color-stroke-surface-neutral-weak, #e0e0e0);
 	}
-}
-
-.earn-content {
-	box-sizing: border-box;
-	margin: 0 auto;
-	max-width: 1040px;
-	width: 100%;
 }
 
 // Small override for card component headers

--- a/client/my-sites/plugins/plugins-dashboard/style.scss
+++ b/client/my-sites/plugins/plugins-dashboard/style.scss
@@ -143,12 +143,6 @@
 
 		.item-preview__content {
 			padding: 10px 10px 88px; /* 88px matches the padding from PR #39201. */
-
-			.backup__page .main {
-				/* Prevents the backup page from overriding our padding and overflow settings. */
-				padding-bottom: 88px; /* 88px matches the padding from PR #39201. */
-				overflow: hidden;
-			}
 		}
 	}
 

--- a/client/my-sites/scan/history/index.tsx
+++ b/client/my-sites/scan/history/index.tsx
@@ -2,6 +2,7 @@ import { Page } from '@wordpress/admin-ui';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
+import JetpackFooter from 'calypso/components/jetpack/jetpack-footer';
 import ThreatHistoryList from 'calypso/components/jetpack/threat-history-list';
 import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
@@ -60,6 +61,7 @@ export default function ScanHistoryPage( { filter }: Props ) {
 			) : (
 				content
 			) }
+			{ isWpcom && <JetpackFooter /> }
 		</Main>
 	);
 }

--- a/client/my-sites/scan/history/index.tsx
+++ b/client/my-sites/scan/history/index.tsx
@@ -21,47 +21,40 @@ interface Props {
 
 export default function ScanHistoryPage( { filter }: Props ) {
 	const translate = useTranslate();
-	const isJetpackPlatform = isJetpackCloud();
-	const isWpcom = ! ( isJetpackPlatform || isA8CForAgencies() );
-
-	const content = (
-		<>
-			<ScanNavigation section="history" />
-			<section className="history__body">
-				<p className="history__description">
-					{ translate(
-						'The scanning history contains a record of all previously active threats on your site.'
-					) }
-				</p>
-				<ThreatHistoryList filter={ filter } />
-			</section>
-		</>
-	);
+	const isJetpackPlatform = isJetpackCloud() || isA8CForAgencies();
+	const showHeader = ! isJetpackPlatform;
 
 	return (
 		<Main
-			fullWidthLayout={ isWpcom }
-			wideLayout={ ! isWpcom }
+			fullWidthLayout
 			className={ clsx( 'scan history', {
-				is_jetpackcom: isJetpackPlatform,
+				is_jetpackcom: isJetpackCloud(),
 			} ) }
 		>
 			<DocumentHead title={ translate( 'Scan' ) } />
-			{ isJetpackPlatform && <SidebarNavigation /> }
+			{ isJetpackCloud() && <SidebarNavigation /> }
 			<PageViewTracker path="/scan/history/:site" title="Scan History" />
-			{ isWpcom ? (
-				<Page
-					hasPadding
-					showSidebarToggle={ false }
-					title={ <JetpackTitle title={ translate( 'Scan' ) } /> }
-					subTitle={ translate( 'Automated malware scanning and firewall protection.' ) }
-				>
-					{ content }
-				</Page>
-			) : (
-				content
-			) }
-			{ isWpcom && <JetpackFooter /> }
+			<Page
+				hasPadding
+				showSidebarToggle={ false }
+				title={ showHeader ? <JetpackTitle title={ translate( 'Scan' ) } /> : undefined }
+				subTitle={
+					showHeader
+						? translate( 'Automated malware scanning and firewall protection.' )
+						: undefined
+				}
+			>
+				<ScanNavigation section="history" />
+				<section className="history__body">
+					<p className="history__description">
+						{ translate(
+							'The scanning history contains a record of all previously active threats on your site.'
+						) }
+					</p>
+					<ThreatHistoryList filter={ filter } />
+				</section>
+			</Page>
+			{ showHeader && <JetpackFooter /> }
 		</Main>
 	);
 }

--- a/client/my-sites/scan/main.tsx
+++ b/client/my-sites/scan/main.tsx
@@ -342,8 +342,8 @@ class ScanPage extends Component< Props > {
 
 	render() {
 		const { siteId, siteSettingsUrl } = this.props;
-		const isJetpackPlatform = isJetpackCloud();
-		const isWpcom = ! ( isJetpackPlatform || isA8CForAgencies() );
+		const isJetpackPlatform = isJetpackCloud() || isA8CForAgencies();
+		const showHeader = ! isJetpackPlatform;
 		let mainClass = 'scan';
 
 		if ( ! siteId ) {
@@ -354,40 +354,33 @@ class ScanPage extends Component< Props > {
 			mainClass = 'scan-new';
 		}
 
-		const content = (
-			<>
-				<TimeMismatchWarning siteId={ siteId } settingsUrl={ siteSettingsUrl } />
-				<QueryJetpackScan siteId={ siteId } />
-				<ScanNavigation section="scanner" />
-				<div className="scan__content">{ this.renderScanState() }</div>
-				{ this.renderJetpackReviewPrompt() }
-			</>
-		);
-
 		return (
 			<Main
-				fullWidthLayout={ isWpcom }
-				wideLayout={ ! isWpcom }
+				fullWidthLayout
 				className={ clsx( mainClass, {
-					is_jetpackcom: isJetpackPlatform,
+					is_jetpackcom: isJetpackCloud(),
 				} ) }
 			>
 				<DocumentHead title="Scan" />
-				{ isJetpackPlatform && <SidebarNavigation /> }
+				{ isJetpackCloud() && <SidebarNavigation /> }
 				<PageViewTracker path="/scan/:site" title="Scanner" />
-				{ isWpcom ? (
-					<Page
-						hasPadding
-						showSidebarToggle={ false }
-						title={ <JetpackTitle title={ translate( 'Scan' ) } /> }
-						subTitle={ translate( 'Automated malware scanning and firewall protection.' ) }
-					>
-						{ content }
-					</Page>
-				) : (
-					content
-				) }
-				{ isWpcom && <JetpackFooter /> }
+				<Page
+					hasPadding
+					showSidebarToggle={ false }
+					title={ showHeader ? <JetpackTitle title={ translate( 'Scan' ) } /> : undefined }
+					subTitle={
+						showHeader
+							? translate( 'Automated malware scanning and firewall protection.' )
+							: undefined
+					}
+				>
+					<TimeMismatchWarning siteId={ siteId } settingsUrl={ siteSettingsUrl } />
+					<QueryJetpackScan siteId={ siteId } />
+					<ScanNavigation section="scanner" />
+					<div className="scan__content">{ this.renderScanState() }</div>
+					{ this.renderJetpackReviewPrompt() }
+				</Page>
+				{ showHeader && <JetpackFooter /> }
 			</Main>
 		);
 	}

--- a/client/my-sites/scan/style.scss
+++ b/client/my-sites/scan/style.scss
@@ -10,9 +10,13 @@ body.is-section-scan {
 		gap: 24px;
 	}
 
-	.scan__content > .card {
+}
 
-		justify-content: center;
+// Card on both Calypso and A4A needs flex
+body.is-section-scan,
+.hosting-dashboard-item-view__content {
+
+	.scan__content > .card {
 
 		.security-icon {
 			margin: 0 auto;
@@ -23,6 +27,7 @@ body.is-section-scan {
 			display: flex;
 			gap: 24px;
 			align-items: flex-start;
+			justify-content: center;
 
 			.scan__header {
 				flex-shrink: 0;

--- a/client/my-sites/scan/style.scss
+++ b/client/my-sites/scan/style.scss
@@ -3,6 +3,7 @@
 body.is-section-scan {
 	@include admin-ui-page-layout;
 	@include admin-ui-page-layout-constrained-content($max-width: 1040px);
+	@include admin-ui-page-sticky-footer;
 
 	.scan__wpcom-upsell .promo-card {
 		display: flex;

--- a/client/my-sites/site-settings/podcasting-details/style.scss
+++ b/client/my-sites/site-settings/podcasting-details/style.scss
@@ -4,14 +4,31 @@ body.is-section-settings-podcasting {
 	@include admin-ui-page-layout;
 	@include admin-ui-page-layout-constrained-content;
 
-	.layout,
-	.layout__content,
-	.layout__primary {
-		height: 100%;
-	}
+	.layout__content {
+		display: flex;
 
-	.layout__primary .main {
-		height: 100%;
+		.layout__primary {
+			flex: 1;
+			display: flex;
+
+			.main {
+				margin: 0;
+				flex-grow: 1;
+				position: relative;
+				padding-bottom: 65px;
+
+				.jetpack-footer {
+					position: fixed;
+					z-index: 1;
+					bottom: 0;
+					background-color: var( --wpds-color-bg-surface-neutral );
+
+					@include break-medium {
+						max-width: calc( 100% - var( --sidebar-width-max ) );
+					}
+				}
+			}
+		}
 	}
 }
 

--- a/client/my-sites/site-settings/podcasting-details/style.scss
+++ b/client/my-sites/site-settings/podcasting-details/style.scss
@@ -3,6 +3,16 @@
 body.is-section-settings-podcasting {
 	@include admin-ui-page-layout;
 	@include admin-ui-page-layout-constrained-content;
+
+	.layout,
+	.layout__content,
+	.layout__primary {
+		height: 100%;
+	}
+
+	.layout__primary .main {
+		height: 100%;
+	}
 }
 
 .podcasting-details__publish-wrapper {

--- a/client/my-sites/site-settings/podcasting-details/style.scss
+++ b/client/my-sites/site-settings/podcasting-details/style.scss
@@ -3,33 +3,7 @@
 body.is-section-settings-podcasting {
 	@include admin-ui-page-layout;
 	@include admin-ui-page-layout-constrained-content;
-
-	.layout__content {
-		display: flex;
-
-		.layout__primary {
-			flex: 1;
-			display: flex;
-
-			.main {
-				margin: 0;
-				flex-grow: 1;
-				position: relative;
-				padding-bottom: 65px;
-
-				.jetpack-footer {
-					position: fixed;
-					z-index: 1;
-					bottom: 0;
-					background-color: var( --wpds-color-bg-surface-neutral );
-
-					@include break-medium {
-						max-width: calc( 100% - var( --sidebar-width-max ) );
-					}
-				}
-			}
-		}
-	}
+	@include admin-ui-page-sticky-footer;
 }
 
 .podcasting-details__publish-wrapper {

--- a/client/my-sites/site-settings/podcasting-details/style.scss
+++ b/client/my-sites/site-settings/podcasting-details/style.scss
@@ -64,6 +64,11 @@ body.is-section-settings-podcasting {
 	display: flex;
 	gap: 24px;
 	margin-bottom: 16px;
+	flex-direction: column;
+
+	@include break-medium {
+		flex-direction: row;
+	}
 
 	.podcast-cover-image-setting {
 		flex-shrink: 0;

--- a/client/sites/components/style.scss
+++ b/client/sites/components/style.scss
@@ -96,12 +96,6 @@
 
 		.hosting-dashboard-item-view__content {
 			padding: 10px 10px 88px; /* 88px matches the padding from PR #39201. */
-
-			.backup__page .main {
-				/* Prevents the backup page from overriding our padding and overflow settings. */
-				padding-bottom: 88px; /* 88px matches the padding from PR #39201. */
-				overflow: hidden;
-			}
 		}
 	}
 

--- a/client/sites/marketing/traffic/style.scss
+++ b/client/sites/marketing/traffic/style.scss
@@ -3,6 +3,7 @@
 body.is-section-marketing-traffic {
 	@include admin-ui-page-layout;
 	@include admin-ui-page-layout-constrained-content;
+	@include admin-ui-page-sticky-footer;
 }
 
 .settings-traffic.site-settings {


### PR DESCRIPTION
Part of JETPACK-1391

## Proposed Changes

* Normalize the JSX layout of every Jetpack admin page in Calypso (Backup, Scan, Activity Log, Earn/Monetize, Podcasting, Traffic, Social promo) to a single structural pattern: `<Main fullWidthLayout>` + `<Page hasPadding>` + `<JetpackFooter />`.
* Extract a shared `admin-ui-page-sticky-footer` SCSS mixin that pins `<JetpackFooter />` to the viewport bottom and converts `.layout__primary` into a fixed-height viewport-bounded column. Applied to all sections via `body.is-section-<name>`.
* Flatten Pattern C pages (Backup, Scan, Scan history) from conditional `isWpcom ? <Page>… : content` to unconditional `<Page hasPadding>` with conditional `title`/`subTitle`/`actions`.
* Flatten Earn's Pattern D conditional `<Page>` — always render `<Page>`, use `title={undefined}` / `subTitle={undefined}` to skip the header natively. Fixes a latent `@wordpress/admin-ui` scroll-container bug (`.admin-ui-page__content` only renders when `hasPadding={true}`).
* Fix Earn navigation trap on JP Cloud mobile — add `<SidebarNavigation />` (was the only Jetpack admin page missing it).
* Fix Social promo navigation trap on JP Cloud mobile — add `<SidebarNavigation />`, wrap in `<Page hasPadding>`, apply layout + sticky-footer mixins.
* Fix 16px horizontal scroll on JP Cloud mobile (Backup, Scan) caused by `overflow-y: auto` silently promoting `overflow-x` to `auto` per CSS spec, interacting with sidebar-nav's `margin: 0 -16px`.
* Remove dead `.backup__last-backup-status` wrapper (styles defeated by `initial` resets in 2 of 3 consumers).
* Prune ~20 lines of dead defensive CSS across sites-dashboard, plugins-dashboard, and sites/components.
* Extend Earn mixin scope to JP Cloud by adding `is-section-jetpack-monetize` selector (JP Cloud alias per `client/sections.js`).
* Replace bespoke `.earn-content` max-width with the `admin-ui-page-layout-constrained-content` mixin.

## Before / after

| Page | Before | After |
|------|--------|-------|
| **Footer pinned** (Scan, WP.com) | <img width="1260" height="769" alt="before-calypso-desktop-scan" src="https://github.com/user-attachments/assets/00c27866-f1a1-4dce-8a43-fd409296928c" /> | <img width="1260" height="769" alt="after-calypso-desktop-scan" src="https://github.com/user-attachments/assets/482e4ba1-3470-49f2-a606-3d3fadc6b884" /> |
| **Hamburger alignment** (Backup, JP Cloud mobile) | <img width="334" height="728" alt="before-jpc-mobile-backup" src="https://github.com/user-attachments/assets/9d7f3a1c-0c78-4ac2-9712-6a548732d12e" /> | <img width="334" height="726" alt="after-jpc-mobile-backup" src="https://github.com/user-attachments/assets/76d74679-316d-4dd1-b8b9-a57f97aa7930" /> |
| **Earn nav trap** (JP Cloud mobile) | <img width="334" height="728" alt="before-jpc-mobile-earn" src="https://github.com/user-attachments/assets/78f746eb-b9bb-4766-be2d-ab907deb20c1" /> | <img width="334" height="728" alt="after-jpc-mobile-earn" src="https://github.com/user-attachments/assets/4095a95b-ba65-4aed-bfd8-ff712a0688f2" /> |
| **Upsell chrome** (Scan upsell, WP.com) | <img width="1260" height="769" alt="before-calypso-desktop-scan-upsell" src="https://github.com/user-attachments/assets/b89d8b17-4178-4995-84e0-e057a401c4fb" /> | <img width="1260" height="769" alt="after-calypso-desktop-scan-upsell" src="https://github.com/user-attachments/assets/f0f9fd64-0e70-4b15-b1ce-05a85a78a771" /> |
| **Neutral background preview** (Backup, WP.com) | — | <img width="1260" height="769" alt="after-calypso-desktop-backup-with-neutral-bg" src="https://github.com/user-attachments/assets/33acb197-620b-435a-a2f5-589717d4fed6" /> |













## Why are these changes being made?

The p1HpG7-xG5-p2 identified a core problem: every Jetpack sub-page on WordPress.com looks like a different product — different widths, colors, fonts, and loading spinners. That walkthrough kicked off the **Jetpack Experience Unification initiative** to standardize the IA, routes, and UI system.

Header unification shipped in 15.7 as the first step. At the p1HpG7-xUC-p2, footer consolidation was declared the next phase. This PR is that next phase.

The immediate structural problem was that Jetpack admin pages used 4 different ad-hoc JSX layout patterns. Cross-cutting changes had to understand and handle each pattern separately — a maintenance trap that explains how the inconsistencies accumulated. This PR collapses all 4 into one canonical pattern, then applies the sticky-footer mixin globally.

### Out of scope

* **Earn visual polish.** The structural alignment gives Earn the same shell as everything else, but the content layout (tabs, grid, subscriber detail) needs design work. A follow-up is in order.
* **Upstream `<Page>` bug.** The `hasPadding` / scroll-container coupling is worked around, not fixed. Upstream PR to Gutenberg should be discussed.

## Testing Instructions

**Setup:** Check out this branch, `yarn start`, log in to Calypso with a WP.com site (Business plan or higher for full Earn testing).

**Pages to verify on WP.com** (resize viewport height to ~700px to see scrolling):

- [ ] Podcasting — `/settings/podcasting/<site-slug>`
- [ ] Marketing Traffic — `/marketing/traffic/<site-slug>`
- [ ] Activity Log — `/activity-log/<site-slug>`
- [ ] Scan — `/scan/<site-slug>`
- [ ] Scan history — `/scan/history/<site-slug>`
- [ ] Backup — `/backup/<site-slug>`
- [ ] Earn main — `/earn/<site-slug>`
- [ ] Scan upsell (site without Scan feature)
- [ ] Backup upsell (site without Backup feature)

**On each page verify:**
1. Jetpack footer pinned at viewport bottom, not floating mid-page
2. Main content scrolls internally, body does not scroll
3. Admin-ui sticky header stays pinned at top of content column
4. Sidebar full-height, unaffected by content scroll

**JP Cloud mobile** (check at mobile viewport width):
- [ ] Earn/Monetize — `/monetize/<site-slug>` — hamburger menu present (was missing before)
- [ ] Social promo — `/jetpack-social/<site-slug>` — hamburger menu present (was missing before)
- [ ] Backup, Scan — no horizontal scroll, hamburger aligned correctly

**JP Cloud policy check:**
- [ ] On JP Cloud (backup, scan, activity, monetize), verify `<JetpackFooter />` is **not** rendered

**Earn paid-subscription detail screen:**

Navigate to `/earn/paid-subscriptions/<site-slug>`. If no paid subscribers exist, inject a mock via devtools:

<details>
<summary>Mock injection snippet</summary>

Open browser devtools, walk the React fiber tree from `#wpcom` to find the Redux store, then dispatch a mock paid subscriber. The detail screen renders without a page header (title/subTitle undefined → admin-ui skips `<Header>`), with breadcrumbs visible, internal scroll working, and footer pinned.

</details>



## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?