### PR TITLE
MSD: Server-render the interim omnibar in the user's language

### DIFF
--- a/client/dashboard/app/i18n.tsx
+++ b/client/dashboard/app/i18n.tsx
@@ -1,34 +1,8 @@
-import { defaultI18n, type I18n, type LocaleData } from '@wordpress/i18n';
+import { defaultI18n, type I18n } from '@wordpress/i18n';
 import { I18nProvider as WPI18nProvider } from '@wordpress/react-i18n';
 import { useEffect, useState, type PropsWithChildren } from 'react';
 import { useAuth } from './auth';
-
-async function fetchLocaleData(
-	language: string,
-	signal: AbortSignal
-): Promise< [ string, LocaleData | undefined ] > {
-	if ( language === 'en' ) {
-		return [ language, undefined ];
-	}
-
-	try {
-		const response = await fetch(
-			`https://widgets.wp.com/languages/calypso/${ language }-v1.1.json`,
-			{ signal }
-		);
-
-		return [ language, await response.json() ];
-	} catch ( error ) {
-		// Only fall back to `en` when the error is not an abort
-		if ( error instanceof Error && error.name === 'AbortError' ) {
-			throw error;
-		}
-
-		// Fall back to `en` when fetching the language data fails. Without this
-		// the i18n provider would be stuck forever in a non-loaded state.
-		return [ 'en', undefined ];
-	}
-}
+import { getUserLanguage, loadUserLocaleData } from './shared-locale-loader';
 
 function getHtmlLangAttribute( i18n: I18n, fallback: string ) {
 	// translation of this string contains the desired HTML attribute value
@@ -145,12 +119,7 @@ async function switchWebpackCSS( isRTL: boolean ) {
 // slug in the route path.
 function useLocaleSlug() {
 	const { user } = useAuth();
-	type ComputedAttributes = {
-		localeSlug?: string;
-		localeVariant?: string;
-	};
-	const u = user as typeof user & ComputedAttributes;
-	return u.localeVariant || u.localeSlug || user.locale_variant || user.language || 'en';
+	return getUserLanguage( user );
 }
 
 export function I18nProvider( { children }: PropsWithChildren ) {
@@ -160,23 +129,21 @@ export function I18nProvider( { children }: PropsWithChildren ) {
 	const i18n = defaultI18n;
 
 	useEffect( () => {
-		const abortController = new AbortController();
+		let cancelled = false;
 
-		fetchLocaleData( language, abortController.signal )
-			.then( ( [ realLanguage, data ] ) => {
-				i18n.resetLocaleData( data );
-				// `realLanguage` can be different from `language` when loading language data fails
-				// and it falls back to `en`.
-				setLoadedLocale( realLanguage );
-				setLocaleInDOM( i18n, realLanguage );
-				switchWebpackCSS( i18n.isRTL() );
-			} )
-			.catch( () => {
-				// Ignore abort errors as they are expected during cleanup
-			} );
+		loadUserLocaleData( language ).then( ( data ) => {
+			if ( cancelled ) {
+				return;
+			}
+			i18n.resetLocaleData( data );
+			const realLanguage = data ? language : 'en';
+			setLoadedLocale( realLanguage );
+			setLocaleInDOM( i18n, realLanguage );
+			switchWebpackCSS( i18n.isRTL() );
+		} );
 
 		return () => {
-			abortController.abort();
+			cancelled = true;
 		};
 	}, [ i18n, language ] );
 

--- a/client/dashboard/app/i18n.tsx
+++ b/client/dashboard/app/i18n.tsx
@@ -1,8 +1,35 @@
-import { defaultI18n, type I18n } from '@wordpress/i18n';
+import { defaultI18n, type I18n, type LocaleData } from '@wordpress/i18n';
 import { I18nProvider as WPI18nProvider } from '@wordpress/react-i18n';
 import { useEffect, useState, type PropsWithChildren } from 'react';
 import { useAuth } from './auth';
-import { getUserLanguage, loadUserLocaleData } from './shared-locale-loader';
+import { getUserLanguage } from './shared-locale-loader';
+
+async function fetchLocaleData(
+	language: string,
+	signal: AbortSignal
+): Promise< [ string, LocaleData | undefined ] > {
+	if ( language === 'en' ) {
+		return [ language, undefined ];
+	}
+
+	try {
+		const response = await fetch(
+			`https://widgets.wp.com/languages/calypso/${ language }-v1.1.json`,
+			{ signal }
+		);
+
+		return [ language, await response.json() ];
+	} catch ( error ) {
+		// Only fall back to `en` when the error is not an abort
+		if ( error instanceof Error && error.name === 'AbortError' ) {
+			throw error;
+		}
+
+		// Fall back to `en` when fetching the language data fails. Without this
+		// the i18n provider would be stuck forever in a non-loaded state.
+		return [ 'en', undefined ];
+	}
+}
 
 function getHtmlLangAttribute( i18n: I18n, fallback: string ) {
 	// translation of this string contains the desired HTML attribute value
@@ -129,21 +156,23 @@ export function I18nProvider( { children }: PropsWithChildren ) {
 	const i18n = defaultI18n;
 
 	useEffect( () => {
-		let cancelled = false;
+		const abortController = new AbortController();
 
-		loadUserLocaleData( language ).then( ( data ) => {
-			if ( cancelled ) {
-				return;
-			}
-			i18n.resetLocaleData( data );
-			const realLanguage = data ? language : 'en';
-			setLoadedLocale( realLanguage );
-			setLocaleInDOM( i18n, realLanguage );
-			switchWebpackCSS( i18n.isRTL() );
-		} );
+		fetchLocaleData( language, abortController.signal )
+			.then( ( [ realLanguage, data ] ) => {
+				i18n.resetLocaleData( data );
+				// `realLanguage` can be different from `language` when loading language data fails
+				// and it falls back to `en`.
+				setLoadedLocale( realLanguage );
+				setLocaleInDOM( i18n, realLanguage );
+				switchWebpackCSS( i18n.isRTL() );
+			} )
+			.catch( () => {
+				// Ignore abort errors as they are expected during cleanup
+			} );
 
 		return () => {
-			cancelled = true;
+			abortController.abort();
 		};
 	}, [ i18n, language ] );
 

--- a/client/dashboard/app/interim-omnibar/index.tsx
+++ b/client/dashboard/app/interim-omnibar/index.tsx
@@ -1,4 +1,5 @@
-import { defaultI18n } from '@wordpress/i18n';
+// eslint-disable-next-line no-restricted-imports
+import { I18N, I18NContext } from 'i18n-calypso';
 import { hydrateRoot } from 'react-dom/client';
 import { getUserLanguage, loadUserLocaleData } from '../shared-locale-loader';
 import type { OmnibarEvents } from './omnibar-events';
@@ -27,19 +28,23 @@ export default async function loadOmnibar( events: OmnibarEvents ) {
 		events.linkClick.emit( { href, event } );
 	} );
 
-	// Apply the user's locale to `defaultI18n` before hydrating so the first
-	// client render matches the SSR-translated HTML. `getUserLanguage` mirrors
-	// the server's `setUpLoggedInRoute` derivation so both sides agree on the
-	// effective locale.
+	// Create a per-tree i18n-calypso instance loaded with the user's locale so
+	// the first client render matches the SSR-translated HTML. Provided via
+	// I18NContext so the `localize()` HOC picks it up without any global mutation.
 	const [ { InterimOmnibarContainer }, localeData ] = await Promise.all( [
 		import( './interim-omnibar-container' ),
 		loadUserLocaleData( getUserLanguage( window.currentUser ?? null ) ),
 	] );
 
-	defaultI18n.resetLocaleData( localeData );
+	const i18n = new I18N();
+	if ( localeData ) {
+		i18n.setLocale( localeData );
+	}
 
 	hydrateRoot(
 		container,
-		<InterimOmnibarContainer initialUser={ window.currentUser ?? null } events={ events } />
+		<I18NContext.Provider value={ i18n }>
+			<InterimOmnibarContainer initialUser={ window.currentUser ?? null } events={ events } />
+		</I18NContext.Provider>
 	);
 }

--- a/client/dashboard/app/interim-omnibar/index.tsx
+++ b/client/dashboard/app/interim-omnibar/index.tsx
@@ -1,4 +1,6 @@
+import { defaultI18n } from '@wordpress/i18n';
 import { hydrateRoot } from 'react-dom/client';
+import { getUserLanguage, loadUserLocaleData } from '../shared-locale-loader';
 import type { OmnibarEvents } from './omnibar-events';
 
 export default async function loadOmnibar( events: OmnibarEvents ) {
@@ -25,7 +27,16 @@ export default async function loadOmnibar( events: OmnibarEvents ) {
 		events.linkClick.emit( { href, event } );
 	} );
 
-	const { InterimOmnibarContainer } = await import( './interim-omnibar-container' );
+	// Apply the user's locale to `defaultI18n` before hydrating so the first
+	// client render matches the SSR-translated HTML. `getUserLanguage` mirrors
+	// the server's `setUpLoggedInRoute` derivation so both sides agree on the
+	// effective locale.
+	const [ { InterimOmnibarContainer }, localeData ] = await Promise.all( [
+		import( './interim-omnibar-container' ),
+		loadUserLocaleData( getUserLanguage( window.currentUser ?? null ) ),
+	] );
+
+	defaultI18n.resetLocaleData( localeData );
 
 	hydrateRoot(
 		container,

--- a/client/dashboard/app/interim-omnibar/index.tsx
+++ b/client/dashboard/app/interim-omnibar/index.tsx
@@ -1,4 +1,6 @@
+import { defaultI18n } from '@wordpress/i18n';
 import { hydrateRoot } from 'react-dom/client';
+import { getUserLanguage, loadUserLocaleData } from '../shared-locale-loader';
 import type { OmnibarEvents } from '../omnibar/events';
 
 export default async function loadOmnibar( events: OmnibarEvents ) {
@@ -25,7 +27,16 @@ export default async function loadOmnibar( events: OmnibarEvents ) {
 		events.linkClick.emit( { href, event } );
 	} );
 
-	const { InterimOmnibarContainer } = await import( './interim-omnibar-container' );
+	// Apply the user's locale to `defaultI18n` before hydrating so the first
+	// client render matches the SSR-translated HTML. `getUserLanguage` mirrors
+	// the server's `setUpLoggedInRoute` derivation so both sides agree on the
+	// effective locale.
+	const [ { InterimOmnibarContainer }, localeData ] = await Promise.all( [
+		import( './interim-omnibar-container' ),
+		loadUserLocaleData( getUserLanguage( window.currentUser ?? null ) ),
+	] );
+
+	defaultI18n.resetLocaleData( localeData );
 
 	hydrateRoot(
 		container,

--- a/client/dashboard/app/interim-omnibar/index.tsx
+++ b/client/dashboard/app/interim-omnibar/index.tsx
@@ -1,4 +1,5 @@
-import { defaultI18n } from '@wordpress/i18n';
+// eslint-disable-next-line no-restricted-imports
+import { I18N, I18NContext } from 'i18n-calypso';
 import { hydrateRoot } from 'react-dom/client';
 import { getUserLanguage, loadUserLocaleData } from '../shared-locale-loader';
 import type { OmnibarEvents } from '../omnibar/events';
@@ -27,19 +28,23 @@ export default async function loadOmnibar( events: OmnibarEvents ) {
 		events.linkClick.emit( { href, event } );
 	} );
 
-	// Apply the user's locale to `defaultI18n` before hydrating so the first
-	// client render matches the SSR-translated HTML. `getUserLanguage` mirrors
-	// the server's `setUpLoggedInRoute` derivation so both sides agree on the
-	// effective locale.
+	// Create a per-tree i18n-calypso instance loaded with the user's locale so
+	// the first client render matches the SSR-translated HTML. Provided via
+	// I18NContext so the `localize()` HOC picks it up without any global mutation.
 	const [ { InterimOmnibarContainer }, localeData ] = await Promise.all( [
 		import( './interim-omnibar-container' ),
 		loadUserLocaleData( getUserLanguage( window.currentUser ?? null ) ),
 	] );
 
-	defaultI18n.resetLocaleData( localeData );
+	const i18n = new I18N();
+	if ( localeData ) {
+		i18n.setLocale( localeData );
+	}
 
 	hydrateRoot(
 		container,
-		<InterimOmnibarContainer initialUser={ window.currentUser ?? null } events={ events } />
+		<I18NContext.Provider value={ i18n }>
+			<InterimOmnibarContainer initialUser={ window.currentUser ?? null } events={ events } />
+		</I18NContext.Provider>
 	);
 }

--- a/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
+++ b/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-restricted-imports */
 import { isEcommercePlan } from '@automattic/calypso-products';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { localize } from 'i18n-calypso';
 import { useEffect, useMemo } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { MasterbarLoggedIn } from 'calypso/layout/masterbar/logged-in';
@@ -10,6 +11,8 @@ import { logout } from '../auth';
 import { omnibarEvents, useOmnibarEvent } from '../omnibar/events';
 import { createOmnibarStore } from './omnibar-store';
 import type { User, Site } from '@automattic/api-core';
+
+const LocalizedMasterbarLoggedIn = localize( MasterbarLoggedIn );
 
 const noop = () => {};
 
@@ -73,7 +76,7 @@ export function InterimOmnibar( {
 	return (
 		<QueryClientProvider client={ omnibarQueryClient }>
 			<ReduxProvider store={ store }>
-				<MasterbarLoggedIn
+				<LocalizedMasterbarLoggedIn
 					// User
 					user={ user }
 					hasNoSites={ user.site_count === 0 }

--- a/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
+++ b/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-restricted-imports */
 import { isEcommercePlan } from '@automattic/calypso-products';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { localize } from 'i18n-calypso';
 import { useEffect, useMemo } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { MasterbarLoggedIn } from 'calypso/layout/masterbar/logged-in';
@@ -10,6 +11,8 @@ import { logout } from '../auth';
 import { omnibarEvents, useOmnibarEvent } from './omnibar-events';
 import { createOmnibarStore } from './omnibar-store';
 import type { User, Site } from '@automattic/api-core';
+
+const LocalizedMasterbarLoggedIn = localize( MasterbarLoggedIn );
 
 const noop = () => {};
 
@@ -73,7 +76,7 @@ export function InterimOmnibar( {
 	return (
 		<QueryClientProvider client={ omnibarQueryClient }>
 			<ReduxProvider store={ store }>
-				<MasterbarLoggedIn
+				<LocalizedMasterbarLoggedIn
 					// User
 					user={ user }
 					hasNoSites={ user.site_count === 0 }

--- a/client/dashboard/app/shared-locale-loader.ts
+++ b/client/dashboard/app/shared-locale-loader.ts
@@ -5,25 +5,24 @@ import type { User } from '@automattic/api-core';
 const dataPromises = new Map< string, Promise< LocaleData > >();
 
 /**
- * Derives the effective locale slug for a user. Mirrors the server's
- * `setUpLoggedInRoute` logic so SSR and client produce the same value:
+ * Derives the effective locale slug for a user. Called by both the dashboard
+ * SSR middleware (`loadDashboardLocaleData`) and the client hydration path
+ * (`loadOmnibar`), so the two agree on which locale file to load:
  *
  *   - Falls back to English when the user has
  *     `use_fallback_for_incomplete_languages` enabled and their language
- *     is not fully translated.
- *   - Otherwise returns the bootstrap-provided `localeSlug` (preferred),
- *     or the REST `locale_variant` / `language` for non-bootstrapped
- *     sessions.
- *
- * The server's incompleteness check uses `localeVariant || localeSlug`,
- * so we mirror that here.
+ *     is not fully translated (checked against `localeVariant || localeSlug`,
+ *     matching `setUpLoggedInRoute`).
+ *   - Prefers `localeVariant` (e.g. `es-mx`) so users get region-specific
+ *     translations, falling back to `localeSlug`, then to the REST
+ *     `locale_variant` / `language` fields for non-bootstrapped sessions.
  */
 export function getUserLanguage( user: User | null | undefined ): string {
 	if ( ! user ) {
 		return 'en';
 	}
 
-	const slug = user.localeSlug || user.locale_variant || user.language;
+	const slug = user.localeVariant || user.localeSlug || user.locale_variant || user.language;
 	if ( ! slug ) {
 		return 'en';
 	}

--- a/client/dashboard/app/shared-locale-loader.ts
+++ b/client/dashboard/app/shared-locale-loader.ts
@@ -1,0 +1,71 @@
+import { isTranslatedIncompletely } from '@automattic/i18n-utils';
+import { type LocaleData } from '@wordpress/i18n';
+import type { User } from '@automattic/api-core';
+
+const dataPromises = new Map< string, Promise< LocaleData > >();
+
+/**
+ * Derives the effective locale slug for a user. Mirrors the server's
+ * `setUpLoggedInRoute` logic so SSR and client produce the same value:
+ *
+ *   - Falls back to English when the user has
+ *     `use_fallback_for_incomplete_languages` enabled and their language
+ *     is not fully translated.
+ *   - Otherwise returns the bootstrap-provided `localeSlug` (preferred),
+ *     or the REST `locale_variant` / `language` for non-bootstrapped
+ *     sessions.
+ *
+ * The server's incompleteness check uses `localeVariant || localeSlug`,
+ * so we mirror that here.
+ */
+export function getUserLanguage( user: User | null | undefined ): string {
+	if ( ! user ) {
+		return 'en';
+	}
+
+	const slug = user.localeSlug || user.locale_variant || user.language;
+	if ( ! slug ) {
+		return 'en';
+	}
+
+	const checkAgainst = user.localeVariant || slug;
+	if ( user.use_fallback_for_incomplete_languages && isTranslatedIncompletely( checkAgainst ) ) {
+		return 'en';
+	}
+
+	return slug;
+}
+
+/**
+ * Fetches the user's locale JSON from the Calypso CDN and returns a cached
+ * promise per language, so concurrent callers share a single network
+ * request. Returns `undefined` for English (nothing to load) or on error.
+ *
+ * Pure cache + fetch — no singleton mutation. Callers are responsible for
+ * applying the result to `defaultI18n` (typically via `resetLocaleData`),
+ * gated on their own cancellation state.
+ */
+export function loadUserLocaleData( language: string ): Promise< LocaleData | undefined > {
+	if ( ! language || language === 'en' ) {
+		return Promise.resolve( undefined );
+	}
+
+	let dataPromise = dataPromises.get( language );
+	if ( ! dataPromise ) {
+		dataPromise = fetch( `https://widgets.wp.com/languages/calypso/${ language }-v1.1.json` ).then(
+			( response ) => {
+				if ( ! response.ok ) {
+					throw new Error( `Failed to load locale data for ${ language }` );
+				}
+				return response.json() as Promise< LocaleData >;
+			}
+		);
+		dataPromises.set( language, dataPromise );
+	}
+
+	return dataPromise.catch( () => {
+		// Drop the cached rejection so a later call can retry.
+		dataPromises.delete( language );
+		return undefined;
+	} );
+}

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -4,6 +4,7 @@ import { WordPressLogo } from '@automattic/components';
 import { isLocaleRtl } from '@automattic/i18n-utils';
 import { Step } from '@automattic/onboarding';
 import clsx from 'clsx';
+import defaultCalypsoI18n, { I18NContext } from 'i18n-calypso';
 import { useMemo, Component } from 'react';
 import A4ALogo from 'calypso/a8c-for-agencies/components/a4a-logo';
 import EnvironmentBadge, {
@@ -172,11 +173,13 @@ class Document extends Component {
 						config.isEnabled( 'dashboard/omnibar' ) &&
 						! config.isEnabled( 'dashboard/omnibar-radical' ) && (
 							<div id="wpcom-omnibar">
-								<InterimOmnibar
-									user={ user || null }
-									site={ null }
-									currentRoute={ this.props.path ?? '/' }
-								/>
+								<I18NContext.Provider value={ this.props.i18nCalypso || defaultCalypsoI18n }>
+									<InterimOmnibar
+										user={ user || null }
+										site={ null }
+										currentRoute={ this.props.path ?? '/' }
+									/>
+								</I18NContext.Provider>
 							</div>
 						) }
 					{ renderedLayout ? (

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -4,6 +4,7 @@ import { WordPressLogo } from '@automattic/components';
 import { isLocaleRtl } from '@automattic/i18n-utils';
 import { Step } from '@automattic/onboarding';
 import clsx from 'clsx';
+import defaultCalypsoI18n, { I18NContext } from 'i18n-calypso';
 import { useMemo, Component } from 'react';
 import A4ALogo from 'calypso/a8c-for-agencies/components/a4a-logo';
 import EnvironmentBadge, {
@@ -163,16 +164,18 @@ class Document extends Component {
 						'is-mobile-app-view': app?.isWpMobileApp || app?.isWcMobileApp,
 					} ) }
 				>
-					{ /* eslint-disable wpcalypso/jsx-classname-namespace, react/no-danger */ }
 					{ dashboard && config.isEnabled( 'dashboard/omnibar' ) && (
 						<div id="wpcom-omnibar">
-							<InterimOmnibar
-								user={ user || null }
-								site={ null }
-								currentRoute={ this.props.path ?? '/' }
-							/>
+							<I18NContext.Provider value={ this.props.i18nCalypso || defaultCalypsoI18n }>
+								<InterimOmnibar
+									user={ user || null }
+									site={ null }
+									currentRoute={ this.props.path ?? '/' }
+								/>
+							</I18NContext.Provider>
 						</div>
 					) }
+					{ /* eslint-disable react/no-danger */ }
 					{ renderedLayout ? (
 						<div
 							id="wpcom"

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -3,8 +3,7 @@ import { isEcommercePlan } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Gridicon } from '@automattic/components';
 import { Badge } from '@automattic/ui';
-import { createInterpolateElement } from '@wordpress/element';
-import { __, _x, sprintf } from '@wordpress/i18n';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { parse } from 'qs';
 import { Component } from 'react';
@@ -234,6 +233,8 @@ class MasterbarLoggedIn extends Component {
 	 * In nav unification, the menu is openned with the Sites button
 	 */
 	renderSidebarMobileMenu() {
+		const { translate } = this.props;
+
 		return (
 			<Item
 				tipTarget="mobile-menu"
@@ -241,7 +242,7 @@ class MasterbarLoggedIn extends Component {
 				onClick={ this.handleToggleMobileMenu }
 				isActive={ this.isSidebarOpen() }
 				className="masterbar__item-sidebar-menu"
-				tooltip={ __( 'Menu' ) }
+				tooltip={ translate( 'Menu' ) }
 			/>
 		);
 	}
@@ -251,6 +252,7 @@ class MasterbarLoggedIn extends Component {
 		const {
 			domainOnlySite,
 			siteSlug,
+			translate,
 			section,
 			currentRoute,
 			isGlobalSidebarVisible,
@@ -276,11 +278,11 @@ class MasterbarLoggedIn extends Component {
 			: [
 					[
 						{
-							label: __( 'Sites' ),
+							label: translate( 'Sites' ),
 							url: dashboardOptIn ? dashboardLink( '/sites' ) : '/sites',
 						},
 						{
-							label: __( 'Domains' ),
+							label: translate( 'Domains' ),
 							url: dashboardOptIn ? dashboardLink( '/domains' ) : '/domains/manage',
 						},
 					],
@@ -289,11 +291,11 @@ class MasterbarLoggedIn extends Component {
 						: [
 								[
 									{
-										label: __( 'About WordPress' ),
+										label: translate( 'About WordPress' ),
 										url: `${ siteAdminUrl }about.php`,
 									},
 									{
-										label: __( 'Get Involved' ),
+										label: translate( 'Get Involved' ),
 										url: `${ siteAdminUrl }contribute.php`,
 									},
 								],
@@ -309,7 +311,7 @@ class MasterbarLoggedIn extends Component {
 				subItems={ subItems }
 				onClick={ this.clickMySites }
 				isActive={ this.isMySitesActive() }
-				tooltip={ __( 'Manage your sites' ) }
+				tooltip={ translate( 'Manage your sites' ) }
 				preloadSection={ this.preloadMySites }
 				hasGlobalBorderStyle
 			/>
@@ -406,6 +408,7 @@ class MasterbarLoggedIn extends Component {
 	renderSiteBadges() {
 		const {
 			site,
+			translate,
 			isUnlaunchedSite,
 			isTrial,
 			isSiteP2,
@@ -439,12 +442,12 @@ class MasterbarLoggedIn extends Component {
 
 		// Staging Badge
 		if ( site?.is_wpcom_staging_site ) {
-			badges.push( __( 'Staging' ) );
+			badges.push( translate( 'Staging' ) );
 		}
 
 		// Trial Badge
 		if ( isTrial ) {
-			badges.push( __( 'Trial' ) );
+			badges.push( translate( 'Trial' ) );
 		}
 
 		// P2 Workspace Badge
@@ -455,28 +458,30 @@ class MasterbarLoggedIn extends Component {
 		// Private/Coming Soon Badge
 		if ( site.is_private ) {
 			badges.push(
-				shouldShowPrivateByDefaultComingSoonBadge ? __( 'Coming Soon' ) : __( 'Private' )
+				shouldShowPrivateByDefaultComingSoonBadge
+					? translate( 'Coming Soon' )
+					: translate( 'Private' )
 			);
 		}
 
 		// Express Service Badge
 		if ( site.options && site.options.is_difm_lite_in_progress ) {
-			badges.push( __( 'Express Service' ) );
+			badges.push( translate( 'Express Service' ) );
 		}
 
 		// Public Coming Soon Badge
 		if ( shouldShowPublicComingSoonSiteBadge ) {
-			badges.push( __( 'Coming Soon' ) );
+			badges.push( translate( 'Coming Soon' ) );
 		}
 
 		// Redirect Badge
 		if ( site.options && site.options.is_redirect ) {
-			badges.push( __( 'Redirect' ) );
+			badges.push( translate( 'Redirect' ) );
 		}
 
 		// Domain Badge
 		if ( site.options && site.options.is_domain_only ) {
-			badges.push( __( 'Domain' ) );
+			badges.push( translate( 'Domain' ) );
 		}
 
 		return badges.length > 0
@@ -491,6 +496,7 @@ class MasterbarLoggedIn extends Component {
 	renderSiteMenu() {
 		const {
 			siteSlug,
+			translate,
 			siteTitle,
 			siteUrl,
 			isClassicView,
@@ -506,19 +512,19 @@ class MasterbarLoggedIn extends Component {
 			return null;
 		}
 
-		const menuItems = [ { label: __( 'Visit Site' ), url: siteUrl } ];
+		const menuItems = [ { label: translate( 'Visit Site' ), url: siteUrl } ];
 
 		if ( isClassicView ) {
-			menuItems.push( { label: __( 'Dashboard' ), url: siteAdminUrl } );
+			menuItems.push( { label: translate( 'Dashboard' ), url: siteAdminUrl } );
 		} else {
-			menuItems.push( { label: __( 'My Home' ), url: siteHomeUrl } );
+			menuItems.push( { label: translate( 'My Home' ), url: siteHomeUrl } );
 		}
 
 		if ( ! site?.is_wpcom_staging_site ) {
 			menuItems.push( {
 				label: (
 					<div className="masterbar__site-info masterbar__site-plan">
-						<span className="masterbar__site-info-label">{ __( 'Plan' ) }</span>
+						<span className="masterbar__site-info-label">{ translate( 'Plan' ) }</span>
 						<div className="masterbar__info-badges">
 							<Badge className="masterbar__info-badge">{ sitePlanName }</Badge>
 						</div>
@@ -536,7 +542,7 @@ class MasterbarLoggedIn extends Component {
 			menuItems.push( {
 				label: (
 					<div className="masterbar__site-info masterbar__site-status">
-						<span className="masterbar__site-info-label">{ __( 'Status' ) }</span>
+						<span className="masterbar__site-info-label">{ translate( 'Status' ) }</span>
 						<div className="masterbar__info-badges">{ siteBadges }</div>
 					</div>
 				),
@@ -560,6 +566,7 @@ class MasterbarLoggedIn extends Component {
 		const {
 			siteSlug,
 			isClassicView,
+			translate,
 			siteAdminUrl,
 			newPostUrl,
 			newPageUrl,
@@ -580,38 +587,38 @@ class MasterbarLoggedIn extends Component {
 		if ( siteSlug ) {
 			siteActions = [
 				{
-					label: __( 'Post' ),
+					label: translate( 'Post' ),
 					url: newPostUrl,
 				},
 				{
-					label: __( 'Media' ),
+					label: translate( 'Media' ),
 					url: isClassicView ? `${ siteAdminUrl }media-new.php` : `/media/${ siteSlug }`,
 				},
 				{
-					label: __( 'Page' ),
+					label: translate( 'Page' ),
 					url: newPageUrl,
 				},
 				{
-					label: __( 'User' ),
+					label: translate( 'User' ),
 					url: isClassicView ? `${ siteAdminUrl }user-new.php` : `/people/new/${ siteSlug }`,
 				},
 			];
 		} else {
 			siteActions = [
 				{
-					label: __( 'Post' ),
+					label: translate( 'Post' ),
 					url: '/post',
 				},
 				{
-					label: __( 'Media' ),
+					label: translate( 'Media' ),
 					url: '/media',
 				},
 				{
-					label: __( 'Page' ),
+					label: translate( 'Page' ),
 					url: '/page',
 				},
 				{
-					label: __( 'User' ),
+					label: translate( 'User' ),
 					url: '/people/new',
 				},
 			];
@@ -622,10 +629,10 @@ class MasterbarLoggedIn extends Component {
 				url={ siteActions[ 0 ].url }
 				subItems={ [ siteActions ] }
 				icon={ <span className="dashicons-before dashicons-plus" /> }
-				tooltip={ _x( 'New', 'admin bar menu group label' ) }
+				tooltip={ translate( 'New', { context: 'admin bar menu group label' } ) }
 				tipTarget="new-menu"
 			>
-				{ _x( 'New', 'admin bar menu group label' ) }
+				{ translate( 'New', { context: 'admin bar menu group label' } ) }
 			</Item>
 		);
 	}
@@ -641,7 +648,7 @@ class MasterbarLoggedIn extends Component {
 	}
 
 	renderProfileMenu() {
-		const { user, isGlobalSidebarVisible, siteAdminUrl } = this.props;
+		const { translate, user, isGlobalSidebarVisible, siteAdminUrl } = this.props;
 		const profileActions = [
 			{
 				label: (
@@ -660,7 +667,7 @@ class MasterbarLoggedIn extends Component {
 								{ user.username }
 							</span>
 							<span className="display-name edit-profile">
-								{ isGlobalSidebarVisible ? __( 'My Profile' ) : __( 'Edit Profile' ) }
+								{ isGlobalSidebarVisible ? translate( 'My Profile' ) : translate( 'Edit Profile' ) }
 							</span>
 						</div>
 					</div>
@@ -668,9 +675,9 @@ class MasterbarLoggedIn extends Component {
 				url: isGlobalSidebarVisible ? '/me' : `${ siteAdminUrl }profile.php`,
 			},
 			{
-				label: __( 'Log Out' ),
+				label: translate( 'Log Out' ),
 				onClick: () => this.props.redirectToLogout(),
-				tooltip: __( 'Log out of WordPress.com' ),
+				tooltip: translate( 'Log out of WordPress.com' ),
 				className: 'logout-link',
 			},
 		];
@@ -679,13 +686,15 @@ class MasterbarLoggedIn extends Component {
 			{
 				label: (
 					<span className="button wpcom-button">
-						{ createInterpolateElement( __( 'My <wpcomIcon /> WordPress.com Account' ), {
-							wpcomIcon:
-								typeof this.wordpressIcon() !== 'string' ? (
-									this.wordpressIcon()
-								) : (
-									<Gridicon icon={ this.wordpressIcon() } size={ 24 } />
-								),
+						{ translate( 'My {{wpcomIcon/}} WordPress.com Account', {
+							components: {
+								wpcomIcon:
+									typeof this.wordpressIcon() !== 'string' ? (
+										this.wordpressIcon()
+									) : (
+										<Gridicon icon={ this.wordpressIcon() } size={ 24 } />
+									),
+							},
 						} ) }
 					</span>
 				),
@@ -701,18 +710,16 @@ class MasterbarLoggedIn extends Component {
 				onClick={ this.clickMe }
 				isActive={ this.isActive( 'me', true ) }
 				className="masterbar__item-howdy"
-				tooltip={ __( 'Update your profile, personal settings, and more' ) }
+				tooltip={ translate( 'Update your profile, personal settings, and more' ) }
 				preloadSection={ this.preloadMe }
 				subItems={ [ profileActions, wpcomActions ] }
 				hasGlobalBorderStyle
 			>
 				{ user.display_name && (
 					<span className="masterbar__item-howdy-howdy">
-						{ sprintf(
-							/* translators: %s is the user's display name */
-							__( 'Howdy, %s' ),
-							user.display_name
-						) }
+						{ translate( 'Howdy, %(display_name)s', {
+							args: { display_name: user.display_name },
+						} ) }
 					</span>
 				) }
 				<Gravatar
@@ -726,6 +733,7 @@ class MasterbarLoggedIn extends Component {
 	}
 
 	renderReader() {
+		const { translate } = this.props;
 		return (
 			<Item
 				tipTarget="reader"
@@ -734,12 +742,12 @@ class MasterbarLoggedIn extends Component {
 				icon={ <ReaderIcon className="masterbar__menu-icon masterbar_svg-reader" /> }
 				onClick={ this.clickReader }
 				isActive={ this.isActive( 'reader', true ) }
-				tooltip={ __( 'Read the blogs and topics you follow' ) }
+				tooltip={ translate( 'Read the blogs and topics you follow' ) }
 				preloadSection={ this.preloadReader }
 				hasGlobalBorderStyle
 			>
 				<span className="masterbar__icon-label masterbar__item-reader-label">
-					{ __( 'Reader' ) }
+					{ translate( 'Reader' ) }
 				</span>
 			</Item>
 		);
@@ -772,31 +780,31 @@ class MasterbarLoggedIn extends Component {
 	}
 
 	renderNotifications() {
+		const { translate } = this.props;
 		return (
 			<Notifications
 				isShowing
 				isActive={ this.isActive( 'notifications' ) }
 				className="masterbar__item-notifications"
-				tooltip={ __( 'Manage your notifications' ) }
+				tooltip={ translate( 'Manage your notifications' ) }
 			>
 				<span className="masterbar__item-notifications-label">
-					{
-						/* translators: Toolbar, must be shorter than ~12 chars */
-						_x( 'Notifications', 'masterbar' )
-					}
+					{ translate( 'Notifications', {
+						comment: 'Toolbar, must be shorter than ~12 chars',
+					} ) }
 				</span>
 			</Notifications>
 		);
 	}
 
 	renderHelpCenter() {
-		const { siteId, useUnifiedAgent } = this.props;
+		const { siteId, translate, useUnifiedAgent } = this.props;
 
 		if ( useUnifiedAgent ) {
 			const placeholder = (
 				<Item
 					className="masterbar__item-agents-manager"
-					tooltip={ __( 'Help' ) }
+					tooltip={ translate( 'Help' ) }
 					icon={ <AgentsManagerIcon hasUnread={ false } /> }
 				/>
 			);
@@ -809,7 +817,7 @@ class MasterbarLoggedIn extends Component {
 				<AsyncLoad
 					require={ loadMasterbarAgentsManager }
 					siteId={ siteId }
-					tooltip={ __( 'Help' ) }
+					tooltip={ translate( 'Help' ) }
 					placeholder={ placeholder }
 				/>
 			);
@@ -818,7 +826,7 @@ class MasterbarLoggedIn extends Component {
 		const placeholder = (
 			<Item
 				className="masterbar__item-help"
-				tooltip={ __( 'Help' ) }
+				tooltip={ translate( 'Help' ) }
 				icon={ <HelpCenterIcon hasUnread={ false } /> }
 			/>
 		);
@@ -831,7 +839,7 @@ class MasterbarLoggedIn extends Component {
 			<AsyncLoad
 				require={ loadMasterbarHelpCenter }
 				siteId={ siteId }
-				tooltip={ __( 'Help' ) }
+				tooltip={ translate( 'Help' ) }
 				placeholder={ placeholder }
 			/>
 		);
@@ -934,4 +942,4 @@ export default connect(
 		requestAdminMenu,
 		redirectToLogout,
 	}
-)( MasterbarLoggedIn );
+)( localize( MasterbarLoggedIn ) );

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -3,8 +3,7 @@ import { isEcommercePlan } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Gridicon } from '@automattic/components';
 import { Badge } from '@automattic/ui';
-import { createInterpolateElement } from '@wordpress/element';
-import { __, _x, sprintf } from '@wordpress/i18n';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { parse } from 'qs';
 import { Component } from 'react';
@@ -215,6 +214,8 @@ class MasterbarLoggedIn extends Component {
 	 * In nav unification, the menu is openned with the Sites button
 	 */
 	renderSidebarMobileMenu() {
+		const { translate } = this.props;
+
 		return (
 			<Item
 				tipTarget="mobile-menu"
@@ -222,7 +223,7 @@ class MasterbarLoggedIn extends Component {
 				onClick={ this.handleToggleMobileMenu }
 				isActive={ this.isSidebarOpen() }
 				className="masterbar__item-sidebar-menu"
-				tooltip={ __( 'Menu' ) }
+				tooltip={ translate( 'Menu' ) }
 			/>
 		);
 	}
@@ -232,6 +233,7 @@ class MasterbarLoggedIn extends Component {
 		const {
 			domainOnlySite,
 			siteSlug,
+			translate,
 			section,
 			currentRoute,
 			isGlobalSidebarVisible,
@@ -257,11 +259,11 @@ class MasterbarLoggedIn extends Component {
 			: [
 					[
 						{
-							label: __( 'Sites' ),
+							label: translate( 'Sites' ),
 							url: dashboardOptIn ? dashboardLink( '/sites' ) : '/sites',
 						},
 						{
-							label: __( 'Domains' ),
+							label: translate( 'Domains' ),
 							url: dashboardOptIn ? dashboardLink( '/domains' ) : '/domains/manage',
 						},
 					],
@@ -270,11 +272,11 @@ class MasterbarLoggedIn extends Component {
 						: [
 								[
 									{
-										label: __( 'About WordPress' ),
+										label: translate( 'About WordPress' ),
 										url: `${ siteAdminUrl }about.php`,
 									},
 									{
-										label: __( 'Get Involved' ),
+										label: translate( 'Get Involved' ),
 										url: `${ siteAdminUrl }contribute.php`,
 									},
 								],
@@ -290,7 +292,7 @@ class MasterbarLoggedIn extends Component {
 				subItems={ subItems }
 				onClick={ this.clickMySites }
 				isActive={ this.isMySitesActive() }
-				tooltip={ __( 'Manage your sites' ) }
+				tooltip={ translate( 'Manage your sites' ) }
 				preloadSection={ this.preloadMySites }
 				hasGlobalBorderStyle
 			/>
@@ -387,6 +389,7 @@ class MasterbarLoggedIn extends Component {
 	renderSiteBadges() {
 		const {
 			site,
+			translate,
 			isUnlaunchedSite,
 			isTrial,
 			isSiteP2,
@@ -420,12 +423,12 @@ class MasterbarLoggedIn extends Component {
 
 		// Staging Badge
 		if ( site?.is_wpcom_staging_site ) {
-			badges.push( __( 'Staging' ) );
+			badges.push( translate( 'Staging' ) );
 		}
 
 		// Trial Badge
 		if ( isTrial ) {
-			badges.push( __( 'Trial' ) );
+			badges.push( translate( 'Trial' ) );
 		}
 
 		// P2 Workspace Badge
@@ -436,28 +439,30 @@ class MasterbarLoggedIn extends Component {
 		// Private/Coming Soon Badge
 		if ( site.is_private ) {
 			badges.push(
-				shouldShowPrivateByDefaultComingSoonBadge ? __( 'Coming Soon' ) : __( 'Private' )
+				shouldShowPrivateByDefaultComingSoonBadge
+					? translate( 'Coming Soon' )
+					: translate( 'Private' )
 			);
 		}
 
 		// Express Service Badge
 		if ( site.options && site.options.is_difm_lite_in_progress ) {
-			badges.push( __( 'Express Service' ) );
+			badges.push( translate( 'Express Service' ) );
 		}
 
 		// Public Coming Soon Badge
 		if ( shouldShowPublicComingSoonSiteBadge ) {
-			badges.push( __( 'Coming Soon' ) );
+			badges.push( translate( 'Coming Soon' ) );
 		}
 
 		// Redirect Badge
 		if ( site.options && site.options.is_redirect ) {
-			badges.push( __( 'Redirect' ) );
+			badges.push( translate( 'Redirect' ) );
 		}
 
 		// Domain Badge
 		if ( site.options && site.options.is_domain_only ) {
-			badges.push( __( 'Domain' ) );
+			badges.push( translate( 'Domain' ) );
 		}
 
 		return badges.length > 0
@@ -472,6 +477,7 @@ class MasterbarLoggedIn extends Component {
 	renderSiteMenu() {
 		const {
 			siteSlug,
+			translate,
 			siteTitle,
 			siteUrl,
 			isClassicView,
@@ -487,19 +493,19 @@ class MasterbarLoggedIn extends Component {
 			return null;
 		}
 
-		const menuItems = [ { label: __( 'Visit Site' ), url: siteUrl } ];
+		const menuItems = [ { label: translate( 'Visit Site' ), url: siteUrl } ];
 
 		if ( isClassicView ) {
-			menuItems.push( { label: __( 'Dashboard' ), url: siteAdminUrl } );
+			menuItems.push( { label: translate( 'Dashboard' ), url: siteAdminUrl } );
 		} else {
-			menuItems.push( { label: __( 'My Home' ), url: siteHomeUrl } );
+			menuItems.push( { label: translate( 'My Home' ), url: siteHomeUrl } );
 		}
 
 		if ( ! site?.is_wpcom_staging_site ) {
 			menuItems.push( {
 				label: (
 					<div className="masterbar__site-info masterbar__site-plan">
-						<span className="masterbar__site-info-label">{ __( 'Plan' ) }</span>
+						<span className="masterbar__site-info-label">{ translate( 'Plan' ) }</span>
 						<div className="masterbar__info-badges">
 							<Badge className="masterbar__info-badge">{ sitePlanName }</Badge>
 						</div>
@@ -517,7 +523,7 @@ class MasterbarLoggedIn extends Component {
 			menuItems.push( {
 				label: (
 					<div className="masterbar__site-info masterbar__site-status">
-						<span className="masterbar__site-info-label">{ __( 'Status' ) }</span>
+						<span className="masterbar__site-info-label">{ translate( 'Status' ) }</span>
 						<div className="masterbar__info-badges">{ siteBadges }</div>
 					</div>
 				),
@@ -541,6 +547,7 @@ class MasterbarLoggedIn extends Component {
 		const {
 			siteSlug,
 			isClassicView,
+			translate,
 			siteAdminUrl,
 			newPostUrl,
 			newPageUrl,
@@ -561,38 +568,38 @@ class MasterbarLoggedIn extends Component {
 		if ( siteSlug ) {
 			siteActions = [
 				{
-					label: __( 'Post' ),
+					label: translate( 'Post' ),
 					url: newPostUrl,
 				},
 				{
-					label: __( 'Media' ),
+					label: translate( 'Media' ),
 					url: isClassicView ? `${ siteAdminUrl }media-new.php` : `/media/${ siteSlug }`,
 				},
 				{
-					label: __( 'Page' ),
+					label: translate( 'Page' ),
 					url: newPageUrl,
 				},
 				{
-					label: __( 'User' ),
+					label: translate( 'User' ),
 					url: isClassicView ? `${ siteAdminUrl }user-new.php` : `/people/new/${ siteSlug }`,
 				},
 			];
 		} else {
 			siteActions = [
 				{
-					label: __( 'Post' ),
+					label: translate( 'Post' ),
 					url: '/post',
 				},
 				{
-					label: __( 'Media' ),
+					label: translate( 'Media' ),
 					url: '/media',
 				},
 				{
-					label: __( 'Page' ),
+					label: translate( 'Page' ),
 					url: '/page',
 				},
 				{
-					label: __( 'User' ),
+					label: translate( 'User' ),
 					url: '/people/new',
 				},
 			];
@@ -603,10 +610,10 @@ class MasterbarLoggedIn extends Component {
 				url={ siteActions[ 0 ].url }
 				subItems={ [ siteActions ] }
 				icon={ <span className="dashicons-before dashicons-plus" /> }
-				tooltip={ _x( 'New', 'admin bar menu group label' ) }
+				tooltip={ translate( 'New', { context: 'admin bar menu group label' } ) }
 				tipTarget="new-menu"
 			>
-				{ _x( 'New', 'admin bar menu group label' ) }
+				{ translate( 'New', { context: 'admin bar menu group label' } ) }
 			</Item>
 		);
 	}
@@ -622,7 +629,7 @@ class MasterbarLoggedIn extends Component {
 	}
 
 	renderProfileMenu() {
-		const { user, isGlobalSidebarVisible, siteAdminUrl } = this.props;
+		const { translate, user, isGlobalSidebarVisible, siteAdminUrl } = this.props;
 		const profileActions = [
 			{
 				label: (
@@ -641,7 +648,7 @@ class MasterbarLoggedIn extends Component {
 								{ user.username }
 							</span>
 							<span className="display-name edit-profile">
-								{ isGlobalSidebarVisible ? __( 'My Profile' ) : __( 'Edit Profile' ) }
+								{ isGlobalSidebarVisible ? translate( 'My Profile' ) : translate( 'Edit Profile' ) }
 							</span>
 						</div>
 					</div>
@@ -649,9 +656,9 @@ class MasterbarLoggedIn extends Component {
 				url: isGlobalSidebarVisible ? '/me' : `${ siteAdminUrl }profile.php`,
 			},
 			{
-				label: __( 'Log Out' ),
+				label: translate( 'Log Out' ),
 				onClick: () => this.props.redirectToLogout(),
-				tooltip: __( 'Log out of WordPress.com' ),
+				tooltip: translate( 'Log out of WordPress.com' ),
 				className: 'logout-link',
 			},
 		];
@@ -660,13 +667,15 @@ class MasterbarLoggedIn extends Component {
 			{
 				label: (
 					<span className="button wpcom-button">
-						{ createInterpolateElement( __( 'My <wpcomIcon /> WordPress.com Account' ), {
-							wpcomIcon:
-								typeof this.wordpressIcon() !== 'string' ? (
-									this.wordpressIcon()
-								) : (
-									<Gridicon icon={ this.wordpressIcon() } size={ 24 } />
-								),
+						{ translate( 'My {{wpcomIcon/}} WordPress.com Account', {
+							components: {
+								wpcomIcon:
+									typeof this.wordpressIcon() !== 'string' ? (
+										this.wordpressIcon()
+									) : (
+										<Gridicon icon={ this.wordpressIcon() } size={ 24 } />
+									),
+							},
 						} ) }
 					</span>
 				),
@@ -682,18 +691,16 @@ class MasterbarLoggedIn extends Component {
 				onClick={ this.clickMe }
 				isActive={ this.isActive( 'me', true ) }
 				className="masterbar__item-howdy"
-				tooltip={ __( 'Update your profile, personal settings, and more' ) }
+				tooltip={ translate( 'Update your profile, personal settings, and more' ) }
 				preloadSection={ this.preloadMe }
 				subItems={ [ profileActions, wpcomActions ] }
 				hasGlobalBorderStyle
 			>
 				{ user.display_name && (
 					<span className="masterbar__item-howdy-howdy">
-						{ sprintf(
-							/* translators: %s is the user's display name */
-							__( 'Howdy, %s' ),
-							user.display_name
-						) }
+						{ translate( 'Howdy, %(display_name)s', {
+							args: { display_name: user.display_name },
+						} ) }
 					</span>
 				) }
 				<Gravatar
@@ -707,6 +714,7 @@ class MasterbarLoggedIn extends Component {
 	}
 
 	renderReader() {
+		const { translate } = this.props;
 		return (
 			<Item
 				tipTarget="reader"
@@ -715,12 +723,12 @@ class MasterbarLoggedIn extends Component {
 				icon={ <ReaderIcon className="masterbar__menu-icon masterbar_svg-reader" /> }
 				onClick={ this.clickReader }
 				isActive={ this.isActive( 'reader', true ) }
-				tooltip={ __( 'Read the blogs and topics you follow' ) }
+				tooltip={ translate( 'Read the blogs and topics you follow' ) }
 				preloadSection={ this.preloadReader }
 				hasGlobalBorderStyle
 			>
 				<span className="masterbar__icon-label masterbar__item-reader-label">
-					{ __( 'Reader' ) }
+					{ translate( 'Reader' ) }
 				</span>
 			</Item>
 		);
@@ -753,31 +761,31 @@ class MasterbarLoggedIn extends Component {
 	}
 
 	renderNotifications() {
+		const { translate } = this.props;
 		return (
 			<Notifications
 				isShowing
 				isActive={ this.isActive( 'notifications' ) }
 				className="masterbar__item-notifications"
-				tooltip={ __( 'Manage your notifications' ) }
+				tooltip={ translate( 'Manage your notifications' ) }
 			>
 				<span className="masterbar__item-notifications-label">
-					{
-						/* translators: Toolbar, must be shorter than ~12 chars */
-						_x( 'Notifications', 'masterbar' )
-					}
+					{ translate( 'Notifications', {
+						comment: 'Toolbar, must be shorter than ~12 chars',
+					} ) }
 				</span>
 			</Notifications>
 		);
 	}
 
 	renderHelpCenter() {
-		const { siteId, useUnifiedAgent } = this.props;
+		const { siteId, translate, useUnifiedAgent } = this.props;
 
 		if ( useUnifiedAgent ) {
 			const placeholder = (
 				<Item
 					className="masterbar__item-agents-manager"
-					tooltip={ __( 'Help' ) }
+					tooltip={ translate( 'Help' ) }
 					icon={ <AgentsManagerIcon hasUnread={ false } /> }
 				/>
 			);
@@ -790,7 +798,7 @@ class MasterbarLoggedIn extends Component {
 				<AsyncLoad
 					require="./masterbar-agents-manager"
 					siteId={ siteId }
-					tooltip={ __( 'Help' ) }
+					tooltip={ translate( 'Help' ) }
 					placeholder={ placeholder }
 				/>
 			);
@@ -799,7 +807,7 @@ class MasterbarLoggedIn extends Component {
 		const placeholder = (
 			<Item
 				className="masterbar__item-help"
-				tooltip={ __( 'Help' ) }
+				tooltip={ translate( 'Help' ) }
 				icon={ <HelpCenterIcon hasUnread={ false } /> }
 			/>
 		);
@@ -812,7 +820,7 @@ class MasterbarLoggedIn extends Component {
 			<AsyncLoad
 				require="./masterbar-help-center"
 				siteId={ siteId }
-				tooltip={ __( 'Help' ) }
+				tooltip={ translate( 'Help' ) }
 				placeholder={ placeholder }
 			/>
 		);
@@ -915,4 +923,4 @@ export default connect(
 		requestAdminMenu,
 		redirectToLogout,
 	}
-)( MasterbarLoggedIn );
+)( localize( MasterbarLoggedIn ) );

--- a/client/server/dashboard-i18n.ts
+++ b/client/server/dashboard-i18n.ts
@@ -2,6 +2,7 @@
 import { readFile } from 'fs/promises';
 import { type Request, type RequestHandler } from 'express';
 import { I18N } from 'i18n-calypso';
+import { getUserLanguage } from 'calypso/dashboard/app/shared-locale-loader';
 import getAssetFilePath from 'calypso/lib/get-asset-file-path';
 import { getLanguageFile } from 'calypso/lib/i18n-utils/switch-locale';
 
@@ -9,7 +10,9 @@ type LocaleData = Parameters< I18N[ 'setLocale' ] >[ 0 ];
 
 const localeDataCache = new Map< string, LocaleData >();
 
-type CalypsoRequest = Request & { context?: { lang?: string; i18nCalypso?: I18N } };
+type CalypsoRequest = Request & {
+	context?: { user?: Parameters< typeof getUserLanguage >[ 0 ]; i18nCalypso?: I18N };
+};
 
 /**
  * Creates a per-request i18n-calypso instance loaded with the user's locale so
@@ -19,7 +22,8 @@ type CalypsoRequest = Request & { context?: { lang?: string; i18nCalypso?: I18N 
  * `I18NContext.Provider`.
  */
 export const loadDashboardLocaleData: RequestHandler = ( req, res, next ) => {
-	const language = ( req as CalypsoRequest ).context?.lang;
+	const user = ( req as CalypsoRequest ).context?.user;
+	const language = getUserLanguage( user );
 	if ( ! language || language === 'en' ) {
 		next();
 		return;

--- a/client/server/dashboard-i18n.ts
+++ b/client/server/dashboard-i18n.ts
@@ -1,30 +1,37 @@
 // eslint-disable-next-line import/no-nodejs-modules
 import { readFile } from 'fs/promises';
-import { defaultI18n, type LocaleData } from '@wordpress/i18n';
 import { type Request, type RequestHandler } from 'express';
+import { I18N } from 'i18n-calypso';
 import getAssetFilePath from 'calypso/lib/get-asset-file-path';
 import { getLanguageFile } from 'calypso/lib/i18n-utils/switch-locale';
 
+type LocaleData = Parameters< I18N[ 'setLocale' ] >[ 0 ];
+
 const localeDataCache = new Map< string, LocaleData >();
 
-type CalypsoRequest = Request & { context?: { lang?: string } };
+type CalypsoRequest = Request & { context?: { lang?: string; i18nCalypso?: I18N } };
 
 /**
- * Populates `defaultI18n` with the bootstrapped user's locale for the duration
- * of the request's render, so the server-side render of the interim omnibar
- * emits translated strings. Loads from `public/languages/` when available and
- * falls back to the Calypso CDN otherwise.
+ * Creates a per-request i18n-calypso instance loaded with the user's locale so
+ * the server-side render of the interim omnibar emits translated strings
+ * without mutating any global singleton. The instance is stored on
+ * `req.context.i18nCalypso` and provided to the React tree via
+ * `I18NContext.Provider`.
  */
 export const loadDashboardLocaleData: RequestHandler = ( req, res, next ) => {
 	const language = ( req as CalypsoRequest ).context?.lang;
 	if ( ! language || language === 'en' ) {
-		defaultI18n.resetLocaleData();
 		next();
 		return;
 	}
 
 	const apply = ( data: LocaleData ) => {
-		defaultI18n.resetLocaleData( data );
+		const i18n = new I18N();
+		i18n.setLocale( data );
+		const ctx = ( req as CalypsoRequest ).context;
+		if ( ctx ) {
+			ctx.i18nCalypso = i18n;
+		}
 		next();
 	};
 
@@ -36,13 +43,12 @@ export const loadDashboardLocaleData: RequestHandler = ( req, res, next ) => {
 
 	readFile( getAssetFilePath( `languages/${ language }-v1.1.json` ), 'utf-8' )
 		.then( ( raw ) => JSON.parse( raw ) as LocaleData )
-		.catch( () => getLanguageFile( language ) as Promise< LocaleData > )
+		.catch( () => getLanguageFile( language ) as unknown as Promise< LocaleData > )
 		.then( ( data ) => {
 			localeDataCache.set( language, data );
 			apply( data );
 		} )
 		.catch( () => {
-			defaultI18n.resetLocaleData();
 			next();
 		} );
 };

--- a/client/server/dashboard-i18n.ts
+++ b/client/server/dashboard-i18n.ts
@@ -1,0 +1,48 @@
+// eslint-disable-next-line import/no-nodejs-modules
+import { readFile } from 'fs/promises';
+import { defaultI18n, type LocaleData } from '@wordpress/i18n';
+import { type Request, type RequestHandler } from 'express';
+import getAssetFilePath from 'calypso/lib/get-asset-file-path';
+import { getLanguageFile } from 'calypso/lib/i18n-utils/switch-locale';
+
+const localeDataCache = new Map< string, LocaleData >();
+
+type CalypsoRequest = Request & { context?: { lang?: string } };
+
+/**
+ * Populates `defaultI18n` with the bootstrapped user's locale for the duration
+ * of the request's render, so the server-side render of the interim omnibar
+ * emits translated strings. Loads from `public/languages/` when available and
+ * falls back to the Calypso CDN otherwise.
+ */
+export const loadDashboardLocaleData: RequestHandler = ( req, res, next ) => {
+	const language = ( req as CalypsoRequest ).context?.lang;
+	if ( ! language || language === 'en' ) {
+		defaultI18n.resetLocaleData();
+		next();
+		return;
+	}
+
+	const apply = ( data: LocaleData ) => {
+		defaultI18n.resetLocaleData( data );
+		next();
+	};
+
+	const cached = localeDataCache.get( language );
+	if ( cached ) {
+		apply( cached );
+		return;
+	}
+
+	readFile( getAssetFilePath( `languages/${ language }-v1.1.json` ), 'utf-8' )
+		.then( ( raw ) => JSON.parse( raw ) as LocaleData )
+		.catch( () => getLanguageFile( language ) as Promise< LocaleData > )
+		.then( ( data ) => {
+			localeDataCache.set( language, data );
+			apply( data );
+		} )
+		.catch( () => {
+			defaultI18n.resetLocaleData();
+			next();
+		} );
+};

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -36,6 +36,7 @@ import { login } from 'calypso/lib/paths';
 import loginRouter, { LOGIN_SECTION_DEFINITION } from 'calypso/login';
 import sections from 'calypso/sections';
 import isSectionEnabled from 'calypso/sections-filter';
+import { loadDashboardLocaleData } from 'calypso/server/dashboard-i18n';
 import { serverRouter, getCacheKey } from 'calypso/server/isomorphic-routing';
 import { isWpMobileApp, isWcMobileApp } from 'calypso/server/lib/is-mobile-app';
 import performanceMark from 'calypso/server/lib/performance-mark/index';
@@ -1190,7 +1191,7 @@ export default function pages() {
 	 * This approach allows requests to an SSR section to skip any section-specific
 	 * SSR middleware if the request wasn't going to be resolved with SSR anyways.
 	 */
-	function handleSectionPath( section, sectionPath, entrypoint, reqFilter ) {
+	function handleSectionPath( section, sectionPath, entrypoint, reqFilter, extraMiddleware ) {
 		const pathRegex = pathToRegExp( sectionPath );
 
 		app.get(
@@ -1210,6 +1211,7 @@ export default function pages() {
 				next();
 			},
 			setUpRoute, // For SSR requests, this will happen in the serverRouter.
+			...( extraMiddleware ? [ extraMiddleware ] : [] ),
 			serverRender
 		);
 	}
@@ -1232,7 +1234,8 @@ export default function pages() {
 				DOTCOM_DASHBOARD_SECTION_DEFINITION,
 				route,
 				'entry-dashboard-dotcom',
-				( req ) => isAllowedDotcomDashboardHostname( req.hostname )
+				( req ) => isAllowedDotcomDashboardHostname( req.hostname ),
+				loadDashboardLocaleData
 			);
 		} );
 		DASHBOARD_SECTION_PATHS.forEach( ( route ) => {
@@ -1240,14 +1243,16 @@ export default function pages() {
 				CIAB_DASHBOARD_SECTION_DEFINITION,
 				route,
 				'entry-dashboard-ciab',
-				( req ) => isAllowedCiabDashboardHostname( req.hostname )
+				( req ) => isAllowedCiabDashboardHostname( req.hostname ),
+				loadDashboardLocaleData
 			);
 		} );
 		handleSectionPath(
 			CIAB_DASHBOARD_SECTION_DEFINITION,
 			'/start-store',
 			'entry-dashboard-ciab',
-			( req ) => isAllowedCiabDashboardHostname( req.hostname )
+			( req ) => isAllowedCiabDashboardHostname( req.hostname ),
+			loadDashboardLocaleData
 		);
 	}
 

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -36,6 +36,7 @@ import { login } from 'calypso/lib/paths';
 import loginRouter, { LOGIN_SECTION_DEFINITION } from 'calypso/login';
 import sections from 'calypso/sections';
 import isSectionEnabled from 'calypso/sections-filter';
+import { loadDashboardLocaleData } from 'calypso/server/dashboard-i18n';
 import { serverRouter, getCacheKey } from 'calypso/server/isomorphic-routing';
 import { isWpMobileApp, isWcMobileApp } from 'calypso/server/lib/is-mobile-app';
 import performanceMark from 'calypso/server/lib/performance-mark/index';
@@ -1075,7 +1076,7 @@ export default function pages() {
 	 * This approach allows requests to an SSR section to skip any section-specific
 	 * SSR middleware if the request wasn't going to be resolved with SSR anyways.
 	 */
-	function handleSectionPath( section, sectionPath, entrypoint, reqFilter ) {
+	function handleSectionPath( section, sectionPath, entrypoint, reqFilter, extraMiddleware ) {
 		const pathRegex = pathToRegExp( sectionPath );
 
 		app.get(
@@ -1095,6 +1096,7 @@ export default function pages() {
 				next();
 			},
 			setUpRoute, // For SSR requests, this will happen in the serverRouter.
+			...( extraMiddleware ? [ extraMiddleware ] : [] ),
 			serverRender
 		);
 	}
@@ -1117,7 +1119,8 @@ export default function pages() {
 				DOTCOM_DASHBOARD_SECTION_DEFINITION,
 				route,
 				'entry-dashboard-dotcom',
-				( req ) => isAllowedDotcomDashboardHostname( req.hostname )
+				( req ) => isAllowedDotcomDashboardHostname( req.hostname ),
+				loadDashboardLocaleData
 			);
 		} );
 		DASHBOARD_SECTION_PATHS.forEach( ( route ) => {
@@ -1125,14 +1128,16 @@ export default function pages() {
 				CIAB_DASHBOARD_SECTION_DEFINITION,
 				route,
 				'entry-dashboard-ciab',
-				( req ) => isAllowedCiabDashboardHostname( req.hostname )
+				( req ) => isAllowedCiabDashboardHostname( req.hostname ),
+				loadDashboardLocaleData
 			);
 		} );
 		handleSectionPath(
 			CIAB_DASHBOARD_SECTION_DEFINITION,
 			'/start-store',
 			'entry-dashboard-ciab',
-			( req ) => isAllowedCiabDashboardHostname( req.hostname )
+			( req ) => isAllowedCiabDashboardHostname( req.hostname ),
+			loadDashboardLocaleData
 		);
 	}
 

--- a/packages/i18n-calypso/src/types/index.d.ts
+++ b/packages/i18n-calypso/src/types/index.d.ts
@@ -139,6 +139,7 @@ export interface I18N {
 
 declare const i18n: I18N;
 export default i18n;
+export declare const I18N: new () => I18N;
 export declare const translate: typeof i18n.translate;
 export declare const setLocale: typeof i18n.setLocale;
 export declare const addTranslations: typeof i18n.addTranslations;


### PR DESCRIPTION
Part of DOTMSD-1199

## Proposed Changes

- Render the interim omnibar in the user's language on the server, so non-English users see translations on the first visible frame instead of a flash of English.
- Prefer the user's regional variant (e.g. `es-mx`) over the base locale, so variant users get region-specific translations.

## Why are these changes being made?

- The omnibar currently renders in English regardless of account language, then flips to the user's language once the main dashboard finishes loading.

## Requirements

Requires `wpcom-user-bootstrap: true` so the server knows the user's locale at render time. Horizon, stage, and production dashboard environments have this enabled; local dev (`dashboard-development.json`) does not by default.

## Testing Instructions

1. Set your WordPress.com account language to a non-English locale (French, Arabic, etc.).
2. Hard-reload a dashboard page with the omnibar visible.
3. Confirm the masterbar renders translated on the first visible frame.
4. Change your account language, return to the dashboard, reload. Confirm the new language applies (including when switching back to English).

To test locally, flip `wpcom-user-bootstrap: true` in `config/dashboard-development.json` and make sure `wpcom_calypso_rest_api_key` is in your secrets.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?