### PR TITLE
Purchases & Domains: rename status column to "Renewal/Expiry"

### DIFF
--- a/client/dashboard/me/billing-purchases/dataviews.tsx
+++ b/client/dashboard/me/billing-purchases/dataviews.tsx
@@ -375,7 +375,7 @@ export function getFields( {
 		},
 		{
 			id: 'status',
-			label: __( 'Expires/Renews on' ),
+			label: __( 'Renewal/Expiry' ),
 			type: 'text',
 			enableGlobalSearch: true,
 			enableSorting: true,

--- a/client/dashboard/me/billing-purchases/dataviews.tsx
+++ b/client/dashboard/me/billing-purchases/dataviews.tsx
@@ -375,7 +375,7 @@ export function getFields( {
 		},
 		{
 			id: 'status',
-			label: __( 'Renewal/Expiry' ),
+			label: __( 'Renewal/expiry' ),
 			type: 'text',
 			enableGlobalSearch: true,
 			enableSorting: true,

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -301,7 +301,7 @@ export function getPurchasesFieldDefinitions( {
 		},
 		{
 			id: 'status',
-			label: translate( 'Renewal/Expiry' ),
+			label: translate( 'Renewal/expiry' ),
 			type: 'text',
 			enableGlobalSearch: true,
 			enableSorting: true,

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -301,7 +301,7 @@ export function getPurchasesFieldDefinitions( {
 		},
 		{
 			id: 'status',
-			label: translate( 'Expires/Renews on' ),
+			label: translate( 'Renewal/Expiry' ),
 			type: 'text',
 			enableGlobalSearch: true,
 			enableSorting: true,

--- a/client/my-sites/domains/domain-management/dataviews/use-fields.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/use-fields.tsx
@@ -115,7 +115,7 @@ export function useFields() {
 			},
 			{
 				id: 'expiry',
-				label: translate( 'Expires/Renews on' ),
+				label: translate( 'Renewal/Expiry' ),
 				enableHiding: false,
 				enableSorting: true,
 				getValue: ( { item }: { item: PartialDomainData } ) =>

--- a/client/my-sites/domains/domain-management/dataviews/use-fields.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/use-fields.tsx
@@ -115,7 +115,7 @@ export function useFields() {
 			},
 			{
 				id: 'expiry',
-				label: translate( 'Renewal/Expiry' ),
+				label: translate( 'Renewal/expiry' ),
 				enableHiding: false,
 				enableSorting: true,
 				getValue: ( { item }: { item: PartialDomainData } ) =>


### PR DESCRIPTION
fixes: https://linear.app/a8c/issue/RSM-550

## Summary

Renames the status column header from **"Expires/Renews on"** to **"Renewal/Expiry"** in three DataViews tables:

- **New dashboard – Purchases:** `client/dashboard/me/billing-purchases/dataviews.tsx`
- **Legacy – Purchases list:** `client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx`
- **My Sites – Domain management:** `client/my-sites/domains/domain-management/dataviews/use-fields.tsx`

The new label is shorter, scans better in narrow columns, and reads naturally whether the row is expiring or auto-renewing.

**Before**

<img width="1796" height="1196" alt="image" src="https://github.com/user-attachments/assets/8e2425db-20cc-4a25-8785-a87e629ba059" />

<img width="1796" height="1196" alt="image" src="https://github.com/user-attachments/assets/fd99bbcd-114e-4975-b957-42d813652c61" />

<img width="1796" height="1196" alt="image" src="https://github.com/user-attachments/assets/f73d8905-a043-463d-a5cc-b0d62b93a7e1" />



**After**

<img width="1796" height="1196" alt="image" src="https://github.com/user-attachments/assets/e00b3028-36fd-4ab4-ae6d-fa44e806b47f" />

<img width="1796" height="1196" alt="image" src="https://github.com/user-attachments/assets/f063fab0-9bbd-4cd8-baa8-ec6010092086" />

<img width="1796" height="1196" alt="image" src="https://github.com/user-attachments/assets/153c23c1-99fe-4119-bb1f-597f9471538d" />



## Why

The previous header read like an action ("Expires/Renews **on**") which implied a single date semantics, but the column actually shows mixed state (renewal date for active items, expiry date for expired ones). "Renewal/Expiry" describes the column contents, not an event. It also leads with Renewals on a more positive note.

## Translation helpers

Each surface uses the correct helper for its area:

| File | Helper |
|------|--------|
| `client/dashboard/…` | `__` from `@wordpress/i18n` |
| `client/me/purchases/…` | `translate` from `i18n-calypso` |
| `client/my-sites/domains/…` | `translate` from `i18n-calypso` |

## Test plan

- [ ] **New dashboard purchases** – visit `/me/billing/purchases` and confirm the column header reads **"Renewal/Expiry"** (was "Expires/Renews on")
- [ ] **Legacy purchases list** – visit `/me/purchases` (DataViews variant) and confirm the same header text
- [ ] **Domains DataViews** – visit `/domains/manage` (or any DataViews-enabled domain list) and confirm the expiry column header reads **"Renewal/Expiry"**
- [ ] **Sorting still works** – click the new header in each surface; sorting toggles ascending/descending as before
- [ ] **Translations** – switch to a non-English locale (e.g. `?locale=fr`) and confirm the new string is picked up by the translation pipeline (will show English until translated, but no raw key should appear)

## Notes

- No logic changes — pure label rename.
- No tests added or updated; existing tests assert on field IDs (`status`, `expiry`), not the human-readable label.