### PR TITLE
Dashboard: Make Logs accessible to sites with Jetpack critical errors

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -51,13 +51,13 @@ import {
 	canViewHundredYearPlanSettings,
 } from '../../sites/features';
 import { shouldLoadWpVersionNotice } from '../../sites/overview/wp-version-notice';
-import { hasJetpackCriticalError } from '../../sites/site/notices';
 import { reauthRequiredLink } from '../../utils/link';
 import {
 	getActivityLogHiddenGroups,
 	hasHostingFeature,
 	hasPlanFeature,
 } from '../../utils/site-features';
+import { isInJetpackCriticalErrorState } from '../../utils/site-jetpack-critical-error';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { isSiteMigrationInProgress, getSiteMigrationState } from '../../utils/site-status';
 import { hasSiteTrialEnded } from '../../utils/site-trial';
@@ -133,11 +133,7 @@ export const siteRoute = createRoute( {
 
 		// Only intercept the overview entry point — other inaccessible-Jetpack-allowed
 		// routes (domains, etc.) should remain reachable.
-		if (
-			site.__inaccessible_jetpack_error &&
-			hasJetpackCriticalError( site ) &&
-			isOnOverviewRoute( matches.at( -1 )?.routeId )
-		) {
+		if ( isInJetpackCriticalErrorState( site ) && isOnOverviewRoute( matches.at( -1 )?.routeId ) ) {
 			throw dashboardRedirect( { to: criticalErrorUrl } );
 		}
 
@@ -295,7 +291,7 @@ export const siteMonitoringRoute = createRoute( {
 );
 
 export const siteLogsRoute = createRoute( {
-	staticData: { requiresSiteTypeSupport: 'logs' },
+	staticData: { requiresSiteTypeSupport: 'logs', availableToInaccessibleJetpackSites: true },
 	head: () => ( {
 		meta: [
 			{
@@ -325,10 +321,7 @@ export const siteLogsPhpRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteLogsRoute,
 	path: 'php',
-	loader: async ( { params: { siteSlug } } ) => {
-		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		await queryClient.ensureQueryData( siteSettingsQuery( site.ID ) );
-	},
+	loader: loadSiteLogsRoute,
 } ).lazy( () =>
 	import( '../../sites/logs' ).then( ( d ) =>
 		createLazyRoute( 'site-logs-php' )( {
@@ -347,10 +340,7 @@ export const siteLogsServerRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteLogsRoute,
 	path: 'server',
-	loader: async ( { params: { siteSlug } } ) => {
-		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		await queryClient.ensureQueryData( siteSettingsQuery( site.ID ) );
-	},
+	loader: loadSiteLogsRoute,
 } ).lazy( () =>
 	import( '../../sites/logs' ).then( ( d ) =>
 		createLazyRoute( 'site-logs-server' )( {
@@ -369,10 +359,7 @@ export const siteLogsActivityRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteLogsRoute,
 	path: 'activity',
-	loader: async ( { params: { siteSlug } } ) => {
-		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		await queryClient.ensureQueryData( siteSettingsQuery( site.ID ) );
-	},
+	loader: loadSiteLogsRoute,
 } ).lazy( () =>
 	import( '../../sites/logs' ).then( ( d ) =>
 		createLazyRoute( 'site-logs-activity' )( {
@@ -1439,7 +1426,7 @@ export const siteCriticalErrorRoute = createRoute( {
 		}
 
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		if ( ! site.__inaccessible_jetpack_error || ! hasJetpackCriticalError( site ) ) {
+		if ( ! isInJetpackCriticalErrorState( site ) ) {
 			throw dashboardRedirect( { to: siteOverviewRoute.fullPath, params: { siteSlug } } );
 		}
 	},
@@ -1708,6 +1695,15 @@ function getDifmLiteAllowedRoutes() {
 
 function isOnOverviewRoute( routeId: string | undefined ) {
 	return routeId === siteOverviewRoute.id;
+}
+
+async function loadSiteLogsRoute( { params: { siteSlug } }: { params: { siteSlug: string } } ) {
+	const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+	// Skip the settings prefetch for sites we know can't reach Jetpack —
+	// the request would fail and the Logs page falls back to UTC defaults.
+	if ( ! site.__inaccessible_jetpack_error ) {
+		await queryClient.prefetchQuery( siteSettingsQuery( site.ID ) );
+	}
 }
 
 function redirectAsNotAllowed( options: {

--- a/client/dashboard/sites/critical-error/index.tsx
+++ b/client/dashboard/sites/critical-error/index.tsx
@@ -12,7 +12,10 @@ import { Card, CardBody, CardDivider } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { Text } from '../../components/text';
-import { getJetpackCriticalErrorMessage, hasJetpackCriticalError } from '../site/notices';
+import {
+	getJetpackCriticalErrorMessage,
+	isInJetpackCriticalErrorState,
+} from '../../utils/site-jetpack-critical-error';
 import type { ReactElement, ReactNode } from 'react';
 
 type Item = {
@@ -34,7 +37,7 @@ const SiteCriticalError = ( { siteSlug }: { siteSlug: string } ) => {
 	const navigate = useNavigate();
 
 	const isAdmin = !! site.capabilities?.manage_options;
-	const hasRecovered = ! site.__inaccessible_jetpack_error || ! hasJetpackCriticalError( site );
+	const hasRecovered = ! isInJetpackCriticalErrorState( site );
 
 	useEffect( () => {
 		recordTracksEvent( 'calypso_dashboard_critical_error_impression' );

--- a/client/dashboard/sites/logs-activity/dataviews/actions.tsx
+++ b/client/dashboard/sites/logs-activity/dataviews/actions.tsx
@@ -22,6 +22,13 @@ export function useActivityActions( {
 	const { recordTracksEvent } = useAnalytics();
 
 	return useMemo( () => {
+		// Inaccessible Jetpack sites can't open the backup detail route (it
+		// doesn't opt into availableToInaccessibleJetpackSites), so hide the
+		// action rather than route the user into a dead end.
+		if ( site.__inaccessible_jetpack_error ) {
+			return [];
+		}
+
 		const backupAction: Action< Activity > = {
 			id: 'backup',
 			isPrimary: true,

--- a/client/dashboard/sites/logs/index.tsx
+++ b/client/dashboard/sites/logs/index.tsx
@@ -1,4 +1,4 @@
-import { HostingFeatures, LogType } from '@automattic/api-core';
+import { HostingFeatures, LogType, type Site, type SiteSettings } from '@automattic/api-core';
 import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
 import { useSuspenseQuery } from '@tanstack/react-query';
@@ -26,11 +26,61 @@ import { getLogsCalloutProps } from './logs-callout';
 import { LOG_TABS } from './utils';
 import './style.scss';
 
+const selectTimeZone = ( s: SiteSettings | undefined ) => ( {
+	gmtOffset: Number( s?.gmt_offset ) || 0,
+	timezoneString: s?.timezone_string || undefined,
+} );
+
 function SiteLogs( { logType }: { logType: LogType } ) {
-	const locale = useLocale();
 	const { siteSlug } = siteRoute.useParams();
-	const router = useRouter();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+
+	// Sites with a Jetpack connection error can't reach the settings endpoint;
+	// fall back to UTC defaults so the Logs page remains accessible.
+	if ( site.__inaccessible_jetpack_error ) {
+		return (
+			<SiteLogsContent
+				site={ site }
+				logType={ logType }
+				gmtOffset={ 0 }
+				timezoneString={ undefined }
+			/>
+		);
+	}
+
+	return <SiteLogsForReachableSite site={ site } logType={ logType } />;
+}
+
+function SiteLogsForReachableSite( { site, logType }: { site: Site; logType: LogType } ) {
+	const { data } = useSuspenseQuery( {
+		...siteSettingsQuery( site.ID ),
+		select: selectTimeZone,
+	} );
+
+	return (
+		<SiteLogsContent
+			site={ site }
+			logType={ logType }
+			gmtOffset={ data.gmtOffset }
+			timezoneString={ data.timezoneString }
+		/>
+	);
+}
+
+function SiteLogsContent( {
+	site,
+	logType,
+	gmtOffset,
+	timezoneString,
+}: {
+	site: Site;
+	logType: LogType;
+	gmtOffset: number;
+	timezoneString: string | undefined;
+} ) {
+	const locale = useLocale();
+	const router = useRouter();
+	const siteSlug = site.slug;
 
 	const settingsUrl = site.options?.admin_url
 		? `${ site.options.admin_url }options-general.php`
@@ -73,16 +123,6 @@ function SiteLogs( { logType }: { logType: LogType } ) {
 			// noop: if URL is not parseable, skip normalization
 		}
 	}, [] );
-
-	const { data } = useSuspenseQuery( {
-		...siteSettingsQuery( siteId ),
-		select: ( s ) => ( {
-			gmtOffset: Number( s?.gmt_offset ) || 0,
-			timezoneString: s?.timezone_string || undefined,
-		} ),
-	} );
-
-	const { gmtOffset, timezoneString } = data!;
 
 	const { dateRange, handleDateRangeChange } = useDateRange( {
 		timezoneString,
@@ -165,11 +205,19 @@ function SiteLogs( { logType }: { logType: LogType } ) {
 					{ autoRefreshDisabledReason && (
 						<Notice variant="warning">{ autoRefreshDisabledReason }</Notice>
 					) }
-					<TimeMismatchNotice
-						settingsUrl={ settingsUrl }
-						siteTime={ gmtOffset }
-						siteId={ siteId }
-					/>
+					{ site.__inaccessible_jetpack_error ? (
+						<Notice variant="warning">
+							{ __(
+								'Your site’s time zone setting is currently unavailable. Dates and times on this page are displayed in UTC instead.'
+							) }
+						</Notice>
+					) : (
+						<TimeMismatchNotice
+							settingsUrl={ settingsUrl }
+							siteTime={ gmtOffset }
+							siteId={ siteId }
+						/>
+					) }
 				</>
 			}
 		>

--- a/client/dashboard/sites/site/notices.tsx
+++ b/client/dashboard/sites/site/notices.tsx
@@ -4,7 +4,6 @@ import { __ } from '@wordpress/i18n';
 import { useEffect } from 'react';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { Notice } from '../../components/notice';
-import type { Site } from '@automattic/api-core';
 
 export function InaccessibleJetpackNotice( { error }: { error: Error } ) {
 	useEffect( () => {
@@ -31,52 +30,4 @@ export function InaccessibleJetpackNotice( { error }: { error: Error } ) {
 			{ error.message }
 		</Notice>
 	);
-}
-
-const FIFTEEN_MINUTES = 15 * 60;
-
-function getJetpackCriticalErrorState(
-	site: Site,
-	now: number = Math.floor( Date.now() / 1000 )
-): 'in-recovery' | 'critical-error' | null {
-	const status = site.options?.jetpack_recovery_mode_status;
-	if ( ! status ) {
-		return null;
-	}
-
-	const enteredAt = status.recovery_session_entered_at ?? 0;
-	const exitedAt = status.recovery_session_exited_at ?? 0;
-	const lastSent = status.recovery_mode_email_last_sent ?? 0;
-
-	if ( enteredAt > 0 && enteredAt > exitedAt ) {
-		return 'in-recovery';
-	}
-
-	// Suppress for 15 min after a clean exit so a just-resolved error doesn't linger.
-	if ( exitedAt >= lastSent && now - exitedAt < FIFTEEN_MINUTES ) {
-		return null;
-	}
-
-	if ( lastSent > 0 && enteredAt < lastSent ) {
-		return 'critical-error';
-	}
-
-	return null;
-}
-
-export function hasJetpackCriticalError( site: Site ): boolean {
-	return getJetpackCriticalErrorState( site ) !== null;
-}
-
-export function getJetpackCriticalErrorMessage( site: Site ): string | null {
-	if ( ! hasJetpackCriticalError( site ) ) {
-		return null;
-	}
-
-	const isAdmin = !! site.capabilities?.manage_options;
-	return isAdmin
-		? __( 'There has been a critical error on this website. Here’s what you can try next:' )
-		: __(
-				'There has been a critical error on this website. A site administrator has been notified.'
-		  );
 }

--- a/client/dashboard/utils/site-jetpack-critical-error.ts
+++ b/client/dashboard/utils/site-jetpack-critical-error.ts
@@ -1,0 +1,55 @@
+import { __ } from '@wordpress/i18n';
+import type { Site } from '@automattic/api-core';
+
+const FIFTEEN_MINUTES = 15 * 60;
+
+function getJetpackCriticalErrorState(
+	site: Site,
+	now: number = Math.floor( Date.now() / 1000 )
+): 'in-recovery' | 'critical-error' | null {
+	const status = site.options?.jetpack_recovery_mode_status;
+	if ( ! status ) {
+		return null;
+	}
+
+	const enteredAt = status.recovery_session_entered_at ?? 0;
+	const exitedAt = status.recovery_session_exited_at ?? 0;
+	const lastSent = status.recovery_mode_email_last_sent ?? 0;
+
+	if ( enteredAt > 0 && enteredAt > exitedAt ) {
+		return 'in-recovery';
+	}
+
+	// Suppress for 15 min after a clean exit so a just-resolved error doesn't linger.
+	if ( exitedAt >= lastSent && now - exitedAt < FIFTEEN_MINUTES ) {
+		return null;
+	}
+
+	if ( lastSent > 0 && enteredAt < lastSent ) {
+		return 'critical-error';
+	}
+
+	return null;
+}
+
+export function hasJetpackCriticalError( site: Site ): boolean {
+	return getJetpackCriticalErrorState( site ) !== null;
+}
+
+// Criteria for being redirected to /critical-error.
+export function isInJetpackCriticalErrorState( site: Site ): boolean {
+	return !! site.__inaccessible_jetpack_error && hasJetpackCriticalError( site );
+}
+
+export function getJetpackCriticalErrorMessage( site: Site ): string | null {
+	if ( ! hasJetpackCriticalError( site ) ) {
+		return null;
+	}
+
+	const isAdmin = !! site.capabilities?.manage_options;
+	return isAdmin
+		? __( 'There has been a critical error on this website. Here’s what you can try next:' )
+		: __(
+				'There has been a critical error on this website. A site administrator has been notified.'
+		  );
+}

--- a/client/sites/overview/components/critical-error/index.tsx
+++ b/client/sites/overview/components/critical-error/index.tsx
@@ -8,7 +8,7 @@ import { Icon, envelope, help } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { HostingHero } from 'calypso/components/hosting-hero';
-import { getJetpackCriticalErrorMessage } from 'calypso/dashboard/sites/site/notices';
+import { getJetpackCriticalErrorMessage } from 'calypso/dashboard/utils/site-jetpack-critical-error';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { ReactElement, ReactNode } from 'react';
 

--- a/client/sites/v2/site-overview/router.tsx
+++ b/client/sites/v2/site-overview/router.tsx
@@ -7,7 +7,7 @@ import { createLazyRoute, createRoute, createRouter } from '@tanstack/react-rout
 import { APP_CONTEXT_DEFAULT_CONFIG } from 'calypso/dashboard/app/context';
 import { handleOnCatch } from 'calypso/dashboard/app/logger';
 import * as appRouterSites from 'calypso/dashboard/app/router/sites';
-import { hasJetpackCriticalError } from 'calypso/dashboard/sites/site/notices';
+import { isInJetpackCriticalErrorState } from 'calypso/dashboard/utils/site-jetpack-critical-error';
 import CriticalErrorOverview from 'calypso/sites/overview/components/critical-error';
 import { rootRoute, dashboardSitesCompatibilityRoute, siteRoute } from '../router';
 import siteSettingsRouter from '../site-settings/router';
@@ -27,7 +27,7 @@ const siteOverviewRoute = createRoute( {
 				const { data: site } = useQuery( siteBySlugQuery( siteSlug ) );
 				const isWide = useBreakpoint( WIDE_BREAKPOINT );
 
-				if ( site?.__inaccessible_jetpack_error && hasJetpackCriticalError( site ) ) {
+				if ( site && isInJetpackCriticalErrorState( site ) ) {
 					return <CriticalErrorOverview siteSlug={ siteSlug } />;
 				}
 


### PR DESCRIPTION
Part of #

## Proposed Changes

- Allow the Logs route to be reached for sites flagged with `__inaccessible_jetpack_error` (the same sites that are redirected to `/critical-error`) by adding `availableToInaccessibleJetpackSites: true` on `siteLogsRoute`.
- Skip the settings endpoint prefetch for those sites in the route loader and split `SiteLogs` so an inner `SiteLogsForReachableSite` suspends on `siteSettingsQuery` only when the settings call can succeed; the unreachable branch renders directly with `gmtOffset = 0` / `timezoneString = undefined`.
- Replace `TimeMismatchNotice` with a warning explaining the UTC fallback when the time zone setting is unavailable.
- Hide the Manage backup action in the activity log for inaccessible Jetpack sites, since `siteBackupDetailRoute` does not opt into the same accessibility flag.
- Extract the Jetpack critical-error helpers (`hasJetpackCriticalError`, `getJetpackCriticalErrorMessage`) out of `sites/site/notices.tsx` into a new `utils/site-jetpack-critical-error.ts`, and add `isInJetpackCriticalErrorState` to capture the precise predicate for being redirected to `/critical-error`. Update the existing call sites (router, critical-error page, classic Calypso overview) to use the new helper.

## Why are these changes being made?

Sites that are currently in a Jetpack critical-error state are redirected to `/critical-error` from most routes. Until now, the Logs page suspended on `siteSettingsQuery`, which fails for those sites, so the page was completely unavailable to users who needed it most — exactly when their site was unreachable. This change makes Logs reachable for those sites with sensible UTC defaults, surfaces a clear notice about the fallback, and keeps the page navigation honest by hiding the backup action that would otherwise dead-end on the inaccessible backup detail route.

## Testing Instructions

1. Find or simulate a site whose API responses set `__inaccessible_jetpack_error` together with the Jetpack recovery-mode flags.
2. Visit `/sites/<slug>/logs/activity`. The page should render without errors, dates should be in UTC, and a warning should read: "Your site's time zone setting is currently unavailable. Dates and times on this page are displayed in UTC instead."
3. The "Manage backup" action in the activity dataviews should not be present on rewindable rows for that site.
4. For a site without `__inaccessible_jetpack_error`, the existing `TimeMismatchNotice` and Manage backup action should still appear and behave as before.
5. Visit `/sites/<slug>/critical-error` for an unreachable site — it should still render. As soon as the site recovers, the page should redirect back to overview.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?