### PR TITLE
CI: refactor AI PR-review workflows + add @claude /review

### DIFF
--- a/.github/prompts/general-pr-review.md
+++ b/.github/prompts/general-pr-review.md
@@ -2,51 +2,69 @@
 
 ## Primary Objective
 
-Review the PR against Calypso's authoritative guidelines:
+Review the PR by reading the relevant `AGENTS.md` files AND applying the review-focus axes below. The repo has 19 `AGENTS.md` files. Always read at minimum:
 
-- @AGENTS.md (top-level: architecture, deprecations, PR hygiene)
-- @client/AGENTS.md (client conventions: i18n, components, TypeScript, CSS, testing)
-- Any AGENTS.md or README in the paths the diff touches
+- `AGENTS.md` (top-level: architecture, deprecations, PR hygiene, shared infra)
+- `client/AGENTS.md` (i18n, components, TypeScript, CSS, testing conventions)
+- The nearest `AGENTS.md` for each non-trivial path the diff touches (e.g., `client/reader/AGENTS.md`, `packages/help-center/AGENTS.md`).
 
-If the diff touches shared infrastructure (`client/state`, `client/components`, `client/lib`, `client/layout`, or `packages/**`), call out cross-client blast radius. Calypso, Jetpack Cloud, and A4A all consume these.
+If other shared packages or docs are referenced in the PR description, treat them as additional guidance but prioritize the AGENTS.md files above.
 
-## Review focus (when applicable to the diff)
+If the diff touches paths AGENTS.md identifies as shared infrastructure, call out cross-client blast radius (Calypso, Jetpack Cloud, A4A consume them).
 
-1. **Backwards compatibility.** Exported function/component prop signatures, public hook contracts (`use*`), Redux action/selector shapes, REST endpoint shapes, persisted state schema. Breaking changes must be intentional and called out.
+## Non-goals
 
-2. **Auth and authz.** Capability checks before admin UI, route guards, `canCurrentUser` selectors, CSRF/nonce headers on mutating fetches, IDOR via author-controlled IDs.
+- Do NOT run tests, lint, or typecheck.
+- Do NOT validate PR-description hygiene.
+- Do NOT try to list recent PRs when reviewing - you do not have permission to do so.
+- Do NOT comment on a line if a Copilot or earlier review already covers the same issue within 5 lines.
 
-3. **Web-app security.** `dangerouslySetInnerHTML`, `href={userUrl}` with untrusted protocols (`javascript:`, `data:`), event-handler interpolation, `target="_blank"` without `rel="noopener"`.
+## Review focus
 
-4. **Injection / XSS.** Untrusted input in templates, log lines, shell calls, fetch URLs. Validate after decode/canonicalize, not before.
+For each axis, only flag when the trigger pattern matches the diff. Provide a fix suggestion in each comment.
 
-5. **Type safety.** Unjustified `any` or `as`, loose `==` on user data, `Object.assign` or spread of attacker-controlled JSON (prototype pollution via `__proto__`).
+**1. Backwards compatibility.** Flag when the diff changes an exported function/component prop signature, public hook contract (`use*`), Redux action/selector shape, REST endpoint shape, or persisted state schema.
+Message: `Breaking change to public API at <symbol>. <Specifics>. Confirm intentional and called out in PR description.`
 
-6. **Resource and DoS.** Unanchored regexes on user input (ReDoS), unbounded arrays/strings from API responses, missing `useMemo`/`useCallback`, network waterfalls, missing `select` memoization in `@wordpress/data`.
+**2. Auth and authz.** Flag missing capability checks, route guards, or CSRF/nonce headers; IDOR on new path-param routes; mass assignment via spread of form/state into mutating fetches.
+Message: `Missing <capability check | guard | CSRF header | authz check> at <location>. <Specific fix>.`
 
