### PR TITLE
Reader ATmosphere: Bluesky timeline frontend (slice 4)

### DIFF
--- a/client/reader/atmosphere/atmosphere-account-view.tsx
+++ b/client/reader/atmosphere/atmosphere-account-view.tsx
@@ -74,7 +74,7 @@ function renderTab( slug: string, connection: AtmosphereConnection ) {
 			return <SettingsPanel />;
 		case TIMELINE_TAB:
 		default:
-			return <TimelinePanel />;
+			return <TimelinePanel connection={ connection } />;
 	}
 }
 

--- a/client/reader/atmosphere/connect-form.tsx
+++ b/client/reader/atmosphere/connect-form.tsx
@@ -80,7 +80,9 @@ function errorMessage(
 		case 'upstream_unavailable':
 			return translate( 'Bluesky is unreachable right now.' );
 		case 'auth_failed':
+		case 'auth_required':
 		case 'connection_not_found':
+		case 'not_found':
 		case 'bad_request':
 		case 'unknown':
 			return translate( 'Something went wrong.' );

--- a/client/reader/atmosphere/test/atmosphere-account-view.test.tsx
+++ b/client/reader/atmosphere/test/atmosphere-account-view.test.tsx
@@ -18,6 +18,13 @@ jest.mock(
 		}
 );
 
+// recordReaderTracksEvent is a thunk that reads state.reader.follows. The test
+// store from renderWithProvider does not provide that slice. Replace it with a
+// no-op action creator so dispatch() does not throw.
+jest.mock( 'calypso/state/reader/analytics/actions', () => ( {
+	recordReaderTracksEvent: () => ( { type: '@@TEST/NOOP' } ),
+} ) );
+
 jest.mock( 'calypso/components/data/document-head', () => () => null );
 
 jest.mock( '@automattic/calypso-router', () => {

--- a/client/reader/atmosphere/test/timeline-panel.test.tsx
+++ b/client/reader/atmosphere/test/timeline-panel.test.tsx
@@ -154,4 +154,101 @@ describe( 'TimelinePanel', () => {
 			expect.objectContaining( { connection_id: 42, error_kind: 'upstream_unavailable' } )
 		);
 	} );
+
+	it( 'fires post_clicked when the timestamp anchor is clicked', async () => {
+		const spy = analytics.recordReaderTracksEvent as unknown as jest.Mock;
+		nock( BASE )
+			.get( PATH )
+			.query( {} )
+			.reply( 200, { feed: [ makePost( 'at://abc', 'hello' ) ], cursor: null } );
+		const user = userEvent.setup();
+		renderWithProvider( <TimelinePanel connection={ connection } />, {
+			queryClient: makeQueryClient(),
+		} );
+		await waitFor( () => expect( screen.getByText( 'hello' ) ).toBeVisible() );
+		const link = screen
+			.getAllByRole( 'link' )
+			.find(
+				( a ) => a.getAttribute( 'href' ) === 'https://bsky.app/profile/alice.bsky.social/post/x'
+			);
+		expect( link ).toBeDefined();
+		await user.click( link as HTMLElement );
+		expect( spy ).toHaveBeenCalledWith(
+			'calypso_reader_atmosphere_timeline_post_clicked',
+			expect.objectContaining( { connection_id: 42, post_uri: 'at://abc' } )
+		);
+	} );
+
+	it( 'fires author_clicked when the author anchor is clicked', async () => {
+		const spy = analytics.recordReaderTracksEvent as unknown as jest.Mock;
+		nock( BASE )
+			.get( PATH )
+			.query( {} )
+			.reply( 200, { feed: [ makePost( 'at://abc', 'hi' ) ], cursor: null } );
+		const user = userEvent.setup();
+		renderWithProvider( <TimelinePanel connection={ connection } />, {
+			queryClient: makeQueryClient(),
+		} );
+		await waitFor( () => expect( screen.getByText( 'hi' ) ).toBeVisible() );
+		await user.click( screen.getByRole( 'link', { name: /alice/i } ) );
+		expect( spy ).toHaveBeenCalledWith(
+			'calypso_reader_atmosphere_timeline_author_clicked',
+			expect.objectContaining( { connection_id: 42, author_handle: 'alice.bsky.social' } )
+		);
+	} );
+
+	it( 'fires external_clicked when an external embed is clicked', async () => {
+		const spy = analytics.recordReaderTracksEvent as unknown as jest.Mock;
+		const post = makePost( 'at://abc', 'with link' );
+		( post as unknown as { embed: unknown } ).embed = {
+			type: 'external',
+			uri: 'https://example.com/article',
+			title: 'T',
+			description: 'D',
+			thumb: null,
+		};
+		nock( BASE )
+			.get( PATH )
+			.query( {} )
+			.reply( 200, { feed: [ post ], cursor: null } );
+		const user = userEvent.setup();
+		renderWithProvider( <TimelinePanel connection={ connection } />, {
+			queryClient: makeQueryClient(),
+		} );
+		await waitFor( () => expect( screen.getByText( 'T' ) ).toBeVisible() );
+		await user.click( screen.getByText( 'T' ) );
+		expect( spy ).toHaveBeenCalledWith(
+			'calypso_reader_atmosphere_timeline_external_clicked',
+			expect.objectContaining( {
+				connection_id: 42,
+				post_uri: 'at://abc',
+				external_uri: 'https://example.com/article',
+			} )
+		);
+	} );
+
+	it( 'fires quote_clicked when a live quote embed is clicked', async () => {
+		const spy = analytics.recordReaderTracksEvent as unknown as jest.Mock;
+		const inner = makePost( 'at://quoted', 'inner text' );
+		const outer = makePost( 'at://abc', 'outer' );
+		( outer as unknown as { embed: unknown } ).embed = { type: 'quote', post: inner };
+		nock( BASE )
+			.get( PATH )
+			.query( {} )
+			.reply( 200, { feed: [ outer ], cursor: null } );
+		const user = userEvent.setup();
+		renderWithProvider( <TimelinePanel connection={ connection } />, {
+			queryClient: makeQueryClient(),
+		} );
+		await waitFor( () => expect( screen.getByText( 'inner text' ) ).toBeVisible() );
+		await user.click( screen.getByText( 'inner text' ) );
+		expect( spy ).toHaveBeenCalledWith(
+			'calypso_reader_atmosphere_timeline_quote_clicked',
+			expect.objectContaining( {
+				connection_id: 42,
+				parent_uri: 'at://abc',
+				quoted_uri: 'at://quoted',
+			} )
+		);
+	} );
 } );

--- a/client/reader/atmosphere/test/timeline-panel.test.tsx
+++ b/client/reader/atmosphere/test/timeline-panel.test.tsx
@@ -1,13 +1,157 @@
 /**
  * @jest-environment jsdom
  */
