### PR TITLE
A4A: Enable Site migration manual verification flow in staging and pr…

### DIFF
--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -42,7 +42,7 @@
 		"jetpack/crm-downloads": true,
 		"upgrades/redirect-payments": true,
 		"a4a-bd-term-pricing": true,
-		"a4a-migrations-request-verification": false,
+		"a4a-migrations-request-verification": true,
 		"checkout/stripe-upi": true
 	},
 	"enable_all_sections": false,

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -47,7 +47,7 @@
 		"jetpack/crm-downloads": true,
 		"upgrades/redirect-payments": true,
 		"a4a-bd-term-pricing": true,
-		"a4a-migrations-request-verification": false,
+		"a4a-migrations-request-verification": true,
 		"checkout/stripe-upi": true
 	},
 	"enable_all_sections": false,


### PR DESCRIPTION


## Proposed Changes

This pull request enables the `a4a-migrations-request-verification` feature flag in both the production and staging configuration files. This means the request verification step for migrations will now be active in both environments.

Configuration updates:

* Enabled the `a4a-migrations-request-verification` feature flag in `config/a8c-for-agencies-production.json`, changing its value from `false` to `true`.
* Enabled the `a4a-migrations-request-verification` feature flag in `config/a8c-for-agencies-stage.json`, changing its value from `false` to `true`.

## Why are these changes being made?

* Allow agencies to request re-verification of sites that were migrated and previously rejected.

## Testing Instructions

* Check changes are good.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
