### PR TITLE
temp branch: Help caly build on macs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ ENV CONTAINER=docker
 ENV IS_CI=true
 
 # For Sentry uploads
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y python3 make g++ bzip2 && rm -rf /var/lib/apt/lists/*
 # Build a "base" layer
 #
 # This layer should never change unless env-config.sh
@@ -113,6 +113,7 @@ WORKDIR /calypso
 #
 # This layer is populated with up-to-date files from
 # Calypso development.
+RUN apt-get update && apt-get install -y python3 make g++ bzip2 && rm -rf /var/lib/apt/lists/*
 COPY . /calypso/
 RUN yarn run build-packages:web
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -27,7 +27,7 @@ ENV COMMIT_SHA $commit_sha
 
 ## If you're testing running on a mac architecture, you may need to add the following
 ## line to make lzma work:
-## RUN apt-get update && apt-get install -y python3 make g++ bzip2 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y python3 make g++ bzip2 && rm -rf /var/lib/apt/lists/*
 
 COPY . .
 

--- a/Dockerfile.cache-seed
+++ b/Dockerfile.cache-seed
@@ -19,6 +19,7 @@ ENV SKIP_CALYPSO_POSTINSTALL=true
 ENV SKIP_CALYPSO_PACKAGE_BUILDS=true
 ENV IS_CI=true
 
+RUN apt-get update && apt-get install -y python3 make g++ bzip2 && rm -rf /var/lib/apt/lists/*
 # Build a "base" layer
 #
 # This layer should never change unless env-config.sh

--- a/bin/build-languages.js
+++ b/bin/build-languages.js
@@ -54,40 +54,79 @@ async function downloadLanguagesRevions() {
 }
 
 // Request and write language files
+//
+const sleep = ( ms ) => new Promise( ( resolve ) => setTimeout( resolve, ms ) );
+
+async function fetchJsonWithRetry( url, { retries = 3, baseDelayMs = 500 } = {} ) {
+	let lastError;
+
+	for ( let attempt = 0; attempt <= retries; attempt++ ) {
+		try {
+			const response = await fetch( url );
+
+			if ( response.ok ) {
+				return await response.json();
+			}
+
+			const retryable = response.status === 429 || response.status >= 500;
+			const error = Object.assign( new Error( `Request failed with HTTP ${ response.status }.` ), {
+				retryable,
+			} );
+
+			throw error;
+		} catch ( error ) {
+			lastError = error;
+
+			const isLastAttempt = attempt === retries;
+			if ( isLastAttempt || error.retryable === false ) {
+				throw lastError;
+			}
+
+			const delay = baseDelayMs * 2 ** attempt;
+			console.warn( `Request failed (${ error.message }). Retrying in ${ delay }ms...` );
+
+			await sleep( delay );
+		}
+	}
+
+	throw lastError;
+}
+
 async function downloadLanguages( languageRevisions ) {
 	return await Promise.all(
 		langSlugs.map( async ( langSlug ) => {
 			const filename = `${ langSlug }-v1.1.json`;
-
 			const output = `${ OUTPUT_PATH }/${ filename }`;
 			const translationUrl = `${ LANGUAGES_BASE_URL }/${ filename }`;
 
 			console.log( `Downloading ${ filename }...` );
 
-			const response = await fetch( translationUrl );
-			if ( response.status !== 200 ) {
-				// Script should exit with an error if any of the
-				// translation download jobs for a language included
-				// in language revisions file fails.
-				// Failed downloads for languages that are not
-				// included in language revisions file could be skipped
-				// without interrupting the script.
+			try {
+				const json = await fetchJsonWithRetry( translationUrl, {
+					retries: 3,
+					baseDelayMs: 500,
+				} );
+
+				await writeFile( output, JSON.stringify( json ) );
+
+				console.log( `Downloading ${ filename } complete.` );
+
+				return { langSlug, languageTranslations: json };
+			} catch ( error ) {
 				if ( langSlug in languageRevisions ) {
-					throw new Error( `Failed to download translations for "${ langSlug }".` );
+					console.log( `Failed to download translations for "${ langSlug }" after retries.` );
+					console.log( translationUrl );
+
+					throw new Error( `Failed to download translations for "${ langSlug }" after retries.` );
 				}
+
+				console.warn( `Skipping optional language "${ langSlug }": ${ error.message }` );
+
 				return { langSlug, failed: true };
 			}
-
-			const json = await response.json();
-			await writeFile( output, JSON.stringify( json ) );
-
-			console.log( `Downloading ${ filename } complete.` );
-
-			return { langSlug, languageTranslations: json };
 		} )
 	);
 }
-
 // Split language translations into chunks
 function buildLanguageChunks( downloadedLanguages, languageRevisions ) {
 	console.log( 'Building language chunks...' );


### PR DESCRIPTION
Using this for Dserve testing. These are changes I use to help Caly build on the dockerfile locally.

## Proposed Changes

*

## Why are these changes being made?

*

## Testing Instructions


*

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
