### PR TITLE
[RSM] Reader Chat: add public frontend bundle

### DIFF
--- a/apps/agents-manager/__tests__/reader-chat.test.js
+++ b/apps/agents-manager/__tests__/reader-chat.test.js
@@ -289,7 +289,7 @@ describe( 'normalizeSuggestions', () => {
 		).toEqual( [
 			{
 				id: 'ai-0-can-you-summarize-this-post',
-				label: 'Explore this blog',
+				label: 'Explore recent posts',
 				prompt: 'Can you summarize this post?',
 			},
 		] );
@@ -310,7 +310,7 @@ describe( 'normalizeSuggestions', () => {
 		).toEqual( [
 			{
 				id: 'ai-0-what-does-this-post-say-about-spontaneou',
-				label: 'Explore this blog',
+				label: 'Explore recent posts',
 				prompt: 'What does this post say about spontaneous travel?',
 			},
 		] );
@@ -363,7 +363,7 @@ describe( 'getFallbackSuggestions', () => {
 		// (no currentPost), so getFallbackSuggestions returns the no-post branch.
 		const suggestions = getFallbackSuggestions();
 		expect( suggestions ).toHaveLength( 3 );
-		expect( suggestions.map( ( s ) => s.id ) ).toEqual( [ 'popular', 'about', 'recommend' ] );
+		expect( suggestions.map( ( s ) => s.id ) ).toEqual( [ 'recent', 'about', 'recommend' ] );
 	} );
 
 	it( 'each generic suggestion has `id`, `label`, and `prompt` strings', () => {

--- a/apps/agents-manager/__tests__/reader-chat.test.js
+++ b/apps/agents-manager/__tests__/reader-chat.test.js
@@ -254,6 +254,26 @@ describe( 'normalizeSuggestions', () => {
 		] );
 	} );
 
+	it( 'keeps concise question labels so post-specific chips can be shown', () => {
+		expect(
+			normalizeSuggestions(
+				[
+					{
+						label: 'Why refuse tips?',
+						prompt: 'Why does the fisherman refuse tips in this post?',
+					},
+				],
+				'ai-suggestion'
+			)
+		).toEqual( [
+			{
+				id: 'ai-suggestion-0-why-does-the-fisherman-refuse-tips-in-th',
+				label: 'Why refuse tips?',
+				prompt: 'Why does the fisherman refuse tips in this post?',
+			},
+		] );
+	} );
+
 	it( 'falls back to a short chip label when the returned label is empty', () => {
 		expect(
 			normalizeSuggestions( [ { label: ' ', prompt: 'Can you summarize this post?' } ], 'ai' )
@@ -266,7 +286,7 @@ describe( 'normalizeSuggestions', () => {
 		] );
 	} );
 
-	it( 'replaces long question labels with short fallback labels', () => {
+	it( 'replaces overly long labels with short fallback labels', () => {
 		expect(
 			normalizeSuggestions(
 				[

--- a/apps/agents-manager/__tests__/reader-chat.test.js
+++ b/apps/agents-manager/__tests__/reader-chat.test.js
@@ -52,6 +52,11 @@ const {
 	slugify,
 	getFallbackSuggestions,
 	isCollapsedLauncherTarget,
+	normalizeReaderSiteId,
+	decodeHtmlEntities,
+	getReaderEmptyViewHeading,
+	normalizeSuggestions,
+	parseSuggestionsResponse,
 } = require( '../reader-chat' );
 
 // ---------------------------------------------------------------------------
@@ -159,6 +164,131 @@ describe( 'slugify', () => {
 } );
 
 // ---------------------------------------------------------------------------
+// normalizeReaderSiteId
+// ---------------------------------------------------------------------------
+
+describe( 'normalizeReaderSiteId', () => {
+	it( 'accepts numeric site IDs', () => {
+		expect( normalizeReaderSiteId( 247750866 ) ).toBe( 247750866 );
+	} );
+
+	it( 'coerces localized string site IDs to numbers', () => {
+		expect( normalizeReaderSiteId( '247750866' ) ).toBe( 247750866 );
+	} );
+
+	it( 'rejects missing or invalid site IDs', () => {
+		expect( normalizeReaderSiteId( undefined ) ).toBeUndefined();
+		expect( normalizeReaderSiteId( 'site-id' ) ).toBeUndefined();
+		expect( normalizeReaderSiteId( 0 ) ).toBeUndefined();
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// decodeHtmlEntities
+// ---------------------------------------------------------------------------
+
+describe( 'decodeHtmlEntities', () => {
+	it( 'decodes encoded punctuation and non-breaking spaces from post titles', () => {
+		expect( decodeHtmlEntities( 'The Fisherman Who Won&#8217;t Take&nbsp;Tips' ) ).toBe(
+			'The Fisherman Who Won’t Take Tips'
+		);
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// getReaderEmptyViewHeading
+// ---------------------------------------------------------------------------
+
+describe( 'getReaderEmptyViewHeading', () => {
+	it( 'uses post-specific copy on singular posts', () => {
+		expect( getReaderEmptyViewHeading( { currentPost: { id: 1 } } ) ).toBe(
+			'Ask me anything about this post.'
+		);
+	} );
+
+	it( 'uses blog copy when no post is selected', () => {
+		expect( getReaderEmptyViewHeading( {} ) ).toBe( 'Ask me anything about this blog.' );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// parseSuggestionsResponse
+// ---------------------------------------------------------------------------
+
+describe( 'parseSuggestionsResponse', () => {
+	it( 'parses JSON arrays from plain text', () => {
+		expect( parseSuggestionsResponse( '[{"label":"A","prompt":"B"}]' ) ).toEqual( [
+			{ label: 'A', prompt: 'B' },
+		] );
+	} );
+
+	it( 'parses JSON arrays from fenced code blocks', () => {
+		expect( parseSuggestionsResponse( '```json\n[{"label":"A","prompt":"B"}]\n```' ) ).toEqual( [
+			{ label: 'A', prompt: 'B' },
+		] );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// normalizeSuggestions
+// ---------------------------------------------------------------------------
+
+describe( 'normalizeSuggestions', () => {
+	it( 'keeps a concise label separate from the submitted prompt', () => {
+		expect(
+			normalizeSuggestions(
+				[
+					{
+						label: 'Trip planning',
+						prompt: 'What criteria do you use to select the places you visit?',
+					},
+				],
+				'ai-suggestion'
+			)
+		).toEqual( [
+			{
+				id: 'ai-suggestion-0-what-criteria-do-you-use-to-select-the-p',
+				label: 'Trip planning',
+				prompt: 'What criteria do you use to select the places you visit?',
+			},
+		] );
+	} );
+
+	it( 'falls back to a short chip label when the returned label is empty', () => {
+		expect(
+			normalizeSuggestions( [ { label: ' ', prompt: 'Can you summarize this post?' } ], 'ai' )
+		).toEqual( [
+			{
+				id: 'ai-0-can-you-summarize-this-post',
+				label: 'Explore this blog',
+				prompt: 'Can you summarize this post?',
+			},
+		] );
+	} );
+
+	it( 'replaces long question labels with short fallback labels', () => {
+		expect(
+			normalizeSuggestions(
+				[
+					{
+						label:
+							'What led you to embrace a more spontaneous and less structured style of travel?',
+						prompt: 'What does this post say about spontaneous travel?',
+					},
+				],
+				'ai'
+			)
+		).toEqual( [
+			{
+				id: 'ai-0-what-does-this-post-say-about-spontaneou',
+				label: 'Explore this blog',
+				prompt: 'What does this post say about spontaneous travel?',
+			},
+		] );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
 // isCollapsedLauncherTarget
 // ---------------------------------------------------------------------------
 
@@ -213,6 +343,7 @@ describe( 'getFallbackSuggestions', () => {
 			expect( typeof s.id ).toBe( 'string' );
 			expect( typeof s.label ).toBe( 'string' );
 			expect( typeof s.prompt ).toBe( 'string' );
+			expect( s.label.length ).toBeLessThan( s.prompt.length );
 		}
 	} );
 } );

--- a/apps/agents-manager/__tests__/reader-chat.test.js
+++ b/apps/agents-manager/__tests__/reader-chat.test.js
@@ -55,6 +55,7 @@ const {
 	normalizeReaderSiteId,
 	decodeHtmlEntities,
 	getReaderEmptyViewHeading,
+	getReaderClientContext,
 	normalizeSuggestions,
 	parseSuggestionsResponse,
 } = require( '../reader-chat' );
@@ -217,6 +218,31 @@ describe( 'getReaderEmptyViewHeading', () => {
 				currentPost: { id: 1, title: 'Home', url: 'https://example.com/' },
 			} )
 		).toBe( 'Ask me anything about this blog.' );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// getReaderClientContext
+// ---------------------------------------------------------------------------
+
+describe( 'getReaderClientContext', () => {
+	it( 'sends selected site and current post context for server-side resolution', () => {
+		const currentPost = {
+			id: 123,
+			title: 'Reader post',
+			url: 'https://example.com/reader-post/',
+		};
+
+		expect( getReaderClientContext( currentPost, 247750866 ) ).toEqual( {
+			selectedSiteId: 247750866,
+			currentPost,
+		} );
+	} );
+
+	it( 'omits currentPost on blog-level views', () => {
+		expect( getReaderClientContext( null, 247750866 ) ).toEqual( {
+			selectedSiteId: 247750866,
+		} );
 	} );
 } );
 

--- a/apps/agents-manager/__tests__/reader-chat.test.js
+++ b/apps/agents-manager/__tests__/reader-chat.test.js
@@ -1,0 +1,218 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests for the pure helper functions exported from reader-chat.js.
+ *
+ * The file is an entry point with heavy side-effecting top-level code
+ * (DOM mounting, global mutation). We mock all heavy imports and the
+ * DOM entry point so only the three pure helpers are exercised.
+ */
+
+// Mock the side-effecting imports before any module load.
+jest.mock( '../config', () => {}, { virtual: true } );
+jest.mock( '@automattic/agents-manager', () => ( { default: () => null } ), { virtual: true } );
+jest.mock(
+	'@tanstack/react-query',
+	() => ( {
+		QueryClient: jest.fn( () => ( {} ) ),
+		QueryClientProvider: ( { children } ) => children,
+	} ),
+	{ virtual: true }
+);
+jest.mock(
+	'@wordpress/element',
+	() => {
+		const element = jest.requireActual( '@wordpress/element' );
+		return {
+			...element,
+			useState: jest.requireActual( 'react' ).useState,
+			useEffect: jest.requireActual( 'react' ).useEffect,
+		};
+	},
+	{ virtual: true }
+);
+jest.mock(
+	'react-dom/client',
+	() => ( { createRoot: jest.fn( () => ( { render: jest.fn() } ) ) } ),
+	{ virtual: true }
+);
+
+// Provide a minimal JetpackReaderChatConfig so the module-level readerConfig
+// is safe to read (no currentPost by default — exercises the no-post branch).
+beforeAll( () => {
+	globalThis.window.JetpackReaderChatConfig = {};
+	// Suppress the top-level DOM mount — the container lookup returns null so
+	// the `if ( container )` branch is skipped entirely.
+	jest.spyOn( document, 'getElementById' ).mockReturnValue( null );
+} );
+
+// Import after mocks are registered.
+const {
+	parseAgentSseResponse,
+	slugify,
+	getFallbackSuggestions,
+	isCollapsedLauncherTarget,
+} = require( '../reader-chat' );
+
+// ---------------------------------------------------------------------------
+// parseAgentSseResponse
+// ---------------------------------------------------------------------------
+
+describe( 'parseAgentSseResponse', () => {
+	function makeEvent( text ) {
+		const payload = {
+			jsonrpc: '2.0',
+			result: {
+				status: {
+					message: {
+						parts: [ { type: 'text', text } ],
+					},
+				},
+			},
+		};
+		return `data: ${ JSON.stringify( payload ) }\n`;
+	}
+
+	it( 'extracts text from a valid JSON-RPC SSE event', () => {
+		const raw = makeEvent( 'Hello, reader!' );
+		expect( parseAgentSseResponse( raw ) ).toBe( 'Hello, reader!' );
+	} );
+
+	it( 'returns `null` for malformed JSON in the data line', () => {
+		expect( parseAgentSseResponse( 'data: not-valid-json\n' ) ).toBeNull();
+	} );
+
+	it( 'skips non-data lines and still finds the text part', () => {
+		const raw = `event: message\nid: 1\n${ makeEvent( 'Found it' ) }`;
+		expect( parseAgentSseResponse( raw ) ).toBe( 'Found it' );
+	} );
+
+	it( 'returns `null` when input has no data lines', () => {
+		expect( parseAgentSseResponse( 'event: ping\n' ) ).toBeNull();
+	} );
+
+	it( "skips the '[DONE]' sentinel line and falls through to null", () => {
+		expect( parseAgentSseResponse( 'data: [DONE]\n' ) ).toBeNull();
+	} );
+
+	it( 'returns text from the first matching data line when multiple are present', () => {
+		const raw = `${ makeEvent( 'First' ) }${ makeEvent( 'Second' ) }`;
+		expect( parseAgentSseResponse( raw ) ).toBe( 'First' );
+	} );
+
+	it( 'returns `null` when `parts` array is empty', () => {
+		const payload = { result: { status: { message: { parts: [] } } } };
+		expect( parseAgentSseResponse( `data: ${ JSON.stringify( payload ) }\n` ) ).toBeNull();
+	} );
+
+	it( 'returns `null` when `parts` contains only non-text entries', () => {
+		const payload = {
+			result: { status: { message: { parts: [ { type: 'data', data: {} } ] } } },
+		};
+		expect( parseAgentSseResponse( `data: ${ JSON.stringify( payload ) }\n` ) ).toBeNull();
+	} );
+
+	it( 'handles CRLF line endings', () => {
+		const raw = makeEvent( 'CRLF text' ).replace( /\n/g, '\r\n' );
+		expect( parseAgentSseResponse( raw ) ).toBe( 'CRLF text' );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// slugify
+// ---------------------------------------------------------------------------
+
+describe( 'slugify', () => {
+	it( 'lowercases the label', () => {
+		expect( slugify( 'Hello World' ) ).toBe( 'hello-world' );
+	} );
+
+	it( 'replaces spaces with dashes', () => {
+		expect( slugify( 'foo bar baz' ) ).toBe( 'foo-bar-baz' );
+	} );
+
+	it( 'strips non-alphanumeric characters', () => {
+		expect( slugify( 'What is this?!' ) ).toBe( 'what-is-this' );
+	} );
+
+	it( 'collapses multiple non-alphanumeric chars into a single dash', () => {
+		expect( slugify( 'hello---world' ) ).toBe( 'hello-world' );
+	} );
+
+	it( 'strips leading and trailing dashes', () => {
+		expect( slugify( '  trim me  ' ) ).toBe( 'trim-me' );
+	} );
+
+	it( 'truncates to 40 characters', () => {
+		const label = 'a'.repeat( 50 );
+		expect( slugify( label ) ).toHaveLength( 40 );
+	} );
+
+	it( 'handles an empty string', () => {
+		expect( slugify( '' ) ).toBe( '' );
+	} );
+
+	it( 'handles null / undefined gracefully', () => {
+		expect( slugify( null ) ).toBe( '' );
+		expect( slugify( undefined ) ).toBe( '' );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// isCollapsedLauncherTarget
+// ---------------------------------------------------------------------------
+
+describe( 'isCollapsedLauncherTarget', () => {
+	it( 'matches clicks inside the collapsed launcher', () => {
+		const container = document.createElement( 'div' );
+		const collapsedView = document.createElement( 'div' );
+		const button = document.createElement( 'button' );
+
+		collapsedView.dataset.slot = 'collapsed-view';
+		collapsedView.appendChild( button );
+		container.appendChild( collapsedView );
+
+		expect( isCollapsedLauncherTarget( button, container ) ).toBe( true );
+	} );
+
+	it( 'does not match targets outside the reader-chat container', () => {
+		const container = document.createElement( 'div' );
+		const collapsedView = document.createElement( 'div' );
+		const button = document.createElement( 'button' );
+
+		collapsedView.dataset.slot = 'collapsed-view';
+		collapsedView.appendChild( button );
+
+		expect( isCollapsedLauncherTarget( button, container ) ).toBe( false );
+	} );
+
+	it( 'does not match non-element targets', () => {
+		const container = document.createElement( 'div' );
+		const textNode = document.createTextNode( 'Open chat' );
+
+		expect( isCollapsedLauncherTarget( textNode, container ) ).toBe( false );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// getFallbackSuggestions
+// ---------------------------------------------------------------------------
+
+describe( 'getFallbackSuggestions', () => {
+	it( 'returns 3 generic suggestions when no currentPost is set', () => {
+		// readerConfig is captured at module-load time with JetpackReaderChatConfig = {}
+		// (no currentPost), so getFallbackSuggestions returns the no-post branch.
+		const suggestions = getFallbackSuggestions();
+		expect( suggestions ).toHaveLength( 3 );
+		expect( suggestions.map( ( s ) => s.id ) ).toEqual( [ 'popular', 'about', 'recommend' ] );
+	} );
+
+	it( 'each generic suggestion has `id`, `label`, and `prompt` strings', () => {
+		const suggestions = getFallbackSuggestions();
+		for ( const s of suggestions ) {
+			expect( typeof s.id ).toBe( 'string' );
+			expect( typeof s.label ).toBe( 'string' );
+			expect( typeof s.prompt ).toBe( 'string' );
+		}
+	} );
+} );

--- a/apps/agents-manager/__tests__/reader-chat.test.js
+++ b/apps/agents-manager/__tests__/reader-chat.test.js
@@ -209,6 +209,15 @@ describe( 'getReaderEmptyViewHeading', () => {
 	it( 'uses blog copy when no post is selected', () => {
 		expect( getReaderEmptyViewHeading( {} ) ).toBe( 'Ask me anything about this blog.' );
 	} );
+
+	it( 'uses blog copy when the current post is the static front page', () => {
+		expect(
+			getReaderEmptyViewHeading( {
+				siteUrl: 'https://example.com/',
+				currentPost: { id: 1, title: 'Home', url: 'https://example.com/' },
+			} )
+		).toBe( 'Ask me anything about this blog.' );
+	} );
 } );
 
 // ---------------------------------------------------------------------------

--- a/apps/agents-manager/jest.config.js
+++ b/apps/agents-manager/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	preset: '../../test/packages/jest-preset.js',
+	testEnvironment: 'jsdom',
+	testMatch: [ '<rootDir>/**/__tests__/*.[jt]s?(x)', '!**/.eslintrc.*' ],
+	moduleFileExtensions: [ 'js', 'jsx', 'ts', 'tsx', 'json' ],
+};

--- a/apps/agents-manager/reader-chat-route-stub.js
+++ b/apps/agents-manager/reader-chat-route-stub.js
@@ -1,0 +1,3 @@
+export default function ReaderChatRouteStub() {
+	return null;
+}

--- a/apps/agents-manager/reader-chat.js
+++ b/apps/agents-manager/reader-chat.js
@@ -1,0 +1,823 @@
+/**
+ * Reader Chat Entry Point
+ *
+ * Loads the Agents Manager chat UI for blog readers (logged-out visitors).
+ * Reads config from window.JetpackReaderChatConfig, mounts to #jetpack-reader-chat.
+ *
+ * IMPORTANT: This bundle is built without DependencyExtractionWebpackPlugin so
+ * React, @wordpress/data, and all other WP packages are bundled inline. This
+ * makes it safe to load on the frontend where WordPress's script loader is absent.
+ */
+
+import './config';
+import AgentsManager, { AGENTS_MANAGER_STORE } from '@automattic/agents-manager';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { dispatch, select, subscribe } from '@wordpress/data';
+import { useState, useEffect } from '@wordpress/element';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Push a Tracks event onto the global _tkq queue.
+ *
+ * Equivalent to @automattic/calypso-analytics' recordTracksEvent but
+ * without the 23MB of transitive deps (getCurrentUser, super-props,
+ * tracking prefs, event-name validation, etc.) that would bloat this
+ * public-facing blog bundle. The queue is drained by stats.js / the
+ * Tracks library if/when it loads on the page — and on blogs where
+ * it doesn't load, events simply stay queued with no ill effect.
+ *
+ * @param {string} eventName Must start with an allowed source prefix
+ *                           (e.g. 'jetpack_...') to be accepted by Tracks.
+ * @param {Object} [props]   Flat property bag. Nested objects are not
+ *                           supported by Tracks — keep values scalar.
+ */
+function recordTracksEvent( eventName, props ) {
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+	window._tkq = window._tkq || [];
+	window._tkq.push( [ 'recordEvent', eventName, props || {} ] );
+}
+
+const queryClient = new QueryClient();
+
+/**
+ * Reset inherited styles from the host theme. Blog themes often set a
+ * serif body font that cascades into the chat UI and makes it look
+ * foreign. Scoping font-family and line-height to the mount node
+ * restores the AgentsManager's intended look without affecting the
+ * rest of the page.
+ */
+function injectScopedReset() {
+	if ( document.getElementById( 'jetpack-reader-chat-reset' ) ) {
+		return;
+	}
+	const style = document.createElement( 'style' );
+	style.id = 'jetpack-reader-chat-reset';
+	style.textContent = `
+		#jetpack-reader-chat,
+		#jetpack-reader-chat *,
+		.agents-manager-chat,
+		.agents-manager-chat *,
+		.components-popover,
+		.components-popover * {
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", Arial, sans-serif !important;
+		}
+		/*
+		 * Form controls don't inherit font-family by default — browsers
+		 * apply UA styles. The * selector above is unreliable across
+		 * browsers for input/textarea/button, so target them explicitly
+		 * to match the display text.
+		 */
+		#jetpack-reader-chat input,
+		#jetpack-reader-chat textarea,
+		#jetpack-reader-chat button,
+		.agents-manager-chat input,
+		.agents-manager-chat textarea,
+		.agents-manager-chat button {
+			font-family: inherit !important;
+			font-size: inherit !important;
+		}
+		/*
+		 * Themes often give inputs/textareas thick borders that leak
+		 * into the chat composer. Reset them to let the AgentsManager's
+		 * own focus ring show through.
+		 */
+		#jetpack-reader-chat input,
+		#jetpack-reader-chat textarea,
+		.agents-manager-chat input,
+		.agents-manager-chat textarea {
+			border: 0 !important;
+			outline: 0 !important;
+			box-shadow: none !important;
+			background: transparent !important;
+		}
+		#jetpack-reader-chat,
+		.agents-manager-chat {
+			line-height: 1.5 !important;
+			color: #1e1e1e !important;
+		}
+		/*
+		 * wp-components dropdown/menu fix: the popover is portalled to body
+		 * and the theme's global CSS doesn't always include the full
+		 * components-dropdown-menu rules. Items default to display: inline-block
+		 * via .components-button and end up flowing horizontally. Force them
+		 * block and give the menu a usable layout.
+		 */
+		/*
+		 * Popover itself has z-index: auto by default — sits behind the
+		 * chat container's stacking context. Force it above everything
+		 * so the menu is actually visible when opened.
+		 */
+		.components-popover {
+			z-index: 2147483647 !important;
+		}
+		.components-dropdown-menu__menu {
+			display: flex !important;
+			flex-direction: column !important;
+			min-width: 200px !important;
+			padding: 4px !important;
+			background: #ffffff !important;
+			border: 1px solid #dddddd !important;
+			border-radius: 4px !important;
+			box-shadow: 0 2px 10px rgba(0,0,0,0.1) !important;
+		}
+		.components-dropdown-menu__menu-item {
+			display: flex !important;
+			align-items: center !important;
+			gap: 8px !important;
+			width: 100% !important;
+			padding: 8px 12px !important;
+			background: transparent !important;
+			border: 0 !important;
+			text-align: left !important;
+			cursor: pointer !important;
+		}
+		.components-dropdown-menu__menu-item:hover {
+			background: #f0f0f0 !important;
+		}
+		.components-dropdown-menu__menu-item[aria-disabled="true"] {
+			opacity: 0.5 !important;
+			cursor: default !important;
+		}
+		/*
+		 * Move reader-chat launcher and panel to the bottom-left.
+		 * Default agents-manager positioning is bottom-right (see
+		 * packages/agents-manager/src/components/agent-dock/style.scss).
+		 * Reader-chat is opt-in per-blog so the FAB sits in the reader's
+		 * lower-left to avoid clashing with the host theme's floating
+		 * widgets (share buttons, cookie banners) that almost always
+		 * anchor to the bottom-right.
+		 */
+		.agents-manager-sidebar-fab {
+			left: 16px !important;
+			right: auto !important;
+		}
+
+	`;
+	document.head.appendChild( style );
+}
+
+// Read config injected by PHP.
+const readerConfig = window.JetpackReaderChatConfig || {};
+const readerAgentId = readerConfig.agentId || 'reader-chat';
+
+// Set agentId for useAgentConfig() to pick up via agentsManagerData global.
+window.agentsManagerData = window.agentsManagerData || {};
+window.agentsManagerData.agentId = readerAgentId;
+
+// Expose page context on the global so the default context provider
+// and agent hooks can read it. The AgentsManager default context
+// provider sends window.location info; we augment with post-level data.
+window.agentsManagerData.currentPost = readerConfig.currentPost || null;
+window.agentsManagerData.siteName = readerConfig.siteName || '';
+window.agentsManagerData.siteUrl = readerConfig.siteUrl || '';
+
+/**
+ * Build fallback suggested prompts based on the current page context.
+ * These appear immediately while AI-generated suggestions fetch, and
+ * stay if the AI call fails.
+ */
+function getFallbackSuggestions() {
+	const post = readerConfig.currentPost;
+
+	if ( ! post ) {
+		return [
+			{
+				id: 'popular',
+				label: 'What are the most popular posts here?',
+				prompt: 'What are the most popular posts on this blog?',
+			},
+			{
+				id: 'about',
+				label: 'What is this blog about?',
+				prompt: 'What is this blog about? What topics does it cover?',
+			},
+			{
+				id: 'recommend',
+				label: 'Recommend something to read',
+				prompt: 'Can you recommend a good post to read on this blog?',
+			},
+		];
+	}
+
+	const title = post.title || 'this post';
+
+	return [
+		{
+			id: 'summarize',
+			label: 'Summarize this post',
+			prompt: `Can you summarize "${ title }" for me?`,
+		},
+		{
+			id: 'explain',
+			label: 'Explain something from this post',
+			prompt: `Can you explain the main points of "${ title }" in simple terms?`,
+		},
+		{
+			id: 'related',
+			label: 'Find related posts',
+			prompt: `What other posts on this blog are related to "${ title }"?`,
+		},
+	];
+}
+
+const SUGGESTIONS_ENDPOINT =
+	'https://public-api.wordpress.com/wpcom/v2/ai/agent/reader-chat-suggestions';
+const SUGGESTIONS_TIMEOUT_MS = 15000;
+const FOLLOWUP_DEBOUNCE_MS = 2500;
+const MIN_FOLLOWUP_AGENT_TEXT_LENGTH = 40;
+
+function createAbortController() {
+	return typeof window.AbortController === 'function' ? new window.AbortController() : null;
+}
+
+function slugify( label ) {
+	return String( label || '' )
+		.toLowerCase()
+		.replace( /[^a-z0-9]+/g, '-' )
+		.replace( /^-|-$/g, '' )
+		.slice( 0, 40 );
+}
+
+/**
+ * Extract the assistant text from a JSON-RPC SSE response like:
+ *   data: {"jsonrpc":"2.0","result":{"status":{"message":{"parts":[{"type":"text","text":"..."}]}}}}
+ *
+ * Returns the first "text" part content, or null if not found.
+ */
+function parseAgentSseResponse( raw ) {
+	for ( const line of raw.split( /\r?\n/ ) ) {
+		const trimmed = line.trim();
+		if ( ! trimmed.startsWith( 'data:' ) ) {
+			continue;
+		}
+		const json = trimmed.slice( 'data:'.length ).trim();
+		if ( ! json || json === '[DONE]' ) {
+			continue;
+		}
+		try {
+			const payload = JSON.parse( json );
+			const parts = payload?.result?.status?.message?.parts;
+			if ( Array.isArray( parts ) ) {
+				const textPart = parts.find( ( p ) => p?.type === 'text' && typeof p.text === 'string' );
+				if ( textPart ) {
+					return textPart.text;
+				}
+			}
+		} catch {
+			// skip malformed events
+		}
+	}
+	return null;
+}
+
+/**
+ * Call the reader-chat-suggestions agent with an arbitrary user message and
+ * return a list of {id,label,prompt} suggestions, or null on failure.
+ *
+ * Both the initial contextual chips and the post-turn follow-ups use this
+ * path — the only differences are the prompt text, the JSON-RPC request-id
+ * prefix, and the fallback id prefix applied to normalized results.
+ * @param   {Object} params                 Parameters.
+ * @param   {string} params.messageText     Prose message to send to the agent.
+ * @param   {string} params.requestIdPrefix JSON-RPC request id prefix (debugging aid).
+ * @param   {string} params.resultIdPrefix  Prefix used when synthesizing missing ids on returned items.
+ * @param   {AbortSignal} [params.signal]   Optional signal for cancelling stale requests.
+ * @returns {Promise<Array|null>}           Normalized suggestions, or null on failure.
+ */
+async function fetchSuggestions( { messageText, requestIdPrefix, resultIdPrefix, signal } ) {
+	const body = {
+		jsonrpc: '2.0',
+		id: `${ requestIdPrefix }-${ Date.now() }`,
+		method: 'message/stream',
+		params: {
+			message: {
+				role: 'user',
+				parts: [
+					{ type: 'text', text: messageText },
+					{
+						type: 'data',
+						data: {
+							clientContext: {
+								post_url: readerConfig.currentPost?.url || '',
+								selectedSiteId: readerConfig.siteId,
+							},
+						},
+					},
+				],
+				kind: 'message',
+				messageId: `msg-${ Date.now() }`,
+			},
+		},
+		tokenStreaming: false,
+	};
+
+	if ( signal?.aborted ) {
+		return null;
+	}
+
+	const controller = createAbortController();
+	const timeoutId = controller
+		? setTimeout( () => controller.abort(), SUGGESTIONS_TIMEOUT_MS )
+		: null;
+	const abortRequest = () => controller?.abort();
+	signal?.addEventListener( 'abort', abortRequest, { once: true } );
+
+	try {
+		const fetchOptions = {
+			method: 'POST',
+			credentials: 'omit',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify( body ),
+		};
+		if ( controller ) {
+			fetchOptions.signal = controller.signal;
+		}
+		const response = await fetch( SUGGESTIONS_ENDPOINT, fetchOptions );
+		if ( ! response.ok ) {
+			return null;
+		}
+		// SSE response wraps a JSON-RPC result; we read the whole thing and
+		// pull out the assistant message text from the first completed event.
+		const text = parseAgentSseResponse( await response.text() );
+		if ( ! text ) {
+			return null;
+		}
+
+		const parsed = JSON.parse( text );
+		const items = Array.isArray( parsed ) ? parsed : [];
+		const valid = items.filter(
+			( s ) => s && typeof s.label === 'string' && typeof s.prompt === 'string'
+		);
+		if ( valid.length === 0 ) {
+			return null;
+		}
+		// Normalize: ensure every item has an id (stable React key).
+		return valid.slice( 0, 3 ).map( ( s, i ) => ( {
+			id: s.id || `${ resultIdPrefix }-${ i }-${ slugify( s.label ) }`,
+			label: s.label,
+			prompt: s.prompt,
+		} ) );
+	} catch {
+		return null;
+	} finally {
+		if ( timeoutId ) {
+			clearTimeout( timeoutId );
+		}
+		signal?.removeEventListener( 'abort', abortRequest );
+	}
+}
+
+/**
+ * Fetch AI-generated suggestions based on the current page context.
+ * Falls back to static templates if the call fails or returns empty.
+ *
+ * Called fire-and-forget after mount — the empty view shows fallback
+ * chips immediately and re-renders with AI suggestions when they arrive.
+ */
+function fetchAiSuggestions( signal ) {
+	const post = readerConfig.currentPost;
+	const siteName = readerConfig.siteName || '';
+	const siteUrl = readerConfig.siteUrl || '';
+
+	// Build the message: post-specific if we're on a singular view, site-level
+	// if we're on the home/archive. The agent handles both — it just needs a
+	// prose description of what the reader is looking at.
+	const messageText = post?.url
+		? `Context: reader is on a specific blog post.\nPost title: ${
+				post.title || ''
+		  }\n\nPost excerpt:\n${
+				post.excerpt || ''
+		  }\n\nGenerate 3 questions a reader might click to learn more ABOUT THIS POST specifically.`
+		: `Context: reader is on the home/stream of a blog (no specific post selected).\nSite name: ${ siteName }\nSite URL: ${ siteUrl }\n\nGenerate 3 questions a reader might click to explore THIS BLOG overall — its topics, recent posts, or recommendations. Infer topics from the site name and URL.`;
+
+	return fetchSuggestions( {
+		messageText,
+		requestIdPrefix: 'reader-suggestions',
+		resultIdPrefix: 'ai-suggestion',
+		signal,
+	} );
+}
+
+/**
+ * Fetch 2-3 follow-up questions based on the last user+agent turn.
+ * Reuses the reader-chat-suggestions agent with a message shape that
+ * describes the exchange and asks for follow-ups.
+ */
+function fetchFollowupSuggestions( userText, agentText, signal ) {
+	if ( ! userText || ! agentText ) {
+		return Promise.resolve( null );
+	}
+
+	const messageText = `The reader just had this exchange on a blog:
+
+Reader asked: ${ userText }
+
+Blog replied: ${ agentText }
+
+Generate 2-3 follow-up questions the reader might want to ask next, based on what was discussed. Questions should feel like natural next-step curiosity — go deeper on a point, connect to a related theme, or explore an implication. Not generic.`;
+
+	return fetchSuggestions( {
+		messageText,
+		requestIdPrefix: 'reader-followup',
+		resultIdPrefix: 'followup',
+		signal,
+	} );
+}
+
+/**
+ * Append a "follow-up chips" strip below the chat panel. Clicking a chip
+ * fills the input and submits it. Observes the chat thread for new
+ * assistant messages via MutationObserver; after each one, fires a
+ * fetch for fresh follow-ups.
+ */
+function setupFollowupChips() {
+	// Shared state the useSuggestions hook will read.
+	// A MutationObserver watches the chat DOM for new assistant messages;
+	// when one completes, we fetch fresh chips and dispatch an event so
+	// the React hook re-renders with them.
+	window.agentsManagerData = window.agentsManagerData || {};
+	window.__jetpackReaderFollowupChips = [];
+	window.__jetpackReaderFollowupVersion = 0;
+
+	// Supply a useSuggestions hook that AgentsManager will pick up via the
+	// host-hook path in load-external-providers. This plugs our chips into
+	// the native suggestion rendering (above the input, same as the
+	// orchestrator's chip strip) — no custom DOM required.
+	window.agentsManagerData.useSuggestions = function useReaderFollowupSuggestions() {
+		const [ chips, setChips ] = useState( window.__jetpackReaderFollowupChips || [] );
+		useEffect( () => {
+			const handler = () => {
+				setChips( window.__jetpackReaderFollowupChips || [] );
+			};
+			window.addEventListener( 'reader-chat-followups-updated', handler );
+			return () => window.removeEventListener( 'reader-chat-followups-updated', handler );
+		}, [] );
+		return { suggestions: chips };
+	};
+
+	function publish( chips ) {
+		window.__jetpackReaderFollowupChips = chips || [];
+		window.__jetpackReaderFollowupVersion++;
+		window.dispatchEvent( new Event( 'reader-chat-followups-updated' ) );
+	}
+
+	function getLatestExchange( chat ) {
+		const agentMessages = chat.querySelectorAll(
+			'[data-slot="message"][data-role="agent"], [data-slot="message"][data-role="assistant"]'
+		);
+		const userMessages = chat.querySelectorAll( '[data-slot="message"][data-role="user"]' );
+		if ( agentMessages.length === 0 || userMessages.length === 0 ) {
+			return null;
+		}
+		const agentText = ( agentMessages[ agentMessages.length - 1 ].textContent || '' ).trim();
+		const userText = ( userMessages[ userMessages.length - 1 ].textContent || '' ).trim();
+		if ( agentText.length < MIN_FOLLOWUP_AGENT_TEXT_LENGTH || ! userText ) {
+			return null;
+		}
+		return {
+			agentText,
+			userText,
+			key: `${ userMessages.length }:${ userText }`,
+		};
+	}
+
+	// Observe the chat DOM for new complete assistant messages.
+	let debounceTimer = null;
+	let pendingExchangeKey = '';
+	let lastPublishedExchangeKey = '';
+	let followupController = null;
+	let requestSeq = 0;
+	let observedChat = null;
+	let chatObserver = null;
+	let pageObserver = null;
+	let unsubscribeOpen = null;
+	let observeScheduled = false;
+
+	function cleanup() {
+		if ( debounceTimer ) {
+			clearTimeout( debounceTimer );
+		}
+		followupController?.abort();
+		chatObserver?.disconnect();
+		pageObserver?.disconnect();
+		unsubscribeOpen?.();
+	}
+
+	window.addEventListener( 'pagehide', cleanup, { once: true } );
+
+	const handleChatMutation = () => {
+		const exchange = getLatestExchange( observedChat );
+		if (
+			! exchange ||
+			exchange.key === pendingExchangeKey ||
+			exchange.key === lastPublishedExchangeKey
+		) {
+			return;
+		}
+
+		if ( debounceTimer ) {
+			clearTimeout( debounceTimer );
+		}
+
+		debounceTimer = setTimeout( async () => {
+			const stableExchange = getLatestExchange( observedChat );
+			if (
+				! stableExchange ||
+				stableExchange.key !== exchange.key ||
+				stableExchange.agentText !== exchange.agentText ||
+				stableExchange.key === pendingExchangeKey ||
+				stableExchange.key === lastPublishedExchangeKey
+			) {
+				return;
+			}
+
+			followupController?.abort();
+			const requestController = createAbortController();
+			followupController = requestController;
+			const requestId = ++requestSeq;
+			pendingExchangeKey = stableExchange.key;
+			publish( [] ); // clear while fetching
+
+			const chips = await fetchFollowupSuggestions(
+				stableExchange.userText,
+				stableExchange.agentText,
+				requestController?.signal
+			);
+
+			if ( requestId !== requestSeq || requestController?.signal.aborted ) {
+				pendingExchangeKey = '';
+				followupController = null;
+				return;
+			}
+
+			lastPublishedExchangeKey = stableExchange.key;
+			pendingExchangeKey = '';
+			followupController = null;
+			publish( chips || [] );
+		}, FOLLOWUP_DEBOUNCE_MS );
+	};
+
+	function attachToChat( chat ) {
+		if ( ! chat || chat === observedChat ) {
+			return;
+		}
+
+		chatObserver?.disconnect();
+		observedChat = chat;
+		chatObserver = new window.MutationObserver( handleChatMutation );
+		chatObserver.observe( chat, { childList: true, subtree: true, characterData: true } );
+	}
+
+	function tryObserve() {
+		const chat = document.querySelector( '[data-slot=conversation-view]' );
+		if ( chat ) {
+			attachToChat( chat );
+			return;
+		}
+
+		if ( observedChat && document.body && ! document.body.contains( observedChat ) ) {
+			chatObserver?.disconnect();
+			chatObserver = null;
+			observedChat = null;
+		}
+	}
+
+	function scheduleObserve() {
+		if ( observeScheduled ) {
+			return;
+		}
+		observeScheduled = true;
+		const run = () => {
+			observeScheduled = false;
+			tryObserve();
+		};
+		if ( typeof window.requestAnimationFrame === 'function' ) {
+			window.requestAnimationFrame( run );
+		} else {
+			setTimeout( run, 0 );
+		}
+	}
+
+	if ( document.body ) {
+		pageObserver = new window.MutationObserver( scheduleObserve );
+		pageObserver.observe( document.body, { childList: true, subtree: true } );
+	}
+
+	unsubscribeOpen = subscribe( () => {
+		const state = select( AGENTS_MANAGER_STORE ).getAgentsManagerState?.();
+		if ( state?.isOpen ) {
+			scheduleObserve();
+		}
+	} );
+
+	tryObserve();
+}
+
+function setupInitialSuggestions() {
+	const controller = createAbortController();
+	window.addEventListener(
+		'pagehide',
+		() => {
+			controller?.abort();
+		},
+		{ once: true }
+	);
+
+	fetchAiSuggestions( controller?.signal ).then( ( aiSuggestions ) => {
+		if ( controller?.signal.aborted ) {
+			return;
+		}
+		window.agentsManagerData.readerSuggestions = aiSuggestions || getFallbackSuggestions();
+		// Signal to useEmptyViewSuggestions (inside AgentsManager) that
+		// the global override changed — the hook re-reads on this event
+		// and triggers a state update.
+		window.dispatchEvent( new Event( 'reader-chat-suggestions-updated' ) );
+	} );
+}
+
+/**
+ * Wire up Reader-Chat-specific Tracks events.
+ *
+ * Reader Chat renders through an AgentsManager portal attached to `body`, so
+ * UI events do not bubble through the #jetpack-reader-chat mount node. Attach
+ * document-level listeners from this public reader-chat entry instead. All
+ * events use the jetpack_reader_chat_* namespace to match the Jetpack-side
+ * feature.
+ *
+ * Three events:
+ * - jetpack_reader_chat_opened: chat UI goes from closed -> open
+ * - jetpack_reader_chat_suggestion_click: a prompt suggestion chip was clicked
+ * - jetpack_reader_chat_message_sent: the user submitted a message
+ *   (button click or Enter keypress on the composer textarea)
+ *
+ * All three work for anonymous readers — calypso-analytics pings the
+ * public pixel endpoint with _ut=anon when no user is known.
+ *
+ */
+function setupTracksEvents() {
+	const config = window.JetpackReaderChatConfig || {};
+	const baseProps = config.siteId ? { blog_id: config.siteId } : {};
+
+	// Chat open: watch the shared store for isOpen transitioning from
+	// false -> true. Fires once per open; closing + reopening re-fires.
+	let wasOpen = false;
+	const unsubscribe = subscribe( () => {
+		const state = select( AGENTS_MANAGER_STORE ).getAgentsManagerState?.();
+		const isOpen = !! state?.isOpen;
+		if ( isOpen && ! wasOpen ) {
+			recordTracksEvent( 'jetpack_reader_chat_opened', baseProps );
+		}
+		wasOpen = isOpen;
+	} );
+
+	// Suggestion click + send-button click via event delegation so we
+	// don't have to patch agenttic-ui or agents-manager.
+	const handleClick = ( event ) => {
+		const target = event.target;
+		if ( ! target || typeof target.closest !== 'function' ) {
+			return;
+		}
+		const suggestionBtn = target.closest( '.Suggestions-module_button' );
+		if ( suggestionBtn ) {
+			recordTracksEvent( 'jetpack_reader_chat_suggestion_click', {
+				...baseProps,
+				suggestion: ( suggestionBtn.textContent || '' ).trim().slice( 0, 200 ),
+			} );
+			return;
+		}
+		const sendBtn = target.closest( '[aria-label="Send message"]' );
+		if ( sendBtn && ! sendBtn.disabled ) {
+			recordTracksEvent( 'jetpack_reader_chat_message_sent', {
+				...baseProps,
+				trigger: 'button',
+			} );
+		}
+	};
+	// Enter-to-send on the composer textarea. Shift+Enter inserts a
+	// newline, plain Enter submits — match that convention.
+	const handleKeydown = ( event ) => {
+		if ( event.key !== 'Enter' || event.shiftKey || event.isComposing ) {
+			return;
+		}
+		const target = event.target;
+		if ( ! target || target.tagName !== 'TEXTAREA' ) {
+			return;
+		}
+		if ( ! target.closest( '[data-slot="chat-input"]' ) ) {
+			return;
+		}
+		if ( target.value.trim() === '' ) {
+			return;
+		}
+		recordTracksEvent( 'jetpack_reader_chat_message_sent', {
+			...baseProps,
+			trigger: 'enter',
+		} );
+	};
+	document.addEventListener( 'click', handleClick );
+	document.addEventListener( 'keydown', handleKeydown );
+
+	window.addEventListener(
+		'pagehide',
+		() => {
+			unsubscribe?.();
+			document.removeEventListener( 'click', handleClick );
+			document.removeEventListener( 'keydown', handleKeydown );
+		},
+		{ once: true }
+	);
+}
+
+function isCollapsedLauncherTarget( target, root = document ) {
+	if ( ! target || typeof target.closest !== 'function' ) {
+		return false;
+	}
+
+	const collapsedView = target.closest( '[data-slot="collapsed-view"]' );
+	return !! collapsedView && ( ! root || root.contains( collapsedView ) );
+}
+
+function setupCollapsedLauncherPointerFallback() {
+	const handleLauncherStart = ( event ) => {
+		if ( ! isCollapsedLauncherTarget( event.target ) ) {
+			return;
+		}
+
+		// Agenttic's draggable wrapper can prevent the later click in some
+		// browsers. Open on the initial pointer/mouse/touch event so the public
+		// reader launcher remains usable without changing shared AgentsManager
+		// behavior.
+		dispatch( AGENTS_MANAGER_STORE ).setIsOpen( true, false );
+	};
+
+	document.addEventListener( 'pointerdown', handleLauncherStart, true );
+	document.addEventListener( 'mousedown', handleLauncherStart, true );
+	document.addEventListener( 'touchstart', handleLauncherStart, true );
+
+	window.addEventListener(
+		'pagehide',
+		() => {
+			document.removeEventListener( 'pointerdown', handleLauncherStart, true );
+			document.removeEventListener( 'mousedown', handleLauncherStart, true );
+			document.removeEventListener( 'touchstart', handleLauncherStart, true );
+		},
+		{ once: true }
+	);
+}
+
+function ReaderChatApp() {
+	const config = window.JetpackReaderChatConfig || {};
+
+	const site = config.siteId
+		? {
+				ID: config.siteId,
+				URL: config.siteUrl || window.location.origin,
+				name: config.siteName || '',
+		  }
+		: null;
+
+	return (
+		<QueryClientProvider client={ queryClient }>
+			<AgentsManager
+				sectionName="reader-chat"
+				site={ site }
+				currentSiteId={ config.siteId || undefined }
+				agentId={ readerAgentId }
+			/>
+		</QueryClientProvider>
+	);
+}
+
+const container = document.getElementById( 'jetpack-reader-chat' );
+if ( container ) {
+	injectScopedReset();
+	setupFollowupChips();
+	setupTracksEvents();
+	setupCollapsedLauncherPointerFallback();
+
+	// Reader-chat defaults the floating panel to the left side of the
+	// viewport. The shared AgentsManager reducer default is 'right' (set
+	// for the wp-admin sidebar use-case); logged-out readers can't
+	// persist preferences to the server, so we pass shouldSave=false to
+	// avoid a doomed API call. Dragging within a session still works —
+	// it just won't survive a reload, which is fine for anonymous
+	// visitors.
+	dispatch( AGENTS_MANAGER_STORE ).setFloatingPosition( 'left', false );
+
+	// Start with an empty override so the empty view shows no chips
+	// while we fetch AI suggestions. This avoids the flash where
+	// generic "Summarize this post" chips appear for a beat and then
+	// get replaced with contextual ones — the user sees the contextual
+	// chips appear once, or the fallback if AI fails.
+	window.agentsManagerData.readerSuggestions = [];
+
+	const root = createRoot( container );
+	root.render( <ReaderChatApp /> );
+
+	setupInitialSuggestions();
+}
+
+// Exported for unit tests only — these are pure helpers with no side effects.
+export { parseAgentSseResponse, slugify, getFallbackSuggestions, isCollapsedLauncherTarget };

--- a/apps/agents-manager/reader-chat.js
+++ b/apps/agents-manager/reader-chat.js
@@ -231,7 +231,7 @@ const FOLLOWUP_DEBOUNCE_MS = 2500;
 const MIN_FOLLOWUP_AGENT_TEXT_LENGTH = 40;
 const MAX_SUGGESTION_LABEL_LENGTH = 48;
 const MAX_SUGGESTION_LABEL_WORDS = 7;
-const POST_FALLBACK_LABELS = [ 'Summarize this post', 'Explore this topic', 'Find related posts' ];
+const POST_FALLBACK_LABELS = [ 'Main takeaway', 'Key details', 'Related context' ];
 const BLOG_FALLBACK_LABELS = [ 'Explore this blog', 'Find popular posts', 'Recommend a post' ];
 const FOLLOWUP_FALLBACK_LABELS = [ 'Go deeper', 'Learn more', 'Ask a follow-up' ];
 
@@ -328,8 +328,7 @@ function isConciseSuggestionLabel( label ) {
 	}
 	return (
 		label.length <= MAX_SUGGESTION_LABEL_LENGTH &&
-		label.split( /\s+/ ).length <= MAX_SUGGESTION_LABEL_WORDS &&
-		! /[?]/.test( label )
+		label.split( /\s+/ ).length <= MAX_SUGGESTION_LABEL_WORDS
 	);
 }
 
@@ -479,10 +478,12 @@ ${ postExcerpt }
 
 Return only a JSON array of exactly 3 objects, with no markdown or commentary.
 Each object must have:
-- "label": short chip text, 2-5 words, no question mark, max 48 characters.
+- "label": short chip text, 2-5 words, max 48 characters. Prefer a specific reader question; question marks are okay.
 - "prompt": a full question for the blog assistant to answer.
 
 Generate questions a reader might click to learn more ABOUT THIS POST specifically.
+Use concrete details from the title or excerpt when possible.
+Avoid generic labels like "Summarize this post", "Explain this post", or "Find related posts".
 Do not ask the author personal interview questions.
 Do not address the author as "you" or "your".
 Phrase prompts around "this post", "the post", "the author", or the topic discussed.`
@@ -492,7 +493,7 @@ Site URL: ${ siteUrl }
 
 Return only a JSON array of exactly 3 objects, with no markdown or commentary.
 Each object must have:
-- "label": short chip text, 2-5 words, no question mark, max 48 characters.
+- "label": short chip text, 2-5 words, max 48 characters. Question marks are okay.
 - "prompt": a full question for the blog assistant to answer.
 
 Generate questions a reader might click to explore THIS BLOG overall: its topics, recent posts, or recommendations.
@@ -524,7 +525,7 @@ Reader asked: ${ userText }
 Blog replied: ${ agentText }
 
 Return only a JSON array of 2-3 objects, with no markdown or commentary. Each object must have "label" and "prompt" strings.
-Labels must be short chip text, 2-5 words, no question mark, max 48 characters.
+Labels must be short chip text, 2-5 words, max 48 characters. Question marks are okay.
 Generate follow-up questions the reader might want to ask next, based on what was discussed.
 Do not ask the author/site owner personal interview questions or address them as "you".
 Questions should feel like natural next-step curiosity: go deeper on a point, connect to a related theme, or explore an implication. Not generic.`;

--- a/apps/agents-manager/reader-chat.js
+++ b/apps/agents-manager/reader-chat.js
@@ -281,6 +281,13 @@ function getReaderEmptyViewHeading( config ) {
 		: 'Ask me anything about this blog.';
 }
 
+function getReaderClientContext( currentPost = readerCurrentPost, siteId = readerSiteId ) {
+	return {
+		...( siteId ? { selectedSiteId: siteId } : {} ),
+		...( currentPost ? { currentPost } : {} ),
+	};
+}
+
 function createAbortController() {
 	return typeof window.AbortController === 'function' ? new window.AbortController() : null;
 }
@@ -414,10 +421,7 @@ async function fetchSuggestions( { messageText, requestIdPrefix, resultIdPrefix,
 					{
 						type: 'data',
 						data: {
-							clientContext: {
-								post_url: readerCurrentPost?.url || '',
-								selectedSiteId: readerSiteId,
-							},
+							clientContext: getReaderClientContext(),
 						},
 					},
 				],
@@ -966,6 +970,7 @@ export {
 	normalizeReaderSiteId,
 	decodeHtmlEntities,
 	getReaderEmptyViewHeading,
+	getReaderClientContext,
 	normalizeSuggestions,
 	parseSuggestionsResponse,
 };

--- a/apps/agents-manager/reader-chat.js
+++ b/apps/agents-manager/reader-chat.js
@@ -187,9 +187,9 @@ function getFallbackSuggestions() {
 	if ( ! post ) {
 		return [
 			{
-				id: 'popular',
-				label: 'Find popular posts',
-				prompt: 'What are the most popular posts on this blog?',
+				id: 'recent',
+				label: 'Explore recent posts',
+				prompt: 'What recent posts can I read on this blog?',
 			},
 			{
 				id: 'about',
@@ -233,7 +233,11 @@ const MIN_FOLLOWUP_AGENT_TEXT_LENGTH = 40;
 const MAX_SUGGESTION_LABEL_LENGTH = 48;
 const MAX_SUGGESTION_LABEL_WORDS = 7;
 const POST_FALLBACK_LABELS = [ 'Main takeaway', 'Key details', 'Related context' ];
-const BLOG_FALLBACK_LABELS = [ 'Explore this blog', 'Find popular posts', 'Recommend a post' ];
+const BLOG_FALLBACK_LABELS = [
+	'Explore recent posts',
+	'Learn about this blog',
+	'Recommend a post',
+];
 const FOLLOWUP_FALLBACK_LABELS = [ 'Go deeper', 'Learn more', 'Ask a follow-up' ];
 
 function normalizeReaderSiteId( siteId ) {
@@ -546,9 +550,11 @@ Blog replied: ${ agentText }
 
 Return only a JSON array of 2-3 objects, with no markdown or commentary. Each object must have "label" and "prompt" strings.
 Labels must be short chip text, 2-5 words, max 48 characters. Question marks are okay.
-Generate follow-up questions the reader might want to ask next, based on what was discussed.
+Generate follow-up questions the reader might want to ask next, based only on the reader's question and the blog reply above.
+Anchor every question in a concrete detail, place, person, phrase, or theme from the reply.
+Do not ask for broad advice, outside recommendations, popularity, traffic, trends, or facts not implied by the reply.
 Do not ask the author/site owner personal interview questions or address them as "you".
-Questions should feel like natural next-step curiosity: go deeper on a point, connect to a related theme, or explore an implication. Not generic.`;
+Questions should feel like natural next-step curiosity: clarify a detail, go deeper on a named point, or ask how two details connect.`;
 
 	return fetchSuggestions( {
 		messageText,

--- a/apps/agents-manager/reader-chat.js
+++ b/apps/agents-manager/reader-chat.js
@@ -25,7 +25,6 @@ import { createRoot } from 'react-dom/client';
  * public-facing blog bundle. The queue is drained by stats.js / the
  * Tracks library if/when it loads on the page — and on blogs where
  * it doesn't load, events simply stay queued with no ill effect.
- *
  * @param {string} eventName Must start with an allowed source prefix
  *                           (e.g. 'jetpack_...') to be accepted by Tracks.
  * @param {Object} [props]   Flat property bag. Nested objects are not
@@ -161,10 +160,13 @@ function injectScopedReset() {
 // Read config injected by PHP.
 const readerConfig = window.JetpackReaderChatConfig || {};
 const readerAgentId = readerConfig.agentId || 'reader-chat';
+const readerSiteId = normalizeReaderSiteId( readerConfig.siteId );
 
 // Set agentId for useAgentConfig() to pick up via agentsManagerData global.
 window.agentsManagerData = window.agentsManagerData || {};
 window.agentsManagerData.agentId = readerAgentId;
+window.agentsManagerData.siteId = readerSiteId;
+window.agentsManagerData.emptyViewHeading = getReaderEmptyViewHeading( readerConfig );
 
 // Expose page context on the global so the default context provider
 // and agent hooks can read it. The AgentsManager default context
@@ -185,23 +187,23 @@ function getFallbackSuggestions() {
 		return [
 			{
 				id: 'popular',
-				label: 'What are the most popular posts here?',
+				label: 'Find popular posts',
 				prompt: 'What are the most popular posts on this blog?',
 			},
 			{
 				id: 'about',
-				label: 'What is this blog about?',
+				label: 'Learn about this blog',
 				prompt: 'What is this blog about? What topics does it cover?',
 			},
 			{
 				id: 'recommend',
-				label: 'Recommend something to read',
+				label: 'Recommend a post',
 				prompt: 'Can you recommend a good post to read on this blog?',
 			},
 		];
 	}
 
-	const title = post.title || 'this post';
+	const title = decodeHtmlEntities( post.title || 'this post' );
 
 	return [
 		{
@@ -211,7 +213,7 @@ function getFallbackSuggestions() {
 		},
 		{
 			id: 'explain',
-			label: 'Explain something from this post',
+			label: 'Explain this post',
 			prompt: `Can you explain the main points of "${ title }" in simple terms?`,
 		},
 		{
@@ -227,6 +229,31 @@ const SUGGESTIONS_ENDPOINT =
 const SUGGESTIONS_TIMEOUT_MS = 15000;
 const FOLLOWUP_DEBOUNCE_MS = 2500;
 const MIN_FOLLOWUP_AGENT_TEXT_LENGTH = 40;
+const MAX_SUGGESTION_LABEL_LENGTH = 48;
+const MAX_SUGGESTION_LABEL_WORDS = 7;
+const POST_FALLBACK_LABELS = [ 'Summarize this post', 'Explore this topic', 'Find related posts' ];
+const BLOG_FALLBACK_LABELS = [ 'Explore this blog', 'Find popular posts', 'Recommend a post' ];
+const FOLLOWUP_FALLBACK_LABELS = [ 'Go deeper', 'Learn more', 'Ask a follow-up' ];
+
+function normalizeReaderSiteId( siteId ) {
+	const numericSiteId = Number( siteId );
+	return Number.isFinite( numericSiteId ) && numericSiteId > 0 ? numericSiteId : undefined;
+}
+
+function decodeHtmlEntities( text ) {
+	if ( typeof document === 'undefined' ) {
+		return String( text || '' );
+	}
+	const textarea = document.createElement( 'textarea' );
+	textarea.innerHTML = String( text || '' );
+	return textarea.value.replace( /\u00a0/g, ' ' );
+}
+
+function getReaderEmptyViewHeading( config ) {
+	return config?.currentPost
+		? 'Ask me anything about this post.'
+		: 'Ask me anything about this blog.';
+}
 
 function createAbortController() {
 	return typeof window.AbortController === 'function' ? new window.AbortController() : null;
@@ -272,6 +299,71 @@ function parseAgentSseResponse( raw ) {
 	return null;
 }
 
+function parseSuggestionsResponse( text ) {
+	const unfenced = String( text || '' )
+		.trim()
+		.replace( /^```(?:json)?\s*/i, '' )
+		.replace( /\s*```$/i, '' )
+		.trim();
+
+	try {
+		return JSON.parse( unfenced );
+	} catch {
+		const start = unfenced.indexOf( '[' );
+		const end = unfenced.lastIndexOf( ']' );
+		if ( start === -1 || end <= start ) {
+			return null;
+		}
+		try {
+			return JSON.parse( unfenced.slice( start, end + 1 ) );
+		} catch {
+			return null;
+		}
+	}
+}
+
+function isConciseSuggestionLabel( label ) {
+	if ( ! label ) {
+		return false;
+	}
+	return (
+		label.length <= MAX_SUGGESTION_LABEL_LENGTH &&
+		label.split( /\s+/ ).length <= MAX_SUGGESTION_LABEL_WORDS &&
+		! /[?]/.test( label )
+	);
+}
+
+function getFallbackSuggestionLabel( index, resultIdPrefix ) {
+	if ( resultIdPrefix === 'followup' ) {
+		return FOLLOWUP_FALLBACK_LABELS[ index ] || 'Ask a follow-up';
+	}
+	const labels = readerConfig.currentPost ? POST_FALLBACK_LABELS : BLOG_FALLBACK_LABELS;
+	return (
+		labels[ index ] || ( readerConfig.currentPost ? 'Ask about this post' : 'Explore this blog' )
+	);
+}
+
+function normalizeSuggestions( items, resultIdPrefix ) {
+	const valid = ( Array.isArray( items ) ? items : [] ).filter(
+		( s ) => s && typeof s.label === 'string' && typeof s.prompt === 'string'
+	);
+	if ( valid.length === 0 ) {
+		return null;
+	}
+	return valid.slice( 0, 3 ).map( ( s, i ) => {
+		const prompt = decodeHtmlEntities( s.prompt ).trim();
+		const labelCandidate = decodeHtmlEntities( s.label ).trim();
+		const label = isConciseSuggestionLabel( labelCandidate )
+			? labelCandidate
+			: getFallbackSuggestionLabel( i, resultIdPrefix );
+		return {
+			id: s.id || `${ resultIdPrefix }-${ i }-${ slugify( prompt ) }`,
+			label,
+			prompt,
+		};
+	} );
+}
+
 /**
  * Call the reader-chat-suggestions agent with an arbitrary user message and
  * return a list of {id,label,prompt} suggestions, or null on failure.
@@ -301,7 +393,7 @@ async function fetchSuggestions( { messageText, requestIdPrefix, resultIdPrefix,
 						data: {
 							clientContext: {
 								post_url: readerConfig.currentPost?.url || '',
-								selectedSiteId: readerConfig.siteId,
+								selectedSiteId: readerSiteId,
 							},
 						},
 					},
@@ -345,20 +437,12 @@ async function fetchSuggestions( { messageText, requestIdPrefix, resultIdPrefix,
 			return null;
 		}
 
-		const parsed = JSON.parse( text );
-		const items = Array.isArray( parsed ) ? parsed : [];
-		const valid = items.filter(
-			( s ) => s && typeof s.label === 'string' && typeof s.prompt === 'string'
-		);
-		if ( valid.length === 0 ) {
+		const parsed = parseSuggestionsResponse( text );
+		const suggestions = normalizeSuggestions( parsed, resultIdPrefix );
+		if ( ! suggestions ) {
 			return null;
 		}
-		// Normalize: ensure every item has an id (stable React key).
-		return valid.slice( 0, 3 ).map( ( s, i ) => ( {
-			id: s.id || `${ resultIdPrefix }-${ i }-${ slugify( s.label ) }`,
-			label: s.label,
-			prompt: s.prompt,
-		} ) );
+		return suggestions;
 	} catch {
 		return null;
 	} finally {
@@ -380,17 +464,40 @@ function fetchAiSuggestions( signal ) {
 	const post = readerConfig.currentPost;
 	const siteName = readerConfig.siteName || '';
 	const siteUrl = readerConfig.siteUrl || '';
+	const postTitle = decodeHtmlEntities( post?.title || '' );
+	const postExcerpt = decodeHtmlEntities( post?.excerpt || '' );
 
 	// Build the message: post-specific if we're on a singular view, site-level
 	// if we're on the home/archive. The agent handles both — it just needs a
 	// prose description of what the reader is looking at.
 	const messageText = post?.url
-		? `Context: reader is on a specific blog post.\nPost title: ${
-				post.title || ''
-		  }\n\nPost excerpt:\n${
-				post.excerpt || ''
-		  }\n\nGenerate 3 questions a reader might click to learn more ABOUT THIS POST specifically.`
-		: `Context: reader is on the home/stream of a blog (no specific post selected).\nSite name: ${ siteName }\nSite URL: ${ siteUrl }\n\nGenerate 3 questions a reader might click to explore THIS BLOG overall — its topics, recent posts, or recommendations. Infer topics from the site name and URL.`;
+		? `Context: a reader is on a specific blog post.
+Post title: ${ postTitle }
+
+Post excerpt:
+${ postExcerpt }
+
+Return only a JSON array of exactly 3 objects, with no markdown or commentary.
+Each object must have:
+- "label": short chip text, 2-5 words, no question mark, max 48 characters.
+- "prompt": a full question for the blog assistant to answer.
+
+Generate questions a reader might click to learn more ABOUT THIS POST specifically.
+Do not ask the author personal interview questions.
+Do not address the author as "you" or "your".
+Phrase prompts around "this post", "the post", "the author", or the topic discussed.`
+		: `Context: a reader is on the home/stream of a blog (no specific post selected).
+Site name: ${ siteName }
+Site URL: ${ siteUrl }
+
+Return only a JSON array of exactly 3 objects, with no markdown or commentary.
+Each object must have:
+- "label": short chip text, 2-5 words, no question mark, max 48 characters.
+- "prompt": a full question for the blog assistant to answer.
+
+Generate questions a reader might click to explore THIS BLOG overall: its topics, recent posts, or recommendations.
+Do not ask the site owner personal interview questions.
+Do not address the site owner as "you" or "your".`;
 
 	return fetchSuggestions( {
 		messageText,
@@ -416,7 +523,11 @@ Reader asked: ${ userText }
 
 Blog replied: ${ agentText }
 
-Generate 2-3 follow-up questions the reader might want to ask next, based on what was discussed. Questions should feel like natural next-step curiosity — go deeper on a point, connect to a related theme, or explore an implication. Not generic.`;
+Return only a JSON array of 2-3 objects, with no markdown or commentary. Each object must have "label" and "prompt" strings.
+Labels must be short chip text, 2-5 words, no question mark, max 48 characters.
+Generate follow-up questions the reader might want to ask next, based on what was discussed.
+Do not ask the author/site owner personal interview questions or address them as "you".
+Questions should feel like natural next-step curiosity: go deeper on a point, connect to a related theme, or explore an implication. Not generic.`;
 
 	return fetchSuggestions( {
 		messageText,
@@ -770,9 +881,9 @@ function setupCollapsedLauncherPointerFallback() {
 function ReaderChatApp() {
 	const config = window.JetpackReaderChatConfig || {};
 
-	const site = config.siteId
+	const site = readerSiteId
 		? {
-				ID: config.siteId,
+				ID: readerSiteId,
 				URL: config.siteUrl || window.location.origin,
 				name: config.siteName || '',
 		  }
@@ -783,7 +894,7 @@ function ReaderChatApp() {
 			<AgentsManager
 				sectionName="reader-chat"
 				site={ site }
-				currentSiteId={ config.siteId || undefined }
+				currentSiteId={ readerSiteId }
 				agentId={ readerAgentId }
 			/>
 		</QueryClientProvider>
@@ -820,4 +931,14 @@ if ( container ) {
 }
 
 // Exported for unit tests only — these are pure helpers with no side effects.
-export { parseAgentSseResponse, slugify, getFallbackSuggestions, isCollapsedLauncherTarget };
+export {
+	parseAgentSseResponse,
+	slugify,
+	getFallbackSuggestions,
+	isCollapsedLauncherTarget,
+	normalizeReaderSiteId,
+	decodeHtmlEntities,
+	getReaderEmptyViewHeading,
+	normalizeSuggestions,
+	parseSuggestionsResponse,
+};

--- a/apps/agents-manager/reader-chat.js
+++ b/apps/agents-manager/reader-chat.js
@@ -161,6 +161,7 @@ function injectScopedReset() {
 const readerConfig = window.JetpackReaderChatConfig || {};
 const readerAgentId = readerConfig.agentId || 'reader-chat';
 const readerSiteId = normalizeReaderSiteId( readerConfig.siteId );
+const readerCurrentPost = getReaderCurrentPost( readerConfig );
 
 // Set agentId for useAgentConfig() to pick up via agentsManagerData global.
 window.agentsManagerData = window.agentsManagerData || {};
@@ -171,7 +172,7 @@ window.agentsManagerData.emptyViewHeading = getReaderEmptyViewHeading( readerCon
 // Expose page context on the global so the default context provider
 // and agent hooks can read it. The AgentsManager default context
 // provider sends window.location info; we augment with post-level data.
-window.agentsManagerData.currentPost = readerConfig.currentPost || null;
+window.agentsManagerData.currentPost = readerCurrentPost;
 window.agentsManagerData.siteName = readerConfig.siteName || '';
 window.agentsManagerData.siteUrl = readerConfig.siteUrl || '';
 
@@ -181,7 +182,7 @@ window.agentsManagerData.siteUrl = readerConfig.siteUrl || '';
  * stay if the AI call fails.
  */
 function getFallbackSuggestions() {
-	const post = readerConfig.currentPost;
+	const post = readerCurrentPost;
 
 	if ( ! post ) {
 		return [
@@ -207,19 +208,19 @@ function getFallbackSuggestions() {
 
 	return [
 		{
-			id: 'summarize',
-			label: 'Summarize this post',
-			prompt: `Can you summarize "${ title }" for me?`,
+			id: 'takeaway',
+			label: 'Main takeaway',
+			prompt: `What is the main takeaway from "${ title }"?`,
 		},
 		{
-			id: 'explain',
-			label: 'Explain this post',
-			prompt: `Can you explain the main points of "${ title }" in simple terms?`,
+			id: 'details',
+			label: 'Key details',
+			prompt: `What details from "${ title }" are most important?`,
 		},
 		{
-			id: 'related',
-			label: 'Find related posts',
-			prompt: `What other posts on this blog are related to "${ title }"?`,
+			id: 'context',
+			label: 'Related context',
+			prompt: `What related ideas or posts help explain "${ title }"?`,
 		},
 	];
 }
@@ -249,8 +250,29 @@ function decodeHtmlEntities( text ) {
 	return textarea.value.replace( /\u00a0/g, ' ' );
 }
 
+function normalizeReaderUrl( url ) {
+	try {
+		const parsed = new URL( url );
+		return `${ parsed.origin }${ parsed.pathname }`.replace( /\/+$/, '' );
+	} catch {
+		return String( url || '' ).replace( /\/+$/, '' );
+	}
+}
+
+function getReaderCurrentPost( config ) {
+	const post = config?.currentPost || null;
+	if ( ! post ) {
+		return null;
+	}
+
+	const postUrl = normalizeReaderUrl( post.url );
+	const siteUrl = normalizeReaderUrl( config?.siteUrl );
+
+	return postUrl && siteUrl && postUrl === siteUrl ? null : post;
+}
+
 function getReaderEmptyViewHeading( config ) {
-	return config?.currentPost
+	return getReaderCurrentPost( config )
 		? 'Ask me anything about this post.'
 		: 'Ask me anything about this blog.';
 }
@@ -336,10 +358,8 @@ function getFallbackSuggestionLabel( index, resultIdPrefix ) {
 	if ( resultIdPrefix === 'followup' ) {
 		return FOLLOWUP_FALLBACK_LABELS[ index ] || 'Ask a follow-up';
 	}
-	const labels = readerConfig.currentPost ? POST_FALLBACK_LABELS : BLOG_FALLBACK_LABELS;
-	return (
-		labels[ index ] || ( readerConfig.currentPost ? 'Ask about this post' : 'Explore this blog' )
-	);
+	const labels = readerCurrentPost ? POST_FALLBACK_LABELS : BLOG_FALLBACK_LABELS;
+	return labels[ index ] || ( readerCurrentPost ? 'Ask about this post' : 'Explore this blog' );
 }
 
 function normalizeSuggestions( items, resultIdPrefix ) {
@@ -391,7 +411,7 @@ async function fetchSuggestions( { messageText, requestIdPrefix, resultIdPrefix,
 						type: 'data',
 						data: {
 							clientContext: {
-								post_url: readerConfig.currentPost?.url || '',
+								post_url: readerCurrentPost?.url || '',
 								selectedSiteId: readerSiteId,
 							},
 						},
@@ -460,7 +480,7 @@ async function fetchSuggestions( { messageText, requestIdPrefix, resultIdPrefix,
  * chips immediately and re-renders with AI suggestions when they arrive.
  */
 function fetchAiSuggestions( signal ) {
-	const post = readerConfig.currentPost;
+	const post = readerCurrentPost;
 	const siteName = readerConfig.siteName || '';
 	const siteUrl = readerConfig.siteUrl || '';
 	const postTitle = decodeHtmlEntities( post?.title || '' );

--- a/apps/agents-manager/webpack.config.js
+++ b/apps/agents-manager/webpack.config.js
@@ -94,6 +94,67 @@ function getIndividualConfig( options = {} ) {
 	};
 }
 
+/**
+ * Reader chat config — bundles all dependencies (no WP externals).
+ *
+ * Omits DependencyExtractionWebpackPlugin entirely so React, @wordpress/data,
+ * and other WP packages are inlined. The resulting reader-chat.min.js is
+ * self-contained and safe to load on the frontend (no WP script loader needed).
+ *
+ * @param   {Object}  options                       options
+ * @param   {Object}  options.env                   environment options
+ * @param   {Object}  options.argv                  webpack CLI args
+ * @returns {Object}                                webpack config
+ */
+function getReaderConfig( options = {} ) {
+	const { env, argv } = options;
+	const outputPath = path.join( __dirname, 'dist' );
+	const webpackConfig = getBaseWebpackConfig( env, argv );
+
+	return {
+		...webpackConfig,
+		mode: isDevelopment ? 'development' : 'production',
+		entry: { 'reader-chat': path.join( __dirname, 'reader-chat.js' ) },
+		output: {
+			...webpackConfig.output,
+			path: outputPath,
+			filename: '[name].min.js',
+		},
+		module: {
+			...webpackConfig.module,
+			rules: [ ...( webpackConfig.module?.rules || [] ) ],
+		},
+		resolve: {
+			...webpackConfig.resolve,
+			alias: {
+				...( webpackConfig.resolve?.alias || {} ),
+				'../agent-history': path.join( __dirname, 'reader-chat-route-stub.js' ),
+				'../support-guide': path.join( __dirname, 'reader-chat-route-stub.js' ),
+				'../support-guides': path.join( __dirname, 'reader-chat-route-stub.js' ),
+				'../zendesk-chat': path.join( __dirname, 'reader-chat-route-stub.js' ),
+			},
+		},
+		optimization: {
+			...webpackConfig.optimization,
+			// Disable module concatenation so __() calls are not renamed.
+			concatenateModules: false,
+		},
+		plugins: [
+			// Strip the base config's DependencyExtractionWebpackPlugin — we want
+			// everything bundled, not externalized.
+			...webpackConfig.plugins.filter(
+				( plugin ) => plugin.constructor.name !== 'DependencyExtractionWebpackPlugin'
+			),
+			new webpack.DefinePlugin( {
+				__i18n_text_domain__: JSON.stringify( 'default' ),
+				'process.env.NODE_DEBUG': JSON.stringify( process.env.NODE_DEBUG || false ),
+			} ),
+			new ReadableJsAssetsWebpackPlugin(),
+			// Intentionally NO DependencyExtractionWebpackPlugin — all WP deps are bundled.
+		],
+	};
+}
+
 /* Arguments to this function replicate webpack's so this config can be used on the command line,
  * with individual options overridden by command line args.
  * @see {@link https://webpack.js.org/configuration/configuration-types/#exporting-a-function}
@@ -130,6 +191,7 @@ function getWebpackConfig( env = { source: '' }, argv = {} ) {
 		getIndividualConfig( { env, argv, name: 'block-notes' } ),
 		getIndividualConfig( { env, argv, name: 'agents-manager-ciab' } ),
 		getIndividualConfig( { env, argv, name: 'agents-manager-wooai' } ),
+		getReaderConfig( { env, argv } ),
 	];
 
 	// Attach the copy plugin to the first config.

--- a/bin/did-calypso-app-change.mjs
+++ b/bin/did-calypso-app-change.mjs
@@ -16,7 +16,10 @@ const exec = async ( cmd, opts ) => {
 };
 
 export default async function didCalypsoAppChange( { slug, dir, artifactDir } ) {
-	await downloadPrevBuild( slug, dir );
+	const hasPreviousBuild = await downloadPrevBuild( slug, dir );
+	if ( ! hasPreviousBuild ) {
+		return true;
+	}
 	const prevReleaseDir = path.join( dir, 'prev-release' );
 
 	const normalizer = path.join( dir, 'bin/normalize-artifact.sh' );
@@ -49,19 +52,27 @@ export default async function didCalypsoAppChange( { slug, dir, artifactDir } ) 
 
 async function downloadPrevBuild( appSlug, dir ) {
 	const prevBuildZip = `${ dir }/prev-archive-download.zip`;
-	const stream = createWriteStream( prevBuildZip );
 
 	const prevBuildUrl = `${ process.env.tc_sever_url }/repository/download/calypso_calypso_WPComPlugins_Build_Plugins/${ appSlug }-release-build.tcbuildtag/${ appSlug }.zip?guest=1&branch=trunk`;
 	console.info( `Fetching previous release build for ${ appSlug } from ${ prevBuildUrl }` );
 
 	const { body, status } = await fetch( prevBuildUrl );
+	if ( status === 404 ) {
+		console.info(
+			`No previous release build found for ${ appSlug }; treating current build as changed.`
+		);
+		return false;
+	}
+
 	if ( status !== 200 ) {
 		throw new Error(
-			`Could not fetch previous build for ${ appSlug } (response code ${ status })! You can ignore this error when first adding a new app — just add a \`teamcity:build-app\` package script so it's ready for subsequent PRs, and add your app to the \`keepReleaseBuilds\` and \`artifactRules\` lists in \`.teamcity/_self/projects/WPComPlugins.kt\`.`
+			`Could not fetch previous build for ${ appSlug } (response code ${ status })!`
 		);
 	}
 
 	console.info( `Extracting downloaded archive for ${ appSlug }...` );
+	const stream = createWriteStream( prevBuildZip );
 	await finished( Readable.fromWeb( body ).pipe( stream ) );
 	await exec( `unzip -q ${ prevBuildZip } -d ${ dir }/prev-release` );
+	return true;
 }

--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -458,6 +458,12 @@ body.post-new-php.agents-manager-sidebar-container {
 		width: 100%;
 	}
 
+	.Suggestions-module_vertical .Suggestions-module_button {
+		white-space: normal;
+		text-align: left;
+		overflow-wrap: anywhere;
+	}
+
 	.big-sky__chat-actions {
 		width: 100%;
 		margin-top: auto;

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -153,18 +153,23 @@ export default function OrchestratorChat( {
 
 	// Use dynamic suggestions from the external provider (e.g., Big Sky block-based suggestions)
 	const dynamicSuggestions = useSuggestions?.();
+	const dynamicSuggestionsList = dynamicSuggestions?.suggestions ?? [];
+	const dynamicSuggestionsKey = JSON.stringify(
+		dynamicSuggestionsList.map( ( s ) => [ s.id, s.label, s.prompt ] )
+	);
 
 	// Register dynamic suggestions whenever they change
 	useEffect( () => {
-		const currentSuggestions = dynamicSuggestions?.suggestions;
-
-		if ( currentSuggestions && currentSuggestions.length > 0 ) {
-			registerSuggestions?.( currentSuggestions );
+		if ( dynamicSuggestionsList.length > 0 ) {
+			registerSuggestions?.( dynamicSuggestionsList );
 		} else {
 			// Clear suggestions when there are none
 			clearSuggestions?.();
 		}
-	}, [ dynamicSuggestions?.suggestions, registerSuggestions, clearSuggestions ] );
+		// Track suggestion content, not array identity. Some merged providers
+		// return a fresh empty array on each render.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ dynamicSuggestionsKey, registerSuggestions, clearSuggestions ] );
 
 	// Persist the chat route so the conversation can be resumed later.
 	useSaveNewChatRoute( hasUserSentMessage );

--- a/packages/agents-manager/src/hooks/__tests__/use-conversation.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-conversation.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-disable import/order -- jest.mock calls must precede imports */
+jest.mock(
+	'@automattic/agenttic-client',
+	() => ( {
+		loadAllMessagesFromServer: jest.fn(),
+	} ),
+	{ virtual: true }
+);
+
+jest.mock( '@tanstack/react-query', () => ( {
+	useQuery: jest.fn(),
+} ) );
+
+jest.mock( '../../contexts', () => ( {
+	useAgentsManagerContext: jest.fn(),
+} ) );
+
+import { useQuery } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import { useAgentsManagerContext } from '../../contexts';
+import useConversation from '../use-conversation';
+
+const mockUseQuery = useQuery as jest.Mock;
+const mockUseAgentsManagerContext = useAgentsManagerContext as jest.Mock;
+
+describe( 'useConversation', () => {
+	beforeEach( () => {
+		mockUseQuery.mockReturnValue( {
+			data: undefined,
+			error: null,
+			isError: false,
+			isLoading: false,
+		} );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'does not fetch stored conversations for Reader Chat', () => {
+		mockUseAgentsManagerContext.mockReturnValue( {
+			agentConfig: {
+				agentId: 'reader-chat',
+				sessionId: 'reader-session',
+				authProvider: {},
+			},
+		} );
+
+		renderHook( () => useConversation( {} ) );
+
+		expect( mockUseQuery ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				enabled: false,
+			} )
+		);
+	} );
+
+	it( 'fetches stored conversations for non-Reader Chat agents with a session ID', () => {
+		mockUseAgentsManagerContext.mockReturnValue( {
+			agentConfig: {
+				agentId: 'wp-orchestrator',
+				sessionId: 'orchestrator-session',
+				authProvider: {},
+			},
+		} );
+
+		renderHook( () => useConversation( {} ) );
+
+		expect( mockUseQuery ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				enabled: true,
+			} )
+		);
+	} );
+} );

--- a/packages/agents-manager/src/hooks/__tests__/use-empty-view-suggestions.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-empty-view-suggestions.test.ts
@@ -1,0 +1,164 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-disable import/order -- jest.mock calls must precede imports */
+const mockUseSelect = jest.fn();
+let mockContext = {
+	sectionName: 'gutenberg',
+	currentRoute: undefined as string | undefined,
+};
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: (
+		mapSelect: ( select: ( storeName: string ) => unknown ) => unknown,
+		deps: unknown[]
+	) => mockUseSelect( mapSelect, deps ),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text: string ) => text,
+} ) );
+
+jest.mock( '../../contexts', () => ( {
+	useAgentsManagerContext: () => mockContext,
+} ) );
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { useEmptyViewSuggestions } from '../use-empty-view-suggestions';
+import type { LoadedProviders } from '../../utils/load-external-providers';
+
+const readerSuggestion = {
+	id: 'reader-summary',
+	label: 'Summarize this post',
+	prompt: 'Can you summarize this post?',
+};
+
+const bigSkySuggestion = {
+	id: 'big-sky',
+	label: 'Big Sky suggestion',
+	prompt: 'Use theme-aware Big Sky suggestion.',
+};
+
+const siteEditorSuggestion = {
+	id: 'customize-colors',
+	label: 'Customize colors',
+	prompt: 'Show me color palettes for my site that are:',
+};
+
+function mockCoreStoreReady( isReady: boolean ) {
+	mockUseSelect.mockImplementation( ( mapSelect ) =>
+		mapSelect( () => ( {
+			getCurrentTheme: () => ( isReady ? { stylesheet: 'pub/theme' } : null ),
+		} ) )
+	);
+}
+
+function setReaderSuggestions( readerSuggestions: unknown ) {
+	( window as unknown as { agentsManagerData?: Record< string, unknown > } ).agentsManagerData = {
+		agentId: 'reader-chat',
+		readerSuggestions,
+	};
+}
+
+describe( 'useEmptyViewSuggestions', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		window.history.pushState( {}, '', '/' );
+		mockContext = {
+			sectionName: 'gutenberg',
+			currentRoute: undefined,
+		};
+		mockCoreStoreReady( true );
+	} );
+
+	afterEach( () => {
+		delete ( window as unknown as { agentsManagerData?: unknown } ).agentsManagerData;
+		window.history.pushState( {}, '', '/' );
+	} );
+
+	it( 'uses Reader Chat overrides before waiting for the core store', async () => {
+		mockCoreStoreReady( false );
+		setReaderSuggestions( [ readerSuggestion ] );
+		const getEmptyViewSuggestions = jest.fn( () => [ bigSkySuggestion ] );
+		const loadedProviders = { getEmptyViewSuggestions } as unknown as LoadedProviders;
+
+		const { result } = renderHook( () => useEmptyViewSuggestions( { loadedProviders } ) );
+
+		await waitFor( () => expect( result.current ).toEqual( [ readerSuggestion ] ) );
+		expect( getEmptyViewSuggestions ).not.toHaveBeenCalled();
+	} );
+
+	it( 'keeps an empty Reader Chat override as an explicit no-suggestions state', async () => {
+		mockCoreStoreReady( false );
+		setReaderSuggestions( [] );
+		const getEmptyViewSuggestions = jest.fn( () => [ bigSkySuggestion ] );
+		const loadedProviders = { getEmptyViewSuggestions } as unknown as LoadedProviders;
+
+		const { result } = renderHook( () => useEmptyViewSuggestions( { loadedProviders } ) );
+
+		await waitFor( () => expect( result.current ).toEqual( [] ) );
+		expect( getEmptyViewSuggestions ).not.toHaveBeenCalled();
+	} );
+
+	it( 'filters malformed Reader Chat override items', async () => {
+		mockCoreStoreReady( false );
+		setReaderSuggestions( [
+			{ id: 'bad-label', label: 123, prompt: 'Prompt must not be enough.' },
+			{ id: 'bad-prompt', label: 'Label must not be enough.', prompt: null },
+			readerSuggestion,
+		] );
+		const getEmptyViewSuggestions = jest.fn( () => [ bigSkySuggestion ] );
+		const loadedProviders = { getEmptyViewSuggestions } as unknown as LoadedProviders;
+
+		const { result } = renderHook( () => useEmptyViewSuggestions( { loadedProviders } ) );
+
+		await waitFor( () => expect( result.current ).toEqual( [ readerSuggestion ] ) );
+		expect( getEmptyViewSuggestions ).not.toHaveBeenCalled();
+	} );
+
+	it( 'filters site-editor-only provider suggestions outside Site Editor', async () => {
+		const getEmptyViewSuggestions = jest.fn( () => [ siteEditorSuggestion, bigSkySuggestion ] );
+		const loadedProviders = { getEmptyViewSuggestions } as unknown as LoadedProviders;
+
+		const { result } = renderHook( () => useEmptyViewSuggestions( { loadedProviders } ) );
+
+		await waitFor( () => expect( result.current ).toEqual( [ bigSkySuggestion ] ) );
+	} );
+
+	it( 'returns no provider suggestions when all suggestions are site-editor-only outside Site Editor', async () => {
+		const getEmptyViewSuggestions = jest.fn( () => [ siteEditorSuggestion ] );
+		const loadedProviders = { getEmptyViewSuggestions } as unknown as LoadedProviders;
+
+		const { result } = renderHook( () => useEmptyViewSuggestions( { loadedProviders } ) );
+
+		await waitFor( () => expect( result.current ).toEqual( [] ) );
+	} );
+
+	it( 'filters site-editor-only provider suggestions in the post editor even if section is misreported', async () => {
+		mockContext = {
+			sectionName: 'site-editor',
+			currentRoute: '/wp-admin/post.php?post=1&action=edit',
+		};
+		const getEmptyViewSuggestions = jest.fn( () => [ siteEditorSuggestion ] );
+		const loadedProviders = { getEmptyViewSuggestions } as unknown as LoadedProviders;
+
+		const { result } = renderHook( () => useEmptyViewSuggestions( { loadedProviders } ) );
+
+		await waitFor( () => expect( result.current ).toEqual( [] ) );
+	} );
+
+	it( 'keeps site-editor-only provider suggestions in Site Editor', async () => {
+		mockContext = {
+			sectionName: 'site-editor',
+			currentRoute: undefined,
+		};
+		const getEmptyViewSuggestions = jest.fn( () => [ siteEditorSuggestion, bigSkySuggestion ] );
+		const loadedProviders = { getEmptyViewSuggestions } as unknown as LoadedProviders;
+
+		const { result } = renderHook( () => useEmptyViewSuggestions( { loadedProviders } ) );
+
+		await waitFor( () =>
+			expect( result.current ).toEqual( [ siteEditorSuggestion, bigSkySuggestion ] )
+		);
+	} );
+} );

--- a/packages/agents-manager/src/hooks/use-conversation.ts
+++ b/packages/agents-manager/src/hooks/use-conversation.ts
@@ -3,7 +3,6 @@ import { useQuery } from '@tanstack/react-query';
 import { useEffect, useRef } from '@wordpress/element';
 import { API_BASE_URL } from '../constants';
 import { useAgentsManagerContext } from '../contexts';
-import { isFreshSession } from '../utils/agent-session';
 import { getConversationBotId } from '../utils/conversation-bot-id';
 import { isReaderChatAgent } from '../utils/is-reader-chat-agent';
 
@@ -53,11 +52,10 @@ export default function useConversation( {
 				true
 			);
 		},
-		// Skip server fetch for brand-new client-created sessions — they
-		// have no history to load and the extra round-trip blocks the
-		// skeleton unnecessarily.
-		enabled:
-			enabled && !! sessionId && ! ( isReaderChatAgent( agentId ) && isFreshSession( agentId ) ),
+		// Public Reader Chat does not expose conversation history, and the
+		// server-side history endpoint requires permissions public readers
+		// usually do not have.
+		enabled: enabled && !! sessionId && ! isReaderChatAgent( agentId ),
 		refetchOnWindowFocus: false,
 	} );
 

--- a/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
+++ b/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
@@ -2,12 +2,22 @@ import { type Suggestion } from '@automattic/agenttic-ui';
 import { useSelect } from '@wordpress/data';
 import { useEffect, useState, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { useAgentsManagerContext } from '../contexts';
 import { isReaderChatHost } from '../utils/is-reader-chat-agent';
 import type { LoadedProviders } from '../utils/load-external-providers';
 
 interface UseEmptyViewSuggestionsOptions {
 	loadedProviders: LoadedProviders | null;
 }
+
+const SITE_EDITOR_ONLY_SUGGESTION_IDS = new Set( [
+	'customize-colors',
+	'choose-new-fonts',
+	'change-page-layout',
+	'edit-pages',
+	'add-new-page',
+	'what-else-can-i-do',
+] );
 
 /**
  * Hook to manage empty view suggestions, handling Big Sky's theme-dependent suggestions
@@ -46,15 +56,69 @@ function readOverrideSuggestions(): Suggestion[] | null {
 	}
 	const valid = override.filter(
 		( s ): s is Suggestion =>
-			!! s && typeof s === 'object' && 'label' in s && 'prompt' in s && 'id' in s
+			!! s &&
+			typeof s === 'object' &&
+			'id' in s &&
+			'label' in s &&
+			'prompt' in s &&
+			typeof s.id === 'string' &&
+			typeof s.label === 'string' &&
+			typeof s.prompt === 'string'
 	);
 	return valid.length > 0 ? valid : null;
+}
+
+function getSuggestionsKey( suggestions: Suggestion[] | null ): string | null {
+	return suggestions
+		? JSON.stringify( suggestions.map( ( s ) => [ s.id, s.label, s.prompt ] ) )
+		: null;
+}
+
+function getWindowPathname(): string {
+	return typeof window !== 'undefined' ? window.location.pathname : '';
+}
+
+function isPostEditorSurface( sectionName: string, currentRoute?: string ): boolean {
+	const pathname = getWindowPathname();
+	return (
+		sectionName === 'gutenberg' ||
+		!! currentRoute?.includes( 'post.php' ) ||
+		!! currentRoute?.includes( 'post-new.php' ) ||
+		pathname.includes( 'post.php' ) ||
+		pathname.includes( 'post-new.php' )
+	);
+}
+
+function isSiteEditorSurface( sectionName: string, currentRoute?: string ): boolean {
+	if ( isPostEditorSurface( sectionName, currentRoute ) ) {
+		return false;
+	}
+
+	return (
+		sectionName === 'site-editor' ||
+		!! currentRoute?.includes( 'site-editor.php' ) ||
+		getWindowPathname().includes( 'site-editor.php' )
+	);
+}
+
+function filterEmptyViewSuggestions(
+	suggestions: Suggestion[],
+	shouldShowSiteEditorSuggestions: boolean
+): Suggestion[] {
+	if ( shouldShowSiteEditorSuggestions ) {
+		return suggestions;
+	}
+	return suggestions.filter(
+		( suggestion ) => ! SITE_EDITOR_ONLY_SUGGESTION_IDS.has( suggestion.id )
+	);
 }
 
 export function useEmptyViewSuggestions( {
 	loadedProviders,
 }: UseEmptyViewSuggestionsOptions ): Suggestion[] | null {
 	const isReaderChat = isReaderChatHost();
+	const { sectionName, currentRoute } = useAgentsManagerContext();
+	const shouldShowSiteEditorSuggestions = isSiteEditorSurface( sectionName, currentRoute );
 
 	// Default suggestions - used when Big Sky doesn't provide custom ones
 	const defaultSuggestions = useMemo(
@@ -121,25 +185,21 @@ export function useEmptyViewSuggestions( {
 	}, [ isReaderChat ] );
 
 	useEffect( () => {
-		if ( ! loadedProviders || ! isCoreStoreReady ) {
-			return;
-		}
-
-		// Re-read override on every effect run. We compare by JSON-identity
-		// against the current state so we only call setState when the
-		// override content actually changes — otherwise a fresh array
-		// reference every render would loop infinitely.
+		// Re-read override before the core-store readiness gate. Reader-chat
+		// suggestions come from the host page and do not depend on theme data.
+		// Compare against current state so a fresh override array does not
+		// trigger a render loop.
 		const currentOverride = readOverrideSuggestions();
-		if ( currentOverride ) {
-			const currentKey = JSON.stringify(
-				currentOverride.map( ( s ) => [ s.id, s.label, s.prompt ] )
-			);
-			const stateKey = emptyViewSuggestions
-				? JSON.stringify( emptyViewSuggestions.map( ( s ) => [ s.id, s.label, s.prompt ] ) )
-				: null;
+		if ( currentOverride !== null ) {
+			const currentKey = getSuggestionsKey( currentOverride );
+			const stateKey = getSuggestionsKey( emptyViewSuggestions );
 			if ( currentKey !== stateKey ) {
 				setEmptyViewSuggestions( currentOverride );
 			}
+			return;
+		}
+
+		if ( ! loadedProviders || ! isCoreStoreReady ) {
 			return;
 		}
 
@@ -152,9 +212,19 @@ export function useEmptyViewSuggestions( {
 			setEmptyViewSuggestions( defaultSuggestions );
 		} else {
 			// Big Sky provides suggestions and store is ready - get filtered suggestions
-			const suggestions = loadedProviders.getEmptyViewSuggestions?.();
-			if ( suggestions && suggestions.length > 0 ) {
+			const providerSuggestions = loadedProviders.getEmptyViewSuggestions?.() ?? [];
+			const suggestions = filterEmptyViewSuggestions(
+				providerSuggestions,
+				shouldShowSiteEditorSuggestions
+			);
+			if ( suggestions.length > 0 ) {
 				setEmptyViewSuggestions( suggestions );
+			} else if ( providerSuggestions.length > 0 ) {
+				// The provider returned suggestions, but all of them are hidden
+				// on this surface (for example Site Editor suggestions in the
+				// post editor). Keep the empty view empty instead of falling
+				// back to generic suggestions.
+				setEmptyViewSuggestions( [] );
 			} else {
 				// Provider exists but returned empty/undefined (e.g. lazy proxy
 				// race where the IIFE hasn't set window globals yet). Fall back
@@ -169,6 +239,7 @@ export function useEmptyViewSuggestions( {
 		defaultSuggestions,
 		emptyViewSuggestions,
 		overrideVersion,
+		shouldShowSiteEditorSuggestions,
 	] );
 
 	return emptyViewSuggestions;

--- a/packages/agents-manager/src/utils/__tests__/create-agent-config.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/create-agent-config.test.ts
@@ -73,4 +73,18 @@ describe( 'createAgentConfig', () => {
 			} )
 		);
 	} );
+
+	it( 'uses the Reader Chat host site ID when no site prop is available', async () => {
+		setAgentsManagerData( {
+			siteId: '247750866',
+		} );
+
+		const config = await createAgentConfig( {
+			sessionId: 'session-1',
+			agentId: 'reader-chat',
+		} );
+		const context = config.contextProvider?.getClientContext();
+
+		expect( context ).toEqual( expect.objectContaining( { selectedSiteId: 247750866 } ) );
+	} );
 } );

--- a/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
@@ -1,4 +1,15 @@
-import { mergeCapabilitiesInto, type ProviderCapabilities } from '../load-external-providers';
+/**
+ * @jest-environment jsdom
+ */
+import {
+	loadExternalProviders,
+	mergeCapabilitiesInto,
+	mergeUseSuggestionsHooks,
+} from '../load-external-providers';
+import type {
+	ProviderCapabilities,
+	UseSuggestionsHook,
+} from '../load-external-providers';
 
 describe( 'mergeCapabilitiesInto', () => {
 	it( 'is a no-op when capabilities is undefined', () => {
@@ -57,5 +68,69 @@ describe( 'mergeCapabilitiesInto', () => {
 		const merged: ProviderCapabilities = {};
 		mergeCapabilitiesInto( merged, lazyCapabilities );
 		expect( merged.supportsSplitScreen ).toBe( true );
+	} );
+} );
+
+describe( 'loadExternalProviders', () => {
+	afterEach( () => {
+		delete ( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData;
+		delete ( window as typeof window & { agentsManagerData?: unknown } ).agentsManagerData;
+	} );
+
+	it( 'does not merge external editor providers into Reader Chat', async () => {
+		const agentsManagerData = {
+			agentId: 'reader-chat',
+			agentProviders: [ 'https://widgets.wp.com/agents-manager/jetpack-ai-sidebar.provider.mjs' ],
+		};
+		( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData =
+			agentsManagerData;
+		( window as typeof window & { agentsManagerData?: unknown } ).agentsManagerData =
+			agentsManagerData;
+
+		const providers = await loadExternalProviders();
+
+		expect( providers.toolProvider ).toBeUndefined();
+		expect( providers.contextProvider ).toBeUndefined();
+		expect( providers.useSuggestions ).toEqual( expect.any( Function ) );
+	} );
+} );
+
+describe( 'mergeUseSuggestionsHooks', () => {
+	it( 'treats undefined provider hook results as no suggestions', () => {
+		const undefinedHook = jest.fn( () => undefined ) as UseSuggestionsHook;
+		const suggestionsHook = jest.fn( () => ( {
+			suggestions: [ { id: 'reader-followup', label: 'Follow up', prompt: 'Follow up on this.' } ],
+		} ) ) as UseSuggestionsHook;
+
+		const merged = mergeUseSuggestionsHooks( [ undefinedHook, suggestionsHook ] );
+
+		expect( merged?.() ).toEqual( {
+			suggestions: [ { id: 'reader-followup', label: 'Follow up', prompt: 'Follow up on this.' } ],
+		} );
+	} );
+
+	it( 'dedupes suggestions by id when multiple providers return suggestions', () => {
+		const firstHook = jest.fn( () => ( {
+			suggestions: [
+				{ id: 'shared', label: 'First shared', prompt: 'First shared prompt.' },
+				{ id: 'first-only', label: 'First only', prompt: 'First only prompt.' },
+			],
+		} ) ) as UseSuggestionsHook;
+		const secondHook = jest.fn( () => ( {
+			suggestions: [
+				{ id: 'shared', label: 'Second shared', prompt: 'Second shared prompt.' },
+				{ id: 'second-only', label: 'Second only', prompt: 'Second only prompt.' },
+			],
+		} ) ) as UseSuggestionsHook;
+
+		const merged = mergeUseSuggestionsHooks( [ firstHook, secondHook ] );
+
+		expect( merged?.() ).toEqual( {
+			suggestions: [
+				{ id: 'shared', label: 'First shared', prompt: 'First shared prompt.' },
+				{ id: 'first-only', label: 'First only', prompt: 'First only prompt.' },
+				{ id: 'second-only', label: 'Second only', prompt: 'Second only prompt.' },
+			],
+		} );
 	} );
 } );

--- a/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
@@ -6,10 +6,7 @@ import {
 	mergeCapabilitiesInto,
 	mergeUseSuggestionsHooks,
 } from '../load-external-providers';
-import type {
-	ProviderCapabilities,
-	UseSuggestionsHook,
-} from '../load-external-providers';
+import type { ProviderCapabilities, UseSuggestionsHook } from '../load-external-providers';
 
 describe( 'mergeCapabilitiesInto', () => {
 	it( 'is a no-op when capabilities is undefined', () => {

--- a/packages/agents-manager/src/utils/__tests__/reader-followup-hook.test.tsx
+++ b/packages/agents-manager/src/utils/__tests__/reader-followup-hook.test.tsx
@@ -19,6 +19,10 @@ type FollowupWindow = Window & {
 	__jetpackReaderFollowupChips?: Array< { id: string; label: string; prompt?: string } >;
 };
 
+function getSuggestions( result: { current: ReturnType< typeof useReaderFollowupSuggestions > } ) {
+	return result.current?.suggestions ?? [];
+}
+
 describe( 'useReaderFollowupSuggestions', () => {
 	afterEach( () => {
 		// Clean up global state between tests.
@@ -30,7 +34,7 @@ describe( 'useReaderFollowupSuggestions', () => {
 
 		const { result } = renderHook( () => useReaderFollowupSuggestions() );
 
-		expect( result.current.suggestions ).toEqual( [] );
+		expect( getSuggestions( result ) ).toEqual( [] );
 	} );
 
 	it( 'returns existing chips on mount when the global is already populated', () => {
@@ -42,7 +46,7 @@ describe( 'useReaderFollowupSuggestions', () => {
 
 		const { result } = renderHook( () => useReaderFollowupSuggestions() );
 
-		expect( result.current.suggestions ).toEqual( chips );
+		expect( getSuggestions( result ) ).toEqual( chips );
 	} );
 
 	it( 'updates state when the `reader-chat-followups-updated` event fires', () => {
@@ -50,7 +54,7 @@ describe( 'useReaderFollowupSuggestions', () => {
 
 		const { result } = renderHook( () => useReaderFollowupSuggestions() );
 
-		expect( result.current.suggestions ).toEqual( [] );
+		expect( getSuggestions( result ) ).toEqual( [] );
 
 		const newChips = [ { id: 'followup-1', label: 'Go deeper', prompt: 'Expand on this.' } ];
 
@@ -59,7 +63,7 @@ describe( 'useReaderFollowupSuggestions', () => {
 			window.dispatchEvent( new Event( 'reader-chat-followups-updated' ) );
 		} );
 
-		expect( result.current.suggestions ).toEqual( newChips );
+		expect( getSuggestions( result ) ).toEqual( newChips );
 	} );
 
 	it( 'removes the event listener on unmount', () => {
@@ -88,13 +92,13 @@ describe( 'useReaderFollowupSuggestions', () => {
 			window.dispatchEvent( new Event( 'reader-chat-followups-updated' ) );
 		} );
 
-		expect( result.current.suggestions ).toEqual( first );
+		expect( getSuggestions( result ) ).toEqual( first );
 
 		act( () => {
 			( window as FollowupWindow ).__jetpackReaderFollowupChips = second;
 			window.dispatchEvent( new Event( 'reader-chat-followups-updated' ) );
 		} );
 
-		expect( result.current.suggestions ).toEqual( second );
+		expect( getSuggestions( result ) ).toEqual( second );
 	} );
 } );

--- a/packages/agents-manager/src/utils/create-agent-config.ts
+++ b/packages/agents-manager/src/utils/create-agent-config.ts
@@ -87,6 +87,11 @@ async function canAccessZendeskForAgent( agentId?: string ): Promise< boolean > 
 	return canConnectToZendesk();
 }
 
+function normalizeSiteId( siteId: unknown ): number | undefined {
+	const numericSiteId = Number( siteId );
+	return Number.isFinite( numericSiteId ) && numericSiteId > 0 ? numericSiteId : undefined;
+}
+
 /**
  * Create a context provider that resolves context entries.
  */
@@ -99,6 +104,7 @@ async function createWrappedContextProvider(
 	const canAccessZendesk = await canAccessZendeskForAgent( agentId );
 	return {
 		getClientContext: () => {
+			const resolvedSiteId = normalizeSiteId( siteId );
 			const pluginContext = contextProvider.getClientContext();
 
 			let resolvedContext = pluginContext.contextEntries?.length
@@ -125,7 +131,8 @@ async function createWrappedContextProvider(
 				currentScreen: resolvedContext.currentScreen || {
 					url: window.location.href,
 				},
-				...( siteId && ! resolvedContext.selectedSiteId && { selectedSiteId: siteId } ),
+				...( resolvedSiteId &&
+					! resolvedContext.selectedSiteId && { selectedSiteId: resolvedSiteId } ),
 				constructorArguments: {
 					...( resolvedContext.constructorArguments || {} ),
 					...( version && { version } ),
@@ -157,6 +164,7 @@ async function createDefaultContextProvider(
 				? ( window as unknown as { agentsManagerData?: Record< string, unknown > } )
 						.agentsManagerData ?? {}
 				: {};
+			const resolvedSiteId = normalizeSiteId( siteId ?? hostData.siteId );
 
 			const externalEntries = getExternalContextEntries();
 			const contextEntries = externalEntries.length
@@ -171,7 +179,7 @@ async function createDefaultContextProvider(
 				environment,
 				// Match Odie's context shape so the server can read current_screen.url
 				currentScreen: { url: window.location.href },
-				...( siteId && { selectedSiteId: siteId } ),
+				...( resolvedSiteId && { selectedSiteId: resolvedSiteId } ),
 				...( hostData.currentPost ? { currentPost: hostData.currentPost } : {} ),
 				...( hostData.siteName ? { siteName: hostData.siteName } : {} ),
 				...( hostData.siteUrl ? { siteUrl: hostData.siteUrl } : {} ),

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -72,7 +72,7 @@ export type AbilitiesSetupHook = ( actions: {
  */
 export type UseSuggestionsHook = ( maxSuggestions?: number ) => {
 	suggestions: Suggestion[];
-};
+} | void;
 
 export type SiteBuildUtils = {
 	hasSiteBuildMessages: ( messages: UIMessage[] ) => boolean;
@@ -161,6 +161,33 @@ export interface LoadedProviders {
 	capabilities?: ProviderCapabilities;
 }
 
+export function mergeUseSuggestionsHooks(
+	hooks: UseSuggestionsHook[]
+): UseSuggestionsHook | undefined {
+	if ( hooks.length === 0 ) {
+		return undefined;
+	}
+
+	if ( hooks.length === 1 ) {
+		return hooks[ 0 ];
+	}
+
+	return ( maxSuggestions?: number ) => {
+		const combined: Suggestion[] = [];
+		const seenIds = new Set< string >();
+		for ( const hook of hooks ) {
+			const suggestions = hook( maxSuggestions )?.suggestions ?? [];
+			for ( const s of suggestions ) {
+				if ( ! seenIds.has( s.id ) ) {
+					seenIds.add( s.id );
+					combined.push( s );
+				}
+			}
+		}
+		return { suggestions: combined };
+	};
+}
+
 /**
  * Load external agent providers from agentsManagerData.agentProviders.
  *
@@ -183,11 +210,14 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 				?.agentId
 		);
 
+	if ( registerReaderFollowups ) {
+		// Reader Chat runs on the public frontend and should not inherit editor providers
+		// such as the Jetpack AI sidebar.
+		return { useSuggestions: useReaderFollowupSuggestions };
+	}
+
 	if ( agentProviders.length === 0 ) {
-		// Even with no external agentProviders, register the reader-chat
-		// follow-up hook if this host is reader-chat. Previously this path
-		// early-returned an empty object, so the hook never registered.
-		return registerReaderFollowups ? { useSuggestions: useReaderFollowupSuggestions } : {};
+		return {};
 	}
 
 	let mergedToolProvider: ToolProvider | undefined;
@@ -198,7 +228,6 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 	let mergedNavigationContinuation: NavigationContinuationHook | undefined;
 	let mergedAbilitiesSetup: AbilitiesSetupHook | undefined;
 	let mergedGetChatComponent: GetChatComponent | undefined;
-	let mergedUseSuggestions: UseSuggestionsHook | undefined;
 	let mergedSiteBuildUtils: SiteBuildUtils | undefined;
 	let mergedImageUpload: ImageUploadHook | undefined;
 	let mergedUseCheckpoint: UseCheckpointHook | undefined;
@@ -211,12 +240,6 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 	const allAbilitiesSetups: AbilitiesSetupHook[] = [];
 	const allUseSuggestions: UseSuggestionsHook[] = [];
 	const allGetEmptyViewSuggestions: ( () => Suggestion[] )[] = [];
-
-	// Also add reader-chat hook to the merge path when there ARE other
-	// providers.
-	if ( registerReaderFollowups ) {
-		allUseSuggestions.push( useReaderFollowupSuggestions );
-	}
 
 	// Load all providers in parallel to avoid serializing network/module fetches.
 	// Results are processed in registration order to preserve first-write-wins semantics.
@@ -371,24 +394,7 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 	}
 
 	// Merge useSuggestions: combine from all providers, dedupe by id.
-	if ( allUseSuggestions.length === 1 ) {
-		mergedUseSuggestions = allUseSuggestions[ 0 ];
-	} else if ( allUseSuggestions.length > 1 ) {
-		mergedUseSuggestions = ( ( maxSuggestions?: number ) => {
-			const combined: Suggestion[] = [];
-			const seenIds = new Set< string >();
-			for ( const hook of allUseSuggestions ) {
-				const { suggestions } = hook( maxSuggestions );
-				for ( const s of suggestions ) {
-					if ( ! seenIds.has( s.id ) ) {
-						seenIds.add( s.id );
-						combined.push( s );
-					}
-				}
-			}
-			return { suggestions: combined };
-		} ) as UseSuggestionsHook;
-	}
+	const mergedUseSuggestions = mergeUseSuggestionsHooks( allUseSuggestions );
 
 	// Merge getEmptyViewSuggestions: combine from all providers, dedupe by id.
 	if ( allGetEmptyViewSuggestions.length === 1 ) {


### PR DESCRIPTION
Stacked on #110225. Split from #110024; the original PR ~~stays open~~ is closed.

## Summary
- Adds the self-contained public `reader-chat` Agents Manager bundle.
- Adds Reader Chat frontend setup for page context, initial suggestions, follow-up suggestions, Tracks events, launcher fallback, and scoped style resets.
- Adds the reader-specific webpack entry and stubs non-reader routes out of the public bundle.

<img width="1461" height="1533" alt="image" src="https://github.com/user-attachments/assets/fd3cdd6c-b55a-400d-88ea-54d076b082b1" />


## Test Plan
- `yarn jest apps/agents-manager/__tests__/reader-chat.test.js --runInBand`

## Steps to test
1. Install Jetpack PR `bin/jetpack-downloader test jetpack add/jetpack-reader-chat`
2. Install wp-calypso PR `install-plugin.sh am add/reader-chat-public-bundle`
3. Go to Jetpack Search > Upgrade > Enable Reader Chat
4. Optional: Set Guidelines > Additional > to set chat voice
5. Go to your site and you should see the Chat widget
6. Initial prompts should show and should be relevant to your site/blog
7. Follow-up prompts should show after succeeding messages