### PR TITLE
Dashboard: Show upsell on Settings > WordPress for sites below Business

### DIFF
--- a/client/dashboard/sites/features.ts
+++ b/client/dashboard/sites/features.ts
@@ -1,5 +1,4 @@
 import { DotcomFeatures, HostingFeatures } from '@automattic/api-core';
-import { isEnabled } from '@automattic/calypso-config';
 import { isDashboardBackport } from '../utils/is-dashboard-backport';
 import { hasHostingFeature, hasPlanFeature } from '../utils/site-features';
 import { isSiteMigrationInProgress } from '../utils/site-status';
@@ -40,13 +39,6 @@ export function canViewHundredYearPlanSettings( site: Site ) {
 }
 
 // Settings -> Server
-
-export function canViewWordPressSettings( site: Site ) {
-	if ( isEnabled( 'dashboard/wp-beta-program' ) ) {
-		return hasPlanFeature( site, HostingFeatures.BACKUPS_SELF_SERVE );
-	}
-	return site.is_wpcom_staging_site;
-}
 
 export function canSwitchWordPressVersion( site: Site ) {
 	return hasHostingFeature( site, HostingFeatures.BACKUPS_SELF_SERVE );

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -62,17 +62,9 @@ function VersionManagement( { site }: { site: Site } ) {
 export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 
-	const header = (
-		<PageHeader
-			prefix={ <Breadcrumbs length={ 2 } /> }
-			title="WordPress"
-			description={ __( 'Manage your WordPress version.' ) }
-		/>
-	);
-
-	if ( isEnabled( 'dashboard/wp-beta-program' ) ) {
-		return (
-			<PageLayout size="small" header={ header }>
+	const renderContent = () => {
+		if ( isEnabled( 'dashboard/wp-beta-program' ) ) {
+			return (
 				<HostingFeatureGatedWithCallout
 					site={ site }
 					feature={ HostingFeatures.BACKUPS_SELF_SERVE }
@@ -80,20 +72,14 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 				>
 					<VersionManagement site={ site } />
 				</HostingFeatureGatedWithCallout>
-			</PageLayout>
-		);
-	}
+			);
+		}
 
-	if ( site.is_wpcom_staging_site ) {
+		if ( site.is_wpcom_staging_site ) {
+			return <VersionManagement site={ site } />;
+		}
+
 		return (
-			<PageLayout size="small" header={ header }>
-				<VersionManagement site={ site } />
-			</PageLayout>
-		);
-	}
-
-	return (
-		<PageLayout size="small" header={ header }>
 			<Notice>
 				<VStack>
 					<Text as="p">
@@ -117,6 +103,21 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 					) }
 				</VStack>
 			</Notice>
+		);
+	};
+
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					prefix={ <Breadcrumbs length={ 2 } /> }
+					title="WordPress"
+					description={ __( 'Manage your WordPress version.' ) }
+				/>
+			}
+		>
+			{ renderContent() }
 		</PageLayout>
 	);
 }

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -4,6 +4,7 @@ import {
 	siteWordPressVersionQuery,
 	wpOrgCoreVersionQuery,
 } from '@automattic/api-queries';
+import { isEnabled } from '@automattic/calypso-config';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack, __experimentalText as Text } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
@@ -14,7 +15,6 @@ import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { getFormattedWordPressVersion } from '../../utils/wp-version';
-import { canViewWordPressSettings } from '../features';
 import HostingFeatureGatedWithCallout from '../hosting-feature-gated-with-callout';
 import { BetaProgramNotice } from './beta-program-notice';
 import { LatestVersionNotice } from './latest-version-notice';
@@ -70,45 +70,53 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 		/>
 	);
 
-	if ( ! canViewWordPressSettings( site ) ) {
+	if ( isEnabled( 'dashboard/wp-beta-program' ) ) {
 		return (
 			<PageLayout size="small" header={ header }>
-				<Notice>
-					<VStack>
-						<Text as="p">
-							{ sprintf(
-								// translators: %s: WordPress version, e.g. 6.8
-								__( 'Every WordPress.com site runs the latest WordPress version (%s).' ),
-								getFormattedWordPressVersion( site )
-							) }
-						</Text>
-						{ site.is_wpcom_atomic && (
-							<Text as="p">
-								{ createInterpolateElement(
-									__(
-										'Switch to a staging site to test a beta version of the next WordPress release. <learnMoreLink />'
-									),
-									{
-										learnMoreLink: <InlineSupportLink supportContext="switch-to-staging-site" />,
-									}
-								) }
-							</Text>
-						) }
-					</VStack>
-				</Notice>
+				<HostingFeatureGatedWithCallout
+					site={ site }
+					feature={ HostingFeatures.BACKUPS_SELF_SERVE }
+					upsellId="site-settings-wordpress"
+				>
+					<VersionManagement site={ site } />
+				</HostingFeatureGatedWithCallout>
+			</PageLayout>
+		);
+	}
+
+	if ( site.is_wpcom_staging_site ) {
+		return (
+			<PageLayout size="small" header={ header }>
+				<VersionManagement site={ site } />
 			</PageLayout>
 		);
 	}
 
 	return (
 		<PageLayout size="small" header={ header }>
-			<HostingFeatureGatedWithCallout
-				site={ site }
-				feature={ HostingFeatures.BACKUPS_SELF_SERVE }
-				upsellId="site-settings-wordpress"
-			>
-				<VersionManagement site={ site } />
-			</HostingFeatureGatedWithCallout>
+			<Notice>
+				<VStack>
+					<Text as="p">
+						{ sprintf(
+							// translators: %s: WordPress version, e.g. 6.8
+							__( 'Every WordPress.com site runs the latest WordPress version (%s).' ),
+							getFormattedWordPressVersion( site )
+						) }
+					</Text>
+					{ site.is_wpcom_atomic && (
+						<Text as="p">
+							{ createInterpolateElement(
+								__(
+									'Switch to a staging site to test a beta version of the next WordPress release. <learnMoreLink />'
+								),
+								{
+									learnMoreLink: <InlineSupportLink supportContext="switch-to-staging-site" />,
+								}
+							) }
+						</Text>
+					) }
+				</VStack>
+			</Notice>
 		</PageLayout>
 	);
 }

