### PR TITLE
Cancel survey: update button copy for cancel intent

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -446,7 +446,9 @@ class CancelPurchaseForm extends Component {
 					disabled={ this.state.isSubmitting }
 					refundAmount={ this.getRefundAmount() }
 					intent={ intent }
-					declineButtonText={ intent === 'remove' ? translate( 'Continue removal' ) : translate( 'No, thanks' ) }
+					declineButtonText={
+						intent === 'remove' ? translate( 'Continue removal' ) : translate( 'No, thanks' )
+					}
 					downgradePlanPrice={
 						'downgrade-personal' === this.state.upsell
 							? this.props.downgradePlanToPersonalPrice

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -446,7 +446,7 @@ class CancelPurchaseForm extends Component {
 					disabled={ this.state.isSubmitting }
 					refundAmount={ this.getRefundAmount() }
 					intent={ intent }
-					declineButtonText={ intent === 'remove' ? translate( 'Continue removal' ) : undefined }
+					declineButtonText={ intent === 'remove' ? translate( 'Continue removal' ) : translate( 'No, thanks' ) }
 					downgradePlanPrice={
 						'downgrade-personal' === this.state.upsell
 							? this.props.downgradePlanToPersonalPrice
@@ -617,15 +617,27 @@ class CancelPurchaseForm extends Component {
 
 		if ( ! isLastStep ) {
 			return (
-				<GutenbergButton
-					isPrimary
-					isDefault
-					isDestructive={ intent === 'remove' }
-					disabled={ ! this.canGoNext() }
-					onClick={ this.clickNext }
-				>
-					{ intent === 'remove' ? translate( 'Continue removal' ) : translate( 'Continue' ) }
-				</GutenbergButton>
+				<>
+					<GutenbergButton
+						isPrimary
+						isDefault
+						isDestructive={ intent === 'remove' }
+						disabled={ ! this.canGoNext() }
+						onClick={ this.clickNext }
+					>
+						{ intent === 'remove' ? translate( 'Continue removal' ) : translate( 'Continue' ) }
+					</GutenbergButton>
+					{ intent === 'cancel' && (
+						<GutenbergButton
+							isTertiary
+							isBusy={ isCancelling }
+							disabled={ isCancelling }
+							onClick={ this.onSubmit }
+						>
+							{ translate( 'No, thanks' ) }
+						</GutenbergButton>
+					) }
+				</>
 			);
 		}
 
@@ -682,16 +694,28 @@ class CancelPurchaseForm extends Component {
 		}
 
 		return (
-			<GutenbergButton
-				isPrimary={ surveyStep !== UPSELL_STEP }
-				isSecondary={ surveyStep === UPSELL_STEP }
-				isDefault={ surveyStep !== UPSELL_STEP }
-				isBusy={ isCancelling }
-				disabled={ ! this.canGoNext() }
-				onClick={ this.onSubmit }
-			>
-				{ translate( 'Submit' ) }
-			</GutenbergButton>
+			<>
+				<GutenbergButton
+					isPrimary={ surveyStep !== UPSELL_STEP }
+					isSecondary={ surveyStep === UPSELL_STEP }
+					isDefault={ surveyStep !== UPSELL_STEP }
+					isBusy={ isCancelling }
+					disabled={ ! this.canGoNext() }
+					onClick={ this.onSubmit }
+				>
+					{ intent === 'cancel' ? translate( 'Complete' ) : translate( 'Submit' ) }
+				</GutenbergButton>
+				{ intent === 'cancel' && (
+					<GutenbergButton
+						isTertiary
+						isBusy={ isCancelling }
+						disabled={ isCancelling }
+						onClick={ this.onSubmit }
+					>
+						{ translate( 'No, thanks' ) }
+					</GutenbergButton>
+				) }
+			</>
 		);
 	};
 

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/feedback-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/feedback-step.tsx
@@ -167,7 +167,11 @@ export default function FeedbackStep( {
 		<div className="cancel-purchase-form__feedback">
 			<FormattedHeader
 				brandFont
-				headerText={ translate( 'Share your feedback' ) }
+				headerText={
+					intent === 'cancel'
+						? translate( 'Cancellation confirmed' )
+						: translate( 'Share your feedback' )
+				}
 				subHeaderText={ translate(
 					'Before you go, please answer a few quick questions to help us improve %(productName)s.',
 					{

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
@@ -65,7 +65,7 @@ function Upsell( { image, ...props }: UpsellProps ) {
 						{ props.acceptButtonText }
 					</Button>
 					<Button
-						variant={ props.intent === 'remove' ? 'tertiary' : 'secondary' }
+						variant={ props.intent ? 'tertiary' : 'secondary' }
 						isDestructive={ props.intent === 'remove' }
 						onClick={ () => {
 							setBusyButton( 'decline' );

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
@@ -193,7 +193,7 @@ function SurveyContent( {
 				cancellationReason={ questionOneText }
 				closeDialog={ closeDialog }
 				currencyCode={ purchase.currency_code }
-				declineButtonText={ intent === 'remove' ? __( 'Continue removal' ) : undefined }
+				declineButtonText={ intent === 'remove' ? __( 'Continue removal' ) : __( 'No, thanks' ) }
 				downgradePlan={ downgradePlan }
 				includedDomainPurchase={ includedDomainPurchase }
 				intent={ intent ?? undefined }
@@ -312,11 +312,6 @@ function StepButtons( {
 
 	const isLastStep = surveyStep === allSteps?.[ allSteps.length - 1 ];
 
-	// Check if ANY step in the flow is a warning/confirmation step
-	// If so, we should not show Skip button at all to avoid bypassing warnings
-	const hasWarningStep =
-		allSteps?.includes( ATOMIC_REVERT_STEP ) || allSteps?.includes( REMOVE_PLAN_STEP );
-
 	if ( surveyStep === UPSELL_STEP ) {
 		return null;
 	}
@@ -342,14 +337,14 @@ function StepButtons( {
 				<Button variant="primary" disabled={ ! canGoNext || isCancelling } onClick={ clickNext }>
 					{ __( 'Continue' ) }
 				</Button>
-				{ ! hasWarningStep && (
+				{ intent === 'cancel' && (
 					<Button
 						variant="tertiary"
 						isBusy={ isCancelling }
 						disabled={ isCancelling }
 						onClick={ onSubmit }
 					>
-						{ __( 'Skip' ) }
+						{ __( 'No, thanks' ) }
 					</Button>
 				) }
 			</ButtonStack>
@@ -441,16 +436,16 @@ function StepButtons( {
 				onClick={ onSubmit }
 				variant={ variant }
 			>
-				{ __( 'Continue' ) }
+				{ intent === 'cancel' ? __( 'Complete' ) : __( 'Continue' ) }
 			</Button>
-			{ ! canGoNext && ! hasWarningStep && (
+			{ intent === 'cancel' && (
 				<Button
 					variant="tertiary"
 					isBusy={ isCancelling }
 					disabled={ isCancelling }
 					onClick={ onSubmit }
 				>
-					{ __( 'Skip' ) }
+					{ __( 'No, thanks' ) }
 				</Button>
 			) }
 		</ButtonStack>

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/upsell-step.tsx
@@ -41,7 +41,7 @@ function Upsell( { ...props }: UpsellProps ) {
 					{ props.acceptButtonText }
 				</Button>
 				<Button
-					variant={ props.intent === 'remove' ? 'tertiary' : 'secondary' }
+					variant={ props.intent ? 'tertiary' : 'secondary' }
 					isDestructive={ props.intent === 'remove' }
 					onClick={ props.onDecline }
 					disabled={ props.isBusy }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -532,7 +532,7 @@ function CancelPurchaseInner() {
 		purchase,
 		upsell: state.upsell,
 		cancellationOffer,
-		hasQuestionTwo: Boolean( questionTwoOrder.length ),
+		hasQuestionTwo: Boolean( state.questionTwoOrder?.length ),
 		plans,
 		userHasCompletedCancelSurveyForPurchase,
 	} );


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/RSM-474

## Proposed Changes

Fixes copy in cancel flow for Calypso / MSD cancel flow. Remove coming in another PR.

Changes include:

- **Skip → "No, thanks"**: Non-last survey steps show a tertiary "No, thanks" button (both surfaces)
- **Continue → "Complete"**: Last survey step primary button says "Complete" for cancel intent (both surfaces)
- **Upsell decline → "No, thanks"**: Tertiary button replaces "Cancel my current plan" default (both surfaces)
- **Legacy feedback title → "Cancellation confirmed"**: Matches the dashboard heading
- **Fix `hasQuestionTwo`**: Reads from React state instead of always-empty local variable — plans now correctly show multi-step surveys
- **Fix `hasWarningStep` gate**: "No, thanks" button shows regardless of post-mutation warning steps (the cancellation already happened; warning gates are unreliable after mutation)

## Why are these changes being made?

Post-cancel survey copy is inconsistent and confusing. "Skip" is ambiguous (skip what?), "Continue" on the last step suggests more steps follow, and "Cancel my current plan" on the upsell decline is alarming when the user has already canceled. These changes align the survey copy with the intent-aware language used elsewhere in the cancel flow, reducing user confusion and support tickets.

## Testing Instructions

1. Go to Purchases → any plan → Cancel subscription (dashboard: `my.localhost:3000`, legacy: `calypso.localhost:3000`)
2. On the survey steps, verify:
   - Non-last steps show "No, thanks" tertiary button alongside "Continue"
   - Last step shows "Complete" as the primary button and "No, thanks" as tertiary
3. Pick a reason that triggers an upsell (e.g., "Too expensive") — verify the decline button says "No, thanks" (tertiary)
4. Pick a reason with no upsell (e.g., "No longer need it") — verify multi-step survey appears (not collapsed to one step)
5. Legacy only: verify the feedback step title says "Cancellation confirmed"
6. Remove intent (`?intent=remove`) should be unchanged — no "No, thanks" buttons, original copy preserved

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?