### PR TITLE
E2E: stabilize /me sidebar navigation

### DIFF
--- a/packages/calypso-e2e/src/lib/components/me/me-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/me/me-sidebar-component.ts
@@ -40,6 +40,16 @@ export class MeSidebarComponent {
 	 * @param {string} menu Menu item label or href to navigate to.
 	 */
 	async navigate( menu: string ): Promise< void > {
-		await this.page.click( selectors.menuItem( menu ) );
+		// The /me sidebar can re-render shortly after page load while
+		// account/site state hydrates. Clicking before the sidebar has
+		// settled causes the link to be detached mid-click, so wait for
+		// the sidebar to be present and the page to be idle first, then
+		// click via a Locator (which re-resolves on retry, unlike
+		// page.click which can keep timing out against a detached node).
+		await this.page.waitForLoadState( 'networkidle' );
+		await this.page.locator( '.sidebar' ).first().waitFor();
+		const menuItem = this.page.locator( selectors.menuItem( menu ) ).first();
+		await menuItem.waitFor();
+		await menuItem.click();
 	}
 }


### PR DESCRIPTION
## Proposed Changes

- `MeSidebarComponent.navigate` now waits for `networkidle` and for the `.sidebar` root before clicking, so the click no longer races the post-load hydration that re-renders the `/me` sidebar.
- Switched from `page.click(cssSelector)` to `Locator.click()` on the menu item, so actionability retries re-resolve the element instead of holding on to a stale handle that has been detached from the DOM.
- Aligns the desktop navigation path with the existing mobile path (`openMobileMenu`), which already waits for `networkidle` for the same reason.

## Why are these changes being made?

The `As a new user, I can create a paid site, add a domain, then cancel the plan` test in `flows/setup-domain__flows.spec.ts` was failing on the `[Desktop]` E2E run with `TimeoutError: page.click: Timeout 10000ms exceeded` while clicking the `Purchases` link in the `/me` sidebar. The Playwright call log showed the locator resolving to the right anchor but the element being detached from the DOM mid-click and retrying until the action timeout expired.

The `/me` sidebar re-renders shortly after page load while account/site Redux state hydrates. The original `navigate` called `page.click(...)` immediately, which both started the actionability check before the sidebar settled and held on to a single resolved handle that became stale on re-render — so every retry inside the same call hit the same detached node.

Evidence of the failure: [TeamCity build 17452235](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Playwright_Test_Matrix/17452235).

## Testing Instructions

- Run `yarn playwright test test/e2e/specs/flows/setup-domain__flows.spec.ts --reporter=list --repeat-each=10` locally; all runs should pass.
- Or rely on this PR's CI run of the E2E matrix to exercise the change.