### PR TITLE
Stats: Replace JetpackColophon with centralized JetpackFooter

### DIFF
--- a/apps/odyssey-stats/webpack.config.js
+++ b/apps/odyssey-stats/webpack.config.js
@@ -186,10 +186,6 @@ module.exports = {
 			path.resolve( __dirname, 'src/lib/config-api' )
 		),
 		new webpack.NormalModuleReplacementPlugin(
-			/^calypso\/components\/jetpack-colophon$/,
-			'calypso/components/jetpack/jetpack-footer'
-		),
-		new webpack.NormalModuleReplacementPlugin(
 			/^calypso\/components\/formatted-header$/,
 			( resource ) => {
 				// Only replace for the navigation-header context

--- a/client/components/jetpack/jetpack-footer/index.tsx
+++ b/client/components/jetpack/jetpack-footer/index.tsx
@@ -1,30 +1,77 @@
 import { JetpackLogo } from '@automattic/components';
 import { __ } from '@wordpress/i18n';
 import { Stack } from '@wordpress/ui';
+import clsx from 'clsx';
 import AutomatticBylineLogo from '../automattic-byline-logo';
 import './style.scss';
 import type { FC } from 'react';
 
+export interface JetpackFooterMenuItem {
+	label: string;
+	title?: string;
+	href?: string;
+	role?: string;
+	onClick?: () => void;
+	onKeyDown?: () => void;
+}
+
+interface JetpackFooterProps {
+	className?: string;
+	menu?: JetpackFooterMenuItem[];
+}
+
 /**
  * JetpackFooter component displays a tiny Jetpack logo on the left and the Automattic Airline "by line" on the right.
  */
-const JetpackFooter: FC = () => {
+const JetpackFooter: FC< JetpackFooterProps > = ( { className, menu } ) => {
 	return (
 		<Stack
 			render={ <footer /> }
-			className="jetpack-footer"
+			className={ clsx( 'jetpack-footer', className ) }
 			aria-label={ __( 'Jetpack', 'jetpack-components' ) }
 			role="contentinfo"
 			direction="row"
-			justify="space-between"
+			justify="flex-start"
 			align="center"
 			wrap="wrap"
 			gap="xl"
 		>
 			<Stack className="jetpack-footer__logo" direction="row" gap="sm" align="center">
-				<JetpackLogo size={ 16 } />
+				<JetpackLogo size={ 16 } aria-hidden="true" />
 				<span className="jetpack-footer__logo-text">Jetpack</span>
 			</Stack>
+			{ menu && menu.length > 0 && (
+				<ul className="jetpack-footer__menu">
+					{ menu.map( ( item ) => {
+						const isButton = item.role === 'button';
+						return (
+							<li key={ item.label }>
+								{ isButton ? (
+									<span
+										className="jetpack-footer__menu-item"
+										role="button"
+										tabIndex={ 0 }
+										onClick={ item.onClick }
+										onKeyDown={ item.onKeyDown }
+									>
+										{ item.label }
+									</span>
+								) : (
+									<a
+										className="jetpack-footer__menu-item"
+										href={ item.href }
+										title={ item.title }
+										onClick={ item.onClick }
+										onKeyDown={ item.onKeyDown }
+									>
+										{ item.label }
+									</a>
+								) }
+							</li>
+						);
+					} ) }
+				</ul>
+			) }
 			<a
 				className="jetpack-footer__a8c"
 				href="https://jetpack.com/redirect/?source=a8c-about"

--- a/client/components/jetpack/jetpack-footer/style.scss
+++ b/client/components/jetpack/jetpack-footer/style.scss
@@ -19,7 +19,34 @@
 	line-height: var(--wpds-font-line-height-sm);
 }
 
+.jetpack-footer__menu {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--wpds-dimension-gap-lg, 16px);
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.jetpack-footer__menu-item {
+	font-size: var(--wpds-font-size-md);
+	font-family: var(--wpds-font-family-body);
+
+	&:any-link,
+	&[role="button"] {
+		color: var(--wpds-color-fg-interactive-neutral-weak);
+		cursor: pointer;
+		text-decoration: none;
+	}
+
+	&:hover {
+		text-decoration: underline;
+	}
+}
+
 a.jetpack-footer__a8c {
+	margin-inline-start: auto;
+
 	svg {
 		fill: var(--wpds-color-fg-interactive-neutral-weak);
 	}

--- a/client/my-sites/stats/components/stats-main/index.tsx
+++ b/client/my-sites/stats/components/stats-main/index.tsx
@@ -6,6 +6,7 @@ import { useTranslate } from 'i18n-calypso';
 import { ReactNode } from 'react';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import QuerySiteSettings from 'calypso/components/data/query-site-settings';
+import JetpackFooter from 'calypso/components/jetpack/jetpack-footer';
 import JetpackTitle from 'calypso/components/jetpack-title';
 import Main, { MainProps } from 'calypso/components/main';
 import useWPAdminTheme from 'calypso/my-sites/stats/hooks/use-wp-admin-theme';
@@ -128,6 +129,7 @@ export default function StatsMain( {
 				{ pageTabs }
 				{ children }
 			</Page>
+			<JetpackFooter />
 			{ upsellModalView && <StatsUpsellModal siteId={ siteId } /> }
 		</Main>
 	);

--- a/client/my-sites/stats/components/stats-main/index.tsx
+++ b/client/my-sites/stats/components/stats-main/index.tsx
@@ -16,6 +16,7 @@ import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getUpsellModalView } from 'calypso/state/stats/paid-stats-upsell/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { STATS_HEADER_TITLE } from '../../constants';
+import type { JetpackFooterMenuItem } from 'calypso/components/jetpack/jetpack-footer';
 
 export interface BreadcrumbItem {
 	label: string;
@@ -110,6 +111,20 @@ export default function StatsMain( {
 	// Make the upsell modal view available on all Stats pages.
 	const upsellModalView = useSelector( ( state ) => getUpsellModalView( state, siteId ) );
 
+	const translate = useTranslate();
+	const footerMenu: JetpackFooterMenuItem[] = isWPAdminAndNotSimpleSite
+		? [
+				{
+					label: translate( 'Products' ),
+					href: 'admin.php?page=my-jetpack#/products',
+				},
+				{
+					label: translate( 'Help' ),
+					href: 'admin.php?page=my-jetpack#/help',
+				},
+		  ]
+		: [];
+
 	const titleContent = breadcrumbs ? (
 		<StatsBreadcrumbs items={ breadcrumbs } />
 	) : (
@@ -129,7 +144,7 @@ export default function StatsMain( {
 				{ pageTabs }
 				{ children }
 			</Page>
-			<JetpackFooter />
+			<JetpackFooter menu={ footerMenu } />
 			{ upsellModalView && <StatsUpsellModal siteId={ siteId } /> }
 		</Main>
 	);

--- a/client/my-sites/stats/feedback/style.scss
+++ b/client/my-sites/stats/feedback/style.scss
@@ -1,5 +1,10 @@
 @import '@automattic/components/src/styles/typography';
 @import '@wordpress/base-styles/breakpoints';
+@import 'calypso/my-sites/stats/components/highlight-cards/variables';
+
+.stats-feedback-container {
+	margin-bottom: $vertical-margin;
+}
 
 .stats-feedback-content {
 	font-family: $font-sf-pro-text;

--- a/client/my-sites/stats/modernized-layout-styles.scss
+++ b/client/my-sites/stats/modernized-layout-styles.scss
@@ -106,11 +106,5 @@ $sidebar-appearance-break-point: $break-medium;
 		@media (min-width: $sidebar-appearance-break-point) {
 			padding: $stats-layout-contnet-padding-top 0 0 calc(var(--sidebar-width-max) + 1px);
 		}
-
-		.jetpack-colophon {
-			padding-top: $vertical-margin;
-			padding-bottom: $vertical-margin;
-			margin-top: 0;
-		}
 	}
 }

--- a/client/my-sites/stats/overview.jsx
+++ b/client/my-sites/stats/overview.jsx
@@ -6,7 +6,6 @@ import { connect } from 'react-redux';
 import titlecase from 'to-title-case';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
-import JetpackColophon from 'calypso/components/jetpack-colophon';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/my-sites/stats/components/stats-main';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
@@ -96,7 +95,6 @@ class StatsOverview extends Component {
 					title={ `Stats > ${ titlecase( period ) }` }
 				/>
 				{ sites.length !== 0 ? sitesList : this.placeholders() }
-				<JetpackColophon />
 			</Main>
 		);
 	}

--- a/client/my-sites/stats/pages/insights/index.jsx
+++ b/client/my-sites/stats/pages/insights/index.jsx
@@ -5,7 +5,6 @@ import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
 import DocumentHead from 'calypso/components/data/document-head';
-import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/my-sites/stats/components/stats-main';
 import { STATS_FEATURE_PAGE_INSIGHTS, STATS_PRODUCT_NAME } from 'calypso/my-sites/stats/constants';
 import StatsModuleComments from 'calypso/my-sites/stats/features/modules/stats-comments';
@@ -125,7 +124,6 @@ function StatsInsights( { context } ) {
 								/>
 							) }
 						</StatsModuleListing>
-						<JetpackColophon />
 					</>
 				) }
 			</div>

--- a/client/my-sites/stats/pages/purchase/index.tsx
+++ b/client/my-sites/stats/pages/purchase/index.tsx
@@ -12,7 +12,6 @@ import StatsNavigation from 'calypso/blocks/stats-navigation';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
-import JetpackColophon from 'calypso/components/jetpack-colophon';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import Main from 'calypso/my-sites/stats/components/stats-main';
 import { STATS_PRODUCT_NAME } from 'calypso/my-sites/stats/constants';
@@ -245,7 +244,6 @@ const StatsPurchasePage = ( {
 						</>
 					)
 				}
-				<JetpackColophon />
 			</div>
 		</Main>
 	);

--- a/client/my-sites/stats/pages/realtime/index.jsx
+++ b/client/my-sites/stats/pages/realtime/index.jsx
@@ -5,7 +5,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
 import AsyncLoad from 'calypso/components/async-load';
 import DocumentHead from 'calypso/components/data/document-head';
-import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/my-sites/stats/components/stats-main';
 import { STATS_PRODUCT_NAME } from 'calypso/my-sites/stats/constants';
 import StatsModuleCountries from 'calypso/my-sites/stats/features/modules/stats-countries';
@@ -151,7 +150,6 @@ function StatsRealtime( { context } ) {
 						isRealTime
 					/>
 				</StatsModuleListing>
-				<JetpackColophon />
 			</div>
 		</Main>
 	);

--- a/client/my-sites/stats/pages/subscribers/index.tsx
+++ b/client/my-sites/stats/pages/subscribers/index.tsx
@@ -5,7 +5,6 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
 import DocumentHead from 'calypso/components/data/document-head';
-import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/my-sites/stats/components/stats-main';
 import { STATS_PRODUCT_NAME } from 'calypso/my-sites/stats/constants';
 import StatsModuleEmails from 'calypso/my-sites/stats/features/modules/stats-emails';
@@ -188,7 +187,6 @@ const StatsSubscribersPage = ( { period, context }: StatsSubscribersPageProps ) 
 							</StatsModuleListing>
 						</>
 					) ) }
-				<JetpackColophon />
 			</div>
 		</Main>
 	);

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -21,7 +21,6 @@ import QueryKeyringConnections from 'calypso/components/data/query-keyring-conne
 import QuerySiteKeyrings from 'calypso/components/data/query-site-keyrings';
 import { useShortcuts } from 'calypso/components/date-range/use-shortcuts';
 import EmptyContent from 'calypso/components/empty-content';
