### PR TITLE
Dashboard: use calendar icon in Last backup overview card

### DIFF
--- a/client/dashboard/sites/overview-backup-card/index.tsx
+++ b/client/dashboard/sites/overview-backup-card/index.tsx
@@ -2,7 +2,7 @@ import { HostingFeatures } from '@automattic/api-core';
 import { siteActivityLogQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { __, sprintf } from '@wordpress/i18n';
-import { backup } from '@wordpress/icons';
+import { calendar } from '@wordpress/icons';
 import { useFormattedTime } from '../../components/formatted-time';
 import OverviewCard from '../../components/overview-card';
 import { useTimeSince } from '../../components/time-since';
@@ -12,7 +12,7 @@ import JetpackConnectionWarningCard from '../overview-jetpack-connection-warning
 import type { Site, SiteActivityLog } from '@automattic/api-core';
 
 const CARD_PROPS = {
-	icon: backup,
+	icon: calendar,
 	title: __( 'Last backup' ),
 	tracksId: 'site-overview-backups',
 };


### PR DESCRIPTION
## Proposed Changes

* Replace the `backup` icon with a `calendar` icon from `@wordpress/icons` in the Last backup overview card on the site overview page.

## Why are these changes being made?

* Visual design change to use a calendar icon instead of the backup icon in the Last backup card.

## Testing Instructions

* Navigate to a site overview page (e.g. `/sites/<site-slug>`).
* Confirm the Last backup card now shows a calendar icon instead of the backup icon.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?