-import { render, screen } from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { mockAllIsIntersecting } from 'react-intersection-observer/test-utils';
+import * as analytics from 'calypso/state/reader/analytics/actions';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { TimelinePanel } from '../timeline-panel';
+import type { AtmosphereConnection } from '@automattic/api-core';
+
+const connection: AtmosphereConnection = {
+	id: 42,
+	did: 'did:plc:abc',
+	handle: 'alice.bsky.social',
+	display_name: 'Alice',
+	avatar: null,
+};
+
+const BASE = 'https://public-api.wordpress.com';
+const PATH = '/wpcom/v2/reader/atmosphere/connections/42/timeline';
+
+function makePost( uri: string, text = 'hello' ) {
+	return {
+		uri,
+		cid: 'c',
+		author: {
+			did: 'did:plc:abc',
+			handle: 'alice.bsky.social',
+			display_name: 'Alice',
+			avatar: null,
+		},
+		created_at: '2026-04-27T10:00:00Z',
+		indexed_at: '2026-04-27T10:00:00Z',
+		text,
+		html: `<p>${ text }</p>`,
+		lang: [],
+		reply_parent: null,
+		reply_root: null,
+		reason: null,
+		embed: null,
+		counts: { replies: 0, reposts: 0, likes: 0, quotes: 0 },
+		bluesky_url: 'https://bsky.app/profile/alice.bsky.social/post/x',
+	};
+}
+
+function makeQueryClient() {
+	return new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+}
 
 describe( 'TimelinePanel', () => {
-	it( 'renders the coming-soon placeholder text', () => {
-		render( <TimelinePanel /> );
-		expect( screen.getByRole( 'heading', { name: /timeline/i } ) ).toBeVisible();
-		expect( screen.getByText( /still building this part/i ) ).toBeVisible();
+	beforeEach( () => {
+		// recordReaderTracksEvent is a thunk that reads state.reader.follows.
+		// Replace it with a no-op action creator so dispatch() doesn't throw,
+		// while still letting spies observe call-site arguments.
+		jest
+			.spyOn( analytics, 'recordReaderTracksEvent' )
+			.mockImplementation( () => ( { type: '@@TEST/NOOP' } ) as never );
+	} );
+
+	afterEach( () => {
+		nock.cleanAll();
+		jest.restoreAllMocks();
+	} );
+
+	it( 'renders the skeleton, then the first page of posts', async () => {
+		nock( BASE )
+			.get( PATH )
+			.query( {} )
+			.reply( 200, { feed: [ makePost( 'at://x', 'first post' ) ], cursor: null } );
+
+		const { container } = renderWithProvider( <TimelinePanel connection={ connection } />, {
+			queryClient: makeQueryClient(),
+		} );
+		expect(
+			container.querySelectorAll( '.social-feed-list-skeleton__row' ).length
+		).toBeGreaterThan( 0 );
+		await waitFor( () => expect( screen.getByText( 'first post' ) ).toBeVisible() );
+	} );
+
+	it( 'fires the timeline_viewed Tracks event on mount', async () => {
+		const spy = analytics.recordReaderTracksEvent as unknown as jest.Mock;
+		nock( BASE ).get( PATH ).query( {} ).reply( 200, { feed: [], cursor: null } );
+
+		renderWithProvider( <TimelinePanel connection={ connection } />, {
+			queryClient: makeQueryClient(),
+		} );
+		await waitFor( () =>
+			expect( spy ).toHaveBeenCalledWith(
+				'calypso_reader_atmosphere_timeline_viewed',
+				expect.objectContaining( { connection_id: 42 } )
+			)
+		);
+	} );
+
+	it( 'renders the empty state when feed is []', async () => {
+		nock( BASE ).get( PATH ).query( {} ).reply( 200, { feed: [], cursor: null } );
+
+		renderWithProvider( <TimelinePanel connection={ connection } />, {
+			queryClient: makeQueryClient(),
+		} );
+		await waitFor( () =>
+			expect( screen.getAllByText( /caught up/i ).length ).toBeGreaterThan( 0 )
+		);
+	} );
+
+	it( 'paginates when sentinel comes into view', async () => {
+		nock( BASE )
+			.get( PATH )
+			.query( {} )
+			.reply( 200, { feed: [ makePost( 'at://1', 'first' ) ], cursor: 'next' } );
+		nock( BASE )
+			.get( PATH )
+			.query( { cursor: 'next' } )
+			.reply( 200, { feed: [ makePost( 'at://2', 'second' ) ], cursor: null } );
+
+		renderWithProvider( <TimelinePanel connection={ connection } />, {
+			queryClient: makeQueryClient(),
+		} );
+		await waitFor( () => expect( screen.getByText( 'first' ) ).toBeVisible() );
+		mockAllIsIntersecting( true );
+		await waitFor( () => expect( screen.getByText( 'second' ) ).toBeVisible() );
+	} );
+
+	it( 'fires error_shown on upstream_unavailable + recovers via Retry', async () => {
+		const spy = analytics.recordReaderTracksEvent as unknown as jest.Mock;
+		nock( BASE )
+			.get( PATH )
+			.query( {} )
+			.reply( 502, { error: 'atmosphere_upstream_unavailable', message: 'down' } );
+
+		const user = userEvent.setup();
+		renderWithProvider( <TimelinePanel connection={ connection } />, {
+			queryClient: makeQueryClient(),
+		} );
+		await waitFor( () =>
+			expect( screen.getAllByText( /unreachable/i ).length ).toBeGreaterThan( 0 )
+		);
+		expect( spy ).toHaveBeenCalledWith(
+			'calypso_reader_atmosphere_timeline_error_shown',
+			expect.objectContaining( { connection_id: 42, error_kind: 'upstream_unavailable' } )
+		);
+
+		nock( BASE )
+			.get( PATH )
+			.query( {} )
+			.reply( 200, { feed: [ makePost( 'at://x', 'recovered' ) ], cursor: null } );
+		await user.click( screen.getByRole( 'button', { name: /retry/i } ) );
+		await waitFor( () => expect( screen.getByText( 'recovered' ) ).toBeVisible() );
+		expect( spy ).toHaveBeenCalledWith(
+			'calypso_reader_atmosphere_timeline_retry_clicked',
+			expect.objectContaining( { connection_id: 42, error_kind: 'upstream_unavailable' } )
+		);
 	} );
 } );

--- a/client/reader/atmosphere/test/timeline-panel.test.tsx
+++ b/client/reader/atmosphere/test/timeline-panel.test.tsx
@@ -69,7 +69,7 @@ describe( 'TimelinePanel', () => {
 		nock( BASE )
 			.get( PATH )
 			.query( {} )
-			.reply( 200, { feed: [ makePost( 'at://x', 'first post' ) ], cursor: null } );
+			.reply( 200, { items: [ makePost( 'at://x', 'first post' ) ], cursor: null } );
 
 		const { container } = renderWithProvider( <TimelinePanel connection={ connection } />, {
 			queryClient: makeQueryClient(),
@@ -82,7 +82,7 @@ describe( 'TimelinePanel', () => {
 
 	it( 'fires the timeline_viewed Tracks event on mount', async () => {
 		const spy = analytics.recordReaderTracksEvent as unknown as jest.Mock;
-		nock( BASE ).get( PATH ).query( {} ).reply( 200, { feed: [], cursor: null } );
+		nock( BASE ).get( PATH ).query( {} ).reply( 200, { items: [], cursor: null } );
 
 		renderWithProvider( <TimelinePanel connection={ connection } />, {
 			queryClient: makeQueryClient(),
@@ -96,7 +96,7 @@ describe( 'TimelinePanel', () => {
 	} );
 
 	it( 'renders the empty state when feed is []', async () => {
-		nock( BASE ).get( PATH ).query( {} ).reply( 200, { feed: [], cursor: null } );
+		nock( BASE ).get( PATH ).query( {} ).reply( 200, { items: [], cursor: null } );
 
 		renderWithProvider( <TimelinePanel connection={ connection } />, {
 			queryClient: makeQueryClient(),
@@ -110,11 +110,11 @@ describe( 'TimelinePanel', () => {
 		nock( BASE )
 			.get( PATH )
 			.query( {} )
-			.reply( 200, { feed: [ makePost( 'at://1', 'first' ) ], cursor: 'next' } );
+			.reply( 200, { items: [ makePost( 'at://1', 'first' ) ], cursor: 'next' } );
 		nock( BASE )
 			.get( PATH )
 			.query( { cursor: 'next' } )
-			.reply( 200, { feed: [ makePost( 'at://2', 'second' ) ], cursor: null } );
+			.reply( 200, { items: [ makePost( 'at://2', 'second' ) ], cursor: null } );
 
 		renderWithProvider( <TimelinePanel connection={ connection } />, {
 			queryClient: makeQueryClient(),
@@ -146,7 +146,7 @@ describe( 'TimelinePanel', () => {
 		nock( BASE )
 			.get( PATH )
 			.query( {} )
-			.reply( 200, { feed: [ makePost( 'at://x', 'recovered' ) ], cursor: null } );
+			.reply( 200, { items: [ makePost( 'at://x', 'recovered' ) ], cursor: null } );
 		await user.click( screen.getByRole( 'button', { name: /retry/i } ) );
 		await waitFor( () => expect( screen.getByText( 'recovered' ) ).toBeVisible() );
 		expect( spy ).toHaveBeenCalledWith(
@@ -160,7 +160,7 @@ describe( 'TimelinePanel', () => {
 		nock( BASE )
 			.get( PATH )
 			.query( {} )
-			.reply( 200, { feed: [ makePost( 'at://abc', 'hello' ) ], cursor: null } );
+			.reply( 200, { items: [ makePost( 'at://abc', 'hello' ) ], cursor: null } );
 		const user = userEvent.setup();
 		renderWithProvider( <TimelinePanel connection={ connection } />, {
 			queryClient: makeQueryClient(),
@@ -184,7 +184,7 @@ describe( 'TimelinePanel', () => {
 		nock( BASE )
 			.get( PATH )
 			.query( {} )
-			.reply( 200, { feed: [ makePost( 'at://abc', 'hi' ) ], cursor: null } );
+			.reply( 200, { items: [ makePost( 'at://abc', 'hi' ) ], cursor: null } );
 		const user = userEvent.setup();
 		renderWithProvider( <TimelinePanel connection={ connection } />, {
 			queryClient: makeQueryClient(),
@@ -210,7 +210,7 @@ describe( 'TimelinePanel', () => {
 		nock( BASE )
 			.get( PATH )
 			.query( {} )
-			.reply( 200, { feed: [ post ], cursor: null } );
+			.reply( 200, { items: [ post ], cursor: null } );
 		const user = userEvent.setup();
 		renderWithProvider( <TimelinePanel connection={ connection } />, {
 			queryClient: makeQueryClient(),
@@ -235,7 +235,7 @@ describe( 'TimelinePanel', () => {
 		nock( BASE )
 			.get( PATH )
 			.query( {} )
-			.reply( 200, { feed: [ outer ], cursor: null } );
+			.reply( 200, { items: [ outer ], cursor: null } );
 		const user = userEvent.setup();
 		renderWithProvider( <TimelinePanel connection={ connection } />, {
 			queryClient: makeQueryClient(),

--- a/client/reader/atmosphere/timeline-panel.tsx
+++ b/client/reader/atmosphere/timeline-panel.tsx
@@ -2,10 +2,13 @@ import { useTimelineInfiniteQuery } from '@automattic/api-queries';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useDispatch } from 'react-redux';
+import { UnknownAction } from 'redux';
+import { ThunkDispatch } from 'redux-thunk';
 import { SocialFeedList, SocialPostCard } from 'calypso/reader/social';
 import { SocialAnalyticsProvider } from 'calypso/reader/social/components/post-card/analytics-context';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import type { AtmosphereConnection, AtmosphereFeedItem } from '@automattic/api-core';
+import type { AppState } from 'calypso/types';
 
 interface TimelinePanelProps {
 	connection: AtmosphereConnection;
@@ -13,7 +16,7 @@ interface TimelinePanelProps {
 
 export function TimelinePanel( { connection }: TimelinePanelProps ) {
 	const translate = useTranslate();
-	const dispatch = useDispatch();
+	const dispatch = useDispatch< ThunkDispatch< AppState, void, UnknownAction > >();
 	const lastErrorKind = useRef< string | null >( null );
 
 	const {

--- a/client/reader/atmosphere/timeline-panel.tsx
+++ b/client/reader/atmosphere/timeline-panel.tsx
@@ -72,6 +72,12 @@ export function TimelinePanel( { connection }: TimelinePanelProps ) {
 		[ dispatch ]
 	);
 
+	const renderItem = useCallback(
+		( post: AtmosphereFeedItem ) => <SocialPostCard post={ post } variant="default" />,
+		[]
+	);
+	const itemKey = useCallback( ( post: AtmosphereFeedItem ) => post.uri, [] );
+
 	return (
 		<SocialAnalyticsProvider
 			value={ {
@@ -89,8 +95,8 @@ export function TimelinePanel( { connection }: TimelinePanelProps ) {
 				isFetchingNextPage={ isFetchingNextPage }
 				fetchNextPage={ fetchNextPage }
 				refetch={ handleRetry }
-				renderItem={ ( post ) => <SocialPostCard post={ post } variant="default" /> }
-				itemKey={ ( post ) => post.uri }
+				renderItem={ renderItem }
+				itemKey={ itemKey }
 				emptyTitle={ translate( "You're all caught up." ) }
 				emptyLine={ translate( 'Follow some accounts on Bluesky to see posts here.' ) }
 				emptyActionLabel={ translate( 'Browse Bluesky' ) }

--- a/client/reader/atmosphere/timeline-panel.tsx
+++ b/client/reader/atmosphere/timeline-panel.tsx
@@ -1,16 +1,87 @@
-import { Card, CardBody } from '@wordpress/components';
+import { useTimelineInfiniteQuery } from '@automattic/api-queries';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect, useMemo, useRef } from 'react';
+import { useDispatch } from 'react-redux';
+import { SocialFeedList, SocialPostCard } from 'calypso/reader/social';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import type { AtmosphereConnection, AtmosphereFeedItem } from '@automattic/api-core';
 
-export function TimelinePanel() {
+interface TimelinePanelProps {
+	connection: AtmosphereConnection;
+}
+
+export function TimelinePanel( { connection }: TimelinePanelProps ) {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const lastErrorKind = useRef< string | null >( null );
+
+	const {
+		data,
+		isPending,
+		isError,
+		error,
+		hasNextPage,
+		isFetchingNextPage,
+		fetchNextPage,
+		refetch,
+	} = useTimelineInfiniteQuery( connection.id );
+
+	const items: AtmosphereFeedItem[] = useMemo(
+		() => data?.pages.flatMap( ( page ) => page.feed ) ?? [],
+		[ data ]
+	);
+
+	useEffect( () => {
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_atmosphere_timeline_viewed', {
+				connection_id: connection.id,
+			} )
+		);
+	}, [ connection.id, dispatch ] );
+
+	useEffect( () => {
+		if ( isError && error && error.kind !== lastErrorKind.current ) {
+			lastErrorKind.current = error.kind;
+			dispatch(
+				recordReaderTracksEvent( 'calypso_reader_atmosphere_timeline_error_shown', {
+					connection_id: connection.id,
+					error_kind: error.kind,
+				} )
+			);
+		}
+		if ( ! isError ) {
+			lastErrorKind.current = null;
+		}
+	}, [ isError, error, connection.id, dispatch ] );
+
+	const handleRetry = () => {
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_atmosphere_timeline_retry_clicked', {
+				connection_id: connection.id,
+				error_kind: error?.kind ?? 'unknown',
+			} )
+		);
+		refetch();
+	};
+
 	return (
-		<Card>
-			<CardBody>
-				<h2>{ translate( 'Timeline' ) }</h2>
-				<p>
-					{ translate( 'Your Bluesky timeline will appear here. We’re still building this part.' ) }
-				</p>
-			</CardBody>
-		</Card>
+		<SocialFeedList< AtmosphereFeedItem >
+			items={ items }
+			isPending={ isPending }
+			isError={ isError }
+			error={ error ?? null }
+			hasNextPage={ Boolean( hasNextPage ) }
+			isFetchingNextPage={ isFetchingNextPage }
+			fetchNextPage={ fetchNextPage }
+			refetch={ handleRetry }
+			renderItem={ ( post ) => <SocialPostCard post={ post } variant="default" /> }
+			itemKey={ ( post ) => post.uri }
+			emptyTitle={ translate( "You're all caught up." ) }
+			emptyLine={ translate( 'Follow some accounts on Bluesky to see posts here.' ) }
+			emptyActionLabel={ translate( 'Browse Bluesky' ) }
+			emptyActionURL="https://bsky.app"
+		/>
 	);
 }
+
+export default TimelinePanel;

--- a/client/reader/atmosphere/timeline-panel.tsx
+++ b/client/reader/atmosphere/timeline-panel.tsx
@@ -1,8 +1,9 @@
 import { useTimelineInfiniteQuery } from '@automattic/api-queries';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { SocialFeedList, SocialPostCard } from 'calypso/reader/social';
+import { SocialAnalyticsProvider } from 'calypso/reader/social/components/post-card/analytics-context';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import type { AtmosphereConnection, AtmosphereFeedItem } from '@automattic/api-core';
 
@@ -64,23 +65,38 @@ export function TimelinePanel( { connection }: TimelinePanelProps ) {
 		refetch();
 	};
 
+	const onClickAnalytics = useCallback(
+		( event: string, props: Record< string, unknown > ) => {
+			dispatch( recordReaderTracksEvent( event, props ) );
+		},
+		[ dispatch ]
+	);
+
 	return (
-		<SocialFeedList< AtmosphereFeedItem >
-			items={ items }
-			isPending={ isPending }
-			isError={ isError }
-			error={ error ?? null }
-			hasNextPage={ Boolean( hasNextPage ) }
-			isFetchingNextPage={ isFetchingNextPage }
-			fetchNextPage={ fetchNextPage }
-			refetch={ handleRetry }
-			renderItem={ ( post ) => <SocialPostCard post={ post } variant="default" /> }
-			itemKey={ ( post ) => post.uri }
-			emptyTitle={ translate( "You're all caught up." ) }
-			emptyLine={ translate( 'Follow some accounts on Bluesky to see posts here.' ) }
-			emptyActionLabel={ translate( 'Browse Bluesky' ) }
-			emptyActionURL="https://bsky.app"
-		/>
+		<SocialAnalyticsProvider
+			value={ {
+				source: 'atmosphere',
+				connectionId: connection.id,
+				onClick: onClickAnalytics,
+			} }
+		>
+			<SocialFeedList< AtmosphereFeedItem >
+				items={ items }
+				isPending={ isPending }
+				isError={ isError }
+				error={ error ?? null }
+				hasNextPage={ Boolean( hasNextPage ) }
+				isFetchingNextPage={ isFetchingNextPage }
+				fetchNextPage={ fetchNextPage }
+				refetch={ handleRetry }
+				renderItem={ ( post ) => <SocialPostCard post={ post } variant="default" /> }
+				itemKey={ ( post ) => post.uri }
+				emptyTitle={ translate( "You're all caught up." ) }
+				emptyLine={ translate( 'Follow some accounts on Bluesky to see posts here.' ) }
+				emptyActionLabel={ translate( 'Browse Bluesky' ) }
+				emptyActionURL="https://bsky.app"
+			/>
+		</SocialAnalyticsProvider>
 	);
 }
 

--- a/client/reader/atmosphere/timeline-panel.tsx
+++ b/client/reader/atmosphere/timeline-panel.tsx
@@ -28,7 +28,10 @@ export function TimelinePanel( { connection }: TimelinePanelProps ) {
 	} = useTimelineInfiniteQuery( connection.id );
 
 	const items: AtmosphereFeedItem[] = useMemo(
-		() => data?.pages.flatMap( ( page ) => page.feed ) ?? [],
+		() =>
+			data?.pages
+				.flatMap( ( page ) => page.items ?? [] )
+				.filter( ( post ): post is AtmosphereFeedItem => Boolean( post?.uri ) ) ?? [],
 		[ data ]
 	);
 

--- a/client/reader/atmosphere/verify-panel.tsx
+++ b/client/reader/atmosphere/verify-panel.tsx
@@ -66,6 +66,7 @@ function errorMessage(
 ): TranslateResult {
 	switch ( error.kind ) {
 		case 'auth_failed':
+		case 'auth_required':
 			return translate(
 				'Your Bluesky connection needs to be re-authorized. Disconnect and reconnect.'
 			);
@@ -74,6 +75,7 @@ function errorMessage(
 		case 'upstream_unavailable':
 			return translate( 'Bluesky is unreachable right now.' );
 		case 'connection_not_found':
+		case 'not_found':
 			return translate( 'That connection is no longer available.' );
 		case 'invalid_handle':
 		case 'invalid_credentials':

--- a/client/reader/social/AGENTS.md
+++ b/client/reader/social/AGENTS.md
@@ -1,0 +1,187 @@
+# Reader Social
+
+Shared UI primitives for Reader's third-party social-network surfaces: Bluesky / ATProto (shipping under the user-facing label "ATmosphere") today, Mastodon next, additional protocols later.
+
+This directory is a **components-only** package. It owns no routes, no controllers, no Redux state, and no top-level pages. The protocol-specific shells live next to it (e.g. `client/reader/atmosphere/`, future `client/reader/mastodon/`) and import from here.
+
+## Scope
+
+In scope:
+
+- Presentational React components rendered by per-protocol shells (profile cards, feed lists, post cards, post-card subcomponents).
+- Helpers tightly coupled to those components (HTML sanitisation, analytics context, link-pattern primitives).
+- Per-component styles (`style.scss` next to each component).
+- Tests for everything above.
+
+Out of scope (lives elsewhere):
+
+- Routes / `controller.tsx` / `index.tsx` page entrypoints — `client/reader/<protocol>/`.
+- Data fetchers and React Query hooks — `packages/api-core/` and `packages/api-queries/`.
+- Connection and account-management flows specific to one protocol — `client/reader/<protocol>/`.
+- Anything that talks to Redux state or the legacy data-layer — new social code is React Query only.
+
+## Directory layout
+
+```
+client/reader/social/
+  index.ts                      # public barrel — only export from here
+  profile-card.tsx              # SocialProfileCard (used by every protocol's profile/verify view)
+  style.scss                    # SocialProfileCard styles
+  test/
+    profile-card.test.tsx
+
+  components/                   # mirror of client/reader/discover/components/ shape
+    feed-list/
+      index.tsx                 # SocialFeedList<T> — generic list shell, accepts a renderItem
+      feed-list-skeleton.tsx
+      feed-list-empty.tsx       # loading / empty / per-error-kind EmptyContent variants
+      style.scss
+      test/
+
+    post-card/
+      index.tsx                 # SocialPostCard — thin shell, dispatches to subcomponents
+      analytics-context.tsx     # SocialAnalyticsProvider + useSocialAnalytics
+      post-card-header.tsx      # avatar + name/handle + timestamp + repost reason + reply context
+      post-card-body.tsx        # sanitized post.html injected as HTML
+      post-card-counts.tsx      # replies / reposts / likes / quotes row
+      post-card-link.tsx        # card-link accessibility pattern (one real <a> + ::after overlay)
+      post-card-embed.tsx       # dispatcher on embed.type
+      post-card-embed-images.tsx
+      post-card-embed-video.tsx
+      post-card-embed-external.tsx
+      post-card-embed-quote.tsx
+      post-card-embed-quote-tombstone.tsx
+      post-card-embed-quote-with-media.tsx
+      sanitize-post-html.ts     # DOMPurify allow-list helper
+      style.scss
+      test/
+```
+
+## Architectural decisions
+
+### Bluesky-shaped types today, abstract when Mastodon arrives
+
+`SocialPostCard` and the embed dispatcher take `AtmosphereFeedItem` from `@automattic/api-core` directly — there is no protocol-agnostic `SocialPost` shape yet. This is deliberate: a generic shape designed against one protocol is just that protocol's shape with extra layers, and Mastodon's data model (`content` vs `html`, `media_attachments` vs `embed`, `reblog` vs `reason`, no native quotes) is non-trivially different.
+
+When Mastodon's shape is concretely in front of us, decide between:
+
+- **Refactor in place** — introduce a `SocialPost` shape with per-protocol mappers, if Bluesky and Mastodon overlap cleanly enough.
+- **Fork** — `BlueskyPostCard` / `MastodonPostCard` siblings sharing only the truly-protocol-agnostic bits below.
+
+Don't speculate ahead of that signal. Adding a generic shape now will make the abstraction wrong in a way only the second protocol can reveal.
+
+### What's already protocol-agnostic (reuse as-is for Mastodon)
+
+- `SocialProfileCard` — generic over a `stats[]` array; accepts plain-text `bio` or sanitised `bioHtml`. Already used by ATmosphere and intended for Mastodon.
+- `SocialFeedList<T>` — generic over item type via `renderItem` and `itemKey`. Mastodon plugs in a different data hook and a different `renderItem` callback; the list shell, sentinel-based pagination, skeleton, and error variants don't change.
+- `PostCardLink` — the card-link accessibility pattern (one real `<a>` + `::after` overlay + nested `position: relative; z-index: 1` anchors).
+- `sanitizePostHtml` — DOMPurify wrapper with allow-list (`<p> <br> <a>` / `href, rel, target`) and the `target="_blank"` rel-hardening hook. Conservative enough for Mastodon content too, possibly with a small extension to that allow-list once we see what Mastodon emits.
+- `SocialAnalyticsProvider` / `useSocialAnalytics` — the per-protocol shell wraps its tree with a `source` ('atmosphere' | 'mastodon' | …) + `connectionId` + `onClick(event, props)` callback. The post-card subcomponents call into this context instead of dispatching `recordReaderTracksEvent` directly. Adding a protocol just means adding a `source` value and wiring up the protocol's per-event Tracks call in the shell.
+
+### What's Bluesky-specific today (likely needs forking or refactoring)
+
+- `SocialPostCard` and every `post-card-*` subcomponent take `AtmosphereFeedItem`.
+- `PostCardEmbed`'s discriminated union (`'images' | 'video' | 'external' | 'quote' | 'quote_with_media'`) matches the backend `ReaderATmosphere_Normalizer` shape. Mastodon attachments are different.
+- `SocialPostCard`'s `variant: 'default' | 'compact'` covers top-level and quote-embed renderings — Mastodon has no native quote concept and may not need `compact` at all.
+
+### Data layer
+
+This directory does no data fetching. Per-protocol shells consume:
+
+- `@automattic/api-core` — typed fetchers + error classifiers + query keys.
+- `@automattic/api-queries` — React Query hooks (`useInfiniteQuery` for timelines).
+
+New social code is React Query end-to-end. Do not add new Redux data-layer handlers, do not add `connect()` HOCs, do not import from `client/state/data-layer/wpcom/read/`.
+
+### Tracks events
+
+Use the `SocialAnalyticsProvider` context, not direct `recordReaderTracksEvent` calls inside post-card subcomponents. The provider's `onClick(event, props)` is wired up in the per-protocol shell (e.g. `TimelinePanel`) so:
+
+- Per-protocol shell decides the event name (`calypso_reader_atmosphere_timeline_post_clicked` vs `calypso_reader_mastodon_timeline_post_clicked`).
+- Subcomponents pass protocol-agnostic props (`post_uri`, `has_embed`, `embed_type`, `is_repost`, `is_reply`, …) without knowing the prefix.
+- Connection identity (`connection_id`) is added by the provider, not threaded through prop drilling.
+
+All Reader Tracks events use the `calypso_reader_*` prefix per `client/reader/AGENTS.md`. Emit them via the `recordReaderTracksEvent` Redux action — `recordTrack()` from `client/reader/stats` is deprecated.
+
+### HTML sanitisation (defence-in-depth)
+
+Every place this directory injects HTML from a third-party network — `SocialProfileCard` for bios, `PostCardBody` for post content — runs the input through DOMPurify with a tight allow-list **before** handing it to React's HTML-injection prop. The backend already runs `wp_kses` over the same content with a matching allow-list, but the client double-sanitises so a future backend change can't silently widen what reaches the DOM.
+
+Allow-list shape:
+
+- `ALLOWED_TAGS: ['p', 'br', 'a']` for post content (extend cautiously for new protocols).
+- `ALLOWED_TAGS: ['p', 'br', 'a', 'span']` for profile bios (Mastodon emits `<span>` mention scaffolding).
+- `ALLOWED_ATTR` capped to `href`, `rel`, `target`, `class` (bio only).
+- DOMPurify's default scheme allow-list strips `javascript:` / `data:` / etc. on `href`. Don't extend it.
+- An `afterSanitizeAttributes` hook forces `rel="nofollow noopener noreferrer"` on any `<a target="_blank">` that survives sanitisation. Belt-and-suspenders against window-opener leaks if upstream ever drops the rel attribute.
+
+### Card-link accessibility pattern
+
+`PostCardLink` implements [Inclusive Components' card-link pattern](https://inclusive-components.design/cards/):
+
+- Exactly one real `<a>` per card (the post timestamp), with a `::after` pseudo-element covering the whole card as the click target.
+- Inner clickable elements (author chip, external embed, quote embed) are `position: relative; z-index: 1` so they sit above the overlay and remain individually clickable.
+- Card text remains selectable (the overlay sits behind text via `z-index`-stacking, not in front of it).
+
+Don't replace this with a `<a>`-wrapping-the-whole-card structure (illegal nested anchors) or `onClick` on a `<div>` (kills keyboard navigation and screen-reader semantics).
+
+### Click destinations
+
+Today every click destination opens `bsky.app` in a new tab (`target="_blank" rel="noopener noreferrer"`). Slice 5 will rewrite three of those (parent post → in-app thread route, quote → in-app thread route, author → in-app profile route) without touching the card-link plumbing itself. When wiring a new card surface, route through `PostCardLink` rather than spreading `target="_blank"` anchors directly across subcomponents.
+
+## Boundaries (for new code)
+
+Inherits everything from `client/reader/AGENTS.md` and `client/AGENTS.md`. Highlights worth restating because they trip up new contributors:
+
+- TypeScript only (`.tsx`), strict, no `any` unless justified.
+- Functional components only. Named exports — no default exports. Don't export prop types; consumers use `React.ComponentProps<typeof Component>`.
+- `useSelector`/`useDispatch` hooks — no `connect()` HOC.
+- `useTranslate()` from `i18n-calypso` — no `localize` HOC.
+- `@wordpress/components` primitives over custom HTML. `VStack` / `HStack` / `Card` / `CardBody` / `Spinner` for layout. No `@automattic/components` (deprecated).
+- `clsx` (not `classnames`).
+- Per-component `style.scss`. Imported with one blank line between `import './style.scss'` and other imports.
+- CSS logical properties (`margin-inline-start`, not `margin-left`). No BEM `&--` / `&__` shortcuts.
+- Preserve curly quotes (' ' " ") exactly as authored. See the project `CLAUDE.md` for the safe-Edit pattern when curly quotes coexist with straight quote string delimiters.
+
+## Tests
+
+- `userEvent.setup()` + `user.click()` (not `fireEvent`).
+- ARIA queries (`getByRole`, `getByLabelText`). No CSS selectors. No `data-testid` unless absolutely unavoidable.
+- `renderWithProvider` from `calypso/test-helpers/testing-library` for components needing Redux + React Query.
+- `nock` for HTTP mocking. Never mock components that contain real behaviour.
+- DOMPurify allow-list tests: assert preserved tags, stripped tags, stripped attributes, stripped `javascript:` URLs, and the `target="_blank"` rel-hardening hook.
+- For the card-link pattern, test the surface map: timestamp-as-real-`<a>`, author chip click target, quote click target, external click target, card-background click via overlay, and that all anchors carry `target="_blank" rel="noopener noreferrer"`.
+
+Run tests with:
+
+```bash
+yarn test-client client/reader/social
+yarn test-client:watch client/reader/social
+```
+
+## Adding a new protocol
+
+When wiring up a second (Mastodon) or third social protocol, expect to:
+
+1. **Add a per-protocol shell** under `client/reader/<protocol>/` (e.g. `client/reader/mastodon/`) — routes, controller, account view, panels (timeline / profile / settings).
+2. **Add per-protocol fetchers + types + hooks** under `packages/api-core/src/reader-<protocol>/` and `packages/api-queries/src/reader-<protocol>.ts`. Mirror the ATmosphere shape: typed fetchers, error classifier, query keys, infinite-query factory + hook.
+3. **Reuse this directory's protocol-agnostic primitives directly:** `SocialProfileCard`, `SocialFeedList`, `PostCardLink`, `sanitizePostHtml`, `SocialAnalyticsProvider`. Don't duplicate.
+4. **Decide on the post card.** Either refactor `SocialPostCard` and the embed dispatcher to take a `SocialPost` shape with a Bluesky→`SocialPost` mapper and a Mastodon→`SocialPost` mapper, or fork into `BlueskyPostCard` / `MastodonPostCard` keeping shared subcomponents (`PostCardLink`, `PostCardCounts`, etc.). Pick after looking at concrete fixtures, not before.
+5. **Wire the analytics provider** in the protocol shell. Pass `source: '<protocol>'`, the connection id, and an `onClick` callback that dispatches `calypso_reader_<protocol>_*` Tracks events via `recordReaderTracksEvent`.
+6. **Re-use the empty / error vocabulary** in `feed-list-empty.tsx` if the new protocol's error classifier produces the same kinds (`auth_required`, `rate_limited`, `upstream_unavailable`, `not_found`, `unknown`). Extend the dispatch only if a new kind appears.
+
+Future-extraction candidates flagged for later PRs (currently in `client/reader/atmosphere/`, expected to move shared-side once Mastodon needs them):
+
+- `connect-form.tsx` — likely shareable with Mastodon's connect flow.
+- `verify-panel.tsx` — already uses `SocialProfileCard`; the panel shell could move shared-side.
+- `atmosphere-navigation.tsx` — the Timeline / Profile / Settings tab structure likely ports.
+
+## References
+
+- Reader-wide guidance: [`client/reader/AGENTS.md`](../AGENTS.md).
+- Calypso-wide guidance: [`client/AGENTS.md`](../../AGENTS.md).
+- Slice 4 design (Bluesky timeline frontend): `~/notes/1-Projects/code/a8c/calypso/2026-04-27-reader-atmosphere-slice4-frontend-design.md`.
+- Slice 4 plan (task-by-task): `~/notes/1-Projects/code/a8c/calypso/2026-04-27-reader-atmosphere-slice4-frontend-plan.md`.
+- Slice 1 (connections + profile): `~/notes/1-Projects/code/a8c/calypso/2026-04-22-reader-atmosphere-slice1-design.md` and `…-plan.md`.
+- ATmosphere shell consuming this directory: [`client/reader/atmosphere/`](../atmosphere/).
+- Public barrel — only import from here: [`./index.ts`](./index.ts).

--- a/client/reader/social/CLAUDE.md
+++ b/client/reader/social/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/client/reader/social/components/feed-list/feed-list-empty.tsx
+++ b/client/reader/social/components/feed-list/feed-list-empty.tsx
@@ -1,0 +1,98 @@
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import EmptyContent from 'calypso/components/empty-content';
+import type { AtmosphereError } from '@automattic/api-core';
+
+interface FeedListEmptyProps {
+	error: AtmosphereError | null;
+	onRetry: () => void;
+	emptyTitle: string;
+	emptyLine: string;
+	emptyActionLabel?: string;
+	emptyActionURL?: string;
+}
+
+export function FeedListEmpty( {
+	error,
+	onRetry,
+	emptyTitle,
+	emptyLine,
+	emptyActionLabel,
+	emptyActionURL,
+}: FeedListEmptyProps ) {
+	const translate = useTranslate();
+
+	if ( ! error ) {
+		return (
+			<EmptyContent
+				title={ emptyTitle }
+				line={ emptyLine }
+				action={ emptyActionLabel }
+				actionURL={ emptyActionURL }
+			/>
+		);
+	}
+
+	switch ( error.kind ) {
+		case 'auth_required':
+			return (
+				<EmptyContent
+					title={ translate( 'Reconnect needed' ) }
+					line={ translate( 'Your Bluesky connection needs to be reconnected. Coming soon.' ) }
+				/>
+			);
+		case 'rate_limited': {
+			const retryAfter = ( error as { retry_after?: number } ).retry_after;
+			return (
+				<EmptyContent
+					title={ translate( 'Slow down' ) }
+					line={
+						retryAfter
+							? translate( 'Bluesky is asking us to slow down. Try again in %(n)ds.', {
+									args: { n: retryAfter },
+							  } )
+							: translate( 'Bluesky is asking us to slow down. Try again in a moment.' )
+					}
+					action={
+						<Button variant="primary" onClick={ onRetry }>
+							{ translate( 'Retry' ) }
+						</Button>
+					}
+				/>
+			);
+		}
+		case 'upstream_unavailable':
+			return (
+				<EmptyContent
+					title={ translate( 'Bluesky unreachable' ) }
+					line={ translate( 'Bluesky is temporarily unreachable. Try again in a moment.' ) }
+					action={
+						<Button variant="primary" onClick={ onRetry }>
+							{ translate( 'Retry' ) }
+						</Button>
+					}
+				/>
+			);
+		case 'not_found':
+			return (
+				<EmptyContent
+					title={ translate( 'Connection not found' ) }
+					line={ translate( 'This connection no longer exists.' ) }
+					action={ translate( 'Back to ATmosphere' ) }
+					actionURL="/reader/atmosphere"
+				/>
+			);
+		default:
+			return (
+				<EmptyContent
+					title={ translate( "Couldn't load timeline" ) }
+					line={ translate( 'Something went wrong.' ) }
+					action={
+						<Button variant="primary" onClick={ onRetry }>
+							{ translate( 'Retry' ) }
+						</Button>
+					}
+				/>
+			);
+	}
+}

--- a/client/reader/social/components/feed-list/feed-list-skeleton.tsx
+++ b/client/reader/social/components/feed-list/feed-list-skeleton.tsx
@@ -1,0 +1,18 @@
+import Skeleton from 'calypso/reader/components/skeleton';
+
+export function FeedListSkeleton() {
+	return (
+		<div className="social-feed-list-skeleton">
+			{ [ 0, 1, 2 ].map( ( i ) => (
+				<div key={ i } className="social-feed-list-skeleton__row">
+					<Skeleton height="40px" width="40px" shape="circle" />
+					<div className="social-feed-list-skeleton__row-body">
+						<Skeleton height="16px" width="40%" />
+						<Skeleton height="14px" width="100%" />
+						<Skeleton height="14px" width="80%" />
+					</div>
+				</div>
+			) ) }
+		</div>
+	);
+}

--- a/client/reader/social/components/feed-list/index.tsx
+++ b/client/reader/social/components/feed-list/index.tsx
@@ -80,7 +80,7 @@ export function SocialFeedList< T >( props: SocialFeedListProps< T > ) {
 	}
 
 	return (
-		<VStack spacing={ 4 } className="social-feed-list">
+		<VStack spacing={ 0 } className="social-feed-list">
 			{ items.map( ( item ) => (
 				<div key={ itemKey( item ) } className="social-feed-list__item">
 					{ renderItem( item ) }

--- a/client/reader/social/components/feed-list/index.tsx
+++ b/client/reader/social/components/feed-list/index.tsx
@@ -1,0 +1,94 @@
+import './style.scss';
+
+import { Spinner, __experimentalVStack as VStack } from '@wordpress/components';
+import { useEffect } from 'react';
+import { useInView } from 'react-intersection-observer';
+import { FeedListEmpty } from './feed-list-empty';
+import { FeedListSkeleton } from './feed-list-skeleton';
+import type { AtmosphereError } from '@automattic/api-core';
+import type { ReactElement } from 'react';
+
+interface SocialFeedListProps< T > {
+	items: T[];
+	isPending: boolean;
+	isError: boolean;
+	error: AtmosphereError | null;
+	hasNextPage: boolean;
+	isFetchingNextPage: boolean;
+	fetchNextPage: () => void;
+	refetch: () => void;
+	renderItem: ( item: T ) => ReactElement;
+	itemKey: ( item: T ) => string;
+	emptyTitle: string;
+	emptyLine: string;
+	emptyActionLabel?: string;
+	emptyActionURL?: string;
+}
+
+export function SocialFeedList< T >( props: SocialFeedListProps< T > ) {
+	const {
+		items,
+		isPending,
+		isError,
+		error,
+		hasNextPage,
+		isFetchingNextPage,
+		fetchNextPage,
+		refetch,
+		renderItem,
+		itemKey,
+		emptyTitle,
+		emptyLine,
+		emptyActionLabel,
+		emptyActionURL,
+	} = props;
+
+	const { ref, inView } = useInView();
+
+	useEffect( () => {
+		if ( inView && hasNextPage && ! isFetchingNextPage ) {
+			fetchNextPage();
+		}
+	}, [ inView, hasNextPage, isFetchingNextPage, fetchNextPage ] );
+
+	if ( isPending ) {
+		return <FeedListSkeleton />;
+	}
+
+	if ( isError ) {
+		return (
+			<FeedListEmpty
+				error={ error }
+				onRetry={ refetch }
+				emptyTitle={ emptyTitle }
+				emptyLine={ emptyLine }
+			/>
+		);
+	}
+
+	if ( items.length === 0 ) {
+		return (
+			<FeedListEmpty
+				error={ null }
+				onRetry={ refetch }
+				emptyTitle={ emptyTitle }
+				emptyLine={ emptyLine }
+				emptyActionLabel={ emptyActionLabel }
+				emptyActionURL={ emptyActionURL }
+			/>
+		);
+	}
+
+	return (
+		<VStack spacing={ 4 } className="social-feed-list">
+			{ items.map( ( item ) => (
+				<div key={ itemKey( item ) } className="social-feed-list__item">
+					{ renderItem( item ) }
+				</div>
+			) ) }
+			<div ref={ ref } className="social-feed-list__sentinel" aria-hidden="true">
+				{ isFetchingNextPage && <Spinner /> }
+			</div>
+		</VStack>
+	);
+}

--- a/client/reader/social/components/feed-list/index.tsx
+++ b/client/reader/social/components/feed-list/index.tsx
@@ -1,6 +1,7 @@
 import './style.scss';
 
 import { Spinner, __experimentalVStack as VStack } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { FeedListEmpty } from './feed-list-empty';
@@ -43,6 +44,7 @@ export function SocialFeedList< T >( props: SocialFeedListProps< T > ) {
 		emptyActionURL,
 	} = props;
 
+	const translate = useTranslate();
 	const { ref, inView } = useInView();
 
 	useEffect( () => {
@@ -86,8 +88,13 @@ export function SocialFeedList< T >( props: SocialFeedListProps< T > ) {
 					{ renderItem( item ) }
 				</div>
 			) ) }
-			<div ref={ ref } className="social-feed-list__sentinel" aria-hidden="true">
-				{ isFetchingNextPage && <Spinner /> }
+			<div ref={ ref } className="social-feed-list__sentinel" role="status" aria-live="polite">
+				{ isFetchingNextPage && (
+					<>
+						<Spinner />
+						<span className="screen-reader-text">{ translate( 'Loading more posts' ) }</span>
+					</>
+				) }
 			</div>
 		</VStack>
 	);

--- a/client/reader/social/components/feed-list/style.scss
+++ b/client/reader/social/components/feed-list/style.scss
@@ -1,0 +1,18 @@
+.social-feed-list-skeleton {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+
+	.social-feed-list-skeleton__row {
+		display: flex;
+		gap: 12px;
+		padding-block: 12px;
+	}
+
+	.social-feed-list-skeleton__row-body {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+}

--- a/client/reader/social/components/feed-list/test/feed-list-empty.test.tsx
+++ b/client/reader/social/components/feed-list/test/feed-list-empty.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FeedListEmpty } from '../feed-list-empty';
+import type { AtmosphereError } from '@automattic/api-core';
+
+describe( 'FeedListEmpty', () => {
+	it( 'renders the empty title and action when there is no error', () => {
+		render(
+			<FeedListEmpty
+				error={ null }
+				onRetry={ () => {} }
+				emptyTitle="All caught up."
+				emptyLine="Follow accounts to see posts."
+				emptyActionLabel="Browse Bluesky"
+				emptyActionURL="https://bsky.app"
+			/>
+		);
+		expect( screen.getByText( 'All caught up.' ) ).toBeVisible();
+		expect( screen.getByText( 'Follow accounts to see posts.' ) ).toBeVisible();
+		expect( screen.getByRole( 'link', { name: 'Browse Bluesky' } ) ).toHaveAttribute(
+			'href',
+			'https://bsky.app'
+		);
+	} );
+
+	it( 'renders the rate-limited error with a Retry button that calls onRetry', async () => {
+		const onRetry = jest.fn();
+		const user = userEvent.setup();
+		render(
+			<FeedListEmpty
+				error={ { kind: 'rate_limited', retry_after: 60 } as AtmosphereError }
+				onRetry={ onRetry }
+				emptyTitle=""
+				emptyLine=""
+			/>
+		);
+		expect( screen.getAllByText( /slow down/i ).length ).toBeGreaterThan( 0 );
+		await user.click( screen.getByRole( 'button', { name: /retry/i } ) );
+		expect( onRetry ).toHaveBeenCalled();
+	} );
+
+	it( 'renders the upstream-unavailable error with a Retry button', () => {
+		render(
+			<FeedListEmpty
+				error={ { kind: 'upstream_unavailable' } as AtmosphereError }
+				onRetry={ () => {} }
+				emptyTitle=""
+				emptyLine=""
+			/>
+		);
+		expect( screen.getAllByText( /unreachable/i ).length ).toBeGreaterThan( 0 );
+		expect( screen.getByRole( 'button', { name: /retry/i } ) ).toBeVisible();
+	} );
+
+	it( 'renders the auth-required error WITHOUT a Retry button', () => {
+		render(
+			<FeedListEmpty
+				error={ { kind: 'auth_required' } as AtmosphereError }
+				onRetry={ () => {} }
+				emptyTitle=""
+				emptyLine=""
+			/>
+		);
+		expect( screen.getAllByText( /reconnect/i ).length ).toBeGreaterThan( 0 );
+		expect( screen.queryByRole( 'button', { name: /retry/i } ) ).toBeNull();
+	} );
+
+	it( 'renders the not-found error with a back-to-ATmosphere link', () => {
+		render(
+			<FeedListEmpty
+				error={ { kind: 'not_found' } as AtmosphereError }
+				onRetry={ () => {} }
+				emptyTitle=""
+				emptyLine=""
+			/>
+		);
+		expect( screen.getByRole( 'link', { name: /back to atmosphere/i } ) ).toHaveAttribute(
+			'href',
+			'/reader/atmosphere'
+		);
+	} );
+
+	it( 'renders the unknown / generic error with a Retry button', () => {
+		render(
+			<FeedListEmpty
+				error={ { kind: 'unknown', cause: null } as AtmosphereError }
+				onRetry={ () => {} }
+				emptyTitle=""
+				emptyLine=""
+			/>
+		);
+		expect( screen.getByText( /something went wrong/i ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: /retry/i } ) ).toBeVisible();
+	} );
+} );

--- a/client/reader/social/components/feed-list/test/feed-list-skeleton.test.tsx
+++ b/client/reader/social/components/feed-list/test/feed-list-skeleton.test.tsx
@@ -1,0 +1,12 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react';
+import { FeedListSkeleton } from '../feed-list-skeleton';
+
+describe( 'FeedListSkeleton', () => {
+	it( 'renders 3 skeleton rows', () => {
+		const { container } = render( <FeedListSkeleton /> );
+		expect( container.querySelectorAll( '.social-feed-list-skeleton__row' ) ).toHaveLength( 3 );
+	} );
+} );

--- a/client/reader/social/components/feed-list/test/index.test.tsx
+++ b/client/reader/social/components/feed-list/test/index.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import { mockAllIsIntersecting } from 'react-intersection-observer/test-utils';
+import { SocialFeedList } from '../index';
+import type { AtmosphereError } from '@automattic/api-core';
+
+interface Item {
+	id: string;
+	label: string;
+}
+
+const items: Item[] = [
+	{ id: 'a', label: 'first' },
+	{ id: 'b', label: 'second' },
+];
+
+const baseProps = {
+	itemKey: ( i: Item ) => i.id,
+	renderItem: ( i: Item ) => <div>{ i.label }</div>,
+	emptyTitle: 'Empty',
+	emptyLine: 'Empty line',
+};
+
+describe( 'SocialFeedList', () => {
+	it( 'renders the skeleton when isPending', () => {
+		const { container } = render(
+			<SocialFeedList< Item >
+				items={ [] }
+				isPending
+				isError={ false }
+				error={ null }
+				hasNextPage={ false }
+				isFetchingNextPage={ false }
+				fetchNextPage={ () => {} }
+				refetch={ () => {} }
+				{ ...baseProps }
+			/>
+		);
+		expect( container.querySelectorAll( '.social-feed-list-skeleton__row' ) ).toHaveLength( 3 );
+	} );
+
+	it( 'renders the empty state when items is [] and not pending', () => {
+		render(
+			<SocialFeedList< Item >
+				items={ [] }
+				isPending={ false }
+				isError={ false }
+				error={ null }
+				hasNextPage={ false }
+				isFetchingNextPage={ false }
+				fetchNextPage={ () => {} }
+				refetch={ () => {} }
+				{ ...baseProps }
+			/>
+		);
+		expect( screen.getByText( 'Empty' ) ).toBeVisible();
+	} );
+
+	it( 'renders items via renderItem', () => {
+		render(
+			<SocialFeedList< Item >
+				items={ items }
+				isPending={ false }
+				isError={ false }
+				error={ null }
+				hasNextPage={ false }
+				isFetchingNextPage={ false }
+				fetchNextPage={ () => {} }
+				refetch={ () => {} }
+				{ ...baseProps }
+			/>
+		);
+		expect( screen.getByText( 'first' ) ).toBeVisible();
+		expect( screen.getByText( 'second' ) ).toBeVisible();
+	} );
+
+	it( 'calls fetchNextPage when sentinel comes into view', async () => {
+		const fetchNextPage = jest.fn();
+		render(
+			<SocialFeedList< Item >
+				items={ items }
+				isPending={ false }
+				isError={ false }
+				error={ null }
+				hasNextPage
+				isFetchingNextPage={ false }
+				fetchNextPage={ fetchNextPage }
+				refetch={ () => {} }
+				{ ...baseProps }
+			/>
+		);
+		mockAllIsIntersecting( true );
+		await waitFor( () => expect( fetchNextPage ).toHaveBeenCalled() );
+	} );
+
+	it( 'does not call fetchNextPage while a fetch is already in flight', () => {
+		const fetchNextPage = jest.fn();
+		render(
+			<SocialFeedList< Item >
+				items={ items }
+				isPending={ false }
+				isError={ false }
+				error={ null }
+				hasNextPage
+				isFetchingNextPage
+				fetchNextPage={ fetchNextPage }
+				refetch={ () => {} }
+				{ ...baseProps }
+			/>
+		);
+		mockAllIsIntersecting( true );
+		expect( fetchNextPage ).not.toHaveBeenCalled();
+	} );
+
+	it( 'renders an error state when isError is true', () => {
+		render(
+			<SocialFeedList< Item >
+				items={ [] }
+				isPending={ false }
+				isError
+				error={ { kind: 'upstream_unavailable' } as AtmosphereError }
+				hasNextPage={ false }
+				isFetchingNextPage={ false }
+				fetchNextPage={ () => {} }
+				refetch={ () => {} }
+				{ ...baseProps }
+			/>
+		);
+		expect( screen.getAllByText( /unreachable/i ).length ).toBeGreaterThan( 0 );
+	} );
+} );

--- a/client/reader/social/components/post-card/analytics-context.tsx
+++ b/client/reader/social/components/post-card/analytics-context.tsx
@@ -1,0 +1,23 @@
+import { createContext, useContext, type ReactNode } from 'react';
+
+export interface SocialAnalyticsContextValue {
+	source: 'atmosphere' | 'mastodon';
+	connectionId: number;
+	onClick: ( event: string, props: Record< string, unknown > ) => void;
+}
+
+const Ctx = createContext< SocialAnalyticsContextValue | null >( null );
+
+export function SocialAnalyticsProvider( {
+	value,
+	children,
+}: {
+	value: SocialAnalyticsContextValue;
+	children: ReactNode;
+} ) {
+	return <Ctx.Provider value={ value }>{ children }</Ctx.Provider>;
+}
+
+export function useSocialAnalytics(): SocialAnalyticsContextValue | null {
+	return useContext( Ctx );
+}

--- a/client/reader/social/components/post-card/index.tsx
+++ b/client/reader/social/components/post-card/index.tsx
@@ -26,36 +26,73 @@ function formatRelative( iso: string, translate: ReturnType< typeof useTranslate
 	const seconds = Math.max( 1, Math.floor( ( Date.now() - ts ) / 1000 ) );
 	const out = ( v: TranslateResult ): string => String( v );
 	if ( seconds < 60 ) {
-		return out( translate( '%(n)ds', { args: { n: seconds } } ) );
+		return out(
+			translate( '%(n)ds', {
+				args: { n: seconds },
+				comment: 'Time-ago suffix for seconds, e.g. "30s"',
+			} )
+		);
 	}
 	const minutes = Math.floor( seconds / 60 );
 	if ( minutes < 60 ) {
-		return out( translate( '%(n)dm', { args: { n: minutes } } ) );
+		return out(
+			translate( '%(n)dm', {
+				args: { n: minutes },
+				comment: 'Time-ago suffix for minutes, e.g. "5m"',
+			} )
+		);
 	}
 	const hours = Math.floor( minutes / 60 );
 	if ( hours < 24 ) {
-		return out( translate( '%(n)dh', { args: { n: hours } } ) );
+		return out(
+			translate( '%(n)dh', {
+				args: { n: hours },
+				comment: 'Time-ago suffix for hours, e.g. "2h"',
+			} )
+		);
 	}
 	const days = Math.floor( hours / 24 );
-	return out( translate( '%(n)dd', { args: { n: days } } ) );
+	return out(
+		translate( '%(n)dd', {
+			args: { n: days },
+			comment: 'Time-ago suffix for days, e.g. "3d"',
+		} )
+	);
 }
 
 export function SocialPostCard( { post, variant = 'default' }: SocialPostCardProps ) {
 	const translate = useTranslate();
 	const isCompact = variant === 'compact';
 	const timestampLabel = formatRelative( post.created_at || post.indexed_at, translate );
+
+	const card = (
+		<Card className={ clsx( 'social-post-card', `social-post-card--${ variant }` ) }>
+			<CardBody>
+				<PostCardHeader post={ post } variant={ variant } />
+				<PostCardBody post={ post } />
+				{ ! isCompact && post.embed && (
+					<PostCardEmbed embed={ post.embed } parentPostUri={ post.uri } />
+				) }
+				{ ! isCompact && <PostCardCounts counts={ post.counts } /> }
+				{ isCompact && timestampLabel && (
+					<span className="social-post-card-link__timestamp social-post-card-link__timestamp--inert">
+						{ timestampLabel }
+					</span>
+				) }
+			</CardBody>
+		</Card>
+	);
+
+	// Compact mode renders without any anchors so the consumer
+	// (e.g. PostCardEmbedQuote) can wrap it in its own outer anchor without
+	// creating invalid nested-<a> markup.
+	if ( isCompact ) {
+		return card;
+	}
+
 	return (
 		<PostCardLink post={ post } variant={ variant } timestampLabel={ timestampLabel }>
-			<Card className={ clsx( 'social-post-card', `social-post-card--${ variant }` ) }>
-				<CardBody>
-					<PostCardHeader post={ post } variant={ variant } />
-					<PostCardBody post={ post } />
-					{ ! isCompact && post.embed && (
-						<PostCardEmbed embed={ post.embed } parentPostUri={ post.uri } />
-					) }
-					{ ! isCompact && <PostCardCounts counts={ post.counts } /> }
-				</CardBody>
-			</Card>
+			{ card }
 		</PostCardLink>
 	);
 }

--- a/client/reader/social/components/post-card/index.tsx
+++ b/client/reader/social/components/post-card/index.tsx
@@ -1,0 +1,61 @@
+import { Card, CardBody } from '@wordpress/components';
+import clsx from 'clsx';
+import { useTranslate, type TranslateResult } from 'i18n-calypso';
+import { PostCardBody } from './post-card-body';
+import { PostCardCounts } from './post-card-counts';
+import { PostCardEmbed } from './post-card-embed';
+import { PostCardHeader } from './post-card-header';
+import { PostCardLink } from './post-card-link';
+import type { AtmosphereFeedItem } from '@automattic/api-core';
+
+type SocialPostCardVariant = 'default' | 'compact';
+
+interface SocialPostCardProps {
+	post: AtmosphereFeedItem;
+	variant?: SocialPostCardVariant;
+}
+
+function formatRelative( iso: string, translate: ReturnType< typeof useTranslate > ): string {
+	if ( ! iso ) {
+		return '';
+	}
+	const ts = Date.parse( iso );
+	if ( Number.isNaN( ts ) ) {
+		return '';
+	}
+	const seconds = Math.max( 1, Math.floor( ( Date.now() - ts ) / 1000 ) );
+	const out = ( v: TranslateResult ): string => String( v );
+	if ( seconds < 60 ) {
+		return out( translate( '%(n)ds', { args: { n: seconds } } ) );
+	}
+	const minutes = Math.floor( seconds / 60 );
+	if ( minutes < 60 ) {
+		return out( translate( '%(n)dm', { args: { n: minutes } } ) );
+	}
+	const hours = Math.floor( minutes / 60 );
+	if ( hours < 24 ) {
+		return out( translate( '%(n)dh', { args: { n: hours } } ) );
+	}
+	const days = Math.floor( hours / 24 );
+	return out( translate( '%(n)dd', { args: { n: days } } ) );
+}
+
+export function SocialPostCard( { post, variant = 'default' }: SocialPostCardProps ) {
+	const translate = useTranslate();
+	const isCompact = variant === 'compact';
+	const timestampLabel = formatRelative( post.created_at || post.indexed_at, translate );
+	return (
+		<PostCardLink post={ post } variant={ variant } timestampLabel={ timestampLabel }>
+			<Card className={ clsx( 'social-post-card', `social-post-card--${ variant }` ) }>
+				<CardBody>
+					<PostCardHeader post={ post } variant={ variant } />
+					<PostCardBody post={ post } />
+					{ ! isCompact && post.embed && (
+						<PostCardEmbed embed={ post.embed } parentPostUri={ post.uri } />
+					) }
+					{ ! isCompact && <PostCardCounts counts={ post.counts } /> }
+				</CardBody>
+			</Card>
+		</PostCardLink>
+	);
+}

--- a/client/reader/social/components/post-card/index.tsx
+++ b/client/reader/social/components/post-card/index.tsx
@@ -1,6 +1,5 @@
 import { Card, CardBody } from '@wordpress/components';
 import clsx from 'clsx';
-import { useTranslate, type TranslateResult } from 'i18n-calypso';
 import { PostCardBody } from './post-card-body';
 import { PostCardCounts } from './post-card-counts';
 import { PostCardEmbed } from './post-card-embed';
@@ -15,60 +14,13 @@ interface SocialPostCardProps {
 	variant?: SocialPostCardVariant;
 }
 
-function formatRelative( iso: string, translate: ReturnType< typeof useTranslate > ): string {
-	if ( ! iso ) {
-		return '';
-	}
-	const ts = Date.parse( iso );
-	if ( Number.isNaN( ts ) ) {
-		return '';
-	}
-	const seconds = Math.max( 1, Math.floor( ( Date.now() - ts ) / 1000 ) );
-	const out = ( v: TranslateResult ): string => String( v );
-	if ( seconds < 60 ) {
-		return out(
-			translate( '%(n)ds', {
-				args: { n: seconds },
-				comment: 'Time-ago suffix for seconds, e.g. "30s"',
-			} )
-		);
-	}
-	const minutes = Math.floor( seconds / 60 );
-	if ( minutes < 60 ) {
-		return out(
-			translate( '%(n)dm', {
-				args: { n: minutes },
-				comment: 'Time-ago suffix for minutes, e.g. "5m"',
-			} )
-		);
-	}
-	const hours = Math.floor( minutes / 60 );
-	if ( hours < 24 ) {
-		return out(
-			translate( '%(n)dh', {
-				args: { n: hours },
-				comment: 'Time-ago suffix for hours, e.g. "2h"',
-			} )
-		);
-	}
-	const days = Math.floor( hours / 24 );
-	return out(
-		translate( '%(n)dd', {
-			args: { n: days },
-			comment: 'Time-ago suffix for days, e.g. "3d"',
-		} )
-	);
-}
-
 export function SocialPostCard( { post, variant = 'default' }: SocialPostCardProps ) {
-	const translate = useTranslate();
 	const isCompact = variant === 'compact';
-	const timestampLabel = formatRelative( post.created_at || post.indexed_at, translate );
 
 	const card = (
 		<Card className={ clsx( 'social-post-card', `social-post-card--${ variant }` ) }>
 			<CardBody>
-				<PostCardHeader post={ post } variant={ variant } timestampLabel={ timestampLabel } />
+				<PostCardHeader post={ post } variant={ variant } />
 				<PostCardBody post={ post } />
 				{ ! isCompact && post.embed && (
 					<PostCardEmbed embed={ post.embed } parentPostUri={ post.uri } />

--- a/client/reader/social/components/post-card/index.tsx
+++ b/client/reader/social/components/post-card/index.tsx
@@ -1,3 +1,5 @@
+import './style.scss';
+
 import { Card, CardBody } from '@wordpress/components';
 import clsx from 'clsx';
 import { PostCardBody } from './post-card-body';

--- a/client/reader/social/components/post-card/index.tsx
+++ b/client/reader/social/components/post-card/index.tsx
@@ -68,17 +68,12 @@ export function SocialPostCard( { post, variant = 'default' }: SocialPostCardPro
 	const card = (
 		<Card className={ clsx( 'social-post-card', `social-post-card--${ variant }` ) }>
 			<CardBody>
-				<PostCardHeader post={ post } variant={ variant } />
+				<PostCardHeader post={ post } variant={ variant } timestampLabel={ timestampLabel } />
 				<PostCardBody post={ post } />
 				{ ! isCompact && post.embed && (
 					<PostCardEmbed embed={ post.embed } parentPostUri={ post.uri } />
 				) }
 				{ ! isCompact && <PostCardCounts counts={ post.counts } /> }
-				{ isCompact && timestampLabel && (
-					<span className="social-post-card-link__timestamp social-post-card-link__timestamp--inert">
-						{ timestampLabel }
-					</span>
-				) }
 			</CardBody>
 		</Card>
 	);
@@ -90,9 +85,5 @@ export function SocialPostCard( { post, variant = 'default' }: SocialPostCardPro
 		return card;
 	}
 
-	return (
-		<PostCardLink post={ post } variant={ variant } timestampLabel={ timestampLabel }>
-			{ card }
-		</PostCardLink>
-	);
+	return <PostCardLink variant={ variant }>{ card }</PostCardLink>;
 }

--- a/client/reader/social/components/post-card/post-card-body.tsx
+++ b/client/reader/social/components/post-card/post-card-body.tsx
@@ -1,0 +1,23 @@
+import { sanitizePostHtml } from './sanitize-post-html';
+import type { AtmosphereFeedItem } from '@automattic/api-core';
+
+interface PostCardBodyProps {
+	post: AtmosphereFeedItem;
+}
+
+export function PostCardBody( { post }: PostCardBodyProps ) {
+	if ( ! post.html ) {
+		return <p className="social-post-card-body">{ post.text }</p>;
+	}
+	// DOMPurify-sanitised via sanitizePostHtml; see sanitize-post-html.ts.
+	// The backend already wp_kses-sanitises post.html with the same
+	// allow-list, so this is defence-in-depth, not the only line of defence.
+	const __html = sanitizePostHtml( post.html );
+	return (
+		<div
+			className="social-post-card-body"
+			// eslint-disable-next-line react/no-danger
+			dangerouslySetInnerHTML={ { __html } }
+		/>
+	);
+}

--- a/client/reader/social/components/post-card/post-card-counts.tsx
+++ b/client/reader/social/components/post-card/post-card-counts.tsx
@@ -21,20 +21,24 @@ export function PostCardCounts( { counts }: PostCardCountsProps ) {
 			justify="flex-start"
 			className="social-post-card-counts"
 		>
-			<span aria-label={ translate( 'Replies' ) }>
+			<span>
 				<ReaderCommentIcon iconSize={ ICON_SIZE } />
+				<span className="screen-reader-text">{ translate( 'Replies:' ) } </span>
 				{ counts.replies }
 			</span>
-			<span aria-label={ translate( 'Reposts' ) }>
+			<span>
 				<ReaderRepostIcon iconSize={ ICON_SIZE } />
+				<span className="screen-reader-text">{ translate( 'Reposts:' ) } </span>
 				{ counts.reposts }
 			</span>
-			<span aria-label={ translate( 'Likes' ) }>
+			<span>
 				<ReaderLikeIcon iconSize={ ICON_SIZE } liked={ false } />
+				<span className="screen-reader-text">{ translate( 'Likes:' ) } </span>
 				{ counts.likes }
 			</span>
-			<span aria-label={ translate( 'Quotes' ) }>
+			<span>
 				<Icon icon={ quote } size={ ICON_SIZE } />
+				<span className="screen-reader-text">{ translate( 'Quotes:' ) } </span>
 				{ counts.quotes }
 			</span>
 		</HStack>

--- a/client/reader/social/components/post-card/post-card-counts.tsx
+++ b/client/reader/social/components/post-card/post-card-counts.tsx
@@ -1,6 +1,12 @@
 import { __experimentalHStack as HStack } from '@wordpress/components';
+import { Icon, quote } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import ReaderCommentIcon from 'calypso/reader/components/icons/comment-icon';
+import ReaderLikeIcon from 'calypso/reader/components/icons/like-icon';
+import ReaderRepostIcon from 'calypso/reader/components/icons/repost';
 import type { AtmosphereCounts } from '@automattic/api-core';
+
+const ICON_SIZE = 16;
 
 interface PostCardCountsProps {
 	counts: AtmosphereCounts;
@@ -15,10 +21,22 @@ export function PostCardCounts( { counts }: PostCardCountsProps ) {
 			justify="flex-start"
 			className="social-post-card-counts"
 		>
-			<span aria-label={ translate( 'Replies' ) }>💬 { counts.replies }</span>
-			<span aria-label={ translate( 'Reposts' ) }>🔁 { counts.reposts }</span>
-			<span aria-label={ translate( 'Likes' ) }>♥ { counts.likes }</span>
-			<span aria-label={ translate( 'Quotes' ) }>📎 { counts.quotes }</span>
+			<span aria-label={ translate( 'Replies' ) }>
+				<ReaderCommentIcon iconSize={ ICON_SIZE } />
+				{ counts.replies }
+			</span>
+			<span aria-label={ translate( 'Reposts' ) }>
+				<ReaderRepostIcon iconSize={ ICON_SIZE } />
+				{ counts.reposts }
+			</span>
+			<span aria-label={ translate( 'Likes' ) }>
+				<ReaderLikeIcon iconSize={ ICON_SIZE } liked={ false } />
+				{ counts.likes }
+			</span>
+			<span aria-label={ translate( 'Quotes' ) }>
+				<Icon icon={ quote } size={ ICON_SIZE } />
+				{ counts.quotes }
+			</span>
 		</HStack>
 	);
 }

--- a/client/reader/social/components/post-card/post-card-counts.tsx
+++ b/client/reader/social/components/post-card/post-card-counts.tsx
@@ -1,0 +1,24 @@
+import { __experimentalHStack as HStack } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import type { AtmosphereCounts } from '@automattic/api-core';
+
+interface PostCardCountsProps {
+	counts: AtmosphereCounts;
+}
+
+export function PostCardCounts( { counts }: PostCardCountsProps ) {
+	const translate = useTranslate();
+	return (
+		<HStack
+			alignment="center"
+			spacing={ 4 }
+			justify="flex-start"
+			className="social-post-card-counts"
+		>
+			<span aria-label={ translate( 'Replies' ) }>💬 { counts.replies }</span>
+			<span aria-label={ translate( 'Reposts' ) }>🔁 { counts.reposts }</span>
+			<span aria-label={ translate( 'Likes' ) }>♥ { counts.likes }</span>
+			<span aria-label={ translate( 'Quotes' ) }>📎 { counts.quotes }</span>
+		</HStack>
+	);
+}

--- a/client/reader/social/components/post-card/post-card-embed-external.tsx
+++ b/client/reader/social/components/post-card/post-card-embed-external.tsx
@@ -2,12 +2,11 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
+import { useSocialAnalytics } from './analytics-context';
 import type { AtmosphereEmbedExternal } from '@automattic/api-core';
 
 interface PostCardEmbedExternalProps {
 	embed: AtmosphereEmbedExternal;
-	// Unused in slice 4's render path, required for the analytics wiring in
-	// Task 24. Reserved here so the prop signature stays stable.
 	parentPostUri: string;
 }
 
@@ -19,13 +18,25 @@ function safeHost( uri: string ): string {
 	}
 }
 
-export function PostCardEmbedExternal( { embed }: PostCardEmbedExternalProps ) {
+export function PostCardEmbedExternal( { embed, parentPostUri }: PostCardEmbedExternalProps ) {
+	const analytics = useSocialAnalytics();
+	const handleClick = () => {
+		if ( ! analytics ) {
+			return;
+		}
+		analytics.onClick( `calypso_reader_${ analytics.source }_timeline_external_clicked`, {
+			connection_id: analytics.connectionId,
+			post_uri: parentPostUri,
+			external_uri: embed.uri,
+		} );
+	};
 	return (
 		<a
 			className="social-post-card-embed-external"
 			href={ embed.uri }
 			target="_blank"
 			rel="noopener noreferrer"
+			onClick={ handleClick }
 		>
 			<HStack alignment="flex-start" spacing={ 3 } justify="flex-start">
 				{ embed.thumb && (

--- a/client/reader/social/components/post-card/post-card-embed-external.tsx
+++ b/client/reader/social/components/post-card/post-card-embed-external.tsx
@@ -1,0 +1,49 @@
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import type { AtmosphereEmbedExternal } from '@automattic/api-core';
+
+interface PostCardEmbedExternalProps {
+	embed: AtmosphereEmbedExternal;
+	// Unused in slice 4's render path, required for the analytics wiring in
+	// Task 24. Reserved here so the prop signature stays stable.
+	parentPostUri: string;
+}
+
+function safeHost( uri: string ): string {
+	try {
+		return new URL( uri ).host;
+	} catch {
+		return '';
+	}
+}
+
+export function PostCardEmbedExternal( { embed }: PostCardEmbedExternalProps ) {
+	return (
+		<a
+			className="social-post-card-embed-external"
+			href={ embed.uri }
+			target="_blank"
+			rel="noopener noreferrer"
+		>
+			<HStack alignment="flex-start" spacing={ 3 } justify="flex-start">
+				{ embed.thumb && (
+					<img
+						className="social-post-card-embed-external__thumb"
+						src={ embed.thumb }
+						alt=""
+						loading="lazy"
+					/>
+				) }
+				<VStack spacing={ 1 }>
+					<span className="social-post-card-embed-external__title">{ embed.title }</span>
+					<span className="social-post-card-embed-external__description">
+						{ embed.description }
+					</span>
+					<span className="social-post-card-embed-external__host">{ safeHost( embed.uri ) }</span>
+				</VStack>
+			</HStack>
+		</a>
+	);
+}

--- a/client/reader/social/components/post-card/post-card-embed-images.tsx
+++ b/client/reader/social/components/post-card/post-card-embed-images.tsx
@@ -7,6 +7,7 @@ interface PostCardEmbedImagesProps {
 
 export function PostCardEmbedImages( { embed }: PostCardEmbedImagesProps ) {
 	const count = Math.min( embed.images.length, 4 );
+	const isSingle = count === 1;
 	return (
 		<div
 			className={ clsx(
@@ -21,8 +22,12 @@ export function PostCardEmbedImages( { embed }: PostCardEmbedImagesProps ) {
 					href={ image.fullsize }
 					target="_blank"
 					rel="noopener noreferrer"
+					// Only honour the per-image aspect ratio for single-image
+					// embeds. Multi-image grids use uniform cells (set in CSS) so
+					// the layout stays even when individual images differ in
+					// shape. matching bsky.app's tile behaviour.
 					style={
-						image.aspect_ratio
+						isSingle && image.aspect_ratio
 							? {
 									aspectRatio: `${ image.aspect_ratio.width } / ${ image.aspect_ratio.height }`,
 							  }

--- a/client/reader/social/components/post-card/post-card-embed-images.tsx
+++ b/client/reader/social/components/post-card/post-card-embed-images.tsx
@@ -1,0 +1,37 @@
+import clsx from 'clsx';
+import type { AtmosphereEmbedImages } from '@automattic/api-core';
+
+interface PostCardEmbedImagesProps {
+	embed: AtmosphereEmbedImages;
+}
+
+export function PostCardEmbedImages( { embed }: PostCardEmbedImagesProps ) {
+	const count = Math.min( embed.images.length, 4 );
+	return (
+		<div
+			className={ clsx(
+				'social-post-card-embed-images',
+				`social-post-card-embed-images--count-${ count }`
+			) }
+		>
+			{ embed.images.slice( 0, 4 ).map( ( image ) => (
+				<a
+					key={ image.thumb }
+					className="social-post-card-embed-images__item"
+					href={ image.fullsize }
+					target="_blank"
+					rel="noopener noreferrer"
+					style={
+						image.aspect_ratio
+							? {
+									aspectRatio: `${ image.aspect_ratio.width } / ${ image.aspect_ratio.height }`,
+							  }
+							: undefined
+					}
+				>
+					<img src={ image.thumb } alt={ image.alt } loading="lazy" />
+				</a>
+			) ) }
+		</div>
+	);
+}

--- a/client/reader/social/components/post-card/post-card-embed-quote-tombstone.tsx
+++ b/client/reader/social/components/post-card/post-card-embed-quote-tombstone.tsx
@@ -1,0 +1,17 @@
+import { useTranslate } from 'i18n-calypso';
+import type { AtmosphereQuoteTombstone } from '@automattic/api-core';
+
+interface PostCardEmbedQuoteTombstoneProps {
+	tombstone: AtmosphereQuoteTombstone;
+}
+
+export function PostCardEmbedQuoteTombstone( { tombstone }: PostCardEmbedQuoteTombstoneProps ) {
+	const translate = useTranslate();
+	return (
+		<div className="social-post-card-embed-quote-tombstone">
+			{ tombstone.type === 'blocked'
+				? translate( 'Quoted post is from a blocked author.' )
+				: translate( 'Quoted post unavailable.' ) }
+		</div>
+	);
+}

--- a/client/reader/social/components/post-card/post-card-embed-quote-with-media.tsx
+++ b/client/reader/social/components/post-card/post-card-embed-quote-with-media.tsx
@@ -1,0 +1,26 @@
+import { __experimentalVStack as VStack } from '@wordpress/components';
+import { PostCardEmbedImages } from './post-card-embed-images';
+import { PostCardEmbedQuote } from './post-card-embed-quote';
+import { PostCardEmbedVideo } from './post-card-embed-video';
+import type { AtmosphereEmbedQuoteWithMedia } from '@automattic/api-core';
+
+interface PostCardEmbedQuoteWithMediaProps {
+	embed: AtmosphereEmbedQuoteWithMedia;
+	parentPostUri: string;
+}
+
+export function PostCardEmbedQuoteWithMedia( {
+	embed,
+	parentPostUri,
+}: PostCardEmbedQuoteWithMediaProps ) {
+	return (
+		<VStack spacing={ 2 } className="social-post-card-embed-quote-with-media">
+			<PostCardEmbedQuote
+				embed={ { type: 'quote', post: embed.post } }
+				parentPostUri={ parentPostUri }
+			/>
+			{ embed.media?.type === 'images' && <PostCardEmbedImages embed={ embed.media } /> }
+			{ embed.media?.type === 'video' && <PostCardEmbedVideo embed={ embed.media } /> }
+		</VStack>
+	);
+}

--- a/client/reader/social/components/post-card/post-card-embed-quote.tsx
+++ b/client/reader/social/components/post-card/post-card-embed-quote.tsx
@@ -1,3 +1,4 @@
+import { useSocialAnalytics } from './analytics-context';
 import { PostCardEmbedQuoteTombstone } from './post-card-embed-quote-tombstone';
 import { SocialPostCard } from './index';
 import type { AtmosphereEmbedQuote } from '@automattic/api-core';
@@ -7,9 +8,31 @@ interface PostCardEmbedQuoteProps {
 	parentPostUri: string;
 }
 
-export function PostCardEmbedQuote( { embed }: PostCardEmbedQuoteProps ) {
+export function PostCardEmbedQuote( { embed, parentPostUri }: PostCardEmbedQuoteProps ) {
+	const analytics = useSocialAnalytics();
 	if ( embed.post.type === 'not_found' || embed.post.type === 'blocked' ) {
 		return <PostCardEmbedQuoteTombstone tombstone={ embed.post } />;
 	}
-	return <SocialPostCard post={ embed.post } variant="compact" />;
+	const inner = embed.post;
+	const handleClick = () => {
+		if ( ! analytics ) {
+			return;
+		}
+		analytics.onClick( `calypso_reader_${ analytics.source }_timeline_quote_clicked`, {
+			connection_id: analytics.connectionId,
+			parent_uri: parentPostUri,
+			quoted_uri: inner.uri,
+		} );
+	};
+	return (
+		<a
+			className="social-post-card-embed-quote-link"
+			href={ inner.bluesky_url }
+			target="_blank"
+			rel="noopener noreferrer"
+			onClick={ handleClick }
+		>
+			<SocialPostCard post={ inner } variant="compact" />
+		</a>
+	);
 }

--- a/client/reader/social/components/post-card/post-card-embed-quote.tsx
+++ b/client/reader/social/components/post-card/post-card-embed-quote.tsx
@@ -1,0 +1,15 @@
+import { PostCardEmbedQuoteTombstone } from './post-card-embed-quote-tombstone';
+import { SocialPostCard } from './index';
+import type { AtmosphereEmbedQuote } from '@automattic/api-core';
+
+interface PostCardEmbedQuoteProps {
+	embed: AtmosphereEmbedQuote;
+	parentPostUri: string;
+}
+
+export function PostCardEmbedQuote( { embed }: PostCardEmbedQuoteProps ) {
+	if ( embed.post.type === 'not_found' || embed.post.type === 'blocked' ) {
+		return <PostCardEmbedQuoteTombstone tombstone={ embed.post } />;
+	}
+	return <SocialPostCard post={ embed.post } variant="compact" />;
+}

--- a/client/reader/social/components/post-card/post-card-embed-quote.tsx
+++ b/client/reader/social/components/post-card/post-card-embed-quote.tsx
@@ -10,7 +10,9 @@ interface PostCardEmbedQuoteProps {
 
 export function PostCardEmbedQuote( { embed, parentPostUri }: PostCardEmbedQuoteProps ) {
 	const analytics = useSocialAnalytics();
-	if ( embed.post.type === 'not_found' || embed.post.type === 'blocked' ) {
+	// AtmosphereFeedItem has no `type` field; the discriminator only exists on
+	// the tombstone shape, so narrow via `in` rather than property access.
+	if ( 'type' in embed.post ) {
 		return <PostCardEmbedQuoteTombstone tombstone={ embed.post } />;
 	}
 	const inner = embed.post;

--- a/client/reader/social/components/post-card/post-card-embed-video.tsx
+++ b/client/reader/social/components/post-card/post-card-embed-video.tsx
@@ -1,0 +1,30 @@
+import type { AtmosphereEmbedVideo } from '@automattic/api-core';
+
+interface PostCardEmbedVideoProps {
+	embed: AtmosphereEmbedVideo;
+}
+
+export function PostCardEmbedVideo( { embed }: PostCardEmbedVideoProps ) {
+	return (
+		<div
+			className="social-post-card-embed-video"
+			style={
+				embed.aspect_ratio
+					? {
+							aspectRatio: `${ embed.aspect_ratio.width } / ${ embed.aspect_ratio.height }`,
+					  }
+					: undefined
+			}
+		>
+			<img
+				className="social-post-card-embed-video__thumbnail"
+				src={ embed.thumbnail }
+				alt={ embed.alt || '' }
+				loading="lazy"
+			/>
+			<span className="social-post-card-embed-video__play" aria-hidden="true">
+				▶
+			</span>
+		</div>
+	);
+}

--- a/client/reader/social/components/post-card/post-card-embed.tsx
+++ b/client/reader/social/components/post-card/post-card-embed.tsx
@@ -1,0 +1,26 @@
+import { PostCardEmbedExternal } from './post-card-embed-external';
+import { PostCardEmbedImages } from './post-card-embed-images';
+import { PostCardEmbedQuote } from './post-card-embed-quote';
+import { PostCardEmbedQuoteWithMedia } from './post-card-embed-quote-with-media';
+import { PostCardEmbedVideo } from './post-card-embed-video';
+import type { AtmosphereEmbed } from '@automattic/api-core';
+
+interface PostCardEmbedProps {
+	embed: AtmosphereEmbed;
+	parentPostUri: string;
+}
+
+export function PostCardEmbed( { embed, parentPostUri }: PostCardEmbedProps ) {
+	switch ( embed.type ) {
+		case 'images':
+			return <PostCardEmbedImages embed={ embed } />;
+		case 'video':
+			return <PostCardEmbedVideo embed={ embed } />;
+		case 'external':
+			return <PostCardEmbedExternal embed={ embed } parentPostUri={ parentPostUri } />;
+		case 'quote':
+			return <PostCardEmbedQuote embed={ embed } parentPostUri={ parentPostUri } />;
+		case 'quote_with_media':
+			return <PostCardEmbedQuoteWithMedia embed={ embed } parentPostUri={ parentPostUri } />;
+	}
+}

--- a/client/reader/social/components/post-card/post-card-header.tsx
+++ b/client/reader/social/components/post-card/post-card-header.tsx
@@ -1,0 +1,66 @@
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import type { AtmosphereFeedItem } from '@automattic/api-core';
+
+interface PostCardHeaderProps {
+	post: AtmosphereFeedItem;
+	variant: 'default' | 'compact';
+}
+
+export function PostCardHeader( { post, variant }: PostCardHeaderProps ) {
+	const translate = useTranslate();
+	const displayName = post.author.display_name || post.author.handle;
+	const profileUrl = `https://bsky.app/profile/${ post.author.handle }`;
+	const avatarSize = variant === 'compact' ? 24 : 40;
+
+	return (
+		<VStack spacing={ 1 } className="social-post-card-header">
+			{ post.reason && post.reason.type === 'repost' && (
+				<div className="social-post-card-header__reason">
+					{ translate( '🔁 Reposted by %(name)s', {
+						args: { name: post.reason.by.display_name || post.reason.by.handle },
+					} ) }
+				</div>
+			) }
+			{ post.reply_parent && (
+				<div className="social-post-card-header__reply-context">
+					{ translate( '↩ Replying to @%(handle)s', {
+						args: { handle: post.reply_parent.author.handle },
+					} ) }
+				</div>
+			) }
+			<HStack alignment="center" spacing={ 2 } justify="flex-start">
+				<a
+					className="social-post-card-header__author"
+					href={ profileUrl }
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					{ post.author.avatar ? (
+						<img
+							src={ post.author.avatar }
+							alt={ post.author.handle }
+							width={ avatarSize }
+							height={ avatarSize }
+							loading="lazy"
+							className="social-post-card-header__avatar"
+						/>
+					) : (
+						<div
+							className="social-post-card-header__avatar social-post-card-header__avatar--placeholder"
+							style={ { width: avatarSize, height: avatarSize } }
+							aria-hidden="true"
+						/>
+					) }
+					<VStack spacing={ 0 }>
+						<span className="social-post-card-header__display-name">{ displayName }</span>
+						<span className="social-post-card-header__handle">@{ post.author.handle }</span>
+					</VStack>
+				</a>
+			</HStack>
+		</VStack>
+	);
+}

--- a/client/reader/social/components/post-card/post-card-header.tsx
+++ b/client/reader/social/components/post-card/post-card-header.tsx
@@ -3,6 +3,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { useSocialAnalytics } from './analytics-context';
 import type { AtmosphereFeedItem } from '@automattic/api-core';
 
 interface PostCardHeaderProps {
@@ -12,9 +13,21 @@ interface PostCardHeaderProps {
 
 export function PostCardHeader( { post, variant }: PostCardHeaderProps ) {
 	const translate = useTranslate();
+	const analytics = useSocialAnalytics();
 	const displayName = post.author.display_name || post.author.handle;
 	const profileUrl = `https://bsky.app/profile/${ post.author.handle }`;
 	const avatarSize = variant === 'compact' ? 24 : 40;
+
+	const handleAuthorClick = () => {
+		if ( ! analytics ) {
+			return;
+		}
+		analytics.onClick( `calypso_reader_${ analytics.source }_timeline_author_clicked`, {
+			connection_id: analytics.connectionId,
+			author_did: post.author.did,
+			author_handle: post.author.handle,
+		} );
+	};
 
 	return (
 		<VStack spacing={ 1 } className="social-post-card-header">
@@ -38,6 +51,7 @@ export function PostCardHeader( { post, variant }: PostCardHeaderProps ) {
 					href={ profileUrl }
 					target="_blank"
 					rel="noopener noreferrer"
+					onClick={ handleAuthorClick }
 				>
 					{ post.author.avatar ? (
 						<img

--- a/client/reader/social/components/post-card/post-card-header.tsx
+++ b/client/reader/social/components/post-card/post-card-header.tsx
@@ -5,6 +5,7 @@ import {
 import { useTranslate } from 'i18n-calypso';
 import { useSocialAnalytics } from './analytics-context';
 import type { AtmosphereFeedItem } from '@automattic/api-core';
+import type { ReactNode } from 'react';
 
 interface PostCardHeaderProps {
 	post: AtmosphereFeedItem;
@@ -14,9 +15,10 @@ interface PostCardHeaderProps {
 export function PostCardHeader( { post, variant }: PostCardHeaderProps ) {
 	const translate = useTranslate();
 	const analytics = useSocialAnalytics();
+	const isCompact = variant === 'compact';
 	const displayName = post.author.display_name || post.author.handle;
 	const profileUrl = `https://bsky.app/profile/${ post.author.handle }`;
-	const avatarSize = variant === 'compact' ? 24 : 40;
+	const avatarSize = isCompact ? 24 : 40;
 
 	const handleAuthorClick = () => {
 		if ( ! analytics ) {
@@ -29,51 +31,65 @@ export function PostCardHeader( { post, variant }: PostCardHeaderProps ) {
 		} );
 	};
 
+	const authorBody: ReactNode = (
+		<>
+			{ post.author.avatar ? (
+				<img
+					src={ post.author.avatar }
+					alt={ post.author.handle }
+					width={ avatarSize }
+					height={ avatarSize }
+					loading="lazy"
+					className="social-post-card-header__avatar"
+				/>
+			) : (
+				<div
+					className="social-post-card-header__avatar social-post-card-header__avatar--placeholder"
+					style={ { width: avatarSize, height: avatarSize } }
+					aria-hidden="true"
+				/>
+			) }
+			<VStack spacing={ 0 }>
+				<span className="social-post-card-header__display-name">{ displayName }</span>
+				<span className="social-post-card-header__handle">@{ post.author.handle }</span>
+			</VStack>
+		</>
+	);
+
 	return (
 		<VStack spacing={ 1 } className="social-post-card-header">
 			{ post.reason && post.reason.type === 'repost' && (
 				<div className="social-post-card-header__reason">
-					{ translate( '🔁 Reposted by %(name)s', {
+					<span aria-hidden="true">🔁 </span>
+					{ translate( 'Reposted by %(name)s', {
 						args: { name: post.reason.by.display_name || post.reason.by.handle },
 					} ) }
 				</div>
 			) }
 			{ post.reply_parent && (
 				<div className="social-post-card-header__reply-context">
-					{ translate( '↩ Replying to @%(handle)s', {
+					<span aria-hidden="true">↩ </span>
+					{ translate( 'Replying to @%(handle)s', {
 						args: { handle: post.reply_parent.author.handle },
 					} ) }
 				</div>
 			) }
 			<HStack alignment="center" spacing={ 2 } justify="flex-start">
-				<a
-					className="social-post-card-header__author"
-					href={ profileUrl }
-					target="_blank"
-					rel="noopener noreferrer"
-					onClick={ handleAuthorClick }
-				>
-					{ post.author.avatar ? (
-						<img
-							src={ post.author.avatar }
-							alt={ post.author.handle }
-							width={ avatarSize }
-							height={ avatarSize }
-							loading="lazy"
-							className="social-post-card-header__avatar"
-						/>
-					) : (
-						<div
-							className="social-post-card-header__avatar social-post-card-header__avatar--placeholder"
-							style={ { width: avatarSize, height: avatarSize } }
-							aria-hidden="true"
-						/>
-					) }
-					<VStack spacing={ 0 }>
-						<span className="social-post-card-header__display-name">{ displayName }</span>
-						<span className="social-post-card-header__handle">@{ post.author.handle }</span>
-					</VStack>
-				</a>
+				{ isCompact ? (
+					<div className="social-post-card-header__author social-post-card-header__author--inert">
+						{ authorBody }
+					</div>
+				) : (
+					<a
+						className="social-post-card-header__author"
+						href={ profileUrl }
+						target="_blank"
+						rel="noopener noreferrer"
+						onClick={ handleAuthorClick }
+					>
+						{ authorBody }
+					</a>
+				) }
 			</HStack>
 		</VStack>
 	);

--- a/client/reader/social/components/post-card/post-card-header.tsx
+++ b/client/reader/social/components/post-card/post-card-header.tsx
@@ -1,7 +1,4 @@
-import {
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-} from '@wordpress/components';
+import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSocialAnalytics } from './analytics-context';
 import type { AtmosphereFeedItem } from '@automattic/api-core';
@@ -10,17 +7,18 @@ import type { ReactNode } from 'react';
 interface PostCardHeaderProps {
 	post: AtmosphereFeedItem;
 	variant: 'default' | 'compact';
+	timestampLabel?: string;
 }
 
-export function PostCardHeader( { post, variant }: PostCardHeaderProps ) {
+export function PostCardHeader( { post, variant, timestampLabel }: PostCardHeaderProps ) {
 	const translate = useTranslate();
 	const analytics = useSocialAnalytics();
 	const isCompact = variant === 'compact';
 	const displayName = post.author.display_name || post.author.handle;
 	const profileUrl = `https://bsky.app/profile/${ post.author.handle }`;
-	const avatarSize = isCompact ? 24 : 40;
+	const avatarSize = isCompact ? 24 : 36;
 
-	const handleAuthorClick = () => {
+	const fireAuthorClicked = () => {
 		if ( ! analytics ) {
 			return;
 		}
@@ -31,28 +29,44 @@ export function PostCardHeader( { post, variant }: PostCardHeaderProps ) {
 		} );
 	};
 
+	const firePostClicked = () => {
+		if ( ! analytics ) {
+			return;
+		}
+		analytics.onClick( `calypso_reader_${ analytics.source }_timeline_post_clicked`, {
+			connection_id: analytics.connectionId,
+			post_uri: post.uri,
+			has_embed: post.embed !== null,
+			embed_type: post.embed?.type ?? null,
+			is_repost: post.reason !== null,
+			is_reply: post.reply_parent !== null,
+		} );
+	};
+
+	const avatarEl: ReactNode = post.author.avatar ? (
+		<img
+			src={ post.author.avatar }
+			alt=""
+			width={ avatarSize }
+			height={ avatarSize }
+			loading="lazy"
+			className="social-post-card-header__avatar"
+		/>
+	) : (
+		<div
+			className="social-post-card-header__avatar social-post-card-header__avatar--placeholder"
+			style={ { width: avatarSize, height: avatarSize } }
+			aria-hidden="true"
+		/>
+	);
+
 	const authorBody: ReactNode = (
 		<>
-			{ post.author.avatar ? (
-				<img
-					src={ post.author.avatar }
-					alt={ post.author.handle }
-					width={ avatarSize }
-					height={ avatarSize }
-					loading="lazy"
-					className="social-post-card-header__avatar"
-				/>
-			) : (
-				<div
-					className="social-post-card-header__avatar social-post-card-header__avatar--placeholder"
-					style={ { width: avatarSize, height: avatarSize } }
-					aria-hidden="true"
-				/>
-			) }
-			<VStack spacing={ 0 }>
+			{ avatarEl }
+			<span className="social-post-card-header__author-text">
 				<span className="social-post-card-header__display-name">{ displayName }</span>
 				<span className="social-post-card-header__handle">@{ post.author.handle }</span>
-			</VStack>
+			</span>
 		</>
 	);
 
@@ -74,7 +88,7 @@ export function PostCardHeader( { post, variant }: PostCardHeaderProps ) {
 					} ) }
 				</div>
 			) }
-			<HStack alignment="center" spacing={ 2 } justify="flex-start">
+			<div className="social-post-card-header__row">
 				{ isCompact ? (
 					<div className="social-post-card-header__author social-post-card-header__author--inert">
 						{ authorBody }
@@ -85,12 +99,32 @@ export function PostCardHeader( { post, variant }: PostCardHeaderProps ) {
 						href={ profileUrl }
 						target="_blank"
 						rel="noopener noreferrer"
-						onClick={ handleAuthorClick }
+						onClick={ fireAuthorClicked }
 					>
 						{ authorBody }
 					</a>
 				) }
-			</HStack>
+				{ timestampLabel && (
+					<>
+						<span className="social-post-card-header__dot" aria-hidden="true">
+							·
+						</span>
+						{ isCompact ? (
+							<span className="social-post-card-header__timestamp">{ timestampLabel }</span>
+						) : (
+							<a
+								className="social-post-card-header__timestamp"
+								href={ post.bluesky_url }
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={ firePostClicked }
+							>
+								{ timestampLabel }
+							</a>
+						) }
+					</>
+				) }
+			</div>
 		</VStack>
 	);
 }

--- a/client/reader/social/components/post-card/post-card-header.tsx
+++ b/client/reader/social/components/post-card/post-card-header.tsx
@@ -1,3 +1,4 @@
+import { TimeSince } from '@automattic/components';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSocialAnalytics } from './analytics-context';
@@ -7,16 +8,16 @@ import type { ReactNode } from 'react';
 interface PostCardHeaderProps {
 	post: AtmosphereFeedItem;
 	variant: 'default' | 'compact';
-	timestampLabel?: string;
 }
 
-export function PostCardHeader( { post, variant, timestampLabel }: PostCardHeaderProps ) {
+export function PostCardHeader( { post, variant }: PostCardHeaderProps ) {
 	const translate = useTranslate();
 	const analytics = useSocialAnalytics();
 	const isCompact = variant === 'compact';
 	const displayName = post.author.display_name || post.author.handle;
 	const profileUrl = `https://bsky.app/profile/${ post.author.handle }`;
 	const avatarSize = isCompact ? 24 : 36;
+	const timestampIso = post.created_at || post.indexed_at;
 
 	const fireAuthorClicked = () => {
 		if ( ! analytics ) {
@@ -104,13 +105,13 @@ export function PostCardHeader( { post, variant, timestampLabel }: PostCardHeade
 						{ authorBody }
 					</a>
 				) }
-				{ timestampLabel && (
+				{ timestampIso && (
 					<>
 						<span className="social-post-card-header__dot" aria-hidden="true">
 							·
 						</span>
 						{ isCompact ? (
-							<span className="social-post-card-header__timestamp">{ timestampLabel }</span>
+							<TimeSince className="social-post-card-header__timestamp" date={ timestampIso } />
 						) : (
 							<a
 								className="social-post-card-header__timestamp"
@@ -119,7 +120,7 @@ export function PostCardHeader( { post, variant, timestampLabel }: PostCardHeade
 								rel="noopener noreferrer"
 								onClick={ firePostClicked }
 							>
-								{ timestampLabel }
+								<TimeSince date={ timestampIso } />
 							</a>
 						) }
 					</>

--- a/client/reader/social/components/post-card/post-card-link.tsx
+++ b/client/reader/social/components/post-card/post-card-link.tsx
@@ -1,47 +1,21 @@
 import './style.scss';
 
 import clsx from 'clsx';
-import { useSocialAnalytics } from './analytics-context';
-import type { AtmosphereFeedItem } from '@automattic/api-core';
 import type { ReactNode } from 'react';
 
 interface PostCardLinkProps {
-	post: AtmosphereFeedItem;
 	variant: 'default' | 'compact';
-	timestampLabel: string;
 	children: ReactNode;
 }
 
-export function PostCardLink( { post, variant, timestampLabel, children }: PostCardLinkProps ) {
-	const analytics = useSocialAnalytics();
-	const handleClick = () => {
-		if ( ! analytics ) {
-			return;
-		}
-		analytics.onClick( `calypso_reader_${ analytics.source }_timeline_post_clicked`, {
-			connection_id: analytics.connectionId,
-			post_uri: post.uri,
-			has_embed: post.embed !== null,
-			embed_type: post.embed?.type ?? null,
-			is_repost: post.reason !== null,
-			is_reply: post.reply_parent !== null,
-		} );
-	};
+// Card-link wrapper: provides the positioning context for the ::after overlay
+// the timestamp anchor in PostCardHeader uses to make the whole card a click
+// target for `post_clicked`. Compact mode is rendered without this wrapper —
+// see SocialPostCard.
+export function PostCardLink( { variant, children }: PostCardLinkProps ) {
 	return (
 		<div className={ clsx( 'social-post-card-link', `social-post-card-link--${ variant }` ) }>
 			{ children }
-			<a
-				className="social-post-card-link__timestamp"
-				href={ post.bluesky_url }
-				target="_blank"
-				rel="noopener noreferrer"
-				onClick={ handleClick }
-			>
-				<span>{ timestampLabel }</span>
-				<span className="social-post-card-link__cue" aria-hidden="true">
-					↗
-				</span>
-			</a>
 		</div>
 	);
 }

--- a/client/reader/social/components/post-card/post-card-link.tsx
+++ b/client/reader/social/components/post-card/post-card-link.tsx
@@ -1,6 +1,7 @@
 import './style.scss';
 
 import clsx from 'clsx';
+import { useSocialAnalytics } from './analytics-context';
 import type { AtmosphereFeedItem } from '@automattic/api-core';
 import type { ReactNode } from 'react';
 
@@ -12,6 +13,20 @@ interface PostCardLinkProps {
 }
 
 export function PostCardLink( { post, variant, timestampLabel, children }: PostCardLinkProps ) {
+	const analytics = useSocialAnalytics();
+	const handleClick = () => {
+		if ( ! analytics ) {
+			return;
+		}
+		analytics.onClick( `calypso_reader_${ analytics.source }_timeline_post_clicked`, {
+			connection_id: analytics.connectionId,
+			post_uri: post.uri,
+			has_embed: post.embed !== null,
+			embed_type: post.embed?.type ?? null,
+			is_repost: post.reason !== null,
+			is_reply: post.reply_parent !== null,
+		} );
+	};
 	return (
 		<div className={ clsx( 'social-post-card-link', `social-post-card-link--${ variant }` ) }>
 			{ children }
@@ -20,6 +35,7 @@ export function PostCardLink( { post, variant, timestampLabel, children }: PostC
 				href={ post.bluesky_url }
 				target="_blank"
 				rel="noopener noreferrer"
+				onClick={ handleClick }
 			>
 				<span>{ timestampLabel }</span>
 				<span className="social-post-card-link__cue" aria-hidden="true">

--- a/client/reader/social/components/post-card/post-card-link.tsx
+++ b/client/reader/social/components/post-card/post-card-link.tsx
@@ -1,0 +1,31 @@
+import './style.scss';
+
+import clsx from 'clsx';
+import type { AtmosphereFeedItem } from '@automattic/api-core';
+import type { ReactNode } from 'react';
+
+interface PostCardLinkProps {
+	post: AtmosphereFeedItem;
+	variant: 'default' | 'compact';
+	timestampLabel: string;
+	children: ReactNode;
+}
+
+export function PostCardLink( { post, variant, timestampLabel, children }: PostCardLinkProps ) {
+	return (
+		<div className={ clsx( 'social-post-card-link', `social-post-card-link--${ variant }` ) }>
+			{ children }
+			<a
+				className="social-post-card-link__timestamp"
+				href={ post.bluesky_url }
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				<span>{ timestampLabel }</span>
+				<span className="social-post-card-link__cue" aria-hidden="true">
+					↗
+				</span>
+			</a>
+		</div>
+	);
+}

--- a/client/reader/social/components/post-card/sanitize-post-html.ts
+++ b/client/reader/social/components/post-card/sanitize-post-html.ts
@@ -1,0 +1,39 @@
+import DOMPurify from 'dompurify';
+
+const CONFIG = {
+	ALLOWED_TAGS: [ 'p', 'br', 'a' ],
+	ALLOWED_ATTR: [ 'href', 'rel', 'target' ],
+};
+
+let hookRegistered = false;
+
+function ensureHook() {
+	if ( hookRegistered ) {
+		return;
+	}
+	DOMPurify.addHook( 'afterSanitizeAttributes', ( node ) => {
+		if ( node.tagName !== 'A' ) {
+			return;
+		}
+		const target = node.getAttribute( 'target' );
+		if ( target?.toLowerCase() !== '_blank' ) {
+			return;
+		}
+		const existing = ( node.getAttribute( 'rel' ) || '' ).split( /\s+/ ).filter( Boolean );
+		for ( const token of [ 'nofollow', 'noopener', 'noreferrer' ] ) {
+			if ( ! existing.includes( token ) ) {
+				existing.push( token );
+			}
+		}
+		node.setAttribute( 'rel', existing.join( ' ' ) );
+	} );
+	hookRegistered = true;
+}
+
+export function sanitizePostHtml( html: string ): string {
+	if ( ! html ) {
+		return '';
+	}
+	ensureHook();
+	return DOMPurify.sanitize( html, CONFIG );
+}

--- a/client/reader/social/components/post-card/style.scss
+++ b/client/reader/social/components/post-card/style.scss
@@ -1,0 +1,19 @@
+.social-post-card-link {
+	position: relative;
+
+	.social-post-card-link__timestamp {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		text-decoration: none;
+		font-size: 0.85em;
+		color: var(--studio-gray-50);
+
+		&::after {
+			content: '';
+			position: absolute;
+			inset: 0;
+			z-index: 0;
+		}
+	}
+}

--- a/client/reader/social/components/post-card/style.scss
+++ b/client/reader/social/components/post-card/style.scss
@@ -16,4 +16,24 @@
 			z-index: 0;
 		}
 	}
+
+	.social-post-card-link__timestamp--inert {
+		// Compact-mode timestamp inside a quoted card: plain text, no overlay.
+		&::after {
+			content: none;
+		}
+	}
+
+	// Inner anchors must stay clickable above the ::after card-link overlay.
+	// Without this, the absolutely-positioned overlay (z-index: 0, covering
+	// the entire wrapper) would hit-test above sibling inline anchors and
+	// swallow author_clicked / external_clicked / quote_clicked / per-image
+	// clicks, sending every click to post_clicked.
+	.social-post-card-header__author,
+	.social-post-card-embed-external,
+	.social-post-card-embed-quote-link,
+	.social-post-card-embed-images__item {
+		position: relative;
+		z-index: 1;
+	}
 }

--- a/client/reader/social/components/post-card/style.scss
+++ b/client/reader/social/components/post-card/style.scss
@@ -7,7 +7,7 @@
 		gap: 4px;
 		text-decoration: none;
 		font-size: 0.85em;
-		color: var(--studio-gray-50);
+		color: var( --studio-gray-50 );
 
 		&::after {
 			content: '';

--- a/client/reader/social/components/post-card/style.scss
+++ b/client/reader/social/components/post-card/style.scss
@@ -195,16 +195,37 @@ a.social-post-card-header__timestamp::after {
 	grid-template-columns: 1fr;
 }
 
+// 2-, 3- and 4-image grids use uniform 1:1 tiles so the grid stays even
+// when individual images differ in aspect ratio (matches bsky.app).
 .social-post-card-embed-images--count-2 {
 	grid-template-columns: 1fr 1fr;
+
+	.social-post-card-embed-images__item {
+		aspect-ratio: 1 / 1;
+	}
 }
 
+// 3-image grid: tall left tile, two stacked right tiles, all 1:1.
 .social-post-card-embed-images--count-3 {
 	grid-template-columns: 1fr 1fr;
+	grid-template-rows: 1fr 1fr;
+
+	.social-post-card-embed-images__item {
+		aspect-ratio: 1 / 1;
+	}
+
+	.social-post-card-embed-images__item:first-child {
+		grid-row: span 2;
+		aspect-ratio: 1 / 2;
+	}
 }
 
 .social-post-card-embed-images--count-4 {
 	grid-template-columns: 1fr 1fr;
+
+	.social-post-card-embed-images__item {
+		aspect-ratio: 1 / 1;
+	}
 }
 
 .social-post-card-embed-images__item {

--- a/client/reader/social/components/post-card/style.scss
+++ b/client/reader/social/components/post-card/style.scss
@@ -1,34 +1,7 @@
 .social-post-card-link {
 	position: relative;
 
-	.social-post-card-link__timestamp {
-		display: inline-flex;
-		align-items: center;
-		gap: 4px;
-		text-decoration: none;
-		font-size: 0.85em;
-		color: var( --studio-gray-50 );
-
-		&::after {
-			content: '';
-			position: absolute;
-			inset: 0;
-			z-index: 0;
-		}
-	}
-
-	.social-post-card-link__timestamp--inert {
-		// Compact-mode timestamp inside a quoted card: plain text, no overlay.
-		&::after {
-			content: none;
-		}
-	}
-
-	// Inner anchors must stay clickable above the ::after card-link overlay.
-	// Without this, the absolutely-positioned overlay (z-index: 0, covering
-	// the entire wrapper) would hit-test above sibling inline anchors and
-	// swallow author_clicked / external_clicked / quote_clicked / per-image
-	// clicks, sending every click to post_clicked.
+	// Inner anchors stay clickable above the timestamp ::after card-link overlay.
 	.social-post-card-header__author,
 	.social-post-card-embed-external,
 	.social-post-card-embed-quote-link,
@@ -36,4 +9,316 @@
 		position: relative;
 		z-index: 1;
 	}
+}
+
+.social-post-card {
+	box-shadow: none;
+	border-radius: 0;
+	border-bottom: 1px solid var( --studio-gray-5 );
+
+	&:hover {
+		background: var( --studio-gray-0 );
+	}
+
+	.components-card__body {
+		padding: 12px 16px;
+	}
+}
+
+.social-post-card--compact {
+	border-bottom: 1px solid var( --studio-gray-5 );
+	border-radius: 8px;
+
+	.components-card__body {
+		padding: 10px 12px;
+	}
+
+	&:hover {
+		background: transparent;
+	}
+}
+
+.social-post-card-header {
+	gap: 4px;
+}
+
+.social-post-card-header__reason,
+.social-post-card-header__reply-context {
+	font-size: 0.875rem;
+	color: var( --studio-gray-50 );
+	line-height: 1.4;
+}
+
+.social-post-card-header__row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	min-width: 0;
+}
+
+.social-post-card-header__author {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	min-width: 0;
+	flex-shrink: 1;
+	text-decoration: none;
+	color: inherit;
+	max-width: 100%;
+	overflow: hidden;
+}
+
+a.social-post-card-header__author:hover .social-post-card-header__display-name {
+	text-decoration: underline;
+}
+
+.social-post-card-header__avatar {
+	flex-shrink: 0;
+	border-radius: 50%;
+	object-fit: cover;
+	background: var( --studio-gray-5 );
+}
+
+.social-post-card-header__avatar--placeholder {
+	background: var( --studio-gray-10 );
+}
+
+.social-post-card-header__author-text {
+	display: flex;
+	align-items: baseline;
+	gap: 6px;
+	min-width: 0;
+	flex-wrap: nowrap;
+	overflow: hidden;
+}
+
+.social-post-card-header__display-name {
+	font-weight: 600;
+	color: var( --studio-gray-100 );
+	font-size: 0.875rem;
+	line-height: 1.3;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	max-width: 100%;
+}
+
+.social-post-card-header__handle {
+	color: var( --studio-gray-50 );
+	font-size: 0.875rem;
+	line-height: 1.3;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	min-width: 0;
+}
+
+.social-post-card-header__dot {
+	color: var( --studio-gray-50 );
+	font-size: 0.875rem;
+	flex-shrink: 0;
+}
+
+.social-post-card-header__timestamp {
+	color: var( --studio-gray-50 );
+	font-size: 0.875rem;
+	text-decoration: none;
+	white-space: nowrap;
+	flex-shrink: 0;
+
+	&:hover {
+		text-decoration: underline;
+	}
+}
+
+a.social-post-card-header__timestamp::after {
+	content: '';
+	position: absolute;
+	inset: 0;
+	z-index: 0;
+}
+
+.social-post-card-body {
+	font-size: 1rem;
+	line-height: 1.5;
+	color: var( --studio-gray-100 );
+	margin: 8px 0;
+	white-space: pre-wrap;
+	word-wrap: break-word;
+
+	p {
+		margin: 0 0 0.5em;
+
+		&:last-child {
+			margin-bottom: 0;
+		}
+	}
+
+	a {
+		color: var( --studio-blue-50 );
+		text-decoration: none;
+
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+}
+
+.social-post-card-counts {
+	margin-top: 8px;
+	font-size: 0.875rem;
+	color: var( --studio-gray-50 );
+	gap: 16px;
+
+	span {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+	}
+}
+
+.social-post-card-embed-images {
+	display: grid;
+	gap: 4px;
+	margin-top: 8px;
+	border-radius: 8px;
+	overflow: hidden;
+}
+
+.social-post-card-embed-images--count-1 {
+	grid-template-columns: 1fr;
+}
+
+.social-post-card-embed-images--count-2 {
+	grid-template-columns: 1fr 1fr;
+}
+
+.social-post-card-embed-images--count-3 {
+	grid-template-columns: 1fr 1fr;
+}
+
+.social-post-card-embed-images--count-4 {
+	grid-template-columns: 1fr 1fr;
+}
+
+.social-post-card-embed-images__item {
+	display: block;
+	overflow: hidden;
+	background: var( --studio-gray-5 );
+
+	img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		display: block;
+	}
+}
+
+.social-post-card-embed-video {
+	position: relative;
+	overflow: hidden;
+	border-radius: 8px;
+	margin-top: 8px;
+	background: var( --studio-gray-90 );
+}
+
+.social-post-card-embed-video__thumbnail {
+	width: 100%;
+	height: auto;
+	display: block;
+	object-fit: cover;
+}
+
+.social-post-card-embed-video__play {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 3rem;
+	color: rgba( 255, 255, 255, 0.95 );
+	text-shadow: 0 2px 8px rgba( 0, 0, 0, 0.5 );
+	pointer-events: none;
+}
+
+.social-post-card-embed-external {
+	display: block;
+	margin-top: 8px;
+	border: 1px solid var( --studio-gray-5 );
+	border-radius: 8px;
+	overflow: hidden;
+	text-decoration: none;
+	color: inherit;
+	background: var( --studio-white );
+
+	&:hover {
+		background: var( --studio-gray-0 );
+	}
+
+	.components-h-stack {
+		padding: 12px;
+	}
+}
+
+.social-post-card-embed-external__thumb {
+	width: 64px;
+	height: 64px;
+	border-radius: 8px;
+	object-fit: cover;
+	flex-shrink: 0;
+}
+
+.social-post-card-embed-external__title {
+	font-weight: 600;
+	font-size: 0.875rem;
+	color: var( --studio-gray-100 );
+	line-height: 1.3;
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+}
+
+.social-post-card-embed-external__description {
+	font-size: 0.75rem;
+	color: var( --studio-gray-50 );
+	line-height: 1.4;
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+}
+
+.social-post-card-embed-external__host {
+	font-size: 0.75rem;
+	color: var( --studio-gray-50 );
+}
+
+.social-post-card-embed-quote-link {
+	display: block;
+	margin-top: 8px;
+	border: 1px solid var( --studio-gray-5 );
+	border-radius: 8px;
+	overflow: hidden;
+	text-decoration: none;
+	color: inherit;
+
+	&:hover {
+		background: var( --studio-gray-0 );
+	}
+}
+
+.social-post-card-embed-quote-tombstone {
+	margin-top: 8px;
+	padding: 12px;
+	border: 1px solid var( --studio-gray-5 );
+	border-radius: 8px;
+	color: var( --studio-gray-50 );
+	font-size: 0.875rem;
+	font-style: italic;
+}
+
+.social-post-card-embed-quote-with-media {
+	margin-top: 8px;
+	gap: 4px !important;
 }

--- a/client/reader/social/components/post-card/style.scss
+++ b/client/reader/social/components/post-card/style.scss
@@ -11,10 +11,14 @@
 	}
 }
 
-.social-post-card {
+// Override the @wordpress/components Card defaults (7px radius + 1px
+// shadow-border) so feed cards stack as a flat scrolling list with a single
+// hairline divider between rows, matching bsky.app's compact density.
+.social-post-card.components-card {
 	box-shadow: none;
 	border-radius: 0;
 	border-bottom: 1px solid var( --studio-gray-5 );
+	background: transparent;
 
 	&:hover {
 		background: var( --studio-gray-0 );
@@ -25,9 +29,11 @@
 	}
 }
 
-.social-post-card--compact {
-	border-bottom: 1px solid var( --studio-gray-5 );
+.social-post-card--compact.components-card {
 	border-radius: 8px;
+	border-bottom: none;
+	box-shadow: 0 0 0 1px var( --studio-gray-5 );
+	background: transparent;
 
 	.components-card__body {
 		padding: 10px 12px;

--- a/client/reader/social/components/post-card/style.scss
+++ b/client/reader/social/components/post-card/style.scss
@@ -350,7 +350,10 @@ a.social-post-card-header__timestamp::after {
 	font-style: italic;
 }
 
-.social-post-card-embed-quote-with-media {
+// Override @wordpress/components VStack's higher-specificity `gap` so the
+// inner quote and media stack tightly. Selector specificity must beat the
+// component's own internal rule.
+.components-flex.social-post-card-embed-quote-with-media {
 	margin-top: 8px;
-	gap: 4px !important;
+	gap: 4px;
 }

--- a/client/reader/social/components/post-card/style.scss
+++ b/client/reader/social/components/post-card/style.scss
@@ -181,6 +181,11 @@ a.social-post-card-header__timestamp::after {
 		align-items: center;
 		gap: 4px;
 	}
+
+	svg {
+		flex-shrink: 0;
+		fill: currentColor;
+	}
 }
 
 .social-post-card-embed-images {

--- a/client/reader/social/components/post-card/test/index.test.tsx
+++ b/client/reader/social/components/post-card/test/index.test.tsx
@@ -53,6 +53,11 @@ describe( 'SocialPostCard', () => {
 		expect( screen.queryByLabelText( /likes/i ) ).toBeNull();
 	} );
 
+	it( 'compact variant renders no anchors so consumers can wrap it in their own', () => {
+		const { container } = render( <SocialPostCard post={ post } variant="compact" /> );
+		expect( container.querySelectorAll( 'a' ) ).toHaveLength( 0 );
+	} );
+
 	it( 'renders embed when present in default variant', () => {
 		render(
 			<SocialPostCard

--- a/client/reader/social/components/post-card/test/index.test.tsx
+++ b/client/reader/social/components/post-card/test/index.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { SocialPostCard } from '../index';
+import type { AtmosphereFeedItem } from '@automattic/api-core';
+
+const post: AtmosphereFeedItem = {
+	uri: 'at://did:plc:abc/app.bsky.feed.post/x',
+	cid: 'c',
+	author: { did: 'did:plc:abc', handle: 'alice.bsky.social', display_name: 'Alice', avatar: null },
+	created_at: '2026-04-27T10:00:00Z',
+	indexed_at: '2026-04-27T10:00:00Z',
+	text: 'hello',
+	html: '<p>hello</p>',
+	lang: [ 'en' ],
+	reply_parent: null,
+	reply_root: null,
+	reason: null,
+	embed: null,
+	counts: { replies: 1, reposts: 2, likes: 3, quotes: 4 },
+	bluesky_url: 'https://bsky.app/profile/alice.bsky.social/post/x',
+};
+
+describe( 'SocialPostCard', () => {
+	it( 'renders header, body, counts, and timestamp link in default variant', () => {
+		render( <SocialPostCard post={ post } variant="default" /> );
+		expect( screen.getByText( 'Alice' ) ).toBeVisible();
+		expect( screen.getByText( 'hello' ) ).toBeVisible();
+		expect( screen.getByLabelText( /likes/i ) ).toHaveTextContent( '3' );
+		// The ↗ cue is aria-hidden, so the timestamp link's accessible name is
+		// the time-ago label. Find it by href instead of matching the cue.
+		const timestampLink = screen
+			.getAllByRole( 'link' )
+			.find( ( a ) => a.getAttribute( 'href' ) === post.bluesky_url );
+		expect( timestampLink ).toBeDefined();
+	} );
+
+	it( 'omits embed and counts in compact variant', () => {
+		render(
+			<SocialPostCard
+				post={ {
+					...post,
+					embed: {
+						type: 'images',
+						images: [ { thumb: 't', fullsize: 'f', alt: 'a', aspect_ratio: null } ],
+					},
+				} }
+				variant="compact"
+			/>
+		);
+		expect( screen.queryByRole( 'img', { name: 'a' } ) ).toBeNull();
+		expect( screen.queryByLabelText( /likes/i ) ).toBeNull();
+	} );
+
+	it( 'renders embed when present in default variant', () => {
+		render(
+			<SocialPostCard
+				post={ {
+					...post,
+					embed: {
+						type: 'external',
+						uri: 'https://x.example',
+						title: 'T',
+						description: 'D',
+						thumb: null,
+					},
+				} }
+				variant="default"
+			/>
+		);
+		expect( screen.getByText( 'T' ) ).toBeVisible();
+	} );
+} );

--- a/client/reader/social/components/post-card/test/index.test.tsx
+++ b/client/reader/social/components/post-card/test/index.test.tsx
@@ -27,7 +27,7 @@ describe( 'SocialPostCard', () => {
 		render( <SocialPostCard post={ post } variant="default" /> );
 		expect( screen.getByText( 'Alice' ) ).toBeVisible();
 		expect( screen.getByText( 'hello' ) ).toBeVisible();
-		expect( screen.getByLabelText( /likes/i ) ).toHaveTextContent( '3' );
+		expect( screen.getByText( /likes:/i ).parentElement ).toHaveTextContent( /likes:\s*3/i );
 		// The ↗ cue is aria-hidden, so the timestamp link's accessible name is
 		// the time-ago label. Find it by href instead of matching the cue.
 		const timestampLink = screen
@@ -50,7 +50,7 @@ describe( 'SocialPostCard', () => {
 			/>
 		);
 		expect( screen.queryByRole( 'img', { name: 'a' } ) ).toBeNull();
-		expect( screen.queryByLabelText( /likes/i ) ).toBeNull();
+		expect( screen.queryByText( /likes:/i ) ).toBeNull();
 	} );
 
 	it( 'compact variant renders no anchors so consumers can wrap it in their own', () => {

--- a/client/reader/social/components/post-card/test/post-card-body.test.tsx
+++ b/client/reader/social/components/post-card/test/post-card-body.test.tsx
@@ -3,8 +3,9 @@
  */
 import { render } from '@testing-library/react';
 import { PostCardBody } from '../post-card-body';
+import type { AtmosphereFeedItem } from '@automattic/api-core';
 
-function baseHtml( html: string ) {
+function baseHtml( html: string ): AtmosphereFeedItem {
 	return {
 		uri: 'at://x',
 		cid: 'c',
@@ -20,7 +21,7 @@ function baseHtml( html: string ) {
 		embed: null,
 		counts: { replies: 0, reposts: 0, likes: 0, quotes: 0 },
 		bluesky_url: '',
-	} as const;
+	};
 }
 
 describe( 'PostCardBody', () => {

--- a/client/reader/social/components/post-card/test/post-card-body.test.tsx
+++ b/client/reader/social/components/post-card/test/post-card-body.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react';
+import { PostCardBody } from '../post-card-body';
+
+function baseHtml( html: string ) {
+	return {
+		uri: 'at://x',
+		cid: 'c',
+		author: { did: 'd', handle: 'h.bsky.social', display_name: '', avatar: null },
+		created_at: '',
+		indexed_at: '',
+		text: 'hello',
+		html,
+		lang: [],
+		reply_parent: null,
+		reply_root: null,
+		reason: null,
+		embed: null,
+		counts: { replies: 0, reposts: 0, likes: 0, quotes: 0 },
+		bluesky_url: '',
+	} as const;
+}
+
+describe( 'PostCardBody', () => {
+	it( 'renders the sanitised html via DOMPurify', () => {
+		const { container } = render(
+			<PostCardBody post={ baseHtml( '<p>hello <strong>x</strong></p>' ) } />
+		);
+		// strong is stripped by the sanitiser allow-list (only p / br / a allowed)
+		expect( container.querySelector( 'p' ) ).not.toBeNull();
+		expect( container.querySelector( 'strong' ) ).toBeNull();
+	} );
+
+	it( 'falls back to raw text when html is empty', () => {
+		const { getByText } = render( <PostCardBody post={ baseHtml( '' ) } /> );
+		expect( getByText( 'hello' ) ).toBeVisible();
+	} );
+} );

--- a/client/reader/social/components/post-card/test/post-card-counts.test.tsx
+++ b/client/reader/social/components/post-card/test/post-card-counts.test.tsx
@@ -1,0 +1,20 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { PostCardCounts } from '../post-card-counts';
+
+describe( 'PostCardCounts', () => {
+	it( 'renders all four counts with their labels', () => {
+		render( <PostCardCounts counts={ { replies: 1, reposts: 2, likes: 3, quotes: 4 } } /> );
+		expect( screen.getByLabelText( /replies/i ) ).toHaveTextContent( '1' );
+		expect( screen.getByLabelText( /reposts/i ) ).toHaveTextContent( '2' );
+		expect( screen.getByLabelText( /likes/i ) ).toHaveTextContent( '3' );
+		expect( screen.getByLabelText( /quotes/i ) ).toHaveTextContent( '4' );
+	} );
+
+	it( 'renders zeros without crashing', () => {
+		render( <PostCardCounts counts={ { replies: 0, reposts: 0, likes: 0, quotes: 0 } } /> );
+		expect( screen.getByLabelText( /replies/i ) ).toHaveTextContent( '0' );
+	} );
+} );

--- a/client/reader/social/components/post-card/test/post-card-counts.test.tsx
+++ b/client/reader/social/components/post-card/test/post-card-counts.test.tsx
@@ -5,16 +5,16 @@ import { render, screen } from '@testing-library/react';
 import { PostCardCounts } from '../post-card-counts';
 
 describe( 'PostCardCounts', () => {
-	it( 'renders all four counts with their labels', () => {
+	it( 'renders all four counts with screen-reader labels next to them', () => {
 		render( <PostCardCounts counts={ { replies: 1, reposts: 2, likes: 3, quotes: 4 } } /> );
-		expect( screen.getByLabelText( /replies/i ) ).toHaveTextContent( '1' );
-		expect( screen.getByLabelText( /reposts/i ) ).toHaveTextContent( '2' );
-		expect( screen.getByLabelText( /likes/i ) ).toHaveTextContent( '3' );
-		expect( screen.getByLabelText( /quotes/i ) ).toHaveTextContent( '4' );
+		expect( screen.getByText( /replies:/i ).parentElement ).toHaveTextContent( /replies:\s*1/i );
+		expect( screen.getByText( /reposts:/i ).parentElement ).toHaveTextContent( /reposts:\s*2/i );
+		expect( screen.getByText( /likes:/i ).parentElement ).toHaveTextContent( /likes:\s*3/i );
+		expect( screen.getByText( /quotes:/i ).parentElement ).toHaveTextContent( /quotes:\s*4/i );
 	} );
 
 	it( 'renders zeros without crashing', () => {
 		render( <PostCardCounts counts={ { replies: 0, reposts: 0, likes: 0, quotes: 0 } } /> );
-		expect( screen.getByLabelText( /replies/i ) ).toHaveTextContent( '0' );
+		expect( screen.getByText( /replies:/i ).parentElement ).toHaveTextContent( /replies:\s*0/i );
 	} );
 } );

--- a/client/reader/social/components/post-card/test/post-card-embed-external.test.tsx
+++ b/client/reader/social/components/post-card/test/post-card-embed-external.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { PostCardEmbedExternal } from '../post-card-embed-external';
+
+const embed = {
+	type: 'external' as const,
+	uri: 'https://example.com/article',
+	title: 'Title',
+	description: 'Description',
+	thumb: 'https://example.com/thumb.jpg',
+};
+
+describe( 'PostCardEmbedExternal', () => {
+	it( 'renders a link to the external URI', () => {
+		render( <PostCardEmbedExternal embed={ embed } parentPostUri="at://post" /> );
+		const link = screen.getByRole( 'link' );
+		expect( link ).toHaveAttribute( 'href', embed.uri );
+		expect( link ).toHaveAttribute( 'target', '_blank' );
+		expect( link ).toHaveAttribute( 'rel', 'noopener noreferrer' );
+	} );
+
+	it( 'renders title, description and host', () => {
+		render( <PostCardEmbedExternal embed={ embed } parentPostUri="at://post" /> );
+		expect( screen.getByText( 'Title' ) ).toBeVisible();
+		expect( screen.getByText( 'Description' ) ).toBeVisible();
+		expect( screen.getByText( 'example.com' ) ).toBeVisible();
+	} );
+
+	it( 'renders without a thumbnail when thumb is null', () => {
+		const { container } = render(
+			<PostCardEmbedExternal embed={ { ...embed, thumb: null } } parentPostUri="at://post" />
+		);
+		expect( container.querySelector( 'img' ) ).toBeNull();
+	} );
+} );

--- a/client/reader/social/components/post-card/test/post-card-embed-images.test.tsx
+++ b/client/reader/social/components/post-card/test/post-card-embed-images.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { PostCardEmbedImages } from '../post-card-embed-images';
+
+const embed = {
+	type: 'images' as const,
+	images: [
+		{
+			thumb: 'https://x/t1.jpg',
+			fullsize: 'https://x/f1.jpg',
+			alt: 'first',
+			aspect_ratio: { width: 1, height: 1 },
+		},
+		{
+			thumb: 'https://x/t2.jpg',
+			fullsize: 'https://x/f2.jpg',
+			alt: 'second',
+			aspect_ratio: null,
+		},
+	],
+};
+
+describe( 'PostCardEmbedImages', () => {
+	it( 'renders one img per source with alt text', () => {
+		render( <PostCardEmbedImages embed={ embed } /> );
+		const imgs = screen.getAllByRole( 'img' );
+		expect( imgs ).toHaveLength( 2 );
+		expect( imgs[ 0 ] ).toHaveAttribute( 'alt', 'first' );
+		expect( imgs[ 1 ] ).toHaveAttribute( 'alt', 'second' );
+	} );
+
+	it( 'each image is wrapped in an anchor pointing at fullsize', () => {
+		render( <PostCardEmbedImages embed={ embed } /> );
+		const links = screen.getAllByRole( 'link' );
+		expect( links[ 0 ] ).toHaveAttribute( 'href', 'https://x/f1.jpg' );
+		expect( links[ 1 ] ).toHaveAttribute( 'href', 'https://x/f2.jpg' );
+		links.forEach( ( link ) => {
+			expect( link ).toHaveAttribute( 'target', '_blank' );
+			expect( link ).toHaveAttribute( 'rel', 'noopener noreferrer' );
+		} );
+	} );
+} );

--- a/client/reader/social/components/post-card/test/post-card-embed-quote-tombstone.test.tsx
+++ b/client/reader/social/components/post-card/test/post-card-embed-quote-tombstone.test.tsx
@@ -1,0 +1,25 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { PostCardEmbedQuoteTombstone } from '../post-card-embed-quote-tombstone';
+
+describe( 'PostCardEmbedQuoteTombstone', () => {
+	it( 'renders the unavailable copy for a not_found tombstone', () => {
+		render(
+			<PostCardEmbedQuoteTombstone
+				tombstone={ { type: 'not_found', uri: 'at://x', reason: 'notfound' } }
+			/>
+		);
+		expect( screen.getByText( /unavailable/i ) ).toBeVisible();
+	} );
+
+	it( 'renders the blocked copy for a blocked tombstone', () => {
+		render(
+			<PostCardEmbedQuoteTombstone
+				tombstone={ { type: 'blocked', uri: 'at://y', reason: 'blocked' } }
+			/>
+		);
+		expect( screen.getByText( /blocked author/i ) ).toBeVisible();
+	} );
+} );

--- a/client/reader/social/components/post-card/test/post-card-embed-quote-with-media.test.tsx
+++ b/client/reader/social/components/post-card/test/post-card-embed-quote-with-media.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { PostCardEmbedQuoteWithMedia } from '../post-card-embed-quote-with-media';
+import type { AtmosphereFeedItem } from '@automattic/api-core';
+
+const innerPost: AtmosphereFeedItem = {
+	uri: 'at://did:plc:abc/app.bsky.feed.post/q',
+	cid: 'c',
+	author: { did: 'did:plc:abc', handle: 'q.bsky.social', display_name: 'Q', avatar: null },
+	created_at: '',
+	indexed_at: '',
+	text: 'quoted',
+	html: '<p>quoted</p>',
+	lang: [],
+	reply_parent: null,
+	reply_root: null,
+	reason: null,
+	embed: null,
+	counts: { replies: 0, reposts: 0, likes: 0, quotes: 0 },
+	bluesky_url: 'https://bsky.app/profile/q.bsky.social/post/q',
+};
+
+describe( 'PostCardEmbedQuoteWithMedia', () => {
+	it( 'renders inner quote + image grid', () => {
+		render(
+			<PostCardEmbedQuoteWithMedia
+				embed={ {
+					type: 'quote_with_media',
+					post: innerPost,
+					media: {
+						type: 'images',
+						images: [
+							{
+								thumb: 'https://x/t.jpg',
+								fullsize: 'https://x/f.jpg',
+								alt: 'pic',
+								aspect_ratio: null,
+							},
+						],
+					},
+				} }
+				parentPostUri="at://parent"
+			/>
+		);
+		expect( screen.getByText( 'quoted' ) ).toBeVisible();
+		expect( screen.getByRole( 'img', { name: 'pic' } ) ).toBeVisible();
+	} );
+
+	it( 'renders inner quote + video thumb', () => {
+		render(
+			<PostCardEmbedQuoteWithMedia
+				embed={ {
+					type: 'quote_with_media',
+					post: innerPost,
+					media: {
+						type: 'video',
+						playlist: 'https://x/p.m3u8',
+						thumbnail: 'https://x/t.jpg',
+						alt: 'vid',
+						aspect_ratio: null,
+					},
+				} }
+				parentPostUri="at://parent"
+			/>
+		);
+		expect( screen.getByText( 'quoted' ) ).toBeVisible();
+		expect( screen.getByRole( 'img', { name: /vid/i } ) ).toBeVisible();
+		expect( screen.getByText( '▶' ) ).toBeVisible();
+	} );
+
+	it( 'still renders the quote when media is null', () => {
+		render(
+			<PostCardEmbedQuoteWithMedia
+				embed={ { type: 'quote_with_media', post: innerPost, media: null } }
+				parentPostUri="at://parent"
+			/>
+		);
+		expect( screen.getByText( 'quoted' ) ).toBeVisible();
+	} );
+} );

--- a/client/reader/social/components/post-card/test/post-card-embed-quote.test.tsx
+++ b/client/reader/social/components/post-card/test/post-card-embed-quote.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { PostCardEmbedQuote } from '../post-card-embed-quote';
+import type { AtmosphereFeedItem } from '@automattic/api-core';
+
+const innerPost: AtmosphereFeedItem = {
+	uri: 'at://did:plc:abc/app.bsky.feed.post/inner',
+	cid: 'c',
+	author: { did: 'did:plc:abc', handle: 'inner.bsky.social', display_name: 'Inner', avatar: null },
+	created_at: '2026-04-27T09:00:00Z',
+	indexed_at: '2026-04-27T09:00:00Z',
+	text: 'inner text',
+	html: '<p>inner text</p>',
+	lang: [],
+	reply_parent: null,
+	reply_root: null,
+	reason: null,
+	embed: null,
+	counts: { replies: 0, reposts: 0, likes: 0, quotes: 0 },
+	bluesky_url: 'https://bsky.app/profile/inner.bsky.social/post/inner',
+};
+
+describe( 'PostCardEmbedQuote', () => {
+	it( 'renders a tombstone for a not_found quote', () => {
+		render(
+			<PostCardEmbedQuote
+				embed={ {
+					type: 'quote',
+					post: { type: 'not_found', uri: 'at://x', reason: 'notfound' },
+				} }
+				parentPostUri="at://parent"
+			/>
+		);
+		expect( screen.getByText( /unavailable/i ) ).toBeVisible();
+	} );
+
+	it( 'renders a tombstone for a blocked quote', () => {
+		render(
+			<PostCardEmbedQuote
+				embed={ { type: 'quote', post: { type: 'blocked', uri: 'at://y', reason: 'blocked' } } }
+				parentPostUri="at://parent"
+			/>
+		);
+		expect( screen.getByText( /blocked author/i ) ).toBeVisible();
+	} );
+
+	it( 'renders the inner post for a live quote', () => {
+		render(
+			<PostCardEmbedQuote
+				embed={ { type: 'quote', post: innerPost } }
+				parentPostUri="at://parent"
+			/>
+		);
+		expect( screen.getByText( 'inner text' ) ).toBeVisible();
+		expect( screen.getByText( '@inner.bsky.social' ) ).toBeVisible();
+	} );
+} );

--- a/client/reader/social/components/post-card/test/post-card-embed-video.test.tsx
+++ b/client/reader/social/components/post-card/test/post-card-embed-video.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { PostCardEmbedVideo } from '../post-card-embed-video';
+
+const embed = {
+	type: 'video' as const,
+	playlist: 'https://x/playlist.m3u8',
+	thumbnail: 'https://x/thumb.jpg',
+	alt: 'a video',
+	aspect_ratio: { width: 16, height: 9 },
+};
+
+describe( 'PostCardEmbedVideo', () => {
+	it( 'renders the thumbnail with alt text', () => {
+		render( <PostCardEmbedVideo embed={ embed } /> );
+		const img = screen.getByRole( 'img', { name: /a video/i } );
+		expect( img ).toHaveAttribute( 'src', embed.thumbnail );
+	} );
+
+	it( 'renders the play overlay', () => {
+		render( <PostCardEmbedVideo embed={ embed } /> );
+		expect( screen.getByText( '▶' ) ).toBeVisible();
+	} );
+
+	it( 'is not itself an anchor (click bubbles to parent card-link)', () => {
+		const { container } = render( <PostCardEmbedVideo embed={ embed } /> );
+		expect( container.querySelector( 'a' ) ).toBeNull();
+	} );
+} );

--- a/client/reader/social/components/post-card/test/post-card-embed.test.tsx
+++ b/client/reader/social/components/post-card/test/post-card-embed.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { PostCardEmbed } from '../post-card-embed';
+
+describe( 'PostCardEmbed dispatcher', () => {
+	it( 'images → grid', () => {
+		render(
+			<PostCardEmbed
+				embed={ {
+					type: 'images',
+					images: [ { thumb: 't', fullsize: 'f', alt: 'pic', aspect_ratio: null } ],
+				} }
+				parentPostUri="at://parent"
+			/>
+		);
+		expect( screen.getByRole( 'img', { name: 'pic' } ) ).toBeVisible();
+	} );
+
+	it( 'video → thumbnail', () => {
+		render(
+			<PostCardEmbed
+				embed={ { type: 'video', playlist: 'p', thumbnail: 't', alt: 'v', aspect_ratio: null } }
+				parentPostUri="at://parent"
+			/>
+		);
+		expect( screen.getByRole( 'img', { name: 'v' } ) ).toBeVisible();
+		expect( screen.getByText( '▶' ) ).toBeVisible();
+	} );
+
+	it( 'external → link card', () => {
+		render(
+			<PostCardEmbed
+				embed={ {
+					type: 'external',
+					uri: 'https://x.example',
+					title: 'T',
+					description: 'D',
+					thumb: null,
+				} }
+				parentPostUri="at://parent"
+			/>
+		);
+		expect( screen.getByText( 'T' ) ).toBeVisible();
+		expect( screen.getByText( 'D' ) ).toBeVisible();
+	} );
+
+	it( 'quote tombstone → unavailable copy', () => {
+		render(
+			<PostCardEmbed
+				embed={ {
+					type: 'quote',
+					post: { type: 'not_found', uri: 'at://x', reason: 'notfound' },
+				} }
+				parentPostUri="at://parent"
+			/>
+		);
+		expect( screen.getByText( /unavailable/i ) ).toBeVisible();
+	} );
+} );

--- a/client/reader/social/components/post-card/test/post-card-header.test.tsx
+++ b/client/reader/social/components/post-card/test/post-card-header.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { PostCardHeader } from '../post-card-header';
+import type { AtmosphereFeedItem } from '@automattic/api-core';
+
+const base: AtmosphereFeedItem = {
+	uri: 'at://did:plc:abc/app.bsky.feed.post/x',
+	cid: 'c',
+	author: { did: 'did:plc:abc', handle: 'alice.bsky.social', display_name: 'Alice', avatar: null },
+	created_at: '2026-04-27T10:00:00Z',
+	indexed_at: '2026-04-27T10:00:00Z',
+	text: '',
+	html: '',
+	lang: [],
+	reply_parent: null,
+	reply_root: null,
+	reason: null,
+	embed: null,
+	counts: { replies: 0, reposts: 0, likes: 0, quotes: 0 },
+	bluesky_url: 'https://bsky.app/profile/alice.bsky.social/post/x',
+};
+
+describe( 'PostCardHeader', () => {
+	it( 'renders display name, handle, and a link to the author profile on bsky.app', () => {
+		render( <PostCardHeader post={ base } variant="default" /> );
+		expect( screen.getByText( 'Alice' ) ).toBeVisible();
+		expect( screen.getByText( '@alice.bsky.social' ) ).toBeVisible();
+		const authorLink = screen.getByRole( 'link', { name: /alice/i } );
+		expect( authorLink ).toHaveAttribute( 'href', 'https://bsky.app/profile/alice.bsky.social' );
+		expect( authorLink ).toHaveAttribute( 'target', '_blank' );
+	} );
+
+	it( 'falls back to handle when display_name is empty', () => {
+		render(
+			<PostCardHeader
+				post={ { ...base, author: { ...base.author, display_name: '' } } }
+				variant="default"
+			/>
+		);
+		expect( screen.getAllByText( /alice\.bsky\.social/ ).length ).toBeGreaterThan( 0 );
+	} );
+
+	it( 'renders the repost reason when post.reason is present', () => {
+		render(
+			<PostCardHeader
+				post={ {
+					...base,
+					reason: {
+						type: 'repost',
+						by: { did: 'did:plc:bob', handle: 'bob.bsky.social', display_name: 'Bob' },
+					},
+				} }
+				variant="default"
+			/>
+		);
+		expect( screen.getByText( /Reposted by Bob/ ) ).toBeVisible();
+	} );
+
+	it( 'renders the reply context when post.reply_parent is present', () => {
+		render(
+			<PostCardHeader
+				post={ {
+					...base,
+					reply_parent: {
+						uri: 'at://x',
+						author: { did: 'did:plc:c', handle: 'carol.bsky.social' },
+					},
+				} }
+				variant="default"
+			/>
+		);
+		expect( screen.getByText( /Replying to @carol\.bsky\.social/ ) ).toBeVisible();
+	} );
+} );

--- a/client/reader/social/components/post-card/test/post-card-link.test.tsx
+++ b/client/reader/social/components/post-card/test/post-card-link.test.tsx
@@ -4,51 +4,25 @@
 import { render, screen } from '@testing-library/react';
 import { PostCardLink } from '../post-card-link';
 
-const post = {
-	uri: 'at://did:plc:abc/app.bsky.feed.post/x',
-	cid: 'cid1',
-	bluesky_url: 'https://bsky.app/profile/a.bsky.social/post/x',
-	created_at: '2026-04-27T10:00:00Z',
-	indexed_at: '2026-04-27T10:00:00Z',
-	text: '',
-	html: '',
-	lang: [],
-	reply_parent: null,
-	reply_root: null,
-	reason: null,
-	embed: null,
-	counts: { replies: 0, reposts: 0, likes: 0, quotes: 0 },
-	author: { did: 'did:plc:abc', handle: 'a.bsky.social', display_name: 'A', avatar: null },
-} as const;
-
 describe( 'PostCardLink', () => {
-	it( 'renders a single anchor pointing at bluesky_url with target=_blank rel=noopener noreferrer', () => {
-		render(
-			<PostCardLink post={ post } variant="default" timestampLabel="2h ago">
-				<div>body</div>
-			</PostCardLink>
-		);
-		const link = screen.getByRole( 'link', { name: /2h ago/i } );
-		expect( link ).toHaveAttribute( 'href', post.bluesky_url );
-		expect( link ).toHaveAttribute( 'target', '_blank' );
-		expect( link ).toHaveAttribute( 'rel', 'noopener noreferrer' );
-	} );
-
-	it( 'renders the View on Bluesky cue', () => {
-		render(
-			<PostCardLink post={ post } variant="default" timestampLabel="2h ago">
-				<div>body</div>
-			</PostCardLink>
-		);
-		expect( screen.getByText( '↗' ) ).toBeVisible();
-	} );
-
-	it( 'renders the children inside the wrapper', () => {
-		render(
-			<PostCardLink post={ post } variant="default" timestampLabel="2h ago">
+	it( 'renders its children inside a position-relative wrapper', () => {
+		const { container } = render(
+			<PostCardLink variant="default">
 				<div>body content</div>
 			</PostCardLink>
 		);
 		expect( screen.getByText( 'body content' ) ).toBeVisible();
+		expect( container.querySelector( '.social-post-card-link' ) ).not.toBeNull();
+	} );
+
+	it( 'applies a variant modifier class', () => {
+		const { container } = render(
+			<PostCardLink variant="default">
+				<div>x</div>
+			</PostCardLink>
+		);
+		expect(
+			container.querySelector( '.social-post-card-link.social-post-card-link--default' )
+		).not.toBeNull();
 	} );
 } );

--- a/client/reader/social/components/post-card/test/post-card-link.test.tsx
+++ b/client/reader/social/components/post-card/test/post-card-link.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { PostCardLink } from '../post-card-link';
+
+const post = {
+	uri: 'at://did:plc:abc/app.bsky.feed.post/x',
+	cid: 'cid1',
+	bluesky_url: 'https://bsky.app/profile/a.bsky.social/post/x',
+	created_at: '2026-04-27T10:00:00Z',
+	indexed_at: '2026-04-27T10:00:00Z',
+	text: '',
+	html: '',
+	lang: [],
+	reply_parent: null,
+	reply_root: null,
+	reason: null,
+	embed: null,
+	counts: { replies: 0, reposts: 0, likes: 0, quotes: 0 },
+	author: { did: 'did:plc:abc', handle: 'a.bsky.social', display_name: 'A', avatar: null },
+} as const;
+
+describe( 'PostCardLink', () => {
+	it( 'renders a single anchor pointing at bluesky_url with target=_blank rel=noopener noreferrer', () => {
+		render(
+			<PostCardLink post={ post } variant="default" timestampLabel="2h ago">
+				<div>body</div>
+			</PostCardLink>
+		);
+		const link = screen.getByRole( 'link', { name: /2h ago/i } );
+		expect( link ).toHaveAttribute( 'href', post.bluesky_url );
+		expect( link ).toHaveAttribute( 'target', '_blank' );
+		expect( link ).toHaveAttribute( 'rel', 'noopener noreferrer' );
+	} );
+
+	it( 'renders the View on Bluesky cue', () => {
+		render(
+			<PostCardLink post={ post } variant="default" timestampLabel="2h ago">
+				<div>body</div>
+			</PostCardLink>
+		);
+		expect( screen.getByText( '↗' ) ).toBeVisible();
+	} );
+
+	it( 'renders the children inside the wrapper', () => {
+		render(
+			<PostCardLink post={ post } variant="default" timestampLabel="2h ago">
+				<div>body content</div>
+			</PostCardLink>
+		);
+		expect( screen.getByText( 'body content' ) ).toBeVisible();
+	} );
+} );

--- a/client/reader/social/components/post-card/test/sanitize-post-html.test.ts
+++ b/client/reader/social/components/post-card/test/sanitize-post-html.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment jsdom
+ */
+import { sanitizePostHtml } from '../sanitize-post-html';
+
+describe( 'sanitizePostHtml', () => {
+	it( 'preserves allowed tags (p, br, a)', () => {
+		const html = '<p>hello <a href="https://example.com">there</a><br>world</p>';
+		expect( sanitizePostHtml( html ) ).toBe( html );
+	} );
+
+	it( 'strips disallowed tags but keeps inner text', () => {
+		expect( sanitizePostHtml( '<p>hi <script>alert(1)</script> bye</p>' ) ).toBe(
+			'<p>hi  bye</p>'
+		);
+		expect( sanitizePostHtml( '<p><iframe src="x"></iframe>x</p>' ) ).toBe( '<p>x</p>' );
+		expect( sanitizePostHtml( '<p><img src="x">y</p>' ) ).toBe( '<p>y</p>' );
+	} );
+
+	it( 'strips disallowed attributes', () => {
+		const html = '<p>x <a href="https://example.com" onclick="evil()" style="color:red">y</a></p>';
+		const out = sanitizePostHtml( html );
+		expect( out ).not.toContain( 'onclick' );
+		expect( out ).not.toContain( 'style' );
+		expect( out ).toContain( 'href="https://example.com"' );
+	} );
+
+	it( 'strips javascript: URLs', () => {
+		const out = sanitizePostHtml( '<p><a href="javascript:alert(1)">x</a></p>' );
+		expect( out ).not.toContain( 'javascript:' );
+	} );
+
+	it( 'forces rel="nofollow noopener noreferrer" on target=_blank anchors', () => {
+		const out = sanitizePostHtml( '<p><a href="https://x.example" target="_blank">x</a></p>' );
+		expect( out ).toContain( 'rel="nofollow noopener noreferrer"' );
+	} );
+
+	it( 'preserves existing rel tokens on target=_blank anchors', () => {
+		const out = sanitizePostHtml(
+			'<p><a href="https://x.example" target="_blank" rel="me">x</a></p>'
+		);
+		expect( out ).toContain( 'me' );
+		expect( out ).toContain( 'noopener' );
+		expect( out ).toContain( 'noreferrer' );
+	} );
+
+	it( 'returns empty string for empty input', () => {
+		expect( sanitizePostHtml( '' ) ).toBe( '' );
+	} );
+} );

--- a/client/reader/social/index.ts
+++ b/client/reader/social/index.ts
@@ -2,3 +2,6 @@ import './style.scss';
 
 export { SocialProfileCard } from './profile-card';
 export type { SocialProfileCardProps, SocialProfileStat } from './profile-card';
+
+export { SocialPostCard } from './components/post-card';
+export { SocialFeedList } from './components/feed-list';

--- a/packages/api-core/src/reader-atmosphere/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/reader-atmosphere/__tests__/fetchers.test.ts
@@ -79,7 +79,7 @@ describe( 'atmosphere fetchers', () => {
 
 		it( 'fetches the first page without a cursor', async () => {
 			const body = {
-				feed: [
+				items: [
 					{
 						uri: 'at://did:plc:abc/app.bsky.feed.post/x',
 						cid: 'cid1',
@@ -113,9 +113,9 @@ describe( 'atmosphere fetchers', () => {
 			nock( BASE )
 				.get( PATH )
 				.query( { cursor: 'abc', limit: '25' } )
-				.reply( 200, { feed: [], cursor: null } );
+				.reply( 200, { items: [], cursor: null } );
 			const result = await getTimeline( { connectionId: 42, cursor: 'abc', limit: 25 } );
-			expect( result ).toEqual( { feed: [], cursor: null } );
+			expect( result ).toEqual( { items: [], cursor: null } );
 		} );
 
 		it( 'classifies a 401 as auth_required', async () => {

--- a/packages/api-core/src/reader-atmosphere/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/reader-atmosphere/__tests__/fetchers.test.ts
@@ -1,5 +1,5 @@
 import nock from 'nock';
-import { createConnection, getConnection, getConnections } from '../fetchers';
+import { createConnection, getConnection, getConnections, getTimeline } from '../fetchers';
 
 const BASE = 'https://public-api.wordpress.com';
 
@@ -68,5 +68,105 @@ describe( 'atmosphere fetchers', () => {
 			status: 401,
 		} );
 		await expect( getConnections() ).rejects.toMatchObject( { kind: 'unknown' } );
+	} );
+
+	describe( 'getTimeline', () => {
+		const PATH = '/wpcom/v2/reader/atmosphere/connections/42/timeline';
+
+		afterEach( () => {
+			nock.cleanAll();
+		} );
+
+		it( 'fetches the first page without a cursor', async () => {
+			const body = {
+				feed: [
+					{
+						uri: 'at://did:plc:abc/app.bsky.feed.post/x',
+						cid: 'cid1',
+						author: {
+							did: 'did:plc:abc',
+							handle: 'a.bsky.social',
+							display_name: 'A',
+							avatar: null,
+						},
+						created_at: '2026-04-27T10:00:00Z',
+						indexed_at: '2026-04-27T10:00:01Z',
+						text: 'hi',
+						html: '<p>hi</p>',
+						lang: [],
+						reply_parent: null,
+						reply_root: null,
+						reason: null,
+						embed: null,
+						counts: { replies: 0, reposts: 0, likes: 0, quotes: 0 },
+						bluesky_url: 'https://bsky.app/profile/a.bsky.social/post/x',
+					},
+				],
+				cursor: 'next-cursor',
+			};
+			nock( BASE ).get( PATH ).query( {} ).reply( 200, body );
+			const result = await getTimeline( { connectionId: 42 } );
+			expect( result ).toEqual( body );
+		} );
+
+		it( 'forwards cursor and limit query params', async () => {
+			nock( BASE )
+				.get( PATH )
+				.query( { cursor: 'abc', limit: '25' } )
+				.reply( 200, { feed: [], cursor: null } );
+			const result = await getTimeline( { connectionId: 42, cursor: 'abc', limit: 25 } );
+			expect( result ).toEqual( { feed: [], cursor: null } );
+		} );
+
+		it( 'classifies a 401 as auth_required', async () => {
+			nock( BASE )
+				.get( PATH )
+				.query( {} )
+				.reply( 401, { error: 'atmosphere_auth_required', message: 'Reconnect needed' } );
+			await expect( getTimeline( { connectionId: 42 } ) ).rejects.toMatchObject( {
+				kind: 'auth_required',
+			} );
+		} );
+
+		it( 'classifies a 429 as rate_limited', async () => {
+			nock( BASE )
+				.get( PATH )
+				.query( {} )
+				.reply( 429, {
+					error: 'atmosphere_rate_limited',
+					message: 'Slow down',
+					data: { retry_after: 60 },
+				} );
+			await expect( getTimeline( { connectionId: 42 } ) ).rejects.toMatchObject( {
+				kind: 'rate_limited',
+			} );
+		} );
+
+		it( 'classifies a 502 as upstream_unavailable', async () => {
+			nock( BASE ).get( PATH ).query( {} ).reply( 502, {
+				error: 'atmosphere_upstream_unavailable',
+				message: 'Bluesky unreachable',
+			} );
+			await expect( getTimeline( { connectionId: 42 } ) ).rejects.toMatchObject( {
+				kind: 'upstream_unavailable',
+			} );
+		} );
+
+		it( 'classifies a 404 as not_found', async () => {
+			nock( BASE ).get( PATH ).query( {} ).reply( 404, {
+				error: 'atmosphere_not_found',
+				message: 'Connection not found',
+			} );
+			await expect( getTimeline( { connectionId: 42 } ) ).rejects.toMatchObject( {
+				kind: 'not_found',
+			} );
+		} );
+
+		it( 'classifies a network error as unknown', async () => {
+			nock( BASE ).get( PATH ).query( {} ).replyWithError( 'boom' );
+			await expect( getTimeline( { connectionId: 42 } ) ).rejects.toMatchObject( {
+				kind: 'unknown',
+			} );
+		} );
 	} );
 } );

--- a/packages/api-core/src/reader-atmosphere/errors.ts
+++ b/packages/api-core/src/reader-atmosphere/errors.ts
@@ -2,8 +2,10 @@ export type AtmosphereError =
 	| { kind: 'invalid_handle' }
 	| { kind: 'invalid_credentials' }
 	| { kind: 'auth_failed' }
+	| { kind: 'auth_required' }
 	| { kind: 'connection_not_found' }
-	| { kind: 'rate_limited' }
+	| { kind: 'not_found' }
+	| { kind: 'rate_limited'; retry_after?: number }
 	| { kind: 'upstream_unavailable' }
 	| { kind: 'bad_request'; message: string }
 	| { kind: 'unknown'; cause: unknown };
@@ -13,6 +15,7 @@ interface WpErrorLike {
 	statusCode?: number;
 	status?: number;
 	message?: string;
+	data?: { retry_after?: number } & Record< string, unknown >;
 }
 
 function isWpErrorLike( e: unknown ): e is WpErrorLike {
@@ -30,11 +33,22 @@ export function classifyAtmosphereError( raw: unknown ): AtmosphereError {
 			return { kind: 'invalid_credentials' };
 		case 'auth_failed':
 			return { kind: 'auth_failed' };
+		case 'atmosphere_auth_required':
+			return { kind: 'auth_required' };
 		case 'connection_not_found':
 			return { kind: 'connection_not_found' };
+		case 'atmosphere_not_found':
+			return { kind: 'not_found' };
 		case 'rate_limited':
 			return { kind: 'rate_limited' };
+		case 'atmosphere_rate_limited': {
+			const retryAfter = raw.data?.retry_after;
+			return typeof retryAfter === 'number'
+				? { kind: 'rate_limited', retry_after: retryAfter }
+				: { kind: 'rate_limited' };
+		}
 		case 'upstream_unavailable':
+		case 'atmosphere_upstream_unavailable':
 			return { kind: 'upstream_unavailable' };
 		case 'bad_request':
 			return { kind: 'bad_request', message: raw.message ?? '' };

--- a/packages/api-core/src/reader-atmosphere/fetchers.ts
+++ b/packages/api-core/src/reader-atmosphere/fetchers.ts
@@ -4,6 +4,7 @@ import type {
 	AtmosphereConnectionDetails,
 	AtmosphereConnectionsResponse,
 	AtmosphereCreateConnectionResponse,
+	AtmosphereTimelinePage,
 } from './types';
 
 const NAMESPACE = 'wpcom/v2';
@@ -44,6 +45,34 @@ export async function getConnection( id: number ): Promise< AtmosphereConnection
 			path: `/reader/atmosphere/connections/${ id }`,
 			apiNamespace: NAMESPACE,
 		} ) ) as AtmosphereConnectionDetails;
+	} catch ( raw ) {
+		throw classifyAtmosphereError( raw );
+	}
+}
+
+export interface GetTimelineParams {
+	connectionId: number;
+	cursor?: string;
+	limit?: number;
+}
+
+export async function getTimeline( params: GetTimelineParams ): Promise< AtmosphereTimelinePage > {
+	const { connectionId, cursor, limit } = params;
+	const query: Record< string, string > = {};
+	if ( cursor ) {
+		query.cursor = cursor;
+	}
+	if ( limit ) {
+		query.limit = String( limit );
+	}
+	try {
+		return ( await wpcom.req.get(
+			{
+				path: `/reader/atmosphere/connections/${ connectionId }/timeline`,
+				apiNamespace: NAMESPACE,
+			},
+			query
+		) ) as AtmosphereTimelinePage;
 	} catch ( raw ) {
 		throw classifyAtmosphereError( raw );
 	}

--- a/packages/api-core/src/reader-atmosphere/query-keys.ts
+++ b/packages/api-core/src/reader-atmosphere/query-keys.ts
@@ -2,4 +2,6 @@ export const readerAtmosphereKeys = {
 	all: [ 'reader', 'atmosphere' ] as const,
 	connections: () => [ ...readerAtmosphereKeys.all, 'connections' ] as const,
 	connection: ( id: number | null ) => [ ...readerAtmosphereKeys.all, 'connection', id ] as const,
+	timeline: ( connectionId: number ) =>
+		[ ...readerAtmosphereKeys.all, 'timeline', connectionId ] as const,
 };

--- a/packages/api-core/src/reader-atmosphere/types.ts
+++ b/packages/api-core/src/reader-atmosphere/types.ts
@@ -128,6 +128,6 @@ export interface AtmosphereFeedItem {
 }
 
 export interface AtmosphereTimelinePage {
-	feed: AtmosphereFeedItem[];
+	items: AtmosphereFeedItem[];
 	cursor: string | null;
 }

--- a/packages/api-core/src/reader-atmosphere/types.ts
+++ b/packages/api-core/src/reader-atmosphere/types.ts
@@ -32,3 +32,102 @@ export interface AtmosphereConnectionDetails {
 	counts: AtmosphereProfileCounts;
 	raw: Record< string, unknown >;
 }
+
+export interface AtmosphereAuthor {
+	did: string;
+	handle: string;
+	display_name: string;
+	avatar: string | null;
+}
+
+export interface AtmosphereReplyRef {
+	uri: string;
+	author: { did: string; handle: string };
+}
+
+export interface AtmosphereRepostReason {
+	type: 'repost';
+	by: { did: string; handle: string; display_name: string };
+}
+
+export interface AtmosphereCounts {
+	replies: number;
+	reposts: number;
+	likes: number;
+	quotes: number;
+}
+
+export interface AtmosphereImage {
+	thumb: string;
+	fullsize: string;
+	alt: string;
+	aspect_ratio: { width: number; height: number } | null;
+}
+
+export interface AtmosphereEmbedImages {
+	type: 'images';
+	images: AtmosphereImage[];
+}
+
+export interface AtmosphereEmbedVideo {
+	type: 'video';
+	playlist: string;
+	thumbnail: string;
+	alt: string;
+	aspect_ratio: { width: number; height: number } | null;
+}
+
+export interface AtmosphereEmbedExternal {
+	type: 'external';
+	uri: string;
+	title: string;
+	description: string;
+	thumb: string | null;
+}
+
+export interface AtmosphereQuoteTombstone {
+	type: 'not_found' | 'blocked';
+	uri: string;
+	reason: 'notfound' | 'blocked';
+	author?: { did: string };
+}
+
+export interface AtmosphereEmbedQuote {
+	type: 'quote';
+	post: AtmosphereFeedItem | AtmosphereQuoteTombstone;
+}
+
+export interface AtmosphereEmbedQuoteWithMedia {
+	type: 'quote_with_media';
+	post: AtmosphereFeedItem | AtmosphereQuoteTombstone;
+	media: AtmosphereEmbedImages | AtmosphereEmbedVideo | null;
+}
+
+export type AtmosphereEmbed =
+	| AtmosphereEmbedImages
+	| AtmosphereEmbedVideo
+	| AtmosphereEmbedExternal
+	| AtmosphereEmbedQuote
+	| AtmosphereEmbedQuoteWithMedia;
+
+export interface AtmosphereFeedItem {
+	uri: string;
+	cid: string;
+	author: AtmosphereAuthor;
+	created_at: string;
+	indexed_at: string;
+	text: string;
+	html: string;
+	lang: string[];
+	reply_parent: AtmosphereReplyRef | null;
+	reply_root: AtmosphereReplyRef | null;
+	reason: AtmosphereRepostReason | null;
+	embed: AtmosphereEmbed | null;
+	counts: AtmosphereCounts;
+	bluesky_url: string;
+}
+
+export interface AtmosphereTimelinePage {
+	feed: AtmosphereFeedItem[];
+	cursor: string | null;
+}

--- a/packages/api-queries/src/__tests__/reader-atmosphere.test.tsx
+++ b/packages/api-queries/src/__tests__/reader-atmosphere.test.tsx
@@ -1,11 +1,12 @@
 import { readerAtmosphereKeys } from '@automattic/api-core';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import nock from 'nock';
 import {
 	useConnectionQuery,
 	useConnectionsQuery,
 	useCreateConnectionMutation,
+	useTimelineInfiniteQuery,
 } from '../reader-atmosphere';
 
 const BASE = 'https://public-api.wordpress.com';
@@ -69,5 +70,87 @@ describe( 'reader-atmosphere hooks', () => {
 		} );
 		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
 		expect( result.current.data?.avatar ).toBe( 'https://cdn/avatar.png' );
+	} );
+
+	describe( 'useTimelineInfiniteQuery', () => {
+		const PATH = '/wpcom/v2/reader/atmosphere/connections/42/timeline';
+
+		let wrapper: React.FC< { children: React.ReactNode } >;
+
+		// TanStack Query's default `notifyOnChangeProps: 'tracked'` only re-renders
+		// when previously-accessed properties change. Production code naturally
+		// touches these via JSX/destructuring; renderHook does not. Touching them
+		// inside the render callback ensures the observer notifies on later updates.
+		const renderTimelineHook = ( connectionId: number ) =>
+			renderHook(
+				() => {
+					const q = useTimelineInfiniteQuery( connectionId );
+					void q.data;
+					void q.hasNextPage;
+					void q.isFetchingNextPage;
+					void q.isError;
+					void q.error;
+					return q;
+				},
+				{ wrapper }
+			);
+
+		beforeEach( () => {
+			const client = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+			wrapper = ( { children } ) => (
+				<QueryClientProvider client={ client }>{ children }</QueryClientProvider>
+			);
+		} );
+
+		afterEach( () => {
+			nock.cleanAll();
+		} );
+
+		it( 'is disabled when connectionId is 0', async () => {
+			const { result } = renderTimelineHook( 0 );
+			expect( result.current.fetchStatus ).toBe( 'idle' );
+			expect( result.current.data ).toBeUndefined();
+		} );
+
+		it( 'fetches the first page on mount', async () => {
+			nock( BASE ).get( PATH ).query( {} ).reply( 200, { feed: [], cursor: null } );
+			const { result } = renderTimelineHook( 42 );
+			await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+			expect( result.current.data?.pages[ 0 ].feed ).toEqual( [] );
+		} );
+
+		it( 'paginates via cursor returned by the previous page', async () => {
+			nock( BASE ).get( PATH ).query( {} ).reply( 200, { feed: [], cursor: 'page-2' } );
+			nock( BASE )
+				.get( PATH )
+				.query( { cursor: 'page-2' } )
+				.reply( 200, { feed: [], cursor: null } );
+
+			const { result } = renderTimelineHook( 42 );
+			await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+			expect( result.current.hasNextPage ).toBe( true );
+
+			await act( async () => {
+				await result.current.fetchNextPage();
+			} );
+			expect( result.current.data?.pages.length ).toBe( 2 );
+			expect( result.current.hasNextPage ).toBe( false );
+		} );
+
+		it( 'surfaces typed errors and recovers via refetch', async () => {
+			nock( BASE )
+				.get( PATH )
+				.query( {} )
+				.reply( 502, { error: 'atmosphere_upstream_unavailable', message: 'down' } );
+			const { result } = renderTimelineHook( 42 );
+			await waitFor( () => expect( result.current.isError ).toBe( true ) );
+			expect( result.current.error ).toMatchObject( { kind: 'upstream_unavailable' } );
+
+			nock( BASE ).get( PATH ).query( {} ).reply( 200, { feed: [], cursor: null } );
+			await act( async () => {
+				await result.current.refetch();
+			} );
+			expect( result.current.isSuccess ).toBe( true );
+		} );
 	} );
 } );

--- a/packages/api-queries/src/__tests__/reader-atmosphere.test.tsx
+++ b/packages/api-queries/src/__tests__/reader-atmosphere.test.tsx
@@ -113,18 +113,18 @@ describe( 'reader-atmosphere hooks', () => {
 		} );
 
 		it( 'fetches the first page on mount', async () => {
-			nock( BASE ).get( PATH ).query( {} ).reply( 200, { feed: [], cursor: null } );
+			nock( BASE ).get( PATH ).query( {} ).reply( 200, { items: [], cursor: null } );
 			const { result } = renderTimelineHook( 42 );
 			await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
-			expect( result.current.data?.pages[ 0 ].feed ).toEqual( [] );
+			expect( result.current.data?.pages[ 0 ].items ).toEqual( [] );
 		} );
 
 		it( 'paginates via cursor returned by the previous page', async () => {
-			nock( BASE ).get( PATH ).query( {} ).reply( 200, { feed: [], cursor: 'page-2' } );
+			nock( BASE ).get( PATH ).query( {} ).reply( 200, { items: [], cursor: 'page-2' } );
 			nock( BASE )
 				.get( PATH )
 				.query( { cursor: 'page-2' } )
-				.reply( 200, { feed: [], cursor: null } );
+				.reply( 200, { items: [], cursor: null } );
 
 			const { result } = renderTimelineHook( 42 );
 			await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
@@ -146,7 +146,7 @@ describe( 'reader-atmosphere hooks', () => {
 			await waitFor( () => expect( result.current.isError ).toBe( true ) );
 			expect( result.current.error ).toMatchObject( { kind: 'upstream_unavailable' } );
 
-			nock( BASE ).get( PATH ).query( {} ).reply( 200, { feed: [], cursor: null } );
+			nock( BASE ).get( PATH ).query( {} ).reply( 200, { items: [], cursor: null } );
 			await act( async () => {
 				await result.current.refetch();
 			} );

--- a/packages/api-queries/src/reader-atmosphere.ts
+++ b/packages/api-queries/src/reader-atmosphere.ts
@@ -2,14 +2,25 @@ import {
 	createConnection,
 	getConnection,
 	getConnections,
+	getTimeline,
 	readerAtmosphereKeys,
 } from '@automattic/api-core';
-import { queryOptions, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+	infiniteQueryOptions,
+	queryOptions,
+	useInfiniteQuery,
+	useMutation,
+	useQuery,
+	useQueryClient,
+	type InfiniteData,
+	type QueryKey,
+} from '@tanstack/react-query';
 import type {
 	AtmosphereConnectionDetails,
 	AtmosphereConnectionsResponse,
 	AtmosphereCreateConnectionResponse,
 	AtmosphereError,
+	AtmosphereTimelinePage,
 	CreateConnectionParams,
 } from '@automattic/api-core';
 
@@ -57,4 +68,25 @@ export const connectionQueryOptions = ( id: number | null ) =>
 
 export function useConnectionQuery( id: number | null ) {
 	return useQuery( connectionQueryOptions( id ) );
+}
+
+export const timelineInfiniteQuery = ( connectionId: number ) =>
+	infiniteQueryOptions<
+		AtmosphereTimelinePage,
+		AtmosphereError,
+		InfiniteData< AtmosphereTimelinePage >,
+		QueryKey,
+		string | undefined
+	>( {
+		queryKey: readerAtmosphereKeys.timeline( connectionId ),
+		queryFn: ( { pageParam } ) => getTimeline( { connectionId, cursor: pageParam } ),
+		initialPageParam: undefined,
+		getNextPageParam: ( lastPage ) => lastPage.cursor ?? undefined,
+		enabled: connectionId > 0,
+		staleTime: 30_000,
+		gcTime: 5 * 60_000,
+	} );
+
+export function useTimelineInfiniteQuery( connectionId: number ) {
+	return useInfiniteQuery( timelineInfiniteQuery( connectionId ) );
 }


### PR DESCRIPTION
Fixes CM-622

> [!NOTE]
> **Backend companion:** 213323-ghe-Automattic/wpcom — must merge before merging this PR. The `/wpcom/v2/reader/atmosphere/connections/:id/timeline` route 404s without that PR.

## Proposed Changes

Replaces the placeholder `TimelinePanel` at `/reader/atmosphere/:id/timeline` with the user's authenticated Bluesky home feed, paginated, fully formatted, with all five embed variants and the seven design-spec Tracks events.

* **Data layer** (`packages/api-core/.../reader-atmosphere/`): adds the `AtmosphereFeedItem` family of types; adds `getTimeline()` fetcher with cursor + limit; adds `readerAtmosphereKeys.timeline()`. Extends `classifyAtmosphereError` with `auth_required` / `not_found` kinds, optional `retry_after` on `rate_limited`, and the `atmosphere_*`-prefixed error codes the timeline endpoint returns.
* **Hook layer** (`packages/api-queries/src/reader-atmosphere.ts`): adds `useTimelineInfiniteQuery()` over `useInfiniteQuery` with cursor-based `getNextPageParam` and a 30s `staleTime`.
* **Components** (`client/reader/social/components/post-card/`, `client/reader/social/components/feed-list/`):
    * `SocialPostCard` composes header / body / embed / counts, wrapped in a card-link (`PostCardLink`) so the whole card is clickable while inner anchors (author, external embed, quoted post) still capture their own clicks via `::after` overlay + nested `<a>` pattern.
    * `PostCardEmbed` dispatches to five variants: images grid, video thumb, external link card, quote, and quote-with-media.
    * `SocialFeedList<T>` is a generic list shell (TanStack `useInfiniteQuery` consumer + `react-intersection-observer` sentinel + `EmptyContent`-driven empty/error views).
    * `sanitizePostHtml` is a DOMPurify wrapper applied to every `post.html` injection — defence-in-depth on top of the backend's `wp_kses` pass. Allow-list: `p`, `br`, `a`; auto-applies `rel="nofollow noopener noreferrer"` on `target=_blank` anchors.
* **Tracks events**: seven events wired through `SocialAnalyticsProvider` context so the same components emit the right prefix from either a Bluesky or (future) Mastodon timeline. Events: `viewed`, `error_shown`, `retry_clicked` (panel-level, dispatched directly by `TimelinePanel`); `post_clicked`, `author_clicked`, `external_clicked`, `quote_clicked` (anchor-level, dispatched via the context's `onClick`).
* **Wire-up**: `AtmosphereAccountView` now passes `connection` to `TimelinePanel`. `TimelinePanel` consumes the hook, renders `SocialFeedList<AtmosphereFeedItem>` with `SocialPostCard` items, and provides the analytics context.
* **Barrel**: `client/reader/social/index.ts` now re-exports `SocialPostCard` and `SocialFeedList`.

## Why are these changes being made?

Slice 1 added the ATmosphere connect/profile/settings panes but left the timeline as a "still building this part" placeholder. This slice (CM-622) ships the actual reading experience — paginated feed, all native Bluesky embed types, and the analytics needed to measure engagement. All clicks open `bsky.app` in a new tab; slice 5 will swap them for in-app routes.

## Testing Instructions

> [!NOTE]
> **This PR cannot be deployed until Automattic/wpcom#213323 is deployed**, as the timeline endpoint 404s. To test, apply PR on your sandbox, and sandbox `public-api.wordpress.com`

1. `yarn start` and visit `http://calypso.localhost:3000/reader/atmosphere`. Connect a Bluesky account if you don't already have one.
2. Navigate to `/reader/atmosphere/<connection-id>/timeline`. Expect:
    - Skeleton flash on first load.
    - Posts render with header (avatar, display name, handle), body text, four engagement counts, and a timestamp.
    - An image-embed post shows a 1–4 grid of thumbnails. Click one → opens fullsize on `bsky.app` in a new tab.
    - A video-embed post shows a thumbnail with `▶` overlay. Clicking the card opens the post on `bsky.app`.
    - An external-embed post shows a link card (thumb / title / description / host). Click it → opens the external URL in a new tab (records `external_clicked`).
    - A quote-embed post shows a nested compact card; clicking it opens the quoted post on `bsky.app` and records `quote_clicked`.
    - Clicking the card background opens the post on `bsky.app` and records `post_clicked`.
    - Clicking the author chip opens the author profile on `bsky.app` and records `author_clicked`.
    - Scrolling to the bottom triggers the next page (Spinner appears at the sentinel, second page request includes `?cursor=…`).
3. **Empty state**: connect a brand-new Bluesky account that follows nobody. Expect "You're all caught up." + "Browse Bluesky" link.
4. **Error states**: temporarily blackhole the timeline route (e.g., DevTools network override → 502). Expect "Bluesky unreachable" with a Retry button. Click Retry → records `retry_clicked`, refetches.
5. **Tracks events**: in DevTools, watch `pixel.wp.com` for:
    - `calypso_reader_atmosphere_timeline_viewed` on mount.
    - `calypso_reader_atmosphere_timeline_post_clicked` / `_author_clicked` / `_external_clicked` / `_quote_clicked` on the corresponding clicks.
    - `calypso_reader_atmosphere_timeline_error_shown` / `_retry_clicked` on error.

Automated tests:

```bash
yarn test-client client/reader/atmosphere/ client/reader/social/
yarn test-packages packages/api-core/src/reader-atmosphere/__tests__/ packages/api-queries/src/__tests__/reader-atmosphere.test.tsx
yarn typecheck-client
yarn eslint client/reader/atmosphere/ client/reader/social/
```

Total: 124 tests (95 client + 29 package). All green.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?