### PR TITLE
Add monitoring page charts dark mode

### DIFF
--- a/client/dashboard/app/chart-theme.ts
+++ b/client/dashboard/app/chart-theme.ts
@@ -1,0 +1,24 @@
+import type { ChartTheme } from '@automattic/charts';
+
+export const dashboardChartTheme: Partial< ChartTheme > = {
+	backgroundColor: 'var(--dashboard-surface__background-color)',
+	gridColor: 'var(--dashboard-surface__border-color)',
+	gridColorDark: 'var(--dashboard-surface__border-color)',
+	gridStyles: {
+		stroke: 'var(--dashboard-surface__border-color)',
+		strokeWidth: 1,
+	},
+	xAxisLineStyles: {
+		stroke: 'var(--dashboard-surface__border-color)',
+		strokeWidth: 1,
+	},
+	xTickLineStyles: {
+		stroke: 'var(--dashboard-surface__border-color)',
+	},
+	legendLabelStyles: {
+		color: 'var(--dashboard__text-muted-color)',
+	},
+	svgLabelSmall: {
+		fill: 'var(--dashboard__text-muted-color)',
+	},
+};

--- a/client/dashboard/app/layout.tsx
+++ b/client/dashboard/app/layout.tsx
@@ -5,6 +5,7 @@ import {
 	recordTracksEvent,
 	recordTracksPageViewWithPageParams,
 } from '@automattic/calypso-analytics';
+import { GlobalChartsProvider } from '@automattic/charts';
 import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { RouterProvider, type AnyRouter } from '@tanstack/react-router';
@@ -12,6 +13,7 @@ import { useMemo, useEffect } from 'react';
 import { AnalyticsProvider, type AnalyticsClient } from './analytics';
 import { getNormalizedPath, getSuperProps } from './analytics/super-props';
 import { AuthProvider, useAuth } from './auth';
+import { dashboardChartTheme } from './chart-theme';
 import { ColorSchemeProvider } from './color-scheme';
 import { AppProvider, useAppContext } from './context';
 import { I18nProvider } from './i18n';
@@ -78,7 +80,9 @@ function Layout( { config }: { config: AppConfig } ) {
 			<AuthProvider>
 				<I18nProvider>
 					<AnalyticsProviderWithClient router={ router }>
-						<RouterProvider router={ router } context={ { config } } />
+						<GlobalChartsProvider theme={ dashboardChartTheme }>
+							<RouterProvider router={ router } context={ { config } } />
+						</GlobalChartsProvider>
 					</AnalyticsProviderWithClient>
 				</I18nProvider>
 			</AuthProvider>

--- a/client/dashboard/app/style.scss
+++ b/client/dashboard/app/style.scss
@@ -38,11 +38,15 @@ a {
 	color: var( --wp-admin-theme-color );
 }
 
-// This is a temporary fix to ensure the tooltip has a box-shadow.
+// This is a temporary fix to ensure the tooltip has dashboard colors and a box-shadow.
 // Currently, there is an issue with @automattic/charts where svgLabelSmall.fill is defined with var().
 // This causes the visx tooltip to render a malformed box-shadow value, given that it interpolates the color. e.g: `${theme?.color}55`.
+// Pie charts also use @visx/tooltip directly, so they do not get the background from the chart theme.
 .visx-tooltip:has(div[role="tooltip"]) {
-	box-shadow: 0 1px 2px $gray-300 !important;
+	box-shadow: 0 1px 2px var( --dashboard-surface__border-color ) !important;
+	background: var( --dashboard-surface__background-color ) !important;
+	border: 1px solid var( --dashboard-surface__border-color );
+	color: var( --dashboard__text-color ) !important;
 }
 
 :root[data-theme='dark'] {

--- a/client/dashboard/sites/monitoring-card/style.scss
+++ b/client/dashboard/sites/monitoring-card/style.scss
@@ -95,8 +95,9 @@
 			margin-top: 20px;
 			margin-inline-start: 20px;
 			border-radius: 4px;
-			border: 1px solid #DDD;
-			background: #FFF;
+			border: 1px solid var( --dashboard-surface__border-color );
+			background: var( --dashboard-surface__background-color );
+			color: var( --dashboard__text-color );
 			padding: 16px;
 			text-wrap: nowrap;
 			z-index: 1;


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/RSM-1497/multiple-issues-in-graphs

The various graphs found in the monitoring page and the others had some hardcoded colors. I tried many approaches, and later I found that, fortunately, the chart package exposes a `GlobalChartsProvider` that can be used to change colors and other settings.

Without that, we needed to force a lot of `!important` rules on the `.dashboard-monitoring-card__line-chart--tooltip` exposed class to win against the inline style applied.

## Proposed Changes

* Remove chart hardcoded colors
* Remove tooltip hardcoded colors
* Add a new chart provider with default colors

Important:
1. The donut chart background was forced to `#fff`
2. White colors are not touched.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To remove hardcoded colors
* To add dark mode to monitoring page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `https://my.wordpress.com/sites/_SITE_/monitoring`
* Visit `https://my.localhost:3000/sites/_SITE_/monitoring`
* Hover the graphs
* Be sure that the light mode is untouched
* Check dark mode colors

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
