### PR TITLE
Importer: handle wp-admin entry for the Instagram step

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
@@ -438,6 +438,7 @@ const siteSetupFlow: Flow = {
 
 				case 'importerWix':
 				case 'importerBlogger':
+				case 'importerInstagram':
 				case 'importerSubstack':
 				case 'importerMedium':
 				case 'importerSquarespace': {
@@ -541,6 +542,7 @@ const siteSetupFlow: Flow = {
 				}
 
 				case 'importerBlogger':
+				case 'importerInstagram':
 				case 'importerMedium':
 				case 'importerSubstack':
 				case 'importerSquarespace':


### PR DESCRIPTION
Part of #

## Proposed Changes

* Add `case 'importerInstagram':` to the two importer `switch` blocks in `site-setup-flow.ts` so the submit handler and the Back-button handler route the Instagram step through the same branches as Medium, Squarespace, Substack and Blogger.

## Why are these changes being made?

This PR unblocks a new entry point that lands users directly on the Instagram importer from **inside wp-admin**, instead of requiring them to find it through the Calypso `/import` picker.

The flow is:

1. From wp-admin/import.php (on both Simple and Atomic) we added an **Instagram** row in `jetpack-mu-wpcom` — see [Automattic/jetpack#48289](https://github.com/Automattic/jetpack/pull/48289). Clicking **Run Importer** redirects to:
   `https://wordpress.com/setup/site-setup/importerInstagram?ref=wp-admin-importers-list-direct-importer&siteSlug=<host>`
2. That URL mounts the Instagram importer step added in [#110131](https://github.com/Automattic/wp-calypso/pull/110131).
3. The `ref=wp-admin-importers-list-direct-importer` query param tells the site-setup flow's Back-button handler to return the user to `wp-admin/import.php` instead of the generic Calypso import list.

Without the cases this PR adds, that Back-button branch never runs for `importerInstagram`: it falls through the switch, so the user either gets no response on Back or lands somewhere generic. The submit branch has the same problem for post-upload navigation. Both cases already exist for the other importers; this PR extends the existing behaviour to Instagram.

The change is deliberately tiny (two lines) and orthogonal to the importer UI itself, which is why it is landing as its own PR.

## Testing Instructions

> Requires #110131 to be deployed first, because it owns the step registration for `importerInstagram`. This PR alone will compile and pass tests, but the user-facing flow is only meaningful once #110131 is live.

1. `yarn start`.
2. Visit `http://calypso.localhost:3000/setup/site-setup/importerInstagram?ref=wp-admin-importers-list-direct-importer&siteSlug=<site>` for a site you own.
3. Confirm the Instagram importer step mounts (dropzone visible).
4. Click the Back button. You should be redirected to the site's `wp-admin/import.php` page instead of `/setup/site-setup/importList`.
5. Re-visit the same URL without the `ref` query param. Back should take you to `/setup/site-setup/importList?...` (the pre-existing default).
6. Repeat the flow for `importerMedium` to confirm the existing Medium behaviour is unchanged.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Related PRs

- [#110131](https://github.com/Automattic/wp-calypso/pull/110131) — Calypso: registers the `importerInstagram` step, adds the UI and configs. Must land first (or with this) for the entry point to resolve.
- [Automattic/jetpack#48289](https://github.com/Automattic/jetpack/pull/48289) — jetpack-mu-wpcom: adds the **Instagram** row to wp-admin/import.php with the redirect that lands on the URL this PR handles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)