### PR TITLE
Fix badge hardcoded colors

### DIFF
--- a/client/dashboard/app/_dark-theme.scss
+++ b/client/dashboard/app/_dark-theme.scss
@@ -796,6 +796,43 @@
 	--color-border-subtle: var( --dashboard-surface__border-color );
 }
 
+/* Site Logs Badges */
+@mixin dashboard-dark-theme-site-logs-badges {
+	// Data table badges in the logs views don't declare a Badge intent, and
+	// override the colors locally, so we have to target them directly here.
+	:is( .site-logs-card, .site-logs-details-modal ) :is(
+			.badge--POST,
+			.badge--deprecated,
+			.badge--GET,
+			.badge--DELETE,
+			.badge--error,
+			.badge--fatal,
+			.badge--warning,
+			.badge--user
+		) {
+		background-color: color-mix(
+			in srgb,
+			var( --wp-components-color-background ) 90%,
+			var( --base-color )
+		);
+		color: color-mix(
+			in srgb,
+			var( --wp-components-color-foreground ) 50%,
+			var( --base-color )
+		);
+
+		// `<Badge intent="default">` adds `.is-default`, which the Badge
+		// component pairs with an inset box-shadow in dark mode to stay
+		// visible against the card surface. The colored variants above
+		// already make the chip visible, so clear the shadow — except for
+		// `.badge--user`, whose gray-tinted bg is too close to the surface
+		// to stand on its own.
+		&:not( .badge--user ) {
+			box-shadow: none;
+		}
+	}
+}
+
 // :root variables overridden for dark theme
 @mixin dashboard-dark-theme {
 	// Overrides the default `--wp-components-*` to ensure all components that
@@ -896,22 +933,23 @@
 	--jp-gray-100: #f0f0f0;
 	--jp-gray-off: #2a2a2a;
 
+	@include dashboard-calypso-theme-properties;
 	@include dashboard-dark-theme-action-list;
 	@include dashboard-dark-theme-breadcrumbs;
-	@include dashboard-dark-theme-card;
 	@include dashboard-dark-theme-callout;
+	@include dashboard-dark-theme-card;
 	@include dashboard-dark-theme-dataviews;
 	@include dashboard-dark-theme-destructive-secondary-button;
 	@include dashboard-dark-theme-emails;
 	@include dashboard-dark-theme-form-controls;
 	@include dashboard-dark-theme-item-group;
-	@include dashboard-dark-theme-panel;
-	@include dashboard-dark-theme-popover;
-	@include dashboard-dark-theme-plugins;
 	@include dashboard-dark-theme-muted-text;
+	@include dashboard-dark-theme-panel;
+	@include dashboard-dark-theme-plugins;
+	@include dashboard-dark-theme-popover;
 	@include dashboard-dark-theme-scan;
 	@include dashboard-dark-theme-section-header;
 	@include dashboard-dark-theme-site-icon;
+	@include dashboard-dark-theme-site-logs-badges;
 	@include dashboard-dark-theme-summary-button;
-	@include dashboard-calypso-theme-properties;
 }

--- a/client/dashboard/sites/logs/dataviews/style.scss
+++ b/client/dashboard/sites/logs/dataviews/style.scss
@@ -18,11 +18,13 @@
 	// Data tables always use the default intent, and override the colors.
 	.badge--POST,
 	.badge--deprecated {
+		--base-color: var(--color-deprecated-blue-50);
 		background-color: var(--color-deprecated-blue-5);
 		color: var(--color-deprecated-blue-80);
 	}
 
 	.badge--GET {
+		--base-color: var(--studio-green-50);
 		background-color: var(--studio-green-5);
 		color: var(--studio-green-80);
 	}
@@ -30,6 +32,7 @@
 	.badge--DELETE,
 	.badge--error,
 	.badge--fatal {
+		--base-color: var(--studio-red-50);
 		background-color: var(--studio-red-5);
 		color: var(--studio-red-80);
 	}
@@ -39,11 +42,13 @@
 	}
 
 	.badge--warning {
+		--base-color: var(--studio-yellow-50);
 		background-color: var(--studio-yellow-5);
 		color: var(--studio-yellow-80);
 	}
 
 	.badge--user {
+		--base-color: var(--studio-gray-50);
 		background-color: var(--studio-gray-5);
 		color: var(--studio-gray-80);
 	}

