### PR TITLE
Fix locale-dependent test in reader-site-subscription

### DIFF
--- a/client/blocks/reader-site-subscription/test/index.tsx
+++ b/client/blocks/reader-site-subscription/test/index.tsx
@@ -75,7 +75,7 @@ const renderReaderSiteSubscription = (
 describe( 'ReaderSiteSubscription', () => {
 	// Tests that the component renders with default props and no errors
 	it( 'should render with default props and no errors', () => {
-		const date = Intl.DateTimeFormat( undefined, { dateStyle: 'medium' } ).format(
+		const date = Intl.DateTimeFormat( 'en', { dateStyle: 'medium' } ).format(
 			new Date( '2023-01-01' )
 		);
 


### PR DESCRIPTION
## Summary
- Fix flaky unit test in `client/blocks/reader-site-subscription` that fails on systems where the default locale differs from `en`.
- The test used `Intl.DateTimeFormat(undefined, ...)` which picks up the system locale, but the component formats dates with the `'en'` locale from `translate.localeSlug`. Changed to `Intl.DateTimeFormat('en', ...)` to match.

## Test plan
- [ ] Run `yarn test-client client/blocks/reader-site-subscription/test/index.tsx` on a machine with a non-US locale and confirm tests pass.