### PR TITLE
Launch Site Flow: Allow purchasing a domain if launching an Atomic site

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -1036,8 +1036,10 @@ export function isDomainFulfilled( stepName, defaultDependencies, nextProps ) {
 		return;
 	}
 
-	if ( siteDomains && siteDomains.length > 1 ) {
-		const tracksEventValue = siteDomains.map( ( siteDomain ) => siteDomain.domain ).join( ', ' );
+	const customDomains = siteDomains?.filter( ( siteDomain ) => ! siteDomain.isWPCOMDomain ) ?? [];
+
+	if ( customDomains.length > 0 ) {
+		const tracksEventValue = customDomains.map( ( siteDomain ) => siteDomain.domain ).join( ', ' );
 		excludeDomainStep( stepName, tracksEventValue, submitSignupStep );
 	}
 }


### PR DESCRIPTION
Closes DATSCI-1293.

## Proposed Changes

- Update `isDomainFulfilled` in `client/lib/signup/step-actions/index.js` so the launch-site signup flow only auto-skips the domains step when the site already has at least one **custom** (non-WPCOM) domain, instead of using a raw `siteDomains.length > 1` check.

## Why are these changes being made?

In the `/start/launch-site` flow, **Atomic** sites could end up with more than one entry in `siteDomains` even when the user had **no custom domain** (e.g. a `.wordpress.com` and a `.wpcomstaging.com` domain). The previous condition (`siteDomains.length > 1`) treated that as “domain fulfilled” and skipped the domains step, so users could not pick or purchase a domain when launching. DATSCI-1293 describes this: the domains step should not be skipped when there are no custom domains attached.

The fix filters to domains where `! siteDomain.isWPCOMDomain` and only excludes the domain step when that list is non-empty, matching the intent: skip only when a custom domain already exists.

## Testing Instructions

**Prerequisites**

- An **Atomic** site that has **no custom domain** (only the WPCOM and WPCOMSTAGING domain situation described in the issue).

**Before (buggy behavior)**

1. Open the launch-site flow with that site, e.g. `/start/launch-site?siteSlug=<your-site-slug>` (use the real slug for the Atomic site).
2. **Expected (bug):** The domains step is **skipped** even though the site has no custom domain.

**After (fixed behavior)**

1. Repeat the same URL and flow with the same Atomic site (no custom domain).
2. **Expected:** The **domains** step is **shown** so the user can search for / select / purchase a domain as part of launch.

**Regression check**

- On a site that **does** have at least one custom (non-WPCOM) domain, the domains step should still be **skipped** as before (domain already fulfilled).
- On a Simple site with no custom domains (free site for example), **the domains step should be displayed**.