### PR TITLE
Cancel/Remove: cancel plan before showing survey

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-header-title.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-header-title.tsx
@@ -8,15 +8,22 @@ interface CancelHeaderTitleProps {
 	displayVariant: DisplayVariant;
 	purchase: Purchase;
 	surveyStep?: string;
+	surveyShown?: boolean;
 }
 
 export default function CancelHeaderTitle( {
 	displayVariant,
 	purchase,
 	surveyStep,
+	surveyShown,
 }: CancelHeaderTitleProps ) {
 	if ( surveyStep === CANCELLATION_OFFER_STEP ) {
 		return __( 'Thanks for your feedback' );
+	}
+	// Once the cancel mutation has resolved and the user is on the survey,
+	// the cancellation has already happened — reflect that in the title.
+	if ( surveyShown && displayVariant === 'cancel' ) {
+		return __( 'Cancellation confirmed' );
 	}
 	return getCancellationHeading( {
 		purchase,

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
@@ -27,6 +27,7 @@ interface CancellationMainContentProps {
 	selectedDomain?: Domain;
 	state: CancelPurchaseState;
 	purchaseCancelFeatures?: UpgradesCancelFeaturesResponse;
+	isBusy?: boolean;
 	onCancelConfirmationStateChange: ( newState: Partial< CancelPurchaseState > ) => void;
 	onDomainConfirmationChange: ( checked: boolean ) => void;
 	onCustomerConfirmedUnderstandingChange: ( checked: boolean ) => void;
@@ -56,6 +57,7 @@ export default function CancellationMainContent( {
 	selectedDomain,
 	state,
 	purchaseCancelFeatures,
+	isBusy,
 	onCancelConfirmationStateChange,
 	onDomainConfirmationChange,
 	onCustomerConfirmedUnderstandingChange,
@@ -154,6 +156,7 @@ export default function CancellationMainContent( {
 				includedDomainPurchase={ includedDomainPurchase }
 				atomicTransfer={ atomicTransfer }
 				state={ state }
+				isBusy={ isBusy }
 				onDomainConfirmationChange={ onDomainConfirmationChange }
 				onCustomerConfirmedUnderstandingChange={ onCustomerConfirmedUnderstandingChange }
 				onCustomerConfirmedUnderstandingAtomicPlanRevert={

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-pre-survey-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-pre-survey-content.tsx
@@ -17,6 +17,7 @@ interface CancellationPreSurveyContentProps {
 	selectedDomain?: Domain;
 	state: CancelPurchaseState;
 	purchaseCancelFeatures?: UpgradesCancelFeaturesResponse;
+	isBusy?: boolean;
 	onCancelConfirmationStateChange: ( newState: Partial< CancelPurchaseState > ) => void;
 	onDomainConfirmationChange: ( checked: boolean ) => void;
 	onCustomerConfirmedUnderstandingChange: ( checked: boolean ) => void;
@@ -36,6 +37,7 @@ export default function CancellationPreSurveyContent( {
 	selectedDomain,
 	state,
 	purchaseCancelFeatures,
+	isBusy,
 	onCancelConfirmationStateChange,
 	onDomainConfirmationChange,
 	onCustomerConfirmedUnderstandingChange,
@@ -66,6 +68,7 @@ export default function CancellationPreSurveyContent( {
 			selectedDomain={ selectedDomain }
 			state={ state }
 			purchaseCancelFeatures={ purchaseCancelFeatures }
+			isBusy={ isBusy }
 			onCancelConfirmationStateChange={ onCancelConfirmationStateChange }
 			onDomainConfirmationChange={ onDomainConfirmationChange }
 			onCustomerConfirmedUnderstandingChange={ onCustomerConfirmedUnderstandingChange }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy.ts
@@ -469,6 +469,11 @@ export function getCheckboxLabel(): string {
 
 /**
  * Primary and secondary button labels.
+ *
+ * Remove intent: primary is always "Continue removal" — the actual deletion
+ * runs after the survey, so the confirmation button signals continuation, not
+ * the terminal action. Secondary stays per-category so "Keep plan" / "Keep
+ * domain" still match the surrounding copy.
  */
 export function getButtonLabels( { purchase, intent }: ConfirmationCopyArgs ): {
 	primary: string;
@@ -476,23 +481,21 @@ export function getButtonLabels( { purchase, intent }: ConfirmationCopyArgs ): {
 } {
 	const category = getProductCategory( purchase );
 	if ( intent === 'remove' ) {
+		const primary = __( 'Continue removal' );
 		switch ( category ) {
 			case 'plan':
-				return { primary: __( 'Remove plan' ), secondary: __( 'Keep plan' ) };
+				return { primary, secondary: __( 'Keep plan' ) };
 			case 'domain':
-				return { primary: __( 'Remove domain' ), secondary: __( 'Keep domain' ) };
+				return { primary, secondary: __( 'Keep domain' ) };
 			case 'email':
-				return { primary: __( 'Remove email' ), secondary: __( 'Keep email' ) };
+				return { primary, secondary: __( 'Keep email' ) };
 			case 'marketplace':
 				if ( purchase.product_type === 'marketplace_theme' ) {
-					return { primary: __( 'Remove theme' ), secondary: __( 'Keep theme' ) };
+					return { primary, secondary: __( 'Keep theme' ) };
 				}
-				return { primary: __( 'Remove plugin' ), secondary: __( 'Keep plugin' ) };
+				return { primary, secondary: __( 'Keep plugin' ) };
 			default:
-				return {
-					primary: __( 'Remove subscription' ),
-					secondary: __( 'Keep subscription' ),
-				};
+				return { primary, secondary: __( 'Keep subscription' ) };
 		}
 	}
 	// Cancel intent: always "Cancel subscription" / "Keep subscription" to match

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -86,6 +86,7 @@ import MarketPlaceSubscriptionsDialog from './marketplace-subscriptions-dialog';
 import nextStep from './next-step';
 import RefundEligibilityNotice from './refund-eligibility-notice';
 import TimeRemainingNotice from './time-remaining-notice';
+import { useCancelMutationOnConfirm } from './use-cancel-mutation-on-confirm';
 import { useShowRefundEligibilityNotice } from './use-show-refund-eligibility-notice';
 import type { CancelPurchaseState } from './types';
 import type {
@@ -411,6 +412,13 @@ function CancelPurchaseInner() {
 		error: offerApplyError,
 	} = useMutation( applyCancellationOfferMutation( purchase.blog_id, purchase.ID ) );
 	const marketingSurveyMutate = useMutation( marketingSurveyMutation() );
+
+	const { isPending: isMutationPending, fireMutationOnConfirm } = useCancelMutationOnConfirm( {
+		purchase,
+		cancelAndRefundMutation,
+		removePurchaseMutator,
+		destinationRoute: purchasesRoute.to ?? '/me/billing/purchases',
+	} );
 
 	const showRefundEligibilityNotice = useShowRefundEligibilityNotice( purchase );
 
@@ -741,6 +749,116 @@ function CancelPurchaseInner() {
 		} ) );
 	};
 
+	const cancelAllMarketplaceSubscriptions = () => {
+		const cancelAndRefundActiveSubscriptions: Purchase[] = [];
+		const cancelActiveSubscriptions: Purchase[] = [];
+		const marketplaceSubscriptions = getActiveMarketplaceSubscriptions();
+		marketplaceSubscriptions.forEach( ( subscription ) => {
+			hasAmountAvailableToRefund( subscription )
+				? cancelAndRefundActiveSubscriptions.push( subscription )
+				: cancelActiveSubscriptions.push( subscription );
+		} );
+		cancelAndRefundActiveSubscriptions.forEach( ( marketplaceSubscription ) => {
+			cancelAndRefundMutation.mutate(
+				{
+					purchaseId: marketplaceSubscription.ID,
+					options: {
+						product_id: marketplaceSubscription.product_id,
+						cancel_bundled_domain: false,
+					},
+				},
+				{
+					onError: ( error: Error ) => {
+						createErrorNotice( ( error as Error ).message, { type: 'snackbar' } );
+					},
+				}
+			);
+		} );
+		cancelActiveSubscriptions.forEach( ( marketplaceSubscription ) => {
+			setPurchaseAutoRenewMutation.mutate(
+				{ purchaseId: marketplaceSubscription.ID, autoRenew: false },
+				{
+					onError: () => {
+						const purchaseName = marketplaceSubscription.product_name;
+						createErrorNotice(
+							sprintf(
+								/* translators: %(purchaseName)s is the name of the product that was purchased. */
+								__(
+									'There was a problem canceling %(purchaseName)s. Please try again later or contact support.'
+								),
+								{ purchaseName }
+							),
+							{ type: 'snackbar' }
+						);
+						setState( ( state ) => ( { ...state, surveyShown: false, isLoading: false } ) );
+					},
+				}
+			);
+		} );
+	};
+
+	// Mirrors the survey-submit decision so the same effective flow is
+	// available before the mutation fires.
+	const computeEffectiveFlowType = (
+		cancelIntent: CancelPurchaseState[ 'cancelIntent' ]
+	): CancelFlowType => {
+		if ( intent ) {
+			return mutationFlowType;
+		}
+		if ( cancelIntent === 'refund' ) {
+			return CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND;
+		}
+		if ( flowType === CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND && showRefundEligibilityNotice ) {
+			return CANCEL_FLOW_TYPE.CANCEL_AUTORENEW;
+		}
+		return mutationFlowType;
+	};
+
+	// Wraps the hook's mutation-fire with the success/error UX
+	// (snackbar, Survicate, marketplace cleanup) that submitRemovePurchase
+	// and submitCancelAndRefundPurchase otherwise own on the survey-submit path.
+	const fireMutationFromConfirm = (
+		effectiveFlowType: CancelFlowType,
+		cancelBundledDomain?: boolean
+	) => {
+		fireMutationOnConfirm( effectiveFlowType, cancelBundledDomain )
+			.then( () => {
+				if ( effectiveFlowType === CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND ) {
+					if ( purchase.is_plan ) {
+						cancelAllMarketplaceSubscriptions();
+					}
+					createSuccessNotice( __( 'Your refund has been processed and your purchase removed.' ), {
+						type: 'snackbar',
+					} );
+					invokeSurvicateEvent( 'purchaseRefunded' );
+				} else {
+					const purchaseName = purchase.is_domain ? purchase.meta : purchase.product_name;
+					createSuccessNotice(
+						sprintf(
+							/* translators: %(productName)s is the name of a product (e.g., "WordPress.com Premium") and %(siteName)s is a domain name */
+							__( '%(productName)s was removed from %(siteName)s.' ),
+							{
+								productName: purchaseName,
+								siteName: purchase.domain,
+							}
+						),
+						{ type: 'snackbar' }
+					);
+					invokeSurvicateEvent( 'purchaseRemoved' );
+				}
+			} )
+			.catch( ( error: Error ) => {
+				createErrorNotice( error.message, { type: 'snackbar' } );
+			} );
+	};
+
+	// Returns true if the flag-gated mutation-on-confirm path applies for
+	// the given flow. CANCEL_AUTORENEW keeps the trunk in-place flow.
+	const shouldFireMutationOnConfirm = ( effectiveFlowType: CancelFlowType ): boolean =>
+		config.isEnabled( 'purchases/split-cancel-remove' ) &&
+		( effectiveFlowType === CANCEL_FLOW_TYPE.REMOVE ||
+			effectiveFlowType === CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND );
+
 	const onCancellationComplete = () => {
 		recordTracksEvent( 'calypso_purchases_cancel_form_start', {
 			cancellation_flow: flowType,
@@ -748,6 +866,10 @@ function CancelPurchaseInner() {
 			is_atomic: site?.is_wpcom_atomic ?? false,
 			user_lang: locale,
 		} );
+		const effectiveFlowType = computeEffectiveFlowType( state.cancelIntent );
+		if ( shouldFireMutationOnConfirm( effectiveFlowType ) ) {
+			fireMutationFromConfirm( effectiveFlowType, state.cancelBundledDomain ?? false );
+		}
 		setState( ( state ) => ( {
 			...state,
 			confirmationPassed: true,
@@ -786,6 +908,10 @@ function CancelPurchaseInner() {
 				is_atomic: site?.is_wpcom_atomic ?? false,
 				user_lang: locale,
 			} );
+			const effectiveFlowType = computeEffectiveFlowType( cancelIntent );
+			if ( shouldFireMutationOnConfirm( effectiveFlowType ) ) {
+				fireMutationFromConfirm( effectiveFlowType );
+			}
 			setState( ( state ) => ( {
 				...state,
 				cancelIntent,
@@ -935,54 +1061,6 @@ function CancelPurchaseInner() {
 	const activeSubscriptions = getActiveMarketplaceSubscriptions();
 	const shouldHandleMarketplaceSubscriptions = () => {
 		return activeSubscriptions?.length > 0;
-	};
-
-	const cancelAllMarketplaceSubscriptions = () => {
-		const cancelAndRefundActiveSubscriptions: Purchase[] = [];
-		const cancelActiveSubscriptions: Purchase[] = [];
-		const marketplaceSubscriptions = getActiveMarketplaceSubscriptions();
-		marketplaceSubscriptions.forEach( ( subscription ) => {
-			hasAmountAvailableToRefund( subscription )
-				? cancelAndRefundActiveSubscriptions.push( subscription )
-				: cancelActiveSubscriptions.push( subscription );
-		} );
-		cancelAndRefundActiveSubscriptions.forEach( ( marketplaceSubscription ) => {
-			cancelAndRefundMutation.mutate(
-				{
-					purchaseId: marketplaceSubscription.ID,
-					options: {
-						product_id: marketplaceSubscription.product_id,
-						cancel_bundled_domain: false,
-					},
-				},
-				{
-					onError: ( error: Error ) => {
-						createErrorNotice( ( error as Error ).message, { type: 'snackbar' } );
-					},
-				}
-			);
-		} );
-		cancelActiveSubscriptions.forEach( ( marketplaceSubscription ) => {
-			setPurchaseAutoRenewMutation.mutate(
-				{ purchaseId: marketplaceSubscription.ID, autoRenew: false },
-				{
-					onError: () => {
-						const purchaseName = marketplaceSubscription.product_name;
-						createErrorNotice(
-							sprintf(
-								/* translators: %(purchaseName)s is the name of the product that was purchased. */
-								__(
-									'There was a problem canceling %(purchaseName)s. Please try again later or contact support.'
-								),
-								{ purchaseName }
-							),
-							{ type: 'snackbar' }
-						);
-						setState( ( state ) => ( { ...state, surveyShown: false, isLoading: false } ) );
-					},
-				}
-			);
-		} );
 	};
 
 	const submitCancelAndRefundPurchase = ( purchase: Purchase ) => {
@@ -1191,6 +1269,15 @@ function CancelPurchaseInner() {
 			) {
 				effectiveFlowType = CANCEL_FLOW_TYPE.CANCEL_AUTORENEW;
 			}
+		}
+
+		// Flag-on path: the mutation already fired at confirm-click via
+		// fireMutationFromConfirm. The success notice and navigation cleanup
+		// are owned by that helper; here we only need to leave the cancel
+		// flow once the user finishes (or skips) the survey.
+		if ( shouldFireMutationOnConfirm( effectiveFlowType ) ) {
+			navigate( { to: purchasesRoute.to } );
+			return;
 		}
 
 		switch ( effectiveFlowType ) {
@@ -1458,12 +1545,12 @@ function CancelPurchaseInner() {
 			atomicRevertOnClickCheckTwo={ atomicRevertOnClickCheckTwo }
 			atomicTransfer={ atomicTransfer }
 			cancelBundledDomain={ state.cancelBundledDomain }
-			cancellationInProgress={ state.isLoading }
+			cancellationInProgress={ state.isLoading || isMutationPending }
 			cancellationOffer={ cancellationOffer }
 			intent={ intent }
 			clickNext={ clickNext }
 			closeDialog={ closeDialog }
-			disableButtons={ state.isLoading }
+			disableButtons={ state.isLoading || isMutationPending }
 			downgradeClick={ downgradeClick }
 			downgradePlan={ downgradePlan }
 			flowType={ flowType }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -410,7 +410,6 @@ function CancelPurchaseInner() {
 	} = useCancelMutationOnConfirm( {
 		purchase: livePurchase as Purchase,
 		cancelAndRefundMutation,
-		removePurchaseMutator,
 		setPurchaseAutoRenewMutation,
 	} );
 
@@ -865,58 +864,60 @@ function CancelPurchaseInner() {
 		return mutationFlowType;
 	};
 
-	// Wraps the hook's mutation-fire with the success/error UX
-	// (snackbar, Survicate, marketplace cleanup) that submitRemovePurchase
-	// and submitCancelAndRefundPurchase otherwise own on the survey-submit path.
-	const fireMutationFromConfirm = (
+	// Fire the cancel mutation at confirm-time and only advance to the survey
+	// once it resolves. The snackbar is deferred to onSurveyComplete so it
+	// shows on the destination (purchase management) screen, not mid-survey.
+	// Survicate stays tied to mutation success — a background analytics
+	// concern the user doesn't see in the UI.
+	const fireMutationFromConfirm = async (
 		effectiveFlowType: CancelFlowType,
 		cancelBundledDomain?: boolean
 	) => {
-		fireMutationOnConfirm( effectiveFlowType, cancelBundledDomain )
-			.then( () => {
-				const purchaseName = purchase.is_domain ? purchase.meta : purchase.product_name;
-				if ( effectiveFlowType === CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND ) {
-					if ( purchase.is_plan ) {
-						cancelAllMarketplaceSubscriptions();
-					}
-					createSuccessNotice( __( 'Your refund has been processed and your purchase removed.' ), {
-						type: 'snackbar',
-					} );
-					invokeSurvicateEvent( 'purchaseRefunded' );
-				} else if ( effectiveFlowType === CANCEL_FLOW_TYPE.CANCEL_AUTORENEW ) {
-					const subscriptionEndDate = intlFormat(
-						purchase.expiry_date,
-						{ dateStyle: 'medium' },
-						{ locale: 'en-US' }
-					);
-					createSuccessNotice(
-						sprintf(
-							/* translators: %(purchaseName)s is the name of the product that was purchased, %(subscriptionEndDate)s is the date the product will no longer be available because the subscription has ended */
-							__(
-								'%(purchaseName)s was successfully cancelled. It will be available for use until it expires on %(subscriptionEndDate)s.'
-							),
-							{ purchaseName, subscriptionEndDate }
-						),
-						{ type: 'snackbar' }
-					);
-					invokeSurvicateEvent( 'purchaseCancelled' );
-				} else {
-					createSuccessNotice( getRemoveSuccessMessage( purchase ), { type: 'snackbar' } );
-					invokeSurvicateEvent( 'purchaseRemoved' );
-				}
-			} )
-			.catch( ( error: Error ) => {
-				createErrorNotice( error.message, { type: 'snackbar' } );
-			} );
+		try {
+			await fireMutationOnConfirm( effectiveFlowType, cancelBundledDomain );
+			invokeSurvicateEvent( 'purchaseCancelled' );
+			setState( ( state ) => ( {
+				...state,
+				confirmationPassed: true,
+				surveyShown: true,
+				isLoading: false,
+			} ) );
+		} catch ( error ) {
+			createErrorNotice( ( error as Error ).message, { type: 'snackbar' } );
+			// Stay on the confirmation page so the user can retry or back out.
+		}
 	};
 
-	// Returns true if the flag-gated mutation-on-confirm path applies. The
-	// compliance driver (one-click cancel) covers all cancel flows, so any
-	// effectiveFlowType qualifies — REMOVE / CANCEL_WITH_REFUND go through
-	// the deletion-aware cache machinery in the hook; CANCEL_AUTORENEW
-	// dispatches setPurchaseAutoRenewMutation without touching the cache.
+	// Snackbar copy shown on the destination screen after the user finishes (or
+	// skips) the survey on the cancel-intent path. Only CANCEL_AUTORENEW and
+	// CANCEL_WITH_REFUND can reach here — the cancel-intent gate excludes
+	// REMOVE flows.
+	const getCancelSuccessMessage = ( effectiveFlowType: CancelFlowType ): string => {
+		if ( effectiveFlowType === CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND ) {
+			return __( 'Your refund has been processed and your purchase removed.' );
+		}
+		const purchaseName = purchase.is_domain ? purchase.meta : purchase.product_name;
+		const subscriptionEndDate = intlFormat(
+			purchase.expiry_date,
+			{ dateStyle: 'medium' },
+			{ locale: 'en-US' }
+		);
+		return sprintf(
+			/* translators: %(purchaseName)s is the name of the product that was purchased, %(subscriptionEndDate)s is the date the product will no longer be available because the subscription has ended */
+			__(
+				'%(purchaseName)s was successfully cancelled. It will be available for use until it expires on %(subscriptionEndDate)s.'
+			),
+			{ purchaseName, subscriptionEndDate }
+		);
+	};
+
+	// Fire-on-confirm applies to the URL-intent Cancel path only — the user
+	// clicked "Cancel" on Purchase Settings and we want their cancellation to
+	// settle before the survey appears (so the heading can read "Cancellation
+	// confirmed"). Remove (and the no-intent legacy deep link) defer the
+	// mutation to onSurveyComplete, matching trunk's submit-handlers.
 	const shouldFireMutationOnConfirm = (): boolean =>
-		config.isEnabled( 'purchases/split-cancel-remove' );
+		config.isEnabled( 'purchases/split-cancel-remove' ) && intent === 'cancel';
 
 	const onCancellationComplete = () => {
 		recordTracksEvent( 'calypso_purchases_cancel_form_start', {
@@ -926,8 +927,13 @@ function CancelPurchaseInner() {
 			user_lang: locale,
 		} );
 		const effectiveFlowType = computeEffectiveFlowType( state.cancelIntent );
+		// Cancel intent fires the mutation now and only advances to the survey
+		// after it resolves — see fireMutationFromConfirm. Remove (and any non-
+		// intent path) defers to onSurveyComplete and navigates to the survey
+		// synchronously.
 		if ( shouldFireMutationOnConfirm() ) {
 			fireMutationFromConfirm( effectiveFlowType, state.cancelBundledDomain ?? false );
+			return;
 		}
 		setState( ( state ) => ( {
 			...state,
@@ -968,8 +974,17 @@ function CancelPurchaseInner() {
 				user_lang: locale,
 			} );
 			const effectiveFlowType = computeEffectiveFlowType( cancelIntent );
+			// See onCancellationComplete for the rationale on why the cancel
+			// intent path defers surveyShown until the mutation resolves.
 			if ( shouldFireMutationOnConfirm() ) {
+				setState( ( state ) => ( {
+					...state,
+					cancelIntent,
+					customerConfirmedUnderstanding,
+					siteId: purchase.blog_id,
+				} ) );
 				fireMutationFromConfirm( effectiveFlowType );
+				return;
 			}
 			setState( ( state ) => ( {
 				...state,
@@ -1290,12 +1305,15 @@ function CancelPurchaseInner() {
 
 		const effectiveFlowType = computeEffectiveFlowType( state.cancelIntent );
 
-		// Flag-on path: the mutation already fired at confirm-click via
-		// fireMutationFromConfirm. The success notice and navigation cleanup
-		// are owned by that helper; here we only need to leave the cancel
-		// flow once the user finishes (or skips) the survey.
 		if ( shouldFireMutationOnConfirm() ) {
-			navigate( { to: purchasesRoute.to } );
+			// Cancel intent: the mutation already fired at confirm-click via
+			// fireMutationFromConfirm. Show the deferred success snackbar on the
+			// destination (purchase management) screen, then navigate.
+			createSuccessNotice( getCancelSuccessMessage( effectiveFlowType ), { type: 'snackbar' } );
+			navigate( {
+				to: purchaseSettingsRoute.fullPath,
+				params: { purchaseId: purchase.ID },
+			} );
 			return;
 		}
 
@@ -1622,6 +1640,7 @@ function CancelPurchaseInner() {
 							displayVariant={ displayVariant }
 							purchase={ purchase }
 							surveyStep={ state.surveyStep }
+							surveyShown={ state.surveyShown }
 						/>
 					}
 					prefix={ <Breadcrumbs length={ 4 } /> }
@@ -1654,6 +1673,7 @@ function CancelPurchaseInner() {
 									selectedDomain={ selectedDomain }
 									state={ state }
 									purchaseCancelFeatures={ purchaseCancelFeatures }
+									isBusy={ isMutationPending }
 									onCancelConfirmationStateChange={ onCancelConfirmationStateChange }
 									onDomainConfirmationChange={ onDomainConfirmationChange }
 									onCustomerConfirmedUnderstandingChange={ onCustomerConfirmedUnderstandingChange }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -846,8 +846,11 @@ function CancelPurchaseInner() {
 		} );
 	};
 
-	// Mirrors the survey-submit decision so the same effective flow is
-	// available before the mutation fires.
+	// Single source of truth for the effective flow when intent is URL-sourced
+	// (Purchase Settings Cancel/Remove buttons), the eligibility banner sets
+	// refund intent, or the treatment banner forces auto-renew off on the
+	// default Cancel of a refundable plan. Takes cancelIntent as a parameter
+	// so confirm-click callers can pass the fresh value before setState commits.
 	const computeEffectiveFlowType = (
 		cancelIntent: CancelPurchaseState[ 'cancelIntent' ]
 	): CancelFlowType => {
@@ -1286,23 +1289,7 @@ function CancelPurchaseInner() {
 		// Set loading state to show busy button
 		setState( ( state ) => ( { ...state, isLoading: true } ) );
 
-		// When intent is URL-sourced (user arrived via the Purchase Settings
-		// Cancel/Remove buttons), mutationFlowType is already the correct choice.
-		// When intent is absent, fall back to today's banner-driven override:
-		// refund intent set by the eligibility banner forces the refund flow;
-		// the default Cancel on a refundable plan + treatment banner falls back to
-		// auto-renew off.
-		let effectiveFlowType: CancelFlowType = mutationFlowType;
-		if ( ! intent ) {
-			if ( state.cancelIntent === 'refund' ) {
-				effectiveFlowType = CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND;
-			} else if (
-				flowType === CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND &&
-				showRefundEligibilityNotice
-			) {
-				effectiveFlowType = CANCEL_FLOW_TYPE.CANCEL_AUTORENEW;
-			}
-		}
+		const effectiveFlowType = computeEffectiveFlowType( state.cancelIntent );
 
 		// Flag-on path: the mutation already fired at confirm-click via
 		// fireMutationFromConfirm. The success notice and navigation cleanup

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -417,6 +417,7 @@ function CancelPurchaseInner() {
 		purchase,
 		cancelAndRefundMutation,
 		removePurchaseMutator,
+		setPurchaseAutoRenewMutation,
 		destinationRoute: purchasesRoute.to ?? '/me/billing/purchases',
 	} );
 
@@ -823,6 +824,7 @@ function CancelPurchaseInner() {
 	) => {
 		fireMutationOnConfirm( effectiveFlowType, cancelBundledDomain )
 			.then( () => {
+				const purchaseName = purchase.is_domain ? purchase.meta : purchase.product_name;
 				if ( effectiveFlowType === CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND ) {
 					if ( purchase.is_plan ) {
 						cancelAllMarketplaceSubscriptions();
@@ -831,8 +833,24 @@ function CancelPurchaseInner() {
 						type: 'snackbar',
 					} );
 					invokeSurvicateEvent( 'purchaseRefunded' );
+				} else if ( effectiveFlowType === CANCEL_FLOW_TYPE.CANCEL_AUTORENEW ) {
+					const subscriptionEndDate = intlFormat(
+						purchase.expiry_date,
+						{ dateStyle: 'medium' },
+						{ locale: 'en-US' }
+					);
+					createSuccessNotice(
+						sprintf(
+							/* translators: %(purchaseName)s is the name of the product that was purchased, %(subscriptionEndDate)s is the date the product will no longer be available because the subscription has ended */
+							__(
+								'%(purchaseName)s was successfully cancelled. It will be available for use until it expires on %(subscriptionEndDate)s.'
+							),
+							{ purchaseName, subscriptionEndDate }
+						),
+						{ type: 'snackbar' }
+					);
+					invokeSurvicateEvent( 'purchaseCancelled' );
 				} else {
-					const purchaseName = purchase.is_domain ? purchase.meta : purchase.product_name;
 					createSuccessNotice(
 						sprintf(
 							/* translators: %(productName)s is the name of a product (e.g., "WordPress.com Premium") and %(siteName)s is a domain name */
@@ -852,12 +870,13 @@ function CancelPurchaseInner() {
 			} );
 	};
 
-	// Returns true if the flag-gated mutation-on-confirm path applies for
-	// the given flow. CANCEL_AUTORENEW keeps the trunk in-place flow.
-	const shouldFireMutationOnConfirm = ( effectiveFlowType: CancelFlowType ): boolean =>
-		config.isEnabled( 'purchases/split-cancel-remove' ) &&
-		( effectiveFlowType === CANCEL_FLOW_TYPE.REMOVE ||
-			effectiveFlowType === CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND );
+	// Returns true if the flag-gated mutation-on-confirm path applies. The
+	// compliance driver (one-click cancel) covers all cancel flows, so any
+	// effectiveFlowType qualifies — REMOVE / CANCEL_WITH_REFUND go through
+	// the deletion-aware cache machinery in the hook; CANCEL_AUTORENEW
+	// dispatches setPurchaseAutoRenewMutation without touching the cache.
+	const shouldFireMutationOnConfirm = (): boolean =>
+		config.isEnabled( 'purchases/split-cancel-remove' );
 
 	const onCancellationComplete = () => {
 		recordTracksEvent( 'calypso_purchases_cancel_form_start', {
@@ -867,7 +886,7 @@ function CancelPurchaseInner() {
 			user_lang: locale,
 		} );
 		const effectiveFlowType = computeEffectiveFlowType( state.cancelIntent );
-		if ( shouldFireMutationOnConfirm( effectiveFlowType ) ) {
+		if ( shouldFireMutationOnConfirm() ) {
 			fireMutationFromConfirm( effectiveFlowType, state.cancelBundledDomain ?? false );
 		}
 		setState( ( state ) => ( {
@@ -909,7 +928,7 @@ function CancelPurchaseInner() {
 				user_lang: locale,
 			} );
 			const effectiveFlowType = computeEffectiveFlowType( cancelIntent );
-			if ( shouldFireMutationOnConfirm( effectiveFlowType ) ) {
+			if ( shouldFireMutationOnConfirm() ) {
 				fireMutationFromConfirm( effectiveFlowType );
 			}
 			setState( ( state ) => ( {
@@ -1275,7 +1294,7 @@ function CancelPurchaseInner() {
 		// fireMutationFromConfirm. The success notice and navigation cleanup
 		// are owned by that helper; here we only need to leave the cancel
 		// flow once the user finishes (or skips) the survey.
-		if ( shouldFireMutationOnConfirm( effectiveFlowType ) ) {
+		if ( shouldFireMutationOnConfirm() ) {
 			navigate( { to: purchasesRoute.to } );
 			return;
 		}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -412,7 +412,6 @@ function CancelPurchaseInner() {
 		cancelAndRefundMutation,
 		removePurchaseMutator,
 		setPurchaseAutoRenewMutation,
-		destinationRoute: purchasesRoute.to ?? '/me/billing/purchases',
 	} );
 
 	// Pre-confirm: livePurchase from the cache (loader pre-fetched).

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -146,6 +146,36 @@ function renderTopNotice( args: TopNoticeArgs ) {
 	);
 }
 
+// Build the success-snackbar message after a Remove mutation. Three shapes:
+// 1. Default: "%(productName)s was removed from %(siteName)s."
+// 2. Akismet/Jetpack holding-site purchase: drops the siteless.* domain.
+// 3. Domain registration: addresses the domain by name.
+function getRemoveSuccessMessage( purchase: Purchase ): string {
+	const purchaseName = purchase.is_domain ? purchase.meta : purchase.product_name;
+	if ( isAkismetHoldingSitePurchase( purchase ) || isJetpackHoldingSitePurchase( purchase ) ) {
+		return sprintf(
+			/* translators: %(productName)s is the name of a product (e.g., "WordPress.com Premium") */
+			__( '%(productName)s was removed from your account.' ),
+			{ productName: purchaseName }
+		);
+	}
+	if ( purchase.is_domain_registration ) {
+		return sprintf(
+			/* translators: %(domain)s is a domain name */
+			__( 'The domain %(domain)s was removed from your account.' ),
+			{ domain: purchaseName }
+		);
+	}
+	return sprintf(
+		/* translators: %(productName)s is the name of a product (e.g., "WordPress.com Premium") and %(siteName)s is a domain name */
+		__( '%(productName)s was removed from %(siteName)s.' ),
+		{
+			productName: purchaseName,
+			siteName: purchase.domain,
+		}
+	);
+}
+
 const willShowDomainOptionsRadioButtons = (
 	includedDomainPurchase: Purchase,
 	purchase: Purchase
@@ -359,9 +389,38 @@ function CancelPurchaseInner() {
 	};
 
 	// Queries
-	const { data: purchase, isPending: purchaseQueryIsPending } = useSuspenseQuery(
+	// `useQuery` (not `useSuspenseQuery`) so a post-mutation 404 from the
+	// prefix-matched invalidation cascade returns an error result rather than
+	// throwing to the error boundary; the snapshot below covers the read.
+	// The route loader pre-fetches via `ensureQueryData`, so first paint is
+	// instant — `livePurchase` is defined on first render.
+	const { data: livePurchase, isPending: purchaseQueryIsPending } = useQuery(
 		purchaseQuery( parseInt( purchaseId ) )
 	);
+
+	// Mutations consumed by useCancelMutationOnConfirm
+	const setPurchaseAutoRenewMutation = useMutation( userPurchaseSetAutoRenewQuery() );
+	const cancelAndRefundMutation = useMutation( cancelAndRefundPurchaseMutation() );
+	const removePurchaseMutator = useMutation( removePurchaseMutation() );
+
+	const {
+		isPending: isMutationPending,
+		fireMutationOnConfirm,
+		snapshotPurchase,
+	} = useCancelMutationOnConfirm( {
+		purchase: livePurchase as Purchase,
+		cancelAndRefundMutation,
+		removePurchaseMutator,
+		setPurchaseAutoRenewMutation,
+		destinationRoute: purchasesRoute.to ?? '/me/billing/purchases',
+	} );
+
+	// Pre-confirm: livePurchase from the cache (loader pre-fetched).
+	// Post-confirm: the hook captured snapshotPurchase synchronously at
+	// fire-time, so reads of `purchase` continue to work even if the
+	// mutation's invalidation tears down livePurchase.
+	const purchase = ( snapshotPurchase ?? livePurchase ) as Purchase;
+
 	const { data: sitePurchases } = useSuspenseQuery( sitePurchasesQuery( purchase.blog_id ) );
 	const { data: siteFeatures, isPending: siteFeaturesQueryIsPending } = useSuspenseQuery(
 		siteFeaturesQuery( purchase.blog_id )
@@ -397,10 +456,7 @@ function CancelPurchaseInner() {
 		useQuery( userPreferenceQuery( getCancelPurchaseSurveyCompletedPreferenceKey( purchase.ID ) ) );
 	const userHasCompletedCancelSurveyForPurchase = Boolean( userPreferenceForSurveyComplete );
 
-	// Mutations
-	const setPurchaseAutoRenewMutation = useMutation( userPurchaseSetAutoRenewQuery() );
-	const cancelAndRefundMutation = useMutation( cancelAndRefundPurchaseMutation() );
-	const removePurchaseMutator = useMutation( removePurchaseMutation() );
+	// Mutations (continued)
 	const extendWithFreeMonthMutation = useMutation( extendPurchaseWithFreeMonthMutation() );
 	const surveyCompletedMutator = useMutation(
 		userPreferenceMutation( getCancelPurchaseSurveyCompletedPreferenceKey( purchase.ID ) )
@@ -412,14 +468,6 @@ function CancelPurchaseInner() {
 		error: offerApplyError,
 	} = useMutation( applyCancellationOfferMutation( purchase.blog_id, purchase.ID ) );
 	const marketingSurveyMutate = useMutation( marketingSurveyMutation() );
-
-	const { isPending: isMutationPending, fireMutationOnConfirm } = useCancelMutationOnConfirm( {
-		purchase,
-		cancelAndRefundMutation,
-		removePurchaseMutator,
-		setPurchaseAutoRenewMutation,
-		destinationRoute: purchasesRoute.to ?? '/me/billing/purchases',
-	} );
 
 	const showRefundEligibilityNotice = useShowRefundEligibilityNotice( purchase );
 
@@ -851,17 +899,7 @@ function CancelPurchaseInner() {
 					);
 					invokeSurvicateEvent( 'purchaseCancelled' );
 				} else {
-					createSuccessNotice(
-						sprintf(
-							/* translators: %(productName)s is the name of a product (e.g., "WordPress.com Premium") and %(siteName)s is a domain name */
-							__( '%(productName)s was removed from %(siteName)s.' ),
-							{
-								productName: purchaseName,
-								siteName: purchase.domain,
-							}
-						),
-						{ type: 'snackbar' }
-					);
+					createSuccessNotice( getRemoveSuccessMessage( purchase ), { type: 'snackbar' } );
 					invokeSurvicateEvent( 'purchaseRemoved' );
 				}
 			} )
@@ -1172,31 +1210,7 @@ function CancelPurchaseInner() {
 
 		removePurchaseMutator.mutate( purchase.ID, {
 			onSuccess: () => {
-				const purchaseName = purchase.is_domain ? purchase.meta : purchase.product_name;
-				/* translators: %(productName)s is the name of a product (e.g., "WordPress.com Premium") and %(siteName)s is a domain name */
-				let successMessage = sprintf( __( '%(productName)s was removed from %(siteName)s.' ), {
-					productName: purchaseName,
-					siteName: purchase.domain,
-				} );
-				if (
-					isAkismetHoldingSitePurchase( purchase ) ||
-					isJetpackHoldingSitePurchase( purchase )
-				) {
-					/* translators: %(productName)s is the name of a product (e.g., "WordPress.com Premium") */
-					successMessage = sprintf( __( '%(productName)s was removed from your account.' ), {
-						productName: purchaseName,
-					} );
-				}
-				if ( purchase.is_domain_registration ) {
-					successMessage = sprintf(
-						/* translators: %(domain)s is a domain name */
-						__( 'The domain %(domain)s was removed from your account.' ),
-						{
-							domain: purchaseName,
-						}
-					);
-				}
-				createSuccessNotice( successMessage, { type: 'snackbar' } );
+				createSuccessNotice( getRemoveSuccessMessage( purchase ), { type: 'snackbar' } );
 				invokeSurvicateEvent( 'purchaseRemoved' );
 				navigate( {
 					to: purchaseSettingsRoute.fullPath,

--- a/client/dashboard/me/billing-purchases/cancel-purchase/plan-product-revert-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/plan-product-revert-content.tsx
@@ -13,6 +13,7 @@ interface PlanProductRevertContentProps {
 	includedDomainPurchase?: Purchase;
 	atomicTransfer?: AtomicTransfer;
 	state: CancelPurchaseState;
+	isBusy?: boolean;
 	onDomainConfirmationChange: ( checked: boolean ) => void;
 	onCustomerConfirmedUnderstandingChange: ( checked: boolean ) => void;
 	onCustomerConfirmedUnderstandingAtomicPlanRevert: ( checked: boolean ) => void;
@@ -26,6 +27,7 @@ export default function PlanProductRevertContent( {
 	includedDomainPurchase,
 	atomicTransfer,
 	state,
+	isBusy,
 	onDomainConfirmationChange,
 	onCustomerConfirmedUnderstandingChange,
 	onCustomerConfirmedUnderstandingAtomicPlanRevert,
@@ -55,6 +57,7 @@ export default function PlanProductRevertContent( {
 					includedDomainPurchase={ includedDomainPurchase }
 					atomicTransfer={ atomicTransfer }
 					state={ state }
+					isBusy={ isBusy }
 					onClick={ onCancelClick }
 				/>
 				<KeepSubscriptionButton

--- a/client/dashboard/me/billing-purchases/cancel-purchase/test/get-confirmation-copy.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/test/get-confirmation-copy.ts
@@ -226,16 +226,16 @@ describe( 'getButtonLabels', () => {
 			} );
 		}
 	} );
-	test( 'Remove uses category labels', () => {
+	test( 'Remove primary is "Continue removal"; secondary stays per-category', () => {
 		expect(
 			getButtonLabels( { purchase: makePurchaseForCategory( 'plan' ), intent: 'remove' } )
-		).toEqual( { primary: 'Remove plan', secondary: 'Keep plan' } );
+		).toEqual( { primary: 'Continue removal', secondary: 'Keep plan' } );
 		expect(
 			getButtonLabels( { purchase: makePurchaseForCategory( 'domain' ), intent: 'remove' } )
-		).toEqual( { primary: 'Remove domain', secondary: 'Keep domain' } );
+		).toEqual( { primary: 'Continue removal', secondary: 'Keep domain' } );
 		expect(
 			getButtonLabels( { purchase: makePurchaseForCategory( 'email' ), intent: 'remove' } )
-		).toEqual( { primary: 'Remove email', secondary: 'Keep email' } );
+		).toEqual( { primary: 'Continue removal', secondary: 'Keep email' } );
 	} );
 } );
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/test/use-cancel-mutation-on-confirm.test.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/test/use-cancel-mutation-on-confirm.test.tsx
@@ -1,9 +1,10 @@
 /**
  * @jest-environment jsdom
  */
+import { userPurchasesQuery } from '@automattic/api-queries';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, act, waitFor } from '@testing-library/react';
-import { useState, type ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import { CANCEL_FLOW_TYPE } from '../../../../utils/purchase';
 import { useCancelMutationOnConfirm } from '../use-cancel-mutation-on-confirm';
 import type { Purchase } from '@automattic/api-core';
@@ -50,17 +51,19 @@ function makeMutations() {
 	};
 }
 
-function TestWrapper( { children }: { children: ReactNode } ) {
-	const [ queryClient ] = useState(
-		() =>
-			new QueryClient( {
-				defaultOptions: {
-					queries: { retry: false },
-					mutations: { retry: false },
-				},
-			} )
-	);
-	return <QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>;
+function makeQueryClient() {
+	return new QueryClient( {
+		defaultOptions: {
+			queries: { retry: false },
+			mutations: { retry: false },
+		},
+	} );
+}
+
+function makeTestWrapper( queryClient: QueryClient ) {
+	return function TestWrapper( { children }: { children: ReactNode } ) {
+		return <QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>;
+	};
 }
 
 describe( 'useCancelMutationOnConfirm', () => {
@@ -70,6 +73,7 @@ describe( 'useCancelMutationOnConfirm', () => {
 
 	test( 'fireMutationOnConfirm dispatches the remove mutation for REMOVE flow', async () => {
 		const mutations = makeMutations();
+		const queryClient = makeQueryClient();
 
 		const { result } = renderHook(
 			() =>
@@ -78,7 +82,7 @@ describe( 'useCancelMutationOnConfirm', () => {
 					...mutations,
 					destinationRoute: '/me/purchases',
 				} ),
-			{ wrapper: TestWrapper }
+			{ wrapper: makeTestWrapper( queryClient ) }
 		);
 
 		act( () => {
@@ -94,6 +98,7 @@ describe( 'useCancelMutationOnConfirm', () => {
 
 	test( 'fireMutationOnConfirm dispatches the auto-renew-off mutation for CANCEL_AUTORENEW flow', async () => {
 		const mutations = makeMutations();
+		const queryClient = makeQueryClient();
 
 		const { result } = renderHook(
 			() =>
@@ -102,7 +107,7 @@ describe( 'useCancelMutationOnConfirm', () => {
 					...mutations,
 					destinationRoute: '/me/purchases',
 				} ),
-			{ wrapper: TestWrapper }
+			{ wrapper: makeTestWrapper( queryClient ) }
 		);
 
 		act( () => {
@@ -119,6 +124,142 @@ describe( 'useCancelMutationOnConfirm', () => {
 		expect( mutations.cancelAndRefundMutation.mutateAsync ).not.toHaveBeenCalled();
 	} );
 
+	test( 'fireMutationOnConfirm dispatches the cancel-and-refund mutation for CANCEL_WITH_REFUND flow', async () => {
+		const mutations = makeMutations();
+		const queryClient = makeQueryClient();
+
+		const purchaseWithProductId = {
+			...mockPurchase,
+			product_id: 9876,
+		} as Purchase;
+
+		const { result } = renderHook(
+			() =>
+				useCancelMutationOnConfirm( {
+					purchase: purchaseWithProductId,
+					...mutations,
+					destinationRoute: '/me/purchases',
+				} ),
+			{ wrapper: makeTestWrapper( queryClient ) }
+		);
+
+		act( () => {
+			result.current.fireMutationOnConfirm( CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND, true );
+		} );
+
+		await waitFor( () => {
+			expect( mutations.cancelAndRefundMutation.mutateAsync ).toHaveBeenCalledWith( {
+				purchaseId: purchaseWithProductId.ID,
+				options: {
+					product_id: 9876,
+					cancel_bundled_domain: true,
+				},
+			} );
+		} );
+		expect( mutations.removePurchaseMutator.mutateAsync ).not.toHaveBeenCalled();
+		expect( mutations.setPurchaseAutoRenewMutation.mutateAsync ).not.toHaveBeenCalled();
+	} );
+
+	test( 'fireMutationOnConfirm strips the deleted purchase from userPurchasesQuery cache after success', async () => {
+		const mutations = makeMutations();
+		const queryClient = makeQueryClient();
+
+		const otherPurchase = { ID: 99999 } as Purchase;
+		queryClient.setQueryData( userPurchasesQuery().queryKey, [ mockPurchase, otherPurchase ] );
+
+		const { result } = renderHook(
+			() =>
+				useCancelMutationOnConfirm( {
+					purchase: mockPurchase,
+					...mutations,
+					destinationRoute: '/me/purchases',
+				} ),
+			{ wrapper: makeTestWrapper( queryClient ) }
+		);
+
+		act( () => {
+			result.current.fireMutationOnConfirm( CANCEL_FLOW_TYPE.REMOVE );
+		} );
+
+		await waitFor( () => {
+			expect( queryClient.getQueryData( userPurchasesQuery().queryKey ) ).toEqual( [
+				otherPurchase,
+			] );
+		} );
+	} );
+
+	test( 'fireMutationOnConfirm captures the purchase into snapshotPurchase for REMOVE flow', async () => {
+		const mutations = makeMutations();
+		const queryClient = makeQueryClient();
+
+		const { result } = renderHook(
+			() =>
+				useCancelMutationOnConfirm( {
+					purchase: mockPurchase,
+					...mutations,
+					destinationRoute: '/me/purchases',
+				} ),
+			{ wrapper: makeTestWrapper( queryClient ) }
+		);
+
+		expect( result.current.snapshotPurchase ).toBeNull();
+
+		act( () => {
+			result.current.fireMutationOnConfirm( CANCEL_FLOW_TYPE.REMOVE );
+		} );
+
+		await waitFor( () => {
+			expect( result.current.snapshotPurchase ).toBe( mockPurchase );
+		} );
+	} );
+
+	test( 'fireMutationOnConfirm captures the purchase into snapshotPurchase for CANCEL_WITH_REFUND flow', async () => {
+		const mutations = makeMutations();
+		const queryClient = makeQueryClient();
+
+		const { result } = renderHook(
+			() =>
+				useCancelMutationOnConfirm( {
+					purchase: mockPurchase,
+					...mutations,
+					destinationRoute: '/me/purchases',
+				} ),
+			{ wrapper: makeTestWrapper( queryClient ) }
+		);
+
+		act( () => {
+			result.current.fireMutationOnConfirm( CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND );
+		} );
+
+		await waitFor( () => {
+			expect( result.current.snapshotPurchase ).toBe( mockPurchase );
+		} );
+	} );
+
+	test( 'fireMutationOnConfirm does NOT capture snapshotPurchase for CANCEL_AUTORENEW flow', async () => {
+		const mutations = makeMutations();
+		const queryClient = makeQueryClient();
+
+		const { result } = renderHook(
+			() =>
+				useCancelMutationOnConfirm( {
+					purchase: mockPurchase,
+					...mutations,
+					destinationRoute: '/me/purchases',
+				} ),
+			{ wrapper: makeTestWrapper( queryClient ) }
+		);
+
+		act( () => {
+			result.current.fireMutationOnConfirm( CANCEL_FLOW_TYPE.CANCEL_AUTORENEW );
+		} );
+
+		await waitFor( () =>
+			expect( mutations.setPurchaseAutoRenewMutation.mutateAsync ).toHaveBeenCalled()
+		);
+		expect( result.current.snapshotPurchase ).toBeNull();
+	} );
+
 	test( 'isPending is true while the mutation is in flight, false after it resolves', async () => {
 		let resolveMutation: ( value?: unknown ) => void = () => {};
 		const removePurchaseMutator = {
@@ -131,6 +272,7 @@ describe( 'useCancelMutationOnConfirm', () => {
 		} as unknown as { mutateAsync: jest.Mock };
 		const cancelAndRefundMutation = makeMutation();
 		const setPurchaseAutoRenewMutation = makeMutation();
+		const queryClient = makeQueryClient();
 
 		const { result } = renderHook(
 			() =>
@@ -141,7 +283,7 @@ describe( 'useCancelMutationOnConfirm', () => {
 					setPurchaseAutoRenewMutation,
 					destinationRoute: '/me/purchases',
 				} ),
-			{ wrapper: TestWrapper }
+			{ wrapper: makeTestWrapper( queryClient ) }
 		);
 
 		expect( result.current.isPending ).toBe( false );
@@ -161,6 +303,7 @@ describe( 'useCancelMutationOnConfirm', () => {
 
 	test( 'skipSurvey navigates to destination without dispatching any mutation', () => {
 		const mutations = makeMutations();
+		const queryClient = makeQueryClient();
 
 		const { result } = renderHook(
 			() =>
@@ -169,7 +312,7 @@ describe( 'useCancelMutationOnConfirm', () => {
 					...mutations,
 					destinationRoute: '/me/purchases',
 				} ),
-			{ wrapper: TestWrapper }
+			{ wrapper: makeTestWrapper( queryClient ) }
 		);
 
 		act( () => {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/test/use-cancel-mutation-on-confirm.test.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/test/use-cancel-mutation-on-confirm.test.tsx
@@ -11,16 +11,6 @@ import type { Purchase } from '@automattic/api-core';
 
 jest.mock( '@automattic/api-core', () => ( {} ) );
 
-const mockNavigate = jest.fn();
-
-jest.mock( '@tanstack/react-router', () => {
-	const actual = jest.requireActual( '@tanstack/react-router' );
-	return {
-		...actual,
-		useNavigate: () => mockNavigate,
-	};
-} );
-
 jest.mock( '@wordpress/data', () => ( {
 	useDispatch: () => ( {
 		createSuccessNotice: jest.fn(),
@@ -67,10 +57,6 @@ function makeTestWrapper( queryClient: QueryClient ) {
 }
 
 describe( 'useCancelMutationOnConfirm', () => {
-	beforeEach( () => {
-		mockNavigate.mockClear();
-	} );
-
 	test( 'fireMutationOnConfirm dispatches the remove mutation for REMOVE flow', async () => {
 		const mutations = makeMutations();
 		const queryClient = makeQueryClient();
@@ -80,7 +66,6 @@ describe( 'useCancelMutationOnConfirm', () => {
 				useCancelMutationOnConfirm( {
 					purchase: mockPurchase,
 					...mutations,
-					destinationRoute: '/me/purchases',
 				} ),
 			{ wrapper: makeTestWrapper( queryClient ) }
 		);
@@ -105,7 +90,6 @@ describe( 'useCancelMutationOnConfirm', () => {
 				useCancelMutationOnConfirm( {
 					purchase: mockPurchase,
 					...mutations,
-					destinationRoute: '/me/purchases',
 				} ),
 			{ wrapper: makeTestWrapper( queryClient ) }
 		);
@@ -138,7 +122,6 @@ describe( 'useCancelMutationOnConfirm', () => {
 				useCancelMutationOnConfirm( {
 					purchase: purchaseWithProductId,
 					...mutations,
-					destinationRoute: '/me/purchases',
 				} ),
 			{ wrapper: makeTestWrapper( queryClient ) }
 		);
@@ -172,7 +155,6 @@ describe( 'useCancelMutationOnConfirm', () => {
 				useCancelMutationOnConfirm( {
 					purchase: mockPurchase,
 					...mutations,
-					destinationRoute: '/me/purchases',
 				} ),
 			{ wrapper: makeTestWrapper( queryClient ) }
 		);
@@ -197,7 +179,6 @@ describe( 'useCancelMutationOnConfirm', () => {
 				useCancelMutationOnConfirm( {
 					purchase: mockPurchase,
 					...mutations,
-					destinationRoute: '/me/purchases',
 				} ),
 			{ wrapper: makeTestWrapper( queryClient ) }
 		);
@@ -222,7 +203,6 @@ describe( 'useCancelMutationOnConfirm', () => {
 				useCancelMutationOnConfirm( {
 					purchase: mockPurchase,
 					...mutations,
-					destinationRoute: '/me/purchases',
 				} ),
 			{ wrapper: makeTestWrapper( queryClient ) }
 		);
@@ -245,7 +225,6 @@ describe( 'useCancelMutationOnConfirm', () => {
 				useCancelMutationOnConfirm( {
 					purchase: mockPurchase,
 					...mutations,
-					destinationRoute: '/me/purchases',
 				} ),
 			{ wrapper: makeTestWrapper( queryClient ) }
 		);
@@ -281,7 +260,6 @@ describe( 'useCancelMutationOnConfirm', () => {
 					cancelAndRefundMutation,
 					removePurchaseMutator,
 					setPurchaseAutoRenewMutation,
-					destinationRoute: '/me/purchases',
 				} ),
 			{ wrapper: makeTestWrapper( queryClient ) }
 		);
@@ -299,29 +277,5 @@ describe( 'useCancelMutationOnConfirm', () => {
 		} );
 
 		await waitFor( () => expect( result.current.isPending ).toBe( false ) );
-	} );
-
-	test( 'skipSurvey navigates to destination without dispatching any mutation', () => {
-		const mutations = makeMutations();
-		const queryClient = makeQueryClient();
-
-		const { result } = renderHook(
-			() =>
-				useCancelMutationOnConfirm( {
-					purchase: mockPurchase,
-					...mutations,
-					destinationRoute: '/me/purchases',
-				} ),
-			{ wrapper: makeTestWrapper( queryClient ) }
-		);
-
-		act( () => {
-			result.current.skipSurvey();
-		} );
-
-		expect( mockNavigate ).toHaveBeenCalledWith( { to: '/me/purchases' } );
-		expect( mutations.removePurchaseMutator.mutateAsync ).not.toHaveBeenCalled();
-		expect( mutations.cancelAndRefundMutation.mutateAsync ).not.toHaveBeenCalled();
-		expect( mutations.setPurchaseAutoRenewMutation.mutateAsync ).not.toHaveBeenCalled();
 	} );
 } );

--- a/client/dashboard/me/billing-purchases/cancel-purchase/test/use-cancel-mutation-on-confirm.test.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/test/use-cancel-mutation-on-confirm.test.tsx
@@ -35,7 +35,6 @@ function makeMutation() {
 
 function makeMutations() {
 	return {
-		removePurchaseMutator: makeMutation(),
 		cancelAndRefundMutation: makeMutation(),
 		setPurchaseAutoRenewMutation: makeMutation(),
 	};
@@ -57,30 +56,6 @@ function makeTestWrapper( queryClient: QueryClient ) {
 }
 
 describe( 'useCancelMutationOnConfirm', () => {
-	test( 'fireMutationOnConfirm dispatches the remove mutation for REMOVE flow', async () => {
-		const mutations = makeMutations();
-		const queryClient = makeQueryClient();
-
-		const { result } = renderHook(
-			() =>
-				useCancelMutationOnConfirm( {
-					purchase: mockPurchase,
-					...mutations,
-				} ),
-			{ wrapper: makeTestWrapper( queryClient ) }
-		);
-
-		act( () => {
-			result.current.fireMutationOnConfirm( CANCEL_FLOW_TYPE.REMOVE );
-		} );
-
-		await waitFor( () => {
-			expect( mutations.removePurchaseMutator.mutateAsync ).toHaveBeenCalledWith( mockPurchase.ID );
-		} );
-		expect( mutations.cancelAndRefundMutation.mutateAsync ).not.toHaveBeenCalled();
-		expect( mutations.setPurchaseAutoRenewMutation.mutateAsync ).not.toHaveBeenCalled();
-	} );
-
 	test( 'fireMutationOnConfirm dispatches the auto-renew-off mutation for CANCEL_AUTORENEW flow', async () => {
 		const mutations = makeMutations();
 		const queryClient = makeQueryClient();
@@ -104,7 +79,6 @@ describe( 'useCancelMutationOnConfirm', () => {
 				autoRenew: false,
 			} );
 		} );
-		expect( mutations.removePurchaseMutator.mutateAsync ).not.toHaveBeenCalled();
 		expect( mutations.cancelAndRefundMutation.mutateAsync ).not.toHaveBeenCalled();
 	} );
 
@@ -139,11 +113,10 @@ describe( 'useCancelMutationOnConfirm', () => {
 				},
 			} );
 		} );
-		expect( mutations.removePurchaseMutator.mutateAsync ).not.toHaveBeenCalled();
 		expect( mutations.setPurchaseAutoRenewMutation.mutateAsync ).not.toHaveBeenCalled();
 	} );
 
-	test( 'fireMutationOnConfirm strips the deleted purchase from userPurchasesQuery cache after success', async () => {
+	test( 'fireMutationOnConfirm strips the deleted purchase from userPurchasesQuery cache after CANCEL_WITH_REFUND', async () => {
 		const mutations = makeMutations();
 		const queryClient = makeQueryClient();
 
@@ -160,37 +133,13 @@ describe( 'useCancelMutationOnConfirm', () => {
 		);
 
 		act( () => {
-			result.current.fireMutationOnConfirm( CANCEL_FLOW_TYPE.REMOVE );
+			result.current.fireMutationOnConfirm( CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND );
 		} );
 
 		await waitFor( () => {
 			expect( queryClient.getQueryData( userPurchasesQuery().queryKey ) ).toEqual( [
 				otherPurchase,
 			] );
-		} );
-	} );
-
-	test( 'fireMutationOnConfirm captures the purchase into snapshotPurchase for REMOVE flow', async () => {
-		const mutations = makeMutations();
-		const queryClient = makeQueryClient();
-
-		const { result } = renderHook(
-			() =>
-				useCancelMutationOnConfirm( {
-					purchase: mockPurchase,
-					...mutations,
-				} ),
-			{ wrapper: makeTestWrapper( queryClient ) }
-		);
-
-		expect( result.current.snapshotPurchase ).toBeNull();
-
-		act( () => {
-			result.current.fireMutationOnConfirm( CANCEL_FLOW_TYPE.REMOVE );
-		} );
-
-		await waitFor( () => {
-			expect( result.current.snapshotPurchase ).toBe( mockPurchase );
 		} );
 	} );
 
@@ -241,7 +190,7 @@ describe( 'useCancelMutationOnConfirm', () => {
 
 	test( 'isPending is true while the mutation is in flight, false after it resolves', async () => {
 		let resolveMutation: ( value?: unknown ) => void = () => {};
-		const removePurchaseMutator = {
+		const cancelAndRefundMutation = {
 			mutateAsync: jest.fn(
 				() =>
 					new Promise( ( resolve ) => {
@@ -249,7 +198,6 @@ describe( 'useCancelMutationOnConfirm', () => {
 					} )
 			),
 		} as unknown as { mutateAsync: jest.Mock };
-		const cancelAndRefundMutation = makeMutation();
 		const setPurchaseAutoRenewMutation = makeMutation();
 		const queryClient = makeQueryClient();
 
@@ -258,7 +206,6 @@ describe( 'useCancelMutationOnConfirm', () => {
 				useCancelMutationOnConfirm( {
 					purchase: mockPurchase,
 					cancelAndRefundMutation,
-					removePurchaseMutator,
 					setPurchaseAutoRenewMutation,
 				} ),
 			{ wrapper: makeTestWrapper( queryClient ) }
@@ -267,7 +214,7 @@ describe( 'useCancelMutationOnConfirm', () => {
 		expect( result.current.isPending ).toBe( false );
 
 		act( () => {
-			result.current.fireMutationOnConfirm( CANCEL_FLOW_TYPE.REMOVE );
+			result.current.fireMutationOnConfirm( CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND );
 		} );
 
 		await waitFor( () => expect( result.current.isPending ).toBe( true ) );

--- a/client/dashboard/me/billing-purchases/cancel-purchase/test/use-cancel-mutation-on-confirm.test.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/test/use-cancel-mutation-on-confirm.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useState, type ReactNode } from 'react';
+import { CANCEL_FLOW_TYPE } from '../../../../utils/purchase';
+import { useCancelMutationOnConfirm } from '../use-cancel-mutation-on-confirm';
+import type { Purchase } from '@automattic/api-core';
+
+jest.mock( '@automattic/api-core', () => ( {} ) );
+
+const mockNavigate = jest.fn();
+
+jest.mock( '@tanstack/react-router', () => {
+	const actual = jest.requireActual( '@tanstack/react-router' );
+	return {
+		...actual,
+		useNavigate: () => mockNavigate,
+	};
+} );
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( {
+		createSuccessNotice: jest.fn(),
+		createErrorNotice: jest.fn(),
+	} ),
+} ) );
+
+const mockPurchase = {
+	ID: 12345,
+	product_name: 'WordPress.com Business',
+	product_slug: 'business-bundle',
+	is_domain: false,
+	is_plan: true,
+	domain: 'example.wordpress.com',
+	will_atomic_revert_after_removal: false,
+} as Purchase;
+
+function makeMutation( resolveValue: unknown = undefined ) {
+	const mutateAsync = jest.fn( () => Promise.resolve( resolveValue ) );
+	return { mutateAsync } as unknown as { mutateAsync: jest.Mock };
+}
+
+function TestWrapper( { children }: { children: ReactNode } ) {
+	const [ queryClient ] = useState(
+		() =>
+			new QueryClient( {
+				defaultOptions: {
+					queries: { retry: false },
+					mutations: { retry: false },
+				},
+			} )
+	);
+	return <QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>;
+}
+
+describe( 'useCancelMutationOnConfirm', () => {
+	beforeEach( () => {
+		mockNavigate.mockClear();
+	} );
+
+	test( 'fireMutationOnConfirm dispatches the remove mutation for REMOVE flow', async () => {
+		const removePurchaseMutator = makeMutation();
+		const cancelAndRefundMutation = makeMutation();
+
+		const { result } = renderHook(
+			() =>
+				useCancelMutationOnConfirm( {
+					purchase: mockPurchase,
+					cancelAndRefundMutation,
+					removePurchaseMutator,
+					destinationRoute: '/me/purchases',
+				} ),
+			{ wrapper: TestWrapper }
+		);
+
+		act( () => {
+			result.current.fireMutationOnConfirm( CANCEL_FLOW_TYPE.REMOVE );
+		} );
+
+		await waitFor( () => {
+			expect( removePurchaseMutator.mutateAsync ).toHaveBeenCalledWith( mockPurchase.ID );
+		} );
+		expect( cancelAndRefundMutation.mutateAsync ).not.toHaveBeenCalled();
+	} );
+
+	test( 'isPending is true while the mutation is in flight, false after it resolves', async () => {
+		let resolveMutation: ( value?: unknown ) => void = () => {};
+		const removePurchaseMutator = {
+			mutateAsync: jest.fn(
+				() =>
+					new Promise( ( resolve ) => {
+						resolveMutation = resolve;
+					} )
+			),
+		} as unknown as { mutateAsync: jest.Mock };
+		const cancelAndRefundMutation = makeMutation();
+
+		const { result } = renderHook(
+			() =>
+				useCancelMutationOnConfirm( {
+					purchase: mockPurchase,
+					cancelAndRefundMutation,
+					removePurchaseMutator,
+					destinationRoute: '/me/purchases',
+				} ),
+			{ wrapper: TestWrapper }
+		);
+
+		expect( result.current.isPending ).toBe( false );
+
+		act( () => {
+			result.current.fireMutationOnConfirm( CANCEL_FLOW_TYPE.REMOVE );
+		} );
+
+		await waitFor( () => expect( result.current.isPending ).toBe( true ) );
+
+		await act( async () => {
+			resolveMutation();
+		} );
+
+		await waitFor( () => expect( result.current.isPending ).toBe( false ) );
+	} );
+
+	test( 'skipSurvey navigates to destination without dispatching any mutation', () => {
+		const removePurchaseMutator = makeMutation();
+		const cancelAndRefundMutation = makeMutation();
+
+		const { result } = renderHook(
+			() =>
+				useCancelMutationOnConfirm( {
+					purchase: mockPurchase,
+					cancelAndRefundMutation,
+					removePurchaseMutator,
+					destinationRoute: '/me/purchases',
+				} ),
+			{ wrapper: TestWrapper }
+		);
+
+		act( () => {
+			result.current.skipSurvey();
+		} );
+
+		expect( mockNavigate ).toHaveBeenCalledWith( { to: '/me/purchases' } );
+		expect( removePurchaseMutator.mutateAsync ).not.toHaveBeenCalled();
+		expect( cancelAndRefundMutation.mutateAsync ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/dashboard/me/billing-purchases/cancel-purchase/test/use-cancel-mutation-on-confirm.test.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/test/use-cancel-mutation-on-confirm.test.tsx
@@ -37,9 +37,17 @@ const mockPurchase = {
 	will_atomic_revert_after_removal: false,
 } as Purchase;
 
-function makeMutation( resolveValue: unknown = undefined ) {
-	const mutateAsync = jest.fn( () => Promise.resolve( resolveValue ) );
+function makeMutation() {
+	const mutateAsync = jest.fn( () => Promise.resolve() );
 	return { mutateAsync } as unknown as { mutateAsync: jest.Mock };
+}
+
+function makeMutations() {
+	return {
+		removePurchaseMutator: makeMutation(),
+		cancelAndRefundMutation: makeMutation(),
+		setPurchaseAutoRenewMutation: makeMutation(),
+	};
 }
 
 function TestWrapper( { children }: { children: ReactNode } ) {
@@ -61,15 +69,13 @@ describe( 'useCancelMutationOnConfirm', () => {
 	} );
 
 	test( 'fireMutationOnConfirm dispatches the remove mutation for REMOVE flow', async () => {
-		const removePurchaseMutator = makeMutation();
-		const cancelAndRefundMutation = makeMutation();
+		const mutations = makeMutations();
 
 		const { result } = renderHook(
 			() =>
 				useCancelMutationOnConfirm( {
 					purchase: mockPurchase,
-					cancelAndRefundMutation,
-					removePurchaseMutator,
+					...mutations,
 					destinationRoute: '/me/purchases',
 				} ),
 			{ wrapper: TestWrapper }
@@ -80,9 +86,37 @@ describe( 'useCancelMutationOnConfirm', () => {
 		} );
 
 		await waitFor( () => {
-			expect( removePurchaseMutator.mutateAsync ).toHaveBeenCalledWith( mockPurchase.ID );
+			expect( mutations.removePurchaseMutator.mutateAsync ).toHaveBeenCalledWith( mockPurchase.ID );
 		} );
-		expect( cancelAndRefundMutation.mutateAsync ).not.toHaveBeenCalled();
+		expect( mutations.cancelAndRefundMutation.mutateAsync ).not.toHaveBeenCalled();
+		expect( mutations.setPurchaseAutoRenewMutation.mutateAsync ).not.toHaveBeenCalled();
+	} );
+
+	test( 'fireMutationOnConfirm dispatches the auto-renew-off mutation for CANCEL_AUTORENEW flow', async () => {
+		const mutations = makeMutations();
+
+		const { result } = renderHook(
+			() =>
+				useCancelMutationOnConfirm( {
+					purchase: mockPurchase,
+					...mutations,
+					destinationRoute: '/me/purchases',
+				} ),
+			{ wrapper: TestWrapper }
+		);
+
+		act( () => {
+			result.current.fireMutationOnConfirm( CANCEL_FLOW_TYPE.CANCEL_AUTORENEW );
+		} );
+
+		await waitFor( () => {
+			expect( mutations.setPurchaseAutoRenewMutation.mutateAsync ).toHaveBeenCalledWith( {
+				purchaseId: mockPurchase.ID,
+				autoRenew: false,
+			} );
+		} );
+		expect( mutations.removePurchaseMutator.mutateAsync ).not.toHaveBeenCalled();
+		expect( mutations.cancelAndRefundMutation.mutateAsync ).not.toHaveBeenCalled();
 	} );
 
 	test( 'isPending is true while the mutation is in flight, false after it resolves', async () => {
@@ -96,6 +130,7 @@ describe( 'useCancelMutationOnConfirm', () => {
 			),
 		} as unknown as { mutateAsync: jest.Mock };
 		const cancelAndRefundMutation = makeMutation();
+		const setPurchaseAutoRenewMutation = makeMutation();
 
 		const { result } = renderHook(
 			() =>
@@ -103,6 +138,7 @@ describe( 'useCancelMutationOnConfirm', () => {
 					purchase: mockPurchase,
 					cancelAndRefundMutation,
 					removePurchaseMutator,
+					setPurchaseAutoRenewMutation,
 					destinationRoute: '/me/purchases',
 				} ),
 			{ wrapper: TestWrapper }
@@ -124,15 +160,13 @@ describe( 'useCancelMutationOnConfirm', () => {
 	} );
 
 	test( 'skipSurvey navigates to destination without dispatching any mutation', () => {
-		const removePurchaseMutator = makeMutation();
-		const cancelAndRefundMutation = makeMutation();
+		const mutations = makeMutations();
 
 		const { result } = renderHook(
 			() =>
 				useCancelMutationOnConfirm( {
 					purchase: mockPurchase,
-					cancelAndRefundMutation,
-					removePurchaseMutator,
+					...mutations,
 					destinationRoute: '/me/purchases',
 				} ),
 			{ wrapper: TestWrapper }
@@ -143,7 +177,8 @@ describe( 'useCancelMutationOnConfirm', () => {
 		} );
 
 		expect( mockNavigate ).toHaveBeenCalledWith( { to: '/me/purchases' } );
-		expect( removePurchaseMutator.mutateAsync ).not.toHaveBeenCalled();
-		expect( cancelAndRefundMutation.mutateAsync ).not.toHaveBeenCalled();
+		expect( mutations.removePurchaseMutator.mutateAsync ).not.toHaveBeenCalled();
+		expect( mutations.cancelAndRefundMutation.mutateAsync ).not.toHaveBeenCalled();
+		expect( mutations.setPurchaseAutoRenewMutation.mutateAsync ).not.toHaveBeenCalled();
 	} );
 } );

--- a/client/dashboard/me/billing-purchases/cancel-purchase/use-cancel-mutation-on-confirm.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/use-cancel-mutation-on-confirm.ts
@@ -1,4 +1,4 @@
-import { purchaseQuery, userPurchasesQuery } from '@automattic/api-queries';
+import { userPurchasesQuery } from '@automattic/api-queries';
 import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { useCallback, useState } from 'react';
@@ -30,10 +30,6 @@ interface UseCancelMutationOnConfirmArgs {
 	destinationRoute: string;
 }
 
-// Window for the cache-subscription guard. After this elapses, the server
-// is assumed settled — ad-hoc, but matches PR-G's tested envelope.
-const CACHE_GUARD_TTL_MS = 15_000;
-
 export function useCancelMutationOnConfirm( {
 	purchase,
 	cancelAndRefundMutation,
@@ -44,6 +40,7 @@ export function useCancelMutationOnConfirm( {
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
 	const [ isPending, setIsPending ] = useState( false );
+	const [ snapshotPurchase, setSnapshotPurchase ] = useState< Purchase | null >( null );
 
 	const fireMutationOnConfirm = useCallback(
 		( effectiveFlowType: CancelFlowType, cancelBundledDomain?: boolean ): Promise< void > => {
@@ -61,30 +58,10 @@ export function useCancelMutationOnConfirm( {
 					} );
 			}
 
-			const stripPurchaseFromList = () => {
-				queryClient.setQueryData( userPurchasesQuery().queryKey, ( old: Purchase[] | undefined ) =>
-					( old ?? [] ).filter( ( p ) => p.ID !== purchase.ID )
-				);
-			};
-
-			// Re-strip the purchase from cache whenever any background refetch
-			// (route loader, focus, the mutation's own invalidation cascade)
-			// returns server data that still includes the just-deleted purchase
-			// during the eventual-consistency window.
-			const targetHash = JSON.stringify( userPurchasesQuery().queryKey );
-			const unsubscribeGuard = queryClient.getQueryCache().subscribe( ( event ) => {
-				if ( event.query.queryHash === targetHash ) {
-					const data = event.query.state.data as Purchase[] | undefined;
-					if ( data?.some( ( p ) => p.ID === purchase.ID ) ) {
-						stripPurchaseFromList();
-					}
-				}
-			} );
-
-			setTimeout( () => {
-				unsubscribeGuard();
-				queryClient.invalidateQueries( userPurchasesQuery() );
-			}, CACHE_GUARD_TTL_MS );
+			// Capture snapshot synchronously, before the mutation fires. From this
+			// point, the component reads from the snapshot instead of the live
+			// query cache, which the mutation's invalidation will tear down.
+			setSnapshotPurchase( purchase );
 
 			const mutationPromise =
 				effectiveFlowType === CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND
@@ -99,13 +76,15 @@ export function useCancelMutationOnConfirm( {
 
 			return mutationPromise
 				.then( () => {
-					stripPurchaseFromList();
-					// Evict the individual purchase query so the prefix-matched
-					// invalidation triggered by the mutation's onSuccess can't
-					// refetch a 404 into the still-mounted survey observer.
-					queryClient.removeQueries( {
-						queryKey: purchaseQuery( purchase.ID ).queryKey,
-					} );
+					// One-shot strip on success. If the server's eventual-consistency
+					// window returns the deleted purchase back on a subsequent
+					// refetch, the user briefly sees it on the destination list;
+					// accepted as a small UX cost over the previous re-stripping
+					// daemon's brittleness.
+					queryClient.setQueryData(
+						userPurchasesQuery().queryKey,
+						( old: Purchase[] | undefined ) => ( old ?? [] ).filter( ( p ) => p.ID !== purchase.ID )
+					);
 				} )
 				.finally( () => {
 					setIsPending( false );
@@ -124,5 +103,5 @@ export function useCancelMutationOnConfirm( {
 		navigate( { to: destinationRoute } );
 	}, [ navigate, destinationRoute ] );
 
-	return { isPending, fireMutationOnConfirm, skipSurvey };
+	return { isPending, fireMutationOnConfirm, skipSurvey, snapshotPurchase };
 }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/use-cancel-mutation-on-confirm.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/use-cancel-mutation-on-confirm.ts
@@ -17,10 +17,16 @@ interface CancelAndRefundVariables {
 	};
 }
 
+interface SetAutoRenewVariables {
+	purchaseId: number;
+	autoRenew: boolean;
+}
+
 interface UseCancelMutationOnConfirmArgs {
 	purchase: Purchase;
 	cancelAndRefundMutation: MutationLike< CancelAndRefundVariables >;
 	removePurchaseMutator: MutationLike< number >;
+	setPurchaseAutoRenewMutation: MutationLike< SetAutoRenewVariables >;
 	destinationRoute: string;
 }
 
@@ -32,6 +38,7 @@ export function useCancelMutationOnConfirm( {
 	purchase,
 	cancelAndRefundMutation,
 	removePurchaseMutator,
+	setPurchaseAutoRenewMutation,
 	destinationRoute,
 }: UseCancelMutationOnConfirmArgs ) {
 	const navigate = useNavigate();
@@ -41,6 +48,18 @@ export function useCancelMutationOnConfirm( {
 	const fireMutationOnConfirm = useCallback(
 		( effectiveFlowType: CancelFlowType, cancelBundledDomain?: boolean ): Promise< void > => {
 			setIsPending( true );
+
+			// CANCEL_AUTORENEW just disables auto-renew — the purchase stays in
+			// the user's list. None of the deletion-flow cache machinery
+			// (strip-from-list, removeQueries, subscription guard) applies.
+			if ( effectiveFlowType === CANCEL_FLOW_TYPE.CANCEL_AUTORENEW ) {
+				return setPurchaseAutoRenewMutation
+					.mutateAsync( { purchaseId: purchase.ID, autoRenew: false } )
+					.then( () => undefined )
+					.finally( () => {
+						setIsPending( false );
+					} );
+			}
 
 			const stripPurchaseFromList = () => {
 				queryClient.setQueryData( userPurchasesQuery().queryKey, ( old: Purchase[] | undefined ) =>
@@ -92,7 +111,13 @@ export function useCancelMutationOnConfirm( {
 					setIsPending( false );
 				} );
 		},
-		[ purchase, cancelAndRefundMutation, removePurchaseMutator, queryClient ]
+		[
+			purchase,
+			cancelAndRefundMutation,
+			removePurchaseMutator,
+			setPurchaseAutoRenewMutation,
+			queryClient,
+		]
 	);
 
 	const skipSurvey = useCallback( () => {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/use-cancel-mutation-on-confirm.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/use-cancel-mutation-on-confirm.ts
@@ -1,0 +1,103 @@
+import { purchaseQuery, userPurchasesQuery } from '@automattic/api-queries';
+import { useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import { useCallback, useState } from 'react';
+import { CANCEL_FLOW_TYPE, type CancelFlowType } from '../../../utils/purchase';
+import type { Purchase } from '@automattic/api-core';
+
+interface MutationLike< TVariables > {
+	mutateAsync: ( variables: TVariables ) => Promise< unknown >;
+}
+
+interface CancelAndRefundVariables {
+	purchaseId: number;
+	options: {
+		product_id: number;
+		cancel_bundled_domain: boolean;
+	};
+}
+
+interface UseCancelMutationOnConfirmArgs {
+	purchase: Purchase;
+	cancelAndRefundMutation: MutationLike< CancelAndRefundVariables >;
+	removePurchaseMutator: MutationLike< number >;
+	destinationRoute: string;
+}
+
+// Window for the cache-subscription guard. After this elapses, the server
+// is assumed settled — ad-hoc, but matches PR-G's tested envelope.
+const CACHE_GUARD_TTL_MS = 15_000;
+
+export function useCancelMutationOnConfirm( {
+	purchase,
+	cancelAndRefundMutation,
+	removePurchaseMutator,
+	destinationRoute,
+}: UseCancelMutationOnConfirmArgs ) {
+	const navigate = useNavigate();
+	const queryClient = useQueryClient();
+	const [ isPending, setIsPending ] = useState( false );
+
+	const fireMutationOnConfirm = useCallback(
+		( effectiveFlowType: CancelFlowType, cancelBundledDomain?: boolean ): Promise< void > => {
+			setIsPending( true );
+
+			const stripPurchaseFromList = () => {
+				queryClient.setQueryData( userPurchasesQuery().queryKey, ( old: Purchase[] | undefined ) =>
+					( old ?? [] ).filter( ( p ) => p.ID !== purchase.ID )
+				);
+			};
+
+			// Re-strip the purchase from cache whenever any background refetch
+			// (route loader, focus, the mutation's own invalidation cascade)
+			// returns server data that still includes the just-deleted purchase
+			// during the eventual-consistency window.
+			const targetHash = JSON.stringify( userPurchasesQuery().queryKey );
+			const unsubscribeGuard = queryClient.getQueryCache().subscribe( ( event ) => {
+				if ( event.query.queryHash === targetHash ) {
+					const data = event.query.state.data as Purchase[] | undefined;
+					if ( data?.some( ( p ) => p.ID === purchase.ID ) ) {
+						stripPurchaseFromList();
+					}
+				}
+			} );
+
+			setTimeout( () => {
+				unsubscribeGuard();
+				queryClient.invalidateQueries( userPurchasesQuery() );
+			}, CACHE_GUARD_TTL_MS );
+
+			const mutationPromise =
+				effectiveFlowType === CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND
+					? cancelAndRefundMutation.mutateAsync( {
+							purchaseId: purchase.ID,
+							options: {
+								product_id: purchase.product_id,
+								cancel_bundled_domain: cancelBundledDomain ?? false,
+							},
+					  } )
+					: removePurchaseMutator.mutateAsync( purchase.ID );
+
+			return mutationPromise
+				.then( () => {
+					stripPurchaseFromList();
+					// Evict the individual purchase query so the prefix-matched
+					// invalidation triggered by the mutation's onSuccess can't
+					// refetch a 404 into the still-mounted survey observer.
+					queryClient.removeQueries( {
+						queryKey: purchaseQuery( purchase.ID ).queryKey,
+					} );
+				} )
+				.finally( () => {
+					setIsPending( false );
+				} );
+		},
+		[ purchase, cancelAndRefundMutation, removePurchaseMutator, queryClient ]
+	);
+
+	const skipSurvey = useCallback( () => {
+		navigate( { to: destinationRoute } );
+	}, [ navigate, destinationRoute ] );
+
+	return { isPending, fireMutationOnConfirm, skipSurvey };
+}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/use-cancel-mutation-on-confirm.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/use-cancel-mutation-on-confirm.ts
@@ -24,14 +24,15 @@ interface SetAutoRenewVariables {
 interface UseCancelMutationOnConfirmArgs {
 	purchase: Purchase;
 	cancelAndRefundMutation: MutationLike< CancelAndRefundVariables >;
-	removePurchaseMutator: MutationLike< number >;
 	setPurchaseAutoRenewMutation: MutationLike< SetAutoRenewVariables >;
 }
 
+// Hook for the Cancel paths (CANCEL_AUTORENEW, CANCEL_WITH_REFUND) only —
+// REMOVE defers its mutation to survey-submit, so it doesn't need the
+// snapshot/cache-guard machinery here.
 export function useCancelMutationOnConfirm( {
 	purchase,
 	cancelAndRefundMutation,
-	removePurchaseMutator,
 	setPurchaseAutoRenewMutation,
 }: UseCancelMutationOnConfirmArgs ) {
 	const queryClient = useQueryClient();
@@ -44,7 +45,7 @@ export function useCancelMutationOnConfirm( {
 
 			// CANCEL_AUTORENEW just disables auto-renew — the purchase stays in
 			// the user's list. None of the deletion-flow cache machinery
-			// (strip-from-list, removeQueries, subscription guard) applies.
+			// (strip-from-list, snapshot) applies.
 			if ( effectiveFlowType === CANCEL_FLOW_TYPE.CANCEL_AUTORENEW ) {
 				return setPurchaseAutoRenewMutation
 					.mutateAsync( { purchaseId: purchase.ID, autoRenew: false } )
@@ -54,23 +55,19 @@ export function useCancelMutationOnConfirm( {
 					} );
 			}
 
-			// Capture snapshot synchronously, before the mutation fires. From this
-			// point, the component reads from the snapshot instead of the live
-			// query cache, which the mutation's invalidation will tear down.
+			// CANCEL_WITH_REFUND deletes the purchase. Capture a snapshot
+			// synchronously so survey rendering keeps working after the
+			// mutation's invalidation tears down the live purchase query.
 			setSnapshotPurchase( purchase );
 
-			const mutationPromise =
-				effectiveFlowType === CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND
-					? cancelAndRefundMutation.mutateAsync( {
-							purchaseId: purchase.ID,
-							options: {
-								product_id: purchase.product_id,
-								cancel_bundled_domain: cancelBundledDomain ?? false,
-							},
-					  } )
-					: removePurchaseMutator.mutateAsync( purchase.ID );
-
-			return mutationPromise
+			return cancelAndRefundMutation
+				.mutateAsync( {
+					purchaseId: purchase.ID,
+					options: {
+						product_id: purchase.product_id,
+						cancel_bundled_domain: cancelBundledDomain ?? false,
+					},
+				} )
 				.then( () => {
 					// One-shot strip on success. If the server's eventual-consistency
 					// window returns the deleted purchase back on a subsequent
@@ -86,13 +83,7 @@ export function useCancelMutationOnConfirm( {
 					setIsPending( false );
 				} );
 		},
-		[
-			purchase,
-			cancelAndRefundMutation,
-			removePurchaseMutator,
-			setPurchaseAutoRenewMutation,
-			queryClient,
-		]
+		[ purchase, cancelAndRefundMutation, setPurchaseAutoRenewMutation, queryClient ]
 	);
 
 	return { isPending, fireMutationOnConfirm, snapshotPurchase };

--- a/client/dashboard/me/billing-purchases/cancel-purchase/use-cancel-mutation-on-confirm.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/use-cancel-mutation-on-confirm.ts
@@ -1,6 +1,5 @@
 import { userPurchasesQuery } from '@automattic/api-queries';
 import { useQueryClient } from '@tanstack/react-query';
-import { useNavigate } from '@tanstack/react-router';
 import { useCallback, useState } from 'react';
 import { CANCEL_FLOW_TYPE, type CancelFlowType } from '../../../utils/purchase';
 import type { Purchase } from '@automattic/api-core';
@@ -27,7 +26,6 @@ interface UseCancelMutationOnConfirmArgs {
 	cancelAndRefundMutation: MutationLike< CancelAndRefundVariables >;
 	removePurchaseMutator: MutationLike< number >;
 	setPurchaseAutoRenewMutation: MutationLike< SetAutoRenewVariables >;
-	destinationRoute: string;
 }
 
 export function useCancelMutationOnConfirm( {
@@ -35,9 +33,7 @@ export function useCancelMutationOnConfirm( {
 	cancelAndRefundMutation,
 	removePurchaseMutator,
 	setPurchaseAutoRenewMutation,
-	destinationRoute,
 }: UseCancelMutationOnConfirmArgs ) {
-	const navigate = useNavigate();
 	const queryClient = useQueryClient();
 	const [ isPending, setIsPending ] = useState( false );
 	const [ snapshotPurchase, setSnapshotPurchase ] = useState< Purchase | null >( null );
@@ -99,9 +95,5 @@ export function useCancelMutationOnConfirm( {
 		]
 	);
 
-	const skipSurvey = useCallback( () => {
-		navigate( { to: destinationRoute } );
-	}, [ navigate, destinationRoute ] );
-
-	return { isPending, fireMutationOnConfirm, skipSurvey, snapshotPurchase };
+	return { isPending, fireMutationOnConfirm, snapshotPurchase };
 }

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -349,16 +349,11 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		}
 	};
 
-	// True when the flag-gated mutation-on-confirm path applies. CANCEL_AUTORENEW
-	// keeps the trunk in-place flow (the purchase is not deleted, so there is
-	// no eventual-consistency window to manage).
-	shouldFireMutationOnConfirm = (): boolean => {
-		if ( ! config.isEnabled( 'purchases/split-cancel-remove' ) ) {
-			return false;
-		}
-		const flowType = this.getCancelFlowType( this.props.purchase );
-		return flowType === CANCEL_FLOW_TYPE.REMOVE || flowType === CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND;
-	};
+	// True when the flag-gated mutation-on-confirm path applies. The
+	// compliance driver (one-click cancel) covers all cancel flows, including
+	// CANCEL_AUTORENEW — that path skips the marketplace-cleanup step
+	// because the purchase isn't deleted.
+	shouldFireMutationOnConfirm = (): boolean => config.isEnabled( 'purchases/split-cancel-remove' );
 
 	// Fire the cancel/remove mutation when the user confirms (the
 	// purchases/split-cancel-remove behavior). Mirrors onSurveyComplete's
@@ -368,10 +363,18 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 	fireMutationFromConfirm = async () => {
 		this.setState( { isLoading: true } );
 		try {
-			const result = await this.submitCancelAndRefundPurchase( this.props.purchase );
+			const flowType = this.getCancelFlowType( this.props.purchase );
+			const isAutoRenewIntent = flowType === CANCEL_FLOW_TYPE.CANCEL_AUTORENEW;
+			const result = isAutoRenewIntent
+				? await this.cancelPurchase( this.props.purchase )
+				: await this.submitCancelAndRefundPurchase( this.props.purchase );
 			if ( result.success ) {
-				const refundable = hasAmountAvailableToRefund( this.props.purchase );
-				await this.handleMarketplaceSubscriptions( refundable );
+				const refundable = isAutoRenewIntent
+					? false
+					: hasAmountAvailableToRefund( this.props.purchase );
+				if ( ! isAutoRenewIntent ) {
+					await this.handleMarketplaceSubscriptions( refundable );
+				}
 				this.props.refreshSitePlans( this.props.purchase.siteId );
 				this.props.clearPurchases();
 				this.props.successNotice( result.message, {

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -328,6 +328,9 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		} else {
 			// For direct cancellations (no domain options step), show survey directly
 			this.setState( { surveyShown: true } );
+			if ( this.shouldFireMutationOnConfirm() ) {
+				this.fireMutationFromConfirm();
+			}
 		}
 	};
 
@@ -341,6 +344,51 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			cancelBundledDomain: domainOptions.cancelBundledDomain,
 			confirmCancelBundledDomain: domainOptions.confirmCancelBundledDomain,
 		} );
+		if ( this.shouldFireMutationOnConfirm() ) {
+			this.fireMutationFromConfirm();
+		}
+	};
+
+	// True when the flag-gated mutation-on-confirm path applies. CANCEL_AUTORENEW
+	// keeps the trunk in-place flow (the purchase is not deleted, so there is
+	// no eventual-consistency window to manage).
+	shouldFireMutationOnConfirm = (): boolean => {
+		if ( ! config.isEnabled( 'purchases/split-cancel-remove' ) ) {
+			return false;
+		}
+		const flowType = this.getCancelFlowType( this.props.purchase );
+		return flowType === CANCEL_FLOW_TYPE.REMOVE || flowType === CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND;
+	};
+
+	// Fire the cancel/remove mutation when the user confirms (the
+	// purchases/split-cancel-remove behavior). Mirrors onSurveyComplete's
+	// mutation block minus the page.redirect — navigation moves to the
+	// survey-submit handler so the user stays on the survey while the
+	// mutation settles.
+	fireMutationFromConfirm = async () => {
+		this.setState( { isLoading: true } );
+		try {
+			const result = await this.submitCancelAndRefundPurchase( this.props.purchase );
+			if ( result.success ) {
+				const refundable = hasAmountAvailableToRefund( this.props.purchase );
+				await this.handleMarketplaceSubscriptions( refundable );
+				this.props.refreshSitePlans( this.props.purchase.siteId );
+				this.props.clearPurchases();
+				this.props.successNotice( result.message, {
+					displayOnNextPage: true,
+					duration: 10000,
+				} );
+				invokeSurvicateEvent( refundable ? 'purchaseRefunded' : 'purchaseCancelled' );
+			} else {
+				this.props.errorNotice( result.error );
+				this.setState( { surveyShown: false, cancelIntent: null } );
+			}
+		} catch ( error ) {
+			this.props.errorNotice( ( error as Error ).message );
+			this.setState( { surveyShown: false, cancelIntent: null } );
+		} finally {
+			this.setState( { isLoading: false } );
+		}
 	};
 
 	cancelPurchase = async ( purchase: Purchases.Purchase ) => {
@@ -471,6 +519,20 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 	};
 
 	onSurveyComplete = async () => {
+		// Flag-on path: the mutation already fired at confirm-click via
+		// fireMutationFromConfirm. The success notice and redirect are owned
+		// by that helper and this handler respectively; here we only need to
+		// leave the cancel flow once the user finishes (or skips) the survey.
+		if ( this.shouldFireMutationOnConfirm() ) {
+			const managePurchaseUrl = ( this.props.getManagePurchaseUrlFor ?? managePurchase )(
+				this.props.siteSlug,
+				this.props.purchaseId
+			);
+			const backupRedirect = this.props.purchaseListUrl ?? purchasesRoot;
+			page.redirect( managePurchaseUrl ?? backupRedirect );
+			return;
+		}
+
 		// Set loading state to show busy button
 		this.setState( { isLoading: true } );
 

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -325,12 +325,12 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			willShowDomainOptionsRadioButtons( includedDomainPurchase, purchase )
 		) {
 			this.setState( { showDomainOptionsStep: true } );
+		} else if ( this.shouldFireMutationOnConfirm() ) {
+			// Cancel-intent flag-on: fire the mutation first; surveyShown
+			// flips to true inside fireMutationFromConfirm on success.
+			this.fireMutationFromConfirm();
 		} else {
-			// For direct cancellations (no domain options step), show survey directly
 			this.setState( { surveyShown: true } );
-			if ( this.shouldFireMutationOnConfirm() ) {
-				this.fireMutationFromConfirm();
-			}
 		}
 	};
 
@@ -338,31 +338,35 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		cancelBundledDomain: boolean;
 		confirmCancelBundledDomain: boolean;
 	} ) => {
+		// Persist domain options first so fireMutationFromConfirm can read
+		// cancelBundledDomain when constructing the cancelAndRefund payload.
 		this.setState( {
 			showDomainOptionsStep: false,
-			surveyShown: true,
 			cancelBundledDomain: domainOptions.cancelBundledDomain,
 			confirmCancelBundledDomain: domainOptions.confirmCancelBundledDomain,
 		} );
 		if ( this.shouldFireMutationOnConfirm() ) {
 			this.fireMutationFromConfirm();
+		} else {
+			this.setState( { surveyShown: true } );
 		}
 	};
 
-	// True when the flag-gated mutation-on-confirm path applies. The
-	// compliance driver (one-click cancel) covers all cancel flows, including
-	// CANCEL_AUTORENEW — that path skips the marketplace-cleanup step
-	// because the purchase isn't deleted.
-	shouldFireMutationOnConfirm = (): boolean => config.isEnabled( 'purchases/split-cancel-remove' );
+	// Fire-on-confirm applies to the URL-intent Cancel path only — the user
+	// clicked "Cancel" on Purchase Settings and we want their cancellation to
+	// settle before the survey appears (so the heading reads "Cancellation
+	// confirmed"). Remove (and the no-intent legacy deep link) defer the
+	// mutation to onSurveyComplete, matching trunk's submit-handlers.
+	shouldFireMutationOnConfirm = (): boolean =>
+		config.isEnabled( 'purchases/split-cancel-remove' ) && this.props.intent === 'cancel';
 
-	// Fire the cancel/remove mutation when the user confirms (the
-	// purchases/split-cancel-remove behavior). Mirrors onSurveyComplete's
-	// mutation block minus the page.redirect AND minus refreshSitePlans /
-	// clearPurchases — those clear Redux state synchronously, which flips
-	// hasLoadedUserPurchasesFromServer to false and causes isDataLoading
-	// to render CancelPurchaseLoadingPlaceholder over the survey. They
-	// move to the survey-submit handler so they run during navigation
-	// when the placeholder isn't visible.
+	// Fire the cancel mutation when the user confirms, then advance to the
+	// survey. The success notice is queued with displayOnNextPage so it shows
+	// on the destination (manage-purchase) screen after the user submits or
+	// skips the survey. refreshSitePlans / clearPurchases stay on the
+	// survey-submit path — calling them now would flip
+	// hasLoadedUserPurchasesFromServer and render the loading placeholder
+	// over the survey.
 	fireMutationFromConfirm = async () => {
 		this.setState( { isLoading: true } );
 		try {
@@ -370,11 +374,9 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			const isAutoRenewIntent = flowType === CANCEL_FLOW_TYPE.CANCEL_AUTORENEW;
 			const result = isAutoRenewIntent
 				? await this.cancelPurchase( this.props.purchase )
-				: await this.submitCancelAndRefundPurchase( this.props.purchase );
+				: await this.cancelAndRefund( this.props.purchase );
 			if ( result.success ) {
-				const refundable = isAutoRenewIntent
-					? false
-					: hasAmountAvailableToRefund( this.props.purchase );
+				const refundable = ! isAutoRenewIntent && hasAmountAvailableToRefund( this.props.purchase );
 				if ( ! isAutoRenewIntent ) {
 					await this.handleMarketplaceSubscriptions( refundable );
 				}
@@ -383,14 +385,14 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 					duration: 10000,
 				} );
 				invokeSurvicateEvent( refundable ? 'purchaseRefunded' : 'purchaseCancelled' );
+				this.setState( { surveyShown: true, isLoading: false } );
 			} else {
 				this.props.errorNotice( result.error );
-				this.setState( { surveyShown: false, cancelIntent: null } );
+				this.setState( { isLoading: false } );
+				// Stay on the confirmation page so the user can retry.
 			}
 		} catch ( error ) {
 			this.props.errorNotice( ( error as Error ).message );
-			this.setState( { surveyShown: false, cancelIntent: null } );
-		} finally {
 			this.setState( { isLoading: false } );
 		}
 	};
@@ -1086,10 +1088,15 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		const { siteName, siteId } = purchase;
 
 		const displayVariant: 'cancel' | 'remove' = intent === 'remove' ? 'remove' : 'cancel';
-		const heading = getCancellationHeading( {
-			purchase: toPurchaseForCopy( purchase ),
-			intent: displayVariant,
-		} );
+		// Once the cancel mutation has resolved and the user is on the survey,
+		// the cancellation has already happened — reflect that in the heading.
+		const heading =
+			this.state.surveyShown && displayVariant === 'cancel'
+				? this.props.translate( 'Cancellation confirmed' )
+				: getCancellationHeading( {
+						purchase: toPurchaseForCopy( purchase ),
+						intent: displayVariant,
+				  } );
 
 		// When a plan has an included domain that can be cancelled together,
 		// show the higher (full) refund amount in the notice since the user

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -357,9 +357,12 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 
 	// Fire the cancel/remove mutation when the user confirms (the
 	// purchases/split-cancel-remove behavior). Mirrors onSurveyComplete's
-	// mutation block minus the page.redirect — navigation moves to the
-	// survey-submit handler so the user stays on the survey while the
-	// mutation settles.
+	// mutation block minus the page.redirect AND minus refreshSitePlans /
+	// clearPurchases — those clear Redux state synchronously, which flips
+	// hasLoadedUserPurchasesFromServer to false and causes isDataLoading
+	// to render CancelPurchaseLoadingPlaceholder over the survey. They
+	// move to the survey-submit handler so they run during navigation
+	// when the placeholder isn't visible.
 	fireMutationFromConfirm = async () => {
 		this.setState( { isLoading: true } );
 		try {
@@ -375,8 +378,6 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 				if ( ! isAutoRenewIntent ) {
 					await this.handleMarketplaceSubscriptions( refundable );
 				}
-				this.props.refreshSitePlans( this.props.purchase.siteId );
-				this.props.clearPurchases();
 				this.props.successNotice( result.message, {
 					displayOnNextPage: true,
 					duration: 10000,
@@ -523,10 +524,13 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 
 	onSurveyComplete = async () => {
 		// Flag-on path: the mutation already fired at confirm-click via
-		// fireMutationFromConfirm. The success notice and redirect are owned
-		// by that helper and this handler respectively; here we only need to
-		// leave the cancel flow once the user finishes (or skips) the survey.
+		// fireMutationFromConfirm. fireMutationFromConfirm intentionally
+		// skipped clearPurchases / refreshSitePlans so they wouldn't flip
+		// isDataLoading mid-survey; we run them here, immediately before
+		// the redirect, so the destination page picks up fresh server data.
 		if ( this.shouldFireMutationOnConfirm() ) {
+			this.props.refreshSitePlans( this.props.purchase.siteId );
+			this.props.clearPurchases();
 			const managePurchaseUrl = ( this.props.getManagePurchaseUrlFor ?? managePurchase )(
 				this.props.siteSlug,
 				this.props.purchaseId


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/RSM-474

## Summary

Behind the `purchases/split-cancel-remove` flag, cancelling fires when the user confirms the cancellation rather than when they finish the survey. The survey renders post-cancellation with inline-disabled controls until the cancellation completes; once the user submits feedback or skips, they navigate back to the active-upgrades list.

- **Dashboard** adds `useCancelMutationOnConfirm` — a hook that fires the mutation, tracks an `isPending` flag for the survey controls, and runs the cache-subscription guard adapted from Filippo's `fireRemoveMutationAndLeave` so the still-mounted `purchaseQuery(id)` observer doesn't 404 on the prefix-matched invalidation cascade after delete.
- **Calypso `/me`** threads the same idea through `fireMutationFromConfirm` — a class method that reuses the existing `cancelPurchase` / `submitCancelAndRefundPurchase` async paths but moves the redirect to the survey-submit handler so the survey stays mounted while the request is in flight.
- `onSurveyComplete` short-circuits to a navigate when the flag is on and the flow is `REMOVE` or `CANCEL_WITH_REFUND`. `CANCEL_AUTORENEW` keeps the trunk in-place flow (the purchase isn't deleted, so there's no eventual-consistency window to manage).
- With the flag off, behavior on both surfaces is identical to trunk.

Extracted from Filippo's `update/cancel-mutation-timing` (#110163) commit 4. From Filippo's original commit, the following are deferred for follow-ups: skipping the survey when already complete; atomic skip + success-screen variant

## Notes

- **Helper extraction:** `useCancelMutationOnConfirm` is a new hook owning the cache-guard subscribe, `mutateAsync` discipline, and per-purchase `removeQueries` cleanup. Lives next to `index.tsx`. Three unit tests in `test/use-cancel-mutation-on-confirm.test.tsx` cover the contract surface (fire-on-confirm, isPending, skip-navigates).
- **The 15s cache-guard window** is preserved from PR-G as-is. Server eventual-consistency on user-purchases isn't going to be solved by a smaller number, and `cancelQueries` / `setQueryData` alone don't survive route-loader refetches.
- **\`pr-g/dashboard-cache-guard\`** (local-only, \`023617789c1\`) remains available for evaluating Filippo's full navigate-away pattern in manual testing — independent of this PR.
- Typecheck (\`yarn typecheck-client\`) clean on the touched files. Lint clean. 3 hook unit tests pass.

## Test plan

- [ ] **Dashboard, flag ON, click Cancel/Remove → confirm:** Cancel/Remove primary button on the confirmation screen fires the mutation immediately. The survey appears with submit/skip buttons disabled while the request is in flight. When the request settles, controls re-enable; survey submit or skip navigates to Active upgrades. The success snackbar shows once.
- [ ] **Dashboard, flag ON, REMOVE flow with refund:** confirms `cancelAndRefundMutation` fires; success notice reads "Your refund has been processed and your purchase removed."; if the plan has marketplace subscriptions, those cancel in the background.
- [ ] **Dashboard, flag ON, REMOVE flow without refund:** confirms `removePurchase` fires; success notice reads "%(productName)s was removed from %(siteName)s."
- [ ] **Dashboard, flag ON, CANCEL_AUTORENEW flow (e.g. expired-after-refund-window plan):** unchanged from trunk — mutation fires at survey submit.
- [ ] **Dashboard, flag OFF, all flows:** byte-identical to trunk — mutation at survey submit, redirect via `submitCancelAndRefundPurchase` / `submitRemovePurchase`.
- [ ] **Dashboard, error path:** server returns 500 from the cancel endpoint. Error snackbar appears; survey UI re-enables; user can navigate away.
- [ ] **Legacy /me, flag ON, click Cancel/Remove:** mutation fires immediately; survey appears with the existing `isLoading` toggle disabling controls; survey submit redirects to `managePurchaseUrl` with the persisted success notice.
- [ ] **Legacy /me, flag OFF:** byte-identical to trunk.
- [ ] **Cache-guard verification (dashboard):** trigger the cancel flow with React Query devtools open; confirm that `userPurchasesQuery` data has the cancelled purchase stripped after mutation success and that no `purchaseQuery(id)` 404 surfaces during the survey window.