### PR TITLE
E2E: fix Plugins "Recommended for you" assertion

### DIFF
--- a/test/e2e/specs/plugins/plugins__search.ts
+++ b/test/e2e/specs/plugins/plugins__search.ts
@@ -83,8 +83,6 @@ describe( DataHelper.createSuiteTitle( 'Plugins search' ), function () {
 	} );
 
 	it( 'Plugins page exposes a "Recommended for you" section', async function () {
-		await page
-			.locator( 'h2:has-text("Recommended for you - this header does not exist")' )
-			.waitFor( { timeout: 5 * 1000 } );
+		await page.locator( 'h2:has-text("Recommended for you")' ).waitFor( { timeout: 5 * 1000 } );
 	} );
 } );


### PR DESCRIPTION
## Proposed Changes

- Restore the `h2:has-text(...)` selector in `test/e2e/specs/plugins/plugins__search.ts` to target the real `Recommended for you` heading by dropping the bogus `- this header does not exist` suffix.
- No other test logic, fixtures, helpers, or product code are changed.

## Why are these changes being made?

The `Plugins page exposes a "Recommended for you" section` test was waiting on the locator `h2:has-text("Recommended for you - this header does not exist")`. The literal `- this header does not exist` suffix was a deliberate sabotage introduced in commit `de2d448bc67`. No such heading is rendered by the Plugins page, so the locator never matched a real DOM node and the `waitFor` always timed out after 5 s on both Desktop and Mobile.

Failure evidence:

- Desktop build: https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Playwright_desktop/17511414
- Mobile build: https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Playwright_mobile/17511419

## Testing Instructions

Run `yarn playwright test test/e2e/specs/plugins/plugins__search.ts --reporter=list --repeat-each=10` locally; all runs should pass.