### PR TITLE
Feature flagged new reader save left nav link and stubbed out page

### DIFF
--- a/client/reader/components/icons/saved-icon.jsx
+++ b/client/reader/components/icons/saved-icon.jsx
@@ -1,0 +1,17 @@
+export default function ReaderSavedIcon( { viewBox = '0 0 24 24' } ) {
+	return (
+		<svg
+			className="sidebar__menu-icon sidebar_svg-saved"
+			height="24"
+			viewBox={ viewBox }
+			width="24"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<path
+				fillRule="evenodd"
+				clipRule="evenodd"
+				d="M6.5 4h11a1.5 1.5 0 011.5 1.5v14.25a.75.75 0 01-1.19.61L12 15.9l-5.81 4.46A.75.75 0 015 19.75V5.5A1.5 1.5 0 016.5 4zm0 1.5v12.58l5.06-3.88a.75.75 0 01.88 0l5.06 3.88V5.5h-11z"
+			></path>
+		</svg>
+	);
+}

--- a/client/reader/saved-stream/controller.js
+++ b/client/reader/saved-stream/controller.js
@@ -1,0 +1,24 @@
+import AsyncLoad from 'calypso/components/async-load';
+import { sectionify } from 'calypso/lib/route';
+import { trackPageLoad } from 'calypso/reader/controller-helper';
+
+const analyticsPageTitle = 'Reader';
+
+const exported = {
+	saved( context, next ) {
+		const basePath = sectionify( context.path );
+		const fullAnalyticsPageTitle = analyticsPageTitle + ' > Saved';
+		const mcKey = 'saved';
+
+		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
+
+		context.primary = (
+			<AsyncLoad require="calypso/reader/saved-stream/main" key="saved" placeholder={ null } />
+		);
+		next();
+	},
+};
+
+export default exported;
+
+export const { saved } = exported;

--- a/client/reader/saved-stream/empty.tsx
+++ b/client/reader/saved-stream/empty.tsx
@@ -1,0 +1,18 @@
+import { useTranslate } from 'i18n-calypso';
+import EmptyContent from 'calypso/components/empty-content';
+
+export default function SavedStreamEmpty() {
+	const translate = useTranslate();
+
+	return (
+		<EmptyContent
+			title={ translate( 'No saved posts yet' ) }
+			line={ translate( 'Save posts to read them later.' ) }
+			action={
+				<a className="empty-content__action button is-primary" href="/reader">
+					{ translate( 'Back to Reader' ) }
+				</a>
+			}
+		/>
+	);
+}

--- a/client/reader/saved-stream/index.js
+++ b/client/reader/saved-stream/index.js
@@ -1,0 +1,11 @@
+import { isEnabled } from '@automattic/calypso-config';
+import page from '@automattic/calypso-router';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { sidebar, setBeforePrimary } from 'calypso/reader/controller';
+import { saved } from './controller';
+
+export default function () {
+	if ( isEnabled( 'reader/saved-posts' ) ) {
+		page( '/read/saved', sidebar, setBeforePrimary, saved, makeLayout, clientRender );
+	}
+}

--- a/client/reader/saved-stream/main.tsx
+++ b/client/reader/saved-stream/main.tsx
@@ -1,0 +1,36 @@
+import { useTranslate } from 'i18n-calypso';
+import DocumentHead from 'calypso/components/data/document-head';
+import NavigationHeader from 'calypso/components/navigation-header';
+import ReaderMain from 'calypso/reader/components/reader-main';
+import { useSelector } from 'calypso/state';
+import { getSavedPostsCount } from 'calypso/state/reader/saved/selectors';
+import EmptyContent from './empty';
+
+import './style.scss';
+
+export default function SavedPostsStream() {
+	const translate = useTranslate();
+	const count = useSelector( getSavedPostsCount );
+
+	const title = translate( 'Saved' );
+	const documentTitle = translate( '%s ‹ Reader', {
+		args: title,
+		comment: '%s is the section name. For example: "Saved"',
+	} );
+
+	const subtitle = translate( 'Your reading list for later.' );
+
+	return (
+		<ReaderMain className="saved-stream">
+			<DocumentHead title={ documentTitle } />
+			<NavigationHeader title={ title } subtitle={ subtitle } />
+			{ count === 0 ? (
+				<EmptyContent />
+			) : (
+				<div className="saved-stream__list">
+					{ /* Phase 4: SavedPostsList with drag-and-drop will go here */ }
+				</div>
+			) }
+		</ReaderMain>
+	);
+}

