### PR TITLE
[RSM-1107] Add dark mode to Plugins

### DIFF
--- a/client/dashboard/app/_dark-theme.scss
+++ b/client/dashboard/app/_dark-theme.scss
@@ -53,7 +53,8 @@
 	.components-textarea-control__input,
 	.components-base-control__label,
 	.components-input-control__label,
-	.components-checkbox-control__label {
+	.components-checkbox-control__label,
+	.components-toggle-control__label:not( .is-disabled ) {
 		color: var( --dashboard__text-color );
 	}
 
@@ -331,6 +332,27 @@
 		.dataviews-view-table__group-header-cell {
 			color: var( --dashboard__text-color );
 		}
+
+		tr.is-selected {
+			background-color: var( --dashboard-item-selected__background-color );
+			color: var( --dashboard__text-color );
+
+			&,
+			& + tr {
+				border-top-color: var( --dashboard-item-selected__border-color );
+			}
+
+			.dataviews-view-table__actions-column--sticky {
+				background-color: var( --dashboard-item-selected__background-color );
+			}
+		}
+
+		&.has-bulk-actions tr.is-selected,
+		&.has-bulk-actions tr.is-selected:hover {
+			.dataviews-view-table__actions-column--sticky {
+				background-color: var( --dashboard-item-selected__background-color );
+			}
+		}
 	}
 
 	// Title field (used as the row's primary link/label)
@@ -364,6 +386,26 @@
 		border-top-color: var( --dashboard-surface__border-color );
 	}
 
+	.dataviews-view-list div[role='row'].is-selected,
+	.dataviews-view-list div[role='article'].is-selected {
+		border-top-color: var( --dashboard-item-selected__border-color );
+
+		& + div[role='row'],
+		& + div[role='article'] {
+			border-top-color: var( --dashboard-item-selected__border-color );
+		}
+
+		.dataviews-view-list__item-wrapper {
+			background-color: var( --dashboard-item-selected__background-color );
+			color: var( --dashboard__text-color );
+
+			.dataviews-title-field,
+			.dataviews-view-list__field {
+				color: var( --dashboard__text-color );
+			}
+		}
+	}
+
 	.dataviews-view-list .dataviews-view-list__field {
 		color: var( --dashboard-subtle__color );
 	}
@@ -388,6 +430,10 @@
 		border-top-color: var( --dashboard-surface__border-color );
 	}
 
+	.dataviews-bulk-actions-footer__item-count {
+		color: var( --dashboard__text-muted-color );
+	}
+
 	// URL field override from our local styles.scss
 	a.dataviews-url-field {
 		color: var( --dashboard-subtle__color );
@@ -395,6 +441,61 @@
 		&:hover {
 			color: var( --wp-admin-theme-color );
 		}
+	}
+}
+
+/* Plugins */
+@mixin dashboard-dark-theme-plugins {
+	.plugin-switcher-item {
+		border-top-color: var( --dashboard-surface__border-color );
+
+		&:focus-visible:not( :disabled ) {
+			box-shadow: inset 0 0 0 2px var( --wp-admin-theme-color );
+			outline: none;
+		}
+
+		&:hover {
+			background-color: color-mix(
+				in srgb,
+				var( --dashboard-surface__background-color ) 82%,
+				var( --wp-admin-theme-color )
+			);
+		}
+
+		&.is-selected {
+			background: var( --dashboard-item-selected__background-color );
+			border-top-color: var( --dashboard-item-selected__border-color );
+
+			&:hover {
+				background: var( --dashboard-item-selected-hover__background-color );
+			}
+		}
+
+		&.is-selected + & {
+			border-top-color: var( --dashboard-item-selected__border-color );
+		}
+	}
+
+	.plugin-switcher-item-name {
+		color: var( --dashboard__text-color );
+	}
+
+	.plugin-icon-wrapper.is-fallback {
+		background: var( --dashboard-surface__background-color );
+		border-color: var( --dashboard-surface__border-color );
+
+		svg {
+			fill: var( --dashboard__text-muted-color );
+		}
+	}
+
+	.plugin-icon-placeholder {
+		background-color: color-mix(
+			in srgb,
+			var( --dashboard-surface__background-color ) 80%,
+			var( --dashboard__text-muted-color )
+		);
+		box-shadow: inset 0 0 0 1px var( --dashboard-surface__border-color );
 	}
 }
 
@@ -440,6 +541,17 @@
 	--dashboard-field__border-color: #949494;
 	--dashboard__text-muted-color: #bdbdbd;
 	--dashboard-subtle__color: #bdbdbd;
+	--dashboard-item-selected__background-color: color-mix(
+		in srgb,
+		var( --dashboard-surface__background-color ) 88%,
+		var( --wp-admin-theme-color )
+	);
+	--dashboard-item-selected-hover__background-color: color-mix(
+		in srgb,
+		var( --dashboard-surface__background-color ) 76%,
+		var( --wp-admin-theme-color )
+	);
+	--dashboard-item-selected__border-color: var( --wp-admin-theme-color );
 	--dashboard-warning__background-color: rgba( 212, 118, 8, 0.18 );
 	--dashboard-warning__border-color: var( --dashboard__background-color-warning );
 	--dashboard-warning__action-color: var( --dashboard__text-color );
@@ -491,6 +603,7 @@
 	@include dashboard-dark-theme-form-controls;
 	@include dashboard-dark-theme-item-group;
 	@include dashboard-dark-theme-popover;
+	@include dashboard-dark-theme-plugins;
 	@include dashboard-dark-theme-muted-text;
 	@include dashboard-dark-theme-section-header;
 	@include dashboard-dark-theme-summary-button;


### PR DESCRIPTION
Part of RSM-1107

## Proposed Changes

<img width="2772" height="1458" alt="CleanShot 2026-04-24 at 10 53 38@2x" src="https://github.com/user-attachments/assets/15a8a1b0-2053-408a-aa1f-a2d996074676" />


* Add shared dark-mode selected-state tokens for Dashboard list and table surfaces.
* Apply those tokens to DataViews table rows, DataViews list rows, and the plugins switcher selection state.
* Override dark-mode form control labels used by plugin action toggles so selected rows keep readable text.

## Why are these changes being made?

The Dashboard plugins page had a few light-mode defaults leaking into dark mode: selected plugin rows, selected DataViews rows, bulk-action footer counts, and toggle labels could become low contrast or white on dark surfaces. Those styles come from a mix of shared DataViews defaults and plugin-specific switcher styles, so the fix centralizes the reusable selected-state colors in the Dashboard dark theme and applies them where those shared components render.

This also makes the selected-state treatment available to other Dashboard DataViews list pages, including backups. The backups page uses DataViews list layout rather than the plugins page table layout, so it now receives the same dark-mode selected row treatment without a backups-specific override.

## Testing Instructions

* Open `http://my.localhost:3000/sites/<site>/backups`, enable dark mode, select a backup from the list, and confirm the selected row background, title, metadata, and row borders remain readable.
* Open `http://my.localhost:3000/plugins/manage`, enable dark mode, select plugins in the left list, and confirm hover and selected states remain readable.
* From the plugins page, open a plugin detail view, select a site row, and confirm the selected table row, bulk action count, and `On` toggle labels remain readable.
* Confirm local style linting passes for the changed dashboard stylesheet.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
