### PR TITLE
[RSM-981] Fix dashboard dark mode bugs

### DIFF
--- a/client/dashboard/app/_dark-theme.scss
+++ b/client/dashboard/app/_dark-theme.scss
@@ -70,6 +70,10 @@
 		color: var( --dashboard-surface__border-color );
 		border-color: var( --dashboard-surface__border-color );
 	}
+
+	.components-card__header {
+		border-bottom-color: var( --dashboard-surface__border-color );
+	}
 }
 
 /* Panel */
@@ -365,7 +369,9 @@
 		}
 
 		.summary-button-navigation-icon,
+		.summary-button-decoration,
 		.summary-button-decoration svg {
+			color: var( --dashboard__text-muted-color );
 			fill: var( --dashboard__text-muted-color );
 		}
 
@@ -392,7 +398,9 @@
 			}
 
 			.summary-button-navigation-icon,
+			.summary-button-decoration,
 			.summary-button-decoration svg {
+				color: var( --dashboard-menu-item-active__color );
 				fill: var( --dashboard-menu-item-active__color );
 			}
 		}
@@ -505,7 +513,11 @@
 			border-top-color: var( --dashboard-surface__border-color );
 		}
 
-		td.dataviews-view-table__actions-column--stuck::after,
+		th.dataviews-view-table__actions-column--stuck::after,
+		td.dataviews-view-table__actions-column--stuck::after {
+			background-color: var( --dashboard-surface__border-color );
+		}
+
 		thead.dataviews-view-table__thead--stuck::after {
 			background-color: var( --dashboard-surface__background-color );
 		}

--- a/client/dashboard/app/notifications/style.scss
+++ b/client/dashboard/app/notifications/style.scss
@@ -1,3 +1,5 @@
+@use '../../../../packages/ui/src/utils/mixins' as ui-mixins;
+
 // The Dropdown component doesn't support to hide the header if the `expandOnMobile` is enabled.
 .dashboard-notifications.components-popover.is-expanded {
 	.components-popover__header {
@@ -9,10 +11,20 @@
 	}
 }
 
+.dashboard-notifications .components-card__header {
+	@include ui-mixins.when-dark-theme {
+		color: var( --dashboard__text-color );
+
+		svg {
+			fill: var( --dashboard__text-color );
+		}
+	}
+}
+
 .dashboard-notifications__icon {
 	svg {
 		circle {
-			fill: var(--wp-admin-theme-color);
+			fill: var( --wp-admin-theme-color );
 		}
 	}
 }

