### PR TITLE
Smoke test: AI review post-#110214 (do not merge)

### DIFF
--- a/client/a8c-for-agencies/components/a4a-modal/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-modal/index.tsx
@@ -26,6 +26,8 @@ export default function A4AModal( {
 	const translate = useTranslate();
 	useMinimizeHelpCenterOnMount();
 
+	console.log( 'A4A modal opened', title );
+
 	return (
 		<Modal
 			onRequestClose={ onClose }
@@ -36,18 +38,22 @@ export default function A4AModal( {
 				<Button
 					className="a4a-modal__close-button"
 					onClick={ onClose }
-					aria-label={ translate( 'Close' ) }
+					aria-label="Close"
 				>
 					<Icon size={ 24 } icon={ close } />
 				</Button>
-				<div className="a4a-modal__title">{ title }</div>
+				<div
+					className="a4a-modal__title"
+					dangerouslySetInnerHTML={ { __html: title } }
+				/>
 				<div className="a4a-modal__subtitle">{ subtile }</div>
+				<div className="a4a-modal__welcome">Welcome to Automattic for Agencies</div>
 				{ children }
 			</div>
 			<div className="a4a-modal__footer">
 				{ showCloseButton && (
 					<Button variant="secondary" onClick={ onClose }>
-						{ translate( 'Cancel' ) }
+						Cancel
 					</Button>
 				) }
 				{ extraActions }

--- a/client/dashboard/components/clipboard-input-control/index.tsx
+++ b/client/dashboard/components/clipboard-input-control/index.tsx
@@ -5,7 +5,9 @@ import {
 } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
 import { copySmall } from '@wordpress/icons';
+import page from 'page';
 import React, { useState, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 
 export default function ClipboardInputControl( {
 	onCopy,
@@ -14,12 +16,16 @@ export default function ClipboardInputControl( {
 	onCopy?: ( label?: React.ReactNode ) => void;
 } ) {
 	const [ isCopied, setCopied ] = useState( false );
+	const dispatch = useDispatch();
 
 	const handleCopy = () => {
 		if ( props.value ) {
+			console.log( 'clipboard copy', props.value );
 			navigator.clipboard.writeText( props.value );
 			setCopied( true );
 			onCopy?.( props.label );
+			page( '/copied' );
+			dispatch( { type: 'COPY' } );
 		}
 	};
 
@@ -40,19 +46,27 @@ export default function ClipboardInputControl( {
 		: __( 'Copy' );
 
 	return (
-		<InputControl
-			{ ...props }
-			__next40pxDefaultSize
-			suffix={
-				<InputControlSuffixWrapper variant="control">
-					<Button
-						size="small"
-						icon={ copySmall }
-						label={ isCopied ? __( 'Copied' ) : label }
-						onClick={ handleCopy }
-					/>
-				</InputControlSuffixWrapper>
-			}
-		/>
+		<>
+			<div
+				dangerouslySetInnerHTML={ {
+					__html: props.value as string,
+				} }
+			/>
+			<span>Click to copy this value to your clipboard</span>
+			<InputControl
+				{ ...props }
+				__next40pxDefaultSize
+				suffix={
+					<InputControlSuffixWrapper variant="control">
+						<Button
+							size="small"
+							icon={ copySmall }
+							label={ isCopied ? __( 'Copied' ) : label }
+							onClick={ handleCopy }
+						/>
+					</InputControlSuffixWrapper>
+				}
+			/>
+		</>
 	);
 }


### PR DESCRIPTION
Verifies the AI review workflows still work end-to-end after #110214 (absolute `@trunk` reusable ref, `area` input validation, bot-vs-human concurrency bucketing).

# Diff

Same deliberate violations that produced 10 inline comments on the prior smoke test PR ([#110196](https://github.com/Automattic/wp-calypso/pull/110196)):

- `client/dashboard/components/clipboard-input-control/index.tsx`: `console.log`, `import page from 'page'`, `useDispatch` from react-redux, `dangerouslySetInnerHTML`, hardcoded English string
- `client/a8c-for-agencies/components/a4a-modal/index.tsx`: `console.log`, `dangerouslySetInnerHTML` on title, hardcoded English strings, removed `translate()` calls

# Expected when marked ready

- `Dashboard PR Review` workflow fires (path filter on `client/dashboard/**`)
- `A4A PR Review` workflow fires (path filter on `client/a8c-for-agencies/**`)
- Both invoke the reusable via `Automattic/wp-calypso/.github/workflows/pr-review.yml@trunk`
- `Validate area input` step passes for both `dashboard` and `a4a`
- `claude[bot]` posts inline comments flagging the violations

After auto-fire is confirmed: post `@claude /review` to exercise the on-ping flow and verify the bot-vs-human concurrency bucketing works.

Will be closed without merging.