### PR TITLE
blackbox: Add challenge widget to login implementation (take 2)

### DIFF
--- a/client/blocks/login/blackbox-challenge.jsx
+++ b/client/blocks/login/blackbox-challenge.jsx
@@ -1,0 +1,24 @@
+import config from '@automattic/calypso-config';
+import { useEffect, useRef } from 'react';
+import { useBlackbox } from 'calypso/blocks/login/utils/use-blackbox';
+
+/**
+ * Renders the Blackbox challenge container and manages SDK lifecycle.
+ * Communicates challenge state back to the parent via onChallengeActiveChange.
+ * @param {Object}   props
+ * @param {Function} props.onChallengeActiveChange Called with true/false when challenge state changes.
+ */
+export default function BlackboxChallenge( { onChallengeActiveChange } ) {
+	const containerRef = useRef( null );
+	const { isChallengeActive } = useBlackbox( { containerRef } );
+
+	useEffect( () => {
+		onChallengeActiveChange( isChallengeActive );
+	}, [ isChallengeActive, onChallengeActiveChange ] );
+
+	if ( ! config.isEnabled( 'blackbox-login' ) || ! config( 'blackbox_api_key' ) ) {
+		return null;
+	}
+
+	return <div ref={ containerRef } className="login__form-blackbox-challenge" />;
+}

--- a/client/blocks/login/blackbox-challenge.jsx
+++ b/client/blocks/login/blackbox-challenge.jsx
@@ -1,20 +1,22 @@
 import config from '@automattic/calypso-config';
-import { useEffect, useRef } from 'react';
+import { useEffect, useLayoutEffect, useRef } from 'react';
 import { useBlackbox } from 'calypso/blocks/login/utils/use-blackbox';
+
+const useIsomorphicLayoutEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect;
 
 /**
  * Renders the Blackbox challenge container and manages SDK lifecycle.
- * Communicates challenge state back to the parent via onChallengeActiveChange.
+ * Communicates submit-blocking state back to the parent via onSubmitBlockedChange.
  * @param {Object}   props
- * @param {Function} props.onChallengeActiveChange Called with true/false when challenge state changes.
+ * @param {Function} props.onSubmitBlockedChange Called with true/false when Blackbox should block submit.
  */
