### PR TITLE
Improve version switch UI copy

### DIFF
--- a/client/dashboard/sites/settings-wordpress/beta-program-notice.tsx
+++ b/client/dashboard/sites/settings-wordpress/beta-program-notice.tsx
@@ -35,7 +35,7 @@ export function BetaProgramNotice( { site, wpVersion }: BetaProgramNoticeProps )
 				  )
 				: createInterpolateElement(
 						__(
-							'If you notice anything unexpected, <support>let us know</support>. Your feedback helps shape WordPress. You can switch back to the stable release anytime. A <backup>backup of your site</backup> is available if you ever need it.'
+							'If you notice anything unexpected, <support>let us know</support>. Your feedback helps shape WordPress. You can switch back to the stable release or <backup>restore your backup</backup> anytime.'
 						),
 						{
 							support: <Button variant="link" onClick={ () => setShowHelpCenter( true ) } />,

--- a/client/dashboard/sites/settings-wordpress/beta-program-notice.tsx
+++ b/client/dashboard/sites/settings-wordpress/beta-program-notice.tsx
@@ -1,9 +1,11 @@
+import { Link } from '@tanstack/react-router';
 import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useHelpCenter } from '../../app/help-center';
 import { Notice } from '../../components/notice';
 import { getBackupUrl } from '../../utils/site-backup';
+import { isRelativeUrl } from '../../utils/url';
 import type { Site } from '@automattic/api-core';
 
 interface BetaProgramNoticeProps {
@@ -39,7 +41,11 @@ export function BetaProgramNotice( { site, wpVersion }: BetaProgramNoticeProps )
 						),
 						{
 							support: <Button variant="link" onClick={ () => setShowHelpCenter( true ) } />,
-							backup: <a href={ backupUrl } />,
+							backup: isRelativeUrl( backupUrl ) ? (
+								<Link to={ backupUrl } />
+							) : (
+								<a href={ backupUrl } />
+							),
 						}
 				  ) }
 		</Notice>

--- a/client/dashboard/sites/settings-wordpress/version-switch-notice.tsx
+++ b/client/dashboard/sites/settings-wordpress/version-switch-notice.tsx
@@ -16,11 +16,11 @@ export function VersionSwitchNotice( { backupState, targetVersion }: VersionSwit
 				variant="info"
 				title={ sprintf(
 					// translators: %s: WordPress version, e.g. "7.0-RC2"
-					__( 'Switching to WordPress %s…' ),
+					__( 'Switching to WordPress %s' ),
 					targetVersion
 				) }
 			>
-				{ __( 'Creating a backup of your site before switching.' ) }
+				{ __( 'Backing up your site.' ) }
 			</Notice>
 		);
 	}
@@ -31,15 +31,13 @@ export function VersionSwitchNotice( { backupState, targetVersion }: VersionSwit
 				variant="info"
 				title={ sprintf(
 					// translators: %s: WordPress version, e.g. "7.0-RC2"
-					__( 'Switching to WordPress %s…' ),
+					__( 'Switching to WordPress %s' ),
 					targetVersion
 				) }
 			>
 				{ sprintf(
 					// translators: %s: backup progress percentage
-					__(
-						'Generating backup… (%s%% progress). A backup is being created before switching. This may take a few minutes.'
-					),
+					__( 'Backing up your site… (%s%% progress). This may take a few minutes.' ),
 					backup?.percent ?? '0'
 				) }
 			</Notice>
@@ -52,11 +50,11 @@ export function VersionSwitchNotice( { backupState, targetVersion }: VersionSwit
 				variant="info"
 				title={ sprintf(
 					// translators: %s: WordPress version, e.g. "7.0-RC2"
-					__( 'Switching to WordPress %s…' ),
+					__( 'Switching to WordPress %s' ),
 					targetVersion
 				) }
 			>
-				{ __( 'Backup completed. Now switching WordPress version…' ) }
+				{ __( 'Backup complete. Switching versions now.' ) }
 			</Notice>
 		);
 	}
@@ -75,11 +73,11 @@ export function VersionSwitchNotice( { backupState, targetVersion }: VersionSwit
 			variant="info"
 			title={ sprintf(
 				// translators: %s: WordPress version, e.g. "7.0-RC2"
-				__( 'Switching to WordPress %s…' ),
+				__( 'Switching to WordPress %s' ),
 				targetVersion
 			) }
 		>
-			{ __( 'Preparing to switch WordPress version…' ) }
+			{ __( 'Starting version switch.' ) }
 		</Notice>
 	);
 }


### PR DESCRIPTION
Part of DOTCOM-16607

## Proposed Changes

- Simplify and clarify version switch notice copy across all states (idle, enqueued, running, backup complete)
- Remove trailing ellipsis from notice titles for consistency
- Update post-switch beta program notice to combine "switch back" and "restore backup" into a single sentence

| Before | After |
  |--------|-------|
  | **Switching to WordPress %s…** · Preparing to switch WordPress version… | **Switching to WordPress %s** · Starting version switch. |
  | **Switching to WordPress %s…** · Creating a backup of your site before switching. | **Switching to WordPress %s** · Backing up your site. |
  | **Switching to WordPress %s…** · Generating backup… (%s%% progress). A backup is being created before switching. This may take a few minutes. | **Switching to WordPress %s** · Backing up your site… (%s%% progress). This may take a few minutes. |
  | **Switching to WordPress %s…** · Backup completed. Now switching WordPress version… | **Switching to WordPress %s** · Backup complete. Switching versions now. |
  | **Your site is running WordPress %s** · If you notice anything unexpected, <support>let us know</support>. Your feedback helps shape WordPress. You can switch back to the stable release anytime. A <backup>backup of your site</backup> is available if you ever need it. | **Your site is running WordPress %s** · If you notice anything unexpected, <support>let us know</support>. Your feedback helps shape WordPress. You can switch back to the stable release or <backup>restore your backup</backup> anytime. |

<img width="707" height="425" alt="Screenshot 2026-04-09 at 11 34 35 AM" src="https://github.com/user-attachments/assets/1cbf6780-8c54-4a42-810c-da42fa7dd34a" />

<img width="684" height="421" alt="Screenshot 2026-04-09 at 11 31 40 AM" src="https://github.com/user-attachments/assets/82a30b4f-c6ad-46b7-9451-1681de26e280" />

<img width="709" height="447" alt="Screenshot 2026-04-09 at 11 22 23 AM" src="https://github.com/user-attachments/assets/2cab1c44-612e-4877-b80a-a466d6c6f55b" />

<img width="696" height="460" alt="Screenshot 2026-04-09 at 11 24 23 AM" src="https://github.com/user-attachments/assets/835b8c01-55e2-45f2-a67d-65a11d955ea3" />



## Why are these changes being made?

The existing version switch copy was verbose and inconsistent. This update makes the messaging clearer and more concise at each step of the version switch flow, improving the user experience.

## Testing Instructions

1. Navigate to a non-staging site's WordPress settings (Dashboard → Settings → WordPress)
2. Initiate a version switch to a beta/RC version
3. Verify the notices show the updated copy at each stage:
   - **Idle**: "Starting version switch."
   - **Enqueued**: "Backing up your site."
   - **Running**: "Backing up your site… (X% progress). This may take a few minutes."
   - **Backup complete**: "Backup complete. Switching versions now."
4. After the switch completes, verify the beta program notice reads: "If you notice anything unexpected, let us know. Your feedback helps shape WordPress. You can switch back to the stable release or restore your backup anytime."
5. For staging sites, verify the notice still reads: "…You can switch back to the stable release anytime." (no backup mention)

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?