-7. **Information disclosure.** Tokens or PII in `console.log`, stack traces in client-visible error responses, analytics payloads.
+**3. Web-app security.** Flag `dangerouslySetInnerHTML` without sanitizer; `href={userUrl}` with attacker-controlled URL or `javascript:`/`data:` protocols; event-handler interpolation; open redirect via `router.push(req.query.next)` or similar; `postMessage` with `'*'` or no origin gate on receiver; `target="_blank"` without `rel="noopener"`.
+Message: `<Specific risk> at <location>. <Specific fix>.`
 
-8. **Supply chain.** Only when the diff touches `.github/workflows/`: `pull_request_target` + PR-branch checkout, `${{ ... }}` interpolation in `run:` with attacker-controllable values, unpinned third-party actions.
+**4. Injection / XSS.** Flag untrusted input flowing into HTML, template, `eval`, `Function`, shell calls (in scripts), or fetch URLs concatenated from input.
+Message: `Untrusted input from <source> flows into <sink>. Validate after decode/canonicalize.`
 
-9. **Regression prevention.** If the diff touches a path that has prior security fixes (per `git log --oneline` on those files), flag for extra scrutiny.
+**5. Type safety / prototype pollution.** Flag prototype pollution via `Object.assign`, recursive merge, or lodash `_.merge` on attacker-controlled JSON; `as` casts on `JSON.parse` or fetched JSON; loose `==` on user data; unjustified `any` (see `client/AGENTS.md`).
+Message: `<Specific risk> at <location>. <Specific fix>.`
 
-10. **Architecture awareness.** Calypso has two architectures: classic (Redux + page.js, mostly under `client/my-sites/`, deprecated) and Dashboard (TanStack Query + TanStack Router, under `client/dashboard/`). Flag patterns from one bleeding into the other; question new feature work in the deprecated half.
+**6. Resource and DoS.** Flag ReDoS via unanchored regex on user input; unbounded loops over API responses; client-side state growth from streams/polling without bounds; missing `useMemo`/`useCallback` causing re-renders or network waterfalls.
+Message: `<Specific risk> at <location>. <Specific fix>.`
 
-## Method
+**7. Information disclosure.** Flag tokens or PII in `console.log`, Sentry, or analytics payloads; stack traces in client-visible error responses. Calypso-internal IDs (`blog_id`, `studio_site_id`) are not PII.
+Message: `<Field> in <log | Sentry | analytics> may leak <category>.`
 
-- Read prior Copilot/human/bot comments before posting your own. Validate concerns by tracing code, not just the diff.
-- Use `mcp__github_inline_comment__create_inline_comment` for line-specific feedback.
-- DO NOT post a comment if Copilot or an earlier review already covers the same line within 5 lines (dedupe).
-- For diffs over ~2000 lines: focus on security-sensitive code, public APIs, and shared infra. Skip cosmetic or generated files.
-- Skip entirely: `node_modules/**`, `build/**`, `dist/**`, `**/*.min.*`, `**/*.map`, snapshot files, generated types, `*.po`/`*.mo`.
-- Don't nitpick minor style unless it violates a documented guideline.
-- Before suggesting alternative implementations, check if the PR description already explains the choice.
-- If the diff is straightforward, review it directly. Don't over-explore.
+**8. Supply chain.** Only when the diff touches `.github/workflows/`. Flag `pull_request_target` + PR-branch checkout, `${{ ... }}` interpolation in `run:` with attacker-controllable values, unpinned third-party actions.
+Message: `<Specific risk> at <location>. <Specific fix>.`
 
-## Output
+**9. Architecture awareness.** Flag when the diff imports `page.js` inside `client/dashboard/`, uses `useDispatch` from `react-redux` inside `client/dashboard/`, or adds new feature work to `client/my-sites/` (deprecated per AGENTS.md).
+Message: `<Pattern> bleeds <classic | dashboard> into <other>. <Suggested approach>.`
 
