### PR TITLE
Reader: Add achievement settings and visibility controls

### DIFF
--- a/client/data/reader/use-trophies-query.ts
+++ b/client/data/reader/use-trophies-query.ts
@@ -8,17 +8,18 @@ export function useTrophiesQuery() {
 		staleTime: 10 * 60 * 1000, // 10 minutes
 	} );
 
-	const { hasNextPage, isFetchingNextPage, fetchNextPage } = query;
+	const { hasNextPage, isFetchingNextPage, isError, fetchNextPage } = query;
 
 	useEffect( () => {
-		if ( hasNextPage && ! isFetchingNextPage ) {
+		if ( hasNextPage && ! isFetchingNextPage && ! isError ) {
 			fetchNextPage();
 		}
-	}, [ hasNextPage, isFetchingNextPage, fetchNextPage ] );
+	}, [ hasNextPage, isFetchingNextPage, isError, fetchNextPage ] );
 
 	return {
 		trophies: query.data?.pages.flatMap( ( p ) => p.trophies ?? [] ) ?? [],
 		found: query.data?.pages[ 0 ]?.found ?? 0,
-		isLoading: query.isLoading || hasNextPage,
+		isLoading: ( query.isLoading || hasNextPage ) && ! isError,
+		isError,
 	};
 }

