### PR TITLE
A4A: Add AI and MCP Connect agent page

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -61,6 +61,7 @@ export const A4A_LEARN_LINK = `${ A4A_RESOURCES_LINK }/learn`;
 export const A4A_DEV_TOOLS_LINK = `${ A4A_RESOURCES_LINK }/dev-tools`;
 export const A4A_AI_MCP_LINK = `${ A4A_RESOURCES_LINK }/ai-mcp`;
 export const A4A_AI_MCP_AVAILABLE_TOOLS_LINK = `${ A4A_AI_MCP_LINK }/tools`;
+export const A4A_AI_MCP_CONNECT_LINK = `${ A4A_AI_MCP_LINK }/connect`;
 
 // Client
 export const A4A_CLIENT_LANDING_LINK = '/client/landing';

--- a/client/a8c-for-agencies/lib/permission.ts
+++ b/client/a8c-for-agencies/lib/permission.ts
@@ -59,6 +59,7 @@ import {
 	A4A_DEV_TOOLS_LINK,
 	A4A_AI_MCP_LINK,
 	A4A_AI_MCP_AVAILABLE_TOOLS_LINK,
+	A4A_AI_MCP_CONNECT_LINK,
 	A4A_EXCLUSIVE_OFFERS_LINK,
 } from '../components/sidebar-menu/lib/constants';
 import type { Agency } from 'calypso/state/a8c-for-agencies/types';
