### PR TITLE
Remove flow: destructive buttons + intent-aware copy

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -445,9 +445,8 @@ class CancelPurchaseForm extends Component {
 					site={ site }
 					disabled={ this.state.isSubmitting }
 					refundAmount={ this.getRefundAmount() }
-					declineButtonText={
-						intent === 'remove' ? translate( 'Remove my current plan' ) : undefined
-					}
+					intent={ intent }
+					declineButtonText={ intent === 'remove' ? translate( 'Continue removal' ) : undefined }
 					downgradePlanPrice={
 						'downgrade-personal' === this.state.upsell
 							? this.props.downgradePlanToPersonalPrice
@@ -605,7 +604,7 @@ class CancelPurchaseForm extends Component {
 	}
 
 	renderStepButtons = () => {
-		const { translate, disableButtons, purchase } = this.props;
+		const { translate, disableButtons, purchase, intent } = this.props;
 		const { isSubmitting, surveyStep, solution } = this.state;
 		const isCancelling = ( disableButtons || isSubmitting ) && ! solution;
 
@@ -621,10 +620,11 @@ class CancelPurchaseForm extends Component {
 				<GutenbergButton
 					isPrimary
 					isDefault
+					isDestructive={ intent === 'remove' }
 					disabled={ ! this.canGoNext() }
 					onClick={ this.clickNext }
 				>
-					{ translate( 'Continue' ) }
+					{ intent === 'remove' ? translate( 'Continue removal' ) : translate( 'Continue' ) }
 				</GutenbergButton>
 			);
 		}
@@ -650,6 +650,32 @@ class CancelPurchaseForm extends Component {
 						onClick={ this.closeDialog }
 					>
 						{ translate( 'Keep plan' ) }
+					</GutenbergButton>
+				</>
+			);
+		}
+
+		if ( intent === 'remove' ) {
+			return (
+				<>
+					<GutenbergButton
+						isPrimary
+						isDefault
+						isDestructive
+						isBusy={ isCancelling }
+						disabled={ ! this.canGoNext() }
+						onClick={ this.onSubmit }
+					>
+						{ translate( 'Complete removal' ) }
+					</GutenbergButton>
+					<GutenbergButton
+						isDestructive
+						variant="tertiary"
+						isBusy={ isCancelling }
+						disabled={ isCancelling }
+						onClick={ this.onSubmit }
+					>
+						{ translate( 'Skip and remove' ) }
 					</GutenbergButton>
 				</>
 			);

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
@@ -27,6 +27,7 @@ const HELP_CENTER_STORE = HelpCenter.register();
 type UpsellProps = {
 	children?: React.ReactNode;
 	image: string;
+	intent?: string;
 	title: TranslateResult;
 	acceptButtonText: TranslateResult;
 	acceptButtonUrl?: string;
@@ -53,6 +54,7 @@ function Upsell( { image, ...props }: UpsellProps ) {
 				<div className="cancel-purchase-form__upsell-buttons">
 					<Button
 						variant="primary"
+						isDestructive={ props.intent === 'remove' }
 						href={ props.acceptButtonUrl }
 						onClick={ () => {
 							setBusyButton( 'accept' );
@@ -63,7 +65,8 @@ function Upsell( { image, ...props }: UpsellProps ) {
 						{ props.acceptButtonText }
 					</Button>
 					<Button
-						variant="secondary"
+						variant={ props.intent === 'remove' ? 'tertiary' : 'secondary' }
+						isDestructive={ props.intent === 'remove' }
 						onClick={ () => {
 							setBusyButton( 'decline' );
 							props.onDecline?.();
@@ -106,6 +109,7 @@ type StepProps = {
 	closeDialog?: () => void;
 	cancelBundledDomain?: boolean;
 	includedDomainPurchase?: object;
+	intent?: string;
 	onDeclineUpsell?: () => void;
 	onClickFreeMonthOffer?: () => void;
 	onClickDowngrade?: ( upsell: string ) => void;
@@ -159,6 +163,7 @@ export default function UpsellStep( { upsell, site, purchase, ...props }: StepPr
 
 						props.closeDialog?.();
 					} }
+					intent={ props.intent }
 					declineButtonText={ props.declineButtonText }
 					onDecline={ props.onDeclineUpsell }
 					image={ imgLiveChat }
@@ -192,6 +197,7 @@ export default function UpsellStep( { upsell, site, purchase, ...props }: StepPr
 						recordTracksEvent( 'calypso_cancellation_upsell_step_buily_by_click' );
 						window.location.replace( builtByURL );
 					} }
+					intent={ props.intent }
 					declineButtonText={ props.declineButtonText }
 					onDecline={ props.onDeclineUpsell }
 					image={ imgBuiltBy }
@@ -216,6 +222,7 @@ export default function UpsellStep( { upsell, site, purchase, ...props }: StepPr
 					onAccept={ () => {
 						recordTracksEvent( 'calypso_cancellation_upgrade_at_step_upgrade_click' );
 					} }
+					intent={ props.intent }
 					declineButtonText={ props.declineButtonText }
 					onDecline={ props.onDeclineUpsell }
 					image={ imgBusinessPlan }
@@ -245,6 +252,7 @@ export default function UpsellStep( { upsell, site, purchase, ...props }: StepPr
 					title={ translate( 'Switch to flexible monthly payments' ) }
 					acceptButtonText={ translate( 'Switch to monthly payments' ) }
 					onAccept={ () => props.onClickDowngrade?.( upsell ) }
+					intent={ props.intent }
 					declineButtonText={ props.declineButtonText }
 					onDecline={ props.onDeclineUpsell }
 					image={ imgMonthlyPayments }
@@ -291,6 +299,7 @@ export default function UpsellStep( { upsell, site, purchase, ...props }: StepPr
 						args: { plan: getPlan( PLAN_PERSONAL )?.getTitle() ?? '' },
 					} ) }
 					onAccept={ () => props.onClickDowngrade?.( upsell ) }
+					intent={ props.intent }
 					declineButtonText={ props.declineButtonText }
 					onDecline={ props.onDeclineUpsell }
 					image={ imgSwitchPlan }
@@ -331,6 +340,7 @@ export default function UpsellStep( { upsell, site, purchase, ...props }: StepPr
 					title={ translate( 'How about a free month?' ) }
 					acceptButtonText={ translate( 'Get a free month' ) }
 					onAccept={ () => props.onClickFreeMonthOffer?.() }
+					intent={ props.intent }
 					declineButtonText={ props.declineButtonText }
 					onDecline={ props.onDeclineUpsell }
 					image={ imgFreeMonth }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
@@ -193,9 +193,10 @@ function SurveyContent( {
 				cancellationReason={ questionOneText }
 				closeDialog={ closeDialog }
 				currencyCode={ purchase.currency_code }
-				declineButtonText={ intent === 'remove' ? __( 'Remove my current plan' ) : undefined }
+				declineButtonText={ intent === 'remove' ? __( 'Continue removal' ) : undefined }
 				downgradePlan={ downgradePlan }
 				includedDomainPurchase={ includedDomainPurchase }
+				intent={ intent ?? undefined }
 				onClickDowngrade={ downgradeClick }
 				onClickFreeMonthOffer={ freeMonthOfferClick }
 				onDeclineUpsell={ isLastStep ? onSubmit : clickNext }
@@ -295,6 +296,7 @@ function StepButtons( {
 	clickNext,
 	closeDialog,
 	disableButtons,
+	intent,
 	isSubmitting,
 	onSubmit,
 	solution,
@@ -320,6 +322,21 @@ function StepButtons( {
 	}
 
 	if ( ! isLastStep ) {
+		if ( intent === 'remove' ) {
+			return (
+				<ButtonStack justify="flex-start">
+					<Button
+						variant="primary"
+						isDestructive
+						disabled={ ! canGoNext || isCancelling }
+						onClick={ clickNext }
+					>
+						{ __( 'Continue removal' ) }
+					</Button>
+				</ButtonStack>
+			);
+		}
+
 		return (
 			<ButtonStack justify="flex-start">
 				<Button variant="primary" disabled={ ! canGoNext || isCancelling } onClick={ clickNext }>
@@ -384,6 +401,31 @@ function StepButtons( {
 					variant="secondary"
 				>
 					{ __( 'No, thanks' ) }
+				</Button>
+			</ButtonStack>
+		);
+	}
+
+	if ( intent === 'remove' ) {
+		return (
+			<ButtonStack justify="flex-start">
+				<Button
+					isDestructive
+					disabled={ ! canGoNext }
+					isBusy={ isCancelling }
+					onClick={ onSubmit }
+					variant="primary"
+				>
+					{ __( 'Complete removal' ) }
+				</Button>
+				<Button
+					isDestructive
+					variant="tertiary"
+					isBusy={ isCancelling }
+					disabled={ isCancelling }
+					onClick={ onSubmit }
+				>
+					{ __( 'Skip and remove' ) }
 				</Button>
 			</ButtonStack>
 		);

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/upsell-step.tsx
@@ -13,6 +13,7 @@ import type { PlanProduct, Purchase } from '@automattic/api-core';
 
 type UpsellProps = {
 	children?: React.ReactNode;
+	intent?: string;
 	title: string;
 	acceptButtonText: string;
 	acceptButtonUrl?: string;
@@ -32,13 +33,19 @@ function Upsell( { ...props }: UpsellProps ) {
 			<ButtonStack justify="flex-start">
 				<Button
 					variant="primary"
+					isDestructive={ props.intent === 'remove' }
 					href={ props.acceptButtonUrl }
 					onClick={ props.onAccept }
 					isBusy={ props.isBusy }
 				>
 					{ props.acceptButtonText }
 				</Button>
-				<Button variant="secondary" onClick={ props.onDecline } disabled={ props.isBusy }>
+				<Button
+					variant={ props.intent === 'remove' ? 'tertiary' : 'secondary' }
+					isDestructive={ props.intent === 'remove' }
+					onClick={ props.onDecline }
+					disabled={ props.isBusy }
+				>
 					{ declineButtonText }
 				</Button>
 			</ButtonStack>
@@ -70,6 +77,7 @@ type StepProps = {
 	declineButtonText?: string;
 	downgradePlan?: PlanProduct | null;
 	includedDomainPurchase?: object;
+	intent?: string;
 	onClickDowngrade?: ( upsell: string ) => void;
 	onClickFreeMonthOffer?: () => void;
 	onDeclineUpsell?: () => void;
@@ -133,6 +141,7 @@ export default function UpsellStep( {
 
 						props.closeDialog && props.closeDialog();
 					} }
+					intent={ props.intent }
 					declineButtonText={ props.declineButtonText }
 					onDecline={ props.onDeclineUpsell }
 					isBusy={ cancellationInProgress }
@@ -170,6 +179,7 @@ export default function UpsellStep( {
 						recordTracksEvent( 'calypso_cancellation_upsell_step_buily_by_click' );
 						window.location.replace( builtByURL );
 					} }
+					intent={ props.intent }
 					declineButtonText={ props.declineButtonText }
 					onDecline={ props.onDeclineUpsell }
 					isBusy={ cancellationInProgress }
@@ -203,6 +213,7 @@ export default function UpsellStep( {
 					onAccept={ () => {
 						recordTracksEvent( 'calypso_cancellation_upgrade_at_step_upgrade_click' );
 					} }
+					intent={ props.intent }
 					declineButtonText={ props.declineButtonText }
 					onDecline={ props.onDeclineUpsell }
 					isBusy={ cancellationInProgress }
@@ -232,6 +243,7 @@ export default function UpsellStep( {
 					title={ __( 'Switch to flexible monthly payments' ) }
 					acceptButtonText={ __( 'Switch to monthly payments' ) }
 					onAccept={ () => props.onClickDowngrade?.( upsell ) }
+					intent={ props.intent }
 					declineButtonText={ props.declineButtonText }
 					onDecline={ props.onDeclineUpsell }
 					isBusy={ cancellationInProgress }
@@ -281,6 +293,7 @@ export default function UpsellStep( {
 						plan: personalPlanName,
 					} ) }
 					onAccept={ () => props.onClickDowngrade?.( upsell ) }
+					intent={ props.intent }
 					declineButtonText={ props.declineButtonText }
 					onDecline={ props.onDeclineUpsell }
 					isBusy={ cancellationInProgress }
@@ -314,6 +327,7 @@ export default function UpsellStep( {
 					title={ __( 'How about a free month?' ) }
 					acceptButtonText={ __( 'Get a free month' ) }
 					onAccept={ () => props.onClickFreeMonthOffer?.() }
+					intent={ props.intent }
 					declineButtonText={ props.declineButtonText }
 					onDecline={ props.onDeclineUpsell }
 					isBusy={ cancellationInProgress }


### PR DESCRIPTION
## Summary

This PR updates copy in the remove product flow. 

Changes:
- When `intent === 'remove'`, survey and upsell buttons become visually destructive (red) on both legacy and dashboard surfaces
- Non-last steps: "Continue removal" with no skip button; last step: "Complete removal" + destructive tertiary "Skip and remove" always visible
- Upsell accept buttons become destructive, decline buttons switch to destructive tertiary with "Continue removal" copy
- Scoped entirely to `intent === 'remove'` — cancel flow untouched

Flag: `purchases/split-cancel-remove` (remove flow is only reachable behind the flag)

## Test plan
- [ ] Navigate to a purchase with remove intent behind `purchases/split-cancel-remove` flag
- [ ] Verify survey non-last step shows red "Continue removal" button, no skip
- [ ] Verify survey last step shows red "Complete removal" + red borderless "Skip and remove"
- [ ] Verify "Complete removal" shows busy state on click
- [ ] Verify upsell step accept button is red, decline is red borderless tertiary
- [ ] Verify cancel intent flow is completely unchanged
- [ ] Test on both legacy (`calypso.localhost:3000`) and dashboard (`my.localhost:3000`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)