### PR TITLE
Help Center: add 'Browse guides' link to intro message and auto-send search re-submissions into open chat

### DIFF
--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -34,6 +34,9 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 	const isTestMode = isTestModeEnvironment();
 	const createZendeskConversation = useCreateZendeskConversation();
 	const [ searchParams, setSearchParams ] = useSearchParams();
+	const queryFromParam = searchParams.get( 'query' ) || '';
+	const chatIdFromParam = searchParams.get( 'chatId' );
+	const queryForBrowseGuides = chatIdFromParam ? '' : queryFromParam;
 	const navigate = useNavigate();
 	const isForwardingToZendesk =
 		searchParams.get( 'provider' ) === 'zendesk' && chat.provider !== 'zendesk';
@@ -143,7 +146,8 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 					<ChatMessage
 						message={ getOdieInitialMessage(
 							supportInteraction?.bot_slug || ODIE_DEFAULT_BOT_SLUG_LEGACY,
-							currentUser?.display_name
+							currentUser?.display_name,
+							queryForBrowseGuides
 						) }
 						key={ 0 }
 					/>

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -160,15 +160,9 @@ export const OdieSendMessageButton = () => {
 		if ( initialQuery && ! isProcessing && chat.status !== 'loading' ) {
 			setInputValue( initialQuery );
 			setInitialQuery( '' );
-			sendMessageHandler();
+			sendMessageHandler( initialQuery );
 		}
-	}, [
-		initialQuery,
-		sendMessageHandler,
-		isProcessing,
-		isDisabled,
-		chat.status,
-	] );
+	}, [ initialQuery, sendMessageHandler, isProcessing, isDisabled, chat.status ] );
 
 	return (
 		<>

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -160,16 +160,13 @@ export const OdieSendMessageButton = () => {
 		if ( initialQuery && ! isProcessing && chat.status !== 'loading' ) {
 			setInputValue( initialQuery );
 			setInitialQuery( '' );
-			if ( chat.messages.length === 0 ) {
-				sendMessageHandler();
-			}
+			sendMessageHandler();
 		}
 	}, [
 		initialQuery,
 		sendMessageHandler,
 		isProcessing,
 		isDisabled,
-		chat.messages.length,
 		chat.status,
 	] );
 

