### PR TITLE
CI: hotfix — escape inlined prompt expression that broke workflow parse

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -239,7 +239,7 @@ jobs:
             **7. Information disclosure.** Flag tokens or PII in `console.log`, Sentry, or analytics payloads; stack traces in client-visible error responses. Calypso-internal IDs (`blog_id`, `studio_site_id`) are not PII.
             Message: `<Field> in <log | Sentry | analytics> may leak <category>.`
 
-            **8. Supply chain.** Only when the diff touches `.github/workflows/`. Flag `pull_request_target` + PR-branch checkout, `${{ ... }}` interpolation in `run:` with attacker-controllable values, unpinned third-party actions.
+            **8. Supply chain.** Only when the diff touches `.github/workflows/`. Flag `pull_request_target` + PR-branch checkout, GitHub Actions expression interpolation in `run:` bodies with attacker-controllable values (the dollar-double-curly syntax), unpinned third-party actions.
             Message: `<Specific risk> at <location>. <Specific fix>.`
 
             **9. Architecture awareness.** Flag when the diff imports `page.js` inside `client/dashboard/`, uses `useDispatch` from `react-redux` inside `client/dashboard/`, or adds new feature work to `client/my-sites/` (deprecated per AGENTS.md).


### PR DESCRIPTION
Trunk's \`pr-review.yml\` fails to load because of a literal \`\${\{ ... \}\}\` inside the inlined general prompt:

> \`(Line: 195, Col: 19): Unexpected symbol: '...'. Located at position 1 within expression: ...\`

GitHub Actions parses YAML expressions even inside literal-block scalars, so the prompt's axis 8 (which described the GHA expression-interpolation security pattern using its literal syntax) got interpreted as a workflow expression and failed.

Effect: every PR opened or updated against trunk shows three failed checks (\`pr-review.yml\`, \`dashboard-pr-review.yml\`, \`a4a-pr-review.yml\`).

Fix: rewrite axis 8 to describe the pattern in words ("GitHub Actions expression interpolation in run: bodies, the dollar-double-curly syntax") instead of the literal characters. Functionally equivalent for Claude; doesn't trip the GHA parser.

Lands clean on trunk; will need merge ASAP to unblock other contributors.