### PR TITLE
Onboarding: track post-checkout setup errors via Tracks

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
@@ -18,6 +18,7 @@ import { WOO_HOSTING_SOLUTIONS_REF } from 'calypso/landing/stepper/constants';
 import { useQuery as useUrlParams } from 'calypso/landing/stepper/hooks/use-query';
 import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import { waitForPluginsActive } from 'calypso/landing/stepper/utils/wait-for-plugins-active';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useExperiment } from 'calypso/lib/explat';
 import { useMarketplaceThemeProducts } from '../../../../hooks/use-marketplace-theme-products';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
@@ -159,6 +160,18 @@ const PostCheckoutOnboarding: StepType< {
 		isExternallyManagedThemeAvailable;
 
 	const hasError = isErrorSite || isErrorMarketplaceThemeProducts || isErrorSiteTransferStatus;
+
+	useEffect( () => {
+		if ( ! hasError ) {
+			return;
+		}
+		recordTracksEvent( 'calypso_onboarding_post_checkout_setup_error', {
+			flow,
+			error_site: isErrorSite,
+			error_marketplace_theme_products: isErrorMarketplaceThemeProducts,
+			error_site_transfer_status: isErrorSiteTransferStatus,
+		} );
+	}, [ hasError, flow, isErrorSite, isErrorMarketplaceThemeProducts, isErrorSiteTransferStatus ] );
 
 	useEffect( () => {
 		if (


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-1937/post-checkout-onboarding-loader-pages-can-spin-forever

## Proposed Changes

Fires a Tracks event when the post-checkout onboarding step hits a data fetch error, so these failures are visible in analytics.

* Add `calypso_onboarding_post_checkout_setup_error` Tracks event that fires when `hasError` becomes true in `PostCheckoutOnboarding`
* Event includes `flow` and per-source boolean flags (`error_site`, `error_marketplace_theme_products`, `error_site_transfer_status`) to attribute which fetch failed

## Why are these changes being made?

The previous PR in this series (https://github.com/Automattic/wp-calypso/pull/110172) added an error UI when any of the three setup data fetches (site, marketplace theme products, site transfer status) fail — previously these would leave the step silently stuck. Now that the error state is surfaced to users, we also need observability into how often it occurs and which source is responsible, so this fires a Tracks event on each occurrence with enough context to break down error rates by flow and error source.

## Testing Instructions

Manual testing:
* In a dev environment, temporarily force one of the three query hooks to return `isError: true` (e.g. mock `siteBySlugQuery` to reject)
* Load the post-checkout step and confirm the error UI appears
* Open the browser console / Tracks debugger and confirm `calypso_onboarding_post_checkout_setup_error` fires once with the correct `flow` and error flag set to `true`