### PR TITLE
Dashboard: Fix AI tools settings page

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -20,8 +20,8 @@ const contextLinks = {
 		post_id: 213203,
 	},
 	'ai-tools': {
-		link: 'https://wordpress.com/support/ai-website-builder/',
-		post_id: 404989,
+		link: 'https://wordpress.com/support/ai/',
+		post_id: 437308,
 	},
 	autorenewal: {
 		link: 'https://wordpress.com/support/manage-purchases/automatic-renewal/',

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -1,4 +1,4 @@
-import { HostingFeatures, DotcomFeatures, LogType } from '@automattic/api-core';
+import { HostingFeatures, DotcomFeatures, LogType, fetchTwoStep } from '@automattic/api-core';
 import {
 	bigSkyPluginQuery,
 	userSettingsQuery,
@@ -51,6 +51,7 @@ import {
 	canViewHundredYearPlanSettings,
 } from '../../sites/features';
 import { shouldLoadWpVersionNotice } from '../../sites/overview/wp-version-notice';
+import { reauthRequiredLink } from '../../utils/link';
 import {
 	getActivityLogHiddenGroups,
 	hasHostingFeature,
@@ -661,6 +662,13 @@ export const siteSettingsAIToolsRoute = createRoute( {
 
 		if ( ! isEnabled( 'wordpress-ai-tools' ) ) {
 			throw redirectAsNotAllowed( { to: siteSettingsRoute.fullPath, params: { siteSlug } } );
+		}
+
+		if ( cause === 'enter' ) {
+			const twoStep = await fetchTwoStep();
+			if ( twoStep.two_step_reauthorization_required ) {
+				throw dashboardRedirect( { href: reauthRequiredLink(), reloadDocument: true } );
+			}
 		}
 	},
 	loader: async ( { params: { siteSlug } } ) => {

--- a/client/sites/v2/site-settings/router.tsx
+++ b/client/sites/v2/site-settings/router.tsx
@@ -37,9 +37,8 @@ const siteVisibilityRoute = createRoute( {
 );
 
 const aiToolsLayoutRoute = createRoute( {
-	path: 'ai-tools',
+	...appRouterSites.siteSettingsAIToolsRoute.options,
 	getParentRoute: () => settingsRoute,
-	head: () => ( { meta: [ { title: __( 'AI tools' ) } ] } ),
 } );
 
 const aiToolsIndexRoute = createRoute( {


### PR DESCRIPTION
Part of #

## Proposed Changes

* Update the `ai-tools` support doc link to point to https://wordpress.com/support/ai/ (post ID 437308), replacing the previous `ai-website-builder` URL
* Add a `two_step_reauthorization_required` check to `siteSettingsAIToolsRoute` to redirect users through reauth before loading the page, preventing a 500 error ("A fresh access token must be used to query information about the current user")

## Why are these changes being made?

* The "Learn More" link on `/sites/*/settings/ai-tools` was pointing to an outdated support article.
* The AI tools settings page is unique among site settings pages in that it calls `userSettingsQuery()`, which requires a fresh access token. Without the reauth check, users with stale tokens hit a 500 error. The `/me/mcp` page (which has the same requirement) handles this via the `meRoute` `beforeLoad` — this PR applies the same pattern directly to `siteSettingsAIToolsRoute`.

## Testing Instructions

* Visit `/sites/*/settings/ai-tools` and confirm the "Learn More" link opens https://wordpress.com/support/ai/
* To test the reauth redirect: intercept the `GET /me/two-step` response in browser devtools to return `{ two_step_reauthorization_required: true }` and confirm navigating to the page redirects to the reauth flow instead of showing a 500 error

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)