### PR TITLE
Image Studio: Fix style_selected tracks event and default toolbar label

### DIFF
--- a/packages/image-studio/src/components/style-picker/index.test.tsx
+++ b/packages/image-studio/src/components/style-picker/index.test.tsx
@@ -278,6 +278,40 @@ describe( 'StylePicker', () => {
 			} );
 		} );
 
+		it( 'sends "none" sentinel when the None style is selected', async () => {
+			const user = userEvent.setup();
+
+			render( <StylePicker mode={ ImageStudioMode.Generate } /> );
+
+			// Open dropdown
+			await user.click( screen.getByTestId( 'toolbar-button' ) );
+
+			// The "None" option has value: '' and is the first option with a preview.
+			// Distinguish it from the placeholder 'Select style' option (which has no preview
+			// and is filtered out of the rendered UI).
+			const noneButton = screen
+				.getAllByRole( 'button' )
+				.find(
+					( button ) =>
+						button.textContent?.trim() === 'None' &&
+						button.getAttribute( 'data-testid' ) !== 'toolbar-button'
+				);
+
+			expect( noneButton ).toBeDefined();
+			await user.click( noneButton! );
+
+			// The Redux store must still receive the empty string — the client-context
+			// truthy check relies on '' to mean "no style selected".
+			expect( mockSetSelectedStyle ).toHaveBeenCalledWith( '' );
+
+			// But the tracking event should receive the 'none' sentinel so the event
+			// is not logged with an empty style value.
+			expect( mockTrackStyleSelected ).toHaveBeenCalledWith( {
+				style: 'none',
+				mode: ImageStudioMode.Generate,
+			} );
+		} );
+
 		it( 'closes dropdown after style selection', async () => {
 			const user = userEvent.setup();
 

--- a/packages/image-studio/src/components/style-picker/index.test.tsx
+++ b/packages/image-studio/src/components/style-picker/index.test.tsx
@@ -92,7 +92,7 @@ describe( 'StylePicker', () => {
 
 		mockUseSelect.mockImplementation( ( selector: any ) => {
 			const result = selector( () => ( {
-				getSelectedStyle: () => '',
+				getSelectedStyle: () => null,
 			} ) );
 			return result;
 		} );
@@ -115,8 +115,8 @@ describe( 'StylePicker', () => {
 		it( 'renders style picker with default label', () => {
 			render( <StylePicker mode={ ImageStudioMode.Generate } /> );
 
-			// When selectedStyle is '', it shows 'None' (the label for value: '')
-			expect( screen.getByTestId( 'toolbar-button' ) ).toHaveTextContent( 'None' );
+			// When selectedStyle is null (initial state), it shows the fallback label 'Style'
+			expect( screen.getByTestId( 'toolbar-button' ) ).toHaveTextContent( 'Style' );
 		} );
 
 		it( 'renders style picker with selected style label', () => {
@@ -146,14 +146,11 @@ describe( 'StylePicker', () => {
 			// Open dropdown
 			await user.click( screen.getByTestId( 'toolbar-button' ) );
 
-			// Filter out the first option which has no preview
-			const optionsWithPreviews = STYLE_OPTIONS.filter( ( opt ) => opt.preview );
-
 			const styleButtons = screen.getAllByRole( 'button' ).filter( ( button ) => {
 				return button.querySelector( 'img' ) !== null;
 			} );
 
-			expect( styleButtons ).toHaveLength( optionsWithPreviews.length );
+			expect( styleButtons ).toHaveLength( STYLE_OPTIONS.length );
 		} );
 
 		it( 'renders style option labels', async () => {
@@ -278,7 +275,7 @@ describe( 'StylePicker', () => {
 			} );
 		} );
 
-		it( 'sends "none" sentinel when the None style is selected', async () => {
+		it( 'tracks "none" when the None style is selected', async () => {
 			const user = userEvent.setup();
 
 			render( <StylePicker mode={ ImageStudioMode.Generate } /> );
@@ -286,9 +283,8 @@ describe( 'StylePicker', () => {
 			// Open dropdown
 			await user.click( screen.getByTestId( 'toolbar-button' ) );
 
-			// The "None" option has value: '' and is the first option with a preview.
-			// Distinguish it from the placeholder 'Select style' option (which has no preview
-			// and is filtered out of the rendered UI).
+			// The "None" option has value: 'none' — a real, non-empty value that is
+			// distinct from the initial null state.
 			const noneButton = screen
 				.getAllByRole( 'button' )
 				.find(
@@ -300,12 +296,10 @@ describe( 'StylePicker', () => {
 			expect( noneButton ).toBeDefined();
 			await user.click( noneButton! );
 
-			// The Redux store must still receive the empty string — the client-context
-			// truthy check relies on '' to mean "no style selected".
-			expect( mockSetSelectedStyle ).toHaveBeenCalledWith( '' );
+			// The store receives 'none' directly.
+			expect( mockSetSelectedStyle ).toHaveBeenCalledWith( 'none' );
 
-			// But the tracking event should receive the 'none' sentinel so the event
-			// is not logged with an empty style value.
+			// The tracking event receives the same 'none' value — no sentinel translation.
 			expect( mockTrackStyleSelected ).toHaveBeenCalledWith( {
 				style: 'none',
 				mode: ImageStudioMode.Generate,
@@ -443,7 +437,7 @@ describe( 'StylePicker', () => {
 
 			// Test a few key mappings
 			const testCases = [
-				{ label: 'None', value: '' },
+				{ label: 'None', value: 'none' },
 				{ label: 'Vivid', value: 'vivid' },
 				{ label: '3D Model', value: '3d-model' },
 				{ label: 'Pixel Art', value: 'pixel-art' },
@@ -477,8 +471,8 @@ describe( 'StylePicker', () => {
 		it( 'updates label when selected style changes', () => {
 			const { rerender } = render( <StylePicker mode={ ImageStudioMode.Generate } /> );
 
-			// When selectedStyle is '', it matches the 'None' option
-			expect( screen.getByTestId( 'toolbar-button' ) ).toHaveTextContent( 'None' );
+			// When selectedStyle is null (initial state), it shows the fallback label 'Style'
+			expect( screen.getByTestId( 'toolbar-button' ) ).toHaveTextContent( 'Style' );
 
 			// Update selected style
 			mockUseSelect.mockImplementation( ( selector: any ) => {
@@ -503,9 +497,9 @@ describe( 'StylePicker', () => {
 
 			render( <StylePicker mode={ ImageStudioMode.Generate } /> );
 
-			// Should fall back to 'Styles' when value doesn't match any option
+			// Should fall back to 'Style' when value doesn't match any option
 			const toolbarButton = screen.getByTestId( 'toolbar-button' );
-			expect( toolbarButton ).toHaveTextContent( 'Styles' );
+			expect( toolbarButton ).toHaveTextContent( 'Style' );
 		} );
 
 		it( 'reflects selection state across multiple instances', async () => {

--- a/packages/image-studio/src/components/style-picker/index.tsx
+++ b/packages/image-studio/src/components/style-picker/index.tsx
@@ -125,7 +125,7 @@ export function StylePicker( { disabled = false, mode }: StylePickerProps ) {
 	const handleStyleSelect = ( value: string ) => {
 		setSelectedStyle( value );
 		// Track style selection
-		trackImageStudioStyleSelected( { style: value, mode } );
+		trackImageStudioStyleSelected( { style: value || 'none', mode } );
 		// Close dropdown by triggering a mousedown event outside the InputToolbar container
 		// We use requestAnimationFrame to ensure the state update completes first
 		requestAnimationFrame( () => {

--- a/packages/image-studio/src/components/style-picker/index.tsx
+++ b/packages/image-studio/src/components/style-picker/index.tsx
@@ -30,8 +30,7 @@ interface StylePickerProps {
 }
 
 export const STYLE_OPTIONS = [
-	{ label: __( 'Select style', __i18n_text_domain__ ), value: 'none', preview: null },
-	{ label: __( 'None', __i18n_text_domain__ ), value: '', preview: nonePreview },
+	{ label: __( 'None', __i18n_text_domain__ ), value: 'none', preview: nonePreview },
 	{
 		label: __( 'Vivid', __i18n_text_domain__ ),
 		value: 'vivid',
@@ -125,7 +124,7 @@ export function StylePicker( { disabled = false, mode }: StylePickerProps ) {
 	const handleStyleSelect = ( value: string ) => {
 		setSelectedStyle( value );
 		// Track style selection
-		trackImageStudioStyleSelected( { style: value || 'none', mode } );
+		trackImageStudioStyleSelected( { style: value, mode } );
 		// Close dropdown by triggering a mousedown event outside the InputToolbar container
 		// We use requestAnimationFrame to ensure the state update completes first
 		requestAnimationFrame( () => {
@@ -141,7 +140,7 @@ export function StylePicker( { disabled = false, mode }: StylePickerProps ) {
 
 	const selectedLabel =
 		STYLE_OPTIONS.find( ( opt ) => opt.value === selectedStyle )?.label ??
-		__( 'Styles', __i18n_text_domain__ );
+		__( 'Style', __i18n_text_domain__ );
 
 	return (
 		<AgentUI.InputToolbar
@@ -151,7 +150,7 @@ export function StylePicker( { disabled = false, mode }: StylePickerProps ) {
 			disabled={ disabled }
 		>
 			<div className="image-studio-input-toolbar-dialog-grid">
-				{ STYLE_OPTIONS.filter( ( opt ) => opt.preview ).map( ( option ) => (
+				{ STYLE_OPTIONS.map( ( option ) => (
 					<button
 						key={ option.value }
 						type="button"

--- a/packages/image-studio/src/store/index.test.ts
+++ b/packages/image-studio/src/store/index.test.ts
@@ -92,7 +92,7 @@ describe( 'Image Studio Store', () => {
 				navigationCurrentPage: 1,
 				navigationHasMorePages: true,
 				isSidebarOpen: false,
-				selectedStyle: '',
+				selectedStyle: null,
 				selectedAspectRatio: null,
 				lastAgentMessageId: null,
 			} );

--- a/packages/image-studio/src/store/index.ts
+++ b/packages/image-studio/src/store/index.ts
@@ -349,7 +349,7 @@ const initialState: ImageStudioState = {
 	navigationCurrentPage: 1,
 	navigationHasMorePages: true,
 	isSidebarOpen: getSidebarIsOpenStateFromLocalStorage(),
-	selectedStyle: '',
+	selectedStyle: null,
 	selectedAspectRatio: null,
 	lastAgentMessageId: null,
 };

--- a/packages/image-studio/src/utils/client-context.ts
+++ b/packages/image-studio/src/utils/client-context.ts
@@ -212,7 +212,7 @@ function detectImageEntity(): ImageStudioData | null {
 			metadata: {},
 		};
 
-		if ( selectedStyle ) {
+		if ( selectedStyle && selectedStyle !== 'none' ) {
 			imageStudio.style = selectedStyle;
 		}
 


### PR DESCRIPTION
Fixes FORNO-331

## Proposed Changes

This PR does two things together — the second was discovered while reviewing the first, and the cleaner structure makes the original fix simpler.

**1. Fix the `style_selected` tracks bug.** The "None" style in the style picker was firing `jetpack_big_sky_image_studio_style_selected` (or `wpcom_big_sky_…`) with `style: ''`, which Tracks drops as null. 8.9% of `style_selected` events (479 of 5,410 in the last 30 days) had no style value — "None" is the 3rd most popular choice but invisible in analytics.

**2. Mirror the aspect-ratio picker's empty-state pattern.** The style picker had a dead placeholder row (`{ label: 'Select style', value: 'none', preview: null }`) that existed only to be filtered out of the UI, and the real "None" option used `value: ''` which collided with the store's initial state. As a result, the toolbar button read **"None"** on load, before the user had picked anything. The aspect-ratio picker does this correctly: no placeholder, `null` initial state, `??` fallback label.

### Before

<img width="1646" height="502" alt="image" src="https://github.com/user-attachments/assets/0dec488a-ea29-4f2f-bc88-3fb079b0bfc0" />

### After

<img width="572" height="111" alt="Screenshot 2026-04-14 at 2 33 48 PM" src="https://github.com/user-attachments/assets/c8100d68-d699-4d5b-9c54-ba2602142d5e" />


### What changed

- `packages/image-studio/src/components/style-picker/index.tsx`
  - Removed the dead `'Select style'` placeholder row from `STYLE_OPTIONS`
  - Changed the None option's value from `''` to `'none'`
  - Dropped the now-unnecessary `.filter( opt => opt.preview )` in the render loop
  - Changed the fallback toolbar label from `'Styles'` to `'Style'` (singular, matches "Aspect Ratio")
  - Simplified the tracking call from `style: value || 'none'` to `style: value` — the sentinel fallback is no longer needed
- `packages/image-studio/src/store/index.ts`
  - Initial state `selectedStyle: ''` → `selectedStyle: null`
- `packages/image-studio/src/utils/client-context.ts`
  - Gate the new `'none'` value out of the AI agent context: `if ( selectedStyle && selectedStyle !== 'none' )`. Preserves the pre-fix behavior where selecting None meant the agent received no `style` property, while Tracks still captures the explicit `'none'` value for analytics.
- Tests updated in `style-picker/index.test.tsx` and `store/index.test.ts` to reflect the new initial state and None value.

### Why not just touch the tracking call?

The original approach was a tracking-only fix: substitute `'none'` at the `trackImageStudioStyleSelected` call site while leaving the underlying `''` in place. That worked but patched over the real problem — the structural mismatch between `STYLE_OPTIONS` and the store meant the toolbar button was already showing "None" before the user picked anything. Fixing both at once is a small amount of extra code and leaves the picker consistent with the aspect-ratio picker.

### Companion PR

[`Automattic/big-sky-plugin#5953`](https://github.com/Automattic/big-sky-plugin/pull/5953) applies only the tracking-only fix (`style: value || 'none'`) to the duplicated component in that repo. The UX fix was intentionally skipped there because the Big Sky plugin is being removed.

## Testing Instructions

1. `yarn test-packages packages/image-studio` — all 797 tests should pass, including the updated style-picker and store test cases.
2. In a sandbox, open Image Studio. The style picker toolbar button should read **"Style"** on load (not "None").
3. Open DevTools console and run `localStorage.setItem('debug', 'dops:analytics')`, then reload.
4. Open the style picker and click **None**. Confirm the `…image_studio_style_selected` event fires with `style: 'none'`.
5. Click a non-None style (e.g. Vivid). Confirm that event fires with `style: 'vivid'`.
6. Confirm the selected label in the toolbar updates to match the clicked option.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
