### PR TITLE
Site Launch Celebration Modal: Refetch data within Calypso when React Query data changes

### DIFF
--- a/client/dashboard/sites/performance/index.tsx
+++ b/client/dashboard/sites/performance/index.tsx
@@ -15,7 +15,6 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import HostingFeatureGatedWithCallout from '../hosting-feature-gated-with-callout';
 import { SiteLaunchButton } from '../site-launch-button';
-import SiteLaunchCelebrationModal from '../site-launch-celebration-modal';
 import DeviceToggle from './device-toggle';
 import PageSelector from './page-selector';
 import { getPerformanceCalloutProps } from './performance-callout';
@@ -202,7 +201,6 @@ function SitePerformance() {
 				<SitePerformanceContent site={ site } />
 			) }
 			<PerformanceTrackerStop />
-			<SiteLaunchCelebrationModal site={ site } />
 		</HostingFeatureGatedWithCallout>
 	);
 }

--- a/client/dashboard/sites/settings-site-visibility/index.tsx
+++ b/client/dashboard/sites/settings-site-visibility/index.tsx
@@ -15,13 +15,7 @@ import { LaunchAgencyDevelopmentSiteForm, LaunchForm } from './launch-form';
 import { PrivacyForm } from './privacy-form';
 import { ShareSiteForm } from './share-site-form';
 
