### PR TITLE
AI Review: skip review when PR edits AGENTS.md or CLAUDE.md

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -87,6 +87,26 @@ jobs:
             *) echo "::error::Denying review: $PR_USER permission=$PERM"; exit 1 ;;
           esac
 
+      # AGENTS.md / CLAUDE.md are bot instructions; skip review if a PR edits them
+      # so the bot doesn't review under guidance the PR itself is modifying.
+      - name: Skip AI review on trusted-instruction file edits
+        id: trusted_files
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          FILES=$(gh pr diff "$PR_NUMBER" --repo "$REPO" --name-only)
+          if echo "$FILES" | grep -qiE '(^|/)(AGENTS|CLAUDE)\.md$'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body \
+              "AI review skipped: this PR modifies \`AGENTS.md\` or \`CLAUDE.md\` files, which the review bot reads as instructions. Edits to these files require human review."
+            exit 1
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # Always check out the default branch, never PR code. claude-code-action
       # does its own `git checkout <PR_head>` later, so this is mostly a
       # warm-up; the real defense for trusted prompts is keeping prompt
@@ -99,7 +119,7 @@ jobs:
           persist-credentials: false
 
       - name: Run review (dashboard)
-        if: inputs.area == 'dashboard'
+        if: inputs.area == 'dashboard' && steps.trusted_files.outputs.skip == 'false'
         uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434 # v1.0.107
         with:
           anthropic_api_key: ${{ secrets.anthropic_api_key }}
@@ -157,7 +177,7 @@ jobs:
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git show:*),Bash(git diff:*),Bash(git log:*),Bash(git ls-files:*),Bash(git grep:*),Bash(rg *),Read,Glob,Grep"
 
       - name: Run review (a4a)
-        if: inputs.area == 'a4a'
+        if: inputs.area == 'a4a' && steps.trusted_files.outputs.skip == 'false'
         uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434 # v1.0.107
         with:
           anthropic_api_key: ${{ secrets.anthropic_api_key }}
@@ -213,7 +233,7 @@ jobs:
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git show:*),Bash(git diff:*),Bash(git log:*),Bash(git ls-files:*),Bash(git grep:*),Bash(rg *),Read,Glob,Grep"
 
       - name: Run review (general)
-        if: inputs.area == 'general'
+        if: inputs.area == 'general' && steps.trusted_files.outputs.skip == 'false'
         uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434 # v1.0.107
         with:
           anthropic_api_key: ${{ secrets.anthropic_api_key }}


### PR DESCRIPTION
Follow up to: https://github.com/Automattic/wp-calypso/pull/110214

## Proposed Changes

* Skip AI review when a PR modifies any `AGENTS.md` or `CLAUDE.md` file. Post a comment explaining why human review is needed and fail the workflow so the PR shows a red X.

## Why are these changes being made?

* These files are loaded by the bot as instructions; a PR shouldn't be self-reviewed against guidance it's modifying.
* This is **not currently exploitable** on Calypso. The action's existing [`restoreConfigFromBase`](https://github.com/anthropics/claude-code-action/blob/main/src/github/operations/restore-config.ts) defense covers only root `CLAUDE.md` and `.claude/` — `AGENTS.md` and nested `CLAUDE.md` are outside its `SENSITIVE_PATHS` list. We're insulated today by two separate properties: (1) we run `claude-code-action` in agent mode (the workflow passes a `prompt:` input), and agent mode does not check out the PR head into the working tree the way tag mode does via `setupBranch`; (2) our checkout step pins `ref: github.event.repository.default_branch`, leaving the working tree at `trunk` regardless. The bot's `Read` of `@AGENTS.md` therefore resolves `trunk`'s copy.
* This guard preserves the no-self-review property regardless of future config drift (e.g., adoption of tag mode, changes to the checkout ref).
* Failing the workflow gives reviewers a visible red X in the checks panel. AI review isn't a required status check, so the failure is informational only and does not block merge.

## Testing Instructions

* Workflow changes can't be exercised on the modifying PR (OIDC). After merge, verify on follow-ups: a PR touching `AGENTS.md` or `CLAUDE.md` should get a skip comment plus a failed AI Review check; one that doesn't should review normally.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
