### PR TITLE
CIAB: Use Woo logo for dashboard loading and skip SSR loader

### DIFF
--- a/client/dashboard/app-ciab/index.tsx
+++ b/client/dashboard/app-ciab/index.tsx
@@ -8,6 +8,7 @@ import {
 /* eslint-enable no-restricted-imports */
 import boot from '../app/boot';
 import { getPostHogConfig } from './posthog';
+import CiabDashboardStepperLogo from './stepper-logo';
 import './translations';
 import type {
 	FetchSitesOptions,
@@ -22,6 +23,7 @@ boot( {
 	basePath: '/',
 	mainRoute: '/sites',
 	Logo: null,
+	LoadingLogo: CiabDashboardStepperLogo,
 	supports: {
 		sites: true,
 		domains: true,

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -359,9 +359,10 @@ function LoadingPlaceholder( {
 		);
 	}
 
-	// CIAB dashboard routes render their own loading logo in the dashboard Root
-	// after hydration. Skipping the SSR logo avoids a double-flash with jitter.
-	if ( dashboard === 'ciab' ) {
+	// Dashboard apps render their own loading logo in the dashboard Root after
+	// hydration. Skipping the SSR logo avoids a double-render with positional
+	// jitter between the SSR and Root containers.
+	if ( dashboard ) {
 		return null;
 	}
 

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -359,6 +359,12 @@ function LoadingPlaceholder( {
 		);
 	}
 
+	// CIAB dashboard routes render their own loading logo in the dashboard Root
+	// after hydration. Skipping the SSR logo avoids a double-flash with jitter.
+	if ( dashboard === 'ciab' ) {
+		return null;
+	}
+
 	const LoadingLogo = chooseLoadingLogo( {
 		isWpMobileApp: app?.isWpMobileApp,
 		isWcMobileApp: app?.isWcMobileApp,


### PR DESCRIPTION
Resolves SHILL-1879

## Proposed Changes

- `client/dashboard/app-ciab/index.tsx`: set `LoadingLogo: CiabDashboardStepperLogo` in the CIAB app boot config so the dashboard Root loader renders the Woo logo (instead of the default `WordPressLogo`) during initial load, slow in-dashboard navigation, and `fullPageLoader` queries.
- `client/document/index.jsx`: have `LoadingPlaceholder` return `null` whenever `dashboard` is set (both `'ciab'` and `'dotcom'`). The SSR loader is unnecessary on any dashboard route because the dashboard Root always renders its own `<LoadingLogo />` post-hydration. Skipping the SSR logo avoids a double-render with positional jitter between the SSR and Root containers.

## Why

On every CIAB page load (not just the back-navigation repro from the issue), users briefly saw the WordPress logo during the loading transition before the dashboard hydrated. This is a branding leak at the CIAB boundary.

The dotcom dashboard hit the same double-render, but it was invisible because both the SSR and Root loaders defaulted to `WordPressLogo` — same jitter, same redundant render, just not user-visible. Returning `null` from SSR for any dashboard app fixes both.

  ## Related                                                     

  - #108549
  - #109352
  - #109491 (open, same goal via partner-branding abstraction)

## Testing Instructions

### CIAB (`my.woo.localhost` / `my.woo.ai`)

Load each of the following and confirm the loading logo is the Woo logo (or no logo briefly, then Woo) — never the WordPress logo:

- http://my.woo.localhost:3000/sites/
- http://my.woo.localhost:3000/sites/{siteSlug}
- http://my.woo.localhost:3000/me/billing/purchases/{purchaseId}

Also navigate CIAB Billings → Upgrade → browser Back and confirm the WP logo no longer flashes on the return to Billings (original SHILL-1879 repro).

### Dotcom dashboard (`my.localhost` / `my.wordpress.com`)

Load each of the following and confirm no WP logo flash during initial load:

- http://my.localhost:3000/sites
- http://my.localhost:3000/me/billing/purchases/{purchaseId}

To see the loader under slow conditions, throttle the Network tab in DevTools (e.g. 4G) — you should see a single centered loader during the wait, not two.

### Non-dashboard routes

Classic Calypso routes (e.g., `/me`, `/my-sites`) on `wordpress.com` / `calypso.localhost` still show the WordPress logo during loading — non-dashboard behavior is unchanged.