--- a/client/dashboard/sites/logs/dataviews/style.scss
+++ b/client/dashboard/sites/logs/dataviews/style.scss
@@ -15,22 +15,23 @@
 /* Badges */
 .site-logs-card,
 .site-logs-details-modal {
+	// Data tables always use the default intent, and override the colors.
 	.badge--POST,
 	.badge--deprecated {
-		background-color: #bbe0fa;
-		color: #02395c;
+		background-color: var(--color-deprecated-blue-5);
+		color: var(--color-deprecated-blue-80);
 	}
 
 	.badge--GET {
-		background-color: #b8e6bf;
-		color: #00450c;
+		background-color: var(--studio-green-5);
+		color: var(--studio-green-80);
 	}
 
 	.badge--DELETE,
 	.badge--error,
 	.badge--fatal {
-		background-color: #facfd2;
-		color: #691c1c;
+		background-color: var(--studio-red-5);
+		color: var(--studio-red-80);
 	}
 
 	.badge--fatal {
@@ -38,13 +39,13 @@
 	}
 
 	.badge--warning {
-		background-color: #fff2d7;
-		color: #4f3500;
+		background-color: var(--studio-yellow-5);
+		color: var(--studio-yellow-80);
 	}
 
 	.badge--user {
-		background-color: #dcdcee;
-		color: #2c3338;
+		background-color: var(--studio-gray-5);
+		color: var(--studio-gray-80);
 	}
 }
 

--- a/packages/ui/src/badge/style.module.scss
+++ b/packages/ui/src/badge/style.module.scss
@@ -17,11 +17,6 @@ $badge-colors: (
 	background-color: color-mix(in srgb, colors.$white 90%, var(--base-color));
 	color: color-mix(in srgb, colors.$black 50%, var(--base-color));
 
-	@include ui-mixins.when-dark-theme {
-		background-color: color-mix(in srgb, theme.$components-color-background 90%, var(--base-color));
-		color: color-mix(in srgb, theme.$components-color-foreground 50%, var(--base-color));
-	}
-
 	padding: 0 variables.$grid-unit-10;
 	min-height: variables.$grid-unit-30;
 	max-width: 100%;
@@ -53,6 +48,11 @@ $badge-colors: (
 	@each $type, $color in $badge-colors {
 		&.is-#{$type} {
 			--base-color: #{$color};
+
+			@include ui-mixins.when-dark-theme {
+				background-color: color-mix(in srgb, theme.$components-color-background 90%, var(--base-color));
+				color: color-mix(in srgb, theme.$components-color-foreground 50%, var(--base-color));
+			}
 		}
 	}
 }


### PR DESCRIPTION
Part of RSM-1279

Badges declared in `client/dashboard/sites/logs/*` are:

1. All `default` intent
2. Override the default color with a similar variant
3. Don't have icons (they are `default`)

Dark mode applied to all badges did not apply to these badges because their colors were overridden.

| Default light colors | Logs light colors | Logs dark colors |
| --- | --- | --- |
| <img width="130" height="120" alt="Screenshot 2026-04-27 alle 11 37 35" src="https://github.com/user-attachments/assets/a7d92ff6-4656-488d-92c2-57db15ce2bb5" /> | <img width="100" height="161" alt="immagine" src="https://github.com/user-attachments/assets/0d5cab80-1eb8-47d6-a47f-98cf3bb8d6e7" /> | <img width="104" height="170" alt="immagine" src="https://github.com/user-attachments/assets/c87df0cb-cf58-4646-8c97-fa635f413816" />

Dark colors differ slightly from the other badges because they are calculated using a different base. The CSS formula is the same.

## Proposed Changes

* Substitute all hardcoded hex colors in `client/dashboard/sites/logs/dataviews/style.scss` with the `--studio-*` and `--color-*` variable names
* Apply default dark-mode to all intents except the default one
* Fix: missing `--base-color` on logs variant
* Fix: `badge-warning` had the wrong number for the background color

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix hardcoded values
* To apply dark-mode to logs tables

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
