### PR TITLE
AsyncLoad: enforce require callback to be static top-level functions

### DIFF
--- a/apps/odyssey-stats/src/components/layout.tsx
+++ b/apps/odyssey-stats/src/components/layout.tsx
@@ -1,6 +1,11 @@
 import clsx from 'clsx';
 import AsyncLoad from 'calypso/components/async-load';
 
+const loadGlobalNotices = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-components-global-notices" */ 'calypso/components/global-notices'
+	);
+
 interface LayoutProps {
 	sectionGroup: string;
 	sectionName: string;
@@ -17,15 +22,7 @@ export default function Layout( { sectionGroup, sectionName, primary, secondary 
 	return (
 		<div className={ sectionClass }>
 			<div id="content" className="layout__content">
-				<AsyncLoad
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-components-global-notices" */ 'calypso/components/global-notices'
-						)
-					}
-					placeholder={ null }
-					id="notices"
-				/>
+				<AsyncLoad require={ loadGlobalNotices } placeholder={ null } id="notices" />
 				<div id="secondary" className="layout__secondary" role="navigation">
 					{ secondary }
 				</div>

--- a/client/blocks/app-promo/qr-code.tsx
+++ b/client/blocks/app-promo/qr-code.tsx
@@ -4,6 +4,8 @@ import AsyncLoad from 'calypso/components/async-load';
 
 import './style.scss';
 
+const loadQrCode = () => import( /* webpackChunkName: "async-load-qrcode-react" */ 'qrcode.react' );
+
 interface QrCodeProps {
 	campaign?: string;
 	size?: number;
@@ -16,9 +18,7 @@ export const QrCode = ( { campaign = 'calypso-app-promo', size = 150 }: QrCodePr
 		<div className="app-promo__qr-code">
 			<div className="app-promo__qr-code-canvas">
 				<AsyncLoad
-					require={ () =>
-						import( /* webpackChunkName: "async-load-qrcode-react" */ 'qrcode.react' )
-					}
+					require={ loadQrCode }
 					placeholder={
 						<div
 							className="app-promo__qr-code-placeholder"

--- a/client/blocks/author-selector/switcher-shell.jsx
+++ b/client/blocks/author-selector/switcher-shell.jsx
@@ -16,6 +16,9 @@ import 'calypso/components/popover-menu/style.scss';
  */
 const debug = debugModule( 'calypso:author-selector' );
 
+const loadSearch = () =>
+	import( /* webpackChunkName: "async-load-automattic-search" */ '@automattic/search' );
+
 class AuthorSwitcherShell extends Component {
 	static propTypes = {
 		users: PropTypes.array,
@@ -64,11 +67,7 @@ class AuthorSwitcherShell extends Component {
 				>
 					{ ( this.props.search || users.length > 10 ) && (
 						<AsyncLoad
-							require={ () =>
-								import(
-									/* webpackChunkName: "async-load-automattic-search" */ '@automattic/search'
-								)
-							}
+							require={ loadSearch }
 							compact
 							onSearch={ this.props.updateSearch }
 							placeholder={ this.props.translate( 'Find Author…', { context: 'search label' } ) }

--- a/client/blocks/calendar-button/index.jsx
+++ b/client/blocks/calendar-button/index.jsx
@@ -5,6 +5,11 @@ import PropTypes from 'prop-types';
 import { createRef, Component, Fragment } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
 
+const loadCalendarPopover = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-blocks-calendar-popover" */ 'calypso/blocks/calendar-popover'
+	);
+
 const noop = () => {};
 
 class CalendarButton extends Component {
@@ -91,11 +96,7 @@ class CalendarButton extends Component {
 		return (
 			<AsyncLoad
 				{ ...calendarProperties }
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-blocks-calendar-popover" */ 'calypso/blocks/calendar-popover'
-					)
-				}
+				require={ loadCalendarPopover }
 				placeholder={ null }
 				isVisible
 				context={ this.buttonRef.current }

--- a/client/blocks/jitm/index.jsx
+++ b/client/blocks/jitm/index.jsx
@@ -17,88 +17,47 @@ import './style.scss';
 
 const debug = debugFactory( 'calypso:jitm' );
 
+const loadNotice = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-blocks-jitm-templates-notice" */ './templates/notice'
+	);
+const loadSidebarBanner = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-blocks-jitm-templates-sidebar-banner" */ './templates/sidebar-banner'
+	);
+const loadHomeTask = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-blocks-jitm-templates-home-task" */ './templates/home-task'
+	);
+const loadSpotlight = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-blocks-jitm-templates-spotlight" */ './templates/spotlight'
+	);
+const loadModal = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-blocks-jitm-templates-modal" */ './templates/modal'
+	);
+const loadDefault = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-blocks-jitm-templates-default" */ './templates/default'
+	);
+
 function renderTemplate( template, props ) {
 	switch ( template ) {
 		case 'notice':
-			return (
-				<AsyncLoad
-					{ ...props }
-					key="notice"
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-blocks-jitm-templates-notice" */ './templates/notice'
-						)
-					}
-					placeholder={ null }
-				/>
-			);
+			return <AsyncLoad { ...props } require={ loadNotice } placeholder={ null } />;
 		case 'sidebar-banner':
-			return (
-				<AsyncLoad
-					{ ...props }
-					key="sidebar-banner"
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-blocks-jitm-templates-sidebar-banner" */ './templates/sidebar-banner'
-						)
-					}
-					placeholder={ null }
-				/>
-			);
+			return <AsyncLoad { ...props } require={ loadSidebarBanner } placeholder={ null } />;
 		case 'home-task':
-			return (
-				<AsyncLoad
-					{ ...props }
-					key="home-task"
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-blocks-jitm-templates-home-task" */ './templates/home-task'
-						)
-					}
-					placeholder={ null }
-				/>
-			);
+			return <AsyncLoad { ...props } require={ loadHomeTask } placeholder={ null } />;
 		case 'spotlight':
-			return (
-				<AsyncLoad
-					{ ...props }
-					key="spotlight"
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-blocks-jitm-templates-spotlight" */ './templates/spotlight'
-						)
-					}
-					placeholder={ null }
-				/>
-			);
+			return <AsyncLoad { ...props } require={ loadSpotlight } placeholder={ null } />;
 		case 'invisible':
 			return <>{ props.trackImpression && props.trackImpression() }</>;
 		case 'modal':
-			return (
-				<AsyncLoad
-					{ ...props }
-					key="modal"
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-blocks-jitm-templates-modal" */ './templates/modal'
-						)
-					}
-					placeholder={ null }
-				/>
-			);
+			return <AsyncLoad { ...props } require={ loadModal } placeholder={ null } />;
 		default:
-			return (
-				<AsyncLoad
-					{ ...props }
-					key="default"
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-blocks-jitm-templates-default" */ './templates/default'
-						)
-					}
-					placeholder={ null }
-				/>
-			);
+			return <AsyncLoad { ...props } require={ loadDefault } placeholder={ null } />;
 	}
 }
 

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -61,6 +61,19 @@ import { shouldUseMagicCode } from './utils/should-use-magic-code';
 
 import './style.scss';
 
+const loadSocialConnectPrompt = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-blocks-login-social-connect-prompt" */ './social-connect-prompt'
+	);
+const loadLostPasswordForm = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-blocks-login-lost-password-form" */ './lost-password-form'
+	);
+const loadTwoFactorContent = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-blocks-login-two-factor-authentication-two-factor-content" */ './two-factor-authentication/two-factor-content'
+	);
+
 class Login extends Component {
 	static propTypes = {
 		disableAutoFocus: PropTypes.bool,
@@ -410,16 +423,7 @@ class Login extends Component {
 		const signupLink = this.getSignupLinkComponent();
 
 		if ( socialConnect ) {
-			return (
-				<AsyncLoad
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-blocks-login-social-connect-prompt" */ './social-connect-prompt'
-						)
-					}
-					onSuccess={ this.handleValidLogin }
-				/>
-			);
+			return <AsyncLoad require={ loadSocialConnectPrompt } onSuccess={ this.handleValidLogin } />;
 		}
 
 		if ( action === 'lostpassword' ) {
@@ -427,11 +431,7 @@ class Login extends Component {
 				<Fragment>
 					<div className="login__lost-password-form-wrapper">
 						<AsyncLoad
-							require={ () =>
-								import(
-									/* webpackChunkName: "async-load-calypso-blocks-login-lost-password-form" */ './lost-password-form'
-								)
-							}
+							require={ loadLostPasswordForm }
 							redirectToAfterLoginUrl={ this.props.redirectTo }
 							oauth2ClientId={ this.props.oauth2Client && this.props.oauth2Client.id }
 							locale={ locale }
@@ -449,11 +449,7 @@ class Login extends Component {
 			return (
 				<Fragment>
 					<AsyncLoad
-						require={ () =>
-							import(
-								/* webpackChunkName: "async-load-calypso-blocks-login-two-factor-authentication-two-factor-content" */ './two-factor-authentication/two-factor-content'
-							)
-						}
+						require={ loadTwoFactorContent }
 						isBrowserSupported={ this.state.isBrowserSupported }
 						isJetpack={ isJetpack }
 						isBlazePro={ isBlazePro }

--- a/client/blocks/support-article-dialog/index.jsx
+++ b/client/blocks/support-article-dialog/index.jsx
@@ -1,6 +1,11 @@
 import AsyncLoad from 'calypso/components/async-load';
 import { useRouteModal } from 'calypso/lib/route-modal';
 
+const loadDialog = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-blocks-support-article-dialog-dialog" */ './dialog'
+	);
+
 function SupportArticleDialogLoader() {
 	const { isModalOpen } = useRouteModal( 'support-article' );
 
@@ -8,16 +13,7 @@ function SupportArticleDialogLoader() {
 		return null;
 	}
 
-	return (
-		<AsyncLoad
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-calypso-blocks-support-article-dialog-dialog" */ './dialog'
-				)
-			}
-			placeholder={ null }
-		/>
-	);
+	return <AsyncLoad require={ loadDialog } placeholder={ null } />;
 }
 
 export default SupportArticleDialogLoader;

--- a/client/blocks/upsell-nudge/index.tsx
+++ b/client/blocks/upsell-nudge/index.tsx
@@ -39,6 +39,15 @@ import type { TranslateResult } from 'i18n-calypso';
 
 import './style.scss';
 
+const loadPurchaseModalWrapper = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-blocks-upsell-nudge-purchase-modal-wrapper" */ './purchase-modal-wrapper'
+	);
+const loadIsEligibleForOneClickCheckoutWrapper = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-my-sites-checkout-purchase-modal-is-eligible-for-one-click-checkout-wrapper" */ 'calypso/my-sites/checkout/purchase-modal/is-eligible-for-one-click-checkout-wrapper'
+	);
+
 const debug = debugFactory( 'calypso:upsell-nudge' );
 
 type ConnectedProps = {
@@ -231,11 +240,7 @@ export const UpsellNudge = ( {
 		<>
 			{ showPurchaseModal && (
 				<AsyncLoad
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-blocks-upsell-nudge-purchase-modal-wrapper" */ './purchase-modal-wrapper'
-						)
-					}
+					require={ loadPurchaseModalWrapper }
 					plan={ upsellPlan }
 					siteSlug={ siteSlug }
 					setShowPurchaseModal={ setShowPurchaseModal }
@@ -326,11 +331,7 @@ export default function Wrapper( props: OwnProps ) {
 	if ( isOneClickCheckoutEnabled && plan ) {
 		return (
 			<AsyncLoad
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-my-sites-checkout-purchase-modal-is-eligible-for-one-click-checkout-wrapper" */ 'calypso/my-sites/checkout/purchase-modal/is-eligible-for-one-click-checkout-wrapper'
-					)
-				}
+				require={ loadIsEligibleForOneClickCheckoutWrapper }
 				component={ ConnectedUpsellNudge }
 				componentProps={ props }
 			/>

--- a/client/components/add-new-site/content/index.tsx
+++ b/client/components/add-new-site/content/index.tsx
@@ -2,20 +2,15 @@ import AsyncLoad from 'calypso/components/async-load';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import type { AddNewSiteContentProps } from 'calypso/components/add-new-site/types';
 
+const loadA4a = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-components-add-new-site-content-a4a" */ './a4a'
+	);
+
 // Always ensure that we load env-specific content asychronously
 const AddNewSiteContent = ( props: AddNewSiteContentProps ) => {
 	if ( isA8CForAgencies() ) {
-		return (
-			<AsyncLoad
-				{ ...props }
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-components-add-new-site-content-a4a" */ './a4a'
-					)
-				}
-				placeholder={ null }
-			/>
-		);
+		return <AsyncLoad { ...props } require={ loadA4a } placeholder={ null } />;
 	}
 };
 

--- a/client/components/async-load/index.tsx
+++ b/client/components/async-load/index.tsx
@@ -17,7 +17,7 @@ export default function AsyncLoad( {
 	require,
 	...props
 }: AsyncLoadProps ) {
-	const Component = useMemo( () => lazy( require ), [] );
+	const Component = useMemo( () => lazy( require ), [ require ] );
 
 	return (
 		<Suspense fallback={ placeholder }>

--- a/client/components/help-center/async-help-center-app.tsx
+++ b/client/components/help-center/async-help-center-app.tsx
@@ -1,17 +1,18 @@
 import AsyncLoad from 'calypso/components/async-load';
 import type { HelpCenterAppProps } from './help-center-app';
 
+const loadHelpCenterApp = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-components-help-center-help-center-app" */ './help-center-app'
+	);
+
 const AsyncHelpCenterApp = ( props: HelpCenterAppProps ) => {
 	if ( props.requireLogin && ! props.currentUser ) {
 		return null;
 	}
 	return (
 		<AsyncLoad
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-calypso-components-help-center-help-center-app" */ './help-center-app'
-				)
-			}
+			require={ loadHelpCenterApp }
 			placeholder={ null }
 			{ ...props }
 			locale={ props.locale ?? props.currentUser.language }

--- a/client/components/jetpack-header/index.jsx
+++ b/client/components/jetpack-header/index.jsx
@@ -7,6 +7,35 @@ import JetpackPartnerLogoGroup from './partner-logo-group';
 
 import './style.scss';
 
+const loadDreamhost = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-components-jetpack-header-dreamhost" */ './dreamhost'
+	);
+const loadPressable = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-components-jetpack-header-pressable" */ './pressable'
+	);
+const loadBluehost = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-components-jetpack-header-bluehost" */ './bluehost'
+	);
+const loadInmotion = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-components-jetpack-header-inmotion" */ './inmotion'
+	);
+const loadMilesweb = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-components-jetpack-header-milesweb" */ './milesweb'
+	);
+const loadLiquidweb = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-components-jetpack-header-liquidweb" */ './liquidweb'
+	);
+const loadEurodns = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-components-jetpack-header-eurodns" */ './eurodns'
+	);
+
 export class JetpackHeader extends PureComponent {
 	static displayName = 'JetpackHeader';
 
@@ -61,12 +90,7 @@ export class JetpackHeader extends PureComponent {
 						partnerName="DreamHost"
 					>
 						<AsyncLoad
-							key="dreamhost"
-							require={ () =>
-								import(
-									/* webpackChunkName: "async-load-calypso-components-jetpack-header-dreamhost" */ './dreamhost'
-								)
-							}
+							require={ loadDreamhost }
 							darkColorScheme={ darkColorScheme }
 							placeholder={ null }
 						/>
@@ -81,12 +105,7 @@ export class JetpackHeader extends PureComponent {
 						partnerName="Pressable"
 					>
 						<AsyncLoad
-							key="pressable"
-							require={ () =>
-								import(
-									/* webpackChunkName: "async-load-calypso-components-jetpack-header-pressable" */ './pressable'
-								)
-							}
+							require={ loadPressable }
 							darkColorScheme={ darkColorScheme }
 							placeholder={ null }
 						/>
@@ -101,12 +120,7 @@ export class JetpackHeader extends PureComponent {
 						partnerName="Bluehost"
 					>
 						<AsyncLoad
-							key="bluehost"
-							require={ () =>
-								import(
-									/* webpackChunkName: "async-load-calypso-components-jetpack-header-bluehost" */ './bluehost'
-								)
-							}
+							require={ loadBluehost }
 							darkColorScheme={ darkColorScheme }
 							placeholder={ null }
 						/>
@@ -121,12 +135,7 @@ export class JetpackHeader extends PureComponent {
 						partnerName="InMotion"
 					>
 						<AsyncLoad
-							key="inmotion"
-							require={ () =>
-								import(
-									/* webpackChunkName: "async-load-calypso-components-jetpack-header-inmotion" */ './inmotion'
-								)
-							}
+							require={ loadInmotion }
 							darkColorScheme={ darkColorScheme }
 							placeholder={ null }
 						/>
@@ -137,12 +146,7 @@ export class JetpackHeader extends PureComponent {
 				// This is a raster logo that contains the Jetpack logo already.
 				return (
 					<AsyncLoad
-						key="milesweb"
-						require={ () =>
-							import(
-								/* webpackChunkName: "async-load-calypso-components-jetpack-header-milesweb" */ './milesweb'
-							)
-						}
+						require={ loadMilesweb }
 						darkColorScheme={ darkColorScheme }
 						placeholder={ null }
 					/>
@@ -156,12 +160,7 @@ export class JetpackHeader extends PureComponent {
 						partnerName="Liquid Web"
 					>
 						<AsyncLoad
-							key="liquidweb"
-							require={ () =>
-								import(
-									/* webpackChunkName: "async-load-calypso-components-jetpack-header-liquidweb" */ './liquidweb'
-								)
-							}
+							require={ loadLiquidweb }
 							darkColorScheme={ darkColorScheme }
 							placeholder={ null }
 						/>
@@ -175,12 +174,7 @@ export class JetpackHeader extends PureComponent {
 						partnerName="EuroDNS"
 					>
 						<AsyncLoad
-							key="eurodns"
-							require={ () =>
-								import(
-									/* webpackChunkName: "async-load-calypso-components-jetpack-header-eurodns" */ './eurodns'
-								)
-							}
+							require={ loadEurodns }
 							darkColorScheme={ darkColorScheme }
 							placeholder={ null }
 						/>

--- a/client/components/jetpack/masterbar/index.tsx
+++ b/client/components/jetpack/masterbar/index.tsx
@@ -13,6 +13,11 @@ import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 
 import './style.scss';
 
+const loadPortalNav = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-components-jetpack-portal-nav" */ 'calypso/components/jetpack/portal-nav'
+	);
+
 const JetpackCloudMasterBar: React.FC = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -48,14 +53,7 @@ const JetpackCloudMasterBar: React.FC = () => {
 			>
 				<JetpackLogo size={ 28 } full={ ! isNarrow || isExteriorPage } aria={ { hidden: true } } />
 			</a>
-			<AsyncLoad
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-components-jetpack-portal-nav" */ 'calypso/components/jetpack/portal-nav'
-					)
-				}
-				placeholder={ null }
-			/>
+			<AsyncLoad require={ loadPortalNav } placeholder={ null } />
 			{ headerTitle && <h1 className="masterbar__item-title">{ headerTitle }</h1> }
 			<ProfileDropdown />
 		</Masterbar>

--- a/client/components/marketing-message/index.tsx
+++ b/client/components/marketing-message/index.tsx
@@ -7,6 +7,9 @@ import AsyncLoad from 'calypso/components/async-load';
 import { useMarketingMessage } from './use-marketing-message';
 import './style.scss';
 
+const loadJitm = () =>
+	import( /* webpackChunkName: "async-load-calypso-blocks-jitm" */ 'calypso/blocks/jitm' );
+
 type NudgeProps = {
 	siteId?: number | null;
 	path?: string;
@@ -92,9 +95,7 @@ function slugify( text: string ) {
 const limitedTimeOfferDiscountNudge = () => {
 	return (
 		<AsyncLoad
-			require={ () =>
-				import( /* webpackChunkName: "async-load-calypso-blocks-jitm" */ 'calypso/blocks/jitm' )
-			}
+			require={ loadJitm }
 			placeholder={ null }
 			messagePath="calypso:plans:lto_notices"
 			onClick={ ( jitm: JITMTProps ) => {

--- a/client/components/sites-add-new-site/async.tsx
+++ b/client/components/sites-add-new-site/async.tsx
@@ -2,16 +2,11 @@ import { Spinner } from '@wordpress/components';
 import AsyncLoad from 'calypso/components/async-load';
 import type { AddNewSiteProps } from '../../dashboard/sites/add-new-site/types';
 
-export const AsyncContent = ( props: AddNewSiteProps ) => {
-	return (
-		<AsyncLoad
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-calypso-dashboard-sites-add-new-site" */ 'calypso/dashboard/sites/add-new-site'
-				)
-			}
-			placeholder={ <Spinner /> }
-			{ ...props }
-		/>
+const loadAddNewSite = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-dashboard-sites-add-new-site" */ 'calypso/dashboard/sites/add-new-site'
 	);
+
+export const AsyncContent = ( props: AddNewSiteProps ) => {
+	return <AsyncLoad require={ loadAddNewSite } placeholder={ <Spinner /> } { ...props } />;
 };

--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -1,21 +1,16 @@
 import AsyncLoad from 'calypso/components/async-load';
 
+const loadComponent = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-components-web-preview-component" */ 'calypso/components/web-preview/component'
+	);
+
 const WebPreview = ( props ) => {
 	if ( ! props.showPreview ) {
 		return null;
 	}
 
-	return (
-		<AsyncLoad
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-calypso-components-web-preview-component" */ 'calypso/components/web-preview/component'
-				)
-			}
-			placeholder={ null }
-			{ ...props }
-		/>
-	);
+	return <AsyncLoad require={ loadComponent } placeholder={ null } { ...props } />;
 };
 
 export default WebPreview;

--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -17,6 +17,29 @@ import Sidebar from './sidebar';
 import DevWelcome from './welcome';
 import WizardComponent from './wizard-component';
 
+const loadDesign = () =>
+	import( /* webpackChunkName: "async-load-calypso-devdocs-design" */ './design' );
+const loadBlocks = () =>
+	import( /* webpackChunkName: "async-load-calypso-devdocs-design-blocks" */ './design/blocks' );
+const loadPlayground = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-devdocs-design-playground" */ './design/playground'
+	);
+const loadWordpressComponentsGallery = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-devdocs-design-wordpress-components-gallery" */ './design/wordpress-components-gallery'
+	);
+const loadDocsSelectors = () =>
+	import( /* webpackChunkName: "async-load-calypso-devdocs-docs-selectors" */ './docs-selectors' );
+const loadTypography = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-devdocs-design-typography" */ './design/typography'
+	);
+const loadIllustrations = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-devdocs-design-illustrations" */ './design/illustrations'
+	);
+
 const devdocs = {
 	/*
 	 * Documentation is rendered on #primary and doesn't expect a sidebar to exist
@@ -78,15 +101,7 @@ const devdocs = {
 
 	// UI components
 	design: function ( context, next ) {
-		context.primary = (
-			<AsyncLoad
-				key="devdocs-design"
-				component={ context.params.component }
-				require={ () =>
-					import( /* webpackChunkName: "async-load-calypso-devdocs-design" */ './design' )
-				}
-			/>
-		);
+		context.primary = <AsyncLoad component={ context.params.component } require={ loadDesign } />;
 		next();
 	},
 
@@ -97,58 +112,26 @@ const devdocs = {
 
 	// App Blocks
 	blocks: function ( context, next ) {
-		context.primary = (
-			<AsyncLoad
-				key="devdocs-blocks"
-				component={ context.params.component }
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-devdocs-design-blocks" */ './design/blocks'
-					)
-				}
-			/>
-		);
+		context.primary = <AsyncLoad component={ context.params.component } require={ loadBlocks } />;
 		next();
 	},
 
 	playground: function ( context, next ) {
 		context.primary = (
-			<AsyncLoad
-				key="devdocs-playground"
-				component={ context.params.component }
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-devdocs-design-playground" */ './design/playground'
-					)
-				}
-			/>
+			<AsyncLoad component={ context.params.component } require={ loadPlayground } />
 		);
 		next();
 	},
 
 	wpComponentsGallery( context, next ) {
-		context.primary = (
-			<AsyncLoad
-				key="devdocs-wp-components-gallery"
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-devdocs-design-wordpress-components-gallery" */ './design/wordpress-components-gallery'
-					)
-				}
-			/>
-		);
+		context.primary = <AsyncLoad require={ loadWordpressComponentsGallery } />;
 		next();
 	},
 
 	selectors: function ( context, next ) {
 		context.primary = (
 			<AsyncLoad
-				key="devdocs-selectors"
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-devdocs-docs-selectors" */ './docs-selectors'
-					)
-				}
+				require={ loadDocsSelectors }
 				search={ context.query.search }
 				selector={ context.params.selector }
 			/>
