### PR TITLE
Jetpack Connect signup: match the connector-flow styling from the login page

### DIFF
--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -164,6 +164,14 @@ export class JetpackSignup extends Component {
 		return 'jetpack-connector' === this.props.authQuery.from;
 	}
 
+	isFromJetpackOnboarding() {
+		return 'jetpack-onboarding' === this.props.authQuery.from;
+	}
+
+	isUnifiedConnectionFlow() {
+		return this.isFromJetpackOnboarding() || this.isFromJetpackConnector();
+	}
+
 	handleSubmitSignup = ( _, userData, analyticsData, afterSubmit = noop ) => {
 		debug( 'submitting new account', userData );
 		this.setState( { isCreatingAccount: true }, () =>
@@ -343,7 +351,6 @@ export class JetpackSignup extends Component {
 				isFromAutomatticForAgenciesPlugin={ this.isFromAutomatticForAgenciesPlugin() }
 			>
 				<div className="jetpack-connect__authorize-form">
-					{ this.renderLocaleSuggestions() }
 					{ isFromJetpackConnector && connectorBranding ? (
 						<BrandHeader
 							logo={ connectorBranding.logo }
@@ -385,6 +392,7 @@ export class JetpackSignup extends Component {
 					/>
 
 					{ this.renderLoginUser() }
+					{ this.renderLocaleSuggestions() }
 				</div>
 				{ isWooJPC && this.props.authQuery.installedExtSuccess && <WooInstallExtSuccessNotice /> }
 			</MainWrapper>

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -8,6 +8,7 @@
 
 import { isEnabled } from '@automattic/calypso-config';
 import { Modal } from '@wordpress/components';
+import clsx from 'clsx';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
 import { flowRight, get } from 'lodash';
@@ -16,6 +17,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import JetpackConnectSiteOnly from 'calypso/blocks/jetpack-connect-site-only';
 import SignupForm from 'calypso/blocks/signup-form';
+import { BrandHeader } from 'calypso/components/connect-screen/brand-header';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
 import LoggedOutFormLinkItem from 'calypso/components/logged-out-form/link-item';
 import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
@@ -41,6 +43,7 @@ import {
 } from 'calypso/state/notices/actions';
 import isWooJPCFlow from 'calypso/state/selectors/is-woo-jpc-flow';
 import AuthFormHeader from './auth-form-header';
+import { getConnectorBranding } from './connector-branding-config';
 import HelpButton from './help-button';
 import MainWrapper from './main-wrapper';
 import { authQueryPropTypes } from './utils';
@@ -155,6 +158,10 @@ export class JetpackSignup extends Component {
 
 	isFromAutomatticForAgenciesPlugin() {
 		return 'automattic-for-agencies-client' === this.props.authQuery.from;
+	}
+
+	isFromJetpackConnector() {
+		return 'jetpack-connector' === this.props.authQuery.from;
 	}
 
 	handleSubmitSignup = ( _, userData, analyticsData, afterSubmit = noop ) => {
@@ -302,6 +309,10 @@ export class JetpackSignup extends Component {
 	render() {
 		const { isCreatingAccount, newUsername, bearerToken } = this.state;
 		const isWooJPC = this.isWooJPC();
+		const isFromJetpackConnector = this.isFromJetpackConnector();
+		const connectorBranding = isFromJetpackConnector
+			? getConnectorBranding( this.props.authQuery.plugins )
+			: null;
 
 		const isLogging = newUsername && bearerToken;
 		if ( isWooJPC && ( isCreatingAccount || isLogging ) ) {
@@ -324,18 +335,31 @@ export class JetpackSignup extends Component {
 
 		return (
 			<MainWrapper
+				className={ clsx( {
+					'jetpack-connect__authorize-form-wrapper--connector': isFromJetpackConnector,
+				} ) }
 				isWooJPC={ isWooJPC }
+				isJetpackConnector={ isFromJetpackConnector }
 				isFromAutomatticForAgenciesPlugin={ this.isFromAutomatticForAgenciesPlugin() }
 			>
 				<div className="jetpack-connect__authorize-form">
 					{ this.renderLocaleSuggestions() }
-					<AuthFormHeader
-						authQuery={ this.props.authQuery }
-						isWooJPC={ isWooJPC }
-						isFromAutomatticForAgenciesPlugin={ this.isFromAutomatticForAgenciesPlugin() }
-						disableSiteCard={ isWooJPC }
-						wooDnaConfig={ this.getWooDnaConfig() }
-					/>
+					{ isFromJetpackConnector && connectorBranding ? (
+						<BrandHeader
+							logo={ connectorBranding.logo }
+							logoAlt=""
+							title={ connectorBranding.title }
+							description={ connectorBranding.subtitle }
+						/>
+					) : (
+						<AuthFormHeader
+							authQuery={ this.props.authQuery }
+							isWooJPC={ isWooJPC }
+							isFromAutomatticForAgenciesPlugin={ this.isFromAutomatticForAgenciesPlugin() }
+							disableSiteCard={ isWooJPC }
+							wooDnaConfig={ this.getWooDnaConfig() }
+						/>
+					) }
 					<SignupForm
 						disabled={ isCreatingAccount }
 						isPasswordless={ isWooJPC }

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -160,16 +160,16 @@ export class JetpackSignup extends Component {
 		return 'automattic-for-agencies-client' === this.props.authQuery.from;
 	}
 
-	isFromJetpackConnector() {
-		return 'jetpack-connector' === this.props.authQuery.from;
+	isFromJetpackConnector( props = this.props ) {
+		return 'jetpack-connector' === props.authQuery.from;
 	}
 
-	isFromJetpackOnboarding() {
-		return 'jetpack-onboarding' === this.props.authQuery.from;
+	isFromJetpackOnboarding( props = this.props ) {
+		return 'jetpack-onboarding' === props.authQuery.from;
 	}
 
-	isUnifiedConnectionFlow() {
-		return this.isFromJetpackOnboarding() || this.isFromJetpackConnector();
+	isUnifiedConnectionFlow( props = this.props ) {
+		return this.isFromJetpackOnboarding( props ) || this.isFromJetpackConnector( props );
 	}
 
 	handleSubmitSignup = ( _, userData, analyticsData, afterSubmit = noop ) => {

--- a/client/jetpack-connect/signup.jsx
+++ b/client/jetpack-connect/signup.jsx
@@ -164,6 +164,14 @@ export class JetpackSignup extends Component {
 		return 'jetpack-connector' === this.props.authQuery.from;
 	}
 
+	isFromJetpackOnboarding() {
+		return 'jetpack-onboarding' === this.props.authQuery.from;
+	}
+
+	isUnifiedConnectionFlow() {
+		return this.isFromJetpackOnboarding() || this.isFromJetpackConnector();
+	}
+
 	handleSubmitSignup = ( _, userData, analyticsData, afterSubmit = noop ) => {
 		debug( 'submitting new account', userData );
 		this.setState( { isCreatingAccount: true }, () =>
@@ -343,7 +351,6 @@ export class JetpackSignup extends Component {
 				isFromAutomatticForAgenciesPlugin={ this.isFromAutomatticForAgenciesPlugin() }
 			>
 				<div className="jetpack-connect__authorize-form">
-					{ this.renderLocaleSuggestions() }
 					{ isFromJetpackConnector && connectorBranding ? (
 						<BrandHeader
 							logo={ connectorBranding.logo }
@@ -385,6 +392,7 @@ export class JetpackSignup extends Component {
 					/>
 
 					{ this.renderLoginUser() }
+					{ this.renderLocaleSuggestions() }
 				</div>
 				{ isWooJPC && this.props.authQuery.installedExtSuccess && <WooInstallExtSuccessNotice /> }
 			</MainWrapper>

--- a/client/jetpack-connect/signup.jsx
+++ b/client/jetpack-connect/signup.jsx
@@ -8,6 +8,7 @@
 
 import { isEnabled } from '@automattic/calypso-config';
 import { Modal } from '@wordpress/components';
+import clsx from 'clsx';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
 import { flowRight, get } from 'lodash';
@@ -16,6 +17,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import JetpackConnectSiteOnly from 'calypso/blocks/jetpack-connect-site-only';
 import SignupForm from 'calypso/blocks/signup-form';
+import { BrandHeader } from 'calypso/components/connect-screen/brand-header';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
 import LoggedOutFormLinkItem from 'calypso/components/logged-out-form/link-item';
 import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
@@ -41,6 +43,7 @@ import {
 } from 'calypso/state/notices/actions';
 import isWooJPCFlow from 'calypso/state/selectors/is-woo-jpc-flow';
 import AuthFormHeader from './auth-form-header';
+import { getConnectorBranding } from './connector-branding-config';
 import HelpButton from './help-button';
 import MainWrapper from './main-wrapper';
 import { authQueryPropTypes } from './utils';
@@ -155,6 +158,10 @@ export class JetpackSignup extends Component {
 
 	isFromAutomatticForAgenciesPlugin() {
 		return 'automattic-for-agencies-client' === this.props.authQuery.from;
+	}
+
+	isFromJetpackConnector() {
+		return 'jetpack-connector' === this.props.authQuery.from;
 	}
 
 	handleSubmitSignup = ( _, userData, analyticsData, afterSubmit = noop ) => {
@@ -302,6 +309,10 @@ export class JetpackSignup extends Component {
 	render() {
 		const { isCreatingAccount, newUsername, bearerToken } = this.state;
 		const isWooJPC = this.isWooJPC();
+		const isFromJetpackConnector = this.isFromJetpackConnector();
+		const connectorBranding = isFromJetpackConnector
+			? getConnectorBranding( this.props.authQuery.plugins )
+			: null;
 
 		const isLogging = newUsername && bearerToken;
 		if ( isWooJPC && ( isCreatingAccount || isLogging ) ) {
@@ -324,18 +335,31 @@ export class JetpackSignup extends Component {
 
 		return (
 			<MainWrapper
+				className={ clsx( {
+					'jetpack-connect__authorize-form-wrapper--connector': isFromJetpackConnector,
+				} ) }
 				isWooJPC={ isWooJPC }
+				isJetpackConnector={ isFromJetpackConnector }
 				isFromAutomatticForAgenciesPlugin={ this.isFromAutomatticForAgenciesPlugin() }
 			>
 				<div className="jetpack-connect__authorize-form">
 					{ this.renderLocaleSuggestions() }
-					<AuthFormHeader
-						authQuery={ this.props.authQuery }
-						isWooJPC={ isWooJPC }
-						isFromAutomatticForAgenciesPlugin={ this.isFromAutomatticForAgenciesPlugin() }
-						disableSiteCard={ isWooJPC }
-						wooDnaConfig={ this.getWooDnaConfig() }
-					/>
+					{ isFromJetpackConnector && connectorBranding ? (
+						<BrandHeader
+							logo={ connectorBranding.logo }
+							logoAlt=""
+							title={ connectorBranding.title }
+							description={ connectorBranding.subtitle }
+						/>
+					) : (
+						<AuthFormHeader
+							authQuery={ this.props.authQuery }
+							isWooJPC={ isWooJPC }
+							isFromAutomatticForAgenciesPlugin={ this.isFromAutomatticForAgenciesPlugin() }
+							disableSiteCard={ isWooJPC }
+							wooDnaConfig={ this.getWooDnaConfig() }
+						/>
+					) }
 					<SignupForm
 						disabled={ isCreatingAccount }
 						isPasswordless={ isWooJPC }

--- a/client/jetpack-connect/signup.jsx
+++ b/client/jetpack-connect/signup.jsx
@@ -160,16 +160,16 @@ export class JetpackSignup extends Component {
 		return 'automattic-for-agencies-client' === this.props.authQuery.from;
 	}
 
-	isFromJetpackConnector() {
-		return 'jetpack-connector' === this.props.authQuery.from;
+	isFromJetpackConnector( props = this.props ) {
+		return 'jetpack-connector' === props.authQuery.from;
 	}
 
-	isFromJetpackOnboarding() {
-		return 'jetpack-onboarding' === this.props.authQuery.from;
+	isFromJetpackOnboarding( props = this.props ) {
+		return 'jetpack-onboarding' === props.authQuery.from;
 	}
 
-	isUnifiedConnectionFlow() {
-		return this.isFromJetpackOnboarding() || this.isFromJetpackConnector();
+	isUnifiedConnectionFlow( props = this.props ) {
+		return this.isFromJetpackOnboarding( props ) || this.isFromJetpackConnector( props );
 	}
 
 	handleSubmitSignup = ( _, userData, analyticsData, afterSubmit = noop ) => {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -345,6 +345,70 @@ body:not( .is-jetpack-sso-partner-branded--woo ) {
 		color: var( --color-accent );
 	}
 
+	.signup-form {
+		max-width: 758px;
+		margin-left: auto;
+		margin-right: auto;
+
+		.layout & .signup-form__passwordless-form-wrapper .card.logged-out-form,
+		.layout & > .card.auth-form__social {
+			box-shadow: none;
+			border: 0;
+			background: transparent;
+			clip-path: unset;
+		}
+
+		.signup-form__passwordless-form-wrapper .form-fieldset {
+			margin-bottom: 0;
+		}
+
+		@media ( min-width: 782px ) {
+			display: flex;
+			flex-direction: row;
+			align-items: stretch;
+			justify-content: center;
+
+			> .signup-form__passwordless-form-wrapper,
+			> .card.auth-form__social {
+				flex: 0 0 327px;
+				max-width: 327px;
+				margin: 0;
+			}
+
+			> .signup-form__passwordless-form-wrapper,
+			> .signup-form__passwordless-form-wrapper .card.logged-out-form,
+			> .signup-form__passwordless-form-wrapper form {
+				display: flex;
+				flex-direction: column;
+				justify-content: center;
+			}
+
+			.auth-form__separator {
+				flex: 0 0 auto;
+				width: 24px;
+				margin: 0 24px;
+
+				&::before,
+				&::after {
+					border-inline-start: 1px solid #eaeaeb;
+					border-block-start: 0;
+					inset-block-start: 0;
+					inset-inline-start: 50%;
+					height: 40%;
+					width: 0;
+				}
+
+				&::after {
+					top: 60%;
+				}
+
+				.auth-form__separator-text {
+					padding: 24px 0;
+				}
+			}
+		}
+	}
+
 	@media screen and ( max-width: $break-mobile ) {
 		padding: 0 16px;
 	}

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -389,7 +389,7 @@ body:not( .is-jetpack-sso-partner-branded--woo ) {
 
 				&::before,
 				&::after {
-					border-inline-start: 1px solid #eaeaeb;
+					border-inline-start: 1px solid var( --color-border-subtle );
 					border-block-start: 0;
 					inset-block-start: 0;
 					inset-inline-start: 50%;

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -347,8 +347,7 @@ body:not( .is-jetpack-sso-partner-branded--woo ) {
 
 	.signup-form {
 		max-width: 758px;
-		margin-left: auto;
-		margin-right: auto;
+		margin-inline: auto;
 
 		.layout & .signup-form__passwordless-form-wrapper .card.logged-out-form,
 		.layout & > .card.auth-form__social {

--- a/client/jetpack-connect/test/__snapshots__/signup.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/signup.js.snap
@@ -381,3 +381,114 @@ exports[`JetpackSignup should render with locale suggestions 1`] = `
   </main>
 </div>
 `;
+
+exports[`JetpackSignup should render with the connector branding when from=jetpack-connector 1`] = `
+<div>
+  <main
+    class="jetpack-connect__authorize-form-wrapper--connector jetpack-connect__main is-jetpack-connector-flow main"
+    role="main"
+  >
+    DocumentHead
+    <div
+      class="jetpack-connect__authorize-form"
+    >
+      <div
+        class="connect-screen-brand-header"
+      >
+        <div
+          class="connect-screen-brand-header__logo"
+        >
+          <img
+            alt=""
+            class="connect-screen-brand-header__logo-image"
+            src="jetpack-connect-woo.svg"
+          />
+        </div>
+        <h1
+          class="connect-screen-brand-header__title"
+        >
+          Connect your store
+        </h1>
+        <p
+          class="connect-screen-brand-header__description"
+        >
+          Connect your store to unlock powerful features.
+        </p>
+      </div>
+      <div
+        class="signup-form"
+      >
+        <div
+          class="signup-form__passwordless-form-wrapper"
+        >
+          <div
+            class="card logged-out-form"
+          >
+            <form
+              novalidate=""
+            >
+              <fieldset
+                class="validation-fieldset form-fieldset"
+                role="group"
+              >
+                <label
+                  class="form-label"
+                  for="signup-email"
+                >
+                  Enter your email address
+                </label>
+                <input
+                  autocapitalize="off"
+                  autocorrect="off"
+                  class="form-text-input signup-form__passwordless-email"
+                  id="signup-email"
+                  name="email"
+                  type="email"
+                  value="email@an.example.site"
+                />
+                <div
+                  class="validation-fieldset__validation-message"
+                />
+              </fieldset>
+              <div
+                class="card logged-out-form__footer"
+              >
+                <button
+                  class="components-button signup-form__submit is-next-40px-default-size is-primary"
+                  type="submit"
+                >
+                  Continue
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+        <div
+          class="auth-form__separator"
+        >
+          <div
+            class="auth-form__separator-text"
+          >
+            or
+          </div>
+        </div>
+        <div
+          class="card auth-form__social is-signup"
+        >
+          <div
+            class="auth-form__social-buttons"
+          >
+            <div
+              class="auth-form__social-buttons-container"
+            >
+              GoogleSocialButton
+              AppleLoginButton
+              GitHubLoginButton
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </main>
+</div>
+`;

--- a/client/jetpack-connect/test/signup.js
+++ b/client/jetpack-connect/test/signup.js
@@ -93,4 +93,111 @@ describe( 'JetpackSignup', () => {
 
 		expect( container ).toMatchSnapshot();
 	} );
+
+	test( 'should render with the connector branding when from=jetpack-connector', () => {
+		const { container } = render(
+			<JetpackSignup
+				{ ...DEFAULT_PROPS }
+				authQuery={ {
+					...DEFAULT_PROPS.authQuery,
+					from: 'jetpack-connector',
+					plugins: [ 'jetpack', 'woocommerce' ],
+				} }
+			/>
+		);
+
+		expect( container ).toMatchSnapshot();
+	} );
+
+	describe( 'isFromJetpackConnector', () => {
+		const isFromJetpackConnector = new JetpackSignup().isFromJetpackConnector;
+
+		test( 'is from jetpack connector', () => {
+			const props = {
+				authQuery: {
+					from: 'jetpack-connector',
+				},
+			};
+
+			expect( isFromJetpackConnector( props ) ).toBe( true );
+		} );
+
+		test( 'does not match jetpack-connector prefix variants', () => {
+			const props = {
+				authQuery: {
+					from: 'jetpack-connector-v2',
+				},
+			};
+
+			expect( isFromJetpackConnector( props ) ).toBe( false );
+		} );
+
+		test( 'is not from jetpack connector', () => {
+			const props = {
+				authQuery: {
+					from: 'jetpack-onboarding',
+				},
+			};
+
+			expect( isFromJetpackConnector( props ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'isFromJetpackOnboarding', () => {
+		const isFromJetpackOnboarding = new JetpackSignup().isFromJetpackOnboarding;
+
+		test( 'is from jetpack onboarding', () => {
+			const props = {
+				authQuery: {
+					from: 'jetpack-onboarding',
+				},
+			};
+
+			expect( isFromJetpackOnboarding( props ) ).toBe( true );
+		} );
+
+		test( 'is not from jetpack onboarding', () => {
+			const props = {
+				authQuery: {
+					from: 'jetpack-connector',
+				},
+			};
+
+			expect( isFromJetpackOnboarding( props ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'isUnifiedConnectionFlow', () => {
+		const instance = new JetpackSignup();
+
+		test( 'returns true for jetpack-onboarding', () => {
+			const props = {
+				authQuery: {
+					from: 'jetpack-onboarding',
+				},
+			};
+
+			expect( instance.isUnifiedConnectionFlow( props ) ).toBe( true );
+		} );
+
+		test( 'returns true for jetpack-connector', () => {
+			const props = {
+				authQuery: {
+					from: 'jetpack-connector',
+				},
+			};
+
+			expect( instance.isUnifiedConnectionFlow( props ) ).toBe( true );
+		} );
+
+		test( 'returns false for other flows', () => {
+			const props = {
+				authQuery: {
+					from: 'woocommerce-onboarding',
+				},
+			};
+
+			expect( instance.isUnifiedConnectionFlow( props ) ).toBe( false );
+		} );
+	} );
 } );


### PR DESCRIPTION
Part of CONNECT-186

## Proposed Changes

* `client/jetpack-connect/signup.js` — when `from=jetpack-connector`, swap `AuthFormHeader` for `BrandHeader` (with logo/title/subtitle from `getConnectorBranding`) and apply the `jetpack-connect__authorize-form-wrapper--connector` className on `MainWrapper`, mirroring the pattern `authorize.js:1295-1373` uses for the same flow.
* Move `LocaleSuggestions` from above the form header to below the form (applies to all flows), so the locale-suggestion pill sits at the bottom of the page like the login layout.
* Introduce `isFromJetpackOnboarding()` and `isUnifiedConnectionFlow()` helpers on `JetpackSignup`, mirroring `authorize.js:514-526`. They are not yet wired into rendering — they are in place so future flows can be onboarded into the new styling with a one-line change.
* `client/jetpack-connect/style.scss` — under `.jetpack-connect__authorize-form-wrapper--connector .signup-form`, add the two-column layout (email column left, vertical OR divider, social-buttons column right) at `≥ 782px`, locking each column to 327px (the `--login-form-column-max-width` the login form uses). Also drop the card chrome (box-shadow, border, background) and the default 20px form-fieldset bottom margin so the form sits flat and the Continue button hugs the email block, matching the login look.
* `client/jetpack-connect/test/signup.js` — add unit tests for the three new helpers (`isFromJetpackConnector`, `isFromJetpackOnboarding`, `isUnifiedConnectionFlow`) mirroring the equivalent tests in `client/jetpack-connect/test/authorize.js:329-395`, plus a snapshot test that exercises the connector render path with `from=jetpack-connector` + `plugins=[ 'jetpack', 'woocommerce' ]`.

## Why are these changes being made?

* PR #110180 introduced a unified WP.com-blue, two-column-with-vertical-OR look for the Jetpack-connect login screen when `from=jetpack-connector`. The "Create an account" link on that login screen sends users to the signup page, which was still rendering with the legacy stacked, card-bordered, Jetpack-green look. The visual jump between the two pages is jarring.
* This PR makes the signup page match the login page for the connector flow, so the user goes from "Log in to WordPress.com" to "Create an account" without a styling discontinuity.

## Testing Instructions

* On a self-hosted Jetpack site that initiates a connection with `from=jetpack-connector` (e.g. via the new Jetpack Connector card), start the connect flow and reach the WordPress.com login screen.
* Click **Create an account** on that screen (top-right link). You should land on the signup page rendered by `client/jetpack-connect/signup.js`.
* At ≥ 782px width, confirm:
  * The page uses the WP.com-blue palette and serif title (consistent with the login page).
  * The email form sits in the left column, social buttons (Google / Apple / GitHub / PayPal) in the right column, with a vertical OR divider between them.
  * Both columns are equal width (327px).
  * Neither column has the legacy 1px card outline.
  * If your browser advertises a non-English locale (`navigator.languages` set to e.g. Spanish or French), the locale-suggestion pill appears at the bottom of the page, not at the top. English-only browsers will not see the pill at all.
* Below 782px, the form falls back to the vertical stack (email above social buttons, horizontal OR), matching the login mobile fallback.
* Regression check (legacy flows must remain unchanged): repeat with `from=my-jetpack`, `from=jetpack-onboarding`, and any other non-connector value. The signup page should look exactly as it did before this PR — Jetpack-green palette, stacked layout, card outlines preserved, site card via `AuthFormHeader` still present. Only the locale-suggestion pill position changed (now at the bottom for all flows).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?
