### PR TITLE
MSD Visibility Settings: Let user leave the page after launching a site

### DIFF
--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -5,7 +5,7 @@ import { __experimentalVStack as VStack, Button, CheckboxControl } from '@wordpr
 import { DataForm } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useState } from 'react';
+import { useLayoutEffect, useMemo, useState } from 'react';
 import { useAppContext } from '../../app/context';
 import { NavigationBlocker } from '../../app/navigation-blocker';
 import { ButtonStack } from '../../components/button-stack';
@@ -146,12 +146,20 @@ export function PrivacyForm( { site, settings }: { site: Site; settings: SiteSet
 		( domain ) => domain.subtype.id !== DomainSubtype.DEFAULT_ADDRESS
 	);
 
-	const initialData = fromSiteSettings( settings );
+	const initialData = useMemo( () => fromSiteSettings( settings ), [ settings ] );
 	const [ formData, setFormData ] = useState( () => ( {
 		...initialData,
 		preventThirdPartySharing:
 			initialData.discourageSearchEngines || initialData.preventThirdPartySharing,
 	} ) );
+
+	useLayoutEffect( () => {
+		setFormData( {
+			...initialData,
+			preventThirdPartySharing:
+				initialData.discourageSearchEngines || initialData.preventThirdPartySharing,
+		} );
+	}, [ initialData ] );
 
 	const isDirty = Object.entries( initialData ).some(
 		( [ key, value ] ) => formData[ key as keyof PrivacyFormData ] !== value


### PR DESCRIPTION
Closes DATSCI-1287.

## Proposed Changes

When launching a site from visibility settings in the `ungated_site_launch` experience, the form data (stored as local state) becomes stale because the site has been launched.

The form data drifts from the site, coming from the API, and erroneously tells the user that unsaved changes will be lost if they leave the page. Using an effect to sync the local state with the data coming from the API fixes the issue.

Regarding the approach, I also tried passing a `key` prop to `<PrivacyForm />` but I ended up liking that less as the key definition is not colocated with state initialization, making it not immediately clear why it's being used.

## Testing Instructions

1. Assign yourself to the `ungated_site_launch` variant in `calypso_standardized_site_launch_gating_202603_v1`.
2. Enter MSD > Site > Visibility Settings
3. Launch the site
4. Verify you can navigate away without the "unsaved changes" prompt being shown by the browser