### PR TITLE
Dashboard: Open PHP logs pre-filtered to Fatal errors on Critical error screen

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -323,6 +323,9 @@ export const siteLogsPhpRoute = createRoute( {
 	getParentRoute: () => siteLogsRoute,
 	path: 'php',
 	loader: loadSiteLogsRoute,
+	validateSearch: ( search ): { severity?: string } => ( {
+		severity: typeof search.severity === 'string' ? search.severity : undefined,
+	} ),
 } ).lazy( () =>
 	import( '../../sites/logs' ).then( ( d ) =>
 		createLazyRoute( 'site-logs-php' )( {

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -51,6 +51,7 @@ import {
 	canTransferSite,
 	canViewHundredYearPlanSettings,
 } from '../../sites/features';
+import { VALUES_SEVERITY } from '../../sites/logs/dataviews/constants';
 import { shouldLoadWpVersionNotice } from '../../sites/overview/wp-version-notice';
 import { reauthRequiredLink } from '../../utils/link';
 import {
@@ -323,8 +324,8 @@ export const siteLogsPhpRoute = createRoute( {
 	getParentRoute: () => siteLogsRoute,
 	path: 'php',
 	loader: loadSiteLogsRoute,
-	validateSearch: ( search ): { severity?: string } => ( {
-		severity: typeof search.severity === 'string' ? search.severity : undefined,
+	validateSearch: ( search ): { severity?: ( typeof VALUES_SEVERITY )[ number ] } => ( {
+		severity: VALUES_SEVERITY.find( ( v ) => v === search.severity ),
 	} ),
 } ).lazy( () =>
 	import( '../../sites/logs' ).then( ( d ) =>

--- a/client/dashboard/sites/critical-error/index.tsx
+++ b/client/dashboard/sites/critical-error/index.tsx
@@ -78,7 +78,9 @@ const SiteCriticalError = ( { siteSlug }: { siteSlug: string } ) => {
 				__( '<phpLogsLink/> to locate any fatal errors on your site.' ),
 				{
 					phpLogsLink: (
-						<Link to={ `/sites/${ siteSlug }/logs/php` }>{ __( 'Review the PHP logs' ) }</Link>
+						<Link to={ `/sites/${ siteSlug }/logs/php` } search={ { severity: 'Fatal error' } }>
+							{ __( 'Review the PHP logs' ) }
+						</Link>
 					),
 				}
 			),

--- a/client/dashboard/sites/logs/dataviews/constants.ts
+++ b/client/dashboard/sites/logs/dataviews/constants.ts
@@ -1,0 +1,15 @@
+export const VALUES_CACHED = [ 'false', 'true' ] as const;
+export const VALUES_RENDERER = [ 'php', 'static' ] as const;
+export const VALUES_REQUEST_TYPE = [ 'GET', 'HEAD', 'POST', 'PUT', 'DELETE' ] as const;
+export const VALUES_SEVERITY = [ 'User', 'Warning', 'Deprecated', 'Fatal error' ] as const;
+export const VALUES_STATUS = [
+	'200',
+	'301',
+	'302',
+	'400',
+	'401',
+	'403',
+	'404',
+	'429',
+	'500',
+] as const;

--- a/client/dashboard/sites/logs/dataviews/fields.tsx
+++ b/client/dashboard/sites/logs/dataviews/fields.tsx
@@ -6,6 +6,13 @@ import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import { useLocale } from '../../../app/locale';
 import { formatDateCell, getDateTimeLabel } from '../../logs/utils';
+import {
+	VALUES_CACHED,
+	VALUES_RENDERER,
+	VALUES_REQUEST_TYPE,
+	VALUES_SEVERITY,
+	VALUES_STATUS,
+} from './constants';
 import type { Field, Operator, DataViewRenderFieldProps } from '@wordpress/dataviews';
 
 import './style.scss';
@@ -13,12 +20,6 @@ import './style.scss';
 type UseFieldsArgs =
 	| { logType: LogType; timezoneString: string; gmtOffset?: number }
 	| { logType: LogType; timezoneString?: undefined; gmtOffset: number };
-
-const VALUES_CACHED = [ 'false', 'true' ] as const;
-const VALUES_RENDERER = [ 'php', 'static' ] as const;
-const VALUES_REQUEST_TYPE = [ 'GET', 'HEAD', 'POST', 'PUT', 'DELETE' ] as const;
-const VALUES_SEVERITY = [ 'User', 'Warning', 'Deprecated', 'Fatal error' ] as const;
-const VALUES_STATUS = [ '200', '301', '302', '400', '401', '403', '404', '429', '500' ] as const;
 
 const getLabelCached = ( cached: string ) => {
 	switch ( cached ) {

--- a/client/dashboard/sites/logs/dataviews/index.tsx
+++ b/client/dashboard/sites/logs/dataviews/index.tsx
@@ -73,6 +73,7 @@ function SiteLogsDataViews( {
 		slug: `site-logs-${ logType }`,
 		defaultView: logType === LogType.PHP ? DEFAULT_PHP_LOGS_VIEW : DEFAULT_SERVER_LOGS_VIEW,
 		queryParams: search,
+		queryParamFilterFields: logType === LogType.PHP ? [ 'severity' ] : [],
 	} );
 
 	// We want to parse 'from' and 'to' from the URL.

--- a/client/dashboard/sites/logs/dataviews/index.tsx
+++ b/client/dashboard/sites/logs/dataviews/index.tsx
@@ -156,6 +156,9 @@ function SiteLogsDataViews( {
 	}, [] );
 
 	useEffect( () => {
+		if ( ! view.page || view.page === 1 ) {
+			return;
+		}
 		updateView( { ...view, page: 1 } );
 		// eslint-disable-next-line react-hooks/exhaustive-deps -- reset page only when dateRange changes
 	}, [ dateRangeVersion ] );

--- a/client/sites/overview/components/critical-error/index.tsx
+++ b/client/sites/overview/components/critical-error/index.tsx
@@ -6,6 +6,7 @@ import { Button, Card, CardBody } from '@wordpress/components';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { Icon, envelope, formatListBullets, help } from '@wordpress/icons';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { HostingHero } from 'calypso/components/hosting-hero';
@@ -78,7 +79,11 @@ export const CriticalErrorOverview = ( { siteSlug }: { siteSlug: string } ) => {
 									translate( '<phpLogsLink/> to locate any fatal errors on your site.' ) as string,
 									{
 										phpLogsLink: (
-											<a href={ `/site-logs/${ siteSlug }/php` }>
+											<a
+												href={ addQueryArgs( `/site-logs/${ siteSlug }/php`, {
+													severity: 'Fatal error',
+												} ) }
+											>
 												{ translate( 'Review the PHP logs' ) }
 											</a>
 										),


### PR DESCRIPTION
## Proposed Changes

* When a user follows the "Review the PHP logs" link from the site critical-error screen, the PHP logs page now opens with the severity filter pre-applied to "Fatal error".
* Added `severity` to `validateSearch` on `siteLogsPhpRoute` so TanStack Router preserves the param.
* Wired `severity` through `usePersistentView` as a transient query-param filter (PHP only).

## Why are these changes being made?

When a site is in a critical error state, the most actionable signal is usually the latest fatal PHP error. Sending the user to an unfiltered logs view makes them re-apply the filter manually before they can see what's wrong. Pre-filtering to Fatal errors closes that gap.

## Testing Instructions

1. Navigate to a site whose overview redirects to ` /sites/<slug>/critical-error` (or temporarily mock `isInJetpackCriticalErrorState` to return `true`).
2. Click "Review the PHP logs".
3. Confirm the URL is `/sites/<slug>/logs/php?severity=Fatal+error` and the severity filter chip shows "Fatal error" selected with only fatal entries listed.
4. Clear the filter — URL should drop the `severity` param. Re-select another severity — should behave normally.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?

🤖 Generated with [Claude Code](https://claude.com/claude-code)