### PR TITLE
Purchase Settings: transient success notice + expired-state polish

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -264,12 +264,14 @@ export const purchaseSettingsRoute = createRoute( {
 		};
 	},
 	path: '$purchaseId',
-	validateSearch: ( search ): { refunded?: true; upgraded?: true } => {
+	validateSearch: ( search ): { refunded?: true; upgraded?: true; cancelled?: true } => {
 		const isRefunded = search.refunded === true || search.refunded === 'true';
 		const isUpgraded = search.upgraded === true || search.upgraded === 'true';
+		const isCancelled = search.cancelled === true || search.cancelled === 'true';
 		return {
 			...( isRefunded ? { refunded: true } : {} ),
 			...( isUpgraded ? { upgraded: true } : {} ),
+			...( isCancelled ? { cancelled: true } : {} ),
 		};
 	},
 } );

--- a/client/dashboard/me/billing-purchases/purchase-settings/classify-purchase-for-copy.ts
+++ b/client/dashboard/me/billing-purchases/purchase-settings/classify-purchase-for-copy.ts
@@ -1,3 +1,4 @@
+import { __ } from '@wordpress/i18n';
 import { isDomainTransfer, isGoogleWorkspace, isTitanMail } from '../../../utils/purchase';
 import type { Purchase } from '@automattic/api-core';
 
@@ -30,4 +31,26 @@ export function classifyPurchaseForCopy( purchase: Purchase ): CancelRemoveCateg
 		return 'marketplace_plugin';
 	}
 	return 'other';
+}
+
+/**
+ * Plain-English noun for a purchase ("plan" / "domain" / "email" / "theme" /
+ * "plugin" / "subscription"). Shared between the dashboard and legacy
+ * cancelled-redirect notices so both surfaces produce identical copy.
+ */
+export function getProductNounForCategory( category: CancelRemoveCategory ): string {
+	switch ( category ) {
+		case 'plan':
+			return __( 'plan' );
+		case 'domain':
+			return __( 'domain' );
+		case 'email':
+			return __( 'email' );
+		case 'marketplace_theme':
+			return __( 'theme' );
+		case 'marketplace_plugin':
+			return __( 'plugin' );
+		default:
+			return __( 'subscription' );
+	}
 }

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -44,6 +44,7 @@ import {
 	currencyDollar,
 	commentAuthorAvatar,
 	layout,
+	info,
 } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 import { useAnalytics } from '../../../app/analytics';
