### PR TITLE
WIP/exploratory: Move the Google Ads WPcom tracking pixel to the pending page

### DIFF
--- a/client/lib/analytics/ad-tracking/index.js
+++ b/client/lib/analytics/ad-tracking/index.js
@@ -4,6 +4,10 @@ export { adTrackSignupStart } from './ad-track-signup-start';
 export { recordAddToCart } from './record-add-to-cart';
 export { recordAliasInFloodlight } from './record-alias-in-floodlight';
 export { recordOrder } from './record-order';
+export {
+	isPostPurchaseWpcomGoogleAdsEnabled,
+	recordPostPurchaseTracking,
+} from './record-post-purchase';
 export { recordViewCheckout } from './record-view-checkout';
 export { retarget } from './retarget';
 export { retargetViewPlans } from './retarget-view-plans';

--- a/client/lib/analytics/ad-tracking/record-order.ts
+++ b/client/lib/analytics/ad-tracking/record-order.ts
@@ -1,3 +1,4 @@
+import { getCurrentUser } from '@automattic/calypso-analytics';
 import { isPlan } from '@automattic/calypso-products';
 import { costToUSD, refreshCountryCodeCookieGdpr } from 'calypso/lib/analytics/utils';
 import { mayWeTrackByTracker } from '../tracker-buckets';
@@ -489,7 +490,7 @@ export function recordOrderInGoogleAds(
 	}
 
 	// Jetpack
