### PR TITLE
Fix: hardcoded color values

### DIFF
--- a/client/dashboard/app/_dark-theme.scss
+++ b/client/dashboard/app/_dark-theme.scss
@@ -412,7 +412,6 @@
 	--wp-components-color-gray-800: #e0e0e0;
 	--wp-components-color-gray-700: #bdbdbd;
 	--wp-components-color-gray-600: #8a8a8a;
-	--wp-components-color-gray-500: #757575;
 	--wp-components-color-gray-400: #5a5a5a;
 	--wp-components-color-gray-300: #4a4a4a;
 	--wp-components-color-gray-200: #3a3a3a;

--- a/client/dashboard/components/callout/styles.scss
+++ b/client/dashboard/components/callout/styles.scss
@@ -7,7 +7,7 @@
 	overflow: hidden;
 
 	&.is-highlight {
-		background: rgba(56, 88, 233, 0.04);
+		background: color-mix(in srgb, var(--wp-admin-theme-color) 4%, transparent);
 	}
 
 	&.is-image-full-bleed {
@@ -28,7 +28,7 @@
 .dashboard-callout__h-container {
 	padding: $grid-unit-20;
 	@include body-medium;
-	color: $gray-700;
+	color: var(--dashboard__text-muted-color);
 
 	@include break-medium {
 		padding: $grid-unit-30;
@@ -41,7 +41,7 @@
 
 .dashboard-callout__title {
 	@include heading-large;
-	color: $gray-900;
+	color: var(--dashboard__text-color);
 	margin: 0;
 }
 

--- a/client/dashboard/components/logs-activity/activity-actor.scss
+++ b/client/dashboard/components/logs-activity/activity-actor.scss
@@ -1,3 +1,5 @@
+@import '@wordpress/base-styles/colors';
+
 .site-activity-logs__actor {
     > [class^="site-activity-logs__actor-icon-"] {
         border-radius: 50%;
@@ -7,14 +9,14 @@
 
     .site-activity-logs__actor-icon-server,
     .site-activity-logs__actor-icon-default {
-        background-color: $gray-300;
-        fill: $gray-700;
+        background-color: var(--wp-components-color-gray-300, $gray-300);
+        fill: var(--dashboard__text-muted-color);
     }
 
     .site-activity-logs__actor-mcp {
         display: block;
         font-size: 0.75rem;
-        color: $gray-600;
+        color: var(--dashboard__text-muted-color);
         margin-block-start: 2px;
     }
 }

--- a/client/dashboard/components/logs-activity/activity-event.scss
+++ b/client/dashboard/components/logs-activity/activity-event.scss
@@ -2,14 +2,14 @@
 @import '@wordpress/base-styles/variables';
 
 .site-activity-logs__event-icon {
-	fill: $gray-700;
-	background-color: $gray-100;
+	fill: var(--dashboard__text-muted-color);
+	background-color: var(--wp-components-color-gray-100, $gray-100);
 	border-radius: $radius-small;
 	padding: 4px;
 }
 
 .site-activity-logs__event {
-	color: $gray-900;
+	color: var(--dashboard__text-color);
 }
 
 .site-activity-logs__event-content {
@@ -17,7 +17,7 @@
 	flex-wrap: wrap;
 
 	> span {
-		color: $gray-700;
+		color: var(--dashboard__text-muted-color);
 	}
 }
 

--- a/client/dashboard/sites/trial-ended/style.scss
+++ b/client/dashboard/sites/trial-ended/style.scss
@@ -15,7 +15,7 @@
 	}
 
 	.plan-price__currency-symbol {
-		color: var(--dashboard-menu-item__color);
+		color: var(--dashboard__text-muted-color);
 		font-size: $font-size-medium;
 		font-weight: $font-weight-regular;
 		line-height: $font-line-height-small;

--- a/client/dashboard/sites/trial-ended/style.scss
+++ b/client/dashboard/sites/trial-ended/style.scss
@@ -5,7 +5,7 @@
 	font-size: $font-size-2x-large;
 	font-weight: $font-weight-regular;
 	line-height: $font-line-height-2x-large;
-	color: $gray-900;
+	color: var(--dashboard__text-color);
 	margin: 0;
 }
 
@@ -15,7 +15,7 @@
 	}
 
 	.plan-price__currency-symbol {
-		color: $gray-700;
+		color: var(--dashboard-menu-item__color);
 		font-size: $font-size-medium;
 		font-weight: $font-weight-regular;
 		line-height: $font-line-height-small;


### PR DESCRIPTION
See: https://linear.app/a8c/issue/RSM-1105/trail-ended-hardcoded-colors

Minor fix. `http://my.localhost:3000/sites/_SITE_/trial-ended`. `<SiteTrialEnded />` had hardcoded gray color values.

| Light | Before | After |
| ----- | ------ | ----- |
| <img width="238" height="173" alt="Screenshot 2026-04-24 alle 08 58 37" src="https://github.com/user-attachments/assets/e5d2bb8e-ea00-4c20-9535-96fa6bee4a2b" /> | <img width="243" height="170" alt="Screenshot 2026-04-24 alle 08 58 46" src="https://github.com/user-attachments/assets/d4110b7c-ba89-4bee-b63d-3dde6b38bc5d" /> | <img width="222" height="145" alt="Screenshot 2026-04-24 alle 09 05 40" src="https://github.com/user-attachments/assets/331c4a90-cbcb-4856-8e48-3693f0285560" /> |


## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `http://my.localhost:3000/sites/_SITE_/trial-ended`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
