### PR TITLE
Checkout: share refund-window selection helper

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-summary-refund-windows.tsx
+++ b/client/my-sites/checkout/src/components/checkout-summary-refund-windows.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import { Icon, reusableBlock } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { CheckIcon } from './check-icon';
-import { getRefundPolicies, getRefundWindows, RefundPolicy } from './refund-policies';
+import { getRefundWindowSummary } from './refund-policies';
 import type { TranslateResult } from 'i18n-calypso';
 
 const StyledIcon = styled( Icon )`
@@ -48,89 +48,30 @@ export function CheckoutSummaryRefundWindows( {
 } ) {
 	const translate = useTranslate();
 
-	const refundPolicies = getRefundPolicies( cart );
-	const refundWindows = getRefundWindows( refundPolicies );
-
-	if ( ! refundWindows.length || refundPolicies.includes( RefundPolicy.NonRefundable ) ) {
+	const summary = getRefundWindowSummary( cart );
+	if ( ! summary ) {
 		return null;
 	}
-
-	const allCartItemsAreDomains = refundPolicies.every(
-		( refundPolicy ) =>
-			refundPolicy === RefundPolicy.DomainNameRegistration ||
-			refundPolicy === RefundPolicy.DomainNameRegistrationBundled ||
-			refundPolicy === RefundPolicy.DomainNameRenewal
-	);
-
-	if ( allCartItemsAreDomains ) {
-		return null;
-	}
-
-	const allCartItemsAreMonthlyPlanBundle = refundPolicies.every(
-		( refundPolicy ) =>
-			refundPolicy === RefundPolicy.DomainNameRegistration ||
-			refundPolicy === RefundPolicy.PlanMonthlyBundle
-	);
-
-	const allCartItemsArePlanOrDomainRenewals = refundPolicies.every(
-		( refundPolicy ) =>
-			refundPolicy === RefundPolicy.DomainNameRenewal ||
-			refundPolicy === RefundPolicy.PlanMonthlyRenewal ||
-			refundPolicy === RefundPolicy.PlanYearlyRenewal ||
-			refundPolicy === RefundPolicy.PlanBiennialRenewal
-	);
+	const { days, usePlanProductName } = summary;
 
 	let text: TranslateResult;
-
-	if ( refundWindows.length === 1 ) {
-		const refundWindow = refundWindows[ 0 ];
-		const planBundleRefundPolicy = refundPolicies.find(
-			( refundPolicy ) =>
-				refundPolicy === RefundPolicy.PlanBiennialBundle ||
-				refundPolicy === RefundPolicy.PlanYearlyBundle
-		);
+	if ( usePlanProductName ) {
 		const planProduct = cart.products.find( isPlan );
-
-		if ( planBundleRefundPolicy ) {
-			text = translate(
-				'%(days)d-day money back guarantee for %(product)s',
-				'%(days)d-day money back guarantee for %(product)s',
-				{
-					count: refundWindow,
-					args: {
-						days: refundWindow,
-						product: planProduct?.product_name ?? '',
-					},
-				}
-			);
-		} else {
-			text = translate( '%(days)d-day money back guarantee', '%(days)d-day money back guarantee', {
-				count: refundWindow,
-				args: { days: refundWindow },
-			} );
-		}
-	} else if ( allCartItemsAreMonthlyPlanBundle || allCartItemsArePlanOrDomainRenewals ) {
-		const refundWindow = Math.max( ...refundWindows );
-		const planProduct = cart.products.find( isPlan );
-
 		text = translate(
 			'%(days)d-day money back guarantee for %(product)s',
 			'%(days)d-day money back guarantee for %(product)s',
 			{
-				count: refundWindow,
+				count: days,
 				args: {
-					days: refundWindow,
+					days,
 					product: planProduct?.product_name ?? '',
 				},
 			}
 		);
 	} else {
-		const shortestRefundWindow = Math.min( ...refundWindows );
-
 		text = translate( '%(days)d-day money back guarantee', '%(days)d-day money back guarantee', {
-			count: shortestRefundWindow,
-			args: { days: shortestRefundWindow },
-			comment: 'The number of days until the shortest refund window in the cart expires.',
+			count: days,
+			args: { days },
 		} );
 	}
 

--- a/client/my-sites/checkout/src/components/checkout-summary-refund-windows.tsx
+++ b/client/my-sites/checkout/src/components/checkout-summary-refund-windows.tsx
@@ -72,6 +72,7 @@ export function CheckoutSummaryRefundWindows( {
 		text = translate( '%(days)d-day money back guarantee', '%(days)d-day money back guarantee', {
 			count: days,
 			args: { days },
+			comment: 'The number of days until the shortest refund window in the cart expires.',
 		} );
 	}
 

--- a/client/my-sites/checkout/src/components/checkout-trust-cards.tsx
+++ b/client/my-sites/checkout/src/components/checkout-trust-cards.tsx
@@ -10,7 +10,7 @@ import styled from '@emotion/styled';
 import { Icon } from '@wordpress/components';
 import { reusableBlock, shield, payment } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { getRefundPolicies, getRefundWindows, RefundPolicy } from './refund-policies';
+import { getRefundWindowSummary } from './refund-policies';
 
 const TrustCardsRow = styled.div`
 	display: grid;
