### PR TITLE
HD v1: Redirect to reauth when route errors with reauthorization_required

### DIFF
--- a/client/sites/v2/components/500.tsx
+++ b/client/sites/v2/components/500.tsx
@@ -1,9 +1,16 @@
+import { isWpError } from '@automattic/api-core';
 import { __ } from '@wordpress/i18n';
 import Notice from 'calypso/dashboard/components/notice';
 import { PageHeader } from 'calypso/dashboard/components/page-header';
 import PageLayout from 'calypso/dashboard/components/page-layout';
+import { reauthRequiredLink } from 'calypso/dashboard/utils/link';
 
 function UnknownError( { error }: { error: Error } ) {
+	if ( isWpError( error ) && error.error === 'reauthorization_required' ) {
+		window.location.href = reauthRequiredLink();
+		return null;
+	}
+
 	return (
 		<PageLayout
 			header={


### PR DESCRIPTION
Part of #109728

## Proposed Changes

- Backport reauth redirect handling from MSD (PR #109728) to HD v1's global error component (`client/sites/v2/components/500.tsx`)
- When the HD v1 error boundary catches a `reauthorization_required` error, redirect to the reauth flow instead of showing a 500 page

## Why are these changes being made?

PR #109728 fixed the reauth redirect for MSD's `client/dashboard/app/500/index.tsx`, but HD v1 routes (like AI tools settings) use a separate error component that wasn't updated. This causes a 500 error page when navigating to Sites → Settings → AI tools when reauthorization is required, instead of properly redirecting to the reauth flow.

## Testing Instructions

- Navigate to Sites → Pick a site → Settings → AI tools when reauth is required
- Verify redirect to reauth flow instead of 500 error
- Verify other 500 errors still display normally

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)