### PR TITLE
Include Personal & Premium plans on the AI plan picker and update upsell copy [Calypso]

### DIFF
--- a/client/dashboard/sites/settings-ai-tools/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/index.tsx
@@ -240,6 +240,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 					site={ site }
 					feature={ HostingFeatures.BIG_SKY }
 					upsellId="ai-tools"
+					upsellPlanRequirement="any"
 					upsellTitle={ __( 'Your dream site is just a prompt away' ) }
 					upsellDescription={ __(
 						'Get AI-powered assistance to help you build, edit, and redesign your site with ease.'

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1081,7 +1081,11 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 			: baseFeatures;
 	},
 	// Features not displayed but used for checking plan abilities
-	getIncludedFeatures: () => [ FEATURE_AUDIO_UPLOADS, WPCOM_FEATURES_FULL_ACTIVITY_LOG ],
+	getIncludedFeatures: () => [
+		FEATURE_AUDIO_UPLOADS,
+		WPCOM_FEATURES_FULL_ACTIVITY_LOG,
+		WPCOM_FEATURES_BIG_SKY,
+	],
 	getInferiorFeatures: () => [],
 	getCancellationFeatures: () => [
 		FEATURE_FAST_SUPPORT_FROM_EXPERTS,
@@ -1938,6 +1942,7 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_AUDIO_UPLOADS,
 		WPCOM_FEATURES_ANTISPAM,
 		WPCOM_FEATURES_FULL_ACTIVITY_LOG,
+		WPCOM_FEATURES_BIG_SKY,
 	],
 	getInferiorFeatures: () => [],
 	getCancellationFeatures: () => [


### PR DESCRIPTION
Part of DOTMSD-1221

## Proposed Changes

* Add `WPCOM_FEATURES_BIG_SKY` to Personal's `getIncludedFeatures()` in `plans-list.tsx`.
* Add `WPCOM_FEATURES_BIG_SKY` to Premium's `getIncludedFeatures()` in `plans-list.tsx`.
* Add `upsellPlanRequirement="any"` to the AI Tools `<UpsellCallout>` so the subcopy reads "Available on WordPress.com paid plans" instead of "Business and Commerce plans".

## Why are these changes being made?

The wpcom server gate for the Big Sky / AI sidebar feature is widening from Business + Commerce to all paid plans (DOTCOM-16918). Two Calypso surfaces still behave like only Business/Commerce are valid AI plans:

1. The plan-upgrade flow at `/setup/plan-upgrade/?feature=big-sky&siteSlug=…` (used by Free users clicking the AI upsell) filters which plans appear via `planHasFeature(plan, 'big-sky')`. Today only Business and Ecommerce declare `WPCOM_FEATURES_BIG_SKY` in `getIncludedFeatures()`. After this PR, Personal and Premium do too — so a Free user sees Personal/Premium/Business/Commerce in the picker.
2. The AI Settings page at `/sites/<slug>/settings/ai-tools` shows an upsell to free-plan visitors. The shared `UpsellCallout` defaults to "Available on the WordPress.com Business and Commerce plans" — wrong now that Personal/Premium also unlock this feature. `upsellPlanRequirement="any"` is the existing prop value that switches the subcopy to "Available on WordPress.com paid plans" (matches the Activity Logs caller in `activity-logs-callout.tsx`).

Other `UpsellCallout` callers (deployments, logs, monitoring, performance) keep their default copy because those features remain Business/Commerce-only.

**Do not merge until DOTCOM-16918 is live in production**, otherwise the plan picker will show Personal/Premium as AI options but the server will reject enable requests.

**Before:**
<img width="1512" height="829" alt="Screenshot 2026-05-01 at 13 27 51" src="https://github.com/user-attachments/assets/1944b6ed-bf24-43be-ad68-0d8fdaa86cef" />
<img width="1512" height="838" alt="Screenshot 2026-05-01 at 13 28 14" src="https://github.com/user-attachments/assets/58b3f193-2603-4d3f-aced-e487e6f3f2b9" />


**After:** 
<img width="1512" height="835" alt="Screenshot 2026-05-01 at 13 21 46" src="https://github.com/user-attachments/assets/cde4cc11-61a8-4539-a5c2-2c233fa964e8" />

<img width="1512" height="833" alt="Screenshot 2026-05-01 at 13 27 00" src="https://github.com/user-attachments/assets/2365096f-74a7-4622-8ebd-7759d0d101b9" />

## Testing Instructions

Create a free site and go to https://my.wordpress.com/sites/[site-url]/settings/ai-tools. Confirm:
1. Confirm the subcopy reads **"Available on WordPress.com paid plans."** (NOT "...the WordPress.com Business and Commerce plans.")
2. Click "Upgrade plan" -> Confirm: the plan grid shows **Free, Personal, Premium, Business, Commerce** (not just Business/Commerce).


### C. End-to-end after deploy

After this PR merges and deploys, with DOTCOM-16918 also live:

1. Visit `/sites/<personal-slug>/settings/ai-tools` on a real Personal-plan site.
2. Confirm the toggle renders (not the upsell).
3. Click toggle to enable.
5. Open the editor — confirm the AI sidebar appears.

### D. Regression check on other UpsellCallout pages

On a free site, visit each and confirm the copy still says **"Available on the WordPress.com Business and Commerce plans"** (NOT "paid plans"):

* `/sites/<slug>/deployments`
* `/sites/<slug>/logs`
* `/sites/<slug>/monitoring`
* `/sites/<slug>/performance`

Activity Logs (`/sites/<slug>/activity`) already passes `upsellPlanRequirement="any"` and should continue to read "Available on WordPress.com paid plans."

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?