### PR TITLE
Dashboard: Show launch celebration modal when launch_status is false

### DIFF
--- a/client/dashboard/sites/site-launch-celebration-modal/index.tsx
+++ b/client/dashboard/sites/site-launch-celebration-modal/index.tsx
@@ -57,7 +57,9 @@ export default function SiteLaunchCelebrationModal( {
 		const hasCelebrateLaunch = new URLSearchParams( window.location.search ).has(
 			'celebrateLaunch'
 		);
-		if ( site.launch_status === 'launched' && hasCelebrateLaunch ) {
+		const isSiteLaunched = site.launch_status === 'launched' || site.launch_status === false;
+
+		if ( isSiteLaunched && hasCelebrateLaunch ) {
 			onOpen();
 		}
 	}, [ site.launch_status, onOpen ] );

--- a/client/dashboard/sites/site-launch-celebration-modal/test/index.test.tsx
+++ b/client/dashboard/sites/site-launch-celebration-modal/test/index.test.tsx
@@ -79,6 +79,14 @@ describe( '<SiteLaunchCelebrationModal>', () => {
 			// Modal should not be rendered
 			expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
 		} );
+
+		test( 'renders modal when launch_status is false (API missing option) and celebrateLaunch is present', async () => {
+			setupCelebrateLaunchUrl();
+			const mockSite = createMockSite( { launch_status: false } );
+			render( <SiteLaunchCelebrationModal site={ mockSite } /> );
+
+			expect( await screen.findByRole( 'dialog' ) ).toBeVisible();
+		} );
 	} );
 
 	describe( 'Domain Selection Logic', () => {


### PR DESCRIPTION
Closes DATSCI-1288. Closes DATSCI-1290.

## Proposed Changes

- Treat `launch_status === false` the same as `'launched'` when deciding whether to open the site launch celebration modal (URL param `celebrateLaunch`), consistent with other dashboard handling and server-side `is_site_launched` semantics.
- Add a unit test covering the `false` case.

## Why are these changes being made?

The WordPress.com sites API can return `launch_status` as the JSON boolean `false` when the `launch-status` blog option is not set (for example legacy sites), not only the string `'launched'`. The previous check only matched `'launched'`, so users redirected with `celebrateLaunch` after launching from visibility settings could miss the celebration modal even though the site is effectively launched.

## Testing Instructions

1. **Unit tests**
   ```bash
   yarn test-client client/dashboard/sites/site-launch-celebration-modal/test/index.test.tsx
   ```

2. **Manual (Dashboard)**
   - Enter a site where `launch_status: false` and add `celebrateLaunch` to the query parameters
   - Confirm the “Congrats, your site is live!” modal appears
   - Confirm an **unlaunched** site still does **not** open the modal with `celebrateLaunch` alone.
