### PR TITLE
Podcast: add Settings tab

### DIFF
--- a/client/my-sites/podcast/components/settings.tsx
+++ b/client/my-sites/podcast/components/settings.tsx
@@ -410,7 +410,7 @@ const PodcastingSettingsForm = ( {
 							title={
 								isPodcastingEnabled
 									? ( translate( 'Almost ready to submit' ) as string )
-									: ( translate( 'Set up your podcast feed' ) as string )
+									: ( translate( 'Set up your podcast' ) as string )
 							}
 							hideCloseButton
 						>

--- a/client/my-sites/podcast/components/settings.tsx
+++ b/client/my-sites/podcast/components/settings.tsx
@@ -1,8 +1,3 @@
-import {
-	PLAN_PERSONAL,
-	WPCOM_FEATURES_UPLOAD_AUDIO_FILES,
-	getPlan,
-} from '@automattic/calypso-products';
 import { NoticeBanner } from '@automattic/components';
 import {
 	BaseControl,
@@ -24,7 +19,6 @@ import { useTranslate } from 'i18n-calypso';
 import { pick } from 'lodash';
 import { useCallback, useMemo, useState } from 'react';
 import TermFormDialog from 'calypso/blocks/term-form-dialog';
-import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import QueryMedia from 'calypso/components/data/query-media';
 import { decodeEntities } from 'calypso/lib/formatting';
 import PodcastCoverImageSetting from 'calypso/my-sites/site-settings/podcast-cover-image-setting';
@@ -32,8 +26,6 @@ import useTopics from 'calypso/my-sites/site-settings/podcasting-details/use-top
 import wrapSettingsForm from 'calypso/my-sites/site-settings/wrap-settings-form';
 import { useSelector } from 'calypso/state';
 import getMediaItem from 'calypso/state/selectors/get-media-item';
-import { hasLoadedSitePlansFromServer } from 'calypso/state/sites/plans/selectors';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getTerms } from 'calypso/state/terms/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 
@@ -128,21 +120,15 @@ const PodcastingSettingsForm = ( {
 
 	const siteId = useSelector( getSelectedSiteId );
 	const site = useSelector( getSelectedSite );
-	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 	const categories = useSelector(
 		( state ) =>
 			( getTerms( state, siteId ?? 0, 'category' ) as { ID: number; name?: string }[] | null ) ?? []
 	);
-	const plansDataLoaded = useSelector( ( state ) => hasLoadedSitePlansFromServer( state, siteId ) );
 
 	const podcastingCategoryId = fields.podcasting_category_id
 		? Number( fields.podcasting_category_id )
 		: 0;
 	const isPodcastingEnabled = podcastingCategoryId > 0;
-	// Reveal the form for first-time setup (e.g. arriving from Welcome's
-	// "Enable podcasting" CTA) so users can pick a category right away.
-	const [ isEnabling, setIsEnabling ] = useState( ! isPodcastingEnabled );
-	const showSettings = isPodcastingEnabled || isEnabling;
 
 	const isCategoryChanging =
 		! isSavingSettings &&
@@ -150,9 +136,6 @@ const PodcastingSettingsForm = ( {
 		settings &&
 		Number( settings.podcasting_category_id ) > 0 &&
 		podcastingCategoryId !== Number( settings.podcasting_category_id );
-
-	const isAudioUploadEnabled =
-		plansDataLoaded && ( site?.options?.upgraded_filetypes_enabled || isJetpack );
 
 	const disabled = isRequestingSettings || isSavingSettings || isCoverImageUploading;
 
@@ -222,14 +205,12 @@ const PodcastingSettingsForm = ( {
 			}
 
 			if ( isEnabled ) {
-				setIsEnabling( true );
 				if ( ! fields.podcasting_title ) {
 					updateFields( { podcasting_title: settings?.blogname || '' } );
 				}
 				return;
 			}
 
-			setIsEnabling( false );
 			if ( isPodcastingEnabled ) {
 				updateFields( { podcasting_category_id: '0' }, () => submitForm() );
 			}
@@ -247,7 +228,6 @@ const PodcastingSettingsForm = ( {
 	const onCategorySelected = useCallback(
 		( category: { ID: number } ) => {
 			updateFields( { podcasting_category_id: String( category.ID ) }, () => submitForm() );
-			setIsEnabling( false );
 		},
 		[ updateFields, submitForm ]
 	);
@@ -406,7 +386,7 @@ const PodcastingSettingsForm = ( {
 					<CardBody>
 						<ToggleControl
 							__nextHasNoMarginBottom
-							checked={ isPodcastingEnabled || isEnabling }
+							checked={ isPodcastingEnabled }
 							onChange={ onTogglePodcasting }
 							disabled={ disabled }
 							label={ translate( 'Enable podcasting on this site' ) as string }
@@ -443,224 +423,204 @@ const PodcastingSettingsForm = ( {
 					</div>
 				) }
 
-				{ /* Audio upload upsell */ }
-				{ showSettings && plansDataLoaded && ! isAudioUploadEnabled && (
-					<UpsellNudge
-						plan={ PLAN_PERSONAL }
-						title={ translate( 'Upload Audio with WordPress.com %(personalPlanName)s', {
-							args: { personalPlanName: getPlan( PLAN_PERSONAL )?.getTitle() ?? '' },
-						} ) }
-						description={ translate( 'Embed podcast episodes directly from your media library.' ) }
-						feature={ WPCOM_FEATURES_UPLOAD_AUDIO_FILES }
-						event="podcasting_details_upload_audio"
-						tracksImpressionName="calypso_upgrade_nudge_impression"
-						tracksClickName="calypso_upgrade_nudge_cta_click"
-						showIcon
-					/>
-				) }
+				{ /* Category + RSS feed */ }
+				<Card className="site-settings__card podcast__card">
+					<CardHeader>
+						<VStack spacing={ 1 }>
+							<Heading level={ 4 }>{ translate( 'Podcast category' ) }</Heading>
+							<Text variant="muted">
+								{ translate(
+									'Posts in this category are treated as podcast episodes. Add an audio or video block to each one so listeners have something to play.'
+								) }
+							</Text>
+						</VStack>
+					</CardHeader>
+					<CardBody>
+						<VStack spacing={ 6 }>
+							{ ! isPodcastingEnabled && (
+								<Notice status="info" isDismissible={ false }>
+									{ translate( 'Select a category to start your podcast feed.' ) }
+								</Notice>
+							) }
 
-				{ showSettings && (
-					<>
-						{ /* Category + RSS feed */ }
-						<Card className="site-settings__card podcast__card">
-							<CardHeader>
-								<VStack spacing={ 1 }>
-									<Heading level={ 4 }>{ translate( 'Podcast category' ) }</Heading>
-									<Text variant="muted">
-										{ translate(
-											'Posts in this category are treated as podcast episodes. Add an audio or video block to each one so listeners have something to play.'
-										) }
-									</Text>
-								</VStack>
-							</CardHeader>
-							<CardBody>
-								<VStack spacing={ 6 }>
-									{ isEnabling && ! isPodcastingEnabled && (
-										<Notice status="info" isDismissible={ false }>
-											{ translate( 'Select a category to start your podcast feed.' ) }
-										</Notice>
+							<VStack spacing={ 2 }>
+								<SelectControl
+									__nextHasNoMarginBottom
+									__next40pxDefaultSize
+									label={ translate( 'Category' ) as string }
+									hideLabelFromVision
+									value={ podcastingCategoryId ? String( podcastingCategoryId ) : '' }
+									options={ categoryOptions }
+									onChange={ onCategoryDropdownChange }
+									disabled={ disabled }
+								/>
+								<Button
+									variant="link"
+									className="podcast__settings-category-add"
+									onClick={ () => setIsAddCategoryOpen( true ) }
+									disabled={ disabled }
+								>
+									{ translate( 'Create a new category' ) }
+								</Button>
+							</VStack>
+
+							<TermFormDialog
+								showDialog={ isAddCategoryOpen }
+								onClose={ () => setIsAddCategoryOpen( false ) }
+								postType="post"
+								taxonomy="category"
+								onSuccess={ onCategorySelected }
+							/>
+
+							{ isCategoryChanging && (
+								<Notice status="warning" isDismissible={ false }>
+									{ translate(
+										'If you change categories, you will need to resubmit your feed to Apple Podcasts and any other podcasting services.'
 									) }
+								</Notice>
+							) }
+						</VStack>
+					</CardBody>
+				</Card>
 
-									<VStack spacing={ 2 }>
-										<SelectControl
-											__nextHasNoMarginBottom
-											__next40pxDefaultSize
-											label={ translate( 'Category' ) as string }
-											hideLabelFromVision
-											value={ podcastingCategoryId ? String( podcastingCategoryId ) : '' }
-											options={ categoryOptions }
-											onChange={ onCategoryDropdownChange }
-											disabled={ disabled }
-										/>
-										<Button
-											variant="link"
-											className="podcast__settings-category-add"
-											onClick={ () => setIsAddCategoryOpen( true ) }
-											disabled={ disabled }
-										>
-											{ translate( 'Create a new category' ) }
-										</Button>
-									</VStack>
+				{ /* Show details */ }
+				<Card className="site-settings__card podcast__card">
+					<CardHeader>
+						<VStack spacing={ 1 }>
+							<Heading level={ 4 }>{ translate( 'Show details' ) }</Heading>
+							<Text variant="muted">
+								{ translate(
+									'This information appears in podcast apps like Apple Podcasts and Spotify.'
+								) }
+							</Text>
+						</VStack>
+					</CardHeader>
+					<CardBody>
+						<VStack spacing={ 6 }>
+							<div className="podcast__settings-cover">
+								<PodcastCoverImageSetting
+									coverImageId={ Number( fields.podcasting_image_id ?? 0 ) || 0 }
+									coverImageUrl={ fields.podcasting_image ?? '' }
+									onRemove={ onCoverImageRemoved }
+									onSelect={ onCoverImageSelected }
+									onUploadStateChange={ setIsCoverImageUploading }
+									isDisabled={ disabled }
+								/>
+							</div>
 
-									<TermFormDialog
-										showDialog={ isAddCategoryOpen }
-										onClose={ () => setIsAddCategoryOpen( false ) }
-										postType="post"
-										taxonomy="category"
-										onSuccess={ onCategorySelected }
-									/>
+							<TextControl
+								__nextHasNoMarginBottom
+								__next40pxDefaultSize
+								label={ translate( 'Title' ) as string }
+								value={ decodeEntities( fields.podcasting_title ?? '' ) }
+								onChange={ onTextChange( 'podcasting_title' ) }
+								onBlur={ onTextBlur }
+								disabled={ disabled }
+							/>
 
-									{ isCategoryChanging && (
-										<Notice status="warning" isDismissible={ false }>
-											{ translate(
-												'If you change categories, you will need to resubmit your feed to Apple Podcasts and any other podcasting services.'
-											) }
-										</Notice>
-									) }
-								</VStack>
-							</CardBody>
-						</Card>
+							<TextareaControl
+								__nextHasNoMarginBottom
+								label={ translate( 'Summary / Description' ) as string }
+								value={ decodeEntities( fields.podcasting_summary ?? '' ) }
+								onChange={ onTextChange( 'podcasting_summary' ) }
+								onBlur={ onTextBlur }
+								disabled={ disabled }
+								rows={ 4 }
+							/>
 
-						{ /* Show details */ }
-						<Card className="site-settings__card podcast__card">
-							<CardHeader>
-								<VStack spacing={ 1 }>
-									<Heading level={ 4 }>{ translate( 'Show details' ) }</Heading>
-									<Text variant="muted">
-										{ translate(
-											'This information appears in podcast apps like Apple Podcasts and Spotify.'
-										) }
-									</Text>
-								</VStack>
-							</CardHeader>
-							<CardBody>
-								<VStack spacing={ 6 }>
-									<div className="podcast__settings-cover">
-										<PodcastCoverImageSetting
-											coverImageId={ Number( fields.podcasting_image_id ?? 0 ) || 0 }
-											coverImageUrl={ fields.podcasting_image ?? '' }
-											onRemove={ onCoverImageRemoved }
-											onSelect={ onCoverImageSelected }
-											onUploadStateChange={ setIsCoverImageUploading }
-											isDisabled={ disabled }
-										/>
-									</div>
+							<TextControl
+								__nextHasNoMarginBottom
+								__next40pxDefaultSize
+								label={ translate( 'Hosts / Artist / Producer' ) as string }
+								value={ decodeEntities( fields.podcasting_talent_name ?? '' ) }
+								onChange={ onTextChange( 'podcasting_talent_name' ) }
+								onBlur={ onTextBlur }
+								disabled={ disabled }
+							/>
 
-									<TextControl
-										__nextHasNoMarginBottom
-										__next40pxDefaultSize
-										label={ translate( 'Title' ) as string }
-										value={ decodeEntities( fields.podcasting_title ?? '' ) }
-										onChange={ onTextChange( 'podcasting_title' ) }
-										onBlur={ onTextBlur }
-										disabled={ disabled }
-									/>
+							<TextControl
+								__nextHasNoMarginBottom
+								__next40pxDefaultSize
+								label={ translate( 'Copyright' ) as string }
+								value={ decodeEntities( fields.podcasting_copyright ?? '' ) }
+								onChange={ onTextChange( 'podcasting_copyright' ) }
+								onBlur={ onTextBlur }
+								disabled={ disabled }
+							/>
+						</VStack>
+					</CardBody>
+				</Card>
 
-									<TextareaControl
-										__nextHasNoMarginBottom
-										label={ translate( 'Summary / Description' ) as string }
-										value={ decodeEntities( fields.podcasting_summary ?? '' ) }
-										onChange={ onTextChange( 'podcasting_summary' ) }
-										onBlur={ onTextBlur }
-										disabled={ disabled }
-										rows={ 4 }
-									/>
+				{ /* Feed metadata */ }
+				<Card className="site-settings__card podcast__card">
+					<CardHeader>
+						<VStack spacing={ 1 }>
+							<Heading level={ 4 }>{ translate( 'Feed settings' ) }</Heading>
+							<Text variant="muted">
+								{ translate( 'Configure how your podcast appears in directories and apps.' ) }
+							</Text>
+						</VStack>
+					</CardHeader>
+					<CardBody>
+						<VStack spacing={ 6 }>
+							<BaseControl
+								__nextHasNoMarginBottom
+								id="podcast-topics"
+								label={ translate( 'Podcast topics' ) as string }
+								help={
+									translate(
+										'Choose how your podcast should be categorized within Apple Podcasts and other podcasting services. Pick up to three.'
+									) as string
+								}
+							>
+								<FormTokenField
+									__nextHasNoMarginBottom
+									__next40pxDefaultSize
+									__experimentalExpandOnFocus
+									__experimentalShowHowTo={ false }
+									label=""
+									value={ selectedTopicLabels }
+									suggestions={ topicSuggestions }
+									maxLength={ 3 }
+									onChange={ onTopicsChange }
+									disabled={ disabled }
+								/>
+							</BaseControl>
 
-									<TextControl
-										__nextHasNoMarginBottom
-										__next40pxDefaultSize
-										label={ translate( 'Hosts / Artist / Producer' ) as string }
-										value={ decodeEntities( fields.podcasting_talent_name ?? '' ) }
-										onChange={ onTextChange( 'podcasting_talent_name' ) }
-										onBlur={ onTextBlur }
-										disabled={ disabled }
-									/>
+							<SelectControl
+								__nextHasNoMarginBottom
+								__next40pxDefaultSize
+								label={ translate( 'Explicit content' ) as string }
+								value={ String( fields.podcasting_explicit ?? 'no' ) }
+								options={
+									[
+										{ value: 'no', label: translate( 'No' ) as string },
+										{ value: 'yes', label: translate( 'Yes' ) as string },
+										{ value: 'clean', label: translate( 'Clean' ) as string },
+									] as PodcastTopicOption[]
+								}
+								onChange={ onExplicitChange }
+								disabled={ disabled }
+							/>
 
-									<TextControl
-										__nextHasNoMarginBottom
-										__next40pxDefaultSize
-										label={ translate( 'Copyright' ) as string }
-										value={ decodeEntities( fields.podcasting_copyright ?? '' ) }
-										onChange={ onTextChange( 'podcasting_copyright' ) }
-										onBlur={ onTextBlur }
-										disabled={ disabled }
-									/>
-								</VStack>
-							</CardBody>
-						</Card>
-
-						{ /* Feed metadata */ }
-						<Card className="site-settings__card podcast__card">
-							<CardHeader>
-								<VStack spacing={ 1 }>
-									<Heading level={ 4 }>{ translate( 'Feed settings' ) }</Heading>
-									<Text variant="muted">
-										{ translate( 'Configure how your podcast appears in directories and apps.' ) }
-									</Text>
-								</VStack>
-							</CardHeader>
-							<CardBody>
-								<VStack spacing={ 6 }>
-									<BaseControl
-										__nextHasNoMarginBottom
-										id="podcast-topics"
-										label={ translate( 'Podcast topics' ) as string }
-										help={
-											translate(
-												'Choose how your podcast should be categorized within Apple Podcasts and other podcasting services. Pick up to three.'
-											) as string
-										}
-									>
-										<FormTokenField
-											__nextHasNoMarginBottom
-											__next40pxDefaultSize
-											__experimentalExpandOnFocus
-											__experimentalShowHowTo={ false }
-											label=""
-											value={ selectedTopicLabels }
-											suggestions={ topicSuggestions }
-											maxLength={ 3 }
-											onChange={ onTopicsChange }
-											disabled={ disabled }
-										/>
-									</BaseControl>
-
-									<SelectControl
-										__nextHasNoMarginBottom
-										__next40pxDefaultSize
-										label={ translate( 'Explicit content' ) as string }
-										value={ String( fields.podcasting_explicit ?? 'no' ) }
-										options={
-											[
-												{ value: 'no', label: translate( 'No' ) as string },
-												{ value: 'yes', label: translate( 'Yes' ) as string },
-												{ value: 'clean', label: translate( 'Clean' ) as string },
-											] as PodcastTopicOption[]
-										}
-										onChange={ onExplicitChange }
-										disabled={ disabled }
-									/>
-
-									<TextControl
-										__nextHasNoMarginBottom
-										__next40pxDefaultSize
-										type="email"
-										label={ translate( 'Email address' ) as string }
-										help={
-											translate(
-												'Included in your feed so podcast directories can verify ownership. Most require it for submission.'
-											) as string
-										}
-										value={ decodeEntities( fields.podcasting_email ?? '' ) }
-										onChange={ onTextChange( 'podcasting_email' ) }
-										onBlur={ onTextBlur }
-										disabled={ disabled }
-									/>
-								</VStack>
-							</CardBody>
-						</Card>
-					</>
-				) }
+							<TextControl
+								__nextHasNoMarginBottom
+								__next40pxDefaultSize
+								type="email"
+								label={ translate( 'Email address' ) as string }
+								help={
+									translate(
+										'Included in your feed so podcast directories can verify ownership. Most require it for submission.'
+									) as string
+								}
+								value={ decodeEntities( fields.podcasting_email ?? '' ) }
+								onChange={ onTextChange( 'podcasting_email' ) }
+								onBlur={ onTextBlur }
+								disabled={ disabled }
+							/>
+						</VStack>
+					</CardBody>
+				</Card>
 			</VStack>
 		</form>
 	);

--- a/client/my-sites/podcast/components/settings.tsx
+++ b/client/my-sites/podcast/components/settings.tsx
@@ -365,11 +365,13 @@ const PodcastingSettingsForm = ( {
 					<div className="podcast__settings-readiness">
 						<NoticeBanner
 							level="warning"
-							title={ translate( 'Finish setting up your feed' ) as string }
+							title={ translate( 'Almost ready to submit' ) as string }
 							hideCloseButton
 						>
 							<p>
-								{ translate( 'Address these before you submit your feed to podcast directories:' ) }
+								{ translate(
+									'Podcast apps like Apple Podcasts and Spotify need this information so they can list your show in their directories and show it to listeners. Add the following to your feed:'
+								) }
 							</p>
 							<ul className="podcast__settings-issues">
 								{ submissionIssues.map( ( issue ) => (

--- a/client/my-sites/podcast/components/settings.tsx
+++ b/client/my-sites/podcast/components/settings.tsx
@@ -10,6 +10,7 @@ import {
 	SelectControl,
 	TextControl,
 	TextareaControl,
+	__experimentalConfirmDialog as ConfirmDialog,
 	__experimentalHeading as Heading,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
@@ -22,7 +23,8 @@ import { decodeEntities } from 'calypso/lib/formatting';
 import PodcastCoverImageSetting from 'calypso/my-sites/site-settings/podcast-cover-image-setting';
 import useTopics from 'calypso/my-sites/site-settings/podcasting-details/use-topics';
 import wrapSettingsForm from 'calypso/my-sites/site-settings/wrap-settings-form';
-import { useSelector } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getMediaItem from 'calypso/state/selectors/get-media-item';
 import { getTerms } from 'calypso/state/terms/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -117,9 +119,11 @@ const PodcastingSettingsForm = ( {
 }: PodcastingFormProps ) => {
 	const translate = useTranslate();
 	const topicOptions = useTopicOptions();
+	const dispatch = useDispatch();
 
 	const [ isCoverImageUploading, setIsCoverImageUploading ] = useState( false );
 	const [ isAddCategoryOpen, setIsAddCategoryOpen ] = useState( false );
+	const [ isConfirmingDisable, setIsConfirmingDisable ] = useState( false );
 
 	const siteId = useSelector( getSelectedSiteId );
 	const site = useSelector( getSelectedSite );
@@ -227,14 +231,20 @@ const PodcastingSettingsForm = ( {
 		if ( disabled || ! isPodcastingEnabled ) {
 			return;
 		}
+		dispatch(
+			recordTracksEvent( 'calypso_podcast_disabled', { category_id: podcastingCategoryId } )
+		);
 		updateFields( { podcasting_category_id: '0' }, () => submitForm() );
-	}, [ disabled, isPodcastingEnabled, updateFields, submitForm ] );
+	}, [ disabled, isPodcastingEnabled, podcastingCategoryId, dispatch, updateFields, submitForm ] );
 
 	const onCategorySelected = useCallback(
 		( category: { ID: number } ) => {
+			if ( ! isPodcastingEnabled ) {
+				dispatch( recordTracksEvent( 'calypso_podcast_enabled', { category_id: category.ID } ) );
+			}
 			updateFields( { podcasting_category_id: String( category.ID ) }, () => submitForm() );
 		},
-		[ updateFields, submitForm ]
+		[ isPodcastingEnabled, dispatch, updateFields, submitForm ]
 	);
 
 	const onCategoryDropdownChange = useCallback(
@@ -619,14 +629,28 @@ const PodcastingSettingsForm = ( {
 							<Button
 								variant="secondary"
 								isDestructive
-								onClick={ onDisablePodcasting }
+								onClick={ () => setIsConfirmingDisable( true ) }
 								disabled={ disabled }
 							>
-								{ translate( 'Disable podcasting' ) }
+								{ translate( 'Disable' ) }
 							</Button>
 						</CardBody>
 					</Card>
 				) }
+
+				<ConfirmDialog
+					isOpen={ isConfirmingDisable }
+					onConfirm={ () => {
+						setIsConfirmingDisable( false );
+						onDisablePodcasting();
+					} }
+					onCancel={ () => setIsConfirmingDisable( false ) }
+					confirmButtonText={ translate( 'Disable' ) as string }
+				>
+					{ translate(
+						'Disable podcasting? Your feed will stop publishing. Your show details stay saved.'
+					) }
+				</ConfirmDialog>
 			</VStack>
 		</form>
 	);

--- a/client/my-sites/podcast/components/settings.tsx
+++ b/client/my-sites/podcast/components/settings.tsx
@@ -7,6 +7,7 @@ import {
 	Button,
 	Card,
 	CardBody,
+	CardFooter,
 	Notice,
 	SelectControl,
 	TextControl,
@@ -67,6 +68,7 @@ const getFormSettings = ( settings: SiteSettingsShape | undefined ): PodcastingF
 interface PodcastingFormProps {
 	fields: PodcastingFields;
 	settings?: SiteSettingsShape;
+	dirtyFields: string[];
 	handleSubmitForm: ( event?: React.FormEvent< HTMLFormElement > ) => void;
 	isRequestingSettings: boolean;
 	isSavingSettings: boolean;
@@ -111,6 +113,7 @@ const useTopicOptions = (): PodcastTopicOption[] => {
 const PodcastingSettingsForm = ( {
 	fields,
 	settings,
+	dirtyFields,
 	handleSubmitForm,
 	isRequestingSettings,
 	isSavingSettings,
@@ -526,16 +529,18 @@ const PodcastingSettingsForm = ( {
 						</Card>
 
 						{ /* Save */ }
-						<HStack justify="flex-end" className="podcast__settings-actions">
-							<Button
-								variant="primary"
-								type="submit"
-								isBusy={ isSavingSettings }
-								disabled={ disabled || ! isPodcastingEnabled }
-							>
-								{ isSavingSettings ? translate( 'Saving…' ) : translate( 'Save settings' ) }
-							</Button>
-						</HStack>
+						<Card className="site-settings__card podcast__card podcast__settings-save-card">
+							<CardFooter>
+								<Button
+									variant="primary"
+									type="submit"
+									isBusy={ isSavingSettings }
+									disabled={ disabled || ! isPodcastingEnabled || dirtyFields.length === 0 }
+								>
+									{ isSavingSettings ? translate( 'Saving…' ) : translate( 'Save' ) }
+								</Button>
+							</CardFooter>
+						</Card>
 					</>
 				) }
 			</VStack>

--- a/client/my-sites/podcast/components/settings.tsx
+++ b/client/my-sites/podcast/components/settings.tsx
@@ -4,7 +4,6 @@ import {
 	getPlan,
 } from '@automattic/calypso-products';
 import {
-	Button,
 	Card,
 	CardBody,
 	CardHeader,
@@ -23,7 +22,6 @@ import { pick } from 'lodash';
 import { useCallback, useMemo, useState } from 'react';
 import TermTreeSelector from 'calypso/blocks/term-tree-selector';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
-import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
 import { decodeEntities } from 'calypso/lib/formatting';
 import PodcastCoverImageSetting from 'calypso/my-sites/site-settings/podcast-cover-image-setting';
 import useTopics from 'calypso/my-sites/site-settings/podcasting-details/use-topics';
@@ -32,11 +30,7 @@ import { useSelector } from 'calypso/state';
 import { hasLoadedSitePlansFromServer } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getTerm } from 'calypso/state/terms/selectors';
-import {
-	getSelectedSite,
-	getSelectedSiteId,
-	getSelectedSiteSlug,
-} from 'calypso/state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const TRACKED_FIELDS = [
 	'podcasting_category_id',
@@ -128,7 +122,6 @@ const PodcastingSettingsForm = ( {
 
 	const siteId = useSelector( getSelectedSiteId );
 	const site = useSelector( getSelectedSite );
-	const siteSlug = useSelector( getSelectedSiteSlug );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 	const plansDataLoaded = useSelector( ( state ) => hasLoadedSitePlansFromServer( state, siteId ) );
 
@@ -145,18 +138,9 @@ const PodcastingSettingsForm = ( {
 		podcastingCategoryId
 			? ( getTerm( state, siteId ?? 0, 'category', podcastingCategoryId ) as {
 					name?: string;
-					feed_url?: string;
 			  } | null )
 			: null
 	);
-	// WP.com Simple sites can return http:; prefer https for display.
-	const feedUrl = useMemo( () => {
-		const raw = podcastingCategory?.feed_url;
-		if ( ! raw ) {
-			return '';
-		}
-		return isJetpack ? raw : raw.replace( /^http:/, 'https:' );
-	}, [ podcastingCategory, isJetpack ] );
 
 	const isCategoryChanging =
 		! isSavingSettings &&
@@ -253,7 +237,6 @@ const PodcastingSettingsForm = ( {
 	);
 
 	const podcastingCategoryName = podcastingCategory?.name;
-	const newPostUrl = siteSlug ? `/post/${ siteSlug }` : '';
 
 	if ( ! site || ! siteId ) {
 		return null;
@@ -357,26 +340,6 @@ const PodcastingSettingsForm = ( {
 												'If you change categories, you will need to resubmit your feed to Apple Podcasts and any other podcasting services.'
 											) }
 										</Notice>
-									) }
-
-									{ feedUrl && (
-										<VStack spacing={ 2 }>
-											<Text weight={ 500 }>{ translate( 'RSS feed' ) }</Text>
-											<ClipboardButtonInput value={ feedUrl } />
-											<Text variant="muted" size="12">
-												{ translate(
-													'Copy your feed URL and submit it to Apple Podcasts and other podcasting services.'
-												) }
-											</Text>
-										</VStack>
-									) }
-
-									{ isPodcastingEnabled && newPostUrl && (
-										<HStack justify="flex-start">
-											<Button variant="secondary" href={ newPostUrl }>
-												{ translate( 'Create episode' ) }
-											</Button>
-										</HStack>
 									) }
 								</VStack>
 							</CardBody>

--- a/client/my-sites/podcast/components/settings.tsx
+++ b/client/my-sites/podcast/components/settings.tsx
@@ -8,12 +8,14 @@ import {
 	Card,
 	CardBody,
 	CardFooter,
+	CardHeader,
 	Notice,
 	SelectControl,
 	TextControl,
 	TextareaControl,
 	ToggleControl,
 	__experimentalHStack as HStack,
+	__experimentalHeading as Heading,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
@@ -243,6 +245,17 @@ const PodcastingSettingsForm = ( {
 	const podcastingCategoryName = podcastingCategory?.name;
 	const newPostUrl = siteSlug ? `/post/${ siteSlug }` : '';
 
+	const saveButton = (
+		<Button
+			variant="primary"
+			type="submit"
+			isBusy={ isSavingSettings }
+			disabled={ disabled || ! isPodcastingEnabled || dirtyFields.length === 0 }
+		>
+			{ isSavingSettings ? translate( 'Saving…' ) : translate( 'Save' ) }
+		</Button>
+	);
+
 	if ( ! site || ! siteId ) {
 		return null;
 	}
@@ -299,17 +312,18 @@ const PodcastingSettingsForm = ( {
 					<>
 						{ /* Category + RSS feed */ }
 						<Card className="site-settings__card podcast__card">
+							<CardHeader>
+								<VStack spacing={ 1 }>
+									<Heading level={ 4 }>{ translate( 'Podcast category' ) }</Heading>
+									<Text variant="muted">
+										{ translate(
+											'Posts published in this category will be included in your podcast feed.'
+										) }
+									</Text>
+								</VStack>
+							</CardHeader>
 							<CardBody>
 								<VStack spacing={ 6 }>
-									<VStack spacing={ 1 }>
-										<h3 className="podcast__card-title">{ translate( 'Podcast category' ) }</h3>
-										<Text variant="muted">
-											{ translate(
-												'Posts published in this category will be included in your podcast feed.'
-											) }
-										</Text>
-									</VStack>
-
 									{ isEnabling && ! isPodcastingEnabled && (
 										<Notice status="info" isDismissible={ false }>
 											{ translate(
@@ -369,21 +383,23 @@ const PodcastingSettingsForm = ( {
 									) }
 								</VStack>
 							</CardBody>
+							<CardFooter>{ saveButton }</CardFooter>
 						</Card>
 
 						{ /* Show details */ }
 						<Card className="site-settings__card podcast__card">
+							<CardHeader>
+								<VStack spacing={ 1 }>
+									<Heading level={ 4 }>{ translate( 'Show details' ) }</Heading>
+									<Text variant="muted">
+										{ translate(
+											'This information appears in podcast apps like Apple Podcasts and Spotify.'
+										) }
+									</Text>
+								</VStack>
+							</CardHeader>
 							<CardBody>
 								<VStack spacing={ 6 }>
-									<VStack spacing={ 1 }>
-										<h3 className="podcast__card-title">{ translate( 'Show details' ) }</h3>
-										<Text variant="muted">
-											{ translate(
-												'This information appears in podcast apps like Apple Podcasts and Spotify.'
-											) }
-										</Text>
-									</VStack>
-
 									<HStack
 										alignment="flex-start"
 										spacing={ 6 }
@@ -438,19 +454,21 @@ const PodcastingSettingsForm = ( {
 									/>
 								</VStack>
 							</CardBody>
+							<CardFooter>{ saveButton }</CardFooter>
 						</Card>
 
 						{ /* Feed metadata */ }
 						<Card className="site-settings__card podcast__card">
+							<CardHeader>
+								<VStack spacing={ 1 }>
+									<Heading level={ 4 }>{ translate( 'Feed settings' ) }</Heading>
+									<Text variant="muted">
+										{ translate( 'Configure how your podcast appears in directories and apps.' ) }
+									</Text>
+								</VStack>
+							</CardHeader>
 							<CardBody>
 								<VStack spacing={ 6 }>
-									<VStack spacing={ 1 }>
-										<h3 className="podcast__card-title">{ translate( 'Feed settings' ) }</h3>
-										<Text variant="muted">
-											{ translate( 'Configure how your podcast appears in directories and apps.' ) }
-										</Text>
-									</VStack>
-
 									<fieldset className="podcast__settings-topics">
 										<legend className="podcast__settings-topics-legend">
 											{ translate( 'Podcast topics' ) }
@@ -526,20 +544,7 @@ const PodcastingSettingsForm = ( {
 									/>
 								</VStack>
 							</CardBody>
-						</Card>
-
-						{ /* Save */ }
-						<Card className="site-settings__card podcast__card podcast__settings-save-card">
-							<CardFooter>
-								<Button
-									variant="primary"
-									type="submit"
-									isBusy={ isSavingSettings }
-									disabled={ disabled || ! isPodcastingEnabled || dirtyFields.length === 0 }
-								>
-									{ isSavingSettings ? translate( 'Saving…' ) : translate( 'Save' ) }
-								</Button>
-							</CardFooter>
+							<CardFooter>{ saveButton }</CardFooter>
 						</Card>
 					</>
 				) }

--- a/client/my-sites/podcast/components/settings.tsx
+++ b/client/my-sites/podcast/components/settings.tsx
@@ -3,6 +3,7 @@ import {
 	WPCOM_FEATURES_UPLOAD_AUDIO_FILES,
 	getPlan,
 } from '@automattic/calypso-products';
+import { NoticeBanner } from '@automattic/components';
 import {
 	Button,
 	Card,
@@ -23,11 +24,13 @@ import { pick } from 'lodash';
 import { useCallback, useMemo, useState } from 'react';
 import TermFormDialog from 'calypso/blocks/term-form-dialog';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
+import QueryMedia from 'calypso/components/data/query-media';
 import { decodeEntities } from 'calypso/lib/formatting';
 import PodcastCoverImageSetting from 'calypso/my-sites/site-settings/podcast-cover-image-setting';
 import useTopics from 'calypso/my-sites/site-settings/podcasting-details/use-topics';
 import wrapSettingsForm from 'calypso/my-sites/site-settings/wrap-settings-form';
 import { useSelector } from 'calypso/state';
+import getMediaItem from 'calypso/state/selectors/get-media-item';
 import { hasLoadedSitePlansFromServer } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getTerms } from 'calypso/state/terms/selectors';
@@ -151,6 +154,65 @@ const PodcastingSettingsForm = ( {
 		plansDataLoaded && ( site?.options?.upgraded_filetypes_enabled || isJetpack );
 
 	const disabled = isRequestingSettings || isSavingSettings || isCoverImageUploading;
+
+	// Cover-image meta is needed to validate dimensions/format against
+	// Apple Podcasts' cover-art requirements (square, 1400-3000 px, PNG/JPG).
+	const coverImageId = Number( fields.podcasting_image_id ?? 0 ) || 0;
+	const coverImage = useSelector( ( state ) =>
+		coverImageId
+			? ( getMediaItem( state, siteId ?? 0, coverImageId ) as {
+					width?: number;
+					height?: number;
+					mime_type?: string;
+			  } | null )
+			: null
+	);
+
+	const submissionIssues = useMemo( () => {
+		const list: string[] = [];
+		if ( ! ( fields.podcasting_title ?? '' ).trim() ) {
+			list.push( translate( 'Add a title.' ) as string );
+		}
+		if ( ! ( fields.podcasting_summary ?? '' ).trim() ) {
+			list.push( translate( 'Add a summary.' ) as string );
+		}
+		if ( ! ( fields.podcasting_talent_name ?? '' ).trim() ) {
+			list.push( translate( 'Add a host, artist, or producer name.' ) as string );
+		}
+		if ( ! ( fields.podcasting_email ?? '' ).trim() ) {
+			list.push( translate( 'Add an email address.' ) as string );
+		}
+		const primaryTopic = String( fields.podcasting_category_1 ?? '0' );
+		if ( primaryTopic === '0' || primaryTopic === '' ) {
+			list.push( translate( 'Choose a primary podcast topic.' ) as string );
+		}
+		if ( ! coverImageId ) {
+			list.push( translate( 'Add a cover image.' ) as string );
+		} else if ( coverImage ) {
+			const { width, height, mime_type: mimeType } = coverImage;
+			if ( mimeType && mimeType !== 'image/png' && mimeType !== 'image/jpeg' ) {
+				list.push( translate( 'Cover image must be a PNG or JPG.' ) as string );
+			}
+			if ( width && height && width !== height ) {
+				list.push( translate( 'Cover image must be square.' ) as string );
+			}
+			if ( width && ( width < 1400 || width > 3000 ) ) {
+				list.push(
+					translate( 'Cover image must be between 1400×1400 and 3000×3000 pixels.' ) as string
+				);
+			}
+		}
+		return list;
+	}, [
+		fields.podcasting_title,
+		fields.podcasting_summary,
+		fields.podcasting_talent_name,
+		fields.podcasting_email,
+		fields.podcasting_category_1,
+		coverImageId,
+		coverImage,
+		translate,
+	] );
 
 	const onTogglePodcasting = useCallback(
 		( isEnabled: boolean ) => {
@@ -276,6 +338,8 @@ const PodcastingSettingsForm = ( {
 			</header>
 
 			<VStack spacing={ 4 } className="podcast__settings">
+				{ siteId && coverImageId && <QueryMedia siteId={ siteId } mediaId={ coverImageId } /> }
+
 				{ /* Enable / disable */ }
 				<Card className="site-settings__card podcast__card">
 					<CardBody>
@@ -295,6 +359,26 @@ const PodcastingSettingsForm = ( {
 						/>
 					</CardBody>
 				</Card>
+
+				{ /* Submission readiness */ }
+				{ isPodcastingEnabled && submissionIssues.length > 0 && (
+					<div className="podcast__settings-readiness">
+						<NoticeBanner
+							level="warning"
+							title={ translate( 'Finish setting up your feed' ) as string }
+							hideCloseButton
+						>
+							<p>
+								{ translate( 'Address these before you submit your feed to podcast directories:' ) }
+							</p>
+							<ul className="podcast__settings-issues">
+								{ submissionIssues.map( ( issue ) => (
+									<li key={ issue }>{ issue }</li>
+								) ) }
+							</ul>
+						</NoticeBanner>
+					</div>
+				) }
 
 				{ /* Audio upload upsell */ }
 				{ showSettings && plansDataLoaded && ! isAudioUploadEnabled && (

--- a/client/my-sites/podcast/components/settings.tsx
+++ b/client/my-sites/podcast/components/settings.tsx
@@ -5,16 +5,17 @@ import {
 } from '@automattic/calypso-products';
 import { NoticeBanner } from '@automattic/components';
 import {
+	BaseControl,
 	Button,
 	Card,
 	CardBody,
 	CardHeader,
+	FormTokenField,
 	Notice,
 	SelectControl,
 	TextControl,
 	TextareaControl,
 	ToggleControl,
-	__experimentalHStack as HStack,
 	__experimentalHeading as Heading,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
@@ -307,12 +308,72 @@ const PodcastingSettingsForm = ( {
 		}
 	}, [ dirtyFields, submitForm ] );
 
-	const onTopicChange = useCallback(
-		( key: 'podcasting_category_1' | 'podcasting_category_2' | 'podcasting_category_3' ) =>
-			( value: string ) => {
-				updateFields( { [ key ]: value }, () => submitForm() );
-			},
-		[ updateFields, submitForm ]
+	const topicLabelByValue = useMemo( () => {
+		const map = new Map< string, string >();
+		topicOptions.forEach( ( opt ) => {
+			if ( opt.value && opt.value !== '0' ) {
+				map.set( opt.value, opt.label );
+			}
+		} );
+		return map;
+	}, [ topicOptions ] );
+
+	const topicValueByLabel = useMemo( () => {
+		const map = new Map< string, string >();
+		topicOptions.forEach( ( opt ) => {
+			if ( opt.value && opt.value !== '0' ) {
+				map.set( opt.label, opt.value );
+			}
+		} );
+		return map;
+	}, [ topicOptions ] );
+
+	const selectedTopicLabels = useMemo( () => {
+		return [
+			fields.podcasting_category_1,
+			fields.podcasting_category_2,
+			fields.podcasting_category_3,
+		]
+			.map( ( v ) => {
+				const value = String( v ?? '' );
+				if ( ! value || value === '0' ) {
+					return '';
+				}
+				return topicLabelByValue.get( value ) ?? '';
+			} )
+			.filter( Boolean );
+	}, [
+		fields.podcasting_category_1,
+		fields.podcasting_category_2,
+		fields.podcasting_category_3,
+		topicLabelByValue,
+	] );
+
+	const topicSuggestions = useMemo(
+		() => Array.from( topicLabelByValue.values() ),
+		[ topicLabelByValue ]
+	);
+
+	const onTopicsChange = useCallback(
+		( tokens: ( string | { value: string } )[] ) => {
+			const labels = tokens
+				.map( ( t ) => ( typeof t === 'string' ? t : t.value ) )
+				.filter( ( label ) => topicValueByLabel.has( label ) )
+				.slice( 0, 3 );
+			const values = labels.map( ( label ) => topicValueByLabel.get( label ) ?? '0' );
+			while ( values.length < 3 ) {
+				values.push( '0' );
+			}
+			updateFields(
+				{
+					podcasting_category_1: values[ 0 ],
+					podcasting_category_2: values[ 1 ],
+					podcasting_category_3: values[ 2 ],
+				},
+				() => submitForm()
+			);
+		},
+		[ topicValueByLabel, updateFields, submitForm ]
 	);
 
 	const onExplicitChange = useCallback(
@@ -474,12 +535,7 @@ const PodcastingSettingsForm = ( {
 							</CardHeader>
 							<CardBody>
 								<VStack spacing={ 6 }>
-									<HStack
-										alignment="flex-start"
-										spacing={ 6 }
-										justify="flex-start"
-										className="podcast__settings-cover-row"
-									>
+									<div className="podcast__settings-cover">
 										<PodcastCoverImageSetting
 											coverImageId={ Number( fields.podcasting_image_id ?? 0 ) || 0 }
 											coverImageUrl={ fields.podcasting_image ?? '' }
@@ -488,28 +544,27 @@ const PodcastingSettingsForm = ( {
 											onUploadStateChange={ setIsCoverImageUploading }
 											isDisabled={ disabled }
 										/>
+									</div>
 
-										<VStack spacing={ 4 } className="podcast__settings-cover-fields">
-											<TextControl
-												__nextHasNoMarginBottom
-												__next40pxDefaultSize
-												label={ translate( 'Title' ) as string }
-												value={ decodeEntities( fields.podcasting_title ?? '' ) }
-												onChange={ onTextChange( 'podcasting_title' ) }
-												onBlur={ onTextBlur }
-												disabled={ disabled }
-											/>
-											<TextareaControl
-												__nextHasNoMarginBottom
-												label={ translate( 'Summary / Description' ) as string }
-												value={ decodeEntities( fields.podcasting_summary ?? '' ) }
-												onChange={ onTextChange( 'podcasting_summary' ) }
-												onBlur={ onTextBlur }
-												disabled={ disabled }
-												rows={ 4 }
-											/>
-										</VStack>
-									</HStack>
+									<TextControl
+										__nextHasNoMarginBottom
+										__next40pxDefaultSize
+										label={ translate( 'Title' ) as string }
+										value={ decodeEntities( fields.podcasting_title ?? '' ) }
+										onChange={ onTextChange( 'podcasting_title' ) }
+										onBlur={ onTextBlur }
+										disabled={ disabled }
+									/>
+
+									<TextareaControl
+										__nextHasNoMarginBottom
+										label={ translate( 'Summary / Description' ) as string }
+										value={ decodeEntities( fields.podcasting_summary ?? '' ) }
+										onChange={ onTextChange( 'podcasting_summary' ) }
+										onBlur={ onTextBlur }
+										disabled={ disabled }
+										rows={ 4 }
+									/>
 
 									<TextControl
 										__nextHasNoMarginBottom
@@ -546,48 +601,29 @@ const PodcastingSettingsForm = ( {
 							</CardHeader>
 							<CardBody>
 								<VStack spacing={ 6 }>
-									<fieldset className="podcast__settings-topics">
-										<legend className="podcast__settings-topics-legend">
-											{ translate( 'Podcast topics' ) }
-										</legend>
-										<Text variant="muted" size="12">
-											{ translate(
-												'Choose how your podcast should be categorized within Apple Podcasts and other podcasting services.'
-											) }
-										</Text>
-										<VStack spacing={ 3 }>
-											<SelectControl
-												__nextHasNoMarginBottom
-												__next40pxDefaultSize
-												label={ translate( 'Primary topic' ) as string }
-												hideLabelFromVision
-												value={ String( fields.podcasting_category_1 ?? '0' ) }
-												options={ topicOptions }
-												onChange={ onTopicChange( 'podcasting_category_1' ) }
-												disabled={ disabled }
-											/>
-											<SelectControl
-												__nextHasNoMarginBottom
-												__next40pxDefaultSize
-												label={ translate( 'Secondary topic' ) as string }
-												hideLabelFromVision
-												value={ String( fields.podcasting_category_2 ?? '0' ) }
-												options={ topicOptions }
-												onChange={ onTopicChange( 'podcasting_category_2' ) }
-												disabled={ disabled }
-											/>
-											<SelectControl
-												__nextHasNoMarginBottom
-												__next40pxDefaultSize
-												label={ translate( 'Tertiary topic' ) as string }
-												hideLabelFromVision
-												value={ String( fields.podcasting_category_3 ?? '0' ) }
-												options={ topicOptions }
-												onChange={ onTopicChange( 'podcasting_category_3' ) }
-												disabled={ disabled }
-											/>
-										</VStack>
-									</fieldset>
+									<BaseControl
+										__nextHasNoMarginBottom
+										id="podcast-topics"
+										label={ translate( 'Podcast topics' ) as string }
+										help={
+											translate(
+												'Choose how your podcast should be categorized within Apple Podcasts and other podcasting services. Pick up to three.'
+											) as string
+										}
+									>
+										<FormTokenField
+											__nextHasNoMarginBottom
+											__next40pxDefaultSize
+											__experimentalExpandOnFocus
+											__experimentalShowHowTo={ false }
+											label=""
+											value={ selectedTopicLabels }
+											suggestions={ topicSuggestions }
+											maxLength={ 3 }
+											onChange={ onTopicsChange }
+											disabled={ disabled }
+										/>
+									</BaseControl>
 
 									<SelectControl
 										__nextHasNoMarginBottom

--- a/client/my-sites/podcast/components/settings.tsx
+++ b/client/my-sites/podcast/components/settings.tsx
@@ -30,7 +30,7 @@ import wrapSettingsForm from 'calypso/my-sites/site-settings/wrap-settings-form'
 import { useSelector } from 'calypso/state';
 import { hasLoadedSitePlansFromServer } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import { getTerm, getTerms } from 'calypso/state/terms/selectors';
+import { getTerms } from 'calypso/state/terms/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const TRACKED_FIELDS = [
@@ -139,14 +139,6 @@ const PodcastingSettingsForm = ( {
 	// "Enable podcasting" CTA) so users can pick a category right away.
 	const [ isEnabling, setIsEnabling ] = useState( ! isPodcastingEnabled );
 	const showSettings = isPodcastingEnabled || isEnabling;
-
-	const podcastingCategory = useSelector( ( state ) =>
-		podcastingCategoryId
-			? ( getTerm( state, siteId ?? 0, 'category', podcastingCategoryId ) as {
-					name?: string;
-			  } | null )
-			: null
-	);
 
 	const isCategoryChanging =
 		! isSavingSettings &&
@@ -268,8 +260,6 @@ const PodcastingSettingsForm = ( {
 		[ updateFields, submitForm ]
 	);
 
-	const podcastingCategoryName = podcastingCategory?.name;
-
 	if ( ! site || ! siteId ) {
 		return null;
 	}
@@ -341,18 +331,6 @@ const PodcastingSettingsForm = ( {
 									{ isEnabling && ! isPodcastingEnabled && (
 										<Notice status="info" isDismissible={ false }>
 											{ translate( 'Select a category to start your podcast feed.' ) }
-										</Notice>
-									) }
-
-									{ isPodcastingEnabled && podcastingCategoryName && (
-										<Notice status="success" isDismissible={ false }>
-											{ translate(
-												'Publish blog posts in the {{strong}}%s{{/strong}} category to add new episodes.',
-												{
-													args: podcastingCategoryName,
-													components: { strong: <strong /> },
-												}
-											) }
 										</Notice>
 									) }
 

--- a/client/my-sites/podcast/components/settings.tsx
+++ b/client/my-sites/podcast/components/settings.tsx
@@ -1,0 +1,555 @@
+import {
+	PLAN_PERSONAL,
+	WPCOM_FEATURES_UPLOAD_AUDIO_FILES,
+	getPlan,
+} from '@automattic/calypso-products';
+import {
+	Button,
+	Card,
+	CardBody,
+	Notice,
+	SelectControl,
+	TextControl,
+	TextareaControl,
+	ToggleControl,
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { pick } from 'lodash';
+import { useCallback, useMemo, useState } from 'react';
+import TermTreeSelector from 'calypso/blocks/term-tree-selector';
+import UpsellNudge from 'calypso/blocks/upsell-nudge';
+import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
+import { decodeEntities } from 'calypso/lib/formatting';
+import PodcastCoverImageSetting from 'calypso/my-sites/site-settings/podcast-cover-image-setting';
+import useTopics from 'calypso/my-sites/site-settings/podcasting-details/use-topics';
+import wrapSettingsForm from 'calypso/my-sites/site-settings/wrap-settings-form';
+import { useSelector } from 'calypso/state';
+import { hasLoadedSitePlansFromServer } from 'calypso/state/sites/plans/selectors';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getTerm } from 'calypso/state/terms/selectors';
+import {
+	getSelectedSite,
+	getSelectedSiteId,
+	getSelectedSiteSlug,
+} from 'calypso/state/ui/selectors';
+
+const TRACKED_FIELDS = [
+	'podcasting_category_id',
+	'podcasting_title',
+	'podcasting_talent_name',
+	'podcasting_summary',
+	'podcasting_copyright',
+	'podcasting_explicit',
+	'podcasting_image',
+	'podcasting_category_1',
+	'podcasting_category_2',
+	'podcasting_category_3',
+	'podcasting_email',
+	'podcasting_image_id',
+] as const;
+
+type PodcastingFieldKey = ( typeof TRACKED_FIELDS )[ number ];
+
+type PodcastingFields = Partial< Record< PodcastingFieldKey, string > > & {
+	[ key: string ]: unknown;
+};
+
+type SiteSettingsShape = {
+	podcasting_category_id?: string | number;
+	blogname?: string;
+	[ key: string ]: unknown;
+};
+
+const getFormSettings = ( settings: SiteSettingsShape | undefined ): PodcastingFields =>
+	pick( settings ?? {}, TRACKED_FIELDS ) as PodcastingFields;
+
+interface PodcastingFormProps {
+	fields: PodcastingFields;
+	settings?: SiteSettingsShape;
+	handleSubmitForm: ( event?: React.FormEvent< HTMLFormElement > ) => void;
+	handleSelect: ( event: React.ChangeEvent< HTMLSelectElement > ) => void;
+	isRequestingSettings: boolean;
+	isSavingSettings: boolean;
+	updateFields: ( fields: Partial< PodcastingFields >, callback?: () => void ) => void;
+	submitForm: () => void;
+}
+
+interface PodcastTopicOption {
+	value: string;
+	label: string;
+}
+
+const useTopicOptions = (): PodcastTopicOption[] => {
+	const translate = useTranslate();
+	const topics = useTopics();
+
+	return useMemo( () => {
+		const options: PodcastTopicOption[] = [
+			{
+				value: '0',
+				label: translate( 'None', { context: 'podcast topic selector' } ) as string,
+			},
+		];
+
+		topics.forEach( ( topic ) => {
+			// Apple Podcasts topic keys use HTML entities for ampersands.
+			const topicKey = topic.key.replace( '&', '&amp;' );
+			options.push( { value: topicKey, label: topic.label as string } );
+			topic.subtopics.forEach( ( sub ) => {
+				const subKey = topicKey + ',' + sub.key.replace( '&', '&amp;' );
+				options.push( {
+					value: subKey,
+					label: `${ topic.label } » ${ sub.label }`,
+				} );
+			} );
+		} );
+
+		return options;
+	}, [ topics, translate ] );
+};
+
+const PodcastingSettingsForm = ( {
+	fields,
+	settings,
+	handleSubmitForm,
+	handleSelect,
+	isRequestingSettings,
+	isSavingSettings,
+	updateFields,
+	submitForm,
+}: PodcastingFormProps ) => {
+	const translate = useTranslate();
+	const topicOptions = useTopicOptions();
+
+	const [ isCoverImageUploading, setIsCoverImageUploading ] = useState( false );
+	const [ isEnabling, setIsEnabling ] = useState( false );
+
+	const siteId = useSelector( getSelectedSiteId );
+	const site = useSelector( getSelectedSite );
+	const siteSlug = useSelector( getSelectedSiteSlug );
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
+	const plansDataLoaded = useSelector( ( state ) => hasLoadedSitePlansFromServer( state, siteId ) );
+
+	const podcastingCategoryId = fields.podcasting_category_id
+		? Number( fields.podcasting_category_id )
+		: 0;
+	const isPodcastingEnabled = podcastingCategoryId > 0;
+	const showSettings = isPodcastingEnabled || isEnabling;
+
+	const podcastingCategory = useSelector( ( state ) =>
+		podcastingCategoryId
+			? ( getTerm( state, siteId ?? 0, 'category', podcastingCategoryId ) as {
+					name?: string;
+					feed_url?: string;
+			  } | null )
+			: null
+	);
+	// WP.com Simple sites can return http:; prefer https for display.
+	const feedUrl = useMemo( () => {
+		const raw = podcastingCategory?.feed_url;
+		if ( ! raw ) {
+			return '';
+		}
+		return isJetpack ? raw : raw.replace( /^http:/, 'https:' );
+	}, [ podcastingCategory, isJetpack ] );
+
+	const isCategoryChanging =
+		! isSavingSettings &&
+		! isRequestingSettings &&
+		settings &&
+		Number( settings.podcasting_category_id ) > 0 &&
+		podcastingCategoryId !== Number( settings.podcasting_category_id );
+
+	const isAudioUploadEnabled =
+		plansDataLoaded && ( site?.options?.upgraded_filetypes_enabled || isJetpack );
+
+	const disabled = isRequestingSettings || isSavingSettings || isCoverImageUploading;
+
+	const onTogglePodcasting = useCallback(
+		( isEnabled: boolean ) => {
+			if ( disabled ) {
+				return;
+			}
+
+			if ( isEnabled ) {
+				setIsEnabling( true );
+				if ( ! fields.podcasting_title ) {
+					updateFields( { podcasting_title: settings?.blogname || '' } );
+				}
+				return;
+			}
+
+			setIsEnabling( false );
+			if ( isPodcastingEnabled ) {
+				updateFields( { podcasting_category_id: '0' }, () => submitForm() );
+			}
+		},
+		[
+			disabled,
+			isPodcastingEnabled,
+			fields.podcasting_title,
+			settings?.blogname,
+			updateFields,
+			submitForm,
+		]
+	);
+
+	const onCategorySelected = useCallback(
+		( category: { ID: number } ) => {
+			updateFields( { podcasting_category_id: String( category.ID ) } );
+			setIsEnabling( false );
+		},
+		[ updateFields ]
+	);
+
+	const onCoverImageRemoved = useCallback( () => {
+		updateFields( { podcasting_image_id: '0', podcasting_image: '' } );
+	}, [ updateFields ] );
+
+	const onCoverImageSelected = useCallback(
+		( coverId: number, coverUrl: string ) => {
+			updateFields( {
+				podcasting_image_id: String( coverId ),
+				podcasting_image: coverUrl,
+			} );
+		},
+		[ updateFields ]
+	);
+
+	const onTextChange = useCallback(
+		( key: PodcastingFieldKey ) => ( value: string | undefined ) => {
+			updateFields( { [ key ]: value ?? '' } );
+		},
+		[ updateFields ]
+	);
+
+	const onTopicChange = useCallback(
+		( key: 'podcasting_category_1' | 'podcasting_category_2' | 'podcasting_category_3' ) =>
+			( value: string ) => {
+				// `wrapSettingsForm` exposes a generic select handler that expects a
+				// synthetic event shape with `target.name` / `target.value`.
+				handleSelect( {
+					target: { name: key, value },
+				} as unknown as React.ChangeEvent< HTMLSelectElement > );
+			},
+		[ handleSelect ]
+	);
+
+	const onExplicitChange = useCallback(
+		( value: string ) => {
+			updateFields( { podcasting_explicit: value } );
+		},
+		[ updateFields ]
+	);
+
+	const podcastingCategoryName = podcastingCategory?.name;
+	const newPostUrl = siteSlug ? `/post/${ siteSlug }` : '';
+
+	if ( ! site || ! siteId ) {
+		return null;
+	}
+
+	return (
+		<form id="site-settings" onSubmit={ handleSubmitForm }>
+			<header className="podcast__section-header">
+				<h2 className="podcast__section-heading">{ translate( 'Settings' ) }</h2>
+				<p className="podcast__section-description">
+					{ translate(
+						'Configure your podcast feed details. These show up in Apple Podcasts, Spotify, and other directories.'
+					) }
+				</p>
+			</header>
+
+			<VStack spacing={ 4 } className="podcast__settings">
+				{ /* Enable / disable */ }
+				<Card className="site-settings__card podcast__card">
+					<CardBody>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							checked={ isPodcastingEnabled || isEnabling }
+							onChange={ onTogglePodcasting }
+							disabled={ disabled }
+							label={ translate( 'Enable podcasting on this site' ) as string }
+							help={
+								isPodcastingEnabled
+									? ( translate(
+											'Disable to stop publishing your podcast feed. You can always set it up again.'
+									  ) as string )
+									: undefined
+							}
+						/>
+					</CardBody>
+				</Card>
+
+				{ /* Audio upload upsell */ }
+				{ showSettings && plansDataLoaded && ! isAudioUploadEnabled && (
+					<UpsellNudge
+						plan={ PLAN_PERSONAL }
+						title={ translate( 'Upload Audio with WordPress.com %(personalPlanName)s', {
+							args: { personalPlanName: getPlan( PLAN_PERSONAL )?.getTitle() ?? '' },
+						} ) }
+						description={ translate( 'Embed podcast episodes directly from your media library.' ) }
+						feature={ WPCOM_FEATURES_UPLOAD_AUDIO_FILES }
+						event="podcasting_details_upload_audio"
+						tracksImpressionName="calypso_upgrade_nudge_impression"
+						tracksClickName="calypso_upgrade_nudge_cta_click"
+						showIcon
+					/>
+				) }
+
+				{ showSettings && (
+					<>
+						{ /* Category + RSS feed */ }
+						<Card className="site-settings__card podcast__card">
+							<CardBody>
+								<VStack spacing={ 6 }>
+									<VStack spacing={ 1 }>
+										<h3 className="podcast__card-title">{ translate( 'Podcast category' ) }</h3>
+										<Text variant="muted">
+											{ translate(
+												'Posts published in this category will be included in your podcast feed.'
+											) }
+										</Text>
+									</VStack>
+
+									{ isEnabling && ! isPodcastingEnabled && (
+										<Notice status="info" isDismissible={ false }>
+											{ translate(
+												'Select a category for your podcast feed, then save your settings.'
+											) }
+										</Notice>
+									) }
+
+									{ isPodcastingEnabled && podcastingCategoryName && (
+										<Notice status="success" isDismissible={ false }>
+											{ translate(
+												'Publish blog posts in the {{strong}}%s{{/strong}} category to add new episodes.',
+												{
+													args: podcastingCategoryName,
+													components: { strong: <strong /> },
+												}
+											) }
+										</Notice>
+									) }
+
+									<TermTreeSelector
+										taxonomy="category"
+										selected={ podcastingCategoryId ? [ podcastingCategoryId ] : [] }
+										podcastingCategoryId={ podcastingCategoryId }
+										onChange={ onCategorySelected }
+										addTerm
+										onAddTermSuccess={ onCategorySelected }
+										height={ 200 }
+									/>
+
+									{ isCategoryChanging && (
+										<Notice status="warning" isDismissible={ false }>
+											{ translate(
+												'If you change categories, you will need to resubmit your feed to Apple Podcasts and any other podcasting services.'
+											) }
+										</Notice>
+									) }
+
+									{ feedUrl && (
+										<VStack spacing={ 2 }>
+											<Text weight={ 500 }>{ translate( 'RSS feed' ) }</Text>
+											<ClipboardButtonInput value={ feedUrl } />
+											<Text variant="muted" size="12">
+												{ translate(
+													'Copy your feed URL and submit it to Apple Podcasts and other podcasting services.'
+												) }
+											</Text>
+										</VStack>
+									) }
+
+									{ isPodcastingEnabled && newPostUrl && (
+										<HStack justify="flex-start">
+											<Button variant="secondary" href={ newPostUrl }>
+												{ translate( 'Create episode' ) }
+											</Button>
+										</HStack>
+									) }
+								</VStack>
+							</CardBody>
+						</Card>
+
+						{ /* Show details */ }
+						<Card className="site-settings__card podcast__card">
+							<CardBody>
+								<VStack spacing={ 6 }>
+									<VStack spacing={ 1 }>
+										<h3 className="podcast__card-title">{ translate( 'Show details' ) }</h3>
+										<Text variant="muted">
+											{ translate(
+												'This information appears in podcast apps like Apple Podcasts and Spotify.'
+											) }
+										</Text>
+									</VStack>
+
+									<HStack
+										alignment="flex-start"
+										spacing={ 6 }
+										justify="flex-start"
+										className="podcast__settings-cover-row"
+									>
+										<PodcastCoverImageSetting
+											coverImageId={ Number( fields.podcasting_image_id ?? 0 ) || 0 }
+											coverImageUrl={ fields.podcasting_image ?? '' }
+											onRemove={ onCoverImageRemoved }
+											onSelect={ onCoverImageSelected }
+											onUploadStateChange={ setIsCoverImageUploading }
+											isDisabled={ disabled }
+										/>
+
+										<VStack spacing={ 4 } className="podcast__settings-cover-fields">
+											<TextControl
+												__nextHasNoMarginBottom
+												__next40pxDefaultSize
+												label={ translate( 'Title' ) as string }
+												value={ decodeEntities( fields.podcasting_title ?? '' ) }
+												onChange={ onTextChange( 'podcasting_title' ) }
+												disabled={ disabled }
+											/>
+											<TextareaControl
+												__nextHasNoMarginBottom
+												label={ translate( 'Summary / Description' ) as string }
+												value={ decodeEntities( fields.podcasting_summary ?? '' ) }
+												onChange={ onTextChange( 'podcasting_summary' ) }
+												disabled={ disabled }
+												rows={ 4 }
+											/>
+										</VStack>
+									</HStack>
+
+									<TextControl
+										__nextHasNoMarginBottom
+										__next40pxDefaultSize
+										label={ translate( 'Hosts / Artist / Producer' ) as string }
+										value={ decodeEntities( fields.podcasting_talent_name ?? '' ) }
+										onChange={ onTextChange( 'podcasting_talent_name' ) }
+										disabled={ disabled }
+									/>
+
+									<TextControl
+										__nextHasNoMarginBottom
+										__next40pxDefaultSize
+										label={ translate( 'Copyright' ) as string }
+										value={ decodeEntities( fields.podcasting_copyright ?? '' ) }
+										onChange={ onTextChange( 'podcasting_copyright' ) }
+										disabled={ disabled }
+									/>
+								</VStack>
+							</CardBody>
+						</Card>
+
+						{ /* Feed metadata */ }
+						<Card className="site-settings__card podcast__card">
+							<CardBody>
+								<VStack spacing={ 6 }>
+									<VStack spacing={ 1 }>
+										<h3 className="podcast__card-title">{ translate( 'Feed settings' ) }</h3>
+										<Text variant="muted">
+											{ translate( 'Configure how your podcast appears in directories and apps.' ) }
+										</Text>
+									</VStack>
+
+									<VStack spacing={ 3 }>
+										<Text weight={ 500 }>{ translate( 'Podcast topics' ) }</Text>
+										<Text variant="muted" size="12">
+											{ translate(
+												'Choose how your podcast should be categorized within Apple Podcasts and other podcasting services.'
+											) }
+										</Text>
+										<SelectControl
+											__nextHasNoMarginBottom
+											__next40pxDefaultSize
+											label={ translate( 'Primary topic' ) as string }
+											hideLabelFromVision
+											value={ String( fields.podcasting_category_1 ?? '0' ) }
+											options={ topicOptions }
+											onChange={ onTopicChange( 'podcasting_category_1' ) }
+											disabled={ disabled }
+										/>
+										<SelectControl
+											__nextHasNoMarginBottom
+											__next40pxDefaultSize
+											label={ translate( 'Secondary topic' ) as string }
+											hideLabelFromVision
+											value={ String( fields.podcasting_category_2 ?? '0' ) }
+											options={ topicOptions }
+											onChange={ onTopicChange( 'podcasting_category_2' ) }
+											disabled={ disabled }
+										/>
+										<SelectControl
+											__nextHasNoMarginBottom
+											__next40pxDefaultSize
+											label={ translate( 'Tertiary topic' ) as string }
+											hideLabelFromVision
+											value={ String( fields.podcasting_category_3 ?? '0' ) }
+											options={ topicOptions }
+											onChange={ onTopicChange( 'podcasting_category_3' ) }
+											disabled={ disabled }
+										/>
+									</VStack>
+
+									<SelectControl
+										__nextHasNoMarginBottom
+										__next40pxDefaultSize
+										label={ translate( 'Explicit content' ) as string }
+										value={ String( fields.podcasting_explicit ?? 'no' ) }
+										options={
+											[
+												{ value: 'no', label: translate( 'No' ) as string },
+												{ value: 'yes', label: translate( 'Yes' ) as string },
+												{ value: 'clean', label: translate( 'Clean' ) as string },
+											] as PodcastTopicOption[]
+										}
+										onChange={ onExplicitChange }
+										disabled={ disabled }
+									/>
+
+									<TextControl
+										__nextHasNoMarginBottom
+										__next40pxDefaultSize
+										type="email"
+										label={ translate( 'Email address' ) as string }
+										help={
+											translate(
+												'This email address will be displayed in the feed and is required for some services such as Google Play.'
+											) as string
+										}
+										value={ decodeEntities( fields.podcasting_email ?? '' ) }
+										onChange={ onTextChange( 'podcasting_email' ) }
+										disabled={ disabled }
+									/>
+								</VStack>
+							</CardBody>
+						</Card>
+
+						{ /* Save */ }
+						<HStack justify="flex-end" className="podcast__settings-actions">
+							<Button
+								variant="primary"
+								type="submit"
+								isBusy={ isSavingSettings }
+								disabled={ disabled || ! isPodcastingEnabled }
+							>
+								{ isSavingSettings ? translate( 'Saving…' ) : translate( 'Save settings' ) }
+							</Button>
+						</HStack>
+					</>
+				) }
+			</VStack>
+		</form>
+	);
+};
+
+// `wrapSettingsForm` is a JS HOC; type its output loosely and cast its inputs.
+const Settings = wrapSettingsForm( getFormSettings )(
+	PodcastingSettingsForm as unknown as React.ComponentType
+) as unknown as React.ComponentType;
+
+export default Settings;

--- a/client/my-sites/podcast/components/settings.tsx
+++ b/client/my-sites/podcast/components/settings.tsx
@@ -125,7 +125,6 @@ const PodcastingSettingsForm = ( {
 	const topicOptions = useTopicOptions();
 
 	const [ isCoverImageUploading, setIsCoverImageUploading ] = useState( false );
-	const [ isEnabling, setIsEnabling ] = useState( false );
 
 	const siteId = useSelector( getSelectedSiteId );
 	const site = useSelector( getSelectedSite );
@@ -137,6 +136,9 @@ const PodcastingSettingsForm = ( {
 		? Number( fields.podcasting_category_id )
 		: 0;
 	const isPodcastingEnabled = podcastingCategoryId > 0;
+	// Reveal the form for first-time setup (e.g. arriving from Welcome's
+	// "Enable podcasting" CTA) so users can pick a category right away.
+	const [ isEnabling, setIsEnabling ] = useState( ! isPodcastingEnabled );
 	const showSettings = isPodcastingEnabled || isEnabling;
 
 	const podcastingCategory = useSelector( ( state ) =>
@@ -323,9 +325,7 @@ const PodcastingSettingsForm = ( {
 								<VStack spacing={ 6 }>
 									{ isEnabling && ! isPodcastingEnabled && (
 										<Notice status="info" isDismissible={ false }>
-											{ translate(
-												'Select a category for your podcast feed, then save your settings.'
-											) }
+											{ translate( 'Select a category to start your podcast feed.' ) }
 										</Notice>
 									) }
 

--- a/client/my-sites/podcast/components/settings.tsx
+++ b/client/my-sites/podcast/components/settings.tsx
@@ -183,6 +183,9 @@ const PodcastingSettingsForm = ( {
 
 	const submissionIssues = useMemo( () => {
 		const list: string[] = [];
+		if ( ! isPodcastingEnabled ) {
+			list.push( translate( 'Select a podcast category.' ) as string );
+		}
 		if ( ! ( fields.podcasting_title ?? '' ).trim() ) {
 			list.push( translate( 'Add a title.' ) as string );
 		}
@@ -224,6 +227,7 @@ const PodcastingSettingsForm = ( {
 		fields.podcasting_category_1,
 		coverImageId,
 		coverImage,
+		isPodcastingEnabled,
 		translate,
 	] );
 
@@ -399,11 +403,15 @@ const PodcastingSettingsForm = ( {
 			<VStack spacing={ 4 } className="podcast__settings">
 				{ siteId && coverImageId && <QueryMedia siteId={ siteId } mediaId={ coverImageId } /> }
 
-				{ isPodcastingEnabled && submissionIssues.length > 0 && (
+				{ submissionIssues.length > 0 && (
 					<div className="podcast__settings-readiness">
 						<NoticeBanner
 							level="warning"
-							title={ translate( 'Almost ready to submit' ) as string }
+							title={
+								isPodcastingEnabled
+									? ( translate( 'Almost ready to submit' ) as string )
+									: ( translate( 'Set up your podcast feed' ) as string )
+							}
 							hideCloseButton
 						>
 							<p>
@@ -433,12 +441,6 @@ const PodcastingSettingsForm = ( {
 					</CardHeader>
 					<CardBody>
 						<VStack spacing={ 6 }>
-							{ ! isPodcastingEnabled && (
-								<Notice status="info" isDismissible={ false }>
-									{ translate( 'Select a category to start your podcast feed.' ) }
-								</Notice>
-							) }
-
 							<VStack spacing={ 2 }>
 								<SelectControl
 									__nextHasNoMarginBottom

--- a/client/my-sites/podcast/components/settings.tsx
+++ b/client/my-sites/podcast/components/settings.tsx
@@ -351,7 +351,7 @@ const PodcastingSettingsForm = ( {
 											onClick={ () => setIsAddCategoryOpen( true ) }
 											disabled={ disabled }
 										>
-											{ translate( 'Add category' ) }
+											{ translate( 'Create a category' ) }
 										</Button>
 									</HStack>
 

--- a/client/my-sites/podcast/components/settings.tsx
+++ b/client/my-sites/podcast/components/settings.tsx
@@ -92,10 +92,10 @@ const useTopicOptions = (): PodcastTopicOption[] => {
 
 		topics.forEach( ( topic ) => {
 			// Apple Podcasts topic keys use HTML entities for ampersands.
-			const topicKey = topic.key.replace( '&', '&amp;' );
+			const topicKey = topic.key.replaceAll( '&', '&amp;' );
 			options.push( { value: topicKey, label: topic.label as string } );
 			topic.subtopics.forEach( ( sub ) => {
-				const subKey = topicKey + ',' + sub.key.replace( '&', '&amp;' );
+				const subKey = topicKey + ',' + sub.key.replaceAll( '&', '&amp;' );
 				options.push( {
 					value: subKey,
 					label: `${ topic.label } » ${ sub.label }`,
@@ -351,10 +351,13 @@ const PodcastingSettingsForm = ( {
 
 	const onTopicsChange = useCallback(
 		( tokens: ( string | { value: string } )[] ) => {
-			const labels = tokens
-				.map( ( t ) => ( typeof t === 'string' ? t : t.value ) )
-				.filter( ( label ) => topicValueByLabel.has( label ) )
-				.slice( 0, 3 );
+			const labels = Array.from(
+				new Set(
+					tokens
+						.map( ( t ) => ( typeof t === 'string' ? t : t.value ) )
+						.filter( ( label ) => topicValueByLabel.has( label ) )
+				)
+			).slice( 0, 3 );
 			const values = labels.map( ( label ) => topicValueByLabel.get( label ) ?? '0' );
 			while ( values.length < 3 ) {
 				values.push( '0' );
@@ -497,6 +500,7 @@ const PodcastingSettingsForm = ( {
 									onSelect={ onCoverImageSelected }
 									onUploadStateChange={ setIsCoverImageUploading }
 									isDisabled={ disabled }
+									previewSize={ 256 }
 								/>
 							</div>
 
@@ -556,8 +560,6 @@ const PodcastingSettingsForm = ( {
 						<VStack spacing={ 6 }>
 							<BaseControl
 								__nextHasNoMarginBottom
-								id="podcast-topics"
-								label={ translate( 'Podcast topics' ) as string }
 								help={
 									translate(
 										'Choose how your podcast should be categorized within Apple Podcasts and other podcasting services. Pick up to three.'
@@ -569,7 +571,7 @@ const PodcastingSettingsForm = ( {
 									__next40pxDefaultSize
 									__experimentalExpandOnFocus
 									__experimentalShowHowTo={ false }
-									label=""
+									label={ translate( 'Podcast topics' ) as string }
 									value={ selectedTopicLabels }
 									suggestions={ topicSuggestions }
 									maxLength={ 3 }
@@ -588,7 +590,7 @@ const PodcastingSettingsForm = ( {
 										{ value: 'no', label: translate( 'No' ) as string },
 										{ value: 'yes', label: translate( 'Yes' ) as string },
 										{ value: 'clean', label: translate( 'Clean' ) as string },
-									] as PodcastTopicOption[]
+									] as { value: string; label: string }[]
 								}
 								onChange={ onExplicitChange }
 								disabled={ disabled }

--- a/client/my-sites/podcast/components/settings.tsx
+++ b/client/my-sites/podcast/components/settings.tsx
@@ -53,9 +53,7 @@ const TRACKED_FIELDS = [
 
 type PodcastingFieldKey = ( typeof TRACKED_FIELDS )[ number ];
 
-type PodcastingFields = Partial< Record< PodcastingFieldKey, string > > & {
-	[ key: string ]: unknown;
-};
+type PodcastingFields = Partial< Record< PodcastingFieldKey, string > >;
 
 type SiteSettingsShape = {
 	podcasting_category_id?: string | number;
@@ -70,10 +68,9 @@ interface PodcastingFormProps {
 	fields: PodcastingFields;
 	settings?: SiteSettingsShape;
 	handleSubmitForm: ( event?: React.FormEvent< HTMLFormElement > ) => void;
-	handleSelect: ( event: React.ChangeEvent< HTMLSelectElement > ) => void;
 	isRequestingSettings: boolean;
 	isSavingSettings: boolean;
-	updateFields: ( fields: Partial< PodcastingFields >, callback?: () => void ) => void;
+	updateFields: ( fields: Record< string, string >, callback?: () => void ) => void;
 	submitForm: () => void;
 }
 
@@ -115,7 +112,6 @@ const PodcastingSettingsForm = ( {
 	fields,
 	settings,
 	handleSubmitForm,
-	handleSelect,
 	isRequestingSettings,
 	isSavingSettings,
 	updateFields,
@@ -229,13 +225,9 @@ const PodcastingSettingsForm = ( {
 	const onTopicChange = useCallback(
 		( key: 'podcasting_category_1' | 'podcasting_category_2' | 'podcasting_category_3' ) =>
 			( value: string ) => {
-				// `wrapSettingsForm` exposes a generic select handler that expects a
-				// synthetic event shape with `target.name` / `target.value`.
-				handleSelect( {
-					target: { name: key, value },
-				} as unknown as React.ChangeEvent< HTMLSelectElement > );
+				updateFields( { [ key ]: value } );
 			},
-		[ handleSelect ]
+		[ updateFields ]
 	);
 
 	const onExplicitChange = useCallback(
@@ -456,44 +448,48 @@ const PodcastingSettingsForm = ( {
 										</Text>
 									</VStack>
 
-									<VStack spacing={ 3 }>
-										<Text weight={ 500 }>{ translate( 'Podcast topics' ) }</Text>
+									<fieldset className="podcast__settings-topics">
+										<legend className="podcast__settings-topics-legend">
+											{ translate( 'Podcast topics' ) }
+										</legend>
 										<Text variant="muted" size="12">
 											{ translate(
 												'Choose how your podcast should be categorized within Apple Podcasts and other podcasting services.'
 											) }
 										</Text>
-										<SelectControl
-											__nextHasNoMarginBottom
-											__next40pxDefaultSize
-											label={ translate( 'Primary topic' ) as string }
-											hideLabelFromVision
-											value={ String( fields.podcasting_category_1 ?? '0' ) }
-											options={ topicOptions }
-											onChange={ onTopicChange( 'podcasting_category_1' ) }
-											disabled={ disabled }
-										/>
-										<SelectControl
-											__nextHasNoMarginBottom
-											__next40pxDefaultSize
-											label={ translate( 'Secondary topic' ) as string }
-											hideLabelFromVision
-											value={ String( fields.podcasting_category_2 ?? '0' ) }
-											options={ topicOptions }
-											onChange={ onTopicChange( 'podcasting_category_2' ) }
-											disabled={ disabled }
-										/>
-										<SelectControl
-											__nextHasNoMarginBottom
-											__next40pxDefaultSize
-											label={ translate( 'Tertiary topic' ) as string }
-											hideLabelFromVision
-											value={ String( fields.podcasting_category_3 ?? '0' ) }
-											options={ topicOptions }
-											onChange={ onTopicChange( 'podcasting_category_3' ) }
-											disabled={ disabled }
-										/>
-									</VStack>
+										<VStack spacing={ 3 }>
+											<SelectControl
+												__nextHasNoMarginBottom
+												__next40pxDefaultSize
+												label={ translate( 'Primary topic' ) as string }
+												hideLabelFromVision
+												value={ String( fields.podcasting_category_1 ?? '0' ) }
+												options={ topicOptions }
+												onChange={ onTopicChange( 'podcasting_category_1' ) }
+												disabled={ disabled }
+											/>
+											<SelectControl
+												__nextHasNoMarginBottom
+												__next40pxDefaultSize
+												label={ translate( 'Secondary topic' ) as string }
+												hideLabelFromVision
+												value={ String( fields.podcasting_category_2 ?? '0' ) }
+												options={ topicOptions }
+												onChange={ onTopicChange( 'podcasting_category_2' ) }
+												disabled={ disabled }
+											/>
+											<SelectControl
+												__nextHasNoMarginBottom
+												__next40pxDefaultSize
+												label={ translate( 'Tertiary topic' ) as string }
+												hideLabelFromVision
+												value={ String( fields.podcasting_category_3 ?? '0' ) }
+												options={ topicOptions }
+												onChange={ onTopicChange( 'podcasting_category_3' ) }
+												disabled={ disabled }
+											/>
+										</VStack>
+									</fieldset>
 
 									<SelectControl
 										__nextHasNoMarginBottom

--- a/client/my-sites/podcast/components/settings.tsx
+++ b/client/my-sites/podcast/components/settings.tsx
@@ -331,7 +331,7 @@ const PodcastingSettingsForm = ( {
 									<Heading level={ 4 }>{ translate( 'Podcast category' ) }</Heading>
 									<Text variant="muted">
 										{ translate(
-											'Posts published in this category will be included in your podcast feed.'
+											'Posts in this category are treated as podcast episodes. Add an audio or video block to each one so listeners have something to play.'
 										) }
 									</Text>
 								</VStack>

--- a/client/my-sites/podcast/components/settings.tsx
+++ b/client/my-sites/podcast/components/settings.tsx
@@ -420,11 +420,10 @@ const PodcastingSettingsForm = ( {
 										</Notice>
 									) }
 
-									<HStack alignment="flex-end" spacing={ 3 } justify="flex-start">
+									<VStack spacing={ 2 }>
 										<SelectControl
 											__nextHasNoMarginBottom
 											__next40pxDefaultSize
-											className="podcast__settings-category-select"
 											label={ translate( 'Category' ) as string }
 											hideLabelFromVision
 											value={ podcastingCategoryId ? String( podcastingCategoryId ) : '' }
@@ -433,13 +432,14 @@ const PodcastingSettingsForm = ( {
 											disabled={ disabled }
 										/>
 										<Button
-											variant="secondary"
+											variant="link"
+											className="podcast__settings-category-add"
 											onClick={ () => setIsAddCategoryOpen( true ) }
 											disabled={ disabled }
 										>
-											{ translate( 'Create a category' ) }
+											{ translate( 'Create a new category' ) }
 										</Button>
-									</HStack>
+									</VStack>
 
 									<TermFormDialog
 										showDialog={ isAddCategoryOpen }

--- a/client/my-sites/podcast/components/settings.tsx
+++ b/client/my-sites/podcast/components/settings.tsx
@@ -16,8 +16,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { pick } from 'lodash';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import TermFormDialog from 'calypso/blocks/term-form-dialog';
 import QueryMedia from 'calypso/components/data/query-media';
 import { decodeEntities } from 'calypso/lib/formatting';
@@ -55,7 +54,12 @@ type SiteSettingsShape = {
 };
 
 const getFormSettings = ( settings: SiteSettingsShape | undefined ): PodcastingFields =>
-	pick( settings ?? {}, TRACKED_FIELDS ) as PodcastingFields;
+	Object.fromEntries(
+		TRACKED_FIELDS.filter( ( key ) => settings && key in settings ).map( ( key ) => [
+			key,
+			settings![ key ],
+		] )
+	) as PodcastingFields;
 
 interface PodcastingFormProps {
 	fields: PodcastingFields;
@@ -138,6 +142,28 @@ const PodcastingSettingsForm = ( {
 		podcastingCategoryId !== Number( settings.podcasting_category_id );
 
 	const disabled = isRequestingSettings || isSavingSettings || isCoverImageUploading;
+
+	// Pre-fill the title from the site name on first arrival when the user
+	// hasn't enabled podcasting yet. Mirrors the legacy toggle-on behavior so
+	// users coming from Welcome's "Enable podcasting" CTA see a sensible default.
+	useEffect( () => {
+		if (
+			! isRequestingSettings &&
+			! isPodcastingEnabled &&
+			! fields.podcasting_title &&
+			! settings?.podcasting_title &&
+			settings?.blogname
+		) {
+			updateFields( { podcasting_title: settings.blogname } );
+		}
+	}, [
+		isRequestingSettings,
+		isPodcastingEnabled,
+		fields.podcasting_title,
+		settings?.podcasting_title,
+		settings?.blogname,
+		updateFields,
+	] );
 
 	// Cover-image meta is needed to validate dimensions/format against
 	// Apple Podcasts' cover-art requirements (square, 1400-3000 px, PNG/JPG).
@@ -381,27 +407,6 @@ const PodcastingSettingsForm = ( {
 			<VStack spacing={ 4 } className="podcast__settings">
 				{ siteId && coverImageId && <QueryMedia siteId={ siteId } mediaId={ coverImageId } /> }
 
-				{ /* Enable / disable */ }
-				<Card className="site-settings__card podcast__card">
-					<CardBody>
-						<ToggleControl
-							__nextHasNoMarginBottom
-							checked={ isPodcastingEnabled }
-							onChange={ onTogglePodcasting }
-							disabled={ disabled }
-							label={ translate( 'Enable podcasting on this site' ) as string }
-							help={
-								isPodcastingEnabled
-									? ( translate(
-											'Disable to stop publishing your podcast feed. You can always set it up again.'
-									  ) as string )
-									: undefined
-							}
-						/>
-					</CardBody>
-				</Card>
-
-				{ /* Submission readiness */ }
 				{ isPodcastingEnabled && submissionIssues.length > 0 && (
 					<div className="podcast__settings-readiness">
 						<NoticeBanner
@@ -423,7 +428,6 @@ const PodcastingSettingsForm = ( {
 					</div>
 				) }
 
-				{ /* Category + RSS feed */ }
 				<Card className="site-settings__card podcast__card">
 					<CardHeader>
 						<VStack spacing={ 1 }>
@@ -483,7 +487,6 @@ const PodcastingSettingsForm = ( {
 					</CardBody>
 				</Card>
 
-				{ /* Show details */ }
 				<Card className="site-settings__card podcast__card">
 					<CardHeader>
 						<VStack spacing={ 1 }>
@@ -551,7 +554,6 @@ const PodcastingSettingsForm = ( {
 					</CardBody>
 				</Card>
 
-				{ /* Feed metadata */ }
 				<Card className="site-settings__card podcast__card">
 					<CardHeader>
 						<VStack spacing={ 1 }>
@@ -621,14 +623,28 @@ const PodcastingSettingsForm = ( {
 						</VStack>
 					</CardBody>
 				</Card>
+
+				<Card className="site-settings__card podcast__card">
+					<CardBody>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							checked={ isPodcastingEnabled }
+							onChange={ onTogglePodcasting }
+							disabled={ disabled }
+							label={ translate( 'Enable podcasting on this site' ) as string }
+							help={
+								isPodcastingEnabled
+									? ( translate(
+											'Disable to stop publishing your podcast feed. You can always set it up again.'
+									  ) as string )
+									: undefined
+							}
+						/>
+					</CardBody>
+				</Card>
 			</VStack>
 		</form>
 	);
 };
 
-// `wrapSettingsForm` is a JS HOC; type its output loosely and cast its inputs.
-const Settings = wrapSettingsForm( getFormSettings )(
-	PodcastingSettingsForm as unknown as React.ComponentType
-) as unknown as React.ComponentType;
-
-export default Settings;
+export default wrapSettingsForm( getFormSettings )( PodcastingSettingsForm );

--- a/client/my-sites/podcast/components/settings.tsx
+++ b/client/my-sites/podcast/components/settings.tsx
@@ -10,7 +10,6 @@ import {
 	SelectControl,
 	TextControl,
 	TextareaControl,
-	ToggleControl,
 	__experimentalHeading as Heading,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
@@ -224,32 +223,12 @@ const PodcastingSettingsForm = ( {
 		translate,
 	] );
 
-	const onTogglePodcasting = useCallback(
-		( isEnabled: boolean ) => {
-			if ( disabled ) {
-				return;
-			}
-
-			if ( isEnabled ) {
-				if ( ! fields.podcasting_title ) {
-					updateFields( { podcasting_title: settings?.blogname || '' } );
-				}
-				return;
-			}
-
-			if ( isPodcastingEnabled ) {
-				updateFields( { podcasting_category_id: '0' }, () => submitForm() );
-			}
-		},
-		[
-			disabled,
-			isPodcastingEnabled,
-			fields.podcasting_title,
-			settings?.blogname,
-			updateFields,
-			submitForm,
-		]
-	);
+	const onDisablePodcasting = useCallback( () => {
+		if ( disabled || ! isPodcastingEnabled ) {
+			return;
+		}
+		updateFields( { podcasting_category_id: '0' }, () => submitForm() );
+	}, [ disabled, isPodcastingEnabled, updateFields, submitForm ] );
 
 	const onCategorySelected = useCallback(
 		( category: { ID: number } ) => {
@@ -624,24 +603,30 @@ const PodcastingSettingsForm = ( {
 					</CardBody>
 				</Card>
 
-				<Card className="site-settings__card podcast__card">
-					<CardBody>
-						<ToggleControl
-							__nextHasNoMarginBottom
-							checked={ isPodcastingEnabled }
-							onChange={ onTogglePodcasting }
-							disabled={ disabled }
-							label={ translate( 'Enable podcasting on this site' ) as string }
-							help={
-								isPodcastingEnabled
-									? ( translate(
-											'Disable to stop publishing your podcast feed. You can always set it up again.'
-									  ) as string )
-									: undefined
-							}
-						/>
-					</CardBody>
-				</Card>
+				{ isPodcastingEnabled && (
+					<Card className="site-settings__card podcast__card">
+						<CardHeader>
+							<VStack spacing={ 1 }>
+								<Heading level={ 4 }>{ translate( 'Disable podcasting' ) }</Heading>
+								<Text variant="muted">
+									{ translate(
+										'Stops publishing your podcast feed. Your show details stay saved, so you can set it up again later.'
+									) }
+								</Text>
+							</VStack>
+						</CardHeader>
+						<CardBody>
+							<Button
+								variant="secondary"
+								isDestructive
+								onClick={ onDisablePodcasting }
+								disabled={ disabled }
+							>
+								{ translate( 'Disable podcasting' ) }
+							</Button>
+						</CardBody>
+					</Card>
+				) }
 			</VStack>
 		</form>
 	);

--- a/client/my-sites/podcast/components/settings.tsx
+++ b/client/my-sites/podcast/components/settings.tsx
@@ -4,6 +4,7 @@ import {
 	getPlan,
 } from '@automattic/calypso-products';
 import {
+	Button,
 	Card,
 	CardBody,
 	CardHeader,
@@ -20,7 +21,7 @@ import {
 import { useTranslate } from 'i18n-calypso';
 import { pick } from 'lodash';
 import { useCallback, useMemo, useState } from 'react';
-import TermTreeSelector from 'calypso/blocks/term-tree-selector';
+import TermFormDialog from 'calypso/blocks/term-form-dialog';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import { decodeEntities } from 'calypso/lib/formatting';
 import PodcastCoverImageSetting from 'calypso/my-sites/site-settings/podcast-cover-image-setting';
@@ -29,7 +30,7 @@ import wrapSettingsForm from 'calypso/my-sites/site-settings/wrap-settings-form'
 import { useSelector } from 'calypso/state';
 import { hasLoadedSitePlansFromServer } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import { getTerm } from 'calypso/state/terms/selectors';
+import { getTerm, getTerms } from 'calypso/state/terms/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const TRACKED_FIELDS = [
@@ -119,10 +120,15 @@ const PodcastingSettingsForm = ( {
 	const topicOptions = useTopicOptions();
 
 	const [ isCoverImageUploading, setIsCoverImageUploading ] = useState( false );
+	const [ isAddCategoryOpen, setIsAddCategoryOpen ] = useState( false );
 
 	const siteId = useSelector( getSelectedSiteId );
 	const site = useSelector( getSelectedSite );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
+	const categories = useSelector(
+		( state ) =>
+			( getTerms( state, siteId ?? 0, 'category' ) as { ID: number; name?: string }[] | null ) ?? []
+	);
 	const plansDataLoaded = useSelector( ( state ) => hasLoadedSitePlansFromServer( state, siteId ) );
 
 	const podcastingCategoryId = fields.podcasting_category_id
@@ -190,6 +196,32 @@ const PodcastingSettingsForm = ( {
 		},
 		[ updateFields, submitForm ]
 	);
+
+	const onCategoryDropdownChange = useCallback(
+		( value: string ) => {
+			const id = Number( value );
+			if ( ! Number.isFinite( id ) || id <= 0 ) {
+				return;
+			}
+			onCategorySelected( { ID: id } );
+		},
+		[ onCategorySelected ]
+	);
+
+	const categoryOptions = useMemo( () => {
+		const options = categories.map( ( cat ) => ( {
+			value: String( cat.ID ),
+			label: decodeEntities( cat.name ?? '' ),
+		} ) );
+		options.sort( ( a, b ) => a.label.localeCompare( b.label ) );
+		if ( ! podcastingCategoryId ) {
+			options.unshift( {
+				value: '',
+				label: translate( 'Select a category' ) as string,
+			} );
+		}
+		return options;
+	}, [ categories, podcastingCategoryId, translate ] );
 
 	const onCoverImageRemoved = useCallback( () => {
 		updateFields( { podcasting_image_id: '0', podcasting_image: '' }, () => submitForm() );
@@ -324,14 +356,33 @@ const PodcastingSettingsForm = ( {
 										</Notice>
 									) }
 
-									<TermTreeSelector
+									<HStack alignment="flex-end" spacing={ 3 } justify="flex-start">
+										<SelectControl
+											__nextHasNoMarginBottom
+											__next40pxDefaultSize
+											className="podcast__settings-category-select"
+											label={ translate( 'Category' ) as string }
+											hideLabelFromVision
+											value={ podcastingCategoryId ? String( podcastingCategoryId ) : '' }
+											options={ categoryOptions }
+											onChange={ onCategoryDropdownChange }
+											disabled={ disabled }
+										/>
+										<Button
+											variant="secondary"
+											onClick={ () => setIsAddCategoryOpen( true ) }
+											disabled={ disabled }
+										>
+											{ translate( 'Add category' ) }
+										</Button>
+									</HStack>
+
+									<TermFormDialog
+										showDialog={ isAddCategoryOpen }
+										onClose={ () => setIsAddCategoryOpen( false ) }
+										postType="post"
 										taxonomy="category"
-										selected={ podcastingCategoryId ? [ podcastingCategoryId ] : [] }
-										podcastingCategoryId={ podcastingCategoryId }
-										onChange={ onCategorySelected }
-										addTerm
-										onAddTermSuccess={ onCategorySelected }
-										height={ 200 }
+										onSuccess={ onCategorySelected }
 									/>
 
 									{ isCategoryChanging && (

--- a/client/my-sites/podcast/components/settings.tsx
+++ b/client/my-sites/podcast/components/settings.tsx
@@ -7,7 +7,6 @@ import {
 	Button,
 	Card,
 	CardBody,
-	CardFooter,
 	CardHeader,
 	Notice,
 	SelectControl,
@@ -200,24 +199,27 @@ const PodcastingSettingsForm = ( {
 
 	const onCategorySelected = useCallback(
 		( category: { ID: number } ) => {
-			updateFields( { podcasting_category_id: String( category.ID ) } );
+			updateFields( { podcasting_category_id: String( category.ID ) }, () => submitForm() );
 			setIsEnabling( false );
 		},
-		[ updateFields ]
+		[ updateFields, submitForm ]
 	);
 
 	const onCoverImageRemoved = useCallback( () => {
-		updateFields( { podcasting_image_id: '0', podcasting_image: '' } );
-	}, [ updateFields ] );
+		updateFields( { podcasting_image_id: '0', podcasting_image: '' }, () => submitForm() );
+	}, [ updateFields, submitForm ] );
 
 	const onCoverImageSelected = useCallback(
 		( coverId: number, coverUrl: string ) => {
-			updateFields( {
-				podcasting_image_id: String( coverId ),
-				podcasting_image: coverUrl,
-			} );
+			updateFields(
+				{
+					podcasting_image_id: String( coverId ),
+					podcasting_image: coverUrl,
+				},
+				() => submitForm()
+			);
 		},
-		[ updateFields ]
+		[ updateFields, submitForm ]
 	);
 
 	const onTextChange = useCallback(
@@ -227,34 +229,29 @@ const PodcastingSettingsForm = ( {
 		[ updateFields ]
 	);
 
+	const onTextBlur = useCallback( () => {
+		if ( dirtyFields.length > 0 ) {
+			submitForm();
+		}
+	}, [ dirtyFields, submitForm ] );
+
 	const onTopicChange = useCallback(
 		( key: 'podcasting_category_1' | 'podcasting_category_2' | 'podcasting_category_3' ) =>
 			( value: string ) => {
-				updateFields( { [ key ]: value } );
+				updateFields( { [ key ]: value }, () => submitForm() );
 			},
-		[ updateFields ]
+		[ updateFields, submitForm ]
 	);
 
 	const onExplicitChange = useCallback(
 		( value: string ) => {
-			updateFields( { podcasting_explicit: value } );
+			updateFields( { podcasting_explicit: value }, () => submitForm() );
 		},
-		[ updateFields ]
+		[ updateFields, submitForm ]
 	);
 
 	const podcastingCategoryName = podcastingCategory?.name;
 	const newPostUrl = siteSlug ? `/post/${ siteSlug }` : '';
-
-	const saveButton = (
-		<Button
-			variant="primary"
-			type="submit"
-			isBusy={ isSavingSettings }
-			disabled={ disabled || ! isPodcastingEnabled || dirtyFields.length === 0 }
-		>
-			{ isSavingSettings ? translate( 'Saving…' ) : translate( 'Save' ) }
-		</Button>
-	);
 
 	if ( ! site || ! siteId ) {
 		return null;
@@ -383,7 +380,6 @@ const PodcastingSettingsForm = ( {
 									) }
 								</VStack>
 							</CardBody>
-							<CardFooter>{ saveButton }</CardFooter>
 						</Card>
 
 						{ /* Show details */ }
@@ -422,6 +418,7 @@ const PodcastingSettingsForm = ( {
 												label={ translate( 'Title' ) as string }
 												value={ decodeEntities( fields.podcasting_title ?? '' ) }
 												onChange={ onTextChange( 'podcasting_title' ) }
+												onBlur={ onTextBlur }
 												disabled={ disabled }
 											/>
 											<TextareaControl
@@ -429,6 +426,7 @@ const PodcastingSettingsForm = ( {
 												label={ translate( 'Summary / Description' ) as string }
 												value={ decodeEntities( fields.podcasting_summary ?? '' ) }
 												onChange={ onTextChange( 'podcasting_summary' ) }
+												onBlur={ onTextBlur }
 												disabled={ disabled }
 												rows={ 4 }
 											/>
@@ -441,6 +439,7 @@ const PodcastingSettingsForm = ( {
 										label={ translate( 'Hosts / Artist / Producer' ) as string }
 										value={ decodeEntities( fields.podcasting_talent_name ?? '' ) }
 										onChange={ onTextChange( 'podcasting_talent_name' ) }
+										onBlur={ onTextBlur }
 										disabled={ disabled }
 									/>
 
@@ -450,11 +449,11 @@ const PodcastingSettingsForm = ( {
 										label={ translate( 'Copyright' ) as string }
 										value={ decodeEntities( fields.podcasting_copyright ?? '' ) }
 										onChange={ onTextChange( 'podcasting_copyright' ) }
+										onBlur={ onTextBlur }
 										disabled={ disabled }
 									/>
 								</VStack>
 							</CardBody>
-							<CardFooter>{ saveButton }</CardFooter>
 						</Card>
 
 						{ /* Feed metadata */ }
@@ -540,11 +539,11 @@ const PodcastingSettingsForm = ( {
 										}
 										value={ decodeEntities( fields.podcasting_email ?? '' ) }
 										onChange={ onTextChange( 'podcasting_email' ) }
+										onBlur={ onTextBlur }
 										disabled={ disabled }
 									/>
 								</VStack>
 							</CardBody>
-							<CardFooter>{ saveButton }</CardFooter>
 						</Card>
 					</>
 				) }

--- a/client/my-sites/podcast/components/settings.tsx
+++ b/client/my-sites/podcast/components/settings.tsx
@@ -526,7 +526,7 @@ const PodcastingSettingsForm = ( {
 										label={ translate( 'Email address' ) as string }
 										help={
 											translate(
-												'This email address will be displayed in the feed and is required for some services such as Google Play.'
+												'Included in your feed so podcast directories can verify ownership. Most require it for submission.'
 											) as string
 										}
 										value={ decodeEntities( fields.podcasting_email ?? '' ) }

--- a/client/my-sites/podcast/components/welcome.tsx
+++ b/client/my-sites/podcast/components/welcome.tsx
@@ -1,3 +1,9 @@
+import {
+	isBusinessPlan,
+	isEcommercePlan,
+	isPersonalPlan,
+	isPremiumPlan,
+} from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { PlanPrice } from '@automattic/components';
 import {
@@ -12,28 +18,44 @@ import { Icon, audio, check, layout, megaphone } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import getSitePlanSlug from 'calypso/state/sites/selectors/get-site-plan-slug';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
-export type PlanTier = 'free' | 'personal' | 'premium' | 'business';
+type PlanSlug = 'personal' | 'premium' | 'business';
+type PlanTier = 'free' | PlanSlug;
+type Translate = ReturnType< typeof useTranslate >;
 
-interface WelcomeProps {
-	planTier: PlanTier;
-}
+const getPlanTier = ( planSlug: string | null ): PlanTier => {
+	if ( ! planSlug ) {
+		return 'free';
+	}
+	if ( isBusinessPlan( planSlug ) || isEcommercePlan( planSlug ) ) {
+		return 'business';
+	}
+	if ( isPremiumPlan( planSlug ) ) {
+		return 'premium';
+	}
+	if ( isPersonalPlan( planSlug ) ) {
+		return 'personal';
+	}
+	return 'free';
+};
 
 interface PlanDef {
-	slug: 'personal' | 'premium' | 'business';
+	slug: PlanSlug;
 	name: string;
 	blurb: string;
 	price: number;
 	features: string[];
 }
 
-type Translate = ReturnType< typeof useTranslate >;
+type PlanCard = { plan: PlanDef; label: 'your-plan' | 'recommended' | null };
 
-const getPlans = (
-	translate: Translate
-): Record< 'personal' | 'premium' | 'business', PlanDef > => ( {
-	personal: {
+// Show the user's plan + the next one up. Free sees Personal + Premium (Recommended).
+// On paid plans the upgrade target is shown without a "Recommended" push.
+// Business sees only Business.
+function getPlanCards( tier: PlanTier, translate: Translate ): PlanCard[] {
+	const personal: PlanDef = {
 		slug: 'personal',
 		name: translate( 'Personal' ) as string,
 		blurb: translate( 'Run a real podcast with native tools and stats.' ) as string,
@@ -45,8 +67,8 @@ const getPlans = (
 			translate( 'Episode block' ) as string,
 			translate( 'Episode scaffolding on publish' ) as string,
 		],
-	},
-	premium: {
+	};
+	const premium: PlanDef = {
 		slug: 'premium',
 		name: translate( 'Premium' ) as string,
 		blurb: translate( 'Add AI tools and self-hosted video to your show.' ) as string,
@@ -57,8 +79,8 @@ const getPlans = (
 			translate( 'Chapter markers' ) as string,
 			translate( 'Self-hosted video with VideoPress' ) as string,
 		],
-	},
-	business: {
+	};
+	const business: PlanDef = {
 		slug: 'business',
 		name: translate( 'Business' ) as string,
 		blurb: translate( 'Scale your podcast with full hosting and developer tools.' ) as string,
@@ -68,35 +90,27 @@ const getPlans = (
 			translate( 'Priority 24/7 support' ) as string,
 			translate( 'SFTP, WP-CLI, and GitHub Deployments' ) as string,
 		],
-	},
-} );
+	};
 
-// Show the user's plan + the next one up. Free sees Personal + Premium (Recommended).
-// On paid plans the upgrade target is shown without a "Recommended" push.
-// Business sees only Business.
-function getPlanCards(
-	tier: PlanTier,
-	plans: Record< 'personal' | 'premium' | 'business', PlanDef >
-): { plan: PlanDef; label: 'your-plan' | 'recommended' | null }[] {
-	if ( tier === 'free' ) {
-		return [
-			{ plan: plans.personal, label: null },
-			{ plan: plans.premium, label: 'recommended' },
-		];
+	switch ( tier ) {
+		case 'free':
+			return [
+				{ plan: personal, label: null },
+				{ plan: premium, label: 'recommended' },
+			];
+		case 'personal':
+			return [
+				{ plan: personal, label: 'your-plan' },
+				{ plan: premium, label: null },
+			];
+		case 'premium':
+			return [
+				{ plan: premium, label: 'your-plan' },
+				{ plan: business, label: null },
+			];
+		case 'business':
+			return [ { plan: business, label: 'your-plan' } ];
 	}
-	if ( tier === 'personal' ) {
-		return [
-			{ plan: plans.personal, label: 'your-plan' },
-			{ plan: plans.premium, label: null },
-		];
-	}
-	if ( tier === 'premium' ) {
-		return [
-			{ plan: plans.premium, label: 'your-plan' },
-			{ plan: plans.business, label: null },
-		];
-	}
-	return [ { plan: plans.business, label: 'your-plan' } ];
 }
 
 const getBenefits = (
@@ -147,36 +161,27 @@ const getSteps = ( translate: Translate ): { number: string; title: string; body
 	},
 ];
 
-// Mock episodes for the hero preview
-const getSampleShow = ( translate: Translate ) => ( {
-	title: translate( 'Far From Home' ) as string,
-	host: 'Maya Chen',
-} );
-
-const getSampleEpisodes = ( translate: Translate ) => [
-	{
-		number: 4,
-		title: translate( 'Lost in Lisbon: how getting turned around saved my trip' ) as string,
-		duration: translate( '38 min' ) as string,
-	},
-	{
-		number: 3,
-		title: translate( 'Eating my way through Oaxaca' ) as string,
-		duration: translate( '45 min' ) as string,
-	},
-];
-
-function Welcome( { planTier }: WelcomeProps ) {
+function Welcome() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const siteSlug = useSelector( getSelectedSiteSlug );
+	const siteId = useSelector( getSelectedSiteId );
+	const planSlug = useSelector( ( state ) => getSitePlanSlug( state, siteId ) );
+	const planTier = getPlanTier( planSlug );
 
-	const plans = getPlans( translate );
-	const cards = getPlanCards( planTier, plans );
+	const cards = getPlanCards( planTier, translate );
 	const benefits = getBenefits( translate );
 	const steps = getSteps( translate );
-	const sampleShow = getSampleShow( translate );
-	const sampleEpisodes = getSampleEpisodes( translate );
+	const sampleEpisodes = [
+		{
+			title: translate( 'Lost in Lisbon: how getting turned around saved my trip' ) as string,
+			duration: translate( '38 min' ) as string,
+		},
+		{
+			title: translate( 'Eating my way through Oaxaca' ) as string,
+			duration: translate( '45 min' ) as string,
+		},
+	];
 	const isFree = planTier === 'free';
 	const pricingTitle = isFree
 		? ( translate( 'Get more out of podcasting with a plan upgrade' ) as string )
@@ -191,23 +196,22 @@ function Welcome( { planTier }: WelcomeProps ) {
 
 	// Redirect through Calypso checkout, then back to /podcasting so the user can
 	// click Enable on their now-eligible plan.
-	const goToCheckout = ( planSlug: 'personal' | 'premium' | 'business' ) => {
+	const goToCheckout = ( targetPlan: PlanSlug ) => {
 		dispatch(
 			recordTracksEvent( 'calypso_podcast_upgrade_clicked', {
-				plan_slug: planSlug,
+				plan_slug: targetPlan,
 				current_tier: planTier,
 			} )
 		);
 		const returnTo = siteSlug ? `/podcasting/${ siteSlug }` : '/podcasting';
 		const path = siteSlug
-			? `/checkout/${ siteSlug }/${ planSlug }?redirect_to=${ encodeURIComponent( returnTo ) }`
-			: `/checkout/${ planSlug }`;
+			? `/checkout/${ siteSlug }/${ targetPlan }?redirect_to=${ encodeURIComponent( returnTo ) }`
+			: `/checkout/${ targetPlan }`;
 		page.show( path );
 	};
 
 	return (
 		<VStack spacing={ 8 } className="podcast__welcome">
-			{ /* Hero */ }
 			<section className="podcast__welcome-hero">
 				<VStack spacing={ 4 } className="podcast__welcome-hero-copy">
 					<h2 className="podcast__welcome-title">
@@ -233,9 +237,9 @@ function Welcome( { planTier }: WelcomeProps ) {
 									<Icon icon={ audio } />
 								</span>
 								<VStack spacing={ 0 }>
-									<Text weight={ 600 }>{ sampleShow.title }</Text>
+									<Text weight={ 600 }>{ translate( 'Far From Home' ) }</Text>
 									<Text variant="muted" size={ 12 }>
-										{ translate( 'by %(host)s', { args: { host: sampleShow.host } } ) }
+										{ translate( 'by %(host)s', { args: { host: 'Maya Chen' } } ) }
 									</Text>
 									<Text variant="muted" size={ 11 }>
 										{ translate( 'Apple Podcasts · Spotify · Overcast', {
@@ -247,7 +251,7 @@ function Welcome( { planTier }: WelcomeProps ) {
 							</HStack>
 							<VStack as="ul" spacing={ 1 } className="podcast__welcome-hero-preview-episodes">
 								{ sampleEpisodes.map( ( ep ) => (
-									<HStack as="li" key={ ep.number } alignment="center" spacing={ 2 }>
+									<HStack as="li" key={ ep.title } alignment="center" spacing={ 2 }>
 										<Text size={ 11 } variant="muted">
 											▶
 										</Text>
@@ -263,7 +267,6 @@ function Welcome( { planTier }: WelcomeProps ) {
 				</Card>
 			</section>
 
-			{ /* Pricing */ }
 			<section className="podcast__welcome-pricing">
 				<header className="podcast__section-header">
 					<h2 className="podcast__section-heading">{ pricingTitle }</h2>
@@ -331,7 +334,6 @@ function Welcome( { planTier }: WelcomeProps ) {
 				</HStack>
 			</section>
 
-			{ /* Benefits */ }
 			<HStack alignment="stretch" spacing={ 4 } wrap>
 				{ benefits.map( ( b ) => (
 					<Card
@@ -354,7 +356,6 @@ function Welcome( { planTier }: WelcomeProps ) {
 				) ) }
 			</HStack>
 
-			{ /* How it works */ }
 			<Card>
 				<CardBody>
 					<VStack spacing={ 5 }>

--- a/client/my-sites/podcast/components/welcome.tsx
+++ b/client/my-sites/podcast/components/welcome.tsx
@@ -10,7 +10,8 @@ import {
 } from '@wordpress/components';
 import { Icon, audio, check, layout, megaphone } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useSelector } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 export type PlanTier = 'free' | 'personal' | 'premium' | 'business';
@@ -167,6 +168,7 @@ const getSampleEpisodes = ( translate: Translate ) => [
 
 function Welcome( { planTier }: WelcomeProps ) {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const siteSlug = useSelector( getSelectedSiteSlug );
 
 	const plans = getPlans( translate );
@@ -190,6 +192,12 @@ function Welcome( { planTier }: WelcomeProps ) {
 	// Redirect through Calypso checkout, then back to /podcasting so the user can
 	// click Enable on their now-eligible plan.
 	const goToCheckout = ( planSlug: 'personal' | 'premium' | 'business' ) => {
+		dispatch(
+			recordTracksEvent( 'calypso_podcast_upgrade_clicked', {
+				plan_slug: planSlug,
+				current_tier: planTier,
+			} )
+		);
 		const returnTo = siteSlug ? `/podcasting/${ siteSlug }` : '/podcasting';
 		const path = siteSlug
 			? `/checkout/${ siteSlug }/${ planSlug }?redirect_to=${ encodeURIComponent( returnTo ) }`

--- a/client/my-sites/podcast/components/welcome.tsx
+++ b/client/my-sites/podcast/components/welcome.tsx
@@ -180,11 +180,10 @@ function Welcome( { planTier }: WelcomeProps ) {
 		? ( translate( 'Get more out of podcasting with a plan upgrade' ) as string )
 		: ( translate( 'Podcasting is included in your plan' ) as string );
 
-	// Enable podcasting by sending the user to the existing Settings → Podcasting
-	// flow, where picking a category writes podcasting_category_id. Returning to
-	// /podcasting/[site] after that lands the user on the Episodes tab.
+	// Forward into the Settings tab with the form pre-revealed; picking a
+	// category there writes podcasting_category_id and flips podcasting on.
 	const goToSettings = () => {
-		const path = siteSlug ? `/settings/podcasting/${ siteSlug }` : '/settings/podcasting';
+		const path = siteSlug ? `/podcasting/settings/${ siteSlug }` : '/podcasting/settings';
 		page.show( path );
 	};
 

--- a/client/my-sites/podcast/index.ts
+++ b/client/my-sites/podcast/index.ts
@@ -8,6 +8,7 @@ export default function () {
 	page( '/podcasting', siteSelection, sites, makeLayout, clientRender );
 	page( '/podcasting/episodes', siteSelection, sites, makeLayout, clientRender );
 	page( '/podcasting/distribution', siteSelection, sites, makeLayout, clientRender );
+	page( '/podcasting/settings', siteSelection, sites, makeLayout, clientRender );
 
 	page(
 		'/podcasting/:site_id',
@@ -20,7 +21,7 @@ export default function () {
 	);
 
 	page(
-		'/podcasting/:section(episodes|distribution)/:site_id',
+		'/podcasting/:section(episodes|distribution|settings)/:site_id',
 		siteSelection,
 		navigation,
 		siteSettings,

--- a/client/my-sites/podcast/main.tsx
+++ b/client/my-sites/podcast/main.tsx
@@ -91,16 +91,18 @@ const PodcastMain = ( { section }: PodcastMainProps ) => {
 
 	// Keep the URL in sync with the current view: tabs live at
 	// /podcasting/<section>/[site], welcome at the bare /podcasting/[site]. A
-	// disabled podcast on a section URL gets bounced back to welcome.
+	// disabled podcast on episodes/distribution gets bounced back to welcome,
+	// but /podcasting/settings stays accessible so the user can flip podcasting on.
 	useEffect( () => {
 		if ( ! isSetupResolved ) {
 			return;
 		}
 		const path = window.location.pathname;
 		const isSectionUrl = /^\/podcasting\/(episodes|distribution|settings)(\/|$)/.test( path );
+		const isContentSectionUrl = /^\/podcasting\/(episodes|distribution)(\/|$)/.test( path );
 		if ( showTabs && ! isSectionUrl ) {
 			window.history.replaceState( null, '', '/podcasting/episodes' + pathSuffix );
-		} else if ( ! showTabs && isSectionUrl ) {
+		} else if ( ! showTabs && isContentSectionUrl ) {
 			window.history.replaceState( null, '', '/podcasting' + pathSuffix );
 		}
 	}, [ showTabs, isSetupResolved, pathSuffix ] );
@@ -181,6 +183,14 @@ const PodcastMain = ( { section }: PodcastMainProps ) => {
 					</div>
 				</Tabs.Panel>
 			</Tabs.Root>
+		);
+	} else if ( tabSection === 'settings' ) {
+		// Pre-setup users land here from Welcome's "Enable podcasting" CTA;
+		// render Settings on its own so they can pick a category.
+		pageContent = (
+			<div className="podcast__tab-content">
+				<Settings />
+			</div>
 		);
 	} else {
 		pageContent = (

--- a/client/my-sites/podcast/main.tsx
+++ b/client/my-sites/podcast/main.tsx
@@ -114,7 +114,7 @@ const PodcastMain = ( { section }: PodcastMainProps ) => {
 	const prevIsSetUp = useRef( isSetUp );
 	useEffect( () => {
 		if ( isSetupResolved && prevIsSetUp.current && ! isSetUp ) {
-			page.show( '/podcast' + pathSuffix );
+			page.show( '/podcasting' + pathSuffix );
 		}
 		prevIsSetUp.current = isSetUp;
 	}, [ isSetUp, isSetupResolved, pathSuffix ] );

--- a/client/my-sites/podcast/main.tsx
+++ b/client/my-sites/podcast/main.tsx
@@ -1,7 +1,8 @@
+import page from '@automattic/calypso-router';
 import { Page } from '@wordpress/admin-ui';
 import { Tabs } from '@wordpress/ui';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import QueryTerms from 'calypso/components/data/query-terms';
@@ -107,6 +108,17 @@ const PodcastMain = ( { section }: PodcastMainProps ) => {
 		}
 	}, [ showTabs, isSetupResolved, pathSuffix ] );
 
+	// Detect a true→false transition on isSetUp (the user just disabled
+	// podcasting from Settings) and bounce them to Welcome via page.show so
+	// the controller re-runs with no `section` prop.
+	const prevIsSetUp = useRef( isSetUp );
+	useEffect( () => {
+		if ( isSetupResolved && prevIsSetUp.current && ! isSetUp ) {
+			page.show( '/podcast' + pathSuffix );
+		}
+		prevIsSetUp.current = isSetUp;
+	}, [ isSetUp, isSetupResolved, pathSuffix ] );
+
 	const tabs = [
 		{
 			name: 'episodes' as const,
@@ -184,7 +196,7 @@ const PodcastMain = ( { section }: PodcastMainProps ) => {
 				</Tabs.Panel>
 			</Tabs.Root>
 		);
-	} else if ( tabSection === 'settings' ) {
+	} else if ( section === 'settings' ) {
 		// Pre-setup users land here from Welcome's "Enable podcasting" CTA;
 		// render Settings on its own so they can pick a category.
 		pageContent = (

--- a/client/my-sites/podcast/main.tsx
+++ b/client/my-sites/podcast/main.tsx
@@ -22,17 +22,12 @@ import useAccessGate from './hooks/use-access-gate';
 
 import './style.scss';
 
-type PodcastSection = 'episodes' | 'distribution' | 'settings';
+const VALID_SECTIONS = [ 'episodes', 'distribution', 'settings' ] as const;
+type PodcastSection = ( typeof VALID_SECTIONS )[ number ];
 
 type PodcastMainProps = {
 	section?: string;
 };
-
-const VALID_SECTIONS: readonly PodcastSection[] = [
-	'episodes',
-	'distribution',
-	'settings',
-] as const;
 
 const isValidSection = ( s: string | undefined ): s is PodcastSection =>
 	!! s && ( VALID_SECTIONS as readonly string[] ).includes( s );
@@ -42,15 +37,17 @@ const PodcastMain = ( { section }: PodcastMainProps ) => {
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const accessGate = useAccessGate();
-	// Match the Episodes-tab resolution: prefer the legacy setting, then fall
-	// back to a category named "Podcast" so sites with episodes already
-	// flowing through that term land on Episodes by default.
+	// If podcasting_category_id is set, trust it (0 = user disabled). Only
+	// when the setting is missing do we fall back to a "Podcast" category
+	// heuristic so sites with episodes already flowing through that term
+	// land on Episodes by default.
 	const isSetUp = useSelector( ( state ) => {
 		if ( ! siteId ) {
 			return false;
 		}
-		if ( getPodcastingCategoryId( state, siteId ) ) {
-			return true;
+		const categoryId = getPodcastingCategoryId( state, siteId );
+		if ( categoryId !== null ) {
+			return Number( categoryId ) > 0;
 		}
 		const terms = getTerms( state, siteId, 'category' );
 		return Array.isArray( terms )
@@ -58,14 +55,14 @@ const PodcastMain = ( { section }: PodcastMainProps ) => {
 			: false;
 	} );
 	// True once we have a definitive answer for `isSetUp` — either the
-	// setting is set, or the terms list has loaded. Used to suppress a
-	// welcome → tabs flash on the bare /podcasting/[site] URL while data
-	// is still in flight.
+	// setting has loaded (any value, including 0), or the terms list has
+	// loaded. Used to suppress a welcome → tabs flash on the bare
+	// /podcasting/[site] URL while data is still in flight.
 	const isSetupResolved = useSelector( ( state ) => {
 		if ( ! siteId ) {
 			return true;
 		}
-		if ( getPodcastingCategoryId( state, siteId ) ) {
+		if ( getPodcastingCategoryId( state, siteId ) !== null ) {
 			return true;
 		}
 		return Array.isArray( getTerms( state, siteId, 'category' ) );
@@ -151,14 +148,13 @@ const PodcastMain = ( { section }: PodcastMainProps ) => {
 		}
 	};
 
-	// Render nothing until we know whether podcasting is set up — prevents a
-	// Welcome flash before terms/site-settings resolve and we switch to tabs.
-	const isWaitingForSetup = ! isSetupResolved;
-
 	let pageContent;
 	if ( accessGate ) {
 		pageContent = accessGate;
-	} else if ( isWaitingForSetup ) {
+	} else if ( ! isSetupResolved ) {
+		// Render nothing until we know whether podcasting is set up — prevents
+		// a Welcome flash before terms/site-settings resolve and we switch to
+		// tabs.
 		pageContent = null;
 	} else if ( showTabs ) {
 		pageContent = (
@@ -207,7 +203,7 @@ const PodcastMain = ( { section }: PodcastMainProps ) => {
 	} else {
 		pageContent = (
 			<div className="podcast__tab-content">
-				<Welcome planTier="free" />
+				<Welcome />
 			</div>
 		);
 	}

--- a/client/my-sites/podcast/main.tsx
+++ b/client/my-sites/podcast/main.tsx
@@ -15,18 +15,23 @@ import { getTerms } from 'calypso/state/terms/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import Distribution from './components/distribution';
 import Episodes from './components/episodes';
+import Settings from './components/settings';
 import Welcome from './components/welcome';
 import useAccessGate from './hooks/use-access-gate';
 
 import './style.scss';
 
-type PodcastSection = 'episodes' | 'distribution';
+type PodcastSection = 'episodes' | 'distribution' | 'settings';
 
 type PodcastMainProps = {
 	section?: string;
 };
 
-const VALID_SECTIONS: readonly PodcastSection[] = [ 'episodes', 'distribution' ] as const;
+const VALID_SECTIONS: readonly PodcastSection[] = [
+	'episodes',
+	'distribution',
+	'settings',
+] as const;
 
 const isValidSection = ( s: string | undefined ): s is PodcastSection =>
 	!! s && ( VALID_SECTIONS as readonly string[] ).includes( s );
@@ -92,7 +97,7 @@ const PodcastMain = ( { section }: PodcastMainProps ) => {
 			return;
 		}
 		const path = window.location.pathname;
-		const isSectionUrl = /^\/podcasting\/(episodes|distribution)(\/|$)/.test( path );
+		const isSectionUrl = /^\/podcasting\/(episodes|distribution|settings)(\/|$)/.test( path );
 		if ( showTabs && ! isSectionUrl ) {
 			window.history.replaceState( null, '', '/podcasting/episodes' + pathSuffix );
 		} else if ( ! showTabs && isSectionUrl ) {
@@ -110,6 +115,11 @@ const PodcastMain = ( { section }: PodcastMainProps ) => {
 			name: 'distribution' as const,
 			title: translate( 'Distribution' ) as string,
 			path: '/podcasting/distribution' + pathSuffix,
+		},
+		{
+			name: 'settings' as const,
+			title: translate( 'Settings' ) as string,
+			path: '/podcasting/settings' + pathSuffix,
 		},
 	];
 
@@ -163,6 +173,11 @@ const PodcastMain = ( { section }: PodcastMainProps ) => {
 				<Tabs.Panel value="distribution">
 					<div className="podcast__tab-content">
 						<Distribution />
+					</div>
+				</Tabs.Panel>
+				<Tabs.Panel value="settings">
+					<div className="podcast__tab-content">
+						<Settings />
 					</div>
 				</Tabs.Panel>
 			</Tabs.Root>

--- a/client/my-sites/podcast/style.scss
+++ b/client/my-sites/podcast/style.scss
@@ -75,6 +75,35 @@ body.is-section-podcasting {
 	min-inline-size: 0;
 }
 
+.podcast__settings-issues {
+	margin: 4px 0 0;
+	padding-inline-start: 18px;
+	list-style: disc;
+}
+
+.podcast__settings-readiness .notice-banner {
+	padding: 16px;
+	font-size: 13px;
+
+	p {
+		margin: 0;
+		font-size: 13px;
+		line-height: 1.5;
+	}
+}
+
+.podcast__settings-readiness .notice-banner__title {
+	font-size: 13px;
+	font-weight: 500;
+	line-height: 1.5;
+	margin-block-end: 4px;
+}
+
+.podcast__settings-readiness .notice-banner__icon-wrapper {
+	margin-block-start: 0;
+	margin-inline-end: 12px;
+}
+
 .podcast__settings-topics {
 	margin: 0;
 	padding: 0;

--- a/client/my-sites/podcast/style.scss
+++ b/client/my-sites/podcast/style.scss
@@ -78,10 +78,6 @@ body.is-section-podcasting {
 	}
 }
 
-.podcast__settings-actions {
-	padding-block-start: 8px;
-}
-
 .podcast__settings-topics {
 	margin: 0;
 	padding: 0;

--- a/client/my-sites/podcast/style.scss
+++ b/client/my-sites/podcast/style.scss
@@ -87,6 +87,16 @@ body.is-section-podcasting {
 	height: 220px;
 	margin: 0;
 	align-self: start;
+	overflow: hidden;
+}
+
+.podcast__settings-cover .podcast-cover-image-setting__img {
+	width: 100%;
+	height: 100%;
+	max-width: none;
+	max-height: none;
+	object-fit: cover;
+	margin: 0;
 }
 
 // Empty state: turn the preview into an obvious dashed upload zone with a

--- a/client/my-sites/podcast/style.scss
+++ b/client/my-sites/podcast/style.scss
@@ -54,14 +54,6 @@ body.is-section-podcasting {
 	}
 }
 
-.podcast__card-title {
-	margin: 0;
-	font-size: 16px;
-	font-weight: 500;
-	line-height: 1.4;
-	color: var( --wpds-color-fg-content-neutral, #1e1e1e );
-}
-
 .podcast__settings {
 	max-inline-size: 760px;
 }

--- a/client/my-sites/podcast/style.scss
+++ b/client/my-sites/podcast/style.scss
@@ -89,6 +89,46 @@ body.is-section-podcasting {
 	align-self: start;
 }
 
+// Empty state: turn the preview into an obvious dashed upload zone with a
+// "+" affordance, and hide the redundant "Add" button beside it.
+.podcast__settings-cover .podcast-cover-image-setting__preview.is-blank {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-direction: column;
+	gap: 4px;
+	border: 2px dashed var( --wpds-color-stroke-base-tertiary, #c3c4c7 );
+	background: var( --wpds-color-bg-surface-base-secondary, #f6f7f7 );
+	transition: border-color 0.15s ease, background-color 0.15s ease;
+
+	&::before {
+		content: '+';
+		font-size: 28px;
+		font-weight: 400;
+		line-height: 1;
+		color: var( --wpds-color-fg-content-neutral-weak, #757575 );
+	}
+
+	&:hover:not( :disabled ),
+	&:focus-visible {
+		border-color: var( --wpds-color-stroke-status-info-strong, #007cba );
+		background: var( --wpds-color-bg-surface-base, #fff );
+	}
+}
+
+.podcast__settings-cover .podcast-cover-image-setting__preview.is-blank
+	.podcast-cover-image-setting__placeholder {
+	font-style: normal;
+	font-size: 12px;
+	color: var( --wpds-color-fg-content-neutral-weak, #757575 );
+}
+
+.podcast__settings-cover
+	.podcast-cover-image-setting:has( .podcast-cover-image-setting__preview.is-blank )
+	.podcast-cover-image-setting__button {
+	display: none;
+}
+
 .podcast__settings-cover .podcast-cover-image-setting__button {
 	float: none;
 	grid-column: 2;

--- a/client/my-sites/podcast/style.scss
+++ b/client/my-sites/podcast/style.scss
@@ -58,16 +58,45 @@ body.is-section-podcasting {
 	max-inline-size: 760px;
 }
 
-.podcast__settings-cover-fields {
-	flex: 1;
-	min-inline-size: 0;
+// Larger cover preview with manage buttons stacked to the right.
+.podcast__settings-cover .podcast-cover-image-setting {
+	width: auto;
+	display: grid;
+	grid-template-columns: auto 1fr;
+	column-gap: 16px;
+	row-gap: 8px;
+	align-items: start;
 }
 
-.podcast__settings-cover-row {
-	@media ( max-width: 600px ) {
-		flex-direction: column;
-		align-items: stretch !important;
-	}
+.podcast__settings-cover .podcast-cover-image-setting > label,
+.podcast__settings-cover .podcast-cover-image-setting > .form-label {
+	grid-column: 1 / -1;
+	margin: 0;
+	font-size: 11px;
+	font-weight: 500;
+	text-transform: uppercase;
+	letter-spacing: 0;
+	color: inherit;
+}
+
+.podcast__settings-cover .podcast-cover-image-setting__preview {
+	float: none;
+	grid-column: 1;
+	grid-row: 2 / span 10;
+	width: 160px;
+	height: 160px;
+	margin: 0;
+	align-self: start;
+}
+
+.podcast__settings-cover .podcast-cover-image-setting__button {
+	float: none;
+	grid-column: 2;
+	margin: 0;
+	align-self: start;
+	justify-self: start;
+	width: auto;
+	min-inline-size: 110px;
 }
 
 .podcast__settings-category-add {
@@ -101,19 +130,6 @@ body.is-section-podcasting {
 .podcast__settings-readiness .notice-banner__icon-wrapper {
 	margin-block-start: 0;
 	margin-inline-end: 12px;
-}
-
-.podcast__settings-topics {
-	margin: 0;
-	padding: 0;
-	border: 0;
-}
-
-.podcast__settings-topics-legend {
-	display: block;
-	margin-block-end: 4px;
-	padding: 0;
-	font-weight: 500;
 }
 
 // Plan cards: bordered surface, optional corner badge that sits flush with

--- a/client/my-sites/podcast/style.scss
+++ b/client/my-sites/podcast/style.scss
@@ -82,6 +82,19 @@ body.is-section-podcasting {
 	padding-block-start: 8px;
 }
 
+.podcast__settings-topics {
+	margin: 0;
+	padding: 0;
+	border: 0;
+}
+
+.podcast__settings-topics-legend {
+	display: block;
+	margin-block-end: 4px;
+	padding: 0;
+	font-weight: 500;
+}
+
 // Plan cards: bordered surface, optional corner badge that sits flush with
 // the top edge, content stretches so feature list fills the remaining space.
 .podcast__plan-card {

--- a/client/my-sites/podcast/style.scss
+++ b/client/my-sites/podcast/style.scss
@@ -54,6 +54,34 @@ body.is-section-podcasting {
 	}
 }
 
+.podcast__card-title {
+	margin: 0;
+	font-size: 16px;
+	font-weight: 500;
+	line-height: 1.4;
+	color: var( --wpds-color-fg-content-neutral, #1e1e1e );
+}
+
+.podcast__settings {
+	max-inline-size: 760px;
+}
+
+.podcast__settings-cover-fields {
+	flex: 1;
+	min-inline-size: 0;
+}
+
+.podcast__settings-cover-row {
+	@media ( max-width: 600px ) {
+		flex-direction: column;
+		align-items: stretch !important;
+	}
+}
+
+.podcast__settings-actions {
+	padding-block-start: 8px;
+}
+
 // Plan cards: bordered surface, optional corner badge that sits flush with
 // the top edge, content stretches so feature list fills the remaining space.
 .podcast__plan-card {

--- a/client/my-sites/podcast/style.scss
+++ b/client/my-sites/podcast/style.scss
@@ -70,9 +70,8 @@ body.is-section-podcasting {
 	}
 }
 
-.podcast__settings-category-select {
-	flex: 1;
-	min-inline-size: 0;
+.podcast__settings-category-add {
+	align-self: flex-start;
 }
 
 .podcast__settings-issues {

--- a/client/my-sites/podcast/style.scss
+++ b/client/my-sites/podcast/style.scss
@@ -70,6 +70,11 @@ body.is-section-podcasting {
 	}
 }
 
+.podcast__settings-category-select {
+	flex: 1;
+	min-inline-size: 0;
+}
+
 .podcast__settings-topics {
 	margin: 0;
 	padding: 0;

--- a/client/my-sites/podcast/style.scss
+++ b/client/my-sites/podcast/style.scss
@@ -83,8 +83,8 @@ body.is-section-podcasting {
 	float: none;
 	grid-column: 1;
 	grid-row: 2 / span 10;
-	width: 160px;
-	height: 160px;
+	width: 220px;
+	height: 220px;
 	margin: 0;
 	align-self: start;
 }

--- a/client/my-sites/site-settings/podcast-cover-image-setting/index.jsx
+++ b/client/my-sites/site-settings/podcast-cover-image-setting/index.jsx
@@ -182,7 +182,7 @@ class PodcastCoverImageSetting extends PureComponent {
 		const { transientMediaId, isUploading } = this.state;
 		const media = transientMediaId && this.props.getMediaItem( siteId, transientMediaId );
 		const imageUrl = ( media && media.URL ) || coverImageUrl;
-		const imageSrc = imageUrl && resizeImageUrl( imageUrl, 96 );
+		const imageSrc = imageUrl && resizeImageUrl( imageUrl, 256 );
 		const isTransient = !! transientMediaId;
 
 		const classNames = clsx( 'podcast-cover-image-setting__preview', {

--- a/client/my-sites/site-settings/podcast-cover-image-setting/index.jsx
+++ b/client/my-sites/site-settings/podcast-cover-image-setting/index.jsx
@@ -42,7 +42,12 @@ class PodcastCoverImageSetting extends PureComponent {
 		onSelect: PropTypes.func,
 		onUploadStateChange: PropTypes.func,
 		isDisabled: PropTypes.bool,
+		previewSize: PropTypes.number,
 		addMedia: PropTypes.func,
+	};
+
+	static defaultProps = {
+		previewSize: 96,
 	};
 
 	state = {
@@ -178,11 +183,11 @@ class PodcastCoverImageSetting extends PureComponent {
 	}
 
 	renderCoverPreview() {
-		const { coverImageUrl, siteId, translate, isDisabled } = this.props;
+		const { coverImageUrl, siteId, translate, isDisabled, previewSize } = this.props;
 		const { transientMediaId, isUploading } = this.state;
 		const media = transientMediaId && this.props.getMediaItem( siteId, transientMediaId );
 		const imageUrl = ( media && media.URL ) || coverImageUrl;
-		const imageSrc = imageUrl && resizeImageUrl( imageUrl, 256 );
+		const imageSrc = imageUrl && resizeImageUrl( imageUrl, previewSize );
 		const isTransient = !! transientMediaId;
 
 		const classNames = clsx( 'podcast-cover-image-setting__preview', {


### PR DESCRIPTION
## Screenshot

<img width="1262" height="2012" alt="Screenshot on 2026-04-29 at 01-33-52" src="https://github.com/user-attachments/assets/296cdd01-9219-4ad2-a38e-5edaf3c52a0f" />

## Proposed Changes

* Add a Settings tab to `/podcast`, replacing the legacy `/settings/podcasting` page with a cleaner, modernized form.
* Built with hooks/TypeScript and `@wordpress/components` primitives (`Card`, `VStack`, `HStack`, `ToggleControl`, `TextControl`, `TextareaControl`, `SelectControl`, `Notice`).
* Reuses existing pieces: `wrapSettingsForm` for save/load, `PodcastCoverImageSetting`, `TermTreeSelector`, `UpsellNudge`, `ClipboardButtonInput`, `useTopics`.
* Cards: enable toggle → audio-upload upsell → category + RSS feed → show details (cover, title, summary, host, copyright) → feed metadata (topics, explicit, email) → save.

## Why are these changes being made?

Follow-up to #110164 — bring podcasting settings into the new `/podcast` surface so all podcast management lives in one place.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?