--- a/client/dashboard/sites/settings-wordpress/test/index.test.tsx
+++ b/client/dashboard/sites/settings-wordpress/test/index.test.tsx
@@ -109,4 +109,24 @@ describe( '<WordPressSettings>', () => {
 		expect( screen.getByRole( 'button', { name: 'Activate' } ) ).toBeVisible();
 		expect( screen.queryByRole( 'button', { name: 'Save' } ) ).not.toBeInTheDocument();
 	} );
+
+	test( 'renders upsell when the site does not have the plan feature', async () => {
+		mockSite( {
+			...site,
+			is_wpcom_atomic: false,
+			is_wpcom_staging_site: false,
+			plan: {
+				product_slug: 'personal-bundle',
+				product_name_short: 'Personal',
+				is_free: false,
+				features: { active: [] },
+			},
+		} as unknown as Site );
+
+		render( <WordPressSettings siteSlug={ site.slug } /> );
+		await screen.findByRole( 'heading', { name: 'WordPress' } );
+
+		expect( screen.getByRole( 'button', { name: 'Upgrade plan' } ) ).toBeVisible();
+		expect( screen.queryByRole( 'button', { name: 'Save' } ) ).not.toBeInTheDocument();
+	} );
 } );

--- a/client/dashboard/sites/settings-wordpress/test/index.test.tsx
+++ b/client/dashboard/sites/settings-wordpress/test/index.test.tsx
@@ -129,4 +129,37 @@ describe( '<WordPressSettings>', () => {
 		expect( screen.getByRole( 'button', { name: 'Upgrade plan' } ) ).toBeVisible();
 		expect( screen.queryByRole( 'button', { name: 'Save' } ) ).not.toBeInTheDocument();
 	} );
+
+	describe( 'with beta program disabled', () => {
+		beforeAll( () => {
+			disable( 'dashboard/wp-beta-program' );
+		} );
+
+		afterAll( () => {
+			enable( 'dashboard/wp-beta-program' );
+		} );
+
+		test( 'renders the form for a staging site', async () => {
+			mockApi();
+
+			render( <WordPressSettings siteSlug={ site.slug } /> );
+			await screen.findByRole( 'heading', { name: 'WordPress' } );
+
+			expect( await screen.findByRole( 'combobox', { name: 'WordPress version' } ) ).toBeVisible();
+		} );
+
+		test( 'renders the latest-version notice for a non-staging site', async () => {
+			mockSite( { ...site, is_wpcom_staging_site: false } as Site );
+
+			render( <WordPressSettings siteSlug={ site.slug } /> );
+			await screen.findByRole( 'heading', { name: 'WordPress' } );
+
+			expect(
+				screen.getByText( /Every WordPress\.com site runs the latest WordPress version/ )
+			).toBeVisible();
+			expect(
+				screen.queryByRole( 'combobox', { name: 'WordPress version' } )
+			).not.toBeInTheDocument();
+		} );
+	} );
 } );


### PR DESCRIPTION
Follow-up to #109946.

## Proposed Changes

* Route Settings > WordPress through `HostingFeatureGatedWithCallout` (feature: `BACKUPS_SELF_SERVE`) when `dashboard/wp-beta-program` is enabled, matching the Settings > PHP pattern.
* Sites below Business now see the plan upsell instead of the static "every site runs the latest version" notice.
* Remove the now-unused `canViewWordPressSettings` helper.

## Why are these changes being made?

The previous PR enabled the WordPress beta activation flow for Simple Business+ sites. Sites below Business were still shown an informational notice on Settings > WordPress. This change mirrors the Settings > PHP experience by surfacing a plan upsell, giving those users a clear path to unlock the feature.

## Testing Instructions

* Enable `dashboard/wp-beta-program` locally.
* Visit Settings > WordPress on:
  * An Atomic Business+ site — expect the version form.
  * A Simple Business+ site — expect the activation callout.
  * A site below Business (e.g. Personal) — expect the plan upsell with the "Upgrade plan" button.
* Run \`yarn test-client client/dashboard/sites/settings-wordpress\`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?