### PR TITLE
Omnibar: construct site node from new site-specific admin bar endpoint

### DIFF
--- a/client/dashboard/app/interim-omnibar/interim-omnibar-container.tsx
+++ b/client/dashboard/app/interim-omnibar/interim-omnibar-container.tsx
@@ -1,4 +1,4 @@
-import { omnibarCurrentSiteIdQuery, queryClient, siteByIdQuery } from '@automattic/api-queries';
+import { omnibarSiteIdQuery, queryClient, siteByIdQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { useCallback, useEffect, useState } from 'react';
 import { AUTH_QUERY_KEY, initializeCurrentUser } from '../auth';
@@ -46,7 +46,7 @@ function useInterimOmnibarData( {
 
 	const { data: currentSiteId } = useQuery(
 		{
-			...omnibarCurrentSiteIdQuery(),
+			...omnibarSiteIdQuery(),
 			enabled: hydrated,
 		},
 		queryClient

--- a/client/dashboard/app/omnibar/home.tsx
+++ b/client/dashboard/app/omnibar/home.tsx
@@ -1,4 +1,4 @@
-export function OmnibarHomeLogo() {
+export function OmnibarHomeIcon() {
 	return (
 		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" height="24" width="24">
 			<g xmlns="http://www.w3.org/2000/svg">

--- a/client/dashboard/app/omnibar/index.tsx
+++ b/client/dashboard/app/omnibar/index.tsx
@@ -1,19 +1,54 @@
-import { queryClient, dashboardAdminBarQuery } from '@automattic/api-queries';
+import {
+	queryClient,
+	dashboardAdminBarQuery,
+	omnibarSiteIdQuery,
+	siteAdminBarQuery,
+	siteByIdQuery,
+} from '@automattic/api-queries';
 import { Omnibar, buildOmnibarNodesFromAdminBarNodes } from '@automattic/omnibar';
 import { QueryClientProvider, useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { hydrateRoot } from 'react-dom/client';
-import { OmnibarHomeLogo } from './home';
+import SiteIcon from '../../components/site-icon';
+import { getSiteDisplayName } from '../../utils/site-name';
+import { OmnibarHomeIcon } from './home';
 
 function OmnibarContainer() {
-	const { data: { nodes = [] } = {} } = useQuery( dashboardAdminBarQuery() );
+	const { data: siteId } = useQuery( omnibarSiteIdQuery() );
+	const { data: site } = useQuery( {
+		...siteByIdQuery( siteId ?? 0 ),
+		enabled: !! siteId,
+	} );
+
+	const { data: { nodes: dashboardNodes } = {} } = useQuery( dashboardAdminBarQuery() );
+	const { data: { nodes: siteNodes } = {} } = useQuery( {
+		...siteAdminBarQuery( siteId ?? 0 ),
+		enabled: !! siteId,
+	} );
+
 	const omnibarNodes = useMemo( () => {
+		const nodes = siteNodes ?? dashboardNodes ?? [];
 		const result = buildOmnibarNodesFromAdminBarNodes( nodes );
+
 		if ( result.home ) {
-			result.home.render = OmnibarHomeLogo;
+			result.home.icon = <OmnibarHomeIcon />;
 		}
+
+		if ( site ) {
+			if ( ! result.site ) {
+				result.site = {
+					id: 'site-name',
+					title: '',
+					children: [],
+				};
+			}
+
+			result.site.icon = <SiteIcon site={ site } size={ 20 } />;
+			result.site.title = getSiteDisplayName( site );
+		}
+
 		return result;
-	}, [ nodes ] );
+	}, [ dashboardNodes, siteNodes, site ] );
 	return <Omnibar nodes={ omnibarNodes } />;
 }
 

--- a/client/dashboard/app/omnibar/site.ts
+++ b/client/dashboard/app/omnibar/site.ts
@@ -1,5 +1,5 @@
 import {
-	omnibarCurrentSiteIdQuery,
+	omnibarSiteIdQuery,
 	queryClient,
 	userPreferenceQuery,
 	userPreferenceOptimisticMutation,
@@ -16,7 +16,7 @@ import type { Site, User } from '@automattic/api-core';
  * Initializes the current site for the omnibar, which is extracted from the URL,
  * or the most recent sites, or the user's primary blog, in that priority.
  */
-export function useInitializeOmnibarCurrentSite() {
+export function useInitializeOmnibarSite() {
 	const user = queryClient.getQueryData< User >( AUTH_QUERY_KEY );
 
 	const { data: recentSiteIds } = useQuery( userPreferenceQuery( 'recentSites' ), queryClient );
@@ -55,7 +55,7 @@ export function useInitializeOmnibarCurrentSite() {
 		}
 
 		queryClient.setQueryData(
-			omnibarCurrentSiteIdQuery().queryKey,
+			omnibarSiteIdQuery().queryKey,
 			( currentSiteId ) => selectedSiteId || currentSiteId || fallbackSiteId
 		);
 

--- a/client/dashboard/app/root/index.tsx
+++ b/client/dashboard/app/root/index.tsx
@@ -22,7 +22,7 @@ import { useOmnibarEvent } from '../interim-omnibar/omnibar-events';
 import OmnibarHelpCenter from '../interim-omnibar/omnibar-help-center';
 import { NavigationBlockerRegistry } from '../navigation-blocker';
 import Notifications from '../notifications';
-import { useInitializeOmnibarCurrentSite } from '../omnibar/current-site';
+import { useInitializeOmnibarSite } from '../omnibar/site';
 import ResponsiveSidebar from '../responsive-sidebar';
 import Snackbars from '../snackbars';
 import './style.scss';
@@ -47,7 +47,7 @@ function Root() {
 	const [ isSidebarOpen, setIsSidebarOpen ] = useState( false );
 	const closeSidebar = useCallback( () => setIsSidebarOpen( false ), [ setIsSidebarOpen ] );
 
-	useInitializeOmnibarCurrentSite();
+	useInitializeOmnibarSite();
 	useOmnibarEvent( 'mobileMenu', () => setIsSidebarOpen( ( v ) => ! v ) );
 	useOmnibarEvent( 'linkClick', ( { href, event } ) => {
 		const url = new URL( href, window.location.origin );

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -84,6 +84,7 @@ export * from './site';
 export * from './site-activity-log';
 export * from './site-activity-log-backup';
 export * from './site-address-change';
+export * from './site-admin-bar';
 export * from './site-atomic-transfers';
 export * from './site-automated-transfers-eligibility';
 export * from './site-backup-download';

--- a/packages/api-core/src/site-admin-bar/fetchers.ts
+++ b/packages/api-core/src/site-admin-bar/fetchers.ts
@@ -1,0 +1,9 @@
+import { AdminBarResponse } from '../admin-bar/types';
+import { wpcom } from '../wpcom-fetcher';
+
+export async function fetchSiteAdminBar( siteId: number ): Promise< AdminBarResponse > {
+	return wpcom.req.get( {
+		path: `/sites/${ siteId }/admin-bar`,
+		apiNamespace: 'wpcom/v2',
+	} );
+}

--- a/packages/api-core/src/site-admin-bar/index.ts
+++ b/packages/api-core/src/site-admin-bar/index.ts
@@ -1,0 +1,1 @@
+export * from './fetchers';

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -72,6 +72,7 @@ export * from './read-site';
 export * from './site-activity-log';
 export * from './site-activity-log-backup';
 export * from './site-address-change';
+export * from './site-admin-bar';
 export * from './site-agency';
 export * from './site-atomic-transfers';
 export * from './site-automated-transfers-eligibility';

--- a/packages/api-queries/src/omnibar.ts
+++ b/packages/api-queries/src/omnibar.ts
@@ -1,8 +1,8 @@
 import { queryOptions } from '@tanstack/react-query';
 
-export const omnibarCurrentSiteIdQuery = () =>
+export const omnibarSiteIdQuery = () =>
 	queryOptions( {
-		queryKey: [ 'omnibar', 'current-site-id' ],
+		queryKey: [ 'omnibar', 'site-id' ],
 		queryFn: () => Promise.resolve< number | null >( null ),
 		staleTime: Infinity,
 		meta: { persist: false },

--- a/packages/api-queries/src/site-admin-bar.ts
+++ b/packages/api-queries/src/site-admin-bar.ts
@@ -1,0 +1,8 @@
+import { fetchSiteAdminBar } from '@automattic/api-core';
+import { queryOptions } from '@tanstack/react-query';
+
+export const siteAdminBarQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'admin-bar' ],
+		queryFn: () => fetchSiteAdminBar( siteId ),
+	} );

--- a/packages/omnibar/src/components/omnibar/index.tsx
+++ b/packages/omnibar/src/components/omnibar/index.tsx
@@ -1,4 +1,9 @@
-import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+import {
+	__experimentalHStack as HStack,
+	DropdownMenu,
+	MenuGroup,
+	MenuItem,
+} from '@wordpress/components';
 import type { OmnibarNode, OmnibarProps } from '../../types';
 
 import './index.scss';
@@ -45,9 +50,7 @@ function OmnibarDropdownContent( { children }: { children: OmnibarNode[] } ) {
 	);
 }
 
-function OmnibarItem( { node }: { node: OmnibarNode } ) {
-	const content = node.render ? node.render( { node } ) : node.title;
-
+function OmnibarItem( { node, content }: { node: OmnibarNode; content: React.ReactNode } ) {
 	if ( ! node.children ) {
 		return null;
 	}
@@ -68,12 +71,38 @@ function OmnibarItem( { node }: { node: OmnibarNode } ) {
 }
 
 export function Omnibar( { nodes }: OmnibarProps ) {
+	const renderHomeNode = () => {
+		const node = nodes.home;
+		return node && <OmnibarItem node={ node } content={ node.icon } />;
+	};
+
+	const renderSiteNode = () => {
+		const node = nodes.site;
+		return (
+			node && (
+				<OmnibarItem
+					node={ node }
+					content={
+						<HStack>
+							{ node.icon }
+							<span>{ node.title }</span>
+						</HStack>
+					}
+				/>
+			)
+		);
+	};
+
+	const renderUserNode = () => {
+		const node = nodes.user;
+		return node && <OmnibarItem node={ node } content={ node.title } />;
+	};
+
 	return (
 		<div className="omnibar" role="navigation" aria-label="Toolbar">
-			{ nodes.home && <OmnibarItem node={ nodes.home } /> }
-			<div className="omnibar__secondary">
-				{ nodes.user && <OmnibarItem node={ nodes.user } /> }
-			</div>
+			{ renderHomeNode() }
+			{ renderSiteNode() }
+			<div className="omnibar__secondary">{ renderUserNode() }</div>
 		</div>
 	);
 }

--- a/packages/omnibar/src/types/omnibar.ts
+++ b/packages/omnibar/src/types/omnibar.ts
@@ -1,10 +1,10 @@
 export interface OmnibarNode {
 	id: string;
 	title: string;
+	icon?: React.ReactElement;
 	group?: boolean;
 	href?: string;
 	children?: OmnibarNode[];
-	render?: ( props: OmnibarNodeRenderProps ) => React.ReactElement;
 }
 
 export interface OmnibarNodeRenderProps {
@@ -13,6 +13,7 @@ export interface OmnibarNodeRenderProps {
 
 export interface OmnibarNodes {
 	home?: OmnibarNode;
+	site?: OmnibarNode;
 	user?: OmnibarNode;
 }
 

--- a/packages/omnibar/src/utils/admin-bar.ts
+++ b/packages/omnibar/src/utils/admin-bar.ts
@@ -31,6 +31,7 @@ export function buildOmnibarNodesFromAdminBarNodes( adminBarNodes: AdminBarNode[
 	}
 
 	omnibarNodes.home = nodeMap.get( 'wpcom-logo' );
+	omnibarNodes.site = nodeMap.get( 'site-name' );
 	omnibarNodes.user = nodeMap.get( 'my-account' );
 
 	return omnibarNodes;


### PR DESCRIPTION
## Proposed Changes

With https://github.com/Automattic/jetpack/pull/48290, we now have a way to fetch the admin bar nodes from a site's wp-admin (admin context). We can now use the nodes to construct the site node (icon + name).

## Screenshot

<img width="793" height="37" alt="image" src="https://github.com/user-attachments/assets/84626752-8b9b-4873-8da4-fadbed543a8a" />
