### PR TITLE
Reader: redirect /reader/users/me to current user's profile

### DIFF
--- a/client/reader/index.ts
+++ b/client/reader/index.ts
@@ -39,7 +39,7 @@ import {
 	listListing,
 } from './list/controller';
 import { onThisDay } from './on-this-day/controller';
-import { userProfile } from './user-profile/controller';
+import { redirectMeToCurrentUser, userProfile } from './user-profile/controller';
 
 function forceTeamA8C( context: Context, next: () => void ): void {
 	context.params.team = 'a8c';
@@ -134,6 +134,12 @@ export default async function (): Promise< void > {
 		userProfile,
 		makeLayout,
 		clientRender
+	);
+
+	page(
+		[ '/reader/users/me', '/reader/users/me/:view' ],
+		redirectLoggedOutToSignup,
+		redirectMeToCurrentUser
 	);
 
 	page(

--- a/client/reader/user-profile/controller.tsx
+++ b/client/reader/user-profile/controller.tsx
@@ -1,7 +1,8 @@
-import { Context } from '@automattic/calypso-router';
+import page, { Context } from '@automattic/calypso-router';
 import { ReactElement } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
 import { trackPageLoad, trackScrollPage } from 'calypso/reader/controller-helper';
+import { getCurrentUserName } from 'calypso/state/current-user/selectors';
 
 interface UserProfileContext extends Context {
 	params: {
@@ -13,6 +14,17 @@ interface UserProfileContext extends Context {
 }
 
 const analyticsPageTitle = 'Reader';
+
+export function redirectMeToCurrentUser( context: Context, next: () => void ): void {
+	const currentUserName = getCurrentUserName( context.store.getState() );
+	if ( currentUserName ) {
+		page.redirect(
+			context.path.replace( '/reader/users/me', `/reader/users/${ currentUserName }` )
+		);
+		return;
+	}
+	next();
+}
 
 export function userProfile( ctx: Context, next: () => void ): void {
 	const context = ctx as UserProfileContext;

--- a/client/reader/user-profile/test/controller.test.tsx
+++ b/client/reader/user-profile/test/controller.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import page from '@automattic/calypso-router';
+import configureStore from 'redux-mock-store';
+import { redirectMeToCurrentUser } from '../controller';
+
+jest.mock( '@automattic/calypso-router', () => ( {
+	__esModule: true,
+	default: { redirect: jest.fn() },
+} ) );
+
+const mockStore = configureStore();
+
+describe( 'redirectMeToCurrentUser', () => {
+	const next = jest.fn();
+
+	const buildContext = ( path: string, username: string | null = 'deansas' ) =>
+		( {
+			path,
+			store: mockStore( {
+				currentUser: {
+					id: username ? 1 : null,
+					user: username ? { ID: 1, username } : null,
+				},
+			} ),
+		} ) as unknown as Parameters< typeof redirectMeToCurrentUser >[ 0 ];
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'redirects /reader/users/me to the current user profile path', () => {
+		redirectMeToCurrentUser( buildContext( '/reader/users/me' ), next );
+
+		expect( page.redirect ).toHaveBeenCalledWith( '/reader/users/deansas' );
+		expect( next ).not.toHaveBeenCalled();
+	} );
+
+	it( 'redirects /reader/users/me/<view> preserving the view', () => {
+		redirectMeToCurrentUser( buildContext( '/reader/users/me/achievements' ), next );
+
+		expect( page.redirect ).toHaveBeenCalledWith( '/reader/users/deansas/achievements' );
+		expect( next ).not.toHaveBeenCalled();
+	} );
+
+	it( 'falls through to next() when there is no current user', () => {
+		redirectMeToCurrentUser( buildContext( '/reader/users/me', null ), next );
+
+		expect( page.redirect ).not.toHaveBeenCalled();
+		expect( next ).toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of RSM-1195

## Proposed Changes

Add a redirect from /reader/users/me to the current users profile

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

It makes sharing the link in blog posts, announcements or in support chats a little easier.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Use calypso live link
2. Go to `/reader/users/me` or `/reader/users/me/achievements`
3. Get redirected to your profile url, e.g. `/reader/users/deansas` or `/reader/users/deansas/achievements`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
