### PR TITLE
reader following remove early return for only self subscriptions

### DIFF
--- a/client/reader/following/main.tsx
+++ b/client/reader/following/main.tsx
@@ -13,14 +13,12 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { selectSidebarRecentSite } from 'calypso/state/reader-ui/sidebar/actions';
 import Recent from '../recent';
-import { useSiteSubscriptions } from './use-site-subscriptions';
 import { useFollowingView } from './view-preference';
 import ViewToggle from './view-toggle';
 import './style.scss';
 
 function FollowingStream( { ...props } ) {
 	const { currentView } = useFollowingView();
-	const { isLoading, hasNonSelfSubscriptions } = useSiteSubscriptions();
 	const dispatch = useDispatch();
 	const [ isResurrectedModalVisible, setIsResurrectedModalVisible ] = useState( false );
 	const [ shouldDelayReaderOnboarding, setShouldDelayReaderOnboarding ] = useState( false );
@@ -55,30 +53,6 @@ function FollowingStream( { ...props } ) {
 		// Note that 'null' specifically sets the all view.
 		dispatch( selectSidebarRecentSite( { feedId: Number( props.feedId ) || null } ) );
 	}, [ props.feedId, dispatch ] );
-
-	if ( ! isLoading && ! hasNonSelfSubscriptions ) {
-		return (
-			<div className="following-stream--no-subscriptions">
-				<NavigationHeader title={ translate( 'Recent' ) } />
-				<p>
-					{ translate(
-						'{{strong}}Welcome!{{/strong}} Follow your favorite sites and their latest posts will appear here. Read, like, and comment in a distraction-free environment. Get started by selecting your interests below:',
-						{
-							components: {
-								strong: <strong />,
-							},
-						}
-					) }
-				</p>
-				<AsyncLoad
-					require="calypso/reader/onboarding"
-					forceShow
-					onRender={ handleReaderOnboardingRender }
-					isSuppressed={ suppressReaderOnboarding }
-				/>
-			</div>
-		);
-	}
 
 	return (
 		<>

--- a/client/reader/on-this-day/main.tsx
+++ b/client/reader/on-this-day/main.tsx
@@ -10,7 +10,6 @@ import ReaderStream from 'calypso/reader/stream';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { selectSidebarRecentSite } from 'calypso/state/reader-ui/sidebar/actions';
-import { useSiteSubscriptions } from '../following/use-site-subscriptions';
 import { useFollowingView } from '../following/view-preference';
 import ViewToggle from '../following/view-toggle';
 import { OnThisDay } from './index';
@@ -18,7 +17,6 @@ import '../following/style.scss';
 
 function OnThisDayStream() {
 	const { currentView } = useFollowingView();
-	const { isLoading, hasNonSelfSubscriptions } = useSiteSubscriptions();
 	const dispatch = useDispatch();
 	const [ isResurrectedModalVisible, setIsResurrectedModalVisible ] = useState( false );
 	const [ shouldDelayReaderOnboarding, setShouldDelayReaderOnboarding ] = useState( false );
@@ -51,30 +49,6 @@ function OnThisDayStream() {
 	useEffect( () => {
 		dispatch( selectSidebarRecentSite( { feedId: null } ) );
 	}, [ dispatch ] );
-
-	if ( ! isLoading && ! hasNonSelfSubscriptions ) {
-		return (
-			<div className="following-stream--no-subscriptions">
-				<NavigationHeader title={ translate( 'On This Day' ) } />
-				<p>
-					{ translate(
-						'{{strong}}Welcome!{{/strong}} Follow your favorite sites and their latest posts will appear here. Read, like, and comment in a distraction-free environment. Get started by selecting your interests below:',
-						{
-							components: {
-								strong: <strong />,
-							},
-						}
-					) }
-				</p>
-				<AsyncLoad
-					require="calypso/reader/onboarding"
-					forceShow
-					onRender={ handleReaderOnboardingRender }
-					isSuppressed={ suppressReaderOnboarding }
-				/>
-			</div>
-		);
-	}
 
 	return (
 		<>

--- a/client/reader/onboarding/index.tsx
+++ b/client/reader/onboarding/index.tsx
@@ -21,15 +21,14 @@ import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/prefe
 import { getReaderFollows } from 'calypso/state/reader/follows/selectors';
 import hasCompletedReaderProfile from 'calypso/state/reader/onboarding/selectors/has-completed-reader-profile';
 import { getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
+import { useSiteSubscriptions } from '../following/use-site-subscriptions';
 import './style.scss';
 
 const ReaderOnboarding = ( {
 	onRender,
-	forceShow = false,
 	isSuppressed = false,
 }: {
 	onRender?: ( shown: boolean ) => void;
-	forceShow?: boolean;
 	isSuppressed?: boolean;
 } ) => {
 	const dispatch = useDispatch();
@@ -38,6 +37,7 @@ const ReaderOnboarding = ( {
 
 	const preferencesLoaded = useSelector( hasReceivedRemotePreferences );
 	const userRegistrationDate: string | null = useSelector( getCurrentUserDate );
+	const { isLoading, hasNonSelfSubscriptions } = useSiteSubscriptions();
 
 	const followedTags = useSelector( getReaderFollowedTags );
 	const follows = useSelector( getReaderFollows );
@@ -65,6 +65,8 @@ const ReaderOnboarding = ( {
 		! hasCompletedOnboarding &&
 		userRegistrationDate !== null &&
 		new Date( userRegistrationDate ) >= new Date( '2024-10-01T00:00:00Z' );
+
+	const forceShow = ! isLoading && ! hasNonSelfSubscriptions;
 
 	const shouldShowOnboarding =
 		forceShow || isEnabled( 'reader/force-onboarding' ) || !! meetsEligibility;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # p1776793109573719/1776789799.527959-slack-C03NLNTPZ2T

## Proposed Changes

Fix the reader following feed broken state for when the reader has no subscriptions outside of their own blogs.

* remove this early return for when the user `! hasNonSelfSubscriptions` which limits the feed and seems broken.
* also removes this from the recently copied on-this-day stream.
* removes `forceShow` as a prop from the onboarding component, and moves the selector and logic we used for this into the component itself.


BEFORE
<img width="1579" height="834" alt="Screenshot 2026-04-21 at 2 52 00 PM" src="https://github.com/user-attachments/assets/53529c2e-0eef-4c7c-a1dc-c752ea5281bb" />

AFTER
<img width="1577" height="994" alt="Screenshot 2026-04-21 at 2 52 22 PM" src="https://github.com/user-attachments/assets/cf0289f9-ca81-44b2-abe1-f1cd800a4b15" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* p1776793109573719/1776789799.527959-slack-C03NLNTPZ2T an issue where users with only self site subscriptions see an outdated header description and no reader stream.
* It shows no stream, an outdated and poorly placed message about the reader (which should be covered in reader onboarding itself), and no other features of the page outside the onboarding checklist and message. Onboarding checklist is still surfaced in the default return.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create an account that only follows its own blog in the reader.
* Verify the reader format looks the same as when they do subscribe to other blogs. Longer welcome message disappears and stream appears (or "no new posts" message).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?