### PR TITLE
Reader ATmosphere: in-app Bluesky tag-feed surface

### DIFF
--- a/client/reader/atmosphere/author-profile-panel.tsx
+++ b/client/reader/atmosphere/author-profile-panel.tsx
@@ -19,7 +19,7 @@ import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions'
 import { AuthorProfileTabs, useAuthorProfileFilter } from './author-profile-tabs';
 import { projectAtmosphereError } from './error-projection';
 import { errorMessage } from './profile-errors';
-import { getProfileUrl, getThreadUrl, getTimelineUrl } from './route';
+import { getProfileUrl, getTagFeedUrl, getThreadUrl, getTimelineUrl } from './route';
 import type {
 	AtmosphereAuthorFeedFilter,
 	AtmosphereAuthorProfile,
@@ -230,6 +230,11 @@ export function AuthorProfilePanel( { connection, actor }: AuthorProfilePanelPro
 		[ connection.id ]
 	);
 
+	const buildTagUrl = useCallback(
+		( tag: string ) => getTagFeedUrl( connection.id, tag ),
+		[ connection.id ]
+	);
+
 	const renderItem = useCallback(
 		( post: SocialPost ) => <SocialPostCard post={ post } variant="default" />,
 		[]
@@ -267,8 +272,9 @@ export function AuthorProfilePanel( { connection, actor }: AuthorProfilePanelPro
 			onClick: onClickAnalytics,
 			getThreadUrl: buildThreadUrl,
 			getProfileUrl: buildProfileUrl,
+			getTagUrl: buildTagUrl,
 		} ),
-		[ connection.id, onClickAnalytics, buildThreadUrl, buildProfileUrl ]
+		[ connection.id, onClickAnalytics, buildThreadUrl, buildProfileUrl, buildTagUrl ]
 	);
 
 	const renderHeaderError = ( error: AtmosphereError ) => {

--- a/client/reader/atmosphere/controller.tsx
+++ b/client/reader/atmosphere/controller.tsx
@@ -2,7 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import page, { type Context } from '@automattic/calypso-router';
 import AsyncLoad from 'calypso/components/async-load';
 import { TIMELINE_TAB } from './helper';
-import { DID_RE, HANDLE_RE, RKEY_RE } from './route';
+import { DID_RE, HANDLE_RE, RKEY_RE, isValidHashtag } from './route';
 
 const loadAtmosphereLandingView = () =>
 	import(
@@ -23,6 +23,10 @@ const loadAtmosphereThreadView = () =>
 const loadAuthorProfileView = () =>
 	import(
 		/* webpackChunkName: "async-load-calypso-reader-atmosphere-author-profile-view" */ 'calypso/reader/atmosphere/author-profile-view'
+	);
+const loadAtmosphereTagFeedView = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-atmosphere-tag-feed-view" */ 'calypso/reader/atmosphere/tag-feed-view'
 	);
 
 function ensureAtmosphereEnabled(): boolean {
@@ -129,6 +133,37 @@ export const atmosphereProfile = ( context: Context, next: () => void ) => {
 			placeholder={ null }
 			connectionId={ id }
 			actor={ actor }
+		/>
+	);
+	next();
+};
+
+export const atmosphereTagFeed = ( context: Context, next: () => void ) => {
+	if ( ! ensureAtmosphereEnabled() ) {
+		return;
+	}
+
+	const id = Number( context.params.id );
+	const hashtag = String( context.params.hashtag ?? '' )
+		.trim()
+		.toLowerCase()
+		.replace( /^#/, '' );
+
+	const idValid = Number.isFinite( id ) && id > 0;
+	const inputsValid = idValid && isValidHashtag( hashtag );
+
+	if ( ! inputsValid ) {
+		page.redirect( idValid ? `/reader/atmosphere/${ id }` : '/reader/atmosphere' );
+		return;
+	}
+
+	context.primary = (
+		<AsyncLoad
+			key="reader-atmosphere-tag-feed"
+			require={ loadAtmosphereTagFeedView }
+			placeholder={ null }
+			connectionId={ id }
+			hashtag={ hashtag }
 		/>
 	);
 	next();

--- a/client/reader/atmosphere/error-projection.ts
+++ b/client/reader/atmosphere/error-projection.ts
@@ -32,15 +32,24 @@ export function projectAtmosphereError(
 			return err.retry_after !== undefined
 				? { kind: 'rate_limited', retry_after: err.retry_after }
 				: { kind: 'rate_limited' };
-		case 'invalid_handle':
 		case 'bad_request':
+			// Surface the backend's validation message — collapsing to a generic
+			// "Something went wrong" copy hides actionable detail (e.g. "Hashtag
+			// too long" or "Invalid handle"). Mirrors the Mastodon projector.
+			return { kind: 'unknown', cause: err, message: err.message ?? undefined };
+		case 'invalid_handle':
 		case 'unknown':
 			return { kind: 'unknown', cause: err };
 		default:
-			return assertNever( err );
+			// Soft fallback: a future AtmosphereError variant landing in
+			// production before this switch is updated would otherwise crash
+			// the panel mid-render. Surface the gap to devtools and ship the
+			// generic copy. Mirrors the Mastodon projector.
+			// eslint-disable-next-line no-console
+			console.warn(
+				'[reader-atmosphere] unhandled AtmosphereError kind in projectAtmosphereError()',
+				err
+			);
+			return { kind: 'unknown', cause: err };
 	}
-}
-
-function assertNever( value: never ): never {
-	throw new Error( `Unhandled AtmosphereError kind: ${ JSON.stringify( value ) }` );
 }

--- a/client/reader/atmosphere/index.tsx
+++ b/client/reader/atmosphere/index.tsx
@@ -8,6 +8,7 @@ import {
 	atmosphereConnect,
 	atmosphereIdRedirect,
 	atmosphereProfile,
+	atmosphereTagFeed,
 	atmosphereThread,
 	atmosphereAccount,
 } from './controller';
@@ -43,6 +44,14 @@ export default function () {
 		sidebar,
 		setBeforePrimary,
 		atmosphereProfile,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/reader/atmosphere/:id(\\d+)/tag/:hashtag',
+		sidebar,
+		setBeforePrimary,
+		atmosphereTagFeed,
 		makeLayout,
 		clientRender
 	);

--- a/client/reader/atmosphere/route.ts
+++ b/client/reader/atmosphere/route.ts
@@ -64,3 +64,35 @@ export function getProfileUrl( connectionId: number, ref: ProfileRefInput ): str
 	}
 	return null;
 }
+
+// Bluesky hashtag canonical form: Unicode letters/numbers/marks/underscore,
+// 1-64 chars. The 64-char cap matches Bluesky's tag-length limit (64
+// graphemes — chars ≈ graphemes for the common case). Anchored,
+// single-line, lowercase-strict so the in-app route shape is canonical.
+//
+// The frontend regex mirrors the wpcom backend's hashtag validator —
+// keep them in sync. Tags that fail validation fall through to bsky.app
+// via the click-handler in post-card-body, so the regex is the safe-set
+// guarantee, not a strict spec match.
+export const HASHTAG_RE = /^[\p{L}\p{N}\p{M}_]{1,64}$/u;
+
+export function isValidHashtag( hashtag: string ): boolean {
+	return HASHTAG_RE.test( hashtag );
+}
+
+/**
+ * Build the in-app Bluesky tag-feed URL. Lowercases the input, strips a
+ * leading `#`, validates the canonical form, and percent-encodes the
+ * path segment. Returns `null` for any rejection so callers can fall
+ * back to the external bsky.app link.
+ */
+export function getTagFeedUrl( connectionId: number, hashtag: string ): string | null {
+	if ( ! Number.isFinite( connectionId ) || connectionId <= 0 ) {
+		return null;
+	}
+	const canonical = hashtag.trim().toLowerCase().replace( /^#/, '' );
+	if ( ! isValidHashtag( canonical ) ) {
+		return null;
+	}
+	return `/reader/atmosphere/${ connectionId }/tag/${ encodeURIComponent( canonical ) }`;
+}

--- a/client/reader/atmosphere/route.ts
+++ b/client/reader/atmosphere/route.ts
@@ -1,3 +1,5 @@
+import { isValidHashtag } from '@automattic/api-core';
+
 export const POST_NSID = 'app.bsky.feed.post';
 const DID_WEB_HOST = '[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)+';
 const DID_BODY = `(?:plc:[a-z2-7]{24}|web:${ DID_WEB_HOST })`;
@@ -65,20 +67,10 @@ export function getProfileUrl( connectionId: number, ref: ProfileRefInput ): str
 	return null;
 }
 
