### PR TITLE
Dashboard: Update sidebar sub-menu item styling

### DIFF
--- a/client/dashboard/app-dotcom/logo.tsx
+++ b/client/dashboard/app-dotcom/logo.tsx
@@ -22,8 +22,8 @@ function ClassicLogo() {
 	return (
 		<svg
 			style={ { display: 'block' } }
-			width="153"
-			height="24"
+			width="170"
+			height="27"
 			viewBox="0 0 153 24"
 			fill="none"
 			xmlns="http://www.w3.org/2000/svg"

--- a/client/dashboard/app-dotcom/style.scss
+++ b/client/dashboard/app-dotcom/style.scss
@@ -39,7 +39,7 @@
 	--dashboard-secondary-menu-item__color: #{$gray-900};
 
 	// Headings
-	--dashboard-h1__font-size: 40px;
+	--dashboard-h1__font-size: 32px;
 	--dashboard-h1__font-weight: 400;
 	--dashboard-h1__line-height: normal;
 	--dashboard-h1__font-family: Recoleta, sans-serif;

--- a/client/dashboard/app/responsive-sidebar/sidebar.scss
+++ b/client/dashboard/app/responsive-sidebar/sidebar.scss
@@ -25,6 +25,6 @@
 }
 
 .dashboard-responsive-sidebar__logo {
-	padding: 14px $grid-unit-30 + 2px;
+	padding: $grid-unit-20 $grid-unit-30 + 2px;
 	border-block-end: 1px solid var( --dashboard-header__border-color );
 }

--- a/client/dashboard/app/responsive-sidebar/sidebar.scss
+++ b/client/dashboard/app/responsive-sidebar/sidebar.scss
@@ -27,4 +27,9 @@
 .dashboard-responsive-sidebar__logo {
 	padding: $grid-unit-20 $grid-unit-30 + 2px;
 	border-block-end: 1px solid var( --dashboard-header__border-color );
+
+	.components-button svg {
+		width: 170px;
+		height: 27px;
+	}
 }

--- a/client/dashboard/app/responsive-sidebar/sidebar.scss
+++ b/client/dashboard/app/responsive-sidebar/sidebar.scss
@@ -25,7 +25,7 @@
 }
 
 .dashboard-responsive-sidebar__logo {
-	padding: $grid-unit-20 $grid-unit-30 + 2px $grid-unit-20 + 1px;
+	padding: $grid-unit-20 $grid-unit-30 + 2px $grid-unit-20 + 2px;
 	border-block-end: 1px solid var( --dashboard-header__border-color );
 
 	.components-button svg {

--- a/client/dashboard/app/responsive-sidebar/sidebar.scss
+++ b/client/dashboard/app/responsive-sidebar/sidebar.scss
@@ -25,7 +25,7 @@
 }
 
 .dashboard-responsive-sidebar__logo {
-	padding: $grid-unit-20 $grid-unit-30 + 2px;
+	padding: $grid-unit-20 $grid-unit-30 + 2px $grid-unit-20 + 1px;
 	border-block-end: 1px solid var( --dashboard-header__border-color );
 
 	.components-button svg {

--- a/client/dashboard/app/responsive-sidebar/sidebar.tsx
+++ b/client/dashboard/app/responsive-sidebar/sidebar.tsx
@@ -1,7 +1,6 @@
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { brush, envelope, globe, layout, plugins } from '@wordpress/icons';
-import { menuDot } from '../../components/icons';
 import RouterLinkButton from '../../components/router-link-button';
 import { SidebarExpandableMenuItem, SidebarMenu, SidebarMenuItem } from '../../components/sidebar';
 import SidebarNavigator from '../../components/sidebar-navigator';
@@ -73,14 +72,11 @@ function PrimaryMenuSidebar() {
 			) }
 			{ supports.plugins && (
 				<SidebarExpandableMenuItem label={ __( 'Plugins' ) } icon={ plugins } to="/plugins">
-					<SidebarMenuItem icon={ menuDot } to="/plugins/manage">
-						{ __( 'Manage plugins' ) }
-					</SidebarMenuItem>
-					<SidebarMenuItem icon={ menuDot } to="/plugins/scheduled-updates">
+					<SidebarMenuItem to="/plugins/manage">{ __( 'Manage plugins' ) }</SidebarMenuItem>
+					<SidebarMenuItem to="/plugins/scheduled-updates">
 						{ __( 'Scheduled updates' ) }
 					</SidebarMenuItem>
 					<SidebarMenuItem
-						icon={ menuDot }
 						href={ wpcomLink( '/plugins' ) }
 						target="_blank"
 						rel="noopener noreferrer"

--- a/client/dashboard/components/page-layout/index.tsx
+++ b/client/dashboard/components/page-layout/index.tsx
@@ -20,7 +20,7 @@ function PageLayout( {
 } ) {
 	return (
 		<VStack
-			spacing={ 8 }
+			spacing={ 5 }
 			className={ `dashboard-page-layout is-${ size }` }
 			style={ PAGE_LAYOUT_SIZES[ size ] as CSSProperties }
 		>

--- a/client/dashboard/components/page-layout/index.tsx
+++ b/client/dashboard/components/page-layout/index.tsx
@@ -20,7 +20,7 @@ function PageLayout( {
 } ) {
 	return (
 		<VStack
-			spacing={ 5 }
+			spacing={ 3 }
 			className={ `dashboard-page-layout is-${ size }` }
 			style={ PAGE_LAYOUT_SIZES[ size ] as CSSProperties }
 		>

--- a/client/dashboard/components/page-layout/style.scss
+++ b/client/dashboard/components/page-layout/style.scss
@@ -7,7 +7,7 @@
 	--page-layout-inline-padding: #{$grid-unit-20};
 
 	@include break-medium {
-		--page-layout-block-padding: #{$grid-unit-40};
+		--page-layout-block-padding: #{$grid-unit-20};
 		--page-layout-inline-padding: #{$grid-unit-30};
 	}
 

--- a/client/dashboard/components/sidebar/sidebar-expandable-menu-item.scss
+++ b/client/dashboard/components/sidebar/sidebar-expandable-menu-item.scss
@@ -20,5 +20,6 @@
 
 	.dashboard-sidebar__menu-item {
 		min-block-size: 32px;
+		padding-inline-start: calc( 20px + 8px );
 	}
 }

--- a/client/dashboard/components/sidebar/sidebar-expandable-menu-item.scss
+++ b/client/dashboard/components/sidebar/sidebar-expandable-menu-item.scss
@@ -19,7 +19,6 @@
 	}
 
 	.dashboard-sidebar__menu-item {
-		min-block-size: 32px;
 		padding-inline-start: calc( 12px + 20px + 8px );
 	}
 }

--- a/client/dashboard/components/sidebar/sidebar-expandable-menu-item.scss
+++ b/client/dashboard/components/sidebar/sidebar-expandable-menu-item.scss
@@ -20,6 +20,6 @@
 
 	.dashboard-sidebar__menu-item {
 		min-block-size: 32px;
-		padding-inline-start: calc( 20px + 8px );
+		padding-inline-start: calc( 12px + 20px + 8px );
 	}
 }

--- a/client/dashboard/components/sidebar/sidebar-expandable-menu-item.scss
+++ b/client/dashboard/components/sidebar/sidebar-expandable-menu-item.scss
@@ -17,4 +17,8 @@
 		overflow: clip;
 		overflow-clip-margin: 2px;
 	}
+
+	.dashboard-sidebar__menu-item {
+		min-block-size: 32px;
+	}
 }

--- a/client/dashboard/components/sidebar/sidebar-menu-item.scss
+++ b/client/dashboard/components/sidebar/sidebar-menu-item.scss
@@ -14,7 +14,7 @@
 		color: var( --wp-admin-theme-color );
 
 		&:hover {
-			background: transparent;
+			background: color-mix( in srgb, var( --wp-admin-theme-color ) 8%, transparent );
 		}
 	}
 }

