### PR TITLE
Reader Lists: add public view, tags, sites directory, and follow-all

### DIFF
--- a/client/reader/components/create-list-invitation/index.tsx
+++ b/client/reader/components/create-list-invitation/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Card } from '@wordpress/components';
+import { Button, Card, CardBody } from '@wordpress/components';
 import { Icon, formatListBullets } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 
@@ -12,22 +12,24 @@ export function CreateListInvitation( { onCreateClick }: CreateListInvitationPro
 	const translate = useTranslate();
 
 	return (
-		<Card className="create-list-invitation" size="large">
-			<div className="create-list-invitation__header">
-				<Icon className="create-list-invitation__icon" icon={ formatListBullets } size={ 20 } />
-				<span className="create-list-invitation__label">{ translate( 'Share a list' ) }</span>
-			</div>
-			<p className="create-list-invitation__prompt">{ translate( 'Create your own list' ) }</p>
-			<p className="create-list-invitation__description">
-				{ translate(
-					'Got a favorite corner of the web? Bundle the blogs you follow into a list of your own and help other readers find their next great read. It’s an easy way to support the creators you enjoy and grow community around shared interests.'
-				) }
-			</p>
-			<div className="create-list-invitation__footer">
-				<Button variant="primary" href="/reader/list/new" onClick={ onCreateClick }>
-					{ translate( 'Create a list' ) }
-				</Button>
-			</div>
+		<Card className="create-list-invitation">
+			<CardBody>
+				<div className="create-list-invitation__header">
+					<Icon className="create-list-invitation__icon" icon={ formatListBullets } size={ 20 } />
+					<span className="create-list-invitation__label">{ translate( 'Share a list' ) }</span>
+				</div>
+				<p className="create-list-invitation__prompt">{ translate( 'Create your own list' ) }</p>
+				<p className="create-list-invitation__description">
+					{ translate(
+						'Got a favorite corner of the web? Bundle the blogs you follow into a list of your own and help other readers find their next great read. It’s an easy way to support the creators you enjoy and grow community around shared interests.'
+					) }
+				</p>
+				<div className="create-list-invitation__footer">
+					<Button variant="primary" href="/reader/list/new" onClick={ onCreateClick }>
+						{ translate( 'Create a list' ) }
+					</Button>
+				</div>
+			</CardBody>
 		</Card>
 	);
 }

--- a/client/reader/components/create-list-invitation/index.tsx
+++ b/client/reader/components/create-list-invitation/index.tsx
@@ -1,4 +1,5 @@
-import { Button } from '@wordpress/components';
+import { Button, Card } from '@wordpress/components';
+import { Icon, formatListBullets } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 
 import './style.scss';
@@ -11,21 +12,22 @@ export function CreateListInvitation( { onCreateClick }: CreateListInvitationPro
 	const translate = useTranslate();
 
 	return (
-		<div className="create-list-invitation">
-			<h3 className="create-list-invitation__title">{ translate( 'Create your own list' ) }</h3>
+		<Card className="create-list-invitation" size="large">
+			<div className="create-list-invitation__header">
+				<Icon className="create-list-invitation__icon" icon={ formatListBullets } size={ 20 } />
+				<span className="create-list-invitation__label">{ translate( 'Share a list' ) }</span>
+			</div>
+			<p className="create-list-invitation__prompt">{ translate( 'Create your own list' ) }</p>
 			<p className="create-list-invitation__description">
 				{ translate(
 					'Got a favorite corner of the web? Bundle the blogs you follow into a list of your own and help other readers find their next great read. It’s an easy way to support the creators you enjoy and grow community around shared interests.'
 				) }
 			</p>
-			<Button
-				className="create-list-invitation__button"
-				variant="primary"
-				href="/reader/list/new"
-				onClick={ onCreateClick }
-			>
-				{ translate( 'Create a list' ) }
-			</Button>
-		</div>
+			<div className="create-list-invitation__footer">
+				<Button variant="primary" href="/reader/list/new" onClick={ onCreateClick }>
+					{ translate( 'Create a list' ) }
+				</Button>
+			</div>
+		</Card>
 	);
 }

--- a/client/reader/components/create-list-invitation/index.tsx
+++ b/client/reader/components/create-list-invitation/index.tsx
@@ -1,0 +1,31 @@
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+
+import './style.scss';
+
+interface CreateListInvitationProps {
+	onCreateClick?: () => void;
+}
+
+export function CreateListInvitation( { onCreateClick }: CreateListInvitationProps ) {
+	const translate = useTranslate();
+
+	return (
+		<div className="create-list-invitation">
+			<h3 className="create-list-invitation__title">{ translate( 'Create your own list' ) }</h3>
+			<p className="create-list-invitation__description">
+				{ translate(
+					'Got a favorite corner of the web? Bundle the blogs you follow into a list of your own and help other readers find their next great read. It’s an easy way to support the creators you enjoy and grow community around shared interests.'
+				) }
+			</p>
+			<Button
+				className="create-list-invitation__button"
+				variant="primary"
+				href="/reader/list/new"
+				onClick={ onCreateClick }
+			>
+				{ translate( 'Create a list' ) }
+			</Button>
+		</div>
+	);
+}

--- a/client/reader/components/create-list-invitation/style.scss
+++ b/client/reader/components/create-list-invitation/style.scss
@@ -1,27 +1,42 @@
+@import "@wordpress/base-styles/variables";
+
 .create-list-invitation {
-	border: 1px solid var( --color-border-subtle );
-	border-radius: 8px;
-	padding: 24px;
-	background: var( --color-neutral-0 );
-	text-align: center;
 	margin-block-end: 16px;
 }
 
-.create-list-invitation__title {
-	font-size: 1rem;
-	font-weight: 600;
+.create-list-invitation__header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-block-end: 16px;
+	color: var( --color-text-subtle );
+	font-size: $font-body-small;
+}
+
+.create-list-invitation__icon {
+	fill: var( --studio-gray-50 );
+	flex-shrink: 0;
+}
+
+.create-list-invitation__label {
+	color: var( --studio-gray-80 );
+}
+
+.create-list-invitation__prompt {
+	font-size: $font-title-small;
+	font-weight: 500;
+	line-height: 1.4;
 	margin: 0 0 8px;
-	color: var( --color-text );
+	color: var( --studio-gray-80 );
 }
 
 .create-list-invitation__description {
-	font-size: 0.875rem;
+	font-size: $font-body-small;
 	color: var( --color-text-subtle );
 	line-height: 1.5;
-	margin: 0 auto 16px;
-	max-width: 520px;
+	margin: 0 0 16px;
 }
 
