### PR TITLE
Replace ineffective dynamic import of AppleIcon with static import

### DIFF
--- a/client/login/magic-login/magic-login-email/magic-login-email-icon.tsx
+++ b/client/login/magic-login/magic-login-email/magic-login-email-icon.tsx
@@ -25,6 +25,8 @@ interface MagicLoginEmailIconProps {
 export function MagicLoginEmailIcon( { icon }: MagicLoginEmailIconProps ) {
 	switch ( icon ) {
 		case 'apple':
+			// No async import because AppleIcon is already in the login bundle via
+			// social-buttons/apple, so AsyncLoad cannot split it.
 			return <AppleIcon />;
 		case 'gmail':
 			return <AsyncLoad require={ loadGmail } placeholder={ null } />;

--- a/client/login/magic-login/magic-login-email/magic-login-email-icon.tsx
+++ b/client/login/magic-login/magic-login-email/magic-login-email-icon.tsx
@@ -1,9 +1,6 @@
 import AsyncLoad from 'calypso/components/async-load';
+import AppleIcon from 'calypso/components/social-icons/apple';
 
-const loadApple = () =>
-	import(
-		/* webpackChunkName: "async-load-calypso-components-social-icons-apple" */ 'calypso/components/social-icons/apple'
-	);
 const loadGmail = () =>
 	import(
 		/* webpackChunkName: "async-load-calypso-components-social-icons-gmail" */ 'calypso/components/social-icons/gmail'
@@ -28,7 +25,7 @@ interface MagicLoginEmailIconProps {
 export function MagicLoginEmailIcon( { icon }: MagicLoginEmailIconProps ) {
 	switch ( icon ) {
 		case 'apple':
-			return <AsyncLoad require={ loadApple } placeholder={ null } />;
+			return <AppleIcon />;
 		case 'gmail':
 			return <AsyncLoad require={ loadGmail } placeholder={ null } />;
 		case 'outlook':


### PR DESCRIPTION
## Proposed Changes

- Replace the `AsyncLoad` dynamic import of `AppleIcon` in `MagicLoginEmailIcon` with a direct static import.

## Why are these changes being made?

The Vite bundler noticed this "ineffective dynamic import" and it reports it as a warning

```
[INEFFECTIVE_DYNAMIC_IMPORT] Warning: client/components/social-icons/apple.jsx is
dynamically imported by
client/login/magic-login/magic-login-email/magic-login-email-icon.tsx but also statically
imported by client/blocks/login/social-connect-prompt.jsx,
client/components/social-buttons/apple.jsx, client/me/social-login/index.jsx, dynamic
import will not move module into another chunk.
```

## Testing Instructions

First confirm in the ICFY stats that the entry bundle sizes have not changed https://github.com/Automattic/wp-calypso/pull/110249#issuecomment-4333979110

- Visit the magic login page at `/log-in/link` and enter an email with the `apple.com` domain (e.g. `test@apple.com`).
  - I don't have a `@apple.com` email address, I sent a magic link to `{{a really long email name}}@apple.com` and I just have my fingers crossed that no one actually uses that email. 😬 
- Verify the Apple icon renders correctly next to the email the link was sent to
- Verify no console errors.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the \"[Status] String Freeze\" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the \"[Status] Needs Privacy Updates\" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?