### PR TITLE
Omnibar: refactor rendering logic to utilize meta

### DIFF
--- a/client/dashboard/app/omnibar/index.tsx
+++ b/client/dashboard/app/omnibar/index.tsx
@@ -5,13 +5,24 @@ import {
 	siteAdminBarQuery,
 	siteByIdQuery,
 } from '@automattic/api-queries';
-import { Omnibar, buildOmnibarNodesFromAdminBarNodes } from '@automattic/omnibar';
+import { AdminBarNode, Omnibar, buildOmnibarNodesFromAdminBarNodes } from '@automattic/omnibar';
 import { QueryClientProvider, useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { hydrateRoot } from 'react-dom/client';
 import SiteIcon from '../../components/site-icon';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { OmnibarHomeIcon } from './home';
+
+const UNSUPPORTED_DOTCOM_NODE_IDS = new Set( [
+	'site-plan',
+	'site-plan-badge',
+	'site-status-badge',
+	'my-wpcom-account',
+] );
+
+function removeUnsupportedDotcomNodes( nodes: AdminBarNode[] ) {
+	return nodes.filter( ( node ) => ! UNSUPPORTED_DOTCOM_NODE_IDS.has( node.id ) );
+}
 
 function OmnibarContainer() {
 	const { data: siteId } = useQuery( omnibarSiteIdQuery() );
@@ -28,7 +39,7 @@ function OmnibarContainer() {
 
 	const omnibarNodes = useMemo( () => {
 		const nodes = siteNodes ?? dashboardNodes ?? [];
-		const result = buildOmnibarNodesFromAdminBarNodes( nodes );
+		const result = buildOmnibarNodesFromAdminBarNodes( removeUnsupportedDotcomNodes( nodes ) );
 
 		if ( result.home ) {
 			result.home.icon = <OmnibarHomeIcon />;

--- a/packages/omnibar/src/components/omnibar-home.tsx
+++ b/packages/omnibar/src/components/omnibar-home.tsx
@@ -1,6 +1,6 @@
-import { OmnibarItem } from './omnibar-item';
+import { OmnibarMenu } from './omnibar-menu';
 import type { OmnibarNode } from '../types';
 
 export function OmnibarHomeNode( { node }: { node: OmnibarNode } ) {
-	return <OmnibarItem node={ node } content={ node.icon } />;
+	return <OmnibarMenu node={ { ...node, render: ( { icon } ) => icon } } />;
 }

--- a/packages/omnibar/src/components/omnibar-menu.tsx
+++ b/packages/omnibar/src/components/omnibar-menu.tsx
@@ -1,7 +1,8 @@
 import { Button, DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+import { OmnibarNodeContent } from './omnibar-node';
 import type { OmnibarNode } from '../types';
 
-function OmnibarDropdownContent( { children }: { children: OmnibarNode[] } ) {
+function OmnibarDropdownContent( { nodes }: { nodes: OmnibarNode[] } ) {
 	const handleClick = ( href?: string ) => () => {
 		if ( href ) {
 			window.location.href = href;
@@ -11,11 +12,11 @@ function OmnibarDropdownContent( { children }: { children: OmnibarNode[] } ) {
 	const ungroupedItems: OmnibarNode[] = [];
 	const groups: OmnibarNode[] = [];
 
-	for ( const child of children ) {
-		if ( child.group ) {
-			groups.push( child );
+	for ( const node of nodes ) {
+		if ( node.group ) {
+			groups.push( node );
 		} else {
-			ungroupedItems.push( child );
+			ungroupedItems.push( node );
 		}
 	}
 
@@ -25,7 +26,7 @@ function OmnibarDropdownContent( { children }: { children: OmnibarNode[] } ) {
 				<MenuGroup>
 					{ ungroupedItems.map( ( item ) => (
 						<MenuItem key={ item.id } onClick={ handleClick( item.href ) }>
-							{ item.title }
+							<OmnibarNodeContent node={ item } />
 						</MenuItem>
 					) ) }
 				</MenuGroup>
@@ -34,7 +35,7 @@ function OmnibarDropdownContent( { children }: { children: OmnibarNode[] } ) {
 				<MenuGroup key={ group.id } label={ group.title }>
 					{ ( group.children || [] ).map( ( item ) => (
 						<MenuItem key={ item.id } onClick={ handleClick( item.href ) }>
-							{ item.title }
+							<OmnibarNodeContent node={ item } />
 						</MenuItem>
 					) ) }
 				</MenuGroup>
@@ -43,11 +44,11 @@ function OmnibarDropdownContent( { children }: { children: OmnibarNode[] } ) {
 	);
 }
 
-export function OmnibarItem( { node, content }: { node: OmnibarNode; content: React.ReactNode } ) {
+export function OmnibarMenu( { node }: { node: OmnibarNode } ) {
 	if ( ! node.children ) {
 		return (
-			<Button className="omnibar__item" href={ node.href } label={ node.title }>
-				{ content }
+			<Button className="omnibar__menu" href={ node.href } label={ node.title }>
+				<OmnibarNodeContent node={ node } />
 			</Button>
 		);
 	}
@@ -59,11 +60,11 @@ export function OmnibarItem( { node, content }: { node: OmnibarNode; content: Re
 			label={ node.title }
 			popoverProps={ { className: 'omnibar__popover' } }
 			toggleProps={ {
-				className: 'omnibar__item',
-				children: content,
+				className: 'omnibar__menu',
+				children: <OmnibarNodeContent node={ node } />,
 			} }
 		>
-			{ () => <OmnibarDropdownContent children={ node.children || [] } /> }
+			{ () => <OmnibarDropdownContent nodes={ node.children ?? [] } /> }
 		</DropdownMenu>
 	);
 }

--- a/packages/omnibar/src/components/omnibar-node.tsx
+++ b/packages/omnibar/src/components/omnibar-node.tsx
@@ -1,0 +1,8 @@
+import type { OmnibarNode } from '../types';
+
+export function OmnibarNodeContent( { node }: { node: OmnibarNode } ) {
+	if ( node.render ) {
+		return node.render( node );
+	}
+	return node.title;
+}

--- a/packages/omnibar/src/components/omnibar-site.tsx
+++ b/packages/omnibar/src/components/omnibar-site.tsx
@@ -1,32 +1,36 @@
 import { __experimentalHStack as HStack } from '@wordpress/components';
-import { OmnibarItem } from './omnibar-item';
+import { OmnibarMenu } from './omnibar-menu';
 import type { OmnibarNode } from '../types';
 
 export function OmnibarSiteNode( { node }: { node: OmnibarNode } ) {
 	return (
-		<OmnibarItem
-			node={ node }
-			content={
-				<HStack>
-					{ node.icon }
-					<span>{ node.title }</span>
-				</HStack>
-			}
+		<OmnibarMenu
+			node={ {
+				...node,
+				render: ( { icon, title } ) => (
+					<HStack>
+						{ icon }
+						<span>{ title }</span>
+					</HStack>
+				),
+			} }
 		/>
 	);
 }
 
 export function OmnibarSiteActionsNode( { nodes }: { nodes: OmnibarNode[] } ) {
 	return nodes.map( ( node ) => (
-		<OmnibarItem
+		<OmnibarMenu
 			key={ node.id }
-			node={ node }
-			content={
-				<HStack spacing={ 1 }>
-					<span>{ node.title }</span>
-					{ node.subtitle && <span>{ node.subtitle }</span> }
-				</HStack>
-			}
+			node={ {
+				...node,
+				render: ( { title, meta } ) => (
+					<HStack spacing={ 1 }>
+						<span>{ title }</span>
+						{ meta?.subtitle && <span>{ meta.subtitle }</span> }
+					</HStack>
+				),
+			} }
 		/>
 	) );
 }

--- a/packages/omnibar/src/components/omnibar-user.tsx
+++ b/packages/omnibar/src/components/omnibar-user.tsx
@@ -1,19 +1,21 @@
 import { __experimentalHStack as HStack } from '@wordpress/components';
-import { OmnibarItem } from './omnibar-item';
+import { OmnibarMenu } from './omnibar-menu';
 import type { OmnibarNode } from '../types';
 
 import './omnibar-user.scss';
 
 export function OmnibarUserNode( { node }: { node: OmnibarNode } ) {
 	return (
-		<OmnibarItem
-			node={ node }
-			content={
-				<HStack spacing={ 2 }>
-					<span>{ node.title }</span>
-					{ node.icon && <span className="omnibar__user-avatar">{ node.icon }</span> }
-				</HStack>
-			}
+		<OmnibarMenu
+			node={ {
+				...node,
+				render: ( { title, icon } ) => (
+					<HStack spacing={ 2 }>
+						<span>{ title }</span>
+						{ icon && <span className="omnibar__user-avatar">{ icon }</span> }
+					</HStack>
+				),
+			} }
 		/>
 	);
 }

--- a/packages/omnibar/src/components/omnibar.scss
+++ b/packages/omnibar/src/components/omnibar.scss
@@ -28,7 +28,7 @@ $omnibar-highlight-color: #7b90ff;
 		position: relative;
 	}
 
-	.components-button.omnibar__item {
+	.components-button.omnibar__menu {
 		height: $omnibar-height;
 		padding: 0 8px;
 		color: $omnibar-text-color;

--- a/packages/omnibar/src/types/index.ts
+++ b/packages/omnibar/src/types/index.ts
@@ -1,2 +1,2 @@
 export type { AdminBarNode } from './admin-bar';
-export type { OmnibarNode, OmnibarNodeRenderProps, OmnibarNodes, OmnibarProps } from './omnibar';
+export type { OmnibarNode, OmnibarNodes, OmnibarProps } from './omnibar';

--- a/packages/omnibar/src/types/omnibar.ts
+++ b/packages/omnibar/src/types/omnibar.ts
@@ -1,15 +1,21 @@
 export interface OmnibarNode {
 	id: string;
 	title: string;
-	subtitle?: string;
 	icon?: React.ReactElement;
 	group?: boolean;
 	href?: string;
+	meta?: SiteActionNodeMeta & UserInfoNodeMeta;
+	render?: ( node: OmnibarNode ) => React.ReactNode;
 	children?: OmnibarNode[];
 }
 
-export interface OmnibarNodeRenderProps {
-	node: OmnibarNode;
+export interface SiteActionNodeMeta {
+	subtitle?: string;
+}
+
+export interface UserInfoNodeMeta {
+	displayName?: string;
+	username?: string;
 }
 
 export interface OmnibarNodes {

--- a/packages/omnibar/src/utils/admin-bar.tsx
+++ b/packages/omnibar/src/utils/admin-bar.tsx
@@ -2,6 +2,7 @@ import type { AdminBarNode, OmnibarNode, OmnibarNodes } from '../types';
 
 export function buildOmnibarNodesFromAdminBarNodes( adminBarNodes: AdminBarNode[] ): OmnibarNodes {
 	const omnibarNodes: OmnibarNodes = {};
+	const siteActionNodes: OmnibarNode[] = [];
 
 	const nodeMap = new Map< string, OmnibarNode >();
 	for ( const node of adminBarNodes ) {
@@ -13,16 +14,32 @@ export function buildOmnibarNodesFromAdminBarNodes( adminBarNodes: AdminBarNode[
 		};
 
 		switch ( node.id ) {
+			case 'wpcom-logo':
+				omnibarNodes.home = omnibarNode;
+				break;
+			case 'site-name':
+				omnibarNodes.site = omnibarNode;
+				break;
+			case 'new-content': {
+				siteActionNodes.push( omnibarNode );
+				break;
+			}
 			case 'comments': {
 				omnibarNode.title = 'Comments';
 				const doc = new DOMParser().parseFromString( node.title || '', 'text/html' );
-				omnibarNode.subtitle = doc.querySelector( '.pending-count' )?.textContent?.trim();
+				omnibarNode.meta = {
+					subtitle: doc.querySelector( '.pending-count' )?.textContent?.trim(),
+				};
+				siteActionNodes.push( omnibarNode );
 				break;
 			}
 			case 'updates': {
 				omnibarNode.title = 'Updates';
 				const doc = new DOMParser().parseFromString( node.title || '', 'text/html' );
-				omnibarNode.subtitle = doc.querySelector( '.ab-label' )?.textContent?.trim();
+				omnibarNode.meta = {
+					subtitle: doc.querySelector( '.ab-label' )?.textContent?.trim(),
+				};
+				siteActionNodes.push( omnibarNode );
 				break;
 			}
 			case 'my-account': {
@@ -36,11 +53,21 @@ export function buildOmnibarNodesFromAdminBarNodes( adminBarNodes: AdminBarNode[
 						<img src={ url.toString() } alt={ avatar?.getAttribute( 'alt' ) || '' } />
 					);
 				}
+				omnibarNodes.user = omnibarNode;
+				break;
+			}
+			case 'user-info': {
+				const doc = new DOMParser().parseFromString( node.title || '', 'text/html' );
+				omnibarNode.title = doc.querySelector( '.edit-profile' )?.textContent?.trim() || '';
 				break;
 			}
 		}
 
 		nodeMap.set( node.id, omnibarNode );
+	}
+
+	if ( siteActionNodes.length > 0 ) {
+		omnibarNodes.siteActions = siteActionNodes;
 	}
 
 	for ( const node of adminBarNodes ) {
@@ -57,26 +84,6 @@ export function buildOmnibarNodesFromAdminBarNodes( adminBarNodes: AdminBarNode[
 				}
 				parentNode.children.push( omnibarNode );
 			}
-		}
-
-		switch ( node.id ) {
-			case 'wpcom-logo':
-				omnibarNodes.home = omnibarNode;
-				break;
-			case 'site-name':
-				omnibarNodes.site = omnibarNode;
-				break;
-			case 'updates':
-			case 'comments':
-			case 'new-content':
-				if ( ! omnibarNodes.siteActions ) {
-					omnibarNodes.siteActions = [];
-				}
-				omnibarNodes.siteActions.push( omnibarNode );
-				break;
-			case 'my-account':
-				omnibarNodes.user = omnibarNode;
-				break;
 		}
 	}
 


### PR DESCRIPTION
## Proposed Changes (generated)

- Replaced OmnibarItem(node, content) with OmnibarMenu(node) plus a new OmnibarNodeContent dispatcher. Callers now inject presentation by setting node.render, so the menu/dropdown chrome lives in one place and each node type owns its own content rendering.
- Replaced the ad-hoc OmnibarNode.subtitle field with a typed meta?: SiteActionNodeMeta & UserInfoNodeMeta bag, so per-node-type extra data has a real type instead of a stringly-keyed record.
- Refactored buildOmnibarNodesFromAdminBarNodes to assign role slots (home, site, siteActions, user) in a single switch, and added handlers for the wpcom-logo, site-name, new-content, and user-info admin-bar IDs.
- In the dashboard client, filter out admin-bar IDs that don't apply on dotcom (site-plan, site-plan-badge, site-status-badge, my-wpcom-account) before building the omnibar.