### PR TITLE
[RSM] Reader Chat Settings: add Jetpack Search toggle

### DIFF
--- a/client/my-sites/jetpack-search/main.tsx
+++ b/client/my-sites/jetpack-search/main.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { ProductIcon } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -19,6 +20,7 @@ import {
 } from 'calypso/state/ui/selectors';
 import JetpackSearchContent from './content';
 import JetpackSearchFooter from './footer';
+import ReaderChatCard from './reader-chat-card';
 
 import './style.scss';
 
@@ -76,6 +78,7 @@ export default function SearchMain() {
 				onClick={ onSettingsClick }
 				iconComponent={ <ProductIcon slug="jetpack_search" /> }
 			/>
+			{ config.isEnabled( 'reader-chat-settings' ) && <ReaderChatCard /> }
 			<JetpackSearchFooter />
 		</Main>
 	);

--- a/client/my-sites/jetpack-search/reader-chat-card.tsx
+++ b/client/my-sites/jetpack-search/reader-chat-card.tsx
@@ -1,0 +1,65 @@
+import { readerChatSettingsMutation, readerChatSettingsQuery } from '@automattic/api-queries';
+import { Card } from '@automattic/components';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { ExternalLink, ToggleControl } from '@wordpress/components';
+import { translate } from 'i18n-calypso';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+export default function ReaderChatCard() {
+	const dispatch = useDispatch();
+	const siteId = useSelector( getSelectedSiteId );
+	const site = useSelector( getSelectedSite );
+
+	const { data: settings } = useQuery( {
+		...readerChatSettingsQuery( siteId ?? 0 ),
+		enabled: Boolean( siteId ),
+	} );
+	const isEnabled = settings?.enabled ?? false;
+
+	const mutation = useMutation( {
+		...readerChatSettingsMutation( siteId ?? 0 ),
+	} );
+
+	if ( ! siteId ) {
+		return null;
+	}
+
+	const handleToggle = ( next: boolean ) => {
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_search_reader_chat_toggled', {
+				enabled: next,
+				site_id: siteId,
+			} )
+		);
+		mutation.mutate( { enabled: next } );
+	};
+
+	const guidelinesHref = site?.options?.admin_url
+		? `${ site.options.admin_url }site-editor.php?canvas=edit&path=/guidelines/additional`
+		: undefined;
+
+	return (
+		<Card>
+			<h2 className="jetpack-search__header">{ translate( 'Reader Chat' ) }</h2>
+			<p>
+				{ translate( 'Let readers ask your blog questions and get answers from your content.' ) }
+			</p>
+			<ToggleControl
+				__nextHasNoMarginBottom
+				checked={ isEnabled }
+				disabled={ mutation.isPending }
+				label={ translate( 'Enable Reader Chat on your blog' ) }
+				onChange={ handleToggle }
+			/>
+			{ isEnabled && guidelinesHref && (
+				<p>
+					<ExternalLink href={ guidelinesHref }>
+						{ translate( 'Set content guidelines' ) }
+					</ExternalLink>
+				</p>
+			) }
+		</Card>
+	);
+}

--- a/client/my-sites/jetpack-search/reader-chat-card.tsx
+++ b/client/my-sites/jetpack-search/reader-chat-card.tsx
@@ -1,4 +1,8 @@
-import { readerChatSettingsMutation, readerChatSettingsQuery } from '@automattic/api-queries';
+import {
+	isAutomatticianQuery,
+	readerChatSettingsMutation,
+	readerChatSettingsQuery,
+} from '@automattic/api-queries';
 import { Card } from '@automattic/components';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { ExternalLink, ToggleControl } from '@wordpress/components';
@@ -11,10 +15,11 @@ export default function ReaderChatCard() {
 	const dispatch = useDispatch();
 	const siteId = useSelector( getSelectedSiteId );
 	const site = useSelector( getSelectedSite );
+	const { data: isAutomattician } = useQuery( isAutomatticianQuery() );
 
 	const { data: settings } = useQuery( {
 		...readerChatSettingsQuery( siteId ?? 0 ),
-		enabled: Boolean( siteId ),
+		enabled: Boolean( siteId && isAutomattician ),
 	} );
 	const isEnabled = settings?.enabled ?? false;
 
@@ -22,7 +27,7 @@ export default function ReaderChatCard() {
 		...readerChatSettingsMutation( siteId ?? 0 ),
 	} );
 
