### PR TITLE
Image Studio: Persist each image rating for the session (FORNO-277)

### DIFF
--- a/packages/image-studio/src/components/canvas-controls/index.tsx
+++ b/packages/image-studio/src/components/canvas-controls/index.tsx
@@ -8,8 +8,10 @@
 import { FeedbackInput } from '@automattic/agents-manager';
 import { MessageActions, ThumbsDownIcon, ThumbsUpIcon } from '@automattic/agenttic-ui';
 import { Popover, __unstableMotion as motion } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { type ImageStudioActions, store as imageStudioStore } from '../../store';
 import { trackImageStudioImageFeedback } from '../../utils/tracking';
 import { ImageActionsMenu } from '../image-actions-menu';
 import { RevisionNavigator } from './revision-navigator';
@@ -39,24 +41,27 @@ export const CanvasControls = ( {
 	onFeedback,
 	onSubmitFeedbackText,
 }: CanvasControlsProps ) => {
-	const [ selectedFeedback, setSelectedFeedback ] = useState< 'up' | 'down' | null >( null );
+	const selectedFeedback = useSelect(
+		( select ) => select( imageStudioStore ).getSessionFeedback(),
+		[]
+	);
+	const { setSessionFeedback } = useDispatch( imageStudioStore ) as ImageStudioActions;
 	const [ showFeedbackPopover, setShowFeedbackPopover ] = useState( false );
 	const feedbackAnchorRef = useRef< HTMLDivElement | null >( null );
 
-	// Reset feedback when image changes
+	// Close feedback popover when navigating to a different image
 	useEffect( () => {
-		setSelectedFeedback( null );
 		setShowFeedbackPopover( false );
 	}, [ imageUrl ] );
 
 	const handleFeedback = useCallback(
 		( feedback: 'up' | 'down' ) => {
-			// Don't allow changing feedback once selected
+			// Don't allow changing feedback once selected in this session
 			if ( selectedFeedback !== null ) {
 				return;
 			}
 
-			setSelectedFeedback( feedback );
+			setSessionFeedback( feedback );
 			trackImageStudioImageFeedback( { feedback, attachmentId, mode } );
 			onFeedback?.( feedback );
 
@@ -64,7 +69,7 @@ export const CanvasControls = ( {
 				setShowFeedbackPopover( true );
 			}
 		},
-		[ mode, attachmentId, selectedFeedback, onFeedback, onSubmitFeedbackText ]
+		[ mode, attachmentId, selectedFeedback, onFeedback, onSubmitFeedbackText, setSessionFeedback ]
 	);
 
 	const handleCloseFeedbackPopover = useCallback( () => {

--- a/packages/image-studio/src/components/canvas-controls/index.tsx
+++ b/packages/image-studio/src/components/canvas-controls/index.tsx
@@ -42,10 +42,10 @@ export const CanvasControls = ( {
 	onSubmitFeedbackText,
 }: CanvasControlsProps ) => {
 	const selectedFeedback = useSelect(
-		( select ) => select( imageStudioStore ).getSessionFeedback(),
-		[]
+		( select ) => select( imageStudioStore ).getImageRating( attachmentId ),
+		[ attachmentId ]
 	);
-	const { setSessionFeedback } = useDispatch( imageStudioStore ) as ImageStudioActions;
+	const { setImageRating } = useDispatch( imageStudioStore ) as ImageStudioActions;
 	const [ showFeedbackPopover, setShowFeedbackPopover ] = useState( false );
 	const feedbackAnchorRef = useRef< HTMLDivElement | null >( null );
 
@@ -56,12 +56,12 @@ export const CanvasControls = ( {
 
 	const handleFeedback = useCallback(
 		( feedback: 'up' | 'down' ) => {
-			// Don't allow changing feedback once selected in this session
-			if ( selectedFeedback !== null ) {
+			// Don't allow changing feedback once submitted for this image
+			if ( selectedFeedback !== null || attachmentId === null ) {
 				return;
 			}
 
-			setSessionFeedback( feedback );
+			setImageRating( attachmentId, feedback );
 			trackImageStudioImageFeedback( { feedback, attachmentId, mode } );
 			onFeedback?.( feedback );
 
@@ -69,7 +69,7 @@ export const CanvasControls = ( {
 				setShowFeedbackPopover( true );
 			}
 		},
-		[ mode, attachmentId, selectedFeedback, onFeedback, onSubmitFeedbackText, setSessionFeedback ]
+		[ mode, attachmentId, selectedFeedback, onFeedback, onSubmitFeedbackText, setImageRating ]
 	);
 
 	const handleCloseFeedbackPopover = useCallback( () => {

--- a/packages/image-studio/src/components/canvas-controls/style.scss
+++ b/packages/image-studio/src/components/canvas-controls/style.scss
@@ -27,6 +27,10 @@
 	align-items: center;
 }
 
+.canvas-controls__left button[aria-pressed="true"] {
+	cursor: default;
+}
+
 .canvas-controls__nav-button {
 	background: transparent;
 	border: none;

--- a/packages/image-studio/src/components/index.tsx
+++ b/packages/image-studio/src/components/index.tsx
@@ -438,10 +438,11 @@ const ImageStudioContent = withInstanceId(
 			<AnnotationCanvas imageUrl={ finalDisplayUrl } imageElement={ imageRef.current } />
 		) : null;
 
-		// Show feedback buttons when image is AI-processed and not in other states
-		// Don't show for annotated images as they will have different suggestions
+		// Show feedback buttons only for AI-generated/edited images — never for the
+		// original attachment — and not while annotating (suggestions differ there).
+		const isOriginalImage = attachmentId !== null && attachmentId === originalAttachmentId;
 		const showFeedbackButtons =
-			! isCurrentAttachmentAnnotated && !! isAiProcessed && !! finalDisplayUrl;
+			! isCurrentAttachmentAnnotated && !! isAiProcessed && !! finalDisplayUrl && ! isOriginalImage;
 
 		// Show actions menu only in Edit mode after AI has made changes.
 		// canRevert already checks: originalAttachmentId exists, image changed, not processing

--- a/packages/image-studio/src/store/index.test.ts
+++ b/packages/image-studio/src/store/index.test.ts
@@ -95,6 +95,7 @@ describe( 'Image Studio Store', () => {
 				selectedStyle: null,
 				selectedAspectRatio: null,
 				lastAgentMessageId: null,
+				sessionFeedback: null,
 			} );
 		} );
 
@@ -851,6 +852,55 @@ describe( 'Image Studio Store', () => {
 
 				expect( state.lastAgentMessageId ).toBe( 'msg-123' );
 			} );
+
+			it( 'SET_SESSION_FEEDBACK', () => {
+				const state = reducer( getInitialState(), actions.setSessionFeedback( 'up' ) );
+
+				expect( state.sessionFeedback ).toBe( 'up' );
+			} );
+
+			it( 'SET_SESSION_FEEDBACK clears feedback when set to null', () => {
+				const initial: ImageStudioState = { ...getInitialState(), sessionFeedback: 'down' };
+				const state = reducer( initial, actions.setSessionFeedback( null ) );
+
+				expect( state.sessionFeedback ).toBeNull();
+			} );
+
+			it( 'preserves sessionFeedback when UPDATE_IMAGE_STUDIO_CANVAS fires', () => {
+				const initial: ImageStudioState = { ...getInitialState(), sessionFeedback: 'up' };
+				const state = reducer(
+					initial,
+					actions.updateImageStudioCanvas( 'https://example.com/v2.jpg', 456 )
+				);
+
+				expect( state.sessionFeedback ).toBe( 'up' );
+			} );
+
+			it( 'resets sessionFeedback on OPEN_IMAGE_STUDIO', () => {
+				const initial: ImageStudioState = { ...getInitialState(), sessionFeedback: 'up' };
+				const state = reducer( initial, actions.openImageStudio( 123 ) );
+
+				expect( state.sessionFeedback ).toBeNull();
+			} );
+
+			it( 'resets sessionFeedback on CLOSE_IMAGE_STUDIO', () => {
+				const initial: ImageStudioState = { ...getInitialState(), sessionFeedback: 'down' };
+				const state = reducer( initial, actions.closeImageStudio() );
+
+				expect( state.sessionFeedback ).toBeNull();
+			} );
+
+			it( 'resets sessionFeedback on NAVIGATE_TO_ATTACHMENT (new working session)', () => {
+				const initial: ImageStudioState = {
+					...getInitialState(),
+					sessionFeedback: 'up',
+					navigableAttachmentIds: [ 100, 200 ],
+					currentNavigationIndex: 0,
+				};
+				const state = reducer( initial, actions.navigateToAttachment( 200 ) );
+
+				expect( state.sessionFeedback ).toBeNull();
+			} );
 		} );
 	} );
 
@@ -1022,6 +1072,11 @@ describe( 'Image Studio Store', () => {
 		it( 'getLastAgentMessageId', () => {
 			const state: ImageStudioState = { ...getInitialState(), lastAgentMessageId: 'msg-123' };
 			expect( selectors.getLastAgentMessageId( state ) ).toBe( 'msg-123' );
+		} );
+
+		it( 'getSessionFeedback', () => {
+			const state: ImageStudioState = { ...getInitialState(), sessionFeedback: 'up' };
+			expect( selectors.getSessionFeedback( state ) ).toBe( 'up' );
 		} );
 
 		describe( 'getHasUnsavedChanges', () => {

--- a/packages/image-studio/src/store/index.test.ts
+++ b/packages/image-studio/src/store/index.test.ts
@@ -95,7 +95,7 @@ describe( 'Image Studio Store', () => {
 				selectedStyle: null,
 				selectedAspectRatio: null,
 				lastAgentMessageId: null,
-				sessionFeedback: null,
+				imageRatings: {},
 			} );
 		} );
 
@@ -853,53 +853,65 @@ describe( 'Image Studio Store', () => {
 				expect( state.lastAgentMessageId ).toBe( 'msg-123' );
 			} );
 
-			it( 'SET_SESSION_FEEDBACK', () => {
-				const state = reducer( getInitialState(), actions.setSessionFeedback( 'up' ) );
+			it( 'SET_IMAGE_RATING records a rating for an attachment', () => {
+				const state = reducer( getInitialState(), actions.setImageRating( 123, 'up' ) );
 
-				expect( state.sessionFeedback ).toBe( 'up' );
+				expect( state.imageRatings ).toEqual( { 123: 'up' } );
 			} );
 
-			it( 'SET_SESSION_FEEDBACK clears feedback when set to null', () => {
-				const initial: ImageStudioState = { ...getInitialState(), sessionFeedback: 'down' };
-				const state = reducer( initial, actions.setSessionFeedback( null ) );
+			it( 'SET_IMAGE_RATING preserves ratings for other attachments', () => {
+				const initial: ImageStudioState = {
+					...getInitialState(),
+					imageRatings: { 123: 'up' },
+				};
+				const state = reducer( initial, actions.setImageRating( 456, 'down' ) );
 
-				expect( state.sessionFeedback ).toBeNull();
+				expect( state.imageRatings ).toEqual( { 123: 'up', 456: 'down' } );
 			} );
 
-			it( 'preserves sessionFeedback when UPDATE_IMAGE_STUDIO_CANVAS fires', () => {
-				const initial: ImageStudioState = { ...getInitialState(), sessionFeedback: 'up' };
+			it( 'preserves imageRatings when UPDATE_IMAGE_STUDIO_CANVAS fires', () => {
+				const initial: ImageStudioState = {
+					...getInitialState(),
+					imageRatings: { 123: 'up' },
+				};
 				const state = reducer(
 					initial,
 					actions.updateImageStudioCanvas( 'https://example.com/v2.jpg', 456 )
 				);
 
-				expect( state.sessionFeedback ).toBe( 'up' );
+				expect( state.imageRatings ).toEqual( { 123: 'up' } );
 			} );
 
-			it( 'resets sessionFeedback on OPEN_IMAGE_STUDIO', () => {
-				const initial: ImageStudioState = { ...getInitialState(), sessionFeedback: 'up' };
-				const state = reducer( initial, actions.openImageStudio( 123 ) );
-
-				expect( state.sessionFeedback ).toBeNull();
-			} );
-
-			it( 'resets sessionFeedback on CLOSE_IMAGE_STUDIO', () => {
-				const initial: ImageStudioState = { ...getInitialState(), sessionFeedback: 'down' };
-				const state = reducer( initial, actions.closeImageStudio() );
-
-				expect( state.sessionFeedback ).toBeNull();
-			} );
-
-			it( 'resets sessionFeedback on NAVIGATE_TO_ATTACHMENT (new working session)', () => {
+			it( 'resets imageRatings on OPEN_IMAGE_STUDIO', () => {
 				const initial: ImageStudioState = {
 					...getInitialState(),
-					sessionFeedback: 'up',
+					imageRatings: { 123: 'up' },
+				};
+				const state = reducer( initial, actions.openImageStudio( 123 ) );
+
+				expect( state.imageRatings ).toEqual( {} );
+			} );
+
+			it( 'resets imageRatings on CLOSE_IMAGE_STUDIO', () => {
+				const initial: ImageStudioState = {
+					...getInitialState(),
+					imageRatings: { 123: 'down' },
+				};
+				const state = reducer( initial, actions.closeImageStudio() );
+
+				expect( state.imageRatings ).toEqual( {} );
+			} );
+
+			it( 'resets imageRatings on NAVIGATE_TO_ATTACHMENT (new working session)', () => {
+				const initial: ImageStudioState = {
+					...getInitialState(),
+					imageRatings: { 100: 'up' },
 					navigableAttachmentIds: [ 100, 200 ],
 					currentNavigationIndex: 0,
 				};
 				const state = reducer( initial, actions.navigateToAttachment( 200 ) );
 
-				expect( state.sessionFeedback ).toBeNull();
+				expect( state.imageRatings ).toEqual( {} );
 			} );
 		} );
 	} );
@@ -1074,9 +1086,37 @@ describe( 'Image Studio Store', () => {
 			expect( selectors.getLastAgentMessageId( state ) ).toBe( 'msg-123' );
 		} );
 
-		it( 'getSessionFeedback', () => {
-			const state: ImageStudioState = { ...getInitialState(), sessionFeedback: 'up' };
-			expect( selectors.getSessionFeedback( state ) ).toBe( 'up' );
+		describe( 'getImageRating', () => {
+			it( 'returns the rating for an attachment', () => {
+				const state: ImageStudioState = {
+					...getInitialState(),
+					imageRatings: { 123: 'up', 456: 'down' },
+				};
+				expect( selectors.getImageRating( state, 123 ) ).toBe( 'up' );
+				expect( selectors.getImageRating( state, 456 ) ).toBe( 'down' );
+			} );
+
+			it( 'returns null for an unrated attachment', () => {
+				const state: ImageStudioState = {
+					...getInitialState(),
+					imageRatings: { 123: 'up' },
+				};
+				expect( selectors.getImageRating( state, 999 ) ).toBeNull();
+			} );
+
+			it( 'returns null when attachmentId is null', () => {
+				const state: ImageStudioState = {
+					...getInitialState(),
+					imageRatings: { 123: 'up' },
+				};
+				expect( selectors.getImageRating( state, null ) ).toBeNull();
+			} );
+		} );
+
+		it( 'getImageRatings returns the full map', () => {
+			const ratings = { 123: 'up' as const, 456: 'down' as const };
+			const state: ImageStudioState = { ...getInitialState(), imageRatings: ratings };
+			expect( selectors.getImageRatings( state ) ).toEqual( ratings );
 		} );
 
 		describe( 'getHasUnsavedChanges', () => {

--- a/packages/image-studio/src/store/index.ts
+++ b/packages/image-studio/src/store/index.ts
@@ -105,8 +105,10 @@ export interface ImageStudioState {
 	selectedAspectRatio: string | null;
 	// Last agent message ID for feedback tracking
 	lastAgentMessageId: string | null;
-	// Feedback submitted for the current session; once set, the rating buttons stay disabled
-	sessionFeedback: 'up' | 'down' | null;
+	// Ratings the user has submitted in this session, keyed by attachment ID.
+	// Once a rating is recorded for an image it stays for the session so the
+	// buttons remain disabled when navigating back to that image.
+	imageRatings: Record< number, 'up' | 'down' >;
 }
 
 /**
@@ -256,9 +258,12 @@ type SetLastAgentMessageIdAction = {
 	payload: string | null;
 };
 
-type SetSessionFeedbackAction = {
-	type: 'SET_SESSION_FEEDBACK';
-	payload: 'up' | 'down' | null;
+type SetImageRatingAction = {
+	type: 'SET_IMAGE_RATING';
+	payload: {
+		attachmentId: number;
+		rating: 'up' | 'down';
+	};
 };
 
 type ResetCanvasHistoryAction = {
@@ -292,7 +297,7 @@ type ImageStudioAction =
 	| SetSelectedStyleAction
 	| SetSelectedAspectRatioAction
 	| SetLastAgentMessageIdAction
-	| SetSessionFeedbackAction
+	| SetImageRatingAction
 	| ResetCanvasHistoryAction;
 
 /**
@@ -360,7 +365,7 @@ const initialState: ImageStudioState = {
 	selectedStyle: null,
 	selectedAspectRatio: null,
 	lastAgentMessageId: null,
-	sessionFeedback: null,
+	imageRatings: {},
 };
 
 /**
@@ -599,8 +604,8 @@ const reducer = (
 				onCloseCallback: null,
 				entryPoint: null,
 				blockType: null,
-				// Reset feedback for the new file since it's a new working session
-				sessionFeedback: null,
+				// Reset ratings for the new file since it's a new working session
+				imageRatings: {},
 				// Keep navigation state (navigableAttachmentIds, currentNavigationIndex, pagination)
 				// Keep user preferences (isSidebarOpen, selectedStyle, selectedAspectRatio)
 			};
@@ -643,10 +648,13 @@ const reducer = (
 				lastAgentMessageId: action.payload,
 			};
 
-		case 'SET_SESSION_FEEDBACK':
+		case 'SET_IMAGE_RATING':
 			return {
 				...state,
-				sessionFeedback: action.payload,
+				imageRatings: {
+					...state.imageRatings,
+					[ action.payload.attachmentId ]: action.payload.rating,
+				},
 			};
 
 		case 'RESET_CANVAS_HISTORY':
@@ -727,7 +735,10 @@ export interface ImageStudioActions {
 	setSelectedStyle: ( style: string | null ) => Promise< SetSelectedStyleAction >;
 	setSelectedAspectRatio: ( aspectRatio: string | null ) => Promise< SetSelectedAspectRatioAction >;
 	setLastAgentMessageId: ( messageId: string | null ) => Promise< SetLastAgentMessageIdAction >;
-	setSessionFeedback: ( feedback: 'up' | 'down' | null ) => Promise< SetSessionFeedbackAction >;
+	setImageRating: (
+		attachmentId: number,
+		rating: 'up' | 'down'
+	) => Promise< SetImageRatingAction >;
 	resetCanvasHistory: () => Promise< ResetCanvasHistoryAction >;
 }
 
@@ -945,10 +956,10 @@ const actions = {
 		};
 	},
 
-	setSessionFeedback( feedback: 'up' | 'down' | null ): SetSessionFeedbackAction {
+	setImageRating( attachmentId: number, rating: 'up' | 'down' ): SetImageRatingAction {
 		return {
-			type: 'SET_SESSION_FEEDBACK',
-			payload: feedback,
+			type: 'SET_IMAGE_RATING',
+			payload: { attachmentId, rating },
 		};
 	},
 
@@ -997,7 +1008,8 @@ export interface ImageStudioSelectors {
 	getSelectedStyle: ( state: ImageStudioState ) => string | null;
 	getSelectedAspectRatio: ( state: ImageStudioState ) => string | null;
 	getLastAgentMessageId: ( state: ImageStudioState ) => string | null;
-	getSessionFeedback: ( state: ImageStudioState ) => 'up' | 'down' | null;
+	getImageRatings: ( state: ImageStudioState ) => Record< number, 'up' | 'down' >;
+	getImageRating: ( state: ImageStudioState, attachmentId: number | null ) => 'up' | 'down' | null;
 	getSupportedMimeTypes: () => readonly string[];
 }
 
@@ -1172,8 +1184,15 @@ const selectors = {
 		return state.lastAgentMessageId;
 	},
 
-	getSessionFeedback( state: ImageStudioState ): 'up' | 'down' | null {
-		return state.sessionFeedback;
+	getImageRatings( state: ImageStudioState ): Record< number, 'up' | 'down' > {
+		return state.imageRatings;
+	},
+
+	getImageRating( state: ImageStudioState, attachmentId: number | null ): 'up' | 'down' | null {
+		if ( attachmentId === null ) {
+			return null;
+		}
+		return state.imageRatings[ attachmentId ] ?? null;
 	},
 
 	getSupportedMimeTypes(): readonly string[] {

--- a/packages/image-studio/src/store/index.ts
+++ b/packages/image-studio/src/store/index.ts
@@ -105,6 +105,8 @@ export interface ImageStudioState {
 	selectedAspectRatio: string | null;
 	// Last agent message ID for feedback tracking
 	lastAgentMessageId: string | null;
+	// Feedback submitted for the current session; once set, the rating buttons stay disabled
+	sessionFeedback: 'up' | 'down' | null;
 }
 
 /**
@@ -254,6 +256,11 @@ type SetLastAgentMessageIdAction = {
 	payload: string | null;
 };
 
+type SetSessionFeedbackAction = {
+	type: 'SET_SESSION_FEEDBACK';
+	payload: 'up' | 'down' | null;
+};
+
 type ResetCanvasHistoryAction = {
 	type: 'RESET_CANVAS_HISTORY';
 };
@@ -285,6 +292,7 @@ type ImageStudioAction =
 	| SetSelectedStyleAction
 	| SetSelectedAspectRatioAction
 	| SetLastAgentMessageIdAction
+	| SetSessionFeedbackAction
 	| ResetCanvasHistoryAction;
 
 /**
@@ -352,6 +360,7 @@ const initialState: ImageStudioState = {
 	selectedStyle: null,
 	selectedAspectRatio: null,
 	lastAgentMessageId: null,
+	sessionFeedback: null,
 };
 
 /**
@@ -590,6 +599,8 @@ const reducer = (
 				onCloseCallback: null,
 				entryPoint: null,
 				blockType: null,
+				// Reset feedback for the new file since it's a new working session
+				sessionFeedback: null,
 				// Keep navigation state (navigableAttachmentIds, currentNavigationIndex, pagination)
 				// Keep user preferences (isSidebarOpen, selectedStyle, selectedAspectRatio)
 			};
@@ -630,6 +641,12 @@ const reducer = (
 			return {
 				...state,
 				lastAgentMessageId: action.payload,
+			};
+
+		case 'SET_SESSION_FEEDBACK':
+			return {
+				...state,
+				sessionFeedback: action.payload,
 			};
 
 		case 'RESET_CANVAS_HISTORY':
@@ -710,6 +727,7 @@ export interface ImageStudioActions {
 	setSelectedStyle: ( style: string | null ) => Promise< SetSelectedStyleAction >;
 	setSelectedAspectRatio: ( aspectRatio: string | null ) => Promise< SetSelectedAspectRatioAction >;
 	setLastAgentMessageId: ( messageId: string | null ) => Promise< SetLastAgentMessageIdAction >;
+	setSessionFeedback: ( feedback: 'up' | 'down' | null ) => Promise< SetSessionFeedbackAction >;
 	resetCanvasHistory: () => Promise< ResetCanvasHistoryAction >;
 }
 
@@ -927,6 +945,13 @@ const actions = {
 		};
 	},
 
+	setSessionFeedback( feedback: 'up' | 'down' | null ): SetSessionFeedbackAction {
+		return {
+			type: 'SET_SESSION_FEEDBACK',
+			payload: feedback,
+		};
+	},
+
 	resetCanvasHistory(): ResetCanvasHistoryAction {
 		return {
 			type: 'RESET_CANVAS_HISTORY',
@@ -972,6 +997,7 @@ export interface ImageStudioSelectors {
 	getSelectedStyle: ( state: ImageStudioState ) => string | null;
 	getSelectedAspectRatio: ( state: ImageStudioState ) => string | null;
 	getLastAgentMessageId: ( state: ImageStudioState ) => string | null;
+	getSessionFeedback: ( state: ImageStudioState ) => 'up' | 'down' | null;
 	getSupportedMimeTypes: () => readonly string[];
 }
 
@@ -1144,6 +1170,10 @@ const selectors = {
 
 	getLastAgentMessageId( state: ImageStudioState ): string | null {
 		return state.lastAgentMessageId;
+	},
+
+	getSessionFeedback( state: ImageStudioState ): 'up' | 'down' | null {
+		return state.sessionFeedback;
 	},
 
 	getSupportedMimeTypes(): readonly string[] {


### PR DESCRIPTION
Part of FORNO-277

## Proposed Changes

* Move thumbs up/down feedback state from `CanvasControls` local state into the image-studio Redux store as `sessionFeedback`, with matching action, selector and tests.
* Keep the rating buttons disabled for the remainder of the session once a rating is submitted; reset only on modal open/close or when navigating to a different attachment.

## Why are these changes being made?

* The rating buttons were re-enabling after navigating between generated image versions because the component remounts on image swap and its `useEffect` also cleared the feedback on every `imageUrl` change. Lifting the state to the store makes it session-scoped as intended.

## Testing Instructions

* `install-plugin.sh am fix/image-rating-session-persistence` on your sandbox
* Sandbox `widgets.wp.com`
* Open Image Studio on an image.
* Check `getImageRating()` is available: `wp.data.select('image-studio').getImageRating()` 
* Edit the image with AI, and submit a thumbs up vote.
* Use the revision navigator to switch between versions — the rating buttons should stay disabled with the chosen rating still pressed.
* Navigate to a different media library attachment — the rating buttons should be enabled again.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?