### PR TITLE
Reader: Achievements settings API and visibility gating

### DIFF
--- a/client/reader/user-profile/components/user-profile-header/index.tsx
+++ b/client/reader/user-profile/components/user-profile-header/index.tsx
@@ -10,7 +10,7 @@ import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import { getUserProfileUrl } from 'calypso/reader/user-profile/user-profile.utils';
-import { useAchievementsVisibility } from 'calypso/reader/user-profile/views/achievements/use-achievements-visibility';
+import useAchievementsVisibility from 'calypso/reader/user-profile/views/achievements/use-achievements-visibility';
 import UserTopSites from '../top-sites';
 import type { ReaderUser } from '@automattic/api-core';
 

--- a/client/reader/user-profile/components/user-profile-header/test/index.test.tsx
+++ b/client/reader/user-profile/components/user-profile-header/test/index.test.tsx
@@ -37,7 +37,8 @@ jest.mock( '@automattic/calypso-config', () => ( {
 } ) );
 
 jest.mock( 'calypso/reader/user-profile/views/achievements/use-achievements-visibility', () => ( {
-	useAchievementsVisibility: () => ( { isOwnProfile: true, isVisible: true } ),
+	__esModule: true,
+	default: () => ( { isOwnProfile: true, isVisible: true, isLoading: false } ),
 } ) );
 
 const mockIsEnabled = isEnabled as jest.MockedFunction< typeof isEnabled >;

--- a/client/reader/user-profile/views/achievements/achievements-settings/index.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-settings/index.tsx
@@ -21,15 +21,12 @@ export default function AchievementsSettings() {
 		userPreferenceQuery( 'achievements-global-notifications' )
 	);
 
-	const [ isPublic, setIsPublic ] = useState( savedVisibility === 'public' );
-	const [ notificationsEnabled, setNotificationsEnabled ] = useState(
-		savedNotifications === 'enabled'
-	);
-
-	// Sync local state when server data changes (e.g. on initial load).
-	useEffect( () => setIsPublic( savedVisibility === 'public' ), [ savedVisibility ] );
+	// Local state for immediate toggle feedback. Synced from query data on load.
+	const [ visibility, setLocalVisibility ] = useState( savedVisibility ?? 'private' );
+	const [ notifications, setLocalNotifications ] = useState( savedNotifications ?? 'enabled' );
+	useEffect( () => setLocalVisibility( savedVisibility ?? 'private' ), [ savedVisibility ] );
 	useEffect(
-		() => setNotificationsEnabled( savedNotifications === 'enabled' ),
+		() => setLocalNotifications( savedNotifications ?? 'enabled' ),
 		[ savedNotifications ]
 	);
 
@@ -40,72 +37,59 @@ export default function AchievementsSettings() {
 		userPreferenceOptimisticMutation( 'achievements-global-notifications' )
 	);
 
