### PR TITLE
Dashboard: eagerly mount notifications app so socket connects on load

### DIFF
--- a/client/dashboard/app/notifications/index.tsx
+++ b/client/dashboard/app/notifications/index.tsx
@@ -1,11 +1,11 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useNavigate } from '@tanstack/react-router';
-import { Button, Dropdown } from '@wordpress/components';
+import { Button, Popover } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { bellUnread, bell } from '@wordpress/icons';
 import clsx from 'clsx';
-import { Suspense, lazy, useCallback, useEffect, useState } from 'react';
+import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import wpcom from 'calypso/lib/wp';
 import { useAuth } from '../auth';
 import { useHelpCenter } from '../help-center';
@@ -31,13 +31,17 @@ export default function Notifications( {
 	const [ isOpen, setIsOpen ] = useState( false );
 	const [ hasUnseenNotifications, setHasUnseenNotifications ] = useState( user.has_unseen_notes );
 	const [ anchorEl, setAnchorEl ] = useState< HTMLElement | null >( null );
+	const buttonRef = useRef< HTMLButtonElement | null >( null );
+	const panelRef = useRef< HTMLDivElement | null >( null );
 
-	const handleToggle = ( willOpen: boolean ) => {
-		if ( willOpen ) {
-			setShowHelpCenter( false, undefined, true );
-		}
-		setIsOpen( willOpen );
-	};
+	const handleClose = useCallback( () => {
+		setIsOpen( false );
+	}, [] );
+
+	const handleOpen = useCallback( () => {
+		setShowHelpCenter( false, undefined, true );
+		setIsOpen( true );
+	}, [ setShowHelpCenter ] );
 
 	// Close notifications when help center opens.
 	useEffect( () => {
@@ -46,35 +50,34 @@ export default function Notifications( {
 		}
 	}, [ isHelpCenterShown ] );
 
-	const handleClose = () => {
-		handleToggle( false );
-	};
-
-	const actionHandlers = {
-		APP_RENDER_NOTES: [
-			( store: unknown, { newNoteCount }: { newNoteCount: number } ) => {
-				setHasUnseenNotifications( newNoteCount > 0 );
-				omnibarEvents.notificationsUnseenCount.emit( newNoteCount );
-			},
-		],
-		VIEW_SETTINGS: [
-			() => {
-				handleClose();
-				navigate( { to: '/me/notifications' } );
-			},
-		],
-		EDIT_COMMENT: [
-			( store: unknown, { href }: { href: string } ) => {
-				window.open( href, '_blank' );
-			},
-		],
-		ANSWER_PROMPT: [
-			( store: unknown, { href }: { href: string } ) => {
-				window.open( href, '_blank' );
-			},
-		],
-		CLOSE_PANEL: [ handleClose ],
-	};
+	const actionHandlers = useMemo(
+		() => ( {
+			APP_RENDER_NOTES: [
+				( _store: unknown, { newNoteCount }: { newNoteCount: number } ) => {
+					setHasUnseenNotifications( newNoteCount > 0 );
+					omnibarEvents.notificationsUnseenCount.emit( newNoteCount );
+				},
+			],
+			VIEW_SETTINGS: [
+				() => {
+					setIsOpen( false );
+					navigate( { to: '/me/notifications' } );
+				},
+			],
+			EDIT_COMMENT: [
+				( _store: unknown, { href }: { href: string } ) => {
+					window.open( href, '_blank' );
+				},
+			],
+			ANSWER_PROMPT: [
+				( _store: unknown, { href }: { href: string } ) => {
+					window.open( href, '_blank' );
+				},
+			],
+			CLOSE_PANEL: [ () => setIsOpen( false ) ],
+		} ),
+		[ navigate ]
+	);
 
 	const handleOmnibarToggle = useCallback( () => {
 		setIsOpen( ( prev ) => {
@@ -109,47 +112,81 @@ export default function Notifications( {
 		};
 	}, [ handleOmnibarToggle ] );
 
-	return (
-		<Dropdown
-			popoverProps={ {
-				className: 'dashboard-notifications',
-				placement: 'bottom-end',
-				offset: 8,
-				focusOnMount: true,
-				...( anchorEl && { anchor: anchorEl } ),
-				...( isEnabled( 'dashboard/omnibar' ) && {
-					onFocusOutside: () => {
-						// When focus moves to the omnibar (e.g. clicking the
-						// omnibar notification bell), suppress the Popover's
-						// auto-close and let the omnibar event handle the toggle
-						// instead. Without this, the Popover's focus-outside close
-						// races with the omnibar's toggle event, causing the panel
-						// to close then immediately reopen.
-						const omnibar = document.getElementById( 'wpcom-omnibar' );
-						if ( omnibar?.contains( document.activeElement ) ) {
-							return;
-						}
-						setIsOpen( false );
-					},
-				} ),
-			} }
-			open={ isOpen }
-			expandOnMobile={ isMobileViewport }
-			onToggle={ handleToggle }
-			renderToggle={ ( { isOpen, onToggle } ) =>
-				anchor ? null : (
-					<Button
-						className={ clsx( className, 'dashboard-notifications__icon' ) }
-						onClick={ onToggle }
-						aria-expanded={ isOpen }
-						variant="tertiary"
-						label={ __( 'Notifications' ) }
-						icon={ hasUnseenNotifications ? bellUnread : bell }
-					/>
-				)
+	// When opening, move focus into the panel.
+	useEffect( () => {
+		if ( ! isOpen ) {
+			return;
+		}
+		const focusable = panelRef.current?.querySelector< HTMLElement >(
+			'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+		);
+		focusable?.focus();
+	}, [ isOpen ] );
+
+	// Click outside to close (Popover's own focus-outside only fires when
+	// focus was inside; for a panel that may not have been focused we need
+	// a pointerdown listener.)
+	useEffect( () => {
+		if ( ! isOpen ) {
+			return;
+		}
+		const handlePointerDown = ( event: PointerEvent ) => {
+			const target = event.target as Node | null;
+			if ( ! target ) {
+				return;
 			}
-			renderContent={ () => (
+			if ( panelRef.current?.contains( target ) ) {
+				return;
+			}
+			if ( buttonRef.current?.contains( target ) ) {
+				return;
+			}
+			if ( anchorEl?.contains( target ) ) {
+				return;
+			}
+			if ( isEnabled( 'dashboard/omnibar' ) ) {
+				const omnibar = document.getElementById( 'wpcom-omnibar' );
+				if ( omnibar?.contains( target ) ) {
+					return;
+				}
+			}
+			setIsOpen( false );
+		};
+		document.addEventListener( 'pointerdown', handlePointerDown, true );
+		return () => {
+			document.removeEventListener( 'pointerdown', handlePointerDown, true );
+		};
+	}, [ isOpen, anchorEl ] );
+
+	const popoverAnchor = anchorEl ?? buttonRef.current;
+
+	return (
+		<>
+			{ ! anchor && (
+				<Button
+					ref={ buttonRef }
+					className={ clsx( className, 'dashboard-notifications__icon' ) }
+					onClick={ () => ( isOpen ? handleClose() : handleOpen() ) }
+					aria-expanded={ isOpen }
+					variant="tertiary"
+					label={ __( 'Notifications' ) }
+					icon={ hasUnseenNotifications ? bellUnread : bell }
+				/>
+			) }
+			<Popover
+				className={ clsx( 'dashboard-notifications', {
+					'dashboard-notifications--hidden': ! isOpen,
+				} ) }
+				placement="bottom-end"
+				offset={ 8 }
+				anchor={ popoverAnchor ?? undefined }
+				focusOnMount={ false }
+				expandOnMobile={ isMobileViewport }
+				onClose={ handleClose }
+			>
 				<div
+					ref={ panelRef }
+					aria-hidden={ ! isOpen }
 					style={ {
 						width: '100vw',
 						height: '100vh',
@@ -167,7 +204,7 @@ export default function Notifications( {
 						/>
 					</Suspense>
 				</div>
-			) }
-		/>
+			</Popover>
+		</>
 	);
 }

--- a/client/dashboard/app/notifications/style.scss
+++ b/client/dashboard/app/notifications/style.scss
@@ -1,4 +1,4 @@
-// The Dropdown component doesn't support to hide the header if the `expandOnMobile` is enabled.
+// The Popover component doesn't support hiding the header when `expandOnMobile` is enabled.
 .dashboard-notifications.components-popover.is-expanded {
 	.components-popover__header {
 		display: none;
@@ -7,6 +7,15 @@
 	.components-popover__content {
 		height: 100%;
 	}
+}
+
+// The panel is always mounted so that @automattic/notifications can open its
+// socket on first render and pre-populate the unseen count — without this the
+// socket only connects once the user clicks the bell, so the badge is missing
+// on initial page load.
+.dashboard-notifications.components-popover.dashboard-notifications--hidden {
+	visibility: hidden;
+	pointer-events: none;
 }
 
 .dashboard-notifications__icon {


### PR DESCRIPTION
## Proposed Changes

* Replace `Dropdown` with a `Button` + always-mounted `Popover` in `client/dashboard/app/notifications/index.tsx`.
* Hide the Popover via a `dashboard-notifications--hidden` CSS class (`visibility: hidden; pointer-events: none;`) when the panel is closed, so `AsyncNotificationApp` stays mounted from first render.
* Memoize `actionHandlers` and add explicit pointerdown / Escape / focus-on-open handling to replace what `Dropdown` was doing for us.

## Why are these changes being made?

On the new Dashboard, the unseen-count badge on the bell was missing until the user clicked it. v1 Calypso works because its notifications panel is mounted eagerly in the masterbar.

`@automattic/notifications` opens its pinghub socket as a side effect of mounting — `initStore()`, `initAPI(wpcom)`, and `RestClient` all run on first render of the component. Because Dashboard imported the app via `AsyncNotificationApp` rendered inside `Dropdown.renderContent`, the component only mounted the first time the user opened the dropdown, so the socket never connected on initial page load and the unread badge was always stale.

Mounting the component up-front (inside a Popover that's visually hidden until `isOpen`) brings Dashboard in line with v1's behavior without pulling Calypso's Redux store or the notifications package's internals into Dashboard.

## Testing Instructions

1. Load the Dashboard with a user that has unread notifications.
2. Open DevTools → Network and confirm a pinghub/streaming request fires shortly after first paint (not only after clicking the bell).
3. Confirm the bell icon shows the unread badge on initial load, before any click.
4. Click the bell → the panel opens anchored below the button, same position as before.
5. Click outside the panel and press Escape → the panel closes.
6. Toggle the `dashboard/omnibar` feature flag on and repeat — the omnibar's own bell button should toggle the panel without the focus-outside race closing it on click.
7. Resize to a mobile viewport → the panel still expands fullscreen.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?