### PR TITLE
Omnibar: fix body height when omnibar is present

### DIFF
--- a/client/dashboard/app/root/style.scss
+++ b/client/dashboard/app/root/style.scss
@@ -1,4 +1,11 @@
 @import '../responsive-sidebar/variables';
+
+.dashboard-root__layout {
+	display: flex;
+	flex-direction: column;
+	min-height: 100%;
+}
+
 // Old layout (no sidebar): sticky header
 // For pages without sub menus, the first header is the sticky header
 // For pages with sub menus, the second header is the sticky header
@@ -11,7 +18,7 @@
 
 .dashboard-root__body {
 	display: flex;
-	min-height: calc(100vh - var(--masterbar-height) );
+	flex: 1;
 
 	&:has(.dashboard-responsive-sidebar) {
 		overflow-x: hidden;


### PR DESCRIPTION
## Proposed Changes

* Make `.dashboard-root__layout` a flex column with `min-height: 100%`, and switch `.dashboard-root__body` from `min-height: calc(100vh - var(--masterbar-height))` to `flex: 1`.

## Why are these changes being made?

* When the omnibar (or interim omnibar) is shown, the page had a phantom 32px of trailing scrollable space at the bottom.
* The cause: `#wpcom` sets `padding-block-start: 32px` (the omnibar height) and `min-height: calc(100vh - 32px)`, while `.dashboard-root__body` independently set `min-height: calc(100vh - var(--masterbar-height))`. Both calculations are anchored to the viewport (`100vh`) rather than to the parent's content box, so any subpixel/box-sizing slack in that math overshoots the available area by exactly the masterbar/omnibar height (32px on ≥782px), producing the trailing scroll.
* Replacing the viewport-based calc with a flex-grow inside a flex-column layout removes the duplicated `100vh` math. The body now fills its parent's content area directly, regardless of the omnibar/masterbar variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)