### PR TITLE
Dashboard: enable wp-beta-program feature flag in remaining environments

### DIFF
--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -28,7 +28,7 @@
 		"bilmur-script": true,
 		"rum-tracking/logstash": true,
 		"dashboard/omnibar": false,
-		"dashboard/wp-beta-program": false,
+		"dashboard/wp-beta-program": true,
 		"dashboard/v2": false,
 		"domain-transfer-redesign": true,
 		"marketplace-redesign": true,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -27,7 +27,7 @@
 		"cookie-banner": false,
 		"rum-tracking/logstash": true,
 		"dashboard/omnibar": false,
-		"dashboard/wp-beta-program": false,
+		"dashboard/wp-beta-program": true,
 		"dashboard/v2": false,
 		"dev/store-sandbox-helper": true,
 		"domain-transfer-redesign": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -28,7 +28,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dashboard/omnibar": false,
-		"dashboard/wp-beta-program": false,
+		"dashboard/wp-beta-program": true,
 		"dashboard/opt-in-banners": false,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,

--- a/config/production.json
+++ b/config/production.json
@@ -42,7 +42,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dashboard/omnibar": false,
-		"dashboard/wp-beta-program": false,
+		"dashboard/wp-beta-program": true,
 		"dashboard/opt-in-banners": false,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -39,7 +39,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dashboard/omnibar": false,
-		"dashboard/wp-beta-program": false,
+		"dashboard/wp-beta-program": true,
 		"dashboard/opt-in-banners": false,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -38,7 +38,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dashboard/omnibar": false,
-		"dashboard/wp-beta-program": false,
+		"dashboard/wp-beta-program": true,
 		"dashboard/opt-in-banners": false,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,


### PR DESCRIPTION
Part of #

## Proposed Changes

* Set the `dashboard/wp-beta-program` feature flag to `true` in `wpcalypso.json`, `stage.json`, `horizon.json`, `production.json`, `dashboard-stage.json`, and `dashboard-production.json`.

## Why are these changes being made?

* The flag was previously only enabled in development configs. Enabling it across the remaining environments rolls the WordPress beta program feature out to all users of the Dashboard.

## Testing Instructions

* Check out this branch and load the Dashboard against each target environment config.
* Navigate to a site's WordPress settings and verify the beta program / version switch UI is rendered (gated by `isEnabled( 'dashboard/wp-beta-program' )` in `client/dashboard/sites/settings-wordpress/use-version-switch.ts` and `client/dashboard/sites/features.ts`).
* Verify no regressions on non-staging sites and that WPCOM staging sites continue to hide the option.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)