### PR TITLE
Populate messaging flow in the ticket directly

### DIFF
--- a/packages/agents-manager/src/components/zendesk-chat/index.tsx
+++ b/packages/agents-manager/src/components/zendesk-chat/index.tsx
@@ -1,6 +1,7 @@
 import { type MarkdownComponents, type MarkdownExtensions } from '@automattic/agenttic-ui';
 import { useManagedZendeskChat } from '@automattic/zendesk-client';
 import { useEffect } from '@wordpress/element';
+import { useAgentsManagerContext } from '../../contexts';
 import AgentChat from '../agent-chat';
 import { type Options as ChatHeaderOptions } from '../chat-header';
 import ConcludedConversationFooter from '../concluded-conversation-footer';
@@ -36,6 +37,10 @@ export default function ZendeskChat( {
 	markdownExtensions = {},
 	onHasMessagesChange,
 }: Props ) {
+	const context = useAgentsManagerContext();
+	const environment = context.agentConfig?.contextProvider?.getClientContext?.()?.environment;
+	const messagingFlowName = environment === 'ciab-admin' ? 'messaging_flow_commerce_in_a_box' : '';
+
 	const {
 		agentticMessages,
 		onSubmit,
@@ -46,7 +51,7 @@ export default function ZendeskChat( {
 		supportedImageTypes,
 		notice,
 		hasInteractionEnded,
-	} = useManagedZendeskChat();
+	} = useManagedZendeskChat( messagingFlowName );
 
 	// Notify parent when has-messages state changes
 	const hasMessages = agentticMessages.length > 0;

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -143,6 +143,7 @@ export const useCreateZendeskConversation = () => {
 					createdAt: Date.now(),
 					...( activeInteractionId ? { supportInteractionId: activeInteractionId } : {} ),
 					...( chatId ? { odieChatId: chatId } : {} ),
+					'zen:ticket_field:48062253321620': userFieldFlowName || '',
 				},
 			} );
 		} catch ( error ) {

--- a/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
+++ b/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
@@ -161,6 +161,7 @@ function sendMessage(
 
 /**
  * Returns a complete API for managing a Zendesk chat.
+ * @param messagingFlowName - The name of the messaging flow to use.
  * @returns An object with the following properties:
  * - typingStatus: The status of the typing.
  * - clientId: The ID of the client.
@@ -169,7 +170,7 @@ function sendMessage(
  * - agentticMessages: The messages in the conversation in Agenttic-compatible format.
  * - sendMessage: A function to send a message to the conversation.
  */
-export const useManagedZendeskChat = () => {
+export const useManagedZendeskChat = ( messagingFlowName: string = '' ) => {
 	const [ attachmentsNotice, setAttachmentNotice ] = useState< NoticeConfig | undefined >();
 	const { state } = useLocation();
 	const conversationId = state?.conversationId;
@@ -271,6 +272,7 @@ export const useManagedZendeskChat = () => {
 					createdAt: Date.now(),
 					started_from: 'chat',
 					chat_session_id: startedFromChatId,
+					'zen:ticket_field:48062253321620': messagingFlowName || '',
 				},
 			} ).then( ( conversation ) => {
 				setConversation( conversation );
@@ -278,7 +280,15 @@ export const useManagedZendeskChat = () => {
 				Smooch.loadConversation( conversation.id );
 			} );
 		}
-	}, [ Smooch, conversationId, navigate, conversation, Smooch?.render, startedFromChatId ] );
+	}, [
+		Smooch,
+		conversationId,
+		navigate,
+		conversation,
+		Smooch?.render,
+		startedFromChatId,
+		messagingFlowName,
+	] );
 
 	const currentTypingStatus = typingStatus[ conversation?.id ?? '' ];
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
