### PR TITLE
Fix AI tools footer border in Dark Mode

### DIFF
--- a/client/dashboard/sites/settings-ai-tools/style.scss
+++ b/client/dashboard/sites/settings-ai-tools/style.scss
@@ -1,10 +1,16 @@
 @use '../../../../packages/ui/src/utils/mixins' as ui-mixins;
 
 .ai-tools-settings__features-footer {
-	background: #fafafa;
+	background: color-mix( in srgb, var( --dashboard-surface__background-color ) 98%, #000 );
+	border-top-color: var( --dashboard-surface__border-color );
 
 	@include ui-mixins.when-dark-theme {
-		background: var( --dashboard-surface__background-color );
+		background: color-mix( in srgb, var( --dashboard-surface__background-color ) 98%, #fff );
+		// The filled footer covers the card's inset box-shadow border, so redraw the covered edges.
+		box-shadow:
+			inset 1px 0 0 var( --dashboard-surface__border-color ),
+			inset -1px 0 0 var( --dashboard-surface__border-color ),
+			inset 0 -1px 0 var( --dashboard-surface__border-color );
 	}
 }
 


### PR DESCRIPTION
## Proposed Changes

* Update the AI Tools settings footer to derive its light and dark backgrounds from the dashboard surface token instead of hardcoded colors.
* Align the footer divider with the dashboard card border token.
* Redraw the dark-mode footer edges that are covered by the filled footer background so the card border remains visible.

## Why are these changes being made?

The AI Tools settings card footer was using a hardcoded light background and the dark-mode footer fill could cover the card's inset shadow border. On the AI Tools settings page, that made the card outline disappear around the footer in dark mode.

This keeps the footer visually distinct with a subtle 98% surface color mix in both themes while preserving the card border in dark mode. The result matches the surrounding dashboard card treatment without relying on hardcoded surface colors.

## Testing Instructions

* Open the AI Tools settings page at `/sites/<siteUrl>/settings/ai-tools` on a local dashboard port such as 3000.
* Switch between Light and Dark themes.
* Confirm the AI assistant card footer background remains subtle and the card border is visible around the footer in dark mode.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
