### PR TITLE
Add CTA click tracking to plan upsell modal

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-free-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-free-domain-dialog.tsx
@@ -10,7 +10,8 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { DialogContainer, Heading } from './components';
 import PlanUpsellButton from './components/plan-upsell-button';
 import { usePlanUpsellInfo } from './hooks/use-plan-upsell-info';
-import { DomainPlanDialogProps, MODAL_VIEW_EVENT_NAME } from '.';
+import { DomainPlanDialogProps, MODAL_CTA_CLICK_EVENT_NAME, MODAL_VIEW_EVENT_NAME } from '.';
+import type { PlanSlug } from '@automattic/calypso-products';
 import type { TranslateResult } from 'i18n-calypso';
 
 const List = styled.ul`
@@ -99,6 +100,21 @@ export function FreePlanFreeDomainDialog( {
 	const basicPlanUpsellInfo = usePlanUpsellInfo( { planSlug: PLAN_PERSONAL } );
 	const advancePlanUpsellInfo = usePlanUpsellInfo( { planSlug: PLAN_PREMIUM } );
 	const buttonDisabled = generatedWPComSubdomain.isLoading || ! generatedWPComSubdomain.result;
+	function handlePlanSelected( planSlug: PlanSlug ) {
+		recordTracksEvent( MODAL_CTA_CLICK_EVENT_NAME, {
+			dialog_type: 'free_plan_free_domain',
+			plan_slug: planSlug,
+		} );
+		onPlanSelected( planSlug );
+	}
+
+	function handleFreePlanClick() {
+		recordTracksEvent( MODAL_CTA_CLICK_EVENT_NAME, {
+			dialog_type: 'free_plan_free_domain',
+			plan_slug: 'free',
+		} );
+		onFreePlanSelected();
+	}
 
 	useEffect( () => {
 		recordTracksEvent( MODAL_VIEW_EVENT_NAME, {
@@ -190,21 +206,16 @@ export function FreePlanFreeDomainDialog( {
 				<PlanUpsellButton
 					planSlug={ PLAN_PERSONAL }
 					disabled={ buttonDisabled }
-					onPlanSelected={ onPlanSelected }
+					onPlanSelected={ handlePlanSelected }
 				/>
+
 				<PlanUpsellButton
 					planSlug={ PLAN_PREMIUM }
 					disabled={ buttonDisabled }
-					onPlanSelected={ onPlanSelected }
+					onPlanSelected={ handlePlanSelected }
 				/>
 			</ButtonRow>
-			<PlanButton
-				disabled={ buttonDisabled }
-				onClick={ () => {
-					onFreePlanSelected();
-				} }
-				borderless
-			>
+			<PlanButton disabled={ buttonDisabled } onClick={ handleFreePlanClick } borderless>
 				{ translate( 'Continue with Free' ) }
 			</PlanButton>
 			<TextBox fontSize={ 12 } color="gray">

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-paid-domain-dialog.tsx
@@ -14,7 +14,8 @@ import {
 	DomainName,
 } from './components';
 import PaidDomainSuggestedPlanSection from './components/paid-domain-suggested-plan-section';
-import { DomainPlanDialogProps, MODAL_VIEW_EVENT_NAME } from '.';
+import { DomainPlanDialogProps, MODAL_CTA_CLICK_EVENT_NAME, MODAL_VIEW_EVENT_NAME } from '.';
+import type { PlanSlug } from '@automattic/calypso-products';
 
 export function FreePlanPaidDomainDialog( {
 	paidDomainName,
@@ -31,7 +32,19 @@ export function FreePlanPaidDomainDialog( {
 		} );
 	}, [] );
 
+	function handlePlanSelected( planSlug: PlanSlug ) {
+		recordTracksEvent( MODAL_CTA_CLICK_EVENT_NAME, {
+			dialog_type: 'custom_domain_and_free_plan',
+			plan_slug: planSlug,
+		} );
+		onPlanSelected( planSlug );
+	}
+
 	function handleFreePlanClick() {
+		recordTracksEvent( MODAL_CTA_CLICK_EVENT_NAME, {
+			dialog_type: 'custom_domain_and_free_plan',
+			plan_slug: 'free',
+		} );
 		setIsBusy( true );
 		onFreePlanSelected( true );
 	}
@@ -64,7 +77,7 @@ export function FreePlanPaidDomainDialog( {
 					<PaidDomainSuggestedPlanSection
 						paidDomainName={ paidDomainName }
 						isBusy={ isBusy }
-						onPlanSelected={ onPlanSelected }
+						onPlanSelected={ handlePlanSelected }
 					/>
 				</RowWithBorder>
 				<Row>

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/index.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/index.tsx
@@ -38,6 +38,7 @@ type ModalContainerProps = {
 
 // See p2-pbxNRc-2Ri#comment-4703 for more context
 export const MODAL_VIEW_EVENT_NAME = 'calypso_plan_upsell_modal_view';
+export const MODAL_CTA_CLICK_EVENT_NAME = 'calypso_plan_upsell_modal_cta_click';
 
 function getDisplayedModal( modalType: ModalType, dialogProps: DomainPlanDialogProps ) {
 	switch ( modalType ) {

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
@@ -8,7 +8,8 @@ import { getHidePlanPropsBasedOnThemeType } from '../utils/utils';
 import { ButtonContainer, DialogContainer, Heading, Row } from './components';
 import { PlanName, PlanDescription } from './components/plan-item';
 import SuggestedPlanSection from './components/suggested-plan-section';
-import { DomainPlanDialogProps, MODAL_VIEW_EVENT_NAME } from '.';
+import { DomainPlanDialogProps, MODAL_CTA_CLICK_EVENT_NAME, MODAL_VIEW_EVENT_NAME } from '.';
+import type { PlanSlug } from '@automattic/calypso-products';
 
 export const PaidPlanIsRequiredDialog = ( {
 	paidDomainName,
@@ -34,7 +35,19 @@ export const PaidPlanIsRequiredDialog = ( {
 		return translate( 'Custom domains are only available with a paid plan' );
 	};
 
+	function handlePlanSelected( planSlug: PlanSlug ) {
+		recordTracksEvent( MODAL_CTA_CLICK_EVENT_NAME, {
+			dialog_type: 'paid_plan_is_required',
+			plan_slug: planSlug,
+		} );
+		onPlanSelected( planSlug );
+	}
+
 	const handleFreeDomainClick = () => {
+		recordTracksEvent( MODAL_CTA_CLICK_EVENT_NAME, {
+			dialog_type: 'paid_plan_is_required',
+			plan_slug: 'free',
+		} );
 		setIsBusy( true );
 		onFreePlanSelected();
 	};
@@ -54,7 +67,7 @@ export const PaidPlanIsRequiredDialog = ( {
 				<SuggestedPlanSection
 					{ ...hidePlanProps }
 					isBusy={ isBusy }
-					onPlanSelected={ onPlanSelected }
+					onPlanSelected={ handlePlanSelected }
 				/>
 				<Row>
 					<div>

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-paid-domain-dialog.tsx
@@ -13,7 +13,8 @@ import {
 	DomainName,
 } from './components';
 import PaidDomainSuggestedPlanSection from './components/paid-domain-suggested-plan-section';
-import { DomainPlanDialogProps, MODAL_VIEW_EVENT_NAME } from '.';
+import { DomainPlanDialogProps, MODAL_CTA_CLICK_EVENT_NAME, MODAL_VIEW_EVENT_NAME } from '.';
+import type { PlanSlug } from '@automattic/calypso-products';
 
 export function PaidPlanPaidDomainDialog( {
 	paidDomainName,
@@ -31,7 +32,19 @@ export function PaidPlanPaidDomainDialog( {
 		} );
 	}, [] );
 
+	function handlePlanSelected( planSlug: PlanSlug ) {
+		recordTracksEvent( MODAL_CTA_CLICK_EVENT_NAME, {
+			dialog_type: 'paid_plan_is_required',
+			plan_slug: planSlug,
+		} );
+		onPlanSelected( planSlug );
+	}
+
 	function handleFreeDomainClick() {
+		recordTracksEvent( MODAL_CTA_CLICK_EVENT_NAME, {
+			dialog_type: 'paid_plan_is_required',
+			plan_slug: 'free',
+		} );
 		setIsBusy( true );
 		onFreePlanSelected();
 	}
@@ -58,7 +71,7 @@ export function PaidPlanPaidDomainDialog( {
 					<PaidDomainSuggestedPlanSection
 						paidDomainName={ paidDomainName }
 						isBusy={ isBusy }
-						onPlanSelected={ onPlanSelected }
+						onPlanSelected={ handlePlanSelected }
 					/>
 				</RowWithBorder>
 				<Row>


### PR DESCRIPTION
Part of `RSM Mobile Experience Overhaul` (@ollierozdarz + me)

## Proposed changes

* Add `calypso_plan_upsell_modal_cta_click` Tracks event to all CTA buttons in the plan upsell modal

<img width="390" height="844" alt="image" src="https://github.com/user-attachments/assets/0884330a-2abf-48b7-9028-bfbe97e72505" />

* Event fires on: "Get Personal", "Get Premium", and "Continue with Free plan" / "Continue with Free" buttons
* Properties: `dialog_type` (matches the existing view event) and `plan_slug` (the plan slug for paid CTAs, `'free'` for the free option)

## Why are these changes being made?

The modal already fires `calypso_plan_upsell_modal_view` on mount, so we can measure how many people see it. However there was no click instrumentation, making it impossible to know which CTA users chose or whether they completed onboarding after interacting with the modal. This adds the missing click counterpart so the full funnel (view → click → onboarding completion) can be measured.

## Testing instructions

* Trigger the modal by selecting a paid custom domain during onboarding with a free plan
* Open the browser console and run `window._tkq` or use the Tracks Debugger extension
* Click each of the three CTAs and confirm `calypso_plan_upsell_modal_cta_click` fires with the correct properties:
  - "Get Personal" → `{ dialog_type: 'paid_plan_is_required', plan_slug: 'personal-bundle' }`
  - "Get Premium" → `{ dialog_type: 'paid_plan_is_required', plan_slug: 'value_bundle' }`
  - "Continue with Free plan" → `{ dialog_type: 'paid_plan_is_required', plan_slug: 'free' }`
* Repeat for the other dialog variants by temporarily hardcoding the `modalType` prop in `index.tsx` to `FREE_PLAN_PAID_DOMAIN_DIALOG` and `FREE_PLAN_FREE_DOMAIN_DIALOG`

## Pre-merge checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?