### PR TITLE
fix: classify Reader Mastodon errors arriving on .code (wpcom/v2 wire shape)

### DIFF
--- a/packages/api-core/src/reader-mastodon/__tests__/errors.test.ts
+++ b/packages/api-core/src/reader-mastodon/__tests__/errors.test.ts
@@ -9,6 +9,20 @@ function wpErr( code: string, statusCode: number, message = '' ): unknown {
 	return e;
 }
 
+// Mirror the actual shape that wpcom-proxy-request raises for a WP REST
+// envelope error: the WP error code lands on `.code`, not `.error`. The
+// classifier must recognise both to avoid silently falling through to
+// `{ kind: 'unknown' }` for live upstream failures on non-401/429 paths
+// (401 and 429 are accidentally caught by the statusCode fallback).
+function wpProxyErr( code: string, statusCode: number, message = '' ): unknown {
+	const e = new Error( message );
+	( e as unknown as Record< string, unknown > ).code = code;
+	( e as unknown as Record< string, unknown > ).statusCode = statusCode;
+	( e as unknown as Record< string, unknown > ).status = statusCode;
+	( e as unknown as Record< string, unknown > ).message = message;
+	return e;
+}
+
 describe( 'classifyMastodonError', () => {
 	it( 'maps invalid_instance', () => {
 		expect( classifyMastodonError( wpErr( 'invalid_instance', 400 ) ).kind ).toBe(
@@ -101,6 +115,50 @@ describe( 'classifyMastodonError — timeline kinds', () => {
 	it( 'maps mastodon_upstream_unavailable → upstream_unavailable', () => {
 		expect( classifyMastodonError( { error: 'mastodon_upstream_unavailable' } ) ).toEqual( {
 			kind: 'upstream_unavailable',
+		} );
+	} );
+} );
+
+describe( 'classifyMastodonError — wpcom-proxy wire shape', () => {
+	it( 'classifies mastodon_not_found surfaced on .code', () => {
+		expect( classifyMastodonError( wpProxyErr( 'mastodon_not_found', 404 ) ) ).toEqual( {
+			kind: 'not_found',
+		} );
+	} );
+
+	it( 'classifies reader_mastodon_not_found surfaced on .code', () => {
+		expect( classifyMastodonError( wpProxyErr( 'reader_mastodon_not_found', 404 ) ) ).toEqual( {
+			kind: 'not_found',
+		} );
+	} );
+
+	it( 'classifies mastodon_upstream_unavailable surfaced on .code', () => {
+		expect( classifyMastodonError( wpProxyErr( 'mastodon_upstream_unavailable', 502 ) ) ).toEqual( {
+			kind: 'upstream_unavailable',
+		} );
+	} );
+
+	it( 'classifies reader_mastodon_bad_request surfaced on .code, preserving the message', () => {
+		expect(
+			classifyMastodonError( wpProxyErr( 'reader_mastodon_bad_request', 400, 'nope' ) )
+		).toEqual( { kind: 'bad_request', message: 'nope' } );
+	} );
+
+	it( 'classifies invalid_instance surfaced on .code', () => {
+		expect( classifyMastodonError( wpProxyErr( 'invalid_instance', 400 ) ) ).toEqual( {
+			kind: 'invalid_instance',
+		} );
+	} );
+
+	it( 'preserves retry_after when mastodon_rate_limited arrives on .code', () => {
+		const e = new Error( '' );
+		( e as unknown as Record< string, unknown > ).code = 'mastodon_rate_limited';
+		( e as unknown as Record< string, unknown > ).statusCode = 429;
+		( e as unknown as Record< string, unknown > ).status = 429;
+		( e as unknown as Record< string, unknown > ).data = { retry_after: 42 };
+		expect( classifyMastodonError( e ) ).toEqual( {
+			kind: 'rate_limited',
+			retry_after: 42,
 		} );
 	} );
 } );

--- a/packages/api-core/src/reader-mastodon/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/reader-mastodon/__tests__/fetchers.test.ts
@@ -90,12 +90,13 @@ describe( 'mastodon fetchers', () => {
 	} );
 
 	it( 'getMastodonConnections classifies 401 as auth_required', async () => {
-		nock( BASE ).get( '/wpcom/v2/reader/mastodon/connections' ).reply( 401, {
-			error: 'not_authenticated',
-			message: '',
-			statusCode: 401,
-			status: 401,
-		} );
+		nock( BASE )
+			.get( '/wpcom/v2/reader/mastodon/connections' )
+			.reply( 401, {
+				code: 'not_authenticated',
+				message: 'Authentication required.',
+				data: { status: 401 },
+			} );
 		await expect( getMastodonConnections() ).rejects.toMatchObject( { kind: 'auth_required' } );
 	} );
 } );
@@ -124,7 +125,11 @@ describe( 'getMastodonTimeline', () => {
 	it( 'classifies mastodon_rate_limited with retry_after', async () => {
 		nock( BASE )
 			.get( '/wpcom/v2/reader/mastodon/connections/7/timeline' )
-			.reply( 429, { error: 'mastodon_rate_limited', data: { retry_after: 30 } } );
+			.reply( 429, {
+				code: 'mastodon_rate_limited',
+				message: '',
+				data: { status: 429, retry_after: 30 },
+			} );
 		await expect( getMastodonTimeline( { connectionId: 7 } ) ).rejects.toEqual( {
 			kind: 'rate_limited',
 			retry_after: 30,
@@ -178,7 +183,11 @@ describe( 'getMastodonAuthorProfile', () => {
 	it( 'classifies a 401 as auth_required', async () => {
 		nock( BASE )
 			.get( '/wpcom/v2/reader/mastodon/connections/7/profile/108020' )
-			.reply( 401, { error: 'not_authenticated', message: '', statusCode: 401, status: 401 } );
+			.reply( 401, {
+				code: 'not_authenticated',
+				message: 'Authentication required.',
+				data: { status: 401 },
+			} );
 		await expect(
 			getMastodonAuthorProfile( { connectionId: 7, actor: '108020' } )
 		).rejects.toMatchObject( { kind: 'auth_required' } );
@@ -303,7 +312,11 @@ describe( 'getMastodonTagFeed', () => {
 	it( 'classifies a 401 as auth_required', async () => {
 		nock( BASE )
 			.get( '/wpcom/v2/reader/mastodon/connections/7/tag/rust/feed' )
-			.reply( 401, { error: 'not_authenticated', message: '', statusCode: 401, status: 401 } );
+			.reply( 401, {
+				code: 'not_authenticated',
+				message: 'Authentication required.',
+				data: { status: 401 },
+			} );
 		await expect(
 			getMastodonTagFeed( { connectionId: 7, hashtag: 'rust' } )
 		).rejects.toMatchObject( { kind: 'auth_required' } );

--- a/packages/api-core/src/reader-mastodon/errors.ts
+++ b/packages/api-core/src/reader-mastodon/errors.ts
@@ -10,7 +10,13 @@ export type MastodonError =
 	| { kind: 'unknown'; cause: unknown };
 
 interface WpErrorLike {
+	// The wpcom-proxy / wpcom-xhr-request transports surface the WP REST
+	// envelope's error code as `code` on the thrown error. Some legacy
+	// callsites (and the existing test fixtures) populate `error` instead.
+	// Accept both so live errors classify correctly regardless of which
+	// transport raised them.
 	error?: string;
+	code?: string;
 	statusCode?: number;
 	status?: number;
 	message?: string;
@@ -22,7 +28,7 @@ function isWpErrorLike( e: unknown ): e is WpErrorLike {
 		return false;
 	}
 	const obj = e as object;
-	return 'error' in obj || 'statusCode' in obj || 'status' in obj;
+	return 'error' in obj || 'code' in obj || 'statusCode' in obj || 'status' in obj;
 }
 
 export function classifyMastodonError( raw: unknown ): MastodonError {
@@ -38,7 +44,8 @@ export function classifyMastodonError( raw: unknown ): MastodonError {
 	// Slice 4 (timeline) backend used `mastodon_*` codes; slice 5 (thread)
 	// backend uses `reader_mastodon_*`. Accept both so the classifier is
 	// robust across endpoints regardless of which prefix lands on the wire.
-	switch ( raw.error ) {
+	const errorCode = raw.error ?? raw.code;
+	switch ( errorCode ) {
 		case 'invalid_instance':
 			return { kind: 'invalid_instance' };
 		case 'auth_failed':


### PR DESCRIPTION
Fixes CM-654

## Proposed Changes

* Update `classifyMastodonError` in `packages/api-core/src/reader-mastodon/errors.ts` to read `raw.error ?? raw.code` (instead of only `raw.error`) so the WP REST envelope shape that wpcom/v2 actually emits classifies correctly.
* Add `code?: string` to the internal `WpErrorLike` interface and accept `'code' in obj` in the `isWpErrorLike` guard.
* Cover the previously-broken kinds with a new `wpcom-proxy wire shape` describe block in `errors.test.ts`, including a regression guard around the accidentally-correct 429 statusCode fallback.
* Update existing fetcher mocks from `{ error, statusCode, status }` to the realistic `{ code, message, data: { status } }` envelope so the test fixtures match what nock would replay from prod.

## Why are these changes being made?

The wpcom/v2 namespace serializes `WP_Error` as `{ code, message, data: { status } }` (standard WordPress REST envelope). Mastodon's error classifier only read `raw.error`, so non-401/429 errors silently fell through to `{ kind: 'unknown' }` and surfaced as the generic "Something went wrong" toast instead of the action-specific copy that `client/reader/mastodon/error-projection.ts` was built to produce.

401 and 429 happened to classify correctly via the trailing `statusCode` fallback in `classifyMastodonError`, which masked the broader bug for the most common error states.

Verified empirically against the live wpcom edge:

| Endpoint | Status | Body shape |
|---|---|---|
| `wpcom/v2/reader/mastodon/connections` (no auth) | 401 | `{ code: 'not_authenticated', message, data: { status: 401 } }` |
| `wpcom/v2/reader/mastodon/connections/0/timeline` (no auth) | 401 | `{ code: 'not_authenticated', ... }` |
| `wpcom/v2/reader/mastodon/profile/...` | 404 | `{ code: 'rest_no_route', ... }` |

This is the same fix already shipped on trunk for atmosphere in 144f58a869f (slice-7a likes frontend). Mastodon was missed there.

## Testing Instructions

* `yarn jest --config packages/api-core/jest.config.js packages/api-core/src/reader-mastodon` — 59/59 pass.
* `yarn jest --config packages/api-core/jest.config.js packages/api-core` — full package, 135/135 pass.
* `yarn eslint packages/api-core/src/reader-mastodon/errors.ts packages/api-core/src/reader-mastodon/__tests__/errors.test.ts packages/api-core/src/reader-mastodon/__tests__/fetchers.test.ts` — clean.
* For interactive verification: trigger a Mastodon endpoint failure that isn't 401/429 (e.g. visit a Reader Mastodon profile that returns 502 from the upstream instance) and confirm the error UI now shows the upstream-unavailable copy instead of the generic fallback.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed?
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?