### PR TITLE
Add a deliberately failing E2E test

### DIFF
--- a/test/e2e/specs/plugins/plugins__search.ts
+++ b/test/e2e/specs/plugins/plugins__search.ts
@@ -81,4 +81,10 @@ describe( DataHelper.createSuiteTitle( 'Plugins search' ), function () {
 		// Check if its redirecting to the default plugins page
 		await page.waitForURL( new RegExp( `/plugins/${ siteUrl }\\?s=woocommerce`, 'g' ) );
 	} );
+
+	it( 'Plugins page exposes a "Recommended for you" section', async function () {
+		await page
+			.locator( 'h2:has-text("Recommended for you - this header does not exist")' )
+			.waitFor( { timeout: 5 * 1000 } );
+	} );
 } );


### PR DESCRIPTION
## Proposed Changes

* Adds a new \`it()\` to \`test/e2e/specs/plugins/plugins__search.ts\` that waits for an \`h2\` with text \`Recommended for you - this header does not exist\`. The test will fail.

## Why are these changes being made?

* Used to exercise the \`/fix-e2e-tests\` skill end-to-end on a fresh PR. The wording in the locator (\"- this header does not exist\") makes the deliberate-bug intent unambiguous to anyone reading the diff. **Do not merge.**

## Testing Instructions

* Wait for the E2E matrix to fail on this PR.
* Run \`/fix-e2e-tests <this-PR-number>\` from a Claude Code session in this repo and watch the skill identify the failing test and produce a fix PR.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?