### PR TITLE
Masterbar Item: Do not pass component-specific prop to HTML elements

### DIFF
--- a/client/layout/masterbar/item.tsx
+++ b/client/layout/masterbar/item.tsx
@@ -3,7 +3,15 @@ import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import React, { Component, Fragment, forwardRef } from 'react';
 import { navigate } from 'calypso/lib/navigate';
-import type { ReactNode, LegacyRef } from 'react';
+import type {
+	ComponentPropsWithoutRef,
+	ElementRef,
+	ElementType,
+	ForwardedRef,
+	LegacyRef,
+	ReactElement,
+	ReactNode,
+} from 'react';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};
@@ -14,9 +22,9 @@ interface MasterbarSubItemProps {
 	onClick?: () => void;
 	className?: string;
 }
-interface MasterbarItemProps {
+
+type MasterbarItemOwnProps = {
 	url?: string;
-	innerRef?: LegacyRef< HTMLButtonElement | HTMLAnchorElement >;
 	tipTarget?: string;
 	onClick?: () => void;
 	tooltip?: string;
@@ -31,14 +39,24 @@ interface MasterbarItemProps {
 	disabled?: boolean;
 	subItems?: Array< Array< MasterbarSubItemProps > >;
 	hasGlobalBorderStyle?: boolean;
-	as?: React.ComponentType;
-	variant?: string;
 	ariaLabel?: string;
 	openSubMenuOnClick?: boolean;
-	isBusy?: boolean;
-}
+};
 
-class MasterbarItem extends Component< MasterbarItemProps > {
+/** Props accepted by the default `<button>` / `<a>` implementation (no custom `as`). */
+export type MasterbarItemProps< C extends ElementType | undefined = undefined > =
+	MasterbarItemOwnProps &
+		( C extends ElementType
+			? { as: C; asProps?: ComponentPropsWithoutRef< C > }
+			: { as?: undefined; asProps?: never } );
+
+type MasterbarItemWithInnerRef = MasterbarItemOwnProps & {
+	innerRef?: LegacyRef< HTMLButtonElement | HTMLAnchorElement >;
+	as?: ElementType;
+	asProps?: Record< string, unknown >;
+};
+
+class MasterbarItem extends Component< MasterbarItemWithInnerRef > {
 	static propTypes = {
 		url: PropTypes.string,
 		tipTarget: PropTypes.string,
@@ -53,9 +71,9 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 		subItems: PropTypes.array,
 		hasGlobalBorderStyle: PropTypes.bool,
 		as: PropTypes.elementType,
-		variant: PropTypes.string,
 		ariaLabel: PropTypes.string,
 		openSubMenuOnClick: PropTypes.bool,
+		asProps: PropTypes.object,
 	};
 
 	static defaultProps = {
@@ -63,6 +81,7 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 		onClick: noop,
 		hasUnseen: false,
 		url: '',
+		asProps: {},
 	};
 
 	state = {
@@ -245,8 +264,9 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 			onMouseEnter: this.preload,
 			disabled: this.props.disabled,
 			'aria-label': this.props.ariaLabel,
-			isBusy: this.props.isBusy,
 		};
+
+		const asProps = this.props.as ? this.props.asProps : {};
 
 		return (
 			<div
@@ -255,10 +275,10 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 			>
 				<MenuItem
 					as={ this.props.as }
-					variant={ this.props.variant }
 					url={ this.props.url }
 					innerRef={ this.props.innerRef }
 					{ ...attributes }
+					{ ...asProps }
 					onKeyDown={ this.props.subItems && this.toggleMenuByKey }
 					onTouchEnd={ this.props.subItems && this.toggleMenuByTouch }
 				>
@@ -270,19 +290,32 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 	}
 }
 
-// eslint-disable-next-line react/display-name
-export default forwardRef< HTMLButtonElement | HTMLAnchorElement, MasterbarItemProps >(
-	( props, ref ) => <MasterbarItem innerRef={ ref } { ...props } />
-);
+interface MasterbarItemComponent {
+	< C extends ElementType >(
+		props: MasterbarItemProps< C > & { ref?: ForwardedRef< ElementRef< C > > }
+	): ReactElement | null;
+	(
+		props: MasterbarItemProps< undefined > & {
+			ref?: ForwardedRef< HTMLButtonElement | HTMLAnchorElement >;
+		}
+	): ReactElement | null;
+}
 
-type MenuItemProps< R > = {
+// eslint-disable-next-line react/display-name
+const MasterbarItemWithForwardedRef = forwardRef<
+	HTMLButtonElement | HTMLAnchorElement,
+	MasterbarItemWithInnerRef
+>( ( props, ref ) => <MasterbarItem innerRef={ ref } { ...props } /> );
+
+export default MasterbarItemWithForwardedRef as unknown as MasterbarItemComponent;
+
+type MenuItemProps = {
 	url?: string;
-	innerRef?: R;
-	as?: React.ComponentType;
-	variant?: string;
+	innerRef?: LegacyRef< HTMLButtonElement | HTMLAnchorElement >;
+	as?: ElementType;
 } & React.HTMLAttributes< HTMLElement >;
 
-function MenuItem< R >( { url, innerRef, as: Component, ...props }: MenuItemProps< R > ) {
+function MenuItem( { url, innerRef, as: Component, ...props }: MenuItemProps ) {
 	if ( Component ) {
 		return (
 			<Component

--- a/client/layout/masterbar/masterbar-launch-button.tsx
+++ b/client/layout/masterbar/masterbar-launch-button.tsx
@@ -50,9 +50,11 @@ export const MasterbarLaunchButton = ( { siteId }: { siteId: number } ) => {
 	return (
 		<Item
 			as={ Button }
-			variant="primary"
+			asProps={ {
+				variant: 'primary',
+				isBusy: launchSiteMutation.isPending,
+			} }
 			disabled={ isLoading || launchSiteMutation.isPending }
-			isBusy={ launchSiteMutation.isPending }
 			// Keep the Launch button always in blueberry (default scheme: modern) like in wp-admin.
 			className={ clsx( 'masterbar__item-launch-site', 'color-scheme', 'is-global' ) }
 			icon={

--- a/packages/domain-search/src/components/unavailable-search-result/test/index.tsx
+++ b/packages/domain-search/src/components/unavailable-search-result/test/index.tsx
@@ -279,6 +279,11 @@ describe( 'UnavailableSearchResult', () => {
 
 				await waitFor( () => expect( availabilityQuery.isDone() ).toBe( true ) );
 
+				const loadingElement = screen.queryByText( 'LOADING_TEST_CONTENT' );
+				if ( loadingElement ) {
+					await waitForElementToBeRemoved( loadingElement );
+				}
+
 				expect( container ).toBeEmptyDOMElement();
 			}
 		);


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/pull/109896#discussion_r3061592622.

## Proposed Changes

Adds an extra `asProps` prop that is only filled if the user is passing a custom component through the `as` prop.

## Testing Instructions

Enter `/home/%s` where `%s` is a site that has never been launched.

- Verify you don't see the console warning anymore.
- Verify you see the launch button.
- Verify you can click the launch button and the loading state still applies.