### PR TITLE
Remove `wpcom_ai_on_logged_out_support_pages_v3` experiment gating

### DIFF
--- a/apps/happy-blocks/block-library/search-card/includes.php
+++ b/apps/happy-blocks/block-library/search-card/includes.php
@@ -7,9 +7,7 @@
  * @package happy-blocks
  */
 
-// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- We are not processing any data here.
-$enable_odie_answers = ! is_user_logged_in() && ( 'treatment' === \ExPlat\assign_maybe_anon_user( 'wpcom_ai_on_logged_out_support_pages_v3' )
-	|| ( isset( $_GET['dotcom_support_enable_odie_answers'] ) && $_GET['dotcom_support_enable_odie_answers'] === 'true' ) );
+$enable_odie_answers = ! is_user_logged_in();
 
 if ( ! function_exists( 'happy_blocks_get_search_card_asset' ) ) {
 	/**

--- a/apps/happy-blocks/block-library/search-card/index.php
+++ b/apps/happy-blocks/block-library/search-card/index.php
@@ -20,9 +20,7 @@ if ( $is_forums ) {
 } else {
 	$show_search_card = $is_front_page || $is_404_page;
 }
-$enable_odie_answers = ! is_user_logged_in() && ( 'treatment' === \ExPlat\assign_maybe_anon_user( 'wpcom_ai_on_logged_out_support_pages_v3' )
-// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- We are not processing any data here.
-	|| ( isset( $_GET['dotcom_support_enable_odie_answers'] ) && 'true' === $_GET['dotcom_support_enable_odie_answers'] ) );
+$enable_odie_answers           = ! is_user_logged_in();
 $should_show_search_navigation = ( $is_front_page && $enable_odie_answers ) || ( ! $is_front_page && ! $is_404_page );
 
 $form_class              = isset( $args['form_class'] ) ? $args['form_class'] : '';

--- a/apps/happy-blocks/block-library/support-content-footer/includes.php
+++ b/apps/happy-blocks/block-library/support-content-footer/includes.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Title: Footer content for support sites
  * Slug: happy-blocks/support-content-footer
@@ -24,10 +23,5 @@ if ( ! function_exists( 'happy_blocks_get_content_footer_asset' ) ) {
 $css = happy_blocks_get_content_footer_asset( is_rtl() ? 'view.rtl.css' : 'view.css' );
 wp_enqueue_style( 'happy-blocks-support-footer-style', $css['path'], array(), $css['version'] );
 
-$enable_help_center_on_contact_us = is_user_logged_in() || ( 'treatment' === \ExPlat\assign_maybe_anon_user( 'wpcom_ai_on_logged_out_support_pages_v3' )
-	|| ( isset( $_GET['dotcom_support_enable_odie_answers'] ) && $_GET['dotcom_support_enable_odie_answers'] === 'true' ) );
-
-if ( $enable_help_center_on_contact_us ) {
-	$js = happy_blocks_get_content_footer_asset( 'view.js' );
-	wp_enqueue_script( 'happy-blocks-support-footer-view', $js['path'], array(), $js['version'], true );
-}
+$js = happy_blocks_get_content_footer_asset( 'view.js' );
+wp_enqueue_script( 'happy-blocks-support-footer-view', $js['path'], array(), $js['version'], true );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-16695

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
