### PR TITLE
Post-checkout: skip Atomic transfer init for Commerce plans on Woo ref

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
@@ -73,6 +73,11 @@ const PostCheckoutOnboarding: StepType< {
 		[]
 	);
 
+	const planCartItem = useSelect(
+		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getPlanCartItem(),
+		[]
+	);
+
 	const isJetpack = useSelect(
 		( select ) => site && ( select( SITE_STORE ) as SiteSelect ).isJetpackSite( site.ID ),
 		[ site ]
@@ -113,7 +118,11 @@ const PostCheckoutOnboarding: StepType< {
 	const refParameter = useQuery().get( 'ref' );
 	const isWooHostingSolutions = refParameter === WOO_HOSTING_SOLUTIONS_REF;
 
-	const isCommercePlan = !! site?.plan && isEcommerce( site.plan );
+	// Prefer the cart item (what the user just bought — freshest signal during
+	// post-checkout) over site.plan (which can be stale before the site's plan
+	// assignment syncs).
+	const effectivePlan = planCartItem ?? site?.plan;
+	const isCommercePlan = !! effectivePlan && isEcommerce( effectivePlan );
 
 	// Woo-hosting-solutions ref:
 	// - Commerce plans: the backend auto-provisions the Atomic transfer and

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
@@ -1,5 +1,11 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { FEATURE_BIG_SKY, isBusiness, isPersonal, isPremium } from '@automattic/calypso-products';
+import {
+	FEATURE_BIG_SKY,
+	isBusiness,
+	isEcommerce,
+	isPersonal,
+	isPremium,
+} from '@automattic/calypso-products';
 import { SiteIntent } from '@automattic/data-stores/src/onboard';
 import { Step } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -106,7 +112,17 @@ const PostCheckoutOnboarding: StepType< {
 
 	const refParameter = useQuery().get( 'ref' );
 	const isWooHostingSolutions = refParameter === WOO_HOSTING_SOLUTIONS_REF;
-	const pluginToInstall = isWooHostingSolutions ? 'woocommerce' : goalPlugin;
+
+	const isCommercePlan = !! site?.plan && isEcommerce( site.plan );
+
+	// Woo-hosting-solutions ref:
+	// - Commerce plans: the backend auto-provisions the Atomic transfer and
+	//   installs WooCommerce, so we skip frontend initiation and only wait for
+	//   readiness below.
+	// - Business plans: must initiate an Atomic transfer with WooCommerce so
+	//   the plugin gets installed as part of the transfer.
+	const shouldInitiateWooTransfer = isWooHostingSolutions && ! isCommercePlan;
+	const pluginToInstall = shouldInitiateWooTransfer ? 'woocommerce' : goalPlugin;
 	const shouldInstallPlugin = Boolean( pluginToInstall );
 
 	/**
@@ -161,9 +177,11 @@ const PostCheckoutOnboarding: StepType< {
 
 			// Poll for the Woo ref regardless of the atomic path above — the
 			// site may already be Atomic when this effect mounts while
-			// WooCommerce is still finishing installation.
-			if ( isWooHostingSolutions && pluginToInstall ) {
-				await waitForPluginsActive( site.ID, [ pluginToInstall ] );
+			// WooCommerce is still finishing installation. This covers both the
+			// Commerce plan (backend auto-install) and the Business plan (install
+			// via the transfer initiated above).
+			if ( isWooHostingSolutions ) {
+				await waitForPluginsActive( site.ID, [ 'woocommerce' ] );
 			}
 
 			return providedDependencies;


### PR DESCRIPTION
Part of #

## Proposed Changes

- Gate Atomic transfer initiation in the post-checkout step on the purchased plan. Only initiate a transfer with `plugin: 'woocommerce'` for non-Commerce plans arriving via `?ref=woo-hosting-solutions-flow`.
- Always poll `waitForPluginsActive(['woocommerce'])` for the Woo ref so the downstream redirect still blocks until WooCommerce is active, regardless of how it got installed.
- Remove a stale `installAndActivatePlugin` import pointing to a non-existent module.

## Why are these changes being made?

The Commerce (eCommerce) plan auto-provisions the Atomic transfer and installs WooCommerce on the backend at purchase time. Initiating a second transfer from the frontend with `plugin: 'woocommerce'` is redundant and risks conflicting with the backend-provisioned transfer. Business plans don't get the backend auto-install, so they still need frontend initiation to get WooCommerce installed as part of the transfer.

Polling for plugin activation runs for both plans so the downstream redirect to `wc-admin` is safe either way.

## Testing Instructions

1. Start checkout from `/start?ref=woo-hosting-solutions-flow` and purchase a **Business plan**. Verify the post-checkout step initiates an Atomic transfer with `plugin: 'woocommerce'` and waits for activation before redirecting.
2. Repeat with a **Commerce plan**. Verify the frontend does not initiate a new transfer (check the network tab — no `POST /sites/{id}/automated-transfers/initiate` call), and the step still waits for the backend-provisioned WooCommerce install to complete before redirecting.
3. Verify the Sensei/Course goal path is unchanged: selecting the Course goal still initiates a transfer with `plugin: 'sensei-lms'`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)