### PR TITLE
A4A-2521: Add Pressable memory add-on descriptions

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
@@ -14,6 +14,7 @@ export type PressablePlan = {
 	storage: number;
 	category: string;
 	worker?: number;
+	phpMemory?: number;
 	unit?: string;
 };
 
@@ -564,6 +565,14 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 0,
 		visits: 0,
 		storage: 64,
+		category: PRODUCT_CATEGORY_PRESSABLE_ADDON,
+	},
+	'pressable-addon-php-memory-512mb': {
+		slug: 'pressable-addon-php-memory-512mb',
+		install: 0,
+		visits: 0,
+		storage: 0,
+		phpMemory: 512,
 		category: PRODUCT_CATEGORY_PRESSABLE_ADDON,
 	},
 };

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/test/get-pressable-plan.test.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/test/get-pressable-plan.test.ts
@@ -35,6 +35,12 @@ describe( 'getPressablePlan add-on mappings', () => {
 			storage: 1,
 			visits: 0,
 		} );
+		expect( getPressablePlan( 'pressable-addon-php-memory-512mb' ) ).toMatchObject( {
+			install: 0,
+			storage: 0,
+			visits: 0,
+			phpMemory: 512,
+		} );
 	} );
 
 	it( 'returns titan add-on with zero usage-impact capacities', () => {

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/pressable-addons-custom-description/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/pressable-addons-custom-description/index.tsx
@@ -56,6 +56,17 @@ export default function PressableAddonsCustomDescription( { productName, product
 			);
 		}
 
+		if ( addOnType === 'phpMemory' ) {
+			return translate(
+				'PHP memory will be increased by %(phpMemory)s for each PHP worker/process on your Signature plan.',
+				{
+					args: {
+						phpMemory: context.formattedPhpMemory,
+					},
+				}
+			);
+		}
+
 		return translate(
 			'This add-on increases your Signature plan limits while your plan is active.'
 		);
@@ -98,6 +109,17 @@ export default function PressableAddonsCustomDescription( { productName, product
 				{
 					args: {
 						visits: context.formattedVisits,
+					},
+				}
+			);
+		}
+
+		if ( addOnType === 'phpMemory' ) {
+			return translate(
+				'This add-on increases PHP memory by %(phpMemory)s for each PHP worker/process while your Signature plan is active.',
+				{
+					args: {
+						phpMemory: context.formattedPhpMemory,
 					},
 				}
 			);

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/pressable-addons-custom-description/lib/capacity-copy.ts
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/pressable-addons-custom-description/lib/capacity-copy.ts
@@ -1,16 +1,18 @@
 import { formatNumber } from '@automattic/number-formatters';
 import getPressablePlan from 'calypso/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan';
 
-export type PressableAddonType = 'sites' | 'storage' | 'visits' | 'unknown';
+export type PressableAddonType = 'sites' | 'storage' | 'visits' | 'phpMemory' | 'unknown';
 
 export type PressableAddonCapacityCopyContext = {
 	type: PressableAddonType;
 	install: number;
 	storage: number;
 	visits: number;
+	phpMemory: number;
 	formattedInstall: string;
 	formattedStorage: string;
 	formattedVisits: string;
+	formattedPhpMemory: string;
 };
 
 export function getPressableAddonType( productSlug: string ): PressableAddonType {
@@ -24,6 +26,10 @@ export function getPressableAddonType( productSlug: string ): PressableAddonType
 
 	if ( productSlug.startsWith( 'pressable-addon-visits-' ) ) {
 		return 'visits';
+	}
+
+	if ( productSlug.startsWith( 'pressable-addon-php-memory-' ) ) {
+		return 'phpMemory';
 	}
 
 	return 'unknown';
@@ -45,8 +51,10 @@ export function getPressableAddonCapacityCopyContext(
 		install: plan.install,
 		storage: plan.storage,
 		visits: plan.visits,
+		phpMemory: plan.phpMemory ?? 0,
 		formattedInstall: formatNumber( plan.install ),
 		formattedStorage: `${ formatNumber( plan.storage ) } GB`,
 		formattedVisits: formatNumber( plan.visits ),
+		formattedPhpMemory: `${ formatNumber( plan.phpMemory ?? 0 ) } MB`,
 	};
 }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/pressable-addons-custom-description/lib/test/capacity-copy.test.ts
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/pressable-addons-custom-description/lib/test/capacity-copy.test.ts
@@ -7,9 +7,11 @@ describe( 'pressable addon capacity copy context', () => {
 			install: 1,
 			storage: 10,
 			visits: 10000,
+			phpMemory: 0,
 			formattedInstall: '1',
 			formattedStorage: '10 GB',
 			formattedVisits: '10,000',
+			formattedPhpMemory: '0 MB',
 		} );
 	} );
 
@@ -19,9 +21,11 @@ describe( 'pressable addon capacity copy context', () => {
 			install: 5,
 			storage: 20,
 			visits: 50000,
+			phpMemory: 0,
 			formattedInstall: '5',
 			formattedStorage: '20 GB',
 			formattedVisits: '50,000',
+			formattedPhpMemory: '0 MB',
 		} );
 	} );
 
