### PR TITLE
Allow preloading Woo AI assistant before the page renders

### DIFF
--- a/apps/agents-manager/agents-manager-wooai.js
+++ b/apps/agents-manager/agents-manager-wooai.js
@@ -15,5 +15,21 @@ import AgentsManagerWithProvider from './agents-manager-with-provider';
 
 const container = document.createElement( 'div' );
 container.id = 'agents-manager-root';
-document.body.appendChild( container );
-createRoot( container ).render( <AgentsManagerWithProvider useImageUpload={ useImageUpload } /> );
+
+const renderAssistant = () => {
+	createRoot( container ).render( <AgentsManagerWithProvider useImageUpload={ useImageUpload } /> );
+};
+
+if ( document.body ) {
+	document.body.appendChild( container );
+	renderAssistant();
+} else {
+	const observer = new window.MutationObserver( ( _, obs ) => {
+		if ( document.body ) {
+			document.body.appendChild( container );
+			renderAssistant();
+			obs.disconnect();
+		}
+	} );
+	observer.observe( document.documentElement, { childList: true } );
+}

--- a/apps/agents-manager/agents-manager-wooai.jsx
+++ b/apps/agents-manager/agents-manager-wooai.jsx
@@ -15,5 +15,21 @@ import AgentsManagerWithProvider from './agents-manager-with-provider';
 
 const container = document.createElement( 'div' );
 container.id = 'agents-manager-root';
-document.body.appendChild( container );
-createRoot( container ).render( <AgentsManagerWithProvider useImageUpload={ useImageUpload } /> );
+
+const renderAssistant = () => {
+	createRoot( container ).render( <AgentsManagerWithProvider useImageUpload={ useImageUpload } /> );
+};
+
+if ( document.body ) {
+	document.body.appendChild( container );
+	renderAssistant();
+} else {
+	const observer = new window.MutationObserver( ( _, obs ) => {
+		if ( document.body ) {
+			document.body.appendChild( container );
+			renderAssistant();
+			obs.disconnect();
+		}
+	} );
+	observer.observe( document.documentElement, { childList: true } );
+}

--- a/packages/data-stores/src/utils.ts
+++ b/packages/data-stores/src/utils.ts
@@ -21,7 +21,7 @@ export const isInSupportSession = () => {
 			!! document.querySelector( '#wp-admin-bar-support-session-details' ) ||
 			!! document.querySelector( '#a8c-support-session-overlay' ) ||
 			// Atomic
-			document.body.classList.contains( 'support-session' ) ||
+			document.body?.classList.contains( 'support-session' ) ||
 			document.querySelector( '#wpcom > .is-support-session' ) ||
 			( typeof isSupportSession !== 'undefined' && !! isSupportSession ) ||
 			( typeof helpCenterData !== 'undefined' && helpCenterData?.isSU ) ||


### PR DESCRIPTION
Part of WOOAI-501

## Proposed Changes

* Enable loading the assistant script as a head tag injection instead of solely in the footer
* Provides flexibility in how and when the assistant script is loaded on the page

## Why are these changes being made?

Loading scripts in the head allows for better control over script execution timing and can improve performance when combined with async/defer attributes. This change gives sites the flexibility to load the assistant earlier in the page lifecycle, potentially improving user experience and assistant responsiveness.

## Testing Instructions

1. Run `yarn dev --sync` within `apps/agents-manager`.
2. Proxy `widgets.wp.com` to your sandbox's IP address.
3. Run Woo AI locally through Jurassic Tube.

Visit the Jurassic Tube site and verify it still works - on long pages (themes, Woo admin overview) it should load faster than the content of the page.