### PR TITLE
[RSM-981] Fix dark mode dashboard edge cases

### DIFF
--- a/apps/notifications/src/app/note-list/dataviews-overrides.scss
+++ b/apps/notifications/src/app/note-list/dataviews-overrides.scss
@@ -1,5 +1,29 @@
+@use '../../../../../packages/ui/src/utils/mixins' as ui-mixins;
+
 @import '@wordpress/base-styles/colors';
 @import '@wordpress/base-styles/variables';
+
+@mixin dark-unread-note-list-item {
+	div[role="article"]:has(.is-unread),
+	div[role="article"]:has(.is-unread):focus-within {
+		& + & {
+			border-top-color: rgba(var(--wp-admin-theme-color--rgb), 0.22);
+		}
+
+		.dataviews-view-list__item-wrapper {
+			background-color: color-mix(in srgb, var(--wp-admin-theme-color) 16%, var(--color-surface));
+			box-shadow: inset 3px 0 0
+				color-mix(in srgb, var(--wp-admin-theme-color) 72%, transparent);
+		}
+	}
+
+	div[role="article"]:where(.is-hovered):has(.is-unread),
+	div[role="article"]:where(.is-hovered):has(.is-unread):focus-within {
+		.dataviews-view-list__item-wrapper {
+			background-color: color-mix(in srgb, var(--wp-admin-theme-color) 22%, var(--color-surface));
+		}
+	}
+}
 
 .wpnc__note-list .dataviews-view-list {
 	// When displaying fields in the DataViews, using the --wp-admin-theme-color color on hover is overwhelming.
@@ -32,6 +56,10 @@
 		.dataviews-view-list__item-wrapper {
 			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.08);
 		}
+	}
+
+	@include ui-mixins.when-dark-theme {
+		@include dark-unread-note-list-item;
 	}
 
 	// We override the media field

