### PR TITLE
Stepper: Remove redundant designSetup old-slug mapping

### DIFF
--- a/client/landing/stepper/declarative-flow/helpers/get-step-old-slug.ts
+++ b/client/landing/stepper/declarative-flow/helpers/get-step-old-slug.ts
@@ -4,7 +4,6 @@
 export const getStepOldSlug = ( stepSlug: string ): string | undefined => {
 	const stepSlugMap: Record< string, string > = {
 		'create-site': 'site-creation-step',
-		'design-setup': 'designSetup',
 	};
 
 	return stepSlugMap[ stepSlug ];


### PR DESCRIPTION
Part of DOTOBRD-427

## Proposed Changes

* Remove the `'design-setup': 'designSetup'` entry from `getStepOldSlug`'s `stepSlugMap`.

## Why are these changes being made?

The Calypso stepper framework was firing duplicate `calypso_signup_step_start` events on the `design-setup` step of the `site-setup` flow — ~530 double-fires per week, a 19.1% rate. Investigation traced this to a `kebabCase` collision rather than the `useEffect` re-run hypothesis originally proposed in the issue.

`useStepRouteTracking` calls `recordStepStart` twice in the same stack frame when an old-slug mapping exists — once for the current slug, once for the old slug — and both are wrapped in `kebabCase()`. Because `kebabCase('designSetup') === 'design-setup'`, both calls emit the identical `step` value, producing two events with a 0–1ms gap.

The mapping was added in #100318 to preserve the funnel value across a step rename, but the rename was a no-op for Tracks: `kebabCase` had always normalized `'designSetup'` to `'design-setup'` on the way out, so the recorded `step` value never actually changed. The backward-compat entry adds no analytical value while doubling first-step counts.

The other entry (`'create-site' → 'site-creation-step'`) does not collide under `kebabCase`, so it stays.

## Testing Instructions

* Load the `site-setup` flow on the `design-setup` step and confirm only one `calypso_signup_step_start` event is recorded with `step: 'design-setup'` (previously two were recorded 0–1ms apart).
* Confirm the `create-site` → `site-creation-step` mapping still emits both events with their respective `step` values.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

Co-Authored-By: Claude <noreply@anthropic.com>