-	if ( mayWeTrackByTracker( 'googleAds' ) && wpcomJetpackCartInfo.containsJetpackProducts ) {
+	if ( wpcomJetpackCartInfo.containsJetpackProducts ) {
 		const params = [
 			'event',
 			'conversion',

--- a/client/lib/analytics/ad-tracking/record-order.ts
+++ b/client/lib/analytics/ad-tracking/record-order.ts
@@ -1,4 +1,3 @@
-import { getCurrentUser } from '@automattic/calypso-analytics';
 import { isPlan } from '@automattic/calypso-products';
 import { costToUSD, refreshCountryCodeCookieGdpr } from 'calypso/lib/analytics/utils';
 import { mayWeTrackByTracker } from '../tracker-buckets';
@@ -22,6 +21,11 @@ import {
 import { initGTMContainer, loadGTMContainer } from './gtm-container';
 import { loadTrackingScripts } from './load-tracking-scripts';
 import { loadParselyTracker } from './parsely';
+import {
+	isPostPurchaseWpcomGoogleAdsEnabled,
+	recordWpcomGoogleAdsPurchaseConversion,
+	setWpcomGoogleAdsEnhancedConversionUserData,
+} from './record-post-purchase';
 import { isWooExpressUpgrade } from './woo';
 import type { ResponseCart, ResponseCartProduct } from '@automattic/shopping-cart';
 import type { WpcomJetpackCartInfo } from 'calypso/lib/analytics/utils/split-wpcom-jetpack-cart-info';
@@ -462,7 +466,7 @@ function recordOrderInBing(
 /**
  * Records an order/sign_up in Google Ads Gtag
  */
-function recordOrderInGoogleAds(
+export function recordOrderInGoogleAds(
 	cart: ResponseCart,
 	orderId: number | null | undefined,
 	wpcomJetpackCartInfo: WpcomJetpackCartInfo
@@ -474,28 +478,14 @@ function recordOrderInGoogleAds(
 
 	// MCC-level event.
 	// WPCOM
-	if ( mayWeTrackByTracker( 'googleAds' ) ) {
-		const currentUser = getCurrentUser();
-
-		// SHA256 hash of current user's email address for enhanced conversion matching.
-		const currentUserHashedEmail = currentUser?.hashedPii?.email ?? '';
-
-		window.gtag( 'set', 'user_data', {
-			sha256_email_address: currentUserHashedEmail,
+	if ( ! isPostPurchaseWpcomGoogleAdsEnabled() ) {
+		recordWpcomGoogleAdsPurchaseConversion( {
+			value: cart.total_cost,
+			currency: cart.currency,
+			transactionId: orderId,
 		} );
-
-		const params = [
-			'event',
-			'conversion',
-			{
-				send_to: TRACKING_IDS.wpcomGoogleAdsGtagPurchase,
-				value: cart.total_cost,
-				currency: cart.currency,
-				transaction_id: orderId,
-			},
-		];
-		debug( 'recordOrderInGoogleAds: Record WPCom Purchase', params );
-		window.gtag( ...params );
+	} else if ( wpcomJetpackCartInfo.containsJetpackProducts ) {
+		setWpcomGoogleAdsEnhancedConversionUserData();
 	}
 
 	// Jetpack

--- a/client/lib/analytics/ad-tracking/record-post-purchase.ts
+++ b/client/lib/analytics/ad-tracking/record-post-purchase.ts
@@ -142,13 +142,6 @@ function recordPostPurchaseWpcomGoogleAdsPurchase( {
 	rememberTrackedPurchase( dedupeKey );
 	loadTrackingScriptsWithoutWaiting();
 
-	debug( 'recordPostPurchaseTracking: Record WPCom Google Ads Purchase', {
-		receiptId,
-		source,
-		value: conversionValue.value,
-		currency: conversionValue.currency,
-	} );
-
 	recordWpcomGoogleAdsPurchaseConversion( {
 		value: conversionValue.value,
 		currency: conversionValue.currency,

--- a/client/lib/analytics/ad-tracking/record-post-purchase.ts
+++ b/client/lib/analytics/ad-tracking/record-post-purchase.ts
@@ -1,0 +1,206 @@
+import { getCurrentUser } from '@automattic/calypso-analytics';
+import config from '@automattic/calypso-config';
+import { mayWeTrackByTracker } from '../tracker-buckets';
+import { debug, TRACKING_IDS } from './constants';
+import { loadTrackingScripts } from './load-tracking-scripts';
+import type { Receipt } from '@automattic/api-core';
+import type { ResponseCart } from '@automattic/shopping-cart';
+
+// Ensure setup has run.
+import './setup';
+
+export const POST_PURCHASE_WPCOM_GOOGLE_ADS_FEATURE = 'ad-tracking/post-purchase-wpcom-google-ads';
+
+type PostPurchaseTrackingSource = 'checkout-pending' | 'one-click-modal';
+
+type RecordPostPurchaseTrackingArgs = {
+	receiptId: number | null | undefined;
+	cart?: ResponseCart;
+	receipt?: Receipt;
+	source: PostPurchaseTrackingSource;
+};
+
+type WpcomGoogleAdsPurchaseConversionArgs = {
+	value: number;
+	currency: string;
+	transactionId: number | null | undefined;
+};
+
+type ConversionValue = {
+	value: number;
+	currency: string;
+};
+
+const trackedPurchases = new Set< string >();
+
+export function isPostPurchaseWpcomGoogleAdsEnabled(): boolean {
+	return config.isEnabled( POST_PURCHASE_WPCOM_GOOGLE_ADS_FEATURE );
+}
+
+export function recordPostPurchaseTracking( args: RecordPostPurchaseTrackingArgs ): void {
+	try {
+		recordPostPurchaseWpcomGoogleAdsPurchase( args );
+	} catch ( error ) {
+		debug( 'recordPostPurchaseTracking: error recording post-purchase tracking', error );
+	}
+}
+
+export function recordWpcomGoogleAdsPurchaseConversion( {
+	value,
+	currency,
+	transactionId,
+}: WpcomGoogleAdsPurchaseConversionArgs ): void {
+	setWpcomGoogleAdsEnhancedConversionUserData();
+
+	const params = [
+		'event',
+		'conversion',
+		{
+			send_to: TRACKING_IDS.wpcomGoogleAdsGtagPurchase,
+			value,
+			currency,
+			transaction_id: transactionId,
+		},
+	] as const;
+	debug( 'recordWpcomGoogleAdsPurchaseConversion: Record WPCom Purchase', params );
+	window.gtag( ...params );
+}
+
+export function setWpcomGoogleAdsEnhancedConversionUserData(): void {
+	const currentUser = getCurrentUser();
+
+	// SHA256 hash of current user's email address for enhanced conversion matching.
+	const currentUserHashedEmail = currentUser?.hashedPii?.email ?? '';
+
+	window.gtag( 'set', 'user_data', {
+		sha256_email_address: currentUserHashedEmail,
+	} );
+}
+
+function recordPostPurchaseWpcomGoogleAdsPurchase( {
+	receiptId,
+	cart,
+	receipt,
+	source,
+}: RecordPostPurchaseTrackingArgs ): void {
+	if ( ! isPostPurchaseWpcomGoogleAdsEnabled() ) {
+		return;
+	}
+
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+
+	if ( ! receiptId ) {
+		debug( 'recordPostPurchaseTracking: skipping WPCom Google Ads purchase without receipt id' );
+		return;
+	}
+
+	if ( ! mayWeTrackByTracker( 'googleAds' ) ) {
+		debug( 'recordPostPurchaseTracking: skipping as Google Ads tracking is disallowed' );
+		return;
+	}
+
+	if ( cart?.is_signup ) {
+		debug( 'recordPostPurchaseTracking: skipping signup cart', { receiptId, source } );
+		return;
+	}
+
+	const conversionValue = getConversionValue( receipt, cart );
+	if (
+		! conversionValue ||
+		! Number.isFinite( conversionValue.value ) ||
+		conversionValue.value <= 0
+	) {
+		debug( 'recordPostPurchaseTracking: skipping non-positive purchase value', {
+			receiptId,
+			source,
+			value: conversionValue?.value,
+		} );
+		return;
+	}
+
+	const dedupeKey = `wpcom_google_ads_purchase:${ receiptId }`;
+	if ( hasTrackedPurchase( dedupeKey ) ) {
+		debug( 'recordPostPurchaseTracking: skipping duplicate WPCom Google Ads purchase', {
+			receiptId,
+			source,
+		} );
+		return;
+	}
+
+	rememberTrackedPurchase( dedupeKey );
+	loadTrackingScriptsWithoutWaiting();
+
+	debug( 'recordPostPurchaseTracking: Record WPCom Google Ads Purchase', {
+		receiptId,
+		source,
+		value: conversionValue.value,
+		currency: conversionValue.currency,
+	} );
+
+	recordWpcomGoogleAdsPurchaseConversion( {
+		value: conversionValue.value,
+		currency: conversionValue.currency,
+		transactionId: receipt?.id ?? receiptId,
+	} );
+}
+
+function getConversionValue( receipt?: Receipt, cart?: ResponseCart ): ConversionValue | null {
+	if ( receipt ) {
+		return {
+			value: receipt.amount_integer / 100,
+			currency: receipt.currency,
+		};
+	}
+
+	if ( cart ) {
+		return {
+			value: cart.total_cost,
+			currency: cart.currency,
+		};
+	}
+
+	return null;
+}
+
+function hasTrackedPurchase( key: string ): boolean {
+	if ( trackedPurchases.has( key ) ) {
+		return true;
+	}
+
+	if ( hasTrackedPurchaseInSession( key ) ) {
+		trackedPurchases.add( key );
+		return true;
+	}
+
+	return false;
+}
+
+function rememberTrackedPurchase( key: string ): void {
+	trackedPurchases.add( key );
+
+	try {
+		window.sessionStorage.setItem( `calypso:post_purchase_tracking:${ key }`, '1' );
+	} catch {
+		// Best-effort same-tab dedupe only.
+	}
+}
+
+function hasTrackedPurchaseInSession( key: string ): boolean {
+	try {
+		return window.sessionStorage.getItem( `calypso:post_purchase_tracking:${ key }` ) === '1';
+	} catch {
+		return false;
+	}
+}
+
+function loadTrackingScriptsWithoutWaiting(): void {
+	try {
+		Promise.resolve( loadTrackingScripts() ).catch( ( error ) => {
+			debug( 'recordPostPurchaseTracking: error loading tracking scripts', error );
+		} );
+	} catch ( error ) {
+		debug( 'recordPostPurchaseTracking: error loading tracking scripts', error );
+	}
+}

--- a/client/lib/analytics/ad-tracking/record-post-purchase.ts
+++ b/client/lib/analytics/ad-tracking/record-post-purchase.ts
@@ -14,7 +14,7 @@ export const POST_PURCHASE_WPCOM_GOOGLE_ADS_FEATURE = 'ad-tracking/post-purchase
 type PostPurchaseTrackingSource = 'checkout-pending' | 'one-click-modal';
 
 type RecordPostPurchaseTrackingArgs = {
-	receiptId: number | null | undefined;
+	receiptId: number;
 	cart?: ResponseCart;
 	receipt?: Receipt;
 	source: PostPurchaseTrackingSource;
@@ -50,6 +50,13 @@ export function recordWpcomGoogleAdsPurchaseConversion( {
 	currency,
 	transactionId,
 }: WpcomGoogleAdsPurchaseConversionArgs ): void {
+	if ( typeof window === 'undefined' || ! mayWeTrackByTracker( 'googleAds' ) ) {
+		debug(
+			'recordWpcomGoogleAdsPurchaseConversion: skipping as Google Ads tracking is disallowed'
+		);
+		return;
+	}
+
 	setWpcomGoogleAdsEnhancedConversionUserData();
 
 	const params = [
@@ -67,6 +74,13 @@ export function recordWpcomGoogleAdsPurchaseConversion( {
 }
 
 export function setWpcomGoogleAdsEnhancedConversionUserData(): void {
+	if ( typeof window === 'undefined' || ! mayWeTrackByTracker( 'googleAds' ) ) {
+		debug(
+			'setWpcomGoogleAdsEnhancedConversionUserData: skipping as Google Ads tracking is disallowed'
+		);
+		return;
+	}
+
 	const currentUser = getCurrentUser();
 
 	// SHA256 hash of current user's email address for enhanced conversion matching.
@@ -107,11 +121,7 @@ function recordPostPurchaseWpcomGoogleAdsPurchase( {
 	}
 
 	const conversionValue = getConversionValue( receipt, cart );
-	if (
-		! conversionValue ||
-		! Number.isFinite( conversionValue.value ) ||
-		conversionValue.value <= 0
-	) {
+	if ( ! conversionValue ) {
 		debug( 'recordPostPurchaseTracking: skipping non-positive purchase value', {
 			receiptId,
 			source,
@@ -142,19 +152,28 @@ function recordPostPurchaseWpcomGoogleAdsPurchase( {
 	recordWpcomGoogleAdsPurchaseConversion( {
 		value: conversionValue.value,
 		currency: conversionValue.currency,
-		transactionId: receipt?.id ?? receiptId,
+		transactionId: receiptId,
 	} );
 }
 
 function getConversionValue( receipt?: Receipt, cart?: ResponseCart ): ConversionValue | null {
 	if ( receipt ) {
+		const value = receipt.amount_integer / 100;
+		if ( ! Number.isFinite( value ) || receipt.amount_integer <= 0 ) {
+			return null;
+		}
+
 		return {
-			value: receipt.amount_integer / 100,
+			value,
 			currency: receipt.currency,
 		};
 	}
 
 	if ( cart ) {
+		if ( ! Number.isFinite( cart.total_cost ) || cart.total_cost < 0.01 ) {
+			return null;
+		}
+
 		return {
 			value: cart.total_cost,
 			currency: cart.currency,

--- a/client/lib/analytics/ad-tracking/record-post-purchase.ts
+++ b/client/lib/analytics/ad-tracking/record-post-purchase.ts
@@ -125,7 +125,6 @@ function recordPostPurchaseWpcomGoogleAdsPurchase( {
 		debug( 'recordPostPurchaseTracking: skipping non-positive purchase value', {
 			receiptId,
 			source,
-			value: conversionValue?.value,
 		} );
 		return;
 	}

--- a/client/lib/analytics/ad-tracking/test/record-order.ts
+++ b/client/lib/analytics/ad-tracking/test/record-order.ts
@@ -1,0 +1,101 @@
+/**
+ * @jest-environment jsdom
+ */
+// @ts-nocheck - Test fixtures only include the fields used by this branch.
+import { getCurrentUser } from '@automattic/calypso-analytics';
+import config from '@automattic/calypso-config';
+import { mayWeTrackByTracker } from 'calypso/lib/analytics/tracker-buckets';
+import { TRACKING_IDS } from '../constants';
+import { recordOrderInGoogleAds } from '../record-order';
+
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	getCurrentUser: jest.fn(),
+} ) );
+
+jest.mock( '@automattic/calypso-config', () => ( {
+	isEnabled: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/lib/analytics/tracker-buckets', () => ( {
+	mayWeTrackByTracker: jest.fn(),
+	mayWeInitTracker: jest.fn(),
+} ) );
+
+jest.mock( '../load-tracking-scripts', () => ( {
+	loadTrackingScripts: jest.fn(),
+} ) );
+
+jest.mock( '../setup', () => ( {} ) );
+
+const cart = {
+	total_cost: 19.99,
+	currency: 'EUR',
+};
+
+const makeWpcomJetpackCartInfo = ( overrides = {} ) => ( {
+	containsJetpackProducts: false,
+	jetpackCost: 0,
+	...overrides,
+} );
+
+describe( 'recordOrderInGoogleAds', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		window.gtag = jest.fn();
+		config.isEnabled.mockReturnValue( false );
+		mayWeTrackByTracker.mockReturnValue( true );
+		getCurrentUser.mockReturnValue( {
+			hashedPii: {
+				email: 'hashed-email',
+			},
+		} );
+	} );
+
+	it( 'fires the old WP.com Google Ads purchase branch when the feature flag is disabled', () => {
+		recordOrderInGoogleAds( cart, 12345, makeWpcomJetpackCartInfo() );
+
+		expect( window.gtag ).toHaveBeenCalledWith( 'event', 'conversion', {
+			send_to: TRACKING_IDS.wpcomGoogleAdsGtagPurchase,
+			value: 19.99,
+			currency: 'EUR',
+			transaction_id: 12345,
+		} );
+	} );
+
+	it( 'skips the old WP.com Google Ads purchase branch when the feature flag is enabled', () => {
+		config.isEnabled.mockReturnValue( true );
+
+		recordOrderInGoogleAds( cart, 12345, makeWpcomJetpackCartInfo() );
+
+		expect( window.gtag ).not.toHaveBeenCalledWith(
+			'event',
+			'conversion',
+			expect.objectContaining( {
+				send_to: TRACKING_IDS.wpcomGoogleAdsGtagPurchase,
+			} )
+		);
+	} );
+
+	it( 'keeps the Jetpack Google Ads purchase branch when the feature flag is enabled', () => {
+		config.isEnabled.mockReturnValue( true );
+
+		recordOrderInGoogleAds(
+			cart,
+			12345,
+			makeWpcomJetpackCartInfo( {
+				containsJetpackProducts: true,
+				jetpackCost: 5.67,
+			} )
+		);
+
+		expect( window.gtag ).toHaveBeenCalledWith( 'set', 'user_data', {
+			sha256_email_address: 'hashed-email',
+		} );
+		expect( window.gtag ).toHaveBeenCalledWith( 'event', 'conversion', {
+			send_to: TRACKING_IDS.jetpackGoogleAdsGtagPurchase,
+			value: 5.67,
+			currency: 'EUR',
+			transaction_id: 12345,
+		} );
+	} );
+} );

--- a/client/lib/analytics/ad-tracking/test/record-order.ts
+++ b/client/lib/analytics/ad-tracking/test/record-order.ts
@@ -18,7 +18,6 @@ jest.mock( '@automattic/calypso-config', () => ( {
 
 jest.mock( 'calypso/lib/analytics/tracker-buckets', () => ( {
 	mayWeTrackByTracker: jest.fn(),
-	mayWeInitTracker: jest.fn(),
 } ) );
 
 jest.mock( '../load-tracking-scripts', () => ( {

--- a/client/lib/analytics/ad-tracking/test/record-post-purchase.ts
+++ b/client/lib/analytics/ad-tracking/test/record-post-purchase.ts
@@ -204,6 +204,16 @@ describe( 'recordPostPurchaseTracking', () => {
 		expect( window.gtag ).not.toHaveBeenCalled();
 	} );
 
+	it( 'skips cart fallback purchases below the existing purchase threshold', () => {
+		recordPostPurchaseTracking( {
+			receiptId: 1014,
+			cart: makeCart( { total_cost: 0.009, currency: 'USD' } ),
+			source: 'checkout-pending',
+		} );
+
+		expect( window.gtag ).not.toHaveBeenCalled();
+	} );
+
 	it( 'dedupes by receipt id in memory', () => {
 		recordPostPurchaseTracking( {
 			receiptId: 1011,
@@ -224,6 +234,21 @@ describe( 'recordPostPurchaseTracking', () => {
 				transaction_id: 1011,
 			} )
 		);
+	} );
+
+	it( 'dedupes by receipt id from sessionStorage', () => {
+		window.sessionStorage.setItem(
+			'calypso:post_purchase_tracking:wpcom_google_ads_purchase:1015',
+			'1'
+		);
+
+		recordPostPurchaseTracking( {
+			receiptId: 1015,
+			cart: makeCart(),
+			source: 'checkout-pending',
+		} );
+
+		expect( window.gtag ).not.toHaveBeenCalled();
 	} );
 
 	it( 'continues when sessionStorage fails', () => {

--- a/client/lib/analytics/ad-tracking/test/record-post-purchase.ts
+++ b/client/lib/analytics/ad-tracking/test/record-post-purchase.ts
@@ -1,0 +1,271 @@
+/**
+ * @jest-environment jsdom
+ */
+// @ts-nocheck - Test fixtures only include the fields used by this module.
+import { getCurrentUser } from '@automattic/calypso-analytics';
+import config from '@automattic/calypso-config';
+import { mayWeTrackByTracker } from 'calypso/lib/analytics/tracker-buckets';
+import { TRACKING_IDS } from '../constants';
+import { loadTrackingScripts } from '../load-tracking-scripts';
+import { recordPostPurchaseTracking } from '../record-post-purchase';
+
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	getCurrentUser: jest.fn(),
+} ) );
+
+jest.mock( '@automattic/calypso-config', () => ( {
+	isEnabled: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/lib/analytics/tracker-buckets', () => ( {
+	mayWeTrackByTracker: jest.fn(),
+} ) );
+
+jest.mock( '../load-tracking-scripts', () => ( {
+	loadTrackingScripts: jest.fn(),
+} ) );
+
+jest.mock( '../setup', () => ( {} ) );
+
+const makeCart = ( overrides = {} ) => ( {
+	total_cost: 12.34,
+	currency: 'EUR',
+	is_signup: false,
+	products: [],
+	...overrides,
+} );
+
+const makeReceipt = ( overrides = {} ) => ( {
+	id: 12345,
+	amount_integer: 6789,
+	currency: 'GBP',
+	items: [],
+	...overrides,
+} );
+
+describe( 'recordPostPurchaseTracking', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		window.sessionStorage.clear();
+		window.gtag = jest.fn();
+		config.isEnabled.mockReturnValue( true );
+		mayWeTrackByTracker.mockReturnValue( true );
+		loadTrackingScripts.mockResolvedValue( [] );
+		getCurrentUser.mockReturnValue( {
+			hashedPii: {
+				email: 'hashed-email',
+			},
+		} );
+	} );
+
+	it( 'does nothing when the feature flag is disabled', () => {
+		config.isEnabled.mockReturnValue( false );
+
+		recordPostPurchaseTracking( {
+			receiptId: 1001,
+			cart: makeCart(),
+			source: 'checkout-pending',
+		} );
+
+		expect( window.gtag ).not.toHaveBeenCalled();
+		expect( loadTrackingScripts ).not.toHaveBeenCalled();
+	} );
+
+	it( 'fires a Google Ads conversion when the feature flag is enabled', () => {
+		recordPostPurchaseTracking( {
+			receiptId: 1002,
+			cart: makeCart(),
+			source: 'checkout-pending',
+		} );
+
+		expect( loadTrackingScripts ).toHaveBeenCalled();
+		expect( window.gtag ).toHaveBeenCalledWith( 'set', 'user_data', {
+			sha256_email_address: 'hashed-email',
+		} );
+		expect( window.gtag ).toHaveBeenCalledWith( 'event', 'conversion', {
+			send_to: TRACKING_IDS.wpcomGoogleAdsGtagPurchase,
+			value: 12.34,
+			currency: 'EUR',
+			transaction_id: 1002,
+		} );
+	} );
+
+	it( 'uses receipt value and currency when a receipt exists', () => {
+		recordPostPurchaseTracking( {
+			receiptId: 1003,
+			receipt: makeReceipt( { id: 1003, amount_integer: 6789, currency: 'GBP' } ),
+			cart: makeCart( { total_cost: 12.34, currency: 'EUR' } ),
+			source: 'checkout-pending',
+		} );
+
+		expect( window.gtag ).toHaveBeenCalledWith( 'event', 'conversion', {
+			send_to: TRACKING_IDS.wpcomGoogleAdsGtagPurchase,
+			value: 67.89,
+			currency: 'GBP',
+			transaction_id: 1003,
+		} );
+	} );
+
+	it( 'falls back to cart value and currency when no receipt exists', () => {
+		recordPostPurchaseTracking( {
+			receiptId: 1004,
+			cart: makeCart( { total_cost: 23.45, currency: 'AUD' } ),
+			source: 'checkout-pending',
+		} );
+
+		expect( window.gtag ).toHaveBeenCalledWith( 'event', 'conversion', {
+			send_to: TRACKING_IDS.wpcomGoogleAdsGtagPurchase,
+			value: 23.45,
+			currency: 'AUD',
+			transaction_id: 1004,
+		} );
+	} );
+
+	it( 'uses the receipt id as transaction_id', () => {
+		recordPostPurchaseTracking( {
+			receiptId: 1005,
+			cart: makeCart(),
+			source: 'checkout-pending',
+		} );
+
+		expect( window.gtag ).toHaveBeenCalledWith(
+			'event',
+			'conversion',
+			expect.objectContaining( {
+				transaction_id: 1005,
+			} )
+		);
+	} );
+
+	it( 'does not convert WP.com Google Ads values to USD', () => {
+		recordPostPurchaseTracking( {
+			receiptId: 1006,
+			cart: makeCart( { total_cost: 42.5, currency: 'JPY' } ),
+			source: 'checkout-pending',
+		} );
+
+		expect( window.gtag ).toHaveBeenCalledWith(
+			'event',
+			'conversion',
+			expect.objectContaining( {
+				value: 42.5,
+				currency: 'JPY',
+			} )
+		);
+	} );
+
+	it( 'skips when Google Ads tracking is disallowed', () => {
+		mayWeTrackByTracker.mockReturnValue( false );
+
+		recordPostPurchaseTracking( {
+			receiptId: 1007,
+			cart: makeCart(),
+			source: 'checkout-pending',
+		} );
+
+		expect( window.gtag ).not.toHaveBeenCalled();
+		expect( loadTrackingScripts ).not.toHaveBeenCalled();
+	} );
+
+	it( 'skips signup carts', () => {
+		recordPostPurchaseTracking( {
+			receiptId: 1008,
+			receipt: makeReceipt( { id: 1008 } ),
+			cart: makeCart( { is_signup: true } ),
+			source: 'checkout-pending',
+		} );
+
+		expect( window.gtag ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not require a cart when receipt data is present', () => {
+		recordPostPurchaseTracking( {
+			receiptId: 1009,
+			receipt: makeReceipt( { id: 1009, amount_integer: 2500, currency: 'USD' } ),
+			source: 'checkout-pending',
+		} );
+
+		expect( window.gtag ).toHaveBeenCalledWith( 'event', 'conversion', {
+			send_to: TRACKING_IDS.wpcomGoogleAdsGtagPurchase,
+			value: 25,
+			currency: 'USD',
+			transaction_id: 1009,
+		} );
+	} );
+
+	it( 'skips free purchases', () => {
+		recordPostPurchaseTracking( {
+			receiptId: 1010,
+			receipt: makeReceipt( { id: 1010, amount_integer: 0, currency: 'USD' } ),
+			cart: makeCart( { total_cost: 25 } ),
+			source: 'checkout-pending',
+		} );
+
+		expect( window.gtag ).not.toHaveBeenCalled();
+	} );
+
+	it( 'dedupes by receipt id in memory', () => {
+		recordPostPurchaseTracking( {
+			receiptId: 1011,
+			cart: makeCart(),
+			source: 'checkout-pending',
+		} );
+		recordPostPurchaseTracking( {
+			receiptId: 1011,
+			cart: makeCart(),
+			source: 'checkout-pending',
+		} );
+
+		expect( window.gtag ).toHaveBeenCalledTimes( 2 );
+		expect( window.gtag ).toHaveBeenCalledWith(
+			'event',
+			'conversion',
+			expect.objectContaining( {
+				transaction_id: 1011,
+			} )
+		);
+	} );
+
+	it( 'continues when sessionStorage fails', () => {
+		const getItemSpy = jest.spyOn( Storage.prototype, 'getItem' ).mockImplementation( () => {
+			throw new Error( 'sessionStorage get failed' );
+		} );
+		const setItemSpy = jest.spyOn( Storage.prototype, 'setItem' ).mockImplementation( () => {
+			throw new Error( 'sessionStorage set failed' );
+		} );
+
+		recordPostPurchaseTracking( {
+			receiptId: 1012,
+			cart: makeCart(),
+			source: 'checkout-pending',
+		} );
+
+		expect( window.gtag ).toHaveBeenCalledWith(
+			'event',
+			'conversion',
+			expect.objectContaining( {
+				transaction_id: 1012,
+			} )
+		);
+
+		getItemSpy.mockRestore();
+		setItemSpy.mockRestore();
+	} );
+
+	it( 'never throws when tracking scripts or gtag fail', () => {
+		loadTrackingScripts.mockImplementation( () => {
+			throw new Error( 'script failure' );
+		} );
+		window.gtag.mockImplementation( () => {
+			throw new Error( 'gtag failure' );
+		} );
+
+		expect( () =>
+			recordPostPurchaseTracking( {
+				receiptId: 1013,
+				cart: makeCart(),
+				source: 'checkout-pending',
+			} )
+		).not.toThrow();
+	} );
+} );

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -3,7 +3,7 @@ import page from '@automattic/calypso-router';
 import { getUrlParts } from '@automattic/calypso-url';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
 import { Step } from '@automattic/onboarding';
-import { useShoppingCart } from '@automattic/shopping-cart';
+import { useShoppingCart, type ResponseCart } from '@automattic/shopping-cart';
 import { invokeSurvicateEvent } from '@automattic/survicate';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
@@ -77,7 +77,7 @@ interface CheckoutPendingProps {
  * It must be numeric. If set, we know that the transaction is complete and
  * will skip polling for the order.
  */
-function CheckoutPending( {
+export function CheckoutPending( {
 	orderId: orderIdOrPlaceholder,
 	receiptId,
 	siteSlug,
@@ -193,6 +193,10 @@ function useRedirectOnTransactionSuccess( {
 	const reduxDispatch = useDispatch();
 	const cartKey = useCartKey();
 	const { responseCart, reloadFromServer: reloadCart } = useShoppingCart( cartKey );
+	const cartSnapshotRef = useRef< ResponseCart | undefined >( undefined );
+	if ( ! cartSnapshotRef.current && responseCart.total_cost >= 0.01 ) {
+		cartSnapshotRef.current = responseCart;
+	}
 
 	const firstItem = receipt?.items[ 0 ];
 	const isRenewal = receipt?.items.some( ( item ) => item.type === 'recurring' ) ?? false;
@@ -329,7 +333,7 @@ function useRedirectOnTransactionSuccess( {
 			redirectInstructions,
 			receiptId: finalReceiptId,
 			receipt,
-			cart: responseCart,
+			cart: cartSnapshotRef.current,
 		} );
 
 		// Pre-populate the Redux sites store with the newly-purchased site so
@@ -358,7 +362,6 @@ function useRedirectOnTransactionSuccess( {
 		redirectTo,
 		reduxDispatch,
 		reloadCart,
-		responseCart,
 		siteSlug,
 		transaction,
 		translate,

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -24,6 +24,7 @@ import getOrderTransactionError from 'calypso/state/selectors/get-order-transact
 import { requestSite } from 'calypso/state/sites/actions';
 import usePurchaseOrder from '../../src/hooks/use-purchase-order';
 import { logStashLoadErrorEvent } from '../../src/lib/analytics';
+import { recordCheckoutPendingPostPurchaseTracking } from './post-purchase-tracking';
 import type { RedirectInstructions } from 'calypso/my-sites/checkout/src/lib/pending-page';
 import type {
 	OrderTransaction,
@@ -191,7 +192,7 @@ function useRedirectOnTransactionSuccess( {
 	);
 	const reduxDispatch = useDispatch();
 	const cartKey = useCartKey();
-	const { reloadFromServer: reloadCart } = useShoppingCart( cartKey );
+	const { responseCart, reloadFromServer: reloadCart } = useShoppingCart( cartKey );
 
 	const firstItem = receipt?.items[ 0 ];
 	const isRenewal = receipt?.items.some( ( item ) => item.type === 'recurring' ) ?? false;
@@ -324,6 +325,13 @@ function useRedirectOnTransactionSuccess( {
 			reduxDispatch,
 		} );
 
+		recordCheckoutPendingPostPurchaseTracking( {
+			redirectInstructions,
+			receiptId: finalReceiptId,
+			receipt,
+			cart: responseCart,
+		} );
+
 		// Pre-populate the Redux sites store with the newly-purchased site so
 		// that the thank-you page can use it immediately on arrival.
 		if ( blogId ) {
@@ -346,9 +354,11 @@ function useRedirectOnTransactionSuccess( {
 		orderId,
 		productName,
 		receiptId,
+		receipt,
 		redirectTo,
 		reduxDispatch,
 		reloadCart,
+		responseCart,
 		siteSlug,
 		transaction,
 		translate,

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -194,6 +194,7 @@ function useRedirectOnTransactionSuccess( {
 	const cartKey = useCartKey();
 	const { responseCart, reloadFromServer: reloadCart } = useShoppingCart( cartKey );
 	const cartSnapshotRef = useRef< ResponseCart | undefined >( undefined );
+	// Write once so receipt-fetch fallback is not overwritten by the emptied post-purchase cart.
 	if ( ! cartSnapshotRef.current && responseCart.total_cost >= 0.01 ) {
 		cartSnapshotRef.current = responseCart;
 	}

--- a/client/my-sites/checkout/checkout-thank-you/pending/post-purchase-tracking.ts
+++ b/client/my-sites/checkout/checkout-thank-you/pending/post-purchase-tracking.ts
@@ -1,0 +1,39 @@
+import {
+	isPostPurchaseWpcomGoogleAdsEnabled,
+	recordPostPurchaseTracking,
+} from 'calypso/lib/analytics/ad-tracking/record-post-purchase';
+import type { Receipt } from '@automattic/api-core';
+import type { ResponseCart } from '@automattic/shopping-cart';
+import type { RedirectInstructions } from 'calypso/my-sites/checkout/src/lib/pending-page';
+
+export function recordCheckoutPendingPostPurchaseTracking( {
+	redirectInstructions,
+	receiptId,
+	receipt,
+	cart,
+}: {
+	redirectInstructions: RedirectInstructions;
+	receiptId: number | undefined;
+	receipt?: Receipt;
+	cart?: ResponseCart;
+} ): void {
+	try {
+		if (
+			! receiptId ||
+			redirectInstructions.isError ||
+			redirectInstructions.isUnknown ||
+			! isPostPurchaseWpcomGoogleAdsEnabled()
+		) {
+			return;
+		}
+
+		recordPostPurchaseTracking( {
+			receiptId,
+			receipt,
+			cart,
+			source: 'checkout-pending',
+		} );
+	} catch {
+		// Tracking must not prevent the pending page from redirecting.
+	}
+}

--- a/client/my-sites/checkout/checkout-thank-you/pending/test/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/test/index.tsx
@@ -1,0 +1,203 @@
+/**
+ * @jest-environment jsdom
+ */
+// @ts-nocheck - Test fixtures only include the fields used by this component.
+import page from '@automattic/calypso-router';
+import { useShoppingCart } from '@automattic/shopping-cart';
+import { useQuery } from '@tanstack/react-query';
+import { render, waitFor } from '@testing-library/react';
+import { recordPostPurchaseTracking } from 'calypso/lib/analytics/ad-tracking/record-post-purchase';
+import usePurchaseOrder from 'calypso/my-sites/checkout/src/hooks/use-purchase-order';
+import { CheckoutPending } from '../index';
+
+jest.mock( '@automattic/api-queries', () => ( {
+	receiptQuery: jest.fn( ( receiptId ) => ( {
+		queryKey: [ 'receipt', receiptId ],
+		queryFn: jest.fn(),
+	} ) ),
+} ) );
+
+jest.mock( '@automattic/calypso-router' );
+
+jest.mock( '@automattic/composite-checkout', () => ( {
+	CheckoutErrorBoundary: ( { children } ) => children,
+} ) );
+
+jest.mock( '@automattic/onboarding', () => ( {
+	Step: {
+		Loading: () => null,
+	},
+} ) );
+
+jest.mock( '@automattic/shopping-cart', () => ( {
+	useShoppingCart: jest.fn(),
+} ) );
+
+jest.mock( '@automattic/survicate', () => ( {
+	invokeSurvicateEvent: jest.fn(),
+} ) );
+
+jest.mock( '@tanstack/react-query', () => ( {
+	useQuery: jest.fn(),
+} ) );
+
+jest.mock( 'i18n-calypso', () => {
+	const translate = ( text ) => text;
+	return {
+		localize: ( component ) => component,
+		translate,
+		useTranslate: () => translate,
+	};
+} );
+
+jest.mock( 'calypso/components/loading', () => () => null );
+
+jest.mock( 'calypso/components/main', () => ( { children } ) => <main>{ children }</main> );
+
+jest.mock( 'calypso/layout/utils', () => ( {
+	useInitialIsInStepContainerV2FlowContext: () => false,
+} ) );
+
+jest.mock( 'calypso/lib/analytics/ad-tracking/record-post-purchase', () => ( {
+	isPostPurchaseWpcomGoogleAdsEnabled: jest.fn( () => true ),
+	recordPostPurchaseTracking: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/lib/analytics/page-view-tracker', () => () => null );
+
+jest.mock( 'calypso/my-sites/checkout/calypso-shopping-cart-provider', () => ( {
+	__esModule: true,
+	default: ( { children } ) => children,
+} ) );
+
+jest.mock( 'calypso/my-sites/checkout/src/lib/analytics', () => ( {
+	logStashLoadErrorEvent: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/my-sites/checkout/src/hooks/use-purchase-order', () => jest.fn() );
+
+jest.mock( 'calypso/my-sites/checkout/src/lib/popup', () => ( {
+	sendMessageToOpener: jest.fn( () => false ),
+} ) );
+
+jest.mock( 'calypso/my-sites/checkout/use-cart-key', () => jest.fn( () => 'cart-key' ) );
+
+jest.mock( 'calypso/state', () => {
+	const dispatch = jest.fn();
+	return {
+		useDispatch: jest.fn( () => dispatch ),
+		useSelector: jest.fn( ( selector ) => selector( {} ) ),
+	};
+} );
+
+jest.mock( 'calypso/state/current-user/actions', () => ( {
+	fetchCurrentUser: jest.fn( () => Promise.resolve() ),
+} ) );
+
+jest.mock( 'calypso/state/notices/actions', () => ( {
+	errorNotice: jest.fn(),
+	successNotice: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/state/selectors/get-order-transaction-error', () => jest.fn( () => null ) );
+
+jest.mock( 'calypso/state/sites/actions', () => ( {
+	requestSite: jest.fn(),
+} ) );
+
+const reloadCart = jest.fn( () => Promise.resolve() );
+
+const makeCart = ( totalCost: number ) => ( {
+	total_cost: totalCost,
+	currency: 'USD',
+	is_signup: false,
+	products: [],
+} );
+
+const makeReceipt = () => ( {
+	id: 12345,
+	amount_integer: 2500,
+	currency: 'USD',
+	items: [],
+} );
+
+describe( 'CheckoutPending post-purchase tracking', () => {
+	let queryResult;
+	let responseCart;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		queryResult = {
+			data: undefined,
+			isSuccess: false,
+			isError: false,
+		};
+		responseCart = makeCart( 12.34 );
+		( useQuery as jest.Mock ).mockImplementation( () => queryResult );
+		( useShoppingCart as jest.Mock ).mockImplementation( () => ( {
+			responseCart,
+			reloadFromServer: reloadCart,
+		} ) );
+		( usePurchaseOrder as jest.Mock ).mockReturnValue( {
+			isLoading: false,
+			order: null,
+		} );
+	} );
+
+	it( 'does not reload the cart again when only the live cart changes while waiting for the receipt', async () => {
+		const { rerender } = render(
+			<CheckoutPending orderId=":orderId" receiptId={ 12345 } redirectTo="/done" />
+		);
+
+		await waitFor( () => expect( reloadCart ).toHaveBeenCalledTimes( 1 ) );
+
+		responseCart = makeCart( 0 );
+		rerender( <CheckoutPending orderId=":orderId" receiptId={ 12345 } redirectTo="/done" /> );
+
+		expect( reloadCart ).toHaveBeenCalledTimes( 1 );
+		expect( recordPostPurchaseTracking ).not.toHaveBeenCalled();
+		expect( page ).not.toHaveBeenCalled();
+	} );
+
+	it( 'uses the captured cart snapshot when receipt loading fails before redirecting', async () => {
+		const capturedCart = responseCart;
+		const { rerender } = render(
+			<CheckoutPending orderId=":orderId" receiptId={ 12345 } redirectTo="/done" />
+		);
+
+		await waitFor( () => expect( reloadCart ).toHaveBeenCalledTimes( 1 ) );
+
+		responseCart = makeCart( 0 );
+		queryResult = {
+			data: undefined,
+			isSuccess: false,
+			isError: true,
+		};
+		rerender( <CheckoutPending orderId=":orderId" receiptId={ 12345 } redirectTo="/done" /> );
+
+		await waitFor( () =>
+			expect( recordPostPurchaseTracking ).toHaveBeenCalledWith( {
+				receiptId: 12345,
+				receipt: undefined,
+				cart: capturedCart,
+				source: 'checkout-pending',
+			} )
+		);
+		expect( page ).toHaveBeenCalledWith( '/done' );
+	} );
+
+	it( 'redirects when post-purchase tracking throws', async () => {
+		( recordPostPurchaseTracking as jest.Mock ).mockImplementation( () => {
+			throw new Error( 'tracking failed' );
+		} );
+		queryResult = {
+			data: makeReceipt(),
+			isSuccess: true,
+			isError: false,
+		};
+
+		render( <CheckoutPending orderId=":orderId" receiptId={ 12345 } redirectTo="/done" /> );
+
+		await waitFor( () => expect( page ).toHaveBeenCalledWith( '/done' ) );
+	} );
+} );

--- a/client/my-sites/checkout/checkout-thank-you/pending/test/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/test/index.tsx
@@ -186,6 +186,30 @@ describe( 'CheckoutPending post-purchase tracking', () => {
 		expect( page ).toHaveBeenCalledWith( '/done' );
 	} );
 
+	it( 'records loaded receipt details before redirecting successful orders', async () => {
+		const receipt = makeReceipt();
+		queryResult = {
+			data: receipt,
+			isSuccess: true,
+			isError: false,
+		};
+
+		render( <CheckoutPending orderId=":orderId" receiptId={ 12345 } redirectTo="/done" /> );
+
+		await waitFor( () =>
+			expect( recordPostPurchaseTracking ).toHaveBeenCalledWith( {
+				receiptId: 12345,
+				receipt,
+				cart: responseCart,
+				source: 'checkout-pending',
+			} )
+		);
+		expect( page ).toHaveBeenCalledWith( '/done' );
+		expect( recordPostPurchaseTracking.mock.invocationCallOrder[ 0 ] ).toBeLessThan(
+			page.mock.invocationCallOrder[ 0 ]
+		);
+	} );
+
 	it( 'redirects when post-purchase tracking throws', async () => {
 		( recordPostPurchaseTracking as jest.Mock ).mockImplementation( () => {
 			throw new Error( 'tracking failed' );

--- a/client/my-sites/checkout/checkout-thank-you/pending/test/post-purchase-tracking.ts
+++ b/client/my-sites/checkout/checkout-thank-you/pending/test/post-purchase-tracking.ts
@@ -1,0 +1,126 @@
+/**
+ * @jest-environment jsdom
+ */
+// @ts-nocheck - Test fixtures only include the fields used by this helper.
+import {
+	isPostPurchaseWpcomGoogleAdsEnabled,
+	recordPostPurchaseTracking,
+} from 'calypso/lib/analytics/ad-tracking/record-post-purchase';
+import { recordCheckoutPendingPostPurchaseTracking } from '../post-purchase-tracking';
+
+jest.mock( 'calypso/lib/analytics/ad-tracking/record-post-purchase', () => ( {
+	isPostPurchaseWpcomGoogleAdsEnabled: jest.fn(),
+	recordPostPurchaseTracking: jest.fn(),
+} ) );
+
+const receipt = {
+	id: 12345,
+	amount_integer: 1500,
+	currency: 'USD',
+	items: [],
+};
+
+const cart = {
+	total_cost: 15,
+	currency: 'USD',
+	products: [],
+};
+
+describe( 'recordCheckoutPendingPostPurchaseTracking', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		isPostPurchaseWpcomGoogleAdsEnabled.mockReturnValue( true );
+	} );
+
+	it( 'records post-purchase tracking for a successful order with a loaded receipt', () => {
+		recordCheckoutPendingPostPurchaseTracking( {
+			redirectInstructions: { url: '/checkout/thank-you/example.com/12345' },
+			receiptId: 12345,
+			receipt,
+			cart,
+		} );
+
+		expect( recordPostPurchaseTracking ).toHaveBeenCalledWith( {
+			receiptId: 12345,
+			receipt,
+			cart,
+			source: 'checkout-pending',
+		} );
+	} );
+
+	it( 'records post-purchase tracking for a receipt-only success path', () => {
+		recordCheckoutPendingPostPurchaseTracking( {
+			redirectInstructions: { url: '/checkout/thank-you/example.com/12345' },
+			receiptId: 12345,
+			receipt,
+		} );
+
+		expect( recordPostPurchaseTracking ).toHaveBeenCalledWith( {
+			receiptId: 12345,
+			receipt,
+			cart: undefined,
+			source: 'checkout-pending',
+		} );
+	} );
+
+	it( 'does not record tracking without a successful receipt id', () => {
+		recordCheckoutPendingPostPurchaseTracking( {
+			redirectInstructions: { url: '/checkout/example.com' },
+			receiptId: undefined,
+			cart,
+		} );
+
+		expect( recordPostPurchaseTracking ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not record tracking for error, failure, or unknown redirect states', () => {
+		recordCheckoutPendingPostPurchaseTracking( {
+			redirectInstructions: { url: '/checkout/failed-purchases', isError: true },
+			receiptId: 12345,
+			receipt,
+			cart,
+		} );
+		recordCheckoutPendingPostPurchaseTracking( {
+			redirectInstructions: { url: '/checkout/example.com', isError: true },
+			receiptId: 12346,
+			receipt: { ...receipt, id: 12346 },
+			cart,
+		} );
+		recordCheckoutPendingPostPurchaseTracking( {
+			redirectInstructions: { url: '/checkout/example.com', isUnknown: true },
+			receiptId: 12347,
+			receipt: { ...receipt, id: 12347 },
+			cart,
+		} );
+
+		expect( recordPostPurchaseTracking ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not record tracking when the feature flag is disabled', () => {
+		isPostPurchaseWpcomGoogleAdsEnabled.mockReturnValue( false );
+
+		recordCheckoutPendingPostPurchaseTracking( {
+			redirectInstructions: { url: '/checkout/thank-you/example.com/12345' },
+			receiptId: 12345,
+			receipt,
+			cart,
+		} );
+
+		expect( recordPostPurchaseTracking ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not throw when the tracker throws', () => {
+		recordPostPurchaseTracking.mockImplementation( () => {
+			throw new Error( 'tracker failed' );
+		} );
+
+		expect( () =>
+			recordCheckoutPendingPostPurchaseTracking( {
+				redirectInstructions: { url: '/checkout/thank-you/example.com/12345' },
+				receiptId: 12345,
+				receipt,
+				cart,
+			} )
+		).not.toThrow();
+	} );
+} );

--- a/client/my-sites/checkout/src/hooks/use-create-payment-submitted-and-processing-callback.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-submitted-and-processing-callback.tsx
@@ -2,6 +2,10 @@ import { useShoppingCart } from '@automattic/shopping-cart';
 import { isURL } from '@wordpress/url';
 import debugFactory from 'debug';
 import { useCallback } from 'react';
+import {
+	isPostPurchaseWpcomGoogleAdsEnabled,
+	recordPostPurchaseTracking,
+} from 'calypso/lib/analytics/ad-tracking/record-post-purchase';
 import { recordPurchase } from 'calypso/lib/analytics/record-purchase';
 import { hasEcommercePlan } from 'calypso/lib/cart-values/cart-items';
 import getThankYouPageUrl from 'calypso/my-sites/checkout/get-thank-you-page-url';
@@ -203,6 +207,13 @@ export default function useCreatePaymentSubmittedAndProcessingCallback( {
 				reduxDispatch( fetchSiteFeatures( siteId ) );
 			}
 
+			recordOneClickModalPostPurchaseTracking( {
+				disabledThankYouPage,
+				isInModal,
+				responseCart,
+				transactionResult,
+			} );
+
 			// Checkout in the modal might not need thank you page.
 			// For example, Focused Launch is showing a success dialog directly in editor instead of a thank you page.
 			// See https://github.com/Automattic/wp-calypso/pull/47808#issuecomment-755196691
@@ -341,5 +352,45 @@ async function recordPaymentCompleteAnalytics( {
 				failureDescription: 'useCreatePaymentSubmittedAndProcessingCallback',
 			} )
 		);
+	}
+}
+
+export function recordOneClickModalPostPurchaseTracking( {
+	disabledThankYouPage,
+	isInModal,
+	responseCart,
+	transactionResult,
+}: {
+	disabledThankYouPage?: boolean;
+	isInModal?: boolean;
+	responseCart: ResponseCart;
+	transactionResult: WPCOMTransactionEndpointResponse | undefined;
+} ): void {
+	try {
+		const receiptId =
+			transactionResult && 'receipt_id' in transactionResult
+				? transactionResult.receipt_id
+				: undefined;
+
+		if (
+			! isInModal ||
+			! disabledThankYouPage ||
+			hasEcommercePlan( responseCart ) ||
+			! receiptId ||
+			! transactionResult ||
+			! ( 'success' in transactionResult ) ||
+			! transactionResult.success ||
+			! isPostPurchaseWpcomGoogleAdsEnabled()
+		) {
+			return;
+		}
+
+		recordPostPurchaseTracking( {
+			receiptId,
+			cart: responseCart,
+			source: 'one-click-modal',
+		} );
+	} catch {
+		// Tracking must not block the modal success path.
 	}
 }

--- a/client/my-sites/checkout/src/test/one-click-post-purchase-tracking.ts
+++ b/client/my-sites/checkout/src/test/one-click-post-purchase-tracking.ts
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment jsdom
+ */
+// @ts-nocheck - Test fixtures only include the fields used by this helper.
+import {
+	isPostPurchaseWpcomGoogleAdsEnabled,
+	recordPostPurchaseTracking,
+} from 'calypso/lib/analytics/ad-tracking/record-post-purchase';
+import { recordOneClickModalPostPurchaseTracking } from '../hooks/use-create-payment-submitted-and-processing-callback';
+
+jest.mock( 'calypso/lib/analytics/ad-tracking/record-post-purchase', () => ( {
+	isPostPurchaseWpcomGoogleAdsEnabled: jest.fn(),
+	recordPostPurchaseTracking: jest.fn(),
+} ) );
+
+const cart = {
+	total_cost: 19.99,
+	currency: 'USD',
+	products: [],
+};
+
+const successfulTransaction = {
+	success: true,
+	receipt_id: 12345,
+	purchases: {},
+	failed_purchases: {},
+};
+
+describe( 'recordOneClickModalPostPurchaseTracking', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		isPostPurchaseWpcomGoogleAdsEnabled.mockReturnValue( true );
+	} );
+
+	it( 'records post-purchase tracking for successful no-pending modal transactions', () => {
+		recordOneClickModalPostPurchaseTracking( {
+			disabledThankYouPage: true,
+			isInModal: true,
+			responseCart: cart,
+			transactionResult: successfulTransaction,
+		} );
+
+		expect( recordPostPurchaseTracking ).toHaveBeenCalledWith( {
+			receiptId: 12345,
+			cart,
+			source: 'one-click-modal',
+		} );
+	} );
+
+	it( 'does not record tracking when the feature flag is disabled', () => {
+		isPostPurchaseWpcomGoogleAdsEnabled.mockReturnValue( false );
+
+		recordOneClickModalPostPurchaseTracking( {
+			disabledThankYouPage: true,
+			isInModal: true,
+			responseCart: cart,
+			transactionResult: successfulTransaction,
+		} );
+
+		expect( recordPostPurchaseTracking ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not record tracking for failed transactions', () => {
+		recordOneClickModalPostPurchaseTracking( {
+			disabledThankYouPage: true,
+			isInModal: true,
+			responseCart: cart,
+			transactionResult: {
+				...successfulTransaction,
+				success: false,
+			},
+		} );
+
+		expect( recordPostPurchaseTracking ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not throw when the tracker throws', () => {
+		recordPostPurchaseTracking.mockImplementation( () => {
+			throw new Error( 'tracker failed' );
+		} );
+
+		expect( () =>
+			recordOneClickModalPostPurchaseTracking( {
+				disabledThankYouPage: true,
+				isInModal: true,
+				responseCart: cart,
+				transactionResult: successfulTransaction,
+			} )
+		).not.toThrow();
+	} );
+} );

--- a/client/my-sites/checkout/src/test/one-click-post-purchase-tracking.ts
+++ b/client/my-sites/checkout/src/test/one-click-post-purchase-tracking.ts
@@ -74,6 +74,51 @@ describe( 'recordOneClickModalPostPurchaseTracking', () => {
 		expect( recordPostPurchaseTracking ).not.toHaveBeenCalled();
 	} );
 
+	it( 'does not record tracking outside the modal no-pending path', () => {
+		recordOneClickModalPostPurchaseTracking( {
+			disabledThankYouPage: true,
+			isInModal: false,
+			responseCart: cart,
+			transactionResult: successfulTransaction,
+		} );
+		recordOneClickModalPostPurchaseTracking( {
+			disabledThankYouPage: false,
+			isInModal: true,
+			responseCart: cart,
+			transactionResult: successfulTransaction,
+		} );
+
+		expect( recordPostPurchaseTracking ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not record tracking for ecommerce carts because pending handles them', () => {
+		recordOneClickModalPostPurchaseTracking( {
+			disabledThankYouPage: true,
+			isInModal: true,
+			responseCart: {
+				...cart,
+				products: [ { product_slug: 'ecommerce-bundle' } ],
+			},
+			transactionResult: successfulTransaction,
+		} );
+
+		expect( recordPostPurchaseTracking ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not record tracking without a receipt id', () => {
+		recordOneClickModalPostPurchaseTracking( {
+			disabledThankYouPage: true,
+			isInModal: true,
+			responseCart: cart,
+			transactionResult: {
+				...successfulTransaction,
+				receipt_id: 0,
+			},
+		} );
+
+		expect( recordPostPurchaseTracking ).not.toHaveBeenCalled();
+	} );
+
 	it( 'does not throw when the tracker throws', () => {
 		recordPostPurchaseTracking.mockImplementation( () => {
 			throw new Error( 'tracker failed' );

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -43,6 +43,7 @@
 		"a8c-for-agencies": true,
 		"a8c-for-agencies/import-site-from-wpcom": true,
 		"ad-tracking": false,
+		"ad-tracking/post-purchase-wpcom-google-ads": false,
 		"always_use_logout_url": true,
 		"checkout/stripe-upi": true,
 		"cookie-banner": false,

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -39,6 +39,7 @@
 		"a4a/site-migration": true,
 		"a8c-for-agencies": true,
 		"ad-tracking": false,
+		"ad-tracking/post-purchase-wpcom-google-ads": false,
 		"checkout/stripe-upi": true,
 		"cookie-banner": false,
 		"dev/auth-helper": true,

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -39,6 +39,7 @@
 		"a4a-updated-add-new-site": true,
 		"a8c-for-agencies": true,
 		"ad-tracking": true,
+		"ad-tracking/post-purchase-wpcom-google-ads": false,
 		"checkout/stripe-upi": true,
 		"cookie-banner": true,
 		"jetpack/crm-downloads": true,

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -41,6 +41,7 @@
 		"a8c-for-agencies": true,
 		"a8c-for-agencies/import-site-from-wpcom": true,
 		"ad-tracking": false,
+		"ad-tracking/post-purchase-wpcom-google-ads": false,
 		"checkout/stripe-upi": true,
 		"cookie-banner": false,
 		"dev/auth-helper": true,

--- a/config/development.json
+++ b/config/development.json
@@ -43,6 +43,7 @@
 		"100-year-domain": true,
 		"100-year-plan/vip": true,
 		"ad-tracking": false,
+		"ad-tracking/post-purchase-wpcom-google-ads": false,
 		"akismet/checkout-quantity-dropdown": true,
 		"blackbox-login": true,
 		"calypso/ai-blogging-prompts": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -12,6 +12,7 @@
 	"features": {
 		"100-year-plan/vip": true,
 		"ad-tracking": false,
+		"ad-tracking/post-purchase-wpcom-google-ads": false,
 		"blackbox-login": true,
 		"calypso/ai-blogging-prompts": false,
 		"calypso/all-domain-management": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -29,6 +29,7 @@
 	"features": {
 		"activity-log/v2": true,
 		"ad-tracking": true,
+		"ad-tracking/post-purchase-wpcom-google-ads": false,
 		"always_use_logout_url": true,
 		"checkout/checkout-version": false,
 		"checkout/google-pay": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -29,6 +29,7 @@
 	"features": {
 		"activity-log/v2": true,
 		"ad-tracking": false,
+		"ad-tracking/post-purchase-wpcom-google-ads": false,
 		"always_use_logout_url": true,
 		"checkout/checkout-version": false,
 		"checkout/google-pay": false,

--- a/config/production.json
+++ b/config/production.json
@@ -22,6 +22,7 @@
 	"features": {
 		"100-year-plan/vip": true,
 		"ad-tracking": true,
+		"ad-tracking/post-purchase-wpcom-google-ads": false,
 		"akismet/checkout-quantity-dropdown": true,
 		"bilmur-script": true,
 		"blackbox-login": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -20,6 +20,7 @@
 		"100-year-domain": true,
 		"100-year-plan/vip": true,
 		"ad-tracking": false,
+		"ad-tracking/post-purchase-wpcom-google-ads": false,
 		"akismet/checkout-quantity-dropdown": true,
 		"blackbox-login": true,
 		"calypso/ai-blogging-prompts": false,

--- a/config/test.json
+++ b/config/test.json
@@ -23,6 +23,7 @@
 	"features": {
 		"100-year-plan/vip": true,
 		"ad-tracking": false,
+		"ad-tracking/post-purchase-wpcom-google-ads": false,
 		"akismet/checkout-quantity-dropdown": true,
 		"blackbox-login": true,
 		"calypso/all-domain-management": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -20,6 +20,7 @@
 		"100-year-domain": true,
 		"100-year-plan/vip": true,
 		"ad-tracking": false,
+		"ad-tracking/post-purchase-wpcom-google-ads": false,
 		"akismet/checkout-quantity-dropdown": true,
 		"blackbox-login": true,
 		"calypso/ai-blogging-prompts": true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of GE-56
**NOTE: WIP, I'm still testing this, and will clean up the code and automated tests.**


## Proposed Changes

* Move WP.com Google Ads purchase conversion tracking to the checkout pending page gated behind `ad-tracking/post-purchase-wpcom-google-ads`. Preserve the existing purchase tracking path when the feature flag is disabled.
    * We started with this one, because it's the one that was requested in GE-56, and other pixels can follow suit. 

* Keep Jetpack Google Ads purchase tracking unchanged.
* Add one-click/no-pending modal fallback tracking through the same post-purchase helper.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->
This introduces logic for starting to move pixels from the purchase tracking to the pending page, and the 1-click purchases from the modal. 

This should capture more flows, vs. the current approach which won't fire for redirect payment methods.

That's also called out in the code here, so this is a known limitation: https://github.com/Automattic/wp-calypso/blob/ae88e39f6a6470c15f6068b0ecbc3f7d9bf6678f/client/my-sites/checkout/src/hooks/use-create-payment-submitted-and-processing-callback.tsx#L213-L223
* The goal is to capture more purchases in ad/performance trackers, especially if we use the siteless-checkout that creates a site _after_ the purchase.
## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*** TBD, I'm still testing**
* Sandbox the store (tracking does not fire for credits, due to gating)
* Allow ad-tracking and allow all tracking in the GDPR banner if needed. To do this, toggle the feature flags in config/development.json for the cookie-banner, ad-tracking, and the new flag introduced in this PR.
* Go through a purchase with a test card, and notice that the Google Ads pixel for WPcom is not firing among the other pixels (like Facebook), but after, on the pending page. Adding debugger breakpoints to verify if you prefer.
* Go through a siteless checkout, e.g. /checkout/unified/personal, and notice that the Google Ads pixel does fire on the pending page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
