### PR TITLE
[RSM] Blog Talks Back > Support for P2

### DIFF
--- a/apps/agents-manager/reader-chat-suggestions.js
+++ b/apps/agents-manager/reader-chat-suggestions.js
@@ -1,0 +1,119 @@
+/**
+ * Reader Chat Suggestions
+ *
+ * Builds suggested prompts for the empty chat view based on the current
+ * page context (blog vs P2, stream vs single post).
+ *
+ * Extracted from reader-chat.js so the logic can be unit-tested
+ * independently of the entry-point side-effects (window globals, createRoot).
+ */
+
+/**
+ * Build suggested prompts based on the current page context.
+ *
+ * @param {Object}  config            - Page config (mirrors window.JetpackReaderChatConfig).
+ * @param {Object}  [config.currentPost] - Post data, or null/undefined on stream views.
+ * @param {boolean} [config.isP2]     - Whether the site is a P2.
+ * @returns {Array<{id: string, label: string, prompt: string}>} Suggestion list.
+ */
+function getReaderSuggestions( config = {} ) {
+	const post = config.currentPost;
+	const isP2 = !! config.isP2;
+
+	if ( isP2 ) {
+		if ( ! post ) {
+			return [
+				{
+					id: 'catch-me-up',
+					label: 'Catch me up',
+					prompt: 'What have been the most active discussions on this P2 this week?',
+				},
+				{
+					id: 'action-items',
+					label: 'Any open action items?',
+					prompt: 'Are there any unresolved action items or open questions from recent posts?',
+				},
+				{
+					id: 'recent-decisions',
+					label: 'What was decided recently?',
+					prompt: 'What decisions have been made on this P2 recently?',
+				},
+				{
+					id: 'whos-active',
+					label: "Who's been active?",
+					prompt: 'Who has been posting or commenting most actively recently?',
+				},
+			];
+		}
+
+		const title = post.title || 'this post';
+		const hasComments = ( post.commentCount || 0 ) > 0;
+
+		return [
+			{
+				id: 'summarize-discussion',
+				label: 'Summarize this discussion',
+				prompt: hasComments
+					? `Summarize "${ title }" including the key points from the comments.`
+					: `Summarize the main points of "${ title }".`,
+			},
+			{
+				id: 'key-decisions',
+				label: 'What was decided?',
+				prompt: `What was decided or agreed on in "${ title }"?`,
+			},
+			{
+				id: 'whos-involved',
+				label: "Who's involved?",
+				prompt: `Who weighed in on "${ title }" and what were their main points?`,
+			},
+			{
+				id: 'open-questions',
+				label: 'Any open questions?',
+				prompt: `Are there any open questions or unresolved threads in "${ title }"?`,
+			},
+		];
+	}
+
+	if ( ! post ) {
+		return [
+			{
+				id: 'popular',
+				label: 'What are the most popular posts here?',
+				prompt: 'What are the most popular posts on this blog?',
+			},
+			{
+				id: 'about',
+				label: 'What is this blog about?',
+				prompt: 'What is this blog about? What topics does it cover?',
+			},
+			{
+				id: 'recommend',
+				label: 'Recommend something to read',
+				prompt: 'Can you recommend a good post to read on this blog?',
+			},
+		];
+	}
+
+	const title = post.title || 'this post';
+
+	return [
+		{
+			id: 'summarize',
+			label: 'Summarize this post',
+			prompt: `Can you summarize "${ title }" for me?`,
+		},
+		{
+			id: 'explain',
+			label: 'Explain something from this post',
+			prompt: `Can you explain the main points of "${ title }" in simple terms?`,
+		},
+		{
+			id: 'related',
+			label: 'Find related posts',
+			prompt: `What other posts on this blog are related to "${ title }"?`,
+		},
+	];
+}
+
+module.exports = { getReaderSuggestions };

