### PR TITLE
Reader ATmosphere: author feed filter tabs (Posts/Replies/Media)

### DIFF
--- a/client/reader/atmosphere/author-profile-panel.tsx
+++ b/client/reader/atmosphere/author-profile-panel.tsx
@@ -15,10 +15,12 @@ import {
 } from 'calypso/reader/social';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import { AuthorProfileHeader } from './author-profile-header';
+import { AuthorProfileTabs, useAuthorProfileFilter } from './author-profile-tabs';
 import { projectAtmosphereError } from './error-projection';
 import { errorMessage } from './profile-errors';
-import { getBlueskyProfileUrl, getProfileUrl, getThreadUrl } from './route';
+import { getProfileUrl, getThreadUrl } from './route';
 import type {
+	AtmosphereAuthorFeedFilter,
 	AtmosphereAuthorProfile,
 	AtmosphereConnection,
 	AtmosphereError,
@@ -28,6 +30,35 @@ import type { AppState } from 'calypso/types';
 import type { UnknownAction } from 'redux';
 import type { ThunkDispatch } from 'redux-thunk';
 
+function buildEmptyTitle(
+	filter: AtmosphereAuthorFeedFilter,
+	handle: string,
+	translate: ReturnType< typeof useTranslate >
+): string {
+	switch ( filter ) {
+		case 'posts_with_replies':
+			return String(
+				translate( '@%(handle)s hasn’t replied to anyone yet.', {
+					args: { handle },
+				} )
+			);
+		case 'posts_with_media':
+			return String(
+				translate( '@%(handle)s hasn’t posted any media yet.', {
+					args: { handle },
+				} )
+			);
+		case 'posts_no_replies':
+		case 'posts_and_author_threads':
+		default:
+			return String(
+				translate( '@%(handle)s hasn’t posted yet.', {
+					args: { handle },
+				} )
+			);
+	}
+}
+
 interface AuthorProfilePanelProps {
 	connection: AtmosphereConnection;
 	actor: string;
@@ -36,19 +67,31 @@ interface AuthorProfilePanelProps {
 export function AuthorProfilePanel( { connection, actor }: AuthorProfilePanelProps ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch< ThunkDispatch< AppState, void, UnknownAction > >();
+	const filter = useAuthorProfileFilter();
 	const lastErrorKind = useRef< { header: string | null; feed: string | null } >( {
 		header: null,
 		feed: null,
 	} );
 
 	const profile = useAuthorProfileQuery( { actor } );
-	const feed = useAuthorFeedInfiniteQuery( { actor } );
+	// posts_no_replies is the API default — omit the param so the URL stays
+	// clean and matches the original no-filter behaviour when no ?tab is present.
+	const feed = useAuthorFeedInfiniteQuery( {
+		actor,
+		filter: filter === 'posts_no_replies' ? undefined : filter,
+	} );
 
 	// Reset the error_shown dedup ref when navigating between profiles so the
 	// next author's first error fires its analytics even when the kind matches.
 	useEffect( () => {
 		lastErrorKind.current = { header: null, feed: null };
 	}, [ actor, connection.id ] );
+
+	// Per-filter feed errors must each fire their own _error_shown event,
+	// even when the kinds match (e.g. rate_limited on Posts then Replies).
+	useEffect( () => {
+		lastErrorKind.current.feed = null;
+	}, [ filter ] );
 
 	// Fire profile_viewed exactly once per (actor, connection) — but wait until
 	// the profile data resolves so the Tracks payload carries the resolved DID
@@ -68,9 +111,10 @@ export function AuthorProfilePanel( { connection, actor }: AuthorProfilePanelPro
 				actor,
 				actor_did: profile.data.did,
 				actor_handle: profile.data.handle,
+				initial_filter: filter,
 			} )
 		);
-	}, [ actor, connection.id, profile.data, dispatch ] );
+	}, [ actor, connection.id, profile.data, filter, dispatch ] );
 
 	useEffect( () => {
 		if ( profile.isError && profile.error && profile.error.kind !== lastErrorKind.current.header ) {
@@ -98,13 +142,14 @@ export function AuthorProfilePanel( { connection, actor }: AuthorProfilePanelPro
 					actor,
 					error_kind: feed.error.kind,
 					surface: 'feed',
+					filter,
 				} )
 			);
 		}
 		if ( ! feed.isError ) {
 			lastErrorKind.current.feed = null;
 		}
