### PR TITLE
Revert "Image Studio: Persist each image rating for the session (FORNO-277)" (FORNO-348)

### DIFF
--- a/packages/image-studio/src/components/canvas-controls/index.tsx
+++ b/packages/image-studio/src/components/canvas-controls/index.tsx
@@ -8,10 +8,8 @@
 import { FeedbackInput } from '@automattic/agents-manager';
 import { MessageActions, ThumbsDownIcon, ThumbsUpIcon } from '@automattic/agenttic-ui';
 import { Popover, __unstableMotion as motion } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { type ImageStudioActions, store as imageStudioStore } from '../../store';
 import { trackImageStudioImageFeedback } from '../../utils/tracking';
 import { ImageActionsMenu } from '../image-actions-menu';
 import { RevisionNavigator } from './revision-navigator';
@@ -41,27 +39,24 @@ export const CanvasControls = ( {
 	onFeedback,
 	onSubmitFeedbackText,
 }: CanvasControlsProps ) => {
-	const selectedFeedback = useSelect(
-		( select ) => select( imageStudioStore ).getImageRating( attachmentId ),
-		[ attachmentId ]
-	);
-	const { setImageRating } = useDispatch( imageStudioStore ) as ImageStudioActions;
+	const [ selectedFeedback, setSelectedFeedback ] = useState< 'up' | 'down' | null >( null );
 	const [ showFeedbackPopover, setShowFeedbackPopover ] = useState( false );
 	const feedbackAnchorRef = useRef< HTMLDivElement | null >( null );
 
-	// Close feedback popover when navigating to a different image
+	// Reset feedback when image changes
 	useEffect( () => {
+		setSelectedFeedback( null );
 		setShowFeedbackPopover( false );
 	}, [ imageUrl ] );
 
 	const handleFeedback = useCallback(
 		( feedback: 'up' | 'down' ) => {
-			// Don't allow changing feedback once submitted for this image
-			if ( selectedFeedback !== null || attachmentId === null ) {
+			// Don't allow changing feedback once selected
+			if ( selectedFeedback !== null ) {
 				return;
 			}
 
-			setImageRating( attachmentId, feedback );
+			setSelectedFeedback( feedback );
 			trackImageStudioImageFeedback( { feedback, attachmentId, mode } );
 			onFeedback?.( feedback );
 
@@ -69,7 +64,7 @@ export const CanvasControls = ( {
 				setShowFeedbackPopover( true );
 			}
 		},
-		[ mode, attachmentId, selectedFeedback, onFeedback, onSubmitFeedbackText, setImageRating ]
+		[ mode, attachmentId, selectedFeedback, onFeedback, onSubmitFeedbackText ]
 	);
 
 	const handleCloseFeedbackPopover = useCallback( () => {

--- a/packages/image-studio/src/components/canvas-controls/style.scss
+++ b/packages/image-studio/src/components/canvas-controls/style.scss
@@ -27,10 +27,6 @@
 	align-items: center;
 }
 
-.canvas-controls__left button[aria-pressed="true"] {
-	cursor: default;
-}
-
 .canvas-controls__nav-button {
 	background: transparent;
 	border: none;

--- a/packages/image-studio/src/components/index.tsx
+++ b/packages/image-studio/src/components/index.tsx
@@ -438,11 +438,10 @@ const ImageStudioContent = withInstanceId(
 			<AnnotationCanvas imageUrl={ finalDisplayUrl } imageElement={ imageRef.current } />
 		) : null;
 
-		// Show feedback buttons only for AI-generated/edited images — never for the
-		// original attachment — and not while annotating (suggestions differ there).
-		const isOriginalImage = attachmentId !== null && attachmentId === originalAttachmentId;
+		// Show feedback buttons when image is AI-processed and not in other states
+		// Don't show for annotated images as they will have different suggestions
 		const showFeedbackButtons =
-			! isCurrentAttachmentAnnotated && !! isAiProcessed && !! finalDisplayUrl && ! isOriginalImage;
+			! isCurrentAttachmentAnnotated && !! isAiProcessed && !! finalDisplayUrl;
 
 		// Show actions menu only in Edit mode after AI has made changes.
 		// canRevert already checks: originalAttachmentId exists, image changed, not processing

--- a/packages/image-studio/src/store/index.test.ts
+++ b/packages/image-studio/src/store/index.test.ts
@@ -95,7 +95,6 @@ describe( 'Image Studio Store', () => {
 				selectedStyle: null,
 				selectedAspectRatio: null,
 				lastAgentMessageId: null,
-				imageRatings: {},
 			} );
 		} );
 
@@ -852,67 +851,6 @@ describe( 'Image Studio Store', () => {
 
 				expect( state.lastAgentMessageId ).toBe( 'msg-123' );
 			} );
-
-			it( 'SET_IMAGE_RATING records a rating for an attachment', () => {
-				const state = reducer( getInitialState(), actions.setImageRating( 123, 'up' ) );
-
-				expect( state.imageRatings ).toEqual( { 123: 'up' } );
-			} );
-
-			it( 'SET_IMAGE_RATING preserves ratings for other attachments', () => {
-				const initial: ImageStudioState = {
-					...getInitialState(),
-					imageRatings: { 123: 'up' },
-				};
-				const state = reducer( initial, actions.setImageRating( 456, 'down' ) );
-
-				expect( state.imageRatings ).toEqual( { 123: 'up', 456: 'down' } );
-			} );
-
-			it( 'preserves imageRatings when UPDATE_IMAGE_STUDIO_CANVAS fires', () => {
-				const initial: ImageStudioState = {
-					...getInitialState(),
-					imageRatings: { 123: 'up' },
-				};
-				const state = reducer(
-					initial,
-					actions.updateImageStudioCanvas( 'https://example.com/v2.jpg', 456 )
-				);
-
-				expect( state.imageRatings ).toEqual( { 123: 'up' } );
-			} );
-
-			it( 'resets imageRatings on OPEN_IMAGE_STUDIO', () => {
-				const initial: ImageStudioState = {
-					...getInitialState(),
-					imageRatings: { 123: 'up' },
-				};
-				const state = reducer( initial, actions.openImageStudio( 123 ) );
-
-				expect( state.imageRatings ).toEqual( {} );
-			} );
-
-			it( 'resets imageRatings on CLOSE_IMAGE_STUDIO', () => {
-				const initial: ImageStudioState = {
-					...getInitialState(),
-					imageRatings: { 123: 'down' },
-				};
-				const state = reducer( initial, actions.closeImageStudio() );
-
-				expect( state.imageRatings ).toEqual( {} );
-			} );
-
-			it( 'resets imageRatings on NAVIGATE_TO_ATTACHMENT (new working session)', () => {
-				const initial: ImageStudioState = {
-					...getInitialState(),
-					imageRatings: { 100: 'up' },
-					navigableAttachmentIds: [ 100, 200 ],
-					currentNavigationIndex: 0,
-				};
-				const state = reducer( initial, actions.navigateToAttachment( 200 ) );
-
-				expect( state.imageRatings ).toEqual( {} );
-			} );
 		} );
 	} );
 