@@ -158,30 +141,14 @@ const devdocs = {
 
 	typography: function ( context, next ) {
 		context.primary = (
-			<AsyncLoad
-				key="devdocs-typography"
-				component={ context.params.component }
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-devdocs-design-typography" */ './design/typography'
-					)
-				}
-			/>
+			<AsyncLoad component={ context.params.component } require={ loadTypography } />
 		);
 		next();
 	},
 
 	illustrations: function ( context, next ) {
 		context.primary = (
-			<AsyncLoad
-				key="devdocs-illustrations"
-				component={ context.params.component }
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-devdocs-design-illustrations" */ './design/illustrations'
-					)
-				}
-			/>
+			<AsyncLoad component={ context.params.component } require={ loadIllustrations } />
 		);
 		next();
 	},

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/step-container-v2-difm-starting-point.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/step-container-v2-difm-starting-point.tsx
@@ -11,6 +11,11 @@ import { useDIFMHeading } from 'calypso/my-sites/marketing/do-it-for-me/use-difm
 
 import './style.scss';
 
+const loadSiteBuildShowcase = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-my-sites-marketing-do-it-for-me-site-build-showcase" */ 'calypso/my-sites/marketing/do-it-for-me/site-build-showcase'
+	);
+
 export const StepContainerV2DIFMStartingPoint = ( {
 	topBar,
 	siteId,
@@ -82,11 +87,7 @@ export const StepContainerV2DIFMStartingPoint = ( {
 						{ isLargeViewport && (
 							<div className="step-container-v2--difm-starting-point__right-column">
 								<AsyncLoad
-									require={ () =>
-										import(
-											/* webpackChunkName: "async-load-calypso-my-sites-marketing-do-it-for-me-site-build-showcase" */ 'calypso/my-sites/marketing/do-it-for-me/site-build-showcase'
-										)
-									}
+									require={ loadSiteBuildShowcase }
 									placeholder={ <LoadingEllipsis /> }
 									isStoreFlow={ false }
 								/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -54,6 +54,15 @@ import type { OnboardSelect, SiteDetails } from '@automattic/data-stores';
 import type { StepState } from 'calypso/state/signup/progress/schema';
 import './unified-plans-step-styles.scss';
 
+const loadPlanFaq = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-my-sites-plans-features-main-components-plan-faq" */ 'calypso/my-sites/plans-features-main/components/plan-faq'
+	);
+const loadStepWrapper = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-signup-step-wrapper" */ 'calypso/signup/step-wrapper'
+	);
+
 export interface UnifiedPlansStepProps {
 	hideFreePlan?: boolean;
 	hidePersonalPlan?: boolean;
@@ -607,16 +616,7 @@ function UnifiedPlansStep( {
 						return null;
 					}
 
-					return (
-						<AsyncLoad
-							require={ () =>
-								import(
-									/* webpackChunkName: "async-load-calypso-my-sites-plans-features-main-components-plan-faq" */ 'calypso/my-sites/plans-features-main/components/plan-faq'
-								)
-							}
-							placeholder={ null }
-						/>
-					);
+					return <AsyncLoad require={ loadPlanFaq } placeholder={ null } />;
 				} }
 			/>
 		</div>
@@ -697,11 +697,7 @@ function UnifiedPlansStep( {
 						/**
 						 * Common Start/Stepper props [START]
 						 */
-						require={ () =>
-							import(
-								/* webpackChunkName: "async-load-calypso-signup-step-wrapper" */ 'calypso/signup/step-wrapper'
-							)
-						}
+						require={ loadStepWrapper }
 						flowName={ flowName }
 						stepName={ stepName }
 						stepContent={ stepContent }

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -59,6 +59,23 @@ import type { CurrentUser, HelpCenterSelect, HelpCenterDispatch } from '@automat
 import type { AnyAction } from 'redux';
 import type { WpcomRequestParams } from 'wpcom-proxy-request';
 
+const loadCookieBanner = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-blocks-cookie-banner" */ 'calypso/blocks/cookie-banner'
+	);
+const loadGlobalNotices = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-components-global-notices" */ 'calypso/components/global-notices'
+	);
+const loadAgentsManagerLoader = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-layout-agents-manager-loader" */ 'calypso/layout/agents-manager-loader'
+	);
+const loadWebpackBuildMonitor = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-components-webpack-build-monitor" */ 'calypso/components/webpack-build-monitor'
+	);
+
 declare const window: AppWindow;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -254,24 +271,9 @@ async function main() {
 					<BrowserRouter basename="setup">
 						<FlowRenderer flow={ flow } steps={ flowSteps } />
 						{ config.isEnabled( 'cookie-banner' ) && (
-							<AsyncLoad
-								require={ () =>
-									import(
-										/* webpackChunkName: "async-load-calypso-blocks-cookie-banner" */ 'calypso/blocks/cookie-banner'
-									)
-								}
-								placeholder={ null }
-							/>
+							<AsyncLoad require={ loadCookieBanner } placeholder={ null } />
 						) }
-						<AsyncLoad
-							require={ () =>
-								import(
-									/* webpackChunkName: "async-load-calypso-components-global-notices" */ 'calypso/components/global-notices'
-								)
-							}
-							placeholder={ null }
-							id="notices"
-						/>
+						<AsyncLoad require={ loadGlobalNotices } placeholder={ null } id="notices" />
 					</BrowserRouter>
 					{ ! FLOWS_WITHOUT_HELP_CENTER.has( flowName ) &&
 						( flowName === WOO_HOSTED_PLANS_FLOW ? (
@@ -284,11 +286,7 @@ async function main() {
 									sectionName="stepper"
 								/>
 								<AsyncLoad
-									require={ () =>
-										import(
-											/* webpackChunkName: "async-load-calypso-layout-agents-manager-loader" */ 'calypso/layout/agents-manager-loader'
-										)
-									}
+									require={ loadAgentsManagerLoader }
 									placeholder={ null }
 									sectionName={ flowName }
 									loadAgentsManager
@@ -296,14 +294,7 @@ async function main() {
 							</>
 						) ) }
 					{ 'development' === process.env.NODE_ENV && (
-						<AsyncLoad
-							require={ () =>
-								import(
-									/* webpackChunkName: "async-load-calypso-components-webpack-build-monitor" */ 'calypso/components/webpack-build-monitor'
-								)
-							}
-							placeholder={ null }
-						/>
+						<AsyncLoad require={ loadWebpackBuildMonitor } placeholder={ null } />
 					) }
 				</QueryClientProvider>
 			</Provider>

--- a/client/layout/agents-manager-loader.tsx
+++ b/client/layout/agents-manager-loader.tsx
@@ -6,6 +6,11 @@ import getPrimarySiteSlug from 'calypso/state/selectors/get-primary-site-slug';
 import { getSiteBySlug } from 'calypso/state/sites/selectors';
 import { getSelectedSite, isSiteSection } from 'calypso/state/ui/selectors';
 
+const importAgentsManager = () =>
+	import(
+		/* webpackChunkName: "async-load-automattic-agents-manager" */ '@automattic/agents-manager'
+	);
+
 export default function AgentsManagerLoader( {
 	sectionName,
 	loadAgentsManager,
@@ -26,11 +31,7 @@ export default function AgentsManagerLoader( {
 
 	return (
 		<AsyncLoad
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-automattic-agents-manager" */ '@automattic/agents-manager'
-				)
-			}
+			require={ importAgentsManager }
 			placeholder={ null }
 			currentUser={ user }
 			sectionName={ sectionName }

--- a/client/layout/global-notifications/index.tsx
+++ b/client/layout/global-notifications/index.tsx
@@ -10,6 +10,9 @@ import { toggleNotificationsPanel } from 'calypso/state/ui/actions';
 import type { AppState } from 'calypso/types';
 import './style.scss';
 
+const loadNotifications = () =>
+	import( /* webpackChunkName: "async-load-calypso-notifications" */ 'calypso/notifications' );
+
 const GlobalNotifications = () => {
 	const isNotificationsOpen = useSelector( ( state: AppState ) => getIsNotificationsOpen( state ) );
 	const isNotificationsOpenRef = useRef( isNotificationsOpen );
@@ -79,11 +82,7 @@ const GlobalNotifications = () => {
 	return (
 		<div className="global-notifications" ref={ containerRef }>
 			<AsyncLoad
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-notifications" */ 'calypso/notifications'
-					)
-				}
+				require={ loadNotifications }
 				isShowing={ isNotificationsOpen }
 				checkToggle={ checkToggleNotes }
 				placeholder={ null }

--- a/client/layout/guided-tours/index.js
+++ b/client/layout/guided-tours/index.js
@@ -5,6 +5,11 @@ import { resetGuidedToursHistory } from 'calypso/state/guided-tours/actions';
 import { getGuidedTourState } from 'calypso/state/guided-tours/selectors';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 
+const loadComponent = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-layout-guided-tours-component" */ './component'
+	);
+
 function GuidedTours() {
 	const dispatch = useDispatch();
 	const tourState = useSelector( getGuidedTourState );
@@ -21,15 +26,7 @@ function GuidedTours() {
 		return null;
 	}
 
-	return (
-		<AsyncLoad
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-calypso-layout-guided-tours-component" */ './component'
-				)
-			}
-		/>
-	);
+	return <AsyncLoad require={ loadComponent } />;
 }
 
 export default GuidedTours;

--- a/client/layout/help-center-loader.tsx
+++ b/client/layout/help-center-loader.tsx
@@ -15,6 +15,9 @@ import hasCancelableUserPurchases from 'calypso/state/selectors/has-cancelable-u
 import { getSiteBySlug } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
+const importHelpCenter = () =>
+	import( /* webpackChunkName: "async-load-automattic-help-center" */ '@automattic/help-center' );
+
 const HELP_CENTER_STORE = HelpCenter.register();
 
 type Props = {
@@ -57,11 +60,7 @@ export default function HelpCenterLoader( { sectionName, loadHelpCenter, current
 
 	return (
 		<AsyncLoad
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-automattic-help-center" */ '@automattic/help-center'
-				)
-			}
+			require={ importHelpCenter }
 			placeholder={ null }
 			handleClose={ handleClose }
 			currentRoute={ currentRoute }

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -75,6 +75,69 @@ import '@automattic/components/src/card/style.scss';
 
 import './style.scss';
 
+const loadWooCoreProfiler = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-layout-masterbar-woo-core-profiler" */ 'calypso/layout/masterbar/woo-core-profiler'
+	);
+const loadBlazePro = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-layout-masterbar-blaze-pro" */ 'calypso/layout/masterbar/blaze-pro'
+	);
+const loadReaderHeader = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-components-header" */ 'calypso/reader/components/header'
+	);
+const loadCelebrateSiteLaunchModal = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-my-sites-customer-home-celebrate-site-launch-modal" */ 'calypso/my-sites/customer-home/celebrate-site-launch-modal'
+	);
+const loadGuidedTours = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-layout-guided-tours" */ 'calypso/layout/guided-tours'
+	);
+const loadJetpackCloudStyle = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-jetpack-cloud-style" */ 'calypso/jetpack-cloud/style'
+	);
+const loadA8cForAgenciesStyle = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-a8c-for-agencies-style" */ 'calypso/a8c-for-agencies/style'
+	);
+const loadJitm = () =>
+	import( /* webpackChunkName: "async-load-calypso-blocks-jitm" */ 'calypso/blocks/jitm' );
+const loadGlobalNotices = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-components-global-notices" */ 'calypso/components/global-notices'
+	);
+const loadCommunityTranslator = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-layout-community-translator" */ 'calypso/layout/community-translator'
+	);
+const loadWebpackBuildMonitor = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-components-webpack-build-monitor" */ 'calypso/components/webpack-build-monitor'
+	);
+const loadSupportArticleDialog = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-blocks-support-article-dialog" */ 'calypso/blocks/support-article-dialog'
+	);
+const loadCookieBanner = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-blocks-cookie-banner" */ 'calypso/blocks/cookie-banner'
+	);
+const loadAppBanner = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-blocks-app-banner" */ 'calypso/blocks/app-banner'
+	);
+const loadLegalUpdatesBanner = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-blocks-legal-updates-banner" */ 'calypso/blocks/legal-updates-banner'
+	);
+const loadGlobalNotifications = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-layout-global-notifications" */ 'calypso/layout/global-notifications'
+	);
+
 function SidebarScrollSynchronizer() {
 	const isNarrow = useBreakpoint( '<660px' );
 	const active = ! isNarrow && ! config.isEnabled( 'jetpack-cloud' ); // Jetpack cloud hasn't yet aligned with WPCOM.
@@ -183,28 +246,10 @@ class Layout extends Component {
 			return <EmptyMasterbar />;
 		}
 		if ( this.props.isWooJPC ) {
-			return (
-				<AsyncLoad
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-layout-masterbar-woo-core-profiler" */ 'calypso/layout/masterbar/woo-core-profiler'
-						)
-					}
-					placeholder={ null }
-				/>
-			);
+			return <AsyncLoad require={ loadWooCoreProfiler } placeholder={ null } />;
 		}
 		if ( this.props.isBlazePro ) {
-			return (
-				<AsyncLoad
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-layout-masterbar-blaze-pro" */ 'calypso/layout/masterbar/blaze-pro'
-						)
-					}
-					placeholder={ null }
-				/>
-			);
+			return <AsyncLoad require={ loadBlazePro } placeholder={ null } />;
 		}
 
 		if ( this.props.needsColorScheme && this.props.isFetchingColorScheme ) {
@@ -212,16 +257,7 @@ class Layout extends Component {
 		}
 
 		if ( this.props.isMSDEnabledForReader ) {
-			return (
-				<AsyncLoad
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-reader-components-header" */ 'calypso/reader/components/header'
-						)
-					}
-					placeholder={ null }
-				/>
-			);
+			return <AsyncLoad require={ loadReaderHeader } placeholder={ null } />;
 		}
 
 		const MasterbarComponent = config.isEnabled( 'jetpack-cloud' )
