### PR TITLE
Podcast: record wpcom_podcast_feed_submitted on Distribution submit clicks

### DIFF
--- a/client/my-sites/podcast/components/distribution.tsx
+++ b/client/my-sites/podcast/components/distribution.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import {
 	Button,
 	Card,
@@ -9,6 +10,8 @@ import {
 import { useTranslate } from 'i18n-calypso';
 import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import { useSelector } from 'calypso/state';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { useFeedUrl } from '../hooks/use-feed-url';
 import {
 	LogoAmazon,
@@ -69,6 +72,7 @@ const DIRECTORIES: Directory[] = [
 function Distribution() {
 	const translate = useTranslate();
 	const feedUrl = useFeedUrl();
+	const blogId = useSelector( getSelectedSiteId );
 
 	return (
 		<>
@@ -138,6 +142,12 @@ function Distribution() {
 											href={ submitUrl }
 											target="_blank"
 											rel="noopener noreferrer"
+											onClick={ () =>
+												recordTracksEvent( 'wpcom_podcast_feed_submitted', {
+													blog_id: blogId,
+													directory: id,
+												} )
+											}
 										>
 											{ translate( 'Submit' ) }
 										</Button>


### PR DESCRIPTION
Part of PODS-16

## Summary

- Adds an `onClick` to the directory submit buttons on `/podcast/distribution/[site]` that fires `wpcom_podcast_feed_submitted` via `recordTracksEvent` from `@automattic/calypso-analytics`.
- Properties: `blog_id`, `directory` (slug of the directory submitted, one of `pocketcasts`, `apple`, `spotify`, `youtube`, `amazon`, `podcastindex`).
- Companion to the publish-side podcast Tracks events shipped in wpcom#212357.

## Scope

`podcast_feed_submission_result` is intentionally deferred. Today the submit action just opens an external URL, so there is no return signal to call "result." Once the submit-modal redesign (follow-up to #110164) lands, "result" will have clear semantics. Tracking that as a child of PODS-16.

## Test plan

- [ ] Visit `/podcast/distribution/[site]`.
- [ ] Click each directory's Submit button and confirm a `wpcom_podcast_feed_submitted` event lands in Tracks with the matching `directory` slug and current `blog_id`.
- [ ] External URL still opens in a new tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
