### PR TITLE
Pass email variant through cancel API for refund email A/B test

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -994,6 +994,9 @@ function CancelPurchaseInner() {
 					options: {
 						product_id: purchase.product_id,
 						cancel_bundled_domain: state.cancelBundledDomain ?? false,
+						email_variant: config.isEnabled( 'purchases/split-cancel-remove' )
+							? 'treatment'
+							: undefined,
 					},
 				},
 				{

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -996,7 +996,7 @@ function CancelPurchaseInner() {
 						cancel_bundled_domain: state.cancelBundledDomain ?? false,
 						email_variant: config.isEnabled( 'purchases/split-cancel-remove' )
 							? 'treatment'
-							: undefined,
+							: 'control',
 					},
 				},
 				{

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -331,6 +331,9 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			await cancelAndRefundPurchaseAsync( purchase.id, {
 				product_id: purchase.productId,
 				cancel_bundled_domain: cancelBundledDomain ? 1 : 0,
+				email_variant: config.isEnabled( 'purchases/split-cancel-remove' )
+					? 'treatment'
+					: undefined,
 			} );
 			return {
 				success: true,

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -333,7 +333,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 				cancel_bundled_domain: cancelBundledDomain ? 1 : 0,
 				email_variant: config.isEnabled( 'purchases/split-cancel-remove' )
 					? 'treatment'
-					: undefined,
+					: 'control',
 			} );
 			return {
 				success: true,

--- a/packages/api-core/src/upgrades/types.ts
+++ b/packages/api-core/src/upgrades/types.ts
@@ -448,6 +448,12 @@ export interface PurchaseCancelOptions {
 	 * will also be cancelled.
 	 */
 	cancel_bundled_domain: boolean;
+
+	/**
+	 * The experiment variation name for the refund email A/B test.
+	 * When 'treatment', the backend sends the wpcom-2022 themed email.
+	 */
+	email_variant?: string;
 }
 
 /**

--- a/packages/api-core/src/upgrades/types.ts
+++ b/packages/api-core/src/upgrades/types.ts
@@ -453,7 +453,7 @@ export interface PurchaseCancelOptions {
 	 * The experiment variation name for the refund email A/B test.
 	 * When 'treatment', the backend sends the wpcom-2022 themed email.
 	 */
-	email_variant?: string;
+	email_variant?: 'treatment' | 'control';
 }
 
 /**


### PR DESCRIPTION
Fixes: https://linear.app/a8c/issue/RSM-774
Related to: 213651-ghe-Automattic/wpcom

## Proposed Changes

This PR adds a check on the front-end after a refund is requested. If it's part of our treatment group (or our temporary feature flag), then it gets the new email we developed here: 213651-ghe-Automattic/wpcom


## Why are these changes being made?

The refund confirmation email is being updated from the legacy bluestripe theme to the modern wpcom-2022 theme. The backend needs to know which email to send based on whether the user is in the new cancel/remove flow. This PR passes that signal through the existing cancel API payload so the backend can route accordingly.

## Testing Instructions

1. Enable the `purchases/split-cancel-remove` feature flag
2. Cancel a refundable purchase and inspect the network request — the payload should include `email_variant: 'treatment'`.
3. Disable the flag and repeat — `email_variant` should include `email_variant: 'control'`.
4. Non-refundable cancellations and marketplace subscription cancellations should not include `email_variant` in either case

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?