### PR TITLE
E2E: fix flaky "Flaky by race condition"

### DIFF
--- a/test/e2e/specs/infrastructure/infrastructure__flaky-fixture.spec.ts
+++ b/test/e2e/specs/infrastructure/infrastructure__flaky-fixture.spec.ts
@@ -31,8 +31,8 @@ test.describe( 'Infrastructure: Flaky fixture (testing only)', { tag: [ tags.CAL
 			);
 		} );
 
-		await test.step( 'Then the element is visible within a too-short timeout', async function () {
-			await expect( page.locator( '#late' ) ).toBeVisible( { timeout: 150 } );
+		await test.step( 'Then the element becomes visible', async function () {
+			await expect( page.locator( '#late' ) ).toBeVisible();
 		} );
 	} );
 } );


### PR DESCRIPTION
## Proposed Changes

- Drops the explicit `{ timeout: 150 }` option from the `expect(page.locator('#late')).toBeVisible()` assertion in `test/e2e/specs/infrastructure/infrastructure__flaky-fixture.spec.ts`, letting Playwright's default auto-waiting handle the delay.
- Renames the surrounding `test.step` from "Then the element is visible within a too-short timeout" to "Then the element becomes visible" so the step description matches the new behavior.

## Why are these changes being made?

The fixture page injects `#late` after a random delay between 50ms and 850ms, but the assertion used an explicit `toBeVisible({ timeout: 150 })`. Whenever the random delay exceeded ~150ms — which happened on the vast majority of runs — the assertion's polling window expired before the element was appended, producing `element(s) not found` failures. The race was between Playwright's hard-capped 150ms wait and the page's own variable-delay DOM mutation, so the test passed only on the small subset of rolls below the timeout. Failure observed on TeamCity build [17452235](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Playwright_Test_Matrix/17452235) (both `[Mobile]` and `[Desktop]`, including the retry).

Removing the short timeout falls back on Playwright's default auto-waiting, which polls until the element appears or the test timeout is reached — comfortably exceeding the fixture's worst-case 850ms delay and aligning with the guidance in `test/e2e/docs-new/creating_reliable_tests.md` to rely on built-in polling rather than custom short timeouts.

## Testing Instructions

- Run `yarn playwright test test/e2e/specs/infrastructure/infrastructure__flaky-fixture.spec.ts --reporter=list --repeat-each=10` locally; all runs should pass.