### PR TITLE
Domain Search: emphasize commerce TLDs for woo-hosting-solutions ref

### DIFF
--- a/client/landing/stepper/constants.ts
+++ b/client/landing/stepper/constants.ts
@@ -13,6 +13,16 @@ export const SITE_PICKER_FILTER_CONFIG = [ 'wpcom', 'atomic' ];
 
 export const WOO_HOSTING_SOLUTIONS_REF = 'woo-hosting-solutions-flow';
 
+export const WOO_HOSTING_SOLUTIONS_EMPHASIZED_TLDS = [
+	'shop',
+	'store',
+	'co',
+	'boutique',
+	'supply',
+];
+
+export const WOO_HOSTING_SOLUTIONS_DEEMPHASIZED_TLDS = [ 'blog', 'art', 'ninja', 'dev', 'me' ];
+
 export const HOW_TO_MIGRATE_OPTIONS = {
 	DO_IT_FOR_ME: 'difm',
 	DO_IT_MYSELF: 'myself',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -22,6 +22,11 @@ import { useQueryHandler } from 'calypso/components/domains/wpcom-domain-search/
 import FormattedHeader from 'calypso/components/formatted-header';
 import { dashboardLink, dashboardOrigins } from 'calypso/dashboard/utils/link';
 import { isRelativeUrl } from 'calypso/dashboard/utils/url';
+import {
+	WOO_HOSTING_SOLUTIONS_DEEMPHASIZED_TLDS,
+	WOO_HOSTING_SOLUTIONS_EMPHASIZED_TLDS,
+	WOO_HOSTING_SOLUTIONS_REF,
+} from 'calypso/landing/stepper/constants';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -83,6 +88,8 @@ const DomainSearchStep: StepType< {
 	const queryParams = useQuery();
 	const queryParamNew = queryParams.get( 'new' ) ?? '';
 	const tldQuery = queryParams.get( 'tld' );
+	const refParameter = queryParams.get( 'ref' );
+	const isWooHostingSolutions = refParameter === WOO_HOSTING_SOLUTIONS_REF;
 	const source = queryParams.get( 'source' );
 	const backTo = queryParams.get( 'back_to' ) ?? '';
 	const sourceSlug = queryParams.get( 'sourceSlug' );
@@ -140,6 +147,8 @@ const DomainSearchStep: StepType< {
 				isHundredYearPlanFlow( flow ) || isHundredYearDomainFlow( flow )
 					? HUNDRED_YEAR_DOMAIN_TLDS
 					: allowedTlds,
+			emphasizedTlds: isWooHostingSolutions ? WOO_HOSTING_SOLUTIONS_EMPHASIZED_TLDS : [],
+			deemphasizedTlds: isWooHostingSolutions ? WOO_HOSTING_SOLUTIONS_DEEMPHASIZED_TLDS : [],
 			includeOwnedDomainInSuggestions: true,
 			allowsUsingOwnDomain:
 				! isAIBuilderFlow( flow ) &&
@@ -147,7 +156,7 @@ const DomainSearchStep: StepType< {
 				! isHundredYearPlanFlow( flow ) &&
 				( isHundredYearDomainFlow( flow ) ? !! query : true ),
 		};
-	}, [ flow, isCiab, tldQuery, query ] );
+	}, [ flow, isCiab, tldQuery, query, isWooHostingSolutions ] );
 
 	const { submit } = navigation;
 

--- a/packages/domain-search/src/helpers/partition-suggestions.ts
+++ b/packages/domain-search/src/helpers/partition-suggestions.ts
@@ -15,12 +15,85 @@ interface PartitionedSuggestions {
 interface PartitionSuggestionsParams {
 	suggestions: string[];
 	query: string;
+	emphasizedTlds: string[];
 	deemphasizedTlds: string[];
 }
+
+const MAX_FEATURED_SLOTS = 3;
+
+const partitionWithEmphasis = ( {
+	suggestions,
+	query,
+	emphasizedTlds,
+	deemphasizedTlds,
+}: PartitionSuggestionsParams ): PartitionedSuggestions => {
+	const featuredSuggestions: FeaturedSuggestionWithReason[] = [];
+	const featuredSet = new Set< string >();
+
+	// When the query has no TLD, promote `{query}.com` to the exact-match slot so
+	// `.com` keeps the top spot even with emphasized TLDs in play.
+	if ( ! getTld( query ) ) {
+		const queryDotCom = `${ query }.com`;
+		if ( suggestions.includes( queryDotCom ) ) {
+			featuredSuggestions.push( { suggestion: queryDotCom, reason: 'exact-match' } );
+			featuredSet.add( queryDotCom );
+		}
+	}
+
+	for ( const tld of emphasizedTlds ) {
+		if ( featuredSuggestions.length >= MAX_FEATURED_SLOTS ) {
+			break;
+		}
+		const match = suggestions.find(
+			( suggestion ) => ! featuredSet.has( suggestion ) && getTld( suggestion ) === tld
+		);
+		if ( ! match ) {
+			continue;
+		}
+		const reason: FeaturedSuggestionReason = featuredSuggestions.some(
+			( featured ) => featured.reason === 'recommended'
+		)
+			? 'best-alternative'
+			: 'recommended';
+		featuredSuggestions.push( { suggestion: match, reason } );
+		featuredSet.add( match );
+	}
+
+	const remainingEmphasized: string[] = [];
+	const others: string[] = [];
+	const deemphasized: string[] = [];
+
+	for ( const suggestion of suggestions ) {
+		if ( featuredSet.has( suggestion ) ) {
+			continue;
+		}
+		const tld = getTld( suggestion );
+		if ( deemphasizedTlds.includes( tld ) ) {
+			deemphasized.push( suggestion );
+			continue;
+		}
+		if ( emphasizedTlds.includes( tld ) ) {
+			remainingEmphasized.push( suggestion );
+			continue;
+		}
+		others.push( suggestion );
+	}
+
+	const byTldOrder = ( order: string[] ) => ( a: string, b: string ) =>
+		order.indexOf( getTld( a ) ) - order.indexOf( getTld( b ) );
+	remainingEmphasized.sort( byTldOrder( emphasizedTlds ) );
+	deemphasized.sort( byTldOrder( deemphasizedTlds ) );
+
+	return {
+		featuredSuggestions,
+		regularSuggestions: [ ...remainingEmphasized, ...others, ...deemphasized ],
+	};
+};
 
 export const partitionSuggestions = ( {
 	suggestions,
 	query,
+	emphasizedTlds,
 	deemphasizedTlds,
 }: PartitionSuggestionsParams ): PartitionedSuggestions => {
 	const exactMatch = suggestions.find( ( suggestion ) => suggestion === query );
@@ -36,6 +109,15 @@ export const partitionSuggestions = ( {
 			],
 			regularSuggestions: suggestions.filter( ( suggestion ) => suggestion !== query ),
 		};
+	}
+
+	if ( emphasizedTlds.length > 0 ) {
+		return partitionWithEmphasis( {
+			suggestions,
+			query,
+			emphasizedTlds,
+			deemphasizedTlds,
+		} );
 	}
 
 	const featuredSuggestions: FeaturedSuggestionWithReason[] = [];

--- a/packages/domain-search/src/hooks/use-suggestions-list.ts
+++ b/packages/domain-search/src/hooks/use-suggestions-list.ts
@@ -108,11 +108,13 @@ export const useSuggestionsList = () => {
 				} )
 				.map( ( suggestion ) => suggestion.domain_name ),
 			query,
