### PR TITLE
MSD: Use per-request i18n provider for omnibar SSR locale

### DIFF
--- a/client/dashboard/app/interim-omnibar/index.tsx
+++ b/client/dashboard/app/interim-omnibar/index.tsx
@@ -1,4 +1,5 @@
-import { defaultI18n } from '@wordpress/i18n';
+// eslint-disable-next-line no-restricted-imports
+import { I18N, I18NContext } from 'i18n-calypso';
 import { hydrateRoot } from 'react-dom/client';
 import { getUserLanguage, loadUserLocaleData } from '../shared-locale-loader';
 import type { OmnibarEvents } from './click-handlers';
@@ -27,19 +28,23 @@ export default async function loadOmnibar( events: OmnibarEvents ) {
 		events.linkClick.emit( { href, event } );
 	} );
 
-	// Apply the user's locale to `defaultI18n` before hydrating so the first
-	// client render matches the SSR-translated HTML. `getUserLanguage` mirrors
-	// the server's `setUpLoggedInRoute` derivation so both sides agree on the
-	// effective locale.
+	// Create a per-tree i18n-calypso instance loaded with the user's locale so
+	// the first client render matches the SSR-translated HTML. Provided via
+	// I18NContext so the `localize()` HOC picks it up without any global mutation.
 	const [ { InterimOmnibarContainer }, localeData ] = await Promise.all( [
 		import( './interim-omnibar-container' ),
 		loadUserLocaleData( getUserLanguage( window.currentUser ?? null ) ),
 	] );
 
-	defaultI18n.resetLocaleData( localeData );
+	const i18n = new I18N();
+	if ( localeData ) {
+		i18n.setLocale( localeData );
+	}
 
 	hydrateRoot(
 		container,
-		<InterimOmnibarContainer initialUser={ window.currentUser ?? null } events={ events } />
+		<I18NContext.Provider value={ i18n }>
+			<InterimOmnibarContainer initialUser={ window.currentUser ?? null } events={ events } />
+		</I18NContext.Provider>
 	);
 }

--- a/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
+++ b/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-restricted-imports */
 import { isEcommercePlan } from '@automattic/calypso-products';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { localize } from 'i18n-calypso';
 import { useEffect, useMemo } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { MasterbarLoggedIn } from 'calypso/layout/masterbar/logged-in';
@@ -9,6 +10,8 @@ import { getSiteDisplayName } from '../../utils/site-name';
 import { logout } from '../auth';
 import { omnibarEvents } from './click-handlers';
 import type { User, Site } from '@automattic/api-core';
+
+const LocalizedMasterbarLoggedIn = localize( MasterbarLoggedIn );
 
 const noop = () => {};
 
