### PR TITLE
Onboarding: header refinements + Plans back-nav + domain copy

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -302,7 +302,17 @@ const onboarding: FlowV2< typeof initialize > = {
 					return;
 			}
 		};
-		return { submit };
+
+		const goBack = () => {
+			switch ( currentStepSlug ) {
+				case 'plans':
+					return navigate( 'domains' );
+				default:
+					return window.history.back();
+			}
+		};
+
+		return { submit, goBack };
 	},
 	useSideEffect( currentStepSlug ) {
 		const reduxDispatch = useReduxDispatch();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -431,7 +431,7 @@ const DomainSearchStep: StepType< {
 				<>
 					{ config.allowsUsingOwnDomain && (
 						<Step.LinkButton onClick={ () => events.onExternalDomainClick( query ) }>
-							{ __( 'Use a domain I already own' ) }
+							{ __( 'Use a domain I own' ) }
 						</Step.LinkButton>
 					) }
 				</>
@@ -490,7 +490,7 @@ const DomainSearchStep: StepType< {
 				onClick={ () => events.onExternalDomainClick( query ) }
 				variant="link"
 			>
-				<span>{ __( 'Use a domain I already own' ) }</span>
+				<span>{ __( 'Use a domain I own' ) }</span>
 			</Button>
 		);
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -6,11 +6,12 @@ import {
 	PLAN_WOO_HOSTED_FREE_TRIAL_MONTHLY,
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
-import { Plans } from '@automattic/data-stores';
+import { HelpCenter, HelpCenterSelect, Plans } from '@automattic/data-stores';
 import { FREE_THEME } from '@automattic/design-picker';
 import {
 	DOMAIN_FLOW,
 	isNewHostedSiteCreationFlow,
+	isOnboardingFlow,
 	isTailoredSignupFlow,
 	ONBOARDING_FLOW,
 	Step,
@@ -193,6 +194,8 @@ export interface UnifiedPlansStepProps {
 	isStepperUpgradeFlow?: boolean;
 }
 
+const HELP_CENTER_STORE = HelpCenter.register();
+
 /**
  * This is a "unified" plans step component that is utilised by both Start (old framework) and Stepper (new framework).
  * It contains the latest logic/conditioning, properties, etc. that apply to the latest main iterations of the plans step.
@@ -248,6 +251,13 @@ function UnifiedPlansStep( {
 	const dispatch = reduxUseDispatch();
 	const translate = useTranslate();
 	const dashboardOptIn = useSelector( hasDashboardOptIn );
+
+	const { setShowHelpCenter } = useDispatch( HELP_CENTER_STORE );
+	const isHelpCenterShown = useSelect(
+		( select ) => ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).isHelpCenterShown(),
+		[]
+	);
+	const toggleHelpCenter = () => setShowHelpCenter( ! isHelpCenterShown );
 	const initializedSitesBackUrl = useSelector( ( state ) => {
 		if ( getCurrentUserSiteCount( state ) ) {
 			return null;
@@ -620,6 +630,10 @@ function UnifiedPlansStep( {
 
 	if ( useStepContainerV2 && wrapperProps ) {
 		const goBack = wrapperProps.hideBack ? undefined : wrapperProps.goBack;
+		const handleOnboardingBack = () => {
+			window.location.href = '/setup/onboarding/domains';
+		};
+		const backClick = isOnboardingFlow( flowName ) ? handleOnboardingBack : goBack;
 
 		return (
 			<>
@@ -629,8 +643,15 @@ function UnifiedPlansStep( {
 					topBar={
 						<Step.TopBar
 							leftElement={
-								goBack ? (
-									<Step.BackButton onClick={ goBack }>{ backLabelText }</Step.BackButton>
+								backClick ? (
+									<Step.BackButton onClick={ backClick }>{ backLabelText }</Step.BackButton>
+								) : undefined
+							}
+							rightElement={
+								isOnboardingFlow( flowName ) ? (
+									<Step.LinkButton onClick={ toggleHelpCenter }>
+										{ translate( 'Need help?' ) }
+									</Step.LinkButton>
 								) : undefined
 							}
 						/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -630,10 +630,6 @@ function UnifiedPlansStep( {
 
 	if ( useStepContainerV2 && wrapperProps ) {
 		const goBack = wrapperProps.hideBack ? undefined : wrapperProps.goBack;
-		const handleOnboardingBack = () => {
-			window.location.href = getStepUrl( 'onboarding', 'domains' );
-		};
-		const backClick = isOnboardingFlow( flowName ) ? handleOnboardingBack : goBack;
 
 		return (
 			<>
@@ -643,8 +639,8 @@ function UnifiedPlansStep( {
 					topBar={
 						<Step.TopBar
 							leftElement={
-								backClick ? (
-									<Step.BackButton onClick={ backClick }>{ backLabelText }</Step.BackButton>
+								goBack ? (
+									<Step.BackButton onClick={ goBack }>{ backLabelText }</Step.BackButton>
 								) : undefined
 							}
 							rightElement={

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -631,7 +631,7 @@ function UnifiedPlansStep( {
 	if ( useStepContainerV2 && wrapperProps ) {
 		const goBack = wrapperProps.hideBack ? undefined : wrapperProps.goBack;
 		const handleOnboardingBack = () => {
-			window.location.href = '/setup/onboarding/domains';
+			window.location.href = getStepUrl( 'onboarding', 'domains' );
 		};
 		const backClick = isOnboardingFlow( flowName ) ? handleOnboardingBack : goBack;
 

--- a/packages/onboarding/src/step-container-v2/components/TopBar/TopBar.tsx
+++ b/packages/onboarding/src/step-container-v2/components/TopBar/TopBar.tsx
@@ -65,8 +65,6 @@ export const TopBar = ( {
 		<div className="step-container-v2__top-bar">
 			{ ! hideLogo && resolvedLogo }
 
-			{ ! hideLogo && leftElement && <div className="step-container-v2__top-bar-divider" /> }
-
 			{ leftElement && (
 				<div className="step-container-v2__top-bar-left-element">{ leftElement }</div>
 			) }

--- a/packages/onboarding/src/step-container-v2/components/TopBar/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/TopBar/style.scss
@@ -6,6 +6,7 @@
 	box-sizing: border-box;
 	display: flex;
 	align-items: center;
+	gap: 1rem;
 	padding: var( --step-container-v2-top-bar-padding );
 
 	@include break-small {
@@ -32,10 +33,6 @@
 .step-container-v2__top-bar-wordpress-logo {
 	color: var( --color-text );
 	margin: 0;
-
-	@include break-small {
-		margin-right: 0.5rem;
-	}
 }
 
 .step-container-v2__top-bar-wordpress-logo--wordmark {
@@ -61,20 +58,10 @@
 	}
 }
 
-.step-container-v2__top-bar-divider {
-	width: 1px;
-	height: 1rem;
-	background-color: var( --color-border-subtle );
-	margin-inline: 1rem 0;
-
-	@include break-small {
-		margin-inline: 1.5rem 0.75rem;
-	}
-}
-
 .step-container-v2__top-bar-right-element {
 	display: flex;
-	gap: 1.5rem;
+	align-items: center;
+	gap: 1rem;
 	margin-left: auto;
 	font-size: 0.875rem;
 	line-height: 1;

--- a/packages/onboarding/src/step-container-v2/components/buttons/BackButton/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/buttons/BackButton/style.scss
@@ -1,7 +1,16 @@
-.step-container-v2__back-button {
+.step-container-v2__back-button.components-button {
 	--wp-components-color-accent: var(--color-neutral-100);
 	--color-link: var(--color-neutral-100);
 	font-size: 0.875rem;
+	font-weight: 500;
 	line-height: 1;
-	text-decoration: none !important;
+	text-decoration: underline;
+	gap: 4px;
+	padding: 0 !important;
+	min-width: 0;
+	height: auto;
+
+	svg {
+		margin-inline-end: 0;
+	}
 }

--- a/packages/onboarding/src/step-container-v2/components/buttons/LinkButton/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/buttons/LinkButton/style.scss
@@ -1,5 +1,6 @@
-.step-container-v2__link-button {
+.step-container-v2__link-button.components-button {
 	font-size: inherit;
 	line-height: inherit;
 	font-weight: 500;
+	text-decoration: underline;
 }


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/DSGCOM-510

Extracted from #110133 to land the shared header refinements and bug-fix wiring independently of the mobile "X of 3" stepper, which stays on #110133 for separate review.

Context: p1777471813363859/1777392197.641519-slack-C097SQTJV9S

Stacked on #110130.

## Proposed Changes

### Shared `step-container-v2` TopBar refinements (~41 surfaces)

These are visual changes to the shared TopBar and apply to every step-container-v2 surface:

- Remove the vertical divider between the logo and left element.
- `gap: 1rem` on the main container and right-element (was `1.5rem` on right-element, plus divider + margins elsewhere).
- `BackButton` and `LinkButton` are now consistently underlined and `font-weight: 500`. `BackButton` has zero padding and a 4px gap between chevron and text.
- Remove stale `margin-right: 0.5rem` on the logo wrapper (redundant with the new container `gap`).

### Domains (`/setup/onboarding/domains`)

- Rename "Use a domain I already own" → "Use a domain I own", in both the v2 TopBar right element and the pre-v2 step-container variant.

### Plans (`/setup/onboarding/plans`)

- Add a "Need help?" link in the right element that toggles the HelpCenter (gated on `isOnboardingFlow(flowName)`).
- Back button now explicitly navigates to the Domains step via `getStepUrl( 'onboarding', 'domains' )`. Returning from Checkout → Plans → back now lands on Domains rather than on Checkout's browser-history entry.

All onboarding-specific behavior is gated on `isOnboardingFlow(flowName)` — non-onboarding flows are unaffected.

## Why are these changes being made?

Onboarding design refresh — six page headers are moving to the same minimal pattern (no vertical divider, consistent underlined link styling). This PR covers the shared TopBar refinements plus the Domains and Plans page-level wiring.

The Plans Back-button override also fixes a navigation bug: previously, pressing Back from Checkout, then Plans, looped users back to Checkout, not to Domains. The override now sends users explicitly to Domains.

#110133 covers the mobile-only "X of 3" stepper indicator on Domains/Plans/Checkout and stays open for review.

### Approach

The split was chosen because the shared TopBar refinements touch ~41 surfaces and shouldn't be blocked on the stepper review. The bug-fix wiring (Plans back-nav, domain copy rename) lives here because it's tightly coupled to the same pages and the same wiring touches.

The Plans back-button URL uses `getStepUrl( 'onboarding', 'domains' )` rather than a hardcoded path, per review feedback on the original PR.

## Testing Instructions

Run Calypso locally.

### Onboarding pages

| URL | Expected header |
|---|---|
| `/setup/onboarding/domains` | Logo + `< Back` (from #110130) + `Use a domain I own` |
| `/setup/onboarding/plans` | Logo + `< Back` + `Need help?` (click opens HelpCenter) |

### Behavior checks

- **Plans `< Back`** goes to `/setup/onboarding/domains` (not the browser's previous entry, so Domains → Plans → Checkout → Back → Back lands on Domains).

### Regression checks (shared TopBar — ~41 surfaces)

The shared refinements touch every step-container-v2 TopBar. Spot-check:

- `/setup/copy-site/domains`, `/setup/copy-site/plans` — existing layout, no divider.
- `/setup/site-migration-identify` — divider gone; existing elements space correctly.
- Login views (`wp-login/components/one-login-layout.tsx` consumers) — `compactLogo` path still shows the logo, layout intact.
- Onboarding checkout (`/setup/onboarding/checkout`) — Back button still opens the leave-checkout modal; help link layout unchanged.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? — new string `Need help?`; renamed `Use a domain I already own` → `Use a domain I own`.
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?