### PR TITLE
Agents Manager: Restrict zoom action to editor pages

### DIFF
--- a/packages/agents-manager/src/hooks/use-sources-action.ts
+++ b/packages/agents-manager/src/hooks/use-sources-action.ts
@@ -47,7 +47,7 @@ export default function useSourcesAction( registerMessageActions: RegisterMessag
 
 				return [
 					{
-						type: 'component' as const,
+						type: 'component',
 						id: 'sources',
 						label: 'Sources',
 						component: SourcesDisplay,

--- a/packages/agents-manager/src/hooks/use-zoom-action.ts
+++ b/packages/agents-manager/src/hooks/use-zoom-action.ts
@@ -1,5 +1,6 @@
 import { useEffect } from '@wordpress/element';
 import ZoomActionButton from '../components/zoom-action-button';
+import { isEditorPage } from '../utils/is-editor-page';
 import type { UseAgentChatReturn, UIMessage } from '@automattic/agenttic-client';
 
 type RegisterMessageActions = UseAgentChatReturn[ 'registerMessageActions' ];
@@ -12,7 +13,7 @@ export default function useZoomAction( registerMessageActions: RegisterMessageAc
 		registerMessageActions( {
 			id: 'agents-manager-zoom',
 			actions: ( message: UIMessage ) => {
-				if ( message.role !== 'agent' ) {
+				if ( message.role !== 'agent' || ! isEditorPage() ) {
 					return [];
 				}
 
@@ -30,7 +31,7 @@ export default function useZoomAction( registerMessageActions: RegisterMessageAc
 				return [
 					{
 						type: 'component',
-						id: 'zoom-toggle',
+						id: 'zoom',
 						component: ZoomActionButton,
 						order: 5,
 					},


### PR DESCRIPTION
Part of BSKY-1892

## Proposed Changes

- Add an `isEditorPage()` guard to the zoom action hook so the zoom button only appears on editor pages (site editor, post/page editor).
- Align the action `id` from `zoom-toggle` to `zoom`, matching the convention used by other message action hooks (`copy`, `checkpoint`, `sources`).

## Why are these changes being made?

The zoom action button was appearing on all pages, including non-editor contexts where `show_component` tool messages are not meaningful. This restricts it to editor pages only.

## Testing Instructions

A minor fixing, will do self-review, test, and then merge.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?