### PR TITLE
E2E: Test for Instagram iframe along with its fallback

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/instagram.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/instagram.ts
@@ -5,6 +5,13 @@ interface ConfigurationData {
 	expectedPostText: string;
 }
 
+const selectors = {
+	editorInstagramIframe: 'iframe[title="Embedded content from www.instagram.com"]',
+	publishedInstagramIframe: 'iframe.instagram-media-rendered',
+	publishedInstagramBlockquote:
+		'blockquote.instagram-media:has-text("View this post on Instagram")',
+};
+
 /**
  * Class representing the flow of using an Instagram block in the editor
  */
@@ -45,7 +52,7 @@ export class InstagramBlockFlow implements BlockFlow {
 			} )
 			.click();
 
-		await editorCanvas.getByTitle( 'Embedded content from www.instagram.com' ).waitFor();
+		await editorCanvas.locator( selectors.editorInstagramIframe ).waitFor();
 	}
 
 	/**
@@ -54,6 +61,13 @@ export class InstagramBlockFlow implements BlockFlow {
 	 * @param {PublishedPostContext} context The current context for the published post at the point of test execution
 	 */
 	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
-		await context.page.getByRole( 'figure' ).getByText( 'View this post on Instagram' ).waitFor();
+		const renderedIframeLocator = context.page
+			.locator( selectors.publishedInstagramIframe )
+			.first();
+		const bareBlockquoteLocator = context.page
+			.locator( selectors.publishedInstagramBlockquote )
+			.first();
+
+		await Promise.any( [ renderedIframeLocator.waitFor(), bareBlockquoteLocator.waitFor() ] );
 	}
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

It seems the test only expected to test the fallback, but often Instagram often embeds its iframe too quickly. This PR accounts for both scenarios.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

```
yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/blocks/blocks__core-jetpack-extended.ts"
```

You can test the non-iframe variant by applying this patch (it'll pause and you can scroll down to see the fallback):
```patch
diff --git a/packages/calypso-e2e/src/lib/blocks/block-flows/instagram.ts b/packages/calypso-e2e/src/lib/blocks/block-flows/instagram.ts                                                                                                    
index 196a07dd21f..6fe79d1a86c 100644                                                                                 
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/instagram.ts                                                    
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/instagram.ts                                                    
@@ -61,6 +61,11 @@ export class InstagramBlockFlow implements BlockFlow {                                             
         * @param {PublishedPostContext} context The current context for the published post at the point of test execution                                                                                                                  
         */                                                                                                           
        async validateAfterPublish( context: PublishedPostContext ): Promise< void > {                                
+               await context.page.route( '**/platform.instagram.com/**/embeds.js', ( route ) =>                      
+                       route.abort()                                                                                 
+               );                                                                                                    
+               await context.page.reload();                                                                          
+                                                                                                                     
                const renderedIframeLocator = context.page                                                            
                        .locator( selectors.publishedInstagramIframe )                                                
                        .first();                                                                                     
@@ -69,5 +74,6 @@ export class InstagramBlockFlow implements BlockFlow {
                        .first();
 
                await Promise.any( [ renderedIframeLocator.waitFor(), bareBlockquoteLocator.waitFor() ] );
+               await context.page.pause();
        }
 }
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?