### PR TITLE
Handling of html5_v03 format in ad-preview

### DIFF
--- a/client/my-sites/promote-post-i2/components/ad-preview/index.tsx
+++ b/client/my-sites/promote-post-i2/components/ad-preview/index.tsx
@@ -13,9 +13,9 @@ interface Props {
 export default function AdPreview( { htmlCode, isLoading, templateFormat, width }: Props ) {
 	const adWidth = width ? `${ width }` : '300px';
 
-	// Both the classic html5_v2 template and the AI-generated html5_v03 template
+	// Both the classic html5_v2 template and the AI-generated html5_v3 template
 	// emit the same `wa-inline-frame` postMessage protocol to size the iframe.
-	const isResponsiveHtmlFormat = templateFormat === 'html5_v2' || templateFormat === 'html5_v03';
+	const isResponsiveHtmlFormat = templateFormat === 'html5_v2' || templateFormat === 'html5_v3';
 
 	useEffect( () => {
 		if ( ! isLoading && isResponsiveHtmlFormat ) {
@@ -53,7 +53,7 @@ export default function AdPreview( { htmlCode, isLoading, templateFormat, width 
 
 	const classes = clsx( 'campaign-item-details__preview-content', {
 		v02: templateFormat === 'html5_v2',
-		v03: templateFormat === 'html5_v03',
+		v03: templateFormat === 'html5_v3',
 	} );
 
 	return (

--- a/client/my-sites/promote-post-i2/components/ad-preview/index.tsx
+++ b/client/my-sites/promote-post-i2/components/ad-preview/index.tsx
@@ -13,9 +13,12 @@ interface Props {
 export default function AdPreview( { htmlCode, isLoading, templateFormat, width }: Props ) {
 	const adWidth = width ? `${ width }` : '300px';
 
+	// Both the classic html5_v2 template and the AI-generated html5_v03 template
+	// emit the same `wa-inline-frame` postMessage protocol to size the iframe.
+	const isResponsiveHtmlFormat = templateFormat === 'html5_v2' || templateFormat === 'html5_v03';
+
 	useEffect( () => {
-		if ( ! isLoading && templateFormat === 'html5_v2' ) {
-			// we only need this listener to resize the iframe for html5_v2 templates
+		if ( ! isLoading && isResponsiveHtmlFormat ) {
 			window.addEventListener( 'message', function ( msg ) {
 				if ( typeof msg.data !== 'object' ) {
 					return;
@@ -38,7 +41,7 @@ export default function AdPreview( { htmlCode, isLoading, templateFormat, width 
 				}
 			} );
 		}
-	}, [ isLoading, templateFormat ] );
+	}, [ isLoading, isResponsiveHtmlFormat ] );
 
 	if ( isLoading ) {
 		return (
@@ -50,6 +53,7 @@ export default function AdPreview( { htmlCode, isLoading, templateFormat, width 
 
 	const classes = clsx( 'campaign-item-details__preview-content', {
 		v02: templateFormat === 'html5_v2',
+		v03: templateFormat === 'html5_v03',
 	} );
 
 	return (

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -493,17 +493,20 @@ export default function CampaignItemDetails( props: Props ) {
 		? `$${ formatCents( total_budget_used || 0, 2 ) }`
 		: '- ';
 
-	const adPreviewLabel =
-		// maybe we will need to edit this condition when we add more templates
-		format !== 'html5_v2' ? (
-			<div className="campaign-item-details__preview-header-dimensions">
-				<span>{ `${ width }x${ height }` }</span>
-			</div>
-		) : (
-			<div className="campaign-item-details__preview-header-preview-button">
-				<AdPreviewModal templateFormat={ format || '' } htmlCode={ creative_html || '' } />
-			</div>
-		);
+	// Both the classic (html5_v2) and AI-generated (html5_v03) responsive WP
+	// placements ship a renderable HTML doc — anything else has no preview,
+	// just dimensions.
+	const isWpcomHtmlFormat = format === 'html5_v2' || format === 'html5_v03';
+
+	const adPreviewLabel = isWpcomHtmlFormat ? (
+		<div className="campaign-item-details__preview-header-preview-button">
+			<AdPreviewModal templateFormat={ format || '' } htmlCode={ creative_html || '' } />
+		</div>
+	) : (
+		<div className="campaign-item-details__preview-header-dimensions">
+			<span>{ `${ width }x${ height }` }</span>
+		</div>
+	);
 
 	const getDestinationLabel = () => {
 		switch ( type ) {
@@ -1566,7 +1569,7 @@ export default function CampaignItemDetails( props: Props ) {
 								isLoading={ isLoading }
 								htmlCode={ creative_html || '' }
 								templateFormat={ format || '' }
-								width={ format === 'html5_v2' ? '100%' : '300px' }
+								width={ isWpcomHtmlFormat ? '100%' : '300px' }
 							/>
 							<div className="campaign-item-details__preview-disclosure">
 								{ getExternalTabletIcon() }

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -493,10 +493,10 @@ export default function CampaignItemDetails( props: Props ) {
 		? `$${ formatCents( total_budget_used || 0, 2 ) }`
 		: '- ';
 
-	// Both the classic (html5_v2) and AI-generated (html5_v03) responsive WP
+	// Both the classic (html5_v2) and AI-generated (html5_v3) responsive WP
 	// placements ship a renderable HTML doc — anything else has no preview,
 	// just dimensions.
-	const isWpcomHtmlFormat = format === 'html5_v2' || format === 'html5_v03';
+	const isWpcomHtmlFormat = format === 'html5_v2' || format === 'html5_v3';
 
 	const adPreviewLabel = isWpcomHtmlFormat ? (
 		<div className="campaign-item-details__preview-header-preview-button">

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -731,13 +731,15 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 		width: 300px;
 	}
 
-	.campaign-item-details__preview-content.v02 {
+	.campaign-item-details__preview-content.v02,
+	.campaign-item-details__preview-content.v03 {
 		margin: 0 auto;
 		min-width: 300px;
 		width: 100%;
 	}
 
-	.campaign-item-details__preview-content.v02 iframe {
+	.campaign-item-details__preview-content.v02 iframe,
+	.campaign-item-details__preview-content.v03 iframe{
 		height: 200px;
 		width: 100%;
 	}


### PR DESCRIPTION
This is a minor hotfix PR. No linear ticket

Part of https://linear.app/a8c/project/rsm-blaze-ai-ad-manager-6d76354a4fe6/overview

## Proposed Changes
New handling of html5_v03

## Why are these changes being made?

We are planning to implement a new Blaze ad format (with name `html5_v03` 

this PR is just handling the new format (the code is similar to v02 so it is just adding the new format in a couple of conditions and adding some styles)

## Testing Instructions

You can checkout the branch and check in a campaign details page that everything looks ok

(changes are just affecting the ad preview)

![Uploading Screenshot 2026-04-27 at 12.22.15.png…]()


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
