### PR TITLE
WIP: Add Docker AI sandbox templates for Claude and Codex

### DIFF
--- a/Dockerfile.claude-sandbox
+++ b/Dockerfile.claude-sandbox
@@ -27,6 +27,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 USER agent
+ENV NODE_OPTIONS=--max-old-space-size=16384
 ENV NVM_DIR=/home/agent/.nvm
 COPY --chown=agent:agent .nvmrc /tmp/.nvmrc
 COPY --chown=agent:agent package.json /tmp/package.json

--- a/Dockerfile.claude-sandbox
+++ b/Dockerfile.claude-sandbox
@@ -1,0 +1,63 @@
+# Custom Docker AI Sandbox template for Calypso development.
+# Read more: https://docs.docker.com/ai/sandboxes/
+#
+# Extends Docker's default {agent}-docker sandbox variant and adds:
+# - NVM
+# - the correct Node version pinned in .nvmrc
+# - Yarn
+# - jq (agents like to use this tool)
+#
+# Build & load once (sbx has its own image store, separate from Docker's):
+#   ```bash
+#   docker build -f Dockerfile.claude-sandbox -t calypso-claude-sandbox .
+#   docker save calypso-claude-sandbox -o /tmp/calypso-claude-sandbox.tar
+#   sbx template load /tmp/calypso-claude-sandbox.tar
+#   ```
+#
+# Run multiple times:
+#   ```bash
+#   sbx run --template calypso-claude-sandbox claude
+#   ```
+
+FROM docker/sandbox-templates:claude-code-docker
+
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      curl ca-certificates git build-essential jq \
+    && rm -rf /var/lib/apt/lists/*
+
+USER agent
+ENV NVM_DIR=/home/agent/.nvm
+COPY --chown=agent:agent .nvmrc /tmp/.nvmrc
+COPY --chown=agent:agent package.json /tmp/package.json
+SHELL ["/bin/bash", "-c"]
+# The base image sets NPM_CONFIG_PREFIX, which nvm refuses to coexist with.
+# Override to empty for this layer and onwards.
+ENV NPM_CONFIG_PREFIX=
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash \
+ && source "$NVM_DIR/nvm.sh" \
+ && NODE_VERSION="$(tr -d '[:space:]' < /tmp/.nvmrc)" \
+ && nvm install "$NODE_VERSION" \
+ && nvm alias default "$NODE_VERSION" \
+ && ln -sfn "$NVM_DIR/versions/node/v$NODE_VERSION" "$NVM_DIR/current" \
+ && corepack enable \
+ && corepack prepare "$(jq -r .packageManager /tmp/package.json)" --activate
+
+# Put the nvm-installed node binaries on PATH for every shell — interactive,
+# non-interactive, login, or whatever sbx happens to spawn. We can't rely on
+# .bashrc alone since the agent's shell may not source it.
+ENV PATH=$NVM_DIR/current/bin:$PATH
+
+# Source nvm.sh so the `nvm` command itself is available in shells. We write
+# to multiple init files because sbx-spawned shells don't reliably hit any
+# single one: ~/.bashrc covers interactive non-login bash, /etc/profile.d/
+# covers login shells, /etc/bash.bashrc covers system-wide interactive bash.
+USER root
+RUN printf '%s\n' \
+      'export NVM_DIR=/home/agent/.nvm' \
+      '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"' \
+      '[ -f "$PWD/.nvmrc" ] && nvm use --silent 2>/dev/null || true' \
+      | tee /etc/profile.d/nvm.sh >> /etc/bash.bashrc \
+ && tee -a /home/agent/.bashrc < /etc/profile.d/nvm.sh > /dev/null \
+ && chown agent:agent /home/agent/.bashrc
+USER agent

--- a/Dockerfile.codex-sandbox
+++ b/Dockerfile.codex-sandbox
@@ -27,6 +27,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 USER agent
+ENV NODE_OPTIONS=--max-old-space-size=16384
 ENV NVM_DIR=/home/agent/.nvm
 COPY --chown=agent:agent .nvmrc /tmp/.nvmrc
 COPY --chown=agent:agent package.json /tmp/package.json

--- a/Dockerfile.codex-sandbox
+++ b/Dockerfile.codex-sandbox
@@ -1,0 +1,63 @@
+# Custom Docker AI Sandbox template for Calypso development.
+# Read more: https://docs.docker.com/ai/sandboxes/
+#
+# Extends Docker's default {agent}-docker sandbox variant and adds:
+# - NVM
+# - the correct Node version pinned in .nvmrc
+# - Yarn
+# - jq (agents like to use this tool)
+#
+# Build & load once (sbx has its own image store, separate from Docker's):
+#   ```bash
+#   docker build -f Dockerfile.codex-sandbox -t calypso-codex-sandbox .
+#   docker save calypso-codex-sandbox -o /tmp/calypso-codex-sandbox.tar
+#   sbx template load /tmp/calypso-codex-sandbox.tar
+#   ```
+#
+# Run multiple times:
+#   ```bash
+#   sbx run --template calypso-codex-sandbox codex
+#   ```
+
+FROM docker/sandbox-templates:codex-docker
+
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      curl ca-certificates git build-essential jq \
+    && rm -rf /var/lib/apt/lists/*
+
+USER agent
+ENV NVM_DIR=/home/agent/.nvm
+COPY --chown=agent:agent .nvmrc /tmp/.nvmrc
+COPY --chown=agent:agent package.json /tmp/package.json
+SHELL ["/bin/bash", "-c"]
+# The base image sets NPM_CONFIG_PREFIX, which nvm refuses to coexist with.
+# Override to empty for this layer and onwards.
+ENV NPM_CONFIG_PREFIX=
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash \
+ && source "$NVM_DIR/nvm.sh" \
+ && NODE_VERSION="$(tr -d '[:space:]' < /tmp/.nvmrc)" \
+ && nvm install "$NODE_VERSION" \
+ && nvm alias default "$NODE_VERSION" \
+ && ln -sfn "$NVM_DIR/versions/node/v$NODE_VERSION" "$NVM_DIR/current" \
+ && corepack enable \
+ && corepack prepare "$(jq -r .packageManager /tmp/package.json)" --activate
+
+# Put the nvm-installed node binaries on PATH for every shell — interactive,
+# non-interactive, login, or whatever sbx happens to spawn. We can't rely on
+# .bashrc alone since the agent's shell may not source it.
+ENV PATH=$NVM_DIR/current/bin:$PATH
+
+# Source nvm.sh so the `nvm` command itself is available in shells. We write
+# to multiple init files because sbx-spawned shells don't reliably hit any
+# single one: ~/.bashrc covers interactive non-login bash, /etc/profile.d/
+# covers login shells, /etc/bash.bashrc covers system-wide interactive bash.
+USER root
+RUN printf '%s\n' \
+      'export NVM_DIR=/home/agent/.nvm' \
+      '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"' \
+      '[ -f "$PWD/.nvmrc" ] && nvm use --silent 2>/dev/null || true' \
+      | tee /etc/profile.d/nvm.sh >> /etc/bash.bashrc \
+ && tee -a /home/agent/.bashrc < /etc/profile.d/nvm.sh > /dev/null \
+ && chown agent:agent /home/agent/.bashrc
+USER agent


### PR DESCRIPTION
## Proposed Changes

Add `Dockerfile.claude-sandbox` and `Dockerfile.codex-sandbox` templates, extending Docker's default agent sandbox templates with NVM, the Node version pinned in `.nvmrc`, Yarn (via corepack), and `jq`.

## Why are these changes being made?

Docker's stock agent sandbox images don't include the Calypso toolchain. Agents spawned via `sbx run` can do Calypso development, but spend a lot of time at the start spinning around setting up the local dev environment when they should be ready to go immediately. These templates bake in the right Node/Yarn so `sbx run --template calypso-{claude,codex}-sandbox` is productive out of the box.

## Testing Instructions

Documented at the top of the template files.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?