### PR TITLE
E2E: fix flaky Me sidebar navigation

### DIFF
--- a/packages/calypso-e2e/src/lib/components/me/me-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/me/me-sidebar-component.ts
@@ -2,9 +2,12 @@ import { Page } from 'playwright';
 import envVariables from '../../../env-variables';
 
 const selectors = {
-	// Menu items
+	sidebar: '.sidebar',
+	// Menu items. Prefer an exact text match on the inner span to avoid
+	// matching unrelated items, and keep the legacy href clause as a
+	// fallback for callers that pass an href value instead of a label.
 	menuItem: ( menu: string ) =>
-		`.sidebar a:has(span:has-text("${ menu }")), .sidebar a[href="${ menu }"]`,
+		`.sidebar a:has(span:text-is("${ menu }")), .sidebar a[href="${ menu }"]`,
 };
 
 /**
@@ -20,6 +23,21 @@ export class MeSidebarComponent {
 	 */
 	constructor( page: Page ) {
 		this.page = page;
+	}
+
+	/**
+	 * Waits for the Me sidebar to be ready on the page.
+	 *
+	 * The /me endpoint hydrates client-side after navigation, which can
+	 * cause the sidebar links to detach and re-attach mid-click. Waiting
+	 * for the page to be loaded and the sidebar root to be visible avoids
+	 * racing the React re-render.
+	 */
+	private async waitForSidebarInitialization(): Promise< void > {
+		await Promise.all( [
+			this.page.waitForLoadState( 'load', { timeout: 20 * 1000 } ),
+			this.page.locator( selectors.sidebar ).waitFor( { timeout: 20 * 1000 } ),
+		] );
 	}
 
 	/**
@@ -40,6 +58,25 @@ export class MeSidebarComponent {
 	 * @param {string} menu Menu item label or href to navigate to.
 	 */
 	async navigate( menu: string ): Promise< void > {
-		await this.page.click( selectors.menuItem( menu ) );
+		await this.waitForSidebarInitialization();
+
+		// Resolve the menu link as a Locator and wait for it to be visible
+		// before reading its href. This avoids the "element was detached
+		// from the DOM, retrying" race where the sidebar re-renders right
+		// after the element is first resolved.
+		const menuItem = this.page.locator( selectors.menuItem( menu ) ).first();
+		await menuItem.waitFor( { state: 'visible', timeout: 20 * 1000 } );
+		const href = await menuItem.getAttribute( 'href' );
+
+		// Use dispatchEvent to bypass the actionability re-check that was
+		// failing when the link detached mid-click during sidebar hydration.
+		await menuItem.dispatchEvent( 'click' );
+
+		// Confirm the client-side navigation actually completed before the
+		// caller proceeds; otherwise subsequent assertions can run against
+		// the previous page.
+		if ( href ) {
+			await this.page.waitForURL( `**${ href }`, { waitUntil: 'domcontentloaded' } );
+		}
 	}
 }


### PR DESCRIPTION
## Proposed Changes

- Make `MeSidebarComponent.navigate()` resilient to client-side hydration on `/me`: wait for the page `load` state and the `.sidebar` root before doing anything, resolve the menu item as a `Locator`, and wait for the resulting URL to confirm the client-side navigation actually happened before returning.
- Dispatch the click via `dispatchEvent('click')` instead of `page.click()`, so the click bypasses the actionability re-check that was racing the sidebar re-render.
- Tighten the menu selector from `:has-text(...)` to `:text-is(...)` for an exact label match, while keeping the legacy `[href="..."]` fallback clause.

## Why are these changes being made?

The test `Setup Domain Flows › As a new user, I can create a paid site, add a domain, then cancel the plan` flaked on the parent PR's CI run, with the failure landing inside `MeSidebarComponent.navigate("Purchases")`:

```
TimeoutError: page.click: Timeout 10000ms exceeded.
Call log:
  - waiting for locator('.sidebar a:has(span:has-text("Purchases")), .sidebar a[href="Purchases"]')
    - locator resolved to <a href="/me/purchases" class="sidebar__menu-link">…</a>
  - attempting click action
    - waiting for element to be visible, enabled and stable
    - element was detached from the DOM, retrying
```

Evidence of the flake: [TeamCity build 17452235](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Playwright_Test_Matrix/17452235).

The helper called `page.click(...)` directly with no preconditions. After `pageMyProfile.visit()` navigated to `/me`, the Me sidebar was still hydrating client-side — Playwright resolved the `Purchases` `<a>` element, but the React re-render detached it from the DOM right before the click landed, and Playwright then spent the rest of the 10s default click timeout retrying actionability while the element kept being replaced. Fixing the helper rather than the call site means every test that uses `MeSidebarComponent.navigate(...)` benefits, not just this one.

## Testing Instructions

- Run `yarn playwright test test/e2e/specs/flows/setup-domain__flows.spec.ts --reporter=list --repeat-each=10` locally; all runs should pass.