### PR TITLE
Dashboard: Surface recovery session errors as notices on critical error screen

### DIFF
--- a/client/dashboard/sites/critical-error/index.tsx
+++ b/client/dashboard/sites/critical-error/index.tsx
@@ -2,9 +2,14 @@ import { HostingFeatures } from '@automattic/api-core';
 import { siteBySlugQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Link, useNavigate } from '@tanstack/react-router';
-import { Button, __experimentalHStack as HStack } from '@wordpress/components';
+import {
+	Button,
+	Notice,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Icon, envelope, formatListBullets, help } from '@wordpress/icons';
 import { Fragment, useEffect } from 'react';
 import { useAnalytics } from '../../app/analytics';
@@ -16,6 +21,7 @@ import { Text } from '../../components/text';
 import { hasHostingFeature } from '../../utils/site-features';
 import {
 	getJetpackCriticalErrorMessage,
+	getJetpackRecoverySessionErrors,
 	isInJetpackCriticalErrorState,
 } from '../../utils/site-jetpack-critical-error';
 import { siteTypeSupportsFeature } from '../../utils/site-type-feature-support';
@@ -62,6 +68,7 @@ const SiteCriticalError = ( { siteSlug }: { siteSlug: string } ) => {
 	}, [ hasRecovered, navigate, siteSlug ] );
 
 	const message = getJetpackCriticalErrorMessage( site );
+	const recoveryErrors = isAdmin ? getJetpackRecoverySessionErrors( site ) : [];
 
 	const items: Item[] = [];
 	if ( isAdmin ) {
@@ -114,19 +121,60 @@ const SiteCriticalError = ( { siteSlug }: { siteSlug: string } ) => {
 			}
 			size="small"
 		>
-			<Card>
-				{ items.map( ( item, index ) => (
-					<Fragment key={ index }>
-						<CardBody>
-							<HStack spacing={ 3 } alignment="center" justify="flex-start">
-								<Icon icon={ item.icon } size={ 20 } />
-								<Text>{ item.text }</Text>
-							</HStack>
-						</CardBody>
-						{ index < items.length - 1 && <CardDivider /> }
-					</Fragment>
-				) ) }
-			</Card>
+			<VStack spacing={ 4 }>
+				{ recoveryErrors.length > 0 && (
+					<VStack spacing={ 2 }>
+						{ recoveryErrors.map( ( error, index ) => (
+							<Notice
+								key={ error.signature ?? `${ error.kind }-${ error.slug }-${ index }` }
+								status="error"
+								isDismissible={ false }
+							>
+								<VStack spacing={ 1 }>
+									<Text weight={ 500 }>
+										{ sprintf(
+											/* translators: 1: extension type (e.g. "plugin"), 2: extension slug */
+											__( 'Error in %1$s: %2$s' ),
+											error.kind,
+											error.slug
+										) }
+										{ error.version
+											? ' ' +
+											  sprintf(
+													/* translators: %s: extension version */
+													__( '(v%s)' ),
+													error.version
+											  )
+											: '' }
+									</Text>
+									<Text>{ error.message }</Text>
+									<Text variant="muted">
+										{ sprintf(
+											/* translators: 1: file path, 2: line number */
+											__( '%1$s:%2$d' ),
+											error.file,
+											error.line
+										) }
+									</Text>
+								</VStack>
+							</Notice>
+						) ) }
+					</VStack>
+				) }
+				<Card>
+					{ items.map( ( item, index ) => (
+						<Fragment key={ index }>
+							<CardBody>
+								<HStack spacing={ 3 } alignment="center" justify="flex-start">
+									<Icon icon={ item.icon } size={ 20 } />
+									<Text>{ item.text }</Text>
+								</HStack>
+							</CardBody>
+							{ index < items.length - 1 && <CardDivider /> }
+						</Fragment>
+					) ) }
+				</Card>
+			</VStack>
 		</PageLayout>
 	);
 };

