### PR TITLE
A4A: Include estimated transactions in WooPayments dashboard

### DIFF
--- a/client/a8c-for-agencies/sections/woopayments/lib/site-data.ts
+++ b/client/a8c-for-agencies/sections/woopayments/lib/site-data.ts
@@ -13,15 +13,19 @@ export const getSiteData = (
 ): WooPaymentsSiteData => {
 	const siteData = woopaymentsData?.data?.total?.sites?.[ siteId ];
 	const sitePayout = siteData?.payout ?? 0;
-	const siteTransactions = siteData?.transactions ?? 0;
+	const totalTransactions = siteData?.transactions ?? 0;
 
-	// Get estimated payout from current quarter
+	// Get estimated payout and transactions from current quarter
 	const currentQuarterEstimate =
 		woopaymentsData?.data?.estimated?.current_quarter?.sites?.[ siteId ]?.payout ?? 0;
+	const currentQuarterTransactions =
+		woopaymentsData?.data?.estimated?.current_quarter?.sites?.[ siteId ]?.transactions ?? 0;
 
-	// Get estimated payout from previous quarter
+	// Get estimated payout and transactions from previous quarter
 	const previousQuarterEstimate =
 		woopaymentsData?.data?.estimated?.previous_quarter?.sites?.[ siteId ]?.payout ?? 0;
+	const previousQuarterTransactions =
+		woopaymentsData?.data?.estimated?.previous_quarter?.sites?.[ siteId ]?.transactions ?? 0;
 
 	// If next and current payout dates are not equal, add previous quarter estimate
 	const now = new Date();
@@ -29,8 +33,16 @@ export const getSiteData = (
 		? currentQuarterEstimate
 		: currentQuarterEstimate + previousQuarterEstimate;
 
+	// Include estimated transactions from both quarters
+	const estimatedTransactions = areNextAndCurrentPayoutDatesEqual( now )
+		? currentQuarterTransactions
+		: currentQuarterTransactions + previousQuarterTransactions;
+
+	// Total transactions includes both completed and estimated transactions
+	const transactions = totalTransactions + estimatedTransactions;
+
 	return {
-		transactions: siteTransactions,
+		transactions,
 		payout: sitePayout,
 		estimatedPayout,
 	};

--- a/client/a8c-for-agencies/sections/woopayments/lib/site-data.ts
+++ b/client/a8c-for-agencies/sections/woopayments/lib/site-data.ts
@@ -29,12 +29,14 @@ export const getSiteData = (
 
 	// If next and current payout dates are not equal, add previous quarter estimate
 	const now = new Date();
-	const estimatedPayout = areNextAndCurrentPayoutDatesEqual( now )
+	const isCurrentQuarterOnly = areNextAndCurrentPayoutDatesEqual( now );
+
+	const estimatedPayout = isCurrentQuarterOnly
 		? currentQuarterEstimate
 		: currentQuarterEstimate + previousQuarterEstimate;
 
 	// Include estimated transactions from both quarters
-	const estimatedTransactions = areNextAndCurrentPayoutDatesEqual( now )
+	const estimatedTransactions = isCurrentQuarterOnly
 		? currentQuarterTransactions
 		: currentQuarterTransactions + previousQuarterTransactions;
 

--- a/client/a8c-for-agencies/sections/woopayments/lib/test/site-data.test.ts
+++ b/client/a8c-for-agencies/sections/woopayments/lib/test/site-data.test.ts
@@ -119,4 +119,54 @@ describe( 'getSiteData', () => {
 		expect( result.estimatedPayout ).toBe( 0 );
 		expect( result.payout ).toBe( 500 );
 	} );
+
+	it( 'returns estimated transactions even when completed transactions are zero (regression test)', () => {
+		jest.spyOn( payoutDateModule, 'areNextAndCurrentPayoutDatesEqual' ).mockReturnValue( false );
+
+		const newMerchantData: WooPaymentsData = {
+			...mockWooPaymentsData,
+			data: {
+				...mockWooPaymentsData.data,
+				total: {
+					...mockWooPaymentsData.data.total,
+					sites: {
+						456: {
+							payout: 0,
+							tpv: 32000,
+							transactions: 0,
+						},
+					},
+				},
+				estimated: {
+					...mockWooPaymentsData.data.estimated!,
+					current_quarter: {
+						...mockWooPaymentsData.data.estimated!.current_quarter,
+						sites: {
+							456: {
+								payout: 16,
+								tpv: 20000,
+								transactions: 25,
+							},
+						},
+					},
+					previous_quarter: {
+						...mockWooPaymentsData.data.estimated!.previous_quarter,
+						sites: {
+							456: {
+								payout: 6,
+								tpv: 12000,
+								transactions: 15,
+							},
+						},
+					},
+				},
+			},
+		};
+
+		const result = getSiteData( newMerchantData, 456 );
+
+		expect( result.transactions ).toBe( 40 ); // 0 (total) + 25 (current) + 15 (previous)
+		expect( result.estimatedPayout ).toBe( 22 ); // 16 (current) + 6 (previous)
+		expect( result.payout ).toBe( 0 );
+	} );
 } );

--- a/client/a8c-for-agencies/sections/woopayments/lib/test/site-data.test.ts
+++ b/client/a8c-for-agencies/sections/woopayments/lib/test/site-data.test.ts
@@ -1,0 +1,122 @@
+import * as payoutDateModule from '../../../referrals/lib/get-next-payout-date';
+import { getSiteData } from '../site-data';
+import type { WooPaymentsData } from '../../types';
+
+jest.mock( '../../../referrals/lib/get-next-payout-date' );
+
+describe( 'getSiteData', () => {
+	const mockWooPaymentsData: WooPaymentsData = {
+		data: {
+			total: {
+				payout: 1000,
+				tpv: 50000,
+				transactions: 200,
+				sites: {
+					123: {
+						payout: 500,
+						tpv: 25000,
+						transactions: 100,
+					},
+				},
+			},
+			estimated: {
+				payout: 300,
+				tpv: 15000,
+				transactions: 60,
+				current_quarter: {
+					payout: 200,
+					tpv: 10000,
+					transactions: 40,
+					sites: {
+						123: {
+							payout: 150,
+							tpv: 7500,
+							transactions: 30,
+						},
+					},
+				},
+				previous_quarter: {
+					payout: 100,
+					tpv: 5000,
+					transactions: 20,
+					sites: {
+						123: {
+							payout: 50,
+							tpv: 2500,
+							transactions: 10,
+						},
+					},
+				},
+			},
+			commission_eligible_sites: [ 123 ],
+			commission_ineligible_sites: [],
+		},
+		status: 'success',
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'includes only current quarter transactions when next and current payout dates are equal', () => {
+		jest.spyOn( payoutDateModule, 'areNextAndCurrentPayoutDatesEqual' ).mockReturnValue( true );
+
+		const result = getSiteData( mockWooPaymentsData, 123 );
+
+		expect( result.transactions ).toBe( 130 ); // 100 (total) + 30 (current quarter)
+		expect( result.estimatedPayout ).toBe( 150 ); // current quarter only
+		expect( result.payout ).toBe( 500 );
+	} );
+
+	it( 'includes both current and previous quarter transactions when payout dates differ', () => {
+		jest.spyOn( payoutDateModule, 'areNextAndCurrentPayoutDatesEqual' ).mockReturnValue( false );
+
+		const result = getSiteData( mockWooPaymentsData, 123 );
+
+		expect( result.transactions ).toBe( 140 ); // 100 (total) + 30 (current) + 10 (previous)
+		expect( result.estimatedPayout ).toBe( 200 ); // 150 (current) + 50 (previous)
+		expect( result.payout ).toBe( 500 );
+	} );
+
+	it( 'returns null transactions when site has no data', () => {
+		jest.spyOn( payoutDateModule, 'areNextAndCurrentPayoutDatesEqual' ).mockReturnValue( true );
+
+		const result = getSiteData( mockWooPaymentsData, 999 );
+
+		expect( result.transactions ).toBe( 0 );
+		expect( result.estimatedPayout ).toBe( 0 );
+		expect( result.payout ).toBe( 0 );
+	} );
+
+	it( 'handles missing estimated data gracefully', () => {
+		jest.spyOn( payoutDateModule, 'areNextAndCurrentPayoutDatesEqual' ).mockReturnValue( true );
+
+		const dataWithoutEstimates: WooPaymentsData = {
+			...mockWooPaymentsData,
+			data: {
+				...mockWooPaymentsData.data,
+				estimated: {
+					payout: 0,
+					tpv: 0,
+					transactions: 0,
+					current_quarter: {
+						payout: 0,
+						tpv: 0,
+						transactions: 0,
+					},
+					previous_quarter: {
+						payout: 0,
+						tpv: 0,
+						transactions: 0,
+					},
+				},
+			},
+		};
+
+		const result = getSiteData( dataWithoutEstimates, 123 );
+
+		expect( result.transactions ).toBe( 100 ); // Only total transactions
+		expect( result.estimatedPayout ).toBe( 0 );
+		expect( result.payout ).toBe( 500 );
+	} );
+} );

--- a/client/a8c-for-agencies/sections/woopayments/lib/test/site-data.test.ts
+++ b/client/a8c-for-agencies/sections/woopayments/lib/test/site-data.test.ts
@@ -128,7 +128,9 @@ describe( 'getSiteData', () => {
 			data: {
 				...mockWooPaymentsData.data,
 				total: {
-					...mockWooPaymentsData.data.total,
+					payout: 1000,
+					tpv: 50000,
+					transactions: 200,
 					sites: {
 						456: {
 							payout: 0,
@@ -138,9 +140,13 @@ describe( 'getSiteData', () => {
 					},
 				},
 				estimated: {
-					...mockWooPaymentsData.data.estimated!,
+					payout: 300,
+					tpv: 15000,
+					transactions: 60,
 					current_quarter: {
-						...mockWooPaymentsData.data.estimated!.current_quarter,
+						payout: 200,
+						tpv: 10000,
+						transactions: 40,
 						sites: {
 							456: {
 								payout: 16,
@@ -150,7 +156,9 @@ describe( 'getSiteData', () => {
 						},
 					},
 					previous_quarter: {
-						...mockWooPaymentsData.data.estimated!.previous_quarter,
+						payout: 100,
+						tpv: 5000,
+						transactions: 20,
 						sites: {
 							456: {
 								payout: 6,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Part of A4A-1511

## Proposed Changes

* Updated `getSiteData` function to include estimated/pending transactions from current and previous quarters
* Transaction count now shows total of completed transactions plus estimated transactions, matching the pattern used for estimated payouts

## Why are these changes being made?

The WooPayments commission eligibility dashboard was only showing completed transactions in the "Transactions" column. For sites with pending transactions (transactions that haven't been paid out yet), this caused the column to incorrectly display 0 transactions even though the site had significant TPV and estimated commissions.

This was particularly problematic for the case mentioned in the Slack thread where a store with ~$32k TPV was showing 0 transactions, causing confusion about whether the data was being tracked correctly.

The fix ensures that the transactions column includes both:
- Completed transactions from `data.total.sites[siteId].transactions`
- Estimated/pending transactions from `data.estimated.current_quarter.sites[siteId].transactions` and `data.estimated.previous_quarter.sites[siteId].transactions`

This matches the same logic pattern already used for calculating estimated payouts.

## Testing Instructions

1. Navigate to the WooPayments commissions dashboard in A4A
2. Find a site that is a new merchant with recent transactions that haven't been paid out yet
3. Verify that the "Transactions" column now shows a non-zero value that includes both completed and estimated transactions
4. Compare with the "Timeframe Commissions" column to ensure the transaction count aligns with the estimated commission amount

<img width="1918" height="870" alt="Screenshot 2026-04-23 at 4 06 09 PM" src="https://github.com/user-attachments/assets/89fef666-abfa-4979-9f9f-17540f4ea129" />


### Before
Sites with only pending/estimated transactions would show 0 in the Transactions column

### After
Sites with pending/estimated transactions now show the total count including estimated transactions

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
<!-- CURSOR_AGENT_PR_BODY_END -->

p1775143967993449/1775143967.993449-slack-C091P0A65U5