@@ -591,6 +592,9 @@ function PurchaseSettingsActions( { purchase }: { purchase: Purchase } ) {
 	if ( isCentennialPurchase( purchase ) ) {
 		return null;
 	}
+	if ( isExpired( purchase ) ) {
+		return null;
+	}
 
 	return (
 		<VStack spacing={ 4 }>
@@ -776,6 +780,17 @@ function ManageSubscriptionCard( { purchase }: { purchase: Purchase } ) {
 function PurchasePriceCard( { purchase }: { purchase: Purchase } ) {
 	const isCentennial = isCentennialPurchase( purchase );
 	if ( isCentennial ) {
+		return (
+			<OverviewCard
+				icon={ currencyDollar }
+				title={ __( 'Price' ) }
+				heading={ formatCurrency( purchase.price_integer, purchase.currency_code, {
+					isSmallestUnit: true,
+				} ) }
+			/>
+		);
+	}
+	if ( isExpired( purchase ) ) {
 		return (
 			<OverviewCard
 				icon={ currencyDollar }
@@ -1323,53 +1338,57 @@ export default function PurchaseSettings() {
 			<VStack spacing={ 6 }>
 				<PurchaseNotice purchase={ purchase } />
 				<Grid columns={ columns } gap={ spacing }>
-					<OverviewCard
-						icon={ calendar }
-						title={ expiryDateTitle }
-						heading={ ( () => {
-							if ( isOneTimePurchase( purchase ) || isAkismetFreeProduct( purchase ) ) {
-								return __( 'Never expires' );
-							}
-							if ( isInExpirationGracePeriod( purchase ) ) {
+					{ isExpired( purchase ) ? (
+						<OverviewCard icon={ info } title={ __( 'Status' ) } heading={ __( 'Removed' ) } />
+					) : (
+						<OverviewCard
+							icon={ calendar }
+							title={ expiryDateTitle }
+							heading={ ( () => {
+								if ( isOneTimePurchase( purchase ) || isAkismetFreeProduct( purchase ) ) {
+									return __( 'Never expires' );
+								}
+								if ( isInExpirationGracePeriod( purchase ) ) {
+									return formattedExpiry;
+								}
+								if ( willRenew ) {
+									return formattedRenewal;
+								}
+								if ( purchase.subscription_status !== 'active' ) {
+									return __( 'Inactive' );
+								}
 								return formattedExpiry;
-							}
-							if ( willRenew ) {
-								return formattedRenewal;
-							}
-							if ( purchase.subscription_status !== 'active' ) {
-								return __( 'Inactive' );
-							}
-							return formattedExpiry;
-						} )() }
-						description={ ( () => {
-							if ( isCentennial ) {
-								return undefined;
-							}
-							if ( purchase.is_auto_renew_enabled && isInExpirationGracePeriod( purchase ) ) {
-								return __( 'Pending renewal' );
-							}
-							if ( purchase.is_auto_renew_enabled && isRenewing( purchase ) ) {
-								return __( 'Auto-renew is enabled' );
-							}
-							if ( isIncludedWithPlan( purchase ) && purchase.attached_to_purchase_id ) {
-								return (
-									<Link
-										to={ purchaseSettingsRoute.fullPath }
-										params={ { purchaseId: purchase.attached_to_purchase_id } }
-									>
-										{ __( 'Renews with plan' ) }
-									</Link>
-								);
-							}
-							if ( purchase.is_trial_plan || isAkismetFreeProduct( purchase ) ) {
-								return undefined;
-							}
-							if ( purchase.is_auto_renew_enabled ) {
-								return __( 'Will not auto-renew because there is no payment method' );
-							}
-							return __( 'Auto-renew is disabled' );
-						} )() }
-					/>
+							} )() }
+							description={ ( () => {
+								if ( isCentennial ) {
+									return undefined;
+								}
+								if ( purchase.is_auto_renew_enabled && isInExpirationGracePeriod( purchase ) ) {
+									return __( 'Pending renewal' );
+								}
+								if ( purchase.is_auto_renew_enabled && isRenewing( purchase ) ) {
+									return __( 'Auto-renew is enabled' );
+								}
+								if ( isIncludedWithPlan( purchase ) && purchase.attached_to_purchase_id ) {
+									return (
+										<Link
+											to={ purchaseSettingsRoute.fullPath }
+											params={ { purchaseId: purchase.attached_to_purchase_id } }
+										>
+											{ __( 'Renews with plan' ) }
+										</Link>
+									);
+								}
+								if ( purchase.is_trial_plan || isAkismetFreeProduct( purchase ) ) {
+									return undefined;
+								}
+								if ( purchase.is_auto_renew_enabled ) {
+									return __( 'Will not auto-renew because there is no payment method' );
+								}
+								return __( 'Auto-renew is disabled' );
+							} )() }
+						/>
+					) }
 					<PurchasePriceCard purchase={ purchase } />
 					{ site &&
 						( site.options?.is_domain_only &&

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -592,8 +592,18 @@ function PurchaseSettingsActions( { purchase }: { purchase: Purchase } ) {
 	if ( isCentennialPurchase( purchase ) ) {
 		return null;
 	}
+
+	// Expired purchases get only the "Pick another plan/product" CTA — the
+	// other actions (reinstall, upgrade, renew, cancel/remove) don't apply
+	// once the purchase has lapsed.
 	if ( isExpired( purchase ) ) {
-		return null;
+		return (
+			<VStack spacing={ 4 }>
+				<ActionList>
+					<ReSubscribeActionButton purchase={ purchase } />
+				</ActionList>
+			</VStack>
+		);
 	}
 
 	return (

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-cancelled-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-cancelled-notice.tsx
@@ -2,6 +2,7 @@ import { Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { intlFormat } from 'date-fns';
 import Notice from '../../../components/notice';
+import { classifyPurchaseForCopy } from './classify-purchase-for-copy';
 import type { Purchase } from '@automattic/api-core';
 
 /**
@@ -10,33 +11,20 @@ import type { Purchase } from '@automattic/api-core';
  * remove-success snackbar.
  */
 export function getProductNoun( purchase: Purchase ): string {
-	if ( purchase.is_plan ) {
-		return __( 'plan' );
+	switch ( classifyPurchaseForCopy( purchase ) ) {
+		case 'plan':
+			return __( 'plan' );
+		case 'domain':
+			return __( 'domain' );
+		case 'email':
+			return __( 'email' );
+		case 'marketplace_theme':
+			return __( 'theme' );
+		case 'marketplace_plugin':
+			return __( 'plugin' );
+		default:
+			return __( 'subscription' );
 	}
-	if ( purchase.is_domain_registration ) {
-		return __( 'domain' );
-	}
-	const slug = purchase.product_slug ?? '';
-	if (
-		slug.startsWith( 'wp_titan_mail' ) ||
-		slug === 'gapps' ||
-		slug === 'gapps_extra_license' ||
-		slug === 'gapps_business' ||
-		slug === 'gapps_business_extra_license' ||
-		slug.startsWith( 'wp_google_workspace_' )
-	) {
-		return __( 'email' );
-	}
-	if ( purchase.product_type === 'marketplace_theme' ) {
-		return __( 'theme' );
-	}
-	if (
-		purchase.product_type?.startsWith( 'marketplace' ) ||
-		purchase.product_type === 'saas_plugin'
-	) {
-		return __( 'plugin' );
-	}
-	return __( 'subscription' );
 }
 
 /**

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-cancelled-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-cancelled-notice.tsx
@@ -1,0 +1,95 @@
+import { Button } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { intlFormat } from 'date-fns';
+import Notice from '../../../components/notice';
+import type { Purchase } from '@automattic/api-core';
+
+/**
+ * Plain-English noun for a purchase ("plan" / "domain" / "email" / "theme" /
+ * "plugin" / "subscription"). Used by the cancelled success notice and by the
+ * remove-success snackbar.
+ */
+export function getProductNoun( purchase: Purchase ): string {
+	if ( purchase.is_plan ) {
+		return __( 'plan' );
+	}
+	if ( purchase.is_domain_registration ) {
+		return __( 'domain' );
+	}
+	const slug = purchase.product_slug ?? '';
+	if (
+		slug.startsWith( 'wp_titan_mail' ) ||
+		slug === 'gapps' ||
+		slug === 'gapps_extra_license' ||
+		slug === 'gapps_business' ||
+		slug === 'gapps_business_extra_license' ||
+		slug.startsWith( 'wp_google_workspace_' )
+	) {
+		return __( 'email' );
+	}
+	if ( purchase.product_type === 'marketplace_theme' ) {
+		return __( 'theme' );
+	}
+	if (
+		purchase.product_type?.startsWith( 'marketplace' ) ||
+		purchase.product_type === 'saas_plugin'
+	) {
+		return __( 'plugin' );
+	}
+	return __( 'subscription' );
+}
+
+/**
+ * Transient success notice shown on Purchase Settings after a cancel.
+ * Gated by the caller (on the `?cancelled=true` search param). Dismissible via
+ * the built-in close button on the Notice component.
+ */
+export function PurchaseCancelledNotice( {
+	purchase,
+	onClose,
+}: {
+	purchase: Purchase;
+	onClose: () => void;
+} ) {
+	const expiryDate = intlFormat(
+		new Date( purchase.expiry_date ),
+		{ dateStyle: 'long' },
+		{ locale: 'en-US' }
+	);
+
+	if ( purchase.will_atomic_revert_after_removal ) {
+		const exportUrl = `https://${ purchase.domain }/wp-admin/export.php`;
+		return (
+			<Notice
+				variant="success"
+				onClose={ onClose }
+				actions={
+					<Button variant="primary" href={ exportUrl } target="_blank" rel="noreferrer">
+						{ __( 'Download backup' ) }
+					</Button>
+				}
+			>
+				{ sprintf(
+					/* translators: %(expiryDate)s is a date like "April 21, 2027". */
+					__(
+						'Your subscription is cancelled and you won\u2019t be billed again. Your site stays live until %(expiryDate)s. Download a backup to save your content, themes, and plugins.'
+					),
+					{ expiryDate }
+				) }
+			</Notice>
+		);
+	}
+
+	const productNoun = getProductNoun( purchase );
+	return (
+		<Notice variant="success" onClose={ onClose }>
+			{ sprintf(
+				/* translators: %(productNoun)s is plan/domain/email/theme/plugin/subscription, %(expiryDate)s is a date like "April 21, 2027" */
+				__(
+					'Your subscription is cancelled and you won\u2019t be billed again. You\u2019ll continue to have access to the %(productNoun)s until %(expiryDate)s.'
+				),
+				{ productNoun, expiryDate }
+			) }
+		</Notice>
+	);
+}

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-cancelled-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-cancelled-notice.tsx
@@ -39,6 +39,11 @@ export function PurchaseCancelledNotice( {
 	purchase: Purchase;
 	onClose: () => void;
 } ) {
+	// One-time purchases and edge cases without an expiry can't render a
+	// meaningful "until <date>" message, so skip the notice entirely.
+	if ( ! purchase.expiry_date ) {
+		return null;
+	}
 	const expiryDate = intlFormat(
 		new Date( purchase.expiry_date ),
 		{ dateStyle: 'long' },

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-cancelled-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-cancelled-notice.tsx
@@ -2,30 +2,8 @@ import { Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { intlFormat } from 'date-fns';
 import Notice from '../../../components/notice';
-import { classifyPurchaseForCopy } from './classify-purchase-for-copy';
+import { classifyPurchaseForCopy, getProductNounForCategory } from './classify-purchase-for-copy';
 import type { Purchase } from '@automattic/api-core';
-
-/**
- * Plain-English noun for a purchase ("plan" / "domain" / "email" / "theme" /
- * "plugin" / "subscription"). Used by the cancelled success notice and by the
- * remove-success snackbar.
- */
-export function getProductNoun( purchase: Purchase ): string {
-	switch ( classifyPurchaseForCopy( purchase ) ) {
-		case 'plan':
-			return __( 'plan' );
-		case 'domain':
-			return __( 'domain' );
-		case 'email':
-			return __( 'email' );
-		case 'marketplace_theme':
-			return __( 'theme' );
-		case 'marketplace_plugin':
-			return __( 'plugin' );
-		default:
-			return __( 'subscription' );
-	}
-}
 
 /**
  * Transient success notice shown on Purchase Settings after a cancel.
@@ -73,7 +51,7 @@ export function PurchaseCancelledNotice( {
 		);
 	}
 
-	const productNoun = getProductNoun( purchase );
+	const productNoun = getProductNounForCategory( classifyPurchaseForCopy( purchase ) );
 	return (
 		<Notice variant="success" onClose={ onClose }>
 			{ sprintf(

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -6,6 +6,7 @@ import {
 	userPreferenceMutation,
 	userPreferenceQuery,
 } from '@automattic/api-queries';
+import config from '@automattic/calypso-config';
 import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { Button } from '@wordpress/components';
@@ -39,13 +40,30 @@ import {
 	OtherRenewablePurchasesNotice,
 	shouldShowOtherRenewablePurchasesNotice,
 } from './other-renewable-purchases-notice';
+import { PurchaseCancelledNotice } from './purchase-cancelled-notice';
 import { PurchaseExpiringNotice, shouldShowExpiringNotice } from './purchase-expiring-notice';
 import { RenewNoticeAction, shouldShowRenewNoticeAction } from './renew-notice-action';
 import type { Purchase } from '@automattic/api-core';
 
 export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 	const { user } = useAuth();
-	const { refunded, upgraded } = purchaseSettingsRoute.useSearch();
+	const { refunded, upgraded, cancelled } = purchaseSettingsRoute.useSearch();
+	const navigate = purchaseSettingsRoute.useNavigate();
+	// Show the transient cancelled success notice once after a cancel redirects
+	// here. The URL search param is cleared immediately so that a refresh / back
+	// navigation falls through to the regular expiring notice.
+	const [ showCancelledNotice, setShowCancelledNotice ] = useState( Boolean( cancelled ) );
+	useEffect( () => {
+		if ( cancelled ) {
+			navigate( {
+				search: ( prev: Record< string, unknown > ) => {
+					const { cancelled: _cancelled, ...rest } = prev;
+					return rest;
+				},
+				replace: true,
+			} );
+		}
+	}, [ cancelled, navigate ] );
 	const { data: purchaseAttachedTo } = useQuery( {
 		...purchaseQuery( purchase.attached_to_purchase_id ?? 0 ),
 		enabled: Boolean( purchase.attached_to_purchase_id ),
@@ -77,7 +95,6 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 		/>
 	) : null;
 
-	const navigate = purchaseSettingsRoute.useNavigate();
 	const [ showUpgradedNotice, setShowUpgradedNotice ] = useState( () => Boolean( upgraded ) );
 
 	useEffect( () => {
@@ -89,6 +106,18 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 			} );
 		}
 	}, [ upgraded, refunded, navigate ] );
+
+	// Transient cancelled success notice — suppresses every other notice until
+	// dismissed, refreshed, or navigated-away-and-back. Gated on the
+	// `?cancelled=true` search param set by the cancel redirect.
+	if ( config.isEnabled( 'purchases/split-cancel-remove' ) && showCancelledNotice ) {
+		return (
+			<PurchaseCancelledNotice
+				purchase={ purchase }
+				onClose={ () => setShowCancelledNotice( false ) }
+			/>
+		);
+	}
 
 	if ( showUpgradedNotice ) {
 		return (

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -147,6 +147,7 @@ import {
 	hasLoadedUserPurchasesFromServer,
 	hasLoadedSitePurchasesFromServer,
 	getRenewableSitePurchases,
+	willAtomicSiteRevertAfterPurchaseDeactivation,
 } from 'calypso/state/purchases/selectors';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
@@ -230,6 +231,7 @@ export interface ManagePurchaseConnectedProps {
 	isAtomicSite?: boolean | null;
 	isDomainOnlySite?: boolean | null;
 	isProductOwner?: boolean | null;
+	willAtomicSiteRevert?: boolean;
 	isPurchaseTheme?: boolean | null;
 	plan: FilteredPlan | false | undefined;
 	primaryDomain?: ResponseDomain | null;
@@ -1587,6 +1589,7 @@ class ManagePurchase extends Component<
 			getAddNewPaymentMethodUrlFor,
 			getChangePaymentMethodUrlFor,
 			isProductOwner,
+			willAtomicSiteRevert,
 		} = this.props;
 
 		// If there is no purchase, query to load the purchases
@@ -1660,6 +1663,7 @@ class ManagePurchase extends Component<
 						changePaymentMethodPath={ changePaymentMethodPath }
 						getManagePurchaseUrlFor={ getManagePurchaseUrlFor ?? managePurchase }
 						isProductOwner={ isProductOwner }
+						willAtomicSiteRevert={ willAtomicSiteRevert }
 						getAddNewPaymentMethodUrlFor={
 							getAddNewPaymentMethodUrlFor ?? getAddNewPaymentMethodPath
 						}
@@ -1913,6 +1917,9 @@ export default connect( ( state: IAppState, props: ManagePurchaseProps ) => {
 		isAtomicSite: isSiteAtomic( state, siteId ),
 		isDomainOnlySite: purchase && isDomainOnly( state, purchase.siteId ),
 		isProductOwner,
+		willAtomicSiteRevert: purchase
+			? willAtomicSiteRevertAfterPurchaseDeactivation( state, purchase.id, [] )
+			: false,
 		isPurchaseTheme,
 		plan: isPurchasePlan && applyTestFiltersToPlansList( purchase.productSlug, undefined ),
 		primaryDomain: primaryDomain,

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -23,6 +23,7 @@ import { connect } from 'react-redux';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Notice, { NoticeStatus } from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
+import { getProductNounForCategory } from 'calypso/dashboard/me/billing-purchases/purchase-settings/classify-purchase-for-copy';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import {
 	canExplicitRenew,
@@ -52,6 +53,7 @@ import { getTrialCheckoutUrl } from 'calypso/lib/trials/get-trial-checkout-url';
 import { managePurchase } from 'calypso/me/purchases/paths';
 import UpcomingRenewalsDialog from 'calypso/me/purchases/upcoming-renewals/upcoming-renewals-dialog';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { classifyPurchaseForCopy } from '../classify-purchase-for-copy';
 import { getAddNewPaymentMethodPath } from '../utils';
 import type { SiteDetails } from '@automattic/data-stores';
 import type {
@@ -126,39 +128,6 @@ class PurchaseNotice extends Component<
 	};
 
 	/**
-	 * Plain-English noun for the cancelled-redirect notice ("plan" / "domain" /
-	 * "email" / "theme" / "plugin" / "subscription").
-	 */
-	getCancelledNoticeProductNoun( purchase: Purchase ) {
-		const { translate } = this.props;
-		if ( isPlan( purchase ) ) {
-			return translate( 'plan' );
-		}
-		if ( isDomainRegistration( purchase ) ) {
-			return translate( 'domain' );
-		}
-		const slug = purchase.productSlug ?? '';
-		if (
-			slug.startsWith( 'wp_titan_mail' ) ||
-			slug === 'gapps' ||
-			slug.startsWith( 'gapps_' ) ||
-			slug.startsWith( 'wp_google_workspace_' )
-		) {
-			return translate( 'email' );
-		}
-		if ( purchase.productType === 'marketplace_theme' ) {
-			return translate( 'theme' );
-		}
-		if (
-			purchase.productType?.startsWith( 'marketplace' ) ||
-			purchase.productType === 'saas_plugin'
-		) {
-			return translate( 'plugin' );
-		}
-		return translate( 'subscription' );
-	}
-
-	/**
 	 * Transient success notice shown after a cancel-flow redirect. Suppresses
 	 * every other notice until dismissed; the URL param is cleared on mount so
 	 * refresh / back-navigation falls through to the regular notices.
@@ -198,7 +167,7 @@ class PurchaseNotice extends Component<
 			'Your subscription is cancelled and you won’t be billed again. You’ll continue to have access to the %(productNoun)s until %(expiryDate)s.',
 			{
 				args: {
-					productNoun: this.getCancelledNoticeProductNoun( purchase ),
+					productNoun: getProductNounForCategory( classifyPurchaseForCopy( purchase ) ),
 					expiryDate,
 				},
 			}

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -52,7 +52,7 @@ import { getTrialCheckoutUrl } from 'calypso/lib/trials/get-trial-checkout-url';
 import { managePurchase } from 'calypso/me/purchases/paths';
 import UpcomingRenewalsDialog from 'calypso/me/purchases/upcoming-renewals/upcoming-renewals-dialog';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import { willAtomicSiteRevertAfterPurchaseDeactivation } from 'calypso/state/purchases/selectors';
 import { getAddNewPaymentMethodPath } from '../utils';
 import type { SiteDetails } from '@automattic/data-stores';
 import type {
@@ -83,7 +83,7 @@ export interface PurchaseNoticeProps {
 
 export interface PurchaseNoticeConnectedProps {
 	recordTracksEvent: typeof recordTracksEvent;
-	isAtomicSite?: boolean;
+	willAtomicSiteRevert?: boolean;
 }
 
 interface MomentProps {
@@ -165,7 +165,7 @@ class PurchaseNotice extends Component<
 	 * refresh / back-navigation falls through to the regular notices.
 	 */
 	renderCancelledRedirectNotice() {
-		const { purchase, translate, moment, isAtomicSite } = this.props;
+		const { purchase, translate, moment, willAtomicSiteRevert } = this.props;
 		if (
 			! config.isEnabled( 'purchases/split-cancel-remove' ) ||
 			! this.state.showCancelledRedirectNotice ||
@@ -174,7 +174,7 @@ class PurchaseNotice extends Component<
 			return null;
 		}
 		const expiryDate = moment( purchase.expiryDate ).format( 'LL' );
-		if ( isAtomicSite ) {
+		if ( willAtomicSiteRevert ) {
 			const exportUrl = `https://${ purchase.domain }/wp-admin/export.php`;
 			return (
 				<Notice
@@ -1449,7 +1449,10 @@ class PurchaseNotice extends Component<
 }
 
 const mapStateToProps = ( state: object, ownProps: PurchaseNoticeProps ) => ( {
-	isAtomicSite: isSiteAutomatedTransfer( state, ownProps.purchase?.siteId ?? null ),
+	willAtomicSiteRevert: willAtomicSiteRevertAfterPurchaseDeactivation(
+		state,
+		ownProps.purchase?.id
+	),
 } );
 
 export default connect( mapStateToProps, { recordTracksEvent } )(

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -53,8 +53,8 @@ import { getTrialCheckoutUrl } from 'calypso/lib/trials/get-trial-checkout-url';
 import { managePurchase } from 'calypso/me/purchases/paths';
 import UpcomingRenewalsDialog from 'calypso/me/purchases/upcoming-renewals/upcoming-renewals-dialog';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { classifyPurchaseForCopy } from '../classify-purchase-for-copy';
 import { getAddNewPaymentMethodPath } from '../utils';
+import { classifyPurchaseForCopy } from './classify-purchase-for-copy';
 import type { SiteDetails } from '@automattic/data-stores';
 import type {
 	GetManagePurchaseUrlFor,

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -52,7 +52,6 @@ import { getTrialCheckoutUrl } from 'calypso/lib/trials/get-trial-checkout-url';
 import { managePurchase } from 'calypso/me/purchases/paths';
 import UpcomingRenewalsDialog from 'calypso/me/purchases/upcoming-renewals/upcoming-renewals-dialog';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { willAtomicSiteRevertAfterPurchaseDeactivation } from 'calypso/state/purchases/selectors';
 import { getAddNewPaymentMethodPath } from '../utils';
 import type { SiteDetails } from '@automattic/data-stores';
 import type {
@@ -79,11 +78,11 @@ export interface PurchaseNoticeProps {
 	purchaseAttachedTo: Purchase | null | undefined;
 	renewableSitePurchases: Purchase[];
 	selectedSite: SiteDetails | null | undefined;
+	willAtomicSiteRevert?: boolean;
 }
 
 export interface PurchaseNoticeConnectedProps {
 	recordTracksEvent: typeof recordTracksEvent;
-	willAtomicSiteRevert?: boolean;
 }
 
 interface MomentProps {
@@ -1448,13 +1447,6 @@ class PurchaseNotice extends Component<
 	}
 }
 
-const mapStateToProps = ( state: object, ownProps: PurchaseNoticeProps ) => ( {
-	willAtomicSiteRevert: willAtomicSiteRevertAfterPurchaseDeactivation(
-		state,
-		ownProps.purchase?.id
-	),
-} );
-
-export default connect( mapStateToProps, { recordTracksEvent } )(
+export default connect( null, { recordTracksEvent } )(
 	localize( withLocalizedMoment( PurchaseNotice ) )
 );

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -52,6 +52,7 @@ import { getTrialCheckoutUrl } from 'calypso/lib/trials/get-trial-checkout-url';
 import { managePurchase } from 'calypso/me/purchases/paths';
 import UpcomingRenewalsDialog from 'calypso/me/purchases/upcoming-renewals/upcoming-renewals-dialog';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getAddNewPaymentMethodPath } from '../utils';
 import type { SiteDetails } from '@automattic/data-stores';
 import type {
@@ -82,6 +83,7 @@ export interface PurchaseNoticeProps {
 
 export interface PurchaseNoticeConnectedProps {
 	recordTracksEvent: typeof recordTracksEvent;
+	isAtomicSite?: boolean;
 }
 
 interface MomentProps {
@@ -98,7 +100,120 @@ class PurchaseNotice extends Component<
 
 	state = {
 		showUpcomingRenewalsDialog: false,
+		// Seeded from `?cancelled=true` on first render. The URL param is cleared
+		// in componentDidMount so refresh / back-navigation doesn't re-show this
+		// transient notice.
+		showCancelledRedirectNotice:
+			typeof window !== 'undefined' &&
+			new URLSearchParams( window.location.search ).get( 'cancelled' ) === 'true',
 	};
+
+	componentDidMount() {
+		if ( typeof window === 'undefined' ) {
+			return;
+		}
+		const params = new URLSearchParams( window.location.search );
+		if ( params.get( 'cancelled' ) === 'true' ) {
+			params.delete( 'cancelled' );
+			const newSearch = params.toString();
+			const newUrl =
+				window.location.pathname + ( newSearch ? '?' + newSearch : '' ) + window.location.hash;
+			window.history.replaceState( window.history.state, '', newUrl );
+		}
+	}
+
+	dismissCancelledRedirectNotice = () => {
+		this.setState( { showCancelledRedirectNotice: false } );
+	};
+
+	/**
+	 * Plain-English noun for the cancelled-redirect notice ("plan" / "domain" /
+	 * "email" / "theme" / "plugin" / "subscription").
+	 */
+	getCancelledNoticeProductNoun( purchase: Purchase ) {
+		const { translate } = this.props;
+		if ( isPlan( purchase ) ) {
+			return translate( 'plan' );
+		}
+		if ( isDomainRegistration( purchase ) ) {
+			return translate( 'domain' );
+		}
+		const slug = purchase.productSlug ?? '';
+		if (
+			slug.startsWith( 'wp_titan_mail' ) ||
+			slug === 'gapps' ||
+			slug.startsWith( 'gapps_' ) ||
+			slug.startsWith( 'wp_google_workspace_' )
+		) {
+			return translate( 'email' );
+		}
+		if ( purchase.productType === 'marketplace_theme' ) {
+			return translate( 'theme' );
+		}
+		if (
+			purchase.productType?.startsWith( 'marketplace' ) ||
+			purchase.productType === 'saas_plugin'
+		) {
+			return translate( 'plugin' );
+		}
+		return translate( 'subscription' );
+	}
+
+	/**
+	 * Transient success notice shown after a cancel-flow redirect. Suppresses
+	 * every other notice until dismissed; the URL param is cleared on mount so
+	 * refresh / back-navigation falls through to the regular notices.
+	 */
+	renderCancelledRedirectNotice() {
+		const { purchase, translate, moment, isAtomicSite } = this.props;
+		if (
+			! config.isEnabled( 'purchases/split-cancel-remove' ) ||
+			! this.state.showCancelledRedirectNotice ||
+			! purchase
+		) {
+			return null;
+		}
+		const expiryDate = moment( purchase.expiryDate ).format( 'LL' );
+		if ( isAtomicSite ) {
+			const exportUrl = `https://${ purchase.domain }/wp-admin/export.php`;
+			return (
+				<Notice
+					className="manage-purchase__purchase-expiring-notice"
+					showDismiss
+					onDismissClick={ this.dismissCancelledRedirectNotice }
+					status="is-success"
+				>
+					{ translate(
+						'Your subscription is cancelled and you won\u2019t be billed again. Your site stays live until %(expiryDate)s. {{a}}Download a backup{{/a}} to save your content, themes, and plugins.',
+						{
+							args: { expiryDate },
+							components: {
+								a: <a href={ exportUrl } target="_blank" rel="noreferrer" />,
+							},
+						}
+					) }
+				</Notice>
+			);
+		}
+		const noticeText = translate(
+			'Your subscription is cancelled and you won’t be billed again. You’ll continue to have access to the %(productNoun)s until %(expiryDate)s.',
+			{
+				args: {
+					productNoun: this.getCancelledNoticeProductNoun( purchase ),
+					expiryDate,
+				},
+			}
+		);
+		return (
+			<Notice
+				className="manage-purchase__purchase-expiring-notice"
+				showDismiss
+				onDismissClick={ this.dismissCancelledRedirectNotice }
+				status="is-success"
+				text={ noticeText }
+			/>
+		);
+	}
 
 	getExpiringText( purchase: Purchase ) {
 		const { translate, moment, selectedSite } = this.props;
@@ -362,6 +477,7 @@ class PurchaseNotice extends Component<
 		if ( is100Year( purchase ) && ! isCloseToExpiration( purchase ) ) {
 			return null;
 		}
+
 		let noticeStatus: NoticeStatus = 'is-info';
 
 		if ( isCloseToExpiration( currentPurchase ) && ! isRecentMonthlyPurchase( currentPurchase ) ) {
@@ -1268,6 +1384,13 @@ class PurchaseNotice extends Component<
 			return null;
 		}
 
+		// Transient cancelled success notice — suppresses every other notice
+		// until dismissed, refreshed, or navigated-away-and-back.
+		const cancelledRedirectNotice = this.renderCancelledRedirectNotice();
+		if ( cancelledRedirectNotice ) {
+			return cancelledRedirectNotice;
+		}
+
 		if ( purchase.asyncPendingPaymentBlockIsSet ) {
 			return this.renderAsyncPendingPaymentNotice();
 		}
@@ -1325,6 +1448,10 @@ class PurchaseNotice extends Component<
 	}
 }
 
-export default connect( null, { recordTracksEvent } )(
+const mapStateToProps = ( state: object, ownProps: PurchaseNoticeProps ) => ( {
+	isAtomicSite: isSiteAutomatedTransfer( state, ownProps.purchase?.siteId ?? null ),
+} );
+
+export default connect( mapStateToProps, { recordTracksEvent } )(
 	localize( withLocalizedMoment( PurchaseNotice ) )
 );

--- a/client/me/purchases/manage-purchase/test/notices.js
+++ b/client/me/purchases/manage-purchase/test/notices.js
@@ -5,10 +5,14 @@
 import { render, screen } from '@testing-library/react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { createReduxStore } from 'calypso/state';
+import { setStore } from 'calypso/state/redux-store';
 import PurchaseNotice from '../notices';
 
 describe( 'PurchaseNotice', () => {
 	const store = createReduxStore();
+	// Drains the registerReducer queue into this store so dynamically-registered
+	// reducers (e.g. state.purchases) are present for selectors that read them.
+	setStore( store );
 	const futureYearDate = new Date();
 	futureYearDate.setFullYear( futureYearDate.getFullYear() + 10 );
 	const pastYearDate = new Date();

--- a/client/me/purchases/manage-purchase/test/notices.js
+++ b/client/me/purchases/manage-purchase/test/notices.js
@@ -5,14 +5,10 @@
 import { render, screen } from '@testing-library/react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { createReduxStore } from 'calypso/state';
-import { setStore } from 'calypso/state/redux-store';
 import PurchaseNotice from '../notices';
 
 describe( 'PurchaseNotice', () => {
 	const store = createReduxStore();
-	// Drains the registerReducer queue into this store so dynamically-registered
-	// reducers (e.g. state.purchases) are present for selectors that read them.
-	setStore( store );
 	const futureYearDate = new Date();
 	futureYearDate.setFullYear( futureYearDate.getFullYear() + 10 );
 	const pastYearDate = new Date();


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/RSM-474

## Proposed Changes

This adds a dismissible success notice that's shown when the cancel flow redirects back to Purchase Settings. It also tightens how Purchase Settings renders once a purchase is expired. Both surfaces (dashboard + calypso) are updated.

These changes were split off of https://github.com/Automattic/wp-calypso/pull/110163 and refactored slightly to make them easier to review.

* New `PurchaseCancelledNotice` component on the dashboard, displayed when Purchase Settings is loaded with `?cancelled=true` in the URL. Dismissible; clears on refresh. Atomic sites get a "Download a backup" primary action linking to `/wp-admin/export.php`.
* Legacy mirror in `client/me/purchases/manage-purchase/notices.tsx`: new `renderCancelledRedirectNotice` that reads the same query param, suppresses other notices while visible, and surfaces the Atomic download-backup action via `isSiteAutomatedTransfer`.
* Dashboard Purchase Settings: when a purchase is expired, show a "Removed" status card in place of the expiry/renewal card, render the price card in a simplified form, and hide the Actions section entirely.

## Why are these changes being made?

After a user successfully cancels or removes a purchase they stay on the current page today, which leaves the expiring/renewal notice visible and doesn't confirm the action took effect. The transient notice tied to `?cancelled=true` lets the downstream mutation-timing work redirect the user back to a page that's both correct (reflects the cancelled state) and informative (one-shot success message).

The Atomic-specific "Download a backup" action is intentional: on Atomic sites the user's themes/plugins/uploads are on the server being deprovisioned, so the cancel screen is our last chance to surface the export tool before access lapses.

The expired-state polish on the dashboard Purchase Settings page addresses the adjacent case where a user lands on the page after expiry (via deep-link, back button, or notification) — showing "Removed" as a status card communicates state more clearly than a stale expiry date, and hiding Actions prevents confusing buttons for options that no longer apply.

None of this fires on trunk today — no flow currently redirects with `?cancelled=true`. That redirect is added by the follow-up mutation-timing PR. This PR sets up the reception side so that change can stay narrow.

## Testing Instructions

TC:
```
yarn test-client client/me/purchases/manage-purchase/test/notices.js client/dashboard/me/billing-purchases/purchase-settings
```

Manual testing:
* **Transient notice (dashboard):** append \`?cancelled=true\` to a Purchase Settings URL (\`/me/billing/purchases/:purchaseId?cancelled=true\`). Confirm the notice renders, is dismissible, and does not persist across a page refresh. On an Atomic site, confirm the "Download a backup" action appears in the notice.
* **Transient notice (legacy):** same URL pattern on the Classic Purchase Settings page. Confirm the cancelled-redirect notice suppresses any other notice that would otherwise show.
* **Expired-state polish:** navigate to Purchase Settings for an already-expired purchase on the dashboard. Confirm the "Removed" status card appears, the price card renders simplified, and the Actions section is hidden.
