### PR TITLE
Signup: Fix woo-hosting-solutions-flow regressions

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -121,7 +121,7 @@ const onboarding: FlowV2< typeof initialize > = {
 				];
 			}
 
-			if ( refParameter === WOO_HOSTING_SOLUTIONS_REF ) {
+			if ( refParameter === WOO_HOSTING_SOLUTIONS_REF && providedDependencies.siteSlug ) {
 				const siteSlug = providedDependencies.siteSlug as string;
 				const site = await resolveSelect( SITE_STORE ).getSite( siteSlug );
 				const adminUrl = site?.options?.admin_url ?? `https://${ siteSlug }/wp-admin/`;

--- a/client/landing/stepper/declarative-flow/internals/analytics/record-step-start.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-step-start.ts
@@ -1,5 +1,8 @@
 import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
-import { STEPPER_TRACKS_EVENT_SIGNUP_STEP_START } from 'calypso/landing/stepper/constants';
+import {
+	STEPPER_TRACKS_EVENT_SIGNUP_STEP_START,
+	WOO_HOSTING_SOLUTIONS_REF,
+} from 'calypso/landing/stepper/constants';
 import { getVisualSplitPlansIntent } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
@@ -9,7 +12,10 @@ const recordStepStart = (
 	optionalProps?: { [ key: string ]: unknown }
 ) => {
 	const search = new URLSearchParams( window.location.search );
-	const plansIntent = getVisualSplitPlansIntent( search.get( 'intent' ) );
+	const plansIntent =
+		search.get( 'ref' ) === WOO_HOSTING_SOLUTIONS_REF
+			? 'plans-woo-hosting-solutions'
+			: getVisualSplitPlansIntent( search.get( 'intent' ) );
 
 	recordTracksEvent( STEPPER_TRACKS_EVENT_SIGNUP_STEP_START, {
 		flow,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -67,11 +67,11 @@ function getPlansIntent( flowName: string | null ): PlansIntent | null {
 			if ( search.has( 'playground' ) ) {
 				return playgroundPlansIntent( search.get( 'playground' )! );
 			}
-			if ( search.has( 'intent' ) ) {
-				return getVisualSplitPlansIntent( search.get( 'intent' )! );
-			}
 			if ( search.get( 'ref' ) === WOO_HOSTING_SOLUTIONS_REF ) {
 				return 'plans-woo-hosting-solutions';
+			}
+			if ( search.has( 'intent' ) ) {
+				return getVisualSplitPlansIntent( search.get( 'intent' )! );
 			}
 			break;
 		case ONBOARDING_UNIFIED_FLOW:

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-plugin-install/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-plugin-install/index.tsx
@@ -61,12 +61,13 @@ const WaitForPluginInstall: StepType = function WaitForAtomic( { navigation, dat
 		}
 
 		setPendingAction( async () => {
+			const totalTimeoutSeconds = 300;
 			try {
 				await waitForPluginsActive( siteId as number, pluginsToVerify );
 			} catch ( err ) {
 				handlePluginCheckFailure( {
 					type: 'plugin_check_timeout',
-					error: ( err as Error ).message,
+					error: `plugin check took too long (${ totalTimeoutSeconds }s))`,
 					code: 'plugin_check_timeout',
 				} );
 				throw err;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-plugin-install/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-plugin-install/index.tsx
@@ -63,7 +63,9 @@ const WaitForPluginInstall: StepType = function WaitForAtomic( { navigation, dat
 		setPendingAction( async () => {
 			const totalTimeoutSeconds = 300;
 			try {
-				await waitForPluginsActive( siteId as number, pluginsToVerify );
+				await waitForPluginsActive( siteId as number, pluginsToVerify, {
+					totalTimeoutSeconds,
+				} );
 			} catch ( err ) {
 				handlePluginCheckFailure( {
 					type: 'plugin_check_timeout',

--- a/client/landing/stepper/utils/wait-for-plugins-active.ts
+++ b/client/landing/stepper/utils/wait-for-plugins-active.ts
@@ -10,10 +10,11 @@ const wait = ( ms: number ) => new Promise( ( res ) => setTimeout( res, ms ) );
  */
 export const waitForPluginsActive = async (
 	siteId: number,
-	pluginsToVerify: string[] | undefined
+	pluginsToVerify: string[] | undefined,
+	{ totalTimeoutSeconds = 300 }: { totalTimeoutSeconds?: number } = {}
 ): Promise< void > => {
 	const startTime = new Date().getTime();
-	const totalTimeout = 1000 * 300;
+	const totalTimeout = 1000 * totalTimeoutSeconds;
 	const maxFinishTime = startTime + totalTimeout;
 
 	// Poll for transfer status. If there are no plugins to verify, we can skip this step.
@@ -44,7 +45,7 @@ export const waitForPluginsActive = async (
 		}
 
 		if ( maxFinishTime <= new Date().getTime() ) {
-			throw new Error( `plugin check timeout exceeded ${ totalTimeout / 1000 }s` );
+			throw new Error( `plugin check timeout exceeded ${ totalTimeoutSeconds }s` );
 		}
 
 		backoffTime *= 2;


### PR DESCRIPTION
Part of #

Follow-up to #109981.

## Proposed Changes

* **unified-plans**: Check the `ref=woo-hosting-solutions-flow` branch *before* the generic `intent=` branch in `getPlansIntent`, so URLs that carry both params still resolve to the Woo plans intent.
* **record-step-start**: Attribute `plans_intent` to `plans-woo-hosting-solutions` when the Woo ref is present, instead of falling through to `default`.
* **onboarding post-checkout destination**: Guard the Woo redirect on a present `siteSlug` to avoid constructing `https://undefined/wp-admin/...` when the dependency is missing.
* **wait-for-plugin-install**: Restore the original Logstash `error` string (`plugin check took too long (300s))`) so any dashboards/alerts keyed on that exact message keep matching after the helper extraction.

## Why are these changes being made?

Regressions found during review of #109981:

1. The stepper preserves query params across steps, so any inbound link combining `ref=woo-hosting-solutions-flow` with an existing `intent=` param (common from marketing/experiment URLs) produced a split-brain state: full plan grid at checkout, but Woo-only post-checkout pipeline afterward.
2. `record-step-start` derives `plans_intent` only from `?intent=`, so the entire woo-hosting-solutions funnel was mislabeled as `default` in Tracks, breaking launch measurement.
3. `providedDependencies.siteSlug as string` had no guard; a missing slug produced a broken redirect URL.
4. The helper refactor changed the Logstash `error` field string from `plugin check took too long (300s))` to `plugin check timeout exceeded 300s`, which would silently break any alerting keyed on the old wording.

## Testing Instructions

* Visit `/start?ref=woo-hosting-solutions-flow&intent=default_hosting`. Plans step displays only Business + Commerce plans (previously would have shown the default hosting intent set).
* Check Tracks `calypso_signup_step_start` events while in the Woo ref flow — `plans_intent` should report `plans-woo-hosting-solutions` (previously `default`).
* Regression: visiting `/start?intent=default_hosting` without the Woo ref still routes to the default-hosting plans intent.
* Regression: visiting `/start?ref=woo-hosting-solutions-flow` still completes the existing post-checkout Woo auto-install and lands on `wc-admin`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?

🤖 Generated with [Claude Code](https://claude.com/claude-code)