### PR TITLE
e2e: disable flaky domain flow tests on pre-release

### DIFF
--- a/test/e2e/specs/flows/setup-domain__flows.spec.ts
+++ b/test/e2e/specs/flows/setup-domain__flows.spec.ts
@@ -6,13 +6,13 @@ import {
 	NewUserResponse,
 	RestAPIClient,
 } from '@automattic/calypso-e2e';
-import { tags, test, expect } from '../../lib/pw-base';
+import { test, expect } from '../../lib/pw-base';
 import { apiCloseAccount, apiDeleteSite } from '../shared';
 
 test.describe(
 	'Setup Domain Flows',
 	{
-		tag: [ tags.CALYPSO_RELEASE ],
+		tag: [],
 	},
 	() => {
 		const accountsToCleanup: {

--- a/test/e2e/specs/flows/start-domain__purchase-flows.spec.ts
+++ b/test/e2e/specs/flows/start-domain__purchase-flows.spec.ts
@@ -5,13 +5,13 @@ import {
 	NewSiteResponse,
 	RestAPIClient,
 } from '@automattic/calypso-e2e';
-import { tags, test } from '../../lib/pw-base';
+import { test } from '../../lib/pw-base';
 import { apiCloseAccount, apiDeleteSite } from '../shared';
 
 test.describe(
 	'Start Domain Only Flows',
 	{
-		tag: [ tags.CALYPSO_RELEASE ],
+		tag: [],
 	},
 	() => {
 		const accountsToCleanup: {


### PR DESCRIPTION
Moving e2e tests that fail on prerelease during deploy the the `CALYPSO_PR` set, so that they run on every PR.

That's and experiment to see if they fail on the branch, too, and to hopefully help us debug them better.
