### PR TITLE
E2E: fix flaky-fixture race-condition test

### DIFF
--- a/test/e2e/specs/infrastructure/infrastructure__flaky-fixture.spec.ts
+++ b/test/e2e/specs/infrastructure/infrastructure__flaky-fixture.spec.ts
@@ -31,8 +31,8 @@ test.describe( 'Infrastructure: Flaky fixture (testing only)', { tag: [ tags.CAL
 			);
 		} );
 
-		await test.step( 'Then the element is visible within a too-short timeout', async function () {
-			await expect( page.locator( '#late' ) ).toBeVisible( { timeout: 150 } );
+		await test.step( 'Then the element becomes visible', async function () {
+			await expect( page.locator( '#late' ) ).toBeVisible();
 		} );
 	} );
 } );


### PR DESCRIPTION
Part of #

## Proposed Changes

* Removed the `{ timeout: 150 }` override on the `toBeVisible()` assertion in `test/e2e/specs/infrastructure/infrastructure__flaky-fixture.spec.ts` so the step uses Playwright's default expect timeout.
* Renamed the step from "Then the element is visible within a too-short timeout" to "Then the element becomes visible" to match the new behavior.

## Why are these changes being made?

* The fixture injects `#late` into the DOM via `setTimeout` with a 50–850ms random delay, but the assertion capped Playwright's auto-waiting at 150ms. Whenever the random delay landed above ~150ms — most of the range — the locator resolved to zero elements before the expect budget expired and the test failed with `element(s) not found`. A pure test-side race between a deliberately tight expect timeout and the fixture's own random DOM insertion, not a product defect.
* Observed flake: [TeamCity build 17452235](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Playwright_Test_Matrix/17452235) — the test failed on both `[Desktop]` (chrome) and `[Mobile]` (pixel) projects, including the automatic retry.
* Dropping the explicit timeout lets Playwright's default expect timeout + auto-waiting poll until `#late` is attached and visible. The default comfortably covers the fixture's worst-case 850ms insertion delay and eliminates the race without touching fixture timing or product code.

## Testing Instructions

* Run `yarn playwright test test/e2e/specs/infrastructure/infrastructure__flaky-fixture.spec.ts --reporter=list --repeat-each=10` locally; all runs should pass.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?