+			emphasizedTlds: config.emphasizedTlds,
 			deemphasizedTlds: config.deemphasizedTlds,
 		} );
 	}, [
 		suggestions,
 		query,
+		config.emphasizedTlds,
 		config.deemphasizedTlds,
 		availablePremiumDomains,
 		fqdnAvailability,

--- a/packages/domain-search/src/page/context.ts
+++ b/packages/domain-search/src/page/context.ts
@@ -61,6 +61,7 @@ export const DEFAULT_CONTEXT_VALUE: DomainSearchContextType = {
 	config: {
 		vendor: 'variation2_front',
 		skippable: false,
+		emphasizedTlds: [],
 		deemphasizedTlds: [],
 		includeDotBlogSubdomain: false,
 		allowsUsingOwnDomain: false,

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -79,6 +79,7 @@ export interface DomainSearchEvents {
 export interface DomainSearchConfig {
 	vendor: DomainSuggestionQueryVendor;
 	skippable: boolean;
+	emphasizedTlds: string[];
 	deemphasizedTlds: string[];
 	priceRules: PriceRulesConfig;
 	includeDotBlogSubdomain: boolean;


### PR DESCRIPTION
Part of #

## Proposed Changes

* Add an `emphasizedTlds` config to `@automattic/domain-search` that mirrors the existing `deemphasizedTlds`. When non-empty, the partitioner promotes `{query}.com` to the exact-match slot, fills the featured slots (`recommended`, `best-alternative`) from the emphasized list in array order, then orders the regular list as `emphasized → others → deemphasized` (each group ordered by its array).
* Wire the onboarding `/setup/onboarding/domains` step to read `ref` from the URL. When `ref=woo-hosting-solutions-flow`, the step passes Woo-specific TLD lists: emphasized = `shop, store, co, boutique, supply`; deemphasized = `blog, art, ninja, dev, me`.
* Add `WOO_HOSTING_SOLUTIONS_EMPHASIZED_TLDS` and `WOO_HOSTING_SOLUTIONS_DEEMPHASIZED_TLDS` constants next to the existing `WOO_HOSTING_SOLUTIONS_REF` so the policy lives in one place.

When `emphasizedTlds` is empty (every other consumer of the package), `partitionSuggestions` runs the original code path unchanged. All 313 existing package tests pass.

## Why are these changes being made?

Visitors arriving at the onboarding domain search via `?ref=woo-hosting-solutions-flow` are most likely shopping for an e-commerce site name. Today the search treats every TLD equally, so commerce TLDs like `.shop`, `.store`, `.boutique` get no special placement and noisy non-commerce TLDs (`.blog`, `.art`, `.ninja`, `.dev`, `.me`) clutter the visible results. This change re-ranks suggestions client-side so commerce TLDs surface first while preserving `{query}.com` as the top featured result — `.com` remains the safe default we don't want to undersell.

The work is purely client-side reordering. The suggestions API request is unchanged; only TLDs the API already returns can appear.

## Testing Instructions

1. `yarn start`
2. Visit `/setup/onboarding/domains?ref=woo-hosting-solutions-flow` and type `mystore`.
   * **Featured row:** `.com` (exact-match), then `.shop` (recommended), `.store` (best-alternative).
   * **Regular top:** remaining emphasized TLDs in order — `.co`, `.boutique`, `.supply` (subject to API availability).
   * **Regular bottom:** deemphasized TLDs `.blog`, `.art`, `.ninja`, `.dev`, `.me`.
3. Visit `/setup/onboarding/domains` (no `ref`) — expect today's ordering, no regression.
4. Visit `/setup/onboarding/domains?ref=woo-hosting-solutions-flow` and type `mystore.shop` (full FQDN) — expect `mystore.shop` as the lone featured exact-match (literal exact match still wins over emphasis).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?