### PR TITLE
Omnibar: introduce label prop and simplify default rendering

### DIFF
--- a/client/dashboard/app/omnibar/omnibar.tsx
+++ b/client/dashboard/app/omnibar/omnibar.tsx
@@ -54,10 +54,7 @@ export default function OmnibarContainer( { user }: { user?: User } ) {
 		const result = buildOmnibarNodesFromAdminBarNodes( removeUnsupportedDotcomNodes( nodes ) );
 
 		if ( ! result.home ) {
-			result.home = {
-				id: '',
-				title: '',
-			};
+			result.home = { id: '' };
 		}
 
 		result.home.icon = <OmnibarHomeIcon />;
@@ -66,7 +63,6 @@ export default function OmnibarContainer( { user }: { user?: User } ) {
 			if ( ! result.site ) {
 				result.site = {
 					id: 'site-name',
-					title: '',
 					children: [],
 				};
 			}
@@ -78,7 +74,7 @@ export default function OmnibarContainer( { user }: { user?: User } ) {
 		result.plugins = [
 			{
 				id: 'help-center',
-				title: __( 'Help' ),
+				label: __( 'Help' ),
 				icon: <Icon icon={ helpFilled } />,
 				onClick: () => setShowHelpCenter( ! isHelpCenterShown ),
 			},
@@ -99,12 +95,10 @@ export function InitialOmnibar( { user }: { user?: User } ) {
 			nodes={ {
 				home: {
 					id: '',
-					title: '',
 					icon: <OmnibarHomeIcon />,
 				},
 				user: {
 					id: '',
-					title: '',
 					icon: user ? <img src={ user.avatar_URL } alt="" /> : undefined,
 				},
 			} }

--- a/packages/omnibar/src/components/omnibar-home.tsx
+++ b/packages/omnibar/src/components/omnibar-home.tsx
@@ -2,5 +2,5 @@ import { OmnibarMenu } from './omnibar-menu';
 import type { OmnibarNode } from '../types';
 
 export function OmnibarHomeNode( { node }: { node: OmnibarNode } ) {
-	return <OmnibarMenu node={ { ...node, render: ( { icon } ) => icon } } />;
+	return <OmnibarMenu node={ node } />;
 }

--- a/packages/omnibar/src/components/omnibar-menu.tsx
+++ b/packages/omnibar/src/components/omnibar-menu.tsx
@@ -45,14 +45,11 @@ function OmnibarDropdownContent( { nodes }: { nodes: OmnibarNode[] } ) {
 }
 
 export function OmnibarMenu( { node }: { node: OmnibarNode } ) {
+	const label = node.title || node.label || '';
+
 	if ( ! node.children ) {
 		return (
-			<Button
-				className="omnibar__menu"
-				href={ node.href }
-				onClick={ node.onClick }
-				label={ node.title }
-			>
+			<Button className="omnibar__menu" href={ node.href } onClick={ node.onClick } label={ label }>
 				<OmnibarNodeContent node={ node } />
 			</Button>
 		);
@@ -62,7 +59,7 @@ export function OmnibarMenu( { node }: { node: OmnibarNode } ) {
 		<DropdownMenu
 			className="omnibar__dropdown"
 			icon={ null }
-			label={ node.title }
+			label={ label }
 			popoverProps={ { className: 'omnibar__popover', offset: 0 } }
 			toggleProps={ {
 				className: 'omnibar__menu',

--- a/packages/omnibar/src/components/omnibar-node.tsx
+++ b/packages/omnibar/src/components/omnibar-node.tsx
@@ -1,8 +1,17 @@
+import { __experimentalHStack as HStack } from '@wordpress/components';
 import type { OmnibarNode } from '../types';
 
 export function OmnibarNodeContent( { node }: { node: OmnibarNode } ) {
 	if ( node.render ) {
 		return node.render( node );
 	}
-	return node.title;
+	if ( node.icon && node.title ) {
+		return (
+			<HStack>
+				{ node.icon }
+				<span>{ node.title }</span>
+			</HStack>
+		);
+	}
+	return node.icon ?? node.title;
 }

--- a/packages/omnibar/src/components/omnibar-plugins.tsx
+++ b/packages/omnibar/src/components/omnibar-plugins.tsx
@@ -2,7 +2,5 @@ import { OmnibarMenu } from './omnibar-menu';
 import type { OmnibarNode } from '../types';
 
 export function OmnibarPluginsNode( { nodes }: { nodes: OmnibarNode[] } ) {
-	return nodes.map( ( node ) => (
-		<OmnibarMenu key={ node.id } node={ { ...node, render: ( { icon } ) => icon } } />
-	) );
+	return nodes.map( ( node ) => <OmnibarMenu key={ node.id } node={ node } /> );
 }

--- a/packages/omnibar/src/components/omnibar-site.tsx
+++ b/packages/omnibar/src/components/omnibar-site.tsx
@@ -27,18 +27,7 @@ export function OmnibarSiteNode( {
 		: actionNodes?.filter( ( { id } ) => id === 'new-content' );
 
 	return [
-		<OmnibarMenu
-			key={ siteNode.id }
-			node={ {
-				...siteNode,
-				render: ( { icon, title } ) => (
-					<HStack>
-						{ icon }
-						<span>{ title }</span>
-					</HStack>
-				),
-			} }
-		/>,
+		<OmnibarMenu key={ siteNode.id } node={ siteNode } />,
 		siteActionNodes && <OmnibarSiteActionsNode nodes={ siteActionNodes } />,
 	].filter( Boolean );
 }

--- a/packages/omnibar/src/types/omnibar.ts
+++ b/packages/omnibar/src/types/omnibar.ts
@@ -1,6 +1,7 @@
 export interface OmnibarNode {
 	id: string;
-	title: string;
+	title?: string;
+	label?: string;
 	icon?: React.ReactElement;
 	group?: boolean;
 	href?: string;

--- a/packages/omnibar/src/utils/admin-bar.tsx
+++ b/packages/omnibar/src/utils/admin-bar.tsx
@@ -16,6 +16,7 @@ export function buildOmnibarNodesFromAdminBarNodes( adminBarNodes: AdminBarNode[
 		switch ( node.id ) {
 			case 'wp-logo':
 				omnibarNodes.home = omnibarNode;
+				omnibarNodes.home.title = undefined;
 				break;
 			case 'site-name':
 				omnibarNodes.site = omnibarNode;


### PR DESCRIPTION
## Proposed Changes

* Add an optional `label` prop to `OmnibarNode` and make `title` optional.
* `OmnibarNodeContent` now defaults to rendering icon + title (HStack) when both are present, or whichever one is set — no more ad-hoc `render: ({ icon }) => icon` overrides for icon-only nodes.
* `OmnibarMenu` uses `node.title || node.label` as the tooltip on the underlying `Button` / `DropdownMenu`.
* Drop redundant `render` overrides from `OmnibarHomeNode`, `OmnibarPluginsNode`, and the main render in `OmnibarSiteNode` — the new default handles them.
* In the dashboard's `OmnibarContainer`, move the Help node's `__( 'Help' )` from `title` to `label` (so it stays icon-only with a tooltip), and drop the now-unneeded empty `title: ''` placeholders on the `home`/`user`/`site` nodes.
* In `buildOmnibarNodesFromAdminBarNodes`, clear the title on the `wp-logo` → home node so it renders icon-only.

## Why are these changes being made?

* The previous rendering rule was scattered: each call site that wanted icon-only had to pass `render: ({ icon }) => icon`, and the icon+title HStack was duplicated. Folding both into the default keeps individual node definitions declarative.
* Making `title` optional and adding `label` lets icon-only nodes express their accessible name without faking it through a `title` that has to be hidden by a custom render.



🤖 Generated with [Claude Code](https://claude.com/claude-code)
