### PR TITLE
Billing Ticket Buster: replace auto-renew text link with ToggleControl on legacy

### DIFF
--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.tsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.tsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import { Button, ToggleControl } from '@wordpress/components';
 import { localize, LocalizeProps } from 'i18n-calypso';
-import { Component } from 'react';
+import { Component, type ReactNode } from 'react';
 import { connect } from 'react-redux';
 import { disableAutoRenew, enableAutoRenew } from 'calypso/lib/purchases/actions';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -29,7 +29,7 @@ export interface AutoRenewToggleProps {
 	getChangePaymentMethodUrlFor?: GetChangePaymentMethodUrlFor;
 	paymentMethodUrl?: string;
 	showLink?: boolean;
-	label?: string;
+	label?: ReactNode;
 	productSlug?: string;
 	siteSlug?: string | null;
 	children?: React.ReactNode;

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.tsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.tsx
@@ -29,6 +29,7 @@ export interface AutoRenewToggleProps {
 	getChangePaymentMethodUrlFor?: GetChangePaymentMethodUrlFor;
 	paymentMethodUrl?: string;
 	showLink?: boolean;
+	label?: string;
 	productSlug?: string;
 	siteSlug?: string | null;
 	children?: React.ReactNode;
@@ -254,7 +255,7 @@ class AutoRenewToggle extends Component<
 					checked={ this.getToggleUiStatus() }
 					disabled={ this.isUpdatingAutoRenew() || shouldDisable }
 					onChange={ this.onToggleAutoRenew }
-					label={ withTextStatus && this.renderTextStatus() }
+					label={ this.props.label ?? ( withTextStatus ? this.renderTextStatus() : undefined ) }
 				/>
 			);
 		}

--- a/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
@@ -194,7 +194,7 @@ function PurchaseMetaExpiration( {
 				<em className="manage-purchase__detail-label">{ detailLabel }</em>
 				{ ! hideAutoRenew && ! isJetpackPurchaseUsingPrimaryCancellationFlow && (
 					<div className="manage-purchase__auto-renew">
-						{ isSplitEnabled ? (
+						{ isSplitEnabled && shouldRenderToggle ? (
 							<AutoRenewToggle
 								planName={
 									site && ! isCancellableSitelessPurchase ? site.plan?.product_name_short : ''
@@ -203,7 +203,7 @@ function PurchaseMetaExpiration( {
 								siteSlug={ site && ! isCancellableSitelessPurchase ? site.slug : '' }
 								purchase={ purchase }
 								toggleSource="manage-purchase"
-								label={ translate( 'Enable auto-renew' ) as string }
+								label={ translate( 'Enable auto-renew' ) }
 								getChangePaymentMethodUrlFor={ getChangePaymentMethodUrlFor }
 							/>
 						) : (

--- a/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
@@ -86,6 +86,7 @@ function PurchaseMetaExpiration( {
 		( JETPACK_LEGACY_PLANS.some( ( plan ) => plan === purchase.productSlug ) &&
 			! isRenewable( purchase ) ) ||
 		is100Year( purchase );
+	const isSplitEnabled = config.isEnabled( 'purchases/split-cancel-remove' );
 
 	if ( isRenewable( purchase ) && ! isExpired( purchase ) ) {
 		const dateSpan = <span className="manage-purchase__detail-date-span" />;
@@ -193,9 +194,23 @@ function PurchaseMetaExpiration( {
 				<em className="manage-purchase__detail-label">{ detailLabel }</em>
 				{ ! hideAutoRenew && ! isJetpackPurchaseUsingPrimaryCancellationFlow && (
 					<div className="manage-purchase__auto-renew">
-						<span className="manage-purchase__detail manage-purchase__auto-renew-text">
-							{ subsRenewText }
-						</span>
+						{ isSplitEnabled ? (
+							<AutoRenewToggle
+								planName={
+									site && ! isCancellableSitelessPurchase ? site.plan?.product_name_short : ''
+								}
+								siteDomain={ site && ! isCancellableSitelessPurchase ? site.domain : '' }
+								siteSlug={ site && ! isCancellableSitelessPurchase ? site.slug : '' }
+								purchase={ purchase }
+								toggleSource="manage-purchase"
+								label={ translate( 'Enable auto-renew' ) as string }
+								getChangePaymentMethodUrlFor={ getChangePaymentMethodUrlFor }
+							/>
+						) : (
+							<span className="manage-purchase__detail manage-purchase__auto-renew-text">
+								{ subsRenewText }
+							</span>
+						) }
 					</div>
 				) }
 				<span

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -389,6 +389,10 @@
 	margin-bottom: 6px;
 }
 
+.manage-purchase__auto-renew .components-base-control {
+	margin-bottom: 0;
+}
+
 .manage-purchase__expiring-credit-card-notice.calypso-notice,
 .manage-purchase__purchase-expiring-notice.calypso-notice {
 	margin-bottom: 10px;

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -390,10 +390,6 @@
 }
 
 .manage-purchase__auto-renew .components-base-control {
-	margin-bottom: 0;
-}
-
-.manage-purchase__auto-renew .components-base-control__field {
 	margin-bottom: 6px;
 }
 

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -393,6 +393,10 @@
 	margin-bottom: 0;
 }
 
+.manage-purchase__auto-renew .components-base-control__field {
+	margin-bottom: 6px;
+}
+
 .manage-purchase__expiring-credit-card-notice.calypso-notice,
 .manage-purchase__purchase-expiring-notice.calypso-notice {
 	margin-bottom: 10px;


### PR DESCRIPTION
Fixes: https://linear.app/a8c/issue/RSM-1039

## Proposed Changes
Replaces the text based auto-renew toggle with a real toggle.

| Before | After |
| -- | -- |
| <img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/8990f7f8-b63d-44ed-8cdf-0ce7f1ac9e1c" /> | <img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/e0f84b90-6123-48e8-82ca-fc7d0f0d1f82" /> |

## Why are these changes being made?

The dashboard (MSD) already shows a proper `ToggleControl` labeled "Enable auto-renew" in the Subscription Renewal row. The legacy surface used a text link embedded in "Auto-renew is ON/OFF" copy — a weaker affordance that doesn't make clear auto-renew can be toggled. This brings the legacy surface in line with the dashboard under the existing Billing Ticket Buster feature flag (`purchases/split-cancel-remove`), with no change to behavior for flag-off users.

The `label` prop addition is purely additive — existing callers using `withTextStatus` or `showLink` are unaffected.

## Testing Instructions

1. Enable `purchases/split-cancel-remove` in your local config.
2. Go to `/me/purchases` → open any active subscription → Subscription Renewal row.
3. **Flag on**: should show a `ToggleControl` labeled "Enable auto-renew" with 6px spacing below the toggle, followed by the billing/expiry date copy.
4. **Flag off**: should show the existing "Auto-renew is {{ON/OFF}}" text link, unchanged.
5. Toggle the control — the existing dialogs (`AutoRenewDisablingDialog`, `AutoRenewPaymentMethodDialog`) should still fire as expected.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?