-- Be concise. Only post if there are real issues.
+**10. Route deletion → redirect.** Flag when the diff removes a `<Route>` declaration or a route handler with a previously-shipped path.
+Message: `Route <path> deleted. Add a redirect for users with bookmarks if the route had been live.`
+
+**11. Shared-package consumer audit.** Flag when the diff changes a public export in `packages/**`. Grep `apps/**` and `client/**` for imports.
+Message: `<package> is consumed by <list apps>. Verify the change is compatible.`
+
+## Output Format
+
+- Be concise. Only comment if a trigger matched.
+- Each comment shape: `**Issue:** <one-line problem>` then `**Suggestion:** <fix>`.
+- DO NOT comment on lines that are not related to the guidelines listed above.
+- Don't nitpick minor style issues unless they violate the documented guidelines.
+- Cite the source documentation as a clickable link when AGENTS.md or a project README covers the issue (`https://github.com/Automattic/wp-calypso/blob/trunk/<path>`); blockquote the relevant sentence. For security categories not in repo docs, name the axis from this prompt and add a one-line rationale; do not fabricate doc URLs.
 - DO NOT use checkboxes, todo lists, or progress indicators.
-- Each comment shape: `**Issue:** <one-line problem>` then `**Suggestion:** <fix>`. Cite the source documentation as a clickable link `https://github.com/Automattic/wp-calypso/blob/trunk/<path>` and blockquote the specific sentence(s) that justify the comment.
-- If you reviewed prior concerns, classify them: RESOLVED / STILL OUTSTANDING / NEW. Post inline only for NEW; mention RESOLVED/OUTSTANDING in a single summary comment.
-- If everything looks good, post a brief summary saying so. Don't silently skip.
+- If you read prior bot/human comments, post a single summary comment classifying them: `RESOLVED:` / `STILL OUTSTANDING:` / `NEW:`. Post inline only for NEW.
+- If no triggers matched, post: `AI Code Review: no issues found.`
+
+Remember: Calypso is large and shared. Prioritize correctness, security, and cross-client blast radius over style. Flag intent, not taste.

--- a/.github/prompts/general-pr-review.md
+++ b/.github/prompts/general-pr-review.md
@@ -1,0 +1,29 @@
+# Code Review Instructions (General)
+
+## Primary Objective
+
+Review the PR against Calypso's general guidelines in the following documentation files:
+
+- @AGENTS.md
+- @client/AGENTS.md
+
+If the PR changes shared code (e.g. `client/state`, `client/components`), consider impact across clients and call it out.
+
+## Method
+
+- Do NOT try to list recent PRs when reviewing - you do not have permission to do so.
+- Use `mcp__github_inline_comment__create_inline_comment` to post feedback directly on specific lines.
+- Provide fix suggestions in each comment.
+- Don't nitpick minor style issues unless they violate the documented guidelines.
+- Before suggesting alternative implementations, check if the PR description already addresses why that approach wasn't used.
+
+## Output Format
+
+- Be concise.
+- Do NOT use checkboxes, todo lists, or progress indicators.
+- Only comment if there are issues worth addressing.
+- DO NOT comment on lines that are not related to the guidelines listed above.
+- For each comment, cite the source documentation file as a clickable link in the format of `https://github.com/Automattic/wp-calypso/blob/trunk/<path to the file relative to the project>`.
+- For each comment, quote the specific sentence(s) from the cited source that justifies the comment, in a blockquote.
+
+Remember: Calypso prioritizes performance, accessibility, and maintainability while leveraging modern React patterns.

--- a/.github/prompts/general-pr-review.md
+++ b/.github/prompts/general-pr-review.md
@@ -2,28 +2,51 @@
 
 ## Primary Objective
 
-Review the PR against Calypso's general guidelines in the following documentation files:
+Review the PR against Calypso's authoritative guidelines:
 
-- @AGENTS.md
-- @client/AGENTS.md
+- @AGENTS.md (top-level: architecture, deprecations, PR hygiene)
+- @client/AGENTS.md (client conventions: i18n, components, TypeScript, CSS, testing)
+- Any AGENTS.md or README in the paths the diff touches
 
