### PR TITLE
Checkout: sidebar Pay button IS the real submit button (React portal)

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -1,10 +1,4 @@
-import {
-	isYearly,
-	isJetpackPurchasableItem,
-	isMonthlyProduct,
-	isBiennially,
-	isTriennially,
-} from '@automattic/calypso-products';
+import { isJetpackPurchasableItem, isMonthlyProduct } from '@automattic/calypso-products';
 import colorStudio from '@automattic/color-studio';
 import { Gridicon, MaterialIcon } from '@automattic/components';
 import {
@@ -40,7 +34,8 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { pencil } from '@wordpress/icons';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useCallback } from 'react';
+import { useCallback, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
 import Loading from 'calypso/components/loading';
 import { useInitialIsInStepContainerV2FlowContext } from 'calypso/layout/utils';
 import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
@@ -64,6 +59,10 @@ import { CheckoutOrderBanner } from 'calypso/my-sites/checkout/src/components/ch
 import { useCheckoutUiRedesignExperiment } from 'calypso/my-sites/checkout/src/hooks/use-checkout-ui-redesign-experiment';
 import useValidCheckoutBackUrl from 'calypso/my-sites/checkout/src/hooks/use-valid-checkout-back-url';
 import { leaveCheckout } from 'calypso/my-sites/checkout/src/lib/leave-checkout';
+import {
+	SubmitButtonSlotContext,
+	useSubmitButtonSlot,
+} from 'calypso/my-sites/checkout/src/lib/submit-button-slot';
 import { prepareDomainContactValidationRequest } from 'calypso/my-sites/checkout/src/types/wpcom-store-state';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import SitePreview from 'calypso/my-sites/customer-home/cards/features/site-preview';
@@ -82,12 +81,7 @@ import useCouponFieldState from '../hooks/use-coupon-field-state';
 import { validateContactDetails } from '../lib/contact-validation';
 import { updateCartContactDetailsForCheckout } from '../lib/update-cart-contact-details-for-checkout';
 import { CHECKOUT_STORE } from '../lib/wpcom-store';
-import { CheckoutMoneyBackGuarantee } from './CheckoutMoneyBackGuarantee';
 import AcceptTermsOfServiceCheckbox from './accept-terms-of-service-checkbox';
-import badge14Src from './assets/icons/badge-14.svg';
-import badge7Src from './assets/icons/badge-7.svg';
-import badgeGenericSrc from './assets/icons/badge-generic.svg';
-import badgeSecurity from './assets/icons/security.svg';
 import CheckoutNextSteps from './checkout-next-steps';
 import { CheckoutSidebarPlanUpsell } from './checkout-sidebar-plan-upsell';
 import { EmptyCart, shouldShowEmptyCartPage } from './empty-cart';
@@ -334,6 +328,22 @@ function CheckoutSidebarNudge( {
 	);
 }
 
+// Renders CheckoutFormSubmit inside CheckoutStepGroup (so it keeps full step-state
+// awareness) while portaling its output into the sidebar slot registered via
+// SubmitButtonSlotContext. The sidebar button IS the active payment-method submit
+// button — no hidden main-column button, no querySelector click proxy.
+function PortaledCheckoutFormSubmit( {
+	validateForm,
+}: {
+	validateForm?: () => Promise< boolean >;
+} ) {
+	const { slotEl } = useSubmitButtonSlot();
+	if ( ! slotEl ) {
+		return null;
+	}
+	return createPortal( <CheckoutFormSubmit validateForm={ validateForm } />, slotEl );
+}
+
 export default function CheckoutMainContent( {
 	addItemToCart,
 	changeSelection,
@@ -394,6 +404,17 @@ export default function CheckoutMainContent( {
 
 	const leaveModalProps = useCheckoutLeaveModal( { siteUrl: siteUrl ?? '' } );
 
+	// Shared sidebar slot for the active payment-method submit button. We render
+	// <CheckoutFormSubmit> inside <CheckoutStepGroup> so it keeps full step-state
+	// awareness, but createPortal its output into this slot in the sidebar — the
+	// sidebar Pay button IS the real submit button (including native Apple Pay /
+	// Google Pay buttons that require a genuine user click).
+	const [ submitButtonSlotEl, setSubmitButtonSlotEl ] = useState< HTMLElement | null >( null );
+	const submitButtonSlotValue = useMemo(
+		() => ( { slotEl: submitButtonSlotEl, setSlotEl: setSubmitButtonSlotEl } ),
+		[ submitButtonSlotEl ]
+	);
+
 	const searchParams = new URLSearchParams( window.location.search );
 	const isDIFMInCart = hasDIFMProduct( responseCart );
 	const isSignupCheckout = searchParams.get( 'signup' ) === '1';
@@ -416,9 +437,6 @@ export default function CheckoutMainContent( {
 		presalesChatKey !== 'wpcom';
 	usePresalesChat( presalesChatKey, isPresalesChatEnabled );
 
-	const hasCartJetpackProductsOnly = responseCart?.products?.every( ( product ) =>
-		isJetpackPurchasableItem( product.product_slug )
-	);
 	const areThereDomainProductsInCart =
 		hasDomainRegistration( responseCart ) || hasTransferProduct( responseCart );
 	const isGSuiteInCart = hasGoogleApps( responseCart );
@@ -907,17 +925,7 @@ export default function CheckoutMainContent( {
 						setIs100YearPlanTermsAccepted={ setIs100YearPlanTermsAccepted }
 						isSubmitted={ isSubmitted }
 					/>
-					<CheckoutFormSubmit
-						validateForm={ validateForm }
-						submitButtonHeader={ <SubmitButtonHeader /> }
-						submitButtonFooter={
-							hasCartJetpackProductsOnly ? (
-								<JetpackCheckoutSeals />
-							) : (
-								<CheckoutMoneyBackGuarantee cart={ responseCart } />
-							)
-						}
-					/>
+					<PortaledCheckoutFormSubmit validateForm={ validateForm } />
 				</CheckoutStepGroup>
 			</WPCheckoutMainContent>
 		</RestorableProductsProvider>
@@ -925,75 +933,79 @@ export default function CheckoutMainContent( {
 
 	if ( ! isStepContainerV2 ) {
 		return (
-			<WPCheckoutWrapper
-				className="checkout-wrapper"
-				isLargeViewport={ isLargeViewport }
-				isCheckoutUiRedesignV1={ isCheckoutUiRedesignV1 }
-			>
-				{ isCheckoutUiRedesignV1 && ! isLargeViewport && (
-					<WPCheckoutTitle className="checkout__main-title checkout__redesign-header">
-						{ translate( 'Checkout' ) }
-					</WPCheckoutTitle>
-				) }
-				{ checkoutSummary }
-				{ checkoutMainContent }
-			</WPCheckoutWrapper>
+			<SubmitButtonSlotContext.Provider value={ submitButtonSlotValue }>
+				<WPCheckoutWrapper
+					className="checkout-wrapper"
+					isLargeViewport={ isLargeViewport }
+					isCheckoutUiRedesignV1={ isCheckoutUiRedesignV1 }
+				>
+					{ isCheckoutUiRedesignV1 && ! isLargeViewport && (
+						<WPCheckoutTitle className="checkout__main-title checkout__redesign-header">
+							{ translate( 'Checkout' ) }
+						</WPCheckoutTitle>
+					) }
+					{ checkoutSummary }
+					{ checkoutMainContent }
+				</WPCheckoutWrapper>
+			</SubmitButtonSlotContext.Provider>
 		);
 	}
 
 	return (
-		<StepContainerV2CheckoutFixer
-			isLargeViewport={ isLargeViewport }
-			isCheckoutUiRedesignV1={ isCheckoutUiRedesignV1 }
-		>
-			<Step.TwoColumnLayout
-				firstColumnWidth={ 8 }
-				secondColumnWidth={ 4 }
-				topBar={ ( { isLargeViewport } ) => {
-					const topBar = (
-						<Step.TopBar
-							leftElement={ <Step.BackButton onClick={ leaveModalProps.clickClose } /> }
-							rightElement={
-								<span className="checkout-skip-button">
-									{ helpCenterButtonCopy && <label>{ helpCenterButtonCopy }</label> }
-									<Step.LinkButton onClick={ toggleHelpCenter }>
-										{ helpCenterButtonLink }
-									</Step.LinkButton>
-								</span>
-							}
-						/>
-					);
-
-					if ( isLargeViewport ) {
-						return <div className="checkout-top-bar-wrapper">{ topBar }</div>;
-					}
-
-					return (
-						<>
-							{ topBar }
-							{ isCheckoutUiRedesignV1 && (
-								<Step.Heading text={ translate( 'Checkout' ) } align="left" size="small" />
-							) }
-							{ checkoutSummary }
-						</>
-					);
-				} }
+		<SubmitButtonSlotContext.Provider value={ submitButtonSlotValue }>
+			<StepContainerV2CheckoutFixer
+				isLargeViewport={ isLargeViewport }
+				isCheckoutUiRedesignV1={ isCheckoutUiRedesignV1 }
 			>
-				{ ( { isLargeViewport } ) => {
-					if ( isLargeViewport ) {
+				<Step.TwoColumnLayout
+					firstColumnWidth={ 8 }
+					secondColumnWidth={ 4 }
+					topBar={ ( { isLargeViewport } ) => {
+						const topBar = (
+							<Step.TopBar
+								leftElement={ <Step.BackButton onClick={ leaveModalProps.clickClose } /> }
+								rightElement={
+									<span className="checkout-skip-button">
+										{ helpCenterButtonCopy && <label>{ helpCenterButtonCopy }</label> }
+										<Step.LinkButton onClick={ toggleHelpCenter }>
+											{ helpCenterButtonLink }
+										</Step.LinkButton>
+									</span>
+								}
+							/>
+						);
+
+						if ( isLargeViewport ) {
+							return <div className="checkout-top-bar-wrapper">{ topBar }</div>;
+						}
+
 						return (
 							<>
-								{ checkoutMainContent }
+								{ topBar }
+								{ isCheckoutUiRedesignV1 && (
+									<Step.Heading text={ translate( 'Checkout' ) } align="left" size="small" />
+								) }
 								{ checkoutSummary }
 							</>
 						);
-					}
+					} }
+				>
+					{ ( { isLargeViewport } ) => {
+						if ( isLargeViewport ) {
+							return (
+								<>
+									{ checkoutMainContent }
+									{ checkoutSummary }
+								</>
+							);
+						}
 
-					return checkoutMainContent;
-				} }
-			</Step.TwoColumnLayout>
-			<LeaveCheckoutModal { ...leaveModalProps } />
-		</StepContainerV2CheckoutFixer>
+						return checkoutMainContent;
+					} }
+				</Step.TwoColumnLayout>
+				<LeaveCheckoutModal { ...leaveModalProps } />
+			</StepContainerV2CheckoutFixer>
+		</SubmitButtonSlotContext.Provider>
 	);
 }
 
@@ -1653,22 +1665,6 @@ function CheckoutTermsAndCheckboxes( {
 	);
 }
 
-function SubmitButtonHeader() {
-	const translate = useTranslate();
-
-	const scrollToTOS = () => document?.getElementById( 'checkout-terms' )?.scrollIntoView();
-
-	return (
-		<SubmitButtonHeaderWrapper>
-			{ translate( 'By continuing, you agree to our {{button}}Terms of Service{{/button}}.', {
-				components: {
-					button: <button onClick={ scrollToTOS } />,
-				},
-			} ) }
-		</SubmitButtonHeaderWrapper>
-	);
-}
-
 function useDoesCartHaveMarketplaceProductRequiringConfirmation(
 	responseCart: ResponseCart
 ): boolean {
@@ -1682,114 +1678,6 @@ function useDoesCartHaveMarketplaceProductRequiringConfirmation(
 		)
 		.some( ( product ) => product.extra.is_marketplace_product );
 }
-
-const JetpackCheckoutSeals = () => {
-	const cartKey = useCartKey();
-	const { responseCart } = useShoppingCart( cartKey );
-	const translate = useTranslate();
-	const show7DayGuarantee = responseCart?.products?.every( isMonthlyProduct );
-	const show14DayGuarantee = responseCart?.products?.every(
-		( product ) => isYearly( product ) || isBiennially( product ) || isTriennially( product )
-	);
-	const moneybackGuaranteeHeader =
-		show7DayGuarantee || show14DayGuarantee ? (
-			translate( '%(dayCount)s-day money back guarantee', {
-				args: {
-					dayCount: show7DayGuarantee ? 7 : 14,
-				},
-			} )
-		) : (
-			<>
-				{ translate( '14-day money back guarantee on yearly subscriptions' ) }
-				<br />
-				{ translate( '7-day money back guarantee on monthly subscriptions' ) }
-			</>
-		);
-	let moneybackGuaranteeIcon = badgeGenericSrc;
-
-	if ( show7DayGuarantee ) {
-		moneybackGuaranteeIcon = badge7Src;
-	} else if ( show14DayGuarantee ) {
-		moneybackGuaranteeIcon = badge14Src;
-	}
-
-	return (
-		<JetpackCheckoutSealsWrapper>
-			<JetpackCheckoutSealsSection>
-				<img src={ moneybackGuaranteeIcon } alt="" />
-
-				<JetpackSealText>{ moneybackGuaranteeHeader }</JetpackSealText>
-			</JetpackCheckoutSealsSection>
-
-			<JetpackCheckoutSealsSection>
-				<img src={ badgeSecurity } alt="" />
-
-				<JetpackSealText>{ translate( 'SSL Secure checkout' ) }</JetpackSealText>
-			</JetpackCheckoutSealsSection>
-		</JetpackCheckoutSealsWrapper>
-	);
-};
-
-const JetpackCheckoutSealsWrapper = styled.div< React.HTMLAttributes< HTMLDivElement > >`
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	gap: 0.5rem;
-	padding: 1.5rem 4rem 0 1.5rem;
-
-	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
-		padding: 1.5rem 1.5rem 0;
-	}
-
-	img {
-		margin-right: 0.75rem;
-	}
-
-	span {
-		font-weight: 700;
-
-		line-height: 1.12;
-	}
-`;
-
-const JetpackCheckoutSealsSection = styled.div< React.HTMLAttributes< HTMLDivElement > >`
-	display: flex;
-	align-items: center;
-
-	color: ${ ( props ) => props.theme.colors.textColor };
-`;
-
-const JetpackSealText = styled.span`
-	padding: 0.1875rem 0 0 0;
-`;
-
-const SubmitButtonHeaderWrapper = styled.div`
-	display: none;
-	font-size: 13px;
-	margin-top: -5px;
-	margin-bottom: 10px;
-	text-align: center;
-
-	.checkout__step-wrapper--last-step & {
-		display: block;
-
-		@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
-			display: none;
-		}
-	}
-
-	button {
-		color: ${ ( props ) => props.theme.colors.highlight };
-		display: inline;
-		font-size: 13px;
-		text-decoration: underline;
-		width: auto;
-
-		&:hover {
-			color: ${ ( props ) => props.theme.colors.highlightOver };
-		}
-	}
-`;
 
 const WPCheckoutWrapper = styled.div< {
 	isLargeViewport?: boolean;

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -1,4 +1,10 @@
-import { isJetpackPurchasableItem, isMonthlyProduct } from '@automattic/calypso-products';
+import {
+	isYearly,
+	isJetpackPurchasableItem,
+	isMonthlyProduct,
+	isBiennially,
+	isTriennially,
+} from '@automattic/calypso-products';
 import colorStudio from '@automattic/color-studio';
 import { Gridicon, MaterialIcon } from '@automattic/components';
 import {
@@ -81,7 +87,12 @@ import useCouponFieldState from '../hooks/use-coupon-field-state';
 import { validateContactDetails } from '../lib/contact-validation';
 import { updateCartContactDetailsForCheckout } from '../lib/update-cart-contact-details-for-checkout';
 import { CHECKOUT_STORE } from '../lib/wpcom-store';
+import { CheckoutMoneyBackGuarantee } from './CheckoutMoneyBackGuarantee';
 import AcceptTermsOfServiceCheckbox from './accept-terms-of-service-checkbox';
+import badge14Src from './assets/icons/badge-14.svg';
+import badge7Src from './assets/icons/badge-7.svg';
+import badgeGenericSrc from './assets/icons/badge-generic.svg';
+import badgeSecurity from './assets/icons/security.svg';
 import CheckoutNextSteps from './checkout-next-steps';
 import { CheckoutSidebarPlanUpsell } from './checkout-sidebar-plan-upsell';
 import { EmptyCart, shouldShowEmptyCartPage } from './empty-cart';
@@ -437,6 +448,9 @@ export default function CheckoutMainContent( {
 		presalesChatKey !== 'wpcom';
 	usePresalesChat( presalesChatKey, isPresalesChatEnabled );
 
+	const hasCartJetpackProductsOnly = responseCart?.products?.every( ( product ) =>
+		isJetpackPurchasableItem( product.product_slug )
+	);
 	const areThereDomainProductsInCart =
 		hasDomainRegistration( responseCart ) || hasTransferProduct( responseCart );
 	const isGSuiteInCart = hasGoogleApps( responseCart );
@@ -925,7 +939,21 @@ export default function CheckoutMainContent( {
 						setIs100YearPlanTermsAccepted={ setIs100YearPlanTermsAccepted }
 						isSubmitted={ isSubmitted }
 					/>
-					<PortaledCheckoutFormSubmit validateForm={ validateForm } />
+					{ isLargeViewport ? (
+						<PortaledCheckoutFormSubmit validateForm={ validateForm } />
+					) : (
+						<CheckoutFormSubmit
+							validateForm={ validateForm }
+							submitButtonHeader={ <SubmitButtonHeader /> }
+							submitButtonFooter={
+								hasCartJetpackProductsOnly ? (
+									<JetpackCheckoutSeals />
+								) : (
+									<CheckoutMoneyBackGuarantee cart={ responseCart } />
+								)
+							}
+						/>
+					) }
 				</CheckoutStepGroup>
 			</WPCheckoutMainContent>
 		</RestorableProductsProvider>
@@ -1665,6 +1693,22 @@ function CheckoutTermsAndCheckboxes( {
 	);
 }
 
+function SubmitButtonHeader() {
+	const translate = useTranslate();
+
+	const scrollToTOS = () => document?.getElementById( 'checkout-terms' )?.scrollIntoView();
+
+	return (
+		<SubmitButtonHeaderWrapper>
+			{ translate( 'By continuing, you agree to our {{button}}Terms of Service{{/button}}.', {
+				components: {
+					button: <button onClick={ scrollToTOS } />,
+				},
+			} ) }
+		</SubmitButtonHeaderWrapper>
+	);
+}
+
 function useDoesCartHaveMarketplaceProductRequiringConfirmation(
 	responseCart: ResponseCart
 ): boolean {
@@ -1678,6 +1722,114 @@ function useDoesCartHaveMarketplaceProductRequiringConfirmation(
 		)
 		.some( ( product ) => product.extra.is_marketplace_product );
 }
+
+const JetpackCheckoutSeals = () => {
+	const cartKey = useCartKey();
+	const { responseCart } = useShoppingCart( cartKey );
+	const translate = useTranslate();
+	const show7DayGuarantee = responseCart?.products?.every( isMonthlyProduct );
+	const show14DayGuarantee = responseCart?.products?.every(
+		( product ) => isYearly( product ) || isBiennially( product ) || isTriennially( product )
+	);
+	const moneybackGuaranteeHeader =
+		show7DayGuarantee || show14DayGuarantee ? (
+			translate( '%(dayCount)s-day money back guarantee', {
+				args: {
+					dayCount: show7DayGuarantee ? 7 : 14,
+				},
+			} )
+		) : (
+			<>
+				{ translate( '14-day money back guarantee on yearly subscriptions' ) }
+				<br />
+				{ translate( '7-day money back guarantee on monthly subscriptions' ) }
+			</>
+		);
+	let moneybackGuaranteeIcon = badgeGenericSrc;
+
+	if ( show7DayGuarantee ) {
+		moneybackGuaranteeIcon = badge7Src;
+	} else if ( show14DayGuarantee ) {
+		moneybackGuaranteeIcon = badge14Src;
+	}
+
+	return (
+		<JetpackCheckoutSealsWrapper>
+			<JetpackCheckoutSealsSection>
+				<img src={ moneybackGuaranteeIcon } alt="" />
+
+				<JetpackSealText>{ moneybackGuaranteeHeader }</JetpackSealText>
+			</JetpackCheckoutSealsSection>
+
+			<JetpackCheckoutSealsSection>
+				<img src={ badgeSecurity } alt="" />
+
+				<JetpackSealText>{ translate( 'SSL Secure checkout' ) }</JetpackSealText>
+			</JetpackCheckoutSealsSection>
+		</JetpackCheckoutSealsWrapper>
+	);
+};
+
+const JetpackCheckoutSealsWrapper = styled.div< React.HTMLAttributes< HTMLDivElement > >`
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 1.5rem 4rem 0 1.5rem;
+
+	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
+		padding: 1.5rem 1.5rem 0;
+	}
+
+	img {
+		margin-right: 0.75rem;
+	}
+
+	span {
+		font-weight: 700;
+
+		line-height: 1.12;
+	}
+`;
+
+const JetpackCheckoutSealsSection = styled.div< React.HTMLAttributes< HTMLDivElement > >`
+	display: flex;
+	align-items: center;
+
+	color: ${ ( props ) => props.theme.colors.textColor };
+`;
+
+const JetpackSealText = styled.span`
+	padding: 0.1875rem 0 0 0;
+`;
+
+const SubmitButtonHeaderWrapper = styled.div`
+	display: none;
+	font-size: 13px;
+	margin-top: -5px;
+	margin-bottom: 10px;
+	text-align: center;
+
+	.checkout__step-wrapper--last-step & {
+		display: block;
+
+		@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
+			display: none;
+		}
+	}
+
+	button {
+		color: ${ ( props ) => props.theme.colors.highlight };
+		display: inline;
+		font-size: 13px;
+		text-decoration: underline;
+		width: auto;
+
+		&:hover {
+			color: ${ ( props ) => props.theme.colors.highlightOver };
+		}
+	}
+`;
 
 const WPCheckoutWrapper = styled.div< {
 	isLargeViewport?: boolean;

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -23,7 +23,7 @@ import {
 } from '@automattic/calypso-products';
 import colorStudio from '@automattic/color-studio';
 import { Gridicon } from '@automattic/components';
-import { Button, FormStatus, useFormStatus } from '@automattic/composite-checkout';
+import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { formatCurrency } from '@automattic/number-formatters';
 import { useShoppingCart } from '@automattic/shopping-cart';
@@ -50,8 +50,8 @@ import { useCheckoutUiRedesignExperiment } from '../hooks/use-checkout-ui-redesi
 import getAkismetProductFeatures from '../lib/get-akismet-product-features';
 import getJetpackProductFeatures from '../lib/get-jetpack-product-features';
 import getPlanFeatures from '../lib/get-plan-features';
+import { useSubmitButtonSlot } from '../lib/submit-button-slot';
 import { CheckIcon } from './check-icon';
-import { CheckoutSubmitButtonContent } from './checkout-submit-button-content';
 import { ProductsAndCostOverridesList } from './cost-overrides-list';
 import { getRefundPolicies, getRefundWindows, RefundPolicy } from './refund-policies';
 import type { ResponseCart, ResponseCartProduct } from '@automattic/shopping-cart';
@@ -63,36 +63,6 @@ import type { TranslateResult } from 'i18n-calypso';
 const PALETTE = colorStudio.colors;
 const COLOR_GRAY_40 = PALETTE[ 'Gray 40' ];
 const COLOR_GREEN_60 = PALETTE[ 'Green 60' ];
-
-// Mirrors the disabled state of the real submit button rendered inside the active payment
-// method step. composite-checkout disables that button until all prior steps are complete,
-// so we watch its `disabled` attribute to keep the sidebar Pay button in sync.
-function useRealSubmitButtonDisabled(): boolean {
-	const [ isDisabled, setIsDisabled ] = React.useState( true );
-
-	React.useEffect( () => {
-		const readDisabledState = () => {
-			const activeButton = document.querySelector< HTMLButtonElement >(
-				'.checkout-submit-button--active button'
-			);
-			setIsDisabled( ! activeButton || activeButton.disabled );
-		};
-
-		readDisabledState();
-
-		const observer = new MutationObserver( readDisabledState );
-		observer.observe( document.body, {
-			attributes: true,
-			attributeFilter: [ 'disabled', 'class' ],
-			subtree: true,
-			childList: true,
-		} );
-
-		return () => observer.disconnect();
-	}, [] );
-
-	return isDisabled;
-}
 
 const StyledIcon = styled( Icon )`
 	fill: '#1E1E1E';
@@ -199,17 +169,7 @@ function CheckoutSummaryPriceList() {
 	const translate = useTranslate();
 	const monthlyPrices = useEquivalentMonthlyTotals( responseCart.products );
 	const [ , isCheckoutUiRedesignV1 ] = useCheckoutUiRedesignExperiment();
-	const { formStatus } = useFormStatus();
-	const isRealSubmitDisabled = useRealSubmitButtonDisabled();
-
-	// Forward clicks to the real submit button rendered inside the active payment method's
-	// step so PayPal/Apple Pay/Google Pay continue to own their own submit flows.
-	const handleSidebarPayClick = () => {
-		const realSubmitButton = document.querySelector< HTMLButtonElement >(
-			'.checkout-submit-button--active button:not([disabled])'
-		);
-		realSubmitButton?.click();
-	};
+	const { setSlotEl } = useSubmitButtonSlot();
 
 	const subtotalBeforeDiscounts = responseCart.products.reduce( ( subtotal, product ) => {
 		const originalAmountInteger = getSimulatedCostBeforeDiscounts( product, monthlyPrices );
@@ -293,15 +253,10 @@ function CheckoutSummaryPriceList() {
 						{ totalLineItem.formattedAmount }
 					</span>
 				</CheckoutSummaryTotal>
-				<CheckoutSummaryPayButton
-					buttonType="primary"
-					fullWidth
-					disabled={ formStatus !== FormStatus.READY || isRealSubmitDisabled }
-					onClick={ handleSidebarPayClick }
-					className="wp-checkout-order-summary__pay-button"
-				>
-					<CheckoutSubmitButtonContent />
-				</CheckoutSummaryPayButton>
+				<CheckoutSummaryPayButtonSlot
+					ref={ setSlotEl }
+					className="wp-checkout-order-summary__pay-button-slot"
+				/>
 			</CheckoutSummaryAmountWrapper>
 		</>
 	);
@@ -852,8 +807,21 @@ const CheckoutSummaryCard = styled.div`
 	}
 `;
 
-const CheckoutSummaryPayButton = styled( Button )`
+const CheckoutSummaryPayButtonSlot = styled.div`
 	margin-top: 16px;
+
+	/*
+	 * The real submit button renders here via a React portal (see submit-button-slot.ts).
+	 * Each payment method provides its own button element, so we style the slot to give
+	 * them a consistent full-width look in the sidebar.
+	 */
+	.checkout-submit-button {
+		width: 100%;
+	}
+
+	.checkout-submit-button button {
+		width: 100%;
+	}
 `;
 const CheckoutSummaryFeatures = styled.div`
 	padding: 24px 0;

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -35,6 +35,7 @@ import {
 } from '@automattic/wpcom-checkout';
 import { css, keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
+import { useViewportMatch } from '@wordpress/compose';
 import { Icon, reusableBlock } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import * as React from 'react';
@@ -170,6 +171,7 @@ function CheckoutSummaryPriceList() {
 	const monthlyPrices = useEquivalentMonthlyTotals( responseCart.products );
 	const [ , isCheckoutUiRedesignV1 ] = useCheckoutUiRedesignExperiment();
 	const { setSlotEl } = useSubmitButtonSlot();
+	const isLargeViewport = useViewportMatch( 'large', '>=' );
 
 	const subtotalBeforeDiscounts = responseCart.products.reduce( ( subtotal, product ) => {
 		const originalAmountInteger = getSimulatedCostBeforeDiscounts( product, monthlyPrices );
@@ -253,10 +255,12 @@ function CheckoutSummaryPriceList() {
 						{ totalLineItem.formattedAmount }
 					</span>
 				</CheckoutSummaryTotal>
-				<CheckoutSummaryPayButtonSlot
-					ref={ setSlotEl }
-					className="wp-checkout-order-summary__pay-button-slot"
-				/>
+				{ isLargeViewport && (
+					<CheckoutSummaryPayButtonSlot
+						ref={ setSlotEl }
+						className="wp-checkout-order-summary__pay-button-slot"
+					/>
+				) }
 			</CheckoutSummaryAmountWrapper>
 		</>
 	);

--- a/client/my-sites/checkout/src/lib/submit-button-slot.ts
+++ b/client/my-sites/checkout/src/lib/submit-button-slot.ts
@@ -1,0 +1,15 @@
+import { createContext, useContext } from 'react';
+
+interface SubmitButtonSlot {
+	slotEl: HTMLElement | null;
+	setSlotEl: ( el: HTMLElement | null ) => void;
+}
+
+export const SubmitButtonSlotContext = createContext< SubmitButtonSlot >( {
+	slotEl: null,
+	setSlotEl: () => undefined,
+} );
+
+export function useSubmitButtonSlot(): SubmitButtonSlot {
+	return useContext( SubmitButtonSlotContext );
+}


### PR DESCRIPTION
## Proposed Changes

- Replace the DOM-query proxy with a React portal. The main-column `CheckoutFormSubmit` still renders inside `CheckoutStepGroup` so it keeps full step-state awareness, but `createPortal` relocates its output into a slot in the sidebar registered via `SubmitButtonSlotContext`. The sidebar Pay button IS the active payment-method submit button.
- Add `src/lib/submit-button-slot.ts`: `SubmitButtonSlotContext` + `useSubmitButtonSlot()` exposing `{ slotEl, setSlotEl }`. `checkout-main-content.tsx` wraps the render in `<SubmitButtonSlotContext.Provider>`. `wp-checkout-order-summary.tsx` renders a `CheckoutSummaryPayButtonSlot` styled div with `ref={setSlotEl}` inside `CheckoutSummaryAmountWrapper`, gated to desktop via `useViewportMatch( 'large', '>=' )`.
- Delete the `CheckoutSummaryPayButton` styled proxy, the `handleSidebarPayClick` function that forwarded clicks via `querySelector('.checkout-submit-button--active button:not([disabled])').click()`, and the `useRealSubmitButtonDisabled` `MutationObserver` that mirrored the real button's `disabled` attribute.
- Gate the submit render by viewport. Desktop (`isLargeViewport`): `PortaledCheckoutFormSubmit`, since the sidebar slot is sticky and always visible. Mobile and tablet: inline `CheckoutFormSubmit` with the pre-branch `submitButtonHeader` (terms text) and `submitButtonFooter` (`JetpackCheckoutSeals` for Jetpack-only carts, `CheckoutMoneyBackGuarantee` otherwise). Composite-checkout's `SubmitButtonWrapper` already applies `position: fixed; bottom: 0` below `tabletUp`, so no new mobile styles are needed.
- Restore `SubmitButtonHeader`, `JetpackCheckoutSeals`, and the related styled-components (`JetpackCheckoutSealsWrapper`, `JetpackCheckoutSealsSection`, `JetpackSealText`, `SubmitButtonHeaderWrapper`), pulled verbatim from the parent commit. Re-import `CheckoutMoneyBackGuarantee` and the badge SVGs.

## Why are these changes being made?

The sidebar Pay button used to be a visual proxy that forwarded clicks to a hidden main-column button via `querySelector`. It was fragile: any CSS selector change could silently break it, and native Apple Pay / Google Pay sheets only open on a genuine user click. A programmatically forwarded click doesn't trigger them.

Portaling the real button into the sidebar slot fixes both. The button the user clicks is the active payment method's submit button. Each payment method owns its own submit element (Stripe's card button with 3DS, PayPal's redirect button, Apple/Google Pay's native sheet triggers), with no proxy layer between them.

The first portal-only revision broke mobile. On small viewports the order-summary sidebar starts as a collapsed card behind a "Purchase Details" toggle, so the only submit button was hidden by default. Gating by viewport keeps the desktop portal and falls back to the inline submit on mobile and tablet. `SubmitButtonWrapper` handles fixed-bottom positioning below `tabletUp`. The desktop sidebar's trust footer covers terms and guarantee on desktop; the restored `SubmitButtonHeader` and `JetpackCheckoutSeals` / `CheckoutMoneyBackGuarantee` cover them on mobile.

## Testing Instructions

- Desktop (≥960px): the sidebar order summary is sticky, the Pay button lives inside it, and clicking it submits. Stripe / PayPal / Apple Pay / Google Pay all behave as before.
- Mobile (<700px): the order summary collapses behind the "Purchase Details" toggle. A fixed-bottom Pay button appears at the bottom of the viewport with `SubmitButtonHeader` (terms text) above and `JetpackCheckoutSeals` (Jetpack carts) or `CheckoutMoneyBackGuarantee` (other carts) below. Clicking it submits.
- Tablet (700–960px): the Pay button renders inline at the bottom of the payment step, relative-positioned via `SubmitButtonWrapper`.
- Sweep widths 480 / 700 / 960 in DevTools: `document.querySelectorAll('button.checkout-submit-button')` returns exactly one element at every width. No doubled buttons.
- Console: no `originalFactory.call`, `sections-middleware`, or `createPortal` errors during navigation or form submission.
- `yarn eslint` passes on the changed files.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
