### PR TITLE
Add dark-mode config variable

### DIFF
--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -24,6 +24,7 @@
 		"cancel-flow/solutions-cards-upsell": false,
 		"ciab/allow-domain-features": true,
 		"cookie-banner": false,
+		"dark-mode": false,
 		"dashboard/omnibar": true,
 		"dashboard/plans": true,
 		"dashboard/v2": false,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -24,6 +24,7 @@
 		"ciab/allow-domain-features": true,
 		"ciab/custom-branding": true,
 		"cookie-banner": false,
+		"dark-mode": false,
 		"dashboard/omnibar": true,
 		"dashboard/plans": true,
 		"dashboard/v2": false,

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -25,6 +25,7 @@
 		"ciab/allow-domain-features": true,
 		"ciab/custom-branding": true,
 		"cookie-banner": true,
+		"dark-mode": false,
 		"dashboard/omnibar": false,
 		"dashboard/v2": false,
 		"dashboard/wp-beta-program": true,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -24,6 +24,7 @@
 		"ciab/allow-domain-features": true,
 		"ciab/custom-branding": true,
 		"cookie-banner": false,
+		"dark-mode": false,
 		"dashboard/omnibar": false,
 		"dashboard/v2": false,
 		"dashboard/wp-beta-program": true,

--- a/config/development.json
+++ b/config/development.json
@@ -62,6 +62,7 @@
 		"cookie-banner": false,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
+		"dark-mode": false,
 		"dashboard/omnibar": true,
 		"dashboard/opt-in-banners": false,
 		"dashboard/plans": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -27,6 +27,7 @@
 		"cookie-banner": true,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
+		"dark-mode": false,
 		"dashboard/omnibar": false,
 		"dashboard/opt-in-banners": false,
 		"dashboard/plans": true,

--- a/config/production.json
+++ b/config/production.json
@@ -40,6 +40,7 @@
 		"cookie-banner": true,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
+		"dark-mode": false,
 		"dashboard/omnibar": false,
 		"dashboard/opt-in-banners": false,
 		"dashboard/v2": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -37,6 +37,7 @@
 		"cookie-banner": false,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
+		"dark-mode": false,
 		"dashboard/omnibar": false,
 		"dashboard/opt-in-banners": false,
 		"dashboard/v2": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -37,6 +37,7 @@
 		"cookie-banner": true,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
+		"dark-mode": false,
 		"dashboard/omnibar": false,
 		"dashboard/opt-in-banners": false,
 		"dashboard/plans": true,


### PR DESCRIPTION
See https://linear.app/a8c/issue/RSM-154/add-dark-mode-feature

Related to https://github.com/Automattic/wp-calypso/pull/110058

The variable is `false` everywhere. To override it and enable it, create a `config/development.local.json` file:

```json
{
	"features": {
		"dark-mode": true
	}
}
```

## Proposed Changes

* Add a `dark-mode` config variable to all config `.json` files

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To use the config during the development stage

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Unit/E2E tests working well

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
