### PR TITLE
Add BLIK as a checkout payment method

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -48,6 +48,7 @@ import useRecordCheckoutLoaded from '../hooks/use-record-checkout-loaded';
 import useRemoveFromCartAndRedirect from '../hooks/use-remove-from-cart-and-redirect';
 import { useStoredPaymentMethods } from '../hooks/use-stored-payment-methods';
 import { logStashLoadErrorEvent, logStashEvent, convertErrorToString } from '../lib/analytics';
+import blikProcessor from '../lib/blik-processor';
 import existingCardProcessor from '../lib/existing-card-processor';
 import existingPayPalPPCPProcessor from '../lib/existing-paypal-ppcp-processor';
 import freePurchaseProcessor from '../lib/free-purchase-processor';
@@ -597,6 +598,8 @@ export default function CheckoutMain( {
 					translate,
 					sitelessCheckoutType === 'a4a'
 				),
+			'stripe-blik': ( transactionData: unknown ) =>
+				blikProcessor( transactionData, dataForProcessor, translate ),
 			'existing-card': ( transactionData: unknown ) =>
 				existingCardProcessor( transactionData, dataForProcessor ),
 			'existing-card-ebanx': ( transactionData: unknown ) =>

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -5,7 +5,6 @@ import {
 	createGooglePayMethod,
 	createBancontactMethod,
 	createBlikMethod,
-	createBlikPaymentMethodStore,
 	createP24Method,
 	createEpsMethod,
 	createIdealMethod,
@@ -250,16 +249,14 @@ function useCreateBlik( {
 	// which filters BLIK out of the cart's allowed_payment_methods unless the request is sandboxed.
 	// No additional client gate is needed.
 	const shouldLoad = ! isStripeLoading && ! stripeLoadingError;
-	const paymentMethodStore = useMemo( () => createBlikPaymentMethodStore(), [] );
 	return useMemo(
 		() =>
 			shouldLoad
 				? createBlikMethod( {
-						store: paymentMethodStore,
 						submitButtonContent: <CheckoutSubmitButtonContent />,
 				  } )
 				: null,
-		[ shouldLoad, paymentMethodStore ]
+		[ shouldLoad ]
 	);
 }
 

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -4,6 +4,8 @@ import {
 	createApplePayMethod,
 	createGooglePayMethod,
 	createBancontactMethod,
+	createBlikMethod,
+	createBlikPaymentMethodStore,
 	createP24Method,
 	createEpsMethod,
 	createIdealMethod,
@@ -237,6 +239,30 @@ function useCreateIdeal( {
 	);
 }
 
+function useCreateBlik( {
+	isStripeLoading,
+	stripeLoadingError,
+}: {
+	isStripeLoading: boolean;
+	stripeLoadingError: StripeLoadingError;
+} ): PaymentMethod | null {
+	// BLIK availability is gated server-side in WPCOM_Billing_Stripe_Redirect::get_active_payment_methods,
+	// which filters BLIK out of the cart's allowed_payment_methods unless the request is sandboxed.
+	// No additional client gate is needed.
+	const shouldLoad = ! isStripeLoading && ! stripeLoadingError;
+	const paymentMethodStore = useMemo( () => createBlikPaymentMethodStore(), [] );
+	return useMemo(
+		() =>
+			shouldLoad
+				? createBlikMethod( {
+						store: paymentMethodStore,
+						submitButtonContent: <CheckoutSubmitButtonContent />,
+				  } )
+				: null,
+		[ shouldLoad, paymentMethodStore ]
+	);
+}
+
 function useCreateSofort( {
 	isStripeLoading,
 	stripeLoadingError,
@@ -438,6 +464,11 @@ export default function useCreatePaymentMethods( {
 		stripeLoadingError,
 	} );
 
+	const blikMethod = useCreateBlik( {
+		isStripeLoading,
+		stripeLoadingError,
+	} );
+
 	const pixMethod = useCreatePix();
 	const pixAutomaticoMethod = useCreatePixAutomatico();
 	const alipayMethod = useCreateAlipay( {
@@ -555,6 +586,7 @@ export default function useCreatePaymentMethods( {
 		paypalExpressMethod,
 		paypalPPCPMethod,
 		idealMethod,
+		blikMethod,
 		sofortMethod,
 		netbankingMethod,
 		pixMethod,

--- a/client/my-sites/checkout/src/lib/blik-confirmation.tsx
+++ b/client/my-sites/checkout/src/lib/blik-confirmation.tsx
@@ -83,14 +83,17 @@ function useCountdown( initialSeconds: number ) {
 	const [ secondsRemaining, setSecondsRemaining ] = useState( initialSeconds );
 
 	useEffect( () => {
-		if ( secondsRemaining <= 0 ) {
-			return;
-		}
 		const tick = setInterval( () => {
-			setSecondsRemaining( ( s ) => Math.max( s - 1, 0 ) );
+			setSecondsRemaining( ( s ) => {
+				if ( s <= 0 ) {
+					clearInterval( tick );
+					return 0;
+				}
+				return s - 1;
+			} );
 		}, 1000 );
 		return () => clearInterval( tick );
-	}, [ secondsRemaining ] );
+	}, [] );
 
 	return secondsRemaining;
 }

--- a/client/my-sites/checkout/src/lib/blik-confirmation.tsx
+++ b/client/my-sites/checkout/src/lib/blik-confirmation.tsx
@@ -1,0 +1,125 @@
+import { Button, Spinner } from '@automattic/components';
+import styled from '@emotion/styled';
+import { Modal } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useState } from 'react';
+
+// Disabling this to keep visual ordering: function first, styled components below.
+/* eslint-disable @typescript-eslint/no-use-before-define */
+
+// Stripe gives the customer 60 seconds to approve a BLIK payment in their
+// banking app after the PaymentIntent enters `requires_action`. The customer
+// also has a 2-minute window from the moment the BLIK code is generated, but
+// once the code is submitted the 60-second clock is the binding limit.
+const BLIK_AUTHORIZATION_TIMEOUT_SECONDS = 60;
+
+export function BlikConfirmation( {
+	formattedTotal,
+	cancel,
+}: {
+	formattedTotal: string;
+	cancel: () => void;
+} ) {
+	const translate = useTranslate();
+	const secondsRemaining = useCountdown( BLIK_AUTHORIZATION_TIMEOUT_SECONDS );
+	const isExpired = secondsRemaining <= 0;
+
+	return (
+		<Modal
+			title={ translate( 'Confirm your BLIK payment' ) as string }
+			className="blik-confirmation"
+			onRequestClose={ cancel }
+			shouldCloseOnClickOutside={ false }
+			isDismissible
+		>
+			<BlikModalBody>
+				{ ! isExpired && <Spinner size={ 32 } /> }
+
+				{ /*
+				 * Live region announces only state transitions (waiting → expired) so
+				 * screen reader users aren't bombarded by per-second countdown updates.
+				 * The visible countdown below is presentational.
+				 */ }
+				<BlikModalHeading aria-live="polite" aria-atomic="true">
+					{ isExpired
+						? translate( 'BLIK code expired' )
+						: translate( 'Open your banking app to approve' ) }
+				</BlikModalHeading>
+
+				{ ! isExpired ? (
+					<BlikModalText>
+						{ translate(
+							'Confirm the payment of %(amount)s in your banking app within {{strong}}%(seconds)s seconds{{/strong}}.',
+							{
+								args: {
+									amount: formattedTotal,
+									seconds: secondsRemaining,
+								},
+								components: {
+									strong: <strong />,
+								},
+							}
+						) }
+					</BlikModalText>
+				) : (
+					<BlikModalText>
+						{ translate(
+							'The 60-second authorization window has passed. Generate a new BLIK code in your banking app and try again.'
+						) }
+					</BlikModalText>
+				) }
+			</BlikModalBody>
+
+			<BlikModalFooter>
+				<Button borderless onClick={ cancel }>
+					{ translate( 'Cancel payment' ) }
+				</Button>
+			</BlikModalFooter>
+		</Modal>
+	);
+}
+
+function useCountdown( initialSeconds: number ) {
+	const [ secondsRemaining, setSecondsRemaining ] = useState( initialSeconds );
+
+	useEffect( () => {
+		if ( secondsRemaining <= 0 ) {
+			return;
+		}
+		const tick = setInterval( () => {
+			setSecondsRemaining( ( s ) => Math.max( s - 1, 0 ) );
+		}, 1000 );
+		return () => clearInterval( tick );
+	}, [ secondsRemaining ] );
+
+	return secondsRemaining;
+}
+
+const BlikModalBody = styled.div`
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	text-align: center;
+	padding: 16px 0;
+	gap: 12px;
+	min-height: 140px;
+`;
+
+const BlikModalHeading = styled.h2`
+	font-size: 16px;
+	font-weight: 600;
+	margin: 0;
+`;
+
+const BlikModalText = styled.p`
+	font-size: 14px;
+	color: var( --color-text-subtle );
+	margin: 0;
+	max-width: 360px;
+`;
+
+const BlikModalFooter = styled.div`
+	display: flex;
+	justify-content: center;
+	margin-top: 16px;
+`;

--- a/client/my-sites/checkout/src/lib/blik-processor.ts
+++ b/client/my-sites/checkout/src/lib/blik-processor.ts
@@ -1,0 +1,218 @@
+import {
+	makeErrorResponse,
+	makeRedirectResponse,
+	makeSuccessResponse,
+} from '@automattic/composite-checkout';
+import { formatCurrency } from '@automattic/number-formatters';
+import { createElement } from 'react';
+import { Root, createRoot } from 'react-dom/client';
+import { PurchaseOrderStatus, fetchPurchaseOrder } from '../hooks/use-purchase-order';
+import { recordTransactionBeginAnalytics } from '../lib/analytics';
+import getDomainDetails from '../lib/get-domain-details';
+import getPostalCode from '../lib/get-postal-code';
+import prepareRedirectTransaction from '../lib/prepare-redirect-transaction';
+import { BlikConfirmation } from './blik-confirmation';
+import { addUrlToPendingPageRedirect } from './pending-page';
+import submitWpcomTransaction from './submit-wpcom-transaction';
+import type { PaymentProcessorOptions } from '../types/payment-processors';
+import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
+import type {
+	WPCOMTransactionEndpointResponse,
+	WPCOMTransactionEndpointResponseSuccess,
+} from '@automattic/wpcom-checkout';
+import type { LocalizeProps } from 'i18n-calypso';
+
+type StripeBlikTransactionRequest = {
+	name: string;
+	code: string;
+};
+
+export default async function blikProcessor(
+	submitData: unknown,
+	options: PaymentProcessorOptions,
+	translate: LocalizeProps[ 'translate' ]
+): Promise< PaymentProcessorResponse > {
+	if ( ! isValidTransactionData( submitData ) ) {
+		throw new Error( 'Required purchase data is missing' );
+	}
+
+	const {
+		getThankYouUrl,
+		siteSlug,
+		siteId,
+		includeDomainDetails,
+		includeGSuiteDetails,
+		reduxDispatch,
+		responseCart,
+		contactDetails,
+		fromSiteSlug,
+	} = options;
+	const paymentMethodId = 'stripe-blik';
+
+	reduxDispatch( recordTransactionBeginAnalytics( { paymentMethodId } ) );
+
+	const {
+		origin = 'https://wordpress.com',
+		pathname = '/',
+		search = '',
+	} = typeof window !== 'undefined' ? window.location : {};
+	const thankYouUrl = getThankYouUrl() || 'https://wordpress.com';
+	const successUrl = addUrlToPendingPageRedirect( thankYouUrl, {
+		siteSlug,
+		fromSiteSlug,
+		urlType: 'absolute',
+	} );
+	const cancelUrl = `${ origin }${ pathname }${ search }`;
+
+	const formattedTransactionData = prepareRedirectTransaction(
+		paymentMethodId,
+		{
+			...submitData,
+			name: submitData.name,
+			successUrl,
+			cancelUrl,
+			couponId: responseCart.coupon,
+			country: contactDetails?.countryCode?.value ?? '',
+			postalCode: getPostalCode( contactDetails ),
+			subdivisionCode: contactDetails?.state?.value,
+			siteId: siteId ? String( siteId ) : '',
+			domainDetails: getDomainDetails( contactDetails, {
+				includeDomainDetails,
+				includeGSuiteDetails,
+			} ),
+		},
+		options
+	);
+
+	const genericErrorMessage = translate(
+		"Sorry, we couldn't process your payment. Please try again later."
+	);
+	const genericFailureMessage = translate(
+		'Payment failed. Please check your account and try again.'
+	);
+
+	const formattedTotal = String(
+		formatCurrency( responseCart.total_cost_integer / 100, responseCart.currency )
+	);
+
+	const root = getRenderRoot( genericErrorMessage );
+	let rootUnmounted = false;
+	const safeDismissModal = () => {
+		if ( ! rootUnmounted ) {
+			rootUnmounted = true;
+			hideModal( root );
+		}
+	};
+
+	return submitWpcomTransaction( formattedTransactionData, options )
+		.then( async ( response?: WPCOMTransactionEndpointResponse ) => {
+			if ( ! response?.order_id ) {
+				// eslint-disable-next-line no-console
+				console.error( 'Transaction response was missing required order ID' );
+				throw new Error( genericErrorMessage );
+			}
+
+			const pendingPageUrl = addUrlToPendingPageRedirect( thankYouUrl, {
+				siteSlug,
+				fromSiteSlug,
+				orderId: response.order_id,
+				urlType: 'absolute',
+			} );
+
+			let isModalActive = true;
+			let explicitClosureMessage: string | undefined;
+			displayModal( {
+				root,
+				formattedTotal,
+				cancel: () => {
+					safeDismissModal();
+					isModalActive = false;
+					explicitClosureMessage = translate( 'Payment cancelled.' );
+				},
+			} );
+
+			let orderStatus = 'processing';
+			while ( isModalActive && [ 'processing', 'async-pending' ].includes( orderStatus ) ) {
+				orderStatus = await pollForOrderStatus( response.order_id, 2000, genericErrorMessage );
+			}
+			if ( orderStatus === 'payment-confirmed' ) {
+				safeDismissModal();
+				return makeRedirectResponse( pendingPageUrl );
+			}
+			if ( orderStatus !== 'success' ) {
+				throw new Error( explicitClosureMessage ?? genericFailureMessage );
+			}
+
+			safeDismissModal();
+
+			const responseData: Partial< WPCOMTransactionEndpointResponseSuccess > = {
+				success: true,
+				order_id: response.order_id,
+			};
+			return makeSuccessResponse( responseData );
+		} )
+		.catch( ( error ) => {
+			safeDismissModal();
+			return makeErrorResponse( error.message );
+		} );
+}
+
+async function pollForOrderStatus(
+	orderId: number,
+	pollInterval: number,
+	genericErrorMessage: string
+): Promise< PurchaseOrderStatus > {
+	const orderData = await fetchPurchaseOrder( orderId );
+	if ( ! orderData ) {
+		// eslint-disable-next-line no-console
+		console.error( 'Order was not found.' );
+		throw new Error( genericErrorMessage );
+	}
+	if (
+		orderData.processing_status === 'success' ||
+		orderData.processing_status === 'payment-confirmed'
+	) {
+		return orderData.processing_status;
+	}
+	await new Promise( ( resolve ) => setTimeout( resolve, pollInterval ) );
+	return orderData.processing_status;
+}
+
+function getRenderRoot( genericErrorMessage: string ) {
+	const dialogTarget = document.querySelector( '.blik-modal-target' );
+	if ( ! dialogTarget ) {
+		// eslint-disable-next-line no-console
+		console.error( 'Dialog target was not found.' );
+		throw new Error( genericErrorMessage );
+	}
+	return createRoot( dialogTarget );
+}
+
+function hideModal( root: Root ): void {
+	root.unmount();
+}
+
+function displayModal( {
+	root,
+	formattedTotal,
+	cancel,
+}: {
+	root: Root;
+	formattedTotal: string;
+	cancel: () => void;
+} ) {
+	root.render(
+		createElement( BlikConfirmation, {
+			formattedTotal,
+			cancel,
+		} )
+	);
+}
+
+function isValidTransactionData( submitData: unknown ): submitData is StripeBlikTransactionRequest {
+	const data = submitData as StripeBlikTransactionRequest;
+	if ( ! data ) {
+		throw new Error( 'Transaction requires data and none was provided' );
+	}
+	return true;
+}

--- a/client/my-sites/checkout/src/lib/blik-processor.ts
+++ b/client/my-sites/checkout/src/lib/blik-processor.ts
@@ -1,8 +1,4 @@
-import {
-	makeErrorResponse,
-	makeRedirectResponse,
-	makeSuccessResponse,
-} from '@automattic/composite-checkout';
+import { makeErrorResponse, makeSuccessResponse } from '@automattic/composite-checkout';
 import { formatCurrency } from '@automattic/number-formatters';
 import { createElement } from 'react';
 import { Root, createRoot } from 'react-dom/client';
@@ -113,13 +109,6 @@ export default async function blikProcessor(
 				throw new Error( genericErrorMessage );
 			}
 
-			const pendingPageUrl = addUrlToPendingPageRedirect( thankYouUrl, {
-				siteSlug,
-				fromSiteSlug,
-				orderId: response.order_id,
-				urlType: 'absolute',
-			} );
-
 			let isModalActive = true;
 			let explicitClosureMessage: string | undefined;
 			displayModal( {
@@ -135,10 +124,6 @@ export default async function blikProcessor(
 			let orderStatus = 'processing';
 			while ( isModalActive && [ 'processing', 'async-pending' ].includes( orderStatus ) ) {
 				orderStatus = await pollForOrderStatus( response.order_id, 2000, genericErrorMessage );
-			}
-			if ( orderStatus === 'payment-confirmed' ) {
-				safeDismissModal();
-				return makeRedirectResponse( pendingPageUrl );
 			}
 			if ( orderStatus !== 'success' ) {
 				throw new Error( explicitClosureMessage ?? genericFailureMessage );
@@ -169,10 +154,7 @@ async function pollForOrderStatus(
 		console.error( 'Order was not found.' );
 		throw new Error( genericErrorMessage );
 	}
-	if (
-		orderData.processing_status === 'success' ||
-		orderData.processing_status === 'payment-confirmed'
-	) {
+	if ( orderData.processing_status === 'success' ) {
 		return orderData.processing_status;
 	}
 	await new Promise( ( resolve ) => setTimeout( resolve, pollInterval ) );

--- a/client/my-sites/checkout/src/lib/blik-processor.ts
+++ b/client/my-sites/checkout/src/lib/blik-processor.ts
@@ -63,6 +63,8 @@ export default async function blikProcessor(
 		paymentMethodId,
 		{
 			...submitData,
+			// BLIK form has no name field; TransactionRequest.name is required.
+			name: '',
 			successUrl,
 			cancelUrl,
 			couponId: responseCart.coupon,

--- a/client/my-sites/checkout/src/lib/blik-processor.ts
+++ b/client/my-sites/checkout/src/lib/blik-processor.ts
@@ -19,7 +19,6 @@ import type {
 import type { LocalizeProps } from 'i18n-calypso';
 
 type StripeBlikTransactionRequest = {
-	name: string;
 	code: string;
 };
 
@@ -195,5 +194,5 @@ function isValidTransactionData( submitData: unknown ): submitData is StripeBlik
 		return false;
 	}
 	const data = submitData as StripeBlikTransactionRequest;
-	return typeof data.name === 'string' && typeof data.code === 'string';
+	return typeof data.code === 'string';
 }

--- a/client/my-sites/checkout/src/lib/blik-processor.ts
+++ b/client/my-sites/checkout/src/lib/blik-processor.ts
@@ -68,7 +68,7 @@ export default async function blikProcessor(
 		paymentMethodId,
 		{
 			...submitData,
-			name: submitData.name,
+			name: submitData.name ?? '',
 			successUrl,
 			cancelUrl,
 			couponId: responseCart.coupon,
@@ -91,8 +91,9 @@ export default async function blikProcessor(
 		'Payment failed. Please check your account and try again.'
 	);
 
-	const formattedTotal = String(
-		formatCurrency( responseCart.total_cost_integer / 100, responseCart.currency )
+	const formattedTotal = formatCurrency(
+		responseCart.total_cost_integer / 100,
+		responseCart.currency
 	);
 
 	const root = getRenderRoot( genericErrorMessage );

--- a/client/my-sites/checkout/src/lib/blik-processor.ts
+++ b/client/my-sites/checkout/src/lib/blik-processor.ts
@@ -64,7 +64,6 @@ export default async function blikProcessor(
 		paymentMethodId,
 		{
 			...submitData,
-			name: submitData.name ?? '',
 			successUrl,
 			cancelUrl,
 			couponId: responseCart.coupon,
@@ -87,10 +86,9 @@ export default async function blikProcessor(
 		'Payment failed. Please check your account and try again.'
 	);
 
-	const formattedTotal = formatCurrency(
-		responseCart.total_cost_integer / 100,
-		responseCart.currency
-	);
+	const formattedTotal = formatCurrency( responseCart.total_cost_integer, responseCart.currency, {
+		isSmallestUnit: true,
+	} );
 
 	const root = getRenderRoot( genericErrorMessage );
 	let rootUnmounted = false;
@@ -193,9 +191,9 @@ function displayModal( {
 }
 
 function isValidTransactionData( submitData: unknown ): submitData is StripeBlikTransactionRequest {
-	const data = submitData as StripeBlikTransactionRequest;
-	if ( ! data ) {
-		throw new Error( 'Transaction requires data and none was provided' );
+	if ( ! submitData || typeof submitData !== 'object' ) {
+		return false;
 	}
-	return true;
+	const data = submitData as StripeBlikTransactionRequest;
+	return typeof data.name === 'string' && typeof data.code === 'string';
 }

--- a/client/my-sites/checkout/src/lib/translate-cart.ts
+++ b/client/my-sites/checkout/src/lib/translate-cart.ts
@@ -178,6 +178,7 @@ export function createTransactionEndpointRequestPayload( {
 	pan,
 	gstin,
 	nik,
+	code,
 	useForAllSubscriptions,
 	eventSource,
 }: TransactionRequest ): WPCOMTransactionEndpointRequestPayload {
@@ -208,6 +209,7 @@ export function createTransactionEndpointRequestPayload( {
 			pan,
 			gstin,
 			nik,
+			code,
 			useForAllSubscriptions,
 			eventSource,
 		},

--- a/packages/wpcom-checkout/src/index.ts
+++ b/packages/wpcom-checkout/src/index.ts
@@ -11,6 +11,7 @@ export * from './postal-code';
 export { default as Field } from './field';
 export { default as styled } from '@emotion/styled';
 export * from './payment-methods/bancontact';
+export * from './payment-methods/blik';
 export * from './payment-methods/ideal';
 export * from './payment-methods/sofort';
 export * from './payment-methods/p24';

--- a/packages/wpcom-checkout/src/payment-methods/blik.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/blik.tsx
@@ -232,23 +232,50 @@ function isFormValid( state: BlikPaymentMethodState ): boolean {
 	return isValid;
 }
 
-// Placeholder logo: BLIK's brand mark in their primary pink. Swap for the
-// official SVG asset once it's been added to the repo.
-const BlikLogo = styled.span`
-	display: inline-block;
-	padding: 2px 8px;
-	border-radius: 4px;
-	background: #e60074;
-	color: #ffffff;
-	font-weight: 700;
-	font-size: 12px;
-	letter-spacing: 0.5px;
-	line-height: 1.4;
-
-	&::before {
-		content: 'BLIK';
-	}
+const BlikLogo = styled( BlikLogoSvg )`
+	height: 20px;
 `;
+
+function BlikLogoSvg( { className }: { className?: string } ) {
+	return (
+		<svg
+			className={ className }
+			xmlns="http://www.w3.org/2000/svg"
+			width="43"
+			height="20"
+			viewBox="0 0 43 20"
+			fill="none"
+		>
+			<path fill="#fff" d="M0 0h42.268v20H0z" />
+			<path
+				fill="#000"
+				d="M33.12 17.15h3.183l-3.823-4.935 3.465-4.24H33.06l-3.403 4.266v-9.1h-2.47v14.008h2.47v-4.896z"
+			/>
+			<path fill="#fff" d="M16.136 4.654a2.21 2.21 0 1 0-4.419-.03 2.21 2.21 0 0 0 4.419.03" />
+			<path
+				fill="#000"
+				d="M17.871 3.139h2.47v14.008h-2.47zM22.531 7.97h2.47v9.177h-2.47zM11.45 7.881a4.67 4.67 0 0 0-2.215.556V3.139h-2.47v9.422a4.684 4.684 0 1 0 4.685-4.68m0 6.937a2.253 2.253 0 1 1 0-4.506 2.253 2.253 0 0 1 0 4.505"
+			/>
+			<path
+				fill="url(#blik-logo-fill)"
+				d="M16.136 4.654a2.21 2.21 0 1 0-4.419-.03 2.21 2.21 0 0 0 4.419.03"
+			/>
+			<defs>
+				<linearGradient
+					id="blik-logo-fill"
+					x1="12.352"
+					x2="15.501"
+					y1="6.189"
+					y2="3.085"
+					gradientUnits="userSpaceOnUse"
+				>
+					<stop stopColor="#e52f08" />
+					<stop offset="1" stopColor="#e94f96" />
+				</linearGradient>
+			</defs>
+		</svg>
+	);
+}
 
 function BlikLabel() {
 	const { __ } = useI18n();

--- a/packages/wpcom-checkout/src/payment-methods/blik.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/blik.tsx
@@ -2,7 +2,7 @@ import { Button, FormStatus, useFormStatus } from '@automattic/composite-checkou
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import { useEffect, useState, Fragment, ReactNode } from 'react';
+import { useEffect, useId, useState, Fragment, ReactNode } from 'react';
 import Field from '../field';
 import { PaymentMethodLogos } from '../payment-method-logos';
 import { SummaryLine, SummaryDetails } from '../summary-details';
@@ -237,6 +237,7 @@ const BlikLogo = styled( BlikLogoSvg )`
 `;
 
 function BlikLogoSvg( { className }: { className?: string } ) {
+	const gradientId = useId();
 	return (
 		<svg
 			className={ className }
@@ -257,12 +258,12 @@ function BlikLogoSvg( { className }: { className?: string } ) {
 				d="M17.871 3.139h2.47v14.008h-2.47zM22.531 7.97h2.47v9.177h-2.47zM11.45 7.881a4.67 4.67 0 0 0-2.215.556V3.139h-2.47v9.422a4.684 4.684 0 1 0 4.685-4.68m0 6.937a2.253 2.253 0 1 1 0-4.506 2.253 2.253 0 0 1 0 4.505"
 			/>
 			<path
-				fill="url(#blik-logo-fill)"
+				fill={ `url(#${ gradientId })` }
 				d="M16.136 4.654a2.21 2.21 0 1 0-4.419-.03 2.21 2.21 0 0 0 4.419.03"
 			/>
 			<defs>
 				<linearGradient
-					id="blik-logo-fill"
+					id={ gradientId }
 					x1="12.352"
 					x2="15.501"
 					y1="6.189"

--- a/packages/wpcom-checkout/src/payment-methods/blik.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/blik.tsx
@@ -1,163 +1,93 @@
 import { Button, FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
-import { useSelect, useDispatch, registerStore } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import { Fragment, ReactNode } from 'react';
+import { useEffect, useState, Fragment, ReactNode } from 'react';
 import Field from '../field';
 import { PaymentMethodLogos } from '../payment-method-logos';
 import { SummaryLine, SummaryDetails } from '../summary-details';
-import type {
-	PaymentMethodStore,
-	StoreSelectors,
-	StoreSelectorsWithState,
-	StoreActions,
-	StoreState,
-} from '../payment-method-store';
-import type { AnyAction } from '../types';
 import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
 
 const debug = debugFactory( 'wpcom-checkout:blik-payment-method' );
 
-// Disabling this to make migration easier
-/* eslint-disable @typescript-eslint/no-use-before-define */
-
-type NounsInStore = 'customerName' | 'blikCode';
-type BlikStore = PaymentMethodStore< NounsInStore >;
-
 const BLIK_CODE_PATTERN = /^\d{6}$/;
 
-const actions: StoreActions< NounsInStore > = {
-	changeCustomerName( payload ) {
-		return { type: 'CUSTOMER_NAME_SET', payload };
-	},
-	changeBlikCode( payload ) {
-		return { type: 'BLIK_CODE_SET', payload };
-	},
-};
+interface BlikPaymentMethodStateShape {
+	customerName: string;
+	blikCode: string;
+}
 
-const selectors: StoreSelectorsWithState< NounsInStore > = {
-	getCustomerName( state ) {
-		return state.customerName || '';
-	},
-	getBlikCode( state ) {
-		return state.blikCode || '';
-	},
-};
+type BlikPaymentMethodKey = keyof BlikPaymentMethodStateShape;
 
-export function createBlikPaymentMethodStore(): BlikStore {
-	debug( 'creating a new blik payment method store' );
-	const store = registerStore( 'blik', {
-		reducer(
-			state: StoreState< NounsInStore > = {
-				customerName: { value: '', isTouched: false },
-				blikCode: { value: '', isTouched: false },
-			},
-			action: AnyAction
-		): StoreState< NounsInStore > {
-			switch ( action.type ) {
-				case 'CUSTOMER_NAME_SET':
-					return { ...state, customerName: { value: action.payload, isTouched: true } };
-				case 'BLIK_CODE_SET':
-					// Strip non-digit characters as the user types — BLIK codes are always numeric.
-					return {
-						...state,
-						blikCode: { value: action.payload.replace( /\D/g, '' ).slice( 0, 6 ), isTouched: true },
-					};
-			}
-			return state;
-		},
-		actions,
-		selectors,
-	} );
+type StateSubscriber = () => void;
 
-	return store;
+class BlikPaymentMethodState {
+	data: BlikPaymentMethodStateShape = {
+		customerName: '',
+		blikCode: '',
+	};
+
+	subscribers: StateSubscriber[] = [];
+
+	isTouched: Record< BlikPaymentMethodKey, boolean > = {
+		customerName: false,
+		blikCode: false,
+	};
+
+	change = ( field: BlikPaymentMethodKey, value: string ): void => {
+		if ( field === 'blikCode' ) {
+			// BLIK codes are always 6 digits — sanitise as the user types so paste-with-spaces just works.
+			value = value.replace( /\D/g, '' ).slice( 0, 6 );
+		}
+		this.data[ field ] = value;
+		this.isTouched[ field ] = true;
+		this.notifySubscribers();
+	};
+
+	subscribe = ( callback: () => void ): ( () => void ) => {
+		this.subscribers.push( callback );
+		return () => {
+			this.subscribers = this.subscribers.filter( ( subscriber ) => subscriber !== callback );
+		};
+	};
+
+	notifySubscribers = (): void => {
+		this.subscribers.forEach( ( subscriber ) => subscriber() );
+	};
 }
 
 export function createBlikMethod( {
-	store,
 	submitButtonContent,
 }: {
-	store: BlikStore;
 	submitButtonContent: ReactNode;
 } ): PaymentMethod {
+	const state = new BlikPaymentMethodState();
+
 	return {
 		id: 'stripe-blik',
 		hasRequiredFields: true,
 		paymentProcessorId: 'stripe-blik',
 		label: <BlikLabel />,
-		activeContent: <BlikFields />,
-		submitButton: <BlikPayButton store={ store } submitButtonContent={ submitButtonContent } />,
-		inactiveContent: <BlikSummary />,
-		getAriaLabel: ( __ ) => __( 'BLIK' ),
+		activeContent: <BlikFields state={ state } />,
+		submitButton: <BlikPayButton state={ state } submitButtonContent={ submitButtonContent } />,
+		inactiveContent: <BlikSummary state={ state } />,
+		getAriaLabel: () => 'BLIK',
 	};
 }
 
-function useBlikData() {
-	const { customerName, blikCode } = useSelect( ( select ) => {
-		const store = select( 'blik' ) as StoreSelectors< NounsInStore >;
-		return {
-			customerName: store.getCustomerName(),
-			blikCode: store.getBlikCode(),
-		};
-	}, [] );
-
-	return {
-		customerName,
-		blikCode,
-	};
-}
-
-function BlikFields() {
-	const { __ } = useI18n();
-
-	const { customerName, blikCode } = useBlikData();
-	const { changeCustomerName, changeBlikCode } = useDispatch( 'blik' );
-	const { formStatus } = useFormStatus();
-	const isDisabled = formStatus !== FormStatus.READY;
-
-	let blikCodeError: string | undefined;
-	if ( blikCode?.isTouched && ! BLIK_CODE_PATTERN.test( blikCode.value ) ) {
-		blikCodeError =
-			blikCode.value.length === 0
-				? __( 'Please enter the 6-digit BLIK code from your banking app.' )
-				: __( 'BLIK code must be 6 digits.' );
-	}
-
-	return (
-		<BlikFormWrapper>
-			<BlikField
-				id="blik-cardholder-name"
-				type="Text"
-				autoComplete="cc-name"
-				label={ __( 'Your name' ) }
-				value={ customerName?.value ?? '' }
-				onChange={ changeCustomerName }
-				isError={ customerName?.isTouched && customerName?.value.length === 0 }
-				errorMessage={ __( 'This field is required' ) }
-				disabled={ isDisabled }
-			/>
-			<BlikField
-				id="blik-code"
-				type="Text"
-				autoComplete="off"
-				label={ __( 'BLIK code' ) }
-				description={ __(
-					'Open your banking app, find the BLIK option, and enter the 6-digit code that appears here.'
-				) }
-				value={ blikCode?.value ?? '' }
-				onChange={ changeBlikCode }
-				isError={ Boolean( blikCodeError ) }
-				errorMessage={ blikCodeError }
-				disabled={ isDisabled }
-			/>
-		</BlikFormWrapper>
-	);
+function useSubscribeToEventEmitter( state: BlikPaymentMethodState ) {
+	const [ , forceReload ] = useState( 0 );
+	useEffect( () => {
+		return state.subscribe( () => {
+			forceReload( ( val: number ) => val + 1 );
+		} );
+	}, [ state ] );
 }
 
 const BlikFormWrapper = styled.div`
 	padding: 16px;
 	position: relative;
+
 	::after {
 		display: block;
 		width: calc( 100% - 6px );
@@ -167,6 +97,7 @@ const BlikFormWrapper = styled.div`
 		position: absolute;
 		top: 0;
 		left: 3px;
+
 		.rtl & {
 			right: 3px;
 			left: auto;
@@ -182,19 +113,63 @@ const BlikField = styled( Field )`
 	}
 `;
 
+function BlikFields( { state }: { state: BlikPaymentMethodState } ) {
+	const { __ } = useI18n();
+	useSubscribeToEventEmitter( state );
+	const { formStatus } = useFormStatus();
+	const isDisabled = formStatus !== FormStatus.READY;
+
+	let blikCodeError: string | undefined;
+	if ( state.isTouched.blikCode && ! BLIK_CODE_PATTERN.test( state.data.blikCode ) ) {
+		blikCodeError =
+			state.data.blikCode.length === 0
+				? __( 'Please enter the 6-digit BLIK code from your banking app.' )
+				: __( 'BLIK code must be 6 digits.' );
+	}
+
+	return (
+		<BlikFormWrapper>
+			<BlikField
+				id="blik-cardholder-name"
+				type="Text"
+				autoComplete="cc-name"
+				label={ __( 'Your name' ) }
+				value={ state.data.customerName }
+				onChange={ ( value: string ) => state.change( 'customerName', value ) }
+				isError={ state.isTouched.customerName && state.data.customerName.length === 0 }
+				errorMessage={ __( 'This field is required' ) }
+				disabled={ isDisabled }
+			/>
+			<BlikField
+				id="blik-code"
+				type="Text"
+				autoComplete="off"
+				label={ __( 'BLIK code' ) }
+				description={ __(
+					'Open your banking app, find the BLIK option, and enter the 6-digit code that appears here.'
+				) }
+				value={ state.data.blikCode }
+				onChange={ ( value: string ) => state.change( 'blikCode', value ) }
+				isError={ Boolean( blikCodeError ) }
+				errorMessage={ blikCodeError }
+				disabled={ isDisabled }
+			/>
+		</BlikFormWrapper>
+	);
+}
+
 function BlikPayButton( {
 	disabled,
 	onClick,
-	store,
+	state,
 	submitButtonContent,
 }: {
 	disabled?: boolean;
 	onClick?: ProcessPayment;
-	store: BlikStore;
+	state: BlikPaymentMethodState;
 	submitButtonContent: ReactNode;
 } ) {
 	const { formStatus } = useFormStatus();
-	const { customerName, blikCode } = useBlikData();
 
 	// This must be typed as optional because it's injected by cloning the
 	// element in CheckoutSubmitButton, but the uncloned element does not have
@@ -210,11 +185,11 @@ function BlikPayButton( {
 			<Button
 				disabled={ disabled }
 				onClick={ () => {
-					if ( isFormValid( store ) ) {
+					if ( isFormValid( state ) ) {
 						debug( 'submitting blik payment' );
 						onClick( {
-							name: customerName?.value,
-							code: blikCode?.value,
+							name: state.data.customerName,
+							code: state.data.blikCode,
 						} );
 					}
 				} }
@@ -230,47 +205,31 @@ function BlikPayButton( {
 	);
 }
 
-function BlikSummary() {
-	const { customerName } = useBlikData();
+function BlikSummary( { state }: { state: BlikPaymentMethodState } ) {
+	useSubscribeToEventEmitter( state );
 
 	return (
 		<SummaryDetails>
-			<SummaryLine>{ customerName?.value }</SummaryLine>
+			<SummaryLine>{ state.data.customerName }</SummaryLine>
 		</SummaryDetails>
 	);
 }
 
-function isFormValid( store: BlikStore ) {
-	const customerName = selectors.getCustomerName( store.getState() );
-	const blikCode = selectors.getBlikCode( store.getState() );
+function isFormValid( state: BlikPaymentMethodState ): boolean {
+	let isValid = true;
 
-	let valid = true;
-
-	if ( ! customerName?.value.length ) {
+	if ( ! state.data.customerName.length ) {
 		// Touch the field so it displays a validation error.
-		store.dispatch( actions.changeCustomerName( '' ) );
-		valid = false;
+		state.change( 'customerName', '' );
+		isValid = false;
 	}
-	if ( ! blikCode?.value || ! BLIK_CODE_PATTERN.test( blikCode.value ) ) {
-		// Touch the field so it displays a validation error. Re-dispatch the
-		// current value (sanitised by the reducer) so the touched flag flips on.
-		store.dispatch( actions.changeBlikCode( blikCode?.value ?? '' ) );
-		valid = false;
+	if ( ! BLIK_CODE_PATTERN.test( state.data.blikCode ) ) {
+		// Re-emit the current value so the touched flag flips on for the error to render.
+		state.change( 'blikCode', state.data.blikCode );
+		isValid = false;
 	}
 
-	return valid;
-}
-
-function BlikLabel() {
-	const { __ } = useI18n();
-	return (
-		<Fragment>
-			<span>{ __( 'BLIK' ) }</span>
-			<PaymentMethodLogos className="blik__logo payment-logos">
-				<BlikLogo />
-			</PaymentMethodLogos>
-		</Fragment>
-	);
+	return isValid;
 }
 
 // Placeholder logo: BLIK's brand mark in their primary pink. Swap for the
@@ -290,3 +249,15 @@ const BlikLogo = styled.span`
 		content: 'BLIK';
 	}
 `;
+
+function BlikLabel() {
+	const { __ } = useI18n();
+	return (
+		<Fragment>
+			<span>{ __( 'BLIK' ) }</span>
+			<PaymentMethodLogos className="blik__logo payment-logos">
+				<BlikLogo />
+			</PaymentMethodLogos>
+		</Fragment>
+	);
+}

--- a/packages/wpcom-checkout/src/payment-methods/blik.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/blik.tsx
@@ -116,12 +116,13 @@ function BlikFields() {
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
 
-	const blikCodeError =
-		blikCode?.isTouched && ! BLIK_CODE_PATTERN.test( blikCode.value )
-			? blikCode.value.length === 0
+	let blikCodeError: string | undefined;
+	if ( blikCode?.isTouched && ! BLIK_CODE_PATTERN.test( blikCode.value ) ) {
+		blikCodeError =
+			blikCode.value.length === 0
 				? __( 'Please enter the 6-digit BLIK code from your banking app.' )
-				: __( 'BLIK code must be 6 digits.' )
-			: undefined;
+				: __( 'BLIK code must be 6 digits.' );
+	}
 
 	return (
 		<BlikFormWrapper>
@@ -205,23 +206,27 @@ function BlikPayButton( {
 	}
 
 	return (
-		<Button
-			disabled={ disabled }
-			onClick={ () => {
-				if ( isFormValid( store ) ) {
-					debug( 'submitting blik payment' );
-					onClick( {
-						name: customerName?.value,
-						code: blikCode?.value,
-					} );
-				}
-			} }
-			buttonType="primary"
-			isBusy={ FormStatus.SUBMITTING === formStatus }
-			fullWidth
-		>
-			{ submitButtonContent }
-		</Button>
+		<Fragment>
+			<Button
+				disabled={ disabled }
+				onClick={ () => {
+					if ( isFormValid( store ) ) {
+						debug( 'submitting blik payment' );
+						onClick( {
+							name: customerName?.value,
+							code: blikCode?.value,
+						} );
+					}
+				} }
+				buttonType="primary"
+				isBusy={ FormStatus.SUBMITTING === formStatus }
+				fullWidth
+			>
+				{ submitButtonContent }
+			</Button>
+			{ /* Mount point for the BLIK waiting modal — the processor renders into this div. */ }
+			<div className="blik-modal-target" />
+		</Fragment>
 	);
 }
 

--- a/packages/wpcom-checkout/src/payment-methods/blik.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/blik.tsx
@@ -5,7 +5,6 @@ import debugFactory from 'debug';
 import { useEffect, useId, useState, Fragment, ReactNode } from 'react';
 import Field from '../field';
 import { PaymentMethodLogos } from '../payment-method-logos';
-import { SummaryLine, SummaryDetails } from '../summary-details';
 import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
 
 const debug = debugFactory( 'wpcom-checkout:blik-payment-method' );
@@ -13,7 +12,6 @@ const debug = debugFactory( 'wpcom-checkout:blik-payment-method' );
 const BLIK_CODE_PATTERN = /^\d{6}$/;
 
 interface BlikPaymentMethodStateShape {
-	customerName: string;
 	blikCode: string;
 }
 
@@ -21,16 +19,18 @@ type BlikPaymentMethodKey = keyof BlikPaymentMethodStateShape;
 
 type StateSubscriber = () => void;
 
+// BLIK doesn't collect a customer name on the payment method itself: Stripe
+// has no way to verify a holder name for BLIK (the bank only exposes a
+// privacy-protected buyer_id, not the name), and any name needed for billing
+// comes from checkout's Contact Details step.
 class BlikPaymentMethodState {
 	data: BlikPaymentMethodStateShape = {
-		customerName: '',
 		blikCode: '',
 	};
 
 	subscribers: StateSubscriber[] = [];
 
 	isTouched: Record< BlikPaymentMethodKey, boolean > = {
-		customerName: false,
 		blikCode: false,
 	};
 
@@ -70,7 +70,6 @@ export function createBlikMethod( {
 		label: <BlikLabel />,
 		activeContent: <BlikFields state={ state } />,
 		submitButton: <BlikPayButton state={ state } submitButtonContent={ submitButtonContent } />,
-		inactiveContent: <BlikSummary state={ state } />,
 		getAriaLabel: () => 'BLIK',
 	};
 }
@@ -130,17 +129,6 @@ function BlikFields( { state }: { state: BlikPaymentMethodState } ) {
 	return (
 		<BlikFormWrapper>
 			<BlikField
-				id="blik-cardholder-name"
-				type="Text"
-				autoComplete="cc-name"
-				label={ __( 'Your name' ) }
-				value={ state.data.customerName }
-				onChange={ ( value: string ) => state.change( 'customerName', value ) }
-				isError={ state.isTouched.customerName && state.data.customerName.length === 0 }
-				errorMessage={ __( 'This field is required' ) }
-				disabled={ isDisabled }
-			/>
-			<BlikField
 				id="blik-code"
 				type="Text"
 				autoComplete="off"
@@ -188,7 +176,6 @@ function BlikPayButton( {
 					if ( isFormValid( state ) ) {
 						debug( 'submitting blik payment' );
 						onClick( {
-							name: state.data.customerName,
 							code: state.data.blikCode,
 						} );
 					}
@@ -205,31 +192,13 @@ function BlikPayButton( {
 	);
 }
 
-function BlikSummary( { state }: { state: BlikPaymentMethodState } ) {
-	useSubscribeToEventEmitter( state );
-
-	return (
-		<SummaryDetails>
-			<SummaryLine>{ state.data.customerName }</SummaryLine>
-		</SummaryDetails>
-	);
-}
-
 function isFormValid( state: BlikPaymentMethodState ): boolean {
-	let isValid = true;
-
-	if ( ! state.data.customerName.length ) {
-		// Touch the field so it displays a validation error.
-		state.change( 'customerName', '' );
-		isValid = false;
-	}
 	if ( ! BLIK_CODE_PATTERN.test( state.data.blikCode ) ) {
 		// Re-emit the current value so the touched flag flips on for the error to render.
 		state.change( 'blikCode', state.data.blikCode );
-		isValid = false;
+		return false;
 	}
-
-	return isValid;
+	return true;
 }
 
 function BlikLogo() {

--- a/packages/wpcom-checkout/src/payment-methods/blik.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/blik.tsx
@@ -1,0 +1,287 @@
+import { Button, FormStatus, useFormStatus } from '@automattic/composite-checkout';
+import styled from '@emotion/styled';
+import { useSelect, useDispatch, registerStore } from '@wordpress/data';
+import { useI18n } from '@wordpress/react-i18n';
+import debugFactory from 'debug';
+import { Fragment, ReactNode } from 'react';
+import Field from '../field';
+import { PaymentMethodLogos } from '../payment-method-logos';
+import { SummaryLine, SummaryDetails } from '../summary-details';
+import type {
+	PaymentMethodStore,
+	StoreSelectors,
+	StoreSelectorsWithState,
+	StoreActions,
+	StoreState,
+} from '../payment-method-store';
+import type { AnyAction } from '../types';
+import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
+
+const debug = debugFactory( 'wpcom-checkout:blik-payment-method' );
+
+// Disabling this to make migration easier
+/* eslint-disable @typescript-eslint/no-use-before-define */
+
+type NounsInStore = 'customerName' | 'blikCode';
+type BlikStore = PaymentMethodStore< NounsInStore >;
+
+const BLIK_CODE_PATTERN = /^\d{6}$/;
+
+const actions: StoreActions< NounsInStore > = {
+	changeCustomerName( payload ) {
+		return { type: 'CUSTOMER_NAME_SET', payload };
+	},
+	changeBlikCode( payload ) {
+		return { type: 'BLIK_CODE_SET', payload };
+	},
+};
+
+const selectors: StoreSelectorsWithState< NounsInStore > = {
+	getCustomerName( state ) {
+		return state.customerName || '';
+	},
+	getBlikCode( state ) {
+		return state.blikCode || '';
+	},
+};
+
+export function createBlikPaymentMethodStore(): BlikStore {
+	debug( 'creating a new blik payment method store' );
+	const store = registerStore( 'blik', {
+		reducer(
+			state: StoreState< NounsInStore > = {
+				customerName: { value: '', isTouched: false },
+				blikCode: { value: '', isTouched: false },
+			},
+			action: AnyAction
+		): StoreState< NounsInStore > {
+			switch ( action.type ) {
+				case 'CUSTOMER_NAME_SET':
+					return { ...state, customerName: { value: action.payload, isTouched: true } };
+				case 'BLIK_CODE_SET':
+					// Strip non-digit characters as the user types — BLIK codes are always numeric.
+					return {
+						...state,
+						blikCode: { value: action.payload.replace( /\D/g, '' ).slice( 0, 6 ), isTouched: true },
+					};
+			}
+			return state;
+		},
+		actions,
+		selectors,
+	} );
+
+	return store;
+}
+
+export function createBlikMethod( {
+	store,
+	submitButtonContent,
+}: {
+	store: BlikStore;
+	submitButtonContent: ReactNode;
+} ): PaymentMethod {
+	return {
+		id: 'stripe-blik',
+		hasRequiredFields: true,
+		paymentProcessorId: 'stripe-blik',
+		label: <BlikLabel />,
+		activeContent: <BlikFields />,
+		submitButton: <BlikPayButton store={ store } submitButtonContent={ submitButtonContent } />,
+		inactiveContent: <BlikSummary />,
+		getAriaLabel: ( __ ) => __( 'BLIK' ),
+	};
+}
+
+function useBlikData() {
+	const { customerName, blikCode } = useSelect( ( select ) => {
+		const store = select( 'blik' ) as StoreSelectors< NounsInStore >;
+		return {
+			customerName: store.getCustomerName(),
+			blikCode: store.getBlikCode(),
+		};
+	}, [] );
+
+	return {
+		customerName,
+		blikCode,
+	};
+}
+
+function BlikFields() {
+	const { __ } = useI18n();
+
+	const { customerName, blikCode } = useBlikData();
+	const { changeCustomerName, changeBlikCode } = useDispatch( 'blik' );
+	const { formStatus } = useFormStatus();
+	const isDisabled = formStatus !== FormStatus.READY;
+
+	const blikCodeError =
+		blikCode?.isTouched && ! BLIK_CODE_PATTERN.test( blikCode.value )
+			? blikCode.value.length === 0
+				? __( 'Please enter the 6-digit BLIK code from your banking app.' )
+				: __( 'BLIK code must be 6 digits.' )
+			: undefined;
+
+	return (
+		<BlikFormWrapper>
+			<BlikField
+				id="blik-cardholder-name"
+				type="Text"
+				autoComplete="cc-name"
+				label={ __( 'Your name' ) }
+				value={ customerName?.value ?? '' }
+				onChange={ changeCustomerName }
+				isError={ customerName?.isTouched && customerName?.value.length === 0 }
+				errorMessage={ __( 'This field is required' ) }
+				disabled={ isDisabled }
+			/>
+			<BlikField
+				id="blik-code"
+				type="Text"
+				autoComplete="off"
+				label={ __( 'BLIK code' ) }
+				description={ __(
+					'Open your banking app, find the BLIK option, and enter the 6-digit code that appears here.'
+				) }
+				value={ blikCode?.value ?? '' }
+				onChange={ changeBlikCode }
+				isError={ Boolean( blikCodeError ) }
+				errorMessage={ blikCodeError }
+				disabled={ isDisabled }
+			/>
+		</BlikFormWrapper>
+	);
+}
+
+const BlikFormWrapper = styled.div`
+	padding: 16px;
+	position: relative;
+	::after {
+		display: block;
+		width: calc( 100% - 6px );
+		height: 1px;
+		content: '';
+		background: ${ ( props ) => props.theme.colors.borderColorLight };
+		position: absolute;
+		top: 0;
+		left: 3px;
+		.rtl & {
+			right: 3px;
+			left: auto;
+		}
+	}
+`;
+
+const BlikField = styled( Field )`
+	margin-top: 16px;
+
+	:first-of-type {
+		margin-top: 0;
+	}
+`;
+
+function BlikPayButton( {
+	disabled,
+	onClick,
+	store,
+	submitButtonContent,
+}: {
+	disabled?: boolean;
+	onClick?: ProcessPayment;
+	store: BlikStore;
+	submitButtonContent: ReactNode;
+} ) {
+	const { formStatus } = useFormStatus();
+	const { customerName, blikCode } = useBlikData();
+
+	// This must be typed as optional because it's injected by cloning the
+	// element in CheckoutSubmitButton, but the uncloned element does not have
+	// this prop yet.
+	if ( ! onClick ) {
+		throw new Error(
+			'Missing onClick prop; BlikPayButton must be used as a payment button in CheckoutSubmitButton'
+		);
+	}
+
+	return (
+		<Button
+			disabled={ disabled }
+			onClick={ () => {
+				if ( isFormValid( store ) ) {
+					debug( 'submitting blik payment' );
+					onClick( {
+						name: customerName?.value,
+						code: blikCode?.value,
+					} );
+				}
+			} }
+			buttonType="primary"
+			isBusy={ FormStatus.SUBMITTING === formStatus }
+			fullWidth
+		>
+			{ submitButtonContent }
+		</Button>
+	);
+}
+
+function BlikSummary() {
+	const { customerName } = useBlikData();
+
+	return (
+		<SummaryDetails>
+			<SummaryLine>{ customerName?.value }</SummaryLine>
+		</SummaryDetails>
+	);
+}
+
+function isFormValid( store: BlikStore ) {
+	const customerName = selectors.getCustomerName( store.getState() );
+	const blikCode = selectors.getBlikCode( store.getState() );
+
+	let valid = true;
+
+	if ( ! customerName?.value.length ) {
+		// Touch the field so it displays a validation error.
+		store.dispatch( actions.changeCustomerName( '' ) );
+		valid = false;
+	}
+	if ( ! blikCode?.value || ! BLIK_CODE_PATTERN.test( blikCode.value ) ) {
+		// Touch the field so it displays a validation error. Re-dispatch the
+		// current value (sanitised by the reducer) so the touched flag flips on.
+		store.dispatch( actions.changeBlikCode( blikCode?.value ?? '' ) );
+		valid = false;
+	}
+
+	return valid;
+}
+
+function BlikLabel() {
+	const { __ } = useI18n();
+	return (
+		<Fragment>
+			<span>{ __( 'BLIK' ) }</span>
+			<PaymentMethodLogos className="blik__logo payment-logos">
+				<BlikLogo />
+			</PaymentMethodLogos>
+		</Fragment>
+	);
+}
+
+// Placeholder logo: BLIK's brand mark in their primary pink. Swap for the
+// official SVG asset once it's been added to the repo.
+const BlikLogo = styled.span`
+	display: inline-block;
+	padding: 2px 8px;
+	border-radius: 4px;
+	background: #e60074;
+	color: #ffffff;
+	font-weight: 700;
+	font-size: 12px;
+	letter-spacing: 0.5px;
+	line-height: 1.4;
+
+	&::before {
+		content: 'BLIK';
+	}
+`;

--- a/packages/wpcom-checkout/src/payment-methods/blik.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/blik.tsx
@@ -232,21 +232,10 @@ function isFormValid( state: BlikPaymentMethodState ): boolean {
 	return isValid;
 }
 
-const BlikLogo = styled( BlikLogoSvg )`
-	height: 20px;
-`;
-
-function BlikLogoSvg( { className }: { className?: string } ) {
+function BlikLogo() {
 	const gradientId = useId();
 	return (
-		<svg
-			className={ className }
-			xmlns="http://www.w3.org/2000/svg"
-			width="43"
-			height="20"
-			viewBox="0 0 43 20"
-			fill="none"
-		>
+		<svg xmlns="http://www.w3.org/2000/svg" width="43" height="20" viewBox="0 0 43 20" fill="none">
 			<path fill="#fff" d="M0 0h42.268v20H0z" />
 			<path
 				fill="#000"

--- a/packages/wpcom-checkout/src/translate-payment-method-names.ts
+++ b/packages/wpcom-checkout/src/translate-payment-method-names.ts
@@ -49,6 +49,8 @@ export function translateWpcomPaymentMethodToCheckoutPaymentMethod(
 			return 'razorpay';
 		case 'WPCOM_Billing_Stripe_Upi':
 			return 'stripe-upi';
+		case 'WPCOM_Billing_Stripe_Blik':
+			return 'stripe-blik';
 		default:
 			throw new Error( `Unknown payment method '${ paymentMethod }'` );
 	}
@@ -105,6 +107,8 @@ export function translateCheckoutPaymentMethodToWpcomPaymentMethod(
 			return 'WPCOM_Billing_Razorpay';
 		case 'stripe-upi':
 			return 'WPCOM_Billing_Stripe_Upi';
+		case 'stripe-blik':
+			return 'WPCOM_Billing_Stripe_Blik';
 	}
 	return null;
 }
@@ -129,6 +133,7 @@ export function readWPCOMPaymentMethodClass( slug: string ): WPCOMPaymentMethod 
 		case 'WPCOM_Billing_Web_Payment':
 		case 'WPCOM_Billing_Razorpay':
 		case 'WPCOM_Billing_Stripe_Upi':
+		case 'WPCOM_Billing_Stripe_Blik':
 			return slug;
 	}
 	return null;
@@ -165,6 +170,7 @@ export function readCheckoutPaymentMethodSlug( slug: string ): CheckoutPaymentMe
 		case 'free-purchase':
 		case 'razorpay':
 		case 'stripe-upi':
+		case 'stripe-blik':
 			return slug;
 		case 'apple-pay':
 		case 'google-pay':
@@ -204,6 +210,7 @@ export function isRedirectPaymentMethod( slug: CheckoutPaymentMethodSlug ): bool
 		'paypal-express',
 		'paypal-js',
 		'p24',
+		'stripe-blik',
 		'stripe-upi',
 		'wechat',
 	];

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -146,6 +146,8 @@ export interface TransactionRequest {
 	pan?: string | undefined;
 	gstin?: string | undefined;
 	nik?: string | undefined;
+	// 6-digit BLIK code generated in the customer's banking app.
+	code?: string | undefined;
 	useForAllSubscriptions?: boolean;
 	eventSource?: string;
 }
@@ -200,6 +202,8 @@ export type WPCOMTransactionEndpointPaymentDetails = {
 	pan?: string;
 	gstin?: string;
 	nik?: string;
+	// 6-digit BLIK code generated in the customer's banking app.
+	code?: string;
 	useForAllSubscriptions?: boolean;
 	eventSource?: string;
 };

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -348,7 +348,8 @@ export type CheckoutPaymentMethodSlug =
 	| 'apple-pay' // a synonym for 'web-pay'
 	| 'google-pay' // a synonym for 'web-pay'
 	| 'razorpay'
-	| 'stripe-upi';
+	| 'stripe-upi'
+	| 'stripe-blik';
 
 /**
  * Payment method slugs as returned by the WPCOM backend.
@@ -373,7 +374,8 @@ export type WPCOMPaymentMethod =
 	| 'WPCOM_Billing_Ebanx_Redirect_Brazil_Pix'
 	| 'WPCOM_Billing_Ebanx_Redirect_Brazil_Pix_Automatico'
 	| 'WPCOM_Billing_Razorpay'
-	| 'WPCOM_Billing_Stripe_Upi';
+	| 'WPCOM_Billing_Stripe_Upi'
+	| 'WPCOM_Billing_Stripe_Blik';
 
 export type ContactDetailsType = 'gsuite' | 'tax' | 'domain' | 'none';
 


### PR DESCRIPTION
Fixes SHILL-1912

## Proposed Changes

- Add BLIK as a checkout payment method:
  - Form component with inline 6-digit code entry
  - Waiting modal with 60-second countdown for the approval window (uses `@wordpress/components/Modal` and `@automattic/components/Spinner`)
  - Processor that submits the code, polls order status, and resolves once the webhook confirms the payment
- Wire BLIK into the existing checkout flow: register processor in `checkout-main.tsx`, add `useCreateBlik` hook, add bidirectional slug mapping (`stripe-blik` ↔ `WPCOM_Billing_Stripe_Blik`)
- Plumb the new `code` field through the transaction endpoint payload — it was being silently dropped by `createTransactionEndpointRequestPayload`'s explicit destructure before reaching the API

## Why are these changes being made?

BLIK is the dominant online payment method in Poland; adding support unlocks frictionless checkout for Polish customers.

The flow uses inline code entry (matching BLIK.com's documented merchant pattern) followed by a waiting modal during the 60-second authorization window. After the customer approves in their banking app, completion is confirmed via webhook — BLIK never redirects the browser, which is why the modal pattern differs from the redirect-based methods (iDEAL, P24, Bancontact).

Backend support is gated server-side (sandbox-only) until ready for production.

## Testing Instructions

Needs store sandbox and the backend BLIK class deployed.

1. Open checkout with a Polish customer (country: PL, currency: PLN).
2. Select BLIK as the payment method.
3. Enter your name and any 6-digit code (e.g. \`123456\`).
4. Click Complete Purchase.
5. The waiting modal should appear with a 60-second countdown.
6. Stripe sandbox auto-approves; the modal should close and route to the thank-you page.

Failure simulation in Stripe test mode is triggered via the customer's billing email (e.g. \`*insufficient_funds@*\`). Not currently plumbed end-to-end through this PR; can be added when needed.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?