--- a/client/dashboard/components/sidebar/sidebar-menu-item.scss
+++ b/client/dashboard/components/sidebar/sidebar-menu-item.scss
@@ -12,5 +12,9 @@
 	&.active {
 		background: color-mix( in srgb, var( --wp-admin-theme-color ) 8%, transparent );
 		color: var( --wp-admin-theme-color );
+
+		&:hover {
+			background: transparent;
+		}
 	}
 }

--- a/client/dashboard/sites/site-sidebar/index.tsx
+++ b/client/dashboard/sites/site-sidebar/index.tsx
@@ -27,7 +27,6 @@ import {
 	siteDomainsRoute,
 	siteSettingsRoute,
 } from '../../app/router/sites';
-import { menuDot } from '../../components/icons';
 import {
 	SidebarBackButton,
 	SidebarExpandableMenuItem,
@@ -139,13 +138,13 @@ function SiteMenuSidebar( { site }: { site: Site } ) {
 					icon={ formatListBullets }
 					to={ `/sites/${ siteSlug }/logs` }
 				>
-					<SidebarMenuItem icon={ menuDot } to={ `/sites/${ siteSlug }/logs/activity` }>
+					<SidebarMenuItem to={ `/sites/${ siteSlug }/logs/activity` }>
 						{ __( 'Activity' ) }
 					</SidebarMenuItem>
-					<SidebarMenuItem icon={ menuDot } to={ `/sites/${ siteSlug }/logs/php` }>
+					<SidebarMenuItem to={ `/sites/${ siteSlug }/logs/php` }>
 						{ __( 'PHP errors' ) }
 					</SidebarMenuItem>
-					<SidebarMenuItem icon={ menuDot } to={ `/sites/${ siteSlug }/logs/server` }>
+					<SidebarMenuItem to={ `/sites/${ siteSlug }/logs/server` }>
 						{ __( 'Web server' ) }
 					</SidebarMenuItem>
 				</SidebarExpandableMenuItem>
@@ -158,10 +157,10 @@ function SiteMenuSidebar( { site }: { site: Site } ) {
 						icon={ shield }
 						to={ `/sites/${ siteSlug }/scan` }
 					>
-						<SidebarMenuItem icon={ menuDot } to={ `/sites/${ siteSlug }/scan/active` }>
+						<SidebarMenuItem to={ `/sites/${ siteSlug }/scan/active` }>
 							{ __( 'Active threats' ) }
 						</SidebarMenuItem>
-						<SidebarMenuItem icon={ menuDot } to={ `/sites/${ siteSlug }/scan/history` }>
+						<SidebarMenuItem to={ `/sites/${ siteSlug }/scan/history` }>
 							{ __( 'History' ) }
 						</SidebarMenuItem>
 					</SidebarExpandableMenuItem>


### PR DESCRIPTION
## Proposed Changes

* Remove bullet dot icons from sidebar sub-menu items in all expandable sections (Plugins, Logs, Scan)
* Align sub-menu item text with parent item labels
* Preserve the active item background color on hover instead of showing the default button hover background

## Why are these changes being made?

The sidebar sub-menu items appear visually cluttered with the bullet dots. This update removes the dots, aligns the sub-item text with the parent menu item labels for a cleaner look, and fixes the hover state on active items to keep the selected background color consistent.

## Testing Instructions

1. Navigate to the Multi-site Dashboard at `/plugins/manage`
2. Verify the Plugins expandable menu items no longer show gray bullet dots
3. Verify the sub-item text ("Manage plugins", "Scheduled updates", "Browse plugins") aligns with the parent item text ("Plugins")
4. Navigate to a site page (`/sites/<siteslug>`) and expand the Logs and Scan sections
5. Verify those sub-items also have no dots and text is aligned
6. Hover over the currently active/selected sidebar item and verify the background color stays the same (light blue) — it should not change on hover

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] Have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?