### PR TITLE
APM: register performance/apm feature flag

### DIFF
--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -37,6 +37,7 @@
 		"marketplace-redesign": true,
 		"mcp-settings": true,
 		"onboarding/interval-dropdown": true,
+		"performance/apm": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -36,6 +36,7 @@
 		"marketplace-redesign": true,
 		"mcp-settings": true,
 		"onboarding/interval-dropdown": true,
+		"performance/apm": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -33,6 +33,7 @@
 		"marketplace-redesign": true,
 		"mcp-settings": true,
 		"onboarding/interval-dropdown": true,
+		"performance/apm": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -33,6 +33,7 @@
 		"marketplace-redesign": true,
 		"mcp-settings": true,
 		"onboarding/interval-dropdown": true,
+		"performance/apm": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/development.json
+++ b/config/development.json
@@ -160,6 +160,7 @@
 		"onboarding/user-on-stepper-hosting": true,
 		"p2/p2-plus": true,
 		"page/export": true,
+		"performance/apm": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -90,6 +90,7 @@
 		"onboarding/create-course": false,
 		"onboarding/post-checkout-ai-step": true,
 		"p2/p2-plus": true,
+		"performance/apm": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/production.json
+++ b/config/production.json
@@ -118,6 +118,7 @@
 		"onboarding/post-checkout-ai-step": true,
 		"onboarding/user-on-stepper-hosting": false,
 		"p2/p2-plus": true,
+		"performance/apm": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -116,6 +116,7 @@
 		"onboarding/post-checkout-ai-step": true,
 		"p2/p2-plus": true,
 		"page/export": true,
+		"performance/apm": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -122,6 +122,7 @@
 		"onboarding/post-checkout-ai-step": true,
 		"onboarding/user-on-stepper-hosting": true,
 		"p2/p2-plus": true,
+		"performance/apm": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,


### PR DESCRIPTION
Part of the WPCOM APM project. Adds the `performance/apm` Calypso feature flag so follow-up PRs (route registration, sidebar submenu, Frontend/Backend pages) can land safely behind it.

## Proposed Changes

- `development.json` + `dashboard-development.json`: `performance/apm: true`
- `wpcalypso.json`, `horizon.json`, `stage.json`, `production.json`, `dashboard-horizon.json`, `dashboard-stage.json`, `dashboard-production.json`: `performance/apm: false`

Nothing else changes — no consumers reference the flag yet, so this PR is a no-op end-to-end.

## Why are these changes being made?

Splitting the flag registration out of the larger scaffolding PR (#110222) so the feature gate is its own promotion unit. Future env-promotion PRs (wpcalypso → horizon → stage → production) will be one-line follow-ups against this flag.

## Testing Instructions

- `yarn start-dashboard` — should boot unchanged.
- `ENABLE_FEATURES=performance/apm yarn start-dashboard` — flag reads as enabled, but nothing consumes it yet, so still no behavioral change.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?