-import JetpackColophon from 'calypso/components/jetpack-colophon';
 import StickyPanel from 'calypso/components/sticky-panel';
 import version_compare from 'calypso/lib/version-compare';
 import Main from 'calypso/my-sites/stats/components/stats-main';
@@ -804,7 +803,6 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 				<PromoCards isOdysseyStats={ isOdysseyStats } pageSlug="traffic" slug={ slug } />
 			) }
 			{ supportUserFeedback && <StatsFeedbackPresentor siteId={ siteId } /> }
-			<JetpackColophon />
 			<AsyncLoad require="calypso/lib/analytics/track-resurrections" placeholder={ null } />
 		</div>
 	);

--- a/client/my-sites/stats/stats-email-summary/index.jsx
+++ b/client/my-sites/stats/stats-email-summary/index.jsx
@@ -1,7 +1,6 @@
 import { formatNumber } from '@automattic/number-formatters';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useLayoutEffect } from 'react';
-import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/my-sites/stats/components/stats-main';
 import { useShouldGateStats } from 'calypso/my-sites/stats/hooks/use-should-gate-stats';
 import {
@@ -176,7 +175,6 @@ const StatsEmailSummaryInner = ( { period, query, context, breadcrumbTrail } ) =
 						} }
 						listItemClassName="stats__summary--narrow-mobile"
 					/>
