### PR TITLE
Reader: On This Day `month` / `day` query params

### DIFF
--- a/client/reader/on-this-day/get-stream-key.ts
+++ b/client/reader/on-this-day/get-stream-key.ts
@@ -1,0 +1,46 @@
+/**
+ * Build the reader stream key for On This Day.
+ * When month and day query args are present and valid, the key includes them so
+ * stream state and API requests are scoped to that calendar day.
+ */
+export function getOnThisDayStreamKey(
+	query: Record< string, string | string[] | undefined > | null | undefined
+): string {
+	if ( ! query ) {
+		return 'on_this_day';
+	}
+	const rawM = query.month;
+	const rawD = query.day;
+	if ( rawM == null || rawD == null ) {
+		return 'on_this_day';
+	}
+	const m = parseInt( Array.isArray( rawM ) ? rawM[ 0 ] : rawM, 10 );
+	const d = parseInt( Array.isArray( rawD ) ? rawD[ 0 ] : rawD, 10 );
+	if ( ! Number.isFinite( m ) || ! Number.isFinite( d ) || m < 1 || m > 12 || d < 1 || d > 31 ) {
+		return 'on_this_day';
+	}
+	return `on_this_day:${ m }:${ d }`;
+}
+
+type OnThisDayQueryArgs = Parameters< typeof getOnThisDayStreamKey >[ 0 ];
+
+/**
+ * Subtitle for the list header: the selected calendar day, or "today" when no query args.
+ */
+export function getOnThisDayHeaderDateLabel( query: OnThisDayQueryArgs ): string {
+	if ( getOnThisDayStreamKey( query ) === 'on_this_day' ) {
+		return new Date().toLocaleDateString( undefined, {
+			month: 'long',
+			day: 'numeric',
+		} );
+	}
+	const rawM = query?.month;
+	const rawD = query?.day;
+	const m = parseInt( Array.isArray( rawM ) ? rawM[ 0 ] : String( rawM ), 10 );
+	const d = parseInt( Array.isArray( rawD ) ? rawD[ 0 ] : String( rawD ), 10 );
+	const year = 2020; // leap year so Feb 29 displays if ever valid server-side
+	return new Date( year, m - 1, d ).toLocaleDateString( undefined, {
+		month: 'long',
+		day: 'numeric',
+	} );
+}

--- a/client/reader/on-this-day/index.tsx
+++ b/client/reader/on-this-day/index.tsx
@@ -17,7 +17,9 @@ import { getReaderFollowForFeed } from 'calypso/state/reader/follows/selectors';
 import { getPostByKey } from 'calypso/state/reader/posts/selectors';
 import { requestPaginatedStream } from 'calypso/state/reader/streams/actions';
 import { viewStream } from 'calypso/state/reader-ui/actions';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import Skeleton from '../components/skeleton';
+import { getOnThisDayHeaderDateLabel } from './get-stream-key';
 import { OnThisDayPostField } from './on-this-day-post-field';
 import { OnThisDayPostSkeleton } from './on-this-day-post-skeleton';
 import type { AppState } from 'calypso/types';
@@ -65,13 +67,13 @@ function itemKeyString( item: ReaderPost ) {
 	return `${ item.blogId }-${ item.postId }`;
 }
 
-const STREAM_KEY = 'on_this_day';
-
 interface OnThisDayProps {
 	viewToggle?: React.ReactNode;
+	streamKey: string;
 }
 
