### PR TITLE
Dashboard: Gate canSwitchWordPressVersion behind wp-beta-program flag

### DIFF
--- a/client/dashboard/sites/features.ts
+++ b/client/dashboard/sites/features.ts
@@ -1,4 +1,5 @@
 import { DotcomFeatures, HostingFeatures } from '@automattic/api-core';
+import { isEnabled } from '@automattic/calypso-config';
 import { isDashboardBackport } from '../utils/is-dashboard-backport';
 import { hasHostingFeature, hasPlanFeature } from '../utils/site-features';
 import { isSiteMigrationInProgress } from '../utils/site-status';
@@ -41,7 +42,10 @@ export function canViewHundredYearPlanSettings( site: Site ) {
 // Settings -> Server
 
 export function canSwitchWordPressVersion( site: Site ) {
-	return hasHostingFeature( site, HostingFeatures.BACKUPS_SELF_SERVE );
+	if ( isEnabled( 'dashboard/wp-beta-program' ) ) {
+		return hasHostingFeature( site, HostingFeatures.BACKUPS_SELF_SERVE );
+	}
+	return site.is_wpcom_staging_site;
 }
 
 // Settings -> Actions & danger zone


### PR DESCRIPTION
## Proposed Changes

* Gate `canSwitchWordPressVersion` behind `dashboard/wp-beta-program`, mirroring the `canViewWordPressSettings` pattern: flag on → any site with the `BACKUPS_SELF_SERVE` hosting feature; flag off → staging sites only.

## Why are these changes being made?

The overview banner (`WpVersionNotice`) used to get its flag gate transitively through `canViewWordPressSettings` (which checks `dashboard/wp-beta-program`). When the banner was switched to `canSwitchWordPressVersion` so the settings page could keep a plan-feature entry path for the Atomic activation callout, the flag check was dropped.

The regression stayed invisible until wp.org started advertising a beta version (7.0-RC2) on its core API. Once that happened, Business+ sites in production began seeing the "WordPress 7.0-RC2 is available for early access" banner with a "Try it now" link that routes to Settings → WordPress where the switcher is still flag-gated off.

Putting the flag check inside `canSwitchWordPressVersion` itself (and falling back to `is_wpcom_staging_site` when the flag is off) centralizes the semantics — all four callers (banner, settings summary card, `getFormattedWordPressVersion`, router prefetch) pick it up automatically. Staging sites keep their existing behavior because the flag-off branch returns `is_wpcom_staging_site`, so pre-release version strings (`7.0-RC2`) remain preserved on staging across summary cards, the sites dataview column, and overview metadata.

## Testing Instructions

1. With `dashboard/wp-beta-program` disabled (default in production/stage/horizon), open a Business+ site overview — the WordPress beta banner should not appear even while wp.org is advertising 7.0-RC2.
2. Enable the flag locally; the banner should reappear on Business+ sites (not staging sites), and "Try it now" should take you to a working switcher.
3. Staging sites with the flag off should continue to show the version switcher on Settings → WordPress, and pre-release version strings (`7.0-RC2`) should still be preserved in their summary cards / dataview columns.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
