### PR TITLE
Dashboard: Reduce content area spacing and heading size

### DIFF
--- a/client/dashboard/app-dotcom/style.scss
+++ b/client/dashboard/app-dotcom/style.scss
@@ -39,7 +39,7 @@
 	--dashboard-secondary-menu-item__color: #{$gray-900};
 
 	// Headings
-	--dashboard-h1__font-size: 40px;
+	--dashboard-h1__font-size: 32px;
 	--dashboard-h1__font-weight: 400;
 	--dashboard-h1__line-height: normal;
 	--dashboard-h1__font-family: Recoleta, sans-serif;

--- a/client/dashboard/components/page-layout/index.tsx
+++ b/client/dashboard/components/page-layout/index.tsx
@@ -20,7 +20,7 @@ function PageLayout( {
 } ) {
 	return (
 		<VStack
-			spacing={ 8 }
+			spacing={ 3 }
 			className={ `dashboard-page-layout is-${ size }` }
 			style={ PAGE_LAYOUT_SIZES[ size ] as CSSProperties }
 		>

--- a/client/dashboard/components/page-layout/style.scss
+++ b/client/dashboard/components/page-layout/style.scss
@@ -7,7 +7,7 @@
 	--page-layout-inline-padding: #{$grid-unit-20};
 
 	@include break-medium {
-		--page-layout-block-padding: #{$grid-unit-40};
+		--page-layout-block-padding: #{$grid-unit-20};
 		--page-layout-inline-padding: #{$grid-unit-30};
 	}
 


### PR DESCRIPTION
## Proposed Changes

* Reduce page layout top padding from 32px to 16px on desktop
* Reduce heading-to-content gap from 32px to 12px
* Reduce H1 font size from 40px to 32px

## Why are these changes being made?

Tighten the vertical spacing between the page heading and the content area (DataViews) for a more compact layout that aligns better with the sidebar.

## Testing Instructions

1. Navigate to `my.localhost:3000/sites` (or any Dashboard page)
2. Verify the "Sites" heading is smaller (32px) and closer to the top
3. Verify the gap between the heading and the DataView (search bar / table) is tighter
4. Check other pages (Domains, Emails, Plugins) for consistent spacing

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] Have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?