### PR TITLE
Move dashboard dark theme to shared app

### DIFF
--- a/client/dashboard/app-dotcom/style.scss
+++ b/client/dashboard/app-dotcom/style.scss
@@ -1,12 +1,9 @@
 @import '@wordpress/base-styles/colors';
-@import '../app/dark-theme';
 
 /**
  * DotCom theme variables for dashboard
  *
- * Default values under :root target the light theme. Dark values are applied
- * when the <html data-theme="dark"> attribute is set, or when data-theme="system"
- * and the OS prefers a dark color scheme.
+ * Default values under :root target the light theme.
  */
 
 :root {
@@ -52,14 +49,4 @@
 
 	// Overview
 	--dashboard-overview__divider-color: #{$gray-100};
-}
-
-:root[data-theme="dark"] {
-	@include dashboard-dark-theme;
-}
-
-@media (prefers-color-scheme: dark) {
-	:root[data-theme="system"] {
-		@include dashboard-dark-theme;
-	}
 }

--- a/client/dashboard/app/style.scss
+++ b/client/dashboard/app/style.scss
@@ -1,6 +1,7 @@
 @import '@wordpress/base-styles/variables';
 @import '@wordpress/theme/design-tokens.css';
 @import '@wordpress/dataviews/build-style/style.css';
+@import './dark-theme';
 
 // Should be implemented differently once the Multi-site Dashboard is not loaded by the Node server using the Calypso loading screen.
 // I'm tempted to even just replace all this with a display:none on the logo
@@ -42,4 +43,14 @@ a {
 // This causes the visx tooltip to render a malformed box-shadow value, given that it interpolates the color. e.g: `${theme?.color}55`.
 .visx-tooltip:has(div[role="tooltip"]) {
 	box-shadow: 0 1px 2px $gray-300 !important;
+}
+
+:root[data-theme='dark'] {
+	@include dashboard-dark-theme;
+}
+
+@media (prefers-color-scheme: dark) {
+	:root[data-theme='system'] {
+		@include dashboard-dark-theme;
+	}
 }


### PR DESCRIPTION
Part of RSM-954

## Proposed Changes

* move the dashboard dark-theme selectors from the Dotcom app stylesheet into the shared dashboard app stylesheet

## Why are these changes being made?

After discussing this with @p-jackson ([context](https://github.com/Automattic/wp-calypso/pull/110088#discussion_r3130309807)) we realized it was good to move the `_dark-theme` into the root app.

## Testing Instructions

* Open `http://my.localhost:3000/` and confirm the dashboard still works as expected.
* Verify Dark Mode is still available on `http://my.localhost:3000/`.
* Open `http://calypso.localhost:3000/` and verify Dark Mode is not available there.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
