### PR TITLE
Active upgrades: use product-specific icons

### DIFF
--- a/client/dashboard/me/billing-purchases/dataviews.tsx
+++ b/client/dashboard/me/billing-purchases/dataviews.tsx
@@ -1,9 +1,9 @@
 import { JETPACK_CONTACT_SUPPORT } from '@automattic/urls';
 import { Link, useNavigate } from '@tanstack/react-router';
-import { __experimentalHStack as HStack, Popover, Button } from '@wordpress/components';
+import { __experimentalHStack as HStack, Icon, Popover, Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { info } from '@wordpress/icons';
+import { brush, cloud, code, envelope, globe, info, plugins } from '@wordpress/icons';
 import { useState, useMemo } from 'react';
 import akismetIcon from 'calypso/assets/images/icons/akismet-icon.svg';
 import jetpackIcon from 'calypso/assets/images/icons/jetpack-icon.svg';
@@ -17,13 +17,16 @@ import {
 	isTransferredOwnership,
 	isAkismetHoldingSitePurchase,
 	isMarketplaceHoldingSitePurchase,
+	isMarketplacePlugin,
+	isTitanMail,
+	isGSuiteOrGoogleWorkspaceProductSlug,
 	getTitleForListDisplay,
 } from '../../utils/purchase';
 import { PurchasePaymentMethod } from './purchase-payment-method';
 import { PurchaseProduct } from './purchase-product';
 import type { StoredPaymentMethod, Purchase, Site } from '@automattic/api-core';
 import type { SortDirection, View, Fields } from '@wordpress/dataviews';
-import type { ReactNode, ComponentProps } from 'react';
+import type { ReactNode, ComponentProps, ReactElement } from 'react';
 
 import './style.scss';
 
@@ -69,20 +72,38 @@ export function BillingPurchaseInfoPopover( { children }: { children: ReactNode 
 	);
 }
 
+function ProductIcon( { icon, label }: { icon: ReactElement; label: string } ) {
+	const containerSize = 36;
+	const iconSize = 20;
+	return (
+		<span
+			aria-label={ label }
+			className="site-letter"
+			style={ {
+				display: 'inline-flex',
+				alignItems: 'center',
+				justifyContent: 'center',
+				width: containerSize,
+				height: containerSize,
+				minWidth: containerSize,
+				color: 'white',
+				fill: 'white',
+			} }
+		>
+			<Icon icon={ icon } size={ iconSize } />
+		</span>
+	);
+}
+
 function PurchaseItemSiteIcon( { site, purchase }: { site?: Site; purchase: Purchase } ) {
 	const size = 36;
 
-	if (
-		purchase.product_type === 'jetpack' ||
-		purchase.is_jetpack_ai_product ||
-		purchase.is_jetpack_stats_product ||
-		purchase.is_free_jetpack_stats_product
-	) {
+	if ( purchase.is_jetpack_plan_or_product ) {
 		return (
 			<img
 				src={ jetpackIcon }
 				alt="Jetpack icon"
-				style={ { width: size, height: size, minWidth: size } }
+				style={ { display: 'block', width: size, height: size, minWidth: size } }
 			/>
 		);
 	}
@@ -110,14 +131,42 @@ function PurchaseItemSiteIcon( { site, purchase }: { site?: Site; purchase: Purc
 		);
 	}
 
+	if ( isGSuiteOrGoogleWorkspaceProductSlug( purchase.product_slug ) || isTitanMail( purchase ) ) {
+		return <ProductIcon icon={ envelope } label="Email icon" />;
+	}
+
+	if ( isMarketplacePlugin( purchase ) ) {
+		return <ProductIcon icon={ plugins } label="Plugin icon" />;
+	}
+
+	if (
+		purchase.product_type === 'theme' ||
+		purchase.product_type === 'marketplace_theme' ||
+		purchase.product_slug === 'premium_theme' ||
+		purchase.product_slug === 'unlimited_themes'
+	) {
+		return <ProductIcon icon={ brush } label="Theme icon" />;
+	}
+
+	if ( purchase.product_slug === 'custom-design' ) {
+		return <ProductIcon icon={ code } label="CSS icon" />;
+	}
+
+	if (
+		[
+			'1gb_space_upgrade',
+			'5gb_space_upgrade',
+			'10gb_space_upgrade',
+			'50gb_space_upgrade',
+			'100gb_space_upgrade',
+			'wordpress_com_1gb_space_addon_yearly',
+		].includes( purchase.product_slug )
+	) {
+		return <ProductIcon icon={ cloud } label="Storage icon" />;
+	}
+
 	if ( ! site ) {
-		return (
-			<img
-				src={ jetpackIcon }
-				alt="No site icon"
-				style={ { width: size, height: size, minWidth: size } }
-			/>
-		);
+		return <ProductIcon icon={ globe } label="Domain icon" />;
 	}
 
 	return <SiteIcon site={ site } size={ size } />;

--- a/client/dashboard/me/billing-purchases/dataviews.tsx
+++ b/client/dashboard/me/billing-purchases/dataviews.tsx
@@ -18,6 +18,7 @@ import {
 	isAkismetHoldingSitePurchase,
 	isMarketplaceHoldingSitePurchase,
 	isMarketplacePlugin,
+	isStorageUpgrade,
 	isTitanMail,
 	isGSuiteOrGoogleWorkspaceProductSlug,
 	getTitleForListDisplay,
@@ -152,16 +153,7 @@ function PurchaseItemSiteIcon( { site, purchase }: { site?: Site; purchase: Purc
 		return <ProductIcon icon={ code } label={ __( 'CSS icon' ) } />;
 	}
 
-	if (
-		[
-			'1gb_space_upgrade',
-			'5gb_space_upgrade',
-			'10gb_space_upgrade',
-			'50gb_space_upgrade',
-			'100gb_space_upgrade',
-			'wordpress_com_1gb_space_addon_yearly',
-		].includes( purchase.product_slug )
-	) {
+	if ( isStorageUpgrade( purchase ) ) {
 		return <ProductIcon icon={ cloud } label={ __( 'Storage icon' ) } />;
 	}
 

--- a/client/dashboard/me/billing-purchases/dataviews.tsx
+++ b/client/dashboard/me/billing-purchases/dataviews.tsx
@@ -102,7 +102,7 @@ function PurchaseItemSiteIcon( { site, purchase }: { site?: Site; purchase: Purc
 		return (
 			<img
 				src={ jetpackIcon }
-				alt="Jetpack icon"
+				alt={ __( 'Jetpack icon' ) }
 				style={ { display: 'block', width: size, height: size, minWidth: size } }
 			/>
 		);
@@ -115,7 +115,7 @@ function PurchaseItemSiteIcon( { site, purchase }: { site?: Site; purchase: Purc
 		return (
 			<img
 				src={ passportIcon }
-				alt="Passport icon"
+				alt={ __( 'Passport icon' ) }
 				style={ { width: size, height: size, minWidth: size } }
 			/>
 		);
@@ -125,18 +125,18 @@ function PurchaseItemSiteIcon( { site, purchase }: { site?: Site; purchase: Purc
 		return (
 			<img
 				src={ akismetIcon }
-				alt="Akismet icon"
+				alt={ __( 'Akismet icon' ) }
 				style={ { width: size, height: size, minWidth: size } }
 			/>
 		);
 	}
 
 	if ( isGSuiteOrGoogleWorkspaceProductSlug( purchase.product_slug ) || isTitanMail( purchase ) ) {
-		return <ProductIcon icon={ envelope } label="Email icon" />;
+		return <ProductIcon icon={ envelope } label={ __( 'Email icon' ) } />;
 	}
 
 	if ( isMarketplacePlugin( purchase ) ) {
-		return <ProductIcon icon={ plugins } label="Plugin icon" />;
+		return <ProductIcon icon={ plugins } label={ __( 'Plugin icon' ) } />;
 	}
 
 	if (
@@ -145,11 +145,11 @@ function PurchaseItemSiteIcon( { site, purchase }: { site?: Site; purchase: Purc
 		purchase.product_slug === 'premium_theme' ||
 		purchase.product_slug === 'unlimited_themes'
 	) {
-		return <ProductIcon icon={ brush } label="Theme icon" />;
+		return <ProductIcon icon={ brush } label={ __( 'Theme icon' ) } />;
 	}
 
 	if ( purchase.product_slug === 'custom-design' ) {
-		return <ProductIcon icon={ code } label="CSS icon" />;
+		return <ProductIcon icon={ code } label={ __( 'CSS icon' ) } />;
 	}
 
 	if (
@@ -162,11 +162,11 @@ function PurchaseItemSiteIcon( { site, purchase }: { site?: Site; purchase: Purc
 			'wordpress_com_1gb_space_addon_yearly',
 		].includes( purchase.product_slug )
 	) {
-		return <ProductIcon icon={ cloud } label="Storage icon" />;
+		return <ProductIcon icon={ cloud } label={ __( 'Storage icon' ) } />;
 	}
 
 	if ( ! site ) {
-		return <ProductIcon icon={ globe } label="Domain icon" />;
+		return <ProductIcon icon={ globe } label={ __( 'Domain icon' ) } />;
 	}
 
 	return <SiteIcon site={ site } size={ size } />;

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -465,6 +465,20 @@ export function isTieredVolumeSpaceAddon( product: ObjectWithProductSlug ): bool
 	return product.product_slug === PRODUCT_1GB_SPACE;
 }
 
+const SPACE_UPGRADE_SLUGS = [
+	'1gb_space_upgrade',
+	'5gb_space_upgrade',
+	'10gb_space_upgrade',
+	'50gb_space_upgrade',
+	'100gb_space_upgrade',
+];
+
+export function isStorageUpgrade( purchase: Purchase ): boolean {
+	return (
+		SPACE_UPGRADE_SLUGS.includes( purchase.product_slug ) || isTieredVolumeSpaceAddon( purchase )
+	);
+}
+
 /**
  * Checks if a product is a Jetpack Search product.
  */


### PR DESCRIPTION
Fixes: https://linear.app/a8c/issue/RSM-552

## Summary

This PR cleans up the icons on the active upgrades screen. The sizing was wrong for the Jetpack ones and we used some random choices for others.

- Replaces the site-based icon fallback in the Active Upgrades list with product-type-aware icons
- Siteless domains now show a globe icon instead of the Jetpack logo
- Adds dedicated icons for emails (envelope), plugins (plugins), themes (brush), CSS add-on (code), and storage add-ons (cloud)
- Fixes Jetpack icon display glitch by setting `display: block`
- Broadens Jetpack detection to use `is_jetpack_plan_or_product` (covers Jetpack Search Free and other products missed by the old `product_type === 'jetpack'` check)
- Fixes G Suite detection to use `isGSuiteOrGoogleWorkspaceProductSlug` (old G Suite slugs were missed by the previous `isGoogleWorkspace` check)

| Before | After |
| -- | -- |
| <img width="1796" height="1196" alt="image" src="https://github.com/user-attachments/assets/7f883076-cbe5-4e6c-944d-b21132dfc7ad" /> | <img width="1796" height="1196" alt="image" src="https://github.com/user-attachments/assets/78520304-ec80-432c-8971-e4926d8133a4" /> |
| <img width="1796" height="1196" alt="image" src="https://github.com/user-attachments/assets/b9ee3ef6-b5b9-4057-a868-8501b5572d54" /> | <img width="1796" height="1196" alt="image" src="https://github.com/user-attachments/assets/c8081fc3-4df1-4302-85bc-474bd595843b" /> |

## Test plan

- [ ] Browse to `my.localhost:3000/me/billing/purchases`
- [ ] Verify Jetpack products show the Jetpack icon with no white border
- [ ] Verify domain registrations without an attached site show a globe icon
- [ ] Verify plugins (WPBakery, Gravity Forms, Yoast) show the plugins icon
- [ ] Verify themes show the brush icon
- [ ] Verify Google Workspace / G Suite / Titan Mail show the envelope icon
- [ ] Verify Custom CSS add-on shows the code icon
- [ ] Verify storage add-ons show the cloud icon
- [ ] Verify sites with a custom icon still show their site icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)