### PR TITLE
E2E: fix flaky MeSidebar navigate detachment race

### DIFF
--- a/packages/calypso-e2e/src/lib/components/me/me-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/me/me-sidebar-component.ts
@@ -2,9 +2,12 @@ import { Page } from 'playwright';
 import envVariables from '../../../env-variables';
 
 const selectors = {
-	// Menu items
-	menuItem: ( menu: string ) =>
-		`.sidebar a:has(span:has-text("${ menu }")), .sidebar a[href="${ menu }"]`,
+	sidebar: '.sidebar',
+	// Menu items: prefer the visible label inside the sidebar. We match the
+	// anchor that contains a span whose text equals the provided label (text-is
+	// is exact-match, which avoids accidentally matching longer labels that
+	// happen to include the needle substring).
+	menuItem: ( menu: string ) => `.sidebar a:has(span:text-is("${ menu }"))`,
 };
 
 /**
@@ -37,9 +40,39 @@ export class MeSidebarComponent {
 	/**
 	 * Given a string, navigate to the menu on the sidebar.
 	 *
-	 * @param {string} menu Menu item label or href to navigate to.
+	 * The /me sidebar is re-rendered by React when the profile page finishes
+	 * hydrating and when data-dependent subtrees (notification counts, etc.)
+	 * resolve. A plain `page.click()` waits for the element to be visible,
+	 * enabled and stable, which races against those re-renders and regularly
+	 * produces "element was detached from the DOM, retrying" errors that
+	 * exhaust the default 10s action timeout.
+	 *
+	 * To avoid that race, we resolve the target anchor's href first, dispatch
+	 * the click directly on the DOM node (bypassing actionability checks that
+	 * are the source of the detachment race), and then wait for the resulting
+	 * URL to confirm the navigation actually happened. This mirrors the
+	 * pattern used by the main Calypso SidebarComponent.
+	 *
+	 * @param {string} menu Menu item label to navigate to (e.g. "Purchases").
 	 */
 	async navigate( menu: string ): Promise< void > {
-		await this.page.click( selectors.menuItem( menu ) );
+		// Make sure the sidebar itself is present before trying to resolve a
+		// link inside it. This guards against the case where the /me page has
+		// not finished its initial render yet.
+		const sidebar = this.page.locator( selectors.sidebar );
+		await sidebar.waitFor( { state: 'visible' } );
+
+		const menuItem = this.page.locator( selectors.menuItem( menu ) ).first();
+		await menuItem.waitFor( { state: 'attached' } );
+
+		// Capture the href before clicking so we can wait for the navigation
+		// deterministically even if the anchor re-mounts during the click.
+		const href = await menuItem.getAttribute( 'href' );
+
+		await menuItem.dispatchEvent( 'click' );
+
+		if ( href ) {
+			await this.page.waitForURL( `**${ href }`, { waitUntil: 'domcontentloaded' } );
+		}
 	}
 }


### PR DESCRIPTION
Part of #

## Proposed Changes

- Rewrite `MeSidebarComponent.navigate` in `packages/calypso-e2e` to avoid the React re-render race that was detaching the sidebar `<a>` mid-click.
- Resolve the menu anchor with a tighter `:text-is` exact-match selector and drop the never-matching `a[href="<label>"]` fallback that was in the old selector.
- Click via `dispatchEvent('click')` on the locator and `waitForURL` on the captured `href`, so the method returns only once navigation has actually started.

## Why are these changes being made?

The `Setup Domain Flows › As a new user, I can create a paid site, add a domain, then cancel the plan` spec was failing on the Desktop (chrome) project of the [E2E Tests (Playwright Test) matrix](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Playwright_Test_Matrix/17452235) with `TimeoutError: page.click: Timeout 10000ms exceeded` while clicking `Purchases` in the `/me` sidebar. The TeamCity trace shows the locator resolving to the real `<a href="/me/purchases">` anchor, then Playwright's actionability loop repeatedly reporting "element was detached from the DOM, retrying".

The `/me` sidebar is rendered by React and gets re-mounted after the profile page hydrates (user data, notification counts, and other data-dependent subtrees resolve on a second render pass). Playwright's default `page.click()` waits for the element to be visible, enabled and stable, and that stability loop keeps losing the race against the re-render. Playwright does retry detachment internally, but the cumulative waits exceed the 10s default action timeout.

The fix mirrors the pattern already in use by the main Calypso `SidebarComponent`: resolve the target anchor, capture its `href`, `dispatchEvent('click')` (which fires a synthetic DOM click and bypasses the actionability checks that are the source of the race), and `waitForURL` on the captured href to confirm navigation happened. No timeout was widened — we removed the condition that was timing out.

## Testing Instructions

- Run `yarn playwright test test/e2e/specs/flows/setup-domain__flows.spec.ts --reporter=list --repeat-each=10` locally with a running Calypso dev instance; all runs should pass.
- Alternatively, let CI on this PR run the Calypso E2E Playwright matrix and confirm the `Setup Domain Flows` test passes on the chrome project.

## Pre-merge Checklist

- [ ] Has the [relevant documentation](../tree/trunk/docs) been updated or added?
- [ ] Have you tested all the changes on both desktop and mobile?
- [ ] Have you added relevant [end-to-end test(s)](../blob/trunk/test/e2e)?
- [ ] Have you added [relevant unit tests](../blob/trunk/docs/testing-overview.md)?
- [ ] Have you included screenshots or screencasts where helpful?
- [ ] Does this PR need to be tagged for [release tests](../blob/trunk/packages/calypso-e2e/src/lib/flows/README.md)?
- [ ] Will the changes in this PR impact [the privacy](../blob/trunk/docs/privacy.md) of our users, their content or their sites?
- [ ] Does this PR involve changes that should be reflected in the app store listings?