### PR TITLE
Signup: Add `skip_step_render` property to `calypso_signup_step_start` and `calypso_page_view` events

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -42,6 +42,8 @@ export function generateSteps( {
 			stepName: 'domains-launch',
 			apiRequestFunction: addDomainToCart,
 			fulfilledStepCallback: isDomainFulfilled,
+			isReadyForFulfillmentCheck: ( stepName, defaultDependencies, props ) =>
+				props.hasLoadedSiteDomains && ! props.isRequestingSiteDomains,
 			providesDependencies: [
 				'domainItem',
 				'shouldHideFreePlan',
@@ -295,6 +297,8 @@ export function generateSteps( {
 			stepName: 'plans-launch',
 			apiRequestFunction: addPlanToCart,
 			fulfilledStepCallback: isPlanFulfilled,
+			isReadyForFulfillmentCheck: ( stepName, defaultDependencies, props ) =>
+				props.isPaidPlan != null,
 			dependencies: [ 'siteSlug' ],
 			providesDependencies: [ 'cartItems', 'themeSlugWithRepo' ],
 			optionalDependencies: [ 'themeSlugWithRepo' ],

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -5,9 +5,7 @@ import { isEmpty } from 'lodash';
 import { createElement } from 'react';
 import store from 'store';
 import { notFound } from 'calypso/controller';
-import { recordPageView } from 'calypso/lib/analytics/page-view';
 import { login } from 'calypso/lib/paths';
-import { sectionify } from 'calypso/lib/route';
 import { addQueryArgs } from 'calypso/lib/url';
 import flows from 'calypso/signup/config/flows';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -40,11 +38,6 @@ import {
 	getFlowPageTitle,
 	shouldForceLogin,
 } from './utils';
-/**
- * Constants
- */
-const basePageTitle = 'Signup'; // used for analytics, doesn't require translation
-
 /**
  * Module variables
  */
@@ -213,7 +206,6 @@ export default {
 
 	async start( context, next ) {
 		const userLoggedIn = isUserLoggedIn( context.store.getState() );
-		const basePath = sectionify( context.path );
 		const flowName = getFlowName( context.params, userLoggedIn );
 		const stepName = getStepName( context.params );
 		const stepSectionName = getStepSectionName( context.params );
@@ -236,12 +228,6 @@ export default {
 
 		// wait for the step component module to load
 		const stepComponent = await getStepComponent( stepName );
-
-		const params = {
-			flow: flowName,
-		};
-
-		recordPageView( basePath, basePageTitle + ' > Start > ' + flowName + ' > ' + stepName, params );
 
 		context.store.dispatch( setLayoutFocus( 'content' ) );
 		context.store.dispatch( setCurrentFlowName( flowName ) );

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -32,6 +32,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import { startedInHostingFlow } from 'calypso/landing/stepper/utils/hosting-flow';
 import { addHotJarScript } from 'calypso/lib/analytics/hotjar';
+import { recordPageView } from 'calypso/lib/analytics/page-view';
 import {
 	recordSignupStart,
 	recordSignupComplete,
@@ -47,6 +48,7 @@ import {
 	isPartnerPortalOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { detectPartnerConfig, getPartnerFormattedWindowTitle } from 'calypso/lib/partner-branding';
+import { sectionify } from 'calypso/lib/route';
 import SignupFlowController from 'calypso/lib/signup/flow-controller';
 import FlowProgressIndicator from 'calypso/signup/flow-progress-indicator';
 import SignupHeader from 'calypso/signup/signup-header';
@@ -66,7 +68,11 @@ import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
 import { submitSignupStep, removeStep, addStep } from 'calypso/state/signup/progress/actions';
 import { getSignupProgress } from 'calypso/state/signup/progress/selectors';
-import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
+import {
+	getDomainsBySiteId,
+	hasLoadedSiteDomains,
+	isRequestingSiteDomains,
+} from 'calypso/state/sites/domains/selectors';
 import {
 	getSiteId,
 	isCurrentPlanPaid,
@@ -140,6 +146,8 @@ class Signup extends Component {
 		previousFlowName: null,
 	};
 
+	_recordedSteps = new Set();
+
 	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
 	UNSAFE_componentWillMount() {
 		let providedDependencies = this.getDependenciesInQuery();
@@ -164,8 +172,6 @@ class Signup extends Component {
 			reduxStore: this.props.store,
 			onComplete: this.handleSignupFlowControllerCompletion,
 		} );
-
-		this.removeFulfilledSteps( this.props );
 
 		this.updateShouldShowLoadingScreen();
 		this.completeFlowAfterLoggingIn();
@@ -203,7 +209,18 @@ class Signup extends Component {
 		const { stepName, flowName, progress } = nextProps;
 
 		if ( this.props.stepName !== stepName ) {
+			if ( ! this._recordedSteps.has( this.props.stepName ) ) {
+				this._recordStepsInOrder( { includeCurrentStep: true } );
+			}
 			this.removeFulfilledSteps( nextProps );
+			if (
+				! this.state.shouldShowLoadingScreen &&
+				this.isStepFulfillmentReady( stepName, nextProps ) &&
+				! includes( flows.excludedSteps, stepName ) &&
+				! this._recordedSteps.has( stepName )
+			) {
+				this._recordStepsInOrder( { includeCurrentStep: true, forStep: stepName } );
+			}
 		}
 
 		if ( stepName === this.state.resumingStep ) {
@@ -231,14 +248,11 @@ class Signup extends Component {
 		}
 
 		recordSignupStart( this.props.flowName, this.props.refParameter, this.getRecordProps() );
+		this.removeFulfilledSteps( this.props );
 
-		// User-social is recorded as user, to avoid messing up the tracks funnels that we have
 		if ( ! this.state.shouldShowLoadingScreen ) {
-			recordSignupStep(
-				this.props.flowName,
-				this.props.stepName === 'user-social' ? 'user' : this.props.stepName,
-				this.getRecordProps()
-			);
+			const shouldDeferCurrentStep = ! this.isStepFulfillmentReady( this.props.stepName );
+			this._recordStepsInOrder( { includeCurrentStep: ! shouldDeferCurrentStep } );
 		}
 		this.preloadNextStep();
 	}
@@ -246,17 +260,16 @@ class Signup extends Component {
 	componentDidUpdate( prevProps ) {
 		const { flowName, stepName, sitePlanName, sitePlanSlug, signupDependencies, siteDomains } =
 			this.props;
+		const didCurrentStepBecomeFulfillmentReady =
+			! this.isStepFulfillmentReady( stepName, prevProps ) &&
+			this.isStepFulfillmentReady( stepName );
 
 		if (
 			( flowName !== prevProps.flowName || stepName !== prevProps.stepName ) &&
 			! this.state.shouldShowLoadingScreen
 		) {
-			// User-social is recorded as user, to avoid messing up the tracks funnels that we have
-			recordSignupStep(
-				flowName,
-				stepName === 'user-social' ? 'user' : stepName,
-				this.getRecordProps()
-			);
+			const shouldDeferCurrentStep = ! this.isStepFulfillmentReady( stepName );
+			this._recordStepsInOrder( { includeCurrentStep: ! shouldDeferCurrentStep } );
 		}
 
 		if ( stepName !== prevProps.stepName ) {
@@ -284,10 +297,75 @@ class Signup extends Component {
 			clearDomainsDependencies();
 		}
 
-		// Re-check fulfilled steps when siteDomains data changes
-		// This ensures that isDomainFulfilled is called again when domain data loads
-		if ( flowName === 'launch-site' && siteDomains !== prevProps.siteDomains ) {
+		if ( siteDomains !== prevProps.siteDomains || didCurrentStepBecomeFulfillmentReady ) {
 			this.removeFulfilledSteps( this.props );
+
+			if ( ! includes( flows.excludedSteps, stepName ) && ! this._recordedSteps.has( stepName ) ) {
+				this._recordStepsInOrder( { includeCurrentStep: true } );
+			}
+		}
+	}
+
+	recordSignupStepAndPageView( { skipStepRender = false, overrideStepName } = {} ) {
+		const { flowName } = this.props;
+		const stepName = overrideStepName || this.props.stepName;
+
+		const recordedStepName = stepName === 'user-social' ? 'user' : stepName;
+		const skipStepRenderProps = skipStepRender ? { skip_step_render: true } : {};
+
+		recordSignupStep( flowName, recordedStepName, {
+			...this.getRecordProps(),
+			...skipStepRenderProps,
+		} );
+
+		const basePath = overrideStepName
+			? `/start/${ flowName }/${ overrideStepName }`
+			: sectionify( this.props.path );
+		recordPageView( basePath, 'Signup > Start > ' + flowName + ' > ' + stepName, {
+			flow: flowName,
+			...skipStepRenderProps,
+		} );
+	}
+
+	isStepFulfillmentReady = ( stepName, nextProps = this.props ) => {
+		const stepConfig = steps[ stepName ];
+		if ( ! stepConfig?.fulfilledStepCallback ) {
+			return true;
+		}
+
+		const readinessCheck = stepConfig.isReadyForFulfillmentCheck;
+		if ( ! readinessCheck ) {
+			return true;
+		}
+
+		return readinessCheck( stepName, stepConfig.defaultDependencies, nextProps );
+	};
+
+	_recordStepsInOrder( { includeCurrentStep = false, forStep } = {} ) {
+		const { flowName } = this.props;
+		const targetStep = forStep || this.props.stepName;
+		const rawFlow = flows.getFlows()[ flowName ];
+		if ( ! rawFlow ) {
+			return;
+		}
+
+		for ( const step of rawFlow.steps ) {
+			if ( ! this._recordedSteps.has( step ) ) {
+				if ( includes( flows.excludedSteps, step ) ) {
+					this.recordSignupStepAndPageView( {
+						skipStepRender: true,
+						overrideStepName: step,
+					} );
+					this._recordedSteps.add( step );
+				} else if ( includeCurrentStep && step === targetStep ) {
+					this.recordSignupStepAndPageView();
+					this._recordedSteps.add( step );
+				}
+			}
+
+			if ( step === targetStep ) {
+				break;
+			}
 		}
 	}
 
@@ -446,17 +524,56 @@ class Signup extends Component {
 	processFulfilledSteps = ( stepName, nextProps ) => {
 		const isFulfilledCallback = steps[ stepName ].fulfilledStepCallback;
 		const defaultDependencies = steps[ stepName ].defaultDependencies;
-		isFulfilledCallback && isFulfilledCallback( stepName, defaultDependencies, nextProps );
+		if ( ! this.isStepFulfillmentReady( stepName, nextProps ) ) {
+			return;
+		}
+		if ( ! isFulfilledCallback ) {
+			return;
+		}
+
+		let propsForFulfillment = nextProps;
+		if ( stepName === nextProps.stepName && ! this._recordedSteps.has( stepName ) ) {
+			const originalSubmitSignupStep = nextProps.submitSignupStep;
+			propsForFulfillment = {
+				...nextProps,
+				submitSignupStep: ( signupStepData, providedDependencies ) => {
+					if (
+						signupStepData?.stepName === stepName &&
+						signupStepData?.wasSkipped &&
+						! this._recordedSteps.has( stepName )
+					) {
+						this.recordSignupStepAndPageView( {
+							skipStepRender: true,
+							overrideStepName: stepName,
+						} );
+						this._recordedSteps.add( stepName );
+					}
+					return originalSubmitSignupStep( signupStepData, providedDependencies );
+				},
+			};
+		}
+
+		isFulfilledCallback( stepName, defaultDependencies, propsForFulfillment );
 	};
 
 	removeFulfilledSteps = ( nextProps ) => {
 		const { flowName, isLoggedIn, stepName } = nextProps;
 		const flowSteps = flows.getFlow( flowName, isLoggedIn ).steps;
-		const excludedSteps = clone( flows.excludedSteps );
-		map( excludedSteps, ( flowStepName ) => this.processFulfilledSteps( flowStepName, nextProps ) );
-		map( flowSteps, ( flowStepName ) => this.processFulfilledSteps( flowStepName, nextProps ) );
+		const currentStepIndex = flowSteps.indexOf( stepName );
+		const stepsToProcess =
+			currentStepIndex >= 0 ? flowSteps.slice( 0, currentStepIndex + 1 ) : flowSteps;
+		const previouslyExcludedSteps = clone( flows.excludedSteps );
+		map( previouslyExcludedSteps, ( flowStepName ) => {
+			if ( includes( stepsToProcess, flowStepName ) ) {
+				this.processFulfilledSteps( flowStepName, nextProps );
+			}
+		} );
+		map( stepsToProcess, ( flowStepName ) =>
+			this.processFulfilledSteps( flowStepName, nextProps )
+		);
 
 		if ( includes( flows.excludedSteps, stepName ) ) {
+			this._recordStepsInOrder( { forStep: stepName } );
 			this.goToNextStep( flowName );
 		}
 	};
@@ -940,6 +1057,8 @@ export default connect(
 			sitePlanName: getSitePlanName( state, siteId ),
 			sitePlanSlug: getSitePlanSlug( state, siteId ),
 			siteDomains,
+			hasLoadedSiteDomains: hasLoadedSiteDomains( state, siteId ),
+			isRequestingSiteDomains: isRequestingSiteDomains( state, siteId ),
 			siteId,
 			localeSlug: getCurrentLocaleSlug( state ),
 			oauth2Client,

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -147,6 +147,7 @@ class Signup extends Component {
 	};
 
 	_recordedSteps = new Set();
+	_recordedPageViewPaths = new Set();
 
 	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
 	UNSAFE_componentWillMount() {
@@ -321,10 +322,13 @@ class Signup extends Component {
 		const basePath = overrideStepName
 			? `/start/${ flowName }/${ overrideStepName }`
 			: sectionify( this.props.path );
-		recordPageView( basePath, 'Signup > Start > ' + flowName + ' > ' + stepName, {
-			flow: flowName,
-			...skipStepRenderProps,
-		} );
+		if ( ! this._recordedPageViewPaths.has( basePath ) ) {
+			recordPageView( basePath, 'Signup > Start > ' + flowName + ' > ' + stepName, {
+				flow: flowName,
+				...skipStepRenderProps,
+			} );
+			this._recordedPageViewPaths.add( basePath );
+		}
 	}
 
 	isStepFulfillmentReady = ( stepName, nextProps = this.props ) => {
@@ -358,7 +362,9 @@ class Signup extends Component {
 					} );
 					this._recordedSteps.add( step );
 				} else if ( includeCurrentStep && step === targetStep ) {
-					this.recordSignupStepAndPageView();
+					this.recordSignupStepAndPageView( {
+						overrideStepName: targetStep !== this.props.stepName ? targetStep : undefined,
+					} );
 					this._recordedSteps.add( step );
 				}
 			}


### PR DESCRIPTION
Closes DATSCI-1230.

## Proposed Changes

Delays recording `calypso_signup_step_start` and `calypso_page_view` events until we know whether they were skipped by the framework following certain conditions, then annotate them with the `skip_step_render` property.

By "certain conditions," I mean a site that already has a domain or a plan. In these cases, we're automatically submitting the step, and that should be reflected in Tracks.

The use case is the `/start/launch-site` flow, where the user might or might not see the domain and plan steps depending on the site's state. 

## Testing Instructions

### Site with no domain and no plan

- Enter `/start/launch-site?siteSlug=%s` where `%s` is a site without a domain and plan. Go through the flow.
- Verify you DON'T see `skip_step_render: true` in both `calypso_signup_step_start` and `calypso_page_view`. 
- Verify you DON'T see `was_skipped: true` in `calypso_signup_actions_submit_step`.

#### Signup steps

<img width="1277" height="522" alt="CleanShot 2026-04-09 at 11 38 58" src="https://github.com/user-attachments/assets/804a19b9-8f96-4a91-8afe-584106f2c043" />

#### Page view

<img width="1304" height="170" alt="CleanShot 2026-04-09 at 11 38 30" src="https://github.com/user-attachments/assets/1d7379af-6ce7-4045-b98d-ba5f1baadfef" />

### Site with no domain but with a plan

- Enter `/start/launch-site?siteSlug=%s` where `%s` is a site with a plan, but without a domain. Go through the flow.
- For the domains step:
  - Verify you DON'T see `skip_step_render: true` in both `calypso_signup_step_start` and `calypso_page_view`. 
  - Verify you DON'T see `was_skipped: true` in `calypso_signup_actions_submit_step`.
- For the plans step:
  - Verify you DO see `skip_step_render: true` in both `calypso_signup_step_start` and `calypso_page_view`. 
  - Verify you DO see `was_skipped: true` in `calypso_signup_actions_submit_step`.

#### Signup steps

<img width="1287" height="472" alt="CleanShot 2026-04-09 at 11 39 54" src="https://github.com/user-attachments/assets/0a9afa05-9136-4664-b767-d31c1c6c8364" />

#### Page view

<img width="1274" height="168" alt="CleanShot 2026-04-09 at 11 40 20" src="https://github.com/user-attachments/assets/833f5c08-cbb3-4d8a-962b-dd1a474345c3" />

### Site with a domain but no plan

- Enter `/start/launch-site?siteSlug=%s` where `%s` is a site with a domain but without a plan. Go through the flow.
- For the domains step:
  - Verify you DO see `skip_step_render: true` in both `calypso_signup_step_start` and `calypso_page_view`. 
  - Verify you DO see `was_skipped: true` in `calypso_signup_actions_submit_step`.
- For the plans step:
  - Verify you DON'T see `skip_step_render: true` in both `calypso_signup_step_start` and `calypso_page_view`. 
  - Verify you DON'T see `was_skipped: true` in `calypso_signup_actions_submit_step`.

#### Signup steps

<img width="1266" height="514" alt="CleanShot 2026-04-09 at 11 43 06" src="https://github.com/user-attachments/assets/bf1471b3-ec85-41ed-bf15-e5edc65d9cba" />

#### Page view

<img width="1281" height="164" alt="CleanShot 2026-04-09 at 11 43 29" src="https://github.com/user-attachments/assets/4a2448fd-3d2d-464d-9247-464f2548b8b9" />

### Site with domain and plan

- Enter `/start/launch-site?siteSlug=%s` where `%s` is a site with a domain and a plan. Go through the flow.
- For the domains step:
  - Verify you DO see `skip_step_render: true` in both `calypso_signup_step_start` and `calypso_page_view`. 
  - Verify you DO see `was_skipped: true` in `calypso_signup_actions_submit_step`.
- For the plans step:
  - Verify you DO see `skip_step_render: true` in both `calypso_signup_step_start` and `calypso_page_view`. 
  - Verify you DO see `was_skipped: true` in `calypso_signup_actions_submit_step`.

#### Signup steps

<img width="1294" height="472" alt="CleanShot 2026-04-09 at 11 41 20" src="https://github.com/user-attachments/assets/7c4b461f-01e3-4b47-b35b-b51983c28562" />

#### Page view

<img width="1281" height="174" alt="CleanShot 2026-04-09 at 11 41 00" src="https://github.com/user-attachments/assets/88e44993-e750-4112-b6db-e5d2ced8dda7" />

### Unrelated flow (to make sure we didn't break anything)

- Enter `/start/onboarding-pm`. Go through the flow.
- Verify you DON'T see `skip_step_render: true` in both `calypso_signup_step_start` and `calypso_page_view`. 
- Verify you DON'T see `was_skipped: true` in `calypso_signup_actions_submit_step`.

#### Signup steps

<img width="1264" height="405" alt="CleanShot 2026-04-09 at 11 51 01" src="https://github.com/user-attachments/assets/e33a8ce0-2c57-49b1-95b5-e975227a98dd" />

#### Page view

<img width="1279" height="182" alt="CleanShot 2026-04-09 at 11 50 36" src="https://github.com/user-attachments/assets/4bca76ff-960b-44c0-89e2-4056c70e4173" />
