### PR TITLE
Revert: post-checkout-onboarding TanStack Query migration (#110172, #110233)

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -46,7 +46,7 @@ function initialize() {
 		STEPS.SETUP_YOUR_SITE_AI,
 	];
 
-	return [ ...stepsWithRequiredLogin( steps ), STEPS.PLAYGROUND, STEPS.BLUEPRINT, STEPS.ERROR ];
+	return [ ...stepsWithRequiredLogin( steps ), STEPS.PLAYGROUND, STEPS.BLUEPRINT ];
 }
 
 const onboarding: FlowV2< typeof initialize > = {
@@ -78,7 +78,6 @@ const onboarding: FlowV2< typeof initialize > = {
 		);
 		const coupon = useQuery().get( 'coupon' );
 		const refParameter = useQuery().get( 'ref' );
-		const siteSlugParam = useQuery().get( 'siteSlug' );
 
 		const { setShouldShowNotification } = usePurchasePlanNotification();
 
@@ -238,23 +237,6 @@ const onboarding: FlowV2< typeof initialize > = {
 					}
 				}
 				case 'processing': {
-					if (
-						providedDependencies.processingResult === ProcessingResult.NO_ACTION &&
-						siteSlugParam
-					) {
-						// No pending action — the user landed on this page directly without
-						// completing the prior step (e.g. a direct URL load or page refresh).
-						// Redirect back to post-checkout-onboarding so it can set up the
-						// pending action and advance the flow normally.
-						window.location.replace(
-							addQueryArgs( withLocale( '/setup/onboarding/post-checkout-onboarding', locale ), {
-								siteSlug: siteSlugParam,
-								...( refParameter ? { ref: refParameter } : {} ),
-							} )
-						);
-						return;
-					}
-
 					const [ destination, backDestination ] = await getPostCheckoutDestination(
 						providedDependencies,
 						planCartItem
@@ -304,7 +286,8 @@ const onboarding: FlowV2< typeof initialize > = {
 							window.location.replace( destination );
 						}
 					} else {
-						return navigate( 'error' as typeof currentStepSlug );
+						// TODO: Handle errors
+						// navigate( 'error' );
 					}
 					return;
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
@@ -1,4 +1,3 @@
-import { siteBySlugQuery } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
 import {
 	FEATURE_BIG_SKY,
@@ -9,24 +8,21 @@ import {
 } from '@automattic/calypso-products';
 import { SiteIntent } from '@automattic/data-stores/src/onboard';
 import { Step } from '@automattic/onboarding';
-import { useQuery } from '@tanstack/react-query';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useI18n } from '@wordpress/react-i18n';
 import { useEffect } from 'react';
 import Loading from 'calypso/components/loading';
 import { WOO_HOSTING_SOLUTIONS_REF } from 'calypso/landing/stepper/constants';
-import { useQuery as useUrlParams } from 'calypso/landing/stepper/hooks/use-query';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import { waitForPluginsActive } from 'calypso/landing/stepper/utils/wait-for-plugins-active';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useExperiment } from 'calypso/lib/explat';
 import { useMarketplaceThemeProducts } from '../../../../hooks/use-marketplace-theme-products';
-import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
+import { useSiteData } from '../../../../hooks/use-site-data';
 import { useSiteTransferStatusQuery } from '../../../../hooks/use-site-transfer/query';
 import { useWaitForAtomic } from '../../../../hooks/use-wait-for-atomic';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import type { Step as StepType } from '../../types';
