### PR TITLE
Dashboard: gate WP version switch on Atomic infrastructure

### DIFF
--- a/client/dashboard/sites/features.ts
+++ b/client/dashboard/sites/features.ts
@@ -43,7 +43,11 @@ export function canViewHundredYearPlanSettings( site: Site ) {
 
 export function canSwitchWordPressVersion( site: Site ) {
 	if ( isEnabled( 'dashboard/wp-beta-program' ) ) {
-		return hasHostingFeature( site, HostingFeatures.BACKUPS_SELF_SERVE );
+		// Atomic-only API.
+		return (
+			( site.is_wpcom_atomic || site.is_wpcom_flex ) &&
+			hasHostingFeature( site, HostingFeatures.BACKUPS_SELF_SERVE )
+		);
 	}
 	return site.is_wpcom_staging_site;
 }


### PR DESCRIPTION
## Proposed Changes

* Restrict `canSwitchWordPressVersion` to Atomic/Flex sites (`is_wpcom_atomic || is_wpcom_flex`) in addition to the existing `BACKUPS_SELF_SERVE` check, when the `dashboard/wp-beta-program` flag is on.

## Why are these changes being made?

After the `dashboard/wp-beta-program` rollout, the site overview loader started prefetching `siteWordPressVersionQuery` whenever `canSwitchWordPressVersion` returned true. The gate became `hasHostingFeature(BACKUPS_SELF_SERVE)`, which is true for self-hosted Jetpack sites with VaultPress Backup. The underlying `wpcom/v2/sites/{ID}/hosting/wp-version` endpoint is Atomic-only, so the loader's `await Promise.all(...)` rejected and the entire site overview route became inaccessible for those sites.

Reported in #multi-site-dashboard.

## Testing Instructions

* With `dashboard/wp-beta-program` enabled, open a self-hosted Jetpack-connected site (with VaultPress Backup) overview in the Multi-site Dashboard. Before: route fails to load. After: overview loads normally and the WP beta notice is suppressed.
* Open an Atomic site that has the WP beta program eligibility — overview still loads and the beta notice still appears as before.
* Confirm the WordPress settings page (`/sites/{slug}/settings/wordpress`) hides the version switch UI for non-Atomic sites.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE).
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?