### PR TITLE
Dashboard: Increase sidebar WordPress.com logo size

### DIFF
--- a/client/dashboard/app-dotcom/logo.tsx
+++ b/client/dashboard/app-dotcom/logo.tsx
@@ -22,8 +22,8 @@ function ClassicLogo() {
 	return (
 		<svg
 			style={ { display: 'block' } }
-			width="153"
-			height="24"
+			width="170"
+			height="27"
 			viewBox="0 0 153 24"
 			fill="none"
 			xmlns="http://www.w3.org/2000/svg"

--- a/client/dashboard/app/responsive-sidebar/sidebar.scss
+++ b/client/dashboard/app/responsive-sidebar/sidebar.scss
@@ -25,6 +25,11 @@
 }
 
 .dashboard-responsive-sidebar__logo {
-	padding: 14px $grid-unit-30 + 2px;
+	padding: $grid-unit-20 $grid-unit-30 + 2px $grid-unit-20 + 2px;
 	border-block-end: 1px solid var( --dashboard-header__border-color );
+
+	.components-button svg {
+		width: 170px;
+		height: 27px;
+	}
 }


### PR DESCRIPTION
## Proposed Changes

* Scale up the WordPress.com ClassicLogo SVG from 153x24 to 170x27
* Override the WP Button icon size constraint so the logo renders at full size
* Adjust logo wrapper padding to 71px total height for alignment with the content area

## Why are these changes being made?

The sidebar logo was too small relative to the page headings. This increases the logo size and adjusts the wrapper height so the sidebar bottom border aligns with the content area DataView top border.

## Testing Instructions

1. Navigate to `my.localhost:3000/sites` (or any Dashboard page)
2. Verify the WordPress.com logo in the sidebar is visibly larger than before
3. Verify the gray border below the logo aligns horizontally with the top border of the content area DataView

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] Have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?