### PR TITLE
Jetpack AI Sidebar: Fix failing block-update

### DIFF
--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -294,17 +294,17 @@ describe( 'toolProvider', () => {
 	} );
 
 	describe( 'getAbilities', () => {
-		it( 'includes update-block-content and big_sky__show_component', async () => {
+		it( 'includes update-block-content and show-component', async () => {
 			const abilities = await toolProvider.getAbilities();
 			const names = abilities.map( ( a: any ) => a.name );
 
 			expect( names ).toContain( 'wpcom/update-block-content' );
-			expect( names ).toContain( 'big_sky__show_component' );
+			expect( names ).toContain( 'big-sky/show-component' );
 		} );
 
 		it( 'wires a callback on each provided ability', async () => {
 			const abilities = await toolProvider.getAbilities();
-			const showComponent = abilities.find( ( a: any ) => a.name === 'big_sky__show_component' );
+			const showComponent = abilities.find( ( a: any ) => a.name === 'big-sky/show-component' );
 			const updateBlock = abilities.find( ( a: any ) => a.name === 'wpcom/update-block-content' );
 
 			expect( typeof showComponent?.callback ).toBe( 'function' );

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -62,17 +62,17 @@ describe( 'toolProvider', () => {
 	} );
 
 	describe( 'getAbilities', () => {
-		it( 'includes update-block-content and big_sky__show_component', async () => {
+		it( 'includes update-block-content and show-component', async () => {
 			const abilities = await toolProvider.getAbilities();
 			const names = abilities.map( ( a: any ) => a.name );
 
 			expect( names ).toContain( 'wpcom/update-block-content' );
-			expect( names ).toContain( 'big_sky__show_component' );
+			expect( names ).toContain( 'big-sky/show-component' );
 		} );
 
 		it( 'wires a callback on each provided ability', async () => {
 			const abilities = await toolProvider.getAbilities();
-			const showComponent = abilities.find( ( a: any ) => a.name === 'big_sky__show_component' );
+			const showComponent = abilities.find( ( a: any ) => a.name === 'big-sky/show-component' );
 			const updateBlock = abilities.find( ( a: any ) => a.name === 'wpcom/update-block-content' );
 
 			expect( typeof showComponent?.callback ).toBe( 'function' );

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -113,6 +113,10 @@ function getPostLevelSuggestions( currentPostType?: string ) {
 
 // ---------- Show-component ability ----------
 
+// Ability registration uses the slash-form name required by the WP Abilities
+// API (lowercase alphanumeric + dashes + forward slash). AM normalizes this
+// to `big_sky__show_component` for tool routing and envelope matching.
+const SHOW_COMPONENT_ABILITY_NAME = 'big-sky/show-component';
 const SHOW_COMPONENT_TOOL_ID = 'big_sky__show_component';
 
 /**
@@ -123,8 +127,8 @@ const SHOW_COMPONENT_TOOL_ID = 'big_sky__show_component';
  * registration isn't present. Same pattern as update-block-content.
  */
 const SHOW_COMPONENT_ABILITY: any = {
-	id: SHOW_COMPONENT_TOOL_ID,
-	name: SHOW_COMPONENT_TOOL_ID,
+	id: SHOW_COMPONENT_ABILITY_NAME,
+	name: SHOW_COMPONENT_ABILITY_NAME,
 	label: 'Show component',
 	category: 'jetpack-ai',
 	description: 'Render an interactive component in the chat.',
@@ -257,7 +261,7 @@ function filterAbility( abilities: any[], toolId: string ): any[] {
 }
 
 function isShowComponentTool( toolId: string ): boolean {
-	return toolId === SHOW_COMPONENT_TOOL_ID || toolId === 'big_sky__show_component';
+	return toolId === SHOW_COMPONENT_ABILITY_NAME || toolId === SHOW_COMPONENT_TOOL_ID;
 }
 
 export const toolProvider = {

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -225,6 +225,10 @@ function handleUpdateBlockContent( input: any ): any {
 
 // ---------- Show-component ability ----------
 
+// Ability registration uses the slash-form name required by the WP Abilities
+// API (lowercase alphanumeric + dashes + forward slash). AM normalizes this
+// to `big_sky__show_component` for tool routing and envelope matching.
+const SHOW_COMPONENT_ABILITY_NAME = 'big-sky/show-component';
 const SHOW_COMPONENT_TOOL_ID = 'big_sky__show_component';
 
 /**
@@ -235,8 +239,8 @@ const SHOW_COMPONENT_TOOL_ID = 'big_sky__show_component';
  * registration isn't present. Same pattern as update-block-content.
  */
 const SHOW_COMPONENT_ABILITY: any = {
-	id: SHOW_COMPONENT_TOOL_ID,
-	name: SHOW_COMPONENT_TOOL_ID,
+	id: SHOW_COMPONENT_ABILITY_NAME,
+	name: SHOW_COMPONENT_ABILITY_NAME,
 	label: 'Show component',
 	category: 'jetpack-ai',
 	description: 'Render an interactive component in the chat.',
@@ -366,7 +370,7 @@ function filterAbility( abilities: any[], toolId: string ): any[] {
 }
 
 function isShowComponentTool( toolId: string ): boolean {
-	return toolId === SHOW_COMPONENT_TOOL_ID || toolId === 'big_sky__show_component';
+	return toolId === SHOW_COMPONENT_ABILITY_NAME || toolId === SHOW_COMPONENT_TOOL_ID;
 }
 
 export const toolProvider = {


### PR DESCRIPTION
## Summary

Register the show-component ability under `big-sky/show-component` instead of `big_sky__show_component`. The WP Abilities API rejects underscores in ability names, which broke sidebar registration on self-hosted Jetpack sites:

```
Failed to create Frontend_Ability: big_sky__show_component
(Ability name must be a string containing a namespace prefix...)
```

`big_sky__show_component` is the *normalized* routing form (same pattern as `wpcom/update-block-content` → `wpcom__update_block_content`); registration must use the slash form.

## Changes

- Register under `big-sky/show-component`; keep `big_sky__show_component` as the envelope `tool_id` so AM routing and `convert-tool-messages-to-components` match unchanged.
- `isShowComponentTool` accepts both forms.

## Pre-flight

- [ ] Accessibility
- [ ] Type checks
- [x] Tests updated
- [ ] Changelog

## Testing

See WPCOM PR 212171