### PR TITLE
Update external link for repository creation documentation

### DIFF
--- a/client/dashboard/sites/settings-repositories/connect-repository-form.tsx
+++ b/client/dashboard/sites/settings-repositories/connect-repository-form.tsx
@@ -517,7 +517,7 @@ export const ConnectRepositoryForm = ( {
 				),
 				createRepo: (
 					<ExternalLink
-						href="https://developer.wordpress.com/docs/developer-tools/github-deployments/create-repo-existing-source/"
+						href="https://developer.wordpress.com/docs/get-started/github/"
 						children={ null }
 					/>
 				),


### PR DESCRIPTION
The existing link goes to a 404.

## Testing Instructions

* Go to `https://my.wordpress.com/sites/<site>/settings/repositories/connect`
* Click on the "learn how to create a repository↗" link.
* Without this change, link is 404. With this change, goes to a valid page with instructions on how to create a repo.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
