### PR TITLE
Stats: Fix purchase page button selector and checklist spacing

### DIFF
--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -586,8 +586,8 @@ $button-padding: 8px 32px;
 .stats-purchase-single__personal-checklist {
 	margin-bottom: 24px;
 
-	ul li {
-		margin-bottom: 12px;
+	ul li + li {
+		margin-top: 12px;
 	}
 }
 

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -30,8 +30,6 @@ $button-padding: 8px 32px;
 		}
 
 		.stats-purchase-single__personal-checklist {
-			margin-bottom: 24px;
-
 			.components-checkbox-control__input[type="checkbox"] {
 				&:checked {
 					background-color: var(--studio-jetpack-green-50);
@@ -578,9 +576,17 @@ $button-padding: 8px 32px;
 }
 
 .stats-purchase-wizard__actions {
-	.components-button {
+	button {
 		display: block;
 		width: 100%;
+		margin-bottom: 12px;
+	}
+}
+
+.stats-purchase-single__personal-checklist {
+	margin-bottom: 24px;
+
+	ul li {
 		margin-bottom: 12px;
 	}
 }


### PR DESCRIPTION
Fixes STATS-246.

## Proposed Changes

* Change `.stats-purchase-wizard__actions .components-button` selector to `button` for broader matching.
* Move `.stats-purchase-single__personal-checklist` to top-level scope and add `ul li` spacing (12px) for better readability.

## Why are these changes being made?

The button selector was too specific and didn't match all button variants. The checklist items lacked vertical spacing, making them hard to read.

## Testing Instructions
* Test changes for WP.com sites.
* Navigate to Stats commercial purchase page (`/stats/purchase/<site-slug>?from=calypso-stats-commercial-site-upgrade-notice&productType=commercial`).
* Verify action buttons display correctly at full width.
* Verify the personal checklist items have proper spacing between list items.
* Ensure the Stats personal purchase page (`/stats/purchase/<site-slug>?from=calypso-stats-commercial-site-upgrade-notice&productType=personal`) also works well.
* Ensure the layout is not affected on self-hosted sites.

### Stats personal purchase page
|Before|After|
|-|-|
|<img width="718" height="844" alt="截圖 2026-04-11 凌晨2 20 10" src="https://github.com/user-attachments/assets/186feeae-4747-4f60-9ad1-2df4e1df0d36" />|<img width="683" height="745" alt="截圖 2026-04-11 凌晨2 19 31" src="https://github.com/user-attachments/assets/96832deb-e384-45d9-8b53-fdac2fd507bb" />|

### Stats commercial purchase page
|Before|After|
|-|-|
|<img width="843" height="874" alt="截圖 2026-04-11 凌晨1 52 57" src="https://github.com/user-attachments/assets/980c142c-255e-4497-954c-fc339e587f87" />|<img width="957" height="830" alt="截圖 2026-04-11 凌晨2 08 51" src="https://github.com/user-attachments/assets/b7e1a540-91c3-4882-b23b-ba30ad3cf5f4" />|

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?