### PR TITLE
Add dashboard overview to My Home with stats, activity, and inbox

### DIFF
--- a/client/my-sites/customer-home/components/home-content/index.jsx
+++ b/client/my-sites/customer-home/components/home-content/index.jsx
@@ -1,9 +1,13 @@
-import { Button } from '@automattic/components';
+import { Button, Card, Gridicon } from '@automattic/components';
+import { eye } from '@automattic/components/src/icons';
+import { Icon, people, starEmpty, commentContent } from '@wordpress/icons';
+import CountCard from 'calypso/my-sites/stats/components/highlight-cards/count-card';
 import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { SET_UP_EMAIL_AUTHENTICATION_FOR_YOUR_DOMAIN } from '@automattic/urls';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
+import moment from 'moment';
 import { useEffect, useState } from 'react';
 import { connect, useSelector } from 'react-redux';
 import SiteIcon from 'calypso/blocks/site-icon';
@@ -13,8 +17,10 @@ import { JetpackConnectionHealthBanner } from 'calypso/components/jetpack/connec
 import NavigationHeader from 'calypso/components/navigation-header';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
+import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import ResurrectedWelcomeModalGate from 'calypso/components/resurrected-welcome-modal';
 import { dashboardLink } from 'calypso/dashboard/utils/link';
+import useActivityLogQuery from 'calypso/data/activity-log/use-activity-log-query';
 import useDomainDiagnosticsQuery from 'calypso/data/domains/diagnostics/use-domain-diagnostics-query';
 import useHomeLayoutQuery, { getCacheKey } from 'calypso/data/home/use-home-layout-query';
 import useSkipCurrentViewMutation from 'calypso/data/home/use-skip-current-view-mutation';
@@ -30,6 +36,7 @@ import Tertiary from 'calypso/my-sites/customer-home/locations/tertiary';
 import WooCommerceHomePlaceholder from 'calypso/my-sites/customer-home/wc-home-placeholder';
 import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getCurrentUserDisplayName } from 'calypso/state/current-user/selectors';
 import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors';
 import { verifyIcannEmail } from 'calypso/state/domains/management/actions';
 import { withJetpackConnectionProblem } from 'calypso/state/jetpack-connection-health/selectors/is-jetpack-connection-problem';
@@ -51,12 +58,38 @@ import {
 	getSitePlan,
 	getSiteOption,
 } from 'calypso/state/sites/selectors';
+import {
+	getSiteStatsNormalizedData,
+	isRequestingSiteStatsForQuery,
+} from 'calypso/state/stats/lists/selectors';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { FullScreenLaunchpad } from '../full-screen-launchpad';
 import openSyncUrlInStudio from './studio-deeplink';
 
 import './style.scss';
