### PR TITLE
SCSS: fix sass mixed-decls deprecation by reordering decls before nested rules

### DIFF
--- a/apps/notifications/src/panel/boot/stylesheets/block-user.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/block-user.scss
@@ -2,6 +2,7 @@ div.wpnc__user {
 	@extend %container;
 
 	text-align: left;
+	padding: ($wpnc__padding-large - $wpnc__user-margin-adjustment) $wpnc__padding-medium $wpnc__padding-small;
 
 	img {
 		height: $wpnc__icon-size-detail;
@@ -15,8 +16,6 @@ div.wpnc__user {
 		font-size: 0.85em;
 		margin: 0;
 	}
-
-	padding: ($wpnc__padding-large - $wpnc__user-margin-adjustment) $wpnc__padding-medium $wpnc__padding-small;
 
 	.follow-link {
 		margin-top: -0.1em;

--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -5,6 +5,7 @@ $with-sidebar-min-page-width: 1114px;
 @mixin setToggleNoteBehaviour {
 	.wpnc__list-view.wpnc__current {
 		display: block;
+		box-shadow: none;
 
 		.wpnc__selected-note {
 			animation-name: wpnc__selectIn;
@@ -12,8 +13,6 @@ $with-sidebar-min-page-width: 1114px;
 			animation-duration: 0.4s;
 			animation-iteration-count: 1;
 		}
-
-		box-shadow: none;
 	}
 
 	.wpnc__note-list {
@@ -27,6 +26,12 @@ $with-sidebar-min-page-width: 1114px;
 		top: 0;
 		bottom: 0;
 		z-index: -1;
+		-webkit-transform: translate3d(0, 0, 0); // fix for getting scrollbar in right z-index
+		animation-name: wpnc__slideIn;
+		animation-timing-function: ease-out;
+		animation-fill-mode: forwards;
+		animation-duration: 0.2s;
+		animation-iteration-count: 1;
 
 		header {
 			nav {
@@ -37,13 +42,6 @@ $with-sidebar-min-page-width: 1114px;
 		.wpnc__note {
 			margin-top: 0;
 		}
-
-		-webkit-transform: translate3d(0, 0, 0); // fix for getting scrollbar in right z-index
-		animation-name: wpnc__slideIn;
-		animation-timing-function: ease-out;
-		animation-fill-mode: forwards;
-		animation-duration: 0.2s;
-		animation-iteration-count: 1;
 	}
 }
 
@@ -573,12 +571,12 @@ $with-sidebar-min-page-width: 1114px;
 		left: 0;
 		right: 0;
 		box-shadow: -3px 1px 10px -2px color-mix(in srgb, var(--color-neutral-70) 7.5%, transparent);
+		background-color: var(--color-neutral-0);
 
 		@media only screen and (min-width: 480px) {
 			border-left: 1px solid var(--color-neutral-0);
 		}
 
-		background-color: var(--color-neutral-0);
 		ol {
 			height: 100%;
 			overflow-y: auto;

--- a/bin/check-css-byte-equivalence.js
+++ b/bin/check-css-byte-equivalence.js
@@ -187,7 +187,16 @@ async function compareTargets( baseDir, headDir ) {
 			console.error( `             ${ path.join( diffOutputDirectory, 'head' ) }` );
 			console.error( `  Pretty files: ${ path.join( diffOutputDirectory, 'pretty/base' ) }` );
 			console.error( `                ${ path.join( diffOutputDirectory, 'pretty/head' ) }` );
-			console.error( `  Pretty diff: ${ path.join( diffOutputDirectory, 'pretty.diff' ) }` );
+			console.error(
+				`  Pretty sorted: ${ path.join( diffOutputDirectory, 'pretty-sorted/base' ) }`
+			);
+			console.error(
+				`                 ${ path.join( diffOutputDirectory, 'pretty-sorted/head' ) }`
+			);
+			console.error( `  Pretty diff:        ${ path.join( diffOutputDirectory, 'pretty.diff' ) }` );
+			console.error(
+				`  Pretty-sorted diff: ${ path.join( diffOutputDirectory, 'pretty-sorted.diff' ) }`
+			);
 		}
 
 		return failures.length;
@@ -247,10 +256,14 @@ async function writeDiffOutput( outputDir, baseDir, headDir, failures ) {
 	const headOutputDir = path.join( absoluteOutputDir, 'head' );
 	const prettyBaseOutputDir = path.join( absoluteOutputDir, 'pretty/base' );
 	const prettyHeadOutputDir = path.join( absoluteOutputDir, 'pretty/head' );
+	const prettySortedBaseOutputDir = path.join( absoluteOutputDir, 'pretty-sorted/base' );
+	const prettySortedHeadOutputDir = path.join( absoluteOutputDir, 'pretty-sorted/head' );
 	fs.mkdirSync( baseOutputDir, { recursive: true } );
 	fs.mkdirSync( headOutputDir, { recursive: true } );
 	fs.mkdirSync( prettyBaseOutputDir, { recursive: true } );
 	fs.mkdirSync( prettyHeadOutputDir, { recursive: true } );
+	fs.mkdirSync( prettySortedBaseOutputDir, { recursive: true } );
+	fs.mkdirSync( prettySortedHeadOutputDir, { recursive: true } );
 
 	const manifest = {
 		base: baseRef,
@@ -261,20 +274,31 @@ async function writeDiffOutput( outputDir, baseDir, headDir, failures ) {
 
 	for ( const failure of failures ) {
 		const outputFile = path.join( failure.target, failure.file );
-		const baseFormatError = await copyFailureFile(
+		const baseResult = await copyFailureFile(
 			baseDir,
 			path.join( baseOutputDir, outputFile ),
 			path.join( prettyBaseOutputDir, outputFile ),
+			path.join( prettySortedBaseOutputDir, outputFile ),
 			failure,
 			'base'
 		);
-		const headFormatError = await copyFailureFile(
+		const headResult = await copyFailureFile(
 			headDir,
 			path.join( headOutputDir, outputFile ),
 			path.join( prettyHeadOutputDir, outputFile ),
+			path.join( prettySortedHeadOutputDir, outputFile ),
 			failure,
 			'head'
 		);
+
+		const formatErrors = {
+			...( baseResult.formatError ? { base: baseResult.formatError } : {} ),
+			...( headResult.formatError ? { head: headResult.formatError } : {} ),
+		};
+		const sortErrors = {
+			...( baseResult.sortError ? { base: baseResult.sortError } : {} ),
+			...( headResult.sortError ? { head: headResult.sortError } : {} ),
+		};
 
 		manifest.failures.push( {
 			target: failure.target,
@@ -282,14 +306,8 @@ async function writeDiffOutput( outputDir, baseDir, headDir, failures ) {
 			baseExists: failure.baseExists,
 			headExists: failure.headExists,
 			message: failure.message,
-			...( baseFormatError || headFormatError
-				? {
-						prettyFormatErrors: {
-							...( baseFormatError ? { base: baseFormatError } : {} ),
-							...( headFormatError ? { head: headFormatError } : {} ),
-						},
-				  }
-				: {} ),
+			...( Object.keys( formatErrors ).length ? { prettyFormatErrors: formatErrors } : {} ),
+			...( Object.keys( sortErrors ).length ? { prettySortErrors: sortErrors } : {} ),
 		} );
 	}
 
@@ -304,6 +322,11 @@ async function writeDiffOutput( outputDir, baseDir, headDir, failures ) {
 		prettyHeadOutputDir,
 		path.join( absoluteOutputDir, 'pretty.diff' )
 	);
+	runDiffCommand(
+		prettySortedBaseOutputDir,
+		prettySortedHeadOutputDir,
+		path.join( absoluteOutputDir, 'pretty-sorted.diff' )
+	);
 
 	return absoluteOutputDir;
 }
@@ -316,9 +339,16 @@ function prepareDiffOutputDirectory( directory ) {
 	fs.mkdirSync( directory, { recursive: true } );
 }
 
-async function copyFailureFile( sourceRoot, destination, prettyDestination, failure, side ) {
+async function copyFailureFile(
+	sourceRoot,
+	destination,
+	prettyDestination,
+	prettySortedDestination,
+	failure,
+	side
+) {
 	if ( ! failure[ `${ side }Exists` ] ) {
-		return '';
+		return { formatError: '', sortError: '' };
 	}
 
 	const sourceFile = path.join( sourceRoot, failure.file );
@@ -327,15 +357,30 @@ async function copyFailureFile( sourceRoot, destination, prettyDestination, fail
 
 	const sourceCss = fs.readFileSync( sourceFile, 'utf8' );
 	let prettyCss = sourceCss;
+	let formatError = '';
 
 	try {
 		prettyCss = await formatCss( sourceCss );
 	} catch ( error ) {
 		prettyCss = sourceCss;
-		return writePrettyFile( prettyDestination, prettyCss, error.message );
+		formatError = error.message;
 	}
 
-	return writePrettyFile( prettyDestination, prettyCss );
+	writePrettyFile( prettyDestination, prettyCss );
+
+	let sortedCss = prettyCss;
+	let sortError = '';
+
+	try {
+		sortedCss = sortCssDeclarations( prettyCss );
+	} catch ( error ) {
+		sortedCss = prettyCss;
+		sortError = error.message;
+	}
+
+	writePrettyFile( prettySortedDestination, sortedCss );
+
+	return { formatError, sortError };
 }
 
 async function formatCss( css ) {
@@ -347,11 +392,67 @@ async function formatCss( css ) {
 	} );
 }
 
-function writePrettyFile( destination, css, formatError = '' ) {
+function writePrettyFile( destination, css ) {
 	fs.mkdirSync( path.dirname( destination ), { recursive: true } );
 	fs.writeFileSync( destination, css );
+}
 
-	return formatError;
+function sortCssDeclarations( css ) {
+	const postcss = require( 'postcss' );
+	const root = postcss.parse( css );
+
+	root.walk( ( node ) => {
+		if ( ( node.type === 'rule' || node.type === 'atrule' ) && Array.isArray( node.nodes ) ) {
+			sortDeclRuns( node.nodes );
+		}
+	} );
+
+	return root.toString();
+}
+
+function sortDeclRuns( nodes ) {
+	let runStart = -1;
+
+	for ( let i = 0; i <= nodes.length; i++ ) {
+		const node = nodes[ i ];
+		const isDecl = node && node.type === 'decl';
+
+		if ( isDecl ) {
+			if ( runStart === -1 ) {
+				runStart = i;
+			}
+			continue;
+		}
+
+		if ( runStart !== -1 ) {
+			sortRun( nodes, runStart, i );
+			runStart = -1;
+		}
+	}
+}
+
+function sortRun( nodes, start, end ) {
+	if ( end - start < 2 ) {
+		return;
+	}
+
+	const run = nodes.slice( start, end );
+	run.sort( ( a, b ) => declGroupKey( a.prop ).localeCompare( declGroupKey( b.prop ) ) );
+
+	for ( let i = 0; i < run.length; i++ ) {
+		nodes[ start + i ] = run[ i ];
+	}
+}
+
+function declGroupKey( prop ) {
+	if ( prop.startsWith( '--' ) ) {
+		return prop;
+	}
+
+	const vendorMatch = prop.match( /^-[a-z]+-(.+)$/ );
+	const stripped = vendorMatch ? vendorMatch[ 1 ] : prop;
+
+	return stripped.split( '-' )[ 0 ];
 }
 
 function runDiffCommand( baseOutputDir, headOutputDir, diffFile ) {
@@ -398,9 +499,18 @@ This directory contains only CSS files that failed the byte-equivalence check.
 - \`head/\`: generated CSS from ${ headRef }
 - \`pretty/base/\`: Prettier-formatted generated CSS from ${ baseRef }
 - \`pretty/head/\`: Prettier-formatted generated CSS from ${ headRef }
+- \`pretty-sorted/base/\`: Prettier-formatted CSS from ${ baseRef } with declarations
+  inside each rule body stable-sorted by shorthand-family group key (property
+  name up to the first hyphen, vendor prefixes stripped). An empty
+  \`pretty-sorted.diff\` means every reorder between base and head preserves the
+  cascade — duplicate properties and shorthand/longhand pairs stay in source
+  order within each family.
+- \`pretty-sorted/head/\`: same treatment for ${ headRef }.
 - \`manifest.json\`: metadata for each mismatch
 - \`all.diff\`: unified diff for all copied mismatches
 - \`pretty.diff\`: unified diff for all formatted mismatches
+- \`pretty-sorted.diff\`: unified diff after declaration sort. Use this to
+  confirm cascade equivalence when raw bytes differ.
 
 Open \`pretty/base/\` and \`pretty/head/\` in a directory diff viewer for human review.
 Use \`base/\`, \`head/\`, and \`all.diff\` when you need the exact generated bytes.

--- a/bin/render-stylesheet.js
+++ b/bin/render-stylesheet.js
@@ -64,7 +64,6 @@ try {
 		importers: [ importer ],
 		loadPaths: [ path.join( projectRoot, 'node_modules' ) ],
 		style: 'compressed',
-		silenceDeprecations: [ 'mixed-decls' ],
 		quietDeps: true,
 	} );
 

--- a/client/a8c-for-agencies/components/text-placeholder/style.scss
+++ b/client/a8c-for-agencies/components/text-placeholder/style.scss
@@ -1,8 +1,8 @@
 @import "@wordpress/base-styles/mixins";
 
 .a4a-text-placeholder {
-	@include placeholder( --color-neutral-10 );
-
 	display: block;
 	border-radius: 4px;
+
+	@include placeholder( --color-neutral-10 );
 }

--- a/client/assets/stylesheets/shared/_extends-forms.scss
+++ b/client/assets/stylesheets/shared/_extends-forms.scss
@@ -93,14 +93,18 @@
 }
 
 %form-field-core-styles {
-	box-sizing: border-box;
-	width: 100%;
-	height: $grid-unit-50;
-	border-color: var(--color-neutral-10);
-	font-size: $font-body-small;
-	color: var(--color-neutral-60);
-
 	@include input-control;
+
+	& {
+		// override the input-control mixin's font-size, line-height, border-color,
+		// etc. without triggering the mixed-decls warning that reordering would cause.
+		box-sizing: border-box;
+		width: 100%;
+		height: $grid-unit-50;
+		border-color: var(--color-neutral-10);
+		font-size: $font-body-small;
+		color: var(--color-neutral-60);
+	}
 
 	@include break-small {
 		font-size: $font-body-small;

--- a/client/assets/stylesheets/shared/_extends-forms.scss
+++ b/client/assets/stylesheets/shared/_extends-forms.scss
@@ -93,14 +93,14 @@
 }
 
 %form-field-core-styles {
-	@include input-control;
-
 	box-sizing: border-box;
 	width: 100%;
 	height: $grid-unit-50;
 	border-color: var(--color-neutral-10);
 	font-size: $font-body-small;
 	color: var(--color-neutral-60);
+
+	@include input-control;
 
 	@include break-small {
 		font-size: $font-body-small;

--- a/client/assets/stylesheets/shared/_variables.scss
+++ b/client/assets/stylesheets/shared/_variables.scss
@@ -7,13 +7,13 @@
 	--masterbar-height: 46px;
 	--masterbar-checkout-height: 72px;
 
-	@media only screen and (min-width: 782px) {
-		--masterbar-height: 32px;
-	}
-
 	// Sidebar size limits
 	--sidebar-width-max: 272px;
 	--sidebar-width-min: 228px;
+
+	@media only screen and (min-width: 782px) {
+		--masterbar-height: 32px;
+	}
 }
 
 // =======================

--- a/client/blocks/authentication/form-divider/style.scss
+++ b/client/blocks/authentication/form-divider/style.scss
@@ -76,10 +76,14 @@ $breakpoint-mobile: 660px;
 // In this case we want the separator to be vertical
 .layout:not(.is-grav-powered-client) .is-social-first {
 	.auth-form__separator {
-		width: calc(100% - 32px);
-		margin: 20px 0;
-
 		@include horizontal-separator;
+
+		// stylelint-disable-next-line no-duplicate-selectors
+		& {
+			// override horizontal-separator's width without triggering the mixed-decls warning that reordering would cause.
+			width: calc(100% - 32px);
+			margin: 20px 0;
+		}
 
 		@include break-medium {
 			@include vertical-separator;

--- a/client/blocks/authentication/form-divider/style.scss
+++ b/client/blocks/authentication/form-divider/style.scss
@@ -76,9 +76,10 @@ $breakpoint-mobile: 660px;
 // In this case we want the separator to be vertical
 .layout:not(.is-grav-powered-client) .is-social-first {
 	.auth-form__separator {
-		@include horizontal-separator;
 		width: calc(100% - 32px);
 		margin: 20px 0;
+
+		@include horizontal-separator;
 
 		@include break-medium {
 			@include vertical-separator;

--- a/client/blocks/import/style/base.scss
+++ b/client/blocks/import/style/base.scss
@@ -24,8 +24,9 @@
 	}
 
 	.onboarding-title {
-		@include onboarding-import-heading-text;
 		margin-bottom: rem(12px);
+
+		@include onboarding-import-heading-text;
 	}
 
 	.onboarding-subtitle {
@@ -50,11 +51,12 @@
 	}
 
 	.import__header {
-		@include onboarding-heading-padding;
 		display: flex;
 		flex-direction: column;
 		justify-content: center;
 		align-items: center;
+
+		@include onboarding-heading-padding;
 	}
 
 	.import__heading {

--- a/client/blocks/import/style/base.scss
+++ b/client/blocks/import/style/base.scss
@@ -190,11 +190,11 @@
 
 // Layout
 .import-layout {
-	@include onboarding-block-margin;
-	@include onboarding-heading-padding;
 	display: flex;
 	flex-direction: column;
 	gap: 0 20px;
+	@include onboarding-block-margin;
+	@include onboarding-heading-padding;
 
 	@include break-small {
 		flex-direction: row;

--- a/client/blocks/importer/components/uploading-pane/uploading-pane.scss
+++ b/client/blocks/importer/components/uploading-pane/uploading-pane.scss
@@ -66,13 +66,13 @@
 	color: var(--studio-gray-50);
 
 	.inline-support-link {
-		&:hover {
-			color: var(--studio-gray-100);
-		}
-
 		white-space: pre;
 		text-decoration: underline;
 		color: inherit;
+
+		&:hover {
+			color: var(--studio-gray-100);
+		}
 	}
 }
 

--- a/client/blocks/jitm/templates/modal-style.scss
+++ b/client/blocks/jitm/templates/modal-style.scss
@@ -87,6 +87,8 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 );
 		overflow: visible;
 		margin: 0 auto;
 		z-index: 2;
+		// Temporarily disable dots on mobile as alignment is wonky.
+		display: none;
 
 		&::before {
 			display: inline-block;
@@ -100,8 +102,6 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 );
 			margin-bottom: 0;
 		}
 
-		// Temporarily disable dots on mobile as alignment is wonky.
-		display: none;
 		@media (min-width: $wpcom-modal-breakpoint) {
 			display: block;
 		}

--- a/client/blocks/login/social.scss
+++ b/client/blocks/login/social.scss
@@ -15,6 +15,7 @@
 
 .auth-form__social.is-login {
 	margin-bottom: 0;
+	padding: 16px;
 
 	/**
 	* Social First Logins
@@ -34,8 +35,6 @@
 			}
 		}
 	}
-
-	padding: 16px;
 
 	@include break-mobile {
 		padding: 24px 0;

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -117,8 +117,8 @@ $brand-display: "SF Pro Display", sans-serif;
 
 	.plugins-update-manager-multisite-card {
 		margin-bottom: 1rem;
-		@include content-padding;
 		border-bottom: solid 1px var(--studio-gray-0);
+		@include content-padding;
 
 		&:first-child {
 			border-top: solid 1px var(--studio-gray-0);

--- a/client/blocks/post-likes/style.scss
+++ b/client/blocks/post-likes/style.scss
@@ -59,8 +59,8 @@
 
 		&.is-loading {
 			border-color: transparent;
-			@include placeholder();
 			margin: 5px;
+			@include placeholder();
 		}
 	}
 }

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -800,9 +800,9 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 }
 
 .reader-full-post__story-content-placeholder-text {
-	@include placeholder();
 	margin-bottom: 16px;
 	min-height: 200px;
+	@include placeholder();
 }
 
 .post-edit-button {

--- a/client/blocks/reader-suggested-follows/style.scss
+++ b/client/blocks/reader-suggested-follows/style.scss
@@ -158,10 +158,10 @@
 		padding-bottom: 20px;
 
 		.is-placeholder {
-			@include placeholder();
 			background-color: var(--color-neutral-0);
 			height: 60px;
 			border-radius: 6px;
+			@include placeholder();
 		}
 
 		.is-placeholder.placeholder-title {

--- a/client/blocks/reader-suggested-follows/style.scss
+++ b/client/blocks/reader-suggested-follows/style.scss
@@ -158,10 +158,16 @@
 		padding-bottom: 20px;
 
 		.is-placeholder {
-			background-color: var(--color-neutral-0);
-			height: 60px;
-			border-radius: 6px;
 			@include placeholder();
+
+			// stylelint-disable-next-line no-duplicate-selectors
+			& {
+				// override the placeholder mixin's `background` shorthand without
+				// triggering the mixed-decls warning that reordering would cause.
+				background-color: var(--color-neutral-0);
+				height: 60px;
+				border-radius: 6px;
+			}
 		}
 
 		.is-placeholder.placeholder-title {

--- a/client/blocks/site-address-changer/style.scss
+++ b/client/blocks/site-address-changer/style.scss
@@ -98,11 +98,12 @@
 	margin-bottom: 24px;
 
 	.site-address-changer__message {
+		margin-bottom: 24px;
+
 		@media ( min-width: $break-small ) {
 			display: flex;
 			flex-direction: column;
 		}
-		margin-bottom: 24px;
 	}
 }
 

--- a/client/blocks/support-article-dialog/style.scss
+++ b/client/blocks/support-article-dialog/style.scss
@@ -118,7 +118,7 @@
 }
 
 .support-article-dialog__placeholder-text {
-	@include placeholder();
 	margin-bottom: 16px;
 	min-height: 200px;
+	@include placeholder();
 }

--- a/client/components/activity-card-list/style.scss
+++ b/client/components/activity-card-list/style.scss
@@ -210,17 +210,17 @@
 
 .activity-card-list__loading-placeholder {
 	.filterbar {
-		@include placeholder( --color-neutral-10 );
 		height: 51px;
 		margin-bottom: 2rem;
+		@include placeholder( --color-neutral-10 );
 	}
 
 	.activity-card-list__pagination-top,
 	.activity-card-list__pagination-bottom {
-		@include placeholder( --color-neutral-10 );
 		height: 34px;
 		width: 50%;
 		margin: 0 auto;
+		@include placeholder( --color-neutral-10 );
 
 		&.is-compact {
 			height: 28px;

--- a/client/components/activity-card-list/style.scss
+++ b/client/components/activity-card-list/style.scss
@@ -229,10 +229,10 @@
 
 	.activity-card-list__date-group-date {
 		span {
-			@include placeholder( --color-neutral-10 );
 			font-weight: 600;
 			font-size: 1rem;
 			line-height: 23px;
+			@include placeholder( --color-neutral-10 );
 		}
 	}
 
@@ -249,9 +249,9 @@
 	}
 
 	.card {
-		@include placeholder( --color-neutral-10 );
 		height: 102px;
 		border-left: initial;
+		@include placeholder( --color-neutral-10 );
 
 		&::before {
 			background: transparent;

--- a/client/components/activity-card-list/visible-days-limit-upsell/style.scss
+++ b/client/components/activity-card-list/visible-days-limit-upsell/style.scss
@@ -1,15 +1,15 @@
 .visible-days-limit-upsell__next-activity {
-	@include breakpoint-deprecated( ">660px" ) {
-		height: 80px;
-		padding: initial;
-	}
-
 	// Don't allow any interaction with this element;
 	// it's only for display purposes
 	user-select: none;
 	pointer-events: none;
 
 	mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.8) 0, rgba(0, 0, 0, 0.4) 25%, rgba(0, 0, 0, 0.2) 50%, rgba(0, 0, 0, 0.1) 75%, transparent 100%);
+
+	@include breakpoint-deprecated( ">660px" ) {
+		height: 80px;
+		padding: initial;
+	}
 
 	// This is a placeholder activity card with no information,
 	// and including the time would only disrupt the timeline's

--- a/client/components/advanced-credentials/style.scss
+++ b/client/components/advanced-credentials/style.scss
@@ -2,6 +2,10 @@
 @import "@wordpress/base-styles/mixins";
 
 .advanced-credentials {
+	// remove the margin for everything at smaller widths
+	margin-left: -16px;
+	margin-right: -16px;
+
 	.step-progress {
 		margin-top: 16px;
 		margin-bottom: 16px;
@@ -21,10 +25,6 @@
 			background-color: var(--color-neutral-10);
 		}
 	}
-
-	// remove the margin for everything at smaller widths
-	margin-left: -16px;
-	margin-right: -16px;
 
 	@include break-medium {
 		margin-left: auto;
@@ -63,6 +63,7 @@
 .connection-status__disconnected,
 .connection-status__loading {
 	display: flex;
+	align-items: center;
 	*:not(:first-child) {
 		margin-left: 8px;
 	}
@@ -70,7 +71,6 @@
 		height: 16px;
 		width: 16px;
 	}
-	align-items: center;
 }
 
 .connection-status__failed,
@@ -91,8 +91,8 @@
 
 .connection-status__loading {
 	circle {
-		@include placeholder();
 		fill: var(--color-neutral-5);
+		@include placeholder();
 	}
 	span {
 		color: var(--color-neutral-5);

--- a/client/components/backup-retention-management/loading/style.scss
+++ b/client/components/backup-retention-management/loading/style.scss
@@ -7,10 +7,10 @@
 		padding: 0 16px;
 
 		&__placeholder {
-			@include placeholder();
-
 			width: 100%;
 			height: 186px;
+
+			@include placeholder();
 		}
 	}
 }

--- a/client/components/backup-storage-space/style.scss
+++ b/client/components/backup-storage-space/style.scss
@@ -8,9 +8,9 @@
 	box-shadow: 0 0 0 1px var(--color-neutral-5);
 
 	&__loading {
-		@include placeholder(--color-neutral-10);
 		height: 24px;
 		box-shadow: none;
+		@include placeholder(--color-neutral-10);
 	}
 
 	&__storage-full-icon {

--- a/client/components/blogging-prompt-card/style.scss
+++ b/client/components/blogging-prompt-card/style.scss
@@ -17,11 +17,11 @@
 			flex: 1;
 		}
 		.blogging-prompt__lightbulb-icon {
+			position: relative;
+			top: 1px;
 			path {
 				fill: var(--studio-gray-50);
 			}
-			position: relative;
-			top: 1px;
 		}
 		.blogging-prompt__menu {
 			margin-top: -13px;

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -373,10 +373,10 @@ $y-axis-padding: 0 20px;
 		text-align: left;
 
 		ul {
-			@include clear-fix;
 			list-style: none;
 			margin: 0;
 			padding: 0;
+			@include clear-fix;
 
 			li {
 				font-size: $font-body-extra-small;

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -109,11 +109,11 @@ $date-range-mobile-layout-switch: $break-small;
 	display: flex;
 	justify-content: flex-end;
 	padding: 10px 0 0;
+	margin-top: 10px;
 
 	.components-button {
 		margin-left: 0.5em;
 	}
-	margin-top: 10px;
 
 	@media (max-width: $date-range-mobile-layout-switch) {
 		flex-direction: column-reverse;

--- a/client/components/domains/connect-domain-step/style.scss
+++ b/client/components/domains/connect-domain-step/style.scss
@@ -448,10 +448,10 @@ body.connect-domain-setup__body-white {
 }
 
 button.action_buttons__button.action-buttons__back.connect-domain-step__go-back {
+	margin: 16px 0 16px 16px;
+	text-decoration: none;
+
 	@include breakpoint-deprecated( ">660px" ) {
 		margin: 0 0 18px;
 	}
-
-	margin: 16px 0 16px 16px;
-	text-decoration: none;
 }

--- a/client/components/domains/connect-domain-step/style.scss
+++ b/client/components/domains/connect-domain-step/style.scss
@@ -30,8 +30,8 @@ body.connect-domain-setup__body-white {
 
 	&__sidebar-placeholder {
 		width: 100%;
-		@include placeholder(--color-neutral-5);
 		margin: 0;
+		@include placeholder(--color-neutral-5);
 	}
 
 	&.card {
@@ -84,13 +84,13 @@ body.connect-domain-setup__body-white {
 	}
 
 	&__info-links {
-		& + & {
-			margin-top: 8px;
-		}
-
 		font-size: $font-body-small;
 		color: var(--color-text-subtle);
 		padding: 0 16px;
+
+		& + & {
+			margin-top: 8px;
+		}
 
 		@include break-mobile {
 			padding: 0;
@@ -264,11 +264,11 @@ body.connect-domain-setup__body-white {
 	&__suggested-records {
 		.connect-domain-step__records-list-record {
 			width: 100%;
+			max-width: 100%;
+
 			@include break-mobile {
 				width: 314px;
 			}
-
-			max-width: 100%;
 
 			&-item {
 				width: 100%;

--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -282,14 +282,14 @@ input[type="text"].form-text-input {
 	}
 
 	legend {
+		color: var(--color-neutral-70);
+		margin-bottom: 0;
+		font-size: $font-body;
+
 		small {
 			font-size: $font-body-small;
 			padding-left: 10px;
 			color: var(--color-primary);
 		}
-
-		color: var(--color-neutral-70);
-		margin-bottom: 0;
-		font-size: $font-body;
 	}
 }

--- a/client/components/domains/use-my-domain/style.scss
+++ b/client/components/domains/use-my-domain/style.scss
@@ -121,10 +121,10 @@
 }
 
 button.action_buttons__button.action-buttons__back.use-my-domain__go-back {
+	margin: 16px 0 0 16px;
+	text-decoration: none;
+
 	@include break-mobile {
 		margin: 0 0 18px;
 	}
-
-	margin: 16px 0 0 16px;
-	text-decoration: none;
 }

--- a/client/components/domains/use-my-domain/transfer-or-connect/style.scss
+++ b/client/components/domains/use-my-domain/transfer-or-connect/style.scss
@@ -58,10 +58,10 @@
 }
 
 button.action_buttons__button.action-buttons__back.domain-transfer-or-connect__go-back {
+	margin: 16px 0 0 16px;
+	text-decoration: none;
+
 	@include break-mobile {
 		margin: 0 0 18px;
 	}
-
-	margin: 16px 0 0 16px;
-	text-decoration: none;
 }

--- a/client/components/jetpack/backup-placeholder/style.scss
+++ b/client/components/jetpack/backup-placeholder/style.scss
@@ -1,17 +1,17 @@
 .backup-placeholder {
 	&__backup-date-picker {
-		@include placeholder( --color-neutral-10 );
-
 		height: 32px;
 		margin-bottom: 16px;
 		padding: 16px;
+
+		@include placeholder( --color-neutral-10 );
 	}
 
 	&__daily-backup-status {
-		@include placeholder( --color-neutral-10 );
-
 		height: 208px;
 		padding: 32px;
+
+		@include placeholder( --color-neutral-10 );
 
 		@include breakpoint-deprecated( "<660px" ) {
 			height: 244px;

--- a/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
@@ -88,19 +88,19 @@
 	}
 
 	&__price-placeholder {
-		@include placeholder( --color-neutral-10 );
-
 		width: 80px;
 		height: 54px;
 		margin-bottom: 16px;
 		margin-top: 24px;
+
+		@include placeholder( --color-neutral-10 );
 	}
 
 	&__time-frame-placeholder {
-		@include placeholder( --color-neutral-10 );
-
 		width: 80px;
 		height: 16px;
+
+		@include placeholder( --color-neutral-10 );
 	}
 
 	&__you-save,

--- a/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
@@ -215,8 +215,8 @@
 
 	&.is-placeholder {
 		.plan-price {
-			@include placeholder( --color-neutral-10 );
 			transform: scaleY(0.6);
+			@include placeholder( --color-neutral-10 );
 		}
 		.plan-price::before {
 			border-color: transparent;

--- a/client/components/jetpack/card/jetpack-rna-action-card/style.scss
+++ b/client/components/jetpack/card/jetpack-rna-action-card/style.scss
@@ -60,8 +60,8 @@
 				width: auto;
 			}
 			.is-placeholder & {
-				@include placeholder( --studio-gray-5 );
 				color: transparent !important;
+				@include placeholder( --studio-gray-5 );
 			}
 		}
 	}

--- a/client/components/jetpack/jetpack-product-info/style.scss
+++ b/client/components/jetpack/jetpack-product-info/style.scss
@@ -311,12 +311,11 @@ p.jetpack-product-info__product-list-item-description {
 	font-size: $font-body-small;
 	font-weight: 400;
 	margin-block-end: 0;
+	display: none;
 
 	span {
 		white-space: nowrap;
 	}
-
-	display: none;
 
 	@media (min-width: $break-medium) {
 		display: block;

--- a/client/components/jetpack/jetpack-welcome-page/style.scss
+++ b/client/components/jetpack/jetpack-welcome-page/style.scss
@@ -107,12 +107,13 @@
 				padding: 0 10px 0 16px;
 
 				p {
+					margin: 0;
+
 					@include break-mobile {
 						font-size: $font-body;
 						/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 						line-height: 1.5rem;
 					}
-					margin: 0;
 				}
 			}
 		}

--- a/client/components/jetpack/threat-history-list/style.scss
+++ b/client/components/jetpack/threat-history-list/style.scss
@@ -14,11 +14,11 @@
 
 	&__pagination--top.is-placeholder,
 	&__pagination--bottom.is-placeholder {
-		@include placeholder( --color-neutral-10 );
 		height: 34px;
 		width: 50%;
 		margin-left: auto;
 		margin-right: auto;
+		@include placeholder( --color-neutral-10 );
 
 		&.is-compact {
 			height: 28px;
@@ -31,11 +31,11 @@
 	}
 
 	&__filters.is-placeholder {
-		@include placeholder( --color-neutral-10 );
 		height: 36px;
 		max-width: 230px;
 		margin: 0 auto;
 		border-radius: 2px;
+		@include placeholder( --color-neutral-10 );
 	}
 
 	.segmented-control {

--- a/client/components/language-picker/style.scss
+++ b/client/components/language-picker/style.scss
@@ -25,12 +25,12 @@
 
 	&:not([disabled]) {
 		&:focus {
+			box-shadow: 0 0 0 2px var(--color-primary-10);
+
 			&,
 			.language-picker__icon {
 				border-color: var(--color-primary);
 			}
-
-			box-shadow: 0 0 0 2px var(--color-primary-10);
 
 			&:hover {
 				box-shadow: 0 0 0 2px var(--color-primary-20);

--- a/client/components/legend-item/style.scss
+++ b/client/components/legend-item/style.scss
@@ -41,11 +41,11 @@
 .legend-item__placeholder-title-circle,
 .legend-item__placeholder-detail {
 	@include placeholder();
+	border: 2px solid var(--color-border-inverted);
 
 	&::after {
 		content: "";
 	}
-	border: 2px solid var(--color-border-inverted);
 }
 
 .legend-item__placeholder-detail {

--- a/client/components/legend-item/style.scss
+++ b/client/components/legend-item/style.scss
@@ -40,8 +40,8 @@
 .legend-item__placeholder-title-name,
 .legend-item__placeholder-title-circle,
 .legend-item__placeholder-detail {
-	@include placeholder();
 	border: 2px solid var(--color-border-inverted);
+	@include placeholder();
 
 	&::after {
 		content: "";

--- a/client/components/line-chart/style.scss
+++ b/client/components/line-chart/style.scss
@@ -92,9 +92,8 @@
 }
 
 .line-chart__placeholder {
-	@include placeholder();
-
 	padding-bottom: 50%;
+	@include placeholder();
 }
 
 .line-chart__x-axis,

--- a/client/components/option-content/style.scss
+++ b/client/components/option-content/style.scss
@@ -10,8 +10,8 @@
 		.summary-button-title,
 		.summary-button-badge-list *,
 		.summary-button-decoration {
-			@include placeholder();
 			border-color: transparent;
+			@include placeholder();
 		}
 
 		.option-content__button svg,

--- a/client/components/pie-chart/style.scss
+++ b/client/components/pie-chart/style.scss
@@ -121,6 +121,6 @@
 }
 
 .pie-chart__placeholder-drawing-element {
-	@include placeholder();
 	fill: var(--color-neutral-0);
+	@include placeholder();
 }

--- a/client/components/post-stats-card/style.scss
+++ b/client/components/post-stats-card/style.scss
@@ -73,12 +73,12 @@ $border-radius: 5px; // stylelint-disable-line scales/radii
 	grid-area: post;
 
 	.post-stats-card__post-title {
-		@include stats-section-header;
 		display: block;
 		margin-bottom: 4px;
 		// For loading placeholder
 		min-height: 80px;
-	
+		@include stats-section-header;
+
 		&:visited {
 			color: var(--studio-gray-100);
 		}
@@ -115,8 +115,8 @@ $border-radius: 5px; // stylelint-disable-line scales/radii
 }
 
 .post-stats-card__count-value {
-	@include stats-section-header;
 	color: var(--studio-gray-100);
+	@include stats-section-header;
 }
 
 .post-stats-card__thumbnail,

--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -335,12 +335,12 @@
 // Loading state
 .product-card.is-placeholder .product-card__price-group {
 	&::before {
-		@include placeholder( --color-neutral-10 );
 		content: '\00a0';
 		display: inline-block;
 		width: 150px;
 		height: 32px;
 		margin: 0 0 4px;
+		@include placeholder( --color-neutral-10 );
 
 		@include breakpoint-deprecated( '>660px' ) {
 			height: 18px;

--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -25,9 +25,8 @@
 		.purchase-detail__button,
 		.purchase-detail__description,
 		.purchase-detail__title {
-			@include placeholder( --color-neutral-10 );
-
 			display: block;
+			@include placeholder( --color-neutral-10 );
 		}
 
 		.purchase-detail__button {

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -179,6 +179,8 @@
 		height: 100%;
 		position: relative;
 		font-size: $font-body;
+		padding-left: 8px;
+
 		&::before {
 			@include long-content-fade(
 				$size: 32px,
@@ -198,8 +200,6 @@
 				border-radius: inherit;
 			}
 		}
-
-		padding-left: 8px;
 	}
 }
 

--- a/client/components/section-nav/item.scss
+++ b/client/components/section-nav/item.scss
@@ -181,6 +181,8 @@
 	}
 }
 .section-nav-updated.section-nav {
+	margin-bottom: 0;
+
 	.is-selected.section-nav-tab .section-nav-tab__link .a8c-count {
 		color: var(--color-text);
 	}
@@ -221,7 +223,6 @@
 		border: none;
 		font-weight: normal;
 	}
-	margin-bottom: 0;
 	@include breakpoint-deprecated( ">660px" ) {
 		box-shadow: none;
 	}

--- a/client/components/section-nav/tabs.scss
+++ b/client/components/section-nav/tabs.scss
@@ -64,14 +64,14 @@
 	.section-nav-tabs__list {
 		--direction-start: left;
 		--direction-end: right;
+		--fade-width: 4rem;
+		--fade-gradient-base: transparent 0%, #000 var( --fade-width );
+		--fade-gradient-composed: var( --fade-gradient-base ), #000 60%, transparent 50%;
+
 		&:dir( rtl ) {
 			--direction-start: right;
 			--direction-end: left;
 		}
-
-		--fade-width: 4rem;
-		--fade-gradient-base: transparent 0%, #000 var( --fade-width );
-		--fade-gradient-composed: var( --fade-gradient-base ), #000 60%, transparent 50%;
 
 		&.is-overflowing-first {
 			mask-image: linear-gradient(

--- a/client/components/thank-you-card/style.scss
+++ b/client/components/thank-you-card/style.scss
@@ -61,11 +61,17 @@
 	margin-bottom: 5px;
 
 	&.is-placeholder {
-		background-color: var(--color-success-5);
-		margin-left: auto;
-		margin-right: auto;
-		width: 35%;
 		@include placeholder();
+
+		// stylelint-disable-next-line no-duplicate-selectors
+		& {
+			// override the placeholder mixin's `background` shorthand without
+			// triggering the mixed-decls warning that reordering would cause.
+			background-color: var(--color-success-5);
+			margin-left: auto;
+			margin-right: auto;
+			width: 35%;
+		}
 	}
 }
 

--- a/client/components/thank-you-card/style.scss
+++ b/client/components/thank-you-card/style.scss
@@ -61,12 +61,11 @@
 	margin-bottom: 5px;
 
 	&.is-placeholder {
-		@include placeholder();
-
 		background-color: var(--color-success-5);
 		margin-left: auto;
 		margin-right: auto;
 		width: 35%;
+		@include placeholder();
 	}
 }
 
@@ -108,10 +107,10 @@
 
 .thank-you-card__button.is-placeholder,
 .thank-you-card__button.is-placeholder:visited {
-	@include placeholder();
 	pointer-events: none;
 	border-color: transparent;
 	border-radius: 0;
+	@include placeholder();
 }
 
 .thank-you-card__button:focus {

--- a/client/components/vertical-nav/item/style.scss
+++ b/client/components/vertical-nav/item/style.scss
@@ -19,9 +19,8 @@
 
 .vertical-nav-item.is-placeholder {
 	span {
-		@include placeholder( --color-neutral-10 );
-
 		display: inline-block;
+		@include placeholder( --color-neutral-10 );
 
 		&:first-child {
 			width: 35%;

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -84,6 +84,8 @@
 	}
 
 	.videos-ui__body {
+		max-width: 1280px;
+		padding: 64px 20px 97px;
 
 		&.is-loading {
 			width: 100%;
@@ -110,9 +112,6 @@
 				margin: 0 20px 20px;
 			}
 		}
-
-		max-width: 1280px;
-		padding: 64px 20px 97px;
 
 		h3 {
 			font-size: $font-title-medium;

--- a/client/dashboard/app/_dark-theme.scss
+++ b/client/dashboard/app/_dark-theme.scss
@@ -998,19 +998,19 @@
 
 	@include dashboard-calypso-theme-properties;
 	@include dashboard-color-scheme;
+	@include dashboard-dark-theme-palettes;
+	@include dashboard-dark-theme-dataviews;
 	@include dashboard-dark-theme-action-list;
 	@include dashboard-dark-theme-agenttic;
 	@include dashboard-dark-theme-breadcrumbs;
 	@include dashboard-dark-theme-callout;
 	@include dashboard-dark-theme-card;
-	@include dashboard-dark-theme-dataviews;
 	@include dashboard-dark-theme-destructive-secondary-button;
 	@include dashboard-dark-theme-emails;
 	@include dashboard-dark-theme-form-controls;
 	@include dashboard-dark-theme-item-group;
 	@include dashboard-dark-theme-modal;
 	@include dashboard-dark-theme-muted-text;
-	@include dashboard-dark-theme-palettes;
 	@include dashboard-dark-theme-panel;
 	@include dashboard-dark-theme-plugins;
 	@include dashboard-dark-theme-popover;

--- a/client/dashboard/components/overview-card/style.scss
+++ b/client/dashboard/components/overview-card/style.scss
@@ -31,14 +31,13 @@
 .dashboard-overview-card__content {
 	border-radius: $radius-large;
 	padding: #{$grid-unit-20};
+	// HStacks are width 100% and will try to grow as wide as the card body.
+	// We need to ensure this new padding is included as part of that 100%.
+	box-sizing: border-box;
 
 	@include break-medium {
 		padding: #{$grid-unit-30};
 	}
-
-	// HStacks are width 100% and will try to grow as wide as the card body.
-	// We need to ensure this new padding is included as part of that 100%.
-	box-sizing: border-box;
 }
 
 .dashboard-overview-card--has-bottom {

--- a/client/dashboard/components/page-layout/style.scss
+++ b/client/dashboard/components/page-layout/style.scss
@@ -5,12 +5,6 @@
 .dashboard-page-layout {
 	--page-layout-block-padding: #{$grid-unit-20};
 	--page-layout-inline-padding: #{$grid-unit-20};
-
-	@include break-medium {
-		--page-layout-block-padding: #{$grid-unit-40};
-		--page-layout-inline-padding: #{$grid-unit-30};
-	}
-
 	margin: auto;
 	padding: var( --page-layout-block-padding ) var( --page-layout-inline-padding );
 	max-width: var( --page-layout-max-width );
@@ -19,4 +13,9 @@
 	// be on the PageLayout so that the blurred overlay can cover the entire
 	// PageLayout, including the padding.
 	position: relative;
+
+	@include break-medium {
+		--page-layout-block-padding: #{$grid-unit-40};
+		--page-layout-inline-padding: #{$grid-unit-30};
+	}
 }

--- a/client/dashboard/components/responsive-menu/style.scss
+++ b/client/dashboard/components/responsive-menu/style.scss
@@ -6,12 +6,11 @@
 	overflow-x: scroll;
 	-ms-overflow-style: none;  /* Internet Explorer 10+ */
 	scrollbar-width: none;  /* Firefox */
+	// Restores focus ring appearances
+	padding: 2px;
+	margin: -2px;
 
 	&::-webkit-scrollbar {
 		display: none;  /* Safari and Chrome */
 	}
-
-	// Restores focus ring appearances
-	padding: 2px;
-	margin: -2px;
 }

--- a/client/dashboard/sites/logs-activity/dataviews/style.scss
+++ b/client/dashboard/sites/logs-activity/dataviews/style.scss
@@ -13,6 +13,8 @@
 		margin-top: -100px;
 		z-index: 2;
 		width: auto;
+		// animate the callout when it appears so that it slides down from the top
+		animation: slideDown 0.5s ease-out;
 
 		&::before {
 			content: "";
@@ -25,8 +27,6 @@
 			mask-image: linear-gradient( 180deg, transparent 1.13%, #000 17.26% );
 		}
 
-		// animate the callout when it appears so that it slides down from the top
-		animation: slideDown 0.5s ease-out;
 		@keyframes slideDown {
 			from {
 				transform: translateY( -20px );

--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -40,16 +40,15 @@ a:has(.devdocs__title) {
 		font-size: $font-body;
 		color: var(--color-text);
 		margin-top: 4px;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		overflow: hidden;
 
 		mark {
 			background: color-mix(in srgb, var(--color-primary-light) 40%, transparent);
 			padding: 2px;
 			border-radius: 2px;
 		}
-
-		text-overflow: ellipsis;
-		white-space: nowrap;
-		overflow: hidden;
 	}
 }
 

--- a/client/jetpack-cloud/components/sidebar/header/style.scss
+++ b/client/jetpack-cloud/components/sidebar/header/style.scss
@@ -23,11 +23,6 @@ html.accessible-focus .jetpack-cloud-sidebar__profile-dropdown-button:focus {
 }
 
 .jetpack-cloud-sidebar__profile-dropdown-menu {
-	// Required for older browsers
-	&[hidden] {
-		display: none;
-	}
-
 	position: absolute;
 	// 4px below the bottom of the icon
 	top: calc(100% + 4px);
@@ -35,9 +30,6 @@ html.accessible-focus .jetpack-cloud-sidebar__profile-dropdown-button:focus {
 	// Float the dropdown to the left on small screens,
 	// and to the right on larger screens
 	right: 0;
-	@include breakpoint-deprecated( ">660px" ) {
-		right: initial;
-	}
 
 	// The menu should render "on top" of the profile picture & site switcher
 	z-index: 20;
@@ -55,6 +47,15 @@ html.accessible-focus .jetpack-cloud-sidebar__profile-dropdown-button:focus {
 	list-style-type: none;
 
 	font-size: $font-body-small;
+
+	// Required for older browsers
+	&[hidden] {
+		display: none;
+	}
+
+	@include breakpoint-deprecated( ">660px" ) {
+		right: initial;
+	}
 }
 
 .jetpack-cloud-sidebar__profile-dropdown-menu-item {

--- a/client/jetpack-cloud/sections/partner-portal/text-placeholder/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/text-placeholder/style.scss
@@ -1,7 +1,6 @@
 @import "@wordpress/base-styles/mixins";
 
 .partner-portal-text-placeholder {
-	@include placeholder( --color-neutral-10 );
-
 	display: block;
+	@include placeholder( --color-neutral-10 );
 }

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
@@ -68,6 +68,17 @@ $delay: 0.055s;
 		left: auto !important;
 		right: 0;
 		transform: none !important;
+		position: absolute;
+		top: calc( 100% + 16px );
+		min-width: 160px;
+		padding: 0.5rem 1rem;
+		background-color: var( --studio-white );
+		border-radius: 3px;
+		box-shadow:
+			-1px -1px 2px rgba( 0, 0, 0, 0.15 ),
+			1px 1px 2px rgba( 0, 0, 0, 0.15 );
+		font-size: 0.875rem;
+		text-align: center;
 
 		&::after {
 			display: none !important;
@@ -81,17 +92,6 @@ $delay: 0.055s;
 			border-bottom-color: var( --studio-white );
 			transform: translateX( -50% );
 		}
-		position: absolute;
-		top: calc( 100% + 16px );
-		min-width: 160px;
-		padding: 0.5rem 1rem;
-		background-color: var( --studio-white );
-		border-radius: 3px;
-		box-shadow:
-			-1px -1px 2px rgba( 0, 0, 0, 0.15 ),
-			1px 1px 2px rgba( 0, 0, 0, 0.15 );
-		font-size: 0.875rem;
-		text-align: center;
 	}
 
 	.header__submenu-content {

--- a/client/jetpack-cloud/sections/settings/loading/style.scss
+++ b/client/jetpack-cloud/sections/settings/loading/style.scss
@@ -5,9 +5,8 @@
 	padding: 0 16px;
 
 	&__placeholder {
-		@include placeholder();
-
 		width: 100%;
 		height: 186px;
+		@include placeholder();
 	}
 }

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -928,8 +928,14 @@ body:not( .is-jetpack-sso-partner-branded--woo ) {
 }
 
 .jetpack-connect__sso-placeholder {
-	background-color: transparent;
 	@include placeholder( --color-neutral-10 );
+
+	// stylelint-disable-next-line no-duplicate-selectors
+	& {
+		// override the placeholder mixin's `background` shorthand without
+		// triggering the mixed-decls warning that reordering would cause.
+		background-color: transparent;
+	}
 }
 
 .jetpack-connect__sso-placeholder a {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -928,8 +928,8 @@ body:not( .is-jetpack-sso-partner-branded--woo ) {
 }
 
 .jetpack-connect__sso-placeholder {
-	@include placeholder( --color-neutral-10 );
 	background-color: transparent;
+	@include placeholder( --color-neutral-10 );
 }
 
 .jetpack-connect__sso-placeholder a {
@@ -976,6 +976,9 @@ body:not( .is-jetpack-sso-partner-branded--woo ) {
 }
 
 .jetpack-connect__sso-partner-branded-email-notice {
+	width: 100%;
+	margin-bottom: 0;
+
 	&,
 	* {
 		all: revert-layer;
@@ -989,9 +992,6 @@ body:not( .is-jetpack-sso-partner-branded--woo ) {
 	:where( a, button, .components-button ):focus-visible {
 		all: revert-layer;
 	}
-
-	width: 100%;
-	margin-bottom: 0;
 }
 
 .jetpack-connect__sso-partner-branded-actions {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -819,8 +819,8 @@ body:not( .is-jetpack-sso-partner-branded--woo ) {
 }
 
 .jetpack-connect__sso-placeholder {
-	@include placeholder( --color-neutral-10 );
 	background-color: transparent;
+	@include placeholder( --color-neutral-10 );
 }
 
 .jetpack-connect__sso-placeholder a {
@@ -867,6 +867,9 @@ body:not( .is-jetpack-sso-partner-branded--woo ) {
 }
 
 .jetpack-connect__sso-partner-branded-email-notice {
+	width: 100%;
+	margin-bottom: 0;
+
 	&,
 	* {
 		all: revert-layer;
@@ -880,9 +883,6 @@ body:not( .is-jetpack-sso-partner-branded--woo ) {
 	:where( a, button, .components-button ):focus-visible {
 		all: revert-layer;
 	}
-
-	width: 100%;
-	margin-bottom: 0;
 }
 
 .jetpack-connect__sso-partner-branded-actions {

--- a/client/landing/domains/content-card/style.scss
+++ b/client/landing/domains/content-card/style.scss
@@ -50,11 +50,11 @@
 
 	&.content-card__loading-placeholder {
 		.content-card__illustration {
-			@include placeholder( --color-neutral-10 );
 			width: 400px;
 			height: 250px;
 			margin-left: auto;
 			margin-right: auto;
+			@include placeholder( --color-neutral-10 );
 
 			@include breakpoint-deprecated( "<480px" ) {
 				display: none;
@@ -62,17 +62,17 @@
 		}
 
 		.content-card__message {
-			@include placeholder( --color-neutral-10 );
 			height: 24px;
 			margin: 0 auto 10px;
 			width: 50%;
+			@include placeholder( --color-neutral-10 );
 		}
 
 		.content-card__footer {
-			@include placeholder( --color-neutral-10 );
 			height: 20px;
 			margin: 40px auto;
 			width: 70%;
+			@include placeholder( --color-neutral-10 );
 		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -103,6 +103,14 @@ button {
 .create-site:not(:has(.step-container-v2)) {
 	box-sizing: border-box;
 
+	// WordPress.org components no longer use blue-50 as the primary color.
+	// This changes the primary color to blue-50 to conform to the WordPress.com colors.
+	--color-accent: var(--studio-wordpress-blue-50);
+	--color-accent-60: var(--studio-wordpress-blue-60);
+	--wp-components-color-accent-darker-10: var(--studio-wordpress-blue-60);
+	--wp-components-color-accent-darker-20: var(--studio-wordpress-blue-70);
+	--wp-components-color-accent: var(--studio-wordpress-blue-50);
+
 	.wpcom-loading__boot {
 		margin-top: 32vh;
 	}
@@ -215,14 +223,6 @@ button {
 			}
 		}
 	}
-
-	// WordPress.org components no longer use blue-50 as the primary color.
-	// This changes the primary color to blue-50 to conform to the WordPress.com colors.
-	--color-accent: var(--studio-wordpress-blue-50);
-	--color-accent-60: var(--studio-wordpress-blue-60);
-	--wp-components-color-accent-darker-10: var(--studio-wordpress-blue-60);
-	--wp-components-color-accent-darker-20: var(--studio-wordpress-blue-70);
-	--wp-components-color-accent: var(--studio-wordpress-blue-50);
 
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-confirm/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-confirm/style.scss
@@ -30,14 +30,14 @@ body.is-section-stepper {
 				}
 
 				.formatted-header__subtitle {
+					margin-top: 20px;
+					text-align: inherit;
+					max-width: 448px;
+
 					@media (max-width: 660px) {
 						margin-top: 8px;
 						padding: 0 10px 0 0;
 					}
-
-					margin-top: 20px;
-					text-align: inherit;
-					max-width: 448px;
 				}
 			}
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/survey/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/survey/style.scss
@@ -82,9 +82,6 @@
 	.survey-notice__popup {
 		view-transition-name: survey-notice-popup;
 		animation: slide-in 0.3s ease-out both 0.1s;
-		@media (prefers-reduced-motion) {
-			animation: reduced-motion-slide-in 0.5s ease-in-out both 0.7s;
-		}
 		position: absolute;
 		right: 25px;
 		bottom: 25px;
@@ -97,6 +94,10 @@
 			0 3px 8px 0 rgba(0, 0, 0, 0.12);
 		overflow: hidden;
 		background-color: var(--studio-white);
+
+		@media (prefers-reduced-motion) {
+			animation: reduced-motion-slide-in 0.5s ease-in-out both 0.7s;
+		}
 	}
 
 	.survey-notice__popup-head {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/design-choice.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/design-choice.scss
@@ -7,6 +7,11 @@
 	flex-direction: column;
 	width: 100%;
 	align-items: center;
+	padding: 36px 36px 60px;
+	border-radius: 4px;
+	outline: var(--studio-gray-5) solid 1px;
+	transition: outline ease-in 0.15s;
+	cursor: pointer;
 
 	@include break-small {
 		max-width: 380px;
@@ -15,12 +20,6 @@
 	@include break-medium {
 		align-self: stretch;
 	}
-
-	padding: 36px 36px 60px;
-	border-radius: 4px;
-	outline: var(--studio-gray-5) solid 1px;
-	transition: outline ease-in 0.15s;
-	cursor: pointer;
 
 	.design-choice__title {
 		margin-bottom: 16px;
@@ -45,13 +44,12 @@
 	.design-choice__image-container {
 		display: flex;
 		position: relative; // Allows the price badge to be positioned absolutely
+		min-height: 226px;
+		transition: transform ease-in 0.15s;
 
 		@include break-small {
 			max-width: 308px;
 		}
-
-		min-height: 226px;
-		transition: transform ease-in 0.15s;
 	}
 
 	&:hover,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -662,15 +662,15 @@ $container-padding-large: 48px;
 }
 
 .step-container-v2--design-picker-preview {
+	display: flex;
+	flex: 1;
+	min-height: 0;
+
 	@include break-large {
 		// TODO: Remove this customization once we introduce the FixedColumnOnTheLeftLayout wireframe.
 		margin-block: calc(var(--step-container-v2-content-block-padding) * -1);
 		max-height: calc(100vh - var(--step-container-v2-top-bar-height));
 	}
-
-	display: flex;
-	flex: 1;
-	min-height: 0;
 
 	&__header-design-title {
 		.design-picker-design-title__container {
@@ -708,13 +708,13 @@ $container-padding-large: 48px;
 		}
 
 		@include break-large {
-			.navigator-screen__footer {
-				display: flex;
-			}
-
 			flex: 1;
 			height: auto;
 			gap: 48px;
+
+			.navigator-screen__footer {
+				display: flex;
+			}
 
 			.design-preview__sidebar {
 				padding-top: 24px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -134,6 +134,11 @@
 		}
 
 		@media (max-width: $break-medium) {
+			gap: 0;
+			justify-content: flex-start;
+			margin-top: 24px;
+			width: 100%;
+
 			.step-container__header {
 				width: 100%;
 				margin-top: 48px;
@@ -143,11 +148,6 @@
 					text-align: left;
 				}
 			}
-
-			gap: 0;
-			justify-content: flex-start;
-			margin-top: 24px;
-			width: 100%;
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
@@ -32,15 +32,15 @@ $heading-font-family: "SF Pro Display", $sans;
 		padding: 0;
 
 		@media (max-width: $break-medium) {
-			header {
-				text-align: center;
-			}
-
 			flex-direction: column;
 			gap: 0;
 			justify-content: flex-start;
 			padding-left: 20px;
 			padding-right: 20px;
+
+			header {
+				text-align: center;
+			}
 		}
 
 		.step-container.intro {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-setup/styles.scss
@@ -12,6 +12,7 @@
 			@include primary-button-black-theme;
 		}
 		.formatted-header {
+			margin: 32px 16px;
 			.formatted-header__title {
 				font-size: rem(32px);
 				@include break-small {
@@ -21,7 +22,6 @@
 			@include break-small {
 				margin-top: 72px;
 			}
-			margin: 32px 16px;
 		}
 		.setup-form__form{
 			margin: 0 auto;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-site-picker/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-site-picker/styles.scss
@@ -5,13 +5,13 @@
 .hundred-year-plan-site-picker {
 	.step-container__content {
 		.formatted-header {
+			margin: 32px 24px 0 24px;
 			.formatted-header__title {
 				font-size: rem(32px);
 				@include break-small {
 					font-size: rem(44px);
 				}
 			}
-			margin: 32px 24px 0 24px;
 			@include break-small {
 				margin-top: 72px;
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/style.scss
@@ -31,8 +31,8 @@
 			}
 
 			.is-price-loading {
-				@include onboarding-placeholder;
 				width: 100px;
+				@include onboarding-placeholder;
 			}
 		}
 
@@ -48,8 +48,8 @@
 
 			.hundred-year-plan-step-wrapper__info-column-container {
 				.is-price-loading {
-					@include onboarding-placeholder;
 					width: 100px;
+					@include onboarding-placeholder;
 				}
 			}
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/styles.scss
@@ -17,13 +17,13 @@
 
 .hundred-year-plan-step-wrapper.new-or-existing-site {
 	.formatted-header {
+		margin: 32px 24px 0 24px;
 		.formatted-header__title {
 			font-size: rem(32px);
 			@include break-small {
 				font-size: rem(44px);
 			}
 		}
-		margin: 32px 24px 0 24px;
 		@include break-small {
 			margin-top: 72px;
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-fallback-credentials/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-fallback-credentials/style.scss
@@ -27,12 +27,12 @@ $blueberry-color: #3858e9;
 
 	.site-migration-credentials__content,
 	.site-migration-credentials__error-banner {
+		max-width: 400px;
+		margin: auto;
+
 		@media (min-width: $break-mobile) {
 			margin-bottom: 16px;
 		}
-
-		max-width: 400px;
-		margin: auto;
 
 		hr {
 			margin-top: 1em;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/style.scss
@@ -3,8 +3,8 @@
 @import "@automattic/onboarding/styles/mixins";
 
 .how-to-migrate {
-	@include onboarding-block-margin;
 	max-width: 620px;
+	@include onboarding-block-margin;
 
 	@media ( min-width: $break-medium ) {
 		margin-left: auto;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/style.scss
@@ -75,8 +75,8 @@
 }
 
 .import__capture-wrapper {
-	@include onboarding-block-margin;
 	margin-bottom: 60px;
+	@include onboarding-block-margin;
 
 	@media (min-width: $break-small) {
 		margin-bottom: 0;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/style.scss
@@ -3,8 +3,8 @@
 @import "@automattic/onboarding/styles/mixins";
 
 .import-or-migrate {
-	@include onboarding-block-margin;
 	max-width: 502px;
+	@include onboarding-block-margin;
 
 	@media ( min-width: $break-mobile ) {
 		margin-left: auto;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/provision-status/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/provision-status/style.scss
@@ -37,11 +37,11 @@
 }
 
 .migration-instructions-provisioning__action-icon-error {
+	fill: var(--color-error);
+
 	> svg {
 		display: block;
 	}
-
-	fill: var(--color-error);
 }
 
 .migration-instructions-provisioning__action-text {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/style.scss
@@ -9,9 +9,8 @@
 }
 
 :root .site-migration-upgrade-plan {
-	@include onboarding-block-margin;
-
 	padding-bottom: 5rem;
+	@include onboarding-block-margin;
 
 	@media ( min-width: 1040px ) {
 		padding-bottom: 3rem;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/style.scss
@@ -11,10 +11,11 @@
 		}
 	}
 	.step-container.subscribers {
+		padding: 0 1.5rem;
+
 		.subscribers {
 			padding-top: 0;
 		}
-		padding: 0 1.5rem;
 
 		.add-subscriber__title-container,
 		.add-subscriber__form--container {

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -42,10 +42,10 @@ $brand-text: "SF Pro Text", $sans;
 	}
 
 	.sidebar__body {
-		@include custom-scrollbars-on-hover(transparent, $gray-600);
 		flex: 1;
 		overflow-y: auto;
 		padding-top: 16px;
+		@include custom-scrollbars-on-hover(transparent, $gray-600);
 
 		.sidebar,
 		.sidebar__menu:not(.is-togglable) {

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -13,14 +13,14 @@ $masterbar-color-secondary: #101517;
 
 // Hide the masterbar on WP Mobile App views.
 body.is-mobile-app-view {
-	.masterbar {
-		display: none;
-	}
 	/* We are ignoring these lines because without the px value the calc function does not work as expected */
 	/* stylelint-disable-next-line length-zero-no-unit */
 	--masterbar-checkout-height: 0px;
 	/* stylelint-disable-next-line length-zero-no-unit */
 	--masterbar-height: 0px;
+	.masterbar {
+		display: none;
+	}
 }
 
 // The WordPress.com Masterbar

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -126,15 +126,14 @@
 	display: flex;
 	align-items: center;
 	text-decoration: none;
+	// I think this is some voodoo to change the color
+	// of a link when tapped on iOS.
+	-webkit-tap-highlight-color: color-mix(in srgb, var(--color-neutral-700) 20%, transparent);
 
 	&,
 	&:visited {
 		color: var(--color-sidebar-text);
 	}
-
-	// I think this is some voodoo to change the color
-	// of a link when tapped on iOS.
-	-webkit-tap-highlight-color: color-mix(in srgb, var(--color-neutral-700) 20%, transparent);
 
 	&:hover {
 		background-color: var(--color-sidebar-menu-hover-background);

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -41,7 +41,6 @@ body.is-focus-sites {
 // Setup the content element to adapt to the sidebar,
 // lack of sidebar, or the WebPreview component.
 .layout__content {
-	@include clear-fix;
 	position: relative;
 	margin: 0;
 
@@ -51,6 +50,7 @@ body.is-focus-sites {
 		calc( var( --sidebar-width-max ) + 32px + 1px );
 	box-sizing: border-box;
 	overflow: hidden;
+	@include clear-fix;
 
 	// Various screens dont use a sidebar.
 	.has-no-sidebar & {

--- a/client/me/purchases/billing-history/style.scss
+++ b/client/me/purchases/billing-history/style.scss
@@ -245,8 +245,8 @@ li.billing-history__receipt-item-discount--different-term {
 
 		.billing-history__placeholder-image,
 		.billing-history__placeholder-title {
-			@include placeholder();
 			height: 65px;
+			@include placeholder();
 		}
 
 		.billing-history__placeholder-image {
@@ -265,8 +265,8 @@ li.billing-history__receipt-item-discount--different-term {
 		padding: 0 40px 10px;
 
 		.billing-history__placeholder-link {
-			@include placeholder();
 			margin-bottom: 12px;
+			@include placeholder();
 
 			&:last-child {
 				margin-bottom: 0;

--- a/client/me/purchases/components/loading-placeholder/style.scss
+++ b/client/me/purchases/components/loading-placeholder/style.scss
@@ -2,9 +2,9 @@
 	button.form-button,
 	input[type="text"].form-text-input,
 	select.form-select {
-		@include placeholder( --color-neutral-10 );
 		cursor: default;
 		pointer-events: none;
+		@include placeholder( --color-neutral-10 );
 	}
 }
 

--- a/client/me/purchases/downgrade/style.scss
+++ b/client/me/purchases/downgrade/style.scss
@@ -135,8 +135,8 @@
 	.downgrade__feature,
 	.downgrade__settings-link,
 	.downgrade__confirm-buttons div{
-		@include placeholder( --color-neutral-10 );
 		display: block;
+		@include placeholder( --color-neutral-10 );
 	}
 
 	.downgrade__plan-icon {

--- a/client/me/purchases/manage-purchase/plan-details/style.scss
+++ b/client/me/purchases/manage-purchase/plan-details/style.scss
@@ -8,9 +8,8 @@
 .plan-details__wrapper.is-placeholder {
 	.section-header__label-text,
 	.plan-details__plugin-key {
-		@include placeholder( --color-neutral-10 );
-
 		display: block;
+		@include placeholder( --color-neutral-10 );
 	}
 
 	.section-header__label-text {

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -63,9 +63,8 @@
 		.manage-purchase__settings-link,
 		.manage-purchase__detail-label,
 		.manage-purchase__detail {
-			@include placeholder( --color-neutral-10 );
-
 			display: block;
+			@include placeholder( --color-neutral-10 );
 		}
 
 		.manage-purchase__plan-icon {
@@ -487,10 +486,10 @@
 	}
 
 	&.loading {
-		@include placeholder( --color-neutral-20 );
 		padding: 0.5rem;
 		margin: 0 16px;
 		width: 200px;
+		@include placeholder( --color-neutral-20 );
 	}
 }
 

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -6,12 +6,11 @@
 
 	padding-inline-start: calc( var( --icon-size ) * 2.5 );
 	padding-inline-end: var( --icon-size );
+	color: var( --color-text-subtle );
 
 	@include breakpoint-deprecated( '>660px' ) {
 		--icon-size: 24px;
 	}
-
-	color: var( --color-text-subtle );
 
 	.card__icon {
 		position: absolute;

--- a/client/me/purchases/payment-methods/style.scss
+++ b/client/me/purchases/payment-methods/style.scss
@@ -230,12 +230,12 @@ $card_width: $font-body * 3.75; // roughly 60px wide
 	&__warning {
 		display: flex;
 		gap: 8px;
-		.gridicon {
-			fill: var( --color-warning );
-		}
 		border: 1px solid var(--color-warning);
 		padding: 8px;
 		border-radius: 4px;
+		.gridicon {
+			fill: var( --color-warning );
+		}
 
 		p {
 			color: var( --color-warning );

--- a/client/me/site-blocks/style.scss
+++ b/client/me/site-blocks/style.scss
@@ -16,8 +16,8 @@
 }
 
 .site-blocks__list-item-placeholder-text {
-	@include placeholder();
 	padding-right: 150px;
+	@include placeholder();
 }
 
 .site-blocks__remove-button {

--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -179,9 +179,9 @@
 }
 
 .type-selector__activity-types-selection-placeholder {
-	@include placeholder();
 	height: 24px;
 	margin: 16px 0;
+	@include placeholder();
 }
 
 .filterbar__date-range-selection-info,

--- a/client/my-sites/backup/clone-flow/suggestion-search/style.scss
+++ b/client/my-sites/backup/clone-flow/suggestion-search/style.scss
@@ -36,8 +36,8 @@
 	margin: 0 auto;
 
 	&__placeholder {
-		@include placeholder();
 		width: 100%;
 		height: 89px;
+		@include placeholder();
 	}
 }

--- a/client/my-sites/backup/rewind-flow/style.scss
+++ b/client/my-sites/backup/rewind-flow/style.scss
@@ -51,15 +51,15 @@
 }
 
 .rewind-flow__icon-placeholder {
-	@include placeholder( --color-neutral-light );
 	height: 48px;
 	width: 48px;
+	@include placeholder( --color-neutral-light );
 }
 
 .rewind-flow__title-placeholder {
-	@include placeholder( --color-neutral-light );
 	font-size: $font-title-small;
 	font-weight: 600;
+	@include placeholder( --color-neutral-light );
 }
 
 .rewind-flow__rewind-config-editor {

--- a/client/my-sites/checkout/checkout-thank-you/gift/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/gift/style.scss
@@ -32,11 +32,11 @@
 
 	.thank-you__container-header {
 		padding-top: 50px;
+		min-height: 0;
+		padding-bottom: 0;
 		@media screen and (max-width: 782px) {
 			padding-top: 30px;
 		}
-		min-height: 0;
-		padding-bottom: 0;
 		img {
 			margin-bottom: 32px;
 		}

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -903,10 +903,10 @@ main.akismet-checkout-thank-you {
 		}
 
 		&.loading {
-			@include placeholder( --color-neutral-20 );
 			padding: 0.5rem;
 			margin: 0 16px;
 			width: 200px;
+			@include placeholder( --color-neutral-20 );
 		}
 	}
 

--- a/client/my-sites/checkout/purchase-modal/style.scss
+++ b/client/my-sites/checkout/purchase-modal/style.scss
@@ -39,12 +39,12 @@ $left-margin: 36px;
 
 .purchase-modal__wrapper {
 	display: block;
-	.has-feature-list & {
-		display: flex;
-	}
 	width: 100%;
 	flex-direction: column;
 	gap: 12px;
+	.has-feature-list & {
+		display: flex;
+	}
 	@include break-medium {
 		gap: 36px;
 		flex-direction: row;

--- a/client/my-sites/checkout/purchase-modal/style.scss
+++ b/client/my-sites/checkout/purchase-modal/style.scss
@@ -120,8 +120,8 @@ $left-margin: 36px;
 	}
 
 	&.is-placeholder {
-		@include placeholder();
 		width: 20em;
+		@include placeholder();
 	}
 }
 
@@ -130,9 +130,9 @@ $left-margin: 36px;
 	font-size: $font-body-small;
 
 	&.is-placeholder {
-		@include placeholder();
 		margin-top: 2px;
 		width: 15em;
+		@include placeholder();
 	}
 }
 
@@ -220,13 +220,13 @@ $left-margin: 36px;
 
 	&.is-placeholder {
 		> dt {
-			@include placeholder();
 			width: 8em;
+			@include placeholder();
 		}
 
 		> dd {
-			@include placeholder();
 			width: 5em;
+			@include placeholder();
 		}
 	}
 }
@@ -255,8 +255,8 @@ $left-margin: 36px;
 	}
 
 	&.is-placeholder {
-		@include placeholder();
 		height: 2rem;
+		@include placeholder();
 	}
 }
 

--- a/client/my-sites/customer-home/cards/features/help-search/style.scss
+++ b/client/my-sites/customer-home/cards/features/help-search/style.scss
@@ -15,6 +15,8 @@ $min_results_height: 180px;
 	padding: 16px;
 	border-bottom-left-radius: 3px;
 	border-bottom-right-radius: 3px;
+	box-shadow: none;
+	border-bottom: 1px solid var( --color-border-subtle );
 
 	p {
 		margin: 0;
@@ -25,9 +27,6 @@ $min_results_height: 180px;
 	button {
 		flex-shrink: 0;
 	}
-
-	box-shadow: none;
-	border-bottom: 1px solid var( --color-border-subtle );
 
 	@include break-mobile {
 		box-shadow: 0 0 0 1px var( --color-border-subtle );

--- a/client/my-sites/customer-home/cards/features/quick-start/style.scss
+++ b/client/my-sites/customer-home/cards/features/quick-start/style.scss
@@ -18,7 +18,7 @@
 }
 
 .quick-start__placeholder {
-	@include placeholder();
 	width: 100px;
 	max-width: 80%;
+	@include placeholder();
 }

--- a/client/my-sites/domains/domain-management/components/domain/main-placeholder.scss
+++ b/client/my-sites/domains/domain-management/components/domain/main-placeholder.scss
@@ -11,8 +11,8 @@
 
 .domain__main-placeholder-card {
 	p {
-		@include placeholder( --color-neutral-10 );
 		margin-bottom: 0.5em;
+		@include placeholder( --color-neutral-10 );
 
 		&:first-child {
 			width: 35%;

--- a/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize.scss
+++ b/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize.scss
@@ -21,11 +21,10 @@
 
 	.domain-connect__is-placeholder {
 		span {
-			@include placeholder( --color-neutral-10 );
-
 			display: block;
 			margin: 0.8em 0;
 			height: 1em;
+			@include placeholder( --color-neutral-10 );
 
 			&:last-child {
 				width: 30%;

--- a/client/my-sites/domains/domain-management/settings/cards/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/style.scss
@@ -168,6 +168,8 @@
 		}
 
 		.form-text-input-with-affixes__prefix {
+			padding: 0;
+			border: 0 !important;
 
 			.form-select {
 				border-bottom: 0;
@@ -176,9 +178,6 @@
 					border-bottom: 1px solid var(--color-neutral-10);
 				}
 			}
-
-			padding: 0;
-			border: 0 !important;
 		}
 
 		.form-text-input-with-affixes__suffix {

--- a/client/my-sites/domains/domain-management/settings/style.scss
+++ b/client/my-sites/domains/domain-management/settings/style.scss
@@ -165,10 +165,10 @@ body:not(.is-global).edit__body-white.theme-default.color-scheme {
 
 .domain-settings-page {
 	.name-servers-card__loading {
-		@include placeholder();
 		display: block;
 		margin-top: 4px;
 		margin-bottom: 0;
+		@include placeholder();
 	}
 
 	.set-as-primary__notice {

--- a/client/my-sites/earn/components/add-edit-coupon-modal/style.scss
+++ b/client/my-sites/earn/components/add-edit-coupon-modal/style.scss
@@ -79,10 +79,10 @@
 }
 
 .memberships__dialog-sections-coupon-boolean {
+	margin-bottom: 16px;
 	.components-base-control {
 		margin-bottom: 0 !important;
 	}
-	margin-bottom: 16px;
 	label {
 		padding: 3px;
 	}

--- a/client/my-sites/email/email-management/home/email-plan-subscription/style.scss
+++ b/client/my-sites/email/email-management/home/email-plan-subscription/style.scss
@@ -12,10 +12,10 @@
 
 	&.email-plan-subscription__placeholder {
 		div {
-			@include placeholder( --color-neutral-5 );
 			margin: 0 auto;
 			width: 150px;
 			height: 28px;
+			@include placeholder( --color-neutral-5 );
 		}
 	}
 

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -323,8 +323,8 @@
 
 	&.is-placeholder>span,
 	&.is-placeholder .email-plan-mailboxes-list__mailbox-list-item-main {
-		@include placeholder(--color-neutral-5);
 		width: 50%;
+		@include placeholder(--color-neutral-5);
 	}
 
 	&.no-emails>span {

--- a/client/my-sites/google-my-business/location/style.scss
+++ b/client/my-sites/google-my-business/location/style.scss
@@ -12,16 +12,16 @@
 
 	&.is-loading {
 		.gmb-location__name {
-			@include placeholder();
 			height: 25px;
 			width: 150px;
 			margin: 5px;
+			@include placeholder();
 		}
 		.gmb-location__address {
-			@include placeholder();
 			height: 80px;
 			width: 200px;
 			margin: 5px;
+			@include placeholder();
 		}
 	}
 }

--- a/client/my-sites/importer/newsletter/style.scss
+++ b/client/my-sites/importer/newsletter/style.scss
@@ -210,6 +210,6 @@ $newsletter_importer_line-height: 20px;
 }
 
 .importer-loading .is-loading {
-	@include placeholder( --color-neutral-10 );
 	margin-bottom: 0;
+	@include placeholder( --color-neutral-10 );
 }

--- a/client/my-sites/invites/invite-accept-logged-out/style.scss
+++ b/client/my-sites/invites/invite-accept-logged-out/style.scss
@@ -3,12 +3,12 @@
 
 $font-sf-pro-text: 'SF Pro Text', $sans;
 body.is-section-accept-invite {
+	background: #fdfdfd;
 	.logged-out-wp-logo {
 		position: absolute;
 		left: 24px;
 		top: 24px;
 	}
-	background: #fdfdfd;
 	.invite-accept {
 		padding-top: 50px;
 		height: calc( 100vh - 100px );

--- a/client/my-sites/patterns/components/header/style.scss
+++ b/client/my-sites/patterns/components/header/style.scss
@@ -7,7 +7,6 @@
 	background: #1d2327;
 
 	.patterns-header__inner {
-		@include patterns-page-width;
 		padding-top: 105px;
 		padding-bottom: 64px;
 		background-image: url(./images/background@3x.webp);
@@ -15,6 +14,7 @@
 		background-position: 87% top;
 		background-size: 45% auto;
 		color: var(--studio-white);
+		@include patterns-page-width;
 
 		h1 {
 			font-family: $font-recoleta;

--- a/client/my-sites/patterns/components/pattern-library/style.scss
+++ b/client/my-sites/patterns/components/pattern-library/style.scss
@@ -18,10 +18,10 @@
 	}
 
 	.pattern-library__filters-inner {
-		@include patterns-page-width;
 		padding-top: 32px;
 		padding-bottom: 32px;
 		display: flex;
+		@include patterns-page-width;
 	}
 
 	.category-pill-navigation {
@@ -115,8 +115,8 @@
 }
 
 .pattern-library {
-	@include patterns-page-width;
 	padding-bottom: 96px;
+	@include patterns-page-width;
 
 	@media (max-width: $break-xlarge) {
 		padding-top: 24px;

--- a/client/my-sites/patterns/components/readymade-templates/style.scss
+++ b/client/my-sites/patterns/components/readymade-templates/style.scss
@@ -8,6 +8,8 @@
 	scroll-padding-left: 24px;
 	padding-left: calc((100vw - 1440px) / 2 + 102px);
 	padding-right: 24px;
+	/* Hide scrollbar */
+	scrollbar-width: none; // Chrome, Edge, Firefox
 
 	@media (max-width: $break-wide) {
 		padding-left: 24px;
@@ -19,8 +21,6 @@
 		padding-bottom: 0;
 	}
 
-	/* Hide scrollbar */
-	scrollbar-width: none; // Chrome, Edge, Firefox
 	&::-webkit-scrollbar {
 		display: none; // Safari
 	}

--- a/client/my-sites/patterns/components/section/style.scss
+++ b/client/my-sites/patterns/components/section/style.scss
@@ -46,8 +46,8 @@
 }
 
 .patterns-section__premium-badge {
-	@include patterns-page-width;
 	margin-bottom: 10px;
+	@include patterns-page-width;
 	.premium-badge {
 		margin-left: 0;
 		background-color: #50575e;
@@ -55,8 +55,8 @@
 }
 
 .patterns-section__header {
-	@include patterns-page-width;
 	padding-bottom: 48px;
+	@include patterns-page-width;
 
 	@media (max-width: $break-wide) {
 		padding-bottom: 32px;

--- a/client/my-sites/people/people-list-item/style.scss
+++ b/client/my-sites/people/people-list-item/style.scss
@@ -53,6 +53,7 @@
 	align-self: center;
 	flex-shrink: 0;
 	position: relative;
+	color: var(--color-success);
 
 	&:not(.is-invite-details) {
 		// Get out of the way of the link to the invite details page
@@ -71,8 +72,6 @@
 			margin-left: 80px;
 		}
 	}
-
-	color: var(--color-success);
 
 	&.is-pending {
 		color: var(--color-text-subtle);

--- a/client/my-sites/people/people-profile/style.scss
+++ b/client/my-sites/people/people-profile/style.scss
@@ -72,8 +72,8 @@
 }
 
 .people-profile__badges {
-	@include clear-fix;
 	margin-top: 8px;
+	@include clear-fix;
 }
 
 .people-profile__subscribed {

--- a/client/my-sites/plans/current-plan/my-plan-card/style.scss
+++ b/client/my-sites/plans/current-plan/my-plan-card/style.scss
@@ -25,13 +25,13 @@
 	flex: 1;
 
 	.is-placeholder &::before {
-		@include placeholder( --color-neutral-10 );
 		content: "\00a0";
 		display: inline-block;
 		width: 100%;
 		height: calc(100% - 16px);
 		min-height: 70px;
 		margin-bottom: 16px;
+		@include placeholder( --color-neutral-10 );
 
 		@include breakpoint-deprecated( ">960px" ) {
 			height: 100%;
@@ -81,12 +81,12 @@
 		}
 
 		&::before {
-			@include placeholder( --color-neutral-10 );
 			content: "\00a0";
 			display: inline-block;
 			width: 64px;
 			height: 64px;
 			border-radius: 99%;
+			@include placeholder( --color-neutral-10 );
 		}
 	}
 }
@@ -148,11 +148,11 @@
 	}
 
 	.is-placeholder &::before {
-		@include placeholder( --color-neutral-10 );
 		content: "\00a0";
 		display: inline-block;
 		width: 180px;
 		height: 18px;
+		@include placeholder( --color-neutral-10 );
 	}
 }
 
@@ -165,11 +165,11 @@
 	}
 
 	.is-placeholder &::before {
-		@include placeholder( --color-neutral-10 );
 		content: "\00a0";
 		display: inline-block;
 		width: 110px;
 		height: 29px;
+		@include placeholder( --color-neutral-10 );
 	}
 
 	.button ~ .button {

--- a/client/my-sites/plans/current-plan/style.scss
+++ b/client/my-sites/plans/current-plan/style.scss
@@ -83,9 +83,8 @@
 
 	.current-plan__header-heading,
 	.current-plan__header-text {
-		@include placeholder( --color-neutral-10 );
-
 		display: block;
+		@include placeholder( --color-neutral-10 );
 
 		@include breakpoint-deprecated( "<660px" ) {
 			margin: 0 auto;

--- a/client/my-sites/plans/current-plan/trials/trial-current-plan.scss
+++ b/client/my-sites/plans/current-plan/trials/trial-current-plan.scss
@@ -204,10 +204,10 @@ body.is-section-plans.is-business-trial-plan {
 			margin-top: 30px;
 
 			@media (max-width: $break-mobile) {
+				margin-top: 12px;
 				.feature-not-included-card__text {
 					font-size: $woo-font-body-extra-small;
 				}
-				margin-top: 12px;
 			}
 		}
 

--- a/client/my-sites/plans/doughnut-chart/style.scss
+++ b/client/my-sites/plans/doughnut-chart/style.scss
@@ -1,19 +1,7 @@
 .doughnut-chart__wrapper {
-
-	// percentage (0 to 100)
-	@property --percentage {
-		syntax: "<number>";
-		inherits: true;
-		initial-value: 0;
-	}
 	--width: 80px;
 	--line-width: 9px;
 	--main-color: var(--color-accent);
-
-	&.blue {
-		--main-color: var(--studio-blue-60);
-	}
-
 	background-color: var(--color-surface);
 	width: var(--width);
 	aspect-ratio: 1;
@@ -26,6 +14,17 @@
 	box-shadow:
 		inset 0 0 0 var(--line-width) color-mix(in srgb, var(--main-color) 10%, transparent),
 		inset 0 0 0 10px var(--color-surface);
+
+	// percentage (0 to 100)
+	@property --percentage {
+		syntax: "<number>";
+		inherits: true;
+		initial-value: 0;
+	}
+
+	&.blue {
+		--main-color: var(--studio-blue-60);
+	}
 
 	&::before,
 	&::after {

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
@@ -53,11 +53,11 @@
 	}
 
 	.form-radio:focus {
+		box-shadow: none;
+
 		&:hover {
 			box-shadow: none;
 		}
-
-		box-shadow: none;
 	}
 }
 

--- a/client/my-sites/plans/trials/trial-banner/style.scss
+++ b/client/my-sites/plans/trials/trial-banner/style.scss
@@ -58,13 +58,13 @@
 	}
 
 	.trial-banner__chart-wrapper {
-		@media (max-width: $break-mobile) {
-			display: none;
-		}
-
 		margin-left: 50px;
 		padding: 0;
 		text-align: center;
+
+		@media (max-width: $break-mobile) {
+			display: none;
+		}
 
 		.trial-banner__chart-label {
 			color: var(--color-neutral);

--- a/client/my-sites/plans/woo-express-plans-page/style.scss
+++ b/client/my-sites/plans/woo-express-plans-page/style.scss
@@ -199,13 +199,13 @@ body.is-section-plans.is-woo-express-plan {
 		}
 
 		.woo-express-plans-page__bottom-banner-img-wrapper {
-			@media (max-width: $break-mobile) {
-				display: none;
-			}
-
 			margin-left: 50px;
 			padding: 0 20px;
 			text-align: center;
+
+			@media (max-width: $break-mobile) {
+				display: none;
+			}
 
 			.woo-express-plans-page__bottom-banner-img {
 				width: 166px;

--- a/client/my-sites/plugins/plugin-details-header/style.scss
+++ b/client/my-sites/plugins/plugin-details-header/style.scss
@@ -26,17 +26,17 @@ $rating-star-color: #ffb514;
 	}
 
 	.plugin-details-header__icon {
+		border-radius: 4px;
+		margin-bottom: 15px;
+		width: $mobile-icon-height;
+		height: $mobile-icon-height;
+		flex-shrink: 0;
 		@include break-mobile {
 			width: 72px;
 			height: 72px;
 			margin-right: 20px;
 			margin-bottom: 0;
 		}
-		border-radius: 4px;
-		margin-bottom: 15px;
-		width: $mobile-icon-height;
-		height: $mobile-icon-height;
-		flex-shrink: 0;
 	}
 
 	.full-width-section & {

--- a/client/my-sites/plugins/plugin-management-v2/plugin-action-status/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-action-status/style.scss
@@ -31,9 +31,6 @@
 	color: #00450c;
 	/* reference busy state from https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/button/style.scss */
 	animation: plugin-action-status-inProgress__busy-animation 2500ms infinite linear;
-	@media (prefers-reduced-motion: reduce) {
-		animation-duration: 0s;
-	}
 	background-size: 100px 100%;
 	background-image: linear-gradient(
 	-45deg,
@@ -42,6 +39,9 @@
 		darken( #b8e6bf, 12%) 70%,
 		darken( #b8e6bf, 2%) 70%
 	);
+	@media (prefers-reduced-motion: reduce) {
+		animation-duration: 0s;
+	}
 }
 
 @keyframes plugin-action-status-inProgress__busy-animation {

--- a/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-table/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-table/style.scss
@@ -4,13 +4,13 @@
 
 .plugin-common-table__table {
 	display: none;
-	@include break-xlarge() {
-		display: table;
-	}
 	border: 1px solid var(--studio-gray-5);
 	border-left: none;
 	border-right: none;
 	border-collapse: collapse;
+	@include break-xlarge() {
+		display: table;
+	}
 	tr {
 		height: 1px;
 		background: var(--studio-white);

--- a/client/my-sites/plugins/plugin-sections/style.scss
+++ b/client/my-sites/plugins/plugin-sections/style.scss
@@ -1,4 +1,13 @@
 .plugin-sections__content {
+	position: relative;
+	font-family: $sans;
+	font-size: $font-body;
+	font-weight: 400;
+	line-height: 21px;
+	word-wrap: break-word;
+	hyphens: auto;
+	margin-bottom: 32px;
+
 	h1,
 	h2,
 	h3,
@@ -52,15 +61,6 @@
 		margin: 32px 0;
 		display: block;
 	}
-
-	position: relative;
-	font-family: $sans;
-	font-size: $font-body;
-	font-weight: 400;
-	line-height: 21px;
-	word-wrap: break-word;
-	hyphens: auto;
-	margin-bottom: 32px;
 }
 
 .plugin-sections__header + .plugin-sections__content {

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -116,22 +116,22 @@
 		}
 
 		@include break-medium {
+			width: calc(50% - 9px); // 2 column grid with 18px gutter
 			// select first row for a 2 column grid
 			&:first-of-type,
 			&:nth-of-type(2) {
 				margin-top: 24px;
 			}
-			width: calc(50% - 9px); // 2 column grid with 18px gutter
 		}
 
 		@include break-wide {
+			width: calc(33% - 10px); // 3 column grid with 20px gutter
 			// select first row for a 3 column grid
 			&:first-of-type,
 			&:nth-of-type(2),
 			&:nth-of-type(3) {
 				margin-top: 24px;
 			}
-			width: calc(33% - 10px); // 3 column grid with 20px gutter
 		}
 
 		.full-width-section & {

--- a/client/my-sites/plugins/search-box-header/style.scss
+++ b/client/my-sites/plugins/search-box-header/style.scss
@@ -35,12 +35,11 @@
 				margin: 0 auto;
 				border-radius: 4px;
 				padding-right: 10px;
+				box-shadow: 0 0 0 1px var(--studio-gray-10);
 
 				&.is-expanded-to-container {
 					height: 100%;
 				}
-
-				box-shadow: 0 0 0 1px var(--studio-gray-10);
 
 				.search-component__icon-navigation:focus {
 					box-shadow: none;
@@ -121,6 +120,11 @@
 			text-align: center;
 
 			.search-box-header__recommended-searches-list-item {
+				color: var(--studio-gray-100);
+				font-size: $font-body-small;
+				line-height: 22px;
+				text-align: center;
+
 				&::after {
 					content: ",";
 					display: inline-block;
@@ -143,11 +147,6 @@
 				&:not(.search-box-header__recommended-searches-list-item-selected) {
 					text-decoration: underline;
 				}
-
-				color: var(--studio-gray-100);
-				font-size: $font-body-small;
-				line-height: 22px;
-				text-align: center;
 			}
 		}
 	}

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -256,10 +256,6 @@ $layout-padding-top: 54px;
 $calypso-header-height: 31px;
 .plugin-details__layout {
 	padding-top: $layout-padding-top;
-	&:not( .is-logged-in ) {
-		padding-top: calc( $layout-padding-top - $calypso-header-height );
-	}
-
 	@include display-grid;
 	grid-template-columns: minmax( 380px, auto ) minmax( auto, 395px );
 	grid-column-gap: 60px;
@@ -267,6 +263,10 @@ $calypso-header-height: 31px;
 		'header actions'
 		'content actions';
 	grid-auto-rows: auto 1fr;
+
+	&:not( .is-logged-in ) {
+		padding-top: calc( $layout-padding-top - $calypso-header-height );
+	}
 
 	@include breakpoint-deprecated( '<960px' ) {
 		grid-template-areas:

--- a/client/my-sites/plugins/woocommerce-box.scss
+++ b/client/my-sites/plugins/woocommerce-box.scss
@@ -44,10 +44,6 @@ $c-gray-100: #101517 !default;
 .woocommerce-error,
 .post-theme-info,
 .wcpv-shortcode-registration-form-errors {
-
-	* {
-		vertical-align: baseline;
-	}
 	background: $c-woocommerce-purple-5;
 	border: 1px solid $c-woocommerce-purple-10;
 	border-left-width: 1px !important;
@@ -55,6 +51,10 @@ $c-gray-100: #101517 !default;
 	color: $c-woocommerce-purple-90;
 	margin: 2em 0;
 	padding: 20px;
+
+	* {
+		vertical-align: baseline;
+	}
 
 	p {
 		margin: 0 0 1.618em;

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -196,6 +196,8 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 	}
 
 	.campaign-item-details__notice {
+		margin-bottom: 64px;
+
 		.calypso-notice__content {
 			line-height: 26px;
 			.calypso-notice__text {
@@ -203,8 +205,6 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 				padding-right: 16px;
 			}
 		}
-		margin-bottom: 64px;
-
 	}
 
 	.campaign-item-details__wrapper {

--- a/client/my-sites/promote-post-i2/components/campaigns-table/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaigns-table/style.scss
@@ -156,12 +156,12 @@ $font-sf-pro-text: "SF Pro Text", $sans;
 			height: 16px;
 			border-radius: 4px;
 			margin-top: 8px;
+			@include blazepress-animated-skeleton;
+
 			&.campaign-item__skeleton-text2 {
 				width: 97px;
 				margin-top: 12px;
 			}
-
-			@include blazepress-animated-skeleton;
 		}
 	}
 

--- a/client/my-sites/promote-post-i2/components/campaigns-table/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaigns-table/style.scss
@@ -49,6 +49,15 @@ $font-sf-pro-text: "SF Pro Text", $sans;
 	}
 
 	.campaign-item {
+		font-family: $font-sf-pro-text;
+		font-style: normal;
+		font-weight: 400;
+		font-size: 0.875rem;
+		line-height: 20px;
+		letter-spacing: -0.15px;
+		color: #50575e;
+		padding-bottom: 8px;
+
 		&__data,
 		&__user,
 		&__status,
@@ -113,15 +122,6 @@ $font-sf-pro-text: "SF Pro Text", $sans;
 
 			@include blazepress-animated-skeleton;
 		}
-
-		font-family: $font-sf-pro-text;
-		font-style: normal;
-		font-weight: 400;
-		font-size: 0.875rem;
-		line-height: 20px;
-		letter-spacing: -0.15px;
-		color: #50575e;
-		padding-bottom: 8px;
 	}
 
 	tr {

--- a/client/my-sites/promote-post-i2/style.scss
+++ b/client/my-sites/promote-post-i2/style.scss
@@ -160,14 +160,14 @@ body.is-section-promote-post-i2 {
 
 						@media screen and (max-width: $break-medium) {
 							overflow: auto;
+							/* Hide scrollbar for IE, Edge and Firefox */
+							-ms-overflow-style: none; /* IE and Edge */
+							scrollbar-width: none; /* Firefox */
 
 							/* Hide scrollbar for Chrome, Safari and Opera */
 							&::-webkit-scrollbar {
 								display: none;
 							}
-							/* Hide scrollbar for IE, Edge and Firefox */
-							-ms-overflow-style: none; /* IE and Edge */
-							scrollbar-width: none; /* Firefox */
 						}
 					}
 

--- a/client/my-sites/stats/components/highlight-cards/style.scss
+++ b/client/my-sites/stats/components/highlight-cards/style.scss
@@ -51,11 +51,10 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 }
 
 .highlight-cards-heading {
-	@include stats-section-header;
-
 	margin-bottom: $header-margin-bottom;
 	display: flex;
 	align-items: center;
+	@include stats-section-header;
 
 	small {
 		font-family: $highlight-card-heading-font;
@@ -83,11 +82,11 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 	// Add horizontal scrolling, but without the scrollbar.
 	overflow-x: scroll;
 	scrollbar-width: none;
+	padding: 1px; // Ensures scrollable content box doesn't cover the highlight card.
+
 	&::-webkit-scrollbar {
 		display: none;
 	}
-
-	padding: 1px; // Ensures scrollable content box doesn't cover the highlight card.
 
 	.highlight-card {
 		border-color: var(--studio-gray-5);

--- a/client/my-sites/stats/post-detail-highlights-section/style.scss
+++ b/client/my-sites/stats/post-detail-highlights-section/style.scss
@@ -4,12 +4,13 @@
 @import "@wordpress/base-styles/mixins";
 
 .stats__post-detail-highlights-section {
-	@include break-small {
-		// padding-bottom: $vertical-margin;
-	}
 	padding-top: $vertical-margin;
 
 	padding-bottom: $vertical-margin;
+
+	@include break-small {
+		// padding-bottom: $vertical-margin;
+	}
 
 	.stats > & {
 		@media (max-width: $break-small) {

--- a/client/my-sites/stats/post-detail-table-section/style.scss
+++ b/client/my-sites/stats/post-detail-table-section/style.scss
@@ -75,11 +75,11 @@ $common-border-radius: 4px;
 		}
 
 		th {
+			padding-bottom: 24px;
+
 			&.spacer {
 				color: var(--studio-white);
 			}
-
-			padding-bottom: 24px;
 		}
 
 		td {

--- a/client/my-sites/stats/stats-chart-tabs/style.scss
+++ b/client/my-sites/stats/stats-chart-tabs/style.scss
@@ -5,11 +5,11 @@
 
 //TODO This className seems not to be used
 ul.module-tabs {
-	@include clear-fix;
 	border-top: 1px solid var(--color-neutral-0);
 	list-style: none;
 	background: var(--color-surface);
 	margin: 0;
+	@include clear-fix;
 
 	.module-tab {
 		margin: 0;
@@ -47,10 +47,10 @@ ul.module-tabs {
 		a,
 		.no-link {
 			@extend %mobile-link-element;
-			@include clear-fix;
 			padding: 5px 0 10px;
 			display: block;
 			background: var(--color-surface);
+			@include clear-fix;
 
 			@include breakpoint-deprecated( "<480px" ) {
 				line-height: 24px;

--- a/client/my-sites/stats/stats-email-chart-tabs/style.scss
+++ b/client/my-sites/stats/stats-email-chart-tabs/style.scss
@@ -3,11 +3,11 @@
 
 //TODO This className seems not to be used
 ul.module-tabs {
-	@include clear-fix;
 	border-top: 1px solid var(--color-neutral-0);
 	list-style: none;
 	background: var(--color-surface);
 	margin: 0;
+	@include clear-fix;
 
 	.module-tab {
 		margin: 0;
@@ -45,10 +45,10 @@ ul.module-tabs {
 		a,
 		.no-link {
 			@extend %mobile-link-element;
-			@include clear-fix;
 			padding: 5px 0 10px;
 			display: block;
 			background: var(--color-surface);
+			@include clear-fix;
 
 			@include breakpoint-deprecated( "<480px" ) {
 				line-height: 24px;

--- a/client/my-sites/stats/stats-list/style.scss
+++ b/client/my-sites/stats/stats-list/style.scss
@@ -361,8 +361,6 @@ ul.module-content-list-item-actions {
 	// ### this should be fixed but refraining since we're going to use
 	// the popover and select UI patterns more closely in the future
 	&.collapsed {
-		@include dropdown-menu;
-
 		background: var( --color-neutral-0 );
 		display: none;
 		z-index: z-index( 'root', 'ul.module-content-list-item-actions.collapsed' );
@@ -370,6 +368,7 @@ ul.module-content-list-item-actions {
 		top: 30px;
 		right: auto;
 		left: -172px; // module-content-list-item-right is relative, so this is min-width 220px - action width 48px = 172
+		@include dropdown-menu;
 
 		.module-content-list-item-right.is-expanded & {
 			display: inline-block;
@@ -399,8 +398,6 @@ ul.module-content-list-item-actions {
 	}
 
 	@include breakpoint-deprecated( '<480px' ) {
-		@include dropdown-menu;
-
 		background: var( --color-neutral-0 );
 		display: none;
 		z-index: z-index( 'root', 'ul.module-content-list-item-actions' );
@@ -408,6 +405,7 @@ ul.module-content-list-item-actions {
 		top: 46px;
 		right: auto;
 		left: -172px; // module-content-list-item-right is relative, so this is min-width 220px - action width 48px = 172
+		@include dropdown-menu;
 
 		.module-content-list-item-right.is-expanded & {
 			display: inline-block;
@@ -479,13 +477,12 @@ ul.module-content-list-item-action-submenu {
 	margin: 0;
 
 	@include breakpoint-deprecated( '>480px' ) {
-		@include dropdown-menu;
-
 		display: none;
 		z-index: z-index( 'root', 'ul.module-content-list-item-action-submenu' );
 		margin: 0;
 		top: 32px;
 		right: -20px;
+		@include dropdown-menu;
 
 		.module-content-list-item-action.hidden-action.is-expanded & {
 			display: inline-block;

--- a/client/my-sites/stats/stats-list/style.scss
+++ b/client/my-sites/stats/stats-list/style.scss
@@ -24,6 +24,7 @@
 	// Smaller font-size for narrower, two-column modules
 	font-size: $font-body-small;
 	line-height: 40px;
+	border-top: 1px solid color-mix( in srgb, var( --color-surface ) 0%, transparent );
 
 	// List item height shorter on 2-column modules
 	@include breakpoint-deprecated( '>960px' ) {
@@ -32,8 +33,6 @@
 			line-height: 28px;
 		}
 	}
-
-	border-top: 1px solid color-mix( in srgb, var( --color-surface ) 0%, transparent );
 
 	// Increase touch targets on mobile
 	@include breakpoint-deprecated( '<480px' ) {

--- a/client/my-sites/stats/wordads/earnings.scss
+++ b/client/my-sites/stats/wordads/earnings.scss
@@ -15,8 +15,8 @@
 }
 
 .ads__table-header-title {
-	@include stats-section-header;
 	margin-right: 4px;
+	@include stats-section-header;
 }
 
 .ads__table-header-button {

--- a/client/my-sites/store/components/table/style.scss
+++ b/client/my-sites/store/components/table/style.scss
@@ -1,9 +1,9 @@
 .table {
+	padding: 0;
+
 	table {
 		margin: 0;
 	}
-
-	padding: 0;
 
 	thead .table-heading,
 	thead .table-item {

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -802,10 +802,10 @@ $button-border: 4px;
 	}
 
 	&.theme__preview-upsell-banner {
-		@include banner-dark();
 		width: 100%;
 		margin: 0;
 		text-decoration: none;
+		@include banner-dark();
 	}
 }
 .theme__sheet-reviews-summary {

--- a/client/my-sites/themes/collections/theme-collection-view-header.scss
+++ b/client/my-sites/themes/collections/theme-collection-view-header.scss
@@ -7,6 +7,8 @@
 
 .theme-showcase.is-collection-view {
 	.theme-collection-view-header {
+		padding: 32px 16px;
+
 		&.is-logged-in {
 			margin: 0;
 			padding: 0;
@@ -61,8 +63,6 @@
 				margin-bottom: 16px;
 			}
 		}
-
-		padding: 32px 16px;
 
 		@include breakpoint-deprecated( ">660px" ) {
 			padding: 48px 32px;

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -94,11 +94,12 @@
 			}
 
 			.theme-showcase__all-themes {
+				height: 100%;
+
 				@media ( min-width: $break-mobile ) and ( min-height: $break-mobile ) {
 					overflow-y: auto;
 					overflow-x: hidden;
 				}
-				height: 100%;
 			}
 
 			.themes__controls .theme__search-container,
@@ -106,10 +107,11 @@
 			.themes__showcase .theme-showcase__all-themes {
 				margin: 0 auto;
 				padding-inline: 24px;
+				box-sizing: border-box;
+
 				@media ( max-width: 402px ) {
 					padding-inline: 24px;
 				}
-				box-sizing: border-box;
 			}
 		}
 	}

--- a/client/my-sites/woocommerce/style.scss
+++ b/client/my-sites/woocommerce/style.scss
@@ -70,11 +70,11 @@ body.is-section-woocommerce-installation.theme-default.color-scheme {
 	}
 
 	.landing-page__features-section {
-		@include woocommerce-colors();
 		background-color: var(--color-woocommerce-onboarding-background);
 		margin-top: 100px;
 		padding-top: 60px;
 		padding-bottom: 40px;
+		@include woocommerce-colors();
 
 		.formatted-header .formatted-header__title {
 			@include onboarding-font-recoleta;

--- a/client/reader/components/quick-post/skeleton/style.scss
+++ b/client/reader/components/quick-post/skeleton/style.scss
@@ -1,9 +1,9 @@
 .quick-post-skeleton {
 	span {
-		@include placeholder( --color-neutral-0 );
 		width: 100%;
 		height: 100%;
 		position: relative;
 		margin-bottom: 8px;
+		@include placeholder( --color-neutral-0 );
 	}
 }

--- a/client/reader/on-this-day/style.scss
+++ b/client/reader/on-this-day/style.scss
@@ -94,10 +94,10 @@
 		.dataviews-view-list {
 			height: $list-height;
 			overflow-y: auto;
-			@include custom-scrollbars-on-hover( transparent, $gray-600 );
 			scrollbar-gutter: auto;
 			list-style: none;
 			margin: 0;
+			@include custom-scrollbars-on-hover( transparent, $gray-600 );
 
 			.dataviews-view-list__item-wrapper > div {
 				min-width: 0;

--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -98,10 +98,10 @@ body.is-reader-full-post {
 		.dataviews-view-list {
 			height: $feed-list-height;
 			overflow-y: auto;
-			@include custom-scrollbars-on-hover( transparent, $gray-600 );
 			scrollbar-gutter: auto;
 			list-style: none;
 			margin: 0;
+			@include custom-scrollbars-on-hover( transparent, $gray-600 );
 
 			.dataviews-view-list__item-wrapper > div {
 				min-width: 0;

--- a/client/reader/recommend-button/style.scss
+++ b/client/reader/recommend-button/style.scss
@@ -5,21 +5,21 @@
  */
 $support-old-button-styles: true;
 .reader-recommend-button.is-secondary:not(.is-destructive) {
+	gap: 8px;
+	padding: 12px 24px 12px 20px;
+	font-size: 14px;
+	line-height: 24px;
+	height: 48px;
 	@if $support-old-button-styles {
 		--wp-components-color-accent: initial;
 		--wp-components-color-accent-darker-20: initial;
 		--wp-admin-theme-color: var(--color-neutral-10);
 		--wp-admin-theme-color-darker-20: var(--color-neutral-10);
 		font-weight: 500;
+		color: var(--color-text);
 
 		&:hover {
 			color: var(--color-text);
 		}
-		color: var(--color-text);
 	}
-	gap: 8px;
-	padding: 12px 24px 12px 20px;
-	font-size: 14px;
-	line-height: 24px;
-	height: 48px;
 }

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -112,10 +112,11 @@
 
 // Top margin for site results
 .main.search-stream {
+	padding: 0;
+
 	@include breakpoint-deprecated( "<660px" ) {
 		perspective: none; // Fix search bar pushed up behind the masterbar in Safari
 	}
-	padding: 0;
 }
 
 // Post recommendations in Search

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -278,10 +278,10 @@ body.is-section-reader {
 		&.is-toggle-open {
 			outline: 1px solid #e0e0e0;
 			border-radius: 4px;
+			margin-bottom: 16px;
 			.sidebar__heading {
 				background-color: #fff;
 			}
-			margin-bottom: 16px;
 		}
 
 		&.has-counts .sidebar__menu-link {

--- a/client/reader/site-subscriptions-manager/style.scss
+++ b/client/reader/site-subscriptions-manager/style.scss
@@ -71,11 +71,10 @@ body.is-section-reader .layout.is-section-reader .site-subscriptions-manager {
 		width: 305px;
 
 		button.components-button {
-			@include hover-color;
-
 			padding: 0 15px;
 
 			justify-content: flex-start;
+			@include hover-color;
 
 			.reader-import-button__label,
 			.reader-export-button__label {

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -838,12 +838,12 @@ body.is-section-reader div.layout.is-global-sidebar-visible .is-site-stream .bac
 			width: 90px;
 
 			&.is-placeholder {
-				@include placeholder();
 				display: inline-block;
 				width: 48px;
 				height: 1em;
 				border-radius: 2px;
 				vertical-align: middle;
+				@include placeholder();
 			}
 		}
 

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -877,10 +877,10 @@ body.is-section-reader div.layout.is-global-sidebar-visible .is-site-stream .bac
 		font-size: 13px;
 		white-space: nowrap;
 		cursor: pointer;
+		color: var( --color-neutral-100 );
 		&:hover {
 			color: var( --color-text-subtle );
 		}
-		color: var( --color-neutral-100 );
 		&:focus {
 			outline: dotted 1px;
 		}

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -866,10 +866,10 @@ body.is-section-reader div.layout.is-global-sidebar-visible .is-site-stream .bac
 		font-size: 13px;
 		white-space: nowrap;
 		cursor: pointer;
+		color: var( --color-neutral-100 );
 		&:hover {
 			color: var( --color-text-subtle );
 		}
-		color: var( --color-neutral-100 );
 		&:focus {
 			outline: dotted 1px;
 		}

--- a/client/reader/tags/style.scss
+++ b/client/reader/tags/style.scss
@@ -260,10 +260,10 @@
 
 .alphabetic-tags__table {
 	padding-bottom: 26px;
+	margin-bottom: 26px;
 	&:not(:last-child) {
 		border-bottom: 1px solid var(--studio-gray-5);
 	}
-	margin-bottom: 26px;
 
 	.alphabetic-tags__letter-title {
 		font-size: 32px;

--- a/client/reader/user-profile/components/top-sites/style.scss
+++ b/client/reader/user-profile/components/top-sites/style.scss
@@ -6,10 +6,10 @@
 		margin-top: 16px;
 
 		.skeleton {
-			@include placeholder( --color-neutral-5 );
 			width: 110px;
 			height: 30px;
 			border-radius: 2px;
+			@include placeholder( --color-neutral-5 );
 		}
 	}
 

--- a/client/signup/steps/design-picker/design-picker-category-filter.scss
+++ b/client/signup/steps/design-picker/design-picker-category-filter.scss
@@ -29,6 +29,7 @@ $design-picker-category-filter-text-color-active: var(--studio-gray-100);
 		}
 
 		&.is-pressed {
+			background: transparent;
 			.design-picker-category-filter__item-name {
 				text-decoration: underline;
 				font-weight: 500;
@@ -38,7 +39,6 @@ $design-picker-category-filter-text-color-active: var(--studio-gray-100);
 					color: $design-picker-category-filter-text-color-active;
 				}
 			}
-			background: transparent;
 
 			&:focus:not(:disabled),
 			&:focus-visible:not(:disabled) {
@@ -78,10 +78,6 @@ $design-picker-category-filter-text-color-active: var(--studio-gray-100);
 }
 
 .design-picker-category-filter__dropdown {
-	@include break-small {
-		display: none;
-	}
-
 	font-family: $sans;
 	font-size: $font-body-small;
 	line-height: 24px;
@@ -100,6 +96,10 @@ $design-picker-category-filter-text-color-active: var(--studio-gray-100);
 		url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHJlY3QgeD0iMCIgZmlsbD0ibm9uZSIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ii8+PGc+PHBhdGggZmlsbD0iI2MzYzRjNyIgZD0iTTIwIDlsLTggOC04LTggMS40MTQtMS40MTRMMTIgMTQuMTcybDYuNTg2LTYuNTg2eiIvPjwvZz48L3N2Zz4=)
 		no-repeat right 12px top 50%;
 	background-size: 20px;
+
+	@include break-small {
+		display: none;
+	}
 
 	&:focus,
 	&:focus-visible {

--- a/client/signup/steps/design-picker/design-picker.scss
+++ b/client/signup/steps/design-picker/design-picker.scss
@@ -11,11 +11,10 @@
 	}
 
 	.design-picker__header {
-		@include onboarding-heading-padding;
-
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
+		@include onboarding-heading-padding;
 	}
 
 	.design-picker__heading {

--- a/client/signup/steps/woocommerce-install/style.scss
+++ b/client/signup/steps/woocommerce-install/style.scss
@@ -37,14 +37,14 @@
 				}
 
 				.formatted-header__subtitle {
+					margin-top: 20px;
+					text-align: inherit;
+					max-width: 448px;
+
 					@media (max-width: 660px) {
 						margin-top: 8px;
 						padding: 0 10px 0 0;
 					}
-
-					margin-top: 20px;
-					text-align: inherit;
-					max-width: 448px;
 				}
 			}
 		}

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -183,9 +183,9 @@ body.is-section-signup .layout:not(.dops) {
 
 .layout.is-wccom-oauth-flow {
 	@import "jetpack-connect/colors";
-	@include woocommerce-colors();
 	background-color: var(--color-woocommerce-onboarding-background);
 	height: 100%;
+	@include woocommerce-colors();
 
 	.layout__content {
 		padding-top: 48px;

--- a/client/site-profiler/components/domain-analyzer/styles.scss
+++ b/client/site-profiler/components/domain-analyzer/styles.scss
@@ -11,6 +11,9 @@
 }
 
 .domain-analyzer {
+	// subtract the height of the domain-analyzer--msg hidden element
+	margin-bottom: -1.5rem;
+
 	p + .domain-analyzer--form {
 		margin-top: 2.5rem;
 
@@ -18,9 +21,6 @@
 			margin-top: 2.25rem;
 		}
 	}
-
-	// subtract the height of the domain-analyzer--msg hidden element
-	margin-bottom: -1.5rem;
 }
 
 .domain-analyzer--form-container {

--- a/client/site-profiler/components/get-report-form/styles.scss
+++ b/client/site-profiler/components/get-report-form/styles.scss
@@ -141,10 +141,10 @@
 		font-size: 0.75rem;
 		line-height: 1.5;
 		.components-flex.components-h-stack {
+			gap: 10px;
 			@media (min-width: $break-small) {
 				align-items: center;
 			}
-			gap: 10px;
 		}
 
 		.components-checkbox-control__input {

--- a/client/site-profiler/components/landing-page-header/styles.scss
+++ b/client/site-profiler/components/landing-page-header/styles.scss
@@ -10,6 +10,9 @@
 }
 
 .landing-page-header {
+	// subtract the height of the landing-page-header--msg hidden element
+	margin-bottom: -1.5rem;
+
 	p + .landing-page-header--form {
 		margin-top: 2.5rem;
 
@@ -17,9 +20,6 @@
 			margin-top: 2.25rem;
 		}
 	}
-
-	// subtract the height of the landing-page-header--msg hidden element
-	margin-bottom: -1.5rem;
 }
 
 .landing-page-header--form-container {

--- a/client/sites/components/sites-dashboard-header.scss
+++ b/client/sites/components/sites-dashboard-header.scss
@@ -1,5 +1,9 @@
 .sites-dashboard-header {
 	.add-new-site__button {
+		outline: none;
+		border-radius: 2px 0 0 2px;
+		-moz-osx-font-smoothing: grayscale;
+
 		&.is-secondary {
 			background-color: rgb(56, 88, 233);
 			border-color: rgb(56, 88, 233);
@@ -9,10 +13,6 @@
 			font-weight: 400;
 			line-height: 22px
 		}
-
-		outline: none;
-		border-radius: 2px 0 0 2px;
-		-moz-osx-font-smoothing: grayscale;
 
 	}
 

--- a/client/sites/deployments/components/repositories/style.scss
+++ b/client/sites/deployments/components/repositories/style.scss
@@ -52,6 +52,10 @@
 }
 
 .github-repositories-list {
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+
 	&-permissions-notice {
 		margin-top: auto;
 	}
@@ -63,10 +67,6 @@
 			margin-top: initial;
 		}
 	}
-
-	display: flex;
-	flex-direction: column;
-	flex: 1;
 }
 
 .github-deployments-repository-list-table {

--- a/client/sites/marketing/style.scss
+++ b/client/sites/marketing/style.scss
@@ -616,8 +616,8 @@
 }
 
 .sharing-buttons__fieldset-group {
-	@include clear-fix;
 	margin: 0 -3%;
+	@include clear-fix;
 
 	@include breakpoint-deprecated( "<660px" ) {
 		margin: 0;

--- a/client/sites/marketing/style.scss
+++ b/client/sites/marketing/style.scss
@@ -605,7 +605,6 @@
 }
 
 .sharing-buttons__panel {
-	@include clear-fix;
 	position: relative;
 	margin-bottom: 20px;
 	padding: 20px 24px;
@@ -613,6 +612,7 @@
 	box-shadow:
 		0 0 0 1px color-mix(in srgb, var(--color-neutral-10) 50%, transparent),
 		0 1px 2px var(--color-neutral-0);
+	@include clear-fix;
 }
 
 .sharing-buttons__fieldset-group {

--- a/client/sites/overview/components/site-backup-card/style.scss
+++ b/client/sites/overview/components/site-backup-card/style.scss
@@ -8,9 +8,9 @@
 	}
 
 	&__placeholder {
-		@include placeholder();
 		height: 24px;
 		margin-bottom: 16px;
+		@include placeholder();
 
 		&.is-large {
 			height: 48px;

--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -98,10 +98,9 @@ body.wp-admin.agents-manager-sidebar-container--closing {
 }
 
 body.wp-admin.agents-manager-sidebar-container--sidebar-open:not( .modal-open ) {
+	background-color: $gray-900;
 	@include wp-admin-sidebar-open-specific( $admin-menu-width-classic );
 	@include notice-panel-open( '#wpnt-notes-panel2' );
-
-	background-color: $gray-900;
 
 	#wpadminbar {
 		position: fixed !important;

--- a/packages/calypso-build/webpack/sass.js
+++ b/packages/calypso-build/webpack/sass.js
@@ -42,7 +42,6 @@ module.exports.loader = ( { includePaths, prelude, postCssOptions } ) => ( {
 				sassOptions: ( loaderContext ) => ( {
 					loadPaths: includePaths,
 					quietDeps: true,
-					silenceDeprecations: [ 'mixed-decls' ],
 					...( loaderContext.resourcePath.endsWith( '.css' ) ? { syntax: 'scss' } : {} ),
 				} ),
 			},

--- a/packages/calypso-build/webpack/sass.js
+++ b/packages/calypso-build/webpack/sass.js
@@ -41,7 +41,6 @@ module.exports.loader = ( { includePaths, prelude, postCssOptions } ) => ( {
 				sassOptions: {
 					loadPaths: includePaths,
 					quietDeps: true,
-					silenceDeprecations: [ 'mixed-decls' ],
 				},
 			},
 		},

--- a/packages/calypso-storybook/package.json
+++ b/packages/calypso-storybook/package.json
@@ -38,7 +38,7 @@
 		"css-loader": "^6.11.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"sass-loader": "^13.3.3",
+		"sass-loader": "^14.2.1",
 		"style-loader": "^1.3.0",
 		"webpack": "^5.99.8"
 	}

--- a/packages/calypso-storybook/src/index.js
+++ b/packages/calypso-storybook/src/index.js
@@ -81,9 +81,18 @@ module.exports = function storybookDefaultConfig( {
 				{
 					test: /\.scss$/,
 					use: [
-						'style-loader', // Injects styles into the DOM
-						'css-loader', // Translates CSS into CommonJS
-						'sass-loader', // Compiles Sass to CSS
+						require.resolve( 'style-loader' ), // Injects styles into the DOM
+						require.resolve( 'css-loader' ), // Translates CSS into CommonJS
+						{
+							loader: require.resolve( 'sass-loader' ), // Compiles Sass to CSS
+							options: {
+								api: 'modern',
+								sassOptions: {
+									quietDeps: true,
+									silenceDeprecations: [ 'mixed-decls' ],
+								},
+							},
+						},
 					],
 				},
 			];

--- a/packages/calypso-storybook/src/index.js
+++ b/packages/calypso-storybook/src/index.js
@@ -89,7 +89,6 @@ module.exports = function storybookDefaultConfig( {
 								api: 'modern',
 								sassOptions: {
 									quietDeps: true,
-									silenceDeprecations: [ 'mixed-decls' ],
 								},
 							},
 						},

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -23,6 +23,9 @@
 	border-radius: 2px;
 	padding: 8px 14px;
 	appearance: none;
+	background-color: var(--color-surface);
+	color: var(--color-neutral-70);
+	border-color: var(--color-neutral-10);
 
 
 	.rtl & {
@@ -49,10 +52,6 @@
 	&.is-active {
 		border-width: 1px;
 	}
-
-	background-color: var(--color-surface);
-	color: var(--color-neutral-70);
-	border-color: var(--color-neutral-10);
 
 	&:hover {
 		border-color: var(--color-neutral-20);

--- a/packages/components/src/dot-pager/style.scss
+++ b/packages/components/src/dot-pager/style.scss
@@ -2,9 +2,9 @@
 
 .dot-pager__page {
 	transition: opacity 0.5s ease-in-out, visibility 0.5s ease-in-out;
-	@include reduce-motion( "transition" );
 	opacity: 1;
 	visibility: visible;
+	@include reduce-motion( "transition" );
 
 	&.is-prev,
 	&.is-next {

--- a/packages/components/src/foldable-card/style.scss
+++ b/packages/components/src/foldable-card/style.scss
@@ -4,10 +4,10 @@
 
 // Multisite
 .foldable-card.card {
-	@include a8c-clear-fix;
 	position: relative;
 	transition: margin 0.15s linear;
 	padding: 0;
+	@include a8c-clear-fix;
 }
 
 .foldable-card__header {

--- a/packages/components/src/tabs/style.module.scss
+++ b/packages/components/src/tabs/style.module.scss
@@ -7,15 +7,19 @@
 	display: flex;
 	align-items: stretch;
 	overflow-x: auto;
+	--direction-factor: 1;
+	--direction-start: left;
+	--direction-end: right;
+	--selected-start: var( --selected-left, 0 );
+	position: relative;
+	/* Using a large value to avoid antialiasing rounding issues
+			when scaling in the transform, see: https://stackoverflow.com/a/52159123 */
+	--antialiasing-factor: 100;
 
 	&:where( [aria-orientation='horizontal'] ) {
 		width: fit-content;
 	}
 
-	--direction-factor: 1;
-	--direction-start: left;
-	--direction-end: right;
-	--selected-start: var( --selected-left, 0 );
 	&:dir( rtl ) {
 		--direction-factor: -1;
 		--direction-start: right;
@@ -30,7 +34,6 @@
 			transition-timing-function: ease-out;
 		}
 	}
-	position: relative;
 	&::before {
 		content: '';
 		position: absolute;
@@ -42,9 +45,6 @@
 		outline-offset: -1px;
 	}
 
-	/* Using a large value to avoid antialiasing rounding issues
-			when scaling in the transform, see: https://stackoverflow.com/a/52159123 */
-	--antialiasing-factor: 100;
 	&[aria-orientation='horizontal'] {
 		--fade-width: 4rem;
 		--fade-gradient-base: transparent 0%, #{colors.$black} var( --fade-width );
@@ -119,6 +119,8 @@
 	line-height: 1.2; // Characters in some languages (e.g. Japanese) may have a native higher line-height.
 	font-weight: 400;
 	color: theme.$components-color-foreground;
+	// Focus indicator.
+	position: relative;
 
 	&[aria-disabled='true'] {
 		cursor: default;
@@ -134,8 +136,6 @@
 		outline: none;
 	}
 
-	// Focus indicator.
-	position: relative;
 	&::after {
 		position: absolute;
 		pointer-events: none;
@@ -210,10 +210,10 @@
 .tab__chevron {
 	flex-shrink: 0;
 	margin-inline-end: variables.$grid-unit-05 * -1;
+	opacity: 0;
 	[aria-orientation='horizontal'] & {
 		display: none;
 	}
-	opacity: 0;
 	[role='tab']:is( [aria-selected='true'], [data-focus-visible], :hover ) & {
 		opacity: 1;
 	}

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -11,11 +11,10 @@
 	}
 
 	.design-picker__header {
-		@include onboarding-heading-padding;
-
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
+		@include onboarding-heading-padding;
 	}
 
 	.design-picker__heading {

--- a/packages/domains-table/src/domains-table-filters/style.scss
+++ b/packages/domains-table/src/domains-table-filters/style.scss
@@ -14,10 +14,9 @@
 }
 
 .domains-table-filter {
-	@include search-control-wpcom-styles;
-
 	display: flex;
 	justify-content: space-between;
+	@include search-control-wpcom-styles;
 
 	@media (max-width: 480px) {
 		flex-direction: column;

--- a/packages/help-center/src/components/help-center-header.scss
+++ b/packages/help-center/src/components/help-center-header.scss
@@ -98,11 +98,11 @@
 	}
 
 	button:disabled {
+		color: var(--wp-components-color-gray-600, #949494);
+
 		svg {
 			fill: var(--wp-components-color-gray-600, #949494);
 		}
-
-		color: var(--wp-components-color-gray-600, #949494);
 	}
 
 	button {

--- a/packages/language-picker/src/style.scss
+++ b/packages/language-picker/src/style.scss
@@ -124,11 +124,6 @@
 
 	.language-picker-component__labels {
 		display: none;
-
-		@include break-small() {
-			display: flex;
-		}
-
 		flex-direction: row;
 		flex-wrap: nowrap;
 		font-family: $default-font;
@@ -136,6 +131,10 @@
 		color: $gray-600;
 		font-size: 0.875rem;
 		text-transform: uppercase;
+
+		@include break-small() {
+			display: flex;
+		}
 	}
 
 	.language-picker-component__content {

--- a/packages/launchpad/src/checklist-item/style.scss
+++ b/packages/launchpad/src/checklist-item/style.scss
@@ -87,11 +87,11 @@
 
 .checklist-item__task-content.components-button:hover:not([disabled]),
 .checklist-item__task-content.components-button:focus:not([disabled]) {
+	border-bottom: 1px solid var(--studio-gray-5);
 	&:is(button, a) {
 		fill: var(--studio-blue-50);
 		color: var(--studio-blue-50);
 	}
-	border-bottom: 1px solid var(--studio-gray-5);
 }
 
 .checklist-item__task-content.components-button[disabled],

--- a/packages/odie-client/src/components/message/messages-cluster/style.scss
+++ b/packages/odie-client/src/components/message/messages-cluster/style.scss
@@ -7,6 +7,8 @@
 
 	&.role-attachment {
 		padding: 0 16px;
+		animation: fadeInAttachment 0.2s ease-in-out forwards;
+		transform-origin: center top;
 
 		img {
 			display: block;
@@ -17,9 +19,6 @@
 			border-radius: 0;
 			padding: 0;
 		}
-
-		animation: fadeInAttachment 0.2s ease-in-out forwards;
-		transform-origin: center top;
 
 		@keyframes fadeInAttachment {
 			from {

--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -309,11 +309,11 @@ $blueberry-color: #3858e9;
 	}
 
 	.odie-feedback-component-container {
+		margin-top: 32px;
+		font-size: 1rem;
 		&.odie-question-collapse {
 			margin-top: 0;
 		}
-		margin-top: 32px;
-		font-size: 1rem;
 	}
 
 	&.odie-chatbox-message.odie-chatbox-message-business.odie-chatbox-message-conversation-feedback {

--- a/packages/odie-client/src/components/support-link/styles.scss
+++ b/packages/odie-client/src/components/support-link/styles.scss
@@ -27,6 +27,15 @@ $gray-700: #646970;
 
 		a,
 		button {
+			display: flex;
+			text-decoration: none;
+			color: var(--studio-gray-900);
+			font-size: $font-body-small;
+			align-items: center;
+			width: 100%;
+			min-width: 0;
+			box-sizing: border-box;
+
 			&:hover {
 				color: var(--wp-components-color-accent, var(--wp-admin-theme-color, $help-center-blue));
 				cursor: pointer;
@@ -40,15 +49,6 @@ $gray-700: #646970;
 				outline: $help-center-blue solid 2px;
 				outline-offset: -2px;
 			}
-	
-			display: flex;
-			text-decoration: none;
-			color: var(--studio-gray-900);
-			font-size: $font-body-small;
-			align-items: center;
-			width: 100%;
-			min-width: 0;
-			box-sizing: border-box;
 
 			svg {
 				fill: $gray-700;

--- a/packages/omnibar/src/components/omnibar.scss
+++ b/packages/omnibar/src/components/omnibar.scss
@@ -11,11 +11,6 @@ $omnibar-highlight-color: #7b90ff;
 
 .omnibar {
 	--omnibar-height: #{$omnibar-height-mobile};
-
-	@media ( min-width: 782px ) {
-		--omnibar-height: #{$omnibar-height};
-	}
-
 	background-color: $omnibar-base-color;
 	min-height: var( --omnibar-height );
 	height: var( --omnibar-height );
@@ -24,6 +19,10 @@ $omnibar-highlight-color: #7b90ff;
 	margin: 0;
 	font-size: $omnibar-font-size;
 	line-height: var( --omnibar-height );
+
+	@media ( min-width: 782px ) {
+		--omnibar-height: #{$omnibar-height};
+	}
 
 	.omnibar__secondary {
 		display: flex;

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -71,7 +71,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"redux": "^5.0.1",
-		"sass-loader": "^13.3.3",
+		"sass-loader": "^14.2.1",
 		"storybook": "^8.6.14",
 		"style-loader": "^1.3.0",
 		"typescript": "^5.8.3",

--- a/packages/onboarding/src/step-container-v2/components/ContentWrapper/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/ContentWrapper/style.scss
@@ -8,34 +8,8 @@
 	width: 100%;
 	box-sizing: border-box;
 	flex: 1;
-
-	&.axis-vertical {
-		flex-direction: column;
-	}
-
-	&.axis-horizontal {
-		flex-direction: row;
-	}
-
 	padding: var( --step-container-v2-content-block-padding )
 		var( --step-container-v2-content-inline-padding );
-
-	&.no-top-padding {
-		padding-top: 0;
-	}
-
-	&.no-bottom-padding {
-		padding-bottom: 0;
-	}
-
-	&.no-inline-padding {
-		padding: 0;
-	}
-
-	&.no-gap {
-		gap: 0;
-	}
-
 	--step-container-v2-content-max-width: 1344px;
 
 	max-width: calc(
@@ -53,6 +27,30 @@
 	--step-container-v2-content-column-width: calc(
 		var( --step-container-v2-content-max-width-minus-column-gaps ) / 12
 	);
+
+	&.axis-vertical {
+		flex-direction: column;
+	}
+
+	&.axis-horizontal {
+		flex-direction: row;
+	}
+
+	&.no-top-padding {
+		padding-top: 0;
+	}
+
+	&.no-bottom-padding {
+		padding-bottom: 0;
+	}
+
+	&.no-inline-padding {
+		padding: 0;
+	}
+
+	&.no-gap {
+		gap: 0;
+	}
 
 	&.center-aligned {
 		@include break-small {

--- a/packages/onboarding/src/step-container-v2/components/StepContainerV2/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/StepContainerV2/style.scss
@@ -7,15 +7,14 @@
 
 	--step-container-v2-top-bar-padding: 1rem;
 	--step-container-v2-top-bar-content-height: 24px;
-
-	@include break-small {
-		--step-container-v2-content-inline-padding: 3rem;
-	}
-
 	width: 100%;
 	min-height: 100vh;
 	margin: 0;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
+
+	@include break-small {
+		--step-container-v2-content-inline-padding: 3rem;
+	}
 }

--- a/packages/onboarding/src/step-container-v2/components/StickyBottomBar/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/StickyBottomBar/style.scss
@@ -1,10 +1,4 @@
 .step-container-v2__sticky-bottom-bar {
-	&-wrapper {
-		position: sticky;
-		bottom: 0;
-		width: 100%;
-	}
-
 	width: 100%;
 	display: flex;
 	justify-content: space-between;
@@ -12,6 +6,12 @@
 	align-items: center;
 	box-shadow: var( --color-border-subtle ) 0 1px 0 inset;
 	background-color: var( --color-surface );
+
+	&-wrapper {
+		position: sticky;
+		bottom: 0;
+		width: 100%;
+	}
 
 	&--no-box-shadow {
 		box-shadow: none;

--- a/packages/plans-grid-next/src/components/comparison-grid/style.scss
+++ b/packages/plans-grid-next/src/components/comparison-grid/style.scss
@@ -208,13 +208,13 @@
 
 		.plan-comparison-grid__plan-conditional-title {
 			@extend %plan-comparison-grid__plan-subtitle;
+			text-wrap: balance;
+			max-width: 160px;
+			hyphens: unset;
 			@include plans-grid-medium-large {
 				color: unset;
 				margin-bottom: 0;
 			}
-			text-wrap: balance;
-			max-width: 160px;
-			hyphens: unset;
 		}
 
 		&:not(.has-feature):not(.has-feature-label) {

--- a/packages/privacy-toolset/src/cookie-banner/styles.scss
+++ b/packages/privacy-toolset/src/cookie-banner/styles.scss
@@ -34,15 +34,6 @@ $cookie-banner-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Robo
  Cookie Banner styling.
 */
 .cookie-banner {
-	@keyframes fadeIn {
-		0% {
-			opacity: 0;
-		}
-		100% {
-			opacity: 1;
-		}
-	}
-
 	font-family: $cookie-banner-font-family;
 	display: flex;
 	position: fixed;
@@ -65,6 +56,15 @@ $cookie-banner-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Robo
 	animation: fadeIn 0.6s;
 	color: $cookie-banner-text-color;
 	box-sizing: border-box;
+
+	@keyframes fadeIn {
+		0% {
+			opacity: 0;
+		}
+		100% {
+			opacity: 1;
+		}
+	}
 
 	* {
 		box-sizing: border-box;

--- a/packages/search/src/style.scss
+++ b/packages/search/src/style.scss
@@ -220,6 +220,7 @@ $input-z-index: 20;
 			height: 100%;
 			position: relative;
 			font-size: $font-body;
+			padding-left: 8px;
 
 			&::before {
 				@include long-content-fade( $direction: right, $size: 32px, $z-index: $input-z-index + 2, $color: var( --color-surface ) );
@@ -237,8 +238,6 @@ $input-z-index: 20;
 					border-radius: inherit;
 				}
 			}
-
-			padding-left: 8px;
 		}
 	}
 

--- a/packages/support-articles/src/components/help-center-article/help-center-article.scss
+++ b/packages/support-articles/src/components/help-center-article/help-center-article.scss
@@ -46,6 +46,15 @@
 		}
 
 		.help-center-article-content__main {
+			color: var( --color-neutral-70 );
+			font-size: $font-body;
+			line-height: 1.7;
+			margin: 0;
+			padding-top: 16px;
+			position: relative;
+			overflow-wrap: break-word;
+			word-wrap: break-word;
+
 			h2,
 			h3,
 			h4,
@@ -253,15 +262,6 @@
 				display: block;
 				padding: 12px 0 0;
 			}
-
-			color: var( --color-neutral-70 );
-			font-size: $font-body;
-			line-height: 1.7;
-			margin: 0;
-			padding-top: 16px;
-			position: relative;
-			overflow-wrap: break-word;
-			word-wrap: break-word;
 
 			// Temporary fix on the help center article content inside the editor
 			.wp-block-columns-is-layout-flex {

--- a/packages/support-articles/src/components/help-center-article/help-center-article.scss
+++ b/packages/support-articles/src/components/help-center-article/help-center-article.scss
@@ -45,6 +45,15 @@
 		}
 
 		.help-center-article-content__main {
+			color: var( --color-neutral-70 );
+			font-size: $font-body;
+			line-height: 1.7;
+			margin: 0;
+			padding-top: 16px;
+			position: relative;
+			overflow-wrap: break-word;
+			word-wrap: break-word;
+
 			h2,
 			h3,
 			h4,
@@ -252,15 +261,6 @@
 				display: block;
 				padding: 12px 0 0;
 			}
-
-			color: var( --color-neutral-70 );
-			font-size: $font-body;
-			line-height: 1.7;
-			margin: 0;
-			padding-top: 16px;
-			position: relative;
-			overflow-wrap: break-word;
-			word-wrap: break-word;
 
 			// Temporary fix on the help center article content inside the editor
 			.wp-block-columns-is-layout-flex {

--- a/packages/ui/src/badge/style.module.scss
+++ b/packages/ui/src/badge/style.module.scss
@@ -12,8 +12,6 @@ $badge-colors: (
 );
 
 .badge {
-	@include mixins.reset;
-
 	background-color: color-mix(in srgb, colors.$white 90%, var(--base-color));
 	color: color-mix(in srgb, colors.$black 50%, var(--base-color));
 
@@ -27,6 +25,7 @@ $badge-colors: (
 	display: inline-flex;
 	align-items: center;
 	gap: 2px;
+	@include mixins.reset;
 
 	&:where(.is-default) {
 		background-color: theme.$components-color-gray-100;

--- a/packages/ui/src/calendar/styles.module.scss
+++ b/packages/ui/src/calendar/styles.module.scss
@@ -16,12 +16,6 @@
 	// TODO: themify / align to DS tokens
 	--a8c-calendar-range-middle-background-color: color-mix(in srgb, #{theme.$components-color-accent} 4%, transparent);
 	--a8c-calendar-preview-border-color: color-mix(in srgb, #{theme.$components-color-accent} 16%, transparent);
-
-	@include ui-mixins.when-dark-theme {
-		// Set a stronger background color in dark mode for better visibility
-		--a8c-calendar-range-middle-background-color: color-mix(in srgb, #{theme.$components-color-accent} 8%, transparent);
-	}
-
 	position: relative; /* Required to position the navigation toolbar. */
 	box-sizing: border-box;
 	display: inline flow-root;
@@ -30,6 +24,11 @@
 	font-size: variables.$font-size-medium;
 	font-weight: variables.$font-weight-regular;
 	z-index: 0; // Create a stacking context and render on top of the background.
+
+	@include ui-mixins.when-dark-theme {
+		// Set a stronger background color in dark mode for better visibility
+		--a8c-calendar-range-middle-background-color: color-mix(in srgb, #{theme.$components-color-accent} 8%, transparent);
+	}
 
 	*, *::before, *::after {
 		box-sizing: border-box;

--- a/yarn.lock
+++ b/yarn.lock
@@ -725,7 +725,7 @@ __metadata:
     css-loader: "npm:^6.11.0"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    sass-loader: "npm:^13.3.3"
+    sass-loader: "npm:^14.2.1"
     storybook: "npm:^8.6.14"
     style-loader: "npm:^1.3.0"
     webpack: "npm:^5.99.8"
@@ -1926,7 +1926,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     react-router-dom: "npm:^6.23.1"
     redux: "npm:^5.0.1"
-    sass-loader: "npm:^13.3.3"
+    sass-loader: "npm:^14.2.1"
     storybook: "npm:^8.6.14"
     style-loader: "npm:^1.3.0"
     tslib: "npm:^2.8.1"
@@ -29515,30 +29515,6 @@ __metadata:
   bin:
     sass: dist/bin/sass.js
   checksum: b6a62a51252907db5acd9414c781abaf26bb5d1de7f2f0668d17e54a085bcabcabd1f094009d70b41a705c070205789e998fa74ae9d4672fcc7a55ae5b6c80c0
-  languageName: node
-  linkType: hard
-
-"sass-loader@npm:^13.3.3":
-  version: 13.3.3
-  resolution: "sass-loader@npm:13.3.3"
-  dependencies:
-    neo-async: "npm:^2.6.2"
-  peerDependencies:
-    fibers: ">= 3.1.0"
-    node-sass: ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
-    sass: ^1.3.0
-    sass-embedded: "*"
-    webpack: ^5.0.0
-  peerDependenciesMeta:
-    fibers:
-      optional: true
-    node-sass:
-      optional: true
-    sass:
-      optional: true
-    sass-embedded:
-      optional: true
-  checksum: 5e955a4ffce35ee0a46fce677ce51eaa69587fb5371978588c83af00f49e7edc36dcf3bb559cbae27681c5e24a71284463ebe03a1fb65e6ecafa1db0620e3fc8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed Changes

* Remove `silenceDeprecations: [ 'mixed-decls' ]` from `packages/calypso-build/webpack/sass.js`, `bin/render-stylesheet.js`, and `packages/calypso-storybook/src/index.js`.
* Reorder declarations across 185 SCSS files so plain decls come before nested rules / `@media` blocks / `@include` calls that emit nested rules within the same scope.
* Where reordering would change the cascade (mixin `@include` after local decls letting mixin output win), wrap trailing decls in `& {}` to preserve order while suppressing the warning. Five sites: `_extends-forms.scss`, `form-divider`, `reader-suggested-follows`, `thank-you-card`, `jetpack-connect`.
* Augment `bin/check-css-byte-equivalence.js` with a pretty-sorted diff that stable-sorts decls within each rule by shorthand-family group key, preserving duplicate-property and shorthand+longhand source order so cascade-changing reorders remain visible.

## Why are these changes being made?

Sass 1.77 emits a `mixed-decls` deprecation warning for declarations that appear after nested rules. The base PR silences these. This PR fixes them at the source across all 8 build targets (notifications, help-center, o2-blocks, wpcom-block-editor, agents-manager, blaze-dashboard, odyssey-stats, happy-blocks) and removes the silencer entirely.

Most fixes are mechanical reorders — byte-equivalence checked against trunk via `bin/check-css-byte-equivalence.js`. The `& {}` wrapper is used only where naive reordering would change the cascade.

## Testing Instructions

* `yarn start` and confirm the dev build still compiles successfully with no `mixed-decls` warnings.
* Smoke-test pages affected by changed stylesheets — e.g., site-profiler, plans, plugins, reader, dashboard.
* Optional: diff emitted CSS against the base branch to confirm no rendered differences. Example:
  ```
  node bin/check-css-byte-equivalence.js                                       # all targets
  node bin/check-css-byte-equivalence.js --target help-center                  # single target
  node bin/check-css-byte-equivalence.js --target help-center --diff-output .cache/css-diffs
  ```

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the \"[Status] String Freeze\" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the \"[Status] Needs Privacy Updates\" label?