### PR TITLE
E2E: Have Forms test wait for modal to close rather than doing a 1s timeout

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
@@ -199,8 +199,12 @@ export class FeedbackInboxPage {
 		// Use .last() to get the button in the side panel, not in the table row
 		await this.page.getByRole( 'button', { name: 'Not spam' } ).last().click();
 		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
-			// On mobile, the modal closes after the action
-			await this.page.waitForTimeout( 1000 );
+			// On mobile, the modal closes after the action. Wait for it to actually
+			// close rather than using a fixed timeout, so slow CI agents don't leave
+			// the modal covering the folder tabs when the next action runs.
+			await this.page
+				.getByRole( 'dialog', { name: 'Response' } )
+				.waitFor( { state: 'hidden', timeout: 5000 } );
 		} else {
 			// Wait for the success notification (use .first() to avoid a11y-speak duplicate)
 			await this.page
@@ -217,8 +221,11 @@ export class FeedbackInboxPage {
 		// Use .last() to get the button in the side panel, not in the table row
 		await this.page.getByRole( 'button', { name: 'Spam' } ).last().click();
 		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
-			// On mobile, the modal closes after the action
-			await this.page.waitForTimeout( 1000 );
+			// On mobile, the modal closes after the action. Wait for it to actually
+			// close rather than using a fixed timeout.
+			await this.page
+				.getByRole( 'dialog', { name: 'Response' } )
+				.waitFor( { state: 'hidden', timeout: 5000 } );
 		} else {
 			// Wait for the success notification (use .first() to avoid a11y-speak duplicate)
 			await this.page.getByText( 'Response marked as spam.' ).first().waitFor( { timeout: 5000 } );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

This attempts to address some flakiness in Forms tests where the modal was still open after a timeout. Now we wait for the modal to disappear prior to moving to the next step.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

```
yarn workspace wp-e2e-tests build
VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/published-content/forms__submissions.ts"
VIEWPORT_NAME="mobile" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/published-content/forms__submissions.ts"
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?