### PR TITLE
Help Center: prevent Smooch reinit on JWT rotation, fixing dropped chat messages

### DIFF
--- a/packages/help-center/src/components/help-center-smooch.tsx
+++ b/packages/help-center/src/components/help-center-smooch.tsx
@@ -109,6 +109,14 @@ const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } )
 	const authExternalId = authData?.externalId;
 	const authIsLoggedIn = authData?.isLoggedIn;
 	const { isMessagingScriptLoaded } = useLoadZendeskMessaging( allowChat, allowChat );
+
+	// Keep a ref to the latest JWT so the init effect can always read a fresh value
+	// without listing the JWT string itself as a dependency. JWT rotation is handled
+	// by Smooch's onInvalidAuth delegate — we only need to (re-)initialize when a JWT
+	// transitions from absent → present, not on every value change.
+	const authJwtRef = useRef< string | undefined >( authJwt );
+	authJwtRef.current = authJwt;
+	const hasAuthJwt = !! authJwt;
 	const {
 		setIsChatLoaded,
 		setZendeskClientId,
@@ -177,7 +185,7 @@ const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } )
 
 	// Initialize Smooch which communicates with Zendesk
 	useEffect( () => {
-		if ( ! isMessagingScriptLoaded || ! authIsLoggedIn || ! authJwt || ! authExternalId ) {
+		if ( ! isMessagingScriptLoaded || ! authIsLoggedIn || ! hasAuthJwt || ! authExternalId ) {
 			return;
 		}
 
@@ -200,7 +208,10 @@ const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } )
 			}
 
 			try {
-				await initSmooch( authJwt, authExternalId, queryClient );
+				// Read the JWT from the ref so we always use the freshest token without
+				// this effect needing to re-run (and destroy + reinit Smooch) on every
+				// JWT rotation. Rotations are handled by Smooch's onInvalidAuth delegate.
+				await initSmooch( authJwtRef.current!, authExternalId, queryClient );
 
 				if ( isCancelled ) {
 					return;
@@ -244,7 +255,7 @@ const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } )
 	}, [
 		isMessagingScriptLoaded,
 		authIsLoggedIn,
-		authJwt,
+		hasAuthJwt,
 		authExternalId,
 		setIsChatLoaded,
 		queryClient,

--- a/packages/help-center/src/components/help-center-smooch.tsx
+++ b/packages/help-center/src/components/help-center-smooch.tsx
@@ -217,10 +217,6 @@ const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } )
 					return;
 				}
 
-				if ( smoochRef.current ) {
-					Smooch.render( smoochRef.current );
-				}
-
 				setIsChatLoaded( true );
 				recordTracksEvent( 'calypso_smooch_messenger_init', {
 					success: true,
@@ -241,6 +237,10 @@ const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } )
 		};
 
 		initialize();
+
+		if ( smoochRef.current ) {
+			Smooch.render( smoochRef.current );
+		}
 
 		return () => {
 			isCancelled = true;

--- a/packages/help-center/src/components/help-center-smooch.tsx
+++ b/packages/help-center/src/components/help-center-smooch.tsx
@@ -217,6 +217,10 @@ const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } )
 					return;
 				}
 
+				if ( smoochRef.current ) {
+					Smooch.render( smoochRef.current );
+				}
+
 				setIsChatLoaded( true );
 				recordTracksEvent( 'calypso_smooch_messenger_init', {
 					success: true,
@@ -237,10 +241,6 @@ const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } )
 		};
 
 		initialize();
-
-		if ( smoochRef.current ) {
-			Smooch.render( smoochRef.current );
-		}
 
 		return () => {
 			isCancelled = true;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-15974

## Proposed Changes

* Introduce `authJwtRef` to always hold the latest JWT value without adding the JWT string to the `useEffect` dependency array.
* Derive `hasAuthJwt` from `authJwt` and use it as the effect dependency instead of the raw string, so `Smooch` only reinitializes when a JWT transitions from absent to present, not on every JWT value rotation.
* Inside `initialize()`, read the JWT from `authJwtRef.current` so the freshest token is always used at call time.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* When the `getMessagingAuth` query refetched and returned a new JWT string, the `useEffect` that initializes Smooch would re-run because `authJwt` was listed as a dependency. This caused Smooch to destroy and reinitialize unnecessarily; JWT rotation is already handled internally by Smooch's `onInvalidAuth` delegate, so the component never needed to react to JWT value changes, only to the JWT becoming available for the first time.

* During the destroy/reinit cycle, the `message:received` listener was torn down along with the Smooch instance. Any messages sent to the user during that window were silently dropped, never appearing in the chat UI. This manifested as users intermittently missing Help Center chat messages without any visible error. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This needs to be tested locally:

* Checkout this branch
* On `packages/help-center/src/components/help-center-smooch.tsx`, add `( window as any ).__hcQueryClient = queryClient;` on line 81, this will help us force a Smooch init call:

<img width="1804" height="267" alt="image" src="https://github.com/user-attachments/assets/dfff9b5b-f56b-4530-81ea-4c0fa4a95dc6" />

* Open the Help Center
* Send the `talk to a human` message
* Go to Zendesk staging and answer the conversation
* On Zendesk, type `Message sent during disconnection`, but do not send it
* Now, this step needs to be fast. On the calypso tab, open the console and write `__hcQueryClient.invalidateQueries({ queryKey: ['getMessagingAuth'] })`. Click enter to run the invalidation and immediately change to the Zendesk staging tab and from there hit Enter to send the message
* Go back to calyspo, the message should be received

Video recording from the trunk branch, where the message is not received:

[Screencast from 2026-04-09 21-01-58.webm](https://github.com/user-attachments/assets/3c9306b4-1ab2-446d-9d0f-165e2fc69cee)

Video recording from this branch, where the message is received:

[Screencast from 2026-04-09 21-09-54.webm](https://github.com/user-attachments/assets/43dae1d5-97da-4c95-aebc-2e3af31edbe8)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
