### PR TITLE
Comment Stripe co-brand compliance in card-entry forms

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/credit-card-fields/credit-card-element-field.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/credit-card-fields/credit-card-element-field.tsx
@@ -32,6 +32,7 @@ export default function CreditCardElementField( {
 						'credit-card-fields__stripe-element--has-error': cardError,
 					} ) }
 				>
+					{ /* Legacy unified CardElement: lacks Stripe's in-Element co-brand picker — migrate to split CardNumberElement with `showIcon: true` for EU compliance. */ }
 					<CardElement
 						options={ {
 							disabled: isDisabled,

--- a/client/jetpack-cloud/sections/partner-portal/credit-card-fields/credit-card-element-field.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/credit-card-fields/credit-card-element-field.tsx
@@ -32,6 +32,7 @@ export default function CreditCardElementField( {
 						'credit-card-fields__stripe-element--has-error': cardError,
 					} ) }
 				>
+					{ /* Legacy unified CardElement: lacks Stripe's in-Element co-brand picker — migrate to split CardNumberElement with `showIcon: true` for EU compliance. */ }
 					<CardElement
 						options={ {
 							disabled: isDisabled,

--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-number-field.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-number-field.tsx
@@ -71,6 +71,7 @@ export default function CreditCardNumberField( {
 					options={ {
 						style: stripeElementStyle,
 						disabled: isDisabled,
+						// Required for EU co-brand network-choice compliance: enables Stripe's in-Element picker for co-branded cards.
 						showIcon: true,
 					} }
 					onReady={ () => {


### PR DESCRIPTION
Part of SHILL-386

## Proposed Changes

* Add an inline comment at `client/my-sites/checkout/src/payment-methods/credit-card/credit-card-number-field.tsx` flagging `showIcon: true` as load-bearing for EU co-brand network-choice compliance (Reg. 2015/751).
* Add inline comments at the two legacy partner-facing card-entry sites that still use Stripe's older unified `CardElement` (Jetpack Cloud Partner Portal and A8C for Agencies), documenting the missing in-Element co-brand picker and the migration target.

## Why are these changes being made?

* `showIcon: true` looks purely cosmetic but is the mechanism that satisfies the EU co-brand network-choice rule (Reg. 2015/751) for the main checkout. Without inline context, a future cleanup could remove it and silently break compliance.
* The two remaining legacy `CardElement` sites are pre-existing partner-facing flows that lack a co-brand picker. They aren't being migrated as part of this change, but documenting them in place gives anyone editing those files the context — and the migration target — without redoing the investigation. See SHILL-386 for the full background.

## Testing Instructions

* No runtime behavior changes — comments only. Lint and type-check should pass.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?