### PR TITLE
Subscribers: fix layout gap and add SidebarNavigation on JP Cloud

### DIFF
--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -1062,7 +1062,7 @@ $font-size: rem(14px);
 		}
 
 		.focus-content:not(.has-no-sidebar):not(.has-no-masterbar) .layout__content {
-			padding-top: 62px;
+			padding-top: var(--masterbar-height, 62px); // keep old value as fallback
 			padding-bottom: 0;
 		}
 

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -1049,7 +1049,7 @@ $font-size: rem(14px);
 		}
 
 		.focus-content:not(.has-no-sidebar):not(.has-no-masterbar) .layout__content {
-			padding-top: 62px;
+			padding-top: var(--masterbar-height, 62px); // keep old value as fallback
 			padding-bottom: 0;
 		}
 

--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -23,8 +23,7 @@ body.is-section-subscribers:not( .is-global ),
 	.has-no-masterbar {
 		.layout__content {
 			background: var( --studio-gray-0 );
-			padding: calc( var( --masterbar-height ) + #{$padding-standard} ) $padding-standard
-				$padding-standard calc( var( --sidebar-width-max ) + #{$padding-standard} );
+			padding: var( --masterbar-height ) 0 0 var( --sidebar-width-max );
 
 			// Full width rules when sidebar is collapsed
 			&:where( body.is-section-subscribers * ) {
@@ -58,8 +57,8 @@ body.is-section-subscribers:not( .is-global ),
 			flex-direction: row;
 			flex: 1 1 auto;
 			position: relative;
-			gap: 24px;
-			height: calc( 100vh - var( --masterbar-height ) - #{$padding-standard * 2} );
+			gap: $padding-standard;
+			height: calc( 100vh - var( --masterbar-height ) );
 
 			@media ( max-width: $break-small ) {
 				padding: 0;

--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -20,8 +20,7 @@ body.is-section-subscribers,
 	.has-no-masterbar {
 		.layout__content {
 			background: var( --studio-gray-0 );
-			padding: calc( var( --masterbar-height ) + #{$padding-standard} ) $padding-standard
-				$padding-standard calc( var( --sidebar-width-max ) + #{$padding-standard} );
+			padding: var( --masterbar-height ) 0 0 var( --sidebar-width-max );
 
 			// Full width rules when sidebar is collapsed
 			&:where( body.is-section-subscribers * ) {
@@ -55,8 +54,8 @@ body.is-section-subscribers,
 			flex-direction: row;
 			flex: 1 1 auto;
 			position: relative;
-			gap: 24px;
-			height: calc( 100vh - var( --masterbar-height ) - #{$padding-standard * 2} );
+			gap: $padding-standard;
+			height: calc( 100vh - var( --masterbar-height ) );
 
 			@media ( max-width: $break-small ) {
 				padding: 0;

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -7,8 +7,10 @@ import DocumentHead from 'calypso/components/data/document-head';
 import QueryMemberships from 'calypso/components/data/query-memberships';
 import QueryMembershipsSettings from 'calypso/components/data/query-memberships-settings';
 import Main from 'calypso/components/main';
+import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import SubscriberValidationGate from 'calypso/components/subscribers-validation-gate';
 import { useCompleteLaunchpadTaskWithNoticeOnLoad } from 'calypso/launchpad/hooks/use-complete-launchpad-task-with-notice-on-load';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import CompSubscriptionModal from 'calypso/my-sites/subscribers/components/comp-modal/comp-modal';
 import RemoveCompModal from 'calypso/my-sites/subscribers/components/remove-comp-modal/remove-comp-modal';
 import { SubscriberDataViews } from 'calypso/my-sites/subscribers/components/subscriber-data-views';
@@ -84,7 +86,8 @@ const SubscribersPage = ( { subscriberId }: Props ) => {
 		<>
 			<QueryMemberships siteId={ siteId ?? 0 } />
 			<QueryMembershipsSettings siteId={ siteId ?? 0 } source="calypso" />
-			<Main wideLayout className="subscribers">
+			<Main fullWidthLayout className="subscribers">
+				{ isJetpackCloud() && <SidebarNavigation /> }
 				<DocumentHead title={ translate( 'Subscribers' ) } />
 				<SubscriberValidationGate siteId={ siteId }>
 					<SubscriberDataViews


### PR DESCRIPTION
Part of JETPACK-1513

## Proposed Changes

* Remove extra padding on `.layout__content` that created a visible gap around the Subscribers DataViews table. Simplify padding to match the masterbar/sidebar boundaries directly.
* Switch `<Main>` from `wideLayout` to `fullWidthLayout` so the page fills the content area.
* Add `<SidebarNavigation />` on JP Cloud so mobile users have the hamburger menu to navigate away (was missing — same navigation trap as Earn/Social).
* Replace hardcoded `62px` padding-top in the sidebar focus-content rule with `var(--masterbar-height, 62px)` for consistency.

## Why are these changes being made?

The Subscribers page on Calypso had a visible gap between the content area and the sidebar/masterbar boundaries, caused by extra padding in `.layout__content`. This was inconsistent with other Jetpack admin pages that sit flush against the layout edges.

On JP Cloud mobile, the Subscribers page was missing `<SidebarNavigation />` — the same navigation trap we fixed on Earn and Social in #109899. Without the hamburger menu, users had no way to navigate away from the page on mobile.

## Testing Instructions

**Calypso (WP.com):**
- [ ] Navigate to `/subscribers/<site-slug>`
- [ ] Verify content sits flush against sidebar and masterbar (no extra gap/padding)
- [ ] Verify the DataViews table fills the available viewport height
- [ ] On mobile viewport: verify the page works correctly without sidebar

**JP Cloud:**
- [ ] Navigate to `/subscribers/<site-slug>` on cloud.jetpack.com
- [ ] Desktop: verify same flush layout
- [ ] Mobile: verify hamburger menu is present (was missing before)

## Before / after

### Calypso Desktop — gap removed
| Before | After |
|--------|-------|
| <img width="1280" height="900" alt="before-calypso-desktop-subscribers" src="https://github.com/user-attachments/assets/4992f41a-2b4c-4bc0-bb44-ace3c87d0c95" /> | <img width="1280" height="900" alt="after-calypso-desktop-subscribers" src="https://github.com/user-attachments/assets/f7027a3a-5cad-44bf-9c0d-e3e8bc94dd50" /> |
| <img width="1260" height="769" alt="calypso-desktop-before" src="https://github.com/user-attachments/assets/e933aabc-58ff-4d79-871d-10dbf071cd32" /> | <img width="1260" height="769" alt="calypso-desktop-after" src="https://github.com/user-attachments/assets/f41d54b3-f1b1-4e6f-9ae6-2ab2a58964be" /> |


Content now sits flush against sidebar and masterbar. No extra padding gap.

### Calypso Mobile
| Before | After |
|--------|-------|
| <img width="393" height="852" alt="before-calypso-mobile-subscribers" src="https://github.com/user-attachments/assets/b14d0b4e-455c-4ee9-9088-116a6e1d67ff" /> | <img width="393" height="852" alt="after-calypso-mobile-subscribers" src="https://github.com/user-attachments/assets/6e70e780-ddb6-4a3d-b902-20edcde56214" /> |
| <img width="333" height="726" alt="calypso-mobile-before" src="https://github.com/user-attachments/assets/274cd2cd-8af4-493f-9997-e0b60de17133" /> | <img width="333" height="726" alt="calypso-mobile-after" src="https://github.com/user-attachments/assets/003e5203-5740-428b-aed0-fba8b34a7eeb" /> |



### JP Cloud Desktop
| Before | After |
|--------|-------|
| <img width="1280" height="900" alt="before-jpc-desktop-subscribers" src="https://github.com/user-attachments/assets/9ba1acaf-f455-40bf-9bb6-b02a03320542" /> | <img width="1280" height="900" alt="after-jpc-desktop-subscribers" src="https://github.com/user-attachments/assets/732fdcd9-737b-4ff3-931b-661a45bcacd2" /> |
| <img width="1260" height="769" alt="jpc-desktop-before" src="https://github.com/user-attachments/assets/dd343ab3-92d5-4dbd-90cd-4091217abce6" /> | <img width="1260" height="769" alt="jpc-desktop-after" src="https://github.com/user-attachments/assets/cbbb40bd-2014-4e28-8a2a-a121bb6bfa1f" /> |



### JP Cloud Mobile — navigation trap fixed
| Before | After |
|--------|-------|
| <img width="393" height="852" alt="before-jpc-mobile-subscribers" src="https://github.com/user-attachments/assets/f94fea87-c955-4565-8f72-4168cd214f30" /> | <img width="393" height="852" alt="after-jpc-mobile-subscribers" src="https://github.com/user-attachments/assets/e14b09c6-cf65-46a6-90df-344485463a6d" /> |
| <img width="333" height="726" alt="jpc-mobile-before" src="https://github.com/user-attachments/assets/c3683816-2ba8-474a-8ef9-996108ae78e8" /> | <img width="333" height="726" alt="jpc-mobile-after" src="https://github.com/user-attachments/assets/3851f658-701d-4c7a-8f77-cc27bb92eb42" /> |



Before: no hamburger menu, no way to navigate out. After: hamburger + site title present.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?