### PR TITLE
Omnibar: migrate to @wordpress/ui

### DIFF
--- a/packages/omnibar/package.json
+++ b/packages/omnibar/package.json
@@ -37,7 +37,8 @@
 	"dependencies": {
 		"@wordpress/components": "^29.0.0",
 		"@wordpress/compose": "^7.23.0",
-		"@wordpress/icons": "^10.23.0"
+		"@wordpress/icons": "^10.23.0",
+		"@wordpress/ui": "^0.9.0"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^10.23.0",

--- a/packages/omnibar/src/components/omnibar-menu.tsx
+++ b/packages/omnibar/src/components/omnibar-menu.tsx
@@ -1,4 +1,5 @@
-import { Button, DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+import { Button } from '@wordpress/ui';
 import { OmnibarNodeContent } from './omnibar-node';
 import type { OmnibarNode } from '../types';
 
@@ -49,7 +50,13 @@ export function OmnibarMenu( { node }: { node: OmnibarNode } ) {
 
 	if ( ! node.children ) {
 		return (
-			<Button className="omnibar__menu" href={ node.href } onClick={ node.onClick } label={ label }>
+			<Button
+				variant="unstyled"
+				className="omnibar__menu"
+				render={ node.href ? <a href={ node.href } /> : undefined }
+				onClick={ node.onClick }
+				aria-label={ label }
+			>
 				<OmnibarNodeContent node={ node } />
 			</Button>
 		);

--- a/packages/omnibar/src/components/omnibar-node.tsx
+++ b/packages/omnibar/src/components/omnibar-node.tsx
@@ -1,4 +1,4 @@
-import { __experimentalHStack as HStack } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import type { OmnibarNode } from '../types';
 
 export function OmnibarNodeContent( { node }: { node: OmnibarNode } ) {
@@ -7,10 +7,10 @@ export function OmnibarNodeContent( { node }: { node: OmnibarNode } ) {
 	}
 	if ( node.icon && node.title ) {
 		return (
-			<HStack>
+			<Stack direction="row" gap="sm" align="center">
 				{ node.icon }
 				<span>{ node.title }</span>
-			</HStack>
+			</Stack>
 		);
 	}
 	return node.icon ?? node.title;

--- a/packages/omnibar/src/components/omnibar-responsive-menu.scss
+++ b/packages/omnibar/src/components/omnibar-responsive-menu.scss
@@ -1,5 +1,5 @@
 .omnibar {
-	.components-button.omnibar__responsive-menu {
+	.omnibar__menu.omnibar__responsive-menu {
 		svg {
 			fill: currentColor;
 			width: 24px;

--- a/packages/omnibar/src/components/omnibar-responsive-menu.tsx
+++ b/packages/omnibar/src/components/omnibar-responsive-menu.tsx
@@ -1,5 +1,5 @@
-import { Button } from '@wordpress/components';
 import { Icon, menu } from '@wordpress/icons';
+import { Button } from '@wordpress/ui';
 
 import './omnibar-responsive-menu.scss';
 
@@ -10,8 +10,9 @@ export function OmnibarResponsiveMenu( {
 } ) {
 	return (
 		<Button
+			variant="unstyled"
 			className="omnibar__menu omnibar__responsive-menu"
-			label="Menu"
+			aria-label="Menu"
 			onClick={ onClickResponsiveMenu }
 		>
 			<Icon icon={ menu } />

--- a/packages/omnibar/src/components/omnibar-site.tsx
+++ b/packages/omnibar/src/components/omnibar-site.tsx
@@ -1,5 +1,5 @@
-import { __experimentalHStack as HStack } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
+import { Stack } from '@wordpress/ui';
 import { OmnibarMenu } from './omnibar-menu';
 import type { OmnibarNode } from '../types';
 
@@ -46,14 +46,14 @@ export function OmnibarSiteActionsNode( { nodes }: { nodes: OmnibarNode[] } ) {
 			node={ {
 				...node,
 				render: ( { title, meta } ) => (
-					<HStack spacing={ 1 }>
+					<Stack direction="row" gap="xs" align="center">
 						<span>{ title }</span>
 						{ meta?.subtitle && (
 							<span style={ { opacity: meta.subtitle !== '0' ? undefined : '0.5' } }>
 								{ meta.subtitle }
 							</span>
 						) }
-					</HStack>
+					</Stack>
 				),
 			} }
 		/>

--- a/packages/omnibar/src/components/omnibar-user.tsx
+++ b/packages/omnibar/src/components/omnibar-user.tsx
@@ -1,8 +1,5 @@
-import {
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-} from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
+import { Stack } from '@wordpress/ui';
 import { OmnibarMenu } from './omnibar-menu';
 import type { OmnibarNode } from '../types';
 
@@ -21,10 +18,10 @@ export function OmnibarUserNode( { node }: { node: OmnibarNode } ) {
 						return userAvatar;
 					}
 					return (
-						<HStack spacing={ 1 }>
+						<Stack direction="row" gap="xs" align="center">
 							<span>{ title }</span>
 							{ userAvatar }
-						</HStack>
+						</Stack>
 					);
 				},
 				children: node.children?.map( ( child ) => ( {
@@ -34,16 +31,16 @@ export function OmnibarUserNode( { node }: { node: OmnibarNode } ) {
 							return {
 								...grandChild,
 								render: ( { title, icon, meta } ) => (
-									<HStack spacing={ 3 } expanded={ false } className="omnibar__user">
+									<Stack direction="row" gap="md" align="center" className="omnibar__user">
 										{ icon && <span className="omnibar__user-avatar">{ icon }</span> }
-										<VStack>
-											<VStack spacing={ 1 }>
+										<Stack direction="column" gap="sm">
+											<Stack direction="column" gap="xs">
 												<span>{ meta?.displayName }</span>
 												<span className="omnibar__user-info">@{ meta?.username }</span>
-											</VStack>
+											</Stack>
 											<span className="omnibar__user-info">{ title }</span>
-										</VStack>
-									</HStack>
+										</Stack>
+									</Stack>
 								),
 							};
 						}

--- a/packages/omnibar/src/components/omnibar.scss
+++ b/packages/omnibar/src/components/omnibar.scss
@@ -35,22 +35,33 @@ $omnibar-highlight-color: #7b90ff;
 		position: relative;
 	}
 
-	.components-button.omnibar__menu {
+	.omnibar__menu {
+		display: inline-flex;
+		align-items: center;
 		height: var( --omnibar-height );
 		padding: 0 12px;
 		color: $omnibar-text-color;
 		background-color: transparent;
 		font-size: $omnibar-font-size;
 		line-height: var( --omnibar-height );
+		border: 0;
 		border-radius: 0;
+		text-decoration: none;
+		transition: none;
+		cursor: pointer;
 
 		&:hover,
 		&:focus,
 		&:active,
 		&[aria-expanded='true'] {
 			background-color: $omnibar-submenu-background;
+			color: $omnibar-text-color;
 			box-shadow: none;
 			outline: none;
+		}
+
+		svg {
+			fill: currentColor;
 		}
 
 		@media ( min-width: 782px ) {
@@ -89,10 +100,6 @@ $omnibar-highlight-color: #7b90ff;
 				color: $omnibar-highlight-color;
 				box-shadow: none;
 				outline: none;
-			}
-
-			svg {
-				fill: currentColor;
 			}
 		}
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1891,6 +1891,7 @@ __metadata:
     "@wordpress/components": "npm:^29.0.0"
     "@wordpress/compose": "npm:^7.23.0"
     "@wordpress/icons": "npm:^10.23.0"
+    "@wordpress/ui": "npm:^0.9.0"
     typescript: "npm:^5.8.3"
   peerDependencies:
     "@wordpress/data": ^10.23.0


### PR DESCRIPTION
## Proposed Changes

Migrate Button, VStack/HStack to from `@wordpress/components` to `@wordpress/ui`.

