### PR TITLE
Fix flaky Pre-Release E2E Test: `specs/onboarding/signup__with-theme-premium.ts`

### DIFF
--- a/packages/calypso-e2e/src/lib/components/me/me-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/me/me-sidebar-component.ts
@@ -27,6 +27,9 @@ export class MeSidebarComponent {
 	 */
 	async openMobileMenu() {
 		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			// Wait for the masterbar to finish re-rendering after page navigation
+			// before clicking, otherwise the element can be detached mid-click.
+			await this.page.waitForLoadState( 'networkidle' );
 			await this.page.getByTitle( 'Menu' ).click();
 		}
 	}

--- a/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
@@ -245,6 +245,12 @@ export class CartCheckoutPage {
 	 * @param {RegistrarDetails} registrarDetails Domain registrar details.
 	 */
 	async enterDomainRegistrarDetails( registrarDetails: RegistrarDetails ): Promise< void > {
+		// The registrar form appears after a checkout page navigation. Wait for it
+		// to be visible with a generous timeout before filling to avoid timing out
+		// while the page is still loading.
+		await this.page
+			.locator( selectors.firstNameInput )
+			.waitFor( { state: 'visible', timeout: 30_000 } );
 		await this.page.fill( selectors.firstNameInput, registrarDetails.firstName );
 		await this.page.fill( selectors.lastNameInput, registrarDetails.lastName );
 		await this.page.selectOption( selectors.phoneSelect, registrarDetails.countryCode );

--- a/test/e2e/specs/onboarding/signup__with-theme-premium.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-premium.ts
@@ -171,7 +171,7 @@ describe( 'Lifecyle: Premium theme signup, onboard, launch and cancel subscripti
 
 		const restAPIClient = new RestAPIClient(
 			{
-				username: testUser.username,
+				username: newUserDetails.body.username,
 				password: testUser.password,
 			},
 			newUserDetails.body.bearer_token

--- a/test/e2e/specs/shared/api-close-account.ts
+++ b/test/e2e/specs/shared/api-close-account.ts
@@ -17,12 +17,16 @@ export async function apiCloseAccount(
 	accountDetails: AccountDetails
 ): Promise< void > {
 	console.log( `Closing account ${ accountDetails.userID }.` );
-	const response: AccountClosureResponse = await client.closeAccount( accountDetails );
+	try {
+		const response: AccountClosureResponse = await client.closeAccount( accountDetails );
 
-	if ( response.success !== true ) {
-		console.warn( `Failed to delete user ID ${ accountDetails.userID }` );
-		console.warn( response );
-	} else {
-		console.log( `Successfully deleted user ID ${ accountDetails.userID }` );
+		if ( response.success !== true ) {
+			console.warn( `Failed to delete user ID ${ accountDetails.userID }` );
+			console.warn( response );
+		} else {
+			console.log( `Successfully deleted user ID ${ accountDetails.userID }` );
+		}
+	} catch ( error ) {
+		console.warn( `Error closing account ${ accountDetails.userID }: ${ error }` );
 	}
 }


### PR DESCRIPTION

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-16661

## Proposed Changes

* In `api-close-account.ts`: wrap the `closeAccount()` call in a `try-catch` so that authentication errors during teardown are logged as warnings instead of propagating exceptions that mark a passing test as failed.            
* In `signup__with-theme-premium.ts`: use `newUserDetails.body.username` (the server-assigned username) instead of `testUser.username` (a locally-generated placeholder) when constructing the `RestAPIClient` in `afterAll`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

On https://github.com/Automattic/wp-calypso/commit/500f82c0f1ffc665346b74d6c8fb506728d387b2 I got the following error for suite `specs/onboarding/signup__with-theme-premium.ts`:

```
Error: invalid_username: We don't seem to have an account with that name. Double-check the spelling and try again!
    at RestAPIClient.getBearerToken (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/packages/calypso-e2e/src/rest-api-client.ts:121:10)
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
    at RestAPIClient.getAuthorizationHeader (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/packages/calypso-e2e/src/rest-api-client.ts:138:24)
    at RestAPIClient.getMyAccountInformation (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/packages/calypso-e2e/src/rest-api-client.ts:481:20)
    at RestAPIClient.closeAccount (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/packages/calypso-e2e/src/rest-api-client.ts:540:30)
    at apiCloseAccount (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/test/e2e/specs/shared/api-close-account.ts:20:43)
    at Object.<anonymous> (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/test/e2e/specs/onboarding/signup__with-theme-premium.ts:180:3)
```

This test uses an email-only signup flow (`signupSocialFirstWithEmail ), where WordPress.com auto-generates the username server-side. The locally-generated `testUser.username` never gets registered on the server.               

Normally this doesn't matter because `newUserDetails.body.bearer_token` (captured from the signup network response) is used directly for auth in `afterAll`. But when that token is missing or falsy — a flaky scenario, e.g. a race in Playwright's network interception: `RestAPIClient` falls back to authenticating with `testUser.username` + `testUser.password`, neither of which exists on the server, causing `invalid_username`.                              

Using the server-assigned username fixes the fallback credential. Wrapping `apiCloseAccount` in `try-catch` ensures that any remaining auth failure during cleanup logs a warning rather than surfacing as a test failure, since account closure is teardown, not an assertion.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Just check the code.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
