### PR TITLE
Launch Site Standardization: Send the user to the site home if launching from site visibility settings

### DIFF
--- a/client/dashboard/sites/settings-site-visibility/launch-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/launch-form.tsx
@@ -133,6 +133,7 @@ export function LaunchForm( { site, onSiteLaunch }: { site: Site; onSiteLaunch?:
 						site={ site }
 						tracksContext="site_settings"
 						onSiteLaunch={ onSiteLaunch }
+						backTo={ `/sites/${ site.slug }` }
 					/>
 				}
 			>

--- a/client/dashboard/sites/site-launch-button/index.tsx
+++ b/client/dashboard/sites/site-launch-button/index.tsx
@@ -9,7 +9,7 @@ import { useExperiment } from 'calypso/lib/explat';
 import { useAnalytics } from '../../app/analytics';
 import { useAppContext } from '../../app/context';
 import { getCurrentDashboard } from '../../app/routing';
-import { redirectToDashboardLink, wpcomLink } from '../../utils/link';
+import { dashboardLinkWithBackport, redirectToDashboardLink, wpcomLink } from '../../utils/link';
 import {
 	isSitePlanLaunchable as getIsSitePlanLaunchable,
 	isSitePlanBigSkyTrial,
@@ -23,6 +23,7 @@ export function SiteLaunchButton( {
 	launchUrl,
 	LaunchModal,
 	onSiteLaunch,
+	backTo,
 }: {
 	site: Site;
 	tracksContext: string;
@@ -33,6 +34,7 @@ export function SiteLaunchButton( {
 		onLaunch: () => void;
 	} >;
 	onSiteLaunch?: () => void;
+	backTo?: string;
 } ) {
 	const { queries } = useAppContext();
 	const { recordTracksEvent } = useAnalytics();
@@ -74,7 +76,9 @@ export function SiteLaunchButton( {
 			siteSlug: site.slug,
 			new: site.name,
 			hide_initial_query: 'yes',
-			back_to: redirectToDashboardLink( { supportBackport: true } ),
+			back_to: backTo
+				? dashboardLinkWithBackport( backTo )
+				: redirectToDashboardLink( { supportBackport: true } ),
 			dashboard: getCurrentDashboard(),
 		} );
 	};


### PR DESCRIPTION
Closes DATSCI-1287. Closes DATSCI-1291.

## Proposed Changes

The visibility settings page is useless if the user just launched the site - there's a 99% chance they'll browse elsewhere, so let's send them to `/sites/%s` directly after launching.

## Testing Instructions

Follow the instructions from the video below, and verify you observe the same behavior:


https://github.com/user-attachments/assets/a51becfe-83de-4b30-9e55-00cb3f53c32a

