### PR TITLE
Image Studio: increase prompt input limit from 600 to 1000 characters

### DIFF
--- a/packages/image-studio/src/components/index.tsx
+++ b/packages/image-studio/src/components/index.tsx
@@ -169,6 +169,7 @@ function ImageStudioAgentChat( {
 			inputValue={ inputValue }
 			onInputChange={ setInputValue }
 			onSuggestionClick={ handleSuggestionClick }
+			maxInputLength={ 1000 }
 		>
 			<AgentUI.ConversationView showHeader={ false }>
 				<AgentUI.Messages />


### PR DESCRIPTION
## Summary

- The legacy Jetpack AI image generators (DALLE, Stable Diffusion, FLUX) silently truncated user prompts at **1000 characters**
- In Jetpack 15.7, Image Studio replaced these generators but defaults to **600 characters** (the `agenttic-ui` default), blocking prompts that previously worked
- This PR passes `maxInputLength={ 1000 }` to `AgentUI.Container` in Image Studio — matching the legacy limit without touching the `agenttic-ui` default (other agents keep 600)

### Before

<img width="1774" height="1322" alt="image" src="https://github.com/user-attachments/assets/a5cf0b1d-da95-4462-9666-0434548ea32a" />

### After

<img width="1728" height="997" alt="Screenshot 2026-04-10 at 5 22 46 PM" src="https://github.com/user-attachments/assets/ff7b1ffa-6285-4390-ac84-1a8f8a983916" />

## Test plan

### Setup
Open Image Studio on a Simple or Atomic site (Generate or Edit mode).

### Test 1 — 694-char prompt (should now be accepted, was previously blocked)

Paste this prompt and confirm it submits successfully:

```
A breathtaking aerial photograph of a misty mountain valley at golden hour, where ancient pine forests cascade down steep rocky slopes into a winding turquoise river below. The warm amber light of the setting sun breaks through scattered clouds, casting long dramatic shadows across the rugged landscape. Snow-capped peaks rise majestically in the distance, their reflections shimmering in the still waters of a hidden alpine lake nestled below. Wildflowers in shades of purple and gold dot the open meadows, while a lone wooden cabin with smoke gently curling from its stone chimney sits nestled among the tall trees, suggesting warmth and quiet solitude in this vast and untouched wilderness.
```

### Test 2 — 1006-char prompt (should still be rejected at 1000 chars)

Paste this prompt and confirm the input is blocked at 1000 characters:

```
A breathtaking aerial photograph of a misty mountain valley at golden hour, where ancient pine forests cascade down steep rocky slopes into a winding turquoise river below. The warm amber light of the setting sun breaks through scattered clouds, casting long dramatic shadows across the rugged landscape. Snow-capped peaks rise majestically in the distance, their reflections shimmering in the still waters of a hidden alpine lake nestled below. Wildflowers in shades of purple and gold dot the open meadows, while a lone wooden cabin with smoke gently curling from its stone chimney sits nestled among the tall trees, suggesting warmth and quiet solitude in this vast and untouched wilderness. A family of deer grazes peacefully near the riverbank, completely unaware of the golden eagle soaring overhead on the thermal winds. Mist clings to the lower valleys like a soft white blanket, diffusing the last light of day into a dreamlike haze of amber, rose, and violet hues that paint the entire sky above.
```

### Test 3 — Other agents unaffected
- [ ] Confirm Help Center and other Agents Manager surfaces still enforce the 600-char default

<img width="758" height="1006" alt="Screenshot 2026-04-10 at 5 28 51 PM" src="https://github.com/user-attachments/assets/729c25b1-08a5-4a0f-8010-558f2048596a" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)