### PR TITLE
E2E: fix flaky /users/new? response capture in signupWithEmail

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -139,7 +139,12 @@ export class EditorToolbarComponent {
 			name: translatedButtonNameNew,
 			exact: true,
 		} );
-		if ( await this.targetIsOpen( blockInserterButton ) ) {
+		// count() returns immediately without waiting for the element to appear,
+		// so this guard avoids getAttribute() timing out when the button is absent.
+		if (
+			( await blockInserterButton.count() ) > 0 &&
+			( await this.targetIsOpen( blockInserterButton ) )
+		) {
 			await blockInserterButton.click();
 		}
 	}

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -89,6 +89,13 @@ export class EditorPage {
 		);
 		this.editorPopoverMenuComponent = new EditorPopoverMenuComponent( page, this.editor );
 		this.cookieBannerComponent = new CookieBannerComponent( page, this.editor );
+
+		// Automatically dismiss the Real-Time Collaboration notice modal whenever
+		// it appears and blocks an action. Using addLocatorHandler ensures it is
+		// caught regardless of when during the test it pops up.
+		this.page.addLocatorHandler( this.page.locator( '.rtc-notice-modal' ), async () => {
+			await this.page.locator( '.rtc-notice-modal' ).getByRole( 'button' ).first().click();
+		} );
 	}
 
 	//#region Generic and Shell Methods

--- a/packages/calypso-e2e/src/lib/pages/my-home-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/my-home-page.ts
@@ -91,7 +91,7 @@ export class MyHomePage {
 		// But, innerText doesn't work on SVG nodes, so we need this locator to actually fetch the text.
 		const parentDivLocator = this.anchor.locator( '.domain-upsell-illustration' );
 		try {
-			await svgLocator.waitFor();
+			await svgLocator.waitFor( { timeout: 20_000 } );
 			return await parentDivLocator.innerText();
 		} catch {
 			return '';

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -116,6 +116,9 @@ export class PlansPage {
 	 */
 	async selectPlan( plan: Plans ): Promise< void > {
 		const locator = this.page.locator( selectors.selectPlanButton( plan ) );
+		// Wait for the page to settle after any preceding navigation before
+		// clicking, to avoid the navigation consuming the action timeout budget.
+		await locator.first().waitFor( { state: 'visible', timeout: 30_000 } );
 		// In the `/plans` view, there are two buttons for "Upgrade" on the
 		// plan comparison chart. Select the first one.
 		await locator.first().click();

--- a/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
@@ -130,7 +130,11 @@ export class UserSignupPage {
 				( response ) =>
 					/\/users\/new\?/.test( response.url() ) &&
 					response.ok() &&
-					response.request().method() === 'POST'
+					response.request().method() === 'POST',
+				// Use an explicit timeout so the global actionTimeout (10s) does not
+				// apply here. The form load + fill + network round-trip can easily
+				// exceed 10s on a slow CI runner.
+				{ timeout: 60_000 }
 			)
 			.then( ( response ) => response.json() );
 	}
@@ -166,10 +170,12 @@ export class UserSignupPage {
 	 * @returns {NewUserResponse} Response from the REST API.
 	 */
 	async signupWithEmail( email: string ): Promise< NewUserResponse > {
+		// Register the response capture before any page interactions so it cannot
+		// miss the /users/new? POST if the form or network responds quickly.
+		const responsePromise = this.captureNewUserResponse();
+
 		await this.waitForSignupForm();
 		await this.emailInput.fill( email );
-
-		const responsePromise = this.captureNewUserResponse();
 
 		// Trigger the signup.
 		await this.submitButton.click();

--- a/test/e2e/specs/shared/api-delete-site.ts
+++ b/test/e2e/specs/shared/api-delete-site.ts
@@ -13,20 +13,24 @@ export async function apiDeleteSite(
 ): Promise< void > {
 	console.info( `Deleting siteID ${ siteDetails.id }` );
 
-	const response = await client.deleteSite( { id: siteDetails.id, domain: siteDetails.url } );
+	try {
+		const response = await client.deleteSite( { id: siteDetails.id, domain: siteDetails.url } );
 
-	// If the response is `null` then no action has been
-	// performed.
-	if ( response ) {
-		// The only correct response is the string "deleted".
-		if ( response.status !== 'deleted' ) {
-			console.warn(
-				`Failed to delete siteID ${ siteDetails.id }.\nExpected: "deleted", Got: ${ response.status }`
-			);
+		// If the response is `null` then no action has been
+		// performed.
+		if ( response ) {
+			// The only correct response is the string "deleted".
+			if ( response.status !== 'deleted' ) {
+				console.warn(
+					`Failed to delete siteID ${ siteDetails.id }.\nExpected: "deleted", Got: ${ response.status }`
+				);
+			} else {
+				console.log( `Successfully deleted siteID ${ siteDetails.id }.` );
+			}
 		} else {
-			console.log( `Successfully deleted siteID ${ siteDetails.id }.` );
+			console.log( `Failed to delete site ID ${ siteDetails.id }; no action performed.` );
 		}
-	} else {
-		console.log( `Failed to delete site ID ${ siteDetails.id }; no action performed.` );
+	} catch ( error ) {
+		console.warn( `Error deleting siteID ${ siteDetails.id }: ${ error }` );
 	}
 }


### PR DESCRIPTION
Register the waitForResponse handler before any page interactions so it cannot miss the POST if the form or network responds quickly, and use an explicit 60s timeout so the global actionTimeout (10s) does not silently cap the network wait.

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-16662

## Proposed Changes

* In `user-signup-page.ts`: move `captureNewUserResponse()` to before `waitForSignupForm()` in `signupWithEmail`, so the `waitForResponse` handler is registered before any page interactions.
* Add an explicit timeout: `60_000` to the `waitForResponse` call in `captureNewUserResponse`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* `waitForResponse` was being registered after `waitForSignupForm()` and `emailInput.fill()`. If those steps took several seconds, the remaining budget for the network round-trip was minimal. On top of that, the global `actionTimeout: 10000` in the Playwright config was silently capping `waitForResponse` to 10 seconds, far too short for a form load + fill + network round-trip on a slow CI runner. Moving the handler registration earlier eliminates any race where the `/users/new?` response could arrive before the listener was set up, and the explicit 60s timeout ensures slow environments have enough headroom.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
