### PR TITLE
Dashboard: simplify 100-year plan and domain purchase settings

### DIFF
--- a/client/dashboard/components/overview-card/index.tsx
+++ b/client/dashboard/components/overview-card/index.tsx
@@ -85,10 +85,7 @@ export default function OverviewCard( {
 		if ( isLoading ) {
 			return <TextSkeleton length={ 20 } />;
 		}
-		if ( description ) {
-			return description;
-		}
-		return <>&nbsp;</>;
+		return description ?? null;
 	};
 
 	// Stepper/onboarding flows are not considered relative links because they can't be loaded by TanStack Router.

--- a/client/dashboard/components/purchase-expiry-status/index.tsx
+++ b/client/dashboard/components/purchase-expiry-status/index.tsx
@@ -24,6 +24,7 @@ import {
 	creditCardHasAlreadyExpired,
 	creditCardExpiresBeforeSubscription,
 	isInExpirationGracePeriod,
+	isCentennialPurchase,
 } from '../../utils/purchase';
 import type { Purchase } from '@automattic/api-core';
 
@@ -137,9 +138,7 @@ export function PurchaseExpiryStatus( {
 		);
 	}
 
-	const isCentennial =
-		purchase.bill_period_days === SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD ||
-		purchase.is_hundred_year_domain;
+	const isCentennial = isCentennialPurchase( purchase );
 
 	if ( isCentennial ) {
 		if ( isIncludedWithPlan( purchase ) ) {

--- a/client/dashboard/components/purchase-expiry-status/index.tsx
+++ b/client/dashboard/components/purchase-expiry-status/index.tsx
@@ -137,6 +137,23 @@ export function PurchaseExpiryStatus( {
 		);
 	}
 
+	const isCentennial =
+		purchase.bill_period_days === SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD ||
+		purchase.is_hundred_year_domain;
+
+	if ( isCentennial ) {
+		if ( isIncludedWithPlan( purchase ) ) {
+			return __( 'Included with plan' );
+		}
+		return createInterpolateElement(
+			// translators: date is a formatted expiry date
+			__( 'Paid until <date />' ),
+			{
+				date: <FormattedExpiryDate locale={ locale } purchase={ purchase } />,
+			}
+		);
+	}
+
 	const isIntroductoryOfferFreeTrial = purchase.introductory_offer?.cost_per_interval === 0;
 	if (
 		purchase.introductory_offer?.is_within_period &&

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -109,7 +109,7 @@ const SPACING = {
 function isCentennialPurchase( purchase: Purchase ): boolean {
 	return (
 		purchase.bill_period_days === SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD ||
-		Boolean( purchase.product_slug?.includes( '100-year' ) )
+		purchase.is_hundred_year_domain
 	);
 }
 

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -1,5 +1,4 @@
 import {
-	SubscriptionBillPeriod,
 	DomainProductSlugs,
 	useMyDomainInputMode,
 	WPCOM_DIFM_LITE,
@@ -89,6 +88,7 @@ import {
 	isAkismetFreeProduct,
 	isInExpirationGracePeriod,
 	isA4ABillingDragonPurchase,
+	isCentennialPurchase,
 } from '../../../utils/purchase';
 import { getSitePurchaseUpgradeUrl } from '../../../utils/site-url';
 import BillingFlexUsageCard from '../../billing-flex-usage';
@@ -105,13 +105,6 @@ const SPACING = {
 	DEFAULT: 6,
 	SMALL: 4,
 };
-
-function isCentennialPurchase( purchase: Purchase ): boolean {
-	return (
-		purchase.bill_period_days === SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD ||
-		purchase.is_hundred_year_domain
-	);
-}
 
 function renewPurchase( purchase: Purchase ): void {
 	window.location.href = getRenewalUrlFromPurchase( purchase );

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -1096,7 +1096,7 @@ function PurchaseSubtitle( { purchase }: { purchase: Purchase } ) {
 		purchase.bill_period_days === SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD &&
 		purchase.meta
 	) {
-		return <MetadataItem title={ purchase.meta } />;
+		return <MetadataItem title={ getTitleForDisplay( purchase ) } />;
 	}
 
 	const subtitle = getSubtitleForDisplay( purchase );
@@ -1168,7 +1168,11 @@ export default function PurchaseSettings() {
 				<VStack>
 					<PageHeader
 						prefix={ <Breadcrumbs length={ 3 } /> }
-						title={ getTitleForDisplay( purchase ) }
+						title={
+							purchase.is_domain && isCentennial && purchase.meta
+								? purchase.meta
+								: getTitleForDisplay( purchase )
+						}
 						actions={
 							site?.options?.admin_url &&
 							! isCentennial && (

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -106,6 +106,13 @@ const SPACING = {
 	SMALL: 4,
 };
 
+function isCentennialPurchase( purchase: Purchase ): boolean {
+	return (
+		purchase.bill_period_days === SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD ||
+		Boolean( purchase.product_slug?.includes( '100-year' ) )
+	);
+}
+
 function renewPurchase( purchase: Purchase ): void {
 	window.location.href = getRenewalUrlFromPurchase( purchase );
 }
@@ -656,7 +663,7 @@ function ManageSubscriptionCard( { purchase }: { purchase: Purchase } ) {
 }
 
 function PurchasePriceCard( { purchase }: { purchase: Purchase } ) {
-	const isCentennial = purchase.bill_period_days === SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD;
+	const isCentennial = isCentennialPurchase( purchase );
 	if ( isCentennial ) {
 		return (
 			<OverviewCard
@@ -1023,7 +1030,7 @@ function PurchaseSecondSubtitle( { purchase, site }: { purchase: Purchase; site?
 			return null;
 		}
 
-		if ( purchase.bill_period_days === SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD ) {
+		if ( isCentennialPurchase( purchase ) ) {
 			return null;
 		}
 
@@ -1091,11 +1098,7 @@ function PurchaseSecondSubtitle( { purchase, site }: { purchase: Purchase; site?
 }
 
 function PurchaseSubtitle( { purchase }: { purchase: Purchase } ) {
-	if (
-		purchase.is_domain &&
-		purchase.bill_period_days === SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD &&
-		purchase.meta
-	) {
+	if ( purchase.is_domain && isCentennialPurchase( purchase ) && purchase.meta ) {
 		return <MetadataItem title={ getTitleForDisplay( purchase ) } />;
 	}
 
@@ -1146,7 +1149,7 @@ export default function PurchaseSettings() {
 		if ( isInExpirationGracePeriod( purchase ) ) {
 			return __( 'Expired' );
 		}
-		if ( purchase.bill_period_days === SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD ) {
+		if ( isCentennialPurchase( purchase ) ) {
 			return __( 'Paid until' );
 		}
 		if ( willRenew ) {
@@ -1155,7 +1158,7 @@ export default function PurchaseSettings() {
 		return __( 'Expires' );
 	} )();
 
-	const isCentennial = purchase.bill_period_days === SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD;
+	const isCentennial = isCentennialPurchase( purchase );
 
 	const isSmallViewport = useViewportMatch( 'medium', '<' );
 	const columns = isSmallViewport ? 1 : 2;

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -656,6 +656,18 @@ function ManageSubscriptionCard( { purchase }: { purchase: Purchase } ) {
 }
 
 function PurchasePriceCard( { purchase }: { purchase: Purchase } ) {
+	const isCentennial = purchase.bill_period_days === SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD;
+	if ( isCentennial ) {
+		return (
+			<OverviewCard
+				icon={ currencyDollar }
+				title={ __( 'Price' ) }
+				heading={ formatCurrency( purchase.price_integer, purchase.currency_code, {
+					isSmallestUnit: true,
+				} ) }
+			/>
+		);
+	}
 	if ( purchase.partner_name && ! isA4ABillingDragonPurchase( purchase ) ) {
 		return (
 			<OverviewCard
@@ -1012,13 +1024,7 @@ function PurchaseSecondSubtitle( { purchase, site }: { purchase: Purchase; site?
 		}
 
 		if ( purchase.bill_period_days === SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD ) {
-			return (
-				<Text variant="muted">
-					{ __(
-						'Your stories, achievements, and memories preserved for generations to come. One payment. One hundred years of legacy.'
-					) }
-				</Text>
-			);
+			return null;
 		}
 
 		return (
@@ -1085,6 +1091,14 @@ function PurchaseSecondSubtitle( { purchase, site }: { purchase: Purchase; site?
 }
 
 function PurchaseSubtitle( { purchase }: { purchase: Purchase } ) {
+	if (
+		purchase.is_domain &&
+		purchase.bill_period_days === SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD &&
+		purchase.meta
+	) {
+		return <MetadataItem title={ purchase.meta } />;
+	}
+
 	const subtitle = getSubtitleForDisplay( purchase );
 	if ( ! subtitle ) {
 		return null;
@@ -1141,6 +1155,8 @@ export default function PurchaseSettings() {
 		return __( 'Expires' );
 	} )();
 
+	const isCentennial = purchase.bill_period_days === SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD;
+
 	const isSmallViewport = useViewportMatch( 'medium', '<' );
 	const columns = isSmallViewport ? 1 : 2;
 	const spacing = isSmallViewport ? SPACING.SMALL : SPACING.DEFAULT;
@@ -1154,7 +1170,8 @@ export default function PurchaseSettings() {
 						prefix={ <Breadcrumbs length={ 3 } /> }
 						title={ getTitleForDisplay( purchase ) }
 						actions={
-							site?.options?.admin_url && (
+							site?.options?.admin_url &&
+							! isCentennial && (
 								<HStack justify="space-between">
 									{ purchase.is_upgradable && upgradeUrl && (
 										<Button __next40pxDefaultSize variant="primary" href={ upgradeUrl }>
@@ -1207,6 +1224,9 @@ export default function PurchaseSettings() {
 							return formattedExpiry;
 						} )() }
 						description={ ( () => {
+							if ( isCentennial ) {
+								return undefined;
+							}
 							if ( purchase.is_auto_renew_enabled && isInExpirationGracePeriod( purchase ) ) {
 								return __( 'Pending renewal' );
 							}
@@ -1280,10 +1300,12 @@ export default function PurchaseSettings() {
 				{ isWpcomFlexSubscription( purchase ) && (
 					<BillingFlexUsageCard purchaseId={ purchase.ID } />
 				) }
-				{ ! purchase.is_trial_plan && purchase.subscription_status === 'active' && (
-					<ManageSubscriptionCard purchase={ purchase } />
-				) }
-				<PurchaseSettingsActions purchase={ purchase } />
+				{ ! purchase.is_trial_plan &&
+					! isCentennial &&
+					purchase.subscription_status === 'active' && (
+						<ManageSubscriptionCard purchase={ purchase } />
+					) }
+				{ ! isCentennial && <PurchaseSettingsActions purchase={ purchase } /> }
 			</VStack>
 		</PageLayout>
 	);

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -708,6 +708,13 @@ export function getPurchaseCancellationFlowType( purchase: Purchase ): CancelFlo
 /**
  * Returns true if a list of products includes a product with a matching product or store product slug.
  */
+export function isCentennialPurchase( purchase: Purchase ): boolean {
+	return (
+		purchase.bill_period_days === SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD ||
+		purchase.is_hundred_year_domain
+	);
+}
+
 export const hasMarketplaceProduct = ( productsList: Product[], searchSlug: string ): boolean =>
 	// storeProductSlug is from the legacy store_products system, billing_product_slug is from
 	// the non-legacy billing system and for marketplace plugins will match the slug of the plugin


### PR DESCRIPTION
Fixes: https://linear.app/a8c/issue/RSM-551

## Proposed Changes

This PR cleans up the MSD purchase settings screen for the 100 year products. This aligns the screen with the decisions made to exclude certain elements from the calypso screens:
| 100 year plan | 100 year domain |
| --- | --- |
| <img width="1796" height="1196" alt="image" src="https://github.com/user-attachments/assets/e5b1aafe-b4f3-4ab6-92c6-91452a836dca" /> | <img width="1796" height="1196" alt="image" src="https://github.com/user-attachments/assets/7123216f-7eeb-43b0-9b62-e48a1dca0ea3" /> |

The following updates were made:

* Hide upgrade button, action menu (upgrade/renew), auto-renew toggle, and all bottom action items for 100-year plan and domain purchases
* Rename "Renewal price" card to "Price" and remove micro-copy (bill period, taxes note) for centennial purchases
* Remove the "Paid until" card description (auto-renew status) for centennial purchases
* Replace "blog Domain Registration" subtitle with the product type.
* Remove the "Your stories, achievements..." and "When used with a paid plan..." marketing copy for 100-year domain purchases
* Fix `OverviewCard` to omit the description row entirely when no description is provided, instead of rendering a blank `&nbsp;` spacer
* Update active purchase table to only show paid until date.

| Before | After |
| --- | --- |
| <img width="1796" height="1196" alt="image" src="https://github.com/user-attachments/assets/b1cbce8c-d8a1-4968-b0c4-7cf7fa8df43d" /> |  <img width="1796" height="1196" alt="image" src="https://github.com/user-attachments/assets/d35cd990-1f39-4e04-8312-15c5aca9e900" /> |
| <img width="1796" height="1196" alt="image" src="https://github.com/user-attachments/assets/2a6b7b77-1eae-426e-8b75-f94ca1012889" /> | <img width="1796" height="1196" alt="image" src="https://github.com/user-attachments/assets/256cb3d5-4293-48f7-8fa4-ed204de77453" /> |
| <img width="1796" height="1196" alt="image" src="https://github.com/user-attachments/assets/c13728e9-59b0-4a04-b585-448b3c2f8298" /> | <img width="1796" height="1196" alt="image" src="https://github.com/user-attachments/assets/1ce80ac3-8f07-49b3-bec6-96ba08188705" /> |


## Why are these changes being made?

100-year plans and domains are one-time purchases — there's no higher plan to upgrade to, no manual renewal needed, and auto-renew is not applicable. The purchase settings page was showing a full set of subscription management controls that were either non-functional or misleading for these products. This change gives 100-year purchases a clean, read-only view appropriate to their nature.

## Testing Instructions

1. Navigate to Billing > Active upgrades and open a **WordPress.com 100-Year Plan** purchase
   - Upgrade button and action menu (⋮) should be gone from the header
   - "Paid until" card should show the date with no description below
   - "Renewal price" card should be renamed to "Price" with no micro-copy
   - Auto-renew toggle / Manage subscription card should not appear
   - No action items at the bottom of the page
2. Open a **100-Year Domain Registration** purchase
   - Same button/action/auto-renew changes as above
   - The subtitle line should show the domain name (e.g. `example.blog`) instead of "blog Domain Registration"
   - No marketing copy below the subtitle
3. Open a **regular plan or domain** purchase — verify all controls still appear normally
4. Verify `OverviewCard` cards without a description render cleanly (no blank row below the heading)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?