--- a/client/dashboard/me/billing-purchases/payment-methods/credit-card-fields.scss
+++ b/client/dashboard/me/billing-purchases/payment-methods/credit-card-fields.scss
@@ -1,3 +1,5 @@
+@use '../../../../../packages/ui/src/utils/mixins' as ui-mixins;
+
 .credit-card-field__label {
 	display: block;
 	margin-bottom: 8px;
@@ -25,6 +27,10 @@
 		transition:
 			border-color 0.1s ease-in-out,
 			box-shadow 0.1s ease-in-out;
+
+		@include ui-mixins.when-dark-theme {
+			background-color: var( --dashboard-surface__background-color );
+		}
 
 		&:hover {
 			border-color: var( --dashboard__text-color );

--- a/client/dashboard/me/billing-purchases/payment-methods/credit-card-fields.scss
+++ b/client/dashboard/me/billing-purchases/payment-methods/credit-card-fields.scss
@@ -1,3 +1,5 @@
+@use '../../../../../packages/ui/src/utils/mixins' as ui-mixins;
+
 .credit-card-field__label {
 	display: block;
 	margin-bottom: 8px;
@@ -5,7 +7,7 @@
 	font-weight: 500;
 	line-height: 1.4;
 	text-transform: uppercase;
-	color: #1e1e1e;
+	color: var( --dashboard__text-color );
 }
 
 .credit-card-field__stripe-element {
@@ -16,31 +18,38 @@
 		display: block;
 		width: 100%;
 		box-sizing: border-box;
-		border: 1px solid #949494;
+		border: 1px solid var( --dashboard-field__border-color, #949494 );
 		border-radius: 2px;
 		padding: 10px 16px;
 		font-size: 13px;
 		line-height: 20px;
 		background-color: #fff;
-		transition: border-color 0.1s ease-in-out, box-shadow 0.1s ease-in-out;
+		transition:
+			border-color 0.1s ease-in-out,
+			box-shadow 0.1s ease-in-out;
+
+		@include ui-mixins.when-dark-theme {
+			background-color: var( --dashboard-surface__background-color );
+		}
 
 		&:hover {
-			border-color: #1e1e1e;
+			border-color: var( --dashboard__text-color );
 		}
 
 		&--focus {
-			border-color: var(--wp-admin-theme-color, #3858e9);
-			box-shadow: 0 0 0 1px var(--wp-admin-theme-color, #3858e9);
+			border-color: var( --wp-admin-theme-color, #3858e9 );
+			box-shadow: 0 0 0 1px var( --wp-admin-theme-color, #3858e9 );
 			outline: 2px solid transparent;
 		}
 
 		&--invalid {
-			border-color: #cc1818;
+			border-color: var( --dashboard-danger__color, var( --dashboard__background-color-error ) );
 		}
 
 		&--focus.StripeElement--invalid {
-			border-color: #cc1818;
-			box-shadow: 0 0 0 1px #cc1818;
+			border-color: var( --dashboard-danger__color, var( --dashboard__background-color-error ) );
+			box-shadow: 0 0 0 1px
+				var( --dashboard-danger__color, var( --dashboard__background-color-error ) );
 		}
 	}
 }

--- a/client/dashboard/me/billing-purchases/payment-methods/credit-card-fields.scss
+++ b/client/dashboard/me/billing-purchases/payment-methods/credit-card-fields.scss
@@ -31,8 +31,12 @@
 		@include ui-mixins.when-dark-theme {
 			background-color: var( --dashboard-surface__background-color );
 
-			&:not( .StripeElement--invalid ) iframe {
-				filter: brightness( 2.8 );
+			&.StripeElement--empty:not( .StripeElement--invalid ) iframe {
+				filter: grayscale( 1 ) brightness( 1.04 );
+			}
+
+			&:not( .StripeElement--empty ):not( .StripeElement--invalid ) iframe {
+				filter: grayscale( 1 ) brightness( 4.2 );
 			}
 		}
 

--- a/client/dashboard/me/billing-purchases/payment-methods/credit-card-fields.scss
+++ b/client/dashboard/me/billing-purchases/payment-methods/credit-card-fields.scss
@@ -1,5 +1,3 @@
-@use '../../../../../packages/ui/src/utils/mixins' as ui-mixins;
-
 .credit-card-field__label {
 	display: block;
 	margin-bottom: 8px;
@@ -27,10 +25,6 @@
 		transition:
 			border-color 0.1s ease-in-out,
 			box-shadow 0.1s ease-in-out;
-
-		@include ui-mixins.when-dark-theme {
-			background-color: var( --dashboard-surface__background-color );
-		}
 
 		&:hover {
 			border-color: var( --dashboard__text-color );

--- a/client/dashboard/me/billing-purchases/payment-methods/credit-card-fields.scss
+++ b/client/dashboard/me/billing-purchases/payment-methods/credit-card-fields.scss
@@ -30,6 +30,10 @@
 
 		@include ui-mixins.when-dark-theme {
 			background-color: var( --dashboard-surface__background-color );
+
+			&:not( .StripeElement--invalid ) iframe {
+				filter: brightness( 2.8 );
+			}
 		}
 
 		&:hover {

--- a/client/dashboard/me/billing-purchases/payment-methods/credit-card-fields.tsx
+++ b/client/dashboard/me/billing-purchases/payment-methods/credit-card-fields.tsx
@@ -12,6 +12,7 @@ const stripeElementStyle: StripeElementStyle = {
 	base: {
 		fontSize: '16px',
 		color: '#32325d',
+		iconColor: '#aab7c4',
 		fontFamily:
 			'-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif',
 		'::placeholder': {

--- a/client/dashboard/me/billing-purchases/payment-methods/credit-card-fields.tsx
+++ b/client/dashboard/me/billing-purchases/payment-methods/credit-card-fields.tsx
@@ -2,7 +2,7 @@ import { CardNumberElement, CardExpiryElement, CardCvcElement } from '@stripe/re
 import { __experimentalInputControl as InputControl } from '@wordpress/components';
 import { DataForm } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { StripeElementStyle } from '@stripe/stripe-js';
 import type { Field, DataFormControlProps } from '@wordpress/dataviews';
 
@@ -25,6 +25,78 @@ const stripeElementStyle: StripeElementStyle = {
 	},
 };
 
+function isDarkTheme() {
+	if ( typeof window === 'undefined' ) {
+		return false;
+	}
+
+	const theme = document.documentElement.dataset.theme;
+
+	return (
+		theme === 'dark' ||
+		( theme === 'system' && window.matchMedia?.( '(prefers-color-scheme: dark)' ).matches )
+	);
+}
+
+function getDashboardColor( variable: string, fallback: string ) {
+	if ( typeof window === 'undefined' ) {
+		return fallback;
+	}
+
+	return (
+		getComputedStyle( document.documentElement ).getPropertyValue( variable ).trim() || fallback
+	);
+}
+
+function getStripeElementStyle(): StripeElementStyle {
+	if ( ! isDarkTheme() ) {
+		return stripeElementStyle;
+	}
+
+	const textColor = getDashboardColor( '--dashboard__text-color', '#e0e0e0' );
+	const mutedColor = getDashboardColor( '--dashboard__text-muted-color', '#bdbdbd' );
+
+	return {
+		...stripeElementStyle,
+		base: {
+			...stripeElementStyle.base,
+			color: textColor,
+			iconColor: mutedColor,
+			'::placeholder': {
+				color: mutedColor,
+			},
+		},
+	};
+}
+
+function useStripeElementStyle() {
+	const [ elementStyle, setElementStyle ] = useState< StripeElementStyle >( getStripeElementStyle );
+
+	useEffect( () => {
+		const updateElementStyle = () => {
+			setElementStyle( getStripeElementStyle() );
+		};
+		const mediaQuery = window.matchMedia?.( '(prefers-color-scheme: dark)' );
+		const observer =
+			typeof MutationObserver !== 'undefined'
+				? new MutationObserver( updateElementStyle )
+				: undefined;
+
+		observer?.observe( document.documentElement, {
+			attributes: true,
+			attributeFilter: [ 'data-theme' ],
+		} );
+		mediaQuery?.addEventListener( 'change', updateElementStyle );
+
+		return () => {
+			observer?.disconnect();
+			mediaQuery?.removeEventListener( 'change', updateElementStyle );
+		};
+	}, [] );
+
+	return elementStyle;
+}
+
 interface CreditCardFieldsData {
 	cardholderName: string;
 	cardNumber: string;
@@ -32,7 +104,11 @@ interface CreditCardFieldsData {
 	cardCvc: string;
 }
 
-function StripeCardNumberField( { field }: DataFormControlProps< CreditCardFieldsData > ) {
+interface StripeFieldProps extends DataFormControlProps< CreditCardFieldsData > {
+	elementStyle: StripeElementStyle;
+}
+
+function StripeCardNumberField( { field, elementStyle }: StripeFieldProps ) {
 	return (
 		<>
 			<label htmlFor="card-number" className="credit-card-field__label">
@@ -42,7 +118,7 @@ function StripeCardNumberField( { field }: DataFormControlProps< CreditCardField
 				<CardNumberElement
 					id="card-number"
 					options={ {
-						style: stripeElementStyle,
+						style: elementStyle,
 						showIcon: true,
 					} }
 				/>
@@ -51,7 +127,7 @@ function StripeCardNumberField( { field }: DataFormControlProps< CreditCardField
 	);
 }
 
-function StripeCardExpiryField( { field }: DataFormControlProps< CreditCardFieldsData > ) {
+function StripeCardExpiryField( { field, elementStyle }: StripeFieldProps ) {
 	return (
 		<>
 			<label htmlFor="card-expiry" className="credit-card-field__label">
@@ -61,7 +137,7 @@ function StripeCardExpiryField( { field }: DataFormControlProps< CreditCardField
 				<CardExpiryElement
 					id="card-expiry"
 					options={ {
-						style: stripeElementStyle,
+						style: elementStyle,
 					} }
 				/>
 			</div>
@@ -69,7 +145,7 @@ function StripeCardExpiryField( { field }: DataFormControlProps< CreditCardField
 	);
 }
 
-function StripeCardCvcField( { field }: DataFormControlProps< CreditCardFieldsData > ) {
+function StripeCardCvcField( { field, elementStyle }: StripeFieldProps ) {
 	return (
 		<>
 			<label htmlFor="card-cvc" className="credit-card-field__label">
@@ -79,7 +155,7 @@ function StripeCardCvcField( { field }: DataFormControlProps< CreditCardFieldsDa
 				<CardCvcElement
 					id="card-cvc"
 					options={ {
-						style: stripeElementStyle,
+						style: elementStyle,
 					} }
 				/>
 			</div>
@@ -100,6 +176,7 @@ export function CreditCardFields( {
 		cardExpiry: '',
 		cardCvc: '',
 	};
+	const elementStyle = useStripeElementStyle();
 
 	const fields: Field< CreditCardFieldsData >[] = useMemo(
 		() => [
@@ -124,20 +201,20 @@ export function CreditCardFields( {
 			{
 				id: 'cardNumber',
 				label: __( 'Card number' ),
-				Edit: StripeCardNumberField,
+				Edit: ( props ) => <StripeCardNumberField { ...props } elementStyle={ elementStyle } />,
 			},
 			{
 				id: 'cardExpiry',
 				label: __( 'Expiry date' ),
-				Edit: StripeCardExpiryField,
+				Edit: ( props ) => <StripeCardExpiryField { ...props } elementStyle={ elementStyle } />,
 			},
 			{
 				id: 'cardCvc',
 				label: __( 'CVV' ),
-				Edit: StripeCardCvcField,
+				Edit: ( props ) => <StripeCardCvcField { ...props } elementStyle={ elementStyle } />,
 			},
 		],
-		[]
+		[ elementStyle ]
 	);
 
 	const form = useMemo(

--- a/client/dashboard/me/billing-purchases/payment-methods/credit-card-fields.tsx
+++ b/client/dashboard/me/billing-purchases/payment-methods/credit-card-fields.tsx
@@ -2,7 +2,7 @@ import { CardNumberElement, CardExpiryElement, CardCvcElement } from '@stripe/re
 import { __experimentalInputControl as InputControl } from '@wordpress/components';
 import { DataForm } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import type { StripeElementStyle } from '@stripe/stripe-js';
 import type { Field, DataFormControlProps } from '@wordpress/dataviews';
 
@@ -25,78 +25,6 @@ const stripeElementStyle: StripeElementStyle = {
 	},
 };
 
-function isDarkTheme() {
-	if ( typeof window === 'undefined' ) {
-		return false;
-	}
-
-	const theme = document.documentElement.dataset.theme;
-
-	return (
-		theme === 'dark' ||
-		( theme === 'system' && window.matchMedia?.( '(prefers-color-scheme: dark)' ).matches )
-	);
-}
-
-function getDashboardColor( variable: string, fallback: string ) {
-	if ( typeof window === 'undefined' ) {
-		return fallback;
-	}
-
-	return (
-		getComputedStyle( document.documentElement ).getPropertyValue( variable ).trim() || fallback
-	);
-}
-
-function getStripeElementStyle(): StripeElementStyle {
-	if ( ! isDarkTheme() ) {
-		return stripeElementStyle;
-	}
-
-	const textColor = getDashboardColor( '--dashboard__text-color', '#e0e0e0' );
-	const mutedColor = getDashboardColor( '--dashboard__text-muted-color', '#bdbdbd' );
-
-	return {
-		...stripeElementStyle,
-		base: {
-			...stripeElementStyle.base,
-			color: textColor,
-			iconColor: mutedColor,
-			'::placeholder': {
-				color: mutedColor,
-			},
-		},
-	};
-}
-
-function useStripeElementStyle() {
-	const [ elementStyle, setElementStyle ] = useState< StripeElementStyle >( getStripeElementStyle );
-
-	useEffect( () => {
-		const updateElementStyle = () => {
-			setElementStyle( getStripeElementStyle() );
-		};
-		const mediaQuery = window.matchMedia?.( '(prefers-color-scheme: dark)' );
-		const observer =
-			typeof MutationObserver !== 'undefined'
-				? new MutationObserver( updateElementStyle )
-				: undefined;
-
-		observer?.observe( document.documentElement, {
-			attributes: true,
-			attributeFilter: [ 'data-theme' ],
-		} );
-		mediaQuery?.addEventListener( 'change', updateElementStyle );
-
-		return () => {
-			observer?.disconnect();
-			mediaQuery?.removeEventListener( 'change', updateElementStyle );
-		};
-	}, [] );
-
-	return elementStyle;
-}
-
 interface CreditCardFieldsData {
 	cardholderName: string;
 	cardNumber: string;
@@ -104,11 +32,7 @@ interface CreditCardFieldsData {
 	cardCvc: string;
 }
 
-interface StripeFieldProps extends DataFormControlProps< CreditCardFieldsData > {
-	elementStyle: StripeElementStyle;
-}
-
-function StripeCardNumberField( { field, elementStyle }: StripeFieldProps ) {
+function StripeCardNumberField( { field }: DataFormControlProps< CreditCardFieldsData > ) {
 	return (
 		<>
 			<label htmlFor="card-number" className="credit-card-field__label">
@@ -118,7 +42,7 @@ function StripeCardNumberField( { field, elementStyle }: StripeFieldProps ) {
 				<CardNumberElement
 					id="card-number"
 					options={ {
-						style: elementStyle,
+						style: stripeElementStyle,
 						showIcon: true,
 					} }
 				/>
@@ -127,7 +51,7 @@ function StripeCardNumberField( { field, elementStyle }: StripeFieldProps ) {
 	);
 }
 
-function StripeCardExpiryField( { field, elementStyle }: StripeFieldProps ) {
+function StripeCardExpiryField( { field }: DataFormControlProps< CreditCardFieldsData > ) {
 	return (
 		<>
 			<label htmlFor="card-expiry" className="credit-card-field__label">
@@ -137,7 +61,7 @@ function StripeCardExpiryField( { field, elementStyle }: StripeFieldProps ) {
 				<CardExpiryElement
 					id="card-expiry"
 					options={ {
-						style: elementStyle,
+						style: stripeElementStyle,
 					} }
 				/>
 			</div>
@@ -145,7 +69,7 @@ function StripeCardExpiryField( { field, elementStyle }: StripeFieldProps ) {
 	);
 }
 
-function StripeCardCvcField( { field, elementStyle }: StripeFieldProps ) {
+function StripeCardCvcField( { field }: DataFormControlProps< CreditCardFieldsData > ) {
 	return (
 		<>
 			<label htmlFor="card-cvc" className="credit-card-field__label">
@@ -155,7 +79,7 @@ function StripeCardCvcField( { field, elementStyle }: StripeFieldProps ) {
 				<CardCvcElement
 					id="card-cvc"
 					options={ {
-						style: elementStyle,
+						style: stripeElementStyle,
 					} }
 				/>
 			</div>
@@ -176,7 +100,6 @@ export function CreditCardFields( {
 		cardExpiry: '',
 		cardCvc: '',
 	};
-	const elementStyle = useStripeElementStyle();
 
 	const fields: Field< CreditCardFieldsData >[] = useMemo(
 		() => [
@@ -201,20 +124,20 @@ export function CreditCardFields( {
 			{
 				id: 'cardNumber',
 				label: __( 'Card number' ),
-				Edit: ( props ) => <StripeCardNumberField { ...props } elementStyle={ elementStyle } />,
+				Edit: StripeCardNumberField,
 			},
 			{
 				id: 'cardExpiry',
 				label: __( 'Expiry date' ),
-				Edit: ( props ) => <StripeCardExpiryField { ...props } elementStyle={ elementStyle } />,
+				Edit: StripeCardExpiryField,
 			},
 			{
 				id: 'cardCvc',
 				label: __( 'CVV' ),
-				Edit: ( props ) => <StripeCardCvcField { ...props } elementStyle={ elementStyle } />,
+				Edit: StripeCardCvcField,
 			},
 		],
-		[ elementStyle ]
+		[]
 	);
 
 	const form = useMemo(

--- a/client/dashboard/me/billing-purchases/style.scss
+++ b/client/dashboard/me/billing-purchases/style.scss
@@ -1,3 +1,5 @@
+@use '../../../../packages/ui/src/utils/mixins' as ui-mixins;
+
 img.payment-method-image {
 	vertical-align: middle;
 }
@@ -10,6 +12,41 @@ img.payment-method-image {
 .checkout-submit-button > button.is-primary {
 	width: 100%;
 	justify-content: center;
+}
+
+.payment-method-selector__content {
+	@include ui-mixins.when-dark-theme {
+		.checkout-steps__submit-button-wrapper {
+			background: var( --dashboard-surface__background-color );
+		}
+
+		.payment-method-selector__list .has-highlight {
+			&::before {
+				border-bottom-color: var( --dashboard-surface__border-color );
+			}
+
+			&.is-checked::before,
+			&:hover::before {
+				border-color: var( --dashboard-item-selected__border-color, var( --wp-admin-theme-color ) );
+			}
+
+			> input:not( :disabled ) + label::before {
+				background: var( --dashboard-surface__background-color );
+				border-color: var(
+					--dashboard-field__border-color,
+					var( --dashboard-surface__border-color )
+				);
+			}
+
+			> input:not( :disabled ) + label::after {
+				background: var( --dashboard-surface__background-color );
+			}
+
+			&.is-checked > input:not( :disabled ) + label::after {
+				background: var( --dashboard-item-selected__border-color, var( --wp-admin-theme-color ) );
+			}
+		}
+	}
 }
 
 .dataviews-view-table__cell-content-wrapper .purchase-payment-method__wrapper {

--- a/client/dashboard/sites/overview-site-preview-card/index.tsx
+++ b/client/dashboard/sites/overview-site-preview-card/index.tsx
@@ -36,7 +36,7 @@ const SitePreviewCard = ( { site }: { site: Site } ) => {
 						bottom: 0,
 						left: 0,
 						overflow: 'hidden',
-						backgroundColor: '#f0f0f0',
+						backgroundColor: 'var(--wp-components-color-gray-100, #f0f0f0)',
 					} }
 				>
 					<SitePreview url={ url } scale={ width / 1200 } height={ height / ( width / 1200 ) } />

--- a/client/dashboard/sites/settings-ai-tools/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/index.tsx
@@ -270,7 +270,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 						</VStack>
 					</CardBody>
 					{ ! isEnabled && (
-						<CardFooter style={ { background: '#FAFAFA' } }>
+						<CardFooter className="ai-tools-settings__features-footer">
 							<VStack as="ul" spacing={ 1 } style={ { padding: 0, margin: 0 } }>
 								{ features.map( ( feature, i ) => (
 									<HStack key={ i } as="li" justify="flex-start" spacing={ 3 }>

--- a/client/dashboard/sites/settings-ai-tools/style.scss
+++ b/client/dashboard/sites/settings-ai-tools/style.scss
@@ -1,3 +1,13 @@
+@use '../../../../packages/ui/src/utils/mixins' as ui-mixins;
+
+.ai-tools-settings__features-footer {
+	background: #fafafa;
+
+	@include ui-mixins.when-dark-theme {
+		background: var( --dashboard-surface__background-color );
+	}
+}
+
 // Override box-shadow-based hr divider which renders invisibly at zero height.
 .mcp-settings__sub-divider {
 	background: transparent;
@@ -5,6 +15,10 @@
 	border-top: 1px solid rgba( 0, 0, 0, 0.1 );
 	height: 0;
 	margin: 0;
+
+	@include ui-mixins.when-dark-theme {
+		border-top-color: var( --color-border-subtle );
+	}
 }
 
 // Clip children (summary button hover highlights) to the card's rounded corners,

--- a/client/dashboard/sites/settings-ai-tools/style.scss
+++ b/client/dashboard/sites/settings-ai-tools/style.scss
@@ -17,7 +17,7 @@
 	margin: 0;
 
 	@include ui-mixins.when-dark-theme {
-		border-top-color: var( --color-border-subtle );
+		border-top-color: var( --dashboard-surface__border-color );
 	}
 }
 

--- a/client/dashboard/sites/settings-ai-tools/style.scss
+++ b/client/dashboard/sites/settings-ai-tools/style.scss
@@ -17,7 +17,7 @@
 	margin: 0;
 
 	@include ui-mixins.when-dark-theme {
-		border-top-color: var( --dashboard-surface__border-color );
+		border-top-color: var( --color-border-subtle );
 	}
 }
 


### PR DESCRIPTION
Part of RSM-981, RSM-1341, RSM-1340, RSM-1326, RSM-982, RSM-1504

## Proposed Changes



* Replaces several hardcoded Dashboard colors with existing Dashboard and WordPress component color tokens so the affected UI adapts in dark mode while preserving light-mode colors.
* Adds scoped dark-mode overrides for billing payment method controls, Stripe card fields, notifications, AI tools card footers, DataViews sticky action columns, summary icon colors, and site preview placeholders.
* Keeps the Stripe card icon readable by configuring the Stripe Element icon color with the existing placeholder color value used by the same field style.
| | |
|---|---|
| <img width="2064" height="2100" alt="CleanShot 2026-04-28 at 15 00 35@2x" src="https://github.com/user-attachments/assets/1e845b10-6e2e-4f70-90b9-0ede399366c5" />| <img width="3030" height="1398" alt="CleanShot 2026-04-28 at 15 00 50@2x" src="https://github.com/user-attachments/assets/8688a4b6-66dc-4fc5-8a12-33d882b5f131" />|
| <img width="2114" height="2070" alt="CleanShot 2026-04-28 at 15 01 22@2x" src="https://github.com/user-attachments/assets/492ab073-d47d-4ead-81ef-d7e1b2a33334" />| <img width="1878" height="962" alt="CleanShot 2026-04-28 at 15 02 18@2x" src="https://github.com/user-attachments/assets/b2c54ff0-07c2-4d11-9b32-133fd3fd5871" /> |
|<img width="1962" height="1036" alt="CleanShot 2026-04-28 at 15 02 50@2x" src="https://github.com/user-attachments/assets/6cec4d0d-eb4b-4a46-a0fb-4153fca4521d" /> | |



## Why are these changes being made?

Minor dark-mode bugs were making several Dashboard surfaces look inconsistent or difficult to read. The affected areas used hardcoded light colors, inherited upstream component defaults, or missed dark-mode token mappings, which produced white payment fields, low-contrast icons, mismatched card/footer backgrounds, and overly bright or missing dividers.

This updates those surfaces to reuse existing color tokens where possible and scopes component-specific dark-mode changes through the Dashboard dark-theme mixin. Light-mode visual colors are preserved for the reviewed cases, while dark mode now uses the existing Dashboard surface, border, text, and selected-item tokens.

## Testing Instructions

Manual testing suggestions:

* Visit `http://my.localhost:3000/sites/<siteUrl>/settings/crontab` and confirm the metadata icons are visible in dark mode.
* Visit `http://my.localhost:3000/me/security/social-logins` and confirm social login rows/icons still render correctly in dark mode.
* Visit `http://my.localhost:3000/me/billing/purchases/<purchaseId>/payment-method/change` and confirm the payment method selector, Stripe fields, card icon, PayPal row, terms area, and Save card area are readable in dark mode.
* Visit `http://my.localhost:3000/sites/<siteUrl>/domains` and confirm the sticky Actions column border is visible but not too bright in dark mode.
* Visit `http://my.localhost:3000/sites/<siteUrl>/settings/ai-tools` and confirm the AI tools footer background and MCP dividers match both light and dark mode.


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in Memoizing with create-selector and related docs.
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
