### PR TITLE
Dashboard: keep notifications popover anchored when bell re-mounts

### DIFF
--- a/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
+++ b/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
@@ -49,13 +49,34 @@ export function InterimOmnibar( {
 	);
 
 	// Announce the bell button element to subscribers (e.g. the Notifications
-	// component) so they can anchor a popover to it. Re-runs on every commit so
-	// it stays correct if MasterbarLoggedIn re-renders and replaces the node.
+	// component) so they can anchor a popover to it. The bell re-mounts itself
+	// when an unseen-count change flips its internal `key`, so we observe the
+	// omnibar subtree and re-emit whenever the `.masterbar-notifications` node
+	// is replaced — otherwise the Popover stays anchored to a detached node
+	// and falls back to the top-left of the viewport.
 	useEffect( () => {
 		const container = document.getElementById( 'wpcom-omnibar' );
-		const bell = container?.querySelector< HTMLElement >( '.masterbar-notifications' ) ?? null;
-		omnibarEvents.notificationsAnchor.emit( bell );
-	} );
+		if ( ! container ) {
+			return;
+		}
+
+		let currentBell: HTMLElement | null = null;
+
+		const syncBell = () => {
+			const bell = container.querySelector< HTMLElement >( '.masterbar-notifications' ) ?? null;
+			if ( bell !== currentBell ) {
+				currentBell = bell;
+				omnibarEvents.notificationsAnchor.emit( bell );
+			}
+		};
+
+		syncBell();
+
+		const observer = new MutationObserver( syncBell );
+		observer.observe( container, { childList: true, subtree: true } );
+
+		return () => observer.disconnect();
+	}, [] );
 
 	// Dispatch the user's unseen note count to the store so the unread marker appears.
 	useEffect( () => {


### PR DESCRIPTION
Fixes: https://linear.app/a8c/issue/RSM-584

## Proposed Changes

This problem fixes a bug in MSD when there's a new notification. The panel appears on the left side:

<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/00c8ac95-06a5-4293-9bd3-f0c41d67246d" />

With the update, the notifications panel opens where its supposed to:

<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/3f51fbea-8faf-41f7-8cda-ccfe34ec593c" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ask someone to like one of your posts
* Open the notification panel

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
