### PR TITLE
Image Studio: fix missing is_test and post_type on track events

### DIFF
--- a/packages/image-studio/jest.config.js
+++ b/packages/image-studio/jest.config.js
@@ -5,6 +5,7 @@ module.exports = {
 	modulePathIgnorePatterns: [ '<rootDir>/dist' ],
 	testEnvironment: 'jsdom',
 	moduleNameMapper: {
+		'^@automattic/calypso-analytics$': '<rootDir>/src/__mocks__/@automattic/calypso-analytics.ts',
 		'^@wordpress/data$': '<rootDir>/src/__mocks__/@wordpress/data.ts',
 		'^@wordpress/core-data$': '<rootDir>/src/__mocks__/@wordpress/core-data.ts',
 		'^@wordpress/block-editor$': '<rootDir>/src/__mocks__/@wordpress/block-editor.ts',

--- a/packages/image-studio/src/__mocks__/@automattic/calypso-analytics.ts
+++ b/packages/image-studio/src/__mocks__/@automattic/calypso-analytics.ts
@@ -1,0 +1,4 @@
+/**
+ * Mock for @automattic/calypso-analytics package
+ */
+export const recordTracksEvent = jest.fn();

--- a/packages/image-studio/src/index.tsx
+++ b/packages/image-studio/src/index.tsx
@@ -25,6 +25,7 @@ import {
 interface ImageStudioData {
 	enabled?: boolean | string;
 	environment?: 'wp-admin' | 'ciab-admin';
+	isDevMode?: boolean;
 }
 
 declare global {

--- a/packages/image-studio/src/utils/tracking.test.ts
+++ b/packages/image-studio/src/utils/tracking.test.ts
@@ -1,0 +1,88 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests for Image Studio tracking functions
+ */
+import { recordTracksEvent as recordTracksEventBase } from '@automattic/calypso-analytics';
+import { select } from '@wordpress/data';
+import { ImageStudioEntryPoint } from '../store';
+import { trackImageStudioOpened } from './tracking';
+
+// Mock session
+jest.mock( '../utils/session', () => ( {
+	getSessionId: jest.fn( () => 'test-session-id' ),
+} ) );
+
+const recordTracksEventMock = recordTracksEventBase as jest.Mock;
+const selectMock = select as jest.Mock;
+
+describe( 'trackImageStudioOpened', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		selectMock.mockReturnValue( {
+			getEntryPoint: jest.fn( () => null ),
+		} );
+		// Set up window properties for screen/post_type
+		( window as any ).pagenow = 'post';
+		( window as any ).typenow = 'page';
+	} );
+
+	afterEach( () => {
+		delete ( window as any ).pagenow;
+		delete ( window as any ).typenow;
+	} );
+
+	it( 'should include sessionid in the opened event', () => {
+		trackImageStudioOpened( { mode: 'edit' } );
+
+		expect( recordTracksEventMock ).toHaveBeenCalledWith(
+			'jetpack_big_sky_image_studio_opened',
+			expect.objectContaining( { sessionid: 'test-session-id' } )
+		);
+	} );
+
+	it( 'should include screen and post_type from window globals', () => {
+		trackImageStudioOpened( { mode: 'edit' } );
+
+		expect( recordTracksEventMock ).toHaveBeenCalledWith(
+			'jetpack_big_sky_image_studio_opened',
+			expect.objectContaining( {
+				screen: 'post',
+				post_type: 'page',
+			} )
+		);
+	} );
+
+	it( 'should use the passed entryPoint as placement when store has no value', () => {
+		// At open time the store has not been updated yet, so it returns null
+		selectMock.mockReturnValue( {
+			getEntryPoint: jest.fn( () => null ),
+		} );
+
+		trackImageStudioOpened( {
+			mode: 'generate',
+			entryPoint: ImageStudioEntryPoint.EditorBlock,
+		} );
+
+		expect( recordTracksEventMock ).toHaveBeenCalledWith(
+			'jetpack_big_sky_image_studio_opened',
+			expect.objectContaining( { placement: 'editor_block' } )
+		);
+	} );
+
+	it( 'should include mode and attachment_id', () => {
+		trackImageStudioOpened( {
+			mode: 'edit',
+			attachmentId: 42,
+			entryPoint: ImageStudioEntryPoint.MediaLibrary,
+		} );
+
+		expect( recordTracksEventMock ).toHaveBeenCalledWith(
+			'jetpack_big_sky_image_studio_opened',
+			expect.objectContaining( {
+				mode: 'edit',
+				attachment_id: 42,
+			} )
+		);
+	} );
+} );

--- a/packages/image-studio/src/utils/tracking.test.ts
+++ b/packages/image-studio/src/utils/tracking.test.ts
@@ -6,7 +6,7 @@
 import { recordTracksEvent as recordTracksEventBase } from '@automattic/calypso-analytics';
 import { select } from '@wordpress/data';
 import { ImageStudioEntryPoint } from '../store';
-import { trackImageStudioOpened } from './tracking';
+import { trackImageStudioClosed, trackImageStudioOpened } from './tracking';
 
 // Mock session
 jest.mock( '../utils/session', () => ( {
@@ -84,5 +84,59 @@ describe( 'trackImageStudioOpened', () => {
 				attachment_id: 42,
 			} )
 		);
+	} );
+} );
+
+describe( 'recordImageStudioEvent — is_test property', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		selectMock.mockReturnValue( {
+			getEntryPoint: jest.fn( () => null ),
+		} );
+		delete ( window as any ).imageStudioData;
+		delete ( window as any ).pagenow;
+		delete ( window as any ).typenow;
+	} );
+
+	afterEach( () => {
+		delete ( window as any ).imageStudioData;
+	} );
+
+	it( 'should include is_test when imageStudioData.isDevMode is true', () => {
+		( window as any ).imageStudioData = { enabled: true, isDevMode: true };
+
+		trackImageStudioClosed( { mode: 'edit' } );
+
+		expect( recordTracksEventMock ).toHaveBeenCalledWith(
+			'jetpack_big_sky_image_studio_closed',
+			expect.objectContaining( { is_test: true } )
+		);
+	} );
+
+	it( 'should include is_test as false when imageStudioData.isDevMode is false', () => {
+		( window as any ).imageStudioData = { enabled: true, isDevMode: false };
+
+		trackImageStudioClosed( { mode: 'edit' } );
+
+		expect( recordTracksEventMock ).toHaveBeenCalledWith(
+			'jetpack_big_sky_image_studio_closed',
+			expect.objectContaining( { is_test: false } )
+		);
+	} );
+
+	it( 'should not include is_test when imageStudioData is absent', () => {
+		trackImageStudioClosed( { mode: 'edit' } );
+
+		const callArgs = recordTracksEventMock.mock.calls[ 0 ][ 1 ];
+		expect( callArgs ).not.toHaveProperty( 'is_test' );
+	} );
+
+	it( 'should not include is_test when isDevMode is not set', () => {
+		( window as any ).imageStudioData = { enabled: true };
+
+		trackImageStudioClosed( { mode: 'edit' } );
+
+		const callArgs = recordTracksEventMock.mock.calls[ 0 ][ 1 ];
+		expect( callArgs ).not.toHaveProperty( 'is_test' );
 	} );
 } );

