### PR TITLE
Image Studio: guard canvas-controls against stale registered store (FORNO-348)

### DIFF
--- a/packages/image-studio/src/components/canvas-controls/index.tsx
+++ b/packages/image-studio/src/components/canvas-controls/index.tsx
@@ -41,11 +41,18 @@ export const CanvasControls = ( {
 	onFeedback,
 	onSubmitFeedbackText,
 }: CanvasControlsProps ) => {
+	// FORNO-348: tolerate an older registered image-studio store that pre-dates
+	// FORNO-277's rating selectors/actions. No-op instead of crashing the modal.
 	const selectedFeedback = useSelect(
-		( select ) => select( imageStudioStore ).getImageRating( attachmentId ),
+		( select ) => {
+			const selectors = select( imageStudioStore ) as unknown as {
+				getImageRating?: ( id: number | null ) => 'up' | 'down' | null;
+			};
+			return selectors.getImageRating?.( attachmentId ) ?? null;
+		},
 		[ attachmentId ]
 	);
-	const { setImageRating } = useDispatch( imageStudioStore ) as ImageStudioActions;
+	const { setImageRating } = useDispatch( imageStudioStore ) as Partial< ImageStudioActions >;
 	const [ showFeedbackPopover, setShowFeedbackPopover ] = useState( false );
 	const feedbackAnchorRef = useRef< HTMLDivElement | null >( null );
 
@@ -58,6 +65,11 @@ export const CanvasControls = ( {
 		( feedback: 'up' | 'down' ) => {
 			// Don't allow changing feedback once submitted for this image
 			if ( selectedFeedback !== null || attachmentId === null ) {
+				return;
+			}
+
+			// FORNO-348: skip tracking/popover when we can't persist the rating.
+			if ( ! setImageRating ) {
 				return;
 			}
 


### PR DESCRIPTION
Part of FORNO-348

## Proposed Changes

* Guard `CanvasControls` against calling `getImageRating` / `setImageRating` when the registered `image-studio` store is missing them. Optional-chain both the selector and the dispatcher, defaulting the selected feedback to `null` when the selector is absent.

## Why are these changes being made?

When an older `@automattic/image-studio` bundle wins the Redux store registration race, the registered store is missing selectors/actions added after that bundle was built. On Atomic sites with an outdated Big Sky plugin, Big Sky's own scripts load before `widgets.wp.com/agents-manager/image-studio.min.js` and register an older copy of the shared `image-studio` store.

FORNO-277 (#110020) moved thumbs-up/down rating state from local `useState` into the Redux store and added `getImageRating` / `setImageRating`. After that landed, any Atomic site running a Big Sky plugin built before the FORNO-277 commit crashes in `CanvasControls` with:

```
TypeError: select(...).getImageRating is not a function
    at CanvasControls (...)
```

The crash tears down the modal moments after the generated image renders. From the user's perspective, the image briefly appears, the modal closes, and `editPost({ featured_media })` never runs — so the featured image is never set. This is the behavior reported in FORNO-348 ("Featured image not created or added to the page").

This patch prevents the crash regardless of which bundle wins. Feedback thumbs silently no-op when the registered store is stale (better than crashing); the main flow — generate, Save, apply featured image — is restored.

The root cause (duplicate registration of the `image-studio` store across Big Sky and Calypso bundles) is tracked in FORNO-234 / big-sky `#5828`. That's the permanent fix; this PR is a band-aid until it lands and until Atomic sites update their Big Sky plugins.

## Testing Instructions

Before this PR, on such a site:
1. Open a post/page in the block editor.
2. Use the Jetpack AI "Set featured image" flow to open Image Studio in Generate mode.
3. Prompt any image; observe that the image appears briefly then the modal tears down. Console shows `TypeError: select(...).getImageRating is not a function`.

After this PR:
1. Same flow — image renders, modal stays, rating thumbs are visually present but no-op on click (expected on stale-store sites; will work normally everywhere else).
2. Click Save. Featured image applies to the post correctly.

Diagnostic to confirm which path a site is on (run in the post-editor top frame):

```js
const s = wp.data.select( 'image-studio' );
console.log( 'has getImageRating:', typeof s?.getImageRating );
```

* `function` → site has the current store (no skew). This PR is a no-op for that site.
* `undefined` → site has the stale store. This PR prevents the crash there.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?