### PR TITLE
Migrate the FormFields devdocs example to Storybook

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,8 +1,13 @@
+const path = require( 'path' );
 const sharedConfig = require( '../config/_shared.json' );
 const devConfig = require( '../config/development.json' );
 const storybookDefaultConfig = require( '@automattic/calypso-storybook' );
 
 const storybookConfig = storybookDefaultConfig( {
+	sassAdditionalData: `@use '${ path.resolve(
+		__dirname,
+		'../client/assets/stylesheets/shared/_utils.scss'
+	) }' as *;`,
 	stories: [
 		'../client/components/**/*.stories.{js,jsx,tsx}',
 		'../client/blocks/**/*.stories.{js,jsx,tsx}',

--- a/client/components/forms/index.stories.jsx
+++ b/client/components/forms/index.stories.jsx
@@ -4,8 +4,6 @@ import { Card, FormInputValidation, FormLabel } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
-import { connect } from 'react-redux';
-import QuerySmsCountries from 'calypso/components/data/query-countries/sms';
 import FormButton from 'calypso/components/forms/form-button';
 import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
@@ -28,9 +26,8 @@ import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-w
 import FormTextarea from 'calypso/components/forms/form-textarea';
 import FormStateSelector from 'calypso/components/forms/us-state-selector';
 import PhoneInput from 'calypso/components/phone-input';
-import getCountries from 'calypso/state/selectors/get-countries';
 
-export const CURRENCIES = {
+const CURRENCIES = {
 	ALL: {
 		symbol: 'Lek',
 		grouping: '.',
@@ -122,6 +119,15 @@ const visualCurrencyList = Object.entries( CURRENCIES ).map( ( [ code, { symbol 
 	code,
 	label: `${ code } ${ symbol }`,
 } ) );
+
+const countriesList = [
+	{ code: 'US', name: 'United States' },
+	{ code: 'GB', name: 'United Kingdom' },
+	{ code: 'CA', name: 'Canada' },
+	{ code: 'AU', name: 'Australia' },
+	{ code: 'DE', name: 'Germany' },
+	{ code: 'FR', name: 'France' },
+];
 
 class FormFields extends PureComponent {
 	static propTypes = {
@@ -302,7 +308,6 @@ class FormFields extends PureComponent {
 
 					<FormFieldset>
 						<FormLabel htmlFor="country_code">Form country select</FormLabel>
-						<QuerySmsCountries />
 						<FormCountrySelect
 							name="country_code"
 							id="country_code"
@@ -515,10 +520,14 @@ class FormFields extends PureComponent {
 	}
 }
 
-const ConnectedFormFields = connect( ( state ) => ( {
-	countriesList: getCountries( state, 'sms' ),
-} ) )( FormFields );
+FormFields.displayName = 'FormFields';
 
-ConnectedFormFields.displayName = 'FormFields';
+export default {
+	title: 'client/components/Forms/Form Fields',
+	component: FormFields,
+	args: {
+		countriesList,
+	},
+};
 
-export default ConnectedFormFields;
+export const Default = {};

--- a/client/devdocs/design/component-examples.js
+++ b/client/devdocs/design/component-examples.js
@@ -28,7 +28,6 @@ export { default as FilePickers } from 'calypso/components/file-picker/docs/exam
 export { default as FoldableCard } from '@automattic/components/src/foldable-card/docs/example';
 export { default as FormattedDate } from 'calypso/components/formatted-date/docs/example';
 export { default as FormattedHeader } from 'calypso/components/formatted-header/docs/example';
-export { default as FormFields } from 'calypso/components/forms/docs/example';
 export { default as GlobalNotices } from 'calypso/components/global-notices/docs/example';
 export { default as Headers } from 'calypso/components/header-cake/docs/example';
 export { default as ImagePreloader } from 'calypso/components/image-preloader/docs/example';

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -53,7 +53,6 @@ import FormattedDate from 'calypso/components/formatted-date/docs/example';
 import FormattedHeader from 'calypso/components/formatted-header/docs/example';
 import ClipboardButtons from 'calypso/components/forms/clipboard-button/docs/example';
 import CountedTextareas from 'calypso/components/forms/counted-textarea/docs/example';
-import FormFields from 'calypso/components/forms/docs/example';
 import Ranges from 'calypso/components/forms/range/docs/example';
 import GlobalNotices from 'calypso/components/global-notices/docs/example';
 import GravatarCaterpillar from 'calypso/components/gravatar-caterpillar/docs/example';
@@ -197,7 +196,6 @@ export default class DesignAssets extends Component {
 					<FoldableFAQ readmeFilePath="foldable-faq" />
 					<FormattedDate readmeFilePath="formatted-date" />
 					<FormattedHeader readmeFilePath="formatted-header" />
-					<FormFields searchKeywords="input textbox textarea radio" readmeFilePath="forms" />
 					<GlobalNotices readmeFilePath="global-notices" />
 					<Gravatar readmeFilePath="gravatar" />
 					<GravatarCaterpillar readmeFilePath="gravatar-caterpillar" />

--- a/packages/calypso-storybook/src/index.js
+++ b/packages/calypso-storybook/src/index.js
@@ -6,6 +6,7 @@ module.exports = function storybookDefaultConfig( {
 	stories,
 	plugins = [],
 	webpackAliases = {},
+	sassAdditionalData,
 	babelCacheDirectory = path.join( __dirname, '../../../.cache/babel-storybook' ),
 } = {} ) {
 	return {
@@ -81,9 +82,15 @@ module.exports = function storybookDefaultConfig( {
 				{
 					test: /\.scss$/,
 					use: [
-						'style-loader', // Injects styles into the DOM
-						'css-loader', // Translates CSS into CommonJS
-						'sass-loader', // Compiles Sass to CSS
+						'style-loader',
+						'css-loader',
+						{
+							loader: 'sass-loader',
+							options: {
+								...( sassAdditionalData && { additionalData: sassAdditionalData } ),
+								sassOptions: { quietDeps: true },
+							},
+						},
 					],
 				},
 			];


### PR DESCRIPTION
As we want to remove devdocs in #110044, this is an experiment to migrate a `docs/example.jsx` file to a Storybook story.

It's very straightforward, close to just renaming the file 🙂 The only trouble is that the example no longer runs inside the Calypso framework, so it can't do REST queries like the original did. Instead of `QuerySmsCountries`, we need to hardcode a fixture with the results.

What do you think @p-jackson?