@@ -260,11 +296,7 @@ class Layout extends Component {
 
 		return (
 			<AsyncLoad
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-my-sites-customer-home-celebrate-site-launch-modal" */ 'calypso/my-sites/customer-home/celebrate-site-launch-modal'
-					)
-				}
+				require={ loadCelebrateSiteLaunchModal }
 				placeholder={ null }
 				siteId={ this.props.siteId }
 			/>
@@ -357,61 +389,26 @@ class Layout extends Component {
 				<QuerySiteAdminColor siteId={ this.props.siteId } />
 				<UserVerificationChecker />
 				{ config.isEnabled( 'layout/guided-tours' ) && (
-					<AsyncLoad
-						require={ () =>
-							import(
-								/* webpackChunkName: "async-load-calypso-layout-guided-tours" */ 'calypso/layout/guided-tours'
-							)
-						}
-						placeholder={ null }
-					/>
+					<AsyncLoad require={ loadGuidedTours } placeholder={ null } />
 				) }
 				<div className="layout__header-section">{ this.renderMasterbar( loadHelpCenter ) }</div>
 				<LayoutLoader />
-				{ isJetpackCloud() && (
-					<AsyncLoad
-						require={ () =>
-							import(
-								/* webpackChunkName: "async-load-calypso-jetpack-cloud-style" */ 'calypso/jetpack-cloud/style'
-							)
-						}
-						placeholder={ null }
-					/>
-				) }
+				{ isJetpackCloud() && <AsyncLoad require={ loadJetpackCloudStyle } placeholder={ null } /> }
 				{ isA8CForAgencies() && (
 					<>
-						<AsyncLoad
-							require={ () =>
-								import(
-									/* webpackChunkName: "async-load-calypso-a8c-for-agencies-style" */ 'calypso/a8c-for-agencies/style'
-								)
-							}
-							placeholder={ null }
-						/>
+						<AsyncLoad require={ loadA8cForAgenciesStyle } placeholder={ null } />
 						<QueryAgencies />
 					</>
 				) }
 				<div id="content" className="layout__content">
 					{ config.isEnabled( 'jitms' ) && this.props.isEligibleForJITM && (
 						<AsyncLoad
-							require={ () =>
-								import(
-									/* webpackChunkName: "async-load-calypso-blocks-jitm" */ 'calypso/blocks/jitm'
-								)
-							}
+							require={ loadJitm }
 							placeholder={ null }
 							messagePath={ `calypso:${ this.props.sectionJitmPath }:admin_notices` }
 						/>
 					) }
-					<AsyncLoad
-						require={ () =>
-							import(
-								/* webpackChunkName: "async-load-calypso-components-global-notices" */ 'calypso/components/global-notices'
-							)
-						}
-						placeholder={ null }
-						id="notices"
-					/>
+					<AsyncLoad require={ loadGlobalNotices } placeholder={ null } id="notices" />
 					{ ! ( this.props.needsColorScheme && this.props.isFetchingColorScheme ) && (
 						<>
 							<div id="secondary" className="layout__secondary" role="navigation">
@@ -424,77 +421,28 @@ class Layout extends Component {
 						</>
 					) }
 				</div>
-				<AsyncLoad
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-layout-community-translator" */ 'calypso/layout/community-translator'
-						)
-					}
-					placeholder={ null }
-				/>
+				<AsyncLoad require={ loadCommunityTranslator } placeholder={ null } />
 				{ 'development' === process.env.NODE_ENV && (
 					<>
 						<SympathyDevWarning />
-						<AsyncLoad
-							require={ () =>
-								import(
-									/* webpackChunkName: "async-load-calypso-components-webpack-build-monitor" */ 'calypso/components/webpack-build-monitor'
-								)
-							}
-							placeholder={ null }
-						/>
+						<AsyncLoad require={ loadWebpackBuildMonitor } placeholder={ null } />
 					</>
 				) }
 				{ config.isEnabled( 'layout/support-article-dialog' ) && (
-					<AsyncLoad
-						require={ () =>
-							import(
-								/* webpackChunkName: "async-load-calypso-blocks-support-article-dialog" */ 'calypso/blocks/support-article-dialog'
-							)
-						}
-						placeholder={ null }
-					/>
+					<AsyncLoad require={ loadSupportArticleDialog } placeholder={ null } />
 				) }
 				{ config.isEnabled( 'cookie-banner' ) && (
-					<AsyncLoad
-						require={ () =>
-							import(
-								/* webpackChunkName: "async-load-calypso-blocks-cookie-banner" */ 'calypso/blocks/cookie-banner'
-							)
-						}
-						placeholder={ null }
-					/>
+					<AsyncLoad require={ loadCookieBanner } placeholder={ null } />
 				) }
 				{ config.isEnabled( 'layout/app-banner' ) && (
-					<AsyncLoad
-						require={ () =>
-							import(
-								/* webpackChunkName: "async-load-calypso-blocks-app-banner" */ 'calypso/blocks/app-banner'
-							)
-						}
-						placeholder={ null }
-					/>
+					<AsyncLoad require={ loadAppBanner } placeholder={ null } />
 				) }
 				{ config.isEnabled( 'legal-updates-banner' ) && (
-					<AsyncLoad
-						require={ () =>
-							import(
-								/* webpackChunkName: "async-load-calypso-blocks-legal-updates-banner" */ 'calypso/blocks/legal-updates-banner'
-							)
-						}
-						placeholder={ null }
-					/>
+					<AsyncLoad require={ loadLegalUpdatesBanner } placeholder={ null } />
 				) }
 
 				{ ! this.props.isMSDEnabledForReader && (
-					<AsyncLoad
-						require={ () =>
-							import(
-								/* webpackChunkName: "async-load-calypso-layout-global-notifications" */ 'calypso/layout/global-notifications'
-							)
-						}
-						placeholder={ null }
-					/>
+					<AsyncLoad require={ loadGlobalNotifications } placeholder={ null } />
 				) }
 				{ this.renderCelebrateSiteLaunchModal() }
 			</div>

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -58,6 +58,27 @@ import HelpCenterLoader from './help-center-loader';
 
 import './style.scss';
 
+const loadWooCoreProfiler = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-layout-masterbar-woo-core-profiler" */ 'calypso/layout/masterbar/woo-core-profiler'
+	);
+const loadJetpackCloudStyle = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-jetpack-cloud-style" */ 'calypso/jetpack-cloud/style'
+	);
+const loadA8cForAgenciesStyle = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-a8c-for-agencies-style" */ 'calypso/a8c-for-agencies/style'
+	);
+const loadGlobalNotices = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-components-global-notices" */ 'calypso/components/global-notices'
+	);
+const loadSupportArticleDialog = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-blocks-support-article-dialog" */ 'calypso/blocks/support-article-dialog'
+	);
+
 const LayoutLoggedOut = ( {
 	isAkismet,
 	isPassport,
@@ -251,16 +272,7 @@ const LayoutLoggedOut = ( {
 	} else if ( isWooJPC ) {
 		classes.woo = true;
 		classes[ 'has-no-masterbar' ] = false;
-		masterbar = (
-			<AsyncLoad
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-layout-masterbar-woo-core-profiler" */ 'calypso/layout/masterbar/woo-core-profiler'
-					)
-				}
-				placeholder={ null }
-			/>
-		);
+		masterbar = <AsyncLoad require={ loadWooCoreProfiler } placeholder={ null } />;
 	} else {
 		masterbar = ! masterbarIsHidden && (
 			<MasterbarLoggedOut
@@ -299,35 +311,13 @@ const LayoutLoggedOut = ( {
 					) }
 				</div>
 				{ isJetpackCloudEnvironment() && (
-					<AsyncLoad
-						require={ () =>
-							import(
-								/* webpackChunkName: "async-load-calypso-jetpack-cloud-style" */ 'calypso/jetpack-cloud/style'
-							)
-						}
-						placeholder={ null }
-					/>
+					<AsyncLoad require={ loadJetpackCloudStyle } placeholder={ null } />
 				) }
 				{ isA8CForAgencies() && (
-					<AsyncLoad
-						require={ () =>
-							import(
-								/* webpackChunkName: "async-load-calypso-a8c-for-agencies-style" */ 'calypso/a8c-for-agencies/style'
-							)
-						}
-						placeholder={ null }
-					/>
+					<AsyncLoad require={ loadA8cForAgenciesStyle } placeholder={ null } />
 				) }
 				<div id="content" className="layout__content">
-					<AsyncLoad
-						require={ () =>
-							import(
-								/* webpackChunkName: "async-load-calypso-components-global-notices" */ 'calypso/components/global-notices'
-							)
-						}
-						placeholder={ null }
-						id="notices"
-					/>
+					<AsyncLoad require={ loadGlobalNotices } placeholder={ null } id="notices" />
 					<div id="primary" className="layout__primary">
 						{ primary }
 					</div>
@@ -344,14 +334,7 @@ const LayoutLoggedOut = ( {
 						<UniversalNavbarFooter currentRoute={ currentRoute } isLoggedIn={ isLoggedIn } />
 
 						{ config.isEnabled( 'layout/support-article-dialog' ) && (
-							<AsyncLoad
-								require={ () =>
-									import(
-										/* webpackChunkName: "async-load-calypso-blocks-support-article-dialog" */ 'calypso/blocks/support-article-dialog'
-									)
-								}
-								placeholder={ null }
-							/>
+							<AsyncLoad require={ loadSupportArticleDialog } placeholder={ null } />
 						) }
 					</>
 				) }

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -65,6 +65,25 @@ import { HelpCenterIcon } from './masterbar-help-center/help-center-icon';
 import { MasterbarLaunchButton } from './masterbar-launch-button';
 import Notifications from './masterbar-notifications/notifications-button';
 
+const loadCheckout = () =>
+	import( /* webpackChunkName: "async-load-calypso-layout-masterbar-checkout" */ './checkout.tsx' );
+const loadQuickLanguageSwitcher = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-layout-masterbar-quick-language-switcher" */ './quick-language-switcher'
+	);
+const loadMasterbarCartWrapper = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-layout-masterbar-masterbar-cart-masterbar-cart-wrapper" */ './masterbar-cart/masterbar-cart-wrapper'
+	);
+const loadMasterbarAgentsManager = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-layout-masterbar-masterbar-agents-manager" */ './masterbar-agents-manager'
+	);
+const loadMasterbarHelpCenter = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-layout-masterbar-masterbar-help-center" */ './masterbar-help-center'
+	);
+
 class MasterbarLoggedIn extends Component {
 	static propTypes = {
 		user: PropTypes.object.isRequired,
@@ -311,11 +330,7 @@ class MasterbarLoggedIn extends Component {
 
 		return (
 			<AsyncLoad
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-layout-masterbar-checkout" */ './checkout.tsx'
-					)
-				}
+				require={ loadCheckout }
 				placeholder={ null }
 				title={ title }
 				isJetpackNotAtomic={ isJetpackNotAtomic }
@@ -732,16 +747,7 @@ class MasterbarLoggedIn extends Component {
 
 	renderLanguageSwitcher() {
 		if ( this.props.isSupportSession || config.isEnabled( 'quick-language-switcher' ) ) {
-			return (
-				<AsyncLoad
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-layout-masterbar-quick-language-switcher" */ './quick-language-switcher'
-						)
-					}
-					placeholder={ null }
-				/>
-			);
+			return <AsyncLoad require={ loadQuickLanguageSwitcher } placeholder={ null } />;
 		}
 		return null;
 	}
@@ -754,11 +760,7 @@ class MasterbarLoggedIn extends Component {
 		}
 		return (
 			<AsyncLoad
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-layout-masterbar-masterbar-cart-masterbar-cart-wrapper" */ './masterbar-cart/masterbar-cart-wrapper'
-					)
-				}
+				require={ loadMasterbarCartWrapper }
 				placeholder={ null }
 				goToCheckout={ this.goToCheckout }
 				onRemoveProduct={ this.onRemoveCartProduct }
@@ -805,11 +807,7 @@ class MasterbarLoggedIn extends Component {
 
 			return (
 				<AsyncLoad
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-layout-masterbar-masterbar-agents-manager" */ './masterbar-agents-manager'
-						)
-					}
+					require={ loadMasterbarAgentsManager }
 					siteId={ siteId }
 					tooltip={ __( 'Help' ) }
 					placeholder={ placeholder }
@@ -831,11 +829,7 @@ class MasterbarLoggedIn extends Component {
 
 		return (
 			<AsyncLoad
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-layout-masterbar-masterbar-help-center" */ './masterbar-help-center'
-					)
-				}
+				require={ loadMasterbarHelpCenter }
 				siteId={ siteId }
 				tooltip={ __( 'Help' ) }
 				placeholder={ placeholder }

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -16,6 +16,13 @@ import { addQueryArgs } from 'calypso/lib/route';
 import Item from './item';
 import Masterbar from './masterbar';
 
