### PR TITLE
Dashboard: fix expiry notice copy for domain-only purchases

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -1314,7 +1314,10 @@ export default function PurchaseSettings() {
 			}
 		>
 			<VStack spacing={ 6 }>
-				<PurchaseNotice purchase={ purchase } />
+				<PurchaseNotice
+					purchase={ purchase }
+					isDomainWithoutSite={ Boolean( site?.options?.is_domain_only && purchase.is_domain ) }
+				/>
 				<Grid columns={ columns } gap={ spacing }>
 					<OverviewCard
 						icon={ calendar }

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -1314,10 +1314,7 @@ export default function PurchaseSettings() {
 			}
 		>
 			<VStack spacing={ 6 }>
-				<PurchaseNotice
-					purchase={ purchase }
-					isDomainWithoutSite={ Boolean( site?.options?.is_domain_only && purchase.is_domain ) }
-				/>
+				<PurchaseNotice purchase={ purchase } />
 				<Grid columns={ columns } gap={ spacing }>
 					<OverviewCard
 						icon={ calendar }

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-expiring-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-expiring-notice.tsx
@@ -1,6 +1,4 @@
 import { SubscriptionBillPeriod } from '@automattic/api-core';
-import { siteBySlugQuery } from '@automattic/api-queries';
-import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
@@ -62,9 +60,11 @@ export function shouldShowExpiringNotice(
 export function PurchaseExpiringNotice( {
 	purchase,
 	purchaseAttachedTo,
+	isDomainWithoutSite,
 }: {
 	purchase: Purchase;
 	purchaseAttachedTo: Purchase | undefined;
+	isDomainWithoutSite: boolean;
 } ) {
 	// For purchases included with a plan (for example, a domain mapping
 	// bundled with the plan), the plan purchase is used on this page when
@@ -78,12 +78,6 @@ export function PurchaseExpiringNotice( {
 		usePlanInsteadOfIncludedPurchase && purchaseAttachedTo ? purchaseAttachedTo : purchase;
 
 	const includedPurchase = purchase;
-
-	const { data: site } = useQuery( {
-		...siteBySlugQuery( currentPurchase.site_slug ?? '' ),
-		enabled: Boolean( currentPurchase.site_slug ) && ! currentPurchase.is_attached_to_holding_site,
-	} );
-	const isDomainOnlySite = Boolean( site?.options?.is_domain_only && currentPurchase.is_domain );
 
 	if ( usePlanInsteadOfIncludedPurchase && purchase.site_slug ) {
 		// We can't show the action here, because it would try to renew the
@@ -142,24 +136,24 @@ export function PurchaseExpiringNotice( {
 				) : undefined
 			}
 		>
-			<ExpiringText purchase={ currentPurchase } isDomainOnlySite={ isDomainOnlySite } />
+			<ExpiringText purchase={ currentPurchase } isDomainWithoutSite={ isDomainWithoutSite } />
 		</Notice>
 	);
 }
 
 function ExpiringText( {
 	purchase,
-	isDomainOnlySite,
+	isDomainWithoutSite,
 }: {
 	purchase: Purchase;
-	isDomainOnlySite: boolean;
+	isDomainWithoutSite: boolean;
 } ) {
 	if (
 		purchase.site_slug &&
 		purchase.expiry_status === 'manual-renew' &&
 		purchase.bill_period_days !== SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD
 	) {
-		return <ExpiringLaterText purchase={ purchase } isDomainOnlySite={ isDomainOnlySite } />;
+		return <ExpiringLaterText purchase={ purchase } isDomainWithoutSite={ isDomainWithoutSite } />;
 	}
 
 	const purchaseName = purchase.is_domain ? purchase.meta ?? '' : purchase.product_name;
@@ -178,7 +172,7 @@ function ExpiringText( {
 			);
 		}
 
-		const message = isDomainOnlySite
+		const message = isDomainWithoutSite
 			? // translators: purchaseName is the name of the domain and daysToExpiry is a number of days
 			  __(
 					'%(purchaseName)s will expire and be removed from your account in %(daysToExpiry)d days.'
@@ -201,7 +195,7 @@ function ExpiringText( {
 		} );
 	}
 
-	const message = isDomainOnlySite
+	const message = isDomainWithoutSite
 		? // translators: purchaseName is the name of the domain and expiry is a formatted string like "in 3 months".
 		  __( '%(purchaseName)s will expire and be removed from your account %(expiry)s.' )
 		: // translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
@@ -215,11 +209,11 @@ function ExpiringText( {
 export function ExpiringLaterText( {
 	purchase,
 	autoRenewingUpgradesAction,
-	isDomainOnlySite = false,
+	isDomainWithoutSite = false,
 }: {
 	purchase: Purchase;
 	autoRenewingUpgradesAction?: () => void;
-	isDomainOnlySite?: boolean;
+	isDomainWithoutSite?: boolean;
 } ) {
 	const purchaseName = purchase.is_domain ? purchase.meta ?? '' : purchase.product_name;
 	const expiry = getRelativeTimeString( new Date( purchase.expiry_date ) );
@@ -266,7 +260,7 @@ export function ExpiringLaterText( {
 				);
 			}
 
-			const message = isDomainOnlySite
+			const message = isDomainWithoutSite
 				? // translators: purchaseName is the name of the domain and expiry is a formatted string like "in 3 months".
 				  __(
 						'%(purchaseName)s will expire and be removed from your account %(expiry)s. Please enable auto-renewal so you don‘t lose out on your paid features!'
@@ -293,7 +287,7 @@ export function ExpiringLaterText( {
 			);
 		}
 
-		const message = isDomainOnlySite
+		const message = isDomainWithoutSite
 			? // translators: purchaseName is the name of the domain and expiry is a formatted string like "in 3 months".
 			  __(
 					'%(purchaseName)s will expire and be removed from your account %(expiry)s. Please renew before expiry so you don‘t lose out on your paid features!'
@@ -320,7 +314,7 @@ export function ExpiringLaterText( {
 		);
 	}
 
-	const message = isDomainOnlySite
+	const message = isDomainWithoutSite
 		? // translators: purchaseName is the name of the domain and expiry is a formatted string like "in 3 months".
 		  __(
 				'%(purchaseName)s will expire and be removed from your account %(expiry)s. Update your payment information so you don‘t lose out on your paid features!'

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-expiring-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-expiring-notice.tsx
@@ -252,18 +252,18 @@ export function ExpiringLaterText( {
 	if ( purchase.payment_type ) {
 		if ( purchase.is_rechargeable ) {
 			if ( autoRenewingUpgradesAction ) {
-				const message = isDomainOnlySite
-					? // translators: purchaseName is the name of the domain and expiry is a formatted string like "in 3 months".
-					  __(
-							'%(purchaseName)s will expire and be removed from your account %(expiry)s – please enable auto-renewal so you don‘t lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon.'
-					  )
-					: // translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
-					  __(
-							'%(purchaseName)s will expire and be removed from your site %(expiry)s – please enable auto-renewal so you don‘t lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon.'
-					  );
-				return createInterpolateElement( sprintf( message, { purchaseName, expiry } ), {
-					link: <Button variant="link" onClick={ autoRenewingUpgradesAction } />,
-				} );
+				return createInterpolateElement(
+					sprintf(
+						// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
+						__(
+							'%(purchaseName)s will expire and be removed from your site %(expiry)s – please enable auto-renewal so you don’t lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon.'
+						),
+						{ purchaseName, expiry }
+					),
+					{
+						link: <Button variant="link" onClick={ autoRenewingUpgradesAction } />,
+					}
+				);
 			}
 
 			const message = isDomainOnlySite
@@ -279,18 +279,18 @@ export function ExpiringLaterText( {
 		}
 
 		if ( autoRenewingUpgradesAction ) {
-			const message = isDomainOnlySite
-				? // translators: purchaseName is the name of the domain and expiry is a formatted string like "in 3 months".
-				  __(
-						'%(purchaseName)s will expire and be removed from your account %(expiry)s – please renew before expiry so you don‘t lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon.'
-				  )
-				: // translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
-				  __(
-						'%(purchaseName)s will expire and be removed from your site %(expiry)s – please renew before expiry so you don‘t lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon.'
-				  );
-			return createInterpolateElement( sprintf( message, { purchaseName, expiry } ), {
-				link: <Button variant="link" onClick={ autoRenewingUpgradesAction } />,
-			} );
+			return createInterpolateElement(
+				sprintf(
+					// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
+					__(
+						'%(purchaseName)s will expire and be removed from your site %(expiry)s – please renew before expiry so you don’t lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon.'
+					),
+					{ purchaseName, expiry }
+				),
+				{
+					link: <Button variant="link" onClick={ autoRenewingUpgradesAction } />,
+				}
+			);
 		}
 
 		const message = isDomainOnlySite
@@ -306,18 +306,18 @@ export function ExpiringLaterText( {
 	}
 
 	if ( autoRenewingUpgradesAction ) {
-		const message = isDomainOnlySite
-			? // translators: purchaseName is the name of the domain and expiry is a formatted string like "in 3 months".
-			  __(
-					'%(purchaseName)s will expire and be removed from your account %(expiry)s – update your payment information so you don‘t lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon.'
-			  )
-			: // translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
-			  __(
-					'%(purchaseName)s will expire and be removed from your site %(expiry)s – update your payment information so you don‘t lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon.'
-			  );
-		return createInterpolateElement( sprintf( message, { purchaseName, expiry } ), {
-			link: <Button variant="link" onClick={ autoRenewingUpgradesAction } />,
-		} );
+		return createInterpolateElement(
+			sprintf(
+				// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
+				__(
+					'%(purchaseName)s will expire and be removed from your site %(expiry)s – update your payment information so you don’t lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon.'
+				),
+				{ purchaseName, expiry }
+			),
+			{
+				link: <Button variant="link" onClick={ autoRenewingUpgradesAction } />,
+			}
+		);
 	}
 
 	const message = isDomainOnlySite

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-expiring-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-expiring-notice.tsx
@@ -1,4 +1,6 @@
 import { SubscriptionBillPeriod } from '@automattic/api-core';
+import { siteBySlugQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
@@ -77,6 +79,12 @@ export function PurchaseExpiringNotice( {
 
 	const includedPurchase = purchase;
 
+	const { data: site } = useQuery( {
+		...siteBySlugQuery( currentPurchase.site_slug ?? '' ),
+		enabled: Boolean( currentPurchase.site_slug ) && ! currentPurchase.is_attached_to_holding_site,
+	} );
+	const isDomainOnlySite = Boolean( site?.options?.is_domain_only && currentPurchase.is_domain );
+
 	if ( usePlanInsteadOfIncludedPurchase && purchase.site_slug ) {
 		// We can't show the action here, because it would try to renew the
 		// included purchase (rather than the plan that it is attached to).
@@ -134,18 +142,24 @@ export function PurchaseExpiringNotice( {
 				) : undefined
 			}
 		>
-			<ExpiringText purchase={ currentPurchase } />
+			<ExpiringText purchase={ currentPurchase } isDomainOnlySite={ isDomainOnlySite } />
 		</Notice>
 	);
 }
 
-function ExpiringText( { purchase }: { purchase: Purchase } ) {
+function ExpiringText( {
+	purchase,
+	isDomainOnlySite,
+}: {
+	purchase: Purchase;
+	isDomainOnlySite: boolean;
+} ) {
 	if (
 		purchase.site_slug &&
 		purchase.expiry_status === 'manual-renew' &&
 		purchase.bill_period_days !== SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD
 	) {
-		return <ExpiringLaterText purchase={ purchase } />;
+		return <ExpiringLaterText purchase={ purchase } isDomainOnlySite={ isDomainOnlySite } />;
 	}
 
 	const purchaseName = purchase.is_domain ? purchase.meta ?? '' : purchase.product_name;
@@ -164,14 +178,19 @@ function ExpiringText( { purchase }: { purchase: Purchase } ) {
 			);
 		}
 
-		return sprintf(
-			// translators: purchaseName is the name of the plan and daysToExpiry is a number of days
-			__( '%(purchaseName)s will expire and be removed from your site in %(daysToExpiry)d days.' ),
-			{
-				purchaseName,
-				daysToExpiry,
-			}
-		);
+		const message = isDomainOnlySite
+			? // translators: purchaseName is the name of the domain and daysToExpiry is a number of days
+			  __(
+					'%(purchaseName)s will expire and be removed from your account in %(daysToExpiry)d days.'
+			  )
+			: // translators: purchaseName is the name of the plan and daysToExpiry is a number of days
+			  __(
+					'%(purchaseName)s will expire and be removed from your site in %(daysToExpiry)d days.'
+			  );
+		return sprintf( message, {
+			purchaseName,
+			daysToExpiry,
+		} );
 	}
 
 	if ( purchase.is_attached_to_holding_site ) {
@@ -182,22 +201,25 @@ function ExpiringText( { purchase }: { purchase: Purchase } ) {
 		} );
 	}
 
-	return sprintf(
-		// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
-		__( '%(purchaseName)s will expire and be removed from your site %(expiry)s.' ),
-		{
-			purchaseName,
-			expiry: getRelativeTimeString( new Date( purchase.expiry_date ) ),
-		}
-	);
+	const message = isDomainOnlySite
+		? // translators: purchaseName is the name of the domain and expiry is a formatted string like "in 3 months".
+		  __( '%(purchaseName)s will expire and be removed from your account %(expiry)s.' )
+		: // translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
+		  __( '%(purchaseName)s will expire and be removed from your site %(expiry)s.' );
+	return sprintf( message, {
+		purchaseName,
+		expiry: getRelativeTimeString( new Date( purchase.expiry_date ) ),
+	} );
 }
 
 export function ExpiringLaterText( {
 	purchase,
 	autoRenewingUpgradesAction,
+	isDomainOnlySite = false,
 }: {
 	purchase: Purchase;
 	autoRenewingUpgradesAction?: () => void;
+	isDomainOnlySite?: boolean;
 } ) {
 	const purchaseName = purchase.is_domain ? purchase.meta ?? '' : purchase.product_name;
 	const expiry = getRelativeTimeString( new Date( purchase.expiry_date ) );
@@ -230,73 +252,82 @@ export function ExpiringLaterText( {
 	if ( purchase.payment_type ) {
 		if ( purchase.is_rechargeable ) {
 			if ( autoRenewingUpgradesAction ) {
-				return createInterpolateElement(
-					sprintf(
-						// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
-						__(
+				const message = isDomainOnlySite
+					? // translators: purchaseName is the name of the domain and expiry is a formatted string like "in 3 months".
+					  __(
+							'%(purchaseName)s will expire and be removed from your account %(expiry)s – please enable auto-renewal so you don‘t lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon.'
+					  )
+					: // translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
+					  __(
 							'%(purchaseName)s will expire and be removed from your site %(expiry)s – please enable auto-renewal so you don‘t lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon.'
-						),
-						{ purchaseName, expiry }
-					),
-					{
-						link: <Button variant="link" onClick={ autoRenewingUpgradesAction } />,
-					}
-				);
+					  );
+				return createInterpolateElement( sprintf( message, { purchaseName, expiry } ), {
+					link: <Button variant="link" onClick={ autoRenewingUpgradesAction } />,
+				} );
 			}
 
-			return sprintf(
-				// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
-				__(
-					'%(purchaseName)s will expire and be removed from your site %(expiry)s. Please enable auto-renewal so you don‘t lose out on your paid features!'
-				),
-				{ purchaseName, expiry }
-			);
+			const message = isDomainOnlySite
+				? // translators: purchaseName is the name of the domain and expiry is a formatted string like "in 3 months".
+				  __(
+						'%(purchaseName)s will expire and be removed from your account %(expiry)s. Please enable auto-renewal so you don‘t lose out on your paid features!'
+				  )
+				: // translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
+				  __(
+						'%(purchaseName)s will expire and be removed from your site %(expiry)s. Please enable auto-renewal so you don‘t lose out on your paid features!'
+				  );
+			return sprintf( message, { purchaseName, expiry } );
 		}
 
 		if ( autoRenewingUpgradesAction ) {
-			return createInterpolateElement(
-				sprintf(
-					// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
-					__(
+			const message = isDomainOnlySite
+				? // translators: purchaseName is the name of the domain and expiry is a formatted string like "in 3 months".
+				  __(
+						'%(purchaseName)s will expire and be removed from your account %(expiry)s – please renew before expiry so you don‘t lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon.'
+				  )
+				: // translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
+				  __(
 						'%(purchaseName)s will expire and be removed from your site %(expiry)s – please renew before expiry so you don‘t lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon.'
-					),
-					{ purchaseName, expiry }
-				),
-				{
-					link: <Button variant="link" onClick={ autoRenewingUpgradesAction } />,
-				}
-			);
+				  );
+			return createInterpolateElement( sprintf( message, { purchaseName, expiry } ), {
+				link: <Button variant="link" onClick={ autoRenewingUpgradesAction } />,
+			} );
 		}
 
-		return sprintf(
-			// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
-			__(
-				'%(purchaseName)s will expire and be removed from your site %(expiry)s. Please renew before expiry so you don‘t lose out on your paid features!'
-			),
-			{ purchaseName, expiry }
-		);
+		const message = isDomainOnlySite
+			? // translators: purchaseName is the name of the domain and expiry is a formatted string like "in 3 months".
+			  __(
+					'%(purchaseName)s will expire and be removed from your account %(expiry)s. Please renew before expiry so you don‘t lose out on your paid features!'
+			  )
+			: // translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
+			  __(
+					'%(purchaseName)s will expire and be removed from your site %(expiry)s. Please renew before expiry so you don‘t lose out on your paid features!'
+			  );
+		return sprintf( message, { purchaseName, expiry } );
 	}
 
 	if ( autoRenewingUpgradesAction ) {
-		return createInterpolateElement(
-			sprintf(
-				// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
-				__(
+		const message = isDomainOnlySite
+			? // translators: purchaseName is the name of the domain and expiry is a formatted string like "in 3 months".
+			  __(
+					'%(purchaseName)s will expire and be removed from your account %(expiry)s – update your payment information so you don‘t lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon.'
+			  )
+			: // translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
+			  __(
 					'%(purchaseName)s will expire and be removed from your site %(expiry)s – update your payment information so you don‘t lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon.'
-				),
-				{ purchaseName, expiry }
-			),
-			{
-				link: <Button variant="link" onClick={ autoRenewingUpgradesAction } />,
-			}
-		);
+			  );
+		return createInterpolateElement( sprintf( message, { purchaseName, expiry } ), {
+			link: <Button variant="link" onClick={ autoRenewingUpgradesAction } />,
+		} );
 	}
 
-	return sprintf(
-		// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
-		__(
-			'%(purchaseName)s will expire and be removed from your site %(expiry)s. Update your payment information so you don‘t lose out on your paid features!'
-		),
-		{ purchaseName, expiry }
-	);
+	const message = isDomainOnlySite
+		? // translators: purchaseName is the name of the domain and expiry is a formatted string like "in 3 months".
+		  __(
+				'%(purchaseName)s will expire and be removed from your account %(expiry)s. Update your payment information so you don‘t lose out on your paid features!'
+		  )
+		: // translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
+		  __(
+				'%(purchaseName)s will expire and be removed from your site %(expiry)s. Update your payment information so you don‘t lose out on your paid features!'
+		  );
+	return sprintf( message, { purchaseName, expiry } );
 }

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -41,7 +41,13 @@ import { PurchaseExpiringNotice, shouldShowExpiringNotice } from './purchase-exp
 import { RenewNoticeAction, shouldShowRenewNoticeAction } from './renew-notice-action';
 import type { Purchase } from '@automattic/api-core';
 
-export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
+export function PurchaseNotice( {
+	purchase,
+	isDomainWithoutSite,
+}: {
+	purchase: Purchase;
+	isDomainWithoutSite: boolean;
+} ) {
 	const { user } = useAuth();
 	const { refunded } = purchaseSettingsRoute.useSearch();
 	const { data: purchaseAttachedTo } = useQuery( {
@@ -130,7 +136,11 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 		return (
 			<>
 				{ cancellationOfferNotice && cancellationOfferNotice }
-				<PurchaseExpiringNotice purchase={ purchase } purchaseAttachedTo={ purchaseAttachedTo } />
+				<PurchaseExpiringNotice
+					purchase={ purchase }
+					purchaseAttachedTo={ purchaseAttachedTo }
+					isDomainWithoutSite={ isDomainWithoutSite }
+				/>
 			</>
 		);
 	}

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -2,6 +2,7 @@ import { DomainProductSlugs, DotcomPlans, WooHostedPlans } from '@automattic/api
 import {
 	purchaseQuery,
 	sitePurchasesQuery,
+	siteBySlugQuery,
 	userPreferenceMutation,
 	userPreferenceQuery,
 } from '@automattic/api-queries';
@@ -41,13 +42,7 @@ import { PurchaseExpiringNotice, shouldShowExpiringNotice } from './purchase-exp
 import { RenewNoticeAction, shouldShowRenewNoticeAction } from './renew-notice-action';
 import type { Purchase } from '@automattic/api-core';
 
-export function PurchaseNotice( {
-	purchase,
-	isDomainWithoutSite,
-}: {
-	purchase: Purchase;
-	isDomainWithoutSite: boolean;
-} ) {
+export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 	const { user } = useAuth();
 	const { refunded } = purchaseSettingsRoute.useSearch();
 	const { data: purchaseAttachedTo } = useQuery( {
@@ -57,6 +52,11 @@ export function PurchaseNotice( {
 	const { data: sitePurchases } = useQuery( {
 		...sitePurchasesQuery( purchase.blog_id ?? 0 ),
 	} );
+	const { data: site } = useQuery( {
+		...siteBySlugQuery( purchase.site_slug ?? '' ),
+		enabled: Boolean( purchase.site_slug ) && ! purchase.is_attached_to_holding_site,
+	} );
+	const isDomainWithoutSite = Boolean( site?.options?.is_domain_only && purchase.is_domain );
 	const renewableSitePurchases = sitePurchases?.filter( needsToRenewSoon );
 
 	const { data: isDismissedPersisted } = useSuspenseQuery(


### PR DESCRIPTION
Fixes: https://linear.app/a8c/issue/RSM-553

## Proposed Changes

When a domain is not attached to a site (domain-only site), the expiring notice now reads "will be removed from your account" instead of "will be removed from your site". The fix covers all variants: short form, monthly-days form, and the six long-form payment/renew branches for MSD only.

| before | after |
| -- | -- |
| <img width="1796" height="1196" alt="image" src="https://github.com/user-attachments/assets/78d1247a-439c-473d-828d-43b456896006" /> | <img width="1796" height="1196" alt="image" src="https://github.com/user-attachments/assets/1e3957d8-6b02-4b32-8cf1-590da8dd195f" /> |


## Why are these changes being made?

The copy "removed from your site" is misleading for domains that aren't attached to any WordPress site — there is no site to speak of. "Removed from your account" is the accurate description in that case.

`isDomainOnlySite` is derived by querying `siteBySlugQuery` and checking `site.options.is_domain_only && purchase.is_domain`, matching the same detection already used elsewhere in the purchase settings page.

## Testing Instructions

* Go to `my.localhost:3000/me/billing/purchases/<id>` for a domain registration that has no site attached.
* Confirm the expiry notice reads "{domain} will expire and be removed from your account in X."
* For a domain with a site attached, confirm the notice still reads "removed from your site."

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)