### PR TITLE
Add the Business plan to the newsletter intent for onboarding and plans page

### DIFF
--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -121,7 +121,7 @@ describe( 'PlansFeaturesMain', () => {
 		test( 'Should render <PlanFeatures /> with Newsletter plans when called with newsletter intent', () => {
 			renderWithProvider( <PlansFeaturesMain { ...props } intent="plans-newsletter" /> );
 			expect( screen.getByTestId( 'visible-plans' ) ).toHaveTextContent(
-				JSON.stringify( [ PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM ] )
+				JSON.stringify( [ PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS ] )
 			);
 		} );
 
@@ -132,7 +132,7 @@ describe( 'PlansFeaturesMain', () => {
 			} ) );
 			renderWithProvider( <PlansFeaturesMain { ...props } /> );
 			expect( screen.getByTestId( 'visible-plans' ) ).toHaveTextContent(
-				JSON.stringify( [ PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM ] )
+				JSON.stringify( [ PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS ] )
 			);
 		} );
 

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1984,6 +1984,10 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 	},
 	getBlogOnboardingTagLine: () =>
 		i18n.translate( 'Expand your blog with plugins and powerful tools to help you scale.' ),
+	getNewsletterTagLine: () =>
+		i18n.translate(
+			'Scale your newsletter with advanced customization, powerful publishing tools, and priority support.'
+		),
 	getDescription: () =>
 		i18n.translate(
 			'{{strong}}Best for developers and business owners:{{/strong}} Use powerful developer and business tools, without the overhead.',
@@ -2044,6 +2048,23 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_UPLOAD_THEMES_PLUGINS,
 		FEATURE_200GB_STORAGE,
 		FEATURE_ALL_PREMIUM_FEATURES,
+	],
+	getNewsletterSignupFeatures: () => [
+		FEATURE_CUSTOM_DOMAIN,
+		FEATURE_UNLIMITED_SUBSCRIBERS,
+		FEATURE_PAYMENT_TRANSACTION_FEES_2,
+		FEATURE_PRIORITY_24_7_SUPPORT,
+		FEATURE_PLUGINS_THEMES,
+		FEATURE_CONNECT_ANALYTICS,
+		FEATURE_REALTIME_BACKUPS_JP,
+		FEATURE_DEV_TOOLS,
+	],
+	getNewsletterHighlightedFeatures: () => [
+		FEATURE_CUSTOM_DOMAIN,
+		FEATURE_UNLIMITED_EMAILS,
+		FEATURE_PRIORITY_24_7_SUPPORT,
+		FEATURE_PLUGINS_THEMES,
+		FEATURE_REALTIME_BACKUPS_JP,
 	],
 	getSignupCompareAvailableFeatures: () => {
 		const baseFeatures = [

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -173,7 +173,7 @@ export const usePlanTypesWithIntent = ( {
 			planTypes = [ TYPE_FREE, TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS ];
 			break;
 		case 'plans-newsletter':
-			planTypes = [ TYPE_FREE, TYPE_PERSONAL, TYPE_PREMIUM ];
+			planTypes = [ TYPE_FREE, TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS ];
 			break;
 		case 'plans-new-hosted-site':
 			planTypes = [ TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ];


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of M4R73CH-1691

## Proposed Changes

* Adds the business plan to `usePlanTypesWithIntent` for the `plans-newsletter case`, which ensures that it will show up as an option for https://wordpress.com/setup/newsletter/, and once these users go to the plans page to upgrade.
* Adds a new tagline, and assigns `getNewsletterHighlightedFeatures` and `getNewsletterSignupFeatures`. We should revise these.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We should allow newsletter users to upgrade to Business, as they may want it in the future for developer features, more storage, etc., and not hide it behind the "view all plans"

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Happy CI/tests
* Go to the live link or checkout this branch locally. Go to /setup/newsletter/
    * You should see four plans at the plans step
    * Continue as a free user
    * Skip the onboarding post site creation
* Once in the admin, go to the plans page.
    * You should see four plans here too.   
<img width="4138" height="2354" alt="CleanShot 2026-04-30 at 12 54 40@2x" src="https://github.com/user-attachments/assets/3118a10c-3dcb-4f31-95c1-fd231490d5fe" />
<img width="4158" height="2524" alt="CleanShot 2026-04-30 at 12 54 07@2x" src="https://github.com/user-attachments/assets/43a42187-a39c-4066-900d-e1971dbaf7e0" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