-export default function BlackboxChallenge( { onChallengeActiveChange } ) {
+export default function BlackboxChallenge( { onSubmitBlockedChange } ) {
 	const containerRef = useRef( null );
-	const { isChallengeActive } = useBlackbox( { containerRef } );
+	const { isChallengeActive, isLoading, hasChallengeContent } = useBlackbox( { containerRef } );
 
-	useEffect( () => {
-		onChallengeActiveChange( isChallengeActive );
-	}, [ isChallengeActive, onChallengeActiveChange ] );
+	useIsomorphicLayoutEffect( () => {
+		onSubmitBlockedChange( isChallengeActive || isLoading || hasChallengeContent );
+	}, [ isChallengeActive, isLoading, hasChallengeContent, onSubmitBlockedChange ] );
 
 	if ( ! config.isEnabled( 'blackbox-login' ) || ! config( 'blackbox_api_key' ) ) {
 		return null;

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -154,8 +154,10 @@ export class LoginForm extends Component {
 	}
 
 	componentWillUnmount() {
-		challengeCallbacks.onChallengeStart = null;
-		challengeCallbacks.onChallengeComplete = null;
+		if ( config.isEnabled( 'blackbox-login' ) && config( 'blackbox_api_key' ) ) {
+			challengeCallbacks.onChallengeStart = null;
+			challengeCallbacks.onChallengeComplete = null;
+		}
 	}
 
 	componentDidUpdate( prevProps, prevState ) {

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -115,11 +115,12 @@ export class LoginForm extends Component {
 		emailSuggestionError: false,
 		password: '',
 		lastUsedAuthenticationMethod: this.getLastUsedAuthenticationMethod(),
-		isBlackboxChallengeActive: false,
+		isBlackboxSubmitBlocked:
+			config.isEnabled( 'blackbox-login' ) && !! config( 'blackbox_api_key' ),
 	};
 
-	handleBlackboxChallengeActiveChange = ( isActive ) => {
-		this.setState( { isBlackboxChallengeActive: isActive } );
+	handleBlackboxSubmitBlockedChange = ( isBlocked ) => {
+		this.setState( { isBlackboxSubmitBlocked: isBlocked } );
 	};
 
 	componentDidMount() {
@@ -644,7 +645,7 @@ export class LoginForm extends Component {
 		const isFormDisabled = this.state.isFormDisabledWhileLoading || this.props.isFormDisabled;
 		const isEmailOrUsernameInputDisabled =
 			isFormDisabled || this.isPasswordView() || isGravatarFixedAccountLogin;
-		const isSubmitButtonDisabled = isFormDisabled || this.state.isBlackboxChallengeActive;
+		const isSubmitButtonDisabled = isFormDisabled || this.state.isBlackboxSubmitBlocked;
 		let loginUrl;
 		const isPasswordHidden = this.isUsernameOrEmailView();
 		const signupUrl = this.getSignupUrl();
@@ -857,9 +858,7 @@ export class LoginForm extends Component {
 
 						{ shouldRenderForgotPasswordLink && this.renderLostPasswordLink() }
 
-						<BlackboxChallenge
-							onChallengeActiveChange={ this.handleBlackboxChallengeActiveChange }
-						/>
+						<BlackboxChallenge onSubmitBlockedChange={ this.handleBlackboxSubmitBlockedChange } />
 
 						<div className="login__form-action">
 							<LoginSubmitButton

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -15,8 +15,8 @@ import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import { FormDivider } from 'calypso/blocks/authentication';
 import JetpackConnectSiteOnly from 'calypso/blocks/jetpack-connect-site-only';
+import BlackboxChallenge from 'calypso/blocks/login/blackbox-challenge';
 import LoginSubmitButton from 'calypso/blocks/login/login-submit-button';
-import { loadBlackboxSdk, challengeCallbacks } from 'calypso/blocks/login/utils/blackbox-sdk';
 import FormPasswordInput from 'calypso/components/forms/form-password-input';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import { LastUsedSocialButton } from 'calypso/components/social-buttons';
@@ -118,12 +118,8 @@ export class LoginForm extends Component {
 		isBlackboxChallengeActive: false,
 	};
 
-	handleBlackboxChallengeStart = () => {
-		this.setState( { isBlackboxChallengeActive: true } );
-	};
-
-	handleBlackboxChallengeComplete = () => {
-		this.setState( { isBlackboxChallengeActive: false } );
+	handleBlackboxChallengeActiveChange = ( isActive ) => {
+		this.setState( { isBlackboxChallengeActive: isActive } );
 	};
 
 	componentDidMount() {
@@ -138,25 +134,6 @@ export class LoginForm extends Component {
 		if ( this.props.currentQuery?.username_only ) {
 			url.searchParams.delete( 'username_only' );
 			window.history.replaceState( {}, document.title, url );
-		}
-
-		if ( config.isEnabled( 'blackbox-login' ) && config( 'blackbox_api_key' ) ) {
-			// Write callbacks into the slots before triggering load. The slots are
-			// read by wrapper closures inside configure(), so they're live even if
-			// configure() was already called (script cached from a prior mount).
-			challengeCallbacks.onChallengeStart = this.handleBlackboxChallengeStart;
-			challengeCallbacks.onChallengeComplete = this.handleBlackboxChallengeComplete;
-
-			// #blackbox-challenge-root is now in the DOM (render() completed before
-			// componentDidMount). Safe to inject the script.
-			loadBlackboxSdk();
-		}
-	}
-
-	componentWillUnmount() {
-		if ( config.isEnabled( 'blackbox-login' ) && config( 'blackbox_api_key' ) ) {
-			challengeCallbacks.onChallengeStart = null;
-			challengeCallbacks.onChallengeComplete = null;
 		}
 	}
 
@@ -880,9 +857,9 @@ export class LoginForm extends Component {
 
 						{ shouldRenderForgotPasswordLink && this.renderLostPasswordLink() }
 
-						{ config.isEnabled( 'blackbox-login' ) && config( 'blackbox_api_key' ) && (
-							<div id="blackbox-challenge-root" className="login__form-blackbox-challenge" />
-						) }
+						<BlackboxChallenge
+							onChallengeActiveChange={ this.handleBlackboxChallengeActiveChange }
+						/>
 
 						<div className="login__form-action">
 							<LoginSubmitButton

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -16,6 +16,7 @@ import { connect } from 'react-redux';
 import { FormDivider } from 'calypso/blocks/authentication';
 import JetpackConnectSiteOnly from 'calypso/blocks/jetpack-connect-site-only';
 import LoginSubmitButton from 'calypso/blocks/login/login-submit-button';
+import { loadBlackboxSdk, challengeCallbacks } from 'calypso/blocks/login/utils/blackbox-sdk';
 import FormPasswordInput from 'calypso/components/forms/form-password-input';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import { LastUsedSocialButton } from 'calypso/components/social-buttons';
@@ -114,6 +115,15 @@ export class LoginForm extends Component {
 		emailSuggestionError: false,
 		password: '',
 		lastUsedAuthenticationMethod: this.getLastUsedAuthenticationMethod(),
+		isBlackboxChallengeActive: false,
+	};
+
+	handleBlackboxChallengeStart = () => {
+		this.setState( { isBlackboxChallengeActive: true } );
+	};
+
+	handleBlackboxChallengeComplete = () => {
+		this.setState( { isBlackboxChallengeActive: false } );
 	};
 
 	componentDidMount() {
@@ -129,6 +139,23 @@ export class LoginForm extends Component {
 			url.searchParams.delete( 'username_only' );
 			window.history.replaceState( {}, document.title, url );
 		}
+
+		if ( config.isEnabled( 'blackbox-login' ) && config( 'blackbox_api_key' ) ) {
+			// Write callbacks into the slots before triggering load. The slots are
+			// read by wrapper closures inside configure(), so they're live even if
+			// configure() was already called (script cached from a prior mount).
+			challengeCallbacks.onChallengeStart = this.handleBlackboxChallengeStart;
+			challengeCallbacks.onChallengeComplete = this.handleBlackboxChallengeComplete;
+
+			// #blackbox-challenge-root is now in the DOM (render() completed before
+			// componentDidMount). Safe to inject the script.
+			loadBlackboxSdk();
+		}
+	}
+
+	componentWillUnmount() {
+		challengeCallbacks.onChallengeStart = null;
+		challengeCallbacks.onChallengeComplete = null;
 	}
 
 	componentDidUpdate( prevProps, prevState ) {
@@ -638,7 +665,7 @@ export class LoginForm extends Component {
 		const isFormDisabled = this.state.isFormDisabledWhileLoading || this.props.isFormDisabled;
 		const isEmailOrUsernameInputDisabled =
 			isFormDisabled || this.isPasswordView() || isGravatarFixedAccountLogin;
-		const isSubmitButtonDisabled = isFormDisabled;
+		const isSubmitButtonDisabled = isFormDisabled || this.state.isBlackboxChallengeActive;
 		let loginUrl;
 		const isPasswordHidden = this.isUsernameOrEmailView();
 		const signupUrl = this.getSignupUrl();
@@ -850,6 +877,10 @@ export class LoginForm extends Component {
 						{ isGravPoweredClient && <p className="login__form-terms">{ renderTerms() }</p> }
 
 						{ shouldRenderForgotPasswordLink && this.renderLostPasswordLink() }
+
+						{ config.isEnabled( 'blackbox-login' ) && config( 'blackbox_api_key' ) && (
+							<div id="blackbox-challenge-root" className="login__form-blackbox-challenge" />
+						) }
 
 						<div className="login__form-action">
 							<LoginSubmitButton

--- a/client/blocks/login/utils/blackbox-sdk.js
+++ b/client/blocks/login/utils/blackbox-sdk.js
@@ -1,20 +1,14 @@
 import config from '@automattic/calypso-config';
 import { loadScript } from '@automattic/load-script';
 
-const CHALLENGE_CONTAINER = '#blackbox-challenge-root';
-
-/** Mutable slots — login-form.jsx writes these in componentDidMount. */
-export const challengeCallbacks = {
-	onChallengeStart: null,
-	onChallengeComplete: null,
-};
-
 let loadPromise = null;
 
 /**
- * Inject the Blackbox SDK script once and call configure() after it loads.
+ * Inject the Blackbox SDK script once.
  * Returns a Promise that always resolves (never rejects) so Blackbox can never block login.
  * Subsequent calls return the same Promise — the script is only injected once.
+ *
+ * Callers are responsible for calling window.Blackbox.configure() after this resolves.
  * @returns {Promise<void>}
  */
 export function loadBlackboxSdk() {
@@ -36,39 +30,8 @@ export function loadBlackboxSdk() {
 	}
 
 	loadPromise = new Promise( ( resolve ) => {
-		loadScript(
-			blackboxUrl,
-			( error ) => {
-				if ( ! error ) {
-					configureBlackboxSdk();
-				}
-				resolve();
-			},
-			{ 'data-apikey': config( 'blackbox_api_key' ) }
-		);
+		loadScript( blackboxUrl, () => resolve(), { 'data-apikey': config( 'blackbox_api_key' ) } );
 	} );
 
 	return loadPromise;
-}
-
-/**
- * Call window.Blackbox.configure() with the complete config.
- * Wrapper functions delegate to challengeCallbacks slots so configure() only
- * needs to be called once — updating the slots is enough to change callbacks.
- */
-function configureBlackboxSdk() {
-	if ( typeof window.Blackbox?.configure !== 'function' ) {
-		return;
-	}
-
-	try {
-		window.Blackbox.configure( {
-			apiKey: config( 'blackbox_api_key' ),
-			challengeContainer: CHALLENGE_CONTAINER,
-			onChallengeStart: () => challengeCallbacks.onChallengeStart?.(),
-			onChallengeComplete: () => challengeCallbacks.onChallengeComplete?.(),
-		} );
-	} catch {
-		// Intentionally ignored — Blackbox must never block login.
-	}
 }

--- a/client/blocks/login/utils/blackbox-sdk.js
+++ b/client/blocks/login/utils/blackbox-sdk.js
@@ -1,0 +1,77 @@
+import config from '@automattic/calypso-config';
+import { loadScript } from '@automattic/load-script';
+
+const CHALLENGE_CONTAINER = '#blackbox-challenge-root';
+
+/** Mutable slots — login-form.jsx writes these in componentDidMount. */
+export const challengeCallbacks = {
+	onChallengeStart: null,
+	onChallengeComplete: null,
+};
+
+let loadPromise = null;
+
+/**
+ * Inject the Blackbox SDK script once and call configure() after it loads.
+ * Returns a Promise that always resolves (never rejects) so Blackbox can never block login.
+ * Subsequent calls return the same Promise — the script is only injected once.
+ *
+ * @returns {Promise<void>}
+ */
+export function loadBlackboxSdk() {
+	if ( typeof document === 'undefined' ) {
+		return Promise.resolve();
+	}
+
+	if ( ! config.isEnabled( 'blackbox-login' ) || ! config( 'blackbox_api_key' ) ) {
+		loadPromise = Promise.resolve();
+		return loadPromise;
+	}
+
+	if ( loadPromise ) {
+		return loadPromise;
+	}
+
+	const blackboxUrl = config( 'blackbox_url' );
+	if ( typeof blackboxUrl !== 'string' || ! blackboxUrl ) {
+		loadPromise = Promise.resolve();
+		return loadPromise;
+	}
+
+	loadPromise = new Promise( ( resolve ) => {
+		loadScript(
+			blackboxUrl,
+			( error ) => {
+				if ( ! error ) {
+					configureBlackboxSdk();
+				}
+				resolve();
+			},
+			{ 'data-apikey': config( 'blackbox_api_key' ) }
+		);
+	} );
+
+	return loadPromise;
+}
+
+/**
+ * Call window.Blackbox.configure() with the complete config.
+ * Wrapper functions delegate to challengeCallbacks slots so configure() only
+ * needs to be called once — updating the slots is enough to change callbacks.
+ */
+function configureBlackboxSdk() {
+	if ( typeof window.Blackbox?.configure !== 'function' ) {
+		return;
+	}
+
+	try {
+		window.Blackbox.configure( {
+			apiKey: config( 'blackbox_api_key' ),
+			challengeContainer: CHALLENGE_CONTAINER,
+			onChallengeStart: () => challengeCallbacks.onChallengeStart?.(),
+			onChallengeComplete: () => challengeCallbacks.onChallengeComplete?.(),
+		} );
+	} catch {
+		// Intentionally ignored — Blackbox must never block login.
+	}
+}

--- a/client/blocks/login/utils/blackbox-sdk.js
+++ b/client/blocks/login/utils/blackbox-sdk.js
@@ -29,9 +29,22 @@ export function loadBlackboxSdk() {
 		return Promise.resolve();
 	}
 
-	loadPromise = new Promise( ( resolve ) => {
-		loadScript( blackboxUrl, () => resolve(), { 'data-apikey': config( 'blackbox_api_key' ) } );
+	let didFailSynchronously = false;
+	const scriptLoadPromise = new Promise( ( resolve ) => {
+		loadScript(
+			blackboxUrl,
+			( error ) => {
+				if ( error ) {
+					didFailSynchronously = true;
+					loadPromise = null;
+				}
+				resolve();
+			},
+			{ 'data-apikey': config( 'blackbox_api_key' ) }
+		);
 	} );
 
-	return loadPromise;
+	loadPromise = didFailSynchronously ? null : scriptLoadPromise;
+
+	return scriptLoadPromise;
 }

--- a/client/blocks/login/utils/blackbox-sdk.js
+++ b/client/blocks/login/utils/blackbox-sdk.js
@@ -24,8 +24,7 @@ export function loadBlackboxSdk() {
 	}
 
 	if ( ! config.isEnabled( 'blackbox-login' ) || ! config( 'blackbox_api_key' ) ) {
-		loadPromise = Promise.resolve();
-		return loadPromise;
+		return Promise.resolve();
 	}
 
 	if ( loadPromise ) {
@@ -34,8 +33,7 @@ export function loadBlackboxSdk() {
 
 	const blackboxUrl = config( 'blackbox_url' );
 	if ( typeof blackboxUrl !== 'string' || ! blackboxUrl ) {
-		loadPromise = Promise.resolve();
-		return loadPromise;
+		return Promise.resolve();
 	}
 
 	loadPromise = new Promise( ( resolve ) => {

--- a/client/blocks/login/utils/blackbox-sdk.js
+++ b/client/blocks/login/utils/blackbox-sdk.js
@@ -15,7 +15,6 @@ let loadPromise = null;
  * Inject the Blackbox SDK script once and call configure() after it loads.
  * Returns a Promise that always resolves (never rejects) so Blackbox can never block login.
  * Subsequent calls return the same Promise — the script is only injected once.
- *
  * @returns {Promise<void>}
  */
 export function loadBlackboxSdk() {

--- a/client/blocks/login/utils/get-blackbox-session-id.js
+++ b/client/blocks/login/utils/get-blackbox-session-id.js
@@ -3,9 +3,12 @@ import { loadBlackboxSdk } from 'calypso/blocks/login/utils/blackbox-sdk';
 /**
  * Retrieve a Blackbox bot-detection session ID.
  *
- * Awaits the lazy SDK load, calls collect() to trigger data collection, and
- * returns the session ID. Blackbox returns BlackboxError instead of throwing,
- * so the typeof check filters those out. The try/catch is defense-in-depth.
+ * Awaits the lazy SDK load, then calls getSessionId() which returns the
+ * cached session ID immediately (non-blocking) and ships accumulated
+ * behavioral data in the background.
+ *
+ * Blackbox returns BlackboxError instead of throwing, so the typeof check
+ * filters those out. The try/catch is defense-in-depth.
  * @returns {Promise<string|undefined>} Session ID, or undefined on any failure.
  */
 export async function getBlackboxSessionId() {
@@ -19,22 +22,18 @@ export async function getBlackboxSessionId() {
 		return undefined;
 	}
 
-	if ( ! window.Blackbox?.collect ) {
+	if ( typeof window.Blackbox?.getSessionId !== 'function' ) {
 		return undefined;
 	}
 
 	try {
-		const result = await Promise.race( [
-			window.Blackbox.collect(),
+		const sessionId = await Promise.race( [
+			window.Blackbox.getSessionId(),
 			new Promise( ( resolve ) => setTimeout( resolve, 2000 ) ),
 		] );
 
-		if ( typeof result === 'string' ) {
-			return result;
-		}
-
-		if ( result && typeof result.sessionId === 'string' ) {
-			return result.sessionId;
+		if ( typeof sessionId === 'string' ) {
+			return sessionId;
 		}
 	} catch {
 		// Intentionally ignored — Blackbox must never block login.

--- a/client/blocks/login/utils/get-blackbox-session-id.js
+++ b/client/blocks/login/utils/get-blackbox-session-id.js
@@ -3,9 +3,14 @@ import { loadBlackboxSdk } from 'calypso/blocks/login/utils/blackbox-sdk';
 /**
  * Retrieve a Blackbox bot-detection session ID.
  *
- * Awaits the lazy SDK load, then calls getSessionId() which returns the
- * cached session ID immediately (non-blocking) and ships accumulated
- * behavioral data in the background.
+ * Awaits the lazy SDK load, then calls collect() to flush accumulated
+ * behavioral data (keypress timing, mouse movements, etc.) to the server.
+ * This ensures the server-side session score reflects behavioral signals
+ * before the login request fires — critical for enforcement via verify().
+ *
+ * collect() is safe to call at submit time because the login form's submit
+ * button is disabled while a challenge is active (isBlackboxChallengeActive),
+ * so this only fires when no challenge widget is in progress.
  *
  * Blackbox returns BlackboxError instead of throwing, so the typeof check
  * filters those out. The try/catch is defense-in-depth.
@@ -22,18 +27,22 @@ export async function getBlackboxSessionId() {
 		return undefined;
 	}
 
-	if ( typeof window.Blackbox?.getSessionId !== 'function' ) {
+	if ( typeof window.Blackbox?.collect !== 'function' ) {
 		return undefined;
 	}
 
 	try {
-		const sessionId = await Promise.race( [
-			window.Blackbox.getSessionId(),
+		const result = await Promise.race( [
+			window.Blackbox.collect(),
 			new Promise( ( resolve ) => setTimeout( resolve, 2000 ) ),
 		] );
 
-		if ( typeof sessionId === 'string' ) {
-			return sessionId;
+		if ( typeof result === 'string' ) {
+			return result;
+		}
+
+		if ( result && typeof result.sessionId === 'string' ) {
+			return result.sessionId;
 		}
 	} catch {
 		// Intentionally ignored — Blackbox must never block login.

--- a/client/blocks/login/utils/get-blackbox-session-id.js
+++ b/client/blocks/login/utils/get-blackbox-session-id.js
@@ -20,7 +20,7 @@ export async function getBlackboxSessionId() {
 	try {
 		await Promise.race( [
 			loadBlackboxSdk(),
-			new Promise( ( resolve ) => setTimeout( resolve, 2000 ) ),
+			new Promise( ( resolve ) => setTimeout( resolve, 5000 ) ),
 		] );
 	} catch {
 		// loadBlackboxSdk() always resolves, but guard here in case that contract changes.
@@ -34,7 +34,7 @@ export async function getBlackboxSessionId() {
 	try {
 		const result = await Promise.race( [
 			window.Blackbox.collect(),
-			new Promise( ( resolve ) => setTimeout( resolve, 2000 ) ),
+			new Promise( ( resolve ) => setTimeout( resolve, 5000 ) ),
 		] );
 
 		if ( typeof result === 'string' ) {

--- a/client/blocks/login/utils/get-blackbox-session-id.js
+++ b/client/blocks/login/utils/get-blackbox-session-id.js
@@ -9,8 +9,8 @@ import { loadBlackboxSdk } from 'calypso/blocks/login/utils/blackbox-sdk';
  * before the login request fires — critical for enforcement via verify().
  *
  * collect() is safe to call at submit time because the login form's submit
- * button is disabled while a challenge is active (isBlackboxChallengeActive),
- * so this only fires when no challenge widget is in progress.
+ * button is disabled while Blackbox is loading or a challenge is active, so
+ * this only fires when no challenge widget is in progress.
  *
  * Blackbox returns BlackboxError instead of throwing, so the typeof check
  * filters those out. The try/catch is defense-in-depth.

--- a/client/blocks/login/utils/get-blackbox-session-id.js
+++ b/client/blocks/login/utils/get-blackbox-session-id.js
@@ -1,26 +1,45 @@
+import { loadBlackboxSdk } from 'calypso/blocks/login/utils/blackbox-sdk';
+
 /**
- * Retrieve a Blackbox bot-detection session ID, if the library is loaded.
+ * Retrieve a Blackbox bot-detection session ID.
  *
- * Blackbox returns `BlackboxError` instead of throwing, so the `typeof`
- * check filters those out. The try/catch is defense-in-depth in case the
- * third-party script misbehaves — Blackbox must never block login.
- * @returns {Promise<string|undefined>} Session ID, or undefined on failure.
+ * Awaits the lazy SDK load, calls collect() to trigger data collection, and
+ * returns the session ID. Blackbox returns BlackboxError instead of throwing,
+ * so the typeof check filters those out. The try/catch is defense-in-depth.
+ *
+ * @returns {Promise<string|undefined>} Session ID, or undefined on any failure.
  */
 export async function getBlackboxSessionId() {
-	if ( ! window.Blackbox?.getSessionId ) {
+	try {
+		await Promise.race( [
+			loadBlackboxSdk(),
+			new Promise( ( resolve ) => setTimeout( resolve, 2000 ) ),
+		] );
+	} catch {
+		// loadBlackboxSdk() always resolves, but guard here in case that contract changes.
+		return undefined;
+	}
+
+	if ( ! window.Blackbox?.collect ) {
 		return undefined;
 	}
 
 	try {
 		const result = await Promise.race( [
-			window.Blackbox.getSessionId(),
+			window.Blackbox.collect(),
 			new Promise( ( resolve ) => setTimeout( resolve, 2000 ) ),
 		] );
+
 		if ( typeof result === 'string' ) {
 			return result;
+		}
+
+		if ( result && typeof result.sessionId === 'string' ) {
+			return result.sessionId;
 		}
 	} catch {
 		// Intentionally ignored — Blackbox must never block login.
 	}
+
 	return undefined;
 }

--- a/client/blocks/login/utils/get-blackbox-session-id.js
+++ b/client/blocks/login/utils/get-blackbox-session-id.js
@@ -6,7 +6,6 @@ import { loadBlackboxSdk } from 'calypso/blocks/login/utils/blackbox-sdk';
  * Awaits the lazy SDK load, calls collect() to trigger data collection, and
  * returns the session ID. Blackbox returns BlackboxError instead of throwing,
  * so the typeof check filters those out. The try/catch is defense-in-depth.
- *
  * @returns {Promise<string|undefined>} Session ID, or undefined on any failure.
  */
 export async function getBlackboxSessionId() {

--- a/client/blocks/login/utils/test/blackbox-sdk.js
+++ b/client/blocks/login/utils/test/blackbox-sdk.js
@@ -71,6 +71,19 @@ describe( 'blackbox-sdk', () => {
 		await expect( loadBlackboxSdk() ).resolves.toBeUndefined();
 	} );
 
+	test( 'loadBlackboxSdk retries on the next call after the script fails to load', async () => {
+		const { loadScript } = require( '@automattic/load-script' );
+		loadScript
+			.mockImplementationOnce( ( _url, callback ) => callback( new Error( 'fail' ) ) )
+			.mockImplementationOnce( ( _url, callback ) => callback( null ) );
+		const { loadBlackboxSdk } = require( '../blackbox-sdk' );
+
+		await loadBlackboxSdk();
+		await loadBlackboxSdk();
+
+		expect( loadScript ).toHaveBeenCalledTimes( 2 );
+	} );
+
 	test( 'loadBlackboxSdk resolves immediately without calling loadScript when feature flag is off', async () => {
 		const config = require( '@automattic/calypso-config' );
 		config.isEnabled.mockReturnValueOnce( false );

--- a/client/blocks/login/utils/test/blackbox-sdk.js
+++ b/client/blocks/login/utils/test/blackbox-sdk.js
@@ -4,8 +4,12 @@
 
 jest.mock( '@automattic/calypso-config', () => {
 	const config = jest.fn( ( key ) => {
-		if ( key === 'blackbox_api_key' ) return 'test-api-key';
-		if ( key === 'blackbox_url' ) return 'https://blackbox-api.wp.com/v.js';
+		if ( key === 'blackbox_api_key' ) {
+			return 'test-api-key';
+		}
+		if ( key === 'blackbox_url' ) {
+			return 'https://blackbox-api.wp.com/v.js';
+		}
 		return undefined;
 	} );
 	config.isEnabled = jest.fn( ( flag ) => flag === 'blackbox-login' );
@@ -14,7 +18,9 @@ jest.mock( '@automattic/calypso-config', () => {
 
 jest.mock( '@automattic/load-script', () => ( {
 	loadScript: jest.fn( ( _url, callback ) => {
-		if ( typeof callback === 'function' ) callback( null );
+		if ( typeof callback === 'function' ) {
+			callback( null );
+		}
 	} ),
 } ) );
 

--- a/client/blocks/login/utils/test/blackbox-sdk.js
+++ b/client/blocks/login/utils/test/blackbox-sdk.js
@@ -1,0 +1,107 @@
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock( '@automattic/calypso-config', () => {
+	const config = jest.fn( ( key ) => {
+		if ( key === 'blackbox_api_key' ) return 'test-api-key';
+		if ( key === 'blackbox_url' ) return 'https://blackbox-api.wp.com/v.js';
+		return undefined;
+	} );
+	config.isEnabled = jest.fn( ( flag ) => flag === 'blackbox-login' );
+	return config;
+} );
+
+jest.mock( '@automattic/load-script', () => ( {
+	loadScript: jest.fn( ( _url, callback ) => {
+		if ( typeof callback === 'function' ) callback( null );
+	} ),
+} ) );
+
+describe( 'blackbox-sdk', () => {
+	beforeEach( () => {
+		jest.resetModules();
+		jest.clearAllMocks();
+		delete window.Blackbox;
+	} );
+
+	test( 'loadBlackboxSdk calls loadScript with the configured URL and data-apikey', async () => {
+		const { loadScript } = require( '@automattic/load-script' );
+		const { loadBlackboxSdk } = require( '../blackbox-sdk' );
+
+		await loadBlackboxSdk();
+
+		expect( loadScript ).toHaveBeenCalledWith(
+			'https://blackbox-api.wp.com/v.js',
+			expect.any( Function ),
+			expect.objectContaining( { 'data-apikey': 'test-api-key' } )
+		);
+	} );
+
+	test( 'loadBlackboxSdk only injects the script once on repeated calls', async () => {
+		const { loadScript } = require( '@automattic/load-script' );
+		const { loadBlackboxSdk } = require( '../blackbox-sdk' );
+
+		await loadBlackboxSdk();
+		await loadBlackboxSdk();
+
+		expect( loadScript ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'configure() is called once after load with the full config including wrapper callbacks', async () => {
+		window.Blackbox = { configure: jest.fn(), collect: jest.fn(), getSessionId: jest.fn() };
+		const { loadBlackboxSdk } = require( '../blackbox-sdk' );
+
+		await loadBlackboxSdk();
+
+		expect( window.Blackbox.configure ).toHaveBeenCalledTimes( 1 );
+		expect( window.Blackbox.configure ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				apiKey: 'test-api-key',
+				challengeContainer: '#blackbox-challenge-root',
+				onChallengeStart: expect.any( Function ),
+				onChallengeComplete: expect.any( Function ),
+			} )
+		);
+	} );
+
+	test( 'wrapper callbacks delegate to challengeCallbacks slots', async () => {
+		const onStart = jest.fn();
+		const onComplete = jest.fn();
+		window.Blackbox = { configure: jest.fn(), collect: jest.fn(), getSessionId: jest.fn() };
+
+		const { loadBlackboxSdk, challengeCallbacks } = require( '../blackbox-sdk' );
+		challengeCallbacks.onChallengeStart = onStart;
+		challengeCallbacks.onChallengeComplete = onComplete;
+
+		await loadBlackboxSdk();
+
+		// Extract the wrappers passed to configure() and invoke them
+		const [ configArg ] = window.Blackbox.configure.mock.calls[ 0 ];
+		configArg.onChallengeStart();
+		configArg.onChallengeComplete();
+
+		expect( onStart ).toHaveBeenCalledTimes( 1 );
+		expect( onComplete ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'loadBlackboxSdk resolves even when the script fails to load', async () => {
+		const { loadScript } = require( '@automattic/load-script' );
+		loadScript.mockImplementationOnce( ( _url, callback ) => callback( new Error( 'fail' ) ) );
+		window.Blackbox = { configure: jest.fn() };
+		const { loadBlackboxSdk } = require( '../blackbox-sdk' );
+
+		await expect( loadBlackboxSdk() ).resolves.toBeUndefined();
+		expect( window.Blackbox.configure ).not.toHaveBeenCalled();
+	} );
+
+	test( 'loadBlackboxSdk resolves immediately without calling loadScript when feature flag is off', async () => {
+		const config = require( '@automattic/calypso-config' );
+		config.isEnabled.mockReturnValueOnce( false );
+		const { loadScript } = require( '@automattic/load-script' );
+		const { loadBlackboxSdk } = require( '../blackbox-sdk' );
+
+		await expect( loadBlackboxSdk() ).resolves.toBeUndefined();
+		expect( loadScript ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/blocks/login/utils/test/blackbox-sdk.js
+++ b/client/blocks/login/utils/test/blackbox-sdk.js
@@ -54,51 +54,21 @@ describe( 'blackbox-sdk', () => {
 		expect( loadScript ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	test( 'configure() is called once after load with the full config including wrapper callbacks', async () => {
-		window.Blackbox = { configure: jest.fn(), collect: jest.fn(), getSessionId: jest.fn() };
+	test( 'loadBlackboxSdk does not call configure after load', async () => {
+		window.Blackbox = { configure: jest.fn(), getSessionId: jest.fn() };
 		const { loadBlackboxSdk } = require( '../blackbox-sdk' );
 
 		await loadBlackboxSdk();
 
-		expect( window.Blackbox.configure ).toHaveBeenCalledTimes( 1 );
-		expect( window.Blackbox.configure ).toHaveBeenCalledWith(
-			expect.objectContaining( {
-				apiKey: 'test-api-key',
-				challengeContainer: '#blackbox-challenge-root',
-				onChallengeStart: expect.any( Function ),
-				onChallengeComplete: expect.any( Function ),
-			} )
-		);
-	} );
-
-	test( 'wrapper callbacks delegate to challengeCallbacks slots', async () => {
-		const onStart = jest.fn();
-		const onComplete = jest.fn();
-		window.Blackbox = { configure: jest.fn(), collect: jest.fn(), getSessionId: jest.fn() };
-
-		const { loadBlackboxSdk, challengeCallbacks } = require( '../blackbox-sdk' );
-		challengeCallbacks.onChallengeStart = onStart;
-		challengeCallbacks.onChallengeComplete = onComplete;
-
-		await loadBlackboxSdk();
-
-		// Extract the wrappers passed to configure() and invoke them
-		const [ configArg ] = window.Blackbox.configure.mock.calls[ 0 ];
-		configArg.onChallengeStart();
-		configArg.onChallengeComplete();
-
-		expect( onStart ).toHaveBeenCalledTimes( 1 );
-		expect( onComplete ).toHaveBeenCalledTimes( 1 );
+		expect( window.Blackbox.configure ).not.toHaveBeenCalled();
 	} );
 
 	test( 'loadBlackboxSdk resolves even when the script fails to load', async () => {
 		const { loadScript } = require( '@automattic/load-script' );
 		loadScript.mockImplementationOnce( ( _url, callback ) => callback( new Error( 'fail' ) ) );
-		window.Blackbox = { configure: jest.fn() };
 		const { loadBlackboxSdk } = require( '../blackbox-sdk' );
 
 		await expect( loadBlackboxSdk() ).resolves.toBeUndefined();
-		expect( window.Blackbox.configure ).not.toHaveBeenCalled();
 	} );
 
 	test( 'loadBlackboxSdk resolves immediately without calling loadScript when feature flag is off', async () => {

--- a/client/blocks/login/utils/test/get-blackbox-session-id.js
+++ b/client/blocks/login/utils/test/get-blackbox-session-id.js
@@ -15,31 +15,38 @@ describe( 'getBlackboxSessionId', () => {
 		jest.clearAllMocks();
 	} );
 
-	test( 'awaits loadBlackboxSdk before calling getSessionId', async () => {
-		window.Blackbox = { getSessionId: jest.fn( () => Promise.resolve( 'sid' ) ) };
+	test( 'awaits loadBlackboxSdk before calling collect', async () => {
+		window.Blackbox = { collect: jest.fn( () => Promise.resolve( { sessionId: 'sid' } ) ) };
 
 		await getBlackboxSessionId();
 
 		expect( loadBlackboxSdk ).toHaveBeenCalled();
-		expect( window.Blackbox.getSessionId ).toHaveBeenCalled();
+		expect( window.Blackbox.collect ).toHaveBeenCalled();
 	} );
 
-	test( 'returns session id when getSessionId resolves a string', async () => {
-		window.Blackbox = { getSessionId: jest.fn( () => Promise.resolve( 'abc123' ) ) };
+	test( 'returns session id when collect resolves a string', async () => {
+		window.Blackbox = { collect: jest.fn( () => Promise.resolve( 'abc123' ) ) };
 		await expect( getBlackboxSessionId() ).resolves.toBe( 'abc123' );
+	} );
+
+	test( 'returns session id when collect resolves { sessionId }', async () => {
+		window.Blackbox = {
+			collect: jest.fn( () => Promise.resolve( { sessionId: 'def456' } ) ),
+		};
+		await expect( getBlackboxSessionId() ).resolves.toBe( 'def456' );
 	} );
 
 	test( 'returns undefined when Blackbox is not loaded', async () => {
 		await expect( getBlackboxSessionId() ).resolves.toBeUndefined();
 	} );
 
-	test( 'returns undefined when getSessionId is not a function', async () => {
+	test( 'returns undefined when collect is not a function', async () => {
 		window.Blackbox = {};
 		await expect( getBlackboxSessionId() ).resolves.toBeUndefined();
 	} );
 
-	test( 'returns undefined when getSessionId throws', async () => {
-		window.Blackbox = { getSessionId: jest.fn( () => Promise.reject( new Error( 'boom' ) ) ) };
+	test( 'returns undefined when collect throws', async () => {
+		window.Blackbox = { collect: jest.fn( () => Promise.reject( new Error( 'boom' ) ) ) };
 		await expect( getBlackboxSessionId() ).resolves.toBeUndefined();
 	} );
 } );

--- a/client/blocks/login/utils/test/get-blackbox-session-id.js
+++ b/client/blocks/login/utils/test/get-blackbox-session-id.js
@@ -15,31 +15,31 @@ describe( 'getBlackboxSessionId', () => {
 		jest.clearAllMocks();
 	} );
 
-	test( 'awaits loadBlackboxSdk before calling collect', async () => {
-		window.Blackbox = { collect: jest.fn( () => Promise.resolve( 'sid' ) ) };
+	test( 'awaits loadBlackboxSdk before calling getSessionId', async () => {
+		window.Blackbox = { getSessionId: jest.fn( () => Promise.resolve( 'sid' ) ) };
 
 		await getBlackboxSessionId();
 
 		expect( loadBlackboxSdk ).toHaveBeenCalled();
-		expect( window.Blackbox.collect ).toHaveBeenCalled();
+		expect( window.Blackbox.getSessionId ).toHaveBeenCalled();
 	} );
 
-	test( 'returns session id when collect resolves a string', async () => {
-		window.Blackbox = { collect: jest.fn( () => Promise.resolve( 'abc123' ) ) };
+	test( 'returns session id when getSessionId resolves a string', async () => {
+		window.Blackbox = { getSessionId: jest.fn( () => Promise.resolve( 'abc123' ) ) };
 		await expect( getBlackboxSessionId() ).resolves.toBe( 'abc123' );
-	} );
-
-	test( 'returns session id when collect resolves { sessionId }', async () => {
-		window.Blackbox = { collect: jest.fn( () => Promise.resolve( { sessionId: 'def456' } ) ) };
-		await expect( getBlackboxSessionId() ).resolves.toBe( 'def456' );
 	} );
 
 	test( 'returns undefined when Blackbox is not loaded', async () => {
 		await expect( getBlackboxSessionId() ).resolves.toBeUndefined();
 	} );
 
-	test( 'returns undefined when collect throws', async () => {
-		window.Blackbox = { collect: jest.fn( () => Promise.reject( new Error( 'boom' ) ) ) };
+	test( 'returns undefined when getSessionId is not a function', async () => {
+		window.Blackbox = {};
+		await expect( getBlackboxSessionId() ).resolves.toBeUndefined();
+	} );
+
+	test( 'returns undefined when getSessionId throws', async () => {
+		window.Blackbox = { getSessionId: jest.fn( () => Promise.reject( new Error( 'boom' ) ) ) };
 		await expect( getBlackboxSessionId() ).resolves.toBeUndefined();
 	} );
 } );

--- a/client/blocks/login/utils/test/get-blackbox-session-id.js
+++ b/client/blocks/login/utils/test/get-blackbox-session-id.js
@@ -1,0 +1,45 @@
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock( '../blackbox-sdk', () => ( {
+	loadBlackboxSdk: jest.fn( () => Promise.resolve() ),
+} ) );
+
+import { loadBlackboxSdk } from '../blackbox-sdk';
+import { getBlackboxSessionId } from '../get-blackbox-session-id';
+
+describe( 'getBlackboxSessionId', () => {
+	afterEach( () => {
+		delete window.Blackbox;
+		jest.clearAllMocks();
+	} );
+
+	test( 'awaits loadBlackboxSdk before calling collect', async () => {
+		window.Blackbox = { collect: jest.fn( () => Promise.resolve( 'sid' ) ) };
+
+		await getBlackboxSessionId();
+
+		expect( loadBlackboxSdk ).toHaveBeenCalled();
+		expect( window.Blackbox.collect ).toHaveBeenCalled();
+	} );
+
+	test( 'returns session id when collect resolves a string', async () => {
+		window.Blackbox = { collect: jest.fn( () => Promise.resolve( 'abc123' ) ) };
+		await expect( getBlackboxSessionId() ).resolves.toBe( 'abc123' );
+	} );
+
+	test( 'returns session id when collect resolves { sessionId }', async () => {
+		window.Blackbox = { collect: jest.fn( () => Promise.resolve( { sessionId: 'def456' } ) ) };
+		await expect( getBlackboxSessionId() ).resolves.toBe( 'def456' );
+	} );
+
+	test( 'returns undefined when Blackbox is not loaded', async () => {
+		await expect( getBlackboxSessionId() ).resolves.toBeUndefined();
+	} );
+
+	test( 'returns undefined when collect throws', async () => {
+		window.Blackbox = { collect: jest.fn( () => Promise.reject( new Error( 'boom' ) ) ) };
+		await expect( getBlackboxSessionId() ).resolves.toBeUndefined();
+	} );
+} );

--- a/client/blocks/login/utils/test/use-blackbox.jsx
+++ b/client/blocks/login/utils/test/use-blackbox.jsx
@@ -1,0 +1,130 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, render, screen } from '@testing-library/react';
+import { useRef } from 'react';
+import { loadBlackboxSdk } from '../blackbox-sdk';
+import { useBlackbox } from '../use-blackbox';
+
+jest.mock( '@automattic/calypso-config', () => {
+	const config = jest.fn( ( key ) => {
+		if ( key === 'blackbox_api_key' ) {
+			return 'test-api-key';
+		}
+		return undefined;
+	} );
+	config.isEnabled = jest.fn( ( flag ) => flag === 'blackbox-login' );
+	return config;
+} );
+
+jest.mock( '../blackbox-sdk', () => ( {
+	loadBlackboxSdk: jest.fn( () => Promise.resolve() ),
+} ) );
+
+function TestComponent() {
+	const containerRef = useRef( null );
+	const { hasChallengeContent, isChallengeActive, isLoading } = useBlackbox( { containerRef } );
+
+	return (
+		<>
+			<div ref={ containerRef } data-testid="blackbox-container" />
+			<div data-testid="blackbox-state">
+				{ `${ isLoading ? 'loading' : 'ready' }/${ isChallengeActive ? 'active' : 'inactive' }/${
+					hasChallengeContent ? 'content' : 'empty'
+				}` }
+			</div>
+		</>
+	);
+}
+
+describe( 'useBlackbox', () => {
+	beforeEach( () => {
+		jest.useFakeTimers();
+		jest.clearAllMocks();
+		window.Blackbox = {
+			configure: jest.fn(),
+		};
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+		delete window.Blackbox;
+	} );
+
+	test( 'keeps Blackbox loading until configure has had time to settle', async () => {
+		render( <TestComponent /> );
+
+		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'loading/inactive/empty' );
+
+		await act( async () => {} );
+
+		expect( loadBlackboxSdk ).toHaveBeenCalled();
+		expect( window.Blackbox.configure ).toHaveBeenCalled();
+		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'loading/inactive/empty' );
+
+		act( () => jest.advanceTimersByTime( 500 ) );
+
+		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/inactive/empty' );
+	} );
+
+	test( 'keeps Blackbox loading when completion fires before a challenge starts', async () => {
+		let callbacks;
+		window.Blackbox.configure.mockImplementationOnce( ( config ) => {
+			callbacks = config;
+		} );
+
+		render( <TestComponent /> );
+
+		await act( async () => {} );
+		act( () => callbacks.onChallengeComplete() );
+
+		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'loading/inactive/empty' );
+
+		act( () => jest.advanceTimersByTime( 500 ) );
+
+		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/inactive/empty' );
+	} );
+
+	test( 'marks Blackbox ready but active when a challenge starts', async () => {
+		let callbacks;
+		window.Blackbox.configure.mockImplementationOnce( ( config ) => {
+			callbacks = config;
+		} );
+
+		render( <TestComponent /> );
+
+		await act( async () => {} );
+		act( () => callbacks.onChallengeStart() );
+
+		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/active/empty' );
+
+		act( () => callbacks.onChallengeComplete() );
+
+		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/inactive/empty' );
+	} );
+
+	test( 'tracks challenge container content as a blocking signal', async () => {
+		let callbacks;
+		window.Blackbox.configure.mockImplementationOnce( ( config ) => {
+			callbacks = config;
+		} );
+
+		render( <TestComponent /> );
+
+		await act( async () => {} );
+		act( () => jest.advanceTimersByTime( 500 ) );
+
+		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/inactive/empty' );
+
+		await act( async () => {
+			screen.getByTestId( 'blackbox-container' ).appendChild( document.createElement( 'iframe' ) );
+		} );
+
+		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/inactive/content' );
+
+		act( () => callbacks.onChallengeComplete() );
+
+		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/inactive/empty' );
+	} );
+} );

--- a/client/blocks/login/utils/use-blackbox.js
+++ b/client/blocks/login/utils/use-blackbox.js
@@ -47,6 +47,11 @@ export function useBlackbox( { containerRef } ) {
 							setIsChallengeActive( false );
 						}
 					},
+					onChallengeFailure: () => {
+						if ( ! cancelled ) {
+							setIsChallengeActive( false );
+						}
+					},
 				} );
 
 				if ( hasConfiguredOnce && typeof window.Blackbox.reset === 'function' ) {

--- a/client/blocks/login/utils/use-blackbox.js
+++ b/client/blocks/login/utils/use-blackbox.js
@@ -2,6 +2,11 @@ import config from '@automattic/calypso-config';
 import { useEffect, useState } from 'react';
 import { loadBlackboxSdk } from 'calypso/blocks/login/utils/blackbox-sdk';
 
+// Tracks whether configure() has been called at least once across mounts.
+// On remount (e.g. back from 2FA), we call reset() to start a fresh session
+// so the new challenge container can surface a challenge.
+let hasConfiguredOnce = false;
+
 /**
  * Hook that loads the Blackbox SDK, calls configure() with the given container
  * ref and challenge callbacks, and tracks whether a challenge is active.
@@ -35,6 +40,15 @@ export function useBlackbox( { containerRef } ) {
 					onChallengeStart: () => setIsChallengeActive( true ),
 					onChallengeComplete: () => setIsChallengeActive( false ),
 				} );
+
+				if ( hasConfiguredOnce && typeof window.Blackbox.reset === 'function' ) {
+					// Remount (e.g. user navigated back from 2FA): clear the
+					// stale session and kick off a fresh collect so the SDK can
+					// surface a challenge in the new container.
+					window.Blackbox.reset();
+				}
+
+				hasConfiguredOnce = true;
 			} catch {
 				// Intentionally ignored — Blackbox must never block login.
 			}

--- a/client/blocks/login/utils/use-blackbox.js
+++ b/client/blocks/login/utils/use-blackbox.js
@@ -37,8 +37,16 @@ export function useBlackbox( { containerRef } ) {
 				window.Blackbox.configure( {
 					apiKey: config( 'blackbox_api_key' ),
 					challengeContainer: containerRef.current,
-					onChallengeStart: () => setIsChallengeActive( true ),
-					onChallengeComplete: () => setIsChallengeActive( false ),
+					onChallengeStart: () => {
+						if ( ! cancelled ) {
+							setIsChallengeActive( true );
+						}
+					},
+					onChallengeComplete: () => {
+						if ( ! cancelled ) {
+							setIsChallengeActive( false );
+						}
+					},
 				} );
 
 				if ( hasConfiguredOnce && typeof window.Blackbox.reset === 'function' ) {

--- a/client/blocks/login/utils/use-blackbox.js
+++ b/client/blocks/login/utils/use-blackbox.js
@@ -2,6 +2,11 @@ import config from '@automattic/calypso-config';
 import { useEffect, useState } from 'react';
 import { loadBlackboxSdk } from 'calypso/blocks/login/utils/blackbox-sdk';
 
+// Give the SDK a short window to synchronously or near-synchronously start a challenge
+// after configure(), avoiding a brief enabled submit button while the widget initializes.
+const BLACKBOX_CONFIGURE_SETTLE_TIMEOUT_MS = 500;
+const BLACKBOX_FAIL_OPEN_TIMEOUT_MS = 5000;
+
 // Tracks whether configure() has been called at least once across mounts.
 // On remount (e.g. back from 2FA), we call reset() to start a fresh session
 // so the new challenge container can surface a challenge.
@@ -12,17 +17,59 @@ let hasConfiguredOnce = false;
  * ref and challenge callbacks, and tracks whether a challenge is active.
  * @param {Object}  options
  * @param {import('react').RefObject<HTMLDivElement>} options.containerRef Ref to the challenge container element.
- * @returns {{ isChallengeActive: boolean }}
+ * @returns {{ isChallengeActive: boolean, isLoading: boolean, hasChallengeContent: boolean }}
  */
 export function useBlackbox( { containerRef } ) {
+	const isEnabled = config.isEnabled( 'blackbox-login' ) && !! config( 'blackbox_api_key' );
 	const [ isChallengeActive, setIsChallengeActive ] = useState( false );
+	const [ isLoading, setIsLoading ] = useState( isEnabled );
+	const [ hasChallengeContent, setHasChallengeContent ] = useState( false );
 
 	useEffect( () => {
-		if ( ! config.isEnabled( 'blackbox-login' ) || ! config( 'blackbox_api_key' ) ) {
+		const container = containerRef.current;
+
+		if ( ! isEnabled || ! container || typeof window.MutationObserver !== 'function' ) {
+			return;
+		}
+
+		const updateHasChallengeContent = () => {
+			setHasChallengeContent( container.childElementCount > 0 );
+		};
+		const observer = new window.MutationObserver( updateHasChallengeContent );
+
+		updateHasChallengeContent();
+		observer.observe( container, { childList: true } );
+
+		return () => {
+			observer.disconnect();
+		};
+	}, [ containerRef, isEnabled ] );
+
+	useEffect( () => {
+		if ( ! isEnabled ) {
 			return;
 		}
 
 		let cancelled = false;
+		let hasStartedChallenge = false;
+		let settleTimeout;
+		const failOpenTimeout = setTimeout( () => {
+			if ( ! cancelled ) {
+				setIsLoading( false );
+			}
+		}, BLACKBOX_FAIL_OPEN_TIMEOUT_MS );
+
+		const clearPendingTimeouts = () => {
+			clearTimeout( settleTimeout );
+			clearTimeout( failOpenTimeout );
+		};
+
+		const stopLoading = () => {
+			clearPendingTimeouts();
+			if ( ! cancelled ) {
+				setIsLoading( false );
+			}
+		};
 
 		loadBlackboxSdk().then( () => {
 			if ( cancelled ) {
@@ -30,6 +77,7 @@ export function useBlackbox( { containerRef } ) {
 			}
 
 			if ( typeof window.Blackbox?.configure !== 'function' ) {
+				stopLoading();
 				return;
 			}
 
@@ -39,16 +87,26 @@ export function useBlackbox( { containerRef } ) {
 					challengeContainer: containerRef.current,
 					onChallengeStart: () => {
 						if ( ! cancelled ) {
+							hasStartedChallenge = true;
+							stopLoading();
 							setIsChallengeActive( true );
 						}
 					},
 					onChallengeComplete: () => {
 						if ( ! cancelled ) {
+							if ( hasStartedChallenge ) {
+								stopLoading();
+							}
+							setHasChallengeContent( false );
 							setIsChallengeActive( false );
 						}
 					},
 					onChallengeFailure: () => {
 						if ( ! cancelled ) {
+							if ( hasStartedChallenge ) {
+								stopLoading();
+							}
+							setHasChallengeContent( false );
 							setIsChallengeActive( false );
 						}
 					},
@@ -62,15 +120,18 @@ export function useBlackbox( { containerRef } ) {
 				}
 
 				hasConfiguredOnce = true;
+				settleTimeout = setTimeout( stopLoading, BLACKBOX_CONFIGURE_SETTLE_TIMEOUT_MS );
 			} catch {
 				// Intentionally ignored — Blackbox must never block login.
+				stopLoading();
 			}
 		} );
 
 		return () => {
 			cancelled = true;
+			clearPendingTimeouts();
 		};
-	}, [ containerRef ] );
+	}, [ containerRef, isEnabled ] );
 
-	return { isChallengeActive };
+	return { isChallengeActive, isLoading, hasChallengeContent };
 }

--- a/client/blocks/login/utils/use-blackbox.js
+++ b/client/blocks/login/utils/use-blackbox.js
@@ -1,0 +1,49 @@
+import config from '@automattic/calypso-config';
+import { useEffect, useState } from 'react';
+import { loadBlackboxSdk } from 'calypso/blocks/login/utils/blackbox-sdk';
+
+/**
+ * Hook that loads the Blackbox SDK, calls configure() with the given container
+ * ref and challenge callbacks, and tracks whether a challenge is active.
+ * @param {Object}  options
+ * @param {import('react').RefObject<HTMLDivElement>} options.containerRef Ref to the challenge container element.
+ * @returns {{ isChallengeActive: boolean }}
+ */
+export function useBlackbox( { containerRef } ) {
+	const [ isChallengeActive, setIsChallengeActive ] = useState( false );
+
+	useEffect( () => {
+		if ( ! config.isEnabled( 'blackbox-login' ) || ! config( 'blackbox_api_key' ) ) {
+			return;
+		}
+
+		let cancelled = false;
+
+		loadBlackboxSdk().then( () => {
+			if ( cancelled ) {
+				return;
+			}
+
+			if ( typeof window.Blackbox?.configure !== 'function' ) {
+				return;
+			}
+
+			try {
+				window.Blackbox.configure( {
+					apiKey: config( 'blackbox_api_key' ),
+					challengeContainer: containerRef.current,
+					onChallengeStart: () => setIsChallengeActive( true ),
+					onChallengeComplete: () => setIsChallengeActive( false ),
+				} );
+			} catch {
+				// Intentionally ignored — Blackbox must never block login.
+			}
+		} );
+
+		return () => {
+			cancelled = true;
+		};
+	}, [ containerRef ] );
+
+	return { isChallengeActive };
+}

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -264,17 +264,6 @@ class Document extends Component {
 						/>
 					) }
 
-					{ sectionName === 'login' &&
-						config.isEnabled( 'blackbox-login' ) &&
-						config( 'blackbox_api_key' ) && (
-							<script
-								nonce={ inlineScriptNonce }
-								defer
-								src={ config( 'blackbox_url' ) }
-								data-apikey={ config( 'blackbox_api_key' ) }
-							/>
-						) }
-
 					{ entrypoint?.language?.manifest && (
 						<script nonce={ inlineScriptNonce } src={ entrypoint.language.manifest } />
 					) }

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -267,17 +267,6 @@ class Document extends Component {
 						/>
 					) }
 
-					{ sectionName === 'login' &&
-						config.isEnabled( 'blackbox-login' ) &&
-						config( 'blackbox_api_key' ) && (
-							<script
-								nonce={ inlineScriptNonce }
-								defer
-								src={ config( 'blackbox_url' ) }
-								data-apikey={ config( 'blackbox_api_key' ) }
-							/>
-						) }
-
 					{ entrypoint?.language?.manifest && (
 						<script nonce={ inlineScriptNonce } src={ entrypoint.language.manifest } />
 					) }

--- a/client/types.ts
+++ b/client/types.ts
@@ -141,7 +141,7 @@ declare global {
 		Blackbox?: {
 			configure: ( config: {
 				apiKey: string;
-				challengeContainer: string;
+				challengeContainer: string | HTMLElement;
 				onChallengeStart?: () => void;
 				onChallengeComplete?: () => void;
 			} ) => void;

--- a/client/types.ts
+++ b/client/types.ts
@@ -144,6 +144,7 @@ declare global {
 				challengeContainer: string | HTMLElement;
 				onChallengeStart?: () => void;
 				onChallengeComplete?: () => void;
+				onChallengeFailure?: ( reason: 'timeout' | 'exhausted' ) => void;
 			} ) => void;
 			collect: () => Promise< string | { sessionId: string } >;
 			getSessionId: () => Promise< string >;

--- a/client/types.ts
+++ b/client/types.ts
@@ -138,5 +138,16 @@ declare global {
 		};
 		currentUser?: User;
 		__REDUX_DEVTOOLS_EXTENSION__?: () => void;
+		Blackbox?: {
+			configure: ( config: {
+				apiKey: string;
+				challengeContainer: string;
+				onChallengeStart?: () => void;
+				onChallengeComplete?: () => void;
+			} ) => void;
+			collect: () => Promise< string | { sessionId: string } >;
+			getSessionId: () => Promise< string >;
+			reset?: () => void;
+		};
 	}
 }

--- a/packages/load-script/README.md
+++ b/packages/load-script/README.md
@@ -53,6 +53,17 @@ await loadScript( REMOTE_SCRIPT_URL, undefined, { id: 'my-script-tag-id' } );
 // Script tag id will be set to 'my-script-tag-id';
 ```
 
+`data-*` and `aria-*` keys are written as HTML attributes:
+
+```js
+await loadScript( REMOTE_SCRIPT_URL, undefined, {
+	'data-apikey': 'example-key',
+} );
+// Script tag includes data-apikey="example-key";
+```
+
+Other keys continue to be assigned as script element properties (for example `id`, `async`, `nonce`).
+
 ## Error handling
 
 If using the callback, it should expect a single argument, which will be `null` on success or an object on failure. This error object contains the `src` property, which will contain the src url of the script that failed to load. If using the Promise form, the error object will be passed to the nearest `catch` handler as a rejection.

--- a/packages/load-script/src/dom-operations.js
+++ b/packages/load-script/src/dom-operations.js
@@ -6,7 +6,7 @@ const debug = debugFactory( 'lib/load-script/dom-operations' );
 function setScriptOption( script, key, value ) {
 	// data-/aria- keys must be real attributes (script['data-*'] is not valid DOM mapping).
 	if ( key.startsWith( 'data-' ) || key.startsWith( 'aria-' ) ) {
-		script.setAttribute( key, String( value ) );
+		script.setAttribute( key, value );
 		return;
 	}
 

--- a/packages/load-script/src/dom-operations.js
+++ b/packages/load-script/src/dom-operations.js
@@ -3,6 +3,16 @@ import { handleRequestError, handleRequestSuccess } from './callback-handler';
 
 const debug = debugFactory( 'lib/load-script/dom-operations' );
 
+function setScriptOption( script, key, value ) {
+	// data-/aria- keys must be real attributes (script['data-*'] is not valid DOM mapping).
+	if ( key.startsWith( 'data-' ) || key.startsWith( 'aria-' ) ) {
+		script.setAttribute( key, String( value ) );
+		return;
+	}
+
+	script[ key ] = value;
+}
+
 export function createScriptElement( url, args ) {
 	debug( `Creating script element for "${ url }"` );
 	const script = document.createElement( 'script' );
@@ -14,7 +24,7 @@ export function createScriptElement( url, args ) {
 	script.async = true;
 
 	if ( args ) {
-		Object.entries( args ).forEach( ( [ key, value ] ) => ( script[ key ] = value ) );
+		Object.entries( args ).forEach( ( [ key, value ] ) => setScriptOption( script, key, value ) );
 	}
 
 	return script;

--- a/packages/load-script/src/types/index.d.ts
+++ b/packages/load-script/src/types/index.d.ts
@@ -1,13 +1,13 @@
 export function loadScript(
 	url: string,
 	callback: ( () => void ) | undefined,
-	args?: Record< string, string >
+	args?: Record< string, string | number | boolean >
 ): undefined;
 export function loadScript( url: string ): Promise< void >;
 
 export function loadjQueryDependentScript(
 	url: string,
 	callback: ( () => void ) | undefined,
-	args?: Record< string, string >
+	args?: Record< string, string | number | boolean >
 ): undefined;
 export function loadjQueryDependentScript( url: string ): Promise< void >;

--- a/packages/load-script/test/dom-operations.js
+++ b/packages/load-script/test/dom-operations.js
@@ -25,5 +25,20 @@ describe( 'loadScript/dom-operations', () => {
 			expect( script.id ).toBe( args.id );
 			expect( script.async ).toBe( false );
 		} );
+
+		test( 'createScriptElement sets data attributes as attributes', () => {
+			const url = 'https://example.com/';
+			const args = {
+				'data-apikey': 'secret-api-key',
+				'data-challenge-container': '#blackbox-root',
+			};
+
+			const script = createScriptElement( url, args );
+
+			expect( script.getAttribute( 'data-apikey' ) ).toBe( args[ 'data-apikey' ] );
+			expect( script.getAttribute( 'data-challenge-container' ) ).toBe(
+				args[ 'data-challenge-container' ]
+			);
+		} );
 	} );
 } );


### PR DESCRIPTION
A rework of #109787

Part of #109787 (rework)                                                                                                                                      
                                                                                                                                                 
  Proposed Changes                                                                                                                                              
                                                                                                                                                 
  - Rework the Blackbox bot-detection challenge widget integration using a simpler singleton pattern
  - Add client/blocks/login/utils/blackbox-sdk.js — a singleton module that loads the SDK via loadScript, calls configure() once at load time with wrapper
  closures, and exposes a challengeCallbacks object for the form to write its state handlers into                                                               
  - Update getBlackboxSessionId to await loadBlackboxSdk() before calling collect()
  - Integrate into login-form.jsx: mount the #blackbox-challenge-root container, register callbacks in componentDidMount, clear them in componentWillUnmount,   
  and gate submit button on isBlackboxChallengeActive state                                                                                      
  - Remove the server-side <script> tag from client/document/index.jsx — loading is now done client-side in componentDidMount
  - Add data-* / aria-* attribute support to @automattic/load-script via setAttribute (previously attribute assignment was a no-op on script elements)          
  - Add Blackbox SDK type to the Window interface in client/types.ts
                                                                                                                                                                
  Why are these changes being made?                                                                                                              
                                         
  The previous implementation (#109787) accumulated complexity across multiple iterations: parallel callback registration paths (data-on-challenge-* globals +  
  configure()/setConfig()), a CustomEvent bridge, and triple call sites for tryRegisterBlackboxRuntimeCallbacks. This was all unnecessary because
  data-on-challenge-start / data-on-challenge-complete are not real SDK attributes — only configure() can register callbacks.                                   
                                                                                                                                                 
  This rework replaces that with a minimal wrapper-closure singleton: configure() is called once at script load with stable wrapper functions that delegate to a
   shared challengeCallbacks object. The form simply writes its setState methods into those slots on mount and clears them on unmount. No re-configuring, no
  event bridging.                                                                                                                                               
                                                                                                                                                 
  Testing Instructions                   

  - Enable the blackbox-login feature flag and set blackbox_api_key / blackbox_url in config
  - Load the login form — the #blackbox-challenge-root div should appear and the SDK should be injected client-side
  - Trigger a bot-detection challenge — the submit button should be disabled while the challenge is active and re-enabled on completion
  - Disable the feature flag — no script should be injected, no containers rendered, submit button unaffected
  - Verify getBlackboxSessionId() returns a session ID on successful collect and undefined on failure without blocking login    