--- a/client/reader/saved-stream/style.scss
+++ b/client/reader/saved-stream/style.scss
@@ -1,0 +1,5 @@
+.saved-stream {
+	.saved-stream__list {
+		margin-block-start: 16px;
+	}
+}

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -1,5 +1,6 @@
 import 'calypso/my-sites/sidebar/style.scss'; // Copy styles from the My Sites sidebar.
 import './style.scss';
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Icon, plus } from '@wordpress/icons';
 import clsx from 'clsx';
@@ -22,6 +23,7 @@ import ReaderConversationsIcon from 'calypso/reader/components/icons/conversatio
 import ReaderDiscoverIcon from 'calypso/reader/components/icons/discover-icon';
 import ReaderLikesIcon from 'calypso/reader/components/icons/likes-icon';
 import ReaderManageSubscriptionsIcon from 'calypso/reader/components/icons/manage-subscriptions-icon';
+import ReaderSavedIcon from 'calypso/reader/components/icons/saved-icon';
 import ReaderSearchIcon from 'calypso/reader/components/icons/search-icon';
 import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
 import { getTagStreamUrl } from 'calypso/reader/route';
@@ -80,6 +82,11 @@ const TrackingKeys = {
 		action: 'clicked_reader_sidebar_manage_subscriptions',
 		gaEvent: 'Clicked Reader Sidebar Manage Subscriptions',
 		tracksEvent: 'calypso_reader_sidebar_manage_subscriptions_clicked',
+	},
+	saved: {
+		action: 'clicked_reader_sidebar_saved',
+		gaEvent: 'Clicked Reader Sidebar Saved',
+		tracksEvent: 'calypso_reader_sidebar_saved_clicked',
 	},
 };
 
@@ -197,6 +204,18 @@ export class ReaderSidebar extends Component {
 							'sidebar-activity__likes': true,
 						} ) }
 					/>
+
+					{ isEnabled( 'reader/saved-posts' ) && (
+						<SidebarItem
+							label={ translate( 'Saved' ) }
+							onNavigate={ this.handleSidebarMenuClick( TrackingKeys.saved ) }
+							customIcon={ <ReaderSavedIcon viewBox="0 0 24 24" /> }
+							link="/read/saved"
+							className={ ReaderSidebarHelper.itemLinkClass( '/read/saved', path, {
+								'sidebar-streams__saved': true,
+							} ) }
+						/>
+					) }
 
 					<SidebarItem
 						className={ ReaderSidebarHelper.itemLinkClass( '/reader/conversations', path, {

--- a/client/sections.js
+++ b/client/sections.js
@@ -478,6 +478,13 @@ const sections = [
 	},
 	{
 		name: 'reader',
+		paths: [ '/read/saved' ],
+		module: 'calypso/reader/saved-stream',
+		group: 'reader',
+		trackLoadPerformance: true,
+	},
+	{
+		name: 'reader',
 		paths: [
 			'/reader/search',
 			'/([a-z]{2,3}|[a-z]{2}-[a-z]{2})/reader/search',


### PR DESCRIPTION
## Summary 
- Adds "Saved" nav item to the Reader sidebar (below Likes, before Conversations) with a bookmark icon
- Registers the /read/saved route with a placeholder stream page showing an empty state
- All UI is gated behind the reader/saved-posts feature flag — no visible changes inproduction 
- Part of the Reader "Saved" (read-it-later) feature (https://github.com/Automattic/wp-calypso/blob/trunk/saved-posts-planmd)

## Test plan

- Enable the reader/saved-posts flag (enabled by default indevelopment)
- Navigate to /reader — confirm "Saved" appears in the sidebar below Likes with a bookmark icon
- Click "Saved" — confirm it navigates to /read/saved and shows the empty state ("No saved posts yet")
- Confirm the sidebar item highlights as selected on /read/saved
- Disable the flag (?flags=-reader/saved-posts) — confirm the sidebar item and route are both hidden
- Confirm no regressions in other Reader sidebar items (Likes, Discover, Conversations, etc.) 