### PR TITLE
[RSM] Agents Manager: support Reader Chat hosts

### DIFF
--- a/packages/agents-manager/src/components/__tests__/agent-dock.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-dock.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-disable import/order -- jest.mock calls must precede imports */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type { AgentsManagerContextType } from '../../contexts';
+
+const mockAbortCurrentRequest = jest.fn();
+const mockSetIsOpen = jest.fn();
+const mockSetIsDocked = jest.fn();
+const mockUseAgentLayoutManager = jest.fn();
+let mockShouldUseUnifiedAgent = false;
+let mockContext: Partial< AgentsManagerContextType > = {};
+
+jest.mock(
+	'@automattic/agenttic-client',
+	() => ( {
+		getAgentManager: () => ( {
+			hasAgent: () => true,
+			abortCurrentRequest: mockAbortCurrentRequest,
+		} ),
+	} ),
+	{ virtual: true }
+);
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( {
+		setIsOpen: mockSetIsOpen,
+		setIsDocked: mockSetIsDocked,
+	} ),
+	useSelect: () => ( {
+		isOpen: true,
+		isDocked: false,
+	} ),
+} ) );
+jest.mock( '@wordpress/i18n', () => ( { __: ( text: string ) => text } ) );
+jest.mock( '@wordpress/icons', () => ( {
+	comment: 'comment',
+	drawerRight: 'drawerRight',
+	help: 'help',
+	login: 'login',
+	lifesaver: 'lifesaver',
+} ) );
+jest.mock( '../../contexts', () => ( {
+	useAgentsManagerContext: () => mockContext,
+} ) );
+jest.mock( '../../hooks/use-admin-bar-integration', () => () => {} );
+jest.mock( '../../hooks/use-agent-layout-manager', () => ( options: unknown ) => {
+	mockUseAgentLayoutManager( options );
+	return {
+		isDocked: false,
+		canDock: false,
+		dock: jest.fn(),
+		undock: jest.fn(),
+		openSidebar: jest.fn(),
+		closeSidebar: jest.fn(),
+		createAgentPortal: ( children: React.ReactNode ) => children,
+	};
+} );
+jest.mock( '../../hooks/use-setup-custom-actions', () => () => {} );
+jest.mock( '../../hooks/use-should-use-unified-agent', () => ( {
+	useShouldUseUnifiedAgent: () => mockShouldUseUnifiedAgent,
+} ) );
+jest.mock( '../../stores', () => ( { AGENTS_MANAGER_STORE: 'agents-manager' } ) );
+jest.mock( '../../utils/persist-last-activity', () => ( {
+	persistLastActivity: jest.fn(),
+} ) );
+jest.mock( '../agent-dock/style.scss', () => ( {} ) );
+jest.mock( '../orchestrator-chat', () => ( {
+	__esModule: true,
+	default: ( {
+		chatHeaderOptions,
+		onExpand,
+	}: {
+		chatHeaderOptions: { title: string }[];
+		onExpand: () => void;
+	} ) => (
+		<div data-testid="orchestrator-chat">
+			{ chatHeaderOptions.map( ( option ) => option.title ).join( '|' ) }
+			<button onClick={ onExpand }>Expand chat</button>
+		</div>
+	),
+} ) );
+jest.mock( '../zendesk-chat', () => ( {
+	__esModule: true,
+	default: () => <div data-testid="zendesk-chat">Zendesk chat</div>,
+} ) );
+jest.mock( '../agent-history', () => ( {
+	__esModule: true,
+	default: () => <div data-testid="agent-history">History</div>,
+} ) );
+jest.mock( '../support-guide', () => ( {
+	__esModule: true,
+	default: () => <div data-testid="support-guide">Support guide</div>,
+} ) );
+jest.mock( '../support-guides', () => ( {
+	__esModule: true,
+	default: () => <div data-testid="support-guides">Support guides</div>,
+} ) );
+
+import AgentDock from '../agent-dock';
+
+function renderAgentDock( initialEntry = '/chat' ) {
+	return render(
+		<MemoryRouter initialEntries={ [ initialEntry ] }>
+			<AgentDock />
+		</MemoryRouter>
+	);
+}
+
+describe( 'AgentDock', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockShouldUseUnifiedAgent = false;
+		mockContext = {
+			siteKey: 'site-1',
+			sectionName: 'reader-chat',
+			agentConfig: {
+				agentId: 'reader-chat',
+			},
+		} as Partial< AgentsManagerContextType >;
+	} );
+
+	it( 'does not expose Zendesk chat for Reader Chat when Unified Chat is enabled', async () => {
+		mockShouldUseUnifiedAgent = true;
+
+		renderAgentDock();
+
+		expect( screen.getByTestId( 'orchestrator-chat' ).textContent ).toContain( 'New chat' );
+		expect( screen.getByTestId( 'orchestrator-chat' ).textContent ).not.toContain(
+			'New Zendesk chat'
+		);
+
+		renderAgentDock( '/zendesk' );
+
+		await waitFor( () => expect( screen.queryByTestId( 'zendesk-chat' ) ).toBeNull() );
+	} );
+
+	it( 'keeps Zendesk chat available for regular agents when Unified Chat is enabled', () => {
+		mockShouldUseUnifiedAgent = true;
+		mockContext = {
+			siteKey: 'site-1',
+			sectionName: 'wp-admin',
+			agentConfig: {
+				agentId: 'wp-orchestrator',
+			},
+		} as Partial< AgentsManagerContextType >;
+
+		renderAgentDock();
+
+		expect( screen.getByTestId( 'orchestrator-chat' ).textContent ).toContain( 'New Zendesk chat' );
+	} );
+
+	it( 'opens Reader Chat without saving shared Agents Manager state', () => {
+		renderAgentDock();
+
+		fireEvent.click( screen.getByText( 'Expand chat' ) );
+
+		expect( mockSetIsOpen ).toHaveBeenCalledWith( true, false );
+	} );
+
+	it( 'forces Reader Chat to render undocked even if shared state is docked', () => {
+		renderAgentDock();
+
+		expect( mockUseAgentLayoutManager ).toHaveBeenCalledWith(
+			expect.objectContaining( { defaultDocked: false } )
+		);
+	} );
+
+	it( 'opens regular agents and saves shared Agents Manager state', () => {
+		mockContext = {
+			siteKey: 'site-1',
+			sectionName: 'wp-admin',
+			agentConfig: {
+				agentId: 'wp-orchestrator',
+			},
+		} as Partial< AgentsManagerContextType >;
+
+		renderAgentDock();
+
+		fireEvent.click( screen.getByText( 'Expand chat' ) );
+
+		expect( mockSetIsOpen ).toHaveBeenCalledWith( true, true );
+	} );
+} );

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -15,6 +15,7 @@ import { useMemo, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { AGENTS_MANAGER_STORE } from '../../stores';
+import { isReaderChatHost } from '../../utils/is-reader-chat-agent';
 import ChatHeader, { type Options as ChatHeaderOptions } from '../chat-header';
 import ChatMessageSkeleton from '../chat-message-skeleton';
 import CustomALink from '../custom-a-link';
@@ -92,6 +93,51 @@ const DEFAULT_ACCEPTED_IMAGE_TYPES = [
 	'image/heic-sequence',
 	'image/heif-sequence',
 ];
+
+/**
+ * Read a string override from `window.agentsManagerData[key]`. Reader-chat
+ * hosts can customize the empty-view greeting/help copy by setting these
+ * keys before AgentsManager mounts.
+ */
+function readAgentsManagerDataString(
+	key: 'emptyViewHeading' | 'emptyViewHelp'
+): string | undefined {
+	if ( typeof window === 'undefined' || ! isReaderChatHost() ) {
+		return undefined;
+	}
+	const data = ( window as unknown as { agentsManagerData?: Record< string, unknown > } )
+		.agentsManagerData;
+	const value = data?.[ key ];
+	return typeof value === 'string' ? value : undefined;
+}
+
+/**
+ * Returns the empty-view greeting. Priority:
+ *   1. Explicit host override via `window.agentsManagerData.emptyViewHeading`.
+ *   2. Reader-chat default (contextual to blog frontends).
+ *   3. Orchestrator default.
+ */
+function getEmptyViewHeading(): string {
+	const override = readAgentsManagerDataString( 'emptyViewHeading' );
+	if ( override ) {
+		return override;
+	}
+	if ( isReaderChatHost() ) {
+		return __( 'Ask me anything about this blog.', '__i18n_text_domain__' );
+	}
+	return __( 'Howdy! How can I help you today?', '__i18n_text_domain__' );
+}
+
+function getEmptyViewHelp(): string {
+	const override = readAgentsManagerDataString( 'emptyViewHelp' );
+	if ( override ) {
+		return override;
+	}
+	if ( isReaderChatHost() ) {
+		return __( 'Or type your own question below.', '__i18n_text_domain__' );
+	}
+	return __( 'Got a different request? Ask away.', '__i18n_text_domain__' );
+}
 
 export default function AgentChat( {
 	messages,
@@ -181,12 +227,8 @@ export default function AgentChat( {
 					<ChatMessageSkeleton count={ 3 } />
 				) : (
 					<EmptyView
-						heading={ __( 'Howdy! How can I help you today?', '__i18n_text_domain__' ) }
-						help={
-							emptyViewSuggestions.length > 0
-								? __( 'Got a different request? Ask away.', '__i18n_text_domain__' )
-								: undefined
-						}
+						heading={ getEmptyViewHeading() }
+						help={ emptyViewSuggestions.length > 0 ? getEmptyViewHelp() : undefined }
 						suggestions={ emptyViewSuggestions }
 						icon={ <AI size={ 32 } /> }
 					/>

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -5,7 +5,7 @@ import {
 	type Suggestion,
 } from '@automattic/agenttic-ui';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useCallback, useState } from '@wordpress/element';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { comment, drawerRight, help, login, lifesaver } from '@wordpress/icons';
 import { Routes, Route, Navigate, useLocation, useNavigate } from 'react-router-dom';
@@ -16,6 +16,7 @@ import useSetupCustomActions from '../../hooks/use-setup-custom-actions';
 import { useShouldUseUnifiedAgent } from '../../hooks/use-should-use-unified-agent';
 import { AGENTS_MANAGER_STORE } from '../../stores';
 import { LocalConversationListItem } from '../../types';
+import { isReaderChatAgent } from '../../utils/is-reader-chat-agent';
 import { persistLastActivity } from '../../utils/persist-last-activity';
 import AgentHistory from '../agent-history';
 import { type Options as ChatHeaderOptions } from '../chat-header';
@@ -97,14 +98,23 @@ export default function AgentDock( {
 
 	// `agentConfig` is guaranteed non-null here because AgentSetup guards rendering
 	const agentId = agentConfig!.agentId;
+	// Reader-chat runs on public blog frontends where there's no wp-admin
+	// sidebar to dock into. Detect that context so we can hide options that
+	// don't apply and avoid persisting open/close state through the logged-in
+	// Agents Manager REST state endpoint.
+	const isReaderChat = isReaderChatAgent( agentId );
+	const setOpenState = useCallback(
+		( isOpen: boolean ) => setIsOpen( isOpen, ! isReaderChat ),
+		[ isReaderChat, setIsOpen ]
+	);
 
 	const { isDocked, canDock, dock, undock, openSidebar, closeSidebar, createAgentPortal } =
 		useAgentLayoutManager( {
-			defaultDocked: isPersistedDocked,
+			defaultDocked: isReaderChat ? false : isPersistedDocked,
 			defaultOpen: isPersistedOpen,
 			desktopMediaQuery,
-			onOpenSidebar: () => setIsOpen( true ),
-			onCloseSidebar: () => setIsOpen( false ),
+			onOpenSidebar: () => setOpenState( true ),
+			onCloseSidebar: () => setOpenState( false ),
 		} );
 
 	// Handle WordPress admin bar integration
@@ -113,7 +123,7 @@ export default function AgentDock( {
 		sectionName,
 		maybeOpenChat: () => {
 			if ( ! isPersistedOpen ) {
-				isDocked ? openSidebar() : setIsOpen( true );
+				isDocked ? openSidebar() : setOpenState( true );
 			}
 		},
 		navigate,
@@ -138,6 +148,8 @@ export default function AgentDock( {
 		}
 	}, [ agentId ] );
 
+	const shouldShowUnifiedSupport = shouldUseUnifiedAgent && ! isReaderChat;
+
 	const handleChatHasMessagesChange = useCallback(
 		( hasMessages: boolean ) => setIsOrchestratorChatEmpty( ! hasMessages ),
 		[]
@@ -147,10 +159,10 @@ export default function AgentDock( {
 		[]
 	);
 
-	const handleClose = isDocked ? closeSidebar : () => setIsOpen( false );
+	const handleClose = isDocked ? closeSidebar : () => setOpenState( false );
 
 	const handleExpand = () => {
-		setIsOpen( true );
+		setOpenState( true );
 		if ( pathname === '/history' ) {
 			navigate( '/' );
 		}
@@ -158,6 +170,9 @@ export default function AgentDock( {
 
 	const handleSelectConversation = ( conversation: LocalConversationListItem ) => {
 		if ( conversation.is_zendesk ) {
+			if ( isReaderChat ) {
+				return;
+			}
 			navigate( '/zendesk', { state: { conversationId: conversation.conversation_id } } );
 		} else {
 			const sessionId = conversation.session_id || '';
@@ -168,6 +183,40 @@ export default function AgentDock( {
 		}
 	};
 
+	// Persist reader-chat open/closed state across page navigations via
+	// localStorage — the AGENTS_MANAGER_STORE is in-memory only, so a fresh
+	// page load resets isOpen to false by default. Read the stored flag on
+	// mount and restore; write it on every toggle.
+	const OPEN_STORAGE_KEY = `jetpack-reader-chat-open-${ agentId }`;
+	useEffect( () => {
+		if ( ! isReaderChat ) {
+			return;
+		}
+		try {
+			if ( localStorage.getItem( OPEN_STORAGE_KEY ) === '1' && ! isPersistedOpen ) {
+				setOpenState( true );
+			}
+		} catch {
+			// ignore
+		}
+		// Only restore on first mount.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+	useEffect( () => {
+		if ( ! isReaderChat ) {
+			return;
+		}
+		try {
+			if ( isPersistedOpen ) {
+				localStorage.setItem( OPEN_STORAGE_KEY, '1' );
+			} else {
+				localStorage.removeItem( OPEN_STORAGE_KEY );
+			}
+		} catch {
+			// ignore
+		}
+	}, [ isPersistedOpen, isReaderChat, OPEN_STORAGE_KEY ] );
+
 	const getChatHeaderOptions = (): ChatHeaderOptions => {
 		return [
 			{
@@ -176,7 +225,7 @@ export default function AgentDock( {
 				isDisabled: pathname === '/chat' && isOrchestratorChatEmpty,
 				onClick: () => navigate( '/' ),
 			},
-			shouldUseUnifiedAgent && {
+			shouldShowUnifiedSupport && {
 				icon: lifesaver,
 				title: __( 'New Zendesk chat', '__i18n_text_domain__' ),
 				isDisabled: pathname === '/zendesk' && isZendeskChatEmpty,
@@ -186,21 +235,26 @@ export default function AgentDock( {
 				},
 			},
 			// TODO: For testing. Remove before release.
-			{
+			! isReaderChat && {
 				icon: help,
 				title: __( 'Support guides', '__i18n_text_domain__' ),
 				isDisabled: pathname === '/support-guides',
 				onClick: () => navigate( '/support-guides' ),
 			},
-			isDocked && {
-				icon: login,
-				title: __( 'Pop out sidebar', '__i18n_text_domain__' ),
-				onClick: () => {
-					undock();
-					setIsDocked( false );
+			// Sidebar docking only makes sense in wp-admin where a block-editor
+			// sidebar slot exists. On public reader-chat frontends there's no
+			// sidebar to dock into — the click does nothing, so hide the option.
+			! isReaderChat &&
+				isDocked && {
+					icon: login,
+					title: __( 'Pop out sidebar', '__i18n_text_domain__' ),
+					onClick: () => {
+						undock();
+						setIsDocked( false );
+					},
 				},
-			},
-			! isDocked &&
+			! isReaderChat &&
+				! isDocked &&
 				canDock && {
 					icon: drawerRight,
 					title: __( 'Move to sidebar', '__i18n_text_domain__' ),
@@ -287,10 +341,10 @@ export default function AgentDock( {
 			// NOTE: Use route state to pass data that needs to be accessed throughout the app.
 			<Routes>
 				<Route path="/chat" element={ OrchestratorChatRoute } />
-				<Route path="/post" element={ SupportGuideRoute } />
-				<Route path="/zendesk" element={ ZendeskChatRoute } />
-				<Route path="/support-guides" element={ SupportGuidesRoute } />
-				<Route path="/history" element={ HistoryRoute } />
+				{ ! isReaderChat && <Route path="/post" element={ SupportGuideRoute } /> }
+				{ shouldShowUnifiedSupport && <Route path="/zendesk" element={ ZendeskChatRoute } /> }
+				{ ! isReaderChat && <Route path="/support-guides" element={ SupportGuidesRoute } /> }
+				{ ! isReaderChat && <Route path="/history" element={ HistoryRoute } /> }
 				<Route path="*" element={ <Navigate to="/chat" state={ { isNewChat: true } } replace /> } />
 			</Routes>
 		)

--- a/packages/agents-manager/src/components/agents-manager.tsx
+++ b/packages/agents-manager/src/components/agents-manager.tsx
@@ -12,8 +12,9 @@ import { AgentsManagerContextProvider, useAgentsManagerContext } from '../contex
 import { useAgentConfig } from '../hooks/use-agent-config';
 import { useEmptyViewSuggestions } from '../hooks/use-empty-view-suggestions';
 import { AGENTS_MANAGER_STORE } from '../stores';
-import { clearSessionId } from '../utils/agent-session';
+import { clearSessionId, getOrCreateSessionId } from '../utils/agent-session';
 import { createAgentConfig } from '../utils/create-agent-config';
+import { isReaderChatAgent } from '../utils/is-reader-chat-agent';
 import {
 	loadExternalProviders,
 	type ImageUploadHook,
@@ -33,6 +34,8 @@ export interface AgentsManagerProps {
 	currentRoute?: string;
 	/** The ID of the currently selected site, or undefined for non-site contexts. */
 	currentSiteId?: number;
+	/** Explicit agent ID for hosts that must not fall back to Unified Chat. */
+	agentId?: string;
 	/** Called when the agent is closed. */
 	handleClose?: () => void;
 	/** The hook for handling image uploads. */
@@ -47,6 +50,7 @@ export default function AgentsManager( {
 	site,
 	currentRoute,
 	currentSiteId,
+	agentId,
 	useImageUpload,
 }: AgentsManagerProps ): JSX.Element | null {
 	// Wait for the store to load before rendering PersistentRouter
@@ -68,7 +72,7 @@ export default function AgentsManager( {
 		>
 			<QueryClientProvider client={ queryClient }>
 				<PersistentRouter siteKey={ siteKey }>
-					<AgentSetup useImageUpload={ useImageUpload } />
+					<AgentSetup agentId={ agentId } useImageUpload={ useImageUpload } />
 				</PersistentRouter>
 			</QueryClientProvider>
 		</AgentsManagerContextProvider>
@@ -77,8 +81,10 @@ export default function AgentsManager( {
 
 // Separate component that uses hooks within `PersistentRouter` context
 function AgentSetup( {
+	agentId: hostAgentId,
 	useImageUpload: fallbackUseImageUpload,
 }: {
+	agentId?: string;
 	useImageUpload?: ImageUploadHook;
 } ): JSX.Element | null {
 	const { site, currentRoute, agentConfig, setAgentConfig } = useAgentsManagerContext();
@@ -88,12 +94,23 @@ function AgentSetup( {
 
 	// Detect new chat requests via `state.isNewChat` on the `/chat` route.
 	const isNewChat = pathname.startsWith( '/chat' ) && !! state?.isNewChat;
-	// Restore the session ID from route state for existing chats; empty for new chats.
-	const sessionId = ( ! isNewChat && state?.sessionId ) || '';
 
 	// Read agent/version overrides from browser URL (?agent=, ?version=).
 	// PersistentRouter (memory router) does not track window.location.search.
-	const { agentId, version, isLoading: isAgentConfigLoading } = useAgentConfig();
+	const { agentId, version, isLoading: isAgentConfigLoading } = useAgentConfig( hostAgentId );
+
+	// Restore the session ID. Priority:
+	//   1. Router state (calypso navigation carries sessionId on resume).
+	//   2. localStorage (reader-chat on blog frontends, where there's no
+	//      router state on fresh page loads). We persist client-side so
+	//      the same session_id flows with every request.
+	//   3. Generate a new client-side UUID, persist, and use it.
+	// This is more robust than relying on agenttic-client's own sessionIdStorageKey
+	// write — that fires after the server returns a sessionId, which can be
+	// skipped if the response shape doesn't match what the client parses.
+	const sessionId =
+		( ! isNewChat && state?.sessionId ) ||
+		( isReaderChatAgent( agentId ) ? getOrCreateSessionId( isNewChat, agentId ) : '' );
 
 	useEffect( () => {
 		// Wait for the agent config to stabilize before initializing.
@@ -152,6 +169,7 @@ function AgentSetup( {
 		sessionId,
 		setAgentConfig,
 		site?.ID,
+		hostAgentId,
 		version,
 	] );
 

--- a/packages/agents-manager/src/components/chat-header/index.tsx
+++ b/packages/agents-manager/src/components/chat-header/index.tsx
@@ -2,6 +2,7 @@ import { Button, DropdownMenu } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { close, moreVertical, backup, chevronLeft, Icon } from '@wordpress/icons';
 import { useNavigate } from 'react-router-dom';
+import { isReaderChatHost } from '../../utils/is-reader-chat-agent';
 import type { ComponentProps } from 'react';
 import './style.scss';
 
@@ -38,13 +39,21 @@ export default function ChatHeader( { onClose, options, title, onBack }: Props )
 					label={ __( 'More Options', '__i18n_text_domain__' ) }
 					toggleProps={ { size: 'small' } }
 				/>
-				<Button
-					className="agents-manager-chat-header__history-btn"
-					icon={ backup }
-					onClick={ () => navigate( '/history' ) }
-					label={ __( 'View history', '__i18n_text_domain__' ) }
-					size="small"
-				/>
+				{ /*
+				 * Public reader-chat runs on blog frontends where session history
+				 * isn't user-accessible (no account, per-visit local storage).
+				 * Hide the history icon for that context — it navigates to a
+				 * route with nothing to show.
+				 */ }
+				{ ! isReaderChatHost() && (
+					<Button
+						className="agents-manager-chat-header__history-btn"
+						icon={ backup }
+						onClick={ () => navigate( '/history' ) }
+						label={ __( 'View history', '__i18n_text_domain__' ) }
+						size="small"
+					/>
+				) }
 				<Button
 					className="agents-manager-chat-header__close-btn"
 					icon={ close }

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -17,7 +17,9 @@ import useFeedbackAction from '../../hooks/use-feedback-action';
 import useSaveNewChatRoute from '../../hooks/use-save-new-chat-route';
 import useSourcesAction from '../../hooks/use-sources-action';
 import useZoomAction from '../../hooks/use-zoom-action';
+import { markSessionUsed } from '../../utils/agent-session';
 import convertToolMessagesToComponents from '../../utils/convert-tool-messages-to-components';
+import { isReaderChatAgent } from '../../utils/is-reader-chat-agent';
 import { persistLastActivity } from '../../utils/persist-last-activity';
 import AgentChat from '../agent-chat';
 import { type Options as ChatHeaderOptions } from '../chat-header';
@@ -116,8 +118,20 @@ export default function OrchestratorChat( {
 		progressMessage,
 	} = useAgentChat( agentConfig! );
 
+	// Reader-chat sessions are short (usually < 50 messages) — don't waste
+	// time paginating 10 pages deep. One page covers typical use.
+	const isReaderChat = isReaderChatAgent( agentConfig?.agentId );
+	const shouldLoadConversation =
+		! isReaderChat || ( ! hasUserSentMessage && messages.length === 0 && ! isProcessing );
+
 	const { isLoading: isLoadingConversation } = useConversation( {
+		maxPages: isReaderChat ? 1 : 10,
+		enabled: shouldLoadConversation,
 		onSuccess: ( loadedMessages, serverSessionId ) => {
+			if ( isReaderChat && ( hasUserSentMessage || messages.length > 0 || isProcessing ) ) {
+				return;
+			}
+
 			// Update the UI with the loaded messages
 			loadMessages( loadedMessages );
 			// Make sure future messages go to the right session
@@ -165,7 +179,7 @@ export default function OrchestratorChat( {
 	useZoomAction( registerMessageActions );
 
 	// Register a "Sources" action on agent messages with sources data.
-	useSourcesAction( registerMessageActions );
+	useSourcesAction( registerMessageActions, ! isReaderChat );
 
 	const imageUpload = useImageUpload?.();
 	const pendingImages = imageUpload?.pendingImages || [];
@@ -207,10 +221,20 @@ export default function OrchestratorChat( {
 				}
 			} else {
 				// No images, just send normally
-				onSubmit( message );
+				await onSubmit( message );
+			}
+			if ( isReaderChat ) {
+				markSessionUsed( agentConfig?.agentId );
 			}
 		},
-		[ onSubmit, pendingImages.length, siteKey, uploadImagesToWordPress ]
+		[
+			agentConfig?.agentId,
+			isReaderChat,
+			onSubmit,
+			pendingImages.length,
+			siteKey,
+			uploadImagesToWordPress,
+		]
 	);
 
 	// Handle navigation continuation if hook is provided

--- a/packages/agents-manager/src/hooks/__tests__/use-agent-config.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-agent-config.test.ts
@@ -25,11 +25,13 @@ describe( 'useAgentConfig', () => {
 
 	beforeEach( () => {
 		mockSearch( '' );
+		mockUseUnifiedAiChat.mockClear();
 		mockUseUnifiedAiChat.mockReturnValue( { data: undefined } );
 	} );
 
 	afterEach( () => {
 		window.history.pushState( {}, '', '/' );
+		delete ( globalThis as Record< string, unknown > ).agentsManagerData;
 	} );
 
 	it( 'returns `ORCHESTRATOR_AGENT_ID` when `useUnifiedAiChat` returns `undefined`', () => {
@@ -112,6 +114,16 @@ describe( 'useAgentConfig', () => {
 		};
 		const { result } = renderHook( () => useAgentConfig() );
 		expect( result.current.agentId ).toBe( 'woo-workflow-unified_chat' );
-		delete ( globalThis as Record< string, unknown > ).agentsManagerData;
+	} );
+
+	it( 'uses an explicit host agent ID over URL and unified chat overrides', () => {
+		mockUseUnifiedAiChat.mockReturnValue( { data: true, isLoading: true } );
+		mockSearch( '?agent=wpcom-workflow-unified_chat' );
+
+		const { result } = renderHook( () => useAgentConfig( 'reader-chat' ) );
+
+		expect( result.current.agentId ).toBe( 'reader-chat' );
+		expect( result.current.isLoading ).toBe( false );
+		expect( mockUseUnifiedAiChat ).toHaveBeenCalledWith( false );
 	} );
 } );

--- a/packages/agents-manager/src/hooks/__tests__/use-setup-custom-actions.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-setup-custom-actions.test.ts
@@ -4,6 +4,13 @@
 import { renderHook } from '@testing-library/react';
 import useSetupCustomActions from '../use-setup-custom-actions';
 
+const mockSetIsOpen = jest.fn();
+const mockSetIsDocked = jest.fn();
+let mockContext = {
+	getActiveSessionId: jest.fn( () => 'session-123' ),
+	agentConfig: { agentId: 'reader-chat' },
+};
+
 jest.mock( '@wordpress/data', () => ( {
 	useSelect: jest.fn( () => ( {
 		hasLoaded: true,
@@ -12,8 +19,8 @@ jest.mock( '@wordpress/data', () => ( {
 		floatingPosition: '',
 	} ) ),
 	useDispatch: jest.fn( () => ( {
-		setIsOpen: jest.fn(),
-		setIsDocked: jest.fn(),
+		setIsOpen: mockSetIsOpen,
+		setIsDocked: mockSetIsDocked,
 	} ) ),
 } ) );
 
@@ -22,9 +29,7 @@ jest.mock( 'react-router-dom', () => ( {
 } ) );
 
 jest.mock( '../../contexts', () => ( {
-	useAgentsManagerContext: jest.fn( () => ( {
-		getActiveSessionId: jest.fn( () => 'session-123' ),
-	} ) ),
+	useAgentsManagerContext: jest.fn( () => mockContext ),
 } ) );
 
 jest.mock( '../../stores', () => ( {
@@ -44,7 +49,12 @@ const baseProps = {
 
 describe( 'useSetupCustomActions — ready signal', () => {
 	beforeEach( () => {
+		jest.clearAllMocks();
 		delete window.__agentsManagerActions;
+		mockContext = {
+			getActiveSessionId: jest.fn( () => 'session-123' ),
+			agentConfig: { agentId: 'reader-chat' },
+		};
 	} );
 
 	it( 'sets isReady on the global after mount', () => {
@@ -88,5 +98,25 @@ describe( 'useSetupCustomActions — ready signal', () => {
 		expect( snapshot?.setChatOpen ).toBeInstanceOf( Function );
 		expect( snapshot?.setChatDocked ).toBeInstanceOf( Function );
 		expect( snapshot?.isReady ).toBe( true );
+	} );
+
+	it( 'opens Reader Chat without persisting shared Agents Manager state', () => {
+		renderHook( () => useSetupCustomActions( { ...baseProps, canDock: false } ) );
+
+		window.__agentsManagerActions?.setChatOpen?.( true );
+
+		expect( mockSetIsOpen ).toHaveBeenCalledWith( true, false );
+	} );
+
+	it( 'opens regular agents while preserving shared Agents Manager state persistence', () => {
+		mockContext = {
+			getActiveSessionId: jest.fn( () => 'session-123' ),
+			agentConfig: { agentId: 'wp-orchestrator' },
+		};
+		renderHook( () => useSetupCustomActions( { ...baseProps, canDock: false } ) );
+
+		window.__agentsManagerActions?.setChatOpen?.( true );
+
+		expect( mockSetIsOpen ).toHaveBeenCalledWith( true, true );
 	} );
 } );

--- a/packages/agents-manager/src/hooks/use-agent-config.ts
+++ b/packages/agents-manager/src/hooks/use-agent-config.ts
@@ -8,21 +8,22 @@ interface AgentConfig {
 }
 
 /**
- * Resolves agent ID and version from URL parameters or defaults.
+ * Resolves agent ID and version from host configuration, URL parameters, or defaults.
  * `isLoading` is true until the default agent ID is determined.
  *
  * Priority chain:
- * 1. `?agent=` URL param (testing override)
- * 2. `agentsManagerData.agentId` (host-level override, e.g., WooCommerce AI)
- * 3. Unified experience toggle (`useUnifiedAiChat`)
- * 4. `ORCHESTRATOR_AGENT_ID` (default)
+ * 1. Explicit host `agentId` prop (hard override, e.g. Reader Chat)
+ * 2. `?agent=` URL param (testing override)
+ * 3. `agentsManagerData.agentId` (host-level override, e.g., WooCommerce AI)
+ * 4. Unified experience toggle (`useUnifiedAiChat`)
+ * 5. `ORCHESTRATOR_AGENT_ID` (default)
  *
  * Query parameters:
  * - `agent`: Override the agent ID (e.g., `?agent=wpcom-workflow-support_chat`)
  * - `version`: Override the agent version (e.g., `?version=1.0.25`)
  */
-export function useAgentConfig(): AgentConfig {
-	const { data: useUnifiedExperience, isLoading } = useUnifiedAiChat();
+export function useAgentConfig( hostAgentId?: string ): AgentConfig {
+	const { data: useUnifiedExperience, isLoading } = useUnifiedAiChat( ! hostAgentId );
 	const urlSearchParams = new URLSearchParams( window.location.search );
 	const agentIdParam = urlSearchParams.get( 'agent' );
 	const versionParam = urlSearchParams.get( 'version' );
@@ -32,8 +33,9 @@ export function useAgentConfig(): AgentConfig {
 	const unifiedChatAgentId = useUnifiedExperience ? UNIFIED_CHAT_AGENT_ID : undefined;
 
 	return {
-		agentId: agentIdParam || inlineAgentId || unifiedChatAgentId || ORCHESTRATOR_AGENT_ID,
+		agentId:
+			hostAgentId || agentIdParam || inlineAgentId || unifiedChatAgentId || ORCHESTRATOR_AGENT_ID,
 		version: versionParam || undefined,
-		isLoading,
+		isLoading: hostAgentId ? false : isLoading,
 	};
 }

--- a/packages/agents-manager/src/hooks/use-conversation-list.ts
+++ b/packages/agents-manager/src/hooks/use-conversation-list.ts
@@ -1,7 +1,5 @@
 import {
 	listConversationsFromServer,
-	createOdieBotId,
-	isOdieBotId,
 	type ServerConversationListItem,
 } from '@automattic/agenttic-client';
 import { useGetZendeskConversations } from '@automattic/zendesk-client';
@@ -10,7 +8,9 @@ import { useEffect, useMemo } from '@wordpress/element';
 import { API_BASE_URL } from '../constants';
 import { useAgentsManagerContext } from '../contexts';
 import { LocalConversationListItem } from '../types';
+import { getConversationBotId } from '../utils/conversation-bot-id';
 import { parseUTCTimestamp } from '../utils/conversation-history-formatters';
+import { isReaderChatAgent } from '../utils/is-reader-chat-agent';
 import { normalizeZendeskConversations } from '../utils/zendesk';
 import { useShouldUseUnifiedAgent } from './use-should-use-unified-agent';
 
@@ -19,12 +19,13 @@ export default function useConversationList() {
 	const { agentId, authProvider } = agentConfig!;
 	const urlSearchParams = new URLSearchParams( window.location.search );
 	const hasAgentParam = urlSearchParams.has( 'agent' );
-	const botId = hasAgentParam || isOdieBotId( agentId ) ? agentId : createOdieBotId( agentId );
+	const botId = getConversationBotId( agentId, hasAgentParam );
+	const isReaderChat = isReaderChatAgent( agentId );
 	const shouldUseUnifiedAgent = useShouldUseUnifiedAgent();
 
 	// Only fetch Zendesk conversations if the unified agent flag is enabled
 	const { conversations: zendeskConversations, isLoading: isLoadingZendeskConversations } =
-		useGetZendeskConversations( !! shouldUseUnifiedAgent );
+		useGetZendeskConversations( !! shouldUseUnifiedAgent && ! isReaderChat );
 
 	const {
 		data: orchestratorConversations,

--- a/packages/agents-manager/src/hooks/use-conversation.ts
+++ b/packages/agents-manager/src/hooks/use-conversation.ts
@@ -1,16 +1,15 @@
-import {
-	loadAllMessagesFromServer,
-	createOdieBotId,
-	isOdieBotId,
-	type Message,
-} from '@automattic/agenttic-client';
+import { loadAllMessagesFromServer, type Message } from '@automattic/agenttic-client';
 import { useQuery } from '@tanstack/react-query';
 import { useEffect, useRef } from '@wordpress/element';
 import { API_BASE_URL } from '../constants';
 import { useAgentsManagerContext } from '../contexts';
+import { isFreshSession } from '../utils/agent-session';
+import { getConversationBotId } from '../utils/conversation-bot-id';
+import { isReaderChatAgent } from '../utils/is-reader-chat-agent';
 
 interface Config {
 	maxPages?: number;
+	enabled?: boolean;
 	onSuccess?: ( messages: Message[], sessionId: string ) => void;
 }
 
@@ -23,7 +22,11 @@ interface Result {
 /**
  * Fetches a conversation from the server when a `sessionId` is available.
  */
-export default function useConversation( { maxPages = 10, onSuccess = () => {} }: Config ): Result {
+export default function useConversation( {
+	maxPages = 10,
+	enabled = true,
+	onSuccess = () => {},
+}: Config ): Result {
 	const { agentConfig } = useAgentsManagerContext();
 	const { agentId, sessionId, authProvider } = agentConfig!;
 
@@ -37,7 +40,7 @@ export default function useConversation( { maxPages = 10, onSuccess = () => {} }
 		queryFn: async () => {
 			const urlSearchParams = new URLSearchParams( window.location.search );
 			const hasAgentParam = urlSearchParams.has( 'agent' );
-			const botId = hasAgentParam || isOdieBotId( agentId ) ? agentId : createOdieBotId( agentId );
+			const botId = getConversationBotId( agentId, hasAgentParam );
 
 			return await loadAllMessagesFromServer(
 				sessionId,
@@ -50,7 +53,11 @@ export default function useConversation( { maxPages = 10, onSuccess = () => {} }
 				true
 			);
 		},
-		enabled: !! sessionId,
+		// Skip server fetch for brand-new client-created sessions — they
+		// have no history to load and the extra round-trip blocks the
+		// skeleton unnecessarily.
+		enabled:
+			enabled && !! sessionId && ! ( isReaderChatAgent( agentId ) && isFreshSession( agentId ) ),
 		refetchOnWindowFocus: false,
 	} );
 

--- a/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
+++ b/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
@@ -2,6 +2,7 @@ import { type Suggestion } from '@automattic/agenttic-ui';
 import { useSelect } from '@wordpress/data';
 import { useEffect, useState, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { isReaderChatHost } from '../utils/is-reader-chat-agent';
 import type { LoadedProviders } from '../utils/load-external-providers';
 
 interface UseEmptyViewSuggestionsOptions {
@@ -19,9 +20,42 @@ interface UseEmptyViewSuggestionsOptions {
  * @param params.loadedProviders - External providers loaded from plugins (e.g., Big Sky)
  * @returns The computed suggestions (either from Big Sky or defaults), or null while loading
  */
+/**
+ * Direct override path: a host that renders AgentsManager (e.g. reader-chat
+ * on a blog frontend) can set `window.agentsManagerData.readerSuggestions`
+ * to a Suggestion[] and this hook will return it verbatim, bypassing the
+ * provider flow. Reassigning the global and forcing a re-render causes
+ * the empty view to update with fresh suggestions.
+ */
+function readOverrideSuggestions(): Suggestion[] | null {
+	if ( typeof window === 'undefined' || ! isReaderChatHost() ) {
+		return null;
+	}
+	const data = ( window as unknown as { agentsManagerData?: { readerSuggestions?: unknown } } )
+		.agentsManagerData;
+	const override = data?.readerSuggestions;
+	// Key absent entirely — no host override, fall through to defaults.
+	if ( ! Array.isArray( override ) ) {
+		return null;
+	}
+	// Empty array is an explicit "no chips yet" signal (host is fetching
+	// AI suggestions and wants the empty view to show nothing until they
+	// arrive). Return it verbatim rather than falling through to defaults.
+	if ( override.length === 0 ) {
+		return [];
+	}
+	const valid = override.filter(
+		( s ): s is Suggestion =>
+			!! s && typeof s === 'object' && 'label' in s && 'prompt' in s && 'id' in s
+	);
+	return valid.length > 0 ? valid : null;
+}
+
 export function useEmptyViewSuggestions( {
 	loadedProviders,
 }: UseEmptyViewSuggestionsOptions ): Suggestion[] | null {
+	const isReaderChat = isReaderChatHost();
+
 	// Default suggestions - used when Big Sky doesn't provide custom ones
 	const defaultSuggestions = useMemo(
 		() => [
@@ -70,8 +104,46 @@ export function useEmptyViewSuggestions( {
 	// Compute empty view suggestions once when store is ready
 	const [ emptyViewSuggestions, setEmptyViewSuggestions ] = useState< Suggestion[] | null >( null );
 
+	// Signal that bumps whenever the host dispatches
+	// `reader-chat-suggestions-updated`. Reader chat fires this after async
+	// AI suggestions arrive so the empty view re-reads the override without
+	// the component tree having to re-mount.
+	const [ overrideVersion, setOverrideVersion ] = useState( 0 );
 	useEffect( () => {
-		if ( ! loadedProviders || ! isCoreStoreReady || emptyViewSuggestions !== null ) {
+		if ( typeof window === 'undefined' || ! isReaderChat ) {
+			return;
+		}
+		const handler = () => setOverrideVersion( ( v ) => v + 1 );
+		window.addEventListener( 'reader-chat-suggestions-updated', handler );
+		return () => {
+			window.removeEventListener( 'reader-chat-suggestions-updated', handler );
+		};
+	}, [ isReaderChat ] );
+
+	useEffect( () => {
+		if ( ! loadedProviders || ! isCoreStoreReady ) {
+			return;
+		}
+
+		// Re-read override on every effect run. We compare by JSON-identity
+		// against the current state so we only call setState when the
+		// override content actually changes — otherwise a fresh array
+		// reference every render would loop infinitely.
+		const currentOverride = readOverrideSuggestions();
+		if ( currentOverride ) {
+			const currentKey = JSON.stringify(
+				currentOverride.map( ( s ) => [ s.id, s.label, s.prompt ] )
+			);
+			const stateKey = emptyViewSuggestions
+				? JSON.stringify( emptyViewSuggestions.map( ( s ) => [ s.id, s.label, s.prompt ] ) )
+				: null;
+			if ( currentKey !== stateKey ) {
+				setEmptyViewSuggestions( currentOverride );
+			}
+			return;
+		}
+
+		if ( emptyViewSuggestions !== null ) {
 			return;
 		}
 
@@ -96,6 +168,7 @@ export function useEmptyViewSuggestions( {
 		hasBigSkySuggestions,
 		defaultSuggestions,
 		emptyViewSuggestions,
+		overrideVersion,
 	] );
 
 	return emptyViewSuggestions;

--- a/packages/agents-manager/src/hooks/use-setup-custom-actions/index.ts
+++ b/packages/agents-manager/src/hooks/use-setup-custom-actions/index.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { useNavigate } from 'react-router-dom';
 import { useAgentsManagerContext } from '../../contexts';
 import { AGENTS_MANAGER_STORE } from '../../stores';
+import { isReaderChatAgent } from '../../utils/is-reader-chat-agent';
 import type { AgentsManagerSelect } from '@automattic/data-stores';
 
 interface Props {
@@ -31,10 +32,11 @@ export default function useSetupCustomActions( {
 		return store.getAgentsManagerState();
 	}, [] );
 	const { setIsOpen, setIsDocked } = useDispatch( AGENTS_MANAGER_STORE );
-	const { getActiveSessionId } = useAgentsManagerContext();
+	const { agentConfig, getActiveSessionId } = useAgentsManagerContext();
 	const navigate = useNavigate();
 	const resolveRef = useRef< ( ( state: AgentsManagerChatState ) => void ) | null >( null );
 	const hasFiredReadyRef = useRef( false );
+	const shouldPersistOpenState = ! isReaderChatAgent( agentConfig?.agentId );
 
 	const setChatOpen = useCallback(
 		( shouldOpen: boolean ) => {
@@ -43,7 +45,7 @@ export default function useSetupCustomActions( {
 			}
 
 			if ( ! isDocked || ! canDock ) {
-				return setIsOpen( shouldOpen );
+				return setIsOpen( shouldOpen, shouldPersistOpenState );
 			}
 
 			if ( shouldOpen ) {
@@ -54,7 +56,7 @@ export default function useSetupCustomActions( {
 				closeSidebar();
 			}
 		},
-		[ canDock, closeSidebar, isDocked, openSidebar, setIsOpen ]
+		[ canDock, closeSidebar, isDocked, openSidebar, setIsOpen, shouldPersistOpenState ]
 	);
 
 	const setChatDocked = useCallback(

--- a/packages/agents-manager/src/hooks/use-sources-action.ts
+++ b/packages/agents-manager/src/hooks/use-sources-action.ts
@@ -30,8 +30,15 @@ function getMessageSources( message: UIMessage ): Source[] | null {
  * Registers the SourcesDisplay component as a message action on agent messages
  * that contain a sources data block.
  */
-export default function useSourcesAction( registerMessageActions: RegisterMessageActions ): void {
+export default function useSourcesAction(
+	registerMessageActions: RegisterMessageActions,
+	enabled = true
+): void {
 	useEffect( () => {
+		if ( ! enabled ) {
+			return;
+		}
+
 		registerMessageActions( {
 			id: 'agents-manager-sources',
 			actions: ( message ) => {
@@ -56,5 +63,5 @@ export default function useSourcesAction( registerMessageActions: RegisterMessag
 				];
 			},
 		} );
-	}, [ registerMessageActions ] );
+	}, [ enabled, registerMessageActions ] );
 }

--- a/packages/agents-manager/src/utils/__tests__/agent-session.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/agent-session.test.ts
@@ -1,0 +1,274 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+	SESSION_STORAGE_KEY,
+	getSessionStorageKey,
+	getSessionId,
+	clearSessionId,
+	isFreshSession,
+	markSessionUsed,
+	getOrCreateSessionId,
+} from '../agent-session';
+
+// The ORCHESTRATOR_AGENT_ID constant ('wp-orchestrator') is used internally in
+// getSessionStorageKey to fall back to the base key. Reference it via the same
+// module so tests don't hard-code the string.
+const ORCHESTRATOR_AGENT_ID = 'wp-orchestrator';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeStoredSession( sessionId: string, ageMs = 0 ) {
+	return JSON.stringify( { sessionId, timestamp: Date.now() - ageMs } );
+}
+
+// jsdom's `crypto` object does not expose `randomUUID`. Polyfill it so spyOn
+// can find the property, matching the behaviour of real browser environments.
+function ensureCryptoRandomUUID() {
+	if ( typeof globalThis.crypto.randomUUID !== 'function' ) {
+		( globalThis.crypto as Crypto ).randomUUID = () =>
+			'00000000-0000-4000-8000-000000000000' as ReturnType< Crypto[ 'randomUUID' ] >;
+	}
+}
+
+// ---------------------------------------------------------------------------
+
+describe( 'getSessionStorageKey', () => {
+	it( 'returns base key when agentId is undefined', () => {
+		expect( getSessionStorageKey( undefined ) ).toBe( SESSION_STORAGE_KEY );
+	} );
+
+	it( 'returns base key for the orchestrator agent', () => {
+		expect( getSessionStorageKey( ORCHESTRATOR_AGENT_ID ) ).toBe( SESSION_STORAGE_KEY );
+	} );
+
+	it( "returns suffixed key for 'reader-chat'", () => {
+		expect( getSessionStorageKey( 'reader-chat' ) ).toBe( `${ SESSION_STORAGE_KEY }-reader-chat` );
+	} );
+
+	it( "returns suffixed key for 'p2-reader-chat'", () => {
+		expect( getSessionStorageKey( 'p2-reader-chat' ) ).toBe(
+			`${ SESSION_STORAGE_KEY }-p2-reader-chat`
+		);
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+
+describe( 'getSessionId', () => {
+	let getItemSpy: jest.SpyInstance;
+	let removeItemSpy: jest.SpyInstance;
+
+	beforeEach( () => {
+		getItemSpy = jest.spyOn( Storage.prototype, 'getItem' ).mockReturnValue( null );
+		removeItemSpy = jest.spyOn( Storage.prototype, 'removeItem' ).mockImplementation( () => {} );
+	} );
+
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	it( 'returns empty string when nothing is in localStorage', () => {
+		expect( getSessionId() ).toBe( '' );
+	} );
+
+	it( 'returns stored session ID when the session is within 24 h', () => {
+		getItemSpy.mockReturnValue( makeStoredSession( 'session-abc', 0 ) );
+		expect( getSessionId() ).toBe( 'session-abc' );
+	} );
+
+	it( 'returns empty string and removes the key when the session is expired (> 24 h)', () => {
+		const TWENTY_FIVE_HOURS = 25 * 60 * 60 * 1000;
+		getItemSpy.mockReturnValue( makeStoredSession( 'old-session', TWENTY_FIVE_HOURS ) );
+
+		expect( getSessionId() ).toBe( '' );
+		expect( removeItemSpy ).toHaveBeenCalledWith( SESSION_STORAGE_KEY );
+	} );
+
+	it( 'returns empty string gracefully when localStorage value is malformed JSON', () => {
+		getItemSpy.mockReturnValue( 'not-valid-json' );
+		// The implementation logs a console.error — suppress it to keep test output clean.
+		const consoleSpy = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+		expect( getSessionId() ).toBe( '' );
+		consoleSpy.mockRestore();
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+
+describe( 'clearSessionId', () => {
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	it( 'removes the session key from localStorage', () => {
+		const removeItemSpy = jest
+			.spyOn( Storage.prototype, 'removeItem' )
+			.mockImplementation( () => {} );
+
+		clearSessionId( 'reader-chat' );
+
+		expect( removeItemSpy ).toHaveBeenCalledWith( `${ SESSION_STORAGE_KEY }-reader-chat` );
+	} );
+
+	it( 'removes the base session key when no agentId is provided', () => {
+		const removeItemSpy = jest
+			.spyOn( Storage.prototype, 'removeItem' )
+			.mockImplementation( () => {} );
+
+		clearSessionId();
+
+		expect( removeItemSpy ).toHaveBeenCalledWith( SESSION_STORAGE_KEY );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+
+describe( 'isFreshSession', () => {
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	it( 'returns `false` by default (no fresh flag stored)', () => {
+		jest.spyOn( Storage.prototype, 'getItem' ).mockReturnValue( null );
+		expect( isFreshSession() ).toBe( false );
+	} );
+
+	it( "returns `true` when the fresh flag is set for 'reader-chat'", () => {
+		jest.spyOn( Storage.prototype, 'getItem' ).mockImplementation( ( key ) => {
+			if ( key === 'agents-manager-session-fresh-reader-chat' ) {
+				return '1';
+			}
+			return null;
+		} );
+		expect( isFreshSession( 'reader-chat' ) ).toBe( true );
+	} );
+
+	it( 'returns `false` when the fresh flag is not set for the given agentId', () => {
+		jest.spyOn( Storage.prototype, 'getItem' ).mockReturnValue( null );
+		expect( isFreshSession( 'reader-chat' ) ).toBe( false );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+
+describe( 'markSessionUsed', () => {
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	it( 'removes the fresh-session flag from localStorage', () => {
+		const removeItemSpy = jest
+			.spyOn( Storage.prototype, 'removeItem' )
+			.mockImplementation( () => {} );
+
+		markSessionUsed( 'reader-chat' );
+
+		expect( removeItemSpy ).toHaveBeenCalledWith( 'agents-manager-session-fresh-reader-chat' );
+	} );
+
+	it( 'clears the default flag when no agentId is provided', () => {
+		const removeItemSpy = jest
+			.spyOn( Storage.prototype, 'removeItem' )
+			.mockImplementation( () => {} );
+
+		markSessionUsed();
+
+		expect( removeItemSpy ).toHaveBeenCalledWith( 'agents-manager-session-fresh-default' );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+
+describe( 'getOrCreateSessionId', () => {
+	let getItemSpy: jest.SpyInstance;
+	let setItemSpy: jest.SpyInstance;
+	let removeItemSpy: jest.SpyInstance;
+
+	beforeEach( () => {
+		ensureCryptoRandomUUID();
+		getItemSpy = jest.spyOn( Storage.prototype, 'getItem' ).mockReturnValue( null );
+		setItemSpy = jest.spyOn( Storage.prototype, 'setItem' ).mockImplementation( () => {} );
+		removeItemSpy = jest.spyOn( Storage.prototype, 'removeItem' ).mockImplementation( () => {} );
+	} );
+
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	it( 'returns an existing valid session without creating a new one', () => {
+		getItemSpy.mockImplementation( ( key ) => {
+			if ( key === `${ SESSION_STORAGE_KEY }-reader-chat` ) {
+				return makeStoredSession( 'existing-session-id', 0 );
+			}
+			return null;
+		} );
+
+		const result = getOrCreateSessionId( false, 'reader-chat' );
+
+		expect( result ).toBe( 'existing-session-id' );
+		expect( setItemSpy ).not.toHaveBeenCalled();
+	} );
+
+	it( 'clears existing session and generates a new UUID when isNewChat is true', () => {
+		const mockUUID = 'new-uuid-1234';
+		const randomUUIDSpy = jest
+			.spyOn( globalThis.crypto, 'randomUUID' )
+			.mockReturnValue( mockUUID as ReturnType< Crypto[ 'randomUUID' ] > );
+
+		const result = getOrCreateSessionId( true, 'reader-chat' );
+
+		// Should have cleared the old key first.
+		expect( removeItemSpy ).toHaveBeenCalledWith( `${ SESSION_STORAGE_KEY }-reader-chat` );
+		expect( result ).toBe( mockUUID );
+		randomUUIDSpy.mockRestore();
+	} );
+
+	it( 'generates a new UUID with crypto.randomUUID when no stored session exists', () => {
+		const mockUUID = 'crypto-uuid-5678';
+		const randomUUIDSpy = jest
+			.spyOn( globalThis.crypto, 'randomUUID' )
+			.mockReturnValue( mockUUID as ReturnType< Crypto[ 'randomUUID' ] > );
+
+		const result = getOrCreateSessionId( false, 'reader-chat' );
+
+		expect( result ).toBe( mockUUID );
+		// Should persist the new session and set the fresh flag.
+		expect( setItemSpy ).toHaveBeenCalledWith(
+			`${ SESSION_STORAGE_KEY }-reader-chat`,
+			expect.stringContaining( mockUUID )
+		);
+		expect( setItemSpy ).toHaveBeenCalledWith( 'agents-manager-session-fresh-reader-chat', '1' );
+		randomUUIDSpy.mockRestore();
+	} );
+
+	it( 'sets fresh flag when generating a new session', () => {
+		const mockUUID = 'fresh-uuid-9999';
+		const randomUUIDSpy = jest
+			.spyOn( globalThis.crypto, 'randomUUID' )
+			.mockReturnValue( mockUUID as ReturnType< Crypto[ 'randomUUID' ] > );
+
+		getOrCreateSessionId( false );
+
+		expect( setItemSpy ).toHaveBeenCalledWith( 'agents-manager-session-fresh-default', '1' );
+		randomUUIDSpy.mockRestore();
+	} );
+
+	it( 'uses xxx-xxxx fallback pattern when crypto.randomUUID is unavailable', () => {
+		// Temporarily remove randomUUID to simulate older browsers.
+		const savedRandomUUID = globalThis.crypto.randomUUID;
+		// @ts-expect-error - Simulating missing randomUUID
+		delete globalThis.crypto.randomUUID;
+
+		const result = getOrCreateSessionId( false, 'reader-chat' );
+
+		// The fallback produces a string matching the xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx pattern.
+		expect( result ).toMatch(
+			/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+		);
+
+		globalThis.crypto.randomUUID = savedRandomUUID;
+	} );
+} );

--- a/packages/agents-manager/src/utils/__tests__/conversation-bot-id.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/conversation-bot-id.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-disable import/order -- jest.mock calls must precede imports */
+jest.mock(
+	'@automattic/agenttic-client',
+	() => ( {
+		createOdieBotId: jest.fn(
+			( agentId: string ) => `wpcom-agent-${ agentId.replace( /-/g, '_' ) }`
+		),
+		isOdieBotId: jest.fn( ( agentId: string ) => agentId.startsWith( 'wpcom-' ) ),
+	} ),
+	{ virtual: true }
+);
+
+import { createOdieBotId } from '@automattic/agenttic-client';
+import { getConversationBotId } from '../conversation-bot-id';
+
+const mockCreateOdieBotId = createOdieBotId as jest.Mock;
+
+describe( 'getConversationBotId', () => {
+	beforeEach( () => {
+		mockCreateOdieBotId.mockClear();
+	} );
+
+	it( 'keeps reader-chat agent IDs unchanged', () => {
+		expect( getConversationBotId( 'reader-chat', false ) ).toBe( 'reader-chat' );
+		expect( getConversationBotId( 'p2-reader-chat', false ) ).toBe( 'p2-reader-chat' );
+		expect( mockCreateOdieBotId ).not.toHaveBeenCalled();
+	} );
+
+	it( 'keeps explicit agent URL overrides unchanged', () => {
+		expect( getConversationBotId( 'custom-agent', true ) ).toBe( 'custom-agent' );
+		expect( mockCreateOdieBotId ).not.toHaveBeenCalled();
+	} );
+
+	it( 'keeps existing Odie bot IDs unchanged', () => {
+		expect( getConversationBotId( 'wpcom-agent-wp_orchestrator', false ) ).toBe(
+			'wpcom-agent-wp_orchestrator'
+		);
+		expect( mockCreateOdieBotId ).not.toHaveBeenCalled();
+	} );
+
+	it( 'converts regular agent IDs to Odie bot IDs', () => {
+		expect( getConversationBotId( 'wp-orchestrator', false ) ).toBe(
+			'wpcom-agent-wp_orchestrator'
+		);
+		expect( mockCreateOdieBotId ).toHaveBeenCalledWith( 'wp-orchestrator' );
+	} );
+} );

--- a/packages/agents-manager/src/utils/__tests__/create-agent-config.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/create-agent-config.test.ts
@@ -1,0 +1,76 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-disable import/order -- jest.mock calls must precede imports */
+jest.mock( '../../auth/calypso-auth-provider', () => ( {
+	createCalypsoAuthProvider: jest.fn( () => ( { type: 'auth-provider' } ) ),
+} ) );
+
+jest.mock( '../can-connect-to-zendesk', () => ( {
+	canConnectToZendesk: jest.fn( () => Promise.resolve( false ) ),
+} ) );
+
+import { createAgentConfig } from '../create-agent-config';
+import { canConnectToZendesk } from '../can-connect-to-zendesk';
+
+const mockCanConnectToZendesk = canConnectToZendesk as jest.Mock;
+
+function setAgentsManagerData( data: Record< string, unknown > ) {
+	( window as unknown as { agentsManagerData?: Record< string, unknown > } ).agentsManagerData =
+		data;
+}
+
+describe( 'createAgentConfig', () => {
+	beforeEach( () => {
+		mockCanConnectToZendesk.mockClear();
+	} );
+
+	afterEach( () => {
+		delete ( window as unknown as { agentsManagerData?: Record< string, unknown > } )
+			.agentsManagerData;
+	} );
+
+	it( 'does not add reader page context for regular agents', async () => {
+		setAgentsManagerData( {
+			currentPost: { id: 1, title: 'Reader post' },
+			siteName: 'Reader Site',
+			siteUrl: 'https://example.com',
+		} );
+
+		const config = await createAgentConfig( {
+			sessionId: 'session-1',
+			agentId: 'wp-orchestrator',
+		} );
+		const context = config.contextProvider?.getClientContext();
+
+		expect( mockCanConnectToZendesk ).toHaveBeenCalledTimes( 1 );
+		expect( context ).not.toHaveProperty( 'currentPost' );
+		expect( context ).not.toHaveProperty( 'siteName' );
+		expect( context ).not.toHaveProperty( 'siteUrl' );
+	} );
+
+	it( 'adds reader page context for Reader Chat agents', async () => {
+		const currentPost = { id: 1, title: 'Reader post' };
+		setAgentsManagerData( {
+			currentPost,
+			siteName: 'Reader Site',
+			siteUrl: 'https://example.com',
+		} );
+
+		const config = await createAgentConfig( {
+			sessionId: 'session-1',
+			agentId: 'reader-chat',
+		} );
+		const context = config.contextProvider?.getClientContext();
+
+		expect( mockCanConnectToZendesk ).not.toHaveBeenCalled();
+		expect( context ).toEqual( expect.objectContaining( { can_access_zendesk: false } ) );
+		expect( context ).toEqual(
+			expect.objectContaining( {
+				currentPost,
+				siteName: 'Reader Site',
+				siteUrl: 'https://example.com',
+			} )
+		);
+	} );
+} );

--- a/packages/agents-manager/src/utils/__tests__/is-reader-chat-agent.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/is-reader-chat-agent.test.ts
@@ -1,0 +1,83 @@
+import {
+	READER_CHAT_AGENT_IDS,
+	isReaderChatAgent,
+	isReaderChatHost,
+} from '../is-reader-chat-agent';
+
+describe( 'READER_CHAT_AGENT_IDS', () => {
+	it( "includes 'reader-chat'", () => {
+		expect( READER_CHAT_AGENT_IDS ).toContain( 'reader-chat' );
+	} );
+
+	it( "includes 'p2-reader-chat'", () => {
+		expect( READER_CHAT_AGENT_IDS ).toContain( 'p2-reader-chat' );
+	} );
+} );
+
+describe( 'isReaderChatAgent', () => {
+	it( "returns `true` for 'reader-chat'", () => {
+		expect( isReaderChatAgent( 'reader-chat' ) ).toBe( true );
+	} );
+
+	it( "returns `true` for 'p2-reader-chat'", () => {
+		expect( isReaderChatAgent( 'p2-reader-chat' ) ).toBe( true );
+	} );
+
+	it( "returns `false` for 'orchestrator'", () => {
+		expect( isReaderChatAgent( 'orchestrator' ) ).toBe( false );
+	} );
+
+	it( 'returns `false` for `undefined`', () => {
+		expect( isReaderChatAgent( undefined ) ).toBe( false );
+	} );
+
+	it( 'returns `false` for an empty string', () => {
+		expect( isReaderChatAgent( '' ) ).toBe( false );
+	} );
+} );
+
+describe( 'isReaderChatHost', () => {
+	const originalWindow = globalThis.window;
+
+	afterEach( () => {
+		globalThis.window = originalWindow;
+	} );
+
+	it( 'returns `false` when `window` is undefined (SSR)', () => {
+		// @ts-expect-error - Mocking window
+		delete globalThis.window;
+		expect( isReaderChatHost() ).toBe( false );
+	} );
+
+	it( "returns `true` when `window.agentsManagerData.agentId` is 'reader-chat'", () => {
+		globalThis.window = {
+			...originalWindow,
+			agentsManagerData: { agentId: 'reader-chat' },
+		} as unknown as Window & typeof globalThis;
+		expect( isReaderChatHost() ).toBe( true );
+	} );
+
+	it( "returns `true` when `window.agentsManagerData.agentId` is 'p2-reader-chat'", () => {
+		globalThis.window = {
+			...originalWindow,
+			agentsManagerData: { agentId: 'p2-reader-chat' },
+		} as unknown as Window & typeof globalThis;
+		expect( isReaderChatHost() ).toBe( true );
+	} );
+
+	it( "returns `false` when `window.agentsManagerData.agentId` is 'orchestrator'", () => {
+		globalThis.window = {
+			...originalWindow,
+			agentsManagerData: { agentId: 'orchestrator' },
+		} as unknown as Window & typeof globalThis;
+		expect( isReaderChatHost() ).toBe( false );
+	} );
+
+	it( 'returns `false` when `agentsManagerData` is missing', () => {
+		globalThis.window = {
+			...originalWindow,
+			agentsManagerData: undefined,
+		} as unknown as Window & typeof globalThis;
+		expect( isReaderChatHost() ).toBe( false );
+	} );
+} );

--- a/packages/agents-manager/src/utils/__tests__/reader-followup-hook.test.tsx
+++ b/packages/agents-manager/src/utils/__tests__/reader-followup-hook.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook, act } from '@testing-library/react';
+import { useReaderFollowupSuggestions } from '../reader-followup-hook';
+
+// reader-followup-hook imports from @wordpress/element, mock it with the real React
+// hooks so the hook behaviour is actually exercised.
+jest.mock(
+	'@wordpress/element',
+	() => ( {
+		useState: jest.requireActual( 'react' ).useState,
+		useEffect: jest.requireActual( 'react' ).useEffect,
+	} ),
+	{ virtual: true }
+);
+
+type FollowupWindow = Window & {
+	__jetpackReaderFollowupChips?: Array< { id: string; label: string; prompt?: string } >;
+};
+
+describe( 'useReaderFollowupSuggestions', () => {
+	afterEach( () => {
+		// Clean up global state between tests.
+		delete ( window as FollowupWindow ).__jetpackReaderFollowupChips;
+	} );
+
+	it( 'returns an empty suggestions array when the global is not set', () => {
+		delete ( window as FollowupWindow ).__jetpackReaderFollowupChips;
+
+		const { result } = renderHook( () => useReaderFollowupSuggestions() );
+
+		expect( result.current.suggestions ).toEqual( [] );
+	} );
+
+	it( 'returns existing chips on mount when the global is already populated', () => {
+		const chips = [
+			{ id: 'chip-1', label: 'Tell me more', prompt: 'Tell me more about this.' },
+			{ id: 'chip-2', label: 'Related posts', prompt: 'What are related posts?' },
+		];
+		( window as FollowupWindow ).__jetpackReaderFollowupChips = chips;
+
+		const { result } = renderHook( () => useReaderFollowupSuggestions() );
+
+		expect( result.current.suggestions ).toEqual( chips );
+	} );
+
+	it( 'updates state when the `reader-chat-followups-updated` event fires', () => {
+		delete ( window as FollowupWindow ).__jetpackReaderFollowupChips;
+
+		const { result } = renderHook( () => useReaderFollowupSuggestions() );
+
+		expect( result.current.suggestions ).toEqual( [] );
+
+		const newChips = [ { id: 'followup-1', label: 'Go deeper', prompt: 'Expand on this.' } ];
+
+		act( () => {
+			( window as FollowupWindow ).__jetpackReaderFollowupChips = newChips;
+			window.dispatchEvent( new Event( 'reader-chat-followups-updated' ) );
+		} );
+
+		expect( result.current.suggestions ).toEqual( newChips );
+	} );
+
+	it( 'removes the event listener on unmount', () => {
+		const removeListenerSpy = jest.spyOn( window, 'removeEventListener' );
+
+		const { unmount } = renderHook( () => useReaderFollowupSuggestions() );
+
+		unmount();
+
+		expect( removeListenerSpy ).toHaveBeenCalledWith(
+			'reader-chat-followups-updated',
+			expect.any( Function )
+		);
+
+		removeListenerSpy.mockRestore();
+	} );
+
+	it( 'reflects the latest global value each time the event fires', () => {
+		const { result } = renderHook( () => useReaderFollowupSuggestions() );
+
+		const first = [ { id: 'a', label: 'First', prompt: 'First prompt' } ];
+		const second = [ { id: 'b', label: 'Second', prompt: 'Second prompt' } ];
+
+		act( () => {
+			( window as FollowupWindow ).__jetpackReaderFollowupChips = first;
+			window.dispatchEvent( new Event( 'reader-chat-followups-updated' ) );
+		} );
+
+		expect( result.current.suggestions ).toEqual( first );
+
+		act( () => {
+			( window as FollowupWindow ).__jetpackReaderFollowupChips = second;
+			window.dispatchEvent( new Event( 'reader-chat-followups-updated' ) );
+		} );
+
+		expect( result.current.suggestions ).toEqual( second );
+	} );
+} );

--- a/packages/agents-manager/src/utils/agent-session.ts
+++ b/packages/agents-manager/src/utils/agent-session.ts
@@ -64,3 +64,76 @@ export function clearSessionId( agentId?: string ): void {
 		console.error( '[agent-session] Error clearing session ID:', error );
 	}
 }
+
+export const FRESH_SESSION_FLAG_PREFIX = 'agents-manager-session-fresh';
+
+function getFreshFlagKey( agentId?: string ): string {
+	return `${ FRESH_SESSION_FLAG_PREFIX }-${ agentId || 'default' }`;
+}
+
+/**
+ * Check whether the current session is "fresh" — generated client-side and
+ * never yet sent to the server. Callers can use this to skip an initial
+ * server-side conversation fetch (there's nothing to fetch).
+ * The flag clears automatically once a request is made with this session.
+ */
+export function isFreshSession( agentId?: string ): boolean {
+	try {
+		return localStorage.getItem( getFreshFlagKey( agentId ) ) === '1';
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Clear the fresh-session flag. Call after the first message round-trip
+ * completes so subsequent page loads re-enable the server fetch.
+ */
+export function markSessionUsed( agentId?: string ): void {
+	try {
+		localStorage.removeItem( getFreshFlagKey( agentId ) );
+	} catch {
+		// ignore
+	}
+}
+
+/**
+ * Get an existing session ID from localStorage, or create + persist a new
+ * client-side UUID. Use this when the caller wants a stable session ID
+ * across page loads WITHOUT depending on agenttic-client's own write path
+ * (which only fires after the server's first response).
+ *
+ * Pass isNewChat=true to force creation of a fresh session.
+ */
+export function getOrCreateSessionId( isNewChat: boolean, agentId?: string ): string {
+	if ( isNewChat ) {
+		clearSessionId( agentId );
+	}
+	const existing = getSessionId( agentId );
+	if ( existing ) {
+		return existing;
+	}
+	try {
+		const newId =
+			typeof crypto !== 'undefined' && crypto.randomUUID
+				? crypto.randomUUID()
+				: // Fallback for older browsers.
+				  'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace( /[xy]/g, ( c ) => {
+						const r = ( Math.random() * 16 ) | 0;
+						const v = c === 'x' ? r : ( r & 0x3 ) | 0x8;
+						return v.toString( 16 );
+				  } );
+		localStorage.setItem(
+			getSessionStorageKey( agentId ),
+			JSON.stringify( { sessionId: newId, timestamp: Date.now() } )
+		);
+		// Mark as fresh so useConversation can skip its initial server fetch.
+		// Cleared after the first real request round-trip completes.
+		localStorage.setItem( getFreshFlagKey( agentId ), '1' );
+		return newId;
+	} catch ( error ) {
+		// eslint-disable-next-line no-console
+		console.error( '[agent-session] Error creating session ID:', error );
+		return '';
+	}
+}

--- a/packages/agents-manager/src/utils/conversation-bot-id.ts
+++ b/packages/agents-manager/src/utils/conversation-bot-id.ts
@@ -1,0 +1,10 @@
+import { createOdieBotId, isOdieBotId } from '@automattic/agenttic-client';
+import { isReaderChatAgent } from './is-reader-chat-agent';
+
+export function getConversationBotId( agentId: string, hasAgentParam: boolean ): string {
+	if ( hasAgentParam || isOdieBotId( agentId ) || isReaderChatAgent( agentId ) ) {
+		return agentId;
+	}
+
+	return createOdieBotId( agentId );
+}

--- a/packages/agents-manager/src/utils/create-agent-config.ts
+++ b/packages/agents-manager/src/utils/create-agent-config.ts
@@ -10,6 +10,7 @@ import { createCalypsoAuthProvider } from '../auth/calypso-auth-provider';
 import { ORCHESTRATOR_AGENT_ID, ORCHESTRATOR_AGENT_URL } from '../constants';
 import { getSessionStorageKey } from './agent-session';
 import { canConnectToZendesk } from './can-connect-to-zendesk';
+import { isReaderChatAgent } from './is-reader-chat-agent';
 import type { ContextEntry, ToolProvider, ContextProvider } from '../extension-types';
 import type { UseAgentChatConfig, Ability as AgenticAbility } from '@automattic/agenttic-client';
 
@@ -77,15 +78,24 @@ function wrapToolProvider( toolProvider: ToolProvider ): UseAgentChatConfig[ 'to
 	};
 }
 
+async function canAccessZendeskForAgent( agentId?: string ): Promise< boolean > {
+	if ( isReaderChatAgent( agentId ) ) {
+		return false;
+	}
+
+	return canConnectToZendesk();
+}
+
 /**
  * Create a context provider that resolves context entries.
  */
 async function createWrappedContextProvider(
 	contextProvider: ContextProvider,
 	siteId?: number,
+	agentId?: string,
 	version?: string
 ): Promise< UseAgentChatConfig[ 'contextProvider' ] > {
-	const canAccessZendesk = await canConnectToZendesk();
+	const canAccessZendesk = await canAccessZendeskForAgent( agentId );
 	return {
 		getClientContext: () => {
 			const pluginContext = contextProvider.getClientContext();
@@ -120,22 +130,38 @@ async function createDefaultContextProvider(
 	currentRoute: string | undefined,
 	environment: string,
 	siteId?: number,
+	agentId?: string,
 	version?: string
 ): Promise< UseAgentChatConfig[ 'contextProvider' ] > {
-	const canAccessZendesk = await canConnectToZendesk();
+	const canAccessZendesk = await canAccessZendeskForAgent( agentId );
 	return {
-		getClientContext: () => ( {
-			url: window.location.href,
-			pathname: currentRoute || window.location.pathname,
-			search: window.location.search,
-			can_access_zendesk: canAccessZendesk,
-			environment,
-			// Match Odie's context shape so the server can read current_screen.url
-			currentScreen: { url: window.location.href },
-			...( siteId && { selectedSiteId: siteId } ),
-			// TODO: Remove once agenttic-client supports top-level constructorArguments
-			...( version && { constructorArguments: { version } } ),
-		} ),
+		getClientContext: () => {
+			// Hosts that don't have a plugin context (e.g. reader-chat on a
+			// blog frontend) can still surface page metadata by assigning it
+			// to `window.agentsManagerData`. Pick up `currentPost`, `siteName`,
+			// and `siteUrl` here so the orchestrator knows which post the
+			// reader is viewing without every host wiring its own provider.
+			const hostData = isReaderChatAgent( agentId )
+				? ( window as unknown as { agentsManagerData?: Record< string, unknown > } )
+						.agentsManagerData ?? {}
+				: {};
+
+			return {
+				url: window.location.href,
+				pathname: currentRoute || window.location.pathname,
+				search: window.location.search,
+				can_access_zendesk: canAccessZendesk,
+				environment,
+				// Match Odie's context shape so the server can read current_screen.url
+				currentScreen: { url: window.location.href },
+				...( siteId && { selectedSiteId: siteId } ),
+				...( hostData.currentPost ? { currentPost: hostData.currentPost } : {} ),
+				...( hostData.siteName ? { siteName: hostData.siteName } : {} ),
+				...( hostData.siteUrl ? { siteUrl: hostData.siteUrl } : {} ),
+				// TODO: Remove once agenttic-client supports top-level constructorArguments
+				...( version && { constructorArguments: { version } } ),
+			};
+		},
 	};
 }
 
@@ -173,12 +199,18 @@ export async function createAgentConfig(
 	}
 
 	if ( contextProvider ) {
-		config.contextProvider = await createWrappedContextProvider( contextProvider, siteId, version );
+		config.contextProvider = await createWrappedContextProvider(
+			contextProvider,
+			siteId,
+			agentId,
+			version
+		);
 	} else {
 		config.contextProvider = await createDefaultContextProvider(
 			currentRoute,
 			environment,
 			siteId,
+			agentId,
 			version
 		);
 	}

--- a/packages/agents-manager/src/utils/is-reader-chat-agent.ts
+++ b/packages/agents-manager/src/utils/is-reader-chat-agent.ts
@@ -1,0 +1,36 @@
+/**
+ * Reader-chat agent identification helpers.
+ *
+ * Reader-chat runs on public blog frontends (logged-out visitors) under a
+ * constrained set of agent IDs. Several components branch on this context
+ * to hide wp-admin-only affordances (docking, history, etc.). Keeping the
+ * ID list in one place avoids drift if a new reader-chat variant is added.
+ */
+
+export const READER_CHAT_AGENT_IDS = [ 'reader-chat', 'p2-reader-chat' ] as const;
+
+type ReaderChatAgentId = ( typeof READER_CHAT_AGENT_IDS )[ number ];
+
+/**
+ * True if the given agentId is a reader-chat variant.
+ */
+export function isReaderChatAgent( agentId: string | undefined | null ): boolean {
+	return !! agentId && ( READER_CHAT_AGENT_IDS as readonly string[] ).includes( agentId );
+}
+
+/**
+ * True if the current host is running under a reader-chat agent.
+ * Reads from `window.agentsManagerData.agentId` (set by the reader-chat
+ * entry before AgentsManager mounts). Safe in SSR — returns `false` when
+ * `window` is unavailable.
+ */
+export function isReaderChatHost(): boolean {
+	if ( typeof window === 'undefined' ) {
+		return false;
+	}
+	const agentId = ( window as unknown as { agentsManagerData?: { agentId?: string } } )
+		.agentsManagerData?.agentId;
+	return isReaderChatAgent( agentId );
+}
+
+export type { ReaderChatAgentId };

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -12,6 +12,8 @@
  */
 
 import { getAgentManager, UIMessage } from '@automattic/agenttic-client';
+import { isReaderChatAgent } from './is-reader-chat-agent';
+import { useReaderFollowupSuggestions } from './reader-followup-hook';
 import type { ImageUploadHook } from '../hooks/use-image-upload';
 import type { ToolProvider, ContextProvider, Suggestion, BigSkyMessage } from '../types';
 import type { UseAgentChatReturn } from '@automattic/agenttic-client';
@@ -147,8 +149,22 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 	const agentProviders =
 		typeof agentsManagerData !== 'undefined' ? agentsManagerData?.agentProviders || [] : [];
 
+	// Only the public reader-chat entry registers the follow-up chip globals
+	// (`window.__jetpackReaderFollowupChips` / `reader-chat-followups-updated`).
+	// Register the bridge for every reader-chat agent variant that uses the
+	// public reader-chat entry.
+	const registerReaderFollowups =
+		typeof window !== 'undefined' &&
+		isReaderChatAgent(
+			( window as unknown as { agentsManagerData?: { agentId?: string } } ).agentsManagerData
+				?.agentId
+		);
+
 	if ( agentProviders.length === 0 ) {
-		return {};
+		// Even with no external agentProviders, register the reader-chat
+		// follow-up hook if this host is reader-chat. Previously this path
+		// early-returned an empty object, so the hook never registered.
+		return registerReaderFollowups ? { useSuggestions: useReaderFollowupSuggestions } : {};
 	}
 
 	let mergedToolProvider: ToolProvider | undefined;
@@ -170,6 +186,12 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 	const allAbilitiesSetups: AbilitiesSetupHook[] = [];
 	const allUseSuggestions: UseSuggestionsHook[] = [];
 	const allGetEmptyViewSuggestions: ( () => Suggestion[] )[] = [];
+
+	// Also add reader-chat hook to the merge path when there ARE other
+	// providers.
+	if ( registerReaderFollowups ) {
+		allUseSuggestions.push( useReaderFollowupSuggestions );
+	}
 
 	// Load all providers in parallel to avoid serializing network/module fetches.
 	// Results are processed in registration order to preserve first-write-wins semantics.

--- a/packages/agents-manager/src/utils/reader-followup-hook.ts
+++ b/packages/agents-manager/src/utils/reader-followup-hook.ts
@@ -1,0 +1,42 @@
+// global.d.ts declares ambient globals (e.g. agentsManagerData) that are injected server-side.
+// Ambient declaration files cannot be `import`ed; a triple-slash reference is required to ensure
+// the global is visible when TypeScript resolves this file via the import graph rather than the
+// tsconfig include list (e.g. during sandbox / CI builds).
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference path="../global.d.ts" />
+/**
+ * Reader-chat follow-up suggestions bridge.
+ *
+ * `reader-chat.js` (the frontend entry) sets `window.__jetpackReaderFollowupChips`
+ * and dispatches `reader-chat-followups-updated` after each agent reply. This
+ * hook reads both using the AgentsManager package's own React instance —
+ * critical, because cross-bundle React hooks don't share state — so the
+ * suggestion strip re-renders when chips arrive.
+ */
+
+import { useState, useEffect } from '@wordpress/element';
+import type { Suggestion } from '../types';
+import type { UseSuggestionsHook } from './load-external-providers';
+
+type FollowupWindow = Window & { __jetpackReaderFollowupChips?: Suggestion[] };
+
+function readChips(): Suggestion[] {
+	if ( typeof window === 'undefined' ) {
+		return [];
+	}
+	const chips = ( window as FollowupWindow ).__jetpackReaderFollowupChips;
+	return Array.isArray( chips ) ? chips : [];
+}
+
+export const useReaderFollowupSuggestions: UseSuggestionsHook = () => {
+	const [ chips, setChips ] = useState< Suggestion[] >( readChips );
+	useEffect( () => {
+		if ( typeof window === 'undefined' ) {
+			return;
+		}
+		const handler = () => setChips( readChips() );
+		window.addEventListener( 'reader-chat-followups-updated', handler );
+		return () => window.removeEventListener( 'reader-chat-followups-updated', handler );
+	}, [] );
+	return { suggestions: chips };
+};


### PR DESCRIPTION
Split from #110024. The original PR ~~stays open for comparison~~ is closed.

## Summary
- Adds Reader Chat host handling inside Agents Manager while keeping existing Agents Manager behavior gated off the normal agent IDs.
- Prevents Unified/Zendesk/support/history UI from leaking into Reader Chat.
- Uses Reader Chat session IDs directly instead of Odie bot IDs, skips wasted Zendesk probes, and avoids loading fresh reader sessions while a live answer is in flight.
- Adds focused coverage for Reader Chat agent detection, session helpers, bot ID selection, follow-up hooks, and dock behavior.

## Steps to test
1. Checkout wpcom 212890 PR on your sandbox
2. Install this PR on your sandbox `install-plugin.sh am add/agents-manager-reader-chat-support`
3. Enable [Unified Chat](https://dashboard.wordpress.com/wp-admin/profile.php) 

## Test Plan

### Existing Agents Manager behavior
- Navigate to AI Editor
- Confirm the chat opens and closes.
- Send a normal message and confirm the response streams.
- Confirm the history button is still visible and opens conversation history.
- Confirm the overflow menu still shows the existing non-Reader Chat entries where expected, including Zendesk/support/docking options for eligible contexts.
- Confirm Unified Chat/Odie behavior still works for non-Reader Chat agents.
- Confirm there are no new console errors.

### Focused automated tests
- `yarn jest packages/agents-manager/src/utils/__tests__/agent-session.test.ts packages/agents-manager/src/utils/__tests__/conversation-bot-id.test.ts packages/agents-manager/src/utils/__tests__/create-agent-config.test.ts packages/agents-manager/src/utils/__tests__/is-reader-chat-agent.test.ts packages/agents-manager/src/utils/__tests__/reader-followup-hook.test.tsx packages/agents-manager/src/hooks/__tests__/use-agent-config.test.ts packages/agents-manager/src/hooks/__tests__/use-setup-custom-actions.test.ts packages/agents-manager/src/components/__tests__/agent-dock.test.tsx --runInBand`

Reader Chat E2E is covered by the stacked public bundle PR (#110226).