--- a/packages/odie-client/src/components/send-message-input/use-send-message-handler.ts
+++ b/packages/odie-client/src/components/send-message-input/use-send-message-handler.ts
@@ -26,79 +26,83 @@ export function useSendMessageHandler( {
 	trackEvent,
 	sendMessage,
 }: UseSendMessageHandlerProps ) {
-	return useCallback( async () => {
-		const message = inputValue.trim().substring( 0, MAX_MESSAGE_LENGTH );
+	return useCallback(
+		async ( messageOverride?: string ) => {
+			const effectiveValue = messageOverride !== undefined ? messageOverride : inputValue;
+			const message = effectiveValue.trim().substring( 0, MAX_MESSAGE_LENGTH );
 
-		// Allow submission if there's either a message or attachments
-		if ( ( message === '' && ! hasAttachments ) || isChatBusy ) {
-			return;
-		}
-
-		// Immediately clear the input field
-		if ( chat?.provider === 'odie' ) {
-			setInputValue( '' );
-		} else if ( chat.conversationId ) {
-			Smooch?.stopTyping?.();
-			sendAttachments();
-		}
-
-		if ( ! message ) {
-			textareaRef.current?.focus();
-			return;
-		}
-
-		try {
-			trackEvent( 'chat_message_action_send', {
-				message_length: inputValue.length,
-				provider: chat?.provider,
-			} );
-
-			const messageObj = {
-				content: inputValue,
-				role: 'user',
-				type: 'message',
-			} as Message;
-
-			if ( chat?.provider === 'zendesk' ) {
-				messageObj.metadata = {
-					temporary_id: crypto.randomUUID(),
-					local_timestamp: Date.now() / 1000,
-				};
+			// Allow submission if there's either a message or attachments
+			if ( ( message === '' && ! hasAttachments ) || isChatBusy ) {
+				return;
 			}
 
-			sendMessage( messageObj ).catch( ( error ) => {
-				if ( error?.type === 'abort' ) {
-					setInputValue( inputValue );
-				}
-			} );
-
-			// Clear input after zendesk messages are sent
-			if ( chat?.provider === 'zendesk' ) {
+			// Immediately clear the input field
+			if ( chat?.provider === 'odie' ) {
 				setInputValue( '' );
+			} else if ( chat.conversationId ) {
+				Smooch?.stopTyping?.();
+				sendAttachments();
 			}
 
-			trackEvent( 'chat_message_action_receive', {
-				message_length: inputValue.length,
-				provider: chat?.provider,
-			} );
-		} catch ( e ) {
-			const error = e as Error;
-			trackEvent( 'chat_message_error', {
-				error: error?.message,
-			} );
-		} finally {
-			textareaRef.current?.focus();
-		}
-	}, [
-		inputValue,
-		isChatBusy,
-		chat?.provider,
-		sendMessage,
-		trackEvent,
-		chat.conversationId,
-		sendAttachments,
-		hasAttachments,
-		setInputValue,
-		textareaRef,
-	] );
+			if ( ! message ) {
+				textareaRef.current?.focus();
+				return;
+			}
+
+			try {
+				trackEvent( 'chat_message_action_send', {
+					message_length: effectiveValue.length,
+					provider: chat?.provider,
+				} );
+
+				const messageObj = {
+					content: effectiveValue,
+					role: 'user',
+					type: 'message',
+				} as Message;
+
+				if ( chat?.provider === 'zendesk' ) {
+					messageObj.metadata = {
+						temporary_id: crypto.randomUUID(),
+						local_timestamp: Date.now() / 1000,
+					};
+				}
+
+				sendMessage( messageObj ).catch( ( error ) => {
+					if ( error?.type === 'abort' ) {
+						setInputValue( effectiveValue );
+					}
+				} );
+
+				// Clear input after zendesk messages are sent
+				if ( chat?.provider === 'zendesk' ) {
+					setInputValue( '' );
+				}
+
+				trackEvent( 'chat_message_action_receive', {
+					message_length: effectiveValue.length,
+					provider: chat?.provider,
+				} );
+			} catch ( e ) {
+				const error = e as Error;
+				trackEvent( 'chat_message_error', {
+					error: error?.message,
+				} );
+			} finally {
+				textareaRef.current?.focus();
+			}
+		},
+		[
+			inputValue,
+			isChatBusy,
+			chat?.provider,
+			sendMessage,
+			trackEvent,
+			chat.conversationId,
+			sendAttachments,
+			hasAttachments,
+			setInputValue,
+			textareaRef,
+		]
+	);
 }

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -254,6 +254,9 @@ export const getOdieInitialMessage = (
 		) }** \n\n ${ __(
 			"I'm your personal AI assistant. I can help with any questions about your site or account.",
 			__i18n_text_domain__
+		) } ${ __(
+			'Want to browse guides instead? [Browse guides](https://wordpress.com/support/guides/)',
+			__i18n_text_domain__
 		) }`,
 		role: 'bot',
 		type: 'introduction',

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -255,7 +255,7 @@ export const getOdieInitialMessage = (
 			"I'm your personal AI assistant. I can help with any questions about your site or account.",
 			__i18n_text_domain__
 		) } ${ __(
-			'Want to browse guides instead? [Browse guides](https://wordpress.com/support/guides/)',
+			'Want to browse guides instead? [Browse guides](https://wordpress.com/support?s=)',
 			__i18n_text_domain__
 		) }`,
 		role: 'bot',

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -1,3 +1,4 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { isTestModeEnvironment } from '@automattic/zendesk-client';
 import { __, sprintf } from '@wordpress/i18n';
 import type { Context, Message, OdieAllowedBots, OdieAllBotSlugs } from './types';
@@ -242,7 +243,8 @@ const getOdieInitialPromptContext = ( botNameSlug: OdieAllowedBots ): Context | 
 
 export const getOdieInitialMessage = (
 	botNameSlug: OdieAllowedBots,
-	displayName: string
+	displayName: string,
+	query?: string
 ): Message => {
 	return {
 		content: `**${ sprintf(
@@ -254,9 +256,10 @@ export const getOdieInitialMessage = (
 		) }** \n\n ${ __(
 			"I'm your personal AI assistant. I can help with any questions about your site or account.",
 			__i18n_text_domain__
-		) } ${ __(
-			'Want to browse guides instead? [Browse guides](https://wordpress.com/support?s=)',
-			__i18n_text_domain__
+		) } \n\n${ sprintf(
+			/* translators: %s: URL to the WordPress.com support search page */
+			__( 'Want to browse guides instead? [Browse guides](%s).', __i18n_text_domain__ ),
+			`${ localizeUrl( 'https://wordpress.com/support' ) }?s=${ encodeURIComponent( query || '' ) }`
 		) }`,
 		role: 'bot',
 		type: 'introduction',


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/DOTCOM-16695/ship-logged-out-ai-support-experience-to-100percent-of-users
## Proposed Changes
- Appends a "Want to browse guides instead? [Browse guides](https://wordpress.com/support?s=)" link to the Odie intro message shown when chat opens for logged-out users
- Removes the `chat.messages.length === 0` guard in `OdieSendMessageButton` so that re-submitting the "How can we help you?" search box while chat is already open sends the new query into the existing conversation, instead of silently doing nothing
## Why are these changes being made?
After shipping the logged-out AI support experience to 100% of users, two UX issues surfaced:
1. **No orientation on chat open.** When a user types in the search box and chat opens, there's no explanation of what happened or how to browse support guides manually instead of chatting.
2. **Search box re-submit does nothing.** When the chat is already open and the user types a new query in the search box and submits, nothing visible happens. The `query` URL param updates and the textarea gets filled silently, but the `chat.messages.length === 0` guard blocks the auto-send. Tracks data shows ~20% of sessions re-submit the search box, and the most common follow-up actions are closing the chat (37 sessions) or navigating away (45 sessions) — consistent with users giving up after getting no feedback.
The re-submit fix is shipped as a hypothesis: if users now stay and engage after their query is auto-sent, it confirms they intended to continue chatting. If close rates remain high, we'll revisit with a disambiguation UI.
## Testing Instructions
1. Open `wordpress.com/support` in a logged-out browser session
2. Type a query in the "How can we help you?" search box and submit
3. **Expected:** Chat opens showing `Howdy there 👋 … Want to browse guides instead? Browse guides`
4. Click "Browse guides" → should land on `wordpress.com/support?s=`
5. With chat already open, type a new query in the search box and submit
6. **Expected:** New query is sent into the existing conversation (previous messages remain visible)
7. Verify a fresh chat (no prior messages) still auto-sends the initial query correctly