--- a/client/dashboard/sites/critical-error/index.tsx
+++ b/client/dashboard/sites/critical-error/index.tsx
@@ -4,7 +4,6 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { Link, useNavigate } from '@tanstack/react-router';
 import {
 	Button,
-	Notice,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
@@ -15,8 +14,10 @@ import { Fragment, useEffect } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { useHelpCenter } from '../../app/help-center';
 import { Card, CardBody, CardDivider } from '../../components/card';
+import { Notice } from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import { SectionHeader } from '../../components/section-header';
 import { Text } from '../../components/text';
 import { hasHostingFeature } from '../../utils/site-features';
 import {
@@ -25,6 +26,7 @@ import {
 	isInJetpackCriticalErrorState,
 } from '../../utils/site-jetpack-critical-error';
 import { siteTypeSupportsFeature } from '../../utils/site-type-feature-support';
+import type { JetpackRecoverySessionError } from '@automattic/api-core';
 import type { ReactElement, ReactNode } from 'react';
 
 type Item = {
@@ -35,6 +37,31 @@ type Item = {
 // Poll while the user is on the critical-error screen so we can send them back
 // to the overview as soon as the site comes back online.
 const RECOVERY_POLL_INTERVAL_MS = 30_000;
+
+const RecoveryErrorNotice = ( { error }: { error: JetpackRecoverySessionError } ) => (
+	<VStack spacing={ 3 }>
+		<SectionHeader
+			level={ 3 }
+			title={ error.kind === 'themes' ? __( 'Suspected theme' ) : __( 'Suspected plugin' ) }
+		/>
+		<Notice variant="error">
+			<VStack spacing={ 1 }>
+				<Text weight={ 500 }>
+					{ error.version ? `${ error.slug } (v${ error.version })` : error.slug }
+				</Text>
+				<Text>{ error.message }</Text>
+				<Text variant="muted">
+					{ sprintf(
+						/* translators: 1: file path, 2: line number */
+						__( '%1$s:%2$d' ),
+						error.file,
+						error.line
+					) }
+				</Text>
+			</VStack>
+		</Notice>
+	</VStack>
+);
 
 const SiteCriticalError = ( { siteSlug }: { siteSlug: string } ) => {
 	const { data: site } = useSuspenseQuery( {
@@ -74,7 +101,11 @@ const SiteCriticalError = ( { siteSlug }: { siteSlug: string } ) => {
 	if ( isAdmin ) {
 		items.push( {
 			icon: envelope,
-			text: __( 'Check your site admin email inbox for instructions to troubleshoot.' ),
+			text: createInterpolateElement(
+				// translators: <q/> is the search phrase to use in the email inbox.
+				__( 'Search your admin email inbox for <q/> for troubleshooting instructions.' ),
+				{ q: <strong>{ __( 'critical error' ) }</strong> }
+			),
 		} );
 	}
 	if ( canAccessPhpLogs ) {
@@ -122,58 +153,28 @@ const SiteCriticalError = ( { siteSlug }: { siteSlug: string } ) => {
 			size="small"
 		>
 			<VStack spacing={ 4 }>
-				{ recoveryErrors.length > 0 && (
-					<VStack spacing={ 2 }>
-						{ recoveryErrors.map( ( error, index ) => (
-							<Notice
-								key={ error.signature ?? `${ error.kind }-${ error.slug }-${ index }` }
-								status="error"
-								isDismissible={ false }
-							>
-								<VStack spacing={ 1 }>
-									<Text weight={ 500 }>
-										{ sprintf(
-											/* translators: 1: extension type (e.g. "plugin"), 2: extension slug */
-											__( 'Error in %1$s: %2$s' ),
-											error.kind,
-											error.slug
-										) }
-										{ error.version
-											? ' ' +
-											  sprintf(
-													/* translators: %s: extension version */
-													__( '(v%s)' ),
-													error.version
-											  )
-											: '' }
-									</Text>
-									<Text>{ error.message }</Text>
-									<Text variant="muted">
-										{ sprintf(
-											/* translators: 1: file path, 2: line number */
-											__( '%1$s:%2$d' ),
-											error.file,
-											error.line
-										) }
-									</Text>
-								</VStack>
-							</Notice>
+				{ recoveryErrors.map( ( error, index ) => (
+					<RecoveryErrorNotice
+						key={ error.signature ?? `${ error.kind }-${ error.slug }-${ index }` }
+						error={ error }
+					/>
+				) ) }
+				<VStack spacing={ 3 }>
+					<SectionHeader level={ 3 } title={ __( 'What you can try next' ) } />
+					<Card>
+						{ items.map( ( item, index ) => (
+							<Fragment key={ index }>
+								<CardBody>
+									<HStack spacing={ 3 } alignment="center" justify="flex-start">
+										<Icon icon={ item.icon } size={ 20 } />
+										<Text>{ item.text }</Text>
+									</HStack>
+								</CardBody>
+								{ index < items.length - 1 && <CardDivider /> }
+							</Fragment>
 						) ) }
-					</VStack>
-				) }
-				<Card>
-					{ items.map( ( item, index ) => (
-						<Fragment key={ index }>
-							<CardBody>
-								<HStack spacing={ 3 } alignment="center" justify="flex-start">
-									<Icon icon={ item.icon } size={ 20 } />
-									<Text>{ item.text }</Text>
-								</HStack>
-							</CardBody>
-							{ index < items.length - 1 && <CardDivider /> }
-						</Fragment>
-					) ) }
-				</Card>
+					</Card>
+				</VStack>
 			</VStack>
 		</PageLayout>
 	);

--- a/client/dashboard/sites/critical-error/index.tsx
+++ b/client/dashboard/sites/critical-error/index.tsx
@@ -103,7 +103,9 @@ const SiteCriticalError = ( { siteSlug }: { siteSlug: string } ) => {
 			icon: envelope,
 			text: createInterpolateElement(
 				// translators: <q/> is the search phrase to use in the email inbox.
-				__( 'Search your admin email inbox for <q/> for troubleshooting instructions.' ),
+				__(
+					'Search your admin email inbox for the keyword <q/> for troubleshooting instructions.'
+				),
 				{ q: <strong>{ __( 'critical error' ) }</strong> }
 			),
 		} );
@@ -155,7 +157,7 @@ const SiteCriticalError = ( { siteSlug }: { siteSlug: string } ) => {
 			<VStack spacing={ 4 }>
 				{ recoveryErrors.map( ( error, index ) => (
 					<RecoveryErrorNotice
-						key={ error.signature ?? `${ error.kind }-${ error.slug }-${ index }` }
+						key={ `${ error.kind }-${ error.slug }-${ index }` }
 						error={ error }
 					/>
 				) ) }

--- a/client/dashboard/utils/site-jetpack-critical-error.ts
+++ b/client/dashboard/utils/site-jetpack-critical-error.ts
@@ -52,6 +52,8 @@ export function getJetpackCriticalErrorMessage( site: Site ): string | null {
 
 	const isAdmin = !! site.capabilities?.manage_options;
 	return isAdmin
-		? __( 'There has been a critical error on this site. Here’s what you can try next:' )
+		? __(
+				'There has been a critical error on this website. Here is what we know and what you can do next.'
+		  )
 		: __( 'There has been a critical error on this site. A site administrator has been notified.' );
 }

--- a/client/dashboard/utils/site-jetpack-critical-error.ts
+++ b/client/dashboard/utils/site-jetpack-critical-error.ts
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import type { Site } from '@automattic/api-core';
+import type { JetpackRecoverySessionError, Site } from '@automattic/api-core';
 
 const FIFTEEN_MINUTES = 15 * 60;
 
@@ -39,6 +39,10 @@ export function hasJetpackCriticalError( site: Site ): boolean {
 // Criteria for being redirected to /critical-error.
 export function isInJetpackCriticalErrorState( site: Site ): boolean {
 	return !! site.__inaccessible_jetpack_error && hasJetpackCriticalError( site );
+}
+
+export function getJetpackRecoverySessionErrors( site: Site ): JetpackRecoverySessionError[] {
+	return site.options?.jetpack_recovery_mode_status?.recovery_session_errors ?? [];
 }
 
 export function getJetpackCriticalErrorMessage( site: Site ): string | null {

--- a/client/sites/overview/components/critical-error/index.tsx
+++ b/client/sites/overview/components/critical-error/index.tsx
@@ -2,7 +2,7 @@ import { HostingFeatures } from '@automattic/api-core';
 import { siteBySlugQuery } from '@automattic/api-queries';
 import { HelpCenter } from '@automattic/data-stores';
 import { useQuery } from '@tanstack/react-query';
-import { Button, Card, CardBody } from '@wordpress/components';
+import { Button, Card, CardBody, __experimentalVStack as VStack } from '@wordpress/components';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { Icon, envelope, formatListBullets, help } from '@wordpress/icons';
@@ -10,15 +10,49 @@ import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { HostingHero } from 'calypso/components/hosting-hero';
+import { Notice } from 'calypso/dashboard/components/notice';
+import { SectionHeader } from 'calypso/dashboard/components/section-header';
+import { Text } from 'calypso/dashboard/components/text';
 import { hasHostingFeature } from 'calypso/dashboard/utils/site-features';
-import { getJetpackCriticalErrorMessage } from 'calypso/dashboard/utils/site-jetpack-critical-error';
+import {
+	getJetpackCriticalErrorMessage,
+	getJetpackRecoverySessionErrors,
+} from 'calypso/dashboard/utils/site-jetpack-critical-error';
 import { siteTypeSupportsFeature } from 'calypso/dashboard/utils/site-type-feature-support';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import type { JetpackRecoverySessionError } from '@automattic/api-core';
 import type { ReactElement, ReactNode } from 'react';
 
 import './style.scss';
 
 const HELP_CENTER_STORE = HelpCenter.register();
+
+const RecoveryErrorNotice = ( { error }: { error: JetpackRecoverySessionError } ) => {
+	const translate = useTranslate();
+	return (
+		<VStack spacing={ 3 }>
+			<SectionHeader
+				level={ 3 }
+				title={
+					error.kind === 'themes' ? translate( 'Suspected theme' ) : translate( 'Suspected plugin' )
+				}
+			/>
+			<Notice variant="error">
+				<VStack spacing={ 1 }>
+					<Text weight={ 500 }>
+						{ error.version ? `${ error.slug } (v${ error.version })` : error.slug }
+					</Text>
+					<Text>{ error.message }</Text>
+					<Text variant="muted">
+						{ translate( '%(file)s:%(line)d', {
+							args: { file: error.file, line: error.line },
+						} ) }
+					</Text>
+				</VStack>
+			</Notice>
+		</VStack>
+	);
+};
 
 const Item = ( { icon, children }: { icon: ReactElement; children: ReactNode } ) => (
 	<div className="critical-error-overview__item">
@@ -53,6 +87,7 @@ export const CriticalErrorOverview = ( { siteSlug }: { siteSlug: string } ) => {
 		hasHostingFeature( site, HostingFeatures.LOGS );
 
 	const message = getJetpackCriticalErrorMessage( site );
+	const recoveryErrors = isAdmin ? getJetpackRecoverySessionErrors( site ) : [];
 
 	return (
 		// Wrapper class is also used by the `:has()` override in style.scss to
@@ -62,13 +97,27 @@ export const CriticalErrorOverview = ( { siteSlug }: { siteSlug: string } ) => {
 				<h1>{ translate( 'Your site cannot currently be reached' ) }</h1>
 				<p>{ message }</p>
 			</HostingHero>
+			{ recoveryErrors.length > 0 && (
+				<VStack spacing={ 4 } className="critical-error-overview__recovery-errors">
+					{ recoveryErrors.map( ( error, index ) => (
+						<RecoveryErrorNotice
+							key={ `${ error.kind }-${ error.slug }-${ index }` }
+							error={ error }
+						/>
+					) ) }
+				</VStack>
+			) }
 			<Card className="critical-error-overview__card">
 				<CardBody>
 					<div className="critical-error-overview__items">
 						{ isAdmin && (
 							<Item icon={ envelope }>
-								{ translate(
-									'Check your site admin email inbox for instructions to troubleshoot.'
+								{ createInterpolateElement(
+									// translators: <q/> is the search phrase to use in the email inbox.
+									translate(
+										'Search your admin email inbox for the keyword <q/> for troubleshooting instructions.'
+									) as string,
+									{ q: <strong>{ translate( 'critical error' ) }</strong> }
 								) }
 							</Item>
 						) }

--- a/client/sites/overview/components/critical-error/index.tsx
+++ b/client/sites/overview/components/critical-error/index.tsx
@@ -98,7 +98,7 @@ export const CriticalErrorOverview = ( { siteSlug }: { siteSlug: string } ) => {
 				<p>{ message }</p>
 			</HostingHero>
 			{ recoveryErrors.length > 0 && (
-				<VStack spacing={ 4 } className="critical-error-overview__recovery-errors">
+				<VStack spacing={ 0 } className="critical-error-overview__recovery-errors">
 					{ recoveryErrors.map( ( error, index ) => (
 						<RecoveryErrorNotice
 							key={ `${ error.kind }-${ error.slug }-${ index }` }
@@ -107,60 +107,65 @@ export const CriticalErrorOverview = ( { siteSlug }: { siteSlug: string } ) => {
 					) ) }
 				</VStack>
 			) }
-			<Card className="critical-error-overview__card">
-				<CardBody>
-					<div className="critical-error-overview__items">
-						{ isAdmin && (
-							<Item icon={ envelope }>
+			<VStack spacing={ 3 } className="critical-error-overview__next-steps">
+				<SectionHeader level={ 3 } title={ translate( 'What you can try next' ) } />
+				<Card>
+					<CardBody>
+						<div className="critical-error-overview__items">
+							{ isAdmin && (
+								<Item icon={ envelope }>
+									{ createInterpolateElement(
+										// translators: <q/> is the search phrase to use in the email inbox.
+										translate(
+											'Search your admin email inbox for the keyword <q/> for troubleshooting instructions.'
+										) as string,
+										{ q: <strong>{ translate( 'critical error' ) }</strong> }
+									) }
+								</Item>
+							) }
+							{ canAccessPhpLogs && (
+								<Item icon={ formatListBullets }>
+									{ createInterpolateElement(
+										// translators: <phpLogsLink/> is a link to the PHP logs page with the text "Review the PHP logs"
+										translate(
+											'<phpLogsLink/> to locate any fatal errors on your site.'
+										) as string,
+										{
+											phpLogsLink: (
+												<a
+													href={ addQueryArgs( `/site-logs/${ siteSlug }/php`, {
+														severity: 'Fatal error',
+													} ) }
+												>
+													{ translate( 'Review the PHP logs' ) }
+												</a>
+											),
+										}
+									) }
+								</Item>
+							) }
+							<Item icon={ help }>
 								{ createInterpolateElement(
-									// translators: <q/> is the search phrase to use in the email inbox.
 									translate(
-										'Search your admin email inbox for the keyword <q/> for troubleshooting instructions.'
+										'<button>Contact WordPress.com support</button> and we will help you get back online.'
 									) as string,
-									{ q: <strong>{ translate( 'critical error' ) }</strong> }
-								) }
-							</Item>
-						) }
-						{ canAccessPhpLogs && (
-							<Item icon={ formatListBullets }>
-								{ createInterpolateElement(
-									// translators: <phpLogsLink/> is a link to the PHP logs page with the text "Review the PHP logs"
-									translate( '<phpLogsLink/> to locate any fatal errors on your site.' ) as string,
 									{
-										phpLogsLink: (
-											<a
-												href={ addQueryArgs( `/site-logs/${ siteSlug }/php`, {
-													severity: 'Fatal error',
-												} ) }
-											>
-												{ translate( 'Review the PHP logs' ) }
-											</a>
+										button: (
+											<Button
+												variant="link"
+												onClick={ () => {
+													recordTracksEvent( 'calypso_critical_error_contact_support_click' );
+													setShowHelpCenter( true );
+												} }
+											/>
 										),
 									}
 								) }
 							</Item>
-						) }
-						<Item icon={ help }>
-							{ createInterpolateElement(
-								translate(
-									'<button>Contact WordPress.com support</button> and we will help you get back online.'
-								) as string,
-								{
-									button: (
-										<Button
-											variant="link"
-											onClick={ () => {
-												recordTracksEvent( 'calypso_critical_error_contact_support_click' );
-												setShowHelpCenter( true );
-											} }
-										/>
-									),
-								}
-							) }
-						</Item>
-					</div>
-				</CardBody>
-			</Card>
+						</div>
+					</CardBody>
+				</Card>
+			</VStack>
 		</div>
 	);
 };

--- a/client/sites/overview/components/critical-error/style.scss
+++ b/client/sites/overview/components/critical-error/style.scss
@@ -3,9 +3,14 @@
 }
 
 .critical-error-overview {
-	.critical-error-overview__card {
+	.critical-error-overview__card,
+	.critical-error-overview__recovery-errors {
 		max-width: 480px;
 		margin: 0 auto;
+	}
+
+	.critical-error-overview__recovery-errors {
+		margin-block-end: 1.5rem;
 	}
 
 	.critical-error-overview__items {

--- a/client/sites/overview/components/critical-error/style.scss
+++ b/client/sites/overview/components/critical-error/style.scss
@@ -3,14 +3,10 @@
 }
 
 .critical-error-overview {
-	.critical-error-overview__card,
+	.critical-error-overview__next-steps,
 	.critical-error-overview__recovery-errors {
 		max-width: 480px;
 		margin: 0 auto;
-	}
-
-	.critical-error-overview__recovery-errors {
-		margin-block-end: 1.5rem;
 	}
 
 	.critical-error-overview__items {

--- a/packages/api-core/src/site/types.ts
+++ b/packages/api-core/src/site/types.ts
@@ -6,7 +6,6 @@ export interface JetpackRecoverySessionError {
 	message: string;
 	file: string;
 	line: number;
-	signature?: string;
 }
 
 interface SitePlan {

--- a/packages/api-core/src/site/types.ts
+++ b/packages/api-core/src/site/types.ts
@@ -1,3 +1,14 @@
+export interface JetpackRecoverySessionError {
+	kind: string;
+	slug: string;
+	version?: string;
+	errno: number;
+	message: string;
+	file: string;
+	line: number;
+	signature?: string;
+}
+
 interface SitePlan {
 	product_id: number;
 	product_slug: string;
@@ -31,6 +42,7 @@ export interface SiteOptions {
 		recovery_mode_email_last_sent?: number;
 		recovery_session_entered_at?: number;
 		recovery_session_exited_at?: number;
+		recovery_session_errors?: JetpackRecoverySessionError[];
 	} | null;
 	migration_source_site_domain?: string;
 	p2_hub_blog_id?: number;


### PR DESCRIPTION
Follow-up https://github.com/Automattic/jetpack/pull/48440

## Proposed Changes

* Extend the `Site.options.jetpack_recovery_mode_status` type with `recovery_session_errors` (kind / slug / version / errno / message / file / line / signature) in `@automattic/api-core`.
* Add `getJetpackRecoverySessionErrors()` helper in `site-jetpack-critical-error.ts`.
* On the critical-error screen, render each recovery session error (admin-only) as a `SectionHeader` ("Suspected plugin" / "Suspected theme") followed by an error `Notice` showing slug + version, message, and `file:line`, mirroring the wpcomsh fatal-error template.
* Add a "What you can try next" `SectionHeader` above the existing action card.
* Refine the inbox-search hint to give admins the search phrase: *Search your admin email inbox for **critical error** for troubleshooting instructions.*
* Update intro copy to "There has been a critical error on this website. Here is what we know and what you can do next."

<img width="750" height="550" alt="image" src="https://github.com/user-attachments/assets/3b34b6f3-0bdc-4df6-a134-46abaa46d142" />


## Why are these changes being made?

The Jetpack recovery-mode payload now includes per-extension fatal error details. Surfacing them directly on the critical-error screen lets the site owner identify the offending plugin/theme without first navigating to the PHP logs, and the new structure mirrors the wpcomsh white-screen template so the in-app and email-linked experiences stay consistent.

## Testing Instructions

1. Navigate to a site whose `options.jetpack_recovery_mode_status.recovery_session_errors` contains entries (or temporarily mock `isInJetpackCriticalErrorState` to return `true` and seed `getJetpackRecoverySessionErrors` with a fixture entry).
2. Visit `/sites/<slug>/critical-error`.
3. As an admin, confirm each error renders as: a "Suspected plugin" / "Suspected theme" SectionHeader, then a red Notice containing **slug (vversion)**, the error message, and a muted `file:line` line.
4. Confirm the action card is preceded by a "What you can try next" SectionHeader, and the email-inbox item highlights `critical error` as a bold search term.
5. Non-admins see no error notices (privacy: error contents are admin-only).

## Notes

* A "Deactivate plugin" CTA was prototyped on the Notice but removed — the wpcom plugin endpoint can't reach a site in recovery / critical-error state, so the action would always fail. A dedicated recovery-mode endpoint would be needed first.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?

🤖 Generated with [Claude Code](https://claude.com/claude-code)