--- a/apps/agents-manager/reader-chat-suggestions.test.js
+++ b/apps/agents-manager/reader-chat-suggestions.test.js
@@ -1,0 +1,115 @@
+/**
+ * Tests for reader-chat suggestion builder.
+ */
+
+const { getReaderSuggestions } = require( './reader-chat-suggestions' );
+
+describe( 'getReaderSuggestions', () => {
+	describe( 'blog (non-P2)', () => {
+		it( 'returns stream suggestions when no post is provided', () => {
+			const suggestions = getReaderSuggestions( {} );
+			const ids = suggestions.map( ( s ) => s.id );
+			expect( ids ).toContain( 'popular' );
+			expect( ids ).toContain( 'about' );
+			expect( ids ).toContain( 'recommend' );
+		} );
+
+		it( 'returns post suggestions when a post is provided', () => {
+			const suggestions = getReaderSuggestions( { currentPost: { title: 'Hello World' } } );
+			const ids = suggestions.map( ( s ) => s.id );
+			expect( ids ).toContain( 'summarize' );
+			expect( ids ).toContain( 'explain' );
+			expect( ids ).toContain( 'related' );
+		} );
+
+		it( 'includes the post title in prompts', () => {
+			const suggestions = getReaderSuggestions( { currentPost: { title: 'My Post' } } );
+			const summarize = suggestions.find( ( s ) => s.id === 'summarize' );
+			expect( summarize.prompt ).toContain( 'My Post' );
+		} );
+
+		it( 'falls back to "this post" when title is missing', () => {
+			const suggestions = getReaderSuggestions( { currentPost: {} } );
+			const summarize = suggestions.find( ( s ) => s.id === 'summarize' );
+			expect( summarize.prompt ).toContain( 'this post' );
+		} );
+
+		it( 'returns stream suggestions when config is empty', () => {
+			const suggestions = getReaderSuggestions();
+			expect( suggestions.length ).toBeGreaterThan( 0 );
+			expect( suggestions[ 0 ].id ).toBe( 'popular' );
+		} );
+	} );
+
+	describe( 'P2', () => {
+		it( 'returns P2 stream suggestions when no post is provided', () => {
+			const suggestions = getReaderSuggestions( { isP2: true } );
+			const ids = suggestions.map( ( s ) => s.id );
+			expect( ids ).toContain( 'catch-me-up' );
+			expect( ids ).toContain( 'action-items' );
+			expect( ids ).toContain( 'recent-decisions' );
+			expect( ids ).toContain( 'whos-active' );
+		} );
+
+		it( 'returns P2 post suggestions when a post is provided', () => {
+			const suggestions = getReaderSuggestions( {
+				isP2: true,
+				currentPost: { title: 'Team Update', commentCount: 3 },
+			} );
+			const ids = suggestions.map( ( s ) => s.id );
+			expect( ids ).toContain( 'summarize-discussion' );
+			expect( ids ).toContain( 'key-decisions' );
+			expect( ids ).toContain( 'whos-involved' );
+			expect( ids ).toContain( 'open-questions' );
+		} );
+
+		it( 'includes comments in summarize-discussion prompt when post has comments', () => {
+			const suggestions = getReaderSuggestions( {
+				isP2: true,
+				currentPost: { title: 'Q3 Planning', commentCount: 5 },
+			} );
+			const summarize = suggestions.find( ( s ) => s.id === 'summarize-discussion' );
+			expect( summarize.prompt ).toContain( 'comments' );
+		} );
+
+		it( 'omits comments from summarize-discussion prompt when post has no comments', () => {
+			const suggestions = getReaderSuggestions( {
+				isP2: true,
+				currentPost: { title: 'Q3 Planning', commentCount: 0 },
+			} );
+			const summarize = suggestions.find( ( s ) => s.id === 'summarize-discussion' );
+			expect( summarize.prompt ).not.toContain( 'comments' );
+		} );
+
+		it( 'treats missing commentCount as zero', () => {
+			const suggestions = getReaderSuggestions( {
+				isP2: true,
+				currentPost: { title: 'No Count' },
+			} );
+			const summarize = suggestions.find( ( s ) => s.id === 'summarize-discussion' );
+			expect( summarize.prompt ).not.toContain( 'comments' );
+		} );
+	} );
+
+	describe( 'return shape', () => {
+		it( 'every suggestion has id, label, and prompt fields', () => {
+			const configs = [
+				{},
+				{ currentPost: { title: 'Test' } },
+				{ isP2: true },
+				{ isP2: true, currentPost: { title: 'P2 Post' } },
+			];
+			configs.forEach( ( config ) => {
+				const suggestions = getReaderSuggestions( config );
+				suggestions.forEach( ( s ) => {
+					expect( typeof s.id ).toBe( 'string' );
+					expect( typeof s.label ).toBe( 'string' );
+					expect( typeof s.prompt ).toBe( 'string' );
+					expect( s.id.length ).toBeGreaterThan( 0 );
+					expect( s.label.length ).toBeGreaterThan( 0 );
+					expect( s.prompt.length ).toBeGreaterThan( 0 );
+				} );
+			} );
+		} );
+	} );
+} );

