### PR TITLE
Reader: Hide x-post user hovercard during j/k navigation

### DIFF
--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -180,9 +180,9 @@ class ReaderStream extends Component {
 		const ref = this.listRef.current && this.listRef.current.refs[ postRefKey ];
 		const node = ReactDom.findDOMNode( ref );
 
-		// if the post is found, focus the first anchor tag within it.
 		if ( node ) {
-			const firstLink = node.querySelector( 'a' );
+			// Skip anchors inside .user-avatar to avoid triggering hovercard.
+			const firstLink = node.querySelector( 'a:not(.user-avatar a)' );
 
 			if ( firstLink ) {
 				firstLink.focus();


### PR DESCRIPTION
  Fixes READ-483

  ## Proposed Changes                                                                                                                                                       
   
  * When navigating the Reader feed with `j`/`k`, the focus target inside the selected card now skips anchors rendered inside `.user-avatar`, so x-post cards no longer     
  trigger the author hovercard via `UserAvatar`'s `onFocus` handler.                                                                                                      
                                                                                                                                                                            
  ## Why are these changes being made?                                                                                                                                    

  * On x-post cards, `<UserAvatar>` is the first focusable element in the card. `focusSelectedPost` in `client/reader/stream/index.jsx` programmatically focuses the first  
  `<a>` of the selected card after each `j`/`k` press, which lands on the avatar's profile anchor. That focus bubbles to the avatar container's `onFocus`, which shows the
  author hovercard — even though the user is just scrolling through the list.                                                                                               
  * Tabbing onto the avatar is still considered intentional element focus, and continues to show the hovercard. Mouse hover behavior is unchanged.                          
                                                                                                                                                                            
  ## Testing Instructions                                                                                                                                                   
                                                                                                                                                                            
  1. Open the Reader Following stream and find an x-post.
  2. Use `j`/`k` to navigate onto and past the x-post — no hovercard should appear.
  3. `Tab` onto the x-post avatar — hovercard should still appear (intentional focus).                                                                                      
  4. Hover the x-post avatar with the mouse — hovercard should still appear.                                                                                                
  5. `j`/`k` onto a regular post — behavior unchanged; `Enter` still opens it.      