### PR TITLE
Domain-only flow: skip site-or-domain step for experiment treatment variant

### DIFF
--- a/client/signup/steps/domains/index.tsx
+++ b/client/signup/steps/domains/index.tsx
@@ -19,6 +19,7 @@ import { isRelativeUrl } from 'calypso/dashboard/utils/url';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { isMonthlyOrFreeFlow } from 'calypso/lib/cart-values/cart-items';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
+import { useExperiment } from 'calypso/lib/explat';
 import {
 	domainMapping,
 	domainAddNew,
@@ -70,6 +71,12 @@ const DomainSearchUI = (
 
 	const isDomainOnlyFlow = flowName === 'domain';
 	const isOnboardingWithEmailFlow = flowName === 'onboarding-with-email';
+
+	const [ , experimentAssignment ] = useExperiment(
+		'calypso_signup_domain_only_checkout_simplification_v1',
+		{ isEligible: isDomainOnlyFlow }
+	);
+	const isTreatment = experimentAssignment?.variationName === 'treatment';
 
 	const site = useSelector( getSelectedSite );
 
@@ -198,6 +205,28 @@ const DomainSearchUI = (
 						{ stepName: 'site-picker', wasSkipped: true },
 						{ themeSlugWithRepo: 'pub/twentysixteen' }
 					);
+				} else if ( isTreatment && isDomainOnlyFlow ) {
+					// Experiment: skip the 'Choose how to use your domain' step for domain-only purchases.
+					submitSignupStep(
+						{
+							stepName: 'site-or-domain',
+							domainItem,
+							designType: 'domain',
+							siteSlug: domainItem.meta,
+							siteUrl: domainItem.meta,
+							isPurchasingItem: true,
+							domainCart,
+						},
+						{ designType: 'domain', domainItem, siteUrl: domainItem.meta, domainCart }
+					);
+					submitSignupStep(
+						{ stepName: 'site-picker', wasSkipped: true, domainCart },
+						{ themeSlugWithRepo: 'pub/twentysixteen' }
+					);
+					submitSignupStep(
+						{ stepName: 'plans-site-selected', wasSkipped: true },
+						{ cartItems: null }
+					);
 				}
 
 				goToNextStep();
@@ -237,6 +266,7 @@ const DomainSearchUI = (
 		goToNextStep,
 		locale,
 		isDomainOnlyFlow,
+		isTreatment,
 		baseSubmitStepProps,
 		baseSubmitProvidedDependencies,
 		dashboard,

--- a/client/signup/steps/domains/test/index.tsx
+++ b/client/signup/steps/domains/test/index.tsx
@@ -1,0 +1,148 @@
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock( 'calypso/lib/explat', () => ( { useExperiment: jest.fn() } ) );
+jest.mock(
+	'calypso/signup/step-wrapper',
+	() => ( props: { stepContent?: React.ReactNode } ) => props.stepContent ?? null
+);
+jest.mock( 'calypso/components/domains/wpcom-domain-search', () => ( {
+	WPCOMDomainSearch: jest.fn().mockReturnValue( null ),
+} ) );
+jest.mock( 'calypso/components/domains/wpcom-domain-search/use-query-handler', () => ( {
+	useQueryHandler: () => ( { query: '', setQuery: jest.fn(), clearQuery: jest.fn() } ),
+} ) );
+
+import React from 'react';
+import { WPCOMDomainSearch } from 'calypso/components/domains/wpcom-domain-search';
+import { useExperiment } from 'calypso/lib/explat';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import DomainSearchStep from '../';
+
+const mockUseExperiment = useExperiment as jest.Mock;
+const mockWPCOMDomainSearch = WPCOMDomainSearch as jest.Mock;
+
+const domainItem = { meta: 'example.com', product_slug: 'domain_reg' };
+
+const baseProps = {
+	flowName: 'domain',
+	stepName: 'domain-only',
+	stepSectionName: null,
+	goToStep: jest.fn(),
+	goToNextStep: jest.fn(),
+	submitSignupStep: jest.fn(),
+	queryObject: {} as Record< string, string | undefined >,
+	locale: 'en',
+	previousStepName: null,
+};
+
+function renderStep( props = baseProps ) {
+	mockWPCOMDomainSearch.mockClear();
+	renderWithProvider( <DomainSearchStep { ...props } /> );
+	return mockWPCOMDomainSearch.mock.calls[ 0 ][ 0 ].events;
+}
+
+describe( 'DomainSearchStep — calypso_signup_domain_only_checkout_simplification_v1 experiment', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockWPCOMDomainSearch.mockReturnValue( null );
+	} );
+
+	it( 'auto-submits site-or-domain, site-picker, and plans-site-selected for treatment users in the domain flow', () => {
+		mockUseExperiment.mockReturnValue( [ false, { variationName: 'treatment' } ] );
+
+		const submitSignupStep = jest.fn();
+		const goToNextStep = jest.fn();
+		const events = renderStep( { ...baseProps, submitSignupStep, goToNextStep } );
+
+		events.onContinue( [ domainItem ] );
+
+		// 4 total: domain-only step + 3 skipped steps
+		expect( submitSignupStep ).toHaveBeenCalledTimes( 4 );
+		expect( submitSignupStep ).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining( {
+				stepName: 'domain-only',
+				domainItem,
+				isPurchasingItem: true,
+				siteUrl: 'example.com',
+			} ),
+			expect.objectContaining( {
+				domainItem,
+				siteUrl: 'example.com',
+			} )
+		);
+		expect( submitSignupStep ).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining( { stepName: 'site-or-domain', designType: 'domain' } ),
+			expect.objectContaining( { designType: 'domain' } )
+		);
+		expect( submitSignupStep ).toHaveBeenNthCalledWith(
+			3,
+			expect.objectContaining( { stepName: 'site-picker', wasSkipped: true } ),
+			expect.objectContaining( { themeSlugWithRepo: 'pub/twentysixteen' } )
+		);
+		expect( submitSignupStep ).toHaveBeenNthCalledWith(
+			4,
+			expect.objectContaining( { stepName: 'plans-site-selected', wasSkipped: true } ),
+			expect.objectContaining( { cartItems: null } )
+		);
+		expect( goToNextStep ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'submits the domain step with correct payload and does not skip steps for control users in the domain flow', () => {
+		mockUseExperiment.mockReturnValue( [ false, { variationName: 'control' } ] );
+
+		const submitSignupStep = jest.fn();
+		const goToNextStep = jest.fn();
+		const events = renderStep( { ...baseProps, submitSignupStep, goToNextStep } );
+
+		events.onContinue( [ domainItem ] );
+
+		expect( submitSignupStep ).toHaveBeenCalledTimes( 1 );
+		expect( submitSignupStep ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				stepName: 'domain-only',
+				domainItem,
+				isPurchasingItem: true,
+				siteUrl: 'example.com',
+			} ),
+			expect.objectContaining( {
+				domainItem,
+				siteUrl: 'example.com',
+			} )
+		);
+		expect( goToNextStep ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'submits the domain step and does not skip steps for treatment users in a non-domain flow', () => {
+		mockUseExperiment.mockReturnValue( [ false, { variationName: 'treatment' } ] );
+
+		const submitSignupStep = jest.fn();
+		const goToNextStep = jest.fn();
+		const events = renderStep( {
+			...baseProps,
+			flowName: 'onboarding',
+			submitSignupStep,
+			goToNextStep,
+		} );
+
+		events.onContinue( [ domainItem ] );
+
+		expect( submitSignupStep ).toHaveBeenCalledTimes( 1 );
+		expect( submitSignupStep ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				stepName: 'domain-only',
+				domainItem,
+				isPurchasingItem: true,
+				siteUrl: 'example.com',
+			} ),
+			expect.objectContaining( {
+				domainItem,
+				siteUrl: 'example.com',
+			} )
+		);
+		expect( goToNextStep ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -3,12 +3,11 @@ import { Gridicon } from '@automattic/components';
 import { SelectItems } from '@automattic/onboarding';
 import { globe, addCard, layout } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
-import { Component, useEffect } from 'react';
+import { Component } from 'react';
 import { connect } from 'react-redux';
 import { getUserSiteCountForPlatform } from 'calypso/components/site-selector/utils';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
 import { getDomainProductSlug } from 'calypso/lib/domains';
-import { useExperiment } from 'calypso/lib/explat';
 import { preventWidows } from 'calypso/lib/formatting';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { isUserLoggedIn, getCurrentUser } from 'calypso/state/current-user/selectors';
@@ -267,62 +266,6 @@ class SiteOrDomain extends Component {
 	}
 }
 
-function SiteOrDomainWithExperiment( props ) {
-	const [ isLoadingExperiment, experimentAssignment ] = useExperiment(
-		'calypso_signup_domain_only_checkout_simplification_v1'
-	);
-	const isTreatment = ! isLoadingExperiment && experimentAssignment?.variationName === 'treatment';
-
-	useEffect( () => {
-		if ( ! isTreatment ) {
-			return;
-		}
-
-		const { stepName, signupDependencies, flowName, submitSignupStep: submit, goToStep } = props;
-		const domainCart = signupDependencies?.domainCart ?? [];
-		const domain = domainCart[ 0 ]?.meta;
-
-		if ( ! domain ) {
-			return;
-		}
-
-		const productSlug = getDomainProductSlug( domain );
-		const domainItem = domainRegistration( {
-			productSlug,
-			domain,
-			extra: { flow_name: flowName },
-		} );
-		const siteUrl = domain;
-
-		// Submit this step as domain-only, mirroring handleClickChoice( 'domain' )
-		submit(
-			{
-				stepName,
-				domainItem,
-				designType: 'domain',
-				siteSlug: domain,
-				siteUrl,
-				isPurchasingItem: true,
-				domainCart,
-			},
-			{ designType: 'domain', domainItem, siteUrl, domainCart }
-		);
-		// Skip site-picker and plans-site-selected — the user is just buying a domain
-		submit(
-			{ stepName: 'site-picker', wasSkipped: true, domainCart },
-			{ themeSlugWithRepo: 'pub/twentysixteen' }
-		);
-		submit( { stepName: 'plans-site-selected', wasSkipped: true }, { cartItems: null } );
-		goToStep( config.isEnabled( 'signup/social-first' ) ? 'user-social' : 'user' );
-	}, [ isTreatment ] ); // eslint-disable-line react-hooks/exhaustive-deps
-
-	if ( isLoadingExperiment || isTreatment ) {
-		return null;
-	}
-
-	return <SiteOrDomain { ...props } />;
-}
-
 export default connect(
 	( state ) => {
 		const user = getCurrentUser( state );
@@ -333,4 +276,4 @@ export default connect(
 		};
 	},
 	{ submitSignupStep }
-)( localize( SiteOrDomainWithExperiment ) );
+)( localize( SiteOrDomain ) );

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -3,11 +3,12 @@ import { Gridicon } from '@automattic/components';
 import { SelectItems } from '@automattic/onboarding';
 import { globe, addCard, layout } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
