### PR TITLE
A4A: Fix siteless renewal showing error screen instead of checkout

### DIFF
--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -310,7 +310,8 @@ class ManagePurchase extends Component<
 		const isSitelessRenewal =
 			purchase &&
 			( isAkismetTemporarySitePurchase( purchase ) ||
-				isMarketplaceTemporarySitePurchase( purchase ) );
+				isMarketplaceTemporarySitePurchase( purchase ) ||
+				isA4ATemporarySitePurchase( purchase ) );
 
 		if ( ! purchase ) {
 			return;


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-2382/renew-now-fails-for-pressable-siteless-purchase

Context: p1775673063900849-slack-C091P0A65U5

## Proposed Changes

* Add `isA4ATemporarySitePurchase` to the `isSitelessRenewal` check in `manage-purchase/index.tsx`, so A4A managed site renewals drop the site slug before calling `handleRenewNowClick`.

## Why are these changes being made?

When a user clicked "Renew now" on an A4A siteless purchase, the renewal URL included the siteless site slug. This routed through the site-based checkout flow, triggering the siteSelection middleware and resulting in an error screen instead of the renewal checkout page.

The fix mirrors how Akismet and Marketplace siteless renewals already work — by dropping the site slug, the renewal goes through the siteless checkout flow and bypasses `siteSelection` entirely.

## Testing Instructions

* Open Calypso live link
* Go to https://wordpress.com/me/purchases
* Open any A4A siteless product
* Click the "Renew now" button
* Verify the renewal checkout page loads correctly instead of showing "You don't have access to that site"
* Purchase the product and verify everything looks good. 

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?