@@ -72,55 +72,9 @@ const CardLogos = styled.div`
 	}
 `;
 
-// Mirrors the day-count selection in `CheckoutSummaryRefundWindows`
-// (wp-checkout-order-summary.tsx) so the trust card and sidebar always
-// agree on the headline number — for example, a yearly plan with a
-// separately-purchased domain shows 4 days in both, while an all-renewals
-// cart shows the longer plan window in both.
-function getRefundWindowDays( cart: ResponseCart ): number | null {
-	const refundPolicies = getRefundPolicies( cart );
-	const refundWindows = getRefundWindows( refundPolicies );
-
-	if ( ! refundWindows.length || refundPolicies.includes( RefundPolicy.NonRefundable ) ) {
-		return null;
-	}
-
-	const allCartItemsAreDomains = refundPolicies.every(
-		( refundPolicy ) =>
-			refundPolicy === RefundPolicy.DomainNameRegistration ||
-			refundPolicy === RefundPolicy.DomainNameRegistrationBundled ||
-			refundPolicy === RefundPolicy.DomainNameRenewal
-	);
-	if ( allCartItemsAreDomains ) {
-		return null;
-	}
-
-	if ( refundWindows.length === 1 ) {
-		return refundWindows[ 0 ];
-	}
-
-	const allCartItemsAreMonthlyPlanBundle = refundPolicies.every(
-		( refundPolicy ) =>
-			refundPolicy === RefundPolicy.DomainNameRegistration ||
-			refundPolicy === RefundPolicy.PlanMonthlyBundle
-	);
-	const allCartItemsArePlanOrDomainRenewals = refundPolicies.every(
-		( refundPolicy ) =>
-			refundPolicy === RefundPolicy.DomainNameRenewal ||
-			refundPolicy === RefundPolicy.PlanMonthlyRenewal ||
-			refundPolicy === RefundPolicy.PlanYearlyRenewal ||
-			refundPolicy === RefundPolicy.PlanBiennialRenewal
-	);
-	if ( allCartItemsAreMonthlyPlanBundle || allCartItemsArePlanOrDomainRenewals ) {
-		return Math.max( ...refundWindows );
-	}
-
-	return Math.min( ...refundWindows );
-}
-
 export default function CheckoutTrustCards( { cart }: { cart: ResponseCart } ) {
 	const translate = useTranslate();
-	const refundDays = getRefundWindowDays( cart );
+	const refundDays = getRefundWindowSummary( cart )?.days ?? null;
 
 	return (
 		<TrustCardsRow className="checkout-trust-cards">

--- a/client/my-sites/checkout/src/components/refund-policies.tsx
+++ b/client/my-sites/checkout/src/components/refund-policies.tsx
@@ -236,6 +236,68 @@ export function getRefundWindows( refundPolicies: RefundPolicy[] ): RefundWindow
 	return Array.from( new Set( refundWindows ) ).filter( isValueTruthy );
 }
 
+export type RefundWindowSummary = {
+	days: number;
+	usePlanProductName: boolean;
+};
+
+/**
+ * Picks the headline refund-window day count to surface to the user, plus a
+ * flag indicating whether the headline copy should name the plan product.
+ *
+ * Returns null when no refund window applies (cart is non-refundable, contains
+ * only domains, or has no refund windows). When multiple windows exist, picks
+ * the longest plan window for renewal-only / monthly-bundle carts and the
+ * shortest window otherwise. The product-name flag captures the cases the
+ * sidebar copy uses to render "X-day money back guarantee for %(product)s";
+ * surfaces that don't show the product name (e.g. trust cards) can ignore it.
+ */
+export function getRefundWindowSummary( cart: ResponseCart ): RefundWindowSummary | null {
+	const refundPolicies = getRefundPolicies( cart );
+	const refundWindows = getRefundWindows( refundPolicies );
+
+	if ( ! refundWindows.length || refundPolicies.includes( RefundPolicy.NonRefundable ) ) {
+		return null;
+	}
+
+	const allCartItemsAreDomains = refundPolicies.every(
+		( refundPolicy ) =>
+			refundPolicy === RefundPolicy.DomainNameRegistration ||
+			refundPolicy === RefundPolicy.DomainNameRegistrationBundled ||
+			refundPolicy === RefundPolicy.DomainNameRenewal
+	);
+	if ( allCartItemsAreDomains ) {
+		return null;
+	}
+
+	if ( refundWindows.length === 1 ) {
+		const usePlanProductName = refundPolicies.some(
+			( refundPolicy ) =>
+				refundPolicy === RefundPolicy.PlanBiennialBundle ||
+				refundPolicy === RefundPolicy.PlanYearlyBundle
+		);
+		return { days: refundWindows[ 0 ], usePlanProductName };
+	}
+
+	const allCartItemsAreMonthlyPlanBundle = refundPolicies.every(
+		( refundPolicy ) =>
+			refundPolicy === RefundPolicy.DomainNameRegistration ||
+			refundPolicy === RefundPolicy.PlanMonthlyBundle
+	);
+	const allCartItemsArePlanOrDomainRenewals = refundPolicies.every(
+		( refundPolicy ) =>
+			refundPolicy === RefundPolicy.DomainNameRenewal ||
+			refundPolicy === RefundPolicy.PlanMonthlyRenewal ||
+			refundPolicy === RefundPolicy.PlanYearlyRenewal ||
+			refundPolicy === RefundPolicy.PlanBiennialRenewal
+	);
+	if ( allCartItemsAreMonthlyPlanBundle || allCartItemsArePlanOrDomainRenewals ) {
+		return { days: Math.max( ...refundWindows ), usePlanProductName: true };
+	}
+
+	return { days: Math.min( ...refundWindows ), usePlanProductName: false };
+}
+
 function RefundPolicyItem( {
 	refundPolicy,
 	cart,

--- a/client/my-sites/checkout/src/components/test/refund-policies.ts
+++ b/client/my-sites/checkout/src/components/test/refund-policies.ts
@@ -13,7 +13,12 @@ import {
 	WPCOM_DIFM_LITE,
 } from '@automattic/calypso-products';
 import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
-import { getRefundPolicies, getRefundWindows, RefundPolicy } from '../refund-policies';
+import {
+	getRefundPolicies,
+	getRefundWindows,
+	getRefundWindowSummary,
+	RefundPolicy,
+} from '../refund-policies';
 
 function getPlanAndDomainBundle( planSlug: string ) {
 	const cart = getEmptyResponseCart();
@@ -415,5 +420,154 @@ describe( 'getRefundWindows', () => {
 		const refundWindows = getRefundWindows( [ RefundPolicy.NonRefundable ] );
 
 		expect( refundWindows ).toEqual( [] );
+	} );
+} );
+
+describe( 'getRefundWindowSummary', () => {
+	test( 'returns null for a non-refundable cart (DIFM)', () => {
+		const cart = getEmptyResponseCart();
+		cart.products.push( {
+			...getEmptyResponseCartProduct(),
+			bill_period: '-1',
+			item_subtotal_integer: 500,
+			product_slug: WPCOM_DIFM_LITE,
+		} );
+
+		expect( getRefundWindowSummary( cart ) ).toBeNull();
+	} );
+
+	test( 'returns null for an all-domains cart (paid domain only)', () => {
+		const cart = getEmptyResponseCart();
+		cart.products.push( {
+			...getEmptyResponseCartProduct(),
+			item_subtotal_integer: 10,
+			is_domain_registration: true,
+			meta: 'test.live',
+			product_slug: 'dotlive_domain',
+		} );
+
+		expect( getRefundWindowSummary( cart ) ).toBeNull();
+	} );
+
+	test( 'returns null for an empty / free-domain-only cart (no refund window applies)', () => {
+		const cart = getEmptyResponseCart();
+		cart.products.push( {
+			...getEmptyResponseCartProduct(),
+			is_domain_registration: true,
+			meta: 'free.live',
+			product_slug: 'dotlive_domain',
+		} );
+
+		expect( getRefundWindowSummary( cart ) ).toBeNull();
+	} );
+
+	test( 'yearly plan + bundled domain → 14 days, usePlanProductName true', () => {
+		const cart = getPlanAndDomainBundle( PLAN_PERSONAL );
+
+		expect( getRefundWindowSummary( cart ) ).toEqual( {
+			days: 14,
+			usePlanProductName: true,
+		} );
+	} );
+
+	test( 'biennial plan + bundled domain → 14 days, usePlanProductName true', () => {
+		const cart = getPlanAndDomainBundle( PLAN_PREMIUM_2_YEARS );
+
+		expect( getRefundWindowSummary( cart ) ).toEqual( {
+			days: 14,
+			usePlanProductName: true,
+		} );
+	} );
+
+	test( 'standalone biennial plan → 14 days, usePlanProductName false', () => {
+		const cart = getEmptyResponseCart();
+		cart.products.push( {
+			...getEmptyResponseCartProduct(),
+			bill_period: `${ PLAN_BIENNIAL_PERIOD }`,
+			item_subtotal_integer: 35,
+			product_slug: PLAN_PREMIUM_2_YEARS,
+		} );
+
+		expect( getRefundWindowSummary( cart ) ).toEqual( {
+			days: 14,
+			usePlanProductName: false,
+		} );
+	} );
+
+	test( 'standalone monthly plan → 7 days, usePlanProductName false', () => {
+		const cart = getEmptyResponseCart();
+		cart.products.push( {
+			...getEmptyResponseCartProduct(),
+			bill_period: `${ PLAN_MONTHLY_PERIOD }`,
+			item_subtotal_integer: 10,
+			product_slug: PLAN_PREMIUM_MONTHLY,
+		} );
+
+		expect( getRefundWindowSummary( cart ) ).toEqual( {
+			days: 7,
+			usePlanProductName: false,
+		} );
+	} );
+
+	test( 'monthly plan + bundled paid domain → longest window (7), usePlanProductName true', () => {
+		const cart = getEmptyResponseCart();
+		cart.products.push( {
+			...getEmptyResponseCartProduct(),
+			is_domain_registration: true,
+			item_subtotal_integer: 10,
+			meta: 'test.live',
+			product_slug: 'dotlive_domain',
+		} );
+		cart.products.push( {
+			...getEmptyResponseCartProduct(),
+			bill_period: `${ PLAN_MONTHLY_PERIOD }`,
+			extra: { domain_to_bundle: 'test.live' },
+			item_subtotal_integer: 10,
+			product_slug: PLAN_PREMIUM_MONTHLY,
+		} );
+
+		expect( getRefundWindowSummary( cart ) ).toEqual( {
+			days: 7,
+			usePlanProductName: true,
+		} );
+	} );
+
+	test( 'yearly plan renewal + domain renewal → longest window (14), usePlanProductName true', () => {
+		const cart = getEmptyResponseCart();
+		cart.products.push( {
+			...getEmptyResponseCartProduct(),
+			extra: { purchaseType: 'renewal' },
+			item_subtotal_integer: 10,
+			product_slug: PLAN_PREMIUM,
+		} );
+		cart.products.push( {
+			...getEmptyResponseCartProduct(),
+			extra: { purchaseType: 'renewal' },
+			is_domain_registration: true,
+			item_subtotal_integer: 10,
+			meta: 'test.live',
+			product_slug: 'dotlive_domain',
+		} );
+
+		expect( getRefundWindowSummary( cart ) ).toEqual( {
+			days: 14,
+			usePlanProductName: true,
+		} );
+	} );
+
+	test( 'yearly plan + bundled domain + extra paid domain → shortest window (4), usePlanProductName false', () => {
+		const cart = getPlanAndDomainBundle( PLAN_PERSONAL );
+		cart.products.push( {
+			...getEmptyResponseCartProduct(),
+			item_subtotal_integer: 10,
+			is_domain_registration: true,
+			meta: 'test2.live',
+			product_slug: 'dotlive_domain',
+		} );
+
+		expect( getRefundWindowSummary( cart ) ).toEqual( {
+			days: 4,
+			usePlanProductName: false,
+		} );
 	} );
 } );


### PR DESCRIPTION
Part of #

## Proposed Changes

* Add `getRefundWindowSummary( cart )` to `refund-policies.tsx`. Returns `{ days, usePlanProductName } | null` — the day count to surface, plus a flag indicating whether the headline copy should name the plan product. Encodes all the "which window do we pick" predicates in one place: null on non-refundable / all-domain / no-window carts, longest plan window for renewal-only / monthly-bundle carts, shortest otherwise.
* Drop the mirror `getRefundWindowDays()` function from `CheckoutTrustCards` and call the shared helper. The trust card ignores `usePlanProductName` since its copy is product-agnostic.
* Replace the inline three-branch day-count + predicate logic in `CheckoutSummaryRefundWindows` with the helper. The component now only owns the text-formatting decision (with or without `for %(product)s`), driven by the flag returned from the helper.
* Add unit tests for `getRefundWindowSummary` covering null paths (non-refundable, all-domain, free-domain-only), single-window paths (with and without `usePlanProductName`), the multi-window max branch (monthly-plan-bundle and yearly-renewal carts), and the multi-window min branch (mixed cart with both a plan bundle and an extra paid domain).

No behavior change.

## Why are these changes being made?

The trust card landed with a `getRefundWindowDays()` function whose comment explicitly described it as a mirror of the inline day-count selection in `CheckoutSummaryRefundWindows`. Two surfaces hand-syncing on a refund-policy decision is a real drift risk: if refund rules change (for example, a new `RefundPolicy` enum value, or a new "all-X-renewals" predicate) and only one place is updated, the trust card and the sidebar quietly disagree on the headline number for the same cart.

Centralizing the predicate logic also makes the next refactor cheaper — a future "use the plan product name in trust cards too" change is now a single property toggle, not a three-branch rewrite.

## Merge dependency

This PR is based on `try/cta_always_visibe` (#110099), where `CheckoutSummaryRefundWindows` was already extracted out of `wp-checkout-order-summary.tsx` into its own file. On trunk that extraction has not landed yet, so trunk's `wp-checkout-order-summary.tsx` still contains the old inline `CheckoutSummaryRefundWindows` and imports `getRefundPolicies` / `getRefundWindows` directly. This PR's diff is correct against its base; it is not intended to be cherry-picked onto trunk in isolation. When #110099 merges, the inline trunk version is replaced and this PR sits cleanly on top.

## Testing Instructions

The change is a refactor with no intended behavior difference. To verify the trust card and the sidebar still agree across cart shapes:

1. `yarn test-client client/my-sites/checkout/src/components/test/refund-policies.ts` — should pass (36 tests including 10 new for `getRefundWindowSummary`).
2. `yarn test-client --findRelatedTests client/my-sites/checkout/src/components/refund-policies.tsx client/my-sites/checkout/src/components/checkout-trust-cards.tsx client/my-sites/checkout/src/components/checkout-summary-refund-windows.tsx` — should pass.
3. Walk through checkout for several cart shapes and confirm the refund line in the sidebar and the money-back trust card show the same number of days (or both hide):
   * Single yearly plan only — both show the plan window.
   * Yearly plan + new domain registration — both show 4 days (shortest window).
   * All-renewals cart (plan renewal + domain renewal) — both show the longest plan window.
   * All-domain cart (single domain registration, no plan) — both hide.
   * Non-refundable product (e.g. domain transfer only) — both hide.
4. `yarn typecheck-client` — clean.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?