@@ -76,7 +79,7 @@ export function InterimOmnibar( {
 	return (
 		<QueryClientProvider client={ omnibarQueryClient }>
 			<ReduxProvider store={ store }>
-				<MasterbarLoggedIn
+				<LocalizedMasterbarLoggedIn
 					// User
 					user={ user }
 					hasNoSites={ user.site_count === 0 }

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -4,6 +4,7 @@ import { WordPressLogo } from '@automattic/components';
 import { isLocaleRtl } from '@automattic/i18n-utils';
 import { Step } from '@automattic/onboarding';
 import clsx from 'clsx';
+import defaultCalypsoI18n, { I18NContext } from 'i18n-calypso';
 import { useMemo, Component } from 'react';
 import A4ALogo from 'calypso/a8c-for-agencies/components/a4a-logo';
 import EnvironmentBadge, {
@@ -163,16 +164,18 @@ class Document extends Component {
 						'is-mobile-app-view': app?.isWpMobileApp || app?.isWcMobileApp,
 					} ) }
 				>
-					{ /* eslint-disable wpcalypso/jsx-classname-namespace, react/no-danger */ }
 					{ dashboard && config.isEnabled( 'dashboard/omnibar' ) && (
 						<div id="wpcom-omnibar">
-							<InterimOmnibar
-								user={ user || null }
-								site={ null }
-								currentRoute={ this.props.path ?? '/' }
-							/>
+							<I18NContext.Provider value={ this.props.i18nCalypso || defaultCalypsoI18n }>
+								<InterimOmnibar
+									user={ user || null }
+									site={ null }
+									currentRoute={ this.props.path ?? '/' }
+								/>
+							</I18NContext.Provider>
 						</div>
 					) }
+					{ /* eslint-disable react/no-danger */ }
 					{ renderedLayout ? (
 						<div
 							id="wpcom"

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -2,8 +2,7 @@ import config from '@automattic/calypso-config';
 import { isEcommercePlan } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Badge } from '@automattic/ui';
-import { createInterpolateElement } from '@wordpress/element';
-import { __, _x, sprintf } from '@wordpress/i18n';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { parse } from 'qs';
 import { Component } from 'react';
@@ -214,6 +213,8 @@ class MasterbarLoggedIn extends Component {
 	 * In nav unification, the menu is openned with the Sites button
 	 */
 	renderSidebarMobileMenu() {
+		const { translate } = this.props;
+
 		return (
 			<Item
 				tipTarget="mobile-menu"
@@ -221,7 +222,7 @@ class MasterbarLoggedIn extends Component {
 				onClick={ this.handleToggleMobileMenu }
 				isActive={ this.isSidebarOpen() }
 				className="masterbar__item-sidebar-menu"
-				tooltip={ __( 'Menu' ) }
+				tooltip={ translate( 'Menu' ) }
 			/>
 		);
 	}
@@ -231,6 +232,7 @@ class MasterbarLoggedIn extends Component {
 		const {
 			domainOnlySite,
 			siteSlug,
+			translate,
 			section,
 			currentRoute,
 			isGlobalSidebarVisible,
@@ -256,11 +258,11 @@ class MasterbarLoggedIn extends Component {
 			: [
 					[
 						{
-							label: __( 'Sites' ),
+							label: translate( 'Sites' ),
 							url: dashboardOptIn ? dashboardLink( '/sites' ) : '/sites',
 						},
 						{
-							label: __( 'Domains' ),
+							label: translate( 'Domains' ),
 							url: dashboardOptIn ? dashboardLink( '/domains' ) : '/domains/manage',
 						},
 					],
@@ -269,11 +271,11 @@ class MasterbarLoggedIn extends Component {
 						: [
 								[
 									{
-										label: __( 'About WordPress' ),
+										label: translate( 'About WordPress' ),
 										url: `${ siteAdminUrl }about.php`,
 									},
 									{
-										label: __( 'Get Involved' ),
+										label: translate( 'Get Involved' ),
 										url: `${ siteAdminUrl }contribute.php`,
 									},
 								],
@@ -289,7 +291,7 @@ class MasterbarLoggedIn extends Component {
 				subItems={ subItems }
 				onClick={ this.clickMySites }
 				isActive={ this.isMySitesActive() }
-				tooltip={ __( 'Manage your sites' ) }
+				tooltip={ translate( 'Manage your sites' ) }
 				preloadSection={ this.preloadMySites }
 				hasGlobalBorderStyle
 			/>
@@ -386,6 +388,7 @@ class MasterbarLoggedIn extends Component {
 	renderSiteBadges() {
 		const {
 			site,
+			translate,
 			isUnlaunchedSite,
 			isTrial,
 			isSiteP2,
@@ -419,12 +422,12 @@ class MasterbarLoggedIn extends Component {
 
 		// Staging Badge
 		if ( site?.is_wpcom_staging_site ) {
-			badges.push( __( 'Staging' ) );
+			badges.push( translate( 'Staging' ) );
 		}
 
 		// Trial Badge
 		if ( isTrial ) {
-			badges.push( __( 'Trial' ) );
+			badges.push( translate( 'Trial' ) );
 		}
 
 		// P2 Workspace Badge
@@ -435,28 +438,30 @@ class MasterbarLoggedIn extends Component {
 		// Private/Coming Soon Badge
 		if ( site.is_private ) {
 			badges.push(
-				shouldShowPrivateByDefaultComingSoonBadge ? __( 'Coming Soon' ) : __( 'Private' )
+				shouldShowPrivateByDefaultComingSoonBadge
+					? translate( 'Coming Soon' )
+					: translate( 'Private' )
 			);
 		}
 
 		// Express Service Badge
 		if ( site.options && site.options.is_difm_lite_in_progress ) {
-			badges.push( __( 'Express Service' ) );
+			badges.push( translate( 'Express Service' ) );
 		}
 
 		// Public Coming Soon Badge
 		if ( shouldShowPublicComingSoonSiteBadge ) {
-			badges.push( __( 'Coming Soon' ) );
+			badges.push( translate( 'Coming Soon' ) );
 		}
 
 		// Redirect Badge
 		if ( site.options && site.options.is_redirect ) {
-			badges.push( __( 'Redirect' ) );
+			badges.push( translate( 'Redirect' ) );
 		}
 
 		// Domain Badge
 		if ( site.options && site.options.is_domain_only ) {
-			badges.push( __( 'Domain' ) );
+			badges.push( translate( 'Domain' ) );
 		}
 
 		return badges.length > 0
@@ -471,6 +476,7 @@ class MasterbarLoggedIn extends Component {
 	renderSiteMenu() {
 		const {
 			siteSlug,
+			translate,
 			siteTitle,
 			siteUrl,
 			isClassicView,
@@ -486,19 +492,19 @@ class MasterbarLoggedIn extends Component {
 			return null;
 		}
 
-		const menuItems = [ { label: __( 'Visit Site' ), url: siteUrl } ];
+		const menuItems = [ { label: translate( 'Visit Site' ), url: siteUrl } ];
 
 		if ( isClassicView ) {
-			menuItems.push( { label: __( 'Dashboard' ), url: siteAdminUrl } );
+			menuItems.push( { label: translate( 'Dashboard' ), url: siteAdminUrl } );
 		} else {
-			menuItems.push( { label: __( 'My Home' ), url: siteHomeUrl } );
+			menuItems.push( { label: translate( 'My Home' ), url: siteHomeUrl } );
 		}
 
 		if ( ! site?.is_wpcom_staging_site ) {
 			menuItems.push( {
 				label: (
 					<div className="masterbar__site-info masterbar__site-plan">
-						<span className="masterbar__site-info-label">{ __( 'Plan' ) }</span>
+						<span className="masterbar__site-info-label">{ translate( 'Plan' ) }</span>
 						<div className="masterbar__info-badges">
 							<Badge className="masterbar__info-badge">{ sitePlanName }</Badge>
 						</div>
@@ -516,7 +522,7 @@ class MasterbarLoggedIn extends Component {
 			menuItems.push( {
 				label: (
 					<div className="masterbar__site-info masterbar__site-status">
-						<span className="masterbar__site-info-label">{ __( 'Status' ) }</span>
+						<span className="masterbar__site-info-label">{ translate( 'Status' ) }</span>
 						<div className="masterbar__info-badges">{ siteBadges }</div>
 					</div>
 				),
@@ -540,6 +546,7 @@ class MasterbarLoggedIn extends Component {
 		const {
 			siteSlug,
 			isClassicView,
+			translate,
 			siteAdminUrl,
 			newPostUrl,
 			newPageUrl,
@@ -560,38 +567,38 @@ class MasterbarLoggedIn extends Component {
 		if ( siteSlug ) {
 			siteActions = [
 				{
-					label: __( 'Post' ),
+					label: translate( 'Post' ),
 					url: newPostUrl,
 				},
 				{
-					label: __( 'Media' ),
+					label: translate( 'Media' ),
 					url: isClassicView ? `${ siteAdminUrl }media-new.php` : `/media/${ siteSlug }`,
 				},
 				{
-					label: __( 'Page' ),
+					label: translate( 'Page' ),
 					url: newPageUrl,
 				},
 				{
-					label: __( 'User' ),
+					label: translate( 'User' ),
 					url: isClassicView ? `${ siteAdminUrl }user-new.php` : `/people/new/${ siteSlug }`,
 				},
 			];
 		} else {
 			siteActions = [
 				{
-					label: __( 'Post' ),
+					label: translate( 'Post' ),
 					url: '/post',
 				},
 				{
-					label: __( 'Media' ),
+					label: translate( 'Media' ),
 					url: '/media',
 				},
 				{
-					label: __( 'Page' ),
+					label: translate( 'Page' ),
 					url: '/page',
 				},
 				{
-					label: __( 'User' ),
+					label: translate( 'User' ),
 					url: '/people/new',
 				},
 			];
@@ -602,10 +609,10 @@ class MasterbarLoggedIn extends Component {
 				url={ siteActions[ 0 ].url }
 				subItems={ [ siteActions ] }
 				icon={ <span className="dashicons-before dashicons-plus" /> }
-				tooltip={ _x( 'New', 'admin bar menu group label' ) }
+				tooltip={ translate( 'New', { context: 'admin bar menu group label' } ) }
 				tipTarget="new-menu"
 			>
-				{ _x( 'New', 'admin bar menu group label' ) }
+				{ translate( 'New', { context: 'admin bar menu group label' } ) }
 			</Item>
 		);
 	}
@@ -621,7 +628,7 @@ class MasterbarLoggedIn extends Component {
 	}
 
 	renderProfileMenu() {
-		const { user, isGlobalSidebarVisible, siteAdminUrl } = this.props;
+		const { translate, user, isGlobalSidebarVisible, siteAdminUrl } = this.props;
 		const profileActions = [
 			{
 				label: (
@@ -640,7 +647,7 @@ class MasterbarLoggedIn extends Component {
 								{ user.username }
 							</span>
 							<span className="display-name edit-profile">
-								{ isGlobalSidebarVisible ? __( 'My Profile' ) : __( 'Edit Profile' ) }
+								{ isGlobalSidebarVisible ? translate( 'My Profile' ) : translate( 'Edit Profile' ) }
 							</span>
 						</div>
 					</div>
@@ -648,9 +655,9 @@ class MasterbarLoggedIn extends Component {
 				url: isGlobalSidebarVisible ? '/me' : `${ siteAdminUrl }profile.php`,
 			},
 			{
-				label: __( 'Log Out' ),
+				label: translate( 'Log Out' ),
 				onClick: () => this.props.redirectToLogout(),
-				tooltip: __( 'Log out of WordPress.com' ),
+				tooltip: translate( 'Log out of WordPress.com' ),
 				className: 'logout-link',
 			},
 		];
@@ -659,8 +666,10 @@ class MasterbarLoggedIn extends Component {
 			{
 				label: (
 					<span className="button wpcom-button">
-						{ createInterpolateElement( __( 'My <wpcomIcon /> WordPress.com Account' ), {
-							wpcomIcon: this.wordpressIcon(),
+						{ translate( 'My {{wpcomIcon/}} WordPress.com Account', {
+							components: {
+								wpcomIcon: this.wordpressIcon(),
+							},
 						} ) }
 					</span>
 				),
@@ -676,18 +685,16 @@ class MasterbarLoggedIn extends Component {
 				onClick={ this.clickMe }
 				isActive={ this.isActive( 'me', true ) }
 				className="masterbar__item-howdy"
-				tooltip={ __( 'Update your profile, personal settings, and more' ) }
+				tooltip={ translate( 'Update your profile, personal settings, and more' ) }
 				preloadSection={ this.preloadMe }
 				subItems={ [ profileActions, wpcomActions ] }
 				hasGlobalBorderStyle
 			>
 				{ user.display_name && (
 					<span className="masterbar__item-howdy-howdy">
-						{ sprintf(
-							/* translators: %s is the user's display name */
-							__( 'Howdy, %s' ),
-							user.display_name
-						) }
+						{ translate( 'Howdy, %(display_name)s', {
+							args: { display_name: user.display_name },
+						} ) }
 					</span>
 				) }
 				<Gravatar
@@ -701,6 +708,7 @@ class MasterbarLoggedIn extends Component {
 	}
 
 	renderReader() {
+		const { translate } = this.props;
 		return (
 			<Item
 				tipTarget="reader"
@@ -709,12 +717,12 @@ class MasterbarLoggedIn extends Component {
 				icon={ <ReaderIcon className="masterbar__menu-icon masterbar_svg-reader" /> }
 				onClick={ this.clickReader }
 				isActive={ this.isActive( 'reader', true ) }
-				tooltip={ __( 'Read the blogs and topics you follow' ) }
+				tooltip={ translate( 'Read the blogs and topics you follow' ) }
 				preloadSection={ this.preloadReader }
 				hasGlobalBorderStyle
 			>
 				<span className="masterbar__icon-label masterbar__item-reader-label">
-					{ __( 'Reader' ) }
+					{ translate( 'Reader' ) }
 				</span>
 			</Item>
 		);
@@ -747,31 +755,31 @@ class MasterbarLoggedIn extends Component {
 	}
 
 	renderNotifications() {
+		const { translate } = this.props;
 		return (
 			<Notifications
 				isShowing
 				isActive={ this.isActive( 'notifications' ) }
 				className="masterbar__item-notifications"
-				tooltip={ __( 'Manage your notifications' ) }
+				tooltip={ translate( 'Manage your notifications' ) }
 			>
 				<span className="masterbar__item-notifications-label">
-					{
-						/* translators: Toolbar, must be shorter than ~12 chars */
-						_x( 'Notifications', 'masterbar' )
-					}
+					{ translate( 'Notifications', {
+						comment: 'Toolbar, must be shorter than ~12 chars',
+					} ) }
 				</span>
 			</Notifications>
 		);
 	}
 
 	renderHelpCenter() {
-		const { siteId, useUnifiedAgent } = this.props;
+		const { siteId, translate, useUnifiedAgent } = this.props;
 
 		if ( useUnifiedAgent ) {
 			const placeholder = (
 				<Item
 					className="masterbar__item-agents-manager"
-					tooltip={ __( 'Help' ) }
+					tooltip={ translate( 'Help' ) }
 					icon={ <AgentsManagerIcon hasUnread={ false } /> }
 				/>
 			);
@@ -784,7 +792,7 @@ class MasterbarLoggedIn extends Component {
 				<AsyncLoad
 					require="./masterbar-agents-manager"
 					siteId={ siteId }
-					tooltip={ __( 'Help' ) }
+					tooltip={ translate( 'Help' ) }
 					placeholder={ placeholder }
 				/>
 			);
@@ -793,7 +801,7 @@ class MasterbarLoggedIn extends Component {
 		const placeholder = (
 			<Item
 				className="masterbar__item-help"
-				tooltip={ __( 'Help' ) }
+				tooltip={ translate( 'Help' ) }
 				icon={ <HelpCenterIcon hasUnread={ false } /> }
 			/>
 		);
@@ -806,7 +814,7 @@ class MasterbarLoggedIn extends Component {
 			<AsyncLoad
 				require="./masterbar-help-center"
 				siteId={ siteId }
-				tooltip={ __( 'Help' ) }
+				tooltip={ translate( 'Help' ) }
 				placeholder={ placeholder }
 			/>
 		);
@@ -909,4 +917,4 @@ export default connect(
 		requestAdminMenu,
 		redirectToLogout,
 	}
-)( MasterbarLoggedIn );
+)( localize( MasterbarLoggedIn ) );

--- a/client/server/dashboard-i18n.ts
+++ b/client/server/dashboard-i18n.ts
@@ -1,30 +1,37 @@
 // eslint-disable-next-line import/no-nodejs-modules
 import { readFile } from 'fs/promises';
-import { defaultI18n, type LocaleData } from '@wordpress/i18n';
 import { type Request, type RequestHandler } from 'express';
+import { I18N } from 'i18n-calypso';
 import getAssetFilePath from 'calypso/lib/get-asset-file-path';
 import { getLanguageFile } from 'calypso/lib/i18n-utils/switch-locale';
 
+type LocaleData = Parameters< I18N[ 'setLocale' ] >[ 0 ];
+
 const localeDataCache = new Map< string, LocaleData >();
 
-type CalypsoRequest = Request & { context?: { lang?: string } };
+type CalypsoRequest = Request & { context?: { lang?: string; i18nCalypso?: I18N } };
 
 /**
- * Populates `defaultI18n` with the bootstrapped user's locale for the duration
- * of the request's render, so the server-side render of the interim omnibar
- * emits translated strings. Loads from `public/languages/` when available and
- * falls back to the Calypso CDN otherwise.
+ * Creates a per-request i18n-calypso instance loaded with the user's locale so
+ * the server-side render of the interim omnibar emits translated strings
+ * without mutating any global singleton. The instance is stored on
+ * `req.context.i18nCalypso` and provided to the React tree via
+ * `I18NContext.Provider`.
  */
 export const loadDashboardLocaleData: RequestHandler = ( req, res, next ) => {
 	const language = ( req as CalypsoRequest ).context?.lang;
 	if ( ! language || language === 'en' ) {
-		defaultI18n.resetLocaleData();
 		next();
 		return;
 	}
 
 	const apply = ( data: LocaleData ) => {
-		defaultI18n.resetLocaleData( data );
+		const i18n = new I18N();
+		i18n.setLocale( data );
+		const ctx = ( req as CalypsoRequest ).context;
+		if ( ctx ) {
+			ctx.i18nCalypso = i18n;
+		}
 		next();
 	};
 
@@ -36,13 +43,12 @@ export const loadDashboardLocaleData: RequestHandler = ( req, res, next ) => {
 
 	readFile( getAssetFilePath( `languages/${ language }-v1.1.json` ), 'utf-8' )
 		.then( ( raw ) => JSON.parse( raw ) as LocaleData )
-		.catch( () => getLanguageFile( language ) as Promise< LocaleData > )
+		.catch( () => getLanguageFile( language ) as unknown as Promise< LocaleData > )
 		.then( ( data ) => {
 			localeDataCache.set( language, data );
 			apply( data );
 		} )
 		.catch( () => {
-			defaultI18n.resetLocaleData();
 			next();
 		} );
 };


### PR DESCRIPTION
Part of #109904

## Proposed Changes

- Revert the masterbar's migration from `localize()` HOC to `@wordpress/i18n` direct imports (PR #109489)
- Replace global `defaultI18n` singleton mutation with a per-request `I18N` instance from i18n-calypso, provided via `I18NContext.Provider`
- Wrap both the SSR render and client hydration trees with the provider

## Why are these changes being made?

PR #109904 made the interim omnibar SSR work in the user's language by setting locale data on the global `defaultI18n` singleton. But Node handles requests concurrently — setting global state can cause one request's locale to bleed into another's.

The `localize()` HOC from i18n-calypso reads from `I18NContext` (React context), which is scoped to the React tree. By reverting to `localize()` and providing a per-request `I18N` instance via `I18NContext.Provider`, we get correct SSR translations without any global mutation.

## Testing Instructions

1. Enable `wpcom-user-bootstrap` in `config/dashboard-development.json`
2. Set your test account to a non-English language (e.g., French)
3. Load the dashboard — the omnibar should render in the user's language on both SSR and after hydration
4. Verify no hydration mismatches in the console

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?