### PR TITLE
Image Studio: Rename Image Editor to Jetpack Image Editor

### DIFF
--- a/packages/image-studio/src/components/header/index.test.tsx
+++ b/packages/image-studio/src/components/header/index.test.tsx
@@ -135,7 +135,6 @@ describe( 'Header', () => {
 			render( <Header { ...defaultProps } mode={ ImageStudioMode.Generate } /> );
 
 			expect( screen.getByText( 'Jetpack Image Editor' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Beta' ) ).toBeInTheDocument();
 		} );
 
 		it( 'renders navigation pill in Edit mode with filename', () => {

--- a/packages/image-studio/src/components/header/index.test.tsx
+++ b/packages/image-studio/src/components/header/index.test.tsx
@@ -134,7 +134,7 @@ describe( 'Header', () => {
 		it( 'renders header with title in Generate mode', () => {
 			render( <Header { ...defaultProps } mode={ ImageStudioMode.Generate } /> );
 
-			expect( screen.getByText( 'Image Editor' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Jetpack Image Editor' ) ).toBeInTheDocument();
 			expect( screen.getByText( 'Beta' ) ).toBeInTheDocument();
 		} );
 

--- a/packages/image-studio/src/components/header/index.tsx
+++ b/packages/image-studio/src/components/header/index.tsx
@@ -206,7 +206,7 @@ export const Header = ( {
 								'image-studio-sr-only': showTitle,
 							} ) }
 						>
-							{ __( 'Image Editor', __i18n_text_domain__ ) }{ ' ' }
+							{ __( 'Jetpack Image Editor', __i18n_text_domain__ ) }{ ' ' }
 							<span className="image-studio-badge">{ __( 'Beta', __i18n_text_domain__ ) }</span>
 						</h2>
 					) }

--- a/packages/image-studio/src/components/header/index.tsx
+++ b/packages/image-studio/src/components/header/index.tsx
@@ -206,8 +206,7 @@ export const Header = ( {
 								'image-studio-sr-only': showTitle,
 							} ) }
 						>
-							{ __( 'Jetpack Image Editor', __i18n_text_domain__ ) }{ ' ' }
-							<span className="image-studio-badge">{ __( 'Beta', __i18n_text_domain__ ) }</span>
+							{ __( 'Jetpack Image Editor', __i18n_text_domain__ ) }
 						</h2>
 					) }
 				</div>

--- a/packages/image-studio/src/components/style.scss
+++ b/packages/image-studio/src/components/style.scss
@@ -200,19 +200,6 @@ body.js.is-image-studio-open {
 	gap: 8px;
 }
 
-.image-studio-badge {
-	padding: 2px 8px;
-	min-height: 24px;
-	border-radius: 2px;
-	max-width: 100%;
-	display: inline-block;
-	background-color: #1f2c70;
-	color: #9fadfb;
-	font-size: $text-xs;
-	font-weight: 400;
-	line-height: 20px;
-}
-
 /* ==========================================================================
    Image Studio Chat - Match SidebarPortal Styling
    ========================================================================== */


### PR DESCRIPTION
## Proposed Changes

* Rename the header title from "Image Editor" to "Jetpack Image Editor"
* Remove the "Beta" badge from the header

## Why are these changes being made?

The Image Editor currently feels like a WordPress core feature because Jetpack branding is not visible. Adding "Jetpack" to the title makes it clear the feature is provided by Jetpack.

<img width="4096" height="1856" alt="CleanShot 2026-04-14 at 22 48 07@2x" src="https://github.com/user-attachments/assets/69514234-6c50-43f5-856a-41eb203953d5" />

## Testing Instructions
* Sandbox your test WPCOM site and perform `install-plugin.sh agents-manager forno-339-rename-image-editor-to-jetpack-image-editor`
* Open the Image Studio modal (via "Edit with AI" on any image or the Generate flow)
* Verify the header in the top-left reads "Jetpack Image Editor" without a "Beta" badge

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)