### PR TITLE
E2E: fix flaky signup-with-theme-LOHP

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/lohp-theme-signup-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/lohp-theme-signup-flow.ts
@@ -55,10 +55,20 @@ export class LOHPThemeSignupFlow {
 	 */
 	async visitCalypsoGetStartedLinkForTheme(): Promise< string > {
 		const pageThemeDetails = new ThemesDetailPage( this.page );
+		// Ensure the theme details view has rendered the "Get started" link
+		// before reading its href; on mobile the transition from the themes
+		// showcase to the details view can race the href read.
+		await this.page
+			.getByRole( 'link', { name: 'Get started' } )
+			.first()
+			.waitFor( { state: 'attached', timeout: 30_000 } );
 		const calypsoGetStartedLink = await pageThemeDetails.calypsoGetStartedLink();
 		const themeSlug =
 			pageThemeDetails.getThemeSlugFromCalypsoGetStartedLink( calypsoGetStartedLink );
 		await this.page.goto( calypsoGetStartedLink );
+		// Wait for the signup flow URL to settle before returning so the
+		// subsequent assertions don't race the in-flight navigation.
+		await this.page.waitForURL( /\/start\//, { timeout: 30_000 } );
 		return themeSlug;
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/logged-out-themes-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/logged-out-themes-page.ts
@@ -18,10 +18,19 @@ export class LoggedOutThemesPage {
 	/**
 	 * Filters the themes by the given filter.
 	 *
+	 * Waits for the theme grid to re-render with at least one card attached
+	 * and visible after the filter is applied, so callers can safely interact
+	 * with `firstThemeCard` without racing the re-render.
+	 *
 	 * @param {string} filter - The filter to apply.
 	 */
 	async filterBy( filter: string ) {
 		await this.page.getByRole( 'combobox', { name: 'View' } ).click();
 		await this.page.getByRole( 'option', { name: filter } ).click();
+
+		// The theme grid re-renders asynchronously after the filter selection.
+		// Wait for the first theme card to be attached and visible before
+		// returning so subsequent clicks don't race the re-render.
+		await this.firstThemeCard.waitFor( { state: 'visible', timeout: 30_000 } );
 	}
 }


### PR DESCRIPTION
Part of #

## Proposed Changes

* `LoggedOutThemesPage.filterBy()` waits for the first theme card to become visible after the filter option is clicked, so callers don't race the grid re-render.
* `LOHPThemeSignupFlow.visitCalypsoGetStartedLinkForTheme()` waits for the "Get started" link to attach before reading its `href`, and waits for the URL to match `/\/start\//` after navigation, so callers see a stable signup page before asserting.
* No product code changes, no skips/mutes, no weakened assertions.

## Why are these changes being made?

The `signup__with-theme-LOHP.spec.ts` "One: As a new WordPress.com user I can sign up for a new Premium plan site using a theme from the Logged Out Home Page" test has been failing on `[Mobile]` (pixel) with two distinct races in the LOHP → theme → signup handoff, both amplified on mobile where layouts and re-renders cost more:

1. `filterBy('Free')` only awaited the dropdown option click and returned before the theme grid re-rendered, so the immediate `firstThemeCard.click()` could fire against a grid that had not yet attached `[data-e2e-theme]` cards (the Retry #1 failure — `locator('[data-e2e-theme]').first()` timing out).
2. `visitCalypsoGetStartedLinkForTheme()` read the "Get started" link `href` without first waiting for the theme details view to render, and after `page.goto()` it returned while the `/start/...` navigation was still in flight, so the subsequent `expect(createYourAccountHeading).toBeVisible()` could be evaluated before the signup app finished mounting (the original failure).

TeamCity build where this was observed: <https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Playwright_Test_Matrix/17452235>.

## Testing Instructions

* Run `yarn playwright test test/e2e/specs/onboarding/signup__with-theme-LOHP.spec.ts --reporter=list --repeat-each=10` locally; all runs should pass.
* CI on this PR will re-exercise the test on both `[Desktop]` and `[Mobile]` matrices.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?