-					<JetpackColophon />
 				</div>
 			</div>
 		</Main>

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -14,7 +14,6 @@ import QueryPostStats from 'calypso/components/data/query-post-stats';
 import QueryPosts from 'calypso/components/data/query-posts';
 import EmptyContent from 'calypso/components/empty-content';
 import useSupportDocData from 'calypso/components/inline-support-link/use-support-doc-data';
-import JetpackColophon from 'calypso/components/jetpack-colophon';
 import WebPreview from 'calypso/components/web-preview';
 import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
 import { isHttps } from 'calypso/lib/url';
@@ -313,8 +312,6 @@ class StatsPostDetail extends Component {
 							<PostDetailTableSection siteId={ siteId } postId={ postId } />
 						</>
 					) }
-
-					<JetpackColophon />
 				</div>
 
 				<WebPreview

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -5,7 +5,6 @@ import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import titlecase from 'to-title-case';
 import QueryMedia from 'calypso/components/data/query-media';
-import JetpackColophon from 'calypso/components/jetpack-colophon';
 import AnnualSiteStats from 'calypso/my-sites/stats/annual-site-stats';
 import Main from 'calypso/my-sites/stats/components/stats-main';
 import StatsModuleAuthors from 'calypso/my-sites/stats/features/modules/stats-authors';
