### PR TITLE
Add performance page dark mode

### DIFF
--- a/client/dashboard/app/_dark-theme.scss
+++ b/client/dashboard/app/_dark-theme.scss
@@ -14,6 +14,38 @@
 	}
 }
 
+/* Panel */
+@mixin dashboard-dark-theme-panel {
+	// `@wordpress/components` hardcodes `#fff` background, `#e0e0e0` / `#ddd`
+	// borders, and near-black text on the PanelBody title button.
+	.components-panel {
+		background: var( --dashboard-surface__background-color );
+		border-color: var( --dashboard-surface__border-color );
+	}
+
+	.components-panel__body {
+		border-top-color: var( --dashboard-surface__border-color );
+		border-bottom-color: var( --dashboard-surface__border-color );
+	}
+
+	.components-panel__header {
+		border-bottom-color: var( --dashboard-surface__border-color );
+	}
+
+	.components-panel__body-toggle.components-button,
+	.components-panel__body-toggle.components-button .components-panel__arrow {
+		color: var( --dashboard__text-color );
+	}
+
+	.components-panel__body > .components-panel__body-title:hover {
+		background: color-mix(
+			in srgb,
+			var( --dashboard-surface__background-color ) 82%,
+			var( --wp-admin-theme-color )
+		);
+	}
+}
+
 /* Form Controls */
 @mixin dashboard-dark-theme-form-controls {
 	.components-input-control__container {
@@ -614,6 +646,7 @@
 	@include dashboard-dark-theme-destructive-secondary-button;
 	@include dashboard-dark-theme-form-controls;
 	@include dashboard-dark-theme-item-group;
+	@include dashboard-dark-theme-panel;
 	@include dashboard-dark-theme-popover;
 	@include dashboard-dark-theme-plugins;
 	@include dashboard-dark-theme-muted-text;

--- a/client/dashboard/sites/performance/llm-notice.scss
+++ b/client/dashboard/sites/performance/llm-notice.scss
@@ -1,14 +1,4 @@
-.llm-notice.is-loading {
-	img {
-		animation: rotation 3s infinite linear;
-	}
-
-	@keyframes rotation {
-		from {
-			transform: rotate(0deg);
-		}
-		to {
-			transform: rotate(360deg);
-		}
-	}
+.llm-notice-card {
+	$overlay: color-mix(in srgb, var(--color-surface, #fff) 95%, transparent);
+	background: linear-gradient(0deg, $overlay, $overlay), linear-gradient(90deg, #4458e4, var(--studio-jetpack-green, #069e08));
 }

--- a/client/dashboard/sites/performance/llm-notice.tsx
+++ b/client/dashboard/sites/performance/llm-notice.tsx
@@ -10,6 +10,8 @@ import { Text } from '../../components/text';
 import { VIEWPORT_BREAKPOINTS } from './constants';
 import type { ReactNode } from 'react';
 
+import './llm-notice.scss';
+
 const LLMNotice = ( {
 	children,
 	isLoading,
@@ -22,13 +24,7 @@ const LLMNotice = ( {
 	const isMediumScreen = useViewportMatch( VIEWPORT_BREAKPOINTS.medium, '<' );
 
 	return (
-		<Card
-			size="xSmall"
-			style={ {
-				background:
-					'linear-gradient(0deg,#fffffff2,#fffffff2),linear-gradient(90deg,#4458e4,#069e08)',
-			} }
-		>
+		<Card className="llm-notice-card" size="xSmall">
 			<CardBody>
 				<HStack
 					direction={ isMediumScreen ? 'column' : 'row' }

--- a/client/dashboard/sites/performance/performance-insight.scss
+++ b/client/dashboard/sites/performance/performance-insight.scss
@@ -1,4 +1,3 @@
-@import '@wordpress/base-styles/colors';
 @import "@wordpress/base-styles/variables";
 
 .performance-insight__markdown {
@@ -6,7 +5,7 @@
 		max-width: 100%;
 		padding: $grid-unit-20;
 		border-radius: $radius-small;
-		background-color: $gray-100;
+		background-color: var( --dashboard-inline-code__background-color, #f0f0f1 );
 		overflow: auto;
 	}
 }


### PR DESCRIPTION
See https://linear.app/a8c/issue/RSM-1049/add-dark-mode-to-performance

Important: the `client/dashboard/sites/performance/llm-notice.scss` file wasn't included in any files and had an old animation inside, which I removed. BTW, I used it, removing the inline style.

There are two colors:
1. `--studio-jetpack-green` (was hardcoded)
2. `#fff` moved to `--color-surface`
3. `#4458e4` is a color that appears only here, so I didn't replace it. See p1717033700529129/1716983434.861409-slack-C025Q5CPE
4. I used a `color-mix()` to apply 95% traslucency instead of having an harcoded `#ffffff_{f2}`

## Proposed Changes

* Remove hardcoded values
* Remove hardcoded inline styles
* Remove useless css code

<img width="1237" height="476" alt="Screenshot 2026-04-24 alle 17 17 21" src="https://github.com/user-attachments/assets/f7562355-03e3-4107-980f-03497f7f8191" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To add dark-mode to performance page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit `http://my.localhost:3000/sites/_BLOG_/performance`. If you select a site that is not 100% performant is better. Watch if some hardcoded whites pop up.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?