### PR TITLE
Launch Site Standardization: Refetch site data after launching within Calypso Dashboard site visibility settings

### DIFF
--- a/client/dashboard/sites/settings-site-visibility/index.tsx
+++ b/client/dashboard/sites/settings-site-visibility/index.tsx
@@ -15,7 +15,13 @@ import { LaunchAgencyDevelopmentSiteForm, LaunchForm } from './launch-form';
 import { PrivacyForm } from './privacy-form';
 import { ShareSiteForm } from './share-site-form';
 
-export default function SiteVisibilitySettings( { siteSlug }: { siteSlug: string } ) {
+export default function SiteVisibilitySettings( {
+	siteSlug,
+	onSiteLaunch,
+}: {
+	siteSlug: string;
+	onSiteLaunch?: () => void;
+} ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: settings } = useSuspenseQuery( siteSettingsQuery( site.ID ) );
 	const { back_to } = useSearch( {
@@ -29,7 +35,7 @@ export default function SiteVisibilitySettings( { siteSlug }: { siteSlug: string
 					{ site.is_a4a_dev_site ? (
 						<LaunchAgencyDevelopmentSiteForm site={ site } />
 					) : (
-						<LaunchForm site={ site } />
+						<LaunchForm site={ site } onSiteLaunch={ onSiteLaunch } />
 					) }
 					{ site.is_coming_soon && <ShareSiteForm site={ site } /> }
 				</>

--- a/client/dashboard/sites/settings-site-visibility/launch-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/launch-form.tsx
@@ -122,13 +122,19 @@ export function LaunchAgencyDevelopmentSiteForm( { site }: { site: Site } ) {
 	);
 }
 
-export function LaunchForm( { site }: { site: Site } ) {
+export function LaunchForm( { site, onSiteLaunch }: { site: Site; onSiteLaunch?: () => void } ) {
 	return (
 		<>
 			<TrialUpsellNotice site={ site } />
 			<Notice
 				title={ __( 'Your site hasn’t been launched yet' ) }
-				actions={ <SiteLaunchButton site={ site } tracksContext="site_settings" /> }
+				actions={
+					<SiteLaunchButton
+						site={ site }
+						tracksContext="site_settings"
+						onSiteLaunch={ onSiteLaunch }
+					/>
+				}
 			>
 				{ __( 'It is hidden from visitors behind a “Coming Soon” notice until it is launched.' ) }
 			</Notice>

--- a/client/dashboard/sites/site-launch-button/index.tsx
+++ b/client/dashboard/sites/site-launch-button/index.tsx
@@ -1,5 +1,5 @@
 import { DotcomPlans } from '@automattic/api-core';
-import { queryClient, siteBySlugQuery, siteLaunchMutation } from '@automattic/api-queries';
+import { siteLaunchMutation } from '@automattic/api-queries';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -83,16 +83,11 @@ export function SiteLaunchButton( {
 		recordTracksEvent( 'calypso_dashboard_site_launch_button_click', { context: tracksContext } );
 	};
 
-	const onSiteLaunchSuccess = () => {
-		onSiteLaunch?.();
-		queryClient.invalidateQueries( siteBySlugQuery( site.slug ) );
-	};
-
 	const handleLaunch = () => {
 		handleTracksEvent();
 		launchMutation.mutate( undefined, {
 			onSuccess: () => {
-				onSiteLaunchSuccess();
+				onSiteLaunch?.();
 			},
 			onSettled: () => {
 				setIsLaunchModalOpen( false );
@@ -104,7 +99,7 @@ export function SiteLaunchButton( {
 		handleTracksEvent();
 		launchMutation.mutate( undefined, {
 			onSuccess: () => {
-				onSiteLaunchSuccess();
+				onSiteLaunch?.();
 
 				// Add query param to trigger celebration modal in parent component
 				window.history.replaceState(

--- a/client/dashboard/sites/site-launch-button/index.tsx
+++ b/client/dashboard/sites/site-launch-button/index.tsx
@@ -1,5 +1,5 @@
 import { DotcomPlans } from '@automattic/api-core';
-import { siteLaunchMutation } from '@automattic/api-queries';
+import { queryClient, siteBySlugQuery, siteLaunchMutation } from '@automattic/api-queries';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -22,6 +22,7 @@ export function SiteLaunchButton( {
 	tracksContext,
 	launchUrl,
 	LaunchModal,
+	onSiteLaunch,
 }: {
 	site: Site;
 	tracksContext: string;
@@ -31,6 +32,7 @@ export function SiteLaunchButton( {
 		onClose: () => void;
 		onLaunch: () => void;
 	} >;
+	onSiteLaunch?: () => void;
 } ) {
 	const { queries } = useAppContext();
 	const { recordTracksEvent } = useAnalytics();
@@ -81,9 +83,17 @@ export function SiteLaunchButton( {
 		recordTracksEvent( 'calypso_dashboard_site_launch_button_click', { context: tracksContext } );
 	};
 
+	const onSiteLaunchSuccess = () => {
+		onSiteLaunch?.();
+		queryClient.invalidateQueries( siteBySlugQuery( site.slug ) );
+	};
+
 	const handleLaunch = () => {
 		handleTracksEvent();
 		launchMutation.mutate( undefined, {
+			onSuccess: () => {
+				onSiteLaunchSuccess();
+			},
 			onSettled: () => {
 				setIsLaunchModalOpen( false );
 			},
@@ -94,6 +104,8 @@ export function SiteLaunchButton( {
 		handleTracksEvent();
 		launchMutation.mutate( undefined, {
 			onSuccess: () => {
+				onSiteLaunchSuccess();
+
 				// Add query param to trigger celebration modal in parent component
 				window.history.replaceState(
 					null,

--- a/client/sites/v2/site-settings/router.tsx
+++ b/client/sites/v2/site-settings/router.tsx
@@ -34,17 +34,20 @@ const siteVisibilityRoute = createRoute( {
 } ).lazy( () =>
 	import( 'calypso/dashboard/sites/settings-site-visibility' ).then( ( d ) =>
 		createLazyRoute( 'site-visibility' )( {
-			component: () => {
-				// eslint-disable-next-line react-hooks/rules-of-hooks
+			component: function CalypsoDashboardSiteVisibilitySettings() {
 				const siteId = useSelector( getSelectedSiteId );
-				// eslint-disable-next-line react-hooks/rules-of-hooks
 				const dispatch = useDispatch();
+
+				if ( ! siteId ) {
+					throw new Error( 'No site ID selected. This is a bug.' );
+				}
 
 				return (
 					<d.default
 						siteSlug={ siteRoute.useParams().siteSlug }
 						onSiteLaunch={ () => {
-							dispatch( requestSite( siteId! ) );
+							// The site launch celebration modal reads the site data from Redux, not React Query, so we need to refetch it.
+							dispatch( requestSite( siteId ) );
 						} }
 					/>
 				);

--- a/client/sites/v2/site-settings/router.tsx
+++ b/client/sites/v2/site-settings/router.tsx
@@ -4,6 +4,9 @@ import { __ } from '@wordpress/i18n';
 import { APP_CONTEXT_DEFAULT_CONFIG } from 'calypso/dashboard/app/context';
 import { handleOnCatch } from 'calypso/dashboard/app/logger';
 import * as appRouterSites from 'calypso/dashboard/app/router/sites';
+import { useDispatch, useSelector } from 'calypso/state';
+import { requestSite } from 'calypso/state/sites/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { rootRoute, dashboardSitesCompatibilityRoute, siteRoute } from '../router';
 import { getRouterOptions, createBrowserHistoryAndMemoryRouterSync } from '../utils/router';
 import type { AppConfig } from 'calypso/dashboard/app/context';
@@ -31,7 +34,21 @@ const siteVisibilityRoute = createRoute( {
 } ).lazy( () =>
 	import( 'calypso/dashboard/sites/settings-site-visibility' ).then( ( d ) =>
 		createLazyRoute( 'site-visibility' )( {
-			component: () => <d.default siteSlug={ siteRoute.useParams().siteSlug } />,
+			component: () => {
+				// eslint-disable-next-line react-hooks/rules-of-hooks
+				const siteId = useSelector( getSelectedSiteId );
+				// eslint-disable-next-line react-hooks/rules-of-hooks
+				const dispatch = useDispatch();
+
+				return (
+					<d.default
+						siteSlug={ siteRoute.useParams().siteSlug }
+						onSiteLaunch={ () => {
+							dispatch( requestSite( siteId! ) );
+						} }
+					/>
+				);
+			},
 		} )
 	)
 );


### PR DESCRIPTION
Closes DATSCI-1289.

## Proposed Changes

- Add an optional onSiteLaunch callback to SiteLaunchButton, invoked after a successful launch.
- Thread `onSiteLaunch` through `LaunchForm` and `SiteVisibilitySettings` so the Calypso dashboard can run host-specific side effects.
- In the Calypso dashboard backport (`client/sites/v2/site-settings/router.tsx`), pass `onSiteLaunch` that dispatches `requestSite( siteId )` so Redux site data matches the server after launch.

https://github.com/user-attachments/assets/d324df11-3d54-4577-b666-5d5a8fc1d1aa

## Why are these changes being made?

The site wasn't being refetched after launching in Calypso dashboard (Redux) and because of that the data was out of sync with what came from the REST API, which caused the celebration modal to never be shown

## Testing Instructions

Follow the steps taken in the video and you observe that launching in the ungated experience on both MSD and Calypso Dashboard reflects the changes.