### PR TITLE
A4A: Add AI and MCP settings page under Resources and tools

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-learn-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-learn-menu-items.tsx
@@ -1,14 +1,22 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { BigSkyLogo } from '@automattic/components/src/logos/big-sky-logo';
 import { pages, tool } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
-import { A4A_DEV_TOOLS_LINK, A4A_LEARN_LINK, A4A_RESOURCES_LINK } from '../lib/constants';
+import {
+	A4A_AI_MCP_LINK,
+	A4A_DEV_TOOLS_LINK,
+	A4A_LEARN_LINK,
+	A4A_RESOURCES_LINK,
+} from '../lib/constants';
 import { createItem } from '../lib/utils';
 
 const useLearnMenuItems = ( path: string ) => {
 	const translate = useTranslate();
+	const isAiMcpEnabled = isEnabled( 'a4a-ai-mcp' );
 
 	const menuItems = useMemo( () => {
-		return [
+		const items = [
 			createItem(
 				{
 					icon: pages,
@@ -34,7 +42,26 @@ const useLearnMenuItems = ( path: string ) => {
 				path
 			),
 		];
-	}, [ path, translate ] );
+
+		if ( isAiMcpEnabled ) {
+			items.push(
+				createItem(
+					{
+						icon: <BigSkyLogo.CentralLogo heartless size={ 24 } />,
+						path: A4A_AI_MCP_LINK,
+						link: A4A_AI_MCP_LINK,
+						title: translate( 'AI and MCP' ),
+						trackEventProps: {
+							menu_item: 'Automattic for Agencies / Resources and tools / AI and MCP',
+						},
+					},
+					path
+				)
+			);
+		}
+
+		return items;
+	}, [ path, translate, isAiMcpEnabled ] );
 
 	return menuItems;
 };

--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -59,6 +59,8 @@ export const A4A_EXCLUSIVE_OFFERS_LINK = '/exclusive-offers';
 export const A4A_RESOURCES_LINK = '/resources-and-tools';
 export const A4A_LEARN_LINK = `${ A4A_RESOURCES_LINK }/learn`;
 export const A4A_DEV_TOOLS_LINK = `${ A4A_RESOURCES_LINK }/dev-tools`;
+export const A4A_AI_MCP_LINK = `${ A4A_RESOURCES_LINK }/ai-mcp`;
+export const A4A_AI_MCP_AVAILABLE_TOOLS_LINK = `${ A4A_AI_MCP_LINK }/tools`;
 
 // Client
 export const A4A_CLIENT_LANDING_LINK = '/client/landing';

--- a/client/a8c-for-agencies/components/text-placeholder/index.tsx
+++ b/client/a8c-for-agencies/components/text-placeholder/index.tsx
@@ -1,5 +1,5 @@
 import './style.scss';
 
-export default function TextPlaceholder() {
-	return <span className="a4a-text-placeholder" />;
+export default function TextPlaceholder( { style }: { style?: React.CSSProperties } ) {
+	return <span className="a4a-text-placeholder" style={ style } />;
 }

--- a/client/a8c-for-agencies/data/mcp-ai/types.ts
+++ b/client/a8c-for-agencies/data/mcp-ai/types.ts
@@ -1,0 +1,24 @@
+export interface McpAvailableAbility {
+	name: string;
+	title: string;
+	description: string;
+	default_enabled: boolean;
+	effective_enabled: boolean;
+}
+
+export interface McpSettings {
+	enabled: boolean;
+	abilities: Record< string, boolean >;
+	available_abilities: McpAvailableAbility[];
+}
+
+export interface McpSettingsUpdate {
+	enabled?: boolean;
+	abilities?: Record< string, boolean >;
+}
+
+export interface McpApiError {
+	status: number;
+	code: string | null;
+	message: string;
+}

--- a/client/a8c-for-agencies/data/mcp-ai/types.ts
+++ b/client/a8c-for-agencies/data/mcp-ai/types.ts
@@ -2,13 +2,11 @@ export interface McpAvailableAbility {
 	name: string;
 	title: string;
 	description: string;
-	default_enabled: boolean;
-	effective_enabled: boolean;
+	enabled: boolean;
 }
 
 export interface McpSettings {
 	enabled: boolean;
-	abilities: Record< string, boolean >;
 	available_abilities: McpAvailableAbility[];
 }
 

--- a/client/a8c-for-agencies/data/mcp-ai/use-fetch-mcp-settings.ts
+++ b/client/a8c-for-agencies/data/mcp-ai/use-fetch-mcp-settings.ts
@@ -1,20 +1,25 @@
 import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import type { McpSettings } from './types';
 
-export const getMcpSettingsQueryKey = () => [ 'a4a-mcp-settings' ];
+export const getMcpSettingsQueryKey = ( agencyId?: number ) => [ 'a4a-mcp-settings', agencyId ];
 
-function fetchMcpSettings(): Promise< McpSettings > {
+function fetchMcpSettings( agencyId: number ): Promise< McpSettings > {
 	return wpcom.req.get( {
 		apiNamespace: 'wpcom/v2',
-		path: '/a4a-mcp/settings',
+		path: `/agency/${ agencyId }/a4a-mcp/settings`,
 	} );
 }
 
 export default function useFetchMcpSettings() {
+	const agencyId = useSelector( getActiveAgencyId );
+
 	return useQuery< McpSettings >( {
-		queryKey: getMcpSettingsQueryKey(),
-		queryFn: fetchMcpSettings,
+		queryKey: getMcpSettingsQueryKey( agencyId ),
+		queryFn: () => fetchMcpSettings( agencyId as number ),
+		enabled: !! agencyId,
 		refetchOnWindowFocus: false,
 	} );
 }

--- a/client/a8c-for-agencies/data/mcp-ai/use-fetch-mcp-settings.ts
+++ b/client/a8c-for-agencies/data/mcp-ai/use-fetch-mcp-settings.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import type { McpSettings } from './types';
+
+export const getMcpSettingsQueryKey = () => [ 'a4a-mcp-settings' ];
+
+function fetchMcpSettings(): Promise< McpSettings > {
+	return wpcom.req.get( {
+		apiNamespace: 'wpcom/v2',
+		path: '/a4a-mcp/settings',
+	} );
+}
+
+export default function useFetchMcpSettings() {
+	return useQuery< McpSettings >( {
+		queryKey: getMcpSettingsQueryKey(),
+		queryFn: fetchMcpSettings,
+		refetchOnWindowFocus: false,
+	} );
+}

--- a/client/a8c-for-agencies/data/mcp-ai/use-update-mcp-settings-mutation.ts
+++ b/client/a8c-for-agencies/data/mcp-ai/use-update-mcp-settings-mutation.ts
@@ -5,14 +5,16 @@ import {
 	UseMutationResult,
 } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { getMcpSettingsQueryKey } from './use-fetch-mcp-settings';
 import type { McpApiError, McpSettings, McpSettingsUpdate } from './types';
 
-function updateMcpSettings( input: McpSettingsUpdate ): Promise< McpSettings > {
+function updateMcpSettings( input: McpSettingsUpdate, agencyId: number ): Promise< McpSettings > {
 	return wpcom.req.post(
 		{
 			apiNamespace: 'wpcom/v2',
-			path: '/a4a-mcp/settings',
+			path: `/agency/${ agencyId }/a4a-mcp/settings`,
 		},
 		input
 	);
@@ -22,14 +24,24 @@ export default function useUpdateMcpSettingsMutation< TContext = unknown >(
 	options?: UseMutationOptions< McpSettings, McpApiError, McpSettingsUpdate, TContext >
 ): UseMutationResult< McpSettings, McpApiError, McpSettingsUpdate, TContext > {
 	const queryClient = useQueryClient();
+	const agencyId = useSelector( getActiveAgencyId );
 
 	return useMutation< McpSettings, McpApiError, McpSettingsUpdate, TContext >( {
 		...options,
-		mutationFn: updateMcpSettings,
+		mutationFn: ( input ) => {
+			if ( ! agencyId ) {
+				return Promise.reject( {
+					status: 400,
+					code: 'no_active_agency',
+					message: 'No active agency in context.',
+				} as McpApiError );
+			}
+			return updateMcpSettings( input, agencyId );
+		},
 		onSuccess: ( next, variables, context ) => {
 			// Seed the query cache with the fresh server state so the UI stays in sync
 			// without an extra round-trip.
-			queryClient.setQueryData( getMcpSettingsQueryKey(), next );
+			queryClient.setQueryData( getMcpSettingsQueryKey( agencyId ), next );
 			options?.onSuccess?.( next, variables, context );
 		},
 	} );

--- a/client/a8c-for-agencies/data/mcp-ai/use-update-mcp-settings-mutation.ts
+++ b/client/a8c-for-agencies/data/mcp-ai/use-update-mcp-settings-mutation.ts
@@ -1,0 +1,36 @@
+import {
+	useMutation,
+	useQueryClient,
+	UseMutationOptions,
+	UseMutationResult,
+} from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { getMcpSettingsQueryKey } from './use-fetch-mcp-settings';
+import type { McpApiError, McpSettings, McpSettingsUpdate } from './types';
+
+function updateMcpSettings( input: McpSettingsUpdate ): Promise< McpSettings > {
+	return wpcom.req.post(
+		{
+			apiNamespace: 'wpcom/v2',
+			path: '/a4a-mcp/settings',
+		},
+		input
+	);
+}
+
+export default function useUpdateMcpSettingsMutation< TContext = unknown >(
+	options?: UseMutationOptions< McpSettings, McpApiError, McpSettingsUpdate, TContext >
+): UseMutationResult< McpSettings, McpApiError, McpSettingsUpdate, TContext > {
+	const queryClient = useQueryClient();
+
+	return useMutation< McpSettings, McpApiError, McpSettingsUpdate, TContext >( {
+		...options,
+		mutationFn: updateMcpSettings,
+		onSuccess: ( next, variables, context ) => {
+			// Seed the query cache with the fresh server state so the UI stays in sync
+			// without an extra round-trip.
+			queryClient.setQueryData( getMcpSettingsQueryKey(), next );
+			options?.onSuccess?.( next, variables, context );
+		},
+	} );
+}

--- a/client/a8c-for-agencies/lib/permission.ts
+++ b/client/a8c-for-agencies/lib/permission.ts
@@ -57,6 +57,8 @@ import {
 	A4A_LEARN_LINK,
 	A4A_RESOURCES_LINK,
 	A4A_DEV_TOOLS_LINK,
+	A4A_AI_MCP_LINK,
+	A4A_AI_MCP_AVAILABLE_TOOLS_LINK,
 	A4A_EXCLUSIVE_OFFERS_LINK,
 } from '../components/sidebar-menu/lib/constants';
 import type { Agency } from 'calypso/state/a8c-for-agencies/types';
@@ -120,6 +122,8 @@ const MEMBER_ACCESSIBLE_PATHS: Record< string, string[] > = {
 	[ A4A_RESOURCES_LINK ]: [ 'a4a_read_learn' ],
 	[ A4A_LEARN_LINK ]: [ 'a4a_read_learn' ],
 	[ A4A_DEV_TOOLS_LINK ]: [ 'a4a_read_learn' ],
+	[ A4A_AI_MCP_LINK ]: [ 'a4a_read_learn' ],
+	[ A4A_AI_MCP_AVAILABLE_TOOLS_LINK ]: [ 'a4a_read_learn' ],
 };
 
 const MEMBER_ACCESSIBLE_DYNAMIC_PATHS: Record< string, string[] > = {

--- a/client/a8c-for-agencies/sections/ai-mcp/controller.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/controller.tsx
@@ -1,0 +1,30 @@
+import { type Callback } from '@automattic/calypso-router';
+import PageViewTracker from 'calypso/a8c-for-agencies/components/a4a-page-view-tracker';
+import LearnSidebar from 'calypso/a8c-for-agencies/components/sidebar-menu/learn';
+import AiMcpAvailableTools from './primary/available-tools';
+import AiMcpOverview from './primary/overview';
+
+export const aiMcpOverviewContext: Callback = ( context, next ) => {
+	context.primary = (
+		<>
+			<PageViewTracker title="Resources and tools > AI and MCP" path={ context.path } />
+			<AiMcpOverview />
+		</>
+	);
+	context.secondary = <LearnSidebar path={ context.path } />;
+	next();
+};
+
+export const aiMcpAvailableToolsContext: Callback = ( context, next ) => {
+	context.primary = (
+		<>
+			<PageViewTracker
+				title="Resources and tools > AI and MCP > Available tools"
+				path={ context.path }
+			/>
+			<AiMcpAvailableTools />
+		</>
+	);
+	context.secondary = <LearnSidebar path={ context.path } />;
+	next();
+};

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/available-tools/available-tools-content.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/available-tools/available-tools-content.tsx
@@ -1,0 +1,86 @@
+import {
+	ToggleControl,
+	__experimentalHStack as HStack,
+	__experimentalSpacer as Spacer,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import useFetchMcpSettings from 'calypso/a8c-for-agencies/data/mcp-ai/use-fetch-mcp-settings';
+import useUpdateMcpSettingsMutation from 'calypso/a8c-for-agencies/data/mcp-ai/use-update-mcp-settings-mutation';
+import { Card, CardBody } from 'calypso/dashboard/components/card';
+import { preventWidows } from 'calypso/lib/formatting';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { errorNotice } from 'calypso/state/notices/actions';
+
+export default function AiMcpAvailableToolsContent() {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const { data: settings, isLoading } = useFetchMcpSettings();
+
+	const mutation = useUpdateMcpSettingsMutation( {
+		onError: () => {
+			dispatch( errorNotice( translate( 'Could not save. Please try again.' ) ) );
+		},
+	} );
+
+	const onToggleAbility = useCallback(
+		( abilityName: string, next: boolean ) => {
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_ai_mcp_ability_toggled', {
+					ability_name: abilityName,
+					enabled: next,
+				} )
+			);
+			mutation.mutate( { abilities: { [ abilityName ]: next } } );
+		},
+		[ dispatch, mutation ]
+	);
+
+	const abilities = settings?.available_abilities ?? [];
+
+	if ( isLoading ) {
+		return <Text>{ translate( 'Loading…' ) }</Text>;
+	}
+
+	if ( abilities.length === 0 ) {
+		return <Text>{ translate( 'No tools are currently available.' ) }</Text>;
+	}
+
+	return (
+		<>
+			<Spacer className="a4a-ai-mcp-overview__intro" marginBottom={ 12 }>
+				<Text size={ 15 }>
+					{ preventWidows(
+						translate( 'Control which AI tools are available to your external AI assistant.' )
+					) }
+				</Text>
+			</Spacer>
+			<VStack spacing={ 3 }>
+				{ abilities.map( ( ability ) => (
+					<Card key={ ability.name }>
+						<CardBody>
+							<HStack alignment="left" spacing={ 4 }>
+								<ToggleControl
+									label=""
+									checked={ ability.effective_enabled }
+									onChange={ ( next: boolean ) => onToggleAbility( ability.name, next ) }
+									disabled={ mutation.isPending }
+								/>
+								<VStack spacing={ 1 }>
+									<Text weight={ 600 } size={ 15 }>
+										{ ability.title }
+									</Text>
+									<Text variant="muted">{ ability.description }</Text>
+								</VStack>
+							</HStack>
+						</CardBody>
+					</Card>
+				) ) }
+			</VStack>
+		</>
+	);
+}

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/available-tools/available-tools-content.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/available-tools/available-tools-content.tsx
@@ -5,8 +5,9 @@ import {
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { useTranslate } from 'i18n-calypso';
+import { __ } from '@wordpress/i18n';
 import { useCallback } from 'react';
+import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import useFetchMcpSettings from 'calypso/a8c-for-agencies/data/mcp-ai/use-fetch-mcp-settings';
 import useUpdateMcpSettingsMutation from 'calypso/a8c-for-agencies/data/mcp-ai/use-update-mcp-settings-mutation';
 import { Card, CardBody } from 'calypso/dashboard/components/card';
@@ -16,14 +17,13 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice } from 'calypso/state/notices/actions';
 
 export default function AiMcpAvailableToolsContent() {
-	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const { data: settings, isLoading } = useFetchMcpSettings();
+	const { data: settings } = useFetchMcpSettings();
 
 	const mutation = useUpdateMcpSettingsMutation( {
 		onError: () => {
-			dispatch( errorNotice( translate( 'Could not save. Please try again.' ) ) );
+			dispatch( errorNotice( __( 'Could not save. Please try again.' ) ) );
 		},
 	} );
 
@@ -42,44 +42,50 @@ export default function AiMcpAvailableToolsContent() {
 
 	const abilities = settings?.available_abilities ?? [];
 
-	if ( isLoading ) {
-		return <Text>{ translate( 'Loading…' ) }</Text>;
-	}
-
-	if ( abilities.length === 0 ) {
-		return <Text>{ translate( 'No tools are currently available.' ) }</Text>;
-	}
-
 	return (
 		<>
 			<Spacer className="a4a-ai-mcp-overview__intro" marginBottom={ 12 }>
 				<Text size={ 15 }>
 					{ preventWidows(
-						translate( 'Control which AI tools are available to your external AI assistant.' )
+						__( 'Control which AI tools are available to your external AI assistant.' )
 					) }
 				</Text>
 			</Spacer>
 			<VStack spacing={ 3 }>
-				{ abilities.map( ( ability ) => (
-					<Card key={ ability.name }>
+				{ ! abilities.length ? (
+					<Card>
 						<CardBody>
 							<HStack alignment="left" spacing={ 4 }>
-								<ToggleControl
-									label=""
-									checked={ ability.enabled }
-									onChange={ ( next: boolean ) => onToggleAbility( ability.name, next ) }
-									disabled={ mutation.isPending }
-								/>
+								<ToggleControl label="" checked={ false } onChange={ () => {} } disabled />
 								<VStack spacing={ 1 }>
-									<Text weight={ 600 } size={ 15 }>
-										{ ability.title }
-									</Text>
-									<Text variant="muted">{ ability.description }</Text>
+									<TextPlaceholder style={ { width: '200px' } } />
+									<TextPlaceholder style={ { width: '300px' } } />
 								</VStack>
 							</HStack>
 						</CardBody>
 					</Card>
-				) ) }
+				) : (
+					abilities.map( ( ability ) => (
+						<Card key={ ability.name }>
+							<CardBody>
+								<HStack alignment="left" spacing={ 4 }>
+									<ToggleControl
+										label=""
+										checked={ ability.enabled }
+										onChange={ ( next: boolean ) => onToggleAbility( ability.name, next ) }
+										disabled={ mutation.isPending }
+									/>
+									<VStack spacing={ 1 }>
+										<Text weight={ 600 } size={ 15 }>
+											{ ability.title }
+										</Text>
+										<Text variant="muted">{ ability.description }</Text>
+									</VStack>
+								</HStack>
+							</CardBody>
+						</Card>
+					) )
+				) }
 			</VStack>
 		</>
 	);

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/available-tools/available-tools-content.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/available-tools/available-tools-content.tsx
@@ -66,7 +66,7 @@ export default function AiMcpAvailableToolsContent() {
 							<HStack alignment="left" spacing={ 4 }>
 								<ToggleControl
 									label=""
-									checked={ ability.effective_enabled }
+									checked={ ability.enabled }
 									onChange={ ( next: boolean ) => onToggleAbility( ability.name, next ) }
 									disabled={ mutation.isPending }
 								/>

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/available-tools/available-tools-content.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/available-tools/available-tools-content.tsx
@@ -16,6 +16,8 @@ import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice } from 'calypso/state/notices/actions';
 
+import '../style.scss';
+
 export default function AiMcpAvailableToolsContent() {
 	const dispatch = useDispatch();
 

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/available-tools/index.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/available-tools/index.tsx
@@ -1,4 +1,4 @@
-import { useTranslate } from 'i18n-calypso';
+import { __ } from '@wordpress/i18n';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
@@ -11,8 +11,7 @@ import LayoutHeader, {
 import AiMcpAvailableToolsContent from './available-tools-content';
 
 export default function AiMcpAvailableTools() {
-	const translate = useTranslate();
-	const title = translate( 'Available tools' );
+	const title = __( 'Available tools' );
 
 	return (
 		<Layout title={ title } wide>
@@ -22,7 +21,7 @@ export default function AiMcpAvailableTools() {
 						hideOnMobile
 						items={ [
 							{
-								label: translate( 'AI and MCP' ),
+								label: __( 'AI and MCP' ),
 								href: A4A_AI_MCP_LINK,
 							},
 							{

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/available-tools/index.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/available-tools/index.tsx
@@ -1,0 +1,43 @@
+import { useTranslate } from 'i18n-calypso';
+import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
+import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import { A4A_AI_MCP_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import LayoutBody from 'calypso/layout/hosting-dashboard/body';
+import LayoutHeader, {
+	LayoutHeaderActions as Actions,
+	LayoutHeaderBreadcrumb as Breadcrumb,
+} from 'calypso/layout/hosting-dashboard/header';
+import AiMcpAvailableToolsContent from './available-tools-content';
+
+export default function AiMcpAvailableTools() {
+	const translate = useTranslate();
+	const title = translate( 'Available tools' );
+
+	return (
+		<Layout title={ title } wide>
+			<LayoutTop>
+				<LayoutHeader>
+					<Breadcrumb
+						hideOnMobile
+						items={ [
+							{
+								label: translate( 'AI and MCP' ),
+								href: A4A_AI_MCP_LINK,
+							},
+							{
+								label: title,
+							},
+						] }
+					/>
+					<Actions useColumnAlignment>
+						<MobileSidebarNavigation />
+					</Actions>
+				</LayoutHeader>
+			</LayoutTop>
+			<LayoutBody>
+				<AiMcpAvailableToolsContent />
+			</LayoutBody>
+		</Layout>
+	);
+}

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/overview/index.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/overview/index.tsx
@@ -1,4 +1,4 @@
-import { useTranslate } from 'i18n-calypso';
+import { __ } from '@wordpress/i18n';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
@@ -10,8 +10,7 @@ import LayoutHeader, {
 import AiMcpOverviewContent from './overview-content';
 
 export default function AiMcpOverview() {
-	const translate = useTranslate();
-	const title = translate( 'AI and MCP' );
+	const title = __( 'AI and MCP' );
 
 	return (
 		<Layout title={ title } wide className="a4a-ai-mcp-overview">

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/overview/index.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/overview/index.tsx
@@ -1,0 +1,31 @@
+import { useTranslate } from 'i18n-calypso';
+import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
+import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import LayoutBody from 'calypso/layout/hosting-dashboard/body';
+import LayoutHeader, {
+	LayoutHeaderTitle as Title,
+	LayoutHeaderActions as Actions,
+} from 'calypso/layout/hosting-dashboard/header';
+import AiMcpOverviewContent from './overview-content';
+
+export default function AiMcpOverview() {
+	const translate = useTranslate();
+	const title = translate( 'AI and MCP' );
+
+	return (
+		<Layout title={ title } wide className="a4a-ai-mcp-overview">
+			<LayoutTop>
+				<LayoutHeader>
+					<Title>{ title }</Title>
+					<Actions>
+						<MobileSidebarNavigation />
+					</Actions>
+				</LayoutHeader>
+			</LayoutTop>
+			<LayoutBody>
+				<AiMcpOverviewContent />
+			</LayoutBody>
+		</Layout>
+	);
+}

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/overview/overview-content.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/overview/overview-content.tsx
@@ -4,9 +4,8 @@ import {
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { Icon, shield } from '@wordpress/icons';
-import { useTranslate } from 'i18n-calypso';
+import { __, sprintf } from '@wordpress/i18n';
+import { Icon, tool } from '@wordpress/icons';
 import { useCallback } from 'react';
 import { A4A_AI_MCP_AVAILABLE_TOOLS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useFetchMcpSettings from 'calypso/a8c-for-agencies/data/mcp-ai/use-fetch-mcp-settings';
@@ -21,14 +20,13 @@ import { errorNotice } from 'calypso/state/notices/actions';
 import '../style.scss';
 
 export default function AiMcpOverviewContent() {
-	const translate = useTranslate();
 	const dispatch = useDispatch();
 
 	const { data: settings, isLoading } = useFetchMcpSettings();
 
 	const mutation = useUpdateMcpSettingsMutation( {
 		onError: () => {
-			dispatch( errorNotice( translate( 'Could not save. Please try again.' ) ) );
+			dispatch( errorNotice( __( 'Could not save. Please try again.' ) ) );
 		},
 	} );
 
@@ -53,12 +51,13 @@ export default function AiMcpOverviewContent() {
 		totalCount > 0
 			? {
 					/* translators: %1$d enabled, %2$d total */
-					text: translate( '%1$d of %2$d enabled', {
-						args: [ enabledCount, totalCount ],
+					text: sprintf( __( '%(enabledCount)d of %(totalCount)d enabled' ), {
+						enabledCount,
+						totalCount,
 					} ) as string,
 					intent: ( enabledCount > 0 ? 'info' : undefined ) as 'info' | undefined,
 			  }
-			: { text: translate( 'No tools available' ) as string };
+			: { text: __( 'No tools available' ) as string };
 
 	return (
 		<>
@@ -75,27 +74,26 @@ export default function AiMcpOverviewContent() {
 					<CardBody>
 						<VStack spacing={ 3 }>
 							<Text weight={ 600 } size={ 15 }>
-								{ translate( 'External AI agent access' ) }
+								{ __( 'External AI agent access' ) }
 							</Text>
 							<Text variant="muted">
-								{ translate(
+								{ __(
 									'Allow external AI agents to access your Automattic for Agencies account via MCP.'
 								) }
 							</Text>
 							<ToggleControl
-								label={ translate( 'Enable MCP access' ) }
+								label={ __( 'Enable MCP access' ) }
 								checked={ mainEnabled }
 								onChange={ onMainToggle }
 								disabled={ isLoading || mutation.isPending }
-								__nextHasNoMarginBottom
 							/>
 						</VStack>
 					</CardBody>
 					<CardDivider style={ { borderColor: '#f0f0f0' } } />
 					<DashboardSummaryButton
 						density="medium"
-						title={ translate( 'Available tools' ) }
-						decoration={ <Icon icon={ shield } size={ 24 } /> }
+						title={ __( 'Available tools' ) }
+						decoration={ <Icon icon={ tool } size={ 24 } /> }
 						badges={ [ availableToolsBadge ] }
 						href={ A4A_AI_MCP_AVAILABLE_TOOLS_LINK }
 						onClick={ onAvailableToolsClick }

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/overview/overview-content.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/overview/overview-content.tsx
@@ -89,7 +89,7 @@ export default function AiMcpOverviewContent() {
 							/>
 						</VStack>
 					</CardBody>
-					<CardDivider style={ { borderColor: '#f0f0f0' } } />
+					<CardDivider style={ { borderColor: 'var(--color-neutral-5)' } } />
 					<DashboardSummaryButton
 						density="medium"
 						title={ __( 'Available tools' ) }

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/overview/overview-content.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/overview/overview-content.tsx
@@ -1,0 +1,108 @@
+import {
+	ToggleControl,
+	__experimentalSpacer as Spacer,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Icon, shield } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import { A4A_AI_MCP_AVAILABLE_TOOLS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import useFetchMcpSettings from 'calypso/a8c-for-agencies/data/mcp-ai/use-fetch-mcp-settings';
+import useUpdateMcpSettingsMutation from 'calypso/a8c-for-agencies/data/mcp-ai/use-update-mcp-settings-mutation';
+import { Card, CardBody, CardDivider } from 'calypso/dashboard/components/card';
+import DashboardSummaryButton from 'calypso/dashboard/components/summary-button';
+import { preventWidows } from 'calypso/lib/formatting';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { errorNotice } from 'calypso/state/notices/actions';
+
+import '../style.scss';
+
+export default function AiMcpOverviewContent() {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const { data: settings, isLoading } = useFetchMcpSettings();
+
+	const mutation = useUpdateMcpSettingsMutation( {
+		onError: () => {
+			dispatch( errorNotice( translate( 'Could not save. Please try again.' ) ) );
+		},
+	} );
+
+	const onMainToggle = useCallback(
+		( next: boolean ) => {
+			dispatch( recordTracksEvent( 'calypso_a4a_ai_mcp_enable_toggled', { enabled: next } ) );
+			mutation.mutate( { enabled: next } );
+		},
+		[ dispatch, mutation ]
+	);
+
+	const onAvailableToolsClick = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_ai_mcp_available_tools_click' ) );
+	}, [ dispatch ] );
+
+	const availableAbilities = settings?.available_abilities ?? [];
+	const enabledCount = availableAbilities.filter( ( a ) => a.effective_enabled ).length;
+	const totalCount = availableAbilities.length;
+	const mainEnabled = !! settings?.enabled;
+
+	const availableToolsBadge =
+		totalCount > 0
+			? {
+					/* translators: %1$d enabled, %2$d total */
+					text: translate( '%1$d of %2$d enabled', {
+						args: [ enabledCount, totalCount ],
+					} ) as string,
+					intent: ( enabledCount > 0 ? 'info' : undefined ) as 'info' | undefined,
+			  }
+			: { text: translate( 'No tools available' ) as string };
+
+	return (
+		<>
+			<Spacer className="a4a-ai-mcp-overview__intro" marginBottom={ 12 }>
+				<Text size={ 15 }>
+					{ preventWidows(
+						__( 'Control how AI assistants interact with your Automattic for Agencies account.' )
+					) }
+				</Text>
+			</Spacer>
+
+			<VStack spacing={ 4 }>
+				<Card className="a4a-ai-mcp-overview__card">
+					<CardBody>
+						<VStack spacing={ 3 }>
+							<Text weight={ 600 } size={ 15 }>
+								{ translate( 'External AI agent access' ) }
+							</Text>
+							<Text variant="muted">
+								{ translate(
+									'Allow external AI agents to access your Automattic for Agencies account via MCP.'
+								) }
+							</Text>
+							<ToggleControl
+								label={ translate( 'Enable MCP access' ) }
+								checked={ mainEnabled }
+								onChange={ onMainToggle }
+								disabled={ isLoading || mutation.isPending }
+								__nextHasNoMarginBottom
+							/>
+						</VStack>
+					</CardBody>
+					<CardDivider style={ { borderColor: '#f0f0f0' } } />
+					<DashboardSummaryButton
+						density="medium"
+						title={ translate( 'Available tools' ) }
+						decoration={ <Icon icon={ shield } size={ 24 } /> }
+						badges={ [ availableToolsBadge ] }
+						href={ A4A_AI_MCP_AVAILABLE_TOOLS_LINK }
+						onClick={ onAvailableToolsClick }
+						disabled={ ! mainEnabled }
+					/>
+				</Card>
+			</VStack>
+		</>
+	);
+}

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/overview/overview-content.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/overview/overview-content.tsx
@@ -45,7 +45,7 @@ export default function AiMcpOverviewContent() {
 	}, [ dispatch ] );
 
 	const availableAbilities = settings?.available_abilities ?? [];
-	const enabledCount = availableAbilities.filter( ( a ) => a.effective_enabled ).length;
+	const enabledCount = availableAbilities.filter( ( a ) => a.enabled ).length;
 	const totalCount = availableAbilities.length;
 	const mainEnabled = !! settings?.enabled;
 

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/style.scss
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/style.scss
@@ -1,0 +1,19 @@
+.a4a-ai-mcp-overview__intro {
+	max-width: 650px;
+
+	+ .page-section-columns {
+		padding-block-start: 0;
+	}
+}
+
+.a4a-ai-mcp-overview .a4a-ai-mcp-overview__card {
+	a.summary-button.components-button {
+		border-radius: 0;
+		padding: 16px 24px;
+		border-bottom: none;
+		&:hover {
+			border-bottom: none;
+			background: none;
+		}
+	}
+}

--- a/client/a8c-for-agencies/sections/learn/index.ts
+++ b/client/a8c-for-agencies/sections/learn/index.ts
@@ -1,11 +1,15 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import {
+	A4A_AI_MCP_AVAILABLE_TOOLS_LINK,
+	A4A_AI_MCP_LINK,
 	A4A_DEV_TOOLS_LINK,
 	A4A_LEARN_LINK,
 	A4A_RESOURCES_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { requireAccessContext } from 'calypso/a8c-for-agencies/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
+import { aiMcpAvailableToolsContext, aiMcpOverviewContext } from '../ai-mcp/controller';
 import { devToolsContext } from '../dev-tools/controller';
 import * as controller from './controller';
 
@@ -18,5 +22,17 @@ export default function () {
 		clientRender
 	);
 	page( A4A_DEV_TOOLS_LINK, requireAccessContext, devToolsContext, makeLayout, clientRender );
+
+	if ( isEnabled( 'a4a-ai-mcp' ) ) {
+		page( A4A_AI_MCP_LINK, requireAccessContext, aiMcpOverviewContext, makeLayout, clientRender );
+		page(
+			A4A_AI_MCP_AVAILABLE_TOOLS_LINK,
+			requireAccessContext,
+			aiMcpAvailableToolsContext,
+			makeLayout,
+			clientRender
+		);
+	}
+
 	page( A4A_RESOURCES_LINK, () => page.redirect( A4A_LEARN_LINK ) );
 }

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -28,6 +28,7 @@
 	],
 	"oauth_client_id": 95928,
 	"features": {
+		"a4a-ai-mcp": true,
 		"a4a-bd-checkout": false,
 		"a4a-bd-term-pricing": true,
 		"a4a-migrations-request-verification": true,

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -25,6 +25,7 @@
 		}
 	],
 	"features": {
+		"a4a-ai-mcp": false,
 		"a4a-bd-checkout": false,
 		"a4a-bd-term-pricing": true,
 		"a4a-migrations-request-verification": true,

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -27,6 +27,7 @@
 	],
 	"oauth_client_id": 95932,
 	"features": {
+		"a4a-ai-mcp": false,
 		"a4a-bd-checkout": false,
 		"a4a-bd-term-pricing": true,
 		"a4a-migrations-request-verification": true,

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -27,6 +27,7 @@
 	],
 	"oauth_client_id": 95931,
 	"features": {
+		"a4a-ai-mcp": false,
 		"a4a-bd-checkout": false,
 		"a4a-bd-term-pricing": true,
 		"a4a-migrations-request-verification": true,


### PR DESCRIPTION
Part of A4A-2523
Resolves A4A-2525

## Proposed Changes

- New page at \`/resources-and-tools/ai-mcp\` under the existing **Resources and tools** sidebar group, with two views:
  - **AI and MCP overview** — \`Enable MCP access\` master toggle plus an **Available tools** drilldown row showing the enabled-tool count.
  - **Available tools** — per-ability \`ToggleControl\` cards listing every ability the user can grant the MCP server.
- New sidebar entry **AI and MCP** under Resources and tools, gated behind a new \`a4a-ai-mcp\` feature flag (enabled in development only; off in production, stage and horizon).
- Routes registered conditionally on the same flag — production users see no behavior change until rollout.
- Permissions wired through \`MEMBER_ACCESSIBLE_PATHS\` using \`a4a_read_learn\` to match sibling Learn / Developer tools entries.
- Data layer hooks \`useFetchMcpSettings\` and \`useUpdateMcpSettingsMutation\` follow A4A's per-feature \`data/\` convention — no inline \`wpcom.req\` calls in components.
- Pages reuse \`DashboardSummaryButton\` and the dashboard \`Card\` wrapper from \`calypso/dashboard/components/*\`, so the visual is consistent with WordPress.com's \`/me/preferences/mcp\`.

## Why are these changes being made?

The Automattic for Agencies MCP server (\`/wpcom/v2/a4a-mcp/v1\`) lets external AI assistants — Claude, Cursor, Codex, VS Code, etc. — read the agency user's account info via the Model Context Protocol. Agencies need an opt-in surface to enable the server and pick which tools they expose. This PR adds that settings surface, mirroring the WordPress.com \`/me/preferences/mcp\` UX but scoped to A4A's flat ability catalog (no site/post-write granularity).

The MVP ships with a single ability (Agency Details). The scaffolding lets us add more abilities or per-ability Read/Write splits later without reshaping the contract.

**Backend dependency:** This PR talks to \`GET/POST /wpcom/v2/a4a-mcp/settings\`, which is delivered in 212906-ghe-Automattic/wpcom. That PR must land before this one is functional end-to-end on production.

## Testing Instructions

1. Enable the feature flag locally — \`config/a8c-for-agencies-development.json\` already sets \`a4a-ai-mcp: true\`, so a fresh \`yarn start\` against \`a8c-for-agencies\` is enough.
2. Open \`http://calypso.localhost:3000/resources-and-tools/ai-mcp\`. The sidebar should show **AI and MCP** as the third entry under Resources and tools.
3. Master toggle:
   - With \`Enable MCP access\` off, the **Available tools** row is greyed out and the count badge reads \`No tools available\` (until backend serves a non-empty catalog).
   - Toggle on → row becomes clickable; clicking opens the Available tools drilldown.
4. Available tools page:
   - While loading, a placeholder Card with two \`TextPlaceholder\` rows is shown.
   - After load, each ability renders as a Card with title, description, and a \`ToggleControl\`. Toggling fires \`POST /wpcom/v2/a4a-mcp/settings\` and updates the cached settings.
5. Routes are flag-gated — flip \`a4a-ai-mcp\` to \`false\` in your local dev config, restart, and confirm:
   - The sidebar no longer shows the AI and MCP entry.
   - Direct visits to \`/resources-and-tools/ai-mcp{,/tools}\` redirect to the overview (because the route isn't registered).
6. No console warnings or TypeScript errors in either page.

<img width="1920" height="500" alt="Screenshot 2026-04-27 at 8 21 24 PM" src="https://github.com/user-attachments/assets/4d792a28-a969-4a7d-b625-6353c9d40d97" />
<img width="1920" height="500" alt="Screenshot 2026-04-27 at 8 21 27 PM" src="https://github.com/user-attachments/assets/77521ca9-8a21-4e81-b026-99b9ee99e8e7" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?