### PR TITLE
Domains: surface Atomic primary-domain conflict errors

### DIFF
--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -35,20 +35,15 @@ const SiteChangeAddressContent = lazy(
 
 const noop = () => {};
 
+const ATOMIC_DOMAIN_IN_USE_PATTERN = /Domain.*already used|TXT record verification is required/i;
+
 export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) => {
 	const router = useRouter();
 	const { recordTracksEvent } = useAnalytics();
-	const { createSuccessNotice } = useDispatch( noticesStore );
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { data: purchases } = useQuery( userPurchasesQuery() );
 
-	const setPrimaryDomainMutation = useMutation( {
-		...siteSetPrimaryDomainMutation(),
-		meta: {
-			snackbar: {
-				error: { source: 'server' },
-			},
-		},
-	} );
+	const setPrimaryDomainMutation = useMutation( siteSetPrimaryDomainMutation() );
 
 	const sitesByBlogId: Record< number, Site > = useMemo( () => {
 		if ( ! sites ) {
@@ -197,6 +192,16 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 									origin: 'dataviews_actions',
 									error_message: error.message,
 								} );
+
+								const isAtomicDomainInUse = ATOMIC_DOMAIN_IN_USE_PATTERN.test( error.message );
+								const message = isAtomicDomainInUse
+									? __(
+											'This domain is already in use on another WordPress.com or WP Cloud site. Remove it from the originating site, or contact support to set up TXT record verification.'
+									  )
+									: error.message ||
+									  __( "Something went wrong and we couldn't change your primary domain." );
+
+								createErrorNotice( message, { type: 'snackbar' } );
 							},
 						}
 					);
@@ -333,6 +338,7 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 			purchases,
 			setPrimaryDomainMutation,
 			createSuccessNotice,
+			createErrorNotice,
 			sitesByBlogId,
 			recordTracksEvent,
 		]

--- a/client/state/domains/management/actions.tsx
+++ b/client/state/domains/management/actions.tsx
@@ -123,8 +123,28 @@ export const showUpdatePrimaryDomainSuccessNotice = ( domainName: string ) => {
 	};
 };
 
