### PR TITLE
Add performance and connection data to tracks

### DIFF
--- a/client/lib/analytics/super-props.js
+++ b/client/lib/analytics/super-props.js
@@ -1,3 +1,4 @@
+import { getWebVitalsProps } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { shouldReportOmitBlogId } from 'calypso/lib/analytics/utils';
 import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
@@ -26,6 +27,7 @@ const getSuperProps = ( reduxStore ) => ( eventProperties ) => {
 		Object.assign( superProps, {
 			vph: window.innerHeight,
 			vpw: window.innerWidth,
+			...getWebVitalsProps(),
 		} );
 	}
 

--- a/client/lib/analytics/super-props.js
+++ b/client/lib/analytics/super-props.js
@@ -1,4 +1,4 @@
-import { getWebVitalsProps } from '@automattic/calypso-analytics';
+import { getConnectionSpeedData } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { shouldReportOmitBlogId } from 'calypso/lib/analytics/utils';
 import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
@@ -27,7 +27,7 @@ const getSuperProps = ( reduxStore ) => ( eventProperties ) => {
 		Object.assign( superProps, {
 			vph: window.innerHeight,
 			vpw: window.innerWidth,
-			...getWebVitalsProps(),
+			...getConnectionSpeedData(),
 		} );
 	}
 

--- a/packages/calypso-analytics/src/index.ts
+++ b/packages/calypso-analytics/src/index.ts
@@ -31,6 +31,6 @@ export {
 	recordTrainTracksInteract,
 	getNewRailcarId,
 } from './train-tracks';
-export { getWebVitalsProps } from './utils/web-vitals';
+export { getConnectionSpeedData } from './utils/connection-speed-data';
 
 export type { Railcar } from './train-tracks';

--- a/packages/calypso-analytics/src/index.ts
+++ b/packages/calypso-analytics/src/index.ts
@@ -31,5 +31,6 @@ export {
 	recordTrainTracksInteract,
 	getNewRailcarId,
 } from './train-tracks';
+export { getWebVitalsProps } from './utils/web-vitals';
 
 export type { Railcar } from './train-tracks';

--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -4,11 +4,11 @@ import { EventEmitter } from 'events';
 import { loadScript } from '@automattic/load-script';
 import cookie from 'cookie';
 import { getPageViewParams } from './page-view-params';
+import { getConnectionSpeedData } from './utils/connection-speed-data';
 import { getCurrentUser, setCurrentUser } from './utils/current-user';
 import debug from './utils/debug';
 import getDoNotTrack from './utils/do-not-track';
 import getTrackingPrefs from './utils/get-tracking-prefs';
