### PR TITLE
Onboarding plans: align heading with the domains step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/style.scss
@@ -37,13 +37,6 @@
 		padding-bottom: 0;
 	}
 
-	// This is temporary until we make the plans step more consistent according to the designs.
-	@media ( max-width: calc($break-small - 1px) ) {
-		.plans-features-main .plans-features-main__subheader {
-			text-align: left;
-		}
-	}
-
 	@media ( max-width: calc($break-medium - 1px) ) {
 		.plan-type-selector {
 			width: 100%;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/style.scss
@@ -41,7 +41,7 @@
 	// to look like a link instead of a default borderless button. The legacy
 	// <PlansPageSubheader> applied equivalent styles to the same button via its
 	// styled <Subheader>; those don't carry over to Step.Heading's <p>.
-	.step-container-v2__heading p button.is-borderless {
+	.plans-features-main__free-plan-cta {
 		padding: 0;
 		color: inherit;
 		font-size: inherit;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/style.scss
@@ -37,6 +37,23 @@
 		padding-bottom: 0;
 	}
 
+	// Style the inline `start with a free plan` CTA inside Step.Heading subText
+	// to look like a link instead of a default borderless button. The legacy
+	// <PlansPageSubheader> applied equivalent styles to the same button via its
+	// styled <Subheader>; those don't carry over to Step.Heading's <p>.
+	.step-container-v2__heading p button.is-borderless {
+		padding: 0;
+		color: inherit;
+		font-size: inherit;
+		font-weight: 500;
+		text-decoration: underline;
+
+		&:hover,
+		&:focus {
+			color: inherit;
+		}
+	}
+
 	@media ( max-width: calc($break-medium - 1px) ) {
 		.plan-type-selector {
 			width: 100%;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/style.scss
@@ -33,13 +33,6 @@
 		padding: 0;
 	}
 
-	// This is temporary until we make the plans step more consistent according to the designs.
-	@media ( max-width: calc($break-small - 1px) ) {
-		.plans-features-main .plans-features-main__subheader {
-			text-align: left;
-		}
-	}
-
 	@media ( max-width: calc($break-medium - 1px) ) {
 		.plan-type-selector {
 			width: 100%;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -543,6 +543,16 @@ function UnifiedPlansStep( {
 			);
 		}
 
+		// In stepper-v2, <PlansPageSubheader>'s deemphasize branch is suppressed,
+		// so surface its "Unlock a powerful bundle…" copy here as Step.Heading subText
+		// to keep the free-plan CTA visible.
+		if ( useStepContainerV2 && deemphasizeFreePlan ) {
+			return translate(
+				'Unlock a powerful bundle of features. Or {{link}}start with a free plan{{/link}}.',
+				{ components: { link: freePlanButton } }
+			);
+		}
+
 		if ( deemphasizeFreePlanFromProps ) {
 			return null;
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -488,11 +488,21 @@ function UnifiedPlansStep( {
 		}
 
 		if ( intent === 'plans-wordpress-hosting' ) {
-			return null; // Use PlansFeaturesMain subheader for hosting
+			return translate(
+				'All the security, flexibility, and control you need — without the overhead.'
+			);
 		}
 
 		if ( intent === 'plans-website-builder' ) {
-			return null; // Use PlansFeaturesMain subheader for website-builder
+			if ( deemphasizeFreePlan ) {
+				return translate(
+					'Everything you need to go from idea to one-of-a-kind site, blog, or newsletter. Or {{link}}start with our free plan{{/link}}.',
+					{ components: { link: freePlanButton } }
+				);
+			}
+			return translate(
+				'Everything you need to go from idea to one-of-a-kind site, blog, or newsletter.'
+			);
 		}
 
 		if ( intent === 'plans-woo-hosted' ) {
@@ -535,6 +545,10 @@ function UnifiedPlansStep( {
 
 		if ( deemphasizeFreePlanFromProps ) {
 			return null;
+		}
+
+		if ( isOnboardingFlow( flowName ) || intent === 'plans-upgrade' ) {
+			return translate( 'Whatever site you’re building, there’s a plan to make it happen sooner.' );
 		}
 	};
 
@@ -649,6 +663,7 @@ function UnifiedPlansStep( {
 			<>
 				<MarketingMessage path="signup/plans" />
 				<Step.WideLayout
+					headingColumnWidth={ 6 }
 					className="step-container-v2--plans"
 					topBar={
 						<Step.TopBar

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -11,6 +11,7 @@ import { FREE_THEME } from '@automattic/design-picker';
 import {
 	DOMAIN_FLOW,
 	isNewHostedSiteCreationFlow,
+	isOnboardingFlow,
 	isTailoredSignupFlow,
 	ONBOARDING_FLOW,
 	Step,
@@ -474,11 +475,21 @@ function UnifiedPlansStep( {
 		}
 
 		if ( intent === 'plans-wordpress-hosting' ) {
-			return null; // Use PlansFeaturesMain subheader for hosting
+			return translate(
+				'All the security, flexibility, and control you need — without the overhead.'
+			);
 		}
 
 		if ( intent === 'plans-website-builder' ) {
-			return null; // Use PlansFeaturesMain subheader for website-builder
+			if ( deemphasizeFreePlan ) {
+				return translate(
+					'Everything you need to go from idea to one-of-a-kind site, blog, or newsletter. Or {{link}}start with our free plan{{/link}}.',
+					{ components: { link: freePlanButton } }
+				);
+			}
+			return translate(
+				'Everything you need to go from idea to one-of-a-kind site, blog, or newsletter.'
+			);
 		}
 
 		if ( intent === 'plans-woo-hosted' ) {
@@ -515,6 +526,10 @@ function UnifiedPlansStep( {
 
 		if ( deemphasizeFreePlanFromProps ) {
 			return null;
+		}
+
+		if ( isOnboardingFlow( flowName ) || intent === 'plans-upgrade' ) {
+			return translate( 'Whatever site you’re building, there’s a plan to make it happen sooner.' );
 		}
 	};
 
@@ -629,6 +644,7 @@ function UnifiedPlansStep( {
 			<>
 				<MarketingMessage path="signup/plans" />
 				<Step.WideLayout
+					headingColumnWidth={ 6 }
 					className="step-container-v2--plans"
 					topBar={
 						<Step.TopBar

--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -277,7 +277,7 @@ const PlansPageSubheader = ( {
 		}
 
 		// Website Builder intent: use the new copy
-		if ( intent === 'plans-website-builder' ) {
+		if ( ! isUsingStepContainerV2 && intent === 'plans-website-builder' ) {
 			if ( deemphasizeFreePlan && offeringFreePlan ) {
 				return (
 					<Subheader { ...subheaderCommonProps }>
@@ -299,7 +299,7 @@ const PlansPageSubheader = ( {
 		}
 
 		// WordPress Hosting intent: use hosting-specific copy
-		if ( intent === 'plans-wordpress-hosting' ) {
+		if ( ! isUsingStepContainerV2 && intent === 'plans-wordpress-hosting' ) {
 			return (
 				<Subheader { ...subheaderCommonProps }>
 					{ translate(
@@ -316,7 +316,7 @@ const PlansPageSubheader = ( {
 			return null;
 		}
 
-		if ( deemphasizeFreePlan && offeringFreePlan ) {
+		if ( ! isUsingStepContainerV2 && deemphasizeFreePlan && offeringFreePlan ) {
 			return (
 				<Subheader { ...subheaderCommonProps }>
 					{ translate(
@@ -335,7 +335,7 @@ const PlansPageSubheader = ( {
 			return <PlanBenefitHeader />;
 		}
 
-		if ( isOnboarding || intent === 'plans-upgrade' ) {
+		if ( ! isUsingStepContainerV2 && ( isOnboarding || intent === 'plans-upgrade' ) ) {
 			return (
 				<Subheader { ...subheaderCommonProps }>
 					{ translate( 'Whatever site you’re building, there’s a plan to make it happen sooner.' ) }

--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -277,7 +277,7 @@ const PlansPageSubheader = ( {
 		}
 
 		// Website Builder intent: use the new copy
-		if ( intent === 'plans-website-builder' ) {
+		if ( ! isUsingStepContainerV2 && intent === 'plans-website-builder' ) {
 			if ( deemphasizeFreePlan && offeringFreePlan ) {
 				return (
 					<Subheader { ...subheaderCommonProps }>
@@ -299,7 +299,7 @@ const PlansPageSubheader = ( {
 		}
 
 		// WordPress Hosting intent: use hosting-specific copy
-		if ( intent === 'plans-wordpress-hosting' ) {
+		if ( ! isUsingStepContainerV2 && intent === 'plans-wordpress-hosting' ) {
 			return (
 				<Subheader { ...subheaderCommonProps }>
 					{ translate(
@@ -308,7 +308,7 @@ const PlansPageSubheader = ( {
 				</Subheader>
 			);
 		}
-		if ( deemphasizeFreePlan && offeringFreePlan ) {
+		if ( ! isUsingStepContainerV2 && deemphasizeFreePlan && offeringFreePlan ) {
 			return (
 				<Subheader { ...subheaderCommonProps }>
 					{ translate(
@@ -327,7 +327,7 @@ const PlansPageSubheader = ( {
 			return <PlanBenefitHeader />;
 		}
 
-		if ( isOnboarding || intent === 'plans-upgrade' ) {
+		if ( ! isUsingStepContainerV2 && ( isOnboarding || intent === 'plans-upgrade' ) ) {
 			return (
 				<Subheader { ...subheaderCommonProps }>
 					{ translate( 'Whatever site you’re building, there’s a plan to make it happen sooner.' ) }

--- a/packages/onboarding/src/step-container-v2/wireframes/WideLayout/WideLayout.stories.tsx
+++ b/packages/onboarding/src/step-container-v2/wireframes/WideLayout/WideLayout.stories.tsx
@@ -3,7 +3,7 @@ import { Heading, TopBar, BackButton, PrimaryButton, StickyBottomBar } from '../
 import { WireframePlaceholder } from '../../helpers/wireframe-placeholder';
 import { withStepContainerV2ContextDecorator } from '../../helpers/withStepContainerV2ContextDecorator';
 import { WideLayout } from './WideLayout';
-import type { Meta } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta< typeof WideLayout > = {
 	title: 'Onboarding/StepWireframes/WideLayout',
@@ -20,7 +20,7 @@ export const Wide_Default = () => (
 			<Heading
 				text="Wide layout"
 				subText={ createInterpolateElement(
-					'An example of the <code>WideLayout</code> wireframe layout.',
+					'A <code>WideLayout</code> with the heading rendered in the default 12-column track. This subtext is intentionally long enough that you can compare it side-by-side with the 6-column variant and see the wrapping change.',
 					{
 						code: <code />,
 					}
@@ -32,3 +32,52 @@ export const Wide_Default = () => (
 		<WireframePlaceholder height={ 616 }>Main</WireframePlaceholder>
 	</WideLayout>
 );
+
+export const Wide_HeadingSixColumns = () => (
+	<WideLayout
+		topBar={ <TopBar leftElement={ <BackButton /> } /> }
+		heading={
+			<Heading
+				text="Wide layout — 6-column heading"
+				subText={ createInterpolateElement(
+					'A <code>WideLayout</code> with the heading constrained to a 6-column track (matching the heading width used by <code>CenteredColumnLayout</code> by default). Main content keeps the full 12-column width. This subtext is intentionally long enough that you can compare it side-by-side with the default and see the wrapping change.',
+					{
+						code: <code />,
+					}
+				) }
+			/>
+		}
+		headingColumnWidth={ 6 }
+		stickyBottomBar={ <StickyBottomBar rightElement={ <PrimaryButton /> } /> }
+	>
+		<WireframePlaceholder height={ 616 }>Main</WireframePlaceholder>
+	</WideLayout>
+);
+
+type WideLayoutStory = StoryObj< typeof WideLayout >;
+
+export const Wide_Playground: WideLayoutStory = {
+	args: {
+		topBar: <TopBar leftElement={ <BackButton /> } />,
+		heading: (
+			<Heading
+				text="Wide layout — Playground"
+				subText={ createInterpolateElement(
+					'Use the <code>Controls</code> panel to switch <code>headingColumnWidth</code> between values and watch the heading wrapper resize. The main content row below stays full-width regardless.',
+					{
+						code: <code />,
+					}
+				) }
+			/>
+		),
+		headingColumnWidth: 6,
+		stickyBottomBar: <StickyBottomBar rightElement={ <PrimaryButton /> } />,
+		children: <WireframePlaceholder height={ 616 }>Main</WireframePlaceholder>,
+	},
+	argTypes: {
+		headingColumnWidth: {
+			control: { type: 'select' },
+			options: [ undefined, 4, 5, 6, 8, 10 ],
+		},
+	},
+};

--- a/packages/onboarding/src/step-container-v2/wireframes/WideLayout/WideLayout.tsx
+++ b/packages/onboarding/src/step-container-v2/wireframes/WideLayout/WideLayout.tsx
@@ -9,6 +9,7 @@ import { TopBarRenderer } from '../../components/TopBar/TopBarRenderer';
 interface WideLayoutProps {
 	topBar?: ContentProp;
 	heading?: ReactNode;
+	headingColumnWidth?: 4 | 5 | 6 | 8 | 10;
 	className?: string;
 	children?: ContentProp;
 	stickyBottomBar?: ContentProp;
@@ -17,6 +18,7 @@ interface WideLayoutProps {
 export const WideLayout = ( {
 	topBar,
 	heading,
+	headingColumnWidth,
 	className,
 	children,
 	stickyBottomBar,
@@ -30,7 +32,7 @@ export const WideLayout = ( {
 					<>
 						<TopBarRenderer topBar={ topBar } />
 						<ContentWrapper>
-							{ heading && <ContentRow>{ heading }</ContentRow> }
+							{ heading && <ContentRow columns={ headingColumnWidth }>{ heading }</ContentRow> }
 							<ContentRow className={ className }>{ content }</ContentRow>
 						</ContentWrapper>
 						<StickyBottomBarRenderer stickyBottomBar={ stickyBottomBar } />


### PR DESCRIPTION
Part of RSM: Dotcom mobile experience overhaul phcsdm-LZ-p2

## Why are these changes being made?

The plans onboarding step (`/setup/onboarding/plans`) renders its heading area very differently from the domains step (`/setup/onboarding/domains`) — both visually and structurally. Today plans renders **two** heading-like elements:

1. `<Step.Heading>` inside `<Step.WideLayout heading>`, but stretched to the full 12-column track because `WideLayout` has no heading-column constraint.
2. A separate emotion-styled `<Subheader>` `<p>` rendered inside `<PlansFeaturesMain>` via `<PlansPageSubheader>`, with a negative top margin (-16/-32/-40px) that pulls itself up into the heading area.

A single `<Step.Heading>` renders both the title and the subheader, in a 6-column track that matches the domains step. The plans grid below keeps its full 12-column content width so we don't lose room for plan cards.

## Screenshots
Now the `Plans` step in the Onboarding flow matches the previous step, `Domains`. This is fixes a papercut and a consistency issue. Mobile gets tighter as well.

| Before | After |
| --- | --- |
| <img width="2880" height="1800" alt="wordpress com_setup_onboarding_plans_source=sites-dashboard ref=new-site-popover(Default (Cris))" src="https://github.com/user-attachments/assets/2f4908e4-98bc-43f7-ab75-faaf8c424040" /> | <img width="2880" height="1800" alt="calypso localhost_3000_setup_onboarding_plans(Default (Cris)) (1)" src="https://github.com/user-attachments/assets/a4ecc8ed-bacb-48fe-92de-f816083899d7" /> |
| <img width="750" height="1334" alt="wordpress com_setup_onboarding_domains_source=sites-dashboard ref=new-site-popover(iPhone SE)" src="https://github.com/user-attachments/assets/1f218e55-5dcd-48bb-9405-cd1638f723f2" /> | <img width="750" height="1334" alt="calypso localhost_3000_setup_onboarding_plans(iPhone SE)" src="https://github.com/user-attachments/assets/f48abbd6-b0da-460e-ac80-889a6e76a549" /> |

## Proposed Changes

1. **Add `headingColumnWidth` prop to `Step.WideLayout`** — mirrors `CenteredColumnLayout`'s heading-constraint API. Backward-compatible: heading stays full-width unless the prop is set.
2. **Use `Step.Heading` as the single subheader source for stepper-v2 plans** — move the per-intent subheader copy from `<PlansPageSubheader>` into `getSubheaderText()` (so it flows into `Step.Heading subText`), gate the inline `<Subheader>` paragraph behind `! isUsingStepContainerV2`, and pass `headingColumnWidth={ 6 }` to `Step.WideLayout`. Non-stepper consumers and rich blocks (`DifferentiatorHeader`, `PlanBenefitHeader`, `SecondaryFormattedHeader`) are untouched.
3. **Drop the dead `.plans-features-main__subheader` CSS rule** — the class isn't emitted (the subheader uses emotion); the rule has been a no-op since the migration.


## Testing Instructions

1. `yarn start` and load `http://calypso.localhost:3000/setup/onboarding/plans` at viewports 1440×900, 1024×768, 768×1024, and 375×812.
2. Confirm:
    - Single heading + subText, centered in a 6-column track. No second grey paragraph below it with negative-margin overlap.
    - Plans grid below is the full 12-column width — same width as before this PR.
    - Compare side-by-side with `/setup/onboarding/domains` — heading area should align.
3. Test variant intents:
    - `?intent=plans-website-builder` — `IntentToggle` still renders above the heading; subText reads "Everything you need to go from idea to one-of-a-kind site, blog, or newsletter."
    - `?intent=plans-wordpress-hosting` — subText reads "All the security, flexibility, and control you need — without the overhead."
    - Default onboarding — subText reads "Whatever site you're building, there's a plan to make it happen sooner."
4. Test `deemphasizeFreePlan` flow (pick a paid domain in the prior step, then arrive at plans with the website-builder intent). Subheader includes a clickable "start with our free plan" link inside the `Step.Heading subText`.
5. Verify non-stepper plans pages are visually unchanged: `/plans/<site>`, `/plugins/plans/<site>`, `/plans/business-trial/<site>` (if accessible). The inline `<Subheader>` should still render there.


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?