--- a/client/data/reader/use-trophies-query.ts
+++ b/client/data/reader/use-trophies-query.ts
@@ -3,7 +3,10 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import { useEffect } from 'react';
 
 export function useTrophiesQuery() {
-	const query = useInfiniteQuery( trophiesQuery() );
+	const query = useInfiniteQuery( {
+		...trophiesQuery(),
+		staleTime: 10 * 60 * 1000, // 10 minutes
+	} );
 
 	const { hasNextPage, isFetchingNextPage, fetchNextPage } = query;
 
@@ -16,6 +19,6 @@ export function useTrophiesQuery() {
 	return {
 		trophies: query.data?.pages.flatMap( ( p ) => p.trophies ?? [] ) ?? [],
 		found: query.data?.pages[ 0 ]?.found ?? 0,
-		isLoading: query.isLoading,
+		isLoading: query.isLoading || hasNextPage,
 	};
 }

--- a/client/reader/user-profile/components/user-profile-header/index.tsx
+++ b/client/reader/user-profile/components/user-profile-header/index.tsx
@@ -10,6 +10,7 @@ import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import { getUserProfileUrl } from 'calypso/reader/user-profile/user-profile.utils';
+import { useAchievementsVisibility } from 'calypso/reader/user-profile/views/achievements/use-achievements-visibility';
 import UserTopSites from '../top-sites';
 import type { ReaderUser } from '@automattic/api-core';
 
@@ -20,6 +21,7 @@ interface UserProfileHeaderProps {
 
 const UserProfileHeader = ( { user, view }: UserProfileHeaderProps ): JSX.Element => {
 	const translate = useTranslate();
+	const { isVisible: showAchievements } = useAchievementsVisibility( user.user_login );
 	const [ isExpanded, setIsExpanded ] = useState( false );
 	const [ showMoreToggle, setShowMoreToggle ] = useState( false );
 	const bioRef = useRef< HTMLParagraphElement >( null );
@@ -58,7 +60,7 @@ const UserProfileHeader = ( { user, view }: UserProfileHeaderProps ): JSX.Elemen
 			path: `${ userProfileUrl }/recommended-blogs`,
 			selected: view === 'recommended-blogs',
 		},
-		...( isEnabled( 'reader/achievements' )
+		...( isEnabled( 'reader/achievements' ) && showAchievements
 			? [
 					{
 						label: translate( 'Achievements' ),

--- a/client/reader/user-profile/components/user-profile-header/test/index.test.tsx
+++ b/client/reader/user-profile/components/user-profile-header/test/index.test.tsx
@@ -36,6 +36,10 @@ jest.mock( '@automattic/calypso-config', () => ( {
 	isEnabled: jest.fn(),
 } ) );
 
+jest.mock( 'calypso/reader/user-profile/views/achievements/use-achievements-visibility', () => ( {
+	useAchievementsVisibility: () => ( { isOwnProfile: true, isVisible: true } ),
+} ) );
+
 const mockIsEnabled = isEnabled as jest.MockedFunction< typeof isEnabled >;
 
 describe( 'UserProfileHeader', () => {

--- a/client/reader/user-profile/index.tsx
+++ b/client/reader/user-profile/index.tsx
@@ -65,7 +65,7 @@ export function UserProfile( props: UserProfileProps ): JSX.Element | null {
 			case 'recommended-blogs':
 				return <UserRecommendedBlogs user={ user } />;
 			case 'achievements':
-				return <UserAchievements />;
+				return <UserAchievements user={ user } />;
 			default:
 				return null;
 		}

--- a/client/reader/user-profile/views/achievements/achievements-settings/index.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-settings/index.tsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation } from '@tanstack/react-query';
 import { Button, Dropdown, ToggleControl } from '@wordpress/components';
 import { settings } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { useState, useEffect } from 'react';
 import { recordAction } from 'calypso/reader/stats';
 import { useDispatch } from 'calypso/state';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
@@ -15,9 +16,21 @@ export default function AchievementsSettings() {
 	const translate = useTranslate();
 	const recordReaderTracksEvent = useRecordReaderTracksEvent();
 
-	const { data: isPublic } = useQuery( userPreferenceQuery( 'achievements-page-public' ) );
-	const { data: notificationsEnabled } = useQuery(
+	const { data: savedIsPublic } = useQuery( userPreferenceQuery( 'achievements-page-public' ) );
+	const { data: savedNotifications } = useQuery(
 		userPreferenceQuery( 'achievements-notifications-enabled' )
+	);
+
+	const [ isPublic, setIsPublic ] = useState( !! savedIsPublic );
+	const [ notificationsEnabled, setNotificationsEnabled ] = useState(
+		savedNotifications !== false
+	);
+
+	// Sync local state when server data changes (e.g. on initial load).
+	useEffect( () => setIsPublic( !! savedIsPublic ), [ savedIsPublic ] );
+	useEffect(
+		() => setNotificationsEnabled( savedNotifications !== false ),
+		[ savedNotifications ]
 	);
 
 	const { mutate: setPublic, isPending: isSetPublicPending } = useMutation(
@@ -45,6 +58,7 @@ export default function AchievementsSettings() {
 	const handleSetPublic = ( value: boolean ) => {
 		setPublic( value, {
 			onSuccess( _, data ) {
+				setIsPublic( data );
 				if ( data ) {
 					dispatchSuccessNotice( translate( 'The achievements page is now public.' ) );
 					recordAction( 'set_achievements_page_public' );
@@ -70,6 +84,7 @@ export default function AchievementsSettings() {
 	const handleSetNotifications = ( value: boolean ) => {
 		setNotifications( value, {
 			onSuccess( _, data ) {
+				setNotificationsEnabled( data );
 				if ( data ) {
 					dispatchSuccessNotice( translate( 'Achievements notifications are now enabled.' ) );
 					recordAction( 'set_achievements_notifications_enabled' );
@@ -114,14 +129,14 @@ export default function AchievementsSettings() {
 			renderContent={ () => (
 				<div className="achievements-settings__content">
 					<ToggleControl
-						checked={ !! isPublic }
+						checked={ isPublic }
 						disabled={ isSetPublicPending }
 						onChange={ handleSetPublic }
 						label={ translate( 'Public achievements' ) }
 						help={ translate( 'When enabled, your achievements page is visible to other users.' ) }
 					/>
 					<ToggleControl
-						checked={ notificationsEnabled !== false }
+						checked={ notificationsEnabled }
 						disabled={ isSetNotificationsPending }
 						onChange={ handleSetNotifications }
 						label={ translate( 'Achievement notifications' ) }

--- a/client/reader/user-profile/views/achievements/achievements-settings/index.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-settings/index.tsx
@@ -3,23 +3,96 @@ import { useQuery, useMutation } from '@tanstack/react-query';
 import { Button, Dropdown, ToggleControl } from '@wordpress/components';
 import { settings } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { recordAction } from 'calypso/reader/stats';
+import { useDispatch } from 'calypso/state';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRecordReaderTracksEvent';
 
 import './style.scss';
 
 export default function AchievementsSettings() {
+	const dispatch = useDispatch();
 	const translate = useTranslate();
+	const recordReaderTracksEvent = useRecordReaderTracksEvent();
 
 	const { data: isPublic } = useQuery( userPreferenceQuery( 'achievements-page-public' ) );
 	const { data: notificationsEnabled } = useQuery(
 		userPreferenceQuery( 'achievements-notifications-enabled' )
 	);
 
-	const { mutate: setPublic } = useMutation(
+	const { mutate: setPublic, isPending: isSetPublicPending } = useMutation(
 		userPreferenceOptimisticMutation( 'achievements-page-public' )
 	);
-	const { mutate: setNotifications } = useMutation(
+	const { mutate: setNotifications, isPending: isSetNotificationsPending } = useMutation(
 		userPreferenceOptimisticMutation( 'achievements-notifications-enabled' )
 	);
+
+	const dispatchSuccessNotice = ( message: string ) => {
+		dispatch(
+			successNotice( message, {
+				duration: 4000,
+			} )
+		);
+	};
+	const dispatchErrorNotice = ( message: string ) => {
+		dispatch(
+			errorNotice( message, {
+				duration: 4000,
+			} )
+		);
+	};
+
+	const handleSetPublic = ( value: boolean ) => {
+		setPublic( value, {
+			onSuccess( _, data ) {
+				if ( data ) {
+					dispatchSuccessNotice( translate( 'The achievements page is now public.' ) );
+					recordAction( 'set_achievements_page_public' );
+					recordReaderTracksEvent( 'calypso_reader_achievements_settings', {
+						setting: 'achievements-page-visibility',
+						value: 'public',
+					} );
+				} else {
+					dispatchSuccessNotice( translate( 'The achievements page is now private.' ) );
+					recordAction( 'set_achievements_page_private' );
+					recordReaderTracksEvent( 'calypso_reader_achievements_settings', {
+						setting: 'achievements-page-visibility',
+						value: 'private',
+					} );
+				}
+			},
+			onError() {
+				dispatchErrorNotice( translate( 'Failed to save the achievements page settings.' ) );
+			},
+		} );
+	};
+
+	const handleSetNotifications = ( value: boolean ) => {
+		setNotifications( value, {
+			onSuccess( _, data ) {
+				if ( data ) {
+					dispatchSuccessNotice( translate( 'Achievements notifications are now enabled.' ) );
+					recordAction( 'set_achievements_notifications_enabled' );
+					recordReaderTracksEvent( 'calypso_reader_achievements_settings', {
+						setting: 'achievements-notifications',
+						value: 'enabled',
+					} );
+				} else {
+					dispatchSuccessNotice( translate( 'Achievements notifications are now disabled.' ) );
+					recordAction( 'set_achievements_notifications_disabled' );
+					recordReaderTracksEvent( 'calypso_reader_achievements_settings', {
+						setting: 'achievements-notifications',
+						value: 'disabled',
+					} );
+				}
+			},
+			onError() {
+				dispatchErrorNotice(
+					translate( 'Failed to save the achievements notifications settings.' )
+				);
+			},
+		} );
+	};
 
 	return (
 		<Dropdown
@@ -42,13 +115,15 @@ export default function AchievementsSettings() {
 				<div className="achievements-settings__content">
 					<ToggleControl
 						checked={ !! isPublic }
-						onChange={ ( value ) => setPublic( value ) }
+						disabled={ isSetPublicPending }
+						onChange={ handleSetPublic }
 						label={ translate( 'Public achievements' ) }
 						help={ translate( 'When enabled, your achievements page is visible to other users.' ) }
 					/>
 					<ToggleControl
 						checked={ notificationsEnabled !== false }
-						onChange={ ( value ) => setNotifications( value ) }
+						disabled={ isSetNotificationsPending }
+						onChange={ handleSetNotifications }
 						label={ translate( 'Achievement notifications' ) }
 						help={ translate(
 							'Receive notifications when you unlock new achievements. This overrides {{a}}site-level settings{{/a}}.',

--- a/client/reader/user-profile/views/achievements/achievements-settings/index.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-settings/index.tsx
@@ -62,14 +62,14 @@ export default function AchievementsSettings() {
 				if ( data ) {
 					dispatchSuccessNotice( translate( 'The achievements page is now public.' ) );
 					recordAction( 'set_achievements_page_public' );
-					recordReaderTracksEvent( 'calypso_reader_achievements_settings', {
+					recordReaderTracksEvent( 'calypso_reader_achievements_settings_saved', {
 						setting: 'achievements-page-visibility',
 						value: 'public',
 					} );
 				} else {
 					dispatchSuccessNotice( translate( 'The achievements page is now private.' ) );
 					recordAction( 'set_achievements_page_private' );
-					recordReaderTracksEvent( 'calypso_reader_achievements_settings', {
+					recordReaderTracksEvent( 'calypso_reader_achievements_settings_saved', {
 						setting: 'achievements-page-visibility',
 						value: 'private',
 					} );
@@ -88,14 +88,14 @@ export default function AchievementsSettings() {
 				if ( data ) {
 					dispatchSuccessNotice( translate( 'Achievements notifications are now enabled.' ) );
 					recordAction( 'set_achievements_notifications_enabled' );
-					recordReaderTracksEvent( 'calypso_reader_achievements_settings', {
+					recordReaderTracksEvent( 'calypso_reader_achievements_settings_saved', {
 						setting: 'achievements-notifications',
 						value: 'enabled',
 					} );
 				} else {
 					dispatchSuccessNotice( translate( 'Achievements notifications are now disabled.' ) );
 					recordAction( 'set_achievements_notifications_disabled' );
-					recordReaderTracksEvent( 'calypso_reader_achievements_settings', {
+					recordReaderTracksEvent( 'calypso_reader_achievements_settings_saved', {
 						setting: 'achievements-notifications',
 						value: 'disabled',
 					} );
@@ -120,7 +120,13 @@ export default function AchievementsSettings() {
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<Button
 					className="achievements-settings__button"
-					onClick={ onToggle }
+					onClick={ () => {
+						if ( ! isOpen ) {
+							recordAction( 'open_achievements_settings_popover' );
+							recordReaderTracksEvent( 'calypso_reader_achievements_settings_popover_opened' );
+						}
+						onToggle();
+					} }
 					aria-expanded={ isOpen }
 					icon={ settings }
 					label={ translate( 'Achievement settings' ) }

--- a/client/reader/user-profile/views/achievements/achievements-settings/index.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-settings/index.tsx
@@ -58,7 +58,7 @@ export default function AchievementsSettings() {
 	const handleSetPublic = ( value: boolean ) => {
 		setPublic( value, {
 			onSuccess( _, data ) {
-				setIsPublic( data );
+				setIsPublic( !! data );
 				if ( data ) {
 					dispatchSuccessNotice( translate( 'The achievements page is now public.' ) );
 					recordAction( 'set_achievements_page_public' );
@@ -84,7 +84,7 @@ export default function AchievementsSettings() {
 	const handleSetNotifications = ( value: boolean ) => {
 		setNotifications( value, {
 			onSuccess( _, data ) {
-				setNotificationsEnabled( data );
+				setNotificationsEnabled( !! data );
 				if ( data ) {
 					dispatchSuccessNotice( translate( 'Achievements notifications are now enabled.' ) );
 					recordAction( 'set_achievements_notifications_enabled' );

--- a/client/reader/user-profile/views/achievements/achievements-settings/index.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-settings/index.tsx
@@ -1,0 +1,66 @@
+import { userPreferenceQuery, userPreferenceOptimisticMutation } from '@automattic/api-queries';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { Button, Dropdown, ToggleControl } from '@wordpress/components';
+import { settings } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+
+import './style.scss';
+
+export default function AchievementsSettings() {
+	const translate = useTranslate();
+
+	const { data: isPublic } = useQuery( userPreferenceQuery( 'achievements-page-public' ) );
+	const { data: notificationsEnabled } = useQuery(
+		userPreferenceQuery( 'achievements-notifications-enabled' )
+	);
+
+	const { mutate: setPublic } = useMutation(
+		userPreferenceOptimisticMutation( 'achievements-page-public' )
+	);
+	const { mutate: setNotifications } = useMutation(
+		userPreferenceOptimisticMutation( 'achievements-notifications-enabled' )
+	);
+
+	return (
+		<Dropdown
+			popoverProps={ {
+				className: 'achievements-settings__popover',
+				placement: 'bottom-end',
+				offset: 8,
+				noArrow: false,
+			} }
+			renderToggle={ ( { isOpen, onToggle } ) => (
+				<Button
+					className="achievements-settings__button"
+					onClick={ onToggle }
+					aria-expanded={ isOpen }
+					icon={ settings }
+					label={ translate( 'Achievement settings' ) }
+				/>
+			) }
+			renderContent={ () => (
+				<div className="achievements-settings__content">
+					<ToggleControl
+						checked={ !! isPublic }
+						onChange={ ( value ) => setPublic( value ) }
+						label={ translate( 'Public achievements' ) }
+						help={ translate( 'When enabled, your achievements page is visible to other users.' ) }
+					/>
+					<ToggleControl
+						checked={ notificationsEnabled !== false }
+						onChange={ ( value ) => setNotifications( value ) }
+						label={ translate( 'Achievement notifications' ) }
+						help={ translate(
+							'Receive notifications when you unlock new achievements. This overrides {{a}}site-level settings{{/a}}.',
+							{
+								components: {
+									a: <a href="/me/notifications" />,
+								},
+							}
+						) }
+					/>
+				</div>
+			) }
+		/>
+	);
+}

--- a/client/reader/user-profile/views/achievements/achievements-settings/style.scss
+++ b/client/reader/user-profile/views/achievements/achievements-settings/style.scss
@@ -1,0 +1,10 @@
+.achievements-settings__popover {
+	.achievements-settings__content {
+		padding: 16px;
+		min-width: 300px;
+	}
+
+	.components-toggle-control + .components-toggle-control {
+		margin-top: 16px;
+	}
+}

--- a/client/reader/user-profile/views/achievements/index.tsx
+++ b/client/reader/user-profile/views/achievements/index.tsx
@@ -1,12 +1,22 @@
 import { isEnabled } from '@automattic/calypso-config';
 import AchievementsGrid from './achievements-grid';
+import AchievementsSettings from './achievements-settings';
+
+import './style.scss';
 
 const UserAchievements = (): JSX.Element | null => {
 	if ( ! isEnabled( 'reader/achievements' ) ) {
 		return null;
 	}
 
-	return <AchievementsGrid />;
+	return (
+		<div className="achievements">
+			<div className="achievements__header">
+				<AchievementsSettings />
+			</div>
+			<AchievementsGrid />
+		</div>
+	);
 };
 
 export default UserAchievements;

--- a/client/reader/user-profile/views/achievements/index.tsx
+++ b/client/reader/user-profile/views/achievements/index.tsx
@@ -1,19 +1,25 @@
 import { isEnabled } from '@automattic/calypso-config';
 import AchievementsGrid from './achievements-grid';
 import AchievementsSettings from './achievements-settings';
+import { useAchievementsVisibility } from './use-achievements-visibility';
+import type { ReaderUser } from '@automattic/api-core';
 
 import './style.scss';
 
-const UserAchievements = (): JSX.Element | null => {
-	if ( ! isEnabled( 'reader/achievements' ) ) {
+interface UserAchievementsProps {
+	user: ReaderUser;
+}
+
+const UserAchievements = ( { user }: UserAchievementsProps ): JSX.Element | null => {
+	const { isOwnProfile, isVisible } = useAchievementsVisibility( user.user_login );
+
+	if ( ! isEnabled( 'reader/achievements' ) || ! isVisible ) {
 		return null;
 	}
 
 	return (
 		<div className="achievements">
-			<div className="achievements__header">
-				<AchievementsSettings />
-			</div>
+			<div className="achievements__header">{ isOwnProfile && <AchievementsSettings /> }</div>
 			<AchievementsGrid />
 		</div>
 	);

--- a/client/reader/user-profile/views/achievements/style.scss
+++ b/client/reader/user-profile/views/achievements/style.scss
@@ -1,0 +1,8 @@
+.is-reader-page {
+	.achievements__header {
+		display: flex;
+		align-items: center;
+		justify-content: flex-end;
+		margin: 16px 0;
+	}
+}

--- a/client/reader/user-profile/views/achievements/test/index.test.tsx
+++ b/client/reader/user-profile/views/achievements/test/index.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment jsdom
+ */
+import { isEnabled } from '@automattic/calypso-config';
+import { render, screen } from '@testing-library/react';
+import UserAchievements from '../index';
+import type { ReaderUser } from '@automattic/api-core';
+
+jest.mock( '@automattic/calypso-config', () => ( {
+	isEnabled: jest.fn(),
+} ) );
+
+jest.mock( '../use-achievements-visibility' );
+
+jest.mock( '../achievements-grid', () => ( {
+	__esModule: true,
+	default: () => <div data-testid="achievements-grid" />,
+} ) );
+
+jest.mock( '../achievements-settings', () => ( {
+	__esModule: true,
+	default: () => <button data-testid="achievements-settings">Settings</button>,
+} ) );
+
+const mockIsEnabled = isEnabled as jest.MockedFunction< typeof isEnabled >;
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { useAchievementsVisibility } = require( '../use-achievements-visibility' ) as {
+	useAchievementsVisibility: jest.Mock;
+};
+
+describe( 'UserAchievements', () => {
+	const defaultUser: ReaderUser = {
+		ID: 123,
+		user_login: 'test_user',
+		nice_name: 'nice_name',
+		first_name: 'First',
+		last_name: 'Last',
+		display_name: 'Test User',
+		avatar_URL: 'https://example.com/avatar.jpg',
+		profile_URL: '',
+		description: '',
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockIsEnabled.mockReturnValue( true );
+	} );
+
+	test( 'should render nothing when feature flag is disabled', () => {
+		mockIsEnabled.mockReturnValue( false );
+		useAchievementsVisibility.mockReturnValue( { isOwnProfile: true, isVisible: true } );
+
+		const { container } = render( <UserAchievements user={ defaultUser } /> );
+
+		expect( container.innerHTML ).toBe( '' );
+	} );
+
+	test( 'should render nothing when achievements are not visible', () => {
+		useAchievementsVisibility.mockReturnValue( { isOwnProfile: false, isVisible: false } );
+
+		const { container } = render( <UserAchievements user={ defaultUser } /> );
+
+		expect( container.innerHTML ).toBe( '' );
+	} );
+
+	test( 'should render achievements grid when visible', () => {
+		useAchievementsVisibility.mockReturnValue( { isOwnProfile: true, isVisible: true } );
+
+		render( <UserAchievements user={ defaultUser } /> );
+
+		expect( screen.getByTestId( 'achievements-grid' ) ).toBeVisible();
+	} );
+
+	test( 'should show settings button on own profile', () => {
+		useAchievementsVisibility.mockReturnValue( { isOwnProfile: true, isVisible: true } );
+
+		render( <UserAchievements user={ defaultUser } /> );
+
+		expect( screen.getByTestId( 'achievements-settings' ) ).toBeVisible();
+	} );
+
+	test( 'should not show settings button on other user profile', () => {
+		useAchievementsVisibility.mockReturnValue( { isOwnProfile: false, isVisible: true } );
+
+		render( <UserAchievements user={ defaultUser } /> );
+
+		expect( screen.getByTestId( 'achievements-grid' ) ).toBeVisible();
+		expect( screen.queryByTestId( 'achievements-settings' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/reader/user-profile/views/achievements/use-achievements-visibility.ts
+++ b/client/reader/user-profile/views/achievements/use-achievements-visibility.ts
@@ -1,0 +1,14 @@
+import { useSelector } from 'calypso/state';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+
+export function useAchievementsVisibility( profileUserLogin?: string ) {
+	const currentUser = useSelector( getCurrentUser );
+	const isOwnProfile = currentUser?.username === profileUserLogin;
+
+	// The achievements page is only visible to the profile owner for now.
+	// Public visibility will require a server-side check once a public API exists.
+	return {
+		isOwnProfile,
+		isVisible: isOwnProfile,
+	};
+}

--- a/packages/api-core/src/me-preferences/types.ts
+++ b/packages/api-core/src/me-preferences/types.ts
@@ -31,4 +31,6 @@ export interface UserPreferences {
 	'sites-landing-page'?: SitesLandingPage;
 	[ key: `cancel-purchase-survey-completed-${ string | number }` ]: string | undefined;
 	[ key: `cancellation-offer-accepted-notice-dismissed-${ string | number }` ]: string | undefined;
+	'achievements-page-public'?: boolean;
+	'achievements-notifications-enabled'?: boolean;
 }

--- a/packages/api-queries/src/me-preferences.ts
+++ b/packages/api-queries/src/me-preferences.ts
@@ -16,6 +16,8 @@ const defaultValues: Required< UserPreferences > = {
 		useSitesAsLandingPage: false,
 		updatedAt: 0,
 	},
+	'achievements-page-public': false,
+	'achievements-notifications-enabled': true,
 };
 
 // Returns all user preferences, without applying any defaults.


### PR DESCRIPTION
Fixes RSM-397

## Proposed Changes

- Add a settings dropdown to the achievements page header with two toggles persisted via `/me/preferences`:
  - **Public achievements** (opt-in, private by default).
  - **Achievement notifications** (enabled by default, overrides site-level settings with link to `/me/notifications`).
- Gate achievements page and tab visibility to the profile owner using a shared `useAchievementsVisibility` hook.
- Only show the settings button on own profile.
- Also: fix loading spinner to wait for all trophy pages before rendering, and set 10-minute stale time on trophies query to avoid unnecessary re-fetching.

<img width="336" height="262" alt="Screenshot 2026-04-23 at 15 56 16" src="https://github.com/user-attachments/assets/2ec98cad-7fb5-4042-b29c-27d6e830a418" />

## Why are these changes being made?

Users need controls over their achievements page privacy and notification preferences. The page should only be visible to the profile owner until a public API exists for cross-user visibility.

## Testing Instructions

- Enable the `reader/achievements` feature flag (already on in development).
- Navigate to your own profile's achievements page.
- Verify the settings cog appears in the header row with a popover containing two toggles.
- Toggle both settings and verify they persist across page reloads.
- Navigate to another user's profile and verify the Achievements tab is not visible.
- Verify the loading spinner stays visible until all trophy pages are fetched.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?