### PR TITLE
Reader / ATmosphere: repost interactions on Bluesky posts

### DIFF
--- a/client/reader/atmosphere/test/timeline-panel.test.tsx
+++ b/client/reader/atmosphere/test/timeline-panel.test.tsx
@@ -305,6 +305,58 @@ describe( 'TimelinePanel', () => {
 		expect( screen.getByRole( 'button', { name: /like, 6 likes/i } ) ).toHaveTextContent( '6' );
 		await waitFor( () => expect( nock.isDone() ).toBe( true ) );
 	} );
+
+	it( 'opens the repost menu, fires POST on Repost click, and toggles directly on un-repost', async () => {
+		const POST_URI = 'at://did:plc:author/app.bsky.feed.post/3krepost';
+		const REPOST_URI = 'at://did:plc:caller/app.bsky.feed.repost/3krrkeyrkeyrk';
+
+		nock( BASE )
+			.get( PATH )
+			.query( {} )
+			.reply( 200, {
+				items: [
+					{
+						...makePost( POST_URI, 'repostable post' ),
+						cid: 'bafy-cid',
+						counts: { replies: 0, reposts: 5, likes: 0, quotes: 0 },
+						viewer: { like: null, repost: null },
+					},
+				],
+				cursor: null,
+			} );
+		nock( BASE )
+			.post( '/wpcom/v2/reader/atmosphere/connections/42/reposts', {
+				post_uri: POST_URI,
+				post_cid: 'bafy-cid',
+			} )
+			.reply( 200, {
+				repost: { uri: REPOST_URI, cid: 'bafy-r-cid', rkey: '3krrkeyrkeyrk' },
+			} );
+
+		const user = userEvent.setup();
+		renderWithProvider( <TimelinePanel connection={ connection } />, {
+			queryClient: makeQueryClient(),
+		} );
+
+		const trigger = await screen.findByRole( 'button', { name: /repost, 5 reposts/i } );
+		expect( trigger ).toHaveAttribute( 'aria-haspopup', 'menu' );
+		await user.click( trigger );
+
+		await user.click( await screen.findByRole( 'menuitem', { name: 'Repost' } ) );
+
+		const updated = await screen.findByRole( 'button', { name: /undo repost, 6 reposts/i } );
+		expect( updated ).toHaveAttribute( 'aria-pressed', 'true' );
+
+		nock( BASE )
+			.delete( '/wpcom/v2/reader/atmosphere/connections/42/reposts/3krrkeyrkeyrk' )
+			.reply( 204 );
+
+		await user.click( updated );
+		expect( screen.queryByRole( 'menuitem', { name: 'Repost' } ) ).toBeNull();
+
+		const reverted = await screen.findByRole( 'button', { name: /repost, 5 reposts/i } );
+		expect( reverted ).toHaveAttribute( 'aria-haspopup', 'menu' );
+	} );
 } );
 
 const connection7: AtmosphereConnection = {

--- a/client/reader/components/icons/repost.jsx
+++ b/client/reader/components/icons/repost.jsx
@@ -6,6 +6,7 @@ export default function ReaderRepostIcon( { iconSize, viewBox = '0 0 20 20' } ) 
 			height={ iconSize }
 			viewBox={ viewBox }
 			xmlns="http://www.w3.org/2000/svg"
+			fill="currentColor"
 		>
 			<path
 				fillRule="evenodd"

--- a/client/reader/social/AGENTS.md
+++ b/client/reader/social/AGENTS.md
@@ -277,6 +277,37 @@ The connection ID flows from the protocol shell:
 interactive count button that writes via a user's PDS should follow the same
 shape rather than reading connection identity from global state.
 
+### Repost interactions
+
+`<RepostButton>` lives next to `<LikeButton>` and is rendered by `<PostCardCounts>`
+under the same gating as `<LikeButton>` — only when the host shell passes both a
+`connectionId` and a post `cid`. Today only
+`client/reader/atmosphere/timeline-panel.tsx` opts in; thread, author-feed,
+quoted-post, and non-ATmosphere card contexts fall back to the static reposts
+count.
+
+Two render branches by viewer state:
+
+- **Reposted** — plain `<button aria-pressed="true">`. Clicking it fires the
+  delete-repost mutation directly; no menu opens. Loses access to the Quote-post
+  menu item on a reposted post; that's a known follow-up.
+- **Not reposted** — `<Dropdown>` from `@wordpress/components` whose toggle is
+  the same shape of button (`aria-haspopup="menu"`). The menu has two
+  `<MenuItem>`s: "Repost" (enabled, fires the create-repost mutation) and
+  "Quote post" (disabled — wires up in slice 7d).
+
+The button uses `useCreateRepostMutation()` / `useDeleteRepostMutation()` from
+`@automattic/api-queries`. Like the like mutations, those hooks reuse the
+generic `patchAtmospherePostCaches` helper to optimistically patch every cached
+atmosphere query containing the target post, then restore the snapshot on error.
+The create path temporarily stores `PENDING_REPOST_URI` in `viewer.repost`; keep
+using `rkeyFromUri()` for un-repost flows because it returns `null` for that
+sentinel and prevents a DELETE with a fake rkey.
+
+The connection ID flows from the protocol shell:
+`TimelinePanel` → `SocialPostCard` → `PostCardCounts` → `RepostButton`. Same
+shape as the like button.
+
 ## Boundaries (for new code)
 
 Inherits everything from `client/reader/AGENTS.md` and `client/AGENTS.md`. Highlights worth restating because they trip up new contributors:

--- a/client/reader/social/components/post-card/post-card-counts.tsx
+++ b/client/reader/social/components/post-card/post-card-counts.tsx
@@ -6,6 +6,7 @@ import ReaderLikeIcon from 'calypso/reader/components/icons/like-icon';
 import ReaderRepostIcon from 'calypso/reader/components/icons/repost';
 import { useSocialAnalytics } from './analytics-context';
 import { LikeButton } from './like-button';
+import { RepostButton } from './repost-button';
 import type { SocialPost } from '../../types';
 
 const ICON_SIZE = 16;
@@ -60,11 +61,23 @@ export function PostCardCounts( { post, connectionId }: PostCardCountsProps ) {
 			) : (
 				<span>{ repliesContent }</span>
 			) }
