### PR TITLE
Dashboard: auto-redirect from critical-error screen when site recovers

### DIFF
--- a/client/dashboard/sites/critical-error/index.tsx
+++ b/client/dashboard/sites/critical-error/index.tsx
@@ -42,9 +42,6 @@ const SiteCriticalError = ( { siteSlug }: { siteSlug: string } ) => {
 
 	useEffect( () => {
 		if ( hasRecovered ) {
-			// Replace history so Back doesn't return to this now-obsolete screen,
-			// and skip the view transition since this is an automatic redirect,
-			// matching the convention in dashboardRedirect().
 			navigate( {
 				to: '/sites/$siteSlug',
 				params: { siteSlug },

--- a/client/dashboard/sites/critical-error/index.tsx
+++ b/client/dashboard/sites/critical-error/index.tsx
@@ -1,5 +1,6 @@
 import { siteBySlugQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
 import { Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -11,7 +12,7 @@ import { Card, CardBody, CardDivider } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { Text } from '../../components/text';
-import { getJetpackCriticalErrorMessage } from '../site/notices';
+import { getJetpackCriticalErrorMessage, hasJetpackCriticalError } from '../site/notices';
 import type { ReactElement, ReactNode } from 'react';
 
 type Item = {
@@ -19,16 +20,31 @@ type Item = {
 	text: ReactNode;
 };
 
+// Poll while the user is on the critical-error screen so we can send them back
+// to the overview as soon as the site comes back online.
+const RECOVERY_POLL_INTERVAL_MS = 30_000;
+
 const SiteCriticalError = ( { siteSlug }: { siteSlug: string } ) => {
-	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+	const { data: site } = useSuspenseQuery( {
+		...siteBySlugQuery( siteSlug ),
+		refetchInterval: RECOVERY_POLL_INTERVAL_MS,
+	} );
 	const { setShowHelpCenter } = useHelpCenter();
 	const { recordTracksEvent } = useAnalytics();
+	const navigate = useNavigate();
 
 	const isAdmin = !! site.capabilities?.manage_options;
+	const hasRecovered = ! site.__inaccessible_jetpack_error || ! hasJetpackCriticalError( site );
 
 	useEffect( () => {
 		recordTracksEvent( 'calypso_dashboard_critical_error_impression' );
 	}, [ recordTracksEvent ] );
+
+	useEffect( () => {
+		if ( hasRecovered ) {
+			navigate( { to: '/sites/$siteSlug', params: { siteSlug } } );
+		}
+	}, [ hasRecovered, navigate, siteSlug ] );
 
 	const message = getJetpackCriticalErrorMessage( site );
 

--- a/client/dashboard/sites/critical-error/index.tsx
+++ b/client/dashboard/sites/critical-error/index.tsx
@@ -42,7 +42,15 @@ const SiteCriticalError = ( { siteSlug }: { siteSlug: string } ) => {
 
 	useEffect( () => {
 		if ( hasRecovered ) {
-			navigate( { to: '/sites/$siteSlug', params: { siteSlug } } );
+			// Replace history so Back doesn't return to this now-obsolete screen,
+			// and skip the view transition since this is an automatic redirect,
+			// matching the convention in dashboardRedirect().
+			navigate( {
+				to: '/sites/$siteSlug',
+				params: { siteSlug },
+				replace: true,
+				viewTransition: false,
+			} );
 		}
 	}, [ hasRecovered, navigate, siteSlug ] );
 


### PR DESCRIPTION
Part of #110098

Follow-up to [this review comment](https://github.com/Automattic/wp-calypso/pull/110098#discussion_r3130685865).

## Proposed Changes

* Poll the site every 30 seconds while the user is on the Jetpack critical-error screen.
* When the site no longer meets the critical-error criteria (`__inaccessible_jetpack_error` cleared or `hasJetpackCriticalError` returns false), navigate the user back to the site overview.

## Why are these changes being made?

Today the critical-error screen is a dead end — the user has to manually refresh once the site recovers. Polling the site query lets us send them back to the overview automatically as soon as Jetpack is reachable again and the recovery-mode state has cleared. The redirect condition mirrors the existing guard in `siteCriticalErrorRoute.beforeLoad`, so the two entry points stay consistent.

## Testing Instructions

1. Open a Jetpack site that is in Jetpack recovery mode / has `__inaccessible_jetpack_error`. You should land on `/sites/<slug>/critical-error`.
2. Resolve the critical error on the site (or mock the response so `jetpack_recovery_mode_status` no longer indicates an active critical error).
3. Within 30 seconds of the next poll, the dashboard should automatically redirect to `/sites/<slug>`.
4. Confirm that while the site is still in critical error the screen stays put and does not flash between pages.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?