### PR TITLE
Stats: Fix Insights page loading state using hasLoadedSiteFeatures

### DIFF
--- a/client/my-sites/stats/hooks/test/use-should-gate-stats.ts
+++ b/client/my-sites/stats/hooks/test/use-should-gate-stats.ts
@@ -60,6 +60,7 @@ describe( 'shouldGateStats in Calypso', () => {
 			sites: {
 				features: {
 					[ siteId ]: {
+						hasLoadedFromServer: true,
 						data: {
 							active: [],
 						},
@@ -87,6 +88,7 @@ describe( 'shouldGateStats in Calypso', () => {
 			sites: {
 				features: {
 					[ siteId ]: {
+						hasLoadedFromServer: true,
 						data: {
 							active: [ FEATURE_STATS_PAID ],
 						},
@@ -114,6 +116,7 @@ describe( 'shouldGateStats in Calypso', () => {
 			sites: {
 				features: {
 					[ siteId ]: {
+						hasLoadedFromServer: true,
 						data: {
 							active: [ FEATURE_STATS_PAID ],
 						},
@@ -141,6 +144,7 @@ describe( 'shouldGateStats in Calypso', () => {
 			sites: {
 				features: {
 					[ siteId ]: {
+						hasLoadedFromServer: true,
 						data: {
 							active: [],
 						},
@@ -168,6 +172,7 @@ describe( 'shouldGateStats in Calypso', () => {
 			sites: {
 				features: {
 					[ siteId ]: {
+						hasLoadedFromServer: true,
 						data: {
 							active: [],
 						},
@@ -195,6 +200,7 @@ describe( 'shouldGateStats in Calypso', () => {
 			sites: {
 				features: {
 					[ siteId ]: {
+						hasLoadedFromServer: true,
 						data: {
 							active: [],
 						},
@@ -222,6 +228,7 @@ describe( 'shouldGateStats in Calypso', () => {
 			sites: {
 				features: {
 					[ siteId ]: {
+						hasLoadedFromServer: true,
 						data: {
 							active: [],
 						},
@@ -254,6 +261,7 @@ describe( 'shouldGateStats in Calypso', () => {
 			sites: {
 				features: {
 					[ siteId ]: {
+						hasLoadedFromServer: true,
 						data: {
 							active: [ FEATURE_STATS_PAID ], // FEATURE_STATS_COMMERCIAL
 						},
@@ -281,6 +289,7 @@ describe( 'shouldGateStats in Calypso', () => {
 			sites: {
 				features: {
 					[ siteId ]: {
+						hasLoadedFromServer: true,
 						data: {
 							active: [ FEATURE_STATS_PAID ], // FEATURE_STATS_COMMERCIAL
 						},

--- a/client/my-sites/stats/hooks/use-should-gate-stats.ts
+++ b/client/my-sites/stats/hooks/use-should-gate-stats.ts
@@ -6,7 +6,7 @@ import {
 	FEATURE_STATS_BASIC,
 } from '@automattic/calypso-products';
 import { useSelector } from 'calypso/state';
-import getSiteFeatures from 'calypso/state/selectors/get-site-features';
+import hasLoadedSiteFeatures from 'calypso/state/selectors/has-loaded-site-features';
 import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -245,14 +245,13 @@ export const shouldGateStats = ( state: object, siteId: number | null, statType:
 		return [ ...jetpackStatsAdvancedPaywall ].includes( statType );
 	}
 
-	const siteFeatures = getSiteFeatures( state, siteId );
 	const siteHasCommercialStats = siteHasFeature( state, siteId, FEATURE_STATS_COMMERCIAL );
 	const siteHasFreeStats = siteHasFeature( state, siteId, FEATURE_STATS_FREE );
 	const siteHasPaidStats = siteHasFeature( state, siteId, FEATURE_STATS_PAID );
 	const siteHasBasicStats = siteHasFeature( state, siteId, FEATURE_STATS_BASIC );
 
 	// Check if the site features have loaded.
-	if ( ! siteFeatures ) {
+	if ( ! hasLoadedSiteFeatures( state, siteId ) ) {
 		return false;
 	}
 

--- a/client/my-sites/stats/hooks/use-should-gate-stats.ts
+++ b/client/my-sites/stats/hooks/use-should-gate-stats.ts
@@ -301,3 +301,19 @@ export const useShouldGateStats = ( statType: string ) => {
 
 	return isGatedStats;
 };
+
+/*
+ * Returns true while the data needed to determine gating is still loading.
+ * QuerySiteFeatures is skipped when running inside a Jetpack site's wp-admin
+ * (is_running_in_jetpack_site), so features will never load in that context.
+ */
+export const useIsGateStatsLoading = () => {
+	const siteId = useSelector( getSelectedSiteId );
+	const hasLoadedFeatures = useSelector( ( state ) => hasLoadedSiteFeatures( state, siteId ) );
+
+	if ( isEnabled( 'is_running_in_jetpack_site' ) ) {
+		return false;
+	}
+
+	return ! hasLoadedFeatures;
+};

--- a/client/my-sites/stats/modernized-chart-tabs-styles.scss
+++ b/client/my-sites/stats/modernized-chart-tabs-styles.scss
@@ -7,8 +7,11 @@ $custom-stats-tab-mobile-break: $break-medium;
 
 .stats > .stats-content {
 	padding-top: $vertical-margin;
+	padding-bottom: $vertical-margin;
+
 	@media (max-width: $custom-mobile-breakpoint) {
 		padding-top: 0;
+		padding-bottom: 0;
 	}
 }
 

--- a/client/my-sites/stats/pages/insights/index.jsx
+++ b/client/my-sites/stats/pages/insights/index.jsx
@@ -11,11 +11,13 @@ import StatsModuleComments from 'calypso/my-sites/stats/features/modules/stats-c
 import StatShares from 'calypso/my-sites/stats/features/modules/stats-shares';
 import StatsModuleTags from 'calypso/my-sites/stats/features/modules/stats-tags';
 import usePlanUsageQuery from 'calypso/my-sites/stats/hooks/use-plan-usage-query';
-import { useShouldGateStats } from 'calypso/my-sites/stats/hooks/use-should-gate-stats';
+import {
+	useShouldGateStats,
+	useIsGateStatsLoading,
+} from 'calypso/my-sites/stats/hooks/use-should-gate-stats';
 import { recordCurrentScreen } from 'calypso/my-sites/stats/hooks/use-stats-navigation-history';
 import { useSelector } from 'calypso/state';
 import { STATS_PLAN_USAGE_RECEIVE } from 'calypso/state/action-types';
-import hasLoadedSiteFeatures from 'calypso/state/selectors/has-loaded-site-features';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import useStatsStrings from '../../hooks/use-stats-strings';
@@ -35,8 +37,6 @@ function StatsInsights( { context } ) {
 	const moduleStrings = useStatsStrings();
 	const { isPending, data: usageInfo } = usePlanUsageQuery( siteId );
 	const reduxDispatch = useDispatch();
-	const hasLoadedFeatures = useSelector( ( state ) => hasLoadedSiteFeatures( state, siteId ) );
-
 	// Dispatch the plan usage data to the Redux store for monthly views check in shouldGateStats.
 	useEffect( () => {
 		if ( ! isPending ) {
@@ -49,6 +49,7 @@ function StatsInsights( { context } ) {
 	}, [ reduxDispatch, isPending, siteId, usageInfo ] );
 
 	const shouldGateInsights = useShouldGateStats( STATS_FEATURE_PAGE_INSIGHTS );
+	const isGateLoading = useIsGateStatsLoading();
 	const shouldRendeUpsell = config.isEnabled( 'stats/paid-wpcom-v3' ) && shouldGateInsights;
 
 	useEffect(
@@ -74,7 +75,7 @@ function StatsInsights( { context } ) {
 	const insightsPageClasses = clsx( 'stats', { 'is-odyssey-stats': isWPAdmin } );
 
 	let content = PageLoading;
-	if ( hasLoadedFeatures ) {
+	if ( ! isGateLoading ) {
 		content = shouldRendeUpsell ? (
 			<div id="my-stats-content" className="stats-content">
 				<StatsUpsell siteId={ siteId } />

--- a/client/my-sites/stats/pages/insights/index.jsx
+++ b/client/my-sites/stats/pages/insights/index.jsx
@@ -15,6 +15,7 @@ import { useShouldGateStats } from 'calypso/my-sites/stats/hooks/use-should-gate
 import { recordCurrentScreen } from 'calypso/my-sites/stats/hooks/use-stats-navigation-history';
 import { useSelector } from 'calypso/state';
 import { STATS_PLAN_USAGE_RECEIVE } from 'calypso/state/action-types';
+import hasLoadedSiteFeatures from 'calypso/state/selectors/has-loaded-site-features';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import useStatsStrings from '../../hooks/use-stats-strings';
@@ -24,6 +25,7 @@ import AnnualHighlightsSection from '../../sections/annual-highlights-section';
 import PostingActivity from '../../sections/posting-activity-section';
 import PageViewTracker from '../../stats-page-view-tracker';
 import StatsUpsell from '../../stats-upsell/insights-upsell';
+import PageLoading from '../shared/page-loading';
 import StatsModuleListing from '../shared/stats-module-listing';
 
 function StatsInsights( { context } ) {
@@ -33,6 +35,7 @@ function StatsInsights( { context } ) {
 	const moduleStrings = useStatsStrings();
 	const { isPending, data: usageInfo } = usePlanUsageQuery( siteId );
 	const reduxDispatch = useDispatch();
+	const hasLoadedFeatures = useSelector( ( state ) => hasLoadedSiteFeatures( state, siteId ) );
 
 	// Dispatch the plan usage data to the Redux store for monthly views check in shouldGateStats.
 	useEffect( () => {
@@ -70,6 +73,55 @@ function StatsInsights( { context } ) {
 	const isWPAdmin = config.isEnabled( 'is_odyssey' );
 	const insightsPageClasses = clsx( 'stats', { 'is-odyssey-stats': isWPAdmin } );
 
+	let content = PageLoading;
+	if ( hasLoadedFeatures ) {
+		content = shouldRendeUpsell ? (
+			<div id="my-stats-content" className="stats-content">
+				<StatsUpsell siteId={ siteId } />
+			</div>
+		) : (
+			<>
+				<AnnualHighlightsSection siteId={ siteId } />
+				<AllTimeHighlightsSection siteId={ siteId } siteSlug={ siteSlug } />
+				<PostingActivity siteId={ siteId } />
+				<AllTimeViewsSection siteId={ siteId } slug={ siteSlug } />
+				<StatsModuleListing className="stats__module-list--insights" siteId={ siteId }>
+					<StatsModuleTags
+						moduleStrings={ moduleStrings.tags }
+						hideSummaryLink
+						className={ clsx(
+							{
+								'stats__flexible-grid-item--half': isJetpack,
+								'stats__flexible-grid-item--full--large': isJetpack,
+							},
+							{
+								'stats__flexible-grid-item--full': ! isJetpack,
+							}
+						) }
+					/>
+
+					<StatsModuleComments
+						className={ clsx(
+							'stats__flexible-grid-item--half',
+							'stats__flexible-grid-item--full--large'
+						) }
+					/>
+
+					{ /** TODO: The feature depends on Jetpack Sharing module and is disabled for all Jetpack Sites for now. */ }
+					{ ! isJetpack && (
+						<StatShares
+							siteId={ siteId }
+							className={ clsx(
+								'stats__flexible-grid-item--half',
+								'stats__flexible-grid-item--full--large'
+							) }
+						/>
+					) }
+				</StatsModuleListing>
+			</>
+		);
+	}
+
 	// TODO: should be refactored into separate components
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
@@ -80,53 +132,7 @@ function StatsInsights( { context } ) {
 		>
 			<DocumentHead title={ STATS_PRODUCT_NAME } />
 			<PageViewTracker path="/stats/insights/:site" title="Stats > Insights" />
-			<div className={ insightsPageClasses }>
-				{ shouldRendeUpsell ? (
-					<div id="my-stats-content" className="stats-content">
-						<StatsUpsell siteId={ siteId } />
-					</div>
-				) : (
-					<>
-						<AnnualHighlightsSection siteId={ siteId } />
-						<AllTimeHighlightsSection siteId={ siteId } siteSlug={ siteSlug } />
-						<PostingActivity siteId={ siteId } />
-						<AllTimeViewsSection siteId={ siteId } slug={ siteSlug } />
-						<StatsModuleListing className="stats__module-list--insights" siteId={ siteId }>
-							<StatsModuleTags
-								moduleStrings={ moduleStrings.tags }
-								hideSummaryLink
-								className={ clsx(
-									{
-										'stats__flexible-grid-item--half': isJetpack,
-										'stats__flexible-grid-item--full--large': isJetpack,
-									},
-									{
-										'stats__flexible-grid-item--full': ! isJetpack,
-									}
-								) }
-							/>
-
-							<StatsModuleComments
-								className={ clsx(
-									'stats__flexible-grid-item--half',
-									'stats__flexible-grid-item--full--large'
-								) }
-							/>
-
-							{ /** TODO: The feature depends on Jetpack Sharing module and is disabled for all Jetpack Sites for now. */ }
-							{ ! isJetpack && (
-								<StatShares
-									siteId={ siteId }
-									className={ clsx(
-										'stats__flexible-grid-item--half',
-										'stats__flexible-grid-item--full--large'
-									) }
-								/>
-							) }
-						</StatsModuleListing>
-					</>
-				) }
-			</div>
+			<div className={ insightsPageClasses }>{ content }</div>
 		</Main>
 	);
 	/* eslint-enable wpcalypso/jsx-classname-namespace */


### PR DESCRIPTION
Fixes STATS-250.

## Proposed Changes

* Add `useIsGateStatsLoading` hook to `use-should-gate-stats` that exposes the loading state for gating decisions
* In the Insights page, use `useIsGateStatsLoading` instead of `hasLoadedSiteFeatures` to gate rendering

## Why are these changes being made?

`QuerySiteFeatures` (which fetches site features and sets `hasLoadedFromServer`) is intentionally not rendered in Jetpack wp-admin context (`is_running_in_jetpack_site`), so `hasLoadedSiteFeatures` was always `false` there — causing the Insights page to be stuck in a loading state.

The new `useIsGateStatsLoading` hook directly mirrors the `QuerySiteFeatures` render condition: it skips waiting for features when `is_running_in_jetpack_site` is enabled, since features will never be fetched in that context. This correctly handles both self-hosted Jetpack and Atomic sites in wp-admin.

## Testing Instructions

* Navigate to `/stats/insights/:site` on a WordPress.com Free plan site
* Verify the page shows a spinner while features are loading, then renders correctly
* Verify the upsell shows for sites that should be gated, and content shows for sites that should not
* Follow PCYsg-Pp7-p2#option-3 to test for WP-Admin and make sure the WordPress.com Premium plan site does not show the upsell.

### WP-Admin of Premium plan site

#### Before
https://github.com/user-attachments/assets/c98e99ca-17ea-4377-9f34-710fa664e3df

#### After
https://github.com/user-attachments/assets/10389212-984f-4a12-8af3-0156959071a9

### WPCOM of Free plan site

#### Before
https://github.com/user-attachments/assets/16c3a88b-4a43-4e76-9c5c-b1a079c510c3

#### After
https://github.com/user-attachments/assets/5c023cbc-cf23-44ef-8782-cf2f141ca181

### WP-Admin of Free plan site (Not changed)

#### Before
https://github.com/user-attachments/assets/ef985c2a-7c6d-45c5-a0e7-12cb3d57b373

#### After
https://github.com/user-attachments/assets/279ff0e9-ff98-48e3-8459-0665edf50a2e

### WPCOM of Premium plan site (Not changed)

#### Before
https://github.com/user-attachments/assets/f0a8776d-0c34-4063-a815-f52d21eaa072

#### After
https://github.com/user-attachments/assets/5bcbd561-6bd4-4352-8728-7a73e5e068fe

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?