### PR TITLE
Agents Manager: Implement support guides search

### DIFF
--- a/packages/agents-manager/package.json
+++ b/packages/agents-manager/package.json
@@ -63,6 +63,7 @@
 		"@wordpress/icons": "^10.23.0",
 		"@wordpress/primitives": "^4.23.0",
 		"@wordpress/private-apis": "^1.39.0",
+		"@wordpress/url": "^4.23.0",
 		"clsx": "^2.1.1",
 		"history": "^5.3.0",
 		"i18n-calypso": "workspace:^",

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -70,7 +70,7 @@ export default function AgentDock( {
 	useImageUpload,
 	useCheckpoint,
 }: Props ) {
-	const { site, siteKey, sectionName, isEligibleForChat, agentConfig } = useAgentsManagerContext();
+	const { siteKey, sectionName, agentConfig } = useAgentsManagerContext();
 
 	const [ isCompactMode, setIsCompactMode ] = useState(
 		window.__agentsManagerActions?.isCompactMode ?? false
@@ -263,13 +263,10 @@ export default function AgentDock( {
 
 	const SupportGuideRoute = (
 		<SupportGuide
-			isEligibleForChat={ isEligibleForChat }
 			onAbort={ handleAbort }
 			onClose={ closeSidebar }
 			isDocked={ isDocked }
 			isOpen={ isPersistedOpen }
-			sectionName={ sectionName }
-			currentSiteDomain={ site?.domain }
 			chatHeaderOptions={ chatHeaderOptions }
 		/>
 	);

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -7,7 +7,7 @@ import {
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { comment, drawerRight, login, lifesaver } from '@wordpress/icons';
+import { comment, drawerRight, help, login, lifesaver } from '@wordpress/icons';
 import { Routes, Route, Navigate, useLocation, useNavigate } from 'react-router-dom';
 import { useAgentsManagerContext } from '../../contexts';
 import useAdminBarIntegration from '../../hooks/use-admin-bar-integration';
@@ -184,6 +184,13 @@ export default function AgentDock( {
 					handleAbort();
 					navigate( '/zendesk' );
 				},
+			},
+			// TODO: For testing. Remove before release.
+			{
+				icon: help,
+				title: __( 'Support guides', '__i18n_text_domain__' ),
+				isDisabled: pathname === '/support-guides',
+				onClick: () => navigate( '/support-guides' ),
 			},
 			isDocked && {
 				icon: login,

--- a/packages/agents-manager/src/components/support-guide/index.tsx
+++ b/packages/agents-manager/src/components/support-guide/index.tsx
@@ -6,11 +6,12 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { useAgentsManagerContext } from '../../contexts';
 import { AGENTS_MANAGER_STORE } from '../../stores';
 import ChatHeader, { type Options as ChatHeaderOptions } from '../chat-header';
 import './style.scss';
 
-interface Props {
+interface SupportGuideProps {
 	/** Chat header menu options. */
 	chatHeaderOptions: ChatHeaderOptions;
 	/** Indicates if the chat is docked in the sidebar. */
@@ -21,12 +22,6 @@ interface Props {
 	onAbort: () => void;
 	/** Called when the chat is closed. */
 	onClose: () => void;
-	/** The current site domain for contextual support. */
-	currentSiteDomain?: string;
-	/** The current Calypso section name. */
-	sectionName: string;
-	/** Indicates if the user is eligible for live chat support. */
-	isEligibleForChat: boolean;
 }
 
 export default function SupportGuide( {
@@ -35,10 +30,8 @@ export default function SupportGuide( {
 	isDocked,
 	onAbort,
 	onClose,
-	currentSiteDomain,
-	sectionName,
-	isEligibleForChat,
-}: Props ) {
+}: SupportGuideProps ) {
+	const { site, sectionName, isEligibleForChat } = useAgentsManagerContext();
 	const navigate = useNavigate();
 	const { state } = useLocation();
 	const { setFloatingPosition } = useDispatch( AGENTS_MANAGER_STORE );
@@ -86,7 +79,7 @@ export default function SupportGuide( {
 					<div className="agent-manager-support-guide-content help-center__container-content">
 						<HelpCenterArticle
 							sectionName={ sectionName }
-							currentSiteDomain={ currentSiteDomain }
+							currentSiteDomain={ site?.domain }
 							isEligibleForChat={ isEligibleForChat }
 							forceEmailSupport={ false }
 						/>

--- a/packages/agents-manager/src/components/support-guide/index.tsx
+++ b/packages/agents-manager/src/components/support-guide/index.tsx
@@ -49,6 +49,17 @@ export default function SupportGuide( {
 
 	const isFromChat = !! ( state?.sessionId || state?.conversationId );
 
+	// Navigate back to the source route, preserving relevant state.
+	const handleBack = () => {
+		if ( state?.sessionId ) {
+			navigate( '/chat', { state } );
+		} else if ( state?.conversationId ) {
+			navigate( '/zendesk', { state } );
+		} else {
+			navigate( '/support-guides', { state } );
+		}
+	};
+
 	return (
 		<AgentUI.Container
 			initialChatPosition={ floatingPosition }
@@ -67,14 +78,7 @@ export default function SupportGuide( {
 			<AgentUI.ConversationView>
 				<ChatHeader
 					onClose={ onClose }
-					onBack={ () => {
-						// Navigate back to the source route, preserving `state` (`sessionId`/`conversationId`).
-						if ( state?.sessionId ) {
-							navigate( '/chat', { state } );
-						} else {
-							navigate( '/zendesk', { state } );
-						}
-					} }
+					onBack={ handleBack }
 					options={ chatHeaderOptions }
 					title={ __( 'Support Guides', '__i18n_text_domain__' ) }
 				/>

--- a/packages/agents-manager/src/components/support-guides/index.tsx
+++ b/packages/agents-manager/src/components/support-guides/index.tsx
@@ -7,35 +7,31 @@ import {
 	__experimentalItem as Item,
 	Spinner,
 } from '@wordpress/components';
+import { useDebouncedInput } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
-import { getLocaleSlug } from 'i18n-calypso';
-import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
+import useHelpSearchQuery from '../../hooks/use-help-search-query';
 import { AGENTS_MANAGER_STORE } from '../../stores';
 import ChatHeader, { type Options as ChatHeaderOptions } from '../chat-header';
 import './style.scss';
 
-/**
- * Stub for useHelpSearchQuery.
- * TODO: Implement actual search functionality when adding support for support guides.
- * This was previously imported from @automattic/help-center but removed to decouple packages.
- */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function useHelpSearchQuery( query: string, locale: string, sectionName: string ) {
-	return {
-		data: [] as Array< { post_id: number; link: string; title: string } >,
-		isFetching: false,
-	};
+interface SearchResultsProps {
+	searchInput: string;
 }
 
-function SearchResults( { searchInput }: { searchInput: string } ) {
-	const { data: searchData, isFetching: isSearching } = useHelpSearchQuery(
-		searchInput,
-		getLocaleSlug() ?? 'en',
-		'sectionName'
-	);
+function SearchResults( { searchInput }: SearchResultsProps ) {
+	const trimmedInput = searchInput.trim();
+	const { data: searchData, isFetching: isSearching } = useHelpSearchQuery( trimmedInput );
+
+	if ( ! trimmedInput ) {
+		return (
+			<div className="agent-manager-support-guides__status">
+				{ __( 'Search guides to find answers to your questions.', '__i18n_text_domain__' ) }
+			</div>
+		);
+	}
 
 	if ( isSearching ) {
 		return <Spinner />;
@@ -43,8 +39,8 @@ function SearchResults( { searchInput }: { searchInput: string } ) {
 
 	if ( ! searchData?.length ) {
 		return (
-			<div className="agent-manager-support-guides-no-results">
-				{ __( 'No results found', '__i18n_text_domain__' ) }
+			<div className="agent-manager-support-guides__status">
+				{ __( 'No results found.', '__i18n_text_domain__' ) }
 			</div>
 		);
 	}
@@ -53,14 +49,19 @@ function SearchResults( { searchInput }: { searchInput: string } ) {
 		<ItemGroup isSeparated isBordered isRounded>
 			{ searchData?.map( ( item ) => (
 				<Item key={ item.post_id }>
-					<Link to={ `/post?link=${ item.link }` }>{ item.title }</Link>
+					<Link
+						to={ `/post?link=${ encodeURIComponent( item.link ) }` }
+						state={ { searchQuery: trimmedInput } }
+					>
+						{ item.title }
+					</Link>
 				</Item>
 			) ) }
 		</ItemGroup>
 	);
 }
 
-interface Props {
+interface SupportGuidesProps {
 	/** Chat header menu options. */
 	chatHeaderOptions: ChatHeaderOptions;
 	/** Indicates if the chat is docked in the sidebar. */
@@ -79,8 +80,11 @@ export default function SupportGuides( {
 	isDocked,
 	onAbort,
 	onClose,
-}: Props ) {
-	const [ searchInput, setSearchInput ] = useState( '' );
+}: SupportGuidesProps ) {
+	const { state } = useLocation();
+	const [ searchInput, setSearchInput, debouncedSearchInput ] = useDebouncedInput(
+		state?.searchQuery ?? ''
+	);
 	const { setFloatingPosition } = useDispatch( AGENTS_MANAGER_STORE );
 	const { floatingPosition } = useSelect( ( select ) => {
 		const store: AgentsManagerSelect = select( AGENTS_MANAGER_STORE );
@@ -119,7 +123,7 @@ export default function SupportGuides( {
 						onClick={ ( e ) => e.currentTarget.focus() }
 						value={ searchInput }
 					/>
-					<SearchResults searchInput={ searchInput } />
+					<SearchResults searchInput={ debouncedSearchInput } />
 				</VStack>
 			</AgentUI.ConversationView>
 		</AgentUI.Container>

--- a/packages/agents-manager/src/components/support-guides/index.tsx
+++ b/packages/agents-manager/src/components/support-guides/index.tsx
@@ -101,7 +101,7 @@ export default function SupportGuides( {
 	onAbort,
 	onClose,
 }: SupportGuidesProps ) {
-	const { state } = useLocation() as { state?: { searchQuery?: string } };
+	const { state } = useLocation();
 	const [ searchInput, setSearchInput, debouncedSearchInput ] = useDebouncedInput(
 		state?.searchQuery ?? ''
 	);

--- a/packages/agents-manager/src/components/support-guides/index.tsx
+++ b/packages/agents-manager/src/components/support-guides/index.tsx
@@ -1,6 +1,7 @@
 import { AgentUI } from '@automattic/agenttic-ui';
 import { AgentsManagerSelect } from '@automattic/data-stores';
 import {
+	Button,
 	SearchControl,
 	__experimentalVStack as VStack,
 	__experimentalItemGroup as ItemGroup,
@@ -23,7 +24,7 @@ interface SearchResultsProps {
 
 function SearchResults( { searchInput }: SearchResultsProps ) {
 	const trimmedInput = searchInput.trim();
-	const { data: searchData, isFetching: isSearching } = useHelpSearchQuery( trimmedInput );
+	const { data, isFetching, isError, refetch } = useHelpSearchQuery( trimmedInput );
 
 	if ( ! trimmedInput ) {
 		return (
@@ -33,11 +34,30 @@ function SearchResults( { searchInput }: SearchResultsProps ) {
 		);
 	}
 
-	if ( isSearching ) {
-		return <Spinner />;
+	if ( isFetching ) {
+		return (
+			<div className="agent-manager-support-guides__status">
+				<Spinner />
+			</div>
+		);
 	}
 
-	if ( ! searchData?.length ) {
+	if ( isError ) {
+		return (
+			<div className="agent-manager-support-guides__status">
+				{ __( 'Something went wrong.', '__i18n_text_domain__' ) }{ ' ' }
+				<Button
+					className="agent-manager-support-guides__retry"
+					variant="link"
+					onClick={ () => refetch() }
+				>
+					{ __( 'Try again', '__i18n_text_domain__' ) }
+				</Button>
+			</div>
+		);
+	}
+
+	if ( ! data?.length ) {
 		return (
 			<div className="agent-manager-support-guides__status">
 				{ __( 'No results found.', '__i18n_text_domain__' ) }
@@ -47,7 +67,7 @@ function SearchResults( { searchInput }: SearchResultsProps ) {
 
 	return (
 		<ItemGroup isSeparated isBordered isRounded>
-			{ searchData?.map( ( item ) => (
+			{ data?.map( ( item ) => (
 				<Item key={ item.post_id }>
 					<Link
 						to={ `/post?link=${ encodeURIComponent( item.link ) }` }
@@ -81,7 +101,7 @@ export default function SupportGuides( {
 	onAbort,
 	onClose,
 }: SupportGuidesProps ) {
-	const { state } = useLocation();
+	const { state } = useLocation() as { state?: { searchQuery?: string } };
 	const [ searchInput, setSearchInput, debouncedSearchInput ] = useDebouncedInput(
 		state?.searchQuery ?? ''
 	);

--- a/packages/agents-manager/src/components/support-guides/style.scss
+++ b/packages/agents-manager/src/components/support-guides/style.scss
@@ -5,7 +5,7 @@
 	height: calc( 100% - 32px );
 	padding: 16px;
 
-	.agent-manager-support-guides-no-results {
+	.agent-manager-support-guides__status {
 		text-align: center;
 		font-size: $font-size-small;
 		color: var( --color-muted-foreground );
@@ -27,11 +27,14 @@
 					color: var( --color-muted-foreground );
 				}
 			}
+
+			.components-input-control__suffix .components-button {
+				color: var( --color-muted-foreground );
+			}
 		}
 
 		.components-input-base {
 			border-radius: 16px;
-			color: var( --color-foreground );
 		}
 
 		.components-input-control__backdrop {
@@ -46,10 +49,8 @@
 	.components-item-group {
 		border-radius: 16px;
 		border-color: var( --color-muted );
-
-		div[role='listitem'] + div[role='listitem'] {
-			border-top: 1px solid var( --color-muted );
-		}
+		max-height: 85%;
+		overflow-y: auto;
 
 		div[role='listitem'] {
 			box-sizing: border-box;
@@ -70,16 +71,6 @@
 					display: block;
 				}
 			}
-
-			&:first-child .components-item {
-				border-top-left-radius: 16px;
-				border-top-right-radius: 16px;
-			}
-
-			&:last-child .components-item {
-				border-bottom-left-radius: 16px;
-				border-bottom-right-radius: 16px;
-			}
 		}
 	}
 }
@@ -89,5 +80,9 @@
 	.agent-manager-support-guides-wrapper {
 		padding-left: 0;
 		padding-right: 0;
+	}
+
+	.components-item-group div[role='listitem'] + div[role='listitem'] {
+		border-top: 1px solid var( --color-muted );
 	}
 }

--- a/packages/agents-manager/src/components/support-guides/style.scss
+++ b/packages/agents-manager/src/components/support-guides/style.scss
@@ -10,6 +10,10 @@
 		font-size: $font-size-small;
 		color: var( --color-muted-foreground );
 		padding: 16px;
+
+		.agent-manager-support-guides__retry {
+			font-size: inherit;
+		}
 	}
 
 	.components-search-control {

--- a/packages/agents-manager/src/hooks/use-help-search-query.ts
+++ b/packages/agents-manager/src/hooks/use-help-search-query.ts
@@ -48,8 +48,10 @@ const fetchArticlesAPI = async (
 				path: `/help-center/search?${ queryString }`,
 		  } as ApiFetchOptions );
 
+	const results = Array.isArray( searchResults ) ? searchResults : [];
+
 	// Record TrainTracks render events
-	searchResults.forEach( ( result, index ) => {
+	results.forEach( ( result, index ) => {
 		if ( result.railcar ) {
 			queueMicrotask( () => {
 				recordTracksEvent( 'calypso_agents_manager_search_traintracks_render', {
@@ -61,7 +63,7 @@ const fetchArticlesAPI = async (
 		}
 	} );
 
-	return searchResults;
+	return results;
 };
 
 export default function useHelpSearchQuery(

--- a/packages/agents-manager/src/hooks/use-help-search-query.ts
+++ b/packages/agents-manager/src/hooks/use-help-search-query.ts
@@ -1,0 +1,81 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { useQuery } from '@tanstack/react-query';
+import apiFetch from '@wordpress/api-fetch';
+import { buildQueryString } from '@wordpress/url';
+import { getLocaleSlug } from 'i18n-calypso';
+import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+import { useAgentsManagerContext } from '../contexts';
+
+type ApiFetchOptions = Parameters< typeof apiFetch >[ 0 ] & { global?: boolean };
+
+interface HelpSearchRailcar {
+	railcar?: string;
+	fetch_algo?: string;
+	fetch_lang?: string;
+	fetch_position?: string;
+	fetch_query?: string;
+	rec_post_id?: number;
+	rec_blog_id?: number;
+	session_id?: string;
+}
+
+interface HelpSearchResult {
+	railcar: HelpSearchRailcar;
+	link: string;
+	title: string;
+	content?: string;
+	icon?: string;
+	post_id?: number;
+	blog_id?: number;
+	source?: string;
+}
+
+const fetchArticlesAPI = async (
+	search: string,
+	locale: string,
+	sectionName: string
+): Promise< HelpSearchResult[] > => {
+	const queryString = buildQueryString( { query: search, locale, section: sectionName } );
+
+	// TODO: Use agents-manager API endpoint instead of help-center endpoint.
+	const searchResults = canAccessWpcomApis()
+		? ( ( await wpcomRequest( {
+				path: `/help/search?${ queryString }`,
+				apiNamespace: 'wpcom/v2',
+		  } ) ) as HelpSearchResult[] )
+		: await apiFetch< HelpSearchResult[] >( {
+				global: true,
+				path: `/help-center/search?${ queryString }`,
+		  } as ApiFetchOptions );
+
+	// Record TrainTracks render events
+	searchResults.forEach( ( result, index ) => {
+		if ( result.railcar ) {
+			queueMicrotask( () => {
+				recordTracksEvent( 'calypso_agents_manager_search_traintracks_render', {
+					...result.railcar,
+					ui_algo: 'default',
+					ui_position: index,
+				} );
+			} );
+		}
+	} );
+
+	return searchResults;
+};
+
+export default function useHelpSearchQuery(
+	search: string,
+	queryOptions: Record< string, unknown > = {}
+) {
+	const locale = getLocaleSlug() ?? 'en';
+	const { sectionName } = useAgentsManagerContext();
+
+	return useQuery( {
+		queryKey: [ 'agents-manager-help-search', search, locale, sectionName ],
+		queryFn: () => fetchArticlesAPI( search, locale, sectionName ),
+		refetchOnWindowFocus: false,
+		enabled: !! search,
+		...queryOptions,
+	} );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -170,6 +170,7 @@ __metadata:
     "@wordpress/icons": "npm:^10.23.0"
     "@wordpress/primitives": "npm:^4.23.0"
     "@wordpress/private-apis": "npm:^1.39.0"
+    "@wordpress/url": "npm:^4.23.0"
     clsx: "npm:^2.1.1"
     history: "npm:^5.3.0"
     i18n-calypso: "workspace:^"


### PR DESCRIPTION
Part of AI-873

## Proposed Changes

- Implement `useHelpSearchQuery` hook to replace the stub, using the WPcom/apiFetch dual-endpoint pattern
- Add debounced search, error handling with retry, and search query persistence across navigation
- Improve back navigation in support-guide to handle support-guides route
- Add support guides menu option to chat header (for testing, remove before release)

## Why are these changes being made?

The support guides search was stubbed out when `@automattic/help-center` was decoupled. This implements actual search functionality so users can search and browse help articles from the agents manager.

## Testing Instructions

1. Check out this PR
2. Run `yarn start`
3. Go to `http://calypso.localhost:3000/me`
4. Select the "Support guides" from the header options, and test the search function; it should work as expected:

https://github.com/user-attachments/assets/7e37ef3c-4ccc-4fba-a2f4-d9ff7663e882

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)