### PR TITLE
Dashboard: Update sidebar sub-menu item styling

### DIFF
--- a/client/dashboard/app/responsive-sidebar/sidebar.tsx
+++ b/client/dashboard/app/responsive-sidebar/sidebar.tsx
@@ -1,7 +1,6 @@
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { brush, envelope, globe, layout, plugins } from '@wordpress/icons';
-import { menuDot } from '../../components/icons';
 import RouterLinkButton from '../../components/router-link-button';
 import { SidebarExpandableMenuItem, SidebarMenu, SidebarMenuItem } from '../../components/sidebar';
 import SidebarNavigator from '../../components/sidebar-navigator';
@@ -73,14 +72,11 @@ function PrimaryMenuSidebar() {
 			) }
 			{ supports.plugins && (
 				<SidebarExpandableMenuItem label={ __( 'Plugins' ) } icon={ plugins } to="/plugins">
-					<SidebarMenuItem icon={ menuDot } to="/plugins/manage">
-						{ __( 'Manage plugins' ) }
-					</SidebarMenuItem>
-					<SidebarMenuItem icon={ menuDot } to="/plugins/scheduled-updates">
+					<SidebarMenuItem to="/plugins/manage">{ __( 'Manage plugins' ) }</SidebarMenuItem>
+					<SidebarMenuItem to="/plugins/scheduled-updates">
 						{ __( 'Scheduled updates' ) }
 					</SidebarMenuItem>
 					<SidebarMenuItem
-						icon={ menuDot }
 						href={ wpcomLink( '/plugins' ) }
 						target="_blank"
 						rel="noopener noreferrer"

--- a/client/dashboard/components/sidebar/sidebar-expandable-menu-item.scss
+++ b/client/dashboard/components/sidebar/sidebar-expandable-menu-item.scss
@@ -17,4 +17,8 @@
 		overflow: clip;
 		overflow-clip-margin: 2px;
 	}
+
+	.dashboard-sidebar__menu-item {
+		padding-inline-start: calc( 12px + 20px + 8px );
+	}
 }

--- a/client/dashboard/components/sidebar/sidebar-menu-item.scss
+++ b/client/dashboard/components/sidebar/sidebar-menu-item.scss
@@ -12,5 +12,9 @@
 	&.active {
 		background: color-mix( in srgb, var( --wp-admin-theme-color ) 8%, transparent );
 		color: var( --wp-admin-theme-color );
+
+		&:hover {
+			background: color-mix( in srgb, var( --wp-admin-theme-color ) 8%, transparent );
+		}
 	}
 }

--- a/client/dashboard/sites/site-sidebar/index.tsx
+++ b/client/dashboard/sites/site-sidebar/index.tsx
@@ -27,7 +27,6 @@ import {
 	siteDomainsRoute,
 	siteSettingsRoute,
 } from '../../app/router/sites';
-import { menuDot } from '../../components/icons';
 import {
 	SidebarBackButton,
 	SidebarExpandableMenuItem,
@@ -139,13 +138,13 @@ function SiteMenuSidebar( { site }: { site: Site } ) {
 					icon={ formatListBullets }
 					to={ `/sites/${ siteSlug }/logs` }
 				>
-					<SidebarMenuItem icon={ menuDot } to={ `/sites/${ siteSlug }/logs/activity` }>
+					<SidebarMenuItem to={ `/sites/${ siteSlug }/logs/activity` }>
 						{ __( 'Activity' ) }
 					</SidebarMenuItem>
-					<SidebarMenuItem icon={ menuDot } to={ `/sites/${ siteSlug }/logs/php` }>
+					<SidebarMenuItem to={ `/sites/${ siteSlug }/logs/php` }>
 						{ __( 'PHP errors' ) }
 					</SidebarMenuItem>
-					<SidebarMenuItem icon={ menuDot } to={ `/sites/${ siteSlug }/logs/server` }>
+					<SidebarMenuItem to={ `/sites/${ siteSlug }/logs/server` }>
 						{ __( 'Web server' ) }
 					</SidebarMenuItem>
 				</SidebarExpandableMenuItem>
@@ -158,10 +157,10 @@ function SiteMenuSidebar( { site }: { site: Site } ) {
 						icon={ shield }
 						to={ `/sites/${ siteSlug }/scan` }
 					>
-						<SidebarMenuItem icon={ menuDot } to={ `/sites/${ siteSlug }/scan/active` }>
+						<SidebarMenuItem to={ `/sites/${ siteSlug }/scan/active` }>
 							{ __( 'Active threats' ) }
 						</SidebarMenuItem>
-						<SidebarMenuItem icon={ menuDot } to={ `/sites/${ siteSlug }/scan/history` }>
+						<SidebarMenuItem to={ `/sites/${ siteSlug }/scan/history` }>
 							{ __( 'History' ) }
 						</SidebarMenuItem>
 					</SidebarExpandableMenuItem>


### PR DESCRIPTION
## Proposed Changes

* Remove bullet dot icons from sidebar sub-menu items in all expandable sections (Plugins, Logs, Scan)
* Align sub-menu item text with parent item labels via inline padding
* Preserve the active item background color on hover

## Why are these changes being made?

The sidebar sub-menu items appear visually cluttered with the bullet dots. This update removes the dots, aligns the sub-item text with parent labels for a cleaner look, and fixes the hover state on active items to keep the selected background color consistent.

## Testing Instructions

1. Navigate to `/plugins/manage` and verify Plugins sub-items have no dots and text aligns with "Plugins" label
2. Navigate to a site page and expand Logs and Scan — verify same treatment
3. Hover over the active sidebar item and verify the background color stays the same

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] Have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?