### PR TITLE
AsyncLoad: add key props when used in a router controller

### DIFF
--- a/client/blocks/jitm/index.jsx
+++ b/client/blocks/jitm/index.jsx
@@ -23,6 +23,7 @@ function renderTemplate( template, props ) {
 			return (
 				<AsyncLoad
 					{ ...props }
+					key="notice"
 					require={ () =>
 						import(
 							/* webpackChunkName: "async-load-calypso-blocks-jitm-templates-notice" */ './templates/notice'
@@ -35,6 +36,7 @@ function renderTemplate( template, props ) {
 			return (
 				<AsyncLoad
 					{ ...props }
+					key="sidebar-banner"
 					require={ () =>
 						import(
 							/* webpackChunkName: "async-load-calypso-blocks-jitm-templates-sidebar-banner" */ './templates/sidebar-banner'
@@ -47,6 +49,7 @@ function renderTemplate( template, props ) {
 			return (
 				<AsyncLoad
 					{ ...props }
+					key="home-task"
 					require={ () =>
 						import(
 							/* webpackChunkName: "async-load-calypso-blocks-jitm-templates-home-task" */ './templates/home-task'
@@ -59,6 +62,7 @@ function renderTemplate( template, props ) {
 			return (
 				<AsyncLoad
 					{ ...props }
+					key="spotlight"
 					require={ () =>
 						import(
 							/* webpackChunkName: "async-load-calypso-blocks-jitm-templates-spotlight" */ './templates/spotlight'
@@ -73,6 +77,7 @@ function renderTemplate( template, props ) {
 			return (
 				<AsyncLoad
 					{ ...props }
+					key="modal"
 					require={ () =>
 						import(
 							/* webpackChunkName: "async-load-calypso-blocks-jitm-templates-modal" */ './templates/modal'
@@ -85,6 +90,7 @@ function renderTemplate( template, props ) {
 			return (
 				<AsyncLoad
 					{ ...props }
+					key="default"
 					require={ () =>
 						import(
 							/* webpackChunkName: "async-load-calypso-blocks-jitm-templates-default" */ './templates/default'

--- a/client/components/jetpack-header/index.jsx
+++ b/client/components/jetpack-header/index.jsx
@@ -61,6 +61,7 @@ export class JetpackHeader extends PureComponent {
 						partnerName="DreamHost"
 					>
 						<AsyncLoad
+							key="dreamhost"
 							require={ () =>
 								import(
 									/* webpackChunkName: "async-load-calypso-components-jetpack-header-dreamhost" */ './dreamhost'
@@ -80,6 +81,7 @@ export class JetpackHeader extends PureComponent {
 						partnerName="Pressable"
 					>
 						<AsyncLoad
+							key="pressable"
 							require={ () =>
 								import(
 									/* webpackChunkName: "async-load-calypso-components-jetpack-header-pressable" */ './pressable'
@@ -99,6 +101,7 @@ export class JetpackHeader extends PureComponent {
 						partnerName="Bluehost"
 					>
 						<AsyncLoad
+							key="bluehost"
 							require={ () =>
 								import(
 									/* webpackChunkName: "async-load-calypso-components-jetpack-header-bluehost" */ './bluehost'
@@ -118,6 +121,7 @@ export class JetpackHeader extends PureComponent {
 						partnerName="InMotion"
 					>
 						<AsyncLoad
+							key="inmotion"
 							require={ () =>
 								import(
 									/* webpackChunkName: "async-load-calypso-components-jetpack-header-inmotion" */ './inmotion'
@@ -133,6 +137,7 @@ export class JetpackHeader extends PureComponent {
 				// This is a raster logo that contains the Jetpack logo already.
 				return (
 					<AsyncLoad
+						key="milesweb"
 						require={ () =>
 							import(
 								/* webpackChunkName: "async-load-calypso-components-jetpack-header-milesweb" */ './milesweb'
@@ -151,6 +156,7 @@ export class JetpackHeader extends PureComponent {
 						partnerName="Liquid Web"
 					>
 						<AsyncLoad
+							key="liquidweb"
 							require={ () =>
 								import(
 									/* webpackChunkName: "async-load-calypso-components-jetpack-header-liquidweb" */ './liquidweb'
@@ -169,6 +175,7 @@ export class JetpackHeader extends PureComponent {
 						partnerName="EuroDNS"
 					>
 						<AsyncLoad
+							key="eurodns"
 							require={ () =>
 								import(
 									/* webpackChunkName: "async-load-calypso-components-jetpack-header-eurodns" */ './eurodns'

--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -80,6 +80,7 @@ const devdocs = {
 	design: function ( context, next ) {
 		context.primary = (
 			<AsyncLoad
+				key="devdocs-design"
 				component={ context.params.component }
 				require={ () =>
 					import( /* webpackChunkName: "async-load-calypso-devdocs-design" */ './design' )
@@ -98,6 +99,7 @@ const devdocs = {
 	blocks: function ( context, next ) {
 		context.primary = (
 			<AsyncLoad
+				key="devdocs-blocks"
 				component={ context.params.component }
 				require={ () =>
 					import(
@@ -112,6 +114,7 @@ const devdocs = {
 	playground: function ( context, next ) {
 		context.primary = (
 			<AsyncLoad
+				key="devdocs-playground"
 				component={ context.params.component }
 				require={ () =>
 					import(
@@ -126,6 +129,7 @@ const devdocs = {
 	wpComponentsGallery( context, next ) {
 		context.primary = (
 			<AsyncLoad
+				key="devdocs-wp-components-gallery"
 				require={ () =>
 					import(
 						/* webpackChunkName: "async-load-calypso-devdocs-design-wordpress-components-gallery" */ './design/wordpress-components-gallery'
@@ -139,6 +143,7 @@ const devdocs = {
 	selectors: function ( context, next ) {
 		context.primary = (
 			<AsyncLoad
+				key="devdocs-selectors"
 				require={ () =>
 					import(
 						/* webpackChunkName: "async-load-calypso-devdocs-docs-selectors" */ './docs-selectors'
@@ -154,6 +159,7 @@ const devdocs = {
 	typography: function ( context, next ) {
 		context.primary = (
 			<AsyncLoad
+				key="devdocs-typography"
 				component={ context.params.component }
 				require={ () =>
 					import(
@@ -168,6 +174,7 @@ const devdocs = {
 	illustrations: function ( context, next ) {
 		context.primary = (
 			<AsyncLoad
+				key="devdocs-illustrations"
 				component={ context.params.component }
 				require={ () =>
 					import(

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -148,6 +148,7 @@ export function overview( context, next ) {
 		siteId !== null ? (
 			<StatsPageLoader>
 				<AsyncLoad
+					key="stats-overview"
 					require={ () =>
 						import(
 							/* webpackChunkName: "async-load-calypso-my-sites-stats-overview" */ './overview'
@@ -160,6 +161,7 @@ export function overview( context, next ) {
 			</StatsPageLoader>
 		) : (
 			<AsyncLoad
+				key="stats-overview"
 				require={ () =>
 					import(
 						/* webpackChunkName: "async-load-calypso-my-sites-stats-overview" */ './overview'
@@ -315,6 +317,7 @@ export function summary( context, next ) {
 	context.primary = (
 		<StatsPageLoader>
 			<AsyncLoad
+				key="stats-summary"
 				require={ () =>
 					import( /* webpackChunkName: "async-load-calypso-my-sites-stats-summary" */ './summary' )
 				}
@@ -347,6 +350,7 @@ export function post( context, next ) {
 	context.primary = (
 		<StatsPageLoader>
 			<AsyncLoad
+				key="stats-post-detail"
 				require={ () =>
 					import(
 						/* webpackChunkName: "async-load-calypso-my-sites-stats-stats-post-detail" */ './stats-post-detail'
@@ -389,6 +393,7 @@ export function follows( context, next ) {
 	context.primary = (
 		<StatsPageLoader>
 			<AsyncLoad
+				key="stats-comment-follows"
 				require={ () =>
 					import(
 						/* webpackChunkName: "async-load-calypso-my-sites-stats-comment-follows" */ './comment-follows'
@@ -439,6 +444,7 @@ export function wordAds( context, next ) {
 
 	context.primary = (
 		<AsyncLoad
+			key="stats-wordads"
 			require={ () =>
 				import( /* webpackChunkName: "async-load-calypso-my-sites-stats-wordads" */ './wordads' )
 			}

--- a/client/my-sites/stats/pages/insights/controller.tsx
+++ b/client/my-sites/stats/pages/insights/controller.tsx
@@ -10,6 +10,7 @@ setTimeout(
 function insights( context: Context, next: () => void ) {
 	context.primary = (
 		<AsyncLoad
+			key="stats-pagesinsights"
 			require={ () =>
 				import( /* webpackChunkName: "async-load-calypso-my-sites-stats-pages-insights" */ '.' )
 			}

--- a/client/my-sites/stats/pages/purchase/controller.tsx
+++ b/client/my-sites/stats/pages/purchase/controller.tsx
@@ -7,6 +7,7 @@ function purchase( context: Context, next: () => void ) {
 		// DO NOT WRAP WITH <StatsPageLoader />
 		// Or the site-less purchase flow will not work because there is no permission to access Stats.
 		<AsyncLoad
+			key="stats-pages-purchase"
 			require={ () =>
 				import( /* webpackChunkName: "async-load-calypso-my-sites-stats-pages-purchase" */ '.' )
 			}

--- a/client/my-sites/stats/pages/realtime/controller.tsx
+++ b/client/my-sites/stats/pages/realtime/controller.tsx
@@ -10,6 +10,7 @@ setTimeout(
 function realtime( context: Context, next: () => void ) {
 	context.primary = (
 		<AsyncLoad
+			key="stats-pages-realtime"
 			require={ () =>
 				import( /* webpackChunkName: "async-load-calypso-my-sites-stats-pages-realtime" */ '.' )
 			}

--- a/client/my-sites/stats/pages/subscribers/controller.tsx
+++ b/client/my-sites/stats/pages/subscribers/controller.tsx
@@ -26,6 +26,7 @@ function subscribers( context: Context, next: () => void ) {
 
 	context.primary = (
 		<AsyncLoad
+			key="stats-pages-subscribers"
 			require={ () =>
 				import( /* webpackChunkName: "async-load-calypso-my-sites-stats-pages-subscribers" */ '.' )
 			}

--- a/client/my-sites/store/app/store-stats/controller.js
+++ b/client/my-sites/store/app/store-stats/controller.js
@@ -73,6 +73,7 @@ export default function StatsController( context, next ) {
 		case 'orders':
 			asyncComponent = (
 				<AsyncLoad
+					key="store-app-store-stats"
 					placeholder={ placeholder }
 					require={ () =>
 						import(
@@ -86,6 +87,7 @@ export default function StatsController( context, next ) {
 		default:
 			asyncComponent = (
 				<AsyncLoad
+					key="store-app-store-stats-listview"
 					placeholder={ placeholder }
 					require={ () =>
 						import(

--- a/client/reader/atmosphere/controller.tsx
+++ b/client/reader/atmosphere/controller.tsx
@@ -17,6 +17,7 @@ export const atmosphereLanding = ( context: Context, next: () => void ) => {
 	}
 	context.primary = (
 		<AsyncLoad
+			key="reader-atmosphere-landing"
 			require={ () =>
 				import(
 					/* webpackChunkName: "async-load-calypso-reader-atmosphere-landing-view" */ 'calypso/reader/atmosphere/atmosphere-landing-view'
@@ -34,6 +35,7 @@ export const atmosphereConnect = ( context: Context, next: () => void ) => {
 	}
 	context.primary = (
 		<AsyncLoad
+			key="reader-atmosphere-connect"
 			require={ () =>
 				/* webpackChunkName: "async-load-calypso-reader-atmosphere-connect-view" */ import(
 					'calypso/reader/atmosphere/atmosphere-connect-view'
@@ -65,6 +67,7 @@ export const atmosphereAccount = ( context: Context, next: () => void ) => {
 	const tab = String( context.params.tab ?? '' );
 	context.primary = (
 		<AsyncLoad
+			key="reader-atmosphere-account"
 			require={ () =>
 				import(
 					/* webpackChunkName: "async-load-calypso-reader-atmosphere-account-view" */ 'calypso/reader/atmosphere/atmosphere-account-view'

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -38,6 +38,7 @@ export function sidebar( context, next ) {
 	if ( isUserLoggedIn( state ) ) {
 		context.secondary = (
 			<AsyncLoad
+				key="reader-sidebar"
 				require={ () =>
 					import(
 						/* webpackChunkName: "async-load-calypso-reader-sidebar" */ 'calypso/reader/sidebar'
@@ -109,6 +110,7 @@ export function loadNewSubscriptionPage( context, next ) {
 	const selectedTab = getCurrentTabFromURL( context.path, 'reader/new', 'add-new' );
 	context.primary = (
 		<AsyncLoad
+			key="reader-new-subscription"
 			require={ () =>
 				import(
 					/* webpackChunkName: "async-load-calypso-reader-new-subscription" */ 'calypso/reader/new-subscription'
@@ -174,6 +176,7 @@ export const setBeforePrimary = ( context, next ) => {
 	const isMSDEnabledForReader = isReaderMSDEnabled( state );
 	context.beforePrimary = isMSDEnabledForReader ? (
 		<AsyncLoad
+			key="reader-mobile-header"
 			require={ () =>
 				import(
 					/* webpackChunkName: "async-load-calypso-reader-components-mobile-header" */ 'calypso/reader/components/mobile-header'
@@ -279,7 +282,7 @@ export function readA8C( context, next ) {
 					/* webpackChunkName: "async-load-calypso-reader-a8c-main" */ 'calypso/reader/a8c/main'
 				)
 			}
-			key="read-a8c"
+			key="reader-a8c"
 			className="is-a8c"
 			listName="Automattic"
 			streamKey={ streamKey }
@@ -318,7 +321,7 @@ export function readFollowingP2( context, next ) {
 					/* webpackChunkName: "async-load-calypso-reader-p2-main" */ 'calypso/reader/p2/main'
 				)
 			}
-			key="read-p2"
+			key="reader-p2"
 			listName="P2"
 			streamKey={ streamKey }
 			startDate={ startDate }
@@ -371,6 +374,7 @@ export async function siteSubscriptionsManager( context, next ) {
 
 	context.primary = (
 		<AsyncLoad
+			key="reader-site-subscriptions-manager"
 			require={ () =>
 				import(
 					/* webpackChunkName: "async-load-calypso-reader-site-subscriptions-manager" */ 'calypso/reader/site-subscriptions-manager'
@@ -400,6 +404,7 @@ export async function siteSubscription( context, next ) {
 
 	context.primary = (
 		<AsyncLoad
+			key="reader-site-subscription"
 			require={ () =>
 				import(
 					/* webpackChunkName: "async-load-calypso-reader-site-subscription" */ 'calypso/reader/site-subscription'
@@ -421,6 +426,7 @@ export async function commentSubscriptionsManager( context, next ) {
 
 	context.primary = (
 		<AsyncLoad
+			key="reader-comment-subscriptions-manager"
 			require={ () =>
 				import(
 					/* webpackChunkName: "async-load-calypso-reader-site-subscriptions-manager-comment-subscriptions-manager" */ 'calypso/reader/site-subscriptions-manager/comment-subscriptions-manager'
@@ -439,6 +445,7 @@ export async function pendingSubscriptionsManager( context, next ) {
 
 	context.primary = (
 		<AsyncLoad
+			key="reader-pending-subscriptions-manager"
 			require={ () =>
 				import(
 					/* webpackChunkName: "async-load-calypso-reader-site-subscriptions-manager-pending-subscriptions-manager" */ 'calypso/reader/site-subscriptions-manager/pending-subscriptions-manager'

--- a/client/reader/conversations/controller.js
+++ b/client/reader/conversations/controller.js
@@ -33,7 +33,7 @@ export function conversations( context, next ) {
 					/* webpackChunkName: "async-load-calypso-reader-conversations-stream" */ 'calypso/reader/conversations/stream'
 				)
 			}
-			key="conversations"
+			key="reader-conversations"
 			streamKey={ streamKey }
 			trackScrollPage={ scrollTracker }
 		/>
@@ -71,7 +71,7 @@ export function conversationsA8c( context, next ) {
 					/* webpackChunkName: "async-load-calypso-reader-conversations-stream" */ 'calypso/reader/conversations/stream'
 				)
 			}
-			key="conversations"
+			key="reader-conversations-a8c"
 			title="Conversations @ Automattic"
 			streamKey={ streamKey }
 			store={ { id: streamKey } }

--- a/client/reader/full-post/controller.js
+++ b/client/reader/full-post/controller.js
@@ -27,6 +27,7 @@ export function blogPost( context, next ) {
 
 	context.primary = (
 		<AsyncLoad
+			key="reader-blog-post"
 			require={ () =>
 				import(
 					/* webpackChunkName: "async-load-calypso-blocks-reader-full-post" */ 'calypso/blocks/reader-full-post'
@@ -41,6 +42,7 @@ export function blogPost( context, next ) {
 	if ( isUserLoggedIn( state ) ) {
 		context.secondary = (
 			<AsyncLoad
+				key="reader-sidebar"
 				require={ () =>
 					import(
 						/* webpackChunkName: "async-load-calypso-reader-sidebar" */ 'calypso/reader/sidebar'
@@ -66,6 +68,7 @@ export function feedPost( context, next ) {
 
 	context.primary = (
 		<AsyncLoad
+			key="reader-feed-post"
 			require={ () =>
 				import(
 					/* webpackChunkName: "async-load-calypso-blocks-reader-full-post" */ 'calypso/blocks/reader-full-post'
@@ -79,6 +82,7 @@ export function feedPost( context, next ) {
 	if ( isUserLoggedIn( state ) ) {
 		context.secondary = (
 			<AsyncLoad
+				key="reader-sidebar"
 				require={ () =>
 					import(
 						/* webpackChunkName: "async-load-calypso-reader-sidebar" */ 'calypso/reader/sidebar'

--- a/client/reader/list/controller.js
+++ b/client/reader/list/controller.js
@@ -24,7 +24,7 @@ export const createList = ( context, next ) => {
 					/* webpackChunkName: "async-load-calypso-reader-list-manage" */ 'calypso/reader/list-manage'
 				)
 			}
-			key="list-manage"
+			key="reader-list-create"
 			isCreateForm
 		/>
 	);
@@ -92,7 +92,7 @@ export const editList = ( context, next ) => {
 					/* webpackChunkName: "async-load-calypso-reader-list-manage" */ 'calypso/reader/list-manage'
 				)
 			}
-			key="list-manage"
+			key="reader-list-edit"
 			owner={ encodeURIComponent( context.params.user ) }
 			slug={ encodeURIComponent( context.params.list ) }
 			selectedSection="details"
@@ -119,7 +119,7 @@ export const editListItems = ( context, next ) => {
 					/* webpackChunkName: "async-load-calypso-reader-list-manage" */ 'calypso/reader/list-manage'
 				)
 			}
-			key="list-manage"
+			key="reader-list-edit-list-items"
 			owner={ encodeURIComponent( context.params.user ) }
 			slug={ encodeURIComponent( context.params.list ) }
 			selectedSection="items"
@@ -146,7 +146,7 @@ export const exportList = ( context, next ) => {
 					/* webpackChunkName: "async-load-calypso-reader-list-manage" */ 'calypso/reader/list-manage'
 				)
 			}
-			key="list-manage"
+			key="reader-list-export"
 			owner={ encodeURIComponent( context.params.user ) }
 			slug={ encodeURIComponent( context.params.list ) }
 			selectedSection="export"
@@ -173,7 +173,7 @@ export const deleteList = ( context, next ) => {
 					/* webpackChunkName: "async-load-calypso-reader-list-manage" */ 'calypso/reader/list-manage'
 				)
 			}
-			key="list-manage"
+			key="reader-list-delete"
 			owner={ encodeURIComponent( context.params.user ) }
 			slug={ encodeURIComponent( context.params.list ) }
 			selectedSection="delete"

--- a/client/reader/mastodon/controller.tsx
+++ b/client/reader/mastodon/controller.tsx
@@ -17,6 +17,7 @@ export const mastodonLanding = ( context: Context, next: () => void ) => {
 	}
 	context.primary = (
 		<AsyncLoad
+			key="reader-mastodon-landing"
 			require={ () =>
 				import(
 					/* webpackChunkName: "async-load-calypso-reader-mastodon-landing-view" */ 'calypso/reader/mastodon/mastodon-landing-view'
@@ -34,6 +35,7 @@ export const mastodonConnect = ( context: Context, next: () => void ) => {
 	}
 	context.primary = (
 		<AsyncLoad
+			key="reader-mastodon-connect"
 			require={ () => import( 'calypso/reader/mastodon/mastodon-connect-view' ) }
 			placeholder={ null }
 		/>
@@ -48,6 +50,7 @@ export const mastodonOauthCallback = ( context: Context, next: () => void ) => {
 	const query = context.query as { state?: string; code?: string; error?: string };
 	context.primary = (
 		<AsyncLoad
+			key="reader-mastodon-oauth-callback"
 			require={ () => import( 'calypso/reader/mastodon/mastodon-oauth-callback-view' ) }
 			placeholder={ null }
 			query={ query }
@@ -76,6 +79,7 @@ export const mastodonAccount = ( context: Context, next: () => void ) => {
 	const tab = String( context.params.tab ?? '' );
 	context.primary = (
 		<AsyncLoad
+			key="reader-mastodon-account"
 			require={ () =>
 				import(
 					/* webpackChunkName: "async-load-calypso-reader-mastodon-account-view" */ 'calypso/reader/mastodon/mastodon-account-view'

--- a/client/reader/notifications/controller.jsx
+++ b/client/reader/notifications/controller.jsx
@@ -49,6 +49,7 @@ export function notifications( context, next ) {
 			<NotificationTitle />
 			<div className="reader-notifications__panel">
 				<AsyncLoad
+					key="reader-notifications"
 					require={ () =>
 						import(
 							/* webpackChunkName: "async-load-calypso-notifications" */ 'calypso/notifications'

--- a/client/reader/on-this-day/controller.jsx
+++ b/client/reader/on-this-day/controller.jsx
@@ -25,6 +25,7 @@ export function onThisDay( context, next ) {
 
 	context.primary = (
 		<AsyncLoad
+			key="reader-on-this-day"
 			require={ () =>
 				import(
 					/* webpackChunkName: "async-load-calypso-reader-on-this-day-main" */ 'calypso/reader/on-this-day/main'


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/Automattic/wp-calypso/pull/110042 where `<AsyncLoad>` instances don't update their inner component when the `require` callback changes meaningfully.

The `require` callback is saved on initial mount and further updates are ignored. But in some cases, especially when `<AsyncLoad>` is rendered at top of a router handler, this can break navigations.
