### PR TITLE
MCP settings: add sub-category dividers to Design card and route design tools correctly

### DIFF
--- a/client/dashboard/me/mcp/categories.ts
+++ b/client/dashboard/me/mcp/categories.ts
@@ -8,9 +8,13 @@
  * Display categories are coarser than API categories: several API categories
  * are merged into a single card with visual sub-category dividers.
  *
- *   Posts card:  posts | comments | categories-tags
- *   Sites card:  sites | media | users/plugins/site-settings | analytics
+ *   Posts card:   posts | comments | categories-tags
+ *   Sites card:   sites | media | users | plugins | site-settings | analytics
+ *   Design card:  design (themes, patterns, blocks, templates, global styles, navigation)
  *   Account card: account | notifications | billing
+ *
+ * Design-card tools all share `design` as their API category, so sub-groups within the
+ * Design card are derived from tool ID prefixes in getSubCategory().
  */
 
 import { __ } from '@wordpress/i18n';
@@ -54,6 +58,13 @@ const SUB_CATEGORIES = {
 	// Account sub-categories
 	ACCOUNT: __( 'Account', 'calypso' ),
 	NOTIFICATIONS: __( 'Notifications', 'calypso' ),
+	// Design sub-categories
+	THEMES: __( 'Themes', 'calypso' ),
+	PATTERNS: __( 'Patterns', 'calypso' ),
+	TEMPLATES: __( 'Templates', 'calypso' ),
+	GLOBAL_STYLES: __( 'Global styles', 'calypso' ),
+	NAVIGATION: __( 'Navigation', 'calypso' ),
+	BLOCKS: __( 'Blocks', 'calypso' ),
 } as const;
 
 /**
@@ -72,6 +83,14 @@ export const SUB_CATEGORY_ORDER: Record< string, readonly string[] > = {
 		SUB_CATEGORIES.ANALYTICS,
 	],
 	[ DISPLAY_CATEGORIES.ACCOUNT ]: [ SUB_CATEGORIES.ACCOUNT, SUB_CATEGORIES.NOTIFICATIONS ],
+	[ DISPLAY_CATEGORIES.DESIGN ]: [
+		SUB_CATEGORIES.THEMES,
+		SUB_CATEGORIES.PATTERNS,
+		SUB_CATEGORIES.TEMPLATES,
+		SUB_CATEGORIES.GLOBAL_STYLES,
+		SUB_CATEGORIES.NAVIGATION,
+		SUB_CATEGORIES.BLOCKS,
+	],
 };
 
 /**
@@ -85,7 +104,7 @@ const API_CATEGORY_TO_DISPLAY: Record< string, string > = {
 	'categories-tags': DISPLAY_CATEGORIES.POSTS,
 	// Pages card
 	pages: DISPLAY_CATEGORIES.PAGES,
-	// Design card
+	// Design card — all design tools share the 'design' category
 	design: DISPLAY_CATEGORIES.DESIGN,
 	// Sites card
 	sites: DISPLAY_CATEGORIES.SITES,
@@ -107,6 +126,9 @@ const API_CATEGORY_TO_DISPLAY: Record< string, string > = {
 /**
  * Maps API category values to the sub-category divider within their display card.
  * Only needed for API categories that are merged into a card with multiple sub-groups.
+ *
+ * Design-card tools all share `design` as their API category, so their sub-groups
+ * are derived from tool ID prefixes in getSubCategory() instead.
  */
 const API_CATEGORY_TO_SUB_CATEGORY: Record< string, string > = {
 	// Posts card sub-categories
@@ -127,6 +149,25 @@ const API_CATEGORY_TO_SUB_CATEGORY: Record< string, string > = {
 };
 
 /**
+ * Maps tool ID prefixes to Design-card sub-categories.
+ * All Design tools share `design` as their API category, so the tool ID is the only
+ * signal available for sub-grouping within the card.
+ */
+const TOOL_ID_PREFIX_TO_DESIGN_SUB_CATEGORY: Record< string, string > = {
+	'wpcom-mcp/theme-': SUB_CATEGORIES.THEMES,
+	'wpcom-mcp/themes-': SUB_CATEGORIES.THEMES,
+	'wpcom-mcp/patterns-': SUB_CATEGORIES.PATTERNS,
+	'wpcom-mcp/synced-patterns-': SUB_CATEGORIES.PATTERNS,
+	'wpcom-mcp/templates-': SUB_CATEGORIES.TEMPLATES,
+	'wpcom-mcp/template-parts-': SUB_CATEGORIES.TEMPLATES,
+	'wpcom-mcp/global-styles-': SUB_CATEGORIES.GLOBAL_STYLES,
+	'wpcom-mcp/navigation-': SUB_CATEGORIES.NAVIGATION,
+	'wpcom-mcp/menus-': SUB_CATEGORIES.NAVIGATION,
+	'wpcom-mcp/menu-items-': SUB_CATEGORIES.NAVIGATION,
+	'wpcom-mcp/blocks-': SUB_CATEGORIES.BLOCKS,
+};
+
+/**
  * Pass-through sort — preserved for interface compatibility.
  */
 export function sortTools< T >( tools: Array< [ string, T ] > ): Array< [ string, T ] > {
@@ -136,17 +177,31 @@ export function sortTools< T >( tools: Array< [ string, T ] > ): Array< [ string
 /**
  * Get the sub-category for a tool within its merged display card.
  * Returns undefined for tools in cards that have no sub-category dividers.
- * @param toolId - Unused; kept for interface compatibility.
- * @param ability - Ability object with category from API
- * @param ability.category - API category value from abilities-config.php
- * @returns The sub-category label, or undefined
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function getSubCategory(
 	toolId: string,
 	ability?: { category?: string }
 ): string | undefined {
 	const apiCategory = ability?.category;
+
+	// Design-card tools use tool ID prefix for sub-grouping. This covers both
+	// 'design'-category tools and 'sites'-category tools that are routed to the
+	// Design card by getDisplayCategory (e.g. navigation, menus, themes).
+	if ( apiCategory === 'design' || apiCategory === 'sites' ) {
+		for ( const [ prefix, subCategory ] of Object.entries(
+			TOOL_ID_PREFIX_TO_DESIGN_SUB_CATEGORY
+		) ) {
+			if ( toolId.startsWith( prefix ) ) {
+				return subCategory;
+			}
+		}
+		// 'sites'-category tools with no Design prefix stay in the Sites card's Sites sub-group.
+		if ( apiCategory === 'sites' ) {
+			return API_CATEGORY_TO_SUB_CATEGORY[ 'sites' ];
+		}
+		return undefined;
+	}
+
 	if ( apiCategory ) {
 		return API_CATEGORY_TO_SUB_CATEGORY[ apiCategory ];
 	}
@@ -156,10 +211,6 @@ export function getSubCategory(
 /**
  * Returns true if a tool should be treated as a write operation.
  * Uses the `readonly` field from the API: a tool is a write tool when readonly is explicitly false.
- * @param toolId - Unused; kept for interface compatibility.
- * @param ability - Optional ability object with readonly flag from API
- * @param ability.readonly - Whether the tool is read-only
- * @returns Whether the tool is a write operation
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function isWriteTool( toolId: string, ability?: { readonly?: boolean } ): boolean {
@@ -168,14 +219,25 @@ export function isWriteTool( toolId: string, ability?: { readonly?: boolean } ):
 
 /**
  * Get the display category (card) for a tool based on its API category.
- * @param toolId - Unused; kept for interface compatibility.
- * @param ability - Ability object with category from API
- * @param ability.category - API category value from abilities-config.php
- * @returns The display category label
+ *
+ * Navigation, menus, and theme tools may carry `category: 'sites'` from the
+ * backend but belong in the Design card. Tool ID prefix takes precedence over
+ * the API category for these tools.
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function getDisplayCategory( toolId: string, ability?: { category?: string } ): string {
 	const apiCategory = ability?.category;
+
+	// For 'design' and 'sites' category tools, check if the tool ID prefix
+	// indicates it belongs in the Design card.
+	if ( apiCategory === 'design' || apiCategory === 'sites' ) {
+		for ( const prefix of Object.keys( TOOL_ID_PREFIX_TO_DESIGN_SUB_CATEGORY ) ) {
+			if ( toolId.startsWith( prefix ) ) {
+				return DISPLAY_CATEGORIES.DESIGN;
+			}
+		}
+	}
+
 	if ( apiCategory && API_CATEGORY_TO_DISPLAY[ apiCategory ] ) {
 		return API_CATEGORY_TO_DISPLAY[ apiCategory ];
 	}

--- a/client/dashboard/me/mcp/categories.ts
+++ b/client/dashboard/me/mcp/categories.ts
@@ -52,6 +52,7 @@ const SUB_CATEGORIES = {
 	CATEGORIES_TAGS: __( 'Categories & tags', 'calypso' ),
 	// Sites sub-categories
 	SITES: __( 'Sites', 'calypso' ),
+	PLUGINS: __( 'Plugins', 'calypso' ),
 	MEDIA: __( 'Media', 'calypso' ),
 	SITE_SETTINGS: __( 'Site settings', 'calypso' ),
 	ANALYTICS: __( 'Analytics', 'calypso' ),
@@ -78,6 +79,7 @@ export const SUB_CATEGORY_ORDER: Record< string, readonly string[] > = {
 	],
 	[ DISPLAY_CATEGORIES.SITES ]: [
 		SUB_CATEGORIES.SITES,
+		SUB_CATEGORIES.PLUGINS,
 		SUB_CATEGORIES.SITE_SETTINGS,
 		SUB_CATEGORIES.MEDIA,
 		SUB_CATEGORIES.ANALYTICS,
@@ -139,7 +141,7 @@ const API_CATEGORY_TO_SUB_CATEGORY: Record< string, string > = {
 	sites: SUB_CATEGORIES.SITES,
 	media: SUB_CATEGORIES.MEDIA,
 	users: SUB_CATEGORIES.SITE_SETTINGS,
-	plugins: SUB_CATEGORIES.SITE_SETTINGS,
+	plugins: SUB_CATEGORIES.PLUGINS,
 	'site-settings': SUB_CATEGORIES.SITE_SETTINGS,
 	analytics: SUB_CATEGORIES.ANALYTICS,
 	// Account card sub-categories
@@ -224,7 +226,6 @@ export function isWriteTool( toolId: string, ability?: { readonly?: boolean } ):
  * backend but belong in the Design card. Tool ID prefix takes precedence over
  * the API category for these tools.
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function getDisplayCategory( toolId: string, ability?: { category?: string } ): string {
 	const apiCategory = ability?.category;
 

--- a/client/dashboard/me/mcp/read/index.tsx
+++ b/client/dashboard/me/mcp/read/index.tsx
@@ -142,9 +142,12 @@ export default function McpRead() {
 
 		const order = SUB_CATEGORY_ORDER[ categoryName ] ?? [];
 		const subGroups = order.filter( ( sub ) => subGrouped[ sub ] && subGrouped[ sub ].length > 0 );
+		// Tools with no sub-category are appended at the end so they are never silently dropped.
+		const ungrouped = subGrouped[ '' ] ?? [];
+		const allGroups = ungrouped.length > 0 ? [ ...subGroups, '' ] : subGroups;
 
-		return subGroups.map( ( subName, index ) => (
-			<Fragment key={ subName }>
+		return allGroups.map( ( subName, index ) => (
+			<Fragment key={ subName || '__ungrouped__' }>
 				{ index > 0 && (
 					<CardBody style={ { padding: 'calc(4px * 2) calc(4px * 6)' } }>
 						<hr

--- a/client/dashboard/me/mcp/write/index.tsx
+++ b/client/dashboard/me/mcp/write/index.tsx
@@ -142,9 +142,12 @@ export default function McpWrite() {
 
 		const order = SUB_CATEGORY_ORDER[ categoryName ] ?? [];
 		const subGroups = order.filter( ( sub ) => subGrouped[ sub ] && subGrouped[ sub ].length > 0 );
+		// Tools with no sub-category are appended at the end so they are never silently dropped.
+		const ungrouped = subGrouped[ '' ] ?? [];
+		const allGroups = ungrouped.length > 0 ? [ ...subGroups, '' ] : subGroups;
 
-		return subGroups.map( ( subName, index ) => (
-			<Fragment key={ subName }>
+		return allGroups.map( ( subName, index ) => (
+			<Fragment key={ subName || '__ungrouped__' }>
 				{ index > 0 && (
 					<CardBody style={ { padding: 'calc(4px * 2) calc(4px * 6)' } }>
 						<hr

--- a/client/dashboard/sites/settings-ai-tools/read/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/read/index.tsx
@@ -168,9 +168,12 @@ export default function SiteAIToolsRead() {
 
 		const order = SUB_CATEGORY_ORDER[ categoryName ] ?? [];
 		const subGroups = order.filter( ( sub ) => subGrouped[ sub ] && subGrouped[ sub ].length > 0 );
+		// Tools with no sub-category are appended at the end so they are never silently dropped.
+		const ungrouped = subGrouped[ '' ] ?? [];
+		const allGroups = ungrouped.length > 0 ? [ ...subGroups, '' ] : subGroups;
 
-		return subGroups.map( ( subName, index ) => (
-			<Fragment key={ subName }>
+		return allGroups.map( ( subName, index ) => (
+			<Fragment key={ subName || '__ungrouped__' }>
 				{ index > 0 && <CardDivider className="mcp-settings__tool-group-divider" /> }
 				<CardBody>
 					<VStack spacing={ 4 }>{ renderToolToggles( sortTools( subGrouped[ subName ] ) ) }</VStack>

--- a/client/dashboard/sites/settings-ai-tools/write/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/write/index.tsx
@@ -170,9 +170,12 @@ export default function SiteAIToolsWrite() {
 
 		const order = SUB_CATEGORY_ORDER[ categoryName ] ?? [];
 		const subGroups = order.filter( ( sub ) => subGrouped[ sub ] && subGrouped[ sub ].length > 0 );
+		// Tools with no sub-category are appended at the end so they are never silently dropped.
+		const ungrouped = subGrouped[ '' ] ?? [];
+		const allGroups = ungrouped.length > 0 ? [ ...subGroups, '' ] : subGroups;
 
-		return subGroups.map( ( subName, index ) => (
-			<Fragment key={ subName }>
+		return allGroups.map( ( subName, index ) => (
+			<Fragment key={ subName || '__ungrouped__' }>
 				{ index > 0 && <CardDivider className="mcp-settings__tool-group-divider" /> }
 				<CardBody>
 					<VStack spacing={ 4 }>{ renderToolToggles( sortTools( subGrouped[ subName ] ) ) }</VStack>

--- a/client/me/mcp/tools-subpage.jsx
+++ b/client/me/mcp/tools-subpage.jsx
@@ -171,9 +171,12 @@ export default function McpToolsSubpage( {
 
 		const order = SUB_CATEGORY_ORDER[ categoryName ] ?? [];
 		const subGroups = order.filter( ( sub ) => subGrouped[ sub ] && subGrouped[ sub ].length > 0 );
+		// Tools with no sub-category are appended at the end so they are never silently dropped.
+		const ungrouped = subGrouped[ '' ] ?? [];
+		const allGroups = ungrouped.length > 0 ? [ ...subGroups, '' ] : subGroups;
 
-		return subGroups.map( ( subName, index ) => (
-			<Fragment key={ subName }>
+		return allGroups.map( ( subName, index ) => (
+			<Fragment key={ subName || '__ungrouped__' }>
 				{ index > 0 && <div className="mcp-tools-subpage__sub-divider" /> }
 				<div
 					className={


### PR DESCRIPTION
## Proposed Changes

* Add sub-category dividers to the Design card on all MCP settings pages (account-level and site-level)
* Design sub-categories: Themes, Patterns, Templates, Global styles, Navigation, Blocks
* Route navigation/menu/themes tools (API `category: 'sites'`) to the Design card using tool ID prefix matching, cleaning up the Sites card's Sites sub-group
* Add ungrouped catch-all in `renderSubGroupedTools` on all five renderers so tools with no matched sub-category are never silently dropped

## Why are these changes being made?

The Design card previously showed all tools in one flat list with no visual grouping. Sites and Posts cards already had sub-category dividers; this brings Design to the same standard.

All Design-card tools share a single `design` API category (and some navigation/menu/themes tools have `sites`), so there is no API-level signal to sub-group them — sub-grouping is derived from tool ID prefix instead, following the same approach already used for the Sites card.

## Testing Instructions

* Visit `/me/mcp/read` and `/me/mcp/write` — Design card should show tools grouped into Themes / Patterns / Templates / Global styles / Navigation / Blocks with dividers between groups
* Visit `sites/<slug>/settings/ai-tools/read` and `.../write` — same Design sub-groups visible
* Sites card: navigation, menu, and themes tools should no longer appear in the Sites sub-group; site-management tools (List your sites, List site resources) should remain

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
