### PR TITLE
Reader: migrate remaining date-based streams to React Query (READ-485)

### DIFF
--- a/client/reader/on-this-day/index.tsx
+++ b/client/reader/on-this-day/index.tsx
@@ -197,7 +197,7 @@ export const OnThisDay = ( { viewToggle, streamKey }: OnThisDayProps ) => {
 				streamKey,
 				page: view.page,
 				perPage: view.perPage,
-			} ) as UnknownAction
+			} )
 		);
 	}, [ dispatch, view, streamKey ] );
 

--- a/client/reader/onboarding-rsm/subscribe-modal/index.tsx
+++ b/client/reader/onboarding-rsm/subscribe-modal/index.tsx
@@ -7,7 +7,6 @@ import clsx from 'clsx';
 import { getLocaleSlug } from 'i18n-calypso';
 import React, { useMemo, useState, ComponentType, useEffect, useCallback } from 'react';
 import { useSelector } from 'react-redux';
-import { AnyAction } from 'redux';
 import ConnectedReaderSubscriptionListItem from 'calypso/blocks/reader-subscription-list-item/connected';
 import { useFollowedReaderTags } from 'calypso/data/reader/use-reader-tags';
 import wpcom from 'calypso/lib/wp';
@@ -290,7 +289,7 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 				streamKey: 'recent',
 				page: 1,
 				perPage: 10,
-			} ) as AnyAction
+			} )
 		);
 
 		handleClose();

--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -7,7 +7,6 @@ import clsx from 'clsx';
 import { getLocaleSlug } from 'i18n-calypso';
 import React, { useMemo, useState, ComponentType, useEffect, useCallback } from 'react';
 import { useSelector } from 'react-redux';
-import { AnyAction } from 'redux';
 import ConnectedReaderSubscriptionListItem from 'calypso/blocks/reader-subscription-list-item/connected';
 import { useFollowedReaderTags } from 'calypso/data/reader/use-reader-tags';
 import wpcom from 'calypso/lib/wp';
@@ -286,7 +285,7 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 				streamKey: 'recent',
 				page: 1,
 				perPage: 10,
-			} ) as AnyAction
+			} )
 		);
 
 		handleClose();

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -182,7 +182,7 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 				streamKey,
 				page: view.page,
 				perPage: view.perPage,
