### PR TITLE
E2E: Refresh/retry newsletter subscriber search

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/subscribers-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/subscribers-page.ts
@@ -29,11 +29,27 @@ export class SubscribersPage {
 
 	/**
 	 * Validate that supplied `text` matches at least one subscriber.
+	 * Retries with page reloads because subscription confirmation
+	 * can take longer than the initial page load.
 	 *
 	 * @param {string} identifier Identifier to locate the subscriber by.
 	 */
 	async validateSubscriber( identifier: string ) {
-		await this.anchor.getByRole( 'cell' ).filter( { hasText: identifier } ).waitFor();
+		const locator = this.anchor.getByRole( 'cell' ).filter( { hasText: identifier } );
+		const maxRetries = 3;
+
+		for ( let i = 0; i < maxRetries; i++ ) {
+			try {
+				await locator.waitFor( { timeout: 10 * 1000 } );
+				return;
+			} catch {
+				if ( i === maxRetries - 1 ) {
+					throw new Error( `Subscriber ${ identifier } not found after ${ maxRetries } attempts.` );
+				}
+				// We need to reload to refresh API query.
+				await this.page.reload();
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

This flaky test pops up regularly. The test runs in two windows, and it seems the issue is likely a race condition where the backend subscriber search window loads prior to the frontend subscriber confirmation window finishing.

In this case, because the test only checks for DOM refreshes, it fails. We now do 3x reload/retry to allow the API query to be refreshed.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

```
yarn workspace wp-e2e-tests build
VIEWPORT_NAME="mobile" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/users/newsletter__subscribe-remove.ts"
VIEWPORT_NAME="mobile" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/users/newsletter__subscribe-remove.ts"
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?