### PR TITLE
Reader: Fix cannot read from null error

### DIFF
--- a/client/blocks/reader-full-post/header-meta.jsx
+++ b/client/blocks/reader-full-post/header-meta.jsx
@@ -17,7 +17,7 @@ const ReaderFullPostHeaderMeta = ( { post, author, siteName, feedId, siteId } ) 
 		areEqualIgnoringWhitespaceAndCase( String( siteName ), String( author?.name ) );
 	const showAuthorLink = hasAuthorName && ! hasMatchingAuthorAndSiteNames;
 	const avatarUrl =
-		! author.avatar_URL && post.is_external ? feed?.site_icon || feed?.image : author?.avatar_URL;
+		! author?.avatar_URL && post.is_external ? feed?.site_icon || feed?.image : author?.avatar_URL;
 
 	return (
 		<div className="reader-full-post__header-meta-wrapper">


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related: https://github.com/Automattic/wp-calypso/pull/109895

## Proposed Changes

In some cases RSS feeds sends `null` as author which is causing app to crash so this fixes it.