-If the PR changes shared code (e.g. `client/state`, `client/components`), consider impact across clients and call it out.
+If the diff touches shared infrastructure (`client/state`, `client/components`, `client/lib`, `client/layout`, or `packages/**`), call out cross-client blast radius. Calypso, Jetpack Cloud, and A4A all consume these.
+
+## Review focus (when applicable to the diff)
+
+1. **Backwards compatibility.** Exported function/component prop signatures, public hook contracts (`use*`), Redux action/selector shapes, REST endpoint shapes, persisted state schema. Breaking changes must be intentional and called out.
+
+2. **Auth and authz.** Capability checks before admin UI, route guards, `canCurrentUser` selectors, CSRF/nonce headers on mutating fetches, IDOR via author-controlled IDs.
+
+3. **Web-app security.** `dangerouslySetInnerHTML`, `href={userUrl}` with untrusted protocols (`javascript:`, `data:`), event-handler interpolation, `target="_blank"` without `rel="noopener"`.
+
+4. **Injection / XSS.** Untrusted input in templates, log lines, shell calls, fetch URLs. Validate after decode/canonicalize, not before.
+
+5. **Type safety.** Unjustified `any` or `as`, loose `==` on user data, `Object.assign` or spread of attacker-controlled JSON (prototype pollution via `__proto__`).
+
+6. **Resource and DoS.** Unanchored regexes on user input (ReDoS), unbounded arrays/strings from API responses, missing `useMemo`/`useCallback`, network waterfalls, missing `select` memoization in `@wordpress/data`.
+
+7. **Information disclosure.** Tokens or PII in `console.log`, stack traces in client-visible error responses, analytics payloads.
+
+8. **Supply chain.** Only when the diff touches `.github/workflows/`: `pull_request_target` + PR-branch checkout, `${{ ... }}` interpolation in `run:` with attacker-controllable values, unpinned third-party actions.
+
+9. **Regression prevention.** If the diff touches a path that has prior security fixes (per `git log --oneline` on those files), flag for extra scrutiny.
+
+10. **Architecture awareness.** Calypso has two architectures: classic (Redux + page.js, mostly under `client/my-sites/`, deprecated) and Dashboard (TanStack Query + TanStack Router, under `client/dashboard/`). Flag patterns from one bleeding into the other; question new feature work in the deprecated half.
 
 ## Method
 
-- Do NOT try to list recent PRs when reviewing - you do not have permission to do so.
-- Use `mcp__github_inline_comment__create_inline_comment` to post feedback directly on specific lines.
-- Provide fix suggestions in each comment.
-- Don't nitpick minor style issues unless they violate the documented guidelines.
-- Before suggesting alternative implementations, check if the PR description already addresses why that approach wasn't used.
+- Read prior Copilot/human/bot comments before posting your own. Validate concerns by tracing code, not just the diff.
+- Use `mcp__github_inline_comment__create_inline_comment` for line-specific feedback.
+- DO NOT post a comment if Copilot or an earlier review already covers the same line within 5 lines (dedupe).
+- For diffs over ~2000 lines: focus on security-sensitive code, public APIs, and shared infra. Skip cosmetic or generated files.
+- Skip entirely: `node_modules/**`, `build/**`, `dist/**`, `**/*.min.*`, `**/*.map`, snapshot files, generated types, `*.po`/`*.mo`.
+- Don't nitpick minor style unless it violates a documented guideline.
+- Before suggesting alternative implementations, check if the PR description already explains the choice.
+- If the diff is straightforward, review it directly. Don't over-explore.
 
-## Output Format
+## Output
 
