### PR TITLE
A4A-2389: Hide payout notice on overview until agency has activity.

### DIFF
--- a/client/a8c-for-agencies/sections/overview/overview.tsx
+++ b/client/a8c-for-agencies/sections/overview/overview.tsx
@@ -23,12 +23,12 @@ export default function Overview() {
 	const translate = useTranslate();
 	const title = translate( 'Agency overview' );
 
-	const { hasActivity } = useHasCommissionActivity();
+	const { hasActivity, isLoading: isLoadingActivity } = useHasCommissionActivity();
 
 	return (
 		<Layout title={ title } wide>
 			<LayoutTop>
-				{ hasActivity && <MissingPaymentSettingsNotice /> }
+				{ ! isLoadingActivity && hasActivity && <MissingPaymentSettingsNotice /> }
 				<A4AAgencyApprovalNotice />
 				<PressableUsageLimitNotice />
 

--- a/client/a8c-for-agencies/sections/overview/overview.tsx
+++ b/client/a8c-for-agencies/sections/overview/overview.tsx
@@ -11,6 +11,7 @@ import LayoutHeader, {
 	LayoutHeaderTitle as Title,
 } from 'calypso/layout/hosting-dashboard/header';
 import { MissingPaymentSettingsNotice } from '../referrals/common/missing-payment-settings-notice';
+import useHasCommissionActivity from '../referrals/common/missing-payment-settings-notice/use-has-commission-activity';
 import OverviewBody from './body';
 import OverviewHeaderActions from './header-actions';
 import PartnerDirectoryOnboardingCard from './partner-directory-onboarding-card';
@@ -22,10 +23,12 @@ export default function Overview() {
 	const translate = useTranslate();
 	const title = translate( 'Agency overview' );
 
+	const { hasActivity } = useHasCommissionActivity();
+
 	return (
 		<Layout title={ title } wide>
 			<LayoutTop>
-				<MissingPaymentSettingsNotice />
+				{ hasActivity && <MissingPaymentSettingsNotice /> }
 				<A4AAgencyApprovalNotice />
 				<PressableUsageLimitNotice />
 

--- a/client/a8c-for-agencies/sections/referrals/common/missing-payment-settings-notice/test/use-has-commission-activity.ts
+++ b/client/a8c-for-agencies/sections/referrals/common/missing-payment-settings-notice/test/use-has-commission-activity.ts
@@ -1,0 +1,134 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook } from '@testing-library/react';
+import useFetchAllLicenses from 'calypso/a8c-for-agencies/data/purchases/use-fetch-all-licenses';
+import useFetchSitesWithPlugins from 'calypso/a8c-for-agencies/data/sites/use-fetch-sites-with-plugins';
+import useFetchTaggedSitesForMigration from 'calypso/a8c-for-agencies/sections/migrations/hooks/use-fetch-tagged-sites-for-migration';
+import useFetchReferrals from '../../../hooks/use-fetch-referrals';
+import useHasCommissionActivity from '../use-has-commission-activity';
+
+jest.mock( '../../../hooks/use-fetch-referrals' );
+jest.mock(
+	'calypso/a8c-for-agencies/sections/migrations/hooks/use-fetch-tagged-sites-for-migration'
+);
+jest.mock( 'calypso/a8c-for-agencies/data/purchases/use-fetch-all-licenses' );
+jest.mock( 'calypso/a8c-for-agencies/data/sites/use-fetch-sites-with-plugins' );
+
+const mockUseFetchReferrals = useFetchReferrals as jest.MockedFunction< typeof useFetchReferrals >;
+const mockUseFetchTaggedSitesForMigration = useFetchTaggedSitesForMigration as jest.MockedFunction<
+	typeof useFetchTaggedSitesForMigration
+>;
+const mockUseFetchAllLicenses = useFetchAllLicenses as jest.MockedFunction<
+	typeof useFetchAllLicenses
+>;
+const mockUseFetchSitesWithPlugins = useFetchSitesWithPlugins as jest.MockedFunction<
+	typeof useFetchSitesWithPlugins
+>;
+
+type QueryResult< T > = { data: T; isLoading: boolean };
+
+const queryResult = < T >( data: T, isLoading = false ): QueryResult< T > =>
+	( { data, isLoading } ) as QueryResult< T >;
+
+const setMocks = ( {
+	referrals = [],
+	taggedSites = [],
+	licenses = { items: [], total: 0 },
+	sitesWithPlugins = [],
+	loading = {
+		referrals: false,
+		migrations: false,
+		licenses: false,
+		plugins: false,
+	},
+}: {
+	referrals?: unknown[];
+	taggedSites?: unknown[];
+	licenses?: { items: unknown[]; total: number };
+	sitesWithPlugins?: unknown[];
+	loading?: {
+		referrals?: boolean;
+		migrations?: boolean;
+		licenses?: boolean;
+		plugins?: boolean;
+	};
+} = {} ) => {
+	mockUseFetchReferrals.mockReturnValue(
+		queryResult( referrals, loading.referrals ) as ReturnType< typeof useFetchReferrals >
+	);
+	mockUseFetchTaggedSitesForMigration.mockReturnValue(
+		queryResult( taggedSites, loading.migrations ) as ReturnType<
+			typeof useFetchTaggedSitesForMigration
+		>
+	);
+	mockUseFetchAllLicenses.mockReturnValue(
+		queryResult( licenses, loading.licenses ) as ReturnType< typeof useFetchAllLicenses >
+	);
+	mockUseFetchSitesWithPlugins.mockReturnValue(
+		queryResult( sitesWithPlugins, loading.plugins ) as ReturnType<
+			typeof useFetchSitesWithPlugins
+		>
+	);
+};
+
+describe( 'useHasCommissionActivity', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'returns hasActivity=false when all data sources are empty', () => {
+		setMocks();
+
+		const { result } = renderHook( () => useHasCommissionActivity() );
+
+		expect( result.current.hasActivity ).toBe( false );
+		expect( result.current.isLoading ).toBe( false );
+	} );
+
+	it( 'returns hasActivity=true when the agency has sent a referral', () => {
+		setMocks( { referrals: [ { id: 1 } ] } );
+
+		const { result } = renderHook( () => useHasCommissionActivity() );
+
+		expect( result.current.hasActivity ).toBe( true );
+	} );
+
+	it( 'returns hasActivity=true when the agency has migrated a site', () => {
+		setMocks( { taggedSites: [ { id: 1 } ] } );
+
+		const { result } = renderHook( () => useHasCommissionActivity() );
+
+		expect( result.current.hasActivity ).toBe( true );
+	} );
+
+	it( 'returns hasActivity=true when the agency has a WooPayments license', () => {
+		setMocks( { licenses: { items: [ { id: 1 } ], total: 1 } } );
+
+		const { result } = renderHook( () => useHasCommissionActivity() );
+
+		expect( result.current.hasActivity ).toBe( true );
+	} );
+
+	it( 'returns hasActivity=true when the agency has a site with the WooPayments plugin', () => {
+		setMocks( { sitesWithPlugins: [ { blog_id: 1 } ] } );
+
+		const { result } = renderHook( () => useHasCommissionActivity() );
+
+		expect( result.current.hasActivity ).toBe( true );
+	} );
+
+	it.each( [
+		[ 'referrals', { referrals: true } ],
+		[ 'migrations', { migrations: true } ],
+		[ 'licenses', { licenses: true } ],
+		[ 'plugins', { plugins: true } ],
+	] )( 'returns isLoading=true while %s is still loading', ( _, loading ) => {
+		setMocks( { loading } );
+
+		const { result } = renderHook( () => useHasCommissionActivity() );
+
+		expect( result.current.isLoading ).toBe( true );
+	} );
+} );

--- a/client/a8c-for-agencies/sections/referrals/common/missing-payment-settings-notice/use-has-commission-activity.ts
+++ b/client/a8c-for-agencies/sections/referrals/common/missing-payment-settings-notice/use-has-commission-activity.ts
@@ -1,0 +1,45 @@
+import useFetchAllLicenses from 'calypso/a8c-for-agencies/data/purchases/use-fetch-all-licenses';
+import useFetchSitesWithPlugins from 'calypso/a8c-for-agencies/data/sites/use-fetch-sites-with-plugins';
+import useFetchTaggedSitesForMigration from 'calypso/a8c-for-agencies/sections/migrations/hooks/use-fetch-tagged-sites-for-migration';
+import {
+	LicenseFilter,
+	LicenseSortField,
+	LicenseSortDirection,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import useFetchReferrals from '../../hooks/use-fetch-referrals';
+
+/**
+ * Determines whether the agency has performed any commission-generating
+ * activity: sent a referral, migrated a site, or set up WooPayments.
+ *
+ * Used to gate the "add payout information" notice so it doesn't clutter
+ * the UI for brand-new accounts that have no context for it yet.
+ */
+export default function useHasCommissionActivity() {
+	const { data: referrals, isLoading: isLoadingReferrals } = useFetchReferrals();
+
+	const { data: taggedSites, isLoading: isLoadingMigrations } = useFetchTaggedSitesForMigration();
+
+	const { data: woopaymentsLicenses, isLoading: isLoadingLicenses } = useFetchAllLicenses(
+		LicenseFilter.Attached,
+		'woopayments',
+		LicenseSortField.IssuedAt,
+		LicenseSortDirection.Descending
+	);
+
+	const { data: sitesWithWooPaymentsPlugin, isLoading: isLoadingSitesWithPlugin } =
+		useFetchSitesWithPlugins( [ 'woocommerce-payments/woocommerce-payments' ] );
+
+	const isLoading =
+		isLoadingReferrals || isLoadingMigrations || isLoadingLicenses || isLoadingSitesWithPlugin;
+
+	const hasReferrals = !! referrals?.length;
+	const hasMigratedSites = !! taggedSites?.length;
+	const hasWooPayments =
+		!! woopaymentsLicenses?.items?.length || !! sitesWithWooPaymentsPlugin?.length;
+
+	return {
+		hasActivity: hasReferrals || hasMigratedSites || hasWooPayments,
+		isLoading,
+	};
+}


### PR DESCRIPTION


Closes  https://linear.app/a8c/issue/A4A-2389/payout-notice-dont-show-immediately-after-sign-up


## Proposed Changes

The "Add your payout information" notice was shown immediately on the Agency overview after sign-up with no contextual introduction to referrals or other commission-generating tools. Now it only appears once the agency has sent a referral, migrated a site, or set up WooPayments.

## Why are these changes being made?

* The Notice is cluttering the UI for new agencies without prior context on referrals or commission-generating tools.

## Testing Instructions

* Use the A4A live link and navigate /signup.
* Create a new agency.
* After a successful signup. Confirm that you don't see the noticed.
* Do any of the following
   * Sent referral
   * Connected a WooPayments
   * Tagged a Site migration
* Confirm you see the notice.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
