### PR TITLE
Reader Mastodon: hashtag tag feeds (CM-638)

### DIFF
--- a/client/reader/mastodon/author-profile-panel.tsx
+++ b/client/reader/mastodon/author-profile-panel.tsx
@@ -15,7 +15,7 @@ import {
 import { MastodonAuthorProfileTabs, useMastodonAuthorFeedFilter } from './author-profile-tabs';
 import { projectMastodonError } from './error-projection';
 import { errorMessage } from './profile-errors';
-import { getProfileUrl, getThreadUrl, getTimelineUrl } from './route';
+import { getProfileUrl, getTagFeedUrl, getThreadUrl, getTimelineUrl } from './route';
 import type {
 	MastodonAuthorProfile,
 	MastodonConnection,
@@ -153,6 +153,11 @@ export function MastodonAuthorProfilePanel( {
 		[ connection.id ]
 	);
 
+	const buildTagUrl = useCallback(
+		( tag: string ) => getTagFeedUrl( connection.id, tag ),
+		[ connection.id ]
+	);
+
 	// Mastodon-specific empty state: when the account is locked and we have
 	// no items, the feed isn't actually empty — we just can't see it without
 	// following. Surface that explicitly so the empty state isn't misleading.
@@ -181,6 +186,7 @@ export function MastodonAuthorProfilePanel( {
 			projectFeedError={ projectMastodonError }
 			buildProfileUrl={ buildProfileUrl }
 			buildThreadUrl={ buildThreadUrl }
+			buildTagUrl={ buildTagUrl }
 			emptyTitle={
 				isLockedEmpty
 					? String( translate( 'This account’s posts are private.' ) )

--- a/client/reader/mastodon/controller.tsx
+++ b/client/reader/mastodon/controller.tsx
@@ -2,7 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import page, { type Context } from '@automattic/calypso-router';
 import AsyncLoad from 'calypso/components/async-load';
 import { TIMELINE_TAB } from './helper';
-import { isValidActor, STATUS_ID_RE } from './route';
+import { isValidActor, isValidHashtag, STATUS_ID_RE } from './route';
 
 const loadMastodonLandingView = () =>
 	import(
@@ -22,6 +22,10 @@ const loadMastodonThreadView = () =>
 const loadMastodonAuthorProfileView = () =>
 	import(
 		/* webpackChunkName: "async-load-calypso-reader-mastodon-author-profile-view" */ 'calypso/reader/mastodon/author-profile-view'
+	);
+const loadMastodonTagFeedView = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-mastodon-tag-feed-view" */ 'calypso/reader/mastodon/tag-feed-view'
 	);
 
 function ensureMastodonEnabled(): boolean {
@@ -142,6 +146,37 @@ export const mastodonProfile = ( context: Context, next: () => void ) => {
 			placeholder={ null }
 			connectionId={ id }
 			actor={ actor }
+		/>
+	);
+	next();
+};
+
+export const mastodonTagFeed = ( context: Context, next: () => void ) => {
+	if ( ! ensureMastodonEnabled() ) {
+		return;
+	}
+
+	const id = Number( context.params.id );
+	const hashtag = String( context.params.hashtag ?? '' )
+		.trim()
+		.toLowerCase()
+		.replace( /^#/, '' );
+
+	const idValid = Number.isFinite( id ) && id > 0;
+	const inputsValid = idValid && isValidHashtag( hashtag );
+
+	if ( ! inputsValid ) {
+		page.redirect( idValid ? `/reader/mastodon/${ id }` : '/reader/mastodon' );
+		return;
+	}
+
+	context.primary = (
+		<AsyncLoad
+			key="reader-mastodon-tag-feed"
+			require={ loadMastodonTagFeedView }
+			placeholder={ null }
+			connectionId={ id }
+			hashtag={ hashtag }
 		/>
 	);
 	next();

--- a/client/reader/mastodon/index.tsx
+++ b/client/reader/mastodon/index.tsx
@@ -10,6 +10,7 @@ import {
 	mastodonAccount,
 	mastodonOauthCallback,
 	mastodonProfile,
+	mastodonTagFeed,
 	mastodonThread,
 } from './controller';
 
@@ -45,6 +46,14 @@ export default function () {
 		sidebar,
 		setBeforePrimary,
 		mastodonProfile,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/reader/mastodon/:id(\\d+)/tag/:hashtag',
+		sidebar,
+		setBeforePrimary,
+		mastodonTagFeed,
 		makeLayout,
 		clientRender
 	);

--- a/client/reader/mastodon/route.ts
+++ b/client/reader/mastodon/route.ts
@@ -77,3 +77,28 @@ export function getProfileUrl(
 	}
 	return `/reader/mastodon/${ connectionId }/profile/${ encodeURIComponent( canonical ) }`;
 }
+
+// Mastodon hashtags: ASCII alphanumeric + underscore, 1-128 chars. The
+// protocol allows a wider Unicode set per joinmastodon.org; restrict to
+// the safe ASCII subset for now and revisit if non-ASCII tags become a
+// real signal. Anchored, single-line, rejects path-traversal characters
+// by construction.
+export const HASHTAG_RE = /^[A-Za-z0-9_]{1,128}$/;
+
+export function isValidHashtag( hashtag: string ): boolean {
+	return HASHTAG_RE.test( hashtag );
+}
+
+// Build the in-app hashtag-feed URL. Lowercases the input, strips a
+// leading `#`, validates the canonical form, and percent-encodes the
+// path segment for safety.
+export function getTagFeedUrl( connectionId: number, hashtag: string ): string | null {
+	if ( ! Number.isFinite( connectionId ) || connectionId <= 0 ) {
+		return null;
+	}
+	const canonical = hashtag.trim().toLowerCase().replace( /^#/, '' );
+	if ( ! isValidHashtag( canonical ) ) {
+		return null;
+	}
+	return `/reader/mastodon/${ connectionId }/tag/${ encodeURIComponent( canonical ) }`;
+}

--- a/client/reader/mastodon/route.ts
+++ b/client/reader/mastodon/route.ts
@@ -78,13 +78,19 @@ export function getProfileUrl(
 	return `/reader/mastodon/${ connectionId }/profile/${ encodeURIComponent( canonical ) }`;
 }
 
-// Mastodon hashtags: ASCII alphanumeric + underscore, 1-128 chars. The
-// protocol allows a wider Unicode set per joinmastodon.org; restrict to
-// the safe ASCII subset for now and revisit if non-ASCII tags become a
-// real signal. Anchored, single-line, rejects path-traversal characters
-// by construction.
-export const HASHTAG_RE = /^[A-Za-z0-9_]{1,128}$/;
+// Mastodon hashtags in canonical form: lowercase ASCII + underscore,
+// 1-128 chars. The protocol allows a wider Unicode set per joinmastodon.org;
+// restrict to the safe ASCII subset for now and revisit if non-ASCII tags
+// become a real signal. Anchored, single-line, rejects path-traversal
+// characters by construction. Case-strict (lowercase only) so the in-app
+// route shape is canonical — a single `/tag/rust` URL, not two distinct
+// React-router paths for `Rust` and `rust`.
+export const HASHTAG_RE = /^[a-z0-9_]{1,128}$/;
 
+// Validates a hashtag against the canonical form. Callers with raw input
+// (mixed case, leading `#`, surrounding whitespace) must canonicalise
+// first via `getTagFeedUrl`, which trim/lowercase/strip-`#`s before
+// validating.
 export function isValidHashtag( hashtag: string ): boolean {
 	return HASHTAG_RE.test( hashtag );
 }

--- a/client/reader/mastodon/style.scss
+++ b/client/reader/mastodon/style.scss
@@ -23,3 +23,36 @@
 		padding-top: 5px;
 	}
 }
+
+.mastodon-tag-feed .mastodon-tag-feed__header {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.mastodon-tag-feed .mastodon-tag-feed__heading {
+	margin: 0;
+	font-size: 24px;
+	font-weight: 600;
+	line-height: 1.2;
+}
+
+.mastodon-tag-feed .mastodon-tag-feed__count {
+	margin: 0;
+	color: var(--color-text-subtle);
+	font-size: 14px;
+}
+
+.mastodon-tag-feed .mastodon-tag-feed__external-link {
+	font-size: 13px;
+}
+
+.mastodon-view .mastodon-tag-feed-tabs {
+	.section-nav-tabs__list {
+		overflow-x: auto;
+	}
+
+	.section-nav-tab__link {
+		padding-top: 5px;
+	}
+}

--- a/client/reader/mastodon/tag-feed-panel.tsx
+++ b/client/reader/mastodon/tag-feed-panel.tsx
@@ -1,0 +1,218 @@
+import { useMastodonTagFeedInfiniteQuery } from '@automattic/api-queries';
+import { __experimentalVStack as VStack } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useDispatch } from 'react-redux';
+import {
+	AuthorProfileHeader,
+	SocialAnalyticsProvider,
+	SocialFeedList,
+	SocialPostCard,
+	mapMastodonFeedItemToSocialPost,
+	type SocialPost,
+} from 'calypso/reader/social';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import { projectMastodonError } from './error-projection';
+import { getProfileUrl, getTagFeedUrl, getThreadUrl, getTimelineUrl } from './route';
+import { MastodonTagFeedTabs, useMastodonTagFilter } from './tag-feed-tabs';
+import type { MastodonConnection, MastodonFeedItem } from '@automattic/api-core';
+import type { AppState } from 'calypso/types';
+import type { UnknownAction } from 'redux';
+import type { ThunkDispatch } from 'redux-thunk';
+
+interface Props {
+	connection: MastodonConnection;
+	hashtag: string;
+}
+
+export function MastodonTagFeedPanel( { connection, hashtag }: Props ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch< ThunkDispatch< AppState, void, UnknownAction > >();
+	const lastErrorKind = useRef< string | null >( null );
+
+	const filter = useMastodonTagFilter();
+	const feed = useMastodonTagFeedInfiniteQuery( connection.id, hashtag, filter );
+
+	// Reset error_shown dedup when filter changes so each filter's first
+	// error fires its own analytics event even when the kind matches the
+	// prior filter.
+	useEffect( () => {
+		lastErrorKind.current = null;
+	}, [ filter ] );
+
+	// Fire tag_feed_viewed exactly once per (connection, hashtag) — gated
+	// on resolved feed data so the payload reflects what the user actually
+	// saw on first load. Subsequent tab switches don't re-fire.
+	const viewedFor = useRef< string | null >( null );
+	useEffect( () => {
+		const key = `${ connection.id }:${ hashtag }`;
+		if ( viewedFor.current === key || ! feed.data ) {
+			return;
+		}
+		viewedFor.current = key;
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_mastodon_tag_feed_viewed', {
+				connection_id: connection.id,
+				hashtag,
+				initial_filter: filter,
+			} )
+		);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ connection.id, hashtag, feed.data, dispatch ] );
+
+	useEffect( () => {
+		if ( feed.isError && feed.error && feed.error.kind !== lastErrorKind.current ) {
+			lastErrorKind.current = feed.error.kind;
+			dispatch(
+				recordReaderTracksEvent( 'calypso_reader_mastodon_tag_feed_error_shown', {
+					connection_id: connection.id,
+					hashtag,
+					error_kind: feed.error.kind,
+					filter,
+				} )
+			);
+		}
+		if ( ! feed.isError ) {
+			lastErrorKind.current = null;
+		}
+	}, [ feed.isError, feed.error, connection.id, hashtag, filter, dispatch ] );
+
+	const handleRetry = useCallback( () => {
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_mastodon_tag_feed_retry_clicked', {
+				connection_id: connection.id,
+				hashtag,
+				filter,
+				error_kind: feed.error?.kind ?? 'unknown',
+			} )
+		);
+		feed.refetch();
+	}, [ connection.id, hashtag, filter, feed, dispatch ] );
+
+	const handleBackToTimeline = useCallback( () => {
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_mastodon_tag_feed_back_to_timeline_clicked', {
+				connection_id: connection.id,
+				hashtag,
+			} )
+		);
+	}, [ connection.id, hashtag, dispatch ] );
+
+	const onClickAnalytics = useCallback(
+		( event: string, props: Record< string, unknown > ) => {
+			// Subcomponents emit `calypso_reader_mastodon_timeline_*`. Rewrite the
+			// surface to `_tag_feed_` so dashboards can split.
+			const TIMELINE_PREFIX = 'calypso_reader_mastodon_timeline_';
+			const TAG_PREFIX = 'calypso_reader_mastodon_tag_feed_';
+			const reprefixed = event.startsWith( TIMELINE_PREFIX )
+				? TAG_PREFIX + event.slice( TIMELINE_PREFIX.length )
+				: event;
+			dispatch( recordReaderTracksEvent( reprefixed, { ...props, hashtag } ) );
+		},
+		[ dispatch, hashtag ]
+	);
+
+	const buildThreadUrl = useCallback(
+		( uri: string ) => getThreadUrl( connection.id, uri ),
+		[ connection.id ]
+	);
+
+	const buildProfileUrl = useCallback(
+		( ref: { id?: string | null; handle?: string | null } ) => {
+			if ( ref.id ) {
+				return getProfileUrl( connection.id, ref.id );
+			}
+			if ( ref.handle ) {
+				return getProfileUrl( connection.id, ref.handle, { instance: connection.instance } );
+			}
+			return null;
+		},
+		[ connection.id, connection.instance ]
+	);
+
+	const buildTagUrl = useCallback(
+		( tag: string ) => getTagFeedUrl( connection.id, tag ),
+		[ connection.id ]
+	);
+
+	const items: SocialPost[] = useMemo( () => {
+		const seen = new Set< string >();
+		const deduped: MastodonFeedItem[] = [];
+		for ( const post of feed.data?.pages.flatMap( ( page ) => page.items ?? [] ) ?? [] ) {
+			if ( ! post?.id || seen.has( post.id ) ) {
+				continue;
+			}
+			seen.add( post.id );
+			deduped.push( post );
+		}
+		return deduped.map( ( item ) =>
+			mapMastodonFeedItemToSocialPost( item, { instance: connection.instance } )
+		);
+	}, [ feed.data, connection.instance ] );
+
+	const renderItem = useCallback(
+		( post: SocialPost ) => <SocialPostCard post={ post } variant="default" />,
+		[]
+	);
+	const itemKey = useCallback( ( post: SocialPost ) => post.uri, [] );
+
+	const analyticsValue = useMemo(
+		() => ( {
+			source: 'mastodon' as const,
+			connectionId: connection.id,
+			onClick: onClickAnalytics,
+			getThreadUrl: buildThreadUrl,
+			getProfileUrl: buildProfileUrl,
+			getTagUrl: buildTagUrl,
+		} ),
+		[ connection.id, onClickAnalytics, buildThreadUrl, buildProfileUrl, buildTagUrl ]
+	);
+
+	const tagInfo = feed.data?.pages[ 0 ]?.tag;
+	const countLine =
+		tagInfo?.count !== undefined
+			? translate( '%(count)d post', '%(count)d posts', {
+					count: tagInfo.count,
+					args: { count: tagInfo.count },
+			  } )
+			: null;
+
+	return (
+		<SocialAnalyticsProvider value={ analyticsValue }>
+			<VStack spacing={ 4 } className="mastodon-tag-feed">
+				<AuthorProfileHeader
+					timelineUrl={ getTimelineUrl( connection.id ) }
+					onBackToTimeline={ handleBackToTimeline }
+				/>
+				<div className="mastodon-tag-feed__header">
+					<h1 className="mastodon-tag-feed__heading">{ `#${ hashtag }` }</h1>
+					{ countLine ? <p className="mastodon-tag-feed__count">{ countLine }</p> : null }
+				</div>
+				<MastodonTagFeedTabs
+					connectionId={ connection.id }
+					hashtag={ hashtag }
+					activeFilter={ filter }
+				/>
+				<SocialFeedList< SocialPost >
+					items={ items }
+					isPending={ feed.isPending }
+					isError={ feed.isError }
+					error={ projectMastodonError( feed.error ) }
+					hasNextPage={ Boolean( feed.hasNextPage ) }
+					isFetchingNextPage={ feed.isFetchingNextPage }
+					fetchNextPage={ feed.fetchNextPage }
+					refetch={ handleRetry }
+					renderItem={ renderItem }
+					itemKey={ itemKey }
+					emptyTitle={ String(
+						translate( 'No posts found for #%(hashtag)s.', { args: { hashtag } } )
+					) }
+					emptyLine={ String( translate( 'Try a different filter or check back later.' ) ) }
+					protocolLabel="Mastodon"
+					protocolHomeURL="/reader/mastodon"
+					protocolHomeLabel={ String( translate( 'Back to Mastodon' ) ) }
+				/>
+			</VStack>
+		</SocialAnalyticsProvider>
+	);
+}