-import type { OnboardSelect } from '@automattic/data-stores';
+import type { OnboardSelect, SiteSelect } from '@automattic/data-stores';
 
 const usePluginByGoal = () => {
 	const intent = useSelect(
@@ -48,19 +44,9 @@ const PostCheckoutOnboarding: StepType< {
 		postCheckoutBigSky?: boolean;
 	};
 } > = ( { flow, navigation } ) => {
-	const { __ } = useI18n();
 	const { submit } = navigation;
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
-
-	const siteSlug = useSiteSlugParam() ?? '';
-	const {
-		data: site,
-		isLoading: isLoadingSite,
-		isError: isErrorSite,
-	} = useQuery( {
-		...siteBySlugQuery( siteSlug ),
-		enabled: !! siteSlug,
-	} );
+	const { site, siteSlug } = useSiteData();
 
 	const eligibleForExperiment =
 		isEnabled( 'onboarding/post-checkout-ai-step' ) &&
@@ -92,23 +78,29 @@ const PostCheckoutOnboarding: StepType< {
 		[]
 	);
 
-	const isJetpackOrAtomic = !! site?.jetpack || !! site?.is_wpcom_atomic;
+	const isJetpack = useSelect(
+		( select ) => site && ( select( SITE_STORE ) as SiteSelect ).isJetpackSite( site.ID ),
+		[ site ]
+	);
+
+	const isAtomic = useSelect(
+		( select ) => site && ( select( SITE_STORE ) as SiteSelect ).isSiteAtomic( site.ID ),
+		[ site ]
+	);
+
+	const isJetpackOrAtomic = isJetpack || isAtomic;
 
 	const {
 		isLoading: isLoadingMarketplaceThemeProducts,
-		isError: isErrorMarketplaceThemeProducts,
 		isMarketplaceThemeSubscribed,
 		isExternallyManagedThemeAvailable,
-	} = useMarketplaceThemeProducts( { siteId: site?.ID } );
+	} = useMarketplaceThemeProducts();
 
-	const {
-		data: siteTransferStatusData,
-		isLoading: isLoadingSiteTransferStatusData,
-		isError: isErrorSiteTransferStatus,
-	} = useSiteTransferStatusQuery( site?.ID );
+	const { data: siteTransferStatusData, isLoading: isLoadingSiteTransferStatusData } =
+		useSiteTransferStatusQuery( site?.ID );
 
 	const { waitForInitiateTransfer, waitForTransfer, waitForFeature, waitForLatestSiteData } =
-		useWaitForAtomic( { siteId: site?.ID } );
+		useWaitForAtomic( {} );
 
 	const { setIntentOnSite, setGoalsOnSite } = useDispatch( SITE_STORE );
 
@@ -123,7 +115,7 @@ const PostCheckoutOnboarding: StepType< {
 	const goalPlugin = usePluginByGoal();
 	const hasPluginByGoal = !! goalPlugin;
 
-	const refParameter = useUrlParams().get( 'ref' );
+	const refParameter = useQuery().get( 'ref' );
 	const isWooHostingSolutions = refParameter === WOO_HOSTING_SOLUTIONS_REF;
 
 	// Prefer the cart item (what the user just bought — freshest signal during
@@ -148,7 +140,7 @@ const PostCheckoutOnboarding: StepType< {
 	 * - Verify that the site is atomic, as the theme should be installed on the user's site.
 	 *
 	 * The atomic transfer will be initiated immediately after the user purchases an externally managed theme.
-	 * If it's not initiated, we need to trigger the atomic transfer manually.
+	 * If it’s not initiated, we need to trigger the atomic transfer manually.
 	 *
 	 * Note that an externally managed theme is only available when both of the following conditions are met:
 	 * - The site must be subscribed to the theme.
@@ -159,26 +151,10 @@ const PostCheckoutOnboarding: StepType< {
 		isMarketplaceThemeSubscribed &&
 		isExternallyManagedThemeAvailable;
 
-	const hasError = isErrorSite || isErrorMarketplaceThemeProducts || isErrorSiteTransferStatus;
-
-	useEffect( () => {
-		if ( ! hasError ) {
-			return;
-		}
-		recordTracksEvent( 'calypso_onboarding_post_checkout_setup_error', {
-			flow,
-			error_site: isErrorSite,
-			error_marketplace_theme_products: isErrorMarketplaceThemeProducts,
-			error_site_transfer_status: isErrorSiteTransferStatus,
-		} );
-	}, [ hasError, flow, isErrorSite, isErrorMarketplaceThemeProducts, isErrorSiteTransferStatus ] );
-
 	useEffect( () => {
 		if (
-			hasError ||
 			! site ||
 			! siteSlug ||
-			isLoadingSite ||
 			isLoadingMarketplaceThemeProducts ||
 			isLoadingSiteTransferStatusData ||
 			isLoadingExperiment
@@ -225,10 +201,8 @@ const PostCheckoutOnboarding: StepType< {
 			siteSlug,
 		} );
 	}, [
-		hasError,
 		site,
 		siteSlug,
-		isLoadingSite,
 		isLoadingMarketplaceThemeProducts,
 		isLoadingSiteTransferStatusData,
 		isLoadingExperiment,
@@ -239,27 +213,6 @@ const PostCheckoutOnboarding: StepType< {
 		isExternallyManagedThemeAvailable,
 		shouldInstallPlugin,
 	] );
-
-	if ( hasError ) {
-		const heading = __( "We've hit a snag" );
-		const body = __(
-			'Something went wrong while setting up your site. Please try refreshing the page, or contact support if the problem persists.'
-		);
-
-		if ( shouldUseStepContainerV2( flow ) ) {
-			return (
-				<Step.CenteredColumnLayout
-					columnWidth={ 8 }
-					topBar={ <Step.TopBar /> }
-					heading={ <Step.Heading text={ heading } /> }
-				>
-					{ body }
-				</Step.CenteredColumnLayout>
-			);
-		}
-
-		return <Loading className="wpcom-loading__boot" title={ heading } subtitle={ body } />;
-	}
 
 	if ( shouldUseStepContainerV2( flow ) ) {
 		return <Step.Loading />;

--- a/client/landing/stepper/hooks/use-marketplace-theme-products.ts
+++ b/client/landing/stepper/hooks/use-marketplace-theme-products.ts
@@ -1,22 +1,26 @@
-import { productsQuery, siteFeaturesQuery, sitePurchasesQuery } from '@automattic/api-queries';
-import { FEATURE_WOOP, WPCOM_FEATURES_ATOMIC } from '@automattic/calypso-products';
 import { getThemeIdFromDesign } from '@automattic/design-picker';
-import { useQuery } from '@tanstack/react-query';
 import { useSelect } from '@wordpress/data';
+import { useQueryProductsList } from 'calypso/components/data/query-products-list';
+import { useQuerySiteFeatures } from 'calypso/components/data/query-site-features';
+import { useQuerySitePurchases } from 'calypso/components/data/query-site-purchases';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { useSelector } from 'calypso/state';
+import {
+	getProductBillingSlugByThemeId,
+	getProductsByBillingSlug,
+	isProductsListFetching,
+} from 'calypso/state/products-list/selectors';
+import { isFetchingSitePurchases } from 'calypso/state/purchases/selectors';
+import {
+	isMarketplaceThemeSubscribed as getIsMarketplaceThemeSubscribed,
+	isSiteEligibleForManagedExternalThemes,
+} from 'calypso/state/themes/selectors';
 import { getPreferredBillingCycleProductSlug } from 'calypso/state/themes/theme-utils';
 import { useSiteData } from './use-site-data';
 import type { OnboardSelect } from '@automattic/data-stores';
 
-interface UseMarketplaceThemeProductsProps {
-	siteId?: number;
-}
-
-export const useMarketplaceThemeProducts = ( {
-	siteId: providedSiteId,
-}: UseMarketplaceThemeProductsProps = {} ) => {
+export const useMarketplaceThemeProducts = () => {
 	const { site } = useSiteData();
-	const siteId = providedSiteId ?? site?.ID;
 
 	const selectedDesign = useSelect( ( select ) => {
 		const { getSelectedDesign } = select( ONBOARD_STORE ) as OnboardSelect;
@@ -24,45 +28,21 @@ export const useMarketplaceThemeProducts = ( {
 	}, [] );
 
 	const selectedDesignThemeId = selectedDesign ? getThemeIdFromDesign( selectedDesign ) : null;
-	const billingProductSlug = selectedDesignThemeId
-		? `wp-mp-theme-${ selectedDesignThemeId }`
-		: null;
 
-	const {
-		isLoading: isLoadingProducts,
-		isError: isErrorProducts,
-		data: productsData,
-	} = useQuery( productsQuery( 'all' ) );
-
-	const {
-		isLoading: isLoadingSiteFeatures,
-		isError: isErrorSiteFeatures,
-		data: siteFeatures,
-	} = useQuery( {
-		...siteFeaturesQuery( siteId as number ),
-		enabled: !! siteId,
-	} );
-
-	const {
-		isLoading: isLoadingSitePurchases,
-		isError: isErrorSitePurchases,
-		data: sitePurchasesData,
-	} = useQuery( {
-		...sitePurchasesQuery( siteId as number ),
-		enabled: !! siteId,
-	} );
-
-	const allProductsList = productsData ? Object.values( productsData ) : [];
-	const sitePurchasesList = sitePurchasesData ?? [];
-
-	const isExternallyManagedThemeAvailable = !! (
-		siteFeatures?.active?.includes( FEATURE_WOOP ) &&
-		siteFeatures?.active?.includes( WPCOM_FEATURES_ATOMIC )
+	const isExternallyManagedThemeAvailable = useSelector(
+		( state ) => site?.ID && isSiteEligibleForManagedExternalThemes( state, site.ID )
 	);
 
-	const marketplaceThemeProducts = billingProductSlug
-		? allProductsList.filter( ( p ) => p.billing_product_slug === billingProductSlug )
-		: [];
+	const isLoadingProductList = useSelector( ( state ) => isProductsListFetching( state ) );
+	const isLoadingSitePurchases = useSelector( ( state ) => isFetchingSitePurchases( state ) );
+
+	const marketplaceThemeProducts =
+		useSelector( ( state ) =>
+			getProductsByBillingSlug(
+				state,
+				getProductBillingSlugByThemeId( state, selectedDesignThemeId ?? '' )
+			)
+		) || [];
 
 	const marketplaceProductSlug =
 		marketplaceThemeProducts.length !== 0
@@ -70,14 +50,15 @@ export const useMarketplaceThemeProducts = ( {
 			: null;
 
 	const selectedMarketplaceProduct =
-		marketplaceThemeProducts.find( ( p ) => p.product_slug === marketplaceProductSlug ) ??
-		marketplaceThemeProducts[ 0 ];
+		marketplaceThemeProducts.find(
+			( product ) => product.product_slug === marketplaceProductSlug
+		) || marketplaceThemeProducts[ 0 ];
 
-	const isMarketplaceThemeSubscribed = !! (
-		marketplaceThemeProducts.length > 0 &&
-		sitePurchasesList.some( ( purchase ) =>
-			marketplaceThemeProducts.some( ( p ) => purchase.product_slug === p.product_slug )
-		)
+	const isMarketplaceThemeSubscribed = useSelector(
+		( state ) =>
+			site &&
+			selectedDesignThemeId &&
+			getIsMarketplaceThemeSubscribed( state, selectedDesignThemeId, site.ID )
 	);
 
 	const isMarketplaceThemeSubscriptionNeeded = !! (
@@ -89,9 +70,12 @@ export const useMarketplaceThemeProducts = ( {
 			? [ marketplaceProductSlug ]
 			: [];
 
+	useQueryProductsList();
+	useQuerySiteFeatures( [ site?.ID ] );
+	useQuerySitePurchases( site?.ID ?? -1 );
+
 	return {
-		isLoading: isLoadingProducts || isLoadingSiteFeatures || isLoadingSitePurchases,
-		isError: isErrorProducts || isErrorSiteFeatures || isErrorSitePurchases,
+		isLoading: isLoadingProductList || isLoadingSitePurchases,
 		selectedMarketplaceProduct,
 		selectedMarketplaceProductCartItems,
 		isMarketplaceThemeSubscriptionNeeded,

--- a/client/state/products-list/selectors/get-products-list.ts
+++ b/client/state/products-list/selectors/get-products-list.ts
@@ -28,8 +28,7 @@ export interface ProductListItem {
 	introductory_offer?: ProductIntroductoryOffer;
 	price_tier_list: PriceTierEntry[];
 	price_tier_usage_quantity: null | number;
-	/** @deprecated use price_tier_usage_quantity instead */
-	price_tier_slug?: string;
+	price_tier_slug: string;
 	sale_coupon?: {
 		discount?: number;
 		allowed_for_domain_transfers?: boolean;

--- a/client/state/themes/theme-utils.ts
+++ b/client/state/themes/theme-utils.ts
@@ -1,20 +1,22 @@
 import { isWpComMonthlyPlan } from '@automattic/calypso-products';
+import { SitePlanData } from 'calypso/my-sites/checkout/src/hooks/product-variants';
+import { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 
-interface ProductWithBillingCycle {
-	product_slug: string;
-	product_term?: string;
-}
-
+/**
+ * Get the preferred product slug from the products list.
+ * @param products list of products
+ * @returns string
+ */
 export function getPreferredBillingCycleProductSlug(
-	products: Array< ProductWithBillingCycle >,
-	currentPlanSlug?: string
+	products: Array< ProductListItem >,
+	currentPlan?: SitePlanData | any
 ): string {
 	if ( products.length === 0 ) {
 		throw new Error( 'No products available' );
 	}
 	let preferredBillingCycle = 'month';
 
-	if ( currentPlanSlug && ! isWpComMonthlyPlan( currentPlanSlug ) ) {
+	if ( currentPlan && ! isWpComMonthlyPlan( currentPlan.productSlug ) ) {
 		preferredBillingCycle = 'year';
 	}
 

--- a/packages/api-core/src/products/fetchers.ts
+++ b/packages/api-core/src/products/fetchers.ts
@@ -57,10 +57,9 @@ function normalizeProduct( product: Product ): Product {
 	};
 }
 
-export async function fetchProducts( type?: string ): Promise< Record< string, Product > > {
+export async function fetchProducts(): Promise< Record< string, Product > > {
 	const products: Record< string, Product > = await wpcom.req.get( {
 		path: '/products/',
-		...( type ? { qs: { type } } : {} ),
 	} );
 	return Object.fromEntries(
 		Object.entries( products ).map( ( [ key, product ] ) => [ key, normalizeProduct( product ) ] )

--- a/packages/api-core/src/products/types.ts
+++ b/packages/api-core/src/products/types.ts
@@ -61,7 +61,7 @@ export interface Product {
 }
 
 interface IntroductoryOffer {
-	interval_unit: IntroductoryOfferTimeUnit;
+	interval_unit: string;
 	interval_count: number;
 	usage_limit: number | null;
 	cost_per_interval: number;

--- a/packages/api-queries/src/products.ts
+++ b/packages/api-queries/src/products.ts
@@ -1,9 +1,8 @@
 import { fetchProducts } from '@automattic/api-core';
 import { queryOptions } from '@tanstack/react-query';
 
-export const productsQuery = ( type?: string ) =>
+export const productsQuery = () =>
 	queryOptions( {
-		queryKey: [ 'products', type ],
-		queryFn: () => fetchProducts( type ),
-		staleTime: 5 * 60 * 1000,
+		queryKey: [ 'products' ],
+		queryFn: () => fetchProducts(),
 	} );


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/SHILL-1937/post-checkout-onboarding-loader-pages-can-spin-forever

## Proposed changes

Reverts the TanStack Query migration and error-tracking additions in the post-checkout-onboarding flow that were merged in #110172 and #110233.

## Why are these changes being made?

The TanStack Query migration in #110172 introduced regressions in the post-checkout-onboarding flow. While the original intent was to fix an indefinite loading spinner caused by global Redux flags blocking the `useEffect` guard, the replacement approach has caused new issues that need investigation before re-landing.

Reverting now to restore the previous behaviour while we diagnose the root cause and prepare a safer fix.

