### PR TITLE
Fix Gravatar domain redirect after purchase

### DIFF
--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -80,6 +80,7 @@ const allowedExternalSites = [
 	'jetpack.cloud.localhost',
 	'jetpack.com',
 	'akismet.com',
+	'gravatar.com',
 	'difmrequest.com',
 ];
 

--- a/client/my-sites/checkout/src/lib/pending-page.ts
+++ b/client/my-sites/checkout/src/lib/pending-page.ts
@@ -298,6 +298,7 @@ function isRedirectAllowed( url: string, siteSlug: string | undefined ): boolean
 		'cloud.jetpack.com',
 		'jetpack.com',
 		'akismet.com',
+		'gravatar.com',
 		'difmrequest.com',
 		'agencies.automattic.com',
 		'agencies.localhost',

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -122,8 +122,13 @@ function getLaunchDestination( dependencies ) {
 	return addQueryArgs( { celebrateLaunch: 'true' }, `/home/${ dependencies.siteSlug }` );
 }
 
-function getDomainSignupFlowDestination( { designType, siteSlug } ) {
+function getDomainSignupFlowDestination( { designType, siteSlug, flowName } ) {
 	const dashboardType = new URLSearchParams( window.location.search ).get( 'dashboard' );
+
+	// For Gravatar domain purchases, redirect back to Gravatar
+	if ( isDomainForGravatarFlow( flowName ) ) {
+		return 'https://gravatar.com/profile/';
+	}
 
 	// This designType represents a new site.
 	if ( designType === 'page' ) {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -127,7 +127,7 @@ function getDomainSignupFlowDestination( { designType, siteSlug, flowName } ) {
 
 	// For Gravatar domain purchases, redirect back to Gravatar
 	if ( isDomainForGravatarFlow( flowName ) ) {
-		return 'https://gravatar.com/profile/';
+		return 'https://gravatar.com/profile/?modal=account-settings&path=profile-url';
 	}
 
 	// This designType represents a new site.


### PR DESCRIPTION
For Gravatar domain purchases, users should be redirected back to Gravatar after checkout instead of being shown the generic domain-only thank-you page.

## Changes

1. **flows.js** - Added Gravatar flow detection in getDomainSignupFlowDestination() to return the Gravatar profile URL when it's a Gravatar domain purchase.

2. **get-thank-you-page-url/index.ts** - Added gravatar.com to allowedExternalSites list so external redirects to Gravatar are allowed by the checkout controller.

3. **pending-page.ts** - Added gravatar.com to allowedHostsForRedirect list so the pending page allows redirects to Gravatar after transaction completion.

## Root Cause

Commit 98a62d52162 changed flows.js to delegate redirect handling to the checkout controller (by returning empty string for non-page/non-existing-site designTypes). However, gravatar.com was not in the allowed external sites and hosts lists, causing the Gravatar redirect to be blocked and users to see the generic thank-you page instead.

## Test Plan

1. Make sure you don't have a Gravatar domain
2. Go to `/start/domain-for-gravatar`
3. Complete the domain purchase flow
4. Verify that:
   - You do NOT see the Thank you page
   - You are redirected to Gravatar profile page (`gravatar.com/profile/`)