### PR TITLE
e2e: Update Jetpack Settings tab locators for newer navigation

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/wp-admin/jetpack-dashboard-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/wp-admin/jetpack-dashboard-page.ts
@@ -58,17 +58,17 @@ export class JetpackDashboardPage {
 		await this.page.waitForURL( new RegExp( `page=jetpack#/${ param.view }`, 'i' ) );
 
 		if ( param.view === 'Settings' ) {
-			// Settings tabs are NavLink elements inside a <nav> landmark.
+			// Settings tabs use @wordpress/ui.
 			const nav = this.page
 				.getByRole( 'main' )
-				.getByRole( 'navigation', { name: 'Jetpack settings sections' } );
+				.getByRole( 'tablist', { name: 'Jetpack settings sections' } );
 
-			await nav.getByRole( 'link', { name: param.tab, exact: true } ).click();
+			await nav.getByRole( 'tab', { name: param.tab, exact: true } ).click();
 
-			// Verify the clicked tab is now active (NavLink sets aria-current="page").
+			// Verify the clicked tab is now active.
 			await nav
-				.getByRole( 'link', { name: param.tab, exact: true } )
-				.and( this.page.locator( '[aria-current="page"]' ) )
+				.getByRole( 'tab', { name: param.tab, exact: true } )
+				.and( this.page.locator( '[aria-selected="true"]' ) )
 				.waitFor();
 		} else {
 			// Dashboard tabs use NavItem components (role="menuitem" + .is-selected).


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

Update Jetpack Settings tab locators for newer navigation

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

PR #109333 updated it once, now Automattic/jetpack#47940 changed it again.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn workspace wp-e2e-tests build && CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME="desktop" ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/jetpack/jetpack__dashboard-smoke.ts`
* Shouldn't have to worry about non-Jetpack-Edge tests, as this only runs for Jetpack runs.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
