### PR TITLE
Add calendar dark mode

### DIFF
--- a/client/dashboard/components/date-range-picker/style.scss
+++ b/client/dashboard/components/date-range-picker/style.scss
@@ -14,19 +14,19 @@
 	&__field {
 		// The extra class is to make sure it overrides the default button styles
 		&.components-button {
-			background: $white;
+			background: var( --dashboard-surface__background-color );
 			padding: $grid-unit-05 $grid-unit-05 $grid-unit-05 $grid-unit-10;
 			box-shadow: none;
 			border-radius: $radius-small;
-			border: 1px solid $gray-600;
+			border: 1px solid var(--dashboard-field__border-color, $gray-600);
 		}
 		svg {
-			color: $gray-900;
+			color: var(--dashboard__text-color);
 			padding: $grid-unit-05;
 		}
 	}
 	&__text {
-		color: $gray-900;
+		color: var(--dashboard__text-color);
 		padding: 0 $grid-unit-05;
 	}
 }

--- a/packages/ui/src/calendar/styles.module.scss
+++ b/packages/ui/src/calendar/styles.module.scss
@@ -1,4 +1,5 @@
 @use '@wordpress/base-styles/mixins';
+@use '../utils/mixins' as ui-mixins;
 @use '@wordpress/base-styles/variables';
 @use '../utils/theme-variables' as theme;
 
@@ -15,6 +16,11 @@
 	// TODO: themify / align to DS tokens
 	--a8c-calendar-range-middle-background-color: color-mix(in srgb, #{theme.$components-color-accent} 4%, transparent);
 	--a8c-calendar-preview-border-color: color-mix(in srgb, #{theme.$components-color-accent} 16%, transparent);
+
+	@include ui-mixins.when-dark-theme {
+		// Set a stronger background color in dark mode for better visibility
+		--a8c-calendar-range-middle-background-color: color-mix(in srgb, #{theme.$components-color-accent} 8%, transparent);
+	}
 
 	position: relative; /* Required to position the navigation toolbar. */
 	box-sizing: border-box;


### PR DESCRIPTION
Part of RSM-1280

| Light mode | Dark mode |
| ---------- | --------- |
| <img width="658" height="613" alt="Screenshot 2026-04-27 alle 16 16 32" src="https://github.com/user-attachments/assets/71dcb6f5-77f8-4463-be72-603d986abb05" /> | <img width="671" height="619" alt="Screenshot 2026-04-27 alle 16 09 15" src="https://github.com/user-attachments/assets/7e9ff345-56ab-42ac-9cac-51a67c25d133" /> |

N.b. in light mode, the range days background isn't very visible. I've doubled it in dark mode.

## Proposed Changes

* Fix hardcoded color values
* Double contrast of the selected range in dark mode

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
