### PR TITLE
Reader: show locked and secret achievements

### DIFF
--- a/client/data/reader/test/use-achievements-query.test.tsx
+++ b/client/data/reader/test/use-achievements-query.test.tsx
@@ -113,4 +113,39 @@ describe( 'useAchievementsQuery', () => {
 
 		expect( result.current.yearsOfService ).toBeUndefined();
 	} );
+
+	test( 'should expose lockedAchievements from the first page', async () => {
+		mockGet.mockResolvedValue( {
+			found: 0,
+			achievements: [],
+			locked_achievements: [
+				{
+					achievement_id: 99,
+					slug: 'locked',
+					name: 'Locked',
+					description: 'd',
+					badge_prefix: 'p',
+					is_secret: false,
+					date_created: '2026-01-01T00:00:00Z',
+				},
+			],
+		} );
+
+		const { result } = renderHook( () => useAchievementsQuery( 'testuser' ), { wrapper } );
+
+		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+
+		expect( result.current.lockedAchievements ).toHaveLength( 1 );
+		expect( result.current.lockedAchievements[ 0 ].achievement_id ).toBe( 99 );
+	} );
+
+	test( 'should default lockedAchievements to an empty array when absent', async () => {
+		mockGet.mockResolvedValue( { found: 0, achievements: [] } );
+
+		const { result } = renderHook( () => useAchievementsQuery( 'testuser' ), { wrapper } );
+
+		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+
+		expect( result.current.lockedAchievements ).toEqual( [] );
+	} );
 } );

