### PR TITLE
Dashboard: rename cancel survey Submit button to Continue

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
@@ -395,7 +395,7 @@ function StepButtons( {
 				onClick={ onSubmit }
 				variant={ variant }
 			>
-				{ __( 'Submit' ) }
+				{ __( 'Continue' ) }
 			</Button>
 			{ ! canGoNext && ! hasWarningStep && (
 				<Button


### PR DESCRIPTION
Fixes: https://linear.app/a8c/issue/RSM-556

## What

Renames the \"Submit\" button on the cancel survey to \"Continue\", matching the label already used on intermediate steps.

| Before | After |
| -- | -- |
| <img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/1f8bbd29-bca4-4601-aa99-5556129685d6" /> |  <img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/71279545-c014-4509-a284-f2ddd4aeb510" /> | 

## Why

Submit is robotic and there's no need for these buttons to change on some random logic. 

## Testing

1. Go to Billing > any active plan > Cancel plan
2. Complete all survey steps
3. Verify the final step's primary button says **Continue** (not Submit)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Automattic/wp-calypso/blob/trunk/docs/CONTRIBUTING.md) doc
- [ ] I have added tests for my changes
- [x] My changes generate no new warnings
- [x] I have tested my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)