### PR TITLE
e2e-failure-comment: tighten the call-to-action wording

### DIFF
--- a/.github/workflows/e2e-failure-comment.yml
+++ b/.github/workflows/e2e-failure-comment.yml
@@ -36,7 +36,7 @@ jobs:
               watermark,
               `Looks like one of the E2E tests has failed.`,
               ``,
-              `To investigate with Claude Code, follow these steps:`,
+              `You can fix them following these steps:`,
               ``,
               `1. Check out this branch locally:`,
               `   \`\`\`bash`,


### PR DESCRIPTION
## Proposed Changes

* Change the line in the auto-posted E2E-failure comment from \`To investigate with Claude Code, follow these steps:\` to \`You can fix them following these steps:\`.

## Why are these changes being made?

* The previous wording framed the comment as an open-ended investigation. The \`/fix-e2e-tests\` skill is opinionated: it identifies the failing test, dispatches an agent, and produces a fix PR. The new wording sets that expectation up front.

## Testing Instructions

* Trigger an E2E failure on a PR (or look at an existing failed run, e.g. #110264). The auto-posted comment should now read \"You can fix them following these steps:\" with the same numbered list of commands underneath.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?