### PR TITLE
Woo hosting solutions flow: include Personal and Premium plans

### DIFF
--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -279,7 +279,7 @@ export const usePlanTypesWithIntent = ( {
 		// Used by the woo-hosting-solutions-flow ref: only show plans that support
 		// post-checkout WooCommerce auto-install.
 		case 'plans-woo-hosting-solutions':
-			planTypes = [ TYPE_BUSINESS, TYPE_ECOMMERCE ];
+			planTypes = [ TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ];
 			break;
 		case 'plans-migration':
 			planTypes = [ TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ];


### PR DESCRIPTION
## Proposed Changes

* Add `TYPE_PERSONAL` and `TYPE_PREMIUM` to the `plans-woo-hosting-solutions` intent in `usePlanTypesWithIntent`, so `/start?ref=woo-hosting-solutions-flow` surfaces Personal and Premium alongside Business and Commerce.

## Why are these changes being made?

* The backend now grants the `woop` feature to Personal and Premium, so post-checkout WooCommerce auto-install is supported on those plans. The plans grid used by the Woo hosting solutions flow was previously restricted to Business/Commerce; this opens up the lower tiers so customers can pick the plan that fits them.

## Testing Instructions

* Visit \`/start?ref=woo-hosting-solutions-flow\` and confirm the plans grid now shows Personal/Premium/Business/Commerce as expected (per the intent's filter logic).
* Complete checkout on Personal or Premium and verify the WooCommerce auto-install handoff succeeds.
* Regression: other intents (\`plans-woo-hosted\`, \`plans-migration\`, default onboarding) are unaffected.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?