+const ATOMIC_DOMAIN_IN_USE_PATTERN = /Domain.*already used|TXT record verification is required/i;
+
 export const showUpdatePrimaryDomainErrorNotice = ( errorMessage: string ) => {
 	return ( dispatch: CalypsoDispatch ) => {
+		if ( errorMessage && ATOMIC_DOMAIN_IN_USE_PATTERN.test( errorMessage ) ) {
+			dispatch(
+				errorNotice(
+					translate(
+						'This domain is already in use on another WordPress.com or WP Cloud site. Remove it from the originating site, or contact support to set up TXT record verification.'
+					),
+					{
+						duration: 10000,
+						isPersistent: true,
+						href: 'https://wordpress.com/help/contact',
+						button: translate( 'Get help' ),
+						showDismiss: true,
+					}
+				)
+			);
+			return;
+		}
+
 		dispatch(
 			errorNotice(
 				errorMessage ||

--- a/client/state/domains/management/test/actions.tsx
+++ b/client/state/domains/management/test/actions.tsx
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment jsdom
+ */
+import { showUpdatePrimaryDomainErrorNotice } from '../actions';
+
+const ATOMIC_DOMAIN_IN_USE_COPY =
+	'This domain is already in use on another WordPress.com or WP Cloud site. Remove it from the originating site, or contact support to set up TXT record verification.';
+
+const dispatchAndCaptureNotice = ( errorMessage: string ) => {
+	const dispatch = jest.fn();
+	showUpdatePrimaryDomainErrorNotice( errorMessage )( dispatch );
+	expect( dispatch ).toHaveBeenCalledTimes( 1 );
+	return dispatch.mock.calls[ 0 ][ 0 ].notice;
+};
+
+describe( 'showUpdatePrimaryDomainErrorNotice', () => {
+	test( 'shows actionable copy when message matches Atomic "domain already used" error', () => {
+		const notice = dispatchAndCaptureNotice(
+			'Domain already used on a different site [example.com]. TXT record verification is required to bypass this check.'
+		);
+
+		expect( notice.status ).toBe( 'is-error' );
+		expect( notice.text ).toBe( ATOMIC_DOMAIN_IN_USE_COPY );
+		expect( notice.href ).toBe( 'https://wordpress.com/help/contact' );
+	} );
+
+	test( 'shows actionable copy when message matches Atomic "setting domain-as-primary failed" error', () => {
+		const notice = dispatchAndCaptureNotice(
+			'Setting domain-as-primary failed: Domain name already used [example.com]. TXT record verification is required to bypass this check.'
+		);
+
+		expect( notice.status ).toBe( 'is-error' );
+		expect( notice.text ).toBe( ATOMIC_DOMAIN_IN_USE_COPY );
+		expect( notice.href ).toBe( 'https://wordpress.com/help/contact' );
+	} );
+
+	test( 'falls through to passthrough copy for unrelated error messages', () => {
+		const notice = dispatchAndCaptureNotice( 'Something else broke' );
+
+		expect( notice.status ).toBe( 'is-error' );
+		expect( notice.text ).toBe( 'Something else broke' );
+		expect( notice.href ).toBeUndefined();
+	} );
+
+	test( 'falls through to default copy when error message is empty', () => {
+		const notice = dispatchAndCaptureNotice( '' );
+
+		expect( notice.status ).toBe( 'is-error' );
+		expect( notice.text ).toBe(
+			"Something went wrong and we couldn't change your primary domain."
+		);
+		expect( notice.href ).toBeUndefined();
+	} );
+} );

--- a/client/state/sites/domains/actions.js
+++ b/client/state/sites/domains/actions.js
@@ -178,7 +178,10 @@ export function updatePrimaryDomainCompleteAction( siteId, domain ) {
 export const setPrimaryDomain = ( siteId, domain ) => async ( dispatch ) => {
 	dispatch( updatePrimaryDomainAction( siteId, domain ) );
 	debug( 'setPrimaryDomain', siteId, domain );
-	await wpcom.req.post( `/sites/${ siteId }/domains/primary`, { domain } );
+	const data = await wpcom.req.post( `/sites/${ siteId }/domains/primary`, { domain } );
+	if ( data?.error ) {
+		throw new Error( data.message );
+	}
 	await Promise.all( [
 		dispatch( requestSite( siteId ) ),
 		dispatch( fetchSiteDomains( siteId ) ),

--- a/client/state/sites/domains/test/actions.js
+++ b/client/state/sites/domains/test/actions.js
@@ -5,6 +5,7 @@ import {
 	domainsRequestSuccessAction,
 	domainsRequestFailureAction,
 	fetchSiteDomains,
+	setPrimaryDomain,
 } from '../actions';
 import {
 	SITE_ID_FIRST as siteId,
@@ -89,6 +90,29 @@ describe( 'actions', () => {
 
 			return promise.then( () => {
 				expect( spy ).toHaveBeenCalledWith( failureAction );
+			} );
+		} );
+	} );
+
+	describe( '#setPrimaryDomain()', () => {
+		const ATOMIC_ERROR_MESSAGE =
+			'Setting domain-as-primary failed: Domain name already used [example.com]. TXT record verification is required to bypass this check.';
+
+		describe( 'body-level error response', () => {
+			useNock( ( nock ) => {
+				nock( 'https://public-api.wordpress.com:443' )
+					.persist()
+					.post( `/rest/v1.1/sites/${ siteId }/domains/primary` )
+					.reply( 200, {
+						error: true,
+						message: ATOMIC_ERROR_MESSAGE,
+					} );
+			} );
+
+			test( 'throws an Error with the API message when the response body has error: true', () => {
+				return expect( setPrimaryDomain( siteId, 'example.com' )( spy ) ).rejects.toThrow(
+					ATOMIC_ERROR_MESSAGE
+				);
 			} );
 		} );
 	} );

--- a/packages/api-core/src/site-domains/__tests__/mutators.test.ts
+++ b/packages/api-core/src/site-domains/__tests__/mutators.test.ts
@@ -1,0 +1,30 @@
+import nock from 'nock';
+import { setPrimaryDomain } from '../mutators';
+
+const BASE = 'https://public-api.wordpress.com';
+const SITE_ID = 12345;
+const ATOMIC_ERROR_MESSAGE =
+	'Setting domain-as-primary failed: Domain name already used [example.com]. TXT record verification is required to bypass this check.';
+
+describe( 'setPrimaryDomain mutator', () => {
+	afterEach( () => nock.cleanAll() );
+
+	it( 'resolves on a normal success response', async () => {
+		nock( BASE )
+			.post( `/rest/v1.1/sites/${ SITE_ID }/domains/primary` )
+			.reply( 200, { success: true } );
+
+		await expect( setPrimaryDomain( SITE_ID, 'example.com' ) ).resolves.toBeUndefined();
+	} );
+
+	it( 'rejects with the API message when the response body has error: true', async () => {
+		nock( BASE ).post( `/rest/v1.1/sites/${ SITE_ID }/domains/primary` ).reply( 200, {
+			error: true,
+			message: ATOMIC_ERROR_MESSAGE,
+		} );
+
+		await expect( setPrimaryDomain( SITE_ID, 'example.com' ) ).rejects.toThrow(
+			ATOMIC_ERROR_MESSAGE
+		);
+	} );
+} );

--- a/packages/api-core/src/site-domains/mutators.ts
+++ b/packages/api-core/src/site-domains/mutators.ts
@@ -1,5 +1,8 @@
 import { wpcom } from '../wpcom-fetcher';
 
 export async function setPrimaryDomain( siteId: number, domain: string ): Promise< void > {
-	await wpcom.req.post( `/sites/${ siteId }/domains/primary`, { domain } );
+	const data = await wpcom.req.post( `/sites/${ siteId }/domains/primary`, { domain } );
+	if ( data?.error ) {
+		throw new Error( data.message );
+	}
 }


### PR DESCRIPTION
Fixes DOTSITE-79

## Proposed Changes

* `client/state/sites/domains/actions.js` — `setPrimaryDomain` thunk now throws on body-level errors (HTTP 200 with `{ error: true, message }`), matching the existing `fetchSiteDomains` pattern in the same file.
* `client/state/domains/management/actions.tsx` — `showUpdatePrimaryDomainErrorNotice` detects the two known Atomic conflict messages via regex and shows actionable copy with a **Get help** action linking to `/help/contact`. Unrelated error messages still pass through unchanged.
* `packages/api-core/src/site-domains/mutators.ts` — Same body-error check on the Dashboard's TanStack Query mutator so the mutation rejects and the consumer's `onError` fires.
* `client/dashboard/domains/dataviews/actions.tsx` — Adds an `onError` handler that mirrors the Classic regex+copy logic, surfaced as a snackbar. Removes the now-redundant `meta.snackbar.error` config.
* New unit tests in three locations covering the thunk, the notice action, and the mutator.

## Why are these changes being made?

When a customer tries to set a primary domain on an Atomic site for a domain that's already in use on another WordPress.com or WP Cloud site (Pressable, Newspack, etc.), the Atomic API returns HTTP 200 with `{ error: true, message: "..." }` rather than a non-2xx status. Calypso's `wpcom-proxy-request` only rejects on non-2xx, so the success path ran and we showed the user *"Primary domain changed: all domains will redirect to ..."* — even though nothing changed. The user had no idea anything had gone wrong, and support had no signal either.

Same root cause on both surfaces (Classic Calypso Redux + Multi-Site Dashboard TanStack Query), so both are fixed in this PR. Targeted copy is shown only when the message matches one of the two known Atomic conflict shapes; other errors fall through to the existing passthrough copy.

## Testing Instructions

### Unit tests

```
yarn test-client client/state/sites/domains/test/actions.js
yarn test-client client/state/domains/management/test/actions.tsx
yarn workspace @automattic/api-core test
```

All eight new tests should pass.

### Manual repro (DevTools "Override content")

The real failure mode requires a domain mapped to two different WP Cloud sites, which is heavy setup. Faking the API response is faster and exercises the same code path.

1. `yarn start` (or `SECTION_LIMIT=domains yarn start` for a faster build).
2. Open `http://calypso.localhost:3000/domains/manage/<your-test-site>` on a site with at least two domains.
3. DevTools → Network. Click **Set as primary** on a non-primary domain to capture the `POST /sites/{id}/domains/primary?http_envelope=1` request.
4. Right-click that request → **Override content**. The response body has the shape `{ "code": 200, "headers": [...], "body": { ... } }` — only the inner `body` field needs editing.

**Scenario A — success path (no override active):** click *Set as primary*. Expect the existing "Primary domain changed" green toast. Confirms no regression.

<img width="784" height="139" alt="02-classic-success" src="https://github.com/user-attachments/assets/5f9fe594-e47e-4f5c-adc2-76bac0956d05" />


**Scenario B — Atomic error #1.** Set the override `body` to:

```json
{ "error": true, "message": "Domain already used on a different site [example.com]. TXT record verification is required to bypass this check." }
```

Click *Set as primary*. Expect a red error notice with the new actionable copy and a **Get help** action.

<img width="1296" height="139" alt="03-classic-atomic-error-1" src="https://github.com/user-attachments/assets/5daf308f-5322-4cee-853b-27d2c76e02ad" />


**Scenario C — Atomic error #2.** Set the override `body` to:

```json
{ "error": true, "message": "Setting domain-as-primary failed: Domain name already used [example.com]. TXT record verification is required to bypass this check." }
```

Click *Set as primary*. Expect the same actionable copy + **Get help** action as Scenario B.

<img width="1324" height="116" alt="04-classic-atomic-error-2" src="https://github.com/user-attachments/assets/1dd813e5-ddd8-49f4-b7c6-b096bc4147cd" />


**Scenario D — passthrough error.** Set the override `body` to:

```json
{ "error": true, "message": "Something else broke" }
```

Click *Set as primary*. Expect a red error notice that says exactly *"Something else broke"*, with **no** Get help action — confirms unrelated errors aren't rewritten.

<img width="351" height="126" alt="05-classic-passthrough" src="https://github.com/user-attachments/assets/70c29083-8359-4741-b5c4-1435d1bbfc6a" />


The Dashboard side hits the same endpoint and uses identical regex+copy logic — verified by unit test in `packages/api-core/src/site-domains/__tests__/mutators.test.ts` and reading `client/dashboard/domains/dataviews/actions.tsx`. The only difference is snackbar rendering vs. inline notice.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

_Authored with Claude Code._
