### PR TITLE
Reader: migrate Discover streams to React Query (READ-497)

### DIFF
--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -1,7 +1,6 @@
 import warn from '@wordpress/warning';
 import i18n from 'i18n-calypso';
 import { random, map } from 'lodash';
-import { buildDiscoverStreamKey, getTagsFromStreamKey } from 'calypso/reader/discover/helper';
 import { keyForPost } from 'calypso/reader/post-key';
 import XPostHelper from 'calypso/reader/xpost-helper';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
@@ -12,13 +11,12 @@ import {
 	READER_STREAMS_PAGINATED_REQUEST,
 } from 'calypso/state/reader/action-types';
 import { receivePosts } from 'calypso/state/reader/posts/actions';
-import { receiveRecommendedSites } from 'calypso/state/reader/recommended-sites/actions';
 import {
 	receivePage,
 	receiveUpdates,
 	receiveStreamError,
 } from 'calypso/state/reader/streams/actions';
-import { MIGRATED_STREAM_TYPES } from 'calypso/state/reader/streams/migrated-stream-types';
+import { isMigratedStream } from 'calypso/state/reader/streams/migrated-stream-types';
 import {
 	PER_FETCH,
 	INITIAL_FETCH,
@@ -80,26 +78,6 @@ function createStreamItemFromSite( site, dateProperty ) {
 	return createStreamItemFromSiteAndPost( site, post, dateProperty );
 }
 
-function createStreamDataFromCards( cards, dateProperty ) {
-	// TODO: We may want to extract the related tags and update related tags stream too
-	const cardPosts = [];
-	let cardRecommendedSites = [];
-	let newSites = [];
-	cards.forEach( ( card ) => {
-		if ( card.type === 'post' ) {
-			cardPosts.push( card.data );
-		} else if ( card.type === 'recommended_blogs' ) {
-			cardRecommendedSites = card.data;
-		} else if ( card.type === 'new_sites' ) {
-			newSites = card.data;
-		}
-	} );
-
-	const streamSites = createStreamSitesFromRecommendedSites( cardRecommendedSites );
-	const streamNewSites = createStreamSitesFromRecommendedSites( newSites );
-	return { ...createStreamDataFromPosts( cardPosts, dateProperty ), streamSites, streamNewSites };
-}
-
 function createStreamDataFromSites( sites, dateProperty ) {
 	const streamItems = [];
 	const streamPosts = [];
@@ -117,23 +95,6 @@ function createStreamDataFromSites( sites, dateProperty ) {
 	} );
 
 	return { streamItems, streamPosts };
-}
-
-function createStreamSitesFromRecommendedSites( sites ) {
-	const streamSites = sites.map( ( site ) => {
-		return {
-			feed_ID: site.feed_ID,
-			url: site.URL,
-			site_icon: site.icon?.ico,
-			site_description: site.description,
-			site_name: site.name,
-			feed_URL: site.feed_URL,
-			feedId: site.feed_ID, // filtered by feedId in receiveRecommendedSites reducer
-		};
-	} );
-
-	// Filter out nulls
-	return streamSites.filter( ( item ) => item !== null );
 }
 
 const defaultQueryFn = getQueryString;
