### PR TITLE
Add a workflow that adds a comment when e2e tests fail

### DIFF
--- a/.github/workflows/e2e-failure-comment.yml
+++ b/.github/workflows/e2e-failure-comment.yml
@@ -36,7 +36,7 @@ jobs:
               watermark,
               `Looks like one of the E2E tests has failed.`,
               ``,
-              `To try to fix it, you can use a Claude skill called \`/fix-e2e-failure\`.`,
+              `To try to fix it, you can use a Claude skill called \`/fix-e2e-tests\`.`,
             ].join('\n');
 
             for (const pr of openPrs) {

--- a/.github/workflows/e2e-failure-comment.yml
+++ b/.github/workflows/e2e-failure-comment.yml
@@ -1,0 +1,58 @@
+name: E2E Failure Comment
+
+on:
+  status:
+
+jobs:
+  comment-on-failure:
+    name: Comment on PR when an e2e test fails
+    runs-on: ubuntu-latest
+    # TeamCity (.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt) posts a commit
+    # status for each e2e build. Only react to failed terminal states.
+    if: >-
+      contains(github.event.context, 'E2E') &&
+      (github.event.state == 'failure' || github.event.state == 'error')
+    permissions:
+      pull-requests: write
+      issues: write
+    timeout-minutes: 5
+    steps:
+      - name: Post comment on PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const watermark = '<!--e2e-failure-watermark:v1-->';
+
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.payload.sha,
+            });
+            const openPrs = prs.filter((pr) => pr.state === 'open');
+            if (openPrs.length === 0) return;
+
+            const body = [
+              watermark,
+              `Looks like one of the E2E tests has failed.`,
+              ``,
+              `To try to fix it, you can use a Claude skill called \`/fix-e2e-failure\`.`,
+            ].join('\n');
+
+            for (const pr of openPrs) {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+              });
+
+              // Skip if we've already commented on this PR.
+              if (comments.some((c) => c.body && c.body.includes(watermark))) continue;
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body,
+              });
+            }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #DOTCOM-16872

## Proposed Changes

* Add a workflow that adds a GitHub comment on the PR if the E2E tests are failing

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It's part of RSM. This comment will encourage developers to use the skill implemented in DOTCOM-16872

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* N/A - I've made a test by forking wp-calypso and manually trigger the e2e action

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
