### PR TITLE
Checkout: Route partial failure orders to failed-purchases page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/failed-purchase-details.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/failed-purchase-details.tsx
@@ -7,7 +7,7 @@ export default function FailedPurchaseDetails( {
 	failedPurchases,
 	purchases,
 }: {
-	purchases?: ReceiptPurchase[];
+	purchases?: Pick< ReceiptPurchase, 'productId' | 'productName' | 'meta' >[];
 	failedPurchases?: FailedReceiptPurchase[];
 } ) {
 	const translate = useTranslate();

--- a/client/my-sites/checkout/checkout-thank-you/failed-purchase-page.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/failed-purchase-page.tsx
@@ -1,17 +1,51 @@
 import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import DocumentHead from 'calypso/components/data/document-head';
+import Loading from 'calypso/components/loading';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { useDispatch, useSelector } from 'calypso/state';
+import { fetchReceipt } from 'calypso/state/receipts/actions';
+import { getReceiptById } from 'calypso/state/receipts/selectors';
 import FailedPurchaseDetails from './failed-purchase-details';
 
 import './style.scss';
 
 export function FailedPurchasePage() {
 	const translate = useTranslate();
+	const location = useLocation();
+	const dispatch = useDispatch();
+
+	// Get receipt ID from query param: /checkout/failed-purchases?receipt_id=12345
+	const params = new URLSearchParams( location.search );
+	const receiptId = params.get( 'receipt_id' );
+	const receiptIdNum = receiptId ? parseInt( receiptId, 10 ) : null;
+
+	// Fetch receipt from Redux if available
+	const receipt = useSelector( ( state ) =>
+		receiptIdNum ? getReceiptById( state, receiptIdNum ) : null
+	);
+
+	// Fetch receipt if not already loaded
+	useEffect( () => {
+		if ( receiptIdNum && ! receipt?.data ) {
+			dispatch( fetchReceipt( receiptIdNum ) );
+		}
+	}, [ receiptIdNum, receipt?.data, dispatch ] );
+
+	// Show loading state while fetching
+	if ( receiptIdNum && ! receipt?.data && receipt?.isRequesting ) {
+		return <Loading />;
+	}
+
 	return (
 		<div className="failed-purchases-page">
 			<PageViewTracker path="/checkout/failed-purchases" title="Failed purchases" />
 			<DocumentHead title={ translate( 'Checkout' ) } />
-			<FailedPurchaseDetails />
+			<FailedPurchaseDetails
+				failedPurchases={ receipt?.data?.failedPurchases }
+				purchases={ receipt?.data?.purchases }
+			/>
 		</div>
 	);
 }

--- a/client/my-sites/checkout/checkout-thank-you/failed-purchase-page.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/failed-purchase-page.tsx
@@ -1,49 +1,52 @@
+import { receiptQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import Loading from 'calypso/components/loading';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { useDispatch, useSelector } from 'calypso/state';
-import { fetchReceipt } from 'calypso/state/receipts/actions';
-import { getReceiptById } from 'calypso/state/receipts/selectors';
 import FailedPurchaseDetails from './failed-purchase-details';
 
 import './style.scss';
 
 export function FailedPurchasePage() {
 	const translate = useTranslate();
-	const dispatch = useDispatch();
 
-	// Get receipt ID from query param: /checkout/failed-purchases?receipt_id=12345
 	const params = new URLSearchParams( window.location.search );
 	const receiptId = params.get( 'receipt_id' );
 	const receiptIdNum = receiptId ? parseInt( receiptId, 10 ) : null;
 
-	// Fetch receipt from Redux if available
-	const receipt = useSelector( ( state ) =>
-		receiptIdNum ? getReceiptById( state, receiptIdNum ) : null
-	);
+	const { data: receipt, isLoading } = useQuery( {
+		...receiptQuery( receiptIdNum ?? 0, { includeFailedPurchases: true } ),
+		enabled: !! receiptIdNum,
+	} );
 
-	// Fetch receipt if not already loaded
-	useEffect( () => {
-		if ( receiptIdNum && ! receipt?.data ) {
-			dispatch( fetchReceipt( receiptIdNum, true ) );
-		}
-	}, [ receiptIdNum, receipt?.data, dispatch ] );
-
-	// Show loading state while fetching
-	if ( receiptIdNum && ! receipt?.data && receipt?.isRequesting ) {
+	if ( receiptIdNum && isLoading ) {
 		return <Loading />;
 	}
+
+	const purchases = receipt?.items.map( ( item ) => ( {
+		productId: item.id,
+		productName: item.product,
+		meta: item.variation,
+	} ) );
+
+	const failedPurchases = receipt?.failed_purchases
+		? Object.values( receipt.failed_purchases )
+				.flat()
+				.map( ( item ) => ( {
+					productId: item.product_id,
+					productName: item.product_name,
+					productSlug: item.product_slug,
+					productCost: item.product_cost,
+					meta: item.product_meta,
+				} ) )
+		: undefined;
 
 	return (
 		<div className="failed-purchases-page">
 			<PageViewTracker path="/checkout/failed-purchases" title="Failed purchases" />
 			<DocumentHead title={ translate( 'Checkout' ) } />
-			<FailedPurchaseDetails
-				failedPurchases={ receipt?.data?.failedPurchases }
-				purchases={ receipt?.data?.purchases }
-			/>
+			<FailedPurchaseDetails failedPurchases={ failedPurchases } purchases={ purchases } />
 		</div>
 	);
 }

--- a/client/my-sites/checkout/checkout-thank-you/failed-purchase-page.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/failed-purchase-page.tsx
@@ -24,22 +24,52 @@ export function FailedPurchasePage() {
 		return <Loading />;
 	}
 
-	const purchases = receipt?.items.map( ( item ) => ( {
-		productId: item.id,
-		productName: item.product,
-		meta: item.variation,
-	} ) );
+	const failedItems = receipt?.failed_purchases
+		? Object.values( receipt.failed_purchases ).flat()
+		: [];
+
+	// A failed line item still lives in `receipt.items` — the refund is recorded on a
+	// separate cancellation receipt, so the original line persists here. Exclude
+	// anything that also appears in `failed_purchases` (and any domain connection
+	// orphaned by a failed domain) from the "added successfully" list, so a failed
+	// item isn't shown as both succeeded and failed.
+	const failedItemKeys = new Set(
+		failedItems.map( ( item ) => `${ item.product_slug }:${ item.product_meta }` )
+	);
+	const failedDomains = new Set(
+		failedItems.map( ( item ) => item.product_meta ).filter( Boolean )
+	);
+
+	const purchases = receipt?.items
+		.filter( ( item ) => {
+			if ( failedItemKeys.has( `${ item.wpcom_product_slug }:${ item.domain ?? '' }` ) ) {
+				return false;
+			}
+			// `domain_map` is a connection to a domain; if that domain failed to register,
+			// the connection is orphaned and shouldn't be listed as a success.
+			if (
+				item.wpcom_product_slug === 'domain_map' &&
+				item.domain &&
+				failedDomains.has( item.domain )
+			) {
+				return false;
+			}
+			return true;
+		} )
+		.map( ( item ) => ( {
+			productId: item.id,
+			productName: item.variation || item.product,
+			meta: item.domain ?? '',
+		} ) );
 
 	const failedPurchases = receipt?.failed_purchases
-		? Object.values( receipt.failed_purchases )
-				.flat()
-				.map( ( item ) => ( {
-					productId: item.product_id,
-					productName: item.product_name,
-					productSlug: item.product_slug,
-					productCost: item.product_cost,
-					meta: item.product_meta,
-				} ) )
+		? failedItems.map( ( item ) => ( {
+				productId: item.product_id,
+				productName: item.product_name,
+				productSlug: item.product_slug,
+				productCost: item.product_cost,
+				meta: item.product_meta,
+		  } ) )
 		: undefined;
 
 	return (

--- a/client/my-sites/checkout/checkout-thank-you/failed-purchase-page.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/failed-purchase-page.tsx
@@ -1,6 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
 import DocumentHead from 'calypso/components/data/document-head';
 import Loading from 'calypso/components/loading';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -13,11 +12,10 @@ import './style.scss';
 
 export function FailedPurchasePage() {
 	const translate = useTranslate();
-	const location = useLocation();
 	const dispatch = useDispatch();
 
 	// Get receipt ID from query param: /checkout/failed-purchases?receipt_id=12345
-	const params = new URLSearchParams( location.search );
+	const params = new URLSearchParams( window.location.search );
 	const receiptId = params.get( 'receipt_id' );
 	const receiptIdNum = receiptId ? parseInt( receiptId, 10 ) : null;
 

--- a/client/my-sites/checkout/checkout-thank-you/failed-purchase-page.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/failed-purchase-page.tsx
@@ -27,7 +27,7 @@ export function FailedPurchasePage() {
 	// Fetch receipt if not already loaded
 	useEffect( () => {
 		if ( receiptIdNum && ! receipt?.data ) {
-			dispatch( fetchReceipt( receiptIdNum ) );
+			dispatch( fetchReceipt( receiptIdNum, true ) );
 		}
 	}, [ receiptIdNum, receipt?.data, dispatch ] );
 

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -181,7 +181,7 @@ function useRedirectOnTransactionSuccess( {
 		isSuccess: isReceiptSuccess,
 		isError: isReceiptError,
 	} = useQuery( {
-		...receiptQuery( finalReceiptId ?? 0 ),
+		...receiptQuery( finalReceiptId ?? 0, true ),
 		enabled: !! finalReceiptId,
 	} );
 	const isReceiptLoaded = isReceiptSuccess || isReceiptError;

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -181,7 +181,7 @@ function useRedirectOnTransactionSuccess( {
 		isSuccess: isReceiptSuccess,
 		isError: isReceiptError,
 	} = useQuery( {
-		...receiptQuery( finalReceiptId ?? 0, true ),
+		...receiptQuery( finalReceiptId ?? 0, { includeFailedPurchases: true } ),
 		enabled: !! finalReceiptId,
 	} );
 	const isReceiptLoaded = isReceiptSuccess || isReceiptError;
@@ -346,6 +346,7 @@ function useRedirectOnTransactionSuccess( {
 		blogId,
 		orderId,
 		productName,
+		receipt,
 		receiptId,
 		redirectTo,
 		reduxDispatch,

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -356,7 +356,6 @@ function useRedirectOnTransactionSuccess( {
 		translate,
 		fromSiteSlug,
 		resolvedPurchaseId,
-		receipt,
 	] );
 
 	return { headingText };

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -295,6 +295,7 @@ function useRedirectOnTransactionSuccess( {
 			saasRedirectUrl,
 			fromSiteSlug,
 			purchaseId: resolvedPurchaseId,
+			receipt,
 		} );
 
 		if ( ! redirectInstructions ) {
@@ -354,6 +355,7 @@ function useRedirectOnTransactionSuccess( {
 		translate,
 		fromSiteSlug,
 		resolvedPurchaseId,
+		receipt,
 	] );
 
 	return { headingText };

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -290,6 +290,7 @@ function useRedirectOnTransactionSuccess( {
 			siteSlug,
 			saasRedirectUrl,
 			fromSiteSlug,
+			receipt,
 		} );
 
 		if ( ! redirectInstructions ) {

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -181,7 +181,7 @@ function useRedirectOnTransactionSuccess( {
 		isSuccess: isReceiptSuccess,
 		isError: isReceiptError,
 	} = useQuery( {
-		...receiptQuery( finalReceiptId ?? 0, true ),
+		...receiptQuery( finalReceiptId ?? 0, { includeFailedPurchases: true } ),
 		enabled: !! finalReceiptId,
 	} );
 	const isReceiptLoaded = isReceiptSuccess || isReceiptError;
@@ -341,6 +341,7 @@ function useRedirectOnTransactionSuccess( {
 		blogId,
 		orderId,
 		productName,
+		receipt,
 		receiptId,
 		redirectTo,
 		reduxDispatch,

--- a/client/my-sites/checkout/checkout-thank-you/test/failed-purchase-page.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/test/failed-purchase-page.tsx
@@ -79,13 +79,18 @@ describe( 'FailedPurchasePage', () => {
 		} );
 	} );
 
-	it( 'maps successful items and flattens failed purchases across sites', () => {
+	it( 'labels successful items by their variation and flattens failed purchases across sites', () => {
 		setSearch( '?receipt_id=12345' );
 		setupUseQuery( {
 			data: {
 				items: [
-					{ id: 1, product: 'WordPress.com Personal', variation: 'Annual' },
-					{ id: 2, product: 'Domain', variation: 'example.com' },
+					{
+						id: 1,
+						product: 'wp-bundles',
+						variation: 'WordPress.com Premium',
+						wpcom_product_slug: 'value_bundle',
+						domain: 'example.wordpress.com',
+					},
 				],
 				failed_purchases: {
 					100: [
@@ -114,8 +119,7 @@ describe( 'FailedPurchasePage', () => {
 
 		expect( mockFailedPurchaseDetails ).toHaveBeenCalledWith( {
 			purchases: [
-				{ productId: 1, productName: 'WordPress.com Personal', meta: 'Annual' },
-				{ productId: 2, productName: 'Domain', meta: 'example.com' },
+				{ productId: 1, productName: 'WordPress.com Premium', meta: 'example.wordpress.com' },
 			],
 			failedPurchases: [
 				{
@@ -136,18 +140,90 @@ describe( 'FailedPurchasePage', () => {
 		} );
 	} );
 
-	it( 'passes undefined failedPurchases when the receipt reports none', () => {
-		setSearch( '?receipt_id=12345' );
+	it( 'excludes a failed item and its orphaned domain connection from the success list', () => {
+		// Mirrors a real partial-failure receipt: a plan succeeds, the .blog
+		// registration fails, and its domain connection is left orphaned. The failed
+		// registration and connection still appear in `items`, so both must be filtered.
+		setSearch( '?receipt_id=20691080' );
 		setupUseQuery( {
 			data: {
-				items: [ { id: 1, product: 'WordPress.com Personal', variation: 'Annual' } ],
+				items: [
+					{
+						id: 1,
+						product: 'wp-bundles',
+						variation: 'WordPress.com Premium',
+						wpcom_product_slug: 'value_bundle',
+						domain: 'eamartin.wordpress.com',
+					},
+					{
+						id: 2,
+						product: 'Domain',
+						variation: '.blog Domain Registration',
+						wpcom_product_slug: 'dotblog_domain',
+						domain: 'eamartin.blog',
+					},
+					{
+						id: 3,
+						product: 'Domain',
+						variation: 'Domain Connection',
+						wpcom_product_slug: 'domain_map',
+						domain: 'eamartin.blog',
+					},
+				],
+				failed_purchases: {
+					6144760: [
+						{
+							product_id: 76,
+							product_name: '.blog Domain Registration',
+							product_slug: 'dotblog_domain',
+							product_cost: 21,
+							product_meta: 'eamartin.blog',
+						},
+					],
+				},
 			},
 		} );
 
 		render( <FailedPurchasePage /> );
 
 		expect( mockFailedPurchaseDetails ).toHaveBeenCalledWith( {
-			purchases: [ { productId: 1, productName: 'WordPress.com Personal', meta: 'Annual' } ],
+			purchases: [
+				{ productId: 1, productName: 'WordPress.com Premium', meta: 'eamartin.wordpress.com' },
+			],
+			failedPurchases: [
+				{
+					productId: 76,
+					productName: '.blog Domain Registration',
+					productSlug: 'dotblog_domain',
+					productCost: 21,
+					meta: 'eamartin.blog',
+				},
+			],
+		} );
+	} );
+
+	it( 'passes undefined failedPurchases when the receipt reports none', () => {
+		setSearch( '?receipt_id=12345' );
+		setupUseQuery( {
+			data: {
+				items: [
+					{
+						id: 1,
+						product: 'wp-bundles',
+						variation: 'WordPress.com Premium',
+						wpcom_product_slug: 'value_bundle',
+						domain: 'example.wordpress.com',
+					},
+				],
+			},
+		} );
+
+		render( <FailedPurchasePage /> );
+
+		expect( mockFailedPurchaseDetails ).toHaveBeenCalledWith( {
+			purchases: [
+				{ productId: 1, productName: 'WordPress.com Premium', meta: 'example.wordpress.com' },
+			],
 			failedPurchases: undefined,
 		} );
 	} );

--- a/client/my-sites/checkout/checkout-thank-you/test/failed-purchase-page.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/test/failed-purchase-page.tsx
@@ -1,0 +1,154 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { FailedPurchasePage } from '../failed-purchase-page';
+
+const mockUseQuery = jest.fn();
+jest.mock( '@tanstack/react-query', () => ( {
+	useQuery: ( options: unknown ) => mockUseQuery( options ),
+} ) );
+
+const mockReceiptQuery = jest.fn();
+jest.mock( '@automattic/api-queries', () => ( {
+	receiptQuery: ( receiptId: number, options: unknown ) => mockReceiptQuery( receiptId, options ),
+} ) );
+
+jest.mock( 'calypso/lib/analytics/page-view-tracker', () => () => null );
+jest.mock( 'calypso/components/data/document-head', () => () => null );
+jest.mock( 'calypso/components/loading', () => () => <div data-testid="loading" /> );
+
+// Capture the props the page hands to the details component — that mapping is
+// the logic under test.
+const mockFailedPurchaseDetails = jest.fn();
+jest.mock( '../failed-purchase-details', () => ( props: unknown ) => {
+	mockFailedPurchaseDetails( props );
+	return <div data-testid="failed-purchase-details" />;
+} );
+
+type QueryResult = { data?: unknown; isLoading?: boolean };
+
+function setupUseQuery( response: QueryResult = {} ) {
+	mockUseQuery.mockReturnValue( {
+		data: response.data,
+		isLoading: response.isLoading ?? false,
+	} );
+}
+
+function setSearch( search: string ) {
+	window.history.pushState( {}, '', `/checkout/failed-purchases${ search }` );
+}
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	mockReceiptQuery.mockReturnValue( { queryKey: [ 'receipt' ], queryFn: jest.fn() } );
+	setSearch( '' );
+} );
+
+describe( 'FailedPurchasePage', () => {
+	it( 'requests the receipt with failed purchases included, keyed on the receipt_id query param', () => {
+		setSearch( '?receipt_id=12345' );
+		setupUseQuery( { data: undefined } );
+
+		render( <FailedPurchasePage /> );
+
+		expect( mockReceiptQuery ).toHaveBeenCalledWith( 12345, { includeFailedPurchases: true } );
+	} );
+
+	it( 'shows the loading state while the receipt is being fetched', () => {
+		setSearch( '?receipt_id=12345' );
+		setupUseQuery( { isLoading: true } );
+
+		render( <FailedPurchasePage /> );
+
+		expect( screen.getByTestId( 'loading' ) ).toBeVisible();
+		expect( screen.queryByTestId( 'failed-purchase-details' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'does not show the loading state when there is no receipt_id, even while loading', () => {
+		setSearch( '' );
+		setupUseQuery( { isLoading: true } );
+
+		render( <FailedPurchasePage /> );
+
+		expect( screen.queryByTestId( 'loading' ) ).not.toBeInTheDocument();
+		expect( screen.getByTestId( 'failed-purchase-details' ) ).toBeVisible();
+		expect( mockFailedPurchaseDetails ).toHaveBeenCalledWith( {
+			failedPurchases: undefined,
+			purchases: undefined,
+		} );
+	} );
+
+	it( 'maps successful items and flattens failed purchases across sites', () => {
+		setSearch( '?receipt_id=12345' );
+		setupUseQuery( {
+			data: {
+				items: [
+					{ id: 1, product: 'WordPress.com Personal', variation: 'Annual' },
+					{ id: 2, product: 'Domain', variation: 'example.com' },
+				],
+				failed_purchases: {
+					100: [
+						{
+							product_id: 50,
+							product_name: 'Failed Plugin',
+							product_slug: 'failed-plugin',
+							product_cost: '25',
+							product_meta: 'meta-a',
+						},
+					],
+					200: [
+						{
+							product_id: 60,
+							product_name: 'Failed Theme',
+							product_slug: 'failed-theme',
+							product_cost: 10,
+							product_meta: 'meta-b',
+						},
+					],
+				},
+			},
+		} );
+
+		render( <FailedPurchasePage /> );
+
+		expect( mockFailedPurchaseDetails ).toHaveBeenCalledWith( {
+			purchases: [
+				{ productId: 1, productName: 'WordPress.com Personal', meta: 'Annual' },
+				{ productId: 2, productName: 'Domain', meta: 'example.com' },
+			],
+			failedPurchases: [
+				{
+					productId: 50,
+					productName: 'Failed Plugin',
+					productSlug: 'failed-plugin',
+					productCost: '25',
+					meta: 'meta-a',
+				},
+				{
+					productId: 60,
+					productName: 'Failed Theme',
+					productSlug: 'failed-theme',
+					productCost: 10,
+					meta: 'meta-b',
+				},
+			],
+		} );
+	} );
+
+	it( 'passes undefined failedPurchases when the receipt reports none', () => {
+		setSearch( '?receipt_id=12345' );
+		setupUseQuery( {
+			data: {
+				items: [ { id: 1, product: 'WordPress.com Personal', variation: 'Annual' } ],
+			},
+		} );
+
+		render( <FailedPurchasePage /> );
+
+		expect( mockFailedPurchaseDetails ).toHaveBeenCalledWith( {
+			purchases: [ { productId: 1, productName: 'WordPress.com Personal', meta: 'Annual' } ],
+			failedPurchases: undefined,
+		} );
+	} );
+} );

--- a/client/my-sites/checkout/src/lib/pending-page.ts
+++ b/client/my-sites/checkout/src/lib/pending-page.ts
@@ -411,6 +411,24 @@ export function getRedirectFromPendingPage( {
 	const checkoutUrl = siteSlug ? `/checkout/${ siteSlug }` : '/checkout/no-site';
 	const errorUrl = '/checkout/failed-purchases';
 
+	// If the receipt reports that some purchases failed, route to the
+	// failed-purchases page instead of the normal thank-you flow. Returns
+	// `undefined` when there are no partial failures so callers can fall through.
+	const getFailedPurchaseRedirect = (
+		effectiveReceiptId: number | undefined
+	): RedirectInstructions | undefined => {
+		if ( receipt?.failed_purchases && Object.keys( receipt.failed_purchases ).length > 0 ) {
+			return {
+				url: filterAllowedRedirect(
+					`${ errorUrl }?receipt_id=${ effectiveReceiptId }`,
+					siteSlug || fromSiteSlug,
+					errorUrl
+				),
+			};
+		}
+		return undefined;
+	};
+
 	// If SaaS Product Redirect URL was passed then just return as redirect instruction so that
 	// we can redirect user immediately to vendor application.
 	if ( saasRedirectUrl ) {
@@ -429,24 +447,16 @@ export function getRedirectFromPendingPage( {
 	// (eg: for free purchases which do not use Orders), then the order must
 	// already be complete. In that case, we can redirect immediately.
 	if ( receiptId && ! isLoadingOrder && ! transaction ) {
-		// Check for partial failures before redirecting to the normal thank-you flow.
-		if ( receipt?.failed_purchases && Object.keys( receipt.failed_purchases ).length > 0 ) {
-			return {
-				url: filterAllowedRedirect(
-					`${ errorUrl }?receipt_id=${ receiptId }`,
-					siteSlug || fromSiteSlug,
-					errorUrl
-				),
-			};
-		}
-
-		return buildSuccessRedirect( {
-			effectiveReceiptId: receiptId,
-			redirectTo,
-			siteSlug,
-			fromSiteSlug,
-			purchaseId,
-		} );
+		return (
+			getFailedPurchaseRedirect( receiptId ) ??
+			buildSuccessRedirect( {
+				effectiveReceiptId: receiptId,
+				redirectTo,
+				siteSlug,
+				fromSiteSlug,
+				purchaseId,
+			} )
+		);
 	}
 
 	// If the order ID is missing and there is no receiptId, we don't know
@@ -462,24 +472,16 @@ export function getRedirectFromPendingPage( {
 	}
 
 	if ( transaction?.processingStatus === SUCCESS ) {
-		// Check for partial failures first
-		if ( receipt?.failed_purchases && Object.keys( receipt.failed_purchases ).length > 0 ) {
-			return {
-				url: filterAllowedRedirect(
-					`${ errorUrl }?receipt_id=${ receiptId }`,
-					siteSlug || fromSiteSlug,
-					errorUrl
-				),
-			};
-		}
-
-		return buildSuccessRedirect( {
-			effectiveReceiptId: transaction.receiptId,
-			redirectTo,
-			siteSlug,
-			fromSiteSlug,
-			purchaseId,
-		} );
+		return (
+			getFailedPurchaseRedirect( transaction.receiptId ?? receiptId ) ??
+			buildSuccessRedirect( {
+				effectiveReceiptId: transaction.receiptId,
+				redirectTo,
+				siteSlug,
+				fromSiteSlug,
+				purchaseId,
+			} )
+		);
 	}
 
 	// If the processing status indicates that there was something wrong,

--- a/client/my-sites/checkout/src/lib/pending-page.ts
+++ b/client/my-sites/checkout/src/lib/pending-page.ts
@@ -7,7 +7,7 @@ import {
 	PROCESSING,
 	ASYNC_PENDING,
 } from 'calypso/state/order-transactions/constants';
-import type { ReceiptData } from 'calypso/state/receipts/types';
+import type { Receipt } from '@automattic/api-core';
 import type { OrderTransaction } from 'calypso/state/selectors/get-order-transaction';
 
 export interface PendingPageRedirectOptions {
@@ -63,7 +63,7 @@ export interface RedirectForTransactionStatusArgs {
 	 * the caller resolves the ID.
 	 */
 	purchaseId?: number;
-	receipt?: ReceiptData;
+	receipt?: Receipt;
 }
 
 /**
@@ -452,7 +452,7 @@ export function getRedirectFromPendingPage( {
 
 	if ( transaction?.processingStatus === SUCCESS ) {
 		// Check for partial failures first
-		if ( receipt?.failedPurchases && Object.keys( receipt.failedPurchases ).length > 0 ) {
+		if ( receipt?.failed_purchases && Object.keys( receipt.failed_purchases ).length > 0 ) {
 			return {
 				url: filterAllowedRedirect(
 					`${ errorUrl }?receipt_id=${ receiptId }`,

--- a/client/my-sites/checkout/src/lib/pending-page.ts
+++ b/client/my-sites/checkout/src/lib/pending-page.ts
@@ -7,6 +7,7 @@ import {
 	PROCESSING,
 	ASYNC_PENDING,
 } from 'calypso/state/order-transactions/constants';
+import type { ReceiptData } from 'calypso/state/receipts/types';
 import type { OrderTransaction } from 'calypso/state/selectors/get-order-transaction';
 
 export interface PendingPageRedirectOptions {
@@ -62,6 +63,7 @@ export interface RedirectForTransactionStatusArgs {
 	 * the caller resolves the ID.
 	 */
 	purchaseId?: number;
+	receipt?: ReceiptData;
 }
 
 /**
@@ -404,6 +406,7 @@ export function getRedirectFromPendingPage( {
 	saasRedirectUrl,
 	fromSiteSlug,
 	purchaseId,
+	receipt,
 }: RedirectForTransactionStatusArgs ): RedirectInstructions | undefined {
 	const checkoutUrl = siteSlug ? `/checkout/${ siteSlug }` : '/checkout/no-site';
 	const errorUrl = '/checkout/failed-purchases';
@@ -448,6 +451,17 @@ export function getRedirectFromPendingPage( {
 	}
 
 	if ( transaction?.processingStatus === SUCCESS ) {
+		// Check for partial failures first
+		if ( receipt?.failedPurchases && Object.keys( receipt.failedPurchases ).length > 0 ) {
+			return {
+				url: filterAllowedRedirect(
+					`${ errorUrl }?receipt_id=${ receiptId }`,
+					siteSlug || fromSiteSlug,
+					errorUrl
+				),
+			};
+		}
+
 		return buildSuccessRedirect( {
 			effectiveReceiptId: transaction.receiptId,
 			redirectTo,

--- a/client/my-sites/checkout/src/lib/pending-page.ts
+++ b/client/my-sites/checkout/src/lib/pending-page.ts
@@ -429,6 +429,17 @@ export function getRedirectFromPendingPage( {
 	// (eg: for free purchases which do not use Orders), then the order must
 	// already be complete. In that case, we can redirect immediately.
 	if ( receiptId && ! isLoadingOrder && ! transaction ) {
+		// Check for partial failures before redirecting to the normal thank-you flow.
+		if ( receipt?.failed_purchases && Object.keys( receipt.failed_purchases ).length > 0 ) {
+			return {
+				url: filterAllowedRedirect(
+					`${ errorUrl }?receipt_id=${ receiptId }`,
+					siteSlug || fromSiteSlug,
+					errorUrl
+				),
+			};
+		}
+
 		return buildSuccessRedirect( {
 			effectiveReceiptId: receiptId,
 			redirectTo,

--- a/client/my-sites/checkout/src/lib/pending-page.ts
+++ b/client/my-sites/checkout/src/lib/pending-page.ts
@@ -371,6 +371,7 @@ export function getRedirectFromPendingPage( {
 	siteSlug,
 	saasRedirectUrl,
 	fromSiteSlug,
+	receipt,
 }: RedirectForTransactionStatusArgs ): RedirectInstructions | undefined {
 	const checkoutUrl = siteSlug ? `/checkout/${ siteSlug }` : '/checkout/no-site';
 	const errorUrl = '/checkout/failed-purchases';

--- a/client/my-sites/checkout/src/lib/pending-page.ts
+++ b/client/my-sites/checkout/src/lib/pending-page.ts
@@ -7,6 +7,7 @@ import {
 	PROCESSING,
 	ASYNC_PENDING,
 } from 'calypso/state/order-transactions/constants';
+import type { ReceiptData } from 'calypso/state/receipts/types';
 import type { OrderTransaction } from 'calypso/state/selectors/get-order-transaction';
 
 export interface PendingPageRedirectOptions {
@@ -53,6 +54,7 @@ export interface RedirectForTransactionStatusArgs {
 	 * logged in).
 	 */
 	fromSiteSlug?: string;
+	receipt?: ReceiptData;
 }
 
 /**
@@ -416,6 +418,17 @@ export function getRedirectFromPendingPage( {
 	}
 
 	if ( transaction?.processingStatus === SUCCESS ) {
+		// Check for partial failures first
+		if ( receipt?.failedPurchases && Object.keys( receipt.failedPurchases ).length > 0 ) {
+			return {
+				url: filterAllowedRedirect(
+					`${ errorUrl }?receipt_id=${ receiptId }`,
+					siteSlug || fromSiteSlug,
+					errorUrl
+				),
+			};
+		}
+
 		// If the order is complete, we can redirect to the final page.
 		const { receiptId: transactionReceiptId } = transaction;
 

--- a/client/my-sites/checkout/src/lib/pending-page.ts
+++ b/client/my-sites/checkout/src/lib/pending-page.ts
@@ -7,7 +7,7 @@ import {
 	PROCESSING,
 	ASYNC_PENDING,
 } from 'calypso/state/order-transactions/constants';
-import type { ReceiptData } from 'calypso/state/receipts/types';
+import type { Receipt } from '@automattic/api-core';
 import type { OrderTransaction } from 'calypso/state/selectors/get-order-transaction';
 
 export interface PendingPageRedirectOptions {
@@ -54,7 +54,7 @@ export interface RedirectForTransactionStatusArgs {
 	 * logged in).
 	 */
 	fromSiteSlug?: string;
-	receipt?: ReceiptData;
+	receipt?: Receipt;
 }
 
 /**
@@ -420,7 +420,7 @@ export function getRedirectFromPendingPage( {
 
 	if ( transaction?.processingStatus === SUCCESS ) {
 		// Check for partial failures first
-		if ( receipt?.failedPurchases && Object.keys( receipt.failedPurchases ).length > 0 ) {
+		if ( receipt?.failed_purchases && Object.keys( receipt.failed_purchases ).length > 0 ) {
 			return {
 				url: filterAllowedRedirect(
 					`${ errorUrl }?receipt_id=${ receiptId }`,

--- a/client/my-sites/checkout/src/lib/pending-page.ts
+++ b/client/my-sites/checkout/src/lib/pending-page.ts
@@ -394,6 +394,17 @@ export function getRedirectFromPendingPage( {
 	// (eg: for free purchases which do not use Orders), then the order must
 	// already be complete. In that case, we can redirect immediately.
 	if ( receiptId && ! isLoadingOrder && ! transaction ) {
+		// Check for partial failures before redirecting to the normal thank-you flow.
+		if ( receipt?.failed_purchases && Object.keys( receipt.failed_purchases ).length > 0 ) {
+			return {
+				url: filterAllowedRedirect(
+					`${ errorUrl }?receipt_id=${ receiptId }`,
+					siteSlug || fromSiteSlug,
+					errorUrl
+				),
+			};
+		}
+
 		return {
 			url: filterAllowedRedirect(
 				interpolateReceiptId(

--- a/client/state/receipts/actions.ts
+++ b/client/state/receipts/actions.ts
@@ -12,20 +12,15 @@ import type { WPCOMTransactionEndpointResponseSuccess } from '@automattic/wpcom-
 
 import 'calypso/state/receipts/init';
 
-export function fetchReceipt( receiptId: number, includeFailedPurchases = false ) {
+export function fetchReceipt( receiptId: number ) {
 	return ( dispatch: CalypsoDispatch ) => {
 		dispatch( {
 			type: RECEIPT_FETCH,
 			receiptId,
 		} );
 
-		let path = `/me/billing-history/receipt/${ receiptId }`;
-		if ( includeFailedPurchases ) {
-			path += '?include_failed_purchases=true';
-		}
-
 		return wpcom.req
-			.get( path )
+			.get( `/me/billing-history/receipt/${ receiptId }` )
 			.then( ( data: RawReceiptData ) => {
 				dispatch( fetchReceiptCompleted( receiptId, data ) );
 			} )

--- a/client/state/receipts/actions.ts
+++ b/client/state/receipts/actions.ts
@@ -12,15 +12,20 @@ import type { WPCOMTransactionEndpointResponseSuccess } from '@automattic/wpcom-
 
 import 'calypso/state/receipts/init';
 
-export function fetchReceipt( receiptId: number ) {
+export function fetchReceipt( receiptId: number, includeFailedPurchases = false ) {
 	return ( dispatch: CalypsoDispatch ) => {
 		dispatch( {
 			type: RECEIPT_FETCH,
 			receiptId,
 		} );
 
+		let path = `/me/billing-history/receipt/${ receiptId }`;
+		if ( includeFailedPurchases ) {
+			path += '?include_failed_purchases=true';
+		}
+
 		return wpcom.req
-			.get( `/me/billing-history/receipt/${ receiptId }` )
+			.get( path )
 			.then( ( data: RawReceiptData ) => {
 				dispatch( fetchReceiptCompleted( receiptId, data ) );
 			} )

--- a/packages/api-core/src/me-billing-history/fetchers.ts
+++ b/packages/api-core/src/me-billing-history/fetchers.ts
@@ -39,9 +39,17 @@ export async function fetchUserReceipts(): Promise< Receipt[] > {
 	return fullBillingHistory;
 }
 
-export async function fetchReceipt( receiptId: number ): Promise< Receipt > {
+export async function fetchReceipt(
+	receiptId: number,
+	includeFailedPurchases = false
+): Promise< Receipt > {
+	let path = `/me/billing-history/receipt/${ receiptId }`;
+	if ( includeFailedPurchases ) {
+		path += '?include_failed_purchases=true';
+	}
+
 	return wpcom.req.get( {
-		path: `/me/billing-history/receipt/${ receiptId }`,
+		path,
 		apiVersion: '1.2',
 	} );
 }

--- a/packages/api-core/src/me-billing-history/fetchers.ts
+++ b/packages/api-core/src/me-billing-history/fetchers.ts
@@ -41,10 +41,10 @@ export async function fetchUserReceipts(): Promise< Receipt[] > {
 
 export async function fetchReceipt(
 	receiptId: number,
-	includeFailedPurchases = false
+	options?: { includeFailedPurchases?: boolean }
 ): Promise< Receipt > {
 	let path = `/me/billing-history/receipt/${ receiptId }`;
-	if ( includeFailedPurchases ) {
+	if ( options?.includeFailedPurchases ) {
 		path += '?include_failed_purchases=true';
 	}
 

--- a/packages/api-core/src/me-billing-history/types.ts
+++ b/packages/api-core/src/me-billing-history/types.ts
@@ -110,6 +110,11 @@ export interface Receipt {
 	items: ReceiptItem[];
 	tax_vendor_info?: TaxVendorInfo;
 	checkout_type?: string;
+	/**
+	 * Line items that failed to provision during checkout, keyed by site (blog) ID.
+	 * Only populated when the receipt is fetched with `include_failed_purchases=true`;
+	 * omitted otherwise. Used to surface partial-failure orders on the failed-purchases page.
+	 */
 	failed_purchases?: Record<
 		string,
 		Array< {

--- a/packages/api-core/src/me-billing-history/types.ts
+++ b/packages/api-core/src/me-billing-history/types.ts
@@ -110,4 +110,14 @@ export interface Receipt {
 	items: ReceiptItem[];
 	tax_vendor_info?: TaxVendorInfo;
 	checkout_type?: string;
+	failed_purchases?: Record<
+		string,
+		Array< {
+			product_meta: string;
+			product_id: string | number;
+			product_slug: string;
+			product_cost: string | number;
+			product_name: string;
+		} >
+	>;
 }

--- a/packages/api-core/src/me-billing-history/types.ts
+++ b/packages/api-core/src/me-billing-history/types.ts
@@ -107,4 +107,14 @@ export interface Receipt {
 	items: ReceiptItem[];
 	tax_vendor_info?: TaxVendorInfo;
 	checkout_type?: string;
+	failed_purchases?: Record<
+		string,
+		Array< {
+			product_meta: string;
+			product_id: string | number;
+			product_slug: string;
+			product_cost: string | number;
+			product_name: string;
+		} >
+	>;
 }

--- a/packages/api-queries/src/me-billing-history.ts
+++ b/packages/api-queries/src/me-billing-history.ts
@@ -7,16 +7,15 @@ export const userReceiptsQuery = () =>
 		queryFn: () => fetchUserReceipts(),
 	} );
 
-export const receiptQueryKey = ( receiptId: number, includeFailedPurchases = false ) => [
-	'receipt',
-	receiptId,
-	includeFailedPurchases,
-];
+export const receiptQueryKey = (
+	receiptId: number,
+	options?: { includeFailedPurchases?: boolean }
+) => [ 'receipt', receiptId, options?.includeFailedPurchases ?? false ];
 
-export const receiptQuery = ( receiptId: number, includeFailedPurchases = false ) =>
+export const receiptQuery = ( receiptId: number, options?: { includeFailedPurchases?: boolean } ) =>
 	queryOptions( {
-		queryKey: receiptQueryKey( receiptId, includeFailedPurchases ),
-		queryFn: () => fetchReceipt( receiptId, includeFailedPurchases ),
+		queryKey: receiptQueryKey( receiptId, options ),
+		queryFn: () => fetchReceipt( receiptId, options ),
 	} );
 
 export const sendReceiptEmailMutation = () =>

--- a/packages/api-queries/src/me-billing-history.ts
+++ b/packages/api-queries/src/me-billing-history.ts
@@ -16,11 +16,7 @@ export const receiptQueryKey = ( receiptId: number, includeFailedPurchases = fal
 export const receiptQuery = ( receiptId: number, includeFailedPurchases = false ) =>
 	queryOptions( {
 		queryKey: receiptQueryKey( receiptId, includeFailedPurchases ),
-		queryFn: () =>
-			fetchReceipt(
-				receiptId,
-				includeFailedPurchases ? { includeFailedPurchases: 'true' } : undefined
-			),
+		queryFn: () => fetchReceipt( receiptId, includeFailedPurchases ),
 	} );
 
 export const sendReceiptEmailMutation = () =>

--- a/packages/api-queries/src/me-billing-history.ts
+++ b/packages/api-queries/src/me-billing-history.ts
@@ -7,12 +7,20 @@ export const userReceiptsQuery = () =>
 		queryFn: () => fetchUserReceipts(),
 	} );
 
-export const receiptQueryKey = ( receiptId: number ) => [ 'receipt', receiptId ];
+export const receiptQueryKey = ( receiptId: number, includeFailedPurchases = false ) => [
+	'receipt',
+	receiptId,
+	includeFailedPurchases,
+];
 
-export const receiptQuery = ( receiptId: number ) =>
+export const receiptQuery = ( receiptId: number, includeFailedPurchases = false ) =>
 	queryOptions( {
-		queryKey: receiptQueryKey( receiptId ),
-		queryFn: () => fetchReceipt( receiptId ),
+		queryKey: receiptQueryKey( receiptId, includeFailedPurchases ),
+		queryFn: () =>
+			fetchReceipt(
+				receiptId,
+				includeFailedPurchases ? { includeFailedPurchases: 'true' } : undefined
+			),
 	} );
 
 export const sendReceiptEmailMutation = () =>


### PR DESCRIPTION
Part of [SHILL-217](https://linear.app/a8c/issue/SHILL-217/order-step-not-being-created-for-unexpected-error-in-paypal-ppcp)

## Summary

Wire up the client-side routing and receipt data display for orders with partial item failures. Users now see exactly which items failed, which succeeded, and the refund amount instead of a generic error message.

Depends on 211405-ghe-Automattic/wpcom

## Changes

- **pending-page.ts**: Add check for `receipt.failedPurchases` when transaction status is SUCCESS. If failures exist, route to failed-purchases page instead of thank-you page.
- **pending/index.tsx**: Pass receipt data to the redirect routing function.
- **failed-purchase-page.tsx**: Load receipt data from Redux using receipt_id query parameter and pass failed/successful purchases to the details component.

## Test plan

- [ ] Order with partial failures completes and routes to `/checkout/failed-purchases?receipt_id=XXX`
- [ ] Failed purchases page displays: list of failed items, list of successful items, refund amount
- [ ] Order with all successful items routes to normal thank-you page
- [ ] Page handles loading state while fetching receipt
- [ ] No regressions in normal checkout flow

## Related

Pairs with server-side changes in wpcom repo that:
- Remove exception update that was causing orders to get stuck
- Add failed_purchases to receipt API response