### PR TITLE
Add /domains dark mode

### DIFF
--- a/client/dashboard/app/_dark-theme.scss
+++ b/client/dashboard/app/_dark-theme.scss
@@ -416,7 +416,6 @@
 	}
 }
 
-// :root variables overridden for dark theme
 /* Site Icon */
 @mixin dashboard-dark-theme-site-icon {
 	// `.site-icon` hardcodes `background: $white` so user-uploaded favicons

--- a/client/dashboard/app/_dark-theme.scss
+++ b/client/dashboard/app/_dark-theme.scss
@@ -331,6 +331,19 @@
 		.dataviews-view-table__group-header-cell {
 			color: var( --dashboard__text-color );
 		}
+
+		// Selected row background (upstream mixes the admin color with hardcoded
+		// `#fff`, which produces a light tint against the dark surface).
+		tr.is-selected,
+		tr.is-selected .dataviews-view-table__actions-column--sticky,
+		&.has-bulk-actions tr.is-selected .dataviews-view-table__actions-column--sticky,
+		&.has-bulk-actions tr.is-selected:hover .dataviews-view-table__actions-column--sticky {
+			background-color: color-mix(
+				in srgb,
+				rgb( var( --wp-admin-theme-color--rgb ) ) 12%,
+				var( --dashboard-surface__background-color )
+			);
+		}
 	}
 
 	// Title field (used as the row's primary link/label)
@@ -388,6 +401,11 @@
 		border-top-color: var( --dashboard-surface__border-color );
 	}
 
+	// "N items" count in the footer (hardcoded to #1e1e1e upstream).
+	.dataviews-bulk-actions-footer__item-count {
+		color: var( --dashboard__text-color );
+	}
+
 	// URL field override from our local styles.scss
 	a.dataviews-url-field {
 		color: var( --dashboard-subtle__color );
@@ -399,6 +417,16 @@
 }
 
 // :root variables overridden for dark theme
+/* Site Icon */
+@mixin dashboard-dark-theme-site-icon {
+	// `.site-icon` hardcodes `background: $white` so user-uploaded favicons
+	// (often dark glyphs on transparent) stay legible. A pure-white chip pops
+	// harshly against the dark surface; use a light neutral instead.
+	.site-icon {
+		background: var( --wp-components-color-gray-600 );
+	}
+}
+
 @mixin dashboard-dark-theme {
 	// Overrides the default `--wp-components-*` to ensure all components that
 	// rely on it adapt to the dark theme's text color.
@@ -493,5 +521,6 @@
 	@include dashboard-dark-theme-popover;
 	@include dashboard-dark-theme-muted-text;
 	@include dashboard-dark-theme-section-header;
+	@include dashboard-dark-theme-site-icon;
 	@include dashboard-dark-theme-summary-button;
 }


### PR DESCRIPTION
See https://linear.app/a8c/issue/RSM-956/add-dark-mode-to-domains

Before:

<img width="804" height="403" alt="immagine" src="https://github.com/user-attachments/assets/f5a957dd-e088-44af-bb74-a63917986693" />

After:

<img width="635" height="388" alt="immagine" src="https://github.com/user-attachments/assets/c78a5c79-0af1-4530-8d74-a18c1e097297" />

## Proposed Changes

* Fix minor issues in the `/domains` page

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To add dark mode to `/domains` page

## Testing Instructions

* Visit http://my.localhost:3000/domains page in dark-mode and check if colors are correct
* Be sure text in the footer area is ok
* Select the bottom-left checkbox and check if the selected rows are ok

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
