### PR TITLE
Fix: Disable dashboard/omnibar on horizon

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -28,7 +28,7 @@
 		"cookie-banner": true,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
-		"dashboard/omnibar": true,
+		"dashboard/omnibar": false,
 		"dashboard/wp-beta-program": false,
 		"dashboard/opt-in-banners": false,
 		"dashboard/v2": true,


### PR DESCRIPTION
## Proposed Changes

* Disable `dashboard/omnibar` feature flag on horizon.

## Why are these changes being made?

The horizon domain is currently broken because this feature flag was turned on in #109900. This reverts the horizon portion of that change.

## Testing Instructions

* Load horizon and verify the dashboard loads without errors.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?