--- a/client/data/reader/use-achievements-query.ts
+++ b/client/data/reader/use-achievements-query.ts
@@ -19,6 +19,7 @@ export function useAchievementsQuery( userIdOrLogin?: number | string ) {
 
 	return {
 		achievements: query.data?.pages.flatMap( ( p ) => p.achievements ?? [] ) ?? [],
+		lockedAchievements: query.data?.pages[ 0 ]?.locked_achievements ?? [],
 		yearsOfService: query.data?.pages[ 0 ]?.years_of_service,
 		found: query.data?.pages[ 0 ]?.found ?? 0,
 		isLoading: query.isLoading,

--- a/client/reader/user-profile/views/achievements/achievements-grid/achievement-card.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/achievement-card.tsx
@@ -1,11 +1,16 @@
+import { Icon } from '@wordpress/components';
+import { lock } from '@wordpress/icons';
+import clsx from 'clsx';
 import type { ReactNode } from 'react';
 
 interface AchievementCardProps {
-	image: string;
 	title: string;
 	badge?: ReactNode;
 	description?: ReactNode;
 	caption?: ReactNode;
+	image?: string;
+	locked?: boolean;
+	secret?: boolean;
 }
 
 export default function AchievementCard( {
@@ -14,10 +19,24 @@ export default function AchievementCard( {
 	badge,
 	description,
 	caption,
+	locked,
+	secret,
 }: AchievementCardProps ) {
+	const showLockIcon = locked || secret;
+	const rootClass = clsx( 'achievement-card', {
+		'is-locked': locked,
+		'is-secret': secret,
+	} );
+
 	return (
-		<div className="achievement-card">
-			<img className="achievement-card__icon" src={ image } alt="" />
+		<div className={ rootClass }>
+			{ showLockIcon ? (
+				<div className="achievement-card__icon achievement-card__icon--lock">
+					<Icon icon={ lock } />
+				</div>
+			) : (
+				<img className="achievement-card__icon" src={ image } alt="" />
+			) }
 			<div className="achievement-card__details">
 				<h3 className="achievement-card__title">
 					{ title }

--- a/client/reader/user-profile/views/achievements/achievements-grid/index.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/index.tsx
@@ -2,7 +2,12 @@ import { Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useAchievementsQuery } from 'calypso/data/reader/use-achievements-query';
-import { dedupeById, deduplicateAchievements, isFullyEarned, isMaskedSecret } from '../utils';
+import {
+	deduplicateAchievementsById,
+	deduplicateAchievementsBySlug,
+	isFullyEarned,
+	isMaskedSecret,
+} from '../utils';
 import AnniversaryAchievement from './anniversary-achievement';
 import GenericAchievement from './generic-achievement';
 import LockedAchievementCard from './locked-achievement-card';
@@ -46,9 +51,9 @@ export default function AchievementsGrid( { userLogin, isOwnProfile }: Achieveme
 	}
 
 	const earned = achievements.filter( isFullyEarned );
-	const maskedSecrets = dedupeById( achievements.filter( isMaskedSecret ) );
-	const dedupedEarned = deduplicateAchievements( earned );
-	const sortedLocked = dedupeById(
+	const maskedSecrets = deduplicateAchievementsById( achievements.filter( isMaskedSecret ) );
+	const dedupedEarned = deduplicateAchievementsBySlug( earned );
+	const sortedLocked = deduplicateAchievementsById(
 		[ ...lockedAchievements ].sort( ( a, b ) => a.date_created.localeCompare( b.date_created ) )
 	);
 

--- a/client/reader/user-profile/views/achievements/achievements-grid/index.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/index.tsx
@@ -2,16 +2,30 @@ import { Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useAchievementsQuery } from 'calypso/data/reader/use-achievements-query';
-import { deduplicateAchievements } from '../utils';
+import { dedupeById, deduplicateAchievements, isFullyEarned, isMaskedSecret } from '../utils';
 import AnniversaryAchievement from './anniversary-achievement';
 import GenericAchievement from './generic-achievement';
+import LockedAchievementCard from './locked-achievement-card';
+import SecretAchievementCard from './secret-achievement-card';
 
 import './style.scss';
 
-export default function AchievementsGrid( { userLogin }: { userLogin: string } ) {
+interface AchievementsGridProps {
+	userLogin: string;
+	isOwnProfile: boolean;
+}
+
+export default function AchievementsGrid( { userLogin, isOwnProfile }: AchievementsGridProps ) {
 	const translate = useTranslate();
-	const { achievements, isLoading, isError, hasNextPage, isFetchingNextPage, fetchNextPage } =
-		useAchievementsQuery( userLogin );
+	const {
+		achievements,
+		lockedAchievements,
+		isLoading,
+		isError,
+		hasNextPage,
+		isFetchingNextPage,
+		fetchNextPage,
+	} = useAchievementsQuery( userLogin );
 
 	useEffect( () => {
 		if ( hasNextPage && ! isFetchingNextPage && ! isError ) {
@@ -27,33 +41,61 @@ export default function AchievementsGrid( { userLogin }: { userLogin: string } )
 		);
 	}
 
-	if ( ! achievements.length ) {
+	if ( ! achievements.length && ! lockedAchievements.length ) {
 		return <p className="achievements-grid__empty">{ translate( 'No achievements yet.' ) }</p>;
 	}
 
-	const deduplicated = deduplicateAchievements( achievements );
+	const earned = achievements.filter( isFullyEarned );
+	const maskedSecrets = dedupeById( achievements.filter( isMaskedSecret ) );
+	const dedupedEarned = deduplicateAchievements( earned );
+	const sortedLocked = dedupeById(
+		[ ...lockedAchievements ].sort( ( a, b ) => a.date_created.localeCompare( b.date_created ) )
+	);
+
+	const showCelebratory = isOwnProfile && earned.length > 0 && lockedAchievements.length === 0;
+	const showLockedSection = isOwnProfile && sortedLocked.length > 0;
 
 	return (
-		<div className="achievements-grid">
-			{ deduplicated.map( ( achievement ) => {
-				if ( achievement.slug === 'user_anniversary' ) {
-					return (
-						<AnniversaryAchievement
-							key={ achievement.achievement_id }
-							achievement={ achievement }
-							achievements={ achievements }
-						/>
-					);
-				}
+		<>
+			{ ( dedupedEarned.length > 0 || maskedSecrets.length > 0 ) && (
+				<div className="achievements-grid">
+					{ dedupedEarned.map( ( a ) =>
+						a.slug === 'user_anniversary' ? (
+							<AnniversaryAchievement
+								key={ a.achievement_id }
+								achievement={ a }
+								achievements={ earned }
+							/>
+						) : (
+							<GenericAchievement
+								key={ a.achievement_id }
+								achievement={ a }
+								achievements={ earned }
+							/>
+						)
+					) }
+					{ maskedSecrets.map( ( a ) => (
+						<SecretAchievementCard key={ a.achievement_id } unlockedDate={ a.date } />
+					) ) }
+				</div>
+			) }
 
-				return (
-					<GenericAchievement
-						key={ achievement.achievement_id }
-						achievement={ achievement }
-						achievements={ achievements }
-					/>
-				);
-			} ) }
-		</div>
+			{ showCelebratory && (
+				<p className="achievements-grid__celebratory">
+					{ translate( 'You’ve unlocked them all! 🎉 More achievements are on the way.' ) }
+				</p>
+			) }
+
+			{ showLockedSection && (
+				<>
+					<h2 className="achievements__locked-heading">{ translate( 'Locked achievements' ) }</h2>
+					<div className="achievements-grid achievements-grid--locked">
+						{ sortedLocked.map( ( a ) => (
+							<LockedAchievementCard key={ a.achievement_id } entry={ a } />
+						) ) }
+					</div>
+				</>
+			) }
+		</>
 	);
 }

--- a/client/reader/user-profile/views/achievements/achievements-grid/locked-achievement-card.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/locked-achievement-card.tsx
@@ -1,0 +1,11 @@
+import AchievementCard from './achievement-card';
+import SecretAchievementCard from './secret-achievement-card';
+import type { LockedAchievementEntry } from '@automattic/api-core';
+
+export default function LockedAchievementCard( { entry }: { entry: LockedAchievementEntry } ) {
+	if ( entry.is_secret ) {
+		return <SecretAchievementCard locked />;
+	}
+
+	return <AchievementCard locked title={ entry.name } description={ entry.description } />;
+}

--- a/client/reader/user-profile/views/achievements/achievements-grid/secret-achievement-card.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/secret-achievement-card.tsx
@@ -1,0 +1,34 @@
+import { TimeSince } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import AchievementCard from './achievement-card';
+
+interface SecretAchievementCardProps {
+	/** Render the locked variant — faded card. Omit for unlocked masked secrets. */
+	locked?: boolean;
+	/** Profile owner's unlock date. Present only for masked secrets in the earned list. */
+	unlockedDate?: string;
+}
+
+export default function SecretAchievementCard( {
+	locked,
+	unlockedDate,
+}: SecretAchievementCardProps ) {
+	const translate = useTranslate();
+	const title = translate( 'Secret achievement' );
+	const description = translate( 'This one’s a mystery. Earn it to reveal the details.' );
+	const caption = unlockedDate
+		? translate( 'Unlocked: {{timeSince/}}', {
+				components: { timeSince: <TimeSince date={ unlockedDate } /> },
+		  } )
+		: undefined;
+
+	return (
+		<AchievementCard
+			locked={ locked }
+			secret
+			title={ title }
+			description={ description }
+			caption={ caption }
+		/>
+	);
+}

--- a/client/reader/user-profile/views/achievements/achievements-grid/style.scss
+++ b/client/reader/user-profile/views/achievements/achievements-grid/style.scss
@@ -72,4 +72,35 @@
 		margin-top: 26px;
 		text-align: center;
 	}
+
+	.achievement-card.is-locked {
+		opacity: 0.5;
+	}
+
+	.achievement-card__icon--lock {
+		align-items: center;
+		background: var( --studio-gray-5 );
+		border-radius: 50%;
+		color: var( --studio-gray-40 );
+		display: flex;
+		height: 48px;
+		justify-content: center;
+		width: 48px;
+	}
+
+	.achievements__locked-heading {
+		font-size: 1.25rem;
+		font-weight: 500;
+		margin: 32px 0 16px;
+	}
+
+	.achievements-grid--locked {
+		margin-top: 0;
+	}
+
+	.achievements-grid__celebratory {
+		color: var( --studio-gray-60 );
+		margin: 24px 0 0;
+		text-align: center;
+	}
 }

--- a/client/reader/user-profile/views/achievements/achievements-grid/test/achievement-card.test.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/test/achievement-card.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import AchievementCard from '../achievement-card';
+
+describe( 'AchievementCard', () => {
+	test( 'renders an image when not locked or secret', () => {
+		render(
+			<AchievementCard
+				image="https://example.com/badge.png"
+				title="Earned"
+				description="A normal badge."
+			/>
+		);
+
+		const img = screen.getByRole( 'presentation' );
+		expect( img ).toBeVisible();
+		expect( img ).toHaveAttribute( 'src', 'https://example.com/badge.png' );
+	} );
+
+	test( 'renders a lock icon and applies .is-locked when locked', () => {
+		const { container } = render( <AchievementCard locked title="Locked" description="Hidden." /> );
+
+		expect( container.querySelector( 'img' ) ).toBeNull();
+		expect( container.querySelector( '.achievement-card.is-locked' ) ).not.toBeNull();
+		expect( container.querySelector( '.achievement-card__icon--lock svg' ) ).not.toBeNull();
+	} );
+
+	test( 'applies .is-secret when secret', () => {
+		const { container } = render(
+			<AchievementCard secret title="Secret achievement" description="Mystery." />
+		);
+
+		expect( container.querySelector( '.achievement-card.is-secret' ) ).not.toBeNull();
+	} );
+
+	test( 'applies both modifier classes and renders lock icon when locked + secret', () => {
+		const { container } = render(
+			<AchievementCard locked secret title="Secret achievement" description="Mystery." />
+		);
+
+		expect( container.querySelector( 'img' ) ).toBeNull();
+		const root = container.querySelector( '.achievement-card.is-locked.is-secret' );
+		expect( root ).not.toBeNull();
+		expect( container.querySelector( '.achievement-card__icon--lock svg' ) ).not.toBeNull();
+	} );
+} );

--- a/client/reader/user-profile/views/achievements/achievements-grid/test/index.test.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/test/index.test.tsx
@@ -1,0 +1,261 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, within } from '@testing-library/react';
+import React from 'react';
+import AchievementsGrid from '../index';
+
+jest.mock( 'calypso/data/reader/use-achievements-query' );
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const useAchievementsQuery = require( 'calypso/data/reader/use-achievements-query' )
+	.useAchievementsQuery as jest.Mock;
+
+const earned = ( overrides: Record< string, unknown > = {} ) => ( {
+	achievement_id: 1,
+	slug: 'first_post',
+	name: 'First Post',
+	description: 'You wrote your first post.',
+	badge_prefix: 'p',
+	level: 1,
+	date: '2026-01-15T00:00:00Z',
+	image: 'https://example.com/first.png',
+	retired: false,
+	is_secret: false,
+	...overrides,
+} );
+
+const maskedSecret = ( overrides: Record< string, unknown > = {} ) => ( {
+	achievement_id: 2,
+	is_secret: true,
+	date: '2026-02-15T00:00:00Z',
+	...overrides,
+} );
+
+const locked = ( overrides: Record< string, unknown > = {} ) => ( {
+	achievement_id: 10,
+	slug: 'comment_streak',
+	name: 'Comment Streak',
+	description: 'Comment for 7 days in a row.',
+	badge_prefix: 'p',
+	is_secret: false,
+	date_created: '2026-01-01T00:00:00Z',
+	...overrides,
+} );
+
+const lockedSecret = ( overrides: Record< string, unknown > = {} ) => ( {
+	achievement_id: 99,
+	is_secret: true,
+	date_created: '2026-01-10T00:00:00Z',
+	...overrides,
+} );
+
+const baseQueryReturn = {
+	achievements: [],
+	lockedAchievements: [],
+	isLoading: false,
+	isError: false,
+	hasNextPage: false,
+	isFetchingNextPage: false,
+	fetchNextPage: jest.fn(),
+};
+
+function renderGrid( props: { userLogin: string; isOwnProfile: boolean } ) {
+	const client = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+	return render(
+		<QueryClientProvider client={ client }>
+			<AchievementsGrid { ...props } />
+		</QueryClientProvider>
+	);
+}
+
+describe( 'AchievementsGrid', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'renders the empty copy when both grids are empty', () => {
+		useAchievementsQuery.mockReturnValue( { ...baseQueryReturn } );
+
+		renderGrid( { userLogin: 'me', isOwnProfile: true } );
+
+		expect( screen.getByText( 'No achievements yet.' ) ).toBeVisible();
+		expect( screen.queryByText( 'Locked achievements' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders earned grid only when not own profile and no locked', () => {
+		useAchievementsQuery.mockReturnValue( {
+			...baseQueryReturn,
+			achievements: [ earned() ],
+		} );
+
+		renderGrid( { userLogin: 'someone', isOwnProfile: false } );
+
+		expect( screen.getByText( 'First Post' ) ).toBeVisible();
+		expect( screen.queryByText( 'Locked achievements' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /You.*unlocked them all/ ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders the locked section heading and locked cards on own profile', () => {
+		useAchievementsQuery.mockReturnValue( {
+			...baseQueryReturn,
+			achievements: [ earned() ],
+			lockedAchievements: [ locked() ],
+		} );
+
+		renderGrid( { userLogin: 'me', isOwnProfile: true } );
+
+		expect( screen.getByRole( 'heading', { name: 'Locked achievements' } ) ).toBeVisible();
+		expect( screen.getByText( 'Comment Streak' ) ).toBeVisible();
+		expect( screen.getByText( 'Comment for 7 days in a row.' ) ).toBeVisible();
+	} );
+
+	test( 'hides the locked section on cross-user view even if API returns locked', () => {
+		useAchievementsQuery.mockReturnValue( {
+			...baseQueryReturn,
+			achievements: [ earned() ],
+			lockedAchievements: [ locked() ],
+		} );
+
+		renderGrid( { userLogin: 'someone', isOwnProfile: false } );
+
+		expect(
+			screen.queryByRole( 'heading', { name: 'Locked achievements' } )
+		).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Comment Streak' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders celebratory message when own profile, has earned, and zero locked', () => {
+		useAchievementsQuery.mockReturnValue( {
+			...baseQueryReturn,
+			achievements: [ earned() ],
+			lockedAchievements: [],
+		} );
+
+		renderGrid( { userLogin: 'me', isOwnProfile: true } );
+
+		expect( screen.getByText( /You.*unlocked them all/ ) ).toBeVisible();
+		expect(
+			screen.queryByRole( 'heading', { name: 'Locked achievements' } )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'hides celebratory message on cross-user view', () => {
+		useAchievementsQuery.mockReturnValue( {
+			...baseQueryReturn,
+			achievements: [ earned() ],
+			lockedAchievements: [],
+		} );
+
+		renderGrid( { userLogin: 'someone', isOwnProfile: false } );
+
+		expect( screen.queryByText( /You.*unlocked them all/ ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders locked secret with the secret title and mystery description', () => {
+		useAchievementsQuery.mockReturnValue( {
+			...baseQueryReturn,
+			achievements: [ earned() ],
+			lockedAchievements: [ lockedSecret() ],
+		} );
+
+		renderGrid( { userLogin: 'me', isOwnProfile: true } );
+
+		expect( screen.getByText( 'Secret achievement' ) ).toBeVisible();
+		expect(
+			screen.getByText( /This one.*s a mystery\. Earn it to reveal the details\./ )
+		).toBeVisible();
+	} );
+
+	test( 'renders masked secret in earned list with caption Unlocked: <time>', () => {
+		useAchievementsQuery.mockReturnValue( {
+			...baseQueryReturn,
+			achievements: [ earned(), maskedSecret() ],
+			lockedAchievements: [],
+		} );
+
+		renderGrid( { userLogin: 'someone', isOwnProfile: false } );
+
+		const secretCard = screen.getByText( 'Secret achievement' ).closest( '.achievement-card' );
+		expect( secretCard ).not.toBeNull();
+		expect( within( secretCard as HTMLElement ).getByText( /^Unlocked:/ ) ).toBeVisible();
+	} );
+
+	test( 'sorts locked entries by date_created ascending', () => {
+		useAchievementsQuery.mockReturnValue( {
+			...baseQueryReturn,
+			achievements: [ earned() ],
+			lockedAchievements: [
+				locked( { achievement_id: 20, name: 'Z', date_created: '2026-03-01' } ),
+				locked( { achievement_id: 21, name: 'A', date_created: '2026-01-01' } ),
+				locked( { achievement_id: 22, name: 'M', date_created: '2026-02-01' } ),
+			],
+		} );
+
+		const { container } = renderGrid( { userLogin: 'me', isOwnProfile: true } );
+
+		const lockedSection = container.querySelector( '.achievements-grid--locked' );
+		expect( lockedSection ).not.toBeNull();
+		const titles = within( lockedSection as HTMLElement ).getAllByRole( 'heading', {
+			level: 3,
+		} );
+		expect( titles.map( ( h ) => h.textContent ) ).toEqual( [ 'A', 'M', 'Z' ] );
+	} );
+
+	test( 'new-user own profile with only locked entries renders the locked grid only', () => {
+		useAchievementsQuery.mockReturnValue( {
+			...baseQueryReturn,
+			achievements: [],
+			lockedAchievements: [ locked() ],
+		} );
+
+		renderGrid( { userLogin: 'me', isOwnProfile: true } );
+
+		expect( screen.queryByText( 'No achievements yet.' ) ).not.toBeInTheDocument();
+		expect( screen.getByRole( 'heading', { name: 'Locked achievements' } ) ).toBeVisible();
+		expect( screen.getByText( 'Comment Streak' ) ).toBeVisible();
+	} );
+
+	test( 'dedupes masked secrets in the earned list by achievement_id', () => {
+		useAchievementsQuery.mockReturnValue( {
+			...baseQueryReturn,
+			achievements: [
+				earned(),
+				maskedSecret( { achievement_id: 50, date: '2026-02-01T00:00:00Z' } ),
+				maskedSecret( { achievement_id: 50, date: '2026-03-01T00:00:00Z' } ),
+			],
+			lockedAchievements: [],
+		} );
+
+		renderGrid( { userLogin: 'someone', isOwnProfile: false } );
+
+		expect( screen.getAllByText( 'Secret achievement' ) ).toHaveLength( 1 );
+	} );
+
+	test( 'dedupes locked entries by achievement_id', () => {
+		useAchievementsQuery.mockReturnValue( {
+			...baseQueryReturn,
+			achievements: [ earned() ],
+			lockedAchievements: [
+				lockedSecret( { achievement_id: 77, date_created: '2026-01-01' } ),
+				lockedSecret( { achievement_id: 77, date_created: '2026-02-01' } ),
+			],
+		} );
+
+		renderGrid( { userLogin: 'me', isOwnProfile: true } );
+
+		expect( screen.getAllByText( 'Secret achievement' ) ).toHaveLength( 1 );
+	} );
+
+	test( 'shows the loading spinner while pages are still being fetched', () => {
+		useAchievementsQuery.mockReturnValue( {
+			...baseQueryReturn,
+			isLoading: true,
+		} );
+
+		renderGrid( { userLogin: 'me', isOwnProfile: true } );
+
+		expect( screen.getByText( /Loading achievements/ ) ).toBeVisible();
+	} );
+} );

--- a/client/reader/user-profile/views/achievements/achievements-grid/test/index.test.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/test/index.test.tsx
@@ -248,6 +248,20 @@ describe( 'AchievementsGrid', () => {
 		expect( screen.getAllByText( 'Secret achievement' ) ).toHaveLength( 1 );
 	} );
 
+	test( 'renders earned achievements from a legacy response that omits is_secret', () => {
+		const { is_secret: _omit, ...legacy } = earned();
+		useAchievementsQuery.mockReturnValue( {
+			...baseQueryReturn,
+			achievements: [ legacy ],
+			lockedAchievements: [],
+		} );
+
+		renderGrid( { userLogin: 'me', isOwnProfile: true } );
+
+		expect( screen.getByText( 'First Post' ) ).toBeVisible();
+		expect( screen.queryByText( 'No achievements yet.' ) ).not.toBeInTheDocument();
+	} );
+
 	test( 'shows the loading spinner while pages are still being fetched', () => {
 		useAchievementsQuery.mockReturnValue( {
 			...baseQueryReturn,

--- a/client/reader/user-profile/views/achievements/index.tsx
+++ b/client/reader/user-profile/views/achievements/index.tsx
@@ -43,7 +43,7 @@ const UserAchievements = ( { user }: UserAchievementsProps ): JSX.Element | null
 				) }
 				{ isOwnProfile && <AchievementsSettings /> }
 			</div>
-			<AchievementsGrid userLogin={ user.user_login } />
+			<AchievementsGrid userLogin={ user.user_login } isOwnProfile={ isOwnProfile } />
 		</div>
 	);
 };

--- a/client/reader/user-profile/views/achievements/test/index.test.tsx
+++ b/client/reader/user-profile/views/achievements/test/index.test.tsx
@@ -14,9 +14,13 @@ jest.mock( 'calypso/reader/components/achievements/use-achievements-visibility' 
 
 jest.mock( 'calypso/data/reader/use-achievements-query' );
 
+const mockAchievementsGridProps = jest.fn();
 jest.mock( '../achievements-grid', () => ( {
 	__esModule: true,
-	default: () => <div data-testid="achievements-grid" />,
+	default: ( props: { userLogin: string; isOwnProfile: boolean } ) => {
+		mockAchievementsGridProps( props );
+		return <div data-testid="achievements-grid" />;
+	},
 } ) );
 
 jest.mock( '../achievements-settings', () => ( {
@@ -56,8 +60,13 @@ describe( 'UserAchievements', () => {
 
 	beforeEach( () => {
 		jest.clearAllMocks();
+		mockAchievementsGridProps.mockClear();
 		mockIsEnabled.mockReturnValue( true );
-		useAchievementsQuery.mockReturnValue( { yearsOfService: undefined, isLoading: false } );
+		useAchievementsQuery.mockReturnValue( {
+			yearsOfService: undefined,
+			lockedAchievements: [],
+			isLoading: false,
+		} );
 	} );
 
 	test( 'should render nothing when feature flag is disabled', () => {
@@ -168,10 +177,42 @@ describe( 'UserAchievements', () => {
 			isVisible: true,
 			isLoading: false,
 		} );
-		useAchievementsQuery.mockReturnValue( { yearsOfService: undefined, isLoading: false } );
+		useAchievementsQuery.mockReturnValue( {
+			yearsOfService: undefined,
+			lockedAchievements: [],
+			isLoading: false,
+		} );
 
 		render( <UserAchievements user={ defaultUser } /> );
 
 		expect( screen.queryByTestId( 'years-of-service-badge' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'forwards isOwnProfile=true to AchievementsGrid on own profile', () => {
+		useAchievementsVisibility.mockReturnValue( {
+			isOwnProfile: true,
+			isVisible: true,
+			isLoading: false,
+		} );
+
+		render( <UserAchievements user={ defaultUser } /> );
+
+		expect( mockAchievementsGridProps ).toHaveBeenCalledWith(
+			expect.objectContaining( { userLogin: 'test_user', isOwnProfile: true } )
+		);
+	} );
+
+	test( 'forwards isOwnProfile=false to AchievementsGrid on someone else’s profile', () => {
+		useAchievementsVisibility.mockReturnValue( {
+			isOwnProfile: false,
+			isVisible: true,
+			isLoading: false,
+		} );
+
+		render( <UserAchievements user={ defaultUser } /> );
+
+		expect( mockAchievementsGridProps ).toHaveBeenCalledWith(
+			expect.objectContaining( { userLogin: 'test_user', isOwnProfile: false } )
+		);
 	} );
 } );

--- a/client/reader/user-profile/views/achievements/test/utils.test.ts
+++ b/client/reader/user-profile/views/achievements/test/utils.test.ts
@@ -1,6 +1,6 @@
 import {
-	dedupeById,
-	deduplicateAchievements,
+	deduplicateAchievementsById,
+	deduplicateAchievementsBySlug,
 	isFullyEarned,
 	isLockedSecret,
 	isMaskedSecret,
@@ -82,9 +82,9 @@ describe( 'isLockedSecret', () => {
 	} );
 } );
 
-describe( 'dedupeById', () => {
+describe( 'deduplicateAchievementsById', () => {
 	test( 'keeps the first occurrence of each achievement_id', () => {
-		const result = dedupeById( [
+		const result = deduplicateAchievementsById( [
 			{ achievement_id: 1, name: 'first' },
 			{ achievement_id: 2, name: 'second' },
 			{ achievement_id: 1, name: 'duplicate' },
@@ -98,11 +98,11 @@ describe( 'dedupeById', () => {
 
 	test( 'returns the input unchanged when there are no duplicates', () => {
 		const input = [ { achievement_id: 1 }, { achievement_id: 2 }, { achievement_id: 3 } ];
-		expect( dedupeById( input ) ).toEqual( input );
+		expect( deduplicateAchievementsById( input ) ).toEqual( input );
 	} );
 } );
 
-describe( 'deduplicateAchievements', () => {
+describe( 'deduplicateAchievementsBySlug', () => {
 	test( 'keeps the highest level and oldest date for a leveled slug', () => {
 		const a: Achievement = { ...fullyEarned, achievement_id: 10, level: 1, date: '2026-01-01' };
 		const b: Achievement = {
@@ -113,7 +113,7 @@ describe( 'deduplicateAchievements', () => {
 			image: 'https://example.com/level2.png',
 		};
 
-		const result = deduplicateAchievements( [ a, b ] );
+		const result = deduplicateAchievementsBySlug( [ a, b ] );
 
 		expect( result ).toHaveLength( 1 );
 		expect( result[ 0 ].level ).toBe( 2 );

--- a/client/reader/user-profile/views/achievements/test/utils.test.ts
+++ b/client/reader/user-profile/views/achievements/test/utils.test.ts
@@ -55,6 +55,11 @@ describe( 'isFullyEarned', () => {
 	test( 'returns false for a MaskedSecretAchievement', () => {
 		expect( isFullyEarned( maskedSecret ) ).toBe( false );
 	} );
+
+	test( 'returns true for a legacy Achievement without is_secret set', () => {
+		const { is_secret: _omit, ...legacy } = fullyEarned;
+		expect( isFullyEarned( legacy as Achievement ) ).toBe( true );
+	} );
 } );
 
 describe( 'isMaskedSecret', () => {

--- a/client/reader/user-profile/views/achievements/test/utils.test.ts
+++ b/client/reader/user-profile/views/achievements/test/utils.test.ts
@@ -1,0 +1,118 @@
+import {
+	dedupeById,
+	deduplicateAchievements,
+	isFullyEarned,
+	isLockedSecret,
+	isMaskedSecret,
+} from '../utils';
+import type {
+	Achievement,
+	LockedAchievement,
+	LockedSecretAchievement,
+	MaskedSecretAchievement,
+} from '@automattic/api-core';
+
+const fullyEarned: Achievement = {
+	achievement_id: 1,
+	slug: 'test',
+	name: 'Test',
+	description: 'desc',
+	badge_prefix: 'p',
+	level: 1,
+	date: '2026-01-01T00:00:00Z',
+	image: 'https://example.com/img.png',
+	retired: false,
+	is_secret: false,
+};
+
+const maskedSecret: MaskedSecretAchievement = {
+	achievement_id: 2,
+	is_secret: true,
+	date: '2026-01-02T00:00:00Z',
+};
+
+const locked: LockedAchievement = {
+	achievement_id: 3,
+	slug: 'locked',
+	name: 'Locked',
+	description: 'd',
+	badge_prefix: 'p',
+	is_secret: false,
+	date_created: '2026-01-03T00:00:00Z',
+};
+
+const lockedSecret: LockedSecretAchievement = {
+	achievement_id: 4,
+	is_secret: true,
+	date_created: '2026-01-04T00:00:00Z',
+};
+
+describe( 'isFullyEarned', () => {
+	test( 'returns true for an Achievement', () => {
+		expect( isFullyEarned( fullyEarned ) ).toBe( true );
+	} );
+
+	test( 'returns false for a MaskedSecretAchievement', () => {
+		expect( isFullyEarned( maskedSecret ) ).toBe( false );
+	} );
+} );
+
+describe( 'isMaskedSecret', () => {
+	test( 'returns true for a MaskedSecretAchievement', () => {
+		expect( isMaskedSecret( maskedSecret ) ).toBe( true );
+	} );
+
+	test( 'returns false for a fully earned Achievement', () => {
+		expect( isMaskedSecret( fullyEarned ) ).toBe( false );
+	} );
+} );
+
+describe( 'isLockedSecret', () => {
+	test( 'returns true for a LockedSecretAchievement', () => {
+		expect( isLockedSecret( lockedSecret ) ).toBe( true );
+	} );
+
+	test( 'returns false for a non-secret LockedAchievement', () => {
+		expect( isLockedSecret( locked ) ).toBe( false );
+	} );
+} );
+
+describe( 'dedupeById', () => {
+	test( 'keeps the first occurrence of each achievement_id', () => {
+		const result = dedupeById( [
+			{ achievement_id: 1, name: 'first' },
+			{ achievement_id: 2, name: 'second' },
+			{ achievement_id: 1, name: 'duplicate' },
+		] );
+
+		expect( result ).toEqual( [
+			{ achievement_id: 1, name: 'first' },
+			{ achievement_id: 2, name: 'second' },
+		] );
+	} );
+
+	test( 'returns the input unchanged when there are no duplicates', () => {
+		const input = [ { achievement_id: 1 }, { achievement_id: 2 }, { achievement_id: 3 } ];
+		expect( dedupeById( input ) ).toEqual( input );
+	} );
+} );
+
+describe( 'deduplicateAchievements', () => {
+	test( 'keeps the highest level and oldest date for a leveled slug', () => {
+		const a: Achievement = { ...fullyEarned, achievement_id: 10, level: 1, date: '2026-01-01' };
+		const b: Achievement = {
+			...fullyEarned,
+			achievement_id: 11,
+			level: 2,
+			date: '2026-02-01',
+			image: 'https://example.com/level2.png',
+		};
+
+		const result = deduplicateAchievements( [ a, b ] );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].level ).toBe( 2 );
+		expect( result[ 0 ].image ).toBe( 'https://example.com/level2.png' );
+		expect( result[ 0 ].date ).toBe( '2026-01-01' );
+	} );
+} );

--- a/client/reader/user-profile/views/achievements/utils.ts
+++ b/client/reader/user-profile/views/achievements/utils.ts
@@ -1,4 +1,10 @@
-import type { Achievement } from '@automattic/api-core';
+import type {
+	Achievement,
+	EarnedAchievementEntry,
+	LockedAchievementEntry,
+	LockedSecretAchievement,
+	MaskedSecretAchievement,
+} from '@automattic/api-core';
 
 /**
  * Find the oldest achievement of a given slug by comparing dates.
@@ -39,3 +45,29 @@ export function deduplicateAchievements( achievements: Achievement[] ): Achievem
 		return highest;
 	} );
 }
+
+/**
+ * Deduplicate by `achievement_id`, keeping the first occurrence. Used for
+ * shapes that lack a slug (masked secrets and locked entries) — the backend
+ * may return the same id more than once for secret achievements.
+ */
+export function dedupeById< T extends { achievement_id: number } >( entries: T[] ): T[] {
+	const seen = new Set< number >();
+	const result: T[] = [];
+	for ( const entry of entries ) {
+		if ( ! seen.has( entry.achievement_id ) ) {
+			seen.add( entry.achievement_id );
+			result.push( entry );
+		}
+	}
+	return result;
+}
+
+export const isFullyEarned = ( a: EarnedAchievementEntry ): a is Achievement =>
+	a.is_secret === false;
+
+export const isMaskedSecret = ( a: EarnedAchievementEntry ): a is MaskedSecretAchievement =>
+	a.is_secret === true;
+
+export const isLockedSecret = ( a: LockedAchievementEntry ): a is LockedSecretAchievement =>
+	a.is_secret === true;

--- a/client/reader/user-profile/views/achievements/utils.ts
+++ b/client/reader/user-profile/views/achievements/utils.ts
@@ -64,7 +64,7 @@ export function dedupeById< T extends { achievement_id: number } >( entries: T[]
 }
 
 export const isFullyEarned = ( a: EarnedAchievementEntry ): a is Achievement =>
-	a.is_secret === false;
+	a.is_secret !== true;
 
 export const isMaskedSecret = ( a: EarnedAchievementEntry ): a is MaskedSecretAchievement =>
 	a.is_secret === true;

--- a/client/reader/user-profile/views/achievements/utils.ts
+++ b/client/reader/user-profile/views/achievements/utils.ts
@@ -26,7 +26,7 @@ export function getOldestAchievement(
  * - For leveled achievements, keep the highest level.
  * - Otherwise, keep the oldest (first unlocked).
  */
-export function deduplicateAchievements( achievements: Achievement[] ): Achievement[] {
+export function deduplicateAchievementsBySlug( achievements: Achievement[] ): Achievement[] {
 	// Build a map of slug → highest level for that slug.
 	const highestBySlug = achievements.reduce( ( map, achievement ) => {
 		const existing = map.get( achievement.slug );
@@ -51,7 +51,9 @@ export function deduplicateAchievements( achievements: Achievement[] ): Achievem
  * shapes that lack a slug (masked secrets and locked entries) — the backend
  * may return the same id more than once for secret achievements.
  */
-export function dedupeById< T extends { achievement_id: number } >( entries: T[] ): T[] {
+export function deduplicateAchievementsById< T extends { achievement_id: number } >(
+	entries: T[]
+): T[] {
 	const seen = new Set< number >();
 	const result: T[] = [];
 	for ( const entry of entries ) {

--- a/packages/api-core/src/read-achievements/types.ts
+++ b/packages/api-core/src/read-achievements/types.ts
@@ -1,3 +1,7 @@
+/**
+ * Earned, fully-visible achievement. The shape returned for own-profile reads
+ * and for non-secret entries on cross-user reads.
+ */
 export interface Achievement {
 	achievement_id: number;
 	slug: string;
@@ -8,14 +12,53 @@ export interface Achievement {
 	date: string;
 	image: string;
 	retired: boolean;
+	is_secret: false;
 	/** Only present when viewing your own achievements. */
 	site_ID?: number;
 	/** Only present when viewing your own achievements. */
 	url?: string;
 }
 
+/**
+ * Earned by the profile owner, masked because the requester has not earned
+ * the same secret. Cross-user reads only.
+ */
+export interface MaskedSecretAchievement {
+	achievement_id: number;
+	is_secret: true;
+	date: string;
+}
+
+/**
+ * Registry entry the requester has not earned yet. Self-reads only.
+ * The endpoint omits an `image` URL — the UI renders a generic lock icon.
+ */
+export interface LockedAchievement {
+	achievement_id: number;
+	slug: string;
+	name: string;
+	description: string;
+	badge_prefix: string;
+	is_secret: false;
+	date_created: string;
+}
+
+/**
+ * Locked + secret. Self-reads only.
+ */
+export interface LockedSecretAchievement {
+	achievement_id: number;
+	is_secret: true;
+	date_created: string;
+}
+
+export type EarnedAchievementEntry = Achievement | MaskedSecretAchievement;
+export type LockedAchievementEntry = LockedAchievement | LockedSecretAchievement;
+
 export interface AchievementsResponse {
 	found: number;
-	achievements: Achievement[];
+	achievements: EarnedAchievementEntry[];
+	/** Self-reads only. Endpoint returns the full set on page 1; not paginated. */
+	locked_achievements?: LockedAchievementEntry[];
 	years_of_service?: number;
 }

--- a/packages/api-core/src/read-achievements/types.ts
+++ b/packages/api-core/src/read-achievements/types.ts
@@ -12,7 +12,8 @@ export interface Achievement {
 	date: string;
 	image: string;
 	retired: boolean;
-	is_secret: false;
+	/** Optional — legacy responses (pre-locked-achievements rollout) omit it. */
+	is_secret?: false;
 	/** Only present when viewing your own achievements. */
 	site_ID?: number;
 	/** Only present when viewing your own achievements. */


### PR DESCRIPTION
Part of RSM-1965

## Proposed Changes

- Render the new `locked_achievements` array (own-profile only) below the earned grid under a “Locked achievements” heading, sorted by `date_created` ascending and deduplicated by `achievement_id`.
- Render secret achievements with a generic lock icon and non-revealing copy:
  - **Locked secret** (own profile, unearned): faded card, “Secret achievement” / “This one’s a mystery. Earn it to reveal the details.”
  - **Masked secret in earned list** (cross-user, the requester hasn’t earned it): full-opacity card with the same secret copy plus an “Unlocked: …” caption.
- Show a celebratory message in place of the locked section when the user has unlocked every visible registry entry.
- Introduce a discriminated-union type model in `@automattic/api-core` with `is_secret` as the tag (`Achievement` | `MaskedSecretAchievement` | `LockedAchievement` | `LockedSecretAchievement`).
- Add `locked` / `secret` modifier props to `AchievementCard` (lock-icon swap and `.is-locked` opacity).
- New `SecretAchievementCard` and `LockedAchievementCard` components; the latter delegates to the former for secret entries.

## Why are these changes being made?

The back-end change in Automattic/wpcom#214305 adds a `locked_achievements` array on self-reads and masks secret achievements when the requester hasn’t earned them. This PR is the front-end side: surfaces the new data and applies the privacy-preserving treatment to secrets.

## Testing Instructions

1. Sandbox `/wpcom/v2/read/achievements/:self` so the back-end PR is active.
2. As your own user, visit your Reader profile’s Achievements tab. Confirm:
   - Earned grid renders as before.
   - A “Locked achievements” heading appears below it followed by a faded grid of locked cards.
   - Locked cards are sorted by registry date (oldest first).
   - Locked secret cards show the lock icon, “Secret achievement”, and the mystery copy.
   - When you have everything unlocked, the locked section is replaced by the celebratory message.
3. Visit a teammate’s Achievements tab where you both have at least one earned achievement, but only they have a given `is_secret` achievement:
   - The masked secret renders with full opacity, the lock icon, the secret copy, and an “Unlocked: …” caption.
   - No “Locked achievements” heading appears on cross-user views.
4. Run `yarn test-client client/reader/user-profile/views/achievements client/data/reader/test/use-achievements-query.test.tsx` — 41 tests should pass.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?