### PR TITLE
Checkout: unify sidebar + main column on white, match upsell shadow to summary card

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -2315,7 +2315,7 @@ const WPCheckoutCompletedMainContent = styled.div`
 `;
 
 const WPCheckoutSidebarContent = styled.div`
-	background: ${ ( props ) => props.theme.colors.background };
+	background: ${ colorStudio.colors[ 'White' ] };
 	grid-area: sidebar-content;
 	margin-top: var( --masterbar-checkout-height );
 

--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/style.scss
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/style.scss
@@ -3,8 +3,13 @@
 	margin-bottom: 24px;
 }
 
-.promo-card.checkout-sidebar-plan-upsell {
+.card.promo-card.checkout-sidebar-plan-upsell {
 	padding: 24px;
+	background: #fff;
+	border-radius: 3px;
+	box-shadow:
+		0 3px 1px rgba(0, 0, 0, 0.04),
+		0 3px 8px rgba(0, 0, 0, 0.12);
 }
 
 .promo-card.checkout-sidebar-plan-upsell .action-panel__title {


### PR DESCRIPTION
## Proposed Changes

- Change `WPCheckoutSidebarContent`'s background from `theme.colors.background` (neutral gray) to `colorStudio.colors['White']` so the right column blends with the main column as one continuous white canvas.
- Give the two-year upsell card (`CheckoutSidebarPlanUpsell`) the same two-layer box-shadow the `CheckoutSummaryCard` uses natively: `0 3px 1px rgba(0,0,0,0.04), 0 3px 8px rgba(0,0,0,0.12)`. Both cards now sit on the canvas with the same elevation.
- Bump the SCSS selector specificity to `.card.promo-card.checkout-sidebar-plan-upsell` so the shadow overrides `@automattic/components` Card's default `0 0 0 1px var(--color-border-subtle)` outline.

## Why are these changes being made?

The checkout page was two visually distinct strips: a white main column on the left and a neutral-gray sidebar on the right. The split made the page feel like two different surfaces when it's really one flow. Making both white gives the page a single canvas.

On a white canvas the upsell card's gradient-on-transparent visual disappears, and the Card component's default 1px subtle outline reads as no container at all. Matching the summary card's drop shadow restores the card's presence as a distinct element.

## Testing Instructions

- Open a desktop checkout with a plan + domain + a two-year-eligible offer.
- The right column background is white, matching the main column. No vertical color seam between the columns.
- The "Save 19% extra by paying for two years" card sits below the "Your order" summary with a soft drop shadow matching the summary card above it.
- Resize to tablet / mobile: the sidebar still collapses correctly; the mobile summary card retains its own gray wrapper (`#f5f5f5` with 1px Gray 10 border).
- `yarn eslint` and `yarn stylelint` pass on changed files.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.