### PR TITLE
CI: harden AI review workflows per @taipeicoder review

### DIFF
--- a/.github/workflows/a4a-pr-review.yml
+++ b/.github/workflows/a4a-pr-review.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   review:
     if: github.event.pull_request.draft == false
-    uses: ./.github/workflows/pr-review.yml
+    uses: Automattic/wp-calypso/.github/workflows/pr-review.yml@trunk
     with:
       area: a4a
     secrets:

--- a/.github/workflows/dashboard-pr-review.yml
+++ b/.github/workflows/dashboard-pr-review.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   review:
     if: github.event.pull_request.draft == false
-    uses: ./.github/workflows/pr-review.yml
+    uses: Automattic/wp-calypso/.github/workflows/pr-review.yml@trunk
     with:
       area: dashboard
     secrets:

--- a/.github/workflows/pr-review-on-ping.yml
+++ b/.github/workflows/pr-review-on-ping.yml
@@ -9,9 +9,10 @@ on:
     types: [submitted]
 
 concurrency:
-  # Scope by event_name and sender so the bot's own review and
-  # review-comment posts don't cancel an in-progress run.
-  group: pr-review-on-ping-${{ github.event_name }}-${{ github.event.sender.login }}-${{ github.event.issue.number || github.event.pull_request.number }}
+  # Bot senders get a unique bucket per run so their inline-comment posts
+  # don't cancel an in-progress review. Human pings on the same PR share
+  # a bucket so a newer ping cancels an older one.
+  group: ${{ github.event.sender.type == 'Bot' && format('pr-review-on-ping-bot-{0}-{1}', github.event.sender.login, github.run_id) || format('pr-review-on-ping-{0}', github.event.issue.number || github.event.pull_request.number) }}
   cancel-in-progress: true
 
 permissions:
@@ -56,7 +57,7 @@ jobs:
 
   review:
     needs: detect
-    uses: ./.github/workflows/pr-review.yml
+    uses: Automattic/wp-calypso/.github/workflows/pr-review.yml@trunk
     with:
       area: ${{ needs.detect.outputs.area }}
     secrets:

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -35,6 +35,15 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
+      - name: Validate area input
+        env:
+          AREA: ${{ inputs.area }}
+        run: |
+          case "$AREA" in
+            dashboard|a4a|general) ;;
+            *) echo "::error::Unknown area: '$AREA'. Must be one of: dashboard, a4a, general."; exit 1 ;;
+          esac
+
       # Fork-reject. With pull_request, GitHub already strips secrets from
       # fork PRs, but the issue_comment trigger on pr-review-on-ping.yml
       # fires from the default branch with secrets in scope, so a fork PR


### PR DESCRIPTION
Three follow-ups from @taipeicoder's review of #110194.

# 1. Lock the reusable to trunk ([discussion](https://github.com/Automattic/wp-calypso/pull/110194#discussion_r3147645101))

Each caller now uses an absolute ref:

```yaml
uses: Automattic/wp-calypso/.github/workflows/pr-review.yml@trunk
```

With the relative path (`./.github/workflows/pr-review.yml`) the runner resolved the reusable from the PR head's tree on `pull_request` events, which meant a same-repo PR could modify `pr-review.yml` in its branch and have that version run.

About OIDC defense as a fallback: the OIDC token sent to api.anthropic.com is a JWT containing both `workflow_ref` (entry workflow) and `job_workflow_ref` (workflow file running the job) as claims, per [GitHub's OIDC token docs](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#understanding-the-oidc-token). The action source forwards the JWT verbatim ([`src/github/token.ts:60-80`](https://github.com/anthropics/claude-code-action/blob/567fe954a4527e81f132d87d1bdbcc94f7737434/src/github/token.ts#L60-L80) — Bearer header, body is just `{ permissions }`, no client-side decoding) and only reads back the server's `error_code` if the exchange fails. Which claim Anthropic's server validates is opaque to the client. The `@trunk` defense operates at the runner level before any of that.

Same shape as the [woocommerce/.github reusable callers](https://github.com/woocommerce/automatewoo-birthdays/blob/trunk/.github/workflows/ai-code-review.yml#L12) (`uses: woocommerce/.github/.github/workflows/ai-code-review.yml@trunk`), which has been running in production across 17 satellite repos.

# 2. Validate the `area` input ([discussion](https://github.com/Automattic/wp-calypso/pull/110194#discussion_r3147463411))

```yaml
- name: Validate area input
  env:
    AREA: ${{ inputs.area }}
  run: |
    case "$AREA" in
      dashboard|a4a|general) ;;
      *) echo "::error::Unknown area: '$AREA'. Must be one of: dashboard, a4a, general."; exit 1 ;;
    esac
```

Without this, a typo (e.g. `dashbaord`) silently skips all three `Run review (X)` steps' if-conditions, leaves the job passing with zero output, and nobody notices.

# 3. Refine on-ping concurrency bucketing ([discussion](https://github.com/Automattic/wp-calypso/pull/110194#discussion_r3147621083))

Previous key included `sender.login`, which gave every sender a unique bucket. That fixed the bot-self-cancel issue but stopped two humans pinging the same PR from cancelling each other (they'd race in parallel, doubling cost).

New key uses `sender.type`:

```yaml
group: ${{ github.event.sender.type == 'Bot' && format('pr-review-on-ping-bot-{0}-{1}', github.event.sender.login, github.run_id) || format('pr-review-on-ping-{0}', github.event.issue.number || github.event.pull_request.number) }}
```

- Bot senders get a unique bucket per run → bot's inline-comment posts can't cancel an in-progress review.
- All human senders on the same PR share a bucket → newer ping cancels older one (original intent).

# Validation

- `actionlint` exit 0 across all four files
- All three changes are pure prompt/control-flow; no functional change to what the bot does once it's running

# Notes

Per the OIDC catch-22 we hit all day: this PR's changes will not be exercisable on the PR itself. Will land and verify on a follow-up smoke test.