### PR TITLE
Environment badge dark mode

### DIFF
--- a/client/components/environment-badge/style.scss
+++ b/client/components/environment-badge/style.scss
@@ -1,3 +1,5 @@
+@import "@automattic/calypso-color-schemes/root-only";
+
 $z-index: 999;
 
 .environment-badge {
@@ -25,16 +27,20 @@ $z-index: 999;
 	.bug-report {
 		position: relative;
 		display: inline-flex;
-		background-color: #fff;
-		border: solid 1px #3c434a;
+		background-color: var(--color-surface);
+		border: solid 1px var(--studio-gray-70);
 		border-radius: 50%;
-		color: #3c434a;
+		color: var(--color-text);
 		margin-left: -4px;
 		text-decoration: none;
 		text-align: center;
 		z-index: $z-index + 1;
 		transition: border-radius 0.2s ease-out;
 		vertical-align: middle;
+
+		svg {
+			fill: currentColor;
+		}
 	}
 
 	.environment {
@@ -47,8 +53,8 @@ $z-index: 999;
 		padding: 4px 7px 4px 6px;
 		vertical-align: middle;
 		transition: all 0.2s ease-out;
-		background-color: #fff;
-		box-shadow: 0 0 0 1px #3c434a;
+		background-color: var(--color-surface);
+		box-shadow: 0 0 0 1px var(--studio-gray-70);
 
 		&.is-env {
 			display: inline-block;
@@ -56,7 +62,7 @@ $z-index: 999;
 		a {
 			text-decoration: none;
 			display: inline-block;
-			color: #3c434a;
+			color: var(--studio-gray-70);
 
 			&:hover {
 				transform: scale(1.1);
@@ -64,32 +70,32 @@ $z-index: 999;
 		}
 
 		&.is-staging {
-			color: #361f00;
-			background-color: #faa754;
+			color: var(--studio-orange-90);
+			background-color: var(--studio-orange-20);
 		}
 		&.is-wpcalypso {
-			color: #003024;
-			background-color: #31cc9f;
+			color: var(--studio-celadon-90);
+			background-color: var(--studio-celadon-20);
 		}
 		&.is-dev {
-			color: #35163b;
-			background-color: #d48fc8;
+			color: var(--studio-purple-90);
+			background-color: var(--studio-purple-20);
 		}
 		&.is-horizon,
 		&.is-feedback {
-			color: #14215a;
-			background-color: #adbaf3;
+			color: var(--studio-blue-90);
+			background-color: var(--studio-blue-20);
 		}
 		&.is-jetpack-cloud-dev,
 		&.is-jetpack-cloud-staging {
-			color: #003010;
-			background-color: #64ca43;
+			color: var(--studio-jetpack-green-90);
+			background-color: var(--studio-jetpack-green-20);
 		}
 
 		&.branch-name {
 			text-transform: inherit;
-			background-color: #3c434a;
-			color: #fff;
+			background-color: var(--studio-gray-70);
+			color: var(--color-text-inverted);
 		}
 	}
 

--- a/client/dashboard/app/_dark-theme.scss
+++ b/client/dashboard/app/_dark-theme.scss
@@ -507,6 +507,13 @@
 	}
 }
 
+@mixin dashboard-calypso-theme-properties {
+	// This is a list of Calypso theme properties overridden for dark mode.
+	--color-text: var( --dashboard__text-color );
+	--color-surface: var( --dashboard-surface__background-color );
+	--color-border-subtle: var( --dashboard-surface__border-color );
+}
+
 // :root variables overridden for dark theme
 @mixin dashboard-dark-theme {
 	// Overrides the default `--wp-components-*` to ensure all components that
@@ -580,9 +587,6 @@
 	// Overview
 	--dashboard-overview__divider-color: #2f2f2f;
 
-	// Shared border tokens
-	--color-border-subtle: var( --dashboard-surface__border-color );
-
 	// Jetpack grayscale, inverted so darker numbers render as lighter shades on dark.
 	// `--jp-black` / `--jp-white` stay literal — they're brand constants, and many usages
 	// (white text on colored bg, black outlines) depend on them being literal.
@@ -616,4 +620,5 @@
 	@include dashboard-dark-theme-section-header;
 	@include dashboard-dark-theme-site-icon;
 	@include dashboard-dark-theme-summary-button;
+	@include dashboard-calypso-theme-properties;
 }

--- a/client/lib/auth-helper/style.scss
+++ b/client/lib/auth-helper/style.scss
@@ -7,8 +7,8 @@
 	position: absolute;
 	bottom: 100%;
 	padding: 4px;
-	background: #fff;
-	box-shadow: 0 0 0 1px #dcdcde;
+	background: var(--color-surface);
+	box-shadow: 0 0 0 1px var(--color-border-subtle);
 }
 
 .auth-helper__label {

--- a/client/lib/store-sandbox-helper/style.scss
+++ b/client/lib/store-sandbox-helper/style.scss
@@ -1,5 +1,4 @@
 .store-sandbox-helper__menu-item.is-enabled {
-	color: var(--studio-green);
 	color: var(--dashboard__foreground-color-success);
 }
 
@@ -12,7 +11,7 @@
 	position: absolute;
 	bottom: 100%;
 	padding: 12px;
-	background: #fff;
-	box-shadow: 0 0 0 1px #dcdcde;
+	background: var(--color-surface);
+	box-shadow: 0 0 0 1px var(--color-border-subtle);
 	width: 230px;
 }


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/RSM-161/add-dark-mode-to-environment-badge

Important: this PR starts removing all the hardcoded whites and other colors and substitutes them with the reusable, not-color-specific variable.

The first three colors needed have now a dark-mode version:
```
--color-text: var( --dashboard__text-color );
--color-surface: var( --dashboard-surface__background-color );
--color-border-subtle: var( --dashboard-surface__border-color );
```

The border one was already created. I moved it to the "theme properties" mixin.

## Proposed Changes

* Remove environment badge hardcoded colors
* Add dark mode

<img width="598" height="64" alt="Screenshot 2026-04-24 alle 15 44 10" src="https://github.com/user-attachments/assets/8b48e5f0-3430-4666-825f-49fba8e66611" />
<img width="592" height="63" alt="Screenshot 2026-04-24 alle 15 44 22" src="https://github.com/user-attachments/assets/f90cef92-f333-48a6-bfc4-fe5bc30a5477" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Check if the environment badge is ok. You can test other environment by running `document.getElementsByClassName('is-env')[0].classList.add('is-staging')`. Values are `is-staging`, `is-wpcalypso`, `is-horizon` etc.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
