### PR TITLE
Plans: Fix term selector showing 99% off for intro offer plans

### DIFF
--- a/packages/plans-grid-next/src/components/plan-type-selector/hooks/use-max-discount.ts
+++ b/packages/plans-grid-next/src/components/plan-type-selector/hooks/use-max-discount.ts
@@ -45,10 +45,12 @@ export default function useMaxDiscount(
 			return 0;
 		}
 
-		const yearlyPlanAnnualCost =
-			yearlyPlansPricing?.[ yearlyVariantPlanSlug ]?.discountedPrice.full ||
-			yearlyPlansPricing?.[ yearlyVariantPlanSlug ]?.originalPrice.full ||
-			0;
+		const yearlyVariantPricing = yearlyPlansPricing?.[ yearlyVariantPlanSlug ];
+		const isOnIntroOffer =
+			yearlyVariantPricing?.introOffer && ! yearlyVariantPricing.introOffer.isOfferComplete;
+		const yearlyPlanAnnualCost = isOnIntroOffer
+			? yearlyVariantPricing?.originalPrice.full || 0
+			: yearlyVariantPricing?.discountedPrice.full || yearlyVariantPricing?.originalPrice.full || 0;
 
 		return Math.floor(
 			( ( monthlyPlanAnnualCost - yearlyPlanAnnualCost ) / ( monthlyPlanAnnualCost || 1 ) ) * 100

--- a/packages/plans-grid-next/src/components/plan-type-selector/hooks/use-max-discounts-for-plan-terms.ts
+++ b/packages/plans-grid-next/src/components/plan-type-selector/hooks/use-max-discounts-for-plan-terms.ts
@@ -76,8 +76,11 @@ export default function useMaxDiscountsForPlanTerms(
 			const variantPlanSlug =
 				getPlanSlugForTermVariant( lowestTermPlanSlug, termMapping.term ) ?? '';
 			const variantPlanPricing = plansPricing?.[ variantPlanSlug ];
-			const variantTermPrice =
-				variantPlanPricing?.discountedPrice?.full || variantPlanPricing?.originalPrice?.full || 0;
+			const isOnIntroOffer =
+				variantPlanPricing?.introOffer && ! variantPlanPricing.introOffer.isOfferComplete;
+			const variantTermPrice = isOnIntroOffer
+				? variantPlanPricing?.originalPrice?.full || 0
+				: variantPlanPricing?.discountedPrice?.full || variantPlanPricing?.originalPrice?.full || 0;
 			if ( ! variantTermPrice ) {
 				return 0;
 			}


### PR DESCRIPTION
Resolves SHILL-1872

## Proposed Changes

* Add intro offer guard to plan term selector discount calculations in `use-max-discounts-for-plan-terms.ts` and `use-max-discount.ts`
* When a plan has an active intro offer, use `originalPrice` instead of `discountedPrice` for the annual savings percentage

## Why are these changes being made?

The "Pay yearly" dropdown on the CIAB plans page shows "up to 99% off" instead of the correct ~24% savings. The discount calculation uses `discountedPrice` which includes the $1 intro offer price, making the math: monthly $19/mo vs annual $1/12mo = ~99% off.

The correct pattern already exists in `header-price/index.tsx` - when `introOffer && !introOffer.isOfferComplete`, it uses `originalPrice` for savings calculations. This PR applies the same guard to the two term selector hooks that were missing it.

| Scenario | Before | After |
|----------|--------|-------|
| CIAB plans with $1 intro offer | "Pay yearly up to 99% off" | "Pay yearly Save 24%" |
| Plans without intro offers | Uses discountedPrice (correct) | No change |
| Plans with coupon/sale pricing | Uses discountedPrice (correct) | No change |

## Screenshot
<img width="612" height="311" alt="Screenshot 2026-04-10 at 3 08 26 PM" src="https://github.com/user-attachments/assets/fa41304f-bec4-477b-9506-e6ea7a9c58db" />


## Testing Instructions

**Steps:**
1. Navigate to CIAB plans page: `/setup/woo-hosted-plans?siteSlug=yoursite.commerce-garden.com`
2. Verify the billing interval dropdown shows "Pay yearly Save 24%" (not "up to 99% off")
3. Switch to Monthly - verify no discount text shown
4. Switch back to Annually - verify "Save 24%" persists
5. Navigate to a regular WordPress.com plans page (`/plans/yoursite.wordpress.com`) and verify the term selector discount is unaffected

**Calypso Live:**
- `https://fix-ciab-plan-discount.calypso.live/setup/woo-hosted-plans?siteSlug=yoursite.commerce-garden.com`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
