### PR TITLE
Performance: enable/disable APM toggle on the Backend page

### DIFF
--- a/client/dashboard/sites/performance/backend/enable-apm-callout.tsx
+++ b/client/dashboard/sites/performance/backend/enable-apm-callout.tsx
@@ -1,0 +1,72 @@
+import { siteApmEnabledMutation } from '@automattic/api-queries';
+import { useMutation } from '@tanstack/react-query';
+import { __experimentalText as Text, Button } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+import { chartBar } from '@wordpress/icons';
+import { useEffect } from 'react';
+import { useAnalytics } from '../../../app/analytics';
+import { Callout } from '../../../components/callout';
+import EmptyState from '../../../components/empty-state';
+import illustrationUrl from '../performance-callout-illustration.svg';
+import type { Site } from '@automattic/api-core';
+
+export default function EnableApmCallout( { site }: { site: Site } ) {
+	const { recordTracksEvent } = useAnalytics();
+	const isDesktop = useViewportMatch( 'medium' );
+
+	useEffect( () => {
+		recordTracksEvent( 'calypso_dashboard_site_apm_enable_impression' );
+	}, [ recordTracksEvent ] );
+
+	const { mutate, isPending } = useMutation( {
+		...siteApmEnabledMutation( site.ID ),
+		meta: {
+			snackbar: {
+				success: __( 'APM enabled.' ),
+				error: __( 'Failed to enable APM.' ),
+			},
+		},
+	} );
+
+	const handleClick = () => {
+		recordTracksEvent( 'calypso_dashboard_site_apm_enable_click' );
+		mutate( true );
+	};
+
+	const callout = (
+		<Callout
+			icon={ chartBar }
+			image={ illustrationUrl }
+			imageAlt=""
+			title={ __( 'Optimize your backend performance' ) }
+			description={
+				<Text variant="muted">
+					{ __(
+						'Get request-level tracing, top slow endpoints, and plugin bottleneck detection for your site.'
+					) }
+				</Text>
+			}
+			actions={
+				<Button
+					variant="primary"
+					isBusy={ isPending }
+					disabled={ isPending }
+					onClick={ handleClick }
+				>
+					{ __( 'Enable' ) }
+				</Button>
+			}
+		/>
+	);
+
+	if ( ! isDesktop ) {
+		return callout;
+	}
+
+	return (
+		<EmptyState.Wrapper>
+			<div style={ { maxWidth: '600px' } }>{ callout }</div>
+		</EmptyState.Wrapper>
+	);
+}

--- a/client/dashboard/sites/performance/backend/index.tsx
+++ b/client/dashboard/sites/performance/backend/index.tsx
@@ -1,11 +1,16 @@
 import { BusinessPlans, EcommercePlans } from '@automattic/api-core';
-import { siteBySlugQuery } from '@automattic/api-queries';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { siteApmEnabledMutation, siteBySlugQuery } from '@automattic/api-queries';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useAnalytics } from '../../../app/analytics';
+import { Card, CardBody, CardFooter } from '../../../components/card';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
 import UpsellCallout from '../../hosting-feature-gated-with-callout/upsell';
 import { getBackendCalloutProps } from '../backend-callout';
