### PR TITLE
Checkout: keep two-year upsell 24px below order card throughout scroll

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -713,20 +713,21 @@ export default function CheckoutMainContent( {
 								) }
 							</CheckoutSummaryBody>
 						</CheckoutErrorBoundary>
+						{
+							// Rendered inside CheckoutSummaryArea so it sits within the sticky
+							// container and stays 24px below the order card as the page scrolls.
+							// At desktop width the upsell is always visible; at mobile it's only
+							// shown when the checkout summary is toggled open.
+							isCheckoutUiRedesignV1 && ( isSummaryVisible || isLargeViewport ) && (
+								<CheckoutSummaryNudgeArea>
+									<CheckoutSidebarNudge
+										addItemToCart={ addItemToCart }
+										areThereDomainProductsInCart={ areThereDomainProductsInCart }
+									/>
+								</CheckoutSummaryNudgeArea>
+							)
+						}
 					</CheckoutSummaryArea>
-					{
-						// This upsell should always be displayed in the
-						// sidebar at desktop width but only shown at mobile
-						// width if the checkout summary is toggled open.
-						isCheckoutUiRedesignV1 && ( isSummaryVisible || isLargeViewport ) && (
-							<CheckoutSummaryNudgeArea>
-								<CheckoutSidebarNudge
-									addItemToCart={ addItemToCart }
-									areThereDomainProductsInCart={ areThereDomainProductsInCart }
-								/>
-							</CheckoutSummaryNudgeArea>
-						)
-					}
 				</>
 			) }
 		</WPCheckoutSidebarContent>
@@ -1479,6 +1480,15 @@ const CheckoutSummary = styled.div`
 	width: 100%;
 	display: flex;
 	flex-direction: column;
+
+	/*
+	 * Lock intrinsic child sizing so the 24px gap between the sticky order card
+	 * and the two-year upsell isn't collapsed when the sticky area reaches the
+	 * bottom of its grid cell and some browsers compress flex children to fit.
+	 */
+	& > * {
+		flex-shrink: 0;
+	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		padding-left: 24px;
@@ -2392,6 +2402,7 @@ const CheckoutSummaryBagIconWrapper = styled.span`
 
 const CheckoutSummaryNudgeArea = styled.div`
 	margin: 8px 16px 12px;
+	flex-shrink: 0;
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		margin-inline: 0;

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -802,13 +802,6 @@ const CheckoutSummaryCard = styled.div`
 		0 3px 1px rgb( 0 0 0 / 4% ),
 		0 3px 8px rgb( 0 0 0 / 12% );
 	margin-bottom: 20px;
-
-	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
-		position: sticky;
-		top: 32px;
-		max-height: calc( 100vh - 64px );
-		overflow-y: auto;
-	}
 `;
 
 const CheckoutSummaryPayButtonSlot = styled.div`


### PR DESCRIPTION
## Proposed Changes

- Move the Save 19% two-year upsell inside the sticky `CheckoutSummaryArea` so it scrolls with the order card, keeping a constant 24px gap at every scroll position.
- Drop the redundant desktop sticky block on `CheckoutSummaryCard` (`position: sticky; top: 32px; max-height: calc(100vh - 64px); overflow-y: auto`). With the outer `.checkout__summary-area` already sticky at the same offset, the inner sticky collapsed the gap to zero as the outer neared the bottom of its containing block.
- Add `flex-shrink: 0` on `CheckoutSummary`'s children and on `CheckoutSummaryNudgeArea` as a defensive layer.

## Why are these changes being made?

Scrolling to the bottom of the checkout page made the Save 19% upsell drift upward and end up flush against the order card. The cause was nested `position: sticky` at the same `top: 32px` offset: the inner sticky stayed pinned while the outer un-stuck and moved up, and the sibling below the inner (the upsell) followed the outer's motion. The fix is to own stickiness at one layer — the outer `.checkout__summary-area`, which wraps both the order card and the upsell — so the whole block scrolls together.

## Testing Instructions

- Open a desktop checkout where the two-year upsell is shown (e.g., a plan cart that qualifies for "Save 19% extra by paying for two years").
- Scroll from top to bottom. The gap between the "Your order" card and the "Save 19% extra" card should stay at 24px at every scroll position, including at the bottom.
- Resize to tablet / mobile; the upsell should still appear only when the summary is toggled open.
- `yarn eslint` passes on the changed files.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.