### PR TITLE
Login: improve Lost Password link placement and Support link target (DOTOBRD-412)

### DIFF
--- a/client/blocks/login/lost-password-form.jsx
+++ b/client/blocks/login/lost-password-form.jsx
@@ -195,14 +195,6 @@ const LostPasswordForm = ( {
 					ref={ inputRef }
 				/>
 				{ showError && <FormInputValidation isError text={ error } /> }
-				<ExternalLink
-					href={ localizeUrl(
-						'https://wordpress.com/support/account-recovery/#verify-your-account-ownership',
-						locale
-					) }
-				>
-					{ translate( 'Need more help?' ) }
-				</ExternalLink>
 			</div>
 			<div className="login__form-action">
 				<Button
@@ -214,6 +206,16 @@ const LostPasswordForm = ( {
 				>
 					{ isBusy && isWoo ? <Spinner /> : translate( 'Reset my password' ) }
 				</Button>
+			</div>
+			<div className="login__form-help">
+				<ExternalLink
+					href={ localizeUrl(
+						'https://wordpress.com/support/account-recovery/#verify-your-account-ownership',
+						locale
+					) }
+				>
+					{ translate( 'Need more help?' ) }
+				</ExternalLink>
 			</div>
 		</form>
 	);

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -181,14 +181,13 @@ $breakpoint-mobile: 782px; //Mobile size.
 
 }
 
-// Ensure inline support links beside the form inputs inherit the subheader styling
-// without needing bespoke classes on the JSX.
-.login__form-userdata .components-external-link {
+.login__form-help .components-external-link {
 	color: var(--studio-gray-50, #646970);
 	font-weight: 400;
 	font-size: $font-body-small;
 	text-align: center;
 	display: block;
+	margin-block-start: 16px;
 
 	&:visited,
 	&:hover,

--- a/client/blocks/login/test/lost-password-form.jsx
+++ b/client/blocks/login/test/lost-password-form.jsx
@@ -155,6 +155,17 @@ describe( 'LostPasswordForm', () => {
 		expect( screen.queryByRole( 'alert' ) ).toBeNull();
 	} );
 
+	test( 'renders the "Need more help?" link below the submit button', () => {
+		render( <LostPasswordForm redirectToAfterLoginUrl="" oauth2ClientId="" locale="" /> );
+
+		const btn = screen.getByRole( 'button', { name: /Reset my password/i } );
+		const helpLink = screen.getByRole( 'link', { name: /Need more help/i } );
+
+		// eslint-disable-next-line no-bitwise
+		const isFollowing = btn.compareDocumentPosition( helpLink ) & Node.DOCUMENT_POSITION_FOLLOWING;
+		expect( isFollowing ).toBeTruthy();
+	} );
+
 	test( 'handles error messages coming from /wp-login.php?action=lostpassword', async () => {
 		const mockHTMLResponse = `
 			<body id="error-page">

--- a/client/login/wp-login/components/one-login-footer.scss
+++ b/client/login/wp-login/components/one-login-footer.scss
@@ -11,6 +11,16 @@
 		text-decoration: underline;
 		padding: 0;
 		height: auto;
+
+		// For ExternalLink-rendered footer links, only underline the text content
+		// so the trailing "opens in new tab" arrow icon stays clean.
+		&.components-external-link {
+			text-decoration: none;
+
+			.components-external-link__contents {
+				text-decoration: underline;
+			}
+		}
 	}
 
 	.one-login__footer-links-wrapper {

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -225,6 +225,8 @@ export class Login extends Component {
 			<a
 				className="one-login__footer-link"
 				href="/support/category/manage-your-account/account-settings/"
+				target="_blank"
+				rel="noopener noreferrer"
 			>
 				{ this.props.translate( 'Support' ) }
 			</a>

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -1,6 +1,7 @@
 import page from '@automattic/calypso-router';
 import { Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { ExternalLink } from '@wordpress/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
@@ -222,14 +223,12 @@ export class Login extends Component {
 
 	getSupportLink() {
 		return (
-			<a
+			<ExternalLink
 				className="one-login__footer-link"
 				href="/support/category/manage-your-account/account-settings/"
-				target="_blank"
-				rel="noopener noreferrer"
 			>
 				{ this.props.translate( 'Support' ) }
-			</a>
+			</ExternalLink>
 		);
 	}
 


### PR DESCRIPTION
Part of DOTOBRD-412

## Proposed Changes

* On the Lost Password form (`client/blocks/login/lost-password-form.jsx`), move the "Need more help?" external link from inside the email-input group to a dedicated `.login__form-help` wrapper rendered below the primary "Reset my password" button.
* Rename the matching rule in `client/blocks/login/style.scss` from `.login__form-userdata .components-external-link` to `.login__form-help .components-external-link`, add `margin-block-start: 16px` for spacing under the CTA, and drop the now-stale comment.
* In `client/login/wp-login/index.jsx`, add `target="_blank" rel="noopener noreferrer"` to the footer "Support" link returned by `getSupportLink()` so users keep their context when consulting the help docs.

## Why are these changes being made?

DOTOBRD-412 reports two usability issues on the password-reset screen:

1. The "Need more help?" link was rendered above the primary CTA, competing with the main action. Moving it below preserves the help affordance while letting the CTA remain the focal point.
2. The footer "Support" link opened in the same tab, dropping users out of the recovery flow. Opening it in a new tab keeps the recovery context intact while users consult the docs.

The "Need more help?" link uses `<ExternalLink>` from `@wordpress/components`, which already sets `target="_blank"` and shows an external-link icon, so no additional change was needed for that link's tab behaviour. The footer Support link, however, is a plain `<a>` and needed the explicit attributes.

**Before**
<img width="1725" height="807" alt="SCR-20260502-ljzx" src="https://github.com/user-attachments/assets/a914fc08-45f1-4ab8-b42f-43c297861082" />

**After**

<img width="1640" height="753" alt="SCR-20260502-cxdo" src="https://github.com/user-attachments/assets/67e0f2d3-6e64-4f93-b699-6307c53373d2" />


## Testing Instructions

1. Visit `/log-in/lostpassword` (logged-out flow).
2. Confirm the "Need more help?" link now sits **below** the "Reset my password" button, with subheader-style gray text and a small top margin.
3. Click "Need more help?" — should open the account-recovery support article in a new tab (existing behaviour, preserved).
4. Click the footer "Support" link — should now open the Account Settings support article in a **new** tab instead of replacing the current page.
5. Confirm the existing form behaviour (validation on input, submit, error states) is unchanged.

> Note: This PR was opened on github.com, so Linear may not auto-update DOTOBRD-412's status. Treating this as review-ready, not actively in development by an engineer.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?