### PR TITLE
Reader: migrate Following stream to React Query (READ-485)

### DIFF
--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -1,10 +1,9 @@
 import warn from '@wordpress/warning';
 import i18n from 'i18n-calypso';
-import { random, map, includes, get } from 'lodash';
+import { random, map } from 'lodash';
 import { buildDiscoverStreamKey, getTagsFromStreamKey } from 'calypso/reader/discover/helper';
 import { keyForPost } from 'calypso/reader/post-key';
 import XPostHelper from 'calypso/reader/xpost-helper';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
@@ -19,6 +18,22 @@ import {
 	receiveUpdates,
 	receiveStreamError,
 } from 'calypso/state/reader/streams/actions';
+import {
+	PER_FETCH,
+	INITIAL_FETCH,
+	PER_GAP,
+	QUERY_META,
+	SITE_LIMITER_FIELDS,
+	analyticsForStream,
+	createStreamDataFromPosts,
+	extractPageHandle,
+	getAlgorithmForStream,
+	getQueryString,
+	getQueryStringForPoll,
+} from 'calypso/state/reader/streams/normalize';
+
+// Re-exported for legacy consumers (e.g. client/reader/stream/index.jsx).
+export { PER_FETCH, INITIAL_FETCH, QUERY_META, SITE_LIMITER_FIELDS };
 
 /**
  * Pull the suffix off of a stream key
@@ -41,37 +56,6 @@ function streamKeySuffix( streamKey ) {
 	return streamKey.substring( streamKey.indexOf( ':' ) + 1 );
 }
 
-const analyticsAlgoMap = new Map();
-function analyticsForStream( { streamKey, algorithm, items } ) {
-	if ( ! streamKey || ! algorithm || ! items ) {
-		return [];
-	}
-
-	analyticsAlgoMap.set( streamKey, algorithm );
-
-	const eventName = 'calypso_traintracks_render';
-	const analyticsActions = items
-		.filter( ( item ) => !! item.railcar )
-		.map( ( item ) => recordTracksEvent( eventName, item.railcar ) );
-	return analyticsActions;
-}
-const getAlgorithmForStream = ( streamKey ) => analyticsAlgoMap.get( streamKey );
-
-function createStreamItemFromPost( post, dateProperty ) {
-	return {
-		...keyForPost( post ),
-		date: post[ dateProperty ],
-		...( post.comments && { comments: map( post.comments, 'ID' ).reverse() } ), // include comments for conversations
-		url: post.URL,
-		site_icon: post.site_icon?.ico,
-		site_description: post.description,
-		site_name: post.site_name,
-		feed_URL: post.feed_URL,
-		feed_ID: post.feed_ID,
-		xPostMetadata: XPostHelper.getXPostMetadata( post ),
-	};
-}
-
 function createStreamItemFromSiteAndPost( site, post, dateProperty ) {
 	return {
 		...keyForPost( post ),
@@ -85,14 +69,6 @@ function createStreamItemFromSiteAndPost( site, post, dateProperty ) {
 		feed_ID: post.feed_ID,
 		xPostMetadata: XPostHelper.getXPostMetadata( post ),
 	};
-}
-
-function createStreamDataFromPosts( posts, dateProperty ) {
-	const streamItems = Array.isArray( posts )
-		? posts.map( ( post ) => createStreamItemFromPost( post, dateProperty ) )
-		: [];
-	const streamPosts = posts;
-	return { streamItems, streamPosts };
 }
 
 function createStreamItemFromSite( site, dateProperty ) {
@@ -159,36 +135,8 @@ function createStreamSitesFromRecommendedSites( sites ) {
 	return streamSites.filter( ( item ) => item !== null );
 }
 
-export const PER_FETCH = 7;
-export const INITIAL_FETCH = 4;
-const PER_POLL = 40;
-const PER_GAP = 40;
-
-export const QUERY_META = [ 'post', 'discover_original_post' ].join( ',' );
-export const getQueryString = ( extras = {} ) => {
-	return { orderBy: 'date', meta: QUERY_META, ...extras, content_width: 675 };
-};
 const defaultQueryFn = getQueryString;
 
-export const SITE_LIMITER_FIELDS = [
-	'ID',
-	'site_ID',
-	'date',
-	'feed_ID',
-	'feed_item_ID',
-	'global_ID',
-	'metadata',
-	'site_URL',
-	'URL',
-];
-function getQueryStringForPoll( extraFields = [], extraQueryParams = {} ) {
-	return {
-		orderBy: 'date',
-		number: PER_POLL,
-		fields: [ SITE_LIMITER_FIELDS, ...extraFields ].join( ',' ),
-		...extraQueryParams,
-	};
-}
 const seed = random( 0, 1000 );
 
 const streamApis = {
@@ -434,30 +382,10 @@ export function requestPage( action ) {
 	} );
 }
 
-function get_page_handle( streamType, action, data ) {
-	const { date_range, meta, next_page, next_page_handle } = data;
-	if ( next_page_handle ) {
-		return { page_handle: next_page_handle };
-	} else if ( includes( streamType, 'rec' ) ) {
-		const offset = get( action, 'payload.pageHandle.offset', 0 ) + PER_FETCH;
-		return { offset };
-	} else if ( next_page || ( meta && meta.next_page ) ) {
-		// sites give page handles nested within the meta key
-		return { page_handle: next_page || meta.next_page };
-	} else if ( date_range && date_range.after ) {
-		// feeds use date_range. no next_page handles here
-		// search api will give you a date_range but for relevance search it will have before/after=null
-		// and offsets must be used
-		const { after } = date_range;
-		return { before: after };
-	}
-	return null;
-}
-
 export function handlePage( action, data ) {
 	const { posts, sites, cards } = data;
 	const { streamKey, query, isPoll, gap, streamType, page, perPage } = action.payload;
-	const pageHandle = get_page_handle( streamType, action, data );
+	const pageHandle = extractPageHandle( streamType, action, data );
 	const { dateProperty } = streamApis[ streamType ];
 
 	let streamItems = [];

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -18,6 +18,7 @@ import {
 	receiveUpdates,
 	receiveStreamError,
 } from 'calypso/state/reader/streams/actions';
+import { MIGRATED_STREAM_TYPES } from 'calypso/state/reader/streams/migrated-stream-types';
 import {
 	PER_FETCH,
 	INITIAL_FETCH,
@@ -336,6 +337,15 @@ export function requestPage( action ) {
 	const {
 		payload: { streamKey, streamType, feedId, pageHandle, isPoll, gap, localeSlug, page, perPage },
 	} = action;
+
+	// Migrated stream types are fetched by the React Query thunk in
+	// `client/state/reader/streams/actions.js`. The action is still dispatched
+	// so the reducer's `isRequesting`/`error` transitions fire, but the HTTP
+	// call must not be issued here too.
+	if ( MIGRATED_STREAM_TYPES.has( streamType ) ) {
+		return;
+	}
+
 	const api = streamApis[ streamType ];
 
 	if ( ! api ) {

--- a/client/state/data-layer/wpcom/read/streams/test/index.js
+++ b/client/state/data-layer/wpcom/read/streams/test/index.js
@@ -1,11 +1,7 @@
 import deepfreeze from 'deep-freeze';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
-import {
-	requestPage as requestPageAction,
-	receivePage,
-	receiveUpdates,
-} from 'calypso/state/reader/streams/actions';
-import { requestPage, handlePage, INITIAL_FETCH, PER_FETCH, QUERY_META } from '../';
+import { receivePage, receiveUpdates } from 'calypso/state/reader/streams/actions';
+import { requestPage, handlePage, INITIAL_FETCH, QUERY_META } from '../';
 
 jest.mock( 'calypso/lib/analytics/tracks', () => ( {
 	recordTracksEvent: jest.fn(),
@@ -15,8 +11,32 @@ jest.mock( 'calypso/lib/wp' );
 jest.mock( 'calypso/reader/stats', () => ( { recordTrack: () => {} } ) );
 jest.mock( '@wordpress/warning', () => () => {} );
 
+// `requestPage` in `state/reader/streams/actions` is a thunk; it dispatches the
+// action below for unmigrated streams. Build the action shape directly here so
+// these legacy data-layer tests don't depend on the thunk's runtime.
+function makeAction( { streamKey, ...overrides } ) {
+	const colon = streamKey.indexOf( ':' );
+	const streamType = colon === -1 ? streamKey : streamKey.substring( 0, colon );
+	return deepfreeze( {
+		type: 'READER_STREAMS_PAGE_REQUEST',
+		payload: {
+			streamKey,
+			streamType,
+			pageHandle: undefined,
+			isPoll: false,
+			gap: null,
+			localeSlug: null,
+			feedId: undefined,
+			...overrides,
+		},
+	} );
+}
+
 describe( 'streams', () => {
-	const action = deepfreeze( requestPageAction( { streamKey: 'following', page: 2 } ) );
+	// `following` is migrated to React Query (see
+	// client/state/reader/streams/test/actions.js). Use a still-unmigrated
+	// stream type for the shared `handlePage` action below.
+	const action = makeAction( { streamKey: 'site:1234' } );
 
 	describe( 'requestPage', () => {
 		const query = {
@@ -27,50 +47,11 @@ describe( 'streams', () => {
 			lang: 'en',
 		};
 
-		it( 'should return an http request', () => {
-			expect( requestPage( action ) ).toEqual(
-				http( {
-					method: 'GET',
-					path: '/read/following',
-					apiVersion: '1.2',
-					query,
-					onSuccess: action,
-					onFailure: action,
-				} )
-			);
-		} );
-
-		it( 'should set proper params for subsequent fetches', () => {
-			const pageHandle = { after: 'the robots attack' };
-			const secondPage = { ...action, payload: { ...action.payload, pageHandle, feedId: 1234 } };
-			const httpAction = requestPage( secondPage );
-
-			expect( httpAction ).toEqual(
-				http( {
-					method: 'GET',
-					path: '/read/following',
-					apiVersion: '1.2',
-					query: { ...query, feed_id: 1234, number: PER_FETCH, after: 'the robots attack' },
-					onSuccess: secondPage,
-					onFailure: secondPage,
-				} )
-			);
-		} );
-
 		describe( 'stream types', () => {
 			// a bunch of test cases
 			// each test is an assertion of the http call that should be made
 			// when the given stream id is handed to request page
 			[
-				{
-					stream: 'following',
-					expected: {
-						method: 'GET',
-						path: '/read/following',
-						apiVersion: '1.2',
-						query,
-					},
-				},
 				{
 					stream: 'discover:freshly-pressed',
 					expected: {
@@ -243,7 +224,7 @@ describe( 'streams', () => {
 				},
 			].forEach( ( testCase ) => {
 				it( testCase.stream + ' should pass the expected params', () => {
-					const pageAction = requestPageAction( { streamKey: testCase.stream } );
+					const pageAction = makeAction( { streamKey: testCase.stream } );
 					const expected = {
 						onSuccess: pageAction,
 						onFailure: pageAction,
@@ -311,7 +292,7 @@ describe( 'streams', () => {
 
 	describe( 'handlePage with sites data (custom_recs_sites_with_images)', () => {
 		const makeSiteAction = () =>
-			deepfreeze( requestPageAction( { streamKey: 'custom_recs_sites_with_images', page: 1 } ) );
+			makeAction( { streamKey: 'custom_recs_sites_with_images', page: 1 } );
 
 		it( 'should not throw when a site is missing the posts property', () => {
 			const siteAction = makeSiteAction();

--- a/client/state/data-layer/wpcom/read/streams/test/index.js
+++ b/client/state/data-layer/wpcom/read/streams/test/index.js
@@ -47,6 +47,10 @@ describe( 'streams', () => {
 			lang: 'en',
 		};
 
+		it( 'returns undefined for migrated stream types so no HTTP fires', () => {
+			expect( requestPage( makeAction( { streamKey: 'following' } ) ) ).toBeUndefined();
+		} );
+
 		describe( 'stream types', () => {
 			// a bunch of test cases
 			// each test is an assertion of the http call that should be made

--- a/client/state/data-layer/wpcom/read/streams/test/index.js
+++ b/client/state/data-layer/wpcom/read/streams/test/index.js
@@ -1,5 +1,6 @@
 import deepfreeze from 'deep-freeze';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
+import { READER_STREAMS_PAGE_REQUEST } from 'calypso/state/reader/action-types';
 import { receivePage, receiveUpdates } from 'calypso/state/reader/streams/actions';
 import { requestPage, handlePage, INITIAL_FETCH, QUERY_META } from '../';
 
@@ -18,7 +19,7 @@ function makeAction( { streamKey, ...overrides } ) {
 	const colon = streamKey.indexOf( ':' );
 	const streamType = colon === -1 ? streamKey : streamKey.substring( 0, colon );
 	return deepfreeze( {
-		type: 'READER_STREAMS_PAGE_REQUEST',
+		type: READER_STREAMS_PAGE_REQUEST,
 		payload: {
 			streamKey,
 			streamType,

--- a/client/state/reader/streams/actions.js
+++ b/client/state/reader/streams/actions.js
@@ -122,11 +122,15 @@ async function dispatchMigratedStreamRequest( dispatch, params ) {
 	try {
 		const queryClient = getCalypsoQueryClient();
 		const queryOpts = readStreamQuery( streamKey, queryParams, pageHandle ?? null );
-		// Polls share the same queryKey as the initial page (both have a null
-		// pageHandle), so without bypassing freshness a poll within `staleTime`
-		// would return cached data and the "N new posts" indicator would never
-		// update.
-		const fetchOpts = isPoll ? { ...queryOpts, staleTime: 0 } : queryOpts;
+		// Every call into this thunk represents an explicit intent to fetch
+		// (initial load, pagination, poll, refresh after `clearStream`, locale
+		// change). The legacy data-layer always hit the network, so callers
+		// like `subscribe-modal` rely on `clearStream` + `requestPage` returning
+		// fresh data — without bypassing freshness, `fetchQuery` could serve a
+		// stale cache entry within `staleTime` and miss newly-followed sites or
+		// new posts. Keep `readStreamQuery`'s `staleTime` as a sane default for
+		// future `useQuery` consumers, but force network here.
+		const fetchOpts = { ...queryOpts, staleTime: 0 };
 		data = queryClient ? await queryClient.fetchQuery( fetchOpts ) : await queryOpts.queryFn();
 	} catch ( error ) {
 		dispatch(

--- a/client/state/reader/streams/actions.js
+++ b/client/state/reader/streams/actions.js
@@ -187,9 +187,16 @@ async function dispatchMigratedStreamRequest( dispatch, params ) {
  */
 export const requestPage = ( params ) => ( dispatch ) => {
 	const streamType = getStreamType( params.streamKey );
+	const action = buildPageRequestAction( params );
+
+	// Dispatch the legacy request action so the reducer sets `isRequesting`
+	// and clears any prior `error` state. For migrated stream types the
+	// data-layer's `requestPage` is gated on `MIGRATED_STREAM_TYPES` and
+	// no-ops, so this dispatch only drives reducer state.
+	dispatch( action );
 
 	if ( ! MIGRATED_STREAM_TYPES.has( streamType ) ) {
-		return dispatch( buildPageRequestAction( params ) );
+		return action;
 	}
 
 	// SSR no-op: matches the legacy data-layer, which never fired stream

--- a/client/state/reader/streams/actions.js
+++ b/client/state/reader/streams/actions.js
@@ -1,4 +1,7 @@
+import { readStreamQuery } from '@automattic/api-queries';
+import i18n from 'i18n-calypso';
 import { getStreamType } from 'calypso/reader/utils';
+import { getCalypsoQueryClient } from 'calypso/state/query-client';
 import {
 	READER_STREAMS_PAGE_REQUEST,
 	READER_STREAMS_PAGE_RECEIVE,
@@ -12,20 +15,24 @@ import {
 	READER_STREAMS_REMOVE_ITEM,
 	READER_STREAMS_ERROR,
 } from 'calypso/state/reader/action-types';
+import { receivePosts } from 'calypso/state/reader/posts/actions';
 import { getStream } from 'calypso/state/reader/streams/selectors';
+import { MIGRATED_STREAM_TYPES } from './migrated-stream-types';
+import {
+	PER_FETCH,
+	INITIAL_FETCH,
+	PER_GAP,
+	analyticsForStream,
+	createStreamDataFromPosts,
+	extractPageHandle,
+	getAlgorithmForStream,
+	getQueryString,
+	getQueryStringForPoll,
+} from './normalize';
 import 'calypso/state/data-layer/wpcom/read/streams';
 import 'calypso/state/reader/init';
 
-/**
- * Fetch posts into a stream
- *
- * This action will fetch a range of posts for a stream and then dispatch
- * READER_STREAM_PAGE_RECEIVE when the page returns. This is usually used to
- * fetch the next page of results, but could be used to fetch arbitrary ranges.
- * @param  {string} streamKey The stream to fetch posts for
- * @returns {Object}          The action object
- */
-export function requestPage( {
+function buildPageRequestAction( {
 	streamKey,
 	feedId,
 	pageHandle,
@@ -34,7 +41,6 @@ export function requestPage( {
 	localeSlug = null,
 } ) {
 	const streamType = getStreamType( streamKey );
-
 	return {
 		type: READER_STREAMS_PAGE_REQUEST,
 		payload: {
@@ -48,6 +54,152 @@ export function requestPage( {
 		},
 	};
 }
+
+/**
+ * Build the WordPress.com REST query payload for a migrated stream request.
+ *
+ * Mirrors the param composition in the legacy `requestPage` data-layer handler
+ * so the new fetcher hits the API with the exact same shape.
+ */
+function buildStreamQueryParams( {
+	streamKey,
+	feedId,
+	pageHandle,
+	isPoll,
+	gap,
+	localeSlug,
+	page,
+	perPage,
+} ) {
+	const algorithmValue = getAlgorithmForStream( streamKey );
+	const algorithm = algorithmValue ? { algorithm: algorithmValue } : {};
+	const fetchCount = pageHandle ? PER_FETCH : INITIAL_FETCH;
+	let number;
+	if ( page ) {
+		number = perPage;
+	} else {
+		number = gap ? PER_GAP : fetchCount;
+	}
+	const lang = localeSlug || i18n.getLocaleSlug();
+	const commonQueryParams = { ...algorithm, feed_id: feedId };
+
+	if ( isPoll ) {
+		return getQueryStringForPoll( [], commonQueryParams );
+	}
+	return getQueryString( {
+		...commonQueryParams,
+		...pageHandle,
+		number,
+		lang,
+		page,
+	} );
+}
+
+async function dispatchMigratedStreamRequest( dispatch, params ) {
+	const {
+		streamKey,
+		feedId,
+		pageHandle,
+		isPoll = false,
+		gap = null,
+		localeSlug = null,
+		page,
+		perPage,
+	} = params;
+	const streamType = getStreamType( streamKey );
+	const queryParams = buildStreamQueryParams( {
+		streamKey,
+		feedId,
+		pageHandle,
+		isPoll,
+		gap,
+		localeSlug,
+		page,
+		perPage,
+	} );
+
+	let data;
+	try {
+		const queryClient = getCalypsoQueryClient();
+		const queryOpts = readStreamQuery( streamKey, queryParams, pageHandle ?? null );
+		data = queryClient ? await queryClient.fetchQuery( queryOpts ) : await queryOpts.queryFn();
+	} catch ( error ) {
+		dispatch(
+			receiveStreamError(
+				buildPageRequestAction( { streamKey, feedId, pageHandle, isPoll, gap, localeSlug } ),
+				error
+			)
+		);
+		return;
+	}
+
+	const dateProperty = 'date'; // PR 1 only handles `following`
+	const { streamItems, streamPosts } = createStreamDataFromPosts( data.posts, dateProperty );
+	const newPageHandle = extractPageHandle( streamType, { payload: { pageHandle } }, data );
+
+	// Dispatch in the same order as the legacy `handlePage`:
+	// analytics → receivePosts → receivePage (or receiveUpdates for polls).
+	const analyticsActions = analyticsForStream( {
+		streamKey,
+		algorithm: data.algorithm,
+		items: streamPosts,
+	} );
+	analyticsActions.forEach( ( a ) => dispatch( a ) );
+
+	if ( isPoll ) {
+		dispatch( receiveUpdates( { streamKey, streamItems, query: queryParams } ) );
+		return;
+	}
+
+	if ( streamPosts.length > 0 ) {
+		dispatch( receivePosts( streamPosts ) );
+	}
+
+	const totalItems = data.total_cards || data.found || streamItems.length;
+	const totalPages = data.total_pages || Math.ceil( totalItems / ( perPage || PER_FETCH ) );
+
+	dispatch(
+		receivePage( {
+			streamKey,
+			query: queryParams,
+			streamItems,
+			pageHandle: newPageHandle,
+			gap,
+			totalItems,
+			totalPages,
+			page,
+			perPage,
+		} )
+	);
+}
+
+/**
+ * Fetch posts into a stream
+ *
+ * For migrated stream types (see `MIGRATED_STREAM_TYPES`), runs through React
+ * Query via `queryClient.fetchQuery` and dispatches the same receive actions
+ * the legacy data-layer used to. For unmigrated stream types, dispatches the
+ * legacy `READER_STREAMS_PAGE_REQUEST` so the existing data-layer handler
+ * keeps working — this gate shrinks per PR until the data-layer is deleted.
+ * @param {Object} params
+ * @param {string} params.streamKey The stream to fetch posts for
+ * @returns {Function} Thunk
+ */
+export const requestPage = ( params ) => ( dispatch ) => {
+	const streamType = getStreamType( params.streamKey );
+
+	if ( ! MIGRATED_STREAM_TYPES.has( streamType ) ) {
+		return dispatch( buildPageRequestAction( params ) );
+	}
+
+	// SSR no-op: matches the legacy data-layer, which never fired stream
+	// requests during server-side rendering.
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+
+	return dispatchMigratedStreamRequest( dispatch, params );
+};
 
 export function receivePage( {
 	streamKey,

--- a/client/state/reader/streams/actions.js
+++ b/client/state/reader/streams/actions.js
@@ -122,7 +122,12 @@ async function dispatchMigratedStreamRequest( dispatch, params ) {
 	try {
 		const queryClient = getCalypsoQueryClient();
 		const queryOpts = readStreamQuery( streamKey, queryParams, pageHandle ?? null );
-		data = queryClient ? await queryClient.fetchQuery( queryOpts ) : await queryOpts.queryFn();
+		// Polls share the same queryKey as the initial page (both have a null
+		// pageHandle), so without bypassing freshness a poll within `staleTime`
+		// would return cached data and the "N new posts" indicator would never
+		// update.
+		const fetchOpts = isPoll ? { ...queryOpts, staleTime: 0 } : queryOpts;
+		data = queryClient ? await queryClient.fetchQuery( fetchOpts ) : await queryOpts.queryFn();
 	} catch ( error ) {
 		dispatch(
 			receiveStreamError(

--- a/client/state/reader/streams/migrated-stream-types.ts
+++ b/client/state/reader/streams/migrated-stream-types.ts
@@ -1,0 +1,11 @@
+/**
+ * Stream types that route through the React Query thunk wrapper instead of the
+ * legacy `dispatchRequest`-based data-layer in
+ * `client/state/data-layer/wpcom/read/streams/index.js`.
+ *
+ * Each PR in the READ-485 migration adds entries here once the matching fetcher
+ * exists in `@automattic/api-core` and is wired into `readStreamQuery` in
+ * `@automattic/api-queries`. When this set covers every stream type, the gate
+ * and the legacy data-layer file are removed in the cleanup PR.
+ */
+export const MIGRATED_STREAM_TYPES: ReadonlySet< string > = new Set( [ 'following' ] );

--- a/client/state/reader/streams/normalize.ts
+++ b/client/state/reader/streams/normalize.ts
@@ -1,0 +1,146 @@
+import { map } from 'lodash';
+import { keyForPost } from 'calypso/reader/post-key';
+import XPostHelper from 'calypso/reader/xpost-helper';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+export const PER_FETCH = 7;
+export const INITIAL_FETCH = 4;
+export const PER_POLL = 40;
+export const PER_GAP = 40;
+
+export const QUERY_META = [ 'post', 'discover_original_post' ].join( ',' );
+
+export const SITE_LIMITER_FIELDS = [
+	'ID',
+	'site_ID',
+	'date',
+	'feed_ID',
+	'feed_item_ID',
+	'global_ID',
+	'metadata',
+	'site_URL',
+	'URL',
+];
+
+export const getQueryString = ( extras: Record< string, unknown > = {} ) => ( {
+	orderBy: 'date',
+	meta: QUERY_META,
+	...extras,
+	content_width: 675,
+} );
+
+export const getQueryStringForPoll = (
+	extraFields: string[] = [],
+	extraQueryParams: Record< string, unknown > = {}
+) => ( {
+	orderBy: 'date',
+	number: PER_POLL,
+	fields: [ ...SITE_LIMITER_FIELDS, ...extraFields ].join( ',' ),
+	...extraQueryParams,
+} );
+
+const analyticsAlgoMap = new Map< string, string >();
+
+interface AnalyticsArgs {
+	streamKey?: string;
+	algorithm?: string;
+	items?: Array< { railcar?: unknown } > | null;
+}
+
+export function analyticsForStream( { streamKey, algorithm, items }: AnalyticsArgs ) {
+	if ( ! streamKey || ! algorithm || ! items ) {
+		return [];
+	}
+
+	analyticsAlgoMap.set( streamKey, algorithm );
+
+	const eventName = 'calypso_traintracks_render';
+	return items
+		.filter( ( item ) => !! item.railcar )
+		.map( ( item ) => recordTracksEvent( eventName, item.railcar as Record< string, unknown > ) );
+}
+
+export const getAlgorithmForStream = ( streamKey: string ): string | undefined =>
+	analyticsAlgoMap.get( streamKey );
+
+interface RawPost {
+	ID: number;
+	site_ID?: number;
+	feed_ID?: number;
+	feed_item_ID?: number;
+	URL?: string;
+	site_icon?: { ico?: string };
+	description?: string;
+	site_name?: string;
+	feed_URL?: string;
+	comments?: Array< { ID: number } >;
+	[ key: string ]: unknown;
+}
+
+export function createStreamItemFromPost( post: RawPost, dateProperty: string ) {
+	return {
+		...keyForPost( post ),
+		date: post[ dateProperty ],
+		// Include comments for conversations
+		...( post.comments && { comments: map( post.comments, 'ID' ).reverse() } ),
+		url: post.URL,
+		site_icon: post.site_icon?.ico,
+		site_description: post.description,
+		site_name: post.site_name,
+		feed_URL: post.feed_URL,
+		feed_ID: post.feed_ID,
+		xPostMetadata: XPostHelper.getXPostMetadata( post ),
+	};
+}
+
+export function createStreamDataFromPosts(
+	posts: RawPost[] | null | undefined,
+	dateProperty: string
+) {
+	const streamItems = Array.isArray( posts )
+		? posts.map( ( post ) => createStreamItemFromPost( post, dateProperty ) )
+		: [];
+	const streamPosts = posts ?? [];
+	return { streamItems, streamPosts };
+}
+
+interface PageHandleAction {
+	payload?: { pageHandle?: { offset?: number } };
+}
+
+interface PageHandleData {
+	date_range?: { after?: string | null; before?: string | null };
+	meta?: { next_page?: string };
+	next_page?: string;
+	next_page_handle?: string;
+}
+
+/**
+ * Extract the next-page handle from a stream response.
+ *
+ * Mirrors the legacy `get_page_handle` from
+ * `client/state/data-layer/wpcom/read/streams/index.js`. Branch order matters:
+ * the API uses different pagination conventions per endpoint family and the
+ * legacy code preferred them in this order.
+ */
+export function extractPageHandle(
+	streamType: string,
+	action: PageHandleAction,
+	data: PageHandleData
+): { page_handle: string } | { offset: number } | { before: string } | null {
+	const { date_range, meta, next_page, next_page_handle } = data;
+	if ( next_page_handle ) {
+		return { page_handle: next_page_handle };
+	}
+	if ( streamType.includes( 'rec' ) ) {
+		const offset = ( action.payload?.pageHandle?.offset ?? 0 ) + PER_FETCH;
+		return { offset };
+	}
+	if ( next_page || meta?.next_page ) {
+		return { page_handle: next_page || meta!.next_page! };
+	}
+	if ( date_range?.after ) {
+		return { before: date_range.after };
+	}
+	return null;
+}

--- a/client/state/reader/streams/test/actions.js
+++ b/client/state/reader/streams/test/actions.js
@@ -1,0 +1,161 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient } from '@tanstack/react-query';
+import nock from 'nock';
+import {
+	READER_STREAMS_PAGE_REQUEST,
+	READER_STREAMS_PAGE_RECEIVE,
+	READER_STREAMS_UPDATES_RECEIVE,
+	READER_STREAMS_ERROR,
+	READER_POSTS_RECEIVE,
+} from 'calypso/state/reader/action-types';
+import { requestPage } from '../actions';
+
+const BASE = 'https://public-api.wordpress.com';
+
+let mockQueryClient = null;
+
+jest.mock( 'calypso/state/query-client', () => ( {
+	getCalypsoQueryClient: () => mockQueryClient,
+} ) );
+
+// Hide railcar/analytics noise in receivePosts.
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
+jest.mock( 'calypso/reader/stats', () => ( { recordTrack: () => {}, pageViewForPost: () => {} } ) );
+
+function newClient() {
+	return new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+}
+
+function runThunk( params ) {
+	const dispatch = jest.fn( ( action ) => {
+		// Pass thunks through (e.g. receivePosts is itself a thunk that dispatches READER_POSTS_RECEIVE).
+		if ( typeof action === 'function' ) {
+			return action( dispatch, () => ( {} ) );
+		}
+		return action;
+	} );
+	const result = requestPage( params )( dispatch );
+	return { dispatch, result };
+}
+
+describe( 'requestPage thunk', () => {
+	beforeEach( () => {
+		mockQueryClient = newClient();
+	} );
+	afterEach( () => {
+		nock.cleanAll();
+		mockQueryClient = null;
+	} );
+
+	describe( 'unmigrated stream type', () => {
+		it( 'dispatches the legacy READER_STREAMS_PAGE_REQUEST', () => {
+			const { dispatch } = runThunk( { streamKey: 'site:1234' } );
+			expect( dispatch ).toHaveBeenCalledTimes( 1 );
+			const action = dispatch.mock.calls[ 0 ][ 0 ];
+			expect( action.type ).toBe( READER_STREAMS_PAGE_REQUEST );
+			expect( action.payload ).toMatchObject( {
+				streamKey: 'site:1234',
+				streamType: 'site',
+				isPoll: false,
+			} );
+		} );
+	} );
+
+	describe( 'migrated `following` stream', () => {
+		const followingResponse = {
+			posts: [
+				{
+					ID: 10,
+					site_ID: 200,
+					feed_ID: 999,
+					feed_item_ID: 50,
+					date: '2026-01-01',
+					URL: 'https://example.com/post-10',
+					site_name: 'Example',
+				},
+			],
+			date_range: { after: '2026-01-01' },
+			found: 1,
+		};
+
+		it( 'fetches and dispatches receivePosts then receivePage in order', async () => {
+			nock( BASE ).get( '/rest/v1.2/read/following' ).query( true ).reply( 200, followingResponse );
+
+			const { dispatch, result } = runThunk( { streamKey: 'following' } );
+			await result;
+
+			const types = dispatch.mock.calls
+				.map( ( c ) => c[ 0 ] )
+				.filter( ( a ) => a && typeof a === 'object' && a.type )
+				.map( ( a ) => a.type );
+
+			// receivePosts dispatches READER_POSTS_RECEIVE; receivePage dispatches READER_STREAMS_PAGE_RECEIVE.
+			const postsIdx = types.indexOf( READER_POSTS_RECEIVE );
+			const pageIdx = types.indexOf( READER_STREAMS_PAGE_RECEIVE );
+			expect( postsIdx ).toBeGreaterThanOrEqual( 0 );
+			expect( pageIdx ).toBeGreaterThan( postsIdx );
+		} );
+
+		it( 'extracts the page handle from date_range.after', async () => {
+			nock( BASE ).get( '/rest/v1.2/read/following' ).query( true ).reply( 200, followingResponse );
+
+			const { dispatch, result } = runThunk( { streamKey: 'following' } );
+			await result;
+
+			const receivePageAction = dispatch.mock.calls
+				.map( ( c ) => c[ 0 ] )
+				.find( ( a ) => a && a.type === READER_STREAMS_PAGE_RECEIVE );
+			expect( receivePageAction.payload.pageHandle ).toEqual( { before: '2026-01-01' } );
+			expect( receivePageAction.payload.streamItems ).toHaveLength( 1 );
+		} );
+
+		it( 'dispatches only receiveUpdates when isPoll is true', async () => {
+			nock( BASE ).get( '/rest/v1.2/read/following' ).query( true ).reply( 200, followingResponse );
+
+			const { dispatch, result } = runThunk( { streamKey: 'following', isPoll: true } );
+			await result;
+
+			const types = dispatch.mock.calls
+				.map( ( c ) => c[ 0 ] )
+				.filter( ( a ) => a && typeof a === 'object' && a.type )
+				.map( ( a ) => a.type );
+			expect( types ).toContain( READER_STREAMS_UPDATES_RECEIVE );
+			expect( types ).not.toContain( READER_STREAMS_PAGE_RECEIVE );
+		} );
+
+		it( 'dispatches receiveStreamError on a failed fetch', async () => {
+			nock( BASE )
+				.get( '/rest/v1.2/read/following' )
+				.query( true )
+				.reply( 500, { error: 'server' } );
+
+			const { dispatch, result } = runThunk( { streamKey: 'following' } );
+			await result;
+
+			const errorAction = dispatch.mock.calls
+				.map( ( c ) => c[ 0 ] )
+				.find( ( a ) => a && a.type === READER_STREAMS_ERROR );
+			expect( errorAction ).toBeDefined();
+			expect( errorAction.payload.streamKey ).toBe( 'following' );
+			expect( errorAction.payload.error ).toBeDefined();
+		} );
+
+		it( 'falls back to a direct fetch when the QueryClient is null', async () => {
+			mockQueryClient = null;
+			nock( BASE ).get( '/rest/v1.2/read/following' ).query( true ).reply( 200, followingResponse );
+
+			const { dispatch, result } = runThunk( { streamKey: 'following' } );
+			await result;
+
+			const types = dispatch.mock.calls
+				.map( ( c ) => c[ 0 ] )
+				.filter( ( a ) => a && typeof a === 'object' && a.type )
+				.map( ( a ) => a.type );
+			expect( types ).toContain( READER_STREAMS_PAGE_RECEIVE );
+		} );
+	} );
+} );

--- a/client/state/reader/streams/test/actions.js
+++ b/client/state/reader/streams/test/actions.js
@@ -82,7 +82,7 @@ describe( 'requestPage thunk', () => {
 			found: 1,
 		};
 
-		it( 'fetches and dispatches receivePosts then receivePage in order', async () => {
+		it( 'fetches and dispatches PAGE_REQUEST, receivePosts, then receivePage in order', async () => {
 			nock( BASE ).get( '/rest/v1.2/read/following' ).query( true ).reply( 200, followingResponse );
 
 			const { dispatch, result } = runThunk( { streamKey: 'following' } );
@@ -93,10 +93,14 @@ describe( 'requestPage thunk', () => {
 				.filter( ( a ) => a && typeof a === 'object' && a.type )
 				.map( ( a ) => a.type );
 
+			// PAGE_REQUEST must be dispatched first so the reducer's
+			// `isRequesting`/`error` transitions still fire for migrated streams.
 			// receivePosts dispatches READER_POSTS_RECEIVE; receivePage dispatches READER_STREAMS_PAGE_RECEIVE.
+			const requestIdx = types.indexOf( READER_STREAMS_PAGE_REQUEST );
 			const postsIdx = types.indexOf( READER_POSTS_RECEIVE );
 			const pageIdx = types.indexOf( READER_STREAMS_PAGE_RECEIVE );
-			expect( postsIdx ).toBeGreaterThanOrEqual( 0 );
+			expect( requestIdx ).toBe( 0 );
+			expect( postsIdx ).toBeGreaterThan( requestIdx );
 			expect( pageIdx ).toBeGreaterThan( postsIdx );
 		} );
 

--- a/client/state/reader/streams/test/normalize.js
+++ b/client/state/reader/streams/test/normalize.js
@@ -1,0 +1,213 @@
+/**
+ * @jest-environment node
+ */
+import {
+	PER_FETCH,
+	PER_POLL,
+	QUERY_META,
+	SITE_LIMITER_FIELDS,
+	analyticsForStream,
+	createStreamDataFromPosts,
+	createStreamItemFromPost,
+	extractPageHandle,
+	getAlgorithmForStream,
+	getQueryString,
+	getQueryStringForPoll,
+} from '../normalize';
+
+describe( 'getQueryString', () => {
+	it( 'sets default orderBy/meta/content_width', () => {
+		expect( getQueryString() ).toEqual( {
+			orderBy: 'date',
+			meta: QUERY_META,
+			content_width: 675,
+		} );
+	} );
+
+	it( 'merges extras while keeping content_width as the last word', () => {
+		expect( getQueryString( { number: 7, lang: 'en', content_width: 100 } ) ).toEqual( {
+			orderBy: 'date',
+			meta: QUERY_META,
+			number: 7,
+			lang: 'en',
+			content_width: 675,
+		} );
+	} );
+} );
+
+describe( 'getQueryStringForPoll', () => {
+	it( 'returns the poll query with site-limiter fields by default', () => {
+		expect( getQueryStringForPoll() ).toEqual( {
+			orderBy: 'date',
+			number: PER_POLL,
+			fields: SITE_LIMITER_FIELDS.join( ',' ),
+		} );
+	} );
+
+	it( 'appends extra fields and merges extra query params', () => {
+		expect( getQueryStringForPoll( [ 'date_liked' ], { index: 'a8c' } ) ).toEqual( {
+			orderBy: 'date',
+			number: PER_POLL,
+			fields: [ ...SITE_LIMITER_FIELDS, 'date_liked' ].join( ',' ),
+			index: 'a8c',
+		} );
+	} );
+} );
+
+describe( 'createStreamItemFromPost', () => {
+	it( 'maps a blog post to a stream item with blogId/postId', () => {
+		const item = createStreamItemFromPost(
+			{
+				ID: 10,
+				site_ID: 200,
+				date: '2026-01-01',
+				URL: 'https://example.com/p',
+				site_name: 'Example',
+				site_icon: { ico: 'icon.png' },
+				description: 'desc',
+				feed_URL: 'https://example.com/feed',
+				feed_ID: 999,
+			},
+			'date'
+		);
+
+		expect( item ).toMatchObject( {
+			blogId: 200,
+			postId: 10,
+			date: '2026-01-01',
+			url: 'https://example.com/p',
+			site_name: 'Example',
+			site_icon: 'icon.png',
+			site_description: 'desc',
+			feed_URL: 'https://example.com/feed',
+			feed_ID: 999,
+		} );
+	} );
+
+	it( 'derives the date from the requested dateProperty', () => {
+		const item = createStreamItemFromPost(
+			{ ID: 1, site_ID: 2, date_liked: '2026-02-02' },
+			'date_liked'
+		);
+		expect( item.date ).toBe( '2026-02-02' );
+	} );
+
+	it( 'reverses comment IDs (newest first) when present', () => {
+		const item = createStreamItemFromPost(
+			{ ID: 1, site_ID: 2, comments: [ { ID: 1 }, { ID: 2 }, { ID: 3 } ] },
+			'date'
+		);
+		expect( item.comments ).toEqual( [ 3, 2, 1 ] );
+	} );
+
+	it( 'omits comments when not provided', () => {
+		const item = createStreamItemFromPost( { ID: 1, site_ID: 2 }, 'date' );
+		expect( item.comments ).toBeUndefined();
+	} );
+} );
+
+describe( 'createStreamDataFromPosts', () => {
+	it( 'returns empty arrays for null/undefined input', () => {
+		expect( createStreamDataFromPosts( null, 'date' ) ).toEqual( {
+			streamItems: [],
+			streamPosts: [],
+		} );
+		expect( createStreamDataFromPosts( undefined, 'date' ) ).toEqual( {
+			streamItems: [],
+			streamPosts: [],
+		} );
+	} );
+
+	it( 'maps each post and returns the original posts as streamPosts', () => {
+		const posts = [
+			{ ID: 1, site_ID: 10, date: 'a' },
+			{ ID: 2, site_ID: 10, date: 'b' },
+		];
+		const result = createStreamDataFromPosts( posts, 'date' );
+		expect( result.streamItems ).toHaveLength( 2 );
+		expect( result.streamItems[ 0 ] ).toMatchObject( { blogId: 10, postId: 1, date: 'a' } );
+		expect( result.streamPosts ).toBe( posts );
+	} );
+} );
+
+describe( 'analyticsForStream', () => {
+	it( 'returns no actions when streamKey, algorithm, or items are missing', () => {
+		expect( analyticsForStream( {} ) ).toEqual( [] );
+		expect( analyticsForStream( { streamKey: 'k', algorithm: 'a' } ) ).toEqual( [] );
+		expect( analyticsForStream( { streamKey: 'k', items: [] } ) ).toEqual( [] );
+	} );
+
+	it( 'emits one recordTracksEvent per railcar item, ignoring items without a railcar', () => {
+		const actions = analyticsForStream( {
+			streamKey: 'following',
+			algorithm: 'algo/1',
+			items: [ { railcar: { id: 'r1' } }, {}, { railcar: { id: 'r2' } } ],
+		} );
+		expect( actions ).toHaveLength( 2 );
+		actions.forEach( ( a ) =>
+			expect( a ).toMatchObject( { type: expect.stringMatching( /ANALYTICS/ ) } )
+		);
+	} );
+
+	it( 'remembers the last algorithm seen for a streamKey via getAlgorithmForStream', () => {
+		analyticsForStream( {
+			streamKey: 'following:algo-cache-test',
+			algorithm: 'algo/v2',
+			items: [ { railcar: {} } ],
+		} );
+		expect( getAlgorithmForStream( 'following:algo-cache-test' ) ).toBe( 'algo/v2' );
+	} );
+} );
+
+describe( 'extractPageHandle', () => {
+	const noAction = { payload: {} };
+
+	it( 'returns null when nothing in the response signals pagination', () => {
+		expect( extractPageHandle( 'following', noAction, {} ) ).toBeNull();
+	} );
+
+	it( 'prefers next_page_handle over every other branch', () => {
+		expect(
+			extractPageHandle( 'following', noAction, {
+				next_page_handle: 'NPH',
+				next_page: 'NP',
+				meta: { next_page: 'META' },
+				date_range: { after: '2026-01-01' },
+			} )
+		).toEqual( { page_handle: 'NPH' } );
+	} );
+
+	it( 'returns an offset when streamType contains "rec" (recommendations family)', () => {
+		expect(
+			extractPageHandle( 'recommendations_posts', noAction, { date_range: { after: 'X' } } )
+		).toEqual( { offset: PER_FETCH } );
+	} );
+
+	it( 'increments the existing offset for the recommendations family', () => {
+		expect(
+			extractPageHandle(
+				'custom_recs_posts_with_images',
+				{ payload: { pageHandle: { offset: 14 } } },
+				{}
+			)
+		).toEqual( { offset: 14 + PER_FETCH } );
+	} );
+
+	it( 'falls back to next_page when present', () => {
+		expect( extractPageHandle( 'site', noAction, { next_page: 'PAGE2' } ) ).toEqual( {
+			page_handle: 'PAGE2',
+		} );
+	} );
+
+	it( 'falls back to meta.next_page when next_page is absent', () => {
+		expect( extractPageHandle( 'site', noAction, { meta: { next_page: 'META2' } } ) ).toEqual( {
+			page_handle: 'META2',
+		} );
+	} );
+
+	it( 'returns { before } from date_range.after as the lowest-priority branch', () => {
+		expect(
+			extractPageHandle( 'following', noAction, { date_range: { after: '2026-01-01' } } )
+		).toEqual( { before: '2026-01-01' } );
+	} );
+} );

--- a/client/state/reader/streams/test/reducer.js
+++ b/client/state/reader/streams/test/reducer.js
@@ -1,5 +1,6 @@
 import deepfreeze from 'deep-freeze';
 import moment from 'moment';
+import { READER_STREAMS_PAGE_REQUEST } from 'calypso/state/reader/action-types';
 import { dismissPost } from 'calypso/state/reader/site-dismissals/actions';
 import {
 	receivePage,
@@ -7,7 +8,6 @@ import {
 	receiveUpdates,
 	selectNextItem,
 	selectPrevItem,
-	requestPage,
 	receiveStreamError,
 	clearStream,
 } from '../actions';
@@ -23,6 +23,12 @@ import {
 } from '../reducer';
 
 jest.mock( '@wordpress/warning', () => () => {} );
+
+// `requestPage` is now a thunk; for reducer tests we only need the legacy
+// action it would dispatch for unmigrated streams, so build it inline.
+function pageRequestAction( streamKey ) {
+	return { type: READER_STREAMS_PAGE_REQUEST, payload: { streamKey } };
+}
 
 const TIME1 = '2018-01-01T00:00:00.000Z';
 const TIME2 = '2018-01-02T00:00:00.000Z';
@@ -288,7 +294,7 @@ describe( 'streams.isRequesting', () => {
 	} );
 
 	it( 'should set to true after request is initiated', () => {
-		const action = requestPage( { streamKey: 'following' } );
+		const action = pageRequestAction( 'following' );
 		expect( isRequesting( undefined, action ) ).toBe( true );
 	} );
 
@@ -313,7 +319,7 @@ describe( 'streams.error', () => {
 
 	it( 'should cleanup the error after a page request', () => {
 		const previousError = new Error( 'test error' );
-		const action = requestPage( { streamKey: 'following' } );
+		const action = pageRequestAction( 'following' );
 
 		expect( error( previousError, action ) ).toBe( null );
 	} );

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -83,6 +83,7 @@ export * from './read-organizations';
 export * from './read-post';
 export * from './read-related-posts';
 export * from './read-sites';
+export * from './read-streams';
 export * from './read-tags';
 export * from './read-teams';
 export * from './read-thumbnails';

--- a/packages/api-core/src/read-streams/fetchers.ts
+++ b/packages/api-core/src/read-streams/fetchers.ts
@@ -1,0 +1,21 @@
+import { addQueryArgs } from '@wordpress/url';
+import { wpcom } from '../wpcom-fetcher';
+import type { ReadStreamQueryParams, ReadStreamResponse } from './types';
+
+// READ-485: only `following` is migrated in this PR. The remaining 18+ Reader
+// stream shapes (`recent`, `feed`, `site`, `featured`, `tag`, `tag_popular`,
+// `p2`, `a8c`, `likes`, `notifications`, `user`, `on_this_day`, `discover:*`,
+// `search`, `list`, `conversations`, `conversations-a8c`,
+// `recommendations_posts`, `custom_recs_*`) are added here incrementally by
+// the follow-up PRs of this same task. See the legacy `streamApis` map in
+// `client/state/data-layer/wpcom/read/streams/index.js` for the canonical
+// per-shape `path`, `apiVersion`, `apiNamespace`, and `query` definitions to
+// mirror when porting each one.
+export const fetchReadFollowing = (
+	params: ReadStreamQueryParams = {}
+): Promise< ReadStreamResponse > =>
+	wpcom.req.get( {
+		path: addQueryArgs( '/read/following', params ),
+		apiVersion: '1.2',
+		method: 'GET',
+	} );

--- a/packages/api-core/src/read-streams/index.ts
+++ b/packages/api-core/src/read-streams/index.ts
@@ -1,0 +1,2 @@
+export * from './fetchers';
+export * from './types';

--- a/packages/api-core/src/read-streams/types.ts
+++ b/packages/api-core/src/read-streams/types.ts
@@ -1,0 +1,37 @@
+export interface ReadStreamPost {
+	ID: number;
+	site_ID?: number;
+	feed_ID?: number;
+	feed_item_ID?: number;
+	global_ID?: string;
+	date?: string;
+	URL?: string;
+	site_icon?: { ico?: string };
+	site_name?: string;
+	description?: string;
+	feed_URL?: string;
+	railcar?: unknown;
+	is_external?: boolean;
+	[ key: string ]: unknown;
+}
+
+export interface ReadStreamDateRange {
+	after?: string | null;
+	before?: string | null;
+}
+
+export interface ReadStreamResponse {
+	posts?: ReadStreamPost[];
+	date_range?: ReadStreamDateRange;
+	next_page?: string;
+	next_page_handle?: string;
+	meta?: { next_page?: string };
+	found?: number;
+	algorithm?: string;
+	total_cards?: number;
+	total_pages?: number;
+	user_interests?: string[];
+	[ key: string ]: unknown;
+}
+
+export type ReadStreamQueryParams = Record< string, string | number | boolean | null | undefined >;

--- a/packages/api-queries/src/__tests__/read-streams.test.tsx
+++ b/packages/api-queries/src/__tests__/read-streams.test.tsx
@@ -1,0 +1,63 @@
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import { readStreamQuery } from '../read-streams';
+
+const BASE = 'https://public-api.wordpress.com';
+
+function makeWrapper( client: QueryClient ) {
+	return function Wrapper( { children }: { children: React.ReactNode } ) {
+		return <QueryClientProvider client={ client }>{ children }</QueryClientProvider>;
+	};
+}
+
+function newClient() {
+	return new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+}
+
+describe( 'readStreamQuery', () => {
+	afterEach( () => nock.cleanAll() );
+
+	it( 'builds a stable queryKey from streamKey and pageHandle', () => {
+		const opts = readStreamQuery( 'following', { number: 4 }, null );
+		expect( opts.queryKey ).toEqual( [ 'read', 'stream', 'following', null ] );
+	} );
+
+	it( 'includes the pageHandle in the queryKey', () => {
+		const opts = readStreamQuery( 'following', { number: 7 }, { before: '2026-01-01' } );
+		expect( opts.queryKey ).toEqual( [ 'read', 'stream', 'following', { before: '2026-01-01' } ] );
+	} );
+
+	it( 'fetches following posts from /read/following', async () => {
+		const scope = nock( BASE )
+			.get( '/rest/v1.2/read/following' )
+			.query( true )
+			.reply( 200, {
+				posts: [ { ID: 1, site_ID: 100, date: '2026-01-01', URL: 'https://example.com/a' } ],
+				date_range: { after: '2026-01-01' },
+			} );
+
+		const client = newClient();
+		const { result } = renderHook(
+			() =>
+				useQuery(
+					readStreamQuery(
+						'following',
+						{ orderBy: 'date', meta: 'post,discover_original_post', number: 4, content_width: 675 },
+						null
+					)
+				),
+			{ wrapper: makeWrapper( client ) }
+		);
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+		expect( scope.isDone() ).toBe( true );
+		expect( result.current.data?.posts ).toHaveLength( 1 );
+		expect( result.current.data?.date_range?.after ).toBe( '2026-01-01' );
+	} );
+
+	it( 'throws when called for an unmigrated streamType', () => {
+		const opts = readStreamQuery( 'site:1234', { number: 4 }, null );
+		expect( () => opts.queryFn!( {} as never ) ).toThrow( /unsupported streamType "site"/ );
+	} );
+} );

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -74,6 +74,7 @@ export * from './read-organizations';
 export * from './read-post';
 export * from './read-related-posts';
 export * from './read-site';
+export * from './read-streams';
 export * from './read-tags';
 export * from './read-teams';
 export * from './read-thumbnails';

--- a/packages/api-queries/src/read-streams.ts
+++ b/packages/api-queries/src/read-streams.ts
@@ -1,0 +1,50 @@
+import {
+	fetchReadFollowing,
+	type ReadStreamQueryParams,
+	type ReadStreamResponse,
+} from '@automattic/api-core';
+import { queryOptions } from '@tanstack/react-query';
+
+const STREAM_STALE_TIME = 30 * 1000;
+
+const getStreamType = ( streamKey: string ): string => {
+	const colon = streamKey.indexOf( ':' );
+	return colon === -1 ? streamKey : streamKey.substring( 0, colon );
+};
+
+/**
+ * React Query factory for Reader stream pages (READ-485).
+ *
+ * Only `following` is wired in this PR. The remaining stream types
+ * (`recent`, `feed`, `site`, `featured`, `tag`, `tag_popular`, `p2`, `a8c`,
+ * `likes`, `notifications`, `user`, `on_this_day`, `discover:*`, `search`,
+ * `list`, `conversations`, `conversations-a8c`, `recommendations_posts`,
+ * `custom_recs_*`) are migrated incrementally in the follow-up PRs of this
+ * same task — each PR adds the fetcher in `@automattic/api-core`, a case in
+ * the switch below, and the streamType to `MIGRATED_STREAM_TYPES` in
+ * `client/state/reader/streams/migrated-stream-types.ts`. Until then those
+ * streams keep flowing through the legacy data-layer at
+ * `client/state/data-layer/wpcom/read/streams/index.js` and never reach this
+ * factory.
+ */
+export const readStreamQuery = (
+	streamKey: string,
+	queryParams: ReadStreamQueryParams,
+	pageHandle: unknown = null
+) =>
+	queryOptions< ReadStreamResponse >( {
+		queryKey: [ 'read', 'stream', streamKey, pageHandle ?? null ],
+		queryFn: () => {
+			const streamType = getStreamType( streamKey );
+			switch ( streamType ) {
+				case 'following':
+					return fetchReadFollowing( queryParams );
+				default:
+					throw new Error(
+						`readStreamQuery: unsupported streamType "${ streamType }". Add the fetcher in @automattic/api-core and a case here when migrating this stream.`
+					);
+			}
+		},
+		staleTime: STREAM_STALE_TIME,
+		meta: { persist: false },
+	} );


### PR DESCRIPTION
Part of READ-485

## Proposed Changes

- New `read-streams` module in `@automattic/api-core` with `fetchReadFollowing` + response/param types (only the `following` shape — others added incrementally in follow-up PRs of this same task).
- New `readStreamQuery` factory in `@automattic/api-queries` that dispatches to the right fetcher per `streamType` (currently `following`; throws for unmigrated types).
- `client/state/reader/streams/normalize.ts` extracts the helpers shared between the legacy data-layer and the new thunk: `analyticsForStream`, `createStreamItemFromPost/Posts`, `extractPageHandle`, `getQueryString`, `getQueryStringForPoll`, plus `PER_FETCH`/`INITIAL_FETCH`/`PER_POLL`/`PER_GAP`/`QUERY_META`/`SITE_LIMITER_FIELDS`.
- `client/state/reader/streams/migrated-stream-types.ts` adds the gate (`Set(['following'])`) consulted by the thunk.
- `client/state/reader/streams/actions.js` — `requestPage` is now a thunk: migrated streamTypes call `queryClient.fetchQuery(readStreamQuery(...))` and dispatch in the same order as the legacy `handlePage` (analytics → `receivePosts` → `receivePage`, or only `receiveUpdates` for polls); unmigrated streamTypes dispatch the legacy `READER_STREAMS_PAGE_REQUEST` so the existing data-layer keeps handling them.
- `client/state/data-layer/wpcom/read/streams/index.js` now imports the shared helpers from `normalize.ts` and re-exports `PER_FETCH`/`INITIAL_FETCH`/`QUERY_META`/`SITE_LIMITER_FIELDS` for the existing consumer in `client/reader/stream/index.jsx`.
- Tests: 4 in api-queries (queryKey shape, nock URL, throw for unmigrated), 6 in the new thunk test (success/poll/error/unmigrated/null-queryClient), 20 covering `normalize.ts`. Legacy data-layer test updated to drop the `following` cases (now in the thunk test) and stop depending on the new thunk shape.

## Why are these changes being made?

The Reader streams data-layer is the largest remaining writer of `state.reader.posts.items`. READ-485 migrates its network-fetch layer to React Query while keeping the imperative action API and Redux receive actions untouched, so consumers can be migrated separately later. To keep blast radius small and reviews tractable, the rollout is staged across 6 PRs (one stream type or family per PR); this is PR 1, scoped to infra + the highest-traffic shape (`following`). The remaining stream types continue to flow through the legacy `dispatchRequest` handler until each subsequent PR migrates them.

## Testing Instructions

- `yarn test-client client/state/reader/streams/ client/state/data-layer/wpcom/read/streams/` (60 tests).
- `yarn test-packages packages/api-queries/src/__tests__/read-streams.test.tsx` (4 tests).
- Manual smoke: `yarn start`, log in, open `/read` (Following stream); load more on scroll; trigger a poll (wait for "N new posts"); click "Try again" after a forced offline failure. With React Query devtools open, confirm `[ 'read', 'stream', 'following', null ]` appears for the initial fetch and `[ 'read', 'stream', 'following', { before: ... } ]` for subsequent pages.
- Logged-out: navigate to `/discover` directly — the page shell should render (the SSR no-op in the thunk preserves the legacy behavior of never firing stream requests server-side); after hydration the stream loads.
- Regression check: navigate to other Reader streams (`/tag/photography`, `/read/blogs/{id}`, `/read/conversations`, `/discover/recommended`, `/read/recent`, `/activities/likes`) and confirm they still load — these still use the legacy data-layer.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?