### PR TITLE
smoke-test: verify AGENTS.md/CLAUDE.md skip guard (post-#110238)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,3 +80,6 @@ yarn reformat-files # Fix formatting with Prettier
   - Avoid mentioning people's names.
   - Do not link to wordpress.com URLs.
   - Include all checklist items from .github/PULL_REQUEST_TEMPLATE.md. Only mark items as completed (`[x]`) if they actually apply; leave inapplicable items unchecked (`[ ]`).
+
+## Smoke test marker (post-#110238)
+Verifying the AGENTS.md/CLAUDE.md skip guard fires for both auto-review and `@claude /review` on-ping flows. This section is intentionally added for testing and will be reverted.


### PR DESCRIPTION
Smoke test for #110238. Edits root `AGENTS.md` to verify the trusted-files skip guard fires on both flows:

1. Auto-review (general area, fires on PR open) — should post skip comment + fail the AI Review check.
2. On-ping (`@claude /review` triggered manually after open) — should also post skip comment + fail.

Will close after observation, no merge intended.