### PR TITLE
Omnibar: construct user info node

### DIFF
--- a/packages/omnibar/src/components/omnibar-user.scss
+++ b/packages/omnibar/src/components/omnibar-user.scss
@@ -1,4 +1,5 @@
-.omnibar {
+.omnibar,
+.omnibar__popover {
 	.omnibar__user-avatar {
 		display: inline-flex;
 		width: 20px;
@@ -6,11 +7,23 @@
 		border-radius: 50%;
 		overflow: hidden;
 
+		&.omnibar__user-info-avatar {
+			width: 56px;
+			height: 56px;
+		}
+
 		> * {
 			width: 100%;
 			height: 100%;
 			display: block;
 			object-fit: cover;
 		}
+	}
+}
+
+.omnibar__popover {
+	.omnibar__user-avatar {
+		width: 56px;
+		height: 56px;
 	}
 }

--- a/packages/omnibar/src/components/omnibar-user.tsx
+++ b/packages/omnibar/src/components/omnibar-user.tsx
@@ -1,4 +1,7 @@
-import { __experimentalHStack as HStack } from '@wordpress/components';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
 import { OmnibarMenu } from './omnibar-menu';
 import type { OmnibarNode } from '../types';
 
@@ -15,6 +18,27 @@ export function OmnibarUserNode( { node }: { node: OmnibarNode } ) {
 						{ icon && <span className="omnibar__user-avatar">{ icon }</span> }
 					</HStack>
 				),
+				children: node.children?.map( ( child ) => ( {
+					...child,
+					children: child.children?.map( ( grandChild ) => {
+						if ( grandChild.id === 'user-info' ) {
+							return {
+								...grandChild,
+								render: ( { title, icon, meta } ) => (
+									<HStack spacing={ 3 } expanded={ false }>
+										{ icon && <span className="omnibar__user-avatar">{ icon }</span> }
+										<VStack>
+											<span>{ meta?.displayName }</span>
+											<span>@{ meta?.username }</span>
+											<span>{ title }</span>
+										</VStack>
+									</HStack>
+								),
+							};
+						}
+						return grandChild;
+					} ),
+				} ) ),
 			} }
 		/>
 	);

--- a/packages/omnibar/src/utils/admin-bar.tsx
+++ b/packages/omnibar/src/utils/admin-bar.tsx
@@ -59,6 +59,11 @@ export function buildOmnibarNodesFromAdminBarNodes( adminBarNodes: AdminBarNode[
 			case 'user-info': {
 				const doc = new DOMParser().parseFromString( node.title || '', 'text/html' );
 				omnibarNode.title = doc.querySelector( '.edit-profile' )?.textContent?.trim() || '';
+				omnibarNode.icon = omnibarNodes.user?.icon;
+				omnibarNode.meta = {
+					displayName: doc.querySelector( '.display-name' )?.textContent?.trim(),
+					username: doc.querySelector( '.username' )?.textContent?.trim(),
+				};
 				break;
 			}
 		}


### PR DESCRIPTION
## Proposed Changes

Construct the user info node for Omnibar as follows:

<img width="204" height="252" alt="image" src="https://github.com/user-attachments/assets/77dbe9e0-275b-48c8-a5ed-c0e6749cbee2" />