-.create-list-invitation__button {
-	justify-content: center;
+.create-list-invitation__footer {
+	display: flex;
 }

--- a/client/reader/components/create-list-invitation/style.scss
+++ b/client/reader/components/create-list-invitation/style.scss
@@ -1,0 +1,27 @@
+.create-list-invitation {
+	border: 1px solid var( --color-border-subtle );
+	border-radius: 8px;
+	padding: 24px;
+	background: var( --color-neutral-0 );
+	text-align: center;
+	margin-block-end: 16px;
+}
+
+.create-list-invitation__title {
+	font-size: 1rem;
+	font-weight: 600;
+	margin: 0 0 8px;
+	color: var( --color-text );
+}
+
+.create-list-invitation__description {
+	font-size: 0.875rem;
+	color: var( --color-text-subtle );
+	line-height: 1.5;
+	margin: 0 auto 16px;
+	max-width: 520px;
+}
+
+.create-list-invitation__button {
+	justify-content: center;
+}

--- a/client/reader/components/create-list-invitation/style.scss
+++ b/client/reader/components/create-list-invitation/style.scss
@@ -2,6 +2,10 @@
 
 .create-list-invitation {
 	margin-block-end: 16px;
+
+	.components-card__body {
+		padding: 24px;
+	}
 }
 
 .create-list-invitation__header {

--- a/client/reader/components/create-list-invitation/test/index.test.tsx
+++ b/client/reader/components/create-list-invitation/test/index.test.tsx
@@ -7,10 +7,10 @@ import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { CreateListInvitation } from '../index';
 
 describe( 'CreateListInvitation', () => {
-	test( 'renders the title', () => {
+	test( 'renders the prompt text', () => {
 		renderWithProvider( <CreateListInvitation /> );
 
-		expect( screen.getByRole( 'heading', { name: /create your own list/i } ) ).toBeVisible();
+		expect( screen.getByText( /create your own list/i ) ).toBeVisible();
 	} );
 
 	test( 'renders the description', () => {

--- a/client/reader/components/create-list-invitation/test/index.test.tsx
+++ b/client/reader/components/create-list-invitation/test/index.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { CreateListInvitation } from '../index';
+
+describe( 'CreateListInvitation', () => {
+	test( 'renders the title', () => {
+		renderWithProvider( <CreateListInvitation /> );
+
+		expect( screen.getByRole( 'heading', { name: /create your own list/i } ) ).toBeVisible();
+	} );
+
+	test( 'renders the description', () => {
+		renderWithProvider( <CreateListInvitation /> );
+
+		expect( screen.getByText( /bundle the blogs you follow/i ) ).toBeVisible();
+	} );
+
+	test( 'renders the create button linking to /reader/list/new', () => {
+		renderWithProvider( <CreateListInvitation /> );
+
+		const link = screen.getByRole( 'link', { name: /create a list/i } );
+		expect( link ).toHaveAttribute( 'href', '/reader/list/new' );
+	} );
+
+	test( 'fires onCreateClick when the button is clicked', async () => {
+		const user = userEvent.setup();
+		const onCreateClick = jest.fn();
+		renderWithProvider( <CreateListInvitation onCreateClick={ onCreateClick } /> );
+
+		await user.click( screen.getByRole( 'link', { name: /create a list/i } ) );
+
+		expect( onCreateClick ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/client/reader/components/list-card/index.tsx
+++ b/client/reader/components/list-card/index.tsx
@@ -5,7 +5,7 @@ import { SiteIconsRow } from 'calypso/reader/components/site-icons-row';
 import './style.scss';
 
 interface ListCardItem {
-	site_name: string;
+	site_name: string | null;
 	site_icon: string | null;
 }
 

--- a/client/reader/components/list-card/index.tsx
+++ b/client/reader/components/list-card/index.tsx
@@ -1,0 +1,84 @@
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { SiteIconsRow } from 'calypso/reader/components/site-icons-row';
+
+import './style.scss';
+
+interface ListCardItem {
+	site_name: string;
+	site_icon: string | null;
+}
+
+interface ListCardProps {
+	title: string;
+	description: string;
+	owner: string;
+	itemCount: number;
+	tags: string[];
+	items: ListCardItem[];
+	listUrl: string;
+	isLoadingItems: boolean;
+	onOpenList?: () => void;
+}
+
+export function ListCard( {
+	title,
+	description,
+	owner,
+	itemCount,
+	tags,
+	items,
+	listUrl,
+	isLoadingItems,
+	onOpenList,
+}: ListCardProps ) {
+	const translate = useTranslate();
+
+	return (
+		<div className="list-card">
+			<div className="list-card__header">
+				<div className="list-card__meta">
+					<h3 className="list-card__title">{ title }</h3>
+					<span className="list-card__byline">
+						{ translate( 'by %(owner)s', { args: { owner } } ) }
+						{ ' \u00B7 ' }
+						{ translate( '%(count)d site', '%(count)d sites', {
+							count: itemCount,
+							args: { count: itemCount },
+						} ) }
+					</span>
+				</div>
+				<Button
+					className="list-card__open-button"
+					variant="primary"
+					href={ listUrl }
+					onClick={ onOpenList }
+				>
+					{ translate( 'Open list' ) }
+				</Button>
+			</div>
+
+			<p className="list-card__description">{ description }</p>
+
+			{ tags.length > 0 && (
+				<div className="list-card__tags">
+					{ tags.map( ( tag ) => (
+						<span key={ tag } className="list-card__tag">
+							{ tag }
+						</span>
+					) ) }
+				</div>
+			) }
+
+			{ isLoadingItems ? (
+				<div className="list-card__icons-skeleton">
+					{ Array.from( { length: 5 } ).map( ( _, i ) => (
+						<span key={ i } className="list-card__icon-placeholder" />
+					) ) }
+				</div>
+			) : (
+				<SiteIconsRow items={ items } totalCount={ itemCount } />
+			) }
+		</div>
+	);
+}

--- a/client/reader/components/list-card/style.scss
+++ b/client/reader/components/list-card/style.scss
@@ -1,0 +1,89 @@
+.list-card {
+	border: 1px solid var( --color-border-subtle );
+	border-radius: 8px;
+	padding: 20px;
+	background: var( --color-surface );
+	margin-block-end: 16px;
+}
+
+.list-card__header {
+	display: flex;
+	justify-content: space-between;
+	align-items: flex-start;
+	margin-block-end: 10px;
+}
+
+.list-card__meta {
+	flex: 1;
+	min-width: 0;
+}
+
+.list-card__title {
+	font-size: 1rem;
+	font-weight: 600;
+	margin: 0;
+	color: var( --color-text );
+}
+
+.list-card__byline {
+	font-size: 0.875rem;
+	color: var( --color-text-subtle );
+	margin-block-start: 3px;
+	display: block;
+}
+
+.list-card__open-button {
+	margin-inline-start: 16px;
+	flex-shrink: 0;
+}
+
+.list-card__description {
+	font-size: 0.875rem;
+	color: var( --color-text );
+	line-height: 1.5;
+	margin: 0 0 12px;
+}
+
+.list-card__tags {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+	margin-block-end: 14px;
+}
+
+.list-card__tag {
+	background: var( --color-neutral-5 );
+	border-radius: 16px;
+	padding: 3px 10px;
+	font-size: 0.75rem;
+	color: var( --color-text );
+}
+
+.list-card__icons-skeleton {
+	display: flex;
+	align-items: center;
+}
+
+.list-card__icon-placeholder {
+	width: 34px;
+	height: 34px;
+	border-radius: 50%;
+	background: var( --color-neutral-5 );
+	border: 2px solid var( --color-surface );
+	flex-shrink: 0;
+	animation: list-card-pulse 1.5s ease-in-out infinite;
+
+	&:not(:first-child) {
+		margin-inline-start: -8px;
+	}
+}
+
+@keyframes list-card-pulse {
+	0%,
+	100% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.5;
+	}
+}

--- a/client/reader/components/list-card/test/index.test.tsx
+++ b/client/reader/components/list-card/test/index.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { ListCard } from '../index';
+
+const defaultProps = {
+	title: 'Quirky Histories',
+	description: 'A cabinet of curiosities',
+	owner: 'benhuberman',
+	itemCount: 30,
+	tags: [ 'Arts & Entertainment', 'Technology', 'Science' ],
+	items: [
+		{ site_name: 'Site A', site_icon: 'https://example.com/a.png' },
+		{ site_name: 'Site B', site_icon: null },
+	],
+	listUrl: '/reader/list/benhuberman/quirky-histories',
+	isLoadingItems: false,
+};
+
+describe( 'ListCard', () => {
+	test( 'renders title, description, and owner', () => {
+		renderWithProvider( <ListCard { ...defaultProps } /> );
+
+		expect( screen.getByText( 'Quirky Histories' ) ).toBeVisible();
+		expect( screen.getByText( 'A cabinet of curiosities' ) ).toBeVisible();
+		expect( screen.getByText( /benhuberman/ ) ).toBeVisible();
+	} );
+
+	test( 'renders site count', () => {
+		renderWithProvider( <ListCard { ...defaultProps } /> );
+
+		expect( screen.getByText( /30 sites/ ) ).toBeVisible();
+	} );
+
+	test( 'renders tag pills', () => {
+		renderWithProvider( <ListCard { ...defaultProps } /> );
+
+		expect( screen.getByText( 'Arts & Entertainment' ) ).toBeVisible();
+		expect( screen.getByText( 'Technology' ) ).toBeVisible();
+		expect( screen.getByText( 'Science' ) ).toBeVisible();
+	} );
+
+	test( 'renders Open list link with correct URL', () => {
+		renderWithProvider( <ListCard { ...defaultProps } /> );
+
+		const link = screen.getByRole( 'link', { name: /open list/i } );
+		expect( link ).toHaveAttribute( 'href', '/reader/list/benhuberman/quirky-histories' );
+	} );
+
+	test( 'renders with empty tags', () => {
+		renderWithProvider( <ListCard { ...defaultProps } tags={ [] } /> );
+
+		expect( screen.getByText( 'Quirky Histories' ) ).toBeVisible();
+	} );
+
+	test( 'renders with empty items', () => {
+		renderWithProvider( <ListCard { ...defaultProps } items={ [] } /> );
+
+		expect( screen.getByText( 'Quirky Histories' ) ).toBeVisible();
+	} );
+
+	test( 'renders site icons', () => {
+		renderWithProvider( <ListCard { ...defaultProps } /> );
+
+		const img = screen.getByRole( 'img', { name: 'Site A' } );
+		expect( img ).toBeVisible();
+	} );
+
+	test( 'shows skeleton icons when loading items', () => {
+		const { container } = renderWithProvider(
+			<ListCard { ...defaultProps } items={ [] } isLoadingItems />
+		);
+
+		expect( container.querySelector( '.list-card__icons-skeleton' ) ).toBeInTheDocument();
+	} );
+} );

--- a/client/reader/components/site-icons-row/index.tsx
+++ b/client/reader/components/site-icons-row/index.tsx
@@ -1,0 +1,59 @@
+import './style.scss';
+
+const MAX_ICONS = 10;
+
+interface SiteIconItem {
+	site_name: string;
+	site_icon: string | null;
+}
+
+interface SiteIconsRowProps {
+	items: SiteIconItem[];
+	totalCount: number;
+}
+
+function getInitials( name: string ): string {
+	return name.slice( 0, 2 );
+}
+
+function SiteIcon( { item }: { item: SiteIconItem } ) {
+	if ( item.site_icon ) {
+		return (
+			<img
+				className="site-icons-row__icon"
+				src={ item.site_icon }
+				alt={ item.site_name }
+				loading="lazy"
+			/>
+		);
+	}
+
+	return (
+		<span
+			className="site-icons-row__icon site-icons-row__icon--initials"
+			aria-label={ item.site_name }
+		>
+			{ getInitials( item.site_name ) }
+		</span>
+	);
+}
+
+export function SiteIconsRow( { items, totalCount }: SiteIconsRowProps ) {
+	if ( ! items || items.length === 0 ) {
+		return null;
+	}
+
+	const displayedItems = items.slice( 0, MAX_ICONS );
+	const overflowCount = totalCount - displayedItems.length;
+
+	return (
+		<div className="site-icons-row">
+			{ displayedItems.map( ( item, index ) => (
+				<SiteIcon key={ index } item={ item } />
+			) ) }
+			{ overflowCount > 0 && (
+				<span className="site-icons-row__icon site-icons-row__overflow">+{ overflowCount }</span>
+			) }
+		</div>
+	);
+}

--- a/client/reader/components/site-icons-row/index.tsx
+++ b/client/reader/components/site-icons-row/index.tsx
@@ -3,7 +3,7 @@ import './style.scss';
 const MAX_ICONS = 10;
 
 interface SiteIconItem {
-	site_name: string;
+	site_name: string | null;
 	site_icon: string | null;
 }
 
@@ -12,27 +12,21 @@ interface SiteIconsRowProps {
 	totalCount: number;
 }
 
-function getInitials( name: string ): string {
-	return name.slice( 0, 2 );
+function getInitials( name: string | null ): string {
+	return name ? name.slice( 0, 2 ) : '';
 }
 
 function SiteIcon( { item }: { item: SiteIconItem } ) {
+	const name = item.site_name ?? '';
+
 	if ( item.site_icon ) {
 		return (
-			<img
-				className="site-icons-row__icon"
-				src={ item.site_icon }
-				alt={ item.site_name }
-				loading="lazy"
-			/>
+			<img className="site-icons-row__icon" src={ item.site_icon } alt={ name } loading="lazy" />
 		);
 	}
 
 	return (
-		<span
-			className="site-icons-row__icon site-icons-row__icon--initials"
-			aria-label={ item.site_name }
-		>
+		<span className="site-icons-row__icon site-icons-row__icon--initials" aria-label={ name }>
 			{ getInitials( item.site_name ) }
 		</span>
 	);

--- a/client/reader/components/site-icons-row/style.scss
+++ b/client/reader/components/site-icons-row/style.scss
@@ -1,0 +1,37 @@
+.site-icons-row {
+	display: flex;
+	align-items: center;
+}
+
+.site-icons-row__icon {
+	width: 34px;
+	height: 34px;
+	border-radius: 50%;
+	border: 2px solid var( --color-surface );
+	flex-shrink: 0;
+	object-fit: cover;
+
+	&:not(:first-child) {
+		margin-inline-start: -8px;
+	}
+}
+
+.site-icons-row__icon--initials {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: var( --color-neutral-10 );
+	color: var( --color-neutral-70 );
+	font-size: 11px;
+	font-weight: 600;
+}
+
+.site-icons-row__overflow {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: var( --color-neutral-5 );
+	color: var( --color-neutral-70 );
+	font-size: 10px;
+	font-weight: 600;
+}

--- a/client/reader/components/site-icons-row/test/index.test.tsx
+++ b/client/reader/components/site-icons-row/test/index.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { SiteIconsRow } from '../index';
+
+const mockItems = [
+	{ site_name: 'Smitten Kitchen', site_icon: 'https://example.com/sk.png' },
+	{ site_name: 'Another Blog', site_icon: 'https://example.com/ab.png' },
+	{ site_name: 'No Icon Site', site_icon: null },
+];
+
+describe( 'SiteIconsRow', () => {
+	test( 'renders an icon for each item', () => {
+		render( <SiteIconsRow items={ mockItems } totalCount={ 3 } /> );
+
+		const images = screen.getAllByRole( 'img' );
+		expect( images ).toHaveLength( 2 );
+		expect( images[ 0 ] ).toHaveAttribute( 'alt', 'Smitten Kitchen' );
+	} );
+
+	test( 'renders initials fallback when site_icon is null', () => {
+		render( <SiteIconsRow items={ mockItems } totalCount={ 3 } /> );
+
+		expect( screen.getByText( 'No' ) ).toBeVisible();
+	} );
+
+	test( 'caps displayed icons at 10', () => {
+		const manyItems = Array.from( { length: 15 }, ( _, i ) => ( {
+			site_name: `Site ${ i }`,
+			site_icon: `https://example.com/${ i }.png`,
+		} ) );
+
+		render( <SiteIconsRow items={ manyItems } totalCount={ 15 } /> );
+
+		const images = screen.getAllByRole( 'img' );
+		expect( images ).toHaveLength( 10 );
+	} );
+
+	test( 'shows +N overflow bubble when totalCount exceeds displayed icons', () => {
+		render( <SiteIconsRow items={ mockItems } totalCount={ 25 } /> );
+
+		expect( screen.getByText( '+22' ) ).toBeVisible();
+	} );
+
+	test( 'does not show overflow bubble when totalCount equals item count', () => {
+		render( <SiteIconsRow items={ mockItems } totalCount={ 3 } /> );
+
+		expect( screen.queryByText( /\+\d+/ ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders nothing when items is empty', () => {
+		const { container } = render( <SiteIconsRow items={ [] } totalCount={ 0 } /> );
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );

--- a/client/reader/list-stream/follow-all-sites-button.tsx
+++ b/client/reader/list-stream/follow-all-sites-button.tsx
@@ -1,0 +1,78 @@
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import { useDispatch, useSelector } from 'calypso/state';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { successNotice } from 'calypso/state/notices/actions';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import { follow } from 'calypso/state/reader/follows/actions';
+import { registerLastActionRequiresLogin } from 'calypso/state/reader-ui/actions';
+import type { PublicListItem } from './use-public-list-query';
+
+interface FollowAllSitesButtonProps {
+	items: PublicListItem[];
+	followSource: string;
+}
+
+export function FollowAllSitesButton( { items }: FollowAllSitesButtonProps ): JSX.Element | null {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const isLoggedIn = useSelector( isUserLoggedIn );
+	const [ isFollowing, setIsFollowing ] = useState( false );
+
+	if ( ! items || items.length === 0 ) {
+		return null;
+	}
+
+	async function handleFollowAll() {
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_list_follow_all_clicked', {
+				site_count: items.length,
+			} )
+		);
+
+		if ( ! isLoggedIn ) {
+			dispatch(
+				registerLastActionRequiresLogin( {
+					type: 'follow-site',
+					siteUrl: items[ 0 ].site_url,
+				} )
+			);
+			return;
+		}
+
+		setIsFollowing( true );
+
+		for ( const item of items ) {
+			dispatch( follow( item.site_url ) );
+		}
+
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_list_follow_all_completed', {
+				site_count: items.length,
+			} )
+		);
+
+		dispatch(
+			successNotice(
+				translate( 'Subscribed to %(count)d sites.', {
+					args: { count: items.length },
+				} ),
+				{ duration: 5000 }
+			)
+		);
+
+		setIsFollowing( false );
+	}
+
+	return (
+		<Button
+			variant="secondary"
+			onClick={ handleFollowAll }
+			isBusy={ isFollowing }
+			disabled={ isFollowing }
+		>
+			{ isFollowing ? translate( 'Subscribing\u2026' ) : translate( 'Follow all sites' ) }
+		</Button>
+	);
+}

--- a/client/reader/list-stream/follow-all-sites-button.tsx
+++ b/client/reader/list-stream/follow-all-sites-button.tsx
@@ -1,6 +1,7 @@
-import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import SplitButton from 'calypso/components/split-button';
 import { useDispatch, useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { successNotice } from 'calypso/state/notices/actions';
@@ -12,9 +13,17 @@ import type { PublicListItem } from './use-public-list-query';
 interface FollowAllSitesButtonProps {
 	items: PublicListItem[];
 	followSource: string;
+	showSubscribeToList?: boolean;
+	isSubscribedToList?: boolean;
+	onSubscribeToggle?: ( isFollowRequested: boolean ) => void;
 }
 
-export function FollowAllSitesButton( { items }: FollowAllSitesButtonProps ): JSX.Element | null {
+export function FollowAllSitesButton( {
+	items,
+	showSubscribeToList,
+	isSubscribedToList,
+	onSubscribeToggle,
+}: FollowAllSitesButtonProps ): JSX.Element | null {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const isLoggedIn = useSelector( isUserLoggedIn );
@@ -24,7 +33,7 @@ export function FollowAllSitesButton( { items }: FollowAllSitesButtonProps ): JS
 		return null;
 	}
 
-	async function handleFollowAll() {
+	function handleFollowAll() {
 		dispatch(
 			recordReaderTracksEvent( 'calypso_reader_list_follow_all_clicked', {
 				site_count: items.length,
@@ -65,14 +74,32 @@ export function FollowAllSitesButton( { items }: FollowAllSitesButtonProps ): JS
 		setIsFollowing( false );
 	}
 
+	function handleSubscribeToggle() {
+		if ( onSubscribeToggle ) {
+			onSubscribeToggle( ! isSubscribedToList );
+		}
+	}
+
+	const label = isFollowing ? translate( 'Subscribing\u2026' ) : translate( 'Follow all sites' );
+
+	if ( ! showSubscribeToList ) {
+		return (
+			<SplitButton
+				label={ label }
+				onClick={ handleFollowAll }
+				disabled={ isFollowing }
+				disableMenu
+			/>
+		);
+	}
+
 	return (
-		<Button
-			variant="secondary"
-			onClick={ handleFollowAll }
-			isBusy={ isFollowing }
-			disabled={ isFollowing }
-		>
-			{ isFollowing ? translate( 'Subscribing\u2026' ) : translate( 'Follow all sites' ) }
-		</Button>
+		<SplitButton label={ label } onClick={ handleFollowAll } disabled={ isFollowing }>
+			<PopoverMenuItem onClick={ handleSubscribeToggle }>
+				{ isSubscribedToList
+					? translate( 'Unsubscribe from list' )
+					: translate( 'Subscribe to list' ) }
+			</PopoverMenuItem>
+		</SplitButton>
 	);
 }

--- a/client/reader/list-stream/follow-all-sites-button.tsx
+++ b/client/reader/list-stream/follow-all-sites-button.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
@@ -84,12 +85,9 @@ export function FollowAllSitesButton( {
 
 	if ( ! showSubscribeToList ) {
 		return (
-			<SplitButton
-				label={ label }
-				onClick={ handleFollowAll }
-				disabled={ isFollowing }
-				disableMenu
-			/>
+			<Button variant="secondary" onClick={ handleFollowAll } disabled={ isFollowing }>
+				{ label }
+			</Button>
 		);
 	}
 

--- a/client/reader/list-stream/header.tsx
+++ b/client/reader/list-stream/header.tsx
@@ -4,6 +4,9 @@ import FollowButton from 'calypso/blocks/follow-button/button';
 import AutoDirection from 'calypso/components/auto-direction';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { isExternal } from 'calypso/lib/url';
+import { FollowAllSitesButton } from './follow-all-sites-button';
+import { ListTags } from './list-tags';
+import type { PublicListItem } from './use-public-list-query';
 
 interface ListStreamHeaderProps {
 	isPublic?: boolean;
@@ -14,6 +17,8 @@ interface ListStreamHeaderProps {
 	showFollow?: boolean;
 	following?: boolean;
 	onFollowToggle?: () => void;
+	tags?: string[];
+	items?: PublicListItem[];
 }
 
 const ListStreamHeader = ( {
@@ -25,6 +30,8 @@ const ListStreamHeader = ( {
 	showFollow,
 	following,
 	onFollowToggle,
+	tags,
+	items,
 }: ListStreamHeaderProps ) => {
 	const translate = useTranslate();
 
@@ -59,6 +66,10 @@ const ListStreamHeader = ( {
 					</div>
 				) }
 
+				{ showFollow && items && items.length > 0 && (
+					<FollowAllSitesButton items={ items } followSource="reader-list-header" />
+				) }
+
 				{ showEdit && editUrl && (
 					<div className="list-stream__header-edit">
 						<Button rel={ isExternal( editUrl ) ? 'external' : '' } href={ editUrl }>
@@ -67,6 +78,7 @@ const ListStreamHeader = ( {
 					</div>
 				) }
 			</NavigationHeader>
+			<ListTags tags={ tags } />
 		</AutoDirection>
 	);
 };

--- a/client/reader/list-stream/header.tsx
+++ b/client/reader/list-stream/header.tsx
@@ -1,6 +1,5 @@
 import { Gridicon, Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import FollowButton from 'calypso/blocks/follow-button/button';
 import AutoDirection from 'calypso/components/auto-direction';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { isExternal } from 'calypso/lib/url';
@@ -16,7 +15,7 @@ interface ListStreamHeaderProps {
 	editUrl?: string;
 	showFollow?: boolean;
 	following?: boolean;
-	onFollowToggle?: () => void;
+	onFollowToggle?: ( isFollowRequested: boolean ) => void;
 	tags?: string[];
 	items?: PublicListItem[];
 }
@@ -56,18 +55,14 @@ const ListStreamHeader = ( {
 					</div>
 				) }
 
-				{ showFollow && (
-					<div className="list-stream__header-follow">
-						<FollowButton
-							iconSize={ 24 }
-							following={ following }
-							onFollowToggle={ onFollowToggle }
-						/>
-					</div>
-				) }
-
 				{ items && items.length > 0 && (
-					<FollowAllSitesButton items={ items } followSource="reader-list-header" />
+					<FollowAllSitesButton
+						items={ items }
+						followSource="reader-list-header"
+						showSubscribeToList={ showFollow }
+						isSubscribedToList={ following }
+						onSubscribeToggle={ onFollowToggle }
+					/>
 				) }
 
 				{ showEdit && editUrl && (

--- a/client/reader/list-stream/header.tsx
+++ b/client/reader/list-stream/header.tsx
@@ -44,12 +44,9 @@ const ListStreamHeader = ( {
 			<div>
 				{ description }
 				{ showEdit && editUrl && (
-					<>
-						{ ' ' }
-						<a className="list-stream__header-edit-link" href={ editUrl }>
-							{ translate( 'Edit list' ) }
-						</a>
-					</>
+					<div className="list-stream__header-edit-link">
+						<a href={ editUrl }>{ translate( 'Edit list' ) }</a>
+					</div>
 				) }
 			</div>
 		</AutoDirection>

--- a/client/reader/list-stream/header.tsx
+++ b/client/reader/list-stream/header.tsx
@@ -41,7 +41,17 @@ const ListStreamHeader = ( {
 
 	const formattedDescription = (
 		<AutoDirection>
-			<div>{ description }</div>
+			<div>
+				{ description }
+				{ showEdit && editUrl && (
+					<>
+						{ ' ' }
+						<a className="list-stream__header-edit-link" href={ editUrl }>
+							{ translate( 'Edit list' ) }
+						</a>
+					</>
+				) }
+			</div>
 		</AutoDirection>
 	);
 
@@ -64,11 +74,6 @@ const ListStreamHeader = ( {
 					/>
 				) }
 			</NavigationHeader>
-			{ showEdit && editUrl && (
-				<a className="list-stream__header-edit-link" href={ editUrl }>
-					{ translate( 'Edit list' ) }
-				</a>
-			) }
 			<ListTags tags={ tags } />
 		</AutoDirection>
 	);

--- a/client/reader/list-stream/header.tsx
+++ b/client/reader/list-stream/header.tsx
@@ -66,7 +66,7 @@ const ListStreamHeader = ( {
 					</div>
 				) }
 
-				{ showFollow && items && items.length > 0 && (
+				{ items && items.length > 0 && (
 					<FollowAllSitesButton items={ items } followSource="reader-list-header" />
 				) }
 

--- a/client/reader/list-stream/header.tsx
+++ b/client/reader/list-stream/header.tsx
@@ -1,8 +1,7 @@
-import { Gridicon, Button } from '@automattic/components';
+import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import AutoDirection from 'calypso/components/auto-direction';
 import NavigationHeader from 'calypso/components/navigation-header';
-import { isExternal } from 'calypso/lib/url';
 import { FollowAllSitesButton } from './follow-all-sites-button';
 import { ListTags } from './list-tags';
 import type { PublicListItem } from './use-public-list-query';
@@ -64,15 +63,12 @@ const ListStreamHeader = ( {
 						onSubscribeToggle={ onFollowToggle }
 					/>
 				) }
-
-				{ showEdit && editUrl && (
-					<div className="list-stream__header-edit">
-						<Button rel={ isExternal( editUrl ) ? 'external' : '' } href={ editUrl }>
-							{ translate( 'Edit' ) }
-						</Button>
-					</div>
-				) }
 			</NavigationHeader>
+			{ showEdit && editUrl && (
+				<a className="list-stream__header-edit-link" href={ editUrl }>
+					{ translate( 'Edit list' ) }
+				</a>
+			) }
 			<ListTags tags={ tags } />
 		</AutoDirection>
 	);

--- a/client/reader/list-stream/index.jsx
+++ b/client/reader/list-stream/index.jsx
@@ -1,10 +1,13 @@
-import { localize } from 'i18n-calypso';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryReaderList from 'calypso/components/data/query-reader-list';
+import SectionNav from 'calypso/components/section-nav';
+import NavItem from 'calypso/components/section-nav/item';
+import NavTabs from 'calypso/components/section-nav/tabs';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import Stream from 'calypso/reader/stream';
+import { useSelector, useDispatch } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import { followList, unfollowList } from 'calypso/state/reader/lists/actions';
@@ -16,28 +19,37 @@ import {
 } from 'calypso/state/reader/lists/selectors';
 import EmptyContent from './empty';
 import ListStreamHeader from './header';
+import { ListSitesDirectory } from './list-sites-directory';
 import ListMissing from './missing';
+import { usePublicListQuery } from './use-public-list-query';
 import './style.scss';
 
-const createEmptyContent = ( list ) => {
-	const EmptyContentWithList = () => <EmptyContent list={ list } />;
-	EmptyContentWithList.displayName = 'EmptyContentWithList';
-	return EmptyContentWithList;
-};
+const TAB_POSTS = 'posts';
+const TAB_SITES = 'sites';
 
-class ListStream extends Component {
-	constructor( props ) {
-		super( props );
-		this.title = props.translate( 'Loading list' );
-	}
+function ListStream( props ) {
+	const { owner, slug } = props;
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const [ activeTab, setActiveTab ] = useState( TAB_POSTS );
 
-	toggleFollowing = ( isFollowRequested ) => {
-		const list = this.props.list;
+	const list = useSelector( ( state ) => getListByOwnerAndSlug( state, owner, slug ) );
+	const isSubscribed = useSelector( ( state ) => isSubscribedByOwnerAndSlug( state, owner, slug ) );
+	const hasRequested = useSelector( ( state ) =>
+		hasRequestedListByOwnerAndSlug( state, owner, slug )
+	);
+	const isMissing = useSelector( ( state ) => isMissingByOwnerAndSlug( state, owner, slug ) );
+	const currentUser = useSelector( getCurrentUser );
 
+	const { data: publicListData } = usePublicListQuery( owner, slug );
+
+	const shouldShowFollow = list && ! list.is_owner;
+
+	function toggleFollowing( isFollowRequested ) {
 		if ( isFollowRequested ) {
-			this.props.followList( list.owner, list.slug );
+			dispatch( followList( list.owner, list.slug ) );
 		} else {
-			this.props.unfollowList( list.owner, list.slug );
+			dispatch( unfollowList( list.owner, list.slug ) );
 		}
 
 		recordAction( isFollowRequested ? 'followed_list' : 'unfollowed_list' );
@@ -45,102 +57,130 @@ class ListStream extends Component {
 			isFollowRequested ? 'Clicked Follow List' : 'Clicked Unfollow List',
 			list.owner + ':' + list.slug
 		);
-		this.props.recordReaderTracksEvent(
-			isFollowRequested
-				? 'calypso_reader_reader_list_followed'
-				: 'calypso_reader_reader_list_unfollowed',
-			{
-				list_owner: list.owner,
-				list_slug: list.slug,
-			}
-		);
-	};
-
-	render() {
-		const list = this.props.list;
-		const shouldShowFollow = list && ! list.is_owner;
-		const listStreamIconClasses = 'gridicon gridicon__list';
-
-		if ( ! this.props.hasRequested ) {
-			return <QueryReaderList owner={ this.props.owner } slug={ this.props.slug } />;
-		}
-
-		let formattedTitle = this.title;
-		if ( list ) {
-			// Show author name in parentheses if the list is owned by someone other than the current user
-			const isOwnedByCurrentUser =
-				this.props.currentUser && list.owner === this.props.currentUser.username;
-			this.title = isOwnedByCurrentUser ? list.title : `${ list.title } (${ list.owner })`;
-			formattedTitle = isOwnedByCurrentUser ? (
-				list.title
-			) : (
-				<>
-					{ list.title } (<a href={ `/reader/users/${ list.owner }` }>{ list.owner }</a>)
-				</>
-			);
-		}
-
-		if ( this.props.isMissing ) {
-			return <ListMissing owner={ this.props.owner } slug={ this.props.slug } />;
-		}
-
-		return (
-			<Stream
-				{ ...this.props }
-				listName={ this.title }
-				emptyContent={ createEmptyContent( list ) }
-				showFollowInHeader={ shouldShowFollow }
-			>
-				<DocumentHead
-					title={ this.props.translate( '%s ‹ Reader', {
-						args: this.title,
-						comment: '%s is the section name. For example: "My Likes"',
-					} ) }
-				/>
-				<QueryReaderList owner={ this.props.owner } slug={ this.props.slug } />
-				<ListStreamHeader
-					isPublic={ list?.is_public }
-					icon={
-						<svg
-							className={ listStreamIconClasses }
-							height="32"
-							width="32"
-							xmlns="http://www.w3.org/2000/svg"
-							viewBox="0 0 24 24"
-						>
-							<g>
-								<path
-									d="M9 19h10v-2H9v2zm0-6h10v-2H9v2zm0-8v2h10V5H9zm-3-.5c-.828
-									0-1.5.672-1.5 1.5S5.172 7.5 6 7.5 7.5 6.828 7.5 6 6.828 4.5 6
-									4.5zm0 6c-.828 0-1.5.672-1.5 1.5s.672 1.5 1.5 1.5 1.5-.672
-									1.5-1.5-.672-1.5-1.5-1.5zm0 6c-.828 0-1.5.672-1.5 1.5s.672 1.5
-									1.5 1.5 1.5-.672 1.5-1.5-.672-1.5-1.5-1.5z"
-								/>
-							</g>
-						</svg>
-					}
-					title={ formattedTitle }
-					description={ list?.description }
-					showFollow={ shouldShowFollow }
-					following={ this.props.isSubscribed }
-					onFollowToggle={ this.toggleFollowing }
-					showEdit={ list && list.is_owner }
-					editUrl={ window.location.href + '/edit' }
-				/>
-			</Stream>
+		dispatch(
+			recordReaderTracksEvent(
+				isFollowRequested
+					? 'calypso_reader_reader_list_followed'
+					: 'calypso_reader_reader_list_unfollowed',
+				{
+					list_owner: list.owner,
+					list_slug: list.slug,
+				}
+			)
 		);
 	}
+
+	if ( ! hasRequested ) {
+		return <QueryReaderList owner={ owner } slug={ slug } />;
+	}
+
+	let pageTitle = translate( 'Loading list' );
+	let formattedTitle = pageTitle;
+	if ( list ) {
+		const isOwnedByCurrentUser = currentUser && list.owner === currentUser.username;
+		pageTitle = isOwnedByCurrentUser ? list.title : `${ list.title } (${ list.owner })`;
+		formattedTitle = isOwnedByCurrentUser ? (
+			list.title
+		) : (
+			<>
+				{ list.title } (<a href={ `/reader/users/${ list.owner }` }>{ list.owner }</a>)
+			</>
+		);
+	}
+
+	if ( isMissing ) {
+		return <ListMissing owner={ owner } slug={ slug } />;
+	}
+
+	const listStreamIconClasses = 'gridicon gridicon__list';
+	const EmptyContentWithList = () => <EmptyContent list={ list } />;
+	EmptyContentWithList.displayName = 'EmptyContentWithList';
+
+	function handleTabChange( tab ) {
+		setActiveTab( tab );
+		if ( tab === TAB_SITES ) {
+			dispatch(
+				recordReaderTracksEvent( 'calypso_reader_list_sites_tab_viewed', {
+					list_owner: owner,
+					list_slug: slug,
+				} )
+			);
+		}
+	}
+
+	return (
+		<>
+			<DocumentHead
+				title={ translate( '%s ‹ Reader', {
+					args: pageTitle,
+					comment: '%s is the section name. For example: "My Likes"',
+				} ) }
+			/>
+			<QueryReaderList owner={ owner } slug={ slug } />
+			<ListStreamHeader
+				isPublic={ list?.is_public }
+				icon={
+					<svg
+						className={ listStreamIconClasses }
+						height="32"
+						width="32"
+						xmlns="http://www.w3.org/2000/svg"
+						viewBox="0 0 24 24"
+					>
+						<g>
+							<path
+								d="M9 19h10v-2H9v2zm0-6h10v-2H9v2zm0-8v2h10V5H9zm-3-.5c-.828
+								0-1.5.672-1.5 1.5S5.172 7.5 6 7.5 7.5 6.828 7.5 6 6.828 4.5 6
+								4.5zm0 6c-.828 0-1.5.672-1.5 1.5s.672 1.5 1.5 1.5 1.5-.672
+								1.5-1.5-.672-1.5-1.5-1.5zm0 6c-.828 0-1.5.672-1.5 1.5s.672 1.5
+								1.5 1.5 1.5-.672 1.5-1.5-.672-1.5-1.5-1.5z"
+							/>
+						</g>
+					</svg>
+				}
+				title={ formattedTitle }
+				description={ list?.description }
+				showFollow={ shouldShowFollow }
+				following={ isSubscribed }
+				onFollowToggle={ toggleFollowing }
+				showEdit={ list && list.is_owner }
+				editUrl={ window.location.href + '/edit' }
+				tags={ publicListData?.tags }
+				items={ publicListData?.items }
+			/>
+
+			<SectionNav className="list-stream__tabs" variation="minimal">
+				<NavTabs>
+					<NavItem
+						selected={ activeTab === TAB_POSTS }
+						onClick={ () => handleTabChange( TAB_POSTS ) }
+					>
+						{ translate( 'Posts' ) }
+					</NavItem>
+					<NavItem
+						selected={ activeTab === TAB_SITES }
+						onClick={ () => handleTabChange( TAB_SITES ) }
+						count={ publicListData?.item_count }
+					>
+						{ translate( 'Sites' ) }
+					</NavItem>
+				</NavTabs>
+			</SectionNav>
+
+			{ activeTab === TAB_POSTS && (
+				<Stream
+					{ ...props }
+					listName={ pageTitle }
+					emptyContent={ EmptyContentWithList }
+					showFollowInHeader={ false }
+				/>
+			) }
+
+			{ activeTab === TAB_SITES && publicListData && (
+				<ListSitesDirectory items={ publicListData.items } followSource="reader-list-sites-tab" />
+			) }
+		</>
+	);
 }
 
-export default connect(
-	( state, ownProps ) => {
-		return {
-			list: getListByOwnerAndSlug( state, ownProps.owner, ownProps.slug ),
-			isSubscribed: isSubscribedByOwnerAndSlug( state, ownProps.owner, ownProps.slug ),
-			hasRequested: hasRequestedListByOwnerAndSlug( state, ownProps.owner, ownProps.slug ),
-			isMissing: isMissingByOwnerAndSlug( state, ownProps.owner, ownProps.slug ),
-			currentUser: getCurrentUser( state ),
-		};
-	},
-	{ followList, recordReaderTracksEvent, unfollowList }
-)( localize( ListStream ) );
+export default ListStream;

--- a/client/reader/list-stream/index.jsx
+++ b/client/reader/list-stream/index.jsx
@@ -32,7 +32,7 @@ function ListStream( props ) {
 	const { owner, slug } = props;
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const [ activeTab, setActiveTab ] = useState( TAB_POSTS );
+	const [ activeTab, setActiveTab ] = useState( TAB_SITES );
 
 	const list = useSelector( ( state ) => getListByOwnerAndSlug( state, owner, slug ) );
 	const isSubscribed = useSelector( ( state ) => isSubscribedByOwnerAndSlug( state, owner, slug ) );

--- a/client/reader/list-stream/index.jsx
+++ b/client/reader/list-stream/index.jsx
@@ -5,6 +5,7 @@ import QueryReaderList from 'calypso/components/data/query-reader-list';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
+import ReaderMain from 'calypso/reader/components/reader-main';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import Stream from 'calypso/reader/stream';
 import { useSelector, useDispatch } from 'calypso/state';
@@ -109,7 +110,7 @@ function ListStream( props ) {
 	}
 
 	return (
-		<>
+		<ReaderMain>
 			<DocumentHead
 				title={ translate( '%s ‹ Reader', {
 					args: pageTitle,
@@ -170,6 +171,7 @@ function ListStream( props ) {
 			{ activeTab === TAB_POSTS && (
 				<Stream
 					{ ...props }
+					isMain={ false }
 					listName={ pageTitle }
 					emptyContent={ EmptyContentWithList }
 					showFollowInHeader={ false }
@@ -179,7 +181,7 @@ function ListStream( props ) {
 			{ activeTab === TAB_SITES && publicListData && (
 				<ListSitesDirectory items={ publicListData.items } followSource="reader-list-sites-tab" />
 			) }
-		</>
+		</ReaderMain>
 	);
 }
 

--- a/client/reader/list-stream/list-sites-directory.scss
+++ b/client/reader/list-stream/list-sites-directory.scss
@@ -1,0 +1,27 @@
+.is-reader-page {
+	.list-sites-directory {
+		margin-top: 16px;
+	}
+
+	.list-sites-directory__empty {
+		padding: 40px 0;
+		text-align: center;
+		color: var( --studio-gray-40 );
+	}
+
+	.list-sites-directory__fediverse-handle {
+		margin-top: -12px;
+		margin-bottom: 12px;
+		padding-inline-start: 54px;
+		font-size: rem( 13px );
+
+		a {
+			color: var( --studio-gray-40 );
+			text-decoration: none;
+
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+}

--- a/client/reader/list-stream/list-sites-directory.scss
+++ b/client/reader/list-stream/list-sites-directory.scss
@@ -23,18 +23,3 @@
 		border-bottom: none;
 	}
 }
-
-.list-sites-directory__fediverse-handle {
-	padding-bottom: 12px;
-	padding-inline-start: 54px;
-	font-size: rem( 13px );
-
-	a {
-		color: var( --studio-gray-40 );
-		text-decoration: none;
-
-		&:hover {
-			text-decoration: underline;
-		}
-	}
-}

--- a/client/reader/list-stream/list-sites-directory.scss
+++ b/client/reader/list-stream/list-sites-directory.scss
@@ -1,27 +1,25 @@
-.is-reader-page {
-	.list-sites-directory {
-		margin-top: 16px;
-	}
+.list-sites-directory {
+	margin-top: 16px;
+}
 
-	.list-sites-directory__empty {
-		padding: 40px 0;
-		text-align: center;
+.list-sites-directory__empty {
+	padding: 40px 0;
+	text-align: center;
+	color: var( --studio-gray-40 );
+}
+
+.list-sites-directory__fediverse-handle {
+	margin-top: -12px;
+	margin-bottom: 12px;
+	padding-inline-start: 54px;
+	font-size: rem( 13px );
+
+	a {
 		color: var( --studio-gray-40 );
-	}
+		text-decoration: none;
 
-	.list-sites-directory__fediverse-handle {
-		margin-top: -12px;
-		margin-bottom: 12px;
-		padding-inline-start: 54px;
-		font-size: rem( 13px );
-
-		a {
-			color: var( --studio-gray-40 );
-			text-decoration: none;
-
-			&:hover {
-				text-decoration: underline;
-			}
+		&:hover {
+			text-decoration: underline;
 		}
 	}
 }

--- a/client/reader/list-stream/list-sites-directory.scss
+++ b/client/reader/list-stream/list-sites-directory.scss
@@ -8,9 +8,24 @@
 	color: var( --studio-gray-40 );
 }
 
+.list-sites-directory__site {
+	border-bottom: 1px solid var( --color-neutral-5 );
+
+	&:last-child {
+		border-bottom: none;
+	}
+
+	.reader-sites-list {
+		margin: 0;
+	}
+
+	.reader-site-item {
+		border-bottom: none;
+	}
+}
+
 .list-sites-directory__fediverse-handle {
-	margin-top: -12px;
-	margin-bottom: 12px;
+	padding-bottom: 12px;
 	padding-inline-start: 54px;
 	font-size: rem( 13px );
 

--- a/client/reader/list-stream/list-sites-directory.tsx
+++ b/client/reader/list-stream/list-sites-directory.tsx
@@ -1,22 +1,12 @@
 import { useTranslate } from 'i18n-calypso';
-import { ReaderSitesList } from 'calypso/reader/sites-list';
+import { ReaderSiteItem } from 'calypso/reader/sites-list/site-item';
 import type { PublicListItem } from './use-public-list-query';
-import type { ReaderSite } from 'calypso/reader/sites-list/site-item';
 
 import './list-sites-directory.scss';
 
 interface ListSitesDirectoryProps {
 	items: PublicListItem[];
 	followSource: string;
-}
-
-function mapItemToReaderSite( item: PublicListItem ): ReaderSite {
-	return {
-		siteId: item.blog_id ? String( item.blog_id ) : undefined,
-		feedId: String( item.feed_id ),
-		name: item.site_name,
-		feedUrl: item.site_url,
-	};
 }
 
 export function ListSitesDirectory( {
@@ -33,26 +23,33 @@ export function ListSitesDirectory( {
 		);
 	}
 
-	const sites = items.map( mapItemToReaderSite );
-
 	return (
 		<div className="list-sites-directory">
-			<ReaderSitesList sites={ sites } variant="default" followSource={ followSource } />
-			{ items.map(
-				( item ) =>
-					item.fediverse_handle &&
-					item.fediverse_handle_url && (
-						<div
-							key={ `fediverse-${ item.feed_id }` }
-							className="list-sites-directory__fediverse-handle"
-							data-feed-id={ item.feed_id }
-						>
-							<a href={ item.fediverse_handle_url } target="_blank" rel="noopener noreferrer">
-								{ item.fediverse_handle }
-							</a>
-						</div>
-					)
-			) }
+			{ items
+				.filter( ( item ) => item.site_url )
+				.map( ( item ) => (
+					<div key={ `list-site-${ item.feed_id }` } className="list-sites-directory__site">
+						<ul className="reader-sites-list is-default-view">
+							<ReaderSiteItem
+								site={ {
+									siteId: item.blog_id ? String( item.blog_id ) : undefined,
+									feedId: String( item.feed_id ),
+									name: item.site_name,
+									feedUrl: item.site_url,
+								} }
+								followSource={ followSource }
+								variant="default"
+							/>
+						</ul>
+						{ item.fediverse_handle && item.fediverse_handle_url && (
+							<div className="list-sites-directory__fediverse-handle">
+								<a href={ item.fediverse_handle_url } target="_blank" rel="noopener noreferrer">
+									{ item.fediverse_handle }
+								</a>
+							</div>
+						) }
+					</div>
+				) ) }
 		</div>
 	);
 }

--- a/client/reader/list-stream/list-sites-directory.tsx
+++ b/client/reader/list-stream/list-sites-directory.tsx
@@ -41,13 +41,6 @@ export function ListSitesDirectory( {
 								variant="default"
 							/>
 						</ul>
-						{ item.fediverse_handle && item.fediverse_handle_url && (
-							<div className="list-sites-directory__fediverse-handle">
-								<a href={ item.fediverse_handle_url } target="_blank" rel="noopener noreferrer">
-									{ item.fediverse_handle }
-								</a>
-							</div>
-						) }
 					</div>
 				) ) }
 		</div>

--- a/client/reader/list-stream/list-sites-directory.tsx
+++ b/client/reader/list-stream/list-sites-directory.tsx
@@ -1,0 +1,58 @@
+import { useTranslate } from 'i18n-calypso';
+import { ReaderSitesList } from 'calypso/reader/sites-list';
+import type { PublicListItem } from './use-public-list-query';
+import type { ReaderSite } from 'calypso/reader/sites-list/site-item';
+
+import './list-sites-directory.scss';
+
+interface ListSitesDirectoryProps {
+	items: PublicListItem[];
+	followSource: string;
+}
+
+function mapItemToReaderSite( item: PublicListItem ): ReaderSite {
+	return {
+		siteId: item.blog_id ? String( item.blog_id ) : undefined,
+		feedId: String( item.feed_id ),
+		name: item.site_name,
+		feedUrl: item.site_url,
+	};
+}
+
+export function ListSitesDirectory( {
+	items,
+	followSource,
+}: ListSitesDirectoryProps ): JSX.Element {
+	const translate = useTranslate();
+
+	if ( ! items || items.length === 0 ) {
+		return (
+			<div className="list-sites-directory__empty">
+				<p>{ translate( 'No sites in this list yet.' ) }</p>
+			</div>
+		);
+	}
+
+	const sites = items.map( mapItemToReaderSite );
+
+	return (
+		<div className="list-sites-directory">
+			<ReaderSitesList sites={ sites } variant="default" followSource={ followSource } />
+			{ items.map(
+				( item ) =>
+					item.fediverse_handle &&
+					item.fediverse_handle_url && (
+						<div
+							key={ `fediverse-${ item.feed_id }` }
+							className="list-sites-directory__fediverse-handle"
+							data-feed-id={ item.feed_id }
+						>
+							<a href={ item.fediverse_handle_url } target="_blank" rel="noopener noreferrer">
+								{ item.fediverse_handle }
+							</a>
+						</div>
+					)
+			) }
+		</div>
+	);
+}

--- a/client/reader/list-stream/list-tags.scss
+++ b/client/reader/list-stream/list-tags.scss
@@ -1,18 +1,16 @@
-.is-reader-page {
-	.list-tags {
+.list-tags {
 		display: flex;
 		flex-wrap: wrap;
 		gap: 12px;
 		margin-top: 16px;
 	}
 
-	.list-tags__tag {
-		display: flex;
-		background-color: #f0f0f0;
-		align-items: center;
-		border-radius: 2px;
-		padding: 6px 8px;
-		font-size: rem( 13px );
-		color: var( --studio-gray-90 );
-	}
+.list-tags__tag {
+	display: flex;
+	background-color: #f0f0f0;
+	align-items: center;
+	border-radius: 2px;
+	padding: 6px 8px;
+	font-size: rem( 13px );
+	color: var( --studio-gray-90 );
 }

--- a/client/reader/list-stream/list-tags.scss
+++ b/client/reader/list-stream/list-tags.scss
@@ -1,0 +1,18 @@
+.is-reader-page {
+	.list-tags {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 12px;
+		margin-top: 16px;
+	}
+
+	.list-tags__tag {
+		display: flex;
+		background-color: #f0f0f0;
+		align-items: center;
+		border-radius: 2px;
+		padding: 6px 8px;
+		font-size: rem( 13px );
+		color: var( --studio-gray-90 );
+	}
+}

--- a/client/reader/list-stream/list-tags.tsx
+++ b/client/reader/list-stream/list-tags.tsx
@@ -1,0 +1,21 @@
+import './list-tags.scss';
+
+interface ListTagsProps {
+	tags: string[] | undefined;
+}
+
+export function ListTags( { tags }: ListTagsProps ): JSX.Element | null {
+	if ( ! tags || tags.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<div className="list-tags">
+			{ tags.map( ( tag ) => (
+				<span key={ tag } className="list-tags__tag">
+					#{ tag }
+				</span>
+			) ) }
+		</div>
+	);
+}

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -50,12 +50,16 @@
 }
 
 .list-stream__header-edit-link {
-	color: var( --studio-gray-40 );
-	text-decoration: none;
+	margin-top: 8px;
 
-	&:hover {
-		text-decoration: underline;
+	a {
+		font-size: rem( 13px );
 		color: var( --color-primary );
+		text-decoration: none;
+
+		&:hover {
+			text-decoration: underline;
+		}
 	}
 }
 

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -77,6 +77,7 @@
 }
 
 .navigation-header__actions .split-button {
+	display: flex;
 	flex-shrink: 0;
 }
 

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -70,3 +70,7 @@
 		}
 	}
 }
+
+.list-stream__tabs {
+	margin-bottom: 16px;
+}

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -50,11 +50,8 @@
 }
 
 .list-stream__header-edit-link {
-	font-size: rem( 13px );
 	color: var( --studio-gray-40 );
 	text-decoration: none;
-	margin-top: 4px;
-	display: inline-block;
 
 	&:hover {
 		text-decoration: underline;

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -76,6 +76,10 @@
 	}
 }
 
+.navigation-header__actions .split-button {
+	flex-shrink: 0;
+}
+
 .list-stream__tabs {
 	margin-bottom: 16px;
 }

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -49,11 +49,16 @@
 	}
 }
 
-.list-stream__header-edit {
-	margin-left: auto;
+.list-stream__header-edit-link {
+	font-size: rem( 13px );
+	color: var( --studio-gray-40 );
+	text-decoration: none;
+	margin-top: 4px;
+	display: inline-block;
 
-	.list-stream__header-action-icon .gridicon {
-		fill: var(--color-neutral-dark);
+	&:hover {
+		text-decoration: underline;
+		color: var( --color-primary );
 	}
 }
 

--- a/client/reader/list-stream/test/follow-all-sites-button.test.tsx
+++ b/client/reader/list-stream/test/follow-all-sites-button.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { FollowAllSitesButton } from '../follow-all-sites-button';
+import type { PublicListItem } from '../use-public-list-query';
+
+const mockFollow = jest.fn( ( feedUrl: string ) => ( {
+	type: 'READER_FOLLOW',
+	payload: { feedUrl },
+} ) );
+jest.mock( 'calypso/state/reader/follows/actions', () => ( {
+	follow: ( feedUrl: string ) => mockFollow( feedUrl ),
+} ) );
+
+jest.mock( 'calypso/state/reader/analytics/actions', () => ( {
+	recordReaderTracksEvent: ( event: string, props: Record< string, unknown > ) => ( {
+		type: 'ANALYTICS_EVENT_RECORD',
+		meta: { analytics: [ { type: 'mc', payload: { stat: event, ...props } } ] },
+	} ),
+} ) );
+
+const mockItems: PublicListItem[] = [
+	{
+		blog_id: 1,
+		feed_id: 100,
+		site_name: 'Site One',
+		site_url: 'https://siteone.com',
+		fediverse_handle: null,
+		fediverse_handle_url: null,
+	},
+	{
+		blog_id: 2,
+		feed_id: 200,
+		site_name: 'Site Two',
+		site_url: 'https://sitetwo.com',
+		fediverse_handle: null,
+		fediverse_handle_url: null,
+	},
+];
+
+describe( 'FollowAllSitesButton', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'renders the button with site count', () => {
+		renderWithProvider( <FollowAllSitesButton items={ mockItems } followSource="reader-list" /> );
+
+		expect( screen.getByRole( 'button', { name: /follow all/i } ) ).toBeVisible();
+	} );
+
+	test( 'dispatches follow actions for each site on click when logged in', async () => {
+		const user = userEvent.setup();
+
+		renderWithProvider( <FollowAllSitesButton items={ mockItems } followSource="reader-list" />, {
+			initialState: {
+				currentUser: { id: 1 },
+			},
+		} );
+
+		await user.click( screen.getByRole( 'button', { name: /follow all/i } ) );
+
+		expect( mockFollow ).toHaveBeenCalledTimes( 2 );
+		expect( mockFollow ).toHaveBeenNthCalledWith( 1, 'https://siteone.com' );
+		expect( mockFollow ).toHaveBeenNthCalledWith( 2, 'https://sitetwo.com' );
+	} );
+
+	test( 'renders nothing when items is empty', () => {
+		const { container } = renderWithProvider(
+			<FollowAllSitesButton items={ [] } followSource="reader-list" />
+		);
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );

--- a/client/reader/list-stream/test/list-sites-directory.test.tsx
+++ b/client/reader/list-stream/test/list-sites-directory.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { ListSitesDirectory } from '../list-sites-directory';
+import type { PublicListItem } from '../use-public-list-query';
+
+// Mock ReaderSitesList to avoid deep dependency chain
+jest.mock( 'calypso/reader/sites-list', () => ( {
+	ReaderSitesList: ( { sites }: { sites: Array< { name: string } > } ) => (
+		<ul data-testid="mock-sites-list">
+			{ sites.map( ( site ) => (
+				<li key={ site.name }>{ site.name }</li>
+			) ) }
+		</ul>
+	),
+} ) );
+
+const mockItems: PublicListItem[] = [
+	{
+		blog_id: 456,
+		feed_id: 1234,
+		site_name: 'Smitten Kitchen',
+		site_url: 'https://smittenkitchen.com',
+		fediverse_handle: '@smittenkitchen@smittenkitchen.com',
+		fediverse_handle_url: 'https://smittenkitchen.com/@smittenkitchen',
+	},
+	{
+		blog_id: 789,
+		feed_id: 5678,
+		site_name: 'Another Blog',
+		site_url: 'https://anotherblog.com',
+		fediverse_handle: null,
+		fediverse_handle_url: null,
+	},
+];
+
+describe( 'ListSitesDirectory', () => {
+	test( 'renders site items for each list item', () => {
+		renderWithProvider( <ListSitesDirectory items={ mockItems } followSource="reader-list" /> );
+
+		expect( screen.getByText( 'Smitten Kitchen' ) ).toBeVisible();
+		expect( screen.getByText( 'Another Blog' ) ).toBeVisible();
+	} );
+
+	test( 'shows fediverse handle when available', () => {
+		renderWithProvider( <ListSitesDirectory items={ mockItems } followSource="reader-list" /> );
+
+		expect( screen.getByText( '@smittenkitchen@smittenkitchen.com' ) ).toBeVisible();
+		expect(
+			screen.getByRole( 'link', { name: '@smittenkitchen@smittenkitchen.com' } )
+		).toHaveAttribute( 'href', 'https://smittenkitchen.com/@smittenkitchen' );
+	} );
+
+	test( 'does not show fediverse handle when null', () => {
+		renderWithProvider(
+			<ListSitesDirectory items={ [ mockItems[ 1 ] ] } followSource="reader-list" />
+		);
+
+		expect( screen.queryByText( /@.*@/ ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders empty state when items is empty', () => {
+		renderWithProvider( <ListSitesDirectory items={ [] } followSource="reader-list" /> );
+
+		expect( screen.getByText( /no sites/i ) ).toBeVisible();
+	} );
+} );

--- a/client/reader/list-stream/test/list-sites-directory.test.tsx
+++ b/client/reader/list-stream/test/list-sites-directory.test.tsx
@@ -6,14 +6,10 @@ import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { ListSitesDirectory } from '../list-sites-directory';
 import type { PublicListItem } from '../use-public-list-query';
 
-// Mock ReaderSitesList to avoid deep dependency chain
-jest.mock( 'calypso/reader/sites-list', () => ( {
-	ReaderSitesList: ( { sites }: { sites: Array< { name: string } > } ) => (
-		<ul data-testid="mock-sites-list">
-			{ sites.map( ( site ) => (
-				<li key={ site.name }>{ site.name }</li>
-			) ) }
-		</ul>
+// Mock ReaderSiteItem to avoid deep dependency chain
+jest.mock( 'calypso/reader/sites-list/site-item', () => ( {
+	ReaderSiteItem: ( { site }: { site: { name: string } } ) => (
+		<li data-testid="mock-site-item">{ site.name }</li>
 	),
 } ) );
 

--- a/client/reader/list-stream/test/list-sites-directory.test.tsx
+++ b/client/reader/list-stream/test/list-sites-directory.test.tsx
@@ -40,23 +40,6 @@ describe( 'ListSitesDirectory', () => {
 		expect( screen.getByText( 'Another Blog' ) ).toBeVisible();
 	} );
 
-	test( 'shows fediverse handle when available', () => {
-		renderWithProvider( <ListSitesDirectory items={ mockItems } followSource="reader-list" /> );
-
-		expect( screen.getByText( '@smittenkitchen@smittenkitchen.com' ) ).toBeVisible();
-		expect(
-			screen.getByRole( 'link', { name: '@smittenkitchen@smittenkitchen.com' } )
-		).toHaveAttribute( 'href', 'https://smittenkitchen.com/@smittenkitchen' );
-	} );
-
-	test( 'does not show fediverse handle when null', () => {
-		renderWithProvider(
-			<ListSitesDirectory items={ [ mockItems[ 1 ] ] } followSource="reader-list" />
-		);
-
-		expect( screen.queryByText( /@.*@/ ) ).not.toBeInTheDocument();
-	} );
-
 	test( 'renders empty state when items is empty', () => {
 		renderWithProvider( <ListSitesDirectory items={ [] } followSource="reader-list" /> );
 

--- a/client/reader/list-stream/test/list-tags.test.tsx
+++ b/client/reader/list-stream/test/list-tags.test.tsx
@@ -1,0 +1,25 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { ListTags } from '../list-tags';
+
+describe( 'ListTags', () => {
+	test( 'renders tag pills with hashtag prefix', () => {
+		render( <ListTags tags={ [ 'Food & Drink', 'Travel', 'Technology' ] } /> );
+
+		expect( screen.getByText( '#Food & Drink' ) ).toBeVisible();
+		expect( screen.getByText( '#Travel' ) ).toBeVisible();
+		expect( screen.getByText( '#Technology' ) ).toBeVisible();
+	} );
+
+	test( 'renders nothing when tags array is empty', () => {
+		const { container } = render( <ListTags tags={ [] } /> );
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	test( 'renders nothing when tags is undefined', () => {
+		const { container } = render( <ListTags tags={ undefined } /> );
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );

--- a/client/reader/list-stream/test/use-public-list-query.test.ts
+++ b/client/reader/list-stream/test/use-public-list-query.test.ts
@@ -1,0 +1,93 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { usePublicListQuery, type PublicListResponse } from '../use-public-list-query';
+
+const mockResponse: PublicListResponse = {
+	ID: 12345,
+	title: 'Test List',
+	slug: 'test-list',
+	description: 'A test list',
+	owner: 'testuser',
+	item_count: 2,
+	tags: [ 'Food & Drink', 'Travel' ],
+	items: [
+		{
+			blog_id: 456,
+			feed_id: 1234,
+			site_name: 'Test Site',
+			site_url: 'https://testsite.com',
+			fediverse_handle: '@test@testsite.com',
+			fediverse_handle_url: 'https://testsite.com/@test',
+		},
+		{
+			blog_id: null,
+			feed_id: 5678,
+			site_name: 'External Feed',
+			site_url: 'https://external.com',
+			fediverse_handle: null,
+			fediverse_handle_url: null,
+		},
+	],
+};
+
+function createWrapper() {
+	const queryClient = new QueryClient( {
+		defaultOptions: { queries: { retry: false } },
+	} );
+	return function Wrapper( { children }: { children: React.ReactNode } ) {
+		return React.createElement( QueryClientProvider, { client: queryClient }, children );
+	};
+}
+
+describe( 'usePublicListQuery', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'fetches and returns public list data', async () => {
+		( global.fetch as jest.Mock ).mockResolvedValueOnce( {
+			ok: true,
+			json: () => Promise.resolve( mockResponse ),
+		} );
+
+		const { result } = renderHook( () => usePublicListQuery( 'testuser', 'test-list' ), {
+			wrapper: createWrapper(),
+		} );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		expect( result.current.data ).toEqual( mockResponse );
+		expect( result.current.data?.tags ).toHaveLength( 2 );
+		expect( result.current.data?.items ).toHaveLength( 2 );
+		expect( global.fetch ).toHaveBeenCalledWith(
+			'https://public-api.wordpress.com/wpcom/v2/read/lists/testuser/test-list'
+		);
+	} );
+
+	test( 'returns error for missing list', async () => {
+		( global.fetch as jest.Mock ).mockResolvedValueOnce( {
+			ok: false,
+			status: 404,
+		} );
+
+		const { result } = renderHook( () => usePublicListQuery( 'testuser', 'nonexistent' ), {
+			wrapper: createWrapper(),
+		} );
+
+		await waitFor( () => expect( result.current.isError ).toBe( true ) );
+	} );
+
+	test( 'does not fetch when owner or slug is empty', () => {
+		const { result } = renderHook( () => usePublicListQuery( '', 'test-list' ), {
+			wrapper: createWrapper(),
+		} );
+
+		expect( result.current.isFetching ).toBe( false );
+		expect( global.fetch ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/reader/list-stream/use-public-list-query.ts
+++ b/client/reader/list-stream/use-public-list-query.ts
@@ -1,0 +1,44 @@
+import { useQuery } from '@tanstack/react-query';
+
+export interface PublicListItem {
+	blog_id: number | null;
+	feed_id: number;
+	site_name: string;
+	site_url: string;
+	fediverse_handle: string | null;
+	fediverse_handle_url: string | null;
+}
+
+export interface PublicListResponse {
+	ID: number;
+	title: string;
+	slug: string;
+	description: string;
+	owner: string;
+	item_count: number;
+	tags: string[];
+	items: PublicListItem[];
+}
+
+async function fetchPublicList( owner: string, slug: string ): Promise< PublicListResponse > {
+	const response = await globalThis.fetch(
+		`https://public-api.wordpress.com/wpcom/v2/read/lists/${ encodeURIComponent(
+			owner
+		) }/${ encodeURIComponent( slug ) }`
+	);
+
+	if ( ! response.ok ) {
+		throw new Error( `Failed to fetch list: ${ response.status }` );
+	}
+
+	return response.json();
+}
+
+export function usePublicListQuery( owner: string, slug: string ) {
+	return useQuery( {
+		queryKey: [ 'reader', 'public-list', owner, slug ],
+		queryFn: () => fetchPublicList( owner, slug ),
+		enabled: Boolean( owner ) && Boolean( slug ),
+		staleTime: 5 * 60 * 1000, // 5 minutes
+	} );
+}

--- a/client/reader/list-stream/use-public-list-query.ts
+++ b/client/reader/list-stream/use-public-list-query.ts
@@ -5,6 +5,7 @@ export interface PublicListItem {
 	feed_id: number;
 	site_name: string;
 	site_url: string;
+	site_icon: string | null;
 	fediverse_handle: string | null;
 	fediverse_handle_url: string | null;
 }

--- a/client/reader/list/controller.js
+++ b/client/reader/list/controller.js
@@ -25,6 +25,24 @@ export const createList = ( context, next ) => {
 	next();
 };
 
+export const listsLanding = ( context, next ) => {
+	const basePath = '/reader/lists';
+	const fullAnalyticsPageTitle = `${ analyticsPageTitle } > Lists`;
+	const mcKey = 'lists';
+	const state = context.store.getState();
+
+	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
+	recordTrack( 'calypso_reader_lists_landing_loaded' );
+
+	if ( ! isUserLoggedIn( state ) ) {
+		context.renderHeaderSection = renderHeaderSection;
+		recordTrack( 'calypso_reader_lists_landing_viewed_logged_out' );
+	}
+
+	context.primary = <AsyncLoad require="calypso/reader/lists-landing" key="lists-landing" />;
+	next();
+};
+
 export const listListing = ( context, next ) => {
 	const basePath = '/reader/list/:owner/:slug';
 	const fullAnalyticsPageTitle =

--- a/client/reader/list/controller.js
+++ b/client/reader/list/controller.js
@@ -46,6 +46,10 @@ export const listListing = ( context, next ) => {
 
 	if ( ! isUserLoggedIn( state ) ) {
 		context.renderHeaderSection = renderHeaderSection;
+		recordTrack( 'calypso_reader_list_viewed_logged_out', {
+			list_owner: context.params.user,
+			list_slug: context.params.list,
+		} );
 	}
 
 	context.primary = (

--- a/client/reader/list/controller.js
+++ b/client/reader/list/controller.js
@@ -5,7 +5,9 @@ import {
 	trackScrollPage,
 } from 'calypso/reader/controller-helper';
 import { recordTrack } from 'calypso/reader/stats';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import renderHeaderSection from '../lib/header-section';
 
 const analyticsPageTitle = 'Reader';
 
@@ -41,6 +43,10 @@ export const listListing = ( context, next ) => {
 		},
 		{ pathnameOverride: getCurrentRoute( state ) }
 	);
+
+	if ( ! isUserLoggedIn( state ) ) {
+		context.renderHeaderSection = renderHeaderSection;
+	}
 
 	context.primary = (
 		<AsyncLoad

--- a/client/reader/list/index.js
+++ b/client/reader/list/index.js
@@ -9,6 +9,7 @@ import {
 	editListItems,
 	exportList,
 	listListing,
+	listsLanding,
 } from './controller';
 
 export default function () {
@@ -27,6 +28,19 @@ export default function () {
 		sidebar,
 		setBeforePrimary,
 		editList,
+		makeLayout,
+		clientRender
+	);
+
+	// Lists landing page (must be before /reader/list/:user/:list)
+	page( '/reader/lists', sidebar, setBeforePrimary, listsLanding, makeLayout, clientRender );
+
+	// Locale-prefixed route for logged-out users
+	page(
+		`/${ defined }/reader/lists`,
+		sidebar,
+		setBeforePrimary,
+		listsLanding,
 		makeLayout,
 		clientRender
 	);

--- a/client/reader/list/index.js
+++ b/client/reader/list/index.js
@@ -1,4 +1,5 @@
 import page from '@automattic/calypso-router';
+import { getAnyLanguageRouteParam } from '@automattic/i18n-utils';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { sidebar, setBeforePrimary } from 'calypso/reader/controller';
 import {
@@ -11,6 +12,8 @@ import {
 } from './controller';
 
 export default function () {
+	const defined = getAnyLanguageRouteParam();
+
 	page(
 		'/reader/list/:user/:list/edit/items',
 		sidebar,
@@ -44,6 +47,16 @@ export default function () {
 		sidebar,
 		setBeforePrimary,
 		deleteList,
+		makeLayout,
+		clientRender
+	);
+
+	// Locale-prefixed route for logged-out users
+	page(
+		`/${ defined }/reader/list/:user/:list`,
+		sidebar,
+		setBeforePrimary,
+		listListing,
 		makeLayout,
 		clientRender
 	);

--- a/client/reader/lists-landing/index.tsx
+++ b/client/reader/lists-landing/index.tsx
@@ -1,5 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
+import { CreateListInvitation } from 'calypso/reader/components/create-list-invitation';
 import { ListCard } from 'calypso/reader/components/list-card';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import { usePublicListQuery } from 'calypso/reader/list-stream/use-public-list-query';
@@ -61,10 +62,15 @@ function ListsLandingSkeleton() {
 
 function ListsLanding() {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const { data, isLoading } = usePopularListsQuery();
 
 	const lists = data?.lists?.slice( 0, MAX_DISPLAYED_LISTS ) ?? [];
 	const isEmpty = ! isLoading && lists.length === 0;
+
+	function handleCreateListClick() {
+		dispatch( recordReaderTracksEvent( 'calypso_reader_lists_landing_create_clicked' ) );
+	}
 
 	return (
 		<ReaderMain>
@@ -94,6 +100,8 @@ function ListsLanding() {
 				{ lists.map( ( list ) => (
 					<ListCardWithDetails key={ list.ID } list={ list } />
 				) ) }
+
+				{ ! isLoading && <CreateListInvitation onCreateClick={ handleCreateListClick } /> }
 			</div>
 		</ReaderMain>
 	);

--- a/client/reader/lists-landing/index.tsx
+++ b/client/reader/lists-landing/index.tsx
@@ -1,0 +1,102 @@
+import { useTranslate } from 'i18n-calypso';
+import DocumentHead from 'calypso/components/data/document-head';
+import { ListCard } from 'calypso/reader/components/list-card';
+import ReaderMain from 'calypso/reader/components/reader-main';
+import { usePublicListQuery } from 'calypso/reader/list-stream/use-public-list-query';
+import { useDispatch } from 'calypso/state';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import { usePopularListsQuery } from './use-popular-lists-query';
+import type { PopularListSummary } from './use-popular-lists-query';
+
+import './style.scss';
+
+const MAX_DISPLAYED_LISTS = 5;
+
+function ListCardWithDetails( { list }: { list: PopularListSummary } ) {
+	const dispatch = useDispatch();
+	const { data: listDetail, isLoading } = usePublicListQuery( list.owner, list.slug );
+
+	function handleOpenList() {
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_lists_landing_list_clicked', {
+				list_owner: list.owner,
+				list_slug: list.slug,
+			} )
+		);
+	}
+
+	return (
+		<ListCard
+			title={ list.title }
+			description={ list.description }
+			owner={ list.owner }
+			itemCount={ list.item_count }
+			tags={ list.tags }
+			items={
+				listDetail?.items?.map( ( item ) => ( {
+					site_name: item.site_name,
+					site_icon: item.site_icon ?? null,
+				} ) ) ?? []
+			}
+			listUrl={ `/reader/list/${ list.owner }/${ list.slug }` }
+			isLoadingItems={ isLoading }
+			onOpenList={ handleOpenList }
+		/>
+	);
+}
+
+function ListsLandingSkeleton() {
+	return (
+		<div className="lists-landing__skeleton">
+			{ Array.from( { length: 3 } ).map( ( _, i ) => (
+				<div key={ i } className="lists-landing__skeleton-card">
+					<div className="lists-landing__skeleton-title" />
+					<div className="lists-landing__skeleton-description" />
+					<div className="lists-landing__skeleton-tags" />
+				</div>
+			) ) }
+		</div>
+	);
+}
+
+function ListsLanding() {
+	const translate = useTranslate();
+	const { data, isLoading } = usePopularListsQuery();
+
+	const lists = data?.lists?.slice( 0, MAX_DISPLAYED_LISTS ) ?? [];
+	const isEmpty = ! isLoading && lists.length === 0;
+
+	return (
+		<ReaderMain>
+			<DocumentHead
+				title={ translate( '%s \u2039 Reader', {
+					args: translate( 'Discover Lists' ),
+					comment: '%s is the section name. For example: "My Likes"',
+				} ) }
+			/>
+
+			<div className="lists-landing">
+				<header className="lists-landing__header">
+					<h1 className="lists-landing__title">{ translate( 'Discover Lists' ) }</h1>
+					<p className="lists-landing__subtitle">
+						{ translate(
+							'Explore curated groups of interesting creators in the WordPress.com community.'
+						) }
+					</p>
+				</header>
+
+				{ isLoading && <ListsLandingSkeleton /> }
+
+				{ isEmpty && (
+					<p className="lists-landing__empty">{ translate( 'No lists to show right now.' ) }</p>
+				) }
+
+				{ lists.map( ( list ) => (
+					<ListCardWithDetails key={ list.ID } list={ list } />
+				) ) }
+			</div>
+		</ReaderMain>
+	);
+}
+
+export default ListsLanding;

--- a/client/reader/lists-landing/style.scss
+++ b/client/reader/lists-landing/style.scss
@@ -1,0 +1,73 @@
+.lists-landing {
+	max-width: 780px;
+	padding-block-start: 8px;
+}
+
+.lists-landing__header {
+	margin-block-end: 28px;
+}
+
+.lists-landing__title {
+	font-size: 1.75rem;
+	font-weight: 700;
+	color: var( --color-text );
+	margin: 0 0 8px;
+}
+
+.lists-landing__subtitle {
+	font-size: 0.875rem;
+	color: var( --color-text-subtle );
+	margin: 0;
+	line-height: 1.5;
+}
+
+.lists-landing__empty {
+	text-align: center;
+	color: var( --color-text-subtle );
+	padding: 48px 0;
+	font-size: 0.875rem;
+}
+
+.lists-landing__skeleton-card {
+	border: 1px solid var( --color-border-subtle );
+	border-radius: 8px;
+	padding: 20px;
+	margin-block-end: 16px;
+	background: var( --color-surface );
+}
+
+.lists-landing__skeleton-title {
+	width: 40%;
+	height: 20px;
+	background: var( --color-neutral-5 );
+	border-radius: 4px;
+	margin-block-end: 12px;
+	animation: lists-landing-pulse 1.5s ease-in-out infinite;
+}
+
+.lists-landing__skeleton-description {
+	width: 80%;
+	height: 14px;
+	background: var( --color-neutral-5 );
+	border-radius: 4px;
+	margin-block-end: 12px;
+	animation: lists-landing-pulse 1.5s ease-in-out infinite;
+}
+
+.lists-landing__skeleton-tags {
+	width: 50%;
+	height: 14px;
+	background: var( --color-neutral-5 );
+	border-radius: 4px;
+	animation: lists-landing-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes lists-landing-pulse {
+	0%,
+	100% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.5;
+	}
+}

--- a/client/reader/lists-landing/test/index.test.tsx
+++ b/client/reader/lists-landing/test/index.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { screen, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import ListsLanding from '../index';
+
+jest.mock(
+	'../../components/reader-main',
+	() =>
+		function ReaderMain( { children }: { children: React.ReactNode } ) {
+			return <div>{ children }</div>;
+		}
+);
+
+jest.mock( 'calypso/components/data/document-head', () => () => null );
+
+jest.mock( 'calypso/state/reader/analytics/actions', () => ( {
+	recordReaderTracksEvent: jest.fn( () => ( { type: 'READER_TRACKS_EVENT' } ) ),
+} ) );
+
+const popularResponse = {
+	lists: [
+		{
+			ID: 1,
+			title: 'Quirky Histories',
+			slug: 'quirky-histories',
+			description: 'A cabinet of curiosities',
+			owner: 'benhuberman',
+			subscriber_count: 28,
+			item_count: 30,
+			tags: [ 'Arts & Entertainment' ],
+		},
+		{
+			ID: 2,
+			title: 'Fediverse Food Blogs',
+			slug: 'fediverse-food-blogs',
+			description: 'Food bloggers on the Fediverse',
+			owner: 'jeherve',
+			subscriber_count: 15,
+			item_count: 10,
+			tags: [ 'Food & Drink' ],
+		},
+	],
+};
+
+const listDetailResponse = {
+	ID: 1,
+	title: 'Quirky Histories',
+	slug: 'quirky-histories',
+	description: 'A cabinet of curiosities',
+	owner: 'benhuberman',
+	item_count: 30,
+	tags: [ 'Arts & Entertainment' ],
+	items: [
+		{
+			blog_id: 456,
+			feed_id: 1234,
+			site_name: 'History Blog',
+			site_url: 'https://historyblog.com',
+			site_icon: 'https://historyblog.com/icon.png',
+			fediverse_handle: null,
+			fediverse_handle_url: null,
+		},
+	],
+};
+
+function mockFetchResponse( data: unknown ) {
+	return Promise.resolve( {
+		ok: true,
+		status: 200,
+		json: () => Promise.resolve( data ),
+	} );
+}
+
+function renderWithQueryClient( ui: React.ReactElement ) {
+	const queryClient = new QueryClient( {
+		defaultOptions: { queries: { retry: false } },
+	} );
+	return renderWithProvider(
+		<QueryClientProvider client={ queryClient }>{ ui }</QueryClientProvider>
+	);
+}
+
+describe( 'ListsLanding', () => {
+	afterEach( () => {
+		nock.cleanAll();
+		jest.clearAllMocks();
+	} );
+
+	test( 'renders heading and subtitle', async () => {
+		( global.fetch as jest.Mock ).mockImplementation( ( url: string ) => {
+			if ( url.includes( '/popular' ) ) {
+				return mockFetchResponse( popularResponse );
+			}
+			return mockFetchResponse( listDetailResponse );
+		} );
+
+		renderWithQueryClient( <ListsLanding /> );
+
+		await waitFor( () => {
+			expect( screen.getByRole( 'heading', { name: /discover lists/i } ) ).toBeVisible();
+		} );
+	} );
+
+	test( 'renders list cards when data loads', async () => {
+		( global.fetch as jest.Mock ).mockImplementation( ( url: string ) => {
+			if ( url.includes( '/popular' ) ) {
+				return mockFetchResponse( popularResponse );
+			}
+			return mockFetchResponse( listDetailResponse );
+		} );
+
+		renderWithQueryClient( <ListsLanding /> );
+
+		await waitFor( () => {
+			expect( screen.getByText( 'Quirky Histories' ) ).toBeVisible();
+			expect( screen.getByText( 'Fediverse Food Blogs' ) ).toBeVisible();
+		} );
+	} );
+
+	test( 'shows skeleton state while loading', () => {
+		( global.fetch as jest.Mock ).mockImplementation(
+			() =>
+				new Promise( () => {
+					// Never resolves — simulates a slow fetch
+				} )
+		);
+
+		const { container } = renderWithQueryClient( <ListsLanding /> );
+
+		expect( container.querySelector( '.lists-landing__skeleton-card' ) ).toBeInTheDocument();
+	} );
+
+	test( 'shows empty state when no lists returned', async () => {
+		( global.fetch as jest.Mock ).mockImplementation( () => mockFetchResponse( { lists: [] } ) );
+
+		renderWithQueryClient( <ListsLanding /> );
+
+		await waitFor( () => {
+			expect( screen.getByText( /no lists to show/i ) ).toBeVisible();
+		} );
+	} );
+} );

--- a/client/reader/lists-landing/use-popular-lists-query.ts
+++ b/client/reader/lists-landing/use-popular-lists-query.ts
@@ -1,0 +1,36 @@
+import { useQuery } from '@tanstack/react-query';
+
+export interface PopularListSummary {
+	ID: number;
+	title: string;
+	slug: string;
+	description: string;
+	owner: string;
+	subscriber_count: number;
+	item_count: number;
+	tags: string[];
+}
+
+interface PopularListsResponse {
+	lists: PopularListSummary[];
+}
+
+async function fetchPopularLists(): Promise< PopularListsResponse > {
+	const response = await globalThis.fetch(
+		'https://public-api.wordpress.com/wpcom/v2/read/lists/popular'
+	);
+
+	if ( ! response.ok ) {
+		throw new Error( `Failed to fetch popular lists: ${ response.status }` );
+	}
+
+	return response.json();
+}
+
+export function usePopularListsQuery() {
+	return useQuery( {
+		queryKey: [ 'reader', 'popular-lists' ],
+		queryFn: fetchPopularLists,
+		staleTime: 5 * 60 * 1000, // 5 minutes
+	} );
+}

--- a/client/reader/sidebar/reader-sidebar-lists/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/index.jsx
@@ -20,10 +20,8 @@ export class ReaderSidebarLists extends Component {
 	};
 
 	selectMenu = () => {
-		const { onClick, lists, isOpen, path } = this.props;
-		const defaultSelection = lists?.length
-			? `/reader/list/${ lists[ 0 ]?.owner }/${ lists[ 0 ]?.slug }`
-			: '/reader/list/new';
+		const { onClick, isOpen, path } = this.props;
+		const defaultSelection = '/reader/lists';
 		if ( ! isOpen ) {
 			onClick();
 		}

--- a/client/sections.js
+++ b/client/sections.js
@@ -493,6 +493,7 @@ const sections = [
 		paths: [ '/reader/list' ],
 		module: 'calypso/reader/list',
 		group: 'reader',
+		enableLoggedOut: true,
 	},
 	{
 		name: 'reader',

--- a/client/sections.js
+++ b/client/sections.js
@@ -490,7 +490,7 @@ const sections = [
 	},
 	{
 		name: 'reader',
-		paths: [ '/reader/list' ],
+		paths: [ '/reader/list', '/reader/lists' ],
 		module: 'calypso/reader/list',
 		group: 'reader',
 		enableLoggedOut: true,


### PR DESCRIPTION
## Proposed Changes

This PR enhances the Reader list page (`/reader/list/:owner/:slug`) to make lists a better discovery and sharing tool. Four additions:

- **Public/logged-out access** — list pages are now accessible without authentication, following the same pattern used by Discover, tags, and search (logged-out header, 10-post soft gate, login prompt for follow actions).
- **Tags display** — auto-inferred topic tags shown as pill badges below the list header. Styled like the `UserTopSites` component on user profiles.
- **Sites directory tab** — a new "Sites" tab alongside the default "Posts" tab, showing all sites in the list via `ReaderSiteItem` cards. Fediverse handles are displayed when available.
- **"Follow All Sites" button** — lets visitors subscribe to every site in the list at once, using the existing `follow()` action in a client-side loop.

## Why are these changes being made?

Right now, Reader lists are mostly a personal organizational tool; there's no good way to share a curated list with someone and let them easily follow the sites in it. I'm hoping this can turn lists into a lightweight discovery surface — you find someone's list, browse the sites, and follow the ones you like (or all of them at once).

This also lays the groundwork for a public list page that can eventually support ActivityPub content negotiation.

Of note, this PR depends on a new public API endpoint (`GET /wpcom/v2/read/lists/{owner}/{slug}`) that's being built in parallel. The existing post stream and list subscription features continue to work independently; the new features (tags, sites tab, follow-all) will populate once the endpoint is live.

## Testing Instructions

1. Check out this branch and run `yarn start`
2. Navigate to a Reader list page (e.g., `/reader/list/jeherve/fediverse-food-blogs`)
3. Verify the Posts/Sites tabs appear below the header
4. Click the "Sites" tab — you should see site cards (once the API endpoint is available)
5. Verify tags appear as pill badges below the list description (once the API endpoint is available)
6. Open an incognito window and visit the same list URL — it should load without redirecting, showing the "WordPress Reader" header and no sidebar
7. As a logged-out user, click "Follow all sites" — it should prompt a login dialog

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?