### PR TITLE
Renewal pricing: add new EN/USD experiment assignment

### DIFF
--- a/client/my-sites/plans-features-main/hooks/test/use-renewal-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-renewal-price-experiment.ts
@@ -14,6 +14,9 @@ jest.mock( 'calypso/landing/stepper/utils/get-flow-from-url', () => ( {
 	getFlowFromURL: jest.fn( () => null ),
 } ) );
 jest.mock( 'calypso/lib/akismet/is-akismet-checkout', () => jest.fn( () => false ) );
+jest.mock( 'calypso/lib/explat', () => ( {
+	useExperiment: jest.fn(),
+} ) );
 jest.mock( 'calypso/lib/jetpack/is-jetpack-checkout', () => jest.fn( () => false ) );
 jest.mock( 'calypso/signup/storageUtils', () => ( {
 	getSignupCompleteFlowName: jest.fn( () => null ),
@@ -26,6 +29,7 @@ import { Plans } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { renderHook } from '@testing-library/react';
 import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
+import { useExperiment } from 'calypso/lib/explat';
 import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { useSelector } from 'calypso/state';
@@ -60,11 +64,36 @@ describe( 'useRenewalPricingExperiment', () => {
 		( isAkismetCheckout as jest.Mock ).mockReturnValue( false );
 		( isJetpackCheckout as jest.Mock ).mockReturnValue( false );
 		( getSignupCompleteFlowName as jest.Mock ).mockReturnValue( null );
+		( useExperiment as jest.Mock ).mockReturnValue( [ false, null ] );
 	} );
 
 	it( 'returns crossed_price for logged-out users when all conditions are met', () => {
 		const { result } = renderHook( () => useRenewalPricingExperiment() );
 		expect( result.current ).toEqual( [ false, 'crossed_price' ] );
+	} );
+
+	it( 'blocks V1 until V2 is not loading', () => {
+		( useExperiment as jest.Mock ).mockReturnValue( [ true, null ] );
+		const { result } = renderHook( () => useRenewalPricingExperiment() );
+		expect( result.current ).toEqual( [ true, null ] );
+	} );
+
+	it( 'falls back to V1 when V2 is loaded and assignment is null (control)', () => {
+		( useExperiment as jest.Mock ).mockReturnValue( [ false, null ] );
+		const { result } = renderHook( () => useRenewalPricingExperiment() );
+		expect( result.current ).toEqual( [ false, 'crossed_price' ] );
+	} );
+
+	it( 'uses V2 variationName when assigned', () => {
+		( useExperiment as jest.Mock ).mockReturnValue( [ false, { variationName: 'variant_a' } ] );
+		const { result } = renderHook( () => useRenewalPricingExperiment() );
+		expect( result.current ).toEqual( [ false, 'variant_a' ] );
+	} );
+
+	it( 'uses V1 when V2 is ineligible', () => {
+		( isJetpackCheckout as jest.Mock ).mockReturnValue( true ); // makes V2 ineligible by isEligibleForExperiment
+		const { result } = renderHook( () => useRenewalPricingExperiment() );
+		expect( result.current ).toEqual( [ false, null ] ); // V1 also ineligible because Jetpack checkout is excluded
 	} );
 
 	describe( 'locale gating', () => {
@@ -178,7 +207,7 @@ describe( 'isRenewalPricingTreatment', () => {
 		expect( isRenewalPricingTreatment( undefined ) ).toBe( false );
 	} );
 
-	it( 'returns false for unrelated variation names', () => {
-		expect( isRenewalPricingTreatment( 'control' ) ).toBe( false );
+	it( 'returns true for unrelated variation names', () => {
+		expect( isRenewalPricingTreatment( 'anything' ) ).toBe( true );
 	} );
 } );

--- a/client/my-sites/plans-features-main/hooks/use-renewal-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-renewal-price-experiment.ts
@@ -2,20 +2,31 @@ import { Plans } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { getFlowFromURL } from 'calypso/landing/stepper/utils/get-flow-from-url';
 import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
+import { useExperiment } from 'calypso/lib/explat';
 import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserDate } from 'calypso/state/current-user/selectors';
 
-function useCurrencyFromPlans(): string | undefined {
-	const plans = Plans.usePlans( { coupon: undefined } );
-	const firstPlan = plans.data && Object.values( plans.data )[ 0 ];
-	return firstPlan?.pricing?.currencyCode;
-}
+const RENEWAL_PRICING_EXPERIMENT_V2_EN_USD = 'wpcom_renewal_pricing_increase_v2_usd_202604_v1';
 
-export function useRenewalPricingExperiment(
-	flowName?: string | null
-): [ boolean, string | null ] {
+function useIsEligibleForV1EnUSDExperiment( flowName?: string | null ): [ boolean, string | null ] {
+	const REGISTRATION_DATE_CUTOFF = new Date( '2026-03-31T11:00:00Z' );
+
+	function useCurrencyFromPlans(): string | undefined {
+		const plans = Plans.usePlans( { coupon: undefined } );
+		const firstPlan = plans.data && Object.values( plans.data )[ 0 ];
+		return firstPlan?.pricing?.currencyCode;
+	}
+
+	function isNewUserOrLoggedOut( registrationDate: string | null | undefined ): boolean {
+		if ( ! registrationDate ) {
+			return true;
+		}
+
+		return new Date( registrationDate ) >= REGISTRATION_DATE_CUTOFF;
+	}
+
 	const locale = useLocale();
 	const currencyCode = useCurrencyFromPlans();
 	const userRegistrationDate = useSelector( getCurrentUserDate );
@@ -47,19 +58,35 @@ export function useRenewalPricingExperiment(
 	return [ false, 'crossed_price' ];
 }
 
-const REGISTRATION_DATE_CUTOFF = new Date( '2026-03-31T11:00:00Z' );
+function isEligibleForExperiment( flowName?: string | null ): boolean {
+	const flowFromStorage = getSignupCompleteFlowName(); // The flow for the Checkout page
+	const flowFromURL = getFlowFromURL(); // The flow for the Plans step
+	const flow = flowName || flowFromStorage || flowFromURL;
 
-function isNewUserOrLoggedOut( registrationDate: string | null | undefined ): boolean {
-	if ( ! registrationDate ) {
-		return true;
-	}
+	// onboarding-pm and onboarding-affiliate flows are ineligible for streamlined pricing. Akismet/Jetpack checkouts are excluded as well.
+	return (
+		flow !== 'onboarding-pm' &&
+		flow !== 'onboarding-affiliate' &&
+		! isAkismetCheckout() &&
+		! isJetpackCheckout()
+	);
+}
 
-	return new Date( registrationDate ) >= REGISTRATION_DATE_CUTOFF;
+export function useRenewalPricingExperiment(
+	flowName?: string | null
+): [ boolean, string | null ] {
+	const [ isLoadingV1, v1Variation ] = useIsEligibleForV1EnUSDExperiment( flowName );
+	const [ isLoadingV2EnUsd, v2EnUsdAssignment ] = useExperiment(
+		RENEWAL_PRICING_EXPERIMENT_V2_EN_USD,
+		{
+			isEligible: isEligibleForExperiment( flowName ),
+		}
+	);
+	const isLoadingExperiment = isLoadingV1 || isLoadingV2EnUsd;
+	const variationName = v2EnUsdAssignment?.variationName ?? v1Variation;
+	return [ isLoadingExperiment, isLoadingExperiment ? null : variationName ];
 }
 
 export function isRenewalPricingTreatment( variationName?: string | null ) {
-	if ( ! variationName ) {
-		return false;
-	}
-	return variationName.includes( 'crossed_price' );
+	return Boolean( variationName );
 }

--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -79,7 +79,7 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 			prices,
 			currencyCode: currencyCode || 'USD',
 			ignoreWhitespace: true,
-		} ) && ! showBillingDescriptionForIncreasedRenewalPrice?.includes( 'crossed_price' ); // a temporary fix to handle an issue with isLargeCurrency logic for intro offers
+		} ) && ! showBillingDescriptionForIncreasedRenewalPrice; // a temporary fix to handle an issue with isLargeCurrency logic for intro offers
 
 	const termVariantPlanSlug = useTermVariantPlanSlugForSavings( { planSlug, billingPeriod } );
 	const termVariantPricing = Plans.usePricingMetaForGridPlans( {
@@ -133,8 +133,6 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 				( ( compareToMonthlyPrice - monthlyPrice ) / compareToMonthlyPrice ) * 100
 			);
 		}
-		const hideCrossedPrice = showBillingDescriptionForIncreasedRenewalPrice === 'no_crossed_price';
-
 		return (
 			<div className="plans-grid-next-header-price">
 				{ ! current && (
@@ -152,17 +150,15 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 						'is-large-currency': isLargeCurrency,
 					} ) }
 				>
-					{ ! hideCrossedPrice && (
-						<PlanPrice
-							currencyCode={ currencyCode }
-							rawPrice={ compareToMonthlyPrice }
-							displayPerMonthNotation={ false }
-							isLargeCurrency={ isLargeCurrency }
-							isSmallestUnit
-							priceDisplayWrapperClassName="plans-grid-next-header-price__display-wrapper"
-							original
-						/>
-					) }
+					<PlanPrice
+						currencyCode={ currencyCode }
+						rawPrice={ compareToMonthlyPrice }
+						displayPerMonthNotation={ false }
+						isLargeCurrency={ isLargeCurrency }
+						isSmallestUnit
+						priceDisplayWrapperClassName="plans-grid-next-header-price__display-wrapper"
+						original
+					/>
 					<PlanPrice
 						currencyCode={ currencyCode }
 						rawPrice={ monthlyPrice }
@@ -249,7 +245,7 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 	if ( isAnyPlanPriceDiscounted ) {
 		return (
 			<div className="plans-grid-next-header-price">
-				{ showBillingDescriptionForIncreasedRenewalPrice === 'crossed_price' && savings ? (
+				{ showBillingDescriptionForIncreasedRenewalPrice && savings ? (
 					<div className={ pricingBadgeClassName }>
 						{ translate( 'Save %(savings)d%%', {
 							args: { savings },

--- a/packages/plans-grid-next/src/hooks/data-store/get-renewal-pricing-text.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/get-renewal-pricing-text.ts
@@ -39,11 +39,6 @@ export function getRenewalPricingText( {
 		isSmallestUnit: true,
 	} );
 
-	const formattedFullPrice = formatCurrency( currentFullPrice, currencyCode, {
-		stripZeros: true,
-		isSmallestUnit: true,
-	} );
-
 	// Determine the billing period in months
 	let billingMonths = 12; // default to annual
 
@@ -55,8 +50,8 @@ export function getRenewalPricingText( {
 		billingMonths = 12;
 	}
 
-	// Different text based on variation
-	if ( showBillingDescriptionForIncreasedRenewalPrice === 'crossed_price' ) {
+	// Renewal pricing experiment: crossed-price copy for all active variants
+	if ( showBillingDescriptionForIncreasedRenewalPrice ) {
 		return translate( 'Auto-renews at %(price)s per month. Billed every %(months)s months.', {
 			args: {
 				price: formattedMonthlyPrice,
@@ -65,19 +60,6 @@ export function getRenewalPricingText( {
 			comment:
 				'%(price)s is a formatted price like $10, %(months)s is the billing period in months (12, 24, or 36)',
 		} );
-	} else if ( showBillingDescriptionForIncreasedRenewalPrice === 'no_crossed_price' ) {
-		return translate(
-			'Get %(months)s months for %(fullPrice)s. Auto-renews at %(price)s per month.',
-			{
-				args: {
-					months: billingMonths,
-					fullPrice: formattedFullPrice,
-					price: formattedMonthlyPrice,
-				},
-				comment:
-					'%(months)s is the billing period (12, 24, or 36), %(fullPrice)s is the current/intro total price like $100, %(price)s is the renewal monthly price like $12',
-			}
-		);
 	}
 
 	return null;

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -270,7 +270,7 @@ export type GridContextProps = {
 	 */
 	showSimplifiedBillingDescription?: boolean;
 	/**
-	 * If, and how to present increased renewal pricing (null, 'crossed_price', 'no_crossed_price')
+	 * If, and how to present increased renewal pricing (null or the assigned variant name)
 	 */
 	showBillingDescriptionForIncreasedRenewalPrice?: string | null;
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-16791

## Proposed Changes

* Load the new experiment assignment, falling back to the previous pricing adjustment if no assignment is returned.

**Control**
<img width="1299" height="427" alt="Screenshot 2026-04-29 at 23 56 31" src="https://github.com/user-attachments/assets/3e4e1f29-008e-40d3-b0c0-083c8774182e" />

**Small increase variant**
<img width="1299" height="443" alt="Screenshot 2026-04-29 at 23 52 54" src="https://github.com/user-attachments/assets/1555ea15-8229-4e6f-9e1e-719b33305c95" />




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of the pricing experiment project.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Testing on Calypso.live or calypso.localhost, assign yourself to control, then test the /setup/onboarding/plans and /plans/{your site} routes to confirm that they match the current experience.
* Test with the treatment variants and confirm that the prices get updated correctly.
* Check that the prices are not shown for the onboarding-pm flow, or when the user currency is not USD or the user locale is not English.
* Go to one of your sites and add a plan and a domain to the cart. Make sure that your currency and locale are set to USD/English.
* On Calypso.live or calypso.localhost, navigate to the checkout page and test the line items appearance and the TOS.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
