### PR TITLE
Support CMUX_PORT and CONDUCTOR_PORT as port fallbacks

### DIFF
--- a/client/server/config/parser.js
+++ b/client/server/config/parser.js
@@ -60,7 +60,7 @@ module.exports = function ( configPath, defaultOpts ) {
 	// `protocol`, `hostname` and `port` config values can be overridden by env variables
 	data.protocol = process.env.PROTOCOL || data.protocol;
 	data.hostname = process.env.HOST || data.hostname;
-	data.port = process.env.PORT || data.port;
+	data.port = process.env.PORT || process.env.CMUX_PORT || process.env.CONDUCTOR_PORT || data.port;
 
 	const serverData = Object.assign( {}, data, getDataFromFile( secretsPath ) );
 	const clientData = Object.assign( {}, data );

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -4,6 +4,14 @@ import './load-env';
 import { defineConfig, devices, type ReporterDescription } from 'playwright/test';
 import { tags, type CustomOptions } from './lib/pw-base';
 
+const port = process.env.PORT || process.env.CMUX_PORT || process.env.CONDUCTOR_PORT;
+if ( port && ! process.env.CALYPSO_BASE_URL ) {
+	process.env.CALYPSO_BASE_URL = `http://calypso.localhost:${ port }`;
+}
+if ( port && ! process.env.DASHBOARD_BASE_URL ) {
+	process.env.DASHBOARD_BASE_URL = `http://my.localhost:${ port }`;
+}
+
 /**
  * Creates a use config object with custom options.
  * This helper exists to provide type safety for our custom Playwright options.


### PR DESCRIPTION
Part of #109963

## Proposed Changes

- Add `CMUX_PORT` and `CONDUCTOR_PORT` as fallbacks when resolving the server port in the config parser (`PORT || CMUX_PORT || CONDUCTOR_PORT || config default`)
- In the Playwright E2E config, derive `CALYPSO_BASE_URL` and `DASHBOARD_BASE_URL` from the resolved port when not explicitly set

## Why are these changes being made?

Cmux and conductor assign each session its own port via `CMUX_PORT` / `CONDUCTOR_PORT`. Respecting these env vars lets developers run a separate Calypso instance per session without manually setting `PORT`, unlocking the multi-session workflows these multiplexers are designed for.

## Testing Instructions

- Set `CMUX_PORT=4321` (without setting `PORT`) and run `yarn start`
- Verify the server listens on port 4321
- Verify `config('port')` returns `4321`
- Same for `CONDUCTOR_PORT=5555`
- Verify `PORT` still takes priority over both

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?