### PR TITLE
Replace hardcoded port 3000 with dynamic port in dev URLs

### DIFF
--- a/client/blocks/jetpack-connect-site-only/index.js
+++ b/client/blocks/jetpack-connect-site-only/index.js
@@ -25,7 +25,7 @@ class JetpackConnectSiteOnly extends Component {
 		const redirectParams = new URLSearchParams( urlParams.get( 'redirect_to' ) );
 		const purchaseNonce = redirectParams.get( 'purchase_nonce' );
 
-		const port = config( 'port' ) ?? 3000;
+		const port = config( 'port' ) ?? 3001;
 		const url =
 			'development' === calypsoEnv
 				? `http://jetpack.cloud.localhost:${ port }/pricing/${ slug }`

--- a/client/blocks/jetpack-connect-site-only/index.js
+++ b/client/blocks/jetpack-connect-site-only/index.js
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -24,9 +25,10 @@ class JetpackConnectSiteOnly extends Component {
 		const redirectParams = new URLSearchParams( urlParams.get( 'redirect_to' ) );
 		const purchaseNonce = redirectParams.get( 'purchase_nonce' );
 
+		const port = config( 'port' ) ?? 3000;
 		const url =
 			'development' === calypsoEnv
-				? `http://jetpack.cloud.localhost:3001/pricing/${ slug }`
+				? `http://jetpack.cloud.localhost:${ port }/pricing/${ slug }`
 				: `https://cloud.jetpack.com/pricing/${ slug }`;
 
 		return addQueryArgs(

--- a/client/dashboard/app-ciab/routing.ts
+++ b/client/dashboard/app-ciab/routing.ts
@@ -36,7 +36,8 @@ export function isAllowedCiabLegacyRoute( path: string = '' ): boolean {
 
 export function buildCiabDashboardLink( path: string = '' ) {
 	if ( config( 'env' ) === 'development' ) {
-		return new URL( path, 'http://my.woo.localhost:3000' ).href;
+		const port = config( 'port' ) ?? 3000;
+		return new URL( path, `http://my.woo.localhost:${ port }` ).href;
 	}
 	return new URL( path, 'https://my.woo.ai' ).href;
 }

--- a/client/dashboard/app-dotcom/routing.ts
+++ b/client/dashboard/app-dotcom/routing.ts
@@ -13,7 +13,8 @@ export function isAllowedDotcomDashboardHostname( hostname?: string ): boolean {
 
 export function buildDotcomDashboardLink( path: string = '' ) {
 	if ( config( 'env' ) === 'development' ) {
-		return new URL( path, 'http://my.localhost:3000' ).href;
+		const port = config( 'port' ) ?? 3000;
+		return new URL( path, `http://my.localhost:${ port }` ).href;
 	}
 	return new URL( path, 'https://my.wordpress.com' ).href;
 }

--- a/client/dashboard/utils/link.ts
+++ b/client/dashboard/utils/link.ts
@@ -6,10 +6,11 @@ import { isDashboardBackport } from './is-dashboard-backport';
  * This function returns all the origins for the dashboard.
  */
 export function dashboardOrigins(): string[] {
+	const port = config( 'port' ) ?? 3000;
 	return [
-		'http://my.localhost:3000',
+		`http://my.localhost:${ port }`,
 		'https://my.wordpress.com',
-		'http://my.woo.localhost:3000',
+		`http://my.woo.localhost:${ port }`,
 		'https://my.woo.ai',
 	];
 }
@@ -45,7 +46,8 @@ export function wpcomLink( path: string ) {
  */
 export function a4aLink( path: string ) {
 	if ( config( 'env' ) === 'development' ) {
-		return new URL( path, 'http://agencies.localhost:3000' ).href;
+		const port = config( 'port' ) ?? 3000;
+		return new URL( path, `http://agencies.localhost:${ port }` ).href;
 	}
 
 	return new URL( path, 'https://agencies.automattic.com' ).href;

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import {
 	PRODUCT_JETPACK_BACKUP_T1_YEARLY,
 	WPCOM_FEATURES_BACKUPS,
@@ -340,10 +341,9 @@ export class JetpackAuthorize extends Component {
 				// The /jetpack/connect/authorize controller requires `redirectAfterAuth` to be a
 				// valid well-formed uri (via validUrl.isWebUri()), so here we are removing the url
 				// host so that it becomes a relative url.
-				redirectAfterAuth.replace(
-					/^(https?:\/\/wordpress\.com|http:\/\/calypso\.localhost:3000)/,
-					''
-				)
+				redirectAfterAuth
+					.replace( /^https?:\/\/wordpress\.com/, '' )
+					.replace( `http://calypso.localhost:${ config( 'port' ) ?? 3000 }`, '' )
 			);
 		} else if ( this.isFromJetpackBackupPlugin() && ! siteHasBackups ) {
 			debug( `Redirecting directly to cart with ${ PRODUCT_JETPACK_BACKUP_T1_YEARLY } in cart.` );

--- a/client/my-sites/plans/jetpack-plans/get-purchase-url-callback.ts
+++ b/client/my-sites/plans/jetpack-plans/get-purchase-url-callback.ts
@@ -1,4 +1,5 @@
 import { getCurrentUser, getTracksAnonymousUserId } from '@automattic/calypso-analytics';
+import config from '@automattic/calypso-config';
 import {
 	PRODUCT_JETPACK_SEARCH,
 	PRODUCT_JETPACK_SEARCH_MONTHLY,
@@ -55,9 +56,10 @@ export function buildCheckoutURL(
 		}
 	}
 	// host maybe needed in either siteless or userless checkout below
+	const port = config( 'port' ) ?? 3000;
 	const host =
 		'development' === urlQueryArgs.calypso_env
-			? 'http://calypso.localhost:3000'
+			? `http://calypso.localhost:${ port }`
 			: 'https://wordpress.com';
 
 	// siteless checkout

--- a/client/server/config/index.js
+++ b/client/server/config/index.js
@@ -1,5 +1,5 @@
 const configPath = require( 'path' ).resolve( __dirname, '..', '..', '..', 'config' );
-const { default: createConfig } = require( '@automattic/create-calypso-config' );
+const { default: createConfig, resolveTemplates } = require( '@automattic/create-calypso-config' );
 const parser = require( './parser' );
 
 const { serverData, clientData } = parser( configPath, {
@@ -9,4 +9,4 @@ const { serverData, clientData } = parser( configPath, {
 } );
 
 module.exports = createConfig( serverData );
-module.exports.clientData = clientData;
+module.exports.clientData = resolveTemplates( clientData );

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -17,7 +17,7 @@
 	"port": 3000,
 	"wpcom_signup_id": "39911",
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
-	"wpcom_url": "http://calypso.localhost:3000",
+	"wpcom_url": "http://calypso.localhost:{{port}}",
 	"wpcom_login_url": "https://wordpress.com/log-in",
 	"features": {
 		"calypso/ai-site-builder-flow": true,

--- a/config/development.json
+++ b/config/development.json
@@ -10,7 +10,7 @@
 		"my.woo.localhost": {
 			"oauth_client_id": 134404,
 			"wpcom_login_url": "/connect",
-			"logout_url": "http://my.woo.localhost:3000",
+			"logout_url": "http://my.woo.localhost:{{port}}",
 			"features": { "oauth": true }
 		}
 	},
@@ -27,7 +27,7 @@
 	"theme_color": "#1D2327",
 	"hotjar_enabled": true,
 	"survicate_enabled": true,
-	"wpcom_url": "http://calypso.localhost:3000",
+	"wpcom_url": "http://calypso.localhost:{{port}}",
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",

--- a/packages/calypso-url/src/get-calypso-url.ts
+++ b/packages/calypso-url/src/get-calypso-url.ts
@@ -2,12 +2,14 @@
  * These are the known places that Calypso is allowed to run.
  * Note that https://wordpress.com is not included as it's the default.
  */
-const ALLOWED_ORIGINS = [
-	'https://horizon.wordpress.com',
-	'https://wpcalypso.wordpress.com',
-	'http://calypso.localhost:3000',
-	'https://calypso.localhost:3000',
-];
+const ALLOWED_ORIGINS = [ 'https://horizon.wordpress.com', 'https://wpcalypso.wordpress.com' ];
+
+/**
+ * Checks if the origin is a local Calypso development server on any port.
+ */
+function isCalypsoLocalhost( origin: string ) {
+	return /^https?:\/\/calypso\.localhost(:\d+)?$/.test( origin );
+}
 
 /**
  * Checks if the origin is allowed by checking against ALLOWED_ORIGINS and Calypso Live sites.
@@ -15,7 +17,9 @@ const ALLOWED_ORIGINS = [
  * @returns true if the origin is allowed
  */
 function isAllowedOrigin( origin: string ) {
-	return ALLOWED_ORIGINS.includes( origin ) || isCalypsoLive( origin );
+	return (
+		ALLOWED_ORIGINS.includes( origin ) || isCalypsoLocalhost( origin ) || isCalypsoLive( origin )
+	);
 }
 
 /**

--- a/packages/create-calypso-config/src/index.ts
+++ b/packages/create-calypso-config/src/index.ts
@@ -129,7 +129,39 @@ export interface ConfigApi {
 	disable: ( feature: string ) => void;
 }
 
+/**
+ * Resolves {{key}} templates in config string values using top-level config
+ * values. For example, `"http://calypso.localhost:{{port}}"` becomes
+ * `"http://calypso.localhost:3000"` when `data.port` is `3000`.
+ */
+function resolveTemplates( data: ConfigData ): ConfigData {
+	const resolve = ( value: unknown ): unknown => {
+		if ( typeof value === 'string' && value.includes( '{{' ) ) {
+			return value.replace( /\{\{(\w+)\}\}/g, ( match, key ) =>
+				key in data ? String( data[ key ] ) : match
+			);
+		}
+		if ( typeof value === 'object' && value !== null && ! Array.isArray( value ) ) {
+			const result: Record< string, unknown > = {};
+			for ( const k of Object.keys( value ) ) {
+				result[ k ] = resolve( ( value as Record< string, unknown > )[ k ] );
+			}
+			return result;
+		}
+		return value;
+	};
+
+	const resolved: ConfigData = {};
+	for ( const key of Object.keys( data ) ) {
+		resolved[ key ] = resolve( data[ key ] );
+	}
+	return resolved;
+}
+
+export { resolveTemplates };
+
 export default ( data: ConfigData ): ConfigApi => {
+	data = resolveTemplates( data );
 	const configApi = config( data ) as ConfigApi;
 	configApi.isEnabled = isEnabled( data );
 	configApi.enabledFeatures = enabledFeatures( data );

--- a/packages/create-calypso-config/src/test/index.js
+++ b/packages/create-calypso-config/src/test/index.js
@@ -1,4 +1,4 @@
-import createConfig from '../';
+import createConfig, { resolveTemplates } from '../';
 
 describe( 'index', () => {
 	describe( 'config without data', () => {
@@ -121,6 +121,37 @@ describe( 'index', () => {
 				config.disable( 'flagZXY' );
 				expect( config.isEnabled( 'flagZXY' ) ).toBe( false );
 			} );
+		} );
+	} );
+
+	describe( 'template resolution', () => {
+		test( 'resolves {{key}} from top-level config values', () => {
+			const config = createConfig( {
+				port: 4321,
+				wpcom_url: 'http://calypso.localhost:{{port}}',
+			} );
+			expect( config( 'wpcom_url' ) ).toBe( 'http://calypso.localhost:4321' );
+		} );
+
+		test( 'resolves templates in nested objects', () => {
+			const config = createConfig( {
+				port: 3000,
+				overrides: { logout_url: 'http://my.woo.localhost:{{port}}' },
+			} );
+			expect( config( 'overrides' ).logout_url ).toBe( 'http://my.woo.localhost:3000' );
+		} );
+
+		test( 'leaves unrecognized templates unchanged', () => {
+			const config = createConfig( {
+				url: 'http://localhost:{{unknown}}',
+			} );
+			expect( config( 'url' ) ).toBe( 'http://localhost:{{unknown}}' );
+		} );
+
+		test( 'resolveTemplates returns plain data object', () => {
+			const data = { port: 4321, wpcom_url: 'http://calypso.localhost:{{port}}' };
+			const resolved = resolveTemplates( data );
+			expect( resolved ).toEqual( { port: 4321, wpcom_url: 'http://calypso.localhost:4321' } );
 		} );
 	} );
 } );

--- a/packages/create-calypso-config/src/test/index.js
+++ b/packages/create-calypso-config/src/test/index.js
@@ -1,4 +1,4 @@
-import createConfig, { resolveTemplates } from '../';
+import createConfig from '../';
 
 describe( 'index', () => {
 	describe( 'config without data', () => {
@@ -146,12 +146,6 @@ describe( 'index', () => {
 				url: 'http://localhost:{{unknown}}',
 			} );
 			expect( config( 'url' ) ).toBe( 'http://localhost:{{unknown}}' );
-		} );
-
-		test( 'resolveTemplates returns plain data object', () => {
-			const data = { port: 4321, wpcom_url: 'http://calypso.localhost:{{port}}' };
-			const resolved = resolveTemplates( data );
-			expect( resolved ).toEqual( { port: 4321, wpcom_url: 'http://calypso.localhost:4321' } );
 		} );
 	} );
 } );

--- a/packages/wpcom-proxy-request/src/index.js
+++ b/packages/wpcom-proxy-request/src/index.js
@@ -554,18 +554,6 @@ const wpcomAllowedOrigins = [
 	'https://dev-mc.a8c.com',
 	'https://mc.a8c.com',
 	'https://dserve.a8c.com',
-	'http://calypso.localhost:3000',
-	'https://calypso.localhost:3000',
-	'http://jetpack.cloud.localhost:3000',
-	'https://jetpack.cloud.localhost:3000',
-	'http://agencies.localhost:3000',
-	'https://agencies.localhost:3000',
-	'http://my.localhost:3000',
-	'https://my.localhost:3000',
-	'http://my.woo.localhost:3000',
-	'https://my.woo.localhost:3000',
-	'http://calypso.localhost:3001',
-	'https://calypso.localhost:3001',
 	'https://calypso.live',
 	'http://127.0.0.1:41050',
 	'http://send.linguine.localhost:3000',
@@ -577,11 +565,37 @@ const wpcomAllowedOrigins = [
  * @param urlOrigin
  * @returns
  */
+// Local development origins allowed on any port. Listed without a port so we
+// can compare after stripping the port from the input.
+const localDevOrigins = [
+	'http://calypso.localhost/',
+	'https://calypso.localhost/',
+	'http://jetpack.cloud.localhost/',
+	'https://jetpack.cloud.localhost/',
+	'http://agencies.localhost/',
+	'https://agencies.localhost/',
+	'http://my.localhost/',
+	'https://my.localhost/',
+	'http://my.woo.localhost/',
+	'https://my.woo.localhost/',
+];
+
+function isLocalDevOrigin( urlOrigin ) {
+	try {
+		const url = new URL( urlOrigin );
+		url.port = '';
+		return localDevOrigins.includes( url.href );
+	} catch {
+		return false;
+	}
+}
+
 function isAllowedOrigin( urlOrigin ) {
 	// sites in the allow-list and some subdomains of "calypso.live" and "wordpress.com"
 	// are allowed without further check
 	return (
 		wpcomAllowedOrigins.includes( urlOrigin ) ||
+		isLocalDevOrigin( urlOrigin ) ||
 		/^https:\/\/[a-z0-9-]+\.calypso\.live$/.test( urlOrigin ) ||
 		/^https:\/\/([a-z0-9-]+\.)+wordpress\.com$/.test( urlOrigin )
 	);

--- a/packages/wpcom-proxy-request/src/index.js
+++ b/packages/wpcom-proxy-request/src/index.js
@@ -559,12 +559,6 @@ const wpcomAllowedOrigins = [
 	'http://send.linguine.localhost:3000',
 ];
 
-/**
- * Shelved from rest-proxy/provider-v2.0.js.
- * This returns true for all WPCOM origins except Atomic sites.
- * @param urlOrigin
- * @returns
- */
 // Local development origins allowed on any port. Listed without a port so we
 // can compare after stripping the port from the input.
 const localDevOrigins = [
@@ -590,6 +584,12 @@ function isLocalDevOrigin( urlOrigin ) {
 	}
 }
 
+/**
+ * Shelved from rest-proxy/provider-v2.0.js.
+ * This returns true for all WPCOM origins except Atomic sites.
+ * @param urlOrigin
+ * @returns
+ */
 function isAllowedOrigin( urlOrigin ) {
 	// sites in the allow-list and some subdomains of "calypso.live" and "wordpress.com"
 	// are allowed without further check

--- a/packages/wpcom-proxy-request/src/index.js
+++ b/packages/wpcom-proxy-request/src/index.js
@@ -559,26 +559,18 @@ const wpcomAllowedOrigins = [
 	'http://send.linguine.localhost:3000',
 ];
 
-// Local development origins allowed on any port. Listed without a port so we
-// can compare after stripping the port from the input.
-const localDevOrigins = [
-	'http://calypso.localhost/',
-	'https://calypso.localhost/',
-	'http://jetpack.cloud.localhost/',
-	'https://jetpack.cloud.localhost/',
-	'http://agencies.localhost/',
-	'https://agencies.localhost/',
-	'http://my.localhost/',
-	'https://my.localhost/',
-	'http://my.woo.localhost/',
-	'https://my.woo.localhost/',
+// Local development hostnames allowed on any port and scheme.
+const localDevHosts = [
+	'calypso.localhost',
+	'jetpack.cloud.localhost',
+	'agencies.localhost',
+	'my.localhost',
+	'my.woo.localhost',
 ];
 
 function isLocalDevOrigin( urlOrigin ) {
 	try {
-		const url = new URL( urlOrigin );
-		url.port = '';
-		return localDevOrigins.includes( url.href );
+		return localDevHosts.includes( new URL( urlOrigin ).hostname );
 	} catch {
 		return false;
 	}


### PR DESCRIPTION
## Proposed Changes

- Add `{{key}}` template support to config values in `create-calypso-config`, resolved at config creation time
- Config JSON files (`development.json`, `dashboard-development.json`) use `{{port}}` in URL values (`wpcom_url`, `logout_url`) so they reflect the actual server port
- Client code uses `config('port')` for dev URLs in dashboard routing, jetpack-connect, and checkout
- CORS allowlists in `wpcom-proxy-request` and `calypso-url` match localhost origins on any port by stripping the port and comparing against known dev origins
- Export `resolveTemplates` from `create-calypso-config` for server-side use on `clientData` (which must remain a plain object)

## Why are these changes being made?

When running Calypso on a non-default port (e.g. via `PORT=4321` or cmux/conductor), many URLs were hardcoded to `:3000` — the Reader link in the masterbar, dashboard cross-origin links, CORS allowlists, etc. This makes the port fully dynamic so all dev URLs match the actual server port.

## Testing Instructions

- Run `PORT=4321 yarn start` (or any non-3000 port)
- Verify the Reader link in the masterbar points to `:4321`
- Verify `window.configData.wpcom_url` contains the correct port
- Verify no `:3000` appears in the HTML source: `curl -s http://calypso.localhost:4321 | grep -c ':3000'` should be 0
- Verify dashboard links work on `http://my.localhost:4321`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?