-// Bluesky hashtag canonical form: Unicode letters/numbers/marks/underscore,
-// 1-64 chars. The 64-char cap matches Bluesky's tag-length limit (64
-// graphemes — chars ≈ graphemes for the common case). Anchored,
-// single-line, lowercase-strict so the in-app route shape is canonical.
-//
-// The frontend regex mirrors the wpcom backend's hashtag validator —
-// keep them in sync. Tags that fail validation fall through to bsky.app
-// via the click-handler in post-card-body, so the regex is the safe-set
-// guarantee, not a strict spec match.
-export const HASHTAG_RE = /^[\p{L}\p{N}\p{M}_]{1,64}$/u;
-
-export function isValidHashtag( hashtag: string ): boolean {
-	return HASHTAG_RE.test( hashtag );
-}
+// Hashtag validator lives in @automattic/api-core so both the route layer
+// and the query factory in api-queries share a single regex — preventing
+// drift between the controller's validation and the query's `enabled` gate.
+export { HASHTAG_RE, isValidHashtag } from '@automattic/api-core';
 
 /**
  * Build the in-app Bluesky tag-feed URL. Lowercases the input, strips a

--- a/client/reader/atmosphere/tag-feed-panel.tsx
+++ b/client/reader/atmosphere/tag-feed-panel.tsx
@@ -1,5 +1,5 @@
 import { useAtmosphereTagFeedInfiniteQuery } from '@automattic/api-queries';
-import { ExternalLink, __experimentalVStack as VStack } from '@wordpress/components';
+import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useDispatch } from 'react-redux';
@@ -165,20 +165,6 @@ export function TagFeedPanel( { connection, hashtag }: Props ) {
 			  } )
 			: null;
 
-	// Defence-in-depth on a third-party-supplied URL: only honour https URLs.
-	// Anything else (javascript:, http://, malformed) falls through to no link
-	// rather than reaching the DOM as an anchor href.
-	const externalTagUrl = ( () => {
-		if ( ! tagInfo?.url ) {
-			return null;
-		}
-		try {
-			return new URL( tagInfo.url ).protocol === 'https:' ? tagInfo.url : null;
-		} catch {
-			return null;
-		}
-	} )();
-
 	return (
 		<SocialAnalyticsProvider value={ analyticsValue }>
 			<VStack spacing={ 4 } className="atmosphere-tag-feed">
@@ -189,11 +175,6 @@ export function TagFeedPanel( { connection, hashtag }: Props ) {
 				<div className="atmosphere-tag-feed__header">
 					<h1 className="atmosphere-tag-feed__heading">{ `#${ hashtag }` }</h1>
 					{ countLine ? <p className="atmosphere-tag-feed__count">{ countLine }</p> : null }
-					{ externalTagUrl ? (
-						<ExternalLink className="atmosphere-tag-feed__external-link" href={ externalTagUrl }>
-							{ translate( 'View on Bluesky' ) }
-						</ExternalLink>
-					) : null }
 				</div>
 				<SocialFeedList< SocialPost >
 					items={ items }

--- a/client/reader/atmosphere/tag-feed-panel.tsx
+++ b/client/reader/atmosphere/tag-feed-panel.tsx
@@ -37,9 +37,11 @@ export function TagFeedPanel( { connection, hashtag }: Props ) {
 
 	const feed = useAtmosphereTagFeedInfiniteQuery( connection.id, hashtag );
 
-	// Fire tag_feed_viewed exactly once per (connection, hashtag) — gated on
-	// resolved feed data so the payload reflects what the user actually saw
-	// on first load. Subsequent fetches (pagination) don't re-fire.
+	// Fire tag_feed_viewed once per mounted (connection, hashtag) pair —
+	// gated on resolved feed data so the payload reflects what the user
+	// actually saw on first load. Pagination doesn't re-fire; switching
+	// hashtags within the same mount does. Re-mounting (e.g., navigating
+	// away and back) re-fires intentionally — that's a fresh view.
 	const viewedFor = useRef< string | null >( null );
 	useEffect( () => {
 		const key = `${ connection.id }:${ hashtag }`;

--- a/client/reader/atmosphere/tag-feed-panel.tsx
+++ b/client/reader/atmosphere/tag-feed-panel.tsx
@@ -1,0 +1,215 @@
+import { useAtmosphereTagFeedInfiniteQuery } from '@automattic/api-queries';
+import { ExternalLink, __experimentalVStack as VStack } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useDispatch } from 'react-redux';
+import {
+	AuthorProfileHeader,
+	SocialAnalyticsProvider,
+	SocialFeedList,
+	SocialPostCard,
+	mapAtmosphereFeedItemToSocialPost,
+	type SocialPost,
+} from 'calypso/reader/social';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import { projectAtmosphereError } from './error-projection';
+import {
+	getProfileUrl as buildProfileUrl,
+	getTagFeedUrl,
+	getThreadUrl as buildThreadUrl,
+	getTimelineUrl,
+	type ProfileRefInput,
+} from './route';
+import type { AtmosphereConnection, AtmosphereFeedItem } from '@automattic/api-core';
+import type { AppState } from 'calypso/types';
+import type { UnknownAction } from 'redux';
+import type { ThunkDispatch } from 'redux-thunk';
+
+interface Props {
+	connection: AtmosphereConnection;
+	hashtag: string;
+}
+
+export function TagFeedPanel( { connection, hashtag }: Props ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch< ThunkDispatch< AppState, void, UnknownAction > >();
+	const lastErrorKind = useRef< string | null >( null );
+
+	const feed = useAtmosphereTagFeedInfiniteQuery( connection.id, hashtag );
+
+	// Fire tag_feed_viewed exactly once per (connection, hashtag) — gated on
+	// resolved feed data so the payload reflects what the user actually saw
+	// on first load. Subsequent fetches (pagination) don't re-fire.
+	const viewedFor = useRef< string | null >( null );
+	useEffect( () => {
+		const key = `${ connection.id }:${ hashtag }`;
+		if ( viewedFor.current === key || ! feed.data ) {
+			return;
+		}
+		viewedFor.current = key;
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_atmosphere_tag_feed_viewed', {
+				connection_id: connection.id,
+				hashtag,
+			} )
+		);
+	}, [ connection.id, hashtag, feed.data, dispatch ] );
+
+	useEffect( () => {
+		if ( feed.isError && feed.error && feed.error.kind !== lastErrorKind.current ) {
+			lastErrorKind.current = feed.error.kind;
+			dispatch(
+				recordReaderTracksEvent( 'calypso_reader_atmosphere_tag_feed_error_shown', {
+					connection_id: connection.id,
+					hashtag,
+					error_kind: feed.error.kind,
+				} )
+			);
+		}
+		if ( ! feed.isError ) {
+			lastErrorKind.current = null;
+		}
+	}, [ feed.isError, feed.error, connection.id, hashtag, dispatch ] );
+
+	const handleRetry = useCallback( () => {
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_atmosphere_tag_feed_retry_clicked', {
+				connection_id: connection.id,
+				hashtag,
+				error_kind: feed.error?.kind ?? 'unknown',
+			} )
+		);
+		feed.refetch();
+	}, [ connection.id, hashtag, feed, dispatch ] );
+
+	const handleBackToTimeline = useCallback( () => {
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_atmosphere_tag_feed_back_to_timeline_clicked', {
+				connection_id: connection.id,
+				hashtag,
+			} )
+		);
+	}, [ connection.id, hashtag, dispatch ] );
+
+	const onClickAnalytics = useCallback(
+		( event: string, props: Record< string, unknown > ) => {
+			// Subcomponents emit `calypso_reader_atmosphere_timeline_*`. Rewrite
+			// the surface to `_tag_feed_` so dashboards can split.
+			const TIMELINE_PREFIX = 'calypso_reader_atmosphere_timeline_';
+			const TAG_PREFIX = 'calypso_reader_atmosphere_tag_feed_';
+			const reprefixed = event.startsWith( TIMELINE_PREFIX )
+				? TAG_PREFIX + event.slice( TIMELINE_PREFIX.length )
+				: event;
+			dispatch( recordReaderTracksEvent( reprefixed, { ...props, hashtag } ) );
+		},
+		[ dispatch, hashtag ]
+	);
+
+	const getThreadUrl = useCallback(
+		( uri: string ) => buildThreadUrl( connection.id, uri ),
+		[ connection.id ]
+	);
+
+	const getProfileUrl = useCallback(
+		( ref: ProfileRefInput ) => buildProfileUrl( connection.id, ref ),
+		[ connection.id ]
+	);
+
+	const getTagUrl = useCallback(
+		( tag: string ) => getTagFeedUrl( connection.id, tag ),
+		[ connection.id ]
+	);
+
+	const items: SocialPost[] = useMemo( () => {
+		const seen = new Set< string >();
+		const deduped: AtmosphereFeedItem[] = [];
+		for ( const post of feed.data?.pages.flatMap( ( pageData ) => pageData.items ?? [] ) ?? [] ) {
+			if ( ! post?.uri || seen.has( post.uri ) ) {
+				continue;
+			}
+			seen.add( post.uri );
+			deduped.push( post );
+		}
+		return deduped.map( mapAtmosphereFeedItemToSocialPost );
+	}, [ feed.data ] );
+
+	const renderItem = useCallback(
+		( post: SocialPost ) => <SocialPostCard post={ post } variant="default" />,
+		[]
+	);
+	const itemKey = useCallback( ( post: SocialPost ) => post.uri, [] );
+
+	const analyticsValue = useMemo(
+		() => ( {
+			source: 'atmosphere' as const,
+			connectionId: connection.id,
+			onClick: onClickAnalytics,
+			getThreadUrl,
+			getProfileUrl,
+			getTagUrl,
+		} ),
+		[ connection.id, onClickAnalytics, getThreadUrl, getProfileUrl, getTagUrl ]
+	);
+
+	const tagInfo = feed.data?.pages[ 0 ]?.tag;
+	const countLine =
+		tagInfo?.count !== undefined
+			? translate( '%(count)d post', '%(count)d posts', {
+					count: tagInfo.count,
+					args: { count: tagInfo.count },
+			  } )
+			: null;
+
+	// Defence-in-depth on a third-party-supplied URL: only honour https URLs.
+	// Anything else (javascript:, http://, malformed) falls through to no link
+	// rather than reaching the DOM as an anchor href.
+	const externalTagUrl = ( () => {
+		if ( ! tagInfo?.url ) {
+			return null;
+		}
+		try {
+			return new URL( tagInfo.url ).protocol === 'https:' ? tagInfo.url : null;
+		} catch {
+			return null;
+		}
+	} )();
+
+	return (
+		<SocialAnalyticsProvider value={ analyticsValue }>
+			<VStack spacing={ 4 } className="atmosphere-tag-feed">
+				<AuthorProfileHeader
+					timelineUrl={ getTimelineUrl( connection.id ) }
+					onBackToTimeline={ handleBackToTimeline }
+				/>
+				<div className="atmosphere-tag-feed__header">
+					<h1 className="atmosphere-tag-feed__heading">{ `#${ hashtag }` }</h1>
+					{ countLine ? <p className="atmosphere-tag-feed__count">{ countLine }</p> : null }
+					{ externalTagUrl ? (
+						<ExternalLink className="atmosphere-tag-feed__external-link" href={ externalTagUrl }>
+							{ translate( 'View on Bluesky' ) }
+						</ExternalLink>
+					) : null }
+				</div>
+				<SocialFeedList< SocialPost >
+					items={ items }
+					isPending={ feed.isPending }
+					isError={ feed.isError }
+					error={ projectAtmosphereError( feed.error ) }
+					hasNextPage={ Boolean( feed.hasNextPage ) }
+					isFetchingNextPage={ feed.isFetchingNextPage }
+					fetchNextPage={ feed.fetchNextPage }
+					refetch={ handleRetry }
+					renderItem={ renderItem }
+					itemKey={ itemKey }
+					emptyTitle={ String(
+						translate( 'No posts found for #%(hashtag)s.', { args: { hashtag } } )
+					) }
+					emptyLine={ String( translate( 'Check back later.' ) ) }
+					protocolLabel="Bluesky"
+					protocolHomeURL="/reader/atmosphere"
+					protocolHomeLabel={ String( translate( 'Back to ATmosphere' ) ) }
+				/>
+			</VStack>
+		</SocialAnalyticsProvider>
+	);
+}

--- a/client/reader/atmosphere/tag-feed-panel.tsx
+++ b/client/reader/atmosphere/tag-feed-panel.tsx
@@ -154,8 +154,11 @@ export function TagFeedPanel( { connection, hashtag }: Props ) {
 	);
 
 	const tagInfo = feed.data?.pages[ 0 ]?.tag;
+	// Backend emits `count: null` when the AppView's `hitsTotal` is absent
+	// (see `tag-feed-page` normaliser); use a loose check so we hide the
+	// count line for both a missing field and an explicit null.
 	const countLine =
-		tagInfo?.count !== undefined
+		typeof tagInfo?.count === 'number'
 			? translate( '%(count)d post', '%(count)d posts', {
 					count: tagInfo.count,
 					args: { count: tagInfo.count },

--- a/client/reader/atmosphere/tag-feed-view.tsx
+++ b/client/reader/atmosphere/tag-feed-view.tsx
@@ -1,0 +1,64 @@
+import { useConnectionsQuery } from '@automattic/api-queries';
+import page from '@automattic/calypso-router';
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import DocumentHead from 'calypso/components/data/document-head';
+import ReaderMain from 'calypso/reader/components/reader-main';
+import { TagFeedPanel } from './tag-feed-panel';
+
+interface Props {
+	connectionId: number;
+	hashtag: string;
+}
+
+export function TagFeedView( { connectionId, hashtag }: Props ) {
+	const translate = useTranslate();
+	const { data, isPending, isError, refetch } = useConnectionsQuery();
+
+	const connections = data?.connections ?? [];
+	const connection = connections.find( ( c ) => c.id === connectionId ) ?? null;
+
+	useEffect( () => {
+		if ( isPending || isError ) {
+			return;
+		}
+		if ( ! connection ) {
+			page.replace( '/reader/atmosphere' );
+		}
+	}, [ isPending, isError, connection, connectionId ] );
+
+	if ( isError ) {
+		return (
+			<ReaderMain className="atmosphere-view">
+				<DocumentHead title={ translate( 'Tag ‹ Bluesky ‹ Reader' ) } />
+				<div role="alert" className="atmosphere-error">
+					<p>{ translate( "We couldn't load your Bluesky connections." ) }</p>
+					<Button variant="secondary" onClick={ () => refetch() }>
+						{ translate( 'Try again' ) }
+					</Button>
+				</div>
+			</ReaderMain>
+		);
+	}
+
+	if ( ! connection ) {
+		return (
+			<ReaderMain className="atmosphere-view">
+				<DocumentHead title={ translate( 'Tag ‹ Bluesky ‹ Reader' ) } />
+				<div role="status" aria-live="polite">
+					{ translate( 'Loading…' ) }
+				</div>
+			</ReaderMain>
+		);
+	}
+
+	return (
+		<ReaderMain className="atmosphere-view">
+			<DocumentHead title={ translate( '#%s ‹ Bluesky ‹ Reader', { args: hashtag } ) } />
+			<TagFeedPanel connection={ connection } hashtag={ hashtag } />
+		</ReaderMain>
+	);
+}
+
+export default TagFeedView;

--- a/client/reader/atmosphere/test/controller.test.tsx
+++ b/client/reader/atmosphere/test/controller.test.tsx
@@ -14,7 +14,7 @@ jest.mock( '@automattic/calypso-config', () => ( {
 } ) );
 
 import page from '@automattic/calypso-router';
-import { atmosphereProfile, atmosphereThread } from '../controller';
+import { atmosphereProfile, atmosphereTagFeed, atmosphereThread } from '../controller';
 
 const validDid = 'did:plc:abc234567defghi234567jkl';
 const validRkey = '3kabcdefghijk';
@@ -137,6 +137,65 @@ describe( 'atmosphereProfile', () => {
 		config.isEnabled.mockReturnValueOnce( false );
 		const ctx = makeProfileContext( { id: '42', actor: 'alice.bsky.social' } );
 		atmosphereProfile( ctx, mockNext );
+		expect( page.redirect ).toHaveBeenCalledWith( '/reader' );
+		expect( mockNext ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'atmosphereTagFeed', () => {
+	function makeTagContext( params: Record< string, string > ) {
+		return { params, primary: null } as unknown as Parameters< typeof atmosphereTagFeed >[ 0 ];
+	}
+
+	it( 'mounts the AsyncLoad shell on a valid id + hashtag', () => {
+		const ctx = makeTagContext( { id: '42', hashtag: 'rust' } );
+		atmosphereTagFeed( ctx, mockNext );
+		expect( ctx.primary ).toBeTruthy();
+		expect( mockNext ).toHaveBeenCalled();
+	} );
+
+	it( 'lowercases the hashtag before passing it to the view', () => {
+		const ctx = makeTagContext( { id: '42', hashtag: 'Rust' } );
+		atmosphereTagFeed( ctx, mockNext );
+		const primary = ctx.primary as unknown as { props: { hashtag: string } };
+		expect( primary.props.hashtag ).toBe( 'rust' );
+	} );
+
+	it( 'strips a leading # before passing it to the view', () => {
+		const ctx = makeTagContext( { id: '42', hashtag: '#rust' } );
+		atmosphereTagFeed( ctx, mockNext );
+		const primary = ctx.primary as unknown as { props: { hashtag: string } };
+		expect( primary.props.hashtag ).toBe( 'rust' );
+	} );
+
+	it( 'accepts a Unicode hashtag', () => {
+		const ctx = makeTagContext( { id: '42', hashtag: '日本語' } );
+		atmosphereTagFeed( ctx, mockNext );
+		expect( ctx.primary ).toBeTruthy();
+		expect( mockNext ).toHaveBeenCalled();
+	} );
+
+	it( 'redirects to the connection root on an invalid hashtag', () => {
+		const ctx = makeTagContext( { id: '42', hashtag: 'tag-with-hyphen' } );
+		atmosphereTagFeed( ctx, mockNext );
+		expect( page.redirect ).toHaveBeenCalledWith( '/reader/atmosphere/42' );
+		expect( mockNext ).not.toHaveBeenCalled();
+	} );
+
+	it( 'redirects to /reader/atmosphere on a non-numeric id', () => {
+		const ctx = makeTagContext( { id: 'NaN', hashtag: 'rust' } );
+		atmosphereTagFeed( ctx, mockNext );
+		expect( page.redirect ).toHaveBeenCalledWith( '/reader/atmosphere' );
+		expect( mockNext ).not.toHaveBeenCalled();
+	} );
+
+	it( 'redirects to /reader when the feature flag is off', () => {
+		const config = jest.requireMock( '@automattic/calypso-config' ) as {
+			isEnabled: jest.Mock;
+		};
+		config.isEnabled.mockReturnValueOnce( false );
+		const ctx = makeTagContext( { id: '42', hashtag: 'rust' } );
+		atmosphereTagFeed( ctx, mockNext );
 		expect( page.redirect ).toHaveBeenCalledWith( '/reader' );
 		expect( mockNext ).not.toHaveBeenCalled();
 	} );

--- a/client/reader/atmosphere/test/route.test.ts
+++ b/client/reader/atmosphere/test/route.test.ts
@@ -1,4 +1,11 @@
-import { getBlueskyProfileUrl, getProfileUrl, getThreadUrl, getTimelineUrl } from '../route';
+import {
+	getBlueskyProfileUrl,
+	getProfileUrl,
+	getTagFeedUrl,
+	getThreadUrl,
+	getTimelineUrl,
+	isValidHashtag,
+} from '../route';
 
 describe( 'getTimelineUrl', () => {
 	it( 'returns the connection-scoped timeline path', () => {
@@ -109,5 +116,65 @@ describe( 'getBlueskyProfileUrl', () => {
 	it( 'percent-encodes characters that would otherwise mangle the path', () => {
 		expect( getBlueskyProfileUrl( 'foo/bar' ) ).toBe( 'https://bsky.app/profile/foo%2Fbar' );
 		expect( getBlueskyProfileUrl( 'a?b' ) ).toBe( 'https://bsky.app/profile/a%3Fb' );
+	} );
+} );
+
+describe( 'isValidHashtag', () => {
+	it( 'accepts ASCII letters, digits, underscore', () => {
+		expect( isValidHashtag( 'rust' ) ).toBe( true );
+		expect( isValidHashtag( 'rust2024' ) ).toBe( true );
+		expect( isValidHashtag( 'foo_bar' ) ).toBe( true );
+	} );
+
+	it( 'accepts Unicode letters and marks', () => {
+		expect( isValidHashtag( '日本語' ) ).toBe( true );
+		expect( isValidHashtag( 'café' ) ).toBe( true );
+	} );
+
+	it( 'rejects hyphens, dots, slashes, spaces', () => {
+		expect( isValidHashtag( 'tag-with-hyphen' ) ).toBe( false );
+		expect( isValidHashtag( 'tag.with.dot' ) ).toBe( false );
+		expect( isValidHashtag( '../foo' ) ).toBe( false );
+		expect( isValidHashtag( 'has space' ) ).toBe( false );
+	} );
+
+	it( 'rejects empty and 65-char tags', () => {
+		expect( isValidHashtag( '' ) ).toBe( false );
+		expect( isValidHashtag( 'a'.repeat( 65 ) ) ).toBe( false );
+		expect( isValidHashtag( 'a'.repeat( 64 ) ) ).toBe( true );
+	} );
+} );
+
+describe( 'getTagFeedUrl', () => {
+	it( 'returns the in-app tag-feed path for a valid hashtag', () => {
+		expect( getTagFeedUrl( 7, 'rust' ) ).toBe( '/reader/atmosphere/7/tag/rust' );
+	} );
+
+	it( 'lowercases and percent-encodes Unicode tags', () => {
+		expect( getTagFeedUrl( 7, 'Rust' ) ).toBe( '/reader/atmosphere/7/tag/rust' );
+		expect( getTagFeedUrl( 7, '日本語' ) ).toBe(
+			'/reader/atmosphere/7/tag/' + encodeURIComponent( '日本語' )
+		);
+	} );
+
+	it( 'strips a leading # before validating', () => {
+		expect( getTagFeedUrl( 7, '#rust' ) ).toBe( '/reader/atmosphere/7/tag/rust' );
+	} );
+
+	it( 'returns null for malformed hashtags', () => {
+		expect( getTagFeedUrl( 7, 'has spaces' ) ).toBeNull();
+		expect( getTagFeedUrl( 7, '../foo' ) ).toBeNull();
+		expect( getTagFeedUrl( 7, '' ) ).toBeNull();
+		expect( getTagFeedUrl( 7, 'tag-with-hyphen' ) ).toBeNull();
+	} );
+
+	it( 'returns null on a 65-char hashtag', () => {
+		expect( getTagFeedUrl( 7, 'a'.repeat( 65 ) ) ).toBeNull();
+	} );
+
+	it( 'returns null for invalid connection ids', () => {
+		expect( getTagFeedUrl( 0, 'rust' ) ).toBeNull();
+		expect( getTagFeedUrl( -1, 'rust' ) ).toBeNull();
+		expect( getTagFeedUrl( Number.NaN, 'rust' ) ).toBeNull();
 	} );
 } );

--- a/client/reader/atmosphere/test/tag-feed-panel.test.tsx
+++ b/client/reader/atmosphere/test/tag-feed-panel.test.tsx
@@ -95,44 +95,6 @@ describe( 'TagFeedPanel', () => {
 		expect( screen.queryByText( /\d+ posts?/i ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'renders the View on Bluesky link only for https URLs', async () => {
-		nock( BASE )
-			.get( PATH )
-			.reply( 200, {
-				items: [],
-				cursor: null,
-				tag: { name: 'rust', url: 'https://bsky.app/hashtag/rust' },
-			} );
-
-		renderWithProvider( <TagFeedPanel connection={ connection } hashtag="rust" />, {
-			queryClient: makeQueryClient(),
-		} );
-
-		await waitFor( () =>
-			expect( screen.getByRole( 'link', { name: /View on Bluesky/i } ) ).toHaveAttribute(
-				'href',
-				'https://bsky.app/hashtag/rust'
-			)
-		);
-	} );
-
-	it( 'omits the View on Bluesky link when the URL is non-https', async () => {
-		nock( BASE )
-			.get( PATH )
-			.reply( 200, {
-				items: [],
-				cursor: null,
-				tag: { name: 'rust', url: 'javascript:alert(1)' },
-			} );
-
-		renderWithProvider( <TagFeedPanel connection={ connection } hashtag="rust" />, {
-			queryClient: makeQueryClient(),
-		} );
-
-		await waitFor( () => expect( screen.getByRole( 'heading', { name: '#rust' } ) ).toBeVisible() );
-		expect( screen.queryByRole( 'link', { name: /View on Bluesky/i } ) ).not.toBeInTheDocument();
-	} );
-
 	it( 'fires the tag_feed_viewed Tracks event when data resolves', async () => {
 		const spy = analytics.recordReaderTracksEvent as unknown as jest.Mock;
 		nock( BASE )

--- a/client/reader/atmosphere/test/tag-feed-panel.test.tsx
+++ b/client/reader/atmosphere/test/tag-feed-panel.test.tsx
@@ -1,13 +1,20 @@
 /**
  * @jest-environment jsdom
  */
