### PR TITLE
E2E: fix Check SSR locator

### DIFF
--- a/test/e2e/specs/infrastructure/infrastructure__ssr-enabled.ts
+++ b/test/e2e/specs/infrastructure/infrastructure__ssr-enabled.ts
@@ -19,9 +19,7 @@ describe( 'Server-side Rendering', function () {
 
 			it( `Check SSR: ${ endpoint }`, async function () {
 				await page.goto( DataHelper.getCalypsoURL( endpoint ), { timeout: 20 * 1000 } );
-				await page
-					.locator( '#wpcom[data-this-does-not-exist="true"]' )
-					.waitFor( { timeout: 15 * 1000 } );
+				await page.locator( '#wpcom[data-calypso-ssr="true"]' ).waitFor( { timeout: 15 * 1000 } );
 			} );
 		}
 	);


### PR DESCRIPTION
## Proposed Changes

- Restore the SSR detection locator in `test/e2e/specs/infrastructure/infrastructure__ssr-enabled.ts` from `#wpcom[data-this-does-not-exist="true"]` back to `#wpcom[data-calypso-ssr="true"]`.
- The locator now matches the attribute that `client/document/index.jsx` actually emits on the layout container when a route is server-side rendered, so the `waitFor` resolves as soon as the navigation completes instead of timing out at 15s.

## Why are these changes being made?

The test waits on the locator `#wpcom[data-this-does-not-exist="true"]`, which is a non-existent attribute that no element on the page can ever match. Calypso's SSR markup in `client/document/index.jsx` annotates the rendered layout container as `<div id="wpcom" ... data-calypso-ssr="true">`, so the correct attribute name is `data-calypso-ssr`. The selector was changed to a placeholder attribute that does not exist in the rendered HTML, causing `waitFor` to time out after 15s on every endpoint and on both Desktop and Mobile. Failure observed in [TeamCity build 17515811](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Playwright_desktop/17515811) (and the equivalent mobile build).

## Testing Instructions

- Run `yarn playwright test test/e2e/specs/infrastructure/infrastructure__ssr-enabled.ts --reporter=list --repeat-each=10` locally; all runs should pass.