### PR TITLE
MSD Omnibar: Add launch button with full parity to classic masterbar

### DIFF
--- a/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
+++ b/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
@@ -8,6 +8,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { logout } from '../auth';
 import { omnibarEvents } from './omnibar-events';
+import { OmnibarLaunchButton } from './omnibar-launch-button';
 import { createOmnibarStore } from './omnibar-store';
 import type { User, Site } from '@automattic/api-core';
 
@@ -83,7 +84,8 @@ export function InterimOmnibar( {
 					isSimpleSite={ false }
 					isJetpackNotAtomic={ !! site && site.jetpack && ! site.is_wpcom_atomic }
 					domainOnlySite={ !! site?.options?.is_domain_only }
-					isUnlaunchedSite={ false }
+					isUnlaunchedSite={ site?.launch_status === 'unlaunched' }
+					launchButtonSlot={ siteId ? <OmnibarLaunchButton siteId={ siteId } /> : undefined }
 					isTrial={ false }
 					isSiteP2={ !! site?.options?.is_wpforteams_site }
 					isP2Hub={ !! site?.options?.p2_hub_blog_id && site.options.p2_hub_blog_id === site.ID }

--- a/client/dashboard/app/interim-omnibar/omnibar-launch-button.tsx
+++ b/client/dashboard/app/interim-omnibar/omnibar-launch-button.tsx
@@ -1,0 +1,134 @@
+/* eslint-disable no-restricted-imports */
+import { siteByIdQuery, siteDomainsQuery, siteLaunchMutation } from '@automattic/api-queries';
+import {
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_MONTHLY,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_PERSONAL_3_YEARS,
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_MONTHLY,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_BUSINESS_3_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_MONTHLY,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_PREMIUM_3_YEARS,
+	PLAN_ECOMMERCE,
+	PLAN_ECOMMERCE_MONTHLY,
+	PLAN_ECOMMERCE_2_YEARS,
+	PLAN_ECOMMERCE_3_YEARS,
+	PLAN_HOSTING_TRIAL_MONTHLY,
+} from '@automattic/calypso-products';
+import { updateLaunchpadSettings } from '@automattic/data-stores';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { addQueryArgs } from '@wordpress/url';
+import { MasterbarLaunchButtonView } from 'calypso/layout/masterbar/masterbar-launch-button';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+
+// Plans that exclude a site from the Big Sky trial classification. Kept in
+// sync with `client/state/sites/plans/selectors/is-site-big-sky-trial.ts`.
+const NON_BIG_SKY_PLANS = [
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_MONTHLY,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_PERSONAL_3_YEARS,
+	PLAN_ECOMMERCE,
+	PLAN_ECOMMERCE_MONTHLY,
+	PLAN_ECOMMERCE_2_YEARS,
+	PLAN_ECOMMERCE_3_YEARS,
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_MONTHLY,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_BUSINESS_3_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_MONTHLY,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_PREMIUM_3_YEARS,
+];
+
+function addCelebrateLaunchQueryParams() {
+	const url = new URL( window.location.href );
+	url.searchParams.set( 'celebrateLaunch', 'true' );
+	window.history.replaceState( {}, '', url.toString() );
+}
+
+/**
+ * Dashboard container for the shared `MasterbarLaunchButtonView`. Sources site
+ * and domain data from TanStack Query and mirrors the branching behavior of
+ * the classic `launchSiteOrRedirectToLaunchSignupFlow` thunk so the dashboard
+ * and classic masterbars behave identically on click.
+ *
+ * TODO: Dashboard does not yet render a post-launch celebration modal. The
+ * classic masterbar flow adds `?celebrateLaunch=true` to the URL and a
+ * Calypso page elsewhere reads it to show a modal. Revisit once the dashboard
+ * has an equivalent surface.
+ */
+export function OmnibarLaunchButton( { siteId }: { siteId: number } ) {
+	const queryClient = useQueryClient();
+	const { data: site } = useQuery( siteByIdQuery( siteId ) );
+	const { data: domains } = useQuery( siteDomainsQuery( siteId ) );
+	const launchMutation = useMutation( siteLaunchMutation( siteId ) );
+
+	const onSiteLaunched = ( isWpcomAtomic: boolean ) => {
+		addCelebrateLaunchQueryParams();
+		queryClient.invalidateQueries( { queryKey: siteByIdQuery( siteId ).queryKey } );
+		if ( isWpcomAtomic ) {
+			updateLaunchpadSettings( siteId, {
+				checklist_statuses: { site_launched: true },
+			} );
+		}
+	};
+
+	const onDefaultLaunch = () => {
+		if ( site?.launch_status !== 'unlaunched' ) {
+			return;
+		}
+
+		const productSlug = site.plan?.product_slug;
+		const isPaid = site.plan ? ! site.plan.is_free : false;
+		const hasMultipleDomains = ( domains?.length ?? 0 ) > 1;
+		const isHostingTrial = productSlug === PLAN_HOSTING_TRIAL_MONTHLY;
+
+		if ( ( isPaid && hasMultipleDomains ) || isHostingTrial ) {
+			launchMutation.mutate( undefined, {
+				onSuccess: () => onSiteLaunched( !! site.is_wpcom_atomic ),
+			} );
+			return;
+		}
+
+		const isBigSkyTrial =
+			site.options?.site_creation_flow === 'ai-site-builder' &&
+			( ! productSlug || ! NON_BIG_SKY_PLANS.includes( productSlug ) );
+
+		if ( isBigSkyTrial ) {
+			window.location.href = addQueryArgs( '/setup/ai-site-builder/domains', {
+				siteId,
+				source: null,
+				redirect: 'site-launch',
+				new: null,
+				search: null,
+			} );
+			return;
+		}
+
+		window.location.href = addQueryArgs( '/start/launch-site', {
+			siteSlug: site.slug,
+			source: null,
+			hide_initial_query: 'yes',
+			new: null,
+			search: null,
+		} );
+	};
+
+	return (
+		<MasterbarLaunchButtonView
+			siteId={ siteId }
+			siteSlug={ site?.slug }
+			isWpcomAtomic={ !! site?.is_wpcom_atomic }
+			trackingSource="dashboard"
+			recordTracks={ ( name, props ) => recordTracksEvent( name, props ) }
+			onDefaultLaunch={ onDefaultLaunch }
+			onSiteLaunched={ onSiteLaunched }
+		/>
+	);
+}

--- a/client/dashboard/app/interim-omnibar/test/omnibar-launch-button.tsx
+++ b/client/dashboard/app/interim-omnibar/test/omnibar-launch-button.tsx
@@ -1,0 +1,286 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-disable no-restricted-imports */
+import { updateLaunchpadSettings } from '@automattic/data-stores';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { render } from '../../../test-utils';
+import { OmnibarLaunchButton } from '../omnibar-launch-button';
+
+// ---------- Module mocks ----------
+
+// Capture the props passed to the shared view so each test can inspect and
+// invoke the callbacks directly.
+let viewProps: Record< string, unknown > = {};
+jest.mock( 'calypso/layout/masterbar/masterbar-launch-button', () => ( {
+	__esModule: true,
+	MasterbarLaunchButtonView: ( props: Record< string, unknown > ) => {
+		viewProps = props;
+		return <div data-testid="view" />;
+	},
+} ) );
+
+// Mock the api-queries factories so we can recognize which query is which by
+// its queryKey, but otherwise leave them as simple config objects.
+jest.mock( '@automattic/api-queries', () => ( {
+	siteByIdQuery: jest.fn( ( siteId: number ) => ( {
+		queryKey: [ 'site', siteId ],
+		queryFn: jest.fn(),
+	} ) ),
+	siteDomainsQuery: jest.fn( ( siteId: number ) => ( {
+		queryKey: [ 'site-domains', siteId ],
+		queryFn: jest.fn(),
+	} ) ),
+	siteLaunchMutation: jest.fn( ( siteId: number ) => ( {
+		mutationFn: jest.fn(),
+		mutationKey: [ 'site-launch', siteId ],
+	} ) ),
+} ) );
+
+jest.mock( '@automattic/data-stores', () => ( {
+	updateLaunchpadSettings: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
+
+// Selectively mock tanstack hooks but preserve the rest of the module so the
+// dashboard test-utils still gets a real QueryClientProvider.
+const mockMutate = jest.fn();
+const mockInvalidateQueries = jest.fn();
+let replaceStateSpy: jest.SpyInstance;
+jest.mock( '@tanstack/react-query', () => {
+	const actual = jest.requireActual( '@tanstack/react-query' );
+	return {
+		...actual,
+		useQuery: jest.fn(),
+		useMutation: jest.fn(),
+		useQueryClient: jest.fn(),
+	};
+} );
+
+// ---------- Fixtures ----------
+
+const SITE_ID = 1234;
+
+type PartialSite = {
+	ID: number;
+	slug: string;
+	is_wpcom_atomic?: boolean;
+	launch_status?: string;
+	plan?: { product_slug?: string; is_free?: boolean };
+	options?: { site_creation_flow?: string };
+};
+
+type PartialDomain = { domain: string };
+
+const defaultSite: PartialSite = {
+	ID: SITE_ID,
+	slug: 'example.wordpress.com',
+	is_wpcom_atomic: false,
+	launch_status: 'unlaunched',
+	plan: { product_slug: 'free_plan', is_free: true },
+	options: { site_creation_flow: 'onboarding' },
+};
+
+const oneDomain: PartialDomain[] = [ { domain: 'example.wordpress.com' } ];
+
+function setupQueries( {
+	site = defaultSite,
+	domains = oneDomain,
+}: { site?: PartialSite | undefined; domains?: PartialDomain[] } = {} ) {
+	( useQuery as jest.Mock ).mockImplementation( ( config: { queryKey: unknown[] } ) => {
+		if ( config.queryKey[ 0 ] === 'site' ) {
+			return { data: site };
+		}
+		if ( config.queryKey[ 0 ] === 'site-domains' ) {
+			return { data: domains };
+		}
+		return { data: undefined };
+	} );
+}
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	viewProps = {};
+
+	( useMutation as jest.Mock ).mockReturnValue( {
+		mutate: mockMutate,
+		isPending: false,
+	} );
+	( useQueryClient as jest.Mock ).mockReturnValue( {
+		invalidateQueries: mockInvalidateQueries,
+	} );
+
+	setupQueries();
+
+	// Stub window.location so direct assignments to href don't trigger jsdom
+	// navigation errors. Tests read back from this mock to observe redirects.
+	Object.defineProperty( window, 'location', {
+		configurable: true,
+		writable: true,
+		value: {
+			href: 'http://localhost/current-path',
+			pathname: '/current-path',
+			assign: jest.fn(),
+		},
+	} );
+
+	// Spy on history.replaceState without actually mutating jsdom's URL (which
+	// would throw under same-origin checks in our stubbed location).
+	replaceStateSpy = jest
+		.spyOn( window.history, 'replaceState' )
+		.mockImplementation( () => undefined );
+} );
+
+afterEach( () => {
+	replaceStateSpy.mockRestore();
+} );
+
+// ---------- Tests ----------
+
+describe( 'OmnibarLaunchButton', () => {
+	describe( 'view props wiring', () => {
+		it( 'passes siteSlug, isWpcomAtomic and trackingSource="dashboard" to the view', () => {
+			setupQueries( {
+				site: { ...defaultSite, slug: 'my-site.com', is_wpcom_atomic: true },
+			} );
+			render( <OmnibarLaunchButton siteId={ SITE_ID } /> );
+
+			expect( viewProps.siteId ).toBe( SITE_ID );
+			expect( viewProps.siteSlug ).toBe( 'my-site.com' );
+			expect( viewProps.isWpcomAtomic ).toBe( true );
+			expect( viewProps.trackingSource ).toBe( 'dashboard' );
+		} );
+
+		it( 'uses the standalone recordTracksEvent for the recordTracks callback', () => {
+			render( <OmnibarLaunchButton siteId={ SITE_ID } /> );
+			( viewProps.recordTracks as ( n: string, p: Record< string, unknown > ) => void )(
+				'calypso_masterbar_launch_site',
+				{ source: 'dashboard' }
+			);
+			expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_masterbar_launch_site', {
+				source: 'dashboard',
+			} );
+		} );
+	} );
+
+	describe( 'onDefaultLaunch branching (parity with classic thunk)', () => {
+		it( 'no-ops if the site is already launched', () => {
+			setupQueries( { site: { ...defaultSite, launch_status: 'launched' } } );
+			render( <OmnibarLaunchButton siteId={ SITE_ID } /> );
+
+			( viewProps.onDefaultLaunch as () => void )();
+
+			expect( mockMutate ).not.toHaveBeenCalled();
+			expect( window.location.href ).toBe( 'http://localhost/current-path' );
+		} );
+
+		it( 'calls siteLaunchMutation directly when the site is paid with multiple domains', () => {
+			setupQueries( {
+				site: {
+					...defaultSite,
+					plan: { product_slug: 'business-bundle', is_free: false },
+				},
+				domains: [ { domain: 'example.wordpress.com' }, { domain: 'example.com' } ],
+			} );
+			render( <OmnibarLaunchButton siteId={ SITE_ID } /> );
+
+			( viewProps.onDefaultLaunch as () => void )();
+
+			expect( mockMutate ).toHaveBeenCalledTimes( 1 );
+			expect( window.location.href ).toBe( 'http://localhost/current-path' );
+		} );
+
+		it( 'calls siteLaunchMutation directly when the site is on the hosting trial', () => {
+			setupQueries( {
+				site: {
+					...defaultSite,
+					plan: { product_slug: 'wp_bundle_hosting_trial_monthly', is_free: false },
+				},
+			} );
+			render( <OmnibarLaunchButton siteId={ SITE_ID } /> );
+
+			( viewProps.onDefaultLaunch as () => void )();
+
+			expect( mockMutate ).toHaveBeenCalledTimes( 1 );
+			expect( window.location.href ).toBe( 'http://localhost/current-path' );
+		} );
+
+		it( 'redirects to /setup/ai-site-builder/domains for a Big Sky trial', () => {
+			setupQueries( {
+				site: {
+					...defaultSite,
+					plan: { product_slug: 'free_plan', is_free: true },
+					options: { site_creation_flow: 'ai-site-builder' },
+				},
+			} );
+			render( <OmnibarLaunchButton siteId={ SITE_ID } /> );
+
+			( viewProps.onDefaultLaunch as () => void )();
+
+			expect( window.location.href ).toContain( '/setup/ai-site-builder/domains' );
+			expect( window.location.href ).toContain( `siteId=${ SITE_ID }` );
+			expect( window.location.href ).toContain( 'redirect=site-launch' );
+			expect( mockMutate ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does not treat a paid AI-site-builder site as a Big Sky trial (falls through to default)', () => {
+			setupQueries( {
+				site: {
+					...defaultSite,
+					plan: { product_slug: 'business-bundle', is_free: false },
+					options: { site_creation_flow: 'ai-site-builder' },
+				},
+			} );
+			render( <OmnibarLaunchButton siteId={ SITE_ID } /> );
+
+			( viewProps.onDefaultLaunch as () => void )();
+
+			// Paid + single domain → falls through to the default redirect.
+			expect( window.location.href ).toContain( '/start/launch-site' );
+			expect( window.location.href ).not.toContain( '/setup/ai-site-builder/domains' );
+		} );
+
+		it( 'redirects to /start/launch-site by default', () => {
+			render( <OmnibarLaunchButton siteId={ SITE_ID } /> );
+
+			( viewProps.onDefaultLaunch as () => void )();
+
+			expect( window.location.href ).toContain( '/start/launch-site' );
+			expect( window.location.href ).toContain( 'siteSlug=example.wordpress.com' );
+			expect( mockMutate ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'onSiteLaunched', () => {
+		it( 'invalidates the site query and adds ?celebrateLaunch=true', () => {
+			render( <OmnibarLaunchButton siteId={ SITE_ID } /> );
+
+			( viewProps.onSiteLaunched as ( isAtomic: boolean ) => void )( false );
+
+			expect( mockInvalidateQueries ).toHaveBeenCalledWith( {
+				queryKey: [ 'site', SITE_ID ],
+			} );
+			expect( replaceStateSpy ).toHaveBeenCalledWith(
+				{},
+				'',
+				expect.stringContaining( 'celebrateLaunch=true' )
+			);
+			expect( updateLaunchpadSettings ).not.toHaveBeenCalled();
+		} );
+
+		it( 'also updates launchpad settings for atomic sites', () => {
+			render( <OmnibarLaunchButton siteId={ SITE_ID } /> );
+
+			( viewProps.onSiteLaunched as ( isAtomic: boolean ) => void )( true );
+
+			expect( updateLaunchpadSettings ).toHaveBeenCalledWith( SITE_ID, {
+				checklist_statuses: { site_launched: true },
+			} );
+			expect( mockInvalidateQueries ).toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -82,6 +82,7 @@ class MasterbarLoggedIn extends Component {
 		isGravatarDomain: PropTypes.bool,
 		dashboardOptIn: PropTypes.bool,
 		useUnifiedAgent: PropTypes.bool,
+		launchButtonSlot: PropTypes.node,
 	};
 
 	state = { mounted: false };
@@ -612,13 +613,14 @@ class MasterbarLoggedIn extends Component {
 	}
 
 	renderLaunchButton() {
-		const { isA4ADevSite, isUnlaunchedSite, siteId, isManageSiteOptionsEnabled } = this.props;
+		const { isA4ADevSite, isUnlaunchedSite, siteId, isManageSiteOptionsEnabled, launchButtonSlot } =
+			this.props;
 
 		if ( ! isUnlaunchedSite || ! isManageSiteOptionsEnabled || isA4ADevSite ) {
 			return null;
 		}
 
-		return <MasterbarLaunchButton siteId={ siteId } />;
+		return launchButtonSlot ?? <MasterbarLaunchButton siteId={ siteId } />;
 	}
 
 	renderProfileMenu() {

--- a/client/layout/masterbar/masterbar-launch-button.tsx
+++ b/client/layout/masterbar/masterbar-launch-button.tsx
@@ -13,24 +13,44 @@ import { getSite } from 'calypso/state/sites/selectors';
 import { getSectionName } from 'calypso/state/ui/selectors';
 import Item from './item';
 
-export const MasterbarLaunchButton = ( { siteId }: { siteId: number } ) => {
-	const translate = useTranslate();
-	const dispatch = useDispatch();
-	const site = useSelector( ( state ) => getSite( state, siteId ) );
-	const sectionName = useSelector( getSectionName );
-	const launchSiteMutation = useMutation( siteLaunchMutation( siteId ) );
+interface MasterbarLaunchButtonViewProps {
+	siteId: number;
+	siteSlug: string | undefined;
+	isWpcomAtomic: boolean;
+	trackingSource: string | null;
+	recordTracks: ( eventName: string, eventProps: Record< string, unknown > ) => void;
+	onDefaultLaunch: () => void;
+	onSiteLaunched: ( isWpcomAtomic: boolean ) => void;
+}
 
-	const { onSiteLaunched } = useCelebrateLaunchModalSideEffects( siteId );
+/**
+ * Pure presentation + onClick orchestration for the masterbar Launch button.
+ *
+ * All data and side-effect callbacks are injected as props, so the button can be
+ * reused in any context that provides a QueryClientProvider and the ExPlat
+ * provider (currently classic Calypso and the Dashboard interim omnibar).
+ */
+export function MasterbarLaunchButtonView( {
+	siteId,
+	siteSlug,
+	isWpcomAtomic,
+	trackingSource,
+	recordTracks,
+	onDefaultLaunch,
+	onSiteLaunched,
+}: MasterbarLaunchButtonViewProps ) {
+	const translate = useTranslate();
+	const launchSiteMutation = useMutation( siteLaunchMutation( siteId ) );
 
 	const [ isLoading, data ] = useExperiment( 'calypso_standardized_site_launch_gating_202603_v1' );
 
 	const onLaunchSiteClick = () => {
-		dispatch( recordTracksEvent( 'calypso_masterbar_launch_site', { source: sectionName } ) );
+		recordTracks( 'calypso_masterbar_launch_site', { source: trackingSource } );
 
 		if ( data?.variationName === 'semi_gated_site_launch' ) {
 			window.location.assign(
 				addQueryArgs( '/start/launch-site', {
-					siteSlug: site?.slug,
+					siteSlug,
 					back_to: window.location.pathname,
 				} )
 			);
@@ -39,12 +59,12 @@ export const MasterbarLaunchButton = ( { siteId }: { siteId: number } ) => {
 
 		if ( data?.variationName === 'ungated_site_launch' ) {
 			launchSiteMutation.mutate( undefined, {
-				onSuccess: () => onSiteLaunched( !! site?.is_wpcom_atomic ),
+				onSuccess: () => onSiteLaunched( isWpcomAtomic ),
 			} );
 			return;
 		}
 
-		dispatch( launchSiteOrRedirectToLaunchSignupFlow( siteId ) );
+		onDefaultLaunch();
 	};
 
 	return (
@@ -69,5 +89,28 @@ export const MasterbarLaunchButton = ( { siteId }: { siteId: number } ) => {
 		>
 			{ translate( 'Launch site' ) }
 		</Item>
+	);
+}
+
+/**
+ * Classic Calypso container. Reads site/section from Redux and wires the
+ * thunk-based launch action into the pure view.
+ */
+export const MasterbarLaunchButton = ( { siteId }: { siteId: number } ) => {
+	const dispatch = useDispatch();
+	const site = useSelector( ( state ) => getSite( state, siteId ) );
+	const sectionName = useSelector( getSectionName );
+	const { onSiteLaunched } = useCelebrateLaunchModalSideEffects( siteId );
+
+	return (
+		<MasterbarLaunchButtonView
+			siteId={ siteId }
+			siteSlug={ site?.slug }
+			isWpcomAtomic={ !! site?.is_wpcom_atomic }
+			trackingSource={ sectionName }
+			recordTracks={ ( name, props ) => dispatch( recordTracksEvent( name, props ) ) }
+			onDefaultLaunch={ () => dispatch( launchSiteOrRedirectToLaunchSignupFlow( siteId ) ) }
+			onSiteLaunched={ onSiteLaunched }
+		/>
 	);
 };

--- a/client/layout/masterbar/test/masterbar-launch-button.tsx
+++ b/client/layout/masterbar/test/masterbar-launch-button.tsx
@@ -1,0 +1,181 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useExperiment } from 'calypso/lib/explat';
+import { useCelebrateLaunchModalSideEffects } from 'calypso/my-sites/customer-home/celebrate-site-launch-modal/use-side-effects';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { launchSiteOrRedirectToLaunchSignupFlow } from 'calypso/state/sites/launch/actions';
+import { getSite } from 'calypso/state/sites/selectors';
+import { getSectionName } from 'calypso/state/ui/selectors';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { MasterbarLaunchButton } from '../masterbar-launch-button';
+
+// ---------- Module mocks ----------
+
+jest.mock( 'calypso/lib/explat', () => ( {
+	useExperiment: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/state/sites/launch/actions', () => ( {
+	launchSiteOrRedirectToLaunchSignupFlow: jest.fn( ( siteId: number ) => ( {
+		type: 'MOCK_LAUNCH_THUNK',
+		siteId,
+	} ) ),
+} ) );
+
+jest.mock( 'calypso/state/analytics/actions', () => ( {
+	recordTracksEvent: jest.fn( ( name: string, props: Record< string, unknown > ) => ( {
+		type: 'MOCK_TRACKS_EVENT',
+		name,
+		props,
+	} ) ),
+} ) );
+
+jest.mock( 'calypso/state/sites/selectors', () => ( {
+	getSite: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/state/ui/selectors', () => ( {
+	getSectionName: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/my-sites/customer-home/celebrate-site-launch-modal/use-side-effects', () => ( {
+	useCelebrateLaunchModalSideEffects: jest.fn(),
+} ) );
+
+const mockMutate = jest.fn();
+let mockIsPending = false;
+jest.mock( '@tanstack/react-query', () => {
+	const actual = jest.requireActual( '@tanstack/react-query' );
+	return {
+		...actual,
+		useMutation: jest.fn( () => ( {
+			mutate: mockMutate,
+			isPending: mockIsPending,
+		} ) ),
+	};
+} );
+
+// Stable fake site returned via initialState (see beforeEach).
+const SITE_ID = 1234;
+
+const renderButton = ( {
+	site = {
+		ID: SITE_ID,
+		slug: 'example.wordpress.com',
+		is_wpcom_atomic: false,
+	},
+	sectionName = 'home',
+}: {
+	site?: { ID: number; slug: string; is_wpcom_atomic: boolean } | null;
+	sectionName?: string | null;
+} = {} ) => {
+	( getSite as jest.Mock ).mockReturnValue( site );
+	( getSectionName as jest.Mock ).mockReturnValue( sectionName );
+	return renderWithProvider( <MasterbarLaunchButton siteId={ SITE_ID } /> );
+};
+
+// ---------- Setup ----------
+
+const mockOnSiteLaunched = jest.fn();
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	mockIsPending = false;
+	( useExperiment as jest.Mock ).mockReturnValue( [ false, undefined ] );
+	( useCelebrateLaunchModalSideEffects as jest.Mock ).mockReturnValue( {
+		onSiteLaunched: mockOnSiteLaunched,
+	} );
+	// Stub window.location.assign for semi_gated_site_launch variation.
+	Object.defineProperty( window, 'location', {
+		configurable: true,
+		value: { ...window.location, assign: jest.fn(), pathname: '/current-path' },
+	} );
+} );
+
+// ---------- Tests ----------
+
+describe( 'MasterbarLaunchButton', () => {
+	it( 'renders a button labeled "Launch site"', () => {
+		renderButton();
+		expect( screen.getByRole( 'button', { name: /launch site/i } ) ).toBeVisible();
+	} );
+
+	it( 'is disabled while the experiment is loading', () => {
+		( useExperiment as jest.Mock ).mockReturnValue( [ true, undefined ] );
+		renderButton();
+		expect( screen.getByRole( 'button', { name: /launch site/i } ) ).toBeDisabled();
+	} );
+
+	it( 'is disabled and busy while the launch mutation is pending', () => {
+		mockIsPending = true;
+		renderButton();
+		expect( screen.getByRole( 'button', { name: /launch site/i } ) ).toBeDisabled();
+	} );
+
+	describe( 'control variation (no experiment variationName)', () => {
+		it( 'records tracks and dispatches launchSiteOrRedirectToLaunchSignupFlow(siteId) on click', async () => {
+			const user = userEvent.setup();
+			renderButton();
+
+			await user.click( screen.getByRole( 'button', { name: /launch site/i } ) );
+
+			expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_masterbar_launch_site', {
+				source: 'home',
+			} );
+			expect( launchSiteOrRedirectToLaunchSignupFlow ).toHaveBeenCalledWith( SITE_ID );
+			expect( mockMutate ).not.toHaveBeenCalled();
+			expect( window.location.assign ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'semi_gated_site_launch variation', () => {
+		it( 'redirects to /start/launch-site with siteSlug and back_to', async () => {
+			( useExperiment as jest.Mock ).mockReturnValue( [
+				false,
+				{ variationName: 'semi_gated_site_launch' },
+			] );
+			const user = userEvent.setup();
+			renderButton();
+
+			await user.click( screen.getByRole( 'button', { name: /launch site/i } ) );
+
+			expect( window.location.assign ).toHaveBeenCalledWith(
+				expect.stringContaining( '/start/launch-site' )
+			);
+			const target = ( window.location.assign as jest.Mock ).mock.calls[ 0 ][ 0 ] as string;
+			expect( target ).toContain( 'siteSlug=example.wordpress.com' );
+			expect( target ).toContain( 'back_to=%2Fcurrent-path' );
+			expect( launchSiteOrRedirectToLaunchSignupFlow ).not.toHaveBeenCalled();
+			expect( mockMutate ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'ungated_site_launch variation', () => {
+		it( 'calls the launch mutation and, on success, runs celebrate side-effects', async () => {
+			( useExperiment as jest.Mock ).mockReturnValue( [
+				false,
+				{ variationName: 'ungated_site_launch' },
+			] );
+			const user = userEvent.setup();
+			renderButton( {
+				site: { ID: SITE_ID, slug: 'example.wordpress.com', is_wpcom_atomic: true },
+			} );
+
+			await user.click( screen.getByRole( 'button', { name: /launch site/i } ) );
+
+			expect( mockMutate ).toHaveBeenCalledTimes( 1 );
+			const [ , options ] = mockMutate.mock.calls[ 0 ];
+			// Simulate the mutation success callback.
+			options.onSuccess();
+
+			await waitFor( () => {
+				expect( mockOnSiteLaunched ).toHaveBeenCalledWith( true );
+			} );
+			expect( launchSiteOrRedirectToLaunchSignupFlow ).not.toHaveBeenCalled();
+			expect( window.location.assign ).not.toHaveBeenCalled();
+		} );
+	} );
+} );


### PR DESCRIPTION
Part of DOTMSD-1188

## Proposed Changes

- Split `MasterbarLaunchButton` into a pure `MasterbarLaunchButtonView` + thin Redux container so the view can be reused outside classic Calypso.
- Add `OmnibarLaunchButton` — TanStack Query-backed Dashboard container with full branch parity to the classic thunk: paid+multi-domain direct launch, hosting trial direct launch, Big Sky trial redirect, default `/start/launch-site` redirect.
- Wire into `InterimOmnibar` via a new `launchButtonSlot` prop on `MasterbarLoggedIn`.
- Derive `isUnlaunchedSite` in the interim omnibar from `site.launch_status`.
- 16 new unit tests (6 classic characterization + 10 dashboard container).

## Why are these changes being made?

- MSD omnibar needs the Launch button at parity with the classic masterbar, but the Dashboard can't depend on Redux/thunks.
- Hoisting data + side-effect wiring out of the button lets both surfaces share one view without duplicating the click-handler branching.

## Testing Instructions

- On an unlaunched Simple site, open the MSD interim omnibar → "Launch site" button appears and matches classic masterbar behavior.
- Verify each branch: paid plan with custom domain (direct launch), hosting trial (direct launch), Big Sky trial (redirects to `/setup/ai-site-builder/domains`), default free/single-domain (redirects to `/start/launch-site`).
- Confirm the classic Calypso masterbar Launch button still works unchanged.
- `yarn test-client client/layout/masterbar/test/masterbar-launch-button.tsx client/dashboard/app/interim-omnibar/test/omnibar-launch-button.tsx`

### TODO

- Post-launch celebration modal not yet wired in the Dashboard.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the \"[Status] String Freeze\" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the \"[Status] Needs Privacy Updates\" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?