### PR TITLE
Inline site-dependency warnings on cancel/remove confirmation screen

### DIFF
--- a/client/dashboard/me/billing-purchases/AGENTS.md
+++ b/client/dashboard/me/billing-purchases/AGENTS.md
@@ -109,3 +109,5 @@ marketplace subscriptions on site.
 7. **Transferred purchases** — Always check ownership before allowing purchase actions.
 
 8. **Route params are strings** — `purchaseId` from URL params must be `parseInt()`'d before passing to query functions.
+
+9. **`site.options.unmapped_url` lies for `.home.blog` sites** — Returns the `.wordpress.com` URL even when the site's free domain is `.home.blog` (or another `.blog` subdomain). Don't use it to render the user's free hostname. Read the actual WPCOM domain from `siteDomainsQuery( siteId )` — find the entry flagged `wpcom_domain` or `is_wpcom_staging_domain` and use its `domain` field. This is the same root issue as Classic's `site.wpcom_url`, which is just `withoutHttp( unmapped_url )` — see `client/me/purchases/AGENTS.md` pitfall #6.

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
@@ -110,7 +110,7 @@ export default function CancellationMainContent( {
 		defaultChanges.push( ...atomicRevertChanges );
 	}
 
-	if ( config.isEnabled( 'purchases/split-cancel-remove' ) ) {
+	if ( isSplitCancelRemoveEnabled ) {
 		// Non-primary domain forwarding: plan cancellation on a site with a custom primary domain.
 		if ( purchase.is_plan && site?.URL && site?.options?.unmapped_url ) {
 			const primaryDomain = new URL( site.URL ).hostname;
@@ -209,7 +209,7 @@ export default function CancellationMainContent( {
 		showDefaultChanges = true;
 	}
 	// Under the flag, domain registrations also have warning bullets in defaultChanges.
-	if ( config.isEnabled( 'purchases/split-cancel-remove' ) && isDomainRegistrationPurchase ) {
+	if ( isSplitCancelRemoveEnabled && isDomainRegistrationPurchase ) {
 		showDefaultChanges = true;
 	}
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
@@ -112,12 +112,7 @@ export default function CancellationMainContent( {
 
 	if ( config.isEnabled( 'purchases/split-cancel-remove' ) ) {
 		// Non-primary domain forwarding: plan cancellation on a site with a custom primary domain.
-		if (
-			purchase.is_plan &&
-			! purchase.is_wpcom_atomic &&
-			site?.URL &&
-			site?.options?.unmapped_url
-		) {
+		if ( purchase.is_plan && site?.URL && site?.options?.unmapped_url ) {
 			const primaryDomain = new URL( site.URL ).hostname;
 			const wpcomDomain = new URL( site.options.unmapped_url ).hostname;
 			if ( primaryDomain !== wpcomDomain ) {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
@@ -190,7 +190,7 @@ export default function CancellationMainContent( {
 				}
 			);
 
-			if ( selectedDomain?.is_gravatar_domain ) {
+			if ( selectedDomain?.is_gravatar_restricted_domain ) {
 				defaultChanges.push( {
 					getSlug: () => 'gravatarDomain',
 					getTitle: () =>

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
@@ -16,6 +16,7 @@ import type {
 	Purchase,
 	Domain,
 	AtomicTransfer,
+	Site,
 	UpgradesCancelFeaturesResponse,
 } from '@automattic/api-core';
 
@@ -25,6 +26,8 @@ interface CancellationMainContentProps {
 	includedDomainPurchase?: Purchase;
 	atomicTransfer?: AtomicTransfer;
 	selectedDomain?: Domain;
+	site?: Site;
+	activeMarketplaceSubscriptions?: Purchase[];
 	state: CancelPurchaseState;
 	purchaseCancelFeatures?: UpgradesCancelFeaturesResponse;
 	isBusy?: boolean;
@@ -55,6 +58,8 @@ export default function CancellationMainContent( {
 	includedDomainPurchase,
 	atomicTransfer,
 	selectedDomain,
+	site,
+	activeMarketplaceSubscriptions,
 	state,
 	purchaseCancelFeatures,
 	isBusy,
@@ -105,11 +110,111 @@ export default function CancellationMainContent( {
 		defaultChanges.push( ...atomicRevertChanges );
 	}
 
+	if ( config.isEnabled( 'purchases/split-cancel-remove' ) ) {
+		// Non-primary domain forwarding: plan cancellation on a site with a custom primary domain.
+		if (
+			purchase.is_plan &&
+			! purchase.is_wpcom_atomic &&
+			site?.URL &&
+			site?.options?.unmapped_url
+		) {
+			const primaryDomain = new URL( site.URL ).hostname;
+			const wpcomDomain = new URL( site.options.unmapped_url ).hostname;
+			if ( primaryDomain !== wpcomDomain ) {
+				defaultChanges.push(
+					{
+						getSlug: () => 'domainForwarding',
+						getTitle: () =>
+							sprintf(
+								/* translators: %(primaryDomain)s is the custom domain, %(wpcomDomain)s is the WordPress.com subdomain */
+								__( '%(primaryDomain)s will start forwarding to %(wpcomDomain)s.' ),
+								{ primaryDomain, wpcomDomain }
+							),
+					},
+					{
+						getSlug: () => 'domainVisible',
+						getTitle: () =>
+							sprintf(
+								/* translators: %(wpcomDomain)s is the WordPress.com subdomain */
+								__(
+									'%(wpcomDomain)s will become the address people see when they visit your site.'
+								),
+								{ wpcomDomain }
+							),
+					}
+				);
+			}
+		}
+
+		// WordAds ineligibility: plan cancellation on a site enrolled in WordAds.
+		if ( purchase.is_plan && site?.options?.wordads ) {
+			defaultChanges.push( {
+				getSlug: () => 'wordAdsIneligible',
+				getTitle: () => __( 'You will become ineligible for the WordAds program.' ),
+			} );
+		}
+
+		// Marketplace subscription cascade: plan cancellation with active marketplace subscriptions.
+		if ( activeMarketplaceSubscriptions && activeMarketplaceSubscriptions.length > 0 ) {
+			for ( const sub of activeMarketplaceSubscriptions ) {
+				defaultChanges.push( {
+					getSlug: () => `marketplace-${ sub.ID }`,
+					getTitle: () =>
+						sprintf(
+							/* translators: %(productName)s is the name of a marketplace subscription */
+							__( '%(productName)s will also be removed.' ),
+							{ productName: sub.product_name }
+						),
+				} );
+			}
+		}
+
+		// Domain deletion consequences: removing a domain registration.
+		if ( isDomainRegistrationPurchase ) {
+			defaultChanges.push(
+				{
+					getSlug: () => 'domainServicesUnreachable',
+					getTitle: () =>
+						sprintf(
+							/* translators: %(domain)s is the domain name being deleted */
+							__(
+								'All services connected to %(domain)s will become unreachable, including email and website.'
+							),
+							{ domain: purchase.meta }
+						),
+				},
+				{
+					getSlug: () => 'domainAvailable',
+					getTitle: () =>
+						sprintf(
+							/* translators: %(domain)s is the domain name being deleted */
+							__( '%(domain)s will become available for someone else to register.' ),
+							{ domain: purchase.meta }
+						),
+				}
+			);
+
+			if ( selectedDomain?.is_gravatar_domain ) {
+				defaultChanges.push( {
+					getSlug: () => 'gravatarDomain',
+					getTitle: () =>
+						__(
+							'This domain is provided at no cost for your Gravatar profile. If you delete it, you will have to pay full price for another.'
+						),
+				} );
+			}
+		}
+	}
+
 	// Get features from the API endpoint for this product
 	const cancellationFeatures = purchaseCancelFeatures?.features ?? [];
 
 	let showDefaultChanges = false;
 	if ( ! isJetpack && ! isAkismet && ! isGSuite && ! isDomainRegistrationPurchase ) {
+		showDefaultChanges = true;
+	}
+	// Under the flag, domain registrations also have warning bullets in defaultChanges.
+	if ( config.isEnabled( 'purchases/split-cancel-remove' ) && isDomainRegistrationPurchase ) {
 		showDefaultChanges = true;
 	}
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
@@ -27,6 +27,7 @@ interface CancellationMainContentProps {
 	atomicTransfer?: AtomicTransfer;
 	selectedDomain?: Domain;
 	site?: Site;
+	wpcomDomain?: string | null;
 	activeMarketplaceSubscriptions?: Purchase[];
 	state: CancelPurchaseState;
 	purchaseCancelFeatures?: UpgradesCancelFeaturesResponse;
@@ -59,6 +60,7 @@ export default function CancellationMainContent( {
 	atomicTransfer,
 	selectedDomain,
 	site,
+	wpcomDomain,
 	activeMarketplaceSubscriptions,
 	state,
 	purchaseCancelFeatures,
@@ -112,9 +114,8 @@ export default function CancellationMainContent( {
 
 	if ( isSplitCancelRemoveEnabled ) {
 		// Non-primary domain forwarding: plan cancellation on a site with a custom primary domain.
-		if ( purchase.is_plan && site?.URL && site?.options?.unmapped_url ) {
+		if ( purchase.is_plan && site?.URL && wpcomDomain ) {
 			const primaryDomain = new URL( site.URL ).hostname;
-			const wpcomDomain = new URL( site.options.unmapped_url ).hostname;
 			if ( primaryDomain !== wpcomDomain ) {
 				defaultChanges.push(
 					{

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
@@ -16,6 +16,7 @@ import type {
 	Purchase,
 	Domain,
 	AtomicTransfer,
+	Site,
 	UpgradesCancelFeaturesResponse,
 } from '@automattic/api-core';
 
@@ -25,6 +26,8 @@ interface CancellationMainContentProps {
 	includedDomainPurchase?: Purchase;
 	atomicTransfer?: AtomicTransfer;
 	selectedDomain?: Domain;
+	site?: Site;
+	activeMarketplaceSubscriptions?: Purchase[];
 	state: CancelPurchaseState;
 	skipSurvey?: boolean;
 	purchaseCancelFeatures?: UpgradesCancelFeaturesResponse;
@@ -55,6 +58,8 @@ export default function CancellationMainContent( {
 	includedDomainPurchase,
 	atomicTransfer,
 	selectedDomain,
+	site,
+	activeMarketplaceSubscriptions,
 	state,
 	skipSurvey,
 	purchaseCancelFeatures,
@@ -104,11 +109,111 @@ export default function CancellationMainContent( {
 		defaultChanges.push( ...atomicRevertChanges );
 	}
 
+	if ( config.isEnabled( 'purchases/split-cancel-remove' ) ) {
+		// Non-primary domain forwarding: plan cancellation on a site with a custom primary domain.
+		if (
+			purchase.is_plan &&
+			! purchase.is_wpcom_atomic &&
+			site?.URL &&
+			site?.options?.unmapped_url
+		) {
+			const primaryDomain = new URL( site.URL ).hostname;
+			const wpcomDomain = new URL( site.options.unmapped_url ).hostname;
+			if ( primaryDomain !== wpcomDomain ) {
+				defaultChanges.push(
+					{
+						getSlug: () => 'domainForwarding',
+						getTitle: () =>
+							sprintf(
+								/* translators: %(primaryDomain)s is the custom domain, %(wpcomDomain)s is the WordPress.com subdomain */
+								__( '%(primaryDomain)s will start forwarding to %(wpcomDomain)s.' ),
+								{ primaryDomain, wpcomDomain }
+							),
+					},
+					{
+						getSlug: () => 'domainVisible',
+						getTitle: () =>
+							sprintf(
+								/* translators: %(wpcomDomain)s is the WordPress.com subdomain */
+								__(
+									'%(wpcomDomain)s will become the address people see when they visit your site.'
+								),
+								{ wpcomDomain }
+							),
+					}
+				);
+			}
+		}
+
+		// WordAds ineligibility: plan cancellation on a site enrolled in WordAds.
+		if ( purchase.is_plan && site?.options?.wordads ) {
+			defaultChanges.push( {
+				getSlug: () => 'wordAdsIneligible',
+				getTitle: () => __( 'You will become ineligible for the WordAds program.' ),
+			} );
+		}
+
+		// Marketplace subscription cascade: plan cancellation with active marketplace subscriptions.
+		if ( activeMarketplaceSubscriptions && activeMarketplaceSubscriptions.length > 0 ) {
+			for ( const sub of activeMarketplaceSubscriptions ) {
+				defaultChanges.push( {
+					getSlug: () => `marketplace-${ sub.ID }`,
+					getTitle: () =>
+						sprintf(
+							/* translators: %(productName)s is the name of a marketplace subscription */
+							__( '%(productName)s will also be removed.' ),
+							{ productName: sub.product_name }
+						),
+				} );
+			}
+		}
+
+		// Domain deletion consequences: removing a domain registration.
+		if ( isDomainRegistrationPurchase ) {
+			defaultChanges.push(
+				{
+					getSlug: () => 'domainServicesUnreachable',
+					getTitle: () =>
+						sprintf(
+							/* translators: %(domain)s is the domain name being deleted */
+							__(
+								'All services connected to %(domain)s will become unreachable, including email and website.'
+							),
+							{ domain: purchase.meta }
+						),
+				},
+				{
+					getSlug: () => 'domainAvailable',
+					getTitle: () =>
+						sprintf(
+							/* translators: %(domain)s is the domain name being deleted */
+							__( '%(domain)s will become available for someone else to register.' ),
+							{ domain: purchase.meta }
+						),
+				}
+			);
+
+			if ( selectedDomain?.is_gravatar_domain ) {
+				defaultChanges.push( {
+					getSlug: () => 'gravatarDomain',
+					getTitle: () =>
+						__(
+							'This domain is provided at no cost for your Gravatar profile. If you delete it, you will have to pay full price for another.'
+						),
+				} );
+			}
+		}
+	}
+
 	// Get features from the API endpoint for this product
 	const cancellationFeatures = purchaseCancelFeatures?.features ?? [];
 
 	let showDefaultChanges = false;
 	if ( ! isJetpack && ! isAkismet && ! isGSuite && ! isDomainRegistrationPurchase ) {
+		showDefaultChanges = true;
+	}
+	// Under the flag, domain registrations also have warning bullets in defaultChanges.
+	if ( config.isEnabled( 'purchases/split-cancel-remove' ) && isDomainRegistrationPurchase ) {
 		showDefaultChanges = true;
 	}
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
@@ -111,12 +111,7 @@ export default function CancellationMainContent( {
 
 	if ( config.isEnabled( 'purchases/split-cancel-remove' ) ) {
 		// Non-primary domain forwarding: plan cancellation on a site with a custom primary domain.
-		if (
-			purchase.is_plan &&
-			! purchase.is_wpcom_atomic &&
-			site?.URL &&
-			site?.options?.unmapped_url
-		) {
+		if ( purchase.is_plan && site?.URL && site?.options?.unmapped_url ) {
 			const primaryDomain = new URL( site.URL ).hostname;
 			const wpcomDomain = new URL( site.options.unmapped_url ).hostname;
 			if ( primaryDomain !== wpcomDomain ) {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-pre-survey-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-pre-survey-content.tsx
@@ -17,6 +17,7 @@ interface CancellationPreSurveyContentProps {
 	atomicTransfer?: AtomicTransfer;
 	selectedDomain?: Domain;
 	site?: Site;
+	wpcomDomain?: string | null;
 	activeMarketplaceSubscriptions?: Purchase[];
 	state: CancelPurchaseState;
 	purchaseCancelFeatures?: UpgradesCancelFeaturesResponse;
@@ -39,6 +40,7 @@ export default function CancellationPreSurveyContent( {
 	atomicTransfer,
 	selectedDomain,
 	site,
+	wpcomDomain,
 	activeMarketplaceSubscriptions,
 	state,
 	purchaseCancelFeatures,
@@ -72,6 +74,7 @@ export default function CancellationPreSurveyContent( {
 			atomicTransfer={ atomicTransfer }
 			selectedDomain={ selectedDomain }
 			site={ site }
+			wpcomDomain={ wpcomDomain }
 			activeMarketplaceSubscriptions={ activeMarketplaceSubscriptions }
 			state={ state }
 			purchaseCancelFeatures={ purchaseCancelFeatures }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-pre-survey-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-pre-survey-content.tsx
@@ -6,6 +6,7 @@ import type {
 	Purchase,
 	Domain,
 	AtomicTransfer,
+	Site,
 	UpgradesCancelFeaturesResponse,
 } from '@automattic/api-core';
 
@@ -15,6 +16,8 @@ interface CancellationPreSurveyContentProps {
 	includedDomainPurchase?: Purchase;
 	atomicTransfer?: AtomicTransfer;
 	selectedDomain?: Domain;
+	site?: Site;
+	activeMarketplaceSubscriptions?: Purchase[];
 	state: CancelPurchaseState;
 	purchaseCancelFeatures?: UpgradesCancelFeaturesResponse;
 	isBusy?: boolean;
@@ -35,6 +38,8 @@ export default function CancellationPreSurveyContent( {
 	includedDomainPurchase,
 	atomicTransfer,
 	selectedDomain,
+	site,
+	activeMarketplaceSubscriptions,
 	state,
 	purchaseCancelFeatures,
 	isBusy,
@@ -66,6 +71,8 @@ export default function CancellationPreSurveyContent( {
 			includedDomainPurchase={ includedDomainPurchase }
 			atomicTransfer={ atomicTransfer }
 			selectedDomain={ selectedDomain }
+			site={ site }
+			activeMarketplaceSubscriptions={ activeMarketplaceSubscriptions }
 			state={ state }
 			purchaseCancelFeatures={ purchaseCancelFeatures }
 			isBusy={ isBusy }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-pre-survey-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-pre-survey-content.tsx
@@ -6,6 +6,7 @@ import type {
 	Purchase,
 	Domain,
 	AtomicTransfer,
+	Site,
 	UpgradesCancelFeaturesResponse,
 } from '@automattic/api-core';
 
@@ -15,6 +16,8 @@ interface CancellationPreSurveyContentProps {
 	includedDomainPurchase?: Purchase;
 	atomicTransfer?: AtomicTransfer;
 	selectedDomain?: Domain;
+	site?: Site;
+	activeMarketplaceSubscriptions?: Purchase[];
 	state: CancelPurchaseState;
 	skipSurvey?: boolean;
 	purchaseCancelFeatures?: UpgradesCancelFeaturesResponse;
@@ -35,6 +38,8 @@ export default function CancellationPreSurveyContent( {
 	includedDomainPurchase,
 	atomicTransfer,
 	selectedDomain,
+	site,
+	activeMarketplaceSubscriptions,
 	state,
 	skipSurvey,
 	purchaseCancelFeatures,
@@ -66,6 +71,8 @@ export default function CancellationPreSurveyContent( {
 			includedDomainPurchase={ includedDomainPurchase }
 			atomicTransfer={ atomicTransfer }
 			selectedDomain={ selectedDomain }
+			site={ site }
+			activeMarketplaceSubscriptions={ activeMarketplaceSubscriptions }
 			state={ state }
 			skipSurvey={ skipSurvey }
 			purchaseCancelFeatures={ purchaseCancelFeatures }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
@@ -99,7 +99,11 @@ const CancelPurchaseFeatureList = ( {
 			) }
 			{ cancellationChanges.length > 0 && (
 				<VStack spacing={ 2 }>
-					<Text as="p">{ __( 'We will also make these changes to your site:' ) }</Text>
+					<Text as="p">
+						{ purchase.is_plan
+							? __( 'We will also make these changes to your site:' )
+							: __( "Here's what will happen:" ) }
+					</Text>
 					<VStack as="ul" spacing={ 1 } style={ { listStyle: 'none', padding: 0, margin: 0 } }>
 						{ cancellationChanges.map( ( change ) => (
 							<li key={ change.getSlug() }>

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -1627,6 +1627,8 @@ function CancelPurchaseInner() {
 									includedDomainPurchase={ includedDomainPurchase }
 									atomicTransfer={ atomicTransfer }
 									selectedDomain={ selectedDomain }
+									site={ site }
+									activeMarketplaceSubscriptions={ activeSubscriptions }
 									state={ state }
 									purchaseCancelFeatures={ purchaseCancelFeatures }
 									isBusy={ isMutationPending }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -16,6 +16,7 @@ import {
 	purchaseCancelFeaturesQuery,
 	purchaseQuery,
 	siteByIdQuery,
+	siteDomainsQuery,
 	sitePurchasesQuery,
 	userPreferenceMutation,
 	hasPurchaseBeenExtendedQuery,
@@ -413,6 +414,11 @@ function CancelPurchaseInner() {
 		...domainQuery( purchase.meta ?? '' ),
 		enabled: Boolean( purchase.meta ),
 	} );
+	// site.options.unmapped_url is incorrect for .home.blog sites — read the
+	// actual WPCOM domain from the site's domain list instead.
+	const { data: siteDomains } = useQuery( siteDomainsQuery( purchase.blog_id ) );
+	const wpcomDomain =
+		siteDomains?.find( ( d ) => d.wpcom_domain || d.is_wpcom_staging_domain )?.domain ?? null;
 	const { data: cancellationOffers } = useQuery(
 		cancellationOffersQuery( purchase.blog_id, purchase.ID )
 	);
@@ -1628,6 +1634,7 @@ function CancelPurchaseInner() {
 									atomicTransfer={ atomicTransfer }
 									selectedDomain={ selectedDomain }
 									site={ site }
+									wpcomDomain={ wpcomDomain }
 									activeMarketplaceSubscriptions={ activeSubscriptions }
 									state={ state }
 									purchaseCancelFeatures={ purchaseCancelFeatures }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -100,6 +100,22 @@ import type { ChangeEvent } from 'react';
 
 import './style.scss';
 
+/**
+ * How long to keep the loading spinner visible after the user clicks "Remove"
+ * before navigating away. Short enough to feel snappy; long enough that the
+ * busy state registers as intentional feedback rather than a flash.
+ */
+const REMOVE_BUSY_STATE_DELAY_MS = 500;
+
+/**
+ * How long the query-cache guard stays active after a remove/cancel-and-refund
+ * mutation. Server eventual consistency means the deleted purchase can reappear
+ * in API responses for a few seconds; the guard re-strips it each time. After
+ * this TTL the guard unsubscribes and a final `invalidateQueries` fetches the
+ * authoritative state.
+ */
+const REMOVE_CACHE_GUARD_TTL_MS = 15_000;
+
 type TopNoticeArgs = {
 	surveyShown?: boolean;
 	showDomainOptionsStep?: boolean;
@@ -1146,10 +1162,23 @@ function CancelPurchaseInner() {
 			try {
 				const fresh = await queryClient.fetchQuery( userPurchasesQuery() );
 				stillExists = Boolean( fresh?.some( ( p: Purchase ) => p.ID === purchase.ID ) );
-			} catch {
-				// Verification fetch failed; fall through to error path.
+			} catch ( verifyError ) {
+				// Verification fetch also failed — we can't confirm whether the
+				// removal succeeded. Surface the original error so the user knows
+				// something went wrong, rather than silently showing a stale
+				// success snack.
+				recordTracksEvent( 'calypso_purchases_remove_verify_failed', {
+					product_slug: purchase.product_slug,
+					purchase_id: purchase.ID,
+					original_error: error?.message,
+					verify_error: ( verifyError as Error )?.message,
+				} );
 			}
 			if ( ! stillExists ) {
+				recordTracksEvent( 'calypso_purchases_remove_504_recovery', {
+					product_slug: purchase.product_slug,
+					purchase_id: purchase.ID,
+				} );
 				return;
 			}
 			// Mutation genuinely failed — restore the optimistic removal and
@@ -1185,16 +1214,15 @@ function CancelPurchaseInner() {
 			}
 		} );
 
-		// Clean up after 15 seconds — server should have settled.
+		// Clean up after the cache guard TTL — server should have settled.
 		setTimeout( () => {
 			unsubscribeGuard();
 			// Final refetch to get the authoritative server state.
 			queryClient.invalidateQueries( userPurchasesQuery() );
-		}, 15000 );
+		}, REMOVE_CACHE_GUARD_TTL_MS );
 
 		// Keep the busy state visible briefly so the click-to-leave transition
-		// feels like a real action rather than an instant page swap. 500ms is
-		// enough to register the loading feedback without feeling laggy.
+		// feels like a real action rather than an instant page swap.
 		setTimeout( () => {
 			// Optimistically strip the purchase from the cached list so the
 			// destination page renders without it immediately.
@@ -1241,7 +1269,7 @@ function CancelPurchaseInner() {
 					} );
 				} )
 				.catch( handleError );
-		}, 500 );
+		}, REMOVE_BUSY_STATE_DELAY_MS );
 	};
 
 	const submitCancelAndRefundPurchase = ( purchase: Purchase ) => {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -1881,6 +1881,8 @@ function CancelPurchaseInner() {
 									includedDomainPurchase={ includedDomainPurchase }
 									atomicTransfer={ atomicTransfer }
 									selectedDomain={ selectedDomain }
+									site={ site }
+									activeMarketplaceSubscriptions={ activeSubscriptions }
 									state={ state }
 									skipSurvey={ skipSurvey }
 									purchaseCancelFeatures={ purchaseCancelFeatures }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/test/cancellation-main-content.test.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/test/cancellation-main-content.test.tsx
@@ -86,7 +86,7 @@ describe( '<CancellationMainContent />', () => {
 		render(
 			<CancellationMainContent
 				{ ...defaultProps }
-				purchase={ makePurchase( { is_plan: true, is_wpcom_atomic: false } ) }
+				purchase={ makePurchase( { is_plan: true } ) }
 				site={ makeSite( {
 					URL: 'https://mycustomdomain.com',
 					options: {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/test/cancellation-main-content.test.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/test/cancellation-main-content.test.tsx
@@ -67,6 +67,7 @@ const defaultProps = {
 		isLoading: false,
 		domainConfirmationConfirmed: false,
 		showDomainOptionsStep: false,
+		questionOneOrder: [],
 	},
 	onCancelConfirmationStateChange: noop,
 	onDomainConfirmationChange: noop,

--- a/client/dashboard/me/billing-purchases/cancel-purchase/test/cancellation-main-content.test.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/test/cancellation-main-content.test.tsx
@@ -1,0 +1,245 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import config from '@automattic/calypso-config';
+import { screen } from '@testing-library/react';
+import { render } from '../../../../test-utils';
+import CancellationMainContent from '../cancellation-main-content';
+import type { Purchase, Domain, AtomicTransfer, Site } from '@automattic/api-core';
+
+jest.mock( '@automattic/calypso-config', () => {
+	const fn = jest.fn( () => '' );
+	return Object.assign( fn, {
+		__esModule: true,
+		default: fn,
+		isEnabled: jest.fn( () => false ),
+	} );
+} );
+
+const mockedIsEnabled = config.isEnabled as jest.MockedFunction< typeof config.isEnabled >;
+
+function makePurchase( overrides: Partial< Purchase > = {} ): Purchase {
+	return {
+		ID: 123,
+		product_name: 'WordPress.com Business',
+		product_slug: 'business-bundle',
+		is_plan: true,
+		is_domain_registration: false,
+		is_jetpack_plan_or_product: false,
+		is_wpcom_atomic: false,
+		expiry_status: 'auto-renewing',
+		expiry_date: '2027-04-16T00:00:00+00:00',
+		meta: '',
+		domain: 'example.com',
+		product_type: '',
+		blog_id: 1,
+		...overrides,
+	} as Purchase;
+}
+
+function makeSite( overrides: Partial< Site > = {} ): Site {
+	return {
+		ID: 1,
+		slug: 'example.com',
+		name: 'Test Site',
+		URL: 'https://example.com',
+		is_wpcom_atomic: false,
+		options: {
+			admin_url: 'https://example.com/wp-admin/',
+			software_version: '6.5',
+			unmapped_url: 'https://example.wordpress.com',
+			wordads: false,
+		},
+		...overrides,
+	} as Site;
+}
+
+const noop = () => {};
+const defaultProps = {
+	displayVariant: 'cancel' as const,
+	state: {
+		cancelBundledDomain: false,
+		confirmCancelBundledDomain: false,
+		surveyShown: false,
+		customerConfirmedUnderstanding: false,
+		atomicRevertConfirmed: false,
+		isLoading: false,
+		domainConfirmationConfirmed: false,
+		showDomainOptionsStep: false,
+	},
+	onCancelConfirmationStateChange: noop,
+	onDomainConfirmationChange: noop,
+	onCustomerConfirmedUnderstandingChange: noop,
+	onCustomerConfirmedUnderstandingAtomicPlanRevert: noop,
+	onKeepSubscriptionClick: noop,
+};
+
+describe( '<CancellationMainContent />', () => {
+	beforeEach( () => {
+		mockedIsEnabled.mockImplementation( () => false );
+	} );
+
+	test( 'non-primary domain bullets appear when site has custom primary domain and flag is on', () => {
+		mockedIsEnabled.mockImplementation( ( flag ) => flag === 'purchases/split-cancel-remove' );
+
+		render(
+			<CancellationMainContent
+				{ ...defaultProps }
+				purchase={ makePurchase( { is_plan: true, is_wpcom_atomic: false } ) }
+				site={ makeSite( {
+					URL: 'https://mycustomdomain.com',
+					options: {
+						admin_url: 'https://mycustomdomain.com/wp-admin/',
+						software_version: '6.5',
+						unmapped_url: 'https://example.wordpress.com',
+					},
+				} ) }
+			/>
+		);
+
+		expect(
+			screen.getByText( /mycustomdomain\.com will start forwarding to example\.wordpress\.com/ )
+		).toBeVisible();
+		expect(
+			screen.getByText(
+				/example\.wordpress\.com will become the address people see when they visit your site/
+			)
+		).toBeVisible();
+	} );
+
+	test( 'WordAds bullet appears when site has wordads enabled and flag is on', () => {
+		mockedIsEnabled.mockImplementation( ( flag ) => flag === 'purchases/split-cancel-remove' );
+
+		render(
+			<CancellationMainContent
+				{ ...defaultProps }
+				purchase={ makePurchase( { is_plan: true } ) }
+				site={ makeSite( {
+					options: {
+						admin_url: 'https://example.com/wp-admin/',
+						software_version: '6.5',
+						unmapped_url: 'https://example.wordpress.com',
+						wordads: true,
+					},
+				} ) }
+			/>
+		);
+
+		expect(
+			screen.getByText( 'You will become ineligible for the WordAds program.' )
+		).toBeVisible();
+	} );
+
+	test( 'marketplace bullets appear when activeMarketplaceSubscriptions is non-empty', () => {
+		mockedIsEnabled.mockImplementation( ( flag ) => flag === 'purchases/split-cancel-remove' );
+
+		const marketplaceSub = makePurchase( {
+			ID: 456,
+			product_name: 'Yoast SEO Premium',
+			product_slug: 'yoast-seo-premium',
+			is_plan: false,
+		} );
+
+		render(
+			<CancellationMainContent
+				{ ...defaultProps }
+				purchase={ makePurchase( { is_plan: true } ) }
+				activeMarketplaceSubscriptions={ [ marketplaceSub ] }
+			/>
+		);
+
+		expect( screen.getByText( 'Yoast SEO Premium will also be removed.' ) ).toBeVisible();
+	} );
+
+	test( 'domain deletion bullets appear when purchase is a domain registration', () => {
+		mockedIsEnabled.mockImplementation( ( flag ) => flag === 'purchases/split-cancel-remove' );
+
+		render(
+			<CancellationMainContent
+				{ ...defaultProps }
+				purchase={ makePurchase( {
+					is_plan: false,
+					is_domain_registration: true,
+					meta: 'mydomain.com',
+				} ) }
+			/>
+		);
+
+		expect(
+			screen.getByText( /All services connected to mydomain\.com will become unreachable/ )
+		).toBeVisible();
+		expect(
+			screen.getByText( /mydomain\.com will become available for someone else to register/ )
+		).toBeVisible();
+	} );
+
+	test( 'Gravatar bullet appears when selectedDomain is a Gravatar domain', () => {
+		mockedIsEnabled.mockImplementation( ( flag ) => flag === 'purchases/split-cancel-remove' );
+
+		render(
+			<CancellationMainContent
+				{ ...defaultProps }
+				purchase={ makePurchase( {
+					is_plan: false,
+					is_domain_registration: true,
+					meta: 'mygravatar.com',
+				} ) }
+				selectedDomain={ { is_gravatar_domain: true } as Domain }
+			/>
+		);
+
+		expect(
+			screen.getByText( /This domain is provided at no cost for your Gravatar profile/ )
+		).toBeVisible();
+	} );
+
+	test( 'no extra bullets appear when flag is off even with all conditions true', () => {
+		mockedIsEnabled.mockImplementation( () => false );
+
+		const marketplaceSub = makePurchase( {
+			ID: 456,
+			product_name: 'Yoast SEO Premium',
+			product_slug: 'yoast-seo-premium',
+			is_plan: false,
+		} );
+
+		render(
+			<CancellationMainContent
+				{ ...defaultProps }
+				purchase={ makePurchase( { is_plan: true } ) }
+				site={ makeSite( {
+					URL: 'https://mycustomdomain.com',
+					options: {
+						admin_url: 'https://mycustomdomain.com/wp-admin/',
+						software_version: '6.5',
+						unmapped_url: 'https://example.wordpress.com',
+						wordads: true,
+					},
+				} ) }
+				activeMarketplaceSubscriptions={ [ marketplaceSub ] }
+			/>
+		);
+
+		expect( screen.queryByText( /will start forwarding/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /ineligible for the WordAds program/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /will also be removed/ ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'Atomic items still render regardless of flag', () => {
+		mockedIsEnabled.mockImplementation( () => false );
+
+		render(
+			<CancellationMainContent
+				{ ...defaultProps }
+				purchase={ makePurchase( { is_plan: true, domain: 'example.wordpress.com' } ) }
+				atomicTransfer={ { created_at: '2024-01-01' } as AtomicTransfer }
+			/>
+		);
+
+		expect( screen.getByText( 'Set your site to private.' ) ).toBeVisible();
+		expect(
+			screen.getByText( /Remove your installed themes, plugins, and their data/ )
+		).toBeVisible();
+	} );
+} );

--- a/client/dashboard/me/billing-purchases/cancel-purchase/test/cancellation-main-content.test.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/test/cancellation-main-content.test.tsx
@@ -217,7 +217,7 @@ describe( '<CancellationMainContent />', () => {
 					is_domain_registration: true,
 					meta: 'mygravatar.com',
 				} ) }
-				selectedDomain={ { is_gravatar_domain: true } as Domain }
+				selectedDomain={ { is_gravatar_restricted_domain: true } as Domain }
 			/>
 		);
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/test/cancellation-main-content.test.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/test/cancellation-main-content.test.tsx
@@ -96,6 +96,7 @@ describe( '<CancellationMainContent />', () => {
 						unmapped_url: 'https://example.wordpress.com',
 					},
 				} ) }
+				wpcomDomain="example.wordpress.com"
 			/>
 		);
 
@@ -107,6 +108,36 @@ describe( '<CancellationMainContent />', () => {
 				/example\.wordpress\.com will become the address people see when they visit your site/
 			)
 		).toBeVisible();
+	} );
+
+	test( 'non-primary domain bullets prefer wpcomDomain prop over site.options.unmapped_url (.home.blog fix)', () => {
+		mockedIsEnabled.mockImplementation( ( flag ) => flag === 'purchases/split-cancel-remove' );
+
+		// Server-side unmapped_url returns .wordpress.com even when the site's free
+		// domain is .home.blog. The wpcomDomain prop, sourced from the loaded
+		// domain list, is the source of truth.
+		render(
+			<CancellationMainContent
+				{ ...defaultProps }
+				purchase={ makePurchase( { is_plan: true } ) }
+				site={ makeSite( {
+					URL: 'https://mycustomdomain.com',
+					options: {
+						admin_url: 'https://mycustomdomain.com/wp-admin/',
+						software_version: '6.5',
+						unmapped_url: 'https://example.wordpress.com',
+					},
+				} ) }
+				wpcomDomain="example.home.blog"
+			/>
+		);
+
+		expect(
+			screen.getByText( /mycustomdomain\.com will start forwarding to example\.home\.blog/ )
+		).toBeVisible();
+		expect(
+			screen.queryByText( /example\.wordpress\.com will become the address/ )
+		).not.toBeInTheDocument();
 	} );
 
 	test( 'WordAds bullet appears when site has wordads enabled and flag is on', () => {

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -276,8 +276,8 @@ function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
 	const locale = useLocale();
 	const isSplitEnabled = useIsSplitCancelRemoveEnabled();
 
-	// FIXME: render renderWordAdsEligibilityWarningDialog for refund/cancel
-	// FIXME: render renderNonPrimaryDomainWarningDialog for refund/cancel
+	// WordAds and non-primary domain warnings are shown inline on the confirmation screen
+	// under purchases/split-cancel-remove (see cancellation-main-content.tsx).
 	// FIXME: render "Domain transfers can take anywhere from five to seven days to complete." next to cancel button (see domainTransferDuration)
 
 	const goToCancel = ( intent?: 'cancel' | 'remove' ) =>

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -272,8 +272,8 @@ function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
 	const locale = useLocale();
 	const isSplitEnabled = isEnabled( 'purchases/split-cancel-remove' );
 
-	// FIXME: render renderWordAdsEligibilityWarningDialog for refund/cancel
-	// FIXME: render renderNonPrimaryDomainWarningDialog for refund/cancel
+	// WordAds and non-primary domain warnings are shown inline on the confirmation screen
+	// under purchases/split-cancel-remove (see cancellation-main-content.tsx).
 	// FIXME: render "Domain transfers can take anywhere from five to seven days to complete." next to cancel button (see domainTransferDuration)
 
 	const goToCancel = ( intent?: 'cancel' | 'remove' ) =>

--- a/client/me/purchases/cancel-purchase/atomic-revert-changes.tsx
+++ b/client/me/purchases/cancel-purchase/atomic-revert-changes.tsx
@@ -17,6 +17,7 @@ type AtomicRevertChangesProps = {
 	onConfirmationChange: ( isChecked: boolean ) => void;
 	needsAtomicRevertConfirmation: boolean;
 	isLoading?: boolean;
+	additionalChanges?: Array< { slug: string; text: string } >;
 };
 
 const AtomicRevertChanges = ( {
@@ -25,13 +26,16 @@ const AtomicRevertChanges = ( {
 	onConfirmationChange,
 	needsAtomicRevertConfirmation,
 	isLoading = false,
+	additionalChanges,
 }: AtomicRevertChangesProps ) => {
 	const translate = useTranslate();
 	const [ isConfirmed, setIsConfirmed ] = useState( false );
 
-	// Only show for plan cancellations on Atomic sites — removing a plugin or
-	// domain on an Atomic site does not trigger a site revert.
-	if ( ! atomicTransfer?.created_at || ! isPlan( purchase ) ) {
+	const hasAtomicChanges = Boolean( atomicTransfer?.created_at ) && isPlan( purchase );
+	const hasAdditionalChanges = Boolean( additionalChanges?.length );
+
+	// Only show when there are Atomic changes or additional site-dependency warnings.
+	if ( ! hasAtomicChanges && ! hasAdditionalChanges ) {
 		return null;
 	}
 
@@ -63,7 +67,7 @@ const AtomicRevertChanges = ( {
 		return changes;
 	};
 
-	const changes = getChangesList();
+	const changes = hasAtomicChanges ? getChangesList() : [];
 
 	const handleCheckboxChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
 		const checked = event.target.checked;
@@ -83,6 +87,16 @@ const AtomicRevertChanges = ( {
 							icon="notice-outline"
 						/>
 						<span>{ change }</span>
+					</li>
+				) ) }
+				{ additionalChanges?.map( ( change ) => (
+					<li key={ change.slug }>
+						<Gridicon
+							className="cancel-purchase__atomic-revert-changes--item-notice"
+							size={ 24 }
+							icon="notice-outline"
+						/>
+						<span>{ change.text }</span>
 					</li>
 				) ) }
 			</ul>

--- a/client/me/purchases/cancel-purchase/atomic-revert-changes.tsx
+++ b/client/me/purchases/cancel-purchase/atomic-revert-changes.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import { isRefundable } from 'calypso/lib/purchases';
 import type { Purchase } from 'calypso/lib/purchases/types';
+import type { ReactNode } from 'react';
 
 import './style.scss';
 
@@ -17,7 +18,7 @@ type AtomicRevertChangesProps = {
 	onConfirmationChange: ( isChecked: boolean ) => void;
 	needsAtomicRevertConfirmation: boolean;
 	isLoading?: boolean;
-	additionalChanges?: Array< { slug: string; text: string } >;
+	additionalChanges?: Array< { slug: string; text: ReactNode } >;
 };
 
 const AtomicRevertChanges = ( {

--- a/client/me/purchases/cancel-purchase/atomic-revert-changes.tsx
+++ b/client/me/purchases/cancel-purchase/atomic-revert-changes.tsx
@@ -77,7 +77,11 @@ const AtomicRevertChanges = ( {
 
 	return (
 		<div className="cancel-purchase__atomic-revert-changes">
-			<p>{ translate( 'We will also make these changes to your site:' ) }</p>
+			<p>
+				{ isPlan( purchase )
+					? translate( 'We will also make these changes to your site:' )
+					: translate( "Here's what will happen:" ) }
+			</p>
 			<ul className="cancel-purchase__atomic-revert-changes-list">
 				{ changes.map( ( change, index ) => (
 					<li key={ index }>

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -945,8 +945,8 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		const cancellationFeatures = purchaseCancelFeatures?.features ?? [];
 
 		// Build site-dependency warnings shown inline under the flag.
-		const siteWarnings: Array< { slug: string; text: string } > = [];
-		if ( isSplitEnabled ) {
+		const siteWarnings: Array< { slug: string; text: ReactNode } > = [];
+		if ( isSplitCancelRemoveEnabled ) {
 			// Non-primary domain forwarding.
 			if ( isPlan( purchase ) && hasCustomPrimaryDomain && site ) {
 				const primaryDomain = site.domain;
@@ -1357,7 +1357,8 @@ const ConnectedCancelPurchase = connect(
 			isHundredYearDomain: selectedDomain?.isHundredYearDomain,
 			atomicTransfer: getAtomicTransfer( state, purchase?.siteId ),
 			hasSetupAds: Boolean(
-				site?.options?.wordads || isRequestingWordAdsApprovalForSite( state, site )
+				site?.options?.wordads ||
+					( site && isRequestingWordAdsApprovalForSite( state as object, site ) )
 			),
 			hasCustomPrimaryDomain: hasCustomDomain( site ),
 			selectedDomainIsGravatar: Boolean( selectedDomain?.isGravatarRestrictedDomain ),

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -78,7 +78,7 @@ import {
 	getDowngradePlanFromPurchase,
 } from 'calypso/state/purchases/selectors';
 import getAtomicTransfer from 'calypso/state/selectors/get-atomic-transfer';
-import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
+import { getDomainsBySiteId, getWpComDomainBySiteId } from 'calypso/state/sites/domains/selectors';
 import { refreshSitePlans } from 'calypso/state/sites/plans/actions';
 import { isRequestingSites, getSite } from 'calypso/state/sites/selectors';
 import { isRequestingWordAdsApprovalForSite } from 'calypso/state/wordads/approve/selectors';
@@ -200,6 +200,7 @@ export interface CancelPurchaseConnectedProps {
 	site: SiteDetails;
 	hasSetupAds: boolean;
 	hasCustomPrimaryDomain: boolean | null;
+	wpcomDomain: string | null;
 	selectedDomainIsGravatar: boolean;
 }
 
@@ -939,6 +940,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			site,
 			hasSetupAds,
 			hasCustomPrimaryDomain,
+			wpcomDomain,
 			selectedDomainIsGravatar,
 		} = this.props;
 		const { isSplitCancelRemoveEnabled } = this.props;
@@ -950,7 +952,6 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			// Non-primary domain forwarding.
 			if ( isPlan( purchase ) && hasCustomPrimaryDomain && site ) {
 				const primaryDomain = site.domain;
-				const wpcomDomain = site.wpcom_url;
 				if ( primaryDomain && wpcomDomain ) {
 					siteWarnings.push(
 						{
@@ -1361,6 +1362,9 @@ const ConnectedCancelPurchase = connect(
 					( site && isRequestingWordAdsApprovalForSite( state as object, site ) )
 			),
 			hasCustomPrimaryDomain: hasCustomDomain( site ),
+			// site.wpcom_url is incorrect for .home.blog sites — read the actual WPCOM
+			// domain from the domain list instead.
+			wpcomDomain: getWpComDomainBySiteId( state as object, purchase?.siteId )?.name ?? null,
 			selectedDomainIsGravatar: Boolean( selectedDomain?.isGravatarRestrictedDomain ),
 		};
 	},

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -55,6 +55,7 @@ import {
 	extendPurchaseWithFreeMonth,
 } from 'calypso/lib/purchases/actions';
 import { getMutationFlowType, getPurchaseCancellationFlowType } from 'calypso/lib/purchases/utils';
+import { hasCustomDomain } from 'calypso/lib/site/utils';
 import CancelPurchaseLoadingPlaceholder from 'calypso/me/purchases/cancel-purchase/loading-placeholder';
 import { classifyPurchaseForCopy } from 'calypso/me/purchases/manage-purchase/classify-purchase-for-copy';
 import { managePurchase, purchasesRoot } from 'calypso/me/purchases/paths';
@@ -80,6 +81,7 @@ import getAtomicTransfer from 'calypso/state/selectors/get-atomic-transfer';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { refreshSitePlans } from 'calypso/state/sites/plans/actions';
 import { isRequestingSites, getSite } from 'calypso/state/sites/selectors';
+import { isRequestingWordAdsApprovalForSite } from 'calypso/state/wordads/approve/selectors';
 import AtomicRevertChanges from './atomic-revert-changes';
 import CancelPurchaseButton from './button';
 import CancelPurchaseDomainOptions, { willShowDomainOptionsRadioButtons } from './domain-options';
@@ -196,6 +198,9 @@ export interface CancelPurchaseConnectedProps {
 	purchase: Purchases.Purchase;
 	purchases: Purchases.Purchase[];
 	site: SiteDetails;
+	hasSetupAds: boolean;
+	hasCustomPrimaryDomain: boolean | null;
+	selectedDomainIsGravatar: boolean;
 }
 
 export interface CancelPurchaseProps {
@@ -931,9 +936,90 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			intent,
 			purchaseCancelFeatures,
 			translate,
+			site,
+			hasSetupAds,
+			hasCustomPrimaryDomain,
+			selectedDomainIsGravatar,
 		} = this.props;
 		const { isSplitCancelRemoveEnabled } = this.props;
 		const cancellationFeatures = purchaseCancelFeatures?.features ?? [];
+
+		// Build site-dependency warnings shown inline under the flag.
+		const siteWarnings: Array< { slug: string; text: string } > = [];
+		if ( isSplitEnabled ) {
+			// Non-primary domain forwarding.
+			if ( isPlan( purchase ) && hasCustomPrimaryDomain && site ) {
+				const primaryDomain = site.domain;
+				const wpcomDomain = site.wpcom_url;
+				if ( primaryDomain && wpcomDomain ) {
+					siteWarnings.push(
+						{
+							slug: 'domainForwarding',
+							text: translate( '%(primaryDomain)s will start forwarding to %(wpcomDomain)s.', {
+								args: { primaryDomain, wpcomDomain },
+							} ),
+						},
+						{
+							slug: 'domainVisible',
+							text: translate(
+								'%(wpcomDomain)s will become the address people see when they visit your site.',
+								{ args: { wpcomDomain } }
+							),
+						}
+					);
+				}
+			}
+
+			// WordAds ineligibility.
+			if ( isPlan( purchase ) && hasSetupAds ) {
+				siteWarnings.push( {
+					slug: 'wordAdsIneligible',
+					text: translate( 'You will become ineligible for the WordAds program.' ),
+				} );
+			}
+
+			// Marketplace subscription cascade.
+			const activeMarketplaceSubs = this.getActiveMarketplaceSubscriptions();
+			if ( activeMarketplaceSubs.length > 0 ) {
+				for ( const sub of activeMarketplaceSubs ) {
+					siteWarnings.push( {
+						slug: `marketplace-${ sub.id }`,
+						text: translate( '%(productName)s will also be removed.', {
+							args: { productName: sub.productName },
+						} ),
+					} );
+				}
+			}
+
+			// Domain deletion consequences.
+			if ( isDomainRegistrationPurchase ) {
+				const domainName = getName( purchase );
+				siteWarnings.push(
+					{
+						slug: 'domainServicesUnreachable',
+						text: translate(
+							'All services connected to %(domain)s will become unreachable, including email and website.',
+							{ args: { domain: domainName } }
+						),
+					},
+					{
+						slug: 'domainAvailable',
+						text: translate( '%(domain)s will become available for someone else to register.', {
+							args: { domain: domainName },
+						} ),
+					}
+				);
+
+				if ( selectedDomainIsGravatar ) {
+					siteWarnings.push( {
+						slug: 'gravatarDomain',
+						text: translate(
+							'This domain is provided at no cost for your Gravatar profile. If you delete it, you will have to pay full price for another.'
+						),
+					} );
+				}
+			}
+		}
 
 		const displayVariant: 'cancel' | 'remove' = intent === 'remove' ? 'remove' : 'cancel';
 		const checkboxLabel = getCheckboxLabel();
@@ -980,6 +1066,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 							! isRefundable( purchase )
 					) }
 					isLoading={ this.state.isLoading }
+					additionalChanges={ siteWarnings }
 				/>
 
 				<div className="cancel-purchase__support">
@@ -1253,6 +1340,8 @@ const ConnectedCancelPurchase = connect(
 		const selectedDomain =
 			domains && selectedDomainName && getSelectedDomain( { domains, selectedDomainName } );
 
+		const site = getSite( state, purchase ? purchase.siteId : null );
+
 		return {
 			hasLoadedSites: ! isRequestingSites( state ),
 			hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
@@ -1264,9 +1353,14 @@ const ConnectedCancelPurchase = connect(
 			purchases,
 			productsList,
 			includedDomainPurchase: getIncludedDomainPurchase( state, purchase ),
-			site: getSite( state, purchase ? purchase.siteId : null ),
+			site,
 			isHundredYearDomain: selectedDomain?.isHundredYearDomain,
 			atomicTransfer: getAtomicTransfer( state, purchase?.siteId ),
+			hasSetupAds: Boolean(
+				site?.options?.wordads || isRequestingWordAdsApprovalForSite( state, site )
+			),
+			hasCustomPrimaryDomain: hasCustomDomain( site ),
+			selectedDomainIsGravatar: Boolean( selectedDomain?.isGravatarRestrictedDomain ),
 		};
 	},
 	{

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -50,6 +50,7 @@ import {
 	removePurchaseAsync,
 } from 'calypso/lib/purchases/actions';
 import { getMutationFlowType, getPurchaseCancellationFlowType } from 'calypso/lib/purchases/utils';
+import { hasCustomDomain } from 'calypso/lib/site/utils';
 import CancelPurchaseLoadingPlaceholder from 'calypso/me/purchases/cancel-purchase/loading-placeholder';
 import { managePurchase, purchasesRoot } from 'calypso/me/purchases/paths';
 import PurchaseSiteHeader from 'calypso/me/purchases/purchases-site/header';
@@ -74,6 +75,7 @@ import getAtomicTransfer from 'calypso/state/selectors/get-atomic-transfer';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { refreshSitePlans } from 'calypso/state/sites/plans/actions';
 import { isRequestingSites, getSite } from 'calypso/state/sites/selectors';
+import { isRequestingWordAdsApprovalForSite } from 'calypso/state/wordads/approve/selectors';
 import AtomicRevertChanges from './atomic-revert-changes';
 import CancelPurchaseButton from './button';
 import CancelPurchaseDomainOptions, { willShowDomainOptionsRadioButtons } from './domain-options';
@@ -141,6 +143,9 @@ export interface CancelPurchaseConnectedProps {
 	purchase: Purchases.Purchase;
 	purchases: Purchases.Purchase[];
 	site: SiteDetails;
+	hasSetupAds: boolean;
+	hasCustomPrimaryDomain: boolean | null;
+	selectedDomainIsGravatar: boolean;
 }
 
 export interface CancelPurchaseProps {
@@ -937,9 +942,90 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			isDomainRegistrationPurchase,
 			intent,
 			translate,
+			site,
+			hasSetupAds,
+			hasCustomPrimaryDomain,
+			selectedDomainIsGravatar,
 		} = this.props;
 		const isSplitEnabled = config.isEnabled( 'purchases/split-cancel-remove' );
 		const cancellationFeatures = this.state.serverCancellationFeatures ?? [];
+
+		// Build site-dependency warnings shown inline under the flag.
+		const siteWarnings: Array< { slug: string; text: string } > = [];
+		if ( isSplitEnabled ) {
+			// Non-primary domain forwarding.
+			if ( isPlan( purchase ) && hasCustomPrimaryDomain && site ) {
+				const primaryDomain = site.domain;
+				const wpcomDomain = site.wpcom_url;
+				if ( primaryDomain && wpcomDomain ) {
+					siteWarnings.push(
+						{
+							slug: 'domainForwarding',
+							text: translate( '%(primaryDomain)s will start forwarding to %(wpcomDomain)s.', {
+								args: { primaryDomain, wpcomDomain },
+							} ),
+						},
+						{
+							slug: 'domainVisible',
+							text: translate(
+								'%(wpcomDomain)s will become the address people see when they visit your site.',
+								{ args: { wpcomDomain } }
+							),
+						}
+					);
+				}
+			}
+
+			// WordAds ineligibility.
+			if ( isPlan( purchase ) && hasSetupAds ) {
+				siteWarnings.push( {
+					slug: 'wordAdsIneligible',
+					text: translate( 'You will become ineligible for the WordAds program.' ),
+				} );
+			}
+
+			// Marketplace subscription cascade.
+			const activeMarketplaceSubs = this.getActiveMarketplaceSubscriptions();
+			if ( activeMarketplaceSubs.length > 0 ) {
+				for ( const sub of activeMarketplaceSubs ) {
+					siteWarnings.push( {
+						slug: `marketplace-${ sub.id }`,
+						text: translate( '%(productName)s will also be removed.', {
+							args: { productName: sub.productName },
+						} ),
+					} );
+				}
+			}
+
+			// Domain deletion consequences.
+			if ( isDomainRegistrationPurchase ) {
+				const domainName = getName( purchase );
+				siteWarnings.push(
+					{
+						slug: 'domainServicesUnreachable',
+						text: translate(
+							'All services connected to %(domain)s will become unreachable, including email and website.',
+							{ args: { domain: domainName } }
+						),
+					},
+					{
+						slug: 'domainAvailable',
+						text: translate( '%(domain)s will become available for someone else to register.', {
+							args: { domain: domainName },
+						} ),
+					}
+				);
+
+				if ( selectedDomainIsGravatar ) {
+					siteWarnings.push( {
+						slug: 'gravatarDomain',
+						text: translate(
+							'This domain is provided at no cost for your Gravatar profile. If you delete it, you will have to pay full price for another.'
+						),
+					} );
+				}
+			}
+		}
 
 		const displayVariant: 'cancel' | 'remove' = intent === 'remove' ? 'remove' : 'cancel';
 		const checkboxLabel = getCheckboxLabel();
@@ -986,6 +1072,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 							! isRefundable( purchase )
 					) }
 					isLoading={ this.state.isLoading }
+					additionalChanges={ siteWarnings }
 				/>
 
 				<div className="cancel-purchase__support">
@@ -1274,6 +1361,8 @@ const ConnectedCancelPurchase = connect(
 		const selectedDomain =
 			domains && selectedDomainName && getSelectedDomain( { domains, selectedDomainName } );
 
+		const site = getSite( state, purchase ? purchase.siteId : null );
+
 		return {
 			hasLoadedSites: ! isRequestingSites( state ),
 			hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
@@ -1285,12 +1374,17 @@ const ConnectedCancelPurchase = connect(
 			purchases,
 			productsList,
 			includedDomainPurchase: getIncludedDomainPurchase( state, purchase ),
-			site: getSite( state, purchase ? purchase.siteId : null ),
+			site,
 			isHundredYearDomain: selectedDomain?.isHundredYearDomain,
 			atomicTransfer: getAtomicTransfer( state, purchase?.siteId ),
 			hasCompletedCancelPurchaseSurvey: purchase
 				? !! getPreference( state, getCancelPurchaseSurveyCompletedPreferenceKey( purchase.id ) )
 				: false,
+			hasSetupAds: Boolean(
+				site?.options?.wordads || isRequestingWordAdsApprovalForSite( state, site )
+			),
+			hasCustomPrimaryDomain: hasCustomDomain( site ),
+			selectedDomainIsGravatar: Boolean( selectedDomain?.isGravatarRestrictedDomain ),
 		};
 	},
 	{

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -1086,7 +1086,7 @@ class ManagePurchase extends Component<
 				this.showWordAdsEligibilityWarningDialog( link );
 			}
 
-			if ( this.shouldShowNonPrimaryDomainWarning() ) {
+			if ( ! isSplitEnabled && this.shouldShowNonPrimaryDomainWarning() ) {
 				event.preventDefault();
 				this.showNonPrimaryDomainWarningDialog( link );
 			}

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -1076,7 +1076,7 @@ class ManagePurchase extends Component<
 				this.showWordAdsEligibilityWarningDialog( link );
 			}
 
-			if ( this.shouldShowNonPrimaryDomainWarning() ) {
+			if ( ! isSplitEnabled && this.shouldShowNonPrimaryDomainWarning() ) {
 				event.preventDefault();
 				this.showNonPrimaryDomainWarningDialog( link );
 			}


### PR DESCRIPTION
Depends on #110163.
Fixes: https://linear.app/a8c/issue/RSM-1250

## Summary

Under `purchases/split-cancel-remove`, the cancel/remove confirmation screen now shows contextual amber-icon warning bullets for each applicable scenario — replacing the pre-navigation modals that interrupted users before they could reach the confirmation screen.

- **Non-primary domain forwarding** — when cancelling a plan on a site with a custom primary domain: "{domain} will start forwarding to {wpcom-domain}" + "{wpcom-domain} will become the address people see"
- **WordAds ineligibility** — when cancelling a plan on a site enrolled in WordAds
- **Marketplace subscription cascade** — one bullet per active marketplace subscription that will also be removed
- **Domain deletion consequences** — email/website unreachable, registration available, Gravatar conditional
- **Non-primary domain modal skipped** — gated behind `!isSplitEnabled` in manage-purchase, matching the existing WordAds dialog gate

Both surfaces (dashboard + legacy). Flag-off path untouched.

| Before | After |
| -- | -- |
| <img width="2048" height="1331" alt="image" src="https://github.com/user-attachments/assets/c108ce47-12c8-4a6a-bbc8-68dc40520867" /> | <img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/8268c66d-e552-4327-a17d-eee6b3b0900c" /> |
| <img width="2048" height="1188" alt="image" src="https://github.com/user-attachments/assets/c48a34c1-043c-454d-9ddd-9ce6d8b1301b" /> | <img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/8268c66d-e552-4327-a17d-eee6b3b0900c" /> |




## Test plan

- [ ] Enable `purchases/split-cancel-remove` feature flag
- [ ] **Dashboard**: Navigate to a plan purchase with a custom primary domain → click Cancel → verify domain forwarding bullets appear on the confirmation screen
- [ ] **Dashboard**: Navigate to a plan purchase on a WordAds-enrolled site → verify WordAds ineligibility bullet appears
- [ ] **Dashboard**: Navigate to a plan with active marketplace subscriptions → verify one bullet per subscription
- [ ] **Dashboard**: Navigate to a domain registration purchase → verify domain deletion bullets appear (+ Gravatar conditional if applicable)
- [ ] **Legacy**: Same scenarios on calypso.localhost:3000
- [ ] **Legacy**: Verify the non-primary domain modal no longer appears before navigation under the flag
- [ ] **Flag off**: Verify no extra bullets appear, non-primary domain modal still works
- [ ] Run `yarn test-client --findRelatedTests` on touched files — 131 tests pass across 18 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)