### PR TITLE
Stepper: Plans step copy + refund notice for Woo hosting solutions

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -424,7 +424,7 @@ function UnifiedPlansStep( {
 		}
 
 		if ( intent === 'plans-woo-hosting-solutions' ) {
-			return translate( 'Pick a plan for your store.' );
+			return translate( 'Pick a plan for your store' );
 		}
 
 		return translate( 'There’s a plan for you' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -423,6 +423,10 @@ function UnifiedPlansStep( {
 			return translate( 'Select a plan to launch your store' );
 		}
 
+		if ( intent === 'plans-woo-hosting-solutions' ) {
+			return translate( 'Pick a plan for your store.' );
+		}
+
 		return translate( 'There’s a plan for you' );
 	};
 
@@ -495,6 +499,12 @@ function UnifiedPlansStep( {
 				return translate( 'Your free trial ends soon — select a plan to keep your online store.' );
 			}
 			return translate( 'Choose the plan that fits your business.' );
+		}
+
+		if ( intent === 'plans-woo-hosting-solutions' ) {
+			return translate(
+				'All plans come with WooCommerce. Pick the level of support and features you want.'
+			);
 		}
 
 		if ( useEmailOnboardingSubheader ) {

--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -308,6 +308,14 @@ const PlansPageSubheader = ( {
 				</Subheader>
 			);
 		}
+
+		// Woo hosting solutions intent: subhead is rendered upstream by the
+		// stepper plans step, so suppress this onboarding fallback to avoid
+		// stacking two subheads.
+		if ( intent === 'plans-woo-hosting-solutions' ) {
+			return null;
+		}
+
 		if ( deemphasizeFreePlan && offeringFreePlan ) {
 			return (
 				<Subheader { ...subheaderCommonProps }>

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -942,7 +942,7 @@ const PlansFeaturesMain = ( {
 						) }
 						{ intent === 'plans-woo-hosting-solutions' && (
 							<p className="plans-features-main__money-back-guarantee">
-								{ translate( 'Every plan is backed by our %(days)d-day money-back guarantee', {
+								{ translate( 'Every plan is backed by our %(days)d-day money-back guarantee.', {
 									args: {
 										days: compatibleIntervalType === 'monthly' ? 7 : 14,
 									},

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -940,6 +940,15 @@ const PlansFeaturesMain = ( {
 								coupon={ coupon }
 							/>
 						) }
+						{ intent === 'plans-woo-hosting-solutions' && (
+							<p className="plans-features-main__money-back-guarantee">
+								{ translate( 'Every plan is backed by our %(days)d-day money-back guarantee', {
+									args: {
+										days: compatibleIntervalType === 'monthly' ? 7 : 14,
+									},
+								} ) }
+							</p>
+						) }
 						<div
 							className={ clsx( 'plans-features-main__group', 'is-wpcom', 'is-2023-pricing-grid', {
 								'is-scrollable': plansWithScroll,

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -158,6 +158,13 @@ body.is-section-signup {
 	}
 }
 
+.plans-features-main__money-back-guarantee {
+	margin: 12px 0 0;
+	color: var(--studio-gray-50);
+	font-size: $font-body-small;
+	text-align: center;
+}
+
 .plans-features-main__plan-type-selector-layout {
 	display: flex;
 	justify-content: center;

--- a/packages/plans-grid-next/src/components/plan-logo.tsx
+++ b/packages/plans-grid-next/src/components/plan-logo.tsx
@@ -30,9 +30,12 @@ const PlanLogo: React.FunctionComponent< {
 } > = ( { planSlug, isInSignup, renderedGridPlans, isTableCell, planIndex } ) => {
 	const [ activeTooltipId, setActiveTooltipId ] = useManageTooltipToggle();
 	const translate = useTranslate();
-	const shouldShowWooLogo = isEcommercePlan( planSlug ) && ! isWooExpressPlan( planSlug );
+	const { gridPlansIndex, intent } = usePlansGridContext();
+	const isWooHostingSolutionsIntent = intent === 'plans-woo-hosting-solutions';
+	const shouldShowWooLogo =
+		isWooHostingSolutionsIntent ||
+		( isEcommercePlan( planSlug ) && ! isWooExpressPlan( planSlug ) );
 	const shouldShowPopularBadge = ! isPartnerBundleOnboarding();
-	const { gridPlansIndex } = usePlansGridContext();
 	const { current } = gridPlansIndex[ planSlug ];
 	const highlightAdjacencyMatrix = useHighlightAdjacencyMatrix( {
 		renderedGridPlans,
@@ -75,7 +78,7 @@ const PlanLogo: React.FunctionComponent< {
 				/>
 			) }
 			<header className={ headerClasses }>
-				{ isBusinessPlan( planSlug ) && (
+				{ ! isWooHostingSolutionsIntent && isBusinessPlan( planSlug ) && (
 					<Plans2023Tooltip
 						text={ translate(
 							'WP Cloud gives you the tools you need to add scalable, highly available, extremely fast WordPress hosting.'
@@ -97,7 +100,7 @@ const PlanLogo: React.FunctionComponent< {
 						<WooLogo />
 					</Plans2023Tooltip>
 				) }
-				{ isWpcomEnterpriseGridPlan( planSlug ) && (
+				{ ! isWooHostingSolutionsIntent && isWpcomEnterpriseGridPlan( planSlug ) && (
 					<Plans2023Tooltip
 						text={ translate( 'The trusted choice for enterprise WordPress hosting.' ) }
 						id="enterprise-logo"

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -403,6 +403,26 @@ const useGridPlans: UseGridPlansType = ( {
 			tagline = planConstantObj.getNewsletterTagLine?.() ?? '';
 		} else if ( 'plans-blog-onboarding' === intent ) {
 			tagline = planConstantObj.getBlogOnboardingTagLine?.() ?? '';
+		} else if ( 'plans-woo-hosting-solutions' === intent ) {
+			if ( isPersonalPlan( planSlug ) ) {
+				tagline = translate(
+					'Try out a store idea with low commitment. Custom domain and basic tools.'
+				);
+			} else if ( isPremiumPlan( planSlug ) ) {
+				tagline = translate(
+					'A solid foundation for new stores. More design options and faster support when you need help.'
+				);
+			} else if ( isBusinessPlan( planSlug ) ) {
+				tagline = translate(
+					'Built for real stores. 24/7 priority support, advanced features, and the performance your customers expect.'
+				);
+			} else if ( isEcommercePlan( planSlug ) ) {
+				tagline = translate(
+					'For serious stores. Priority support, advanced extensions, and premium store themes.'
+				);
+			} else {
+				tagline = planConstantObj.getPlanTagline?.() ?? '';
+			}
 		} else {
 			tagline = planConstantObj.getPlanTagline?.() ?? '';
 		}

--- a/packages/plans-grid-next/src/hooks/data-store/use-highlight-labels.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-highlight-labels.ts
@@ -1,5 +1,6 @@
 import {
 	isBusinessPlan,
+	isEcommercePlan,
 	isPremiumPlan,
 	isPersonalPlan,
 	planLevelsMatch,
@@ -74,6 +75,10 @@ const useHighlightLabels = ( {
 				}
 			} else if ( 'plans-affiliate' === intent && isBusinessPlan( planSlug ) ) {
 				label = translate( 'Popular' );
+			} else if ( 'plans-woo-hosting-solutions' === intent ) {
+				if ( isEcommercePlan( planSlug ) ) {
+					label = translate( 'Best value' );
+				}
 			} else if ( isBusinessPlan( planSlug ) && ! selectedPlan && ! isVisualSplitIntent ) {
 				label = translate( 'Best value' );
 			} else if ( isPopularPlan( planSlug ) && ! selectedPlan && ! isVisualSplitIntent ) {


### PR DESCRIPTION
Part of #

## Proposed Changes

When the stepper plans step is reached via the Woo hosting solutions referrer (intent `plans-woo-hosting-solutions`):

* Header swaps to "Pick a plan for your store"; subhead swaps to "All plans come with WooCommerce. Pick the level of support and features you want." Suppresses the generic onboarding fallback subhead so we don't render two stacked subheads.
* Renders a money-back guarantee line below the plan interval switcher. Refund window tracks the selected interval — 7 days for monthly, 14 days for yearly / 2-year / 3-year — matching the existing checkout convention in `checkout-main-content.tsx`.
* Shows the Woo logo on every plan card (Personal, Premium, Business, Commerce), not just Commerce. The WP Cloud and Enterprise/VIP logos that would otherwise appear are suppressed for this intent.
* Overrides plan taglines with store-focused copy. Each tagline is split into two short sentences instead of using em dashes, so the text reads cleanly inside the narrow plan card description area.
  * **Personal:** Try out a store idea with low commitment. Custom domain and basic tools.
  * **Premium:** A solid foundation for new stores. More design options and faster support when you need help.
  * **Business:** Built for real stores. 24/7 priority support, advanced features, and the performance your customers expect.
  * **Commerce:** For serious stores. Priority support, advanced extensions, and premium store themes.
* Moves the "Best value" badge from Business to Commerce and drops the "Most popular" badge from Premium. For store-builder traffic the Commerce plan is the natural recommendation; the other tiers render without a highlight badge.

All changes are strictly gated on `intent === 'plans-woo-hosting-solutions'`. No effect on any other flow or intent.

## Why are these changes being made?

* Woo hosting solutions traffic lands on the plans step expecting commerce framing. The generic plans grid leans on website-builder copy, mixed plan-tier logos (Cloud, VIP), and badges ("Most popular" on Premium, "Best value" on Business) that don't reflect the store-builder mental model. This PR re-points the plans grid at that audience: store-focused header and per-plan copy, Woo branding throughout, Commerce surfaced as the recommendation, and a contextual money-back cue near the interval switcher.

## Testing Instructions

* Run `yarn start` and visit `/setup/onboarding/plans?ref=woo-hosting-solutions-flow`. Confirm:
  * Header reads "Pick a plan for your store"; subhead reads "All plans come with WooCommerce. Pick the level of support and features you want." There should be exactly one subhead, not two stacked.
  * Below the "Pay yearly..." interval switcher, the line "Every plan is backed by our 14-day money-back guarantee." renders. Open the dropdown and pick "Pay monthly" — the line should update to "7-day". Switch back to yearly / 2-year / 3-year — should return to 14-day.
  * Each of the four plan cards (Personal, Premium, Business, Commerce) shows a Woo logo. Business no longer shows the WP Cloud icon.
  * The "Best value" badge is on Commerce; Personal, Premium, and Business render with no highlight badge.
  * Each plan card shows the store-focused tagline listed above.
* Visit `/setup/onboarding/plans` (no ref) and confirm the existing copy, badges, logos, and absence of the refund notice. Spot-check `?intent=plans-woo-hosted` and `?intent=plans-newsletter` to confirm those branches are untouched.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?