### PR TITLE
Image Studio: Disable nav pill while edits are in progress

### DIFF
--- a/packages/image-studio/src/components/header/index.test.tsx
+++ b/packages/image-studio/src/components/header/index.test.tsx
@@ -568,7 +568,7 @@ describe( 'Header', () => {
 			expect( screen.getByLabelText( /Next image/ ) ).toBeDisabled();
 		} );
 
-		it( 'hides the navigation pill when there are drafts', () => {
+		it( 'disables navigation when there are drafts', () => {
 			mockUseSelect.mockImplementation( ( selector: any ) => {
 				const result = selector( () => ( {
 					getImageStudioAiProcessing: () => false,
@@ -584,12 +584,12 @@ describe( 'Header', () => {
 				<Header { ...defaultProps } mode={ ImageStudioMode.Edit } hasPreviousImage hasNextImage />
 			);
 
-			expect( screen.queryByText( 'test-image.jpg' ) ).not.toBeInTheDocument();
-			expect( screen.queryByLabelText( /Previous image/ ) ).not.toBeInTheDocument();
-			expect( screen.queryByLabelText( /Next image/ ) ).not.toBeInTheDocument();
+			expect( screen.getByText( 'test-image.jpg' ) ).toBeInTheDocument();
+			expect( screen.getByLabelText( /Previous image/ ) ).toBeDisabled();
+			expect( screen.getByLabelText( /Next image/ ) ).toBeDisabled();
 		} );
 
-		it( 'hides the navigation pill when metadata has been updated', () => {
+		it( 'disables navigation when metadata has been updated', () => {
 			mockUseSelect.mockImplementation( ( selector: any ) => {
 				const result = selector( () => ( {
 					getImageStudioAiProcessing: () => false,
@@ -605,9 +605,9 @@ describe( 'Header', () => {
 				<Header { ...defaultProps } mode={ ImageStudioMode.Edit } hasPreviousImage hasNextImage />
 			);
 
-			expect( screen.queryByText( 'test-image.jpg' ) ).not.toBeInTheDocument();
-			expect( screen.queryByLabelText( /Previous image/ ) ).not.toBeInTheDocument();
-			expect( screen.queryByLabelText( /Next image/ ) ).not.toBeInTheDocument();
+			expect( screen.getByText( 'test-image.jpg' ) ).toBeInTheDocument();
+			expect( screen.getByLabelText( /Previous image/ ) ).toBeDisabled();
+			expect( screen.getByLabelText( /Next image/ ) ).toBeDisabled();
 		} );
 
 		it( 'disables navigation when AI is processing', () => {

--- a/packages/image-studio/src/components/header/index.test.tsx
+++ b/packages/image-studio/src/components/header/index.test.tsx
@@ -568,7 +568,7 @@ describe( 'Header', () => {
 			expect( screen.getByLabelText( /Next image/ ) ).toBeDisabled();
 		} );
 
-		it( 'disables navigation when there are drafts', () => {
+		it( 'hides the navigation pill when there are drafts', () => {
 			mockUseSelect.mockImplementation( ( selector: any ) => {
 				const result = selector( () => ( {
 					getImageStudioAiProcessing: () => false,
@@ -584,12 +584,30 @@ describe( 'Header', () => {
 				<Header { ...defaultProps } mode={ ImageStudioMode.Edit } hasPreviousImage hasNextImage />
 			);
 
-			// When there are drafts, the nav button labels change to a tooltip message
-			const navButtons = screen.getAllByLabelText( /Save or discard your changes/ );
-			expect( navButtons ).toHaveLength( 2 );
-			navButtons.forEach( ( button ) => {
-				expect( button ).toBeDisabled();
+			expect( screen.queryByText( 'test-image.jpg' ) ).not.toBeInTheDocument();
+			expect( screen.queryByLabelText( /Previous image/ ) ).not.toBeInTheDocument();
+			expect( screen.queryByLabelText( /Next image/ ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'hides the navigation pill when metadata has been updated', () => {
+			mockUseSelect.mockImplementation( ( selector: any ) => {
+				const result = selector( () => ( {
+					getImageStudioAiProcessing: () => false,
+					getHasUpdatedMetadata: () => true,
+					getIsAnnotationMode: () => false,
+					getDraftIds: () => [],
+					getEntryPoint: () => ImageStudioEntryPoint.MediaLibrary,
+				} ) );
+				return result;
 			} );
+
+			render(
+				<Header { ...defaultProps } mode={ ImageStudioMode.Edit } hasPreviousImage hasNextImage />
+			);
+
+			expect( screen.queryByText( 'test-image.jpg' ) ).not.toBeInTheDocument();
+			expect( screen.queryByLabelText( /Previous image/ ) ).not.toBeInTheDocument();
+			expect( screen.queryByLabelText( /Next image/ ) ).not.toBeInTheDocument();
 		} );
 
 		it( 'disables navigation when AI is processing', () => {

--- a/packages/image-studio/src/components/header/index.tsx
+++ b/packages/image-studio/src/components/header/index.tsx
@@ -98,9 +98,15 @@ export const Header = ( {
 
 	const showTools = mode === ImageStudioMode.Edit;
 	const showTitle = mode === ImageStudioMode.Generate;
-	// Show navigation pill in Edit mode on uploads page, if we have a filename to display
+	// Hide the pill while the user has unsaved edits: the displayed filename
+	// tracks the current canvas image across variants, which makes the disabled
+	// library navigation buttons look like they should work.
 	const showNavigationPill =
-		mode === ImageStudioMode.Edit && !! config?.imageData?.filename && window.pagenow === 'upload';
+		mode === ImageStudioMode.Edit &&
+		!! config?.imageData?.filename &&
+		window.pagenow === 'upload' &&
+		! hasDrafts &&
+		! hasUpdatedMetadata;
 
 	// Generate classic editor URL if we have an attachment ID
 	const classicEditorUrl = config?.attachmentId

--- a/packages/image-studio/src/components/header/index.tsx
+++ b/packages/image-studio/src/components/header/index.tsx
@@ -98,15 +98,8 @@ export const Header = ( {
 
 	const showTools = mode === ImageStudioMode.Edit;
 	const showTitle = mode === ImageStudioMode.Generate;
-	// Hide the pill while the user has unsaved edits: the displayed filename
-	// tracks the current canvas image across variants, which makes the disabled
-	// library navigation buttons look like they should work.
 	const showNavigationPill =
-		mode === ImageStudioMode.Edit &&
-		!! config?.imageData?.filename &&
-		window.pagenow === 'upload' &&
-		! hasDrafts &&
-		! hasUpdatedMetadata;
+		mode === ImageStudioMode.Edit && !! config?.imageData?.filename && window.pagenow === 'upload';
 
 	// Generate classic editor URL if we have an attachment ID
 	const classicEditorUrl = config?.attachmentId
@@ -114,7 +107,7 @@ export const Header = ( {
 		: null;
 
 	const modKeySymbol = isAppleOS() ? '⌘' : '^';
-	const isNavDisabled = hasDrafts || isAiProcessing || isSaving;
+	const isNavDisabled = hasDrafts || hasUpdatedMetadata || isAiProcessing || isSaving;
 
 	// Get entry point from store with fallback for navigation
 	const entryPoint = useSelect(
@@ -153,11 +146,6 @@ export const Header = ( {
 				return __( 'Save displayed image to Media Library', __i18n_text_domain__ );
 		}
 	};
-
-	let navButtonDisabledTooltip: string | undefined;
-	if ( hasDrafts || hasUpdatedMetadata ) {
-		navButtonDisabledTooltip = __( 'Save or discard your changes', __i18n_text_domain__ );
-	}
 
 	useKeyboardShortcut( 'mod+z', () => onAnnotationUndo?.(), {
 		isDisabled: ! isAnnotationMode || ! hasPendingAnnotations,
@@ -226,16 +214,12 @@ export const Header = ( {
 								icon={ chevronLeft }
 								onClick={ onNavigatePrevious }
 								disabled={ ! hasPreviousImage || isNavDisabled }
-								label={
-									navButtonDisabledTooltip ||
-									sprintf(
-										/* translators: %s: modifier key (command or control) */
-										__( 'Previous image %s←', __i18n_text_domain__ ),
-										modKeySymbol
-									)
-								}
+								label={ sprintf(
+									/* translators: %s: modifier key (command or control) */
+									__( 'Previous image %s←', __i18n_text_domain__ ),
+									modKeySymbol
+								) }
 								showTooltip
-								accessibleWhenDisabled={ !! navButtonDisabledTooltip }
 								className="image-studio-header__nav-button"
 							/>
 							<span className="image-studio-header__filename">
@@ -246,16 +230,12 @@ export const Header = ( {
 								icon={ chevronRight }
 								onClick={ onNavigateNext }
 								disabled={ ! hasNextImage || isNavDisabled }
-								label={
-									navButtonDisabledTooltip ||
-									sprintf(
-										/* translators: %s: modifier key (command or control) */
-										__( 'Next image %s→', __i18n_text_domain__ ),
-										modKeySymbol
-									)
-								}
+								label={ sprintf(
+									/* translators: %s: modifier key (command or control) */
+									__( 'Next image %s→', __i18n_text_domain__ ),
+									modKeySymbol
+								) }
 								showTooltip
-								accessibleWhenDisabled={ !! navButtonDisabledTooltip }
 								className="image-studio-header__nav-button"
 							/>
 						</div>

--- a/packages/image-studio/src/components/style.scss
+++ b/packages/image-studio/src/components/style.scss
@@ -69,7 +69,7 @@ body.js.is-image-studio-open {
 	input,
 	select,
 	textarea {
-		color: inherit !important;
+		color: inherit;
 	}
 
 	// Restore agenttic-ui button backgrounds stripped by P2's


### PR DESCRIPTION
Part of FORNO-340. Follow-up to #109993.

## Proposed Changes

* Disable the Edit-mode navigation pill when the user has unsaved drafts or metadata changes.

## Why are these changes being made?

On the uploads page, the pill allows navigating between images in the media library. When edits are in progress the library navigation buttons are disabled but they are currently accessible to support a tooltip instructing the user to save or discard their changes. This causes confusion because the buttons appear to be active but they are in fact disabled. Making them fully disabled addresses this. There is still a potential issue where the file name changes when navigating between image variants, however this is also the case in the Image Info so I am not attempting to change this behaviour. I attempted hiding the pill rather than disabling the buttons, however I felt this was more confusing to have it disappear and reappear

See also https://github.com/Automattic/wp-calypso/pull/109993#issuecomment-3499929089.

## Testing Instructions

* `install-plugin.sh am image-editor-nav-feedback` on your sandbox.
* Sandbox `widgets.wp.com`.
* Open Image Studio from the WP Media Library (uploads screen) in Edit mode with multiple library images → the navigation pill should appear and you should be able to step between library images.
* Request an edit, the pill nav buttons should be disabled while edits are unsaved.
* Navigate between image revisions using the arrows beneath the image, the pill buttons should remain disabled
* Save the image
* The pill navigation buttons should be re-enabled

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?