### PR TITLE
e2e: Add error handling in Story block test

### DIFF
--- a/test/e2e/specs/blocks/blocks__story.ts
+++ b/test/e2e/specs/blocks/blocks__story.ts
@@ -7,6 +7,7 @@ import {
 	DataHelper,
 	MediaHelper,
 	EditorPage,
+	ElementHelper,
 	TestAccount,
 	StoryBlock,
 	envVariables,
@@ -72,7 +73,11 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Jetpack Story' ), function () {
 		// `getByRole('main')` resolves, which will fail with the Story
 		// block due to https://github.com/Automattic/jetpack/issues/32976.
 		const postURL = await editorPage.publish();
-		await page.goto( postURL.href );
+		await page.goto( postURL.href, { waitUntil: 'domcontentloaded' } );
+
+		await ElementHelper.reloadAndRetry( page, async function ( page: Page ): Promise< void > {
+			await page.locator( '.wp-story' ).waitFor();
+		} );
 	} );
 
 	it( 'Validate the published post', async function () {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

This test doesn't use the normal `editorPage.publish( { visit: true } )` logic, because something about the block breaks the `getByRole( 'main')` that uses.

Let's add in the reloadAndRetry logic that `visit: test` uses to try to handle some kinds of spurious errors.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Might help E2E reliability.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn workspace wp-e2e-tests build && CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME="desktop" ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/blocks/blocks__story.ts`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