+const loadMasterbarHelpCenter = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-layout-masterbar-masterbar-help-center" */ './masterbar-help-center'
+	);
+const loadCheckout = () =>
+	import( /* webpackChunkName: "async-load-calypso-layout-masterbar-checkout" */ './checkout.tsx' );
+
 class MasterbarLoggedOut extends Component {
 	static propTypes = {
 		redirectUri: PropTypes.string,
@@ -124,11 +131,7 @@ class MasterbarLoggedOut extends Component {
 
 		return (
 			<AsyncLoad
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-layout-masterbar-masterbar-help-center" */ './masterbar-help-center'
-					)
-				}
+				require={ loadMasterbarHelpCenter }
 				siteId={ siteId }
 				tooltip={ translate( 'Help' ) }
 				placeholder={ null }
@@ -241,11 +244,7 @@ class MasterbarLoggedOut extends Component {
 		if ( isCheckout || isCheckoutPending || isCheckoutFailed ) {
 			return (
 				<AsyncLoad
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-layout-masterbar-checkout" */ './checkout.tsx'
-						)
-					}
+					require={ loadCheckout }
 					placeholder={ null }
 					title={ title }
 					isLeavingAllowed={ ! isCheckoutPending }

--- a/client/login/magic-login/magic-login-email/magic-login-email-icon.tsx
+++ b/client/login/magic-login/magic-login-email/magic-login-email-icon.tsx
@@ -1,5 +1,26 @@
 import AsyncLoad from 'calypso/components/async-load';
 
+const loadApple = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-components-social-icons-apple" */ 'calypso/components/social-icons/apple'
+	);
+const loadGmail = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-components-social-icons-gmail" */ 'calypso/components/social-icons/gmail'
+	);
+const loadOutlook = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-components-social-icons-outlook" */ 'calypso/components/social-icons/outlook'
+	);
+const loadYahoo = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-components-social-icons-yahoo" */ 'calypso/components/social-icons/yahoo'
+	);
+const loadAol = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-components-social-icons-aol" */ 'calypso/components/social-icons/aol'
+	);
+
 interface MagicLoginEmailIconProps {
 	icon: string;
 }
@@ -7,60 +28,15 @@ interface MagicLoginEmailIconProps {
 export function MagicLoginEmailIcon( { icon }: MagicLoginEmailIconProps ) {
 	switch ( icon ) {
 		case 'apple':
-			return (
-				<AsyncLoad
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-components-social-icons-apple" */ 'calypso/components/social-icons/apple'
-						)
-					}
-					placeholder={ null }
-				/>
-			);
+			return <AsyncLoad require={ loadApple } placeholder={ null } />;
 		case 'gmail':
-			return (
-				<AsyncLoad
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-components-social-icons-gmail" */ 'calypso/components/social-icons/gmail'
-						)
-					}
-					placeholder={ null }
-				/>
-			);
+			return <AsyncLoad require={ loadGmail } placeholder={ null } />;
 		case 'outlook':
-			return (
-				<AsyncLoad
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-components-social-icons-outlook" */ 'calypso/components/social-icons/outlook'
-						)
-					}
-					placeholder={ null }
-				/>
-			);
+			return <AsyncLoad require={ loadOutlook } placeholder={ null } />;
 		case 'yahoo':
-			return (
-				<AsyncLoad
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-components-social-icons-yahoo" */ 'calypso/components/social-icons/yahoo'
-						)
-					}
-					placeholder={ null }
-				/>
-			);
+			return <AsyncLoad require={ loadYahoo } placeholder={ null } />;
 		case 'aol':
-			return (
-				<AsyncLoad
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-components-social-icons-aol" */ 'calypso/components/social-icons/aol'
-						)
-					}
-					placeholder={ null }
-				/>
-			);
+			return <AsyncLoad require={ loadAol } placeholder={ null } />;
 		default:
 			return null;
 	}

--- a/client/login/qr-code-login-page/index.jsx
+++ b/client/login/qr-code-login-page/index.jsx
@@ -10,6 +10,11 @@ import OneLoginLayout from 'calypso/login/wp-login/components/one-login-layout';
 
 import './style.scss';
 
+const loadQrCodeLogin = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-blocks-qr-code-login" */ 'calypso/blocks/qr-code-login'
+	);
+
 function QrCodeLoginPlaceholder() {
 	return <Card className="qr-code-login-page__placeholder" />;
 }
@@ -21,11 +26,7 @@ function QrCodeLoginPage( { locale, redirectTo, isJetpack = false } ) {
 		<Main className={ clsx( 'qr-code-login-page', { 'is-jetpack': isJetpack } ) }>
 			<div className="qr-code-login-page__form">
 				<AsyncLoad
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-blocks-qr-code-login" */ 'calypso/blocks/qr-code-login'
-						)
-					}
+					require={ loadQrCodeLogin }
 					placeholder={ <QrCodeLoginPlaceholder /> }
 					size={ 300 }
 					locale={ locale }

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -195,6 +195,11 @@ import type { Theme } from 'calypso/types';
 
 import './style.scss';
 
+const loadProductPlanOverlapNotices = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-blocks-product-plan-overlap-notices" */ 'calypso/blocks/product-plan-overlap-notices'
+	);
+
 export interface ManagePurchaseProps {
 	cardTitle?: string;
 	getAddNewPaymentMethodUrlFor?: typeof getAddNewPaymentMethodUrlFor;
@@ -1793,11 +1798,7 @@ function PlanOverlapNotice( {
 		}
 		return (
 			<AsyncLoad
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-blocks-product-plan-overlap-notices" */ 'calypso/blocks/product-plan-overlap-notices'
-					)
-				}
+				require={ loadProductPlanOverlapNotices }
 				placeholder={ null }
 				plans={ JETPACK_PLANS }
 				products={ JETPACK_PRODUCTS_LIST }
@@ -1812,11 +1813,7 @@ function PlanOverlapNotice( {
 	}
 	return (
 		<AsyncLoad
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-calypso-blocks-product-plan-overlap-notices" */ 'calypso/blocks/product-plan-overlap-notices'
-				)
-			}
+			require={ loadProductPlanOverlapNotices }
 			placeholder={ null }
 			plans={ JETPACK_PLANS }
 			products={ JETPACK_PRODUCTS_LIST }

--- a/client/me/purchases/purchases-site/index.tsx
+++ b/client/me/purchases/purchases-site/index.tsx
@@ -15,6 +15,11 @@ import type { Purchase, GetManagePurchaseUrlFor } from 'calypso/lib/purchases/ty
 
 import './style.scss';
 
+const loadProductPlanOverlapNotices = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-blocks-product-plan-overlap-notices" */ 'calypso/blocks/product-plan-overlap-notices'
+	);
+
 export default function PurchasesSite(
 	props:
 		| {
@@ -52,11 +57,7 @@ export default function PurchasesSite(
 			<QuerySites siteId={ siteId } />
 
 			<AsyncLoad
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-blocks-product-plan-overlap-notices" */ 'calypso/blocks/product-plan-overlap-notices'
-					)
-				}
+				require={ loadProductPlanOverlapNotices }
 				placeholder={ null }
 				plans={ JETPACK_PLANS }
 				products={ JETPACK_PRODUCTS_LIST }

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -21,6 +21,9 @@ import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 
+const loadJitm = () =>
+	import( /* webpackChunkName: "async-load-calypso-blocks-jitm" */ 'calypso/blocks/jitm' );
+
 export class SiteNotice extends Component {
 	static propTypes = {
 		site: PropTypes.object,
@@ -120,11 +123,7 @@ export class SiteNotice extends Component {
 				{ siteRedirectNotice }
 				{ showJitms && (
 					<AsyncLoad
-						require={ () =>
-							import(
-								/* webpackChunkName: "async-load-calypso-blocks-jitm" */ 'calypso/blocks/jitm'
-							)
-						}
+						require={ loadJitm }
 						placeholder={ null }
 						messagePath="calypso:sites:sidebar_notice"
 						template="sidebar-banner"

--- a/client/my-sites/current-site/site-notices.jsx
+++ b/client/my-sites/current-site/site-notices.jsx
@@ -3,6 +3,13 @@ import { useSelector } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
+const loadDomainWarnings = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-my-sites-current-site-domain-warnings" */ './domain-warnings'
+	);
+const loadNotice = () =>
+	import( /* webpackChunkName: "async-load-calypso-my-sites-current-site-notice" */ './notice' );
+
 /**
  * SiteNotices component that renders all the notices related to a site
  * This includes domain warnings, site notices, and stale cart items
@@ -17,25 +24,10 @@ function SiteNotices() {
 	return (
 		<>
 			{ isEnabled( 'current-site/domain-warning' ) && (
-				<AsyncLoad
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-my-sites-current-site-domain-warnings" */ './domain-warnings'
-						)
-					}
-					placeholder={ null }
-				/>
+				<AsyncLoad require={ loadDomainWarnings } placeholder={ null } />
 			) }
 			{ isEnabled( 'current-site/notice' ) && (
-				<AsyncLoad
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-my-sites-current-site-notice" */ './notice'
-						)
-					}
-					placeholder={ null }
-					site={ selectedSite }
-				/>
+				<AsyncLoad require={ loadNotice } placeholder={ null } site={ selectedSite } />
 			) }
 		</>
 	);

--- a/client/my-sites/customer-home/components/home-content/index.jsx
+++ b/client/my-sites/customer-home/components/home-content/index.jsx
@@ -54,6 +54,11 @@ import openSyncUrlInStudio from './studio-deeplink';
 
 import './style.scss';
 
+const loadTrackResurrections = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-lib-analytics-track-resurrections" */ 'calypso/lib/analytics/track-resurrections'
+	);
+
 const HomeContent = ( {
 	canUserUseCustomerHome,
 	hasWooCommerceInstalled,
@@ -336,14 +341,7 @@ const HomeContent = ( {
 				</>
 			) : null }
 			<ResurrectedWelcomeModalGate isSuppressed={ celebrateLaunchModalIsOpen } />
-			<AsyncLoad
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-lib-analytics-track-resurrections" */ 'calypso/lib/analytics/track-resurrections'
-					)
-				}
-				placeholder={ null }
-			/>
+			<AsyncLoad require={ loadTrackResurrections } placeholder={ null } />
 		</div>
 	);
 };

--- a/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
@@ -10,6 +10,11 @@ import { useDIFMHeading } from './use-difm-heading';
 
 import './difm-landing.scss';
 
