### PR TITLE
Revert Image Studio: Persist each image rating for the session (FORNO-277)

### DIFF
--- a/packages/image-studio/src/components/canvas-controls/index.tsx
+++ b/packages/image-studio/src/components/canvas-controls/index.tsx
@@ -8,10 +8,8 @@
 import { FeedbackInput } from '@automattic/agents-manager';
 import { MessageActions, ThumbsDownIcon, ThumbsUpIcon } from '@automattic/agenttic-ui';
 import { Popover, __unstableMotion as motion } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { type ImageStudioActions, store as imageStudioStore } from '../../store';
 import { trackImageStudioImageFeedback } from '../../utils/tracking';
 import { ImageActionsMenu } from '../image-actions-menu';
 import { RevisionNavigator } from './revision-navigator';
@@ -41,27 +39,24 @@ export const CanvasControls = ( {
 	onFeedback,
 	onSubmitFeedbackText,
 }: CanvasControlsProps ) => {
-	const selectedFeedback = useSelect(
-		( select ) => select( imageStudioStore ).getImageRating( attachmentId ),
-		[ attachmentId ]
-	);
-	const { setImageRating } = useDispatch( imageStudioStore ) as ImageStudioActions;
+	const [ selectedFeedback, setSelectedFeedback ] = useState< 'up' | 'down' | null >( null );
 	const [ showFeedbackPopover, setShowFeedbackPopover ] = useState( false );
 	const feedbackAnchorRef = useRef< HTMLDivElement | null >( null );
 
-	// Close feedback popover when navigating to a different image
+	// Reset feedback when image changes
 	useEffect( () => {
+		setSelectedFeedback( null );
 		setShowFeedbackPopover( false );
 	}, [ imageUrl ] );
 
 	const handleFeedback = useCallback(
 		( feedback: 'up' | 'down' ) => {
-			// Don't allow changing feedback once submitted for this image
-			if ( selectedFeedback !== null || attachmentId === null ) {
+			// Don't allow changing feedback once selected
+			if ( selectedFeedback !== null ) {
 				return;
 			}
 
-			setImageRating( attachmentId, feedback );
+			setSelectedFeedback( feedback );
 			trackImageStudioImageFeedback( { feedback, attachmentId, mode } );
 			onFeedback?.( feedback );
 
@@ -69,7 +64,7 @@ export const CanvasControls = ( {
 				setShowFeedbackPopover( true );
 			}
 		},
-		[ mode, attachmentId, selectedFeedback, onFeedback, onSubmitFeedbackText, setImageRating ]
+		[ mode, attachmentId, selectedFeedback, onFeedback, onSubmitFeedbackText ]
 	);
 
 	const handleCloseFeedbackPopover = useCallback( () => {

--- a/packages/image-studio/src/components/canvas-controls/style.scss
+++ b/packages/image-studio/src/components/canvas-controls/style.scss
@@ -27,10 +27,6 @@
 	align-items: center;
 }
 
-.canvas-controls__left button[aria-pressed="true"] {
-	cursor: default;
-}
-
 .canvas-controls__nav-button {
 	background: transparent;
 	border: none;

--- a/packages/image-studio/src/components/index.tsx
+++ b/packages/image-studio/src/components/index.tsx
@@ -438,11 +438,10 @@ const ImageStudioContent = withInstanceId(
 			<AnnotationCanvas imageUrl={ finalDisplayUrl } imageElement={ imageRef.current } />
 		) : null;
 
-		// Show feedback buttons only for AI-generated/edited images — never for the
-		// original attachment — and not while annotating (suggestions differ there).
-		const isOriginalImage = attachmentId !== null && attachmentId === originalAttachmentId;
+		// Show feedback buttons when image is AI-processed and not in other states
+		// Don't show for annotated images as they will have different suggestions
 		const showFeedbackButtons =
-			! isCurrentAttachmentAnnotated && !! isAiProcessed && !! finalDisplayUrl && ! isOriginalImage;
+			! isCurrentAttachmentAnnotated && !! isAiProcessed && !! finalDisplayUrl;
 
 		// Show actions menu only in Edit mode after AI has made changes.
 		// canRevert already checks: originalAttachmentId exists, image changed, not processing

--- a/packages/image-studio/src/store/index.test.ts
+++ b/packages/image-studio/src/store/index.test.ts
@@ -95,7 +95,6 @@ describe( 'Image Studio Store', () => {
 				selectedStyle: null,
 				selectedAspectRatio: null,
 				lastAgentMessageId: null,
-				imageRatings: {},
 			} );
 		} );
 
@@ -852,67 +851,6 @@ describe( 'Image Studio Store', () => {
 
 				expect( state.lastAgentMessageId ).toBe( 'msg-123' );
 			} );
-
-			it( 'SET_IMAGE_RATING records a rating for an attachment', () => {
-				const state = reducer( getInitialState(), actions.setImageRating( 123, 'up' ) );
-
-				expect( state.imageRatings ).toEqual( { 123: 'up' } );
-			} );
-
-			it( 'SET_IMAGE_RATING preserves ratings for other attachments', () => {
-				const initial: ImageStudioState = {
-					...getInitialState(),
-					imageRatings: { 123: 'up' },
-				};
-				const state = reducer( initial, actions.setImageRating( 456, 'down' ) );
-
-				expect( state.imageRatings ).toEqual( { 123: 'up', 456: 'down' } );
-			} );
-
-			it( 'preserves imageRatings when UPDATE_IMAGE_STUDIO_CANVAS fires', () => {
-				const initial: ImageStudioState = {
-					...getInitialState(),
-					imageRatings: { 123: 'up' },
-				};
-				const state = reducer(
-					initial,
-					actions.updateImageStudioCanvas( 'https://example.com/v2.jpg', 456 )
-				);
-
-				expect( state.imageRatings ).toEqual( { 123: 'up' } );
-			} );
-
-			it( 'resets imageRatings on OPEN_IMAGE_STUDIO', () => {
-				const initial: ImageStudioState = {
-					...getInitialState(),
-					imageRatings: { 123: 'up' },
-				};
-				const state = reducer( initial, actions.openImageStudio( 123 ) );
-
-				expect( state.imageRatings ).toEqual( {} );
-			} );
-
-			it( 'resets imageRatings on CLOSE_IMAGE_STUDIO', () => {
-				const initial: ImageStudioState = {
-					...getInitialState(),
-					imageRatings: { 123: 'down' },
-				};
-				const state = reducer( initial, actions.closeImageStudio() );
-
-				expect( state.imageRatings ).toEqual( {} );
-			} );
-
-			it( 'resets imageRatings on NAVIGATE_TO_ATTACHMENT (new working session)', () => {
-				const initial: ImageStudioState = {
-					...getInitialState(),
-					imageRatings: { 100: 'up' },
-					navigableAttachmentIds: [ 100, 200 ],
-					currentNavigationIndex: 0,
-				};
-				const state = reducer( initial, actions.navigateToAttachment( 200 ) );
-
-				expect( state.imageRatings ).toEqual( {} );
-			} );
 		} );
 	} );
 
