### PR TITLE
Checkout: tighten trust cards layout

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -2285,7 +2285,6 @@ const WPCheckoutCompletedWrapper = styled.div`
 const WPCheckoutMainContent = styled.div`
 	grid-area: main-content;
 	margin-top: 50px;
-	min-height: 100vh;
 
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
 		padding: 0 24px;

--- a/client/my-sites/checkout/src/components/checkout-trust-cards.tsx
+++ b/client/my-sites/checkout/src/components/checkout-trust-cards.tsx
@@ -25,6 +25,13 @@ const TrustCardsRow = styled.div`
 		grid-template-columns: repeat( 3, 1fr );
 		gap: 24px;
 		padding: 0 40px 48px;
+
+		/* When the refund card is hidden, keep the remaining two cards centered
+		   at the same per-card width as the 3-column layout. */
+		&:has( > :nth-child( 2 ):last-child ) {
+			grid-template-columns: repeat( 2, minmax( 0, 1fr ) );
+			max-width: 880px;
+		}
 	}
 `;
 


### PR DESCRIPTION
Stacks on top of #110099.

## Proposed Changes

* Center the trust cards row when the refund card is hidden. With only two cards, the 3-column grid was left-aligning them and leaving empty space on the right.
* Drop a redundant `min-height: 100vh` on `WPCheckoutMainContent`. The wrapper grid already enforces `min-height: 100vh`, so the inner rule was forcing the main-content row to span a full viewport, pushing the trust cards and the "Your payment will be processed by..." line far below the form on short carts.

## Why are these changes being made?

* For non-refundable carts (e.g. domain renewals) the middle "money-back" card is omitted, leaving the remaining two cards left-aligned in the 3-column grid.
* The redundant `min-height: 100vh` produced an empty band above the trust cards on short carts. Removing it keeps them adjacent to the form.

## Testing Instructions

* Open a non-refundable checkout (e.g. a domain renewal).
* Confirm the two remaining trust cards ("Accepted cards" and "SSL secure payment") are centered horizontally on tablet+.
* Confirm there is no empty band between the form/sidebar and the trust cards.
* Open a refundable checkout (e.g. a yearly plan). Confirm the 3-card layout still looks correct and that the gap above the trust cards is also gone.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?