### PR TITLE
Hosting: skip SFTP feature wait for plans that don't grant it

### DIFF
--- a/client/sites/hosting/components/hosting-activation-button.tsx
+++ b/client/sites/hosting/components/hosting-activation-button.tsx
@@ -8,6 +8,7 @@ import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
 import { HostingHeroButton } from 'calypso/components/hosting-hero';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { ComponentProps } from 'react';
 
@@ -28,6 +29,7 @@ export default function HostingActivationButton( {
 	const [ showEligibility, setShowEligibility ] = useState( showActivationModal );
 
 	const siteId = useSelector( getSelectedSiteId );
+	const hasSftpFeature = useSelector( ( state ) => siteHasFeature( state, siteId, FEATURE_SFTP ) );
 
 	const handleTransfer = ( options: { geo_affinity?: string } ) => {
 		dispatch( recordTracksEvent( 'calypso_hosting_features_activate_confirm' ) );
@@ -45,10 +47,15 @@ export default function HostingActivationButton( {
 			redirect_to: addQueryArgs( redirectUrl, {
 				hosting_features: 'activated',
 			} ),
-			feature: FEATURE_SFTP,
 			initiate_transfer_context: 'hosting',
 			initiate_transfer_geo_affinity: options.geo_affinity || '',
 		} );
+		// Only ask the post-transfer step to wait for SFTP if the plan actually grants it.
+		// Personal/Premium plans include `atomic` (so the transfer can run) but not SFTP, so
+		// waiting on it would loop forever — see DOTDEV-412.
+		if ( hasSftpFeature ) {
+			params.set( 'feature', FEATURE_SFTP );
+		}
 		page( `/setup/transferring-hosted-site?${ params }` );
 	};
 


### PR DESCRIPTION
Resolves DOTDEV-412.

## Proposed Changes

* In `HostingActivationButton`, only append `feature: FEATURE_SFTP` to the `/setup/transferring-hosted-site` URL when the site's plan actually grants SFTP (`siteHasFeature(state, siteId, FEATURE_SFTP)`).

## Why are these changes being made?

Visiting `/hosting-config/{personalSite}` (which redirects to `/hosting-features/{personalSite}`) and confirming the eligibility warning sent the user to the transferring-hosted-site stepper, where the "Installing WordPress" page hung forever on a Personal-plan site.

The activation button hardcoded `feature: FEATURE_SFTP` in the URL params regardless of plan. The stepper's `waitForFeature` (`client/landing/stepper/hooks/use-wait-for-atomic.ts`) then polled `/sites/{id}/features` waiting for SFTP to appear in `plan.features.active`. Personal/Premium plans include the `atomic` feature (so the activation button shows and the underlying Atomic transfer succeeds quickly) but never grant SFTP, so `waitForFeature` looped forever and the stepper never advanced — the loop has no timeout.

Skipping the `feature` param when the plan doesn't grant SFTP makes `waitForFeature` short-circuit (`if ( ! feature ) return;`) and the flow proceeds to `waitForLatestSiteData`, which waits on `is_wpcom_atomic=true` — the actual "transfer is done" signal. Business+ users are unaffected because SFTP is in their plan, so the param is still appended and the wait succeeds as before.

This aligns with the per-feature dashboard activation flow (`client/dashboard/sites/hosting-feature-gated-with-callout/activation.tsx`) and `HostingFeatureGate`, which only render the activation callout when `hasPlanFeature(site, feature)` is true and forward that same feature to the stepper.

## Testing Instructions

1. On a Personal/Premium-plan site that hasn't been transferred to Atomic, visit `/hosting-config/{site}`.
2. Confirm the redirect to `/hosting-features/{site}` and click **Activate**.
3. Accept the eligibility warning.
4. Verify the "Installing WordPress" progress page completes and the user lands on `/sites/{slug}/settings` with the "Hosting features activated successfully!" notice (instead of looping forever).
5. Repeat on a Business-plan (or higher) site to confirm the existing flow still works end-to-end.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?