### PR TITLE
A4A: point self-migration step to site-migration wizard

### DIFF
--- a/client/a8c-for-agencies/sections/migrations/primary/self-migration-tool/migration-info.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/self-migration-tool/migration-info.tsx
@@ -169,7 +169,7 @@ const wpcomSteps = (
 	{
 		stepId: 'go-to-import',
 		count: 2,
-		title: translate( 'Go to wordpress.com/import' ),
+		title: translate( 'Start the migration on WordPress.com' ),
 		description: translate(
 			'Choose your site from the list, then enter the URL of your existing site.'
 		),
@@ -178,7 +178,7 @@ const wpcomSteps = (
 			label: translate( 'Launch WordPress.com' ),
 			icon: external,
 			isExternal: true,
-			href: 'https://wordpress.com/import',
+			href: 'https://wordpress.com/setup/site-migration/',
 			eventName: 'calypso_a4a_migrate_to_wpcom_go_to_import_click',
 		},
 	},


### PR DESCRIPTION
The "Go to wordpress.com/import" step linked to the wrong URL; update it to the proper WordPress.com migration wizard and adjust the step title.

| Header | Header |
|--------|--------|
| <img width="1338" height="209" alt="Screenshot 2026-04-14 at 7 32 02 PM" src="https://github.com/user-attachments/assets/f092e22d-23db-4dbb-8909-76b057291f73" /> | <img width="1335" height="211" alt="Screenshot 2026-04-14 at 7 41 16 PM" src="https://github.com/user-attachments/assets/c1e23268-f3af-4acd-8cc4-1d37c3b16eb8" /> | 


Closes https://linear.app/a8c/issue/A4A-2418/update-outgoing-link-to-proper-wordpresscom-migration-wizard

## Proposed Changes

This pull request updates the self-migration tool in the agency migrations section to improve clarity and accuracy for users migrating sites to WordPress.com. The main changes update the step title and the external link for starting a migration.

User experience improvements:

* Updated the step title in the migration steps to "Start the migration on WordPress.com" for clearer guidance to users.
* Changed the external link for launching WordPress.com from the generic import page to the more specific site migration setup page (`https://wordpress.com/setup/site-migration/`).

## Why are these changes being made?

* Page is redirecting in the wrong URL.

## Testing Instructions

* Use the A4A live link and navigate to `/migrations/overview/migrate-to-wpcom`
* Click the 'Launch to WordPress.com' button.
* Confirm you are redirected to the correct URL.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
