### PR TITLE
i18n: replace webpack chunk callback with section-loaded listeners

### DIFF
--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -7,6 +7,7 @@ import { defaultI18n } from '@wordpress/i18n';
 import debugFactory from 'debug';
 import i18n from 'i18n-calypso';
 import { forEach, throttle } from 'lodash';
+import { getLoadedSections, onSectionLoaded, offSectionLoaded } from 'calypso/sections-middleware';
 const debug = debugFactory( 'calypso:i18n' );
 
 const getPromises = {};
@@ -247,7 +248,7 @@ export function getTranslationChunkFile( chunkId, localeSlug ) {
  */
 function getInstalledChunks() {
 	const installedChunksFromContext = window.installedChunks ?? [];
-	const installedChunksAsync = window?.__requireChunkCallback__?.getInstalledChunks?.() ?? [];
+	const installedChunksAsync = getLoadedSections();
 	const installedChunksSet = new Set(
 		[].concat( installedChunksFromContext, installedChunksAsync )
 	);
@@ -287,14 +288,12 @@ function addRequireChunkTranslationsHandler( localeSlug = i18n.getLocaleSlug(), 
 	const { translatedChunks = [], userTranslations = {} } = options;
 	const loadedTranslationChunks = {};
 
-	const handler = ( { scriptSrc, publicPath }, promises ) => {
-		const chunkId = scriptSrc.replace( publicPath, '' ).replace( /\.js$/, '' );
-
+	const handler = ( chunkId ) => {
 		if ( ! translatedChunks.includes( chunkId ) || loadedTranslationChunks[ chunkId ] ) {
 			return;
 		}
 
-		const translationChunkPromise = getTranslationChunkFile( chunkId, localeSlug )
+		getTranslationChunkFile( chunkId, localeSlug )
 			.then( ( translations ) => {
 				addTranslations( translations, userTranslations );
 				loadedTranslationChunks[ chunkId ] = true;
@@ -308,11 +307,9 @@ function addRequireChunkTranslationsHandler( localeSlug = i18n.getLocaleSlug(), 
 				// captureGetTranslationChunkFileException( error, chunkId, localeSlug );
 				debug( error );
 			} );
-
-		promises.push( translationChunkPromise );
 	};
 
-	window?.__requireChunkCallback__?.add?.( handler );
+	onSectionLoaded( handler );
 	lastRequireChunkTranslationsHandler = handler;
 }
 
@@ -320,7 +317,7 @@ function addRequireChunkTranslationsHandler( localeSlug = i18n.getLocaleSlug(), 
  * Removes require chunk translations handler.
  */
 function removeRequireChunkTranslationsHandler() {
-	window?.__requireChunkCallback__?.remove?.( lastRequireChunkTranslationsHandler );
+	offSectionLoaded( lastRequireChunkTranslationsHandler );
 }
 
 let lastRequestedLocale = null;

--- a/client/sections-middleware.js
+++ b/client/sections-middleware.js
@@ -50,6 +50,27 @@ async function loadSection( context, sectionDefinition ) {
  */
 const _loadedSections = {};
 
+// module path → section name, for all sections that have finished loading.
+const _loadedSectionNames = {};
+
+// Subscribers notified when a section finishes loading.
+const _sectionLoadedListeners = [];
+
+export function getLoadedSections() {
+	return Object.values( _loadedSectionNames );
+}
+
+export function onSectionLoaded( callback ) {
+	_sectionLoadedListeners.push( callback );
+}
+
+export function offSectionLoaded( callback ) {
+	const idx = _sectionLoadedListeners.indexOf( callback );
+	if ( idx !== -1 ) {
+		_sectionLoadedListeners.splice( idx, 1 );
+	}
+}
+
 function loadSectionHandler( sectionDefinition ) {
 	return async ( context, next ) => {
 		try {
@@ -67,6 +88,10 @@ function loadSectionHandler( sectionDefinition ) {
 				// wait until the section module is loaded and the set the map record to `true`
 				await loadingSection;
 				_loadedSections[ sectionDefinition.module ] = true;
+				_loadedSectionNames[ sectionDefinition.module ] = sectionDefinition.name;
+				for ( const listener of _sectionLoadedListeners ) {
+					listener( sectionDefinition.name );
+				}
 			}
 
 			// activate the section after ensuring it's fully loaded


### PR DESCRIPTION
## Proposed Changes

- Replace webpack's `__requireChunkCallback__` with explicit section-loaded event listeners for loading translation chunks
- Add `getLoadedSections()`, `onSectionLoaded()`, and `offSectionLoaded()` exports to `sections-middleware.js`
- Track loaded section names in `sections-middleware` and notify listeners when sections finish loading

## Why are these changes being made?

Translation chunk loading was tightly coupled to webpack internals (`__requireChunkCallback__`). This decouples it by using an explicit pub/sub pattern in sections-middleware, making the i18n system independent of the bundler.

## Testing Instructions

Run `node bin/build-languages.js` to build the translation chunks first, then:
Rather than use the `?useTranslationChunks` query param I just set the `use-translation-chunks` feature flag in `development.json`

### Test 1 — Locale switch loads translations for already-loaded sections

1. Load any Calypso page (e.g. `/me/account`) in English with `?useTranslationChunks`
2. Let the page fully settle — sections already loaded via `window.installedChunks` should be registered
3. Switch locale to French via the language selector in `/me/account`
4. **Expected:** UI strings on the current page translate to French
5. Verify in Network tab: requests to `/calypso/languages/fr-<section-name>.json` appear for already-loaded sections

### Test 2 — Dynamically loaded section gets translations after locale switch

1. Switch locale to French (as above), staying on `/me/account`
2. Navigate to a different section — e.g. Reader (`/read`) or My Sites
3. **Expected:** the newly loaded section's UI is also in French (not English)
4. Verify in Network tab: a `/calypso/languages/fr-<section-name>.json` request fires when you navigate to the new section

### Test 3 — Switching locale twice cleans up properly (no double-loading)

1. Switch locale to French, then back to English, then to French again
2. Navigate around between sections
3. **Expected:** no duplicate translation chunk requests in the Network tab for the same section
4. Verify in Console: no errors about double-registration or missing handler

### Test 4 — Default locale (English) unaffected

1. Load Calypso normally without switching locale
2. **Expected:** no translation chunk requests are made at all (the `isDefaultLocale` branch skips the whole chunk path)

### Test 5 — Verify `window.__requireChunkCallback__` is no longer called

1. Open DevTools Console and run: `window.__requireChunkCallback__`
2. **Expected:** `undefined` (or its methods are no longer invoked by the locale switcher — confirm by setting a breakpoint or temporarily deleting it and verifying no errors during a locale switch)

### What to watch for (potential issues)

- **Blank/missing translations after switch:** could mean `getLoadedSections()` returns section names that don't match the `translatedChunks` array in the language manifest (e.g. manifest uses webpack chunk IDs but middleware now returns section names like `reader`)
- **Translations load on first switch but not on re-switch:** suggests `offSectionLoaded` isn't correctly removing the old handler — check for duplicate network requests
- **Console errors about `import.meta`:** unrelated to this change, but worth noting if they appear

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?