### PR TITLE
Checkout: gate desktop redesign behind isLargeViewport

### DIFF
--- a/client/my-sites/checkout/src/components/CheckoutMoneyBackGuarantee.tsx
+++ b/client/my-sites/checkout/src/components/CheckoutMoneyBackGuarantee.tsx
@@ -1,0 +1,36 @@
+import { isChargeback, isCredits } from '@automattic/calypso-products';
+import { ResponseCart } from '@automattic/shopping-cart';
+import styled from '@emotion/styled';
+import { CheckoutSummaryRefundWindows } from './checkout-summary-refund-windows';
+
+const CheckoutMoneyBackGuaranteeWrapper = styled.div`
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	margin: 1.5em 0 0;
+
+	& p {
+		font-size: 14px;
+		margin: 0 0 0 0.5rem;
+		padding: 0;
+	}
+`;
+
+export function CheckoutMoneyBackGuarantee( { cart }: { cart: ResponseCart } ) {
+	// Return early if the cart is only Chargebacks fees
+	if ( cart.products.every( isChargeback || isCredits ) ) {
+		return null;
+	}
+
+	const allCartItemsAreDomains = cart.products.every(
+		( product ) => product.is_domain_registration === true
+	);
+
+	return (
+		! allCartItemsAreDomains && (
+			<CheckoutMoneyBackGuaranteeWrapper>
+				<CheckoutSummaryRefundWindows cart={ cart } includeRefundIcon />
+			</CheckoutMoneyBackGuaranteeWrapper>
+		)
+	);
+}

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -87,6 +87,7 @@ import useCouponFieldState from '../hooks/use-coupon-field-state';
 import { validateContactDetails } from '../lib/contact-validation';
 import { updateCartContactDetailsForCheckout } from '../lib/update-cart-contact-details-for-checkout';
 import { CHECKOUT_STORE } from '../lib/wpcom-store';
+import { CheckoutMoneyBackGuarantee } from './CheckoutMoneyBackGuarantee';
 import AcceptTermsOfServiceCheckbox from './accept-terms-of-service-checkbox';
 import badge14Src from './assets/icons/badge-14.svg';
 import badge7Src from './assets/icons/badge-7.svg';
@@ -947,7 +948,13 @@ export default function CheckoutMainContent( {
 						<CheckoutFormSubmit
 							validateForm={ validateForm }
 							submitButtonHeader={ <SubmitButtonHeader /> }
-							submitButtonFooter={ hasCartJetpackProductsOnly ? <JetpackCheckoutSeals /> : null }
+							submitButtonFooter={
+								hasCartJetpackProductsOnly ? (
+									<JetpackCheckoutSeals />
+								) : (
+									<CheckoutMoneyBackGuarantee cart={ responseCart } />
+								)
+							}
 						/>
 					) }
 				</CheckoutStepGroup>
@@ -970,8 +977,12 @@ export default function CheckoutMainContent( {
 					) }
 					{ checkoutSummary }
 					{ checkoutMainContent }
-					<CheckoutProcessorNotice />
-					<CheckoutTrustCards cart={ responseCart } />
+					{ isLargeViewport && (
+						<>
+							<CheckoutProcessorNotice />
+							<CheckoutTrustCards cart={ responseCart } />
+						</>
+					) }
 				</WPCheckoutWrapper>
 			</SubmitButtonSlotContext.Provider>
 		);
@@ -1030,8 +1041,12 @@ export default function CheckoutMainContent( {
 					} }
 				</Step.TwoColumnLayout>
 				<LeaveCheckoutModal { ...leaveModalProps } />
-				<CheckoutProcessorNotice />
-				<CheckoutTrustCards cart={ responseCart } />
+				{ isLargeViewport && (
+					<>
+						<CheckoutProcessorNotice />
+						<CheckoutTrustCards cart={ responseCart } />
+					</>
+				) }
 			</StepContainerV2CheckoutFixer>
 		</SubmitButtonSlotContext.Provider>
 	);
@@ -2315,7 +2330,7 @@ const WPCheckoutCompletedMainContent = styled.div`
 `;
 
 const WPCheckoutSidebarContent = styled.div`
-	background: ${ colorStudio.colors[ 'White' ] };
+	background: ${ ( props ) => props.theme.colors.background };
 	grid-area: sidebar-content;
 	margin-top: var( --masterbar-checkout-height );
 
@@ -2324,6 +2339,7 @@ const WPCheckoutSidebarContent = styled.div`
 	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
