### PR TITLE
Fix: Only show domain-only thank you page for actual domain-only flows

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -636,7 +636,11 @@ export class CheckoutThankYou extends Component<
 						/>
 					</>
 				);
-			} else if ( this.props.receipt.data && isOnlyDomainPurchases( purchases ) ) {
+			} else if (
+				this.props.receipt.data &&
+				isOnlyDomainPurchases( purchases ) &&
+				this.props.domainOnlySiteFlow
+			) {
 				if ( domainPurchases.length > 1 ) {
 					const domainsUrl = this.props.hasDashboardOptIn
 						? dashboardLink( '/domains' )

--- a/client/my-sites/checkout/checkout-thank-you/test/index.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/index.js
@@ -44,6 +44,11 @@ jest.mock( '../redesign-v2/pages/plan-only', () => () => (
 jest.mock( '../redesign-v2/pages/generic', () => () => (
 	<div data-testid="component--generic-thank-you" />
 ) );
+// eslint-disable-next-line react/display-name
+jest.mock( '../redesign-v2/pages/domain-only', () => ( {
+	__esModule: true,
+	default: () => <div data-testid="component--domain-only-thank-you" />,
+} ) );
 
 const translate = ( x ) => x;
 
@@ -165,5 +170,52 @@ describe( 'CheckoutThankYou', () => {
 		);
 
 		expect( await screen.getByTestId( 'component--plan-only-thank-you' ) ).toBeInTheDocument();
+	} );
+
+	describe( 'domain-only page', () => {
+		const props = {
+			...defaultProps,
+			receiptId: 12,
+			receipt: {
+				hasLoadedFromServer: true,
+				data: {
+					purchases: [
+						{
+							isDomainRegistration: true,
+							productSlug: 'dotcom_domain',
+							productType: 'domain',
+							meta: 'example.com',
+							blogId: 123,
+							isHundredYearDomain: false,
+							delayedProvisioning: false,
+						},
+					],
+					failedPurchases: [],
+					currency: 'USD',
+				},
+			},
+			refreshSitePlans: () => {},
+		};
+
+		it( 'renders the DomainOnly page when purchasing a domain in a domain-only site flow', () => {
+			render(
+				<Provider store={ store }>
+					<CheckoutThankYou { ...props } domainOnlySiteFlow />
+				</Provider>
+			);
+
+			expect( screen.getByTestId( 'component--domain-only-thank-you' ) ).toBeVisible();
+		} );
+
+		it( 'does not render the DomainOnly page when purchasing a domain outside a domain-only site flow', () => {
+			render(
+				<Provider store={ store }>
+					<CheckoutThankYou { ...props } domainOnlySiteFlow={ false } />
+				</Provider>
+			);
+
+			expect( screen.queryByTestId( 'component--domain-only-thank-you' ) ).not.toBeInTheDocument();
+			expect( screen.getByTestId( 'component--generic-thank-you' ) ).toBeVisible();
+		} );
 	} );
 } );


### PR DESCRIPTION
Fixes CHE-472

## Summary

Fixes a regression where domain purchases on existing sites were incorrectly showing the domain-only thank-you page with options like "Start a new site", "Add a mailbox", "Attach to an existing site", etc.

## Problem

When a user purchases a domain for an existing site (e.g., from `wordpress.com/domains/add/[site]`), the thank-you page was displaying domain-only options instead of an appropriate page for adding a domain to an existing site.

## Root Cause

Commit [ac75c80c6a4](https://github.com/Automattic/wp-calypso/commit/ac75c80c6a4e66af015aa7ff932cbf4ddbdd043b) (Feb 19, 2026) removed a feature flag check that distinguished between:
- Domain-only flows → show `DomainOnly` component with site creation options
- Domain on existing site → show appropriate thank-you page

When the feature flag was removed, the code lost the ability to distinguish between these cases, causing ALL domain purchases to show the domain-only page.

## The Fix

Added `this.props.domainOnlySiteFlow` check to the condition that renders the `DomainOnly` component:

```typescript
} else if (
    this.props.receipt.data &&
    isOnlyDomainPurchases( purchases ) &&
    this.props.domainOnlySiteFlow  // ← NEW CHECK
) {
```

Now the domain-only thank-you page is only shown for actual domain-only flows, allowing other domain purchases to fall through to appropriate thank-you page components.

## Test Plan

1. Purchase a domain for an existing site (e.g., from `wordpress.com/domains/add/[site]`)
2. Verify the thank-you page does NOT show domain-only options
3. Verify you are redirected to an appropriate thank-you page for domain purchases on existing sites

| Before | After |
|--------|--------|
| <img width="650" height="590" alt="Screenshot 2026-04-15 at 13 27 24" src="https://github.com/user-attachments/assets/b3877a51-0f36-4603-bf54-90b290037810" /> | <img width="608" height="421" alt="Screenshot 2026-04-15 at 13 27 46" src="https://github.com/user-attachments/assets/e4773128-67e5-4da7-b365-0e76420b4374" /> | 
