### PR TITLE
Help Center: redirect /support/contact links to Odie

### DIFF
--- a/packages/support-articles/src/hooks/use-content-filter.ts
+++ b/packages/support-articles/src/hooks/use-content-filter.ts
@@ -60,6 +60,17 @@ export const useContentFilter = ( node: HTMLDivElement | null, currentSiteDomain
 						element.setAttribute( 'href', new URL( href, link ).href );
 					}
 
+					// /support/contact is a landing page, not a doc — its layout
+					// breaks inside the Help Center. Route to Odie instead.
+					const parsed = canParse( element.href );
+					if ( parsed && /^(?:\/\w\w)?\/support\/contact\/?$/.test( parsed.pathname ) ) {
+						element.onclick = ( event: Event ) => {
+							event.preventDefault();
+							navigate( '/odie' );
+						};
+						return;
+					}
+
 					element.onclick = ( event: Event ) => {
 						event.preventDefault();
 


### PR DESCRIPTION
Fixes DOTDOCS-824

## Proposed Changes

* In `packages/support-articles/src/hooks/use-content-filter.ts`, special-case in-article anchors that point at `/support/contact` (with optional locale prefix and trailing slash). Clicks now route to the Help Center's `/odie` route instead of falling through to the generic `/post?link=...` handler that loads the broken landing page.

## Why are these changes being made?

* The `/support/contact` URL on the support site is a "Contact us" landing page, not a regular doc/course. When the Help Center loads it inline through its article-rendering pipeline, the layout breaks. Users have been arriving on this broken page from in-article "contact us" links (e.g., the *Troubleshooting payment errors* article) and rating it negatively because they expected a contact form.
* Routing these clicks to `/odie` lands the user on a working in-Help-Center surface that can actually help them, instead of the broken page.

## Testing Instructions

### Calypso

1. `yarn start`
2. Sign in to `http://calypso.localhost:3000/` and open the Help Center via the **Help** button in the top bar.
3. Search for and open the doc **"Troubleshooting payment errors"**.
4. Scroll to the second-last section ("Duplicate payment detected") and click the **Contact us** link in the bullet point. (Also test the "contact us for help" link in the "Charged the wrong account" section.)
5. Expected: the Help Center navigates to the Odie chat surface, not to the broken `/support/contact` page.
6. Click around to other internal `/support/...` links in the same article — they should still open inline as before (regression check).

### Simple / Atomic / CIAB

1. Sandbox `widgets.wp.com`.
2. `cd apps/help-center && yarn dev --sync`
3. Visit any Simple, Atomic, or CIAB site.
4. Open the Help Center, repeat steps 3-6 above.
