### PR TITLE
Image Studio: Scope nav pill to uploads page, fix header spacing

### DIFF
--- a/packages/image-studio/src/components/header/index.test.tsx
+++ b/packages/image-studio/src/components/header/index.test.tsx
@@ -137,21 +137,41 @@ describe( 'Header', () => {
 			expect( screen.getByText( 'Jetpack Image Editor' ) ).toBeInTheDocument();
 		} );
 
-		it( 'renders navigation pill in Edit mode with filename', () => {
-			render( <Header { ...defaultProps } mode={ ImageStudioMode.Edit } /> );
+		describe( 'navigation pill', () => {
+			const originalPagenow = ( window as any ).pagenow;
 
-			expect( screen.getByText( 'test-image.jpg' ) ).toBeInTheDocument();
-		} );
+			afterEach( () => {
+				( window as any ).pagenow = originalPagenow;
+			} );
 
-		it( 'does not render navigation pill when filename is missing', () => {
-			const propsWithoutFilename = {
-				...defaultProps,
-				config: {},
-			};
+			it( 'renders in Edit mode with filename on the uploads page', () => {
+				( window as any ).pagenow = 'upload';
 
-			render( <Header { ...propsWithoutFilename } mode={ ImageStudioMode.Edit } /> );
+				render( <Header { ...defaultProps } mode={ ImageStudioMode.Edit } /> );
 
-			expect( screen.queryByText( 'test-image.jpg' ) ).not.toBeInTheDocument();
+				expect( screen.getByText( 'test-image.jpg' ) ).toBeInTheDocument();
+			} );
+
+			it( 'does not render when filename is missing', () => {
+				( window as any ).pagenow = 'upload';
+
+				const propsWithoutFilename = {
+					...defaultProps,
+					config: {},
+				};
+
+				render( <Header { ...propsWithoutFilename } mode={ ImageStudioMode.Edit } /> );
+
+				expect( screen.queryByText( 'test-image.jpg' ) ).not.toBeInTheDocument();
+			} );
+
+			it( 'does not render when not on the uploads page', () => {
+				( window as any ).pagenow = 'post';
+
+				render( <Header { ...defaultProps } mode={ ImageStudioMode.Edit } /> );
+
+				expect( screen.queryByText( 'test-image.jpg' ) ).not.toBeInTheDocument();
+			} );
 		} );
 
 		it( 'renders toolbar in Edit mode', () => {
@@ -473,6 +493,16 @@ describe( 'Header', () => {
 	} );
 
 	describe( 'Navigation', () => {
+		const originalPagenow = ( window as any ).pagenow;
+
+		beforeEach( () => {
+			( window as any ).pagenow = 'upload';
+		} );
+
+		afterEach( () => {
+			( window as any ).pagenow = originalPagenow;
+		} );
+
 		it( 'calls onNavigatePrevious when previous button is clicked', async () => {
 			const onNavigatePrevious = jest.fn();
 			const user = userEvent.setup();

--- a/packages/image-studio/src/components/header/index.tsx
+++ b/packages/image-studio/src/components/header/index.tsx
@@ -98,8 +98,9 @@ export const Header = ( {
 
 	const showTools = mode === ImageStudioMode.Edit;
 	const showTitle = mode === ImageStudioMode.Generate;
-	// Always show navigation pill in Edit mode if we have a filename to display
-	const showNavigationPill = mode === ImageStudioMode.Edit && !! config?.imageData?.filename;
+	// Show navigation pill in Edit mode on uploads page, if we have a filename to display
+	const showNavigationPill =
+		mode === ImageStudioMode.Edit && !! config?.imageData?.filename && window.pagenow === 'upload';
 
 	// Generate classic editor URL if we have an attachment ID
 	const classicEditorUrl = config?.attachmentId

--- a/packages/image-studio/src/components/header/style.scss
+++ b/packages/image-studio/src/components/header/style.scss
@@ -179,6 +179,8 @@
 		align-items: center;
 		gap: 10px;
 		color: #f0f0f0;
+		margin: 0;
+		padding: 0;
 
 		@media ($breakpoint-medium-down) {
 			@include visually-hidden();


### PR DESCRIPTION
Part of FORNO-340

## Proposed Changes

* Only render the Edit-mode navigation pill when `window.pagenow === 'upload'`, in addition to the existing `filename` check.
* Zero out margin/padding on the title row in the header to fix vertical alignment.

<table><tr>
<td>
Post editor
</td>
<td>
Media Library
</td>
</tr>
<tr>
<td>
<img width="1686" height="1027" alt="Screenshot 2026-04-15 at 14 04 57" src="https://github.com/user-attachments/assets/f9bbc624-12fd-4385-87ac-f6b43cff877b" />
</td>
<td>
<img width="1684" height="1026" alt="Screenshot 2026-04-15 at 14 05 18" src="https://github.com/user-attachments/assets/2fd215d8-3469-4eb3-b4d5-0faad0991a57" />
</td>
</tr>
</table>

## Why are these changes being made?

We already only support navigating between images via the header pill when the Image Studio is opened from the Media Library. Currently we constrain navigation by disabling the next / previous buttons in the pill. However this may confuse some users. With the ability to navigate disabled, the pill's only purpose is to display the file name, however the title will often be truncated which reduces the benefit of this. The full file name is also shown in the Image Info panel.

## Testing Instructions

- `install-plugin.sh am image-studio-header-fixes` on your sandbox
- Sandbox `widgets.wp.com`
* Open Image Studio from the WP Media Library (uploads screen) in Edit mode with a filename present → the navigation pill should appear.
* Open Image Studio from any other surface (e.g. post editor, Jetpack AI flows) in Edit mode → the navigation pill should NOT appear.
* Check header vertical alignment in both Edit and Generate modes.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?