### PR TITLE
Add description to WooHosted Free Plan card

### DIFF
--- a/client/dashboard/sites/overview-plan-card/index.tsx
+++ b/client/dashboard/sites/overview-plan-card/index.tsx
@@ -1,4 +1,4 @@
-import { DotcomPlans, JetpackPlans } from '@automattic/api-core';
+import { DotcomPlans, JetpackPlans, WooHostedPlans } from '@automattic/api-core';
 import { siteCurrentPlanQuery, siteByIdQuery, purchaseQuery } from '@automattic/api-queries';
 import { JetpackLogo } from '@automattic/components/src/logos/jetpack-logo';
 import { useQuery } from '@tanstack/react-query';
@@ -210,14 +210,15 @@ export default function PlanCard( { site }: { site: Site } ) {
 }
 
 function getCardDescription( site: Site, purchase?: Purchase ) {
-	if ( site.plan?.product_slug === DotcomPlans.FREE_PLAN ) {
-		return __( 'Upgrade to access all hosting features.' );
-	}
-
-	if ( site.plan?.product_slug === JetpackPlans.PLAN_JETPACK_FREE ) {
-		return getJetpackProductsForSite( site ).length > 0
-			? __( 'Manage subscriptions.' )
-			: __( 'Upgrade to access more Jetpack tools.' );
+	switch ( site.plan?.product_slug ) {
+		case DotcomPlans.FREE_PLAN:
+			return __( 'Upgrade to access all hosting features.' );
+		case JetpackPlans.PLAN_JETPACK_FREE:
+			return getJetpackProductsForSite( site ).length > 0
+				? __( 'Manage subscriptions.' )
+				: __( 'Upgrade to access more Jetpack tools.' );
+		case WooHostedPlans.WOO_HOSTED_FREE_PLAN:
+			return __( 'Upgrade to keep your online store.' );
 	}
 
 	if ( purchase ) {


### PR DESCRIPTION
Part of SHILL-1881
Related to 789ec75e283-ghe-Automattic/wpcom (the wpcom PR that renames the `WOO_HOSTED_FREE_PLAN` product to `No Plan`).

## Proposed Changes

* In `client/dashboard/sites/overview-plan-card/index.tsx`, import `WooHostedPlans` from `@automattic/api-core`.
* In `getCardDescription()`, return `Upgrade to keep your online store.` when the site's current plan is `WooHostedPlans.WOO_HOSTED_FREE_PLAN`.

## Why are these changes being made?

When a CIAB merchant plan expires or is canceled, the site is downgraded to `WOO_HOSTED_FREE_PLAN` and the Site Overview plan card (new `client/dashboard` route) shows only the Free Plan name with no supporting context.  A companion PR  noted above renames that product to `No Plan` so the label is clean across all surfaces, but the overview card then has nothing under it to prompt the merchant to re-upgrade.

This change adds a short description under the plan card specifically for the `WOO_HOSTED_FREE_PLAN` case, nudging cancelled-plan merchants toward re-upgrading without introducing a new banner or modal. The dotcom/Jetpack free-plan branches already handle their own cases above this block; WooHosted was just falling through to `undefined`.

| Scenario | Before | After |
|----------|--------|-------|
| CIAB site on `WOO_HOSTED_FREE_PLAN` | Card shows plan title only, no description | Card shows plan title plus `Upgrade to keep your online store.` |
| CIAB site on a paid WooHosted plan | Purchase expiry/renewal status shown | Unchanged |
| Simple/Atomic/Jetpack free plans | Existing dotcom/Jetpack handling | Unchanged |

## Testing Instructions

**Steps:**



1. Start at http://my.woo.localhost:3000/sites or https://my.woo.ai/sites/
2. Find or create a CIAB site whose current plan is `WOO_HOSTED_FREE_PLAN` (cancel a paid WooHosted subscription on a sandbox CIAB site, or pick one from the ownership table).
3. Navigate to `/sites/{site-slug}`
4. Verify that the PLAN card shows the plan title plus the description `Upgrade to keep your online store.` directly below it.
5. Navigate to `/sites/{site-slug}` for a CIAB site on a **paid** WooHosted plan (Basic or Pro).
6. Verify that the PLAN card renders the existing `PurchaseExpiryStatus` (renewal/expiry wording) and does **not** show the new "Upgrade to keep your online store." string.


**Before this change:**

- `/sites/{site-slug}` for an expired/cancelled CIAB site on the WOO_HOSTED_FREE_PLAN shows the plan card with no description underneath the plan title.

**After this change:**

- `/sites/{site-slug}` for a WOO_HOSTED_FREE_PLAN CIAB site shows `Upgrade to keep your online store.` under the plan title.


##Screenshots
<img width="754" height="520" alt="Screenshot 2026-04-13 at 1 40 30 PM" src="https://github.com/user-attachments/assets/810ff432-aedc-4c09-98b1-e7f18e16c837" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?