### PR TITLE
E2E: Fix signup__with-theme-premium afterAll crash on missing bearer_token

### DIFF
--- a/test/e2e/specs/onboarding/signup__with-theme-premium.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-premium.ts
@@ -80,7 +80,7 @@ describe( 'Lifecyle: Premium theme signup, onboard, launch and cancel subscripti
 
 			if ( ! newUserDetails.body.bearer_token ) {
 				throw new Error(
-					'Signup response missing bearer_token — account was likely not created (possible Bkismet rejection)'
+					`Signup response missing bearer_token for ${ testUser.email } — account was likely not created (possible Bkismet rejection)`
 				);
 			}
 		} );

--- a/test/e2e/specs/onboarding/signup__with-theme-premium.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-premium.ts
@@ -77,6 +77,12 @@ describe( 'Lifecyle: Premium theme signup, onboard, launch and cancel subscripti
 		it( 'Sign up as new user', async function () {
 			const userSignupPage = new UserSignupPage( page );
 			newUserDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
+
+			if ( ! newUserDetails.body.bearer_token ) {
+				throw new Error(
+					'Signup response missing bearer_token — account was likely not created (possible Bkismet rejection)'
+				);
+			}
 		} );
 
 		it( 'Skip domain selection', async function () {
@@ -165,7 +171,7 @@ describe( 'Lifecyle: Premium theme signup, onboard, launch and cancel subscripti
 	} );
 
 	afterAll( async function () {
-		if ( ! newUserDetails ) {
+		if ( ! newUserDetails || ! newUserDetails.body.bearer_token ) {
 			return;
 		}
 


### PR DESCRIPTION
Closes [TESTOPS-89](https://linear.app/a8c/issue/TESTOPS-89/calypso-e2e-signup-with-theme-premium-afterall-crashes-with-invalid).

## Proposed Changes

- Guard `afterAll` cleanup to skip when `bearer_token` is missing, preventing the `invalid_username` crash
- Fail fast in the signup step with a clear error message when the signup response lacks a `bearer_token`

## Why are these changes being made?

`signup__with-theme-premium.ts` is the #1 flaker in the Jest pre-release suite — it caused 4 out of 5 Jest build failures in the last 50 builds (Apr 9–13).

When signup fails on CI (likely Bkismet rejection due to datacenter IP scoring + `user-name-generated-suffix` rule), the captured response lacks a `bearer_token`. The `afterAll` cleanup then creates a `RestAPIClient` with an undefined token, which falls back to username/password auth and fails with `invalid_username`. This error is **not muted**, so it causes the build to fail even though the domain search timeout that precedes it is muted.

## Testing Instructions

To reproduce the issue locally, temporarily sabotage the bearer token after signup:

```typescript
newUserDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
// TEMP: Sabotage bearer_token to reproduce CI afterAll failure
newUserDetails.body.bearer_token = '';
```

**Before fix**: `invalid_username: We don't seem to have an account with that name.`
**After fix**: `Signup response missing bearer_token — account was likely not created (possible Bkismet rejection)`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)