### PR TITLE
Fix: Masterbar Horizon crash from string icon in createInterpolateElement

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import { isEcommercePlan } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
+import { Gridicon } from '@automattic/components';
 import { Badge } from '@automattic/ui';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
@@ -660,7 +661,12 @@ class MasterbarLoggedIn extends Component {
 				label: (
 					<span className="button wpcom-button">
 						{ createInterpolateElement( __( 'My <wpcomIcon /> WordPress.com Account' ), {
-							wpcomIcon: this.wordpressIcon(),
+							wpcomIcon:
+								typeof this.wordpressIcon() !== 'string' ? (
+									this.wordpressIcon()
+								) : (
+									<Gridicon icon={ this.wordpressIcon() } size={ 24 } />
+								),
 						} ) }
 					</span>
 				),


### PR DESCRIPTION


## Proposed Changes

* In `MasterbarLoggedIn`, wrap the result of `wordpressIcon()` in a `Gridicon` when it returns a string, mirroring the approach used in `client/layout/masterbar/item.tsx` (line 102).

Rather than a broken button label, we now have this. It doesn't look great. But it wasn't working at all before.

<img width="316" alt="CleanShot 2026-04-09 at 16 43 06@2x" src="https://github.com/user-attachments/assets/d2fa7516-6ba1-4b9e-97e9-80d19e8b6e80" />

## Why are these changes being made?

* On Horizon, `wordpressIcon()` returns the string `'my-sites-horizon'` instead of an SVG element. Since #109489 migrated this code from `i18n-calypso`'s `translate()` (with `components`) to `@wordpress/element`'s `createInterpolateElement`, that string crashes the render: `createInterpolateElement` requires every value in the conversion map to be a React element, while the old `translate()` was forgiving and accepted strings. The bug was arguably latent before — the code only ever happened to pass elements — but the stricter API surfaced it on Horizon.
* The same string-or-element pattern exists in `item.tsx`, which already handles it with `typeof icon !== 'string' ? icon : <Gridicon icon={ icon } size={ 24 } />`. This PR uses the same shape for consistency.

## Testing Instructions

* Load the masterbar against Horizon (`hostname === 'horizon.wordpress.com'`) and confirm it renders without crashing and the WordPress.com account icon shows.
* Load on a non-Horizon environment and confirm the SVG icon still renders.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?