### PR TITLE
Checkout: confine footer to form column so the sidebar can stay sticky

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -753,7 +753,7 @@ export default function CheckoutMainContent( {
 				<CheckoutStepGroup
 					loadingHeader={ loadingHeader }
 					onStepChanged={ onStepChanged }
-					scrollToStepOnForwardNavigation
+					scrollToStepOnForwardNavigation={ ! isLargeViewport }
 				>
 					<PerformanceTrackerStop />
 					{ infoMessage }

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -1032,7 +1032,11 @@ export default function CheckoutMainContent( {
 						if ( isLargeViewport ) {
 							return (
 								<>
-									{ checkoutMainContent }
+									<div className="checkout-main-column">
+										{ checkoutMainContent }
+										<CheckoutProcessorNotice />
+										<CheckoutTrustCards cart={ responseCart } />
+									</div>
 									{ checkoutSummary }
 								</>
 							);
@@ -1042,12 +1046,6 @@ export default function CheckoutMainContent( {
 					} }
 				</Step.TwoColumnLayout>
 				<LeaveCheckoutModal { ...leaveModalProps } />
-				{ isLargeViewport && (
-					<>
-						<CheckoutProcessorNotice />
-						<CheckoutTrustCards cart={ responseCart } />
-					</>
-				) }
 			</StepContainerV2CheckoutFixer>
 		</SubmitButtonSlotContext.Provider>
 	);
@@ -1942,8 +1940,8 @@ const WPCheckoutWrapper = styled.div< {
 		grid-template-columns: 1fr minmax( 500px, 688px ) 475px 1fr;
 		grid-template-areas:
 			'main-content main-content sidebar-content sidebar-content'
-			'processor-notice processor-notice processor-notice processor-notice'
-			'trust-cards trust-cards trust-cards trust-cards';
+			'. processor-notice sidebar-content sidebar-content'
+			'. trust-cards sidebar-content sidebar-content';
 		justify-items: end;
 	}
 

--- a/client/my-sites/checkout/src/components/checkout-processor-notice.tsx
+++ b/client/my-sites/checkout/src/components/checkout-processor-notice.tsx
@@ -9,11 +9,14 @@ const Notice = styled.p`
 	color: ${ ( props ) => props.theme.colors.textColorLight };
 	max-width: 1280px;
 	box-sizing: border-box;
+	white-space: pre-line;
 `;
 
 // Legal disclosure; must not be translated. The en-dashes (U+2013) are intentional.
+// The newline between "Inc." and "60" renders as a line break via the
+// `white-space: pre-line` rule on Notice above.
 const PROCESSOR_ADDRESS =
-	'Automattic Inc. 60 29th Street #343 – San Francisco, CA 94110 – United States of America';
+	'Automattic Inc.\n60 29th Street #343 – San Francisco, CA 94110 – United States of America';
 
 export default function CheckoutProcessorNotice() {
 	const translate = useTranslate();

--- a/client/my-sites/checkout/src/components/checkout-trust-cards.tsx
+++ b/client/my-sites/checkout/src/components/checkout-trust-cards.tsx
@@ -9,15 +9,17 @@ const TrustCardsRow = styled.div`
 	display: grid;
 	grid-template-columns: 1fr;
 	gap: 16px;
-	margin: 32px auto 0;
-	padding: 0 24px 32px;
+	margin: 32px 0 32px;
 	box-sizing: border-box;
-	max-width: 880px;
 
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
 		grid-template-columns: repeat( 2, minmax( 0, 1fr ) );
-		gap: 24px;
-		padding: 0 40px 48px;
+		gap: 12px;
+		/* Mirror StepContentWrapper's left inset (composite-checkout
+		   checkout-steps.tsx) so the cards line up with the form selectors
+		   above instead of the green step icons in the gutter. */
+		padding-inline-start: 40px;
+		margin-block-end: 48px;
 	}
 `;
 
@@ -25,9 +27,9 @@ const TrustCard = styled.div`
 	display: flex;
 	flex-direction: column;
 	gap: 8px;
-	padding: 20px 24px;
+	padding: 20px;
 	border: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
-	border-radius: 8px;
+	border-radius: 3px;
 	background: ${ ( props ) => props.theme.colors.surface };
 	box-sizing: border-box;
 `;


### PR DESCRIPTION
Stacks on top of #110099.

## Proposed Changes

* Move the processor notice and the trust cards row out of the page-wide footer and into the form column, so the sidebar column is independent of the form's full-page height.
* Make the legacy `WPCheckoutWrapper`'s sidebar `grid-area` span all three rows (form, processor notice, trust cards), so the sticky summary inside it stays pinned all the way to the bottom of the trust cards instead of releasing at the end of the form.
* In the V2 `StepContainerV2CheckoutFixer` path, wrap the form, processor notice, and trust cards in a single column-0 container of `Step.TwoColumnLayout`. The existing `align-items: stretch` row override extends column 1 (the sidebar) to match.
* Skip `scrollToStepOnForwardNavigation` on desktop. Returning users with saved contact info and saved payment auto-advance through completed steps on mount, and the per-step `scrollIntoView({ block: 'start' })` was landing the page near Payment Method.
* Add a line break in the processor disclosure between "Inc." and the street address so the company name sits on its own line.

## Why are these changes being made?

* With the footer below both columns, scrolling to the bottom released the sticky summary, leaving a gap next to the trust cards. Confining the footer to the form column lets the sidebar's grid-area run the full page height, so the Pay CTA stays pinned to the bottom.
* `scrollToStepOnForwardNavigation` was added for mobile reflow correction; on desktop it scrolled returning users away from the top of the page on initial load.
* Without an explicit break, the processor disclosure wraps mid-address on narrower viewports.

## Testing Instructions

* On a long-cart checkout (e.g. several domains + a plan): scroll from the top to the bottom. The Summary card with Pay CTA should stay pinned to the top of the viewport throughout, including alongside the trust cards row at the bottom.
* On a fresh return-user checkout (saved contact + saved payment): the page should land at the top with the form fully visible, not auto-scrolled to Payment Method.
* Stepper-originated checkout (any \`/checkout/...\` URL with a \`redirect_to\` query param pointing to a \`/setup/...\` flow): the sidebar should also stay pinned all the way down (the V2 path fix).
* The processor disclosure should appear as "Your payment will be processed by Automattic Inc." on one line, then "60 29th Street #343 – San Francisco, CA 94110 – United States of America" on the next.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?