@@ -170,38 +131,6 @@ const streamApis = {
 	feed: {
 		path: ( { streamKey } ) => `/read/feed/${ streamKeySuffix( streamKey ) }/posts`,
 		dateProperty: 'date',
-	},
-
-	discover: {
-		path: ( { streamKey } ) => {
-			if ( streamKeySuffix( streamKey ).includes( 'recommended' ) ) {
-				return '/read/streams/discover';
-			} else if ( streamKeySuffix( streamKey ).includes( 'latest' ) ) {
-				return '/read/tags/posts';
-			} else if ( streamKeySuffix( streamKey ).includes( 'freshly-pressed' ) ) {
-				return '/freshly-pressed';
-			}
-
-			return `/read/streams/discover?tags=${ streamKeySuffix( streamKey ) }`;
-		},
-		dateProperty: 'date',
-		query: ( extras, { streamKey } ) => {
-			if ( streamKeySuffix( streamKey ).includes( 'freshly-pressed' ) ) {
-				return { ...extras };
-			}
-			return getQueryString( {
-				...extras,
-				// Do not supply an empty fallback as null is good info for getDiscoverStreamTags
-				tags: getTagsFromStreamKey( streamKey ),
-				tag_recs_per_card: 5,
-				site_recs_per_card: 5,
-				age_based_decay: 0.5,
-				// Default order is by date (latest) unless we're on the recommended tab which shows popular instead.
-				orderBy: streamKeySuffix( streamKey ).includes( 'recommended' ) ? 'popular' : 'date',
-			} );
-		},
-		apiNamespace: ( { streamKey } ) =>
-			streamKeySuffix( streamKey ).includes( 'freshly-pressed' ) ? null : 'wpcom/v2',
 	},
 	site: {
 		path: ( { streamKey } ) => `/read/sites/${ streamKeySuffix( streamKey ) }/posts`,
@@ -338,11 +267,11 @@ export function requestPage( action ) {
 		payload: { streamKey, streamType, feedId, pageHandle, isPoll, gap, localeSlug, page, perPage },
 	} = action;
 
-	// Migrated stream types are fetched by the React Query thunk in
+	// Migrated streams are fetched by the React Query thunk in
 	// `client/state/reader/streams/actions.js`. The action is still dispatched
 	// so the reducer's `isRequesting`/`error` transitions fire, but the HTTP
 	// call must not be issued here too.
-	if ( MIGRATED_STREAM_TYPES.has( streamType ) ) {
+	if ( isMigratedStream( streamType ) ) {
 		return;
 	}
 
@@ -393,20 +322,14 @@ export function requestPage( action ) {
 }
 
 export function handlePage( action, data ) {
-	const { posts, sites, cards } = data;
+	const { posts, sites } = data;
 	const { streamKey, query, isPoll, gap, streamType, page, perPage } = action.payload;
 	const pageHandle = extractPageHandle( streamType, action, data );
 	const { dateProperty } = streamApis[ streamType ];
 
 	let streamItems = [];
 	let streamPosts = [];
-	let streamSites = [];
-	let streamNewSites = [];
 
-	// If the payload has posts, then this stream is intended to be a post stream
-	// If the payload has sites, then we need to extract the posts from the sites and update the post stream
-	// If the payload has cards, then we need to extract the posts from the cards and update the post stream
-	// Cards also contain recommended sites which we need to extract and update the sites stream
 	if ( posts ) {
 		const streamData = createStreamDataFromPosts( posts, dateProperty );
 		streamItems = streamData.streamItems;
@@ -415,13 +338,6 @@ export function handlePage( action, data ) {
 		const streamData = createStreamDataFromSites( sites, dateProperty );
 		streamItems = streamData.streamItems;
 		streamPosts = streamData.streamPosts;
-	} else if ( cards ) {
-		// Need to extract the posts and recommended sites from the cards
-		const streamData = createStreamDataFromCards( cards, dateProperty );
-		streamItems = streamData.streamItems;
-		streamPosts = streamData.streamPosts;
-		streamSites = streamData.streamSites;
-		streamNewSites = streamData.streamNewSites;
 	}
 
 	const actions = analyticsForStream( {
@@ -432,48 +348,30 @@ export function handlePage( action, data ) {
 
 	if ( isPoll ) {
 		actions.push( receiveUpdates( { streamKey, streamItems, query } ) );
-	} else {
-		if ( streamPosts.length > 0 ) {
-			actions.push( receivePosts( streamPosts ) );
-		}
-		if ( streamSites.length > 0 ) {
-			actions.push(
-				receiveRecommendedSites( { seed: 'discover-recommendations', sites: streamSites } )
-			);
-		}
-		if ( streamNewSites.length > 0 ) {
-			actions.push(
-				receiveRecommendedSites( { seed: 'discover-new-sites', sites: streamNewSites } )
-			);
-		}
-
-		const totalItems = data.total_cards || data.found || streamItems.length;
-		const totalPages =
-			data.total_pages || Math.ceil( totalItems / ( action.payload.perPage || PER_FETCH ) );
-
-		// The first request when going to wordpress.com/discover does not include tags in the streamKey
-		// because it is still waiting for the user's interests to be fetched.
-		// Given that the user interests will be retrieved in the response from /read/streams/discover we
-		// use that values to generate a correct streamKey and prevent doing a new request when the user
-		// interests are finally fetched. More context here: paYKcK-3zo-p2#comment-2528.
-		let newStreamKey = streamKey;
-		if ( streamKey === 'discover:recommended' && data.user_interests ) {
-			newStreamKey = buildDiscoverStreamKey( 'recommended', data.user_interests );
-		}
-		actions.push(
-			receivePage( {
-				streamKey: newStreamKey,
-				query,
-				streamItems,
-				pageHandle,
-				gap,
-				totalItems,
-				totalPages,
-				page,
-				perPage,
-			} )
-		);
+		return actions;
 	}
+
+	if ( streamPosts.length > 0 ) {
+		actions.push( receivePosts( streamPosts ) );
+	}
+
+	const totalItems = data.total_cards || data.found || streamItems.length;
+	const totalPages =
+		data.total_pages || Math.ceil( totalItems / ( action.payload.perPage || PER_FETCH ) );
+
+	actions.push(
+		receivePage( {
+			streamKey,
+			query,
+			streamItems,
+			pageHandle,
+			gap,
+			totalItems,
+			totalPages,
+			page,
+			perPage,
+		} )
+	);
 
 	return actions;
 }

--- a/client/state/data-layer/wpcom/read/streams/test/index.js
+++ b/client/state/data-layer/wpcom/read/streams/test/index.js
@@ -48,8 +48,17 @@ describe( 'streams', () => {
 			lang: 'en',
 		};
 
-		it( 'returns undefined for migrated stream types so no HTTP fires', () => {
-			expect( requestPage( makeAction( { streamKey: 'following' } ) ) ).toBeUndefined();
+		it.each( [
+			'following',
+			'discover:recommended',
+			'discover:recommended--wordpress--blogging',
+			'discover:latest',
+			'discover:latest--wordpress',
+			'discover:tags',
+			'discover:dailyprompt',
+			'discover:freshly-pressed',
+		] )( 'returns undefined for migrated streamKey %s', ( streamKey ) => {
+			expect( requestPage( makeAction( { streamKey } ) ) ).toBeUndefined();
 		} );
 
 		describe( 'stream types', () => {
@@ -57,49 +66,6 @@ describe( 'streams', () => {
 			// each test is an assertion of the http call that should be made
 			// when the given stream id is handed to request page
 			[
-				{
-					stream: 'discover:freshly-pressed',
-					expected: {
-						method: 'GET',
-						path: '/freshly-pressed',
-						apiVersion: '1.2',
-						query: {
-							number: INITIAL_FETCH,
-							lang: 'en',
-						},
-					},
-				},
-				{
-					stream: 'discover:recommended',
-					expected: {
-						method: 'GET',
-						path: '/read/streams/discover',
-						apiNamespace: 'wpcom/v2',
-						query: {
-							...query,
-							tag_recs_per_card: 5,
-							site_recs_per_card: 5,
-							tags: [],
-							age_based_decay: 0.5,
-							orderBy: 'popular',
-						},
-					},
-				},
-				{
-					stream: 'discover:dailyprompt',
-					expected: {
-						method: 'GET',
-						path: `/read/streams/discover?tags=dailyprompt`,
-						apiNamespace: 'wpcom/v2',
-						query: {
-							...query,
-							tag_recs_per_card: 5,
-							site_recs_per_card: 5,
-							tags: [],
-							age_based_decay: 0.5,
-						},
-					},
-				},
 				{
 					stream: 'a8c',
 					expected: {

--- a/client/state/reader/streams/actions.js
+++ b/client/state/reader/streams/actions.js
@@ -135,8 +135,8 @@ function buildDiscoverQueryParams( extras, streamKey ) {
 	}
 	return getQueryString( {
 		...extras,
-		// Do not supply an empty fallback — `null` is meaningful for
-		// `getDiscoverStreamTags` on the server side.
+		// `getTagsFromStreamKey` always returns an array (empty when no tags),
+		// never `null`. `tags=[]` is sent through to the API as-is.
 		tags: getTagsFromStreamKey( streamKey ),
 		tag_recs_per_card: 5,
 		site_recs_per_card: 5,

--- a/client/state/reader/streams/actions.js
+++ b/client/state/reader/streams/actions.js
@@ -119,10 +119,8 @@ function discoverSubTab( streamKey ) {
 }
 
 /**
- * Build the query params for a discover sub-tab. Mirrors the legacy
- * `streamApis.discover.query` in
- * `client/state/data-layer/wpcom/read/streams/index.js` so the migrated request
- * hits the API with the same shape.
+ * Build the query params for a discover sub-tab so the migrated request hits
+ * the API with the same shape the legacy data-layer used.
  *
  * - `freshly-pressed` returns the raw extras (no `getQueryString` wrap), so it
  *   does not pick up `meta`/`content_width`/default `orderBy`.
@@ -247,7 +245,9 @@ async function dispatchMigratedStreamRequest( dispatch, params ) {
 	// to avoid a second request when the interests action lands. See p-paYKcK-3zo.
 	let receiveStreamKey = streamKey;
 	if ( streamKey === 'discover:recommended' && data.user_interests ) {
-		receiveStreamKey = buildDiscoverStreamKey( 'recommended', data.user_interests );
+		// Clone before passing — `buildDiscoverStreamKey` sorts the array in place,
+		// and we don't want to mutate the response payload.
+		receiveStreamKey = buildDiscoverStreamKey( 'recommended', [ ...data.user_interests ] );
 	}
 
 	dispatch(

--- a/client/state/reader/streams/actions.js
+++ b/client/state/reader/streams/actions.js
@@ -1,5 +1,6 @@
 import { readStreamQuery } from '@automattic/api-queries';
 import i18n from 'i18n-calypso';
+import { buildDiscoverStreamKey, getTagsFromStreamKey } from 'calypso/reader/discover/helper';
 import { getStreamType } from 'calypso/reader/utils';
 import { getCalypsoQueryClient } from 'calypso/state/query-client';
 import {
@@ -16,13 +17,15 @@ import {
 	READER_STREAMS_ERROR,
 } from 'calypso/state/reader/action-types';
 import { receivePosts } from 'calypso/state/reader/posts/actions';
+import { receiveRecommendedSites } from 'calypso/state/reader/recommended-sites/actions';
 import { getStream } from 'calypso/state/reader/streams/selectors';
-import { MIGRATED_STREAM_TYPES } from './migrated-stream-types';
+import { isMigratedStream } from './migrated-stream-types';
 import {
 	PER_FETCH,
 	INITIAL_FETCH,
 	PER_GAP,
 	analyticsForStream,
+	createStreamDataFromCards,
 	createStreamDataFromPosts,
 	extractPageHandle,
 	getAlgorithmForStream,
@@ -71,6 +74,7 @@ function buildStreamQueryParams( {
 	page,
 	perPage,
 } ) {
+	const streamType = getStreamType( streamKey );
 	const algorithmValue = getAlgorithmForStream( streamKey );
 	const algorithm = algorithmValue ? { algorithm: algorithmValue } : {};
 	const fetchCount = pageHandle ? PER_FETCH : INITIAL_FETCH;
@@ -86,13 +90,58 @@ function buildStreamQueryParams( {
 	if ( isPoll ) {
 		return getQueryStringForPoll( [], commonQueryParams );
 	}
-	return getQueryString( {
+	const baseParams = getQueryString( {
 		...commonQueryParams,
 		...pageHandle,
 		number,
 		lang,
 		page,
 	} );
+	if ( streamType === 'discover' ) {
+		return applyDiscoverQueryParams( baseParams, streamKey );
+	}
+	return baseParams;
+}
+
+function discoverSubTab( streamKey ) {
+	const colon = streamKey.indexOf( ':' );
+	const suffix = colon === -1 ? '' : streamKey.substring( colon + 1 );
+	if ( suffix.startsWith( 'recommended' ) ) {
+		return 'recommended';
+	}
+	if ( suffix.startsWith( 'latest' ) ) {
+		return 'latest';
+	}
+	if ( suffix === 'freshly-pressed' ) {
+		return 'freshly-pressed';
+	}
+	return 'tags';
+}
+
+/**
+ * Augment the base stream query params with discover-specific fields. Mirrors
+ * the legacy `streamApis.discover.query` in
+ * `client/state/data-layer/wpcom/read/streams/index.js` so the migrated request
+ * hits the API with the same shape.
+ *
+ * - `freshly-pressed` ignores all extras and uses only the base params.
+ * - `recommended` sorts by popularity; `latest` and `tags` sort by date.
+ */
+function applyDiscoverQueryParams( baseParams, streamKey ) {
+	const subTab = discoverSubTab( streamKey );
+	if ( subTab === 'freshly-pressed' ) {
+		return baseParams;
+	}
+	return {
+		...baseParams,
+		// Do not supply an empty fallback — `null` is meaningful for
+		// `getDiscoverStreamTags` on the server side.
+		tags: getTagsFromStreamKey( streamKey ),
+		tag_recs_per_card: 5,
+		site_recs_per_card: 5,
+		age_based_decay: 0.5,
+		orderBy: subTab === 'recommended' ? 'popular' : 'date',
+	};
 }
 
 async function dispatchMigratedStreamRequest( dispatch, params ) {
@@ -142,12 +191,30 @@ async function dispatchMigratedStreamRequest( dispatch, params ) {
 		return;
 	}
 
-	const dateProperty = 'date'; // PR 1 only handles `following`
-	const { streamItems, streamPosts } = createStreamDataFromPosts( data.posts, dateProperty );
+	// `dateProperty` will diverge per streamType once we migrate
+	// `conversations`/`likes`. For now `following` and `discover:recommended`
+	// both use `date`.
+	const dateProperty = 'date';
+	let streamItems = [];
+	let streamPosts = [];
+	let streamSites = [];
+	let streamNewSites = [];
+	if ( data.cards ) {
+		const fromCards = createStreamDataFromCards( data.cards, dateProperty );
+		streamItems = fromCards.streamItems;
+		streamPosts = fromCards.streamPosts;
+		streamSites = fromCards.streamSites;
+		streamNewSites = fromCards.streamNewSites;
+	} else {
+		const fromPosts = createStreamDataFromPosts( data.posts, dateProperty );
+		streamItems = fromPosts.streamItems;
+		streamPosts = fromPosts.streamPosts;
+	}
 	const newPageHandle = extractPageHandle( streamType, { payload: { pageHandle } }, data );
 
 	// Dispatch in the same order as the legacy `handlePage`:
-	// analytics → receivePosts → receivePage (or receiveUpdates for polls).
+	// analytics → receivePosts → receiveRecommendedSites → receivePage
+	// (or receiveUpdates for polls).
 	const analyticsActions = analyticsForStream( {
 		streamKey,
 		algorithm: data.algorithm,
@@ -163,13 +230,28 @@ async function dispatchMigratedStreamRequest( dispatch, params ) {
 	if ( streamPosts.length > 0 ) {
 		dispatch( receivePosts( streamPosts ) );
 	}
+	if ( streamSites.length > 0 ) {
+		dispatch( receiveRecommendedSites( { seed: 'discover-recommendations', sites: streamSites } ) );
+	}
+	if ( streamNewSites.length > 0 ) {
+		dispatch( receiveRecommendedSites( { seed: 'discover-new-sites', sites: streamNewSites } ) );
+	}
 
 	const totalItems = data.total_cards || data.found || streamItems.length;
 	const totalPages = data.total_pages || Math.ceil( totalItems / ( perPage || PER_FETCH ) );
 
+	// The first request to /discover does not include tags in the streamKey
+	// because we are still waiting for the user's interests to be fetched.
+	// The response carries `user_interests`, so rebuild the streamKey with them
+	// to avoid a second request when the interests action lands. See p-paYKcK-3zo.
+	let receiveStreamKey = streamKey;
+	if ( streamKey === 'discover:recommended' && data.user_interests ) {
+		receiveStreamKey = buildDiscoverStreamKey( 'recommended', data.user_interests );
+	}
+
 	dispatch(
 		receivePage( {
-			streamKey,
+			streamKey: receiveStreamKey,
 			query: queryParams,
 			streamItems,
 			pageHandle: newPageHandle,
@@ -185,7 +267,7 @@ async function dispatchMigratedStreamRequest( dispatch, params ) {
 /**
  * Fetch posts into a stream
  *
- * For migrated stream types (see `MIGRATED_STREAM_TYPES`), runs through React
+ * For migrated stream types (see `isMigratedStream`), runs through React
  * Query via `queryClient.fetchQuery` and dispatches the same receive actions
  * the legacy data-layer used to. For unmigrated stream types, dispatches the
  * legacy `READER_STREAMS_PAGE_REQUEST` so the existing data-layer handler
@@ -199,12 +281,12 @@ export const requestPage = ( params ) => ( dispatch ) => {
 	const action = buildPageRequestAction( params );
 
 	// Dispatch the legacy request action so the reducer sets `isRequesting`
-	// and clears any prior `error` state. For migrated stream types the
-	// data-layer's `requestPage` is gated on `MIGRATED_STREAM_TYPES` and
+	// and clears any prior `error` state. For migrated streams the data-layer's
+	// `requestPage` is gated on the same `isMigratedStream` predicate and
 	// no-ops, so this dispatch only drives reducer state.
 	dispatch( action );
 
-	if ( ! MIGRATED_STREAM_TYPES.has( streamType ) ) {
+	if ( ! isMigratedStream( streamType ) ) {
 		return action;
 	}
 

--- a/client/state/reader/streams/actions.js
+++ b/client/state/reader/streams/actions.js
@@ -90,17 +90,17 @@ function buildStreamQueryParams( {
 	if ( isPoll ) {
 		return getQueryStringForPoll( [], commonQueryParams );
 	}
-	const baseParams = getQueryString( {
+	const extras = {
 		...commonQueryParams,
 		...pageHandle,
 		number,
 		lang,
 		page,
-	} );
+	};
 	if ( streamType === 'discover' ) {
-		return applyDiscoverQueryParams( baseParams, streamKey );
+		return buildDiscoverQueryParams( extras, streamKey );
 	}
-	return baseParams;
+	return getQueryString( extras );
 }
 
 function discoverSubTab( streamKey ) {
@@ -119,21 +119,22 @@ function discoverSubTab( streamKey ) {
 }
 
 /**
- * Augment the base stream query params with discover-specific fields. Mirrors
- * the legacy `streamApis.discover.query` in
+ * Build the query params for a discover sub-tab. Mirrors the legacy
+ * `streamApis.discover.query` in
  * `client/state/data-layer/wpcom/read/streams/index.js` so the migrated request
  * hits the API with the same shape.
  *
- * - `freshly-pressed` ignores all extras and uses only the base params.
+ * - `freshly-pressed` returns the raw extras (no `getQueryString` wrap), so it
+ *   does not pick up `meta`/`content_width`/default `orderBy`.
  * - `recommended` sorts by popularity; `latest` and `tags` sort by date.
  */
-function applyDiscoverQueryParams( baseParams, streamKey ) {
+function buildDiscoverQueryParams( extras, streamKey ) {
 	const subTab = discoverSubTab( streamKey );
 	if ( subTab === 'freshly-pressed' ) {
-		return baseParams;
+		return { ...extras };
 	}
-	return {
-		...baseParams,
+	return getQueryString( {
+		...extras,
 		// Do not supply an empty fallback — `null` is meaningful for
 		// `getDiscoverStreamTags` on the server side.
 		tags: getTagsFromStreamKey( streamKey ),
@@ -141,7 +142,7 @@ function applyDiscoverQueryParams( baseParams, streamKey ) {
 		site_recs_per_card: 5,
 		age_based_decay: 0.5,
 		orderBy: subTab === 'recommended' ? 'popular' : 'date',
-	};
+	} );
 }
 
 async function dispatchMigratedStreamRequest( dispatch, params ) {

--- a/client/state/reader/streams/migrated-stream-types.ts
+++ b/client/state/reader/streams/migrated-stream-types.ts
@@ -1,11 +1,16 @@
 /**
- * Stream types that route through the React Query thunk wrapper instead of the
- * legacy `dispatchRequest`-based data-layer in
+ * Stream types that route through the React Query thunk wrapper in
+ * `client/state/reader/streams/actions.js` instead of the legacy
+ * `dispatchRequest`-based data-layer in
  * `client/state/data-layer/wpcom/read/streams/index.js`.
  *
- * Each PR in the READ-485 migration adds entries here once the matching fetcher
+ * Each PR in the READ-485 migration extends this once the matching fetcher
  * exists in `@automattic/api-core` and is wired into `readStreamQuery` in
- * `@automattic/api-queries`. When this set covers every stream type, the gate
- * and the legacy data-layer file are removed in the cleanup PR.
+ * `@automattic/api-queries`. When every stream type is covered the gate and
+ * the legacy data-layer file are removed in the cleanup PR.
  */
-export const MIGRATED_STREAM_TYPES: ReadonlySet< string > = new Set( [ 'following' ] );
+const MIGRATED_STREAM_TYPES: ReadonlySet< string > = new Set( [ 'following', 'discover' ] );
+
+export function isMigratedStream( streamType: string ): boolean {
+	return MIGRATED_STREAM_TYPES.has( streamType );
+}

--- a/client/state/reader/streams/normalize.ts
+++ b/client/state/reader/streams/normalize.ts
@@ -123,18 +123,16 @@ export function createStreamSitesFromRecommendedSites( sites: RawSite[] | null |
 	if ( ! Array.isArray( sites ) ) {
 		return [];
 	}
-	return sites
-		.map( ( site ) => ( {
-			feed_ID: site.feed_ID,
-			url: site.URL,
-			site_icon: site.icon?.ico,
-			site_description: site.description,
-			site_name: site.name,
-			feed_URL: site.feed_URL,
-			// `recommended-sites` reducer filters by `feedId`.
-			feedId: site.feed_ID,
-		} ) )
-		.filter( ( item ) => item !== null );
+	return sites.map( ( site ) => ( {
+		feed_ID: site.feed_ID,
+		url: site.URL,
+		site_icon: site.icon?.ico,
+		site_description: site.description,
+		site_name: site.name,
+		feed_URL: site.feed_URL,
+		// `recommended-sites` reducer filters by `feedId`.
+		feedId: site.feed_ID,
+	} ) );
 }
 
 interface CardBuckets {

--- a/client/state/reader/streams/normalize.ts
+++ b/client/state/reader/streams/normalize.ts
@@ -146,8 +146,7 @@ const EMPTY_BUCKETS: CardBuckets = { cardPosts: [], cardRecommendedSites: [], ne
 /**
  * Split a `cards` payload (used by `discover:recommended` and tag-specific
  * `discover:<tag>` streams) into post stream items, recommended sites, and
- * new sites. Mirrors the legacy `createStreamDataFromCards` in
- * `client/state/data-layer/wpcom/read/streams/index.js`.
+ * new sites.
  */
 export function createStreamDataFromCards(
 	cards: RawCard[] | null | undefined,

--- a/client/state/reader/streams/normalize.ts
+++ b/client/state/reader/streams/normalize.ts
@@ -144,9 +144,9 @@ interface CardBuckets {
 const EMPTY_BUCKETS: CardBuckets = { cardPosts: [], cardRecommendedSites: [], newSites: [] };
 
 /**
- * Split a `cards` payload (used by `discover:recommended`/`discover:tags`) into
- * post stream items, recommended sites, and new sites. Mirrors the legacy
- * `createStreamDataFromCards` in
+ * Split a `cards` payload (used by `discover:recommended` and tag-specific
+ * `discover:<tag>` streams) into post stream items, recommended sites, and
+ * new sites. Mirrors the legacy `createStreamDataFromCards` in
  * `client/state/data-layer/wpcom/read/streams/index.js`.
  */
 export function createStreamDataFromCards(

--- a/client/state/reader/streams/normalize.ts
+++ b/client/state/reader/streams/normalize.ts
@@ -104,6 +104,81 @@ export function createStreamDataFromPosts(
 	return { streamItems, streamPosts };
 }
 
+interface RawSite {
+	feed_ID?: number;
+	URL?: string;
+	icon?: { ico?: string };
+	description?: string;
+	name?: string;
+	feed_URL?: string;
+	[ key: string ]: unknown;
+}
+
+interface RawCard {
+	type: string;
+	data: unknown;
+}
+
+export function createStreamSitesFromRecommendedSites( sites: RawSite[] | null | undefined ) {
+	if ( ! Array.isArray( sites ) ) {
+		return [];
+	}
+	return sites
+		.map( ( site ) => ( {
+			feed_ID: site.feed_ID,
+			url: site.URL,
+			site_icon: site.icon?.ico,
+			site_description: site.description,
+			site_name: site.name,
+			feed_URL: site.feed_URL,
+			// `recommended-sites` reducer filters by `feedId`.
+			feedId: site.feed_ID,
+		} ) )
+		.filter( ( item ) => item !== null );
+}
+
+interface CardBuckets {
+	cardPosts: RawPost[];
+	cardRecommendedSites: RawSite[];
+	newSites: RawSite[];
+}
+
+const EMPTY_BUCKETS: CardBuckets = { cardPosts: [], cardRecommendedSites: [], newSites: [] };
+
+/**
+ * Split a `cards` payload (used by `discover:recommended`/`discover:tags`) into
+ * post stream items, recommended sites, and new sites. Mirrors the legacy
+ * `createStreamDataFromCards` in
+ * `client/state/data-layer/wpcom/read/streams/index.js`.
+ */
+export function createStreamDataFromCards(
+	cards: RawCard[] | null | undefined,
+	dateProperty: string
+) {
+	const buckets = Array.isArray( cards )
+		? cards.reduce< CardBuckets >(
+				( acc, card ) => {
+					if ( card.type === 'post' ) {
+						return { ...acc, cardPosts: [ ...acc.cardPosts, card.data as RawPost ] };
+					}
+					if ( card.type === 'recommended_blogs' ) {
+						return { ...acc, cardRecommendedSites: ( card.data as RawSite[] ) ?? [] };
+					}
+					if ( card.type === 'new_sites' ) {
+						return { ...acc, newSites: ( card.data as RawSite[] ) ?? [] };
+					}
+					return acc;
+				},
+				{ cardPosts: [], cardRecommendedSites: [], newSites: [] }
+		  )
+		: EMPTY_BUCKETS;
+	return {
+		...createStreamDataFromPosts( buckets.cardPosts, dateProperty ),
+		streamSites: createStreamSitesFromRecommendedSites( buckets.cardRecommendedSites ),
+		streamNewSites: createStreamSitesFromRecommendedSites( buckets.newSites ),
+	};
+}
+
 interface PageHandleAction {
 	payload?: { pageHandle?: { offset?: number } };
 }

--- a/client/state/reader/streams/test/actions.js
+++ b/client/state/reader/streams/test/actions.js
@@ -9,6 +9,7 @@ import {
 	READER_STREAMS_UPDATES_RECEIVE,
 	READER_STREAMS_ERROR,
 	READER_POSTS_RECEIVE,
+	READER_RECOMMENDED_SITES_RECEIVE,
 } from 'calypso/state/reader/action-types';
 import { requestPage } from '../actions';
 
@@ -160,6 +161,246 @@ describe( 'requestPage thunk', () => {
 				.filter( ( a ) => a && typeof a === 'object' && a.type )
 				.map( ( a ) => a.type );
 			expect( types ).toContain( READER_STREAMS_PAGE_RECEIVE );
+		} );
+	} );
+
+	describe( 'migrated `discover:recommended` stream', () => {
+		const cardsResponse = {
+			cards: [
+				{
+					type: 'post',
+					data: {
+						ID: 11,
+						site_ID: 201,
+						feed_ID: 998,
+						feed_item_ID: 51,
+						date: '2026-02-01',
+						URL: 'https://example.com/post-11',
+						site_name: 'Discover Example',
+					},
+				},
+				{
+					type: 'recommended_blogs',
+					data: [
+						{
+							feed_ID: 700,
+							URL: 'https://recommended.example.com',
+							name: 'Recommended Blog',
+							feed_URL: 'https://recommended.example.com/feed',
+							icon: { ico: 'icon.png' },
+						},
+					],
+				},
+				{
+					type: 'new_sites',
+					data: [
+						{
+							feed_ID: 800,
+							URL: 'https://newsite.example.com',
+							name: 'New Site',
+							feed_URL: 'https://newsite.example.com/feed',
+						},
+					],
+				},
+			],
+			total_cards: 1,
+		};
+
+		it( 'hits /wpcom/v2/read/streams/discover with the discover-specific params', async () => {
+			let capturedQuery;
+			nock( BASE )
+				.get( '/wpcom/v2/read/streams/discover' )
+				.query( ( q ) => {
+					capturedQuery = q;
+					return true;
+				} )
+				.reply( 200, cardsResponse );
+
+			const { result } = runThunk( { streamKey: 'discover:recommended' } );
+			await result;
+
+			expect( capturedQuery ).toMatchObject( {
+				tag_recs_per_card: '5',
+				site_recs_per_card: '5',
+				age_based_decay: '0.5',
+				orderBy: 'popular',
+			} );
+		} );
+
+		it( 'splits cards into posts + recommendedSites and dispatches both seeds', async () => {
+			nock( BASE )
+				.get( '/wpcom/v2/read/streams/discover' )
+				.query( true )
+				.reply( 200, cardsResponse );
+
+			const { dispatch, result } = runThunk( { streamKey: 'discover:recommended' } );
+			await result;
+
+			const recommendedSiteActions = dispatch.mock.calls
+				.map( ( c ) => c[ 0 ] )
+				.filter( ( a ) => a && a.type === READER_RECOMMENDED_SITES_RECEIVE );
+
+			const seeds = recommendedSiteActions.map( ( a ) => a.seed );
+			expect( seeds ).toEqual(
+				expect.arrayContaining( [ 'discover-recommendations', 'discover-new-sites' ] )
+			);
+		} );
+
+		it( 'rewrites streamKey using user_interests for the bare discover:recommended request', async () => {
+			nock( BASE )
+				.get( '/wpcom/v2/read/streams/discover' )
+				.query( true )
+				.reply( 200, { ...cardsResponse, user_interests: [ 'photography', 'travel' ] } );
+
+			const { dispatch, result } = runThunk( { streamKey: 'discover:recommended' } );
+			await result;
+
+			const receivePageAction = dispatch.mock.calls
+				.map( ( c ) => c[ 0 ] )
+				.find( ( a ) => a && a.type === READER_STREAMS_PAGE_RECEIVE );
+
+			// Tags are sorted by buildDiscoverStreamKey so the streamKey is stable
+			// regardless of input order.
+			expect( receivePageAction.payload.streamKey ).toBe(
+				'discover:recommended--photography--travel'
+			);
+		} );
+
+		it( 'does not rewrite streamKey when one already includes user-interest tags', async () => {
+			nock( BASE )
+				.get( '/wpcom/v2/read/streams/discover' )
+				.query( true )
+				.reply( 200, { ...cardsResponse, user_interests: [ 'photography' ] } );
+
+			const { dispatch, result } = runThunk( {
+				streamKey: 'discover:recommended--photography--travel',
+			} );
+			await result;
+
+			const receivePageAction = dispatch.mock.calls
+				.map( ( c ) => c[ 0 ] )
+				.find( ( a ) => a && a.type === READER_STREAMS_PAGE_RECEIVE );
+			expect( receivePageAction.payload.streamKey ).toBe(
+				'discover:recommended--photography--travel'
+			);
+		} );
+
+		it( 'does not dispatch recommended-site actions when there are no card sites', async () => {
+			nock( BASE )
+				.get( '/wpcom/v2/read/streams/discover' )
+				.query( true )
+				.reply( 200, { cards: [ cardsResponse.cards[ 0 ] ] } );
+
+			const { dispatch, result } = runThunk( { streamKey: 'discover:recommended' } );
+			await result;
+
+			const types = dispatch.mock.calls
+				.map( ( c ) => c[ 0 ] )
+				.filter( ( a ) => a && typeof a === 'object' && a.type )
+				.map( ( a ) => a.type );
+			expect( types ).not.toContain( READER_RECOMMENDED_SITES_RECEIVE );
+			expect( types ).toContain( READER_STREAMS_PAGE_RECEIVE );
+		} );
+	} );
+
+	describe( 'other migrated `discover` sub-tabs', () => {
+		const postsResponse = {
+			posts: [
+				{
+					ID: 12,
+					site_ID: 202,
+					feed_ID: 997,
+					feed_item_ID: 52,
+					date: '2026-03-01',
+					URL: 'https://example.com/post-12',
+					site_name: 'Latest Example',
+				},
+			],
+			date_range: { after: '2026-03-01' },
+			found: 1,
+		};
+
+		it( 'discover:latest hits /wpcom/v2/read/tags/posts with orderBy=date', async () => {
+			let capturedQuery;
+			nock( BASE )
+				.get( '/wpcom/v2/read/tags/posts' )
+				.query( ( q ) => {
+					capturedQuery = q;
+					return true;
+				} )
+				.reply( 200, postsResponse );
+
+			const { dispatch, result } = runThunk( { streamKey: 'discover:latest' } );
+			await result;
+
+			expect( capturedQuery ).toMatchObject( {
+				tag_recs_per_card: '5',
+				site_recs_per_card: '5',
+				age_based_decay: '0.5',
+				orderBy: 'date',
+			} );
+			const types = dispatch.mock.calls
+				.map( ( c ) => c[ 0 ] )
+				.filter( ( a ) => a && typeof a === 'object' && a.type )
+				.map( ( a ) => a.type );
+			expect( types ).toContain( READER_STREAMS_PAGE_RECEIVE );
+		} );
+
+		it( 'discover:tags falls back to /wpcom/v2/read/streams/discover with the tag in the path', async () => {
+			let capturedQuery;
+			nock( BASE )
+				.get( '/wpcom/v2/read/streams/discover' )
+				.query( ( q ) => {
+					capturedQuery = q;
+					return true;
+				} )
+				.reply( 200, postsResponse );
+
+			const { result } = runThunk( { streamKey: 'discover:dailyprompt' } );
+			await result;
+
+			// `tags=dailyprompt` lives in the path; the rest of the params still get
+			// the discover extras with orderBy=date (since suffix !== `recommended`).
+			expect( capturedQuery ).toMatchObject( {
+				tags: 'dailyprompt',
+				orderBy: 'date',
+			} );
+		} );
+
+		it( 'discover:freshly-pressed hits /rest/v1.2/freshly-pressed without discover extras', async () => {
+			let capturedQuery;
+			nock( BASE )
+				.get( '/rest/v1.2/freshly-pressed' )
+				.query( ( q ) => {
+					capturedQuery = q;
+					return true;
+				} )
+				.reply( 200, postsResponse );
+
+			const { result } = runThunk( { streamKey: 'discover:freshly-pressed' } );
+			await result;
+
+			// freshly-pressed only sends the base stream params; the discover
+			// extras (tags, age decay, recs-per-card) must not be merged in.
+			expect( capturedQuery ).not.toHaveProperty( 'tag_recs_per_card' );
+			expect( capturedQuery ).not.toHaveProperty( 'site_recs_per_card' );
+			expect( capturedQuery ).not.toHaveProperty( 'age_based_decay' );
+			expect( capturedQuery ).not.toHaveProperty( 'tags' );
+		} );
+
+		it( 'does not rewrite streamKey for non-recommended sub-tabs even when user_interests is present', async () => {
+			nock( BASE )
+				.get( '/wpcom/v2/read/tags/posts' )
+				.query( true )
+				.reply( 200, { ...postsResponse, user_interests: [ 'travel' ] } );
+
+			const { dispatch, result } = runThunk( { streamKey: 'discover:latest' } );
+			await result;
+
+			const receivePageAction = dispatch.mock.calls
+				.map( ( c ) => c[ 0 ] )
+				.find( ( a ) => a && a.type === READER_STREAMS_PAGE_RECEIVE );
+			expect( receivePageAction.payload.streamKey ).toBe( 'discover:latest' );
 		} );
 	} );
 } );

--- a/client/state/reader/streams/test/actions.js
+++ b/client/state/reader/streams/test/actions.js
@@ -386,6 +386,12 @@ describe( 'requestPage thunk', () => {
 			expect( capturedQuery ).not.toHaveProperty( 'site_recs_per_card' );
 			expect( capturedQuery ).not.toHaveProperty( 'age_based_decay' );
 			expect( capturedQuery ).not.toHaveProperty( 'tags' );
+			// Legacy parity: this sub-tab bypassed `getQueryString`, so the
+			// default `orderBy=date`, `meta`, and `content_width` must not be
+			// added by the migrated path either.
+			expect( capturedQuery ).not.toHaveProperty( 'orderBy' );
+			expect( capturedQuery ).not.toHaveProperty( 'meta' );
+			expect( capturedQuery ).not.toHaveProperty( 'content_width' );
 		} );
 
 		it( 'does not rewrite streamKey for non-recommended sub-tabs even when user_interests is present', async () => {

--- a/client/state/reader/streams/test/migrated-stream-types.ts
+++ b/client/state/reader/streams/test/migrated-stream-types.ts
@@ -1,0 +1,21 @@
+/**
+ * @jest-environment node
+ */
+import { isMigratedStream } from '../migrated-stream-types';
+
+describe( 'isMigratedStream', () => {
+	it( 'returns true for `following`', () => {
+		expect( isMigratedStream( 'following' ) ).toBe( true );
+	} );
+
+	it( 'returns true for every `discover` sub-tab', () => {
+		expect( isMigratedStream( 'discover' ) ).toBe( true );
+	} );
+
+	it( 'returns false for unmigrated stream types', () => {
+		expect( isMigratedStream( 'site' ) ).toBe( false );
+		expect( isMigratedStream( 'feed' ) ).toBe( false );
+		expect( isMigratedStream( 'a8c' ) ).toBe( false );
+		expect( isMigratedStream( 'recommendations_posts' ) ).toBe( false );
+	} );
+} );

--- a/client/state/reader/streams/test/normalize.js
+++ b/client/state/reader/streams/test/normalize.js
@@ -7,8 +7,10 @@ import {
 	QUERY_META,
 	SITE_LIMITER_FIELDS,
 	analyticsForStream,
+	createStreamDataFromCards,
 	createStreamDataFromPosts,
 	createStreamItemFromPost,
+	createStreamSitesFromRecommendedSites,
 	extractPageHandle,
 	getAlgorithmForStream,
 	getQueryString,
@@ -127,6 +129,118 @@ describe( 'createStreamDataFromPosts', () => {
 		expect( result.streamItems ).toHaveLength( 2 );
 		expect( result.streamItems[ 0 ] ).toMatchObject( { blogId: 10, postId: 1, date: 'a' } );
 		expect( result.streamPosts ).toBe( posts );
+	} );
+} );
+
+describe( 'createStreamSitesFromRecommendedSites', () => {
+	it( 'returns an empty array for null/undefined input', () => {
+		expect( createStreamSitesFromRecommendedSites( null ) ).toEqual( [] );
+		expect( createStreamSitesFromRecommendedSites( undefined ) ).toEqual( [] );
+	} );
+
+	it( 'maps API site shape to the streamSites shape (with feedId mirror)', () => {
+		const result = createStreamSitesFromRecommendedSites( [
+			{
+				feed_ID: 700,
+				URL: 'https://recommended.example.com',
+				icon: { ico: 'icon.png' },
+				description: 'A recommendation',
+				name: 'Recommended Blog',
+				feed_URL: 'https://recommended.example.com/feed',
+			},
+		] );
+		expect( result ).toEqual( [
+			{
+				feed_ID: 700,
+				url: 'https://recommended.example.com',
+				site_icon: 'icon.png',
+				site_description: 'A recommendation',
+				site_name: 'Recommended Blog',
+				feed_URL: 'https://recommended.example.com/feed',
+				feedId: 700,
+			},
+		] );
+	} );
+
+	it( 'tolerates missing optional fields', () => {
+		const result = createStreamSitesFromRecommendedSites( [ { feed_ID: 1 } ] );
+		expect( result[ 0 ] ).toMatchObject( { feed_ID: 1, feedId: 1 } );
+		expect( result[ 0 ].site_icon ).toBeUndefined();
+	} );
+} );
+
+describe( 'createStreamDataFromCards', () => {
+	const postCard = {
+		type: 'post',
+		data: { ID: 1, site_ID: 10, date: '2026-01-01', URL: 'https://example.com/p' },
+	};
+	const recommendedCard = {
+		type: 'recommended_blogs',
+		data: [ { feed_ID: 700, URL: 'https://r.example.com', name: 'R' } ],
+	};
+	const newSitesCard = {
+		type: 'new_sites',
+		data: [ { feed_ID: 800, URL: 'https://n.example.com', name: 'N' } ],
+	};
+
+	it( 'returns empty buckets for null/undefined cards', () => {
+		expect( createStreamDataFromCards( null, 'date' ) ).toEqual( {
+			streamItems: [],
+			streamPosts: [],
+			streamSites: [],
+			streamNewSites: [],
+		} );
+		expect( createStreamDataFromCards( undefined, 'date' ) ).toEqual( {
+			streamItems: [],
+			streamPosts: [],
+			streamSites: [],
+			streamNewSites: [],
+		} );
+	} );
+
+	it( 'splits cards into posts, recommended sites, and new sites', () => {
+		const result = createStreamDataFromCards( [ postCard, recommendedCard, newSitesCard ], 'date' );
+		expect( result.streamPosts ).toEqual( [ postCard.data ] );
+		expect( result.streamItems ).toHaveLength( 1 );
+		expect( result.streamItems[ 0 ] ).toMatchObject( { blogId: 10, postId: 1 } );
+		expect( result.streamSites ).toEqual( [
+			expect.objectContaining( { feed_ID: 700, feedId: 700 } ),
+		] );
+		expect( result.streamNewSites ).toEqual( [
+			expect.objectContaining( { feed_ID: 800, feedId: 800 } ),
+		] );
+	} );
+
+	it( 'ignores card types it does not understand', () => {
+		const result = createStreamDataFromCards(
+			[ postCard, { type: 'unknown_card', data: { foo: 'bar' } } ],
+			'date'
+		);
+		expect( result.streamPosts ).toEqual( [ postCard.data ] );
+		expect( result.streamSites ).toEqual( [] );
+		expect( result.streamNewSites ).toEqual( [] );
+	} );
+
+	it( 'accumulates multiple post cards', () => {
+		const second = {
+			type: 'post',
+			data: { ID: 2, site_ID: 10, date: '2026-01-02', URL: 'https://example.com/q' },
+		};
+		const result = createStreamDataFromCards( [ postCard, second ], 'date' );
+		expect( result.streamPosts ).toHaveLength( 2 );
+		expect( result.streamItems ).toHaveLength( 2 );
+	} );
+
+	it( 'treats missing site arrays inside a card as empty', () => {
+		const result = createStreamDataFromCards(
+			[
+				{ type: 'recommended_blogs', data: null },
+				{ type: 'new_sites', data: null },
+			],
+			'date'
+		);
+		expect( result.streamSites ).toEqual( [] );
+		expect( result.streamNewSites ).toEqual( [] );
 	} );
 } );
 

--- a/packages/api-core/src/read-streams/fetchers.ts
+++ b/packages/api-core/src/read-streams/fetchers.ts
@@ -19,3 +19,60 @@ export const fetchReadFollowing = (
 		apiVersion: '1.2',
 		method: 'GET',
 	} );
+
+/**
+ * Fetch the discover (`recommended` sub-tab) stream.
+ *
+ * Hits `/read/streams/discover` on the `wpcom/v2` namespace.
+ */
+export const fetchReadDiscoverRecommended = (
+	params: ReadStreamQueryParams = {}
+): Promise< ReadStreamResponse > =>
+	wpcom.req.get( {
+		path: addQueryArgs( '/read/streams/discover', params ),
+		apiNamespace: 'wpcom/v2',
+		method: 'GET',
+	} );
+
+/**
+ * Fetch the discover `latest` sub-tab — recent posts across followed/default
+ * tags. Hits `/read/tags/posts` on the `wpcom/v2` namespace.
+ */
+export const fetchReadDiscoverLatest = (
+	params: ReadStreamQueryParams = {}
+): Promise< ReadStreamResponse > =>
+	wpcom.req.get( {
+		path: addQueryArgs( '/read/tags/posts', params ),
+		apiNamespace: 'wpcom/v2',
+		method: 'GET',
+	} );
+
+/**
+ * Fetch the discover `tags:<tag>` sub-tab — `/read/streams/discover` with a
+ * single tag in the `tags` query parameter. Forces `tags=<tag>` over whatever
+ * the caller passed (the thunk always populates `tags` from the streamKey, but
+ * for this sub-tab the suffix *is* the tag, so it has to win).
+ */
+export const fetchReadDiscoverTags = (
+	tag: string,
+	params: ReadStreamQueryParams = {}
+): Promise< ReadStreamResponse > =>
+	wpcom.req.get( {
+		path: addQueryArgs( '/read/streams/discover', { ...params, tags: tag } ),
+		apiNamespace: 'wpcom/v2',
+		method: 'GET',
+	} );
+
+/**
+ * Fetch the `/freshly-pressed` stream. Unlike the other discover sub-tabs this
+ * one uses REST `1.2` without a namespace and ignores the discover-specific
+ * extras (tags/age decay/etc.).
+ */
+export const fetchReadDiscoverFreshlyPressed = (
+	params: ReadStreamQueryParams = {}
+): Promise< ReadStreamResponse > =>
+	wpcom.req.get( {
+		path: addQueryArgs( '/freshly-pressed', params ),
+		apiVersion: '1.2',
+		method: 'GET',
+	} );

--- a/packages/api-core/src/read-streams/types.ts
+++ b/packages/api-core/src/read-streams/types.ts
@@ -20,8 +20,25 @@ export interface ReadStreamDateRange {
 	before?: string | null;
 }
 
+export interface ReadStreamRecommendedSite {
+	feed_ID?: number;
+	URL?: string;
+	icon?: { ico?: string };
+	description?: string;
+	name?: string;
+	feed_URL?: string;
+	[ key: string ]: unknown;
+}
+
+export type ReadStreamCard =
+	| { type: 'post'; data: ReadStreamPost }
+	| { type: 'recommended_blogs'; data: ReadStreamRecommendedSite[] }
+	| { type: 'new_sites'; data: ReadStreamRecommendedSite[] }
+	| { type: string; data: unknown };
+
 export interface ReadStreamResponse {
 	posts?: ReadStreamPost[];
+	cards?: ReadStreamCard[];
 	date_range?: ReadStreamDateRange;
 	next_page?: string;
 	next_page_handle?: string;

--- a/packages/api-core/src/read-streams/types.ts
+++ b/packages/api-core/src/read-streams/types.ts
@@ -33,8 +33,7 @@ export interface ReadStreamRecommendedSite {
 export type ReadStreamCard =
 	| { type: 'post'; data: ReadStreamPost }
 	| { type: 'recommended_blogs'; data: ReadStreamRecommendedSite[] }
-	| { type: 'new_sites'; data: ReadStreamRecommendedSite[] }
-	| { type: string; data: unknown };
+	| { type: 'new_sites'; data: ReadStreamRecommendedSite[] };
 
 export interface ReadStreamResponse {
 	posts?: ReadStreamPost[];

--- a/packages/api-queries/src/read-streams.ts
+++ b/packages/api-queries/src/read-streams.ts
@@ -1,4 +1,8 @@
 import {
+	fetchReadDiscoverFreshlyPressed,
+	fetchReadDiscoverLatest,
+	fetchReadDiscoverRecommended,
+	fetchReadDiscoverTags,
 	fetchReadFollowing,
 	type ReadStreamQueryParams,
 	type ReadStreamResponse,
@@ -12,12 +16,34 @@ const getStreamType = ( streamKey: string ): string => {
 	return colon === -1 ? streamKey : streamKey.substring( 0, colon );
 };
 
+const streamKeySuffix = ( streamKey: string ): string =>
+	streamKey.substring( streamKey.indexOf( ':' ) + 1 );
+
+const fetchDiscover = (
+	streamKey: string,
+	queryParams: ReadStreamQueryParams
+): Promise< ReadStreamResponse > => {
+	const suffix = streamKeySuffix( streamKey );
+	if ( suffix.startsWith( 'recommended' ) ) {
+		return fetchReadDiscoverRecommended( queryParams );
+	}
+	if ( suffix.startsWith( 'latest' ) ) {
+		return fetchReadDiscoverLatest( queryParams );
+	}
+	if ( suffix === 'freshly-pressed' ) {
+		return fetchReadDiscoverFreshlyPressed( queryParams );
+	}
+	// Tag fallback: anything else (e.g. `discover:dailyprompt`) is treated as a
+	// single-tag query against `/read/streams/discover?tags=<suffix>`.
+	return fetchReadDiscoverTags( suffix, queryParams );
+};
+
 /**
  * React Query factory for Reader stream pages (READ-485).
  *
- * Only `following` is wired in this PR. The remaining stream types
- * (`recent`, `feed`, `site`, `featured`, `tag`, `tag_popular`, `p2`, `a8c`,
- * `likes`, `notifications`, `user`, `on_this_day`, `discover:*`, `search`,
+ * Migrated so far: `following` and every `discover:*` sub-tab. The remaining
+ * stream types (`recent`, `feed`, `site`, `featured`, `tag`, `tag_popular`,
+ * `p2`, `a8c`, `likes`, `notifications`, `user`, `on_this_day`, `search`,
  * `list`, `conversations`, `conversations-a8c`, `recommendations_posts`,
  * `custom_recs_*`) are migrated incrementally in the follow-up PRs of this
  * same task — each PR adds the fetcher in `@automattic/api-core`, a case in
@@ -39,6 +65,8 @@ export const readStreamQuery = (
 			switch ( streamType ) {
 				case 'following':
 					return fetchReadFollowing( queryParams );
+				case 'discover':
+					return fetchDiscover( streamKey, queryParams );
 				default:
 					throw new Error(
 						`readStreamQuery: unsupported streamType "${ streamType }". Add the fetcher in @automattic/api-core and a case here when migrating this stream.`

--- a/packages/api-queries/src/read-streams.ts
+++ b/packages/api-queries/src/read-streams.ts
@@ -47,7 +47,7 @@ const fetchDiscover = (
  * `list`, `conversations`, `conversations-a8c`, `recommendations_posts`,
  * `custom_recs_*`) are migrated incrementally in the follow-up PRs of this
  * same task — each PR adds the fetcher in `@automattic/api-core`, a case in
- * the switch below, and the streamType to `MIGRATED_STREAM_TYPES` in
+ * the switch below, and the streamType to the `isMigratedStream` gate in
  * `client/state/reader/streams/migrated-stream-types.ts`. Until then those
  * streams keep flowing through the legacy data-layer at
  * `client/state/data-layer/wpcom/read/streams/index.js` and never reach this


### PR DESCRIPTION
Closes READ-497 (sub-task of READ-485)

## Proposed Changes

* Add 4 fetchers in `@automattic/api-core/read-streams`: `fetchReadDiscoverRecommended`, `fetchReadDiscoverLatest`, `fetchReadDiscoverTags`, `fetchReadDiscoverFreshlyPressed`. Extends `ReadStreamResponse` with `cards`/`ReadStreamCard`/`ReadStreamRecommendedSite`.
* In `@automattic/api-queries/read-streams`, add a `case 'discover'` that sub-routes by streamKey suffix (recommended → /read/streams/discover; latest → /read/tags/posts; freshly-pressed → REST 1.2 /freshly-pressed; everything else falls back to /read/streams/discover with the suffix as `tags`).
* Move the cards-handling helpers (`createStreamDataFromCards`, `createStreamSitesFromRecommendedSites`) into `client/state/reader/streams/normalize.ts` so the migrated thunk and the legacy data-layer can share them. Add unit tests for both.
* Extend the migrated thunk in `client/state/reader/streams/actions.js` to: apply discover-specific query params per sub-tab (`orderBy: popular` for recommended, `date` for latest/tags, no extras for freshly-pressed), split the response into posts + recommended sites + new sites, dispatch `receiveRecommendedSites` for the `discover-recommendations` and `discover-new-sites` seeds, and rewrite the streamKey via `buildDiscoverStreamKey('recommended', user_interests)` for the bare `discover:recommended` request.
* Add `'discover'` to `MIGRATED_STREAM_TYPES`, simplify `isMigratedStream(streamType)` back to a set lookup, delete the `discover` entry and now-dead cards/recommended-sites/streamKey-rewrite branches from the legacy data-layer in `client/state/data-layer/wpcom/read/streams/index.js`, and update its tests so every migrated discover streamKey is asserted to be a no-op.

## Why are these changes being made?

* Continues the incremental migration started by #110369 (`following`). Routes Discover through `@automattic/api-queries`/TanStack Query so it benefits from a single client-wide cache and the same dedup/poll behavior the rest of the migration is converging on, and shrinks the legacy data-layer by removing the most complex stream entry. With this PR the gate is back to a plain set, since no other streamType is migrated incrementally per sub-key.

## Testing Instructions

* `yarn test-client client/state/reader/streams/test/ client/state/data-layer/wpcom/read/streams/test/` — 105 tests, all passing.
* Run `yarn start` and visit `/discover/recommended`, `/discover/latest`, `/discover/tags`, and the freshly-pressed sub-tab. Confirm posts render, pagination works, and that the recommended-blogs/new-sites cards appear in the sidebar on `/discover/recommended`.
* Open DevTools Network: every discover request should hit `wpcom/v2` (or `/rest/v1.2/freshly-pressed` for the freshly-pressed sub-tab) and there should be no duplicate request from the legacy data-layer.
* Confirm SSR for `/discover` still renders the placeholder shell (no data prefetch was added or removed; `index.node.js` is unchanged).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?