-export default function SiteVisibilitySettings( {
-	siteSlug,
-	onSiteLaunch,
-}: {
-	siteSlug: string;
-	onSiteLaunch?: () => void;
-} ) {
+export default function SiteVisibilitySettings( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: settings } = useSuspenseQuery( siteSettingsQuery( site.ID ) );
 	const { back_to } = useSearch( {
@@ -35,7 +29,7 @@ export default function SiteVisibilitySettings( {
 					{ site.is_a4a_dev_site ? (
 						<LaunchAgencyDevelopmentSiteForm site={ site } />
 					) : (
-						<LaunchForm site={ site } onSiteLaunch={ onSiteLaunch } />
+						<LaunchForm site={ site } />
 					) }
 					{ site.is_coming_soon && <ShareSiteForm site={ site } /> }
 				</>

--- a/client/dashboard/sites/settings-site-visibility/launch-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/launch-form.tsx
@@ -122,7 +122,7 @@ export function LaunchAgencyDevelopmentSiteForm( { site }: { site: Site } ) {
 	);
 }
 
-export function LaunchForm( { site, onSiteLaunch }: { site: Site; onSiteLaunch?: () => void } ) {
+export function LaunchForm( { site }: { site: Site } ) {
 	return (
 		<>
 			<TrialUpsellNotice site={ site } />
@@ -132,7 +132,6 @@ export function LaunchForm( { site, onSiteLaunch }: { site: Site; onSiteLaunch?:
 					<SiteLaunchButton
 						site={ site }
 						tracksContext="site_settings"
-						onSiteLaunch={ onSiteLaunch }
 						backTo={ `/sites/${ site.slug }` }
 					/>
 				}

--- a/client/dashboard/sites/site-launch-button/index.tsx
+++ b/client/dashboard/sites/site-launch-button/index.tsx
@@ -22,7 +22,6 @@ export function SiteLaunchButton( {
 	tracksContext,
 	launchUrl,
 	LaunchModal,
-	onSiteLaunch,
 	backTo,
 }: {
 	site: Site;
@@ -33,7 +32,6 @@ export function SiteLaunchButton( {
 		onClose: () => void;
 		onLaunch: () => void;
 	} >;
-	onSiteLaunch?: () => void;
 	backTo?: string;
 } ) {
 	const { queries } = useAppContext();
@@ -90,9 +88,6 @@ export function SiteLaunchButton( {
 	const handleLaunch = () => {
 		handleTracksEvent();
 		launchMutation.mutate( undefined, {
-			onSuccess: () => {
-				onSiteLaunch?.();
-			},
 			onSettled: () => {
 				setIsLaunchModalOpen( false );
 			},
@@ -103,8 +98,6 @@ export function SiteLaunchButton( {
 		handleTracksEvent();
 		launchMutation.mutate( undefined, {
 			onSuccess: () => {
-				onSiteLaunch?.();
-
 				// Add query param to trigger celebration modal in parent component
 				window.history.replaceState(
 					null,

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -10,8 +10,6 @@ import { useEffect, useMemo, useState } from 'react';
 import { useSiteSettings } from 'calypso/blocks/plugins-scheduled-updates/hooks/use-site-settings';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import NavigationHeader from 'calypso/components/navigation-header';
-import { AnalyticsProvider } from 'calypso/dashboard/app/analytics';
-import SiteLaunchCelebrationModal from 'calypso/dashboard/sites/site-launch-celebration-modal';
 import {
 	DeviceTabProvider,
 	useDeviceTab,
@@ -42,11 +40,6 @@ import { useSitePerformancePageReports } from './hooks/useSitePerformancePageRep
 import { getSupportLinkProps } from './utils';
 
 import './style.scss';
-
-const analyticsClient = {
-	recordTracksEvent,
-	recordPageView: () => {}, // Required by AnalyticsClient interface; unused by SiteLaunchCelebrationModal
-};
 
 const statType = 'statsTopPosts';
 const statsQuery = {
@@ -390,11 +383,6 @@ const SitePerformanceContent = ( { path }: { path?: string } ) => {
 						</>
 					) }
 				</>
-			) }
-			{ site && (
-				<AnalyticsProvider client={ analyticsClient }>
-					<SiteLaunchCelebrationModal site={ site } />
-				</AnalyticsProvider>
 			) }
 		</div>
 	);

--- a/client/my-sites/customer-home/celebrate-site-launch-modal/index.tsx
+++ b/client/my-sites/customer-home/celebrate-site-launch-modal/index.tsx
@@ -1,14 +1,15 @@
+import { queryClient } from '@automattic/api-queries';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { AnalyticsProvider } from 'calypso/dashboard/app/analytics';
 import SiteLaunchCelebrationModal from 'calypso/dashboard/sites/site-launch-celebration-modal';
-import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { useDispatch, useSelector } from 'calypso/state';
+import { useDispatch } from 'calypso/state';
 import { setSiteLaunchCelebrationModalOpen } from 'calypso/state/sites/launch/actions';
-import { getSite } from 'calypso/state/sites/selectors';
+import { useReduxSiteWithQueryClientLaunchStatusSync } from './use-redux-site-with-query-client-launch-status-sync';
 
-const CelebrateSiteLaunchModal = ( { siteId }: { siteId: number } ) => {
-	const site = useSelector( ( state ) => getSite( state, siteId ) );
+function CelebrateSiteLaunchModalContent( { siteId }: { siteId: number } ) {
+	const site = useReduxSiteWithQueryClientLaunchStatusSync( siteId );
 
 	const dispatch = useDispatch();
 	const analyticsClient = useMemo( () => {
@@ -17,8 +18,6 @@ const CelebrateSiteLaunchModal = ( { siteId }: { siteId: number } ) => {
 			recordPageView() {}, // Unused by this component
 		};
 	}, [] );
-
-	const layout = useHomeLayoutQuery( siteId );
 
 	return (
 		<AnalyticsProvider client={ analyticsClient }>
@@ -30,12 +29,17 @@ const CelebrateSiteLaunchModal = ( { siteId }: { siteId: number } ) => {
 					} }
 					onClose={ () => {
 						dispatch( setSiteLaunchCelebrationModalOpen( false ) );
-						layout?.refetch();
 					} }
 				/>
 			) }
 		</AnalyticsProvider>
 	);
-};
+}
 
-export default CelebrateSiteLaunchModal;
+export default function CelebrateSiteLaunchModal( { siteId }: { siteId: number } ) {
+	return (
+		<QueryClientProvider client={ queryClient }>
+			<CelebrateSiteLaunchModalContent siteId={ siteId } />
+		</QueryClientProvider>
+	);
+}

--- a/client/my-sites/customer-home/celebrate-site-launch-modal/use-redux-site-with-query-client-launch-status-sync.ts
+++ b/client/my-sites/customer-home/celebrate-site-launch-modal/use-redux-site-with-query-client-launch-status-sync.ts
@@ -2,7 +2,7 @@ import { siteByIdQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'calypso/state';
-import { receiveSite } from 'calypso/state/sites/actions';
+import { requestSite } from 'calypso/state/sites/actions';
 import { getSite } from 'calypso/state/sites/selectors';
 
 /**
@@ -27,9 +27,9 @@ export function useReduxSiteWithQueryClientLaunchStatusSync( siteId: number ) {
 		}
 
 		if ( site.launch_status !== cachedReduxSiteLaunchStatus.current ) {
-			dispatch( receiveSite( site ) );
+			dispatch( requestSite( siteId ) );
 		}
-	}, [ site, dispatch ] );
+	}, [ site, siteId, dispatch ] );
 
 	return reduxSite;
 }

--- a/client/my-sites/customer-home/celebrate-site-launch-modal/use-redux-site-with-query-client-launch-status-sync.ts
+++ b/client/my-sites/customer-home/celebrate-site-launch-modal/use-redux-site-with-query-client-launch-status-sync.ts
@@ -1,0 +1,35 @@
+import { siteByIdQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { useEffect, useRef } from 'react';
+import { useDispatch, useSelector } from 'calypso/state';
+import { receiveSite } from 'calypso/state/sites/actions';
+import { getSite } from 'calypso/state/sites/selectors';
+
+/**
+ * Syncs the site launch status from the query client to the Redux store.
+ *
+ * The site launch status is stored in the query client's `site-by-id` cache entry.
+ * When the entry is invalidated, the site launch status is not updated in the Redux store.
+ * This hook fetches the site from the query client and updates the Redux store with the launch status.
+ */
+export function useReduxSiteWithQueryClientLaunchStatusSync( siteId: number ) {
+	const reduxSite = useSelector( ( state ) => getSite( state, siteId ) );
+	const dispatch = useDispatch();
+
+	const { data: site } = useQuery( siteByIdQuery( siteId ) );
+
+	const cachedReduxSiteLaunchStatus = useRef< undefined | string >();
+	cachedReduxSiteLaunchStatus.current = reduxSite?.launch_status;
+
+	useEffect( () => {
+		if ( ! site ) {
+			return;
+		}
+
+		if ( site.launch_status !== cachedReduxSiteLaunchStatus.current ) {
+			dispatch( receiveSite( site ) );
+		}
+	}, [ site, dispatch ] );
+
+	return reduxSite;
+}

--- a/client/my-sites/customer-home/celebrate-site-launch-modal/use-side-effects.ts
+++ b/client/my-sites/customer-home/celebrate-site-launch-modal/use-side-effects.ts
@@ -1,4 +1,5 @@
 import { updateLaunchpadSettings } from '@automattic/data-stores';
+import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
 import { useDispatch } from 'calypso/state';
 import { requestSite } from 'calypso/state/sites/actions';
 
@@ -11,11 +12,14 @@ export function useCelebrateLaunchModalSideEffects( siteId: number ) {
 		window.history.replaceState( {}, '', url.toString() );
 	};
 
+	const layout = useHomeLayoutQuery( siteId );
+
 	return {
 		addCelebrateLaunchQueryParams,
 		onSiteLaunched: ( isWpcomAtomic: boolean ) => {
 			addCelebrateLaunchQueryParams();
 			dispatch( requestSite( siteId ) );
+			layout?.refetch();
 
 			if ( isWpcomAtomic ) {
 				updateLaunchpadSettings( siteId, {

--- a/client/sites/v2/site-settings/router.tsx
+++ b/client/sites/v2/site-settings/router.tsx
@@ -4,9 +4,6 @@ import { __ } from '@wordpress/i18n';
 import { APP_CONTEXT_DEFAULT_CONFIG } from 'calypso/dashboard/app/context';
 import { handleOnCatch } from 'calypso/dashboard/app/logger';
 import * as appRouterSites from 'calypso/dashboard/app/router/sites';
-import { useDispatch, useSelector } from 'calypso/state';
-import { requestSite } from 'calypso/state/sites/actions';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { rootRoute, dashboardSitesCompatibilityRoute, siteRoute } from '../router';
 import { getRouterOptions, createBrowserHistoryAndMemoryRouterSync } from '../utils/router';
 import type { AppConfig } from 'calypso/dashboard/app/context';
@@ -34,24 +31,7 @@ const siteVisibilityRoute = createRoute( {
 } ).lazy( () =>
 	import( 'calypso/dashboard/sites/settings-site-visibility' ).then( ( d ) =>
 		createLazyRoute( 'site-visibility' )( {
-			component: function CalypsoDashboardSiteVisibilitySettings() {
-				const siteId = useSelector( getSelectedSiteId );
-				const dispatch = useDispatch();
-
-				if ( ! siteId ) {
-					throw new Error( 'No site ID selected. This is a bug.' );
-				}
-
-				return (
-					<d.default
-						siteSlug={ siteRoute.useParams().siteSlug }
-						onSiteLaunch={ () => {
-							// The site launch celebration modal reads the site data from Redux, not React Query, so we need to refetch it.
-							dispatch( requestSite( siteId ) );
-						} }
-					/>
-				);
-			},
+			component: () => <d.default siteSlug={ siteRoute.useParams().siteSlug } />,
 		} )
 	)
 );

--- a/client/state/selectors/is-unlaunched-site.js
+++ b/client/state/selectors/is-unlaunched-site.js
@@ -1,4 +1,4 @@
-import getRawSite from 'calypso/state/selectors/get-raw-site';
+import { getSite } from 'calypso/state/sites/selectors';
 
 /**
  * Returns true if the site is unlaunched
@@ -7,7 +7,7 @@ import getRawSite from 'calypso/state/selectors/get-raw-site';
  * @returns {boolean} True if site is unlaunched
  */
 export default function isUnlaunchedSite( state, siteId ) {
-	const site = getRawSite( state, siteId );
+	const site = getSite( state, siteId );
 
 	return site?.launch_status === 'unlaunched';
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/pull/109920#pullrequestreview-4087174929.

## Proposed Changes

When launching a site from the Calypso Dashboard, dispatch the site request action for the Redux store when the site object from React Query changes.

This is because the source of truth in the Calypso dashboard is Redux, but the Site Launch Celebration Modal actually comes from MSD, which fetches data only from React Query.

## Testing Instructions

For each test case, ensure you're assigned to the `ungated_site_launch` variant in the `calypso_standardized_site_launch_gating_202603_v1` experiment, **and the site has never been launched** (`launch_status: unlaunched`).

### Calypso home > Masterbar

https://github.com/user-attachments/assets/1b4d970c-f849-46aa-81ce-3b00bcd5dfd1




### Calypso dashboard > Masterbar


https://github.com/user-attachments/assets/2614f178-e482-4a51-9f52-ce0ff0cae088




### Launchpad


https://github.com/user-attachments/assets/db418f30-f516-4146-bbc0-58acef01b341




### Calypso dashboard > Site visibility settings


https://github.com/user-attachments/assets/d20accfb-8364-4839-b1fc-183d893c9531

### MSD Site > Site visibility settings


https://github.com/user-attachments/assets/730c26f5-4dc7-44cf-a464-a058ebebb812



### Calypso dashboard > Performance

https://github.com/user-attachments/assets/150f1c8e-9e94-4756-808e-fcb8a0cc9747




### MSD Site > Performance

https://github.com/user-attachments/assets/4294909e-18c1-4d45-b3a0-075081768215


