### PR TITLE
Dashboard: Add PHP logs link to critical error screens

### DIFF
--- a/client/dashboard/sites/critical-error/index.tsx
+++ b/client/dashboard/sites/critical-error/index.tsx
@@ -1,10 +1,11 @@
+import { HostingFeatures } from '@automattic/api-core';
 import { siteBySlugQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { useNavigate } from '@tanstack/react-router';
+import { Link, useNavigate } from '@tanstack/react-router';
 import { Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Icon, envelope, help } from '@wordpress/icons';
+import { Icon, envelope, formatListBullets, help } from '@wordpress/icons';
 import { Fragment, useEffect } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { useHelpCenter } from '../../app/help-center';
@@ -12,10 +13,12 @@ import { Card, CardBody, CardDivider } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { Text } from '../../components/text';
+import { hasHostingFeature } from '../../utils/site-features';
 import {
 	getJetpackCriticalErrorMessage,
 	isInJetpackCriticalErrorState,
 } from '../../utils/site-jetpack-critical-error';
+import { siteTypeSupportsFeature } from '../../utils/site-type-feature-support';
 import type { ReactElement, ReactNode } from 'react';
 
 type Item = {
@@ -37,6 +40,10 @@ const SiteCriticalError = ( { siteSlug }: { siteSlug: string } ) => {
 	const navigate = useNavigate();
 
 	const isAdmin = !! site.capabilities?.manage_options;
+	const canAccessPhpLogs =
+		isAdmin &&
+		siteTypeSupportsFeature( site, 'logs' ) &&
+		hasHostingFeature( site, HostingFeatures.LOGS );
 	const hasRecovered = ! isInJetpackCriticalErrorState( site );
 
 	useEffect( () => {
@@ -61,6 +68,20 @@ const SiteCriticalError = ( { siteSlug }: { siteSlug: string } ) => {
 		items.push( {
 			icon: envelope,
 			text: __( 'Check your site admin email inbox for instructions to troubleshoot.' ),
+		} );
+	}
+	if ( canAccessPhpLogs ) {
+		items.push( {
+			icon: formatListBullets,
+			text: createInterpolateElement(
+				// translators: <phpLogsLink/> is a link to the PHP logs page with the text "Review the PHP logs"
+				__( '<phpLogsLink/> to locate any fatal errors on your site.' ),
+				{
+					phpLogsLink: (
+						<Link to={ `/sites/${ siteSlug }/logs/php` }>{ __( 'Review the PHP logs' ) }</Link>
+					),
+				}
+			),
 		} );
 	}
 	items.push( {

--- a/client/dashboard/utils/site-jetpack-critical-error.ts
+++ b/client/dashboard/utils/site-jetpack-critical-error.ts
@@ -48,8 +48,6 @@ export function getJetpackCriticalErrorMessage( site: Site ): string | null {
 
 	const isAdmin = !! site.capabilities?.manage_options;
 	return isAdmin
-		? __( 'There has been a critical error on this website. Here’s what you can try next:' )
-		: __(
-				'There has been a critical error on this website. A site administrator has been notified.'
-		  );
+		? __( 'There has been a critical error on this site. Here’s what you can try next:' )
+		: __( 'There has been a critical error on this site. A site administrator has been notified.' );
 }

--- a/client/sites/overview/components/critical-error/index.tsx
+++ b/client/sites/overview/components/critical-error/index.tsx
@@ -78,7 +78,7 @@ export const CriticalErrorOverview = ( { siteSlug }: { siteSlug: string } ) => {
 									translate( '<phpLogsLink/> to locate any fatal errors on your site.' ) as string,
 									{
 										phpLogsLink: (
-											<a href={ `/sites/${ siteSlug }/logs/php` }>
+											<a href={ `/site-logs/${ siteSlug }/php` }>
 												{ translate( 'Review the PHP logs' ) }
 											</a>
 										),

--- a/client/sites/overview/components/critical-error/index.tsx
+++ b/client/sites/overview/components/critical-error/index.tsx
@@ -1,14 +1,17 @@
+import { HostingFeatures } from '@automattic/api-core';
 import { siteBySlugQuery } from '@automattic/api-queries';
 import { HelpCenter } from '@automattic/data-stores';
 import { useQuery } from '@tanstack/react-query';
 import { Button, Card, CardBody } from '@wordpress/components';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
-import { Icon, envelope, help } from '@wordpress/icons';
+import { Icon, envelope, formatListBullets, help } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { HostingHero } from 'calypso/components/hosting-hero';
+import { hasHostingFeature } from 'calypso/dashboard/utils/site-features';
 import { getJetpackCriticalErrorMessage } from 'calypso/dashboard/utils/site-jetpack-critical-error';
+import { siteTypeSupportsFeature } from 'calypso/dashboard/utils/site-type-feature-support';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { ReactElement, ReactNode } from 'react';
 
@@ -43,6 +46,11 @@ export const CriticalErrorOverview = ( { siteSlug }: { siteSlug: string } ) => {
 		return null;
 	}
 
+	const canAccessPhpLogs =
+		isAdmin &&
+		siteTypeSupportsFeature( site, 'logs' ) &&
+		hasHostingFeature( site, HostingFeatures.LOGS );
+
 	const message = getJetpackCriticalErrorMessage( site );
 
 	return (
@@ -60,6 +68,23 @@ export const CriticalErrorOverview = ( { siteSlug }: { siteSlug: string } ) => {
 							<Item icon={ envelope }>
 								{ translate(
 									'Check your site admin email inbox for instructions to troubleshoot.'
+								) }
+							</Item>
+						) }
+						{ canAccessPhpLogs && (
+							<Item icon={ formatListBullets }>
+								{ createInterpolateElement(
+									translate(
+										// translators: <phpLogsLink/> is a link to the PHP logs page with the text "Review the PHP logs"
+										'<phpLogsLink/> to locate any fatal errors on your site.'
+									) as string,
+									{
+										phpLogsLink: (
+											<a href={ `/sites/${ siteSlug }/logs/php` }>
+												{ translate( 'Review the PHP logs' ) }
+											</a>
+										),
+									}
 								) }
 							</Item>
 						) }

--- a/client/sites/overview/components/critical-error/index.tsx
+++ b/client/sites/overview/components/critical-error/index.tsx
@@ -74,10 +74,8 @@ export const CriticalErrorOverview = ( { siteSlug }: { siteSlug: string } ) => {
 						{ canAccessPhpLogs && (
 							<Item icon={ formatListBullets }>
 								{ createInterpolateElement(
-									translate(
-										// translators: <phpLogsLink/> is a link to the PHP logs page with the text "Review the PHP logs"
-										'<phpLogsLink/> to locate any fatal errors on your site.'
-									) as string,
+									// translators: <phpLogsLink/> is a link to the PHP logs page with the text "Review the PHP logs"
+									translate( '<phpLogsLink/> to locate any fatal errors on your site.' ) as string,
 									{
 										phpLogsLink: (
 											<a href={ `/sites/${ siteSlug }/logs/php` }>


### PR DESCRIPTION
Follow up to #110174.

## Proposed Changes

- Add a `Review the PHP logs` bullet to the Jetpack critical error screens in the dashboard (`client/dashboard/sites/critical-error/index.tsx`) and the classic site overview (`client/sites/overview/components/critical-error/index.tsx`). The bullet uses the `formatListBullets` icon and links to `/sites/$siteSlug/logs/php`.
- Gate the new bullet on `isAdmin && siteTypeSupportsFeature(site, 'logs') && hasHostingFeature(site, HostingFeatures.LOGS)` so it only renders when the user can actually reach the PHP logs page (mirrors the route's site-type gate plus the in-page hosting-feature gate that would otherwise show an upsell).
- Replace `website` with `site` in the two critical error messages produced by `getJetpackCriticalErrorMessage` (`client/dashboard/utils/site-jetpack-critical-error.ts`).

## Why are these changes being made?

When a site is in a Jetpack critical error state, the most actionable thing an admin can do is read the PHP logs to find the fatal error. Surfacing a direct link from the critical error screen — alongside the existing email and contact-support tips — shortens the path from `something is broken` to `here is the failing line`. Gating on the same conditions as the logs route keeps the link from sending users into an upsell or a `not allowed` redirect.

## Testing Instructions

1. Find or simulate a site whose API responses set `__inaccessible_jetpack_error` together with the Jetpack recovery-mode flags (same setup as #110174). Use an Atomic site so the LOGS hosting feature is available.
2. As an admin, visit `/sites/<slug>/critical-error`. You should see three bullets: email-inbox tip, the new `Review the PHP logs` link, and the contact-support button. The hero description should read `There has been a critical error on this site. Here's what you can try next:`.
3. Click `Review the PHP logs`. It should navigate to `/sites/<slug>/logs/php`.
4. As a non-admin on the same site, only the contact-support bullet should appear, and the description should read `There has been a critical error on this site. A site administrator has been notified.`
5. On a site type that does not support logs (e.g. self-hosted Jetpack-connected, Commerce Garden) or a plan without the LOGS hosting feature, the PHP logs bullet should not render.
6. Repeat the admin walkthrough on the classic site overview critical-error screen (rendered via `client/sites/v2/site-overview/router.tsx`) — same three bullets and same gating.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?