### PR TITLE
Calypso Purchases: add intent plumbing + removePurchase helpers

### DIFF
--- a/client/lib/purchases/actions.js
+++ b/client/lib/purchases/actions.js
@@ -46,13 +46,6 @@ export async function cancelAndRefundPurchaseAsync( purchaseId, data ) {
 	} );
 }
 
-export async function removePurchaseAsync( purchaseId ) {
-	return wpcom.req.post( {
-		path: `/purchases/${ purchaseId }/delete`,
-		apiNamespace: 'wpcom/v2',
-	} );
-}
-
 export const submitSurvey = ( surveyName, siteId, surveyData ) => ( dispatch ) => {
 	return wpcom.req
 		.post( '/marketing/survey', {

--- a/client/lib/purchases/actions.js
+++ b/client/lib/purchases/actions.js
@@ -46,6 +46,13 @@ export async function cancelAndRefundPurchaseAsync( purchaseId, data ) {
 	} );
 }
 
+export async function removePurchaseAsync( purchaseId ) {
+	return wpcom.req.post( {
+		path: `/purchases/${ purchaseId }/delete`,
+		apiNamespace: 'wpcom/v2',
+	} );
+}
+
 export const submitSurvey = ( surveyName, siteId, surveyData ) => ( dispatch ) => {
 	return wpcom.req
 		.post( '/marketing/survey', {

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -12,6 +12,7 @@ import NavigationHeader from 'calypso/components/navigation-header';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { useGeoLocationQuery } from 'calypso/data/geo/use-geolocation-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { getCancelIntentFromQuery } from 'calypso/lib/purchases/utils';
 import AddNewPaymentMethod from 'calypso/me/purchases/add-new-payment-method';
 import ChangePaymentMethod from 'calypso/me/purchases/manage-purchase/change-payment-method';
 import {
@@ -94,8 +95,7 @@ export function addCreditCard( context, next ) {
 }
 
 export function cancelPurchase( context, next ) {
-	const rawIntent = context.query?.intent;
-	const intent = rawIntent === 'cancel' || rawIntent === 'remove' ? rawIntent : null;
+	const intent = getCancelIntentFromQuery( context.query ?? {} );
 	// Match the browser-tab/page title to the button the user clicked on
 	// Purchase Settings — "Remove" for Remove, "Cancel Purchase" otherwise.
 	const pageTitle =

--- a/client/my-sites/purchases/controller.js
+++ b/client/my-sites/purchases/controller.js
@@ -40,10 +40,14 @@ export const purchaseDetails = ( context, next ) => {
 };
 
 export const purchaseCancel = ( context, next ) => {
+	const rawIntent = context.query?.intent;
+	const intent = rawIntent === 'cancel' || rawIntent === 'remove' ? rawIntent : null;
+
 	context.primary = (
 		<PurchaseCancel
 			siteSlug={ context.params.site }
 			purchaseId={ parseInt( context.params.purchaseId, 10 ) }
+			intent={ intent }
 		/>
 	);
 	next();

--- a/client/my-sites/purchases/controller.js
+++ b/client/my-sites/purchases/controller.js
@@ -1,4 +1,5 @@
 import page from '@automattic/calypso-router';
+import { getCancelIntentFromQuery } from 'calypso/lib/purchases/utils';
 import { BillingHistory, ReceiptView } from 'calypso/my-sites/purchases/billing-history';
 import CrmDownloads from 'calypso/my-sites/purchases/crm-downloads';
 import {
@@ -40,14 +41,11 @@ export const purchaseDetails = ( context, next ) => {
 };
 
 export const purchaseCancel = ( context, next ) => {
-	const rawIntent = context.query?.intent;
-	const intent = rawIntent === 'cancel' || rawIntent === 'remove' ? rawIntent : null;
-
 	context.primary = (
 		<PurchaseCancel
 			siteSlug={ context.params.site }
 			purchaseId={ parseInt( context.params.purchaseId, 10 ) }
-			intent={ intent }
+			intent={ getCancelIntentFromQuery( context.query ?? {} ) }
 		/>
 	);
 	next();

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -141,9 +141,11 @@ export function PurchaseDetails( {
 export function PurchaseCancel( {
 	purchaseId,
 	siteSlug,
+	intent,
 }: {
 	purchaseId: number;
 	siteSlug: string;
+	intent?: 'cancel' | 'remove' | null;
 } ) {
 	const translate = useTranslate();
 	const logPurchasesError = useLogPurchasesError( 'site level purchase cancel load error' );
@@ -162,6 +164,7 @@ export function PurchaseCancel( {
 				<CancelPurchase
 					purchaseId={ purchaseId }
 					siteSlug={ siteSlug }
+					intent={ intent }
 					getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
 					getConfirmCancelDomainUrlFor={ getConfirmCancelDomainUrlFor }
 					purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -33,6 +33,7 @@ import {
 } from './paths';
 import Subscriptions from './subscriptions';
 import { getChangeOrAddPaymentMethodUrlFor } from './utils';
+import type { CancelIntent } from 'calypso/lib/purchases/utils';
 
 import './styles.scss';
 
@@ -145,7 +146,7 @@ export function PurchaseCancel( {
 }: {
 	purchaseId: number;
 	siteSlug: string;
-	intent?: 'cancel' | 'remove' | null;
+	intent?: CancelIntent | null;
 } ) {
 	const translate = useTranslate();
 	const logPurchasesError = useLogPurchasesError( 'site level purchase cancel load error' );

--- a/client/state/purchases/actions.js
+++ b/client/state/purchases/actions.js
@@ -28,6 +28,22 @@ export const clearPurchases = () => ( dispatch, getState ) => {
 	}
 };
 
+/**
+ * Strips a single purchase from the Redux store without resetting the
+ * hasLoaded flags. Unlike clearPurchases (which dispatches PURCHASES_REMOVE
+ * and wipes the store, forcing QueryUserPurchases to refetch), this dispatches
+ * PURCHASE_REMOVE_COMPLETED with the current list minus the target purchase —
+ * keeping hasLoadedUserPurchasesFromServer / hasLoadedSitePurchasesFromServer
+ * at true so no refetch cascade is triggered.
+ */
+export const removePurchaseFromCache = ( purchaseId ) => ( dispatch, getState ) => {
+	const currentData = getState().purchases.data;
+	dispatch( {
+		type: PURCHASE_REMOVE_COMPLETED,
+		purchases: currentData.filter( ( p ) => String( p.ID ) !== String( purchaseId ) ),
+	} );
+};
+
 export const fetchSitePurchases = ( siteId ) => ( dispatch ) => {
 	dispatch( {
 		type: PURCHASES_SITE_FETCH,

--- a/client/state/purchases/actions.js
+++ b/client/state/purchases/actions.js
@@ -35,13 +35,23 @@ export const clearPurchases = () => ( dispatch, getState ) => {
  * PURCHASE_REMOVE_COMPLETED with the current list minus the target purchase —
  * keeping hasLoadedUserPurchasesFromServer / hasLoadedSitePurchasesFromServer
  * at true so no refetch cascade is triggered.
+ *
+ * Also refreshes the admin menu to match the sibling thunks (clearPurchases,
+ * removePurchase): removing a purchase can change which items appear in the
+ * site's wp-admin sidebar (e.g. a removed plugin's menu section), so the menu
+ * needs to be re-fetched to avoid stale entries until the next navigation.
  */
 export const removePurchaseFromState = ( purchaseId ) => ( dispatch, getState ) => {
-	const currentData = getState().purchases.data ?? [];
+	const state = getState();
+	const currentData = state.purchases.data ?? [];
+	const siteId = getSelectedSiteId( state );
 	dispatch( {
 		type: PURCHASE_REMOVE_COMPLETED,
 		purchases: currentData.filter( ( p ) => String( p.ID ) !== String( purchaseId ) ),
 	} );
+	if ( siteId ) {
+		dispatch( requestAdminMenu( siteId ) );
+	}
 };
 
 export const fetchSitePurchases = ( siteId ) => ( dispatch ) => {

--- a/client/state/purchases/actions.js
+++ b/client/state/purchases/actions.js
@@ -36,8 +36,8 @@ export const clearPurchases = () => ( dispatch, getState ) => {
  * keeping hasLoadedUserPurchasesFromServer / hasLoadedSitePurchasesFromServer
  * at true so no refetch cascade is triggered.
  */
-export const removePurchaseFromCache = ( purchaseId ) => ( dispatch, getState ) => {
-	const currentData = getState().purchases.data;
+export const removePurchaseFromState = ( purchaseId ) => ( dispatch, getState ) => {
+	const currentData = getState().purchases.data ?? [];
 	dispatch( {
 		type: PURCHASE_REMOVE_COMPLETED,
 		purchases: currentData.filter( ( p ) => String( p.ID ) !== String( purchaseId ) ),

--- a/client/state/purchases/actions.js
+++ b/client/state/purchases/actions.js
@@ -40,6 +40,12 @@ export const clearPurchases = () => ( dispatch, getState ) => {
  * removePurchase): removing a purchase can change which items appear in the
  * site's wp-admin sidebar (e.g. a removed plugin's menu section), so the menu
  * needs to be re-fetched to avoid stale entries until the next navigation.
+ *
+ * NOTE: temporary bridge for the legacy `client/me/purchases` surface, which
+ * still reads purchases from Redux. The dashboard surface uses React Query
+ * directly (see `removePurchaseMutation` in
+ * `packages/api-queries/src/upgrades.ts`). Once `client/me/purchases/**`
+ * migrates to `useQuery`, this helper can be removed.
  */
 export const removePurchaseFromState = ( purchaseId ) => ( dispatch, getState ) => {
 	const state = getState();

--- a/client/state/purchases/test/actions.js
+++ b/client/state/purchases/test/actions.js
@@ -134,6 +134,10 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#removePurchaseFromState', () => {
+		beforeEach( () => {
+			dispatch.mockClear();
+		} );
+
 		test( 'dispatches PURCHASE_REMOVE_COMPLETED with the target purchase stripped', () => {
 			const data = [ { ID: 1 }, { ID: 2 }, { ID: 3 } ];
 			getState.mockReturnValueOnce( { purchases: { data } } );
@@ -167,6 +171,28 @@ describe( 'actions', () => {
 				type: PURCHASE_REMOVE_COMPLETED,
 				purchases: [],
 			} );
+		} );
+
+		test( 'refreshes the admin menu when a site is selected', () => {
+			getState.mockReturnValueOnce( {
+				purchases: { data: [ { ID: 1 } ] },
+				ui: { selectedSiteId: siteId },
+			} );
+
+			removePurchaseFromState( 1 )( dispatch, getState );
+
+			expect( dispatch ).toHaveBeenCalledWith( requestAdminMenu( siteId ) );
+		} );
+
+		test( 'skips the admin menu refresh when no site is selected', () => {
+			getState.mockReturnValueOnce( { purchases: { data: [ { ID: 1 } ] } } );
+
+			removePurchaseFromState( 1 )( dispatch, getState );
+
+			const adminMenuCall = dispatch.mock.calls.find(
+				( [ action ] ) => action?.type === requestAdminMenu( siteId ).type
+			);
+			expect( adminMenuCall ).toBeUndefined();
 		} );
 	} );
 } );

--- a/client/state/purchases/test/actions.js
+++ b/client/state/purchases/test/actions.js
@@ -9,7 +9,13 @@ import {
 } from 'calypso/state/action-types';
 import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
 import useNock from 'calypso/test-helpers/use-nock';
-import { clearPurchases, fetchSitePurchases, fetchUserPurchases, removePurchase } from '../actions';
+import {
+	clearPurchases,
+	fetchSitePurchases,
+	fetchUserPurchases,
+	removePurchase,
+	removePurchaseFromState,
+} from '../actions';
 
 describe( 'actions', () => {
 	const purchases = [ { ID: 1 } ];
@@ -123,6 +129,43 @@ describe( 'actions', () => {
 			expect( dispatch ).toHaveBeenCalledWith( {
 				type: PURCHASE_REMOVE_FAILED,
 				error: errorMessage,
+			} );
+		} );
+	} );
+
+	describe( '#removePurchaseFromState', () => {
+		test( 'dispatches PURCHASE_REMOVE_COMPLETED with the target purchase stripped', () => {
+			const data = [ { ID: 1 }, { ID: 2 }, { ID: 3 } ];
+			getState.mockReturnValueOnce( { purchases: { data } } );
+
+			removePurchaseFromState( 2 )( dispatch, getState );
+
+			expect( dispatch ).toHaveBeenCalledWith( {
+				type: PURCHASE_REMOVE_COMPLETED,
+				purchases: [ { ID: 1 }, { ID: 3 } ],
+			} );
+		} );
+
+		test( 'compares IDs as strings so numeric/string mismatches are tolerated', () => {
+			const data = [ { ID: '1' }, { ID: 2 } ];
+			getState.mockReturnValueOnce( { purchases: { data } } );
+
+			removePurchaseFromState( 1 )( dispatch, getState );
+
+			expect( dispatch ).toHaveBeenCalledWith( {
+				type: PURCHASE_REMOVE_COMPLETED,
+				purchases: [ { ID: 2 } ],
+			} );
+		} );
+
+		test( 'dispatches an empty list when state has not been loaded yet', () => {
+			getState.mockReturnValueOnce( { purchases: { data: null } } );
+
+			removePurchaseFromState( 1 )( dispatch, getState );
+
+			expect( dispatch ).toHaveBeenCalledWith( {
+				type: PURCHASE_REMOVE_COMPLETED,
+				purchases: [],
 			} );
 		} );
 	} );


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/RSM-474

## Proposed Changes

This adds the groundwork for some improvements to the cancellation and removal flows in #110163. It adds two small redux/lib helpers for the remove-purchase flow and extends the URL `?intent=` plumbing to site-level purchases so that it matches the account-level changes in #110094.

* `removePurchaseAsync`: Promise-based wrapper for `POST /purchases/:id/delete` - this will allow us to remove a single purchase asynchronously 
* `removePurchaseFromState`: optimistic Redux cache strip that avoids the refetch cascade `clearPurchases()` triggers. Preserves `hasLoadedUserPurchasesFromServer` / `hasLoadedSitePurchasesFromServer` so `<QueryUserPurchases>` doesn't re-request the deleted purchase.
* `client/my-sites/purchases/controller.js`: parse `?intent=` from the URL query and forward to `<PurchaseCancel>`.
* `client/my-sites/purchases/main.tsx`: accept `intent` prop on `<PurchaseCancel>` and thread to `<CancelPurchase>`.

## Why are these changes being made?

The account-level Classic purchase cancel route already accepts and propagates `?intent=cancel` / `?intent=remove` (added in #110094). Users who reach the cancel flow via a site-scoped URL (`/purchases/subscriptions/:site/:purchaseId/cancel`) hit a parallel controller that hadn't been updated yet, so intent got dropped at that entry point. This change makes the two entry points symmetric.

The two helpers are extracted from the same upstream branch: `removePurchaseAsync` is a Promise wrapper we need from a non-Redux call site, and `removePurchaseFromState` avoids a specific UX bug — after DELETE, `clearPurchases()` resets the loaded-flag, which causes `<QueryUserPurchases>` to refetch (and the server may briefly still return the row mid-propagation). Stripping the row in place keeps the UI stable across the transition.

Neither helper has a caller yet — they're prerequisites for a follow-up PR that wires the cancel/remove mutation to fire on confirmation click. Landing the helpers first keeps that follow-up PR narrow.

## Testing Instructions

TC:
```
yarn test-client client/state/purchases client/my-sites/purchases
```

Manual testing:
* The two helpers are currently unreferenced on trunk, so there's no user-visible behavior to exercise in isolation — the test suite running green is the main signal.
* For the intent plumbing: load `/purchases/subscriptions/:site/:purchaseId/cancel?intent=remove` under the `purchases/split-cancel-remove` flag and confirm the cancel page renders the "Remove" confirmation variant (same behavior as the account-level route under the flag).