@@ -1084,39 +1022,6 @@ describe( 'Image Studio Store', () => {
 		it( 'getLastAgentMessageId', () => {
 			const state: ImageStudioState = { ...getInitialState(), lastAgentMessageId: 'msg-123' };
 			expect( selectors.getLastAgentMessageId( state ) ).toBe( 'msg-123' );
-		} );
-
-		describe( 'getImageRating', () => {
-			it( 'returns the rating for an attachment', () => {
-				const state: ImageStudioState = {
-					...getInitialState(),
-					imageRatings: { 123: 'up', 456: 'down' },
-				};
-				expect( selectors.getImageRating( state, 123 ) ).toBe( 'up' );
-				expect( selectors.getImageRating( state, 456 ) ).toBe( 'down' );
-			} );
-
-			it( 'returns null for an unrated attachment', () => {
-				const state: ImageStudioState = {
-					...getInitialState(),
-					imageRatings: { 123: 'up' },
-				};
-				expect( selectors.getImageRating( state, 999 ) ).toBeNull();
-			} );
-
-			it( 'returns null when attachmentId is null', () => {
-				const state: ImageStudioState = {
-					...getInitialState(),
-					imageRatings: { 123: 'up' },
-				};
-				expect( selectors.getImageRating( state, null ) ).toBeNull();
-			} );
-		} );
-
-		it( 'getImageRatings returns the full map', () => {
-			const ratings = { 123: 'up' as const, 456: 'down' as const };
-			const state: ImageStudioState = { ...getInitialState(), imageRatings: ratings };
-			expect( selectors.getImageRatings( state ) ).toEqual( ratings );
 		} );
 
 		describe( 'getHasUnsavedChanges', () => {

--- a/packages/image-studio/src/store/index.ts
+++ b/packages/image-studio/src/store/index.ts
@@ -105,10 +105,6 @@ export interface ImageStudioState {
 	selectedAspectRatio: string | null;
 	// Last agent message ID for feedback tracking
 	lastAgentMessageId: string | null;
-	// Ratings the user has submitted in this session, keyed by attachment ID.
-	// Once a rating is recorded for an image it stays for the session so the
-	// buttons remain disabled when navigating back to that image.
-	imageRatings: Record< number, 'up' | 'down' >;
 }
 
 /**
@@ -258,14 +254,6 @@ type SetLastAgentMessageIdAction = {
 	payload: string | null;
 };
 
-type SetImageRatingAction = {
-	type: 'SET_IMAGE_RATING';
-	payload: {
-		attachmentId: number;
-		rating: 'up' | 'down';
-	};
-};
-
 type ResetCanvasHistoryAction = {
 	type: 'RESET_CANVAS_HISTORY';
 };
@@ -297,7 +285,6 @@ type ImageStudioAction =
 	| SetSelectedStyleAction
 	| SetSelectedAspectRatioAction
 	| SetLastAgentMessageIdAction
-	| SetImageRatingAction
 	| ResetCanvasHistoryAction;
 
 /**
@@ -365,7 +352,6 @@ const initialState: ImageStudioState = {
 	selectedStyle: null,
 	selectedAspectRatio: null,
 	lastAgentMessageId: null,
-	imageRatings: {},
 };
 
 /**
@@ -604,8 +590,6 @@ const reducer = (
 				onCloseCallback: null,
 				entryPoint: null,
 				blockType: null,
-				// Reset ratings for the new file since it's a new working session
-				imageRatings: {},
 				// Keep navigation state (navigableAttachmentIds, currentNavigationIndex, pagination)
 				// Keep user preferences (isSidebarOpen, selectedStyle, selectedAspectRatio)
 			};
@@ -646,15 +630,6 @@ const reducer = (
 			return {
 				...state,
 				lastAgentMessageId: action.payload,
-			};
-
-		case 'SET_IMAGE_RATING':
-			return {
-				...state,
-				imageRatings: {
-					...state.imageRatings,
-					[ action.payload.attachmentId ]: action.payload.rating,
-				},
 			};
 
 		case 'RESET_CANVAS_HISTORY':
@@ -735,10 +710,6 @@ export interface ImageStudioActions {
 	setSelectedStyle: ( style: string | null ) => Promise< SetSelectedStyleAction >;
 	setSelectedAspectRatio: ( aspectRatio: string | null ) => Promise< SetSelectedAspectRatioAction >;
 	setLastAgentMessageId: ( messageId: string | null ) => Promise< SetLastAgentMessageIdAction >;
-	setImageRating: (
-		attachmentId: number,
-		rating: 'up' | 'down'
-	) => Promise< SetImageRatingAction >;
 	resetCanvasHistory: () => Promise< ResetCanvasHistoryAction >;
 }
 
@@ -956,13 +927,6 @@ const actions = {
 		};
 	},
 
-	setImageRating( attachmentId: number, rating: 'up' | 'down' ): SetImageRatingAction {
-		return {
-			type: 'SET_IMAGE_RATING',
-			payload: { attachmentId, rating },
-		};
-	},
-
 	resetCanvasHistory(): ResetCanvasHistoryAction {
 		return {
 			type: 'RESET_CANVAS_HISTORY',
@@ -1008,8 +972,6 @@ export interface ImageStudioSelectors {
 	getSelectedStyle: ( state: ImageStudioState ) => string | null;
 	getSelectedAspectRatio: ( state: ImageStudioState ) => string | null;
 	getLastAgentMessageId: ( state: ImageStudioState ) => string | null;
-	getImageRatings: ( state: ImageStudioState ) => Record< number, 'up' | 'down' >;
-	getImageRating: ( state: ImageStudioState, attachmentId: number | null ) => 'up' | 'down' | null;
 	getSupportedMimeTypes: () => readonly string[];
 }
 
@@ -1182,17 +1144,6 @@ const selectors = {
 
 	getLastAgentMessageId( state: ImageStudioState ): string | null {
 		return state.lastAgentMessageId;
-	},
-
-	getImageRatings( state: ImageStudioState ): Record< number, 'up' | 'down' > {
-		return state.imageRatings;
-	},
-
-	getImageRating( state: ImageStudioState, attachmentId: number | null ): 'up' | 'down' | null {
-		if ( attachmentId === null ) {
-			return null;
-		}
-		return state.imageRatings[ attachmentId ] ?? null;
 	},
 
 	getSupportedMimeTypes(): readonly string[] {


### PR DESCRIPTION
Part of FORNO-348

## Proposed Changes

* Revert `Automattic/wp-calypso#110020` (FORNO-277): moved image-rating state back out of the `image-studio` Redux store and into local `useState` in `CanvasControls`.

## Why are these changes being made?

FORNO-277 (#110020) added `getImageRating` / `setImageRating` selectors and actions to the `image-studio` store. On Atomic sites running a Big Sky plugin built before FORNO-277 shipped (e.g. the customer's site in FORNO-348, `ver=499162500`), Big Sky's own bundled copy of `@automattic/image-studio` wins the Redux store registration race and registers an older store without the new selectors.

When the widgets.wp.com bundle's `CanvasControls` then renders and calls `getImageRating`, it throws:

```
TypeError: select(...).getImageRating is not a function
    at CanvasControls (...)
```

The modal tears down right after the generated image renders, so `editPost({ featured_media })` never runs and the featured image is never applied. That's the user-facing behavior reported in FORNO-348 ("Featured image not created or added to the page").

Reverting FORNO-277 restores the local-useState rating path, which doesn't touch store selectors and therefore isn't affected by the duplicate registration. This is a temporary stopgap — the FORNO-277 behavior fix (rating persisting across image iteration navigation) should be re-applied once the structural problem (Big Sky bundling its own copy of `@automattic/image-studio`) is resolved in FORNO-234 / big-sky `#5828`.

**Alternatives considered**

* `#110035` (band-aid at the `CanvasControls` callsite): optional-chains the selector so it no-ops when absent. Keeps FORNO-277 but degrades the rating UX on stale-Big-Sky sites (thumbs visually present, clicks don't persist). This PR is the heavier stopgap if we'd rather not ship that band-aid.

## Testing Instructions

1. On any site where Image Studio is available, open the block editor and use Image Studio to generate an image. Confirm the generation, save flow, and featured-image application all work.
2. Click thumbs-up / thumbs-down on the generated image. Confirm the rating is recorded for that single image (pre-FORNO-277 behavior — will reset if you iterate to a new image, which is the original bug FORNO-277 was fixing).
3. On an Atomic site with an older Big Sky plugin (e.g. one that predates FORNO-277), confirm the modal no longer crashes and the featured image is applied on Save.

Also verified locally:
* `yarn jest --config packages/image-studio/jest.config.js` — 27 suites, 807 tests pass (10 rating-related tests removed by the revert).
* `tsc --noEmit -p packages/image-studio/tsconfig.json` — clean.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?