### PR TITLE
Dashboard: tighten user-facing notice text

### DIFF
--- a/client/dashboard/app/staging-site-sync-monitor/index.tsx
+++ b/client/dashboard/app/staging-site-sync-monitor/index.tsx
@@ -31,7 +31,7 @@ export default function StagingSiteSyncMonitor( { site }: StagingSiteSyncMonitor
 	useEffect( () => {
 		if ( productionSiteId && wasSyncingRef.current && ! isSyncing ) {
 			if ( stagingSiteSyncState?.status === 'completed' ) {
-				createSuccessNotice( __( 'Synchronization completed successfully.' ), {
+				createSuccessNotice( __( 'Synchronization completed.' ), {
 					type: 'snackbar',
 					explicitDismiss: true,
 				} );

--- a/client/dashboard/domains/dns/add.tsx
+++ b/client/dashboard/domains/dns/add.tsx
@@ -22,7 +22,7 @@ export default function DomainAddDNS() {
 		meta: {
 			snackbar: {
 				/* translators: %s is the domain name */
-				success: sprintf( __( 'DNS record added successfully for %s.' ), domainName ),
+				success: sprintf( __( 'DNS record added for %s.' ), domainName ),
 				error: { source: 'server' },
 			},
 		},

--- a/client/dashboard/domains/dns/edit.tsx
+++ b/client/dashboard/domains/dns/edit.tsx
@@ -25,7 +25,7 @@ export default function DomainEditDNS() {
 		meta: {
 			snackbar: {
 				/* translators: %s is the domain name */
-				success: sprintf( __( 'DNS record updated successfully for %s.' ), domainName ),
+				success: sprintf( __( 'DNS record updated for %s.' ), domainName ),
 				error: { source: 'server' },
 			},
 		},

--- a/client/dashboard/domains/domain-connection-setup/index.tsx
+++ b/client/dashboard/domains/domain-connection-setup/index.tsx
@@ -102,7 +102,7 @@ export default function DomainConnection() {
 				setConnectionMode( data.mode );
 			},
 			onError: () => {
-				createErrorNotice( __( 'We could not verify your domain connection. Please try again.' ), {
+				createErrorNotice( __( 'Failed to verify domain connection.' ), {
 					type: 'snackbar',
 				} );
 			},
@@ -129,7 +129,7 @@ export default function DomainConnection() {
 				} );
 			},
 			onError: () => {
-				createErrorNotice( __( 'We could not restart your domain connection. Please try again.' ), {
+				createErrorNotice( __( 'Failed to restart domain connection.' ), {
 					type: 'snackbar',
 				} );
 			},

--- a/client/dashboard/domains/domain-connection-setup/transfer-setup.tsx
+++ b/client/dashboard/domains/domain-connection-setup/transfer-setup.tsx
@@ -153,7 +153,7 @@ export default function DomainTransferSetup() {
 				createSuccessNotice(
 					sprintf(
 						// translators: %s is a domain name
-						__( 'Domain transfer for %s has started successfully.' ),
+						__( 'Domain transfer for %s started.' ),
 						domainName
 					),
 					{ type: 'snackbar' }

--- a/client/dashboard/domains/domain-contact-details/index.tsx
+++ b/client/dashboard/domains/domain-contact-details/index.tsx
@@ -67,7 +67,7 @@ export default function DomainContactInfo() {
 		meta: {
 			snackbar: {
 				/* translators: %s is the domain name */
-				success: sprintf( __( 'Privacy has been successfully updated for %s!' ), domainName ),
+				success: sprintf( __( 'Privacy protection saved for %s.' ), domainName ),
 				error: { source: 'server' },
 			},
 		},
@@ -77,11 +77,7 @@ export default function DomainContactInfo() {
 		...domainPrivacyDiscloseSaveMutation( domainName ),
 		meta: {
 			snackbar: {
-				success: sprintf(
-					/* translators: %s is the domain name */
-					__( 'Your contact information for %s is now publicly visible!' ),
-					domainName
-				),
+				success: __( 'Contact information disclosed.' ),
 				error: { source: 'server' },
 			},
 		},
@@ -90,8 +86,7 @@ export default function DomainContactInfo() {
 		...domainPrivacyDiscloseSaveMutation( domainName ),
 		meta: {
 			snackbar: {
-				/* translators: %s is the domain name */
-				success: sprintf( __( 'Your contact information for %s is now redacted!' ), domainName ),
+				success: __( 'Contact information redacted.' ),
 				error: { source: 'server' },
 			},
 		},

--- a/client/dashboard/domains/domain-contact-verification/index.tsx
+++ b/client/dashboard/domains/domain-contact-verification/index.tsx
@@ -91,7 +91,7 @@ export default function DomainContactVerification() {
 		} );
 		domainContactVerification( formData, {
 			onSuccess: () => {
-				createSuccessNotice( __( 'Files submitted successfully.' ), { type: 'snackbar' } );
+				createSuccessNotice( __( 'Files submitted.' ), { type: 'snackbar' } );
 				setSubmitted( true );
 			},
 			onError: () => {

--- a/client/dashboard/domains/domain-overview/actions.tsx
+++ b/client/dashboard/domains/domain-overview/actions.tsx
@@ -80,7 +80,7 @@ export default function Actions( { isDisabled }: { isDisabled?: boolean } ) {
 			purchase &&
 			deleteDomain( purchase.ID, {
 				onSuccess: () => {
-					createSuccessNotice( __( 'The domain deletion has been completed.' ), {
+					createSuccessNotice( __( 'Domain deleted.' ), {
 						type: 'snackbar',
 					} );
 					router.navigate( { to: domainsIndexRoute.fullPath } );

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
@@ -70,7 +70,7 @@ export default function TransferDomainToAnyUser() {
 			...updateDomainTransferRequestMutation( domainName, domain.site_slug ),
 			meta: {
 				snackbar: {
-					success: __( 'A domain transfer request has been emailed to the recipient’s address.' ),
+					success: __( 'Domain transfer request sent.' ),
 					error: __( 'Failed to initiate domain transfer.' ),
 				},
 			},

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-other-site.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-other-site.tsx
@@ -37,17 +37,14 @@ export default function DomainTransferToOtherSite() {
 		!! selectedSite &&
 			transferDomainToSite( selectedSite.ID, {
 				onSuccess: () => {
-					createSuccessNotice( __( 'Domain transferred successfully.' ), { type: 'snackbar' } );
+					createSuccessNotice( __( 'Domain transferred.' ), { type: 'snackbar' } );
 					setIsConfirmDialogOpen( false );
 					navigate( { to: domainRoute.fullPath, params: { domainName } } );
 				},
 				onError: ( e ) => {
-					createErrorNotice(
-						e.message || __( 'An error occurred while transferring the domain.' ),
-						{
-							type: 'snackbar',
-						}
-					);
+					createErrorNotice( e.message || __( 'Failed to transfer domain.' ), {
+						type: 'snackbar',
+					} );
 				},
 			} );
 	};

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-other-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-other-user.tsx
@@ -116,7 +116,7 @@ export default function TransferDomainToOtherUser() {
 				createSuccessNotice(
 					sprintf(
 						/* Translators: %s: domainName is the domain name, %s: selectedUserDisplay is the selected user display */
-						__( '%(selectedDomainName)s has been transferred to %(selectedUserDisplay)s' ),
+						__( '%(selectedDomainName)s transferred to %(selectedUserDisplay)s.' ),
 						{
 							args: {
 								selectedDomainName: domainName,

--- a/client/dashboard/domains/name-servers/index.tsx
+++ b/client/dashboard/domains/name-servers/index.tsx
@@ -35,7 +35,7 @@ export default function NameServers() {
 		meta: {
 			snackbar: {
 				/* translators: %s is the domain name */
-				success: sprintf( __( 'Name servers for %s updated successfully.' ), domainName ),
+				success: sprintf( __( 'Name servers for %s updated.' ), domainName ),
 				error: { source: 'server' },
 			},
 		},

--- a/client/dashboard/emails/dataviews/actions/delete-email-forward.tsx
+++ b/client/dashboard/emails/dataviews/actions/delete-email-forward.tsx
@@ -47,7 +47,7 @@ export const useDeleteEmailForwardAction = (): Action< Email > => {
 					createSuccessNotice(
 						sprintf(
 							/* translators: %1$s is the email and %2$s is the forwarding destination address. */
-							__( 'Forwarder from %1$s to %2$s has been removed.' ),
+							__( 'Forwarder from %1$s to %2$s removed.' ),
 							email.emailAddress,
 							email.forwardingTo as string
 						),

--- a/client/dashboard/emails/dataviews/actions/resend-verification.ts
+++ b/client/dashboard/emails/dataviews/actions/resend-verification.ts
@@ -37,7 +37,7 @@ export const useResendVerificationAction = (): Action< Email > => {
 					createSuccessNotice(
 						sprintf(
 							/* translators: %1$s is the forwarding source email address, %2$s is the destination address. */
-							__( 'Successfully sent confirmation email for %1$s to %2$s.' ),
+							__( 'Confirmation email sent for %1$s to %2$s.' ),
 							email.emailAddress,
 							email.forwardingTo
 						),

--- a/client/dashboard/me/billing-history/dataviews.tsx
+++ b/client/dashboard/me/billing-history/dataviews.tsx
@@ -57,7 +57,7 @@ export function useActions() {
 		...sendReceiptEmailMutation(),
 		meta: {
 			snackbar: {
-				success: __( 'Your receipt was sent by email successfully.' ),
+				success: __( 'Receipt sent by email.' ),
 				error: __(
 					'There was a problem sending your receipt. Please try again later or contact support.'
 				),

--- a/client/dashboard/me/billing-history/receipt.tsx
+++ b/client/dashboard/me/billing-history/receipt.tsx
@@ -191,7 +191,7 @@ function UserVatDetails( { receipt }: { receipt: Receipt } ) {
 		...sendReceiptEmailMutation(),
 		meta: {
 			snackbar: {
-				success: __( 'Your receipt was sent by email successfully.' ),
+				success: __( 'Receipt sent by email.' ),
 				error: __(
 					'There was a problem sending your receipt. Please try again later or contact support.'
 				),

--- a/client/dashboard/me/billing-monetize-subscriptions/monetize-subscription.tsx
+++ b/client/dashboard/me/billing-monetize-subscriptions/monetize-subscription.tsx
@@ -167,12 +167,12 @@ function StopSubscriptionButton( {
 					onClick={ () => {
 						stopSubscription( null, {
 							onSuccess: () => {
-								createSuccessNotice( __( 'This item has been removed.' ), { type: 'snackbar' } );
+								createSuccessNotice( __( 'Item removed.' ), { type: 'snackbar' } );
 								navigate( { to: monetizeSubscriptionsRoute.fullPath } );
 							},
 							onError: () => {
 								if ( isProduct ) {
-									createErrorNotice( __( 'There was a problem while removing your product.' ), {
+									createErrorNotice( __( 'Failed to remove product.' ), {
 										actions: [
 											{
 												url: CALYPSO_CONTACT,

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -579,7 +579,7 @@ export default function CancelPurchase() {
 	] );
 
 	if ( offerApplyError ) {
-		createErrorNotice( __( 'There was an error getting the discount!' ), { type: 'snackbar' } );
+		createErrorNotice( __( 'Failed to get discount.' ), { type: 'snackbar' } );
 	}
 
 	const recordClickRadioEvent = ( option: string, value: string ) => {

--- a/client/dashboard/me/billing-purchases/payment-method-selector/index.tsx
+++ b/client/dashboard/me/billing-purchases/payment-method-selector/index.tsx
@@ -184,7 +184,7 @@ function onPaymentSelectComplete( {
 	if ( purchase ) {
 		showSuccessMessage( __( 'Your payment method has been set.' ) );
 	} else {
-		showSuccessMessage( __( 'Your payment method has been added successfully.' ) );
+		showSuccessMessage( __( 'Payment method added.' ) );
 	}
 	successCallback();
 }

--- a/client/dashboard/me/billing-tax-details/user-tax-form.tsx
+++ b/client/dashboard/me/billing-tax-details/user-tax-form.tsx
@@ -175,7 +175,7 @@ export default function UserTaxForm() {
 				createSuccessNotice(
 					sprintf(
 						/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
-						__( 'Your %s details have been updated!' ),
+						__( '%s details saved.' ),
 						taxName ?? __( 'VAT' )
 					),
 					{

--- a/client/dashboard/me/hosting-dashboard/index.tsx
+++ b/client/dashboard/me/hosting-dashboard/index.tsx
@@ -87,7 +87,7 @@ export default function HostingDashboard() {
 					<CardBody>
 						<VStack spacing={ 4 } alignment="flex-start">
 							<SectionHeader
-								title={ __( 'New hosting dashboard' ) }
+								title={ __( 'New Hosting Dashboard' ) }
 								description={ __(
 									"We've recently updated the dashboard with a modern design and smarter tools for managing your hosting."
 								) }
@@ -96,7 +96,7 @@ export default function HostingDashboard() {
 							<ToggleControl
 								__nextHasNoMarginBottom
 								checked={ isEnabled }
-								label={ __( 'Enable new hosting dashboard' ) }
+								label={ __( 'Enable new Hosting Dashboard' ) }
 								disabled={ isPending }
 								onChange={ handleToggle }
 							/>

--- a/client/dashboard/me/notifications-comments/device-settings/index.tsx
+++ b/client/dashboard/me/notifications-comments/device-settings/index.tsx
@@ -84,7 +84,7 @@ export const DevicesSettings = () => {
 					);
 				},
 				onError: () => {
-					createErrorNotice( __( 'There was a problem saving your changes. Please, try again.' ), {
+					createErrorNotice( __( 'Failed to save changes.' ), {
 						type: 'snackbar',
 					} );
 				},

--- a/client/dashboard/me/notifications-comments/email-settings/index.tsx
+++ b/client/dashboard/me/notifications-comments/email-settings/index.tsx
@@ -56,7 +56,7 @@ export const EmailSettings = () => {
 					);
 				},
 				onError: () => {
-					createErrorNotice( __( 'There was a problem saving your changes. Please, try again.' ), {
+					createErrorNotice( __( 'Failed to save changes.' ), {
 						type: 'snackbar',
 					} );
 				},

--- a/client/dashboard/me/notifications-comments/web-settings/index.tsx
+++ b/client/dashboard/me/notifications-comments/web-settings/index.tsx
@@ -64,7 +64,7 @@ export const WebSettings = () => {
 					);
 				},
 				onError: () => {
-					createErrorNotice( __( 'There was a problem saving your changes. Please, try again.' ), {
+					createErrorNotice( __( 'Failed to save changes.' ), {
 						type: 'snackbar',
 					} );
 				},

--- a/client/dashboard/me/notifications-sites/site-settings/device-settings/index.tsx
+++ b/client/dashboard/me/notifications-sites/site-settings/device-settings/index.tsx
@@ -77,7 +77,7 @@ export const DevicesSettings = ( { siteId }: { siteId: number } ) => {
 					);
 				},
 				onError: () => {
-					createErrorNotice( __( 'There was a problem saving your changes. Please, try again.' ), {
+					createErrorNotice( __( 'Failed to save changes.' ), {
 						type: 'snackbar',
 					} );
 				},
@@ -159,7 +159,7 @@ export const DevicesSettings = ( { siteId }: { siteId: number } ) => {
 						device_to_be_used_as_template: siteId,
 						site_to_be_used_as_template: siteId,
 					} );
-					createSuccessNotice( __( 'Settings saved successfully.' ), { type: 'snackbar' } );
+					createSuccessNotice( __( 'Settings saved.' ), { type: 'snackbar' } );
 					setIsConfirmDialogOpen( false );
 				},
 			}

--- a/client/dashboard/me/notifications-sites/site-settings/device-settings/test/index.test.tsx
+++ b/client/dashboard/me/notifications-sites/site-settings/device-settings/test/index.test.tsx
@@ -350,7 +350,7 @@ describe( 'DevicesSettings', () => {
 			expect( updatedSettingsApi.isDone() ).toBe( true );
 			const snackbar = notificationSnackBar();
 			expect( snackbar ).toBeVisible();
-			expect( snackbar ).toHaveTextContent( 'Settings saved successfully.' );
+			expect( snackbar ).toHaveTextContent( 'Settings saved.' );
 		} );
 
 		expect(

--- a/client/dashboard/me/notifications-sites/site-settings/email-settings/index.tsx
+++ b/client/dashboard/me/notifications-sites/site-settings/email-settings/index.tsx
@@ -49,7 +49,7 @@ export const EmailSettings = ( { siteId }: { siteId: number } ) => {
 					} );
 				},
 				onError: () => {
-					createErrorNotice( __( 'There was a problem saving your changes. Please, try again.' ), {
+					createErrorNotice( __( 'Failed to save changes.' ), {
 						type: 'snackbar',
 					} );
 				},
@@ -79,7 +79,7 @@ export const EmailSettings = ( { siteId }: { siteId: number } ) => {
 						stream: 'email',
 						site_to_be_used_as_template: siteId,
 					} );
-					createSuccessNotice( __( 'Settings saved successfully.' ), { type: 'snackbar' } );
+					createSuccessNotice( __( 'Settings saved.' ), { type: 'snackbar' } );
 					setIsConfirmDialogOpen( false );
 				},
 			}

--- a/client/dashboard/me/notifications-sites/site-settings/email-settings/test/index.test.tsx
+++ b/client/dashboard/me/notifications-sites/site-settings/email-settings/test/index.test.tsx
@@ -237,7 +237,7 @@ describe( 'EmailSettings', () => {
 			expect( updatedSettingsApi.isDone() ).toBe( true );
 			const snackbar = notificationSnackBar();
 			expect( snackbar ).toBeVisible();
-			expect( snackbar ).toHaveTextContent( 'Settings saved successfully.' );
+			expect( snackbar ).toHaveTextContent( 'Settings saved.' );
 			expect(
 				screen.queryByRole( 'dialog', { name: 'Apply to all sites?' } )
 			).not.toBeInTheDocument();

--- a/client/dashboard/me/notifications-sites/site-settings/web-settings/index.tsx
+++ b/client/dashboard/me/notifications-sites/site-settings/web-settings/index.tsx
@@ -52,7 +52,7 @@ export const WebSettings = ( { siteId }: { siteId: number } ) => {
 					} );
 				},
 				onError: () => {
-					createErrorNotice( __( 'There was a problem saving your changes. Please, try again.' ), {
+					createErrorNotice( __( 'Failed to save changes.' ), {
 						type: 'snackbar',
 					} );
 				},
@@ -83,7 +83,7 @@ export const WebSettings = ( { siteId }: { siteId: number } ) => {
 						stream: 'timeline',
 						site_to_be_used_as_template: siteId,
 					} );
-					createSuccessNotice( __( 'Settings saved successfully.' ), { type: 'snackbar' } );
+					createSuccessNotice( __( 'Settings saved.' ), { type: 'snackbar' } );
 
 					setIsConfirmDialogOpen( false );
 				},

--- a/client/dashboard/me/notifications-sites/site-settings/web-settings/test/index.test.tsx
+++ b/client/dashboard/me/notifications-sites/site-settings/web-settings/test/index.test.tsx
@@ -240,7 +240,7 @@ describe( 'WebSettings', () => {
 			expect( updatedSettingsApi.isDone() ).toBe( true );
 			const snackbar = notificationSnackBar();
 			expect( snackbar ).toBeVisible();
-			expect( snackbar ).toHaveTextContent( 'Settings saved successfully.' );
+			expect( snackbar ).toHaveTextContent( 'Settings saved.' );
 			expect(
 				screen.queryByRole( 'dialog', { name: 'Apply to all sites?' } )
 			).not.toBeInTheDocument();

--- a/client/dashboard/me/profile-gravatar/index.tsx
+++ b/client/dashboard/me/profile-gravatar/index.tsx
@@ -125,7 +125,7 @@ export default function GravatarProfileSection() {
 		mutation.mutate( edits, {
 			onSuccess: () => {
 				setEdits( {} );
-				createSuccessNotice( __( 'Public Gravatar profile saved successfully.' ), {
+				createSuccessNotice( __( 'Public Gravatar profile saved.' ), {
 					type: 'snackbar',
 				} );
 			},

--- a/client/dashboard/me/profile-personal-details/update-email/email-verification-banner.tsx
+++ b/client/dashboard/me/profile-personal-details/update-email/email-verification-banner.tsx
@@ -153,7 +153,7 @@ export default function EmailVerificationBanner( { userData }: EmailVerification
 			>
 				{ wasEmailChange
 					? __( 'Make sure you update your contact information for any registered domains.' )
-					: __( 'Your email address has been verified successfully.' ) }
+					: __( 'Your email address has been verified.' ) }
 			</Notice>
 		);
 	}

--- a/client/dashboard/me/security-password/index.tsx
+++ b/client/dashboard/me/security-password/index.tsx
@@ -106,7 +106,7 @@ export default function SecurityPassword() {
 				/>
 			}
 		>
-			<FlashMessage id="password" message={ __( 'Your password was saved successfully.' ) } />
+			<FlashMessage id="password" message={ __( 'Password saved.' ) } />
 			<Card className="security-password-card">
 				<CardBody>
 					<form onSubmit={ handleSubmit }>

--- a/client/dashboard/me/security-social-logins/google-login.tsx
+++ b/client/dashboard/me/security-social-logins/google-login.tsx
@@ -114,7 +114,7 @@ export default function GoogleLogin( {
 
 		if ( ! googleSignIn ) {
 			setShowLoading( false );
-			createErrorNotice( __( 'Something went wrong while trying to load Google sign-in.' ), {
+			createErrorNotice( __( 'Failed to load Google sign-in.' ), {
 				type: 'snackbar',
 			} );
 			return;

--- a/client/dashboard/plugins/plugin/components/autoupdate-toggle.tsx
+++ b/client/dashboard/plugins/plugin/components/autoupdate-toggle.tsx
@@ -64,7 +64,7 @@ export const AutoupdateToggle = ( {
 			} }
 			successOn={ sprintf(
 				// translators: %s is the name of the plugin.
-				__( 'Auto‑updates for %s have been enabled.' ),
+				__( 'Auto‑updates for %s enabled.' ),
 				plugin?.name ?? ''
 			) }
 			errorOn={ sprintf(
@@ -74,7 +74,7 @@ export const AutoupdateToggle = ( {
 			) }
 			successOff={ sprintf(
 				// translators: %s is the name of the plugin.
-				__( 'Auto‑updates for %s have been disabled.' ),
+				__( 'Auto‑updates for %s disabled.' ),
 				plugin?.name ?? ''
 			) }
 			errorOff={ sprintf(

--- a/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
+++ b/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
@@ -497,7 +497,7 @@ export const SitesWithThisPlugin = ( {
 				onExecute={ updateAction }
 				onActionPerformed={ invalidatePlugins }
 				onRequestClose={ closeUpdateModal }
-				title={ __( 'Update Plugin' ) }
+				title={ __( 'Update plugin' ) }
 			/>
 		</div>
 	);

--- a/client/dashboard/plugins/scheduled-updates/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/index.tsx
@@ -208,7 +208,7 @@ export default function PluginsScheduledUpdates() {
 		try {
 			setIsDeletingSchedule( true );
 			await deleteSchedules();
-			createSuccessNotice( __( 'Schedule deleted successfully.' ), { type: 'snackbar' } );
+			createSuccessNotice( __( 'Schedule deleted.' ), { type: 'snackbar' } );
 		} catch ( e ) {
 			const message = e instanceof Error ? e.message : __( 'Failed to delete schedule.' );
 			createErrorNotice( message, { type: 'snackbar' } );

--- a/client/dashboard/plugins/scheduled-updates/new/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/new/index.tsx
@@ -29,7 +29,7 @@ function ScheduledUpdatesNew() {
 	const handleSave: ScheduledUpdatesFormOnSubmit = useCallback(
 		async ( inputs ) => {
 			await runCreate( inputs );
-			createSuccessNotice( __( 'Schedule created successfully.' ), { type: 'snackbar' } );
+			createSuccessNotice( __( 'Schedule created.' ), { type: 'snackbar' } );
 			navigate( { to: pluginsScheduledUpdatesRoute.to } );
 		},
 		[ navigate, runCreate, createSuccessNotice ]

--- a/client/dashboard/sites/backup-restore/index.tsx
+++ b/client/dashboard/sites/backup-restore/index.tsx
@@ -58,7 +58,7 @@ function SiteBackupRestore() {
 	const handleRestoreComplete = () => {
 		recordTracksEvent( 'calypso_dashboard_backups_restore_completed' );
 		setCurrentStep( 'success' );
-		createSuccessNotice( __( 'Site restore completed.' ), {
+		createSuccessNotice( __( 'Site restored.' ), {
 			type: 'snackbar',
 		} );
 	};

--- a/client/dashboard/sites/jetpack-site-disconnect/index.tsx
+++ b/client/dashboard/sites/jetpack-site-disconnect/index.tsx
@@ -116,7 +116,7 @@ function ContentConfirmDisconnect( {
 				createSuccessNotice(
 					sprintf(
 						/* translators: %s: site domain */
-						__( '%s has been disconnected.' ),
+						__( '%s disconnected.' ),
 						site.slug
 					),
 					{ type: 'snackbar' }

--- a/client/dashboard/sites/logs/dataviews/actions.tsx
+++ b/client/dashboard/sites/logs/dataviews/actions.tsx
@@ -53,7 +53,7 @@ export function useActions( {
 						await navigator.clipboard.writeText( message );
 						createSuccessNotice( __( 'Copied message.' ), { type: 'snackbar' } );
 					} catch ( e ) {
-						createErrorNotice( __( 'Message could not be copied.' ), { type: 'snackbar' } );
+						createErrorNotice( __( 'Failed to copy message.' ), { type: 'snackbar' } );
 					}
 				},
 			};
@@ -89,7 +89,7 @@ export function useActions( {
 					await navigator.clipboard.writeText( url );
 					createSuccessNotice( __( 'Copied request URL.' ), { type: 'snackbar' } );
 				} catch ( e ) {
-					createErrorNotice( __( 'Request URL could not be copied.' ), { type: 'snackbar' } );
+					createErrorNotice( __( 'Failed to copy URL.' ), { type: 'snackbar' } );
 				}
 			},
 		};

--- a/client/dashboard/sites/migration-overview/pending-content-info.tsx
+++ b/client/dashboard/sites/migration-overview/pending-content-info.tsx
@@ -162,7 +162,7 @@ export function PendingContentInfo( {
 									onClick={ () => {
 										navigator.clipboard.writeText( migrationKey );
 										recordTracksEvent( 'calypso_dashboard_migration_in_progress_copy_key_click' );
-										createSuccessNotice( __( 'Migration key copied successfully.' ), {
+										createSuccessNotice( __( 'Migration key copied.' ), {
 											type: 'snackbar',
 										} );
 									} }

--- a/client/dashboard/sites/settings-database/index.tsx
+++ b/client/dashboard/sites/settings-database/index.tsx
@@ -56,7 +56,7 @@ export default function SiteDatabaseSettings( { siteSlug }: { siteSlug: string }
 
 	const handleResetPasswordSuccess = () => {
 		setIsResetPasswordModalOpen( false );
-		createSuccessNotice( __( 'Your database password has been restored.' ), {
+		createSuccessNotice( __( 'Database password restored.' ), {
 			type: 'snackbar',
 		} );
 	};

--- a/client/dashboard/sites/settings-redirect/create-site-redirect.tsx
+++ b/client/dashboard/sites/settings-redirect/create-site-redirect.tsx
@@ -46,7 +46,9 @@ export default function CreateSiteRedirect( {
 		);
 		const { data, isError, error } = await refetch();
 		if ( isError || ! data.can_redirect ) {
-			createErrorNotice( error?.message ?? __( 'Something went wrong' ), { type: 'snackbar' } );
+			createErrorNotice( error?.message ?? __( 'Failed to create site redirect.' ), {
+				type: 'snackbar',
+			} );
 			setIsSubmitting( false );
 			return;
 		}

--- a/client/dashboard/sites/settings-redirect/manage-site-redirect.tsx
+++ b/client/dashboard/sites/settings-redirect/manage-site-redirect.tsx
@@ -28,7 +28,7 @@ export default function ManageSiteRedirect( { siteId, currentRedirect }: ManageS
 	const handleSubmit = ( formData: SiteRedirectFormData ) => {
 		updateSiteRedirect( formData.redirect ?? '', {
 			onSuccess: () => {
-				createSuccessNotice( __( 'Site redirect updated successfully.' ), {
+				createSuccessNotice( __( 'Site redirect updated.' ), {
 					type: 'snackbar',
 				} );
 			},

--- a/client/dashboard/sites/settings-repositories/configure-repository.tsx
+++ b/client/dashboard/sites/settings-repositories/configure-repository.tsx
@@ -58,7 +58,7 @@ export default function ConfigureRepository() {
 				header={
 					<PageHeader
 						prefix={ <Breadcrumbs length={ 3 } /> }
-						title={ __( 'Configure Repository' ) }
+						title={ __( 'Configure repository' ) }
 						description={ __(
 							'Update the GitHub repository connection to deploy code to your WordPress site.'
 						) }
@@ -75,8 +75,8 @@ export default function ConfigureRepository() {
 							onCancel={ handleCancel }
 							mutation={ updateMutation }
 							initialValues={ initialValues }
-							submitText={ __( 'Update Connection' ) }
-							successMessage={ __( 'Repository settings updated successfully.' ) }
+							submitText={ __( 'Update connection' ) }
+							successMessage={ __( 'Repository settings updated.' ) }
 							errorMessage={
 								// translators: "reason" is why updating the repository failed.
 								__( 'Failed to update repository: %(reason)s' )

--- a/client/dashboard/sites/settings-repositories/connect-repository.tsx
+++ b/client/dashboard/sites/settings-repositories/connect-repository.tsx
@@ -47,7 +47,7 @@ export default function ConnectRepository() {
 			header={
 				<PageHeader
 					prefix={ <Breadcrumbs length={ 3 } /> }
-					title={ __( 'Connect Repository' ) }
+					title={ __( 'Connect repository' ) }
 					description={ __( 'Deploy code from GitHub to your WordPress.com site.' ) }
 				/>
 			}
@@ -62,8 +62,8 @@ export default function ConnectRepository() {
 						onCancel={ handleCancel }
 						mutation={ createMutation }
 						initialValues={ initialValues }
-						submitText={ __( 'Connect Repository' ) }
-						successMessage={ __( 'Repository connected successfully.' ) }
+						submitText={ __( 'Connect repository' ) }
+						successMessage={ __( 'Repository connected.' ) }
 						errorMessage={
 							// translators: "reason" is why connecting the repository failed.
 							__( 'Failed to connect repository: %(reason)s' )

--- a/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
@@ -164,9 +164,7 @@ export default function SshCard( {
 		toggleSshAccessMutation.mutate( undefined, {
 			onSuccess: () => {
 				createSuccessNotice(
-					sshEnabled
-						? __( 'SSH access has been successfully disabled for this site.' )
-						: __( 'SSH access has been successfully enabled for this site.' ),
+					sshEnabled ? __( 'SSH access disabled.' ) : __( 'SSH access enabled.' ),
 					{
 						type: 'snackbar',
 					}

--- a/client/dashboard/sites/settings-transfer-site/invitation-email-sent.tsx
+++ b/client/dashboard/sites/settings-transfer-site/invitation-email-sent.tsx
@@ -37,7 +37,7 @@ export function InvitationEmailSent( {
 						createSuccessNotice(
 							sprintf(
 								/* translators: %(newOwnerEmail)s - the new owner's email */
-								__( 'The site has been successfully transferred to %(newOwnerEmail)s.' ),
+								__( 'Site transferred to %(newOwnerEmail)s.' ),
 								{
 									newOwnerEmail: new_owner_email,
 								}

--- a/client/dashboard/sites/site-change-address-modal/content.tsx
+++ b/client/dashboard/sites/site-change-address-modal/content.tsx
@@ -248,14 +248,14 @@ const ConfirmNewSiteAddressForm = ( {
 					createSuccessNotice(
 						sprintf(
 							/* translators: %s: site name */
-							__( 'The site address has been changed to %s successfully.' ),
+							__( 'Site address changed to %s.' ),
 							newSiteAddress
 						),
 						{ type: 'snackbar' }
 					);
 				},
 				onError: ( error: Error ) => {
-					createErrorNotice( error.message || __( 'Failed to change site address' ), {
+					createErrorNotice( error.message || __( 'Failed to change site address.' ), {
 						type: 'snackbar',
 					} );
 				},

--- a/client/dashboard/sites/site-delete-modal/index.tsx
+++ b/client/dashboard/sites/site-delete-modal/index.tsx
@@ -180,7 +180,7 @@ function SiteDeleteConfirmContent( { site, onClose }: { site: Site; onClose: () 
 				createSuccessNotice(
 					sprintf(
 						/* translators: %s: site name */
-						__( '%s has been deleted.' ),
+						__( '%s deleted.' ),
 						site.slug
 					),
 					{ type: 'snackbar' }

--- a/client/dashboard/sites/site-launch-button/index.tsx
+++ b/client/dashboard/sites/site-launch-button/index.tsx
@@ -46,8 +46,8 @@ export function SiteLaunchButton( {
 		...siteLaunchMutation( site.ID ),
 		meta: {
 			snackbar: {
-				success: __( 'Your site has been launched; now you can share it with the world!' ),
-				error: __( 'Failed to launch site' ),
+				success: __( 'Site launched.' ),
+				error: __( 'Failed to launch site.' ),
 			},
 		},
 	} );

--- a/client/dashboard/sites/site-leave-modal/content-info.tsx
+++ b/client/dashboard/sites/site-leave-modal/content-info.tsx
@@ -138,7 +138,7 @@ function ContentLeaveSite( { site, onClose }: ContentInfoProps ) {
 				recordTracksEvent( 'calypso_sites_dashboard_site_leave_modal_leave_site_success' );
 				createSuccessNotice(
 					/* translators: %s: site domain */
-					sprintf( __( 'You have left %s successfully.' ), site.slug ),
+					sprintf( __( 'You left %s.' ), site.slug ),
 					{ type: 'snackbar' }
 				);
 

--- a/client/dashboard/sites/site-preview/index.tsx
+++ b/client/dashboard/sites/site-preview/index.tsx
@@ -29,7 +29,7 @@ export default function SitePreview( {
 			loading="lazy"
 			// @ts-expect-error For some reason there's no inert type.
 			inert="true"
-			title={ __( 'Site Preview' ) }
+			title={ __( 'Site preview' ) }
 			// Hide banners + `preview` hides cookie banners + `iframe` hides
 			// admin bar for atomic sites.
 			src={ `${ secureUrl }/?hide_banners=true&preview=true&iframe=true` }

--- a/client/dashboard/sites/site-reset-modal/index.tsx
+++ b/client/dashboard/sites/site-reset-modal/index.tsx
@@ -182,7 +182,7 @@ export default function SiteResetModal( { site, onClose }: { site: Site; onClose
 		createSuccessNotice(
 			sprintf(
 				/* translators: %s: site domain */
-				__( '%s has been reset.' ),
+				__( '%s reset.' ),
 				site.slug
 			),
 			{ type: 'snackbar' }

--- a/client/dashboard/sites/site-restore-modal/content-info.tsx
+++ b/client/dashboard/sites/site-restore-modal/content-info.tsx
@@ -30,7 +30,7 @@ export default function SiteRestoreContentInfo( { site, onClose }: ContentInfoPr
 			onSuccess: () => {
 				createSuccessNotice(
 					/* translators: %s: site domain */
-					sprintf( __( '%s has been restored.' ), siteSlug ),
+					sprintf( __( '%s restored.' ), siteSlug ),
 					{ type: 'snackbar' }
 				);
 

--- a/client/dashboard/sites/staging-site-delete-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-delete-modal/index.tsx
@@ -57,7 +57,7 @@ export default function StagingSiteDeleteModal( {
 		mutation.mutate( undefined, {
 			onError: ( error: Error ) => {
 				recordTracksEvent( 'calypso_hosting_configuration_staging_site_delete_failure' );
-				createErrorNotice( error.message || __( 'Failed to delete staging site' ), {
+				createErrorNotice( error.message || __( 'Failed to delete staging site.' ), {
 					type: 'snackbar',
 				} );
 			},


### PR DESCRIPTION
## Proposed Changes

* Remove "successfully" from success notices across all Dashboard screens
* Shorten verbose error/success messages to be more concise
* Fix title-case inconsistencies (e.g., "Update Plugin" → "Update plugin")
* Standardize error notice patterns (e.g., "There was a problem…" → "Failed to…")

## Why are these changes being made?

User-facing text in the Dashboard is inconsistent and often unnecessarily verbose. This pass tightens notice copy to be shorter, more consistent, and less noisy. No functional changes.

## Testing Instructions

* Trigger various success/error notices across Dashboard screens and verify the updated copy reads well.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?