### PR TITLE
Dashboard: use medium font weight for Add New Site option titles

### DIFF
--- a/client/dashboard/sites/add-new-site/menu-item.tsx
+++ b/client/dashboard/sites/add-new-site/menu-item.tsx
@@ -33,7 +33,7 @@ function MenuItem( {
 					<Icon className="dashboard-add-new-site__menu-item-icon" icon={ icon } />
 				</div>
 				<VStack>
-					<Text>{ title }</Text>
+					<Text weight="medium">{ title }</Text>
 					<Text variant="muted" as="p">
 						{ description }
 					</Text>


### PR DESCRIPTION
Fixes: https://linear.app/a8c/issue/RSM-1647

## Proposed Changes

This PR fixes a minor regression on the Add new site option titles. 

**Before**
<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/fd680ff1-f379-437a-aa58-c07dcbf99d5e" />

**After**
<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/0010c49d-05f4-4a24-b432-11d04c3dc848" /> 

## Testing Instructions

1. Go to `my.localhost:3000/sites`
2. Click "Add new site"
3. Verify the option titles render at medium (500) font weight
4. Verify the description text below each title remains at regular weight

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?