### PR TITLE
A4A: Add manual migration verification review flow

### DIFF
--- a/client/a8c-for-agencies/sections/migrations/commissions-list/commission-columns.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/commission-columns.tsx
@@ -51,7 +51,7 @@ export const ReviewStatusColumn = ( {
 					statusText: translate( 'Rejected' ),
 					statusType: 'error',
 				};
-			case 'pending-re-verification':
+			case 'reverification':
 				return {
 					statusText: translate( 'Pending re-verification' ),
 					statusType: 'info',

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/commission-columns.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/commission-columns.tsx
@@ -49,7 +49,7 @@ export const ReviewStatusColumn = ( {
 			case 'rejected':
 				return {
 					statusText: translate( 'Ineligible' ),
-					statusType: 'error',
+					statusType: 'info',
 				};
 			case 'reverification':
 				return {

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/commission-columns.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/commission-columns.tsx
@@ -48,7 +48,7 @@ export const ReviewStatusColumn = ( {
 				};
 			case 'rejected':
 				return {
-					statusText: translate( 'Rejected' ),
+					statusText: translate( 'Ineligible' ),
 					statusType: 'error',
 				};
 			case 'reverification':
@@ -90,7 +90,7 @@ export const ReviewStatusColumn = ( {
 					ref={ buttonRef }
 					className="commission-columns__rejection-reason-button"
 					onClick={ () => setIsPopoverVisible( ! isPopoverVisible ) }
-					aria-label={ translate( 'View rejection reason' ) }
+					aria-label={ translate( 'View ineligibility reason' ) }
 				>
 					<Icon icon={ info } size={ 18 } />
 				</Button>
@@ -103,7 +103,7 @@ export const ReviewStatusColumn = ( {
 					>
 						<div className="commission-columns__rejection-reason-popover">
 							<div className="commission-columns__rejection-reason-title">
-								{ translate( 'Rejection reason' ) }
+								{ translate( 'Ineligibility reason' ) }
 							</div>
 							<div className="commission-columns__rejection-reason-text">{ rejectionReason }</div>
 						</div>

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/commission-columns.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/commission-columns.tsx
@@ -1,5 +1,8 @@
-import { BadgeType } from '@automattic/components';
+import { BadgeType, Popover } from '@automattic/components';
+import { Button } from '@wordpress/components';
+import { Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { useRef, useState } from 'react';
 import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/status-badge';
 import FormattedDate from 'calypso/components/formatted-date';
 import { urlToSlug } from 'calypso/lib/url/http-utils';
@@ -15,8 +18,16 @@ export const MigratedOnColumn = ( { migratedOn }: { migratedOn: number } ) => {
 	return <FormattedDate date={ date } format={ DETAILS_DATE_FORMAT_SHORT } />;
 };
 
-export const ReviewStatusColumn = ( { reviewStatus }: { reviewStatus: string } ) => {
+export const ReviewStatusColumn = ( {
+	reviewStatus,
+	rejectionReason,
+}: {
+	reviewStatus: string;
+	rejectionReason?: string;
+} ) => {
 	const translate = useTranslate();
+	const buttonRef = useRef< HTMLButtonElement | null >( null );
+	const [ isPopoverVisible, setIsPopoverVisible ] = useState( false );
 
 	// Don't show a badge if status is empty
 	if ( ! reviewStatus ) {
@@ -40,6 +51,11 @@ export const ReviewStatusColumn = ( { reviewStatus }: { reviewStatus: string } )
 					statusText: translate( 'Rejected' ),
 					statusType: 'error',
 				};
+			case 'pending-re-verification':
+				return {
+					statusText: translate( 'Pending re-verification' ),
+					statusType: 'info',
+				};
 			case 'pending':
 				return {
 					statusText: translate( 'Pending' ),
@@ -56,7 +72,8 @@ export const ReviewStatusColumn = ( { reviewStatus }: { reviewStatus: string } )
 	if ( ! statusProps ) {
 		return null;
 	}
-	return (
+
+	const badge = (
 		<StatusBadge
 			statusProps={ {
 				children: statusProps.statusText,
@@ -64,4 +81,37 @@ export const ReviewStatusColumn = ( { reviewStatus }: { reviewStatus: string } )
 			} }
 		/>
 	);
+
+	if ( reviewStatus === 'rejected' && rejectionReason ) {
+		return (
+			<span className="commission-columns__rejected-status">
+				{ badge }
+				<Button
+					ref={ buttonRef }
+					className="commission-columns__rejection-reason-button"
+					onClick={ () => setIsPopoverVisible( ! isPopoverVisible ) }
+					aria-label={ translate( 'View rejection reason' ) }
+				>
+					<Icon icon={ info } size={ 18 } />
+				</Button>
+				{ isPopoverVisible && (
+					<Popover
+						context={ buttonRef.current }
+						isVisible
+						position="bottom"
+						onClose={ () => setIsPopoverVisible( false ) }
+					>
+						<div className="commission-columns__rejection-reason-popover">
+							<div className="commission-columns__rejection-reason-title">
+								{ translate( 'Rejection reason' ) }
+							</div>
+							<div className="commission-columns__rejection-reason-text">{ rejectionReason }</div>
+						</div>
+					</Popover>
+				) }
+			</span>
+		);
+	}
+
+	return badge;
 };

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/commission-list-actions.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/commission-list-actions.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
@@ -34,6 +35,10 @@ const CommissionListActions = ( { fetchMigratedSites, site, migrationTags }: Pro
 	const isRejected = useMemo( () => {
 		return site.incentive_status === 'rejected';
 	}, [ site.incentive_status ] );
+
+	const isRequestVerificationEnabled = isEnabled( 'a4a-migrations-request-verification' );
+
+	const canRequestVerification = isRequestVerificationEnabled && ( isRejected || isPendingReview );
 
 	const hasActions = isPendingReview || isRejected;
 
@@ -101,7 +106,7 @@ const CommissionListActions = ( { fetchMigratedSites, site, migrationTags }: Pro
 				onClose={ closeDropdown }
 				position="bottom left"
 			>
-				{ isRejected && (
+				{ canRequestVerification && (
 					<PopoverMenuItem
 						localizeUrl={ false }
 						onClick={ () => {
@@ -109,7 +114,9 @@ const CommissionListActions = ( { fetchMigratedSites, site, migrationTags }: Pro
 							setShowRequestReviewModal( true );
 						} }
 					>
-						{ translate( 'Request another verification' ) }
+						{ isRejected
+							? translate( 'Request another verification' )
+							: translate( 'Request verification' ) }
 					</PopoverMenuItem>
 				) }
 				{ isPendingReview && (

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/commission-list-actions.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/commission-list-actions.tsx
@@ -8,6 +8,7 @@ import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { useDispatch } from 'calypso/state';
 import { successNotice } from 'calypso/state/notices/actions';
 import useUpdateSiteTagsMutation from '../../sites/site-preview-pane/hooks/use-update-site-tags-mutation';
+import RequestReviewModal from '../request-review-modal';
 import type { TaggedSite } from '../types';
 
 type Props = {
@@ -23,11 +24,18 @@ const CommissionListActions = ( { fetchMigratedSites, site, migrationTags }: Pro
 	const buttonActionRef = useRef< HTMLButtonElement | null >( null );
 	const [ isOpen, setIsOpen ] = useState( false );
 	const [ showRemoveSiteDialog, setShowRemoveSiteDialog ] = useState( false );
+	const [ showRequestReviewModal, setShowRequestReviewModal ] = useState( false );
 	const { mutate, isPending } = useUpdateSiteTagsMutation();
 
 	const isPendingReview = useMemo( () => {
 		return site.incentive_status === 'pending';
 	}, [ site.incentive_status ] );
+
+	const isRejected = useMemo( () => {
+		return site.incentive_status === 'rejected';
+	}, [ site.incentive_status ] );
+
+	const hasActions = isPendingReview || isRejected;
 
 	const showActions = useCallback( () => {
 		setIsOpen( true );
@@ -77,8 +85,8 @@ const CommissionListActions = ( { fetchMigratedSites, site, migrationTags }: Pro
 		translate,
 	] );
 
-	// Only render actions if the site is pending review
-	if ( ! isPendingReview ) {
+	// Only render actions if the site is pending review or rejected
+	if ( ! hasActions ) {
 		return null;
 	}
 
@@ -93,14 +101,27 @@ const CommissionListActions = ( { fetchMigratedSites, site, migrationTags }: Pro
 				onClose={ closeDropdown }
 				position="bottom left"
 			>
-				<PopoverMenuItem
-					localizeUrl={ false }
-					onClick={ () => {
-						setShowRemoveSiteDialog( true );
-					} }
-				>
-					{ translate( 'Untag site' ) }
-				</PopoverMenuItem>
+				{ isRejected && (
+					<PopoverMenuItem
+						localizeUrl={ false }
+						onClick={ () => {
+							closeDropdown();
+							setShowRequestReviewModal( true );
+						} }
+					>
+						{ translate( 'Request another verification' ) }
+					</PopoverMenuItem>
+				) }
+				{ isPendingReview && (
+					<PopoverMenuItem
+						localizeUrl={ false }
+						onClick={ () => {
+							setShowRemoveSiteDialog( true );
+						} }
+					>
+						{ translate( 'Untag site' ) }
+					</PopoverMenuItem>
+				) }
 			</PopoverMenu>
 
 			{ showRemoveSiteDialog && (
@@ -120,6 +141,14 @@ const CommissionListActions = ( { fetchMigratedSites, site, migrationTags }: Pro
 							comment: '%(site)s is the site name',
 						}
 					) }
+				/>
+			) }
+
+			{ showRequestReviewModal && (
+				<RequestReviewModal
+					onClose={ () => setShowRequestReviewModal( false ) }
+					site={ site }
+					fetchMigratedSites={ fetchMigratedSites }
 				/>
 			) }
 		</div>

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/index.tsx
@@ -58,7 +58,12 @@ export default function MigrationsCommissionsList( {
 				label: translate( 'Review status' ).toUpperCase(),
 				getValue: () => '-',
 				render: ( { item }: { item: TaggedSite } ): ReactNode => {
-					return <ReviewStatusColumn reviewStatus={ item.incentive_status } />;
+					return (
+						<ReviewStatusColumn
+							reviewStatus={ item.incentive_status }
+							rejectionReason={ item.rejection_reason }
+						/>
+					);
 				},
 				enableHiding: false,
 				enableSorting: false,

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/index.tsx
@@ -61,7 +61,7 @@ export default function MigrationsCommissionsList( {
 					return (
 						<ReviewStatusColumn
 							reviewStatus={ item.incentive_status }
-							rejectionReason={ item.rejection_reason }
+							rejectionReason={ item.incentive_rejection_reason }
 						/>
 					);
 				},

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/style.scss
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/style.scss
@@ -1,5 +1,5 @@
-@import "@wordpress/base-styles/mixins";
-@import "@wordpress/base-styles/variables";
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/variables';
 
 .migrations-commissions-list-mobile-view {
 	padding: 16px;
@@ -7,4 +7,37 @@
 
 .migrations-commissions-list-mobile-view__column {
 	@include body-medium;
+}
+
+.commission-columns__rejected-status {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+}
+
+.commission-columns__rejection-reason-button.components-button {
+	min-width: 0;
+	padding: 0;
+	height: auto;
+	color: var( --color-neutral-50 );
+
+	&:hover {
+		color: var( --color-neutral-70 );
+	}
+}
+
+.commission-columns__rejection-reason-popover {
+	padding: 12px 16px;
+	max-width: 280px;
+}
+
+.commission-columns__rejection-reason-title {
+	font-weight: 600;
+	margin-block-end: 4px;
+}
+
+.commission-columns__rejection-reason-text {
+	color: var( --color-neutral-60 );
+	font-size: 13px;
+	line-height: 1.5;
 }

--- a/client/a8c-for-agencies/sections/migrations/hooks/use-fetch-tagged-sites-for-migration.ts
+++ b/client/a8c-for-agencies/sections/migrations/hooks/use-fetch-tagged-sites-for-migration.ts
@@ -32,7 +32,7 @@ export default function useFetchTaggedSitesForMigration() {
 				status === 'verified' ||
 				status === 'paid' ||
 				status === 'rejected' ||
-				status === 'pending-re-verification'
+				status === 'reverification'
 			);
 		} );
 	}, [ query.data ] );

--- a/client/a8c-for-agencies/sections/migrations/hooks/use-fetch-tagged-sites-for-migration.ts
+++ b/client/a8c-for-agencies/sections/migrations/hooks/use-fetch-tagged-sites-for-migration.ts
@@ -27,7 +27,13 @@ export default function useFetchTaggedSitesForMigration() {
 		const sites = Array.isArray( query.data ) ? query.data : query.data.sites || [];
 		return sites.filter( ( site: TaggedSite ) => {
 			const status = site.incentive_status || '';
-			return status === 'pending' || status === 'verified' || status === 'paid';
+			return (
+				status === 'pending' ||
+				status === 'verified' ||
+				status === 'paid' ||
+				status === 'rejected' ||
+				status === 'pending-re-verification'
+			);
 		} );
 	}, [ query.data ] );
 

--- a/client/a8c-for-agencies/sections/migrations/hooks/use-request-another-review-mutation.ts
+++ b/client/a8c-for-agencies/sections/migrations/hooks/use-request-another-review-mutation.ts
@@ -1,0 +1,39 @@
+import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { APIError } from 'calypso/state/partner-portal/types';
+
+interface RequestAnotherReviewMutationOptions {
+	siteId: number;
+	reason: string;
+}
+
+function mutationRequestAnotherReview( {
+	agencyId,
+	siteId,
+	reason,
+}: RequestAnotherReviewMutationOptions & { agencyId: number | undefined } ): Promise< void > {
+	if ( ! agencyId ) {
+		throw new Error( 'Agency ID is required to request another review' );
+	}
+
+	return wpcom.req.post( {
+		apiNamespace: 'wpcom/v2',
+		path: `/agency/${ agencyId }/sites/${ siteId }/request-review`,
+		body: {
+			reason,
+		},
+	} );
+}
+
+export default function useRequestAnotherReviewMutation< TContext = unknown >(
+	options?: UseMutationOptions< void, APIError, RequestAnotherReviewMutationOptions, TContext >
+): UseMutationResult< void, APIError, RequestAnotherReviewMutationOptions, TContext > {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	return useMutation< void, APIError, RequestAnotherReviewMutationOptions, TContext >( {
+		...options,
+		mutationFn: ( args ) => mutationRequestAnotherReview( { ...args, agencyId } ),
+	} );
+}

--- a/client/a8c-for-agencies/sections/migrations/hooks/use-request-another-review-mutation.ts
+++ b/client/a8c-for-agencies/sections/migrations/hooks/use-request-another-review-mutation.ts
@@ -20,7 +20,7 @@ function mutationRequestAnotherReview( {
 
 	return wpcom.req.post( {
 		apiNamespace: 'wpcom/v2',
-		path: `/agency/${ agencyId }/sites/${ siteId }/request-review`,
+		path: `/agency/${ agencyId }/sites/${ siteId }/request-migration-reverification`,
 		body: {
 			reason,
 		},

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx
@@ -44,50 +44,7 @@ export default function MigrationsCommissions() {
 		refetch: fetchMigratedSites,
 	} = useFetchTaggedSitesForMigration();
 
-	// Demo sample sites for testing different statuses
-	const demoSites = useMemo(
-		() => [
-			{
-				id: 90001,
-				blog_id: 90001,
-				created_at: Math.floor( Date.now() / 1000 ) - 86400 * 10,
-				url: 'demo-rejected-site.example.com',
-				state: 'active',
-				tags: [ { name: 'migration' } ],
-				incentive_status: 'rejected',
-				rejection_reason:
-					'The site does not appear to have been migrated from the specified hosting provider.',
-			},
-			{
-				id: 90002,
-				blog_id: 90002,
-				created_at: Math.floor( Date.now() / 1000 ) - 86400 * 5,
-				url: 'demo-rejected-shop.example.com',
-				state: 'active',
-				tags: [ { name: 'migration' } ],
-				incentive_status: 'rejected',
-				rejection_reason:
-					'The site was already hosted on WordPress.com before the migration period.',
-			},
-			{
-				id: 90003,
-				blog_id: 90003,
-				created_at: Math.floor( Date.now() / 1000 ) - 86400 * 2,
-				url: 'demo-re-verification.example.com',
-				state: 'active',
-				tags: [ { name: 'migration' } ],
-				incentive_status: 'pending-re-verification',
-			},
-		],
-		[]
-	);
-
-	const allSites = useMemo(
-		() => [ ...( taggedSites ?? [] ), ...demoSites ],
-		[ taggedSites, demoSites ]
-	);
-
-	const showEmptyState = ! allSites?.length;
+	const showEmptyState = ! taggedSites?.length;
 
 	const content = useMemo( () => {
 		if ( isLoading ) {
@@ -106,9 +63,9 @@ export default function MigrationsCommissions() {
 			/>
 		) : (
 			<div className="migrations-commissions__content">
-				<MigrationsConsolidatedCommissions items={ allSites } />
+				<MigrationsConsolidatedCommissions items={ taggedSites } />
 				<MigrationsCommissionsList
-					items={ allSites }
+					items={ taggedSites }
 					fetchMigratedSites={ fetchMigratedSites }
 					migrationTags={ migrationTags }
 				/>
@@ -118,7 +75,7 @@ export default function MigrationsCommissions() {
 		isLoading,
 		showEmptyState,
 		canTagSitesForCommission,
-		allSites,
+		taggedSites,
 		fetchMigratedSites,
 		migrationTags,
 	] );

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx
@@ -44,7 +44,50 @@ export default function MigrationsCommissions() {
 		refetch: fetchMigratedSites,
 	} = useFetchTaggedSitesForMigration();
 
-	const showEmptyState = ! taggedSites?.length;
+	// Demo sample sites for testing different statuses
+	const demoSites = useMemo(
+		() => [
+			{
+				id: 90001,
+				blog_id: 90001,
+				created_at: Math.floor( Date.now() / 1000 ) - 86400 * 10,
+				url: 'demo-rejected-site.example.com',
+				state: 'active',
+				tags: [ { name: 'migration' } ],
+				incentive_status: 'rejected',
+				rejection_reason:
+					'The site does not appear to have been migrated from the specified hosting provider.',
+			},
+			{
+				id: 90002,
+				blog_id: 90002,
+				created_at: Math.floor( Date.now() / 1000 ) - 86400 * 5,
+				url: 'demo-rejected-shop.example.com',
+				state: 'active',
+				tags: [ { name: 'migration' } ],
+				incentive_status: 'rejected',
+				rejection_reason:
+					'The site was already hosted on WordPress.com before the migration period.',
+			},
+			{
+				id: 90003,
+				blog_id: 90003,
+				created_at: Math.floor( Date.now() / 1000 ) - 86400 * 2,
+				url: 'demo-re-verification.example.com',
+				state: 'active',
+				tags: [ { name: 'migration' } ],
+				incentive_status: 'pending-re-verification',
+			},
+		],
+		[]
+	);
+
+	const allSites = useMemo(
+		() => [ ...( taggedSites ?? [] ), ...demoSites ],
+		[ taggedSites, demoSites ]
+	);
+
+	const showEmptyState = ! allSites?.length;
 
 	const content = useMemo( () => {
 		if ( isLoading ) {
@@ -63,9 +106,9 @@ export default function MigrationsCommissions() {
 			/>
 		) : (
 			<div className="migrations-commissions__content">
-				<MigrationsConsolidatedCommissions items={ taggedSites } />
+				<MigrationsConsolidatedCommissions items={ allSites } />
 				<MigrationsCommissionsList
-					items={ taggedSites }
+					items={ allSites }
 					fetchMigratedSites={ fetchMigratedSites }
 					migrationTags={ migrationTags }
 				/>
@@ -75,7 +118,7 @@ export default function MigrationsCommissions() {
 		isLoading,
 		showEmptyState,
 		canTagSitesForCommission,
-		taggedSites,
+		allSites,
 		fetchMigratedSites,
 		migrationTags,
 	] );

--- a/client/a8c-for-agencies/sections/migrations/request-review-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/request-review-modal/index.tsx
@@ -1,9 +1,4 @@
-import {
-	Button,
-	TextControl,
-	TextareaControl,
-	__experimentalSpacer as Spacer,
-} from '@wordpress/components';
+import { Button, TextareaControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import A4AModal from 'calypso/a8c-for-agencies/components/a4a-modal';
@@ -93,11 +88,14 @@ export default function RequestReviewModal( {
 				</Button>
 			}
 			title={ translate( 'Request another verification' ) }
-			subtile={ translate( 'Please specify why this site needs to be verified again.' ) }
+			subtile={ translate(
+				'Please specify why {{strong}}%(siteUrl)s{{/strong}} needs to be verified again.',
+				{
+					components: { strong: <strong /> },
+					args: { siteUrl: site.url },
+				}
+			) }
 		>
-			<Spacer marginBottom={ 4 } />
-			<TextControl label={ translate( 'Site URL' ) } value={ site.url } readOnly />
-			<Spacer marginBottom={ 4 } />
 			<TextareaControl
 				label={ translate( 'Reason for re-verification' ) }
 				value={ reason }

--- a/client/a8c-for-agencies/sections/migrations/request-review-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/request-review-modal/index.tsx
@@ -38,7 +38,7 @@ export default function RequestReviewModal( {
 				onSuccess: () => {
 					fetchMigratedSites();
 					dispatch(
-						recordTracksEvent( 'calypso_a8c_migrations_request_another_review_success', {
+						recordTracksEvent( 'calypso_a4a_migrations_request_another_review_success', {
 							site_id: site.id,
 						} )
 					);
@@ -62,7 +62,7 @@ export default function RequestReviewModal( {
 			}
 		);
 		dispatch(
-			recordTracksEvent( 'calypso_a8c_migrations_request_another_review_submit', {
+			recordTracksEvent( 'calypso_a4a_migrations_request_another_review_submit', {
 				site_id: site.id,
 			} )
 		);
@@ -70,7 +70,7 @@ export default function RequestReviewModal( {
 
 	const handleOnClose = () => {
 		onClose();
-		dispatch( recordTracksEvent( 'calypso_a8c_migrations_request_another_review_close' ) );
+		dispatch( recordTracksEvent( 'calypso_a4a_migrations_request_another_review_close' ) );
 	};
 
 	return (

--- a/client/a8c-for-agencies/sections/migrations/request-review-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/request-review-modal/index.tsx
@@ -1,0 +1,110 @@
+import {
+	Button,
+	TextControl,
+	TextareaControl,
+	__experimentalSpacer as Spacer,
+} from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import A4AModal from 'calypso/a8c-for-agencies/components/a4a-modal';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import useRequestAnotherReviewMutation from '../hooks/use-request-another-review-mutation';
+import type { TaggedSite } from '../types';
+
+import './style.scss';
+
+export default function RequestReviewModal( {
+	onClose,
+	site,
+	fetchMigratedSites,
+}: {
+	onClose: () => void;
+	site: TaggedSite;
+	fetchMigratedSites: () => void;
+} ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const { mutate: requestReview, isPending } = useRequestAnotherReviewMutation();
+
+	const [ reason, setReason ] = useState( '' );
+
+	const isValid = reason.trim().length > 0;
+
+	const handleSubmit = () => {
+		requestReview(
+			{
+				siteId: site.id,
+				reason: reason.trim(),
+			},
+			{
+				onSuccess: () => {
+					fetchMigratedSites();
+					dispatch(
+						recordTracksEvent( 'calypso_a8c_migrations_request_another_review_success', {
+							site_id: site.id,
+						} )
+					);
+					dispatch(
+						successNotice(
+							translate(
+								'Your verification request for {{strong}}%(siteUrl)s{{/strong}} has been submitted.',
+								{
+									components: { strong: <strong /> },
+									args: { siteUrl: site.url },
+								}
+							),
+							{ id: 'a4a-commission-request-review-success', duration: 5000 }
+						)
+					);
+					onClose();
+				},
+				onError: ( error ) => {
+					dispatch( errorNotice( error.message ) );
+				},
+			}
+		);
+		dispatch(
+			recordTracksEvent( 'calypso_a8c_migrations_request_another_review_submit', {
+				site_id: site.id,
+			} )
+		);
+	};
+
+	const handleOnClose = () => {
+		onClose();
+		dispatch( recordTracksEvent( 'calypso_a8c_migrations_request_another_review_close' ) );
+	};
+
+	return (
+		<A4AModal
+			onClose={ handleOnClose }
+			className="request-review-modal"
+			extraActions={
+				<Button
+					variant="primary"
+					onClick={ handleSubmit }
+					disabled={ isPending || ! isValid }
+					isBusy={ isPending }
+				>
+					{ translate( 'Submit request' ) }
+				</Button>
+			}
+			title={ translate( 'Request another verification' ) }
+			subtile={ translate( 'Please specify why this site needs to be verified again.' ) }
+		>
+			<Spacer marginBottom={ 4 } />
+			<TextControl label={ translate( 'Site URL' ) } value={ site.url } readOnly />
+			<Spacer marginBottom={ 4 } />
+			<TextareaControl
+				label={ translate( 'Reason for re-verification' ) }
+				value={ reason }
+				onChange={ setReason }
+				placeholder={ translate( 'Describe why this site needs to be verified again' ) }
+				rows={ 4 }
+			/>
+		</A4AModal>
+	);
+}

--- a/client/a8c-for-agencies/sections/migrations/request-review-modal/style.scss
+++ b/client/a8c-for-agencies/sections/migrations/request-review-modal/style.scss
@@ -1,4 +1,22 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .request-review-modal {
+	max-width: 480px;
+
+	.a4a-modal__main {
+		height: auto;
+
+		@include break-large {
+			width: auto;
+		}
+	}
+
+	.a4a-modal__footer {
+		position: static;
+		width: auto;
+	}
+
 	.components-textarea-control__input {
 		resize: vertical;
 	}

--- a/client/a8c-for-agencies/sections/migrations/request-review-modal/style.scss
+++ b/client/a8c-for-agencies/sections/migrations/request-review-modal/style.scss
@@ -1,0 +1,5 @@
+.request-review-modal {
+	.components-textarea-control__input {
+		resize: vertical;
+	}
+}

--- a/client/a8c-for-agencies/sections/migrations/types.ts
+++ b/client/a8c-for-agencies/sections/migrations/types.ts
@@ -10,4 +10,5 @@ export interface TaggedSite {
 	state: string;
 	tags: Tag[];
 	incentive_status: string;
+	rejection_reason?: string;
 }

--- a/client/a8c-for-agencies/sections/migrations/types.ts
+++ b/client/a8c-for-agencies/sections/migrations/types.ts
@@ -10,5 +10,5 @@ export interface TaggedSite {
 	state: string;
 	tags: Tag[];
 	incentive_status: string;
-	rejection_reason?: string;
+	incentive_rejection_reason?: string;
 }

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -50,6 +50,7 @@
 		"jetpack/crm-downloads": true,
 		"upgrades/redirect-payments": true,
 		"a4a-bd-term-pricing": true,
+		"a4a-migrations-request-verification": true,
 		"checkout/stripe-upi": true
 	},
 	"enable_all_sections": false,

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -45,6 +45,7 @@
 		"jetpack/crm-downloads": true,
 		"upgrades/redirect-payments": true,
 		"a4a-bd-term-pricing": true,
+		"a4a-migrations-request-verification": true,
 		"checkout/stripe-upi": true
 	},
 	"enable_all_sections": false,

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -42,6 +42,7 @@
 		"jetpack/crm-downloads": true,
 		"upgrades/redirect-payments": true,
 		"a4a-bd-term-pricing": true,
+		"a4a-migrations-request-verification": false,
 		"checkout/stripe-upi": true
 	},
 	"enable_all_sections": false,

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -47,6 +47,7 @@
 		"jetpack/crm-downloads": true,
 		"upgrades/redirect-payments": true,
 		"a4a-bd-term-pricing": true,
+		"a4a-migrations-request-verification": false,
 		"checkout/stripe-upi": true
 	},
 	"enable_all_sections": false,


### PR DESCRIPTION
Adds a "Request another verification" action for rejected sites in the migrations commissions list. Clicking opens a modal where the agency can provide a reason for re-verification. Also adds a rejection reason popover (triggered by an info icon next to the Rejected badge) and a new "Pending re-verification" status.

Includes demo sample sites to preview the rejected and pending-re-verification flows.


Depends on 211623-ghe-Automattic/wpcom

## Proposed Changes

This pull request adds support for requesting a re-verification of migrated sites in the commissions list, including a modal for submitting a reason, UI improvements for rejected statuses, and feature flag controls. It also updates the data model and filtering to handle new review statuses and reasons.

**New "Request Verification" feature:**
* Added a "Request verification" / "Request another verification" action in the commissions list for sites with a "pending" or "rejected" status, controlled by the `a4a-migrations-request-verification` feature flag. This opens a modal where users can provide a reason for re-verification. (`commission-list-actions.tsx`, `request-review-modal/index.tsx`, `request-review-modal/style.scss`, `config/a8c-for-agencies-*.json`) [[1]](diffhunk://#diff-33bd6e60cc8936a99520526c18643023c84c01f7d3f6263659a4b3eb603cd289R1) [[2]](diffhunk://#diff-33bd6e60cc8936a99520526c18643023c84c01f7d3f6263659a4b3eb603cd289R28-R44) [[3]](diffhunk://#diff-33bd6e60cc8936a99520526c18643023c84c01f7d3f6263659a4b3eb603cd289R109-R122) [[4]](diffhunk://#diff-33bd6e60cc8936a99520526c18643023c84c01f7d3f6263659a4b3eb603cd289R153-R160) [[5]](diffhunk://#diff-888dfae0ce9aaa03afde72e8190326f5ce1de2b943e8a0f5f4496226c36f7e9fR1-R108) [[6]](diffhunk://#diff-0a9a87ec5c4c595dc66685e014c8529e90bfdedb894d1fb971c0897e08013af8R1-R23) [[7]](diffhunk://#diff-b7fdfbca27fe9c8150a2cb73e811d96b030fad1f6072494c8291f188cef9779aR53) [[8]](diffhunk://#diff-1c75c03fadc6b49d3df97ba7dd9ba5ad3304c19beebef3584ffad47314e4ac5fR48) [[9]](diffhunk://#diff-6cae595596e0ea2cf4edffd0083ea7fb071702d10e058839990765fb49f4aa36R45) [[10]](diffhunk://#diff-75d25521c97285a60bd86cedb61e8660ece2a553e9e420e2bba8c2aee89f3cb1R50)

* Implemented a custom React Query mutation hook (`use-request-another-review-mutation.ts`) to handle the API call for requesting re-verification, using the active agency ID.

**UI/UX improvements for review statuses:**
* Updated the review status column to display a popover with the rejection reason and an info icon when the status is "rejected". Also added support for the "pending-re-verification" status. (`commission-columns.tsx`, `style.scss`) [[1]](diffhunk://#diff-f00a54506c1a6ef7efab3013ef603b773a7e3e8f3d5ea481841ecc3982bcdc62L1-R5) [[2]](diffhunk://#diff-f00a54506c1a6ef7efab3013ef603b773a7e3e8f3d5ea481841ecc3982bcdc62L18-R30) [[3]](diffhunk://#diff-f00a54506c1a6ef7efab3013ef603b773a7e3e8f3d5ea481841ecc3982bcdc62R54-R58) [[4]](diffhunk://#diff-f00a54506c1a6ef7efab3013ef603b773a7e3e8f3d5ea481841ecc3982bcdc62L59-R116) [[5]](diffhunk://#diff-08a9330b120124ab9b19d08e47aa9037e1ef2ed34e8228de457f7abc79c69447L61-R66) [[6]](diffhunk://#diff-71c9f579866042e23e8896a6ccb7722181923f5786dc40bc2e53fdde9bc15ac2R11-R43)

**Data model and filtering updates:**
* Updated the `TaggedSite` type to include an optional `rejection_reason` field, and updated filtering logic to support the new statuses. (`types.ts`, `use-fetch-tagged-sites-for-migration.ts`) [[1]](diffhunk://#diff-9406f6855f319dd2f8f3551e021db5652d69fa9d090ca58685b6d906ac890f34R13) [[2]](diffhunk://#diff-4cc6e938ce779736bc873667659a1b3ac008215117f8d934f382fdf9b61acaf4L30-R36)

**Styling:**
* Added and updated SCSS files for the new modal and status UI elements. (`style.scss`, `request-review-modal/style.scss`) [[1]](diffhunk://#diff-71c9f579866042e23e8896a6ccb7722181923f5786dc40bc2e53fdde9bc15ac2R11-R43) [[2]](diffhunk://#diff-0a9a87ec5c4c595dc66685e014c8529e90bfdedb894d1fb971c0897e08013af8R1-R23)

This set of changes enables a more informative and interactive review workflow for site migrations, especially around handling rejections and re-verification requests.

## Why are these changes being made?

* This is part of the Manual Migration review project.

## Testing Instructions
* First, create some sites and tag it for site migration.
* Refer to the patch 211623-ghe-Automattic/wpcom for setting up sandbox
* Make sure you follow the instructions to generate a dummy Migration record.
* Once you have created the dummy record. You can proceed on the Migrations page and look for your site.
   <img width="654" height="81" alt="Screenshot 2026-04-14 at 10 07 43 PM" src="https://github.com/user-attachments/assets/8ede49bb-579a-42ef-8519-aa0c735888f4" />
* In the actions, click `Request verification` and fill up and submit the form.
   <img width="553" height="401" alt="Screenshot 2026-04-14 at 10 07 59 PM" src="https://github.com/user-attachments/assets/8daba56c-bb5f-4301-90fd-3ed3c778eda0" />
* Verify that the submission is successful and the status has changed to pending for review.
   <img width="591" height="84" alt="Screenshot 2026-04-14 at 10 08 55 PM" src="https://github.com/user-attachments/assets/248da2d7-1946-4578-b886-1190dd1ba9f5" />
* Test rejection flow and confirm you see the following. Follow instructions here 161756-ghe-Automattic/missioncontrol:
<img width="275" height="137" alt="Screenshot 2026-04-15 at 11 32 49 PM" src="https://github.com/user-attachments/assets/795ce456-0ca6-4b79-b23a-31e7cd3ee6f6" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?