### PR TITLE
Podcasting settings: show upgrade module on free plans

### DIFF
--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -215,40 +215,48 @@ const PodcastingSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 		<form id="site-settings" onSubmit={ handleSubmitForm }>
 			<QueryTerms siteId={ siteId } taxonomy="category" />
 
-			{ /* Podcasting enable toggle */ }
-			<Card className="site-settings__card">
-				<ToggleControl
-					checked={ isPodcastingEnabled || isEnabling }
-					onChange={ onTogglePodcasting }
-					disabled={ disabled }
-					label={ translate( 'Enable podcasting on this site' ) }
-				/>
-				{ isPodcastingEnabled && (
-					<FormSettingExplanation>
-						{ translate(
-							'Disable to stop publishing your podcast feed. You can always set it up again.'
-						) }
-					</FormSettingExplanation>
-				) }
-			</Card>
-
-			{ /* Upsell nudge for audio upload */ }
-			{ ( isPodcastingEnabled || isEnabling ) && plansDataLoaded && ! isAudioUploadEnabled && (
+			{ /* Podcasting upsell for free plans, toggle for paid plans */ }
+			{ plansDataLoaded && ! isAudioUploadEnabled ? (
 				<UpsellNudge
 					plan={ PLAN_PERSONAL }
-					title={ translate( 'Upload Audio with WordPress.com %(personalPlanName)s', {
+					title={ translate( 'Start a podcast with the %(personalPlanName)s plan', {
 						args: { personalPlanName: getPlan( PLAN_PERSONAL ).getTitle() },
 					} ) }
-					description={ translate( 'Embed podcast episodes directly from your media library.' ) }
+					description={
+						isPodcastingEnabled
+							? translate(
+									'Podcasting was set up on your previous plan. Upgrade to turn it back on and publish to Apple Podcasts, Spotify, and every major app.'
+							  )
+							: translate(
+									'Publish your episodes to Apple Podcasts, Spotify, and every major app. Podcasting is included with any paid plan.'
+							  )
+					}
 					feature={ WPCOM_FEATURES_UPLOAD_AUDIO_FILES }
-					event="podcasting_details_upload_audio"
+					event="podcasting_details_plan_upgrade"
 					tracksImpressionName="calypso_upgrade_nudge_impression"
 					tracksClickName="calypso_upgrade_nudge_cta_click"
 					showIcon
+					horizontal
 				/>
+			) : (
+				<Card className="site-settings__card">
+					<ToggleControl
+						checked={ isPodcastingEnabled || isEnabling }
+						onChange={ onTogglePodcasting }
+						disabled={ disabled }
+						label={ translate( 'Enable podcasting on this site' ) }
+					/>
+					{ isPodcastingEnabled && (
+						<FormSettingExplanation>
+							{ translate(
+								'Disable to stop publishing your podcast feed. You can always set it up again.'
+							) }
+						</FormSettingExplanation>
+					) }
+				</Card>
 			) }
 
-			{ ( isPodcastingEnabled || isEnabling ) && (
+			{ isAudioUploadEnabled && ( isPodcastingEnabled || isEnabling ) && (
 				<>
 					{ /* Podcast category */ }
 					<SettingsSectionHeader


### PR DESCRIPTION
Part of PODS-45

## Proposed Changes

* Replace the unconditional Podcasting toggle card on `/settings/podcasting/:site` with an `UpsellNudge` for sites that lack the `WPCOM_FEATURES_UPLOAD_AUDIO_FILES` feature (free WordPress.com Simple sites).
* Paid-plan Simple and Atomic sites continue to see the toggle and full settings form unchanged.
* Show a dedicated copy variant for users who had podcasting enabled under a previous paid plan so they understand why the UI has changed and how to restore it.
* Remove the inner audio-upload-only nudge that previously appeared after toggling podcasting on; the outer upsell now covers that gate.

## Why are these changes being made?

Podcasting requires audio uploads, which free Simple sites cannot use. Showing the toggle without gating lets users turn on a feature they cannot actually use. Routing them to an upsell that matches the existing Jetpack Search / SEO / Firewall settings patterns sets expectations up front and offers a single clear path to upgrade.

## Testing Instructions

Local:
```
git checkout pods-45-upgrade-module-free-plan && NODE_OPTIONS="--max-old-space-size=8192" yarn start
```

Then:
1. On a free-plan Simple site, visit `/settings/podcasting/<site-slug>`. Expect the upsell banner in place of the toggle, with the copy "Start a podcast with the Personal plan".
2. On a Personal+ Simple site, visit the same URL. Expect the toggle card, and toggling on should reveal the Podcast category / details / feed sections as before. No audio-upload upsell should appear inside the enabled state.
3. On an Atomic site, visit the same URL. Expect toggle + settings form (Atomic sites satisfy the audio-upload gate).
4. On a free-plan site that previously enabled podcasting (simulate by pointing a saved podcasting_category_id at a free site), expect the upsell with the "Podcasting was set up on your previous plan" copy line.
5. Confirm no console errors and no TypeScript warnings.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?