-export const OnThisDay = ( { viewToggle }: OnThisDayProps ) => {
+export const OnThisDay = ( { viewToggle, streamKey }: OnThisDayProps ) => {
+	const query = useSelector( getCurrentQueryArguments );
 	const dispatch = useDispatch< ThunkDispatch< AppState, void, UnknownAction > >();
 	const [ selectedItem, setSelectedItem ] = useState< ReaderPost | null >( null );
 	const isWide = useBreakpoint( WIDE_BREAKPOINT );
@@ -95,7 +97,7 @@ export const OnThisDay = ( { viewToggle }: OnThisDayProps ) => {
 		showMedia: true,
 	} );
 
-	const data = useSelector( ( state: AppState ) => state.reader?.streams?.[ STREAM_KEY ] );
+	const data = useSelector( ( state: AppState ) => state.reader?.streams?.[ streamKey ] );
 	const posts = useSelector( ( state: AppState ) => {
 		const items = data?.items;
 		if ( ! items ) {
@@ -182,15 +184,17 @@ export const OnThisDay = ( { viewToggle }: OnThisDayProps ) => {
 	);
 
 	const fetchData = useCallback( () => {
-		dispatch( viewStream( STREAM_KEY, window.location.pathname ) as UnknownAction );
+		const pathForView =
+			typeof window !== 'undefined' ? window.location.pathname + window.location.search : '';
+		dispatch( viewStream( streamKey, pathForView ) as UnknownAction );
 		dispatch(
 			requestPaginatedStream( {
-				streamKey: STREAM_KEY,
+				streamKey,
 				page: view.page,
 				perPage: view.perPage,
 			} ) as UnknownAction
 		);
-	}, [ dispatch, view ] );
+	}, [ dispatch, view, streamKey ] );
 
 	const defaultPaginationInfo = useMemo( () => {
 		return {
@@ -237,17 +241,14 @@ export const OnThisDay = ( { viewToggle }: OnThisDayProps ) => {
 		[ shownData ]
 	);
 
-	const todayFormatted = new Date().toLocaleDateString( undefined, {
-		month: 'long',
-		day: 'numeric',
-	} );
+	const headerDateLabel = getOnThisDayHeaderDateLabel( query );
 
 	return (
 		/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */
 		<div className="on-this-day" onKeyDown={ handleKeyDown }>
 			<div className={ `on-this-day__list-column ${ selectedItem ? 'has-overlay' : '' }` }>
 				<div className="on-this-day__list-column-header">
-					<NavigationHeader title={ translate( 'On This Day' ) } subtitle={ todayFormatted }>
+					<NavigationHeader title={ translate( 'On This Day' ) } subtitle={ headerDateLabel }>
 						{ viewToggle }
 					</NavigationHeader>
 				</div>

--- a/client/reader/on-this-day/main.tsx
+++ b/client/reader/on-this-day/main.tsx
@@ -1,6 +1,6 @@
 import { Card, CardBody } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
 import NavigationHeader from 'calypso/components/navigation-header';
 import ResurrectedWelcomeModalGate from 'calypso/components/resurrected-welcome-modal';
@@ -11,13 +11,17 @@ import ReaderStream from 'calypso/reader/stream';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { selectSidebarRecentSite } from 'calypso/state/reader-ui/sidebar/actions';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import { useFollowingView } from '../following/view-preference';
 import ViewToggle from '../following/view-toggle';
+import { getOnThisDayStreamKey } from './get-stream-key';
 import { OnThisDay } from './index';
 import '../following/style.scss';
 
 function OnThisDayStream() {
 	const { currentView } = useFollowingView();
+	const query = useSelector( getCurrentQueryArguments );
+	const onThisDayStreamKey = useMemo( () => getOnThisDayStreamKey( query ), [ query ] );
 	const dispatch = useDispatch();
 	const [ isResurrectedModalVisible, setIsResurrectedModalVisible ] = useState( false );
 	const [ shouldDelayReaderOnboarding, setShouldDelayReaderOnboarding ] = useState( false );
@@ -54,9 +58,9 @@ function OnThisDayStream() {
 	return (
 		<>
 			{ currentView === 'recent' ? (
-				<OnThisDay viewToggle={ <ViewToggle /> } />
+				<OnThisDay viewToggle={ <ViewToggle /> } streamKey={ onThisDayStreamKey } />
 			) : (
-				<ReaderStream streamKey="on_this_day" className="following">
+				<ReaderStream streamKey={ onThisDayStreamKey } trackScrollPage className="following">
 					<NavigationHeader
 						title={ translate( 'On This Day' ) }
 						subtitle={ translate( 'Posts from this day in previous years.' ) }

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -362,7 +362,20 @@ const streamApis = {
 		path: () => '/read/streams/on-this-day',
 		dateProperty: 'date',
 		apiNamespace: () => 'wpcom/v2',
-		query: ( extras ) => getQueryString( { ...extras, number: 15 } ),
+		query: ( extras, { streamKey } ) => {
+			const base = { ...extras, number: 15 };
+			if ( streamKey?.startsWith( 'on_this_day:' ) ) {
+				const parts = streamKey.split( ':' );
+				if ( parts.length >= 3 ) {
+					const month = parseInt( parts[ 1 ], 10 );
+					const day = parseInt( parts[ 2 ], 10 );
+					if ( Number.isFinite( month ) && Number.isFinite( day ) ) {
+						return getQueryString( { ...base, month, day } );
+					}
+				}
+			}
+			return getQueryString( base );
+		},
 	},
 };
 


### PR DESCRIPTION
## Summary
Adds support for `?month=` and `?day=` on `/reader/on-this-day`.

- Uses a scoped stream key (`on_this_day:M:D`) when both params are valid so Redux state and fetches stay separate per calendar day.
- Forwards `month` and `day` to the `wpcom/v2` `/read/streams/on-this-day` endpoint via the existing streams data layer.
- Updates the list header subtitle to reflect the selected date (or today when params are absent/invalid).
- Applies the same stream key to the card (`ReaderStream`) view for consistency.

## Testing
- Visit `/reader/on-this-day` (no params): should match current "today" behavior.
- Visit `/reader/on-this-day?month=4&day=27`: list and stream requests should include the month/day; header shows that date.
- Invalid ranges should fall back to default (no extra query args on the API).

Made with [Cursor](https://cursor.com)