-- Be concise.
-- Do NOT use checkboxes, todo lists, or progress indicators.
-- Only comment if there are issues worth addressing.
-- DO NOT comment on lines that are not related to the guidelines listed above.
-- For each comment, cite the source documentation file as a clickable link in the format of `https://github.com/Automattic/wp-calypso/blob/trunk/<path to the file relative to the project>`.
-- For each comment, quote the specific sentence(s) from the cited source that justifies the comment, in a blockquote.
-
-Remember: Calypso prioritizes performance, accessibility, and maintainability while leveraging modern React patterns.
+- Be concise. Only post if there are real issues.
+- DO NOT use checkboxes, todo lists, or progress indicators.
+- Each comment shape: `**Issue:** <one-line problem>` then `**Suggestion:** <fix>`. Cite the source documentation as a clickable link `https://github.com/Automattic/wp-calypso/blob/trunk/<path>` and blockquote the specific sentence(s) that justify the comment.
+- If you reviewed prior concerns, classify them: RESOLVED / STILL OUTSTANDING / NEW. Post inline only for NEW; mention RESOLVED/OUTSTANDING in a single summary comment.
+- If everything looks good, post a brief summary saying so. Don't silently skip.

--- a/.github/prompts/general-pr-review.md
+++ b/.github/prompts/general-pr-review.md
@@ -2,7 +2,7 @@
 
 ## Primary Objective
 
-Review the PR by reading the relevant `AGENTS.md` files AND applying the review-focus axes below. The repo has 19 `AGENTS.md` files. Always read at minimum:
+Review the PR by reading the relevant `AGENTS.md` files AND applying the review-focus axes below. Always read at minimum:
 
 - `AGENTS.md` (top-level: architecture, deprecations, PR hygiene, shared infra)
 - `client/AGENTS.md` (i18n, components, TypeScript, CSS, testing conventions)

--- a/.github/workflows/a4a-pr-review.yml
+++ b/.github/workflows/a4a-pr-review.yml
@@ -23,22 +23,14 @@ permissions:
 
 jobs:
   review:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    if: github.event.pull_request.draft == false
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Run A4A PR Review
-        uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          prompt: |
-            Read and follow the instructions in .github/prompts/a4a-pr-review.md
-
-            Use `mcp__github_inline_comment__create_inline_comment` for review.
-          claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(git show:*),Bash(git diff:*),Bash(git ls-files:*),Bash(git grep:*),Bash(rg *)"
+    if: |
+      github.event.pull_request.draft == false &&
+      (
+        github.event.pull_request.author_association == 'MEMBER' ||
+        github.event.pull_request.author_association == 'OWNER'
+      )
+    uses: ./.github/workflows/pr-review.yml
+    with:
+      prompt_path: .github/prompts/a4a-pr-review.md
+    secrets:
+      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/a4a-pr-review.yml
+++ b/.github/workflows/a4a-pr-review.yml
@@ -7,7 +7,7 @@ on:
         description: 'PR number to review'
         required: true
 
-  pull_request:
+  pull_request_target:
     types: [opened, ready_for_review]
     paths:
       - 'client/a8c-for-agencies/**'

--- a/.github/workflows/dashboard-pr-review.yml
+++ b/.github/workflows/dashboard-pr-review.yml
@@ -23,21 +23,14 @@ permissions:
 
 jobs:
   review:
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Run Dashboard PR Review
-        uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          prompt: |
-            Read and follow the instructions in .github/prompts/dashboard-pr-review.md
-
-            Use `mcp__github_inline_comment__create_inline_comment` for review.
-          claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(git show:*),Bash(git diff:*),Bash(git ls-files:*),Bash(git grep:*),Bash(rg *)"
+    if: |
+      github.event.pull_request.draft == false &&
+      (
+        github.event.pull_request.author_association == 'MEMBER' ||
+        github.event.pull_request.author_association == 'OWNER'
+      )
+    uses: ./.github/workflows/pr-review.yml
+    with:
+      prompt_path: .github/prompts/dashboard-pr-review.md
+    secrets:
+      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/dashboard-pr-review.yml
+++ b/.github/workflows/dashboard-pr-review.yml
@@ -7,7 +7,7 @@ on:
         description: 'PR number to review'
         required: true
 
-  pull_request:
+  pull_request_target:
     types: [opened, ready_for_review]
     paths:
       - 'client/dashboard/**'