-	}, [ feed.isError, feed.error, connection.id, actor, dispatch ] );
+	}, [ feed.isError, feed.error, connection.id, actor, filter, dispatch ] );
 
 	const items: SocialPost[] = useMemo( () => {
 		// Bluesky's getAuthorFeed can return the same post URI more than once
@@ -287,6 +332,7 @@ export function AuthorProfilePanel( { connection, actor }: AuthorProfilePanelPro
 			<VStack spacing={ 4 } className="atmosphere-author-profile">
 				<AuthorProfileHeader connection={ connection } onBackToTimeline={ handleBackToTimeline } />
 				{ renderHeader() }
+				<AuthorProfileTabs connectionId={ connection.id } actor={ actor } activeFilter={ filter } />
 				<SocialFeedList< SocialPost >
 					items={ items }
 					isPending={ feed.isPending }
@@ -298,14 +344,8 @@ export function AuthorProfilePanel( { connection, actor }: AuthorProfilePanelPro
 					refetch={ handleFeedRetry }
 					renderItem={ renderItem }
 					itemKey={ itemKey }
-					emptyTitle={ String(
-						translate( '@%(handle)s hasn’t posted yet.', {
-							args: { handle: emptyHandle },
-						} )
-					) }
-					emptyLine={ String( translate( 'Their feed is empty.' ) ) }
-					emptyActionLabel={ String( translate( 'View on Bluesky' ) ) }
-					emptyActionURL={ profile.data?.bluesky_url ?? getBlueskyProfileUrl( actor ) }
+					emptyTitle={ buildEmptyTitle( filter, emptyHandle, translate ) }
+					emptyLine=""
 					protocolLabel="Bluesky"
 					protocolHomeURL="/reader/atmosphere"
 					protocolHomeLabel={ translate( 'Back to ATmosphere' ) }

--- a/client/reader/atmosphere/author-profile-panel.tsx
+++ b/client/reader/atmosphere/author-profile-panel.tsx
@@ -74,12 +74,7 @@ export function AuthorProfilePanel( { connection, actor }: AuthorProfilePanelPro
 	} );
 
 	const profile = useAuthorProfileQuery( { actor } );
-	// posts_no_replies is the API default — omit the param so the URL stays
-	// clean and matches the original no-filter behaviour when no ?tab is present.
-	const feed = useAuthorFeedInfiniteQuery( {
-		actor,
-		filter: filter === 'posts_no_replies' ? undefined : filter,
-	} );
+	const feed = useAuthorFeedInfiniteQuery( { actor, filter } );
 
 	// Reset the error_shown dedup ref when navigating between profiles so the
 	// next author's first error fires its analytics even when the kind matches.
@@ -105,6 +100,9 @@ export function AuthorProfilePanel( { connection, actor }: AuthorProfilePanelPro
 			return;
 		}
 		viewedFor.current = key;
+		// Capture filter at first-fire time. The event semantics are "what filter
+		// was active when the user first opened this profile", which is decided
+		// the moment profile.data resolves — not on subsequent tab switches.
 		dispatch(
 			recordReaderTracksEvent( 'calypso_reader_atmosphere_profile_viewed', {
 				connection_id: connection.id,
@@ -114,7 +112,8 @@ export function AuthorProfilePanel( { connection, actor }: AuthorProfilePanelPro
 				initial_filter: filter,
 			} )
 		);
-	}, [ actor, connection.id, profile.data, filter, dispatch ] );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ actor, connection.id, profile.data, dispatch ] );
 
 	useEffect( () => {
 		if ( profile.isError && profile.error && profile.error.kind !== lastErrorKind.current.header ) {

--- a/client/reader/atmosphere/author-profile-tabs.tsx
+++ b/client/reader/atmosphere/author-profile-tabs.tsx
@@ -35,7 +35,9 @@ function readPathname(): string {
  * Reads `?tab=` from the current location and returns the corresponding
  * backend enum filter. Side-effects a single `page.replace` to the default
  * tab when the slug is malformed (gated on a ref so repeated renders with
- * the same malformed value don't loop). Returns the default filter on
+ * the same malformed value don't loop). If the user navigates to a valid
+ * tab and then back to a different malformed value, the rewrite re-fires —
+ * the gate clears once a valid slug appears. Returns the default filter on
  * missing or malformed values.
  */
 export function useAuthorProfileFilter(): AtmosphereAuthorFeedFilter {
@@ -48,15 +50,24 @@ export function useAuthorProfileFilter(): AtmosphereAuthorFeedFilter {
 		if ( slug === null ) {
 			return;
 		}
-		if ( slug in SLUG_TO_FILTER ) {
+		if ( Object.hasOwn( SLUG_TO_FILTER, slug ) ) {
 			correctedFor.current = null;
 			return;
 		}
 		if ( correctedFor.current === slug ) {
 			return;
 		}
-		correctedFor.current = slug;
-		const next = new URLSearchParams( readSearch() );
+		// Re-validate against the live URL: between render and effect commit
+		// another `page.replace` (e.g. a same-batch tab click) could have
+		// changed `?tab=` to a valid value. Without this guard the effect
+		// would clobber the user's valid choice with the default.
+		const liveSearch = readSearch();
+		const liveSlug = liveSearch.get( 'tab' );
+		if ( liveSlug === null || Object.hasOwn( SLUG_TO_FILTER, liveSlug ) ) {
+			return;
+		}
+		correctedFor.current = liveSlug;
+		const next = new URLSearchParams( liveSearch );
 		next.set( 'tab', DEFAULT_SLUG );
 		page.replace( `${ readPathname() }?${ next.toString() }` );
 	}, [ slug ] );
@@ -64,7 +75,7 @@ export function useAuthorProfileFilter(): AtmosphereAuthorFeedFilter {
 	if ( slug === null ) {
 		return DEFAULT_FILTER;
 	}
-	if ( slug in SLUG_TO_FILTER ) {
+	if ( Object.hasOwn( SLUG_TO_FILTER, slug ) ) {
 		return SLUG_TO_FILTER[ slug ];
 	}
 	return DEFAULT_FILTER;
@@ -87,9 +98,17 @@ interface TabSpec {
 // validates handle/DID and returns null on invalid; we always have a
 // resolved actor here and need to append the ?tab slug.
 function buildPath( connectionId: number, actor: string, slug: string ): string {
-	return `/reader/atmosphere/${ connectionId }/profile/${ encodeURIComponent(
-		actor
-	) }?tab=${ slug }`;
+	const base = `/reader/atmosphere/${ connectionId }/profile/${ encodeURIComponent( actor ) }`;
+	if ( typeof window === 'undefined' ) {
+		return `${ base }?tab=${ slug }`;
+	}
+	// Preserve any other query params and the fragment (e.g. ?from=timeline,
+	// or #scroll-anchor) that the user may have on the URL when switching
+	// tabs. Mirrors the malformed-rewrite path's URL-preservation behavior.
+	const params = new URLSearchParams( window.location.search );
+	params.set( 'tab', slug );
+	const hash = window.location.hash; // includes leading '#' or '' if absent
+	return `${ base }?${ params.toString() }${ hash }`;
 }
 
 function isPlainLeftClick( event: React.MouseEvent ): boolean {
@@ -163,7 +182,7 @@ export function AuthorProfileTabs( { connectionId, actor, activeFilter }: Author
 					<NavItem
 						key={ tab.slug }
 						path={ tab.path }
-						selected={ tab.filter === activeFilter }
+						selected={ tab.filter === selected.filter }
 						onClick={ ( event: React.MouseEvent< HTMLAnchorElement > ) =>
 							handleClick( event, tab )
 						}

--- a/client/reader/atmosphere/author-profile-tabs.tsx
+++ b/client/reader/atmosphere/author-profile-tabs.tsx
@@ -158,7 +158,7 @@ export function AuthorProfileTabs( { connectionId, actor, activeFilter }: Author
 			variation="minimal"
 			enforceTabsView
 		>
-			<NavTabs>
+			<NavTabs hasHorizontalScroll>
 				{ tabs.map( ( tab ) => (
 					<NavItem
 						key={ tab.slug }

--- a/client/reader/atmosphere/author-profile-tabs.tsx
+++ b/client/reader/atmosphere/author-profile-tabs.tsx
@@ -1,0 +1,177 @@
+import page from '@automattic/calypso-router';
+import { useTranslate, type TranslateResult } from 'i18n-calypso';
+import { useEffect, useMemo, useRef } from 'react';
+import SectionNav from 'calypso/components/section-nav';
+import NavItem from 'calypso/components/section-nav/item';
+import NavTabs from 'calypso/components/section-nav/tabs';
+import { useDispatch } from 'calypso/state';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import type { AtmosphereAuthorFeedFilter } from '@automattic/api-core';
+
+const SLUG_TO_FILTER: Record< string, AtmosphereAuthorFeedFilter > = {
+	posts: 'posts_no_replies',
+	replies: 'posts_with_replies',
+	media: 'posts_with_media',
+};
+
+const DEFAULT_FILTER: AtmosphereAuthorFeedFilter = 'posts_no_replies';
+const DEFAULT_SLUG = 'posts';
+
+function readSearch(): URLSearchParams {
+	if ( typeof window === 'undefined' ) {
+		return new URLSearchParams();
+	}
+	return new URLSearchParams( window.location.search );
+}
+
+function readPathname(): string {
+	if ( typeof window === 'undefined' ) {
+		return '';
+	}
+	return window.location.pathname;
+}
+
+/**
+ * Reads `?tab=` from the current location and returns the corresponding
+ * backend enum filter. Side-effects a single `page.replace` to the default
+ * tab when the slug is malformed (gated on a ref so repeated renders with
+ * the same malformed value don't loop). Returns the default filter on
+ * missing or malformed values.
+ */
+export function useAuthorProfileFilter(): AtmosphereAuthorFeedFilter {
+	const correctedFor = useRef< string | null >( null );
+
+	const search = readSearch();
+	const slug = search.get( 'tab' );
+
+	useEffect( () => {
+		if ( slug === null ) {
+			return;
+		}
+		if ( slug in SLUG_TO_FILTER ) {
+			correctedFor.current = null;
+			return;
+		}
+		if ( correctedFor.current === slug ) {
+			return;
+		}
+		correctedFor.current = slug;
+		const next = new URLSearchParams( readSearch() );
+		next.set( 'tab', DEFAULT_SLUG );
+		page.replace( `${ readPathname() }?${ next.toString() }` );
+	}, [ slug ] );
+
+	if ( slug === null ) {
+		return DEFAULT_FILTER;
+	}
+	if ( slug in SLUG_TO_FILTER ) {
+		return SLUG_TO_FILTER[ slug ];
+	}
+	return DEFAULT_FILTER;
+}
+
+interface AuthorProfileTabsProps {
+	connectionId: number;
+	actor: string;
+	activeFilter: AtmosphereAuthorFeedFilter;
+}
+
+interface TabSpec {
+	filter: AtmosphereAuthorFeedFilter;
+	slug: string;
+	title: TranslateResult;
+	path: string;
+}
+
+// Intentionally separate from route.ts's `getProfileUrl` — that helper
+// validates handle/DID and returns null on invalid; we always have a
+// resolved actor here and need to append the ?tab slug.
+function buildPath( connectionId: number, actor: string, slug: string ): string {
+	return `/reader/atmosphere/${ connectionId }/profile/${ encodeURIComponent(
+		actor
+	) }?tab=${ slug }`;
+}
+
+function isPlainLeftClick( event: React.MouseEvent ): boolean {
+	return (
+		event.button === 0 && ! event.metaKey && ! event.ctrlKey && ! event.shiftKey && ! event.altKey
+	);
+}
+
+export function AuthorProfileTabs( { connectionId, actor, activeFilter }: AuthorProfileTabsProps ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const tabs: TabSpec[] = useMemo(
+		() => [
+			{
+				filter: 'posts_no_replies',
+				slug: 'posts',
+				title: translate( 'Posts' ),
+				path: buildPath( connectionId, actor, 'posts' ),
+			},
+			{
+				filter: 'posts_with_replies',
+				slug: 'replies',
+				title: translate( 'Replies' ),
+				path: buildPath( connectionId, actor, 'replies' ),
+			},
+			{
+				filter: 'posts_with_media',
+				slug: 'media',
+				title: translate( 'Media' ),
+				path: buildPath( connectionId, actor, 'media' ),
+			},
+		],
+		[ connectionId, actor, translate ]
+	);
+
+	// posts_and_author_threads is not surfaced as a UI tab. If a caller
+	// somehow passes it (or any future enum value the type allows but the
+	// UI hasn't onboarded yet), default to Posts visually rather than
+	// render no selection at all.
+	const selected = tabs.find( ( tab ) => tab.filter === activeFilter ) ?? tabs[ 0 ];
+
+	const handleClick = ( event: React.MouseEvent< HTMLAnchorElement >, tab: TabSpec ) => {
+		if ( ! isPlainLeftClick( event ) ) {
+			return;
+		}
+		event.preventDefault();
+		if ( tab.filter === activeFilter ) {
+			return;
+		}
+		page.replace( tab.path );
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_atmosphere_profile_filter_changed', {
+				connection_id: connectionId,
+				actor,
+				from_filter: activeFilter,
+				to_filter: tab.filter,
+			} )
+		);
+	};
+
+	return (
+		<SectionNav
+			className="atmosphere-author-profile-tabs"
+			selectedText={ selected.title }
+			variation="minimal"
+			enforceTabsView
+		>
+			<NavTabs>
+				{ tabs.map( ( tab ) => (
+					<NavItem
+						key={ tab.slug }
+						path={ tab.path }
+						selected={ tab.filter === activeFilter }
+						onClick={ ( event: React.MouseEvent< HTMLAnchorElement > ) =>
+							handleClick( event, tab )
+						}
+					>
+						{ tab.title }
+					</NavItem>
+				) ) }
+			</NavTabs>
+		</SectionNav>
+	);
+}

--- a/client/reader/atmosphere/test/author-profile-panel.test.tsx
+++ b/client/reader/atmosphere/test/author-profile-panel.test.tsx
@@ -398,6 +398,31 @@ describe( 'AuthorProfilePanel', () => {
 			expect( screen.queryByRole( 'button', { name: /view on bluesky/i } ) ).toBeNull();
 			expect( screen.queryByRole( 'link', { name: /view on bluesky/i } ) ).toBeNull();
 		} );
+
+		it( 'shows the Media-tab empty title and no "View on Bluesky" action when ?tab=media', async () => {
+			window.history.replaceState(
+				{},
+				'',
+				'/reader/atmosphere/42/profile/alice.bsky.social?tab=media'
+			);
+
+			nock( 'https://public-api.wordpress.com' )
+				.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social' )
+				.reply( 200, profilePayload );
+			nock( 'https://public-api.wordpress.com' )
+				.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+				.query( true )
+				.reply( 200, { items: [], cursor: null } );
+
+			renderWithProvider(
+				<AuthorProfilePanel connection={ connection } actor="alice.bsky.social" />,
+				{ queryClient: makeQueryClient() }
+			);
+
+			expect( await screen.findByText( /hasn’t posted any media yet/i ) ).toBeVisible();
+			expect( screen.queryByRole( 'button', { name: /view on bluesky/i } ) ).toBeNull();
+			expect( screen.queryByRole( 'link', { name: /view on bluesky/i } ) ).toBeNull();
+		} );
 	} );
 
 	it( 'dedupes feed items by uri across pages (Bluesky returns repeats)', async () => {

--- a/client/reader/atmosphere/test/author-profile-panel.test.tsx
+++ b/client/reader/atmosphere/test/author-profile-panel.test.tsx
@@ -77,6 +77,9 @@ describe( 'AuthorProfilePanel', () => {
 	afterEach( () => {
 		nock.cleanAll();
 		jest.restoreAllMocks();
+		// Reset window.location so per-test ?tab= overrides don't leak into
+		// the next test's useAuthorProfileFilter() read.
+		window.history.replaceState( {}, '', '/' );
 	} );
 
 	it( 'renders the header and feed once both queries resolve', async () => {

--- a/client/reader/atmosphere/test/author-profile-panel.test.tsx
+++ b/client/reader/atmosphere/test/author-profile-panel.test.tsx
@@ -240,6 +240,166 @@ describe( 'AuthorProfilePanel', () => {
 		expect( await screen.findByText( 'second' ) ).toBeVisible();
 	} );
 
+	describe( 'filter tabs', () => {
+		it( 'fetches the feed with no filter when ?tab is absent', async () => {
+			window.history.replaceState( {}, '', '/reader/atmosphere/42/profile/alice.bsky.social' );
+
+			nock( 'https://public-api.wordpress.com' )
+				.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social' )
+				.reply( 200, profilePayload );
+			const feedScope = nock( 'https://public-api.wordpress.com' )
+				.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+				.query( ( q ) => ! ( 'filter' in q ) )
+				.reply( 200, { items: [ feedItem ], cursor: null } );
+
+			renderWithProvider(
+				<AuthorProfilePanel connection={ connection } actor="alice.bsky.social" />,
+				{ queryClient: makeQueryClient() }
+			);
+			await waitFor( () => expect( feedScope.isDone() ).toBe( true ) );
+		} );
+
+		it( 'fetches the feed with filter=posts_with_replies when ?tab=replies', async () => {
+			window.history.replaceState(
+				{},
+				'',
+				'/reader/atmosphere/42/profile/alice.bsky.social?tab=replies'
+			);
+
+			nock( 'https://public-api.wordpress.com' )
+				.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social' )
+				.reply( 200, profilePayload );
+			const feedScope = nock( 'https://public-api.wordpress.com' )
+				.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+				.query( { filter: 'posts_with_replies' } )
+				.reply( 200, { items: [], cursor: null } );
+
+			renderWithProvider(
+				<AuthorProfilePanel connection={ connection } actor="alice.bsky.social" />,
+				{ queryClient: makeQueryClient() }
+			);
+			await waitFor( () => expect( feedScope.isDone() ).toBe( true ) );
+		} );
+
+		it( 'renders three tabs above the feed', async () => {
+			window.history.replaceState( {}, '', '/reader/atmosphere/42/profile/alice.bsky.social' );
+
+			nock( 'https://public-api.wordpress.com' )
+				.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social' )
+				.reply( 200, profilePayload );
+			nock( 'https://public-api.wordpress.com' )
+				.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+				.query( true )
+				.reply( 200, { items: [], cursor: null } );
+
+			renderWithProvider(
+				<AuthorProfilePanel connection={ connection } actor="alice.bsky.social" />,
+				{ queryClient: makeQueryClient() }
+			);
+
+			// NavItem renders <a role="menuitem">, not role="link" (verified in
+			// the author-profile-tabs tests).
+			expect( await screen.findByRole( 'menuitem', { name: 'Posts' } ) ).toBeVisible();
+			expect( screen.getByRole( 'menuitem', { name: 'Replies' } ) ).toBeVisible();
+			expect( screen.getByRole( 'menuitem', { name: 'Media' } ) ).toBeVisible();
+		} );
+
+		it( '_profile_viewed includes initial_filter matching the URL on first paint', async () => {
+			window.history.replaceState(
+				{},
+				'',
+				'/reader/atmosphere/42/profile/alice.bsky.social?tab=media'
+			);
+
+			nock( 'https://public-api.wordpress.com' )
+				.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social' )
+				.reply( 200, profilePayload );
+			nock( 'https://public-api.wordpress.com' )
+				.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+				.query( true )
+				.reply( 200, { items: [], cursor: null } );
+
+			renderWithProvider(
+				<AuthorProfilePanel connection={ connection } actor="alice.bsky.social" />,
+				{ queryClient: makeQueryClient() }
+			);
+
+			await waitFor( () =>
+				expect( analytics.recordReaderTracksEvent ).toHaveBeenCalledWith(
+					'calypso_reader_atmosphere_profile_viewed',
+					expect.objectContaining( { initial_filter: 'posts_with_media' } )
+				)
+			);
+		} );
+
+		it( '_profile_error_shown for surface=feed includes filter; surface=header does not', async () => {
+			window.history.replaceState(
+				{},
+				'',
+				'/reader/atmosphere/42/profile/alice.bsky.social?tab=replies'
+			);
+
+			nock( 'https://public-api.wordpress.com' )
+				.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social' )
+				.reply( 429, { error: 'atmosphere_rate_limited' } );
+			nock( 'https://public-api.wordpress.com' )
+				.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+				.query( true )
+				.reply( 429, { error: 'atmosphere_rate_limited' } );
+
+			renderWithProvider(
+				<AuthorProfilePanel connection={ connection } actor="alice.bsky.social" />,
+				{ queryClient: makeQueryClient() }
+			);
+
+			await waitFor( () =>
+				expect( analytics.recordReaderTracksEvent ).toHaveBeenCalledWith(
+					'calypso_reader_atmosphere_profile_error_shown',
+					expect.objectContaining( { surface: 'feed', filter: 'posts_with_replies' } )
+				)
+			);
+			await waitFor( () =>
+				expect( analytics.recordReaderTracksEvent ).toHaveBeenCalledWith(
+					'calypso_reader_atmosphere_profile_error_shown',
+					expect.objectContaining( { surface: 'header' } )
+				)
+			);
+			const headerCall = (
+				analytics.recordReaderTracksEvent as unknown as jest.Mock
+			 ).mock.calls.find(
+				( c ) =>
+					c[ 0 ] === 'calypso_reader_atmosphere_profile_error_shown' && c[ 1 ]?.surface === 'header'
+			);
+			expect( headerCall ).toBeDefined();
+			expect( headerCall![ 1 ] ).not.toHaveProperty( 'filter' );
+		} );
+
+		it( 'shows per-tab empty title and no "View on Bluesky" action', async () => {
+			window.history.replaceState(
+				{},
+				'',
+				'/reader/atmosphere/42/profile/alice.bsky.social?tab=replies'
+			);
+
+			nock( 'https://public-api.wordpress.com' )
+				.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social' )
+				.reply( 200, profilePayload );
+			nock( 'https://public-api.wordpress.com' )
+				.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+				.query( true )
+				.reply( 200, { items: [], cursor: null } );
+
+			renderWithProvider(
+				<AuthorProfilePanel connection={ connection } actor="alice.bsky.social" />,
+				{ queryClient: makeQueryClient() }
+			);
+
+			expect( await screen.findByText( /hasn’t replied to anyone yet/i ) ).toBeVisible();
+			expect( screen.queryByRole( 'button', { name: /view on bluesky/i } ) ).toBeNull();
+			expect( screen.queryByRole( 'link', { name: /view on bluesky/i } ) ).toBeNull();
+		} );
+	} );
+
 	it( 'dedupes feed items by uri across pages (Bluesky returns repeats)', async () => {
 		nock( 'https://public-api.wordpress.com' )
 			.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social' )

--- a/client/reader/atmosphere/test/author-profile-tabs.test.tsx
+++ b/client/reader/atmosphere/test/author-profile-tabs.test.tsx
@@ -185,6 +185,16 @@ describe( 'AuthorProfileTabs', () => {
 		expect( analytics.recordReaderTracksEvent ).not.toHaveBeenCalled();
 	} );
 
+	it( 'falls back to Posts when activeFilter is the un-tabbed posts_and_author_threads value', () => {
+		renderTabs( { activeFilter: 'posts_and_author_threads' } );
+		// All three tabs render and the Posts tab is shown as selected.
+		expect( screen.getByRole( 'menuitem', { name: 'Posts' } ) ).toBeVisible();
+		expect( screen.getByRole( 'menuitem', { name: 'Replies' } ) ).toBeVisible();
+		expect( screen.getByRole( 'menuitem', { name: 'Media' } ) ).toBeVisible();
+		const postsTab = screen.getByRole( 'menuitem', { name: 'Posts' } );
+		expect( postsTab.closest( 'li' ) ).toHaveClass( 'is-selected' );
+	} );
+
 	it( 'modifier-click does not call preventDefault — native browser handling kicks in', async () => {
 		renderTabs( { activeFilter: 'posts_no_replies' } );
 		const repliesLink = screen.getByRole( 'menuitem', { name: 'Replies' } );

--- a/client/reader/atmosphere/test/author-profile-tabs.test.tsx
+++ b/client/reader/atmosphere/test/author-profile-tabs.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * @jest-environment jsdom
+ */
+import page from '@automattic/calypso-router';
+import { renderHook, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as analytics from 'calypso/state/reader/analytics/actions';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { AuthorProfileTabs, useAuthorProfileFilter } from '../author-profile-tabs';
+
+jest.mock( '@automattic/calypso-router', () => ( {
+	__esModule: true,
+	default: {
+		replace: jest.fn(),
+		show: jest.fn(),
+	},
+} ) );
+
+const replace = page.replace as jest.Mock;
+const showFn = page.show as jest.Mock;
+
+function setLocation( search: string ) {
+	window.history.replaceState( {}, '', '/reader/atmosphere/42/profile/alice.bsky.social' + search );
+}
+
+// NavTabs uses IntersectionObserver which jsdom does not provide.
+beforeAll( () => {
+	global.IntersectionObserver = class IntersectionObserver {
+		observe() {}
+		unobserve() {}
+		disconnect() {}
+	} as unknown as typeof global.IntersectionObserver;
+} );
+
+afterAll( () => {
+	// @ts-expect-error -- cleaning up the stub
+	delete global.IntersectionObserver;
+} );
+
+beforeEach( () => {
+	replace.mockReset();
+	showFn.mockReset();
+	jest
+		.spyOn( analytics, 'recordReaderTracksEvent' )
+		.mockImplementation( () => ( { type: '@@TEST/NOOP' } ) as never );
+	setLocation( '' );
+} );
+
+afterEach( () => {
+	jest.restoreAllMocks();
+} );
+
+describe( 'useAuthorProfileFilter', () => {
+	it( 'returns posts_no_replies when ?tab is absent', () => {
+		setLocation( '' );
+		const { result } = renderHook( () => useAuthorProfileFilter() );
+		expect( result.current ).toBe( 'posts_no_replies' );
+		expect( replace ).not.toHaveBeenCalled();
+	} );
+
+	it( 'maps ?tab=replies to posts_with_replies', () => {
+		setLocation( '?tab=replies' );
+		const { result } = renderHook( () => useAuthorProfileFilter() );
+		expect( result.current ).toBe( 'posts_with_replies' );
+		expect( replace ).not.toHaveBeenCalled();
+	} );
+
+	it( 'maps ?tab=media to posts_with_media', () => {
+		setLocation( '?tab=media' );
+		const { result } = renderHook( () => useAuthorProfileFilter() );
+		expect( result.current ).toBe( 'posts_with_media' );
+		expect( replace ).not.toHaveBeenCalled();
+	} );
+
+	it( 'rewrites a malformed ?tab once and returns the default filter', () => {
+		setLocation( '?tab=garbage' );
+		const { rerender, result } = renderHook( () => useAuthorProfileFilter() );
+		expect( result.current ).toBe( 'posts_no_replies' );
+		expect( replace ).toHaveBeenCalledTimes( 1 );
+		expect( replace ).toHaveBeenCalledWith( expect.stringMatching( /\?tab=posts$/ ) );
+
+		// A subsequent render with the same malformed URL must not call replace again.
+		rerender();
+		expect( replace ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'rewrites again if a malformed value reappears after a valid value', () => {
+		setLocation( '?tab=garbage' );
+		const { rerender, result } = renderHook( () => useAuthorProfileFilter() );
+		expect( replace ).toHaveBeenCalledTimes( 1 );
+		expect( result.current ).toBe( 'posts_no_replies' );
+
+		// User navigates to a valid tab — the ref clears.
+		setLocation( '?tab=replies' );
+		rerender();
+		expect( replace ).toHaveBeenCalledTimes( 1 );
+		expect( result.current ).toBe( 'posts_with_replies' );
+
+		// A new malformed value should re-trigger the rewrite.
+		setLocation( '?tab=garbage2' );
+		rerender();
+		expect( replace ).toHaveBeenCalledTimes( 2 );
+		expect( replace ).toHaveBeenLastCalledWith( expect.stringMatching( /\?tab=posts$/ ) );
+		expect( result.current ).toBe( 'posts_no_replies' );
+	} );
+
+	it( 'maps ?tab=posts to posts_no_replies', () => {
+		setLocation( '?tab=posts' );
+		const { result } = renderHook( () => useAuthorProfileFilter() );
+		expect( result.current ).toBe( 'posts_no_replies' );
+		expect( replace ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'AuthorProfileTabs', () => {
+	function renderTabs( props: Partial< React.ComponentProps< typeof AuthorProfileTabs > > = {} ) {
+		return renderWithProvider(
+			<AuthorProfileTabs
+				connectionId={ 42 }
+				actor="alice.bsky.social"
+				activeFilter="posts_no_replies"
+				{ ...props }
+			/>
+		);
+	}
+
+	it( 'renders three tabs labeled Posts, Replies, and Media', () => {
+		renderTabs();
+		expect( screen.getByRole( 'menuitem', { name: 'Posts' } ) ).toBeVisible();
+		expect( screen.getByRole( 'menuitem', { name: 'Replies' } ) ).toBeVisible();
+		expect( screen.getByRole( 'menuitem', { name: 'Media' } ) ).toBeVisible();
+	} );
+
+	it( 'marks the activeFilter tab as selected', () => {
+		renderTabs( { activeFilter: 'posts_with_replies' } );
+		const repliesTab = screen.getByRole( 'menuitem', { name: 'Replies' } );
+		expect( repliesTab.closest( 'li' ) ).toHaveClass( 'is-selected' );
+	} );
+
+	it( 'tabs anchor to the per-filter URL via href', () => {
+		renderTabs();
+		expect( screen.getByRole( 'menuitem', { name: 'Posts' } ) ).toHaveAttribute(
+			'href',
+			'/reader/atmosphere/42/profile/alice.bsky.social?tab=posts'
+		);
+		expect( screen.getByRole( 'menuitem', { name: 'Replies' } ) ).toHaveAttribute(
+			'href',
+			'/reader/atmosphere/42/profile/alice.bsky.social?tab=replies'
+		);
+		expect( screen.getByRole( 'menuitem', { name: 'Media' } ) ).toHaveAttribute(
+			'href',
+			'/reader/atmosphere/42/profile/alice.bsky.social?tab=media'
+		);
+	} );
+
+	it( 'plain-clicking a non-active tab calls page.replace and dispatches _filter_changed', async () => {
+		const user = userEvent.setup();
+		renderTabs( { activeFilter: 'posts_no_replies' } );
+
+		await user.click( screen.getByRole( 'menuitem', { name: 'Replies' } ) );
+
+		expect( replace ).toHaveBeenCalledTimes( 1 );
+		expect( replace ).toHaveBeenCalledWith(
+			'/reader/atmosphere/42/profile/alice.bsky.social?tab=replies'
+		);
+		expect( showFn ).not.toHaveBeenCalled();
+		expect( analytics.recordReaderTracksEvent ).toHaveBeenCalledWith(
+			'calypso_reader_atmosphere_profile_filter_changed',
+			{
+				connection_id: 42,
+				actor: 'alice.bsky.social',
+				from_filter: 'posts_no_replies',
+				to_filter: 'posts_with_replies',
+			}
+		);
+	} );
+
+	it( 'clicking the already-active tab is a no-op', async () => {
+		const user = userEvent.setup();
+		renderTabs( { activeFilter: 'posts_no_replies' } );
+
+		await user.click( screen.getByRole( 'menuitem', { name: 'Posts' } ) );
+
+		expect( replace ).not.toHaveBeenCalled();
+		expect( analytics.recordReaderTracksEvent ).not.toHaveBeenCalled();
+	} );
+
+	it( 'modifier-click does not call preventDefault — native browser handling kicks in', async () => {
+		renderTabs( { activeFilter: 'posts_no_replies' } );
+		const repliesLink = screen.getByRole( 'menuitem', { name: 'Replies' } );
+
+		// Build a click event that we control so we can assert on defaultPrevented.
+		const event = new MouseEvent( 'click', {
+			bubbles: true,
+			cancelable: true,
+			button: 0,
+			metaKey: true,
+		} );
+		repliesLink.dispatchEvent( event );
+
+		expect( event.defaultPrevented ).toBe( false );
+		expect( replace ).not.toHaveBeenCalled();
+		expect( analytics.recordReaderTracksEvent ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/reader/atmosphere/test/author-profile-view.test.tsx
+++ b/client/reader/atmosphere/test/author-profile-view.test.tsx
@@ -27,6 +27,21 @@ jest.mock( '@automattic/calypso-router', () => ( {
 	default: { replace: jest.fn() },
 } ) );
 
+// NavTabs (used by AuthorProfileTabs inside AuthorProfilePanel) relies on
+// IntersectionObserver, which jsdom does not provide.
+beforeAll( () => {
+	global.IntersectionObserver = class IntersectionObserver {
+		observe() {}
+		unobserve() {}
+		disconnect() {}
+	} as unknown as typeof global.IntersectionObserver;
+} );
+
+afterAll( () => {
+	// @ts-expect-error -- cleaning up the stub
+	delete global.IntersectionObserver;
+} );
+
 afterEach( () => {
 	nock.cleanAll();
 	jest.restoreAllMocks();

--- a/packages/api-core/src/reader-atmosphere/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/reader-atmosphere/__tests__/fetchers.test.ts
@@ -445,6 +445,29 @@ describe( 'atmosphere fetchers', () => {
 			expect( scope.isDone() ).toBe( true );
 		} );
 
+		it( 'forwards filter as a query param when set', async () => {
+			const scope = nock( 'https://public-api.wordpress.com' )
+				.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+				.query( { filter: 'posts_with_replies' } )
+				.reply( 200, { items: [], cursor: null } );
+
+			await getAuthorFeed( {
+				actor: 'alice.bsky.social',
+				filter: 'posts_with_replies',
+			} );
+			expect( scope.isDone() ).toBe( true );
+		} );
+
+		it( 'omits filter from the query string when undefined', async () => {
+			const scope = nock( 'https://public-api.wordpress.com' )
+				.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+				.query( ( q ) => ! ( 'filter' in q ) )
+				.reply( 200, { items: [], cursor: null } );
+
+			await getAuthorFeed( { actor: 'alice.bsky.social' } );
+			expect( scope.isDone() ).toBe( true );
+		} );
+
 		it( 'percent-encodes the actor in the path', async () => {
 			const scope = nock( 'https://public-api.wordpress.com' )
 				.get( '/wpcom/v2/reader/atmosphere/profile/did%3Aplc%3Aabc123/feed' )

--- a/packages/api-core/src/reader-atmosphere/__tests__/query-keys.test.ts
+++ b/packages/api-core/src/reader-atmosphere/__tests__/query-keys.test.ts
@@ -49,4 +49,31 @@ describe( 'readerAtmosphereKeys.authorFeed', () => {
 			readerAtmosphereKeys.profile( 'alice' )
 		);
 	} );
+
+	it( 'preserves the 4-element key shape when filter is undefined', () => {
+		expect( readerAtmosphereKeys.authorFeed( 'alice.bsky.social' ) ).toEqual( [
+			'reader',
+			'atmosphere',
+			'author-feed',
+			'alice.bsky.social',
+		] );
+	} );
+
+	it( 'appends the filter as a fifth element when set', () => {
+		expect( readerAtmosphereKeys.authorFeed( 'alice.bsky.social', 'posts_with_replies' ) ).toEqual(
+			[ 'reader', 'atmosphere', 'author-feed', 'alice.bsky.social', 'posts_with_replies' ]
+		);
+	} );
+
+	it( 'differs from the no-filter key for the same actor', () => {
+		expect( readerAtmosphereKeys.authorFeed( 'alice.bsky.social' ) ).not.toEqual(
+			readerAtmosphereKeys.authorFeed( 'alice.bsky.social', 'posts_with_media' )
+		);
+	} );
+
+	it( 'differs across filter values for the same actor', () => {
+		expect(
+			readerAtmosphereKeys.authorFeed( 'alice.bsky.social', 'posts_no_replies' )
+		).not.toEqual( readerAtmosphereKeys.authorFeed( 'alice.bsky.social', 'posts_with_replies' ) );
+	} );
 } );

--- a/packages/api-core/src/reader-atmosphere/fetchers.ts
+++ b/packages/api-core/src/reader-atmosphere/fetchers.ts
@@ -1,6 +1,7 @@
 import { wpcom } from '../wpcom-fetcher';
 import { classifyAtmosphereError } from './errors';
 import type {
+	AtmosphereAuthorFeedFilter,
 	AtmosphereAuthorFeedPage,
 	AtmosphereAuthorProfile,
 	AtmosphereConnectionDetails,
@@ -132,18 +133,22 @@ export interface GetAuthorFeedParams {
 	actor: string;
 	cursor?: string;
 	limit?: number;
+	filter?: AtmosphereAuthorFeedFilter;
 }
 
 export async function getAuthorFeed(
 	params: GetAuthorFeedParams
 ): Promise< AtmosphereAuthorFeedPage > {
-	const { actor, cursor, limit } = params;
+	const { actor, cursor, limit, filter } = params;
 	const query: Record< string, string > = {};
 	if ( cursor ) {
 		query.cursor = cursor;
 	}
 	if ( limit ) {
 		query.limit = String( limit );
+	}
+	if ( filter ) {
+		query.filter = filter;
 	}
 	try {
 		return ( await wpcom.req.get(

--- a/packages/api-core/src/reader-atmosphere/query-keys.ts
+++ b/packages/api-core/src/reader-atmosphere/query-keys.ts
@@ -1,3 +1,5 @@
+import type { AtmosphereAuthorFeedFilter } from './types';
+
 export const readerAtmosphereKeys = {
 	all: [ 'reader', 'atmosphere' ] as const,
 	connections: () => [ ...readerAtmosphereKeys.all, 'connections' ] as const,
@@ -6,5 +8,8 @@ export const readerAtmosphereKeys = {
 		[ ...readerAtmosphereKeys.all, 'timeline', connectionId ] as const,
 	thread: ( uri: string ) => [ ...readerAtmosphereKeys.all, 'thread', uri ] as const,
 	profile: ( actor: string ) => [ ...readerAtmosphereKeys.all, 'profile', actor ] as const,
-	authorFeed: ( actor: string ) => [ ...readerAtmosphereKeys.all, 'author-feed', actor ] as const,
+	authorFeed: ( actor: string, filter?: AtmosphereAuthorFeedFilter ) =>
+		filter
+			? ( [ ...readerAtmosphereKeys.all, 'author-feed', actor, filter ] as const )
+			: ( [ ...readerAtmosphereKeys.all, 'author-feed', actor ] as const ),
 };

--- a/packages/api-core/src/reader-atmosphere/types.ts
+++ b/packages/api-core/src/reader-atmosphere/types.ts
@@ -199,3 +199,15 @@ export interface AtmosphereAuthorFeedPage {
 	items: AtmosphereFeedItem[];
 	cursor: string | null;
 }
+
+/**
+ * Author feed filter values accepted by the backend, mirroring the four
+ * ATproto `app.bsky.feed.getAuthorFeed` `filter` enum values. The first
+ * three are surfaced as UI tabs (Posts / Replies / Media); the fourth is
+ * type-system supported but not exposed in this slice.
+ */
+export type AtmosphereAuthorFeedFilter =
+	| 'posts_no_replies'
+	| 'posts_with_replies'
+	| 'posts_with_media'
+	| 'posts_and_author_threads';

--- a/packages/api-queries/src/__tests__/reader-atmosphere.test.tsx
+++ b/packages/api-queries/src/__tests__/reader-atmosphere.test.tsx
@@ -497,6 +497,37 @@ describe( 'reader-atmosphere hooks', () => {
 			expect( scope.isDone() ).toBe( true );
 		} );
 
+		it( 'treats filter=posts_no_replies the same as no filter (default normalization)', async () => {
+			const scope = nock( 'https://public-api.wordpress.com' )
+				.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+				.query( ( q ) => ! ( 'filter' in q ) )
+				.reply( 200, { items: [], cursor: null } );
+
+			const queryClient = new QueryClient();
+			const wrapper = makeWrapper( queryClient );
+			const { result } = renderHook(
+				() => {
+					const q = useAuthorFeedInfiniteQuery( {
+						actor: 'alice.bsky.social',
+						filter: 'posts_no_replies',
+					} );
+					void q.data;
+					void q.isError;
+					void q.error;
+					void q.isSuccess;
+					return q;
+				},
+				{ wrapper }
+			);
+
+			await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+			expect( scope.isDone() ).toBe( true );
+
+			// And the cache key should match the slice-6 4-element shape, not 5-element.
+			const cacheKey = queryClient.getQueryCache().getAll()[ 0 ]?.queryKey;
+			expect( cacheKey ).toEqual( [ 'reader', 'atmosphere', 'author-feed', 'alice.bsky.social' ] );
+		} );
+
 		it( 'caches results independently per filter value', async () => {
 			nock( 'https://public-api.wordpress.com' )
 				.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )

--- a/packages/api-queries/src/__tests__/reader-atmosphere.test.tsx
+++ b/packages/api-queries/src/__tests__/reader-atmosphere.test.tsx
@@ -572,7 +572,10 @@ describe( 'reader-atmosphere hooks', () => {
 
 			// Both queries resolved independently — the cache key includes filter,
 			// so the second hook did not reuse the first hook's data.
-			expect( queryClient.getQueryCache().getAll().length ).toBe( 2 );
+			const matched = queryClient.getQueryCache().findAll( {
+				queryKey: readerAtmosphereKeys.authorFeed( 'alice.bsky.social' ),
+			} );
+			expect( matched ).toHaveLength( 2 );
 		} );
 	} );
 } );

--- a/packages/api-queries/src/__tests__/reader-atmosphere.test.tsx
+++ b/packages/api-queries/src/__tests__/reader-atmosphere.test.tsx
@@ -469,5 +469,79 @@ describe( 'reader-atmosphere hooks', () => {
 			await waitFor( () => expect( result.current.data?.pages.length ).toBe( 2 ) );
 			expect( result.current.hasNextPage ).toBe( false );
 		} );
+
+		it( 'forwards filter to the fetcher when set', async () => {
+			const scope = nock( 'https://public-api.wordpress.com' )
+				.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+				.query( { filter: 'posts_with_media' } )
+				.reply( 200, { items: [], cursor: null } );
+
+			const queryClient = new QueryClient();
+			const wrapper = makeWrapper( queryClient );
+			const { result } = renderHook(
+				() => {
+					const q = useAuthorFeedInfiniteQuery( {
+						actor: 'alice.bsky.social',
+						filter: 'posts_with_media',
+					} );
+					void q.data;
+					void q.isError;
+					void q.error;
+					void q.isSuccess;
+					return q;
+				},
+				{ wrapper }
+			);
+
+			await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+			expect( scope.isDone() ).toBe( true );
+		} );
+
+		it( 'caches results independently per filter value', async () => {
+			nock( 'https://public-api.wordpress.com' )
+				.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+				.query( ( q ) => ! ( 'filter' in q ) )
+				.reply( 200, { items: [], cursor: null } );
+			nock( 'https://public-api.wordpress.com' )
+				.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+				.query( { filter: 'posts_with_replies' } )
+				.reply( 200, { items: [], cursor: null } );
+
+			const queryClient = new QueryClient();
+			const wrapper = makeWrapper( queryClient );
+
+			const { result: noFilter } = renderHook(
+				() => {
+					const q = useAuthorFeedInfiniteQuery( { actor: 'alice.bsky.social' } );
+					void q.data;
+					void q.isError;
+					void q.error;
+					void q.isSuccess;
+					return q;
+				},
+				{ wrapper }
+			);
+			await waitFor( () => expect( noFilter.current.isSuccess ).toBe( true ) );
+
+			const { result: withFilter } = renderHook(
+				() => {
+					const q = useAuthorFeedInfiniteQuery( {
+						actor: 'alice.bsky.social',
+						filter: 'posts_with_replies',
+					} );
+					void q.data;
+					void q.isError;
+					void q.error;
+					void q.isSuccess;
+					return q;
+				},
+				{ wrapper }
+			);
+			await waitFor( () => expect( withFilter.current.isSuccess ).toBe( true ) );
+
+			// Both queries resolved independently — the cache key includes filter,
+			// so the second hook did not reuse the first hook's data.
+			expect( queryClient.getQueryCache().getAll().length ).toBe( 2 );
+		} );
 	} );
 } );

--- a/packages/api-queries/src/reader-atmosphere.ts
+++ b/packages/api-queries/src/reader-atmosphere.ts
@@ -19,6 +19,7 @@ import {
 	type QueryKey,
 } from '@tanstack/react-query';
 import type {
+	AtmosphereAuthorFeedFilter,
 	AtmosphereAuthorFeedPage,
 	AtmosphereAuthorProfile,
 	AtmosphereConnectionDetails,
@@ -159,7 +160,7 @@ export function useAuthorProfileQuery( { actor }: UseAuthorProfileQueryParams ) 
 	return useQuery( profileQueryOptions( actor ) );
 }
 
-export const authorFeedInfiniteQuery = ( actor: string ) =>
+export const authorFeedInfiniteQuery = ( actor: string, filter?: AtmosphereAuthorFeedFilter ) =>
 	infiniteQueryOptions<
 		AtmosphereAuthorFeedPage,
 		AtmosphereError,
@@ -167,8 +168,8 @@ export const authorFeedInfiniteQuery = ( actor: string ) =>
 		QueryKey,
 		string | undefined
 	>( {
-		queryKey: readerAtmosphereKeys.authorFeed( actor ),
-		queryFn: ( { pageParam } ) => getAuthorFeed( { actor, cursor: pageParam } ),
+		queryKey: readerAtmosphereKeys.authorFeed( actor, filter ),
+		queryFn: ( { pageParam } ) => getAuthorFeed( { actor, cursor: pageParam, filter } ),
 		initialPageParam: undefined,
 		getNextPageParam: ( lastPage ) => lastPage.cursor || undefined,
 		enabled: actor.length > 0,
@@ -178,8 +179,9 @@ export const authorFeedInfiniteQuery = ( actor: string ) =>
 
 export interface UseAuthorFeedInfiniteQueryParams {
 	actor: string;
+	filter?: AtmosphereAuthorFeedFilter;
 }
 
-export function useAuthorFeedInfiniteQuery( { actor }: UseAuthorFeedInfiniteQueryParams ) {
-	return useInfiniteQuery( authorFeedInfiniteQuery( actor ) );
+export function useAuthorFeedInfiniteQuery( { actor, filter }: UseAuthorFeedInfiniteQueryParams ) {
+	return useInfiniteQuery( authorFeedInfiniteQuery( actor, filter ) );
 }

--- a/packages/api-queries/src/reader-atmosphere.ts
+++ b/packages/api-queries/src/reader-atmosphere.ts
@@ -183,5 +183,10 @@ export interface UseAuthorFeedInfiniteQueryParams {
 }
 
 export function useAuthorFeedInfiniteQuery( { actor, filter }: UseAuthorFeedInfiniteQueryParams ) {
-	return useInfiniteQuery( authorFeedInfiniteQuery( actor, filter ) );
+	// Collapse the default filter to undefined so the cache key and request
+	// URL stay clean for the default tab. Callers can pass 'posts_no_replies'
+	// without paying a cache-key change versus passing nothing at all —
+	// matters for slice-6 cache compatibility.
+	const normalizedFilter = filter === 'posts_no_replies' ? undefined : filter;
+	return useInfiniteQuery( authorFeedInfiniteQuery( actor, normalizedFilter ) );
 }

--- a/packages/api-queries/src/reader-atmosphere.ts
+++ b/packages/api-queries/src/reader-atmosphere.ts
@@ -160,22 +160,30 @@ export function useAuthorProfileQuery( { actor }: UseAuthorProfileQueryParams ) 
 	return useQuery( profileQueryOptions( actor ) );
 }
 
-export const authorFeedInfiniteQuery = ( actor: string, filter?: AtmosphereAuthorFeedFilter ) =>
-	infiniteQueryOptions<
+export const authorFeedInfiniteQuery = ( actor: string, filter?: AtmosphereAuthorFeedFilter ) => {
+	// Collapse the default filter to undefined so the cache key and request
+	// URL stay clean for the default tab. Callers can pass 'posts_no_replies'
+	// without paying a cache-key change versus passing nothing at all —
+	// matters for slice-6 cache compatibility. Centralized here (not in the
+	// hook) so any direct factory caller gets the same behavior.
+	const normalizedFilter = filter === 'posts_no_replies' ? undefined : filter;
+	return infiniteQueryOptions<
 		AtmosphereAuthorFeedPage,
 		AtmosphereError,
 		InfiniteData< AtmosphereAuthorFeedPage >,
 		QueryKey,
 		string | undefined
 	>( {
-		queryKey: readerAtmosphereKeys.authorFeed( actor, filter ),
-		queryFn: ( { pageParam } ) => getAuthorFeed( { actor, cursor: pageParam, filter } ),
+		queryKey: readerAtmosphereKeys.authorFeed( actor, normalizedFilter ),
+		queryFn: ( { pageParam } ) =>
+			getAuthorFeed( { actor, cursor: pageParam, filter: normalizedFilter } ),
 		initialPageParam: undefined,
 		getNextPageParam: ( lastPage ) => lastPage.cursor || undefined,
 		enabled: actor.length > 0,
 		staleTime: 30_000,
 		gcTime: 5 * 60_000,
 	} );
+};
 
 export interface UseAuthorFeedInfiniteQueryParams {
 	actor: string;
@@ -183,10 +191,5 @@ export interface UseAuthorFeedInfiniteQueryParams {
 }
 
 export function useAuthorFeedInfiniteQuery( { actor, filter }: UseAuthorFeedInfiniteQueryParams ) {
-	// Collapse the default filter to undefined so the cache key and request
-	// URL stay clean for the default tab. Callers can pass 'posts_no_replies'
-	// without paying a cache-key change versus passing nothing at all —
-	// matters for slice-6 cache compatibility.
-	const normalizedFilter = filter === 'posts_no_replies' ? undefined : filter;
-	return useInfiniteQuery( authorFeedInfiniteQuery( actor, normalizedFilter ) );
+	return useInfiniteQuery( authorFeedInfiniteQuery( actor, filter ) );
 }


### PR DESCRIPTION
Fixes CM-628

## Proposed Changes

- Add Posts / Replies / Media filter tabs to the slice-6 in-app author profile feed at `/reader/atmosphere/:id/profile/:actor`.
- Thread an optional `filter: AtmosphereAuthorFeedFilter` parameter end-to-end through `getAuthorFeed` → `authorFeedInfiniteQuery` → `useAuthorFeedInfiniteQuery`.
- New presentational `AuthorProfileTabs` component (uses `SectionNav` + `NavTabs` + `NavItem`) and co-located `useAuthorProfileFilter()` hook for `?tab=` URL state.
- Per-tab empty-state copy (no "View on Bluesky" action button).
- New `calypso_reader_atmosphere_profile_filter_changed` Tracks event; existing `_profile_viewed` extended with `initial_filter`; existing `_profile_error_shown` extended with `filter` for `surface: 'feed'` only.

## Why are these changes being made?

CM-628 follow-up to slice 6 (CM-624). Provides bsky.app-parity tabs so users can scope an author's feed to posts-only, replies, or media without leaving Calypso.

The backend (`/wpcom/v2/reader/atmosphere/profile/{actor}/feed`) already accepts the `filter` query param (shipped in slice 4 / CM-608). No wpcom changes required.

## Testing Instructions

1. Connect a Bluesky account: `/reader/atmosphere`.
2. Open a post in the timeline, click the author chip → lands on the author profile feed.
3. Verify the new Posts / Replies / Media tab strip appears under the profile card. Posts is selected by default and the URL has no `?tab=`.
4. Click Replies → URL becomes `?tab=replies`, feed reloads with replies. Click Media → `?tab=media`. Browser **Back** should exit the profile, not step through intermediate tabs (replace history).
5. Refresh on `?tab=media` — lands on Media directly, no flicker through Posts.
6. Hand-edit the URL to `?tab=garbage` — page silently rewrites to `?tab=posts`.
7. Middle-click / cmd-click a tab → opens the tab's URL in a new browser tab.
8. Empty-state: an author with no replies on the Replies tab should show "@handle hasn’t replied to anyone yet." (no "View on Bluesky" button).

## Notes for reviewers

- **Cache compatibility:** `useAuthorFeedInfiniteQuery` collapses `filter: 'posts_no_replies'` to `undefined` internally. Slice-6's existing 4-element cache key shape is preserved for the default tab, so any in-flight cache from before this change keeps its identity. Tested in `packages/api-queries/src/__tests__/reader-atmosphere.test.tsx`.
- **`_profile_viewed` `initial_filter`:** the effect deliberately omits `filter` from its dependency array (with an `eslint-disable-next-line` and explanatory comment). The semantics are "what filter was active when the user first opened the profile," captured at first-fire time — adding `filter` to deps would risk a stale-ref refactor turning this into a per-tab event.
- **Out of scope:** Pinned posts, the 4th backend enum value `posts_and_author_threads` (type-system supported but not surfaced as a UI tab), Mastodon parity (tracked separately as CM-629).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed?
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?