### PR TITLE
E2E: fix flaky Check SSR: log-in

### DIFF
--- a/test/e2e/specs/infrastructure/infrastructure__ssr-enabled.ts
+++ b/test/e2e/specs/infrastructure/infrastructure__ssr-enabled.ts
@@ -19,9 +19,7 @@ describe( 'Server-side Rendering', function () {
 
 			it( `Check SSR: ${ endpoint }`, async function () {
 				await page.goto( DataHelper.getCalypsoURL( endpoint ), { timeout: 20 * 1000 } );
-				await page
-					.locator( '#wpcom[data-calypso-ssr-fsdfdfds="true"]' )
-					.waitFor( { timeout: 15 * 1000 } );
+				await page.locator( '#wpcom[data-calypso-ssr="true"]' ).waitFor( { timeout: 15 * 1000 } );
 			} );
 		}
 	);


### PR DESCRIPTION
## Proposed Changes

- Corrects the SSR assertion locator in `test/e2e/specs/infrastructure/infrastructure__ssr-enabled.ts` from `#wpcom[data-calypso-ssr-fsdfdfds="true"]` to `#wpcom[data-calypso-ssr="true"]`, which is the attribute actually rendered on the SSR'd `<div id="wpcom">`.
- No product code changes. Test structure, timeouts, and endpoints list are unchanged; no test is skipped or quarantined.

## Why are these changes being made?

The locator used by `Check SSR` referenced a malformed attribute name (`data-calypso-ssr-fsdfdfds`) that is never emitted by `client/document/index.jsx`, so the `waitFor` could never match any element and always hit its 15s timeout. Both matrix cells (Desktop and Mobile) reproduced the failure on the parent PR's CI run: https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Playwright_desktop/17472621. Using the correct `data-calypso-ssr="true"` attribute restores the intended assertion.

## Testing Instructions

Run `yarn playwright test test/e2e/specs/infrastructure/infrastructure__ssr-enabled.ts --reporter=list --repeat-each=10` locally; all runs should pass.