### PR TITLE
Cancel: Contact Us opens in-app Help Center chat

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/confirm-checkbox.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/confirm-checkbox.tsx
@@ -1,12 +1,14 @@
 import config from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
 import {
+	Button,
 	CheckboxControl,
 	__experimentalDivider as Divider,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { useHelpCenter } from '../../../app/help-center';
 import { Text } from '../../../components/text';
 import { DisplayVariant } from '../../../utils/purchase';
 import { getCheckboxLabel } from './get-confirmation-copy';
@@ -34,6 +36,7 @@ export default function ConfirmCheckbox( {
 }: ConfirmCheckboxProps ) {
 	const isDomainRegistrationPurchase = purchase && purchase.is_domain_registration;
 	const isSplitEnabled = config.isEnabled( 'purchases/split-cancel-remove' );
+	const { setNewMessagingChat } = useHelpCenter();
 
 	const supportHeadingText =
 		displayVariant === 'remove'
@@ -41,6 +44,17 @@ export default function ConfirmCheckbox( {
 			: __( 'Have a question before canceling?' );
 
 	const planConfirmationLabel = getCheckboxLabel();
+
+	const handleContactClick = () => {
+		setNewMessagingChat( {
+			initialMessage:
+				displayVariant === 'remove'
+					? `I have questions about removing my ${ purchase.product_name }. Can I speak with a human?`
+					: `I have questions about canceling my ${ purchase.product_name }. Can I speak with a human?`,
+			siteUrl: purchase.site_slug,
+			siteId: String( purchase.blog_id ),
+		} );
+	};
 
 	return (
 		<VStack spacing={ 4 }>
@@ -50,7 +64,11 @@ export default function ConfirmCheckbox( {
 					{ createInterpolateElement(
 						__( 'Our support team is here for you. <contactLink>Contact us</contactLink>' ),
 						{
-							contactLink: <a href={ localizeUrl( 'https://wordpress.com/support' ) } />,
+							contactLink: isSplitEnabled ? (
+								<Button variant="link" onClick={ handleContactClick } />
+							) : (
+								<a href={ localizeUrl( 'https://wordpress.com/support' ) } />
+							),
 						}
 					) }
 				</Text>

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -13,12 +13,16 @@ import {
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Card } from '@automattic/components';
+import { HelpCenter } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { formatCurrency } from '@automattic/number-formatters';
 import { invokeSurvicateEvent } from '@automattic/survicate';
+import { useCanConnectToZendeskMessaging } from '@automattic/zendesk-client';
+import { Button as GutenbergButton } from '@wordpress/components';
+import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import moment from 'moment';
-import { Component } from 'react';
+import { Component, useCallback } from 'react';
 import { connect } from 'react-redux';
 import BackupRetentionOptionOnCancelPurchase from 'calypso/components/backup-retention-management/retention-option-on-cancel-purchase';
 import QueryProductsList from 'calypso/components/data/query-products-list';
@@ -81,9 +85,57 @@ import { toPurchaseForCopy } from './to-purchase-for-copy';
 import type { UpgradesCancelFeaturesResponse } from '@automattic/api-core';
 import type { Purchases, SiteDetails } from '@automattic/data-stores';
 import type { GetManagePurchaseUrlFor } from 'calypso/lib/purchases/types';
-import type { ReactNode } from 'react';
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
 
 import './style.scss';
+
+const HELP_CENTER_STORE = HelpCenter.register();
+
+function ContactSupportButton( {
+	purchase,
+	displayVariant,
+	children,
+	...props
+}: {
+	purchase: { siteId: number; siteUrl: string; productName: string };
+	displayVariant: 'cancel' | 'remove';
+	children?: ReactNode;
+} & ButtonHTMLAttributes< HTMLButtonElement > ) {
+	const { setShowHelpCenter, setNavigateToRoute, setNewMessagingChat } =
+		useDataStoreDispatch( HELP_CENTER_STORE );
+	const { data: canConnectToZendeskMessaging } = useCanConnectToZendeskMessaging();
+
+	const handleClick = useCallback( () => {
+		if ( canConnectToZendeskMessaging ) {
+			setNewMessagingChat( {
+				initialMessage:
+					displayVariant === 'remove'
+						? `I have questions about removing my ${ purchase.productName }. Can I speak with a human?`
+						: `I have questions about canceling my ${ purchase.productName }. Can I speak with a human?`,
+				siteUrl: purchase.siteUrl,
+				siteId: String( purchase.siteId ),
+			} );
+		} else {
+			setNavigateToRoute( '/odie' );
+			setShowHelpCenter( true );
+		}
+	}, [
+		canConnectToZendeskMessaging,
+		displayVariant,
+		purchase.productName,
+		purchase.siteUrl,
+		purchase.siteId,
+		setNewMessagingChat,
+		setNavigateToRoute,
+		setShowHelpCenter,
+	] );
+
+	return (
+		<GutenbergButton variant="link" onClick={ handleClick } { ...props }>
+			{ children }
+		</GutenbergButton>
+	);
+}
 
 interface MomentProps {
 	moment: typeof moment;
@@ -756,7 +808,16 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 					<p className="cancel-purchase__support-text">
 						{ translate( 'Our support team is here for you. {{a}}Contact us{{/a}}', {
 							components: {
-								a: (
+								a: isSplitEnabled ? (
+									<ContactSupportButton
+										purchase={ {
+											siteId: purchase.siteId,
+											siteUrl: purchase.siteSlug ?? purchase.domain,
+											productName: purchase.productName,
+										} }
+										displayVariant={ displayVariant }
+									/>
+								) : (
 									<a
 										href={ localizeUrl( 'https://wordpress.com/help/contact' ) }
 										target="_blank"


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/RSM-474

## Summary

When the `purchases/split-cancel-remove` flag is on, the "Contact us" link on the cancel-purchase confirm screen opens the in-app Help Center instead of navigating to `wordpress.com/support` / `wordpress.com/help/contact`. The initial chat message mirrors the user's intent ("canceling" vs. "removing") and includes the product name so the agent has context.

- **Dashboard** routes through the existing `useHelpCenter()` hook (`client/dashboard/app/help-center`); its `setNewMessagingChat` already opens Zendesk messaging via the Help Center store. No new helper introduced.
- **Legacy `/me`** mirrors the existing `cancel-purchase-support-link/support-link.jsx`: dispatch directly against the `automattic/help-center` data store, with `useCanConnectToZendeskMessaging` gating Zendesk vs. an Odie fallback. The new logic is inlined as a small functional `ContactSupportButton` so it can use hooks inside the surrounding class component (matches Filippo's pattern in the source branch).
- With the flag off, the trunk static-link behavior is preserved on both surfaces.

Extracted from Filippo's `update/cancel-mutation-timing` (#110163) commit 4 — item #4 of the 8-part work split.

## Test plan

- [ ] **Dashboard, flag ON:** Click "Contact us" on the cancel-purchase confirm screen. Help Center opens with a pre-filled message reflecting the intent + product name.
- [ ] **Dashboard, flag OFF:** Click "Contact us". Trunk behavior — no Help Center; opens `wordpress.com/support` in a new tab.
- [ ] **Legacy /me, flag ON, Zendesk-eligible user:** Click "Contact support". Help Center opens with Zendesk messaging.
- [ ] **Legacy /me, flag ON, Zendesk-ineligible user:** Click "Contact support". Help Center opens with Odie fallback (`/odie` route).
- [ ] **Legacy /me, flag OFF:** Click "Contact support". Trunk behavior — opens `wordpress.com/help/contact`.
- [ ] **Both surfaces:** verify the chat-prefilled message uses "canceling" for cancel intent and "removing" for remove intent.

## Notes

- Typecheck (`yarn tsc -p client/tsconfig.json`) and lint were not run by the agent that authored this branch (sandbox denied them). Pre-commit prettier ran clean. Worth a local typecheck before merge.
- Dashboard's `useHelpCenter().setNewMessagingChat` always sets `provider=zendesk` with no eligibility pivot — that's the existing dashboard pattern, but it diverges from the legacy Zendesk-vs-Odie behavior. Out of scope here; if product wants parity, follow up with a one-line change in `client/dashboard/app/help-center/index.ts`.