### PR TITLE
E2E: fix flaky "Flaky by race condition" infrastructure test

### DIFF
--- a/test/e2e/specs/infrastructure/infrastructure__flaky-fixture.spec.ts
+++ b/test/e2e/specs/infrastructure/infrastructure__flaky-fixture.spec.ts
@@ -31,8 +31,12 @@ test.describe( 'Infrastructure: Flaky fixture (testing only)', { tag: [ tags.CAL
 			);
 		} );
 
-		await test.step( 'Then the element is visible within a too-short timeout', async function () {
-			await expect( page.locator( '#late' ) ).toBeVisible( { timeout: 150 } );
+		await test.step( 'Then the element eventually becomes visible', async function () {
+			// The fixture appends `#late` after a random delay of up to ~850ms.
+			// Rely on Playwright's built-in auto-waiting rather than a hardcoded
+			// short timeout so the assertion waits long enough for the element
+			// to be attached and visible regardless of the random delay.
+			await expect( page.locator( '#late' ) ).toBeVisible();
 		} );
 	} );
 } );


### PR DESCRIPTION
Part of #

## Proposed Changes

- Remove the hardcoded 150ms timeout on the `#late` visibility assertion in `infrastructure__flaky-fixture.spec.ts` and rely on Playwright's built-in auto-waiting for `toBeVisible()`.
- Rename the step from "Then the element is visible within a too-short timeout" to "Then the element eventually becomes visible" to reflect the new behavior.
- Add a short inline comment explaining why no explicit short timeout is needed.

## Why are these changes being made?

The test loads an inline page whose script appends the `#late` element after a random delay of `50 + floor(random * 800)` ms (i.e. 50–850ms). The assertion was capped at a hardcoded 150ms timeout, so it only passed when the random roll happened to be below ~150ms and failed otherwise with `element(s) not found`. This is a race between the fixture's own async DOM insertion and a too-short explicit Playwright timeout, as observed on the CI run: https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Playwright_Test_Matrix/17452235.

Relying on Playwright's default `expect` timeout comfortably covers the fixture's worst-case ~850ms insertion delay, so the assertion deterministically waits until the element is attached and visible regardless of the random roll. No product code is touched — the flake was purely in the test's timing expectation.

## Testing Instructions

- Run `yarn playwright test test/e2e/specs/infrastructure/infrastructure__flaky-fixture.spec.ts --reporter=list --repeat-each=10` locally; all runs should pass.

## Pre-merge Checklist

- [ ] Has the Docs team been notified about any user-facing changes? If so, which issue on their GH project tracks the update?
- [ ] Has the UX team been notified about any UX changes? If so, which issue on their GH project tracks the update?
- [ ] Have you checked for Accessibility regressions (if applicable)?
- [ ] Have you added developer documentation (if applicable)?
- [ ] Have you added unit tests, integration tests and/or end-to-end tests (as applicable)?