### PR TITLE
Stepper: Domain search header copy for Woo hosting solutions

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -314,13 +314,7 @@ const DomainSearchStep: StepType< {
 
 	const subHeaderText = useMemo( () => {
 		if ( isWooHostingSolutions ) {
-			return (
-				<>
-					{ __( 'Your domain is how customers find you and remember you.' ) }
-					<br />
-					{ __( 'Start with .com, .shop, or .store.' ) }
-				</>
-			);
+			return __( 'Find a .com, .shop, or .store that customers will remember.' );
 		}
 
 		if ( isNewsletterFlow( flow ) ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -22,6 +22,7 @@ import { useQueryHandler } from 'calypso/components/domains/wpcom-domain-search/
 import FormattedHeader from 'calypso/components/formatted-header';
 import { dashboardLink, dashboardOrigins } from 'calypso/dashboard/utils/link';
 import { isRelativeUrl } from 'calypso/dashboard/utils/url';
+import { WOO_HOSTING_SOLUTIONS_REF } from 'calypso/landing/stepper/constants';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -90,6 +91,7 @@ const DomainSearchStep: StepType< {
 	const { __ } = useI18n();
 
 	const isCiab = dashboard === 'ciab';
+	const isWooHostingSolutions = queryParams.get( 'ref' ) === WOO_HOSTING_SOLUTIONS_REF;
 
 	const storedSiteTitle = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedSiteTitle(),
@@ -291,6 +293,10 @@ const DomainSearchStep: StepType< {
 	}, [ isFirstDomainFreeForFirstYear, isCiab ] );
 
 	const headerText = useMemo( () => {
+		if ( isWooHostingSolutions ) {
+			return __( 'Name your store' );
+		}
+
 		if ( isNewsletterFlow( flow ) ) {
 			return __( 'Your domain. Your identity.' );
 		}
@@ -304,9 +310,19 @@ const DomainSearchStep: StepType< {
 		}
 
 		return __( 'Claim your space on the web' );
-	}, [ flow, isCiab, __ ] );
+	}, [ flow, isCiab, isWooHostingSolutions, __ ] );
 
 	const subHeaderText = useMemo( () => {
+		if ( isWooHostingSolutions ) {
+			return (
+				<>
+					{ __( 'Your domain is how customers find you and remember you.' ) }
+					<br />
+					{ __( 'Start with .com, .shop, or .store.' ) }
+				</>
+			);
+		}
+
 		if ( isNewsletterFlow( flow ) ) {
 			return __( 'Make your newsletter stand out with a custom domain.' );
 		}
@@ -323,7 +339,7 @@ const DomainSearchStep: StepType< {
 		}
 
 		return __( 'Make it yours with a .com, .blog, or one of 350+ domain options.' );
-	}, [ flow, isCiab, __ ] );
+	}, [ flow, isCiab, isWooHostingSolutions, __ ] );
 
 	const domainSearchElement = (
 		<WPCOMDomainSearch


### PR DESCRIPTION
## Proposed Changes

* When the stepper domain search step is loaded with `?ref=woo-hosting-solutions-flow`, swap the heading to "Name your store" and the subheading to a commerce-focused two-line copy: "Your domain is how customers find you and remember you. / Start with .com, .shop, or .store."
* No behavioral or ranking changes here — copy only.

<img width="1454" height="892" alt="image" src="https://github.com/user-attachments/assets/483c5df0-82c5-4004-a916-bc81bb714bfa" />


## Why are these changes being made?

* The Woo hosting solutions referrer flow needs commerce-native framing on the domain search step so that store-builder traffic doesn't see generic "Claim your space on the web" copy. This PR is the visual/copy half of that change; the domain ranking changes that promote commerce TLDs are coming in a follow-up PR.

## Testing Instructions

* Run `yarn start` and visit `/setup/onboarding/domains?ref=woo-hosting-solutions-flow`. The header should read "Name your store" and the subhead should split across two lines as described above.
* Visit `/setup/onboarding/domains` (no ref) and confirm the existing copy ("Claim your space on the web") still renders. Spot-check a couple of other refs (e.g., newsletter flow) to confirm those branches are unaffected.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?