-			} ) as UnknownAction
+			} )
 		);
 	}, [ dispatch, view, streamKey ] );
 

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -34,27 +34,6 @@ import {
 // Re-exported for legacy consumers (e.g. client/reader/stream/index.jsx).
 export { PER_FETCH, INITIAL_FETCH, QUERY_META, SITE_LIMITER_FIELDS };
 
-/**
- * Pull the suffix off of a stream key
- *
- * A stream key is a : delimited string, with the form
- * {prefix}:{suffix}
- *
- * Prefix cannot contain a colon, while the suffix may.
- *
- * A colon is not required.
- *
- * Valid IDs look like
- * `following`
- * `site:1234`
- * `search:a:value` ( prefix is `search`, suffix is `a:value` )
- * @param  {string} streamKey The stream ID to break apart
- * @returns {string}          The stream ID suffix
- */
-function streamKeySuffix( streamKey ) {
-	return streamKey.substring( streamKey.indexOf( ':' ) + 1 );
-}
-
 function createStreamItemFromSiteAndPost( site, post, dateProperty ) {
 	return {
 		...keyForPost( post ),
@@ -102,61 +81,11 @@ const defaultQueryFn = getQueryString;
 const seed = random( 0, 1000 );
 
 const streamApis = {
-	following: {
-		path: () => '/read/following',
-		dateProperty: 'date',
-	},
-	recent: {
-		path: () => '/read/streams/following',
-		dateProperty: 'date',
-		apiNamespace: () => 'wpcom/v2',
-		query: ( extras, { streamKey } ) => {
-			const feedId = streamKeySuffix( streamKey );
-			const queryParams = { ...extras };
-			if ( feedId !== 'recent' ) {
-				// 'recent' without a suffix means don't filter by feedId
-				queryParams.feed_id = feedId;
-			}
-			return getQueryString( queryParams );
-		},
-	},
-	search: {
-		path: () => '/read/search',
-		dateProperty: 'date',
-		query: ( pageHandle, { streamKey } ) => {
-			const { sort, q } = JSON.parse( streamKeySuffix( streamKey ) );
-			return { sort, q, ...pageHandle, content_width: 675 };
-		},
-	},
-	feed: {
-		path: ( { streamKey } ) => `/read/feed/${ streamKeySuffix( streamKey ) }/posts`,
-		dateProperty: 'date',
-	},
-	site: {
-		path: ( { streamKey } ) => `/read/sites/${ streamKeySuffix( streamKey ) }/posts`,
-		dateProperty: 'date',
-	},
 	conversations: {
 		path: () => '/read/conversations',
 		dateProperty: 'last_comment_date_gmt',
 		query: ( extras ) => getQueryString( { ...extras, comments_per_post: 20 } ),
 		pollQuery: () => getQueryStringForPoll( [ 'last_comment_date_gmt', 'comments' ] ),
-	},
-	notifications: {
-		path: () => '/read/notifications',
-		dateProperty: 'date',
-	},
-	featured: {
-		path: ( { streamKey } ) => `/read/sites/${ streamKeySuffix( streamKey ) }/featured`,
-		dateProperty: 'date',
-	},
-	p2: {
-		path: () => '/read/following/p2',
-		dateProperty: 'date',
-	},
-	a8c: {
-		path: () => '/read/a8c',
-		dateProperty: 'date',
 	},
 	'conversations-a8c': {
 		path: () => '/read/conversations',
@@ -199,61 +128,6 @@ const streamApis = {
 		// Recommended sites can only return a max of 10 sites per request, so we need to override the default number.
 		pollQuery: ( extraFields = [], extraQueryParams = {} ) =>
 			getQueryStringForPoll( extraFields, { ...extraQueryParams, number: 10 } ),
-	},
-	tag: {
-		path: ( { streamKey } ) => `/read/tags/${ streamKeySuffix( streamKey ) }/posts`,
-		apiNamespace: () => 'wpcom/v2',
-		dateProperty: 'date',
-	},
-	tag_popular: {
-		path: ( { streamKey } ) => `/read/streams/tag/${ streamKeySuffix( streamKey ) }`,
-		apiNamespace: () => 'wpcom/v2',
-		query: ( extras, { streamKey } ) =>
-			getQueryString( {
-				...extras,
-				tags: streamKeySuffix( streamKey ),
-				tag_recs_per_card: 5,
-				site_recs_per_card: 5,
-			} ),
-	},
-	list: {
-		path: ( { streamKey } ) => {
-			const { owner, slug } = JSON.parse( streamKeySuffix( streamKey ) );
-			return `/read/list/${ owner }/${ slug }/posts`;
-		},
-		dateProperty: 'date',
-		apiVersion: '1.3',
-		query: ( extras, { pageHandle } ) => {
-			return {
-				...{ extras, number: 40 },
-				...pageHandle,
-			};
-		},
-	},
-	user: {
-		path: ( { streamKey } ) => `/users/${ streamKeySuffix( streamKey ) }/posts`,
-		dateProperty: 'date',
-		apiVersion: '1',
-		pollQuery: () => getQueryStringForPoll( [], { number: 20 } ),
-	},
-	on_this_day: {
-		path: () => '/read/streams/on-this-day',
-		dateProperty: 'date',
-		apiNamespace: () => 'wpcom/v2',
-		query: ( extras, { streamKey } ) => {
-			const base = { ...extras, number: 15 };
-			if ( streamKey?.startsWith( 'on_this_day:' ) ) {
-				const parts = streamKey.split( ':' );
-				if ( parts.length >= 3 ) {
-					const month = parseInt( parts[ 1 ], 10 );
-					const day = parseInt( parts[ 2 ], 10 );
-					if ( Number.isFinite( month ) && Number.isFinite( day ) ) {
-						return getQueryString( { ...base, month, day } );
-					}
-				}
-			}
-			return getQueryString( base );
-		},
 	},
 };
 

--- a/client/state/data-layer/wpcom/read/streams/test/index.js
+++ b/client/state/data-layer/wpcom/read/streams/test/index.js
@@ -34,10 +34,10 @@ function makeAction( { streamKey, ...overrides } ) {
 }
 
 describe( 'streams', () => {
-	// `following` is migrated to React Query (see
-	// client/state/reader/streams/test/actions.js). Use a still-unmigrated
-	// stream type for the shared `handlePage` action below.
-	const action = makeAction( { streamKey: 'site:1234' } );
+	// All `date`-based streams plus `following`/`discover` are migrated to
+	// React Query (see client/state/reader/streams/test/actions.js). Use a
+	// still-unmigrated stream type for the shared `handlePage` action below.
+	const action = makeAction( { streamKey: 'conversations' } );
 
 	describe( 'requestPage', () => {
 		const query = {
@@ -57,6 +57,21 @@ describe( 'streams', () => {
 			'discover:tags',
 			'discover:dailyprompt',
 			'discover:freshly-pressed',
+			'recent',
+			'recent:1234',
+			'search:{"q":"foo","sort":"date"}',
+			'feed:1234',
+			'site:1234',
+			'notifications',
+			'featured:1234',
+			'p2',
+			'a8c',
+			'tag:photography',
+			'tag_popular:photography',
+			'list:{"owner":"alice","slug":"favs"}',
+			'on_this_day',
+			'on_this_day:3:15',
+			'user:42',
 		] )( 'returns undefined for migrated streamKey %s', ( streamKey ) => {
 			expect( requestPage( makeAction( { streamKey } ) ) ).toBeUndefined();
 		} );
@@ -66,24 +81,6 @@ describe( 'streams', () => {
 			// each test is an assertion of the http call that should be made
 			// when the given stream id is handed to request page
 			[
-				{
-					stream: 'a8c',
-					expected: {
-						method: 'GET',
-						path: '/read/a8c',
-						apiVersion: '1.2',
-						query,
-					},
-				},
-				{
-					stream: 'p2',
-					expected: {
-						method: 'GET',
-						path: '/read/following/p2',
-						apiVersion: '1.2',
-						query,
-					},
-				},
 				{
 					stream: 'conversations',
 					expected: {
@@ -100,63 +97,6 @@ describe( 'streams', () => {
 						path: '/read/conversations',
 						apiVersion: '1.2',
 						query: { ...query, comments_per_post: 20, index: 'a8c' },
-					},
-				},
-				{
-					stream: 'search: { "q": "foo", "sort": "date" }',
-					expected: {
-						method: 'GET',
-						path: '/read/search',
-						apiVersion: '1.2',
-						query: {
-							sort: 'date',
-							q: 'foo',
-							lang: 'en',
-							number: INITIAL_FETCH,
-							content_width: 675,
-						},
-					},
-				},
-				{
-					stream: 'search: { "q": "foo:bar", "sort": "relevance" }',
-					expected: {
-						method: 'GET',
-						path: '/read/search',
-						apiVersion: '1.2',
-						query: {
-							sort: 'relevance',
-							q: 'foo:bar',
-							lang: 'en',
-							number: INITIAL_FETCH,
-							content_width: 675,
-						},
-					},
-				},
-				{
-					stream: 'feed:1234',
-					expected: {
-						method: 'GET',
-						path: '/read/feed/1234/posts',
-						apiVersion: '1.2',
-						query,
-					},
-				},
-				{
-					stream: 'site:1234',
-					expected: {
-						method: 'GET',
-						path: '/read/sites/1234/posts',
-						apiVersion: '1.2',
-						query,
-					},
-				},
-				{
-					stream: 'featured:1234',
-					expected: {
-						method: 'GET',
-						path: '/read/sites/1234/featured',
-						apiVersion: '1.2',
-						query,
 					},
 				},
 				{

--- a/client/state/reader/streams/actions.js
+++ b/client/state/reader/streams/actions.js
@@ -58,6 +58,10 @@ function buildPageRequestAction( {
 	};
 }
 
+function streamKeySuffix( streamKey ) {
+	return streamKey.substring( streamKey.indexOf( ':' ) + 1 );
+}
+
 /**
  * Build the WordPress.com REST query payload for a migrated stream request.
  *
@@ -88,6 +92,10 @@ function buildStreamQueryParams( {
 	const commonQueryParams = { ...algorithm, feed_id: feedId };
 
 	if ( isPoll ) {
+		if ( streamType === 'user' ) {
+			// Legacy `streamApis.user.pollQuery` polled with `number: 20`.
+			return getQueryStringForPoll( [], { ...commonQueryParams, number: 20 } );
+		}
 		return getQueryStringForPoll( [], commonQueryParams );
 	}
 	const extras = {
@@ -97,10 +105,88 @@ function buildStreamQueryParams( {
 		lang,
 		page,
 	};
-	if ( streamType === 'discover' ) {
-		return buildDiscoverQueryParams( extras, streamKey );
+	switch ( streamType ) {
+		case 'discover':
+			return buildDiscoverQueryParams( extras, streamKey );
+		case 'recent':
+			return buildRecentQueryParams( extras, streamKey );
+		case 'search':
+			return buildSearchQueryParams( extras, streamKey );
+		case 'tag_popular':
+			return buildTagPopularQueryParams( extras, streamKey );
+		case 'list':
+			return buildListQueryParams( extras );
+		case 'on_this_day':
+			return buildOnThisDayQueryParams( extras, streamKey );
+		default:
+			return getQueryString( extras );
 	}
-	return getQueryString( extras );
+}
+
+/**
+ * `recent` filters by feed_id when the streamKey carries a suffix. Mirrors
+ * `streamApis.recent.query` in the legacy data-layer.
+ */
+function buildRecentQueryParams( extras, streamKey ) {
+	const suffix = streamKeySuffix( streamKey );
+	const queryParams = { ...extras };
+	if ( suffix !== 'recent' ) {
+		queryParams.feed_id = suffix;
+	}
+	return getQueryString( queryParams );
+}
+
+/**
+ * `search` parses `{ sort, q }` out of the streamKey suffix and (in the
+ * legacy data-layer) skipped `getQueryString`, so `meta`/`orderBy` are not
+ * defaulted — only `content_width` is added explicitly.
+ */
+function buildSearchQueryParams( extras, streamKey ) {
+	const { sort, q } = JSON.parse( streamKeySuffix( streamKey ) );
+	return { sort, q, ...extras, content_width: 675 };
+}
+
+/**
+ * `tag_popular` always carries the suffix as `tags=` plus the
+ * recommendation-card extras. Mirrors `streamApis.tag_popular.query`.
+ */
+function buildTagPopularQueryParams( extras, streamKey ) {
+	return getQueryString( {
+		...extras,
+		tags: streamKeySuffix( streamKey ),
+		tag_recs_per_card: 5,
+		site_recs_per_card: 5,
+	} );
+}
+
+/**
+ * Behaviour change vs. the legacy data-layer: the legacy `streamApis.list.query`
+ * shipped a typoed spread (`...{ extras, number: 40 }`) that wrapped extras
+ * under the literal key `extras`, dropping meta/orderBy/content_width/lang/
+ * feed_id/algorithm/page from the wire query. Fixed here so list streams send
+ * the same enriched query shape as every other stream.
+ */
+function buildListQueryParams( extras ) {
+	return getQueryString( { ...extras, number: 40 } );
+}
+
+/**
+ * `on_this_day` parses optional `month`/`day` numerics out of the streamKey
+ * suffix (`on_this_day:{m}:{d}`) and always pins `number: 15`.
+ */
+function buildOnThisDayQueryParams( extras, streamKey ) {
+	const base = { ...extras, number: 15 };
+	if ( streamKey?.startsWith( 'on_this_day:' ) ) {
+		const parts = streamKey.split( ':' );
+		if ( parts.length >= 3 ) {
+			const month = parseInt( parts[ 1 ], 10 );
+			const day = parseInt( parts[ 2 ], 10 );
+			if ( Number.isFinite( month ) && Number.isFinite( day ) ) {
+				return getQueryString( { ...base, month, day } );
+			}
+		}
+	}
+	return getQueryString( base );
 }
 
 function discoverSubTab( streamKey ) {
@@ -192,9 +278,9 @@ async function dispatchMigratedStreamRequest( dispatch, params ) {
 		return;
 	}
 
-	// `dateProperty` will diverge per streamType once we migrate
-	// `conversations`/`likes`. For now `following` and `discover:recommended`
-	// both use `date`.
+	// Every migrated streamType uses `date`. This will need to become
+	// per-streamType once `conversations` (`last_comment_date_gmt`) and
+	// `likes` (`date_liked`) migrate.
 	const dateProperty = 'date';
 	let streamItems = [];
 	let streamPosts = [];
@@ -387,21 +473,43 @@ export function clearStream( { streamKey } ) {
 	};
 }
 
-export function requestPaginatedStream( { streamKey, page = 1, perPage = 10, localeSlug = null } ) {
-	const streamType = getStreamType( streamKey );
+export const requestPaginatedStream =
+	( { streamKey, page = 1, perPage = 10, localeSlug = null } ) =>
+	( dispatch ) => {
+		const streamType = getStreamType( streamKey );
+		const action = {
+			type: READER_STREAMS_PAGINATED_REQUEST,
+			payload: {
+				streamKey,
+				streamType,
+				isPoll: false,
+				page,
+				perPage,
+				localeSlug,
+			},
+		};
 
-	return {
-		type: READER_STREAMS_PAGINATED_REQUEST,
-		payload: {
+		// Dispatch so the reducer's `isRequesting`/`error` transitions still
+		// fire. For unmigrated streams the legacy data-layer handles
+		// READER_STREAMS_PAGINATED_REQUEST and issues the HTTP request.
+		dispatch( action );
+
+		if ( ! isMigratedStream( streamType ) ) {
+			return action;
+		}
+
+		// SSR no-op: matches the legacy data-layer.
+		if ( typeof window === 'undefined' ) {
+			return;
+		}
+
+		return dispatchMigratedStreamRequest( dispatch, {
 			streamKey,
-			streamType,
-			isPoll: false,
 			page,
 			perPage,
 			localeSlug,
-		},
+		} );
 	};
-}
 
 /**
  * Returns an action object to signal that an error was encountered

--- a/client/state/reader/streams/actions.js
+++ b/client/state/reader/streams/actions.js
@@ -119,8 +119,10 @@ function discoverSubTab( streamKey ) {
 }
 
 /**
- * Build the query params for a discover sub-tab so the migrated request hits
- * the API with the same shape the legacy data-layer used.
+ * Build the query params for a discover sub-tab. Mirrors the legacy
+ * `streamApis.discover.query` in
+ * `client/state/data-layer/wpcom/read/streams/index.js` so the migrated request
+ * hits the API with the same shape.
  *
  * - `freshly-pressed` returns the raw extras (no `getQueryString` wrap), so it
  *   does not pick up `meta`/`content_width`/default `orderBy`.

--- a/client/state/reader/streams/actions.js
+++ b/client/state/reader/streams/actions.js
@@ -257,7 +257,14 @@ async function dispatchMigratedStreamRequest( dispatch, params ) {
 	let data;
 	try {
 		const queryClient = getCalypsoQueryClient();
-		const queryOpts = readStreamQuery( streamKey, queryParams, pageHandle ?? null );
+		// `readStreamQuery`'s third arg is the per-request cache-key discriminator.
+		// Cursor-paginated streams pass `pageHandle`; numbered-page streams (e.g.
+		// `recent`) carry no `pageHandle`, so we key on `{ page, perPage }`
+		// instead. Without this, two in-flight paginated requests for the same
+		// `streamKey` collapse to one promise via `fetchQuery` dedup, and the
+		// later page receives the earlier page's rows.
+		const cacheKey = page != null ? { page, perPage } : pageHandle ?? null;
+		const queryOpts = readStreamQuery( streamKey, queryParams, cacheKey );
 		// Every call into this thunk represents an explicit intent to fetch
 		// (initial load, pagination, poll, refresh after `clearStream`, locale
 		// change). The legacy data-layer always hit the network, so callers

--- a/client/state/reader/streams/migrated-stream-types.ts
+++ b/client/state/reader/streams/migrated-stream-types.ts
@@ -6,10 +6,28 @@
  *
  * Each PR in the READ-485 migration extends this once the matching fetcher
  * exists in `@automattic/api-core` and is wired into `readStreamQuery` in
- * `@automattic/api-queries`. When every stream type is covered the gate and
- * the legacy data-layer file are removed in the cleanup PR.
+ * `@automattic/api-queries`. Streams still served by the legacy data-layer:
+ * `conversations`, `conversations-a8c`, `likes`, `recommendations_posts`,
+ * `custom_recs_posts_with_images`, `custom_recs_sites_with_images`. Those
+ * land in a final cleanup PR that deletes the data-layer file entirely.
  */
-const MIGRATED_STREAM_TYPES: ReadonlySet< string > = new Set( [ 'following', 'discover' ] );
+const MIGRATED_STREAM_TYPES: ReadonlySet< string > = new Set( [
+	'following',
+	'discover',
+	'recent',
+	'search',
+	'feed',
+	'site',
+	'notifications',
+	'featured',
+	'p2',
+	'a8c',
+	'tag',
+	'tag_popular',
+	'list',
+	'on_this_day',
+	'user',
+] );
 
 export function isMigratedStream( streamType: string ): boolean {
 	return MIGRATED_STREAM_TYPES.has( streamType );

--- a/client/state/reader/streams/normalize.ts
+++ b/client/state/reader/streams/normalize.ts
@@ -146,8 +146,7 @@ const EMPTY_BUCKETS: CardBuckets = { cardPosts: [], cardRecommendedSites: [], ne
 /**
  * Split a `cards` payload (used by `discover:recommended` and tag-specific
  * `discover:<tag>` streams) into post stream items, recommended sites, and
- * new sites.
- * Mirrors the legacy `createStreamDataFromCards` in
+ * new sites. Mirrors the legacy `createStreamDataFromCards` in
  * `client/state/data-layer/wpcom/read/streams/index.js`.
  */
 export function createStreamDataFromCards(

--- a/client/state/reader/streams/normalize.ts
+++ b/client/state/reader/streams/normalize.ts
@@ -147,6 +147,8 @@ const EMPTY_BUCKETS: CardBuckets = { cardPosts: [], cardRecommendedSites: [], ne
  * Split a `cards` payload (used by `discover:recommended` and tag-specific
  * `discover:<tag>` streams) into post stream items, recommended sites, and
  * new sites.
+ * Mirrors the legacy `createStreamDataFromCards` in
+ * `client/state/data-layer/wpcom/read/streams/index.js`.
  */
 export function createStreamDataFromCards(
 	cards: RawCard[] | null | undefined,

--- a/client/state/reader/streams/test/actions.js
+++ b/client/state/reader/streams/test/actions.js
@@ -65,13 +65,13 @@ afterEach( () => {
 describe( 'requestPage thunk', () => {
 	describe( 'unmigrated stream type', () => {
 		it( 'dispatches the legacy READER_STREAMS_PAGE_REQUEST', () => {
-			const { dispatch } = runThunk( { streamKey: 'site:1234' } );
+			const { dispatch } = runThunk( { streamKey: 'conversations' } );
 			expect( dispatch ).toHaveBeenCalledTimes( 1 );
 			const action = dispatch.mock.calls[ 0 ][ 0 ];
 			expect( action.type ).toBe( READER_STREAMS_PAGE_REQUEST );
 			expect( action.payload ).toMatchObject( {
-				streamKey: 'site:1234',
-				streamType: 'site',
+				streamKey: 'conversations',
+				streamType: 'conversations',
 				isPoll: false,
 			} );
 		} );
@@ -658,5 +658,67 @@ describe( 'requestPaginatedStream thunk', () => {
 			payload: { streamKey: 'conversations', page: 1, perPage: 10 },
 		} );
 		expect( dispatch ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'does not collapse overlapping page requests for the same streamKey', async () => {
+		// Both pages in flight at once must hit the network independently —
+		// otherwise `fetchQuery` dedups them and page 2 receives page 1's rows.
+		const page1Response = {
+			...recentResponse,
+			posts: [
+				{
+					...recentResponse.posts[ 0 ],
+					ID: 1,
+					feed_item_ID: 1,
+					URL: 'https://example.com/post-1',
+				},
+			],
+		};
+		const page2Response = {
+			...recentResponse,
+			posts: [
+				{
+					...recentResponse.posts[ 0 ],
+					ID: 2,
+					feed_item_ID: 2,
+					URL: 'https://example.com/post-2',
+				},
+			],
+		};
+
+		nock( BASE )
+			.get( '/wpcom/v2/read/streams/following' )
+			.query( ( q ) => q.page === '1' )
+			.reply( 200, page1Response );
+		nock( BASE )
+			.get( '/wpcom/v2/read/streams/following' )
+			.query( ( q ) => q.page === '2' )
+			.reply( 200, page2Response );
+
+		const { dispatch: dispatch1, result: result1 } = runPaginatedThunk( {
+			streamKey: 'recent',
+			page: 1,
+			perPage: 10,
+		} );
+		const { dispatch: dispatch2, result: result2 } = runPaginatedThunk( {
+			streamKey: 'recent',
+			page: 2,
+			perPage: 10,
+		} );
+		await Promise.all( [ result1, result2 ] );
+
+		const findReceive = ( dispatch ) =>
+			dispatch.mock.calls
+				.map( ( c ) => c[ 0 ] )
+				.find( ( a ) => a && a.type === READER_STREAMS_PAGE_RECEIVE );
+
+		const receive1 = findReceive( dispatch1 );
+		const receive2 = findReceive( dispatch2 );
+
+		expect( receive1.payload.page ).toBe( 1 );
+		expect( receive2.payload.page ).toBe( 2 );
+		expect( receive1.payload.streamItems[ 0 ].postId ).not.toBe(
+			receive2.payload.streamItems[ 0 ].postId
+		);
 	} );
 } );

--- a/client/state/reader/streams/test/actions.js
+++ b/client/state/reader/streams/test/actions.js
@@ -11,7 +11,7 @@ import {
 	READER_POSTS_RECEIVE,
 	READER_RECOMMENDED_SITES_RECEIVE,
 } from 'calypso/state/reader/action-types';
-import { requestPage } from '../actions';
+import { requestPage, requestPaginatedStream } from '../actions';
 
 const BASE = 'https://public-api.wordpress.com';
 
@@ -43,15 +43,26 @@ function runThunk( params ) {
 	return { dispatch, result };
 }
 
-describe( 'requestPage thunk', () => {
-	beforeEach( () => {
-		mockQueryClient = newClient();
+function runPaginatedThunk( params ) {
+	const dispatch = jest.fn( ( action ) => {
+		if ( typeof action === 'function' ) {
+			return action( dispatch, () => ( {} ) );
+		}
+		return action;
 	} );
-	afterEach( () => {
-		nock.cleanAll();
-		mockQueryClient = null;
-	} );
+	const result = requestPaginatedStream( params )( dispatch );
+	return { dispatch, result };
+}
 
+beforeEach( () => {
+	mockQueryClient = newClient();
+} );
+afterEach( () => {
+	nock.cleanAll();
+	mockQueryClient = null;
+} );
+
+describe( 'requestPage thunk', () => {
 	describe( 'unmigrated stream type', () => {
 		it( 'dispatches the legacy READER_STREAMS_PAGE_REQUEST', () => {
 			const { dispatch } = runThunk( { streamKey: 'site:1234' } );
@@ -408,5 +419,244 @@ describe( 'requestPage thunk', () => {
 				.find( ( a ) => a && a.type === READER_STREAMS_PAGE_RECEIVE );
 			expect( receivePageAction.payload.streamKey ).toBe( 'discover:latest' );
 		} );
+	} );
+
+	const baseResponse = {
+		posts: [
+			{
+				ID: 99,
+				site_ID: 555,
+				feed_ID: 444,
+				feed_item_ID: 22,
+				date: '2026-04-01',
+				URL: 'https://example.com/post-99',
+				site_name: 'Example',
+			},
+		],
+		date_range: { after: '2026-04-01' },
+		found: 1,
+	};
+
+	// Each case asserts the migrated thunk hits the legacy URL with the
+	// legacy query shape (number/lang/orderBy/meta defaults from
+	// getQueryString unless the stream historically bypassed it).
+	it.each( [
+		{
+			name: 'recent without suffix',
+			streamKey: 'recent',
+			path: '/wpcom/v2/read/streams/following',
+			expectedQuery: { orderBy: 'date', meta: 'post,discover_original_post' },
+			notInQuery: [ 'feed_id' ],
+		},
+		{
+			name: 'recent with feed suffix',
+			streamKey: 'recent:1234',
+			path: '/wpcom/v2/read/streams/following',
+			expectedQuery: { feed_id: '1234' },
+		},
+		{
+			name: 'search parses sort+q from JSON suffix',
+			streamKey: 'search:{"sort":"relevance","q":"react"}',
+			path: '/rest/v1.2/read/search',
+			expectedQuery: { sort: 'relevance', q: 'react', content_width: '675' },
+			// Search historically bypassed getQueryString, so meta/orderBy must NOT be added.
+			notInQuery: [ 'meta', 'orderBy' ],
+		},
+		{
+			name: 'feed',
+			streamKey: 'feed:1234',
+			path: '/rest/v1.2/read/feed/1234/posts',
+			expectedQuery: { orderBy: 'date', meta: 'post,discover_original_post' },
+		},
+		{
+			name: 'site',
+			streamKey: 'site:1234',
+			path: '/rest/v1.2/read/sites/1234/posts',
+			expectedQuery: { orderBy: 'date' },
+		},
+		{
+			name: 'notifications',
+			streamKey: 'notifications',
+			path: '/rest/v1.2/read/notifications',
+			expectedQuery: { orderBy: 'date' },
+		},
+		{
+			name: 'featured',
+			streamKey: 'featured:1234',
+			path: '/rest/v1.2/read/sites/1234/featured',
+			expectedQuery: { orderBy: 'date' },
+		},
+		{
+			name: 'p2',
+			streamKey: 'p2',
+			path: '/rest/v1.2/read/following/p2',
+			expectedQuery: { orderBy: 'date' },
+		},
+		{
+			name: 'a8c',
+			streamKey: 'a8c',
+			path: '/rest/v1.2/read/a8c',
+			expectedQuery: { orderBy: 'date' },
+		},
+		{
+			name: 'tag',
+			streamKey: 'tag:photography',
+			path: '/wpcom/v2/read/tags/photography/posts',
+			expectedQuery: { orderBy: 'date' },
+		},
+		{
+			name: 'tag_popular',
+			streamKey: 'tag_popular:photography',
+			path: '/wpcom/v2/read/streams/tag/photography',
+			expectedQuery: {
+				tags: 'photography',
+				tag_recs_per_card: '5',
+				site_recs_per_card: '5',
+			},
+		},
+		{
+			name: 'on_this_day without month/day',
+			streamKey: 'on_this_day',
+			path: '/wpcom/v2/read/streams/on-this-day',
+			expectedQuery: { number: '15' },
+			notInQuery: [ 'month', 'day' ],
+		},
+		{
+			name: 'on_this_day with month/day',
+			streamKey: 'on_this_day:3:15',
+			path: '/wpcom/v2/read/streams/on-this-day',
+			expectedQuery: { number: '15', month: '3', day: '15' },
+		},
+		{
+			name: 'user',
+			streamKey: 'user:42',
+			path: '/rest/v1/users/42/posts',
+			expectedQuery: { orderBy: 'date' },
+		},
+	] )( '$name hits $path with the right query', async ( c ) => {
+		let captured;
+		nock( BASE )
+			.get( c.path )
+			.query( ( q ) => {
+				captured = q;
+				return true;
+			} )
+			.reply( 200, baseResponse );
+
+		const { result } = runThunk( { streamKey: c.streamKey } );
+		await result;
+
+		expect( captured ).toMatchObject( c.expectedQuery );
+		for ( const key of c.notInQuery ?? [] ) {
+			expect( captured ).not.toHaveProperty( key );
+		}
+	} );
+
+	// The legacy `streamApis.list.query` shipped a typoed spread that
+	// dropped meta/orderBy/content_width/lang from the wire query. The
+	// migration fixes it — assert that the new shape is sent and the old
+	// nested `extras` literal key is gone.
+	it( 'list now sends the same enriched shape as other streams (bug fixed)', async () => {
+		let captured;
+		nock( BASE )
+			.get( '/rest/v1.3/read/list/alice/favs/posts' )
+			.query( ( q ) => {
+				captured = q;
+				return true;
+			} )
+			.reply( 200, baseResponse );
+
+		const { result } = runThunk( {
+			streamKey: 'list:{"owner":"alice","slug":"favs"}',
+		} );
+		await result;
+
+		expect( captured ).toMatchObject( {
+			orderBy: 'date',
+			meta: 'post,discover_original_post',
+			content_width: '675',
+			number: '40',
+		} );
+		expect( captured.lang ).toBeDefined();
+		// The legacy bug nested the extras under a literal key — confirm gone.
+		expect( captured ).not.toHaveProperty( 'extras' );
+	} );
+
+	// `user` had a custom poll query (`number: 20`); other streams use the
+	// PER_POLL default. Verify the override survives the migration.
+	it( 'user poll overrides number to 20', async () => {
+		let captured;
+		nock( BASE )
+			.get( '/rest/v1/users/42/posts' )
+			.query( ( q ) => {
+				captured = q;
+				return true;
+			} )
+			.reply( 200, baseResponse );
+
+		const { result } = runThunk( { streamKey: 'user:42', isPoll: true } );
+		await result;
+
+		expect( captured.number ).toBe( '20' );
+	} );
+} );
+
+describe( 'requestPaginatedStream thunk', () => {
+	const recentResponse = {
+		posts: [
+			{
+				ID: 7,
+				site_ID: 7,
+				feed_ID: 7,
+				feed_item_ID: 7,
+				date: '2026-05-01',
+				URL: 'https://example.com/post-7',
+				site_name: 'Recent',
+			},
+		],
+		total_pages: 3,
+		found: 25,
+	};
+
+	it( 'routes migrated `recent` through React Query with page+perPage', async () => {
+		let captured;
+		nock( BASE )
+			.get( '/wpcom/v2/read/streams/following' )
+			.query( ( q ) => {
+				captured = q;
+				return true;
+			} )
+			.reply( 200, recentResponse );
+
+		const { dispatch, result } = runPaginatedThunk( {
+			streamKey: 'recent',
+			page: 2,
+			perPage: 10,
+		} );
+		await result;
+
+		expect( captured.page ).toBe( '2' );
+		expect( captured.number ).toBe( '10' );
+
+		const types = dispatch.mock.calls
+			.map( ( c ) => c[ 0 ] )
+			.filter( ( a ) => a && typeof a === 'object' && a.type )
+			.map( ( a ) => a.type );
+		expect( types ).toContain( READER_STREAMS_PAGE_RECEIVE );
+	} );
+
+	it( 'returns the legacy action for unmigrated streamKey', () => {
+		const { dispatch, result } = runPaginatedThunk( {
+			streamKey: 'conversations',
+			page: 1,
+			perPage: 10,
+		} );
+		// Action object returned, not a Promise — legacy data-layer
+		// path. The first dispatch carried the same action.
+		expect( result ).toMatchObject( {
+			type: 'READER_STREAMS_PAGINATED_REQUEST',
+			payload: { streamKey: 'conversations', page: 1, perPage: 10 },
+		} );
+		expect( dispatch ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/client/state/reader/streams/test/migrated-stream-types.ts
+++ b/client/state/reader/streams/test/migrated-stream-types.ts
@@ -4,18 +4,34 @@
 import { isMigratedStream } from '../migrated-stream-types';
 
 describe( 'isMigratedStream', () => {
-	it( 'returns true for `following`', () => {
-		expect( isMigratedStream( 'following' ) ).toBe( true );
+	it.each( [
+		'following',
+		'discover',
+		'recent',
+		'search',
+		'feed',
+		'site',
+		'notifications',
+		'featured',
+		'p2',
+		'a8c',
+		'tag',
+		'tag_popular',
+		'list',
+		'on_this_day',
+		'user',
+	] )( 'returns true for `%s`', ( streamType ) => {
+		expect( isMigratedStream( streamType ) ).toBe( true );
 	} );
 
-	it( 'returns true for every `discover` sub-tab', () => {
-		expect( isMigratedStream( 'discover' ) ).toBe( true );
-	} );
-
-	it( 'returns false for unmigrated stream types', () => {
-		expect( isMigratedStream( 'site' ) ).toBe( false );
-		expect( isMigratedStream( 'feed' ) ).toBe( false );
-		expect( isMigratedStream( 'a8c' ) ).toBe( false );
-		expect( isMigratedStream( 'recommendations_posts' ) ).toBe( false );
+	it.each( [
+		'conversations',
+		'conversations-a8c',
+		'likes',
+		'recommendations_posts',
+		'custom_recs_posts_with_images',
+		'custom_recs_sites_with_images',
+	] )( 'returns false for unmigrated `%s`', ( streamType ) => {
+		expect( isMigratedStream( streamType ) ).toBe( false );
 	} );
 } );

--- a/packages/api-core/src/read-streams/fetchers.ts
+++ b/packages/api-core/src/read-streams/fetchers.ts
@@ -126,7 +126,7 @@ export const fetchReadTagPosts = (
 	params: ReadStreamQueryParams = {}
 ): Promise< ReadStreamResponse > =>
 	wpcom.req.get( {
-		path: addQueryArgs( `/read/tags/${ tagSlug }/posts`, params ),
+		path: addQueryArgs( `/read/tags/${ encodeURIComponent( tagSlug ) }/posts`, params ),
 		apiNamespace: 'wpcom/v2',
 		method: 'GET',
 	} );
@@ -139,7 +139,7 @@ export const fetchReadTagPopular = (
 	params: ReadStreamQueryParams = {}
 ): Promise< ReadStreamResponse > =>
 	wpcom.req.get( {
-		path: addQueryArgs( `/read/streams/tag/${ tag }`, params ),
+		path: addQueryArgs( `/read/streams/tag/${ encodeURIComponent( tag ) }`, params ),
 		apiNamespace: 'wpcom/v2',
 		method: 'GET',
 	} );
@@ -156,7 +156,10 @@ export const fetchReadListPosts = (
 	params: ReadStreamQueryParams = {}
 ): Promise< ReadStreamResponse > =>
 	wpcom.req.get( {
-		path: addQueryArgs( `/read/list/${ owner }/${ slug }/posts`, params ),
+		path: addQueryArgs(
+			`/read/list/${ encodeURIComponent( owner ) }/${ encodeURIComponent( slug ) }/posts`,
+			params
+		),
 		apiVersion: '1.3',
 		method: 'GET',
 	} );

--- a/packages/api-core/src/read-streams/fetchers.ts
+++ b/packages/api-core/src/read-streams/fetchers.ts
@@ -2,21 +2,190 @@ import { addQueryArgs } from '@wordpress/url';
 import { wpcom } from '../wpcom-fetcher';
 import type { ReadStreamQueryParams, ReadStreamResponse } from './types';
 
-// READ-485: only `following` is migrated in this PR. The remaining 18+ Reader
-// stream shapes (`recent`, `feed`, `site`, `featured`, `tag`, `tag_popular`,
-// `p2`, `a8c`, `likes`, `notifications`, `user`, `on_this_day`, `discover:*`,
-// `search`, `list`, `conversations`, `conversations-a8c`,
-// `recommendations_posts`, `custom_recs_*`) are added here incrementally by
-// the follow-up PRs of this same task. See the legacy `streamApis` map in
-// `client/state/data-layer/wpcom/read/streams/index.js` for the canonical
-// per-shape `path`, `apiVersion`, `apiNamespace`, and `query` definitions to
-// mirror when porting each one.
+// READ-485: streams migrated incrementally. Streams still served by the
+// legacy data-layer at `client/state/data-layer/wpcom/read/streams/index.js`
+// (with non-`date` dateProperty or non-stream endpoints): `conversations`,
+// `conversations-a8c`, `likes`, `recommendations_posts`,
+// `custom_recs_posts_with_images`, `custom_recs_sites_with_images`. See the
+// legacy `streamApis` map for their canonical per-shape `path`, `apiVersion`,
+// `apiNamespace`, and `query` definitions to mirror when porting each one.
 export const fetchReadFollowing = (
 	params: ReadStreamQueryParams = {}
 ): Promise< ReadStreamResponse > =>
 	wpcom.req.get( {
 		path: addQueryArgs( '/read/following', params ),
 		apiVersion: '1.2',
+		method: 'GET',
+	} );
+
+/**
+ * Fetch the `recent` stream — `/read/streams/following` on `wpcom/v2`. The
+ * caller passes `feed_id` in `params` when filtering by a specific feed; the
+ * thunk derives that from the streamKey suffix.
+ */
+export const fetchReadRecent = (
+	params: ReadStreamQueryParams = {}
+): Promise< ReadStreamResponse > =>
+	wpcom.req.get( {
+		path: addQueryArgs( '/read/streams/following', params ),
+		apiNamespace: 'wpcom/v2',
+		method: 'GET',
+	} );
+
+/**
+ * Fetch the `search` stream. Caller is responsible for passing `q` and `sort`
+ * in `params` (the streamKey suffix is `JSON.parse`-able to `{ sort, q }`).
+ */
+export const fetchReadSearch = (
+	params: ReadStreamQueryParams = {}
+): Promise< ReadStreamResponse > =>
+	wpcom.req.get( {
+		path: addQueryArgs( '/read/search', params ),
+		apiVersion: '1.2',
+		method: 'GET',
+	} );
+
+/**
+ * Fetch a single feed's posts — `/read/feed/{feedId}/posts`.
+ */
+export const fetchReadFeedPosts = (
+	feedId: string | number,
+	params: ReadStreamQueryParams = {}
+): Promise< ReadStreamResponse > =>
+	wpcom.req.get( {
+		path: addQueryArgs( `/read/feed/${ feedId }/posts`, params ),
+		apiVersion: '1.2',
+		method: 'GET',
+	} );
+
+/**
+ * Fetch a single site's posts — `/read/sites/{siteId}/posts`.
+ */
+export const fetchReadSitePosts = (
+	siteId: string | number,
+	params: ReadStreamQueryParams = {}
+): Promise< ReadStreamResponse > =>
+	wpcom.req.get( {
+		path: addQueryArgs( `/read/sites/${ siteId }/posts`, params ),
+		apiVersion: '1.2',
+		method: 'GET',
+	} );
+
+/**
+ * Fetch the `notifications` stream — `/read/notifications`.
+ */
+export const fetchReadNotifications = (
+	params: ReadStreamQueryParams = {}
+): Promise< ReadStreamResponse > =>
+	wpcom.req.get( {
+		path: addQueryArgs( '/read/notifications', params ),
+		apiVersion: '1.2',
+		method: 'GET',
+	} );
+
+/**
+ * Fetch a site's featured posts — `/read/sites/{siteId}/featured`.
+ */
+export const fetchReadSiteFeatured = (
+	siteId: string | number,
+	params: ReadStreamQueryParams = {}
+): Promise< ReadStreamResponse > =>
+	wpcom.req.get( {
+		path: addQueryArgs( `/read/sites/${ siteId }/featured`, params ),
+		apiVersion: '1.2',
+		method: 'GET',
+	} );
+
+/**
+ * Fetch the `p2` stream — followed P2 sites at `/read/following/p2`.
+ */
+export const fetchReadFollowingP2 = (
+	params: ReadStreamQueryParams = {}
+): Promise< ReadStreamResponse > =>
+	wpcom.req.get( {
+		path: addQueryArgs( '/read/following/p2', params ),
+		apiVersion: '1.2',
+		method: 'GET',
+	} );
+
+/**
+ * Fetch the `a8c` stream — Automattic-internal posts at `/read/a8c`.
+ */
+export const fetchReadA8c = ( params: ReadStreamQueryParams = {} ): Promise< ReadStreamResponse > =>
+	wpcom.req.get( {
+		path: addQueryArgs( '/read/a8c', params ),
+		apiVersion: '1.2',
+		method: 'GET',
+	} );
+
+/**
+ * Fetch a tag's posts — `/read/tags/{slug}/posts` on `wpcom/v2`.
+ */
+export const fetchReadTagPosts = (
+	tagSlug: string,
+	params: ReadStreamQueryParams = {}
+): Promise< ReadStreamResponse > =>
+	wpcom.req.get( {
+		path: addQueryArgs( `/read/tags/${ tagSlug }/posts`, params ),
+		apiNamespace: 'wpcom/v2',
+		method: 'GET',
+	} );
+
+/**
+ * Fetch a tag's popular stream — `/read/streams/tag/{tag}` on `wpcom/v2`.
+ */
+export const fetchReadTagPopular = (
+	tag: string,
+	params: ReadStreamQueryParams = {}
+): Promise< ReadStreamResponse > =>
+	wpcom.req.get( {
+		path: addQueryArgs( `/read/streams/tag/${ tag }`, params ),
+		apiNamespace: 'wpcom/v2',
+		method: 'GET',
+	} );
+
+/**
+ * Fetch a Reader list's posts — `/read/list/{owner}/{slug}/posts`. Named with
+ * the `Posts` suffix to avoid colliding with `fetchReadList` in
+ * `packages/api-core/src/read-lists/fetchers.ts`, which fetches the list's
+ * metadata.
+ */
+export const fetchReadListPosts = (
+	owner: string,
+	slug: string,
+	params: ReadStreamQueryParams = {}
+): Promise< ReadStreamResponse > =>
+	wpcom.req.get( {
+		path: addQueryArgs( `/read/list/${ owner }/${ slug }/posts`, params ),
+		apiVersion: '1.3',
+		method: 'GET',
+	} );
+
+/**
+ * Fetch a user's posts — `/users/{userId}/posts`. The legacy data-layer used
+ * REST `1` (no `.2`) for this endpoint; preserve that.
+ */
+export const fetchReadUserPosts = (
+	userId: string | number,
+	params: ReadStreamQueryParams = {}
+): Promise< ReadStreamResponse > =>
+	wpcom.req.get( {
+		path: addQueryArgs( `/users/${ userId }/posts`, params ),
+		apiVersion: '1',
+		method: 'GET',
+	} );
+
+/**
+ * Fetch the `on_this_day` stream — `/read/streams/on-this-day` on `wpcom/v2`.
+ * The thunk derives the optional `month`/`day` from the streamKey suffix and
+ * passes them via `params`.
+ */
+export const fetchReadOnThisDay = (
+	params: ReadStreamQueryParams = {}
+): Promise< ReadStreamResponse > =>
+	wpcom.req.get( {
+		path: addQueryArgs( '/read/streams/on-this-day', params ),
+		apiNamespace: 'wpcom/v2',
 		method: 'GET',
 	} );
 

--- a/packages/api-queries/src/__tests__/read-streams.test.tsx
+++ b/packages/api-queries/src/__tests__/read-streams.test.tsx
@@ -57,7 +57,11 @@ describe( 'readStreamQuery', () => {
 	} );
 
 	it( 'throws when called for an unmigrated streamType', () => {
-		const opts = readStreamQuery( 'site:1234', { number: 4 }, null );
-		expect( () => opts.queryFn!( {} as never ) ).toThrow( /unsupported streamType "site"/ );
+		// `conversations` is still served by the legacy data-layer (different
+		// dateProperty); update this case when it lands in `readStreamQuery`.
+		const opts = readStreamQuery( 'conversations', { number: 4 }, null );
+		expect( () => opts.queryFn!( {} as never ) ).toThrow(
+			/unsupported streamType "conversations"/
+		);
 	} );
 } );

--- a/packages/api-queries/src/read-streams.ts
+++ b/packages/api-queries/src/read-streams.ts
@@ -1,9 +1,22 @@
 import {
+	fetchReadA8c,
 	fetchReadDiscoverFreshlyPressed,
 	fetchReadDiscoverLatest,
 	fetchReadDiscoverRecommended,
 	fetchReadDiscoverTags,
+	fetchReadFeedPosts,
 	fetchReadFollowing,
+	fetchReadFollowingP2,
+	fetchReadListPosts,
+	fetchReadNotifications,
+	fetchReadOnThisDay,
+	fetchReadRecent,
+	fetchReadSearch,
+	fetchReadSiteFeatured,
+	fetchReadSitePosts,
+	fetchReadTagPopular,
+	fetchReadTagPosts,
+	fetchReadUserPosts,
 	type ReadStreamQueryParams,
 	type ReadStreamResponse,
 } from '@automattic/api-core';
@@ -41,17 +54,13 @@ const fetchDiscover = (
 /**
  * React Query factory for Reader stream pages (READ-485).
  *
- * Migrated so far: `following` and every `discover:*` sub-tab. The remaining
- * stream types (`recent`, `feed`, `site`, `featured`, `tag`, `tag_popular`,
- * `p2`, `a8c`, `likes`, `notifications`, `user`, `on_this_day`, `search`,
- * `list`, `conversations`, `conversations-a8c`, `recommendations_posts`,
- * `custom_recs_*`) are migrated incrementally in the follow-up PRs of this
- * same task — each PR adds the fetcher in `@automattic/api-core`, a case in
- * the switch below, and the streamType to the `isMigratedStream` gate in
- * `client/state/reader/streams/migrated-stream-types.ts`. Until then those
- * streams keep flowing through the legacy data-layer at
- * `client/state/data-layer/wpcom/read/streams/index.js` and never reach this
- * factory.
+ * Migrated: `following`, every `discover:*` sub-tab, plus `recent`, `search`,
+ * `feed`, `site`, `notifications`, `featured`, `p2`, `a8c`, `tag`,
+ * `tag_popular`, `list`, `on_this_day`, and `user`. Streams still served by
+ * the legacy data-layer (non-`date` dateProperty or non-stream endpoints):
+ * `conversations`, `conversations-a8c`, `likes`, `recommendations_posts`,
+ * `custom_recs_*`. Those will land in a final cleanup PR that also deletes
+ * the data-layer file.
  */
 export const readStreamQuery = (
 	streamKey: string,
@@ -62,11 +71,40 @@ export const readStreamQuery = (
 		queryKey: [ 'read', 'stream', streamKey, pageHandle ?? null ],
 		queryFn: () => {
 			const streamType = getStreamType( streamKey );
+			const suffix = streamKeySuffix( streamKey );
 			switch ( streamType ) {
 				case 'following':
 					return fetchReadFollowing( queryParams );
 				case 'discover':
 					return fetchDiscover( streamKey, queryParams );
+				case 'recent':
+					return fetchReadRecent( queryParams );
+				case 'search':
+					return fetchReadSearch( queryParams );
+				case 'feed':
+					return fetchReadFeedPosts( suffix, queryParams );
+				case 'site':
+					return fetchReadSitePosts( suffix, queryParams );
+				case 'notifications':
+					return fetchReadNotifications( queryParams );
+				case 'featured':
+					return fetchReadSiteFeatured( suffix, queryParams );
+				case 'p2':
+					return fetchReadFollowingP2( queryParams );
+				case 'a8c':
+					return fetchReadA8c( queryParams );
+				case 'tag':
+					return fetchReadTagPosts( suffix, queryParams );
+				case 'tag_popular':
+					return fetchReadTagPopular( suffix, queryParams );
+				case 'list': {
+					const { owner, slug } = JSON.parse( suffix ) as { owner: string; slug: string };
+					return fetchReadListPosts( owner, slug, queryParams );
+				}
+				case 'user':
+					return fetchReadUserPosts( suffix, queryParams );
+				case 'on_this_day':
+					return fetchReadOnThisDay( queryParams );
 				default:
 					throw new Error(
 						`readStreamQuery: unsupported streamType "${ streamType }". Add the fetcher in @automattic/api-core and a case here when migrating this stream.`


### PR DESCRIPTION
Part of READ-485. Closes READ-492, READ-493, READ-494, READ-495.

## Proposed Changes

* Migrates the remaining date-based Reader stream types from the legacy Redux data-layer (`client/state/data-layer/wpcom/read/streams/index.js`) to `@automattic/api-core` + `@automattic/api-queries`.
* Adds API fetchers and query routing for: `recent`, `search`, `feed`, `site`, `notifications`, `featured`, `p2`, `a8c`, `tag`, `tag_popular`, `list`, `on_this_day`, and `user` streams.
* Extends `MIGRATED_STREAM_TYPES` so the React Query thunk wrapper takes over routing for these streams.
* Keeps `receivePosts(...)` dispatching from the new query layer (the bridge required by READ-485 until `state.reader.posts` is removed in READ-486).

## Subtasks closed by this PR

* READ-492 — Feed streams (`feed:{feedId}`)
* READ-493 — Site streams (`site:{siteId}`)
* READ-494 — Tag streams (`tag:{tagSlug}`, `tag_popular`)
* READ-495 — Search streams (`search:{json}`)

## Why are these changes being made?

* Continues READ-485 by moving Reader streams off the legacy data-layer and onto the shared API query path.
* Narrows the remaining legacy surface to conversations, likes, recommendations, and custom recommendations streams.

## Testing Instructions

* `yarn test-client client/state/reader/streams/test/actions.js client/state/reader/streams/test/migrated-stream-types.ts client/state/data-layer/wpcom/read/streams/test/index.js --runInBand`
* `yarn test-packages packages/api-queries/src/__tests__/read-streams.test.tsx --runInBand`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?