### PR TITLE
Checkout: Simplify and fix cost overrides before/after prices

### DIFF
--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -423,10 +423,30 @@ function getLineItemPriceDisplay(
 		// simulated amount as the crossed-out number if it is greater.
 		const tosData = getTosDataForProduct( product, responseCart );
 		if ( tosData ) {
-			const isDiscounted = tosData.regular_renewal_price_integer < simulatedPriceBeforeDiscounts;
+			const renewalPrice = tosData.regular_renewal_price_integer;
+			const isDiscounted = renewalPrice < simulatedPriceBeforeDiscounts;
+
+			// Some intro offers temporarily increase the price (e.g. $80 → $250),
+			// even if other overrides (coupons) then reduce it. Detect this by
+			// checking the intro override's own before/after subtotals.
+			const introOverride = product.cost_overrides.find( ( override ) =>
+				isOverrideCodeIntroductoryOffer( override.override_code )
+			);
+			const introOfferIncreasedPrice =
+				introOverride && introOverride.new_subtotal_integer > introOverride.old_subtotal_integer;
+
+			let crossedOutAmountDisplay: string | undefined;
+			if ( isDiscounted ) {
+				crossedOutAmountDisplay = fmt( simulatedPriceBeforeDiscounts );
+			} else if ( introOfferIncreasedPrice ) {
+				// Cross out the elevated intro price so the user sees the lower
+				// renewal price as the ongoing cost.
+				crossedOutAmountDisplay = fmt( introOverride.new_subtotal_integer );
+			}
+
 			return {
-				actualAmountDisplay: fmt( tosData.regular_renewal_price_integer ),
-				crossedOutAmountDisplay: isDiscounted ? fmt( simulatedPriceBeforeDiscounts ) : undefined,
+				actualAmountDisplay: fmt( renewalPrice ),
+				crossedOutAmountDisplay,
 			};
 		}
 	}

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -97,6 +97,18 @@ const DeleteButton = styled( Button )< { theme?: Theme } >`
 	color: ${ ( props ) => props.theme.colors.textColorLight };
 `;
 
+function getTosDataForProduct( product: ResponseCartProduct, responseCart: ResponseCart ) {
+	return responseCart.terms_of_service?.find( ( tos ) => {
+		if ( ! new RegExp( `product_id:${ product.product_id }` ).test( tos.key ) ) {
+			return false;
+		}
+		if ( product.meta && ! new RegExp( `meta:${ product.meta }` ).test( tos.key ) ) {
+			return false;
+		}
+		return true;
+	} )?.args;
+}
+
 /**
  * Introductory offers sometimes have complex pricing plans that are not easy
  * to display as a simple discount. This component displays more details about
@@ -117,7 +129,21 @@ function LineItemIntroOfferCostOverrideDetail( {
 	}
 
 	if ( ! isOverrideCodeIntroductoryOffer( costOverride.overrideCode ) ) {
-		return false;
+		return null;
+	}
+
+	// We only want to display this info for introductory offers which have
+	// pricing that is difficult to display as a simple discount. Currently
+	// that is offers with different term lengths or price increases.
+	if (
+		! doesIntroductoryOfferHaveDifferentTermLengthThanProduct(
+			product.cost_overrides,
+			product.introductory_offer_terms,
+			product.months_per_bill_period
+		) &&
+		! doesIntroductoryOfferHavePriceIncrease( product )
+	) {
+		return null;
 	}
 
 	// Introductory offer manual renewals often have prorated prices that are
@@ -127,15 +153,7 @@ function LineItemIntroOfferCostOverrideDetail( {
 		return null;
 	}
 
-	const tosData = responseCart.terms_of_service?.find( ( tos ) => {
-		if ( ! new RegExp( `product_id:${ product.product_id }` ).test( tos.key ) ) {
-			return false;
-		}
-		if ( product.meta && ! new RegExp( `meta:${ product.meta }` ).test( tos.key ) ) {
-			return false;
-		}
-		return true;
-	} )?.args;
+	const tosData = getTosDataForProduct( product, responseCart );
 	const dueDate =
 		tosData && 'subscription_auto_renew_date' in tosData
 			? tosData.subscription_auto_renew_date
@@ -236,13 +254,24 @@ function LineItemCostOverride( {
 		);
 	}
 
+	// We only show the discount amount for introductory offers.
+	const shouldShowDiscount = product.cost_overrides.some( ( override ) =>
+		isOverrideCodeIntroductoryOffer( override.override_code )
+	);
+
 	return (
 		<div className="cost-overrides-list-item" key={ costOverride.humanReadableReason }>
 			<span className="cost-overrides-list-item__reason cost-overrides-list-item__reason--is-discount">
 				{ costOverride.humanReadableReason }
 			</span>
-			{ /* Empty grid placeholder to push LineItemIntroOfferCostOverrideDetail to its own row. */ }
-			<span className="cost-overrides-list-item__discount" />
+			<span className="cost-overrides-list-item__discount">
+				{ costOverride.discountAmount &&
+					shouldShowDiscount &&
+					formatCurrency( -costOverride.discountAmount, product.currency, {
+						isSmallestUnit: true,
+						signForPositive: true, // TODO clk numberFormatCurrency signForPositive only usage
+					} ) }
+			</span>
 			<LineItemIntroOfferCostOverrideDetail product={ product } costOverride={ costOverride } />
 		</div>
 	);
