### PR TITLE
CI: pin AI review to the triggering PR number

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -97,6 +97,14 @@ jobs:
           prompt: |
             # Code Review Instructions
 
+            You are reviewing pull request #${{ github.event.issue.number || github.event.pull_request.number }} in ${{ github.repository }}.
+
+            When fetching the diff or PR metadata, ALWAYS pass the PR number explicitly:
+            - `gh pr diff ${{ github.event.issue.number || github.event.pull_request.number }} --repo ${{ github.repository }}`
+            - `gh pr view ${{ github.event.issue.number || github.event.pull_request.number }} --repo ${{ github.repository }} --json …`
+
+            Do NOT run `gh pr diff` or `gh pr view` without an explicit PR number argument. Do NOT infer the PR number from `git log`, `git branch`, or any other source.
+
             ## Primary Objective
 
             Review the PR based on the following documentation files as the guidelines:
@@ -147,6 +155,14 @@ jobs:
           prompt: |
             # Code Review Instructions (A4A)
 
+            You are reviewing pull request #${{ github.event.issue.number || github.event.pull_request.number }} in ${{ github.repository }}.
+
+            When fetching the diff or PR metadata, ALWAYS pass the PR number explicitly:
+            - `gh pr diff ${{ github.event.issue.number || github.event.pull_request.number }} --repo ${{ github.repository }}`
+            - `gh pr view ${{ github.event.issue.number || github.event.pull_request.number }} --repo ${{ github.repository }} --json …`
+
+            Do NOT run `gh pr diff` or `gh pr view` without an explicit PR number argument. Do NOT infer the PR number from `git log`, `git branch`, or any other source.
+
             ## Primary Objective
 
             Review the PR against the Automattic for Agencies (A4A) guidelines in the following documentation files:
@@ -194,6 +210,14 @@ jobs:
           anthropic_api_key: ${{ secrets.anthropic_api_key }}
           prompt: |
             # Code Review Instructions (General)
+
+            You are reviewing pull request #${{ github.event.issue.number || github.event.pull_request.number }} in ${{ github.repository }}.
+
+            When fetching the diff or PR metadata, ALWAYS pass the PR number explicitly:
+            - `gh pr diff ${{ github.event.issue.number || github.event.pull_request.number }} --repo ${{ github.repository }}`
+            - `gh pr view ${{ github.event.issue.number || github.event.pull_request.number }} --repo ${{ github.repository }} --json …`
+
+            Do NOT run `gh pr diff` or `gh pr view` without an explicit PR number argument. Do NOT infer the PR number from `git log`, `git branch`, or any other source.
 
             ## Primary Objective
 


### PR DESCRIPTION
Tell the bot to always pass an explicit PR number to `gh pr diff` and `gh pr view`. Without this, the bot can call `gh pr diff` with no argument and end up reviewing whatever PR git infers from the current branch, which after a recent merge into trunk can resolve to a different PR than the one `@claude /review` was posted on.

# Observed

[PR #110206](https://github.com/Automattic/wp-calypso/pull/110206) (a 3-line signup-form fix) was reviewed against [PR #110193](https://github.com/Automattic/wp-calypso/pull/110193)'s commit and files. The bot's [first comment on #110206](https://github.com/Automattic/wp-calypso/pull/110206#discussion_r3147307052) flags `client/dashboard/components/logs-activity/activity-event.scss` — a file from #110193, not in #110206's diff. Timeline:

- 12:24 — #110193 (dashboard dark mode) merged into trunk
- 12:30 — `@claude /review` fires on #110206
- 12:35 — bot posts comment with `commit_id: 569b0256` (#110193's head SHA), reviewing a #110193 file

# Fix

Add this block at the top of all three inlined prompts (dashboard / a4a / general):

```
You are reviewing pull request #${{ github.event.issue.number || github.event.pull_request.number }} in ${{ github.repository }}.

When fetching the diff or PR metadata, ALWAYS pass the PR number explicitly:
- `gh pr diff <N> --repo <repo>`
- `gh pr view <N> --repo <repo> --json …`

Do NOT run `gh pr diff` or `gh pr view` without an explicit PR number argument. Do NOT infer the PR number from `git log`, `git branch`, or any other source.
```

GitHub Actions interpolates the `${{ … }}` expressions before the prompt is passed to the action, so Claude sees the literal PR number.

# Why not a tooling-level fix

`claude-code-action`'s `--allowedTools` only supports glob-style patterns (`Bash(gh pr diff:*)`); it can't enforce a specific argument value. Constraining via the prompt is the only available knob short of patching the action.