### PR TITLE
Fix audio block showing 0:00 duration in Reader

### DIFF
--- a/client/lib/post-normalizer/rule-content-disable-autoplay.js
+++ b/client/lib/post-normalizer/rule-content-disable-autoplay.js
@@ -26,9 +26,9 @@ export function disableAutoPlayOnMedia( post, dom ) {
 	}
 	dom.querySelectorAll( 'audio, video' ).forEach( ( el ) => {
 		el.autoplay = false;
+		el.preload = 'metadata';
 		if ( el.tagName === 'VIDEO' ) {
 			el.controls = true;
-			el.preload = 'metadata';
 		}
 	} );
 	return post;

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -238,16 +238,16 @@ describe( 'index', () => {
 			};
 			const normalized = withContentDOM( [ disableAutoPlayOnMedia ] )( post );
 			expect( normalized ).toEqual( {
-				content: '<video controls="" preload="metadata"></video>',
+				content: '<video preload="metadata" controls=""></video>',
 			} );
 		} );
 
-		test( 'should strip autoplay attributes from audio', () => {
+		test( 'should strip autoplay attributes from audio and add preload', () => {
 			const post = {
 				content: '<audio autoplay="1"></audio>',
 			};
 			const normalized = withContentDOM( [ disableAutoPlayOnMedia ] )( post );
-			expect( normalized ).toEqual( { content: '<audio></audio>' } );
+			expect( normalized ).toEqual( { content: '<audio preload="metadata"></audio>' } );
 		} );
 
 		test( 'should strip autoplay like attributes from iframes', () => {


### PR DESCRIPTION
Set preload="metadata" on audio elements in the post normalizer, consistent with how video elements are already handled. Without this, browsers default to preload="none" and don't fetch duration metadata until the user clicks play.

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->


## Proposed Changes

*  Move `el.preload = 'metadata'` outside the VIDEO-only block in                                                                                                                                                  `rule-content-disable-autoplay.js` so it applies to both `<audio>`                                                                                                                                             and `<video>` elements. Update the existing audio test to assert                                                                                                                                                the attribute is now set correctly.        

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Audio blocks in the Reader show 0:00 duration until the user clicks                                                                                                                    play. The post normalizer already sets preload="metadata" on video                                                                                                                                            elements so their duration loads upfront, but audio elements were                                                                                                                                               missed. Without this attribute, browsers default to not fetching                                                                                                                                                audio metadata until playback starts.                                                                                                                                                                             
                                                                                                                                                                                                                    Note: iOS Safari ignores preload="metadata" due to Apple's media                                                                                                                                             autoload restrictions, so duration may still show 0:00 on iOS.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

  1. Open a Reader post that contains an audio block.                                                                                                                                                               
  2. Without clicking play, verify the audio player shows the correct
     duration (not 0:00).                         

Before 
<img width="1940" height="366" alt="CleanShot 2026-04-27 at 16 33 09@2x" src="https://github.com/user-attachments/assets/82eda64f-604f-4cf2-817e-089535f31089" />

After
<img width="1614" height="360" alt="CleanShot 2026-04-27 at 16 33 33@2x" src="https://github.com/user-attachments/assets/3bedd10e-0051-4ef8-b190-04380dff68e1" />


*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
