### PR TITLE
A4A: Add Amplify in-product landing page (initial setup)

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/amplify.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/amplify.tsx
@@ -1,0 +1,31 @@
+import page from '@automattic/calypso-router';
+import { chevronLeft } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import Sidebar from '../sidebar';
+import useAmplifyMenuItems from './hooks/use-amplify-menu-items';
+import { A4A_AMPLIFY_LINK, A4A_OVERVIEW_LINK } from './lib/constants';
+
+type Props = {
+	path: string;
+};
+
+export default function AmplifySidebar( { path }: Props ) {
+	const translate = useTranslate();
+	const menuItems = useAmplifyMenuItems( path );
+
+	return (
+		<Sidebar
+			path={ A4A_AMPLIFY_LINK }
+			title={ translate( 'Amplify' ) }
+			backButtonProps={ {
+				label: translate( 'Back to overview' ),
+				icon: chevronLeft,
+				onClick: () => {
+					page( A4A_OVERVIEW_LINK );
+				},
+			} }
+			menuItems={ menuItems }
+			withUserProfileFooter
+		/>
+	);
+}

--- a/client/a8c-for-agencies/components/sidebar-menu/amplify.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/amplify.tsx
@@ -1,4 +1,5 @@
 import page from '@automattic/calypso-router';
+import { Badge } from '@automattic/components';
 import { chevronLeft } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import Sidebar from '../sidebar';
@@ -16,7 +17,12 @@ export default function AmplifySidebar( { path }: Props ) {
 	return (
 		<Sidebar
 			path={ A4A_AMPLIFY_LINK }
-			title={ translate( 'Amplify' ) }
+			title={
+				<div className="sidebar-menu-item__title-with-badge">
+					<span>{ translate( 'Amplify' ) }</span>
+					<Badge type="info">{ translate( 'Alpha' ) }</Badge>
+				</div>
+			}
 			backButtonProps={ {
 				label: translate( 'Back to overview' ),
 				icon: chevronLeft,

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-amplify-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-amplify-menu-items.tsx
@@ -1,0 +1,45 @@
+import { home, chartBar } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import { A4A_AMPLIFY_LINK, A4A_AMPLIFY_REPORTS_LINK } from '../lib/constants';
+import { createItem } from '../lib/utils';
+
+const useAmplifyMenuItems = ( path: string ) => {
+	const translate = useTranslate();
+	const menuItems = useMemo( () => {
+		return [
+			createItem(
+				{
+					icon: home,
+					path: A4A_AMPLIFY_LINK,
+					link: A4A_AMPLIFY_LINK,
+					title: translate( 'Overview' ),
+					trackEventProps: {
+						menu_item: 'Automattic for Agencies / Amplify / Overview',
+					},
+				},
+				path
+			),
+			createItem(
+				{
+					icon: chartBar,
+					path: A4A_AMPLIFY_LINK,
+					link: A4A_AMPLIFY_REPORTS_LINK,
+					title: translate( 'Reports' ),
+					trackEventProps: {
+						menu_item: 'Automattic for Agencies / Amplify / Reports',
+					},
+				},
+				path
+			),
+		]
+			.map( ( item ) => createItem( item, path ) )
+			.map( ( item ) => ( {
+				...item,
+				isSelected: item.link === path,
+			} ) );
+	}, [ path, translate ] );
+	return menuItems;
+};
+
+export default useAmplifyMenuItems;

--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -57,6 +57,7 @@ export const A4A_WOOPAYMENTS_SITE_SETUP_LINK = `${ A4A_WOOPAYMENTS_LINK }/site-s
 export const A4A_WOOPAYMENTS_OVERVIEW_LINK = `${ A4A_WOOPAYMENTS_LINK }/overview`;
 export const A4A_EXCLUSIVE_OFFERS_LINK = '/exclusive-offers';
 export const A4A_AMPLIFY_LINK = '/amplify';
+export const A4A_AMPLIFY_REPORTS_LINK = `${ A4A_AMPLIFY_LINK }/reports`;
 export const A4A_RESOURCES_LINK = '/resources-and-tools';
 export const A4A_LEARN_LINK = `${ A4A_RESOURCES_LINK }/learn`;
 export const A4A_DEV_TOOLS_LINK = `${ A4A_RESOURCES_LINK }/dev-tools`;

--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -56,6 +56,7 @@ export const A4A_WOOPAYMENTS_PAYMENT_SETTINGS_LINK = `${ A4A_WOOPAYMENTS_LINK }/
 export const A4A_WOOPAYMENTS_SITE_SETUP_LINK = `${ A4A_WOOPAYMENTS_LINK }/site-setup`;
 export const A4A_WOOPAYMENTS_OVERVIEW_LINK = `${ A4A_WOOPAYMENTS_LINK }/overview`;
 export const A4A_EXCLUSIVE_OFFERS_LINK = '/exclusive-offers';
+export const A4A_AMPLIFY_LINK = '/amplify';
 export const A4A_RESOURCES_LINK = '/resources-and-tools';
 export const A4A_LEARN_LINK = `${ A4A_RESOURCES_LINK }/learn`;
 export const A4A_DEV_TOOLS_LINK = `${ A4A_RESOURCES_LINK }/dev-tools`;

--- a/client/a8c-for-agencies/lib/permission.ts
+++ b/client/a8c-for-agencies/lib/permission.ts
@@ -58,6 +58,7 @@ import {
 	A4A_RESOURCES_LINK,
 	A4A_DEV_TOOLS_LINK,
 	A4A_EXCLUSIVE_OFFERS_LINK,
+	A4A_AMPLIFY_LINK,
 } from '../components/sidebar-menu/lib/constants';
 import type { Agency } from 'calypso/state/a8c-for-agencies/types';
 
@@ -146,7 +147,11 @@ export const isPathAllowed = ( pathname: string, agency: Agency | null ) => {
 	}
 
 	// Everyone can access the landing page and the overview page
-	if ( [ A4A_LANDING_LINK, A4A_OVERVIEW_LINK, A4A_FEEDBACK_LINK ].includes( pathname ) ) {
+	if (
+		[ A4A_LANDING_LINK, A4A_OVERVIEW_LINK, A4A_FEEDBACK_LINK, A4A_AMPLIFY_LINK ].includes(
+			pathname
+		)
+	) {
 		return true;
 	}
 

--- a/client/a8c-for-agencies/lib/permission.ts
+++ b/client/a8c-for-agencies/lib/permission.ts
@@ -59,6 +59,7 @@ import {
 	A4A_DEV_TOOLS_LINK,
 	A4A_EXCLUSIVE_OFFERS_LINK,
 	A4A_AMPLIFY_LINK,
+	A4A_AMPLIFY_REPORTS_LINK,
 } from '../components/sidebar-menu/lib/constants';
 import type { Agency } from 'calypso/state/a8c-for-agencies/types';
 
@@ -148,9 +149,13 @@ export const isPathAllowed = ( pathname: string, agency: Agency | null ) => {
 
 	// Everyone can access the landing page and the overview page
 	if (
-		[ A4A_LANDING_LINK, A4A_OVERVIEW_LINK, A4A_FEEDBACK_LINK, A4A_AMPLIFY_LINK ].includes(
-			pathname
-		)
+		[
+			A4A_LANDING_LINK,
+			A4A_OVERVIEW_LINK,
+			A4A_FEEDBACK_LINK,
+			A4A_AMPLIFY_LINK,
+			A4A_AMPLIFY_REPORTS_LINK,
+		].includes( pathname )
 	) {
 		return true;
 	}

--- a/client/a8c-for-agencies/sections/amplify/amplify-add-site-modal.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-add-site-modal.tsx
@@ -1,0 +1,134 @@
+import { Button } from '@wordpress/components';
+import { filterSortAndPaginate } from '@wordpress/dataviews';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useMemo, useState } from 'react';
+import A4AModal from 'calypso/a8c-for-agencies/components/a4a-modal';
+import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
+import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
+import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
+import { A4A_SITES_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import FormRadio from 'calypso/components/forms/form-radio';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import useConnectedSites from './hooks/use-connected-sites';
+import type { Field } from '@wordpress/dataviews';
+
+type SiteItem = {
+	id: number;
+	url: string;
+};
+
+function AmplifySiteTable( {
+	selectedSite,
+	setSelectedSite,
+}: {
+	selectedSite: SiteItem | null;
+	setSelectedSite: ( site: SiteItem ) => void;
+} ) {
+	const { sites, isLoading } = useConnectedSites();
+
+	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
+		...initialDataViewsState,
+		fields: [ 'site' ],
+	} );
+
+	const items: SiteItem[] = useMemo(
+		() => sites.map( ( s ) => ( { id: s.id, url: s.url } ) ),
+		[ sites ]
+	);
+
+	const fields: Field< SiteItem >[] = useMemo(
+		() => [
+			{
+				id: 'site',
+				label: __( 'Site' ),
+				getValue: ( { item }: { item: SiteItem } ) => item.url,
+				render: ( { item }: { item: SiteItem } ) => (
+					<div>
+						<FormRadio
+							htmlFor={ `amplify-site-${ item.id }` }
+							id={ `amplify-site-${ item.id }` }
+							checked={ selectedSite?.id === item.id }
+							onChange={ () => setSelectedSite( item ) }
+							label={ item.url }
+						/>
+					</div>
+				),
+				enableGlobalSearch: true,
+				enableHiding: false,
+				enableSorting: false,
+			},
+		],
+		[ selectedSite?.id, setSelectedSite ]
+	);
+
+	const { data: paginatedItems, paginationInfo } = useMemo(
+		() => filterSortAndPaginate( items, dataViewsState, fields ),
+		[ items, dataViewsState, fields ]
+	);
+
+	return (
+		<div className="redesigned-a8c-table show-overflow-overlay search-enabled">
+			<ItemsDataViews
+				isLoading={ isLoading }
+				data={ {
+					items: paginatedItems,
+					fields,
+					getItemId: ( item: SiteItem ) => `${ item.id }`,
+					pagination: paginationInfo,
+					enableSearch: true,
+					actions: [],
+					dataViewsState,
+					setDataViewsState,
+					defaultLayouts: { table: {} },
+				} }
+			/>
+		</div>
+	);
+}
+
+type Props = {
+	onClose: () => void;
+	onSiteSelected: ( url: string ) => void;
+};
+
+export default function AmplifyAddSiteModal( { onClose, onSiteSelected }: Props ) {
+	const dispatch = useDispatch();
+	const [ selectedSite, setSelectedSite ] = useState< SiteItem | null >( null );
+
+	const handleAmplify = () => {
+		if ( ! selectedSite ) {
+			return;
+		}
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_amplify_audit_open', {
+				site_url: selectedSite.url,
+			} )
+		);
+		onSiteSelected( selectedSite.url );
+	};
+
+	return (
+		<A4AModal
+			title={ __( 'Which site would you like to amplify?' ) }
+			subtile={ createInterpolateElement(
+				/* translators: "Sites Dashboard" is a link to the connected sites management page. */
+				__(
+					"If you don't see the site in the list, connect it first via the <a>Sites Dashboard</a>."
+				),
+				{
+					a: <a href={ A4A_SITES_LINK } />,
+				}
+			) }
+			onClose={ onClose }
+			extraActions={
+				<Button variant="primary" onClick={ handleAmplify } disabled={ ! selectedSite }>
+					{ __( 'Amplify it' ) }
+				</Button>
+			}
+		>
+			<AmplifySiteTable selectedSite={ selectedSite } setSelectedSite={ setSelectedSite } />
+		</A4AModal>
+	);
+}

--- a/client/a8c-for-agencies/sections/amplify/amplify-add-site-modal.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-add-site-modal.tsx
@@ -31,6 +31,12 @@ function AmplifySiteTable( {
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
 		...initialDataViewsState,
 		fields: [ 'site' ],
+		// Default to compact density so more rows are visible without
+		// scrolling — the modal is a quick site picker, not a browse view,
+		// so vertical density matters more than per-row breathing room.
+		// User can switch back to Comfortable via the settings cog
+		// (Appearance → Density).
+		layout: { density: 'compact' },
 	} );
 
 	const items: SiteItem[] = useMemo(

--- a/client/a8c-for-agencies/sections/amplify/amplify-add-site-modal.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-add-site-modal.tsx
@@ -104,6 +104,7 @@ export default function AmplifyAddSiteModal( { onClose, onSiteSelected }: Props 
 		dispatch(
 			recordTracksEvent( 'calypso_a4a_amplify_audit_open', {
 				site_url: selectedSite.url,
+				entry_point: 'add_site_modal',
 			} )
 		);
 		onSiteSelected( selectedSite.url );

--- a/client/a8c-for-agencies/sections/amplify/amplify-ai-section.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-ai-section.tsx
@@ -1,0 +1,269 @@
+import { __ } from '@wordpress/i18n';
+
+type Criterion = {
+	id: string;
+	num: string;
+	title: string;
+	points: number;
+	summary: string;
+	why: string;
+	signals: string[];
+	stats: string[];
+};
+
+const CRITERIA: Criterion[] = [
+	{
+		id: 'technical-health',
+		num: '01',
+		title: __( 'Technical Health' ),
+		points: 20,
+		summary: __(
+			'Can AI tools access, crawl, and render the site? If a crawler cannot reach the content, nothing else matters.'
+		),
+		why: __(
+			'Crawlability is the prerequisite for every other AI signal. A site that blocks AI bots — often by accident — is completely invisible to AI-generated answers, regardless of how good the content is.'
+		),
+		signals: [
+			__( 'robots.txt — not blocking GPTBot, ClaudeBot, or anthropic-ai' ),
+			__( 'noindex — homepage not accidentally flagged to prevent indexing' ),
+			__( 'HTTPS — SSL active with no mixed content warnings' ),
+			__( 'Sitemap — present, linked in robots.txt, with valid lastmod dates' ),
+			__( 'JavaScript dependency — critical content readable in raw HTML' ),
+		],
+		stats: [
+			__(
+				'Sites that block GPTBot, ClaudeBot, or anthropic-ai are invisible to AI-generated answers'
+			),
+			__(
+				'A misconfigured robots.txt can silently block all AI crawlers from ever reaching the content'
+			),
+			__( 'Pages rendered entirely in JavaScript are not reliably indexed by most AI crawlers' ),
+		],
+	},
+	{
+		id: 'structured-data',
+		num: '02',
+		title: __( 'Structured Data' ),
+		points: 18,
+		summary: __(
+			'Schema markup tells AI tools exactly what the site is about rather than making them infer it. The difference between an AI accurately describing your client and producing a generic summary.'
+		),
+		why: __(
+			'Without structured data, AI tools guess. With it, they get an unambiguous, machine-readable record of the business, its services, and its social proof — and cite it with confidence.'
+		),
+		signals: [
+			__( 'Organization schema — name, URL, logo, description, sameAs social profiles' ),
+			__( 'Open Graph and Twitter Card meta — og:title, og:description, og:image' ),
+			__( 'Service schema — individual services in structured markup' ),
+			__( 'FAQ schema — Q&A content marked for direct AI extraction' ),
+			__( 'Review / AggregateRating schema — testimonials readable by crawlers' ),
+		],
+		stats: [
+			__( 'Sites with structured data get 20 to 30% more clicks in search results' ),
+			__( 'FAQ schema can take up to 50% more space in search results, increasing visibility' ),
+			__( "JSON-LD is Google's preferred structured data format" ),
+		],
+	},
+	{
+		id: 'aeo-readiness',
+		num: '03',
+		title: __( 'AEO Readiness' ),
+		points: 16,
+		summary: __(
+			'Answer Engine Optimization. Is the content structured to surface in AI-generated answers? AI tools prioritize pages that answer questions directly, not pages that bury key information.'
+		),
+		why: __(
+			'AI tools pull sentences from web pages to construct answers for users. Content buried in long paragraphs rarely gets cited. Clear, direct answers structured for extraction are far more likely to appear when someone asks an AI to recommend a business like your client.'
+		),
+		signals: [
+			__( 'FAQ section — clear question-and-answer pairs on or linked from the homepage' ),
+			__( 'Direct answers — first sentence after each heading answers the implied question' ),
+			__( 'Who / what / who content — who they are, what they do, who they serve' ),
+			__( 'Featured snippet structure — key facts as clean, extractable sentences' ),
+			__( 'FAQ schema applied — machine-readable Q&A markup' ),
+			__( 'Question-framed headings — H2s and H3s phrased as questions' ),
+		],
+		stats: [
+			__(
+				'ChatGPT reached 100 million users in 2 months — the fastest-growing consumer app in history'
+			),
+			__(
+				'AI-generated answers from ChatGPT, Perplexity, and Google AI Overviews are now the first result many users see'
+			),
+		],
+	},
+	{
+		id: 'eeat-signals',
+		num: '04',
+		title: __( 'E-E-A-T Signals' ),
+		points: 14,
+		summary: __(
+			"Experience, Expertise, Authoritativeness, Trustworthiness. Google's quality framework and the backbone of how AI tools evaluate whether a source is worth citing."
+		),
+		why: __(
+			'Claiming expertise is easy. Demonstrating it through specific case outcomes, named clients, certifications, and press coverage is what AI tools treat as credible evidence — and what prospective clients find convincing.'
+		),
+		signals: [
+			__( 'Named team members with roles — not just "our team"' ),
+			__(
+				'Author credentials — bios citing specific experience, named clients, or certifications'
+			),
+			__( 'Demonstrated expertise — specifics, not claims' ),
+			__( 'External citations or press — publications, podcasts, named award bodies' ),
+			__( 'Industry certifications — Google Partner, WooCommerce Expert, and similar' ),
+			__( 'Years in business stated — founding year or years of experience' ),
+			__( 'About / Team page linked from homepage' ),
+		],
+		stats: [
+			__( "E-E-A-T is a core framework in Google's Search Quality Evaluator Guidelines" ),
+			__(
+				'Google added the first "E" for Experience in December 2022 — recognizing first-hand knowledge as distinct from expertise'
+			),
+		],
+	},
+	{
+		id: 'content-freshness',
+		num: '05',
+		title: __( 'Content Freshness' ),
+		points: 12,
+		summary: __(
+			'Is the content up to date? AI tools and search engines both treat stale content as a signal of lower reliability.'
+		),
+		why: __(
+			'AI tools weight recency when deciding what to cite. A case study from 2019 and a blog post last updated three years ago signal that the business may no longer be active, current, or worth recommending.'
+		),
+		signals: [
+			__( 'Recent blog or content updates — within the last 12 months' ),
+			__( 'Case studies with recent dates' ),
+			__( 'Dated content — publication or modification dates visible to crawlers' ),
+			__( 'sitemap lastmod accuracy — dates reflect actual content changes' ),
+			__( 'No outdated references — technology, pricing, team members' ),
+		],
+		stats: [
+			__( 'AI tools weight content recency when selecting sources for generated answers' ),
+			__(
+				'Accurate lastmod dates in sitemaps tell crawlers which content has changed and is worth re-indexing'
+			),
+		],
+	},
+	{
+		id: 'entity-clarity',
+		num: '06',
+		title: __( 'Entity Clarity' ),
+		points: 10,
+		summary: __(
+			'Does the site make it unambiguous who this business is? AI knowledge graphs depend on clear, consistent entity signals across the web.'
+		),
+		why: __(
+			'If AI tools cannot confidently identify who this business is — its name, location, category, and online presence — they will not recommend it. Entity clarity is what gets a business included in AI knowledge graphs.'
+		),
+		signals: [
+			__( 'Business name consistent across homepage, schema, and social profiles' ),
+			__( 'Physical location or service area stated' ),
+			__( 'Business category clear from homepage copy' ),
+			__( 'Social profiles linked from the site (sameAs in schema)' ),
+			__( 'NAP consistency — Name, Address, Phone matching across the web' ),
+		],
+		stats: [
+			__(
+				'Inconsistent business information across the web confuses AI knowledge graphs and reduces citation likelihood'
+			),
+		],
+	},
+	{
+		id: 'content-specificity',
+		num: '07',
+		title: __( 'Content Specificity' ),
+		points: 7,
+		summary: __(
+			'Does the content say something specific, or could it describe any business in the same category? Generic content is the most common reason AI tools skip a site when generating recommendations.'
+		),
+		why: __(
+			'AI tools cite sources that say something distinct and verifiable. Generic descriptions — "we provide excellent service" — carry no information an AI can act on. Specific claims — "we built 47 WooCommerce stores for DTC brands last year" — do.'
+		),
+		signals: [
+			__( 'Specific service descriptions — named deliverables, not generic categories' ),
+			__( 'Named client types or industries' ),
+			__( 'Quantified outcomes in case studies' ),
+			__( 'Process or methodology described specifically' ),
+			__( 'Low buzzword density across page copy' ),
+		],
+		stats: [
+			__(
+				'Generic descriptions are the most common reason AI tools skip a source when generating recommendations'
+			),
+		],
+	},
+	{
+		id: 'llms-txt',
+		num: '08',
+		title: 'llms.txt',
+		points: 3,
+		summary: __(
+			'An emerging standard that lets businesses publish a machine-readable summary of their site specifically for large language models.'
+		),
+		why: __(
+			'llms.txt is to AI tools what robots.txt was to search engines — a direct, structured way to tell them what the site is about and what it wants them to know. Still early, but adoption is growing fast.'
+		),
+		signals: [
+			__( 'llms.txt file present at /llms.txt' ),
+			__( 'File content includes business name, description, services, and key URLs' ),
+			__( 'llms-full.txt optionally present for extended AI context' ),
+		],
+		stats: [
+			__(
+				'llms.txt is an emerging standard giving AI tools a structured, curated summary of site content'
+			),
+			__( 'Adoption is growing as AI search becomes a primary discovery channel for businesses' ),
+		],
+	},
+];
+
+export default function AmplifyAiSection() {
+	return (
+		<div className="amplify-criteria-section is-ai">
+			<div className="amplify-criteria-section-header">
+				<p className="amplify-criteria-eyebrow">{ __( 'AI analysis' ) }</p>
+				<h2 className="amplify-criteria-title">{ __( 'Get found when buyers use AI' ) }</h2>
+				<p className="amplify-criteria-intro">
+					{ __(
+						"ChatGPT reached 100 million users in two months. Perplexity now fields tens of millions of searches a day. Google AI Overviews appear above organic results for hundreds of millions of queries. When your clients' customers search for products or services using AI, your clients' sites need to be readable, structured, and citable. Most aren't, and most agencies haven't checked."
+					) }
+				</p>
+
+				{ /* ── 3 HERO STATS ── */ }
+				<div className="amplify-criteria-stats">
+					<div className="amplify-criteria-stat">
+						<span className="amplify-criteria-stat-num">100M</span>
+						<span className="amplify-criteria-stat-label">
+							{ __( 'ChatGPT users in just 2 months' ) }
+						</span>
+					</div>
+					<div className="amplify-criteria-stat">
+						<span className="amplify-criteria-stat-num">20–30%</span>
+						<span className="amplify-criteria-stat-label">
+							{ __( 'More clicks with structured data' ) }
+						</span>
+					</div>
+					<div className="amplify-criteria-stat">
+						<span className="amplify-criteria-stat-num">0</span>
+						<span className="amplify-criteria-stat-label">
+							{ __( 'Visibility for sites that block AI crawlers' ) }
+						</span>
+					</div>
+				</div>
+			</div>
+
+			{ /* ── CRITERIA CARDS ── */ }
+			<div className="amplify-criteria-cards">
+				{ CRITERIA.map( ( c ) => (
+					<div key={ c.id } className="amplify-criteria-card">
+						<span className="amplify-criteria-card-num">{ c.num }</span>
+						<h3 className="amplify-criteria-card-title">{ c.title }</h3>
+						<p className="amplify-criteria-card-summary">{ c.summary }</p>
+					</div>
+				) ) }
+			</div>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/amplify/amplify-ai-section.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-ai-section.tsx
@@ -224,7 +224,11 @@ export default function AmplifyAiSection() {
 		<div className="amplify-criteria-section is-ai">
 			<div className="amplify-criteria-section-header">
 				<p className="amplify-criteria-eyebrow">{ __( 'AI analysis' ) }</p>
-				<h2 className="amplify-criteria-title">{ __( 'Get found when buyers use AI' ) }</h2>
+				<h2 className="amplify-criteria-title">
+					{ __( "Your clients' next customers are searching with AI." ) }
+					<br />
+					{ __( 'Ensure they can be found.' ) }
+				</h2>
 				<p className="amplify-criteria-intro">
 					{ __(
 						"ChatGPT reached 100 million users in two months. Perplexity now fields tens of millions of searches a day. Google AI Overviews appear above organic results for hundreds of millions of queries. When your clients' customers search for products or services using AI, your clients' sites need to be readable, structured, and citable. Most aren't, and most agencies haven't checked."

--- a/client/a8c-for-agencies/sections/amplify/amplify-ai-workflow.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-ai-workflow.tsx
@@ -30,38 +30,39 @@ function PromptItem( { label, severity, body }: Prompt ) {
 	);
 }
 
-export default function AmplifyAiWorkflow() {
-	const prompts: Prompt[] = [
-		{
-			label: __( 'Service clarity' ),
-			severity: 'danger',
-			body: __(
-				'Rewrite the services section of this WordPress page to clearly articulate the specific outcomes each service delivers. Replace generic descriptions with client-focused language that answers “what will this do for my business?”'
-			),
-		},
-		{
-			label: __( 'Trust signals' ),
-			severity: 'danger',
-			body: __(
-				'Add a testimonials block above the fold on the homepage using the Jetpack Reviews block. Pull from existing client testimonials and prioritise quotes that reference measurable outcomes or specific project types.'
-			),
-		},
-		{
-			label: __( 'CTA optimization' ),
-			severity: 'warn',
-			body: __(
-				'Update the primary hero button text from “Learn more” to a specific, action-oriented phrase that communicates value. Suggested: “See how we work” or “Start your project.” Ensure it links to the contact or work page.'
-			),
-		},
-		{
-			label: __( 'Visual hierarchy' ),
-			severity: 'warn',
-			body: __(
-				'Audit the heading structure across the homepage. Ensure there is a single H1, that H2s clearly segment each section, and that no decorative text is marked as a heading element. Fix any heading tags used purely for styling.'
-			),
-		},
-	];
+// Hoisted to module scope — static data, no reason to reallocate on every render.
+const PROMPTS: Prompt[] = [
+	{
+		label: __( 'Service clarity' ),
+		severity: 'danger',
+		body: __(
+			'Rewrite the services section of this WordPress page to clearly articulate the specific outcomes each service delivers. Replace generic descriptions with client-focused language that answers “what will this do for my business?”'
+		),
+	},
+	{
+		label: __( 'Trust signals' ),
+		severity: 'danger',
+		body: __(
+			'Add a testimonials block above the fold on the homepage using the Jetpack Reviews block. Pull from existing client testimonials and prioritise quotes that reference measurable outcomes or specific project types.'
+		),
+	},
+	{
+		label: __( 'CTA optimization' ),
+		severity: 'warn',
+		body: __(
+			'Update the primary hero button text from “Learn more” to a specific, action-oriented phrase that communicates value. Suggested: “See how we work” or “Start your project.” Ensure it links to the contact or work page.'
+		),
+	},
+	{
+		label: __( 'Visual hierarchy' ),
+		severity: 'warn',
+		body: __(
+			'Audit the heading structure across the homepage. Ensure there is a single H1, that H2s clearly segment each section, and that no decorative text is marked as a heading element. Fix any heading tags used purely for styling.'
+		),
+	},
+];
 
+export default function AmplifyAiWorkflow() {
 	return (
 		<div className="amplify-landing-workflow">
 			<div className="amplify-landing-workflow-top">
@@ -92,7 +93,7 @@ export default function AmplifyAiWorkflow() {
 						<span className="amplify-landing-workflow-card-count">{ __( '4 issues found' ) }</span>
 					</div>
 					<div className="amplify-landing-workflow-prompt-items">
-						{ prompts.map( ( prompt ) => (
+						{ PROMPTS.map( ( prompt ) => (
 							<PromptItem key={ prompt.label } { ...prompt } />
 						) ) }
 					</div>

--- a/client/a8c-for-agencies/sections/amplify/amplify-ai-workflow.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-ai-workflow.tsx
@@ -1,6 +1,13 @@
+import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
+import { useState } from 'react';
+import PageSectionColumns from 'calypso/a8c-for-agencies/components/page-section-columns';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+type Mode = 'human' | 'ai';
 
 type Severity = 'good' | 'warn' | 'danger';
 
@@ -10,10 +17,15 @@ type Prompt = {
 	body: string;
 };
 
+type ModeData = {
+	issueCount: string;
+	prompts: Prompt[];
+};
+
 function PromptItem( { label, severity, body }: Prompt ) {
 	return (
 		<div className="amplify-landing-workflow-prompt-item">
-			<div className="amplify-landing-workflow-prompt-item-header">
+			<div className="amplify-landing-workflow-prompt-item-content">
 				<span className="amplify-landing-workflow-prompt-item-label">
 					<span
 						className={ clsx( 'amplify-landing-workflow-prompt-item-dot', severity ) }
@@ -21,51 +33,119 @@ function PromptItem( { label, severity, body }: Prompt ) {
 					/>
 					{ label }
 				</span>
-				<button type="button" className="amplify-landing-workflow-prompt-copy">
-					{ __( 'Copy' ) }
-				</button>
+				<div className="amplify-landing-workflow-prompt-text">{ body }</div>
 			</div>
-			<div className="amplify-landing-workflow-prompt-text">{ body }</div>
+			<button type="button" className="amplify-landing-workflow-prompt-copy">
+				{ __( 'Copy' ) }
+			</button>
 		</div>
 	);
 }
 
 // Hoisted to module scope — static data, no reason to reallocate on every render.
-const PROMPTS: Prompt[] = [
-	{
-		label: __( 'Service clarity' ),
-		severity: 'danger',
-		body: __(
-			'Rewrite the services section of this WordPress page to clearly articulate the specific outcomes each service delivers. Replace generic descriptions with client-focused language that answers “what will this do for my business?”'
-		),
+// Each prompt corresponds to one of the pins shown in the See-it-in-action demo
+// above (amplify-how-it-works.tsx) so the narrative across the two sections
+// stays consistent: the demo flags the issues, this card shows the prompts
+// that would be generated to fix them. Labels mirror the pin labels (short
+// form) and bodies are succinct, agent-ready instructions referencing the
+// Crestline Studio mock content.
+const MODES: Record< Mode, ModeData > = {
+	human: {
+		issueCount: __( '4 issues found' ),
+		prompts: [
+			{
+				label: __( 'Hero headline' ),
+				severity: 'warn',
+				body: __(
+					'Rewrite the H1 "We build brands that win online" into a value-specific headline that names who Crestline serves and the outcome delivered.'
+				),
+			},
+			{
+				label: __( 'Client logos' ),
+				severity: 'danger',
+				body: __(
+					'Add a client logos section above the fold with a heading that frames the logos as social proof rather than a list of names.'
+				),
+			},
+			{
+				label: __( 'CTA copy' ),
+				severity: 'warn',
+				body: __(
+					'Replace the "Get in touch" hero button with a specific, action-oriented label such as "Book a discovery call" or "Start your project."'
+				),
+			},
+			{
+				label: __( 'Testimonials' ),
+				severity: 'danger',
+				body: __(
+					'Add a testimonials block above the fold using the Jetpack Reviews block. Prioritize quotes with named clients, photos, and measurable outcomes.'
+				),
+			},
+		],
 	},
-	{
-		label: __( 'Trust signals' ),
-		severity: 'danger',
-		body: __(
-			'Add a testimonials block above the fold on the homepage using the Jetpack Reviews block. Pull from existing client testimonials and prioritise quotes that reference measurable outcomes or specific project types.'
-		),
+	ai: {
+		issueCount: __( '4 issues found' ),
+		prompts: [
+			{
+				label: __( 'Organization schema' ),
+				severity: 'danger',
+				body: __(
+					'Generate JSON-LD Organization schema for Crestline Studio with name, URL, logo, sameAs social profiles, and a one-sentence description.'
+				),
+			},
+			{
+				label: __( 'Service detail' ),
+				severity: 'warn',
+				body: __(
+					'Expand each service block with named deliverables, target client types, and one quantified outcome so AI tools have specifics to cite.'
+				),
+			},
+			{
+				label: __( 'FAQ schema' ),
+				severity: 'danger',
+				body: __(
+					'Add an FAQ section with five common prospect questions and apply FAQPage JSON-LD so AI tools can extract Q&A pairs verbatim.'
+				),
+			},
+			{
+				label: __( 'GPTBot access' ),
+				severity: 'danger',
+				body: __(
+					'Update robots.txt to explicitly allow the GPTBot, ClaudeBot, and anthropic-ai user agents, then verify the homepage is reachable by each.'
+				),
+			},
+		],
 	},
-	{
-		label: __( 'CTA optimization' ),
-		severity: 'warn',
-		body: __(
-			'Update the primary hero button text from “Learn more” to a specific, action-oriented phrase that communicates value. Suggested: “See how we work” or “Start your project.” Ensure it links to the contact or work page.'
-		),
-	},
-	{
-		label: __( 'Visual hierarchy' ),
-		severity: 'warn',
-		body: __(
-			'Audit the heading structure across the homepage. Ensure there is a single H1, that H2s clearly segment each section, and that no decorative text is marked as a heading element. Fix any heading tags used purely for styling.'
-		),
-	},
-];
+};
 
 export default function AmplifyAiWorkflow() {
+	const dispatch = useDispatch();
+	const [ mode, setMode ] = useState< Mode >( 'human' );
+
+	const handleModeChange = ( nextMode: Mode ) => {
+		if ( nextMode === mode ) {
+			return;
+		}
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_amplify_mode_toggle', {
+				mode: nextMode,
+				surface: 'workflow',
+			} )
+		);
+		setMode( nextMode );
+	};
+
+	const data = MODES[ mode ];
+
 	return (
-		<div className="amplify-landing-workflow">
-			<div className="amplify-landing-workflow-top">
+		<PageSectionColumns className="amplify-landing-workflow">
+			<PageSectionColumns.Column>
+				{ /*
+					Wrap so PageSectionColumns' 32px column gap doesn't stack on top
+					of each element's margin-block-end. With the wrapper, eyebrow →
+					title → body spacing is governed by the per-element margins,
+					matching the criteria-section rhythm.
+				*/ }
 				<div className="amplify-landing-workflow-text">
 					<p className="amplify-landing-workflow-eyebrow">{ __( 'AI workflow integration' ) }</p>
 					<h2 className="amplify-landing-workflow-title">
@@ -79,49 +159,56 @@ export default function AmplifyAiWorkflow() {
 						) }
 					</p>
 				</div>
+			</PageSectionColumns.Column>
 
+			<PageSectionColumns.Column>
 				<div className="amplify-landing-workflow-card">
 					<div className="amplify-landing-workflow-card-header">
 						<div className="amplify-landing-workflow-card-header-left">
 							<span className="amplify-landing-workflow-card-title">
 								{ __( 'Generated prompts' ) }
 							</span>
-							<span className="amplify-landing-workflow-card-mode">
-								{ __( 'Human-centric analysis' ) }
-							</span>
+							<span className="amplify-landing-workflow-card-count">{ data.issueCount }</span>
 						</div>
-						<span className="amplify-landing-workflow-card-count">{ __( '4 issues found' ) }</span>
+						<div
+							className="amplify-landing-workflow-mode-toggle"
+							role="tablist"
+							aria-label={ __( 'Analysis mode' ) }
+						>
+							<Button
+								role="tab"
+								aria-selected={ mode === 'human' }
+								className={ clsx( 'amplify-landing-workflow-mode-btn', {
+									'is-active': mode === 'human',
+								} ) }
+								onClick={ () => handleModeChange( 'human' ) }
+							>
+								{ __( 'Human' ) }
+							</Button>
+							<Button
+								role="tab"
+								aria-selected={ mode === 'ai' }
+								className={ clsx( 'amplify-landing-workflow-mode-btn', {
+									'is-active': mode === 'ai',
+								} ) }
+								onClick={ () => handleModeChange( 'ai' ) }
+							>
+								{ __( 'AI' ) }
+							</Button>
+						</div>
 					</div>
 					<div className="amplify-landing-workflow-prompt-items">
-						{ PROMPTS.map( ( prompt ) => (
+						{ data.prompts.map( ( prompt ) => (
 							<PromptItem key={ prompt.label } { ...prompt } />
 						) ) }
 					</div>
 					<div className="amplify-landing-workflow-card-footer">
-						<span className="amplify-landing-workflow-studio-label">
-							<span className="amplify-landing-workflow-studio-dot" aria-hidden="true" />
-							{ __( 'WordPress Studio connected' ) }
-						</span>
-						<button type="button" className="amplify-landing-workflow-send-btn">
-							{ __( 'Send all to Claude' ) }
-							<svg
-								width="13"
-								height="13"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								strokeWidth="2.5"
-								strokeLinecap="round"
-								strokeLinejoin="round"
-								aria-hidden="true"
-							>
-								<path d="M5 12h14" />
-								<path d="m12 5 7 7-7 7" />
-							</svg>
+						<button type="button" className="amplify-landing-workflow-copy-all">
+							{ __( 'Copy all prompts' ) }
 						</button>
 					</div>
 				</div>
-			</div>
-		</div>
+			</PageSectionColumns.Column>
+		</PageSectionColumns>
 	);
 }

--- a/client/a8c-for-agencies/sections/amplify/amplify-ai-workflow.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-ai-workflow.tsx
@@ -1,0 +1,126 @@
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
+
+type Severity = 'good' | 'warn' | 'danger';
+
+type Prompt = {
+	label: string;
+	severity: Severity;
+	body: string;
+};
+
+function PromptItem( { label, severity, body }: Prompt ) {
+	return (
+		<div className="amplify-landing-workflow-prompt-item">
+			<div className="amplify-landing-workflow-prompt-item-header">
+				<span className="amplify-landing-workflow-prompt-item-label">
+					<span
+						className={ clsx( 'amplify-landing-workflow-prompt-item-dot', severity ) }
+						aria-hidden="true"
+					/>
+					{ label }
+				</span>
+				<button type="button" className="amplify-landing-workflow-prompt-copy">
+					{ __( 'Copy' ) }
+				</button>
+			</div>
+			<div className="amplify-landing-workflow-prompt-text">{ body }</div>
+		</div>
+	);
+}
+
+export default function AmplifyAiWorkflow() {
+	const prompts: Prompt[] = [
+		{
+			label: __( 'Service clarity' ),
+			severity: 'danger',
+			body: __(
+				'Rewrite the services section of this WordPress page to clearly articulate the specific outcomes each service delivers. Replace generic descriptions with client-focused language that answers “what will this do for my business?”'
+			),
+		},
+		{
+			label: __( 'Trust signals' ),
+			severity: 'danger',
+			body: __(
+				'Add a testimonials block above the fold on the homepage using the Jetpack Reviews block. Pull from existing client testimonials and prioritise quotes that reference measurable outcomes or specific project types.'
+			),
+		},
+		{
+			label: __( 'CTA optimization' ),
+			severity: 'warn',
+			body: __(
+				'Update the primary hero button text from “Learn more” to a specific, action-oriented phrase that communicates value. Suggested: “See how we work” or “Start your project.” Ensure it links to the contact or work page.'
+			),
+		},
+		{
+			label: __( 'Visual hierarchy' ),
+			severity: 'warn',
+			body: __(
+				'Audit the heading structure across the homepage. Ensure there is a single H1, that H2s clearly segment each section, and that no decorative text is marked as a heading element. Fix any heading tags used purely for styling.'
+			),
+		},
+	];
+
+	return (
+		<div className="amplify-landing-workflow">
+			<div className="amplify-landing-workflow-top">
+				<div className="amplify-landing-workflow-text">
+					<p className="amplify-landing-workflow-eyebrow">{ __( 'AI workflow integration' ) }</p>
+					<h2 className="amplify-landing-workflow-title">
+						{ createInterpolateElement( __( 'Audit to agent<br />in seconds' ), {
+							br: <br />,
+						} ) }
+					</h2>
+					<p className="amplify-landing-workflow-body">
+						{ __(
+							'Amplify generates a precise, agent-ready prompt for every issue it finds. Send any or all of them to your AI tool of choice: Claude, Codex, Gemini, whatever fits your workflow. Then, through WordPress Studio, those changes can be applied at lightning speed directly to your sites in staging or production.'
+						) }
+					</p>
+				</div>
+
+				<div className="amplify-landing-workflow-card">
+					<div className="amplify-landing-workflow-card-header">
+						<div className="amplify-landing-workflow-card-header-left">
+							<span className="amplify-landing-workflow-card-title">
+								{ __( 'Generated prompts' ) }
+							</span>
+							<span className="amplify-landing-workflow-card-mode">
+								{ __( 'Human-centric analysis' ) }
+							</span>
+						</div>
+						<span className="amplify-landing-workflow-card-count">{ __( '4 issues found' ) }</span>
+					</div>
+					<div className="amplify-landing-workflow-prompt-items">
+						{ prompts.map( ( prompt ) => (
+							<PromptItem key={ prompt.label } { ...prompt } />
+						) ) }
+					</div>
+					<div className="amplify-landing-workflow-card-footer">
+						<span className="amplify-landing-workflow-studio-label">
+							<span className="amplify-landing-workflow-studio-dot" aria-hidden="true" />
+							{ __( 'WordPress Studio connected' ) }
+						</span>
+						<button type="button" className="amplify-landing-workflow-send-btn">
+							{ __( 'Send all to Claude' ) }
+							<svg
+								width="13"
+								height="13"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="2.5"
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								aria-hidden="true"
+							>
+								<path d="M5 12h14" />
+								<path d="m12 5 7 7-7 7" />
+							</svg>
+						</button>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/amplify/amplify-analysis-modal.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-analysis-modal.tsx
@@ -22,6 +22,7 @@ import A4AModal from 'calypso/a8c-for-agencies/components/a4a-modal';
 import { A4A_AMPLIFY_REPORTS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import type { ReactNode } from 'react';
 
 export type AnalysisType = 'human' | 'ai' | 'full';
 
@@ -155,6 +156,40 @@ type Option = {
 	icon: React.ReactNode;
 };
 
+// Hoisted to module scope — static data, no reason to reallocate on every render.
+const ANALYSIS_OPTIONS: Option[] = [
+	{
+		type: 'human',
+		title: __( 'Human-centric analysis' ),
+		description: __( 'Score how potential clients perceive your site when they land on it.' ),
+		iconClass: 'is-human',
+		icon: ICON_PERSON,
+	},
+	{
+		type: 'ai',
+		title: __( 'AI analysis' ),
+		description: __(
+			'Score how AI tools like ChatGPT, Gemini, and Perplexity read and rank your site.'
+		),
+		iconClass: 'is-ai',
+		icon: ICON_SPARKLES,
+	},
+	{
+		type: 'full',
+		title: __( 'Full analysis' ),
+		description: __( 'Run both lenses for a complete picture and prompt-ready findings.' ),
+		iconClass: 'is-full',
+		icon: ICON_TARGET,
+	},
+];
+
+// Hoisted to module scope — static translated strings.
+const TYPE_LABELS: Record< AnalysisType, string > = {
+	human: __( 'Human-centric analysis' ),
+	ai: __( 'AI analysis' ),
+	full: __( 'Full analysis' ),
+};
+
 function ChooseAnalysis( {
 	onSelect,
 	isSubmitting,
@@ -162,35 +197,9 @@ function ChooseAnalysis( {
 	onSelect: ( type: AnalysisType ) => void;
 	isSubmitting: boolean;
 } ) {
-	const options: Option[] = [
-		{
-			type: 'human',
-			title: __( 'Human-centric analysis' ),
-			description: __( 'Score how potential clients perceive your site when they land on it.' ),
-			iconClass: 'is-human',
-			icon: ICON_PERSON,
-		},
-		{
-			type: 'ai',
-			title: __( 'AI analysis' ),
-			description: __(
-				'Score how AI tools like ChatGPT, Gemini, and Perplexity read and rank your site.'
-			),
-			iconClass: 'is-ai',
-			icon: ICON_SPARKLES,
-		},
-		{
-			type: 'full',
-			title: __( 'Full analysis' ),
-			description: __( 'Run both lenses for a complete picture and prompt-ready findings.' ),
-			iconClass: 'is-full',
-			icon: ICON_TARGET,
-		},
-	];
-
 	return (
 		<ul className="amplify-analysis-list">
-			{ options.map( ( opt ) => (
+			{ ANALYSIS_OPTIONS.map( ( opt ) => (
 				<li key={ opt.type }>
 					<button
 						type="button"
@@ -217,12 +226,6 @@ function ChooseAnalysis( {
 }
 
 function ProgressContent( { site, type }: { site: string; type: AnalysisType } ) {
-	const typeLabels: Record< AnalysisType, string > = {
-		human: __( 'Human-centric analysis' ),
-		ai: __( 'AI analysis' ),
-		full: __( 'Full analysis' ),
-	};
-
 	return (
 		<div className="amplify-analysis-progress">
 			<div className="amplify-analysis-progress-icon" aria-hidden="true">
@@ -234,14 +237,12 @@ function ProgressContent( { site, type }: { site: string; type: AnalysisType } )
 					__(
 						'Running %1$s for %2$s. This may take 10 to 20 minutes depending on the size of your site.'
 					),
-					typeLabels[ type ],
+					TYPE_LABELS[ type ],
 					site
 				) }
 			</p>
 			<p className="amplify-analysis-progress-body">
-				{ __(
-					'You can navigate away. All your reports can be found in the reports dashboard.'
-				) }
+				{ __( 'You can navigate away. All your reports can be found in the reports dashboard.' ) }
 			</p>
 			<div className="amplify-analysis-progress-bar" aria-hidden="true">
 				<div className="amplify-analysis-progress-fill" />
@@ -303,12 +304,14 @@ export default function AmplifyAnalysisModal( { site, onClose, onAnalysisStarted
 	};
 
 	// Title and subtitle vary by stage.
-	const modalTitle =
-		stage === 'progress'
-			? __( 'Analysis in progress' )
-			: stage === 'error'
-			? __( 'Something went wrong' )
-			: __( 'Choose your analysis' );
+	let modalTitle: string;
+	if ( stage === 'progress' ) {
+		modalTitle = __( 'Analysis in progress' );
+	} else if ( stage === 'error' ) {
+		modalTitle = __( 'Something went wrong' );
+	} else {
+		modalTitle = __( 'Choose your analysis' );
+	}
 
 	const modalSubtitle =
 		stage === 'choose'
@@ -320,16 +323,20 @@ export default function AmplifyAnalysisModal( { site, onClose, onAnalysisStarted
 			: null;
 
 	// Footer actions vary by stage.
-	const extraActions =
-		stage === 'progress' ? (
+	let extraActions: ReactNode;
+	if ( stage === 'progress' ) {
+		extraActions = (
 			<Button __next40pxDefaultSize variant="primary" onClick={ handleViewReports }>
 				{ __( 'View reports dashboard' ) }
 			</Button>
-		) : stage === 'error' ? (
+		);
+	} else if ( stage === 'error' ) {
+		extraActions = (
 			<Button __next40pxDefaultSize variant="primary" onClick={ () => setStage( 'choose' ) }>
 				{ __( 'Try again' ) }
 			</Button>
-		) : undefined;
+		);
+	}
 
 	return (
 		<A4AModal

--- a/client/a8c-for-agencies/sections/amplify/amplify-analysis-modal.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-analysis-modal.tsx
@@ -3,6 +3,8 @@ import { __, sprintf } from '@wordpress/i18n';
 import { Icon, chevronRight } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useEffect, useState } from 'react';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 type AnalysisType = 'human' | 'ai' | 'full';
 
@@ -184,6 +186,7 @@ function ProgressAnalysis( {
 }
 
 export default function AmplifyAnalysisModal( { site, onClose }: Props ) {
+	const dispatch = useDispatch();
 	const [ stage, setStage ] = useState< 'choose' | 'progress' >( 'choose' );
 	const [ selectedType, setSelectedType ] = useState< AnalysisType | null >( null );
 
@@ -199,21 +202,24 @@ export default function AmplifyAnalysisModal( { site, onClose }: Props ) {
 		return null;
 	}
 
+	const handleSelectType = ( type: AnalysisType ) => {
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_amplify_analysis_start', {
+				analysis_type: type,
+				site_url: site,
+			} )
+		);
+		setSelectedType( type );
+		setStage( 'progress' );
+	};
+
 	return (
 		<Modal
 			title={ stage === 'choose' ? __( 'Choose your analysis' ) : __( 'Analysis in progress' ) }
 			onRequestClose={ onClose }
 			className="amplify-analysis-modal"
 		>
-			{ stage === 'choose' && (
-				<ChooseAnalysis
-					site={ site }
-					onSelect={ ( type ) => {
-						setSelectedType( type );
-						setStage( 'progress' );
-					} }
-				/>
-			) }
+			{ stage === 'choose' && <ChooseAnalysis site={ site } onSelect={ handleSelectType } /> }
 			{ stage === 'progress' && selectedType && (
 				<ProgressAnalysis site={ site } type={ selectedType } onDismiss={ onClose } />
 			) }

--- a/client/a8c-for-agencies/sections/amplify/amplify-analysis-modal.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-analysis-modal.tsx
@@ -20,8 +20,10 @@ import clsx from 'clsx';
 import { useEffect, useState } from 'react';
 import A4AModal from 'calypso/a8c-for-agencies/components/a4a-modal';
 import { A4A_AMPLIFY_REPORTS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import type { ReactNode } from 'react';
 
 export type AnalysisType = 'human' | 'ai' | 'full';
@@ -59,17 +61,41 @@ export type AnalysisType = 'human' | 'ai' | 'full';
  *   6. Delete workers/amplify-api/ and the related scripts from package.json
  *      in the a4a-amplify repo (full checklist is in that Worker's index.ts).
  */
-async function startAmplifyAnalysis( url: string, mode: AnalysisType ): Promise< string > {
+async function startAmplifyAnalysis(
+	url: string,
+	mode: AnalysisType,
+	userId: number,
+	agencyId: number
+): Promise< string > {
 	const workerUrl = config< string >( 'amplify_worker_url' );
 	const apiSecret = config< string >( 'amplify_api_secret' );
 
+	// userId + agencyId scope the report so the list can be filtered per
+	// (current user, active agency). A user who belongs to multiple agencies
+	// must not see reports from one agency while operating in the context of
+	// another, so both fields are required and both gate the reports table
+	// on the read side.
+	//
+	// **The Worker forwards these values verbatim and does not (and cannot)
+	// verify them** — a determined client with the API_SECRET could submit
+	// any pair they like. This is acceptable while Amplify is internal-only:
+	// the secret is shared, the cohort is small, and the goal is to keep
+	// coworkers (and cross-agency identities of the same user) from
+	// accidentally seeing each other's reports, not to enforce a hard
+	// authorization boundary. Real per-(user, agency) enforcement lands with
+	// the wpcom endpoint (see the SECURITY LIMITATION block below).
+	//
+	// Convention note: every other A4A list view scopes server-side via
+	// wpcom.req to /agency/${ agencyId }/... and lets the server filter. This
+	// client-side filter is a deliberate departure permitted only by the
+	// interim Worker bridge — do not copy this pattern.
 	const response = await window.fetch( `${ workerUrl }/analyze`, {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',
 			Authorization: `Bearer ${ apiSecret }`,
 		},
-		body: JSON.stringify( { url, mode } ),
+		body: JSON.stringify( { url, mode, userId, agencyId } ),
 	} );
 
 	if ( ! response.ok ) {
@@ -261,6 +287,13 @@ function ProgressContent( { site, type }: { site: string; type: AnalysisType } )
 
 export default function AmplifyAnalysisModal( { site, onClose, onAnalysisStarted }: Props ) {
 	const dispatch = useDispatch();
+	// Used to tag the submitted job so the reports list can scope to the current
+	// (user, agency) pair. The amplify route is gated by requireAccessContext
+	// so both values are loaded by the time this modal renders; the null guard
+	// in handleSelectType is belt-and-suspenders for the (theoretical) case
+	// where the Redux state hasn't hydrated yet.
+	const currentUserId = useSelector( getCurrentUserId );
+	const activeAgencyId = useSelector( getActiveAgencyId );
 	const [ stage, setStage ] = useState< 'choose' | 'progress' | 'error' >( 'choose' );
 	const [ selectedType, setSelectedType ] = useState< AnalysisType | null >( null );
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
@@ -288,8 +321,28 @@ export default function AmplifyAnalysisModal( { site, onClose, onAnalysisStarted
 		setSelectedType( type );
 		setIsSubmitting( true );
 
+		// Bail out before hitting the Worker if we somehow don't have an
+		// identity yet — submitting without it would write an entry to R2
+		// that the reports list (which filters by current user AND active
+		// agency) could never show. Surface the error stage and emit a
+		// dedicated tracks event so the path is visible in analytics if it
+		// ever happens in production.
+		if ( ! currentUserId || ! activeAgencyId ) {
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_amplify_analysis_missing_identity_error', {
+					analysis_type: type,
+					site_url: site,
+					missing_user: ! currentUserId,
+					missing_agency: ! activeAgencyId,
+				} )
+			);
+			setStage( 'error' );
+			setIsSubmitting( false );
+			return;
+		}
+
 		try {
-			const jobId = await startAmplifyAnalysis( site, type );
+			const jobId = await startAmplifyAnalysis( site, type, currentUserId, activeAgencyId );
 			// Notify the parent so it can add an in-progress row to the reports
 			// table immediately, before the R2 index has a chance to update.
 			onAnalysisStarted( {

--- a/client/a8c-for-agencies/sections/amplify/amplify-analysis-modal.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-analysis-modal.tsx
@@ -324,7 +324,7 @@ export default function AmplifyAnalysisModal( { site, onClose, onAnalysisStarted
 	const modalSubtitle =
 		stage === 'choose'
 			? sprintf(
-					/* translators: %s is the site URL being analysed. */
+					/* translators: %s is the site URL being analyzed. */
 					__( 'Run a comprehensive site analysis on %s' ),
 					site
 			  )

--- a/client/a8c-for-agencies/sections/amplify/amplify-analysis-modal.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-analysis-modal.tsx
@@ -76,8 +76,16 @@ async function startAmplifyAnalysis( url: string, mode: AnalysisType ): Promise<
 		throw new Error( `Worker responded with ${ response.status }` );
 	}
 
-	const data: { jobId: string } = await response.json();
-	return data.jobId;
+	const data: unknown = await response.json();
+	if (
+		! data ||
+		typeof data !== 'object' ||
+		! ( 'jobId' in data ) ||
+		typeof ( data as { jobId: unknown } ).jobId !== 'string'
+	) {
+		throw new Error( 'Invalid response from worker: missing jobId' );
+	}
+	return ( data as { jobId: string } ).jobId;
 }
 
 /**

--- a/client/a8c-for-agencies/sections/amplify/amplify-analysis-modal.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-analysis-modal.tsx
@@ -3,10 +3,29 @@ import { __, sprintf } from '@wordpress/i18n';
 import { Icon, chevronRight } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useEffect, useState } from 'react';
+import wpcom from 'calypso/lib/wp';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 type AnalysisType = 'human' | 'ai' | 'full';
+
+interface AmplifyAnalyzeResponse {
+	jobId: string;
+}
+
+// TODO: The /wpcom/v2/amplify/analyze endpoint needs to be implemented in the
+// WordPress.com backend. It should accept POST { url, mode }, trigger a
+// Trigger.dev job (task ID: amplify-analysis), and return { jobId } from the
+// Trigger.dev run handle.
+async function startAmplifyAnalysis( url: string, mode: AnalysisType ): Promise< string > {
+	const data: AmplifyAnalyzeResponse = await wpcom.req.post( {
+		apiNamespace: 'wpcom/v2',
+		path: '/amplify/analyze',
+		body: { url, mode },
+	} );
+
+	return data.jobId;
+}
 
 type Props = {
 	site: string | null;
@@ -73,9 +92,11 @@ type Option = {
 function ChooseAnalysis( {
 	site,
 	onSelect,
+	isSubmitting,
 }: {
 	site: string;
 	onSelect: ( type: AnalysisType ) => void;
+	isSubmitting: boolean;
 } ) {
 	const options: Option[] = [
 		{
@@ -118,6 +139,7 @@ function ChooseAnalysis( {
 						<button
 							type="button"
 							className="amplify-analysis-option"
+							disabled={ isSubmitting }
 							onClick={ () => onSelect( opt.type ) }
 						>
 							<span
@@ -187,14 +209,16 @@ function ProgressAnalysis( {
 
 export default function AmplifyAnalysisModal( { site, onClose }: Props ) {
 	const dispatch = useDispatch();
-	const [ stage, setStage ] = useState< 'choose' | 'progress' >( 'choose' );
+	const [ stage, setStage ] = useState< 'choose' | 'progress' | 'error' >( 'choose' );
 	const [ selectedType, setSelectedType ] = useState< AnalysisType | null >( null );
+	const [ isSubmitting, setIsSubmitting ] = useState( false );
 
 	// Reset internal state whenever the modal opens for a new site.
 	useEffect( () => {
 		if ( site ) {
 			setStage( 'choose' );
 			setSelectedType( null );
+			setIsSubmitting( false );
 		}
 	}, [ site ] );
 
@@ -202,7 +226,7 @@ export default function AmplifyAnalysisModal( { site, onClose }: Props ) {
 		return null;
 	}
 
-	const handleSelectType = ( type: AnalysisType ) => {
+	const handleSelectType = async ( type: AnalysisType ) => {
 		dispatch(
 			recordTracksEvent( 'calypso_a4a_amplify_analysis_start', {
 				analysis_type: type,
@@ -210,18 +234,44 @@ export default function AmplifyAnalysisModal( { site, onClose }: Props ) {
 			} )
 		);
 		setSelectedType( type );
-		setStage( 'progress' );
+		setIsSubmitting( true );
+
+		try {
+			await startAmplifyAnalysis( site, type );
+			setStage( 'progress' );
+		} catch ( err ) {
+			setStage( 'error' );
+		} finally {
+			setIsSubmitting( false );
+		}
 	};
 
+	let modalTitle: string;
+	if ( stage === 'progress' ) {
+		modalTitle = __( 'Analysis in progress' );
+	} else if ( stage === 'error' ) {
+		modalTitle = __( 'Something went wrong' );
+	} else {
+		modalTitle = __( 'Choose your analysis' );
+	}
+
 	return (
-		<Modal
-			title={ stage === 'choose' ? __( 'Choose your analysis' ) : __( 'Analysis in progress' ) }
-			onRequestClose={ onClose }
-			className="amplify-analysis-modal"
-		>
-			{ stage === 'choose' && <ChooseAnalysis site={ site } onSelect={ handleSelectType } /> }
+		<Modal title={ modalTitle } onRequestClose={ onClose } className="amplify-analysis-modal">
+			{ stage === 'choose' && (
+				<ChooseAnalysis site={ site } onSelect={ handleSelectType } isSubmitting={ isSubmitting } />
+			) }
 			{ stage === 'progress' && selectedType && (
 				<ProgressAnalysis site={ site } type={ selectedType } onDismiss={ onClose } />
+			) }
+			{ stage === 'error' && (
+				<div className="amplify-analysis-error">
+					<p className="amplify-analysis-progress-body">
+						{ __( 'We were unable to start your analysis. Please try again in a moment.' ) }
+					</p>
+					<Button __next40pxDefaultSize variant="primary" onClick={ () => setStage( 'choose' ) }>
+						{ __( 'Try again' ) }
+					</Button>
+				</div>
 			) }
 		</Modal>
 	);

--- a/client/a8c-for-agencies/sections/amplify/amplify-analysis-modal.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-analysis-modal.tsx
@@ -1,0 +1,222 @@
+import { Button, Modal } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { Icon, chevronRight } from '@wordpress/icons';
+import clsx from 'clsx';
+import { useEffect, useState } from 'react';
+
+type AnalysisType = 'human' | 'ai' | 'full';
+
+type Props = {
+	site: string | null;
+	onClose: () => void;
+};
+
+const ICON_PERSON = (
+	<svg
+		width="20"
+		height="20"
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		strokeWidth="2"
+		strokeLinecap="round"
+		strokeLinejoin="round"
+	>
+		<path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+		<circle cx="12" cy="7" r="4" />
+	</svg>
+);
+
+const ICON_SPARKLES = (
+	<svg
+		width="20"
+		height="20"
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		strokeWidth="2"
+		strokeLinecap="round"
+		strokeLinejoin="round"
+	>
+		<path d="M12 3l1.9 5.4L19 11l-5.1 2.6L12 19l-1.9-5.4L5 11l5.1-2.6z" />
+		<path d="M5 3v4M3 5h4M19 17v4M17 19h4" />
+	</svg>
+);
+
+const ICON_TARGET = (
+	<svg
+		width="20"
+		height="20"
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		strokeWidth="2"
+		strokeLinecap="round"
+		strokeLinejoin="round"
+	>
+		<circle cx="12" cy="12" r="10" />
+		<circle cx="12" cy="12" r="6" />
+		<circle cx="12" cy="12" r="2" />
+	</svg>
+);
+
+type Option = {
+	type: AnalysisType;
+	title: string;
+	description: string;
+	iconClass: string;
+	icon: React.ReactNode;
+};
+
+function ChooseAnalysis( {
+	site,
+	onSelect,
+}: {
+	site: string;
+	onSelect: ( type: AnalysisType ) => void;
+} ) {
+	const options: Option[] = [
+		{
+			type: 'human',
+			title: __( 'Human-centric analysis' ),
+			description: __( 'Score how potential clients perceive your site when they land on it.' ),
+			iconClass: 'is-human',
+			icon: ICON_PERSON,
+		},
+		{
+			type: 'ai',
+			title: __( 'AI analysis' ),
+			description: __(
+				'Score how AI tools like ChatGPT, Gemini, and Perplexity read and rank your site.'
+			),
+			iconClass: 'is-ai',
+			icon: ICON_SPARKLES,
+		},
+		{
+			type: 'full',
+			title: __( 'Full analysis' ),
+			description: __( 'Run both lenses for a complete picture and prompt-ready findings.' ),
+			iconClass: 'is-full',
+			icon: ICON_TARGET,
+		},
+	];
+
+	return (
+		<div className="amplify-analysis-options">
+			<p className="amplify-analysis-site">
+				{ sprintf(
+					/* translators: %s is the site URL being audited. */
+					__( 'Auditing %s' ),
+					site
+				) }
+			</p>
+			<ul className="amplify-analysis-list">
+				{ options.map( ( opt ) => (
+					<li key={ opt.type }>
+						<button
+							type="button"
+							className="amplify-analysis-option"
+							onClick={ () => onSelect( opt.type ) }
+						>
+							<span
+								className={ clsx( 'amplify-analysis-option-icon', opt.iconClass ) }
+								aria-hidden="true"
+							>
+								{ opt.icon }
+							</span>
+							<span className="amplify-analysis-option-text">
+								<span className="amplify-analysis-option-title">{ opt.title }</span>
+								<span className="amplify-analysis-option-description">{ opt.description }</span>
+							</span>
+							<Icon icon={ chevronRight } size={ 20 } />
+						</button>
+					</li>
+				) ) }
+			</ul>
+		</div>
+	);
+}
+
+function ProgressAnalysis( {
+	site,
+	type,
+	onDismiss,
+}: {
+	site: string;
+	type: AnalysisType;
+	onDismiss: () => void;
+} ) {
+	const typeLabels: Record< AnalysisType, string > = {
+		human: __( 'Human-centric analysis' ),
+		ai: __( 'AI analysis' ),
+		full: __( 'Full analysis' ),
+	};
+
+	return (
+		<div className="amplify-analysis-progress">
+			<div className="amplify-analysis-progress-icon" aria-hidden="true">
+				<div className="amplify-analysis-progress-pulse" />
+			</div>
+			<h2 className="amplify-analysis-progress-title">{ __( 'Analysis in progress' ) }</h2>
+			<p className="amplify-analysis-progress-body">
+				{ sprintf(
+					/* translators: %1$s is the analysis type, %2$s is the site URL. */
+					__(
+						'Running %1$s for %2$s. This may take 10–20 minutes depending on the size of your site.'
+					),
+					typeLabels[ type ],
+					site
+				) }
+			</p>
+			<p className="amplify-analysis-progress-body">
+				{ __(
+					'You can navigate away — we’ll let you know when your report is ready for download.'
+				) }
+			</p>
+			<div className="amplify-analysis-progress-bar" aria-hidden="true">
+				<div className="amplify-analysis-progress-fill" />
+			</div>
+			<Button __next40pxDefaultSize variant="primary" onClick={ onDismiss }>
+				{ __( 'Got it, run in background' ) }
+			</Button>
+		</div>
+	);
+}
+
+export default function AmplifyAnalysisModal( { site, onClose }: Props ) {
+	const [ stage, setStage ] = useState< 'choose' | 'progress' >( 'choose' );
+	const [ selectedType, setSelectedType ] = useState< AnalysisType | null >( null );
+
+	// Reset internal state whenever the modal opens for a new site.
+	useEffect( () => {
+		if ( site ) {
+			setStage( 'choose' );
+			setSelectedType( null );
+		}
+	}, [ site ] );
+
+	if ( ! site ) {
+		return null;
+	}
+
+	return (
+		<Modal
+			title={ stage === 'choose' ? __( 'Choose your analysis' ) : __( 'Analysis in progress' ) }
+			onRequestClose={ onClose }
+			className="amplify-analysis-modal"
+		>
+			{ stage === 'choose' && (
+				<ChooseAnalysis
+					site={ site }
+					onSelect={ ( type ) => {
+						setSelectedType( type );
+						setStage( 'progress' );
+					} }
+				/>
+			) }
+			{ stage === 'progress' && selectedType && (
+				<ProgressAnalysis site={ site } type={ selectedType } onDismiss={ onClose } />
+			) }
+		</Modal>
+	);
+}

--- a/client/a8c-for-agencies/sections/amplify/amplify-analysis-modal.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-analysis-modal.tsx
@@ -1,35 +1,101 @@
-import { Button, Modal } from '@wordpress/components';
+/**
+ * AmplifyAnalysisModal
+ *
+ * Two-stage modal flow managed from amplify-page.tsx:
+ *   1. AmplifyAddSiteModal  — user picks a site (A4AModal)
+ *   2. AmplifyAnalysisModal — user picks analysis type, job is submitted (A4AModal)
+ *
+ * State lives in amplify-page.tsx so both modals can be mounted/unmounted
+ * independently without losing the site selection between them. The page also
+ * holds `pendingJobs` so the reports table can show an in-progress row the
+ * moment an analysis is kicked off, before the R2 index updates.
+ */
+
+import config from '@automattic/calypso-config';
+import page from '@automattic/calypso-router';
+import { Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, chevronRight } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useEffect, useState } from 'react';
-import wpcom from 'calypso/lib/wp';
+import A4AModal from 'calypso/a8c-for-agencies/components/a4a-modal';
+import { A4A_AMPLIFY_REPORTS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
-type AnalysisType = 'human' | 'ai' | 'full';
+export type AnalysisType = 'human' | 'ai' | 'full';
 
-interface AmplifyAnalyzeResponse {
-	jobId: string;
-}
-
-// TODO: The /wpcom/v2/amplify/analyze endpoint needs to be implemented in the
-// WordPress.com backend. It should accept POST { url, mode }, trigger a
-// Trigger.dev job (task ID: amplify-analysis), and return { jobId } from the
-// Trigger.dev run handle.
+/**
+ * ⚠️  INTERIM IMPLEMENTATION — READ BEFORE TOUCHING ⚠️
+ *
+ * This function calls a Cloudflare Worker as a temporary bridge to Trigger.dev
+ * while the real WordPress.com backend endpoint is being built. It is NOT the
+ * intended long-term approach.
+ *
+ * SECURITY LIMITATION: amplify_api_secret is stored in the calypso client-side
+ * config, which means it is bundled into browser JS and visible to any user who
+ * opens devtools. This is acceptable while Amplify is internal-only, but must
+ * be resolved before any broader rollout.
+ *
+ * CLEANUP REQUIRED when POST /wpcom/v2/amplify/analyze is implemented in wpcom:
+ *   1. Remove the config() calls for amplify_worker_url and amplify_api_secret.
+ *   2. Remove the window.fetch block entirely.
+ *   3. Replace this function body with the wpcom.req.post pattern:
+ *
+ *        import wpcom from 'calypso/lib/wp';
+ *        const data = await wpcom.req.post({
+ *            apiNamespace: 'wpcom/v2',
+ *            path: '/amplify/analyze',
+ *            body: { url, mode },
+ *        });
+ *        return data.jobId;
+ *
+ *   4. Remove the `config` import if it is no longer used elsewhere.
+ *   5. Remove amplify_worker_url and amplify_api_secret from:
+ *        config/_shared.json
+ *        config/a8c-for-agencies-development.json
+ *        config/a8c-for-agencies-production.json
+ *   6. Delete workers/amplify-api/ and the related scripts from package.json
+ *      in the a4a-amplify repo (full checklist is in that Worker's index.ts).
+ */
 async function startAmplifyAnalysis( url: string, mode: AnalysisType ): Promise< string > {
-	const data: AmplifyAnalyzeResponse = await wpcom.req.post( {
-		apiNamespace: 'wpcom/v2',
-		path: '/amplify/analyze',
-		body: { url, mode },
+	const workerUrl = config< string >( 'amplify_worker_url' );
+	const apiSecret = config< string >( 'amplify_api_secret' );
+
+	const response = await window.fetch( `${ workerUrl }/analyze`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${ apiSecret }`,
+		},
+		body: JSON.stringify( { url, mode } ),
 	} );
 
+	if ( ! response.ok ) {
+		throw new Error( `Worker responded with ${ response.status }` );
+	}
+
+	const data: { jobId: string } = await response.json();
 	return data.jobId;
 }
+
+/**
+ * PendingJob is passed back to amplify-page.tsx via onAnalysisStarted so the
+ * reports table can show an in-progress row immediately without waiting for the
+ * R2 index to update.
+ */
+export type PendingJob = {
+	jobId: string;
+	site: string;
+	type: AnalysisType;
+	startedAt: string; // ISO timestamp
+};
 
 type Props = {
 	site: string | null;
 	onClose: () => void;
+	/** Called as soon as the job is successfully submitted. */
+	onAnalysisStarted: ( job: PendingJob ) => void;
 };
 
 const ICON_PERSON = (
@@ -90,11 +156,9 @@ type Option = {
 };
 
 function ChooseAnalysis( {
-	site,
 	onSelect,
 	isSubmitting,
 }: {
-	site: string;
 	onSelect: ( type: AnalysisType ) => void;
 	isSubmitting: boolean;
 } ) {
@@ -125,51 +189,34 @@ function ChooseAnalysis( {
 	];
 
 	return (
-		<div className="amplify-analysis-options">
-			<p className="amplify-analysis-site">
-				{ sprintf(
-					/* translators: %s is the site URL being audited. */
-					__( 'Auditing %s' ),
-					site
-				) }
-			</p>
-			<ul className="amplify-analysis-list">
-				{ options.map( ( opt ) => (
-					<li key={ opt.type }>
-						<button
-							type="button"
-							className="amplify-analysis-option"
-							disabled={ isSubmitting }
-							onClick={ () => onSelect( opt.type ) }
+		<ul className="amplify-analysis-list">
+			{ options.map( ( opt ) => (
+				<li key={ opt.type }>
+					<button
+						type="button"
+						className="amplify-analysis-option"
+						disabled={ isSubmitting }
+						onClick={ () => onSelect( opt.type ) }
+					>
+						<span
+							className={ clsx( 'amplify-analysis-option-icon', opt.iconClass ) }
+							aria-hidden="true"
 						>
-							<span
-								className={ clsx( 'amplify-analysis-option-icon', opt.iconClass ) }
-								aria-hidden="true"
-							>
-								{ opt.icon }
-							</span>
-							<span className="amplify-analysis-option-text">
-								<span className="amplify-analysis-option-title">{ opt.title }</span>
-								<span className="amplify-analysis-option-description">{ opt.description }</span>
-							</span>
-							<Icon icon={ chevronRight } size={ 20 } />
-						</button>
-					</li>
-				) ) }
-			</ul>
-		</div>
+							{ opt.icon }
+						</span>
+						<span className="amplify-analysis-option-text">
+							<span className="amplify-analysis-option-title">{ opt.title }</span>
+							<span className="amplify-analysis-option-description">{ opt.description }</span>
+						</span>
+						<Icon icon={ chevronRight } size={ 20 } />
+					</button>
+				</li>
+			) ) }
+		</ul>
 	);
 }
 
-function ProgressAnalysis( {
-	site,
-	type,
-	onDismiss,
-}: {
-	site: string;
-	type: AnalysisType;
-	onDismiss: () => void;
-} ) {
+function ProgressContent( { site, type }: { site: string; type: AnalysisType } ) {
 	const typeLabels: Record< AnalysisType, string > = {
 		human: __( 'Human-centric analysis' ),
 		ai: __( 'AI analysis' ),
@@ -181,12 +228,11 @@ function ProgressAnalysis( {
 			<div className="amplify-analysis-progress-icon" aria-hidden="true">
 				<div className="amplify-analysis-progress-pulse" />
 			</div>
-			<h2 className="amplify-analysis-progress-title">{ __( 'Analysis in progress' ) }</h2>
 			<p className="amplify-analysis-progress-body">
 				{ sprintf(
 					/* translators: %1$s is the analysis type, %2$s is the site URL. */
 					__(
-						'Running %1$s for %2$s. This may take 10–20 minutes depending on the size of your site.'
+						'Running %1$s for %2$s. This may take 10 to 20 minutes depending on the size of your site.'
 					),
 					typeLabels[ type ],
 					site
@@ -194,20 +240,17 @@ function ProgressAnalysis( {
 			</p>
 			<p className="amplify-analysis-progress-body">
 				{ __(
-					'You can navigate away — we’ll let you know when your report is ready for download.'
+					'You can navigate away. All your reports can be found in the reports dashboard.'
 				) }
 			</p>
 			<div className="amplify-analysis-progress-bar" aria-hidden="true">
 				<div className="amplify-analysis-progress-fill" />
 			</div>
-			<Button __next40pxDefaultSize variant="primary" onClick={ onDismiss }>
-				{ __( 'Got it, run in background' ) }
-			</Button>
 		</div>
 	);
 }
 
-export default function AmplifyAnalysisModal( { site, onClose }: Props ) {
+export default function AmplifyAnalysisModal( { site, onClose, onAnalysisStarted }: Props ) {
 	const dispatch = useDispatch();
 	const [ stage, setStage ] = useState< 'choose' | 'progress' | 'error' >( 'choose' );
 	const [ selectedType, setSelectedType ] = useState< AnalysisType | null >( null );
@@ -237,7 +280,15 @@ export default function AmplifyAnalysisModal( { site, onClose }: Props ) {
 		setIsSubmitting( true );
 
 		try {
-			await startAmplifyAnalysis( site, type );
+			const jobId = await startAmplifyAnalysis( site, type );
+			// Notify the parent so it can add an in-progress row to the reports
+			// table immediately, before the R2 index has a chance to update.
+			onAnalysisStarted( {
+				jobId,
+				site,
+				type,
+				startedAt: new Date().toISOString(),
+			} );
 			setStage( 'progress' );
 		} catch ( err ) {
 			setStage( 'error' );
@@ -246,33 +297,63 @@ export default function AmplifyAnalysisModal( { site, onClose }: Props ) {
 		}
 	};
 
-	let modalTitle: string;
-	if ( stage === 'progress' ) {
-		modalTitle = __( 'Analysis in progress' );
-	} else if ( stage === 'error' ) {
-		modalTitle = __( 'Something went wrong' );
-	} else {
-		modalTitle = __( 'Choose your analysis' );
-	}
+	const handleViewReports = () => {
+		onClose();
+		page( A4A_AMPLIFY_REPORTS_LINK );
+	};
+
+	// Title and subtitle vary by stage.
+	const modalTitle =
+		stage === 'progress'
+			? __( 'Analysis in progress' )
+			: stage === 'error'
+			? __( 'Something went wrong' )
+			: __( 'Choose your analysis' );
+
+	const modalSubtitle =
+		stage === 'choose'
+			? sprintf(
+					/* translators: %s is the site URL being analysed. */
+					__( 'Run a comprehensive site analysis on %s' ),
+					site
+			  )
+			: null;
+
+	// Footer actions vary by stage.
+	const extraActions =
+		stage === 'progress' ? (
+			<Button __next40pxDefaultSize variant="primary" onClick={ handleViewReports }>
+				{ __( 'View reports dashboard' ) }
+			</Button>
+		) : stage === 'error' ? (
+			<Button __next40pxDefaultSize variant="primary" onClick={ () => setStage( 'choose' ) }>
+				{ __( 'Try again' ) }
+			</Button>
+		) : undefined;
 
 	return (
-		<Modal title={ modalTitle } onRequestClose={ onClose } className="amplify-analysis-modal">
+		<A4AModal
+			title={ modalTitle }
+			subtile={ modalSubtitle }
+			onClose={ onClose }
+			extraActions={ extraActions }
+			// Hide the Cancel button on the progress screen — the CTA does the job.
+			showCloseButton={ stage !== 'progress' }
+			className="amplify-analysis-modal"
+		>
 			{ stage === 'choose' && (
-				<ChooseAnalysis site={ site } onSelect={ handleSelectType } isSubmitting={ isSubmitting } />
+				<ChooseAnalysis onSelect={ handleSelectType } isSubmitting={ isSubmitting } />
 			) }
 			{ stage === 'progress' && selectedType && (
-				<ProgressAnalysis site={ site } type={ selectedType } onDismiss={ onClose } />
+				<ProgressContent site={ site } type={ selectedType } />
 			) }
 			{ stage === 'error' && (
 				<div className="amplify-analysis-error">
 					<p className="amplify-analysis-progress-body">
 						{ __( 'We were unable to start your analysis. Please try again in a moment.' ) }
 					</p>
-					<Button __next40pxDefaultSize variant="primary" onClick={ () => setStage( 'choose' ) }>
-						{ __( 'Try again' ) }
-					</Button>
 				</div>
 			) }
-		</Modal>
+		</A4AModal>
 	);
 }

--- a/client/a8c-for-agencies/sections/amplify/amplify-benefits.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-benefits.tsx
@@ -1,0 +1,96 @@
+import { __ } from '@wordpress/i18n';
+import type { ReactNode } from 'react';
+
+type BenefitProps = {
+	icon: ReactNode;
+	title: string;
+	body: ReactNode;
+};
+
+function AmplifyBenefit( { icon, title, body }: BenefitProps ) {
+	return (
+		<div className="amplify-landing-benefit">
+			<div className="amplify-landing-benefit-icon" aria-hidden="true">
+				{ icon }
+			</div>
+			<h3 className="amplify-landing-benefit-title">{ title }</h3>
+			<p className="amplify-landing-benefit-body">{ body }</p>
+		</div>
+	);
+}
+
+const ICON_LENS = (
+	<svg
+		width="22"
+		height="22"
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		strokeWidth="2"
+		strokeLinecap="round"
+		strokeLinejoin="round"
+	>
+		<circle cx="12" cy="12" r="3" />
+		<path d="M2 12s4-7 10-7 10 7 10 7-4 7-10 7-10-7-10-7z" />
+	</svg>
+);
+
+const ICON_CHART = (
+	<svg
+		width="22"
+		height="22"
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		strokeWidth="2"
+		strokeLinecap="round"
+		strokeLinejoin="round"
+	>
+		<polyline points="22 7 13.5 15.5 8.5 10.5 2 17" />
+		<polyline points="16 7 22 7 22 13" />
+	</svg>
+);
+
+const ICON_LINK = (
+	<svg
+		width="22"
+		height="22"
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		strokeWidth="2"
+		strokeLinecap="round"
+		strokeLinejoin="round"
+	>
+		<path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+		<path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+	</svg>
+);
+
+export default function AmplifyBenefits() {
+	return (
+		<div className="amplify-landing-benefits-grid">
+			<AmplifyBenefit
+				icon={ ICON_LENS }
+				title={ __( 'Two lenses, one complete picture' ) }
+				body={ __(
+					'Amplify audits your site two ways. Human-centric analysis reveals how a potential client perceives your site when they land on it. AI analysis shows how ChatGPT, Gemini, and Perplexity read and rank your agency when someone searches for help.'
+				) }
+			/>
+			<AmplifyBenefit
+				icon={ ICON_CHART }
+				title={ __( 'See problems where they actually live' ) }
+				body={ __(
+					'Amplify overlays directly on your live site, pinning issues in context so you can see exactly what needs fixing and why, right on the page where it matters.'
+				) }
+			/>
+			<AmplifyBenefit
+				icon={ ICON_LINK }
+				title={ __( 'Audit your sites and your clients’ too' ) }
+				body={ __(
+					'Pull from your connected Automattic for Agencies account, or paste any URL. Amplify works for your agency site and your client sites, delivering more value at every engagement.'
+				) }
+			/>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/amplify/amplify-faq.scss
+++ b/client/a8c-for-agencies/sections/amplify/amplify-faq.scss
@@ -1,0 +1,32 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
+ul.amplify-faqs {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+.amplify-faqs__section {
+	padding: 0;
+
+	.foldable-faq__answer {
+		border-bottom: 1px solid var(--color-primary-5);
+	}
+
+	.foldable-faq__question-text {
+		@include heading-large;
+	}
+
+	.gridicon {
+		fill: var(--color-primary-50);
+	}
+
+	a,
+	a:hover,
+	a:active,
+	a:visited {
+		color: var(--color-text);
+		text-decoration: underline;
+	}
+}

--- a/client/a8c-for-agencies/sections/amplify/amplify-faq.scss
+++ b/client/a8c-for-agencies/sections/amplify/amplify-faq.scss
@@ -1,6 +1,30 @@
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/variables";
 
+// FAQ heading sized to match .amplify-landing-workflow-title and
+// .amplify-criteria-title so all top-level section headings on the page
+// share the same scale.
+.amplify-faqs__title {
+	font-size: clamp(24px, 3vw, 36px);
+	font-weight: 600;
+	line-height: 1.15;
+	letter-spacing: -0.4px;
+	color: var(--color-text-black);
+	margin: 0;
+	// Matches the criteria-section title → intro spacing.
+	margin-block-end: 16px;
+}
+
+// FAQ description sits between the heading and the question list.
+.amplify-faqs__description {
+	font-size: 15px;
+	line-height: 1.65;
+	color: var(--color-text-subtle);
+	margin: 0;
+	// Matches the criteria-section intro → cards spacing.
+	margin-block-end: 36px;
+}
+
 ul.amplify-faqs {
 	margin: 0;
 	padding: 0;

--- a/client/a8c-for-agencies/sections/amplify/amplify-faq.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-faq.tsx
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { useCallback } from 'react';
-import PageSection from 'calypso/a8c-for-agencies/components/page-section';
+import PageSectionColumns from 'calypso/a8c-for-agencies/components/page-section-columns';
 import FoldableFAQ from 'calypso/components/foldable-faq';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -86,7 +86,7 @@ export default function AmplifyFAQ() {
 					} )
 				);
 			} else {
-				history.replaceState( '', document.title, location.pathname + location.search );
+				history.replaceState( null, document.title, location.pathname + location.search );
 				dispatch(
 					recordTracksEvent( 'calypso_a4a_amplify_faq_close', {
 						faq_id: id,
@@ -98,24 +98,37 @@ export default function AmplifyFAQ() {
 	);
 
 	return (
-		<PageSection
-			heading={ __( 'Frequently asked questions' ) }
-			description={ __( 'Curious about the details? We have answers.' ) }
-		>
-			<ul className="amplify-faqs">
-				{ FAQS.map( ( faq ) => (
-					<li key={ faq.id }>
-						<FoldableFAQ
-							id={ faq.id }
-							question={ faq.question }
-							onToggle={ onFaqToggle }
-							className="amplify-faqs__section"
-						>
-							{ faq.answer }
-						</FoldableFAQ>
-					</li>
-				) ) }
-			</ul>
-		</PageSection>
+		<PageSectionColumns background={ { color: 'var(--color-neutral-0)' } }>
+			<PageSectionColumns.Column fullWidth>
+				{ /*
+					Rendering the heading inside the column (rather than via
+					PageSectionColumns' `heading` prop) gives us control over the
+					title size and the gap below it, so the FAQ heading matches the
+					criteria-section / workflow-title rhythm. Wrapping heading +
+					description + list in a div keeps PageSectionColumns' column
+					gap from stacking on top of the per-element margins.
+				*/ }
+				<div className="amplify-faqs-wrapper">
+					<h2 className="amplify-faqs__title">{ __( 'Frequently asked questions' ) }</h2>
+					<p className="amplify-faqs__description">
+						{ __( 'Curious about the details? We have answers.' ) }
+					</p>
+					<ul className="amplify-faqs">
+						{ FAQS.map( ( faq ) => (
+							<li key={ faq.id }>
+								<FoldableFAQ
+									id={ faq.id }
+									question={ faq.question }
+									onToggle={ onFaqToggle }
+									className="amplify-faqs__section"
+								>
+									{ faq.answer }
+								</FoldableFAQ>
+							</li>
+						) ) }
+					</ul>
+				</div>
+			</PageSectionColumns.Column>
+		</PageSectionColumns>
 	);
 }

--- a/client/a8c-for-agencies/sections/amplify/amplify-faq.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-faq.tsx
@@ -1,0 +1,121 @@
+import { __ } from '@wordpress/i18n';
+import { useCallback } from 'react';
+import PageSection from 'calypso/a8c-for-agencies/components/page-section';
+import FoldableFAQ from 'calypso/components/foldable-faq';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+import './amplify-faq.scss';
+
+// Hoisted to module scope - static data, no reason to reallocate on every render.
+const FAQS = [
+	{
+		id: 'what-does-amplify-analyze',
+		question: __( 'What does Amplify actually analyze?' ),
+		answer: __(
+			'Amplify evaluates your homepage through two lenses. Human Mode scores how a potential client perceives the site, covering trust signals, mobile experience, content quality, SEO, conversion paths, and more. AI Mode scores how AI tools like ChatGPT, Perplexity, and Gemini read and rank it, covering structured data, entity clarity, AEO readiness, E-E-A-T signals, and technical accessibility. Each lens produces a score out of 100 with a prioritized list of findings.'
+		),
+	},
+	{
+		id: 'how-is-the-score-calculated',
+		question: __( 'How is the score calculated?' ),
+		answer: __(
+			'Every score is a combination of programmatic checks and AI analysis. Programmatic checks cover signals with one right answer: element presence, character counts, contrast ratios, HTTP status, and page speed measurements. AI analysis covers signals that require judgment, including visual polish, content clarity, trust signal quality, and audience resonance. Each criterion is weighted by its real-world impact on conversion or discoverability, and the total adds up to 100 points per mode.'
+		),
+	},
+	{
+		id: 'what-do-the-thresholds-mean',
+		question: __( 'What do "Strong", "Needs work", and "At risk" mean?' ),
+		answer: __(
+			'These labels reflect where your score falls within a 100-point range. A score of 80 or above is Strong, meaning the site is well-positioned and likely making a good impression. A score of 50 to 79 is Needs work, meaning there are meaningful gaps that are likely costing you leads or visibility. Below 50 is At risk, meaning the site has significant issues that are actively working against you. The thresholds are the same across both Human Mode and AI Mode.'
+		),
+	},
+	{
+		id: 'homepage-only',
+		question: __( 'Does Amplify analyze my entire site or just the homepage?' ),
+		answer: __(
+			'Right now, Amplify focuses on the homepage. This is where first impressions are made for both humans and AI tools, and where the highest-impact improvements tend to live. Full site analysis, covering interior pages, service pages, and blog content, is planned for a future release.'
+		),
+	},
+	{
+		id: 'how-long-does-it-take',
+		question: __( 'How long does an analysis take?' ),
+		answer: __(
+			'Most analyses complete in 10 to 20 minutes, depending on the size and complexity of the site. You can navigate away as soon as the job is submitted. The report will appear in your reports dashboard when it is ready.'
+		),
+	},
+	{
+		id: 'how-often-should-i-run-it',
+		question: __( 'How often should I run an analysis?' ),
+		answer: __(
+			'Amplify produces a point-in-time snapshot of your site. Run it after making significant changes to your homepage copy, design, or structure, and then again a few weeks later to see how the score has moved. For client sites, running it before a quarterly review gives you concrete, data-backed talking points about what has improved and what is still worth addressing.'
+		),
+	},
+	{
+		id: 'can-i-run-it-on-a-client-site',
+		question: __( "Can I run Amplify on a client's site?" ),
+		answer: __(
+			'Yes. Amplify works on any site connected to your Automattic for Agencies account. Running it on a client site before a pitch lets you walk in with a report in hand and show them exactly what you would fix and why. It is a compelling way to demonstrate your expertise and win the contract. For existing clients, it is a strong addition to quarterly business reviews.'
+		),
+	},
+	{
+		id: 'score-accuracy',
+		question: __( 'My score seems off. How accurate is it?' ),
+		answer: __(
+			'Amplify scores are directional indicators grounded in established research, including WCAG, Google Search Central, the Laws of UX, and Automattic expertise. They are not definitive verdicts. Programmatic signals are precise. Signals based on AI analysis carry a higher degree of interpretive variance and may not account for every site-specific context or intentional design decision. If something does not look right, treat it as a prompt for a conversation rather than a final ruling, and factor in your own knowledge of the site and its audience.'
+		),
+	},
+];
+
+export default function AmplifyFAQ() {
+	const dispatch = useDispatch();
+
+	const onFaqToggle = useCallback(
+		( faqArgs: { id: string; buttonId: string; isExpanded: boolean; height: number } ) => {
+			const { id, buttonId, isExpanded } = faqArgs;
+
+			if ( isExpanded ) {
+				history.replaceState(
+					'',
+					document.title,
+					location.pathname + location.search + `#${ buttonId }`
+				);
+				dispatch(
+					recordTracksEvent( 'calypso_a4a_amplify_faq_open', {
+						faq_id: id,
+					} )
+				);
+			} else {
+				history.replaceState( '', document.title, location.pathname + location.search );
+				dispatch(
+					recordTracksEvent( 'calypso_a4a_amplify_faq_close', {
+						faq_id: id,
+					} )
+				);
+			}
+		},
+		[ dispatch ]
+	);
+
+	return (
+		<PageSection
+			heading={ __( 'Frequently asked questions' ) }
+			description={ __( 'Curious about the details? We have answers.' ) }
+		>
+			<ul className="amplify-faqs">
+				{ FAQS.map( ( faq ) => (
+					<li key={ faq.id }>
+						<FoldableFAQ
+							id={ faq.id }
+							question={ faq.question }
+							onToggle={ onFaqToggle }
+							className="amplify-faqs__section"
+						>
+							{ faq.answer }
+						</FoldableFAQ>
+					</li>
+				) ) }
+			</ul>
+		</PageSection>
+	);
+}

--- a/client/a8c-for-agencies/sections/amplify/amplify-how-it-works.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-how-it-works.tsx
@@ -1,6 +1,9 @@
+import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useState } from 'react';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 type Mode = 'human' | 'ai';
 
@@ -117,7 +120,21 @@ function HowMockSite() {
 }
 
 export default function AmplifyHowItWorks() {
+	const dispatch = useDispatch();
 	const [ mode, setMode ] = useState< Mode >( 'human' );
+
+	const handleModeChange = ( nextMode: Mode ) => {
+		if ( nextMode === mode ) {
+			return;
+		}
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_amplify_mode_toggle', {
+				mode: nextMode,
+				surface: 'how_it_works',
+			} )
+		);
+		setMode( nextMode );
+	};
 
 	const modes: Record< Mode, ModeData > = {
 		human: {
@@ -187,28 +204,26 @@ export default function AmplifyHowItWorks() {
 					role="tablist"
 					aria-label={ __( 'Preview mode' ) }
 				>
-					<button
-						type="button"
+					<Button
 						role="tab"
 						aria-selected={ mode === 'human' }
 						className={ clsx( 'amplify-landing-how-mode-btn', {
 							'is-active': mode === 'human',
 						} ) }
-						onClick={ () => setMode( 'human' ) }
+						onClick={ () => handleModeChange( 'human' ) }
 					>
 						{ __( 'Human-centric analysis' ) }
-					</button>
-					<button
-						type="button"
+					</Button>
+					<Button
 						role="tab"
 						aria-selected={ mode === 'ai' }
 						className={ clsx( 'amplify-landing-how-mode-btn', {
 							'is-active': mode === 'ai',
 						} ) }
-						onClick={ () => setMode( 'ai' ) }
+						onClick={ () => handleModeChange( 'ai' ) }
 					>
 						{ __( 'AI analysis' ) }
-					</button>
+					</Button>
 				</div>
 			</div>
 

--- a/client/a8c-for-agencies/sections/amplify/amplify-how-it-works.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-how-it-works.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useState } from 'react';
 import { useDispatch } from 'calypso/state';
@@ -13,8 +13,36 @@ type Pin = {
 	top: string;
 	left: string;
 	label: string;
+	/**
+	 * Criterion name from the Amplify scoring rubric (Trust Signals, Audience
+	 * Resonance, etc.). Rendered as an eyebrow tag above the pin label so the
+	 * demo visibly maps each finding to the framework it scores against. Keep
+	 * these in sync with the rubric in skills/human/SKILL.md and skills/ai/SKILL.md.
+	 */
+	criterion: string;
 	severity: Severity;
+	/**
+	 * Score impact for this finding in the rubric. Negative for points lost,
+	 * positive for points earned. Magnitude reflects the max points of the
+	 * underlying signal (or partial credit if applicable). Rendered inline next
+	 * to the label so viewers see how findings ladder up to the total score.
+	 */
+	pointsImpact: number;
 };
+
+function formatPointsImpact( pts: number ): string {
+	if ( pts === 0 ) {
+		return '';
+	}
+	const abs = Math.abs( pts );
+	const sign = pts > 0 ? '+' : '−';
+	return sprintf(
+		// translators: %1$s is a +/− sign, %2$d is the absolute point value.
+		_n( '%1$s%2$d pt', '%1$s%2$d pts', abs ),
+		sign,
+		abs
+	);
+}
 
 type Bar = {
 	label: string;
@@ -120,6 +148,8 @@ function HowMockSite() {
 }
 
 // Hoisted to module scope — static demo data, no reason to reallocate on every render.
+// Pin labels and criteria mirror the real scoring rubric in skills/human/SKILL.md
+// and skills/ai/SKILL.md so the demo reflects what the tool actually measures.
 const MODES: Record< Mode, ModeData > = {
 	human: {
 		score: 86,
@@ -127,23 +157,62 @@ const MODES: Record< Mode, ModeData > = {
 		modeLabel: __( 'Human-centric analysis' ),
 		improveLabel: __( 'Improve for humans' ),
 		pins: [
-			{ top: '14%', left: '7%', label: __( 'Headline could be sharper' ), severity: 'warn' },
-			{ top: '5%', left: '58%', label: __( 'Nav links not descriptive' ), severity: 'warn' },
+			{
+				top: '14%',
+				left: '7%',
+				label: __( 'Hero headline too vague' ),
+				criterion: __( 'Audience Resonance' ),
+				severity: 'warn',
+				pointsImpact: -1,
+			},
+			{
+				top: '5%',
+				left: '58%',
+				label: __( '4 nav items: focused choices' ),
+				criterion: __( 'Design & Experience' ),
+				severity: 'good',
+				pointsImpact: 1,
+			},
 			{
 				top: '33%',
 				left: '7%',
-				label: __( 'No social proof above the fold' ),
+				label: __( 'No client logos visible' ),
+				criterion: __( 'Trust Signals' ),
 				severity: 'danger',
+				pointsImpact: -2,
 			},
-			{ top: '44%', left: '7%', label: __( 'CTA copy lacks urgency' ), severity: 'warn' },
+			{
+				top: '44%',
+				left: '7%',
+				label: __( 'CTA copy is generic' ),
+				criterion: __( 'Contact & Conversion' ),
+				severity: 'warn',
+				pointsImpact: -2,
+			},
 			{
 				top: '22%',
 				left: '60%',
-				label: __( 'Hero clashes with site palette' ),
+				label: __( 'Aesthetic polish: adequate' ),
+				criterion: __( 'Design & Experience' ),
 				severity: 'warn',
+				pointsImpact: -1,
 			},
-			{ top: '75%', left: '6%', label: __( 'Portfolio quality: solid' ), severity: 'good' },
-			{ top: '77%', left: '38%', label: __( 'Missing testimonials' ), severity: 'danger' },
+			{
+				top: '75%',
+				left: '6%',
+				label: __( 'Case studies linked' ),
+				criterion: __( 'Trust Signals' ),
+				severity: 'good',
+				pointsImpact: 1,
+			},
+			{
+				top: '77%',
+				left: '38%',
+				label: __( 'No testimonials with attribution' ),
+				criterion: __( 'Trust Signals' ),
+				severity: 'danger',
+				pointsImpact: -3,
+			},
 		],
 		bars: [
 			{ label: __( 'Trust signals' ), value: 89 },
@@ -157,13 +226,62 @@ const MODES: Record< Mode, ModeData > = {
 		modeLabel: __( 'AI analysis' ),
 		improveLabel: __( 'Improve for AI' ),
 		pins: [
-			{ top: '14%', left: '7%', label: __( 'H1 missing schema markup' ), severity: 'danger' },
-			{ top: '5%', left: '50%', label: __( 'Entity type undefined' ), severity: 'danger' },
-			{ top: '27%', left: '7%', label: __( 'Thin content detected' ), severity: 'warn' },
-			{ top: '44%', left: '7%', label: __( 'No FAQ structured data' ), severity: 'danger' },
-			{ top: '22%', left: '60%', label: __( 'No breadcrumb schema' ), severity: 'warn' },
-			{ top: '75%', left: '6%', label: __( 'Content freshness: stale' ), severity: 'warn' },
-			{ top: '77%', left: '38%', label: __( 'AEO readiness: 38%' ), severity: 'danger' },
+			{
+				top: '14%',
+				left: '7%',
+				label: __( 'Organization schema missing' ),
+				criterion: __( 'Structured Data' ),
+				severity: 'danger',
+				pointsImpact: -5,
+			},
+			{
+				top: '5%',
+				left: '50%',
+				label: __( 'Clear entity identity' ),
+				criterion: __( 'Entity Clarity' ),
+				severity: 'good',
+				pointsImpact: 3,
+			},
+			{
+				top: '27%',
+				left: '7%',
+				label: __( 'Service detail too thin' ),
+				criterion: __( 'Content Specificity' ),
+				severity: 'warn',
+				pointsImpact: -1,
+			},
+			{
+				top: '44%',
+				left: '7%',
+				label: __( 'No FAQ schema' ),
+				criterion: __( 'Structured Data' ),
+				severity: 'danger',
+				pointsImpact: -3,
+			},
+			{
+				top: '22%',
+				left: '60%',
+				label: __( 'GPTBot blocked in robots.txt' ),
+				criterion: __( 'Technical Health' ),
+				severity: 'danger',
+				pointsImpact: -7,
+			},
+			{
+				top: '75%',
+				left: '6%',
+				label: __( 'Copyright year current' ),
+				criterion: __( 'Content Freshness' ),
+				severity: 'good',
+				pointsImpact: 3,
+			},
+			{
+				top: '77%',
+				left: '38%',
+				label: __( 'No question-framed headings' ),
+				criterion: __( 'AEO Readiness' ),
+				severity: 'danger',
+				pointsImpact: -2,
+			},
 		],
 		bars: [
 			{ label: __( 'Technical health' ), value: 60 },
@@ -198,7 +316,9 @@ export default function AmplifyHowItWorks() {
 			<div className="amplify-landing-how-header">
 				<div>
 					<p className="amplify-landing-how-eyebrow">{ __( 'How it works' ) }</p>
-					<h2 className="amplify-landing-how-title">{ __( 'See it in action' ) }</h2>
+					<h2 className="amplify-landing-how-title">
+						{ __( 'Two lenses. One complete picture.' ) }
+					</h2>
 				</div>
 				<div
 					className="amplify-landing-how-mode-toggle"
@@ -256,7 +376,13 @@ export default function AmplifyHowItWorks() {
 							>
 								<div className={ clsx( 'amplify-landing-how-pin-dot', pin.severity ) } />
 								<div className={ clsx( 'amplify-landing-how-pin-label', pin.severity ) }>
-									{ pin.label }
+									<span className="amplify-landing-how-pin-label-criterion">{ pin.criterion }</span>
+									<span className="amplify-landing-how-pin-label-text">
+										{ pin.label }
+										<span className="amplify-landing-how-pin-label-score">
+											{ formatPointsImpact( pin.pointsImpact ) }
+										</span>
+									</span>
 								</div>
 							</div>
 						) ) }

--- a/client/a8c-for-agencies/sections/amplify/amplify-how-it-works.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-how-it-works.tsx
@@ -246,7 +246,7 @@ export default function AmplifyHowItWorks() {
 					<div className="amplify-landing-how-pins" aria-hidden="true">
 						{ data.pins.map( ( pin, index ) => (
 							<div
-								key={ `${ mode }-${ index }-${ pin.label }` }
+								key={ `${ mode }-${ index }` }
 								className="amplify-landing-how-pin is-visible"
 								style={ {
 									insetBlockStart: pin.top,

--- a/client/a8c-for-agencies/sections/amplify/amplify-how-it-works.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-how-it-works.tsx
@@ -119,6 +119,60 @@ function HowMockSite() {
 	);
 }
 
+// Hoisted to module scope — static demo data, no reason to reallocate on every render.
+const MODES: Record< Mode, ModeData > = {
+	human: {
+		score: 86,
+		thresholdLabel: __( 'Strong' ),
+		modeLabel: __( 'Human-centric analysis' ),
+		improveLabel: __( 'Improve for humans' ),
+		pins: [
+			{ top: '14%', left: '7%', label: __( 'Headline could be sharper' ), severity: 'warn' },
+			{ top: '5%', left: '58%', label: __( 'Nav links not descriptive' ), severity: 'warn' },
+			{
+				top: '33%',
+				left: '7%',
+				label: __( 'No social proof above the fold' ),
+				severity: 'danger',
+			},
+			{ top: '44%', left: '7%', label: __( 'CTA copy lacks urgency' ), severity: 'warn' },
+			{
+				top: '22%',
+				left: '60%',
+				label: __( 'Hero clashes with site palette' ),
+				severity: 'warn',
+			},
+			{ top: '75%', left: '6%', label: __( 'Portfolio quality: solid' ), severity: 'good' },
+			{ top: '77%', left: '38%', label: __( 'Missing testimonials' ), severity: 'danger' },
+		],
+		bars: [
+			{ label: __( 'Trust signals' ), value: 89 },
+			{ label: __( 'Mobile experience' ), value: 92 },
+			{ label: __( 'SEO' ), value: 77 },
+		],
+	},
+	ai: {
+		score: 42,
+		thresholdLabel: __( 'At risk' ),
+		modeLabel: __( 'AI analysis' ),
+		improveLabel: __( 'Improve for AI' ),
+		pins: [
+			{ top: '14%', left: '7%', label: __( 'H1 missing schema markup' ), severity: 'danger' },
+			{ top: '5%', left: '50%', label: __( 'Entity type undefined' ), severity: 'danger' },
+			{ top: '27%', left: '7%', label: __( 'Thin content detected' ), severity: 'warn' },
+			{ top: '44%', left: '7%', label: __( 'No FAQ structured data' ), severity: 'danger' },
+			{ top: '22%', left: '60%', label: __( 'No breadcrumb schema' ), severity: 'warn' },
+			{ top: '75%', left: '6%', label: __( 'Content freshness: stale' ), severity: 'warn' },
+			{ top: '77%', left: '38%', label: __( 'AEO readiness: 38%' ), severity: 'danger' },
+		],
+		bars: [
+			{ label: __( 'Technical health' ), value: 60 },
+			{ label: __( 'AEO readiness' ), value: 38 },
+			{ label: __( 'Structured data' ), value: 33 },
+		],
+	},
+};
+
 export default function AmplifyHowItWorks() {
 	const dispatch = useDispatch();
 	const [ mode, setMode ] = useState< Mode >( 'human' );
@@ -136,60 +190,7 @@ export default function AmplifyHowItWorks() {
 		setMode( nextMode );
 	};
 
-	const modes: Record< Mode, ModeData > = {
-		human: {
-			score: 86,
-			thresholdLabel: __( 'Strong' ),
-			modeLabel: __( 'Human-centric analysis' ),
-			improveLabel: __( 'Improve for humans' ),
-			pins: [
-				{ top: '14%', left: '7%', label: __( 'Headline could be sharper' ), severity: 'warn' },
-				{ top: '5%', left: '58%', label: __( 'Nav links not descriptive' ), severity: 'warn' },
-				{
-					top: '33%',
-					left: '7%',
-					label: __( 'No social proof above the fold' ),
-					severity: 'danger',
-				},
-				{ top: '44%', left: '7%', label: __( 'CTA copy lacks urgency' ), severity: 'warn' },
-				{
-					top: '22%',
-					left: '60%',
-					label: __( 'Hero clashes with site palette' ),
-					severity: 'warn',
-				},
-				{ top: '75%', left: '6%', label: __( 'Portfolio quality: solid' ), severity: 'good' },
-				{ top: '77%', left: '38%', label: __( 'Missing testimonials' ), severity: 'danger' },
-			],
-			bars: [
-				{ label: __( 'Trust signals' ), value: 89 },
-				{ label: __( 'Mobile experience' ), value: 92 },
-				{ label: __( 'SEO' ), value: 77 },
-			],
-		},
-		ai: {
-			score: 42,
-			thresholdLabel: __( 'At risk' ),
-			modeLabel: __( 'AI analysis' ),
-			improveLabel: __( 'Improve for AI' ),
-			pins: [
-				{ top: '14%', left: '7%', label: __( 'H1 missing schema markup' ), severity: 'danger' },
-				{ top: '5%', left: '50%', label: __( 'Entity type undefined' ), severity: 'danger' },
-				{ top: '27%', left: '7%', label: __( 'Thin content detected' ), severity: 'warn' },
-				{ top: '44%', left: '7%', label: __( 'No FAQ structured data' ), severity: 'danger' },
-				{ top: '22%', left: '60%', label: __( 'No breadcrumb schema' ), severity: 'warn' },
-				{ top: '75%', left: '6%', label: __( 'Content freshness: stale' ), severity: 'warn' },
-				{ top: '77%', left: '38%', label: __( 'AEO readiness: 38%' ), severity: 'danger' },
-			],
-			bars: [
-				{ label: __( 'Technical health' ), value: 60 },
-				{ label: __( 'AEO readiness' ), value: 38 },
-				{ label: __( 'Structured data' ), value: 33 },
-			],
-		},
-	};
-
-	const data = modes[ mode ];
+	const data = MODES[ mode ];
 	const ringSeverity = severityFor( data.score );
 
 	return (

--- a/client/a8c-for-agencies/sections/amplify/amplify-how-it-works.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-how-it-works.tsx
@@ -1,0 +1,287 @@
+import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
+import { useState } from 'react';
+
+type Mode = 'human' | 'ai';
+
+type Severity = 'good' | 'warn' | 'danger';
+
+type Pin = {
+	top: string;
+	left: string;
+	label: string;
+	severity: Severity;
+};
+
+type Bar = {
+	label: string;
+	value: number;
+};
+
+type ModeData = {
+	score: number;
+	thresholdLabel: string;
+	modeLabel: string;
+	improveLabel: string;
+	pins: Pin[];
+	bars: Bar[];
+};
+
+function severityFor( value: number ): Severity {
+	if ( value >= 80 ) {
+		return 'good';
+	}
+	if ( value >= 50 ) {
+		return 'warn';
+	}
+	return 'danger';
+}
+
+// Mock agency site shown inside the browser frame. This is decorative example
+// content meant to look like a real agency homepage; it isn't translated.
+function HowMockSite() {
+	return (
+		<div className="amplify-landing-how-mock" aria-hidden="true">
+			<nav className="amplify-landing-how-mock-nav">
+				<div className="amplify-landing-how-mock-logo">
+					<div className="amplify-landing-how-mock-logo-mark">CS</div>
+					<span className="amplify-landing-how-mock-logo-name">Crestline Studio</span>
+				</div>
+				<div className="amplify-landing-how-mock-nav-links">
+					<span>Work</span>
+					<span>Services</span>
+					<span>Studio</span>
+					<span>Contact</span>
+				</div>
+				<div className="amplify-landing-how-mock-nav-cta">Start a project</div>
+			</nav>
+
+			<div className="amplify-landing-how-mock-hero">
+				<div>
+					<div className="amplify-landing-how-mock-hero-eyebrow">Digital agency · Est. 2016</div>
+					<div className="amplify-landing-how-mock-hero-h1">
+						We build brands
+						<br />
+						that win online.
+					</div>
+					<div className="amplify-landing-how-mock-hero-sub">
+						Crestline partners with ambitious companies to craft digital experiences that drive
+						real, measurable growth.
+					</div>
+					<div className="amplify-landing-how-mock-cta-row">
+						<div className="amplify-landing-how-mock-btn-dark">See our work</div>
+						<div className="amplify-landing-how-mock-btn-outline">Get in touch</div>
+					</div>
+				</div>
+				<div className="amplify-landing-how-mock-hero-right">
+					<div className="amplify-landing-how-mock-stat-label">Avg. client growth</div>
+					<div className="amplify-landing-how-mock-stat-num">+143%</div>
+					<div className="amplify-landing-how-mock-stat-sub">in the first 12 months</div>
+				</div>
+			</div>
+
+			<div className="amplify-landing-how-mock-projects">
+				<div className="amplify-landing-how-mock-card">
+					<div
+						className="amplify-landing-how-mock-card-thumb"
+						style={ { background: 'linear-gradient(135deg, #1e3a5f, #2d6a9f)' } }
+					/>
+					<div className="amplify-landing-how-mock-card-body">
+						<div className="amplify-landing-how-mock-card-client">Fintech</div>
+						<div className="amplify-landing-how-mock-card-title">Vaultr: Brand & Web Redesign</div>
+					</div>
+				</div>
+				<div className="amplify-landing-how-mock-card">
+					<div
+						className="amplify-landing-how-mock-card-thumb"
+						style={ { background: 'linear-gradient(135deg, #3d1f5c, #7c3aed)' } }
+					/>
+					<div className="amplify-landing-how-mock-card-body">
+						<div className="amplify-landing-how-mock-card-client">SaaS</div>
+						<div className="amplify-landing-how-mock-card-title">Loopkit Growth Site</div>
+					</div>
+				</div>
+				<div className="amplify-landing-how-mock-card">
+					<div
+						className="amplify-landing-how-mock-card-thumb"
+						style={ { background: 'linear-gradient(135deg, #0f3d2e, #059669)' } }
+					/>
+					<div className="amplify-landing-how-mock-card-body">
+						<div className="amplify-landing-how-mock-card-client">E-commerce</div>
+						<div className="amplify-landing-how-mock-card-title">Brightly: Store & Brand</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export default function AmplifyHowItWorks() {
+	const [ mode, setMode ] = useState< Mode >( 'human' );
+
+	const modes: Record< Mode, ModeData > = {
+		human: {
+			score: 86,
+			thresholdLabel: __( 'Strong' ),
+			modeLabel: __( 'Human-centric analysis' ),
+			improveLabel: __( 'Improve for humans' ),
+			pins: [
+				{ top: '14%', left: '7%', label: __( 'Headline could be sharper' ), severity: 'warn' },
+				{ top: '5%', left: '58%', label: __( 'Nav links not descriptive' ), severity: 'warn' },
+				{
+					top: '33%',
+					left: '7%',
+					label: __( 'No social proof above the fold' ),
+					severity: 'danger',
+				},
+				{ top: '44%', left: '7%', label: __( 'CTA copy lacks urgency' ), severity: 'warn' },
+				{
+					top: '22%',
+					left: '60%',
+					label: __( 'Hero clashes with site palette' ),
+					severity: 'warn',
+				},
+				{ top: '75%', left: '6%', label: __( 'Portfolio quality: solid' ), severity: 'good' },
+				{ top: '77%', left: '38%', label: __( 'Missing testimonials' ), severity: 'danger' },
+			],
+			bars: [
+				{ label: __( 'Trust signals' ), value: 89 },
+				{ label: __( 'Mobile experience' ), value: 92 },
+				{ label: __( 'SEO' ), value: 77 },
+			],
+		},
+		ai: {
+			score: 42,
+			thresholdLabel: __( 'At risk' ),
+			modeLabel: __( 'AI analysis' ),
+			improveLabel: __( 'Improve for AI' ),
+			pins: [
+				{ top: '14%', left: '7%', label: __( 'H1 missing schema markup' ), severity: 'danger' },
+				{ top: '5%', left: '50%', label: __( 'Entity type undefined' ), severity: 'danger' },
+				{ top: '27%', left: '7%', label: __( 'Thin content detected' ), severity: 'warn' },
+				{ top: '44%', left: '7%', label: __( 'No FAQ structured data' ), severity: 'danger' },
+				{ top: '22%', left: '60%', label: __( 'No breadcrumb schema' ), severity: 'warn' },
+				{ top: '75%', left: '6%', label: __( 'Content freshness: stale' ), severity: 'warn' },
+				{ top: '77%', left: '38%', label: __( 'AEO readiness: 38%' ), severity: 'danger' },
+			],
+			bars: [
+				{ label: __( 'Technical health' ), value: 60 },
+				{ label: __( 'AEO readiness' ), value: 38 },
+				{ label: __( 'Structured data' ), value: 33 },
+			],
+		},
+	};
+
+	const data = modes[ mode ];
+	const ringSeverity = severityFor( data.score );
+
+	return (
+		<div className="amplify-landing-how">
+			<div className="amplify-landing-how-header">
+				<div>
+					<p className="amplify-landing-how-eyebrow">{ __( 'How it works' ) }</p>
+					<h2 className="amplify-landing-how-title">{ __( 'See it in action' ) }</h2>
+				</div>
+				<div
+					className="amplify-landing-how-mode-toggle"
+					role="tablist"
+					aria-label={ __( 'Preview mode' ) }
+				>
+					<button
+						type="button"
+						role="tab"
+						aria-selected={ mode === 'human' }
+						className={ clsx( 'amplify-landing-how-mode-btn', {
+							'is-active': mode === 'human',
+						} ) }
+						onClick={ () => setMode( 'human' ) }
+					>
+						{ __( 'Human-centric analysis' ) }
+					</button>
+					<button
+						type="button"
+						role="tab"
+						aria-selected={ mode === 'ai' }
+						className={ clsx( 'amplify-landing-how-mode-btn', {
+							'is-active': mode === 'ai',
+						} ) }
+						onClick={ () => setMode( 'ai' ) }
+					>
+						{ __( 'AI analysis' ) }
+					</button>
+				</div>
+			</div>
+
+			<div className="amplify-landing-how-browser">
+				<div className="amplify-landing-how-browser-chrome">
+					<div className="amplify-landing-how-browser-dots">
+						<span className="amplify-landing-how-browser-dot is-r" />
+						<span className="amplify-landing-how-browser-dot is-y" />
+						<span className="amplify-landing-how-browser-dot is-g" />
+					</div>
+					<div className="amplify-landing-how-browser-address">
+						<div className="amplify-landing-how-browser-bar">crestlinestudio.com</div>
+					</div>
+				</div>
+
+				<div className="amplify-landing-how-preview">
+					<HowMockSite />
+
+					<div className="amplify-landing-how-pins" aria-hidden="true">
+						{ data.pins.map( ( pin, index ) => (
+							<div
+								key={ `${ mode }-${ index }-${ pin.label }` }
+								className="amplify-landing-how-pin is-visible"
+								style={ {
+									insetBlockStart: pin.top,
+									insetInlineStart: pin.left,
+									transitionDelay: `${ index * 60 }ms`,
+								} }
+							>
+								<div className={ clsx( 'amplify-landing-how-pin-dot', pin.severity ) } />
+								<div className={ clsx( 'amplify-landing-how-pin-label', pin.severity ) }>
+									{ pin.label }
+								</div>
+							</div>
+						) ) }
+					</div>
+
+					<div className="amplify-landing-how-overlay">
+						<div className="amplify-landing-how-overlay-mode">{ data.modeLabel }</div>
+						<div className="amplify-landing-how-overlay-score-row">
+							<span className={ clsx( 'amplify-landing-how-overlay-num', ringSeverity ) }>
+								{ data.score }
+							</span>
+							<span className="amplify-landing-how-overlay-of">/ 100</span>
+						</div>
+						<div className={ clsx( 'amplify-landing-how-overlay-title', ringSeverity ) }>
+							{ data.thresholdLabel }
+						</div>
+						<div className="amplify-landing-how-overlay-bars">
+							{ data.bars.map( ( bar ) => {
+								const sev = severityFor( bar.value );
+								return (
+									<div key={ bar.label } className="amplify-landing-how-overlay-row">
+										<span className="amplify-landing-how-overlay-row-label">{ bar.label }</span>
+										<div className="amplify-landing-how-overlay-track">
+											<div
+												className={ clsx( 'amplify-landing-how-overlay-fill', sev ) }
+												style={ { inlineSize: `${ bar.value }%` } }
+											/>
+										</div>
+										<span className={ clsx( 'amplify-landing-how-overlay-val', sev ) }>
+											{ bar.value }
+										</span>
+									</div>
+								);
+							} ) }
+						</div>
+						<button type="button" className="amplify-landing-how-overlay-btn">
+							{ data.improveLabel }
+						</button>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/amplify/amplify-human-section.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-human-section.tsx
@@ -1,0 +1,273 @@
+import { __ } from '@wordpress/i18n';
+
+type Criterion = {
+	id: string;
+	num: string;
+	title: string;
+	points: number;
+	summary: string;
+	why: string;
+	signals: string[];
+	stats: string[];
+};
+
+const CRITERIA: Criterion[] = [
+	{
+		id: 'trust-signals',
+		num: '01',
+		title: __( 'Trust Signals' ),
+		points: 18,
+		summary: __(
+			'Does the site give a prospective client enough evidence to feel safe handing over a project?'
+		),
+		why: __(
+			'Trust is the gate before every conversion. No amount of good design overcomes a site that fails to prove the agency is real, credible, and experienced.'
+		),
+		signals: [
+			__( 'Testimonials — attributed, with name, company, and photo' ),
+			__( 'Case studies with quantified outcomes' ),
+			__( 'Client logos from recognizable brands' ),
+			__( 'Results and metrics ("increased conversions by 40%")' ),
+			__( 'Social proof volume — 5+ reviews' ),
+			__( 'Awards and third-party recognition' ),
+			__( 'Team or About page presence' ),
+			__( 'Years in business or client count' ),
+		],
+		stats: [
+			__( '72% of consumers find testimonials more credible than brand claims' ),
+			__( 'Testimonials drive a 34% increase in conversions on sales pages' ),
+			__( '5+ reviews makes a service 270% more likely to convert' ),
+		],
+	},
+	{
+		id: 'contact-conversion',
+		num: '02',
+		title: __( 'Contact & Conversion' ),
+		points: 15,
+		summary: __(
+			'A prospective client is ready to reach out. Does the site make that easy, or create friction at the worst possible moment?'
+		),
+		why: __(
+			'The best-designed site in the world loses business if a motivated prospect cannot figure out how to contact the agency in under ten seconds.'
+		),
+		signals: [
+			__( 'Primary CTA visible above the fold' ),
+			__( 'Form field count — 4 or fewer for maximum conversion' ),
+			__( 'Contact information present and findable' ),
+			__( 'CTA repeated near the bottom of the page' ),
+			__( 'CTA copy clarity — specific and action-oriented' ),
+			__( 'Response time promise near the contact form' ),
+		],
+		stats: [
+			__( 'Above-fold CTAs outperform below-fold by 304%' ),
+			__( 'Action-oriented CTAs convert 121% more than passive ones' ),
+			__( 'Reducing a form from 11 to 4 fields increases conversions by 120%' ),
+		],
+	},
+	{
+		id: 'seo',
+		num: '03',
+		title: __( 'SEO' ),
+		points: 13,
+		summary: __(
+			'Can a prospective client find this site when they search? All signals are sourced from Google Search Central documentation.'
+		),
+		why: __(
+			'Discoverability is the prerequisite for everything else. A site no one can find cannot convert anyone.'
+		),
+		signals: [
+			__( 'H1 present and heading hierarchy logical' ),
+			__( 'Title tag — unique, under 60 characters, keyword-relevant' ),
+			__( 'Meta description — present, under 160 characters' ),
+			__( 'Image alt text on all meaningful images' ),
+			__( 'robots.txt — not blocking crawlers' ),
+			__( 'Canonical tag — self-referencing' ),
+			__( 'Structured data present on the homepage' ),
+			__( 'No intrusive interstitials on mobile' ),
+		],
+		stats: [
+			__( 'A misconfigured robots.txt can silently remove a site from all search results' ),
+			__( 'Missing alt text means crawlers see blank spaces where your best content should be' ),
+		],
+	},
+	{
+		id: 'mobile-experience',
+		num: '04',
+		title: __( 'Mobile Experience' ),
+		points: 13,
+		summary: __(
+			'A first impression increasingly happens on a phone. Does the site hold up when a prospective client pulls it up on their device?'
+		),
+		why: __(
+			'More than 62% of web traffic is mobile. A site that breaks on a phone is a site that loses the majority of its visitors before they form any opinion at all.'
+		),
+		signals: [
+			__( 'Touch targets — minimum 48×48px with 8px spacing' ),
+			__( 'Body font size — 16px minimum (below this, iOS Safari auto-zooms)' ),
+			__( 'No horizontal overflow or forced scrolling' ),
+			__( 'Responsive breakpoints present in CSS' ),
+			__( 'No intrusive interstitials covering content on mobile' ),
+			__( 'Navigation collapses usably on small screens' ),
+			__( 'Content legibility at mobile viewport' ),
+		],
+		stats: [
+			__( 'Mobile accounts for 62 to 64% of global web traffic as of 2026' ),
+			__( 'Google penalizes intrusive interstitials in mobile rankings' ),
+		],
+	},
+	{
+		id: 'content-quality',
+		num: '05',
+		title: __( 'Content Quality' ),
+		points: 12,
+		summary: __(
+			'Is the writing compelling, clear, and professional? Errors and poor readability erode trust before a client has read a single sentence.'
+		),
+		why: __(
+			"Copy errors are trust killers. Before a prospective client evaluates the agency's work, they read the agency's words. Mistakes in those words signal carelessness in everything else."
+		),
+		signals: [
+			__( 'Flesch Reading Ease score — 60 to 70 target (8th to 9th grade)' ),
+			__( 'Sentence and paragraph length — scannable, not walls of text' ),
+			__( 'Grammar and spelling — AI-checked for visible errors' ),
+			__( 'Sufficient content volume for context' ),
+			__( 'Heading usage for scannability' ),
+			__( 'Low passive voice density' ),
+			__( 'Low buzzword and jargon density' ),
+		],
+		stats: [
+			__( '97.2% of people say grammar influences their perception of a company' ),
+			__( '59% of consumers are less likely to trust a brand with copy errors' ),
+			__( 'Pages with spelling errors have 85% higher bounce rates' ),
+		],
+	},
+	{
+		id: 'design-experience',
+		num: '06',
+		title: __( 'Design & Experience' ),
+		points: 11,
+		summary: __(
+			'Does the site look credible and feel effortless to use? All signals are grounded in the Laws of UX.'
+		),
+		why: __(
+			'Visual polish builds immediate trust and is perceived as more capable, even before a word is read. Low visual quality is often the unconscious reason a visitor bounces within the first five seconds.'
+		),
+		signals: [
+			__( "Hick's Law — nav item count and choice overload" ),
+			__( "Fitts's Law — CTA button size and tap target spacing" ),
+			__( "Jakob's Law — standard pattern conformance (logo, nav, footer)" ),
+			__( 'Serial Position Effect — key content placement first and last' ),
+			__( 'Aesthetic-Usability Effect — overall visual polish from screenshot' ),
+			__( 'Von Restorff Effect — primary CTA visually differentiated' ),
+			__( 'Peak-End Rule — hero quality and final CTA evaluation' ),
+			__( 'Gestalt Laws — layout grouping and visual clarity' ),
+		],
+		stats: [
+			__( '75% of consumers judge credibility based on website design alone' ),
+			__( 'First impressions form in as little as 50 milliseconds' ),
+		],
+	},
+	{
+		id: 'accessibility',
+		num: '07',
+		title: __( 'Accessibility' ),
+		points: 10,
+		summary: __(
+			'Does the site work for everyone? Amplify measures against WCAG AA, the standard referenced by courts and regulators globally.'
+		),
+		why: __(
+			'Accessibility is not a nice-to-have. It is a legal standard in most jurisdictions, and a signal to search engines and AI tools that the site was built with care.'
+		),
+		signals: [
+			__( 'Image alt text — WCAG 1.1.1' ),
+			__( 'Color contrast ratio — 4.5:1 minimum — WCAG 1.4.3' ),
+			__( 'Form labels on all input fields — WCAG 1.3.1' ),
+			__( 'Language attribute on <html> — WCAG 3.1.1' ),
+			__( 'Skip navigation link — WCAG 2.4.1' ),
+			__( 'No auto-playing media — WCAG 1.4.2' ),
+			__( 'Heading levels not skipped — WCAG 1.3.1' ),
+			__( 'Focus indicators on interactive elements — WCAG 2.4.7' ),
+		],
+		stats: [
+			__(
+				'WCAG AA is the legal accessibility standard across the EU, UK, US, Canada, and Australia'
+			),
+		],
+	},
+	{
+		id: 'audience-resonance',
+		num: '08',
+		title: __( 'Audience Resonance' ),
+		points: 8,
+		summary: __(
+			'Does the site feel made for the right client? Within seconds of landing, a prospective client should feel the site is speaking directly to them.'
+		),
+		why: __(
+			'Generic copy describes every agency equally, which differentiates none of them. Specific messaging creates the "that\'s me" feeling that generic copy cannot replicate. That feeling is what turns a browse into an enquiry.'
+		),
+		signals: [
+			__(
+				'5-second clarity test — what does this agency do, who do they serve, why should I care?'
+			),
+			__( 'Audience specificity — a specific type of client, industry, or pain point' ),
+			__( 'Pain point language — in the words real clients would use' ),
+			__( 'Generic claim detection — "results-driven," "passionate," "full-service"' ),
+			__( 'Hero headline clarity — value proposition in the H1' ),
+			__( 'Above-fold content presence — text visible without scrolling' ),
+		],
+		stats: [
+			__( 'Specific, targeted messaging converts 202% better than generic copy' ),
+			__( 'Only 13% of customers feel brands truly understand their needs' ),
+			__( 'Users give a homepage 3 to 5 seconds to earn their trust' ),
+		],
+	},
+];
+
+export default function AmplifyHumanSection() {
+	return (
+		<div className="amplify-criteria-section">
+			<div className="amplify-criteria-section-header">
+				<p className="amplify-criteria-eyebrow">{ __( 'Human-centric analysis' ) }</p>
+				<h2 className="amplify-criteria-title">{ __( 'See what prospective clients see' ) }</h2>
+				<p className="amplify-criteria-intro">
+					{ __(
+						"When someone lands on your client's site, they form an impression in under a second. They scan for trust. They look for contact information. They decide, in 3 to 5 seconds, whether this business is worth their time. Amplify measures all of it across eight criteria, then tells you exactly what to fix and why. This is the analysis that separates agencies who deliver beautiful sites from agencies who deliver sites that actually win business."
+					) }
+				</p>
+
+				{ /* ── 3 HERO STATS ── */ }
+				<div className="amplify-criteria-stats">
+					<div className="amplify-criteria-stat">
+						<span className="amplify-criteria-stat-num">50ms</span>
+						<span className="amplify-criteria-stat-label">
+							{ __( 'Time it takes to form a first impression' ) }
+						</span>
+					</div>
+					<div className="amplify-criteria-stat">
+						<span className="amplify-criteria-stat-num">75%</span>
+						<span className="amplify-criteria-stat-label">
+							{ __( 'Of consumers judge credibility by design alone' ) }
+						</span>
+					</div>
+					<div className="amplify-criteria-stat">
+						<span className="amplify-criteria-stat-num">34%</span>
+						<span className="amplify-criteria-stat-label">
+							{ __( 'Average conversion lift from testimonials on sales pages' ) }
+						</span>
+					</div>
+				</div>
+			</div>
+
+			{ /* ── CRITERIA CARDS ── */ }
+			<div className="amplify-criteria-cards">
+				{ CRITERIA.map( ( c ) => (
+					<div key={ c.id } className="amplify-criteria-card">
+						<span className="amplify-criteria-card-num">{ c.num }</span>
+						<h3 className="amplify-criteria-card-title">{ c.title }</h3>
+						<p className="amplify-criteria-card-summary">{ c.summary }</p>
+					</div>
+				) ) }
+			</div>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/amplify/amplify-human-section.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-human-section.tsx
@@ -228,7 +228,7 @@ export default function AmplifyHumanSection() {
 		<div className="amplify-criteria-section">
 			<div className="amplify-criteria-section-header">
 				<p className="amplify-criteria-eyebrow">{ __( 'Human-centric analysis' ) }</p>
-				<h2 className="amplify-criteria-title">{ __( 'See what prospective clients see' ) }</h2>
+				<h2 className="amplify-criteria-title">{ __( 'See what prospective customers see' ) }</h2>
 				<p className="amplify-criteria-intro">
 					{ __(
 						"When someone lands on your client's site, they form an impression in under a second. They scan for trust. They look for contact information. They decide, in 3 to 5 seconds, whether this business is worth their time. Amplify measures all of it across eight criteria, then tells you exactly what to fix and why. This is the analysis that separates agencies who deliver beautiful sites from agencies who deliver sites that actually win business."

--- a/client/a8c-for-agencies/sections/amplify/amplify-human-section.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-human-section.tsx
@@ -203,7 +203,7 @@ const CRITERIA: Criterion[] = [
 			'Does the site feel made for the right client? Within seconds of landing, a prospective client should feel the site is speaking directly to them.'
 		),
 		why: __(
-			'Generic copy describes every agency equally, which differentiates none of them. Specific messaging creates the "that\'s me" feeling that generic copy cannot replicate. That feeling is what turns a browse into an enquiry.'
+			'Generic copy describes every agency equally, which differentiates none of them. Specific messaging creates the "that\'s me" feeling that generic copy cannot replicate. That feeling is what turns a browse into an inquiry.'
 		),
 		signals: [
 			__(

--- a/client/a8c-for-agencies/sections/amplify/amplify-overview-content.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-overview-content.tsx
@@ -1,11 +1,10 @@
 import './style.scss';
 
-import { createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
-import { A4A_AGENCY_TIER_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { __ } from '@wordpress/i18n';
+import AmplifyAiSection from './amplify-ai-section';
 import AmplifyAiWorkflow from './amplify-ai-workflow';
-import AmplifyBenefits from './amplify-benefits';
 import AmplifyHowItWorks from './amplify-how-it-works';
+import AmplifyHumanSection from './amplify-human-section';
 import AmplifyScoreCard from './amplify-score-card';
 import AmplifySiteSelect from './amplify-site-select';
 
@@ -20,42 +19,45 @@ type Props = {
 export default function AmplifyOverviewContent( { onSiteSelected }: Props ) {
 	return (
 		<div className="amplify-landing">
+			{ /* ── HERO ── */ }
 			<section className="amplify-landing-hero">
 				<div className="amplify-landing-hero-text">
 					<h1 className="amplify-landing-h1">
-						{ createInterpolateElement(
-							__( 'Your agency’s website<br />needs to win more clients' ),
-							{ br: <br /> }
-						) }
+						{ __( 'Your clients want more business. Find out what their site is doing about it.' ) }
 					</h1>
 					<p className="amplify-landing-sub">
 						{ __(
-							'First impressions happen fast, and the way clients find you is changing. AI tools now help businesses discover agencies before a single conversation happens. Amplify audits your site through both lenses, then generates precise, agent-ready prompts so you can elevate your site instantly, captivate prospects, and close more deals.'
+							'Amplify scans your clients’ connected sites through two lenses: how their prospective clients perceive them on first visit, and how AI tools like ChatGPT and Perplexity read and rank them. Run a scan in minutes. Find what’s holding them back. Deliver fixes that prove your value and build trust.'
 						) }
 					</p>
 					<AmplifySiteSelect onSiteSelected={ onSiteSelected } />
 					<p className="amplify-landing-usage">
-						{ sprintf(
-							/* translators: %1$d is the number of audits remaining, %2$d is the monthly limit. */
-							__( '%1$d of %2$d audits remaining this month.' ),
-							REMAINING_AUDITS,
-							MONTHLY_AUDIT_LIMIT
-						) }{ ' ' }
-						<a className="amplify-landing-usage-link" href={ A4A_AGENCY_TIER_LINK }>
-							{ __( 'View your tier limits' ) }
-						</a>
+						{ `${ REMAINING_AUDITS } of ${ MONTHLY_AUDIT_LIMIT } ${ __(
+							'scans remaining this month.'
+						) }` }
 					</p>
 				</div>
 				<div className="amplify-landing-hero-visual">
 					<AmplifyScoreCard />
 				</div>
 			</section>
-			<section className="amplify-landing-benefits">
-				<AmplifyBenefits />
-			</section>
+
+			{ /* ── HOW IT WORKS (interactive browser mockup) ── */ }
 			<section className="amplify-landing-how-section">
 				<AmplifyHowItWorks />
 			</section>
+
+			{ /* ── HUMAN-CENTRIC ANALYSIS ── */ }
+			<section className="amplify-landing-human-section">
+				<AmplifyHumanSection />
+			</section>
+
+			{ /* ── AI ANALYSIS ── */ }
+			<section className="amplify-landing-ai-section">
+				<AmplifyAiSection />
+			</section>
+
+			{ /* ── PROMPT WORKFLOW ── */ }
 			<section className="amplify-landing-workflow-section">
 				<AmplifyAiWorkflow />
 			</section>

--- a/client/a8c-for-agencies/sections/amplify/amplify-overview-content.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-overview-content.tsx
@@ -3,6 +3,7 @@ import './style.scss';
 import { __ } from '@wordpress/i18n';
 import AmplifyAiSection from './amplify-ai-section';
 import AmplifyAiWorkflow from './amplify-ai-workflow';
+import AmplifyFAQ from './amplify-faq';
 import AmplifyHowItWorks from './amplify-how-it-works';
 import AmplifyHumanSection from './amplify-human-section';
 import AmplifyScoreCard from './amplify-score-card';
@@ -18,49 +19,56 @@ type Props = {
 
 export default function AmplifyOverviewContent( { onSiteSelected }: Props ) {
 	return (
-		<div className="amplify-landing">
-			{ /* ── HERO ── */ }
-			<section className="amplify-landing-hero">
-				<div className="amplify-landing-hero-text">
-					<h1 className="amplify-landing-h1">
-						{ __( 'Your clients want more business. Find out what their site is doing about it.' ) }
-					</h1>
-					<p className="amplify-landing-sub">
-						{ __(
-							'Amplify scans your clients’ connected sites through two lenses: how their prospective clients perceive them on first visit, and how AI tools like ChatGPT and Perplexity read and rank them. Run a scan in minutes. Find what’s holding them back. Deliver fixes that prove your value and build trust.'
-						) }
-					</p>
-					<AmplifySiteSelect onSiteSelected={ onSiteSelected } />
-					<p className="amplify-landing-usage">
-						{ `${ REMAINING_AUDITS } of ${ MONTHLY_AUDIT_LIMIT } ${ __(
-							'scans remaining this month.'
-						) }` }
-					</p>
-				</div>
-				<div className="amplify-landing-hero-visual">
-					<AmplifyScoreCard />
-				</div>
-			</section>
+		<>
+			<div className="amplify-landing">
+				{ /* ── HERO ── */ }
+				<section className="amplify-landing-hero">
+					<div className="amplify-landing-hero-text">
+						<h1 className="amplify-landing-h1">
+							{ __(
+								'Your clients want more business. Find out what their site is doing about it.'
+							) }
+						</h1>
+						<p className="amplify-landing-sub">
+							{ __(
+								"Amplify scans your clients' connected sites through two lenses: how their prospective clients perceive them on first visit, and how AI tools like ChatGPT and Perplexity read and rank them. Run a scan in minutes. Find what's holding them back. Deliver fixes that prove your value and build trust."
+							) }
+						</p>
+						<AmplifySiteSelect onSiteSelected={ onSiteSelected } />
+						<p className="amplify-landing-usage">
+							{ `${ REMAINING_AUDITS } of ${ MONTHLY_AUDIT_LIMIT } ${ __(
+								'scans remaining this month.'
+							) }` }
+						</p>
+					</div>
+					<div className="amplify-landing-hero-visual">
+						<AmplifyScoreCard />
+					</div>
+				</section>
 
-			{ /* ── HOW IT WORKS (interactive browser mockup) ── */ }
-			<section className="amplify-landing-how-section">
-				<AmplifyHowItWorks />
-			</section>
+				{ /* ── HOW IT WORKS (interactive browser mockup) ── */ }
+				<section className="amplify-landing-how-section">
+					<AmplifyHowItWorks />
+				</section>
 
-			{ /* ── HUMAN-CENTRIC ANALYSIS ── */ }
-			<section className="amplify-landing-human-section">
-				<AmplifyHumanSection />
-			</section>
+				{ /* ── HUMAN-CENTRIC ANALYSIS ── */ }
+				<section className="amplify-landing-human-section">
+					<AmplifyHumanSection />
+				</section>
 
-			{ /* ── AI ANALYSIS ── */ }
-			<section className="amplify-landing-ai-section">
-				<AmplifyAiSection />
-			</section>
+				{ /* ── AI ANALYSIS ── */ }
+				<section className="amplify-landing-ai-section">
+					<AmplifyAiSection />
+				</section>
 
-			{ /* ── PROMPT WORKFLOW ── */ }
-			<section className="amplify-landing-workflow-section">
-				<AmplifyAiWorkflow />
-			</section>
-		</div>
+				{ /* ── PROMPT WORKFLOW ── */ }
+				<section className="amplify-landing-workflow-section">
+					<AmplifyAiWorkflow />
+				</section>
+			</div>
+
+			{ /* ── FAQ — rendered outside amplify-landing so PageSection spans full width ── */ }
+			<AmplifyFAQ />
+		</>
 	);
 }

--- a/client/a8c-for-agencies/sections/amplify/amplify-overview-content.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-overview-content.tsx
@@ -1,0 +1,28 @@
+import './style.scss';
+
+import { __ } from '@wordpress/i18n';
+import AmplifyScoreCard from './amplify-score-card';
+import AmplifySiteSelect from './amplify-site-select';
+
+export default function AmplifyOverviewContent() {
+	return (
+		<div className="amplify-landing">
+			<section className="amplify-landing-hero">
+				<div className="amplify-landing-hero-text">
+					<h1 className="amplify-landing-h1">
+						{ __( 'Your agency’s website needs to win more clients' ) }
+					</h1>
+					<p className="amplify-landing-sub">
+						{ __(
+							'First impressions happen fast, and the way clients find you is changing. AI tools now help businesses discover agencies before a single conversation happens. Amplify audits your site through both lenses, then generates precise, agent-ready prompts so you can elevate your site instantly, captivate prospects, and close more deals.'
+						) }
+					</p>
+					<AmplifySiteSelect />
+				</div>
+				<div className="amplify-landing-hero-visual">
+					<AmplifyScoreCard />
+				</div>
+			</section>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/amplify/amplify-overview-content.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-overview-content.tsx
@@ -1,8 +1,17 @@
 import './style.scss';
 
-import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { A4A_AGENCY_TIER_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import AmplifyAiWorkflow from './amplify-ai-workflow';
+import AmplifyBenefits from './amplify-benefits';
+import AmplifyHowItWorks from './amplify-how-it-works';
 import AmplifyScoreCard from './amplify-score-card';
 import AmplifySiteSelect from './amplify-site-select';
+
+// Mock monthly usage — will be sourced from the agency's tier in a follow-up.
+const REMAINING_AUDITS = 1;
+const MONTHLY_AUDIT_LIMIT = 3;
 
 export default function AmplifyOverviewContent() {
 	return (
@@ -10,7 +19,10 @@ export default function AmplifyOverviewContent() {
 			<section className="amplify-landing-hero">
 				<div className="amplify-landing-hero-text">
 					<h1 className="amplify-landing-h1">
-						{ __( 'Your agency’s website needs to win more clients' ) }
+						{ createInterpolateElement(
+							__( 'Your agency’s website<br />needs to win more clients' ),
+							{ br: <br /> }
+						) }
 					</h1>
 					<p className="amplify-landing-sub">
 						{ __(
@@ -18,10 +30,30 @@ export default function AmplifyOverviewContent() {
 						) }
 					</p>
 					<AmplifySiteSelect />
+					<p className="amplify-landing-usage">
+						{ sprintf(
+							/* translators: %1$d is the number of audits remaining, %2$d is the monthly limit. */
+							__( '%1$d of %2$d audits remaining this month.' ),
+							REMAINING_AUDITS,
+							MONTHLY_AUDIT_LIMIT
+						) }{ ' ' }
+						<a className="amplify-landing-usage-link" href={ A4A_AGENCY_TIER_LINK }>
+							{ __( 'View your tier limits' ) }
+						</a>
+					</p>
 				</div>
 				<div className="amplify-landing-hero-visual">
 					<AmplifyScoreCard />
 				</div>
+			</section>
+			<section className="amplify-landing-benefits">
+				<AmplifyBenefits />
+			</section>
+			<section className="amplify-landing-how-section">
+				<AmplifyHowItWorks />
+			</section>
+			<section className="amplify-landing-workflow-section">
+				<AmplifyAiWorkflow />
 			</section>
 		</div>
 	);

--- a/client/a8c-for-agencies/sections/amplify/amplify-overview-content.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-overview-content.tsx
@@ -13,7 +13,11 @@ import AmplifySiteSelect from './amplify-site-select';
 const REMAINING_AUDITS = 1;
 const MONTHLY_AUDIT_LIMIT = 3;
 
-export default function AmplifyOverviewContent() {
+type Props = {
+	onSiteSelected: ( url: string ) => void;
+};
+
+export default function AmplifyOverviewContent( { onSiteSelected }: Props ) {
 	return (
 		<div className="amplify-landing">
 			<section className="amplify-landing-hero">
@@ -29,7 +33,7 @@ export default function AmplifyOverviewContent() {
 							'First impressions happen fast, and the way clients find you is changing. AI tools now help businesses discover agencies before a single conversation happens. Amplify audits your site through both lenses, then generates precise, agent-ready prompts so you can elevate your site instantly, captivate prospects, and close more deals.'
 						) }
 					</p>
-					<AmplifySiteSelect />
+					<AmplifySiteSelect onSiteSelected={ onSiteSelected } />
 					<p className="amplify-landing-usage">
 						{ sprintf(
 							/* translators: %1$d is the number of audits remaining, %2$d is the monthly limit. */

--- a/client/a8c-for-agencies/sections/amplify/amplify-overview-content.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-overview-content.tsx
@@ -1,6 +1,7 @@
 import './style.scss';
 
 import { __ } from '@wordpress/i18n';
+import PageSectionColumns from 'calypso/a8c-for-agencies/components/page-section-columns';
 import AmplifyAiSection from './amplify-ai-section';
 import AmplifyAiWorkflow from './amplify-ai-workflow';
 import AmplifyFAQ from './amplify-faq';
@@ -9,20 +10,25 @@ import AmplifyHumanSection from './amplify-human-section';
 import AmplifyScoreCard from './amplify-score-card';
 import AmplifySiteSelect from './amplify-site-select';
 
-// Mock monthly usage — will be sourced from the agency's tier in a follow-up.
-const REMAINING_AUDITS = 1;
-const MONTHLY_AUDIT_LIMIT = 3;
-
 type Props = {
 	onSiteSelected: ( url: string ) => void;
 };
 
+const ZEBRA_BG = { color: 'var(--color-neutral-0)' };
+
 export default function AmplifyOverviewContent( { onSiteSelected }: Props ) {
 	return (
 		<>
-			<div className="amplify-landing">
-				{ /* ── HERO ── */ }
-				<section className="amplify-landing-hero">
+			{ /* ── HERO ── */ }
+			<PageSectionColumns className="amplify-landing-hero">
+				<PageSectionColumns.Column>
+					{ /*
+						Wrap the hero content in a single div so PageSectionColumns'
+						column-level gap (32px between siblings) doesn't stack on top
+						of the per-element margins below. The h1 → sub → selector
+						spacing is then governed entirely by margin-block-end on each
+						element, matching the criteria-section rhythm.
+					*/ }
 					<div className="amplify-landing-hero-text">
 						<h1 className="amplify-landing-h1">
 							{ __(
@@ -35,39 +41,45 @@ export default function AmplifyOverviewContent( { onSiteSelected }: Props ) {
 							) }
 						</p>
 						<AmplifySiteSelect onSiteSelected={ onSiteSelected } />
-						<p className="amplify-landing-usage">
-							{ `${ REMAINING_AUDITS } of ${ MONTHLY_AUDIT_LIMIT } ${ __(
-								'scans remaining this month.'
-							) }` }
-						</p>
+						{ /*
+							TODO: monthly scan usage counter. Previously rendered hardcoded
+							"1 of 3 scans remaining this month" which was misleading to real
+							users. Restore once the agency's tier-based allocation and
+							consumed-count are wired up (see amplify-todo.md item 10:
+							"Tiering structure and analysis allocation").
+						*/ }
 					</div>
-					<div className="amplify-landing-hero-visual">
-						<AmplifyScoreCard />
-					</div>
-				</section>
+				</PageSectionColumns.Column>
+				<PageSectionColumns.Column alignCenter>
+					<AmplifyScoreCard />
+				</PageSectionColumns.Column>
+			</PageSectionColumns>
 
-				{ /* ── HOW IT WORKS (interactive browser mockup) ── */ }
-				<section className="amplify-landing-how-section">
+			{ /* ── HOW IT WORKS (interactive browser mockup) ── */ }
+			<PageSectionColumns background={ ZEBRA_BG }>
+				<PageSectionColumns.Column fullWidth>
 					<AmplifyHowItWorks />
-				</section>
+				</PageSectionColumns.Column>
+			</PageSectionColumns>
 
-				{ /* ── HUMAN-CENTRIC ANALYSIS ── */ }
-				<section className="amplify-landing-human-section">
+			{ /* ── HUMAN-CENTRIC ANALYSIS ── */ }
+			<PageSectionColumns>
+				<PageSectionColumns.Column fullWidth>
 					<AmplifyHumanSection />
-				</section>
+				</PageSectionColumns.Column>
+			</PageSectionColumns>
 
-				{ /* ── AI ANALYSIS ── */ }
-				<section className="amplify-landing-ai-section">
+			{ /* ── AI ANALYSIS ── */ }
+			<PageSectionColumns background={ ZEBRA_BG }>
+				<PageSectionColumns.Column fullWidth>
 					<AmplifyAiSection />
-				</section>
+				</PageSectionColumns.Column>
+			</PageSectionColumns>
 
-				{ /* ── PROMPT WORKFLOW ── */ }
-				<section className="amplify-landing-workflow-section">
-					<AmplifyAiWorkflow />
-				</section>
-			</div>
+			{ /* ── PROMPT WORKFLOW (renders its own PageSectionColumns) ── */ }
+			<AmplifyAiWorkflow />
 
-			{ /* ── FAQ — rendered outside amplify-landing so PageSection spans full width ── */ }
+			{ /* ── FAQ (renders its own PageSectionColumns with the zebra bg) ── */ }
 			<AmplifyFAQ />
 		</>
 	);

--- a/client/a8c-for-agencies/sections/amplify/amplify-overview.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-overview.tsx
@@ -1,0 +1,31 @@
+import { __ } from '@wordpress/i18n';
+import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
+import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import LayoutBody from 'calypso/layout/hosting-dashboard/body';
+import LayoutHeader, {
+	LayoutHeaderTitle as Title,
+	LayoutHeaderActions as Actions,
+} from 'calypso/layout/hosting-dashboard/header';
+import AmplifyOverviewContent from './amplify-overview-content';
+
+export default function AmplifyOverview() {
+	const title = __( 'Amplify' );
+
+	return (
+		<Layout title={ title } wide>
+			<LayoutTop>
+				<LayoutHeader>
+					<Title>{ title }</Title>
+					<Actions>
+						<MobileSidebarNavigation />
+					</Actions>
+				</LayoutHeader>
+			</LayoutTop>
+
+			<LayoutBody>
+				<AmplifyOverviewContent />
+			</LayoutBody>
+		</Layout>
+	);
+}

--- a/client/a8c-for-agencies/sections/amplify/amplify-page.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-page.tsx
@@ -27,7 +27,7 @@
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
@@ -36,6 +36,9 @@ import LayoutHeader, {
 	LayoutHeaderTitle as Title,
 	LayoutHeaderActions as Actions,
 } from 'calypso/layout/hosting-dashboard/header';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import AmplifyAddSiteModal from './amplify-add-site-modal';
 import AmplifyAnalysisModal from './amplify-analysis-modal';
 import AmplifyOverviewContent from './amplify-overview-content';
@@ -49,7 +52,16 @@ type Props = {
 	selectedTab: AmplifyTab;
 };
 
-const PENDING_JOBS_KEY = 'amplify_pending_jobs';
+// Pending jobs are persisted to sessionStorage under a key scoped to the
+// (userId, agencyId) pair. Without per-identity scoping, a logout-then-
+// login-as-different-user (or an agency switch) in the same tab would inherit
+// the previous identity's in-flight site URLs and analysis types as ghost
+// "in progress" rows in the new identity's reports table. Each pair gets its
+// own bucket so a user switching back to a prior identity also recovers the
+// pending jobs they had under that identity.
+function buildPendingJobsKey( userId: number, agencyId: number ): string {
+	return `amplify_pending_jobs_${ userId }_${ agencyId }`;
+}
 
 function isValidPendingJob( job: unknown ): job is PendingJob {
 	if ( ! job || typeof job !== 'object' ) {
@@ -64,14 +76,14 @@ function isValidPendingJob( job: unknown ): job is PendingJob {
 	);
 }
 
-function loadPendingJobs(): PendingJob[] {
+function loadPendingJobs( userId: number, agencyId: number ): PendingJob[] {
 	// Guard against SSR where window/sessionStorage do not exist. A4A is
 	// client-rendered today but this keeps the helper safe if that changes.
 	if ( typeof window === 'undefined' ) {
 		return [];
 	}
 	try {
-		const stored = sessionStorage.getItem( PENDING_JOBS_KEY );
+		const stored = sessionStorage.getItem( buildPendingJobsKey( userId, agencyId ) );
 		if ( ! stored ) {
 			return [];
 		}
@@ -82,12 +94,12 @@ function loadPendingJobs(): PendingJob[] {
 	}
 }
 
-function savePendingJobs( jobs: PendingJob[] ): void {
+function savePendingJobs( jobs: PendingJob[], userId: number, agencyId: number ): void {
 	if ( typeof window === 'undefined' ) {
 		return;
 	}
 	try {
-		sessionStorage.setItem( PENDING_JOBS_KEY, JSON.stringify( jobs ) );
+		sessionStorage.setItem( buildPendingJobsKey( userId, agencyId ), JSON.stringify( jobs ) );
 	} catch {
 		// sessionStorage unavailable — fail silently.
 	}
@@ -96,38 +108,76 @@ function savePendingJobs( jobs: PendingJob[] ): void {
 export default function AmplifyPage( { selectedTab }: Props ) {
 	const [ isSiteSelectOpen, setIsSiteSelectOpen ] = useState( false );
 	const [ analysisFlowSite, setAnalysisFlowSite ] = useState< string | null >( null );
-	const [ pendingJobs, setPendingJobs ] = useState< PendingJob[] >( loadPendingJobs );
+	// Pending jobs are loaded from a per-identity sessionStorage bucket — see
+	// buildPendingJobsKey above. Initialize empty and let the effect below
+	// rehydrate once the (userId, agencyId) pair is available.
+	const [ pendingJobs, setPendingJobs ] = useState< PendingJob[] >( [] );
+
+	// These come from Redux and are also used by the submit modal and reports
+	// list to scope what gets sent and what gets shown. Reading them here lets
+	// us scope the pending-jobs sessionStorage bucket the same way without
+	// prop-drilling identity through the modal flow.
+	const currentUserId = useSelector( getCurrentUserId );
+	const activeAgencyId = useSelector( getActiveAgencyId );
+
+	// Rehydrate the in-memory pending list whenever the active identity
+	// changes. This swaps to the new (userId, agencyId) bucket on a user or
+	// agency switch and clears to [] on logout (or before Redux state
+	// hydrates), preventing the previous identity's in-flight rows from
+	// leaking into the new identity's reports table.
+	useEffect( () => {
+		if ( ! currentUserId || ! activeAgencyId ) {
+			setPendingJobs( [] );
+			return;
+		}
+		setPendingJobs( loadPendingJobs( currentUserId, activeAgencyId ) );
+	}, [ currentUserId, activeAgencyId ] );
 
 	const handleSiteSelected = useCallback( ( url: string ) => {
 		setIsSiteSelectOpen( false );
 		setAnalysisFlowSite( url );
 	}, [] );
 
-	const handleAnalysisStarted = useCallback( ( job: PendingJob ) => {
-		// Add the new job to the front of the pending list so it appears at the
-		// top of the reports table immediately, and persist across page refreshes.
-		setPendingJobs( ( prev ) => {
-			const updated = [ job, ...prev ];
-			savePendingJobs( updated );
-			return updated;
-		} );
-	}, [] );
-
-	const handlePendingJobsResolved = useCallback( ( jobIds: string[] ) => {
-		// AmplifyReportsContent calls this once it sees pending jobs that now have
-		// a matching completed report in the R2 index. We drop those entries from
-		// both state and sessionStorage so the pending list doesn't accumulate.
-		// The reference-equality short-circuit avoids a wasteful re-render when
-		// the callback fires with jobIds that have already been pruned.
-		setPendingJobs( ( prev ) => {
-			const remaining = prev.filter( ( job ) => ! jobIds.includes( job.jobId ) );
-			if ( remaining.length === prev.length ) {
-				return prev;
+	const handleAnalysisStarted = useCallback(
+		( job: PendingJob ) => {
+			// No-op if identity isn't ready yet. The submit modal applies the
+			// same guard before calling startAmplifyAnalysis, so in practice
+			// this is only reachable in a race we don't expect to hit.
+			if ( ! currentUserId || ! activeAgencyId ) {
+				return;
 			}
-			savePendingJobs( remaining );
-			return remaining;
-		} );
-	}, [] );
+			// Add the new job to the front of the pending list so it appears at the
+			// top of the reports table immediately, and persist across page refreshes.
+			setPendingJobs( ( prev ) => {
+				const updated = [ job, ...prev ];
+				savePendingJobs( updated, currentUserId, activeAgencyId );
+				return updated;
+			} );
+		},
+		[ currentUserId, activeAgencyId ]
+	);
+
+	const handlePendingJobsResolved = useCallback(
+		( jobIds: string[] ) => {
+			if ( ! currentUserId || ! activeAgencyId ) {
+				return;
+			}
+			// AmplifyReportsContent calls this once it sees pending jobs that now have
+			// a matching completed report in the R2 index. We drop those entries from
+			// both state and sessionStorage so the pending list doesn't accumulate.
+			// The reference-equality short-circuit avoids a wasteful re-render when
+			// the callback fires with jobIds that have already been pruned.
+			setPendingJobs( ( prev ) => {
+				const remaining = prev.filter( ( job ) => ! jobIds.includes( job.jobId ) );
+				if ( remaining.length === prev.length ) {
+					return prev;
+				}
+				savePendingJobs( remaining, currentUserId, activeAgencyId );
+				return remaining;
+			} );
+		},
+		[ currentUserId, activeAgencyId ]
+	);
 
 	let title: string;
 	let content: ReactNode;

--- a/client/a8c-for-agencies/sections/amplify/amplify-page.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-page.tsx
@@ -51,10 +51,27 @@ type Props = {
 
 const PENDING_JOBS_KEY = 'amplify_pending_jobs';
 
+function isValidPendingJob( job: unknown ): job is PendingJob {
+	if ( ! job || typeof job !== 'object' ) {
+		return false;
+	}
+	const j = job as Record< string, unknown >;
+	return (
+		typeof j.jobId === 'string' &&
+		typeof j.site === 'string' &&
+		( j.type === 'human' || j.type === 'ai' || j.type === 'full' ) &&
+		typeof j.startedAt === 'string'
+	);
+}
+
 function loadPendingJobs(): PendingJob[] {
 	try {
 		const stored = sessionStorage.getItem( PENDING_JOBS_KEY );
-		return stored ? JSON.parse( stored ) : [];
+		if ( ! stored ) {
+			return [];
+		}
+		const parsed: unknown = JSON.parse( stored );
+		return Array.isArray( parsed ) ? parsed.filter( isValidPendingJob ) : [];
 	} catch {
 		return [];
 	}
@@ -78,7 +95,7 @@ export default function AmplifyPage( { selectedTab }: Props ) {
 		setAnalysisFlowSite( url );
 	}, [] );
 
-	const handleAnalysisStarted = ( job: PendingJob ) => {
+	const handleAnalysisStarted = useCallback( ( job: PendingJob ) => {
 		// Add the new job to the front of the pending list so it appears at the
 		// top of the reports table immediately, and persist across page refreshes.
 		setPendingJobs( ( prev ) => {
@@ -86,7 +103,7 @@ export default function AmplifyPage( { selectedTab }: Props ) {
 			savePendingJobs( updated );
 			return updated;
 		} );
-	};
+	}, [] );
 
 	let title: string;
 	let content: ReactNode;
@@ -109,7 +126,7 @@ export default function AmplifyPage( { selectedTab }: Props ) {
 		<Layout
 			title={ title }
 			wide
-			className={ clsx( { 'full-width-layout-with-table': isReports } ) }
+			className={ clsx( 'amplify-layout', { 'full-width-layout-with-table': isReports } ) }
 		>
 			<LayoutTop>
 				<LayoutHeader>

--- a/client/a8c-for-agencies/sections/amplify/amplify-page.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-page.tsx
@@ -8,9 +8,28 @@ import LayoutHeader, {
 	LayoutHeaderActions as Actions,
 } from 'calypso/layout/hosting-dashboard/header';
 import AmplifyOverviewContent from './amplify-overview-content';
+import AmplifyReportsContent from './amplify-reports-content';
+import type { ReactNode } from 'react';
 
-export default function AmplifyOverview() {
-	const title = __( 'Amplify' );
+export type AmplifyTab = 'overview' | 'reports';
+
+type Props = {
+	selectedTab: AmplifyTab;
+};
+
+export default function AmplifyPage( { selectedTab }: Props ) {
+	let title: string;
+	let content: ReactNode;
+	switch ( selectedTab ) {
+		case 'overview':
+			title = __( 'Overview' );
+			content = <AmplifyOverviewContent />;
+			break;
+		case 'reports':
+			title = __( 'Reports' );
+			content = <AmplifyReportsContent />;
+			break;
+	}
 
 	return (
 		<Layout title={ title } wide>
@@ -23,9 +42,7 @@ export default function AmplifyOverview() {
 				</LayoutHeader>
 			</LayoutTop>
 
-			<LayoutBody>
-				<AmplifyOverviewContent />
-			</LayoutBody>
+			<LayoutBody>{ content }</LayoutBody>
 		</Layout>
 	);
 }

--- a/client/a8c-for-agencies/sections/amplify/amplify-page.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-page.tsx
@@ -1,4 +1,7 @@
+import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
+import { useState } from 'react';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
@@ -7,6 +10,8 @@ import LayoutHeader, {
 	LayoutHeaderTitle as Title,
 	LayoutHeaderActions as Actions,
 } from 'calypso/layout/hosting-dashboard/header';
+import AmplifyAddSiteModal from './amplify-add-site-modal';
+import AmplifyAnalysisModal from './amplify-analysis-modal';
 import AmplifyOverviewContent from './amplify-overview-content';
 import AmplifyReportsContent from './amplify-reports-content';
 import type { ReactNode } from 'react';
@@ -18,6 +23,14 @@ type Props = {
 };
 
 export default function AmplifyPage( { selectedTab }: Props ) {
+	const [ isSiteSelectOpen, setIsSiteSelectOpen ] = useState( false );
+	const [ analysisFlowSite, setAnalysisFlowSite ] = useState< string | null >( null );
+
+	const handleSiteSelected = ( url: string ) => {
+		setIsSiteSelectOpen( false );
+		setAnalysisFlowSite( url );
+	};
+
 	let title: string;
 	let content: ReactNode;
 	switch ( selectedTab ) {
@@ -31,18 +44,43 @@ export default function AmplifyPage( { selectedTab }: Props ) {
 			break;
 	}
 
+	const isReports = selectedTab === 'reports';
+
 	return (
-		<Layout title={ title } wide>
+		<Layout
+			title={ title }
+			wide
+			className={ clsx( { 'full-width-layout-with-table': isReports } ) }
+		>
 			<LayoutTop>
 				<LayoutHeader>
 					<Title>{ title }</Title>
 					<Actions>
 						<MobileSidebarNavigation />
+						<Button
+							__next40pxDefaultSize
+							variant="primary"
+							onClick={ () => setIsSiteSelectOpen( true ) }
+						>
+							{ __( 'Amplify a site' ) }
+						</Button>
 					</Actions>
 				</LayoutHeader>
 			</LayoutTop>
 
 			<LayoutBody>{ content }</LayoutBody>
+
+			{ isSiteSelectOpen && (
+				<AmplifyAddSiteModal
+					onClose={ () => setIsSiteSelectOpen( false ) }
+					onSiteSelected={ handleSiteSelected }
+				/>
+			) }
+
+			<AmplifyAnalysisModal
+				site={ analysisFlowSite }
+				onClose={ () => setAnalysisFlowSite( null ) }
+			/>
 		</Layout>
 	);
 }

--- a/client/a8c-for-agencies/sections/amplify/amplify-page.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-page.tsx
@@ -19,14 +19,15 @@
  *   to `pendingJobs`. AmplifyReportsContent merges this list with reports fetched
  *   from R2, showing an "In progress" row immediately without waiting for the
  *   background task to finish and update the index.
- *   Pending jobs are in memory only — they reset on page reload, at which point
- *   the real R2 data takes over.
+ *   Pending jobs are persisted to sessionStorage so they survive a page reload
+ *   within the same tab. On the next full load, real R2 data takes over and
+ *   any completed jobs are dropped from the pending list.
  */
 
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
@@ -72,10 +73,10 @@ export default function AmplifyPage( { selectedTab }: Props ) {
 	const [ analysisFlowSite, setAnalysisFlowSite ] = useState< string | null >( null );
 	const [ pendingJobs, setPendingJobs ] = useState< PendingJob[] >( loadPendingJobs );
 
-	const handleSiteSelected = ( url: string ) => {
+	const handleSiteSelected = useCallback( ( url: string ) => {
 		setIsSiteSelectOpen( false );
 		setAnalysisFlowSite( url );
-	};
+	}, [] );
 
 	const handleAnalysisStarted = ( job: PendingJob ) => {
 		// Add the new job to the front of the pending list so it appears at the
@@ -91,16 +92,13 @@ export default function AmplifyPage( { selectedTab }: Props ) {
 	let content: ReactNode;
 	switch ( selectedTab ) {
 		case 'overview':
-			title = __( 'Overview' );
+			title = __( 'Amplify Overview' );
 			content = <AmplifyOverviewContent onSiteSelected={ handleSiteSelected } />;
 			break;
 		case 'reports':
 			title = __( 'Reports' );
 			content = (
-				<AmplifyReportsContent
-					pendingJobs={ pendingJobs }
-					onSiteSelected={ handleSiteSelected }
-				/>
+				<AmplifyReportsContent pendingJobs={ pendingJobs } onSiteSelected={ handleSiteSelected } />
 			);
 			break;
 	}

--- a/client/a8c-for-agencies/sections/amplify/amplify-page.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-page.tsx
@@ -1,3 +1,28 @@
+/**
+ * AmplifyPage
+ *
+ * Top-level page component for the Amplify section. Owns all modal state and
+ * the list of in-progress jobs so both the modal flow and the reports table
+ * stay in sync without prop-drilling through the router.
+ *
+ * Modal flow (two steps, both managed here):
+ *   1. AmplifyAddSiteModal  — user picks which connected site to analyse
+ *   2. AmplifyAnalysisModal — user picks analysis type, job is submitted
+ *
+ * Why state lives here (not inside the modals):
+ *   AmplifyAddSiteModal and AmplifyAnalysisModal are siblings, not parent/child.
+ *   If the analysis modal owned the site selection, closing the first modal would
+ *   unmount it and lose the value before the second modal could use it.
+ *
+ * In-progress jobs:
+ *   When a job is submitted, onAnalysisStarted fires and adds a PendingJob entry
+ *   to `pendingJobs`. AmplifyReportsContent merges this list with reports fetched
+ *   from R2, showing an "In progress" row immediately without waiting for the
+ *   background task to finish and update the index.
+ *   Pending jobs are in memory only — they reset on page reload, at which point
+ *   the real R2 data takes over.
+ */
+
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
@@ -14,6 +39,7 @@ import AmplifyAddSiteModal from './amplify-add-site-modal';
 import AmplifyAnalysisModal from './amplify-analysis-modal';
 import AmplifyOverviewContent from './amplify-overview-content';
 import AmplifyReportsContent from './amplify-reports-content';
+import type { PendingJob } from './amplify-analysis-modal';
 import type { ReactNode } from 'react';
 
 export type AmplifyTab = 'overview' | 'reports';
@@ -22,13 +48,43 @@ type Props = {
 	selectedTab: AmplifyTab;
 };
 
+const PENDING_JOBS_KEY = 'amplify_pending_jobs';
+
+function loadPendingJobs(): PendingJob[] {
+	try {
+		const stored = sessionStorage.getItem( PENDING_JOBS_KEY );
+		return stored ? JSON.parse( stored ) : [];
+	} catch {
+		return [];
+	}
+}
+
+function savePendingJobs( jobs: PendingJob[] ): void {
+	try {
+		sessionStorage.setItem( PENDING_JOBS_KEY, JSON.stringify( jobs ) );
+	} catch {
+		// sessionStorage unavailable — fail silently.
+	}
+}
+
 export default function AmplifyPage( { selectedTab }: Props ) {
 	const [ isSiteSelectOpen, setIsSiteSelectOpen ] = useState( false );
 	const [ analysisFlowSite, setAnalysisFlowSite ] = useState< string | null >( null );
+	const [ pendingJobs, setPendingJobs ] = useState< PendingJob[] >( loadPendingJobs );
 
 	const handleSiteSelected = ( url: string ) => {
 		setIsSiteSelectOpen( false );
 		setAnalysisFlowSite( url );
+	};
+
+	const handleAnalysisStarted = ( job: PendingJob ) => {
+		// Add the new job to the front of the pending list so it appears at the
+		// top of the reports table immediately, and persist across page refreshes.
+		setPendingJobs( ( prev ) => {
+			const updated = [ job, ...prev ];
+			savePendingJobs( updated );
+			return updated;
+		} );
 	};
 
 	let title: string;
@@ -36,11 +92,16 @@ export default function AmplifyPage( { selectedTab }: Props ) {
 	switch ( selectedTab ) {
 		case 'overview':
 			title = __( 'Overview' );
-			content = <AmplifyOverviewContent />;
+			content = <AmplifyOverviewContent onSiteSelected={ handleSiteSelected } />;
 			break;
 		case 'reports':
 			title = __( 'Reports' );
-			content = <AmplifyReportsContent />;
+			content = (
+				<AmplifyReportsContent
+					pendingJobs={ pendingJobs }
+					onSiteSelected={ handleSiteSelected }
+				/>
+			);
 			break;
 	}
 
@@ -80,6 +141,7 @@ export default function AmplifyPage( { selectedTab }: Props ) {
 			<AmplifyAnalysisModal
 				site={ analysisFlowSite }
 				onClose={ () => setAnalysisFlowSite( null ) }
+				onAnalysisStarted={ handleAnalysisStarted }
 			/>
 		</Layout>
 	);

--- a/client/a8c-for-agencies/sections/amplify/amplify-page.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-page.tsx
@@ -6,7 +6,7 @@
  * stay in sync without prop-drilling through the router.
  *
  * Modal flow (two steps, both managed here):
- *   1. AmplifyAddSiteModal  — user picks which connected site to analyse
+ *   1. AmplifyAddSiteModal  — user picks which connected site to analyze
  *   2. AmplifyAnalysisModal — user picks analysis type, job is submitted
  *
  * Why state lives here (not inside the modals):
@@ -65,6 +65,11 @@ function isValidPendingJob( job: unknown ): job is PendingJob {
 }
 
 function loadPendingJobs(): PendingJob[] {
+	// Guard against SSR where window/sessionStorage do not exist. A4A is
+	// client-rendered today but this keeps the helper safe if that changes.
+	if ( typeof window === 'undefined' ) {
+		return [];
+	}
 	try {
 		const stored = sessionStorage.getItem( PENDING_JOBS_KEY );
 		if ( ! stored ) {
@@ -78,6 +83,9 @@ function loadPendingJobs(): PendingJob[] {
 }
 
 function savePendingJobs( jobs: PendingJob[] ): void {
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
 	try {
 		sessionStorage.setItem( PENDING_JOBS_KEY, JSON.stringify( jobs ) );
 	} catch {
@@ -105,6 +113,22 @@ export default function AmplifyPage( { selectedTab }: Props ) {
 		} );
 	}, [] );
 
+	const handlePendingJobsResolved = useCallback( ( jobIds: string[] ) => {
+		// AmplifyReportsContent calls this once it sees pending jobs that now have
+		// a matching completed report in the R2 index. We drop those entries from
+		// both state and sessionStorage so the pending list doesn't accumulate.
+		// The reference-equality short-circuit avoids a wasteful re-render when
+		// the callback fires with jobIds that have already been pruned.
+		setPendingJobs( ( prev ) => {
+			const remaining = prev.filter( ( job ) => ! jobIds.includes( job.jobId ) );
+			if ( remaining.length === prev.length ) {
+				return prev;
+			}
+			savePendingJobs( remaining );
+			return remaining;
+		} );
+	}, [] );
+
 	let title: string;
 	let content: ReactNode;
 	switch ( selectedTab ) {
@@ -115,7 +139,11 @@ export default function AmplifyPage( { selectedTab }: Props ) {
 		case 'reports':
 			title = __( 'Reports' );
 			content = (
-				<AmplifyReportsContent pendingJobs={ pendingJobs } onSiteSelected={ handleSiteSelected } />
+				<AmplifyReportsContent
+					pendingJobs={ pendingJobs }
+					onSiteSelected={ handleSiteSelected }
+					onPendingJobsResolved={ handlePendingJobsResolved }
+				/>
 			);
 			break;
 	}

--- a/client/a8c-for-agencies/sections/amplify/amplify-reports-content.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-reports-content.tsx
@@ -10,6 +10,8 @@ import {
 } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import type { Field } from '@wordpress/dataviews';
 import type { ReactNode } from 'react';
 
@@ -62,6 +64,7 @@ function formatTimestamp( iso: string ): string {
 }
 
 export default function AmplifyReportsContent() {
+	const dispatch = useDispatch();
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
 		...initialDataViewsState,
 		type: DATAVIEWS_TABLE,
@@ -73,6 +76,16 @@ export default function AmplifyReportsContent() {
 			human: __( 'Human' ),
 			ai: __( 'AI' ),
 			full: __( 'Full' ),
+		};
+
+		const handleDownload = ( item: Report ) => {
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_amplify_report_download', {
+					report_id: item.id,
+					site_url: item.site,
+					analysis_type: item.analysisType,
+				} )
+			);
 		};
 
 		return [
@@ -112,15 +125,13 @@ export default function AmplifyReportsContent() {
 				id: 'download',
 				label: __( 'Download' ),
 				getValue: () => '',
-				render: (): ReactNode => (
+				render: ( { item }: { item: Report } ): ReactNode => (
 					<Button
 						variant="secondary"
 						size="compact"
 						icon={ download }
 						iconSize={ 16 }
-						onClick={ () => {
-							/* Wired in a follow-up. */
-						} }
+						onClick={ () => handleDownload( item ) }
 					>
 						{ __( 'Download PDF' ) }
 					</Button>
@@ -129,7 +140,7 @@ export default function AmplifyReportsContent() {
 				enableSorting: false,
 			},
 		];
-	}, [] );
+	}, [ dispatch ] );
 
 	const { data: items, paginationInfo: pagination } = useMemo( () => {
 		return filterSortAndPaginate( REPORTS, dataViewsState, fields );

--- a/client/a8c-for-agencies/sections/amplify/amplify-reports-content.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-reports-content.tsx
@@ -337,6 +337,14 @@ export default function AmplifyReportsContent( {
 		// Default to showing Active reports only. The user can switch to
 		// Archived or remove the filter for All via the DataViews filter UI.
 		filters: [ { field: 'status', operator: 'is', value: 'active' } ],
+		// Default sort newest-first. Pending and failed rows naturally surface
+		// at the top because their `startedAt` timestamp is the moment of
+		// submission, which is always >= every completed report's timestamp.
+		// ISO 8601 strings sort lexicographically the same as chronologically
+		// (canonical YYYY-MM-DDTHH:MM:SS.sssZ form), so no custom comparator
+		// needed — the timestamp field's getValue returns the raw ISO string
+		// and DataViews handles the rest.
+		sort: { field: 'timestamp', direction: 'desc' },
 		// Override the shared a4a default of 50 — the reports list grows one
 		// row per analysis, so 50/page would push pagination controls off
 		// indefinitely. 10 keeps the page scannable and surfaces pagination

--- a/client/a8c-for-agencies/sections/amplify/amplify-reports-content.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-reports-content.tsx
@@ -19,7 +19,7 @@ import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
 import { download } from '@wordpress/icons';
 import clsx from 'clsx';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
 	DATAVIEWS_TABLE,
 	initialDataViewsState,
@@ -173,8 +173,9 @@ export default function AmplifyReportsContent( {
 		fields: [ 'site', 'mode', 'scores', 'timestamp', 'download' ],
 	} );
 
-	const fields: Field< Report >[] = useMemo( () => {
-		const handleDownload = ( item: Report ) => {
+	// Memoized separately so the fields array below doesn't recreate on every render.
+	const handleDownload = useCallback(
+		( item: Report ) => {
 			dispatch(
 				recordTracksEvent( 'calypso_a4a_amplify_report_download', {
 					report_id: item.id,
@@ -182,13 +183,27 @@ export default function AmplifyReportsContent( {
 					analysis_type: item.mode,
 				} )
 			);
-			// Validate the URL is https:// before opening to guard against
-			// a javascript: or data: URI if the R2 payload were ever tampered with.
-			if ( item.pdfUrl && /^https:\/\//i.test( item.pdfUrl ) ) {
-				window.open( item.pdfUrl, '_blank', 'noopener,noreferrer' );
+			// Validate protocol and domain before opening to guard against a
+			// javascript:, data:, or unexpected host URI if the R2 payload were
+			// ever tampered with.
+			if ( item.pdfUrl ) {
+				try {
+					const parsed = new URL( item.pdfUrl );
+					if (
+						parsed.protocol === 'https:' &&
+						parsed.hostname === 'pub-d85717c601eb44398d8336c65ac7cfbb.r2.dev'
+					) {
+						window.open( item.pdfUrl, '_blank', 'noopener,noreferrer' );
+					}
+				} catch {
+					// Invalid URL — do nothing.
+				}
 			}
-		};
+		},
+		[ dispatch ]
+	);
 
+	const fields: Field< Report >[] = useMemo( () => {
 		return [
 			{
 				id: 'site',

--- a/client/a8c-for-agencies/sections/amplify/amplify-reports-content.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-reports-content.tsx
@@ -27,8 +27,10 @@ import {
 } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { successNotice } from 'calypso/state/notices/actions';
 import AmplifySiteSelect from './amplify-site-select';
 import AmplifyInfoPopover from './components/amplify-info-popover';
@@ -52,6 +54,20 @@ type Report = {
 	score?: number;
 	pdfUrl?: string;
 	reportUrl?: string;
+	/**
+	 * wpcom user ID of the report's owner. Written into the R2 index by the
+	 * Trigger.dev task (see trigger/amplify-analysis.ts). Optional only so we
+	 * can model legacy entries that predate per-user scoping — at render time
+	 * those are filtered out below and never shown to anyone.
+	 */
+	userId?: number;
+	/**
+	 * A4A agency the report was created under. Same scoping rules as userId:
+	 * a row is only visible when both `userId === currentUserId` and
+	 * `agencyId === activeAgencyId`. Legacy entries without this field are
+	 * filtered out from every (user, agency) pair.
+	 */
+	agencyId?: number;
 	/** True for jobs submitted this session that haven't yet appeared in R2. */
 	pending?: boolean;
 	/**
@@ -242,6 +258,22 @@ export default function AmplifyReportsContent( {
 	onPendingJobsResolved?: ( jobIds: string[] ) => void;
 } ) {
 	const dispatch = useDispatch();
+	// The R2 reports/index.json is a global manifest — every Trigger.dev run
+	// from every user (and every agency) lands in the same file because the
+	// underlying bucket is public and the interim Worker has no real
+	// per-identity auth. We scope the list client-side by the current
+	// (user, agency) pair. This is the user-facing privacy boundary today;
+	// the bucket itself remains technically readable to anyone with the
+	// public URL (see workers/amplify-api/index.ts and the SECURITY
+	// LIMITATION block in amplify-analysis-modal.tsx for the broader
+	// caveat). Real enforcement lands with the wpcom endpoint replacement.
+	//
+	// Convention note: every other A4A list view scopes server-side via
+	// wpcom.req to /agency/${ agencyId }/... — server filters, client just
+	// renders. This client-side filter is a deliberate departure permitted
+	// only by the interim Worker bridge. Don't copy this pattern.
+	const currentUserId = useSelector( getCurrentUserId );
+	const activeAgencyId = useSelector( getActiveAgencyId );
 	// Poll the R2 index while at least one *non-stale* pending job is in
 	// flight so the table can flip the row to "Download PDF" without a
 	// manual page refresh. Stale pendings (past STALE_PENDING_THRESHOLD_MS)
@@ -254,7 +286,23 @@ export default function AmplifyReportsContent( {
 	const hasNonStalePending = pendingJobs.some(
 		( job ) => new Date( job.startedAt ).getTime() >= cutoff
 	);
-	const { reports: fetchedReports, isLoading, error } = useAmplifyReports( hasNonStalePending );
+	const { reports: allFetchedReports, isLoading, error } = useAmplifyReports( hasNonStalePending );
+
+	// Hard filter the global R2 index down to reports owned by the current
+	// (user, agency) pair. Legacy entries with no userId or no agencyId are
+	// excluded from every identity — "no owner" never matches an actual
+	// user/agency pair, so they stay invisible. This is intentional:
+	// silently showing unscoped rows to everyone would reintroduce the
+	// cross-identity leak this whole change exists to close. If a legacy
+	// entry needs to be restored, edit it in R2 directly.
+	const fetchedReports = useMemo( () => {
+		if ( ! currentUserId || ! activeAgencyId ) {
+			return [];
+		}
+		return allFetchedReports.filter(
+			( r ) => r.userId === currentUserId && r.agencyId === activeAgencyId
+		);
+	}, [ allFetchedReports, currentUserId, activeAgencyId ] );
 
 	// Archive state is held client-side (localStorage). See the header of
 	// hooks/use-archived-reports.ts for the migration plan to a wpcom endpoint.
@@ -757,7 +805,13 @@ export default function AmplifyReportsContent( {
 		return filterSortAndPaginate( reports, dataViewsState, fields );
 	}, [ reports, dataViewsState, fields ] );
 
-	if ( isLoading ) {
+	// Keep showing the loading state while either identity selector is still
+	// hydrating. The amplify route is gated by requireAccessContext so this
+	// should resolve effectively immediately, but if we render the empty
+	// state before the (user, agency) pair is available we'd flash
+	// "You haven't run any Amplify analyses yet" even for identities that
+	// do have reports.
+	if ( isLoading || ! currentUserId || ! activeAgencyId ) {
 		return <div className="amplify-reports-loading">{ __( 'Loading reports…' ) }</div>;
 	}
 

--- a/client/a8c-for-agencies/sections/amplify/amplify-reports-content.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-reports-content.tsx
@@ -1,0 +1,155 @@
+import { Button } from '@wordpress/components';
+import { filterSortAndPaginate } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { download } from '@wordpress/icons';
+import clsx from 'clsx';
+import { useMemo, useState } from 'react';
+import {
+	DATAVIEWS_TABLE,
+	initialDataViewsState,
+} from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
+import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
+import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
+import type { Field } from '@wordpress/dataviews';
+import type { ReactNode } from 'react';
+
+type AnalysisType = 'human' | 'ai' | 'full';
+
+type Report = {
+	id: string;
+	site: string;
+	analysisType: AnalysisType;
+	timestamp: string;
+};
+
+const REPORTS: Report[] = [
+	{ id: '1', site: 'brightleaf.studio', analysisType: 'human', timestamp: '2026-04-28T15:42:00Z' },
+	{ id: '2', site: 'pixelcraft.agency', analysisType: 'ai', timestamp: '2026-04-28T11:18:00Z' },
+	{ id: '3', site: 'novastudio.design', analysisType: 'full', timestamp: '2026-04-27T17:21:00Z' },
+	{ id: '4', site: 'webweavers.co', analysisType: 'human', timestamp: '2026-04-26T09:04:00Z' },
+	{
+		id: '5',
+		site: 'crestlinestudio.com',
+		analysisType: 'full',
+		timestamp: '2026-04-25T14:33:00Z',
+	},
+	{ id: '6', site: 'atlasdigital.io', analysisType: 'ai', timestamp: '2026-04-24T10:57:00Z' },
+	{ id: '7', site: 'unityworks.studio', analysisType: 'human', timestamp: '2026-04-22T16:09:00Z' },
+	{ id: '8', site: 'forgemedia.co', analysisType: 'full', timestamp: '2026-04-21T13:48:00Z' },
+	{
+		id: '9',
+		site: 'canopycollective.com',
+		analysisType: 'ai',
+		timestamp: '2026-04-19T08:12:00Z',
+	},
+	{
+		id: '10',
+		site: 'lightspring.agency',
+		analysisType: 'full',
+		timestamp: '2026-04-17T15:55:00Z',
+	},
+	{ id: '11', site: 'orbitcreative.io', analysisType: 'human', timestamp: '2026-04-14T11:30:00Z' },
+	{ id: '12', site: 'relayhq.studio', analysisType: 'ai', timestamp: '2026-04-10T18:02:00Z' },
+];
+
+function formatTimestamp( iso: string ): string {
+	return new Date( iso ).toLocaleString( undefined, {
+		month: 'short',
+		day: 'numeric',
+		hour: 'numeric',
+		minute: '2-digit',
+	} );
+}
+
+export default function AmplifyReportsContent() {
+	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
+		...initialDataViewsState,
+		type: DATAVIEWS_TABLE,
+		fields: [ 'site', 'analysisType', 'timestamp', 'download' ],
+	} );
+
+	const fields: Field< Report >[] = useMemo( () => {
+		const analysisLabels: Record< AnalysisType, string > = {
+			human: __( 'Human' ),
+			ai: __( 'AI' ),
+			full: __( 'Full' ),
+		};
+
+		return [
+			{
+				id: 'site',
+				label: __( 'Site' ),
+				getValue: ( { item }: { item: Report } ) => item.site,
+				render: ( { item }: { item: Report } ): ReactNode => (
+					<span className="amplify-reports-site">{ item.site }</span>
+				),
+				enableHiding: false,
+				enableSorting: true,
+			},
+			{
+				id: 'analysisType',
+				label: __( 'Analysis type' ),
+				getValue: ( { item }: { item: Report } ) => analysisLabels[ item.analysisType ],
+				render: ( { item }: { item: Report } ): ReactNode => (
+					<span className={ clsx( 'amplify-reports-badge', `is-${ item.analysisType }` ) }>
+						{ analysisLabels[ item.analysisType ] }
+					</span>
+				),
+				enableHiding: true,
+				enableSorting: true,
+			},
+			{
+				id: 'timestamp',
+				label: __( 'Time & date' ),
+				getValue: ( { item }: { item: Report } ) => item.timestamp,
+				render: ( { item }: { item: Report } ): ReactNode => (
+					<span className="amplify-reports-timestamp">{ formatTimestamp( item.timestamp ) }</span>
+				),
+				enableHiding: false,
+				enableSorting: true,
+			},
+			{
+				id: 'download',
+				label: __( 'Download' ),
+				getValue: () => '',
+				render: (): ReactNode => (
+					<Button
+						variant="secondary"
+						size="compact"
+						icon={ download }
+						iconSize={ 16 }
+						onClick={ () => {
+							/* Wired in a follow-up. */
+						} }
+					>
+						{ __( 'Download PDF' ) }
+					</Button>
+				),
+				enableHiding: false,
+				enableSorting: false,
+			},
+		];
+	}, [] );
+
+	const { data: items, paginationInfo: pagination } = useMemo( () => {
+		return filterSortAndPaginate( REPORTS, dataViewsState, fields );
+	}, [ dataViewsState, fields ] );
+
+	return (
+		<div className="amplify-reports redesigned-a8c-table full-width">
+			<ItemsDataViews
+				data={ {
+					items,
+					getItemId: ( item: Report ) => item.id,
+					pagination,
+					enableSearch: false,
+					fields,
+					actions: [],
+					setDataViewsState,
+					dataViewsState,
+					defaultLayouts: { table: {} },
+				} }
+			/>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/amplify/amplify-reports-content.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-reports-content.tsx
@@ -14,6 +14,7 @@
  *     └── displayed until the page is reloaded and R2 reflects the real status
  */
 
+import { Gridicon } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
@@ -54,6 +55,13 @@ type Report = {
 	/** True for jobs submitted this session that haven't yet appeared in R2. */
 	pending?: boolean;
 	/**
+	 * True for pending jobs whose startedAt is older than
+	 * STALE_PENDING_THRESHOLD_MS — i.e. the Trigger.dev run almost certainly
+	 * failed and we should surface that to the user. Derived per render so
+	 * it flips as soon as the threshold is crossed (within a polling cycle).
+	 */
+	failed?: boolean;
+	/**
 	 * Derived per render from useArchivedReports() (localStorage-backed).
 	 * Pending jobs are always 'active'. Once the wpcom endpoint replaces
 	 * the R2 + localStorage split, this becomes a server-driven field on
@@ -63,6 +71,18 @@ type Report = {
 };
 
 const INDEX_URL = 'https://pub-d85717c601eb44398d8336c65ac7cfbb.r2.dev/reports/index.json';
+
+/**
+ * A pending job that hasn't been resolved by an R2 entry within this many
+ * milliseconds is treated as failed. The Trigger.dev task's maxDuration is
+ * 20 minutes; the fail-loud guard there turns silent worker failures into
+ * visible task failures, but Calypso has no direct signal of those failures
+ * today — so we use a client-side timeout to convert the never-resolving
+ * pending row into a user-facing error state. 30 minutes gives us a 10-min
+ * cushion above maxDuration so a slow-but-legitimate run isn't prematurely
+ * marked as failed.
+ */
+const STALE_PENDING_THRESHOLD_MS = 30 * 60 * 1000;
 
 const MODE_LABELS: Record< AnalysisMode, string > = {
 	human: 'Human',
@@ -222,11 +242,19 @@ export default function AmplifyReportsContent( {
 	onPendingJobsResolved?: ( jobIds: string[] ) => void;
 } ) {
 	const dispatch = useDispatch();
-	// Poll the R2 index while at least one job is in flight so the table can
-	// flip "Report in progress" rows to downloadable ones without a manual
-	// page refresh. Polling stops automatically the moment pendingJobs is
-	// empty (the hook re-runs its effect when shouldPoll changes).
-	const { reports: fetchedReports, isLoading, error } = useAmplifyReports( pendingJobs.length > 0 );
+	// Poll the R2 index while at least one *non-stale* pending job is in
+	// flight so the table can flip the row to "Download PDF" without a
+	// manual page refresh. Stale pendings (past STALE_PENDING_THRESHOLD_MS)
+	// are effectively failed — polling for them is wasted traffic since the
+	// Trigger.dev run is either already errored out or way past its max
+	// duration. The boolean is recomputed on every render rather than
+	// memoized so the staleness check stays correct as the wall clock
+	// advances even when `pendingJobs` itself doesn't change.
+	const cutoff = Date.now() - STALE_PENDING_THRESHOLD_MS;
+	const hasNonStalePending = pendingJobs.some(
+		( job ) => new Date( job.startedAt ).getTime() >= cutoff
+	);
+	const { reports: fetchedReports, isLoading, error } = useAmplifyReports( hasNonStalePending );
 
 	// Archive state is held client-side (localStorage). See the header of
 	// hooks/use-archived-reports.ts for the migration plan to a wpcom endpoint.
@@ -252,15 +280,25 @@ export default function AmplifyReportsContent( {
 	const reports = useMemo< Report[] >( () => {
 		const pendingReports: Report[] = pendingJobs
 			.filter( ( job ) => ! isPendingJobResolved( job, fetchedReports ) )
-			.map( ( job ) => ( {
-				id: job.jobId,
-				agencyName: '',
-				url: job.site,
-				mode: job.type === 'full' ? 'fullanalysis' : ( job.type as AnalysisMode ),
-				timestamp: job.startedAt,
-				pending: true,
-				status: 'active' as const,
-			} ) );
+			.map( ( job ) => {
+				// A pending job whose startedAt is older than the stale
+				// threshold is treated as failed (see STALE_PENDING_THRESHOLD_MS).
+				// `failed` rides alongside `pending` rather than replacing it
+				// because the row is still in sessionStorage and still
+				// pending-by-state — it just won't resolve.
+				const startedAtMs = new Date( job.startedAt ).getTime();
+				const failed = Date.now() - startedAtMs > STALE_PENDING_THRESHOLD_MS;
+				return {
+					id: job.jobId,
+					agencyName: '',
+					url: job.site,
+					mode: job.type === 'full' ? 'fullanalysis' : ( job.type as AnalysisMode ),
+					timestamp: job.startedAt,
+					pending: true,
+					failed,
+					status: 'active' as const,
+				};
+			} );
 		const completedReports: Report[] = fetchedReports.map( ( report ) => ( {
 			...report,
 			status: isArchived( report.id ) ? ( 'archived' as const ) : ( 'active' as const ),
@@ -370,6 +408,46 @@ export default function AmplifyReportsContent( {
 		[ dispatch, onSiteSelected ]
 	);
 
+	// Triggered from the "Try again" CTA inside the failed-report popover.
+	// Drops the stale pending row from sessionStorage and opens the analysis
+	// modal pre-loaded with the same site so the user can re-run cleanly.
+	// We reuse onPendingJobsResolved for the removal — semantically it's
+	// "the job is no longer pending in our view", which fits whether the
+	// resolution was a real R2 entry or a user-initiated dismissal.
+	const handleRetryFailed = useCallback(
+		( item: Report ) => {
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_amplify_report_failed_retry_click', {
+					site_url: item.url,
+					analysis_type: item.mode,
+				} )
+			);
+			onPendingJobsResolved?.( [ item.id ] );
+			onSiteSelected( item.url );
+		},
+		[ dispatch, onPendingJobsResolved, onSiteSelected ]
+	);
+
+	// Triggered from "Archive it" inside the failed-report popover OR from
+	// the new Archive action in the row's ellipsis menu (eligible only on
+	// failed rows). "Archive" here is user-facing language — mechanically
+	// we just remove the stale pending entry from sessionStorage so the
+	// row goes away. Pending jobs don't have an R2 entry to flip into the
+	// localStorage archive list, and tab-scoped sessionStorage means
+	// "archive" can't be undone after a tab close anyway.
+	const handleArchiveFailed = useCallback(
+		( item: Report ) => {
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_amplify_report_failed_dismiss_click', {
+					site_url: item.url,
+					analysis_type: item.mode,
+				} )
+			);
+			onPendingJobsResolved?.( [ item.id ] );
+		},
+		[ dispatch, onPendingJobsResolved ]
+	);
+
 	// Memoized separately so the fields array below doesn't recreate on every render.
 	const handleDownload = useCallback(
 		( item: Report ) => {
@@ -441,14 +519,18 @@ export default function AmplifyReportsContent( {
 				label: __( 'Scores' ),
 				getValue: () => '',
 				render: ( { item }: { item: Report } ): ReactNode => {
-					// Pending rows have no scores yet — render an em dash
-					// placeholder rather than an empty cell so the column
-					// visibly tracks the row instead of looking broken.
+					// Pending and failed rows have no scores — render an em
+					// dash placeholder rather than an empty cell so the
+					// column visibly tracks the row instead of looking broken.
 					if ( item.pending ) {
 						return (
 							<span
 								className="amplify-reports-scores-placeholder"
-								aria-label={ __( 'Scores not yet available' ) }
+								aria-label={
+									item.failed
+										? __( 'Scores unavailable — analysis failed' )
+										: __( 'Scores not yet available' )
+								}
 							>
 								—
 							</span>
@@ -488,6 +570,44 @@ export default function AmplifyReportsContent( {
 				label: __( 'Download' ),
 				getValue: () => '',
 				render: ( { item }: { item: Report } ): ReactNode => {
+					// `failed` is a stale subset of `pending`, so this branch
+					// MUST sit above the plain pending branch — otherwise the
+					// failed row would render as "Analysis in progress".
+					if ( item.failed ) {
+						return (
+							<span className="amplify-reports-failed">
+								<Gridicon
+									className="amplify-reports-failed-icon"
+									icon="notice-outline"
+									size={ 18 }
+								/>
+								<span className="amplify-reports-failed-label">{ __( 'Analysis failed' ) }</span>
+								<AmplifyInfoPopover ariaLabel={ __( 'About this failed analysis' ) }>
+									{ ( { close }: { close: () => void } ) => (
+										<div className="amplify-reports-failed-popover">
+											<p className="amplify-reports-failed-popover-body">
+												{ __(
+													'We couldn’t generate this report. The analysis may have timed out or hit an error.'
+												) }
+											</p>
+											{ /* Single CTA — archiving the failed row is still available
+											     via the row's ellipsis menu, no need to surface it twice. */ }
+											<Button
+												variant="link"
+												className="amplify-reports-failed-popover-cta"
+												onClick={ () => {
+													close();
+													handleRetryFailed( item );
+												} }
+											>
+												{ __( 'Try again' ) }
+											</Button>
+										</div>
+									) }
+								</AmplifyInfoPopover>
+							</span>
+						);
+					}
 					if ( item.pending ) {
 						return (
 							<span className="amplify-reports-in-progress">{ __( 'Analysis in progress' ) }</span>
@@ -567,7 +687,7 @@ export default function AmplifyReportsContent( {
 				enableSorting: false,
 			},
 		];
-	}, [ handleDownload, handleAmplifyNow ] );
+	}, [ handleDownload, handleAmplifyNow, handleRetryFailed ] );
 
 	// DataViews actions appear in a built-in column at the end of each row.
 	// `isPrimary: false` puts them under the row's ellipsis menu rather than
@@ -586,7 +706,12 @@ export default function AmplifyReportsContent( {
 						handleArchive( report );
 					}
 				},
-				isEligible: ( item: Report ) => ! item.pending && item.status !== 'archived',
+				// Eligible only for active completed reports — not for pending,
+				// not for already-archived, and not for failed (failed rows
+				// have their own Archive action below that hits the right
+				// dismiss path).
+				isEligible: ( item: Report ) =>
+					! item.pending && ! item.failed && item.status !== 'archived',
 			},
 			{
 				id: 'unarchive-report',
@@ -598,10 +723,26 @@ export default function AmplifyReportsContent( {
 						handleUnarchive( report );
 					}
 				},
-				isEligible: ( item: Report ) => ! item.pending && item.status === 'archived',
+				isEligible: ( item: Report ) =>
+					! item.pending && ! item.failed && item.status === 'archived',
+			},
+			{
+				// Failed-row archive surfaces the same removal we offer
+				// inside the popover, just as an ellipsis-menu shortcut so
+				// users can clear the row without opening the popover first.
+				id: 'archive-failed-report',
+				label: __( 'Archive' ),
+				isPrimary: false,
+				callback: ( items: Report[] ) => {
+					const report = items[ 0 ];
+					if ( report ) {
+						handleArchiveFailed( report );
+					}
+				},
+				isEligible: ( item: Report ) => !! item.failed,
 			},
 		],
-		[ handleArchive, handleUnarchive ]
+		[ handleArchive, handleUnarchive, handleArchiveFailed ]
 	);
 
 	const { data: items, paginationInfo: pagination } = useMemo( () => {

--- a/client/a8c-for-agencies/sections/amplify/amplify-reports-content.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-reports-content.tsx
@@ -29,9 +29,9 @@ import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashbo
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import AmplifySiteSelect from './amplify-site-select';
+import type { PendingJob } from './amplify-analysis-modal';
 import type { Field } from '@wordpress/dataviews';
 import type { ReactNode } from 'react';
-import type { PendingJob } from './amplify-analysis-modal';
 
 type AnalysisMode = 'human' | 'ai' | 'fullanalysis';
 
@@ -50,8 +50,7 @@ type Report = {
 	pending?: boolean;
 };
 
-const INDEX_URL =
-	'https://pub-d85717c601eb44398d8336c65ac7cfbb.r2.dev/reports/index.json';
+const INDEX_URL = 'https://pub-d85717c601eb44398d8336c65ac7cfbb.r2.dev/reports/index.json';
 
 const MODE_LABELS: Record< AnalysisMode, string > = {
 	human: 'Human',
@@ -116,7 +115,14 @@ function ScoreBadge( { score, label }: { score?: number; label: string } ) {
 	if ( score === undefined ) {
 		return null;
 	}
-	const threshold = score >= 80 ? 'strong' : score >= 50 ? 'needs-work' : 'at-risk';
+	let threshold: string;
+	if ( score >= 80 ) {
+		threshold = 'strong';
+	} else if ( score >= 50 ) {
+		threshold = 'needs-work';
+	} else {
+		threshold = 'at-risk';
+	}
 	return (
 		<span className={ clsx( 'amplify-reports-score', `is-${ threshold }` ) }>
 			{ sprintf(
@@ -144,19 +150,22 @@ export default function AmplifyReportsContent( {
 	// report with the same site + mode appears, the pending row will naturally
 	// be replaced on the next fetch (page reload). We deduplicate by jobId so a
 	// pending row never shows alongside the completed report for the same run.
-	const completedJobIds = new Set( fetchedReports.map( ( r ) => r.id ) );
-	const pendingReports: Report[] = pendingJobs
-		.filter( ( job ) => ! completedJobIds.has( job.jobId ) )
-		.map( ( job ) => ( {
-			id: job.jobId,
-			agencyName: '',
-			url: job.site,
-			mode: job.type === 'full' ? 'fullanalysis' : ( job.type as AnalysisMode ),
-			timestamp: job.startedAt,
-			pending: true,
-		} ) );
-
-	const reports = [ ...pendingReports, ...fetchedReports ];
+	// Memoized so that table interactions (sort/filter/paginate) that trigger a
+	// re-render don't rebuild the Set and re-map the arrays unnecessarily.
+	const reports = useMemo( () => {
+		const completedJobIds = new Set( fetchedReports.map( ( r ) => r.id ) );
+		const pendingReports: Report[] = pendingJobs
+			.filter( ( job ) => ! completedJobIds.has( job.jobId ) )
+			.map( ( job ) => ( {
+				id: job.jobId,
+				agencyName: '',
+				url: job.site,
+				mode: job.type === 'full' ? 'fullanalysis' : ( job.type as AnalysisMode ),
+				timestamp: job.startedAt,
+				pending: true,
+			} ) );
+		return [ ...pendingReports, ...fetchedReports ];
+	}, [ fetchedReports, pendingJobs ] );
 
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
 		...initialDataViewsState,
@@ -173,8 +182,9 @@ export default function AmplifyReportsContent( {
 					analysis_type: item.mode,
 				} )
 			);
-			if ( item.pdfUrl ) {
-				// noopener prevents the new tab from accessing window.opener.
+			// Validate the URL is https:// before opening to guard against
+			// a javascript: or data: URI if the R2 payload were ever tampered with.
+			if ( item.pdfUrl && /^https:\/\//i.test( item.pdfUrl ) ) {
 				window.open( item.pdfUrl, '_blank', 'noopener,noreferrer' );
 			}
 		};
@@ -186,9 +196,7 @@ export default function AmplifyReportsContent( {
 				getValue: ( { item }: { item: Report } ) => item.agencyName || item.url,
 				render: ( { item }: { item: Report } ): ReactNode => (
 					<span className="amplify-reports-site">
-						<span className="amplify-reports-site-name">
-							{ item.agencyName || item.url }
-						</span>
+						<span className="amplify-reports-site-name">{ item.agencyName || item.url }</span>
 						<span className="amplify-reports-site-url">{ item.url }</span>
 					</span>
 				),
@@ -234,9 +242,7 @@ export default function AmplifyReportsContent( {
 				label: __( 'Time & date' ),
 				getValue: ( { item }: { item: Report } ) => item.timestamp,
 				render: ( { item }: { item: Report } ): ReactNode => (
-					<span className="amplify-reports-timestamp">
-						{ formatTimestamp( item.timestamp ) }
-					</span>
+					<span className="amplify-reports-timestamp">{ formatTimestamp( item.timestamp ) }</span>
 				),
 				enableHiding: false,
 				enableSorting: true,
@@ -247,9 +253,7 @@ export default function AmplifyReportsContent( {
 				getValue: () => '',
 				render: ( { item }: { item: Report } ): ReactNode =>
 					item.pending ? (
-						<span className="amplify-reports-in-progress">
-							{ __( 'Report in progress' ) }
-						</span>
+						<span className="amplify-reports-in-progress">{ __( 'Report in progress' ) }</span>
 					) : (
 						<Button
 							variant="secondary"
@@ -273,11 +277,7 @@ export default function AmplifyReportsContent( {
 	}, [ reports, dataViewsState, fields ] );
 
 	if ( isLoading ) {
-		return (
-			<div className="amplify-reports-loading">
-				{ __( 'Loading reports…' ) }
-			</div>
-		);
+		return <div className="amplify-reports-loading">{ __( 'Loading reports…' ) }</div>;
 	}
 
 	// Show the empty / prompt state only when there are truly no rows to display
@@ -299,6 +299,11 @@ export default function AmplifyReportsContent( {
 
 	return (
 		<div className="amplify-reports redesigned-a8c-table full-width">
+			{ error && (
+				<p className="amplify-reports-fetch-error">
+					{ __( 'Could not load previous reports. Showing in-progress jobs only.' ) }
+				</p>
+			) }
 			<ItemsDataViews
 				data={ {
 					items,

--- a/client/a8c-for-agencies/sections/amplify/amplify-reports-content.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-reports-content.tsx
@@ -28,12 +28,17 @@ import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { successNotice } from 'calypso/state/notices/actions';
 import AmplifySiteSelect from './amplify-site-select';
+import AmplifyInfoPopover from './components/amplify-info-popover';
+import useArchivedReports from './hooks/use-archived-reports';
 import type { PendingJob } from './amplify-analysis-modal';
-import type { Field } from '@wordpress/dataviews';
+import type { Action, Field } from '@wordpress/dataviews';
 import type { ReactNode } from 'react';
 
 type AnalysisMode = 'human' | 'ai' | 'fullanalysis';
+
+type ReportStatus = 'active' | 'archived';
 
 type Report = {
 	id: string;
@@ -48,6 +53,13 @@ type Report = {
 	reportUrl?: string;
 	/** True for jobs submitted this session that haven't yet appeared in R2. */
 	pending?: boolean;
+	/**
+	 * Derived per render from useArchivedReports() (localStorage-backed).
+	 * Pending jobs are always 'active'. Once the wpcom endpoint replaces
+	 * the R2 + localStorage split, this becomes a server-driven field on
+	 * the report record itself — see hooks/use-archived-reports.ts.
+	 */
+	status: ReportStatus;
 };
 
 const INDEX_URL = 'https://pub-d85717c601eb44398d8336c65ac7cfbb.r2.dev/reports/index.json';
@@ -81,7 +93,21 @@ function isPendingJobResolved( job: PendingJob, fetchedReports: Report[] ): bool
 	);
 }
 
-function useAmplifyReports(): { reports: Report[]; isLoading: boolean; error: string | null } {
+/**
+ * Fetches the R2 reports index on mount, and (when `shouldPoll` is true)
+ * re-fetches every POLL_INTERVAL_MS so an in-progress job can flip to a
+ * downloadable row without the user reloading the page.
+ *
+ * Callers pass `shouldPoll = pendingJobs.length > 0` so we only poll while a
+ * job is actually outstanding. When the last pending job resolves and the
+ * caller stops passing `true`, this effect tears down the interval and we
+ * go back to the cheap on-mount-only mode.
+ */
+function useAmplifyReports( shouldPoll: boolean ): {
+	reports: Report[];
+	isLoading: boolean;
+	error: string | null;
+} {
 	const [ reports, setReports ] = useState< Report[] >( [] );
 	const [ isLoading, setIsLoading ] = useState( true );
 	const [ error, setError ] = useState< string | null >( null );
@@ -89,38 +115,56 @@ function useAmplifyReports(): { reports: Report[]; isLoading: boolean; error: st
 	useEffect( () => {
 		let cancelled = false;
 
-		window
-			.fetch( `${ INDEX_URL }?_=${ Date.now() }` )
-			.then( ( res ) => {
-				// 404 means no analyses have been run yet — treat as empty, not error.
-				if ( res.status === 404 ) {
-					return { reports: [] };
-				}
-				if ( ! res.ok ) {
-					throw new Error( `Failed to load reports: ${ res.status }` );
-				}
-				return res.json();
-			} )
-			.then( ( data ) => {
-				if ( ! cancelled ) {
+		const fetchReports = () => {
+			window
+				.fetch( `${ INDEX_URL }?_=${ Date.now() }` )
+				.then( ( res ) => {
+					// 404 means no analyses have been run yet — treat as empty, not error.
+					if ( res.status === 404 ) {
+						return { reports: [] };
+					}
+					if ( ! res.ok ) {
+						throw new Error( `Failed to load reports: ${ res.status }` );
+					}
+					return res.json();
+				} )
+				.then( ( data ) => {
+					if ( cancelled ) {
+						return;
+					}
 					setReports( Array.isArray( data.reports ) ? data.reports : [] );
-				}
-			} )
-			.catch( ( err ) => {
-				if ( ! cancelled ) {
-					setError( err.message );
-				}
-			} )
-			.finally( () => {
-				if ( ! cancelled ) {
-					setIsLoading( false );
-				}
-			} );
+					// Clear any previous error once a poll succeeds, so an intermittent
+					// R2 hiccup doesn't pin the table in an error state forever.
+					setError( null );
+				} )
+				.catch( ( err ) => {
+					if ( ! cancelled ) {
+						setError( err.message );
+					}
+				} )
+				.finally( () => {
+					if ( ! cancelled ) {
+						setIsLoading( false );
+					}
+				} );
+		};
+
+		fetchReports();
+
+		// 20s is responsive enough that a finished report flips within ~half a
+		// minute, while keeping the fetch volume tiny — the index payload is
+		// small JSON and Trigger runs take 5–15 minutes, so this is well under
+		// any meaningful R2 traffic threshold.
+		const POLL_INTERVAL_MS = 20_000;
+		const intervalId = shouldPoll ? setInterval( fetchReports, POLL_INTERVAL_MS ) : null;
 
 		return () => {
 			cancelled = true;
+			if ( intervalId !== null ) {
+				clearInterval( intervalId );
+			}
 		};
-	}, [] );
+	}, [ shouldPoll ] );
 
 	return { reports, isLoading, error };
 }
@@ -178,7 +222,15 @@ export default function AmplifyReportsContent( {
 	onPendingJobsResolved?: ( jobIds: string[] ) => void;
 } ) {
 	const dispatch = useDispatch();
-	const { reports: fetchedReports, isLoading, error } = useAmplifyReports();
+	// Poll the R2 index while at least one job is in flight so the table can
+	// flip "Report in progress" rows to downloadable ones without a manual
+	// page refresh. Polling stops automatically the moment pendingJobs is
+	// empty (the hook re-runs its effect when shouldPoll changes).
+	const { reports: fetchedReports, isLoading, error } = useAmplifyReports( pendingJobs.length > 0 );
+
+	// Archive state is held client-side (localStorage). See the header of
+	// hooks/use-archived-reports.ts for the migration plan to a wpcom endpoint.
+	const { isArchived, archive, unarchive } = useArchivedReports();
 
 	// Merge pending jobs into the reports list. A pending job is shown at the
 	// top with the `pending` flag set. Once the R2 index updates and a real
@@ -195,7 +247,9 @@ export default function AmplifyReportsContent( {
 	//
 	// Memoized so that table interactions (sort/filter/paginate) that trigger a
 	// re-render don't rebuild the match index and re-map the arrays unnecessarily.
-	const reports = useMemo( () => {
+	// Pending jobs are always `status: 'active'` — you can't archive a job that
+	// hasn't finished. Completed reports take their status from useArchivedReports.
+	const reports = useMemo< Report[] >( () => {
 		const pendingReports: Report[] = pendingJobs
 			.filter( ( job ) => ! isPendingJobResolved( job, fetchedReports ) )
 			.map( ( job ) => ( {
@@ -205,9 +259,14 @@ export default function AmplifyReportsContent( {
 				mode: job.type === 'full' ? 'fullanalysis' : ( job.type as AnalysisMode ),
 				timestamp: job.startedAt,
 				pending: true,
+				status: 'active' as const,
 			} ) );
-		return [ ...pendingReports, ...fetchedReports ];
-	}, [ fetchedReports, pendingJobs ] );
+		const completedReports: Report[] = fetchedReports.map( ( report ) => ( {
+			...report,
+			status: isArchived( report.id ) ? ( 'archived' as const ) : ( 'active' as const ),
+		} ) );
+		return [ ...pendingReports, ...completedReports ];
+	}, [ fetchedReports, pendingJobs, isArchived ] );
 
 	// Once a pending job is resolved by an R2 entry, tell the parent so it can
 	// drop the job from its state + sessionStorage. Without this, resolved jobs
@@ -237,7 +296,79 @@ export default function AmplifyReportsContent( {
 		...initialDataViewsState,
 		type: DATAVIEWS_TABLE,
 		fields: [ 'site', 'mode', 'scores', 'timestamp', 'download' ],
+		// Default to showing Active reports only. The user can switch to
+		// Archived or remove the filter for All via the DataViews filter UI.
+		filters: [ { field: 'status', operator: 'is', value: 'active' } ],
+		// Override the shared a4a default of 50 — the reports list grows one
+		// row per analysis, so 50/page would push pagination controls off
+		// indefinitely. 10 keeps the page scannable and surfaces pagination
+		// once a Partner Manager has run their 11th analysis. Users can bump
+		// this up via the DataViews settings cog (Items per page).
+		perPage: 10,
 	} );
+
+	// Memoized so the actions array below doesn't recreate on every render,
+	// which in turn keeps DataViews from re-mounting the row action menus.
+	const handleArchive = useCallback(
+		( item: Report ) => {
+			archive( item.id );
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_amplify_report_archive', {
+					report_id: item.id,
+					site_url: item.url,
+					analysis_type: item.mode,
+				} )
+			);
+			dispatch(
+				successNotice( __( 'Report archived.' ), {
+					id: 'amplify-report-archive-success',
+					duration: 4000,
+				} )
+			);
+		},
+		[ archive, dispatch ]
+	);
+
+	const handleUnarchive = useCallback(
+		( item: Report ) => {
+			unarchive( item.id );
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_amplify_report_unarchive', {
+					report_id: item.id,
+					site_url: item.url,
+					analysis_type: item.mode,
+				} )
+			);
+			dispatch(
+				successNotice( __( 'Report restored.' ), {
+					id: 'amplify-report-unarchive-success',
+					duration: 4000,
+				} )
+			);
+		},
+		[ unarchive, dispatch ]
+	);
+
+	// Triggered from the "Amplify now" CTA inside the archived-report
+	// popover. Opens the analysis-type modal pre-loaded with this report's
+	// site URL, skipping the site picker — the parent (amplify-page.tsx)
+	// handles the modal flow via onSiteSelected. The original archived
+	// report stays archived; this only kicks off a brand-new analysis for
+	// the same site. We also fire a dedicated tracks event so we can tell
+	// archive-driven re-runs apart from normal new-analysis flows.
+	const handleAmplifyNow = useCallback(
+		( item: Report ) => {
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_amplify_archived_amplify_now_click', {
+					report_id: item.id,
+					site_url: item.url,
+					analysis_type: item.mode,
+				} )
+			);
+			onSiteSelected( item.url );
+		},
+		[ dispatch, onSiteSelected ]
+	);
 
 	// Memoized separately so the fields array below doesn't recreate on every render.
 	const handleDownload = useCallback(
@@ -274,7 +405,15 @@ export default function AmplifyReportsContent( {
 			{
 				id: 'site',
 				label: __( 'Site' ),
-				getValue: ( { item }: { item: Report } ) => item.agencyName || item.url,
+				// Concatenate agencyName and url so DataViews' built-in search
+				// matches against either token. Sort order is still effectively
+				// alphabetical by agencyName (when present) then url, because the
+				// agencyName lands first in the returned string. `enableGlobalSearch`
+				// is required for the search box to apply to this field —
+				// DataViews ignores fields that don't opt in. (Confirmed against
+				// the existing add-site-modal in this same section.)
+				getValue: ( { item }: { item: Report } ) =>
+					[ item.agencyName, item.url ].filter( Boolean ).join( ' ' ),
 				render: ( { item }: { item: Report } ): ReactNode => (
 					<span className="amplify-reports-site">
 						<span className="amplify-reports-site-name">{ item.agencyName || item.url }</span>
@@ -283,6 +422,7 @@ export default function AmplifyReportsContent( {
 				),
 				enableHiding: false,
 				enableSorting: true,
+				enableGlobalSearch: true,
 			},
 			{
 				id: 'mode',
@@ -300,21 +440,36 @@ export default function AmplifyReportsContent( {
 				id: 'scores',
 				label: __( 'Scores' ),
 				getValue: () => '',
-				render: ( { item }: { item: Report } ): ReactNode => (
-					<span className="amplify-reports-scores">
-						{ item.mode === 'fullanalysis' ? (
-							<>
-								<ScoreBadge score={ item.humanScore } label={ __( 'Human' ) } />
-								<ScoreBadge score={ item.aiScore } label={ __( 'AI' ) } />
-							</>
-						) : (
-							<ScoreBadge
-								score={ item.score }
-								label={ item.mode === 'human' ? __( 'Human' ) : __( 'AI' ) }
-							/>
-						) }
-					</span>
-				),
+				render: ( { item }: { item: Report } ): ReactNode => {
+					// Pending rows have no scores yet — render an em dash
+					// placeholder rather than an empty cell so the column
+					// visibly tracks the row instead of looking broken.
+					if ( item.pending ) {
+						return (
+							<span
+								className="amplify-reports-scores-placeholder"
+								aria-label={ __( 'Scores not yet available' ) }
+							>
+								—
+							</span>
+						);
+					}
+					return (
+						<span className="amplify-reports-scores">
+							{ item.mode === 'fullanalysis' ? (
+								<>
+									<ScoreBadge score={ item.humanScore } label={ __( 'Human' ) } />
+									<ScoreBadge score={ item.aiScore } label={ __( 'AI' ) } />
+								</>
+							) : (
+								<ScoreBadge
+									score={ item.score }
+									label={ item.mode === 'human' ? __( 'Human' ) : __( 'AI' ) }
+								/>
+							) }
+						</span>
+					);
+				},
 				enableHiding: true,
 				enableSorting: false,
 			},
@@ -332,10 +487,51 @@ export default function AmplifyReportsContent( {
 				id: 'download',
 				label: __( 'Download' ),
 				getValue: () => '',
-				render: ( { item }: { item: Report } ): ReactNode =>
-					item.pending ? (
-						<span className="amplify-reports-in-progress">{ __( 'Report in progress' ) }</span>
-					) : (
+				render: ( { item }: { item: Report } ): ReactNode => {
+					if ( item.pending ) {
+						return (
+							<span className="amplify-reports-in-progress">{ __( 'Analysis in progress' ) }</span>
+						);
+					}
+					if ( item.status === 'archived' ) {
+						// Archived reports intentionally hide the Download PDF
+						// button. The underlying PDF still lives in R2 and the
+						// user can Restore the report from the row's ellipsis
+						// menu to get the button back. The popover here tells
+						// them why the action is gone and offers an inline
+						// "Amplify now" link that kicks off a fresh analysis
+						// for the same site. The render-prop form gives us a
+						// `close` handle so the popover dismisses cleanly the
+						// moment the modal flow takes over — we don't want it
+						// to linger underneath the analysis modal.
+						return (
+							<span className="amplify-reports-archived">
+								<span className="amplify-reports-archived-label">{ __( 'Archived' ) }</span>
+								<AmplifyInfoPopover ariaLabel={ __( 'About archived reports' ) }>
+									{ ( { close }: { close: () => void } ) => (
+										<div className="amplify-reports-archived-popover">
+											<p className="amplify-reports-archived-popover-body">
+												{ __(
+													'This report is archived. Sites change quickly. Amplify the site again to see what’s different.'
+												) }
+											</p>
+											<Button
+												variant="link"
+												className="amplify-reports-archived-popover-cta"
+												onClick={ () => {
+													close();
+													handleAmplifyNow( item );
+												} }
+											>
+												{ __( 'Amplify now' ) }
+											</Button>
+										</div>
+									) }
+								</AmplifyInfoPopover>
+							</span>
+						);
+					}
+					return (
 						<Button
 							variant="secondary"
 							size="compact"
@@ -346,12 +542,67 @@ export default function AmplifyReportsContent( {
 						>
 							{ __( 'Download PDF' ) }
 						</Button>
-					),
+					);
+				},
 				enableHiding: false,
 				enableSorting: false,
 			},
+			{
+				// Status field exists for filtering (and for filterSortAndPaginate's
+				// matcher) — it's not added to the visible `fields` array in the
+				// DataViews state, so it doesn't render as a column. The
+				// `elements` here populate the All / Active / Archived filter UI.
+				id: 'status',
+				label: __( 'Status' ),
+				getValue: ( { item }: { item: Report } ) => item.status,
+				elements: [
+					{ value: 'active', label: __( 'Active' ) },
+					{ value: 'archived', label: __( 'Archived' ) },
+				],
+				filterBy: {
+					operators: [ 'is' ],
+					isPrimary: true,
+				},
+				enableHiding: true,
+				enableSorting: false,
+			},
 		];
-	}, [ dispatch ] );
+	}, [ handleDownload, handleAmplifyNow ] );
+
+	// DataViews actions appear in a built-in column at the end of each row.
+	// `isPrimary: false` puts them under the row's ellipsis menu rather than
+	// rendering an inline button. `isEligible` is evaluated per row so we
+	// hide Archive on already-archived (and pending) reports, and hide
+	// Restore on active ones.
+	const actions: Action< Report >[] = useMemo(
+		() => [
+			{
+				id: 'archive-report',
+				label: __( 'Archive' ),
+				isPrimary: false,
+				callback: ( items: Report[] ) => {
+					const report = items[ 0 ];
+					if ( report ) {
+						handleArchive( report );
+					}
+				},
+				isEligible: ( item: Report ) => ! item.pending && item.status !== 'archived',
+			},
+			{
+				id: 'unarchive-report',
+				label: __( 'Restore' ),
+				isPrimary: false,
+				callback: ( items: Report[] ) => {
+					const report = items[ 0 ];
+					if ( report ) {
+						handleUnarchive( report );
+					}
+				},
+				isEligible: ( item: Report ) => ! item.pending && item.status === 'archived',
+			},
+		],
+		[ handleArchive, handleUnarchive ]
+	);
 
 	const { data: items, paginationInfo: pagination } = useMemo( () => {
 		return filterSortAndPaginate( reports, dataViewsState, fields );
@@ -390,9 +641,10 @@ export default function AmplifyReportsContent( {
 					items,
 					getItemId: ( item: Report ) => item.id,
 					pagination,
-					enableSearch: false,
+					enableSearch: true,
+					searchLabel: __( 'Search by site or URL' ),
 					fields,
-					actions: [],
+					actions,
 					setDataViewsState,
 					dataViewsState,
 					defaultLayouts: { table: {} },

--- a/client/a8c-for-agencies/sections/amplify/amplify-reports-content.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-reports-content.tsx
@@ -58,6 +58,29 @@ const MODE_LABELS: Record< AnalysisMode, string > = {
 	fullanalysis: 'Full',
 };
 
+/**
+ * Determines whether a pending Trigger.dev job has a matching completed report
+ * in the R2 index. See the comment on the merge useMemo below for the full
+ * rationale on why we match by url + normalized mode + timestamp window rather
+ * than by ID.
+ */
+function isPendingJobResolved( job: PendingJob, fetchedReports: Report[] ): boolean {
+	const normalizedMode: AnalysisMode =
+		job.type === 'full' ? 'fullanalysis' : ( job.type as AnalysisMode );
+	return fetchedReports.some(
+		( r ) =>
+			r.url === job.site &&
+			r.mode === normalizedMode &&
+			// Lexicographic compare of ISO 8601 strings is correct here only
+			// because both timestamps come from Date.prototype.toISOString(),
+			// which always produces the canonical 'YYYY-MM-DDTHH:mm:ss.sssZ'
+			// form. If a future caller passes a timestamp in any other format
+			// (locale string, offset other than Z, missing milliseconds), switch
+			// this to Date.parse(...) comparisons.
+			r.timestamp >= job.startedAt
+	);
+}
+
 function useAmplifyReports(): { reports: Report[]; isLoading: boolean; error: string | null } {
 	const [ reports, setReports ] = useState< Report[] >( [] );
 	const [ isLoading, setIsLoading ] = useState( true );
@@ -138,24 +161,43 @@ function ScoreBadge( { score, label }: { score?: number; label: string } ) {
 export default function AmplifyReportsContent( {
 	pendingJobs = [],
 	onSiteSelected,
+	onPendingJobsResolved,
 }: {
 	pendingJobs?: PendingJob[];
 	onSiteSelected: ( url: string ) => void;
+	/**
+	 * Called with the jobIds of any pending jobs that now have a matching
+	 * completed report in the R2 index. Used by the parent to prune resolved
+	 * entries out of sessionStorage so the pending list doesn't accumulate.
+	 *
+	 * **Must be referentially stable across renders** (wrap in `useCallback`
+	 * with stable deps in the parent). The effect below lists this prop as a
+	 * dependency, so an unstable reference will fire the effect on every
+	 * render and risk a re-render loop.
+	 */
+	onPendingJobsResolved?: ( jobIds: string[] ) => void;
 } ) {
 	const dispatch = useDispatch();
 	const { reports: fetchedReports, isLoading, error } = useAmplifyReports();
 
 	// Merge pending jobs into the reports list. A pending job is shown at the
 	// top with the `pending` flag set. Once the R2 index updates and a real
-	// report with the same site + mode appears, the pending row will naturally
-	// be replaced on the next fetch (page reload). We deduplicate by jobId so a
-	// pending row never shows alongside the completed report for the same run.
+	// report appears for the same site + mode, the pending row is dropped on the
+	// next render so the table flips from "Report in progress" to the real row.
+	//
+	// We can't match on ID because the Trigger.dev jobId (held by the pending
+	// entry) and the R2 report id (the report filename basename) are different
+	// strings and there's no link between them in the index. Instead we match by
+	// url + normalized mode + a timestamp window: a completed report counts as
+	// the resolution of a pending job if its timestamp is at or after the job's
+	// startedAt. That keeps stale prior runs for the same URL from prematurely
+	// dropping a fresh pending row.
+	//
 	// Memoized so that table interactions (sort/filter/paginate) that trigger a
-	// re-render don't rebuild the Set and re-map the arrays unnecessarily.
+	// re-render don't rebuild the match index and re-map the arrays unnecessarily.
 	const reports = useMemo( () => {
-		const completedJobIds = new Set( fetchedReports.map( ( r ) => r.id ) );
 		const pendingReports: Report[] = pendingJobs
-			.filter( ( job ) => ! completedJobIds.has( job.jobId ) )
+			.filter( ( job ) => ! isPendingJobResolved( job, fetchedReports ) )
 			.map( ( job ) => ( {
 				id: job.jobId,
 				agencyName: '',
@@ -166,6 +208,30 @@ export default function AmplifyReportsContent( {
 			} ) );
 		return [ ...pendingReports, ...fetchedReports ];
 	}, [ fetchedReports, pendingJobs ] );
+
+	// Once a pending job is resolved by an R2 entry, tell the parent so it can
+	// drop the job from its state + sessionStorage. Without this, resolved jobs
+	// would render-filter correctly but accumulate forever in sessionStorage.
+	// The filter pattern in the parent's setter makes a no-op call cheap, but we
+	// still short-circuit here so we don't fire a state update for every render.
+	//
+	// Loop-prevention invariant: the parent's handlePendingJobsResolved must
+	// return the same array reference when nothing was actually pruned
+	// (reference-equality short-circuit in setPendingJobs). Without that, the
+	// new pendingJobs prop reference would re-run this effect every render and
+	// cause a re-render loop. If you change handlePendingJobsResolved, preserve
+	// that short-circuit.
+	useEffect( () => {
+		if ( ! onPendingJobsResolved || pendingJobs.length === 0 || fetchedReports.length === 0 ) {
+			return;
+		}
+		const resolvedIds = pendingJobs
+			.filter( ( job ) => isPendingJobResolved( job, fetchedReports ) )
+			.map( ( job ) => job.jobId );
+		if ( resolvedIds.length > 0 ) {
+			onPendingJobsResolved( resolvedIds );
+		}
+	}, [ pendingJobs, fetchedReports, onPendingJobsResolved ] );
 
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
 		...initialDataViewsState,

--- a/client/a8c-for-agencies/sections/amplify/amplify-reports-content.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-reports-content.tsx
@@ -1,9 +1,25 @@
+/**
+ * AmplifyReportsContent
+ *
+ * Fetches the reports index from Cloudflare R2 and renders them in a DataViews
+ * table. Also accepts `pendingJobs` from amplify-page.tsx — jobs that have been
+ * submitted but not yet written to R2. These are merged at the top of the list
+ * and shown with an "In progress" indicator instead of a download button.
+ *
+ * Data flow:
+ *   R2 index (https://pub-*.r2.dev/reports/index.json)
+ *     └── fetched on mount, refreshed only on page reload
+ *   pendingJobs (in-memory, from amplify-page.tsx)
+ *     └── added immediately when a job is submitted via the analysis modal
+ *     └── displayed until the page is reloaded and R2 reflects the real status
+ */
+
 import { Button } from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { download } from '@wordpress/icons';
 import clsx from 'clsx';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
 	DATAVIEWS_TABLE,
 	initialDataViewsState,
@@ -12,47 +28,80 @@ import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import AmplifySiteSelect from './amplify-site-select';
 import type { Field } from '@wordpress/dataviews';
 import type { ReactNode } from 'react';
+import type { PendingJob } from './amplify-analysis-modal';
 
-type AnalysisType = 'human' | 'ai' | 'full';
+type AnalysisMode = 'human' | 'ai' | 'fullanalysis';
 
 type Report = {
 	id: string;
-	site: string;
-	analysisType: AnalysisType;
+	agencyName: string;
+	url: string;
+	mode: AnalysisMode;
 	timestamp: string;
+	humanScore?: number;
+	aiScore?: number;
+	score?: number;
+	pdfUrl?: string;
+	reportUrl?: string;
+	/** True for jobs submitted this session that haven't yet appeared in R2. */
+	pending?: boolean;
 };
 
-const REPORTS: Report[] = [
-	{ id: '1', site: 'brightleaf.studio', analysisType: 'human', timestamp: '2026-04-28T15:42:00Z' },
-	{ id: '2', site: 'pixelcraft.agency', analysisType: 'ai', timestamp: '2026-04-28T11:18:00Z' },
-	{ id: '3', site: 'novastudio.design', analysisType: 'full', timestamp: '2026-04-27T17:21:00Z' },
-	{ id: '4', site: 'webweavers.co', analysisType: 'human', timestamp: '2026-04-26T09:04:00Z' },
-	{
-		id: '5',
-		site: 'crestlinestudio.com',
-		analysisType: 'full',
-		timestamp: '2026-04-25T14:33:00Z',
-	},
-	{ id: '6', site: 'atlasdigital.io', analysisType: 'ai', timestamp: '2026-04-24T10:57:00Z' },
-	{ id: '7', site: 'unityworks.studio', analysisType: 'human', timestamp: '2026-04-22T16:09:00Z' },
-	{ id: '8', site: 'forgemedia.co', analysisType: 'full', timestamp: '2026-04-21T13:48:00Z' },
-	{
-		id: '9',
-		site: 'canopycollective.com',
-		analysisType: 'ai',
-		timestamp: '2026-04-19T08:12:00Z',
-	},
-	{
-		id: '10',
-		site: 'lightspring.agency',
-		analysisType: 'full',
-		timestamp: '2026-04-17T15:55:00Z',
-	},
-	{ id: '11', site: 'orbitcreative.io', analysisType: 'human', timestamp: '2026-04-14T11:30:00Z' },
-	{ id: '12', site: 'relayhq.studio', analysisType: 'ai', timestamp: '2026-04-10T18:02:00Z' },
-];
+const INDEX_URL =
+	'https://pub-d85717c601eb44398d8336c65ac7cfbb.r2.dev/reports/index.json';
+
+const MODE_LABELS: Record< AnalysisMode, string > = {
+	human: 'Human',
+	ai: 'AI',
+	fullanalysis: 'Full',
+};
+
+function useAmplifyReports(): { reports: Report[]; isLoading: boolean; error: string | null } {
+	const [ reports, setReports ] = useState< Report[] >( [] );
+	const [ isLoading, setIsLoading ] = useState( true );
+	const [ error, setError ] = useState< string | null >( null );
+
+	useEffect( () => {
+		let cancelled = false;
+
+		window
+			.fetch( `${ INDEX_URL }?_=${ Date.now() }` )
+			.then( ( res ) => {
+				// 404 means no analyses have been run yet — treat as empty, not error.
+				if ( res.status === 404 ) {
+					return { reports: [] };
+				}
+				if ( ! res.ok ) {
+					throw new Error( `Failed to load reports: ${ res.status }` );
+				}
+				return res.json();
+			} )
+			.then( ( data ) => {
+				if ( ! cancelled ) {
+					setReports( Array.isArray( data.reports ) ? data.reports : [] );
+				}
+			} )
+			.catch( ( err ) => {
+				if ( ! cancelled ) {
+					setError( err.message );
+				}
+			} )
+			.finally( () => {
+				if ( ! cancelled ) {
+					setIsLoading( false );
+				}
+			} );
+
+		return () => {
+			cancelled = true;
+		};
+	}, [] );
+
+	return { reports, isLoading, error };
+}
 
 function formatTimestamp( iso: string ): string {
 	return new Date( iso ).toLocaleString( undefined, {
@@ -63,60 +112,131 @@ function formatTimestamp( iso: string ): string {
 	} );
 }
 
-export default function AmplifyReportsContent() {
+function ScoreBadge( { score, label }: { score?: number; label: string } ) {
+	if ( score === undefined ) {
+		return null;
+	}
+	const threshold = score >= 80 ? 'strong' : score >= 50 ? 'needs-work' : 'at-risk';
+	return (
+		<span className={ clsx( 'amplify-reports-score', `is-${ threshold }` ) }>
+			{ sprintf(
+				/* translators: %1$s is the score label (e.g. Human), %2$d is the numeric score */
+				__( '%1$s %2$d' ),
+				label,
+				score
+			) }
+		</span>
+	);
+}
+
+export default function AmplifyReportsContent( {
+	pendingJobs = [],
+	onSiteSelected,
+}: {
+	pendingJobs?: PendingJob[];
+	onSiteSelected: ( url: string ) => void;
+} ) {
 	const dispatch = useDispatch();
+	const { reports: fetchedReports, isLoading, error } = useAmplifyReports();
+
+	// Merge pending jobs into the reports list. A pending job is shown at the
+	// top with the `pending` flag set. Once the R2 index updates and a real
+	// report with the same site + mode appears, the pending row will naturally
+	// be replaced on the next fetch (page reload). We deduplicate by jobId so a
+	// pending row never shows alongside the completed report for the same run.
+	const completedJobIds = new Set( fetchedReports.map( ( r ) => r.id ) );
+	const pendingReports: Report[] = pendingJobs
+		.filter( ( job ) => ! completedJobIds.has( job.jobId ) )
+		.map( ( job ) => ( {
+			id: job.jobId,
+			agencyName: '',
+			url: job.site,
+			mode: job.type === 'full' ? 'fullanalysis' : ( job.type as AnalysisMode ),
+			timestamp: job.startedAt,
+			pending: true,
+		} ) );
+
+	const reports = [ ...pendingReports, ...fetchedReports ];
+
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
 		...initialDataViewsState,
 		type: DATAVIEWS_TABLE,
-		fields: [ 'site', 'analysisType', 'timestamp', 'download' ],
+		fields: [ 'site', 'mode', 'scores', 'timestamp', 'download' ],
 	} );
 
 	const fields: Field< Report >[] = useMemo( () => {
-		const analysisLabels: Record< AnalysisType, string > = {
-			human: __( 'Human' ),
-			ai: __( 'AI' ),
-			full: __( 'Full' ),
-		};
-
 		const handleDownload = ( item: Report ) => {
 			dispatch(
 				recordTracksEvent( 'calypso_a4a_amplify_report_download', {
 					report_id: item.id,
-					site_url: item.site,
-					analysis_type: item.analysisType,
+					site_url: item.url,
+					analysis_type: item.mode,
 				} )
 			);
+			if ( item.pdfUrl ) {
+				// noopener prevents the new tab from accessing window.opener.
+				window.open( item.pdfUrl, '_blank', 'noopener,noreferrer' );
+			}
 		};
 
 		return [
 			{
 				id: 'site',
 				label: __( 'Site' ),
-				getValue: ( { item }: { item: Report } ) => item.site,
+				getValue: ( { item }: { item: Report } ) => item.agencyName || item.url,
 				render: ( { item }: { item: Report } ): ReactNode => (
-					<span className="amplify-reports-site">{ item.site }</span>
+					<span className="amplify-reports-site">
+						<span className="amplify-reports-site-name">
+							{ item.agencyName || item.url }
+						</span>
+						<span className="amplify-reports-site-url">{ item.url }</span>
+					</span>
 				),
 				enableHiding: false,
 				enableSorting: true,
 			},
 			{
-				id: 'analysisType',
+				id: 'mode',
 				label: __( 'Analysis type' ),
-				getValue: ( { item }: { item: Report } ) => analysisLabels[ item.analysisType ],
+				getValue: ( { item }: { item: Report } ) => MODE_LABELS[ item.mode ] ?? item.mode,
 				render: ( { item }: { item: Report } ): ReactNode => (
-					<span className={ clsx( 'amplify-reports-badge', `is-${ item.analysisType }` ) }>
-						{ analysisLabels[ item.analysisType ] }
+					<span className={ clsx( 'amplify-reports-badge', `is-${ item.mode }` ) }>
+						{ MODE_LABELS[ item.mode ] ?? item.mode }
 					</span>
 				),
 				enableHiding: true,
 				enableSorting: true,
 			},
 			{
+				id: 'scores',
+				label: __( 'Scores' ),
+				getValue: () => '',
+				render: ( { item }: { item: Report } ): ReactNode => (
+					<span className="amplify-reports-scores">
+						{ item.mode === 'fullanalysis' ? (
+							<>
+								<ScoreBadge score={ item.humanScore } label={ __( 'Human' ) } />
+								<ScoreBadge score={ item.aiScore } label={ __( 'AI' ) } />
+							</>
+						) : (
+							<ScoreBadge
+								score={ item.score }
+								label={ item.mode === 'human' ? __( 'Human' ) : __( 'AI' ) }
+							/>
+						) }
+					</span>
+				),
+				enableHiding: true,
+				enableSorting: false,
+			},
+			{
 				id: 'timestamp',
 				label: __( 'Time & date' ),
 				getValue: ( { item }: { item: Report } ) => item.timestamp,
 				render: ( { item }: { item: Report } ): ReactNode => (
-					<span className="amplify-reports-timestamp">{ formatTimestamp( item.timestamp ) }</span>
+					<span className="amplify-reports-timestamp">
+						{ formatTimestamp( item.timestamp ) }
+					</span>
 				),
 				enableHiding: false,
 				enableSorting: true,
@@ -125,17 +245,23 @@ export default function AmplifyReportsContent() {
 				id: 'download',
 				label: __( 'Download' ),
 				getValue: () => '',
-				render: ( { item }: { item: Report } ): ReactNode => (
-					<Button
-						variant="secondary"
-						size="compact"
-						icon={ download }
-						iconSize={ 16 }
-						onClick={ () => handleDownload( item ) }
-					>
-						{ __( 'Download PDF' ) }
-					</Button>
-				),
+				render: ( { item }: { item: Report } ): ReactNode =>
+					item.pending ? (
+						<span className="amplify-reports-in-progress">
+							{ __( 'Report in progress' ) }
+						</span>
+					) : (
+						<Button
+							variant="secondary"
+							size="compact"
+							icon={ download }
+							iconSize={ 16 }
+							disabled={ ! item.pdfUrl }
+							onClick={ () => handleDownload( item ) }
+						>
+							{ __( 'Download PDF' ) }
+						</Button>
+					),
 				enableHiding: false,
 				enableSorting: false,
 			},
@@ -143,8 +269,33 @@ export default function AmplifyReportsContent() {
 	}, [ dispatch ] );
 
 	const { data: items, paginationInfo: pagination } = useMemo( () => {
-		return filterSortAndPaginate( REPORTS, dataViewsState, fields );
-	}, [ dataViewsState, fields ] );
+		return filterSortAndPaginate( reports, dataViewsState, fields );
+	}, [ reports, dataViewsState, fields ] );
+
+	if ( isLoading ) {
+		return (
+			<div className="amplify-reports-loading">
+				{ __( 'Loading reports…' ) }
+			</div>
+		);
+	}
+
+	// Show the empty / prompt state only when there are truly no rows to display
+	// (no R2 reports and no pending jobs). A fetch error alone is not enough to
+	// hide pending rows — if R2 is unavailable the in-progress jobs should still
+	// be visible in the table.
+	if ( reports.length === 0 ) {
+		return (
+			<div className="amplify-reports-empty">
+				<p className="amplify-reports-empty-heading">
+					{ error
+						? __( 'Unable to load reports. Please refresh to try again.' )
+						: __( "You haven't run any Amplify analyses yet." ) }
+				</p>
+				{ ! error && <AmplifySiteSelect onSiteSelected={ onSiteSelected } /> }
+			</div>
+		);
+	}
 
 	return (
 		<div className="amplify-reports redesigned-a8c-table full-width">

--- a/client/a8c-for-agencies/sections/amplify/amplify-score-card.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-score-card.tsx
@@ -45,6 +45,42 @@ function thresholdLabel( score: number ): string {
 	return __( 'At risk' );
 }
 
+// Hoisted to module scope — static demo data, no reason to reallocate on every render.
+const MODES: Record< Mode, ModeData > = {
+	human: {
+		score: 86,
+		body: __(
+			'Your site is set up to win business. A few targeted refinements will keep you ahead.'
+		),
+		metrics: [
+			{ label: __( 'Trust signals' ), score: 16, max: 18 },
+			{ label: __( 'Contact & conversion' ), score: 13, max: 15 },
+			{ label: __( 'SEO' ), score: 10, max: 13 },
+			{ label: __( 'Mobile experience' ), score: 12, max: 13 },
+			{ label: __( 'Content quality' ), score: 10, max: 12 },
+			{ label: __( 'Design & experience' ), score: 9, max: 11 },
+			{ label: __( 'Accessibility' ), score: 8, max: 10 },
+			{ label: __( 'Audience resonance' ), score: 8, max: 8 },
+		],
+	},
+	ai: {
+		score: 42,
+		body: __(
+			"AI tools can't read or rank your site reliably yet. These gaps are likely costing you visibility."
+		),
+		metrics: [
+			{ label: __( 'Technical health' ), score: 12, max: 20 },
+			{ label: __( 'Structured data' ), score: 6, max: 18 },
+			{ label: __( 'AEO readiness' ), score: 6, max: 16 },
+			{ label: __( 'E-E-A-T signals' ), score: 6, max: 14 },
+			{ label: __( 'Content freshness' ), score: 5, max: 12 },
+			{ label: __( 'Entity clarity' ), score: 4, max: 10 },
+			{ label: __( 'Content specificity' ), score: 3, max: 7 },
+			{ label: 'llms.txt', score: 0, max: 3 },
+		],
+	},
+};
+
 export default function AmplifyScoreCard() {
 	const dispatch = useDispatch();
 	const [ mode, setMode ] = useState< Mode >( 'human' );
@@ -62,42 +98,7 @@ export default function AmplifyScoreCard() {
 		setMode( nextMode );
 	};
 
-	const modes: Record< Mode, ModeData > = {
-		human: {
-			score: 86,
-			body: __(
-				'Your site is set up to win business. A few targeted refinements will keep you ahead.'
-			),
-			metrics: [
-				{ label: __( 'Trust signals' ), score: 16, max: 18 },
-				{ label: __( 'Contact & conversion' ), score: 13, max: 15 },
-				{ label: __( 'SEO' ), score: 10, max: 13 },
-				{ label: __( 'Mobile experience' ), score: 12, max: 13 },
-				{ label: __( 'Content quality' ), score: 10, max: 12 },
-				{ label: __( 'Design & experience' ), score: 9, max: 11 },
-				{ label: __( 'Accessibility' ), score: 8, max: 10 },
-				{ label: __( 'Audience resonance' ), score: 8, max: 8 },
-			],
-		},
-		ai: {
-			score: 42,
-			body: __(
-				'AI tools can’t read or rank your site reliably yet. These gaps are likely costing you visibility.'
-			),
-			metrics: [
-				{ label: __( 'Technical health' ), score: 12, max: 20 },
-				{ label: __( 'Structured data' ), score: 6, max: 18 },
-				{ label: __( 'AEO readiness' ), score: 6, max: 16 },
-				{ label: __( 'E-E-A-T signals' ), score: 6, max: 14 },
-				{ label: __( 'Content freshness' ), score: 5, max: 12 },
-				{ label: __( 'Entity clarity' ), score: 4, max: 10 },
-				{ label: __( 'Content specificity' ), score: 3, max: 7 },
-				{ label: 'llms.txt', score: 0, max: 3 },
-			],
-		},
-	};
-
-	const data = modes[ mode ];
+	const data = MODES[ mode ];
 	const ringSeverity = severityFor( data.score, 100 );
 	const offset = CIRCUMFERENCE - ( data.score / 100 ) * CIRCUMFERENCE;
 

--- a/client/a8c-for-agencies/sections/amplify/amplify-score-card.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-score-card.tsx
@@ -6,12 +6,12 @@ type Mode = 'human' | 'ai';
 
 type Metric = {
 	label: string;
-	value: number;
+	score: number;
+	max: number;
 };
 
 type ModeData = {
 	score: number;
-	title: string;
 	body: string;
 	metrics: Metric[];
 };
@@ -20,14 +20,26 @@ const RADIUS = 36;
 const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
 const SAMPLE_URL = 'yourgroovydomain.com';
 
-function severityFor( value: number ): 'good' | 'warn' | 'danger' {
-	if ( value >= 80 ) {
+function severityFor( score: number, max: number ): 'good' | 'warn' | 'danger' {
+	const pct = ( score / max ) * 100;
+	if ( pct >= 80 ) {
 		return 'good';
 	}
-	if ( value >= 50 ) {
+	if ( pct >= 50 ) {
 		return 'warn';
 	}
 	return 'danger';
+}
+
+function thresholdLabel( score: number ): string {
+	// 80–100 Strong · 50–79 Needs work · 0–49 At risk
+	if ( score >= 80 ) {
+		return __( 'Strong' );
+	}
+	if ( score >= 50 ) {
+		return __( 'Needs work' );
+	}
+	return __( 'At risk' );
 }
 
 export default function AmplifyScoreCard() {
@@ -35,37 +47,41 @@ export default function AmplifyScoreCard() {
 
 	const modes: Record< Mode, ModeData > = {
 		human: {
-			score: 76,
-			title: __( 'Room to amplify' ),
+			score: 86,
 			body: __(
-				'Strong foundations, but a few areas may be costing you clients before they reach out.'
+				'Your site is set up to win business. A few targeted refinements will keep you ahead.'
 			),
 			metrics: [
-				{ label: __( 'First impressions' ), value: 88 },
-				{ label: __( 'Trust signals' ), value: 82 },
-				{ label: __( 'Portfolio quality' ), value: 78 },
-				{ label: __( 'SEO' ), value: 71 },
-				{ label: __( 'Service clarity' ), value: 65 },
+				{ label: __( 'Trust signals' ), score: 16, max: 18 },
+				{ label: __( 'Contact & conversion' ), score: 13, max: 15 },
+				{ label: __( 'SEO' ), score: 10, max: 13 },
+				{ label: __( 'Mobile experience' ), score: 12, max: 13 },
+				{ label: __( 'Content quality' ), score: 10, max: 12 },
+				{ label: __( 'Design & experience' ), score: 9, max: 11 },
+				{ label: __( 'Accessibility' ), score: 8, max: 10 },
+				{ label: __( 'Audience resonance' ), score: 8, max: 8 },
 			],
 		},
 		ai: {
-			score: 52,
-			title: __( 'Needs attention' ),
+			score: 42,
 			body: __(
-				'AI agents are struggling to read and rank your site. These gaps are costing you visibility.'
+				'AI tools can’t read or rank your site reliably yet. These gaps are likely costing you visibility.'
 			),
 			metrics: [
-				{ label: __( 'Technical performance' ), value: 74 },
-				{ label: __( 'Content specificity' ), value: 66 },
-				{ label: __( 'Crawl health' ), value: 61 },
-				{ label: __( 'AEO readiness' ), value: 48 },
-				{ label: __( 'Schema data' ), value: 29 },
+				{ label: __( 'Technical health' ), score: 12, max: 20 },
+				{ label: __( 'Structured data' ), score: 6, max: 18 },
+				{ label: __( 'AEO readiness' ), score: 6, max: 16 },
+				{ label: __( 'E-E-A-T signals' ), score: 6, max: 14 },
+				{ label: __( 'Content freshness' ), score: 5, max: 12 },
+				{ label: __( 'Entity clarity' ), score: 4, max: 10 },
+				{ label: __( 'Content specificity' ), score: 3, max: 7 },
+				{ label: 'llms.txt', score: 0, max: 3 },
 			],
 		},
 	};
 
 	const data = modes[ mode ];
-	const ringSeverity = severityFor( data.score );
+	const ringSeverity = severityFor( data.score, 100 );
 	const offset = CIRCUMFERENCE - ( data.score / 100 ) * CIRCUMFERENCE;
 
 	return (
@@ -85,7 +101,7 @@ export default function AmplifyScoreCard() {
 					} ) }
 					onClick={ () => setMode( 'human' ) }
 				>
-					{ __( 'Human mode' ) }
+					{ __( 'Human-centric analysis' ) }
 				</button>
 				<button
 					type="button"
@@ -96,7 +112,7 @@ export default function AmplifyScoreCard() {
 					} ) }
 					onClick={ () => setMode( 'ai' ) }
 				>
-					{ __( 'AI mode' ) }
+					{ __( 'AI analysis' ) }
 				</button>
 			</div>
 
@@ -119,24 +135,29 @@ export default function AmplifyScoreCard() {
 					</div>
 				</div>
 				<div>
-					<div className="amplify-landing-score-title">{ data.title }</div>
+					<div className={ clsx( 'amplify-landing-score-title', ringSeverity ) }>
+						{ thresholdLabel( data.score ) }
+					</div>
 					<div className="amplify-landing-score-body">{ data.body }</div>
 				</div>
 			</div>
 
 			<div className="amplify-landing-bars">
 				{ data.metrics.map( ( metric ) => {
-					const sev = severityFor( metric.value );
+					const sev = severityFor( metric.score, metric.max );
+					const pct = ( metric.score / metric.max ) * 100;
 					return (
 						<div key={ metric.label } className="amplify-landing-bar-row">
 							<span className="amplify-landing-bar-label">{ metric.label }</span>
 							<div className="amplify-landing-bar-track">
 								<div
 									className={ clsx( 'amplify-landing-bar-fill', sev ) }
-									style={ { inlineSize: `${ metric.value }%` } }
+									style={ { inlineSize: `${ pct }%` } }
 								/>
 							</div>
-							<span className={ clsx( 'amplify-landing-bar-val', sev ) }>{ metric.value }</span>
+							<span className={ clsx( 'amplify-landing-bar-val', sev ) }>
+								{ metric.score } / { metric.max }
+							</span>
 						</div>
 					);
 				} ) }

--- a/client/a8c-for-agencies/sections/amplify/amplify-score-card.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-score-card.tsx
@@ -50,7 +50,7 @@ const MODES: Record< Mode, ModeData > = {
 	human: {
 		score: 86,
 		body: __(
-			'Your site is set up to win business. A few targeted refinements will keep you ahead.'
+			"Your client's site is set up to win business. A few targeted refinements will keep you ahead."
 		),
 		metrics: [
 			{ label: __( 'Trust signals' ), score: 16, max: 18 },
@@ -66,7 +66,7 @@ const MODES: Record< Mode, ModeData > = {
 	ai: {
 		score: 42,
 		body: __(
-			"AI tools can't read or rank your site reliably yet. These gaps are likely costing you visibility."
+			"AI tools can't read or rank your client's site reliably yet. These gaps are likely costing you visibility."
 		),
 		metrics: [
 			{ label: __( 'Technical health' ), score: 12, max: 20 },

--- a/client/a8c-for-agencies/sections/amplify/amplify-score-card.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-score-card.tsx
@@ -1,0 +1,146 @@
+import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
+import { useState } from 'react';
+
+type Mode = 'human' | 'ai';
+
+type Metric = {
+	label: string;
+	value: number;
+};
+
+type ModeData = {
+	score: number;
+	title: string;
+	body: string;
+	metrics: Metric[];
+};
+
+const RADIUS = 36;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+const SAMPLE_URL = 'yourgroovydomain.com';
+
+function severityFor( value: number ): 'good' | 'warn' | 'danger' {
+	if ( value >= 80 ) {
+		return 'good';
+	}
+	if ( value >= 50 ) {
+		return 'warn';
+	}
+	return 'danger';
+}
+
+export default function AmplifyScoreCard() {
+	const [ mode, setMode ] = useState< Mode >( 'human' );
+
+	const modes: Record< Mode, ModeData > = {
+		human: {
+			score: 76,
+			title: __( 'Room to amplify' ),
+			body: __(
+				'Strong foundations, but a few areas may be costing you clients before they reach out.'
+			),
+			metrics: [
+				{ label: __( 'First impressions' ), value: 88 },
+				{ label: __( 'Trust signals' ), value: 82 },
+				{ label: __( 'Portfolio quality' ), value: 78 },
+				{ label: __( 'SEO' ), value: 71 },
+				{ label: __( 'Service clarity' ), value: 65 },
+			],
+		},
+		ai: {
+			score: 52,
+			title: __( 'Needs attention' ),
+			body: __(
+				'AI agents are struggling to read and rank your site. These gaps are costing you visibility.'
+			),
+			metrics: [
+				{ label: __( 'Technical performance' ), value: 74 },
+				{ label: __( 'Content specificity' ), value: 66 },
+				{ label: __( 'Crawl health' ), value: 61 },
+				{ label: __( 'AEO readiness' ), value: 48 },
+				{ label: __( 'Schema data' ), value: 29 },
+			],
+		},
+	};
+
+	const data = modes[ mode ];
+	const ringSeverity = severityFor( data.score );
+	const offset = CIRCUMFERENCE - ( data.score / 100 ) * CIRCUMFERENCE;
+
+	return (
+		<div className="amplify-landing-score-card">
+			<div className="amplify-landing-score-card-header">
+				<span className="amplify-landing-score-url">{ SAMPLE_URL }</span>
+				<span className="amplify-landing-score-status">{ __( 'Audit complete' ) }</span>
+			</div>
+
+			<div className="amplify-landing-mode-toggle" role="tablist" aria-label={ __( 'Score mode' ) }>
+				<button
+					type="button"
+					role="tab"
+					aria-selected={ mode === 'human' }
+					className={ clsx( 'amplify-landing-mode-btn', {
+						'is-active': mode === 'human',
+					} ) }
+					onClick={ () => setMode( 'human' ) }
+				>
+					{ __( 'Human mode' ) }
+				</button>
+				<button
+					type="button"
+					role="tab"
+					aria-selected={ mode === 'ai' }
+					className={ clsx( 'amplify-landing-mode-btn', {
+						'is-active': mode === 'ai',
+					} ) }
+					onClick={ () => setMode( 'ai' ) }
+				>
+					{ __( 'AI mode' ) }
+				</button>
+			</div>
+
+			<div className="amplify-landing-score-main">
+				<div className="amplify-landing-score-ring">
+					<svg viewBox="0 0 88 88" aria-hidden="true">
+						<circle className="amplify-landing-ring-track" cx="44" cy="44" r={ RADIUS } />
+						<circle
+							className={ clsx( 'amplify-landing-ring-fill', ringSeverity ) }
+							cx="44"
+							cy="44"
+							r={ RADIUS }
+							strokeDasharray={ CIRCUMFERENCE }
+							strokeDashoffset={ offset }
+						/>
+					</svg>
+					<div className="amplify-landing-ring-label">
+						<span className="amplify-landing-ring-num">{ data.score }</span>
+						<span className="amplify-landing-ring-of">/ 100</span>
+					</div>
+				</div>
+				<div>
+					<div className="amplify-landing-score-title">{ data.title }</div>
+					<div className="amplify-landing-score-body">{ data.body }</div>
+				</div>
+			</div>
+
+			<div className="amplify-landing-bars">
+				{ data.metrics.map( ( metric ) => {
+					const sev = severityFor( metric.value );
+					return (
+						<div key={ metric.label } className="amplify-landing-bar-row">
+							<span className="amplify-landing-bar-label">{ metric.label }</span>
+							<div className="amplify-landing-bar-track">
+								<div
+									className={ clsx( 'amplify-landing-bar-fill', sev ) }
+									style={ { inlineSize: `${ metric.value }%` } }
+								/>
+							</div>
+							<span className={ clsx( 'amplify-landing-bar-val', sev ) }>{ metric.value }</span>
+						</div>
+					);
+				} ) }
+			</div>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/amplify/amplify-score-card.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-score-card.tsx
@@ -1,6 +1,9 @@
+import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useState } from 'react';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 type Mode = 'human' | 'ai';
 
@@ -43,7 +46,21 @@ function thresholdLabel( score: number ): string {
 }
 
 export default function AmplifyScoreCard() {
+	const dispatch = useDispatch();
 	const [ mode, setMode ] = useState< Mode >( 'human' );
+
+	const handleModeChange = ( nextMode: Mode ) => {
+		if ( nextMode === mode ) {
+			return;
+		}
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_amplify_mode_toggle', {
+				mode: nextMode,
+				surface: 'score_card',
+			} )
+		);
+		setMode( nextMode );
+	};
 
 	const modes: Record< Mode, ModeData > = {
 		human: {
@@ -92,28 +109,26 @@ export default function AmplifyScoreCard() {
 			</div>
 
 			<div className="amplify-landing-mode-toggle" role="tablist" aria-label={ __( 'Score mode' ) }>
-				<button
-					type="button"
+				<Button
 					role="tab"
 					aria-selected={ mode === 'human' }
 					className={ clsx( 'amplify-landing-mode-btn', {
 						'is-active': mode === 'human',
 					} ) }
-					onClick={ () => setMode( 'human' ) }
+					onClick={ () => handleModeChange( 'human' ) }
 				>
 					{ __( 'Human-centric analysis' ) }
-				</button>
-				<button
-					type="button"
+				</Button>
+				<Button
 					role="tab"
 					aria-selected={ mode === 'ai' }
 					className={ clsx( 'amplify-landing-mode-btn', {
 						'is-active': mode === 'ai',
 					} ) }
-					onClick={ () => setMode( 'ai' ) }
+					onClick={ () => handleModeChange( 'ai' ) }
 				>
 					{ __( 'AI analysis' ) }
-				</button>
+				</Button>
 			</div>
 
 			<div className="amplify-landing-score-main">

--- a/client/a8c-for-agencies/sections/amplify/amplify-site-select.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-site-select.tsx
@@ -4,6 +4,7 @@ import { Icon, chevronDown } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useMemo, useState } from 'react';
 import useFetchActiveSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-active-sites';
+import AmplifyAnalysisModal from './amplify-analysis-modal';
 
 type Site = {
 	id: number;
@@ -21,6 +22,7 @@ export default function AmplifySiteSelect() {
 	const { data, isLoading } = useFetchActiveSites( { autoRefresh: false } );
 	const [ selectedUrl, setSelectedUrl ] = useState< string | null >( null );
 	const [ search, setSearch ] = useState( '' );
+	const [ analysisFlowSite, setAnalysisFlowSite ] = useState< string | null >( null );
 
 	const allSites: Site[] = useMemo( () => {
 		const list = Array.isArray( data ) ? ( data as Site[] ) : [];
@@ -140,11 +142,17 @@ export default function AmplifySiteSelect() {
 				variant="primary"
 				disabled={ ! selectedUrl }
 				onClick={ () => {
-					/* Wired in a follow-up. */
+					if ( selectedUrl ) {
+						setAnalysisFlowSite( selectedUrl );
+					}
 				} }
 			>
 				{ __( 'Amplify it' ) }
 			</Button>
+			<AmplifyAnalysisModal
+				site={ analysisFlowSite }
+				onClose={ () => setAnalysisFlowSite( null ) }
+			/>
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/amplify/amplify-site-select.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-site-select.tsx
@@ -2,17 +2,18 @@ import { Button, Dropdown, TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, chevronDown } from '@wordpress/icons';
 import clsx from 'clsx';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import useConnectedSites from './hooks/use-connected-sites';
 
 const RECENT_LIMIT = 10;
+const SEARCH_DEBOUNCE_MS = 150;
 
 type Props = {
 	/**
-	 * Called when the user hits "Amplify it". AmplifyPage owns the analysis
-	 * modal — this component just signals which URL to analyse.
+	 * Called when the user hits "Amplify it." AmplifyPage owns the analysis
+	 * modal — this component just signals which URL to analyze.
 	 */
 	onSiteSelected: ( url: string ) => void;
 };
@@ -20,10 +21,26 @@ type Props = {
 export default function AmplifySiteSelect( { onSiteSelected }: Props ) {
 	const dispatch = useDispatch();
 	const [ selectedUrl, setSelectedUrl ] = useState< string | null >( null );
-	const [ search, setSearch ] = useState( '' );
+
+	// `searchInput` is the controlled value bound to the TextControl so the
+	// field stays responsive to keystrokes. `debouncedSearch` is what we feed
+	// into useConnectedSites, so the filter only re-runs after the user pauses
+	// typing. Keeps the dropdown smooth on accounts with many connected sites.
+	const [ searchInput, setSearchInput ] = useState( '' );
+	const [ debouncedSearch, setDebouncedSearch ] = useState( '' );
+
+	useEffect( () => {
+		if ( searchInput === debouncedSearch ) {
+			return;
+		}
+		const timer = setTimeout( () => {
+			setDebouncedSearch( searchInput );
+		}, SEARCH_DEBOUNCE_MS );
+		return () => clearTimeout( timer );
+	}, [ searchInput, debouncedSearch ] );
 
 	const { sites, isLoading, hasAnyConnectedSites } = useConnectedSites( {
-		search,
+		search: debouncedSearch,
 		limit: RECENT_LIMIT,
 	} );
 
@@ -42,9 +59,7 @@ export default function AmplifySiteSelect( { onSiteSelected }: Props ) {
 
 	const handleSelectSite = ( url: string ) => {
 		setSelectedUrl( url );
-		dispatch(
-			recordTracksEvent( 'calypso_a4a_amplify_site_select', { site_url: url } )
-		);
+		dispatch( recordTracksEvent( 'calypso_a4a_amplify_site_select', { site_url: url } ) );
 	};
 
 	const handleAmplifyClick = () => {
@@ -52,7 +67,10 @@ export default function AmplifySiteSelect( { onSiteSelected }: Props ) {
 			return;
 		}
 		dispatch(
-			recordTracksEvent( 'calypso_a4a_amplify_audit_open', { site_url: selectedUrl } )
+			recordTracksEvent( 'calypso_a4a_amplify_audit_open', {
+				site_url: selectedUrl,
+				entry_point: 'hero_dropdown',
+			} )
 		);
 		onSiteSelected( selectedUrl );
 	};
@@ -60,9 +78,7 @@ export default function AmplifySiteSelect( { onSiteSelected }: Props ) {
 	return (
 		<div className="amplify-landing-selector">
 			<div className="amplify-landing-selector-field">
-				<span className="amplify-landing-selector-label">
-					{ __( 'Recently connected sites' ) }
-				</span>
+				<span className="amplify-landing-selector-label">{ __( 'Recently connected sites' ) }</span>
 				<Dropdown
 					className="amplify-landing-site-dropdown"
 					contentClassName="amplify-landing-site-dropdown-content"
@@ -70,7 +86,10 @@ export default function AmplifySiteSelect( { onSiteSelected }: Props ) {
 					popoverProps={ { offset: 4, shift: true } }
 					onToggle={ ( isOpen ) => {
 						if ( ! isOpen ) {
-							setSearch( '' );
+							// Reset both the input and the debounced value when the
+							// dropdown closes so reopening starts from a clean state.
+							setSearchInput( '' );
+							setDebouncedSearch( '' );
 						}
 					} }
 					renderToggle={ ( { isOpen, onToggle } ) => (
@@ -102,15 +121,13 @@ export default function AmplifySiteSelect( { onSiteSelected }: Props ) {
 									__next40pxDefaultSize
 									label={ __( 'Search' ) }
 									hideLabelFromVision
-									value={ search }
-									onChange={ setSearch }
+									value={ searchInput }
+									onChange={ setSearchInput }
 									placeholder={ __( 'Search connected sites' ) }
 								/>
 							</div>
 							{ sites.length === 0 ? (
-								<p className="amplify-landing-site-dropdown-empty">
-									{ __( 'No matches' ) }
-								</p>
+								<p className="amplify-landing-site-dropdown-empty">{ __( 'No matches' ) }</p>
 							) : (
 								<ul className="amplify-landing-site-dropdown-list" role="listbox">
 									{ sites.map( ( site ) => {

--- a/client/a8c-for-agencies/sections/amplify/amplify-site-select.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-site-select.tsx
@@ -1,0 +1,149 @@
+import { Button, Dropdown, TextControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Icon, chevronDown } from '@wordpress/icons';
+import clsx from 'clsx';
+import { useMemo, useState } from 'react';
+import useFetchActiveSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-active-sites';
+
+type Site = {
+	id: number;
+	url: string;
+	features?: {
+		wpcom_atomic?: {
+			state?: string;
+		};
+	};
+};
+
+const RECENT_LIMIT = 10;
+
+export default function AmplifySiteSelect() {
+	const { data, isLoading } = useFetchActiveSites( { autoRefresh: false } );
+	const [ selectedUrl, setSelectedUrl ] = useState< string | null >( null );
+	const [ search, setSearch ] = useState( '' );
+
+	const allSites: Site[] = useMemo( () => {
+		const list = Array.isArray( data ) ? ( data as Site[] ) : [];
+		return list
+			.filter( ( site ) => {
+				if ( ! site.url ) {
+					return false;
+				}
+				const state = site.features?.wpcom_atomic?.state;
+				return state === undefined || state === 'active';
+			} )
+			.sort( ( a, b ) => b.id - a.id );
+	}, [ data ] );
+
+	const visibleSites = useMemo( () => {
+		const query = search.trim().toLowerCase();
+		return query
+			? allSites.filter( ( site ) => site.url.toLowerCase().includes( query ) )
+			: allSites.slice( 0, RECENT_LIMIT );
+	}, [ allSites, search ] );
+
+	const hasSites = allSites.length > 0;
+	const isDisabled = isLoading || ! hasSites;
+
+	let toggleText: string;
+	if ( selectedUrl ) {
+		toggleText = selectedUrl;
+	} else if ( isLoading ) {
+		toggleText = __( 'Loading sites…' );
+	} else if ( ! hasSites ) {
+		toggleText = __( 'No connected sites yet' );
+	} else {
+		toggleText = __( 'Search or select a site' );
+	}
+
+	return (
+		<div className="amplify-landing-selector">
+			<div className="amplify-landing-selector-field">
+				<span className="amplify-landing-selector-label">{ __( 'Recently connected sites' ) }</span>
+				<Dropdown
+					className="amplify-landing-site-dropdown"
+					contentClassName="amplify-landing-site-dropdown-content"
+					placement="bottom-start"
+					popoverProps={ { offset: 4, shift: true } }
+					onToggle={ ( isOpen ) => {
+						if ( ! isOpen ) {
+							setSearch( '' );
+						}
+					} }
+					renderToggle={ ( { isOpen, onToggle } ) => (
+						<button
+							type="button"
+							className={ clsx( 'amplify-landing-site-dropdown-toggle', {
+								'is-open': isOpen,
+							} ) }
+							disabled={ isDisabled }
+							aria-expanded={ isOpen }
+							aria-haspopup="listbox"
+							onClick={ onToggle }
+						>
+							<span
+								className={ clsx( 'amplify-landing-site-dropdown-value', {
+									'is-placeholder': ! selectedUrl,
+								} ) }
+							>
+								{ toggleText }
+							</span>
+							<Icon icon={ chevronDown } size={ 20 } />
+						</button>
+					) }
+					renderContent={ ( { onClose } ) => (
+						<div className="amplify-landing-site-dropdown-panel">
+							<div className="amplify-landing-site-dropdown-search">
+								<TextControl
+									__nextHasNoMarginBottom
+									__next40pxDefaultSize
+									label={ __( 'Search' ) }
+									hideLabelFromVision
+									value={ search }
+									onChange={ setSearch }
+									placeholder={ __( 'Search connected sites' ) }
+								/>
+							</div>
+							{ visibleSites.length === 0 ? (
+								<p className="amplify-landing-site-dropdown-empty">{ __( 'No matches' ) }</p>
+							) : (
+								<ul className="amplify-landing-site-dropdown-list" role="listbox">
+									{ visibleSites.map( ( site ) => {
+										const isSelected = site.url === selectedUrl;
+										return (
+											<li key={ site.id }>
+												<button
+													type="button"
+													role="option"
+													aria-selected={ isSelected }
+													className={ clsx( 'amplify-landing-site-dropdown-item', {
+														'is-selected': isSelected,
+													} ) }
+													onClick={ () => {
+														setSelectedUrl( site.url );
+														onClose();
+													} }
+												>
+													{ site.url }
+												</button>
+											</li>
+										);
+									} ) }
+								</ul>
+							) }
+						</div>
+					) }
+				/>
+			</div>
+			<Button
+				variant="primary"
+				disabled={ ! selectedUrl }
+				onClick={ () => {
+					/* Wired in a follow-up. */
+				} }
+			>
+				{ __( 'Amplify it' ) }
+			</Button>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/amplify/amplify-site-select.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-site-select.tsx
@@ -136,6 +136,7 @@ export default function AmplifySiteSelect() {
 				/>
 			</div>
 			<Button
+				__next40pxDefaultSize
 				variant="primary"
 				disabled={ ! selectedUrl }
 				onClick={ () => {

--- a/client/a8c-for-agencies/sections/amplify/amplify-site-select.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-site-select.tsx
@@ -10,6 +10,50 @@ import useConnectedSites from './hooks/use-connected-sites';
 const RECENT_LIMIT = 10;
 const SEARCH_DEBOUNCE_MS = 150;
 
+/**
+ * Normalize a user-typed URL. If the user did not include a scheme, prepend
+ * `https://` and then validate. Returns the canonical href on success, or
+ * null if the input is empty or does not parse to a valid http/https URL.
+ *
+ * Examples:
+ *   "acme.com"               → "https://acme.com/"
+ *   "https://acme.com"       → "https://acme.com/"
+ *   "acme.com/team?ref=1"    → "https://acme.com/team?ref=1"
+ *   "  acme.com  "           → "https://acme.com/"  (trims surrounding space)
+ *   ""                       → null
+ *   "ftp://acme.com"         → null  (only http/https allowed)
+ *   "javascript:alert(1)"    → null  (only http/https allowed)
+ *   "not a url"              → null  (no hostname after prepend)
+ *
+ * The auto-prepend matches the downstream Worker's protocol requirements
+ * (see workers/amplify-api/index.ts: parsed.protocol must be http: or
+ * https:), so we fail fast at the input boundary instead of round-tripping
+ * to the Worker for it to return 400.
+ */
+function normalizeUrl( raw: string ): string | null {
+	const trimmed = raw.trim();
+	if ( ! trimmed ) {
+		return null;
+	}
+	const withScheme = /^https?:\/\//i.test( trimmed ) ? trimmed : `https://${ trimmed }`;
+	try {
+		const parsed = new URL( withScheme );
+		if ( parsed.protocol !== 'http:' && parsed.protocol !== 'https:' ) {
+			return null;
+		}
+		// Require either a multi-label hostname (e.g. "acme.com") or literal
+		// "localhost". A bare unqualified label like "foo" parses successfully
+		// as `https://foo/` but is almost always a typo of a real URL, and the
+		// Worker / Trigger pipeline would just spend tokens on a DNS failure.
+		if ( parsed.hostname !== 'localhost' && ! parsed.hostname.includes( '.' ) ) {
+			return null;
+		}
+		return parsed.href;
+	} catch {
+		return null;
+	}
+}
+
 type Props = {
 	/**
 	 * Called when the user hits "Amplify it." AmplifyPage owns the analysis
@@ -20,12 +64,30 @@ type Props = {
 
 export default function AmplifySiteSelect( { onSiteSelected }: Props ) {
 	const dispatch = useDispatch();
-	const [ selectedUrl, setSelectedUrl ] = useState< string | null >( null );
 
-	// `searchInput` is the controlled value bound to the TextControl so the
-	// field stays responsive to keystrokes. `debouncedSearch` is what we feed
-	// into useConnectedSites, so the filter only re-runs after the user pauses
-	// typing. Keeps the dropdown smooth on accounts with many connected sites.
+	// Two input paths, mutually exclusive on submit:
+	//   1. `urlInput` — the user typed a URL directly. Validated and
+	//      normalised (https:// auto-prepended) only at submit time.
+	//   2. `selectedSiteUrl` — the user picked from the connected-sites
+	//      dropdown. Already a canonical URL from the wpcom API.
+	// Typing in one clears the other. The submit button reads whichever is
+	// currently populated; the `entry_point` Tracks property records which.
+	const [ urlInput, setUrlInput ] = useState( '' );
+	const [ selectedSiteUrl, setSelectedSiteUrl ] = useState< string | null >( null );
+
+	// `submitError` is set only when the user clicks "Amplify it" with an
+	// unparseable URL. We deliberately do NOT validate while the user is
+	// typing — interim states like "ac" or "acme" would otherwise flash a
+	// red error before the user has finished, which we saw produce a
+	// jarring "invalid" state mid-keystroke. The error clears as soon as
+	// the user resumes typing or picks a site from the dropdown.
+	const [ submitError, setSubmitError ] = useState< string | null >( null );
+
+	// `searchInput` is the controlled value bound to the dropdown's TextControl
+	// so the field stays responsive to keystrokes. `debouncedSearch` is what we
+	// feed into useConnectedSites, so the filter only re-runs after the user
+	// pauses typing. Keeps the dropdown smooth on accounts with many connected
+	// sites.
 	const [ searchInput, setSearchInput ] = useState( '' );
 	const [ debouncedSearch, setDebouncedSearch ] = useState( '' );
 
@@ -44,127 +106,228 @@ export default function AmplifySiteSelect( { onSiteSelected }: Props ) {
 		limit: RECENT_LIMIT,
 	} );
 
-	const isDisabled = isLoading || ! hasAnyConnectedSites;
+	const isDropdownDisabled = isLoading || ! hasAnyConnectedSites;
 
 	let toggleText: string;
-	if ( selectedUrl ) {
-		toggleText = selectedUrl;
+	if ( selectedSiteUrl ) {
+		toggleText = selectedSiteUrl;
 	} else if ( isLoading ) {
 		toggleText = __( 'Loading sites…' );
 	} else if ( ! hasAnyConnectedSites ) {
 		toggleText = __( 'No connected sites yet' );
 	} else {
-		toggleText = __( 'Search or select a site' );
+		toggleText = __( 'Choose a site' );
 	}
 
+	// The submit button is enabled whenever the user has provided either
+	// input. We don't gate enablement on URL validity because validity is
+	// only computed at submit time — `handleAmplifyClick` is what decides
+	// whether to surface a submit-time error or proceed with the analysis.
+	const hasUrlInput = urlInput.trim().length > 0;
+	const canSubmit = hasUrlInput || !! selectedSiteUrl;
+
+	const handleUrlChange = ( next: string ) => {
+		setUrlInput( next );
+		// Clear any submit-time error as soon as the user resumes typing,
+		// so the error doesn't linger over a corrected input until they
+		// click submit again.
+		if ( submitError ) {
+			setSubmitError( null );
+		}
+		// Mutual exclusivity: typing in the URL field clears any prior
+		// dropdown selection so "Amplify it" can't ambiguously refer to both.
+		if ( next.trim().length > 0 && selectedSiteUrl ) {
+			setSelectedSiteUrl( null );
+		}
+	};
+
 	const handleSelectSite = ( url: string ) => {
-		setSelectedUrl( url );
+		setSelectedSiteUrl( url );
+		if ( submitError ) {
+			setSubmitError( null );
+		}
+		// Mutual exclusivity in the other direction.
+		if ( urlInput ) {
+			setUrlInput( '' );
+		}
 		dispatch( recordTracksEvent( 'calypso_a4a_amplify_site_select', { site_url: url } ) );
 	};
 
 	const handleAmplifyClick = () => {
-		if ( ! selectedUrl ) {
+		// Resolve the URL to submit. URL input takes priority over the
+		// dropdown selection (the mutual-exclusivity logic above means at
+		// most one is non-empty in steady state; the explicit if/else
+		// makes the intent obvious in case that ever drifts).
+		let target: string | null = null;
+		let entryPoint: 'hero_url_input' | 'hero_connected_sites';
+
+		if ( hasUrlInput ) {
+			const normalized = normalizeUrl( urlInput );
+			if ( ! normalized ) {
+				setSubmitError(
+					__( 'That doesn’t look like a valid URL. Try something like https://example.com.' )
+				);
+				return;
+			}
+			target = normalized;
+			entryPoint = 'hero_url_input';
+		} else if ( selectedSiteUrl ) {
+			target = selectedSiteUrl;
+			entryPoint = 'hero_connected_sites';
+		} else {
+			// Defensive — the button is disabled in this state, but if it
+			// somehow gets clicked anyway we just no-op.
 			return;
 		}
+
 		dispatch(
 			recordTracksEvent( 'calypso_a4a_amplify_audit_open', {
-				site_url: selectedUrl,
-				entry_point: 'hero_dropdown',
+				site_url: target,
+				entry_point: entryPoint,
 			} )
 		);
-		onSiteSelected( selectedUrl );
+		onSiteSelected( target );
 	};
 
 	return (
-		<div className="amplify-landing-selector">
-			<div className="amplify-landing-selector-field">
-				<span className="amplify-landing-selector-label">{ __( 'Recently connected sites' ) }</span>
-				<Dropdown
-					className="amplify-landing-site-dropdown"
-					contentClassName="amplify-landing-site-dropdown-content"
-					placement="bottom-start"
-					popoverProps={ { offset: 4, shift: true } }
-					onToggle={ ( isOpen ) => {
-						if ( ! isOpen ) {
-							// Reset both the input and the debounced value when the
-							// dropdown closes so reopening starts from a clean state.
-							setSearchInput( '' );
-							setDebouncedSearch( '' );
-						}
-					} }
-					renderToggle={ ( { isOpen, onToggle } ) => (
-						<button
-							type="button"
-							className={ clsx( 'amplify-landing-site-dropdown-toggle', {
-								'is-open': isOpen,
-							} ) }
-							disabled={ isDisabled }
-							aria-expanded={ isOpen }
-							aria-haspopup="listbox"
-							onClick={ onToggle }
-						>
-							<span
-								className={ clsx( 'amplify-landing-site-dropdown-value', {
-									'is-placeholder': ! selectedUrl,
-								} ) }
-							>
-								{ toggleText }
-							</span>
-							<Icon icon={ chevronDown } size={ 20 } />
-						</button>
-					) }
-					renderContent={ ( { onClose } ) => (
-						<div className="amplify-landing-site-dropdown-panel">
-							<div className="amplify-landing-site-dropdown-search">
-								<TextControl
-									__nextHasNoMarginBottom
-									__next40pxDefaultSize
-									label={ __( 'Search' ) }
-									hideLabelFromVision
-									value={ searchInput }
-									onChange={ setSearchInput }
-									placeholder={ __( 'Search connected sites' ) }
-								/>
-							</div>
-							{ sites.length === 0 ? (
-								<p className="amplify-landing-site-dropdown-empty">{ __( 'No matches' ) }</p>
-							) : (
-								<ul className="amplify-landing-site-dropdown-list" role="listbox">
-									{ sites.map( ( site ) => {
-										const isSelected = site.url === selectedUrl;
-										return (
-											<li key={ site.id }>
-												<button
-													type="button"
-													role="option"
-													aria-selected={ isSelected }
-													className={ clsx( 'amplify-landing-site-dropdown-item', {
-														'is-selected': isSelected,
-													} ) }
-													onClick={ () => {
-														handleSelectSite( site.url );
-														onClose();
-													} }
-												>
-													{ site.url }
-												</button>
-											</li>
-										);
+		<>
+			<div className="amplify-landing-selector">
+				<div className="amplify-landing-selector-fields">
+					<div className="amplify-landing-selector-field amplify-landing-selector-field-url">
+						<span className="amplify-landing-selector-label">{ __( 'Enter a URL' ) }</span>
+						<TextControl
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+							label={ __( 'Site URL' ) }
+							hideLabelFromVision
+							// Use `type="text"` (not `type="url"`) plus `inputMode="url"`
+							// to suppress Chrome's URL-history autocomplete popup
+							// while preserving the URL keyboard layout on mobile.
+							// Chrome ignores `autoComplete="off"` on `type="url"`
+							// inputs and shows the address-bar history regardless;
+							// switching to text bypasses that special-case. URL
+							// validation is handled client-side via normalizeUrl()
+							// at submit time, so we don't lose anything by skipping
+							// the HTML5 type="url" pattern matching.
+							type="text"
+							inputMode="url"
+							value={ urlInput }
+							onChange={ handleUrlChange }
+							placeholder="https://yourgroovydomain.com"
+							className="amplify-landing-selector-url-input"
+							aria-invalid={ !! submitError }
+							aria-errormessage={ submitError ? 'amplify-landing-selector-error' : undefined }
+							autoComplete="off"
+							autoCorrect="off"
+							spellCheck={ false }
+						/>
+					</div>
+
+					<span className="amplify-landing-selector-or" aria-hidden="true">
+						{ __( 'or' ) }
+					</span>
+
+					<div className="amplify-landing-selector-field amplify-landing-selector-field-dropdown">
+						<span className="amplify-landing-selector-label">
+							{ __( 'Pick a connected site' ) }
+						</span>
+						<Dropdown
+							className="amplify-landing-site-dropdown"
+							contentClassName="amplify-landing-site-dropdown-content"
+							placement="bottom-start"
+							popoverProps={ { offset: 4, shift: true } }
+							onToggle={ ( isOpen ) => {
+								if ( ! isOpen ) {
+									setSearchInput( '' );
+									setDebouncedSearch( '' );
+								}
+							} }
+							renderToggle={ ( { isOpen, onToggle } ) => (
+								<button
+									type="button"
+									className={ clsx( 'amplify-landing-site-dropdown-toggle', {
+										'is-open': isOpen,
 									} ) }
-								</ul>
+									disabled={ isDropdownDisabled }
+									aria-expanded={ isOpen }
+									aria-haspopup="listbox"
+									onClick={ onToggle }
+								>
+									<span
+										className={ clsx( 'amplify-landing-site-dropdown-value', {
+											'is-placeholder': ! selectedSiteUrl,
+										} ) }
+									>
+										{ toggleText }
+									</span>
+									<Icon icon={ chevronDown } size={ 20 } />
+								</button>
 							) }
-						</div>
-					) }
-				/>
+							renderContent={ ( { onClose } ) => (
+								<div className="amplify-landing-site-dropdown-panel">
+									<div className="amplify-landing-site-dropdown-search">
+										<TextControl
+											__nextHasNoMarginBottom
+											__next40pxDefaultSize
+											label={ __( 'Search' ) }
+											hideLabelFromVision
+											value={ searchInput }
+											onChange={ setSearchInput }
+											placeholder={ __( 'Search connected sites' ) }
+										/>
+									</div>
+									{ sites.length === 0 ? (
+										<p className="amplify-landing-site-dropdown-empty">{ __( 'No matches' ) }</p>
+									) : (
+										<ul className="amplify-landing-site-dropdown-list" role="listbox">
+											{ sites.map( ( site ) => {
+												const isSelected = site.url === selectedSiteUrl;
+												return (
+													<li key={ site.id }>
+														<button
+															type="button"
+															role="option"
+															aria-selected={ isSelected }
+															className={ clsx( 'amplify-landing-site-dropdown-item', {
+																'is-selected': isSelected,
+															} ) }
+															onClick={ () => {
+																handleSelectSite( site.url );
+																onClose();
+															} }
+														>
+															{ site.url }
+														</button>
+													</li>
+												);
+											} ) }
+										</ul>
+									) }
+								</div>
+							) }
+						/>
+					</div>
+				</div>
+
+				<Button
+					__next40pxDefaultSize
+					variant="primary"
+					disabled={ ! canSubmit }
+					onClick={ handleAmplifyClick }
+					className="amplify-landing-selector-submit"
+				>
+					{ __( 'Amplify it' ) }
+				</Button>
 			</div>
-			<Button
-				__next40pxDefaultSize
-				variant="primary"
-				disabled={ ! selectedUrl }
-				onClick={ handleAmplifyClick }
-			>
-				{ __( 'Amplify it' ) }
-			</Button>
-		</div>
+			{ submitError && (
+				<p
+					id="amplify-landing-selector-error"
+					className="amplify-landing-selector-error"
+					role="alert"
+				>
+					{ submitError }
+				</p>
+			) }
+		</>
 	);
 }

--- a/client/a8c-for-agencies/sections/amplify/amplify-site-select.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-site-select.tsx
@@ -5,16 +5,22 @@ import clsx from 'clsx';
 import { useState } from 'react';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import AmplifyAnalysisModal from './amplify-analysis-modal';
 import useConnectedSites from './hooks/use-connected-sites';
 
 const RECENT_LIMIT = 10;
 
-export default function AmplifySiteSelect() {
+type Props = {
+	/**
+	 * Called when the user hits "Amplify it". AmplifyPage owns the analysis
+	 * modal — this component just signals which URL to analyse.
+	 */
+	onSiteSelected: ( url: string ) => void;
+};
+
+export default function AmplifySiteSelect( { onSiteSelected }: Props ) {
 	const dispatch = useDispatch();
 	const [ selectedUrl, setSelectedUrl ] = useState< string | null >( null );
 	const [ search, setSearch ] = useState( '' );
-	const [ analysisFlowSite, setAnalysisFlowSite ] = useState< string | null >( null );
 
 	const { sites, isLoading, hasAnyConnectedSites } = useConnectedSites( {
 		search,
@@ -37,9 +43,7 @@ export default function AmplifySiteSelect() {
 	const handleSelectSite = ( url: string ) => {
 		setSelectedUrl( url );
 		dispatch(
-			recordTracksEvent( 'calypso_a4a_amplify_site_select', {
-				site_url: url,
-			} )
+			recordTracksEvent( 'calypso_a4a_amplify_site_select', { site_url: url } )
 		);
 	};
 
@@ -48,17 +52,17 @@ export default function AmplifySiteSelect() {
 			return;
 		}
 		dispatch(
-			recordTracksEvent( 'calypso_a4a_amplify_audit_open', {
-				site_url: selectedUrl,
-			} )
+			recordTracksEvent( 'calypso_a4a_amplify_audit_open', { site_url: selectedUrl } )
 		);
-		setAnalysisFlowSite( selectedUrl );
+		onSiteSelected( selectedUrl );
 	};
 
 	return (
 		<div className="amplify-landing-selector">
 			<div className="amplify-landing-selector-field">
-				<span className="amplify-landing-selector-label">{ __( 'Recently connected sites' ) }</span>
+				<span className="amplify-landing-selector-label">
+					{ __( 'Recently connected sites' ) }
+				</span>
 				<Dropdown
 					className="amplify-landing-site-dropdown"
 					contentClassName="amplify-landing-site-dropdown-content"
@@ -104,7 +108,9 @@ export default function AmplifySiteSelect() {
 								/>
 							</div>
 							{ sites.length === 0 ? (
-								<p className="amplify-landing-site-dropdown-empty">{ __( 'No matches' ) }</p>
+								<p className="amplify-landing-site-dropdown-empty">
+									{ __( 'No matches' ) }
+								</p>
 							) : (
 								<ul className="amplify-landing-site-dropdown-list" role="listbox">
 									{ sites.map( ( site ) => {
@@ -142,10 +148,6 @@ export default function AmplifySiteSelect() {
 			>
 				{ __( 'Amplify it' ) }
 			</Button>
-			<AmplifyAnalysisModal
-				site={ analysisFlowSite }
-				onClose={ () => setAnalysisFlowSite( null ) }
-			/>
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/amplify/amplify-site-select.tsx
+++ b/client/a8c-for-agencies/sections/amplify/amplify-site-select.tsx
@@ -2,61 +2,58 @@ import { Button, Dropdown, TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, chevronDown } from '@wordpress/icons';
 import clsx from 'clsx';
-import { useMemo, useState } from 'react';
-import useFetchActiveSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-active-sites';
+import { useState } from 'react';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import AmplifyAnalysisModal from './amplify-analysis-modal';
-
-type Site = {
-	id: number;
-	url: string;
-	features?: {
-		wpcom_atomic?: {
-			state?: string;
-		};
-	};
-};
+import useConnectedSites from './hooks/use-connected-sites';
 
 const RECENT_LIMIT = 10;
 
 export default function AmplifySiteSelect() {
-	const { data, isLoading } = useFetchActiveSites( { autoRefresh: false } );
+	const dispatch = useDispatch();
 	const [ selectedUrl, setSelectedUrl ] = useState< string | null >( null );
 	const [ search, setSearch ] = useState( '' );
 	const [ analysisFlowSite, setAnalysisFlowSite ] = useState< string | null >( null );
 
-	const allSites: Site[] = useMemo( () => {
-		const list = Array.isArray( data ) ? ( data as Site[] ) : [];
-		return list
-			.filter( ( site ) => {
-				if ( ! site.url ) {
-					return false;
-				}
-				const state = site.features?.wpcom_atomic?.state;
-				return state === undefined || state === 'active';
-			} )
-			.sort( ( a, b ) => b.id - a.id );
-	}, [ data ] );
+	const { sites, isLoading, hasAnyConnectedSites } = useConnectedSites( {
+		search,
+		limit: RECENT_LIMIT,
+	} );
 
-	const visibleSites = useMemo( () => {
-		const query = search.trim().toLowerCase();
-		return query
-			? allSites.filter( ( site ) => site.url.toLowerCase().includes( query ) )
-			: allSites.slice( 0, RECENT_LIMIT );
-	}, [ allSites, search ] );
-
-	const hasSites = allSites.length > 0;
-	const isDisabled = isLoading || ! hasSites;
+	const isDisabled = isLoading || ! hasAnyConnectedSites;
 
 	let toggleText: string;
 	if ( selectedUrl ) {
 		toggleText = selectedUrl;
 	} else if ( isLoading ) {
 		toggleText = __( 'Loading sites…' );
-	} else if ( ! hasSites ) {
+	} else if ( ! hasAnyConnectedSites ) {
 		toggleText = __( 'No connected sites yet' );
 	} else {
 		toggleText = __( 'Search or select a site' );
 	}
+
+	const handleSelectSite = ( url: string ) => {
+		setSelectedUrl( url );
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_amplify_site_select', {
+				site_url: url,
+			} )
+		);
+	};
+
+	const handleAmplifyClick = () => {
+		if ( ! selectedUrl ) {
+			return;
+		}
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_amplify_audit_open', {
+				site_url: selectedUrl,
+			} )
+		);
+		setAnalysisFlowSite( selectedUrl );
+	};
 
 	return (
 		<div className="amplify-landing-selector">
@@ -106,11 +103,11 @@ export default function AmplifySiteSelect() {
 									placeholder={ __( 'Search connected sites' ) }
 								/>
 							</div>
-							{ visibleSites.length === 0 ? (
+							{ sites.length === 0 ? (
 								<p className="amplify-landing-site-dropdown-empty">{ __( 'No matches' ) }</p>
 							) : (
 								<ul className="amplify-landing-site-dropdown-list" role="listbox">
-									{ visibleSites.map( ( site ) => {
+									{ sites.map( ( site ) => {
 										const isSelected = site.url === selectedUrl;
 										return (
 											<li key={ site.id }>
@@ -122,7 +119,7 @@ export default function AmplifySiteSelect() {
 														'is-selected': isSelected,
 													} ) }
 													onClick={ () => {
-														setSelectedUrl( site.url );
+														handleSelectSite( site.url );
 														onClose();
 													} }
 												>
@@ -141,11 +138,7 @@ export default function AmplifySiteSelect() {
 				__next40pxDefaultSize
 				variant="primary"
 				disabled={ ! selectedUrl }
-				onClick={ () => {
-					if ( selectedUrl ) {
-						setAnalysisFlowSite( selectedUrl );
-					}
-				} }
+				onClick={ handleAmplifyClick }
 			>
 				{ __( 'Amplify it' ) }
 			</Button>

--- a/client/a8c-for-agencies/sections/amplify/components/amplify-info-popover/index.tsx
+++ b/client/a8c-for-agencies/sections/amplify/components/amplify-info-popover/index.tsx
@@ -1,0 +1,131 @@
+/**
+ * AmplifyInfoPopover
+ *
+ * Small reusable wrapper around the existing A4APopover / A4AInfoModal
+ * primitives. Bundles the "clickable info-outline icon → popover (or modal
+ * on mobile)" pattern that exists hand-rolled in at least three other A4A
+ * sections today (consolidated-stats-card, referrals/assigned-to,
+ * woopayments/site-columns).
+ *
+ * Scoped to the amplify section for this PR to keep the diff focused — once
+ * we're happy with the API, this should be promoted to
+ * `client/a8c-for-agencies/components/a4a-info-popover/` so the three
+ * existing call sites can migrate off their inlined copies.
+ */
+
+import { Gridicon } from '@automattic/components';
+import { useMobileBreakpoint } from '@automattic/viewport-react';
+import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
+import { useCallback, useRef, useState } from 'react';
+import InfoModal from 'calypso/a8c-for-agencies/components/a4a-info-modal';
+import A4APopover from 'calypso/a8c-for-agencies/components/a4a-popover';
+import type { ReactNode } from 'react';
+
+import './style.scss';
+
+/**
+ * Render-prop API exposed to children that need to close the popover from
+ * within — e.g. a CTA inside the popover body that, when clicked, kicks off
+ * an action that should clearly transition the user away from the popover
+ * (opening a modal, navigating, etc.). Pass children as `({ close }) => …`
+ * to opt in.
+ */
+type ChildrenRenderProps = {
+	close: () => void;
+};
+
+type Props = {
+	/**
+	 * Body rendered inside the popover (desktop) or modal (mobile). Accepts
+	 * either plain ReactNode (when no programmatic close is needed) or a
+	 * function that receives `{ close }` — use the function form when the
+	 * body contains an action that should also dismiss the popover.
+	 */
+	children: ReactNode | ( ( api: ChildrenRenderProps ) => ReactNode );
+	/**
+	 * Title shown above the popover/modal body. Pass an empty string (the
+	 * default) to omit it — useful when the content is short enough to stand
+	 * on its own.
+	 */
+	title?: string;
+	/** Icon size in pixels. */
+	iconSize?: number;
+	/**
+	 * Distance in pixels from the trigger to the popover. The 8px default
+	 * matches what the referrals dashboard's `assigned-to` component uses,
+	 * which is the closest visual sibling to this one.
+	 */
+	offset?: number;
+	/** Optional className applied to the trigger wrapper. */
+	className?: string;
+	/**
+	 * Accessible label for the icon button. Defaults to "More info" —
+	 * override when the surrounding label already carries the same meaning
+	 * and you need something more specific for screen readers.
+	 */
+	ariaLabel?: string;
+};
+
+export default function AmplifyInfoPopover( {
+	children,
+	title = '',
+	iconSize = 16,
+	offset = 8,
+	className,
+	ariaLabel,
+}: Props ) {
+	const isMobile = useMobileBreakpoint();
+	const wrapperRef = useRef< HTMLSpanElement >( null );
+	const [ isOpen, setIsOpen ] = useState( false );
+
+	// Stable refs across renders — consumers can safely include them in
+	// useCallback / useMemo deps without forcing re-runs every render.
+	const open = useCallback( () => setIsOpen( true ), [] );
+	const close = useCallback( () => setIsOpen( false ), [] );
+
+	return (
+		<>
+			<span
+				ref={ wrapperRef }
+				className={ clsx( 'amplify-info-popover__trigger', className ) }
+				role="button"
+				tabIndex={ 0 }
+				aria-label={ ariaLabel ?? __( 'More info' ) }
+				aria-haspopup="dialog"
+				aria-expanded={ isOpen }
+				onClick={ open }
+				onKeyDown={ ( event ) => {
+					// Enter and Space both activate the trigger, matching the
+					// default behavior of a native <button>. We preventDefault on
+					// Space so the page doesn't scroll when the trigger is
+					// focused via keyboard.
+					if ( event.key === 'Enter' || event.key === ' ' ) {
+						event.preventDefault();
+						open();
+					}
+				} }
+			>
+				<Gridicon icon="info-outline" size={ iconSize } />
+			</span>
+			{ /* Body is resolved inline inside the isOpen branch so the render-
+			    prop form isn't invoked (and its JSX subtree isn't allocated)
+			    on renders where the popover isn't actually shown. */ }
+			{ isOpen &&
+				( isMobile ? (
+					<InfoModal title={ title } onClose={ close }>
+						{ typeof children === 'function' ? children( { close } ) : children }
+					</InfoModal>
+				) : (
+					<A4APopover
+						title={ title }
+						wrapperRef={ wrapperRef }
+						offset={ offset }
+						onFocusOutside={ close }
+					>
+						{ typeof children === 'function' ? children( { close } ) : children }
+					</A4APopover>
+				) ) }
+		</>
+	);
+}

--- a/client/a8c-for-agencies/sections/amplify/components/amplify-info-popover/style.scss
+++ b/client/a8c-for-agencies/sections/amplify/components/amplify-info-popover/style.scss
@@ -1,0 +1,23 @@
+.amplify-info-popover__trigger {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	color: var(--color-text-subtle);
+	cursor: pointer;
+	border-radius: 50%;
+	line-height: 0;
+
+	&:hover {
+		color: var(--color-text);
+	}
+
+	&:focus-visible {
+		outline: 2px solid var(--color-primary-50);
+		outline-offset: 2px;
+	}
+
+	svg {
+		display: block;
+		fill: currentColor;
+	}
+}

--- a/client/a8c-for-agencies/sections/amplify/controller.tsx
+++ b/client/a8c-for-agencies/sections/amplify/controller.tsx
@@ -1,0 +1,15 @@
+import { type Callback } from '@automattic/calypso-router';
+import PageViewTracker from 'calypso/a8c-for-agencies/components/a4a-page-view-tracker';
+import MainSidebar from 'calypso/a8c-for-agencies/components/sidebar-menu/main';
+import AmplifyOverview from './amplify-overview';
+
+export const amplifyContext: Callback = ( context, next ) => {
+	context.secondary = <MainSidebar path={ context.path } />;
+	context.primary = (
+		<>
+			<PageViewTracker title="Amplify" path={ context.path } />
+			<AmplifyOverview />
+		</>
+	);
+	next();
+};

--- a/client/a8c-for-agencies/sections/amplify/controller.tsx
+++ b/client/a8c-for-agencies/sections/amplify/controller.tsx
@@ -1,14 +1,25 @@
 import { type Callback } from '@automattic/calypso-router';
 import PageViewTracker from 'calypso/a8c-for-agencies/components/a4a-page-view-tracker';
-import MainSidebar from 'calypso/a8c-for-agencies/components/sidebar-menu/main';
-import AmplifyOverview from './amplify-overview';
+import AmplifySidebar from 'calypso/a8c-for-agencies/components/sidebar-menu/amplify';
+import AmplifyPage from './amplify-page';
 
-export const amplifyContext: Callback = ( context, next ) => {
-	context.secondary = <MainSidebar path={ context.path } />;
+export const amplifyOverviewContext: Callback = ( context, next ) => {
+	context.secondary = <AmplifySidebar path={ context.path } />;
 	context.primary = (
 		<>
-			<PageViewTracker title="Amplify" path={ context.path } />
-			<AmplifyOverview />
+			<PageViewTracker title="Amplify > Overview" path={ context.path } />
+			<AmplifyPage selectedTab="overview" />
+		</>
+	);
+	next();
+};
+
+export const amplifyReportsContext: Callback = ( context, next ) => {
+	context.secondary = <AmplifySidebar path={ context.path } />;
+	context.primary = (
+		<>
+			<PageViewTracker title="Amplify > Reports" path={ context.path } />
+			<AmplifyPage selectedTab="reports" />
 		</>
 	);
 	next();

--- a/client/a8c-for-agencies/sections/amplify/hooks/use-archived-reports.ts
+++ b/client/a8c-for-agencies/sections/amplify/hooks/use-archived-reports.ts
@@ -1,0 +1,134 @@
+/**
+ * useArchivedReports
+ *
+ * Tracks which Amplify reports the current user has archived. Archive state
+ * is a UI concern only — the underlying R2 index has no notion of archival —
+ * so we maintain the set of archived report IDs client-side and merge it in
+ * when deriving each report's display status.
+ *
+ * ⚠️  INTERIM IMPLEMENTATION — READ BEFORE TOUCHING ⚠️
+ *
+ * This hook backs archive state with `localStorage`. That gives us:
+ *   - Persistence across page reloads and browser restarts on the same
+ *     device (good enough for an internal Partner Manager tool today).
+ *   - Cross-tab sync via the `storage` event (so archiving in one tab
+ *     reflects in another within the same browser).
+ *
+ * What it intentionally does NOT give us:
+ *   - Cross-device sync. Archiving on a laptop does not propagate to a
+ *     phone or to a different Mac.
+ *   - Cross-user sync. Archive is per-browser, not per-Automattician.
+ *
+ * When the WordPress.com endpoint that owns Amplify reports is built
+ * (mirroring the referrals pattern — see
+ * client/a8c-for-agencies/data/referrals/use-archive-referral.ts and
+ * client/a8c-for-agencies/sections/referrals/hooks/use-handle-referral-archive.ts),
+ * replace the localStorage read/write inside this hook with a wpcom
+ * `useMutation` call and switch the read side to a server-driven status
+ * field on each report. The public surface of this hook (`isArchived`,
+ * `toggleArchive`, `archivedIds`) is designed so the swap is a near-
+ * mechanical change inside this file — the call sites in
+ * `amplify-reports-content.tsx` should not need to change.
+ *
+ * Tracked in the README "What still needs to be built" section under
+ * the wpcom endpoint work.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'amplify_archived_reports';
+
+function readArchivedIds(): Set< string > {
+	if ( typeof window === 'undefined' ) {
+		return new Set();
+	}
+	try {
+		const raw = window.localStorage.getItem( STORAGE_KEY );
+		if ( ! raw ) {
+			return new Set();
+		}
+		const parsed: unknown = JSON.parse( raw );
+		// Defensive — localStorage is user-writable and could contain
+		// anything (a different format from an older build, a string, etc.).
+		// Drop non-string entries silently rather than throwing.
+		if ( ! Array.isArray( parsed ) ) {
+			return new Set();
+		}
+		return new Set( parsed.filter( ( id ): id is string => typeof id === 'string' ) );
+	} catch {
+		return new Set();
+	}
+}
+
+function writeArchivedIds( ids: Set< string > ): void {
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+	try {
+		window.localStorage.setItem( STORAGE_KEY, JSON.stringify( [ ...ids ] ) );
+	} catch {
+		// localStorage can throw (Safari private mode, quota exceeded).
+		// Fail silently — the in-memory state still reflects the user's
+		// intent for this session.
+	}
+}
+
+export type UseArchivedReports = {
+	/** Set of archived report IDs. Treat as read-only; do not mutate. */
+	archivedIds: Set< string >;
+	isArchived: ( id: string ) => boolean;
+	archive: ( id: string ) => void;
+	unarchive: ( id: string ) => void;
+};
+
+export default function useArchivedReports(): UseArchivedReports {
+	const [ archivedIds, setArchivedIds ] = useState< Set< string > >( readArchivedIds );
+
+	// Keep multiple tabs in this browser in sync. The `storage` event fires
+	// in *other* tabs when the value changes, not the one that wrote it —
+	// the writing tab already has the latest value via setArchivedIds.
+	useEffect( () => {
+		if ( typeof window === 'undefined' ) {
+			return;
+		}
+		const onStorage = ( event: StorageEvent ) => {
+			if ( event.key !== STORAGE_KEY ) {
+				return;
+			}
+			setArchivedIds( readArchivedIds() );
+		};
+		window.addEventListener( 'storage', onStorage );
+		return () => window.removeEventListener( 'storage', onStorage );
+	}, [] );
+
+	const isArchived = useCallback(
+		( id: string ): boolean => archivedIds.has( id ),
+		[ archivedIds ]
+	);
+
+	const archive = useCallback( ( id: string ): void => {
+		setArchivedIds( ( prev ) => {
+			if ( prev.has( id ) ) {
+				return prev;
+			}
+			const next = new Set( prev );
+			next.add( id );
+			writeArchivedIds( next );
+			return next;
+		} );
+	}, [] );
+
+	const unarchive = useCallback( ( id: string ): void => {
+		setArchivedIds( ( prev ) => {
+			if ( ! prev.has( id ) ) {
+				return prev;
+			}
+			const next = new Set( prev );
+			next.delete( id );
+			writeArchivedIds( next );
+			return next;
+		} );
+	}, [] );
+
+	return { archivedIds, isArchived, archive, unarchive };
+}

--- a/client/a8c-for-agencies/sections/amplify/hooks/use-connected-sites.ts
+++ b/client/a8c-for-agencies/sections/amplify/hooks/use-connected-sites.ts
@@ -30,7 +30,11 @@ export default function useConnectedSites( { search = '', limit }: Args = {} ): 
 		const list = Array.isArray( data ) ? ( data as ConnectedSite[] ) : [];
 		return list
 			.filter( ( site ) => {
-				if ( ! site.url ) {
+				// Defensive runtime check: the API response is cast above but not
+				// validated. If a malformed site ever comes through with a
+				// non-string url, downstream consumers (e.g. site.url.toLowerCase()
+				// in the search filter) would throw on a normal-looking dropdown.
+				if ( typeof site.url !== 'string' || ! site.url ) {
 					return false;
 				}
 				const state = site.features?.wpcom_atomic?.state;

--- a/client/a8c-for-agencies/sections/amplify/hooks/use-connected-sites.ts
+++ b/client/a8c-for-agencies/sections/amplify/hooks/use-connected-sites.ts
@@ -1,0 +1,58 @@
+import { useMemo } from 'react';
+import useFetchActiveSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-active-sites';
+
+export type ConnectedSite = {
+	id: number;
+	url: string;
+	features?: {
+		wpcom_atomic?: {
+			state?: string;
+		};
+	};
+};
+
+type Args = {
+	search?: string;
+	/** Maximum sites to return when `search` is empty. Ignored when `search` has a value. */
+	limit?: number;
+};
+
+type Result = {
+	sites: ConnectedSite[];
+	isLoading: boolean;
+	hasAnyConnectedSites: boolean;
+};
+
+export default function useConnectedSites( { search = '', limit }: Args = {} ): Result {
+	const { data, isLoading } = useFetchActiveSites( { autoRefresh: false } );
+
+	const allSites = useMemo< ConnectedSite[] >( () => {
+		const list = Array.isArray( data ) ? ( data as ConnectedSite[] ) : [];
+		return list
+			.filter( ( site ) => {
+				if ( ! site.url ) {
+					return false;
+				}
+				const state = site.features?.wpcom_atomic?.state;
+				return state === undefined || state === 'active';
+			} )
+			.sort( ( a, b ) => b.id - a.id );
+	}, [ data ] );
+
+	const sites = useMemo< ConnectedSite[] >( () => {
+		const query = search.trim().toLowerCase();
+		if ( query ) {
+			return allSites.filter( ( site ) => site.url.toLowerCase().includes( query ) );
+		}
+		if ( limit !== undefined ) {
+			return allSites.slice( 0, limit );
+		}
+		return allSites;
+	}, [ allSites, search, limit ] );
+
+	return {
+		sites,
+		isLoading,
+		hasAnyConnectedSites: allSites.length > 0,
+	};
+}

--- a/client/a8c-for-agencies/sections/amplify/index.tsx
+++ b/client/a8c-for-agencies/sections/amplify/index.tsx
@@ -1,9 +1,19 @@
 import page from '@automattic/calypso-router';
-import { A4A_AMPLIFY_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import {
+	A4A_AMPLIFY_LINK,
+	A4A_AMPLIFY_REPORTS_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { requireAccessContext } from 'calypso/a8c-for-agencies/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import { amplifyContext } from './controller';
+import { amplifyOverviewContext, amplifyReportsContext } from './controller';
 
 export default function () {
-	page( A4A_AMPLIFY_LINK, requireAccessContext, amplifyContext, makeLayout, clientRender );
+	page( A4A_AMPLIFY_LINK, requireAccessContext, amplifyOverviewContext, makeLayout, clientRender );
+	page(
+		A4A_AMPLIFY_REPORTS_LINK,
+		requireAccessContext,
+		amplifyReportsContext,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/a8c-for-agencies/sections/amplify/index.tsx
+++ b/client/a8c-for-agencies/sections/amplify/index.tsx
@@ -1,0 +1,9 @@
+import page from '@automattic/calypso-router';
+import { A4A_AMPLIFY_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { requireAccessContext } from 'calypso/a8c-for-agencies/controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { amplifyContext } from './controller';
+
+export default function () {
+	page( A4A_AMPLIFY_LINK, requireAccessContext, amplifyContext, makeLayout, clientRender );
+}

--- a/client/a8c-for-agencies/sections/amplify/style.scss
+++ b/client/a8c-for-agencies/sections/amplify/style.scss
@@ -68,6 +68,257 @@
 	text-decoration: underline;
 }
 
+/* Reports tab — DataViews table */
+.amplify-reports {
+	padding-block-start: 16px;
+}
+
+.amplify-reports .dataviews-view-table {
+	table-layout: fixed;
+	inline-size: 100%;
+}
+
+.amplify-reports .dataviews-view-table th:nth-child(1),
+.amplify-reports .dataviews-view-table td:nth-child(1) {
+	inline-size: 50%;
+}
+
+.amplify-reports .dataviews-view-table th:nth-child(2),
+.amplify-reports .dataviews-view-table td:nth-child(2) {
+	inline-size: 15%;
+}
+
+.amplify-reports .dataviews-view-table th:nth-child(3),
+.amplify-reports .dataviews-view-table td:nth-child(3) {
+	inline-size: 20%;
+}
+
+.amplify-reports .dataviews-view-table th:nth-child(4),
+.amplify-reports .dataviews-view-table td:nth-child(4) {
+	inline-size: 15%;
+}
+
+.amplify-reports-site {
+	display: block;
+	font-weight: 500;
+	color: var(--color-text-black);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.amplify-reports-timestamp {
+	color: var(--color-text-subtle);
+	white-space: nowrap;
+}
+
+.amplify-reports-badge {
+	display: inline-flex;
+	align-items: center;
+	padding-block: 2px;
+	padding-inline: 8px;
+	font-size: 12px;
+	font-weight: 600;
+	border-radius: 16px;
+	white-space: nowrap;
+}
+
+.amplify-reports-badge.is-human {
+	background: var(--color-accent-5);
+	color: var(--color-accent);
+}
+
+.amplify-reports-badge.is-ai {
+	background: rgba(124, 58, 237, 0.1);
+	color: rgb(124, 58, 237);
+}
+
+.amplify-reports-badge.is-full {
+	background: var(--color-success-5);
+	color: var(--color-success);
+}
+
+/* Analysis flow modal */
+.amplify-analysis-modal .components-modal__frame {
+	max-inline-size: 540px;
+}
+
+.amplify-analysis-options {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
+.amplify-analysis-site {
+	font-size: 13px;
+	color: var(--color-text-subtle);
+	margin: 0;
+}
+
+.amplify-analysis-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.amplify-analysis-option {
+	display: flex;
+	align-items: center;
+	gap: 16px;
+	inline-size: 100%;
+	padding: 16px;
+	border: 1px solid var(--color-border-subtle);
+	border-radius: 8px;
+	background: var(--color-surface, #fff);
+	cursor: pointer;
+	transition: border-color 0.15s ease, background 0.15s ease;
+	font-family: inherit;
+	text-align: start;
+}
+
+.amplify-analysis-option:hover {
+	border-color: var(--color-accent);
+	background: var(--color-accent-5);
+}
+
+.amplify-analysis-option:focus-visible {
+	outline: 2px solid var(--color-accent);
+	outline-offset: 2px;
+}
+
+.amplify-analysis-option-icon {
+	inline-size: 40px;
+	block-size: 40px;
+	border-radius: 24px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
+}
+
+.amplify-analysis-option-icon.is-human {
+	background: var(--color-accent-5);
+	color: var(--color-accent);
+}
+
+.amplify-analysis-option-icon.is-ai {
+	background: rgba(124, 58, 237, 0.1);
+	color: rgb(124, 58, 237);
+}
+
+.amplify-analysis-option-icon.is-full {
+	background: var(--color-success-5);
+	color: var(--color-success);
+}
+
+.amplify-analysis-option-text {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	min-inline-size: 0;
+}
+
+.amplify-analysis-option-title {
+	font-size: 14px;
+	font-weight: 600;
+	color: var(--color-text-black);
+}
+
+.amplify-analysis-option-description {
+	font-size: 13px;
+	color: var(--color-text-subtle);
+	line-height: 1.45;
+}
+
+/* Progress stage */
+.amplify-analysis-progress {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	text-align: center;
+	gap: 16px;
+	padding-block-end: 8px;
+}
+
+.amplify-analysis-progress-icon {
+	position: relative;
+	inline-size: 64px;
+	block-size: 64px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.amplify-analysis-progress-pulse {
+	inline-size: 32px;
+	block-size: 32px;
+	border-radius: 24px;
+	background: var(--color-accent);
+	animation: amplify-analysis-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes amplify-analysis-pulse {
+	0%, 100% {
+		opacity: 0.6;
+		transform: scale(0.85);
+		box-shadow: 0 0 0 0 rgba(0, 71, 255, 0.4);
+	}
+
+	50% {
+		opacity: 1;
+		transform: scale(1);
+		box-shadow: 0 0 0 18px rgba(0, 71, 255, 0);
+	}
+}
+
+.amplify-analysis-progress-title {
+	font-size: 18px;
+	font-weight: 600;
+	color: var(--color-text-black);
+	margin: 0;
+}
+
+.amplify-analysis-progress-body {
+	font-size: 14px;
+	line-height: 1.6;
+	color: var(--color-text-subtle);
+	max-inline-size: 420px;
+	margin: 0;
+}
+
+.amplify-analysis-progress-bar {
+	position: relative;
+	inline-size: 100%;
+	block-size: 4px;
+	background: var(--color-neutral-5);
+	border-radius: 2px;
+	overflow: hidden;
+}
+
+.amplify-analysis-progress-fill {
+	position: absolute;
+	inset-block: 0;
+	inset-inline-start: -30%;
+	inline-size: 30%;
+	background: var(--color-accent);
+	border-radius: 2px;
+	animation: amplify-analysis-slide 1.6s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+}
+
+@keyframes amplify-analysis-slide {
+	0% {
+		inset-inline-start: -30%;
+	}
+
+	100% {
+		inset-inline-start: 100%;
+	}
+}
+
 .amplify-landing-selector-label {
 	display: block;
 	font-size: 11px;

--- a/client/a8c-for-agencies/sections/amplify/style.scss
+++ b/client/a8c-for-agencies/sections/amplify/style.scss
@@ -220,6 +220,32 @@
 	color: var(--color-error);
 }
 
+.amplify-reports-in-progress {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 13px;
+	color: var(--color-text-subtle);
+	font-style: italic;
+
+	// Subtle pulsing dot to indicate activity
+	&::before {
+		content: "";
+		display: inline-block;
+		width: 8px;
+		height: 8px;
+		border-radius: 50%;
+		background: var(--color-accent);
+		animation: amplify-pulse 1.6s ease-in-out infinite;
+		flex-shrink: 0;
+	}
+}
+
+@keyframes amplify-pulse {
+	0%, 100% { opacity: 1; }
+	50% { opacity: 0.3; }
+}
+
 .amplify-reports-loading {
 	padding-block: 48px;
 	text-align: center;

--- a/client/a8c-for-agencies/sections/amplify/style.scss
+++ b/client/a8c-for-agencies/sections/amplify/style.scss
@@ -1,9 +1,9 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-// Zero out the hosting-dashboard body padding for the amplify layout so that
-// PageSection components (like the FAQ) can span full width and handle their
-// own internal spacing — the same approach used by migrations-overview-v2.
+// Zero out the hosting-dashboard body padding/max-width so each
+// PageSectionColumns can span the full viewport and own its own padding
+// (same approach used by woopayments-overview and dev-tools-overview).
 .amplify-layout {
 	.hosting-dashboard-layout__body {
 		padding: 0;
@@ -16,45 +16,15 @@
 	}
 }
 
-// amplify-landing is a direct child of hosting-dashboard-layout__body, so it
-// now needs to own its padding (previously inherited from the body > * rule).
-.amplify-landing {
-	padding-block-end: 32px;
-	padding-inline: 16px;
-	max-width: 1500px;
-	margin-inline: auto;
-
-	@include breakpoint-deprecated( '>660px' ) {
-		padding-inline: 64px;
-	}
-}
-
-.amplify-landing-hero {
-	display: grid;
-	grid-template-columns: 1fr;
-	gap: 48px;
-	align-items: center;
-	padding-block-end: 48px;
-
-	@include break-large {
-		grid-template-columns: 1fr 0.85fr;
-		gap: 64px;
-	}
-}
-
-.amplify-landing-hero-visual {
-	@include break-large {
-		margin-block-start: 48px;
-	}
-}
-
 .amplify-landing-h1 {
 	font-size: clamp(28px, 3.6vw, 44px);
 	font-weight: 600;
 	line-height: 1.15;
 	letter-spacing: -0.5px;
 	color: var(--color-text-black);
-	margin-block-end: 20px;
+	// Matches the criteria-section title rhythm (16px gap between title and
+	// the descriptive paragraph that follows).
+	margin-block-end: 16px;
 }
 
 .amplify-landing-sub {
@@ -634,6 +604,10 @@
 	border-radius: 8px;
 	padding: 24px;
 	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05), 0 4px 16px rgba(0, 0, 0, 0.04);
+	// Cap the visual width so the score card doesn't crowd the hero headline
+	// at large breakpoints. Matches the woopayments hero visual treatment.
+	max-inline-size: 520px;
+	inline-size: 100%;
 }
 
 .amplify-landing-score-card-header {
@@ -904,10 +878,9 @@
 }
 
 /* How it works */
-.amplify-landing-how-section {
-	padding-block: 48px;
-}
-
+// Each top-level section is rendered as a PageSectionColumns, so the outer
+// section wrapper and the section-level background colors are handled by that
+// component. Inner-content styles below are still scoped to .amplify-landing-*.
 .amplify-landing-how {
 	display: flex;
 	flex-direction: column;
@@ -948,7 +921,7 @@
 
 .amplify-landing-how-mode-toggle {
 	display: inline-flex;
-	background: var(--color-neutral-0);
+	background: #fff;
 	border: 1px solid var(--color-border-subtle);
 	border-radius: 8px;
 	padding: 4px;
@@ -1336,14 +1309,37 @@
 }
 
 .amplify-landing-how-pin-label {
-	font-size: 11px;
-	font-weight: 600;
-	padding-block: 4px;
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 1px;
+	padding-block: 5px;
 	padding-inline: 10px;
-	border-radius: 16px;
+	border-radius: 8px;
 	white-space: nowrap;
 	color: var(--color-text-inverted);
 	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+	line-height: 1.2;
+}
+
+.amplify-landing-how-pin-label-criterion {
+	font-size: 9px;
+	font-weight: 500;
+	letter-spacing: 0.4px;
+	text-transform: uppercase;
+	opacity: 0.85;
+}
+
+.amplify-landing-how-pin-label-text {
+	font-size: 11px;
+	font-weight: 600;
+}
+
+.amplify-landing-how-pin-label-score {
+	margin-inline-start: 6px;
+	font-weight: 500;
+	opacity: 0.78;
+	font-variant-numeric: tabular-nums;
 }
 
 .amplify-landing-how-pin-label.good {
@@ -1520,27 +1516,10 @@
 }
 
 /* AI workflow */
-.amplify-landing-workflow-section {
-	padding-block: 48px;
-}
-
-
-.amplify-landing-workflow {
-	display: flex;
-	flex-direction: column;
-}
-
-.amplify-landing-workflow-top {
-	display: grid;
-	grid-template-columns: 1fr;
-	gap: 48px;
-	align-items: start;
-
-	@include break-large {
-		grid-template-columns: 1fr 1fr;
-		gap: 80px;
-	}
-}
+// .amplify-landing-workflow is the className passed to the workflow's
+// PageSectionColumns wrapper. Outer layout (padding, column grid, max-width)
+// is owned by PageSectionColumns; the rules below style the inner content
+// of each of its two columns.
 
 .amplify-landing-workflow-eyebrow {
 	font-size: 11px;
@@ -1549,14 +1528,15 @@
 	text-transform: uppercase;
 	color: var(--color-text-subtle);
 	margin: 0;
-	margin-block-end: 16px;
+	// Matches the criteria-section eyebrow rhythm (12px gap to title).
+	margin-block-end: 12px;
 }
 
 .amplify-landing-workflow-title {
-	font-size: clamp(32px, 4vw, 56px);
+	font-size: clamp(24px, 3vw, 36px);
 	font-weight: 600;
-	line-height: 1.05;
-	letter-spacing: -0.5px;
+	line-height: 1.15;
+	letter-spacing: -0.4px;
 	color: var(--color-text-black);
 	margin: 0;
 	margin-block-end: 24px;
@@ -1571,17 +1551,24 @@
 }
 
 /* Prompt card (dark themed to evoke an AI/code surface) */
+// Workflow card — styled to evoke a PDF report rather than a terminal window.
+// Light paper background, dark text, soft layered shadow for the "floating
+// document" feel, and a clean sans-serif body (no monospace).
 .amplify-landing-workflow-card {
-	background: #0d1117;
-	border-radius: 16px;
+	background: #fff;
+	border-radius: 8px;
+	border: 1px solid var(--color-border-subtle);
 	overflow: hidden;
-	box-shadow: 0 24px 80px rgba(0, 0, 0, 0.18), 0 4px 20px rgba(0, 0, 0, 0.1);
+	box-shadow:
+		0 1px 2px rgba(0, 0, 0, 0.04),
+		0 8px 24px rgba(0, 0, 0, 0.08),
+		0 24px 60px rgba(0, 0, 0, 0.06);
 }
 
 .amplify-landing-workflow-card-header {
 	padding-block: 16px;
 	padding-inline: 20px;
-	border-block-end: 1px solid rgba(255, 255, 255, 0.08);
+	border-block-end: 1px solid var(--color-border-subtle);
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
@@ -1590,38 +1577,61 @@
 
 .amplify-landing-workflow-card-header-left {
 	display: flex;
-	align-items: center;
-	gap: 10px;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 2px;
 	min-inline-size: 0;
 }
 
 .amplify-landing-workflow-card-title {
 	font-size: 12px;
 	font-weight: 600;
-	color: rgba(255, 255, 255, 0.5);
+	color: var(--color-text-subtle);
 	letter-spacing: 0.5px;
 	text-transform: uppercase;
 	white-space: nowrap;
 }
 
-.amplify-landing-workflow-card-mode {
-	font-size: 10px;
-	font-weight: 700;
-	letter-spacing: 0.6px;
-	text-transform: uppercase;
-	padding-block: 3px;
-	padding-inline: 8px;
-	border-radius: 16px;
-	background: rgba(79, 124, 255, 0.18);
-	color: #7da4ff;
+// Segmented Human/AI toggle in the workflow card header. Same visual
+// treatment as the toggle in the See-it-in-action section above
+// (.amplify-landing-how-mode-toggle), just scaled down to fit the card header.
+.amplify-landing-workflow-mode-toggle {
+	display: inline-flex;
+	background: var(--color-neutral-0);
+	border: 1px solid var(--color-border-subtle);
+	border-radius: 8px;
+	padding: 3px;
+	gap: 2px;
+	flex-shrink: 0;
+}
+
+.amplify-landing-workflow-mode-btn {
+	font-size: 11px;
+	font-weight: 600;
+	padding-block: 5px;
+	padding-inline: 12px;
+	border-radius: 3px;
+	border: none;
+	background: transparent;
+	color: var(--color-text-subtle);
+	cursor: pointer;
+	font-family: inherit;
+	transition: background 0.2s ease, color 0.2s ease;
 	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
+}
+
+.amplify-landing-workflow-mode-btn:hover:not(.is-active) {
+	color: var(--color-text-black);
+}
+
+.amplify-landing-workflow-mode-btn.is-active {
+	background: var(--color-accent);
+	color: var(--color-text-inverted);
 }
 
 .amplify-landing-workflow-card-count {
 	font-size: 11px;
-	color: rgba(255, 255, 255, 0.25);
+	color: var(--color-text-subtle);
 	white-space: nowrap;
 	flex-shrink: 0;
 }
@@ -1631,24 +1641,28 @@
 	padding-inline: 0;
 }
 
+/// Two-column layout: content (label + body) on the left, Copy button on the
+// right. The body wraps inside the content column so its text never visually
+// runs underneath or close to the Copy button.
 .amplify-landing-workflow-prompt-item {
 	padding-block: 14px;
 	padding-inline: 20px;
-	border-block-end: 1px solid rgba(255, 255, 255, 0.05);
+	border-block-end: 1px solid var(--color-border-subtle);
 	display: flex;
-	flex-direction: column;
-	gap: 6px;
+	align-items: flex-start;
+	gap: 32px;
 }
 
 .amplify-landing-workflow-prompt-item:last-child {
 	border-block-end: none;
 }
 
-.amplify-landing-workflow-prompt-item-header {
+.amplify-landing-workflow-prompt-item-content {
+	flex: 1;
+	min-inline-size: 0;
 	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	gap: 8px;
+	flex-direction: column;
+	gap: 6px;
 }
 
 .amplify-landing-workflow-prompt-item-label {
@@ -1657,7 +1671,7 @@
 	gap: 7px;
 	font-size: 12px;
 	font-weight: 600;
-	color: rgba(255, 255, 255, 0.85);
+	color: var(--color-text-black);
 }
 
 .amplify-landing-workflow-prompt-item-dot {
@@ -1683,9 +1697,9 @@
 	font-size: 10px;
 	font-weight: 600;
 	letter-spacing: 0.4px;
-	color: rgba(255, 255, 255, 0.3);
-	background: rgba(255, 255, 255, 0.06);
-	border: none;
+	color: var(--color-text-subtle);
+	background: var(--color-neutral-0);
+	border: 1px solid var(--color-border-subtle);
 	border-radius: 4px;
 	padding-block: 3px;
 	padding-inline: 8px;
@@ -1697,92 +1711,65 @@
 }
 
 .amplify-landing-workflow-prompt-copy:hover {
-	color: rgba(255, 255, 255, 0.7);
-	background: rgba(255, 255, 255, 0.1);
+	color: var(--color-text);
+	background: var(--color-neutral-5);
 }
 
 .amplify-landing-workflow-prompt-text {
 	font-size: 12px;
-	color: rgba(255, 255, 255, 0.35);
+	color: var(--color-text);
 	line-height: 1.55;
-	font-family: "SF Mono", "Fira Code", monospace;
-	display: -webkit-box;
-	-webkit-line-clamp: 2;
-	-webkit-box-orient: vertical;
-	overflow: hidden;
-}
-
-.amplify-landing-workflow-card-footer {
-	padding-block: 16px;
-	padding-inline: 20px;
-	border-block-start: 1px solid rgba(255, 255, 255, 0.08);
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	gap: 12px;
-}
-
-.amplify-landing-workflow-studio-label {
-	display: flex;
-	align-items: center;
-	gap: 6px;
-	font-size: 11px;
-	color: rgba(255, 255, 255, 0.25);
-}
-
-.amplify-landing-workflow-studio-dot {
-	inline-size: 6px;
-	block-size: 6px;
-	border-radius: 16px;
-	background: var(--color-success);
-	flex-shrink: 0;
-}
-
-.amplify-landing-workflow-send-btn {
-	font-size: 12px;
-	font-weight: 600;
-	color: var(--color-text-inverted);
-	background: var(--color-accent);
-	border: none;
-	border-radius: 4px;
-	padding-block: 8px;
-	padding-inline: 16px;
-	cursor: pointer;
-	display: flex;
-	align-items: center;
-	gap: 6px;
-	transition: opacity 0.15s ease;
+	// Reverted from monospace; sans-serif reads like report body copy and
+	// reinforces the PDF/document framing. Line-clamp intentionally removed
+	// so prompts wrap to their natural length instead of ellipsizing — the
+	// prompt bodies above are written to be succinct enough to fit in 2 lines.
 	font-family: inherit;
-	white-space: nowrap;
 }
 
-.amplify-landing-workflow-send-btn:hover {
-	opacity: 0.9;
+// Footer area with the "Copy all prompts" bulk action. Right-aligned so it
+// reads as a document-level action separate from the per-prompt Copy buttons.
+.amplify-landing-workflow-card-footer {
+	padding-block: 12px;
+	padding-inline: 20px;
+	border-block-start: 1px solid var(--color-border-subtle);
+	display: flex;
+	justify-content: flex-end;
 }
 
-// ── HERO EYEBROW ───────────────────────────────────────────────────────────────
-
-.amplify-landing-eyebrow {
+.amplify-landing-workflow-copy-all {
 	font-size: 11px;
-	font-weight: 700;
-	letter-spacing: 1.2px;
-	text-transform: uppercase;
-	color: var(--color-accent);
-	margin-block-end: 16px;
+	font-weight: 600;
+	letter-spacing: 0.3px;
+	color: var(--color-text);
+	background: var(--color-neutral-0);
+	border: 1px solid var(--color-border-subtle);
+	border-radius: 4px;
+	padding-block: 6px;
+	padding-inline: 14px;
+	cursor: pointer;
+	white-space: nowrap;
+	transition: color 0.15s ease, background 0.15s ease;
+	font-family: inherit;
 }
+
+.amplify-landing-workflow-copy-all:hover {
+	color: var(--color-text-black);
+	background: var(--color-neutral-5);
+}
+
 
 // ── SECTION CONTAINERS ────────────────────────────────────────────────────────
-
-.amplify-landing-human-section,
-.amplify-landing-ai-section {
-	padding-block: 64px;
-	border-block-start: 1px solid var(--color-border);
-}
 
 // ── CRITERIA SECTION SHARED ───────────────────────────────────────────────────
 
 .amplify-criteria-section {
 	width: 100%;
+
+	// Local accent for the stat numbers (50ms, 75%, 34%) and the card numbers
+	// (01, 02, …) in this section. Both Human-centric and AI variants of the
+	// criteria section share this token so the blue stays consistent between
+	// them. Update here to retune both at once.
+	--amplify-criteria-accent: var(--studio-blue-50);
 }
 
 .amplify-criteria-section-header {
@@ -1843,7 +1830,7 @@
 	font-weight: 700;
 	line-height: 1;
 	letter-spacing: -1px;
-	color: var(--color-accent);
+	color: var(--amplify-criteria-accent);
 }
 
 .amplify-criteria-stat-label {
@@ -1972,7 +1959,7 @@
 	font-size: 11px;
 	font-weight: 700;
 	letter-spacing: 0.5px;
-	color: var(--color-accent);
+	color: var(--amplify-criteria-accent);
 	font-variant-numeric: tabular-nums;
 	margin-block-end: 2px;
 }

--- a/client/a8c-for-agencies/sections/amplify/style.scss
+++ b/client/a8c-for-agencies/sections/amplify/style.scss
@@ -22,35 +22,259 @@
 	line-height: 1.15;
 	letter-spacing: -0.5px;
 	color: var(--color-text-black);
-	// Matches the criteria-section title rhythm (16px gap between title and
-	// the descriptive paragraph that follows).
-	margin-block-end: 16px;
+	margin-block-end: 24px;
 }
 
 .amplify-landing-sub {
-	font-size: 15px;
+	font-size: 18px;
 	line-height: 1.65;
 	color: var(--color-text-subtle);
 	max-width: 640px;
-	margin-block-end: 28px;
+	margin-block-end: 32px;
 }
 
+// Hero site selector — a single bordered container that hosts both entry
+// methods side by side (URL input and connected-sites dropdown), separated
+// by an "or" divider, with the "Amplify it" submit affixed flush to the
+// right edge. On narrow viewports we collapse to a stacked layout so the
+// two methods remain easy to scan and tap on mobile.
+//
+// Structure (wide viewport):
+//   ┌──────────────┬────┬────────────────┬───────────┐
+//   │ ENTER A URL  │ OR │ CONNECTED      │           │
+//   │ https://…    │    │ ● Choose a site│ Amplify it│
+//   └──────────────┴────┴────────────────┴───────────┘
+//
+// The outer container is the only visual frame — we strip the inner
+// input/dropdown borders entirely on wide viewports so they read as
+// segments of the same container, with thin vertical dividers between
+// each. `overflow: hidden` crops the rounded outer corners against the
+// submit button so it can sit flush with the container's right edge.
 .amplify-landing-selector {
 	display: flex;
 	flex-direction: column;
 	gap: 12px;
 	align-items: stretch;
-	max-width: 560px;
+	max-width: 720px;
 
 	@include break-medium {
 		flex-direction: row;
-		align-items: flex-end;
+		align-items: stretch;
+		border: 1px solid var(--color-border-subtle);
+		border-radius: 8px;
+		background: var(--color-surface, #fff);
+		padding: 0;
+		gap: 0;
+		overflow: hidden;
+	}
+}
+
+// The two-input row that lives inside the outer container. On wide
+// viewports this is the URL field + or-divider + dropdown sitting on one
+// line; on narrow viewports it collapses to a stacked column so each
+// method remains separately readable.
+.amplify-landing-selector-fields {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	flex: 1;
+	min-inline-size: 0;
+
+	@include break-medium {
+		flex-direction: row;
+		align-items: stretch;
+		gap: 0;
 	}
 }
 
 .amplify-landing-selector-field {
 	flex: 1;
-	min-inline-size: 240px;
+	min-inline-size: 0;
+
+	@include break-medium {
+		// Match the reference's tighter internal padding so labels sit
+		// closer to the inputs and the segment heights line up flush with
+		// the submit button.
+		padding-block: 12px;
+		padding-inline: 16px;
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+	}
+}
+
+// Both input segments share a flex grow factor on wide viewports, but the
+// URL segment is capped tighter than the dropdown so the OR divider
+// shifts visually to the left of centre. The dropdown's larger cap then
+// absorbs the leftover row width on its side, keeping the "OR" reading
+// as the pivot between a compact URL entry and a roomier site picker
+// rather than a perfectly symmetric split.
+// Inner controls cascade to 100% of the URL cap so the input and any
+// descendant box stays inside it even if the content would overflow.
+@include break-medium {
+	.amplify-landing-selector-field.amplify-landing-selector-field-url,
+	.amplify-landing-selector-field.amplify-landing-selector-field-dropdown {
+		flex: 1 1 0;
+	}
+
+	.amplify-landing-selector-field.amplify-landing-selector-field-url {
+		max-inline-size: 260px;
+	}
+
+	.amplify-landing-selector-field.amplify-landing-selector-field-dropdown {
+		max-inline-size: 340px;
+	}
+
+	.amplify-landing-selector-field.amplify-landing-selector-field-url
+		.amplify-landing-selector-url-input,
+	.amplify-landing-selector-field.amplify-landing-selector-field-url
+		.components-text-control__input {
+		max-inline-size: 100%;
+		inline-size: 100%;
+		min-inline-size: 0;
+	}
+}
+
+// Vertical "or" segment. On narrow viewports it becomes a horizontal rule
+// with the OR text floating in the middle so the stacked layout still
+// reads as "either/or". On wide viewports it's just the centered text —
+// the dividers come from border-inline-start on the segment to its right
+// (and on every other segment via the > * + * selector below).
+.amplify-landing-selector-or {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 11px;
+	font-weight: 500;
+	text-transform: uppercase;
+	color: var(--color-text-subtle);
+	letter-spacing: 0.04em;
+	padding-block: 4px;
+	user-select: none;
+
+	&::before,
+	&::after {
+		content: "";
+		flex: 1;
+		block-size: 1px;
+		background: var(--color-border-subtle);
+	}
+
+	&::before {
+		margin-inline-end: 12px;
+	}
+
+	&::after {
+		margin-inline-start: 12px;
+	}
+
+	@include break-medium {
+		flex: 0 0 auto;
+		padding-inline: 12px;
+		padding-block: 0;
+		// On wide viewports the vertical dividers on the neighbouring
+		// segments do the line work; the OR is just text.
+		&::before,
+		&::after {
+			content: none;
+		}
+	}
+}
+
+// Thin vertical divider between interior segments on wide viewports — only
+// rendered between the URL field and the OR text, since both the OR
+// segment itself and the dropdown segment are explicitly excluded. Net
+// effect on the current layout is no dividers at all (the URL segment is
+// the first child and never matches `* + *`), keeping the row as light
+// visually as possible. The rule is preserved structurally in case a
+// future segment needs a divider; today it's effectively dormant.
+@include break-medium {
+	.amplify-landing-selector-fields > * + * {
+		border-inline-start: 1px solid var(--color-border-subtle);
+	}
+
+	.amplify-landing-selector-fields > .amplify-landing-selector-or,
+	.amplify-landing-selector-fields > .amplify-landing-selector-field-dropdown {
+		border-inline-start: none;
+	}
+}
+
+// Strip the WordPress component default borders inside the container so
+// the segments read as parts of the single outer frame. No visible focus
+// underline by design — the visible text caret plus the dropdown's
+// open-state chevron rotation are the focus affordances. This is a
+// deliberate trade-off in favor of a lighter UI; if accessibility audit
+// surfaces it, restore an inset focus indicator scoped to :focus-visible.
+//
+// Both controls also share the same font-size / family / line-height and
+// the placeholder colour matches the dropdown's placeholder text, so the
+// empty URL input and "Choose a site" read as a matched pair instead of
+// two visually different controls happening to sit in the same row.
+@include break-medium {
+	.amplify-landing-selector .amplify-landing-selector-url-input .components-text-control__input,
+	.amplify-landing-selector .amplify-landing-site-dropdown-toggle {
+		border: none;
+		background: transparent;
+		box-shadow: none;
+		padding-inline: 0;
+		block-size: auto;
+		min-block-size: 32px;
+		font-size: 14px;
+		font-family: inherit;
+		line-height: 1.4;
+	}
+
+	.amplify-landing-selector
+		.amplify-landing-selector-url-input
+		.components-text-control__input::placeholder {
+		color: var(--color-text-subtle);
+		// Firefox dims placeholders by default (opacity ~0.5) — force full
+		// opacity so the URL placeholder reads at exactly the same weight
+		// as the dropdown's "Choose a site" placeholder.
+		opacity: 1;
+	}
+}
+
+// Submit-time validation error message. Rendered as a sibling of the
+// `.amplify-landing-selector` container (not inside it), so it sits below
+// the bordered field as a separate block-level element. We intentionally
+// don't apply any in-field red underline or border — validation runs only
+// when the user clicks "Amplify it", and the consolidated message below
+// the container is the single visual cue. Aligned to the start so it
+// reads as belonging to the URL input on the left of the row.
+.amplify-landing-selector-error {
+	margin: 8px 0 0;
+	padding-inline-start: 16px;
+	font-size: 13px;
+	color: var(--color-error, #d63638);
+}
+
+// Submit button — sits inside the outer container with breathing room on
+// all sides so it reads as a CTA tucked into the field, not a separate
+// edge-flush element. On narrow viewports the button returns to its
+// default size and stacks below the inputs.
+.amplify-landing-selector-submit {
+	align-self: stretch;
+
+	@include break-medium {
+		// !important is the cheapest way to outrank the @wordpress/components
+		// Button styles, which set padding / radius / height at higher
+		// specificity than a class selector alone can beat. The alternative
+		// is wrapping each property in a more specific compound selector,
+		// which produces unreadable CSS for the same result.
+		border-radius: 4px !important;
+		padding-inline: 24px !important;
+		block-size: auto !important;
+		min-block-size: 40px;
+		margin-block: 8px;
+		// Increased from 8px so the button sits noticeably inset from the
+		// container's right border instead of hugging it.
+		margin-inline-end: 24px;
+		margin-inline-start: 16px;
+		flex: 0 0 auto;
+		align-self: center;
+		font-weight: 500;
+	}
 }
 
 .amplify-landing-usage {
@@ -617,7 +841,6 @@
 	color: var(--color-text-black);
 	text-transform: uppercase;
 	letter-spacing: 0;
-	margin-block-end: 8px;
 }
 
 .amplify-landing-site-dropdown {
@@ -743,8 +966,28 @@
 	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05), 0 4px 16px rgba(0, 0, 0, 0.04);
 	// Cap the visual width so the score card doesn't crowd the hero headline
 	// at large breakpoints. Matches the woopayments hero visual treatment.
-	max-inline-size: 520px;
+	max-inline-size: 480px;
 	inline-size: 100%;
+}
+
+// Hero-specific grid + alignment overrides.
+//
+// `PageSectionColumns.Column alignCenter` (used for the score card)
+// defaults to `justify-content: center`, which leaves a sizable gap to
+// the right of the card now that the left column has grown. Pin the
+// card to the end of its column so it hugs the hero's right edge, and
+// widen the left column to 1fr / 0.8fr so the headline + selector get
+// more breathing room than the default 1fr / 1fr split allows.
+.amplify-landing-hero {
+	.page-section-columns__content {
+		@include break-large {
+			grid-template-columns: 1fr 0.8fr;
+		}
+	}
+
+	.page-section-column.is-align-center {
+		justify-content: flex-end;
+	}
 }
 
 .amplify-landing-score-card-header {

--- a/client/a8c-for-agencies/sections/amplify/style.scss
+++ b/client/a8c-for-agencies/sections/amplify/style.scss
@@ -71,6 +71,19 @@
 /* Reports tab — DataViews table */
 .amplify-reports {
 	padding-block-start: 16px;
+	max-inline-size: 100%;
+	overflow-x: hidden;
+}
+
+/* Align the DataViews toolbar (settings cog row) with the layout header and
+ * table content. DataViews defaults to 24px horizontal padding; match the 64px
+ * used by both the page title and the first/last table columns. */
+.amplify-reports .dataviews__view-actions {
+	padding-inline: 16px;
+
+	@media ( min-width: 661px ) {
+		padding-inline: 64px;
+	}
 }
 
 .amplify-reports .dataviews-view-table {
@@ -78,34 +91,47 @@
 	inline-size: 100%;
 }
 
-.amplify-reports .dataviews-view-table th:nth-child(1),
-.amplify-reports .dataviews-view-table td:nth-child(1) {
-	inline-size: 50%;
+/* Align the first-column header with cell content.
+ * full-width-layout-with-table sets padding-inline-start: 64px on both th and td.
+ * DataViews' sort button adds its own padding-inline-start: 8px, so the header text
+ * lands 8px further right than the cell content. Zero it out here. */
+.amplify-reports .dataviews-view-table thead th:nth-child(1) .dataviews-view-table-header-button {
+	padding-inline-start: 0;
 }
 
+/* No checkbox column when actions=[] — user columns start at nth-child(1) */
+
+/* Site */
+.amplify-reports .dataviews-view-table th:nth-child(1),
+.amplify-reports .dataviews-view-table td:nth-child(1) {
+	inline-size: 35%;
+}
+
+/* Analysis type */
 .amplify-reports .dataviews-view-table th:nth-child(2),
 .amplify-reports .dataviews-view-table td:nth-child(2) {
 	inline-size: 15%;
 }
 
+/* Scores */
 .amplify-reports .dataviews-view-table th:nth-child(3),
 .amplify-reports .dataviews-view-table td:nth-child(3) {
-	inline-size: 20%;
+	inline-size: 18%;
 }
 
+/* Time & date */
 .amplify-reports .dataviews-view-table th:nth-child(4),
 .amplify-reports .dataviews-view-table td:nth-child(4) {
-	inline-size: 15%;
+	inline-size: 18%;
 }
 
-.amplify-reports-site {
-	display: block;
-	font-weight: 500;
-	color: var(--color-text-black);
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
+/* Download */
+.amplify-reports .dataviews-view-table th:nth-child(5),
+.amplify-reports .dataviews-view-table td:nth-child(5) {
+	inline-size: 14%;
 }
+
+/* .amplify-reports-site styles moved below with site-name/site-url children */
 
 .amplify-reports-timestamp {
 	color: var(--color-text-subtle);
@@ -133,9 +159,88 @@
 	color: rgb(124, 58, 237);
 }
 
-.amplify-reports-badge.is-full {
+.amplify-reports-badge.is-full,
+.amplify-reports-badge.is-fullanalysis {
 	background: var(--color-success-5);
 	color: var(--color-success);
+}
+
+.amplify-reports-site {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	overflow: hidden;
+}
+
+.amplify-reports-site-name {
+	font-weight: 500;
+	color: var(--color-text-black);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.amplify-reports-site-url {
+	font-size: 12px;
+	color: var(--color-text-subtle);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.amplify-reports-scores {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px;
+}
+
+.amplify-reports-score {
+	display: inline-flex;
+	align-items: center;
+	padding-block: 2px;
+	padding-inline: 8px;
+	font-size: 12px;
+	font-weight: 600;
+	border-radius: 16px;
+	white-space: nowrap;
+}
+
+.amplify-reports-score.is-strong {
+	background: var(--color-success-5);
+	color: var(--color-success);
+}
+
+.amplify-reports-score.is-needs-work {
+	background: rgba(234, 179, 8, 0.1);
+	color: rgb(161, 120, 0);
+}
+
+.amplify-reports-score.is-at-risk {
+	background: var(--color-error-5);
+	color: var(--color-error);
+}
+
+.amplify-reports-loading {
+	padding-block: 48px;
+	text-align: center;
+	color: var(--color-text-subtle);
+	font-size: 14px;
+}
+
+.amplify-reports-empty {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	padding-block: 64px;
+	gap: 24px;
+}
+
+.amplify-reports-empty-heading {
+	font-size: 16px;
+	font-weight: 500;
+	color: var(--color-text-black);
+	margin: 0;
+	text-align: center;
 }
 
 /* Analysis flow modal */
@@ -232,6 +337,15 @@
 	font-size: 13px;
 	color: var(--color-text-subtle);
 	line-height: 1.45;
+}
+
+/* Error stage */
+.amplify-analysis-error {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 16px;
+	padding-block-end: 8px;
 }
 
 /* Progress stage */

--- a/client/a8c-for-agencies/sections/amplify/style.scss
+++ b/client/a8c-for-agencies/sections/amplify/style.scss
@@ -10,6 +10,7 @@
 	grid-template-columns: 1fr;
 	gap: 48px;
 	align-items: center;
+	padding-block-end: 48px;
 
 	@include break-large {
 		grid-template-columns: 1fr 0.85fr;
@@ -39,7 +40,6 @@
 	flex-direction: column;
 	gap: 12px;
 	align-items: stretch;
-	margin-block-end: 16px;
 	max-width: 560px;
 
 	@include break-medium {
@@ -51,6 +51,21 @@
 .amplify-landing-selector-field {
 	flex: 1;
 	min-inline-size: 240px;
+}
+
+.amplify-landing-usage {
+	margin: 0;
+	font-size: 13px;
+	color: var(--color-text-subtle);
+}
+
+.amplify-landing-usage-link {
+	color: var(--color-accent);
+	text-decoration: none;
+}
+
+.amplify-landing-usage-link:hover {
+	text-decoration: underline;
 }
 
 .amplify-landing-selector-label {
@@ -217,10 +232,11 @@
 
 .amplify-landing-mode-btn {
 	flex: 1;
+	min-inline-size: 0;
 	font-size: 12px;
 	font-weight: 600;
 	padding-block: 7px;
-	padding-inline: 12px;
+	padding-inline: 8px;
 	border-radius: 4px;
 	border: 1px solid var(--color-border-subtle);
 	background: transparent;
@@ -228,6 +244,9 @@
 	cursor: pointer;
 	transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 	font-family: inherit;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .amplify-landing-mode-btn:hover {
@@ -315,6 +334,18 @@
 	margin-block-end: 4px;
 }
 
+.amplify-landing-score-title.good {
+	color: var(--color-success);
+}
+
+.amplify-landing-score-title.warn {
+	color: var(--color-warning-50);
+}
+
+.amplify-landing-score-title.danger {
+	color: var(--color-error);
+}
+
 .amplify-landing-score-body {
 	font-size: 13px;
 	color: var(--color-text-subtle);
@@ -329,7 +360,7 @@
 
 .amplify-landing-bar-row {
 	display: grid;
-	grid-template-columns: 130px 1fr 28px;
+	grid-template-columns: minmax(140px, 1.4fr) minmax(0, 2fr) auto;
 	align-items: center;
 	gap: 10px;
 }
@@ -381,4 +412,914 @@
 
 .amplify-landing-bar-val.danger {
 	color: var(--color-error);
+}
+
+/* Benefits */
+.amplify-landing-benefits {
+	border-block-start: 1px solid var(--color-border-subtle);
+	padding-block-start: 48px;
+}
+
+.amplify-landing-benefits-grid {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 16px;
+
+	@include break-large {
+		grid-template-columns: repeat(3, 1fr);
+		gap: 20px;
+	}
+}
+
+.amplify-landing-benefit {
+	background: var(--color-neutral-0);
+	border-radius: 8px;
+	padding-block: 32px;
+	padding-inline: 28px;
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
+.amplify-landing-benefit-icon {
+	inline-size: 48px;
+	block-size: 48px;
+	border-radius: 24px;
+	background: var(--color-accent);
+	color: var(--color-text-inverted);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
+}
+
+.amplify-landing-benefit-title {
+	font-size: 18px;
+	font-weight: 600;
+	line-height: 1.3;
+	color: var(--color-text-black);
+	margin: 0;
+}
+
+.amplify-landing-benefit-body {
+	font-size: 14px;
+	line-height: 1.65;
+	color: var(--color-text-subtle);
+	margin: 0;
+}
+
+/* How it works */
+.amplify-landing-how-section {
+	padding-block: 48px;
+}
+
+.amplify-landing-how {
+	display: flex;
+	flex-direction: column;
+	gap: 28px;
+}
+
+.amplify-landing-how-header {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 16px;
+
+	@include break-medium {
+		flex-direction: row;
+		align-items: flex-end;
+	}
+}
+
+.amplify-landing-how-eyebrow {
+	font-size: 11px;
+	font-weight: 600;
+	letter-spacing: 1px;
+	text-transform: uppercase;
+	color: var(--color-text-subtle);
+	margin: 0;
+	margin-block-end: 8px;
+}
+
+.amplify-landing-how-title {
+	font-size: clamp(24px, 2.4vw, 32px);
+	font-weight: 600;
+	line-height: 1.15;
+	letter-spacing: -0.4px;
+	color: var(--color-text-black);
+	margin: 0;
+}
+
+.amplify-landing-how-mode-toggle {
+	display: inline-flex;
+	background: var(--color-neutral-0);
+	border: 1px solid var(--color-border-subtle);
+	border-radius: 8px;
+	padding: 4px;
+	gap: 4px;
+	flex-shrink: 0;
+}
+
+.amplify-landing-how-mode-btn {
+	font-size: 13px;
+	font-weight: 600;
+	padding-block: 8px;
+	padding-inline: 18px;
+	border-radius: 4px;
+	border: none;
+	background: transparent;
+	color: var(--color-text-subtle);
+	cursor: pointer;
+	font-family: inherit;
+	transition: background 0.2s ease, color 0.2s ease;
+	white-space: nowrap;
+}
+
+.amplify-landing-how-mode-btn:hover:not(.is-active) {
+	color: var(--color-text-black);
+}
+
+.amplify-landing-how-mode-btn.is-active {
+	background: var(--color-accent);
+	color: var(--color-text-inverted);
+}
+
+/* Browser mock */
+.amplify-landing-how-browser {
+	border: 1px solid var(--color-border-subtle);
+	border-radius: 8px;
+	overflow: hidden;
+	box-shadow: 0 24px 80px rgba(0, 0, 0, 0.06), 0 4px 20px rgba(0, 0, 0, 0.04);
+}
+
+.amplify-landing-how-browser-chrome {
+	background: var(--color-neutral-0);
+	border-block-end: 1px solid var(--color-border-subtle);
+	padding-block: 10px;
+	padding-inline: 16px;
+	display: flex;
+	align-items: center;
+	gap: 12px;
+}
+
+.amplify-landing-how-browser-dots {
+	display: flex;
+	gap: 6px;
+	flex-shrink: 0;
+}
+
+.amplify-landing-how-browser-dot {
+	inline-size: 11px;
+	block-size: 11px;
+	border-radius: 16px;
+}
+
+.amplify-landing-how-browser-dot.is-r {
+	background: #ff5f57;
+}
+
+.amplify-landing-how-browser-dot.is-y {
+	background: #ffbd2e;
+}
+
+.amplify-landing-how-browser-dot.is-g {
+	background: #28ca41;
+}
+
+.amplify-landing-how-browser-address {
+	flex: 1;
+	display: flex;
+	justify-content: center;
+}
+
+.amplify-landing-how-browser-bar {
+	background: var(--color-surface, #fff);
+	border: 1px solid var(--color-border-subtle);
+	border-radius: 4px;
+	padding-block: 4px;
+	padding-inline: 16px;
+	font-size: 12px;
+	color: var(--color-text-subtle);
+	font-family: "SF Mono", "Fira Code", monospace;
+	max-inline-size: 260px;
+	inline-size: 100%;
+	text-align: center;
+}
+
+.amplify-landing-how-preview {
+	position: relative;
+	block-size: 640px;
+	overflow: hidden;
+}
+
+/* Fake agency site */
+.amplify-landing-how-mock {
+	inline-size: 100%;
+	block-size: 100%;
+	background: #f7f7f5;
+	user-select: none;
+	pointer-events: none;
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+}
+
+.amplify-landing-how-mock-nav {
+	background: #0d1117;
+	block-size: 60px;
+	padding-inline: 48px;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	flex-shrink: 0;
+}
+
+.amplify-landing-how-mock-logo {
+	display: flex;
+	align-items: center;
+	gap: 9px;
+}
+
+.amplify-landing-how-mock-logo-mark {
+	inline-size: 28px;
+	block-size: 28px;
+	border-radius: 4px;
+	background: #3b82f6;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 12px;
+	font-weight: 700;
+	color: #fff;
+}
+
+.amplify-landing-how-mock-logo-name {
+	font-size: 14px;
+	font-weight: 700;
+	color: #fff;
+}
+
+.amplify-landing-how-mock-nav-links {
+	display: flex;
+	gap: 28px;
+}
+
+.amplify-landing-how-mock-nav-links span {
+	font-size: 13px;
+	color: rgba(255, 255, 255, 0.45);
+}
+
+.amplify-landing-how-mock-nav-cta {
+	font-size: 12px;
+	font-weight: 600;
+	color: #0d1117;
+	background: #fff;
+	padding-block: 7px;
+	padding-inline: 16px;
+	border-radius: 4px;
+}
+
+.amplify-landing-how-mock-hero {
+	background: #fff;
+	padding-block: 56px 48px;
+	padding-inline: 48px;
+	display: grid;
+	grid-template-columns: 1fr 0.65fr;
+	gap: 40px;
+	align-items: center;
+	flex-shrink: 0;
+}
+
+.amplify-landing-how-mock-hero-eyebrow {
+	font-size: 10px;
+	font-weight: 700;
+	letter-spacing: 1.4px;
+	text-transform: uppercase;
+	color: #3b82f6;
+	margin-block-end: 14px;
+}
+
+.amplify-landing-how-mock-hero-h1 {
+	font-size: 42px;
+	font-weight: 700;
+	line-height: 1.07;
+	letter-spacing: -1.5px;
+	color: #0d1117;
+	margin-block-end: 16px;
+}
+
+.amplify-landing-how-mock-hero-sub {
+	font-size: 14px;
+	color: #64748b;
+	line-height: 1.7;
+	max-inline-size: 340px;
+	margin-block-end: 28px;
+}
+
+.amplify-landing-how-mock-cta-row {
+	display: flex;
+	gap: 10px;
+}
+
+.amplify-landing-how-mock-btn-dark {
+	font-size: 12px;
+	font-weight: 600;
+	background: #0d1117;
+	color: #fff;
+	padding-block: 10px;
+	padding-inline: 20px;
+	border-radius: 8px;
+}
+
+.amplify-landing-how-mock-btn-outline {
+	font-size: 12px;
+	font-weight: 500;
+	background: transparent;
+	color: #64748b;
+	border: 1px solid #e2e8f0;
+	padding-block: 10px;
+	padding-inline: 20px;
+	border-radius: 8px;
+}
+
+.amplify-landing-how-mock-hero-right {
+	border-radius: 8px;
+	background: linear-gradient(135deg, #0d1117 0%, #1e293b 100%);
+	block-size: 220px;
+	position: relative;
+	overflow: hidden;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.amplify-landing-how-mock-hero-right::before {
+	content: "";
+	position: absolute;
+	inline-size: 220px;
+	block-size: 220px;
+	border-radius: 50%;
+	background: radial-gradient(circle, rgba(59, 130, 246, 0.25) 0%, transparent 70%);
+	inset-block-start: -60px;
+	inset-inline-end: -60px;
+}
+
+.amplify-landing-how-mock-stat-label {
+	font-size: 10px;
+	font-weight: 600;
+	letter-spacing: 1px;
+	text-transform: uppercase;
+	color: rgba(255, 255, 255, 0.35);
+	position: relative;
+}
+
+.amplify-landing-how-mock-stat-num {
+	font-size: 58px;
+	font-weight: 700;
+	letter-spacing: -3px;
+	color: #fff;
+	line-height: 1;
+	position: relative;
+}
+
+.amplify-landing-how-mock-stat-sub {
+	font-size: 11px;
+	color: rgba(255, 255, 255, 0.4);
+	position: relative;
+}
+
+.amplify-landing-how-mock-projects {
+	padding-block: 28px;
+	padding-inline: 48px;
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: 14px;
+	flex: 1;
+}
+
+.amplify-landing-how-mock-card {
+	background: #fff;
+	border-radius: 8px;
+	overflow: hidden;
+	border: 1px solid #eaecef;
+}
+
+.amplify-landing-how-mock-card-thumb {
+	block-size: 80px;
+}
+
+.amplify-landing-how-mock-card-body {
+	padding-block: 10px 12px;
+	padding-inline: 14px;
+}
+
+.amplify-landing-how-mock-card-client {
+	font-size: 10px;
+	font-weight: 700;
+	letter-spacing: 0.8px;
+	text-transform: uppercase;
+	color: #94a3b8;
+	margin-block-end: 3px;
+}
+
+.amplify-landing-how-mock-card-title {
+	font-size: 12px;
+	font-weight: 600;
+	color: #0d1117;
+	line-height: 1.3;
+}
+
+/* Pins overlay */
+.amplify-landing-how-pins {
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
+}
+
+.amplify-landing-how-pin {
+	position: absolute;
+	display: flex;
+	align-items: center;
+	gap: 7px;
+	opacity: 0;
+	transform: translateY(6px) scale(0.92);
+	transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.amplify-landing-how-pin.is-visible {
+	opacity: 1;
+	transform: translateY(0) scale(1);
+}
+
+.amplify-landing-how-pin-dot {
+	inline-size: 14px;
+	block-size: 14px;
+	border-radius: 16px;
+	flex-shrink: 0;
+	position: relative;
+	box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.9);
+}
+
+.amplify-landing-how-pin-dot::after {
+	content: "";
+	position: absolute;
+	inset: -4px;
+	border-radius: 16px;
+	border: 1.5px solid currentColor;
+	opacity: 0.3;
+	animation: amplify-landing-pin-pulse 2s ease-in-out infinite;
+}
+
+@keyframes amplify-landing-pin-pulse {
+	0%, 100% {
+		transform: scale(1);
+		opacity: 0.3;
+	}
+
+	50% {
+		transform: scale(1.4);
+		opacity: 0;
+	}
+}
+
+.amplify-landing-how-pin-dot.good {
+	background: var(--color-success);
+	color: var(--color-success);
+}
+
+.amplify-landing-how-pin-dot.warn {
+	background: var(--color-warning-50);
+	color: var(--color-warning-50);
+}
+
+.amplify-landing-how-pin-dot.danger {
+	background: var(--color-error);
+	color: var(--color-error);
+}
+
+.amplify-landing-how-pin-label {
+	font-size: 11px;
+	font-weight: 600;
+	padding-block: 4px;
+	padding-inline: 10px;
+	border-radius: 16px;
+	white-space: nowrap;
+	color: var(--color-text-inverted);
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+}
+
+.amplify-landing-how-pin-label.good {
+	background: var(--color-success);
+}
+
+.amplify-landing-how-pin-label.warn {
+	background: var(--color-warning-50);
+}
+
+.amplify-landing-how-pin-label.danger {
+	background: var(--color-error);
+}
+
+/* Floating overlay panel */
+.amplify-landing-how-overlay {
+	position: absolute;
+	inset-block-end: 20px;
+	inset-inline-end: 20px;
+	inline-size: 220px;
+	background: var(--color-surface, #fff);
+	border: 1px solid var(--color-border-subtle);
+	border-radius: 8px;
+	padding: 16px;
+	box-shadow: 0 8px 32px rgba(0, 0, 0, 0.14);
+}
+
+.amplify-landing-how-overlay-mode {
+	font-size: 10px;
+	font-weight: 700;
+	letter-spacing: 0.8px;
+	text-transform: uppercase;
+	color: var(--color-accent);
+	margin-block-end: 10px;
+}
+
+.amplify-landing-how-overlay-score-row {
+	display: flex;
+	align-items: baseline;
+	gap: 6px;
+	margin-block-end: 4px;
+}
+
+.amplify-landing-how-overlay-num {
+	font-size: 36px;
+	font-weight: 700;
+	letter-spacing: -2px;
+	color: var(--color-text-black);
+	line-height: 1;
+}
+
+.amplify-landing-how-overlay-num.good {
+	color: var(--color-success);
+}
+
+.amplify-landing-how-overlay-num.warn {
+	color: var(--color-warning-50);
+}
+
+.amplify-landing-how-overlay-num.danger {
+	color: var(--color-error);
+}
+
+.amplify-landing-how-overlay-of {
+	font-size: 12px;
+	color: var(--color-text-subtle);
+}
+
+.amplify-landing-how-overlay-title {
+	font-size: 12px;
+	font-weight: 600;
+	color: var(--color-text-black);
+	margin-block-end: 12px;
+}
+
+.amplify-landing-how-overlay-title.good {
+	color: var(--color-success);
+}
+
+.amplify-landing-how-overlay-title.warn {
+	color: var(--color-warning-50);
+}
+
+.amplify-landing-how-overlay-title.danger {
+	color: var(--color-error);
+}
+
+.amplify-landing-how-overlay-bars {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
+.amplify-landing-how-overlay-row {
+	display: grid;
+	grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr) auto;
+	align-items: center;
+	gap: 6px;
+}
+
+.amplify-landing-how-overlay-row-label {
+	font-size: 10px;
+	color: var(--color-text-subtle);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.amplify-landing-how-overlay-track {
+	block-size: 4px;
+	background: var(--color-neutral-5);
+	border-radius: 2px;
+	overflow: hidden;
+}
+
+.amplify-landing-how-overlay-fill {
+	block-size: 100%;
+	border-radius: 2px;
+	transition: inline-size 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.amplify-landing-how-overlay-fill.good {
+	background: var(--color-success);
+}
+
+.amplify-landing-how-overlay-fill.warn {
+	background: var(--color-warning-50);
+}
+
+.amplify-landing-how-overlay-fill.danger {
+	background: var(--color-error);
+}
+
+.amplify-landing-how-overlay-val {
+	font-size: 10px;
+	font-weight: 600;
+	text-align: end;
+	color: var(--color-text-subtle);
+}
+
+.amplify-landing-how-overlay-val.good {
+	color: var(--color-success);
+}
+
+.amplify-landing-how-overlay-val.warn {
+	color: var(--color-warning-50);
+}
+
+.amplify-landing-how-overlay-val.danger {
+	color: var(--color-error);
+}
+
+.amplify-landing-how-overlay-btn {
+	display: block;
+	inline-size: 100%;
+	margin-block-start: 10px;
+	padding-block: 8px;
+	padding-inline: 0;
+	background: var(--color-accent);
+	color: var(--color-text-inverted);
+	font-size: 11px;
+	font-weight: 700;
+	font-family: inherit;
+	text-align: center;
+	border: none;
+	border-radius: 4px;
+	cursor: pointer;
+	letter-spacing: 0.2px;
+	transition: opacity 0.15s ease;
+}
+
+.amplify-landing-how-overlay-btn:hover {
+	opacity: 0.9;
+}
+
+/* AI workflow */
+.amplify-landing-workflow-section {
+	padding-block: 48px;
+}
+
+.amplify-landing-workflow {
+	display: flex;
+	flex-direction: column;
+}
+
+.amplify-landing-workflow-top {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 48px;
+	align-items: start;
+
+	@include break-large {
+		grid-template-columns: 1fr 1fr;
+		gap: 80px;
+	}
+}
+
+.amplify-landing-workflow-eyebrow {
+	font-size: 11px;
+	font-weight: 600;
+	letter-spacing: 1px;
+	text-transform: uppercase;
+	color: var(--color-text-subtle);
+	margin: 0;
+	margin-block-end: 16px;
+}
+
+.amplify-landing-workflow-title {
+	font-size: clamp(32px, 4vw, 56px);
+	font-weight: 600;
+	line-height: 1.05;
+	letter-spacing: -0.5px;
+	color: var(--color-text-black);
+	margin: 0;
+	margin-block-end: 24px;
+}
+
+.amplify-landing-workflow-body {
+	font-size: 16px;
+	line-height: 1.7;
+	color: var(--color-text-subtle);
+	max-inline-size: 580px;
+	margin: 0;
+}
+
+/* Prompt card (dark themed to evoke an AI/code surface) */
+.amplify-landing-workflow-card {
+	background: #0d1117;
+	border-radius: 16px;
+	overflow: hidden;
+	box-shadow: 0 24px 80px rgba(0, 0, 0, 0.18), 0 4px 20px rgba(0, 0, 0, 0.1);
+}
+
+.amplify-landing-workflow-card-header {
+	padding-block: 16px;
+	padding-inline: 20px;
+	border-block-end: 1px solid rgba(255, 255, 255, 0.08);
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+}
+
+.amplify-landing-workflow-card-header-left {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	min-inline-size: 0;
+}
+
+.amplify-landing-workflow-card-title {
+	font-size: 12px;
+	font-weight: 600;
+	color: rgba(255, 255, 255, 0.5);
+	letter-spacing: 0.5px;
+	text-transform: uppercase;
+	white-space: nowrap;
+}
+
+.amplify-landing-workflow-card-mode {
+	font-size: 10px;
+	font-weight: 700;
+	letter-spacing: 0.6px;
+	text-transform: uppercase;
+	padding-block: 3px;
+	padding-inline: 8px;
+	border-radius: 16px;
+	background: rgba(79, 124, 255, 0.18);
+	color: #7da4ff;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.amplify-landing-workflow-card-count {
+	font-size: 11px;
+	color: rgba(255, 255, 255, 0.25);
+	white-space: nowrap;
+	flex-shrink: 0;
+}
+
+.amplify-landing-workflow-prompt-items {
+	padding-block: 8px;
+	padding-inline: 0;
+}
+
+.amplify-landing-workflow-prompt-item {
+	padding-block: 14px;
+	padding-inline: 20px;
+	border-block-end: 1px solid rgba(255, 255, 255, 0.05);
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
+.amplify-landing-workflow-prompt-item:last-child {
+	border-block-end: none;
+}
+
+.amplify-landing-workflow-prompt-item-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+}
+
+.amplify-landing-workflow-prompt-item-label {
+	display: flex;
+	align-items: center;
+	gap: 7px;
+	font-size: 12px;
+	font-weight: 600;
+	color: rgba(255, 255, 255, 0.85);
+}
+
+.amplify-landing-workflow-prompt-item-dot {
+	inline-size: 6px;
+	block-size: 6px;
+	border-radius: 16px;
+	flex-shrink: 0;
+}
+
+.amplify-landing-workflow-prompt-item-dot.warn {
+	background: var(--color-warning-50);
+}
+
+.amplify-landing-workflow-prompt-item-dot.danger {
+	background: var(--color-error);
+}
+
+.amplify-landing-workflow-prompt-item-dot.good {
+	background: var(--color-success);
+}
+
+.amplify-landing-workflow-prompt-copy {
+	font-size: 10px;
+	font-weight: 600;
+	letter-spacing: 0.4px;
+	color: rgba(255, 255, 255, 0.3);
+	background: rgba(255, 255, 255, 0.06);
+	border: none;
+	border-radius: 4px;
+	padding-block: 3px;
+	padding-inline: 8px;
+	cursor: pointer;
+	white-space: nowrap;
+	flex-shrink: 0;
+	transition: color 0.15s ease, background 0.15s ease;
+	font-family: inherit;
+}
+
+.amplify-landing-workflow-prompt-copy:hover {
+	color: rgba(255, 255, 255, 0.7);
+	background: rgba(255, 255, 255, 0.1);
+}
+
+.amplify-landing-workflow-prompt-text {
+	font-size: 12px;
+	color: rgba(255, 255, 255, 0.35);
+	line-height: 1.55;
+	font-family: "SF Mono", "Fira Code", monospace;
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+}
+
+.amplify-landing-workflow-card-footer {
+	padding-block: 16px;
+	padding-inline: 20px;
+	border-block-start: 1px solid rgba(255, 255, 255, 0.08);
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+}
+
+.amplify-landing-workflow-studio-label {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 11px;
+	color: rgba(255, 255, 255, 0.25);
+}
+
+.amplify-landing-workflow-studio-dot {
+	inline-size: 6px;
+	block-size: 6px;
+	border-radius: 16px;
+	background: var(--color-success);
+	flex-shrink: 0;
+}
+
+.amplify-landing-workflow-send-btn {
+	font-size: 12px;
+	font-weight: 600;
+	color: var(--color-text-inverted);
+	background: var(--color-accent);
+	border: none;
+	border-radius: 4px;
+	padding-block: 8px;
+	padding-inline: 16px;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	transition: opacity 0.15s ease;
+	font-family: inherit;
+	white-space: nowrap;
+}
+
+.amplify-landing-workflow-send-btn:hover {
+	opacity: 0.9;
 }

--- a/client/a8c-for-agencies/sections/amplify/style.scss
+++ b/client/a8c-for-agencies/sections/amplify/style.scss
@@ -18,6 +18,12 @@
 	}
 }
 
+.amplify-landing-hero-visual {
+	@include break-large {
+		margin-block-start: 48px;
+	}
+}
+
 .amplify-landing-h1 {
 	font-size: clamp(28px, 3.6vw, 44px);
 	font-weight: 600;
@@ -54,7 +60,7 @@
 }
 
 .amplify-landing-usage {
-	margin: 0;
+	margin-block-start: 12px;
 	font-size: 13px;
 	color: var(--color-text-subtle);
 }
@@ -244,6 +250,20 @@
 @keyframes amplify-pulse {
 	0%, 100% { opacity: 1; }
 	50% { opacity: 0.3; }
+}
+
+.amplify-reports-fetch-error {
+	margin: 0;
+	padding-block: 10px;
+	padding-inline: 16px;
+	font-size: 13px;
+	color: var(--color-error);
+	background: var(--color-error-5);
+	border-block-end: 1px solid var(--color-error-10);
+
+	@media ( min-width: 661px ) {
+		padding-inline: 64px;
+	}
 }
 
 .amplify-reports-loading {
@@ -1714,3 +1734,402 @@
 .amplify-landing-workflow-send-btn:hover {
 	opacity: 0.9;
 }
+
+// ── HERO EYEBROW ───────────────────────────────────────────────────────────────
+
+.amplify-landing-eyebrow {
+	font-size: 11px;
+	font-weight: 700;
+	letter-spacing: 1.2px;
+	text-transform: uppercase;
+	color: var(--color-accent);
+	margin-block-end: 16px;
+}
+
+// ── SECTION CONTAINERS ────────────────────────────────────────────────────────
+
+.amplify-landing-human-section,
+.amplify-landing-ai-section {
+	padding-block: 64px;
+	border-block-start: 1px solid var(--color-border);
+}
+
+// ── CRITERIA SECTION SHARED ───────────────────────────────────────────────────
+
+.amplify-criteria-section {
+	width: 100%;
+}
+
+.amplify-criteria-section-header {
+	margin-block-end: 48px;
+}
+
+.amplify-criteria-eyebrow {
+	font-size: 11px;
+	font-weight: 700;
+	letter-spacing: 1.2px;
+	text-transform: uppercase;
+	color: var(--color-accent);
+	margin-block-end: 12px;
+}
+
+.amplify-criteria-title {
+	font-size: clamp(24px, 3vw, 36px);
+	font-weight: 600;
+	line-height: 1.15;
+	letter-spacing: -0.4px;
+	color: var(--color-text-black);
+	margin-block-end: 16px;
+}
+
+.amplify-criteria-intro {
+	font-size: 15px;
+	line-height: 1.7;
+	color: var(--color-text-subtle);
+	max-width: 760px;
+	margin-block-end: 36px;
+}
+
+// ── HERO STATS ────────────────────────────────────────────────────────────────
+
+.amplify-criteria-stats {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: 16px;
+	margin-block-end: 36px;
+
+	@include break-small {
+		grid-template-columns: repeat(3, 1fr);
+	}
+}
+
+.amplify-criteria-stat {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	padding: 20px;
+	background: var(--color-surface, #fff);
+	border-radius: 8px;
+	border: 1px solid var(--color-border-subtle);
+}
+
+.amplify-criteria-stat-num {
+	font-size: clamp(26px, 3vw, 36px);
+	font-weight: 700;
+	line-height: 1;
+	letter-spacing: -1px;
+	color: var(--color-accent);
+}
+
+.amplify-criteria-stat-label {
+	font-size: 13px;
+	line-height: 1.5;
+	color: var(--color-text-subtle);
+}
+
+// ── STACKED BAR ───────────────────────────────────────────────────────────────
+
+.amplify-criteria-bar-wrap {
+	display: flex;
+	height: 32px;
+	border-radius: 8px;
+	overflow: hidden;
+	gap: 2px;
+	margin-block-end: 12px;
+}
+
+.amplify-criteria-bar-seg {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 11px;
+	font-weight: 700;
+	color: rgba(255 255 255 / 0.92);
+	background: var(--color-accent);
+	border: none;
+	cursor: pointer;
+	padding: 0;
+	overflow: hidden;
+	white-space: nowrap;
+	opacity: 0.6;
+	transition: opacity 0.15s ease;
+	font-family: inherit;
+
+	&:nth-child(1) { opacity: 0.95; }
+	&:nth-child(2) { opacity: 0.88; }
+	&:nth-child(3) { opacity: 0.81; }
+	&:nth-child(4) { opacity: 0.74; }
+	&:nth-child(5) { opacity: 0.68; }
+	&:nth-child(6) { opacity: 0.62; }
+	&:nth-child(7) { opacity: 0.56; }
+	&:nth-child(8) { opacity: 0.5; }
+
+	&:hover,
+	&.is-active {
+		opacity: 1;
+		outline: 2px solid var(--color-accent);
+		outline-offset: 1px;
+		z-index: 1;
+	}
+}
+
+.amplify-criteria-bar-legend {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px 14px;
+	margin-block-end: 0;
+}
+
+.amplify-criteria-legend-item {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 12px;
+	color: var(--color-text-subtle);
+	background: none;
+	border: none;
+	padding: 0;
+	cursor: pointer;
+	font-family: inherit;
+	transition: color 0.15s ease;
+
+	&:hover,
+	&.is-active {
+		color: var(--color-text);
+		font-weight: 600;
+	}
+}
+
+.amplify-criteria-legend-dot {
+	width: 8px;
+	height: 8px;
+	border-radius: 2px;
+	background: var(--color-accent);
+	flex-shrink: 0;
+}
+
+.amplify-criteria-legend-pts {
+	font-size: 11px;
+	color: var(--color-text-subtle);
+	margin-inline-start: 2px;
+}
+
+// ── CRITERIA CARDS ────────────────────────────────────────────────────────────
+
+.amplify-criteria-cards {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 1px;
+	background: var(--color-border-subtle);
+	border: 1px solid var(--color-border-subtle);
+	border-radius: 8px;
+	overflow: hidden;
+
+	@include break-medium {
+		grid-template-columns: repeat(2, 1fr);
+	}
+}
+
+.amplify-criteria-card {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	padding: 20px 24px;
+	background: var(--color-surface, #fff);
+	transition: background 0.15s ease;
+
+	&:hover {
+		background: var(--color-neutral-0);
+	}
+}
+
+.amplify-criteria-card-num {
+	font-size: 11px;
+	font-weight: 700;
+	letter-spacing: 0.5px;
+	color: var(--color-accent);
+	font-variant-numeric: tabular-nums;
+	margin-block-end: 2px;
+}
+
+.amplify-criteria-card-title {
+	font-size: 14px;
+	font-weight: 600;
+	color: var(--color-text);
+	line-height: 1.3;
+	margin: 0;
+}
+
+.amplify-criteria-card-summary {
+	font-size: 13px;
+	line-height: 1.55;
+	color: var(--color-text-subtle);
+	margin: 0;
+}
+
+// ── CRITERIA ACCORDION ────────────────────────────────────────────────────────
+
+.amplify-criteria-list {
+	display: flex;
+	flex-direction: column;
+	border-block-start: 1px solid var(--color-border);
+}
+
+.amplify-criterion-item {
+	border-block-end: 1px solid var(--color-border);
+
+	&.is-open {
+		.amplify-criterion-chevron {
+			transform: rotate(180deg);
+		}
+
+		.amplify-criterion-num {
+			color: var(--color-accent);
+		}
+	}
+}
+
+.amplify-criterion-trigger {
+	display: grid;
+	grid-template-columns: 36px 1fr auto 20px;
+	align-items: center;
+	gap: 16px;
+	width: 100%;
+	padding-block: 20px;
+	padding-inline: 0;
+	background: none;
+	border: none;
+	cursor: pointer;
+	text-align: start;
+	font-family: inherit;
+	transition: background 0.1s ease;
+
+	&:hover {
+		background: var(--color-surface-backdrop);
+		padding-inline: 12px;
+		margin-inline: -12px;
+		width: calc(100% + 24px);
+	}
+}
+
+.amplify-criterion-num {
+	font-size: 22px;
+	font-weight: 700;
+	color: var(--color-text-subtle);
+	line-height: 1;
+	transition: color 0.15s ease;
+}
+
+.amplify-criterion-trigger-text {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	min-width: 0;
+}
+
+.amplify-criterion-trigger-title {
+	font-size: 15px;
+	font-weight: 600;
+	color: var(--color-text);
+	line-height: 1.3;
+}
+
+.amplify-criterion-trigger-summary {
+	font-size: 13px;
+	color: var(--color-text-subtle);
+	line-height: 1.5;
+}
+
+.amplify-criterion-pts {
+	font-size: 12px;
+	font-weight: 700;
+	color: var(--color-accent);
+	background: color-mix(in srgb, var(--color-accent) 10%, transparent);
+	border: 1px solid color-mix(in srgb, var(--color-accent) 20%, transparent);
+	border-radius: 16px;
+	padding: 3px 10px;
+	white-space: nowrap;
+	flex-shrink: 0;
+}
+
+.amplify-criterion-chevron {
+	color: var(--color-text-subtle);
+	flex-shrink: 0;
+	transition: transform 0.2s ease;
+}
+
+// ── CRITERION BODY (expanded) ─────────────────────────────────────────────────
+
+.amplify-criterion-body {
+	padding-block-end: 28px;
+	padding-inline-start: 52px;
+	display: flex;
+	flex-direction: column;
+	gap: 20px;
+}
+
+.amplify-criterion-why {
+	font-size: 14px;
+	line-height: 1.65;
+	color: var(--color-text-subtle);
+	max-width: 680px;
+}
+
+.amplify-criterion-stat-chips {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
+.amplify-criterion-stat-chip {
+	font-size: 13px;
+	color: var(--color-text-subtle);
+	border-inline-start: 3px solid var(--color-accent);
+	padding-block: 6px;
+	padding-inline: 12px;
+	line-height: 1.5;
+	background: color-mix(in srgb, var(--color-accent) 5%, transparent);
+}
+
+.amplify-criterion-signals {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+}
+
+.amplify-criterion-signals-label {
+	font-size: 11px;
+	font-weight: 700;
+	letter-spacing: 1px;
+	text-transform: uppercase;
+	color: var(--color-text-subtle);
+}
+
+.amplify-criterion-signals-list {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+
+	li {
+		font-size: 13px;
+		color: var(--color-text);
+		line-height: 1.5;
+		padding-inline-start: 16px;
+		position: relative;
+
+		&::before {
+			content: "";
+			position: absolute;
+			inset-inline-start: 0;
+			inset-block-start: 8px;
+			width: 5px;
+			height: 5px;
+			border-radius: 50%;
+			background: var(--color-accent);
+		}
+	}
+}
+

--- a/client/a8c-for-agencies/sections/amplify/style.scss
+++ b/client/a8c-for-agencies/sections/amplify/style.scss
@@ -1,8 +1,32 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
+// Zero out the hosting-dashboard body padding for the amplify layout so that
+// PageSection components (like the FAQ) can span full width and handle their
+// own internal spacing — the same approach used by migrations-overview-v2.
+.amplify-layout {
+	.hosting-dashboard-layout__body {
+		padding: 0;
+
+		> * {
+			max-width: 100%;
+			padding: 0;
+			margin: 0;
+		}
+	}
+}
+
+// amplify-landing is a direct child of hosting-dashboard-layout__body, so it
+// now needs to own its padding (previously inherited from the body > * rule).
 .amplify-landing {
 	padding-block-end: 32px;
+	padding-inline: 16px;
+	max-width: 1500px;
+	margin-inline: auto;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		padding-inline: 64px;
+	}
 }
 
 .amplify-landing-hero {
@@ -1499,6 +1523,7 @@
 .amplify-landing-workflow-section {
 	padding-block: 48px;
 }
+
 
 .amplify-landing-workflow {
 	display: flex;

--- a/client/a8c-for-agencies/sections/amplify/style.scss
+++ b/client/a8c-for-agencies/sections/amplify/style.scss
@@ -86,6 +86,29 @@
 	}
 }
 
+/* The active-filter chips row (e.g. "Status is: Active" + Reset) is a
+ * separate DataViews container directly below the toolbar. It needs the
+ * same horizontal padding so the chips line up flush-left with the search
+ * box above and the first table column below. */
+.amplify-reports .dataviews-filters__container {
+	padding-inline: 16px;
+
+	@media ( min-width: 661px ) {
+		padding-inline: 64px;
+	}
+}
+
+/* The pagination footer (next/prev page controls) only renders when there
+ * are 2+ pages of results. Align it with the toolbar / filter row / table
+ * content so it doesn't jump in at a different inset when it does appear. */
+.amplify-reports .dataviews-footer {
+	padding-inline: 16px;
+
+	@media ( min-width: 661px ) {
+		padding-inline: 64px;
+	}
+}
+
 .amplify-reports .dataviews-view-table {
 	table-layout: fixed;
 	inline-size: 100%;
@@ -99,12 +122,18 @@
 	padding-inline-start: 0;
 }
 
-/* No checkbox column when actions=[] — user columns start at nth-child(1) */
+/* No checkbox column when bulk-select isn't used — user columns start at
+ * nth-child(1). The 6th column is the DataViews actions column (.dataviews-
+ * view-table__actions-column), which holds the ellipsis menu trigger. The
+ * five user columns + the actions column must sum to 100% under
+ * table-layout: fixed; previously the user columns already summed to 100%
+ * and the added actions column overflowed the table, which is what produced
+ * the horizontal scrollbar on large viewports. */
 
 /* Site */
 .amplify-reports .dataviews-view-table th:nth-child(1),
 .amplify-reports .dataviews-view-table td:nth-child(1) {
-	inline-size: 35%;
+	inline-size: 25%;
 }
 
 /* Analysis type */
@@ -128,7 +157,18 @@
 /* Download */
 .amplify-reports .dataviews-view-table th:nth-child(5),
 .amplify-reports .dataviews-view-table td:nth-child(5) {
-	inline-size: 14%;
+	inline-size: 16%;
+}
+
+/* Actions (ellipsis menu) — sized just wide enough for the trigger button
+ * plus the 64px end padding that full-width-layout-with-table applies to the
+ * last column for page-edge alignment. The DataViews default text-align is
+ * already `right`, but reasserting it here is defensive against any future
+ * cascade change and pairs nicely with the explicit column width. */
+.amplify-reports .dataviews-view-table th.dataviews-view-table__actions-column,
+.amplify-reports .dataviews-view-table td.dataviews-view-table__actions-column {
+	inline-size: 8%;
+	text-align: end;
 }
 
 /* .amplify-reports-site styles moved below with site-name/site-url children */
@@ -194,6 +234,16 @@
 	gap: 4px;
 }
 
+/* Pending rows have no scores yet — show an em dash in a soft gray that
+ * matches the row dividers so it reads as "intentionally empty" rather than
+ * a missing value. */
+.amplify-reports-scores-placeholder {
+	color: var(--color-neutral-20);
+	font-size: 16px;
+	line-height: 1;
+	user-select: none;
+}
+
 .amplify-reports-score {
 	display: inline-flex;
 	align-items: center;
@@ -218,6 +268,49 @@
 .amplify-reports-score.is-at-risk {
 	background: var(--color-error-5);
 	color: var(--color-error);
+}
+
+/* Archived state shown in the Download column in place of the Download PDF
+ * button. Visually muted, paired with an info icon that opens a popover
+ * explaining why the download is hidden and nudging the user to amplify
+ * the site again for current data. */
+.amplify-reports-archived {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 13px;
+	color: var(--color-text-subtle);
+}
+
+.amplify-reports-archived-label {
+	font-style: italic;
+}
+
+/* Popover body is rendered into A4APopover's content slot. A4APopover sets
+ * its own padding via the wrapper, so these rules only handle inner
+ * typography and the link styling. */
+.amplify-reports-archived-popover {
+	max-inline-size: 240px;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.amplify-reports-archived-popover-body {
+	margin: 0;
+	font-size: 13px;
+	line-height: 1.5;
+	color: var(--color-text);
+}
+
+/* The "Amplify now" CTA is rendered via <Button variant="link">, which gives
+ * us the standard link affordance for free. We just need to align it to the
+ * start of the popover (the @wordpress/components default centers Button
+ * text-style as flex content in some contexts) and remove any inherited
+ * margin so the gap above does the spacing. */
+.amplify-reports-archived-popover-cta {
+	align-self: flex-start;
+	font-size: 13px;
 }
 
 .amplify-reports-in-progress {

--- a/client/a8c-for-agencies/sections/amplify/style.scss
+++ b/client/a8c-for-agencies/sections/amplify/style.scss
@@ -313,6 +313,50 @@
 	font-size: 13px;
 }
 
+/* Failed state shown in the Download column when a pending row has been
+ * stuck for more than STALE_PENDING_THRESHOLD_MS (30 min). Uses the A4A
+ * error color so the row reads as "something went wrong" at a glance,
+ * paired with a notice-outline Gridicon and an info popover that offers
+ * Try again / Archive it actions. */
+.amplify-reports-failed {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 13px;
+	color: var(--color-error);
+}
+
+.amplify-reports-failed-icon {
+	flex-shrink: 0;
+	fill: var(--color-error);
+}
+
+.amplify-reports-failed-label {
+	font-weight: 500;
+}
+
+.amplify-reports-failed-popover {
+	max-inline-size: 260px;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.amplify-reports-failed-popover-body {
+	margin: 0;
+	font-size: 13px;
+	line-height: 1.5;
+	color: var(--color-text);
+}
+
+/* Single "Try again" link aligned to the start of the popover, matching
+ * the archived popover's CTA treatment. Archiving the row is available via
+ * the row's ellipsis menu — no second link here. */
+.amplify-reports-failed-popover-cta {
+	align-self: flex-start;
+	font-size: 13px;
+}
+
 .amplify-reports-in-progress {
 	display: inline-flex;
 	align-items: center;

--- a/client/a8c-for-agencies/sections/amplify/style.scss
+++ b/client/a8c-for-agencies/sections/amplify/style.scss
@@ -1,0 +1,384 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.amplify-landing {
+	padding-block-end: 32px;
+}
+
+.amplify-landing-hero {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 48px;
+	align-items: center;
+
+	@include break-large {
+		grid-template-columns: 1fr 0.85fr;
+		gap: 64px;
+	}
+}
+
+.amplify-landing-h1 {
+	font-size: clamp(28px, 3.6vw, 44px);
+	font-weight: 600;
+	line-height: 1.15;
+	letter-spacing: -0.5px;
+	color: var(--color-text-black);
+	margin-block-end: 20px;
+}
+
+.amplify-landing-sub {
+	font-size: 15px;
+	line-height: 1.65;
+	color: var(--color-text-subtle);
+	max-width: 640px;
+	margin-block-end: 28px;
+}
+
+.amplify-landing-selector {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	align-items: stretch;
+	margin-block-end: 16px;
+	max-width: 560px;
+
+	@include break-medium {
+		flex-direction: row;
+		align-items: flex-end;
+	}
+}
+
+.amplify-landing-selector-field {
+	flex: 1;
+	min-inline-size: 240px;
+}
+
+.amplify-landing-selector-label {
+	display: block;
+	font-size: 11px;
+	font-weight: 500;
+	color: var(--color-text-black);
+	text-transform: uppercase;
+	letter-spacing: 0;
+	margin-block-end: 8px;
+}
+
+.amplify-landing-site-dropdown {
+	display: block;
+}
+
+.amplify-landing-site-dropdown-toggle {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	inline-size: 100%;
+	block-size: 40px;
+	padding-inline: 12px;
+	border: 1px solid var(--color-border-subtle);
+	border-radius: 4px;
+	background: var(--color-surface, #fff);
+	color: var(--color-text-black);
+	cursor: pointer;
+	font-size: 14px;
+	font-family: inherit;
+	text-align: start;
+	transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.amplify-landing-site-dropdown-toggle:hover:not(:disabled) {
+	border-color: var(--color-neutral-20);
+}
+
+.amplify-landing-site-dropdown-toggle:focus-visible,
+.amplify-landing-site-dropdown-toggle.is-open {
+	outline: none;
+	border-color: var(--color-accent);
+	box-shadow: 0 0 0 1px var(--color-accent);
+}
+
+.amplify-landing-site-dropdown-toggle:disabled {
+	cursor: not-allowed;
+	opacity: 0.6;
+}
+
+.amplify-landing-site-dropdown-value {
+	flex: 1;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.amplify-landing-site-dropdown-value.is-placeholder {
+	color: var(--color-text-subtle);
+}
+
+// Popover content styles (rendered into a portal so it escapes overflow ancestors).
+// Match the toggle's border + radius so the panel reads as a continuation of the field.
+.amplify-landing-site-dropdown-content .components-popover__content {
+	border: 1px solid var(--color-border-subtle);
+	border-radius: 4px;
+	box-shadow: 0 2px 6px rgba(0, 0, 0, 0.04), 0 8px 24px rgba(0, 0, 0, 0.08);
+	overflow: hidden;
+}
+
+.amplify-landing-site-dropdown-panel {
+	min-inline-size: 280px;
+	max-inline-size: 480px;
+	display: flex;
+	flex-direction: column;
+}
+
+.amplify-landing-site-dropdown-search {
+	padding: 8px;
+	border-block-end: 1px solid var(--color-border-subtle);
+}
+
+.amplify-landing-site-dropdown-list {
+	list-style: none;
+	margin: 0;
+	padding-block: 4px;
+	padding-inline: 0;
+	max-block-size: 320px;
+	overflow-y: auto;
+}
+
+.amplify-landing-site-dropdown-item {
+	display: block;
+	inline-size: 100%;
+	padding-block: 8px;
+	padding-inline: 12px;
+	border: none;
+	background: transparent;
+	text-align: start;
+	font-size: 14px;
+	color: var(--color-text-black);
+	cursor: pointer;
+	font-family: inherit;
+	transition: background 0.12s ease;
+}
+
+.amplify-landing-site-dropdown-item:hover,
+.amplify-landing-site-dropdown-item:focus-visible {
+	background: var(--color-neutral-5);
+	outline: none;
+}
+
+.amplify-landing-site-dropdown-item.is-selected {
+	background: var(--color-accent-5);
+	color: var(--color-accent);
+	font-weight: 600;
+}
+
+.amplify-landing-site-dropdown-empty {
+	padding: 16px;
+	color: var(--color-text-subtle);
+	font-size: 13px;
+	text-align: center;
+}
+
+/* Score card */
+.amplify-landing-score-card {
+	background: var(--color-surface, #fff);
+	border: 1px solid var(--color-border-subtle);
+	border-radius: 8px;
+	padding: 24px;
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05), 0 4px 16px rgba(0, 0, 0, 0.04);
+}
+
+.amplify-landing-score-card-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-block-end: 18px;
+}
+
+.amplify-landing-score-url {
+	font-size: 12px;
+	color: var(--color-text-subtle);
+	font-family: "SF Mono", "Fira Code", monospace;
+}
+
+.amplify-landing-score-status {
+	font-size: 11px;
+	font-weight: 600;
+	color: var(--color-success);
+	background: var(--color-success-5);
+	padding-block: 3px;
+	padding-inline: 9px;
+	border-radius: 16px;
+}
+
+.amplify-landing-mode-toggle {
+	display: flex;
+	gap: 6px;
+	margin-block-end: 20px;
+}
+
+.amplify-landing-mode-btn {
+	flex: 1;
+	font-size: 12px;
+	font-weight: 600;
+	padding-block: 7px;
+	padding-inline: 12px;
+	border-radius: 4px;
+	border: 1px solid var(--color-border-subtle);
+	background: transparent;
+	color: var(--color-text-subtle);
+	cursor: pointer;
+	transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+	font-family: inherit;
+}
+
+.amplify-landing-mode-btn:hover {
+	color: var(--color-text-black);
+	border-color: var(--color-neutral-20);
+}
+
+.amplify-landing-mode-btn.is-active {
+	background: var(--color-accent);
+	border-color: var(--color-accent);
+	color: var(--color-text-inverted);
+}
+
+.amplify-landing-score-main {
+	display: flex;
+	align-items: center;
+	gap: 20px;
+	margin-block-end: 24px;
+}
+
+.amplify-landing-score-ring {
+	position: relative;
+	inline-size: 88px;
+	block-size: 88px;
+	flex-shrink: 0;
+}
+
+.amplify-landing-score-ring svg {
+	inline-size: 88px;
+	block-size: 88px;
+	transform: rotate(-90deg);
+}
+
+.amplify-landing-ring-track {
+	fill: none;
+	stroke: var(--color-neutral-5);
+	stroke-width: 7;
+}
+
+.amplify-landing-ring-fill {
+	fill: none;
+	stroke-width: 7;
+	stroke-linecap: round;
+	transition: stroke-dashoffset 0.6s cubic-bezier(0.4, 0, 0.2, 1), stroke 0.4s ease;
+}
+
+.amplify-landing-ring-fill.good {
+	stroke: var(--color-success);
+}
+
+.amplify-landing-ring-fill.warn {
+	stroke: var(--color-warning-50);
+}
+
+.amplify-landing-ring-fill.danger {
+	stroke: var(--color-error);
+}
+
+.amplify-landing-ring-label {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+}
+
+.amplify-landing-ring-num {
+	font-size: 24px;
+	font-weight: 700;
+	line-height: 1;
+	color: var(--color-text-black);
+}
+
+.amplify-landing-ring-of {
+	font-size: 10px;
+	color: var(--color-text-subtle);
+	font-weight: 500;
+}
+
+.amplify-landing-score-title {
+	font-size: 15px;
+	font-weight: 700;
+	color: var(--color-text-black);
+	margin-block-end: 4px;
+}
+
+.amplify-landing-score-body {
+	font-size: 13px;
+	color: var(--color-text-subtle);
+	line-height: 1.5;
+}
+
+.amplify-landing-bars {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+}
+
+.amplify-landing-bar-row {
+	display: grid;
+	grid-template-columns: 130px 1fr 28px;
+	align-items: center;
+	gap: 10px;
+}
+
+.amplify-landing-bar-label {
+	font-size: 12px;
+	color: var(--color-text-subtle);
+}
+
+.amplify-landing-bar-track {
+	block-size: 5px;
+	background: var(--color-neutral-5);
+	border-radius: 3px;
+	overflow: hidden;
+}
+
+.amplify-landing-bar-fill {
+	block-size: 100%;
+	border-radius: 3px;
+	transition: inline-size 0.5s cubic-bezier(0.4, 0, 0.2, 1), background 0.4s ease;
+}
+
+.amplify-landing-bar-fill.good {
+	background: var(--color-success);
+}
+
+.amplify-landing-bar-fill.warn {
+	background: var(--color-warning-50);
+}
+
+.amplify-landing-bar-fill.danger {
+	background: var(--color-error);
+}
+
+.amplify-landing-bar-val {
+	font-size: 11px;
+	font-weight: 600;
+	text-align: end;
+	color: var(--color-text-subtle);
+}
+
+.amplify-landing-bar-val.good {
+	color: var(--color-success);
+}
+
+.amplify-landing-bar-val.warn {
+	color: var(--color-warning-50);
+}
+
+.amplify-landing-bar-val.danger {
+	color: var(--color-error);
+}

--- a/client/sections.js
+++ b/client/sections.js
@@ -965,6 +965,12 @@ const sections = [
 		module: 'calypso/a8c-for-agencies/sections/exclusive-offers',
 		group: 'a8c-for-agencies',
 	},
+	{
+		name: 'a8c-for-agencies-amplify',
+		paths: [ '/amplify' ],
+		module: 'calypso/a8c-for-agencies/sections/amplify',
+		group: 'a8c-for-agencies',
+	},
 ];
 
 module.exports = sections;

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -10,6 +10,8 @@
 	"features": {},
 	"google_recaptcha_site_key": false,
 	"hotjar_enabled": false,
+	"amplify_worker_url": "",
+	"amplify_api_secret": "",
 	"survicate_enabled": false,
 	"hostname": false,
 	"hostname_allowlist": false,

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -185,6 +185,7 @@
 		"a8c-for-agencies-learn": false,
 		"a8c-for-agencies-dev-tools": false,
 		"a8c-for-agencies-exclusive-offers": false,
+		"a8c-for-agencies-amplify": false,
 		"jetpack-cloud": false,
 		"jetpack-cloud-overview": false,
 		"jetpack-cloud-agency-dashboard": false,

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -85,5 +85,7 @@
 	"restricted_me_access": false,
 	"theme_color": "#029CD7",
 	"theme_color_admin_color_scheme_override": false,
-	"hotjar_enabled": true
+	"hotjar_enabled": true,
+	"amplify_worker_url": "http://localhost:8787",
+	"amplify_api_secret": "d891214eed45021b7d7be0c6c0f727c2b856387836957e94e610a12efa6b8017"
 }

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -86,6 +86,6 @@
 	"theme_color": "#029CD7",
 	"theme_color_admin_color_scheme_override": false,
 	"hotjar_enabled": true,
-	"amplify_worker_url": "http://localhost:8787",
-	"amplify_api_secret": "d891214eed45021b7d7be0c6c0f727c2b856387836957e94e610a12efa6b8017"
+	"amplify_worker_url": "https://amplify-api.jeff-golenski.workers.dev",
+	"amplify_api_secret": "c8ba42b00a74a6d2d6ed7fad5e2dc697dc43b4b1d9cec8e6f026341ef974cc8c"
 }

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -77,7 +77,8 @@
 		"a8c-for-agencies-express-checkout": true,
 		"a8c-for-agencies-learn": true,
 		"a8c-for-agencies-dev-tools": true,
-		"a8c-for-agencies-exclusive-offers": true
+		"a8c-for-agencies-exclusive-offers": true,
+		"a8c-for-agencies-amplify": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -72,7 +72,8 @@
 		"a8c-for-agencies-express-checkout": true,
 		"a8c-for-agencies-learn": true,
 		"a8c-for-agencies-dev-tools": true,
-		"a8c-for-agencies-exclusive-offers": true
+		"a8c-for-agencies-exclusive-offers": true,
+		"a8c-for-agencies-amplify": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -80,5 +80,7 @@
 	"restricted_me_access": false,
 	"theme_color": "#029CD7",
 	"theme_color_admin_color_scheme_override": false,
-	"hotjar_enabled": true
+	"hotjar_enabled": true,
+	"amplify_worker_url": "https://amplify-api.jeff-golenski.workers.dev",
+	"amplify_api_secret": "c8ba42b00a74a6d2d6ed7fad5e2dc697dc43b4b1d9cec8e6f026341ef974cc8c"
 }

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -76,5 +76,7 @@
 	"restricted_me_access": false,
 	"theme_color": "#029CD7",
 	"theme_color_admin_color_scheme_override": false,
-	"hotjar_enabled": true
+	"hotjar_enabled": true,
+	"amplify_worker_url": "https://amplify-api.automattic.workers.dev",
+	"amplify_api_secret": ""
 }

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -77,6 +77,6 @@
 	"theme_color": "#029CD7",
 	"theme_color_admin_color_scheme_override": false,
 	"hotjar_enabled": true,
-	"amplify_worker_url": "https://amplify-api.automattic.workers.dev",
+	"amplify_worker_url": "",
 	"amplify_api_secret": ""
 }

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -82,5 +82,7 @@
 	"restricted_me_access": false,
 	"theme_color": "#029CD7",
 	"theme_color_admin_color_scheme_override": false,
-	"hotjar_enabled": true
+	"hotjar_enabled": true,
+	"amplify_worker_url": "https://amplify-api.jeff-golenski.workers.dev",
+	"amplify_api_secret": "c8ba42b00a74a6d2d6ed7fad5e2dc697dc43b4b1d9cec8e6f026341ef974cc8c"
 }

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -74,7 +74,8 @@
 		"a8c-for-agencies-express-checkout": false,
 		"a8c-for-agencies-learn": true,
 		"a8c-for-agencies-dev-tools": true,
-		"a8c-for-agencies-exclusive-offers": true
+		"a8c-for-agencies-exclusive-offers": true,
+		"a8c-for-agencies-amplify": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",


### PR DESCRIPTION
 ## Proposed Changes                                                                                                                                                                        
                                                               
  * Add a new `/amplify` page to the Automattic for Agencies dashboard at `client/a8c-for-agencies/sections/amplify/`.                                                                       
  * Build the masthead/hero with a headline, supporting copy, a "Recently connected sites" dropdown, and an "Amplify it" CTA (placeholder; wired in a follow-up).
  * Add a mock score-card visual with a Human / AI mode toggle, animated SVG ring, and metric bars.                                                                                          
  * Pull live connected-site data via `useFetchActiveSites`, filter out unprovisioned sites, sort by recency, and cap the default view at 10 (search filters across all connected sites).
  * Register the section in `client/sections.js`, add `A4A_AMPLIFY_LINK = '/amplify'` to the sidebar constants, and add `/amplify` to the "everyone can access" bypass list in               
  `lib/permission.ts`.                                                                                                                                                                       
  * Gate the section behind the `a8c-for-agencies-amplify` config flag — default `false` in `_shared.json`, enabled only in `a8c-for-agencies-development.json` for now.                     
                                                                                                                                                                                             
  ## Why are these changes being made?                         
                                                                                                                                                                                             
  * Establish a home for the Amplify product inside the A4A dashboard so we can iterate on the in-product landing experience.                                                                
  * Keep the section disabled outside development so the scaffolding can land before content and CTA wiring are ready.
                                                                                                                                                                                             
  ## Testing Instructions                                      
                                                                                                                                                                                             
  1. Add `127.0.0.1 agencies.localhost` to `/etc/hosts` if it isn't already.
  2. Run `yarn start-a8c-for-agencies` from the repo root.
  3. Sign in via the WordPress.com login flow in the same browser, then visit `http://agencies.localhost:3000/amplify`.                                                                      
  4. Verify the hero renders with the headline, sub copy, dropdown, and mock score card.
  5. Open the "Recently connected sites" dropdown — it should show up to 10 connected sites (no empty entries) and let you search across all connected sites.                                
  6. Toggle between Human mode and AI mode on the score card — the ring and metric bars should re-animate with the new values.                                                               
  7. Confirm the "Amplify it" CTA stays disabled until a site is selected (its click is intentionally a no-op for this PR).                                                                  
                                                                                                                                                                                             
  ## Pre-merge Checklist                                       
                                                                                                                                                                                             
  - [x] Has the general commit checklist been followed? (PCYsg-hS-p2)                                                                                                                        
  - [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
  - [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?                                                           
  - [x] Have you checked for TypeScript, React or other console errors?                                                                                                                      
  - [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive   
  technologies (e.g., screen readers) (PCYsg-S3g-p2).                                                                                                                                        
  - [ ] Have you used memoizing on expensive computations? More info in [Memoizing with                                                                                                      
  create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing                                              
  selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
  - [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?                                                              
      - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.              
  - [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)? 