@@ -374,6 +403,7 @@ const WPCheckoutCheckIcon = styled( CheckIcon )`
  */
 function getLineItemPriceDisplay(
 	product: ResponseCartProduct,
+	responseCart: ResponseCart,
 	monthlyPrices: Record< string, number >
 ): { actualAmountDisplay: string; crossedOutAmountDisplay: string | undefined } {
 	const fmt = ( amount: number ) =>
@@ -385,8 +415,24 @@ function getLineItemPriceDisplay(
 	// times the cost of the monthly version of the same plan, if one exists).
 	const simulatedPriceBeforeDiscounts = getSimulatedCostBeforeDiscounts( product, monthlyPrices );
 
+	const isIntroOffer = product.cost_overrides.some( ( override ) =>
+		isOverrideCodeIntroductoryOffer( override.override_code )
+	);
+	if ( isIntroOffer ) {
+		// For an introductory offer, show the recurring amount as the amount the user will pay and include the
+		// simulated amount as the crossed-out number if it is greater.
+		const tosData = getTosDataForProduct( product, responseCart );
+		if ( tosData ) {
+			const isDiscounted = tosData.regular_renewal_price_integer < simulatedPriceBeforeDiscounts;
+			return {
+				actualAmountDisplay: fmt( tosData.regular_renewal_price_integer ),
+				crossedOutAmountDisplay: isDiscounted ? fmt( simulatedPriceBeforeDiscounts ) : undefined,
+			};
+		}
+	}
+
 	// Show the actual amount as the amount the user will pay and include the
-	// amount before cost overrides if it is greater.
+	// amount before cost overrides as the crossed-out number if it is greater.
 	const isDiscounted = product.item_subtotal_integer < simulatedPriceBeforeDiscounts;
 	return {
 		actualAmountDisplay: fmt( product.item_subtotal_integer ),
@@ -394,7 +440,13 @@ function getLineItemPriceDisplay(
 	};
 }
 
-function SingleProductAndCostOverridesList( { product }: { product: ResponseCartProduct } ) {
+function SingleProductAndCostOverridesList( {
+	product,
+	responseCart,
+}: {
+	product: ResponseCartProduct;
+	responseCart: ResponseCart;
+} ) {
 	const translate = useTranslate();
 	const costOverridesList = filterCostOverridesForLineItem( product, translate );
 	const label = getLabel( product );
@@ -403,6 +455,7 @@ function SingleProductAndCostOverridesList( { product }: { product: ResponseCart
 
 	const { actualAmountDisplay, crossedOutAmountDisplay } = getLineItemPriceDisplay(
 		product,
+		responseCart,
 		monthlyPrices
 	);
 
@@ -484,7 +537,11 @@ export function ProductsAndCostOverridesList( { responseCart }: { responseCart: 
 	return (
 		<ProductsAndCostOverridesListWrapper>
 			{ responseCart.products.map( ( product ) => (
-				<SingleProductAndCostOverridesList product={ product } key={ product.uuid } />
+				<SingleProductAndCostOverridesList
+					product={ product }
+					responseCart={ responseCart }
+					key={ product.uuid }
+				/>
 			) ) }
 			<CouponCostOverride responseCart={ responseCart } />
 		</ProductsAndCostOverridesListWrapper>

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -3,7 +3,6 @@ import {
 	isDIFMProduct,
 	isMonthlyProduct,
 	isTriennially,
-	isWpComPlan,
 	isYearly,
 } from '@automattic/calypso-products';
 import colorStudio from '@automattic/color-studio';
@@ -237,21 +236,13 @@ function LineItemCostOverride( {
 		);
 	}
 
-	const shouldShowDiscount = isWpComPlan( product.product_slug );
-
 	return (
 		<div className="cost-overrides-list-item" key={ costOverride.humanReadableReason }>
 			<span className="cost-overrides-list-item__reason cost-overrides-list-item__reason--is-discount">
 				{ costOverride.humanReadableReason }
 			</span>
-			<span className="cost-overrides-list-item__discount">
-				{ costOverride.discountAmount &&
-					shouldShowDiscount &&
-					formatCurrency( -costOverride.discountAmount, product.currency, {
-						isSmallestUnit: true,
-						signForPositive: true, // TODO clk numberFormatCurrency signForPositive only usage
-					} ) }
-			</span>
+			{ /* Empty grid placeholder to push LineItemIntroOfferCostOverrideDetail to its own row. */ }
+			<span className="cost-overrides-list-item__discount" />
 			<LineItemIntroOfferCostOverrideDetail product={ product } costOverride={ costOverride } />
 		</div>
 	);

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -241,9 +241,11 @@ export function IntroOfferBillingInterval( { product }: { product: ResponseCartP
 function LineItemCostOverride( {
 	costOverride,
 	product,
+	shouldShowDiscount,
 }: {
 	costOverride: LineItemCostOverrideForDisplay;
 	product: ResponseCartProduct;
+	shouldShowDiscount: boolean;
 } ) {
 	const isPriceIncrease = doesIntroductoryOfferHavePriceIncrease( product );
 	if ( isPriceIncrease ) {
@@ -253,11 +255,6 @@ function LineItemCostOverride( {
 			</div>
 		);
 	}
-
-	// We only show the discount amount for introductory offers.
-	const shouldShowDiscount = product.cost_overrides.some( ( override ) =>
-		isOverrideCodeIntroductoryOffer( override.override_code )
-	);
 
 	return (
 		<div className="cost-overrides-list-item" key={ costOverride.humanReadableReason }>
@@ -280,9 +277,11 @@ function LineItemCostOverride( {
 export function LineItemCostOverrides( {
 	costOverridesList,
 	product,
+	shouldShowDiscount,
 }: {
 	costOverridesList: LineItemCostOverrideForDisplay[];
 	product: ResponseCartProduct;
+	shouldShowDiscount: boolean;
 } ) {
 	return (
 		<CostOverridesListStyle>
@@ -290,6 +289,7 @@ export function LineItemCostOverrides( {
 				<LineItemCostOverride
 					product={ product }
 					costOverride={ costOverride }
+					shouldShowDiscount={ shouldShowDiscount }
 					key={ costOverride.humanReadableReason }
 				/>
 			) ) }
@@ -451,6 +451,17 @@ function getLineItemPriceDisplay(
 		}
 	}
 
+	// When the simulated price comes from the monthly equivalent, show the
+	// product's own original cost as the actual amount and the monthly-based
+	// simulated price as the crossed-out number (if greater).
+	if ( simulatedPriceBeforeDiscounts !== product.item_original_subtotal_integer ) {
+		const isDiscounted = product.item_original_subtotal_integer < simulatedPriceBeforeDiscounts;
+		return {
+			actualAmountDisplay: fmt( product.item_original_subtotal_integer ),
+			crossedOutAmountDisplay: isDiscounted ? fmt( simulatedPriceBeforeDiscounts ) : undefined,
+		};
+	}
+
 	// Show the actual amount as the amount the user will pay and include the
 	// amount before cost overrides as the crossed-out number if it is greater.
 	const isDiscounted = product.item_subtotal_integer < simulatedPriceBeforeDiscounts;
@@ -479,6 +490,15 @@ function SingleProductAndCostOverridesList( {
 		monthlyPrices
 	);
 
+	// Show the discount amount when the crossed-out price is simulated from the
+	// monthly equivalent, or when there's an introductory offer.
+	const shouldShowDiscount =
+		getSimulatedCostBeforeDiscounts( product, monthlyPrices ) !==
+			product.item_original_subtotal_integer ||
+		product.cost_overrides.some( ( override ) =>
+			isOverrideCodeIntroductoryOffer( override.override_code )
+		);
+
 	return (
 		<SimplifiedSingleProductAndCostOverridesListWrapper className="cost-overrides-list-product-wrapper">
 			<WPCheckoutCheckIcon />
@@ -489,7 +509,11 @@ function SingleProductAndCostOverridesList( {
 					crossedOutAmount={ crossedOutAmountDisplay }
 				/>
 			</ProductTitleAreaForCostOverridesList>
-			<LineItemCostOverrides product={ product } costOverridesList={ costOverridesList } />
+			<LineItemCostOverrides
+				product={ product }
+				costOverridesList={ costOverridesList }
+				shouldShowDiscount={ shouldShowDiscount }
+			/>
 		</SimplifiedSingleProductAndCostOverridesListWrapper>
 	);
 }

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -404,6 +404,21 @@ function getIntroOfferCrossedOutPrice(
 }
 
 /**
+ * Return the item subtotal with the coupon discount added back. Since coupon
+ * discounts are displayed as a dedicated line item (via CouponCostOverride),
+ * we strip them from the per-product price to avoid showing the discount twice.
+ */
+function getItemSubtotalExcludingCoupon( product: ResponseCartProduct ): number {
+	const couponOverride = product.cost_overrides.find(
+		( override ) => override.override_code === 'coupon-discount'
+	);
+	const couponDiscountAmount = couponOverride
+		? couponOverride.old_subtotal_integer - couponOverride.new_subtotal_integer
+		: 0;
+	return product.item_subtotal_integer + couponDiscountAmount;
+}
+
+/**
  * Return two formatted prices. `actualAmountDisplay` should be the final
  * subtotal after all cost overrides are applied. `crossedOutAmountDisplay`
  * should be the price before cost overrides, but only if it's higher (some
@@ -468,11 +483,13 @@ function getLineItemPriceDisplay(
 		};
 	}
 
-	// Show the actual amount as the amount the user will pay and include the
-	// amount before cost overrides as the crossed-out number if it is greater.
-	const isDiscounted = product.item_subtotal_integer < simulatedPriceBeforeDiscounts;
+	// Show the actual amount as the amount the user will pay (before coupon) and
+	// include the amount before cost overrides as the crossed-out number if it is
+	// greater.
+	const itemSubtotalWithoutCoupon = getItemSubtotalExcludingCoupon( product );
+	const isDiscounted = itemSubtotalWithoutCoupon < simulatedPriceBeforeDiscounts;
 	return {
-		actualAmountDisplay: fmt( product.item_subtotal_integer ),
+		actualAmountDisplay: fmt( itemSubtotalWithoutCoupon ),
 		crossedOutAmountDisplay: isDiscounted ? fmt( simulatedPriceBeforeDiscounts ) : undefined,
 	};
 }

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -20,14 +20,13 @@ import {
 	doesIntroductoryOfferHavePriceIncrease,
 	filterCostOverridesForLineItem,
 	getLabel,
-	getSubtotalWithoutDiscountsForProduct,
 	isOverrideCodeIntroductoryOffer,
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import useEquivalentMonthlyTotals, {
-	getOriginalAmountIntegerForDisplay,
+	getSimulatedCostBeforeDiscounts,
 } from 'calypso/my-sites/checkout/utils/use-equivalent-monthly-totals';
 import { useSelector } from 'calypso/state';
 import {
@@ -382,36 +381,39 @@ const WPCheckoutCheckIcon = styled( CheckIcon )`
 	}
 `;
 
+/**
+ * Return two formatted prices. `actualAmountDisplay` should be the final
+ * subtotal after all cost overrides are applied. `crossedOutAmountDisplay`
+ * should be the price before cost overrides, but only if it's higher (some
+ * cost overrides can _increase_ the price).
+ *
+ * `crossedOutAmountDisplay` (the amount before discounts) may also be
+ * _increased_ by an amount as if the original cost of the product was 12 times
+ * the product's monthly cost. This simulates a discount granted by purchasing
+ * an annual version of the product, but it's not a "real" discount in the
+ * sense that no price changes were applied to the annual product in that case;
+ * it's just the result of comparing the prices of the annual to the monthly
+ * product.
+ */
 function getLineItemPriceDisplay(
 	product: ResponseCartProduct,
 	monthlyPrices: Record< string, number >
 ): { actualAmountDisplay: string; crossedOutAmountDisplay: string | undefined } {
 	const fmt = ( amount: number ) =>
 		formatCurrency( amount, product.currency, { isSmallestUnit: true, stripZeros: true } );
-	const originalAmountInteger = getOriginalAmountIntegerForDisplay( product, monthlyPrices );
-	const itemSubtotalInteger =
-		product.item_subtotal_integer + ( product.coupon_savings_integer ?? 0 );
-	const isDiscounted = itemSubtotalInteger < originalAmountInteger;
 
-	// For products with a price-increasing intro offer followed by a sale
-	// coupon (e.g. premium domains: $80 → $1,100 → $275), show the peak
-	// price crossed out with the final price.
-	const priceBeforeDiscountsInteger = getSubtotalWithoutDiscountsForProduct( product );
-	if (
-		priceBeforeDiscountsInteger > originalAmountInteger &&
-		product.item_subtotal_integer < priceBeforeDiscountsInteger
-	) {
-		return {
-			actualAmountDisplay: fmt( product.item_subtotal_integer ),
-			crossedOutAmountDisplay: fmt( priceBeforeDiscountsInteger ),
-		};
-	}
+	// This is the simulated cost before cost overrides. It's similar to
+	// cost before cost overrides but it may include an increase based on the
+	// monthly cost of a related product in the same tier (eg: it will be 12
+	// times the cost of the monthly version of the same plan, if one exists).
+	const simulatedPriceBeforeDiscounts = getSimulatedCostBeforeDiscounts( product, monthlyPrices );
 
-	// Default: show the pre-coupon subtotal, with the original crossed out
-	// when the product is discounted.
+	// Show the actual amount as the amount the user will pay and include the
+	// amount before cost overrides if it is greater.
+	const isDiscounted = product.item_subtotal_integer < simulatedPriceBeforeDiscounts;
 	return {
-		actualAmountDisplay: fmt( itemSubtotalInteger ),
-		crossedOutAmountDisplay: isDiscounted ? fmt( originalAmountInteger ) : undefined,
+		actualAmountDisplay: fmt( product.item_subtotal_integer ),
+		crossedOutAmountDisplay: isDiscounted ? fmt( simulatedPriceBeforeDiscounts ) : undefined,
 	};
 }
 

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -121,20 +121,6 @@ function LineItemIntroOfferCostOverrideDetail( {
 		return false;
 	}
 
-	// We only want to display this info for introductory offers which have
-	// pricing that is difficult to display as a simple discount. Currently
-	// that is offers with different term lengths or price increases.
-	if (
-		! doesIntroductoryOfferHaveDifferentTermLengthThanProduct(
-			product.cost_overrides,
-			product.introductory_offer_terms,
-			product.months_per_bill_period
-		) &&
-		! doesIntroductoryOfferHavePriceIncrease( product )
-	) {
-		return null;
-	}
-
 	// Introductory offer manual renewals often have prorated prices that are
 	// difficult to display as a simple discount so we keep their display
 	// simple.

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -97,6 +97,16 @@ const DeleteButton = styled( Button )< { theme?: Theme } >`
 	color: ${ ( props ) => props.theme.colors.textColorLight };
 `;
 
+function doesIntroOfferUseDetailDisplay( product: ResponseCartProduct ): boolean {
+	return (
+		doesIntroductoryOfferHaveDifferentTermLengthThanProduct(
+			product.cost_overrides,
+			product.introductory_offer_terms,
+			product.months_per_bill_period
+		) || doesIntroductoryOfferHavePriceIncrease( product )
+	);
+}
+
 function getTosDataForProduct( product: ResponseCartProduct, responseCart: ResponseCart ) {
 	return responseCart.terms_of_service?.find( ( tos ) => {
 		if ( ! new RegExp( `product_id:${ product.product_id }` ).test( tos.key ) ) {
@@ -135,14 +145,7 @@ function LineItemIntroOfferCostOverrideDetail( {
 	// We only want to display this info for introductory offers which have
 	// pricing that is difficult to display as a simple discount. Currently
 	// that is offers with different term lengths or price increases.
-	if (
-		! doesIntroductoryOfferHaveDifferentTermLengthThanProduct(
-			product.cost_overrides,
-			product.introductory_offer_terms,
-			product.months_per_bill_period
-		) &&
-		! doesIntroductoryOfferHavePriceIncrease( product )
-	) {
+	if ( ! doesIntroOfferUseDetailDisplay( product ) ) {
 		return null;
 	}
 
@@ -388,28 +391,16 @@ const WPCheckoutCheckIcon = styled( CheckIcon )`
 `;
 
 /**
- * For intro offers, determine the crossed-out price to display. Returns the
- * simulated pre-discount price if it's higher than the renewal price, or the
- * intro offer's own elevated price if the intro offer increased the price
- * (e.g. $80 → $250 before a coupon reduces it further).
+ * For intro offers whose pricing is simple enough not to need a detail
+ * breakdown, determine the crossed-out price to display. Returns the simulated
+ * pre-discount price if it's higher than the renewal price, otherwise
+ * undefined.
  */
 function getIntroOfferCrossedOutPrice(
-	product: ResponseCartProduct,
 	renewalPrice: number,
 	simulatedPriceBeforeDiscounts: number
 ): number | undefined {
-	if ( renewalPrice < simulatedPriceBeforeDiscounts ) {
-		return simulatedPriceBeforeDiscounts;
-	}
-
-	const introOverride = product.cost_overrides.find( ( override ) =>
-		isOverrideCodeIntroductoryOffer( override.override_code )
-	);
-	if ( introOverride && introOverride.new_subtotal_integer > introOverride.old_subtotal_integer ) {
-		return introOverride.new_subtotal_integer;
-	}
-
-	return undefined;
+	return renewalPrice < simulatedPriceBeforeDiscounts ? simulatedPriceBeforeDiscounts : undefined;
 }
 
 /**
@@ -446,14 +437,16 @@ function getLineItemPriceDisplay(
 	const isIntroOffer = product.cost_overrides.some( ( override ) =>
 		isOverrideCodeIntroductoryOffer( override.override_code )
 	);
-	if ( isIntroOffer ) {
+	// When LineItemIntroOfferCostOverrideDetail renders (different term length or
+	// price increase), it already displays the full pricing breakdown, so we fall
+	// through to the regular logic below.
+	if ( isIntroOffer && ! doesIntroOfferUseDetailDisplay( product ) ) {
 		// For an introductory offer, show the recurring amount as the amount the user will pay and include the
 		// simulated amount as the crossed-out number if it is greater.
 		const tosData = getTosDataForProduct( product, responseCart );
 		if ( tosData ) {
 			const renewalPrice = tosData.regular_renewal_price_integer;
 			const crossedOutPrice = getIntroOfferCrossedOutPrice(
-				product,
 				renewalPrice,
 				simulatedPriceBeforeDiscounts
 			);

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -388,10 +388,38 @@ const WPCheckoutCheckIcon = styled( CheckIcon )`
 `;
 
 /**
+ * For intro offers, determine the crossed-out price to display. Returns the
+ * simulated pre-discount price if it's higher than the renewal price, or the
+ * intro offer's own elevated price if the intro offer increased the price
+ * (e.g. $80 → $250 before a coupon reduces it further).
+ */
+function getIntroOfferCrossedOutPrice(
+	product: ResponseCartProduct,
+	renewalPrice: number,
+	simulatedPriceBeforeDiscounts: number
+): number | undefined {
+	if ( renewalPrice < simulatedPriceBeforeDiscounts ) {
+		return simulatedPriceBeforeDiscounts;
+	}
+
+	const introOverride = product.cost_overrides.find( ( override ) =>
+		isOverrideCodeIntroductoryOffer( override.override_code )
+	);
+	if ( introOverride && introOverride.new_subtotal_integer > introOverride.old_subtotal_integer ) {
+		return introOverride.new_subtotal_integer;
+	}
+
+	return undefined;
+}
+
+/**
  * Return two formatted prices. `actualAmountDisplay` should be the final
  * subtotal after all cost overrides are applied. `crossedOutAmountDisplay`
  * should be the price before cost overrides, but only if it's higher (some
  * cost overrides can _increase_ the price).
+ *
+ * There are also several cases where actualAmountDisplay will be the renewal
+ * price instead (see inline comments).
  *
  * `crossedOutAmountDisplay` (the amount before discounts) may also be
  * _increased_ by an amount as if the original cost of the product was 12 times
@@ -424,29 +452,14 @@ function getLineItemPriceDisplay(
 		const tosData = getTosDataForProduct( product, responseCart );
 		if ( tosData ) {
 			const renewalPrice = tosData.regular_renewal_price_integer;
-			const isDiscounted = renewalPrice < simulatedPriceBeforeDiscounts;
-
-			// Some intro offers temporarily increase the price (e.g. $80 → $250),
-			// even if other overrides (coupons) then reduce it. Detect this by
-			// checking the intro override's own before/after subtotals.
-			const introOverride = product.cost_overrides.find( ( override ) =>
-				isOverrideCodeIntroductoryOffer( override.override_code )
+			const crossedOutPrice = getIntroOfferCrossedOutPrice(
+				product,
+				renewalPrice,
+				simulatedPriceBeforeDiscounts
 			);
-			const introOfferIncreasedPrice =
-				introOverride && introOverride.new_subtotal_integer > introOverride.old_subtotal_integer;
-
-			let crossedOutAmountDisplay: string | undefined;
-			if ( isDiscounted ) {
-				crossedOutAmountDisplay = fmt( simulatedPriceBeforeDiscounts );
-			} else if ( introOfferIncreasedPrice ) {
-				// Cross out the elevated intro price so the user sees the lower
-				// renewal price as the ongoing cost.
-				crossedOutAmountDisplay = fmt( introOverride.new_subtotal_integer );
-			}
-
 			return {
 				actualAmountDisplay: fmt( renewalPrice ),
-				crossedOutAmountDisplay,
+				crossedOutAmountDisplay: crossedOutPrice ? fmt( crossedOutPrice ) : undefined,
 			};
 		}
 	}

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -42,7 +42,7 @@ import { hasFreeCouponTransfersOnly } from 'calypso/lib/cart-values/cart-items';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import useEquivalentMonthlyTotals, {
-	getOriginalAmountIntegerForDisplay,
+	getSimulatedCostBeforeDiscounts,
 } from 'calypso/my-sites/checkout/utils/use-equivalent-monthly-totals';
 import { useSelector } from 'calypso/state';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
@@ -170,7 +170,7 @@ function CheckoutSummaryPriceList() {
 	const [ , isCheckoutUiRedesignV1 ] = useCheckoutUiRedesignExperiment();
 
 	const subtotalBeforeDiscounts = responseCart.products.reduce( ( subtotal, product ) => {
-		const originalAmountInteger = getOriginalAmountIntegerForDisplay( product, monthlyPrices );
+		const originalAmountInteger = getSimulatedCostBeforeDiscounts( product, monthlyPrices );
 		// In specific cases (e.g. premium domains) the original price (renewal) is lower than the due price.
 		return subtotal + Math.max( product.item_subtotal_integer, originalAmountInteger );
 	}, 0 );

--- a/client/my-sites/checkout/utils/use-equivalent-monthly-totals.ts
+++ b/client/my-sites/checkout/utils/use-equivalent-monthly-totals.ts
@@ -60,14 +60,24 @@ export default function useEquivalentMonthlyTotals(
 }
 
 /**
- * Returns the original amount integer for a product, used for displaying a crossed-out price.
- * For renewals, this is always the product's own original subtotal (not the monthly equivalent),
- * since the monthly comparison is only meaningful for new purchases.
+ * Returns the amount for a product before discounts used for displaying a
+ * crossed-out price in checkout.
  *
+ * It's similar to the product's cost before cost overrides are applied, but it
+ * may include an increase based on the monthly cost of a related product in
+ * the same tier (eg: it will be 12 times the cost of the monthly version of
+ * the same plan, if one exists). This is to simulate a discount originating
+ * from the comparison to a monthly version of the same product.
+ *
+ * For renewals, this is always the product's own original subtotal (not the
+ * monthly equivalent), since the monthly comparison is only meaningful for new
+ * purchases.
+ *
+ * The returned value is in the smallest unit for the currency.
  * @param product - The cart product.
  * @param monthlyPrices - Map of plan slug to equivalent monthly total, from `useEquivalentMonthlyTotals`.
  */
-export function getOriginalAmountIntegerForDisplay(
+export function getSimulatedCostBeforeDiscounts(
 	product: ResponseCartProduct,
 	monthlyPrices: Record< PlanSlug, number >
 ): number {

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -256,13 +256,14 @@ function getDiscountForCostOverrideForDisplay( costOverride: ResponseCartCostOve
 }
 
 function getBillPeriodMonthsForIntroductoryOfferInterval(
-	interval: IntroductoryOfferUnit
+	interval: IntroductoryOfferUnit,
+	intervalCount: number = 1
 ): number {
 	switch ( interval ) {
 		case 'month':
-			return 1;
+			return intervalCount;
 		case 'year':
-			return 12;
+			return 12 * intervalCount;
 		default:
 			return 0;
 	}
@@ -289,8 +290,10 @@ export function doesIntroductoryOfferHaveDifferentTermLengthThanProduct(
 		return false;
 	}
 	if (
-		getBillPeriodMonthsForIntroductoryOfferInterval( introductoryOfferTerms.interval_unit ) ===
-		monthsPerBillPeriodForProduct
+		getBillPeriodMonthsForIntroductoryOfferInterval(
+			introductoryOfferTerms.interval_unit,
+			introductoryOfferTerms.interval_count
+		) === monthsPerBillPeriodForProduct
 	) {
 		return false;
 	}
@@ -313,7 +316,8 @@ function doesIntroductoryOfferCostOverrideHavePriceIncrease(
 	const monthsForProductBeforeOverride = product.months_per_bill_period ?? 1;
 	const priceBeforeOverrideMonthly = priceBeforeOverride / monthsForProductBeforeOverride;
 	const monthsForProductAfterOverride = getBillPeriodMonthsForIntroductoryOfferInterval(
-		product.introductory_offer_terms.interval_unit
+		product.introductory_offer_terms.interval_unit,
+		product.introductory_offer_terms.interval_count
 	);
 	const priceAfterOverrideMonthly = priceAfterOverride / monthsForProductAfterOverride;
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/CHE-471/regression-checkout-showing-highly-misleading-prices-for-plans-with
Fixes https://linear.app/a8c/issue/CHE-455/checkout-inconsistent-display-for-first-term-discounts-for

## Proposed Changes

This PR modifies the `ProductsAndCostOverridesList` component from checkout which renders the sidebar price summary to simplify its logic and fix some bugs that had crept in.

Before             |  After
:-------------------------:|:-------------------------:
<img width="412" height="583" alt="before-intro-offer" src="https://github.com/user-attachments/assets/f0ede3ef-dff7-4b00-b570-227bda3124eb" /> | <img width="407" height="570" alt="Screenshot 2026-04-14 at 1 27 45 PM" src="https://github.com/user-attachments/assets/9d2afae3-2e36-42b7-bdb6-b843b88a1ca0" />
<img width="409" height="484" alt="Screenshot 2026-04-14 at 1 05 15 PM" src="https://github.com/user-attachments/assets/2bd5e9cf-abf7-4d7d-99f6-7d343c060ce9" /> | <img width="412" height="491" alt="Screenshot 2026-04-14 at 1 26 57 PM" src="https://github.com/user-attachments/assets/8956de37-4831-4de5-8452-cbc7afb9bd0b" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This unfortunately requires a bit of a story 🎶 ☁️ 🎶 

----

A few years ago as part of a redesign of checkout we added a feature to the sidebar called `ProductsAndCostOverridesList` which lists every item in the cart and its original price, followed by a list of cost overrides (price adjustments) that were applied to that price to reach its final total. The idea was that it would read something like a receipt so you can see exactly how every price was calculated (indeed, after that change we modified our receipts to show this same view). So for a WPCom plan affected by a 10% coupon where the subtotal would be $97.20, that might read something like:

**WordPress.com Premium** $108.00
Coupon SPECIAL_DISCOUNT -10.80

Certain introductory offer discounts are not so easy to explain in a single line so we also added a "detailed" explanation for those. For Titan Mail's "first 3 months free" annual plan, that was rendered without the discount price but with additional details about the offer:

**Professional Email** $35.00
First 3 months free
Due today: $0
Billed July 12, 2026: $26.27
Billed every year $35.00

More recently, another checkout redesign implemented what was called "Streamlined pricing", backed by a successful AB test of checkout performance. This reformatted `ProductsAndCostOverridesList` to do the following: remove the price changes for all cost overrides, change the price displayed next to each item to show the final subtotal instead of the original price, and show the original price (if different) as crossed-out text just before it. For the WPCom plan mentioned above, the result was something like this:

**WordPress.com Premium** ~~$108~~ $97.20
Coupon SPECIAL_DISCOUNT

In addition, logic was added to display the original price _higher_ than it actually was so it appeared that there was a discount being applied based on comparing the annual plan to the monthly plan. No real cost override exists for this; it's just a conceptual discount based on the savings you'd get for buying one product instead of another one. Since the Monthly Premium plan costs $18 per month, it would therefore cost $216 a year, resulting in something like this:

**WordPress.com Premium** ~~$216~~ $97.20
Coupon SPECIAL_DISCOUNT

When this was implemented, there were a few oddities introduced. First, the price changes were _not_ removed for introductory offers for WPCom plans and the subtotal price was rendered _without_ the introductory offer, which was probably not noticed since we had no plans with introductory offers at that time. However, once they were added, we got displays like this:

**WordPress.com Premium** ~~$216~~ $108
Additional discount for first year -$12.00

Second, the logic for calculating these numbers was not properly set up to handle introductory offers which meant that if an introductory offer _increased_ the price, it would show the post-offer price instead of the offer price. For a premium domain which cost $80 with an intro offer of $275, this looked something like:

**apojfawpfjwajgagpjoa.art** $80
Due today: $275
Billed every year $80

To fix that, additional logic was added to undo the special logic of the Streamline pricing and add special original price calculations just for these sorts of introductory offers, so that the domains would correctly look like this:

**apojfawpfjwajgagpjoa.art** ~~$80~~ $275
Due today: $275
Billed every year $80

Which, ironically, is exactly how it would have looked if there wasn't special price calculation happening for the Streamline pricing.

However, when that fix was applied in https://github.com/Automattic/wp-calypso/pull/109472 I noticed the special case price calculation for WPCom plans which didn't make much sense to me, so I had the developer remove it. However, the special case logic for introductory offer cost overrides was still present. The result was that introductory offers for WPCom plans had their final price correctly displayed next to the crossed-out price with all discounts applied but the intro offer override _also_ showed the price, making for a very confusing display (the total is $96 and already includes the -$12):

**WordPress.com Premium** ~~$216~~ $96
Additional discount for first year -$12.00

All this special case logic is unnecessary and can be removed. We can just display the original cost and the final cost of each item, followed by a list of each cost override _without_ its price with two exceptions: introductory offers and products where the crossed-out price is simulated should display the simulated original cost (crossed-out) followed by the _renewal cost_ and in those cases the discounts should be displayed next to their description.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit checkout using various products and make sure the prices in the sidebar make sense. Some key examples are noted below.

Remember that each item should have potentially **two prices shown**: the full price the user will pay today (or the renewal price for intro offers), possibly preceded by a **crossed-out price that represents how much they might have paid** if circumstances were different (mostly if discounts were not applied, but also if they were paying monthly).

- Wpcom annual Premium plan with an introductory offer (must be a new user account to see this).
- Wpcom plan with an upgrade from one plan to another.
- Titan mail introductory offer for an annual plan (3 months free).
- Domain with a domain credit.
- Premium domain with an introductory offer that increases the price and a sale coupon (eg: the `.art` domain which you can only add to the cart on production tables; also make sure it's not using a domain credit; you may need to jump through some hoops on this one as that offer is no longer active – ping me and I can explain how to do it).
- Any of the above with a discount coupon code.
