### PR TITLE
Update plugins FAQ answers for plan availability

### DIFF
--- a/client/my-sites/plugins/plugins-faq/index.tsx
+++ b/client/my-sites/plugins/plugins-faq/index.tsx
@@ -69,7 +69,7 @@ export function PluginsFAQ() {
 				},
 			} ),
 			answer: translate(
-				'Yes. If you’re on a paid plan, you can install plugins from the directory or upload your own. Free plans include built-in features, but don’t support installing plugins.'
+				'Yes. Plugin installation is now included on all WordPress.com paid plans, starting with Personal. You have access to over 50,000 plugins from the WordPress.org repository. This capability was expanded to all paid plans to give our customers full flexibility from day one.'
 			),
 		},
 		{
@@ -160,7 +160,7 @@ export function PluginsFAQ() {
 				},
 			} ),
 			answer: translate(
-				'Plugin installation is available on all paid plans. Free plans come with a curated set of built-in features instead of external plugins.'
+				'Plugin installation is now available on all WordPress.com paid plans, starting with Personal. Free plans come with a curated set of built-in features instead of external plugins.'
 			),
 		},
 		{

--- a/client/my-sites/plugins/plugins-faq/index.tsx
+++ b/client/my-sites/plugins/plugins-faq/index.tsx
@@ -1,3 +1,4 @@
+import { getPlan, PLAN_PERSONAL } from '@automattic/calypso-products';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
@@ -28,6 +29,8 @@ export function PluginsFAQ() {
 		},
 		[ dispatch ]
 	);
+
+	const personalPlanName = getPlan( PLAN_PERSONAL )?.getTitle() ?? '';
 
 	const faqItems: FAQItem[] = [
 		{
@@ -69,7 +72,8 @@ export function PluginsFAQ() {
 				},
 			} ),
 			answer: translate(
-				'Yes. Plugin installation is now included on all WordPress.com paid plans, starting with Personal. You have access to over 50,000 plugins from the WordPress.org repository. This capability was expanded to all paid plans to give our customers full flexibility from day one.'
+				'Yes. Plugin installation is now included on all WordPress.com paid plans, starting with %(planName)s. You have access to over 50,000 plugins from the WordPress.org repository. This capability was expanded to all paid plans to give our customers full flexibility from day one.',
+				{ args: { planName: personalPlanName } }
 			),
 		},
 		{
@@ -160,7 +164,8 @@ export function PluginsFAQ() {
 				},
 			} ),
 			answer: translate(
-				'Plugin installation is now available on all WordPress.com paid plans, starting with Personal. Free plans come with a curated set of built-in features instead of external plugins.'
+				'Plugin installation is now available on all WordPress.com paid plans, starting with %(planName)s. Free plans come with a curated set of built-in features instead of external plugins.',
+				{ args: { planName: personalPlanName } }
 			),
 		},
 		{


### PR DESCRIPTION
Part of DOTMAR-923

## Proposed Changes

* Update the FAQ answer for "Can I install plugins on WordPress.com?" to clarify that plugin installation is included on all paid plans starting with Personal, with access to 50,000+ plugins.
* Update the FAQ answer for "Do plugins work with all WordPress.com plans?" to reflect that plugin installation is now available on all paid plans starting with Personal.

## Why are these changes being made?

* The previous answers were outdated regarding which plans support plugin installation. These updates align the FAQ copy with the current state: plugins are available on all WordPress.com paid plans, starting with Personal.

## Testing Instructions

* Visit `/plugins` logged out (or as a logged-in user with dashboard opt-in and no site selected) so the marketplace redesign is active.
* Scroll to the FAQ section at the bottom.
* Expand "Can I install plugins on WordPress.com?" and verify the updated answer.

<img width="1512" height="471" alt="image" src="https://github.com/user-attachments/assets/380ae7b4-78b5-43f7-acd4-ebcb19930181" />


* Expand "Do plugins work with all WordPress.com plans?" and verify the updated answer.

<img width="1512" height="619" alt="image" src="https://github.com/user-attachments/assets/86b04e75-7b71-45fd-a561-cd41c372df70" />


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?