### PR TITLE
E2E: Replace fixed timeouts in Forms tests with explicit waits

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
@@ -46,7 +46,12 @@ export class FeedbackInboxPage {
 		if ( await responsesTab.isVisible( { timeout: 2000 } ).catch( () => false ) ) {
 			this.isCFM = true;
 			await responsesTab.click();
-			await this.page.waitForTimeout( 1000 );
+			// Wait for the Folder filter chip to render — that's the signal that the
+			// Responses tab content has actually loaded.
+			await this.page
+				.locator( '.dataviews-filters__summary-chip' )
+				.filter( { hasText: /Folder is:/i } )
+				.waitFor( { state: 'visible', timeout: 5000 } );
 		}
 	}
 
@@ -171,7 +176,9 @@ export class FeedbackInboxPage {
 			} );
 			if ( await closeButton.isVisible( { timeout: 500 } ).catch( () => false ) ) {
 				await closeButton.click();
-				await this.page.waitForTimeout( 300 );
+				await this.page
+					.locator( '.jp-forms-response-header' )
+					.waitFor( { state: 'hidden', timeout: 5000 } );
 			}
 
 			// CFM: folder is a DataViews filter chip ("Folder is: Inbox (0)").
@@ -180,7 +187,11 @@ export class FeedbackInboxPage {
 			} );
 			await folderChip.click();
 			await this.page.getByRole( 'option', { name: new RegExp( folderName, 'i' ) } ).click();
-			await this.page.waitForTimeout( 500 );
+			// Wait for the chip text to reflect the selected folder.
+			await this.page
+				.locator( '.dataviews-filters__summary-chip' )
+				.filter( { hasText: new RegExp( `Folder is:\\s*${ folderName }`, 'i' ) } )
+				.waitFor( { timeout: 5000 } );
 			return;
 		}
 