@@ -31,9 +35,11 @@ describe( 'pressable addon capacity copy context', () => {
 			install: 10,
 			storage: 20,
 			visits: 100000,
+			phpMemory: 0,
 			formattedInstall: '10',
 			formattedStorage: '20 GB',
 			formattedVisits: '100,000',
+			formattedPhpMemory: '0 MB',
 		} );
 	} );
 
@@ -43,9 +49,11 @@ describe( 'pressable addon capacity copy context', () => {
 			install: 0,
 			storage: 1,
 			visits: 0,
+			phpMemory: 0,
 			formattedInstall: '0',
 			formattedStorage: '1 GB',
 			formattedVisits: '0',
+			formattedPhpMemory: '0 MB',
 		} );
 	} );
 
@@ -55,9 +63,25 @@ describe( 'pressable addon capacity copy context', () => {
 			install: 0,
 			storage: 0,
 			visits: 10000,
+			phpMemory: 0,
 			formattedInstall: '0',
 			formattedStorage: '0 GB',
 			formattedVisits: '10,000',
+			formattedPhpMemory: '0 MB',
+		} );
+	} );
+
+	it( 'maps pressable-addon-php-memory-512mb with exact memory format', () => {
+		expect( getPressableAddonCapacityCopyContext( 'pressable-addon-php-memory-512mb' ) ).toEqual( {
+			type: 'phpMemory',
+			install: 0,
+			storage: 0,
+			visits: 0,
+			phpMemory: 512,
+			formattedInstall: '0',
+			formattedStorage: '0 GB',
+			formattedVisits: '0',
+			formattedPhpMemory: '512 MB',
 		} );
 	} );
 

--- a/client/jetpack-cloud/sections/partner-portal/hooks/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/hooks/index.tsx
@@ -1,8 +1,10 @@
 import page from '@automattic/calypso-router';
+import { formatNumber } from '@automattic/number-formatters';
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { getQueryArg } from '@wordpress/url';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import getPressablePlan from 'calypso/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan';
 import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
 import ensurePartnerPortalReturnUrl from '../lib/ensure-partner-portal-return-url';
 
@@ -127,6 +129,21 @@ export function useProductDescription( productSlug: string ): {
 		if ( productSlug.startsWith( 'pressable-addon-visits-' ) ) {
 			description = translate(
 				'Add additional monthly visits capacity to your Pressable plan limit.'
+			);
+		}
+
+		if ( productSlug.startsWith( 'pressable-addon-php-memory-' ) ) {
+			const plan = getPressablePlan( productSlug );
+			const phpMemory =
+				plan?.phpMemory != null ? `${ formatNumber( plan.phpMemory ) } MB` : '512 MB';
+
+			description = translate(
+				'Add %(phpMemory)s of PHP memory for each PHP worker/process on your Pressable plan.',
+				{
+					args: {
+						phpMemory,
+					},
+				}
 			);
 		}
 

--- a/client/jetpack-cloud/sections/partner-portal/hooks/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/hooks/index.tsx
@@ -119,8 +119,8 @@ export function useProductDescription( productSlug: string ): {
 	const translate = useTranslate();
 
 	return useMemo( () => {
-		let description = '';
-		const features = [];
+		let description: TranslateResult | null = null;
+		const features: TranslateResult[] = [];
 
 		if ( productSlug.startsWith( 'pressable-addon-storage-' ) ) {
 			description = translate( 'Add additional storage capacity to your Pressable plan limit.' );


### PR DESCRIPTION
Part of A4A-2521

## Proposed Changes

<img width="435" height="288" alt="image" src="https://github.com/user-attachments/assets/fb8f9eca-e175-4bef-9340-a9b1249aa53c" />

<img width="592" height="643" alt="image" src="https://github.com/user-attachments/assets/65a0b3f1-7220-4103-8e03-ec54e39c6a5d" />

* Add marketplace card copy for the Pressable PHP Memory 512MB add-on.
* Add lightbox detail copy for the 512 MB PHP memory limit.
* Add Calypso plan metadata for `pressable-addon-php-memory-512mb`.
* Add tests for the new add-on capacity copy mapping.

## Why are these changes being made?

* The PHP Memory add-on currently falls back to generic Pressable add-on copy in the marketplace.

## Testing Instructions

* Check the code changes.
* Open the Automattic for Agencies Live link for this PR.
* Go to the A4A marketplace products page with the PHP Memory add-on visible.
* Verify the product card shows a specific PHP memory description.
* Click **View details** and verify the lightbox describes the 512 MB PHP memory limit.
* Confirm the focused tests pass:

```
yarn test-client client/a8c-for-agencies/sections/marketplace/products-overview/product-card/pressable-addons-custom-description/lib/test/capacity-copy.test.ts client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/test/get-pressable-plan.test.ts
```

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

_— ClemenAgent (Powered by Codex)_