### PR TITLE
Dashboard AGENTS.md: add rule against branching on appConfig.name

### DIFF
--- a/client/dashboard/AGENTS.md
+++ b/client/dashboard/AGENTS.md
@@ -10,3 +10,7 @@ This is the new hosting dashboard for WordPress.com.
 
 - Use TanStack Query and TanStack Router.
 - Don't use Redux and `calypso/state`.
+- **Never branch on `appConfig.name`** (e.g. `if (appConfig.name === 'CIAB')`). The dashboard has many variants; hardcoding behavior per variant doesn't scale. Some alternatives:
+  1. If the behavior depends on the **site** (e.g. available features, capabilities), use `siteTypeSupportsFeature()` or extend `SiteTypeFeatureSupports` in `utils/site-type-feature-support.ts`.
+  2. If the behavior genuinely differs per dashboard variant, add a property to `AppConfig` that each variant provides, and branch on that property instead of the name.
+  3. Before doing either, ask: if this UX is better for one variant, wouldn't it be better for all users? Prefer a single code path when possible.

--- a/client/dashboard/AGENTS.md
+++ b/client/dashboard/AGENTS.md
@@ -10,7 +10,7 @@ This is the new hosting dashboard for WordPress.com.
 
 - Use TanStack Query and TanStack Router.
 - Don't use Redux and `calypso/state`.
-- **Never branch on `appConfig.name`** (e.g. `if (appConfig.name === 'CIAB')`). The dashboard has many variants; hardcoding behavior per variant doesn't scale. Some alternatives:
+- **Never branch on `appConfig.name`** (e.g. `if (appConfig.name === 'dotcom')`). The dashboard has many variants; hardcoding behavior per variant doesn't scale. Some alternatives:
   1. If the behavior depends on the **site** (e.g. available features, capabilities), use `siteTypeSupportsFeature()` or extend `SiteTypeFeatureSupports` in `utils/site-type-feature-support.ts`.
   2. If the behavior genuinely differs per dashboard variant, add a property to `AppConfig` that each variant provides, and branch on that property instead of the name.
   3. Before doing either, ask: if this UX is better for one variant, wouldn't it be better for all users? Prefer a single code path when possible.


### PR DESCRIPTION
## Proposed Changes

* Add agent instruction to `client/dashboard/AGENTS.md` prohibiting branching on `appConfig.name`.

## Why are these changes being made?

* The dashboard will have many variants. Hardcoding behavior per variant (e.g. `if (appConfig.name === 'dotcom')`) doesn't scale and leads to unwieldy conditionals. This rule nudges toward better patterns: site-type feature support, typed AppConfig properties, or questioning whether the divergence is needed at all.

## Testing Instructions

* Documentation-only change, no testing needed.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?