+import page from '@automattic/calypso-router';
 import { QueryClient } from '@tanstack/react-query';
 import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import * as analytics from 'calypso/state/reader/analytics/actions';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { TagFeedPanel } from '../tag-feed-panel';
 import type { AtmosphereConnection } from '@automattic/api-core';
+
+jest.mock( '@automattic/calypso-router', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
 
 const connection: AtmosphereConnection = {
 	id: 42,
@@ -127,5 +134,108 @@ describe( 'TagFeedPanel', () => {
 				hashtag: 'rust',
 			} )
 		);
+	} );
+
+	it( 're-fires tag_feed_viewed when the hashtag changes within the same mount', async () => {
+		const spy = analytics.recordReaderTracksEvent as unknown as jest.Mock;
+		nock( BASE )
+			.get( PATH )
+			.reply( 200, { items: [], cursor: null, tag: { name: 'rust' } } );
+		nock( BASE )
+			.get( '/wpcom/v2/reader/atmosphere/connections/42/tag/go/feed' )
+			.reply( 200, { items: [], cursor: null, tag: { name: 'go' } } );
+
+		const { rerender } = renderWithProvider(
+			<TagFeedPanel connection={ connection } hashtag="rust" />,
+			{ queryClient: makeQueryClient() }
+		);
+
+		await waitFor( () =>
+			expect( spy ).toHaveBeenCalledWith( 'calypso_reader_atmosphere_tag_feed_viewed', {
+				connection_id: 42,
+				hashtag: 'rust',
+			} )
+		);
+
+		rerender( <TagFeedPanel connection={ connection } hashtag="go" /> );
+
+		await waitFor( () =>
+			expect( spy ).toHaveBeenCalledWith( 'calypso_reader_atmosphere_tag_feed_viewed', {
+				connection_id: 42,
+				hashtag: 'go',
+			} )
+		);
+	} );
+
+	it( 'fires tag_feed_error_shown when the query fails', async () => {
+		const spy = analytics.recordReaderTracksEvent as unknown as jest.Mock;
+		nock( BASE ).get( PATH ).reply( 429, { error: 'atmosphere_rate_limited' } );
+
+		renderWithProvider( <TagFeedPanel connection={ connection } hashtag="rust" />, {
+			queryClient: makeQueryClient(),
+		} );
+
+		await waitFor( () =>
+			expect( spy ).toHaveBeenCalledWith(
+				'calypso_reader_atmosphere_tag_feed_error_shown',
+				expect.objectContaining( {
+					connection_id: 42,
+					hashtag: 'rust',
+					error_kind: 'rate_limited',
+				} )
+			)
+		);
+	} );
+
+	it( 'fires tag_feed_retry_clicked and refetches when the retry button is clicked', async () => {
+		const spy = analytics.recordReaderTracksEvent as unknown as jest.Mock;
+		const user = userEvent.setup();
+		// rate_limited is a terminal error kind — the query factory does not
+		// auto-retry, so a single fail-then-success pair is enough.
+		nock( BASE ).get( PATH ).reply( 429, { error: 'atmosphere_rate_limited' } );
+		nock( BASE )
+			.get( PATH )
+			.reply( 200, { items: [], cursor: null, tag: { name: 'rust' } } );
+
+		renderWithProvider( <TagFeedPanel connection={ connection } hashtag="rust" />, {
+			queryClient: makeQueryClient(),
+		} );
+
+		const retry = await screen.findByRole( 'button', { name: /retry/i } );
+		await user.click( retry );
+
+		expect( spy ).toHaveBeenCalledWith(
+			'calypso_reader_atmosphere_tag_feed_retry_clicked',
+			expect.objectContaining( {
+				connection_id: 42,
+				hashtag: 'rust',
+				error_kind: 'rate_limited',
+			} )
+		);
+		await waitFor( () => expect( screen.getByRole( 'heading', { name: '#rust' } ) ).toBeVisible() );
+	} );
+
+	it( 'fires tag_feed_back_to_timeline_clicked when the back button is clicked', async () => {
+		const spy = analytics.recordReaderTracksEvent as unknown as jest.Mock;
+		const user = userEvent.setup();
+		nock( BASE )
+			.get( PATH )
+			.reply( 200, { items: [], cursor: null, tag: { name: 'rust' } } );
+
+		renderWithProvider( <TagFeedPanel connection={ connection } hashtag="rust" />, {
+			queryClient: makeQueryClient(),
+		} );
+
+		const back = await screen.findByRole( 'button', { name: /back/i } );
+		await user.click( back );
+
+		expect( spy ).toHaveBeenCalledWith(
+			'calypso_reader_atmosphere_tag_feed_back_to_timeline_clicked',
+			{
+				connection_id: 42,
+				hashtag: 'rust',
+			}
+		);
+		expect( page ).toHaveBeenCalledWith( '/reader/atmosphere/42/timeline' );
 	} );
 } );

