### PR TITLE
Update the highlight pabels on onboarding-pm

### DIFF
--- a/packages/plans-grid-next/src/hooks/data-store/types.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/types.ts
@@ -59,7 +59,7 @@ export interface UseGridPlansParams {
 	 */
 	useFocusedNewCopyTaglines?: boolean;
 	/**
-	 * When true, the user is in an experiment variant (not control).
+	 * When true, use experiment-variant feature lists and comparison grid copy.
 	 */
 	isExperimentVariant?: boolean;
 }

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-comparison-grid.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-comparison-grid.ts
@@ -53,7 +53,6 @@ const useGridPlansForComparisonGrid = ( {
 		isDomainOnlySite,
 		reflectStorageSelectionInPlanPrices,
 		useFocusedNewCopyTaglines,
-		isExperimentVariant,
 	} );
 
 	const planFeaturesForComparisonGrid = useRestructuredPlanFeaturesForComparisonGrid( {

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-features-grid.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-features-grid.ts
@@ -52,7 +52,6 @@ const useGridPlansForFeaturesGrid = ( {
 		isDomainOnlySite,
 		reflectStorageSelectionInPlanPrices,
 		useFocusedNewCopyTaglines,
-		isExperimentVariant,
 	} );
 
 	const planFeaturesForFeaturesGrid = usePlanFeaturesForGridPlans( {

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -312,7 +312,6 @@ const useGridPlans: UseGridPlansType = ( {
 	isDomainOnlySite,
 	reflectStorageSelectionInPlanPrices,
 	useFocusedNewCopyTaglines,
-	isExperimentVariant,
 } ) => {
 	const translate = useTranslate();
 	const freeTrialPlanSlugs = useFreeTrialPlanSlugs?.( {
@@ -360,7 +359,6 @@ const useGridPlans: UseGridPlansType = ( {
 		plansAvailabilityForPurchase,
 		highlightLabelOverrides,
 		isDomainOnlySite: isDomainOnlySite || false,
-		isExperimentVariant,
 	} );
 
 	const titleBadges = useTitleBadges( {

--- a/packages/plans-grid-next/src/hooks/data-store/use-highlight-labels.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-highlight-labels.ts
@@ -21,10 +21,6 @@ interface Props {
 	};
 	highlightLabelOverrides?: { [ K in PlanSlug ]?: TranslateResult };
 	isDomainOnlySite: boolean;
-	/**
-	 * When true (pricing differentiators experiment eligible), use treatment copy for grid badges.
-	 */
-	isExperimentVariant?: boolean;
 }
 
 // TODO clk: move to plans data store
@@ -36,7 +32,6 @@ const useHighlightLabels = ( {
 	plansAvailabilityForPurchase,
 	highlightLabelOverrides,
 	isDomainOnlySite,
-	isExperimentVariant,
 }: Props ) => {
 	const translate = useTranslate();
 	const isVisualSplitIntent =
@@ -80,9 +75,9 @@ const useHighlightLabels = ( {
 			} else if ( 'plans-affiliate' === intent && isBusinessPlan( planSlug ) ) {
 				label = translate( 'Popular' );
 			} else if ( isBusinessPlan( planSlug ) && ! selectedPlan && ! isVisualSplitIntent ) {
-				label = isExperimentVariant ? translate( 'Best value' ) : translate( 'Best for devs' );
+				label = translate( 'Best value' );
 			} else if ( isPopularPlan( planSlug ) && ! selectedPlan && ! isVisualSplitIntent ) {
-				label = isExperimentVariant ? translate( 'Most popular' ) : translate( 'Popular' );
+				label = translate( 'Most popular' );
 			}
 
 			return {


### PR DESCRIPTION


Part of M4R73CH-1833

## Proposed Changes

* @michaelostromooukhov  requested a broader update of the plan highlights

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

* Visit /start/onboarding-pm
* Ensure the new highlights are visible (Most popular, Best value)
* Visit /setup/onboarding
* Ensure plans step has no errors

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