+		background: ${ colorStudio.colors[ 'White' ] };
 		margin-top: 0;
 		padding: 144px 24px 24px 64px;
 

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -941,6 +941,7 @@ export default function CheckoutMainContent( {
 						is100YearPlanTermsAccepted={ is100YearPlanTermsAccepted }
 						setIs100YearPlanTermsAccepted={ setIs100YearPlanTermsAccepted }
 						isSubmitted={ isSubmitted }
+						isLargeViewport={ isLargeViewport }
 					/>
 					{ isLargeViewport ? (
 						<PortaledCheckoutFormSubmit validateForm={ validateForm } />
@@ -1676,12 +1677,14 @@ function CheckoutTermsAndCheckboxes( {
 	is100YearPlanTermsAccepted,
 	setIs100YearPlanTermsAccepted,
 	isSubmitted,
+	isLargeViewport,
 }: {
 	is3PDAccountConsentAccepted: boolean;
 	setIs3PDAccountConsentAccepted: ( isAccepted: boolean ) => void;
 	is100YearPlanTermsAccepted: boolean;
 	setIs100YearPlanTermsAccepted: ( isAccepted: boolean ) => void;
 	isSubmitted: boolean;
+	isLargeViewport: boolean;
 } ) {
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
@@ -1698,9 +1701,10 @@ function CheckoutTermsAndCheckboxes( {
 			{
 				// Keep the inline legal block above the consent checkbox so
 				// "I have read and agree to all of the above" still refers to
-				// something visible. For carts without a consent checkbox the
-				// same text is reachable via the sidebar's Read more modal.
-				needsConsentCheckbox && <BeforeSubmitCheckoutHeader />
+				// something visible. On desktop without a consent checkbox the
+				// same text is reachable via the sidebar's Read more modal;
+				// mobile has no sidebar modal, so always render it inline.
+				( ! isLargeViewport || needsConsentCheckbox ) && <BeforeSubmitCheckoutHeader />
 			}
 
 			{ hasMarketplaceProduct && (

--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/style.scss
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/style.scss
@@ -3,9 +3,12 @@
 	margin-bottom: 24px;
 }
 
+.promo-card.checkout-sidebar-plan-upsell {
+	padding: 24px;
+}
+
 @media (min-width: 961px) {
 	.card.promo-card.checkout-sidebar-plan-upsell {
-		padding: 24px;
 		background: #fff;
 		border-radius: 3px;
 		box-shadow:

--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/style.scss
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/style.scss
@@ -3,13 +3,15 @@
 	margin-bottom: 24px;
 }
 
-.card.promo-card.checkout-sidebar-plan-upsell {
-	padding: 24px;
-	background: #fff;
-	border-radius: 3px;
-	box-shadow:
-		0 3px 1px rgba(0, 0, 0, 0.04),
-		0 3px 8px rgba(0, 0, 0, 0.12);
+@media (min-width: 961px) {
+	.card.promo-card.checkout-sidebar-plan-upsell {
+		padding: 24px;
+		background: #fff;
+		border-radius: 3px;
+		box-shadow:
+			0 3px 1px rgba(0, 0, 0, 0.04),
+			0 3px 8px rgba(0, 0, 0, 0.12);
+	}
 }
 
 .promo-card.checkout-sidebar-plan-upsell .action-panel__title {


### PR DESCRIPTION
Part of #110117 (umbrella, closed). Follow-up to the #110099 stack on `try/cta_always_visibe`.

## Proposed Changes

* Wrap `CheckoutProcessorNotice` and `CheckoutTrustCards` in `isLargeViewport` in both layout branches of `checkout-main-content.tsx`.
* Restore `CheckoutMoneyBackGuarantee.tsx` (deleted in the redesign) and render it for non-Jetpack carts on the mobile inline submit footer. Desktop keeps the portaled submit and the sidebar trust footer.
* Move the new white background on `WPCheckoutSidebarContent` into the existing `desktopUp` media query so mobile keeps trunk's themed sidebar background.
* Split the upsell-card SCSS: keep `padding: 24px` unconditional (matches trunk on every viewport) and gate only the new visuals (`background: #fff`, `border-radius: 3px`, `box-shadow`) to `min-width: 961px`. The PR folded trunk's standalone padding rule into the new combined rule, so gating the whole block to desktop would have dropped the 24px padding on mobile and changed where the upsell text wraps.
* Thread `isLargeViewport` into `CheckoutTermsAndCheckboxes` and render the inline `BeforeSubmitCheckoutHeader` legalese on mobile regardless of `needsConsentCheckbox`. Desktop without a consent checkbox still defers to the sidebar's Read more modal.

<img width="402" height="1589" alt="Safari Screenshot 2026-04-29 11 53 17" src="https://github.com/user-attachments/assets/0d02b5a7-edec-4f2b-bb6f-8565d23e0acb" />

## Why are these changes being made?

The redesign stack was scoped to ship desktop-only, but several pieces leaked to mobile:

* `CheckoutTrustCards` and `CheckoutProcessorNotice` rendered at the root of both checkout layouts with no viewport gate.
* The deletion of `CheckoutMoneyBackGuarantee` dropped the refund text from below the mobile submit button. The new mobile submit footer had no fallback for non-Jetpack carts.
* The inline legalese was gated on `needsConsentCheckbox`, on the assumption that other carts would reach the same text via the sidebar's Read more modal. The sidebar collapses on mobile, so non-consent carts (Premium without 3PD or 100-year terms, plain domain renewals) lost the legalese entirely.
* Two cosmetic changes (the white sidebar background and the upsell-card box-shadow) applied on mobile too.

Goal: mobile checkout is visually identical to trunk; desktop ≥961px keeps the full redesign.

## Testing Instructions

1. Open the checkout on a mobile viewport (≤960px) and compare to `trunk`. Order summary, contact info, payment method, inline legalese with Read more, submit button, money-back guarantee text should be pixel-equivalent.
2. Open the checkout on a desktop viewport (≥961px). All redesign elements should still be present: pinned sidebar with white background, sidebar Pay button, sticky two-year upsell, sidebar trust footer with Read more modal, full-width trust cards, processor disclosure line.
3. Resize across the 961px breakpoint. Layout should snap cleanly.
4. Test cart variations:
   * Plain plan cart (no consent checkbox): mobile shows legalese inline; desktop reaches it via sidebar Read more.
   * Domain-only cart: inline legalese on mobile matches trunk.
   * Marketplace product or 100-year plan: consent checkbox present on both viewports with legalese above it.
5. Confirm the money-back guarantee text restores below the mobile submit button for non-Jetpack carts.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