-	const dispatchSuccessNotice = ( message: string ) => {
-		dispatch(
-			successNotice( message, {
-				duration: 4000,
-			} )
-		);
-	};
-	const dispatchErrorNotice = ( message: string ) => {
-		dispatch(
-			errorNotice( message, {
-				duration: 4000,
-			} )
-		);
-	};
-
-	const handleSetVisibility = ( value: boolean ) => {
-		const visibility = value ? 'public' : 'private';
-		setVisibility( visibility, {
-			onSuccess( _, data ) {
-				setIsPublic( data === 'public' );
-				if ( data === 'public' ) {
-					dispatchSuccessNotice( translate( 'The achievements page is now public.' ) );
-					recordAction( 'set_achievements_visibility_public' );
-					recordReaderTracksEvent( 'calypso_reader_achievements_settings_saved', {
-						setting: 'achievements-visibility',
-						value: 'public',
-					} );
-				} else {
-					dispatchSuccessNotice( translate( 'The achievements page is now private.' ) );
-					recordAction( 'set_achievements_visibility_private' );
-					recordReaderTracksEvent( 'calypso_reader_achievements_settings_saved', {
-						setting: 'achievements-visibility',
-						value: 'private',
-					} );
-				}
+	const handleSetVisibility = ( checked: boolean ) => {
+		const newVisibility = checked ? 'public' : 'private';
+		setLocalVisibility( newVisibility );
+		setVisibility( newVisibility, {
+			onSuccess() {
+				dispatch(
+					successNotice(
+						newVisibility === 'public'
+							? translate( 'Your achievements page is now public.' )
+							: translate( 'Your achievements page is now private.' ),
+						{ duration: 4000 }
+					)
+				);
+				recordAction( `set_achievements_visibility_${ newVisibility }` );
+				recordReaderTracksEvent( 'calypso_reader_achievements_settings_saved', {
+					setting: 'achievements-visibility',
+					value: newVisibility,
+				} );
 			},
 			onError() {
-				dispatchErrorNotice( translate( 'Failed to save the achievements page settings.' ) );
+				dispatch(
+					errorNotice( translate( 'Failed to save the achievements visibility settings.' ), {
+						duration: 4000,
+					} )
+				);
 			},
 		} );
 	};
 
-	const handleSetNotifications = ( value: boolean ) => {
-		const notifications = value ? 'enabled' : 'disabled';
-		setNotifications( notifications, {
-			onSuccess( _, data ) {
-				setNotificationsEnabled( data === 'enabled' );
-				if ( data === 'enabled' ) {
-					dispatchSuccessNotice( translate( 'Achievements notifications are now enabled.' ) );
-					recordAction( 'set_achievements_notifications_enabled' );
-					recordReaderTracksEvent( 'calypso_reader_achievements_settings_saved', {
-						setting: 'achievements-notifications',
-						value: 'enabled',
-					} );
-				} else {
-					dispatchSuccessNotice( translate( 'Achievements notifications are now disabled.' ) );
-					recordAction( 'set_achievements_notifications_disabled' );
-					recordReaderTracksEvent( 'calypso_reader_achievements_settings_saved', {
-						setting: 'achievements-notifications',
-						value: 'disabled',
-					} );
-				}
+	const handleSetNotifications = ( checked: boolean ) => {
+		const newNotifications = checked ? 'enabled' : 'disabled';
+		setLocalNotifications( newNotifications );
+		setNotifications( newNotifications, {
+			onSuccess() {
+				dispatch(
+					successNotice(
+						newNotifications === 'enabled'
+							? translate( 'Achievements notifications are now enabled.' )
+							: translate( 'Achievements notifications are now disabled.' ),
+						{ duration: 4000 }
+					)
+				);
+				recordAction( `set_achievements_notifications_${ newNotifications }` );
+				recordReaderTracksEvent( 'calypso_reader_achievements_settings_saved', {
+					setting: 'achievements-notifications',
+					value: newNotifications,
+				} );
 			},
 			onError() {
-				dispatchErrorNotice(
-					translate( 'Failed to save the achievements notifications settings.' )
+				dispatch(
+					errorNotice( translate( 'Failed to save the achievements notifications settings.' ), {
+						duration: 4000,
+					} )
 				);
 			},
 		} );
@@ -137,14 +121,14 @@ export default function AchievementsSettings() {
 			renderContent={ () => (
 				<div className="achievements-settings__content">
 					<ToggleControl
-						checked={ isPublic }
+						checked={ visibility === 'public' }
 						disabled={ isSetVisibilityPending }
 						onChange={ handleSetVisibility }
 						label={ translate( 'Public achievements' ) }
 						help={ translate( 'When enabled, your achievements page is visible to other users.' ) }
 					/>
 					<ToggleControl
-						checked={ notificationsEnabled }
+						checked={ notifications !== 'disabled' }
 						disabled={ isSetNotificationsPending }
 						onChange={ handleSetNotifications }
 						label={ translate( 'Achievement notifications' ) }

--- a/client/reader/user-profile/views/achievements/achievements-settings/index.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-settings/index.tsx
@@ -16,28 +16,28 @@ export default function AchievementsSettings() {
 	const translate = useTranslate();
 	const recordReaderTracksEvent = useRecordReaderTracksEvent();
 
-	const { data: savedIsPublic } = useQuery( userPreferenceQuery( 'achievements-page-public' ) );
+	const { data: savedVisibility } = useQuery( userPreferenceQuery( 'achievements-visibility' ) );
 	const { data: savedNotifications } = useQuery(
-		userPreferenceQuery( 'achievements-notifications-enabled' )
+		userPreferenceQuery( 'achievements-global-notifications' )
 	);
 
-	const [ isPublic, setIsPublic ] = useState( !! savedIsPublic );
+	const [ isPublic, setIsPublic ] = useState( savedVisibility === 'public' );
 	const [ notificationsEnabled, setNotificationsEnabled ] = useState(
-		savedNotifications !== false
+		savedNotifications === 'enabled'
 	);
 
 	// Sync local state when server data changes (e.g. on initial load).
-	useEffect( () => setIsPublic( !! savedIsPublic ), [ savedIsPublic ] );
+	useEffect( () => setIsPublic( savedVisibility === 'public' ), [ savedVisibility ] );
 	useEffect(
-		() => setNotificationsEnabled( savedNotifications !== false ),
+		() => setNotificationsEnabled( savedNotifications === 'enabled' ),
 		[ savedNotifications ]
 	);
 
-	const { mutate: setPublic, isPending: isSetPublicPending } = useMutation(
-		userPreferenceOptimisticMutation( 'achievements-page-public' )
+	const { mutate: setVisibility, isPending: isSetVisibilityPending } = useMutation(
+		userPreferenceOptimisticMutation( 'achievements-visibility' )
 	);
 	const { mutate: setNotifications, isPending: isSetNotificationsPending } = useMutation(
-		userPreferenceOptimisticMutation( 'achievements-notifications-enabled' )
+		userPreferenceOptimisticMutation( 'achievements-global-notifications' )
 	);
 
 	const dispatchSuccessNotice = ( message: string ) => {
@@ -55,11 +55,12 @@ export default function AchievementsSettings() {
 		);
 	};
 
-	const handleSetPublic = ( value: boolean ) => {
-		setPublic( value, {
+	const handleSetVisibility = ( value: boolean ) => {
+		const visibility = value ? 'public' : 'private';
+		setVisibility( visibility, {
 			onSuccess( _, data ) {
-				setIsPublic( !! data );
-				if ( data ) {
+				setIsPublic( data === 'public' );
+				if ( data === 'public' ) {
 					dispatchSuccessNotice( translate( 'The achievements page is now public.' ) );
 					recordAction( 'set_achievements_page_public' );
 					recordReaderTracksEvent( 'calypso_reader_achievements_settings_saved', {
@@ -82,10 +83,11 @@ export default function AchievementsSettings() {
 	};
 
 	const handleSetNotifications = ( value: boolean ) => {
-		setNotifications( value, {
+		const notifications = value ? 'enabled' : 'disabled';
+		setNotifications( notifications, {
 			onSuccess( _, data ) {
-				setNotificationsEnabled( !! data );
-				if ( data ) {
+				setNotificationsEnabled( data === 'enabled' );
+				if ( data === 'enabled' ) {
 					dispatchSuccessNotice( translate( 'Achievements notifications are now enabled.' ) );
 					recordAction( 'set_achievements_notifications_enabled' );
 					recordReaderTracksEvent( 'calypso_reader_achievements_settings_saved', {
@@ -136,8 +138,8 @@ export default function AchievementsSettings() {
 				<div className="achievements-settings__content">
 					<ToggleControl
 						checked={ isPublic }
-						disabled={ isSetPublicPending }
-						onChange={ handleSetPublic }
+						disabled={ isSetVisibilityPending }
+						onChange={ handleSetVisibility }
 						label={ translate( 'Public achievements' ) }
 						help={ translate( 'When enabled, your achievements page is visible to other users.' ) }
 					/>

--- a/client/reader/user-profile/views/achievements/achievements-settings/index.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-settings/index.tsx
@@ -62,16 +62,16 @@ export default function AchievementsSettings() {
 				setIsPublic( data === 'public' );
 				if ( data === 'public' ) {
 					dispatchSuccessNotice( translate( 'The achievements page is now public.' ) );
-					recordAction( 'set_achievements_page_public' );
+					recordAction( 'set_achievements_visibility_public' );
 					recordReaderTracksEvent( 'calypso_reader_achievements_settings_saved', {
-						setting: 'achievements-page-visibility',
+						setting: 'achievements-visibility',
 						value: 'public',
 					} );
 				} else {
 					dispatchSuccessNotice( translate( 'The achievements page is now private.' ) );
-					recordAction( 'set_achievements_page_private' );
+					recordAction( 'set_achievements_visibility_private' );
 					recordReaderTracksEvent( 'calypso_reader_achievements_settings_saved', {
-						setting: 'achievements-page-visibility',
+						setting: 'achievements-visibility',
 						value: 'private',
 					} );
 				}

--- a/client/reader/user-profile/views/achievements/index.tsx
+++ b/client/reader/user-profile/views/achievements/index.tsx
@@ -1,7 +1,9 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { Spinner } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
 import AchievementsGrid from './achievements-grid';
 import AchievementsSettings from './achievements-settings';
-import { useAchievementsVisibility } from './use-achievements-visibility';
+import useAchievementsVisibility from './use-achievements-visibility';
 import type { ReaderUser } from '@automattic/api-core';
 
 import './style.scss';
@@ -11,9 +13,22 @@ interface UserAchievementsProps {
 }
 
 const UserAchievements = ( { user }: UserAchievementsProps ): JSX.Element | null => {
-	const { isOwnProfile, isVisible } = useAchievementsVisibility( user.user_login );
+	const translate = useTranslate();
+	const { isOwnProfile, isVisible, isLoading } = useAchievementsVisibility( user.user_login );
 
-	if ( ! isEnabled( 'reader/achievements' ) || ! isVisible ) {
+	if ( ! isEnabled( 'reader/achievements' ) ) {
+		return null;
+	}
+
+	if ( isLoading ) {
+		return (
+			<div className="user-profile__loader">
+				<Spinner /> { translate( 'Loading…' ) }
+			</div>
+		);
+	}
+
+	if ( ! isVisible ) {
 		return null;
 	}
 

--- a/client/reader/user-profile/views/achievements/test/index.test.tsx
+++ b/client/reader/user-profile/views/achievements/test/index.test.tsx
@@ -25,9 +25,7 @@ jest.mock( '../achievements-settings', () => ( {
 const mockIsEnabled = isEnabled as jest.MockedFunction< typeof isEnabled >;
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const { useAchievementsVisibility } = require( '../use-achievements-visibility' ) as {
-	useAchievementsVisibility: jest.Mock;
-};
+const useAchievementsVisibility = require( '../use-achievements-visibility' ).default as jest.Mock;
 
 describe( 'UserAchievements', () => {
 	const defaultUser: ReaderUser = {
@@ -49,7 +47,11 @@ describe( 'UserAchievements', () => {
 
 	test( 'should render nothing when feature flag is disabled', () => {
 		mockIsEnabled.mockReturnValue( false );
-		useAchievementsVisibility.mockReturnValue( { isOwnProfile: true, isVisible: true } );
+		useAchievementsVisibility.mockReturnValue( {
+			isOwnProfile: true,
+			isVisible: true,
+			isLoading: false,
+		} );
 
 		const { container } = render( <UserAchievements user={ defaultUser } /> );
 
@@ -57,7 +59,11 @@ describe( 'UserAchievements', () => {
 	} );
 
 	test( 'should render nothing when achievements are not visible', () => {
-		useAchievementsVisibility.mockReturnValue( { isOwnProfile: false, isVisible: false } );
+		useAchievementsVisibility.mockReturnValue( {
+			isOwnProfile: false,
+			isVisible: false,
+			isLoading: false,
+		} );
 
 		const { container } = render( <UserAchievements user={ defaultUser } /> );
 
@@ -65,7 +71,11 @@ describe( 'UserAchievements', () => {
 	} );
 
 	test( 'should render achievements grid when visible', () => {
-		useAchievementsVisibility.mockReturnValue( { isOwnProfile: true, isVisible: true } );
+		useAchievementsVisibility.mockReturnValue( {
+			isOwnProfile: true,
+			isVisible: true,
+			isLoading: false,
+		} );
 
 		render( <UserAchievements user={ defaultUser } /> );
 
@@ -73,15 +83,36 @@ describe( 'UserAchievements', () => {
 	} );
 
 	test( 'should show settings button on own profile', () => {
-		useAchievementsVisibility.mockReturnValue( { isOwnProfile: true, isVisible: true } );
+		useAchievementsVisibility.mockReturnValue( {
+			isOwnProfile: true,
+			isVisible: true,
+			isLoading: false,
+		} );
 
 		render( <UserAchievements user={ defaultUser } /> );
 
 		expect( screen.getByTestId( 'achievements-settings' ) ).toBeVisible();
 	} );
 
+	test( 'should show spinner while loading visibility', () => {
+		useAchievementsVisibility.mockReturnValue( {
+			isOwnProfile: false,
+			isVisible: false,
+			isLoading: true,
+		} );
+
+		render( <UserAchievements user={ defaultUser } /> );
+
+		expect( screen.getByText( 'Loading…' ) ).toBeVisible();
+		expect( screen.queryByTestId( 'achievements-grid' ) ).not.toBeInTheDocument();
+	} );
+
 	test( 'should not show settings button on other user profile', () => {
-		useAchievementsVisibility.mockReturnValue( { isOwnProfile: false, isVisible: true } );
+		useAchievementsVisibility.mockReturnValue( {
+			isOwnProfile: false,
+			isVisible: true,
+			isLoading: false,
+		} );
 
 		render( <UserAchievements user={ defaultUser } /> );
 

--- a/client/reader/user-profile/views/achievements/test/use-achievements-visibility.test.ts
+++ b/client/reader/user-profile/views/achievements/test/use-achievements-visibility.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import { renderHook } from '@testing-library/react';
-import { useAchievementsVisibility } from '../use-achievements-visibility';
+import useAchievementsVisibility from '../use-achievements-visibility';
 
 const mockUseQuery = jest.fn();
 jest.mock( '@tanstack/react-query', () => ( {

--- a/client/reader/user-profile/views/achievements/test/use-achievements-visibility.test.ts
+++ b/client/reader/user-profile/views/achievements/test/use-achievements-visibility.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import { useAchievementsVisibility } from '../use-achievements-visibility';
+
+const mockUseQuery = jest.fn();
+jest.mock( '@tanstack/react-query', () => ( {
+	useQuery: ( ...args: unknown[] ) => mockUseQuery( ...args ),
+} ) );
+
+jest.mock( '@automattic/api-queries', () => ( {
+	readAchievementsSettingsQuery: ( userIdOrLogin: string ) => ( {
+		queryKey: [ 'read', 'achievements', userIdOrLogin, 'settings' ],
+	} ),
+} ) );
+
+const mockGetCurrentUser = jest.fn();
+jest.mock( 'calypso/state', () => ( {
+	useSelector: ( selector: ( state: unknown ) => unknown ) => selector( {} ),
+} ) );
+jest.mock( 'calypso/state/current-user/selectors', () => ( {
+	getCurrentUser: ( state: unknown ) => mockGetCurrentUser( state ),
+} ) );
+
+describe( 'useAchievementsVisibility', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockUseQuery.mockReturnValue( { data: undefined, isLoading: false } );
+	} );
+
+	test( 'should return isOwnProfile and isVisible true for own profile', () => {
+		mockGetCurrentUser.mockReturnValue( { username: 'myself' } );
+
+		const { result } = renderHook( () => useAchievementsVisibility( 'myself' ) );
+
+		expect( result.current.isOwnProfile ).toBe( true );
+		expect( result.current.isVisible ).toBe( true );
+		expect( result.current.isLoading ).toBe( false );
+	} );
+
+	test( 'should not fetch settings for own profile', () => {
+		mockGetCurrentUser.mockReturnValue( { username: 'myself' } );
+
+		renderHook( () => useAchievementsVisibility( 'myself' ) );
+
+		expect( mockUseQuery ).toHaveBeenCalledWith( expect.objectContaining( { enabled: false } ) );
+	} );
+
+	test( 'should return isVisible true when other user has public achievements', () => {
+		mockGetCurrentUser.mockReturnValue( { username: 'myself' } );
+		mockUseQuery.mockReturnValue( {
+			data: { settings: { 'achievements-visibility': 'public' } },
+			isLoading: false,
+		} );
+
+		const { result } = renderHook( () => useAchievementsVisibility( 'other_user' ) );
+
+		expect( result.current.isOwnProfile ).toBe( false );
+		expect( result.current.isVisible ).toBe( true );
+		expect( result.current.isLoading ).toBe( false );
+	} );
+
+	test( 'should return isVisible false when other user has private achievements', () => {
+		mockGetCurrentUser.mockReturnValue( { username: 'myself' } );
+		mockUseQuery.mockReturnValue( {
+			data: { settings: { 'achievements-visibility': 'private' } },
+			isLoading: false,
+		} );
+
+		const { result } = renderHook( () => useAchievementsVisibility( 'other_user' ) );
+
+		expect( result.current.isOwnProfile ).toBe( false );
+		expect( result.current.isVisible ).toBe( false );
+	} );
+
+	test( 'should return isLoading true while fetching other user settings', () => {
+		mockGetCurrentUser.mockReturnValue( { username: 'myself' } );
+		mockUseQuery.mockReturnValue( { data: undefined, isLoading: true } );
+
+		const { result } = renderHook( () => useAchievementsVisibility( 'other_user' ) );
+
+		expect( result.current.isLoading ).toBe( true );
+		expect( result.current.isVisible ).toBe( false );
+	} );
+} );

--- a/client/reader/user-profile/views/achievements/test/use-achievements-visibility.test.ts
+++ b/client/reader/user-profile/views/achievements/test/use-achievements-visibility.test.ts
@@ -9,6 +9,10 @@ jest.mock( '@tanstack/react-query', () => ( {
 	useQuery: ( ...args: unknown[] ) => mockUseQuery( ...args ),
 } ) );
 
+jest.mock( '@automattic/calypso-config', () => ( {
+	isEnabled: () => true,
+} ) );
+
 jest.mock( '@automattic/api-queries', () => ( {
 	readAchievementsSettingsQuery: ( userIdOrLogin: string ) => ( {
 		queryKey: [ 'read', 'achievements', userIdOrLogin, 'settings' ],

--- a/client/reader/user-profile/views/achievements/use-achievements-visibility.ts
+++ b/client/reader/user-profile/views/achievements/use-achievements-visibility.ts
@@ -1,14 +1,22 @@
+import { readAchievementsSettingsQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
 import { useSelector } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 
-export function useAchievementsVisibility( profileUserLogin?: string ) {
+export default function useAchievementsVisibility( profileUserLogin?: string ) {
 	const currentUser = useSelector( getCurrentUser );
 	const isOwnProfile = currentUser?.username === profileUserLogin;
 
-	// The achievements page is only visible to the profile owner for now.
-	// Public visibility will require a server-side check once a public API exists.
+	const { data, isLoading } = useQuery( {
+		...readAchievementsSettingsQuery( profileUserLogin ),
+		enabled: ! isOwnProfile && profileUserLogin != null,
+	} );
+
+	const isPublic = data?.settings[ 'achievements-visibility' ] === 'public';
+
 	return {
 		isOwnProfile,
-		isVisible: isOwnProfile,
+		isVisible: isOwnProfile || isPublic,
+		isLoading: ! isOwnProfile && isLoading,
 	};
 }

--- a/client/reader/user-profile/views/achievements/use-achievements-visibility.ts
+++ b/client/reader/user-profile/views/achievements/use-achievements-visibility.ts
@@ -1,4 +1,5 @@
 import { readAchievementsSettingsQuery } from '@automattic/api-queries';
+import { isEnabled } from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
 import { useSelector } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
@@ -9,7 +10,7 @@ export default function useAchievementsVisibility( profileUserLogin?: string ) {
 
 	const { data, isLoading } = useQuery( {
 		...readAchievementsSettingsQuery( profileUserLogin ),
-		enabled: ! isOwnProfile && profileUserLogin != null,
+		enabled: isEnabled( 'reader/achievements' ) && ! isOwnProfile && profileUserLogin != null,
 	} );
 
 	const isPublic = data?.settings[ 'achievements-visibility' ] === 'public';

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -76,6 +76,7 @@ export * from './plugins';
 export * from './products';
 export * from './products';
 export * from './plans';
+export * from './read-achievements-settings';
 export * from './read-feeds';
 export * from './read-lists';
 export * from './read-sites';

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -74,7 +74,6 @@ export * from './p2';
 export * from './payment-methods';
 export * from './plugins';
 export * from './products';
-export * from './products';
 export * from './plans';
 export * from './read-achievements-settings';
 export * from './read-feeds';

--- a/packages/api-core/src/me-preferences/types.ts
+++ b/packages/api-core/src/me-preferences/types.ts
@@ -31,6 +31,6 @@ export interface UserPreferences {
 	'sites-landing-page'?: SitesLandingPage;
 	[ key: `cancel-purchase-survey-completed-${ string | number }` ]: string | undefined;
 	[ key: `cancellation-offer-accepted-notice-dismissed-${ string | number }` ]: string | undefined;
-	'achievements-page-public'?: boolean;
-	'achievements-notifications-enabled'?: boolean;
+	'achievements-visibility'?: 'public' | 'private';
+	'achievements-global-notifications'?: 'enabled' | 'disabled';
 }

--- a/packages/api-core/src/read-achievements-settings/fetchers.ts
+++ b/packages/api-core/src/read-achievements-settings/fetchers.ts
@@ -5,7 +5,7 @@ export const fetchReadAchievementsSettings = (
 	userIdOrLogin: number | string
 ): Promise< ReadAchievementsSettingsResponse > => {
 	return wpcom.req.get( {
-		path: `/read/achievements/${ userIdOrLogin }/settings`,
+		path: `/read/achievements/${ encodeURIComponent( String( userIdOrLogin ) ) }/settings`,
 		apiNamespace: 'wpcom/v2',
 		method: 'GET',
 	} );

--- a/packages/api-core/src/read-achievements-settings/fetchers.ts
+++ b/packages/api-core/src/read-achievements-settings/fetchers.ts
@@ -1,0 +1,12 @@
+import { wpcom } from '../wpcom-fetcher';
+import type { ReadAchievementsSettingsResponse } from './types';
+
+export const fetchReadAchievementsSettings = (
+	userIdOrLogin: number | string
+): Promise< ReadAchievementsSettingsResponse > => {
+	return wpcom.req.get( {
+		path: `/read/achievements/${ userIdOrLogin }/settings`,
+		apiNamespace: 'wpcom/v2',
+		method: 'GET',
+	} );
+};

--- a/packages/api-core/src/read-achievements-settings/index.ts
+++ b/packages/api-core/src/read-achievements-settings/index.ts
@@ -1,0 +1,2 @@
+export * from './fetchers';
+export * from './types';

--- a/packages/api-core/src/read-achievements-settings/types.ts
+++ b/packages/api-core/src/read-achievements-settings/types.ts
@@ -1,0 +1,5 @@
+export interface ReadAchievementsSettingsResponse {
+	settings: {
+		'achievements-visibility': 'public' | 'private';
+	};
+}

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -66,6 +66,7 @@ export * from './payment-methods';
 export * from './plans';
 export * from './plugin';
 export * from './products';
+export * from './read-achievements-settings';
 export * from './read-feed';
 export * from './read-list';
 export * from './read-site';

--- a/packages/api-queries/src/me-preferences.ts
+++ b/packages/api-queries/src/me-preferences.ts
@@ -16,8 +16,8 @@ const defaultValues: Required< UserPreferences > = {
 		useSitesAsLandingPage: false,
 		updatedAt: 0,
 	},
-	'achievements-page-public': false,
-	'achievements-notifications-enabled': true,
+	'achievements-visibility': 'private',
+	'achievements-global-notifications': 'enabled',
 };
 
 // Returns all user preferences, without applying any defaults.

--- a/packages/api-queries/src/read-achievements-settings.ts
+++ b/packages/api-queries/src/read-achievements-settings.ts
@@ -1,0 +1,11 @@
+import { fetchReadAchievementsSettings } from '@automattic/api-core';
+import { queryOptions } from '@tanstack/react-query';
+
+export const readAchievementsSettingsQuery = ( userIdOrLogin?: number | string | null ) => {
+	return queryOptions( {
+		queryKey: [ 'read', 'achievements', userIdOrLogin, 'settings' ],
+		queryFn: () => fetchReadAchievementsSettings( userIdOrLogin! ),
+		enabled: userIdOrLogin != null,
+		staleTime: 10 * 1000, // 10 seconds
+	} );
+};


### PR DESCRIPTION
Related to RSM-381

## Proposed Changes

* Replace boolean user preferences (`achievements-page-public`, `achievements-notifications-enabled`) with declarative string values (`achievements-visibility`: `public`/`private`, `achievements-global-notifications`: `enabled`/`disabled`).
* Add API module for the new `GET /wpcom/v2/read/achievements/:user/settings` endpoint.
* Update `useAchievementsVisibility` hook to fetch another user's settings and gate the Achievements tab/page on their visibility preference.
* Show a spinner in the achievements view while loading another user's settings; hide the tab until the response confirms public visibility.

## Why are these changes being made?

* Boolean preferences are not future-proof — string values allow adding more options (e.g., `friends-only`) without a schema change.
* The achievements page was previously only visible to the profile owner. With the new public endpoint, other users can now see achievements when the profile owner has opted in.

## Testing Instructions

* Visit your own profile at `/reader/users/<your_login>/achievements` — the page should render immediately with the settings gear icon.
* Visit another user's profile — the Achievements tab should only appear after the settings endpoint confirms `public` visibility. While loading, a spinner shows in the content area.
* Toggle the "Public achievements" setting on your own profile and verify it persists across page reloads.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?