### PR TITLE
Reader: Include view fragment in user profile page view tracking

### DIFF
--- a/client/reader/user-profile/controller.tsx
+++ b/client/reader/user-profile/controller.tsx
@@ -19,7 +19,9 @@ export function userProfile( ctx: Context, next: () => void ): void {
 	const view = context.params.view || 'posts';
 	const userLogin = context.params.user_login;
 	const userId = context.params.user_id;
-	const basePath = '/reader/users/:user_login';
+	const basePath = context.params.view
+		? `/reader/users/:user_login/${ view }`
+		: '/reader/users/:user_login';
 	const fullAnalyticsPageTitle =
 		analyticsPageTitle +
 		' > User > ' +


### PR DESCRIPTION
Fixes DOTCOM-16897

## Proposed Changes

* Include the view fragment (e.g., `lists`, `sites`) in the analytics base path for user profile page views.

## Why are these changes being made?

* Page view tracking for the Reader user profile currently only records the generic `/reader/users/:user_login` base path regardless of which tab is active. This makes it impossible to distinguish page views between different profile views in analytics.

## Testing Instructions

* Navigate to a user profile in Reader (e.g., `/reader/users/some_user`).
* Switch between tabs (posts, lists, sites, etc.).
* Verify that page view events include the view fragment in the path (e.g., `/reader/users/:user_login/lists`) when a specific tab is active, and use the base path `/reader/users/:user_login` when on the default posts tab.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?