### PR TITLE
wpcom-block-editor: Track core/missing block actions

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
@@ -5,6 +5,7 @@ import wpcomBlockEditorCloseClick from './wpcom-block-editor-close-click';
 import wpcomBlockEditorDetailsOpen from './wpcom-block-editor-details-open';
 import wpcomBlockEditorGlobalStylesMenuSelected from './wpcom-block-editor-global-styles-menu-selected';
 import wpcomBlockEditorListViewSelect from './wpcom-block-editor-list-view-select';
+import wpcomBlockEditorMissingBlockActionClick from './wpcom-block-editor-missing-block-action-click';
 import wpcomBlockEditorPostPublishAddNewClick from './wpcom-block-editor-post-publish-add-new-click';
 import {
 	wpcomBlockEditorSaveClick,
@@ -72,6 +73,7 @@ const EVENTS_MAPPING = [
 	wpcomTemplatePartChooseBubble(),
 	wpcomTemplatePartReplaceBubble(),
 	wpcomBlockEditorListViewSelect(),
+	wpcomBlockEditorMissingBlockActionClick(),
 	wpcomBlockEditorTemplatePartDetachBlocks(),
 	wpcomBlockEditorPostPublishAddNewClick(),
 	wpcomBlockEditorSaveClick(),

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-missing-block-action-click.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-missing-block-action-click.js
@@ -1,0 +1,44 @@
+import { __ } from '@wordpress/i18n';
+import tracksRecordEvent from './track-record-event';
+
+/**
+ * Map a translated button label to a locale-independent action id.
+ * @param {string} label The button's trimmed innerText.
+ * @returns {string} A stable identifier for the action, or `'unknown'`.
+ */
+const getActionId = ( label ) => {
+	const mapLabelToAction = {
+		[ __( 'Convert to blocks' ) ]: 'convert_to_blocks',
+		[ __( 'Keep as HTML' ) ]: 'keep_as_html',
+	};
+	return mapLabelToAction[ label ] ?? 'unknown';
+};
+
+/**
+ * Track clicks on warning action buttons inside a `.wp-block-missing` block.
+ * @returns {import('./types').DelegateEventHandler} event object definition.
+ */
+export default () => ( {
+	id: 'wpcom-block-editor-missing-block-action-click',
+	selector: '.wp-block-missing .block-editor-warning__action > button',
+	type: 'click',
+	capture: true,
+	handler: ( _event, target ) => {
+		const action = getActionId( target.innerText?.trim() ?? '' );
+
+		const actionsContainer = target.closest( '.block-editor-warning__actions' );
+		const siblingButtons = Array.from(
+			actionsContainer?.querySelectorAll( '.block-editor-warning__action > button' ) ?? []
+		);
+		// Sort so the same set of actions always produces the same string.
+		const availableActions = siblingButtons
+			.map( ( button ) => getActionId( button.innerText?.trim() ?? '' ) )
+			.sort()
+			.join( ',' );
+
+		tracksRecordEvent( 'wpcom_block_editor_missing_block_action_click', {
+			action,
+			available_actions: availableActions,
+		} );
+	},
+} );


### PR DESCRIPTION
Blocked by https://github.com/Automattic/wp-calypso/pull/110188

## Proposed Changes

* Record `wpcom_block_editor_missing_block_action_click` when the user clicks an action button inside a `.wp-block-missing` block. Payload: `action` and `available_actions` (sorted, comma-separated list of ids).

## Why are these changes being made?

* To measure how users respond to deprecated/missing block warnings - notably the Classic block's "Convert to blocks" / "Keep as HTML" choice.

## Testing Instructions

* Sandbox `widgets.wp.com`.
* Run `cd apps/wpcom-block-editor && yarn dev --sync` .
* Navigate to a Simple site and open the block editor for a post or a page.
* Switch to "Code editor" mode and add non-existen block, e.g.:
 ```html
<!-- wp:nonexistentblock -->
<p></p>
<!-- /wp:nonexistentblock -->
 ```
* Switch back to "Visual editor" mode.
* Click on the "Keep as HTML" button in the missing block warning and confirm a tracking event is fired.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