-import { getWebVitalsProps } from './utils/web-vitals';
 
 declare global {
 	interface Window {
@@ -353,7 +353,7 @@ export function getGenericSuperPropsGetter( config: ( key: string ) => string ) 
 			Object.assign( superProps, {
 				vph: window.innerHeight,
 				vpw: window.innerWidth,
-				...getWebVitalsProps(),
+				...getConnectionSpeedData(),
 			} );
 		}
 

--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -8,6 +8,7 @@ import { getCurrentUser, setCurrentUser } from './utils/current-user';
 import debug from './utils/debug';
 import getDoNotTrack from './utils/do-not-track';
 import getTrackingPrefs from './utils/get-tracking-prefs';
+import { getWebVitalsProps } from './utils/web-vitals';
 
 declare global {
 	interface Window {
@@ -352,6 +353,7 @@ export function getGenericSuperPropsGetter( config: ( key: string ) => string ) 
 			Object.assign( superProps, {
 				vph: window.innerHeight,
 				vpw: window.innerWidth,
+				...getWebVitalsProps(),
 			} );
 		}
 

--- a/packages/calypso-analytics/src/utils/connection-speed-data.ts
+++ b/packages/calypso-analytics/src/utils/connection-speed-data.ts
@@ -76,7 +76,7 @@ function init(): void {
  * - `net_rtt`             — whichever is available, connection preferred
  * - `net_downlink`        — from `navigator.connection.downlink`
  */
-export function getWebVitalsProps(): ConnectionProps {
+export function getConnectionSpeedData(): ConnectionProps {
 	return props;
 }
 

--- a/packages/calypso-analytics/src/utils/web-vitals.ts
+++ b/packages/calypso-analytics/src/utils/web-vitals.ts
@@ -107,13 +107,12 @@ function init(): void {
 }
 
 /**
- * Lazily initializes Performance Observer collectors on first call and
- * returns the current snapshot of web-vital metrics plus connection info.
+ * Returns the current snapshot of web-vital metrics and connection info.
  *
- * Safe to call during SSR — returns an empty object on the server.
- * Values populate progressively: TTFB and FCP are available immediately,
- * LCP and CLS arrive via observers and update the same cached object,
- * so every subsequent event gets the latest readings.
+ * Observers are started eagerly at module load (guarded by `typeof window`
+ * so SSR gets an empty object).  TTFB and FCP are available immediately;
+ * LCP and CLS arrive asynchronously via PerformanceObserver and update the
+ * same cached object, so every subsequent call reflects the latest readings.
  */
 export function getWebVitalsProps(): WebVitalsProps {
 	return vitals;

--- a/packages/calypso-analytics/src/utils/web-vitals.ts
+++ b/packages/calypso-analytics/src/utils/web-vitals.ts
@@ -1,0 +1,122 @@
+declare global {
+	interface NavigatorConnection {
+		rtt?: number;
+		downlink?: number;
+		effectiveType?: string;
+	}
+
+	interface Navigator {
+		connection?: NavigatorConnection;
+	}
+}
+
+interface WebVitalsProps {
+	perf_ttfb?: number;
+	perf_fcp?: number;
+	perf_lcp?: number;
+	perf_cls?: number;
+	net_rtt?: number;
+	net_downlink?: number;
+}
+
+const vitals: WebVitalsProps = {};
+let initialized = false;
+
+function collectNavigationMetrics(): void {
+	const [ nav ] = performance.getEntriesByType( 'navigation' ) as PerformanceNavigationTiming[];
+	if ( nav ) {
+		vitals.perf_ttfb = Math.round( nav.responseStart );
+	}
+
+	const fcp = performance
+		.getEntriesByType( 'paint' )
+		.find( ( e ) => e.name === 'first-contentful-paint' );
+	if ( fcp ) {
+		vitals.perf_fcp = Math.round( fcp.startTime );
+	}
+}
+
+function observeLCP(): void {
+	new PerformanceObserver( ( list ) => {
+		const entries = list.getEntries();
+		const last = entries[ entries.length - 1 ];
+		if ( last ) {
+			vitals.perf_lcp = Math.round( last.startTime );
+		}
+	} ).observe( { type: 'largest-contentful-paint', buffered: true } );
+}
+
+function observeCLS(): void {
+	let clsValue = 0;
+	new PerformanceObserver( ( list ) => {
+		for ( const entry of list.getEntries() as ( PerformanceEntry & {
+			hadRecentInput: boolean;
+			value: number;
+		} )[] ) {
+			if ( ! entry.hadRecentInput ) {
+				clsValue += entry.value;
+			}
+		}
+		vitals.perf_cls = Math.round( clsValue * 1000 ) / 1000;
+	} ).observe( { type: 'layout-shift', buffered: true } );
+}
+
+function snapshotConnection(): void {
+	const conn = navigator.connection;
+	if ( ! conn ) {
+		return;
+	}
+	if ( typeof conn.rtt === 'number' ) {
+		vitals.net_rtt = conn.rtt;
+	}
+	if ( typeof conn.downlink === 'number' ) {
+		vitals.net_downlink = conn.downlink;
+	}
+}
+
+function init(): void {
+	if ( initialized || typeof window === 'undefined' ) {
+		return;
+	}
+	initialized = true;
+
+	try {
+		collectNavigationMetrics();
+	} catch {
+		// Navigation/Paint Timing not supported.
+	}
+
+	if ( typeof PerformanceObserver !== 'undefined' ) {
+		try {
+			observeLCP();
+		} catch {
+			// LCP observation not supported.
+		}
+		try {
+			observeCLS();
+		} catch {
+			// Layout Shift observation not supported.
+		}
+	}
+
+	try {
+		snapshotConnection();
+	} catch {
+		// Network Information API not supported.
+	}
+}
+
+/**
+ * Lazily initializes Performance Observer collectors on first call and
+ * returns the current snapshot of web-vital metrics plus connection info.
+ *
+ * Safe to call during SSR — returns an empty object on the server.
+ * Values populate progressively: TTFB and FCP are available immediately,
+ * LCP and CLS arrive via observers and update the same cached object,
+ * so every subsequent event gets the latest readings.
+ */
+export function getWebVitalsProps(): WebVitalsProps {
+	return vitals;
+}
+
+init();

--- a/packages/calypso-analytics/src/utils/web-vitals.ts
+++ b/packages/calypso-analytics/src/utils/web-vitals.ts
@@ -2,7 +2,6 @@ declare global {
 	interface NavigatorConnection {
 		rtt?: number;
 		downlink?: number;
-		effectiveType?: string;
 	}
 
 	interface Navigator {
@@ -10,68 +9,36 @@ declare global {
 	}
 }
 
-interface WebVitalsProps {
-	perf_ttfb?: number;
-	perf_fcp?: number;
-	perf_lcp?: number;
-	perf_cls?: number;
+interface ConnectionProps {
 	net_rtt?: number;
+	net_rtt_connection?: number;
+	net_rtt_estimated?: number;
 	net_downlink?: number;
 }
 
-const vitals: WebVitalsProps = {};
+const props: ConnectionProps = {};
 let initialized = false;
 
-function collectNavigationMetrics(): void {
-	const [ nav ] = performance.getEntriesByType( 'navigation' ) as PerformanceNavigationTiming[];
-	if ( nav ) {
-		vitals.perf_ttfb = Math.round( nav.responseStart );
+/**
+ * Approximates RTT from Navigation Timing when the Network Information API
+ * is unavailable (Firefox, Safari).  Uses `responseStart − requestStart`
+ * which includes server processing time, so it over-estimates slightly.
+ * Tries the Level 2 PerformanceNavigationTiming entry first, then falls
+ * back to the deprecated Level 1 `performance.timing` object.
+ */
+function estimateRttFromNavTiming(): number | undefined {
+	const navEntries = performance.getEntriesByType( 'navigation' ) as PerformanceNavigationTiming[];
+	if ( navEntries.length && navEntries[ 0 ].requestStart > 0 ) {
+		return Math.round( navEntries[ 0 ].responseStart - navEntries[ 0 ].requestStart );
 	}
 
-	const fcp = performance
-		.getEntriesByType( 'paint' )
-		.find( ( e ) => e.name === 'first-contentful-paint' );
-	if ( fcp ) {
-		vitals.perf_fcp = Math.round( fcp.startTime );
+	// Navigation Timing Level 1 fallback (deprecated but widely supported).
+	const timing = performance.timing;
+	if ( timing && timing.requestStart > 0 ) {
+		return Math.round( timing.responseStart - timing.requestStart );
 	}
-}
 
-function observeLCP(): void {
-	new PerformanceObserver( ( list ) => {
-		const entries = list.getEntries();
-		const last = entries[ entries.length - 1 ];
-		if ( last ) {
-			vitals.perf_lcp = Math.round( last.startTime );
-		}
-	} ).observe( { type: 'largest-contentful-paint', buffered: true } );
-}
-
-function observeCLS(): void {
-	let clsValue = 0;
-	new PerformanceObserver( ( list ) => {
-		for ( const entry of list.getEntries() as ( PerformanceEntry & {
-			hadRecentInput: boolean;
-			value: number;
-		} )[] ) {
-			if ( ! entry.hadRecentInput ) {
-				clsValue += entry.value;
-			}
-		}
-		vitals.perf_cls = Math.round( clsValue * 1000 ) / 1000;
-	} ).observe( { type: 'layout-shift', buffered: true } );
-}
-
-function snapshotConnection(): void {
-	const conn = navigator.connection;
-	if ( ! conn ) {
-		return;
-	}
-	if ( typeof conn.rtt === 'number' ) {
-		vitals.net_rtt = conn.rtt;
-	}
-	if ( typeof conn.downlink === 'number' ) {
-		vitals.net_downlink = conn.downlink;
-	}
+	return undefined;
 }
 
 function init(): void {
@@ -81,41 +48,36 @@ function init(): void {
 	initialized = true;
 
 	try {
-		collectNavigationMetrics();
-	} catch {
-		// Navigation/Paint Timing not supported.
-	}
-
-	if ( typeof PerformanceObserver !== 'undefined' ) {
-		try {
-			observeLCP();
-		} catch {
-			// LCP observation not supported.
+		const conn = navigator.connection;
+		if ( conn ) {
+			if ( typeof conn.rtt === 'number' ) {
+				props.net_rtt_connection = conn.rtt;
+			}
+			if ( typeof conn.downlink === 'number' ) {
+				props.net_downlink = conn.downlink;
+			}
 		}
-		try {
-			observeCLS();
-		} catch {
-			// Layout Shift observation not supported.
-		}
-	}
 
-	try {
-		snapshotConnection();
+		props.net_rtt_estimated = estimateRttFromNavTiming();
+		props.net_rtt = props.net_rtt_connection ?? props.net_rtt_estimated;
 	} catch {
-		// Network Information API not supported.
+		// Network / Navigation Timing APIs not supported.
 	}
 }
 
 /**
- * Returns the current snapshot of web-vital metrics and connection info.
+ * Returns cached connection quality metrics.
  *
- * Observers are started eagerly at module load (guarded by `typeof window`
- * so SSR gets an empty object).  TTFB and FCP are available immediately;
- * LCP and CLS arrive asynchronously via PerformanceObserver and update the
- * same cached object, so every subsequent call reflects the latest readings.
+ * Collected eagerly at module load (guarded by `typeof window` so SSR
+ * gets an empty object).
+ *
+ * - `net_rtt_connection`  — from `navigator.connection.rtt` (Chromium only)
+ * - `net_rtt_estimated`   — approximated from Navigation Timing
+ * - `net_rtt`             — whichever is available, connection preferred
+ * - `net_downlink`        — from `navigator.connection.downlink`
  */
-export function getWebVitalsProps(): WebVitalsProps {
-	return vitals;
+export function getWebVitalsProps(): ConnectionProps {
+	return props;
 }
 
 init();


### PR DESCRIPTION
Fixes DOTCOM-16700

## Proposed Changes

- Add a new `web-vitals.ts` utility to `@automattic/calypso-analytics` that collects Core Web Vitals (TTFB, FCP, LCP, CLS) and `navigator.connection` metrics (RTT, downlink) using native browser APIs.
- Wire the collected props into both super-props paths — `getGenericSuperPropsGetter` (subscriptions/standalone clients) and Calypso's Redux-based `getSuperProps`. **This adds them to every event. Like screen size, language, and user agent**, I would appreciate some feedback on this.

## Why are these changes being made?

We currently have no per-event visibility into client performance context. By attaching web vitals and connection quality as super props (the same pattern used for `vph`/`vpw`), we enable analysis like "do users on slow connections abandon checkout more?"

## Testing Instructions

- Start the dev server (`yarn start`) and open the browser console.
- Trigger any Tracks event (e.g. navigate to a page).
- Inspect the `_tkq` queue or the pixel request to verify `perf_ttfb`, `perf_fcp`, `perf_lcp`, `perf_cls` props are present.
  - `perf_ttfb` and `perf_fcp` should appear on the first event after page load.
  - `perf_lcp` appears once the browser reports it (usually after first interaction).
  - `perf_cls` accumulates and updates as layout shifts occur.
- In Chrome DevTools, verify `net_rtt` and `net_downlink` are included (these rely on the Network Information API, which is Chromium-only).
