### PR TITLE
Happy Blocks: enable Odie search for logged-in users on support pages

### DIFF
--- a/apps/happy-blocks/block-library/search-card/includes.php
+++ b/apps/happy-blocks/block-library/search-card/includes.php
@@ -7,8 +7,6 @@
  * @package happy-blocks
  */
 
-$enable_odie_answers = ! is_user_logged_in();
-
 if ( ! function_exists( 'happy_blocks_get_search_card_asset' ) ) {
 	/**
 	 * Find the URL of the asset file from happy-blocks.
@@ -26,10 +24,5 @@ if ( ! function_exists( 'happy_blocks_get_search_card_asset' ) ) {
 $happy_blocks_get_search_card_css = happy_blocks_get_search_card_asset( is_rtl() ? 'view.rtl.css' : 'view.css' );
 wp_enqueue_style( 'happy-blocks-support-search-card-style', $happy_blocks_get_search_card_css['path'], array(), $happy_blocks_get_search_card_css['version'] );
 
-if ( $enable_odie_answers ) {
-	$happy_blocks_get_search_card_js = happy_blocks_get_search_card_asset( 'view-odie.js' );
-	wp_enqueue_script( 'happy-blocks-support-search-card-script', $happy_blocks_get_search_card_js['path'], array(), $happy_blocks_get_search_card_js['version'], true );
-} else {
-	$happy_blocks_get_search_card_js = happy_blocks_get_search_card_asset( 'view.js' );
-	wp_enqueue_script( 'happy-blocks-support-search-card-script', $happy_blocks_get_search_card_js['path'], array(), $happy_blocks_get_search_card_js['version'], true );
-}
+$happy_blocks_get_search_card_js = happy_blocks_get_search_card_asset( 'view-odie.js' );
+wp_enqueue_script( 'happy-blocks-support-search-card-script', $happy_blocks_get_search_card_js['path'], array(), $happy_blocks_get_search_card_js['version'], true );

--- a/apps/happy-blocks/block-library/search-card/index.php
+++ b/apps/happy-blocks/block-library/search-card/index.php
@@ -20,8 +20,7 @@ if ( $is_forums ) {
 } else {
 	$show_search_card = $is_front_page || $is_404_page;
 }
-$enable_odie_answers           = ! is_user_logged_in();
-$should_show_search_navigation = ( $is_front_page && $enable_odie_answers ) || ( ! $is_front_page && ! $is_404_page );
+$should_show_search_navigation = ! $is_404_page;
 
 $form_class              = isset( $args['form_class'] ) ? $args['form_class'] : '';
 $input_class             = isset( $args['input_class'] ) ? $args['input_class'] : '';
@@ -134,21 +133,12 @@ $website                 = isset( $args['website'] ) ? $args['website'] : '';
 			<form id="support-search-form" class="<?php echo esc_attr( $form_class ); ?>" role="search" method="get" action="" data-website="<?php echo esc_attr( $website ); ?>">
 				<input type="hidden" name="group_id" value="blog_id:<?php echo esc_attr( get_current_blog_id() ); ?>"/>
 				<div class="input-wrapper" dir="auto">
-					<?php if ( $enable_odie_answers ) : ?>
-						<input id="support-search-input" type="search" name="odie-query"<?php echo $input_class ? ' class="' . esc_attr( $input_class ) . '"' : ''; ?> placeholder="<?php echo esc_attr( $placeholder ); ?>"/>
-						<button type="submit" class="search-submit-button button-primary" aria-label="<?php echo esc_attr( __( 'Search', 'happy-blocks' ) ); ?>">
-							<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-								<path d="M12.2197 5C12.4186 5 12.6094 5.07902 12.75 5.21967L17 9.46967C17.2929 9.76256 17.2929 10.2374 17 10.5303C16.7071 10.8232 16.2322 10.8232 15.9393 10.5303L12.9697 7.56067V18.25C12.9697 18.6642 12.6339 19 12.2197 19C11.8055 19 11.4697 18.6642 11.4697 18.25V7.56065L8.5 10.5303C8.2071 10.8232 7.73223 10.8232 7.43934 10.5303C7.14644 10.2374 7.14645 9.76256 7.43934 9.46967L11.6894 5.21967C11.83 5.07902 12.0208 5 12.2197 5Z" fill="currentColor"/>
-							</svg>
-						</button>
-					<?php else : ?>
-						<input id="support-search-input" type="search" name="s"<?php echo $input_class ? ' class="' . esc_attr( $input_class ) . '"' : ''; ?> placeholder="<?php echo esc_attr( $placeholder ); ?>"/>
-						<button type="submit" class="search-submit-button" aria-label="<?php echo esc_attr( __( 'Search', 'happy-blocks' ) ); ?>">
-							<svg xmlns="http://www.w3.org/2000/svg" class="search-icon" width="24" height="24" viewBox="0 0 24 24" fill="none">
-								<path d="M13 5C9.7 5 7 7.7 7 11C7 12.4 7.5 13.7 8.3 14.7L4.5 18.5L5.6 19.6L9.4 15.8C10.4 16.6 11.7 17.1 13.1 17.1C16.4 17.1 19.1 14.4 19.1 11.1C19.1 7.8 16.3 5 13 5ZM13 15.5C10.5 15.5 8.5 13.5 8.5 11C8.5 8.5 10.5 6.5 13 6.5C15.5 6.5 17.5 8.5 17.5 11C17.5 13.5 15.5 15.5 13 15.5Z"/>
-							</svg>
-						</button>
-					<?php endif; ?>
+					<input id="support-search-input" type="search" name="odie-query"<?php echo $input_class ? ' class="' . esc_attr( $input_class ) . '"' : ''; ?> placeholder="<?php echo esc_attr( $placeholder ); ?>"/>
+					<button type="submit" class="search-submit-button button-primary" aria-label="<?php echo esc_attr( __( 'Search', 'happy-blocks' ) ); ?>">
+						<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+							<path d="M12.2197 5C12.4186 5 12.6094 5.07902 12.75 5.21967L17 9.46967C17.2929 9.76256 17.2929 10.2374 17 10.5303C16.7071 10.8232 16.2322 10.8232 15.9393 10.5303L12.9697 7.56067V18.25C12.9697 18.6642 12.6339 19 12.2197 19C11.8055 19 11.4697 18.6642 11.4697 18.25V7.56065L8.5 10.5303C8.2071 10.8232 7.73223 10.8232 7.43934 10.5303C7.14644 10.2374 7.14645 9.76256 7.43934 9.46967L11.6894 5.21967C11.83 5.07902 12.0208 5 12.2197 5Z" fill="currentColor"/>
+						</svg>
+					</button>
 				</div>
 			</form>
 


### PR DESCRIPTION

## Proposed Changes

* Always enqueue `view-odie.js` (drop the `is_user_logged_in()` fork) so the AI-backed Help Center flow runs for every visitor of `wordpress.com/support`.
* Always render the Odie-bound search input (`name=\"odie-query\"`) with the Odie submit button.
* Simplify `$should_show_search_navigation` to `! $is_404_page`, which also surfaces the \"Search\" nav link on the front page for logged-in users (giving them a parallel path to keyword search, matching logged-out UX).

## Why are these changes being made?

Today, the happy-blocks support search card opens the Help Center with Odie only for logged-out users; logged-in users are routed to the classic keyword search. We want logged-in users to get the AI experience too.

## Testing Instructions

1. Sandbox `wordpress.com` / `widgets.wp.com` and deploy this branch.
2. Visit `https://wordpress.com/support/` **while logged in**.
3. Type a query into the main search box on the front page and submit. Verify the Help Center opens with Odie and the query is pre-populated.
4. Verify the \"Search\" nav link (magnifying-glass) still appears in the header and takes you to the legacy keyword search.
5. Repeat on a 404 support URL (e.g. `https://wordpress.com/support/does-not-exist`) — the card should still render with an Odie input, and the nav-level search link should be hidden (keyword search is intentionally unavailable on 404 pages).
6. Repeat logged out to confirm no regression.
