### PR TITLE
Cancel survey: intent-aware button copy + next-adventure test coverage

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/domain-cancellation-survey.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/domain-cancellation-survey.tsx
@@ -177,7 +177,7 @@ const DomainCancellationSurvey: React.FC< Props > = ( {
 							disabled={ cancellationInProgress }
 							onClick={ handleSubmit }
 						>
-							{ translate( 'Skip and remove' ) }
+							{ isRemoveIntent ? translate( 'Skip and remove' ) : translate( 'Skip and cancel' ) }
 						</Button>
 					) }
 				</div>

--- a/client/components/marketing-survey/cancel-purchase-form/domain-cancellation-survey.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/domain-cancellation-survey.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { TRANSFER_DOMAIN_REGISTRATION, UPDATE_NAMESERVERS } from '@automattic/urls';
 import { Button, SelectControl, TextareaControl } from '@wordpress/components';
@@ -23,6 +24,7 @@ interface Props {
 	purchase: Purchase;
 	purchaseListUrl: string;
 	isVisible: boolean;
+	intent?: 'cancel' | 'remove' | null;
 	onClose: () => void;
 	onSurveyComplete: () => void;
 	cancellationInProgress?: boolean;
@@ -41,6 +43,7 @@ interface DomainCancellationReason {
 const DomainCancellationSurvey: React.FC< Props > = ( {
 	isVisible = false,
 	purchase,
+	intent,
 	...props
 } ) => {
 	const translate = useTranslate();
@@ -139,18 +142,44 @@ const DomainCancellationSurvey: React.FC< Props > = ( {
 	const renderButtons = () => {
 		const { disableButtons, cancellationInProgress } = props;
 		const disabled = disableButtons || ! selectedReason;
+		const isSplitEnabled = config.isEnabled( 'purchases/split-cancel-remove' );
+		const isRemoveIntent = intent === 'remove';
+		const getCompleteLabel = () => {
+			if ( ! isSplitEnabled ) {
+				return translate( 'Submit' );
+			}
+			return isRemoveIntent
+				? translate( 'Complete removal' )
+				: translate( 'Complete cancellation' );
+		};
+		const getCompletingLabel = () =>
+			isRemoveIntent ? translate( 'Completing removal' ) : translate( 'Completing cancellation' );
+		const primaryLabel =
+			isSplitEnabled && cancellationInProgress ? getCompletingLabel() : getCompleteLabel();
 
 		return (
 			<div className="cancel-purchase-form__actions">
 				<div className="cancel-purchase-form__buttons">
 					<Button
 						variant="primary"
+						isDestructive={ isSplitEnabled }
 						isBusy={ cancellationInProgress }
 						disabled={ disabled }
 						onClick={ handleSubmit }
 					>
-						{ translate( 'Submit' ) }
+						{ primaryLabel }
 					</Button>
+					{ isSplitEnabled && disabled && (
+						<Button
+							variant="tertiary"
+							isDestructive
+							isBusy={ cancellationInProgress }
+							disabled={ cancellationInProgress }
+							onClick={ handleSubmit }
+						>
+							{ translate( 'Skip and remove' ) }
+						</Button>
+					) }
 				</div>
 			</div>
 		);

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -465,9 +465,12 @@ class CancelPurchaseForm extends Component {
 		}
 
 		if ( surveyStep === NEXT_ADVENTURE_STEP ) {
+			const allSteps = this.getAllSurveySteps();
 			return (
 				<NextAdventureStep
 					isPlan={ isPlan( purchase ) }
+					isOnlyStep={ allSteps.length === 1 }
+					intent={ intent }
 					adventureOptions={ this.state.questionTwoOrder }
 					onSelectNextAdventure={ this.onRadioTwoChange }
 					onChangeNextAdventureDetails={ this.onTextTwoChange }

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/next-adventure-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/next-adventure-step.tsx
@@ -19,8 +19,8 @@ interface Props {
 export default function NextAdventureStep( props: Props ) {
 	const translate = useTranslate();
 	const { isPlan, isOnlyStep, intent, onValidationChange } = props;
-	const isCancelPostMutation =
-		config.isEnabled( 'purchases/split-cancel-remove' ) && intent !== 'remove';
+	const isSplitEnabled = config.isEnabled( 'purchases/split-cancel-remove' );
+	const isCancelPostMutation = isSplitEnabled && intent !== 'remove';
 	const [ text, setText ] = useState( '' );
 	const [ nextAdventure, setNextAdventure ] = useState( '' );
 	const [ nextAdventureDetails, setNextAdventureDetails ] = useState( '' );
@@ -87,20 +87,27 @@ export default function NextAdventureStep( props: Props ) {
 	}, [ nextAdventure, isPlan, onValidationChange ] );
 
 	let headerText;
-	if ( isOnlyStep ) {
+	let subHeaderText;
+	if ( ! isSplitEnabled ) {
+		headerText = translate( 'Sorry to see you go' );
+		subHeaderText = translate( 'One last thing', {
+			context: 'This is the last step before cancelling the plan.',
+		} );
+	} else if ( isOnlyStep ) {
 		headerText = isCancelPostMutation
-			? translate( 'Cancelation confirmed' )
+			? translate( 'Cancellation confirmed' )
 			: translate( 'Share your feedback' );
+		subHeaderText = translate(
+			'Before you go, please answer a quick question to help us improve WordPress.com.'
+		);
 	} else {
 		headerText = isCancelPostMutation
 			? translate( 'Thanks for your feedback' )
 			: translate( 'One last thing', {
 					context: 'This is the last step before cancelling the plan.',
 			  } );
+		subHeaderText = undefined;
 	}
-	const subHeaderText = isOnlyStep
-		? translate( 'Before you go, please answer a quick question to help us improve WordPress.com.' )
-		: undefined;
 
 	return (
 		<div className="cancel-purchase-form__feedback">

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/next-adventure-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/next-adventure-step.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { TextareaControl, TextControl, SelectControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
@@ -6,7 +7,9 @@ import { toSelectOption } from '../to-select-options';
 
 interface Props {
 	isPlan: boolean;
+	isOnlyStep?: boolean;
 	adventureOptions: string[];
+	intent?: 'cancel' | 'remove';
 	onChangeText?: ( text: string ) => void;
 	onSelectNextAdventure?: ( nextAdventure: string ) => void;
 	onChangeNextAdventureDetails?: ( details: string ) => void;
@@ -15,7 +18,9 @@ interface Props {
 
 export default function NextAdventureStep( props: Props ) {
 	const translate = useTranslate();
-	const { isPlan, onValidationChange } = props;
+	const { isPlan, isOnlyStep, intent, onValidationChange } = props;
+	const isCancelPostMutation =
+		config.isEnabled( 'purchases/split-cancel-remove' ) && intent !== 'remove';
 	const [ text, setText ] = useState( '' );
 	const [ nextAdventure, setNextAdventure ] = useState( '' );
 	const [ nextAdventureDetails, setNextAdventureDetails ] = useState( '' );
@@ -81,15 +86,25 @@ export default function NextAdventureStep( props: Props ) {
 		}
 	}, [ nextAdventure, isPlan, onValidationChange ] );
 
+	let headerText;
+	if ( isOnlyStep ) {
+		headerText = isCancelPostMutation
+			? translate( 'Cancelation confirmed' )
+			: translate( 'Share your feedback' );
+	} else {
+		headerText = isCancelPostMutation
+			? translate( 'Thanks for your feedback' )
+			: translate( 'One last thing', {
+					context: 'This is the last step before cancelling the plan.',
+			  } );
+	}
+	const subHeaderText = isOnlyStep
+		? translate( 'Before you go, please answer a quick question to help us improve WordPress.com.' )
+		: undefined;
+
 	return (
 		<div className="cancel-purchase-form__feedback">
-			<FormattedHeader
-				brandFont
-				headerText={ translate( 'Sorry to see you go' ) }
-				subHeaderText={ translate( 'One last thing', {
-					context: 'This is the last step before cancelling the plan.',
-				} ) }
-			/>
+			<FormattedHeader brandFont headerText={ headerText } subHeaderText={ subHeaderText } />
 			<div className="cancel-purchase-form__feedback-questions">
 				<div className="cancel-purchase-form__feedback-question">
 					<TextareaControl

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/test/next-adventure-step.test.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/test/next-adventure-step.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ */
+import config from '@automattic/calypso-config';
+import { render, screen } from '@testing-library/react';
+import NextAdventureStep from '../next-adventure-step';
+
+jest.mock( '@automattic/calypso-config', () => {
+	const isEnabled = jest.fn();
+	return { __esModule: true, default: { isEnabled }, isEnabled };
+} );
+
+const SUBTITLE = 'Before you go, please answer a quick question to help us improve WordPress.com.';
+
+describe( 'NextAdventureStep', () => {
+	beforeEach( () => {
+		( config.isEnabled as jest.Mock ).mockReturnValue( true );
+	} );
+
+	it( 'shows "Cancelation confirmed" title with subtitle when isOnlyStep and cancel intent', () => {
+		render(
+			<NextAdventureStep isPlan={ false } isOnlyStep adventureOptions={ [] } intent="cancel" />
+		);
+		expect( screen.getByRole( 'heading', { name: /Cancelation confirmed/ } ) ).toBeVisible();
+		expect( screen.getByText( SUBTITLE ) ).toBeVisible();
+	} );
+
+	it( 'shows "Share your feedback" title with subtitle when isOnlyStep and remove intent', () => {
+		render(
+			<NextAdventureStep isPlan={ false } isOnlyStep adventureOptions={ [] } intent="remove" />
+		);
+		expect( screen.getByRole( 'heading', { name: /Share your feedback/ } ) ).toBeVisible();
+		expect( screen.getByText( SUBTITLE ) ).toBeVisible();
+	} );
+
+	it( 'shows "Thanks for your feedback" title without subtitle in multi-step cancel flow', () => {
+		render(
+			<NextAdventureStep
+				isPlan={ false }
+				isOnlyStep={ false } // must be explicit to override default undefined
+				adventureOptions={ [] }
+				intent="cancel"
+			/>
+		);
+		expect( screen.getByRole( 'heading', { name: /Thanks for your feedback/ } ) ).toBeVisible();
+		expect( screen.queryByText( SUBTITLE ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows "One last thing" title without subtitle in multi-step remove flow', () => {
+		render(
+			<NextAdventureStep
+				isPlan={ false }
+				isOnlyStep={ false } // must be explicit to override default undefined
+				adventureOptions={ [] }
+				intent="remove"
+			/>
+		);
+		expect( screen.getByRole( 'heading', { name: /One last thing/ } ) ).toBeVisible();
+		expect( screen.queryByText( SUBTITLE ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/test/next-adventure-step.test.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/test/next-adventure-step.test.tsx
@@ -13,49 +13,64 @@ jest.mock( '@automattic/calypso-config', () => {
 const SUBTITLE = 'Before you go, please answer a quick question to help us improve WordPress.com.';
 
 describe( 'NextAdventureStep', () => {
-	beforeEach( () => {
-		( config.isEnabled as jest.Mock ).mockReturnValue( true );
+	describe( 'with purchases/split-cancel-remove enabled', () => {
+		beforeEach( () => {
+			( config.isEnabled as jest.Mock ).mockReturnValue( true );
+		} );
+
+		it( 'shows "Cancellation confirmed" title with subtitle when isOnlyStep and cancel intent', () => {
+			render(
+				<NextAdventureStep isPlan={ false } isOnlyStep adventureOptions={ [] } intent="cancel" />
+			);
+			expect( screen.getByRole( 'heading', { name: /Cancellation confirmed/ } ) ).toBeVisible();
+			expect( screen.getByText( SUBTITLE ) ).toBeVisible();
+		} );
+
+		it( 'shows "Share your feedback" title with subtitle when isOnlyStep and remove intent', () => {
+			render(
+				<NextAdventureStep isPlan={ false } isOnlyStep adventureOptions={ [] } intent="remove" />
+			);
+			expect( screen.getByRole( 'heading', { name: /Share your feedback/ } ) ).toBeVisible();
+			expect( screen.getByText( SUBTITLE ) ).toBeVisible();
+		} );
+
+		it( 'shows "Thanks for your feedback" title without subtitle in multi-step cancel flow', () => {
+			render(
+				<NextAdventureStep
+					isPlan={ false }
+					isOnlyStep={ false }
+					adventureOptions={ [] }
+					intent="cancel"
+				/>
+			);
+			expect( screen.getByRole( 'heading', { name: /Thanks for your feedback/ } ) ).toBeVisible();
+			expect( screen.queryByText( SUBTITLE ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'shows "One last thing" title without subtitle in multi-step remove flow', () => {
+			render(
+				<NextAdventureStep
+					isPlan={ false }
+					isOnlyStep={ false }
+					adventureOptions={ [] }
+					intent="remove"
+				/>
+			);
+			expect( screen.getByRole( 'heading', { name: /One last thing/ } ) ).toBeVisible();
+			expect( screen.queryByText( SUBTITLE ) ).not.toBeInTheDocument();
+		} );
 	} );
 
-	it( 'shows "Cancelation confirmed" title with subtitle when isOnlyStep and cancel intent', () => {
-		render(
-			<NextAdventureStep isPlan={ false } isOnlyStep adventureOptions={ [] } intent="cancel" />
-		);
-		expect( screen.getByRole( 'heading', { name: /Cancelation confirmed/ } ) ).toBeVisible();
-		expect( screen.getByText( SUBTITLE ) ).toBeVisible();
-	} );
+	describe( 'with purchases/split-cancel-remove disabled', () => {
+		beforeEach( () => {
+			( config.isEnabled as jest.Mock ).mockReturnValue( false );
+		} );
 
-	it( 'shows "Share your feedback" title with subtitle when isOnlyStep and remove intent', () => {
-		render(
-			<NextAdventureStep isPlan={ false } isOnlyStep adventureOptions={ [] } intent="remove" />
-		);
-		expect( screen.getByRole( 'heading', { name: /Share your feedback/ } ) ).toBeVisible();
-		expect( screen.getByText( SUBTITLE ) ).toBeVisible();
-	} );
-
-	it( 'shows "Thanks for your feedback" title without subtitle in multi-step cancel flow', () => {
-		render(
-			<NextAdventureStep
-				isPlan={ false }
-				isOnlyStep={ false } // must be explicit to override default undefined
-				adventureOptions={ [] }
-				intent="cancel"
-			/>
-		);
-		expect( screen.getByRole( 'heading', { name: /Thanks for your feedback/ } ) ).toBeVisible();
-		expect( screen.queryByText( SUBTITLE ) ).not.toBeInTheDocument();
-	} );
-
-	it( 'shows "One last thing" title without subtitle in multi-step remove flow', () => {
-		render(
-			<NextAdventureStep
-				isPlan={ false }
-				isOnlyStep={ false } // must be explicit to override default undefined
-				adventureOptions={ [] }
-				intent="remove"
-			/>
-		);
-		expect( screen.getByRole( 'heading', { name: /One last thing/ } ) ).toBeVisible();
-		expect( screen.queryByText( SUBTITLE ) ).not.toBeInTheDocument();
+		it( 'renders the trunk header regardless of intent or isOnlyStep', () => {
+			render( <NextAdventureStep isPlan={ false } adventureOptions={ [] } /> );
+			expect( screen.getByRole( 'heading', { name: /Sorry to see you go/ } ) ).toBeVisible();
+			expect( screen.getByText( /One last thing/ ) ).toBeVisible();
+			expect( screen.queryByText( SUBTITLE ) ).not.toBeInTheDocument();
+		} );
 	} );
 } );

--- a/client/me/purchases/cancel-purchase/button.tsx
+++ b/client/me/purchases/cancel-purchase/button.tsx
@@ -241,6 +241,7 @@ class CancelPurchaseButton extends Component<
 						onClose={ this.closeDialog }
 						onSurveyComplete={ this.props.onSurveyComplete }
 						cancellationInProgress={ isLoading }
+						intent={ this.props.displayVariant === 'remove' ? 'remove' : 'cancel' }
 					/>
 				) }
 


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/RSM-474

## Proposed Changes

This makes the shared cancel-purchase survey respect the `?intent=cancel` vs `?intent=remove` URL parameter by swapping button labels to the correct verb. It also adds a test file for the `next-adventure` survey step.

These changes were split off of https://github.com/Automattic/wp-calypso/pull/110163 and refactored slightly to make them easier to review.

* `domain-cancellation-survey.tsx`: primary button label toggles between "Complete cancellation" and "Complete removal" based on intent; in-flight state shows "Completing cancellation" / "Completing removal"; button is marked destructive under the split flag; a tertiary "Skip and remove" action surfaces when the user hasn't picked a reason (remove intent only).
* `next-adventure-step.tsx`: intent-aware copy for the step heading and description, plus a new unit test covering the render variants.
* `cancellation-main-content.tsx` / `cancellation-pre-survey-content.tsx`: thread the `intent` prop through so the upstream cancel survey receives it.

## Why are these changes being made?

The survey is shared between the Cancel and Remove flows, but its button copy was written for Cancel only — "Submit", "Cancel my current plan", etc. When a user enters the Remove variant of the flow the Cancel-framed copy creates friction: "Submit" doesn't confirm what action is about to happen, and the decline button ("Cancel my current plan") is actively wrong for a Remove user who arrived to remove, not cancel.

Intent is already plumbed through the outer cancel-purchase component (from the split-cancel-remove work in #110094); this PR extends the same prop to the survey step components so they can render the correct verb. The additions are additive — under flag-off nothing changes, and under flag-on Cancel users see Cancel-framed copy while Remove users see Remove-framed copy.

The new \`next-adventure-step\` test fills a gap: that step was previously uncovered, and its rendering branches on both \`isOnlyStep\` and \`intent\`, so the permutations deserve explicit test cases.

## Testing Instructions

TC:
```
yarn test-client client/components/marketing-survey/cancel-purchase-form
```

Manual testing:
* Under the \`purchases/split-cancel-remove\` flag, start a cancel flow via Purchase Settings → Cancel. On the survey step, confirm the primary button reads "Complete cancellation" and the decline button reads "Cancel my current plan".
* Start a remove flow via Purchase Settings → Remove. Confirm the primary button reads "Complete removal" and the tertiary "Skip and remove" option appears when no reason is selected.
* With the flag off: no copy changes should be visible; the survey should render identically to trunk.