@@ -189,7 +200,16 @@ export class FeedbackInboxPage {
 			.getByRole( 'tab', { name: folderName } )
 			.or( this.page.getByRole( 'radio', { name: new RegExp( folderName, 'i' ) } ) );
 		await tab.click();
-		await this.page.waitForTimeout( 500 );
+		// Wait for the tab/radio to actually be selected before returning.
+		await this.page
+			.getByRole( 'tab', { name: folderName, selected: true } )
+			.or(
+				this.page.getByRole( 'radio', {
+					name: new RegExp( folderName, 'i' ),
+					checked: true,
+				} )
+			)
+			.waitFor( { timeout: 5000 } );
 	}
 
 	/**
@@ -282,8 +302,11 @@ export class FeedbackInboxPage {
 		// Use .last() to get the button in the side panel, not in the table row
 		await this.page.getByRole( 'button', { name: 'Trash' } ).last().click();
 		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
-			// On mobile, the modal closes after the action
-			await this.page.waitForTimeout( 1000 );
+			// On mobile, the modal closes after the action. Wait for it to actually
+			// close rather than using a fixed timeout.
+			await this.page
+				.getByRole( 'dialog', { name: 'Response' } )
+				.waitFor( { state: 'hidden', timeout: 5000 } );
 		} else {
 			// Wait for the success notification (use .first() to avoid a11y-speak duplicate)
 			await this.page.getByText( 'Response moved to trash.' ).first().waitFor( { timeout: 5000 } );
@@ -297,8 +320,11 @@ export class FeedbackInboxPage {
 		// Use .last() to get the button in the side panel, not in the table row
 		await this.page.getByRole( 'button', { name: 'Restore' } ).last().click();
 		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
-			// On mobile, the modal closes after the action
-			await this.page.waitForTimeout( 1000 );
+			// On mobile, the modal closes after the action. Wait for it to actually
+			// close rather than using a fixed timeout.
+			await this.page
+				.getByRole( 'dialog', { name: 'Response' } )
+				.waitFor( { state: 'hidden', timeout: 5000 } );
 		} else {
 			// Wait for the success notification (use .first() to avoid a11y-speak duplicate)
 			await this.page.getByText( 'Response restored.' ).first().waitFor( { timeout: 5000 } );
@@ -309,18 +335,28 @@ export class FeedbackInboxPage {
 	 * Clicks the "Next" navigation button in the response view.
 	 */
 	async clickNextResponse(): Promise< void > {
+		// The selected response is encoded in the URL's responseIds query param,
+		// so we wait for the URL to change rather than guessing how long it takes.
+		const before = this.page.url();
 		// Use .last() to get the button in the side panel, not pagination buttons
 		await this.page.getByRole( 'button', { name: 'Next', exact: true } ).last().click();
-		await this.page.waitForTimeout( 1000 ); // Wait for the navigation to complete
+		await this.page.waitForFunction( ( prev ) => window.location.href !== prev, before, {
+			timeout: 5000,
+		} );
 	}
 
 	/**
 	 * Clicks the "Previous" navigation button in the response view.
 	 */
 	async clickPreviousResponse(): Promise< void > {
+		// The selected response is encoded in the URL's responseIds query param,
+		// so we wait for the URL to change rather than guessing how long it takes.
+		const before = this.page.url();
 		// Use .last() to get the button in the side panel, not pagination buttons
 		await this.page.getByRole( 'button', { name: 'Previous', exact: true } ).last().click();
-		await this.page.waitForTimeout( 1000 ); // Wait for the navigation to complete
+		await this.page.waitForFunction( ( prev ) => window.location.href !== prev, before, {
+			timeout: 5000,
+		} );
 	}
 
 	/**
@@ -328,7 +364,13 @@ export class FeedbackInboxPage {
 	 */
 	async clickCloseResponse(): Promise< void > {
 		await this.page.getByRole( 'button', { name: 'Close' } ).last().click();
-		await this.page.waitForTimeout( 300 ); // Wait for the panel to close
+		// Wait for whichever panel was open (CFM inspector, legacy desktop side
+		// panel, or mobile dialog) to actually close.
+		await this.page
+			.locator( '.jp-forms-response-header' )
+			.or( this.page.locator( '.jp-forms__inbox-response' ) )
+			.or( this.page.getByRole( 'dialog', { name: 'Response' } ) )
+			.waitFor( { state: 'hidden', timeout: 5000 } );
 	}
 
 	/**

--- a/test/e2e/specs/published-content/forms__submissions.ts
+++ b/test/e2e/specs/published-content/forms__submissions.ts
@@ -188,8 +188,9 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 			await page.getByRole( 'button', { name: /Back|Go back/ } ).click();
 			// Verify the form is visible again and the success message is hidden
 			await publishedFormLocator.getByRole( 'button', { name: 'Send' } ).waitFor();
-			// Wait for the success message to be hidden
-			await page.waitForTimeout( 500 );
+			await page
+				.getByText( /Thank you for your response\.|Your message has been sent/ )
+				.waitFor( { state: 'hidden', timeout: 5000 } );
 		} );
 	} );
 


### PR DESCRIPTION
Part of follow-up work to #110159.

## Proposed Changes

Replaces 10 `waitForTimeout(…)` calls in the Jetpack Forms inbox test helpers and the `forms__submissions.ts` spec with explicit waits on real signals (modal hidden, response header detached, URL change, filter-chip text, tab/radio selected state, success-message hidden).

Files touched:

- `packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts` — `visit()`, `clickFolderTab()` (close + chip + tab-selected), `clickMoveToTrashAction()`, `clickRestoreAction()`, `clickNextResponse()`, `clickPreviousResponse()`, `clickCloseResponse()`
- `test/e2e/specs/published-content/forms__submissions.ts` — `Click "← Back" to return to form`

Six fixed timeouts are intentionally left in place for a follow-up: the search/clear-search `skipWaiting` branches and the CFM `clickMarkAsUnreadAction` auto-read branch — those need different signals (network response wait or row count) and are out of scope for this batch.

## Why are these changes being made?

#110159 established the pattern of replacing fixed timeouts in Forms helpers with `waitFor(...)` on the dialog hidden state, citing flakiness on slow CI agents. The same `waitForTimeout` pattern was used in many other helpers in the same file. Each is a latent flake risk where slow CI can drop the modal/inspector after the next action runs, and on fast runs the test pays the full sleep for nothing.

Replacing the timeouts with the actual readiness signal makes the helpers self-paced: faster on healthy agents, more tolerant on slow ones.

## Testing Instructions

```
yarn workspace wp-e2e-tests build
CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment"   yarn workspace wp-e2e-tests test "test/e2e/specs/published-content/forms__submissions.ts"
CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME="mobile" JETPACK_TARGET="wpcom-deployment"   yarn workspace wp-e2e-tests test "test/e2e/specs/published-content/forms__submissions.ts"
```

Local results on this branch:

| Run | Result | Time |
| --- | --- | --- |
| Desktop | 41/41 passed | 45.5s |
| Mobile  | 41/41 passed | 50.2s |

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?