### PR TITLE
Checkout: sidebar trust footer + Read more terms modal

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -1677,9 +1677,17 @@ function CheckoutTermsAndCheckboxes( {
 
 	const translate = useTranslate();
 
+	const needsConsentCheckbox = hasMarketplaceProduct || has100YearPlan;
+
 	return (
 		<CheckoutTermsAndCheckboxesWrapper className="checkout-terms-and-checkboxes">
-			<BeforeSubmitCheckoutHeader />
+			{
+				// Keep the inline legal block above the consent checkbox so
+				// "I have read and agree to all of the above" still refers to
+				// something visible. For carts without a consent checkbox the
+				// same text is reachable via the sidebar's Read more modal.
+				needsConsentCheckbox && <BeforeSubmitCheckoutHeader />
+			}
 
 			{ hasMarketplaceProduct && (
 				<AcceptTermsOfServiceCheckbox

--- a/client/my-sites/checkout/src/components/checkout-pay-button-footer.tsx
+++ b/client/my-sites/checkout/src/components/checkout-pay-button-footer.tsx
@@ -1,0 +1,121 @@
+import { localizeUrl } from '@automattic/i18n-utils';
+import { ResponseCart } from '@automattic/shopping-cart';
+import styled from '@emotion/styled';
+import { Icon } from '@wordpress/components';
+import { lock } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import { CheckoutSummaryRefundWindows } from './checkout-summary-refund-windows';
+import CheckoutTermsModal from './checkout-terms-modal';
+
+const Wrapper = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	margin-top: 12px;
+	font-size: 13px;
+	color: ${ ( props ) => props.theme.colors.textColorLight };
+`;
+
+const TrustLine = styled.div`
+	display: flex;
+	align-items: center;
+	gap: 8px;
+
+	svg {
+		flex-shrink: 0;
+		fill: currentColor;
+	}
+`;
+
+const RefundLine = styled( TrustLine )`
+	/*
+	 * CheckoutSummaryRefundWindows renders a sibling icon + container pair when
+	 * includeRefundIcon is passed. Make both children align as if they were one row.
+	 */
+	& > * {
+		margin: 0;
+	}
+`;
+
+const Divider = styled.hr`
+	border: 0;
+	border-block-start: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
+	margin: 8px 0;
+`;
+
+const AutoRenewNotice = styled.p`
+	margin: 0;
+	font-size: 12px;
+	line-height: 1.5;
+	color: ${ ( props ) => props.theme.colors.textColorLight };
+
+	a,
+	button {
+		color: ${ ( props ) => props.theme.colors.highlight };
+		text-decoration: underline;
+
+		&:hover {
+			color: ${ ( props ) => props.theme.colors.highlightOver };
+		}
+	}
+
+	button {
+		background: none;
+		border: 0;
+		padding: 0;
+		font: inherit;
+		cursor: pointer;
+	}
+`;
+
+export default function CheckoutPayButtonFooter( { cart }: { cart: ResponseCart } ) {
+	const translate = useTranslate();
+	const [ isTermsModalOpen, setIsTermsModalOpen ] = useState( false );
+
+	return (
+		<Wrapper className="checkout-pay-button-footer">
+			<TrustLine>
+				<Icon icon={ lock } size={ 18 } />
+				<span>{ translate( 'SSL secure payment · 256-bit encryption' ) }</span>
+			</TrustLine>
+
+			<RefundLine>
+				<CheckoutSummaryRefundWindows cart={ cart } includeRefundIcon />
+			</RefundLine>
+
+			<Divider />
+
+			<AutoRenewNotice>
+				{ translate(
+					'By purchasing, you accept the {{tos}}Terms of Service{{/tos}} and {{pp}}Privacy Policy{{/pp}}. Your subscription auto-renews. {{readmore}}Read more{{/readmore}}',
+					{
+						components: {
+							tos: (
+								<a
+									href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+							pp: (
+								<a
+									href={ localizeUrl( 'https://automattic.com/privacy/' ) }
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+							readmore: <button type="button" onClick={ () => setIsTermsModalOpen( true ) } />,
+						},
+					}
+				) }
+			</AutoRenewNotice>
+
+			<CheckoutTermsModal
+				cart={ cart }
+				isOpen={ isTermsModalOpen }
+				onClose={ () => setIsTermsModalOpen( false ) }
+			/>
+		</Wrapper>
+	);
+}

--- a/client/my-sites/checkout/src/components/checkout-summary-refund-windows.tsx
+++ b/client/my-sites/checkout/src/components/checkout-summary-refund-windows.tsx
@@ -8,7 +8,7 @@ import { getRefundPolicies, getRefundWindows, RefundPolicy } from './refund-poli
 import type { TranslateResult } from 'i18n-calypso';
 
 const StyledIcon = styled( Icon )`
-	fill: '#1E1E1E';
+	fill: #1e1e1e;
 	margin-right: 0.3em;
 
 	.rtl & {

--- a/client/my-sites/checkout/src/components/checkout-summary-refund-windows.tsx
+++ b/client/my-sites/checkout/src/components/checkout-summary-refund-windows.tsx
@@ -1,0 +1,146 @@
+import { isPlan } from '@automattic/calypso-products';
+import { ResponseCart } from '@automattic/shopping-cart';
+import styled from '@emotion/styled';
+import { Icon, reusableBlock } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { CheckIcon } from './check-icon';
+import { getRefundPolicies, getRefundWindows, RefundPolicy } from './refund-policies';
+import type { TranslateResult } from 'i18n-calypso';
+
+const StyledIcon = styled( Icon )`
+	fill: '#1E1E1E';
+	margin-right: 0.3em;
+
+	.rtl & {
+		margin-right: 0;
+		margin-left: 0.3em;
+	}
+`;
+
+const CheckoutSummaryRefundWindowsCheckIcon = styled( CheckIcon )`
+	fill: ${ ( props ) => props.theme.colors.success };
+	margin-right: 4px;
+	position: absolute;
+	top: 0;
+	left: 0;
+
+	.rtl & {
+		margin-right: 0;
+		margin-left: 4px;
+		right: 0;
+		left: auto;
+	}
+`;
+
+const Container = styled.p`
+	margin: 0;
+	padding: 0;
+`;
+
+export function CheckoutSummaryRefundWindows( {
+	cart,
+	highlight = false,
+	includeRefundIcon,
+}: {
+	cart: ResponseCart;
+	highlight?: boolean;
+	includeRefundIcon?: boolean;
+} ) {
+	const translate = useTranslate();
+
+	const refundPolicies = getRefundPolicies( cart );
+	const refundWindows = getRefundWindows( refundPolicies );
+
+	if ( ! refundWindows.length || refundPolicies.includes( RefundPolicy.NonRefundable ) ) {
+		return null;
+	}
+
+	const allCartItemsAreDomains = refundPolicies.every(
+		( refundPolicy ) =>
+			refundPolicy === RefundPolicy.DomainNameRegistration ||
+			refundPolicy === RefundPolicy.DomainNameRegistrationBundled ||
+			refundPolicy === RefundPolicy.DomainNameRenewal
+	);
+
+	if ( allCartItemsAreDomains ) {
+		return null;
+	}
+
+	const allCartItemsAreMonthlyPlanBundle = refundPolicies.every(
+		( refundPolicy ) =>
+			refundPolicy === RefundPolicy.DomainNameRegistration ||
+			refundPolicy === RefundPolicy.PlanMonthlyBundle
+	);
+
+	const allCartItemsArePlanOrDomainRenewals = refundPolicies.every(
+		( refundPolicy ) =>
+			refundPolicy === RefundPolicy.DomainNameRenewal ||
+			refundPolicy === RefundPolicy.PlanMonthlyRenewal ||
+			refundPolicy === RefundPolicy.PlanYearlyRenewal ||
+			refundPolicy === RefundPolicy.PlanBiennialRenewal
+	);
+
+	let text: TranslateResult;
+
+	if ( refundWindows.length === 1 ) {
+		const refundWindow = refundWindows[ 0 ];
+		const planBundleRefundPolicy = refundPolicies.find(
+			( refundPolicy ) =>
+				refundPolicy === RefundPolicy.PlanBiennialBundle ||
+				refundPolicy === RefundPolicy.PlanYearlyBundle
+		);
+		const planProduct = cart.products.find( isPlan );
+
+		if ( planBundleRefundPolicy ) {
+			text = translate(
+				'%(days)d-day money back guarantee for %(product)s',
+				'%(days)d-day money back guarantee for %(product)s',
+				{
+					count: refundWindow,
+					args: {
+						days: refundWindow,
+						product: planProduct?.product_name ?? '',
+					},
+				}
+			);
+		} else {
+			text = translate( '%(days)d-day money back guarantee', '%(days)d-day money back guarantee', {
+				count: refundWindow,
+				args: { days: refundWindow },
+			} );
+		}
+	} else if ( allCartItemsAreMonthlyPlanBundle || allCartItemsArePlanOrDomainRenewals ) {
+		const refundWindow = Math.max( ...refundWindows );
+		const planProduct = cart.products.find( isPlan );
+
+		text = translate(
+			'%(days)d-day money back guarantee for %(product)s',
+			'%(days)d-day money back guarantee for %(product)s',
+			{
+				count: refundWindow,
+				args: {
+					days: refundWindow,
+					product: planProduct?.product_name ?? '',
+				},
+			}
+		);
+	} else {
+		const shortestRefundWindow = Math.min( ...refundWindows );
+
+		text = translate( '%(days)d-day money back guarantee', '%(days)d-day money back guarantee', {
+			count: shortestRefundWindow,
+			args: { days: shortestRefundWindow },
+			comment: 'The number of days until the shortest refund window in the cart expires.',
+		} );
+	}
+
+	return (
+		<>
+			{ includeRefundIcon && <StyledIcon icon={ reusableBlock } size={ 24 } /> }
+			<Container>
+				{ ! includeRefundIcon && <CheckoutSummaryRefundWindowsCheckIcon /> }
+				{ highlight ? <strong>{ text }</strong> : text }
+			</Container>
+		</>
+	);
+}

--- a/client/my-sites/checkout/src/components/checkout-terms-modal.tsx
+++ b/client/my-sites/checkout/src/components/checkout-terms-modal.tsx
@@ -59,7 +59,7 @@ export default function CheckoutTermsModal( {
 
 	return (
 		<Modal
-			title={ String( translate( 'Terms and conditions' ) ) }
+			title={ translate( 'Terms and conditions', { textOnly: true } ) }
 			onRequestClose={ onClose }
 			size="medium"
 			className="checkout-terms-modal"

--- a/client/my-sites/checkout/src/components/checkout-terms-modal.tsx
+++ b/client/my-sites/checkout/src/components/checkout-terms-modal.tsx
@@ -1,0 +1,72 @@
+import { ResponseCart } from '@automattic/shopping-cart';
+import styled from '@emotion/styled';
+import { Modal } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import CheckoutTerms from './checkout-terms';
+
+const TermsModalBody = styled.div`
+	font-size: 14px;
+	line-height: 1.5;
+	color: ${ ( props ) => props.theme.colors.textColor };
+
+	& > .checkout__terms {
+		margin-block-end: 16px;
+	}
+
+	& > * {
+		margin-block: 12px;
+	}
+
+	a {
+		text-decoration: underline;
+	}
+
+	/*
+	 * The inline terms keep a FoldableCard for a few edge-case notices
+	 * (bundled-domain, international fee, Jetpack social disclaimer).
+	 * Inside the modal there's no reason to collapse them — show them inline.
+	 */
+	.checkout__terms-foldable-card {
+		box-shadow: none;
+		padding: 0;
+
+		.foldable-card__header {
+			display: none;
+		}
+
+		.foldable-card__content {
+			display: block !important;
+			padding: 0;
+			border-top: none;
+		}
+	}
+`;
+
+export default function CheckoutTermsModal( {
+	cart,
+	isOpen,
+	onClose,
+}: {
+	cart: ResponseCart;
+	isOpen: boolean;
+	onClose: () => void;
+} ) {
+	const translate = useTranslate();
+
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	return (
+		<Modal
+			title={ String( translate( 'Terms and conditions' ) ) }
+			onRequestClose={ onClose }
+			size="medium"
+			className="checkout-terms-modal"
+		>
+			<TermsModalBody>
+				<CheckoutTerms cart={ cart } />
+			</TermsModalBody>
+		</Modal>
+	);
+}

--- a/client/my-sites/checkout/src/components/test/checkout-pay-button-footer.test.tsx
+++ b/client/my-sites/checkout/src/components/test/checkout-pay-button-footer.test.tsx
@@ -3,24 +3,16 @@
  */
 
 import { PLAN_PREMIUM } from '@automattic/calypso-products';
+import { checkoutTheme } from '@automattic/composite-checkout';
 import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
 import { ThemeProvider } from '@emotion/react';
 import { render, screen } from '@testing-library/react';
 import CheckoutPayButtonFooter from '../checkout-pay-button-footer';
 import type { ResponseCart } from '@automattic/shopping-cart';
 
-const theme = {
-	colors: {
-		textColorLight: '#666',
-		borderColorLight: '#ddd',
-		highlight: '#0675c4',
-		highlightOver: '#055d9c',
-	},
-};
-
 function renderFooter( cart: ResponseCart ) {
 	return render(
-		<ThemeProvider theme={ theme }>
+		<ThemeProvider theme={ checkoutTheme }>
 			<CheckoutPayButtonFooter cart={ cart } />
 		</ThemeProvider>
 	);

--- a/client/my-sites/checkout/src/components/test/checkout-pay-button-footer.test.tsx
+++ b/client/my-sites/checkout/src/components/test/checkout-pay-button-footer.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { PLAN_PREMIUM } from '@automattic/calypso-products';
+import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
+import { ThemeProvider } from '@emotion/react';
+import { render, screen } from '@testing-library/react';
+import CheckoutPayButtonFooter from '../checkout-pay-button-footer';
+import type { ResponseCart } from '@automattic/shopping-cart';
+
+const theme = {
+	colors: {
+		textColorLight: '#666',
+		borderColorLight: '#ddd',
+		highlight: '#0675c4',
+		highlightOver: '#055d9c',
+	},
+};
+
+function renderFooter( cart: ResponseCart ) {
+	return render(
+		<ThemeProvider theme={ theme }>
+			<CheckoutPayButtonFooter cart={ cart } />
+		</ThemeProvider>
+	);
+}
+
+describe( 'CheckoutPayButtonFooter', () => {
+	it( 'renders the money-back-guarantee line for a cart that yields a refund window', () => {
+		const cart = getEmptyResponseCart();
+		cart.products.push( {
+			...getEmptyResponseCartProduct(),
+			item_subtotal_integer: 5,
+			product_slug: PLAN_PREMIUM,
+		} );
+
+		renderFooter( cart );
+
+		expect( screen.getByText( /money back guarantee/i ) ).toBeInTheDocument();
+	} );
+
+	it( 'omits the money-back-guarantee line for a cart with no refund window', () => {
+		renderFooter( getEmptyResponseCart() );
+
+		expect( screen.queryByText( /money back guarantee/i ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -36,7 +36,6 @@ import {
 import { css, keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useViewportMatch } from '@wordpress/compose';
-import { Icon, reusableBlock } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import * as React from 'react';
 import { hasFreeCouponTransfersOnly } from 'calypso/lib/cart-values/cart-items';
@@ -53,10 +52,10 @@ import getJetpackProductFeatures from '../lib/get-jetpack-product-features';
 import getPlanFeatures from '../lib/get-plan-features';
 import { useSubmitButtonSlot } from '../lib/submit-button-slot';
 import { CheckIcon } from './check-icon';
+import CheckoutPayButtonFooter from './checkout-pay-button-footer';
+import { CheckoutSummaryRefundWindows } from './checkout-summary-refund-windows';
 import { ProductsAndCostOverridesList } from './cost-overrides-list';
-import { getRefundPolicies, getRefundWindows, RefundPolicy } from './refund-policies';
 import type { ResponseCart, ResponseCartProduct } from '@automattic/shopping-cart';
-import type { TranslateResult } from 'i18n-calypso';
 
 // This will make converting to TS less noisy. The order of components can be reorganized later
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -64,16 +63,6 @@ import type { TranslateResult } from 'i18n-calypso';
 const PALETTE = colorStudio.colors;
 const COLOR_GRAY_40 = PALETTE[ 'Gray 40' ];
 const COLOR_GREEN_60 = PALETTE[ 'Green 60' ];
-
-const StyledIcon = styled( Icon )`
-	fill: '#1E1E1E';
-	margin-right: 0.3em;
-
-	.rtl & {
-		margin-right: 0;
-		margin-left: 0.3em;
-	}
-`;
 
 export function WPCheckoutOrderSummary( {
 	onChangeSelection,
@@ -256,10 +245,13 @@ function CheckoutSummaryPriceList() {
 					</span>
 				</CheckoutSummaryTotal>
 				{ isLargeViewport && (
-					<CheckoutSummaryPayButtonSlot
-						ref={ setSlotEl }
-						className="wp-checkout-order-summary__pay-button-slot"
-					/>
+					<>
+						<CheckoutSummaryPayButtonSlot
+							ref={ setSlotEl }
+							className="wp-checkout-order-summary__pay-button-slot"
+						/>
+						<CheckoutPayButtonFooter cart={ responseCart } />
+					</>
 				) }
 			</CheckoutSummaryAmountWrapper>
 		</>
@@ -302,119 +294,7 @@ function SwitchToAnnualPlan( {
 	return <SwitchToAnnualPlanButton onClick={ handleClick }>{ text }</SwitchToAnnualPlanButton>;
 }
 
-const CheckoutSummaryRefundWindowsContainer = styled.p`
-	margin: 0;
-	padding: 0;
-`;
-
-export function CheckoutSummaryRefundWindows( {
-	cart,
-	highlight = false,
-	includeRefundIcon,
-}: {
-	cart: ResponseCart;
-	highlight?: boolean;
-	includeRefundIcon?: boolean;
-} ) {
-	const translate = useTranslate();
-
-	const refundPolicies = getRefundPolicies( cart );
-	const refundWindows = getRefundWindows( refundPolicies );
-
-	if ( ! refundWindows.length || refundPolicies.includes( RefundPolicy.NonRefundable ) ) {
-		return null;
-	}
-
-	const allCartItemsAreDomains = refundPolicies.every(
-		( refundPolicy ) =>
-			refundPolicy === RefundPolicy.DomainNameRegistration ||
-			refundPolicy === RefundPolicy.DomainNameRegistrationBundled ||
-			refundPolicy === RefundPolicy.DomainNameRenewal
-	);
-
-	if ( allCartItemsAreDomains ) {
-		return null;
-	}
-
-	const allCartItemsAreMonthlyPlanBundle = refundPolicies.every(
-		( refundPolicy ) =>
-			refundPolicy === RefundPolicy.DomainNameRegistration ||
-			refundPolicy === RefundPolicy.PlanMonthlyBundle
-	);
-
-	const allCartItemsArePlanOrDomainRenewals = refundPolicies.every(
-		( refundPolicy ) =>
-			refundPolicy === RefundPolicy.DomainNameRenewal ||
-			refundPolicy === RefundPolicy.PlanMonthlyRenewal ||
-			refundPolicy === RefundPolicy.PlanYearlyRenewal ||
-			refundPolicy === RefundPolicy.PlanBiennialRenewal
-	);
-
-	let text: TranslateResult;
-
-	if ( refundWindows.length === 1 ) {
-		const refundWindow = refundWindows[ 0 ];
-		const planBundleRefundPolicy = refundPolicies.find(
-			( refundPolicy ) =>
-				refundPolicy === RefundPolicy.PlanBiennialBundle ||
-				refundPolicy === RefundPolicy.PlanYearlyBundle
-		);
-		const planProduct = cart.products.find( isPlan );
-
-		if ( planBundleRefundPolicy ) {
-			// Using plural translation because some languages have multiple plural forms and no plural-agnostic.
-			text = translate(
-				'%(days)d-day money back guarantee for %(product)s',
-				'%(days)d-day money back guarantee for %(product)s',
-				{
-					count: refundWindow,
-					args: {
-						days: refundWindow,
-						product: planProduct?.product_name ?? '',
-					},
-				}
-			);
-		} else {
-			text = translate( '%(days)d-day money back guarantee', '%(days)d-day money back guarantee', {
-				count: refundWindow,
-				args: { days: refundWindow },
-			} );
-		}
-	} else if ( allCartItemsAreMonthlyPlanBundle || allCartItemsArePlanOrDomainRenewals ) {
-		const refundWindow = Math.max( ...refundWindows );
-		const planProduct = cart.products.find( isPlan );
-
-		text = translate(
-			'%(days)d-day money back guarantee for %(product)s',
-			'%(days)d-day money back guarantee for %(product)s',
-			{
-				count: refundWindow,
-				args: {
-					days: refundWindow,
-					product: planProduct?.product_name ?? '',
-				},
-			}
-		);
-	} else {
-		const shortestRefundWindow = Math.min( ...refundWindows );
-
-		text = translate( '%(days)d-day money back guarantee', '%(days)d-day money back guarantee', {
-			count: shortestRefundWindow,
-			args: { days: shortestRefundWindow },
-			comment: 'The number of days until the shortest refund window in the cart expires.',
-		} );
-	}
-
-	return (
-		<>
-			{ includeRefundIcon && <StyledIcon icon={ reusableBlock } size={ 24 } /> }
-			<CheckoutSummaryRefundWindowsContainer>
-				{ ! includeRefundIcon && <WPCheckoutCheckIcon /> }
-				{ highlight ? <strong>{ text }</strong> : text }
-			</CheckoutSummaryRefundWindowsContainer>
-		</>
-	);
-}
+export { CheckoutSummaryRefundWindows };
 
 export function CheckoutSummaryFeaturesList( props: {
 	siteId: number | undefined;


### PR DESCRIPTION
## Proposed Changes

- Add a sidebar trust footer under the Pay button: SSL line, dynamic refund line (reuses `CheckoutSummaryRefundWindows` untouched), divider, and a short "By purchasing, you accept the Terms of Service and Privacy Policy. Your subscription auto-renews. Read more" paragraph.
- Add `CheckoutTermsModal`, a medium-width `Modal` from `@wordpress/components` that wraps `<CheckoutTerms cart={cart} />` verbatim. Read more in the sidebar footer opens it. Every cart permutation (domain bundle, marketplace, 100-year plan, renewal, gift) renders its correct legalese because the modal reuses the existing component unchanged.
- Drop the inline "By checking out:" block from the main column for carts without a consent checkbox. Carts that require a consent checkbox (marketplace products, 100-year plan) still render `<BeforeSubmitCheckoutHeader />` above the checkbox, so "I have read and agree to all of the above" still has something to refer to.
- Extract `CheckoutSummaryRefundWindows` from `wp-checkout-order-summary.tsx` into its own file (`checkout-summary-refund-windows.tsx`) to break a circular import with the new `CheckoutPayButtonFooter`. `wp-checkout-order-summary.tsx` re-exports it for back-compat.

## Why are these changes being made?

The bottom of the checkout page used to render a long legal block — Terms, domain agreement, promotional dates, per-plan refund windows, and a "Read more" FoldableCard — right above the main-column submit button. It crowded the call to action, competed with the price recap for attention, and belonged next to the Pay button rather than above it.

This change moves the legal language into a modal reachable from the sidebar and condenses the everyday trust signals (encryption, refund window, auto-renew disclosure) into four compact lines under the Pay button. The modal reuses the existing `CheckoutTerms` component unchanged, so no translated strings are rewritten. Consent carts keep the inline block because their checkbox copy refers to it.

## Testing Instructions

- Open a desktop checkout with a plan + domain.
- Under the sidebar Pay button, expect: SSL line, refund line, divider, auto-renew paragraph with Terms of Service / Privacy Policy / Read more links.
- Click Read more. A medium-width modal opens with the same legal content the inline block used to show. `Esc` closes the modal.
- Main column: no inline "By checking out:" block for non-consent carts.
- Cart variants:
  - 100-year plan or marketplace product: inline block still renders above the consent checkbox.
  - Renewal, gift purchase, bundled domain: the modal's copy adjusts because it reuses `CheckoutTerms` unchanged.
- Terms of Service and Privacy Policy links open in new tabs and point at the localized URLs.
- `yarn eslint` passes on the changed files.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.