### PR TITLE
Checkout: drop auto-renew line and expand terms modal notices

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-pay-button-footer.tsx
+++ b/client/my-sites/checkout/src/components/checkout-pay-button-footer.tsx
@@ -44,7 +44,7 @@ const Divider = styled.hr`
 	margin: 8px 0;
 `;
 
-const AutoRenewNotice = styled.p`
+const LegalNotice = styled.p`
 	margin: 0;
 	font-size: 12px;
 	line-height: 1.5;
@@ -86,9 +86,9 @@ export default function CheckoutPayButtonFooter( { cart }: { cart: ResponseCart 
 
 			<Divider />
 
-			<AutoRenewNotice>
+			<LegalNotice>
 				{ translate(
-					'By purchasing, you accept the {{tos}}Terms of Service{{/tos}} and {{pp}}Privacy Policy{{/pp}}. Your subscription auto-renews. {{readmore}}Read more{{/readmore}}',
+					'By purchasing, you accept the {{tos}}Terms of Service{{/tos}} and {{pp}}Privacy Policy{{/pp}}. {{readmore}}Read more{{/readmore}}',
 					{
 						components: {
 							tos: (
@@ -109,7 +109,7 @@ export default function CheckoutPayButtonFooter( { cart }: { cart: ResponseCart 
 						},
 					}
 				) }
-			</AutoRenewNotice>
+			</LegalNotice>
 
 			<CheckoutTermsModal
 				cart={ cart }

--- a/client/my-sites/checkout/src/components/checkout-terms-modal.tsx
+++ b/client/my-sites/checkout/src/components/checkout-terms-modal.tsx
@@ -65,7 +65,7 @@ export default function CheckoutTermsModal( {
 			className="checkout-terms-modal"
 		>
 			<TermsModalBody>
-				<CheckoutTerms cart={ cart } />
+				<CheckoutTerms cart={ cart } expandReadMore />
 			</TermsModalBody>
 		</Modal>
 	);

--- a/client/my-sites/checkout/src/components/checkout-terms.tsx
+++ b/client/my-sites/checkout/src/components/checkout-terms.tsx
@@ -60,7 +60,13 @@ const TermsCollapsedContent = styled.div`
 	}
 `;
 
-export default function CheckoutTerms( { cart }: { cart: ResponseCart } ) {
+export default function CheckoutTerms( {
+	cart,
+	expandReadMore = false,
+}: {
+	cart: ResponseCart;
+	expandReadMore?: boolean;
+} ) {
 	const isGiftPurchase = cart.is_gift_purchase;
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
@@ -114,7 +120,7 @@ export default function CheckoutTerms( { cart }: { cart: ResponseCart } ) {
 				{ ! isGiftPurchase && <TitanTermsOfService cart={ cart } /> }
 				{ shouldShowRefundPolicy && <RefundPolicies cart={ cart } /> }
 
-				<CheckoutTermsReadMore>
+				<CheckoutTermsReadMore expanded={ expandReadMore }>
 					{ shouldShowBundledDomainNotice && <BundledDomainNotice cart={ cart } /> }
 					{ shouldShowInternationalFeeNotice && <InternationalFeeNotice /> }
 					{ shouldShowJetpackSocialAdvancedPricingDisclaimer && (
@@ -129,7 +135,13 @@ export default function CheckoutTerms( { cart }: { cart: ResponseCart } ) {
 /**
  * Render a FoldableCard to contain TOS items or nothing if there are no items.
  */
-function CheckoutTermsReadMore( { children }: { children: ReactNode } ) {
+function CheckoutTermsReadMore( {
+	children,
+	expanded = false,
+}: {
+	children: ReactNode;
+	expanded?: boolean;
+} ) {
 	const translate = useTranslate();
 	// Note that this technique for finding children does not work for strings or
 	// empty fragments. Hopefully all children passed to this component are
@@ -142,6 +154,7 @@ function CheckoutTermsReadMore( { children }: { children: ReactNode } ) {
 			<FoldableCard
 				clickableHeader
 				compact
+				expanded={ expanded }
 				className="checkout__terms-foldable-card"
 				header={ translate( 'Read more' ) }
 				screenReaderText={ translate( 'Read more' ) }


### PR DESCRIPTION
## Proposed Changes
<img width="4112" height="2658" alt="Screenshot 2026-04-28 at 16 09 43" src="https://github.com/user-attachments/assets/2e4f20b3-4504-4027-8bc5-4693089bb99f" />


* Remove the "Your subscription auto-renews." sentence from the sidebar Pay button footer's legal line in `CheckoutPayButtonFooter`. The styled component holding it is renamed from `AutoRenewNotice` to `LegalNotice` to reflect its narrower role.
* Make notices in the Read-more group (`InternationalFeeNotice`, `BundledDomainNotice`, `JetpackSocialAdvancedPricingDisclaimer`) actually render inside the "Read more" Terms and Conditions modal. `CheckoutTerms` now accepts an `expandReadMore` prop which `CheckoutTermsModal` passes, forcing the inner `FoldableCard` open. Inline checkout terms keep their original collapsed behaviour (prop defaults to `false`).

## Why are these changes being made?

* The auto-renew sentence in the sidebar footer was inaccurate for one-time and gift carts and duplicated language already presented in full inside the Read-more modal's terms list.
* The international-fee notice is a required disclosure for non-US carts. It was effectively hidden in the Read-more modal: `FoldableCard` lazily mounts its children only when expanded, and the modal's CSS hides the `FoldableCard` header — so the user had no way to expand it, and the notice never reached the DOM. A non-US contact (e.g. Israel) opening the modal saw no fee notice at all. Forcing the card expanded inside the modal restores the intended behaviour. The same fix also surfaces `BundledDomainNotice` and `JetpackSocialAdvancedPricingDisclaimer` when their conditions apply.

## Testing Instructions

1. Start Calypso (`yarn start`) and go to checkout for a regular wp.com cart (non-Jetpack, non-Atomic, non-Akismet).
2. Confirm the legal line below the sidebar Pay button reads: "By purchasing, you accept the Terms of Service and Privacy Policy. Read more" — i.e. no "Your subscription auto-renews." sentence.
3. In the contact step, set the country to a non-US country (e.g. Israel) and complete the form so contact info is committed.
4. Click "Read more" to open the Terms and Conditions modal. Verify the "Your issuing bank may choose to charge an international transaction fee…" paragraph appears in the modal body.
5. Set country back to US, reopen the modal — international-fee notice should not appear.
6. Verify the inline terms section (outside the modal) still keeps its read-more group collapsed by default and expands on click.
7. Run `yarn typecheck-client`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
- [ ] 

