### PR TITLE
Magic login: show the connector logo on Magic Link when coming from Connector Flow

### DIFF
--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -389,7 +389,7 @@ const MagicLoginWithContext = ( props ) => {
 	);
 };
 
-export const getConnectorParamsFromRedirectTo = ( redirectToOriginal ) => {
+export const getConnectionFlowFromRedirectTo = ( redirectToOriginal ) => {
 	const redirectToParams = new URLSearchParams( redirectToOriginal?.split( '?' )[ 1 ] );
 	const from = redirectToParams.get( 'from' );
 	const plugins = redirectToParams.get( 'plugins' );
@@ -405,7 +405,7 @@ const mapState = ( state ) => {
 	const currentQuery = getCurrentQueryArguments( state );
 	const initialQuery = getInitialQueryArguments( state );
 	const redirectToOriginal = getRedirectToOriginal( state );
-	const connectorParams = getConnectorParamsFromRedirectTo( redirectToOriginal );
+	const connectorParams = getConnectionFlowFromRedirectTo( redirectToOriginal );
 
 	return {
 		locale: getCurrentLocaleSlug( state ),

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -389,14 +389,23 @@ const MagicLoginWithContext = ( props ) => {
 	);
 };
 
+export const getConnectorParamsFromRedirectTo = ( redirectToOriginal ) => {
+	const redirectToParams = new URLSearchParams( redirectToOriginal?.split( '?' )[ 1 ] );
+	const from = redirectToParams.get( 'from' );
+	const plugins = redirectToParams.get( 'plugins' );
+	return {
+		isUnifiedConnectionFlow: [ 'jetpack-onboarding', 'jetpack-connector' ].includes( from ),
+		isFromJetpackConnector: 'jetpack-connector' === from,
+		connectorPlugins: plugins ? plugins.split( ',' ).filter( Boolean ) : [],
+	};
+};
+
 const mapState = ( state ) => {
 	const currentRoute = getCurrentRoute( state );
 	const currentQuery = getCurrentQueryArguments( state );
 	const initialQuery = getInitialQueryArguments( state );
 	const redirectToOriginal = getRedirectToOriginal( state );
-	const redirectToParams = new URLSearchParams( redirectToOriginal?.split( '?' )[ 1 ] );
-	const redirectToFrom = redirectToParams.get( 'from' );
-	const redirectToPlugins = redirectToParams.get( 'plugins' );
+	const connectorParams = getConnectorParamsFromRedirectTo( redirectToOriginal );
 
 	return {
 		locale: getCurrentLocaleSlug( state ),
@@ -413,11 +422,7 @@ const mapState = ( state ) => {
 		twoFactorNotificationSent: getTwoFactorNotificationSent( state ),
 		redirectToSanitized: getRedirectToSanitized( state ),
 		redirectToOriginal,
-		isUnifiedConnectionFlow: [ 'jetpack-onboarding', 'jetpack-connector' ].includes(
-			redirectToFrom
-		),
-		isFromJetpackConnector: 'jetpack-connector' === redirectToFrom,
-		connectorPlugins: redirectToPlugins ? redirectToPlugins.split( ',' ).filter( Boolean ) : [],
+		...connectorParams,
 		isWooJPC: isWooJPCFlow( state ),
 		publicToken: getMagicLoginPublicToken( state ),
 		partnerConfig: detectPartnerConfig( getCurrentOAuth2Client( state ) ),

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -338,6 +338,7 @@ export class MagicLogin extends Component {
 			<OneLoginLayout
 				isJetpack={ isJetpackLogin }
 				isFromJetpackConnector={ isFromJetpackConnector }
+				isUnifiedConnectionFlow={ isUnifiedConnectionFlow }
 				connectorPlugins={ connectorPlugins }
 			>
 				{ mainContent }
@@ -389,14 +390,20 @@ const MagicLoginWithContext = ( props ) => {
 	);
 };
 
-export const getConnectionFlowFromRedirectTo = ( redirectToOriginal ) => {
+export const getConnectionFlowFromRedirectTo = ( redirectToOriginal, currentQuery = {} ) => {
 	const redirectToParams = new URLSearchParams( redirectToOriginal?.split( '?' )[ 1 ] );
-	const from = redirectToParams.get( 'from' );
-	const plugins = redirectToParams.get( 'plugins' );
+	const from = redirectToParams.get( 'from' ) || currentQuery.from || null;
+	const isFromJetpackConnector = from === 'jetpack-connector';
+	const rawPlugins = isFromJetpackConnector
+		? redirectToParams.get( 'plugins' ) || currentQuery.plugins || ''
+		: '';
 	return {
 		isUnifiedConnectionFlow: [ 'jetpack-onboarding', 'jetpack-connector' ].includes( from ),
-		isFromJetpackConnector: 'jetpack-connector' === from,
-		connectorPlugins: plugins ? plugins.split( ',' ).filter( Boolean ) : [],
+		isFromJetpackConnector,
+		connectorPlugins: rawPlugins
+			.split( ',' )
+			.map( ( s ) => s.trim() )
+			.filter( Boolean ),
 	};
 };
 
@@ -405,7 +412,7 @@ const mapState = ( state ) => {
 	const currentQuery = getCurrentQueryArguments( state );
 	const initialQuery = getInitialQueryArguments( state );
 	const redirectToOriginal = getRedirectToOriginal( state );
-	const connectorParams = getConnectionFlowFromRedirectTo( redirectToOriginal );
+	const connectorParams = getConnectionFlowFromRedirectTo( redirectToOriginal, currentQuery );
 
 	return {
 		locale: getCurrentLocaleSlug( state ),

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -268,8 +268,16 @@ export class MagicLogin extends Component {
 	};
 
 	render() {
-		const { oauth2Client, query, translate, isWooJPC, isJetpackLogin, isUnifiedConnectionFlow } =
-			this.props;
+		const {
+			oauth2Client,
+			query,
+			translate,
+			isWooJPC,
+			isJetpackLogin,
+			isUnifiedConnectionFlow,
+			isFromJetpackConnector,
+			connectorPlugins,
+		} = this.props;
 		const { usernameOrEmail } = this.state;
 
 		if ( isGravPoweredOAuth2Client( oauth2Client ) ) {
@@ -326,7 +334,15 @@ export class MagicLogin extends Component {
 			</Main>
 		);
 
-		return <OneLoginLayout isJetpack={ isJetpackLogin }>{ mainContent }</OneLoginLayout>;
+		return (
+			<OneLoginLayout
+				isJetpack={ isJetpackLogin }
+				isFromJetpackConnector={ isFromJetpackConnector }
+				connectorPlugins={ connectorPlugins }
+			>
+				{ mainContent }
+			</OneLoginLayout>
+		);
 	}
 }
 
@@ -378,6 +394,9 @@ const mapState = ( state ) => {
 	const currentQuery = getCurrentQueryArguments( state );
 	const initialQuery = getInitialQueryArguments( state );
 	const redirectToOriginal = getRedirectToOriginal( state );
+	const redirectToParams = new URLSearchParams( redirectToOriginal?.split( '?' )[ 1 ] );
+	const redirectToFrom = redirectToParams.get( 'from' );
+	const redirectToPlugins = redirectToParams.get( 'plugins' );
 
 	return {
 		locale: getCurrentLocaleSlug( state ),
@@ -395,8 +414,10 @@ const mapState = ( state ) => {
 		redirectToSanitized: getRedirectToSanitized( state ),
 		redirectToOriginal,
 		isUnifiedConnectionFlow: [ 'jetpack-onboarding', 'jetpack-connector' ].includes(
-			new URLSearchParams( redirectToOriginal?.split( '?' )[ 1 ] ).get( 'from' )
+			redirectToFrom
 		),
+		isFromJetpackConnector: 'jetpack-connector' === redirectToFrom,
+		connectorPlugins: redirectToPlugins ? redirectToPlugins.split( ',' ).filter( Boolean ) : [],
 		isWooJPC: isWooJPCFlow( state ),
 		publicToken: getMagicLoginPublicToken( state ),
 		partnerConfig: detectPartnerConfig( getCurrentOAuth2Client( state ) ),

--- a/client/login/magic-login/test/index.test.jsx
+++ b/client/login/magic-login/test/index.test.jsx
@@ -150,13 +150,42 @@ describe( 'getConnectionFlowFromRedirectTo', () => {
 		expect( params.connectorPlugins ).toEqual( [] );
 	} );
 
-	it( 'does not flag the connector for unrelated from values', () => {
+	it( 'does not flag the connector for unrelated from values and ignores plugins', () => {
 		const params = getConnectionFlowFromRedirectTo(
 			'/jetpack/connect/authorize?from=my-jetpack&plugins=jetpack,woocommerce'
 		);
 
 		expect( params.isFromJetpackConnector ).toBe( false );
 		expect( params.isUnifiedConnectionFlow ).toBe( false );
+		expect( params.connectorPlugins ).toEqual( [] );
+	} );
+
+	it( 'falls back to currentQuery.from when redirect_to does not carry from', () => {
+		const params = getConnectionFlowFromRedirectTo( '/jetpack/connect/authorize', {
+			from: 'jetpack-connector',
+			plugins: 'jetpack,woocommerce',
+		} );
+
+		expect( params.isFromJetpackConnector ).toBe( true );
+		expect( params.isUnifiedConnectionFlow ).toBe( true );
+		expect( params.connectorPlugins ).toEqual( [ 'jetpack', 'woocommerce' ] );
+	} );
+
+	it( 'prefers redirect_to over currentQuery for from and plugins when both are present', () => {
+		const params = getConnectionFlowFromRedirectTo(
+			'/jetpack/connect/authorize?from=jetpack-connector&plugins=jetpack',
+			{ from: 'my-jetpack', plugins: 'woocommerce' }
+		);
+
+		expect( params.isFromJetpackConnector ).toBe( true );
+		expect( params.connectorPlugins ).toEqual( [ 'jetpack' ] );
+	} );
+
+	it( 'trims whitespace inside the plugins list', () => {
+		const params = getConnectionFlowFromRedirectTo(
+			'/jetpack/connect/authorize?from=jetpack-connector&plugins=jetpack,%20woocommerce'
+		);
+
 		expect( params.connectorPlugins ).toEqual( [ 'jetpack', 'woocommerce' ] );
 	} );
 

--- a/client/login/magic-login/test/index.test.jsx
+++ b/client/login/magic-login/test/index.test.jsx
@@ -1,11 +1,7 @@
 /** @jest-environment jsdom */
 import React from 'react';
 import { getPartnerSignupTosElement } from 'calypso/lib/partner-branding';
-import {
-	getConnectorParamsFromRedirectTo,
-	getMagicLoginInitialHeaders,
-	MagicLogin,
-} from '../index';
+import { getConnectionFlowFromRedirectTo, getMagicLoginInitialHeaders, MagicLogin } from '../index';
 
 jest.mock( 'calypso/lib/partner-branding', () => ( {
 	detectPartnerConfig: jest.fn(),
@@ -131,9 +127,9 @@ describe( 'magic-login branding behavior', () => {
 	} );
 } );
 
-describe( 'getConnectorParamsFromRedirectTo', () => {
+describe( 'getConnectionFlowFromRedirectTo', () => {
 	it( 'flags the connector flow and parses plugins when from=jetpack-connector', () => {
-		const params = getConnectorParamsFromRedirectTo(
+		const params = getConnectionFlowFromRedirectTo(
 			'/jetpack/connect/authorize?from=jetpack-connector&plugins=jetpack,woocommerce'
 		);
 
@@ -145,7 +141,7 @@ describe( 'getConnectorParamsFromRedirectTo', () => {
 	} );
 
 	it( 'recognises jetpack-onboarding as part of the unified flow without flagging the connector', () => {
-		const params = getConnectorParamsFromRedirectTo(
+		const params = getConnectionFlowFromRedirectTo(
 			'/jetpack/connect/authorize?from=jetpack-onboarding'
 		);
 
@@ -155,7 +151,7 @@ describe( 'getConnectorParamsFromRedirectTo', () => {
 	} );
 
 	it( 'does not flag the connector for unrelated from values', () => {
-		const params = getConnectorParamsFromRedirectTo(
+		const params = getConnectionFlowFromRedirectTo(
 			'/jetpack/connect/authorize?from=my-jetpack&plugins=jetpack,woocommerce'
 		);
 
@@ -165,7 +161,7 @@ describe( 'getConnectorParamsFromRedirectTo', () => {
 	} );
 
 	it( 'returns an empty plugin list when the plugins query param is absent', () => {
-		const params = getConnectorParamsFromRedirectTo(
+		const params = getConnectionFlowFromRedirectTo(
 			'/jetpack/connect/authorize?from=jetpack-connector'
 		);
 
@@ -174,7 +170,7 @@ describe( 'getConnectorParamsFromRedirectTo', () => {
 	} );
 
 	it( 'returns sensible defaults when redirect_to is missing', () => {
-		expect( getConnectorParamsFromRedirectTo( undefined ) ).toEqual( {
+		expect( getConnectionFlowFromRedirectTo( undefined ) ).toEqual( {
 			isFromJetpackConnector: false,
 			isUnifiedConnectionFlow: false,
 			connectorPlugins: [],
@@ -182,7 +178,7 @@ describe( 'getConnectorParamsFromRedirectTo', () => {
 	} );
 
 	it( 'filters empty entries produced by trailing commas in plugins', () => {
-		const params = getConnectorParamsFromRedirectTo(
+		const params = getConnectionFlowFromRedirectTo(
 			'/jetpack/connect/authorize?from=jetpack-connector&plugins=jetpack,,woocommerce,'
 		);
 

--- a/client/login/magic-login/test/index.test.jsx
+++ b/client/login/magic-login/test/index.test.jsx
@@ -1,7 +1,11 @@
 /** @jest-environment jsdom */
 import React from 'react';
 import { getPartnerSignupTosElement } from 'calypso/lib/partner-branding';
-import { getMagicLoginInitialHeaders, MagicLogin } from '../index';
+import {
+	getConnectorParamsFromRedirectTo,
+	getMagicLoginInitialHeaders,
+	MagicLogin,
+} from '../index';
 
 jest.mock( 'calypso/lib/partner-branding', () => ( {
 	detectPartnerConfig: jest.fn(),
@@ -124,5 +128,64 @@ describe( 'magic-login branding behavior', () => {
 				} ),
 			} )
 		);
+	} );
+} );
+
+describe( 'getConnectorParamsFromRedirectTo', () => {
+	it( 'flags the connector flow and parses plugins when from=jetpack-connector', () => {
+		const params = getConnectorParamsFromRedirectTo(
+			'/jetpack/connect/authorize?from=jetpack-connector&plugins=jetpack,woocommerce'
+		);
+
+		expect( params ).toEqual( {
+			isFromJetpackConnector: true,
+			isUnifiedConnectionFlow: true,
+			connectorPlugins: [ 'jetpack', 'woocommerce' ],
+		} );
+	} );
+
+	it( 'recognises jetpack-onboarding as part of the unified flow without flagging the connector', () => {
+		const params = getConnectorParamsFromRedirectTo(
+			'/jetpack/connect/authorize?from=jetpack-onboarding'
+		);
+
+		expect( params.isUnifiedConnectionFlow ).toBe( true );
+		expect( params.isFromJetpackConnector ).toBe( false );
+		expect( params.connectorPlugins ).toEqual( [] );
+	} );
+
+	it( 'does not flag the connector for unrelated from values', () => {
+		const params = getConnectorParamsFromRedirectTo(
+			'/jetpack/connect/authorize?from=my-jetpack&plugins=jetpack,woocommerce'
+		);
+
+		expect( params.isFromJetpackConnector ).toBe( false );
+		expect( params.isUnifiedConnectionFlow ).toBe( false );
+		expect( params.connectorPlugins ).toEqual( [ 'jetpack', 'woocommerce' ] );
+	} );
+
+	it( 'returns an empty plugin list when the plugins query param is absent', () => {
+		const params = getConnectorParamsFromRedirectTo(
+			'/jetpack/connect/authorize?from=jetpack-connector'
+		);
+
+		expect( params.isFromJetpackConnector ).toBe( true );
+		expect( params.connectorPlugins ).toEqual( [] );
+	} );
+
+	it( 'returns sensible defaults when redirect_to is missing', () => {
+		expect( getConnectorParamsFromRedirectTo( undefined ) ).toEqual( {
+			isFromJetpackConnector: false,
+			isUnifiedConnectionFlow: false,
+			connectorPlugins: [],
+		} );
+	} );
+
+	it( 'filters empty entries produced by trailing commas in plugins', () => {
+		const params = getConnectorParamsFromRedirectTo(
+			'/jetpack/connect/authorize?from=jetpack-connector&plugins=jetpack,,woocommerce,'
+		);
+
+		expect( params.connectorPlugins ).toEqual( [ 'jetpack', 'woocommerce' ] );
 	} );
 } );


### PR DESCRIPTION
Part of CONNECT-186

## Proposed Changes

* `client/login/magic-login/index.jsx` — extract a small pure helper `getConnectorParamsFromRedirectTo(redirect_to)` that reads the `from` and `plugins` query params from the original `redirect_to` value and returns `{ isFromJetpackConnector, isUnifiedConnectionFlow, connectorPlugins }`. Use it in `mapState` so the connected component now exposes those props.
* In `MagicLogin.render()`, forward `isFromJetpackConnector` and `connectorPlugins` to `<OneLoginLayout>`. The existing layout → `HeadingLogo` already supports both props (`client/login/wp-login/components/heading-logo.tsx:76-84`); previously the magic-login route was the only entry point not passing them, which is why `/log-in/jetpack/link` showed the single Jetpack mark even when entered via the connector flow.
* `client/login/magic-login/test/index.test.jsx` — six new unit tests for the parsing helper covering: connector flow, unified-non-connector flow, unrelated `from` values, missing `plugins`, missing `redirect_to`, and trailing-comma plugin lists.

## Why are these changes being made?

* The login page (`/log-in/jetpack`) already renders the connector "multi-circle" logo (W / Jetpack / Woo) when `from=jetpack-connector`. The magic-link variant of the same flow (`/log-in/jetpack/link`) was rendering the single green Jetpack mark, so users who chose the magic-link path saw a different brand than users on the password path. This patch makes them consistent.

## Testing Instructions

* On a self-hosted Jetpack site that initiates a connection with `from=jetpack-connector` (e.g. via the Jetpack Connector card), trigger the magic-link path on the WordPress.com login screen — i.e. land on `/log-in/jetpack/link?redirect_to=/jetpack/connect/authorize?from=jetpack-connector&plugins=jetpack,woocommerce&...`.
* Confirm the top-of-page logo is the connector multi-circle (W + Jetpack + Woo) — the same logo `/log-in/jetpack` shows for the connector flow.
* Visit the same URL with `from=my-jetpack` (or any other `from` value) and confirm the **legacy single Jetpack logo is preserved** — the new behaviour is gated on `from=jetpack-connector` only.
* If the `redirect_to` carries `plugins=jetpack` (no Woo), confirm the logo falls back to the Jetpack-only variant (driven by `getConnectorLogoUrl(['jetpack'])` at `client/jetpack-connect/connector-branding-config.js:73-88`).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?