@@ -1084,39 +1022,6 @@ describe( 'Image Studio Store', () => {
 		it( 'getLastAgentMessageId', () => {
 			const state: ImageStudioState = { ...getInitialState(), lastAgentMessageId: 'msg-123' };
 			expect( selectors.getLastAgentMessageId( state ) ).toBe( 'msg-123' );
-		} );
-
-		describe( 'getImageRating', () => {
-			it( 'returns the rating for an attachment', () => {
-				const state: ImageStudioState = {
-					...getInitialState(),
-					imageRatings: { 123: 'up', 456: 'down' },
-				};
-				expect( selectors.getImageRating( state, 123 ) ).toBe( 'up' );
-				expect( selectors.getImageRating( state, 456 ) ).toBe( 'down' );
-			} );
-
-			it( 'returns null for an unrated attachment', () => {
-				const state: ImageStudioState = {
-					...getInitialState(),
-					imageRatings: { 123: 'up' },
-				};
-				expect( selectors.getImageRating( state, 999 ) ).toBeNull();
-			} );
-
-			it( 'returns null when attachmentId is null', () => {
-				const state: ImageStudioState = {
-					...getInitialState(),
-					imageRatings: { 123: 'up' },
-				};
-				expect( selectors.getImageRating( state, null ) ).toBeNull();
-			} );
-		} );
-
-		it( 'getImageRatings returns the full map', () => {
-			const ratings = { 123: 'up' as const, 456: 'down' as const };
-			const state: ImageStudioState = { ...getInitialState(), imageRatings: ratings };
-			expect( selectors.getImageRatings( state ) ).toEqual( ratings );
 		} );
 
 		describe( 'getHasUnsavedChanges', () => {

--- a/packages/image-studio/src/store/index.ts
+++ b/packages/image-studio/src/store/index.ts
@@ -105,10 +105,6 @@ export interface ImageStudioState {
 	selectedAspectRatio: string | null;
 	// Last agent message ID for feedback tracking
 	lastAgentMessageId: string | null;
-	// Ratings the user has submitted in this session, keyed by attachment ID.
-	// Once a rating is recorded for an image it stays for the session so the
-	// buttons remain disabled when navigating back to that image.
-	imageRatings: Record< number, 'up' | 'down' >;
 }
 
 /**
@@ -258,14 +254,6 @@ type SetLastAgentMessageIdAction = {
 	payload: string | null;
 };
 
-type SetImageRatingAction = {
-	type: 'SET_IMAGE_RATING';
-	payload: {
-		attachmentId: number;
-		rating: 'up' | 'down';
-	};
-};
-
 type ResetCanvasHistoryAction = {
 	type: 'RESET_CANVAS_HISTORY';
 };
@@ -297,7 +285,6 @@ type ImageStudioAction =
 	| SetSelectedStyleAction
 	| SetSelectedAspectRatioAction
 	| SetLastAgentMessageIdAction
-	| SetImageRatingAction
 	| ResetCanvasHistoryAction;
 
 /**
@@ -365,7 +352,6 @@ const initialState: ImageStudioState = {
 	selectedStyle: null,
 	selectedAspectRatio: null,
 	lastAgentMessageId: null,
-	imageRatings: {},
 };
 
 /**
@@ -604,8 +590,6 @@ const reducer = (
 				onCloseCallback: null,
 				entryPoint: null,
 				blockType: null,
-				// Reset ratings for the new file since it's a new working session
-				imageRatings: {},
 				// Keep navigation state (navigableAttachmentIds, currentNavigationIndex, pagination)
 				// Keep user preferences (isSidebarOpen, selectedStyle, selectedAspectRatio)
 			};
@@ -646,15 +630,6 @@ const reducer = (
 			return {
 				...state,
 				lastAgentMessageId: action.payload,
-			};
-
-		case 'SET_IMAGE_RATING':
-			return {
-				...state,
-				imageRatings: {
-					...state.imageRatings,
-					[ action.payload.attachmentId ]: action.payload.rating,
-				},
 			};
 
 		case 'RESET_CANVAS_HISTORY':
@@ -735,10 +710,6 @@ export interface ImageStudioActions {
 	setSelectedStyle: ( style: string | null ) => Promise< SetSelectedStyleAction >;
 	setSelectedAspectRatio: ( aspectRatio: string | null ) => Promise< SetSelectedAspectRatioAction >;
 	setLastAgentMessageId: ( messageId: string | null ) => Promise< SetLastAgentMessageIdAction >;
-	setImageRating: (
-		attachmentId: number,
-		rating: 'up' | 'down'
-	) => Promise< SetImageRatingAction >;
 	resetCanvasHistory: () => Promise< ResetCanvasHistoryAction >;
 }
 
@@ -956,13 +927,6 @@ const actions = {
 		};
 	},
 
-	setImageRating( attachmentId: number, rating: 'up' | 'down' ): SetImageRatingAction {
-		return {
-			type: 'SET_IMAGE_RATING',
-			payload: { attachmentId, rating },
-		};
-	},
-
 	resetCanvasHistory(): ResetCanvasHistoryAction {
 		return {
 			type: 'RESET_CANVAS_HISTORY',
@@ -1008,8 +972,6 @@ export interface ImageStudioSelectors {
 	getSelectedStyle: ( state: ImageStudioState ) => string | null;
 	getSelectedAspectRatio: ( state: ImageStudioState ) => string | null;
 	getLastAgentMessageId: ( state: ImageStudioState ) => string | null;
-	getImageRatings: ( state: ImageStudioState ) => Record< number, 'up' | 'down' >;
-	getImageRating: ( state: ImageStudioState, attachmentId: number | null ) => 'up' | 'down' | null;
 	getSupportedMimeTypes: () => readonly string[];
 }
 
@@ -1182,17 +1144,6 @@ const selectors = {
 
 	getLastAgentMessageId( state: ImageStudioState ): string | null {
 		return state.lastAgentMessageId;
-	},
-
-	getImageRatings( state: ImageStudioState ): Record< number, 'up' | 'down' > {
-		return state.imageRatings;
-	},
-
-	getImageRating( state: ImageStudioState, attachmentId: number | null ): 'up' | 'down' | null {
-		if ( attachmentId === null ) {
-			return null;
-		}
-		return state.imageRatings[ attachmentId ] ?? null;
 	},
 
 	getSupportedMimeTypes(): readonly string[] {


### PR DESCRIPTION


This reverts commit 404afc86ac46df3ac8811d404f2866e12756ec82.
Regression: Linear FORNO-348
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