--- a/apps/agents-manager/reader-chat.js
+++ b/apps/agents-manager/reader-chat.js
@@ -1,0 +1,44 @@
+/**
+ * Reader Chat Entry Point
+ *
+ * Loads the Agents Manager chat UI for blog readers (logged-out visitors).
+ * Reads config from window.JetpackReaderChatConfig, mounts to #jetpack-reader-chat.
+ *
+ * IMPORTANT: This bundle is built without DependencyExtractionWebpackPlugin so
+ * React, @wordpress/data, and all other WP packages are bundled inline. This
+ * makes it safe to load on the frontend where WordPress's script loader is absent.
+ */
+
+import './config';
+import AgentsManager from '@automattic/agents-manager';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createRoot } from 'react-dom/client';
+
+const queryClient = new QueryClient();
+
+function ReaderChatApp() {
+	const config = window.JetpackReaderChatConfig || {};
+
+	const site = config.siteId
+		? {
+				ID: config.siteId,
+				URL: config.siteUrl || window.location.origin,
+				name: config.siteName || '',
+		  }
+		: null;
+
+	return (
+		<QueryClientProvider client={ queryClient }>
+			<AgentsManager
+				sectionName="reader-chat"
+				site={ site }
+				currentSiteId={ config.siteId || undefined }
+			/>
+		</QueryClientProvider>
+	);
+}
+
+const container = document.getElementById( 'jetpack-reader-chat' );
+if ( container ) {
+	createRoot( container ).render( <ReaderChatApp /> );
+}

--- a/apps/agents-manager/reader-chat.js
+++ b/apps/agents-manager/reader-chat.js
@@ -16,6 +16,73 @@ import { createRoot } from 'react-dom/client';
 
 const queryClient = new QueryClient();
 
