### PR TITLE
Add AGENTS.md for dark-mode in dashboard and @package/ui

### DIFF
--- a/client/dashboard/AGENTS.md
+++ b/client/dashboard/AGENTS.md
@@ -14,3 +14,9 @@ This is the new hosting dashboard for WordPress.com.
   1. If the behavior depends on the **site** (e.g. available features, capabilities), use `siteTypeSupportsFeature()` or extend `SiteTypeFeatureSupports` in `utils/site-type-feature-support.ts`.
   2. If the behavior genuinely differs per dashboard variant, add a property to `AppConfig` that each variant provides, and branch on that property instead of the name.
   3. Before doing either, ask: if this UX is better for one variant, wouldn't it be better for all users? Prefer a single code path when possible.
+
+### Dark mode
+
+- Dark-mode overrides for the dashboard app live in `client/dashboard/app/_dark-theme.scss`. Add to the existing `dashboard-dark-theme-*` mixins (or add a new one and `@include` it from `dashboard-dark-theme`) instead of writing ad-hoc `:root[data-theme='dark']` blocks elsewhere.
+- Prefer overriding the CSS custom properties already defined there (`--dashboard-*`, `--wp-components-*`, `--jp-*`) over hardcoding hex values in component styles.
+- For styles authored inside a CSS Module (`*.module.scss`), `:root`-based overrides cannot reach the scope-hashed class. Use the `when-dark-theme` mixin from `@automattic/ui` — see `packages/ui/AGENTS.md`.

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -1,0 +1,26 @@
+# @automattic/ui
+
+`@automattic/ui` is a library of React components that adhere to the Automattic Design System, to be used across Automattic products.
+
+## Conventions
+
+### Dark mode in CSS Modules
+
+Component styles in this package live in CSS Modules (`*.module.scss`), so the leaf class is scope-hashed and `:root[data-theme='dark'] .foo` cannot reach it. Use the `when-dark-theme` mixin from `src/utils/_mixins.scss`:
+
+```scss
+@use '../utils/mixins' as ui-mixins;
+@use '../utils/_theme-variables' as theme;
+
+.badge {
+	background-color: colors.$white;
+
+	@include ui-mixins.when-dark-theme {
+		background-color: theme.$components-color-background;
+	}
+}
+```
+
+The mixin emits rules for both `:root[data-theme='dark']` and `:root[data-theme='system']` under `prefers-color-scheme: dark`, so consumers of either toggle behave the same.
+
+Prefer reading colors from `_theme-variables.scss` (which resolves to the `--wp-components-*` custom properties the dashboard overrides in dark mode) over hardcoded hex values, so most components need no dark-mode branch at all.

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -9,6 +9,7 @@
 Component styles in this package live in CSS Modules (`*.module.scss`), so the leaf class is scope-hashed and `:root[data-theme='dark'] .foo` cannot reach it. Use the `when-dark-theme` mixin from `src/utils/_mixins.scss`:
 
 ```scss
+@use '@wordpress/base-styles/colors';
 @use '../utils/mixins' as ui-mixins;
 @use '../utils/_theme-variables' as theme;
 

--- a/packages/ui/CLAUDE.md
+++ b/packages/ui/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
Part of https://linear.app/a8c/project/calypso-dark-mode-49d32ecef427/overview

Add a new dark-mode section. Add a missing `@packages/ui` agents file.

## Proposed Changes

* Add LLM instructions

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Nothing to test

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