@@ -124,6 +125,7 @@ const MEMBER_ACCESSIBLE_PATHS: Record< string, string[] > = {
 	[ A4A_DEV_TOOLS_LINK ]: [ 'a4a_read_learn' ],
 	[ A4A_AI_MCP_LINK ]: [ 'a4a_read_learn' ],
 	[ A4A_AI_MCP_AVAILABLE_TOOLS_LINK ]: [ 'a4a_read_learn' ],
+	[ A4A_AI_MCP_CONNECT_LINK ]: [ 'a4a_read_learn' ],
 };
 
 const MEMBER_ACCESSIBLE_DYNAMIC_PATHS: Record< string, string[] > = {

--- a/client/a8c-for-agencies/sections/ai-mcp/controller.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/controller.tsx
@@ -2,6 +2,7 @@ import { type Callback } from '@automattic/calypso-router';
 import PageViewTracker from 'calypso/a8c-for-agencies/components/a4a-page-view-tracker';
 import LearnSidebar from 'calypso/a8c-for-agencies/components/sidebar-menu/learn';
 import AiMcpAvailableTools from './primary/available-tools';
+import AiMcpConnectAgent from './primary/connect-agent';
 import AiMcpOverview from './primary/overview';
 
 export const aiMcpOverviewContext: Callback = ( context, next ) => {
@@ -23,6 +24,20 @@ export const aiMcpAvailableToolsContext: Callback = ( context, next ) => {
 				path={ context.path }
 			/>
 			<AiMcpAvailableTools />
+		</>
+	);
+	context.secondary = <LearnSidebar path={ context.path } />;
+	next();
+};
+
+export const aiMcpConnectContext: Callback = ( context, next ) => {
+	context.primary = (
+		<>
+			<PageViewTracker
+				title="Resources and tools > AI and MCP > Connect external AI assistant"
+				path={ context.path }
+			/>
+			<AiMcpConnectAgent />
 		</>
 	);
 	context.secondary = <LearnSidebar path={ context.path } />;

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/connect-agent/agent-configs.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/connect-agent/agent-configs.tsx
@@ -1,0 +1,238 @@
+import { ExternalLink } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import type { ReactNode } from 'react';
+
+export const A4A_MCP_URL = 'https://public-api.wordpress.com/wpcom/v2/a4a-mcp/v1';
+
+export interface AgentConfig {
+	id: string;
+	label: string;
+	quickSetupDescription?: string;
+	quickSetup?: ReactNode[];
+	installAction?: {
+		label: string;
+		deepLink: string;
+	};
+	manualSetupFile?: string;
+	manualSetupLanguage: 'json' | 'toml';
+	manualSetupSnippet: string;
+	docsUrl: string;
+	docsLabel: string;
+}
+
+const cursorInstallDeepLink = `cursor://anysphere.cursor-deeplink/mcp/install?name=a4a-mcp&config=${ encodeURIComponent(
+	btoa( JSON.stringify( { command: `npx -y mcp-remote ${ A4A_MCP_URL }` } ) )
+) }`;
+
+export const AGENT_CONFIGS: AgentConfig[] = [
+	{
+		id: 'claude-code',
+		label: 'Claude Code',
+		quickSetupDescription: __(
+			'Claude Code uses a different config format with type: “http”. Use the CLI or copy the configuration below.'
+		),
+		quickSetup: [
+			createInterpolateElement(
+				__(
+					'Install Claude Code: run <code>npm install -g @anthropic-ai/claude-code</code> or see <a>the setup guide</a>.'
+				),
+				{
+					code: <code />,
+					a: (
+						<ExternalLink
+							href="https://docs.anthropic.com/en/docs/claude-code/setup"
+							children={ __( 'the setup guide' ) }
+						/>
+					),
+				}
+			),
+			createInterpolateElement(
+				sprintf(
+					/* translators: %s: A4A MCP server URL, kept inside <code> */
+					__( 'Run in your terminal: <code>claude mcp add --transport http a4a-mcp %s</code>' ),
+					A4A_MCP_URL
+				),
+				{ code: <code /> }
+			),
+			createInterpolateElement(
+				__(
+					'Or copy the configuration below into your project’s <code>.mcp.json</code> or your global <code>~/.claude.json</code> file.'
+				),
+				{ code: <code /> }
+			),
+			createInterpolateElement(
+				__(
+					'Run <code>claude</code> in your terminal, select <code>/mcp</code>, then select <code>a4a-mcp</code> and authenticate. Your browser opens to complete the OAuth flow.'
+				),
+				{ code: <code /> }
+			),
+		],
+		manualSetupFile: '~/.claude.json',
+		manualSetupLanguage: 'json',
+		manualSetupSnippet: JSON.stringify(
+			{
+				mcpServers: {
+					'a4a-mcp': {
+						type: 'http',
+						url: A4A_MCP_URL,
+					},
+				},
+			},
+			null,
+			2
+		),
+		docsUrl: 'https://code.claude.com/docs/en/mcp',
+		docsLabel: __( 'Claude Code documentation' ),
+	},
+	{
+		id: 'claude-desktop',
+		label: 'Claude Desktop',
+		quickSetup: [
+			__( 'Install Node 20 or later (required by mcp-remote).' ),
+			__(
+				'Open Claude Desktop → Settings → Developer, then click “Edit Config” under Local MCP servers.'
+			),
+			createInterpolateElement(
+				__(
+					'Add the configuration below to <code>claude_desktop_config.json</code> (typically at <code>~/Library/Application Support/Claude/claude_desktop_config.json</code>).'
+				),
+				{ code: <code /> }
+			),
+			__( 'Restart Claude Desktop.' ),
+			__(
+				'If you haven’t authenticated yet, Claude Desktop will prompt you in your browser as soon as it reopens.'
+			),
+		],
+		manualSetupFile: 'claude_desktop_config.json',
+		manualSetupLanguage: 'json',
+		manualSetupSnippet: JSON.stringify(
+			{
+				mcpServers: {
+					'a4a-mcp': {
+						command: 'npx',
+						args: [ '-y', 'mcp-remote', A4A_MCP_URL ],
+					},
+				},
+			},
+			null,
+			2
+		),
+		docsUrl: 'https://modelcontextprotocol.io/quickstart/user',
+		docsLabel: __( 'Claude Desktop documentation' ),
+	},
+	{
+		id: 'cursor',
+		label: 'Cursor',
+		installAction: {
+			label: __( 'Install in Cursor' ),
+			deepLink: cursorInstallDeepLink,
+		},
+		quickSetup: [
+			__( 'Install Node 20 or later (required by mcp-remote).' ),
+			createInterpolateElement( __( 'Open <code>~/.cursor/mcp.json</code> in your editor.' ), {
+				code: <code />,
+			} ),
+			createInterpolateElement( __( 'Add the block below under <code>mcpServers</code>.' ), {
+				code: <code />,
+			} ),
+			__( 'Fully quit Cursor (Cmd+Q) and relaunch.' ),
+			__(
+				'If you haven’t authenticated yet, Cursor will prompt you in your browser as soon as it reopens.'
+			),
+		],
+		manualSetupFile: '~/.cursor/mcp.json',
+		manualSetupLanguage: 'json',
+		manualSetupSnippet: JSON.stringify(
+			{
+				mcpServers: {
+					'a4a-mcp': {
+						command: 'npx',
+						args: [ '-y', 'mcp-remote', A4A_MCP_URL ],
+					},
+				},
+			},
+			null,
+			2
+		),
+		docsUrl: 'https://cursor.com/docs/mcp',
+		docsLabel: __( 'Cursor documentation' ),
+	},
+	{
+		id: 'codex',
+		label: 'Codex',
+		quickSetup: [
+			createInterpolateElement( __( 'Open <code>~/.codex/config.toml</code> in your editor.' ), {
+				code: <code />,
+			} ),
+			__( 'Append the block below to the file.' ),
+			__( 'Restart Codex.' ),
+			__( 'Go to Codex → MCP servers → Authenticate.' ),
+		],
+		manualSetupFile: '~/.codex/config.toml',
+		manualSetupLanguage: 'toml',
+		manualSetupSnippet: [
+			'[mcp_servers.a4a-mcp]',
+			`url = "${ A4A_MCP_URL }"`,
+			`oauth_resource = "${ A4A_MCP_URL }"`,
+		].join( '\n' ),
+		docsUrl: 'https://github.com/openai/codex',
+		docsLabel: __( 'Codex documentation' ),
+	},
+	{
+		id: 'vscode',
+		label: 'VS Code',
+		quickSetup: [
+			__( 'Install Node 20 or later (required by mcp-remote).' ),
+			createInterpolateElement(
+				__(
+					'Open <code>~/Library/Application Support/Code/User/mcp.json</code> (create if missing).'
+				),
+				{ code: <code /> }
+			),
+			createInterpolateElement( __( 'Add the block below under <code>servers</code>.' ), {
+				code: <code />,
+			} ),
+			__( 'Restart VS Code.' ),
+			__(
+				'If you haven’t authenticated yet, VS Code will prompt you in your browser as soon as it reopens.'
+			),
+		],
+		manualSetupFile: '~/Library/Application Support/Code/User/mcp.json',
+		manualSetupLanguage: 'json',
+		manualSetupSnippet: JSON.stringify(
+			{
+				servers: {
+					'a4a-mcp': {
+						command: 'npx',
+						args: [ '-y', 'mcp-remote', A4A_MCP_URL ],
+					},
+				},
+			},
+			null,
+			2
+		),
+		docsUrl: 'https://code.visualstudio.com/docs/copilot/customization/mcp-servers',
+		docsLabel: __( 'VS Code MCP documentation' ),
+	},
+	{
+		id: 'other',
+		label: __( 'Other MCP client' ),
+		manualSetupLanguage: 'json',
+		manualSetupSnippet: JSON.stringify(
+			{
+				mcpServers: {
+					'a4a-mcp': {
+						url: A4A_MCP_URL,
+					},
+				},
+			},
+			null,
+			2
+		),
+		docsUrl: 'https://modelcontextprotocol.io/docs/develop/connect-local-servers',
+		docsLabel: __( 'MCP documentation' ),
+	},
+];
+
+export const DEFAULT_AGENT_ID = 'claude-code';

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/connect-agent/connect-agent-content.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/connect-agent/connect-agent-content.tsx
@@ -1,0 +1,174 @@
+import {
+	Button,
+	SelectControl,
+	TextareaControl,
+	ExternalLink,
+	__experimentalHStack as HStack,
+	__experimentalSpacer as Spacer,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { check, copy } from '@wordpress/icons';
+import { useCallback, useMemo, useState } from 'react';
+import { Card, CardBody } from 'calypso/dashboard/components/card';
+import { preventWidows } from 'calypso/lib/formatting';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { AGENT_CONFIGS, DEFAULT_AGENT_ID } from './agent-configs';
+import type { AgentConfig } from './agent-configs';
+
+import '../style.scss';
+
+export default function AiMcpConnectAgentContent() {
+	const dispatch = useDispatch();
+
+	const [ selectedAgentId, setSelectedAgentId ] = useState< string >( DEFAULT_AGENT_ID );
+	const [ copied, setCopied ] = useState( false );
+
+	const selectedAgent: AgentConfig = useMemo( () => {
+		return (
+			AGENT_CONFIGS.find( ( a ) => a.id === selectedAgentId ) ??
+			( AGENT_CONFIGS[ 0 ] as AgentConfig )
+		);
+	}, [ selectedAgentId ] );
+
+	const onAgentChange = useCallback(
+		( next: string ) => {
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_ai_mcp_connect_agent_selected', {
+					agent_id: next,
+				} )
+			);
+			setSelectedAgentId( next );
+		},
+		[ dispatch ]
+	);
+
+	const onInstallActionClick = useCallback( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_ai_mcp_install_action_clicked', {
+				agent_id: selectedAgent.id,
+			} )
+		);
+	}, [ dispatch, selectedAgent ] );
+
+	const onCopy = useCallback( async () => {
+		try {
+			await navigator.clipboard.writeText( selectedAgent.manualSetupSnippet );
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_ai_mcp_manual_config_copied', {
+					agent_id: selectedAgent.id,
+				} )
+			);
+			setCopied( true );
+			setTimeout( () => setCopied( false ), 2000 );
+		} catch {
+			// If the clipboard write fails, stay silent — the user can select the
+			// snippet manually from the pre block.
+		}
+	}, [ dispatch, selectedAgent ] );
+
+	return (
+		<>
+			<Spacer className="a4a-ai-mcp-overview__intro" marginBottom={ 12 }>
+				<Text size={ 15 }>
+					{ preventWidows(
+						__(
+							'Get instructions for connecting your external AI assistant to your Automattic for Agencies account via MCP.'
+						)
+					) }
+				</Text>
+			</Spacer>
+
+			<VStack spacing={ 4 } className="a4a-ai-mcp-connect-agent">
+				<Card>
+					<CardBody>
+						<SelectControl
+							label={ __( 'Choose your AI assistant' ) }
+							value={ selectedAgent.id }
+							options={ AGENT_CONFIGS.map( ( a ) => ( {
+								label: a.label,
+								value: a.id,
+							} ) ) }
+							onChange={ onAgentChange }
+						/>
+					</CardBody>
+				</Card>
+
+				{ selectedAgent.quickSetup && selectedAgent.quickSetup.length > 0 && (
+					<Card>
+						<CardBody>
+							<VStack spacing={ 3 }>
+								<Text weight={ 600 } size={ 15 }>
+									{ __( 'Quick setup' ) }
+								</Text>
+								{ selectedAgent.quickSetupDescription && (
+									<Text variant="muted">{ selectedAgent.quickSetupDescription }</Text>
+								) }
+								<ol>
+									{ selectedAgent.quickSetup.map( ( step, idx ) => (
+										<li key={ idx }>
+											<Text>{ step }</Text>
+										</li>
+									) ) }
+								</ol>
+								{ selectedAgent.installAction && (
+									<>
+										<Text>{ __( 'Or use the one-click install to add the A4A MCP app.' ) }</Text>
+										<Button
+											style={ { width: 'fit-content' } }
+											variant="primary"
+											href={ selectedAgent.installAction.deepLink }
+											onClick={ onInstallActionClick }
+										>
+											{ selectedAgent.installAction.label }
+										</Button>
+									</>
+								) }
+							</VStack>
+						</CardBody>
+					</Card>
+				) }
+
+				<Card>
+					<CardBody>
+						<VStack spacing={ 3 }>
+							<HStack alignment="center">
+								<Text weight={ 600 } size={ 15 }>
+									{ __( 'Manual setup' ) }
+								</Text>
+								<Spacer />
+								<Button
+									variant="tertiary"
+									icon={ copied ? check : copy }
+									label={ copied ? __( 'Copied' ) : __( 'Copy configuration' ) }
+									showTooltip
+									onClick={ onCopy }
+								/>
+							</HStack>
+							<Text variant="muted">
+								{ selectedAgent.manualSetupFile
+									? sprintf(
+											/* translators: %(file)s is the config file name */
+											__( 'Copy this configuration into %(file)s.' ),
+											{
+												file: selectedAgent.manualSetupFile,
+											}
+									  )
+									: __( 'Copy this configuration into your client’s MCP settings.' ) }
+							</Text>
+							<TextareaControl
+								className="a4a-ai-mcp-code-block"
+								value={ selectedAgent.manualSetupSnippet }
+								onChange={ () => {} }
+								readOnly
+							/>
+							<ExternalLink href={ selectedAgent.docsUrl } children={ selectedAgent.docsLabel } />
+						</VStack>
+					</CardBody>
+				</Card>
+			</VStack>
+		</>
+	);
+}

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/connect-agent/index.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/connect-agent/index.tsx
@@ -1,0 +1,42 @@
+import { __ } from '@wordpress/i18n';
+import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
+import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import { A4A_AI_MCP_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import LayoutBody from 'calypso/layout/hosting-dashboard/body';
+import LayoutHeader, {
+	LayoutHeaderActions as Actions,
+	LayoutHeaderBreadcrumb as Breadcrumb,
+} from 'calypso/layout/hosting-dashboard/header';
+import AiMcpConnectAgentContent from './connect-agent-content';
+
+export default function AiMcpConnectAgent() {
+	const title = __( 'Connect external AI assistant' );
+
+	return (
+		<Layout title={ title } wide>
+			<LayoutTop>
+				<LayoutHeader>
+					<Breadcrumb
+						hideOnMobile
+						items={ [
+							{
+								label: __( 'AI and MCP' ),
+								href: A4A_AI_MCP_LINK,
+							},
+							{
+								label: title,
+							},
+						] }
+					/>
+					<Actions useColumnAlignment>
+						<MobileSidebarNavigation />
+					</Actions>
+				</LayoutHeader>
+			</LayoutTop>
+			<LayoutBody>
+				<AiMcpConnectAgentContent />
+			</LayoutBody>
+		</Layout>
+	);
+}

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/overview/overview-content.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/overview/overview-content.tsx
@@ -5,9 +5,12 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { Icon, tool } from '@wordpress/icons';
+import { Icon, plugins, tool } from '@wordpress/icons';
 import { useCallback } from 'react';
-import { A4A_AI_MCP_AVAILABLE_TOOLS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import {
+	A4A_AI_MCP_AVAILABLE_TOOLS_LINK,
+	A4A_AI_MCP_CONNECT_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useFetchMcpSettings from 'calypso/a8c-for-agencies/data/mcp-ai/use-fetch-mcp-settings';
 import useUpdateMcpSettingsMutation from 'calypso/a8c-for-agencies/data/mcp-ai/use-update-mcp-settings-mutation';
 import { Card, CardBody, CardDivider } from 'calypso/dashboard/components/card';
@@ -40,6 +43,10 @@ export default function AiMcpOverviewContent() {
 
 	const onAvailableToolsClick = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_ai_mcp_available_tools_click' ) );
+	}, [ dispatch ] );
+
+	const onConnectClick = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_ai_mcp_connect_click' ) );
 	}, [ dispatch ] );
 
 	const availableAbilities = settings?.available_abilities ?? [];
