### PR TITLE
Fix pre-push hook to check actual pushed refs instead of HEAD

### DIFF
--- a/bin/pre-push-hook.js
+++ b/bin/pre-push-hook.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const execSync = require( 'child_process' ).execSync;
+const fs = require( 'fs' );
 const readline = require( 'readline-sync' );
 
 console.log(
@@ -9,9 +9,19 @@ console.log(
 		'GPLv2 compatible licenses — see docs/CONTRIBUTING.md for details.\n\n'
 );
 
-const currentBranch = execSync( 'git rev-parse --abbrev-ref HEAD' ).toString().trim();
+// Git pre-push hooks receive pushed refs on stdin as:
+// <local ref> <local sha> <remote ref> <remote sha>
+const input = fs.readFileSync( '/dev/stdin', 'utf8' );
+const pushingToTrunk = input
+	.split( '\n' )
+	.filter( Boolean )
+	.some( ( line ) => line.split( ' ' )[ 2 ] === 'refs/heads/trunk' );
 
-if ( 'trunk' === currentBranch ) {
+if ( pushingToTrunk ) {
+	if ( ! process.stdin.isTTY ) {
+		console.log( 'Pushing to trunk is not allowed in non-interactive environments.' );
+		process.exit( 1 );
+	}
 	if ( ! readline.keyInYN( "You're about to push !!![ trunk ]!!!, is that what you intended?" ) ) {
 		process.exit( 1 );
 	}


### PR DESCRIPTION
## Proposed Changes

- Change the pre-push hook to read the actual pushed refs from stdin (provided by git) instead of checking `git rev-parse --abbrev-ref HEAD`
- Block trunk pushes in non-interactive (non-TTY) environments instead of crashing

## Why are these changes being made?

The pre-push hook crashed in non-TTY environments (CI, git worktrees, Claude Code) because `readline-sync` tried to read from `/dev/tty`. This happened even when pushing a feature branch, because the hook checked HEAD (which could be `trunk`) rather than the actual ref being pushed.

By reading stdin, the hook now correctly identifies what's being pushed and only prompts/blocks for actual trunk pushes.

## Testing Instructions

- Push a feature branch from trunk (`git push origin feature-branch:feature-branch` while on trunk) — should pass without prompting
- Push trunk in a terminal — should prompt as before
- Push trunk in a non-TTY environment — should block with an error message

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)