### PR TITLE
E2E: fix flaky LOHP theme signup test

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/logged-out-themes-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/logged-out-themes-page.ts
@@ -18,10 +18,26 @@ export class LoggedOutThemesPage {
 	/**
 	 * Filters the themes by the given filter.
 	 *
+	 * After applying the filter, waits for the filter dropdown to close and
+	 * for the theme grid to settle with at least one filtered theme card
+	 * rendered, so subsequent interactions don't race with the rerender.
+	 *
 	 * @param {string} filter - The filter to apply.
 	 */
 	async filterBy( filter: string ) {
+		const option = this.page.getByRole( 'option', { name: filter } );
+
 		await this.page.getByRole( 'combobox', { name: 'View' } ).click();
-		await this.page.getByRole( 'option', { name: filter } ).click();
+		await option.click();
+
+		// Wait for the option/listbox to be dismissed so the filter selection
+		// has been committed before we look for cards.
+		await option.waitFor( { state: 'hidden' } );
+
+		// Wait for the theme grid to settle after the filter triggers a
+		// refetch + rerender. A brief detach-then-reattach cycle is normal,
+		// so we explicitly wait for a card to be visible (not just attached)
+		// before allowing callers to click one.
+		await this.firstThemeCard.waitFor( { state: 'visible' } );
 	}
 }


### PR DESCRIPTION
## Proposed Changes

- Harden `LoggedOutThemesPage.filterBy()` in `packages/calypso-e2e` so it waits for the filter to actually apply before returning.
- Wait for the filter option/listbox to detach (confirming the combobox committed the selection) and for `firstThemeCard` to be `visible` after the refetch + rerender.
- No product code is touched; only the test page-object is hardened. The spec itself is unchanged.

## Why are these changes being made?

`LoggedOutThemesPage.filterBy()` returned as soon as the option was clicked, without waiting for the filter to actually be applied to the theme grid. Selecting a filter from the `View` combobox triggers a refetch and a React rerender of the `[data-e2e-theme]` cards: the unfiltered cards detach, a brief no-cards window opens, then the filtered cards mount. Because `filterBy` did not block on any of this, the very next call — `firstThemeCard.click()` — raced the rerender. On the unlucky retry interleaving the test either timed out waiting for cards to reappear (the retry log shows `waiting for locator('[data-e2e-theme]').first()` for 10s) or clicked a card from the unfiltered set right before it detached, navigating to a stale theme detail page whose `Get started` link took the flow somewhere other than the user-signup page, causing the original-attempt failure on `createYourAccountHeading`.

Failing TeamCity build: https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Playwright_Test_Matrix/17452235

## Testing Instructions

Run `yarn playwright test test/e2e/specs/onboarding/signup__with-theme-LOHP.spec.ts --reporter=list --repeat-each=10` locally; all runs should pass.