### PR TITLE
Checkout: payment processor disclosure line

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -93,6 +93,7 @@ import badge7Src from './assets/icons/badge-7.svg';
 import badgeGenericSrc from './assets/icons/badge-generic.svg';
 import badgeSecurity from './assets/icons/security.svg';
 import CheckoutNextSteps from './checkout-next-steps';
+import CheckoutProcessorNotice from './checkout-processor-notice';
 import { CheckoutSidebarPlanUpsell } from './checkout-sidebar-plan-upsell';
 import CheckoutTrustCards from './checkout-trust-cards';
 import { EmptyCart, shouldShowEmptyCartPage } from './empty-cart';
@@ -969,6 +970,7 @@ export default function CheckoutMainContent( {
 					) }
 					{ checkoutSummary }
 					{ checkoutMainContent }
+					<CheckoutProcessorNotice />
 					<CheckoutTrustCards cart={ responseCart } />
 				</WPCheckoutWrapper>
 			</SubmitButtonSlotContext.Provider>
@@ -1028,6 +1030,7 @@ export default function CheckoutMainContent( {
 					} }
 				</Step.TwoColumnLayout>
 				<LeaveCheckoutModal { ...leaveModalProps } />
+				<CheckoutProcessorNotice />
 				<CheckoutTrustCards cart={ responseCart } />
 			</StepContainerV2CheckoutFixer>
 		</SubmitButtonSlotContext.Provider>
@@ -1855,6 +1858,7 @@ const WPCheckoutWrapper = styled.div< {
 	grid-template-areas:
 		'sidebar-content'
 		'main-content'
+		'processor-notice'
 		'trust-cards';
 	align-content: start;
 	justify-content: center;
@@ -1865,6 +1869,7 @@ const WPCheckoutWrapper = styled.div< {
 		grid-template-columns: 1fr minmax( 500px, 688px ) 475px 1fr;
 		grid-template-areas:
 			'main-content main-content sidebar-content sidebar-content'
+			'processor-notice processor-notice processor-notice processor-notice'
 			'trust-cards trust-cards trust-cards trust-cards';
 		justify-items: end;
 	}
@@ -1876,6 +1881,11 @@ const WPCheckoutWrapper = styled.div< {
 
 	& > .checkout-trust-cards {
 		grid-area: trust-cards;
+		justify-self: center;
+	}
+
+	& > .checkout-processor-notice {
+		grid-area: processor-notice;
 		justify-self: center;
 	}
 
@@ -1904,6 +1914,7 @@ const WPCheckoutWrapper = styled.div< {
 				'checkout-title-area'
 				'sidebar-content'
 				'main-content'
+				'processor-notice'
 				'trust-cards';
 			.checkout-sidebar-content {
 				background: ${ colorStudio.colors[ 'White' ] };

--- a/client/my-sites/checkout/src/components/checkout-processor-notice.tsx
+++ b/client/my-sites/checkout/src/components/checkout-processor-notice.tsx
@@ -11,13 +11,19 @@ const Notice = styled.p`
 	box-sizing: border-box;
 `;
 
+// Legal disclosure; must not be translated. The en-dashes (U+2013) are intentional.
+const PROCESSOR_ADDRESS =
+	'Automattic Inc. 60 29th Street #343 – San Francisco, CA 94110 – United States of America';
+
 export default function CheckoutProcessorNotice() {
 	const translate = useTranslate();
 	return (
 		<Notice className="checkout-processor-notice">
-			{ translate(
-				'Your payment will be processed by Automattic Inc. 60 29th Street #343 – San Francisco, CA 94110 – United States of America'
-			) }
+			{ translate( 'Your payment will be processed by %(address)s', {
+				args: { address: PROCESSOR_ADDRESS },
+				comment:
+					'Legal disclosure shown below the checkout form. The %(address)s placeholder is a company name and street address; do not translate it.',
+			} ) }
 		</Notice>
 	);
 }

--- a/client/my-sites/checkout/src/components/checkout-processor-notice.tsx
+++ b/client/my-sites/checkout/src/components/checkout-processor-notice.tsx
@@ -1,0 +1,23 @@
+import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
+
+const Notice = styled.p`
+	margin: 0 auto;
+	padding: 24px;
+	text-align: center;
+	font-size: 13px;
+	color: ${ ( props ) => props.theme.colors.textColorLight };
+	max-width: 1280px;
+	box-sizing: border-box;
+`;
+
+export default function CheckoutProcessorNotice() {
+	const translate = useTranslate();
+	return (
+		<Notice className="checkout-processor-notice">
+			{ translate(
+				'Your payment will be processed by Automattic Inc. 60 29th Street #343 – San Francisco, CA 94110 – United States of America'
+			) }
+		</Notice>
+	);
+}


### PR DESCRIPTION
## Proposed Changes

- Add `CheckoutProcessorNotice`: a centered, muted-gray one-liner reading "Your payment will be processed by Automattic Inc. 60 29th Street #343 – San Francisco, CA 94110 – United States of America". The string uses literal en-dashes (U+2013), not hyphens, and is wrapped in `translate()` for localization.
- Render it below the two-column layout in both `WPCheckoutWrapper` and `StepContainerV2CheckoutFixer` render paths.
- Add a `'processor-notice'` row to `WPCheckoutWrapper`'s `grid-template-areas` in every responsive variant (mobile, desktop, and the `isCheckoutUiRedesignV1 && !isLargeViewport` override) and a `.checkout-processor-notice { grid-area: processor-notice; justify-self: center; }` rule.

## Why are these changes being made?

Users should be able to see who processes their payment before clicking Pay. A one-line disclosure is easy to skip when unneeded, but available to anyone who looks. Putting it on its own row (rather than under the submit button or inside the legal block) keeps it from competing with the call to action.

## Testing Instructions

- Open a desktop checkout. Below the two-column layout, a centered muted-gray line reads "Your payment will be processed by Automattic Inc. 60 29th Street #343 – San Francisco, CA 94110 – United States of America". En-dashes, not hyphens.
- Resize to tablet / mobile: the line wraps gracefully, stays centered.
- `yarn eslint` passes on the changed files.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.