+const loadSiteBuildShowcase = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-my-sites-marketing-do-it-for-me-site-build-showcase" */ './site-build-showcase'
+	);
+
 const Wrapper = styled.div`
 	display: flex;
 	align-items: flex-start;
@@ -134,11 +139,7 @@ export default function DIFMLanding( {
 				</ContentSection>
 				<ImageSection>
 					<AsyncLoad
-						require={ () =>
-							import(
-								/* webpackChunkName: "async-load-calypso-my-sites-marketing-do-it-for-me-site-build-showcase" */ './site-build-showcase'
-							)
-						}
+						require={ loadSiteBuildShowcase }
 						placeholder={ <LoadingEllipsis /> }
 						isStoreFlow={ isStoreFlow }
 					/>

--- a/client/my-sites/navigation/index.jsx
+++ b/client/my-sites/navigation/index.jsx
@@ -12,6 +12,15 @@ import { getSidebarType, SidebarType } from 'calypso/state/global-sidebar/select
 import { getSiteDomain } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
+const loadManageSelectedSite = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-jetpack-cloud-sections-sidebar-navigation-manage-selected-site" */ 'calypso/jetpack-cloud/sections/sidebar-navigation/manage-selected-site'
+	);
+const loadSidebar = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-my-sites-sidebar" */ 'calypso/my-sites/sidebar'
+	);
+
 class MySitesNavigation extends Component {
 	static displayName = 'MySitesNavigation';
 
@@ -33,29 +42,11 @@ class MySitesNavigation extends Component {
 		let asyncSidebar = null;
 
 		if ( config.isEnabled( 'jetpack-cloud' ) ) {
-			asyncSidebar = (
-				<AsyncLoad
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-jetpack-cloud-sections-sidebar-navigation-manage-selected-site" */ 'calypso/jetpack-cloud/sections/sidebar-navigation/manage-selected-site'
-						)
-					}
-					{ ...asyncProps }
-				/>
-			);
+			asyncSidebar = <AsyncLoad require={ loadManageSelectedSite } { ...asyncProps } />;
 		} else if ( this.props.isGlobalSidebarVisible ) {
 			return this.renderGlobalSidebar();
 		} else {
-			asyncSidebar = (
-				<AsyncLoad
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-my-sites-sidebar" */ 'calypso/my-sites/sidebar'
-						)
-					}
-					{ ...asyncProps }
-				/>
-			);
+			asyncSidebar = <AsyncLoad require={ loadSidebar } { ...asyncProps } />;
 		}
 
 		return <div className="my-sites__navigation">{ asyncSidebar }</div>;

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -67,6 +67,11 @@ import TrialCurrentPlan from './trials/trial-current-plan';
 
 import './style.scss';
 
+const loadProductPurchaseFeaturesList = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-blocks-product-purchase-features-list" */ 'calypso/blocks/product-purchase-features-list'
+	);
+
 class CurrentPlan extends Component {
 	state = {
 		hideThankYouModal: false,
@@ -188,11 +193,7 @@ class CurrentPlan extends Component {
 					<h1 className="current-plan__header-heading">{ planFeaturesHeader }</h1>
 				</div>
 				<AsyncLoad
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-blocks-product-purchase-features-list" */ 'calypso/blocks/product-purchase-features-list'
-						)
-					}
+					require={ loadProductPurchaseFeaturesList }
 					placeholder={ null }
 					plan={ currentPlanSlug }
 					isPlaceholder={ isLoading }

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -15,6 +15,9 @@ import { PluginsBrowserListVariant } from './types';
 
 import './style.scss';
 
+const loadJitm = () =>
+	import( /* webpackChunkName: "async-load-calypso-blocks-jitm" */ 'calypso/blocks/jitm' );
+
 const DEFAULT_PLACEHOLDER_NUMBER = 6;
 const DEFAULT_CAROUSEL_PAGE_SIZE = 3;
 
@@ -213,9 +216,7 @@ const PluginsBrowserList = ( {
 			) }
 			{ listName === 'paid' && (
 				<AsyncLoad
-					require={ () =>
-						import( /* webpackChunkName: "async-load-calypso-blocks-jitm" */ 'calypso/blocks/jitm' )
-					}
+					require={ loadJitm }
 					template="spotlight"
 					placeholder={ null }
 					messagePath="calypso:plugins:spotlight"
@@ -223,9 +224,7 @@ const PluginsBrowserList = ( {
 			) }
 			{ listType === 'search' && (
 				<AsyncLoad
-					require={ () =>
-						import( /* webpackChunkName: "async-load-calypso-blocks-jitm" */ 'calypso/blocks/jitm' )
-					}
+					require={ loadJitm }
 					template="spotlight"
 					jitmPlaceholder={ SpotlightPlaceholder }
 					messagePath="calypso:plugins:search"
@@ -234,9 +233,7 @@ const PluginsBrowserList = ( {
 			) }
 			{ listType === 'browse' && (
 				<AsyncLoad
-					require={ () =>
-						import( /* webpackChunkName: "async-load-calypso-blocks-jitm" */ 'calypso/blocks/jitm' )
-					}
+					require={ loadJitm }
 					template="spotlight"
 					jitmPlaceholder={ SpotlightPlaceholder }
 					messagePath={ `calypso:${ sectionJitmPath }:spotlight` }

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -26,6 +26,11 @@ import 'calypso/state/admin-menu/init';
 
 import './style.scss';
 
+const loadNotice = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-my-sites-current-site-notice" */ 'calypso/my-sites/current-site/notice'
+	);
+
 export const MySitesSidebarUnified = ( { path, isUnifiedSiteSidebarVisible } ) => {
 	const menuItems = useSiteMenuItems();
 	const isAllDomainsView = useDomainsViewStatus();
@@ -47,15 +52,7 @@ export const MySitesSidebarUnified = ( { path, isUnifiedSiteSidebarVisible } ) =
 			<Sidebar>
 				{ isUnifiedSiteSidebarVisible && selectedSite && ! isAllDomainsView && (
 					<SidebarRegion>
-						<AsyncLoad
-							require={ () =>
-								import(
-									/* webpackChunkName: "async-load-calypso-my-sites-current-site-notice" */ 'calypso/my-sites/current-site/notice'
-								)
-							}
-							placeholder={ null }
-							site={ selectedSite }
-						/>
+						<AsyncLoad require={ loadNotice } placeholder={ null } site={ selectedSite } />
 					</SidebarRegion>
 				) }
 				{ ! isUnifiedSiteSidebarVisible && (

--- a/client/my-sites/site-settings/podcast-cover-image-setting/index.jsx
+++ b/client/my-sites/site-settings/podcast-cover-image-setting/index.jsx
@@ -29,6 +29,11 @@ import './style.scss';
 
 const debug = debugModule( 'calypso:podcast-image' );
 
+const loadMediaModal = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-post-editor-media-modal" */ 'calypso/post-editor/media-modal'
+	);
+
 class PodcastCoverImageSetting extends PureComponent {
 	static propTypes = {
 		coverImageId: PropTypes.number,
@@ -151,9 +156,7 @@ class PodcastCoverImageSetting extends PureComponent {
 	}
 
 	preloadModal() {
-		import(
-			/* webpackChunkName: "async-load-calypso-post-editor-media-modal" */ 'calypso/post-editor/media-modal'
-		);
+		loadMediaModal();
 	}
 
 	renderChangeButton() {
@@ -215,11 +218,7 @@ class PodcastCoverImageSetting extends PureComponent {
 		return (
 			hasToggledModal && (
 				<AsyncLoad
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-post-editor-media-modal" */ 'calypso/post-editor/media-modal'
-						)
-					}
+					require={ loadMediaModal }
 					placeholder={ <EditorMediaModalDialog isVisible /> }
 					siteId={ siteId }
 					onClose={ this.editSelectedMedia }

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -18,6 +18,21 @@ import StatsEmailSummary from './stats-email-summary';
 import StatsPageLoader from './stats-page-loader';
 import { appendQueryStringForRedirection } from './utils';
 
+const loadOverview = () =>
+	import( /* webpackChunkName: "async-load-calypso-my-sites-stats-overview" */ './overview' );
+const loadSummary = () =>
+	import( /* webpackChunkName: "async-load-calypso-my-sites-stats-summary" */ './summary' );
+const loadStatsPostDetail = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-my-sites-stats-stats-post-detail" */ './stats-post-detail'
+	);
+const loadCommentFollows = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-my-sites-stats-comment-follows" */ './comment-follows'
+	);
+const loadWordads = () =>
+	import( /* webpackChunkName: "async-load-calypso-my-sites-stats-wordads" */ './wordads' );
+
 function getNumPeriodAgo( momentSiteZone, date, period ) {
 	const endOfCurrentPeriod = momentSiteZone.endOf( period );
 	const durationAgo = moment.duration( endOfCurrentPeriod.diff( date ) );
@@ -148,12 +163,7 @@ export function overview( context, next ) {
 		siteId !== null ? (
 			<StatsPageLoader>
 				<AsyncLoad
-					key="stats-overview"
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-my-sites-stats-overview" */ './overview'
-						)
-					}
+					require={ loadOverview }
 					placeholder={ PageLoading }
 					period={ activeFilter.period }
 					path={ context.pathname }
@@ -161,12 +171,7 @@ export function overview( context, next ) {
 			</StatsPageLoader>
 		) : (
 			<AsyncLoad
-				key="stats-overview"
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-my-sites-stats-overview" */ './overview'
-					)
-				}
+				require={ loadOverview }
 				placeholder={ PageLoading }
 				period={ activeFilter.period }
 				path={ context.pathname }
@@ -317,10 +322,7 @@ export function summary( context, next ) {
 	context.primary = (
 		<StatsPageLoader>
 			<AsyncLoad
-				key="stats-summary"
-				require={ () =>
-					import( /* webpackChunkName: "async-load-calypso-my-sites-stats-summary" */ './summary' )
-				}
+				require={ loadSummary }
 				placeholder={ PageLoading }
 				path={ context.pathname }
 				statsQueryOptions={ statsQueryOptions }
@@ -350,12 +352,7 @@ export function post( context, next ) {
 	context.primary = (
 		<StatsPageLoader>
 			<AsyncLoad
-				key="stats-post-detail"
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-my-sites-stats-stats-post-detail" */ './stats-post-detail'
-					)
-				}
+				require={ loadStatsPostDetail }
 				placeholder={ PageLoading }
 				path={ context.path }
 				postId={ postId }
@@ -393,12 +390,7 @@ export function follows( context, next ) {
 	context.primary = (
 		<StatsPageLoader>
 			<AsyncLoad
-				key="stats-comment-follows"
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-my-sites-stats-comment-follows" */ './comment-follows'
-					)
-				}
+				require={ loadCommentFollows }
 				placeholder={ PageLoading }
 				path={ context.path }
 				page={ pageNum }
@@ -444,10 +436,7 @@ export function wordAds( context, next ) {
 
 	context.primary = (
 		<AsyncLoad
-			key="stats-wordads"
-			require={ () =>
-				import( /* webpackChunkName: "async-load-calypso-my-sites-stats-wordads" */ './wordads' )
-			}
+			require={ loadWordads }
 			placeholder={ PageLoading }
 			path={ context.pathname }
 			date={ date }

--- a/client/my-sites/stats/pages/insights/controller.tsx
+++ b/client/my-sites/stats/pages/insights/controller.tsx
@@ -2,21 +2,14 @@ import AsyncLoad from 'calypso/components/async-load';
 import PageLoading from '../shared/page-loading';
 import type { Context } from '@automattic/calypso-router';
 
-setTimeout(
-	() => import( /* webpackChunkName: "async-load-calypso-my-sites-stats-pages-insights" */ '.' ),
-	3000
-);
+const loadInsights = () =>
+	import( /* webpackChunkName: "async-load-calypso-my-sites-stats-pages-insights" */ '.' );
+
+setTimeout( loadInsights, 3000 );
 
 function insights( context: Context, next: () => void ) {
 	context.primary = (
-		<AsyncLoad
-			key="stats-pagesinsights"
-			require={ () =>
-				import( /* webpackChunkName: "async-load-calypso-my-sites-stats-pages-insights" */ '.' )
-			}
-			placeholder={ PageLoading }
-			context={ context }
-		/>
+		<AsyncLoad require={ loadInsights } placeholder={ PageLoading } context={ context } />
 	);
 	next();
 }

--- a/client/my-sites/stats/pages/purchase/controller.tsx
+++ b/client/my-sites/stats/pages/purchase/controller.tsx
@@ -2,18 +2,14 @@ import AsyncLoad from 'calypso/components/async-load';
 import PageLoading from '../shared/page-loading';
 import type { Context } from '@automattic/calypso-router';
 
+const loadPurchase = () =>
+	import( /* webpackChunkName: "async-load-calypso-my-sites-stats-pages-purchase" */ '.' );
+
 function purchase( context: Context, next: () => void ) {
 	context.primary = (
 		// DO NOT WRAP WITH <StatsPageLoader />
 		// Or the site-less purchase flow will not work because there is no permission to access Stats.
-		<AsyncLoad
-			key="stats-pages-purchase"
-			require={ () =>
-				import( /* webpackChunkName: "async-load-calypso-my-sites-stats-pages-purchase" */ '.' )
-			}
-			placeholder={ PageLoading }
-			query={ context.query }
-		/>
+		<AsyncLoad require={ loadPurchase } placeholder={ PageLoading } query={ context.query } />
 	);
 	next();
 }

--- a/client/my-sites/stats/pages/realtime/controller.tsx
+++ b/client/my-sites/stats/pages/realtime/controller.tsx
@@ -2,21 +2,14 @@ import AsyncLoad from 'calypso/components/async-load';
 import PageLoading from '../shared/page-loading';
 import type { Context } from '@automattic/calypso-router';
 
-setTimeout(
-	() => import( /* webpackChunkName: "async-load-calypso-my-sites-stats-pages-realtime" */ '.' ),
-	3000
-);
+const loadRealtime = () =>
+	import( /* webpackChunkName: "async-load-calypso-my-sites-stats-pages-realtime" */ '.' );
+
+setTimeout( loadRealtime, 3000 );
 
 function realtime( context: Context, next: () => void ) {
 	context.primary = (
-		<AsyncLoad
-			key="stats-pages-realtime"
-			require={ () =>
-				import( /* webpackChunkName: "async-load-calypso-my-sites-stats-pages-realtime" */ '.' )
-			}
-			placeholder={ PageLoading }
-			context={ context }
-		/>
+		<AsyncLoad require={ loadRealtime } placeholder={ PageLoading } context={ context } />
 	);
 	next();
 }

--- a/client/my-sites/stats/pages/realtime/index.jsx
+++ b/client/my-sites/stats/pages/realtime/index.jsx
@@ -21,6 +21,11 @@ import StatsModuleListing from '../shared/stats-module-listing';
 
 import './style.scss';
 
+const loadChart = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-my-sites-stats-pages-realtime-chart" */ 'calypso/my-sites/stats/pages/realtime/chart'
+	);
+
 // TODO: Update header per design review.
 // Each page has slightly different headers so staying simple
 // and requesting feedback first.
@@ -119,15 +124,7 @@ function StatsRealtime( { context } ) {
 			<PageViewTracker path="/stats/realtime/:site" title="Stats > Realtime" />
 			<div className="stats">
 				<StatsRealtimeHeader />
-				<AsyncLoad
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-my-sites-stats-pages-realtime-chart" */ 'calypso/my-sites/stats/pages/realtime/chart'
-						)
-					}
-					siteId={ siteId }
-					placeholder={ PageLoading }
-				/>
+				<AsyncLoad require={ loadChart } siteId={ siteId } placeholder={ PageLoading } />
 				<StatsModuleListing className="stats__module-list--insights" siteId={ siteId }>
 					<StatsModuleTopPosts
 						moduleStrings={ moduleStrings.posts }

--- a/client/my-sites/stats/pages/subscribers/controller.tsx
+++ b/client/my-sites/stats/pages/subscribers/controller.tsx
@@ -5,10 +5,10 @@ import { getSiteFilters, rangeOfPeriod, type SiteFilterType } from '../shared/he
 import PageLoading from '../shared/page-loading';
 import type { Context } from '@automattic/calypso-router';
 
-setTimeout(
-	() => import( /* webpackChunkName: "async-load-calypso-my-sites-stats-pages-subscribers" */ '.' ),
-	3000
-);
+const loadSubscribers = () =>
+	import( /* webpackChunkName: "async-load-calypso-my-sites-stats-pages-subscribers" */ '.' );
+
+setTimeout( loadSubscribers, 3000 );
 
 function subscribers( context: Context, next: () => void ) {
 	const givenSiteId = context.params.site;
@@ -26,10 +26,7 @@ function subscribers( context: Context, next: () => void ) {
 
 	context.primary = (
 		<AsyncLoad
-			key="stats-pages-subscribers"
-			require={ () =>
-				import( /* webpackChunkName: "async-load-calypso-my-sites-stats-pages-subscribers" */ '.' )
-			}
+			require={ loadSubscribers }
 			placeholder={ PageLoading }
 			period={ rangeOfPeriod( activeFilter?.period || 'day', date ) }
 			context={ context }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -84,6 +84,15 @@ import StatsPlanUsage from './stats-plan-usage';
 import StatsUpsell from './stats-upsell/traffic-upsell';
 import { appendQueryStringForRedirection, getPathWithUpdatedQueryString } from './utils';
 
+const loadJetpackUpsellSection = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-my-sites-stats-jetpack-upsell-section" */ 'calypso/my-sites/stats/jetpack-upsell-section'
+	);
+const loadTrackResurrections = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-lib-analytics-track-resurrections" */ 'calypso/lib/analytics/track-resurrections'
+	);
+
 // Sync hidable modules with StatsNavigation.
 const HIDDABLE_MODULES = AVAILABLE_PAGE_MODULES.traffic.map( ( module ) => {
 	return module.key;
@@ -796,27 +805,12 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 			{ supportsPlanUsage && (
 				<StatsPlanUsage siteId={ siteId } isOdysseyStats={ isOdysseyStats } />
 			) }
-			{ ! shouldShowUpsells ? null : (
-				<AsyncLoad
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-my-sites-stats-jetpack-upsell-section" */ 'calypso/my-sites/stats/jetpack-upsell-section'
-						)
-					}
-				/>
-			) }
+			{ ! shouldShowUpsells ? null : <AsyncLoad require={ loadJetpackUpsellSection } /> }
 			{ ! wpcomShowUpsell && (
 				<PromoCards isOdysseyStats={ isOdysseyStats } pageSlug="traffic" slug={ slug } />
 			) }
 			{ supportUserFeedback && <StatsFeedbackPresentor siteId={ siteId } /> }
-			<AsyncLoad
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-lib-analytics-track-resurrections" */ 'calypso/lib/analytics/track-resurrections'
-					)
-				}
-				placeholder={ null }
-			/>
+			<AsyncLoad require={ loadTrackResurrections } placeholder={ null } />
 		</div>
 	);
 }

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -28,6 +28,11 @@ import { buildChartData, getQueryDate, transformChartDataToLineFormat } from './
 
 import './style.scss';
 
+const loadLineChart = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-my-sites-stats-components-line-chart" */ 'calypso/my-sites/stats/components/line-chart'
+	);
+
 const ChartTabShape = PropTypes.shape( {
 	attr: PropTypes.string,
 	gridicon: PropTypes.string,
@@ -240,11 +245,7 @@ class StatModuleChartTabs extends Component {
 					)
 				) : (
 					<AsyncLoad
-						require={ () =>
-							import(
-								/* webpackChunkName: "async-load-calypso-my-sites-stats-components-line-chart" */ 'calypso/my-sites/stats/components/line-chart'
-							)
-						}
+						require={ loadLineChart }
 						className="stats-chart-tabs__line-chart"
 						chartData={ lineChartData }
 						curveType="monotone" // can use smooth, linear, monotone

--- a/client/my-sites/stats/stats-notices/jitm-wrapper.tsx
+++ b/client/my-sites/stats/stats-notices/jitm-wrapper.tsx
@@ -4,6 +4,9 @@ import { useSelector } from 'calypso/state';
 import { getTopJITM } from 'calypso/state/jitm/selectors';
 import { StatsNoticeProps } from './types';
 
+const loadJitm = () =>
+	import( /* webpackChunkName: "async-load-calypso-blocks-jitm" */ 'calypso/blocks/jitm' );
+
 const JITMWrapper: React.FC< StatsNoticeProps > = ( { isOdysseyStats } ) => {
 	const messagePath = isOdysseyStats
 		? 'wp:jetpack_page_stats:admin_notices'
@@ -18,9 +21,7 @@ const JITMWrapper: React.FC< StatsNoticeProps > = ( { isOdysseyStats } ) => {
 			} ) }
 		>
 			<AsyncLoad
-				require={ () =>
-					import( /* webpackChunkName: "async-load-calypso-blocks-jitm" */ 'calypso/blocks/jitm' )
-				}
+				require={ loadJitm }
 				placeholder={ null }
 				messagePath={ messagePath }
 				searchQuery="page%3Dstats"

--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -19,6 +19,11 @@ import SubscribersNavigationArrows from './subscribers-navigation-arrows';
 import type uPlot from 'uplot';
 
 import './style.scss';
+const loadLineChart = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-my-sites-stats-components-line-chart" */ 'calypso/my-sites/stats/components/line-chart'
+	);
+
 interface SubscribersData {
 	period: PeriodType;
 	subscribers: number;
@@ -277,11 +282,7 @@ export default function SubscribersChartSection( {
 					<div className="subscribers-section-legend" ref={ legendRef }></div>
 					{ isChartLibraryEnabled ? (
 						<AsyncLoad
-							require={ () =>
-								import(
-									/* webpackChunkName: "async-load-calypso-my-sites-stats-components-line-chart" */ 'calypso/my-sites/stats/components/line-chart'
-								)
-							}
+							require={ loadLineChart }
 							chartData={ lineChartData }
 							height={ 300 }
 							curveType="monotone" // can use smooth, linear, monotone

--- a/client/my-sites/store/app/store-stats/controller.js
+++ b/client/my-sites/store/app/store-stats/controller.js
@@ -8,6 +8,13 @@ import StatsPagePlaceholder from 'calypso/my-sites/stats/stats-page-placeholder'
 import { recordTrack } from '../../lib/analytics';
 import { getQueryDate } from './utils';
 
+const loadStoreStats = () =>
+	import( /* webpackChunkName: "async-load-calypso-my-sites-store-app-store-stats" */ '.' );
+const loadListView = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-my-sites-store-app-store-stats-listview" */ './listview'
+	);
+
 function isValidParameters( context ) {
 	const validParameters = {
 		type: [ 'orders', 'products', 'categories', 'coupons' ],
@@ -72,30 +79,12 @@ export default function StatsController( context, next ) {
 	switch ( props.type ) {
 		case 'orders':
 			asyncComponent = (
-				<AsyncLoad
-					key="store-app-store-stats"
-					placeholder={ placeholder }
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-my-sites-store-app-store-stats" */ '.'
-						)
-					}
-					{ ...props }
-				/>
+				<AsyncLoad placeholder={ placeholder } require={ loadStoreStats } { ...props } />
 			);
 			break;
 		default:
 			asyncComponent = (
-				<AsyncLoad
-					key="store-app-store-stats-listview"
-					placeholder={ placeholder }
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-my-sites-store-app-store-stats-listview" */ './listview'
-						)
-					}
-					{ ...props }
-				/>
+				<AsyncLoad placeholder={ placeholder } require={ loadListView } { ...props } />
 			);
 			break;
 	}

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -128,6 +128,13 @@ import ThemeSupportTab from './theme-support-tab';
 
 import './style.scss';
 
+const loadJitm = () =>
+	import( /* webpackChunkName: "async-load-calypso-blocks-jitm" */ 'calypso/blocks/jitm' );
+const loadGlobalNotices = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-components-global-notices" */ 'calypso/components/global-notices'
+	);
+
 const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
 	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 	'@wordpress/components'
@@ -611,11 +618,7 @@ class ThemeSheet extends Component {
 			<div className="theme__sheet-content">
 				{ config.isEnabled( 'jitms' ) && this.props.siteSlug && (
 					<AsyncLoad
-						require={ () =>
-							import(
-								/* webpackChunkName: "async-load-calypso-blocks-jitm" */ 'calypso/blocks/jitm'
-							)
-						}
+						require={ loadJitm }
 						placeholder={ null }
 						messagePath="calypso:theme:admin_notices"
 					/>
@@ -1250,15 +1253,7 @@ class ThemeSheet extends Component {
 					title={ analyticsPageTitle }
 					properties={ { is_logged_in: isLoggedIn } }
 				/>
-				<AsyncLoad
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-components-global-notices" */ 'calypso/components/global-notices'
-						)
-					}
-					placeholder={ null }
-					id="notices"
-				/>
+				<AsyncLoad require={ loadGlobalNotices } placeholder={ null } id="notices" />
 				{
 					siteId && (
 						<QueryActiveTheme siteId={ siteId } />

--- a/client/my-sites/theme/theme-style-variations/index.tsx
+++ b/client/my-sites/theme/theme-style-variations/index.tsx
@@ -3,6 +3,11 @@ import { useSiteGlobalStylesOnPersonal } from 'calypso/state/sites/hooks/use-sit
 import type { StyleVariation } from '@automattic/design-picker';
 import './style.scss';
 
+const loadGlobalStylesVariations = () =>
+	import(
+		/* webpackChunkName: "async-load-automattic-global-styles-src-components-global-styles-variations" */ '@automattic/global-styles/src/components/global-styles-variations'
+	);
+
 interface ThemeStyleVariationsProps {
 	selectedVariation: StyleVariation;
 	variations: StyleVariation[];
@@ -23,11 +28,7 @@ const ThemeStyleVariations = ( {
 		<div className="theme__sheet-style-variations">
 			<div className="theme__sheet-style-variations-previews">
 				<AsyncLoad
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-automattic-global-styles-src-components-global-styles-variations" */ '@automattic/global-styles/src/components/global-styles-variations'
-						)
-					}
+					require={ loadGlobalStylesVariations }
 					placeholder={ null }
 					globalStylesVariations={ variations }
 					selectedGlobalStylesVariation={ selectedVariation }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -62,6 +62,9 @@ import ThemesSelection from './themes-selection';
 import ThemesToolbarGroup from './themes-toolbar-group';
 import './theme-showcase.scss';
 
+const loadJitm = () =>
+	import( /* webpackChunkName: "async-load-calypso-blocks-jitm" */ 'calypso/blocks/jitm' );
+
 const optionShape = PropTypes.shape( {
 	label: PropTypes.string,
 	header: PropTypes.string,
@@ -517,9 +520,7 @@ class ThemeShowcase extends Component {
 		if ( config.isEnabled( 'jitms' ) && ! loggedOutComponent ) {
 			return (
 				<AsyncLoad
-					require={ () =>
-						import( /* webpackChunkName: "async-load-calypso-blocks-jitm" */ 'calypso/blocks/jitm' )
-					}
+					require={ loadJitm }
 					placeholder={ null }
 					messagePath="calypso:themes:showcase-website-design"
 				/>

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -74,6 +74,11 @@ import './style.scss';
 
 const debug = debugFactory( 'calypso:themes:theme-upload' );
 
+const loadUploadDropZone = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-blocks-upload-drop-zone" */ 'calypso/blocks/upload-drop-zone'
+	);
+
 class Upload extends Component {
 	static propTypes = {
 		siteId: PropTypes.number,
@@ -288,11 +293,7 @@ class Upload extends Component {
 				<Card>
 					{ ! inProgress && ! complete && (
 						<AsyncLoad
-							require={ () =>
-								import(
-									/* webpackChunkName: "async-load-calypso-blocks-upload-drop-zone" */ 'calypso/blocks/upload-drop-zone'
-								)
-							}
+							require={ loadUploadDropZone }
 							placeholder={ null }
 							doUpload={ uploadAction }
 							disabled={ isDisabled }

--- a/client/reader/atmosphere/controller.tsx
+++ b/client/reader/atmosphere/controller.tsx
@@ -4,6 +4,19 @@ import AsyncLoad from 'calypso/components/async-load';
 import { TIMELINE_TAB } from './helper';
 import { DID_RE, RKEY_RE } from './route';
 
+const loadAtmosphereLandingView = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-atmosphere-landing-view" */ 'calypso/reader/atmosphere/atmosphere-landing-view'
+	);
+const loadAtmosphereConnectView = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-atmosphere-connect-view" */ 'calypso/reader/atmosphere/atmosphere-connect-view'
+	);
+const loadAtmosphereAccountView = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-atmosphere-account-view" */ 'calypso/reader/atmosphere/atmosphere-account-view'
+	);
+
 function ensureAtmosphereEnabled(): boolean {
 	if ( ! isEnabled( 'reader/social' ) ) {
 		page.redirect( '/reader' );
@@ -16,17 +29,7 @@ export const atmosphereLanding = ( context: Context, next: () => void ) => {
 	if ( ! ensureAtmosphereEnabled() ) {
 		return;
 	}
-	context.primary = (
-		<AsyncLoad
-			key="reader-atmosphere-landing"
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-calypso-reader-atmosphere-landing-view" */ 'calypso/reader/atmosphere/atmosphere-landing-view'
-				)
-			}
-			placeholder={ null }
-		/>
-	);
+	context.primary = <AsyncLoad require={ loadAtmosphereLandingView } placeholder={ null } />;
 	next();
 };
 
@@ -34,17 +37,7 @@ export const atmosphereConnect = ( context: Context, next: () => void ) => {
 	if ( ! ensureAtmosphereEnabled() ) {
 		return;
 	}
-	context.primary = (
-		<AsyncLoad
-			key="reader-atmosphere-connect"
-			require={ () =>
-				/* webpackChunkName: "async-load-calypso-reader-atmosphere-connect-view" */ import(
-					'calypso/reader/atmosphere/atmosphere-connect-view'
-				)
-			}
-			placeholder={ null }
-		/>
-	);
+	context.primary = <AsyncLoad require={ loadAtmosphereConnectView } placeholder={ null } />;
 	next();
 };
 
@@ -68,12 +61,7 @@ export const atmosphereAccount = ( context: Context, next: () => void ) => {
 	const tab = String( context.params.tab ?? '' );
 	context.primary = (
 		<AsyncLoad
-			key="reader-atmosphere-account"
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-calypso-reader-atmosphere-account-view" */ 'calypso/reader/atmosphere/atmosphere-account-view'
-				)
-			}
+			require={ loadAtmosphereAccountView }
 			placeholder={ null }
 			connectionId={ id }
 			tab={ tab }

--- a/client/reader/atmosphere/controller.tsx
+++ b/client/reader/atmosphere/controller.tsx
@@ -16,6 +16,10 @@ const loadAtmosphereAccountView = () =>
 	import(
 		/* webpackChunkName: "async-load-calypso-reader-atmosphere-account-view" */ 'calypso/reader/atmosphere/atmosphere-account-view'
 	);
+const loadAtmosphereThreadView = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-atmosphere-thread-view" */ 'calypso/reader/atmosphere/atmosphere-thread-view'
+	);
 
 function ensureAtmosphereEnabled(): boolean {
 	if ( ! isEnabled( 'reader/social' ) ) {
@@ -89,13 +93,7 @@ export const atmosphereThread = ( context: Context, next: () => void ) => {
 
 	context.primary = (
 		<AsyncLoad
-			key="reader-atmosphere-thread"
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-calypso-reader-atmosphere-thread-view" */
-					'calypso/reader/atmosphere/atmosphere-thread-view'
-				)
-			}
+			require={ loadAtmosphereThreadView }
 			placeholder={ null }
 			connectionId={ id }
 			did={ did }

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -26,6 +26,45 @@ import {
 	getStartDate,
 } from './controller-helper';
 
+const loadSidebar = () =>
+	import( /* webpackChunkName: "async-load-calypso-reader-sidebar" */ 'calypso/reader/sidebar' );
+const loadNewSubscription = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-new-subscription" */ 'calypso/reader/new-subscription'
+	);
+const loadMobileHeader = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-components-mobile-header" */ 'calypso/reader/components/mobile-header'
+	);
+const loadFeedStream = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-feed-stream" */ 'calypso/reader/feed-stream'
+	);
+const loadSiteStream = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-site-stream" */ 'calypso/reader/site-stream'
+	);
+const loadMain = () =>
+	import( /* webpackChunkName: "async-load-calypso-reader-a8c-main" */ 'calypso/reader/a8c/main' );
+const loadP2Main = () =>
+	import( /* webpackChunkName: "async-load-calypso-reader-p2-main" */ 'calypso/reader/p2/main' );
+const loadSiteSubscriptionsManager = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-site-subscriptions-manager" */ 'calypso/reader/site-subscriptions-manager'
+	);
+const loadSiteSubscription = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-site-subscription" */ 'calypso/reader/site-subscription'
+	);
+const loadCommentSubscriptionsManager = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-site-subscriptions-manager-comment-subscriptions-manager" */ 'calypso/reader/site-subscriptions-manager/comment-subscriptions-manager'
+	);
+const loadPendingSubscriptionsManager = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-site-subscriptions-manager-pending-subscriptions-manager" */ 'calypso/reader/site-subscriptions-manager/pending-subscriptions-manager'
+	);
+
 const analyticsPageTitle = 'Reader';
 
 function renderFeedError( context, next ) {
@@ -37,16 +76,7 @@ export function sidebar( context, next ) {
 	const state = context.store.getState();
 	if ( isUserLoggedIn( state ) ) {
 		context.secondary = (
-			<AsyncLoad
-				key="reader-sidebar"
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-reader-sidebar" */ 'calypso/reader/sidebar'
-					)
-				}
-				path={ context.path }
-				placeholder={ null }
-			/>
+			<AsyncLoad require={ loadSidebar } path={ context.path } placeholder={ null } />
 		);
 	}
 
@@ -108,17 +138,7 @@ export function following( context, next ) {
 
 export function loadNewSubscriptionPage( context, next ) {
 	const selectedTab = getCurrentTabFromURL( context.path, 'reader/new', 'add-new' );
-	context.primary = (
-		<AsyncLoad
-			key="reader-new-subscription"
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-calypso-reader-new-subscription" */ 'calypso/reader/new-subscription'
-				)
-			}
-			selectedTab={ selectedTab }
-		/>
-	);
+	context.primary = <AsyncLoad require={ loadNewSubscription } selectedTab={ selectedTab } />;
 
 	trackPageLoad( '/reader/new', 'Reader > New Subscription', 'reader-new-subscription' );
 	next();
@@ -174,16 +194,7 @@ export function feedLookup( context ) {
 export const setBeforePrimary = ( context, next ) => {
 	const state = context.store.getState();
 	const isMSDEnabledForReader = isReaderMSDEnabled( state );
-	context.beforePrimary = isMSDEnabledForReader ? (
-		<AsyncLoad
-			key="reader-mobile-header"
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-calypso-reader-components-mobile-header" */ 'calypso/reader/components/mobile-header'
-				)
-			}
-		/>
-	) : null;
+	context.beforePrimary = isMSDEnabledForReader ? <AsyncLoad require={ loadMobileHeader } /> : null;
 	next();
 };
 
@@ -203,11 +214,7 @@ export function feedListing( context, next ) {
 
 	context.primary = (
 		<AsyncLoad
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-calypso-reader-feed-stream" */ 'calypso/reader/feed-stream'
-				)
-			}
+			require={ loadFeedStream }
 			key={ 'feed-' + feedId }
 			streamKey={ 'feed:' + feedId }
 			feedId={ +feedId }
@@ -240,11 +247,7 @@ export function blogListing( context, next ) {
 
 	context.primary = (
 		<AsyncLoad
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-calypso-reader-site-stream" */ 'calypso/reader/site-stream'
-				)
-			}
+			require={ loadSiteStream }
 			key={ 'site-' + blogId }
 			streamKey={ streamKey }
 			siteId={ +blogId }
@@ -277,12 +280,8 @@ export function readA8C( context, next ) {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	context.primary = (
 		<AsyncLoad
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-calypso-reader-a8c-main" */ 'calypso/reader/a8c/main'
-				)
-			}
-			key="reader-a8c"
+			require={ loadMain }
+			key="read-a8c"
 			className="is-a8c"
 			listName="Automattic"
 			streamKey={ streamKey }
@@ -316,12 +315,8 @@ export function readFollowingP2( context, next ) {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	context.primary = (
 		<AsyncLoad
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-calypso-reader-p2-main" */ 'calypso/reader/p2/main'
-				)
-			}
-			key="reader-p2"
+			require={ loadP2Main }
+			key="read-p2"
 			listName="P2"
 			streamKey={ streamKey }
 			startDate={ startDate }
@@ -372,16 +367,7 @@ export async function siteSubscriptionsManager( context, next ) {
 	const mcKey = 'subscription-sites';
 	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 
-	context.primary = (
-		<AsyncLoad
-			key="reader-site-subscriptions-manager"
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-calypso-reader-site-subscriptions-manager" */ 'calypso/reader/site-subscriptions-manager'
-				)
-			}
-		/>
-	);
+	context.primary = <AsyncLoad require={ loadSiteSubscriptionsManager } />;
 	next();
 }
 
@@ -404,12 +390,7 @@ export async function siteSubscription( context, next ) {
 
 	context.primary = (
 		<AsyncLoad
-			key="reader-site-subscription"
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-calypso-reader-site-subscription" */ 'calypso/reader/site-subscription'
-				)
-			}
+			require={ loadSiteSubscription }
 			subscriptionId={ context.params.subscription_id }
 			blogId={ context.params.blog_id }
 			transition={ context.query.transition === 'true' }
@@ -424,16 +405,7 @@ export async function commentSubscriptionsManager( context, next ) {
 	const mcKey = 'subscription-comments';
 	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 
-	context.primary = (
-		<AsyncLoad
-			key="reader-comment-subscriptions-manager"
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-calypso-reader-site-subscriptions-manager-comment-subscriptions-manager" */ 'calypso/reader/site-subscriptions-manager/comment-subscriptions-manager'
-				)
-			}
-		/>
-	);
+	context.primary = <AsyncLoad require={ loadCommentSubscriptionsManager } />;
 	next();
 }
 
@@ -443,16 +415,7 @@ export async function pendingSubscriptionsManager( context, next ) {
 	const mcKey = 'subscription-pending';
 	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 
-	context.primary = (
-		<AsyncLoad
-			key="reader-pending-subscriptions-manager"
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-calypso-reader-site-subscriptions-manager-pending-subscriptions-manager" */ 'calypso/reader/site-subscriptions-manager/pending-subscriptions-manager'
-				)
-			}
-		/>
-	);
+	context.primary = <AsyncLoad require={ loadPendingSubscriptionsManager } />;
 	next();
 }
 

--- a/client/reader/conversations/controller.js
+++ b/client/reader/conversations/controller.js
@@ -4,6 +4,11 @@ import { trackPageLoad, trackScrollPage } from 'calypso/reader/controller-helper
 import { recordTrack } from 'calypso/reader/stats';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 
+const loadStream = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-conversations-stream" */ 'calypso/reader/conversations/stream'
+	);
+
 export function conversations( context, next ) {
 	const basePath = sectionify( context.path );
 	const mcKey = 'conversations';
@@ -28,12 +33,8 @@ export function conversations( context, next ) {
 
 	context.primary = (
 		<AsyncLoad
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-calypso-reader-conversations-stream" */ 'calypso/reader/conversations/stream'
-				)
-			}
-			key="reader-conversations"
+			require={ loadStream }
+			key="conversations"
 			streamKey={ streamKey }
 			trackScrollPage={ scrollTracker }
 		/>
@@ -66,12 +67,8 @@ export function conversationsA8c( context, next ) {
 
 	context.primary = (
 		<AsyncLoad
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-calypso-reader-conversations-stream" */ 'calypso/reader/conversations/stream'
-				)
-			}
-			key="reader-conversations-a8c"
+			require={ loadStream }
+			key="conversations"
 			title="Conversations @ Automattic"
 			streamKey={ streamKey }
 			store={ { id: streamKey } }

--- a/client/reader/discover/index.web.js
+++ b/client/reader/discover/index.web.js
@@ -25,6 +25,11 @@ import { DiscoverDocumentHead } from './discover-document-head';
 import { FRESHLY_PRESSED_TAB } from './helper';
 import { getPrivateRoutes, getDiscoverRoutes, DISCOVER_PREFIX } from './routes';
 
+const loadDiscoverStream = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-discover-discover-stream" */ 'calypso/reader/discover/discover-stream'
+	);
+
 const ANALYTICS_PAGE_TITLE = 'Reader';
 
 const discover = ( context, next ) => {
@@ -52,11 +57,7 @@ const discover = ( context, next ) => {
 		<>
 			<DiscoverDocumentHead />
 			<AsyncLoad
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-reader-discover-discover-stream" */ 'calypso/reader/discover/discover-stream'
-					)
-				}
+				require={ loadDiscoverStream }
 				key="discover-page"
 				streamKey={ streamKey }
 				title="Discover"

--- a/client/reader/following/main.tsx
+++ b/client/reader/following/main.tsx
@@ -18,6 +18,15 @@ import { useFollowingView } from './view-preference';
 import ViewToggle from './view-toggle';
 import './style.scss';
 
+const loadQuickPost = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-components-quick-post" */ 'calypso/reader/components/quick-post'
+	);
+const loadTrackResurrections = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-lib-analytics-track-resurrections" */ 'calypso/lib/analytics/track-resurrections'
+	);
+
 function FollowingStream( { ...props } ) {
 	const { currentView } = useFollowingView();
 	const dispatch = useDispatch();
@@ -76,14 +85,7 @@ function FollowingStream( { ...props } ) {
 					{ hasSites && (
 						<Card className="following-stream__quick-post-card">
 							<CardBody>
-								<AsyncLoad
-									require={ () =>
-										import(
-											/* webpackChunkName: "async-load-calypso-reader-components-quick-post" */ 'calypso/reader/components/quick-post'
-										)
-									}
-									placeholder={ <QuickPostSkeleton /> }
-								/>
+								<AsyncLoad require={ loadQuickPost } placeholder={ <QuickPostSkeleton /> } />
 							</CardBody>
 						</Card>
 					) }
@@ -94,14 +96,7 @@ function FollowingStream( { ...props } ) {
 				</ReaderStream>
 			) }
 			<ResurrectedWelcomeModalGate onVisibilityChange={ setIsResurrectedModalVisible } />
-			<AsyncLoad
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-lib-analytics-track-resurrections" */ 'calypso/lib/analytics/track-resurrections'
-					)
-				}
-				placeholder={ null }
-			/>
+			<AsyncLoad require={ loadTrackResurrections } placeholder={ null } />
 		</>
 	);
 }

--- a/client/reader/full-post/controller.js
+++ b/client/reader/full-post/controller.js
@@ -3,6 +3,13 @@ import AsyncLoad from 'calypso/components/async-load';
 import { trackPageLoad } from 'calypso/reader/controller-helper';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
+const loadReaderFullPost = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-blocks-reader-full-post" */ 'calypso/blocks/reader-full-post'
+	);
+const loadSidebar = () =>
+	import( /* webpackChunkName: "async-load-calypso-reader-sidebar" */ 'calypso/reader/sidebar' );
+
 const analyticsPageTitle = 'Reader';
 
 const scrollTopIfNoHash = () =>
@@ -27,12 +34,7 @@ export function blogPost( context, next ) {
 
 	context.primary = (
 		<AsyncLoad
-			key="reader-blog-post"
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-calypso-blocks-reader-full-post" */ 'calypso/blocks/reader-full-post'
-				)
-			}
+			require={ loadReaderFullPost }
 			blogId={ blogId }
 			postId={ postId }
 			referral={ referral }
@@ -41,16 +43,7 @@ export function blogPost( context, next ) {
 
 	if ( isUserLoggedIn( state ) ) {
 		context.secondary = (
-			<AsyncLoad
-				key="reader-sidebar"
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-reader-sidebar" */ 'calypso/reader/sidebar'
-					)
-				}
-				path={ context.path }
-				placeholder={ null }
-			/>
+			<AsyncLoad require={ loadSidebar } path={ context.path } placeholder={ null } />
 		);
 	}
 	scrollTopIfNoHash();
@@ -67,30 +60,12 @@ export function feedPost( context, next ) {
 	trackPageLoad( basePath, fullPageTitle, 'full_post' );
 
 	context.primary = (
-		<AsyncLoad
-			key="reader-feed-post"
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-calypso-blocks-reader-full-post" */ 'calypso/blocks/reader-full-post'
-				)
-			}
-			feedId={ feedId }
-			postId={ postId }
-		/>
+		<AsyncLoad require={ loadReaderFullPost } feedId={ feedId } postId={ postId } />
 	);
 
 	if ( isUserLoggedIn( state ) ) {
 		context.secondary = (
-			<AsyncLoad
-				key="reader-sidebar"
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-reader-sidebar" */ 'calypso/reader/sidebar'
-					)
-				}
-				path={ context.path }
-				placeholder={ null }
-			/>
+			<AsyncLoad require={ loadSidebar } path={ context.path } placeholder={ null } />
 		);
 	}
 

--- a/client/reader/list/controller.js
+++ b/client/reader/list/controller.js
@@ -7,6 +7,13 @@ import {
 import { recordTrack } from 'calypso/reader/stats';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 
+const loadListManage = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-list-manage" */ 'calypso/reader/list-manage'
+	);
+const loadList = () =>
+	import( /* webpackChunkName: "async-load-calypso-reader-list" */ 'calypso/reader/list' );
+
 const analyticsPageTitle = 'Reader';
 
 export const createList = ( context, next ) => {
@@ -17,17 +24,7 @@ export const createList = ( context, next ) => {
 	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 	recordTrack( 'calypso_reader_list_create_loaded' );
 
-	context.primary = (
-		<AsyncLoad
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-calypso-reader-list-manage" */ 'calypso/reader/list-manage'
-				)
-			}
-			key="reader-list-create"
-			isCreateForm
-		/>
-	);
+	context.primary = <AsyncLoad require={ loadListManage } key="list-manage" isCreateForm />;
 	next();
 };
 
@@ -53,9 +50,7 @@ export const listListing = ( context, next ) => {
 
 	context.primary = (
 		<AsyncLoad
-			require={ () =>
-				import( /* webpackChunkName: "async-load-calypso-reader-list" */ 'calypso/reader/list' )
-			}
+			require={ loadList }
 			key={ 'tag-' + context.params.user + '-' + context.params.list }
 			streamKey={ streamKey }
 			owner={ encodeURIComponent( context.params.user ) }
@@ -87,12 +82,8 @@ export const editList = ( context, next ) => {
 
 	context.primary = (
 		<AsyncLoad
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-calypso-reader-list-manage" */ 'calypso/reader/list-manage'
-				)
-			}
-			key="reader-list-edit"
+			require={ loadListManage }
+			key="list-manage"
 			owner={ encodeURIComponent( context.params.user ) }
 			slug={ encodeURIComponent( context.params.list ) }
 			selectedSection="details"
@@ -114,12 +105,8 @@ export const editListItems = ( context, next ) => {
 
 	context.primary = (
 		<AsyncLoad
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-calypso-reader-list-manage" */ 'calypso/reader/list-manage'
-				)
-			}
-			key="reader-list-edit-list-items"
+			require={ loadListManage }
+			key="list-manage"
 			owner={ encodeURIComponent( context.params.user ) }
 			slug={ encodeURIComponent( context.params.list ) }
 			selectedSection="items"
@@ -141,12 +128,8 @@ export const exportList = ( context, next ) => {
 
 	context.primary = (
 		<AsyncLoad
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-calypso-reader-list-manage" */ 'calypso/reader/list-manage'
-				)
-			}
-			key="reader-list-export"
+			require={ loadListManage }
+			key="list-manage"
 			owner={ encodeURIComponent( context.params.user ) }
 			slug={ encodeURIComponent( context.params.list ) }
 			selectedSection="export"
@@ -168,12 +151,8 @@ export const deleteList = ( context, next ) => {
 
 	context.primary = (
 		<AsyncLoad
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-calypso-reader-list-manage" */ 'calypso/reader/list-manage'
-				)
-			}
-			key="reader-list-delete"
+			require={ loadListManage }
+			key="list-manage"
 			owner={ encodeURIComponent( context.params.user ) }
 			slug={ encodeURIComponent( context.params.list ) }
 			selectedSection="delete"

--- a/client/reader/mastodon/controller.tsx
+++ b/client/reader/mastodon/controller.tsx
@@ -3,6 +3,18 @@ import page, { type Context } from '@automattic/calypso-router';
 import AsyncLoad from 'calypso/components/async-load';
 import { TIMELINE_TAB } from './helper';
 
+const loadMastodonLandingView = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-mastodon-landing-view" */ 'calypso/reader/mastodon/mastodon-landing-view'
+	);
+const loadMastodonConnectView = () => import( 'calypso/reader/mastodon/mastodon-connect-view' );
+const loadMastodonOauthCallbackView = () =>
+	import( 'calypso/reader/mastodon/mastodon-oauth-callback-view' );
+const loadMastodonAccountView = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-mastodon-account-view" */ 'calypso/reader/mastodon/mastodon-account-view'
+	);
+
 function ensureMastodonEnabled(): boolean {
 	if ( ! isEnabled( 'reader/social' ) ) {
 		page.redirect( '/reader' );
@@ -15,17 +27,7 @@ export const mastodonLanding = ( context: Context, next: () => void ) => {
 	if ( ! ensureMastodonEnabled() ) {
 		return;
 	}
-	context.primary = (
-		<AsyncLoad
-			key="reader-mastodon-landing"
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-calypso-reader-mastodon-landing-view" */ 'calypso/reader/mastodon/mastodon-landing-view'
-				)
-			}
-			placeholder={ null }
-		/>
-	);
+	context.primary = <AsyncLoad require={ loadMastodonLandingView } placeholder={ null } />;
 	next();
 };
 
@@ -33,13 +35,7 @@ export const mastodonConnect = ( context: Context, next: () => void ) => {
 	if ( ! ensureMastodonEnabled() ) {
 		return;
 	}
-	context.primary = (
-		<AsyncLoad
-			key="reader-mastodon-connect"
-			require={ () => import( 'calypso/reader/mastodon/mastodon-connect-view' ) }
-			placeholder={ null }
-		/>
-	);
+	context.primary = <AsyncLoad require={ loadMastodonConnectView } placeholder={ null } />;
 	next();
 };
 
@@ -49,12 +45,7 @@ export const mastodonOauthCallback = ( context: Context, next: () => void ) => {
 	}
 	const query = context.query as { state?: string; code?: string; error?: string };
 	context.primary = (
-		<AsyncLoad
-			key="reader-mastodon-oauth-callback"
-			require={ () => import( 'calypso/reader/mastodon/mastodon-oauth-callback-view' ) }
-			placeholder={ null }
-			query={ query }
-		/>
+		<AsyncLoad require={ loadMastodonOauthCallbackView } placeholder={ null } query={ query } />
 	);
 	next();
 };
@@ -79,12 +70,7 @@ export const mastodonAccount = ( context: Context, next: () => void ) => {
 	const tab = String( context.params.tab ?? '' );
 	context.primary = (
 		<AsyncLoad
-			key="reader-mastodon-account"
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-calypso-reader-mastodon-account-view" */ 'calypso/reader/mastodon/mastodon-account-view'
-				)
-			}
+			require={ loadMastodonAccountView }
 			placeholder={ null }
 			connectionId={ id }
 			tab={ tab }

--- a/client/reader/notifications/controller.jsx
+++ b/client/reader/notifications/controller.jsx
@@ -9,6 +9,9 @@ import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getIsNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
 import { toggleNotificationsPanel } from 'calypso/state/ui/actions';
 
+const loadNotifications = () =>
+	import( /* webpackChunkName: "async-load-calypso-notifications" */ 'calypso/notifications' );
+
 export function notifications( context, next ) {
 	const basePath = sectionify( context.path );
 	const mcKey = 'notifications';
@@ -49,12 +52,7 @@ export function notifications( context, next ) {
 			<NotificationTitle />
 			<div className="reader-notifications__panel">
 				<AsyncLoad
-					key="reader-notifications"
-					require={ () =>
-						import(
-							/* webpackChunkName: "async-load-calypso-notifications" */ 'calypso/notifications'
-						)
-					}
+					require={ loadNotifications }
 					isShowing
 					checkToggle={ () => {} }
 					placeholder={ null }

--- a/client/reader/on-this-day/controller.jsx
+++ b/client/reader/on-this-day/controller.jsx
@@ -5,6 +5,11 @@ import { recordTrack } from 'calypso/reader/stats';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { trackPageLoad, setPageTitle } from '../controller-helper';
 
+const loadMain = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-on-this-day-main" */ 'calypso/reader/on-this-day/main'
+	);
+
 const analyticsPageTitle = 'Reader';
 
 export function onThisDay( context, next ) {
@@ -23,15 +28,6 @@ export function onThisDay( context, next ) {
 
 	setPageTitle( context, i18n.translate( 'On This Day' ) );
 
-	context.primary = (
-		<AsyncLoad
-			key="reader-on-this-day"
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-calypso-reader-on-this-day-main" */ 'calypso/reader/on-this-day/main'
-				)
-			}
-		/>
-	);
+	context.primary = <AsyncLoad require={ loadMain } />;
 	next();
 }

--- a/client/reader/on-this-day/index.tsx
+++ b/client/reader/on-this-day/index.tsx
@@ -24,6 +24,11 @@ import { OnThisDayPostField } from './on-this-day-post-field';
 import { OnThisDayPostSkeleton } from './on-this-day-post-skeleton';
 import type { AppState } from 'calypso/types';
 
+const loadReaderFullPost = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-blocks-reader-full-post" */ 'calypso/blocks/reader-full-post'
+	);
+
 interface ReaderPost {
 	site_name: string;
 	postId: number;
@@ -290,11 +295,7 @@ export const OnThisDay = ( { viewToggle, streamKey }: OnThisDayProps ) => {
 				{ ! isLoading && data?.items.length === 0 && <FollowingEmptyContent view="on-this-day" /> }
 				{ data?.items.length > 0 && selectedItem && getPostFromItem( selectedItem ) && (
 					<AsyncLoad
-						require={ () =>
-							import(
-								/* webpackChunkName: "async-load-calypso-blocks-reader-full-post" */ 'calypso/blocks/reader-full-post'
-							)
-						}
+						require={ loadReaderFullPost }
 						feedId={ selectedItem.feedId }
 						blogId={ selectedItem.blogId }
 						postId={ selectedItem.postId }

--- a/client/reader/on-this-day/main.tsx
+++ b/client/reader/on-this-day/main.tsx
@@ -18,6 +18,15 @@ import { getOnThisDayStreamKey } from './get-stream-key';
 import { OnThisDay } from './index';
 import '../following/style.scss';
 
+const loadQuickPost = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-components-quick-post" */ 'calypso/reader/components/quick-post'
+	);
+const loadTrackResurrections = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-lib-analytics-track-resurrections" */ 'calypso/lib/analytics/track-resurrections'
+	);
+
 function OnThisDayStream() {
 	const { currentView } = useFollowingView();
 	const query = useSelector( getCurrentQueryArguments );
@@ -71,14 +80,7 @@ function OnThisDayStream() {
 					{ hasSites && (
 						<Card className="following-stream__quick-post-card">
 							<CardBody>
-								<AsyncLoad
-									require={ () =>
-										import(
-											/* webpackChunkName: "async-load-calypso-reader-components-quick-post" */ 'calypso/reader/components/quick-post'
-										)
-									}
-									placeholder={ <QuickPostSkeleton /> }
-								/>
+								<AsyncLoad require={ loadQuickPost } placeholder={ <QuickPostSkeleton /> } />
 							</CardBody>
 						</Card>
 					) }
@@ -89,14 +91,7 @@ function OnThisDayStream() {
 				</ReaderStream>
 			) }
 			<ResurrectedWelcomeModalGate onVisibilityChange={ setIsResurrectedModalVisible } />
-			<AsyncLoad
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-lib-analytics-track-resurrections" */ 'calypso/lib/analytics/track-resurrections'
-					)
-				}
-				placeholder={ null }
-			/>
+			<AsyncLoad require={ loadTrackResurrections } placeholder={ null } />
 		</>
 	);
 }

--- a/client/reader/onboarding/gate.tsx
+++ b/client/reader/onboarding/gate.tsx
@@ -1,24 +1,22 @@
 import { isEnabled } from '@automattic/calypso-config';
 import AsyncLoad from 'calypso/components/async-load';
 
+const loadOnboardingRsm = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-onboarding-rsm" */ 'calypso/reader/onboarding-rsm'
+	);
+const loadOnboarding = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-onboarding" */ 'calypso/reader/onboarding'
+	);
+
 type ReaderOnboardingGateProps = {
 	onRender?: ( shown: boolean ) => void;
 	isSuppressed?: boolean;
 };
 
 export default function ReaderOnboardingGate( props: ReaderOnboardingGateProps ) {
-	return (
-		<AsyncLoad
-			require={ () =>
-				isEnabled( 'reader/onboarding-rsm' )
-					? import(
-							/* webpackChunkName: "async-load-calypso-reader-onboarding-rsm" */ 'calypso/reader/onboarding-rsm'
-					  )
-					: import(
-							/* webpackChunkName: "async-load-calypso-reader-onboarding" */ 'calypso/reader/onboarding'
-					  )
-			}
-			{ ...props }
-		/>
-	);
+	const loadComponent = isEnabled( 'reader/onboarding-rsm' ) ? loadOnboardingRsm : loadOnboarding;
+
+	return <AsyncLoad require={ loadComponent } { ...props } />;
 }

--- a/client/reader/onboarding/gate.tsx
+++ b/client/reader/onboarding/gate.tsx
@@ -16,7 +16,9 @@ type ReaderOnboardingGateProps = {
 };
 
 export default function ReaderOnboardingGate( props: ReaderOnboardingGateProps ) {
-	const loadComponent = isEnabled( 'reader/onboarding-rsm' ) ? loadOnboardingRsm : loadOnboarding;
-
-	return <AsyncLoad require={ loadComponent } { ...props } />;
+	return isEnabled( 'reader/onboarding-rsm' ) ? (
+		<AsyncLoad require={ loadOnboardingRsm } { ...props } />
+	) : (
+		<AsyncLoad require={ loadOnboarding } { ...props } />
+	);
 }

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -25,6 +25,11 @@ import RecentPostSkeleton from './recent-post-skeleton';
 import type { PostItem, ReaderPost } from './types';
 import type { AppState } from 'calypso/types';
 
+const loadReaderFullPost = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-blocks-reader-full-post" */ 'calypso/blocks/reader-full-post'
+	);
+
 interface RecentProps {
 	viewToggle?: React.ReactNode;
 }
@@ -289,11 +294,7 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 				{ data?.items.length > 0 && selectedItem && getPostFromItem( selectedItem ) && (
 					<>
 						<AsyncLoad
-							require={ () =>
-								import(
-									/* webpackChunkName: "async-load-calypso-blocks-reader-full-post" */ 'calypso/blocks/reader-full-post'
-								)
-							}
+							require={ loadReaderFullPost }
 							feedId={ selectedItem.feedId }
 							postId={ selectedItem.postId }
 							onClose={ () => {

--- a/client/reader/saved-stream/controller.js
+++ b/client/reader/saved-stream/controller.js
@@ -2,6 +2,11 @@ import AsyncLoad from 'calypso/components/async-load';
 import { sectionify } from 'calypso/lib/route';
 import { trackPageLoad } from 'calypso/reader/controller-helper';
 
+const loadMain = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-saved-stream-main" */ 'calypso/reader/saved-stream/main'
+	);
+
 const analyticsPageTitle = 'Reader';
 
 const exported = {
@@ -12,17 +17,7 @@ const exported = {
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 
-		context.primary = (
-			<AsyncLoad
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-reader-saved-stream-main" */ 'calypso/reader/saved-stream/main'
-					)
-				}
-				key="saved"
-				placeholder={ null }
-			/>
-		);
+		context.primary = <AsyncLoad require={ loadMain } key="saved" placeholder={ null } />;
 		next();
 	},
 };

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -11,6 +11,11 @@ import { recordTrack } from 'calypso/reader/stats';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import renderHeaderSection from '../lib/header-section';
 
+const loadSearchStream = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-search-stream" */ 'calypso/reader/search-stream'
+	);
+
 const analyticsPageTitle = 'Reader';
 
 // TODO: delete this after launching sites in search
@@ -69,11 +74,7 @@ const exported = {
 				<div>
 					<div>
 						<AsyncLoad
-							require={ () =>
-								import(
-									/* webpackChunkName: "async-load-calypso-reader-search-stream" */ 'calypso/reader/search-stream'
-								)
-							}
+							require={ loadSearchStream }
 							key="search"
 							streamKey={ streamKey }
 							isSuggestion={ isQuerySuggestion }

--- a/client/reader/tag-stream/controller.js
+++ b/client/reader/tag-stream/controller.js
@@ -17,6 +17,11 @@ import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import renderHeaderSection from '../lib/header-section';
 
+const loadMain = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-tag-stream-main" */ 'calypso/reader/tag-stream/main'
+	);
+
 const analyticsPageTitle = 'Reader';
 
 export const tagListing = ( context, next ) => {
@@ -63,11 +68,7 @@ export const tagListing = ( context, next ) => {
 				} ) }
 			/>
 			<AsyncLoad
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-reader-tag-stream-main" */ 'calypso/reader/tag-stream/main'
-					)
-				}
+				require={ loadMain }
 				key={ 'tag-' + encodedTag }
 				streamKey={ streamKey }
 				encodedTagSlug={ encodedTag }

--- a/client/reader/user-profile/controller.tsx
+++ b/client/reader/user-profile/controller.tsx
@@ -4,6 +4,11 @@ import AsyncLoad from 'calypso/components/async-load';
 import { trackPageLoad, trackScrollPage } from 'calypso/reader/controller-helper';
 import { getCurrentUserName } from 'calypso/state/current-user/selectors';
 
+const loadUserProfile = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-user-profile" */ 'calypso/reader/user-profile'
+	);
+
 interface UserProfileContext extends Context {
 	params: {
 		user_login?: string;
@@ -46,11 +51,7 @@ export function userProfile( ctx: Context, next: () => void ): void {
 
 	context.primary = (
 		<AsyncLoad
-			require={ () =>
-				import(
-					/* webpackChunkName: "async-load-calypso-reader-user-profile" */ 'calypso/reader/user-profile'
-				)
-			}
+			require={ loadUserProfile }
 			key={ 'user-posts-' + userLogin }
 			userLogin={ userLogin }
 			userId={ userId }

--- a/client/sites/components/sites-dashboard.tsx
+++ b/client/sites/components/sites-dashboard.tsx
@@ -67,6 +67,9 @@ import './dotcom-style.scss';
 
 import './guided-tours.scss';
 
+const loadSitesList = () =>
+	import( /* webpackChunkName: "async-load-calypso-sites-v2-sites-list" */ '../v2/sites-list' );
+
 interface SitesDashboardProps {
 	queryParams: SitesDashboardQueryParams;
 	initialSiteFeature?: string;
@@ -451,16 +454,7 @@ const SitesDashboard = ( {
 			);
 		}
 
-		return (
-			<AsyncLoad
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-sites-v2-sites-list" */ '../v2/sites-list'
-					)
-				}
-				placeholder={ null }
-			/>
-		);
+		return <AsyncLoad require={ loadSitesList } placeholder={ null } />;
 	};
 
 	return (

--- a/client/sites/components/sites-dataviews/actions.tsx
+++ b/client/sites/components/sites-dataviews/actions.tsx
@@ -21,6 +21,15 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import type { Action, RenderModalProps, View } from '@wordpress/dataviews';
 
+const loadRestoreSiteForm = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-sites-settings-administration-tools-restore-site-restore-site-form" */ 'calypso/sites/settings/administration/tools/restore-site/restore-site-form'
+	);
+const loadLeaveSiteModalForm = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-sites-settings-administration-tools-leave-site-leave-site-modal-form" */ 'calypso/sites/settings/administration/tools/leave-site/leave-site-modal-form'
+	);
+
 type Capabilities = Record< string, Record< string, boolean > >;
 
 // Export this function for testing purposes.
@@ -234,11 +243,7 @@ export function useActions( {
 				RenderModal: ( { items, closeModal }: RenderModalProps< SiteExcerptData > ) => {
 					return (
 						<AsyncLoad
-							require={ () =>
-								import(
-									/* webpackChunkName: "async-load-calypso-sites-settings-administration-tools-restore-site-restore-site-form" */ 'calypso/sites/settings/administration/tools/restore-site/restore-site-form'
-								)
-							}
+							require={ loadRestoreSiteForm }
 							placeholder={ null }
 							siteId={ items[ 0 ]?.ID ?? 0 }
 							onClose={ closeModal }
@@ -256,11 +261,7 @@ export function useActions( {
 				RenderModal: ( { items, closeModal }: RenderModalProps< SiteExcerptData > ) => {
 					return (
 						<AsyncLoad
-							require={ () =>
-								import(
-									/* webpackChunkName: "async-load-calypso-sites-settings-administration-tools-leave-site-leave-site-modal-form" */ 'calypso/sites/settings/administration/tools/leave-site/leave-site-modal-form'
-								)
-							}
+							require={ loadLeaveSiteModalForm }
 							placeholder={ null }
 							siteId={ items[ 0 ]?.ID ?? 0 }
 							onSuccess={ () => {

--- a/client/sites/controller.tsx
+++ b/client/sites/controller.tsx
@@ -18,6 +18,11 @@ import { areHostingFeaturesSupported } from './hosting/features';
 import type { Context, Context as PageJSContext } from '@automattic/calypso-router';
 import type { CalypsoDispatch, IAppState } from 'calypso/state/types';
 
+const loadTrackResurrections = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-lib-analytics-track-resurrections" */ 'calypso/lib/analytics/track-resurrections'
+	);
+
 const getStatusFilterValue = ( status?: string ) => {
 	return siteLaunchStatusGroupValues.find( ( value ) => value === status );
 };
@@ -120,14 +125,7 @@ export function sitesDashboard( context: Context, next: () => void ) {
 			<Global styles={ sitesDashboardGlobalStyles } />
 			<PageViewTracker path="/sites" title="Sites Management Page" delay={ 500 } />
 			<ResurrectedWelcomeModalGate />
-			<AsyncLoad
-				require={ () =>
-					import(
-						/* webpackChunkName: "async-load-calypso-lib-analytics-track-resurrections" */ 'calypso/lib/analytics/track-resurrections'
-					)
-				}
-				placeholder={ null }
-			/>
+			<AsyncLoad require={ loadTrackResurrections } placeholder={ null } />
 			<SitesDashboard queryParams={ getQueryParams( context ) } />
 		</>
 	);

--- a/client/sites/marketing/traffic/traffic.js
+++ b/client/sites/marketing/traffic/traffic.js
@@ -30,6 +30,11 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
+const loadForm = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-my-sites-site-settings-seo-settings-form" */ 'calypso/my-sites/site-settings/seo-settings/form'
+	);
+
 const SiteSettingsTraffic = ( {
 	fields,
 	handleAutosavingRadio,
@@ -96,17 +101,7 @@ const SiteSettingsTraffic = ( {
 					{ isAdmin && (
 						<SeoSettingsHelpCard disabled={ isRequestingSettings || isSavingSettings } />
 					) }
-					{ isAdmin && (
-						<AsyncLoad
-							key={ siteId }
-							require={ () =>
-								import(
-									/* webpackChunkName: "async-load-calypso-my-sites-site-settings-seo-settings-form" */ 'calypso/my-sites/site-settings/seo-settings/form'
-								)
-							}
-							placeholder={ null }
-						/>
-					) }
+					{ isAdmin && <AsyncLoad key={ siteId } require={ loadForm } placeholder={ null } /> }
 					{ isJetpackAdmin && (
 						<JetpackSiteStats
 							handleAutosavingToggle={ handleAutosavingToggle }

--- a/client/sites/settings/administration/tools/index.jsx
+++ b/client/sites/settings/administration/tools/index.jsx
@@ -25,6 +25,11 @@ import AdministrationToolCard from './card';
 import { requestRestore } from './restore-plan-software';
 import './style.scss';
 
+const loadLeaveSiteModal = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-sites-settings-administration-tools-leave-site-leave-site-modal" */ './leave-site/leave-site-modal'
+	);
+
 const MODAL_NAMES = {
 	LEAVE_SITE: 'LEAVE_SITE',
 };
@@ -189,11 +194,7 @@ class SiteTools extends Component {
 						/>
 						{ modalOpen[ MODAL_NAMES.LEAVE_SITE ] && (
 							<AsyncLoad
-								require={ () =>
-									import(
-										/* webpackChunkName: "async-load-calypso-sites-settings-administration-tools-leave-site-leave-site-modal" */ './leave-site/leave-site-modal'
-									)
-								}
+								require={ loadLeaveSiteModal }
 								placeholder={ null }
 								siteId={ siteId }
 								onClose={ this.handleCloseModal( MODAL_NAMES.LEAVE_SITE ) }

--- a/packages/eslint-plugin-wpcalypso/lib/configs/recommended.js
+++ b/packages/eslint-plugin-wpcalypso/lib/configs/recommended.js
@@ -151,6 +151,7 @@ module.exports = {
 		'wpcalypso/i18n-named-placeholders': 'error',
 		'wpcalypso/i18n-translate-identifier': 'error',
 		'wpcalypso/i18n-unlocalized-url': 'error',
+		'wpcalypso/jsx-async-load-require-top-level': 'error',
 		'wpcalypso/jsx-gridicon-size': 'error',
 		'wpcalypso/jsx-classname-namespace': 'error',
 		'wpcalypso/redux-no-bound-selectors': 'error',

--- a/packages/eslint-plugin-wpcalypso/lib/rules/index.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/index.js
@@ -8,6 +8,7 @@ module.exports = {
 	'i18n-no-variables': require( './i18n-no-variables' ),
 	'i18n-translate-identifier': require( './i18n-translate-identifier' ),
 	'i18n-unlocalized-url': require( './i18n-unlocalized-url' ),
+	'jsx-async-load-require-top-level': require( './jsx-async-load-require-top-level' ),
 	'jsx-classname-namespace': require( './jsx-classname-namespace' ),
 	'jsx-gridicon-size': require( './jsx-gridicon-size' ),
 	'post-message-no-wildcard-targets': require( './post-message-no-wildcard-targets' ),

--- a/packages/eslint-plugin-wpcalypso/lib/rules/jsx-async-load-require-top-level.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/jsx-async-load-require-top-level.js
@@ -1,0 +1,52 @@
+const ERROR_MESSAGE =
+	'The `require` prop of AsyncLoad must reference a top-level constant, not an inline function or local variable.';
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+	meta: {
+		type: 'problem',
+		messages: {
+			requireTopLevel: ERROR_MESSAGE,
+		},
+		schema: [],
+	},
+	ERROR_MESSAGE,
+	create( context ) {
+		return {
+			JSXAttribute( node ) {
+				if (
+					node.name.name !== 'require' ||
+					node.parent.type !== 'JSXOpeningElement' ||
+					node.parent.name.name !== 'AsyncLoad'
+				) {
+					return;
+				}
+
+				const value = node.value;
+				if ( ! value || value.type !== 'JSXExpressionContainer' ) {
+					return;
+				}
+
+				const expr = value.expression;
+				if ( expr.type === 'Identifier' && isDefinedAtTopLevel( context, expr ) ) {
+					return;
+				}
+
+				context.report( {
+					node: expr,
+					messageId: 'requireTopLevel',
+				} );
+			},
+		};
+	},
+};
+
+function isDefinedAtTopLevel( context, node ) {
+	const scope = context.getSourceCode().getScope( node );
+	const ref = scope.references.find( ( r ) => r.identifier === node );
+	if ( ! ref || ! ref.resolved ) {
+		return false;
+	}
+	const defScope = ref.resolved.scope;
+	return defScope.type === 'module' || defScope.type === 'global';
+}

--- a/packages/eslint-plugin-wpcalypso/lib/rules/test/jsx-async-load-require-top-level.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/test/jsx-async-load-require-top-level.js
@@ -1,0 +1,63 @@
+const RuleTester = require( 'eslint' ).RuleTester;
+const rule = require( '../../../lib/rules/jsx-async-load-require-top-level' );
+
+new RuleTester( {
+	parser: require.resolve( '@babel/eslint-parser' ),
+	parserOptions: {
+		ecmaFeatures: { jsx: true },
+		sourceType: 'module',
+	},
+} ).run( 'jsx-async-load-require-top-level', rule, {
+	valid: [
+		{
+			code: `
+				const loadComponent = () => import( './component' );
+				<AsyncLoad require={ loadComponent } />;
+			`,
+		},
+		{
+			code: `
+				const loadComponent = () => import( './component' );
+				<AsyncLoad require={ loadComponent } placeholder={ null } />;
+			`,
+		},
+		{
+			code: '<Other require={ () => import( "./foo" ) } />',
+		},
+	],
+
+	invalid: [
+		{
+			code: '<AsyncLoad require={ () => import( "./foo" ) } />',
+			errors: [ { messageId: 'requireTopLevel' } ],
+		},
+		{
+			code: '<AsyncLoad require={ function() { return import( "./foo" ); } } />',
+			errors: [ { messageId: 'requireTopLevel' } ],
+		},
+		{
+			code: `
+				const load = () => import( './foo' );
+				<AsyncLoad require={ load() } />;
+			`,
+			errors: [ { messageId: 'requireTopLevel' } ],
+		},
+		{
+			code: `
+				function MyComponent( { loadIt } ) {
+					return <AsyncLoad require={ loadIt } />;
+				}
+			`,
+			errors: [ { messageId: 'requireTopLevel' } ],
+		},
+		{
+			code: `
+				function MyComponent() {
+					const load = () => import( './foo' );
+					return <AsyncLoad require={ load } />;
+				}
+			`,
+			errors: [ { messageId: 'requireTopLevel' } ],
+		},
+	],
+} );


### PR DESCRIPTION
The `AsyncLoad` update in #110042 introduced a bug, something that @p-jackson already touched in this review thread: https://github.com/Automattic/wp-calypso/pull/110042#discussion_r3151493045

The `require` callback value is used only on initial mount (passed to `useMemo`) and on further updates it is ignored. This prevents unwanted rerenders when the callback is an inline arrow lambda:
```jsx
<AsyncLoad require={ () => import( './site' ) } />
```

But this behavior becomes catastrophic when we use `AsyncLoad` in route handlers:
```jsx
function handlerA( context ) {
  context.primary = <AsyncLoad require={ () => import( './a' ) } />;
}
function handlerB( context ) {
  context.primary = <AsyncLoad require={ () => import( './b' ) } />;
}
```
Then, when navigating from route A to route B, we're rendering the same `AsyncLoad` component at the same place, just with different callbacks. But it's an update of an existing component instance, and the switch from A to B in the `import` statement is ignored! The navigation fails!

In #110261 I quickly fixed it by adding a `key` prop everywhere. This PR does a proper fix, or at least a best-effort one.

The solution is to outlaw inline callbacks, and enforce that they are defined as constants at top-level:
```jsx
const loadA = () => import( './a' );
const loadB = () => import( './b' );

<AsyncLoad require={ loadA } />
<AsyncLoad require={ loadB } />
```
Then we can include the `require` value in the `useMemo` dependencies and things will update properly.

This is actually what the old removed Babel transform did: it always defined the generated callbacks statically at top-level.

I added a lint rule to enforce this. And the resulting code is quite elegant. Better formatting, opportunities for deduplication when there is some preload...

All the `key` props from #110261 can be reverted now.