+// Read config injected by PHP.
+const readerConfig = window.JetpackReaderChatConfig || {};
+
+// Set agentId for useAgentConfig() to pick up via agentsManagerData global.
+if ( readerConfig.agentId ) {
+	window.agentsManagerData = window.agentsManagerData || {};
+	window.agentsManagerData.agentId = readerConfig.agentId;
+}
+
+// Expose page context on the global so the default context provider
+// and agent hooks can read it. The AgentsManager default context
+// provider sends window.location info; we augment with post-level data.
+window.agentsManagerData = window.agentsManagerData || {};
+window.agentsManagerData.currentPost = readerConfig.currentPost || null;
+window.agentsManagerData.siteName = readerConfig.siteName || '';
+window.agentsManagerData.siteUrl = readerConfig.siteUrl || '';
+
+/**
+ * Build suggested prompts based on the current page context.
+ * These appear in the empty chat view.
+ */
+function getReaderSuggestions() {
+	const post = readerConfig.currentPost;
+
+	if ( ! post ) {
+		// On non-singular pages (home, archive), show general suggestions.
+		return [
+			{
+				id: 'popular',
+				label: 'What are the most popular posts here?',
+				prompt: 'What are the most popular posts on this blog?',
+			},
+			{
+				id: 'about',
+				label: 'What is this blog about?',
+				prompt: 'What is this blog about? What topics does it cover?',
+			},
+			{
+				id: 'recommend',
+				label: 'Recommend something to read',
+				prompt: 'Can you recommend a good post to read on this blog?',
+			},
+		];
+	}
+
+	// On a specific post, tailor suggestions to its content.
+	const title = post.title || 'this post';
+
+	return [
+		{
+			id: 'summarize',
+			label: `Summarize this post`,
+			prompt: `Can you summarize "${ title }" for me?`,
+		},
+		{
+			id: 'explain',
+			label: 'Explain something from this post',
+			prompt: `Can you explain the main points of "${ title }" in simple terms?`,
+		},
+		{
+			id: 'related',
+			label: 'Find related posts',
+			prompt: `What other posts on this blog are related to "${ title }"?`,
+		},
+	];
+}
+
 function ReaderChatApp() {
 	const config = window.JetpackReaderChatConfig || {};
 
@@ -40,5 +107,8 @@ function ReaderChatApp() {
 
 const container = document.getElementById( 'jetpack-reader-chat' );
 if ( container ) {
+	// Inject suggestions into agentsManagerData for the empty view.
+	window.agentsManagerData.readerSuggestions = getReaderSuggestions();
+
 	createRoot( container ).render( <ReaderChatApp /> );
 }

--- a/apps/agents-manager/webpack.config.js
+++ b/apps/agents-manager/webpack.config.js
@@ -94,6 +94,57 @@ function getIndividualConfig( options = {} ) {
 	};
 }
 
+/**
+ * Reader chat config — bundles all dependencies (no WP externals).
+ *
+ * Omits DependencyExtractionWebpackPlugin entirely so React, @wordpress/data,
+ * and other WP packages are inlined. The resulting reader-chat.min.js is
+ * self-contained and safe to load on the frontend (no WP script loader needed).
+ *
+ * @param   {Object}  options                       options
+ * @param   {Object}  options.env                   environment options
+ * @param   {Object}  options.argv                  webpack CLI args
+ * @returns {Object}                                webpack config
+ */
+function getReaderConfig( options = {} ) {
+	const { env, argv } = options;
+	const outputPath = path.join( __dirname, 'dist' );
+	const webpackConfig = getBaseWebpackConfig( env, argv );
+
+	return {
+		...webpackConfig,
+		mode: isDevelopment ? 'development' : 'production',
+		entry: { 'reader-chat': path.join( __dirname, 'reader-chat.js' ) },
+		output: {
+			...webpackConfig.output,
+			path: outputPath,
+			filename: '[name].min.js',
+		},
+		module: {
+			...webpackConfig.module,
+			rules: [ ...( webpackConfig.module?.rules || [] ) ],
+		},
+		optimization: {
+			...webpackConfig.optimization,
+			// Disable module concatenation so __() calls are not renamed.
+			concatenateModules: false,
+		},
+		plugins: [
+			// Strip the base config's DependencyExtractionWebpackPlugin — we want
+			// everything bundled, not externalized.
+			...webpackConfig.plugins.filter(
+				( plugin ) => plugin.constructor.name !== 'DependencyExtractionWebpackPlugin'
+			),
+			new webpack.DefinePlugin( {
+				__i18n_text_domain__: JSON.stringify( 'default' ),
+				'process.env.NODE_DEBUG': JSON.stringify( process.env.NODE_DEBUG || false ),
+			} ),
+			new ReadableJsAssetsWebpackPlugin(),
+			// Intentionally NO DependencyExtractionWebpackPlugin — all WP deps are bundled.
+		],
+	};
+}
+
 /* Arguments to this function replicate webpack's so this config can be used on the command line,
  * with individual options overridden by command line args.
  * @see {@link https://webpack.js.org/configuration/configuration-types/#exporting-a-function}
@@ -130,6 +181,7 @@ function getWebpackConfig( env = { source: '' }, argv = {} ) {
 		getIndividualConfig( { env, argv, name: 'block-notes' } ),
 		getIndividualConfig( { env, argv, name: 'agents-manager-ciab' } ),
 		getIndividualConfig( { env, argv, name: 'agents-manager-wooai' } ),
+		getReaderConfig( { env, argv } ),
 	];
 
 	// Attach the copy plugin to the first config.


### PR DESCRIPTION
## Summary
- Extract reader-chat suggestion builder into its own module (`reader-chat-suggestions.js`) so the logic is unit-testable
- Adds P2-aware suggestion branches keyed on `config.isP2`:
  - **Stream view:** "Catch me up", "Any open action items?", "What was decided recently?", "Who's been active?"
  - **Single post:** "Summarize this discussion", "What was decided?", "Who's involved?", "Any open questions?"
- Blog suggestions unchanged

Follow-up needed (not in this PR): wire `getReaderSuggestions` from the new module into `reader-chat.js` and remove the inline copy.

## Stacked on
Base: \`add/jetpack-reader-chat\`. Merge that first.

## Test plan
- [ ] `jest apps/agents-manager/reader-chat-suggestions.test.js` passes
- [ ] P2 single-post config returns discussion-shaped prompts
- [ ] P2 stream config returns catch-up prompts
- [ ] Non-P2 blog config returns existing blog prompts