@@ -100,6 +107,14 @@ export default function AiMcpOverviewContent() {
 						disabled={ ! mainEnabled }
 					/>
 				</Card>
+
+				<DashboardSummaryButton
+					title={ __( 'Connect external AI assistant' ) }
+					description={ __( 'Get instructions for connecting your external AI assistant.' ) }
+					decoration={ <Icon icon={ plugins } size={ 24 } /> }
+					href={ A4A_AI_MCP_CONNECT_LINK }
+					onClick={ onConnectClick }
+				/>
 			</VStack>
 		</>
 	);

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/style.scss
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/style.scss
@@ -1,3 +1,10 @@
+
+.a4a-ai-mcp-code-block .components-textarea-control__input {
+	field-sizing: content;
+	min-height: 80px;
+	max-height: 400px;
+}
+
 .a4a-ai-mcp-overview__intro {
 	max-width: 650px;
 
@@ -16,4 +23,12 @@
 			background: none;
 		}
 	}
+}
+
+.a4a-ai-mcp-connect-agent ol code {
+	padding: 2px 6px;
+	border-radius: 3px;
+	background: var( --color-neutral-0 );
+	font-family: monospace;
+	font-size: inherit;
 }

--- a/client/a8c-for-agencies/sections/learn/index.ts
+++ b/client/a8c-for-agencies/sections/learn/index.ts
@@ -2,6 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import {
 	A4A_AI_MCP_AVAILABLE_TOOLS_LINK,
+	A4A_AI_MCP_CONNECT_LINK,
 	A4A_AI_MCP_LINK,
 	A4A_DEV_TOOLS_LINK,
 	A4A_LEARN_LINK,
@@ -9,7 +10,11 @@ import {
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { requireAccessContext } from 'calypso/a8c-for-agencies/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import { aiMcpAvailableToolsContext, aiMcpOverviewContext } from '../ai-mcp/controller';
+import {
+	aiMcpAvailableToolsContext,
+	aiMcpConnectContext,
+	aiMcpOverviewContext,
+} from '../ai-mcp/controller';
 import { devToolsContext } from '../dev-tools/controller';
 import * as controller from './controller';
 
@@ -29,6 +34,13 @@ export default function () {
 			A4A_AI_MCP_AVAILABLE_TOOLS_LINK,
 			requireAccessContext,
 			aiMcpAvailableToolsContext,
+			makeLayout,
+			clientRender
+		);
+		page(
+			A4A_AI_MCP_CONNECT_LINK,
+			requireAccessContext,
+			aiMcpConnectContext,
 			makeLayout,
 			clientRender
 		);


### PR DESCRIPTION
This PR is built on top of #110219.

Part of A4A-2523

Resolves A4A-2526

## Proposed Changes

* New "Connect agent" page under AI and MCP that walks users through wiring an external AI assistant to their A4A account via MCP.
* Five preset agents: Claude Code, Claude Desktop, Cursor, Codex, VS Code, plus a generic "Other MCP client" option.
* Each preset shows a Quick setup ordered list (with inline `<code>` formatting and external doc links where applicable) and a Manual setup card with a copyable JSON/TOML snippet.
* Cursor includes a one-click install button using its `cursor://anysphere.cursor-deeplink/mcp/install?...` deep link.
* Tracks events: `calypso_a4a_ai_mcp_connect_agent_selected`, `calypso_a4a_ai_mcp_install_action_clicked`, `calypso_a4a_ai_mcp_manual_config_copied`.
* All user-facing strings translated via `@wordpress/i18n` (`__`, `sprintf`, `createInterpolateElement`).
* Manual setup textarea auto-grows to fit content via CSS `field-sizing: content` (with min/max-height guardrails).

## Why are these changes being made?

Agencies need a guided setup flow to connect their preferred AI assistant to the new A4A MCP server. The Connect agent page reduces friction by providing copy-paste-ready configuration for each major MCP client, plus a one-click install path for Cursor.

## Testing Instructions

Note: we will update the agent name later.

* Navigate to AI and MCP → Connect agent in A4A.

<img width="1920" height="962" alt="Screenshot 2026-04-28 at 4 00 18 PM" src="https://github.com/user-attachments/assets/0fa0a6a8-ddf7-4ae7-82ce-1cd2b92f8ff5" />

* For each option in the dropdown (Claude Code, Claude Desktop, Cursor, Codex, VS Code, Other MCP client):
  * Verify the Quick setup steps render with correct copy and inline `code` formatting (the Quick setup card is hidden for "Other MCP client").
  * Verify the Manual setup card shows the right config snippet and the file-name hint (or the generic fallback for "Other MCP client").
  * Click the copy icon and confirm the snippet lands on the clipboard.
  * Verify the docs link at the bottom opens the expected URL.
* For Cursor specifically: click "Install in Cursor" and confirm the browser hands off to the `cursor://` deep link.
* Confirm the Manual setup textarea auto-grows for longer snippets and stays bounded around 400px.
* Confirm Tracks events fire on agent change, copy, and install action click.

<img width="1920" height="962" alt="Screenshot 2026-04-28 at 3 59 21 PM" src="https://github.com/user-attachments/assets/402ebafe-6022-4059-bf81-e8c575280543" />

<img width="1920" height="962" alt="Screenshot 2026-04-28 at 3 59 28 PM" src="https://github.com/user-attachments/assets/5e5ab85d-0652-437b-b0d9-8a32e21c334f" />

<img width="1920" height="962" alt="Screenshot 2026-04-28 at 3 59 51 PM" src="https://github.com/user-attachments/assets/158b5346-d390-4f25-bd34-717084e9c8f6" />

<img width="1920" height="962" alt="Screenshot 2026-04-28 at 3 59 58 PM" src="https://github.com/user-attachments/assets/b0b94a0f-0f2f-4c40-836e-43f8e8f39219" />

<img width="1920" height="962" alt="Screenshot 2026-04-28 at 4 00 04 PM" src="https://github.com/user-attachments/assets/7d313356-244f-4431-8d77-8cedaf8fc701" />

<img width="1920" height="962" alt="Screenshot 2026-04-28 at 4 00 11 PM" src="https://github.com/user-attachments/assets/26940a4d-fe4a-42c0-a25f-9a7741dfac74" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?