### PR TITLE
fix-e2e-tests: add baseline-failures.sh

### DIFF
--- a/.claude/skills/fix-e2e-tests/baseline-failures.sh
+++ b/.claude/skills/fix-e2e-tests/baseline-failures.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Count failed E2E builds on TeamCity over a trailing window, to track the
+# impact of the fix-e2e-tests skill over time.
+#
+# Usage:
+#   ./baseline-failures.sh           # last 30 days
+#   DAYS=14 ./baseline-failures.sh   # last 14 days
+#
+# Requires: TeamCity token at ~/.config/teamcity-access-token (TEAMCITY_TOKEN=...),
+# and a SOCKS5 proxy at localhost:8080.
+
+set -euo pipefail
+
+DAYS="${DAYS:-30}"
+SINCE_RAW=$(date -u -d "${DAYS} days ago" +%Y%m%dT%H%M%S%z)
+SINCE="${SINCE_RAW/+/%2B}"
+SINCE_HUMAN=$(date -u -d "${DAYS} days ago" +%Y-%m-%d)
+UNTIL_HUMAN=$(date -u +%Y-%m-%d)
+
+TOKEN_FILE="$HOME/.config/teamcity-access-token"
+if [ ! -r "$TOKEN_FILE" ]; then
+	echo "Token not found at $TOKEN_FILE." >&2
+	echo "Run .claude/skills/fix-e2e-tests/setup-token.sh in a real terminal first." >&2
+	exit 1
+fi
+TOKEN=$(cut -d= -f2 "$TOKEN_FILE")
+
+count() {
+	local locator="$1"
+	curl -sS --socks5 localhost:8080 \
+		-H "Authorization: Bearer $TOKEN" -H "Accept: application/json" \
+		"https://teamcity.a8c.com/app/rest/builds?locator=${locator}&fields=count" \
+		| jq -r .count
+}
+
+printf 'Window: %s → %s (%s days)\n\n' "$SINCE_HUMAN" "$UNTIL_HUMAN" "$DAYS"
+printf '%-50s %10s %10s %8s\n' 'Build config' 'Failures' 'Total' 'Rate'
+printf '%-50s %10s %10s %8s\n' '--------------------------------------------------' '--------' '-----' '----'
+
+for ID in \
+	calypso_calypso_WebApp_Calypso_E2E_Playwright_desktop \
+	calypso_calypso_WebApp_Calypso_E2E_Playwright_mobile \
+	calypso_calypso_WebApp_Calypso_E2E_Playwright_Test_Matrix
+do
+	base="buildType:(id:${ID}),sinceDate:${SINCE},state:finished,branch:default:any,count:10000"
+	total=$(count "${base}")
+	fails=$(count "${base},status:FAILURE")
+	rate=$(awk -v f="$fails" -v t="$total" 'BEGIN{ if (t==0) print "n/a"; else printf "%.1f%%", 100*f/t }')
+	printf '%-50s %10s %10s %8s\n' "$ID" "$fails" "$total" "$rate"
+done


### PR DESCRIPTION
Part of DOTCOM-16871

## Proposed Changes

* Add `.claude/skills/fix-e2e-tests/baseline-failures.sh`, a script that queries the TeamCity REST API and prints failed-build counts and rates over a trailing time window for the three Calypso E2E build configs (`desktop`, `mobile`, `Test_Matrix`).

## Why are these changes being made?

* The `fix-e2e-tests` skill (#110116) lets contributors fix failing E2E tests on a PR. To know whether the skill is moving the needle on overall E2E reliability, we need a repeatable baseline metric. This script captures the same query that produced the initial 30-day baseline (4.2% / 4.2% / 16.3% failure rates), so re-running it in a few weeks gives a directly comparable post-skill number.
* The query uses `branch:default:any` (not `defaultFilter:false`) on purpose: the latter lets `failedToStart:true` builds — TeamCity-side infra failures, not test failures — through, which would inflate the count and obscure the signal we care about.

## Testing Instructions

* Ensure your TeamCity token is set up (`bash .claude/skills/fix-e2e-tests/setup-token.sh` in a real terminal).
* Run `./.claude/skills/fix-e2e-tests/baseline-failures.sh` — should print a table for the trailing 30 days.
* Run `DAYS=14 ./.claude/skills/fix-e2e-tests/baseline-failures.sh` — should print a table for the trailing 14 days.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?