### PR TITLE
Checkout: refactor payment methods to drop @wordpress/data stores (CHE-295)

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/credit-card-fields/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/credit-card-fields/index.tsx
@@ -11,7 +11,6 @@ import useStoredCards from '../../hooks/use-stored-cards';
 import CreditCardElementField from './credit-card-element-field';
 import CreditCardLoading from './credit-card-loading';
 import SetAsPrimaryPaymentMethod from './set-as-primary-payment-method';
-import type { StoreState } from '@automattic/wpcom-checkout';
 import type { StripeElementChangeEvent, StripeElementStyle } from '@stripe/stripe-js';
 
 import './style.scss';
@@ -20,10 +19,7 @@ export default function CreditCardFields() {
 	const translate = useTranslate();
 
 	const [ isStripeFullyLoaded, setIsStripeFullyLoaded ] = useState( false );
-	const fields: StoreState< string > = useSelect(
-		( select ) => select( creditCardStore ).getFields(),
-		[]
-	);
+	const fields = useSelect( ( select ) => select( creditCardStore ).getFields(), [] );
 	const useAsPrimaryPaymentMethod: boolean = useSelect(
 		( select ) => select( creditCardStore ).useAsPrimaryPaymentMethod(),
 		[]

--- a/client/jetpack-cloud/sections/partner-portal/credit-card-fields/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/credit-card-fields/index.tsx
@@ -12,7 +12,6 @@ import { creditCardStore } from 'calypso/state/partner-portal/credit-card-form';
 import CreditCardElementField from './credit-card-element-field';
 import CreditCardLoading from './credit-card-loading';
 import SetAsPrimaryPaymentMethod from './set-as-primary-payment-method';
-import type { StoreState } from '@automattic/wpcom-checkout';
 import type { StripeElementChangeEvent, StripeElementStyle } from '@stripe/stripe-js';
 
 import './style.scss';
@@ -20,10 +19,7 @@ import './style.scss';
 export default function CreditCardFields() {
 	const { __ } = useI18n();
 	const [ isStripeFullyLoaded, setIsStripeFullyLoaded ] = useState( false );
-	const fields: StoreState< string > = useSelect(
-		( select ) => select( creditCardStore ).getFields(),
-		[]
-	);
+	const fields = useSelect( ( select ) => select( creditCardStore ).getFields(), [] );
 	const useAsPrimaryPaymentMethod: boolean = useSelect(
 		( select ) => select( creditCardStore ).useAsPrimaryPaymentMethod(),
 		[]

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -6,13 +6,9 @@ import {
 	createBancontactMethod,
 	createP24Method,
 	createEpsMethod,
-	createEpsPaymentMethodStore,
 	createIdealMethod,
-	createIdealPaymentMethodStore,
 	createSofortMethod,
-	createSofortPaymentMethodStore,
 	createAlipayMethod,
-	createAlipayPaymentMethodStore,
 	createRazorpayMethod,
 	createStripeUpiMethod,
 	isValueTruthy,
@@ -29,17 +25,14 @@ import {
 	createCreditCardMethod,
 } from '../../payment-methods/credit-card';
 import { createFreePaymentMethod } from '../../payment-methods/free-purchase';
-import {
-	createNetBankingPaymentMethodStore,
-	createNetBankingMethod,
-} from '../../payment-methods/netbanking';
-import { createPayPalMethod, createPayPalStore } from '../../payment-methods/paypal';
+import { createNetBankingMethod } from '../../payment-methods/netbanking';
+import { createPayPalMethod } from '../../payment-methods/paypal';
 import { createPayPal } from '../../payment-methods/paypal-js';
 import {
 	createPixPaymentMethod,
 	createPixAutomaticoPaymentMethod,
 } from '../../payment-methods/pix';
-import { createWeChatMethod, createWeChatPaymentMethodStore } from '../../payment-methods/wechat';
+import { createWeChatMethod } from '../../payment-methods/wechat';
 import useCreateExistingCards from './use-create-existing-cards';
 import useCreateExistingPayPalPPCP from './use-create-existing-paypal-ppcp';
 import type { RazorpayConfiguration, RazorpayLoadingError } from '@automattic/calypso-razorpay';
@@ -61,10 +54,9 @@ export function useCreatePayPalExpress( {
 	labelText?: string | null;
 	shouldShowTaxFields?: boolean;
 } ): PaymentMethod | null {
-	const store = useMemo( () => createPayPalStore(), [] );
 	const paypalMethod = useMemo(
-		() => createPayPalMethod( { labelText, store, shouldShowTaxFields } ),
-		[ labelText, shouldShowTaxFields, store ]
+		() => createPayPalMethod( { labelText, shouldShowTaxFields } ),
+		[ labelText, shouldShowTaxFields ]
 	);
 	return paypalMethod;
 }
@@ -166,16 +158,14 @@ function useCreateAlipay( {
 	stripeLoadingError: StripeLoadingError;
 } ): PaymentMethod | null {
 	const shouldLoad = ! isStripeLoading && ! stripeLoadingError;
-	const paymentMethodStore = useMemo( () => createAlipayPaymentMethodStore(), [] );
 	return useMemo(
 		() =>
 			shouldLoad
 				? createAlipayMethod( {
-						store: paymentMethodStore,
 						submitButtonContent: <CheckoutSubmitButtonContent />,
 				  } )
 				: null,
-		[ shouldLoad, paymentMethodStore ]
+		[ shouldLoad ]
 	);
 }
 
@@ -225,16 +215,7 @@ function useCreateWeChat( {
 	stripeLoadingError: StripeLoadingError;
 } ): PaymentMethod | null {
 	const shouldLoad = ! isStripeLoading && ! stripeLoadingError;
-	const paymentMethodStore = useMemo( () => createWeChatPaymentMethodStore(), [] );
-	return useMemo(
-		() =>
-			shouldLoad
-				? createWeChatMethod( {
-						store: paymentMethodStore,
-				  } )
-				: null,
-		[ shouldLoad, paymentMethodStore ]
-	);
+	return useMemo( () => ( shouldLoad ? createWeChatMethod() : null ), [ shouldLoad ] );
 }
 
 function useCreateIdeal( {
@@ -245,16 +226,14 @@ function useCreateIdeal( {
 	stripeLoadingError: StripeLoadingError;
 } ): PaymentMethod | null {
 	const shouldLoad = ! isStripeLoading && ! stripeLoadingError;
-	const paymentMethodStore = useMemo( () => createIdealPaymentMethodStore(), [] );
 	return useMemo(
 		() =>
 			shouldLoad
 				? createIdealMethod( {
-						store: paymentMethodStore,
 						submitButtonContent: <CheckoutSubmitButtonContent />,
 				  } )
 				: null,
-		[ shouldLoad, paymentMethodStore ]
+		[ shouldLoad ]
 	);
 }
 
@@ -266,16 +245,14 @@ function useCreateSofort( {
 	stripeLoadingError: StripeLoadingError;
 } ): PaymentMethod | null {
 	const shouldLoad = ! isStripeLoading && ! stripeLoadingError;
-	const paymentMethodStore = useMemo( () => createSofortPaymentMethodStore(), [] );
 	return useMemo(
 		() =>
 			shouldLoad
 				? createSofortMethod( {
-						store: paymentMethodStore,
 						submitButtonContent: <CheckoutSubmitButtonContent />,
 				  } )
 				: null,
-		[ shouldLoad, paymentMethodStore ]
+		[ shouldLoad ]
 	);
 }
 
@@ -287,28 +264,24 @@ function useCreateEps( {
 	stripeLoadingError: StripeLoadingError;
 } ): PaymentMethod | null {
 	const shouldLoad = ! isStripeLoading && ! stripeLoadingError;
-	const paymentMethodStore = useMemo( () => createEpsPaymentMethodStore(), [] );
 	return useMemo(
 		() =>
 			shouldLoad
 				? createEpsMethod( {
-						store: paymentMethodStore,
 						submitButtonContent: <CheckoutSubmitButtonContent />,
 				  } )
 				: null,
-		[ shouldLoad, paymentMethodStore ]
+		[ shouldLoad ]
 	);
 }
 
 function useCreateNetbanking(): PaymentMethod {
-	const paymentMethodStore = useMemo( () => createNetBankingPaymentMethodStore(), [] );
 	return useMemo(
 		() =>
 			createNetBankingMethod( {
-				store: paymentMethodStore,
 				submitButtonContent: <CheckoutSubmitButtonContent />,
 			} ),
-		[ paymentMethodStore ]
+		[]
 	);
 }
 

--- a/client/my-sites/checkout/src/payment-methods/credit-card/store.ts
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/store.ts
@@ -2,14 +2,14 @@ import { registerStore, createRegistry } from '@wordpress/data';
 import debugFactory from 'debug';
 import { maskField } from 'calypso/lib/checkout';
 import type {
+	CardElementType,
 	CardFieldState,
+	CardStoreAction,
 	CardStoreState,
 	CardStoreType,
-	CardStoreAction,
-	CardElementType,
+	StoreStateValue,
 } from './types';
 import type { SelectFromMap } from '@automattic/data-stores';
-import type { StoreStateValue } from '@automattic/wpcom-checkout';
 import type { AnyAction } from 'redux';
 
 const debug = debugFactory( 'calypso:composite-checkout:credit-card' );

--- a/client/my-sites/checkout/src/payment-methods/credit-card/types.ts
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/types.ts
@@ -1,6 +1,13 @@
-import type { StoreState } from '@automattic/wpcom-checkout';
 import type { StoreDescriptor } from '@wordpress/data';
 import type { AnyAction as Action } from 'redux';
+
+export interface StoreStateValue {
+	value: string;
+	isTouched: boolean;
+	errors?: string[];
+}
+
+export type StoreState< N extends string > = Record< N, StoreStateValue >;
 
 export type CardSubscriber = (
 	callback: () => void,
@@ -13,7 +20,7 @@ export interface CardStore< S, A extends Action = Action > {
 	dispatch( action: A ): A;
 }
 
-export type CardFieldState = StoreState< string >;
+export type CardFieldState = Record< string, StoreStateValue >;
 
 export type CardDataCompleteState = Record< CardElementType, boolean >;
 

--- a/client/my-sites/checkout/src/payment-methods/netbanking.tsx
+++ b/client/my-sites/checkout/src/payment-methods/netbanking.tsx
@@ -2,10 +2,9 @@ import { Button, FormStatus, useFormStatus } from '@automattic/composite-checkou
 import { snakeToCamelCase } from '@automattic/js-utils';
 import { Field } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
-import { useSelect, useDispatch, register, registerStore } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import { Fragment, ReactNode } from 'react';
+import { useEffect, useState, Fragment, ReactNode } from 'react';
 import { maskField } from 'calypso/lib/checkout';
 import { validatePaymentDetails } from 'calypso/lib/checkout/validation';
 import { PaymentMethodLogos } from 'calypso/my-sites/checkout/src/components/payment-method-logos';
@@ -18,197 +17,111 @@ import { useDispatch as useReduxDispatch } from 'calypso/state';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { CountrySpecificPaymentFields } from '../components/country-specific-payment-fields';
 import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
-import type {
-	StoreSelectors,
-	StoreSelectorsWithState,
-	StoreStateValue,
-} from '@automattic/wpcom-checkout';
 import type { CalypsoDispatch } from 'calypso/state/types';
-import type { AnyAction } from 'redux';
 
 const debug = debugFactory( 'composite-checkout:netbanking-payment-method' );
 
-// Disabling this to make migration easier
-/* eslint-disable @typescript-eslint/no-use-before-define */
-
-type NounsInStore = 'customerName';
-type FieldsType = Record< string, StoreStateValue >;
-type NetBankingStoreState< N extends string > = Record< N, StoreStateValue > & {
-	fields: FieldsType;
-};
-
-interface NetBankingPaymentMethodStore< N extends string > extends ReturnType< typeof register > {
-	getState: () => NetBankingStoreState< N >;
+interface NetBankingFieldState {
+	value: string;
+	isTouched: boolean;
+	errors: string[];
 }
-type NetBankingStore = NetBankingPaymentMethodStore< NounsInStore >;
 
-type NetBankingSelectors = StoreSelectors< NounsInStore > & { getFields: () => FieldsType };
+type StateSubscriber = () => void;
 
-const actions = {
-	changeCustomerName( payload: string ) {
-		return { type: 'CUSTOMER_NAME_SET', payload };
-	},
-	setFieldValue( key: string, value: string ) {
-		return { type: 'FIELD_VALUE_SET', payload: { key, value } };
-	},
-	setFieldError( key: string, message: string ) {
-		return { type: 'FIELD_ERROR_SET', payload: { key, message } };
-	},
-	touchAllFields() {
-		return { type: 'TOUCH_ALL_FIELDS' };
-	},
-	resetFields() {
-		return { type: 'RESET_FIELDS' };
-	},
-};
+class NetBankingPaymentMethodState {
+	customerName: { value: string; isTouched: boolean } = { value: '', isTouched: false };
+	fields: Record< string, NetBankingFieldState > = {};
+	subscribers: StateSubscriber[] = [];
 
-const selectors: StoreSelectorsWithState< NounsInStore > & {
-	getFields: ( state: NetBankingStoreState< NounsInStore > ) => FieldsType;
-} = {
-	getCustomerName( state ) {
-		return state.customerName;
-	},
-	getFields( state ) {
-		return state.fields;
-	},
-};
+	changeCustomerName = ( value: string ): void => {
+		this.customerName = { value, isTouched: true };
+		this.notifySubscribers();
+	};
 
-export function createNetBankingPaymentMethodStore(): NetBankingStore {
-	debug( 'creating a new netbanking payment method store' );
-	const store = registerStore( 'netbanking', {
-		reducer(
-			state: NetBankingStoreState< NounsInStore > = {
-				customerName: { value: '', isTouched: false },
-				fields: {},
+	setFieldValue = ( key: string, value: string ): void => {
+		const maskedValue = maskField( key, this.fields[ key ]?.value, value );
+		this.fields = {
+			...this.fields,
+			[ key ]: {
+				value: maskedValue,
+				isTouched: true,
+				errors: [],
 			},
-			action: AnyAction
-		) {
-			switch ( action.type ) {
-				case 'CUSTOMER_NAME_SET':
-					return { ...state, customerName: { value: action.payload, isTouched: true } };
-				case 'FIELD_VALUE_SET':
-					return {
-						...state,
-						fields: {
-							...state.fields,
-							[ action.payload.key ]: {
-								value: maskField(
-									action.payload.key,
-									state.fields[ action.payload.key ]?.value,
-									action.payload.value
-								),
-								isTouched: true,
-								errors: [],
-							},
-						},
-					};
-				case 'FIELD_ERROR_SET':
-					return {
-						...state,
-						fields: {
-							...state.fields,
-							[ action.payload.key ]: {
-								...state.fields[ action.payload.key ],
-								errors: [ action.payload.message ],
-							},
-						},
-					};
-				case 'TOUCH_ALL_FIELDS':
-					return {
-						...state,
-						fields: Object.keys( state.fields ).reduce(
-							( obj, key ) => ( {
-								...obj,
-								[ key ]: {
-									...state.fields[ key ],
-									isTouched: true,
-								},
-							} ),
-							{}
-						),
-					};
-				case 'RESET_FIELDS': {
-					return { ...state, fields: {} };
-				}
-			}
-			return state;
-		},
-		actions,
-		selectors,
-	} );
-	return store;
+		};
+		this.notifySubscribers();
+	};
+
+	setFieldError = ( key: string, message: string ): void => {
+		this.fields = {
+			...this.fields,
+			[ key ]: {
+				...( this.fields[ key ] ?? { value: '', isTouched: false, errors: [] } ),
+				errors: [ message ],
+			},
+		};
+		this.notifySubscribers();
+	};
+
+	touchAllFields = (): void => {
+		this.fields = Object.keys( this.fields ).reduce(
+			( obj, key ) => ( {
+				...obj,
+				[ key ]: {
+					...this.fields[ key ],
+					isTouched: true,
+				},
+			} ),
+			{}
+		);
+		this.notifySubscribers();
+	};
+
+	resetFields = (): void => {
+		this.fields = {};
+		this.notifySubscribers();
+	};
+
+	subscribe = ( callback: () => void ): ( () => void ) => {
+		this.subscribers.push( callback );
+		return () => {
+			this.subscribers = this.subscribers.filter( ( subscriber ) => subscriber !== callback );
+		};
+	};
+
+	notifySubscribers = (): void => {
+		this.subscribers.forEach( ( subscriber ) => subscriber() );
+	};
 }
 
 export function createNetBankingMethod( {
-	store,
 	submitButtonContent,
 }: {
-	store: NetBankingStore;
 	submitButtonContent: ReactNode;
 } ): PaymentMethod {
+	const state = new NetBankingPaymentMethodState();
+
 	return {
 		id: 'netbanking',
 		hasRequiredFields: true,
 		paymentProcessorId: 'netbanking',
 		label: <NetBankingLabel />,
-		activeContent: <NetBankingFields />,
+		activeContent: <NetBankingFields state={ state } />,
 		submitButton: (
-			<NetBankingPayButton store={ store } submitButtonContent={ submitButtonContent } />
+			<NetBankingPayButton state={ state } submitButtonContent={ submitButtonContent } />
 		),
-		inactiveContent: <NetBankingSummary />,
+		inactiveContent: <NetBankingSummary state={ state } />,
 		getAriaLabel: () => 'Transferência bancária',
 	};
 }
 
-function NetBankingFields() {
-	const { __ } = useI18n();
-
-	const fields = useSelect(
-		( select ) => ( select( 'netbanking' ) as NetBankingSelectors ).getFields(),
-		[]
-	);
-	const getField = ( key: string ) => fields[ key ] || {};
-	const getFieldValue = ( key: string ) => getField( key ).value ?? '';
-	const getErrorMessagesForField = ( key: string ) => {
-		const managedValue = getField( key );
-		return managedValue.errors ?? [];
-	};
-	const { setFieldValue } = useDispatch( 'netbanking' );
-
-	const customerName = useSelect(
-		( select ) => ( select( 'netbanking' ) as NetBankingSelectors ).getCustomerName(),
-		[]
-	);
-	const { changeCustomerName } = useDispatch( 'netbanking' );
-	const { formStatus } = useFormStatus();
-	const isDisabled = formStatus !== FormStatus.READY;
-	const countriesList = useCountryList();
-
-	return (
-		<NetBankingFormWrapper>
-			<NetBankingField
-				id="netbanking-cardholder-name"
-				type="Text"
-				autoComplete="cc-name"
-				label={ __( 'Your name' ) }
-				value={ customerName?.value ?? '' }
-				onChange={ changeCustomerName }
-				isError={ customerName?.isTouched && customerName?.value.length === 0 }
-				errorMessage={ __( 'This field is required' ) }
-				disabled={ isDisabled }
-			/>
-			<div className="netbanking__contact-fields">
-				<CountrySpecificPaymentFields
-					countryCode="IN" // If this payment method is available and the country is not India, we have other problems
-					countriesList={ countriesList }
-					getErrorMessages={ getErrorMessagesForField }
-					getFieldValue={ getFieldValue }
-					handleFieldChange={ setFieldValue }
-					disableFields={ isDisabled }
-				/>
-			</div>
-		</NetBankingFormWrapper>
-	);
+function useSubscribeToEventEmitter( state: NetBankingPaymentMethodState ) {
+	const [ , forceReload ] = useState( 0 );
+	useEffect( () => {
+		return state.subscribe( () => {
+			forceReload( ( val: number ) => val + 1 );
+		} );
+	}, [ state ] );
 }
 
 const NetBankingFormWrapper = styled.div`
@@ -240,31 +153,61 @@ const NetBankingField = styled( Field )`
 	}
 `;
 
+function NetBankingFields( { state }: { state: NetBankingPaymentMethodState } ) {
+	const { __ } = useI18n();
+	useSubscribeToEventEmitter( state );
+	const { formStatus } = useFormStatus();
+	const isDisabled = formStatus !== FormStatus.READY;
+	const countriesList = useCountryList();
+
+	const getFieldValue = ( key: string ) => state.fields[ key ]?.value ?? '';
+	const getErrorMessagesForField = ( key: string ) => state.fields[ key ]?.errors ?? [];
+
+	return (
+		<NetBankingFormWrapper>
+			<NetBankingField
+				id="netbanking-cardholder-name"
+				type="Text"
+				autoComplete="cc-name"
+				label={ __( 'Your name' ) }
+				value={ state.customerName.value }
+				onChange={ state.changeCustomerName }
+				isError={ state.customerName.isTouched && state.customerName.value.length === 0 }
+				errorMessage={ __( 'This field is required' ) }
+				disabled={ isDisabled }
+			/>
+			<div className="netbanking__contact-fields">
+				<CountrySpecificPaymentFields
+					countryCode="IN" // If this payment method is available and the country is not India, we have other problems
+					countriesList={ countriesList }
+					getErrorMessages={ getErrorMessagesForField }
+					getFieldValue={ getFieldValue }
+					handleFieldChange={ state.setFieldValue }
+					disableFields={ isDisabled }
+				/>
+			</div>
+		</NetBankingFormWrapper>
+	);
+}
+
 function NetBankingPayButton( {
 	disabled,
 	onClick,
-	store,
+	state,
 	submitButtonContent,
 }: {
 	disabled?: boolean;
 	onClick?: ProcessPayment;
-	store: NetBankingStore;
+	state: NetBankingPaymentMethodState;
 	submitButtonContent: ReactNode;
 } ) {
 	const { __ } = useI18n();
 	const { formStatus } = useFormStatus();
-	const customerName = useSelect(
-		( select ) => ( select( 'netbanking' ) as NetBankingSelectors ).getCustomerName(),
-		[]
-	);
-	const fields = useSelect(
-		( select ) => ( select( 'netbanking' ) as NetBankingSelectors ).getFields(),
-		[]
-	);
-	const massagedFields: typeof fields = Object.entries( fields ).reduce(
-		( accum, [ key, managedValue ] ) => ( {
+	useSubscribeToEventEmitter( state );
+	const massagedFields: Record< string, string > = Object.entries( state.fields ).reduce(
+		( accum, [ key, fieldState ] ) => ( {
 			...accum,
-			[ snakeToCamelCase( key ) ]: managedValue.value,
+			[ snakeToCamelCase( key ) ]: fieldState.value,
 		} ),
 		{}
 	);
@@ -284,11 +227,11 @@ function NetBankingPayButton( {
 		<Button
 			disabled={ disabled }
 			onClick={ () => {
-				if ( isFormValid( store, contactCountryCode, __, reduxDispatch ) ) {
+				if ( isFormValid( state, contactCountryCode, __, reduxDispatch ) ) {
 					debug( 'submitting netbanking payment' );
 					onClick( {
 						...massagedFields,
-						name: customerName?.value,
+						name: state.customerName.value,
 						address: massagedFields?.address1,
 					} );
 				}
@@ -302,44 +245,37 @@ function NetBankingPayButton( {
 	);
 }
 
-function NetBankingSummary() {
-	const customerName = useSelect(
-		( select ) => ( select( 'netbanking' ) as NetBankingSelectors ).getCustomerName(),
-		[]
-	);
+function NetBankingSummary( { state }: { state: NetBankingPaymentMethodState } ) {
+	useSubscribeToEventEmitter( state );
 
 	return (
 		<SummaryDetails>
-			<SummaryLine>{ customerName?.value }</SummaryLine>
+			<SummaryLine>{ state.customerName.value }</SummaryLine>
 		</SummaryDetails>
 	);
 }
 
 function isFormValid(
-	store: NetBankingStore,
+	state: NetBankingPaymentMethodState,
 	contactCountryCode: string,
 	__: ( text: string ) => string,
 	reduxDispatch: CalypsoDispatch
 ) {
 	// Touch fields so that we show errors
-	store.dispatch( actions.touchAllFields() );
+	state.touchAllFields();
 	let isValid = true;
 
-	const customerName = selectors.getCustomerName( store.getState() );
-
-	if ( ! customerName?.value.length ) {
+	if ( ! state.customerName.value.length ) {
 		// Touch the field so it displays a validation error
-		store.dispatch( actions.changeCustomerName( '' ) );
+		state.changeCustomerName( '' );
 		isValid = false;
 	}
 
-	const rawState = selectors.getFields( store.getState() );
-
 	const validationResults = validatePaymentDetails(
 		Object.entries( {
-			...rawState,
+			...state.fields,
 			country: { value: contactCountryCode },
-			name: customerName,
+			name: state.customerName,
 		} ).reduce( ( accum: Record< string, string >, [ key, managedValue ] ) => {
 			accum[ key ] = managedValue.value;
 			return accum;
@@ -350,7 +286,7 @@ function isFormValid(
 	Object.entries( validationResults.errors ).map( ( [ key, errors ] ) => {
 		errors.map( ( error ) => {
 			isValid = false;
-			store.dispatch( actions.setFieldError( key, error ) );
+			state.setFieldError( key, error );
 		} );
 	} );
 	debug( 'netbanking card details validation results: ', validationResults );
@@ -364,6 +300,16 @@ function isFormValid(
 	return isValid;
 }
 
+function NetBankingLogoImg( { className }: { className?: string } ) {
+	return (
+		<img src="/calypso/images/upgrades/netbanking.svg" alt="NetBanking" className={ className } />
+	);
+}
+
+const NetBankingLogo = styled( NetBankingLogoImg )`
+	width: 76px;
+`;
+
 function NetBankingLabel() {
 	return (
 		<Fragment>
@@ -372,15 +318,5 @@ function NetBankingLabel() {
 				<NetBankingLogo />
 			</PaymentMethodLogos>
 		</Fragment>
-	);
-}
-
-const NetBankingLogo = styled( NetBankingLogoImg )`
-	width: 76px;
-`;
-
-function NetBankingLogoImg( { className }: { className?: string } ) {
-	return (
-		<img src="/calypso/images/upgrades/netbanking.svg" alt="NetBanking" className={ className } />
 	);
 }

--- a/client/my-sites/checkout/src/payment-methods/paypal.tsx
+++ b/client/my-sites/checkout/src/payment-methods/paypal.tsx
@@ -7,142 +7,102 @@ import {
 } from '@automattic/composite-checkout';
 import { isValueTruthy } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
-import { useSelect, useDispatch, registerStore } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import { Fragment, useMemo } from 'react';
+import { useEffect, useState, Fragment } from 'react';
 import { PayPalLogo } from 'calypso/dashboard/components/paypal-logo';
 import TaxFields from 'calypso/my-sites/checkout/src/components/tax-fields';
 import useCountryList from 'calypso/my-sites/checkout/src/hooks/use-country-list';
 import { PaymentMethodLogos } from '../components/payment-method-logos';
 import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
-import type {
-	PaymentMethodStore,
-	StoreSelectors,
-	StoreActions,
-	StoreSelectorsWithState,
-	StoreState,
-	ManagedContactDetails,
-} from '@automattic/wpcom-checkout';
-import type { AnyAction } from 'redux';
+import type { ManagedContactDetails } from '@automattic/wpcom-checkout';
 
 const debug = debugFactory( 'calypso:paypal-payment-method' );
 
-const storeKey = 'paypal-express';
-type NounsInStore = 'postalCode' | 'countryCode' | 'address1' | 'organization' | 'city' | 'state';
-type PaypalSelectors = StoreSelectors< NounsInStore >;
+interface PayPalPaymentMethodStateShape {
+	postalCode: string;
+	countryCode: string;
+	address1: string;
+	organization: string;
+	city: string;
+	state: string;
+}
 
-type PayPalStore = PaymentMethodStore< NounsInStore >;
+type PayPalPaymentMethodKey = keyof PayPalPaymentMethodStateShape;
 
-const actions: StoreActions< NounsInStore > = {
-	changePostalCode( payload ) {
-		return { type: 'POSTAL_CODE_SET', payload };
-	},
-	changeCountryCode( payload ) {
-		return { type: 'COUNTRY_CODE_SET', payload };
-	},
-	changeAddress1( payload ) {
-		return { type: 'ADDRESS_SET', payload };
-	},
-	changeOrganization( payload ) {
-		return { type: 'ORGANIZATION_SET', payload };
-	},
-	changeCity( payload ) {
-		return { type: 'CITY_SET', payload };
-	},
-	changeState( payload ) {
-		return { type: 'STATE_SET', payload };
-	},
-};
+type StateSubscriber = () => void;
 
-const selectors: StoreSelectorsWithState< NounsInStore > = {
-	getPostalCode( state ) {
-		return state.postalCode || '';
-	},
-	getCountryCode( state ) {
-		return state.countryCode || '';
-	},
-	getAddress1( state ) {
-		return state.address1 || '';
-	},
-	getOrganization( state ) {
-		return state.organization || '';
-	},
-	getCity( state ) {
-		return state.city || '';
-	},
-	getState( state ) {
-		return state.state || '';
-	},
-};
+class PayPalPaymentMethodState {
+	data: PayPalPaymentMethodStateShape = {
+		postalCode: '',
+		countryCode: '',
+		address1: '',
+		organization: '',
+		city: '',
+		state: '',
+	};
 
-export function createPayPalStore(): PayPalStore {
-	debug( 'creating a new paypal payment method store' );
-	const store = registerStore( storeKey, {
-		reducer(
-			state: StoreState< NounsInStore > = {
-				postalCode: { value: '', isTouched: false },
-				countryCode: { value: '', isTouched: false },
-				address1: { value: '', isTouched: false },
-				organization: { value: '', isTouched: false },
-				city: { value: '', isTouched: false },
-				state: { value: '', isTouched: false },
-			},
-			action: AnyAction
-		): StoreState< NounsInStore > {
-			switch ( action.type ) {
-				case 'POSTAL_CODE_SET':
-					return { ...state, postalCode: { value: action.payload, isTouched: true } };
-				case 'COUNTRY_CODE_SET':
-					return { ...state, countryCode: { value: action.payload, isTouched: true } };
-				case 'ADDRESS_SET':
-					return { ...state, address1: { value: action.payload, isTouched: true } };
-				case 'ORGANIZATION_SET':
-					return { ...state, organization: { value: action.payload, isTouched: true } };
-				case 'CITY_SET':
-					return { ...state, city: { value: action.payload, isTouched: true } };
-				case 'STATE_SET':
-					return { ...state, state: { value: action.payload, isTouched: true } };
-			}
-			return state;
-		},
-		actions,
-		selectors,
-	} );
+	isTouched: Record< PayPalPaymentMethodKey, boolean > = {
+		postalCode: false,
+		countryCode: false,
+		address1: false,
+		organization: false,
+		city: false,
+		state: false,
+	};
 
-	return store;
+	subscribers: StateSubscriber[] = [];
+
+	change = ( field: PayPalPaymentMethodKey, value: string ): void => {
+		this.data[ field ] = value;
+		this.isTouched[ field ] = true;
+		this.notifySubscribers();
+	};
+
+	subscribe = ( callback: () => void ): ( () => void ) => {
+		this.subscribers.push( callback );
+		return () => {
+			this.subscribers = this.subscribers.filter( ( subscriber ) => subscriber !== callback );
+		};
+	};
+
+	notifySubscribers = (): void => {
+		this.subscribers.forEach( ( subscriber ) => subscriber() );
+	};
 }
 
 type PayPalMethodArgs = {
 	labelText?: string | null;
-	store?: PayPalStore;
 	shouldShowTaxFields?: boolean;
 };
 
-type PayPalWithTaxesMethodArgs = PayPalMethodArgs & {
-	// The store is only required if we need to keep state (tax fields).
-	store: PayPalStore;
-	shouldShowTaxFields: true;
-};
-
-export function createPayPalMethod(
-	args: PayPalMethodArgs | PayPalWithTaxesMethodArgs
-): PaymentMethod {
+export function createPayPalMethod( args: PayPalMethodArgs ): PaymentMethod {
 	debug( 'creating new paypal payment method' );
+	const state = new PayPalPaymentMethodState();
+
 	return {
-		id: storeKey,
-		paymentProcessorId: storeKey,
+		id: 'paypal-express',
+		paymentProcessorId: 'paypal-express',
 		label: (
 			<PayPalLabel
 				labelText={ args.labelText }
-				store={ args.shouldShowTaxFields ? args.store : undefined }
+				state={ args.shouldShowTaxFields ? state : undefined }
 			/>
 		),
-		submitButton: <PayPalSubmitButton />,
-		activeContent: args.shouldShowTaxFields ? <PayPalTaxFields /> : undefined,
+		submitButton: <PayPalSubmitButton state={ state } />,
+		activeContent: args.shouldShowTaxFields ? <PayPalTaxFields state={ state } /> : undefined,
 		inactiveContent: <PayPalSummary />,
 		getAriaLabel: () => 'PayPal',
 	};
+}
+
+function useSubscribeToEventEmitter( state: PayPalPaymentMethodState ) {
+	const [ , forceReload ] = useState( 0 );
+	useEffect( () => {
+		return state.subscribe( () => {
+			forceReload( ( val: number ) => val + 1 );
+		} );
+	}, [ state ] );
 }
 
 const PayPalFieldsWrapper = styled.div`
@@ -168,55 +128,38 @@ const PayPalFieldsWrapper = styled.div`
 	}
 `;
 
-function PayPalTaxFields() {
+function PayPalTaxFields( { state }: { state: PayPalPaymentMethodState } ) {
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
 	const countriesList = useCountryList();
-	const postalCode = useSelect(
-		( select ) => ( select( storeKey ) as PaypalSelectors ).getPostalCode(),
-		[]
-	);
-	const countryCode = useSelect(
-		( select ) => ( select( storeKey ) as PaypalSelectors ).getCountryCode(),
-		[]
-	);
-	const address1 = useSelect(
-		( select ) => ( select( storeKey ) as PaypalSelectors ).getAddress1(),
-		[]
-	);
-	const organization = useSelect(
-		( select ) => ( select( storeKey ) as PaypalSelectors ).getOrganization(),
-		[]
-	);
-	const city = useSelect( ( select ) => ( select( storeKey ) as PaypalSelectors ).getCity(), [] );
-	const state = useSelect( ( select ) => ( select( storeKey ) as PaypalSelectors ).getState(), [] );
-	const fields = useMemo(
-		() => ( {
-			postalCode: { ...postalCode, errors: [] },
-			countryCode: { ...countryCode, errors: [] },
-			address1: { ...address1, errors: [] },
-			organization: { ...organization, errors: [] },
-			city: { ...city, errors: [] },
-			state: { ...state, errors: [] },
-		} ),
-		[ postalCode, countryCode, address1, organization, city, state ]
-	);
-	const {
-		changePostalCode,
-		changeCountryCode,
-		changeAddress1,
-		changeCity,
-		changeState,
-		changeOrganization,
-	} = useDispatch( storeKey );
-	const onChangeContactInfo = ( newInfo: ManagedContactDetails ) => {
-		changeCountryCode( newInfo.countryCode?.value ?? '' );
-		changePostalCode( newInfo.postalCode?.value ?? '' );
-		changeAddress1( newInfo.address1?.value ?? '' );
-		changeOrganization( newInfo.organization?.value ?? '' );
-		changeCity( newInfo.city?.value ?? '' );
-		changeState( newInfo.state?.value ?? '' );
+	useSubscribeToEventEmitter( state );
+
+	const fields = {
+		postalCode: { value: state.data.postalCode, isTouched: state.isTouched.postalCode, errors: [] },
+		countryCode: {
+			value: state.data.countryCode,
+			isTouched: state.isTouched.countryCode,
+			errors: [],
+		},
+		address1: { value: state.data.address1, isTouched: state.isTouched.address1, errors: [] },
+		organization: {
+			value: state.data.organization,
+			isTouched: state.isTouched.organization,
+			errors: [],
+		},
+		city: { value: state.data.city, isTouched: state.isTouched.city, errors: [] },
+		state: { value: state.data.state, isTouched: state.isTouched.state, errors: [] },
 	};
+
+	const onChangeContactInfo = ( newInfo: ManagedContactDetails ) => {
+		state.change( 'countryCode', newInfo.countryCode?.value ?? '' );
+		state.change( 'postalCode', newInfo.postalCode?.value ?? '' );
+		state.change( 'address1', newInfo.address1?.value ?? '' );
+		state.change( 'organization', newInfo.organization?.value ?? '' );
+		state.change( 'city', newInfo.city?.value ?? '' );
+		state.change( 'state', newInfo.state?.value ?? '' );
+	};
+
 	return (
 		<PayPalFieldsWrapper>
 			<TaxFields
@@ -232,16 +175,16 @@ function PayPalTaxFields() {
 
 function PayPalLabel( {
 	labelText = null,
-	store,
+	state,
 }: {
 	labelText?: string | null;
-	store?: PayPalStore;
+	state?: PayPalPaymentMethodState;
 } ) {
 	return (
 		<Fragment>
 			<div>
 				<span>{ labelText || 'PayPal' }</span>
-				{ store && <TaxLabel /> }
+				{ state && <TaxLabel state={ state } /> }
 			</div>
 			<PaymentMethodLogos className="paypal__logo payment-logos">
 				<PayPalLogo />
@@ -250,16 +193,11 @@ function PayPalLabel( {
 	);
 }
 
-function TaxLabel() {
-	const postalCode = useSelect(
-		( select ) => ( select( storeKey ) as PaypalSelectors ).getPostalCode(),
-		[]
-	);
-	const countryCode = useSelect(
-		( select ) => ( select( storeKey ) as PaypalSelectors ).getCountryCode(),
-		[]
-	);
-	const taxString = [ countryCode.value, postalCode.value ].filter( isValueTruthy ).join( ', ' );
+function TaxLabel( { state }: { state: PayPalPaymentMethodState } ) {
+	useSubscribeToEventEmitter( state );
+	const taxString = [ state.data.countryCode, state.data.postalCode ]
+		.filter( isValueTruthy )
+		.join( ', ' );
 	if ( taxString.length < 1 ) {
 		return null;
 	}
@@ -273,31 +211,16 @@ function TaxLabel() {
 function PayPalSubmitButton( {
 	disabled,
 	onClick,
+	state,
 }: {
 	disabled?: boolean;
 	onClick?: ProcessPayment;
+	state: PayPalPaymentMethodState;
 } ) {
 	const { __ } = useI18n();
 	const { formStatus } = useFormStatus();
 	const { transactionStatus } = useTransactionStatus();
-	const postalCode = useSelect(
-		( select ) => ( select( storeKey ) as PaypalSelectors ).getPostalCode(),
-		[]
-	);
-	const countryCode = useSelect(
-		( select ) => ( select( storeKey ) as PaypalSelectors ).getCountryCode(),
-		[]
-	);
-	const address1 = useSelect(
-		( select ) => ( select( storeKey ) as PaypalSelectors ).getAddress1(),
-		[]
-	);
-	const organization = useSelect(
-		( select ) => ( select( storeKey ) as PaypalSelectors ).getOrganization(),
-		[]
-	);
-	const city = useSelect( ( select ) => ( select( storeKey ) as PaypalSelectors ).getCity(), [] );
-	const state = useSelect( ( select ) => ( select( storeKey ) as PaypalSelectors ).getState(), [] );
+	useSubscribeToEventEmitter( state );
 
 	const handleButtonPress = () => {
 		if ( ! onClick ) {
@@ -306,12 +229,12 @@ function PayPalSubmitButton( {
 			);
 		}
 		onClick( {
-			postalCode: postalCode?.value,
-			countryCode: countryCode?.value,
-			address: address1?.value,
-			organization: organization?.value,
-			city: city?.value,
-			state: state?.value,
+			postalCode: state.data.postalCode,
+			countryCode: state.data.countryCode,
+			address: state.data.address1,
+			organization: state.data.organization,
+			city: state.data.city,
+			state: state.data.state,
 		} );
 	};
 	return (

--- a/client/my-sites/checkout/src/payment-methods/wechat/index.tsx
+++ b/client/my-sites/checkout/src/payment-methods/wechat/index.tsx
@@ -3,11 +3,10 @@ import { formatCurrency } from '@automattic/number-formatters';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { Field } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
-import { useSelect, useDispatch, registerStore } from '@wordpress/data';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import { Fragment } from 'react';
+import { useEffect, useState, Fragment } from 'react';
 import { PaymentMethodLogos } from 'calypso/my-sites/checkout/src/components/payment-method-logos';
 import {
 	SummaryLine,
@@ -15,63 +14,64 @@ import {
 } from 'calypso/my-sites/checkout/src/components/summary-details';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import type { PaymentMethod, PaymentMethodSubmitButtonProps } from '@automattic/composite-checkout';
-import type {
-	PaymentMethodStore,
-	StoreSelectors,
-	StoreSelectorsWithState,
-	StoreActions,
-	StoreState,
-} from '@automattic/wpcom-checkout';
-import type { AnyAction } from 'redux';
 
 const debug = debugFactory( 'calypso:composite-checkout:wechat-payment-method' );
 
-type NounsInStore = 'customerName';
-type WeChatStore = PaymentMethodStore< NounsInStore >;
-
-const actions: StoreActions< NounsInStore > = {
-	changeCustomerName( payload ) {
-		return { type: 'CUSTOMER_NAME_SET', payload };
-	},
-};
-
-const selectors: StoreSelectorsWithState< NounsInStore > = {
-	getCustomerName( state ) {
-		return state.customerName || '';
-	},
-};
-
-export function createWeChatPaymentMethodStore(): WeChatStore {
-	debug( 'creating a new wechat payment method store' );
-	return registerStore( 'wechat', {
-		reducer(
-			state: StoreState< NounsInStore > = {
-				customerName: { value: '', isTouched: false },
-			},
-			action: AnyAction
-		) {
-			switch ( action.type ) {
-				case 'CUSTOMER_NAME_SET':
-					return { ...state, customerName: { value: action.payload, isTouched: true } };
-			}
-			return state;
-		},
-		actions,
-		selectors,
-	} );
+interface WeChatPaymentMethodStateShape {
+	customerName: string;
 }
 
-export function createWeChatMethod( { store }: { store: WeChatStore } ): PaymentMethod {
+type StateSubscriber = () => void;
+
+class WeChatPaymentMethodState {
+	data: WeChatPaymentMethodStateShape = {
+		customerName: '',
+	};
+
+	subscribers: StateSubscriber[] = [];
+
+	isTouched: boolean = false;
+
+	change = ( value: string ): void => {
+		this.data.customerName = value;
+		this.isTouched = true;
+		this.notifySubscribers();
+	};
+
+	subscribe = ( callback: () => void ): ( () => void ) => {
+		this.subscribers.push( callback );
+		return () => {
+			this.subscribers = this.subscribers.filter( ( subscriber ) => subscriber !== callback );
+		};
+	};
+
+	notifySubscribers = (): void => {
+		this.subscribers.forEach( ( subscriber ) => subscriber() );
+	};
+}
+
+export function createWeChatMethod(): PaymentMethod {
+	const state = new WeChatPaymentMethodState();
+
 	return {
 		id: 'wechat',
 		hasRequiredFields: true,
 		paymentProcessorId: 'wechat',
 		label: <WeChatLabel />,
-		activeContent: <WeChatFields />,
-		submitButton: <WeChatPayButton store={ store } />,
-		inactiveContent: <WeChatSummary />,
+		activeContent: <WeChatFields state={ state } />,
+		submitButton: <WeChatPayButton state={ state } />,
+		inactiveContent: <WeChatSummary state={ state } />,
 		getAriaLabel: () => 'WeChat Pay',
 	};
+}
+
+function useSubscribeToEventEmitter( state: WeChatPaymentMethodState ) {
+	const [ , forceReload ] = useState( 0 );
+	useEffect( () => {
+		return state.subscribe( () => {
+			forceReload( ( val: number ) => val + 1 );
+		} );
+	}, [ state ] );
 }
 
 const WeChatFormWrapper = styled.div`
@@ -103,14 +103,9 @@ const WeChatField = styled( Field )`
 	}
 `;
 
-function WeChatFields() {
+function WeChatFields( { state }: { state: WeChatPaymentMethodState } ) {
 	const { __ } = useI18n();
-
-	const customerName = useSelect(
-		( select ) => ( select( 'wechat' ) as StoreSelectors< NounsInStore > ).getCustomerName(),
-		[]
-	);
-	const { changeCustomerName } = useDispatch( 'wechat' );
+	useSubscribeToEventEmitter( state );
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
 
@@ -121,9 +116,9 @@ function WeChatFields() {
 				type="Text"
 				autoComplete="cc-name"
 				label={ __( 'Your name' ) }
-				value={ customerName?.value ?? '' }
-				onChange={ changeCustomerName }
-				isError={ customerName?.isTouched && customerName?.value.length < 3 }
+				value={ state.data.customerName }
+				onChange={ state.change }
+				isError={ state.isTouched && state.data.customerName.length < 3 }
 				errorMessage={ __( 'Your name must contain at least 3 characters' ) }
 				disabled={ isDisabled }
 			/>
@@ -134,15 +129,11 @@ function WeChatFields() {
 function WeChatPayButton( {
 	disabled,
 	onClick,
-	store,
+	state,
 }: PaymentMethodSubmitButtonProps & {
-	store: WeChatStore;
+	state: WeChatPaymentMethodState;
 } ) {
 	const { formStatus } = useFormStatus();
-	const customerName = useSelect(
-		( select ) => ( select( 'wechat' ) as StoreSelectors< NounsInStore > ).getCustomerName(),
-		[]
-	);
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
 
@@ -159,10 +150,10 @@ function WeChatPayButton( {
 		<Button
 			disabled={ disabled }
 			onClick={ () => {
-				if ( isFormValid( store ) ) {
+				if ( isFormValid( state ) ) {
 					debug( 'submitting wechat payment' );
 					onClick( {
-						name: customerName?.value,
+						name: state.data.customerName,
 					} );
 				}
 			} }
@@ -200,25 +191,20 @@ function ButtonContents( {
 	return <>{ __( 'Please wait…' ) }</>;
 }
 
-function WeChatSummary() {
-	const customerName = useSelect(
-		( select ) => ( select( 'wechat' ) as StoreSelectors< NounsInStore > ).getCustomerName(),
-		[]
-	);
+function WeChatSummary( { state }: { state: WeChatPaymentMethodState } ) {
+	useSubscribeToEventEmitter( state );
 
 	return (
 		<SummaryDetails>
-			<SummaryLine>{ customerName?.value }</SummaryLine>
+			<SummaryLine>{ state.data.customerName }</SummaryLine>
 		</SummaryDetails>
 	);
 }
 
-function isFormValid( store: WeChatStore ): boolean {
-	const customerName = selectors.getCustomerName( store.getState() );
-
-	if ( ! customerName?.value.length || customerName?.value.length < 3 ) {
+function isFormValid( state: WeChatPaymentMethodState ): boolean {
+	if ( ! state.data.customerName.length || state.data.customerName.length < 3 ) {
 		// Touch the field so it displays a validation error
-		store.dispatch( actions.changeCustomerName( '' ) );
+		state.change( '' );
 		return false;
 	}
 	return true;

--- a/client/my-sites/checkout/src/test/netbanking.tsx
+++ b/client/my-sites/checkout/src/test/netbanking.tsx
@@ -12,13 +12,9 @@ import {
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { useDispatch } from '@wordpress/data';
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
-import {
-	createNetBankingMethod,
-	createNetBankingPaymentMethodStore,
-} from 'calypso/my-sites/checkout/src/payment-methods/netbanking';
+import { createNetBankingMethod } from 'calypso/my-sites/checkout/src/payment-methods/netbanking';
 import { createReduxStore } from 'calypso/state';
 
 function TestWrapper( { paymentMethods, paymentProcessors = undefined } ) {
@@ -52,18 +48,9 @@ const customerCity = 'Somewhere';
 const customerState = 'Elsewhere';
 const activePayButtonText = 'Pay 0';
 function getPaymentMethod( additionalArgs = {} ) {
-	const store = createNetBankingPaymentMethodStore();
 	return createNetBankingMethod( {
-		store,
 		submitButtonContent: activePayButtonText,
 		...additionalArgs,
-	} );
-}
-
-function ResetNetbankingStoreFields() {
-	const { resetFields } = useDispatch( 'netbanking' );
-	useEffect( () => {
-		resetFields();
 	} );
 }
 
@@ -129,9 +116,6 @@ describe( 'Netbanking payment method', () => {
 				gstin,
 			} );
 		} );
-
-		// Manually reset the `netbanking` store fields.
-		render( <ResetNetbankingStoreFields /> );
 	} );
 
 	it( 'does not submit the data to the processor when the submit button is pressed if fields are missing', async () => {

--- a/packages/wpcom-checkout/src/index.ts
+++ b/packages/wpcom-checkout/src/index.ts
@@ -3,7 +3,6 @@ import useDisplayCartMessages from './use-display-cart-messages';
 export * from './get-contact-details-type';
 export * from './transformations';
 export * from './types';
-export * from './payment-method-store';
 export * from './payment-method-logos';
 export * from './product-url-encoding';
 export { useDisplayCartMessages };

--- a/packages/wpcom-checkout/src/payment-method-store.ts
+++ b/packages/wpcom-checkout/src/payment-method-store.ts
@@ -1,7 +1,0 @@
-export interface StoreStateValue {
-	value: string;
-	isTouched: boolean;
-	errors?: string[];
-}
-
-export type StoreState< N extends string > = Record< N, StoreStateValue >;

--- a/packages/wpcom-checkout/src/payment-method-store.ts
+++ b/packages/wpcom-checkout/src/payment-method-store.ts
@@ -1,39 +1,7 @@
-import { register } from '@wordpress/data';
-
 export interface StoreStateValue {
 	value: string;
 	isTouched: boolean;
 	errors?: string[];
 }
 
-type AddStateArg< F, S > = F extends ( ...args: infer P ) => infer R
-	? ( store: S, ...args: P ) => R
-	: never;
-
-type AddStateArgs< O, S > = {
-	[ K in keyof O ]: AddStateArg< O[ K ], S >;
-};
-
-type Getters< K extends string > = Record< K, () => StoreStateValue >;
-
-type PrependVerb< V extends string, K extends string > = `${ V }${ Capitalize< K > }`;
-
-export type StoreSelectors< N extends string > = Getters< PrependVerb< 'get', N > >;
-
-export type StoreSelectorsWithState< N extends string > = AddStateArgs<
-	StoreSelectors< N >,
-	StoreState< N >
->;
-
 export type StoreState< N extends string > = Record< N, StoreStateValue >;
-
-export type StoreAction = { type: string; payload: string };
-
-export type StoreActions< N extends string > = Record<
-	PrependVerb< 'change', N >,
-	( payload: string ) => StoreAction
->;
-
-export interface PaymentMethodStore< N extends string > extends ReturnType< typeof register > {
-	getState: () => StoreState< N >;
-}

--- a/packages/wpcom-checkout/src/payment-methods/alipay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/alipay.tsx
@@ -1,115 +1,74 @@
 import { Button, FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
-import { useSelect, useDispatch, registerStore } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import { Fragment, ReactNode } from 'react';
+import { useEffect, useState, Fragment, ReactNode } from 'react';
 import Field from '../field';
 import { PaymentMethodLogos } from '../payment-method-logos';
 import { SummaryLine, SummaryDetails } from '../summary-details';
-import type {
-	PaymentMethodStore,
-	StoreSelectors,
-	StoreSelectorsWithState,
-	StoreActions,
-	StoreState,
-} from '../payment-method-store';
-import type { AnyAction } from '../types';
 import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
 
 const debug = debugFactory( 'wpcom-checkout:alipay-payment-method' );
 
-// Disabling this to make migration easier
-/* eslint-disable @typescript-eslint/no-use-before-define */
-
-type NounsInStore = 'customerName';
-type AlipayStore = PaymentMethodStore< NounsInStore >;
-
-const actions: StoreActions< NounsInStore > = {
-	changeCustomerName( payload ) {
-		return { type: 'CUSTOMER_NAME_SET', payload };
-	},
-};
-
-const selectors: StoreSelectorsWithState< NounsInStore > = {
-	getCustomerName( state ) {
-		return state.customerName || '';
-	},
-};
-
-export function createAlipayPaymentMethodStore(): AlipayStore {
-	debug( 'creating a new alipay payment method store' );
-	return registerStore( 'alipay', {
-		reducer(
-			state: StoreState< NounsInStore > = {
-				customerName: { value: '', isTouched: false },
-			},
-			action: AnyAction
-		): StoreState< NounsInStore > {
-			switch ( action.type ) {
-				case 'CUSTOMER_NAME_SET':
-					return { ...state, customerName: { value: action.payload, isTouched: true } };
-			}
-			return state;
-		},
-		actions,
-		selectors,
-	} );
+interface AlipayPaymentMethodStateShape {
+	customerName: string;
 }
 
-function useCustomerName() {
-	const { customerName } = useSelect( ( select ) => {
-		const store = select( 'alipay' ) as StoreSelectors< NounsInStore >;
-		return {
-			customerName: store.getCustomerName(),
-		};
-	}, [] );
+type StateSubscriber = () => void;
 
-	return customerName;
+class AlipayPaymentMethodState {
+	data: AlipayPaymentMethodStateShape = {
+		customerName: '',
+	};
+
+	subscribers: StateSubscriber[] = [];
+
+	isTouched: boolean = false;
+
+	change = ( value: string ): void => {
+		this.data.customerName = value;
+		this.isTouched = true;
+		this.notifySubscribers();
+	};
+
+	subscribe = ( callback: () => void ): ( () => void ) => {
+		this.subscribers.push( callback );
+		return () => {
+			this.subscribers = this.subscribers.filter( ( subscriber ) => subscriber !== callback );
+		};
+	};
+
+	notifySubscribers = (): void => {
+		this.subscribers.forEach( ( subscriber ) => subscriber() );
+	};
 }
 
 export function createAlipayMethod( {
-	store,
 	submitButtonContent,
 }: {
-	store: AlipayStore;
 	submitButtonContent: ReactNode;
 } ): PaymentMethod {
+	const state = new AlipayPaymentMethodState();
+
 	return {
 		id: 'alipay',
 		hasRequiredFields: true,
 		paymentProcessorId: 'alipay',
 		label: <AlipayLabel />,
-		activeContent: <AlipayFields />,
-		inactiveContent: <AlipaySummary />,
-		submitButton: <AlipayPayButton store={ store } submitButtonContent={ submitButtonContent } />,
+		activeContent: <AlipayFields state={ state } />,
+		inactiveContent: <AlipaySummary state={ state } />,
+		submitButton: <AlipayPayButton state={ state } submitButtonContent={ submitButtonContent } />,
 		getAriaLabel: () => 'Alipay',
 	};
 }
 
-function AlipayFields() {
-	const { __ } = useI18n();
-
-	const customerName = useCustomerName();
-	const { changeCustomerName } = useDispatch( 'alipay' );
-	const { formStatus } = useFormStatus();
-	const isDisabled = formStatus !== FormStatus.READY;
-
-	return (
-		<AlipayFormWrapper>
-			<AlipayField
-				id="alipay-cardholder-name"
-				type="Text"
-				autoComplete="cc-name"
-				label={ __( 'Your name' ) }
-				value={ customerName?.value ?? '' }
-				onChange={ changeCustomerName }
-				isError={ customerName?.isTouched && customerName?.value.length === 0 }
-				errorMessage={ __( 'This field is required' ) }
-				disabled={ isDisabled }
-			/>
-		</AlipayFormWrapper>
-	);
+function useSubscribeToEventEmitter( state: AlipayPaymentMethodState ) {
+	const [ , forceReload ] = useState( 0 );
+	useEffect( () => {
+		return state.subscribe( () => {
+			forceReload( ( val: number ) => val + 1 );
+		} );
+	}, [ state ] );
 }
 
 const AlipayFormWrapper = styled.div`
@@ -141,19 +100,41 @@ const AlipayField = styled( Field )`
 	}
 `;
 
+function AlipayFields( { state }: { state: AlipayPaymentMethodState } ) {
+	const { __ } = useI18n();
+	useSubscribeToEventEmitter( state );
+	const { formStatus } = useFormStatus();
+	const isDisabled = formStatus !== FormStatus.READY;
+
+	return (
+		<AlipayFormWrapper>
+			<AlipayField
+				id="alipay-cardholder-name"
+				type="Text"
+				autoComplete="cc-name"
+				label={ __( 'Your name' ) }
+				value={ state.data.customerName }
+				onChange={ state.change }
+				isError={ state.isTouched && state.data.customerName.length === 0 }
+				errorMessage={ __( 'This field is required' ) }
+				disabled={ isDisabled }
+			/>
+		</AlipayFormWrapper>
+	);
+}
+
 function AlipayPayButton( {
 	disabled,
 	onClick,
-	store,
+	state,
 	submitButtonContent,
 }: {
 	disabled?: boolean;
 	onClick?: ProcessPayment;
-	store: AlipayStore;
+	state: AlipayPaymentMethodState;
 	submitButtonContent: ReactNode;
 } ) {
 	const { formStatus } = useFormStatus();
-	const customerName = useCustomerName();
 
 	// This must be typed as optional because it's injected by cloning the
 	// element in CheckoutSubmitButton, but the uncloned element does not have
@@ -168,10 +149,10 @@ function AlipayPayButton( {
 		<Button
 			disabled={ disabled }
 			onClick={ () => {
-				if ( isFormValid( store ) ) {
+				if ( isFormValid( state ) ) {
 					debug( 'submitting alipay payment' );
 					onClick( {
-						name: customerName?.value,
+						name: state.data.customerName,
 					} );
 				}
 			} }
@@ -184,12 +165,10 @@ function AlipayPayButton( {
 	);
 }
 
-function isFormValid( store: AlipayStore ) {
-	const customerName = selectors.getCustomerName( store.getState() );
-
-	if ( ! customerName?.value.length ) {
+function isFormValid( state: AlipayPaymentMethodState ) {
+	if ( ! state.data.customerName.length ) {
 		// Touch the field so it displays a validation error
-		store.dispatch( actions.changeCustomerName( '' ) );
+		state.change( '' );
 		return false;
 	}
 	return true;
@@ -256,12 +235,12 @@ function AlipayLogo() {
 	);
 }
 
-function AlipaySummary() {
-	const customerName = useCustomerName();
+function AlipaySummary( { state }: { state: AlipayPaymentMethodState } ) {
+	useSubscribeToEventEmitter( state );
 
 	return (
 		<SummaryDetails>
-			<SummaryLine>{ customerName?.value }</SummaryLine>
+			<SummaryLine>{ state.data.customerName }</SummaryLine>
 		</SummaryDetails>
 	);
 }

--- a/packages/wpcom-checkout/src/payment-methods/eps.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/eps.tsx
@@ -1,116 +1,74 @@
 import { Button, FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
-import { useSelect, useDispatch, registerStore } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import { Fragment, ReactNode } from 'react';
+import { useEffect, useState, Fragment, ReactNode } from 'react';
 import Field from '../field';
 import { PaymentMethodLogos } from '../payment-method-logos';
 import { SummaryLine, SummaryDetails } from '../summary-details';
-import type {
-	PaymentMethodStore,
-	StoreSelectors,
-	StoreSelectorsWithState,
-	StoreActions,
-	StoreState,
-} from '../payment-method-store';
-import type { AnyAction } from '../types';
 import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
 
 const debug = debugFactory( 'wpcom-checkout:eps-payment-method' );
 
-// Disabling this to make migration easier
-/* eslint-disable @typescript-eslint/no-use-before-define */
+interface EpsPaymentMethodStateShape {
+	customerName: string;
+}
 
-type NounsInStore = 'customerName';
-type EpsStore = PaymentMethodStore< NounsInStore >;
+type StateSubscriber = () => void;
 
-const actions: StoreActions< NounsInStore > = {
-	changeCustomerName( payload ) {
-		return { type: 'CUSTOMER_NAME_SET', payload };
-	},
-};
+class EpsPaymentMethodState {
+	data: EpsPaymentMethodStateShape = {
+		customerName: '',
+	};
 
-const selectors: StoreSelectorsWithState< NounsInStore > = {
-	getCustomerName( state ) {
-		return state.customerName || '';
-	},
-};
+	subscribers: StateSubscriber[] = [];
 
-export function createEpsPaymentMethodStore(): EpsStore {
-	debug( 'creating a new eps payment method store' );
-	const store = registerStore( 'eps', {
-		reducer(
-			state: StoreState< NounsInStore > = {
-				customerName: { value: '', isTouched: false },
-			},
-			action: AnyAction
-		): StoreState< NounsInStore > {
-			switch ( action.type ) {
-				case 'CUSTOMER_NAME_SET':
-					return { ...state, customerName: { value: action.payload, isTouched: true } };
-			}
-			return state;
-		},
-		actions,
-		selectors,
-	} );
-	return store;
+	isTouched: boolean = false;
+
+	change = ( value: string ): void => {
+		this.data.customerName = value;
+		this.isTouched = true;
+		this.notifySubscribers();
+	};
+
+	subscribe = ( callback: () => void ): ( () => void ) => {
+		this.subscribers.push( callback );
+		return () => {
+			this.subscribers = this.subscribers.filter( ( subscriber ) => subscriber !== callback );
+		};
+	};
+
+	notifySubscribers = (): void => {
+		this.subscribers.forEach( ( subscriber ) => subscriber() );
+	};
 }
 
 export function createEpsMethod( {
-	store,
 	submitButtonContent,
 }: {
-	store: EpsStore;
 	submitButtonContent: ReactNode;
 } ): PaymentMethod {
+	const state = new EpsPaymentMethodState();
+
 	return {
 		id: 'eps',
 		hasRequiredFields: true,
 		paymentProcessorId: 'eps',
 		label: <EpsLabel />,
-		activeContent: <EpsFields />,
-		submitButton: <EpsPayButton store={ store } submitButtonContent={ submitButtonContent } />,
-		inactiveContent: <EpsSummary />,
+		activeContent: <EpsFields state={ state } />,
+		submitButton: <EpsPayButton state={ state } submitButtonContent={ submitButtonContent } />,
+		inactiveContent: <EpsSummary state={ state } />,
 		getAriaLabel: ( __ ) => __( 'EPS e-Pay' ),
 	};
 }
 
-function useCustomerName() {
-	const { customerName } = useSelect( ( select ) => {
-		const store = select( 'eps' ) as StoreSelectors< NounsInStore >;
-		return {
-			customerName: store.getCustomerName(),
-		};
-	}, [] );
-
-	return customerName;
-}
-
-function EpsFields() {
-	const { __ } = useI18n();
-
-	const customerName = useCustomerName();
-	const { changeCustomerName } = useDispatch( 'eps' );
-	const { formStatus } = useFormStatus();
-	const isDisabled = formStatus !== FormStatus.READY;
-
-	return (
-		<EpsFormWrapper>
-			<EpsField
-				id="cardholderName"
-				type="Text"
-				autoComplete="cc-name"
-				label={ __( 'Your name' ) }
-				value={ customerName?.value ?? '' }
-				onChange={ changeCustomerName }
-				isError={ customerName?.isTouched && customerName?.value.length === 0 }
-				errorMessage={ __( 'This field is required' ) }
-				disabled={ isDisabled }
-			/>
-		</EpsFormWrapper>
-	);
+function useSubscribeToEventEmitter( state: EpsPaymentMethodState ) {
+	const [ , forceReload ] = useState( 0 );
+	useEffect( () => {
+		return state.subscribe( () => {
+			forceReload( ( val: number ) => val + 1 );
+		} );
+	}, [ state ] );
 }
 
 const EpsFormWrapper = styled.div`
@@ -142,19 +100,41 @@ const EpsField = styled( Field )`
 	}
 `;
 
+function EpsFields( { state }: { state: EpsPaymentMethodState } ) {
+	const { __ } = useI18n();
+	useSubscribeToEventEmitter( state );
+	const { formStatus } = useFormStatus();
+	const isDisabled = formStatus !== FormStatus.READY;
+
+	return (
+		<EpsFormWrapper>
+			<EpsField
+				id="cardholderName"
+				type="Text"
+				autoComplete="cc-name"
+				label={ __( 'Your name' ) }
+				value={ state.data.customerName }
+				onChange={ state.change }
+				isError={ state.isTouched && state.data.customerName.length === 0 }
+				errorMessage={ __( 'This field is required' ) }
+				disabled={ isDisabled }
+			/>
+		</EpsFormWrapper>
+	);
+}
+
 function EpsPayButton( {
 	disabled,
 	onClick,
-	store,
+	state,
 	submitButtonContent,
 }: {
 	disabled?: boolean;
 	onClick?: ProcessPayment;
-	store: EpsStore;
+	state: EpsPaymentMethodState;
 	submitButtonContent: ReactNode;
 } ) {
 	const { formStatus } = useFormStatus();
-	const customerName = useCustomerName();
 
 	// This must be typed as optional because it's injected by cloning the
 	// element in CheckoutSubmitButton, but the uncloned element does not have
@@ -169,10 +149,10 @@ function EpsPayButton( {
 		<Button
 			disabled={ disabled }
 			onClick={ () => {
-				if ( isFormValid( store ) ) {
+				if ( isFormValid( state ) ) {
 					debug( 'submitting eps payment' );
 					onClick( {
-						name: customerName?.value,
+						name: state.data.customerName,
 					} );
 				}
 			} }
@@ -185,27 +165,33 @@ function EpsPayButton( {
 	);
 }
 
-function EpsSummary() {
-	const customerName = useCustomerName();
+function EpsSummary( { state }: { state: EpsPaymentMethodState } ) {
+	useSubscribeToEventEmitter( state );
 
 	return (
 		<SummaryDetails>
-			<SummaryLine>{ customerName?.value }</SummaryLine>
+			<SummaryLine>{ state.data.customerName }</SummaryLine>
 		</SummaryDetails>
 	);
 }
 
-function isFormValid( store: EpsStore ): boolean {
-	const customerName = selectors.getCustomerName( store.getState() );
-
-	if ( ! customerName?.value.length ) {
+function isFormValid( state: EpsPaymentMethodState ): boolean {
+	if ( ! state.data.customerName.length ) {
 		// Touch the field so it displays a validation error
-		store.dispatch( actions.changeCustomerName( '' ) );
+		state.change( '' );
 		return false;
 	}
 
 	return true;
 }
+
+function EpsLogoImg( { className }: { className?: string } ) {
+	return <img src="/calypso/images/upgrades/eps.svg" alt="EPS e-Pay" className={ className } />;
+}
+
+const EpsLogo = styled( EpsLogoImg )`
+	width: 28px;
+`;
 
 function EpsLabel() {
 	const { __ } = useI18n();
@@ -217,12 +203,4 @@ function EpsLabel() {
 			</PaymentMethodLogos>
 		</Fragment>
 	);
-}
-
-const EpsLogo = styled( EpsLogoImg )`
-	width: 28px;
-`;
-
-function EpsLogoImg( { className }: { className?: string } ) {
-	return <img src="/calypso/images/upgrades/eps.svg" alt="EPS e-Pay" className={ className } />;
 }

--- a/packages/wpcom-checkout/src/payment-methods/ideal.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/ideal.tsx
@@ -1,119 +1,74 @@
 import { Button, FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
-import { useSelect, useDispatch, registerStore } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import { Fragment, ReactNode } from 'react';
+import { useEffect, useState, Fragment, ReactNode } from 'react';
 import Field from '../field';
 import { PaymentMethodLogos } from '../payment-method-logos';
 import { SummaryLine, SummaryDetails } from '../summary-details';
-import type {
-	PaymentMethodStore,
-	StoreSelectors,
-	StoreSelectorsWithState,
-	StoreActions,
-	StoreState,
-} from '../payment-method-store';
-import type { AnyAction } from '../types';
 import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
 
 const debug = debugFactory( 'wpcom-checkout:ideal-payment-method' );
 
-// Disabling this to make migration easier
-/* eslint-disable @typescript-eslint/no-use-before-define */
+interface IdealPaymentMethodStateShape {
+	customerName: string;
+}
 
-type NounsInStore = 'customerName';
-type IdealStore = PaymentMethodStore< NounsInStore >;
+type StateSubscriber = () => void;
 
-const actions: StoreActions< NounsInStore > = {
-	changeCustomerName( payload ) {
-		return { type: 'CUSTOMER_NAME_SET', payload };
-	},
-};
+class IdealPaymentMethodState {
+	data: IdealPaymentMethodStateShape = {
+		customerName: '',
+	};
 
-const selectors: StoreSelectorsWithState< NounsInStore > = {
-	getCustomerName( state ) {
-		return state.customerName || '';
-	},
-};
+	subscribers: StateSubscriber[] = [];
 
-export function createIdealPaymentMethodStore(): IdealStore {
-	debug( 'creating a new ideal payment method store' );
-	const store = registerStore( 'ideal', {
-		reducer(
-			state: StoreState< NounsInStore > = {
-				customerName: { value: '', isTouched: false },
-			},
-			action: AnyAction
-		): StoreState< NounsInStore > {
-			switch ( action.type ) {
-				case 'CUSTOMER_NAME_SET':
-					return { ...state, customerName: { value: action.payload, isTouched: true } };
-			}
-			return state;
-		},
-		actions,
-		selectors,
-	} );
+	isTouched: boolean = false;
 
-	return store;
+	change = ( value: string ): void => {
+		this.data.customerName = value;
+		this.isTouched = true;
+		this.notifySubscribers();
+	};
+
+	subscribe = ( callback: () => void ): ( () => void ) => {
+		this.subscribers.push( callback );
+		return () => {
+			this.subscribers = this.subscribers.filter( ( subscriber ) => subscriber !== callback );
+		};
+	};
+
+	notifySubscribers = (): void => {
+		this.subscribers.forEach( ( subscriber ) => subscriber() );
+	};
 }
 
 export function createIdealMethod( {
-	store,
 	submitButtonContent,
 }: {
-	store: IdealStore;
 	submitButtonContent: ReactNode;
 } ): PaymentMethod {
+	const state = new IdealPaymentMethodState();
+
 	return {
 		id: 'ideal',
 		hasRequiredFields: true,
 		paymentProcessorId: 'ideal',
 		label: <IdealLabel />,
-		activeContent: <IdealFields />,
-		submitButton: <IdealPayButton store={ store } submitButtonContent={ submitButtonContent } />,
-		inactiveContent: <IdealSummary />,
+		activeContent: <IdealFields state={ state } />,
+		submitButton: <IdealPayButton state={ state } submitButtonContent={ submitButtonContent } />,
+		inactiveContent: <IdealSummary state={ state } />,
 		getAriaLabel: ( __ ) => __( 'iDEAL' ),
 	};
 }
 
-function useCustomerData() {
-	const { customerName } = useSelect( ( select ) => {
-		const store = select( 'ideal' ) as StoreSelectors< NounsInStore >;
-		return {
-			customerName: store.getCustomerName(),
-		};
-	}, [] );
-
-	return {
-		customerName,
-	};
-}
-
-function IdealFields() {
-	const { __ } = useI18n();
-
-	const { customerName } = useCustomerData();
-	const { changeCustomerName } = useDispatch( 'ideal' );
-	const { formStatus } = useFormStatus();
-	const isDisabled = formStatus !== FormStatus.READY;
-
-	return (
-		<IdealFormWrapper>
-			<IdealField
-				id="ideal-cardholder-name"
-				type="Text"
-				autoComplete="cc-name"
-				label={ __( 'Your name' ) }
-				value={ customerName?.value ?? '' }
-				onChange={ changeCustomerName }
-				isError={ customerName?.isTouched && customerName?.value.length === 0 }
-				errorMessage={ __( 'This field is required' ) }
-				disabled={ isDisabled }
-			/>
-		</IdealFormWrapper>
-	);
+function useSubscribeToEventEmitter( state: IdealPaymentMethodState ) {
+	const [ , forceReload ] = useState( 0 );
+	useEffect( () => {
+		return state.subscribe( () => {
+			forceReload( ( val: number ) => val + 1 );
+		} );
+	}, [ state ] );
 }
 
 const IdealFormWrapper = styled.div`
@@ -143,19 +98,41 @@ const IdealField = styled( Field )`
 	}
 `;
 
+function IdealFields( { state }: { state: IdealPaymentMethodState } ) {
+	const { __ } = useI18n();
+	useSubscribeToEventEmitter( state );
+	const { formStatus } = useFormStatus();
+	const isDisabled = formStatus !== FormStatus.READY;
+
+	return (
+		<IdealFormWrapper>
+			<IdealField
+				id="ideal-cardholder-name"
+				type="Text"
+				autoComplete="cc-name"
+				label={ __( 'Your name' ) }
+				value={ state.data.customerName }
+				onChange={ state.change }
+				isError={ state.isTouched && state.data.customerName.length === 0 }
+				errorMessage={ __( 'This field is required' ) }
+				disabled={ isDisabled }
+			/>
+		</IdealFormWrapper>
+	);
+}
+
 function IdealPayButton( {
 	disabled,
 	onClick,
-	store,
+	state,
 	submitButtonContent,
 }: {
 	disabled?: boolean;
 	onClick?: ProcessPayment;
-	store: IdealStore;
+	state: IdealPaymentMethodState;
 	submitButtonContent: ReactNode;
 } ) {
 	const { formStatus } = useFormStatus();
-	const { customerName } = useCustomerData();
 
 	// This must be typed as optional because it's injected by cloning the
 	// element in CheckoutSubmitButton, but the uncloned element does not have
@@ -170,10 +147,10 @@ function IdealPayButton( {
 		<Button
 			disabled={ disabled }
 			onClick={ () => {
-				if ( isFormValid( store ) ) {
+				if ( isFormValid( state ) ) {
 					debug( 'submitting ideal payment' );
 					onClick( {
-						name: customerName?.value,
+						name: state.data.customerName,
 					} );
 				}
 			} }
@@ -186,45 +163,24 @@ function IdealPayButton( {
 	);
 }
 
-function IdealSummary() {
-	const { customerName } = useCustomerData();
+function IdealSummary( { state }: { state: IdealPaymentMethodState } ) {
+	useSubscribeToEventEmitter( state );
 
 	return (
 		<SummaryDetails>
-			<SummaryLine>{ customerName?.value }</SummaryLine>
+			<SummaryLine>{ state.data.customerName }</SummaryLine>
 		</SummaryDetails>
 	);
 }
 
-function isFormValid( store: IdealStore ) {
-	const customerName = selectors.getCustomerName( store.getState() );
-
-	if ( ! customerName?.value.length ) {
+function isFormValid( state: IdealPaymentMethodState ): boolean {
+	if ( ! state.data.customerName.length ) {
 		// Touch the field so it displays a validation error
-		store.dispatch( actions.changeCustomerName( '' ) );
-	}
-	if ( ! customerName?.value.length ) {
+		state.change( '' );
 		return false;
 	}
 	return true;
 }
-
-function IdealLabel() {
-	const { __ } = useI18n();
-	return (
-		<Fragment>
-			<span>{ __( 'iDEAL' ) }</span>
-			<PaymentMethodLogos className="ideal__logo payment-logos">
-				<IdealLogo />
-			</PaymentMethodLogos>
-		</Fragment>
-	);
-}
-
-const IdealLogo = styled( IdealLogoSvg )`
-	height: 20px;
-	transform: translateY( -3px );
-`;
 
 function IdealLogoSvg( { className }: { className?: string } ) {
 	return (
@@ -242,5 +198,22 @@ function IdealLogoSvg( { className }: { className?: string } ) {
 				fillRule="evenodd"
 			/>
 		</svg>
+	);
+}
+
+const IdealLogo = styled( IdealLogoSvg )`
+	height: 20px;
+	transform: translateY( -3px );
+`;
+
+function IdealLabel() {
+	const { __ } = useI18n();
+	return (
+		<Fragment>
+			<span>{ __( 'iDEAL' ) }</span>
+			<PaymentMethodLogos className="ideal__logo payment-logos">
+				<IdealLogo />
+			</PaymentMethodLogos>
+		</Fragment>
 	);
 }

--- a/packages/wpcom-checkout/src/payment-methods/sofort.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/sofort.tsx
@@ -1,117 +1,74 @@
 import { Button, FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
-import { useSelect, useDispatch, registerStore } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import { Fragment, ReactNode } from 'react';
+import { useEffect, useState, Fragment, ReactNode } from 'react';
 import Field from '../field';
 import { PaymentMethodLogos } from '../payment-method-logos';
 import { SummaryLine, SummaryDetails } from '../summary-details';
-import type {
-	PaymentMethodStore,
-	StoreSelectors,
-	StoreSelectorsWithState,
-	StoreActions,
-	StoreState,
-} from '../payment-method-store';
-import type { AnyAction } from '../types';
 import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
 
 const debug = debugFactory( 'wpcom-checkout:sofort-payment-method' );
 
-// Disabling this to make migration easier
-/* eslint-disable @typescript-eslint/no-use-before-define */
-
-type NounsInStore = 'customerName';
-type SofortStore = PaymentMethodStore< NounsInStore >;
-
-const actions: StoreActions< NounsInStore > = {
-	changeCustomerName( payload ) {
-		return { type: 'CUSTOMER_NAME_SET', payload };
-	},
-};
-
-const selectors: StoreSelectorsWithState< NounsInStore > = {
-	getCustomerName( state ) {
-		return state.customerName || '';
-	},
-};
-
-function useCustomerName() {
-	const { customerName } = useSelect( ( select ) => {
-		const store = select( 'sofort' ) as StoreSelectors< NounsInStore >;
-		return {
-			customerName: store.getCustomerName(),
-		};
-	}, [] );
-
-	return customerName;
+interface SofortPaymentMethodStateShape {
+	customerName: string;
 }
 
-export function createSofortPaymentMethodStore(): SofortStore {
-	debug( 'creating a new sofort payment method store' );
-	const store = registerStore( 'sofort', {
-		reducer(
-			state: StoreState< NounsInStore > = {
-				customerName: { value: '', isTouched: false },
-			},
-			action: AnyAction
-		): StoreState< NounsInStore > {
-			switch ( action.type ) {
-				case 'CUSTOMER_NAME_SET':
-					return { ...state, customerName: { value: action.payload, isTouched: true } };
-			}
-			return state;
-		},
-		actions,
-		selectors,
-	} );
+type StateSubscriber = () => void;
 
-	return store;
+class SofortPaymentMethodState {
+	data: SofortPaymentMethodStateShape = {
+		customerName: '',
+	};
+
+	subscribers: StateSubscriber[] = [];
+
+	isTouched: boolean = false;
+
+	change = ( value: string ): void => {
+		this.data.customerName = value;
+		this.isTouched = true;
+		this.notifySubscribers();
+	};
+
+	subscribe = ( callback: () => void ): ( () => void ) => {
+		this.subscribers.push( callback );
+		return () => {
+			this.subscribers = this.subscribers.filter( ( subscriber ) => subscriber !== callback );
+		};
+	};
+
+	notifySubscribers = (): void => {
+		this.subscribers.forEach( ( subscriber ) => subscriber() );
+	};
 }
 
 export function createSofortMethod( {
-	store,
 	submitButtonContent,
 }: {
-	store: SofortStore;
 	submitButtonContent: ReactNode;
 } ): PaymentMethod {
+	const state = new SofortPaymentMethodState();
+
 	return {
 		id: 'sofort',
 		hasRequiredFields: true,
 		paymentProcessorId: 'sofort',
 		label: <SofortLabel />,
-		activeContent: <SofortFields />,
-		submitButton: <SofortPayButton store={ store } submitButtonContent={ submitButtonContent } />,
-		inactiveContent: <SofortSummary />,
+		activeContent: <SofortFields state={ state } />,
+		submitButton: <SofortPayButton state={ state } submitButtonContent={ submitButtonContent } />,
+		inactiveContent: <SofortSummary state={ state } />,
 		getAriaLabel: () => 'Sofort',
 	};
 }
 
-function SofortFields() {
-	const { __ } = useI18n();
-
-	const customerName = useCustomerName();
-	const { changeCustomerName } = useDispatch( 'sofort' );
-	const { formStatus } = useFormStatus();
-	const isDisabled = formStatus !== FormStatus.READY;
-
-	return (
-		<SofortFormWrapper>
-			<SofortField
-				id="sofort-cardholder-name"
-				type="Text"
-				autoComplete="cc-name"
-				label={ __( 'Your name' ) }
-				value={ customerName?.value ?? '' }
-				onChange={ changeCustomerName }
-				isError={ customerName?.isTouched && customerName?.value.length === 0 }
-				errorMessage={ __( 'This field is required' ) }
-				disabled={ isDisabled }
-			/>
-		</SofortFormWrapper>
-	);
+function useSubscribeToEventEmitter( state: SofortPaymentMethodState ) {
+	const [ , forceReload ] = useState( 0 );
+	useEffect( () => {
+		return state.subscribe( () => {
+			forceReload( ( val: number ) => val + 1 );
+		} );
+	}, [ state ] );
 }
 
 const SofortFormWrapper = styled.div`
@@ -143,19 +100,41 @@ const SofortField = styled( Field )`
 	}
 `;
 
+function SofortFields( { state }: { state: SofortPaymentMethodState } ) {
+	const { __ } = useI18n();
+	useSubscribeToEventEmitter( state );
+	const { formStatus } = useFormStatus();
+	const isDisabled = formStatus !== FormStatus.READY;
+
+	return (
+		<SofortFormWrapper>
+			<SofortField
+				id="sofort-cardholder-name"
+				type="Text"
+				autoComplete="cc-name"
+				label={ __( 'Your name' ) }
+				value={ state.data.customerName }
+				onChange={ state.change }
+				isError={ state.isTouched && state.data.customerName.length === 0 }
+				errorMessage={ __( 'This field is required' ) }
+				disabled={ isDisabled }
+			/>
+		</SofortFormWrapper>
+	);
+}
+
 function SofortPayButton( {
 	disabled,
 	onClick,
-	store,
+	state,
 	submitButtonContent,
 }: {
 	disabled?: boolean;
 	onClick?: ProcessPayment;
-	store: SofortStore;
+	state: SofortPaymentMethodState;
 	submitButtonContent: ReactNode;
 } ) {
 	const { formStatus } = useFormStatus();
-	const customerName = useCustomerName();
 
 	// This must be typed as optional because it's injected by cloning the
 	// element in CheckoutSubmitButton, but the uncloned element does not have
@@ -170,10 +149,10 @@ function SofortPayButton( {
 		<Button
 			disabled={ disabled }
 			onClick={ () => {
-				if ( isFormValid( store ) ) {
+				if ( isFormValid( state ) ) {
 					debug( 'submitting sofort payment' );
 					onClick( {
-						name: customerName?.value,
+						name: state.data.customerName,
 					} );
 				}
 			} }
@@ -186,26 +165,32 @@ function SofortPayButton( {
 	);
 }
 
-function SofortSummary() {
-	const customerName = useCustomerName();
+function SofortSummary( { state }: { state: SofortPaymentMethodState } ) {
+	useSubscribeToEventEmitter( state );
 
 	return (
 		<SummaryDetails>
-			<SummaryLine>{ customerName?.value }</SummaryLine>
+			<SummaryLine>{ state.data.customerName }</SummaryLine>
 		</SummaryDetails>
 	);
 }
 
-function isFormValid( store: SofortStore ): boolean {
-	const customerName = selectors.getCustomerName( store.getState() );
-
-	if ( ! customerName?.value.length ) {
+function isFormValid( state: SofortPaymentMethodState ): boolean {
+	if ( ! state.data.customerName.length ) {
 		// Touch the field so it displays a validation error
-		store.dispatch( actions.changeCustomerName( '' ) );
+		state.change( '' );
 		return false;
 	}
 	return true;
 }
+
+function SofortLogoImg( { className }: { className?: string } ) {
+	return <img src="/calypso/images/upgrades/sofort.svg" alt="Sofort" className={ className } />;
+}
+
+const SofortLogo = styled( SofortLogoImg )`
+	width: 64px;
+`;
 
 function SofortLabel() {
 	const { __ } = useI18n();
@@ -217,12 +202,4 @@ function SofortLabel() {
 			</PaymentMethodLogos>
 		</Fragment>
 	);
-}
-
-const SofortLogo = styled( SofortLogoImg )`
-	width: 64px;
-`;
-
-function SofortLogoImg( { className }: { className?: string } ) {
-	return <img src="/calypso/images/upgrades/sofort.svg" alt="Sofort" className={ className } />;
 }


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHE-295/

## Proposed changes

Replaces `@wordpress/data` store boilerplate in 7 payment methods with simple event-emitter classes, following the pattern already used by Pix, Bancontact, and P24.

## Why are these changes being made?

The original payment method implementations used `@wordpress/data`'s `registerStore` to manage a handful of simple string fields. That pattern requires defining a reducer, action creators, and selectors — roughly 40–60 lines of boilerplate — just to track one or two field values. Subsequent payment methods (Pix, P24, Bancontact, Razorpay, Stripe UPI) were written with a much simpler approach: a plain class with a subscriber list that triggers React re-renders via a `useState` counter. This PR brings the older payment methods in line with that pattern.

The event-emitter approach is also easier to reason about in tests: because state is encapsulated in the factory function rather than in a global registry, each test automatically gets an isolated instance with no risk of cross-test pollution (which is why the netbanking test previously needed a manual `resetFields()` call after one of its tests).

## Testing instructions

Automated tests should prevent regressions.

> [!NOTE]
> PayPal Express, Sofort, Netbanking, and EPS are not enabled currently so there's no need to test them.

Manual testing:
* Load a checkout session that includes a payment method affected by this change (iDEAL, Alipay, or WeChat Pay).
* Fill in the name field and confirm the error state appears when the field is left blank and the submit button is pressed.