--- a/client/reader/atmosphere/test/tag-feed-panel.test.tsx
+++ b/client/reader/atmosphere/test/tag-feed-panel.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient } from '@tanstack/react-query';
+import { screen, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import * as analytics from 'calypso/state/reader/analytics/actions';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { TagFeedPanel } from '../tag-feed-panel';
+import type { AtmosphereConnection } from '@automattic/api-core';
+
+const connection: AtmosphereConnection = {
+	id: 42,
+	did: 'did:plc:abc',
+	handle: 'alice.bsky.social',
+	display_name: 'Alice',
+	avatar: null,
+};
+
+const BASE = 'https://public-api.wordpress.com';
+const PATH = '/wpcom/v2/reader/atmosphere/connections/42/tag/rust/feed';
+
+function makeQueryClient() {
+	return new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+}
+
+describe( 'TagFeedPanel', () => {
+	beforeEach( () => {
+		jest
+			.spyOn( analytics, 'recordReaderTracksEvent' )
+			.mockImplementation( () => ( { type: '@@TEST/NOOP' } ) as never );
+	} );
+
+	afterEach( () => {
+		nock.cleanAll();
+		jest.restoreAllMocks();
+	} );
+
+	it( 'renders the hashtag heading after the first page resolves', async () => {
+		nock( BASE )
+			.get( PATH )
+			.reply( 200, { items: [], cursor: null, tag: { name: 'rust' } } );
+
+		renderWithProvider( <TagFeedPanel connection={ connection } hashtag="rust" />, {
+			queryClient: makeQueryClient(),
+		} );
+
+		await waitFor( () => expect( screen.getByRole( 'heading', { name: '#rust' } ) ).toBeVisible() );
+	} );
+
+	it( 'renders the count line when count is set', async () => {
+		nock( BASE )
+			.get( PATH )
+			.reply( 200, { items: [], cursor: null, tag: { name: 'rust', count: 1234 } } );
+
+		renderWithProvider( <TagFeedPanel connection={ connection } hashtag="rust" />, {
+			queryClient: makeQueryClient(),
+		} );
+
+		await waitFor( () => expect( screen.getByText( /1,?234 posts/ ) ).toBeVisible() );
+	} );
+
+	it( 'omits the count line when count is undefined', async () => {
+		nock( BASE )
+			.get( PATH )
+			.reply( 200, { items: [], cursor: null, tag: { name: 'rust' } } );
+
+		renderWithProvider( <TagFeedPanel connection={ connection } hashtag="rust" />, {
+			queryClient: makeQueryClient(),
+		} );
+
+		await waitFor( () => expect( screen.getByRole( 'heading', { name: '#rust' } ) ).toBeVisible() );
+		expect( screen.queryByText( /\d+ posts?/i ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the View on Bluesky link only for https URLs', async () => {
+		nock( BASE )
+			.get( PATH )
+			.reply( 200, {
+				items: [],
+				cursor: null,
+				tag: { name: 'rust', url: 'https://bsky.app/hashtag/rust' },
+			} );
+
+		renderWithProvider( <TagFeedPanel connection={ connection } hashtag="rust" />, {
+			queryClient: makeQueryClient(),
+		} );
+
+		await waitFor( () =>
+			expect( screen.getByRole( 'link', { name: /View on Bluesky/i } ) ).toHaveAttribute(
+				'href',
+				'https://bsky.app/hashtag/rust'
+			)
+		);
+	} );
+
+	it( 'omits the View on Bluesky link when the URL is non-https', async () => {
+		nock( BASE )
+			.get( PATH )
+			.reply( 200, {
+				items: [],
+				cursor: null,
+				tag: { name: 'rust', url: 'javascript:alert(1)' },
+			} );
+
+		renderWithProvider( <TagFeedPanel connection={ connection } hashtag="rust" />, {
+			queryClient: makeQueryClient(),
+		} );
+
+		await waitFor( () => expect( screen.getByRole( 'heading', { name: '#rust' } ) ).toBeVisible() );
+		expect( screen.queryByRole( 'link', { name: /View on Bluesky/i } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'fires the tag_feed_viewed Tracks event when data resolves', async () => {
+		const spy = analytics.recordReaderTracksEvent as unknown as jest.Mock;
+		nock( BASE )
+			.get( PATH )
+			.reply( 200, { items: [], cursor: null, tag: { name: 'rust' } } );
+
+		renderWithProvider( <TagFeedPanel connection={ connection } hashtag="rust" />, {
+			queryClient: makeQueryClient(),
+		} );
+
+		await waitFor( () =>
+			expect( spy ).toHaveBeenCalledWith( 'calypso_reader_atmosphere_tag_feed_viewed', {
+				connection_id: 42,
+				hashtag: 'rust',
+			} )
+		);
+	} );
+} );

--- a/client/reader/atmosphere/test/tag-feed-panel.test.tsx
+++ b/client/reader/atmosphere/test/tag-feed-panel.test.tsx
@@ -80,6 +80,21 @@ describe( 'TagFeedPanel', () => {
 		expect( screen.queryByText( /\d+ posts?/i ) ).not.toBeInTheDocument();
 	} );
 
+	// The backend emits `count: null` (not omitted) when the AppView's
+	// `hitsTotal` is absent — guard the loose null/undefined check.
+	it( 'omits the count line when count is null', async () => {
+		nock( BASE )
+			.get( PATH )
+			.reply( 200, { items: [], cursor: null, tag: { name: 'rust', count: null } } );
+
+		renderWithProvider( <TagFeedPanel connection={ connection } hashtag="rust" />, {
+			queryClient: makeQueryClient(),
+		} );
+
+		await waitFor( () => expect( screen.getByRole( 'heading', { name: '#rust' } ) ).toBeVisible() );
+		expect( screen.queryByText( /\d+ posts?/i ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'renders the View on Bluesky link only for https URLs', async () => {
 		nock( BASE )
 			.get( PATH )

--- a/client/reader/atmosphere/test/tag-feed-view.test.tsx
+++ b/client/reader/atmosphere/test/tag-feed-view.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * @jest-environment jsdom
+ */
+import page from '@automattic/calypso-router';
+import { screen, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { TagFeedView } from '../tag-feed-view';
+import type React from 'react';
+
+jest.mock(
+	'calypso/reader/components/reader-main',
+	() =>
+		function ReaderMain( { children }: { children: React.ReactNode } ) {
+			return <div>{ children }</div>;
+		}
+);
+
+jest.mock( 'calypso/state/reader/analytics/actions', () => ( {
+	recordReaderTracksEvent: () => ( { type: '@@TEST/NOOP' } ),
+} ) );
+
+jest.mock( 'calypso/components/data/document-head', () => () => null );
+
+jest.mock( '@automattic/calypso-router', () => ( {
+	__esModule: true,
+	default: { replace: jest.fn() },
+} ) );
+
+const BASE = 'https://public-api.wordpress.com';
+const CONNECTIONS_PATH = '/wpcom/v2/reader/atmosphere/connections';
+const FEED_PATH = '/wpcom/v2/reader/atmosphere/connections/42/tag/rust/feed';
+
+afterEach( () => {
+	nock.cleanAll();
+	jest.restoreAllMocks();
+	( page.replace as jest.Mock ).mockClear();
+} );
+
+describe( 'TagFeedView', () => {
+	it( 'shows a loading status while connections are pending', () => {
+		nock( BASE ).get( CONNECTIONS_PATH ).delay( 5000 ).reply( 200, { connections: [] } );
+
+		renderWithProvider( <TagFeedView connectionId={ 42 } hashtag="rust" /> );
+
+		expect( screen.getByRole( 'status' ) ).toHaveTextContent( /loading/i );
+		expect( page.replace ).not.toHaveBeenCalled();
+	} );
+
+	it( 'redirects to /reader/atmosphere when the connection is missing', async () => {
+		nock( BASE ).get( CONNECTIONS_PATH ).reply( 200, { connections: [] } );
+
+		renderWithProvider( <TagFeedView connectionId={ 42 } hashtag="rust" /> );
+
+		await waitFor( () => expect( page.replace ).toHaveBeenCalledWith( '/reader/atmosphere' ) );
+	} );
+
+	it( 'shows the connection-error UI when the connections query fails', async () => {
+		// auth_required is a terminal error kind — the connections query won't
+		// auto-retry, so a single 401 is enough to surface the error UI.
+		nock( BASE ).get( CONNECTIONS_PATH ).reply( 401, { error: 'atmosphere_auth_required' } );
+
+		renderWithProvider( <TagFeedView connectionId={ 42 } hashtag="rust" /> );
+
+		await waitFor( () =>
+			expect( screen.getByRole( 'alert' ) ).toHaveTextContent( /couldn't load/i )
+		);
+		expect( page.replace ).not.toHaveBeenCalled();
+	} );
+
+	it( 'renders the TagFeedPanel when the connection resolves', async () => {
+		nock( BASE )
+			.get( CONNECTIONS_PATH )
+			.reply( 200, {
+				connections: [
+					{
+						id: 42,
+						did: 'did:plc:viewer',
+						handle: 'viewer.bsky.social',
+						display_name: 'Viewer',
+						avatar: null,
+					},
+				],
+			} );
+		nock( BASE )
+			.get( FEED_PATH )
+			.reply( 200, { items: [], cursor: null, tag: { name: 'rust' } } );
+
+		renderWithProvider( <TagFeedView connectionId={ 42 } hashtag="rust" /> );
+
+		await waitFor( () => expect( screen.getByRole( 'heading', { name: '#rust' } ) ).toBeVisible() );
+		expect( page.replace ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/reader/atmosphere/thread-panel.tsx
+++ b/client/reader/atmosphere/thread-panel.tsx
@@ -10,6 +10,7 @@ import { SocialAnalyticsProvider } from 'calypso/reader/social';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import {
 	getProfileUrl as buildProfileUrl,
+	getTagFeedUrl as buildTagUrl,
 	getThreadUrl as buildThreadUrl,
 	type ProfileRefInput,
 } from './route';
@@ -119,6 +120,11 @@ export function ThreadPanel( { connection, did, rkey }: ThreadPanelProps ) {
 		[ connection.id ]
 	);
 
+	const getTagUrl = useCallback(
+		( tag: string ) => buildTagUrl( connection.id, tag ),
+		[ connection.id ]
+	);
+
 	const analyticsValue = useMemo(
 		() => ( {
 			source: 'atmosphere' as const,
@@ -126,8 +132,9 @@ export function ThreadPanel( { connection, did, rkey }: ThreadPanelProps ) {
 			onClick: onClickAnalytics,
 			getThreadUrl,
 			getProfileUrl,
+			getTagUrl,
 		} ),
-		[ connection.id, onClickAnalytics, getThreadUrl, getProfileUrl ]
+		[ connection.id, onClickAnalytics, getThreadUrl, getProfileUrl, getTagUrl ]
 	);
 
 	return (

--- a/client/reader/atmosphere/timeline-panel.tsx
+++ b/client/reader/atmosphere/timeline-panel.tsx
@@ -14,6 +14,7 @@ import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions'
 import { projectAtmosphereError } from './error-projection';
 import {
 	getProfileUrl as buildProfileUrl,
+	getTagFeedUrl as buildTagUrl,
 	getThreadUrl as buildThreadUrl,
 	type ProfileRefInput,
 } from './route';
@@ -101,6 +102,11 @@ export function TimelinePanel( { connection }: TimelinePanelProps ) {
 		[ connection.id ]
 	);
 
+	const getTagUrl = useCallback(
+		( tag: string ) => buildTagUrl( connection.id, tag ),
+		[ connection.id ]
+	);
+
 	const renderItem = useCallback(
 		( post: SocialPost ) => <SocialPostCard post={ post } variant="default" />,
 		[]
@@ -114,8 +120,9 @@ export function TimelinePanel( { connection }: TimelinePanelProps ) {
 			onClick: onClickAnalytics,
 			getThreadUrl,
 			getProfileUrl,
+			getTagUrl,
 		} ),
-		[ connection.id, onClickAnalytics, getThreadUrl, getProfileUrl ]
+		[ connection.id, onClickAnalytics, getThreadUrl, getProfileUrl, getTagUrl ]
 	);
 
 	return (

--- a/packages/api-core/src/reader-atmosphere/__tests__/errors.test.ts
+++ b/packages/api-core/src/reader-atmosphere/__tests__/errors.test.ts
@@ -9,6 +9,19 @@ function wpErr( code: string, statusCode: number, message = '' ): unknown {
 	return e;
 }
 
+// Mirror the actual shape that wpcom-proxy-request raises for a WP REST
+// envelope error: the WP error code lands on `.code`, not `.error`. The
+// classifier must recognise both to avoid silently falling through to
+// `{ kind: 'unknown' }` for live upstream failures.
+function wpProxyErr( code: string, statusCode: number, message = '' ): unknown {
+	const e = new Error( message );
+	( e as unknown as Record< string, unknown > ).code = code;
+	( e as unknown as Record< string, unknown > ).statusCode = statusCode;
+	( e as unknown as Record< string, unknown > ).status = statusCode;
+	( e as unknown as Record< string, unknown > ).message = message;
+	return e;
+}
+
 describe( 'classifyAtmosphereError', () => {
 	it( 'maps invalid_handle', () => {
 		expect( classifyAtmosphereError( wpErr( 'invalid_handle', 400 ) ).kind ).toBe(
@@ -39,5 +52,17 @@ describe( 'classifyAtmosphereError', () => {
 	it( 'falls back to unknown', () => {
 		const e = classifyAtmosphereError( new Error( 'boom' ) );
 		expect( e.kind ).toBe( 'unknown' );
+	} );
+
+	it( 'classifies wpcom-proxy errors that surface the code on .code', () => {
+		expect(
+			classifyAtmosphereError( wpProxyErr( 'atmosphere_upstream_unavailable', 403 ) ).kind
+		).toBe( 'upstream_unavailable' );
+		expect( classifyAtmosphereError( wpProxyErr( 'atmosphere_rate_limited', 429 ) ).kind ).toBe(
+			'rate_limited'
+		);
+		expect( classifyAtmosphereError( wpProxyErr( 'connection_not_found', 404 ) ).kind ).toBe(
+			'connection_not_found'
+		);
 	} );
 } );

--- a/packages/api-core/src/reader-atmosphere/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/reader-atmosphere/__tests__/fetchers.test.ts
@@ -1,6 +1,7 @@
 import nock from 'nock';
 import {
 	createConnection,
+	getAtmosphereTagFeed,
 	getAuthorFeed,
 	getAuthorProfile,
 	getConnection,
@@ -495,6 +496,67 @@ describe( 'atmosphere fetchers', () => {
 			await expect( getAuthorFeed( { actor: 'alice.bsky.social' } ) ).rejects.toMatchObject( {
 				kind: 'unknown',
 			} );
+		} );
+	} );
+
+	describe( 'getAtmosphereTagFeed', () => {
+		it( 'GETs /reader/atmosphere/connections/:id/tag/<hashtag>/feed', async () => {
+			const scope = nock( BASE )
+				.get( '/wpcom/v2/reader/atmosphere/connections/7/tag/rust/feed' )
+				.reply( 200, {
+					items: [],
+					cursor: 'NEXT',
+					tag: { name: 'rust', count: 100, url: 'https://bsky.app/hashtag/rust' },
+				} );
+			const result = await getAtmosphereTagFeed( { connectionId: 7, hashtag: 'rust' } );
+			expect( result.cursor ).toBe( 'NEXT' );
+			expect( result.tag?.name ).toBe( 'rust' );
+			expect( result.tag?.count ).toBe( 100 );
+			expect( scope.isDone() ).toBe( true );
+		} );
+
+		it( 'forwards cursor and limit as query params', async () => {
+			const scope = nock( BASE )
+				.get( '/wpcom/v2/reader/atmosphere/connections/7/tag/rust/feed' )
+				.query( { cursor: 'PAGE2', limit: '50' } )
+				.reply( 200, { items: [], cursor: null } );
+			await getAtmosphereTagFeed( {
+				connectionId: 7,
+				hashtag: 'rust',
+				cursor: 'PAGE2',
+				limit: 50,
+			} );
+			expect( scope.isDone() ).toBe( true );
+		} );
+
+		it( 'percent-encodes Unicode hashtags in the path', async () => {
+			const scope = nock( BASE )
+				.get(
+					'/wpcom/v2/reader/atmosphere/connections/7/tag/' +
+						encodeURIComponent( '日本語' ) +
+						'/feed'
+				)
+				.reply( 200, { items: [], cursor: null } );
+			await getAtmosphereTagFeed( { connectionId: 7, hashtag: '日本語' } );
+			expect( scope.isDone() ).toBe( true );
+		} );
+
+		it( 'classifies a 401 as auth_required', async () => {
+			nock( BASE )
+				.get( '/wpcom/v2/reader/atmosphere/connections/7/tag/rust/feed' )
+				.reply( 401, { error: 'atmosphere_auth_required' } );
+			await expect(
+				getAtmosphereTagFeed( { connectionId: 7, hashtag: 'rust' } )
+			).rejects.toMatchObject( { kind: 'auth_required' } );
+		} );
+
+		it( 'classifies a 429 as rate_limited', async () => {
+			nock( BASE )
+				.get( '/wpcom/v2/reader/atmosphere/connections/7/tag/rust/feed' )
+				.reply( 429, { error: 'atmosphere_rate_limited' } );
+			await expect(
+				getAtmosphereTagFeed( { connectionId: 7, hashtag: 'rust' } )
+			).rejects.toMatchObject( { kind: 'rate_limited' } );
 		} );
 	} );
 } );

--- a/packages/api-core/src/reader-atmosphere/errors.ts
+++ b/packages/api-core/src/reader-atmosphere/errors.ts
@@ -12,7 +12,13 @@ export type AtmosphereError =
 	| { kind: 'unknown'; cause: unknown };
 
 interface WpErrorLike {
+	// The wpcom-proxy / wpcom-xhr-request transports surface the WP REST
+	// envelope's error code as `code` on the thrown error. Some legacy
+	// callsites (and the existing test fixtures) populate `error` instead.
+	// Accept both so live errors classify correctly regardless of which
+	// transport raised them.
 	error?: string;
+	code?: string;
 	statusCode?: number;
 	status?: number;
 	message?: string;
@@ -20,14 +26,18 @@ interface WpErrorLike {
 }
 
 function isWpErrorLike( e: unknown ): e is WpErrorLike {
-	return typeof e === 'object' && e !== null && 'error' in ( e as object );
+	if ( typeof e !== 'object' || e === null ) {
+		return false;
+	}
+	return 'error' in ( e as object ) || 'code' in ( e as object );
 }
 
 export function classifyAtmosphereError( raw: unknown ): AtmosphereError {
 	if ( ! isWpErrorLike( raw ) ) {
 		return { kind: 'unknown', cause: raw };
 	}
-	switch ( raw.error ) {
+	const errorCode = raw.error ?? raw.code;
+	switch ( errorCode ) {
 		case 'invalid_handle':
 			return { kind: 'invalid_handle' };
 		case 'invalid_credentials':

--- a/packages/api-core/src/reader-atmosphere/fetchers.ts
+++ b/packages/api-core/src/reader-atmosphere/fetchers.ts
@@ -7,6 +7,7 @@ import type {
 	AtmosphereConnectionDetails,
 	AtmosphereConnectionsResponse,
 	AtmosphereCreateConnectionResponse,
+	AtmosphereTagFeedPage,
 	AtmosphereThreadResponse,
 	AtmosphereTimelinePage,
 } from './types';
@@ -158,6 +159,42 @@ export async function getAuthorFeed(
 			},
 			query
 		) ) as AtmosphereAuthorFeedPage;
+	} catch ( raw ) {
+		throw classifyAtmosphereError( raw );
+	}
+}
+
+export interface GetAtmosphereTagFeedParams {
+	connectionId: number;
+	hashtag: string;
+	cursor?: string;
+	limit?: number;
+}
+
+export async function getAtmosphereTagFeed(
+	params: GetAtmosphereTagFeedParams
+): Promise< AtmosphereTagFeedPage > {
+	const { connectionId, hashtag, cursor, limit } = params;
+	const query: Record< string, string > = {};
+	if ( cursor ) {
+		query.cursor = cursor;
+	}
+	if ( limit ) {
+		query.limit = String( limit );
+	}
+	try {
+		return ( await wpcom.req.get(
+			{
+				// Encode `hashtag` defensively. HASHTAG_RE-validated values
+				// already contain only safe Unicode chars, but encoding keeps
+				// multibyte segments safe in the request path.
+				path: `/reader/atmosphere/connections/${ connectionId }/tag/${ encodeURIComponent(
+					hashtag
+				) }/feed`,
+				apiNamespace: NAMESPACE,
+			},
+			query
+		) ) as AtmosphereTagFeedPage;
 	} catch ( raw ) {
 		throw classifyAtmosphereError( raw );
 	}

--- a/packages/api-core/src/reader-atmosphere/fetchers.ts
+++ b/packages/api-core/src/reader-atmosphere/fetchers.ts
@@ -185,9 +185,8 @@ export async function getAtmosphereTagFeed(
 	try {
 		return ( await wpcom.req.get(
 			{
-				// Encode `hashtag` defensively. HASHTAG_RE-validated values
-				// already contain only safe Unicode chars, but encoding keeps
-				// multibyte segments safe in the request path.
+				// Percent-encode the hashtag: HASHTAG_RE allows any Unicode
+				// letter/number/mark, which must be encoded for the URL path.
 				path: `/reader/atmosphere/connections/${ connectionId }/tag/${ encodeURIComponent(
 					hashtag
 				) }/feed`,

--- a/packages/api-core/src/reader-atmosphere/index.ts
+++ b/packages/api-core/src/reader-atmosphere/index.ts
@@ -2,3 +2,4 @@ export * from './errors';
 export * from './fetchers';
 export * from './query-keys';
 export * from './types';
+export * from './validation';

--- a/packages/api-core/src/reader-atmosphere/query-keys.ts
+++ b/packages/api-core/src/reader-atmosphere/query-keys.ts
@@ -12,4 +12,6 @@ export const readerAtmosphereKeys = {
 		filter
 			? ( [ ...readerAtmosphereKeys.all, 'author-feed', actor, filter ] as const )
 			: ( [ ...readerAtmosphereKeys.all, 'author-feed', actor ] as const ),
+	tagFeed: ( connectionId: number, hashtag: string ) =>
+		[ ...readerAtmosphereKeys.all, 'tag-feed', connectionId, hashtag ] as const,
 };

--- a/packages/api-core/src/reader-atmosphere/types.ts
+++ b/packages/api-core/src/reader-atmosphere/types.ts
@@ -212,13 +212,17 @@ export type AtmosphereAuthorFeedFilter =
 	| 'posts_with_media'
 	| 'posts_and_author_threads';
 
-// Optional metadata embedded in the tag-feed response. The AppView's
-// `hitsTotal` is documented as approximate and may be absent, so `count`
-// is optional; `url` is also optional in case the backend omits it.
+// Metadata embedded in the tag-feed response. The backend always emits
+// the `tag` block; `count` is `null` when the AppView's `hitsTotal` is
+// absent (it is documented as approximate). `url` is currently always
+// present, kept optional so a future backend that omits it for an
+// invalid hashtag does not break the type.
 export interface AtmosphereTagInfo {
 	name: string;
-	// Approximate post count from the AppView's `hitsTotal`.
-	count?: number;
+	// Approximate post count from the AppView's `hitsTotal`. Null when
+	// the AppView omits the field; consumers should hide the count line
+	// rather than render a placeholder.
+	count: number | null;
 	// Canonical bsky.app hashtag URL (e.g. `https://bsky.app/hashtag/rust`).
 	// Built server-side as `https://bsky.app/hashtag/<encoded>`, but
 	// consumers should re-validate the protocol before rendering as

--- a/packages/api-core/src/reader-atmosphere/types.ts
+++ b/packages/api-core/src/reader-atmosphere/types.ts
@@ -211,3 +211,25 @@ export type AtmosphereAuthorFeedFilter =
 	| 'posts_with_replies'
 	| 'posts_with_media'
 	| 'posts_and_author_threads';
+
+// Optional metadata embedded in the tag-feed response. The backend MAY
+// include nothing today (the public AppView's `hitsTotal` is documented
+// as "may be rounded/truncated" and is sometimes absent); render hashtag
+// name as a plain header and only show `count` / `url` when set.
+export interface AtmosphereTagInfo {
+	name: string;
+	// Approximate post count from the AppView's `hitsTotal`. Render as a
+	// "N posts" line under the hashtag header; omit the line when undefined.
+	count?: number;
+	// Canonical bsky.app hashtag URL (e.g. `https://bsky.app/hashtag/rust`).
+	// Provided so we can offer an external "View on Bluesky" link. Always
+	// `https:`-validated server-side, but consumers should validate again
+	// before rendering as a defence-in-depth.
+	url?: string;
+}
+
+export interface AtmosphereTagFeedPage {
+	items: AtmosphereFeedItem[];
+	cursor: string | null;
+	tag?: AtmosphereTagInfo;
+}

--- a/packages/api-core/src/reader-atmosphere/types.ts
+++ b/packages/api-core/src/reader-atmosphere/types.ts
@@ -212,19 +212,17 @@ export type AtmosphereAuthorFeedFilter =
 	| 'posts_with_media'
 	| 'posts_and_author_threads';
 
-// Optional metadata embedded in the tag-feed response. The backend MAY
-// include nothing today (the public AppView's `hitsTotal` is documented
-// as "may be rounded/truncated" and is sometimes absent); render hashtag
-// name as a plain header and only show `count` / `url` when set.
+// Optional metadata embedded in the tag-feed response. The AppView's
+// `hitsTotal` is documented as approximate and may be absent, so `count`
+// is optional; `url` is also optional in case the backend omits it.
 export interface AtmosphereTagInfo {
 	name: string;
-	// Approximate post count from the AppView's `hitsTotal`. Render as a
-	// "N posts" line under the hashtag header; omit the line when undefined.
+	// Approximate post count from the AppView's `hitsTotal`.
 	count?: number;
 	// Canonical bsky.app hashtag URL (e.g. `https://bsky.app/hashtag/rust`).
-	// Provided so we can offer an external "View on Bluesky" link. Always
-	// `https:`-validated server-side, but consumers should validate again
-	// before rendering as a defence-in-depth.
+	// Built server-side as `https://bsky.app/hashtag/<encoded>`, but
+	// consumers should re-validate the protocol before rendering as
+	// defence-in-depth against a future backend regression.
 	url?: string;
 }
 

--- a/packages/api-core/src/reader-atmosphere/validation.ts
+++ b/packages/api-core/src/reader-atmosphere/validation.ts
@@ -1,0 +1,14 @@
+// Bluesky hashtag canonical form: Unicode letters/numbers/marks/underscore,
+// 1-64 chars. The 64-char cap matches Bluesky's tag-length limit (64
+// graphemes — chars ≈ graphemes for the common case). Anchored,
+// single-line, lowercase-strict so the in-app route shape is canonical.
+//
+// The frontend regex mirrors the wpcom backend's hashtag validator —
+// keep them in sync. Tags that fail validation fall through to bsky.app
+// via the click-handler in post-card-body, so the regex is the safe-set
+// guarantee, not a strict spec match.
+export const HASHTAG_RE = /^[\p{L}\p{N}\p{M}_]{1,64}$/u;
+
+export function isValidHashtag( hashtag: string ): boolean {
+	return HASHTAG_RE.test( hashtag );
+}

--- a/packages/api-queries/src/reader-atmosphere.ts
+++ b/packages/api-queries/src/reader-atmosphere.ts
@@ -1,5 +1,6 @@
 import {
 	createConnection,
+	getAtmosphereTagFeed,
 	getAuthorFeed,
 	getAuthorProfile,
 	getConnection,
@@ -26,6 +27,7 @@ import type {
 	AtmosphereConnectionsResponse,
 	AtmosphereCreateConnectionResponse,
 	AtmosphereError,
+	AtmosphereTagFeedPage,
 	AtmosphereThreadResponse,
 	AtmosphereTimelinePage,
 	CreateConnectionParams,
@@ -192,4 +194,34 @@ export interface UseAuthorFeedInfiniteQueryParams {
 
 export function useAuthorFeedInfiniteQuery( { actor, filter }: UseAuthorFeedInfiniteQueryParams ) {
 	return useInfiniteQuery( authorFeedInfiniteQuery( actor, filter ) );
+}
+
+export const atmosphereTagFeedInfiniteQuery = ( connectionId: number, hashtag: string ) => {
+	const canonicalHashtag = hashtag.trim().toLowerCase().replace( /^#/, '' );
+	return infiniteQueryOptions<
+		AtmosphereTagFeedPage,
+		AtmosphereError,
+		InfiniteData< AtmosphereTagFeedPage >,
+		QueryKey,
+		string | undefined
+	>( {
+		queryKey: readerAtmosphereKeys.tagFeed( connectionId, canonicalHashtag ),
+		queryFn: ( { pageParam } ) =>
+			getAtmosphereTagFeed( { connectionId, hashtag: canonicalHashtag, cursor: pageParam } ),
+		initialPageParam: undefined,
+		getNextPageParam: ( lastPage ) => lastPage.cursor || undefined,
+		enabled: connectionId > 0 && canonicalHashtag.length > 0,
+		staleTime: 30_000,
+		gcTime: 5 * 60_000,
+		retry: ( failureCount, error ) => {
+			if ( isTerminalError( error ) ) {
+				return false;
+			}
+			return failureCount < 2;
+		},
+	} );
+};
+
+export function useAtmosphereTagFeedInfiniteQuery( connectionId: number, hashtag: string ) {
+	return useInfiniteQuery( atmosphereTagFeedInfiniteQuery( connectionId, hashtag ) );
 }

--- a/packages/api-queries/src/reader-atmosphere.ts
+++ b/packages/api-queries/src/reader-atmosphere.ts
@@ -7,6 +7,7 @@ import {
 	getConnections,
 	getThread,
 	getTimeline,
+	isValidHashtag,
 	readerAtmosphereKeys,
 } from '@automattic/api-core';
 import {
@@ -210,7 +211,7 @@ export const atmosphereTagFeedInfiniteQuery = ( connectionId: number, hashtag: s
 			getAtmosphereTagFeed( { connectionId, hashtag: canonicalHashtag, cursor: pageParam } ),
 		initialPageParam: undefined,
 		getNextPageParam: ( lastPage ) => lastPage.cursor || undefined,
-		enabled: connectionId > 0 && canonicalHashtag.length > 0,
+		enabled: connectionId > 0 && isValidHashtag( canonicalHashtag ),
 		staleTime: 30_000,
 		gcTime: 5 * 60_000,
 		retry: ( failureCount, error ) => {


### PR DESCRIPTION
Fixes CM-650

## Proposed Changes

* Add a new in-app route `/reader/atmosphere/:id/tag/:hashtag` that mounts a hashtag-scoped feed for a Bluesky connection.
* Add `TagFeedView` (resolves the connection, handles loading / error / redirect-on-stale-id) and `TagFeedPanel` (renders the feed, header, optional `count` line, optional `View on Bluesky` external link).
* Add the typed fetcher `getAtmosphereTagFeed`, query factory `atmosphereTagFeedInfiniteQuery`, hook `useAtmosphereTagFeedInfiniteQuery`, query keys, and `AtmosphereTagInfo` / `AtmosphereTagFeedPage` types in `@automattic/api-core` and `@automattic/api-queries`.
* Wire `getTagUrl` through the existing timeline / thread / author-profile panels' `SocialAnalyticsProvider` so `data-tag` clicks in any Bluesky post body or bio route in-app via `page()`, falling back to bsky.app/hashtag/<tag> when the resolver returns null.
* Share `HASHTAG_RE` / `isValidHashtag` between the route layer and the query factory's `enabled` gate by moving them into `@automattic/api-core` — prevents drift between the controller's validation and the query's gate.
* Ship unit tests for the route helpers, the controller, the panel (analytics events, https-only external-link guard, hashtag-change re-fire, error / retry / back-to-timeline events), the view (loading / redirect / error / happy path), and the fetcher (URL shape, query params, percent-encoding, error classification).

## Why are these changes being made?

Bluesky users expect hashtag links to open an in-app stream the way Mastodon already does (CM-638 shipped the Mastodon equivalent). Without this PR, every `#hashtag` in a Bluesky post body or profile bio kicks the user out of Reader to bsky.app, which breaks the in-app reading flow and loses the analytics surface.

The frontend is gated by the existing `reader/social` feature flag and consumes the wpcom backend endpoint (`/reader/atmosphere/connections/:id/tag/<hashtag>/feed`) that ships in CM-649.

## Testing Instructions

* Confirm the `reader/social` feature is enabled.
* Connect a Bluesky account if you haven't (`/reader/atmosphere/connect`).
* From the Bluesky timeline, find a post body or bio that contains a `#hashtag` and click it. Verify the URL becomes `/reader/atmosphere/<id>/tag/<hashtag>` and the panel renders the heading, optional post count, and optional `View on Bluesky` link.
* Repeat from the in-app thread view and from an author profile — clicking a hashtag should route in-app from each surface.
* Visit `/reader/atmosphere/<id>/tag/<invalid-hashtag>` directly (e.g. `tag-with-hyphen`) — the route should redirect to `/reader/atmosphere/<id>`.
* Visit `/reader/atmosphere/<bad-id>/tag/rust` — the route should redirect to `/reader/atmosphere`.
* While on a tag feed, scroll to the bottom and verify pagination loads the next page; verify the empty state appears for a hashtag with no results.
* Trigger a backend error (e.g., disable the network briefly) and verify the error UI renders with a `Retry` button that re-fetches.
* Click the back button in the panel header and verify it routes to `/reader/atmosphere/<id>/timeline`.
* Confirm new Tracks events fire: `calypso_reader_atmosphere_tag_feed_viewed`, `calypso_reader_atmosphere_tag_feed_error_shown`, `calypso_reader_atmosphere_tag_feed_retry_clicked`, `calypso_reader_atmosphere_tag_feed_back_to_timeline_clicked`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?