### PR TITLE
Reader: Fix flickering of primary blog on gravatar hovercard

### DIFF
--- a/client/components/gravatar-with-hovercards/hovercard-content.jsx
+++ b/client/components/gravatar-with-hovercards/hovercard-content.jsx
@@ -15,7 +15,7 @@ function HovercardContent( props ) {
 	// find the read one with this selector.
 	const readerUserData = useSelector( ( state ) => getReaderUser( state, user.wpcom_id, true ) );
 	const { display_name: displayName, user_login: userLogin } = readerUserData || {};
-	const primaryBlogId = readerUserData?.primary_blog || user?.primary_blog || user?.site_ID;
+	const primaryBlogId = readerUserData?.primary_blog?.ID || user?.primary_blog || user?.site_ID;
 
 	useEffect( () => {
 		if ( ! readerUserData && user?.wpcom_id ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related: [READ-467](https://linear.app/a8c/issue/READ-467/reader-update-restv11users-endpoint-to-add-info-needed-for-hovercard)

## Proposed Changes

Resolved the flickering issue with the primary blog content displayed on the Gravatar hovercard. This was achieved by ensuring the primary blog ID is mapped correctly.