### PR TITLE
Dashboard: Enable WP beta activation for Simple Business+ sites

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -47,9 +47,9 @@ import { createLazyRoute, createRoute, lazyRouteComponent, notFound } from '@tan
 import { __ } from '@wordpress/i18n';
 import {
 	canManageSite,
+	canSwitchWordPressVersion,
 	canTransferSite,
 	canViewHundredYearPlanSettings,
-	canViewWordPressSettings,
 } from '../../sites/features';
 import { shouldLoadWpVersionNotice } from '../../sites/overview/wp-version-notice';
 import {
@@ -863,7 +863,7 @@ export const siteSettingsWordPressRoute = createRoute( {
 	path: 'wordpress',
 	loader: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		if ( canViewWordPressSettings( site ) ) {
+		if ( canSwitchWordPressVersion( site ) ) {
 			await queryClient.ensureQueryData( siteWordPressVersionQuery( site.ID ) );
 		}
 	},

--- a/client/dashboard/sites/features.ts
+++ b/client/dashboard/sites/features.ts
@@ -43,9 +43,13 @@ export function canViewHundredYearPlanSettings( site: Site ) {
 
 export function canViewWordPressSettings( site: Site ) {
 	if ( isEnabled( 'dashboard/wp-beta-program' ) ) {
-		return hasHostingFeature( site, HostingFeatures.BACKUPS_SELF_SERVE );
+		return hasPlanFeature( site, HostingFeatures.BACKUPS_SELF_SERVE );
 	}
 	return site.is_wpcom_staging_site;
+}
+
+export function canSwitchWordPressVersion( site: Site ) {
+	return hasHostingFeature( site, HostingFeatures.BACKUPS_SELF_SERVE );
 }
 
 // Settings -> Actions & danger zone

--- a/client/dashboard/sites/overview/wp-version-notice.tsx
+++ b/client/dashboard/sites/overview/wp-version-notice.tsx
@@ -8,13 +8,13 @@ import { useQuery, useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { __, sprintf } from '@wordpress/i18n';
 import Notice from '../../components/notice';
 import RouterLinkButton from '../../components/router-link-button';
-import { canViewWordPressSettings } from '../features';
+import { canSwitchWordPressVersion } from '../features';
 import type { Site, UserPreferences } from '@automattic/api-core';
 
 const PREFERENCE_KEY = 'hosting-dashboard-wp-beta-notice-dismissed' as const;
 
 export function shouldLoadWpVersionNotice( site: Site, preferences: UserPreferences ) {
-	const canView = canViewWordPressSettings( site ) && ! site.is_wpcom_staging_site;
+	const canView = canSwitchWordPressVersion( site ) && ! site.is_wpcom_staging_site;
 	const isDismissed = preferences[ `${ PREFERENCE_KEY }-${ site.ID }` ];
 
 	return canView && ! isDismissed;

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -1,3 +1,4 @@
+import { HostingFeatures } from '@automattic/api-core';
 import {
 	siteBySlugQuery,
 	siteWordPressVersionQuery,
@@ -14,14 +15,15 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { getFormattedWordPressVersion } from '../../utils/wp-version';
 import { canViewWordPressSettings } from '../features';
+import HostingFeatureGatedWithCallout from '../hosting-feature-gated-with-callout';
 import { BetaProgramNotice } from './beta-program-notice';
 import { LatestVersionNotice } from './latest-version-notice';
 import { useVersionSwitch } from './use-version-switch';
 import { VersionForm } from './version-form';
 import { VersionSwitchNotice } from './version-switch-notice';
+import type { Site } from '@automattic/api-core';
 
-function WordPressSettingsForm( { siteSlug }: { siteSlug: string } ) {
-	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+function VersionManagement( { site }: { site: Site } ) {
 	const { data: currentVersion } = useQuery( siteWordPressVersionQuery( site.ID ) );
 	const versionSwitch = useVersionSwitch( site );
 	const { isSwitching, switchedToBeta, switchedToLatest, backupState, targetVersion } =
@@ -33,7 +35,6 @@ function WordPressSettingsForm( { siteSlug }: { siteSlug: string } ) {
 
 	let notice;
 	if ( isSwitching ) {
-		// Switching in progress — show backup/progress notices.
 		notice = (
 			<VersionSwitchNotice
 				backupState={ backupState }
@@ -41,75 +42,73 @@ function WordPressSettingsForm( { siteSlug }: { siteSlug: string } ) {
 			/>
 		);
 	} else if ( switchedToLatest ) {
-		// Just switched back to stable.
 		notice = <LatestVersionNotice wpVersion={ latestVersion } />;
 	} else if ( switchedToBeta || currentVersion === 'beta' ) {
-		// Enrolled in beta — show program notice.
 		notice = <BetaProgramNotice site={ site } wpVersion={ betaVersion } />;
 	}
 
 	return (
-		<PageLayout
-			size="small"
-			header={
-				<PageHeader
-					prefix={ <Breadcrumbs length={ 2 } /> }
-					title="WordPress"
-					description={ __( 'Manage your WordPress version.' ) }
-				/>
-			}
-			notices={ notice }
-		>
+		<VStack spacing={ 6 }>
+			{ notice }
 			<VersionForm
 				site={ site }
 				currentVersion={ currentVersion }
 				versionSwitch={ versionSwitch }
 			/>
-		</PageLayout>
+		</VStack>
 	);
 }
 
 export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 
-	if ( canViewWordPressSettings( site ) ) {
-		return <WordPressSettingsForm siteSlug={ siteSlug } />;
+	const header = (
+		<PageHeader
+			prefix={ <Breadcrumbs length={ 2 } /> }
+			title="WordPress"
+			description={ __( 'Manage your WordPress version.' ) }
+		/>
+	);
+
+	if ( ! canViewWordPressSettings( site ) ) {
+		return (
+			<PageLayout size="small" header={ header }>
+				<Notice>
+					<VStack>
+						<Text as="p">
+							{ sprintf(
+								// translators: %s: WordPress version, e.g. 6.8
+								__( 'Every WordPress.com site runs the latest WordPress version (%s).' ),
+								getFormattedWordPressVersion( site )
+							) }
+						</Text>
+						{ site.is_wpcom_atomic && (
+							<Text as="p">
+								{ createInterpolateElement(
+									__(
+										'Switch to a staging site to test a beta version of the next WordPress release. <learnMoreLink />'
+									),
+									{
+										learnMoreLink: <InlineSupportLink supportContext="switch-to-staging-site" />,
+									}
+								) }
+							</Text>
+						) }
+					</VStack>
+				</Notice>
+			</PageLayout>
+		);
 	}
 
 	return (
-		<PageLayout
-			size="small"
-			header={
-				<PageHeader
-					prefix={ <Breadcrumbs length={ 2 } /> }
-					title="WordPress"
-					description={ __( 'Manage your WordPress version.' ) }
-				/>
-			}
-		>
-			<Notice>
-				<VStack>
-					<Text as="p">
-						{ sprintf(
-							// translators: %s: WordPress version, e.g. 6.8
-							__( 'Every WordPress.com site runs the latest WordPress version (%s).' ),
-							getFormattedWordPressVersion( site )
-						) }
-					</Text>
-					{ site.is_wpcom_atomic && (
-						<Text as="p">
-							{ createInterpolateElement(
-								__(
-									'Switch to a staging site to test a beta version of the next WordPress release. <learnMoreLink />'
-								),
-								{
-									learnMoreLink: <InlineSupportLink supportContext="switch-to-staging-site" />,
-								}
-							) }
-						</Text>
-					) }
-				</VStack>
-			</Notice>
+		<PageLayout size="small" header={ header }>
+			<HostingFeatureGatedWithCallout
+				site={ site }
+				feature={ HostingFeatures.BACKUPS_SELF_SERVE }
+				upsellId="site-settings-wordpress"
+			>
+				<VersionManagement site={ site } />
+			</HostingFeatureGatedWithCallout>
 		</PageLayout>
 	);
 }

--- a/client/dashboard/sites/settings-wordpress/summary.tsx
+++ b/client/dashboard/sites/settings-wordpress/summary.tsx
@@ -4,7 +4,7 @@ import { Icon } from '@wordpress/components';
 import { wordpress } from '@wordpress/icons';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
 import { getFormattedWordPressVersion } from '../../utils/wp-version';
-import { canViewWordPressSettings } from '../features';
+import { canSwitchWordPressVersion } from '../features';
 import type { Site } from '@automattic/api-core';
 import type { Density } from '@automattic/components/src/summary-button/types';
 
@@ -17,7 +17,7 @@ export default function WordPressSettingsSummary( {
 } ) {
 	const { data: versionTag } = useQuery( {
 		...siteWordPressVersionQuery( site.ID ),
-		enabled: canViewWordPressSettings( site ),
+		enabled: canSwitchWordPressVersion( site ),
 	} );
 
 	const wpVersion = getFormattedWordPressVersion( site, versionTag );

--- a/client/dashboard/sites/settings-wordpress/test/index.test.tsx
+++ b/client/dashboard/sites/settings-wordpress/test/index.test.tsx
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import { disable, enable } from '@automattic/calypso-config';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
@@ -19,7 +20,7 @@ const site = {
 		product_name_short: 'Business',
 		is_free: false,
 		features: {
-			active: [ 'atomic', 'sftp', 'backups' ],
+			active: [ 'atomic', 'sftp', 'backups', 'backups-self-serve' ],
 		},
 	},
 	options: {
@@ -27,11 +28,15 @@ const site = {
 	},
 } as Site;
 
-function mockApi() {
+function mockSite( mockedSite: Site ) {
 	nock( 'https://public-api.wordpress.com' )
-		.get( `/rest/v1.1/sites/${ site.slug }` )
+		.get( `/rest/v1.1/sites/${ mockedSite.slug }` )
 		.query( true )
-		.reply( 200, site );
+		.reply( 200, mockedSite );
+}
+
+function mockApi() {
+	mockSite( site );
 
 	nock( 'https://public-api.wordpress.com' )
 		.get( `/wpcom/v2/sites/${ site.ID }/hosting/wp-version` )
@@ -61,6 +66,14 @@ function mockWordPressVersionSaved( expectedVersion: string ) {
 }
 
 describe( '<WordPressSettings>', () => {
+	beforeAll( () => {
+		enable( 'dashboard/wp-beta-program' );
+	} );
+
+	afterAll( () => {
+		disable( 'dashboard/wp-beta-program' );
+	} );
+
 	test( 'renders and saves the form for a Business+ site', async () => {
 		const user = userEvent.setup();
 
@@ -81,5 +94,19 @@ describe( '<WordPressSettings>', () => {
 		await waitFor( () => {
 			expect( scope.isDone() ).toBe( true );
 		} );
+	} );
+
+	test( 'renders activation callout when a Simple site has the plan feature but is not Atomic', async () => {
+		mockSite( {
+			...site,
+			is_wpcom_atomic: false,
+			is_wpcom_staging_site: false,
+		} as Site );
+
+		render( <WordPressSettings siteSlug={ site.slug } /> );
+		await screen.findByRole( 'heading', { name: 'WordPress' } );
+
+		expect( screen.getByRole( 'button', { name: 'Activate' } ) ).toBeVisible();
+		expect( screen.queryByRole( 'button', { name: 'Save' } ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/dashboard/utils/wp-version.ts
+++ b/client/dashboard/utils/wp-version.ts
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { canViewWordPressSettings } from '../sites/features';
+import { canSwitchWordPressVersion } from '../sites/features';
 import type { Site } from '@automattic/api-core';
 
 function getWordPressVersionTagName( versionTag: string ) {
@@ -19,7 +19,7 @@ export function getFormattedWordPressVersion(
 	return formatWordPressVersion(
 		site.options?.software_version ?? '',
 		versionTag,
-		canViewWordPressSettings( site )
+		canSwitchWordPressVersion( site )
 	);
 }
 


### PR DESCRIPTION
## Proposed Changes

* `canViewWordPressSettings` now admits any site whose plan has `BACKUPS_SELF_SERVE` (not just Atomic sites with it active), so Simple Business+ sites can reach Settings > WordPress.
* Added `canSwitchWordPressVersion( site )` — a named helper for the "hosting feature is actually active" check — and replaced the inlined `hasHostingFeature( site, HostingFeatures.BACKUPS_SELF_SERVE )` usages across the summary card, overview notice, router loader, and version formatter.
* `Settings > WordPress` now wraps its version form in `HostingFeatureGatedWithCallout` — mirroring `Settings > PHP`. Simple Business+ sites see the activation callout (Atomic transfer) instead of the fallback message. Atomic Business+ sites see the version form unchanged.
* Split the render so the version-switch hooks (`siteWordPressVersionQuery`, `useVersionSwitch`) only mount when the gate picks the "hosting active" branch — Simple sites never fire the Atomic-only `/hosting/wp-version` endpoints.
* `canViewWordPressSettings` simplified: `hasHostingFeature || hasPlanFeature` → `hasPlanFeature` (the former was strictly subsumed by the latter).

## Why are these changes being made?

Part of the WordPress 7.0 beta self-enrollment rollout. Business+ plans include WordPress beta access, but on Simple infrastructure the underlying hosting features (backups, SFTP, custom versions) aren't provisioned until the site is transferred to Atomic. This mirrors the existing "Activate hosting features" entry point already used by Settings > PHP so the UX is consistent across server-level settings.

## Testing Instructions

1. Start the dashboard with \`yarn start-dashboard\`.
2. Visit a Simple site on a Business (or higher) plan at \`/sites/<slug>/settings\`.
3. Click the **WordPress** summary row → you should see the page header \"WordPress\" followed by the **Activate hosting features** callout (same component as Settings > PHP on a Simple Business+ site). Clicking **Activate** should start the Atomic transfer flow.
4. On an Atomic Business+ site, the version switcher should render unchanged — verify you can toggle between Latest and Beta and the backup-then-switch flow still works.
5. On a Personal/Free site, the page should still show the \"Every WordPress.com site runs the latest WordPress version\" fallback (no activation callout, no upsell).
6. Overview notice (\`WordPress X is available for early access\`) should continue to only appear for Atomic Business+ sites that haven't dismissed it — it is intentionally suppressed for pre-activation Simple sites because its copy promises automatic backups.

Unit tests: \`yarn test-client client/dashboard/sites/settings-wordpress/test/index.test.tsx\` — a new test asserts the activation button renders for a Simple Business+ site.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the \"[Status] String Freeze\" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the \"[Status] Needs Privacy Updates\" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?