### PR TITLE
Add image upload capabilities to external agents

### DIFF
--- a/apps/agents-manager/agents-manager-with-provider.js
+++ b/apps/agents-manager/agents-manager-with-provider.js
@@ -5,7 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 const queryClient = new QueryClient();
 
-export default function AgentsManagerWithProvider() {
+export default function AgentsManagerWithProvider( { useImageUpload } ) {
 	return (
 		<QueryClientProvider client={ queryClient }>
 			<AgentsManager
@@ -13,6 +13,7 @@ export default function AgentsManagerWithProvider() {
 				currentUser={ agentsManagerData.currentUser }
 				site={ agentsManagerData.site }
 				currentSiteId={ agentsManagerData.site?.ID }
+				useImageUpload={ useImageUpload }
 			/>
 		</QueryClientProvider>
 	);

--- a/apps/agents-manager/agents-manager-wooai.js
+++ b/apps/agents-manager/agents-manager-wooai.js
@@ -9,10 +9,11 @@
  * without touching the admin bar or Site Hub.
  */
 
+import { useImageUpload } from '@automattic/agents-manager';
 import { createRoot } from 'react-dom/client';
 import AgentsManagerWithProvider from './agents-manager-with-provider';
 
 const container = document.createElement( 'div' );
 container.id = 'agents-manager-root';
 document.body.appendChild( container );
-createRoot( container ).render( <AgentsManagerWithProvider /> );
+createRoot( container ).render( <AgentsManagerWithProvider useImageUpload={ useImageUpload } /> );

--- a/packages/agents-manager/package.json
+++ b/packages/agents-manager/package.json
@@ -54,6 +54,7 @@
 		"@automattic/zendesk-client": "workspace:^",
 		"@tanstack/react-query": "^5.83.0",
 		"@wordpress/api-fetch": "^7.23.0",
+		"@wordpress/blob": "4.23.0",
 		"@wordpress/block-editor": "^14.18.0",
 		"@wordpress/blocks": "^14.12.0",
 		"@wordpress/components": "^32.1.0",

--- a/packages/agents-manager/package.json
+++ b/packages/agents-manager/package.json
@@ -61,6 +61,7 @@
 		"@wordpress/html-entities": "^4.23.0",
 		"@wordpress/i18n": "^5.23.0",
 		"@wordpress/icons": "^10.23.0",
+		"@wordpress/media-utils": "^5.44.0",
 		"@wordpress/primitives": "^4.23.0",
 		"@wordpress/private-apis": "^1.39.0",
 		"@wordpress/url": "^4.23.0",

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -21,7 +21,7 @@ import CustomALink from '../custom-a-link';
 import FeedbackInput from '../feedback-input';
 import { AI } from '../icons';
 import SelectedBlock from '../selected-block';
-import type { UseImageUploadResult } from '../../utils/load-external-providers';
+import type { UseImageUploadResult } from '../../hooks/use-image-upload';
 import type { Message, NoticeConfig } from '@automattic/agenttic-ui/dist/types';
 import type { AgentsManagerSelect } from '@automattic/data-stores';
 

--- a/packages/agents-manager/src/components/agents-manager.tsx
+++ b/packages/agents-manager/src/components/agents-manager.tsx
@@ -14,7 +14,11 @@ import { useEmptyViewSuggestions } from '../hooks/use-empty-view-suggestions';
 import { AGENTS_MANAGER_STORE } from '../stores';
 import { clearSessionId } from '../utils/agent-session';
 import { createAgentConfig } from '../utils/create-agent-config';
-import { loadExternalProviders, type LoadedProviders } from '../utils/load-external-providers';
+import {
+	ImageUploadHook,
+	loadExternalProviders,
+	type LoadedProviders,
+} from '../utils/load-external-providers';
 import AgentDock from './agent-dock';
 import { PersistentRouter } from './persistent-router';
 
@@ -31,6 +35,8 @@ export interface AgentsManagerProps {
 	currentSiteId?: number;
 	/** Called when the agent is closed. */
 	handleClose?: () => void;
+	/** The hook for handling image uploads. */
+	useImageUpload?: ImageUploadHook;
 }
 
 const queryClient = new QueryClient();
@@ -41,6 +47,7 @@ export default function AgentsManager( {
 	site,
 	currentRoute,
 	currentSiteId,
+	useImageUpload,
 }: AgentsManagerProps ): JSX.Element | null {
 	// Wait for the store to load before rendering PersistentRouter
 	// This ensures router history is restored from persisted state
@@ -61,7 +68,7 @@ export default function AgentsManager( {
 		>
 			<QueryClientProvider client={ queryClient }>
 				<PersistentRouter siteKey={ siteKey }>
-					<AgentSetup />
+					<AgentSetup useImageUpload={ useImageUpload } />
 				</PersistentRouter>
 			</QueryClientProvider>
 		</AgentsManagerContextProvider>
@@ -69,7 +76,11 @@ export default function AgentsManager( {
 }
 
 // Separate component that uses hooks within `PersistentRouter` context
-function AgentSetup(): JSX.Element | null {
+function AgentSetup( {
+	useImageUpload: fallbackUseImageUpload,
+}: {
+	useImageUpload?: ImageUploadHook;
+} ): JSX.Element | null {
 	const { site, currentRoute, agentConfig, setAgentConfig } = useAgentsManagerContext();
 	const loadedProvidersRef = useRef< LoadedProviders | null >( null );
 	const navigate = useNavigate();
@@ -164,7 +175,7 @@ function AgentSetup(): JSX.Element | null {
 			useSuggestions={ loadedProviders.useSuggestions }
 			getChatComponent={ loadedProviders.getChatComponent }
 			siteBuildUtils={ loadedProviders.siteBuildUtils }
-			useImageUpload={ loadedProviders.useImageUpload }
+			useImageUpload={ loadedProviders.useImageUpload ?? fallbackUseImageUpload }
 			useCheckpoint={ loadedProviders.useCheckpoint }
 		/>
 	);

--- a/packages/agents-manager/src/components/agents-manager.tsx
+++ b/packages/agents-manager/src/components/agents-manager.tsx
@@ -15,8 +15,8 @@ import { AGENTS_MANAGER_STORE } from '../stores';
 import { clearSessionId } from '../utils/agent-session';
 import { createAgentConfig } from '../utils/create-agent-config';
 import {
-	ImageUploadHook,
 	loadExternalProviders,
+	type ImageUploadHook,
 	type LoadedProviders,
 } from '../utils/load-external-providers';
 import AgentDock from './agent-dock';

--- a/packages/agents-manager/src/hooks/use-image-upload.ts
+++ b/packages/agents-manager/src/hooks/use-image-upload.ts
@@ -1,0 +1,171 @@
+/**
+ * WordPress dependencies
+ */
+import { isBlobURL } from '@wordpress/blob';
+import { useCallback, useState } from '@wordpress/element';
+import { type Attachment, uploadMedia } from '@wordpress/media-utils';
+/**
+ * External dependencies
+ */
+import type { UploadedImage, UploadingImage } from '@automattic/agenttic-ui';
+
+export interface MediaObject {
+	id: number;
+	title: string;
+	fileName: string;
+	fileType: string;
+	fileSize: number;
+	dimensions: {
+		width: number;
+		height: number;
+	};
+	uploadDate: string;
+	uploadedBy: number;
+	url: string;
+	alt: string;
+	caption: string;
+}
+
+export interface ImagePreview {
+	id: string;
+	url: string;
+	name: string;
+	alt: string;
+	mime_type: string;
+	file: File;
+}
+
+export interface UseImageUploadResult {
+	pendingImages: ImagePreview[];
+	uploadingImages: UploadingImage[];
+	isUploadingImages: boolean;
+	handleFilesSelected: ( files: File[] ) => Promise< void >;
+	handleRemoveImage: ( image: UploadedImage ) => void;
+	uploadImagesToWordPress: () => Promise< MediaObject[] >;
+}
+
+/**
+ * Transform WordPress media API response into our MediaObject format.
+ */
+function transformMediaObject( media: Attachment ): MediaObject {
+	return {
+		id: media.id,
+		title: media.title || '',
+		fileName: ( media.media_details?.file as string ) || media.slug || '',
+		fileType: media.mime_type || '',
+		fileSize: ( media.media_details?.filesize as number ) || 0,
+		dimensions: {
+			width: ( media.media_details?.width as number ) || 0,
+			height: ( media.media_details?.height as number ) || 0,
+		},
+		uploadDate: media.date || '',
+		uploadedBy: media.author || 0,
+		url: media.url || '',
+		alt: media.alt || '',
+		caption: media.caption || '',
+	};
+}
+
+/**
+ * Create an image preview from a File object using FileReader.
+ */
+function createImagePreviewFromFile( file: File ): Promise< ImagePreview > {
+	return new Promise< ImagePreview >( ( resolve, reject ) => {
+		const reader = new FileReader();
+		reader.onload = () => {
+			resolve( {
+				id: `${ file.name }-${ Date.now() }`,
+				url: reader.result as string,
+				name: file.name,
+				alt: file.name,
+				mime_type: file.type,
+				file,
+			} );
+		};
+		reader.onerror = reject;
+		reader.readAsDataURL( file );
+	} );
+}
+
+const isAttachment = ( media?: Partial< Attachment > ): media is Attachment => {
+	return typeof media === 'object' && media !== null && 'id' in media;
+};
+
+/**
+ * Custom hook for handling image upload functionality.
+ *
+ * Manages:
+ * - Pending images state (preview before upload)
+ * - Upload progress state
+ * - File selection UI
+ * - Image removal
+ * - WordPress media library upload
+ */
+export function useImageUpload(): UseImageUploadResult {
+	const [ pendingImages, setPendingImages ] = useState< ImagePreview[] >( [] );
+	const [ uploadingImages, setUploadingImages ] = useState< UploadingImage[] >( [] );
+	const [ isUploadingImages, setIsUploadingImages ] = useState< boolean >( false );
+
+	const handleFilesSelected = useCallback(
+		async ( files: File[] ) => {
+			const previewFiles = await Promise.all(
+				files.map( ( file ) => createImagePreviewFromFile( file ) )
+			);
+			setPendingImages( [ ...pendingImages, ...previewFiles ] );
+		},
+		[ pendingImages ]
+	);
+
+	const handleRemoveImage = useCallback( ( image: UploadedImage ) => {
+		setPendingImages( ( prevImages ) => prevImages.filter( ( img ) => img.id !== image.id ) );
+	}, [] );
+
+	const uploadImagesToWordPress = useCallback( (): Promise< MediaObject[] > => {
+		const imagesToUpload = [ ...pendingImages ];
+
+		setUploadingImages( imagesToUpload.map( ( img ) => ( { id: img.id, file: img.file } ) ) );
+		setPendingImages( [] );
+		setIsUploadingImages( true );
+
+		return new Promise< MediaObject[] >( ( resolve, reject ) => {
+			const files = imagesToUpload.map( ( img ) => img.file );
+
+			uploadMedia( {
+				filesList: files,
+				onFileChange: ( changedFiles ) => {
+					const mediaObjects: MediaObject[] = [];
+					let completedUploads = 0;
+
+					changedFiles.forEach( ( media ) => {
+						if ( ! isBlobURL( media?.url ) && isAttachment( media ) ) {
+							mediaObjects.push( transformMediaObject( media ) );
+							completedUploads++;
+						}
+					} );
+
+					if ( mediaObjects.length > 0 ) {
+						if ( completedUploads === files.length ) {
+							setUploadingImages( [] );
+							setIsUploadingImages( false );
+							resolve( mediaObjects );
+						}
+					}
+				},
+				onError: ( uploadError ) => {
+					setUploadingImages( [] );
+					setIsUploadingImages( false );
+					reject( uploadError );
+				},
+			} );
+		} );
+	}, [ pendingImages ] );
+
+	return {
+		pendingImages,
+		uploadingImages,
+		isUploadingImages,
+		handleFilesSelected,
+		handleRemoveImage,
+		uploadImagesToWordPress,
+	};
+}

--- a/packages/agents-manager/src/hooks/use-image-upload.ts
+++ b/packages/agents-manager/src/hooks/use-image-upload.ts
@@ -106,15 +106,12 @@ export function useImageUpload(): UseImageUploadResult {
 	const [ uploadingImages, setUploadingImages ] = useState< UploadingImage[] >( [] );
 	const [ isUploadingImages, setIsUploadingImages ] = useState< boolean >( false );
 
-	const handleFilesSelected = useCallback(
-		async ( files: File[] ) => {
-			const previewFiles = await Promise.all(
-				files.map( ( file ) => createImagePreviewFromFile( file ) )
-			);
-			setPendingImages( [ ...pendingImages, ...previewFiles ] );
-		},
-		[ pendingImages ]
-	);
+	const handleFilesSelected = useCallback( async ( files: File[] ) => {
+		const previewFiles = await Promise.all(
+			files.map( ( file ) => createImagePreviewFromFile( file ) )
+		);
+		setPendingImages( ( prevImages ) => [ ...prevImages, ...previewFiles ] );
+	}, [] );
 
 	const handleRemoveImage = useCallback( ( image: UploadedImage ) => {
 		setPendingImages( ( prevImages ) => prevImages.filter( ( img ) => img.id !== image.id ) );

--- a/packages/agents-manager/src/hooks/use-image-upload.ts
+++ b/packages/agents-manager/src/hooks/use-image-upload.ts
@@ -169,3 +169,5 @@ export function useImageUpload(): UseImageUploadResult {
 		uploadImagesToWordPress,
 	};
 }
+
+export type ImageUploadHook = typeof useImageUpload;

--- a/packages/agents-manager/src/index.ts
+++ b/packages/agents-manager/src/index.ts
@@ -21,6 +21,7 @@ export type {
 } from './types';
 
 export { useShouldUseUnifiedAgent } from './hooks/use-should-use-unified-agent';
+export { useImageUpload } from './hooks/use-image-upload';
 
 // Feedback exports
 export {

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -12,14 +12,10 @@
  */
 
 import { getAgentManager, UIMessage } from '@automattic/agenttic-client';
+import type { ImageUploadHook } from '../hooks/use-image-upload';
 import type { ToolProvider, ContextProvider, Suggestion, BigSkyMessage } from '../types';
 import type { UseAgentChatReturn } from '@automattic/agenttic-client';
-import type {
-	MarkdownComponents,
-	MarkdownExtensions,
-	UploadedImage,
-	UploadingImage,
-} from '@automattic/agenttic-ui';
+import type { MarkdownComponents, MarkdownExtensions } from '@automattic/agenttic-ui';
 
 /**
  * Check if the unified experience flag is set via agentsManagerData.
@@ -99,43 +95,6 @@ type ChatComponentType =
  */
 export type GetChatComponent = ( type: ChatComponentType ) => React.ComponentType< unknown > | null;
 
-export type ImagePreview = {
-	id: string;
-	url: string;
-	name: string;
-	alt: string;
-	mime_type: string;
-	file: File;
-};
-
-export type MediaObject = {
-	id: number;
-	title: string;
-	fileName: string;
-	fileType: string;
-	fileSize: number;
-	dimensions: {
-		width: number;
-		height: number;
-	};
-	uploadDate: string;
-	uploadedBy: number;
-	url: string;
-	alt: string;
-	caption: string;
-};
-
-export type UseImageUploadResult = {
-	pendingImages: ImagePreview[];
-	uploadingImages: UploadingImage[];
-	isUploadingImages: boolean;
-	handleFilesSelected: ( files: File[] ) => Promise< void >;
-	handleRemoveImage: ( image: UploadedImage ) => void;
-	uploadImagesToWordPress: () => Promise< MediaObject[] >;
-};
-
-export type ImageUploadHook = () => UseImageUploadResult;
-
 /**
  * Checkpoint return type - for saving and restoring editor state so that AI actions can be undone.
  */
@@ -158,6 +117,8 @@ export type UseCheckpointReturn = {
 
 /** Hook that returns checkpoint utilities for the current editor session. */
 export type UseCheckpointHook = () => UseCheckpointReturn;
+
+export type { ImageUploadHook };
 
 export interface LoadedProviders {
 	toolProvider?: ToolProvider;

--- a/yarn.lock
+++ b/yarn.lock
@@ -163,6 +163,7 @@ __metadata:
     "@types/react-dom": "npm:^18.3.1"
     "@wordpress/api-fetch": "npm:^7.23.0"
     "@wordpress/base-styles": "npm:^5.23.0"
+    "@wordpress/blob": "npm:4.23.0"
     "@wordpress/block-editor": "npm:^14.18.0"
     "@wordpress/blocks": "npm:^14.12.0"
     "@wordpress/components": "npm:^32.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -170,6 +170,7 @@ __metadata:
     "@wordpress/html-entities": "npm:^4.23.0"
     "@wordpress/i18n": "npm:^5.23.0"
     "@wordpress/icons": "npm:^10.23.0"
+    "@wordpress/media-utils": "npm:^5.44.0"
     "@wordpress/primitives": "npm:^4.23.0"
     "@wordpress/private-apis": "npm:^1.39.0"
     "@wordpress/url": "npm:^4.23.0"


### PR DESCRIPTION
Fixes WOOAI-495

## Proposed Changes

External agents (e.g., Woo AI, self-hosted) weren't getting image upload capabilities. CIAB and BigSky were, and that's because they're passing a `useImageUpload` hook when mounting the assistant.

This PR makes the `useImageUpload` hook part of `packages/agents-manager`, and each external agent can opt in by passing the hook to `<AgentsManagerWithProvider />`.

The reason I'm doing this (passing the image upload hook within the `agents-manager-(agent).js` file instead of passing it within the `provider-module.js` of the external assistant) is that I believe this is a core capability that should be easy for agents to opt in to, instead of having to implement their own copy every time.

| Before | After |
| --- | --- |
| <img width="344" height="178" alt="CleanShot 2026-04-17 at 13 27 12" src="https://github.com/user-attachments/assets/b7f8cfbe-2e18-4138-80ca-9bc90c911e3d" /> | <img width="353" height="227" alt="CleanShot 2026-04-17 at 13 25 35" src="https://github.com/user-attachments/assets/084772ef-b7b2-4cc1-8c00-d0e6f488f4cf" /> |


## Testing Instructions

1. Run `yarn install && yarn build` within `packages/agents-manager`.
2. Run `yarn dev --sync` within `apps/agents-manager`.
3. Proxy `public-api.wordpress.com` and `widgets.wp.com` to your sandbox's IP address.
4. Run Woo AI locally through Jurassic Tube.
5. Comment out tool filtering (3afb8-pb) and run `bin/allow-sandbox-production-writes`
6. Enter the site, enable the Woo AI assistant, and make sure it's open.
7. Paste or upload an image - you should see the "+" icon below the text input.
8. Run a query. Creating a product with the image you pasted is a good one:

```
Let's create a new product.

Name: 78' Red Mustang
Type: simple
Category: Hot Wheels
Price: $3.99
Description: Be creative
Stock: unlimited
Images: use the ones attached
```

By the end of the run, you should have a new product with the uploaded image.