### PR TITLE
Add badges dark mode

### DIFF
--- a/packages/ui/src/badge/style.module.scss
+++ b/packages/ui/src/badge/style.module.scss
@@ -1,6 +1,7 @@
 @use '@wordpress/base-styles/colors';
 @use '@wordpress/base-styles/mixins';
 @use '@wordpress/base-styles/variables';
+@use '../utils/mixins' as ui-mixins;
 @use '../utils/_theme-variables' as theme;
 
 $badge-colors: (
@@ -15,6 +16,12 @@ $badge-colors: (
 
 	background-color: color-mix(in srgb, colors.$white 90%, var(--base-color));
 	color: color-mix(in srgb, colors.$black 50%, var(--base-color));
+
+	@include ui-mixins.when-dark-theme {
+		background-color: color-mix(in srgb, theme.$components-color-background 90%, var(--base-color));
+		color: color-mix(in srgb, theme.$components-color-foreground 50%, var(--base-color));
+	}
+
 	padding: 0 variables.$grid-unit-10;
 	min-height: variables.$grid-unit-30;
 	max-width: 100%;
@@ -29,6 +36,13 @@ $badge-colors: (
 	&:where(.is-default) {
 		background-color: theme.$components-color-gray-100;
 		color: theme.$components-color-gray-800;
+
+		// The default bg resolves to the dark card surface color, so add an
+		// inset outline to keep the badge visible. `box-shadow` is used
+		// instead of `border` to avoid changing the badge's outer dimensions.
+		@include ui-mixins.when-dark-theme {
+			box-shadow: inset 0 0 0 1px theme.$components-color-gray-300;
+		}
 	}
 
 	&.has-icon {

--- a/packages/ui/src/utils/_mixins.scss
+++ b/packages/ui/src/utils/_mixins.scss
@@ -1,0 +1,14 @@
+// Emits rules for the explicit dark theme AND for the system theme when the
+// OS prefers dark. Intended to be nested inside a CSS-module selector so `&`
+// resolves to the scoped class.
+@mixin when-dark-theme {
+	:root[data-theme="dark"] & {
+		@content;
+	}
+
+	@media (prefers-color-scheme: dark) {
+		:root[data-theme="system"] & {
+			@content;
+		}
+	}
+}


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/RSM-957/add-dark-mode-to-badge-components

| Light mode | Old version | New version |
| ----------- | ------------ | ------------ |
| <img width="108" height="661" alt="Screenshot 2026-04-23 alle 15 46 04" src="https://github.com/user-attachments/assets/0d620f64-6a55-467d-a02a-00a2a5eb755a" /> | <img width="120" height="704" alt="Screenshot 2026-04-23 alle 15 44 47" src="https://github.com/user-attachments/assets/b43cac31-7708-4b75-91f8-f42197fa7b37" /> | <img width="118" height="705" alt="immagine" src="https://github.com/user-attachments/assets/c3830096-7b84-43cf-bd77-fc8ca7efaac7" /> |

## Proposed Changes

* Change default background of badges on dark-mode
* Add a dark-mode mixin

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To have more readable badges

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

For testing it change `client/dashboard/domains/dataviews/field-ssl.tsx` to:
```ts
import { DomainSubtype, DomainSummary } from '@automattic/api-core';
import { sslDetailsQuery } from '@automattic/api-queries';
import { Badge } from '@automattic/ui';
import { useQuery } from '@tanstack/react-query';
import { __ } from '@wordpress/i18n';

const intents = [ 'default', 'info', 'success', 'warning', 'error' ] as const;
let intentIndex = 0;

export const DomainSslField = ( { domain }: { domain: DomainSummary } ) => {
	const { data: sslDetails } = useQuery( {
		...sslDetailsQuery( domain.domain ),
		staleTime: 60_000,
		enabled:
			domain.subtype.id !== DomainSubtype.DOMAIN_TRANSFER &&
			domain.subtype.id !== DomainSubtype.DEFAULT_ADDRESS,
	} );

	if ( domain.subtype.id === DomainSubtype.DOMAIN_TRANSFER ) {
		// TODO: only show this if there is no active domain connection for the domain transfer
		return '-';
	}

	if (
		domain.subtype.id === DomainSubtype.DEFAULT_ADDRESS ||
		sslDetails?.certificate_provisioned
	) {
		const intent = intents[ intentIndex % intents.length ];
		intentIndex++;
		return <Badge intent={ intent }>{ intent }</Badge>;
	}

	return <Badge intent="warning">{ __( 'SSL pending' ) }</Badge>;
};
```
And open http://my.localhost:3000/domains. You will see all the badges. Or use a similar trick.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