-	if ( ! siteId ) {
+	if ( ! siteId || ! isAutomattician ) {
 		return null;
 	}
 

--- a/config/development.json
+++ b/config/development.json
@@ -174,6 +174,7 @@
 		"purchases/new-payment-methods": true,
 		"purchases/split-cancel-remove": true,
 		"push-notifications": true,
+		"reader-chat-settings": true,
 		"reader/achievements": true,
 		"reader/social": true,
 		"reader/full-errors": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -135,6 +135,7 @@
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"purchases/split-cancel-remove": false,
+		"reader-chat-settings": true,
 		"reader/achievements": true,
 		"reader/social": true,
 		"reader/full-errors": true,

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -81,6 +81,7 @@ export * from './read-lists';
 export * from './read-sites';
 export * from './read-teams';
 export * from './reader-atmosphere';
+export * from './reader-chat-settings';
 export * from './reader-mastodon';
 export * from './site';
 export * from './site-activity-log';

--- a/packages/api-core/src/reader-chat-settings/fetchers.ts
+++ b/packages/api-core/src/reader-chat-settings/fetchers.ts
@@ -1,0 +1,9 @@
+import { wpcom } from '../wpcom-fetcher';
+import type { ReaderChatSettings } from './types';
+
+export async function fetchReaderChatSettings( siteId: number ): Promise< ReaderChatSettings > {
+	return wpcom.req.get( {
+		path: `/sites/${ siteId }/reader-chat-settings`,
+		apiNamespace: 'wpcom/v2',
+	} );
+}

--- a/packages/api-core/src/reader-chat-settings/index.ts
+++ b/packages/api-core/src/reader-chat-settings/index.ts
@@ -1,0 +1,3 @@
+export * from './fetchers';
+export * from './mutators';
+export * from './types';

--- a/packages/api-core/src/reader-chat-settings/mutators.ts
+++ b/packages/api-core/src/reader-chat-settings/mutators.ts
@@ -1,0 +1,15 @@
+import { wpcom } from '../wpcom-fetcher';
+import type { ReaderChatSettings, ReaderChatSettingsUpdateRequest } from './types';
+
+export async function updateReaderChatSettings(
+	siteId: number,
+	data: ReaderChatSettingsUpdateRequest
+): Promise< ReaderChatSettings > {
+	return wpcom.req.post(
+		{
+			path: `/sites/${ siteId }/reader-chat-settings`,
+			apiNamespace: 'wpcom/v2',
+		},
+		data
+	);
+}

--- a/packages/api-core/src/reader-chat-settings/types.ts
+++ b/packages/api-core/src/reader-chat-settings/types.ts
@@ -1,0 +1,7 @@
+export interface ReaderChatSettings {
+	enabled: boolean;
+}
+
+export interface ReaderChatSettingsUpdateRequest {
+	enabled: boolean;
+}

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -71,6 +71,7 @@ export * from './read-feed';
 export * from './read-list';
 export * from './read-site';
 export * from './reader-atmosphere';
+export * from './reader-chat-settings';
 export * from './reader-mastodon';
 export * from './site-activity-log';
 export * from './site-activity-log-backup';

--- a/packages/api-queries/src/reader-chat-settings.ts
+++ b/packages/api-queries/src/reader-chat-settings.ts
@@ -1,0 +1,21 @@
+import { fetchReaderChatSettings, updateReaderChatSettings } from '@automattic/api-core';
+import { queryOptions, mutationOptions } from '@tanstack/react-query';
+import { queryClient } from './query-client';
+import type { ReaderChatSettingsUpdateRequest } from '@automattic/api-core';
+
+export const readerChatSettingsQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'reader-chat-settings' ],
+		queryFn: () => fetchReaderChatSettings( siteId ),
+	} );
+
+export const readerChatSettingsMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: ( data: ReaderChatSettingsUpdateRequest ) =>
+			updateReaderChatSettings( siteId, data ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( {
+				queryKey: readerChatSettingsQuery( siteId ).queryKey,
+			} );
+		},
+	} );


### PR DESCRIPTION
Split from #110024. The original PR stays open for comparison.

## Summary
- Adds the Reader Chat card to the Jetpack Search settings page behind `reader-chat-settings`.
- Gates the card to Automatticians/A11Ns via `isAutomatticianQuery()`. Non-A11N users do not see the card and do not call the Reader Chat settings endpoint.
- Adds API core/query helpers for `wpcom/v2/sites/:site/reader-chat-settings`.
- Records a Calypso Tracks event when the setting is toggled.

## Test Plan

### Automated
- `./node_modules/.bin/eslint client/my-sites/jetpack-search/reader-chat-card.tsx --no-cache --quiet`

### Manual
- Make sure the WPCOM endpoint from PR #212890 is available in the test environment.
- Open the Jetpack Search settings page for a test site as an Automattician/A11N.
- Confirm the Reader Chat card is visible when `reader-chat-settings` is enabled.
- Toggle **Enable Reader Chat on your blog** on.
- Confirm the request to `/wpcom/v2/sites/:site/reader-chat-settings` succeeds with `{ enabled: true }`.
- Verify the site option was applied by running `wp option get reader_chat` for the test site and confirming it returns `1`/truthy.
- Refresh the Jetpack Search settings page and confirm the toggle remains on.
- Toggle it off.
- Confirm the request succeeds with `{ enabled: false }`.
- Verify the site option was cleared by running `wp option get reader_chat` for the test site and confirming it returns `0`/false.
- Refresh and confirm the toggle remains off.
- As a non-A11N user, confirm the Reader Chat card does not render and the settings endpoint is not called.
- Confirm the existing Jetpack Search card still renders and its Settings button still works.