### PR TITLE
MSD: Remove canPurchaseBeUpgraded

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -78,7 +78,6 @@ import {
 	isOneTimePurchase,
 	isMarketplaceTemporarySitePurchase,
 	isMarketplacePlugin,
-	isJetpackTemporarySitePurchase,
 	isAkismetProduct,
 	isJetpackCrmProduct,
 	isTitanMail,
@@ -135,15 +134,6 @@ function getWpcomPlanGridUrl( siteSlug: string | undefined ): string {
 		cancel_to: backUrl,
 		dashboard: getCurrentDashboard(),
 	} );
-}
-
-function canPurchaseBeUpgraded( purchase: Purchase ): boolean {
-	return Boolean(
-		purchase.is_upgradable &&
-			getSitePurchaseUpgradeUrl( purchase ) &&
-			! isJetpackTemporarySitePurchase( purchase ) &&
-			! isA4ABillingDragonPurchase( purchase )
-	);
 }
 
 function isAutoRenewToggleDisabled( purchase: Purchase, user: User ): boolean {
@@ -222,7 +212,7 @@ function PurchaseActionMenu( { purchase }: { purchase: Purchase } ) {
 	const upgradeUrl = getSitePurchaseUpgradeUrl( purchase );
 	const { recordTracksEvent } = useAnalytics();
 	const menuItems = [
-		canPurchaseBeUpgraded( purchase ) && upgradeUrl && (
+		purchase.is_upgradable && upgradeUrl && (
 			<MenuItem
 				onClick={ () => {
 					recordTracksEvent( 'calypso_purchases_upgrade_plan', {
@@ -322,7 +312,7 @@ function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
 
 function UpgradeActionButton( { purchase }: { purchase: Purchase } ) {
 	const { recordTracksEvent } = useAnalytics();
-	if ( ! canPurchaseBeUpgraded( purchase ) ) {
+	if ( ! purchase.is_upgradable ) {
 		return null;
 	}
 	const upgradeUrl = getSitePurchaseUpgradeUrl( purchase );
@@ -1167,7 +1157,7 @@ export default function PurchaseSettings() {
 						actions={
 							site?.options?.admin_url && (
 								<HStack justify="space-between">
-									{ canPurchaseBeUpgraded( purchase ) && upgradeUrl && (
+									{ purchase.is_upgradable && upgradeUrl && (
 										<Button __next40pxDefaultSize variant="primary" href={ upgradeUrl }>
 											{ _x( 'Upgrade', 'Change to a plan with more features.' ) }
 										</Button>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1739/move-isjetpacktemporarysitepurchase-guard-to-billing-upgrade-is

## Proposed Changes

This PR removes the function `canPurchaseBeUpgraded()` in the Multi Site Dashboard because it's unnecessary. The `is_upgradable` property of purchase objects already handles this concept (that's why it exists).

Depends on 211328-ghe-Automattic/wpcom

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


There was once a tremendous amount of logic on the frontend to determine if we should display an "Upgrade" button or not for various products when viewing their subscription in purchage management pages. To avoid that bloat and to make the logic centralized and testable, we moved it all to a property, `is_upgradable` on the upgrade object.

However, since then, more logic has been added to the frontend to tack on to `is_upgradable` which is going to recreate the same problem we already fixed. That logic has now been moved to the backend and we can remove it from the frontend.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Make sure 211328-ghe-Automattic/wpcom is deployed or active on your sandbox (and sandbox the API).
- View the purchase management page for an a4a purchase and a Jetpack Temporary site purchase.
- Verify that both do not show an "Upgrade" button.