### PR TITLE
Onboarding: fix post-checkout-onboarding flow getting stuck on loading page

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -46,7 +46,7 @@ function initialize() {
 		STEPS.SETUP_YOUR_SITE_AI,
 	];
 
-	return [ ...stepsWithRequiredLogin( steps ), STEPS.PLAYGROUND, STEPS.BLUEPRINT ];
+	return [ ...stepsWithRequiredLogin( steps ), STEPS.PLAYGROUND, STEPS.BLUEPRINT, STEPS.ERROR ];
 }
 
 const onboarding: FlowV2< typeof initialize > = {
@@ -304,8 +304,7 @@ const onboarding: FlowV2< typeof initialize > = {
 							window.location.replace( destination );
 						}
 					} else {
-						// TODO: Handle errors
-						// navigate( 'error' );
+						return navigate( 'error' as typeof currentStepSlug );
 					}
 					return;
 				}

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -78,6 +78,7 @@ const onboarding: FlowV2< typeof initialize > = {
 		);
 		const coupon = useQuery().get( 'coupon' );
 		const refParameter = useQuery().get( 'ref' );
+		const siteSlugParam = useQuery().get( 'siteSlug' );
 
 		const { setShouldShowNotification } = usePurchasePlanNotification();
 
@@ -237,6 +238,23 @@ const onboarding: FlowV2< typeof initialize > = {
 					}
 				}
 				case 'processing': {
+					if (
+						providedDependencies.processingResult === ProcessingResult.NO_ACTION &&
+						siteSlugParam
+					) {
+						// No pending action — the user landed on this page directly without
+						// completing the prior step (e.g. a direct URL load or page refresh).
+						// Redirect back to post-checkout-onboarding so it can set up the
+						// pending action and advance the flow normally.
+						window.location.replace(
+							addQueryArgs( withLocale( '/setup/onboarding/post-checkout-onboarding', locale ), {
+								siteSlug: siteSlugParam,
+								...( refParameter ? { ref: refParameter } : {} ),
+							} )
+						);
+						return;
+					}
+
 					const [ destination, backDestination ] = await getPostCheckoutDestination(
 						providedDependencies,
 						planCartItem

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
@@ -9,13 +9,13 @@ import {
 } from '@automattic/calypso-products';
 import { SiteIntent } from '@automattic/data-stores/src/onboard';
 import { Step } from '@automattic/onboarding';
-import { useQuery as useTanstackQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect } from 'react';
 import Loading from 'calypso/components/loading';
 import { WOO_HOSTING_SOLUTIONS_REF } from 'calypso/landing/stepper/constants';
-import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { useQuery as useUrlParams } from 'calypso/landing/stepper/hooks/use-query';
 import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import { waitForPluginsActive } from 'calypso/landing/stepper/utils/wait-for-plugins-active';
 import { useExperiment } from 'calypso/lib/explat';
@@ -56,7 +56,7 @@ const PostCheckoutOnboarding: StepType< {
 		data: site,
 		isLoading: isLoadingSite,
 		isError: isErrorSite,
-	} = useTanstackQuery( {
+	} = useQuery( {
 		...siteBySlugQuery( siteSlug ),
 		enabled: !! siteSlug,
 	} );
@@ -122,7 +122,7 @@ const PostCheckoutOnboarding: StepType< {
 	const goalPlugin = usePluginByGoal();
 	const hasPluginByGoal = !! goalPlugin;
 
-	const refParameter = useQuery().get( 'ref' );
+	const refParameter = useUrlParams().get( 'ref' );
 	const isWooHostingSolutions = refParameter === WOO_HOSTING_SOLUTIONS_REF;
 
 	// Prefer the cart item (what the user just bought — freshest signal during

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
@@ -1,3 +1,4 @@
+import { siteBySlugQuery } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
 import {
 	FEATURE_BIG_SKY,
@@ -8,6 +9,7 @@ import {
 } from '@automattic/calypso-products';
 import { SiteIntent } from '@automattic/data-stores/src/onboard';
 import { Step } from '@automattic/onboarding';
+import { useQuery as useTanstackQuery } from '@tanstack/react-query';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect } from 'react';
@@ -18,12 +20,12 @@ import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import { waitForPluginsActive } from 'calypso/landing/stepper/utils/wait-for-plugins-active';
 import { useExperiment } from 'calypso/lib/explat';
 import { useMarketplaceThemeProducts } from '../../../../hooks/use-marketplace-theme-products';
-import { useSiteData } from '../../../../hooks/use-site-data';
+import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
 import { useSiteTransferStatusQuery } from '../../../../hooks/use-site-transfer/query';
 import { useWaitForAtomic } from '../../../../hooks/use-wait-for-atomic';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import type { Step as StepType } from '../../types';
-import type { OnboardSelect, SiteSelect } from '@automattic/data-stores';
+import type { OnboardSelect } from '@automattic/data-stores';
 
 const usePluginByGoal = () => {
 	const intent = useSelect(
@@ -48,7 +50,16 @@ const PostCheckoutOnboarding: StepType< {
 	const { __ } = useI18n();
 	const { submit } = navigation;
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
-	const { site, siteSlug } = useSiteData();
+
+	const siteSlug = useSiteSlugParam() ?? '';
+	const {
+		data: site,
+		isLoading: isLoadingSite,
+		isError: isErrorSite,
+	} = useTanstackQuery( {
+		...siteBySlugQuery( siteSlug ),
+		enabled: !! siteSlug,
+	} );
 
 	const eligibleForExperiment =
 		isEnabled( 'onboarding/post-checkout-ai-step' ) &&
@@ -80,7 +91,7 @@ const PostCheckoutOnboarding: StepType< {
 		[]
 	);
 
-	const isJetpackOrAtomic = !! site?.jetpack || !! site?.options?.is_wpcom_atomic;
+	const isJetpackOrAtomic = !! site?.jetpack || !! site?.is_wpcom_atomic;
 
 	const {
 		isLoading: isLoadingMarketplaceThemeProducts,
@@ -94,11 +105,6 @@ const PostCheckoutOnboarding: StepType< {
 		isLoading: isLoadingSiteTransferStatusData,
 		isError: isErrorSiteTransferStatus,
 	} = useSiteTransferStatusQuery( site?.ID );
-
-	const fetchingSiteError = useSelect(
-		( select ) => ( select( SITE_STORE ) as SiteSelect ).getFetchingSiteError(),
-		[]
-	);
 
 	const { waitForInitiateTransfer, waitForTransfer, waitForFeature, waitForLatestSiteData } =
 		useWaitForAtomic( {} );
@@ -141,7 +147,7 @@ const PostCheckoutOnboarding: StepType< {
 	 * - Verify that the site is atomic, as the theme should be installed on the user's site.
 	 *
 	 * The atomic transfer will be initiated immediately after the user purchases an externally managed theme.
-	 * If it’s not initiated, we need to trigger the atomic transfer manually.
+	 * If it's not initiated, we need to trigger the atomic transfer manually.
 	 *
 	 * Note that an externally managed theme is only available when both of the following conditions are met:
 	 * - The site must be subscribed to the theme.
@@ -152,14 +158,14 @@ const PostCheckoutOnboarding: StepType< {
 		isMarketplaceThemeSubscribed &&
 		isExternallyManagedThemeAvailable;
 
-	const hasError =
-		!! fetchingSiteError?.error || isErrorMarketplaceThemeProducts || isErrorSiteTransferStatus;
+	const hasError = isErrorSite || isErrorMarketplaceThemeProducts || isErrorSiteTransferStatus;
 
 	useEffect( () => {
 		if (
 			hasError ||
 			! site ||
 			! siteSlug ||
+			isLoadingSite ||
 			isLoadingMarketplaceThemeProducts ||
 			isLoadingSiteTransferStatusData ||
 			isLoadingExperiment
@@ -209,6 +215,7 @@ const PostCheckoutOnboarding: StepType< {
 		hasError,
 		site,
 		siteSlug,
+		isLoadingSite,
 		isLoadingMarketplaceThemeProducts,
 		isLoadingSiteTransferStatusData,
 		isLoadingExperiment,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
@@ -9,6 +9,7 @@ import {
 import { SiteIntent } from '@automattic/data-stores/src/onboard';
 import { Step } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { useI18n } from '@wordpress/react-i18n';
 import { useEffect } from 'react';
 import Loading from 'calypso/components/loading';
 import { WOO_HOSTING_SOLUTIONS_REF } from 'calypso/landing/stepper/constants';
@@ -22,7 +23,7 @@ import { useSiteTransferStatusQuery } from '../../../../hooks/use-site-transfer/
 import { useWaitForAtomic } from '../../../../hooks/use-wait-for-atomic';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import type { Step as StepType } from '../../types';
-import type { OnboardSelect } from '@automattic/data-stores';
+import type { OnboardSelect, SiteSelect } from '@automattic/data-stores';
 
 const usePluginByGoal = () => {
 	const intent = useSelect(
@@ -44,6 +45,7 @@ const PostCheckoutOnboarding: StepType< {
 		postCheckoutBigSky?: boolean;
 	};
 } > = ( { flow, navigation } ) => {
+	const { __ } = useI18n();
 	const { submit } = navigation;
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 	const { site, siteSlug } = useSiteData();
@@ -82,12 +84,21 @@ const PostCheckoutOnboarding: StepType< {
 
 	const {
 		isLoading: isLoadingMarketplaceThemeProducts,
+		isError: isErrorMarketplaceThemeProducts,
 		isMarketplaceThemeSubscribed,
 		isExternallyManagedThemeAvailable,
 	} = useMarketplaceThemeProducts();
 
-	const { data: siteTransferStatusData, isLoading: isLoadingSiteTransferStatusData } =
-		useSiteTransferStatusQuery( site?.ID );
+	const {
+		data: siteTransferStatusData,
+		isLoading: isLoadingSiteTransferStatusData,
+		isError: isErrorSiteTransferStatus,
+	} = useSiteTransferStatusQuery( site?.ID );
+
+	const fetchingSiteError = useSelect(
+		( select ) => ( select( SITE_STORE ) as SiteSelect ).getFetchingSiteError(),
+		[]
+	);
 
 	const { waitForInitiateTransfer, waitForTransfer, waitForFeature, waitForLatestSiteData } =
 		useWaitForAtomic( {} );
@@ -141,8 +152,12 @@ const PostCheckoutOnboarding: StepType< {
 		isMarketplaceThemeSubscribed &&
 		isExternallyManagedThemeAvailable;
 
+	const hasError =
+		!! fetchingSiteError?.error || isErrorMarketplaceThemeProducts || isErrorSiteTransferStatus;
+
 	useEffect( () => {
 		if (
+			hasError ||
 			! site ||
 			! siteSlug ||
 			isLoadingMarketplaceThemeProducts ||
@@ -191,6 +206,7 @@ const PostCheckoutOnboarding: StepType< {
 			siteSlug,
 		} );
 	}, [
+		hasError,
 		site,
 		siteSlug,
 		isLoadingMarketplaceThemeProducts,
@@ -203,6 +219,27 @@ const PostCheckoutOnboarding: StepType< {
 		isExternallyManagedThemeAvailable,
 		shouldInstallPlugin,
 	] );
+
+	if ( hasError ) {
+		const heading = __( "We've hit a snag" );
+		const body = __(
+			'Something went wrong while setting up your site. Please try refreshing the page, or contact support if the problem persists.'
+		);
+
+		if ( shouldUseStepContainerV2( flow ) ) {
+			return (
+				<Step.CenteredColumnLayout
+					columnWidth={ 8 }
+					topBar={ <Step.TopBar /> }
+					heading={ <Step.Heading text={ heading } /> }
+				>
+					{ body }
+				</Step.CenteredColumnLayout>
+			);
+		}
+
+		return <Loading className="wpcom-loading__boot" title={ heading } subtitle={ body } />;
+	}
 
 	if ( shouldUseStepContainerV2( flow ) ) {
 		return <Step.Loading />;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
@@ -22,7 +22,7 @@ import { useSiteTransferStatusQuery } from '../../../../hooks/use-site-transfer/
 import { useWaitForAtomic } from '../../../../hooks/use-wait-for-atomic';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import type { Step as StepType } from '../../types';
-import type { OnboardSelect, SiteSelect } from '@automattic/data-stores';
+import type { OnboardSelect } from '@automattic/data-stores';
 
 const usePluginByGoal = () => {
 	const intent = useSelect(
@@ -78,17 +78,7 @@ const PostCheckoutOnboarding: StepType< {
 		[]
 	);
 
-	const isJetpack = useSelect(
-		( select ) => site && ( select( SITE_STORE ) as SiteSelect ).isJetpackSite( site.ID ),
-		[ site ]
-	);
-
-	const isAtomic = useSelect(
-		( select ) => site && ( select( SITE_STORE ) as SiteSelect ).isSiteAtomic( site.ID ),
-		[ site ]
-	);
-
-	const isJetpackOrAtomic = isJetpack || isAtomic;
+	const isJetpackOrAtomic = !! site?.jetpack || !! site?.options?.is_wpcom_atomic;
 
 	const {
 		isLoading: isLoadingMarketplaceThemeProducts,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
@@ -98,7 +98,7 @@ const PostCheckoutOnboarding: StepType< {
 		isError: isErrorMarketplaceThemeProducts,
 		isMarketplaceThemeSubscribed,
 		isExternallyManagedThemeAvailable,
-	} = useMarketplaceThemeProducts();
+	} = useMarketplaceThemeProducts( { siteId: site?.ID } );
 
 	const {
 		data: siteTransferStatusData,
@@ -107,7 +107,7 @@ const PostCheckoutOnboarding: StepType< {
 	} = useSiteTransferStatusQuery( site?.ID );
 
 	const { waitForInitiateTransfer, waitForTransfer, waitForFeature, waitForLatestSiteData } =
-		useWaitForAtomic( {} );
+		useWaitForAtomic( { siteId: site?.ID } );
 
 	const { setIntentOnSite, setGoalsOnSite } = useDispatch( SITE_STORE );
 

--- a/client/landing/stepper/hooks/use-marketplace-theme-products.ts
+++ b/client/landing/stepper/hooks/use-marketplace-theme-products.ts
@@ -8,8 +8,15 @@ import { getPreferredBillingCycleProductSlug } from 'calypso/state/themes/theme-
 import { useSiteData } from './use-site-data';
 import type { OnboardSelect } from '@automattic/data-stores';
 
-export const useMarketplaceThemeProducts = () => {
+interface UseMarketplaceThemeProductsProps {
+	siteId?: number;
+}
+
+export const useMarketplaceThemeProducts = ( {
+	siteId: providedSiteId,
+}: UseMarketplaceThemeProductsProps = {} ) => {
 	const { site } = useSiteData();
+	const siteId = providedSiteId ?? site?.ID;
 
 	const selectedDesign = useSelect( ( select ) => {
 		const { getSelectedDesign } = select( ONBOARD_STORE ) as OnboardSelect;
@@ -32,8 +39,8 @@ export const useMarketplaceThemeProducts = () => {
 		isError: isErrorSiteFeatures,
 		data: siteFeatures,
 	} = useQuery( {
-		...siteFeaturesQuery( site?.ID as number ),
-		enabled: !! site?.ID,
+		...siteFeaturesQuery( siteId as number ),
+		enabled: !! siteId,
 	} );
 
 	const {
@@ -41,8 +48,8 @@ export const useMarketplaceThemeProducts = () => {
 		isError: isErrorSitePurchases,
 		data: sitePurchasesData,
 	} = useQuery( {
-		...sitePurchasesQuery( site?.ID as number ),
-		enabled: !! site?.ID,
+		...sitePurchasesQuery( siteId as number ),
+		enabled: !! siteId,
 	} );
 
 	const allProductsList = productsData ? Object.values( productsData ) : [];

--- a/client/landing/stepper/hooks/use-marketplace-theme-products.ts
+++ b/client/landing/stepper/hooks/use-marketplace-theme-products.ts
@@ -1,23 +1,23 @@
+import { FEATURE_WOOP, WPCOM_FEATURES_ATOMIC } from '@automattic/calypso-products';
+import { Purchases, Site } from '@automattic/data-stores';
 import { getThemeIdFromDesign } from '@automattic/design-picker';
+import { useQuery } from '@tanstack/react-query';
 import { useSelect } from '@wordpress/data';
-import { useQueryProductsList } from 'calypso/components/data/query-products-list';
-import { useQuerySiteFeatures } from 'calypso/components/data/query-site-features';
-import { useQuerySitePurchases } from 'calypso/components/data/query-site-purchases';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
-import { useSelector } from 'calypso/state';
-import {
-	getProductBillingSlugByThemeId,
-	getProductsByBillingSlug,
-	isProductsListFetching,
-} from 'calypso/state/products-list/selectors';
-import { isFetchingSitePurchases } from 'calypso/state/purchases/selectors';
-import {
-	isMarketplaceThemeSubscribed as getIsMarketplaceThemeSubscribed,
-	isSiteEligibleForManagedExternalThemes,
-} from 'calypso/state/themes/selectors';
+import wpcom from 'calypso/lib/wp';
 import { getPreferredBillingCycleProductSlug } from 'calypso/state/themes/theme-utils';
 import { useSiteData } from './use-site-data';
 import type { OnboardSelect } from '@automattic/data-stores';
+import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
+
+type ProductsListResponse = Record< string, ProductListItem >;
+
+const useProductsList = () =>
+	useQuery< ProductsListResponse >( {
+		queryKey: [ 'marketplace-products-list' ],
+		queryFn: () => wpcom.req.get( '/products', { type: 'all' } ),
+		staleTime: 5 * 60 * 1000,
+	} );
 
 export const useMarketplaceThemeProducts = () => {
 	const { site } = useSiteData();
@@ -28,21 +28,31 @@ export const useMarketplaceThemeProducts = () => {
 	}, [] );
 
 	const selectedDesignThemeId = selectedDesign ? getThemeIdFromDesign( selectedDesign ) : null;
+	const billingProductSlug = selectedDesignThemeId
+		? `wp-mp-theme-${ selectedDesignThemeId }`
+		: null;
 
-	const isExternallyManagedThemeAvailable = useSelector(
-		( state ) => site?.ID && isSiteEligibleForManagedExternalThemes( state, site.ID )
+	const { isLoading: isLoadingProducts, data: productsData } = useProductsList();
+
+	const { isLoading: isLoadingSiteFeatures, data: siteFeatures } = Site.useSiteFeatures( {
+		siteIdOrSlug: site?.ID,
+	} );
+
+	const { isLoading: isLoadingSitePurchases, data: sitePurchasesData } = Purchases.useSitePurchases(
+		{ siteId: site?.ID }
 	);
 
-	const isLoadingProductList = useSelector( ( state ) => isProductsListFetching( state ) );
-	const isLoadingSitePurchases = useSelector( ( state ) => isFetchingSitePurchases( state ) );
+	const allProductsList = productsData ? Object.values( productsData ) : [];
+	const sitePurchasesList = sitePurchasesData ? Object.values( sitePurchasesData ) : [];
 
-	const marketplaceThemeProducts =
-		useSelector( ( state ) =>
-			getProductsByBillingSlug(
-				state,
-				getProductBillingSlugByThemeId( state, selectedDesignThemeId ?? '' )
-			)
-		) || [];
+	const isExternallyManagedThemeAvailable = !! (
+		siteFeatures?.active?.includes( FEATURE_WOOP ) &&
+		siteFeatures?.active?.includes( WPCOM_FEATURES_ATOMIC )
+	);
+
+	const marketplaceThemeProducts = billingProductSlug
+		? allProductsList.filter( ( p ) => p.billing_product_slug === billingProductSlug )
+		: [];
 
 	const marketplaceProductSlug =
 		marketplaceThemeProducts.length !== 0
@@ -50,15 +60,14 @@ export const useMarketplaceThemeProducts = () => {
 			: null;
 
 	const selectedMarketplaceProduct =
-		marketplaceThemeProducts.find(
-			( product ) => product.product_slug === marketplaceProductSlug
-		) || marketplaceThemeProducts[ 0 ];
+		marketplaceThemeProducts.find( ( p ) => p.product_slug === marketplaceProductSlug ) ??
+		marketplaceThemeProducts[ 0 ];
 
-	const isMarketplaceThemeSubscribed = useSelector(
-		( state ) =>
-			site &&
-			selectedDesignThemeId &&
-			getIsMarketplaceThemeSubscribed( state, selectedDesignThemeId, site.ID )
+	const isMarketplaceThemeSubscribed = !! (
+		marketplaceThemeProducts.length > 0 &&
+		sitePurchasesList.some( ( purchase ) =>
+			marketplaceThemeProducts.some( ( p ) => purchase.productSlug === p.product_slug )
+		)
 	);
 
 	const isMarketplaceThemeSubscriptionNeeded = !! (
@@ -70,12 +79,8 @@ export const useMarketplaceThemeProducts = () => {
 			? [ marketplaceProductSlug ]
 			: [];
 
-	useQueryProductsList();
-	useQuerySiteFeatures( [ site?.ID ] );
-	useQuerySitePurchases( site?.ID ?? -1 );
-
 	return {
-		isLoading: isLoadingProductList || isLoadingSitePurchases,
+		isLoading: isLoadingProducts || isLoadingSiteFeatures || isLoadingSitePurchases,
 		selectedMarketplaceProduct,
 		selectedMarketplaceProductCartItems,
 		isMarketplaceThemeSubscriptionNeeded,

--- a/client/landing/stepper/hooks/use-marketplace-theme-products.ts
+++ b/client/landing/stepper/hooks/use-marketplace-theme-products.ts
@@ -32,15 +32,25 @@ export const useMarketplaceThemeProducts = () => {
 		? `wp-mp-theme-${ selectedDesignThemeId }`
 		: null;
 
-	const { isLoading: isLoadingProducts, data: productsData } = useProductsList();
+	const {
+		isLoading: isLoadingProducts,
+		isError: isErrorProducts,
+		data: productsData,
+	} = useProductsList();
 
-	const { isLoading: isLoadingSiteFeatures, data: siteFeatures } = Site.useSiteFeatures( {
+	const {
+		isLoading: isLoadingSiteFeatures,
+		isError: isErrorSiteFeatures,
+		data: siteFeatures,
+	} = Site.useSiteFeatures( {
 		siteIdOrSlug: site?.ID,
 	} );
 
-	const { isLoading: isLoadingSitePurchases, data: sitePurchasesData } = Purchases.useSitePurchases(
-		{ siteId: site?.ID }
-	);
+	const {
+		isLoading: isLoadingSitePurchases,
+		isError: isErrorSitePurchases,
+		data: sitePurchasesData,
+	} = Purchases.useSitePurchases( { siteId: site?.ID } );
 
 	const allProductsList = productsData ? Object.values( productsData ) : [];
 	const sitePurchasesList = sitePurchasesData ? Object.values( sitePurchasesData ) : [];
@@ -81,6 +91,7 @@ export const useMarketplaceThemeProducts = () => {
 
 	return {
 		isLoading: isLoadingProducts || isLoadingSiteFeatures || isLoadingSitePurchases,
+		isError: isErrorProducts || isErrorSiteFeatures || isErrorSitePurchases,
 		selectedMarketplaceProduct,
 		selectedMarketplaceProductCartItems,
 		isMarketplaceThemeSubscriptionNeeded,

--- a/client/landing/stepper/hooks/use-marketplace-theme-products.ts
+++ b/client/landing/stepper/hooks/use-marketplace-theme-products.ts
@@ -1,5 +1,5 @@
+import { siteFeaturesQuery, sitePurchasesQuery } from '@automattic/api-queries';
 import { FEATURE_WOOP, WPCOM_FEATURES_ATOMIC } from '@automattic/calypso-products';
-import { Purchases, Site } from '@automattic/data-stores';
 import { getThemeIdFromDesign } from '@automattic/design-picker';
 import { useQuery } from '@tanstack/react-query';
 import { useSelect } from '@wordpress/data';
@@ -42,18 +42,22 @@ export const useMarketplaceThemeProducts = () => {
 		isLoading: isLoadingSiteFeatures,
 		isError: isErrorSiteFeatures,
 		data: siteFeatures,
-	} = Site.useSiteFeatures( {
-		siteIdOrSlug: site?.ID,
+	} = useQuery( {
+		...siteFeaturesQuery( site?.ID as number ),
+		enabled: !! site?.ID,
 	} );
 
 	const {
 		isLoading: isLoadingSitePurchases,
 		isError: isErrorSitePurchases,
 		data: sitePurchasesData,
-	} = Purchases.useSitePurchases( { siteId: site?.ID } );
+	} = useQuery( {
+		...sitePurchasesQuery( site?.ID as number ),
+		enabled: !! site?.ID,
+	} );
 
 	const allProductsList = productsData ? Object.values( productsData ) : [];
-	const sitePurchasesList = sitePurchasesData ? Object.values( sitePurchasesData ) : [];
+	const sitePurchasesList = sitePurchasesData ?? [];
 
 	const isExternallyManagedThemeAvailable = !! (
 		siteFeatures?.active?.includes( FEATURE_WOOP ) &&
@@ -76,7 +80,7 @@ export const useMarketplaceThemeProducts = () => {
 	const isMarketplaceThemeSubscribed = !! (
 		marketplaceThemeProducts.length > 0 &&
 		sitePurchasesList.some( ( purchase ) =>
-			marketplaceThemeProducts.some( ( p ) => purchase.productSlug === p.product_slug )
+			marketplaceThemeProducts.some( ( p ) => purchase.product_slug === p.product_slug )
 		)
 	);
 

--- a/client/landing/stepper/hooks/use-marketplace-theme-products.ts
+++ b/client/landing/stepper/hooks/use-marketplace-theme-products.ts
@@ -1,23 +1,12 @@
-import { siteFeaturesQuery, sitePurchasesQuery } from '@automattic/api-queries';
+import { productsQuery, siteFeaturesQuery, sitePurchasesQuery } from '@automattic/api-queries';
 import { FEATURE_WOOP, WPCOM_FEATURES_ATOMIC } from '@automattic/calypso-products';
 import { getThemeIdFromDesign } from '@automattic/design-picker';
 import { useQuery } from '@tanstack/react-query';
 import { useSelect } from '@wordpress/data';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
-import wpcom from 'calypso/lib/wp';
 import { getPreferredBillingCycleProductSlug } from 'calypso/state/themes/theme-utils';
 import { useSiteData } from './use-site-data';
 import type { OnboardSelect } from '@automattic/data-stores';
-import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
-
-type ProductsListResponse = Record< string, ProductListItem >;
-
-const useProductsList = () =>
-	useQuery< ProductsListResponse >( {
-		queryKey: [ 'marketplace-products-list' ],
-		queryFn: () => wpcom.req.get( '/products', { type: 'all' } ),
-		staleTime: 5 * 60 * 1000,
-	} );
 
 export const useMarketplaceThemeProducts = () => {
 	const { site } = useSiteData();
@@ -36,7 +25,7 @@ export const useMarketplaceThemeProducts = () => {
 		isLoading: isLoadingProducts,
 		isError: isErrorProducts,
 		data: productsData,
-	} = useProductsList();
+	} = useQuery( productsQuery( 'all' ) );
 
 	const {
 		isLoading: isLoadingSiteFeatures,

--- a/client/state/products-list/selectors/get-products-list.ts
+++ b/client/state/products-list/selectors/get-products-list.ts
@@ -28,7 +28,8 @@ export interface ProductListItem {
 	introductory_offer?: ProductIntroductoryOffer;
 	price_tier_list: PriceTierEntry[];
 	price_tier_usage_quantity: null | number;
-	price_tier_slug: string;
+	/** @deprecated use price_tier_usage_quantity instead */
+	price_tier_slug?: string;
 	sale_coupon?: {
 		discount?: number;
 		allowed_for_domain_transfers?: boolean;

--- a/client/state/themes/theme-utils.ts
+++ b/client/state/themes/theme-utils.ts
@@ -1,6 +1,10 @@
 import { isWpComMonthlyPlan } from '@automattic/calypso-products';
 import { SitePlanData } from 'calypso/my-sites/checkout/src/hooks/product-variants';
-import { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
+
+interface ProductWithBillingCycle {
+	product_slug: string;
+	product_term?: string;
+}
 
 /**
  * Get the preferred product slug from the products list.
@@ -8,7 +12,7 @@ import { ProductListItem } from 'calypso/state/products-list/selectors/get-produ
  * @returns string
  */
 export function getPreferredBillingCycleProductSlug(
-	products: Array< ProductListItem >,
+	products: Array< ProductWithBillingCycle >,
 	currentPlan?: SitePlanData | any
 ): string {
 	if ( products.length === 0 ) {

--- a/client/state/themes/theme-utils.ts
+++ b/client/state/themes/theme-utils.ts
@@ -1,26 +1,20 @@
 import { isWpComMonthlyPlan } from '@automattic/calypso-products';
-import { SitePlanData } from 'calypso/my-sites/checkout/src/hooks/product-variants';
 
 interface ProductWithBillingCycle {
 	product_slug: string;
 	product_term?: string;
 }
 
-/**
- * Get the preferred product slug from the products list.
- * @param products list of products
- * @returns string
- */
 export function getPreferredBillingCycleProductSlug(
 	products: Array< ProductWithBillingCycle >,
-	currentPlan?: SitePlanData | any
+	currentPlanSlug?: string
 ): string {
 	if ( products.length === 0 ) {
 		throw new Error( 'No products available' );
 	}
 	let preferredBillingCycle = 'month';
 
-	if ( currentPlan && ! isWpComMonthlyPlan( currentPlan.productSlug ) ) {
+	if ( currentPlanSlug && ! isWpComMonthlyPlan( currentPlanSlug ) ) {
 		preferredBillingCycle = 'year';
 	}
 

--- a/packages/api-core/src/products/fetchers.ts
+++ b/packages/api-core/src/products/fetchers.ts
@@ -57,9 +57,10 @@ function normalizeProduct( product: Product ): Product {
 	};
 }
 
-export async function fetchProducts(): Promise< Record< string, Product > > {
+export async function fetchProducts( type?: string ): Promise< Record< string, Product > > {
 	const products: Record< string, Product > = await wpcom.req.get( {
 		path: '/products/',
+		...( type ? { qs: { type } } : {} ),
 	} );
 	return Object.fromEntries(
 		Object.entries( products ).map( ( [ key, product ] ) => [ key, normalizeProduct( product ) ] )

--- a/packages/api-core/src/products/types.ts
+++ b/packages/api-core/src/products/types.ts
@@ -38,7 +38,6 @@ export interface Product {
 	// Tiered pricing (for products with usage-based pricing)
 	price_tier_list: PriceTierEntry[];
 	price_tier_usage_quantity: number | null;
-	price_tier_slug: string;
 
 	// Domain-specific fields (conditional - only for domain products)
 	is_domain_registration: boolean;

--- a/packages/api-core/src/products/types.ts
+++ b/packages/api-core/src/products/types.ts
@@ -38,6 +38,7 @@ export interface Product {
 	// Tiered pricing (for products with usage-based pricing)
 	price_tier_list: PriceTierEntry[];
 	price_tier_usage_quantity: number | null;
+	price_tier_slug: string;
 
 	// Domain-specific fields (conditional - only for domain products)
 	is_domain_registration: boolean;
@@ -61,7 +62,7 @@ export interface Product {
 }
 
 interface IntroductoryOffer {
-	interval_unit: string;
+	interval_unit: IntroductoryOfferTimeUnit;
 	interval_count: number;
 	usage_limit: number | null;
 	cost_per_interval: number;

--- a/packages/api-queries/src/products.ts
+++ b/packages/api-queries/src/products.ts
@@ -1,8 +1,9 @@
 import { fetchProducts } from '@automattic/api-core';
 import { queryOptions } from '@tanstack/react-query';
 
-export const productsQuery = () =>
+export const productsQuery = ( type?: string ) =>
 	queryOptions( {
-		queryKey: [ 'products' ],
-		queryFn: () => fetchProducts(),
+		queryKey: [ 'products', type ],
+		queryFn: () => fetchProducts( type ),
+		staleTime: 5 * 60 * 1000,
 	} );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-1937/post-checkout-onboarding-loader-pages-can-spin-forever

## Proposed changes

Fixes the `post-checkout-onboarding` step hanging forever with a loading spinner by replacing outdated Redux/data-stores hooks with TanStack Query, and adds an error state so failed fetches surface to the user instead of silently hanging.

* Replace `useSiteData()` (backed by `@automattic/data-stores` SITE_STORE) with `useQuery(siteBySlugQuery())` from `@automattic/api-queries` — the old resolver was not reliably populating the store on fresh page loads, keeping `site` permanently `null`
* Rewrite `useMarketplaceThemeProducts` to use TanStack Query (`useQuery`) instead of Redux selectors — eliminates a bug where the global `isFetchingSitePurchases` Redux flag could be held `true` by an unrelated component, indefinitely blocking the effect
* Add `isError` / `isLoading` guards for all three data fetches (`site`, marketplace theme products, site transfer status) so the step never waits on a fetch that has already failed
* Show a "We've hit a snag" error UI if any fetch errors out, instead of hanging on the loading spinner forever

### Loading screen

<img width="556" height="416" alt="Screenshot 2026-04-24 at 4 11 23 PM" src="https://github.com/user-attachments/assets/3e8655cd-6c33-40d7-8b52-580a9f77c1c2" />


### New error screen

<img width="642" height="205" alt="Screenshot 2026-04-24 at 4 10 31 PM" src="https://github.com/user-attachments/assets/fad8192a-3f02-4c23-a9fd-0a22dc7a8700" />


## Why are these changes being made?

The `post-checkout-onboarding` step is a loading-only screen that gates a `useEffect` on several async data sources before calling `submit()` to advance the flow. Two separate bugs could cause it to hang indefinitely.

The first and more severe bug: `useSiteData()` reads the site from `SITE_STORE` (the `@automattic/data-stores` WordPress data store). During a normal purchase flow the store is already populated by earlier steps, so this worked. But on any fresh page load — revisiting the URL, a redirect back from checkout, or a hard refresh — the store starts empty. The store's `getSite` resolver should trigger a fetch, but it was not reliably doing so for slug-based lookups, leaving `site === null` permanently and the step stuck. Switching to `siteBySlugQuery` from `@automattic/api-queries` gives us a straightforward TanStack Query fetch that always runs and surfaces errors predictably.

The second bug: `useMarketplaceThemeProducts` used `isFetchingSitePurchases` — a global Redux boolean that is `true` whenever *any* component on the page is fetching site purchases. If another component elsewhere held that flag open, the guard in `post-checkout-onboarding` would never clear. Replacing the Redux selectors with per-query TanStack Query `isLoading` flags scopes each guard to its own request lifecycle.

## Testing instructions

Manual testing:
* Visit `http://calypso.localhost:3000/setup/onboarding/post-checkout-onboarding?siteSlug=<any-existing-site>&ref=woo-hosting-solutions-flow` on a fresh page load — it should navigate forward rather than hanging on the spinner
* Verify the full woo-hosting-solutions purchase flow still advances to the WooCommerce admin after checkout
* To test the error state, temporarily break the site fetch (e.g. network throttle to offline after load) and confirm the "We've hit a snag" message appears