-import { Component } from 'react';
+import { Component, useEffect } from 'react';
 import { connect } from 'react-redux';
 import { getUserSiteCountForPlatform } from 'calypso/components/site-selector/utils';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
 import { getDomainProductSlug } from 'calypso/lib/domains';
+import { useExperiment } from 'calypso/lib/explat';
 import { preventWidows } from 'calypso/lib/formatting';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { isUserLoggedIn, getCurrentUser } from 'calypso/state/current-user/selectors';
@@ -266,6 +267,62 @@ class SiteOrDomain extends Component {
 	}
 }
 
+function SiteOrDomainWithExperiment( props ) {
+	const [ isLoadingExperiment, experimentAssignment ] = useExperiment(
+		'calypso_signup_domain_only_checkout_simplification_v1'
+	);
+	const isTreatment = ! isLoadingExperiment && experimentAssignment?.variationName === 'treatment';
+
+	useEffect( () => {
+		if ( ! isTreatment ) {
+			return;
+		}
+
+		const { stepName, signupDependencies, flowName, submitSignupStep: submit, goToStep } = props;
+		const domainCart = signupDependencies?.domainCart ?? [];
+		const domain = domainCart[ 0 ]?.meta;
+
+		if ( ! domain ) {
+			return;
+		}
+
+		const productSlug = getDomainProductSlug( domain );
+		const domainItem = domainRegistration( {
+			productSlug,
+			domain,
+			extra: { flow_name: flowName },
+		} );
+		const siteUrl = domain;
+
+		// Submit this step as domain-only, mirroring handleClickChoice( 'domain' )
+		submit(
+			{
+				stepName,
+				domainItem,
+				designType: 'domain',
+				siteSlug: domain,
+				siteUrl,
+				isPurchasingItem: true,
+				domainCart,
+			},
+			{ designType: 'domain', domainItem, siteUrl, domainCart }
+		);
+		// Skip site-picker and plans-site-selected — the user is just buying a domain
+		submit(
+			{ stepName: 'site-picker', wasSkipped: true, domainCart },
+			{ themeSlugWithRepo: 'pub/twentysixteen' }
+		);
+		submit( { stepName: 'plans-site-selected', wasSkipped: true }, { cartItems: null } );
+		goToStep( config.isEnabled( 'signup/social-first' ) ? 'user-social' : 'user' );
+	}, [ isTreatment ] ); // eslint-disable-line react-hooks/exhaustive-deps
+
+	if ( isLoadingExperiment || isTreatment ) {
+		return null;
+	}
+
+	return <SiteOrDomain { ...props } />;
+}
+
 export default connect(
 	( state ) => {
 		const user = getCurrentUser( state );
@@ -276,4 +333,4 @@ export default connect(
 		};
 	},
 	{ submitSignupStep }
-)( localize( SiteOrDomain ) );
+)( localize( SiteOrDomainWithExperiment ) );


