### PR TITLE
Prevent customer chats from routing to staging Zendesk

### DIFF
--- a/packages/zendesk-client/src/util.tsx
+++ b/packages/zendesk-client/src/util.tsx
@@ -93,8 +93,8 @@ export const isTestModeEnvironment = () => {
 		return false;
 	}
 
-	// Test environments are identified by env_id ending with development, horizon, or stage
-	const testEnvironmentSuffixes = [ 'development', 'horizon', 'stage' ];
+	// Test environments are identified by env_id ending with development, horizon, stage, or staging
+	const testEnvironmentSuffixes = [ 'development', 'horizon', 'stage', 'staging' ];
 	const isTestEnvironment = testEnvironmentSuffixes.some(
 		( suffix ) => envId === suffix || envId?.endsWith( `-${ suffix }` )
 	);

--- a/packages/zendesk-client/src/util.tsx
+++ b/packages/zendesk-client/src/util.tsx
@@ -93,7 +93,10 @@ export const isTestModeEnvironment = () => {
 		return false;
 	}
 
-	// Test environments are identified by env_id ending with development, horizon, stage, or staging
+	// In the Calypso SPA context, env_id follows the config file convention and ends with
+	// 'development', 'horizon', or 'stage' (e.g. 'dashboard-stage', 'jetpack-cloud-horizon').
+	// In the widgets.wp.com bundle context (apps/help-center, apps/agents-manager), config.js
+	// sets env_id to 'staging' for proxied/dev users. Both map to test mode.
 	const testEnvironmentSuffixes = [ 'development', 'horizon', 'stage', 'staging' ];
 	const isTestEnvironment = testEnvironmentSuffixes.some(
 		( suffix ) => envId === suffix || envId?.endsWith( `-${ suffix }` )

--- a/packages/zendesk-client/src/util.tsx
+++ b/packages/zendesk-client/src/util.tsx
@@ -113,7 +113,8 @@ export const isTestModeEnvironment = () => {
 		console.warn( '[isTestModeEnvironment] failed to read `env` from config', error );
 	}
 
-	return env !== 'production';
+	// If `env` is not configured, default to production to avoid routing customers to staging.
+	return env !== undefined && env !== 'production';
 };
 
 export const getBadRatingReasons = () => {

--- a/packages/zendesk-client/test/util.test.tsx
+++ b/packages/zendesk-client/test/util.test.tsx
@@ -135,5 +135,28 @@ describe( 'isTestModeEnvironment', () => {
 
 			expect( isTestModeEnvironment() ).toBe( true );
 		} );
+
+		test( 'should default to production when config is unavailable (env undefined)', () => {
+			// Simulates contexts where window.configData is not set (e.g. Gutenberg editor
+			// before config.js executes), where config() returns undefined without throwing.
+			( config as unknown as jest.Mock ).mockReturnValue( undefined );
+
+			expect( isTestModeEnvironment() ).toBe( false );
+		} );
+
+		test( 'should treat proxied dev environment (staging env_id) as test mode', () => {
+			// apps/help-center/config.js sets env_id = env = 'staging' for proxied Automatticians.
+			( config as unknown as jest.Mock ).mockImplementation( ( key: string ) => {
+				if ( key === 'env_id' ) {
+					return 'staging';
+				}
+				if ( key === 'env' ) {
+					return 'staging';
+				}
+				return undefined;
+			} );
+
+			expect( isTestModeEnvironment() ).toBe( true );
+		} );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-15719

## Proposed Changes                                                                                              
                                                                                                                   
* Add `'staging'` to `testEnvironmentSuffixes` in `isTestModeEnvironment()`. The suffix list (`'development'`, `'horizon'`, `'stage'`) was designed for the Calypso SPA context, where `env_id` follows the standard config file naming convention. In the widgets.wp.com bundle context (`apps/help-center`, `apps/agents-manager`), `config.js` sets `env_id` to `'staging'` for proxied/dev users — a custom value that never matched any suffix and was silently handled by the `env !== 'production'` fallback. Adding `'staging'` makes this explicit.
* Change the final `return` from `return env !== 'production'` to `return env !== undefined && env !== 'production'`. The `try/catch` blocks introduced in #108879 to fix a Gutenberg editor crash silently swallow config failures, leaving `env` as `undefined`. The original fallback then evaluates `undefined !== 'production'` → `true` → staging Zendesk for customers whose config is unavailable.  
                                                                                                                 
## Why are these changes being made?

* There are still some customer chat tickets showing up on zendesk staging; for example the ticket with id 4246 on our ZD staging instance.                                                                            
* `isTestModeEnvironment()` has two failure modes that can route real customers to the staging Zendesk instance.     
* The first is structural: the `testEnvironmentSuffixes` list only covered Calypso SPA environments. The `'staging'` value set by `apps/help-center/config.js` (and `apps/agents-manager/config.js`) for proxied Automatticians never matched any suffix — routing to staging worked by falling through to return `env !== 'production'`. This was correct but implicit and fragile.                                   
* The second, and likely cause of actual customer tickets landing in staging, was introduced by #108879: wrapping `config()` calls in `try/catch` to prevent a crash in the Gutenberg editor. If both `env_id` and `env` fail to load, the `catch` blocks leave them as `undefined`, and `undefined !== 'production'` returns `true`, sending the customer to staging. Changing the return to `env !== undefined && env !== 'production'` makes "config unavailable" default safely to production.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Calypso

* Checkout this branch locally
* Get calypso running
* Open the Help Center
* Send the `talk to a human` message
* Check that you get the `This is the Sandbox version of Zendesk` message

### widgets.wp.com

* `cd apps/help-center`
* `yarn dev --sync`
* On a sandboxed site, go to `/wp-admin/`
* Open the Help Center
* Send the `talk to a human` message
* Check that you get the `This is the Sandbox version of Zendesk` message

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