--- a/.github/workflows/pr-review-on-ping.yml
+++ b/.github/workflows/pr-review-on-ping.yml
@@ -1,0 +1,33 @@
+name: PR Review (on @claude ping)
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  review:
+    if: |
+      (
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.review.author_association == 'MEMBER' ||
+        github.event.review.author_association == 'OWNER'
+      ) && github.event.sender.login != 'matticbot' && (
+        (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+      )
+    uses: ./.github/workflows/pr-review.yml
+    with:
+      prompt_path: .github/prompts/general-pr-review.md
+    secrets:
+      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/pr-review-on-ping.yml
+++ b/.github/workflows/pr-review-on-ping.yml
@@ -1,4 +1,4 @@
-name: PR Review (on @claude ping)
+name: PR Review (on @claude /review)
 
 on:
   issue_comment:
@@ -14,7 +14,7 @@ permissions:
   id-token: write
 
 jobs:
-  review:
+  detect:
     if: |
       (
         github.event.comment.author_association == 'MEMBER' ||
@@ -22,12 +22,38 @@ jobs:
         github.event.review.author_association == 'MEMBER' ||
         github.event.review.author_association == 'OWNER'
       ) && github.event.sender.login != 'matticbot' && (
-        (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+        (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && contains(github.event.comment.body, '@claude /review')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude /review')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude /review'))
       )
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      prompt_path: ${{ steps.path.outputs.prompt_path }}
+      pr_ref: ${{ steps.path.outputs.pr_ref }}
+    steps:
+      - name: Detect prompt path and PR ref
+        id: path
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.issue.number || github.event.pull_request.number }}"
+          FILES=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json files --jq '.files[].path')
+          if echo "$FILES" | grep -q '^client/dashboard/'; then
+            echo "prompt_path=.github/prompts/dashboard-pr-review.md" >> "$GITHUB_OUTPUT"
+          elif echo "$FILES" | grep -q '^client/a8c-for-agencies/'; then
+            echo "prompt_path=.github/prompts/a4a-pr-review.md" >> "$GITHUB_OUTPUT"
+          else
+            echo "prompt_path=.github/prompts/general-pr-review.md" >> "$GITHUB_OUTPUT"
+          fi
+          echo "pr_ref=refs/pull/$PR_NUMBER/merge" >> "$GITHUB_OUTPUT"
+
+  review:
+    needs: detect
     uses: ./.github/workflows/pr-review.yml
     with:
-      prompt_path: .github/prompts/general-pr-review.md
+      prompt_path: ${{ needs.detect.outputs.prompt_path }}
+      pr_ref: ${{ needs.detect.outputs.pr_ref }}
     secrets:
       anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/pr-review-on-ping.yml
+++ b/.github/workflows/pr-review-on-ping.yml
@@ -8,6 +8,10 @@ on:
   pull_request_review:
     types: [submitted]
 
+concurrency:
+  group: pr-review-on-ping-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/pr-review-on-ping.yml
+++ b/.github/workflows/pr-review-on-ping.yml
@@ -35,15 +35,15 @@ jobs:
       pull-requests: read
     outputs:
       prompt_path: ${{ steps.path.outputs.prompt_path }}
-      pr_ref: ${{ steps.path.outputs.pr_ref }}
     steps:
-      - name: Detect prompt path and PR ref
+      - name: Detect prompt path
         id: path
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
         run: |
-          PR_NUMBER="${{ github.event.issue.number || github.event.pull_request.number }}"
-          FILES=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json files --jq '.files[].path')
+          FILES=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json files --jq '.files[].path')
           if echo "$FILES" | grep -q '^client/dashboard/'; then
             echo "prompt_path=.github/prompts/dashboard-pr-review.md" >> "$GITHUB_OUTPUT"
           elif echo "$FILES" | grep -q '^client/a8c-for-agencies/'; then
@@ -51,20 +51,11 @@ jobs:
           else
             echo "prompt_path=.github/prompts/general-pr-review.md" >> "$GITHUB_OUTPUT"
           fi