-			<span>
-				<ReaderRepostIcon iconSize={ ICON_SIZE } />
-				<span className="screen-reader-text">{ translate( 'Reposts:' ) } </span>
-				{ counts.reposts }
-			</span>
+			{ connectionId && post.cid ? (
+				<RepostButton
+					post={ {
+						uri: post.uri,
+						cid: post.cid,
+						counts: post.counts,
+						viewer: post.viewer,
+					} }
+					connectionId={ connectionId }
+				/>
+			) : (
+				<span>
+					<ReaderRepostIcon iconSize={ ICON_SIZE } />
+					<span className="screen-reader-text">{ translate( 'Reposts:' ) } </span>
+					{ counts.reposts }
+				</span>
+			) }
 			{ connectionId && post.cid ? (
 				<LikeButton
 					post={ {

--- a/client/reader/social/components/post-card/repost-button.scss
+++ b/client/reader/social/components/post-card/repost-button.scss
@@ -1,0 +1,40 @@
+.social-post-card-repost-button {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	margin: 0;
+	padding: 2px 4px;
+	background: transparent;
+	border: 0;
+	border-radius: 4px;
+	color: inherit;
+	cursor: pointer;
+	font: inherit;
+	line-height: 1;
+	position: relative;
+	z-index: 1;
+
+	&:hover:not( :disabled ),
+	&:focus-visible {
+		color: var( --studio-green-50 );
+	}
+
+	&:focus-visible {
+		outline: 2px solid var( --studio-blue-50 );
+		outline-offset: 2px;
+	}
+
+	&.is-reposted {
+		color: var( --studio-green-50 );
+	}
+
+	&.is-pending {
+		cursor: default;
+		opacity: 0.6;
+	}
+}
+
+.social-post-card-repost-button__count {
+	font-size: inherit;
+	line-height: 1;
+}

--- a/client/reader/social/components/post-card/repost-button.scss
+++ b/client/reader/social/components/post-card/repost-button.scss
@@ -38,3 +38,14 @@
 	font-size: inherit;
 	line-height: 1;
 }
+
+// `<Dropdown>` from `@wordpress/components` wraps the toggle button in a
+// `<div class="components-dropdown">` whose default `display: block` leaves
+// the inline-flex button top-aligned within a tall line box, knocking the
+// repost icon ~2px above the surrounding counts. Scoping this to the counts
+// row (rather than touching the global `.components-dropdown` rules) lets the
+// row's `align-items: center` reach the button.
+.social-post-card-counts .components-dropdown {
+	display: inline-flex;
+	align-items: center;
+}

--- a/client/reader/social/components/post-card/repost-button.tsx
+++ b/client/reader/social/components/post-card/repost-button.tsx
@@ -50,6 +50,11 @@ export function RepostButton( { post, connectionId }: RepostButtonProps ) {
 	const remove = useDeleteRepostMutation( connectionId );
 
 	const isReposted = Boolean( post.viewer?.repost );
+	// Disable across every instance of this post while a create-repost is in
+	// flight: cache carries `PENDING_REPOST_URI` even on instances whose own
+	// mutation hooks aren't pending, so a user who clicks the repost button on
+	// a duplicate render (e.g. timeline + thread) would otherwise either fire
+	// a duplicate create or hit a dead rkey on un-repost and silently no-op.
 	const isPending =
 		create.isPending || remove.isPending || post.viewer?.repost === PENDING_REPOST_URI;
 	const formattedReposts = formatNumber( post.counts.reposts );
@@ -76,7 +81,7 @@ export function RepostButton( { post, connectionId }: RepostButtonProps ) {
 	};
 
 	const handleRepost = () => {
-		analytics?.onClick( `calypso_reader_${ analytics.source }_repost_published`, {
+		analytics?.onClick( `calypso_reader_${ analytics.source }_repost_clicked`, {
 			connection_id: connectionId,
 			post_uri: post.uri,
 		} );
@@ -91,7 +96,7 @@ export function RepostButton( { post, connectionId }: RepostButtonProps ) {
 		if ( ! rkey ) {
 			return;
 		}
-		analytics?.onClick( `calypso_reader_${ analytics.source }_repost_undone`, {
+		analytics?.onClick( `calypso_reader_${ analytics.source }_unrepost_clicked`, {
 			connection_id: connectionId,
 			post_uri: post.uri,
 		} );

--- a/client/reader/social/components/post-card/repost-button.tsx
+++ b/client/reader/social/components/post-card/repost-button.tsx
@@ -1,0 +1,169 @@
+import { PENDING_REPOST_URI } from '@automattic/api-core';
+import { useCreateRepostMutation, useDeleteRepostMutation } from '@automattic/api-queries';
+import { formatNumber } from '@automattic/number-formatters';
+import { Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import { useDispatch } from 'react-redux';
+import ReaderRepostIcon from 'calypso/reader/components/icons/repost';
+import { rkeyFromUri } from 'calypso/reader/social/utils/rkey-from-uri';
+import { errorNotice } from 'calypso/state/notices/actions';
+import { useSocialAnalytics } from './analytics-context';
+import type { AtmosphereError, AtmosphereFeedItem } from '@automattic/api-core';
+
+import './repost-button.scss';
+
+interface RepostButtonProps {
+	post: Pick< AtmosphereFeedItem, 'uri' | 'cid' | 'counts' | 'viewer' >;
+	connectionId: number;
+}
+
+type RepostDirection = 'repost' | 'unrepost';
+
+function errorMessageForRepost(
+	error: AtmosphereError,
+	translate: ReturnType< typeof useTranslate >
+): string {
+	switch ( error.kind ) {
+		case 'auth_required':
+		case 'auth_failed':
+		case 'invalid_credentials':
+			return translate( 'Reconnect your Bluesky account to repost.' );
+		case 'rate_limited':
+			return translate( "You're reposting too quickly. Try again in a moment." );
+		case 'connection_not_found':
+		case 'not_found':
+			return translate( 'This connection no longer exists.' );
+		case 'bad_request':
+		case 'invalid_handle':
+		case 'upstream_unavailable':
+		case 'unknown':
+			return translate( 'Could not save your repost. Please try again.' );
+	}
+}
+
+export function RepostButton( { post, connectionId }: RepostButtonProps ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const analytics = useSocialAnalytics();
+	const create = useCreateRepostMutation( connectionId );
+	const remove = useDeleteRepostMutation( connectionId );
+
+	const isReposted = Boolean( post.viewer?.repost );
+	const isPending =
+		create.isPending || remove.isPending || post.viewer?.repost === PENDING_REPOST_URI;
+	const formattedReposts = formatNumber( post.counts.reposts );
+	const accessibleLabel = isReposted
+		? translate( 'Undo repost, %(count)s repost', 'Undo repost, %(count)s reposts', {
+				count: post.counts.reposts,
+				args: { count: formattedReposts },
+				textOnly: true,
+		  } )
+		: translate( 'Repost, %(count)s repost', 'Repost, %(count)s reposts', {
+				count: post.counts.reposts,
+				args: { count: formattedReposts },
+				textOnly: true,
+		  } );
+
+	const trackError = ( error: AtmosphereError, direction: RepostDirection ) => {
+		dispatch( errorNotice( errorMessageForRepost( error, translate ) ) );
+		analytics?.onClick( `calypso_reader_${ analytics.source }_repost_error_shown`, {
+			connection_id: connectionId,
+			post_uri: post.uri,
+			error_kind: error.kind,
+			direction,
+		} );
+	};
+
+	const handleRepost = () => {
+		analytics?.onClick( `calypso_reader_${ analytics.source }_repost_published`, {
+			connection_id: connectionId,
+			post_uri: post.uri,
+		} );
+		create.mutate(
+			{ postUri: post.uri, postCid: post.cid },
+			{ onError: ( error ) => trackError( error, 'repost' ) }
+		);
+	};
+
+	const handleUnrepost = () => {
+		const rkey = rkeyFromUri( post.viewer?.repost ?? '' );
+		if ( ! rkey ) {
+			return;
+		}
+		analytics?.onClick( `calypso_reader_${ analytics.source }_repost_undone`, {
+			connection_id: connectionId,
+			post_uri: post.uri,
+		} );
+		remove.mutate(
+			{ rkey, postUri: post.uri },
+			{ onError: ( error ) => trackError( error, 'unrepost' ) }
+		);
+	};
+
+	if ( isReposted ) {
+		return (
+			<button
+				type="button"
+				className={ clsx( 'social-post-card-repost-button', {
+					'is-reposted': true,
+					'is-pending': isPending,
+				} ) }
+				aria-pressed
+				aria-label={ accessibleLabel }
+				disabled={ isPending }
+				onClick={ ( event ) => {
+					event.preventDefault();
+					event.stopPropagation();
+					if ( isPending ) {
+						return;
+					}
+					handleUnrepost();
+				} }
+			>
+				<ReaderRepostIcon iconSize={ 16 } />
+				<span className="social-post-card-repost-button__count">{ formattedReposts }</span>
+			</button>
+		);
+	}
+
+	return (
+		<Dropdown
+			popoverProps={ { placement: 'bottom-start' } }
+			renderToggle={ ( { isOpen, onToggle } ) => (
+				<button
+					type="button"
+					className={ clsx( 'social-post-card-repost-button', { 'is-pending': isPending } ) }
+					aria-haspopup="menu"
+					aria-expanded={ isOpen }
+					aria-label={ accessibleLabel }
+					disabled={ isPending }
+					onClick={ ( event ) => {
+						event.preventDefault();
+						event.stopPropagation();
+						if ( isPending ) {
+							return;
+						}
+						onToggle();
+					} }
+				>
+					<ReaderRepostIcon iconSize={ 16 } />
+					<span className="social-post-card-repost-button__count">{ formattedReposts }</span>
+				</button>
+			) }
+			renderContent={ ( { onClose } ) => (
+				<MenuGroup>
+					<MenuItem
+						onClick={ () => {
+							onClose();
+							handleRepost();
+						} }
+					>
+						{ translate( 'Repost' ) }
+					</MenuItem>
+					<MenuItem disabled>{ translate( 'Quote post' ) }</MenuItem>
+				</MenuGroup>
+			) }
+		/>
+	);
+}

--- a/client/reader/social/components/post-card/test/post-card-counts.test.tsx
+++ b/client/reader/social/components/post-card/test/post-card-counts.test.tsx
@@ -95,4 +95,22 @@ describe( 'PostCardCounts', () => {
 		expect( button ).toHaveAttribute( 'aria-pressed', 'false' );
 		expect( button ).toHaveTextContent( '9' );
 	} );
+
+	it( 'renders reposts as a menu trigger when connectionId and cid are supplied', () => {
+		renderWithProvider( wrap( <PostCardCounts post={ post } connectionId={ 7 } /> ) );
+		const button = screen.getByRole( 'button', { name: /repost, 2 reposts/i } );
+		expect( button ).toHaveAttribute( 'aria-haspopup', 'menu' );
+		expect( button ).toHaveTextContent( '2' );
+	} );
+
+	it( 'renders reposts as a static span when connectionId is missing', () => {
+		render( wrap( <PostCardCounts post={ post } /> ) );
+		expect( screen.queryByRole( 'button', { name: /repost/i } ) ).toBeNull();
+	} );
+
+	it( 'renders reposts as a static span when post.cid is missing', () => {
+		const cidlessPost = { ...post, cid: '' };
+		renderWithProvider( wrap( <PostCardCounts post={ cidlessPost } connectionId={ 7 } /> ) );
+		expect( screen.queryByRole( 'button', { name: /repost/i } ) ).toBeNull();
+	} );
 } );

--- a/client/reader/social/components/post-card/test/repost-button.test.tsx
+++ b/client/reader/social/components/post-card/test/repost-button.test.tsx
@@ -1,0 +1,242 @@
+/**
+ * @jest-environment jsdom
+ */
+import { PENDING_REPOST_URI } from '@automattic/api-core';
+import { QueryClient } from '@tanstack/react-query';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import * as notices from 'calypso/state/notices/actions';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { SocialAnalyticsProvider } from '../analytics-context';
+import { RepostButton } from '../repost-button';
+import type { AtmosphereFeedItem } from '@automattic/api-core';
+
+const BASE = 'https://public-api.wordpress.com';
+const POST_URI = 'at://did:plc:author/app.bsky.feed.post/3kabc';
+const POST_CID = 'bafy-cid';
+const REPOST_URI = 'at://did:plc:caller/app.bsky.feed.repost/3krkeyrkeyrke';
+
+function makePost( overrides: Partial< AtmosphereFeedItem > = {} ): AtmosphereFeedItem {
+	return {
+		uri: POST_URI,
+		cid: POST_CID,
+		author: {
+			did: 'did:plc:author',
+			handle: 'alice.bsky.social',
+			display_name: 'Alice',
+			avatar: null,
+		},
+		created_at: '2026-04-30T12:00:00Z',
+		indexed_at: '2026-04-30T12:00:00Z',
+		text: 'hi',
+		html: '<p>hi</p>',
+		lang: [ 'en' ],
+		reply_parent: null,
+		reply_root: null,
+		reason: null,
+		embed: null,
+		counts: { replies: 0, reposts: 4, likes: 0, quotes: 0 },
+		viewer: { like: null, repost: null },
+		bluesky_url: 'https://bsky.app/profile/alice.bsky.social/post/3kabc',
+		...overrides,
+	};
+}
+
+function makeQueryClient() {
+	return new QueryClient( { defaultOptions: { mutations: { retry: false } } } );
+}
+
+function renderRepostButton(
+	post = makePost(),
+	{ onClick = jest.fn() }: { onClick?: jest.Mock } = {}
+) {
+	return {
+		onClick,
+		...renderWithProvider(
+			<SocialAnalyticsProvider
+				value={ {
+					source: 'atmosphere',
+					connectionId: 42,
+					onClick,
+				} }
+			>
+				<RepostButton post={ post } connectionId={ 42 } />
+			</SocialAnalyticsProvider>,
+			{ queryClient: makeQueryClient() }
+		),
+	};
+}
+
+describe( '<RepostButton>', () => {
+	afterEach( () => {
+		nock.cleanAll();
+		jest.restoreAllMocks();
+	} );
+
+	it( 'renders a menu trigger when not reposted', () => {
+		renderRepostButton();
+		const button = screen.getByRole( 'button', { name: /repost, 4 reposts/i } );
+		expect( button ).toHaveAttribute( 'aria-haspopup', 'menu' );
+		expect( button ).toHaveAttribute( 'aria-expanded', 'false' );
+		expect( button ).toHaveTextContent( '4' );
+	} );
+
+	it( 'renders an aria-pressed toggle when already reposted', () => {
+		renderRepostButton( makePost( { viewer: { like: null, repost: REPOST_URI } } ) );
+		const button = screen.getByRole( 'button', { name: /undo repost, 4 reposts/i } );
+		expect( button ).toHaveAttribute( 'aria-pressed', 'true' );
+	} );
+
+	it( 'click in not-reposted state opens the menu with Repost enabled and Quote post disabled', async () => {
+		const user = userEvent.setup();
+		renderRepostButton();
+		await user.click( screen.getByRole( 'button', { name: /repost, 4 reposts/i } ) );
+
+		const repostItem = await screen.findByRole( 'menuitem', { name: 'Repost' } );
+		const quoteItem = screen.getByRole( 'menuitem', { name: 'Quote post' } );
+		expect( repostItem ).not.toHaveAttribute( 'aria-disabled', 'true' );
+		expect( quoteItem ).toHaveAttribute( 'aria-disabled', 'true' );
+	} );
+
+	it( 'clicking the Repost menu item fires POST and the published Tracks event', async () => {
+		nock( BASE )
+			.post( '/wpcom/v2/reader/atmosphere/connections/42/reposts', {
+				post_uri: POST_URI,
+				post_cid: POST_CID,
+			} )
+			.reply( 200, {
+				repost: { uri: REPOST_URI, cid: 'bafy-r-cid', rkey: '3krkeyrkeyrke' },
+			} );
+
+		const user = userEvent.setup();
+		const { onClick } = renderRepostButton();
+		await user.click( screen.getByRole( 'button', { name: /repost, 4 reposts/i } ) );
+		await user.click( await screen.findByRole( 'menuitem', { name: 'Repost' } ) );
+
+		expect( onClick ).toHaveBeenCalledWith(
+			'calypso_reader_atmosphere_repost_published',
+			expect.objectContaining( { connection_id: 42, post_uri: POST_URI } )
+		);
+		await waitFor( () => expect( nock.isDone() ).toBe( true ) );
+	} );
+
+	it( 'clicking Quote post does not fire any mutation or Tracks event', async () => {
+		const user = userEvent.setup();
+		const { onClick } = renderRepostButton();
+		await user.click( screen.getByRole( 'button', { name: /repost, 4 reposts/i } ) );
+		const quoteItem = await screen.findByRole( 'menuitem', { name: 'Quote post' } );
+		await user.click( quoteItem );
+
+		expect( onClick ).not.toHaveBeenCalled();
+	} );
+
+	it( 'click in reposted state fires DELETE without opening a menu', async () => {
+		nock( BASE )
+			.delete( '/wpcom/v2/reader/atmosphere/connections/42/reposts/3krkeyrkeyrke' )
+			.reply( 204 );
+
+		const user = userEvent.setup();
+		const { onClick } = renderRepostButton(
+			makePost( { viewer: { like: null, repost: REPOST_URI } } )
+		);
+		await user.click( screen.getByRole( 'button', { name: /undo repost, 4 reposts/i } ) );
+
+		expect( screen.queryByRole( 'menuitem', { name: 'Repost' } ) ).toBeNull();
+		expect( onClick ).toHaveBeenCalledWith(
+			'calypso_reader_atmosphere_repost_undone',
+			expect.objectContaining( { connection_id: 42, post_uri: POST_URI } )
+		);
+		await waitFor( () => expect( nock.isDone() ).toBe( true ) );
+	} );
+
+	it( 'disables the button while the pending sentinel is set', async () => {
+		const interceptor = nock( BASE )
+			.delete( /\/reposts\// )
+			.reply( 204 );
+
+		const user = userEvent.setup();
+		renderRepostButton( makePost( { viewer: { like: null, repost: PENDING_REPOST_URI } } ) );
+		const button = screen.getByRole( 'button', { name: /undo repost, 4 reposts/i } );
+		expect( button ).toBeDisabled();
+		await user.click( button );
+
+		expect( interceptor.isDone() ).toBe( false );
+	} );
+
+	it( 'treats viewer:undefined as not-reposted and opens the menu on click', async () => {
+		const user = userEvent.setup();
+		const post = makePost();
+		delete ( post as Partial< AtmosphereFeedItem > ).viewer;
+		renderRepostButton( post );
+		const button = screen.getByRole( 'button', { name: /repost, 4 reposts/i } );
+		expect( button ).toHaveAttribute( 'aria-haspopup', 'menu' );
+
+		await user.click( button );
+		expect( await screen.findByRole( 'menuitem', { name: 'Repost' } ) ).toBeEnabled();
+	} );
+
+	it( 'create-repost error dispatches errorNotice + Tracks error event', async () => {
+		const errorNoticeSpy = jest.spyOn( notices, 'errorNotice' );
+		nock( BASE )
+			.post( '/wpcom/v2/reader/atmosphere/connections/42/reposts' )
+			.reply( 502, { error: 'atmosphere_upstream_unavailable' } );
+
+		const user = userEvent.setup();
+		const { onClick } = renderRepostButton();
+		await user.click( screen.getByRole( 'button', { name: /repost, 4 reposts/i } ) );
+		await user.click( await screen.findByRole( 'menuitem', { name: 'Repost' } ) );
+
+		await waitFor( () =>
+			expect( onClick ).toHaveBeenCalledWith(
+				'calypso_reader_atmosphere_repost_error_shown',
+				expect.objectContaining( { error_kind: 'upstream_unavailable', direction: 'repost' } )
+			)
+		);
+		expect( errorNoticeSpy ).toHaveBeenCalledWith(
+			'Could not save your repost. Please try again.'
+		);
+	} );
+
+	it( 'delete-repost error dispatches errorNotice + Tracks unrepost-error event', async () => {
+		const errorNoticeSpy = jest.spyOn( notices, 'errorNotice' );
+		nock( BASE )
+			.delete( '/wpcom/v2/reader/atmosphere/connections/42/reposts/3krkeyrkeyrke' )
+			.reply( 401, { error: 'atmosphere_unauthenticated' } );
+
+		const user = userEvent.setup();
+		const { onClick } = renderRepostButton(
+			makePost( { viewer: { like: null, repost: REPOST_URI } } )
+		);
+		await user.click( screen.getByRole( 'button', { name: /undo repost, 4 reposts/i } ) );
+
+		await waitFor( () =>
+			expect( onClick ).toHaveBeenCalledWith(
+				'calypso_reader_atmosphere_repost_error_shown',
+				expect.objectContaining( { error_kind: 'auth_required', direction: 'unrepost' } )
+			)
+		);
+		expect( errorNoticeSpy ).toHaveBeenCalledWith( 'Reconnect your Bluesky account to repost.' );
+	} );
+
+	it( 'click does not bubble to a parent listener', async () => {
+		const onParentClick = jest.fn();
+		const user = userEvent.setup();
+		renderWithProvider(
+			<SocialAnalyticsProvider
+				value={ { source: 'atmosphere', connectionId: 42, onClick: jest.fn() } }
+			>
+				<div role="button" tabIndex={ 0 } onClick={ onParentClick } onKeyDown={ onParentClick }>
+					<RepostButton
+						post={ makePost( { viewer: { like: null, repost: PENDING_REPOST_URI } } ) }
+						connectionId={ 42 }
+					/>
+				</div>
+			</SocialAnalyticsProvider>,
+			{ queryClient: makeQueryClient() }
+		);
+
+		await user.click( screen.getByRole( 'button', { name: /undo repost, 4 reposts/i } ) );
+		expect( onParentClick ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/reader/social/components/post-card/test/repost-button.test.tsx
+++ b/client/reader/social/components/post-card/test/repost-button.test.tsx
@@ -99,7 +99,7 @@ describe( '<RepostButton>', () => {
 		expect( quoteItem ).toHaveAttribute( 'aria-disabled', 'true' );
 	} );
 
-	it( 'clicking the Repost menu item fires POST and the published Tracks event', async () => {
+	it( 'clicking the Repost menu item fires POST and the repost_clicked Tracks event', async () => {
 		nock( BASE )
 			.post( '/wpcom/v2/reader/atmosphere/connections/42/reposts', {
 				post_uri: POST_URI,
@@ -115,7 +115,7 @@ describe( '<RepostButton>', () => {
 		await user.click( await screen.findByRole( 'menuitem', { name: 'Repost' } ) );
 
 		expect( onClick ).toHaveBeenCalledWith(
-			'calypso_reader_atmosphere_repost_published',
+			'calypso_reader_atmosphere_repost_clicked',
 			expect.objectContaining( { connection_id: 42, post_uri: POST_URI } )
 		);
 		await waitFor( () => expect( nock.isDone() ).toBe( true ) );
@@ -144,10 +144,67 @@ describe( '<RepostButton>', () => {
 
 		expect( screen.queryByRole( 'menuitem', { name: 'Repost' } ) ).toBeNull();
 		expect( onClick ).toHaveBeenCalledWith(
-			'calypso_reader_atmosphere_repost_undone',
+			'calypso_reader_atmosphere_unrepost_clicked',
 			expect.objectContaining( { connection_id: 42, post_uri: POST_URI } )
 		);
 		await waitFor( () => expect( nock.isDone() ).toBe( true ) );
+	} );
+
+	it( 'does not fire DELETE when the reposted-state URI parses to no rkey', async () => {
+		const interceptor = nock( BASE )
+			.delete( /\/reposts\// )
+			.reply( 204 );
+
+		const user = userEvent.setup();
+		const { onClick } = renderRepostButton(
+			// Malformed at-uri: starts with `at://` but missing the rkey segment
+			// after the collection. `rkeyFromUri()` returns null for this shape,
+			// which gates the DELETE in `handleUnrepost`.
+			makePost( { viewer: { like: null, repost: 'at://did:plc:caller/app.bsky.feed.repost' } } )
+		);
+		await user.click( screen.getByRole( 'button', { name: /undo repost, 4 reposts/i } ) );
+
+		expect( interceptor.isDone() ).toBe( false );
+		expect( onClick ).not.toHaveBeenCalled();
+	} );
+
+	it( 'renders the singular aria-label when reposts === 1', () => {
+		renderRepostButton( makePost( { counts: { replies: 0, reposts: 1, likes: 0, quotes: 0 } } ) );
+		expect( screen.getByRole( 'button', { name: /^repost, 1 repost$/i } ) ).toBeVisible();
+	} );
+
+	it( 'shows a rate-limit notice on rate_limited create errors', async () => {
+		const errorNoticeSpy = jest.spyOn( notices, 'errorNotice' );
+		nock( BASE )
+			.post( '/wpcom/v2/reader/atmosphere/connections/42/reposts' )
+			.reply( 429, { error: 'atmosphere_rate_limited' } );
+
+		const user = userEvent.setup();
+		renderRepostButton();
+		await user.click( screen.getByRole( 'button', { name: /repost, 4 reposts/i } ) );
+		await user.click( await screen.findByRole( 'menuitem', { name: 'Repost' } ) );
+
+		await waitFor( () =>
+			expect( errorNoticeSpy ).toHaveBeenCalledWith(
+				"You're reposting too quickly. Try again in a moment."
+			)
+		);
+	} );
+
+	it( 'shows a connection-missing notice on connection_not_found errors', async () => {
+		const errorNoticeSpy = jest.spyOn( notices, 'errorNotice' );
+		nock( BASE )
+			.post( '/wpcom/v2/reader/atmosphere/connections/42/reposts' )
+			.reply( 404, { error: 'connection_not_found' } );
+
+		const user = userEvent.setup();
+		renderRepostButton();
+		await user.click( screen.getByRole( 'button', { name: /repost, 4 reposts/i } ) );
+		await user.click( await screen.findByRole( 'menuitem', { name: 'Repost' } ) );
+
+		await waitFor( () =>
+			expect( errorNoticeSpy ).toHaveBeenCalledWith( 'This connection no longer exists.' )
+		);
 	} );
 
 	it( 'disables the button while the pending sentinel is set', async () => {

--- a/client/reader/social/utils/rkey-from-uri.ts
+++ b/client/reader/social/utils/rkey-from-uri.ts
@@ -1,16 +1,16 @@
-import { PENDING_LIKE_URI } from '@automattic/api-core';
+import { PENDING_LIKE_URI, PENDING_REPOST_URI } from '@automattic/api-core';
 
 /**
  * Parse the rkey out of an at-uri.
  *
  * `at://did:plc:foo/app.bsky.feed.like/3kabc` → `'3kabc'`
  *
- * Returns null for malformed input, missing rkey segment, or the
- * pending-like sentinel (used during the optimistic-update window
- * before the server response lands).
+ * Returns null for malformed input, missing rkey segment, or either
+ * pending sentinel (used during the optimistic-update window before
+ * the server response lands).
  */
 export function rkeyFromUri( uri: string ): string | null {
-	if ( uri === PENDING_LIKE_URI ) {
+	if ( uri === PENDING_LIKE_URI || uri === PENDING_REPOST_URI ) {
 		return null;
 	}
 	if ( ! uri || ! uri.startsWith( 'at://' ) ) {

--- a/client/reader/social/utils/test/rkey-from-uri.test.ts
+++ b/client/reader/social/utils/test/rkey-from-uri.test.ts
@@ -1,4 +1,4 @@
-import { PENDING_LIKE_URI } from '@automattic/api-core';
+import { PENDING_LIKE_URI, PENDING_REPOST_URI } from '@automattic/api-core';
 import { rkeyFromUri } from '../rkey-from-uri';
 
 describe( 'rkeyFromUri', () => {
@@ -8,8 +8,12 @@ describe( 'rkeyFromUri', () => {
 		);
 	} );
 
-	it( 'returns null for the pending sentinel', () => {
+	it( 'returns null for the pending-like sentinel', () => {
 		expect( rkeyFromUri( PENDING_LIKE_URI ) ).toBeNull();
+	} );
+
+	it( 'returns null for the pending-repost sentinel', () => {
+		expect( rkeyFromUri( PENDING_REPOST_URI ) ).toBeNull();
 	} );
 
 	it( 'returns null for an at-uri without an rkey segment', () => {

--- a/packages/api-core/src/reader-atmosphere/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/reader-atmosphere/__tests__/fetchers.test.ts
@@ -3,8 +3,10 @@ import {
 	createConnection,
 	createFollow,
 	createLike,
+	createRepost,
 	deleteFollow,
 	deleteLike,
+	deleteRepost,
 	getAtmosphereTagFeed,
 	getAuthorFeed,
 	getAuthorProfile,
@@ -725,6 +727,117 @@ describe( 'atmosphere fetchers', () => {
 			).rejects.toMatchObject( {
 				kind: 'upstream_unavailable',
 			} );
+		} );
+	} );
+
+	describe( 'createRepost', () => {
+		it( 'POSTs to /reposts and unwraps the repost envelope', async () => {
+			nock( BASE )
+				.post( '/wpcom/v2/reader/atmosphere/connections/42/reposts', {
+					post_uri: 'at://did:plc:author/app.bsky.feed.post/3kabc',
+					post_cid: 'bafyreid27zk7',
+				} )
+				.reply( 200, {
+					repost: {
+						uri: 'at://did:plc:caller/app.bsky.feed.repost/3krkeyrkeyrke',
+						cid: 'bafyreig27zk7',
+						rkey: '3krkeyrkeyrke',
+					},
+				} );
+
+			const result = await createRepost( {
+				connectionId: 42,
+				postUri: 'at://did:plc:author/app.bsky.feed.post/3kabc',
+				postCid: 'bafyreid27zk7',
+			} );
+
+			expect( result ).toEqual( {
+				uri: 'at://did:plc:caller/app.bsky.feed.repost/3krkeyrkeyrke',
+				cid: 'bafyreig27zk7',
+				rkey: '3krkeyrkeyrke',
+			} );
+		} );
+
+		it( 'classifies 400 as bad_request', async () => {
+			nock( BASE )
+				.post( '/wpcom/v2/reader/atmosphere/connections/42/reposts' )
+				.reply( 400, { error: 'atmosphere_bad_request', message: 'Invalid post reference.' } );
+
+			await expect(
+				createRepost( { connectionId: 42, postUri: 'at://x', postCid: 'y' } )
+			).rejects.toMatchObject( { kind: 'bad_request' } );
+		} );
+
+		it( 'classifies 401 as auth_required', async () => {
+			nock( BASE )
+				.post( '/wpcom/v2/reader/atmosphere/connections/42/reposts' )
+				.reply( 401, { error: 'atmosphere_unauthenticated' } );
+
+			await expect(
+				createRepost( { connectionId: 42, postUri: 'at://x', postCid: 'y' } )
+			).rejects.toMatchObject( { kind: 'auth_required' } );
+		} );
+
+		it( 'classifies 429 as rate_limited', async () => {
+			nock( BASE )
+				.post( '/wpcom/v2/reader/atmosphere/connections/42/reposts' )
+				.reply( 429, { error: 'atmosphere_rate_limited' } );
+
+			await expect(
+				createRepost( { connectionId: 42, postUri: 'at://x', postCid: 'y' } )
+			).rejects.toMatchObject( { kind: 'rate_limited' } );
+		} );
+
+		it( 'classifies 502 as upstream_unavailable', async () => {
+			nock( BASE )
+				.post( '/wpcom/v2/reader/atmosphere/connections/42/reposts' )
+				.reply( 502, { error: 'atmosphere_upstream_unavailable' } );
+
+			await expect(
+				createRepost( { connectionId: 42, postUri: 'at://x', postCid: 'y' } )
+			).rejects.toMatchObject( { kind: 'upstream_unavailable' } );
+		} );
+	} );
+
+	describe( 'deleteRepost', () => {
+		it( 'DELETEs /reposts/{rkey} and resolves on 204', async () => {
+			nock( BASE )
+				.delete( '/wpcom/v2/reader/atmosphere/connections/42/reposts/3krkeyrkeyrke' )
+				.reply( 204 );
+
+			await expect(
+				deleteRepost( { connectionId: 42, rkey: '3krkeyrkeyrke' } )
+			).resolves.toBeUndefined();
+		} );
+
+		it( 'classifies 401 as auth_required', async () => {
+			nock( BASE )
+				.delete( '/wpcom/v2/reader/atmosphere/connections/42/reposts/3krkeyrkeyrke' )
+				.reply( 401, { error: 'atmosphere_unauthenticated' } );
+
+			await expect(
+				deleteRepost( { connectionId: 42, rkey: '3krkeyrkeyrke' } )
+			).rejects.toMatchObject( { kind: 'auth_required' } );
+		} );
+
+		it( 'classifies 429 as rate_limited', async () => {
+			nock( BASE )
+				.delete( '/wpcom/v2/reader/atmosphere/connections/42/reposts/3krkeyrkeyrke' )
+				.reply( 429, { error: 'atmosphere_rate_limited' } );
+
+			await expect(
+				deleteRepost( { connectionId: 42, rkey: '3krkeyrkeyrke' } )
+			).rejects.toMatchObject( { kind: 'rate_limited' } );
+		} );
+
+		it( 'classifies 502 as upstream_unavailable', async () => {
+			nock( BASE )
+				.delete( '/wpcom/v2/reader/atmosphere/connections/42/reposts/3krkeyrkeyrke' )
+				.reply( 502, { error: 'atmosphere_upstream_unavailable' } );
+
+			await expect(
+				deleteRepost( { connectionId: 42, rkey: '3krkeyrkeyrke' } )
+			).rejects.toMatchObject( { kind: 'upstream_unavailable' } );
 		} );
 	} );
 

--- a/packages/api-core/src/reader-atmosphere/constants.ts
+++ b/packages/api-core/src/reader-atmosphere/constants.ts
@@ -6,3 +6,12 @@
  * suppress any DELETE that would race the in-flight POST.
  */
 export const PENDING_LIKE_URI = '__pending_like__';
+
+/**
+ * Sentinel used in `AtmosphereFeedItem.viewer.repost` during the
+ * optimistic-update window after a repost-mutation fires but before
+ * the server response lands. Consumers that parse the rkey out of
+ * the at-uri must treat this value as "no real rkey yet" and
+ * suppress any DELETE that would race the in-flight POST.
+ */
+export const PENDING_REPOST_URI = '__pending_repost__';

--- a/packages/api-core/src/reader-atmosphere/fetchers.ts
+++ b/packages/api-core/src/reader-atmosphere/fetchers.ts
@@ -286,16 +286,14 @@ export interface GetAtmosphereTagFeedParams {
 
 export async function createRepost( params: CreateRepostParams ): Promise< CreateRepostResult > {
 	try {
-		const res = ( await wpcom.req.post(
-			{
-				path: `/reader/atmosphere/connections/${ params.connectionId }/reposts`,
-				apiNamespace: NAMESPACE,
-			},
-			{
+		const res = ( await wpcom.req.post( {
+			path: `/reader/atmosphere/connections/${ params.connectionId }/reposts`,
+			apiNamespace: NAMESPACE,
+			body: {
 				post_uri: params.postUri,
 				post_cid: params.postCid,
-			}
-		) ) as { repost: CreateRepostResult };
+			},
+		} ) ) as { repost: CreateRepostResult };
 		return res.repost;
 	} catch ( raw ) {
 		throw classifyAtmosphereError( raw );

--- a/packages/api-core/src/reader-atmosphere/fetchers.ts
+++ b/packages/api-core/src/reader-atmosphere/fetchers.ts
@@ -14,7 +14,10 @@ import type {
 	AtmosphereTimelinePage,
 	CreateLikeParams,
 	CreateLikeResult,
+	CreateRepostParams,
+	CreateRepostResult,
 	DeleteLikeParams,
+	DeleteRepostParams,
 } from './types';
 
 const NAMESPACE = 'wpcom/v2';
@@ -279,6 +282,36 @@ export interface GetAtmosphereTagFeedParams {
 	hashtag: string;
 	cursor?: string;
 	limit?: number;
+}
+
+export async function createRepost( params: CreateRepostParams ): Promise< CreateRepostResult > {
+	try {
+		const res = ( await wpcom.req.post(
+			{
+				path: `/reader/atmosphere/connections/${ params.connectionId }/reposts`,
+				apiNamespace: NAMESPACE,
+			},
+			{
+				post_uri: params.postUri,
+				post_cid: params.postCid,
+			}
+		) ) as { repost: CreateRepostResult };
+		return res.repost;
+	} catch ( raw ) {
+		throw classifyAtmosphereError( raw );
+	}
+}
+
+export async function deleteRepost( params: DeleteRepostParams ): Promise< void > {
+	try {
+		await wpcom.req.post( {
+			method: 'DELETE',
+			path: `/reader/atmosphere/connections/${ params.connectionId }/reposts/${ params.rkey }`,
+			apiNamespace: NAMESPACE,
+		} );
+	} catch ( raw ) {
+		throw classifyAtmosphereError( raw );
+	}
 }
 
 export async function getAtmosphereTagFeed(

--- a/packages/api-core/src/reader-atmosphere/types.ts
+++ b/packages/api-core/src/reader-atmosphere/types.ts
@@ -288,6 +288,23 @@ export interface DeleteLikeParams {
 	rkey: string;
 }
 
+export interface CreateRepostParams {
+	connectionId: number;
+	postUri: string;
+	postCid: string;
+}
+
+export interface CreateRepostResult {
+	uri: string;
+	cid: string;
+	rkey: string;
+}
+
+export interface DeleteRepostParams {
+	connectionId: number;
+	rkey: string;
+}
+
 // Metadata embedded in the tag-feed response. The backend always emits
 // the `tag` block; `count` is `null` when the AppView's `hitsTotal` is
 // absent (it is documented as approximate). `url` is currently always

--- a/packages/api-queries/src/__tests__/reader-atmosphere.test.tsx
+++ b/packages/api-queries/src/__tests__/reader-atmosphere.test.tsx
@@ -1521,6 +1521,41 @@ describe( 'reader-atmosphere hooks', () => {
 			expect( after.pages[ 0 ].items[ 1 ].counts.reposts ).toBe( 2 );
 			expect( after.pages[ 0 ].items[ 1 ].viewer?.repost ).toBe( REPOST_URI );
 		} );
+
+		it( 'patches the matching post in a thread cache entry', async () => {
+			nock( BASE )
+				.post( '/wpcom/v2/reader/atmosphere/connections/42/reposts' )
+				.reply( 200, { repost: { uri: REPOST_URI, cid: 'bafy-r-cid', rkey: '3krkeyrkeyrke' } } );
+
+			const client = new QueryClient( { defaultOptions: { mutations: { retry: false } } } );
+			const target = makeFeedItem( {
+				uri: POST_URI,
+				cid: POST_CID,
+				counts: { replies: 0, reposts: 2, likes: 0, quotes: 0 },
+				viewer: { like: null, repost: null },
+			} );
+			client.setQueryData< AtmosphereThreadResponse >( readerAtmosphereKeys.thread( POST_URI ), {
+				thread: { type: 'post', post: target, parent: null, replies: [] },
+			} );
+
+			const { result } = renderHook( () => useCreateRepostMutation( 42 ), {
+				wrapper: makeWrapper( client ),
+			} );
+
+			act( () => {
+				result.current.mutate( { postUri: POST_URI, postCid: POST_CID } );
+			} );
+
+			await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+			const after = client.getQueryData< AtmosphereThreadResponse >(
+				readerAtmosphereKeys.thread( POST_URI )
+			);
+			expect( after?.thread.type ).toBe( 'post' );
+			const post = after?.thread.type === 'post' ? after.thread.post : null;
+			expect( post?.viewer?.repost ).toBe( REPOST_URI );
+			expect( post?.counts.reposts ).toBe( 3 );
+		} );
 	} );
 
 	describe( 'useDeleteRepostMutation', () => {

--- a/packages/api-queries/src/__tests__/reader-atmosphere.test.tsx
+++ b/packages/api-queries/src/__tests__/reader-atmosphere.test.tsx
@@ -1,5 +1,6 @@
 import {
 	PENDING_LIKE_URI,
+	PENDING_REPOST_URI,
 	readerAtmosphereKeys,
 	type AtmosphereFeedItem,
 	type AtmosphereScopedProfile,
@@ -27,6 +28,7 @@ import {
 	useConnectionsQuery,
 	useCreateConnectionMutation,
 	useCreateLikeMutation,
+	useCreateRepostMutation,
 	useDeleteLikeMutation,
 	useThreadQuery,
 	useTimelineInfiniteQuery,
@@ -1345,6 +1347,178 @@ describe( 'reader-atmosphere hooks', () => {
 
 				expect( getTimelineCache( client ) ).toEqual( snapshot );
 			} );
+		} );
+	} );
+
+	describe( 'useCreateRepostMutation', () => {
+		const POST_URI = 'at://did:plc:author/app.bsky.feed.post/3kabc';
+		const POST_CID = 'bafy-cid';
+		const REPOST_URI = 'at://did:plc:caller/app.bsky.feed.repost/3krkeyrkeyrke';
+
+		function seedTimeline( client: QueryClient, item: AtmosphereFeedItem ) {
+			const data: InfiniteData< AtmosphereTimelinePage > = {
+				pages: [ { items: [ item ], cursor: 'NEXT' } as unknown as AtmosphereTimelinePage ],
+				pageParams: [ undefined ],
+			};
+			client.setQueryData( readerAtmosphereKeys.timeline( 42 ), data );
+		}
+
+		it( 'optimistically flips viewer.repost to the pending sentinel and bumps counts.reposts', async () => {
+			nock( BASE )
+				.post( '/wpcom/v2/reader/atmosphere/connections/42/reposts' )
+				.delay( 100 )
+				.reply( 200, { repost: { uri: REPOST_URI, cid: 'bafy-r-cid', rkey: '3krkeyrkeyrke' } } );
+
+			const client = new QueryClient( { defaultOptions: { mutations: { retry: false } } } );
+			seedTimeline(
+				client,
+				makeFeedItem( {
+					uri: POST_URI,
+					cid: POST_CID,
+					counts: { replies: 0, reposts: 2, likes: 5, quotes: 0 },
+					viewer: { like: null, repost: null },
+				} )
+			);
+
+			const { result } = renderHook( () => useCreateRepostMutation( 42 ), {
+				wrapper: makeWrapper( client ),
+			} );
+
+			act( () => {
+				result.current.mutate( { postUri: POST_URI, postCid: POST_CID } );
+			} );
+
+			await waitFor( () => {
+				const data = client.getQueryData(
+					readerAtmosphereKeys.timeline( 42 )
+				) as InfiniteData< AtmosphereTimelinePage >;
+				const item = data.pages[ 0 ].items[ 0 ];
+				expect( item.viewer?.repost ).toBe( PENDING_REPOST_URI );
+				expect( item.counts.reposts ).toBe( 3 );
+			} );
+
+			await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+			const after = client.getQueryData(
+				readerAtmosphereKeys.timeline( 42 )
+			) as InfiniteData< AtmosphereTimelinePage >;
+			expect( after.pages[ 0 ].items[ 0 ].viewer?.repost ).toBe( REPOST_URI );
+			expect( after.pages[ 0 ].items[ 0 ].counts.reposts ).toBe( 3 );
+		} );
+
+		it( 'preserves viewer.like across an optimistic repost patch', async () => {
+			nock( BASE )
+				.post( '/wpcom/v2/reader/atmosphere/connections/42/reposts' )
+				.reply( 200, { repost: { uri: REPOST_URI, cid: 'bafy-r-cid', rkey: '3krkeyrkeyrke' } } );
+
+			const client = new QueryClient( { defaultOptions: { mutations: { retry: false } } } );
+			const existingLikeUri = 'at://did:plc:caller/app.bsky.feed.like/3kalreadyliked';
+			seedTimeline(
+				client,
+				makeFeedItem( {
+					uri: POST_URI,
+					cid: POST_CID,
+					counts: { replies: 0, reposts: 0, likes: 5, quotes: 0 },
+					viewer: { like: existingLikeUri, repost: null },
+				} )
+			);
+
+			const { result } = renderHook( () => useCreateRepostMutation( 42 ), {
+				wrapper: makeWrapper( client ),
+			} );
+
+			act( () => {
+				result.current.mutate( { postUri: POST_URI, postCid: POST_CID } );
+			} );
+
+			await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+			const after = client.getQueryData(
+				readerAtmosphereKeys.timeline( 42 )
+			) as InfiniteData< AtmosphereTimelinePage >;
+			const item = after.pages[ 0 ].items[ 0 ];
+			expect( item.viewer?.like ).toBe( existingLikeUri );
+			expect( item.viewer?.repost ).toBe( REPOST_URI );
+			expect( item.counts.likes ).toBe( 5 );
+		} );
+
+		it( 'rolls the cache back on error', async () => {
+			nock( BASE )
+				.post( '/wpcom/v2/reader/atmosphere/connections/42/reposts' )
+				.reply( 502, { error: 'atmosphere_upstream_unavailable' } );
+
+			const client = new QueryClient( { defaultOptions: { mutations: { retry: false } } } );
+			seedTimeline(
+				client,
+				makeFeedItem( {
+					uri: POST_URI,
+					cid: POST_CID,
+					counts: { replies: 0, reposts: 2, likes: 0, quotes: 0 },
+					viewer: { like: null, repost: null },
+				} )
+			);
+
+			const { result } = renderHook( () => useCreateRepostMutation( 42 ), {
+				wrapper: makeWrapper( client ),
+			} );
+
+			act( () => {
+				result.current.mutate( { postUri: POST_URI, postCid: POST_CID } );
+			} );
+
+			await waitFor( () => expect( result.current.isError ).toBe( true ) );
+
+			const after = client.getQueryData(
+				readerAtmosphereKeys.timeline( 42 )
+			) as InfiniteData< AtmosphereTimelinePage >;
+			const item = after.pages[ 0 ].items[ 0 ];
+			expect( item.viewer?.repost ).toBeNull();
+			expect( item.counts.reposts ).toBe( 2 );
+		} );
+
+		it( 'leaves non-matching posts in the cache untouched', async () => {
+			nock( BASE )
+				.post( '/wpcom/v2/reader/atmosphere/connections/42/reposts' )
+				.reply( 200, { repost: { uri: REPOST_URI, cid: 'bafy-r-cid', rkey: '3krkeyrkeyrke' } } );
+
+			const client = new QueryClient( { defaultOptions: { mutations: { retry: false } } } );
+			const otherPost = makeFeedItem( {
+				uri: 'at://did:plc:other/app.bsky.feed.post/3kother',
+				cid: 'cid-other',
+				counts: { replies: 0, reposts: 7, likes: 0, quotes: 0 },
+				viewer: { like: null, repost: null },
+			} );
+			const targetPost = makeFeedItem( {
+				uri: POST_URI,
+				cid: POST_CID,
+				counts: { replies: 0, reposts: 1, likes: 0, quotes: 0 },
+				viewer: { like: null, repost: null },
+			} );
+			const data: InfiniteData< AtmosphereTimelinePage > = {
+				pages: [
+					{ items: [ otherPost, targetPost ], cursor: null } as unknown as AtmosphereTimelinePage,
+				],
+				pageParams: [ undefined ],
+			};
+			client.setQueryData( readerAtmosphereKeys.timeline( 42 ), data );
+
+			const { result } = renderHook( () => useCreateRepostMutation( 42 ), {
+				wrapper: makeWrapper( client ),
+			} );
+
+			act( () => {
+				result.current.mutate( { postUri: POST_URI, postCid: POST_CID } );
+			} );
+
+			await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+			const after = client.getQueryData(
+				readerAtmosphereKeys.timeline( 42 )
+			) as InfiniteData< AtmosphereTimelinePage >;
+			expect( after.pages[ 0 ].items[ 0 ].counts.reposts ).toBe( 7 );
+			expect( after.pages[ 0 ].items[ 0 ].viewer?.repost ).toBeNull();
+			expect( after.pages[ 0 ].items[ 1 ].counts.reposts ).toBe( 2 );
+			expect( after.pages[ 0 ].items[ 1 ].viewer?.repost ).toBe( REPOST_URI );
 		} );
 	} );
 } );

--- a/packages/api-queries/src/__tests__/reader-atmosphere.test.tsx
+++ b/packages/api-queries/src/__tests__/reader-atmosphere.test.tsx
@@ -30,6 +30,7 @@ import {
 	useCreateLikeMutation,
 	useCreateRepostMutation,
 	useDeleteLikeMutation,
+	useDeleteRepostMutation,
 	useThreadQuery,
 	useTimelineInfiniteQuery,
 } from '../reader-atmosphere';
@@ -1519,6 +1520,156 @@ describe( 'reader-atmosphere hooks', () => {
 			expect( after.pages[ 0 ].items[ 0 ].viewer?.repost ).toBeNull();
 			expect( after.pages[ 0 ].items[ 1 ].counts.reposts ).toBe( 2 );
 			expect( after.pages[ 0 ].items[ 1 ].viewer?.repost ).toBe( REPOST_URI );
+		} );
+	} );
+
+	describe( 'useDeleteRepostMutation', () => {
+		const POST_URI = 'at://did:plc:author/app.bsky.feed.post/3kabc';
+		const POST_CID = 'bafy-cid';
+		const REPOST_URI = 'at://did:plc:caller/app.bsky.feed.repost/3krkeyrkeyrke';
+
+		function seedTimeline( client: QueryClient, item: AtmosphereFeedItem ) {
+			const data: InfiniteData< AtmosphereTimelinePage > = {
+				pages: [ { items: [ item ], cursor: 'NEXT' } as unknown as AtmosphereTimelinePage ],
+				pageParams: [ undefined ],
+			};
+			client.setQueryData( readerAtmosphereKeys.timeline( 42 ), data );
+		}
+
+		it( 'optimistically clears viewer.repost and decrements counts.reposts', async () => {
+			nock( BASE )
+				.delete( '/wpcom/v2/reader/atmosphere/connections/42/reposts/3krkeyrkeyrke' )
+				.reply( 204 );
+
+			const client = new QueryClient( { defaultOptions: { mutations: { retry: false } } } );
+			seedTimeline(
+				client,
+				makeFeedItem( {
+					uri: POST_URI,
+					cid: POST_CID,
+					counts: { replies: 0, reposts: 4, likes: 0, quotes: 0 },
+					viewer: { like: null, repost: REPOST_URI },
+				} )
+			);
+
+			const { result } = renderHook( () => useDeleteRepostMutation( 42 ), {
+				wrapper: makeWrapper( client ),
+			} );
+
+			act( () => {
+				result.current.mutate( { rkey: '3krkeyrkeyrke', postUri: POST_URI } );
+			} );
+
+			await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+			const after = client.getQueryData(
+				readerAtmosphereKeys.timeline( 42 )
+			) as InfiniteData< AtmosphereTimelinePage >;
+			const item = after.pages[ 0 ].items[ 0 ];
+			expect( item.viewer?.repost ).toBeNull();
+			expect( item.counts.reposts ).toBe( 3 );
+		} );
+
+		it( 'floors counts.reposts at 0 when the cache is stale at 0', async () => {
+			nock( BASE )
+				.delete( '/wpcom/v2/reader/atmosphere/connections/42/reposts/3krkeyrkeyrke' )
+				.reply( 204 );
+
+			const client = new QueryClient( { defaultOptions: { mutations: { retry: false } } } );
+			seedTimeline(
+				client,
+				makeFeedItem( {
+					uri: POST_URI,
+					cid: POST_CID,
+					counts: { replies: 0, reposts: 0, likes: 0, quotes: 0 },
+					viewer: { like: null, repost: REPOST_URI },
+				} )
+			);
+
+			const { result } = renderHook( () => useDeleteRepostMutation( 42 ), {
+				wrapper: makeWrapper( client ),
+			} );
+
+			act( () => {
+				result.current.mutate( { rkey: '3krkeyrkeyrke', postUri: POST_URI } );
+			} );
+
+			await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+			const after = client.getQueryData(
+				readerAtmosphereKeys.timeline( 42 )
+			) as InfiniteData< AtmosphereTimelinePage >;
+			expect( after.pages[ 0 ].items[ 0 ].counts.reposts ).toBe( 0 );
+		} );
+
+		it( 'rolls the cache back on error', async () => {
+			nock( BASE )
+				.delete( '/wpcom/v2/reader/atmosphere/connections/42/reposts/3krkeyrkeyrke' )
+				.reply( 401, { error: 'atmosphere_unauthenticated' } );
+
+			const client = new QueryClient( { defaultOptions: { mutations: { retry: false } } } );
+			seedTimeline(
+				client,
+				makeFeedItem( {
+					uri: POST_URI,
+					cid: POST_CID,
+					counts: { replies: 0, reposts: 4, likes: 0, quotes: 0 },
+					viewer: { like: null, repost: REPOST_URI },
+				} )
+			);
+
+			const { result } = renderHook( () => useDeleteRepostMutation( 42 ), {
+				wrapper: makeWrapper( client ),
+			} );
+
+			act( () => {
+				result.current.mutate( { rkey: '3krkeyrkeyrke', postUri: POST_URI } );
+			} );
+
+			await waitFor( () => expect( result.current.isError ).toBe( true ) );
+
+			const after = client.getQueryData(
+				readerAtmosphereKeys.timeline( 42 )
+			) as InfiniteData< AtmosphereTimelinePage >;
+			const item = after.pages[ 0 ].items[ 0 ];
+			expect( item.viewer?.repost ).toBe( REPOST_URI );
+			expect( item.counts.reposts ).toBe( 4 );
+		} );
+
+		it( 'preserves viewer.like across an optimistic delete-repost patch', async () => {
+			nock( BASE )
+				.delete( '/wpcom/v2/reader/atmosphere/connections/42/reposts/3krkeyrkeyrke' )
+				.reply( 204 );
+
+			const client = new QueryClient( { defaultOptions: { mutations: { retry: false } } } );
+			const existingLikeUri = 'at://did:plc:caller/app.bsky.feed.like/3kalreadyliked';
+			seedTimeline(
+				client,
+				makeFeedItem( {
+					uri: POST_URI,
+					cid: POST_CID,
+					counts: { replies: 0, reposts: 4, likes: 5, quotes: 0 },
+					viewer: { like: existingLikeUri, repost: REPOST_URI },
+				} )
+			);
+
+			const { result } = renderHook( () => useDeleteRepostMutation( 42 ), {
+				wrapper: makeWrapper( client ),
+			} );
+
+			act( () => {
+				result.current.mutate( { rkey: '3krkeyrkeyrke', postUri: POST_URI } );
+			} );
+
+			await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+			const after = client.getQueryData(
+				readerAtmosphereKeys.timeline( 42 )
+			) as InfiniteData< AtmosphereTimelinePage >;
+			const item = after.pages[ 0 ].items[ 0 ];
+			expect( item.viewer?.like ).toBe( existingLikeUri );
+			expect( item.viewer?.repost ).toBeNull();
+			expect( item.counts.likes ).toBe( 5 );
 		} );
 	} );
 } );

--- a/packages/api-queries/src/reader-atmosphere.ts
+++ b/packages/api-queries/src/reader-atmosphere.ts
@@ -615,6 +615,9 @@ function restoreAtmospherePostSnapshots(
 		}
 		const current = queryClient.getQueryData( key );
 		if ( ! current ) {
+			// Cache entry was evicted between onMutate and onError (e.g. via
+			// gcTime or an explicit removeQueries). Nothing to roll back —
+			// the next refetch will reload from the server.
 			continue;
 		}
 		queryClient.setQueryData( key, restoreAtmosphereQueryData( current, items ) );

--- a/packages/api-queries/src/reader-atmosphere.ts
+++ b/packages/api-queries/src/reader-atmosphere.ts
@@ -2,6 +2,7 @@ import {
 	createConnection,
 	createFollow,
 	createLike,
+	createRepost,
 	deleteFollow,
 	deleteLike,
 	getAtmosphereTagFeed,
@@ -13,6 +14,7 @@ import {
 	getThread,
 	getTimeline,
 	PENDING_LIKE_URI,
+	PENDING_REPOST_URI,
 	isValidHashtag,
 	readerAtmosphereKeys,
 } from '@automattic/api-core';
@@ -45,6 +47,7 @@ import type {
 	AtmosphereTimelinePage,
 	CreateConnectionParams,
 	CreateLikeResult,
+	CreateRepostResult,
 } from '@automattic/api-core';
 
 const TERMINAL_ERROR_KINDS: ReadonlySet< AtmosphereError[ 'kind' ] > = new Set( [
@@ -673,6 +676,41 @@ export function useDeleteLikeMutation( connectionId: number ) {
 			onError: ( _err, _vars, ctx ) => restoreAtmospherePostSnapshots( queryClient, ctx ),
 		}
 	);
+}
+
+export function useCreateRepostMutation( connectionId: number ) {
+	const queryClient = useQueryClient();
+	return useMutation<
+		CreateRepostResult,
+		AtmosphereError,
+		{ postUri: string; postCid: string },
+		OptimisticContext
+	>( {
+		mutationFn: ( { postUri, postCid } ) => createRepost( { connectionId, postUri, postCid } ),
+		onMutate: async ( { postUri } ) => {
+			await queryClient.cancelQueries( {
+				queryKey: readerAtmosphereKeys.all,
+			} );
+			return patchAtmospherePostCaches( queryClient, postUri, ( item ) => ( {
+				...item,
+				viewer: {
+					...( item.viewer ?? { like: null, repost: null } ),
+					repost: PENDING_REPOST_URI,
+				},
+				counts: { ...item.counts, reposts: item.counts.reposts + 1 },
+			} ) );
+		},
+		onError: ( _err, _vars, ctx ) => restoreAtmospherePostSnapshots( queryClient, ctx ),
+		onSuccess: ( result, { postUri } ) => {
+			patchAtmospherePostCaches( queryClient, postUri, ( item ) => ( {
+				...item,
+				viewer: {
+					...( item.viewer ?? { like: null, repost: null } ),
+					repost: result.uri,
+				},
+			} ) );
+		},
+	} );
 }
 
 export const atmosphereTagFeedInfiniteQuery = ( connectionId: number, hashtag: string ) => {

--- a/packages/api-queries/src/reader-atmosphere.ts
+++ b/packages/api-queries/src/reader-atmosphere.ts
@@ -5,6 +5,7 @@ import {
 	createRepost,
 	deleteFollow,
 	deleteLike,
+	deleteRepost,
 	getAtmosphereTagFeed,
 	getAuthorFeed,
 	getAuthorProfile,
@@ -711,6 +712,32 @@ export function useCreateRepostMutation( connectionId: number ) {
 			} ) );
 		},
 	} );
+}
+
+export function useDeleteRepostMutation( connectionId: number ) {
+	const queryClient = useQueryClient();
+	return useMutation< void, AtmosphereError, { rkey: string; postUri: string }, OptimisticContext >(
+		{
+			mutationFn: ( { rkey } ) => deleteRepost( { connectionId, rkey } ),
+			onMutate: async ( { postUri } ) => {
+				await queryClient.cancelQueries( {
+					queryKey: readerAtmosphereKeys.all,
+				} );
+				return patchAtmospherePostCaches( queryClient, postUri, ( item ) => ( {
+					...item,
+					viewer: {
+						...( item.viewer ?? { like: null, repost: null } ),
+						repost: null,
+					},
+					counts: {
+						...item.counts,
+						reposts: Math.max( 0, item.counts.reposts - 1 ),
+					},
+				} ) );
+			},
+			onError: ( _err, _vars, ctx ) => restoreAtmospherePostSnapshots( queryClient, ctx ),
+		}
+	);
 }
 
 export const atmosphereTagFeedInfiniteQuery = ( connectionId: number, hashtag: string ) => {


### PR DESCRIPTION
Fixes CM-643

## Proposed Changes

* New `<RepostButton>` rendered by `<PostCardCounts>` when a `connectionId` and `post.cid` are both available (same gating shape as the slice 7a `<LikeButton>`).
* Two render branches:
  * **Not reposted** — `<Dropdown>` from `@wordpress/components` with two `<MenuItem>`s: "Repost" (enabled, fires `useCreateRepostMutation`) and "Quote post" (disabled — wires up in slice 7d).
  * **Reposted** — plain `<button aria-pressed="true">`. Click fires `useDeleteRepostMutation` directly; no menu opens.
* Optimistic mutation hooks reuse the existing generic `patchAtmospherePostCaches` helper (no new infrastructure). They patch `viewer.repost` + `counts.reposts` across every cached atmosphere query containing the target post and roll back on error.
* New `PENDING_REPOST_URI` sentinel + explicit guard in `rkeyFromUri()` keep racing un-repost clicks from firing a DELETE with a fake rkey during the optimistic-create window.
* New typed fetchers (`createRepost` / `deleteRepost`) wrap the new backend write endpoints (CM-640, in lockstep development).
* `ReaderRepostIcon` learned to inherit color via `currentColor` so the button's `.is-reposted` green tint takes effect.
* Per-action error UX: `errorNotice` Snackbar with per-`error.kind` user-facing strings, plus three Tracks events (`_repost_clicked`, `_unrepost_clicked`, `_repost_error_shown`).
* Tests at every layer: 9 fetcher tests, 8 mutation hook tests, 15 `<RepostButton>` component tests, 3 `<PostCardCounts>` wiring tests, 1 end-to-end integration test on `<TimelinePanel>`. Plus regression coverage for `rkeyFromUri`'s new sentinel branch.
* Documentation refresh: a "Repost interactions" subsection in `client/reader/social/AGENTS.md` mirroring the existing "Like interactions" subsection.

## Why are these changes being made?

Slice 7b of the ATmosphere project. Slice 7a (likes) shipped a few days ago and established the pattern this slice mirrors: typed fetchers in `@automattic/api-core`, optimistic mutation hooks in `@automattic/api-queries` reusing the generic cache patcher, a button component next to `<LikeButton>`, and a gating contract on `<PostCardCounts>`. Repost is the next interaction in the slice 7 program; reply (slice 7c) and quote-composer (slice 7d) follow.

The repost UI is intentionally a menu (rather than a single toggle) because the same affordance will host the Quote-post action in slice 7d. To keep the un-repost click predictable when the menu is unavailable, the reposted state collapses to a direct toggle — that's the toggle-when-reposted decision baked into Q1 of the brainstorming pass.

## Testing Instructions

> ⚠️ **Backend dependency**: this PR cannot merge until the slice 7b backend (CM-640) has merged AND deployed. Until then, the new POST/DELETE endpoints will 404 and the menu's Repost click will surface an error notice.

1. Connect a Bluesky account at `/reader/atmosphere/connect` (if you don't have one connected).
2. Visit `/reader/atmosphere/<your-connection-id>/timeline`.
3. Find a post with at least one repost-able candidate (any post you didn't author works).
4. Click the reposts count → menu opens with "Repost" (enabled) and "Quote post" (disabled).
5. Click "Repost" → button flips to the reposted state (filled icon, count incremented). Verify the icon takes on a green tint.
6. Click the (now reposted) button → un-repost fires directly without opening the menu; count decrements; button reverts.
7. Verify the click on the button does not navigate to bsky.app (the surrounding card-link overlay should not fire).
8. Verify the disabled "Quote post" item visibly looks disabled and clicking it does nothing.
9. Trigger an error (e.g. by pointing the dev environment at an unreachable backend) → confirm the snackbar surfaces a user-friendly message and the optimistic count rolls back.

Automated tests:

```bash
yarn test-client client/reader/social/components/post-card/test/repost-button.test.tsx
yarn test-client client/reader/social/components/post-card/test/post-card-counts.test.tsx
yarn test-client client/reader/atmosphere/test/timeline-panel.test.tsx
yarn test-client client/reader/social/utils/test/rkey-from-uri.test.ts
yarn test-packages packages/api-core/src/reader-atmosphere/__tests__/fetchers.test.ts
yarn test-packages packages/api-queries/src/__tests__/reader-atmosphere.test.tsx
```

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?