### PR TITLE
AsyncLoad: restore useMemo dependency on require prop

### DIFF
--- a/client/components/async-load/index.tsx
+++ b/client/components/async-load/index.tsx
@@ -17,7 +17,7 @@ export default function AsyncLoad( {
 	require,
 	...props
 }: AsyncLoadProps ) {
-	const Component = useMemo( () => lazy( require ), [] );
+	const Component = useMemo( () => lazy( require ), [ require ] );
 
 	return (
 		<Suspense fallback={ placeholder }>


### PR DESCRIPTION
## Summary

- Fixes a regression from #110042 where changing the `useMemo` dependency array in `AsyncLoad` from `[require]` to `[]` caused client-side navigation to break when two pages use `AsyncLoad` in the same layout position (e.g., Reader subscription list → subscription detail).
- With `[]`, React reused the existing `AsyncLoad` instance on navigation but never re-evaluated the `require` prop, so the old lazy component kept rendering.

## Root cause

In #110042, the `useMemo` was changed from:
```js
const Component = useMemo(() => lazy(requireCb), [require]);
```
to:
```js
const Component = useMemo(() => lazy(require), []);
```

The empty dependency array means `lazy(require)` is only evaluated once per component instance. When page.js navigates and React reconciles the tree, it matches the old `AsyncLoad` with the new one (same component type, same position), does a prop update, but `useMemo` ignores the new `require` function.

## Test plan

- [ ] Navigate to `/reader/subscriptions`
- [ ] Click on an individual subscription
- [ ] Verify the subscription detail page renders with site info
- [ ] Verify the URL updates to `/reader/subscriptions/:id`
- [ ] Navigate back and click a different subscription — verify it loads correctly
- [ ] Verify other AsyncLoad-based navigations still work (e.g., Reader → Discover)

🤖 Generated with [Claude Code](https://claude.com/claude-code)