--- a/packages/image-studio/src/utils/tracking.test.ts
+++ b/packages/image-studio/src/utils/tracking.test.ts
@@ -124,19 +124,23 @@ describe( 'recordImageStudioEvent — is_test property', () => {
 		);
 	} );
 
-	it( 'should not include is_test when imageStudioData is absent', () => {
+	it( 'should default is_test to false when imageStudioData is absent', () => {
 		trackImageStudioClosed( { mode: 'edit' } );
 
-		const callArgs = recordTracksEventMock.mock.calls[ 0 ][ 1 ];
-		expect( callArgs ).not.toHaveProperty( 'is_test' );
+		expect( recordTracksEventMock ).toHaveBeenCalledWith(
+			'jetpack_big_sky_image_studio_closed',
+			expect.objectContaining( { is_test: false } )
+		);
 	} );
 
-	it( 'should not include is_test when isDevMode is not set', () => {
+	it( 'should default is_test to false when isDevMode is not set', () => {
 		( window as any ).imageStudioData = { enabled: true };
 
 		trackImageStudioClosed( { mode: 'edit' } );
 
-		const callArgs = recordTracksEventMock.mock.calls[ 0 ][ 1 ];
-		expect( callArgs ).not.toHaveProperty( 'is_test' );
+		expect( recordTracksEventMock ).toHaveBeenCalledWith(
+			'jetpack_big_sky_image_studio_closed',
+			expect.objectContaining( { is_test: false } )
+		);
 	} );
 } );

--- a/packages/image-studio/src/utils/tracking.ts
+++ b/packages/image-studio/src/utils/tracking.ts
@@ -82,9 +82,7 @@ function recordImageStudioEvent(
 	}
 
 	// Add dev mode flag for filtering test/internal traffic
-	if ( win.imageStudioData && typeof win.imageStudioData.isDevMode === 'boolean' ) {
-		baseProps.is_test = win.imageStudioData.isDevMode;
-	}
+	baseProps.is_test = !! win.imageStudioData?.isDevMode;
 
 	recordTracksEvent( eventName, baseProps );
 }

--- a/packages/image-studio/src/utils/tracking.ts
+++ b/packages/image-studio/src/utils/tracking.ts
@@ -180,12 +180,10 @@ export function trackImageStudioOpened( {
 	if ( attachmentId ) {
 		properties.attachment_id = attachmentId;
 	}
-	// For the opened event, use the passed entry point since the store hasn't been updated yet
 	if ( entryPoint ) {
 		properties.placement = entryPoint;
 	}
-	// Don't use recordImageStudioEvent here since we're manually adding placement
-	recordTracksEvent( 'image_studio_opened', properties );
+	recordImageStudioEvent( 'image_studio_opened', properties );
 }
 
 /**

--- a/packages/image-studio/src/utils/tracking.ts
+++ b/packages/image-studio/src/utils/tracking.ts
@@ -81,6 +81,11 @@ function recordImageStudioEvent(
 		baseProps.post_type = win.typenow;
 	}
 
+	// Add dev mode flag for filtering test/internal traffic
+	if ( win.imageStudioData && typeof win.imageStudioData.isDevMode === 'boolean' ) {
+		baseProps.is_test = win.imageStudioData.isDevMode;
+	}
+
 	recordTracksEvent( eventName, baseProps );
 }
 


### PR DESCRIPTION
Part of FORNO-337, FORNO-330

## Proposed Changes

* Route `trackImageStudioOpened` through the shared `recordImageStudioEvent` wrapper so the `_opened` event gets `sessionid`, `screen`, and `post_type` — properties that were lost when tracking moved from the Big Sky plugin to the standalone Calypso package.
* Add `is_test` to every Image Studio event by reading `window.imageStudioData.isDevMode` in the `recordImageStudioEvent` wrapper. Gracefully absent until the PHP-side change ships the value.
* Add `isDevMode` to the `ImageStudioData` interface.
* Add unit tests for both fixes.

## Why are these changes being made?

When Image Studio was extracted from the Big Sky plugin into its own Calypso package, several Tracks event properties were lost. The `_opened` event bypassed the shared wrapper (calling `recordTracksEvent` directly), so it missed `sessionid`, `screen`, and `post_type`. The `is_test` property was never ported to the new package because the PHP-side data source (`isDevMode`) wasn't wired up yet. This PR fixes the JS side so events are correctly enriched once the PHP loader ships `isDevMode`.

## Testing Instructions

* `install-plugin.sh am image-studio-track-events-missing-props` on your sandbox
* Sandbox `widgets.wp.com`
* Enable tracks debug by setting `localStorage.debug = 'calypso:analytics*'`
* On a sandbox, open Image Studio from Media Library and from the block editor toolbar. Verify in Tracks debugger that `_opened` events include `sessionid`, `screen`, `post_type`, and `placement`.
* `is_test` will only appear once the Jetpack PHP loader passes `isDevMode` in `window.imageStudioData`.
* To test this, run `bin/jetpack-downloader test jetpack image-studio-devmode-prop` on your sandbox to install the relevant Jetpack branch which adds this
* Reload the page and open Image Studio and verify `is_test` is true when proxied, `false` when not

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?