+import EnableApmCallout from './enable-apm-callout';
+import type { Site } from '@automattic/api-core';
 
 function hasBackendAccess( productSlug: string | undefined ) {
 	if ( ! productSlug ) {
@@ -17,16 +22,56 @@ function hasBackendAccess( productSlug: string | undefined ) {
 	);
 }
 
+function ApmEnabledPlaceholder( { site }: { site: Site } ) {
+	const { recordTracksEvent } = useAnalytics();
+	const { mutate, isPending } = useMutation( {
+		...siteApmEnabledMutation( site.ID ),
+		meta: {
+			snackbar: {
+				success: __( 'APM disabled.' ),
+				error: __( 'Failed to disable APM.' ),
+			},
+		},
+	} );
+
+	const handleDisable = () => {
+		recordTracksEvent( 'calypso_dashboard_site_apm_disable_click' );
+		mutate( false );
+	};
+
+	return (
+		<Card>
+			<CardBody>{ __( 'APM dashboards coming soon.' ) }</CardBody>
+			<CardFooter>
+				<Button
+					variant="secondary"
+					isBusy={ isPending }
+					disabled={ isPending }
+					onClick={ handleDisable }
+				>
+					{ __( 'Disable' ) }
+				</Button>
+			</CardFooter>
+		</Card>
+	);
+}
+
 export default function SitePerformanceBackend( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 
+	const renderContent = () => {
+		if ( ! hasBackendAccess( site.plan?.product_slug ) ) {
+			return <UpsellCallout site={ site } { ...getBackendCalloutProps() } />;
+		}
+
+		return site.options?.apm_enabled ? (
+			<ApmEnabledPlaceholder site={ site } />
+		) : (
+			<EnableApmCallout site={ site } />
+		);
+	};
+
 	return (
-		<PageLayout header={ <PageHeader title={ __( 'Backend' ) } /> }>
-			{ hasBackendAccess( site.plan?.product_slug ) ? (
-				<p>{ __( 'Application Performance Monitoring — coming soon.' ) }</p>
-			) : (
-				<UpsellCallout site={ site } { ...getBackendCalloutProps() } />
-			) }
-		</PageLayout>
+		<PageLayout header={ <PageHeader title={ __( 'Backend' ) } /> }>{ renderContent() }</PageLayout>
 	);
 }

--- a/client/dashboard/sites/performance/backend/test/index.test.tsx
+++ b/client/dashboard/sites/performance/backend/test/index.test.tsx
@@ -2,39 +2,39 @@
  * @jest-environment jsdom
  */
 
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { render } from '../../../../test-utils';
 import SitePerformanceBackend from '../index';
 import type { Site } from '@automattic/api-core';
 
 const siteSlug = 'test-site.wordpress.com';
+const siteId = 1;
 
-const businessSite = {
-	ID: 1,
-	slug: siteSlug,
-	is_wpcom_atomic: true,
-	plan: {
-		product_slug: 'business-bundle',
-		product_name_short: 'Business',
-		is_free: false,
-		features: {
-			active: [ 'atomic' ],
+const businessSite = ( apmEnabled: boolean ) =>
+	( {
+		ID: siteId,
+		slug: siteSlug,
+		is_wpcom_atomic: true,
+		plan: {
+			product_slug: 'business-bundle',
+			product_name_short: 'Business',
+			is_free: false,
+			features: { active: [ 'atomic' ] },
 		},
-	},
-} as Site;
+		options: { apm_enabled: apmEnabled },
+	} ) as unknown as Site;
 
 const personalSite = {
-	ID: 1,
+	ID: siteId,
 	slug: siteSlug,
 	is_wpcom_atomic: false,
 	plan: {
 		product_slug: 'personal-bundle',
 		product_name_short: 'Personal',
 		is_free: false,
-		features: {
-			active: [],
-		},
+		features: { active: [] },
 	},
 } as unknown as Site;
 
@@ -45,16 +45,58 @@ function mockSite( mockedSite: Site ) {
 		.reply( 200, mockedSite );
 }
 
+function mockApmToggle( expectedActive: boolean ) {
+	return nock( 'https://public-api.wordpress.com' )
+		.post( `/wpcom/v2/sites/${ siteId }/hosting/apm`, ( body ) => {
+			expect( body ).toEqual( { active: expectedActive } );
+			return true;
+		} )
+		.reply( 200, JSON.stringify( expectedActive ), { 'Content-Type': 'application/json' } );
+}
+
 describe( '<SitePerformanceBackend>', () => {
-	test( 'renders placeholder for a site on the Business plan', async () => {
-		mockSite( businessSite );
+	test( 'renders Enable CTA when APM is disabled on a Business site', async () => {
+		mockSite( businessSite( false ) );
 
 		render( <SitePerformanceBackend siteSlug={ siteSlug } /> );
 
-		expect(
-			await screen.findByText( 'Application Performance Monitoring — coming soon.' )
-		).toBeVisible();
-		expect( screen.queryByRole( 'button', { name: 'Upgrade plan' } ) ).not.toBeInTheDocument();
+		expect( await screen.findByRole( 'button', { name: 'Enable' } ) ).toBeVisible();
+		expect( screen.queryByText( 'APM dashboards coming soon.' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders enabled placeholder + Disable when APM is already enabled', async () => {
+		mockSite( businessSite( true ) );
+
+		render( <SitePerformanceBackend siteSlug={ siteSlug } /> );
+
+		expect( await screen.findByText( 'APM dashboards coming soon.' ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Disable' } ) ).toBeVisible();
+	} );
+
+	test( 'clicking Enable POSTs { active: true }', async () => {
+		mockSite( businessSite( false ) );
+		const scope = mockApmToggle( true );
+
+		render( <SitePerformanceBackend siteSlug={ siteSlug } /> );
+
+		await userEvent.click( await screen.findByRole( 'button', { name: 'Enable' } ) );
+
+		await waitFor( () => {
+			expect( scope.isDone() ).toBe( true );
+		} );
+	} );
+
+	test( 'clicking Disable POSTs { active: false }', async () => {
+		mockSite( businessSite( true ) );
+		const scope = mockApmToggle( false );
+
+		render( <SitePerformanceBackend siteSlug={ siteSlug } /> );
+
+		await userEvent.click( await screen.findByRole( 'button', { name: 'Disable' } ) );
+
+		await waitFor( () => {
+			expect( scope.isDone() ).toBe( true );
+		} );
 	} );
 
 	test( 'renders upsell when the site is on a plan below Business', async () => {
@@ -63,8 +105,6 @@ describe( '<SitePerformanceBackend>', () => {
 		render( <SitePerformanceBackend siteSlug={ siteSlug } /> );
 
 		expect( await screen.findByRole( 'button', { name: 'Upgrade plan' } ) ).toBeVisible();
-		expect(
-			screen.queryByText( 'Application Performance Monitoring — coming soon.' )
-		).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Enable' } ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -99,6 +99,7 @@ export * from './site-features';
 export * from './site-hosting';
 export * from './site-hosting-code-deployments';
 export * from './site-hosting-crontab';
+export * from './site-hosting-apm';
 export * from './site-hosting-edge-cache';
 export * from './site-hosting-metrics';
 export * from './site-hosting-sftp';

--- a/packages/api-core/src/site-hosting-apm/index.ts
+++ b/packages/api-core/src/site-hosting-apm/index.ts
@@ -1,0 +1,1 @@
+export * from './mutators';

--- a/packages/api-core/src/site-hosting-apm/mutators.ts
+++ b/packages/api-core/src/site-hosting-apm/mutators.ts
@@ -1,0 +1,11 @@
+import { wpcom } from '../wpcom-fetcher';
+
+export async function updateApmEnabled( siteId: number, active: boolean ): Promise< boolean > {
+	return wpcom.req.post(
+		{
+			path: `/sites/${ siteId }/hosting/apm`,
+			apiNamespace: 'wpcom/v2',
+		},
+		{ active }
+	);
+}

--- a/packages/api-core/src/site/fetchers.ts
+++ b/packages/api-core/src/site/fetchers.ts
@@ -47,6 +47,7 @@ export const JOINED_SITE_FIELDS = SITE_FIELDS.join( ',' );
 
 export const SITE_OPTIONS = [
 	'admin_url',
+	'apm_enabled',
 	'created_at',
 	'unmapped_url',
 	'is_difm_lite_in_progress',

--- a/packages/api-core/src/site/types.ts
+++ b/packages/api-core/src/site/types.ts
@@ -20,6 +20,7 @@ export interface SiteCapabilities {
 
 export interface SiteOptions {
 	admin_url: string;
+	apm_enabled?: boolean;
 	created_at?: string;
 	is_domain_only?: boolean;
 	is_redirect?: boolean;

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -75,6 +75,7 @@ export * from './reader-mastodon';
 export * from './site-activity-log';
 export * from './site-activity-log-backup';
 export * from './site-address-change';
+export * from './site-apm';
 export * from './site-admin-bar';
 export * from './site-agency';
 export * from './site-atomic-transfers';

--- a/packages/api-queries/src/site-apm.ts
+++ b/packages/api-queries/src/site-apm.ts
@@ -1,0 +1,20 @@
+import { updateApmEnabled } from '@automattic/api-core';
+import { mutationOptions } from '@tanstack/react-query';
+import { queryClient } from './query-client';
+import { siteQueryFilter } from './site';
+import type { Site } from '@automattic/api-core';
+
+export const siteApmEnabledMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: ( active: boolean ) => updateApmEnabled( siteId, active ),
+		onSuccess: ( _data, active ) => {
+			queryClient.setQueriesData< Site >( siteQueryFilter( siteId ), ( site ) =>
+				site
+					? {
+							...site,
+							options: { ...site.options, apm_enabled: active } as Site[ 'options' ],
+					  }
+					: site
+			);
+		},
+	} );


### PR DESCRIPTION
Part of #

## Proposed Changes

* Add an "Optimize your backend performance" Callout on the Performance → Backend page that lets Business+ sites turn APM on with a single click. Once enabled, the page renders an "APM dashboards coming soon" placeholder with a Disable affordance.
* New `POST /wpcom/v2/sites/<id>/hosting/apm` mutator with `{ active: boolean }` body — no separate status endpoint. APM-enabled state ships as a new `apm_enabled` field on the existing `Site.options` payload.
* Mutation success updates the cached `Site` object in place (via `siteQueryFilter`), so the UI flips without an extra refetch.

<img width="1167" height="876" alt="Captura de Tela 2026-04-28 às 13 43 40" src="https://github.com/user-attachments/assets/2d4fac50-ad3f-48f9-840a-293404f05cee" />

## Why are these changes being made?

Follow-up to #110222 (which scaffolded the Frontend/Backend split behind the `performance/apm` flag). With the page in place, this PR wires the actual enable/disable affordance so we can start onboarding sites onto the new APM backend before the dashboards land.

## Testing Instructions

* Apply the following backend PRs to your sandbox:
   * https://github.com/Automattic/jetpack/pull/48366
   * 213738-ghe-Automattic/wpcom


1. Make sure `performance/apm` is enabled in `config/development.json`.
2. Visit `/sites/<slug>/performance/backend` on a site whose plan is Business or Commerce.
3. With `apm_enabled` falsy (default), confirm the centered Callout renders with the chart-bar icon and the existing performance illustration. Click **Enable** — a success snackbar (\`APM enabled.\`) should appear and the placeholder card should replace the Callout.
4. Click **Disable** on the placeholder — snackbar (\`APM disabled.\`) and the Callout returns.
5. On a Personal/Premium site, the existing upsell still renders.

Tracks events:
- \`calypso_dashboard_site_apm_enable_impression\`
- \`calypso_dashboard_site_apm_enable_click\`
- \`calypso_dashboard_site_apm_disable_click\`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?