### PR TITLE
Agents Manager: add host-injectable tracking handler

### DIFF
--- a/packages/agents-manager/src/__tests__/tracking.test.ts
+++ b/packages/agents-manager/src/__tests__/tracking.test.ts
@@ -1,0 +1,168 @@
+/**
+ * @jest-environment jsdom
+ */
+import { recordTracksEvent as calypsoRecordTracksEvent } from '@automattic/calypso-analytics';
+import {
+	recordTracksEvent,
+	trackEvent,
+	setTrackingHandler,
+	setDefaultTracksEnabled,
+	__resetTrackingForTests,
+} from '../tracking';
+
+jest.mock( '@automattic/calypso-analytics', () => ( { recordTracksEvent: jest.fn() } ), {
+	virtual: true,
+} );
+
+const mockCalypsoRecordTracksEvent = calypsoRecordTracksEvent as jest.MockedFunction<
+	typeof calypsoRecordTracksEvent
+>;
+
+describe( 'tracking', () => {
+	beforeEach( () => {
+		mockCalypsoRecordTracksEvent.mockReset();
+		__resetTrackingForTests();
+	} );
+
+	describe( 'recordTracksEvent (default + handler path)', () => {
+		it( 'fires through Calypso with the calypso_ prefix by default', () => {
+			recordTracksEvent( 'agents_manager_link_click', {
+				href: 'https://example.com',
+			} );
+
+			expect( mockCalypsoRecordTracksEvent ).toHaveBeenCalledTimes( 1 );
+			expect( mockCalypsoRecordTracksEvent ).toHaveBeenCalledWith(
+				'calypso_agents_manager_link_click',
+				{ href: 'https://example.com' }
+			);
+		} );
+
+		it( 'does not call any handler when none is registered', () => {
+			recordTracksEvent( 'agents_manager_link_click' );
+			// Only the Calypso path fired. Nothing else to assert — absence
+			// of handler is implicit.
+			expect( mockCalypsoRecordTracksEvent ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'also calls the registered handler with the unprefixed name', () => {
+			const fn = jest.fn();
+			setTrackingHandler( fn );
+
+			recordTracksEvent( 'agents_manager_response_feedback_action', {
+				feedback_type: 'up',
+			} );
+
+			expect( mockCalypsoRecordTracksEvent ).toHaveBeenCalledWith(
+				'calypso_agents_manager_response_feedback_action',
+				{ feedback_type: 'up' }
+			);
+			expect( fn ).toHaveBeenCalledWith( 'agents_manager_response_feedback_action', {
+				feedback_type: 'up',
+			} );
+		} );
+
+		it( 'skips the Calypso path when default tracks are disabled', () => {
+			const fn = jest.fn();
+			setTrackingHandler( fn );
+			setDefaultTracksEnabled( false );
+
+			recordTracksEvent( 'agents_manager_link_click', { href: '/a' } );
+
+			expect( mockCalypsoRecordTracksEvent ).not.toHaveBeenCalled();
+			expect( fn ).toHaveBeenCalledWith( 'agents_manager_link_click', {
+				href: '/a',
+			} );
+		} );
+
+		it( 'fires nothing when default is disabled and no handler is registered', () => {
+			setDefaultTracksEnabled( false );
+
+			recordTracksEvent( 'agents_manager_link_click' );
+
+			expect( mockCalypsoRecordTracksEvent ).not.toHaveBeenCalled();
+		} );
+
+		it( 'restores default behavior when setDefaultTracksEnabled( true ) is called', () => {
+			setDefaultTracksEnabled( false );
+			recordTracksEvent( 'agents_manager_link_click' );
+			expect( mockCalypsoRecordTracksEvent ).not.toHaveBeenCalled();
+
+			setDefaultTracksEnabled( true );
+			recordTracksEvent( 'agents_manager_link_click' );
+
+			expect( mockCalypsoRecordTracksEvent ).toHaveBeenCalledTimes( 1 );
+			expect( mockCalypsoRecordTracksEvent ).toHaveBeenCalledWith(
+				'calypso_agents_manager_link_click',
+				undefined
+			);
+		} );
+	} );
+
+	describe( 'trackEvent (handler-only path)', () => {
+		it( 'does nothing when no handler is registered', () => {
+			trackEvent( 'panel_view', { chat_state: 'sidebar' } );
+			expect( mockCalypsoRecordTracksEvent ).not.toHaveBeenCalled();
+		} );
+
+		it( 'calls the registered handler with the event name and props', () => {
+			const fn = jest.fn();
+			setTrackingHandler( fn );
+
+			trackEvent( 'panel_view', { chat_state: 'sidebar' } );
+
+			expect( fn ).toHaveBeenCalledWith( 'panel_view', {
+				chat_state: 'sidebar',
+			} );
+		} );
+
+		it( 'never fires through the Calypso tracks pipeline', () => {
+			const fn = jest.fn();
+			setTrackingHandler( fn );
+
+			trackEvent( 'panel_view' );
+
+			expect( mockCalypsoRecordTracksEvent ).not.toHaveBeenCalled();
+		} );
+
+		it( 'is unaffected by the defaultTracksEnabled switch', () => {
+			const fn = jest.fn();
+			setTrackingHandler( fn );
+			setDefaultTracksEnabled( false );
+
+			trackEvent( 'panel_view' );
+			expect( fn ).toHaveBeenCalledWith( 'panel_view', undefined );
+
+			setDefaultTracksEnabled( true );
+			trackEvent( 'panel_close' );
+			expect( fn ).toHaveBeenCalledWith( 'panel_close', undefined );
+
+			// trackEvent should never hit the Calypso pipeline regardless.
+			expect( mockCalypsoRecordTracksEvent ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'setTrackingHandler', () => {
+		it( 'replaces an existing handler', () => {
+			const first = jest.fn();
+			const second = jest.fn();
+
+			setTrackingHandler( first );
+			setTrackingHandler( second );
+
+			trackEvent( 'panel_view' );
+
+			expect( first ).not.toHaveBeenCalled();
+			expect( second ).toHaveBeenCalledWith( 'panel_view', undefined );
+		} );
+
+		it( 'clears the handler when passed undefined', () => {
+			const fn = jest.fn();
+			setTrackingHandler( fn );
+			setTrackingHandler( undefined );
+
+			trackEvent( 'panel_view' );
+
+			expect( fn ).not.toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -15,6 +15,7 @@ import useAgentLayoutManager from '../../hooks/use-agent-layout-manager';
 import useSetupCustomActions from '../../hooks/use-setup-custom-actions';
 import { useShouldUseUnifiedAgent } from '../../hooks/use-should-use-unified-agent';
 import { AGENTS_MANAGER_STORE } from '../../stores';
+import { trackEvent } from '../../tracking';
 import { LocalConversationListItem } from '../../types';
 import { persistLastActivity } from '../../utils/persist-last-activity';
 import AgentHistory from '../agent-history';
@@ -147,9 +148,25 @@ export default function AgentDock( {
 		[]
 	);
 
-	const handleClose = isDocked ? closeSidebar : () => setIsOpen( false );
+	const handleClose = () => {
+		if ( isDocked ) {
+			// Docked close goes through useAgentLayoutManager.handleCloseSidebar,
+			// which fires the panel_close event itself.
+			closeSidebar();
+		} else {
+			trackEvent( 'panel_close', {
+				chat_state: 'pop_out',
+				section_name: sectionName,
+			} );
+			setIsOpen( false );
+		}
+	};
 
 	const handleExpand = () => {
+		trackEvent( 'panel_view', {
+			chat_state: isDocked ? 'sidebar' : 'pop_out',
+			section_name: sectionName,
+		} );
 		setIsOpen( true );
 		if ( pathname === '/history' ) {
 			navigate( '/' );
@@ -157,6 +174,12 @@ export default function AgentDock( {
 	};
 
 	const handleSelectConversation = ( conversation: LocalConversationListItem ) => {
+		trackEvent( 'button_click', {
+			button_label: 'select_conversation',
+			conversation_type: conversation.is_zendesk ? 'zendesk' : 'orchestrator',
+			section_name: sectionName,
+		} );
+
 		if ( conversation.is_zendesk ) {
 			navigate( '/zendesk', { state: { conversationId: conversation.conversation_id } } );
 		} else {
@@ -174,7 +197,13 @@ export default function AgentDock( {
 				icon: comment,
 				title: __( 'New chat', '__i18n_text_domain__' ),
 				isDisabled: pathname === '/chat' && isOrchestratorChatEmpty,
-				onClick: () => navigate( '/' ),
+				onClick: () => {
+					trackEvent( 'button_click', {
+						button_label: 'new_chat',
+						section_name: sectionName,
+					} );
+					navigate( '/' );
+				},
 			},
 			shouldUseUnifiedAgent && {
 				icon: lifesaver,
@@ -189,6 +218,11 @@ export default function AgentDock( {
 				icon: login,
 				title: __( 'Pop out sidebar', '__i18n_text_domain__' ),
 				onClick: () => {
+					trackEvent( 'panel_mode_change', {
+						previous_state: 'sidebar',
+						new_state: 'pop_out',
+						section_name: sectionName,
+					} );
 					undock();
 					setIsDocked( false );
 				},
@@ -198,6 +232,11 @@ export default function AgentDock( {
 					icon: drawerRight,
 					title: __( 'Move to sidebar', '__i18n_text_domain__' ),
 					onClick: () => {
+						trackEvent( 'panel_mode_change', {
+							previous_state: 'pop_out',
+							new_state: 'sidebar',
+							section_name: sectionName,
+						} );
 						dock();
 						setIsDocked( true );
 					},

--- a/packages/agents-manager/src/components/chat-header/index.tsx
+++ b/packages/agents-manager/src/components/chat-header/index.tsx
@@ -2,6 +2,8 @@ import { Button, DropdownMenu } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { close, moreVertical, backup, chevronLeft, Icon } from '@wordpress/icons';
 import { useNavigate } from 'react-router-dom';
+import { useAgentsManagerContext } from '../../contexts';
+import { trackEvent } from '../../tracking';
 import type { ComponentProps } from 'react';
 import './style.scss';
 
@@ -16,6 +18,15 @@ interface Props {
 
 export default function ChatHeader( { onClose, options, title, onBack }: Props ) {
 	const navigate = useNavigate();
+	const { sectionName } = useAgentsManagerContext();
+
+	const handleViewHistory = () => {
+		trackEvent( 'button_click', {
+			button_label: 'view_history',
+			section_name: sectionName,
+		} );
+		navigate( '/history' );
+	};
 
 	return (
 		<div className="agents-manager-chat-header">
@@ -41,7 +52,7 @@ export default function ChatHeader( { onClose, options, title, onBack }: Props )
 				<Button
 					className="agents-manager-chat-header__history-btn"
 					icon={ backup }
-					onClick={ () => navigate( '/history' ) }
+					onClick={ handleViewHistory }
 					label={ __( 'View history', '__i18n_text_domain__' ) }
 					size="small"
 				/>

--- a/packages/agents-manager/src/components/custom-a-link/index.tsx
+++ b/packages/agents-manager/src/components/custom-a-link/index.tsx
@@ -1,8 +1,8 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isThisASupportArticleLink } from '@automattic/urls';
 import { useMemo } from '@wordpress/element';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAgentsManagerContext } from '../../contexts';
+import { recordTracksEvent } from '../../tracking';
 import { uriTransformer } from '../../utils/uri-transformer';
 
 export default function CustomALink( {
@@ -38,7 +38,7 @@ export default function CustomALink( {
 					} );
 				}
 
-				recordTracksEvent( 'calypso_agents_manager_link_click', {
+				recordTracksEvent( 'agents_manager_link_click', {
 					href: transformedHref,
 					type: isSupportArticle ? 'support_article' : 'external',
 					source: isFromOrchestrator ? 'orchestrator' : 'zendesk',

--- a/packages/agents-manager/src/components/sources-display/index.tsx
+++ b/packages/agents-manager/src/components/sources-display/index.tsx
@@ -1,4 +1,3 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { FoldableCard } from '@automattic/components';
 import { isThisASupportArticleLink } from '@automattic/urls';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -7,6 +6,7 @@ import { Icon, chevronRight, page } from '@wordpress/icons';
 import { useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAgentsManagerContext } from '../../contexts';
+import { recordTracksEvent } from '../../tracking';
 import './style.scss';
 
 interface Source {
@@ -44,7 +44,7 @@ export default function SourcesDisplay( { sources }: Props ) {
 			} );
 		}
 
-		recordTracksEvent( 'calypso_agents_manager_link_click', {
+		recordTracksEvent( 'agents_manager_link_click', {
 			href: url,
 			type: isSupportArticle ? 'support_article' : 'external',
 			source: isFromOrchestrator ? 'orchestrator' : 'zendesk',

--- a/packages/agents-manager/src/global.d.ts
+++ b/packages/agents-manager/src/global.d.ts
@@ -66,6 +66,20 @@ interface AgentsManagerActions {
 	 * instead of waiting for the `agents-manager-ready` event.
 	 */
 	isReady?: boolean;
+	/**
+	 * Host-injected tracking handler. When set (before Agents Manager mounts),
+	 * every event fired by the package is also delivered to this function
+	 * with the unprefixed semantic name. Allows hosts to route chat telemetry
+	 * into their own pipelines (e.g. CIAB routes to `assistant_*`).
+	 */
+	trackingHandler?: ( event: string, props?: Record< string, string | number | boolean > ) => void;
+	/**
+	 * When set to `true` before Agents Manager mounts, suppresses the default
+	 * Calypso tracks path. Events still flow through `trackingHandler` if one
+	 * is registered. Use this when a host wants to fully own chat telemetry
+	 * routing without Calypso-namespace events firing alongside.
+	 */
+	disableDefaultTracks?: boolean;
 }
 
 /**

--- a/packages/agents-manager/src/hooks/__tests__/use-setup-custom-actions.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-setup-custom-actions.test.ts
@@ -2,7 +2,12 @@
  * @jest-environment jsdom
  */
 import { renderHook } from '@testing-library/react';
+import { recordTracksEvent, trackEvent, __resetTrackingForTests } from '../../tracking';
 import useSetupCustomActions from '../use-setup-custom-actions';
+
+jest.mock( '@automattic/calypso-analytics', () => ( { recordTracksEvent: jest.fn() } ), {
+	virtual: true,
+} );
 
 jest.mock( '@wordpress/data', () => ( {
 	useSelect: jest.fn( () => ( {
@@ -45,6 +50,7 @@ const baseProps = {
 describe( 'useSetupCustomActions — ready signal', () => {
 	beforeEach( () => {
 		delete window.__agentsManagerActions;
+		__resetTrackingForTests();
 	} );
 
 	it( 'sets isReady on the global after mount', () => {
@@ -88,5 +94,67 @@ describe( 'useSetupCustomActions — ready signal', () => {
 		expect( snapshot?.setChatOpen ).toBeInstanceOf( Function );
 		expect( snapshot?.setChatDocked ).toBeInstanceOf( Function );
 		expect( snapshot?.isReady ).toBe( true );
+	} );
+} );
+
+describe( 'useSetupCustomActions — tracking integration', () => {
+	beforeEach( () => {
+		delete window.__agentsManagerActions;
+		__resetTrackingForTests();
+	} );
+
+	it( 'wires a pre-set trackingHandler into the tracking module', () => {
+		const fn = jest.fn();
+		window.__agentsManagerActions = { trackingHandler: fn } as AgentsManagerActions;
+
+		renderHook( () => useSetupCustomActions( baseProps ) );
+
+		trackEvent( 'panel_view', { chat_state: 'sidebar' } );
+
+		expect( fn ).toHaveBeenCalledWith( 'panel_view', {
+			chat_state: 'sidebar',
+		} );
+	} );
+
+	it( 'does not register a handler when none is pre-set', () => {
+		renderHook( () => useSetupCustomActions( baseProps ) );
+
+		// No handler → trackEvent should be a no-op. Since we can't directly
+		// observe "nothing happened", rely on the absence of throws and the
+		// fact that default tracks still fire (via the other test below).
+		expect( () => trackEvent( 'panel_view' ) ).not.toThrow();
+	} );
+
+	it( 'disables the default Calypso tracks path when disableDefaultTracks is pre-set', () => {
+		window.__agentsManagerActions = {
+			disableDefaultTracks: true,
+		} as AgentsManagerActions;
+
+		renderHook( () => useSetupCustomActions( baseProps ) );
+
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		const {
+			recordTracksEvent: calypsoRecordTracksEvent,
+		} = require( '@automattic/calypso-analytics' );
+
+		recordTracksEvent( 'agents_manager_link_click', { href: '/a' } );
+
+		expect( calypsoRecordTracksEvent ).not.toHaveBeenCalled();
+	} );
+
+	it( 'leaves the default Calypso tracks path enabled when disableDefaultTracks is not pre-set', () => {
+		renderHook( () => useSetupCustomActions( baseProps ) );
+
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		const {
+			recordTracksEvent: calypsoRecordTracksEvent,
+		} = require( '@automattic/calypso-analytics' );
+		calypsoRecordTracksEvent.mockClear();
+
+		recordTracksEvent( 'agents_manager_link_click', { href: '/a' } );
+
+		expect( calypsoRecordTracksEvent ).toHaveBeenCalledWith( 'calypso_agents_manager_link_click', {
+			href: '/a',
+		} );
 	} );
 } );

--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/index.tsx
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/index.tsx
@@ -11,6 +11,8 @@ import {
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { AI } from '../../components/icons';
+import { useAgentsManagerContext } from '../../contexts';
+import { trackEvent } from '../../tracking';
 
 interface Options {
 	sidebarContainer?: string | HTMLElement;
@@ -45,6 +47,7 @@ export default function useAgentLayoutManager( {
 	onDock = () => {},
 	onUndock = () => {},
 }: Options = {} ): ReturnValue {
+	const { sectionName } = useAgentsManagerContext();
 	const portalRef = useRef< HTMLDivElement >();
 	const wasOpenRef = useRef( defaultOpen );
 	const [ isPortalReady, setIsPortalReady ] = useState( false );
@@ -180,8 +183,13 @@ export default function useAgentLayoutManager( {
 		wasOpenRef.current = true;
 		container.classList.add( 'agents-manager-sidebar-container--sidebar-open' );
 
+		trackEvent( 'panel_view', {
+			chat_state: 'sidebar',
+			section_name: sectionName,
+		} );
+
 		onOpenSidebarRef.current();
-	}, [ canDock, container, isReady ] );
+	}, [ canDock, container, isReady, sectionName ] );
 
 	const handleCloseSidebar = useCallback( () => {
 		if ( ! isReady || ! container || ! canDock ) {
@@ -191,8 +199,13 @@ export default function useAgentLayoutManager( {
 		wasOpenRef.current = false;
 		container.classList.remove( 'agents-manager-sidebar-container--sidebar-open' );
 
+		trackEvent( 'panel_close', {
+			chat_state: 'sidebar',
+			section_name: sectionName,
+		} );
+
 		onCloseSidebarRef.current();
-	}, [ canDock, container, isReady ] );
+	}, [ canDock, container, isReady, sectionName ] );
 
 	const dock = useCallback( () => {
 		if ( ! isReady || ! container ) {

--- a/packages/agents-manager/src/hooks/use-feedback-action.ts
+++ b/packages/agents-manager/src/hooks/use-feedback-action.ts
@@ -1,8 +1,8 @@
 import { createFeedbackActions, ThumbsUpIcon, ThumbsDownIcon } from '@automattic/agenttic-ui';
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { createElement, useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { LOCAL_TOOL_RUNNING_MESSAGE } from '../constants';
 import { useAgentsManagerContext } from '../contexts';
+import { recordTracksEvent } from '../tracking';
 import type { AuthProvider, UseAgentChatReturn } from '@automattic/agenttic-client';
 import type { Message } from '@automattic/agenttic-ui/dist/types';
 
@@ -182,7 +182,7 @@ export default function useFeedbackAction( {
 				return;
 			}
 
-			recordTracksEvent( 'calypso_agents_manager_response_feedback_action', {
+			recordTracksEvent( 'agents_manager_response_feedback_action', {
 				type: feedback === 'up' ? 'thumb_up' : 'thumb_down',
 				message_id: messageId,
 			} );
@@ -280,7 +280,7 @@ export default function useFeedbackAction( {
 				previousMessages
 			);
 
-			recordTracksEvent( 'calypso_agents_manager_response_feedback_submitted', {
+			recordTracksEvent( 'agents_manager_response_feedback_submitted', {
 				message_id: currentMessageId,
 			} );
 		},

--- a/packages/agents-manager/src/hooks/use-setup-custom-actions/README.md
+++ b/packages/agents-manager/src/hooks/use-setup-custom-actions/README.md
@@ -42,11 +42,13 @@ if ( window.__agentsManagerActions?.isReady ) {
 
 Properties can be pre-set on `window.__agentsManagerActions` **before** the hook mounts to control initial state:
 
-| Property            | Type      | Default     | Description                              |
-| ------------------- | --------- | ----------- | ---------------------------------------- |
-| `isCompactMode`     | `boolean` | `false`     | Initial compact mode state.              |
-| `isChatEnabled`     | `boolean` | `true`      | Initial chat rendering state.            |
-| `desktopMediaQuery` | `string`  | `undefined` | Initial media query for sidebar docking. |
+| Property               | Type       | Default     | Description                                                                                                                                                                 |
+| ---------------------- | ---------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `isCompactMode`        | `boolean`  | `false`     | Initial compact mode state.                                                                                                                                                 |
+| `isChatEnabled`        | `boolean`  | `true`      | Initial chat rendering state.                                                                                                                                               |
+| `desktopMediaQuery`    | `string`   | `undefined` | Initial media query for sidebar docking.                                                                                                                                    |
+| `trackingHandler`      | `function` | `undefined` | Host-injected tracking handler. Receives every tracks event fired by the package with the unprefixed semantic name (e.g. `agents_manager_link_click`, `panel_view`).        |
+| `disableDefaultTracks` | `boolean`  | `false`     | When `true`, suppresses the default Calypso tracks path. Events still flow through `trackingHandler` if one is registered. Use when a host wants to fully own chat telemetry routing. |
 
 ## Examples
 

--- a/packages/agents-manager/src/hooks/use-setup-custom-actions/index.ts
+++ b/packages/agents-manager/src/hooks/use-setup-custom-actions/index.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { useNavigate } from 'react-router-dom';
 import { useAgentsManagerContext } from '../../contexts';
 import { AGENTS_MANAGER_STORE } from '../../stores';
+import { setTrackingHandler, setDefaultTracksEnabled } from '../../tracking';
 import type { AgentsManagerSelect } from '@automattic/data-stores';
 
 interface Props {
@@ -141,11 +142,25 @@ export default function useSetupCustomActions( {
 			isReady: true,
 		};
 
-		// Fire the ready event exactly once per mount, after the global has
-		// been fully populated. Hosts (e.g. CIAB) listen for this to safely
-		// invoke actions like `setChatOpen` without polling.
+		// One-time per-mount setup: read host-injected tracking configuration
+		// from the global and fire the ready event. Both flow through the
+		// same `hasFiredReadyRef` guard so they run exactly once per mount
+		// even though the effect re-runs on state changes.
 		if ( ! hasFiredReadyRef.current ) {
 			hasFiredReadyRef.current = true;
+
+			// Wire host-injected tracking handler and default-tracks switch.
+			// Both are pre-set on `window.__agentsManagerActions` by the host
+			// before this hook mounts, following the same pattern as
+			// `isCompactMode`, `isChatEnabled`, and `desktopMediaQuery`.
+			setTrackingHandler( window.__agentsManagerActions?.trackingHandler );
+			if ( window.__agentsManagerActions?.disableDefaultTracks ) {
+				setDefaultTracksEnabled( false );
+			}
+
+			// Fire the ready event after the global has been fully populated
+			// and tracking is wired. Hosts (e.g. CIAB) listen for this to
+			// safely invoke actions like `setChatOpen` without polling.
 			window.dispatchEvent( new CustomEvent( 'agents-manager-ready' ) );
 		}
 

--- a/packages/agents-manager/src/tracking.ts
+++ b/packages/agents-manager/src/tracking.ts
@@ -1,0 +1,113 @@
+/**
+ * Tracking module for `@automattic/agents-manager`.
+ *
+ * Wraps Calypso's `recordTracksEvent` so that all tracks events fired by
+ * the agents-manager package flow through a single gateway. Hosts can
+ * inject a tracking handler to receive the same events (e.g. for routing
+ * into their own telemetry pipeline) and optionally disable the default
+ * Calypso tracks path entirely.
+ *
+ * See `hooks/use-setup-custom-actions/README.md` for the host-side API.
+ */
+
+import { recordTracksEvent as calypsoRecordTracksEvent } from '@automattic/calypso-analytics';
+
+export type TrackingHandler = (
+	event: string,
+	props?: Record< string, string | number | boolean >
+) => void;
+
+let handler: TrackingHandler | undefined;
+let defaultTracksEnabled = true;
+
+// ---------------------------------------------------------------------------
+// Host-controlled switches
+// ---------------------------------------------------------------------------
+
+/**
+ * Register a tracking handler. Hosts inject a function that receives every
+ * event fired by the package. Passing `undefined` clears the handler.
+ *
+ * @param fn - Handler function, or `undefined` to clear.
+ */
+export function setTrackingHandler( fn: TrackingHandler | undefined ): void {
+	handler = fn;
+}
+
+/**
+ * Enable or disable the default Calypso tracks path. When disabled, events
+ * fired via `recordTracksEvent` below are no longer forwarded to Calypso's
+ * analytics pipeline; only the registered handler (if any) receives them.
+ *
+ * Does not affect `trackEvent` (which has no default path).
+ *
+ * @param enabled - `true` to enable the default path (initial state), `false` to disable.
+ */
+export function setDefaultTracksEnabled( enabled: boolean ): void {
+	defaultTracksEnabled = enabled;
+}
+
+// ---------------------------------------------------------------------------
+// Tracking entry points
+// ---------------------------------------------------------------------------
+
+/**
+ * Fire a tracks event with a default Calypso tracks path.
+ *
+ * The event name MUST NOT include the `calypso_` prefix — it's prepended
+ * when firing through the default path. This keeps the handler contract
+ * clean: handlers always receive the unprefixed semantic name.
+ *
+ * Behavior:
+ * - If the default path is enabled (initial state), fires
+ *   `recordTracksEvent( 'calypso_' + eventName, props )` via
+ *   `@automattic/calypso-analytics`.
+ * - If a handler is registered, it's also called with the unprefixed
+ *   event name and the same props.
+ *
+ * Use this as a drop-in replacement for the `recordTracksEvent` import
+ * from `@automattic/calypso-analytics` at call sites where events were
+ * already firing as `calypso_<something>`.
+ *
+ * @param eventName - Event name without `calypso_` prefix (e.g. `agents_manager_link_click`).
+ * @param props     - Optional event properties.
+ */
+export function recordTracksEvent(
+	eventName: string,
+	props?: Record< string, string | number | boolean >
+): void {
+	if ( defaultTracksEnabled ) {
+		calypsoRecordTracksEvent( `calypso_${ eventName }`, props );
+	}
+	handler?.( eventName, props );
+}
+
+/**
+ * Fire a tracks event through the host handler only.
+ *
+ * No default Calypso tracks path — these events are invisible to hosts
+ * that haven't registered a tracking handler. Use for events that have
+ * never existed in the Calypso namespace (e.g. new chat-shell events
+ * like panel_view, panel_close, button_click).
+ *
+ * @param eventName - Event name (passed to the handler as-is).
+ * @param props     - Optional event properties.
+ */
+export function trackEvent(
+	eventName: string,
+	props?: Record< string, string | number | boolean >
+): void {
+	handler?.( eventName, props );
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers (not part of the public API)
+// ---------------------------------------------------------------------------
+
+/**
+ * Reset the tracking module to its initial state. Intended for test teardown.
+ */
+export function __resetTrackingForTests(): void {
+	handler = undefined;
+	defaultTracksEnabled = true;
+}


### PR DESCRIPTION
## Summary

Adds a `tracking` module to `@automattic/agents-manager` that wraps `@automattic/calypso-analytics`'s `recordTracksEvent` so hosts can inject a tracking handler without changing the default Calypso tracks behavior.

Also adds six new chat-shell events (panel_view, panel_close, panel_mode_change, button_click × 3) that fire exclusively through the host handler — invisible to hosts that don't opt in.

This is the first of two companion PRs. The CIAB side is in `add/ciab-assistant-tracking-handler` on ciab-admin, which pre-sets the `trackingHandler` to route chat events into CIAB's tracks pipeline as `assistant_*` with `page_surface_area` context. That PR is blocked on this one merging and deploying.

## Why

Today agents-manager fires four `calypso_agents_manager_*` tracks events (feedback ×2, link click ×2) via direct calls to `@automattic/calypso-analytics`. These work fine in Calypso but there's no way for hosts like CIAB to observe them in their own telemetry pipelines — and there's no chat-shell telemetry at all (no panel opens, closes, dock/undock, button clicks).

This PR introduces a single gateway for all agents-manager tracks events with a host extension point, without changing the default behavior. Hosts that don't care see zero new events. Hosts that opt in receive every event (existing and new) through a single handler they control.

## Design

### `tracking.ts` module

Two entry points for call sites:

- **`recordTracksEvent( name, props )`** — drop-in replacement for the Calypso analytics import. Prepends `calypso_` when firing through the default path, and also delivers the unprefixed name to any registered handler.
- **`trackEvent( name, props )`** — handler-only. No default Calypso path. Use for new events that have never existed in the Calypso namespace.

Two host-controlled switches:

- **`setTrackingHandler( fn )`** — register or clear the handler.
- **`setDefaultTracksEnabled( enabled )`** — toggle the default Calypso path. When disabled, only the handler receives events.

### Host extension surface

Extends the existing `window.__agentsManagerActions` pre-set pattern (same as `isCompactMode`, `isChatEnabled`, `desktopMediaQuery`):

| Property | Type | Default | Description |
|---|---|---|---|
| `trackingHandler` | `function` | `undefined` | Host-injected tracking handler |
| `disableDefaultTracks` | `boolean` | `false` | Suppresses the default Calypso path |

`useSetupCustomActions` reads both on first mount and calls `setTrackingHandler` / `setDefaultTracksEnabled` accordingly.

## Call site changes

### 4 existing `calypso_agents_manager_*` events — dropped `calypso_` prefix + swapped import

| File | Old event name | New event name |
|---|---|---|
| `components/custom-a-link/index.tsx` | `calypso_agents_manager_link_click` | `agents_manager_link_click` |
| `components/sources-display/index.tsx` | `calypso_agents_manager_link_click` | `agents_manager_link_click` |
| `hooks/use-feedback-action.ts` | `calypso_agents_manager_response_feedback_action` | `agents_manager_response_feedback_action` |
| `hooks/use-feedback-action.ts` | `calypso_agents_manager_response_feedback_submitted` | `agents_manager_response_feedback_submitted` |

**What fires at the transport layer is unchanged**: the wrapper prepends `calypso_` before calling the real `recordTracksEvent`, so the tracks pipeline still sees `calypso_agents_manager_link_click` et al. Existing tests that mock `@automattic/calypso-analytics` pass unmodified.

### 6 new chat-shell events — handler-only via `trackEvent`

| Event | File | Trigger |
|---|---|---|
| `panel_view` | `hooks/use-agent-layout-manager/index.tsx` | Sidebar FAB click (docked) |
| `panel_view` | `components/agent-dock/index.tsx` | Pop-out expand |
| `panel_close` | `hooks/use-agent-layout-manager/index.tsx` | Sidebar close (docked) |
| `panel_close` | `components/agent-dock/index.tsx` | Pop-out close |
| `panel_mode_change` | `components/agent-dock/index.tsx` | Dock/undock dropdown (both directions) |
| `button_click` (`new_chat`) | `components/agent-dock/index.tsx` | Header dropdown |
| `button_click` (`view_history`) | `components/chat-header/index.tsx` | History button |
| `button_click` (`select_conversation`) | `components/agent-dock/index.tsx` | `handleSelectConversation` |

All carry `chat_state` and `section_name`. `panel_mode_change` adds `previous_state` / `new_state`. `button_click` adds `button_label` (and `conversation_type` for select_conversation).

## Default behavior

**Unchanged** for hosts that don't register a handler:

- The 4 legacy events still fire as `calypso_agents_manager_*` via the Calypso tracks pipeline (identical bytes on the wire)
- The 6 new events do NOT fire at all — they're pure handler-only events

## Test plan

- [x] New unit tests in `src/__tests__/tracking.test.ts` cover all 4 quadrants (default on/off × handler set/unset) plus the switches
- [x] Extended `use-setup-custom-actions.test.ts` to cover the `trackingHandler` and `disableDefaultTracks` pre-set wiring
- [x] All 112 existing agents-manager tests still pass unmodified
- [x] Lint clean (`yarn lint:js packages/agents-manager`)
- [ ] Sandbox: build + sync to `widgets.wp.com/agents-manager/` on a sandbox, visit a CIAB site, verify:
  - Legacy events (`calypso_agents_manager_link_click` etc.) still fire when no handler is registered
  - After pre-setting `window.__agentsManagerActions = { trackingHandler: (event, props) => console.log('EVENT', event, props) }` in the browser, reload, and verify each panel lifecycle / button click produces a console entry with the unprefixed name
  - After setting `disableDefaultTracks: true` in the same pre-set, verify no `calypso_agents_manager_*` events fire in the Network tab (only the handler receives them)

## Related

- Companion PR (CIAB): `add/ciab-assistant-tracking-handler` — pre-sets the handler to route chat events into CIAB's `assistant_*` namespace with `page_surface_area` context
- Replaces the now-closed Automattic/big-sky-plugin#5932 and Automattic/ciab-admin#4280, which pointed at the wrong code path (Big Sky's OrchestratorDock is disabled in CIAB; the actual chat is agents-manager)

🤖 Generated with [Claude Code](https://claude.com/claude-code)