### PR TITLE
Reader: link years-of-service badge to user achievements page

### DIFF
--- a/client/reader/components/achievements/author-achievement-badges/index.tsx
+++ b/client/reader/components/achievements/author-achievement-badges/index.tsx
@@ -22,7 +22,13 @@ export const AuthorAchievementBadges = ( {
 
 	const badges = [
 		!! yearsOfService && (
-			<YearsOfServiceBadge key="years-of-service" size={ size } yearsOfService={ yearsOfService } />
+			<YearsOfServiceBadge
+				key="years-of-service"
+				size={ size }
+				yearsOfService={ yearsOfService }
+				linked
+				userLogin={ authorLogin }
+			/>
 		),
 	].filter( Boolean );
 

--- a/client/reader/components/achievements/years-of-service-badge/index.tsx
+++ b/client/reader/components/achievements/years-of-service-badge/index.tsx
@@ -1,16 +1,21 @@
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import { getUserProfileUrl } from 'calypso/reader/user-profile/user-profile.utils';
 
 import './style.scss';
 
 interface YearsOfServiceBadgeProps {
 	size: 'large' | 'medium' | 'small';
 	yearsOfService: number;
+	linked?: boolean;
+	userLogin?: string;
 }
 
 export const YearsOfServiceBadge = ( {
 	size,
 	yearsOfService,
+	linked,
+	userLogin,
 }: YearsOfServiceBadgeProps ): JSX.Element => {
 	const translate = useTranslate();
 	const description = String(
@@ -20,8 +25,9 @@ export const YearsOfServiceBadge = ( {
 		} )
 	);
 
-	return (
-		<div className={ clsx( 'years-of-service-badge', `is-${ size }` ) }>
+	const className = clsx( 'years-of-service-badge', `is-${ size }` );
+	const content = (
+		<>
 			<div
 				className="years-of-service-badge__circle"
 				title={ size !== 'large' ? description : undefined }
@@ -36,6 +42,20 @@ export const YearsOfServiceBadge = ( {
 					} ) }
 				</span>
 			) }
-		</div>
+		</>
 	);
+
+	if ( linked && userLogin ) {
+		return (
+			<a
+				className={ className }
+				href={ `${ getUserProfileUrl( userLogin ) }/achievements` }
+				aria-label={ translate( 'View achievements' ) }
+			>
+				{ content }
+			</a>
+		);
+	}
+
+	return <div className={ className }>{ content }</div>;
 };

--- a/client/reader/components/achievements/years-of-service-badge/style.scss
+++ b/client/reader/components/achievements/years-of-service-badge/style.scss
@@ -44,3 +44,49 @@
 	font-size: rem( 13px );
 	color: var( --studio-gray-40 );
 }
+
+a.years-of-service-badge {
+	color: inherit;
+	text-decoration: none;
+
+	.years-of-service-badge__circle {
+		position: relative;
+		overflow: hidden;
+		isolation: isolate;
+	}
+
+	.years-of-service-badge__circle::before {
+		content: "";
+		position: absolute;
+		inset: 0;
+		background: linear-gradient(
+			115deg,
+			transparent 35%,
+			rgba(255, 255, 255, 0.65) 50%,
+			transparent 65%
+		);
+		transform: translateX(-110%);
+		pointer-events: none;
+	}
+
+	&:hover .years-of-service-badge__circle::before,
+	&:focus-visible .years-of-service-badge__circle::before {
+		animation: years-of-service-badge-shine 700ms ease-out;
+	}
+}
+
+@keyframes years-of-service-badge-shine {
+	from {
+		transform: translateX(-110%);
+	}
+	to {
+		transform: translateX(110%);
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	a.years-of-service-badge:hover .years-of-service-badge__circle::before,
+	a.years-of-service-badge:focus-visible .years-of-service-badge__circle::before {
+		animation: none;
+	}
+}


### PR DESCRIPTION
Part of RSM-1352

## Proposed Changes

* Add `linked` and `userLogin` props to `YearsOfServiceBadge`. When both are set, the badge renders as an `<a>` pointing to `/reader/users/{userLogin}/achievements` with `aria-label="View achievements"`.
* `AuthorAchievementBadges` (used in the user profile header and full-post author byline) now passes `linked` so its badges become links automatically. The standalone `size="large"` badge on the achievements page itself is unchanged and stays unlinked.
* Add a subtle diagonal shine animation on hover/focus of the linked badge, with a `prefers-reduced-motion` opt-out.

## Why are these changes being made?

The years-of-service badge surfaces a user's WordPress.com tenure but had no path to the rest of their achievements. Linking it gives readers a direct entry point from the username area on profiles and post bylines. The link is gated by the existing `useAchievementsVisibility` hook, so it only appears when the achievements page is viewable (own profile, or another user's profile when their visibility is set to public).

## Testing Instructions

* Visit a Reader user profile whose achievements visibility is **public** (or your own profile). Hover the small badge next to the username — it should shine and link to the achievements tab.
* Open a full post in the Reader where the author has a years-of-service badge. The small badge in the byline should link to the same achievements page.
* Visit the Achievements tab itself. The large badge in the header should remain a static `<div>` with no shine.
* Visit a profile whose visibility is **private** (and that isn't yours). The badge should not appear at all.
* Verify keyboard focus reaches the linked badge and the shine plays on `:focus-visible`.
* Enable "Reduce motion" in OS settings and confirm the shine animation does not play.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?