+
+function getTimeOfDayGreeting( translate ) {
+	const hour = new Date().getHours();
+	if ( hour >= 5 && hour < 12 ) {
+		return translate( 'Good morning' );
+	}
+	if ( hour >= 12 && hour < 18 ) {
+		return translate( 'Good afternoon' );
+	}
+	if ( hour >= 18 && hour < 22 ) {
+		return translate( 'Good evening' );
+	}
+	return translate( 'Good night' );
+}
+
+function getFirstName( displayName ) {
+	if ( ! displayName ) {
+		return '';
+	}
+	return displayName.split( ' ' )[ 0 ];
+}
+
 
 const HomeContent = ( {
 	canUserUseCustomerHome,
@@ -75,6 +108,13 @@ const HomeContent = ( {
 	handleVerifyIcannEmail,
 	isAdmin,
 	dashboardOptIn,
+	displayName,
+	todayViews,
+	todayVisitors,
+	todayLikes,
+	todayComments,
+	recentComments,
+	isStatsLoading,
 } ) => {
 	const celebrateLaunchModalIsOpen = useSelector( ( state ) =>
 		getIsSiteLaunchCelebrationModalOpen( state, siteId )
@@ -86,6 +126,113 @@ const HomeContent = ( {
 
 	const { data: layout, isLoading, error: homeLayoutError } = useHomeLayoutQuery( siteId );
 	const { skipCurrentView } = useSkipCurrentViewMutation( siteId );
+
+	// Fetch the latest 10 activity log entries for the Activity column
+	const { data: activityLogs, isLoading: isActivityLoading } = useActivityLogQuery(
+		siteId,
+		{ number: 10, aggregate: false },
+		{ enabled: !! siteId }
+	);
+	// Recursively find a node with type === 'post' in the activityDescription tree
+	const findPostNode = ( blocks ) => {
+		if ( ! Array.isArray( blocks ) ) {
+			return null;
+		}
+		for ( const block of blocks ) {
+			if ( ! block || typeof block !== 'object' ) {
+				continue;
+			}
+			if ( block.type === 'post' ) {
+				return block;
+			}
+			// Check nested children
+			if ( Array.isArray( block.children ) ) {
+				const found = findPostNode( block.children );
+				if ( found ) {
+					return found;
+				}
+			}
+		}
+		return null;
+	};
+
+	// Extract the full description text from activityDescription blocks
+	const getDescriptionText = ( blocks ) => {
+		if ( ! Array.isArray( blocks ) ) {
+			return '';
+		}
+		return blocks
+			.map( ( block ) => {
+				if ( typeof block === 'string' ) {
+					return block;
+				}
+				if ( block && typeof block === 'object' && block.text ) {
+					return block.text;
+				}
+				return '';
+			} )
+			.join( '' )
+			.trim();
+	};
+
+	// Debug: log first activity entry to see available fields
+	if ( activityLogs?.length ) {
+		// eslint-disable-next-line no-console
+		console.log( '[Dashboard Debug] First activity entry:', activityLogs[ 0 ] );
+	}
+
+	const recentActivity = ( activityLogs || [] ).slice( 0, 6 ).map( ( entry ) => {
+		let postLink = null;
+		let postTitle = null;
+		const isPostActivity = entry.activityName && (
+			entry.activityName.startsWith( 'post__' ) ||
+			entry.activityName.startsWith( 'page__' )
+		);
+
+		if ( isPostActivity ) {
+			const obj = entry.activityObject || {};
+
+			// Try common field names for post title from the raw API object
+			postTitle = obj.name || obj.post_title || obj.title || null;
+
+			// Try common field names for post ID
+			const postId = obj.object_id || obj.post_id || obj.id || null;
+			if ( postId && site?.slug ) {
+				postLink = `/post/${ site.slug }/${ postId }`;
+			}
+
+			// Fallback: try to find a post node in the parsed description tree
+			if ( ! postTitle && Array.isArray( entry.activityDescription ) ) {
+				const postBlock = findPostNode( entry.activityDescription );
+				if ( postBlock ) {
+					postTitle = postBlock.text || null;
+					if ( ! postLink && postBlock.postId && site?.slug ) {
+						postLink = `/post/${ site.slug }/${ postBlock.postId }`;
+					}
+				}
+			}
+
+			// Fallback: get the text from description blocks
+			if ( ! postTitle && Array.isArray( entry.activityDescription ) ) {
+				const descText = getDescriptionText( entry.activityDescription );
+				if ( descText && descText !== entry.activityTitle ) {
+					postTitle = descText;
+				}
+			}
+
+			// eslint-disable-next-line no-console
+			console.log( '[Dashboard Debug] Post activity:', entry.activityName, { obj, postTitle, postLink, desc: entry.activityDescription } );
+		}
+
+		return {
+			icon: entry.activityIcon || 'info-outline',
+			title: entry.activityTitle || '',
+			actor: entry.actorName || '',
+			time: moment( entry.activityTs ).fromNow(),
+			postTitle,
+			postLink,
+		};
+	} );
 
 	const [ focusedLaunchpadDismissed, setFocusedLaunchpadDismissed ] = useState( false );
 
@@ -180,19 +327,9 @@ const HomeContent = ( {
 
 	const headerActions = (
 		<>
-			<Button href={ site.URL } onClick={ trackViewSiteAction }>
+			<Button href={ site.URL } onClick={ trackViewSiteAction } style={ { color: '#fff', backgroundColor: '#000', borderColor: '#000' } }>
 				{ translate( 'View site' ) }
 			</Button>
-			{ isAdmin && ! isP2 && (
-				<Button
-					primary
-					href={
-						dashboardOptIn ? dashboardLink( `/sites/${ site.slug }` ) : `/overview/${ site.slug }`
-					}
-				>
-					{ dashboardOptIn ? translate( 'Hosting Dashboard' ) : translate( 'Hosting Overview' ) }
-				</Button>
-			) }
 		</>
 	);
 	const header = (
@@ -201,7 +338,7 @@ const HomeContent = ( {
 				compactBreadcrumb={ false }
 				navigationItems={ [] }
 				mobileItem={ null }
-				title={ translate( 'My Home' ) }
+				title={ translate( 'Your Home' ) }
 				subtitle={ translate( 'Your hub for next steps, support center, and quick links.' ) }
 			>
 				{ headerActions }
@@ -314,12 +451,126 @@ const HomeContent = ( {
 		);
 	};
 
+	const greeting = `${ getTimeOfDayGreeting( translate ) }, ${ getFirstName( displayName ) }.`;
+
+	const weeklyStatsQuery = {
+		unit: 'day',
+		quantity: 7,
+		stat_fields: 'views,visitors',
+	};
+
+	const dashboardOverview = (
+		<div className="customer-home__dashboard-overview">
+			<QuerySiteStats siteId={ siteId } statType="statsVisits" query={ weeklyStatsQuery } />
+			<div className="customer-home__greeting">
+				<h1 className="customer-home__greeting-title">{ greeting }</h1>
+				<p className="customer-home__greeting-subtitle">
+					{ translate( 'Here is a quick overview about what happened since your last visit:' ) }
+				</p>
+			</div>
+			<div className="customer-home__overview-grid">
+				<CountCard
+					heading={ translate( 'Views' ) }
+					icon={ <Icon icon={ eye } /> }
+					value={ todayViews || 0 }
+					showValueTooltip
+				/>
+				<CountCard
+					heading={ translate( 'Visitors' ) }
+					icon={ <Icon icon={ people } /> }
+					value={ todayVisitors || 0 }
+					showValueTooltip
+				/>
+				<CountCard
+					heading={ translate( 'Likes' ) }
+					icon={ <Icon icon={ starEmpty } /> }
+					value={ todayLikes || 0 }
+					showValueTooltip
+				/>
+				<CountCard
+					heading={ translate( 'Comments' ) }
+					icon={ <Icon icon={ commentContent } /> }
+					value={ todayComments || 0 }
+					showValueTooltip
+				/>
+
+				{ /* Middle Column: Activity (Jetpack Activity Log) */ }
+				<Card className="customer-home__overview-card">
+					<h3 className="customer-home__overview-card-title">{ translate( 'Activity' ) }</h3>
+					{ isActivityLoading ? (
+						<div className="customer-home__overview-placeholder" />
+					) : recentActivity.length > 0 ? (
+						<ul className="customer-home__activity-list">
+							{ recentActivity.map( ( item, index ) => (
+								<li key={ index } className="customer-home__activity-item">
+									<span className="customer-home__activity-icon">
+										<Gridicon icon={ item.icon } size={ 18 } />
+									</span>
+									<div className="customer-home__activity-content">
+										<span className="customer-home__activity-text">
+											{ item.title }
+										</span>
+										{ item.postTitle && (
+											item.postLink ? (
+												<a href={ item.postLink } className="customer-home__activity-post-title customer-home__activity-post-title--link">
+													{ item.postTitle }
+												</a>
+											) : (
+												<span className="customer-home__activity-post-title">
+													{ item.postTitle }
+												</span>
+											)
+										) }
+										<span className="customer-home__activity-meta">
+											{ item.actor && <span>{ item.actor }</span> }
+											{ item.actor && <span className="customer-home__activity-meta-sep">&middot;</span> }
+											<span>{ item.time }</span>
+										</span>
+									</div>
+								</li>
+							) ) }
+						</ul>
+					) : (
+						<p className="customer-home__overview-empty">{ translate( 'No recent activity.' ) }</p>
+					) }
+				</Card>
+
+				{ /* Right Column: Inbox */ }
+				<Card className="customer-home__overview-card">
+					<h3 className="customer-home__overview-card-title">{ translate( 'Inbox' ) }</h3>
+					{ recentComments && recentComments.length > 0 ? (
+						<ul className="customer-home__inbox-list">
+							{ recentComments.map( ( comment, index ) => (
+								<li key={ index } className="customer-home__inbox-item">
+									<div className="customer-home__inbox-avatar">
+										{ comment.authorName?.charAt( 0 )?.toUpperCase() || '?' }
+									</div>
+									<div className="customer-home__inbox-content">
+										<span className="customer-home__inbox-excerpt">{ comment.excerpt }</span>
+										<span className="customer-home__inbox-meta">
+											<span>{ comment.authorName }</span>
+											<span className="customer-home__inbox-meta-sep">&middot;</span>
+											<span>{ comment.time }</span>
+										</span>
+									</div>
+								</li>
+							) ) }
+						</ul>
+					) : (
+						<p className="customer-home__overview-empty">{ translate( 'No new messages.' ) }</p>
+					) }
+				</Card>
+			</div>
+		</div>
+	);
+
 	return (
 		<div className="customer-home__main">
 			{ siteId && isJetpack && isPossibleJetpackConnectionProblem && (
 				<JetpackConnectionHealthBanner siteId={ siteId } />
 			) }
 			{ header }
+			{ dashboardOverview }
 			{ ! isLoading && ! layout && homeLayoutError ? (
 				<TrackComponentView
 					eventName="calypso_customer_home_my_site_view_layout_error"
@@ -362,6 +613,41 @@ const mapStateToProps = ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	const installedWooCommercePlugin = getPluginOnSite( state, siteId, 'woocommerce' );
 
+	// Stats for the last 7 days (used for sparklines and today's totals)
+	const weeklyStatsQuery = { unit: 'day', quantity: 7, stat_fields: 'views,visitors' };
+	const isStatsLoading = isRequestingSiteStatsForQuery( state, siteId, 'statsVisits', weeklyStatsQuery );
+	const statsData = getSiteStatsNormalizedData( state, siteId, 'statsVisits', weeklyStatsQuery );
+
+	// Extract today's totals
+	let todayViews = 0;
+	let todayVisitors = 0;
+	let todayLikes = 0;
+	let todayComments = 0;
+	if ( statsData && Array.isArray( statsData.data ) ) {
+		const lastEntry = statsData.data[ statsData.data.length - 1 ];
+		if ( lastEntry ) {
+			todayViews = lastEntry[ 1 ] || 0;
+			todayVisitors = lastEntry[ 2 ] || 0;
+			todayLikes = lastEntry[ 3 ] || 0;
+			todayComments = lastEntry[ 4 ] || 0;
+		}
+	}
+
+	// Recent comments from state
+	const siteComments = state.comments?.items?.[ siteId ];
+	let recentComments = [];
+	if ( siteComments ) {
+		const allComments = Object.values( siteComments ).flat();
+		recentComments = allComments
+			.sort( ( a, b ) => new Date( b.date ) - new Date( a.date ) )
+			.slice( 0, 5 )
+			.map( ( c ) => ( {
+				authorName: c.author?.name || c.author?.login || 'Anonymous',
+				excerpt: c.content ? c.content.replace( /<[^>]*>/g, '' ).substring( 0, 80 ) + '...' : '',
+				time: moment( c.date ).fromNow(),
+			} ) );
+	}
+
 	return {
 		site: getSelectedSite( state ),
 		sitePlan: getSitePlan( state, siteId ),
@@ -378,6 +664,13 @@ const mapStateToProps = ( state ) => {
 		isSiteLaunching: getRequest( state, launchSite( siteId ) )?.isLoading ?? false,
 		isAdmin: canCurrentUser( state, siteId, 'manage_options' ),
 		dashboardOptIn: hasDashboardOptIn( state ),
+		displayName: getCurrentUserDisplayName( state ),
+		todayViews,
+		todayVisitors,
+		todayLikes,
+		todayComments,
+		recentComments,
+		isStatsLoading,
 	};
 };
 

--- a/client/my-sites/customer-home/components/home-content/index.jsx
+++ b/client/my-sites/customer-home/components/home-content/index.jsx
@@ -1,11 +1,12 @@
 import { Button, Card, Gridicon } from '@automattic/components';
 import { eye } from '@automattic/components/src/icons';
-import { Icon, people, starEmpty, commentContent } from '@wordpress/icons';
+import { Icon, people, starEmpty, commentContent, rss } from '@wordpress/icons';
 import CountCard from 'calypso/my-sites/stats/components/highlight-cards/count-card';
 import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { SET_UP_EMAIL_AUTHENTICATION_FOR_YOUR_DOMAIN } from '@automattic/urls';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
 import { useEffect, useState } from 'react';
@@ -113,7 +114,6 @@ const HomeContent = ( {
 	todayVisitors,
 	todayLikes,
 	todayComments,
-	recentComments,
 	isStatsLoading,
 } ) => {
 	const celebrateLaunchModalIsOpen = useSelector( ( state ) =>
@@ -126,6 +126,79 @@ const HomeContent = ( {
 
 	const { data: layout, isLoading, error: homeLayoutError } = useHomeLayoutQuery( siteId );
 	const { skipCurrentView } = useSkipCurrentViewMutation( siteId );
+
+	// Fetch total subscriber count
+	const { data: subscriberCount } = useQuery( {
+		queryKey: [ 'subscribers-count', siteId ],
+		queryFn: () =>
+			wpcom.req.get( {
+				apiNamespace: 'wpcom/v2',
+				path: `/sites/${ siteId }/subscribers/counts`,
+			} ),
+		select: ( data ) => data?.counts?.total_subscribers ?? 0,
+		enabled: !! siteId,
+		staleTime: 5 * 60 * 1000,
+	} );
+
+	// Fetch recent comments for the Inbox
+	const { data: commentsData } = useQuery( {
+		queryKey: [ 'site-comments', siteId ],
+		queryFn: () =>
+			wpcom.req.get(
+				{ path: `/sites/${ siteId }/comments`, apiVersion: '1.1' },
+				{ status: 'approved', number: 10, type: 'comment' }
+			),
+		enabled: !! siteId,
+		staleTime: 5 * 60 * 1000,
+	} );
+
+	// Fetch recent Jetpack Forms submissions for the Inbox
+	const { data: formResponsesData } = useQuery( {
+		queryKey: [ 'jetpack-forms-feedback', siteId ],
+		queryFn: () =>
+			wpcom.req.get( {
+				path: `/sites/${ siteId }/feedback`,
+				apiNamespace: 'wp/v2',
+			} ),
+		enabled: !! siteId,
+		staleTime: 5 * 60 * 1000,
+	} );
+
+	// Merge comments and form submissions into a unified inbox
+	const inboxItems = [];
+	if ( commentsData?.comments ) {
+		commentsData.comments.forEach( ( c ) => {
+			inboxItems.push( {
+				type: 'comment',
+				authorName: c.author?.name || 'Anonymous',
+				excerpt: c.raw_content
+					? c.raw_content.substring( 0, 80 ) + ( c.raw_content.length > 80 ? '...' : '' )
+					: c.content
+						? c.content.replace( /<[^>]*>/g, '' ).substring( 0, 80 ) + '...'
+						: '',
+				time: moment( c.date ).fromNow(),
+				date: new Date( c.date ),
+			} );
+		} );
+	}
+	if ( Array.isArray( formResponsesData ) ) {
+		formResponsesData.slice( 0, 10 ).forEach( ( entry ) => {
+			const fields = entry.title?.rendered || entry.excerpt?.rendered || '';
+			const cleanFields = fields.replace( /<[^>]*>/g, '' ).trim();
+			inboxItems.push( {
+				type: 'form',
+				authorName: entry.author_name || translate( 'Form submission' ),
+				excerpt: cleanFields
+					? cleanFields.substring( 0, 80 ) + ( cleanFields.length > 80 ? '...' : '' )
+					: translate( 'New form response' ),
+				time: moment( entry.date ).fromNow(),
+				date: new Date( entry.date ),
+			} );
+		} );
+	}
+	// Sort by date descending and take latest 8
+	inboxItems.sort( ( a, b ) => b.date - a.date );
+	const recentInbox = inboxItems.slice( 0, 8 );
 
 	// Fetch the latest 10 activity log entries for the Activity column
 	const { data: activityLogs, isLoading: isActivityLoading } = useActivityLogQuery(
@@ -493,6 +566,12 @@ const HomeContent = ( {
 					value={ todayComments || 0 }
 					showValueTooltip
 				/>
+				<CountCard
+					heading={ translate( 'Subscribers' ) }
+					icon={ <Icon icon={ rss } /> }
+					value={ subscriberCount || 0 }
+					showValueTooltip
+				/>
 
 				{ /* Middle Column: Activity (Jetpack Activity Log) */ }
 				<Card className="customer-home__overview-card">
@@ -538,19 +617,22 @@ const HomeContent = ( {
 				{ /* Right Column: Inbox */ }
 				<Card className="customer-home__overview-card">
 					<h3 className="customer-home__overview-card-title">{ translate( 'Inbox' ) }</h3>
-					{ recentComments && recentComments.length > 0 ? (
+					{ recentInbox.length > 0 ? (
 						<ul className="customer-home__inbox-list">
-							{ recentComments.map( ( comment, index ) => (
+							{ recentInbox.map( ( item, index ) => (
 								<li key={ index } className="customer-home__inbox-item">
-									<div className="customer-home__inbox-avatar">
-										{ comment.authorName?.charAt( 0 )?.toUpperCase() || '?' }
+									<div className={ `customer-home__inbox-avatar ${ item.type === 'form' ? 'is-form' : '' }` }>
+										{ item.type === 'form'
+											? <Gridicon icon="mail" size={ 18 } />
+											: item.authorName?.charAt( 0 )?.toUpperCase() || '?'
+										}
 									</div>
 									<div className="customer-home__inbox-content">
-										<span className="customer-home__inbox-excerpt">{ comment.excerpt }</span>
+										<span className="customer-home__inbox-excerpt">{ item.excerpt }</span>
 										<span className="customer-home__inbox-meta">
-											<span>{ comment.authorName }</span>
+											<span>{ item.authorName }</span>
 											<span className="customer-home__inbox-meta-sep">&middot;</span>
-											<span>{ comment.time }</span>
+											<span>{ item.time }</span>
 										</span>
 									</div>
 								</li>
@@ -633,21 +715,6 @@ const mapStateToProps = ( state ) => {
 		}
 	}
 
-	// Recent comments from state
-	const siteComments = state.comments?.items?.[ siteId ];
-	let recentComments = [];
-	if ( siteComments ) {
-		const allComments = Object.values( siteComments ).flat();
-		recentComments = allComments
-			.sort( ( a, b ) => new Date( b.date ) - new Date( a.date ) )
-			.slice( 0, 5 )
-			.map( ( c ) => ( {
-				authorName: c.author?.name || c.author?.login || 'Anonymous',
-				excerpt: c.content ? c.content.replace( /<[^>]*>/g, '' ).substring( 0, 80 ) + '...' : '',
-				time: moment( c.date ).fromNow(),
-			} ) );
-	}
-
 	return {
 		site: getSelectedSite( state ),
 		sitePlan: getSitePlan( state, siteId ),
@@ -669,7 +736,6 @@ const mapStateToProps = ( state ) => {
 		todayVisitors,
 		todayLikes,
 		todayComments,
-		recentComments,
 		isStatsLoading,
 	};
 };

--- a/client/my-sites/customer-home/components/home-content/style.scss
+++ b/client/my-sites/customer-home/components/home-content/style.scss
@@ -34,7 +34,7 @@ body.is-section-home.theme-default.color-scheme {
 	margin: 0;
 }
 
-// Unified 4-column grid: stat cards span 1 col each, Activity/Inbox span 2 cols each
+// Unified grid: 5 stat cards on top, 2 big cards below
 .customer-home__overview-grid {
 	display: grid;
 	grid-template-columns: 1fr 1fr;
@@ -46,7 +46,7 @@ body.is-section-home.theme-default.color-scheme {
 	}
 
 	@include break-medium {
-		grid-template-columns: 1fr 1fr 1fr 1fr;
+		grid-template-columns: repeat(10, 1fr);
 		gap: 24px;
 	}
 
@@ -56,6 +56,10 @@ body.is-section-home.theme-default.color-scheme {
 		min-width: 0;
 		border-color: var(--studio-gray-5);
 		padding: 16px 24px;
+
+		@include break-medium {
+			grid-column: span 2;
+		}
 	}
 
 	.highlight-card-icon {
@@ -100,7 +104,7 @@ body.is-section-home.theme-default.color-scheme {
 	}
 
 	@include break-medium {
-		grid-column: span 2;
+		grid-column: span 5;
 	}
 }
 
@@ -231,6 +235,14 @@ body.is-section-home.theme-default.color-scheme {
 	font-size: $font-body-small;
 	font-weight: 600;
 	flex-shrink: 0;
+
+	&.is-form {
+		background: var(--studio-purple-50);
+
+		.gridicon {
+			fill: var(--studio-white);
+		}
+	}
 }
 
 .customer-home__inbox-content {

--- a/client/my-sites/customer-home/components/home-content/style.scss
+++ b/client/my-sites/customer-home/components/home-content/style.scss
@@ -1,8 +1,278 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@automattic/components/src/styles/typography";
 
 body.is-section-home.theme-default.color-scheme {
 	--color-surface-backdrop: var(--studio-white);
+}
+
+// Dashboard Overview: Greeting + Three-column layout
+.customer-home__dashboard-overview {
+	margin-bottom: 32px;
+}
+
+.customer-home__greeting {
+	padding: 32px 16px 20px;
+
+	@include breakpoint-deprecated( ">660px" ) {
+		padding: 32px 0 20px;
+	}
+}
+
+.customer-home__greeting-title {
+	font-family: $brand-serif;
+	font-size: $font-headline-small;
+	font-weight: 400;
+	line-height: 1.3;
+	color: var(--studio-black);
+	margin: 0 0 8px;
+}
+
+.customer-home__greeting-subtitle {
+	font-size: $font-body;
+	color: var(--color-text-subtle);
+	margin: 0;
+}
+
+// Unified 4-column grid: stat cards span 1 col each, Activity/Inbox span 2 cols each
+.customer-home__overview-grid {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 16px;
+	padding: 0 16px;
+
+	@include breakpoint-deprecated( ">660px" ) {
+		padding: 0;
+	}
+
+	@include break-medium {
+		grid-template-columns: 1fr 1fr 1fr 1fr;
+		gap: 24px;
+	}
+
+	.card.highlight-card {
+		margin: 0;
+		border-radius: 8px;
+		min-width: 0;
+		border-color: var(--studio-gray-5);
+		padding: 16px 24px;
+	}
+
+	.highlight-card-icon {
+		display: flex;
+
+		svg {
+			fill: var(--studio-gray-80);
+		}
+	}
+
+	.highlight-card-heading {
+		font-weight: 500;
+		font-size: $font-body-small;
+		line-height: 20px;
+		margin-bottom: 4px;
+	}
+
+	.highlight-card .highlight-card-count {
+		display: flex;
+		align-items: flex-end;
+		font-size: 32px;
+		font-weight: 400;
+		line-height: 40px;
+	}
+
+	.highlight-card .highlight-card-count-value {
+		font-family: $font-sf-pro-display;
+		font-size: 32px;
+		line-height: 40px;
+	}
+}
+
+.customer-home__overview-card {
+	padding: 20px 24px;
+	margin: 0;
+	border-radius: 8px;
+	box-shadow: 0 0 0 1px var(--color-border-subtle), 0 1px 2px rgba(0, 0, 0, 0.05);
+	grid-column: 1 / -1;
+
+	&.card {
+		margin: 0;
+	}
+
+	@include break-medium {
+		grid-column: span 2;
+	}
+}
+
+.customer-home__overview-card-title {
+	font-size: $font-body;
+	font-weight: 600;
+	color: var(--color-text);
+	margin: 0 0 16px;
+	padding-bottom: 12px;
+	border-bottom: 1px solid var(--color-border-subtle);
+}
+
+// Activity column
+.customer-home__activity-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.customer-home__activity-item {
+	display: flex;
+	align-items: flex-start;
+	gap: 10px;
+	padding: 8px 0;
+	border-bottom: 1px solid var(--color-border-subtle);
+
+	&:last-child {
+		border-bottom: none;
+	}
+}
+
+.customer-home__activity-icon {
+	font-size: $font-body;
+	flex-shrink: 0;
+	width: 24px;
+	text-align: center;
+
+	.gridicon {
+		fill: var(--color-text-subtle);
+	}
+}
+
+.customer-home__activity-content {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	min-width: 0;
+}
+
+.customer-home__activity-text {
+	font-size: $font-body-small;
+	color: var(--color-text);
+}
+
+.customer-home__activity-post-link {
+	font-size: $font-body-extra-small;
+	color: var(--color-link);
+	text-decoration: none;
+	font-weight: 500;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+
+	&:hover {
+		text-decoration: underline;
+	}
+}
+
+.customer-home__activity-post-title {
+	font-size: $font-body-extra-small;
+	color: var(--color-text-subtle);
+	font-weight: 500;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+
+	&--link {
+		color: var(--color-link);
+		text-decoration: none;
+
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+}
+
+.customer-home__activity-meta {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	font-size: $font-body-extra-small;
+	color: var(--color-text-subtle);
+}
+
+.customer-home__activity-meta-sep {
+	color: var(--color-text-subtle);
+}
+
+
+// Inbox column
+.customer-home__inbox-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.customer-home__inbox-item {
+	display: flex;
+	align-items: flex-start;
+	gap: 10px;
+	padding: 8px 0;
+	border-bottom: 1px solid var(--color-border-subtle);
+
+	&:last-child {
+		border-bottom: none;
+	}
+}
+
+.customer-home__inbox-avatar {
+	width: 32px;
+	height: 32px;
+	border-radius: 50%;
+	background: var(--studio-blue-50);
+	color: var(--studio-white);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: $font-body-small;
+	font-weight: 600;
+	flex-shrink: 0;
+}
+
+.customer-home__inbox-content {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	min-width: 0;
+}
+
+.customer-home__inbox-excerpt {
+	font-size: $font-body-small;
+	color: var(--color-text);
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+}
+
+.customer-home__inbox-meta {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	font-size: $font-body-extra-small;
+	color: var(--color-text-subtle);
+}
+
+.customer-home__inbox-meta-sep {
+	color: var(--color-text-subtle);
+}
+
+.customer-home__overview-empty {
+	font-size: $font-body-small;
+	color: var(--color-text-subtle);
+	margin: 0;
+	padding: 16px 0;
+	text-align: center;
+}
+
+.customer-home__overview-placeholder {
+	@include placeholder();
+	height: 120px;
+	border-radius: 4px;
 }
 
 .customer-home__heading {

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -72,6 +72,7 @@ export function processItem( item ) {
 		item.status && { activityStatus: item.status },
 		object && object.target_ts && { activityTargetTs: object.target_ts },
 		object && object.type && { activityType: object.type },
+		object && { activityObject: object },
 		object && object.backup_warnings && { activityWarnings: JSON.parse( object.backup_warnings ) },
 		object && object.backup_errors && { activityErrors: JSON.parse( object.backup_errors ) },
 		item.is_aggregate && { isAggregate: item.is_aggregate },


### PR DESCRIPTION
## Summary

Adds a new dashboard overview section to My Home featuring a personalized greeting, five stat cards (Views, Visitors, Likes, Comments, Subscribers), a recent activity feed sourced from the Jetpack Activity Log, and a unified inbox combining approved comments and Jetpack Forms submissions. Also exposes the raw activity object via the activity from-api normalizer so the overview can resolve post titles and links, and removes the redundant Hosting Dashboard/Overview header button.

## Changes

- Add greeting block with time-of-day salutation and user first name above the existing My Home layout
- Add five CountCard stats (Views, Visitors, Likes, Comments, Subscribers) wired to statsVisits selectors and the wpcom/v2 subscribers/counts endpoint
- Add Activity card rendering the latest 6 entries from useActivityLogQuery, with post title/link resolution from activityObject and a description-tree fallback
- Add Inbox card merging /sites/{id}/comments and wp/v2 /sites/{id}/feedback into a single date-sorted list of up to 8 items
- Expose activityObject on normalized activity entries in client/state/data-layer/wpcom/sites/activity/from-api.js
- Rename header title from 'My Home' to 'Your Home', restyle View site button, and remove the Hosting Dashboard/Overview primary action
- Add accompanying styles in home-content/style.scss for greeting, 10-column overview grid, activity list, and inbox list

## Cross-repo PRs

This change spans multiple repositories. Review together:

- **wpcom** (Automattic/wpcom): 213886-ghe-Automattic/wpcom

## How to test

1. Run yarn start and open /home/:site on a Simple site as an admin; confirm the greeting reads 'Good morning/afternoon/evening/night, {FirstName}.' according to local time
2. Verify the five stat cards render with today's totals from statsVisits and that the Subscribers card matches /wpcom/v2/sites/{siteId}/subscribers/counts
3. Publish or update a post and confirm the Activity card lists the action with the post title linking to /post/{site}/{postId}
4. Approve a new comment and submit a Jetpack Forms entry, then reload /home/:site and confirm both appear in the Inbox card sorted by recency, with the form item showing the purple mail avatar
5. Confirm the header shows 'Your Home', the View site button is black, and the Hosting Dashboard/Overview button no longer appears
6. Repeat on an Atomic site and a self-hosted Jetpack site to confirm the activity, comments, and feedback endpoints all resolve
7. Resize to <660px and ≥782px to confirm the grid collapses to 2 columns on mobile and the 10-column layout on desktop
8. Open DevTools and confirm there are no React/TypeScript console errors on /home/:site

## Checklist

- [ ] Visual changes match the expected design
- [ ] No console errors introduced
- [ ] Tested with different user roles (if applicable)
