### PR TITLE
JetpackFooter: Align menu structure and styles with upstream Jetpack component

### DIFF
--- a/client/components/jetpack/jetpack-footer/index.tsx
+++ b/client/components/jetpack/jetpack-footer/index.tsx
@@ -21,7 +21,7 @@ interface JetpackFooterProps {
 }
 
 /**
- * JetpackFooter component displays a tiny Jetpack logo on the left and the Automattic Airline "by line" on the right.
+ * JetpackFooter component displays a tiny Jetpack logo with the product name on the left and the Automattic Airline "by line" on the right.
  */
 const JetpackFooter: FC< JetpackFooterProps > = ( { className, menu } ) => {
 	return (
@@ -41,9 +41,10 @@ const JetpackFooter: FC< JetpackFooterProps > = ( { className, menu } ) => {
 				<span className="jetpack-footer__logo-text">Jetpack</span>
 			</Stack>
 			{ menu && menu.length > 0 && (
-				<ul className="jetpack-footer__menu">
+				<Stack render={ <ul /> } direction="row" gap="lg" wrap="wrap">
 					{ menu.map( ( item ) => {
 						const isButton = item.role === 'button';
+
 						return (
 							<li key={ item.label }>
 								{ isButton ? (
@@ -70,7 +71,7 @@ const JetpackFooter: FC< JetpackFooterProps > = ( { className, menu } ) => {
 							</li>
 						);
 					} ) }
-				</ul>
+				</Stack>
 			) }
 			<a
 				className="jetpack-footer__a8c"

--- a/client/components/jetpack/jetpack-footer/style.scss
+++ b/client/components/jetpack/jetpack-footer/style.scss
@@ -1,11 +1,42 @@
 @import '@wordpress/theme/design-tokens.css';
 
 .jetpack-footer {
+	display: flex;
 	border-top: var(--wpds-border-width-xs, 1px) solid var(--wpds-color-stroke-surface-neutral-weak, #e0e0e0);
 	box-sizing: border-box;
-	display: flex;
+	color: var(--wpds-color-fg-content-neutral, #1e1e1e);
+	font-size: var(--wpds-font-size-md, 13px);
 	padding: var(--wpds-dimension-padding-xl) var(--wpds-dimension-padding-2xl);
 	width: 100%;
+
+	.jetpack-footer__menu-item {
+		font-family: var(--wpds-font-family-body);
+		font-size: var(--wpds-font-size-sm, 12px);
+		font-weight: var(--wpds-font-weight-regular, 400);
+		line-height: var(--wpds-font-line-height-xs, 16px);
+		text-underline-offset: 0.2em;
+
+		&:any-link,
+		&[role="button"] {
+			color: var(--wpds-color-fg-interactive-neutral-weak);
+			cursor: pointer;
+			text-decoration: none;
+		}
+
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+
+	> ul {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+
+		> li {
+			margin: 0;
+		}
+	}
 }
 
 .jetpack-footer__logo {
@@ -13,39 +44,17 @@
 }
 
 .jetpack-footer__logo-text {
+	font-family: var(--wpds-font-family-body);
 	font-size: var(--wpds-font-size-md);
 	font-weight: var(--wpds-font-weight-regular);
-	font-family: var(--wpds-font-family-body);
 	line-height: var(--wpds-font-line-height-sm);
 }
 
-.jetpack-footer__menu {
-	display: flex;
-	flex-wrap: wrap;
-	gap: var(--wpds-dimension-gap-lg, 16px);
-	list-style: none;
-	margin: 0;
-	padding: 0;
-}
-
-.jetpack-footer__menu-item {
-	font-size: var(--wpds-font-size-md);
-	font-family: var(--wpds-font-family-body);
-
-	&:any-link,
-	&[role="button"] {
-		color: var(--wpds-color-fg-interactive-neutral-weak);
-		cursor: pointer;
-		text-decoration: none;
-	}
-
-	&:hover {
-		text-decoration: underline;
-	}
-}
-
 a.jetpack-footer__a8c {
-	margin-inline-start: auto;
+
+	@media (min-width: 480px) {
+		margin-inline-start: auto;
+	}
 
 	svg {
 		fill: var(--wpds-color-fg-interactive-neutral-weak);


### PR DESCRIPTION
## Proposed Changes

Follow-up of https://github.com/Automattic/wp-calypso/pull/109929.

- Replace `<ul className="jetpack-footer__menu">` with `<Stack render={<ul />}>` to match upstream Jetpack component structure
- Adopt upstream SCSS patterns: nested `.jetpack-footer__menu-item`, `> ul` list reset, responsive `a8c` margin
- Apply `body-sm` typography to menu items and `body-md` to logo text (matching upstream `Text` variants via SCSS since Calypso's webpack doesn't support CSS modules from `node_modules`)
- Add footer `color` token `--wpds-color-fg-content-neutral`

## Why are these changes being made?

Align the Calypso `JetpackFooter` component with the upstream Jetpack `js-packages/components` version (`projects/js-packages/components/components/jetpack-footer/`) so both codebases share consistent markup structure and design token usage. This reduces drift and makes future syncs easier.

## Testing Instructions

- Visit any page using the `JetpackFooter` component (e.g., Jetpack Cloud settings)
- Verify the footer renders correctly: Jetpack logo + text on the left, menu links in the middle, Automattic byline on the right
- Verify menu item typography matches upstream (`font-size: 12px`, `line-height: 16px`)

|Before|After|
|-|-|
|<img width="300" height="96" alt="截圖 2026-04-13 下午2 51 53" src="https://github.com/user-attachments/assets/6de84f59-637c-43e9-a8f8-28e93d01f255" />|<img width="279" height="112" alt="截圖 2026-04-13 下午2 44 29" src="https://github.com/user-attachments/assets/3b9ea91b-9c6b-464a-b4b1-6a306167c4f1" />|

- Verify the Automattic byline aligns to the right on viewports >= 480px and wraps naturally on smaller screens

|Before|After|
|-|-|
|<img width="406" height="117" alt="截圖 2026-04-13 下午2 51 47" src="https://github.com/user-attachments/assets/666fa590-57ba-48af-9e80-0652b4f1a202" />|<img width="430" height="121" alt="截圖 2026-04-13 下午2 48 50" src="https://github.com/user-attachments/assets/57c36814-39a3-4ed4-b21a-4136bedadb60" />|

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)