### PR DESCRIPTION
Part of DOTPROD-52

## Proposed Changes

* Adds ExPlat experiment gate (\`calypso_signup_domain_only_checkout_simplification_v1\`) to the \`/start/domain\` signup flow
* For treatment users: the \`onContinue\` handler in the \`domain-only\` step (domain search) auto-submits \`site-or-domain\`, \`site-picker\`, and \`plans-site-selected\` as complete before calling \`goToNextStep()\`, causing the signup framework to skip past all three — following the same pattern already used by the Gravatar flow
* Control group sees the step unchanged

## Why are these changes being made?

The pre-checkout "Choose how to use your domain" step introduces friction at the point of highest purchase intent. Users who arrive at domain search have already decided to buy — asking them to choose a use case before checkout may reduce completion rates. This experiment tests whether removing that step and moving upsells to the Thank You page improves net cash sales per flow entrant and checkout conversion.

The Thank You page upsells are already live; only the removal of the pre-checkout step differs between control and treatment.

## Testing Instructions

* Enroll in the `calypso_signup_domain_only_checkout_simplification_v1` experiment with `treatment` variant
* Go to `/start/domain`, search for and select a domain
* Treatment: the "Choose how to use your domain" step should not appear — flow proceeds directly to auth/checkout
* Control: the step appears as before
* `yarn test-client client/signup/steps/domains`

The skipped screen is:
<img width="1680" height="1264" alt="choose-how-to-use-your-domain" src="https://github.com/user-attachments/assets/7c0f9959-c191-48ac-bb20-8b7d2da72dab" />

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?