### PR TITLE
WIP: Exploration for adding Caturday as a writing prompt

### DIFF
--- a/client/components/blogging-prompt-card/caturday-card.jsx
+++ b/client/components/blogging-prompt-card/caturday-card.jsx
@@ -1,0 +1,47 @@
+import { Card, Button } from '@automattic/components';
+import { addQueryArgs } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import CardHeading from 'calypso/components/card-heading';
+import getEditorUrl from 'calypso/state/selectors/get-editor-url';
+import LightbulbIcon from './lightbulb-icon';
+
+const CATURDAY_PROMPT_ID = 1917;
+const CAT_IMAGE_URL = 'https://wpcom.files.wordpress.com/2026/04/cat-1.png';
+
+const CaturdayCard = ( { siteId } ) => {
+	const translate = useTranslate();
+	const editorUrl = useSelector( ( state ) => getEditorUrl( state, siteId ) );
+	const newPostLink = addQueryArgs( siteId ? editorUrl : '/post', {
+		answer_prompt: CATURDAY_PROMPT_ID,
+	} );
+
+	return (
+		<Card className="blogging-prompt__card caturday-prompt__card customer-home__card is-small-hero">
+			<div className="blogging-prompt__prompt-container">
+				<CardHeading>
+					<LightbulbIcon />
+					<span className="blogging-prompt__heading-text" key="caturday-heading-text">
+						{ translate( "It's Caturday!" ) }
+					</span>
+				</CardHeading>
+				<div className="caturday-prompt__body">
+					<div className="caturday-prompt__content">
+						<p className="blogging-prompt__prompt-text">{ translate( 'Post a cat photo' ) }</p>
+						<div className="blogging-prompt__prompt-answers">
+							<Button href={ newPostLink } className="blogging-prompt__new-post-link">
+								{ translate( 'Post Answer', {
+									comment:
+										'"Post" here is a verb meaning "to publish", as in "post an answer to this writing prompt"',
+								} ) }
+							</Button>
+						</div>
+					</div>
+					<img className="caturday-prompt__cat-image" src={ CAT_IMAGE_URL } alt="" />
+				</div>
+			</div>
+		</Card>
+	);
+};
+
+export default CaturdayCard;

--- a/client/components/blogging-prompt-card/index.jsx
+++ b/client/components/blogging-prompt-card/index.jsx
@@ -5,6 +5,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import isBloganuary from 'calypso/data/blogging-prompt/is-bloganuary';
+import isCaturday from 'calypso/data/blogging-prompt/is-caturday';
 import {
 	useAIBloggingPrompts,
 	mergePromptStreams,
@@ -18,6 +19,7 @@ import {
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getSiteSlug from 'calypso/state/sites/selectors/get-site-slug';
 import BellOffIcon from './bell-off-icon';
+import CaturdayCard from './caturday-card';
 import PromptsNavigation from './prompts-navigation';
 
 import './style.scss';
@@ -99,8 +101,10 @@ const BloggingPromptCard = ( { siteId, viewContext, showMenu, index } ) => {
 		);
 	};
 
+	const showCaturday = isCaturday();
+
 	return (
-		<div className="blogging-prompt">
+		<div className={ clsx( 'blogging-prompt', { 'blogging-prompt--caturday-row': showCaturday } ) }>
 			<Card
 				className={ clsx( 'blogging-prompt__card', {
 					'customer-home__card is-small-hero': viewContext === 'home',
@@ -114,6 +118,7 @@ const BloggingPromptCard = ( { siteId, viewContext, showMenu, index } ) => {
 					menu={ renderMenu() }
 				/>
 			</Card>
+			{ showCaturday && <CaturdayCard siteId={ siteId } /> }
 		</div>
 	);
 };

--- a/client/components/blogging-prompt-card/style.scss
+++ b/client/components/blogging-prompt-card/style.scss
@@ -137,6 +137,39 @@
 			display: none;
 		}
 	}
+	/* Caturday Card ------------------------ */
+	&--caturday-row {
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+
+		.blogging-prompt__card,
+		.caturday-prompt__card {
+			margin-bottom: 0;
+		}
+	}
+
+	.caturday-prompt__card {
+		.caturday-prompt__body {
+			display: flex;
+			align-items: flex-end;
+			gap: 12px;
+		}
+
+		.caturday-prompt__content {
+			flex: 1;
+		}
+
+		.caturday-prompt__cat-image {
+			flex-shrink: 0;
+			height: 120px;
+			margin-block-end: -24px;
+			margin-inline-end: -24px;
+			object-fit: contain;
+			width: auto;
+		}
+	}
+
 	/* Blogging Prompt Menu ------------------------ */
 	.blogging-prompt__menu {
 		.button {

--- a/client/data/blogging-prompt/is-caturday.ts
+++ b/client/data/blogging-prompt/is-caturday.ts
@@ -1,0 +1,3 @@
+export default function isCaturday() {
+	return true || new Date().getDay() === 6;
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes
This is exploration, I don't have design yet, and the Caturday writing prompt is not added to the backend.

<img width="938" height="508" alt="Screenshot 2026-04-23 at 15 02 58" src="https://github.com/user-attachments/assets/01e252a9-579a-4947-8c7c-e2537f96eaaa" />

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
