### PR TITLE
Disable cache-seed image by default for Calypso Docker builds

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -97,7 +97,7 @@ object BuildDockerImage : BuildType({
     }
 
 	params {
-		text("cache_mode", "seed", label = "Docker build cache mode", description = "How the main Docker build sources warm caches. Allowed values: base, seed, none.", allowEmpty = false)
+		text("cache_mode", "none", label = "Docker build cache mode", description = "How the main Docker build sources warm caches. Allowed values: base, seed, none.", allowEmpty = false)
 		text("base_image", "registry.a8c.com/calypso/base:latest", label = "Base docker image", description = "Base docker image", allowEmpty = false)
 		text("cache_seed_image", "registry.a8c.com/calypso/cache-seed:latest", label = "Cache seed image", description = "Cache-only image used when cache_mode=seed", allowEmpty = false)
 		text("base_image_publish_tag", "latest", label = "Tag to use for the published base image", description = "Base docker image tag", allowEmpty = false)


### PR DESCRIPTION
## Proposed Changes

* Change the WebApp TeamCity `cache_mode` default from `seed` to `none`.
* Keep the existing `cache_mode` parameter available so builds can still opt into `base` or `seed` cache modes manually.

See also this thread p1777338150625629-slack-C02DQP0FP

## Why are these changes being made?

* Recent production builds have shown evidence that webpack's persistent cache can emit a fresh CSS chunk while leaving the runtime CSS chunk map pointed at an older hash.
* Using `cache_mode=none` stops trunk Docker builds from consuming the published cache-seed image by default, reducing the risk of carrying a stale seeded webpack cache across commits while preserving the ability to re-enable seeded builds for targeted testing.

## Testing Instructions

* Verify the TeamCity Kotlin settings compile.
* Run a WebApp build and confirm the generated Docker build command includes `--build-arg cache_mode=none` when the parameter is not overridden.
* Confirm Docker builds can still be manually run with `cache_mode=seed` if a seeded-cache comparison is needed.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in Memoizing with create-selector, Using memoizing selectors, and Our Approach to Data.
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?