### PR TITLE
Dashboard: Update sidebar back button styling

### DIFF
--- a/client/dashboard/components/sidebar/sidebar-back-button.scss
+++ b/client/dashboard/components/sidebar/sidebar-back-button.scss
@@ -1,3 +1,5 @@
 .components-button.dashboard-sidebar__back-button {
 	color: var( --dashboard-menu-item__color );
+	font-size: 13px;
+	line-height: 20px;
 }

--- a/client/dashboard/components/sidebar/sidebar-back-button.tsx
+++ b/client/dashboard/components/sidebar/sidebar-back-button.tsx
@@ -7,7 +7,7 @@ export function SidebarBackButton( { to, children }: { to: string; children: Rea
 	return (
 		<SidebarMenu>
 			<RouterLinkButton className="dashboard-sidebar__back-button" size="small" to={ to }>
-				<span aria-hidden="true">←</span> { children }
+				← { children }
 			</RouterLinkButton>
 		</SidebarMenu>
 	);

--- a/client/dashboard/components/sidebar/sidebar-back-button.tsx
+++ b/client/dashboard/components/sidebar/sidebar-back-button.tsx
@@ -1,4 +1,3 @@
-import { arrowLeft } from '@wordpress/icons';
 import RouterLinkButton from '../../components/router-link-button';
 import { SidebarMenu } from './sidebar-menu';
 
@@ -7,14 +6,8 @@ import './sidebar-back-button.scss';
 export function SidebarBackButton( { to, children }: { to: string; children: React.ReactNode } ) {
 	return (
 		<SidebarMenu>
-			<RouterLinkButton
-				className="dashboard-sidebar__back-button"
-				icon={ arrowLeft }
-				iconSize={ 18 }
-				size="small"
-				to={ to }
-			>
-				{ children }
+			<RouterLinkButton className="dashboard-sidebar__back-button" size="small" to={ to }>
+				<span aria-hidden="true">←</span> { children }
 			</RouterLinkButton>
 		</SidebarMenu>
 	);


### PR DESCRIPTION
## Proposed Changes

* Replace the SVG arrow icon (`arrowLeft`) with a `←` text symbol
* Set font size to 13px and line height to 20px

## Why are these changes being made?

Make the back button ("Back to Sites", "Back to Domains") lighter and more consistent with the sidebar's visual style.

## Testing Instructions

1. Navigate to a site overview page (`/sites/<siteSlug>`) and verify the "← Back to Sites" button uses the text arrow symbol, 13px font, 20px line height
2. Navigate to a domain detail page (`/domains/<domainName>`) and verify the same for "← Back to Domains"
3. Verify the color remains gray-700

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] Have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?