-          # The merge ref does not exist for PRs with merge conflicts. Probe
-          # before emitting; fall back to the head ref so checkout doesn't fail
-          # cryptically downstream.
-          if git ls-remote "https://github.com/${{ github.repository }}" "refs/pull/$PR_NUMBER/merge" | grep -q .; then
-            echo "pr_ref=refs/pull/$PR_NUMBER/merge" >> "$GITHUB_OUTPUT"
-          else
-            echo "pr_ref=refs/pull/$PR_NUMBER/head" >> "$GITHUB_OUTPUT"
-          fi
 
   review:
     needs: detect
     uses: ./.github/workflows/pr-review.yml
     with:
       prompt_path: ${{ needs.detect.outputs.prompt_path }}
-      pr_ref: ${{ needs.detect.outputs.pr_ref }}
     secrets:
       anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/pr-review-on-ping.yml
+++ b/.github/workflows/pr-review-on-ping.yml
@@ -51,7 +51,14 @@ jobs:
           else
             echo "prompt_path=.github/prompts/general-pr-review.md" >> "$GITHUB_OUTPUT"
           fi
-          echo "pr_ref=refs/pull/$PR_NUMBER/merge" >> "$GITHUB_OUTPUT"
+          # The merge ref does not exist for PRs with merge conflicts. Probe
+          # before emitting; fall back to the head ref so checkout doesn't fail
+          # cryptically downstream.
+          if git ls-remote "https://github.com/${{ github.repository }}" "refs/pull/$PR_NUMBER/merge" | grep -q .; then
+            echo "pr_ref=refs/pull/$PR_NUMBER/merge" >> "$GITHUB_OUTPUT"
+          else
+            echo "pr_ref=refs/pull/$PR_NUMBER/head" >> "$GITHUB_OUTPUT"
+          fi
 
   review:
     needs: detect

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -7,11 +7,6 @@ on:
         description: 'Path to the per-area review prompt, relative to repo root'
         required: true
         type: string
-      pr_ref:
-        description: 'Optional PR ref to checkout (e.g., refs/pull/123/merge). If empty, falls back to github.ref. Required when invoked from a comment-triggered caller, since github.ref defaults to the default branch for those events.'
-        required: false
-        type: string
-        default: ''
     secrets:
       anthropic_api_key:
         required: true
@@ -40,10 +35,31 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - name: Checkout repository
+      # Reject fork PRs. pull_request_target fires with secrets in scope, so
+      # this guard is the runtime defence against a fork PR slipping past the
+      # caller's author_association gate. Works for both pull_request_target
+      # callers (head.repo is in the payload) and issue_comment callers
+      # (head.repo fetched via gh).
+      - name: Reject fork PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+          BASE_REPO: ${{ github.repository }}
+        run: |
+          if [ -n "$PR_HEAD_REPO" ]; then
+            HEAD_REPO="$PR_HEAD_REPO"
+          else
+            HEAD_REPO=$(gh pr view "$PR_NUMBER" --repo "$BASE_REPO" --json headRepositoryOwner,headRepository --jq '"\(.headRepositoryOwner.login)/\(.headRepository.name)"')
+          fi
+          if [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+            echo "::error::Fork PR rejected. Head repo: $HEAD_REPO, base: $BASE_REPO."
+            exit 1
+          fi
+
+      - name: Checkout repository (default branch only — never PR code)
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: ${{ inputs.pr_ref || github.ref }}
           fetch-depth: 0
 
       - name: Run review

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run review
-        uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6 # v1
+        uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434 # v1.0.107
         with:
           anthropic_api_key: ${{ secrets.anthropic_api_key }}
           prompt: |

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -39,4 +39,4 @@ jobs:
 
             Use `mcp__github_inline_comment__create_inline_comment` for review.
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(git show:*),Bash(git diff:*),Bash(git ls-files:*),Bash(git grep:*),Bash(rg *)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git show:*),Bash(git diff:*),Bash(git ls-files:*),Bash(git grep:*),Bash(rg *)"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -61,6 +61,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run review
         uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434 # v1.0.107

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -17,7 +17,22 @@ on:
         required: true
 
 jobs:
+  guard:
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Reject callers outside Automattic org
+        run: |
+          case "$CALLER_OWNER" in
+            Automattic) ;;
+            *) echo "Caller $CALLER_REPO is not allowed." >&2; exit 1 ;;
+          esac
+        env:
+          CALLER_OWNER: ${{ github.repository_owner }}
+          CALLER_REPO: ${{ github.repository }}
+
   review:
+    needs: guard
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -7,6 +7,11 @@ on:
         description: 'Path to the per-area review prompt, relative to repo root'
         required: true
         type: string
+      pr_ref:
+        description: 'Optional PR ref to checkout (e.g., refs/pull/123/merge). If empty, falls back to github.ref. Required when invoked from a comment-triggered caller, since github.ref defaults to the default branch for those events.'
+        required: false
+        type: string
+        default: ''
     secrets:
       anthropic_api_key:
         required: true
@@ -15,10 +20,14 @@ jobs:
   review:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
+          ref: ${{ inputs.pr_ref || github.ref }}
           fetch-depth: 0
 
       - name: Run review

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -40,4 +40,5 @@ jobs:
 
             Use `mcp__github_inline_comment__create_inline_comment` for review.
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git show:*),Bash(git diff:*),Bash(git ls-files:*),Bash(git grep:*),Bash(rg *)"
+            --max-turns 30
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git show:*),Bash(git diff:*),Bash(git log:*),Bash(git ls-files:*),Bash(git grep:*),Bash(rg *),Read,Glob,Grep"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,33 @@
+name: PR Review (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      prompt_path:
+        description: 'Path to the per-area review prompt, relative to repo root'
+        required: true
+        type: string
+    secrets:
+      anthropic_api_key:
+        required: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run review
+        uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6 # v1
+        with:
+          anthropic_api_key: ${{ secrets.anthropic_api_key }}
+          prompt: |
+            Read and follow the instructions in ${{ inputs.prompt_path }}
+
+            Use `mcp__github_inline_comment__create_inline_comment` for review.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(git show:*),Bash(git diff:*),Bash(git ls-files:*),Bash(git grep:*),Bash(rg *)"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1


### PR DESCRIPTION
Part of [QAO-425](https://linear.app/a8c/issue/QAO-425/wp-calypso-refactor-ai-review-workflows-add-author-gate).

## Proposed Changes

* Factor the two auto-fire workflows (`dashboard-pr-review.yml`, `a4a-pr-review.yml`) into a shared reusable `pr-review.yml`.
* Gate auto-fire to `MEMBER`/`OWNER` PR authors.
* SHA-pin `claude-code-action` and `actions/checkout`.
* New `pr-review-on-ping.yml`: `@claude /review` runs a review on any PR. Prompt path-routed: dashboard / a4a / general fallback.
* Reusable workflow includes a caller-org guard that rejects invocations from outside `Automattic` (mirrors [woocommerce/.github's pattern](https://github.com/woocommerce/.github/blob/67ae7a735e699b5eb0b16a06c05dc0956d74aa43/.github/workflows/ai-code-review.yml#L48)). The reusable lives in a public repo, so the guard makes the support contract explicit.
* `claude.yml` and matticbot's `@claude` proxy are untouched.

## Why are these changes being made?

* Auto-fire workflows duplicate identical YAML; centralizing removes sync burden.
* Author gate prevents external community PRs from burning the API key (public repo).
* Ping flow gives `MEMBER`/`OWNER` reviewers on-demand review for any PR.

## Testing Instructions

* PR touching `client/dashboard/**` or `client/a8c-for-agencies/**` → auto-review fires.
* `@claude /review` from `MEMBER`/`OWNER` on any PR → review with path-routed prompt.
* matticbot's `@claude` proxy continues firing `claude.yml` only.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?