--- a/client/reader/mastodon/tag-feed-panel.tsx
+++ b/client/reader/mastodon/tag-feed-panel.tsx
@@ -1,5 +1,5 @@
 import { useMastodonTagFeedInfiniteQuery } from '@automattic/api-queries';
-import { __experimentalVStack as VStack } from '@wordpress/components';
+import { ExternalLink, __experimentalVStack as VStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useDispatch } from 'react-redux';
@@ -177,6 +177,21 @@ export function MastodonTagFeedPanel( { connection, hashtag }: Props ) {
 			  } )
 			: null;
 
+	// Defence-in-depth on a third-party-supplied URL: only honour https URLs
+	// even though the backend should only ever emit a Mastodon home-instance
+	// URL. Anything else (javascript:, http://, malformed) falls through to
+	// no link rather than reaching the DOM as an anchor href.
+	const externalTagUrl = ( () => {
+		if ( ! tagInfo?.url ) {
+			return null;
+		}
+		try {
+			return new URL( tagInfo.url ).protocol === 'https:' ? tagInfo.url : null;
+		} catch {
+			return null;
+		}
+	} )();
+
 	return (
 		<SocialAnalyticsProvider value={ analyticsValue }>
 			<VStack spacing={ 4 } className="mastodon-tag-feed">
@@ -187,15 +202,10 @@ export function MastodonTagFeedPanel( { connection, hashtag }: Props ) {
 				<div className="mastodon-tag-feed__header">
 					<h1 className="mastodon-tag-feed__heading">{ `#${ hashtag }` }</h1>
 					{ countLine ? <p className="mastodon-tag-feed__count">{ countLine }</p> : null }
-					{ tagInfo?.url ? (
-						<a
-							className="mastodon-tag-feed__external-link"
-							href={ tagInfo.url }
-							target="_blank"
-							rel="noopener noreferrer"
-						>
+					{ externalTagUrl ? (
+						<ExternalLink className="mastodon-tag-feed__external-link" href={ externalTagUrl }>
 							{ translate( 'View on Mastodon' ) }
-						</a>
+						</ExternalLink>
 					) : null }
 				</div>
 				<MastodonTagFeedTabs

--- a/client/reader/mastodon/tag-feed-panel.tsx
+++ b/client/reader/mastodon/tag-feed-panel.tsx
@@ -187,6 +187,16 @@ export function MastodonTagFeedPanel( { connection, hashtag }: Props ) {
 				<div className="mastodon-tag-feed__header">
 					<h1 className="mastodon-tag-feed__heading">{ `#${ hashtag }` }</h1>
 					{ countLine ? <p className="mastodon-tag-feed__count">{ countLine }</p> : null }
+					{ tagInfo?.url ? (
+						<a
+							className="mastodon-tag-feed__external-link"
+							href={ tagInfo.url }
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							{ translate( 'View on Mastodon' ) }
+						</a>
+					) : null }
 				</div>
 				<MastodonTagFeedTabs
 					connectionId={ connection.id }

--- a/client/reader/mastodon/tag-feed-tabs.tsx
+++ b/client/reader/mastodon/tag-feed-tabs.tsx
@@ -1,0 +1,104 @@
+import { useTranslate, type TranslateResult } from 'i18n-calypso';
+import { useMemo } from 'react';
+import { SocialAuthorProfileTabs, useTabSlug, type TabSpec } from 'calypso/reader/social';
+import { useDispatch } from 'calypso/state';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import type { MastodonTagFilter } from '@automattic/api-core';
+
+const ALLOWED_SLUGS = [ 'all', 'media', 'local' ] as const;
+const DEFAULT_SLUG = 'all';
+
+const SLUG_TO_FILTER: Record< string, MastodonTagFilter > = {
+	all: 'all',
+	media: 'media',
+	local: 'local',
+};
+
+const FILTER_TO_SLUG: Record< MastodonTagFilter, string > = {
+	all: 'all',
+	media: 'media',
+	local: 'local',
+};
+
+/**
+ * Reads `?tab=` from the current location and returns the corresponding
+ * Mastodon tag filter. Delegates URL parsing + malformed-slug rewrite to
+ * the shared `useTabSlug` hook.
+ */
+export function useMastodonTagFilter(): MastodonTagFilter {
+	const { slug } = useTabSlug( {
+		allowedSlugs: ALLOWED_SLUGS,
+		defaultSlug: DEFAULT_SLUG,
+	} );
+	return SLUG_TO_FILTER[ slug ] ?? SLUG_TO_FILTER[ DEFAULT_SLUG ];
+}
+
+interface MastodonTagFeedTabsProps {
+	connectionId: number;
+	hashtag: string;
+	activeFilter: MastodonTagFilter;
+}
+
+function buildPath( connectionId: number, hashtag: string, slug: string ): string {
+	const base = `/reader/mastodon/${ connectionId }/tag/${ encodeURIComponent( hashtag ) }`;
+	if ( typeof window === 'undefined' ) {
+		return `${ base }?tab=${ slug }`;
+	}
+	// Preserve any other query params and the fragment so switching tabs
+	// doesn't drop user-relevant URL state. Mirrors the malformed-rewrite
+	// path's URL preservation in useTabSlug.
+	const params = new URLSearchParams( window.location.search );
+	params.set( 'tab', slug );
+	const hash = window.location.hash;
+	return `${ base }?${ params.toString() }${ hash }`;
+}
+
+export function MastodonTagFeedTabs( {
+	connectionId,
+	hashtag,
+	activeFilter,
+}: MastodonTagFeedTabsProps ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const tabs: TabSpec[] = useMemo(
+		() => [
+			{
+				slug: 'all',
+				title: translate( 'All' ) as TranslateResult,
+				path: buildPath( connectionId, hashtag, 'all' ),
+			},
+			{
+				slug: 'media',
+				title: translate( 'Media' ) as TranslateResult,
+				path: buildPath( connectionId, hashtag, 'media' ),
+			},
+			{
+				slug: 'local',
+				title: translate( 'Local' ) as TranslateResult,
+				path: buildPath( connectionId, hashtag, 'local' ),
+			},
+		],
+		[ connectionId, hashtag, translate ]
+	);
+
+	const activeSlug = FILTER_TO_SLUG[ activeFilter ];
+
+	return (
+		<SocialAuthorProfileTabs
+			className="mastodon-tag-feed-tabs"
+			tabs={ tabs }
+			activeSlug={ activeSlug }
+			onTabClick={ ( toSlug, fromSlug ) => {
+				dispatch(
+					recordReaderTracksEvent( 'calypso_reader_mastodon_tag_filter_changed', {
+						connection_id: connectionId,
+						hashtag,
+						from_filter: SLUG_TO_FILTER[ fromSlug ] ?? activeFilter,
+						to_filter: SLUG_TO_FILTER[ toSlug ] ?? activeFilter,
+					} )
+				);
+			} }
+		/>
+	);
+}

--- a/client/reader/mastodon/tag-feed-view.tsx
+++ b/client/reader/mastodon/tag-feed-view.tsx
@@ -1,0 +1,64 @@
+import { useMastodonConnectionsQuery } from '@automattic/api-queries';
+import page from '@automattic/calypso-router';
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import DocumentHead from 'calypso/components/data/document-head';
+import ReaderMain from 'calypso/reader/components/reader-main';
+import { MastodonTagFeedPanel } from './tag-feed-panel';
+
+interface Props {
+	connectionId: number;
+	hashtag: string;
+}
+
+export function MastodonTagFeedView( { connectionId, hashtag }: Props ) {
+	const translate = useTranslate();
+	const { data, isPending, isError, refetch } = useMastodonConnectionsQuery();
+
+	const connections = data?.connections ?? [];
+	const connection = connections.find( ( c ) => c.id === connectionId ) ?? null;
+
+	useEffect( () => {
+		if ( isPending || isError ) {
+			return;
+		}
+		if ( ! connection ) {
+			page.replace( '/reader/mastodon' );
+		}
+	}, [ isPending, isError, connection, connectionId ] );
+
+	if ( isError ) {
+		return (
+			<ReaderMain className="mastodon-view">
+				<DocumentHead title={ translate( 'Tag ‹ Mastodon ‹ Reader' ) } />
+				<div role="alert" className="mastodon-error">
+					<p>{ translate( "We couldn't load your Mastodon connections." ) }</p>
+					<Button variant="secondary" onClick={ () => refetch() }>
+						{ translate( 'Try again' ) }
+					</Button>
+				</div>
+			</ReaderMain>
+		);
+	}
+
+	if ( ! connection ) {
+		return (
+			<ReaderMain className="mastodon-view">
+				<DocumentHead title={ translate( 'Tag ‹ Mastodon ‹ Reader' ) } />
+				<div role="status" aria-live="polite">
+					{ translate( 'Loading…' ) }
+				</div>
+			</ReaderMain>
+		);
+	}
+
+	return (
+		<ReaderMain className="mastodon-view">
+			<DocumentHead title={ translate( '#%s ‹ Mastodon ‹ Reader', { args: hashtag } ) } />
+			<MastodonTagFeedPanel connection={ connection } hashtag={ hashtag } />
+		</ReaderMain>
+	);
+}
+
+export default MastodonTagFeedView;

--- a/client/reader/mastodon/test/controller.test.tsx
+++ b/client/reader/mastodon/test/controller.test.tsx
@@ -14,7 +14,7 @@ jest.mock( '@automattic/calypso-config', () => ( {
 } ) );
 
 import page from '@automattic/calypso-router';
-import { mastodonProfile, mastodonThread } from '../controller';
+import { mastodonProfile, mastodonTagFeed, mastodonThread } from '../controller';
 
 function makeContext( params: Record< string, string > ) {
 	return { params, primary: null } as unknown as Parameters< typeof mastodonProfile >[ 0 ];
@@ -89,5 +89,36 @@ describe( 'mastodonThread controller', () => {
 		mastodonThread( ctx, mockNext );
 		expect( page.redirect ).toHaveBeenCalledWith( '/reader/mastodon/7' );
 		expect( mockNext ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'mastodonTagFeed controller', () => {
+	it( 'sets context.primary on a valid id + hashtag', () => {
+		const ctx = makeContext( { id: '7', hashtag: 'rust' } );
+		mastodonTagFeed( ctx, mockNext );
+		expect( ctx.primary ).not.toBeNull();
+		expect( mockNext ).toHaveBeenCalled();
+	} );
+
+	it( 'redirects to /reader/mastodon when id is non-finite', () => {
+		const ctx = makeContext( { id: 'NaN', hashtag: 'rust' } );
+		mastodonTagFeed( ctx, mockNext );
+		expect( page.redirect ).toHaveBeenCalledWith( '/reader/mastodon' );
+		expect( mockNext ).not.toHaveBeenCalled();
+	} );
+
+	it( 'redirects to /reader/mastodon/:id on a malformed hashtag', () => {
+		const ctx = makeContext( { id: '7', hashtag: 'has spaces' } );
+		mastodonTagFeed( ctx, mockNext );
+		expect( page.redirect ).toHaveBeenCalledWith( '/reader/mastodon/7' );
+		expect( mockNext ).not.toHaveBeenCalled();
+	} );
+
+	it( 'lowercases the hashtag before passing it to the view', () => {
+		const ctx = makeContext( { id: '7', hashtag: 'Rust' } );
+		mastodonTagFeed( ctx, mockNext );
+		expect( ( ctx.primary as unknown as { props: { hashtag: string } } ).props.hashtag ).toBe(
+			'rust'
+		);
 	} );
 } );

--- a/client/reader/mastodon/test/route.test.ts
+++ b/client/reader/mastodon/test/route.test.ts
@@ -1,4 +1,11 @@
-import { getProfileUrl, getThreadUrl, getTimelineUrl, isValidActor } from '../route';
+import {
+	getProfileUrl,
+	getThreadUrl,
+	getTimelineUrl,
+	isValidActor,
+	getTagFeedUrl,
+	isValidHashtag,
+} from '../route';
 
 describe( 'getTimelineUrl', () => {
 	it( 'returns the connection-scoped timeline path', () => {
@@ -82,5 +89,42 @@ describe( 'getProfileUrl', () => {
 		expect( getProfileUrl( 7, 'alice@mastodon.social' ) ).toBe(
 			'/reader/mastodon/7/profile/alice%40mastodon.social'
 		);
+	} );
+} );
+
+describe( 'isValidHashtag', () => {
+	it( 'accepts ASCII alphanumeric + underscore', () => {
+		expect( isValidHashtag( 'rust' ) ).toBe( true );
+		expect( isValidHashtag( 'rust_lang' ) ).toBe( true );
+		expect( isValidHashtag( 'r2d2' ) ).toBe( true );
+	} );
+
+	it( 'rejects path traversal, spaces, leading hash, and empty', () => {
+		expect( isValidHashtag( 'rust/extra' ) ).toBe( false );
+		expect( isValidHashtag( 'rust lang' ) ).toBe( false );
+		expect( isValidHashtag( '#rust' ) ).toBe( false );
+		expect( isValidHashtag( '' ) ).toBe( false );
+		expect( isValidHashtag( '../etc' ) ).toBe( false );
+	} );
+} );
+
+describe( 'getTagFeedUrl', () => {
+	it( 'returns null on a non-positive connection id', () => {
+		expect( getTagFeedUrl( 0, 'rust' ) ).toBeNull();
+		expect( getTagFeedUrl( -1, 'rust' ) ).toBeNull();
+	} );
+
+	it( 'lowercases the canonical hashtag and percent-encodes the segment', () => {
+		expect( getTagFeedUrl( 7, 'Rust' ) ).toBe( '/reader/mastodon/7/tag/rust' );
+	} );
+
+	it( 'strips a leading # before validating', () => {
+		expect( getTagFeedUrl( 7, '#rust' ) ).toBe( '/reader/mastodon/7/tag/rust' );
+	} );
+
+	it( 'returns null on a malformed hashtag', () => {
+		expect( getTagFeedUrl( 7, 'has spaces' ) ).toBeNull();
+		expect( getTagFeedUrl( 7, '../foo' ) ).toBeNull();
+		expect( getTagFeedUrl( 7, '' ) ).toBeNull();
 	} );
 } );

--- a/client/reader/mastodon/test/route.test.ts
+++ b/client/reader/mastodon/test/route.test.ts
@@ -93,10 +93,15 @@ describe( 'getProfileUrl', () => {
 } );
 
 describe( 'isValidHashtag', () => {
-	it( 'accepts ASCII alphanumeric + underscore', () => {
+	it( 'accepts canonical (lowercase) ASCII alphanumeric + underscore', () => {
 		expect( isValidHashtag( 'rust' ) ).toBe( true );
 		expect( isValidHashtag( 'rust_lang' ) ).toBe( true );
 		expect( isValidHashtag( 'r2d2' ) ).toBe( true );
+	} );
+
+	it( 'rejects uppercase (canonical form is lowercase only)', () => {
+		expect( isValidHashtag( 'Rust' ) ).toBe( false );
+		expect( isValidHashtag( 'RUST' ) ).toBe( false );
 	} );
 
 	it( 'rejects path traversal, spaces, leading hash, and empty', () => {
@@ -105,6 +110,11 @@ describe( 'isValidHashtag', () => {
 		expect( isValidHashtag( '#rust' ) ).toBe( false );
 		expect( isValidHashtag( '' ) ).toBe( false );
 		expect( isValidHashtag( '../etc' ) ).toBe( false );
+	} );
+
+	it( 'enforces the 128-char length cap', () => {
+		expect( isValidHashtag( 'a'.repeat( 128 ) ) ).toBe( true );
+		expect( isValidHashtag( 'a'.repeat( 129 ) ) ).toBe( false );
 	} );
 } );
 

--- a/client/reader/mastodon/test/tag-feed-panel.test.tsx
+++ b/client/reader/mastodon/test/tag-feed-panel.test.tsx
@@ -93,6 +93,38 @@ describe( 'MastodonTagFeedPanel', () => {
 		} );
 	} );
 
+	it( 'renders a "View on Mastodon" link when the backend embeds tag.url', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/mastodon/connections/7/tag/rust/feed' )
+			.reply( 200, {
+				items: [],
+				cursor: null,
+				tag: { name: 'rust', url: 'https://mastodon.social/tags/rust' },
+			} );
+
+		renderWithProvider( <MastodonTagFeedPanel connection={ connection } hashtag="rust" />, {
+			queryClient: makeQueryClient(),
+		} );
+
+		const link = await screen.findByRole( 'link', { name: 'View on Mastodon' } );
+		expect( link ).toHaveAttribute( 'href', 'https://mastodon.social/tags/rust' );
+		expect( link ).toHaveAttribute( 'target', '_blank' );
+		expect( link ).toHaveAttribute( 'rel', 'noopener noreferrer' );
+	} );
+
+	it( 'omits the external link when tag.url is not provided', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/mastodon/connections/7/tag/rust/feed' )
+			.reply( 200, { items: [], cursor: null, tag: { name: 'rust', count: 1 } } );
+
+		renderWithProvider( <MastodonTagFeedPanel connection={ connection } hashtag="rust" />, {
+			queryClient: makeQueryClient(),
+		} );
+
+		await waitFor( () => expect( screen.getByRole( 'heading', { name: '#rust' } ) ).toBeVisible() );
+		expect( screen.queryByRole( 'link', { name: 'View on Mastodon' } ) ).toBeNull();
+	} );
+
 	it( 'flows ?tab=media through to the feed query as only_media=true', async () => {
 		window.history.replaceState( {}, '', '/reader/mastodon/7/tag/rust?tab=media' );
 		const feedScope = nock( BASE )

--- a/client/reader/mastodon/test/tag-feed-panel.test.tsx
+++ b/client/reader/mastodon/test/tag-feed-panel.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient } from '@tanstack/react-query';
+import { screen, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import * as analytics from 'calypso/state/reader/analytics/actions';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { MastodonTagFeedPanel } from '../tag-feed-panel';
+import type { MastodonConnection } from '@automattic/api-core';
+
+jest.mock( '@automattic/calypso-router', () => jest.fn() );
+
+beforeAll( () => {
+	global.IntersectionObserver = class IntersectionObserver {
+		observe() {}
+		unobserve() {}
+		disconnect() {}
+	} as unknown as typeof global.IntersectionObserver;
+} );
+
+afterAll( () => {
+	// @ts-expect-error -- cleaning up the stub
+	delete global.IntersectionObserver;
+} );
+
+const BASE = 'https://public-api.wordpress.com';
+
+const connection: MastodonConnection = {
+	id: 7,
+	handle: '@me@mastodon.social',
+	instance: 'mastodon.social',
+	display_name: 'Me',
+	avatar: null,
+};
+
+function makeQueryClient() {
+	return new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+}
+
+describe( 'MastodonTagFeedPanel', () => {
+	beforeEach( () => {
+		jest
+			.spyOn( analytics, 'recordReaderTracksEvent' )
+			.mockImplementation( () => ( { type: '@@TEST/NOOP' } ) as never );
+	} );
+
+	afterEach( () => {
+		nock.cleanAll();
+		jest.restoreAllMocks();
+		window.history.replaceState( {}, '', '/' );
+	} );
+
+	it( 'renders the hashtag header and fires tag_feed_viewed once', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/mastodon/connections/7/tag/rust/feed' )
+			.reply( 200, { items: [], cursor: null } );
+
+		renderWithProvider( <MastodonTagFeedPanel connection={ connection } hashtag="rust" />, {
+			queryClient: makeQueryClient(),
+		} );
+
+		await waitFor( () => expect( screen.getByRole( 'heading', { name: '#rust' } ) ).toBeVisible() );
+		await waitFor( () => {
+			const calls = ( analytics.recordReaderTracksEvent as unknown as jest.Mock ).mock.calls.filter(
+				( c ) => c[ 0 ] === 'calypso_reader_mastodon_tag_feed_viewed'
+			);
+			expect( calls ).toHaveLength( 1 );
+			expect( calls[ 0 ][ 1 ] ).toMatchObject( {
+				connection_id: 7,
+				hashtag: 'rust',
+				initial_filter: 'all',
+			} );
+		} );
+	} );
+
+	it( 'renders the count line when the backend embeds tag.count', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/mastodon/connections/7/tag/rust/feed' )
+			.reply( 200, {
+				items: [],
+				cursor: null,
+				tag: { name: 'rust', count: 42 },
+			} );
+
+		renderWithProvider( <MastodonTagFeedPanel connection={ connection } hashtag="rust" />, {
+			queryClient: makeQueryClient(),
+		} );
+
+		await waitFor( () => {
+			expect( screen.getByRole( 'heading', { name: '#rust' } ) ).toBeVisible();
+			expect( screen.getByText( /42/ ) ).toBeVisible();
+		} );
+	} );
+
+	it( 'flows ?tab=media through to the feed query as only_media=true', async () => {
+		window.history.replaceState( {}, '', '/reader/mastodon/7/tag/rust?tab=media' );
+		const feedScope = nock( BASE )
+			.get( '/wpcom/v2/reader/mastodon/connections/7/tag/rust/feed' )
+			.query( { only_media: 'true' } )
+			.reply( 200, { items: [], cursor: null } );
+
+		renderWithProvider( <MastodonTagFeedPanel connection={ connection } hashtag="rust" />, {
+			queryClient: makeQueryClient(),
+		} );
+
+		await waitFor( () => expect( feedScope.isDone() ).toBe( true ) );
+	} );
+} );

--- a/client/reader/mastodon/test/tag-feed-panel.test.tsx
+++ b/client/reader/mastodon/test/tag-feed-panel.test.tsx
@@ -106,10 +106,13 @@ describe( 'MastodonTagFeedPanel', () => {
 			queryClient: makeQueryClient(),
 		} );
 
-		const link = await screen.findByRole( 'link', { name: 'View on Mastodon' } );
+		const link = await screen.findByRole( 'link', { name: /View on Mastodon/ } );
 		expect( link ).toHaveAttribute( 'href', 'https://mastodon.social/tags/rust' );
 		expect( link ).toHaveAttribute( 'target', '_blank' );
-		expect( link ).toHaveAttribute( 'rel', 'noopener noreferrer' );
+		// `ExternalLink` enforces `rel="external noreferrer noopener"`; assert the
+		// security tokens are present without locking to the exact ordering.
+		const rel = ( link.getAttribute( 'rel' ) ?? '' ).split( /\s+/ );
+		expect( rel ).toEqual( expect.arrayContaining( [ 'noopener', 'noreferrer' ] ) );
 	} );
 
 	it( 'omits the external link when tag.url is not provided', async () => {
@@ -122,7 +125,24 @@ describe( 'MastodonTagFeedPanel', () => {
 		} );
 
 		await waitFor( () => expect( screen.getByRole( 'heading', { name: '#rust' } ) ).toBeVisible() );
-		expect( screen.queryByRole( 'link', { name: 'View on Mastodon' } ) ).toBeNull();
+		expect( screen.queryByRole( 'link', { name: /View on Mastodon/ } ) ).toBeNull();
+	} );
+
+	it( 'rejects non-https tag.url values (defence-in-depth)', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/mastodon/connections/7/tag/rust/feed' )
+			.reply( 200, {
+				items: [],
+				cursor: null,
+				tag: { name: 'rust', url: 'javascript:alert(1)' },
+			} );
+
+		renderWithProvider( <MastodonTagFeedPanel connection={ connection } hashtag="rust" />, {
+			queryClient: makeQueryClient(),
+		} );
+
+		await waitFor( () => expect( screen.getByRole( 'heading', { name: '#rust' } ) ).toBeVisible() );
+		expect( screen.queryByRole( 'link', { name: /View on Mastodon/ } ) ).toBeNull();
 	} );
 
 	it( 'flows ?tab=media through to the feed query as only_media=true', async () => {

--- a/client/reader/mastodon/test/tag-feed-tabs.test.tsx
+++ b/client/reader/mastodon/test/tag-feed-tabs.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * @jest-environment jsdom
+ */
+import page from '@automattic/calypso-router';
+import { renderHook, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as analytics from 'calypso/state/reader/analytics/actions';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { MastodonTagFeedTabs, useMastodonTagFilter } from '../tag-feed-tabs';
+
+jest.mock( '@automattic/calypso-router', () => ( {
+	__esModule: true,
+	default: { replace: jest.fn() },
+} ) );
+
+const replace = page.replace as jest.Mock;
+
+function setLocation( search: string ) {
+	window.history.replaceState( {}, '', '/reader/mastodon/7/tag/rust' + search );
+}
+
+beforeAll( () => {
+	global.IntersectionObserver = class IntersectionObserver {
+		observe() {}
+		unobserve() {}
+		disconnect() {}
+	} as unknown as typeof global.IntersectionObserver;
+} );
+
+afterAll( () => {
+	// @ts-expect-error -- cleaning up the stub
+	delete global.IntersectionObserver;
+} );
+
+beforeEach( () => {
+	replace.mockReset();
+	jest
+		.spyOn( analytics, 'recordReaderTracksEvent' )
+		.mockImplementation( () => ( { type: '@@TEST/NOOP' } ) as never );
+	setLocation( '' );
+} );
+
+afterEach( () => jest.restoreAllMocks() );
+
+describe( 'useMastodonTagFilter', () => {
+	it( 'returns "all" when ?tab is absent', () => {
+		setLocation( '' );
+		const { result } = renderHook( () => useMastodonTagFilter() );
+		expect( result.current ).toBe( 'all' );
+	} );
+
+	it( 'maps ?tab=media to "media"', () => {
+		setLocation( '?tab=media' );
+		const { result } = renderHook( () => useMastodonTagFilter() );
+		expect( result.current ).toBe( 'media' );
+	} );
+
+	it( 'maps ?tab=local to "local"', () => {
+		setLocation( '?tab=local' );
+		const { result } = renderHook( () => useMastodonTagFilter() );
+		expect( result.current ).toBe( 'local' );
+	} );
+
+	it( 'falls back to "all" on a malformed slug', () => {
+		setLocation( '?tab=garbage' );
+		const { result } = renderHook( () => useMastodonTagFilter() );
+		expect( result.current ).toBe( 'all' );
+	} );
+} );
+
+describe( 'MastodonTagFeedTabs', () => {
+	function renderTabs( props: Partial< React.ComponentProps< typeof MastodonTagFeedTabs > > = {} ) {
+		return renderWithProvider(
+			<MastodonTagFeedTabs connectionId={ 7 } hashtag="rust" activeFilter="all" { ...props } />
+		);
+	}
+
+	it( 'renders three tabs labeled All, Media, Local', () => {
+		renderTabs();
+		expect( screen.getByRole( 'menuitem', { name: 'All' } ) ).toBeVisible();
+		expect( screen.getByRole( 'menuitem', { name: 'Media' } ) ).toBeVisible();
+		expect( screen.getByRole( 'menuitem', { name: 'Local' } ) ).toBeVisible();
+	} );
+
+	it( 'tabs anchor to the per-filter URL via href', () => {
+		renderTabs();
+		expect( screen.getByRole( 'menuitem', { name: 'All' } ) ).toHaveAttribute(
+			'href',
+			'/reader/mastodon/7/tag/rust?tab=all'
+		);
+		expect( screen.getByRole( 'menuitem', { name: 'Media' } ) ).toHaveAttribute(
+			'href',
+			'/reader/mastodon/7/tag/rust?tab=media'
+		);
+		expect( screen.getByRole( 'menuitem', { name: 'Local' } ) ).toHaveAttribute(
+			'href',
+			'/reader/mastodon/7/tag/rust?tab=local'
+		);
+	} );
+
+	it( 'plain-clicking a non-active tab navigates and dispatches _tag_filter_changed', async () => {
+		const user = userEvent.setup();
+		renderTabs( { activeFilter: 'all' } );
+
+		await user.click( screen.getByRole( 'menuitem', { name: 'Media' } ) );
+
+		expect( replace ).toHaveBeenCalledWith( '/reader/mastodon/7/tag/rust?tab=media' );
+		expect( analytics.recordReaderTracksEvent ).toHaveBeenCalledWith(
+			'calypso_reader_mastodon_tag_filter_changed',
+			{
+				connection_id: 7,
+				hashtag: 'rust',
+				from_filter: 'all',
+				to_filter: 'media',
+			}
+		);
+	} );
+
+	it( 'clicking the already-active tab is a no-op', async () => {
+		const user = userEvent.setup();
+		renderTabs( { activeFilter: 'all' } );
+
+		await user.click( screen.getByRole( 'menuitem', { name: 'All' } ) );
+
+		expect( replace ).not.toHaveBeenCalled();
+		expect( analytics.recordReaderTracksEvent ).not.toHaveBeenCalled();
+	} );
+
+	it( 'percent-encodes the hashtag in tab paths', () => {
+		renderTabs( { hashtag: 'foo bar' } );
+		expect( screen.getByRole( 'menuitem', { name: 'All' } ) ).toHaveAttribute(
+			'href',
+			'/reader/mastodon/7/tag/foo%20bar?tab=all'
+		);
+	} );
+} );

--- a/client/reader/mastodon/test/tag-feed-view.test.tsx
+++ b/client/reader/mastodon/test/tag-feed-view.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient } from '@tanstack/react-query';
+import { screen, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { MastodonTagFeedView } from '../tag-feed-view';
+import type React from 'react';
+
+jest.mock(
+	'calypso/reader/components/reader-main',
+	() =>
+		function ReaderMain( { children }: { children: React.ReactNode } ) {
+			return <div>{ children }</div>;
+		}
+);
+
+jest.mock( 'calypso/components/data/document-head', () => () => null );
+
+jest.mock( '@automattic/calypso-router', () => {
+	const replace = jest.fn();
+	const fn = jest.fn() as jest.Mock & { replace: jest.Mock };
+	fn.replace = replace;
+	return { __esModule: true, default: fn };
+} );
+
+beforeAll( () => {
+	global.IntersectionObserver = class IntersectionObserver {
+		observe() {}
+		unobserve() {}
+		disconnect() {}
+	} as unknown as typeof global.IntersectionObserver;
+} );
+
+afterAll( () => {
+	// @ts-expect-error -- cleaning up the stub
+	delete global.IntersectionObserver;
+} );
+
+const BASE = 'https://public-api.wordpress.com';
+
+afterEach( () => nock.cleanAll() );
+
+describe( 'MastodonTagFeedView', () => {
+	it( 'renders the panel once the connection resolves', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/mastodon/connections' )
+			.reply( 200, {
+				connections: [
+					{
+						id: 7,
+						handle: '@me@mastodon.social',
+						instance: 'mastodon.social',
+						display_name: 'Me',
+						avatar: null,
+					},
+				],
+			} );
+		nock( BASE )
+			.get( '/wpcom/v2/reader/mastodon/connections/7/tag/rust/feed' )
+			.reply( 200, { items: [], cursor: null } );
+
+		const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+		renderWithProvider( <MastodonTagFeedView connectionId={ 7 } hashtag="rust" />, {
+			queryClient,
+		} );
+		await waitFor( () => expect( screen.getByRole( 'heading', { name: '#rust' } ) ).toBeVisible() );
+	} );
+} );

--- a/client/reader/mastodon/thread-panel.tsx
+++ b/client/reader/mastodon/thread-panel.tsx
@@ -11,7 +11,7 @@ import {
 	mapMastodonThreadResponseToSocialThreadNode,
 } from 'calypso/reader/social';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
-import { getProfileUrl, getThreadUrl as buildThreadUrl } from './route';
+import { getProfileUrl, getTagFeedUrl, getThreadUrl as buildThreadUrl } from './route';
 import { ThreadHeader } from './thread-header';
 import { MastodonThreadTree } from './thread-tree';
 import { MastodonThreadTreeSkeleton } from './thread-tree/thread-tree-skeleton';
@@ -123,6 +123,11 @@ export function ThreadPanel( { connection, statusId }: ThreadPanelProps ) {
 		[ connection.id, connection.instance ]
 	);
 
+	const buildTagUrl = useCallback(
+		( tag: string ) => getTagFeedUrl( connection.id, tag ),
+		[ connection.id ]
+	);
+
 	const analyticsValue = useMemo(
 		() => ( {
 			source: 'mastodon' as const,
@@ -130,8 +135,9 @@ export function ThreadPanel( { connection, statusId }: ThreadPanelProps ) {
 			onClick: onClickAnalytics,
 			getThreadUrl,
 			getProfileUrl: buildProfileUrl,
+			getTagUrl: buildTagUrl,
 		} ),
-		[ connection.id, onClickAnalytics, getThreadUrl, buildProfileUrl ]
+		[ connection.id, onClickAnalytics, getThreadUrl, buildProfileUrl, buildTagUrl ]
 	);
 
 	return (

--- a/client/reader/mastodon/timeline-panel.tsx
+++ b/client/reader/mastodon/timeline-panel.tsx
@@ -12,7 +12,7 @@ import {
 } from 'calypso/reader/social';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import { projectMastodonError } from './error-projection';
-import { getProfileUrl, getThreadUrl as buildThreadUrl } from './route';
+import { getProfileUrl, getTagFeedUrl, getThreadUrl as buildThreadUrl } from './route';
 import type { MastodonConnection, MastodonFeedItem } from '@automattic/api-core';
 import type { SocialPost } from 'calypso/reader/social';
 import type { AppState } from 'calypso/types';
@@ -107,6 +107,11 @@ export function TimelinePanel( { connection }: TimelinePanelProps ) {
 		[ connection.id, connection.instance ]
 	);
 
+	const buildTagUrl = useCallback(
+		( tag: string ) => getTagFeedUrl( connection.id, tag ),
+		[ connection.id ]
+	);
+
 	const renderItem = useCallback(
 		( post: SocialPost ) => <SocialPostCard post={ post } variant="default" />,
 		[]
@@ -120,8 +125,9 @@ export function TimelinePanel( { connection }: TimelinePanelProps ) {
 			onClick: onClickAnalytics,
 			getThreadUrl,
 			getProfileUrl: buildProfileUrl,
+			getTagUrl: buildTagUrl,
 		} ),
-		[ connection.id, onClickAnalytics, getThreadUrl, buildProfileUrl ]
+		[ connection.id, onClickAnalytics, getThreadUrl, buildProfileUrl, buildTagUrl ]
 	);
 
 	return (

--- a/client/reader/social/author-profile-panel.tsx
+++ b/client/reader/social/author-profile-panel.tsx
@@ -91,6 +91,10 @@ export interface SocialAuthorProfilePanelProps<
 		handle?: string | null;
 	} ) => string | null;
 	buildThreadUrl: ( postUri: string ) => string | null;
+	// Slice-8 hashtag resolver. Optional: protocols without a hashtag
+	// concept (atmosphere) leave it unset and `<PostCardBody>` falls
+	// back to the anchor's external href.
+	buildTagUrl?: ( tag: string ) => string | null;
 
 	// Empty / error vocabulary for the SocialFeedList. Wrappers compute
 	// these (e.g. Mastodon swaps in a locked-account variant when the
@@ -135,6 +139,7 @@ export function SocialAuthorProfilePanel< TProfile, TError extends ProtocolError
 	projectFeedError,
 	buildProfileUrl,
 	buildThreadUrl,
+	buildTagUrl,
 	emptyTitle,
 	emptyLine,
 	emptyActionLabel,
@@ -299,8 +304,9 @@ export function SocialAuthorProfilePanel< TProfile, TError extends ProtocolError
 			onClick: onClickAnalytics,
 			getThreadUrl: buildThreadUrl,
 			getProfileUrl: buildProfileUrl,
+			getTagUrl: buildTagUrl,
 		} ),
-		[ source, connectionId, onClickAnalytics, buildThreadUrl, buildProfileUrl ]
+		[ source, connectionId, onClickAnalytics, buildThreadUrl, buildProfileUrl, buildTagUrl ]
 	);
 
 	const renderHeader = () => {

--- a/client/reader/social/components/post-card/analytics-context.tsx
+++ b/client/reader/social/components/post-card/analytics-context.tsx
@@ -30,6 +30,13 @@ export interface SocialAnalyticsContextValue {
 	getThreadUrl?: ( postUri: string ) => string | null;
 	/** Slice 6: resolve an author ref to an in-app profile URL, or null to fall back. */
 	getProfileUrl?: ( ref: SocialProfileRefInput ) => string | null;
+	/**
+	 * Slice 8: in-app hashtag-feed URL for a tag, or null to fall back.
+	 * Mastodon panels bind this; protocols without a hashtag concept
+	 * (atmosphere) leave it unset and `<PostCardBody>` falls back to the
+	 * anchor's external href.
+	 */
+	getTagUrl?: ( tag: string ) => string | null;
 }
 
 const Ctx = createContext< SocialAnalyticsContextValue | null >( null );

--- a/client/reader/social/components/post-card/post-card-body.tsx
+++ b/client/reader/social/components/post-card/post-card-body.tsx
@@ -41,30 +41,51 @@ export function PostCardBody( { post }: PostCardBodyProps ) {
 			return;
 		}
 		const dataId = anchor.getAttribute( 'data-id' );
-		if ( ! dataId ) {
+		if ( dataId ) {
+			const inAppUrl = analytics?.getProfileUrl?.( { id: dataId, did: dataId } ) ?? null;
+			if ( inAppUrl ) {
+				event.preventDefault();
+				page( inAppUrl );
+				return;
+			}
+			// data-id present but resolver returned null — likely a backend ↔
+			// frontend desync (validator rejected an id shape we didn't anticipate,
+			// or the protocol shell forgot to bind getProfileUrl). Surface so it's
+			// observable instead of silently routing to the external host with no
+			// analytics signal.
+			// eslint-disable-next-line no-console
+			console.warn( '[reader-social] data-id mention anchor not resolved to in-app URL', {
+				dataId,
+				href: anchor.getAttribute( 'href' ),
+				source: analytics?.source,
+			} );
+			analytics?.onClick( `calypso_reader_${ analytics.source }_timeline_mention_unresolved`, {
+				connection_id: analytics.connectionId,
+				data_id: dataId,
+			} );
 			return;
 		}
-		const inAppUrl = analytics?.getProfileUrl?.( { id: dataId, did: dataId } ) ?? null;
-		if ( inAppUrl ) {
-			event.preventDefault();
-			page( inAppUrl );
-			return;
+		const dataTag = anchor.getAttribute( 'data-tag' );
+		if ( dataTag ) {
+			const inAppTagUrl = analytics?.getTagUrl?.( dataTag ) ?? null;
+			if ( inAppTagUrl ) {
+				event.preventDefault();
+				page( inAppTagUrl );
+				return;
+			}
+			// data-tag present but resolver returned null — backend ↔ frontend desync.
+			// Same observability pattern as the data-id miss path.
+			// eslint-disable-next-line no-console
+			console.warn( '[reader-social] data-tag anchor not resolved to in-app URL', {
+				dataTag,
+				href: anchor.getAttribute( 'href' ),
+				source: analytics?.source,
+			} );
+			analytics?.onClick( `calypso_reader_${ analytics.source }_timeline_tag_unresolved`, {
+				connection_id: analytics.connectionId,
+				data_tag: dataTag,
+			} );
 		}
-		// data-id present but resolver returned null — likely a backend ↔
-		// frontend desync (validator rejected an id shape we didn't anticipate,
-		// or the protocol shell forgot to bind getProfileUrl). Surface so it's
-		// observable instead of silently routing to the external host with no
-		// analytics signal.
-		// eslint-disable-next-line no-console
-		console.warn( '[reader-social] data-id mention anchor not resolved to in-app URL', {
-			dataId,
-			href: anchor.getAttribute( 'href' ),
-			source: analytics?.source,
-		} );
-		analytics?.onClick( `calypso_reader_${ analytics.source }_timeline_mention_unresolved`, {
-			connection_id: analytics.connectionId,
-			data_id: dataId,
-		} );
 	};
 
 	// onClick on the wrapper div is event delegation onto the real <a>

--- a/client/reader/social/components/post-card/sanitize-post-html.ts
+++ b/client/reader/social/components/post-card/sanitize-post-html.ts
@@ -6,7 +6,7 @@ const CONFIG = {
 	// atmosphere, numeric account id for Mastodon) on @-mention anchors,
 	// emitted by the backend so the client can route mentions in-app
 	// without parsing the href.
-	ALLOWED_ATTR: [ 'href', 'rel', 'target', 'data-id' ],
+	ALLOWED_ATTR: [ 'href', 'rel', 'target', 'data-id', 'data-tag' ],
 	// DOMPurify allows every data-* attribute by default; restrict to the
 	// explicit allow-list above so a future backend change can't smuggle
 	// a new data-* attribute (e.g. `data-tracking`) through to the DOM.

--- a/client/reader/social/components/post-card/test/post-card-body.test.tsx
+++ b/client/reader/social/components/post-card/test/post-card-body.test.tsx
@@ -35,6 +35,8 @@ function baseHtml( html: string ): SocialPost {
 	};
 }
 
+const onClick = jest.fn();
+
 describe( 'PostCardBody', () => {
 	it( 'renders the sanitised html via DOMPurify', () => {
 		const { container } = render(
@@ -51,8 +53,6 @@ describe( 'PostCardBody', () => {
 	} );
 
 	describe( 'data-id mention interception', () => {
-		const onClick = jest.fn();
-
 		function renderWithAnalytics(
 			html: string,
 			getProfileUrl: ( ref: { id?: string | null } ) => string | null
@@ -129,6 +129,77 @@ describe( 'PostCardBody', () => {
 			await user.click( getByText( '@alice' ) );
 			await user.keyboard( '[/MetaLeft]' );
 			expect( pageMock ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'data-tag hashtag interception', () => {
+		beforeEach( () => {
+			pageMock.mockClear();
+			onClick.mockClear();
+		} );
+
+		function renderWithGetTagUrl( html: string, getTagUrl: ( tag: string ) => string | null ) {
+			return render(
+				<SocialAnalyticsProvider
+					value={ { source: 'mastodon', connectionId: 7, onClick, getTagUrl } }
+				>
+					<PostCardBody post={ baseHtml( html ) } />
+				</SocialAnalyticsProvider>
+			);
+		}
+
+		it( 'routes the click in-app when data-tag resolves', async () => {
+			const user = userEvent.setup();
+			const getTagUrl = jest.fn( ( tag ) => `/reader/mastodon/7/tag/${ tag }` );
+			const { getByText } = renderWithGetTagUrl(
+				'<p><a href="https://mastodon.social/tags/rust" data-tag="rust">#rust</a></p>',
+				getTagUrl
+			);
+			await user.click( getByText( '#rust' ) );
+			expect( pageMock ).toHaveBeenCalledWith( '/reader/mastodon/7/tag/rust' );
+		} );
+
+		it( 'fires *_timeline_tag_unresolved Tracks when resolver returns null', async () => {
+			const user = userEvent.setup();
+			const getTagUrl = jest.fn( () => null );
+			const { getByText } = renderWithGetTagUrl(
+				'<p><a href="https://mastodon.social/tags/x" data-tag="bogus">#x</a></p>',
+				getTagUrl
+			);
+			await user.click( getByText( '#x' ) );
+			expect( pageMock ).not.toHaveBeenCalled();
+			expect( onClick ).toHaveBeenCalledWith(
+				'calypso_reader_mastodon_timeline_tag_unresolved',
+				expect.objectContaining( { connection_id: 7, data_tag: 'bogus' } )
+			);
+		} );
+
+		it( 'data-id takes precedence when both attributes are on the same anchor', async () => {
+			const user = userEvent.setup();
+			const getProfileUrl = jest.fn( ( ref ) =>
+				ref.id ? `/reader/mastodon/7/profile/${ ref.id }` : null
+			);
+			const getTagUrl = jest.fn( () => '/reader/mastodon/7/tag/wrong' );
+			const { getByText } = render(
+				<SocialAnalyticsProvider
+					value={ {
+						source: 'mastodon',
+						connectionId: 7,
+						onClick,
+						getProfileUrl,
+						getTagUrl,
+					} }
+				>
+					<PostCardBody
+						post={ baseHtml(
+							'<p><a href="https://mastodon.social/@alice" data-id="108020" data-tag="rust">@alice</a></p>'
+						) }
+					/>
+				</SocialAnalyticsProvider>
+			);
+			await user.click( getByText( '@alice' ) );
+			expect( pageMock ).toHaveBeenCalledWith( '/reader/mastodon/7/profile/108020' );
+			expect( getTagUrl ).not.toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/client/reader/social/components/post-card/test/sanitize-post-html.test.ts
+++ b/client/reader/social/components/post-card/test/sanitize-post-html.test.ts
@@ -62,4 +62,10 @@ describe( 'sanitizePostHtml', () => {
 		expect( out ).not.toContain( 'data-evil' );
 		expect( out ).not.toContain( 'data-tracking' );
 	} );
+
+	it( 'preserves data-tag on hashtag anchors', () => {
+		const html = '<p><a href="https://mastodon.social/tags/rust" data-tag="rust">#rust</a></p>';
+		const out = sanitizePostHtml( html );
+		expect( out ).toContain( 'data-tag="rust"' );
+	} );
 } );

--- a/client/reader/stats/index.ts
+++ b/client/reader/stats/index.ts
@@ -120,6 +120,7 @@ const Routes: RoutesMapping[] = [
 	{ route: matches( /^\/reader\/mastodon\/\d+\/timeline$/ ), tracking: 'mastodon_timeline' },
 	{ route: matches( /^\/reader\/mastodon\/\d+\/profile$/ ), tracking: 'mastodon_profile' },
 	{ route: matches( /^\/reader\/mastodon\/\d+\/settings$/ ), tracking: 'mastodon_settings' },
+	{ route: matches( /^\/reader\/mastodon\/\d+\/tag\/[^/]+$/ ), tracking: 'mastodon_tag_feed' },
 	{ route: exactMatch( '/reader/mastodon' ), tracking: 'mastodon_landing' },
 
 	{ route: SinglePostRoute, tracking: 'single_post' },

--- a/client/reader/stats/test/index.test.ts
+++ b/client/reader/stats/test/index.test.ts
@@ -728,6 +728,11 @@ describe( 'reader stats', () => {
 					expected: 'mastodon_settings',
 					description: 'mastodon settings for a specific connection',
 				},
+				{
+					url: '/reader/mastodon/7/tag/rust',
+					expected: 'mastodon_tag_feed',
+					description: 'mastodon tag feed for a specific connection',
+				},
 			] as const;
 
 			scenarios.map( ( scenario ) => {

--- a/client/sections.js
+++ b/client/sections.js
@@ -539,6 +539,7 @@ const sections = [
 			'/reader/mastodon/:id/:tab',
 			'/reader/mastodon/:id/thread/:status_id',
 			'/reader/mastodon/:id/profile/:actor',
+			'/reader/mastodon/:id/tag/:hashtag',
 		],
 		module: 'calypso/reader/mastodon',
 		group: 'reader',

--- a/packages/api-core/src/reader-mastodon/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/reader-mastodon/__tests__/fetchers.test.ts
@@ -6,6 +6,7 @@ import {
 	getMastodonAuthorProfile,
 	getMastodonConnection,
 	getMastodonConnections,
+	getMastodonTagFeed,
 	getMastodonTimeline,
 } from '../fetchers';
 
@@ -250,5 +251,61 @@ describe( 'getMastodonAuthorFeed filter mapping', () => {
 			filter: 'posts_with_replies',
 		} );
 		expect( scope.isDone() ).toBe( true );
+	} );
+} );
+
+describe( 'getMastodonTagFeed', () => {
+	afterEach( () => nock.cleanAll() );
+
+	it( 'GETs /reader/mastodon/connections/:id/tag/<hashtag>/feed', async () => {
+		const scope = nock( BASE )
+			.get( '/wpcom/v2/reader/mastodon/connections/7/tag/rust/feed' )
+			.reply( 200, { items: [], cursor: null } );
+		const page = await getMastodonTagFeed( { connectionId: 7, hashtag: 'rust' } );
+		expect( page.cursor ).toBeNull();
+		expect( scope.isDone() ).toBe( true );
+	} );
+
+	it( 'sends only_media=true for filter=media', async () => {
+		const scope = nock( BASE )
+			.get( '/wpcom/v2/reader/mastodon/connections/7/tag/rust/feed' )
+			.query( { only_media: 'true' } )
+			.reply( 200, { items: [], cursor: null } );
+		await getMastodonTagFeed( { connectionId: 7, hashtag: 'rust', filter: 'media' } );
+		expect( scope.isDone() ).toBe( true );
+	} );
+
+	it( 'sends local=true for filter=local', async () => {
+		const scope = nock( BASE )
+			.get( '/wpcom/v2/reader/mastodon/connections/7/tag/rust/feed' )
+			.query( { local: 'true' } )
+			.reply( 200, { items: [], cursor: null } );
+		await getMastodonTagFeed( { connectionId: 7, hashtag: 'rust', filter: 'local' } );
+		expect( scope.isDone() ).toBe( true );
+	} );
+
+	it( 'sends no filter params for filter=all', async () => {
+		const scope = nock( BASE )
+			.get( '/wpcom/v2/reader/mastodon/connections/7/tag/rust/feed' )
+			.reply( 200, { items: [], cursor: null } );
+		await getMastodonTagFeed( { connectionId: 7, hashtag: 'rust', filter: 'all' } );
+		expect( scope.isDone() ).toBe( true );
+	} );
+
+	it( 'percent-encodes the hashtag in the path', async () => {
+		const scope = nock( BASE )
+			.get( '/wpcom/v2/reader/mastodon/connections/7/tag/rust_lang/feed' )
+			.reply( 200, { items: [], cursor: null } );
+		await getMastodonTagFeed( { connectionId: 7, hashtag: 'rust_lang' } );
+		expect( scope.isDone() ).toBe( true );
+	} );
+
+	it( 'classifies a 401 as auth_required', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/mastodon/connections/7/tag/rust/feed' )
+			.reply( 401, { error: 'not_authenticated', message: '', statusCode: 401, status: 401 } );
+		await expect(
+			getMastodonTagFeed( { connectionId: 7, hashtag: 'rust' } )
+		).rejects.toMatchObject( { kind: 'auth_required' } );
 	} );
 } );

--- a/packages/api-core/src/reader-mastodon/__tests__/query-keys.test.ts
+++ b/packages/api-core/src/reader-mastodon/__tests__/query-keys.test.ts
@@ -57,3 +57,26 @@ describe( 'readerMastodonKeys.authorFeed filter dimension', () => {
 		] );
 	} );
 } );
+
+describe( 'readerMastodonKeys.tagFeed', () => {
+	it( 'keys by connection id and hashtag (no filter slot)', () => {
+		expect( readerMastodonKeys.tagFeed( 7, 'rust' ) ).toEqual( [
+			'reader',
+			'mastodon',
+			'tag-feed',
+			7,
+			'rust',
+		] );
+	} );
+
+	it( 'appends the filter when set', () => {
+		expect( readerMastodonKeys.tagFeed( 7, 'rust', 'media' ) ).toEqual( [
+			'reader',
+			'mastodon',
+			'tag-feed',
+			7,
+			'rust',
+			'media',
+		] );
+	} );
+} );

--- a/packages/api-core/src/reader-mastodon/__tests__/types.test.ts
+++ b/packages/api-core/src/reader-mastodon/__tests__/types.test.ts
@@ -8,6 +8,9 @@ import type {
 	MastodonCreateConnectionResponse,
 	MastodonFeedItem,
 	MastodonProfileCounts,
+	MastodonTagFilter,
+	MastodonTagInfo,
+	MastodonTagFeedPage,
 } from '../types';
 
 describe( 'reader-mastodon types compile', () => {
@@ -84,5 +87,24 @@ describe( 'MastodonAuthorFeedFilter', () => {
 			'posts_with_replies',
 			'posts_with_media',
 		] );
+	} );
+} );
+
+describe( 'MastodonTagFilter', () => {
+	it( 'accepts the three UI tab values', () => {
+		const a: MastodonTagFilter = 'all';
+		const b: MastodonTagFilter = 'media';
+		const c: MastodonTagFilter = 'local';
+		expect( [ a, b, c ] ).toEqual( [ 'all', 'media', 'local' ] );
+	} );
+} );
+
+describe( 'MastodonTagFeedPage', () => {
+	it( 'has items + cursor + optional tag info', () => {
+		const tag: MastodonTagInfo = { name: 'rust', count: 42 };
+		const page: MastodonTagFeedPage = { items: [], cursor: null, tag };
+		expect( page.tag?.name ).toBe( 'rust' );
+		const minimal: MastodonTagFeedPage = { items: [], cursor: null };
+		expect( minimal.tag ).toBeUndefined();
 	} );
 } );

--- a/packages/api-core/src/reader-mastodon/fetchers.ts
+++ b/packages/api-core/src/reader-mastodon/fetchers.ts
@@ -8,6 +8,8 @@ import type {
 	MastodonConnectionDetails,
 	MastodonConnectionsResponse,
 	MastodonCreateConnectionResponse,
+	MastodonTagFilter,
+	MastodonTagFeedPage,
 	MastodonThreadResponse,
 	MastodonTimelinePage,
 } from './types';
@@ -187,6 +189,50 @@ export async function getMastodonAuthorFeed(
 			},
 			query
 		) ) as MastodonAuthorFeedPage;
+	} catch ( raw ) {
+		throw classifyMastodonError( raw );
+	}
+}
+
+export interface GetMastodonTagFeedParams {
+	connectionId: number;
+	hashtag: string;
+	cursor?: string;
+	limit?: number;
+	filter?: MastodonTagFilter;
+}
+
+export async function getMastodonTagFeed(
+	params: GetMastodonTagFeedParams
+): Promise< MastodonTagFeedPage > {
+	const { connectionId, hashtag, cursor, limit, filter } = params;
+	const query: Record< string, string > = {};
+	if ( cursor ) {
+		query.cursor = cursor;
+	}
+	if ( limit ) {
+		query.limit = String( limit );
+	}
+	// Mastodon's `/api/v1/timelines/tag/:hashtag` exposes `only_media` and
+	// `local` as independent boolean params. `all` and undefined send neither.
+	if ( filter === 'media' ) {
+		query.only_media = 'true';
+	} else if ( filter === 'local' ) {
+		query.local = 'true';
+	}
+	try {
+		return ( await wpcom.req.get(
+			{
+				// Encode `hashtag` defensively; HASHTAG_RE-validated values
+				// contain no chars that need escaping today, but encoding
+				// keeps the request path safe if the validator widens later.
+				path: `/reader/mastodon/connections/${ connectionId }/tag/${ encodeURIComponent(
+					hashtag
+				) }/feed`,
+				apiNamespace: NAMESPACE,
+			},
+			query
+		) ) as MastodonTagFeedPage;
 	} catch ( raw ) {
 		throw classifyMastodonError( raw );
 	}

--- a/packages/api-core/src/reader-mastodon/query-keys.ts
+++ b/packages/api-core/src/reader-mastodon/query-keys.ts
@@ -16,4 +16,11 @@ export const readerMastodonKeys = {
 		filter === undefined
 			? ( [ ...readerMastodonKeys.all, 'profile-feed', connectionId, actor ] as const )
 			: ( [ ...readerMastodonKeys.all, 'profile-feed', connectionId, actor, filter ] as const ),
+	// Tag feeds are keyed by connection + hashtag. `filter` appended only when
+	// set so the no-filter cache key has a stable shape; wrappers collapse the
+	// no-op `all` filter to undefined before keying so equivalent calls dedupe.
+	tagFeed: ( connectionId: number, hashtag: string, filter?: string ) =>
+		filter === undefined
+			? ( [ ...readerMastodonKeys.all, 'tag-feed', connectionId, hashtag ] as const )
+			: ( [ ...readerMastodonKeys.all, 'tag-feed', connectionId, hashtag, filter ] as const ),
 };

--- a/packages/api-core/src/reader-mastodon/types.ts
+++ b/packages/api-core/src/reader-mastodon/types.ts
@@ -162,3 +162,23 @@ export type MastodonAuthorFeedFilter =
 	| 'posts_no_replies'
 	| 'posts_with_replies'
 	| 'posts_with_media';
+
+// Filter values that map to Mastodon's GET /api/v1/timelines/tag/:hashtag
+// query params. Values mirror the UI tab slugs 1:1 so the slug ↔ filter
+// map at the tabs layer is identity beyond the case of `all`.
+export type MastodonTagFilter = 'all' | 'media' | 'local';
+
+// Optional metadata embedded in the feed response. The backend MAY include
+// nothing today; render hashtag name as a plain header and only show
+// `count` when set.
+export interface MastodonTagInfo {
+	name: string;
+	count?: number;
+	url?: string;
+}
+
+export interface MastodonTagFeedPage {
+	items: MastodonFeedItem[];
+	cursor: string | null;
+	tag?: MastodonTagInfo;
+}

--- a/packages/api-core/src/reader-mastodon/types.ts
+++ b/packages/api-core/src/reader-mastodon/types.ts
@@ -173,7 +173,14 @@ export type MastodonTagFilter = 'all' | 'media' | 'local';
 // `count` when set.
 export interface MastodonTagInfo {
 	name: string;
+	// Cumulative recent-post count from Mastodon's `history[]` aggregate
+	// when the backend chooses to project it. Render as a "N posts" line
+	// under the hashtag header; omit the line entirely when undefined.
 	count?: number;
+	// Home-instance Mastodon tag-page URL (e.g.
+	// `https://mastodon.social/tags/rust`). Provided so we can offer an
+	// external "View on Mastodon" link for users who want the home-instance
+	// view.
 	url?: string;
 }
 

--- a/packages/api-queries/src/__tests__/reader-mastodon.test.tsx
+++ b/packages/api-queries/src/__tests__/reader-mastodon.test.tsx
@@ -9,6 +9,7 @@ import {
 	useMastodonAuthorProfileQuery,
 	useMastodonConnectionQuery,
 	useMastodonConnectionsQuery,
+	useMastodonTagFeedInfiniteQuery,
 	useMastodonTimelineInfiniteQuery,
 } from '../reader-mastodon';
 
@@ -291,6 +292,42 @@ describe( 'useMastodonAuthorFeedInfiniteQuery filter', () => {
 			() => useMastodonAuthorFeedInfiniteQuery( 7, '108020', 'posts_with_replies' ),
 			{ wrapper: createWrapper() }
 		);
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+	} );
+} );
+
+describe( 'useMastodonTagFeedInfiniteQuery', () => {
+	afterEach( () => nock.cleanAll() );
+
+	it( 'fetches the first page of a tag feed', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/mastodon/connections/7/tag/rust/feed' )
+			.reply( 200, { items: [], cursor: null } );
+		const { result } = renderHook( () => useMastodonTagFeedInfiniteQuery( 7, 'rust' ), {
+			wrapper: createWrapper(),
+		} );
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+	} );
+
+	it( 'forwards filter=media as only_media=true', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/mastodon/connections/7/tag/rust/feed' )
+			.query( { only_media: 'true' } )
+			.reply( 200, { items: [], cursor: null } );
+		const { result } = renderHook( () => useMastodonTagFeedInfiniteQuery( 7, 'rust', 'media' ), {
+			wrapper: createWrapper(),
+		} );
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+	} );
+
+	it( 'collapses filter=all to no-filter cache key', async () => {
+		// Same nock that the no-filter case would hit — keys must merge.
+		nock( BASE )
+			.get( '/wpcom/v2/reader/mastodon/connections/7/tag/rust/feed' )
+			.reply( 200, { items: [], cursor: null } );
+		const { result } = renderHook( () => useMastodonTagFeedInfiniteQuery( 7, 'rust', 'all' ), {
+			wrapper: createWrapper(),
+		} );
 		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
 	} );
 } );

--- a/packages/api-queries/src/reader-mastodon.ts
+++ b/packages/api-queries/src/reader-mastodon.ts
@@ -5,6 +5,7 @@ import {
 	getMastodonAuthorProfile,
 	getMastodonConnection,
 	getMastodonConnections,
+	getMastodonTagFeed,
 	getMastodonThread,
 	getMastodonTimeline,
 	readerMastodonKeys,
@@ -23,6 +24,7 @@ import type {
 	AuthorizeMastodonConnectionParams,
 	CompleteMastodonConnectionParams,
 	GetMastodonAuthorFeedParams,
+	GetMastodonTagFeedParams,
 	GetMastodonTimelineParams,
 	MastodonAuthorFeedFilter,
 	MastodonAuthorFeedPage,
@@ -32,6 +34,8 @@ import type {
 	MastodonConnectionsResponse,
 	MastodonCreateConnectionResponse,
 	MastodonError,
+	MastodonTagFilter,
+	MastodonTagFeedPage,
 	MastodonThreadResponse,
 	MastodonTimelinePage,
 } from '@automattic/api-core';
@@ -258,4 +262,56 @@ export function useMastodonAuthorFeedInfiniteQuery(
 	filter?: MastodonAuthorFeedFilter
 ) {
 	return useInfiniteQuery( mastodonAuthorFeedInfiniteQuery( connectionId, actor, filter ) );
+}
+
+export const mastodonTagFeedInfiniteQuery = (
+	connectionId: number,
+	hashtag: string,
+	filter?: MastodonTagFilter
+) => {
+	const canonicalHashtag = hashtag.trim().toLowerCase().replace( /^#/, '' );
+	// `all` is the wire default (no filter param); collapse to undefined so
+	// callers that pass it share one cache entry with no-filter callers.
+	const normalizedFilter: MastodonTagFilter | undefined = filter === 'all' ? undefined : filter;
+	return infiniteQueryOptions<
+		MastodonTagFeedPage,
+		MastodonError,
+		InfiniteData< MastodonTagFeedPage >,
+		QueryKey,
+		string | undefined
+	>( {
+		queryKey: readerMastodonKeys.tagFeed( connectionId, canonicalHashtag, normalizedFilter ),
+		queryFn: ( { pageParam } ) =>
+			getMastodonTagFeed( {
+				connectionId,
+				hashtag: canonicalHashtag,
+				cursor: pageParam,
+				filter: normalizedFilter,
+			} as GetMastodonTagFeedParams ),
+		initialPageParam: undefined,
+		getNextPageParam: ( lastPage ) => lastPage.cursor || undefined,
+		enabled: connectionId > 0 && canonicalHashtag.length > 0,
+		staleTime: 30_000,
+		gcTime: 5 * 60_000,
+		retry: ( failureCount, error ) => {
+			if ( error.kind === 'rate_limited' || error.kind === 'upstream_unavailable' ) {
+				return failureCount < 2;
+			}
+			return false;
+		},
+		retryDelay: ( _attempt, error ) => {
+			if ( error.kind === 'rate_limited' && error.retry_after !== undefined ) {
+				return Math.min( error.retry_after * 1000, 30_000 );
+			}
+			return 2_000;
+		},
+	} );
+};
+
+export function useMastodonTagFeedInfiniteQuery(
+	connectionId: number,
+	hashtag: string,
+	filter?: MastodonTagFilter
+) {
+	return useInfiniteQuery( mastodonTagFeedInfiniteQuery( connectionId, hashtag, filter ) );
 }


### PR DESCRIPTION
Part of CM-638

## Proposed Changes

* Add `/reader/mastodon/:id/tag/:hashtag` — an in-app hashtag-feed surface with All / Media / Local filter tabs (`?tab=`), reusing the shared `SocialFeedList`, `SocialPostCard`, and `SocialAuthorProfileTabs` primitives.
* Route `<a data-tag>` anchors in post bodies in-app via a new optional `getTagUrl` resolver on `SocialAnalyticsProvider`. `data-id` (mention) takes precedence over `data-tag` (hashtag) when both are present on the same anchor.
* Backend wire mapping: filter `media` → `only_media=true`, `local` → `local=true`, `all` → no params; cache key collapses `all` to undefined so default-filter callers share the no-filter cache entry.
* Defence-in-depth: extend the `<PostCardBody>` DOMPurify allow-list with `data-tag` (still `ALLOW_DATA_ATTR: false`).
* Bind `getTagUrl` on the existing Mastodon timeline / thread / author-profile analytics providers so hashtag clicks from those surfaces also route in-app. Optional `buildTagUrl?` prop on the shared `SocialAuthorProfilePanel` lets atmosphere remain unaffected (no hashtag concept on ATproto).
* Tracks events: `calypso_reader_mastodon_tag_feed_viewed`, `_tag_filter_changed`, `_tag_feed_error_shown`, `_tag_feed_retry_clicked`, `_tag_feed_back_to_timeline_clicked`, `_timeline_tag_unresolved` (resolver-miss observability).

## Why are these changes being made?

Slice 8 of the Mastodon Reader work. Hashtag links inside post bodies currently fall through to the home-instance Mastodon URL, breaking the in-app browsing experience. This adds a first-class hashtag-feed surface so users can stay in the Reader when they explore a topic, with the same filter affordances Mastodon's web UI offers (All / Media / Local).

## Testing Instructions

1. `yarn start`, sign in, connect a Mastodon account.
2. Navigate to `/reader/mastodon/<id>/tag/rust` directly. Header shows `#rust`, three tabs (All / Media / Local), feed renders.
3. Click each tab. URL updates with `?tab=`. Wire requests carry the right params (verify in DevTools): Media → `only_media=true`, Local → `local=true`, All → no extra params.
4. Refresh on `?tab=local`. Local stays selected.
5. Visit `/reader/mastodon/<id>/tag/rust?tab=garbage`. URL rewrites to `?tab=all`.
6. From the timeline, click a `#hashtag` link in a post body. Routes in-app to the tag feed (no new tab).
7. From the tag feed, click a `@mention` link. Routes in-app to the author profile (verifies `getProfileUrl` is also bound on the tag-feed analytics provider via the existing `data-id` branch).
8. Click "Back to Mastodon" in the tag-feed header. Returns to the timeline.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?