@@ -496,7 +495,6 @@ class StatsSummary extends Component {
 						) : (
 							summaryViews
 						) }
-						<JetpackColophon />
 					</div>
 				</div>
 			</Main>

--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -16,7 +16,6 @@ import { navItems } from 'calypso/blocks/stats-navigation/constants';
 import Intervals from 'calypso/blocks/stats-navigation/intervals';
 import DocumentHead from 'calypso/components/data/document-head';
 import EmptyContent from 'calypso/components/empty-content';
-import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/my-sites/stats/components/stats-main';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
@@ -249,8 +248,6 @@ class WordAds extends Component {
 							</div>
 
 							<PromoCards isOdysseyStats={ isOdysseyStats } pageSlug="ads" slug={ slug } />
-
-							<JetpackColophon />
 						</Fragment>
 					) }
 				</div>


### PR DESCRIPTION
Part of #109899
Follow-up to #109765
Resolves JETPACK-1507.

## Proposed Changes

* Replace the per-page `<JetpackColophon />` ("Powered by Jetpack") with a centralized `<JetpackFooter />` (Jetpack logo + Automattic byline) rendered in the shared `StatsMain` component.
* Add `menu` prop support to the `JetpackFooter` component, matching the Jetpack monorepo footer (Automattic/jetpack#47840).
* In Odyssey Stats (WP Admin) for **non-Simple sites**, show "Products" and "Help" navigation links in the footer for consistency with other Jetpack pages.
* Remove the now-unnecessary `jetpack-colophon` → `jetpack-footer` webpack `NormalModuleReplacementPlugin` entry from Odyssey Stats, since stats pages no longer import `jetpack-colophon`.
* Remove the stale `.jetpack-colophon` CSS override from `modernized-layout-styles.scss`.

## Why are these changes being made?

Stats pages displayed an outdated "Powered by Jetpack" colophon footer. The Jetpack monorepo has already migrated to a unified `JetpackFooter` component (Automattic/jetpack#47840), and #109765 added the same component to Calypso. This PR aligns the stats pages with that direction, centralizing the footer in `StatsMain` so all stats pages render a consistent footer without per-page boilerplate.

The footer now also supports menu items so that Odyssey Stats of **non-Simple sites** can show Products and Help links, matching the behavior of other Jetpack admin pages.

In Odyssey Stats the webpack replacement was the only mechanism that swapped the colophon for the footer. Now that stats pages import `JetpackFooter` directly, the replacement is dead code and is removed.

## Testing Instructions

### Calypso (WP.com)
* Navigate to any Stats page (Traffic, Insights, Subscribers, Realtime, WordAds, Summary, Post Detail, Email Summary, Purchase, Overview).
* Verify the Jetpack footer (Jetpack logo + "Jetpack" + Automattic byline) appears at the bottom — **without** Products/Help links.
* Verify the old "Powered by Jetpack" colophon no longer appears.

|Before|After|
|-|-|
|<img width="1177" height="440" alt="截圖 2026-04-10 下午1 55 37" src="https://github.com/user-attachments/assets/5487f937-a7f0-4b7a-a894-e9cf5ec94094" />|<img width="1136" height="438" alt="截圖 2026-04-10 下午1 52 09" src="https://github.com/user-attachments/assets/046190aa-c9d0-4a23-910a-450871a89366" />|

### Self-hosted/Atomic sites WP-Admin
* Follow PCYsg-Pp7-p2#option-3.
* Navigate to Stats in a self-hosted/Atomic site's WP Admin.
* Verify the footer shows: Jetpack logo + "Jetpack" + **Products** + **Help** + Automattic byline.
* Verify Products links to `my-jetpack#/products` and Help links to `my-jetpack#/help`.

|Before|After|
|-|-|
|<img width="1177" height="338" alt="截圖 2026-04-10 下午1 55 08" src="https://github.com/user-attachments/assets/931b87ac-8534-4017-9122-bb3cb98a79e5" />|<img width="1332" height="298" alt="截圖 2026-04-10 下午2 22 28" src="https://github.com/user-attachments/assets/84de3563-97dc-4150-96aa-596d6ec1946a" />|

### Simple sites WP-Admin
* Follow PCYsg-Pp7-p2#option-3.
* Navigate to any Stats page (Traffic, Insights, Subscribers, Realtime, WordAds, Summary, Post Detail, Email Summary, Purchase, Overview).
* Verify the Jetpack footer (Jetpack logo + "Jetpack" + Automattic byline) appears at the bottom — **without** Products/Help links.
* Verify the old "Powered by Jetpack" colophon no longer appears.

|Before|After|
|-|-|
|<img width="1011" height="518" alt="截圖 2026-04-10 下午1 58 27" src="https://github.com/user-attachments/assets/c98fdb00-1086-4acc-8a5b-256ee5cf17c2" />|<img width="1020" height="471" alt="截圖 2026-04-10 下午1 57 46" src="https://github.com/user-attachments/assets/4c968a5c-9053-4374-b0ac-8414a925354c" />|

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?