### PR TITLE
Enable dashboard/omnibar in development and horizon

### DIFF
--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -25,7 +25,7 @@
 		"ciab/allow-domain-features": true,
 		"cookie-banner": false,
 		"rum-tracking/logstash": true,
-		"dashboard/omnibar": false,
+		"dashboard/omnibar": true,
 		"dashboard/wp-beta-program": true,
 		"dashboard/v2": false,
 		"dev/auth-helper": true,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -25,7 +25,7 @@
 		"ciab/custom-branding": true,
 		"cookie-banner": false,
 		"rum-tracking/logstash": true,
-		"dashboard/omnibar": false,
+		"dashboard/omnibar": true,
 		"dashboard/wp-beta-program": false,
 		"dashboard/v2": false,
 		"dev/auth-helper": true,

--- a/config/development.json
+++ b/config/development.json
@@ -63,7 +63,7 @@
 		"cookie-banner": false,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
-		"dashboard/omnibar": false,
+		"dashboard/omnibar": true,
 		"dashboard/wp-beta-program": true,
 		"dashboard/opt-in-banners": false,
 		"dashboard/v2": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -28,7 +28,7 @@
 		"cookie-banner": true,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
-		"dashboard/omnibar": false,
+		"dashboard/omnibar": true,
 		"dashboard/wp-beta-program": false,
 		"dashboard/opt-in-banners": false,
 		"dashboard/v2": true,

--- a/test/e2e/specs/dashboard/dashboard__rum-tracking.spec.ts
+++ b/test/e2e/specs/dashboard/dashboard__rum-tracking.spec.ts
@@ -123,7 +123,18 @@ test.describe( 'Dashboard: RUM Performance Tracking', { tag: [ tags.DASHBOARD_PR
 		} );
 
 		await test.step( 'When I navigate in-app to the domains page', async function () {
-			if ( viewportName === 'mobile' ) {
+			// The dashboard/omnibar feature flag changes the navigation structure.
+			// Detect it by the presence of `#wpcom-omnibar`, the hydration root.
+			const isOmnibarEnabled = ( await page.locator( '#wpcom-omnibar' ).count() ) > 0;
+
+			if ( isOmnibarEnabled ) {
+				// With omnibar: click Domains in the responsive sidebar.
+				// On mobile, open the sidebar first via the masterbar menu button.
+				if ( viewportName === 'mobile' ) {
+					await page.getByTitle( 'Menu', { exact: true } ).click();
+				}
+				await page.getByRole( 'link', { name: 'Domains' } ).click();
+			} else if ( viewportName === 'mobile' ) {
 				await page.getByRole( 'button', { name: 'Menu' } ).click();
 				await page
 					.getByRole( 'link', { name: 'Domains' } )


### PR DESCRIPTION
## Proposed Changes

* Flip `dashboard/omnibar` to `true` in `config/development.json`, `config/horizon.json`, `config/dashboard-development.json`, and `config/dashboard-horizon.json`.

## Why are these changes being made?

* Enables the Omnibar in non-production environments so it can be tested and iterated on before shipping to production.

## Testing Instructions

* Run the Dashboard locally (`yarn start-dashboard`) against development or horizon and verify the Omnibar is rendered.
* Confirm production config is untouched.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?