### PR TITLE
Launch Site Flow: Fix wrong site when re-entering with a different siteSlug

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -346,7 +346,7 @@ export default {
 		const signupDependencies = getSignupDependencyStore( getState() );
 		let siteIdOrSlug;
 
-		if ( 'woocommerce-install' === flowName ) {
+		if ( 'woocommerce-install' === flowName || 'launch-site' === flowName ) {
 			// forces query precedence on woocommerce-install
 			siteIdOrSlug = context.query?.siteSlug || signupDependencies?.siteSlug;
 		} else {


### PR DESCRIPTION
Follows up on DATSCI-1293.

## Proposed Changes

In #109923 we fixed `/start/launch-site?siteSlug=%s` for Atomic sites that only had the default `.wordpress.com` and `.wpcomstaging.com` domains: the flow was treating those as “enough” and skipping the domains step, even though we want users to be able to buy a custom domain.

After that shipped, a related issue showed up. **Signup dependencies are persisted** (including `siteSlug`). When resolving the selected site, the code preferred `signupDependencies.siteSlug` over the `siteSlug` in the URL. So if someone entered the launch-site flow again with a **different** `?siteSlug=`, the app could keep using the **previous** site from storage. The flow then didn’t match what the URL implied.

This change gives **`siteSlug` from the query string precedence over `signupDependencies`** when setting the selected site for the `launch-site` flow (same pattern as `woocommerce-install` in `setSelectedSiteForSignup`).

## Testing Instructions

On `trunk`, start Calypso with `ENABLE_FEATURES=no-force-sympathy yarn start`. This prevents the local cache from being cleared during testing, so the signup dependencies remain cached.

- Enter `/start/launch-site?siteSlug=%s` where `%s` is a site that has no custom domains. Verify you see the domains step.
- Enter `/start/launch-site?siteSlug=%s` where `%s` is a site that **HAS** a custom domain. Verify you (incorrectly) see the domains step.

Apply this branch locally, then...

- Enter `/start/launch-site?siteSlug=%s` where `%s` is a site that has no custom domains. Verify you see the domains step.
- Enter `/start/launch-site?siteSlug=%s` where `%s` is a site that **HAS** a custom domain. Verify that the domains step was correctly skipped.