### PR TITLE
Signup: skip plugin install wait for new Commerce sites

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -140,7 +140,7 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 
 	const username = useSelector( getCurrentUserName );
 
-	const { setPendingAction } = useDispatch( ONBOARD_STORE );
+	const { setPendingAction, setIsNewSite } = useDispatch( ONBOARD_STORE );
 
 	// when it's empty, the default WordPress theme will be used.
 	let theme = '';
@@ -267,6 +267,8 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 		if ( ! site ) {
 			throw new Error( 'Failed to create site' );
 		}
+
+		setIsNewSite( true );
 
 		const additionalCartItems = [
 			...( planCartItem ? [ planCartItem ] : [] ),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
@@ -79,6 +79,11 @@ const PostCheckoutOnboarding: StepType< {
 
 	const isJetpackOrAtomic = isJetpack || isAtomic;
 
+	const isNewSite = useSelect(
+		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIsNewSite(),
+		[]
+	);
+
 	const {
 		isLoading: isLoadingMarketplaceThemeProducts,
 		isMarketplaceThemeSubscribed,
@@ -150,7 +155,7 @@ const PostCheckoutOnboarding: StepType< {
 					: {} ),
 			};
 
-			if ( ! isJetpackOrAtomic ) {
+			if ( ! isJetpackOrAtomic && ! isNewSite ) {
 				if ( siteTransferStatusData?.isTransferring ) {
 					await waitForAtomic();
 				} else if ( hasExternalTheme || shouldInstallPlugin ) {
@@ -180,6 +185,7 @@ const PostCheckoutOnboarding: StepType< {
 		isLoadingSiteTransferStatusData,
 		isLoadingExperiment,
 		isJetpackOrAtomic,
+		isNewSite,
 		siteTransferStatusData,
 		selectedDesign,
 		isMarketplaceThemeSubscribed,

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -377,6 +377,11 @@ export const setBlueprint = ( blueprint: string | null ) => ( {
 	blueprint,
 } );
 
+export const setIsNewSite = ( isNewSite: boolean ) => ( {
+	type: 'SET_IS_NEW_SITE' as const,
+	isNewSite,
+} );
+
 export type OnboardAction = ReturnType<
 	| typeof addFeature
 	| typeof removeFeature
@@ -439,4 +444,5 @@ export type OnboardAction = ReturnType<
 	| typeof setGardenName
 	| typeof setGardenPartnerName
 	| typeof setBlueprint
+	| typeof setIsNewSite
 >;

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -644,6 +644,16 @@ export const blueprint: Reducer< string | null, OnboardAction > = ( state = null
 	return state;
 };
 
+const isNewSite: Reducer< boolean, OnboardAction > = ( state = false, action ) => {
+	if ( action.type === 'SET_IS_NEW_SITE' ) {
+		return action.isNewSite;
+	}
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return false;
+	}
+	return state;
+};
+
 const reducer = combineReducers( {
 	domain,
 	domainCartItem,
@@ -695,6 +705,7 @@ const reducer = combineReducers( {
 	gardenName,
 	gardenPartnerName,
 	blueprint,
+	isNewSite,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -84,3 +84,4 @@ export const getPartnerBundle = ( state: State ) => state.partnerBundle;
 export const getGardenName = ( state: State ) => state.gardenName;
 export const getGardenPartnerName = ( state: State ) => state.gardenPartnerName;
 export const getBlueprint = ( state: State ) => state.blueprint;
+export const getIsNewSite = ( state: State ) => state.isNewSite;


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/RSM-763/

## Proposed changes

For brand new Commerce plan sites going through the `onboarding-unified` flow, skip the `waitForAtomic()` call in the post-checkout step and navigate directly to `/home` once checkout completes.

* Add `isNewSite: boolean` flag (action, reducer, selector) to the Onboard store in `@automattic/data-stores`
* Set `isNewSite = true` in the `create-site` step immediately after a site is successfully created
* In `post-checkout-onboarding`, read `isNewSite` from the store and skip `waitForAtomic()` when it is true

## Why are these changes being made?

The `onboarding-unified` post-checkout step calls `waitForAtomic()`, which polls until the Atomic transfer reaches `COMPLETED`. For a paid Commerce plan on a brand new site, this takes ~70 seconds: ~20s for WP Cloud to provision the site, then ~50s for WPCOM to run synchronous transfer operations (DB switcheroo, domain proxy setup, software install API call, cache refresh, etc.).

For a brand new site with no existing content, none of this needs to complete before the user sees useful UI. The Calypso `/home` page fetches site data from the WPCOM API and already handles in-progress transfers gracefully via `useCheckSiteTransferStatus` — it shows a transfer-in-progress banner and disables the WP Admin link until the site is ready. By skipping the wait, the user lands on `/home` near-instantly after checkout instead of staring at a loading screen for ~70 seconds.

The `isNewSite` flag is only set during the `create-site` step, so existing sites being transferred to Commerce (plan upgrades on an existing site) are unaffected — they continue to wait for `COMPLETED` as before.

## Testing instructions

Manual testing:
* Go through the paid Commerce plan checkout flow for a brand new site (via `onboarding-unified`). To do this, visit `/setup/onboarding-unified` and select the Commerce plan.
* Confirm the user is navigated to `/home` within a few seconds of checkout completing, instead of after ~70s
* Confirm a "site is being set up" / transfer-in-progress banner appears on `/home` while the transfer runs
* Confirm the WP Admin link is disabled or absent until the transfer completes
* Confirm WP Admin is fully accessible ~60–90s after landing on `/home`
* Confirm upgrading an existing site to Commerce still waits for the full transfer before navigating (`isNewSite` should be false for that path)