### PR TITLE
Reader: Add achievements route to user profile

### DIFF
--- a/client/declarations.d.ts
+++ b/client/declarations.d.ts
@@ -1,3 +1,8 @@
+declare module '*.scss' {
+	const content: Record< string, string >;
+	export default content;
+}
+
 declare module 'browser-filesaver' {
 	export function saveAs( data: Blob, filename: string, disableAutoBOM?: boolean ): void;
 }

--- a/client/reader/user-profile/components/user-profile-header/index.tsx
+++ b/client/reader/user-profile/components/user-profile-header/index.tsx
@@ -1,4 +1,5 @@
 import './style.scss';
+import { isEnabled } from '@automattic/calypso-config';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useLayoutEffect, useRef, useState } from 'react';
@@ -57,6 +58,15 @@ const UserProfileHeader = ( { user, view }: UserProfileHeaderProps ): JSX.Elemen
 			path: `${ userProfileUrl }/recommended-blogs`,
 			selected: view === 'recommended-blogs',
 		},
+		...( isEnabled( 'reader/achievements' )
+			? [
+					{
+						label: translate( 'Achievements' ),
+						path: `${ userProfileUrl }/achievements`,
+						selected: view === 'achievements',
+					},
+			  ]
+			: [] ),
 	];
 
 	return (

--- a/client/reader/user-profile/components/user-profile-header/test/index.test.tsx
+++ b/client/reader/user-profile/components/user-profile-header/test/index.test.tsx
@@ -3,6 +3,7 @@
  */
 
 import { ReaderUser, UserSitesResponse } from '@automattic/api-core';
+import { isEnabled } from '@automattic/calypso-config';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -30,6 +31,12 @@ jest.mock(
 			<div data-testid="nav-tabs">{ children }</div>
 		)
 );
+
+jest.mock( '@automattic/calypso-config', () => ( {
+	isEnabled: jest.fn(),
+} ) );
+
+const mockIsEnabled = isEnabled as jest.MockedFunction< typeof isEnabled >;
 
 describe( 'UserProfileHeader', () => {
 	const defaultUser: ReaderUser = {
@@ -132,6 +139,7 @@ describe( 'UserProfileHeader', () => {
 	} );
 
 	test( 'should render navigation tabs with Posts, Sites, Lists, and Recommended Blogs options', () => {
+		mockIsEnabled.mockReturnValue( false );
 		renderWithClient( <UserProfileHeader user={ defaultUser } view="posts" /> );
 
 		const navItems = screen.getAllByRole( 'menuitem' );
@@ -141,6 +149,17 @@ describe( 'UserProfileHeader', () => {
 		expect( screen.getByRole( 'menuitem', { name: 'Sites' } ) ).toBeVisible();
 		expect( screen.getByRole( 'menuitem', { name: 'Lists' } ) ).toBeVisible();
 		expect( screen.getByRole( 'menuitem', { name: 'Recommended Blogs' } ) ).toBeVisible();
+		expect( screen.queryByRole( 'menuitem', { name: 'Achievements' } ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'should render Achievements tab when reader/achievements flag is enabled', () => {
+		mockIsEnabled.mockImplementation( ( flag ) => flag === 'reader/achievements' );
+		renderWithClient( <UserProfileHeader user={ defaultUser } view="posts" /> );
+
+		const navItems = screen.getAllByRole( 'menuitem' );
+		expect( navItems.length ).toBe( 5 );
+
+		expect( screen.getByRole( 'menuitem', { name: 'Achievements' } ) ).toBeVisible();
 	} );
 
 	test( 'should not render bio section when user has no bio', () => {

--- a/client/reader/user-profile/index.tsx
+++ b/client/reader/user-profile/index.tsx
@@ -8,6 +8,7 @@ import { useEffect } from 'react';
 import EmptyContent from 'calypso/components/empty-content';
 import ReaderBackButton from 'calypso/reader/components/back-button';
 import UserProfileHeader from 'calypso/reader/user-profile/components/user-profile-header';
+import UserAchievements from 'calypso/reader/user-profile/views/achievements';
 import UserLists from 'calypso/reader/user-profile/views/lists';
 import UserPosts from 'calypso/reader/user-profile/views/posts';
 import UserRecommendedBlogs from 'calypso/reader/user-profile/views/recommended-blogs';
@@ -63,6 +64,8 @@ export function UserProfile( props: UserProfileProps ): JSX.Element | null {
 				return <UserLists user={ user } />;
 			case 'recommended-blogs':
 				return <UserRecommendedBlogs user={ user } />;
+			case 'achievements':
+				return <UserAchievements user={ user } />;
 			default:
 				return null;
 		}

--- a/client/reader/user-profile/views/achievements.tsx
+++ b/client/reader/user-profile/views/achievements.tsx
@@ -1,0 +1,12 @@
+import type { ReaderUser } from '@automattic/api-core';
+
+interface UserAchievementsProps {
+	user: ReaderUser;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const UserAchievements = ( { user }: UserAchievementsProps ): JSX.Element | null => {
+	return null;
+};
+
+export default UserAchievements;


### PR DESCRIPTION
Fixes RSM-393

## Proposed Changes

- Add `/reader/users/:user/achievements` route, rendered as a blank user profile page.
- Add "Achievements" tab to the user profile header navigation, after "Recommended Blogs".
- Gate the new tab behind the `reader/achievements` feature flag.

<img width="761" height="544" alt="Screenshot 2026-04-22 at 15 52 39" src="https://github.com/user-attachments/assets/a29c07f7-9ec9-49da-ba8e-8c41ff8944dd" />

## Why are these changes being made?

This sets up the route and navigation entry point for the upcoming Achievements page in the Reader user profile, as part of the RSM Achievements project.

## Testing Instructions

- Enable the `reader/achievements` feature flag (already on in development).
- Navigate to `/reader/users/<username>/achievements`.
- Verify the "Achievements" tab appears as the last item in the user profile navigation.
- Verify the page renders blank (no content yet).
- Disable the flag and confirm the tab is hidden.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?