### PR TITLE
Backup: fix getting-started card layout on desktop

### DIFF
--- a/client/components/jetpack/backup-getting-started/style.scss
+++ b/client/components/jetpack/backup-getting-started/style.scss
@@ -5,13 +5,18 @@ $card-height-desktop: 250px;
 $preview-max-width: 360px;
 $content-max-width: 210px;
 
-.backup-getting-started {
+// Compound selector to beat `.card { display: block }` from @automattic/components,
+// which is loaded after this file and would otherwise override `display: grid`.
+.card.backup-getting-started {
 	display: grid;
 	grid-template-columns: 1fr;
 	background-color: #f9f9f6;
 
 	@include break-medium {
 		background-image: url(calypso/assets/images/jetpack/getting-started-backup-bg.svg);
+		background-repeat: no-repeat;
+		background-position: center;
+		background-size: cover;
 		grid-template-columns: minmax(0, $preview-max-width) minmax($content-max-width, 1fr);
 		grid-column-gap: 1.5rem;
 	}

--- a/client/components/jetpack/backup-getting-started/style.scss
+++ b/client/components/jetpack/backup-getting-started/style.scss
@@ -5,8 +5,6 @@ $card-height-desktop: 250px;
 $preview-max-width: 360px;
 $content-max-width: 210px;
 
-// Compound selector to beat `.card { display: block }` from @automattic/components,
-// which is loaded after this file and would otherwise override `display: grid`.
 .card.backup-getting-started {
 	display: grid;
 	grid-template-columns: 1fr;


### PR DESCRIPTION
Fixes BACKUP-359

## Proposed Changes

* Use a compound selector (`.card.backup-getting-started`) so the component's `display: grid` rule actually wins over `.card { display: block }` from `@automattic/components`, which loads after this file in the cascade and was silently overriding it.
* Add `background-repeat: no-repeat`, `background-position: center`, and `background-size: cover` to the desktop background so the SVG stops tiling at wider viewports.

## Why are these changes being made?

The Backup "Getting started" card was rendering as block flow (single vertical stack) at all breakpoints because `.card { display: block }` had equal specificity but loaded later, quietly overriding the intended `display: grid`. On mobile this was invisible — block stacking and a single-column grid look the same — but on desktop the designed two-column layout (video left, text right) never applied. Bumping specificity with `.card.backup-getting-started` is the minimum-invasive fix and keeps the cascade working as the author intended. The background tiling was a pre-existing oversight only visible once the card actually used the background image at wider viewports.

## Testing Instructions

* Check out this branch, run `yarn start`, open a site with a Jetpack Backup Realtime plan at `/backup/<site-slug>`.
* If the card is already dismissed, clear the preference in the browser console:
  ```js
  await wpcom.req.put( '/me/preferences', { calypso_preferences: { 'dismissible-card-backup-getting-started': null } } ); location.reload();
  ```
* At viewport widths above mobile (≥782px), the card should render with the video preview on the left and the title / description / "Watch the video" button on the right. The background SVG should fill the card without visible tile seams at wide widths (try 1600px+).
* Below `break-medium` (<782px), the card should keep the existing mobile layout: title, description, video preview, button stacked vertically.
* Dismissing (×) and re-showing the card via the snippet above should still work.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