--- a/apps/notifications/src/app/note/index.tsx
+++ b/apps/notifications/src/app/note/index.tsx
@@ -102,7 +102,12 @@ const Note = ( { isDismissible }: { isDismissible?: boolean } ) => {
 		<>
 			<CardHeader
 				size="small"
-				style={ { position: 'sticky', top: 0, background: '#fff', zIndex: 1 } }
+				style={ {
+					position: 'sticky',
+					top: 0,
+					background: 'var( --color-surface, #fff )',
+					zIndex: 1,
+				} }
 			>
 				<HStack>
 					<HStack justify="flex-start">
@@ -120,7 +125,7 @@ const Note = ( { isDismissible }: { isDismissible?: boolean } ) => {
 			<CardBody size="small" style={ { maxHeight: 'unset' } }>
 				<VStack justify="flex-start" spacing={ 4 }>
 					<NoteSummary note={ note } />
-					<Divider style={ { color: '#f0f0f0' } } />
+					<Divider style={ { color: 'var( --color-border-subtle, #f0f0f0 )' } } />
 					<div className={ getClasses( { note, isApproved, isRead } ) }>
 						<NoteBody note={ note } />
 					</div>

--- a/apps/notifications/src/app/templates/body.tsx
+++ b/apps/notifications/src/app/templates/body.tsx
@@ -91,7 +91,12 @@ export const ActionBlock = ( { note, goBack }: { note: Note; goBack: () => void 
 	return (
 		<CardFooter
 			size="small"
-			style={ { position: 'sticky', bottom: 0, background: '#fff', zIndex: 1 } }
+			style={ {
+				position: 'sticky',
+				bottom: 0,
+				background: 'var( --color-surface, #fff )',
+				zIndex: 1,
+			} }
 		>
 			<NoteActions note={ note } goBack={ goBack } />
 		</CardFooter>

--- a/apps/notifications/src/app/templates/gridicons.tsx
+++ b/apps/notifications/src/app/templates/gridicons.tsx
@@ -13,6 +13,7 @@ const Gridicons = forwardRef< SVGSVGElement, GridiconsProps >(
 		const gridiconClass = `gridicons-${ icon }`;
 		const sharedProps = {
 			className: clsx( 'gridicon', gridiconClass ),
+			fill: 'currentColor',
 			height: size,
 			width: size,
 			onClick,

--- a/apps/notifications/src/app/templates/test/gridicons.tsx
+++ b/apps/notifications/src/app/templates/test/gridicons.tsx
@@ -1,0 +1,20 @@
+import { render } from '@testing-library/react';
+import PanelGridicons from '../../../panel/templates/gridicons';
+import AppGridicons from '../gridicons';
+import type { ComponentType } from 'react';
+
+type GridiconsComponent = ComponentType< { icon: string; size?: number } >;
+
+describe( 'Gridicons', () => {
+	it.each< [ string, GridiconsComponent ] >( [
+		[ 'app', AppGridicons ],
+		[ 'panel', PanelGridicons ],
+	] )( 'uses the surrounding text color for %s notification icons', ( _name, Gridicons ) => {
+		const { container } = render( <Gridicons icon="cart" /> );
+
+		expect( container.querySelector( 'svg.gridicons-cart' ) ).toHaveAttribute(
+			'fill',
+			'currentColor'
+		);
+	} );
+} );

--- a/apps/notifications/src/panel/templates/gridicons.tsx
+++ b/apps/notifications/src/panel/templates/gridicons.tsx
@@ -14,6 +14,7 @@ const Gridicons = forwardRef< SVGSVGElement, GridiconsProps >(
 		const gridiconClass = `gridicons-${ icon }`;
 		const sharedProps = {
 			className: clsx( 'gridicon', gridiconClass ),
+			fill: 'currentColor',
 			height: size,
 			width: size,
 			onClick,

--- a/client/dashboard/components/logs-activity/activity-actor.scss
+++ b/client/dashboard/components/logs-activity/activity-actor.scss
@@ -13,6 +13,10 @@
         fill: var(--dashboard__text-muted-color);
     }
 
+    .site-activity-logs__actor-icon-wordpress {
+        fill: var(--dashboard__text-muted-color);
+    }
+
     .site-activity-logs__actor-mcp {
         display: block;
         font-size: 0.75rem;

--- a/client/dashboard/sites/backups/style.scss
+++ b/client/dashboard/sites/backups/style.scss
@@ -23,7 +23,7 @@
 
 	.file-card {
 		.components-button.is-secondary {
-			background: #fff;
+			background: var( --dashboard-surface__background-color, #fff );
 		}
 	}
 	.file-card__preview-sensitive {
@@ -42,7 +42,7 @@
 	}
 
 	.file-card__preview pre {
-		--color-surface: #fff;
+		--color-surface: var( --dashboard-surface__background-color, #fff );
 		padding: 1.6em;
 	}
 }

--- a/client/dashboard/sites/logs-activity/dataviews/style.scss
+++ b/client/dashboard/sites/logs-activity/dataviews/style.scss
@@ -9,11 +9,22 @@
 	&-callout {
 		position: relative;
 		pointer-events: none; // ignore pointer events from the callout gradient
-		background: linear-gradient( 180deg, rgba( 255, 255, 255, 0 ) 1.13%, #fff 17.26% );
 		padding: 75px 24px 50px;
 		margin-top: -100px;
 		z-index: 2;
 		width: auto;
+
+		&::before {
+			content: "";
+			position: absolute;
+			inset: 0;
+			z-index: 0;
+			pointer-events: none;
+			background: var( --dashboard-surface__background-color );
+			-webkit-mask-image: linear-gradient( 180deg, transparent 1.13%, #000 17.26% );
+			mask-image: linear-gradient( 180deg, transparent 1.13%, #000 17.26% );
+		}
+
 		// animate the callout when it appears so that it slides down from the top
 		animation: slideDown 0.5s ease-out;
 		@keyframes slideDown {
@@ -32,6 +43,8 @@
 		}
 
 		&-content {
+			position: relative;
+			z-index: 1;
 			pointer-events: auto; // don't ignore pointer events from the callout itself
 			max-width: 886px;
 			flex-basis: 886px;


### PR DESCRIPTION
Part of RSM-981

Related Linear IDs: RSM-1789, RSM-1701, RSM-1692

## Proposed Changes

This fixes a set of dark mode issues across Dashboard notifications, Activity logs, and backups. Notification detail headers and sticky action footers now use theme surface and border tokens, notification body Gridicons inherit the surrounding text color, unread notification rows get a stronger dark-mode treatment, backup detail surfaces use dashboard surface tokens, and Activity logs now render the free-site callout fade and WordPress actor logo against the active theme surface.

The root issue was a mix of hardcoded white backgrounds, default black SVG fills, and light-mode-only tint values that became too subtle or invisible on dark surfaces. The fixes keep the behavior scoped to the affected surfaces and reuse existing dashboard tokens so light mode remains visually unchanged while dark mode has enough contrast.
| Image 1 | Image 2 |
|---|---|
| <img src="https://github.com/user-attachments/assets/25ceff91-abf1-4d5d-9ed3-fadf7880bcf8" width="100%"> | <img src="https://github.com/user-attachments/assets/7374fb1f-3bda-4674-81d1-e4efe176e336" width="100%"> |
| <img src="https://github.com/user-attachments/assets/295aae4e-6823-4df3-86b2-a54972642c6b" width="100%"> | <img src="https://github.com/user-attachments/assets/b41f1568-9d95-4d6f-9a05-ff1bd6017578" width="100%"> |
| <img src="https://github.com/user-attachments/assets/390a8a02-b288-4c8a-ad68-aecce5223df0" width="100%"> |  |

## Why are these changes being made?

The dark mode rollout exposed several places where UI elements were still assuming a white surface or a light background. This made controls, icons, callouts, and selected/unread states difficult to see in Dashboard workflows. These changes make those elements theme-aware so the same interfaces remain readable in both light and dark mode.

## Testing Instructions

Use port `3000` and replace placeholders with suitable test data:

- RSM-1789: Open `http://my.localhost:3000/sites`, open the notifications panel, then open a comment or reply notification detail. Confirm the detail header, footer, reply field, and notification icons are dark-mode compatible.
- RSM-1789 follow-up: Open `http://my.localhost:3000/sites`, open the notifications panel, and confirm unread notification rows are visibly distinct in dark mode.
- RSM-1701: Open `http://my.localhost:3000/sites/__SITE__/logs/activity` with a free or unpaid site that shows the Activity logs callout. Confirm the callout fade follows the dark surface.
- RSM-1701 follow-up: Open `http://my.localhost:3000/sites/__SITE__/logs/activity` with a date range that includes a `WordPress` actor row. Confirm the WordPress actor logo is visible in dark mode.
- RSM-1692: Open `http://my.localhost:3000/sites/__SITE__/backups/__BACKUP_ID__` and confirm the backup detail/download area is dark-mode compatible.
- RSM-1692 follow-up: Open `http://my.localhost:3000/sites/__SITE__/backups` and confirm the backup file browser surfaces are dark-mode compatible.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
