### PR TITLE
A4A: keep lead-matching business type Other option

### DIFF
--- a/client/a8c-for-agencies/sections/partner-directory/components/hooks/use-form-selectors.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/components/hooks/use-form-selectors.ts
@@ -97,6 +97,7 @@ export function useFormSelectors() {
 		online_store_digital: translate( 'Online stores – digital products / subscriptions only' ),
 		content_media: translate( 'Content / blog / media' ),
 		nonprofit_community: translate( 'Non-profit / community' ),
+		other: translate( 'Other' ),
 	};
 
 	const availableCompanySizes: Record< string, string > = {

--- a/client/a8c-for-agencies/sections/partner-directory/lead-matching/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/lead-matching/index.tsx
@@ -633,6 +633,7 @@ const LeadMatchingForm = ( { initialFormData, profile }: Props ) => {
 					title={ __( 'Business details' ) }
 					className={ getSectionClassName( BUSINESS_DETAILS_FIELDS ) }
 				>
+					{ /* Keep the dormant Other text-field path disabled for now. `other` is a valid saved option. */ }
 					<FormField
 						label={ __( 'Which business types does your agency support?' ) }
 						description={ __( 'Select all that apply.' ) }
@@ -656,7 +657,6 @@ const LeadMatchingForm = ( { initialFormData, profile }: Props ) => {
 						error={ validationError.idealBusinessTypes }
 						fieldName="idealBusinessTypes"
 					>
-						{ /* The free-text Other path stays disabled until HubSpot supports a separate field. */ }
 						<TokenFieldSelector
 							availableOptions={ availableBusinessTypes }
 							selectedSlugs={ formData.idealBusinessTypes }

--- a/client/a8c-for-agencies/sections/partner-directory/lead-matching/options.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/lead-matching/options.ts
@@ -35,6 +35,7 @@ export function getLeadMatchingOptions() {
 			{ label: __( 'Online stores with digital products' ), value: 'online_store_digital' },
 			{ label: __( 'Content and media' ), value: 'content_media' },
 			{ label: __( 'Nonprofits and communities' ), value: 'nonprofit_community' },
+			{ label: __( 'Other' ), value: 'other' },
 		] satisfies LeadMatchingOption[],
 		supportedCompanySizes: [
 			{ label: __( '1–5 employees' ), value: 'size_1_5' },

--- a/client/a8c-for-agencies/sections/partner-directory/lead-matching/test/validation.test.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/lead-matching/test/validation.test.ts
@@ -36,4 +36,23 @@ describe( 'validateLeadMatchingDetails', () => {
 
 		expect( validateLeadMatchingDetails( details ) ).toBeNull();
 	} );
+
+	it( 'allows other as a normal option without requiring the dormant text fields', () => {
+		const details = createDefaultLeadMatchingDetails();
+		details.regions = [ 'americas' ];
+		details.languages = [ 'en' ];
+		details.businessTypes = [ 'other' ];
+		details.idealBusinessTypes = [ 'other' ];
+		details.companySizes = [ 'size_1_5' ];
+		details.projectTypes = [ 'migration' ];
+		details.serviceLevels = [ 'essential' ];
+		details.budgetLevels = [ 'affordable' ];
+		details.timingPreferences = [ 'right_away' ];
+		details.decisionProcesses = [ 'individual' ];
+		details.ongoingRelationships = [ 'care_plans' ];
+
+		expect( details.otherBusinessType ).toBe( '' );
+		expect( details.otherIdealBusinessType ).toBe( '' );
+		expect( validateLeadMatchingDetails( details ) ).toBeNull();
+	} );
 } );

--- a/client/a8c-for-agencies/sections/partner-directory/utils/map-application-form-data.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/utils/map-application-form-data.ts
@@ -12,6 +12,7 @@ const ALLOWED_BUSINESS_TYPES = new Set( [
 	'online_store_digital',
 	'content_media',
 	'nonprofit_community',
+	'other',
 ] );
 
 const ALLOWED_HOSTING_ENVIRONMENTS = new Set( [

--- a/client/a8c-for-agencies/sections/partner-directory/utils/test/map-lead-matching-form-data.test.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/utils/test/map-lead-matching-form-data.test.ts
@@ -355,8 +355,8 @@ describe( 'mapLeadMatchingDetailsToProfile', () => {
 				},
 			} )
 		).toMatchObject( {
-			businessTypes: [ 'local_service', 'online_store_physical' ],
-			idealBusinessTypes: [ 'content_media', 'online_store_digital' ],
+			businessTypes: [ 'local_service', 'online_store_physical', 'other' ],
+			idealBusinessTypes: [ 'content_media', 'online_store_digital', 'other' ],
 			hostingEnvironments: [ 'wpcom' ],
 			migrationPlatforms: [ 'shopify' ],
 			storeComplexities: [ 'custom_pricing', 'customer_portals' ],
@@ -365,6 +365,27 @@ describe( 'mapLeadMatchingDetailsToProfile', () => {
 			minimumBudget: 'above_30k',
 			timingPreferences: [ 'book_1_3_months' ],
 			decisionProcesses: [ 'formal_procurement' ],
+		} );
+	} );
+
+	it( 'round-trips other as a valid saved business type option', () => {
+		const details = createDefaultLeadMatchingDetails();
+		details.businessTypes = [ 'local_service', 'other' ];
+		details.idealBusinessTypes = [ 'other' ];
+
+		const profile = mapLeadMatchingDetailsToProfile( details, null );
+		const hydratedDetails = mapLeadMatchingProfileToFormData( profile );
+
+		expect( profile.business_fit ).toEqual( {
+			supported_business_types: [ 'local_service', 'other' ],
+			ideal_business_types: [ 'other' ],
+			supported_company_sizes: [],
+		} );
+		expect( hydratedDetails ).toMatchObject( {
+			businessTypes: [ 'local_service', 'other' ],
+			idealBusinessTypes: [ 'other' ],
+			otherBusinessType: '',
+			otherIdealBusinessType: '',
 		} );
 	} );
 } );


### PR DESCRIPTION
Related to A4A-2372

## Proposed Changes

* add `other` back to the lead-matching business-type options exposed in the form
* allow `other` to hydrate and round-trip through the grouped lead-matching payload
* keep the dormant free-text `otherBusinessType` and `otherIdealBusinessType` path disabled for now

## Why are these changes being made?

* the grouped lead-matching contract still stores `other` as a valid saved business-type option
* the current UI should accept and preserve that value without reopening the separate free-text path before HubSpot supports it
* focused tests lock the intended behavior while this remains a staged follow-up

## Testing Instructions

* `yarn test-client client/a8c-for-agencies/sections/partner-directory/utils/test/map-lead-matching-form-data.test.ts --runInBand`
* `yarn test-client client/a8c-for-agencies/sections/partner-directory/lead-matching/test/validation.test.ts --runInBand`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
