### PR TITLE
wpcom-block-editor: Attach delegate tracking listeners to canvas iframe

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -1046,12 +1046,49 @@ if (
 		delegateEventTracking( true, event );
 	};
 
+	// Gutenberg renders the block canvas inside an iframe. Events there don't
+	// bubble to the parent document, so we also attach our delegate listeners
+	// to each iframe's document and re-attach on `load` (it's recreated on
+	// preview mode changes).
+	const EDITOR_CANVAS_IFRAME_SELECTOR = 'iframe[name="editor-canvas"]';
+	const attachedIframes = new WeakSet();
+	const attachedDocuments = new WeakSet();
+
+	const attachDelegateListeners = ( doc ) => {
+		if ( ! doc || attachedDocuments.has( doc ) ) {
+			return;
+		}
+		attachedDocuments.add( doc );
+		EVENT_TYPES.forEach( ( eventType ) => {
+			doc.addEventListener( eventType, delegateNonCaptureListener );
+			doc.addEventListener( eventType, delegateCaptureListener, true );
+		} );
+	};
+
+	const attachToEditorCanvasIframe = ( iframe ) => {
+		if ( attachedIframes.has( iframe ) ) {
+			return;
+		}
+		attachedIframes.add( iframe );
+		// Re-attach on every load - the iframe document is recreated on preview-mode changes.
+		attachDelegateListeners( iframe.contentDocument );
+		iframe.addEventListener( 'load', () => attachDelegateListeners( iframe.contentDocument ) );
+	};
+
+	const attachToEditorCanvasIframes = () => {
+		document
+			.querySelectorAll( EDITOR_CANVAS_IFRAME_SELECTOR )
+			.forEach( attachToEditorCanvasIframe );
+	};
+
 	// Registers Plugin.
 	registerPlugin( 'wpcom-block-editor-tracking', {
 		render: () => {
-			EVENT_TYPES.forEach( ( eventType ) => {
-				document.addEventListener( eventType, delegateNonCaptureListener );
-				document.addEventListener( eventType, delegateCaptureListener, true );
+			attachDelegateListeners( document );
+			attachToEditorCanvasIframes();
+			new window.MutationObserver( attachToEditorCanvasIframes ).observe( document.body, {
+				childList: true,
+				subtree: true,
 			} );
 			return null;
 		},


### PR DESCRIPTION
## Proposed Changes

* Mirror the delegate click/keyup listeners onto the editor canvas iframe's `contentDocument`, re-attaching on the iframe's `load` event and watching the DOM for late-mounted iframes.

## Why are these changes being made?

* Gutenberg renders the block canvas inside `iframe[name="editor-canvas"]`. Events from inside don't bubble to the parent document, so any tracking handler with an in-canvas selector (e.g. `.wp-block-*`) silently never fires.

## Testing Instructions

* Sandbox `widgets.wp.com`.
* Run `cd apps/wpcom-block-editor && yarn dev --sync` .
* Add a tracking handler that listens for events on components inside the editor iframe, for example:
 ```diff
 --- a/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
@@ -87,6 +87,15 @@ const EVENTS_MAPPING = [
        wpcomSiteEditorSidebarStylesClick(),
        wpcomSiteEditorSidebarTemplatesClick(),
        wpcomPreviewDropdownSelected(),
+       {
+               id: 'wpcom-block-editor-test-handler',
+               selector: '.wp-block-paragraph',
+               type: 'click',
+               capture: true,
+               handler: () => {
+                       console.log( 'here!' );
+               },
+       },
 ];
 const EVENTS_MAPPING_CAPTURE = EVENTS_MAPPING.filter( ( { capture } ) => capture );
 const EVENTS_MAPPING_NON_CAPTURE = EVENTS_MAPPING.filter( ( { capture } ) => ! capture );
 ```
* On a simple site, create or edit a post, add a paragraph block, and confirm you see the log when you click on the paragraph.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
