### PR TITLE
e2e tests: Fix new post flows

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -16,6 +16,7 @@ import {
 	EditorWelcomeGuideComponent,
 	EditorBlockToolbarComponent,
 	EditorPopoverMenuComponent,
+	SiteSelectComponent,
 	BlockToolbarButtonIdentifier,
 	CookieBannerComponent,
 	EditorToolbarSettingsButton,
@@ -60,6 +61,7 @@ export class EditorPage {
 	private editorBlockToolbarComponent: EditorBlockToolbarComponent;
 	private editorPopoverMenuComponent: EditorPopoverMenuComponent;
 	private cookieBannerComponent: CookieBannerComponent;
+	private siteSelectComponent: SiteSelectComponent;
 
 	/**
 	 * Constructs an instance of the component.
@@ -89,6 +91,7 @@ export class EditorPage {
 		);
 		this.editorPopoverMenuComponent = new EditorPopoverMenuComponent( page, this.editor );
 		this.cookieBannerComponent = new CookieBannerComponent( page, this.editor );
+		this.siteSelectComponent = new SiteSelectComponent( page );
 
 		// Automatically dismiss the Real-Time Collaboration notice modal whenever
 		// it appears and blocks an action. Using addLocatorHandler ensures it is
@@ -112,7 +115,15 @@ export class EditorPage {
 	): Promise< Response | null > {
 		const request = await this.page.goto( getCalypsoURL( `${ type }/${ siteSlug }` ), {
 			timeout: 30 * 1000,
+			waitUntil: 'domcontentloaded',
 		} );
+
+		// Multi-site users can land on the "Select a site to start writing" interstitial
+		// before Calypso routes to the editor.
+		if ( siteSlug && ( await this.siteSelectComponent.isSiteSelectorVisible() ) ) {
+			await this.siteSelectComponent.selectSite( siteSlug, false );
+		}
+
 		await this.waitUntilLoaded();
 
 		return request;
@@ -155,7 +166,25 @@ export class EditorPage {
 	 * @param {number} timeout Timeout for waiting for the final requests.
 	 */
 	private async waitForEditorLoadedRequests( timeout: number = 60 * 1000 ): Promise< void > {
-		await this.page.waitForURL( /(\/post\/.+|\/page\/+|\/post-new.php|\/post.php+)/, { timeout } );
+		const isEditorUrl = ( url: URL ): boolean =>
+			/(^\/post(?:\/[^/?#]+)?\/?$)|(^\/page(?:\/[^/?#]+)?\/?$)|(^\/post-new\.php$)|(^\/post\.php$)/.test(
+				url.pathname
+			);
+
+		// In some environments the route is already settled by the time we start waiting.
+		if ( isEditorUrl( new URL( this.page.url() ) ) ) {
+			return;
+		}
+
+		await this.page.waitForFunction(
+			( regexSource ) => {
+				const editorPathRegex = new RegExp( regexSource );
+				return editorPathRegex.test( window.location.pathname );
+			},
+			/(^\/post(?:\/[^/?#]+)?\/?$)|(^\/page(?:\/[^/?#]+)?\/?$)|(^\/post-new\.php$)|(^\/post\.php$)/
+				.source,
+			{ timeout }
+		);
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -167,7 +167,7 @@ export class EditorPage {
 	 */
 	private async waitForEditorLoadedRequests( timeout: number = 60 * 1000 ): Promise< void > {
 		const isEditorUrl = ( url: URL ): boolean =>
-			/(^\/post(?:\/[^/?#]+)?\/?$)|(^\/page(?:\/[^/?#]+)?\/?$)|(^\/post-new\.php$)|(^\/post\.php$)/.test(
+			/(^\/post(?:\/[^/?#]+)?\/?$)|(^\/page(?:\/[^/?#]+)?\/?$)|(^\/post-new\.php$)|(^\/post\.php$)|(^\/wp-admin\/post-new\.php$)|(^\/wp-admin\/post\.php$)/.test(
 				url.pathname
 			);
 
@@ -181,7 +181,7 @@ export class EditorPage {
 				const editorPathRegex = new RegExp( regexSource );
 				return editorPathRegex.test( window.location.pathname );
 			},
-			/(^\/post(?:\/[^/?#]+)?\/?$)|(^\/page(?:\/[^/?#]+)?\/?$)|(^\/post-new\.php$)|(^\/post\.php$)/
+			/(^\/post(?:\/[^/?#]+)?\/?$)|(^\/page(?:\/[^/?#]+)?\/?$)|(^\/post-new\.php$)|(^\/post\.php$)|(^\/wp-admin\/post-new\.php$)|(^\/wp-admin\/post\.php$)/
 				.source,
 			{ timeout }
 		);

--- a/packages/calypso-e2e/src/lib/pages/posts-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/posts-page.ts
@@ -44,8 +44,36 @@ export class PostsPage {
 	 *
 	 * Example {@link https://wordpress.com/posts}
 	 */
-	async visit(): Promise< Response | null > {
-		return await this.page.goto( getCalypsoURL( 'posts' ) );
+	async visit( { siteSlug = '' }: { siteSlug?: string } = {} ): Promise< Response | null > {
+		const response = await this.page.goto( getCalypsoURL( 'posts' ) );
+
+		if ( siteSlug ) {
+			const siteLink = this.page.locator( `a:has-text("${ siteSlug }")` ).first();
+			const appeared = await siteLink
+				.waitFor( { state: 'visible', timeout: 5000 } )
+				.then( () => true )
+				.catch( () => false );
+
+			if ( appeared ) {
+				await siteLink.click( { noWaitAfter: true } );
+				await this.page.waitForFunction(
+					() => /\/posts\/|\/wp-admin\/edit\.php|\/home\//.test( window.location.pathname ),
+					undefined,
+					{ timeout: 20 * 1000 }
+				);
+			}
+
+			// Some account/site combinations can still land on Home after site selection.
+			// Force a site-scoped Posts route so wp-admin post table actions are available.
+			if ( /\/home\//.test( new URL( this.page.url() ).pathname ) ) {
+				await this.page.goto( getCalypsoURL( `posts/${ siteSlug }` ), {
+					timeout: 30 * 1000,
+					waitUntil: 'domcontentloaded',
+				} );
+			}
+		}
+
+		return response;
 	}
 
 	/**
@@ -87,12 +115,39 @@ export class PostsPage {
 	/**
 	 * Clicks on the `add new post` button.
 	 */
-	async newPost(): Promise< void > {
+	async newPost( { siteSlug = '' }: { siteSlug?: string } = {} ): Promise< void > {
 		const locator = this.page.locator( selectors.addNewPostButton );
-		await Promise.all( [
-			this.page.waitForNavigation( { url: /post-new.php/, timeout: 20 * 1000 } ),
-			locator.click(),
-		] );
+
+		const hasEditorPath = ( pathName: string ): boolean =>
+			/(^\/post(?:\/[^/?#]+)?\/?$)|(^\/post-new\.php$)|(^\/wp-admin\/post-new\.php$)/.test(
+				pathName
+			);
+
+		const addNewVisible = await locator
+			.first()
+			.waitFor( { state: 'visible', timeout: 5000 } )
+			.then( () => true )
+			.catch( () => false );
+
+		if ( addNewVisible ) {
+			await Promise.all( [
+				this.page.waitForFunction(
+					( regexSource ) => new RegExp( regexSource ).test( window.location.pathname ),
+					/(^\/post(?:\/[^/?#]+)?\/?$)|(^\/post-new\.php$)|(^\/wp-admin\/post-new\.php$)/.source,
+					{ timeout: 20 * 1000 }
+				),
+				locator.click( { noWaitAfter: true } ),
+			] );
+		} else if ( siteSlug ) {
+			await this.page.goto( getCalypsoURL( `post/${ siteSlug }` ), {
+				timeout: 30 * 1000,
+				waitUntil: 'domcontentloaded',
+			} );
+		}
+
+		if ( ! hasEditorPath( new URL( this.page.url() ).pathname ) ) {
+			throw new Error( `Expected to navigate to a post editor route, got ${ this.page.url() }` );
+		}
 	}
 
 	/* Post actions */

--- a/test/e2e/specs/blocks/shared/block-smoke-testing.ts
+++ b/test/e2e/specs/blocks/shared/block-smoke-testing.ts
@@ -36,16 +36,19 @@ export function createBlockTests( specName: string, blockFlows: BlockFlow[] ): v
 		let editorPage: EditorPage;
 		let editorContext: EditorContext;
 		let publishedPostContext: PublishedPostContext;
+		let testAccount: TestAccount;
+		let siteSlug: string;
 
 		beforeAll( async () => {
 			page = await browser.newPage();
 			editorPage = new EditorPage( page );
-			const testAccount = new TestAccount( accountName );
+			testAccount = new TestAccount( accountName );
 			await testAccount.authenticate( page );
+			siteSlug = testAccount.getSiteURL( { protocol: false } );
 		} );
 
 		it( 'Go to the new post page', async () => {
-			await editorPage.visit( 'post' );
+			await editorPage.visit( 'post', { siteSlug } );
 		} );
 
 		it( 'Enter post title', async () => {

--- a/test/e2e/specs/editor/editor__post-advanced-flow.ts
+++ b/test/e2e/specs/editor/editor__post-advanced-flow.ts
@@ -33,6 +33,7 @@ describe( 'Editor: Advanced Post Flow', function () {
 
 	let page: Page;
 	let testAccount: TestAccount;
+	let siteSlug: string;
 	let editorPage: EditorPage;
 	let postsPage: PostsPage;
 	let paragraphBlock: ParagraphBlock;
@@ -43,13 +44,14 @@ describe( 'Editor: Advanced Post Flow', function () {
 
 		testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );
+		siteSlug = testAccount.getSiteURL( { protocol: false } );
 	} );
 
 	describe( 'Publish post', function () {
 		it( 'Start a new post from the Posts page', async function () {
 			postsPage = new PostsPage( page );
-			await postsPage.visit();
-			await postsPage.newPost();
+			await postsPage.visit( { siteSlug } );
+			await postsPage.newPost( { siteSlug } );
 		} );
 
 		it( 'Enter post title', async function () {
@@ -98,7 +100,7 @@ describe( 'Editor: Advanced Post Flow', function () {
 			// an iframe when the post is opened from the
 			// PostsPage.
 			// See: https://github.com/Automattic/wp-calypso/issues/74925
-			await postsPage.visit();
+			await postsPage.visit( { siteSlug } );
 			await postsPage.clickPost( postTitle );
 			editorPage = new EditorPage( page );
 		} );
@@ -146,7 +148,7 @@ describe( 'Editor: Advanced Post Flow', function () {
 	describe( 'Revert post to draft', function () {
 		it( 'Re-open the published post from the Posts page', async function () {
 			// See: https://github.com/Automattic/wp-calypso/issues/74925
-			await postsPage.visit();
+			await postsPage.visit( { siteSlug } );
 			await postsPage.clickPost( postTitle );
 			editorPage = new EditorPage( page );
 		} );
@@ -172,7 +174,7 @@ describe( 'Editor: Advanced Post Flow', function () {
 
 	describe( 'Trash post', function () {
 		beforeAll( async function () {
-			await postsPage.visit();
+			await postsPage.visit( { siteSlug } );
 		} );
 
 		it( 'Trash post', async function () {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* Fix new post flows that are part of GB tests

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* These tests were missing instructions for the interstitial /post page as part of the "new post" tests, so this handles redirecting to the correct site to create a new post

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* All e2e tests should pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
