### PR TITLE
APM: add Settings page and link

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -1239,6 +1239,25 @@ export const siteSettingsCachingRoute = createRoute( {
 	)
 );
 
+export const siteSettingsApmRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsServer' },
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Application Performance Monitoring' ),
+			},
+		],
+	} ),
+	getParentRoute: () => siteSettingsRoute,
+	path: 'apm',
+} ).lazy( () =>
+	import( '../../sites/settings-apm' ).then( ( d ) =>
+		createLazyRoute( 'site-settings-apm' )( {
+			component: () => <d.default siteSlug={ siteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
 export const siteSettingsDefensiveModeRoute = createRoute( {
 	staticData: { requiresSiteTypeSupport: 'settingsSecurity' },
 	head: () => ( {
@@ -1841,6 +1860,7 @@ export const createSitesRoutes = ( config: AppConfig ) => {
 		siteSettingsPrimaryDataCenterRoute,
 		siteSettingsStaticFile404Route,
 		siteSettingsCachingRoute,
+		...( isEnabled( 'performance/apm' ) ? [ siteSettingsApmRoute ] : [] ),
 
 		// Security
 		siteSettingsWebApplicationFirewallRoute,

--- a/client/dashboard/sites/performance/backend-access.ts
+++ b/client/dashboard/sites/performance/backend-access.ts
@@ -1,0 +1,11 @@
+import { BusinessPlans, EcommercePlans } from '@automattic/api-core';
+
+export function hasBackendAccess( productSlug: string | undefined ) {
+	if ( ! productSlug ) {
+		return false;
+	}
+	return (
+		( BusinessPlans as readonly string[] ).includes( productSlug ) ||
+		( EcommercePlans as readonly string[] ).includes( productSlug )
+	);
+}

--- a/client/dashboard/sites/performance/backend/index.tsx
+++ b/client/dashboard/sites/performance/backend/index.tsx
@@ -1,4 +1,4 @@
-import { BusinessPlans, EcommercePlans, type Site } from '@automattic/api-core';
+import { type Site } from '@automattic/api-core';
 import { siteBySlugQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
@@ -8,6 +8,7 @@ import { Card, CardBody, CardHeader } from '../../../components/card';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
 import UpsellCallout from '../../hosting-feature-gated-with-callout/upsell';
+import { hasBackendAccess } from '../backend-access';
 import { getBackendCalloutProps } from '../backend-callout';
 import Database from './database';
 import EnableApmCallout from './enable-apm-callout';
@@ -25,16 +26,6 @@ const TAB_PATHS: Record< ApmTab, string > = {
 	database: 'database',
 	'external-requests': 'external-requests',
 };
-
-function hasBackendAccess( productSlug: string | undefined ) {
-	if ( ! productSlug ) {
-		return false;
-	}
-	return (
-		( BusinessPlans as readonly string[] ).includes( productSlug ) ||
-		( EcommercePlans as readonly string[] ).includes( productSlug )
-	);
-}
 
 function ApmDashboard( { site, tab }: { site: Site; tab: ApmTab } ) {
 	const router = useRouter();

--- a/client/dashboard/sites/settings-apm/index.tsx
+++ b/client/dashboard/sites/settings-apm/index.tsx
@@ -1,4 +1,4 @@
-import { HostingFeatures, type Site } from '@automattic/api-core';
+import { BusinessPlans, EcommercePlans, type Site } from '@automattic/api-core';
 import { siteApmEnabledMutation, siteBySlugQuery } from '@automattic/api-queries';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
@@ -9,9 +9,18 @@ import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import { hasHostingFeature } from '../../utils/site-features';
 import UpsellCallout from '../hosting-feature-gated-with-callout/upsell';
 import { getBackendCalloutProps } from '../performance/backend-callout';
+
+function hasApmAccess( productSlug: string | undefined ) {
+	if ( ! productSlug ) {
+		return false;
+	}
+	return (
+		( BusinessPlans as readonly string[] ).includes( productSlug ) ||
+		( EcommercePlans as readonly string[] ).includes( productSlug )
+	);
+}
 
 function ApmToggle( { site }: { site: Site } ) {
 	const enabled = !! site.options?.apm_enabled;
@@ -86,7 +95,7 @@ export default function ApmSettings( { siteSlug }: { siteSlug: string } ) {
 				/>
 			}
 		>
-			{ hasHostingFeature( site, HostingFeatures.APM ) ? (
+			{ hasApmAccess( site.plan?.product_slug ) ? (
 				<ApmToggle site={ site } />
 			) : (
 				<UpsellCallout site={ site } { ...getBackendCalloutProps() } />

--- a/client/dashboard/sites/settings-apm/index.tsx
+++ b/client/dashboard/sites/settings-apm/index.tsx
@@ -1,4 +1,4 @@
-import { BusinessPlans, EcommercePlans, type Site } from '@automattic/api-core';
+import { type Site } from '@automattic/api-core';
 import { siteApmEnabledMutation, siteBySlugQuery } from '@automattic/api-queries';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
@@ -10,17 +10,8 @@ import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import UpsellCallout from '../hosting-feature-gated-with-callout/upsell';
+import { hasBackendAccess } from '../performance/backend-access';
 import { getBackendCalloutProps } from '../performance/backend-callout';
-
-function hasApmAccess( productSlug: string | undefined ) {
-	if ( ! productSlug ) {
-		return false;
-	}
-	return (
-		( BusinessPlans as readonly string[] ).includes( productSlug ) ||
-		( EcommercePlans as readonly string[] ).includes( productSlug )
-	);
-}
 
 function ApmToggle( { site }: { site: Site } ) {
 	const enabled = !! site.options?.apm_enabled;
@@ -95,7 +86,7 @@ export default function ApmSettings( { siteSlug }: { siteSlug: string } ) {
 				/>
 			}
 		>
-			{ hasApmAccess( site.plan?.product_slug ) ? (
+			{ hasBackendAccess( site.plan?.product_slug ) ? (
 				<ApmToggle site={ site } />
 			) : (
 				<UpsellCallout site={ site } { ...getBackendCalloutProps() } />

--- a/client/dashboard/sites/settings-apm/index.tsx
+++ b/client/dashboard/sites/settings-apm/index.tsx
@@ -1,0 +1,96 @@
+import { HostingFeatures, type Site } from '@automattic/api-core';
+import { siteApmEnabledMutation, siteBySlugQuery } from '@automattic/api-queries';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import { Button } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import Breadcrumbs from '../../app/breadcrumbs';
+import InlineSupportLink from '../../components/inline-support-link';
+import Notice from '../../components/notice';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import { hasHostingFeature } from '../../utils/site-features';
+import UpsellCallout from '../hosting-feature-gated-with-callout/upsell';
+import { getBackendCalloutProps } from '../performance/backend-callout';
+
+function ApmToggle( { site }: { site: Site } ) {
+	const enabled = !! site.options?.apm_enabled;
+	const { mutate, isPending } = useMutation( {
+		...siteApmEnabledMutation( site.ID ),
+		meta: {
+			snackbar: {
+				success: enabled ? __( 'APM disabled.' ) : __( 'APM enabled.' ),
+				error: enabled ? __( 'Failed to disable APM.' ) : __( 'Failed to enable APM.' ),
+			},
+		},
+	} );
+
+	const handleClick = () => mutate( ! enabled );
+
+	if ( enabled ) {
+		return (
+			<Notice
+				variant="success"
+				title={ __( 'APM is enabled' ) }
+				actions={
+					<Button
+						variant="primary"
+						size="compact"
+						isBusy={ isPending }
+						disabled={ isPending }
+						onClick={ handleClick }
+					>
+						{ __( 'Disable' ) }
+					</Button>
+				}
+			/>
+		);
+	}
+
+	return (
+		<Notice
+			title={ __( 'APM is disabled' ) }
+			actions={
+				<Button
+					variant="primary"
+					size="compact"
+					isBusy={ isPending }
+					disabled={ isPending }
+					onClick={ handleClick }
+				>
+					{ __( 'Enable' ) }
+				</Button>
+			}
+		/>
+	);
+}
+
+export default function ApmSettings( { siteSlug }: { siteSlug: string } ) {
+	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					prefix={ <Breadcrumbs length={ 2 } /> }
+					title={ __( 'Application Performance Monitoring' ) }
+					description={ createInterpolateElement(
+						__(
+							'Get request-level tracing, top slow endpoints, and plugin bottleneck detection for your site. <learnMoreLink />'
+						),
+						{
+							learnMoreLink: <InlineSupportLink supportContext="site-performance" />,
+						}
+					) }
+				/>
+			}
+		>
+			{ hasHostingFeature( site, HostingFeatures.APM ) ? (
+				<ApmToggle site={ site } />
+			) : (
+				<UpsellCallout site={ site } { ...getBackendCalloutProps() } />
+			) }
+		</PageLayout>
+	);
+}

--- a/client/dashboard/sites/settings-apm/summary.tsx
+++ b/client/dashboard/sites/settings-apm/summary.tsx
@@ -1,22 +1,13 @@
-import { BusinessPlans, EcommercePlans, type Site } from '@automattic/api-core';
+import { type Site } from '@automattic/api-core';
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import { hasBackendAccess } from '../performance/backend-access';
 import type { Density } from '@automattic/components/src/summary-button/types';
 
-function hasApmAccess( productSlug: string | undefined ) {
-	if ( ! productSlug ) {
-		return false;
-	}
-	return (
-		( BusinessPlans as readonly string[] ).includes( productSlug ) ||
-		( EcommercePlans as readonly string[] ).includes( productSlug )
-	);
-}
-
 export default function ApmSettingsSummary( { site, density }: { site: Site; density?: Density } ) {
-	const canView = hasApmAccess( site.plan?.product_slug );
+	const canView = hasBackendAccess( site.plan?.product_slug );
 
 	const getBadge = () => {
 		if ( ! canView ) {

--- a/client/dashboard/sites/settings-apm/summary.tsx
+++ b/client/dashboard/sites/settings-apm/summary.tsx
@@ -18,7 +18,7 @@ export default function ApmSettingsSummary( { site, density }: { site: Site; den
 			return [
 				{
 					text: __( 'Enabled' ),
-					intent: 'info' as const,
+					intent: 'success' as const,
 				},
 			];
 		}

--- a/client/dashboard/sites/settings-apm/summary.tsx
+++ b/client/dashboard/sites/settings-apm/summary.tsx
@@ -1,13 +1,22 @@
-import { HostingFeatures, type Site } from '@automattic/api-core';
+import { BusinessPlans, EcommercePlans, type Site } from '@automattic/api-core';
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
-import { hasHostingFeature } from '../../utils/site-features';
 import type { Density } from '@automattic/components/src/summary-button/types';
 
+function hasApmAccess( productSlug: string | undefined ) {
+	if ( ! productSlug ) {
+		return false;
+	}
+	return (
+		( BusinessPlans as readonly string[] ).includes( productSlug ) ||
+		( EcommercePlans as readonly string[] ).includes( productSlug )
+	);
+}
+
 export default function ApmSettingsSummary( { site, density }: { site: Site; density?: Density } ) {
-	const canView = hasHostingFeature( site, HostingFeatures.APM );
+	const canView = hasApmAccess( site.plan?.product_slug );
 
 	const getBadge = () => {
 		if ( ! canView ) {

--- a/client/dashboard/sites/settings-apm/summary.tsx
+++ b/client/dashboard/sites/settings-apm/summary.tsx
@@ -1,0 +1,42 @@
+import { HostingFeatures, type Site } from '@automattic/api-core';
+import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { chartBar } from '@wordpress/icons';
+import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import { hasHostingFeature } from '../../utils/site-features';
+import type { Density } from '@automattic/components/src/summary-button/types';
+
+export default function ApmSettingsSummary( { site, density }: { site: Site; density?: Density } ) {
+	const canView = hasHostingFeature( site, HostingFeatures.APM );
+
+	const getBadge = () => {
+		if ( ! canView ) {
+			return [];
+		}
+
+		if ( site.options?.apm_enabled ) {
+			return [
+				{
+					text: __( 'Enabled' ),
+					intent: 'info' as const,
+				},
+			];
+		}
+
+		return [
+			{
+				text: __( 'Disabled' ),
+			},
+		];
+	};
+
+	return (
+		<RouterLinkSummaryButton
+			to={ `/sites/${ site.slug }/settings/apm` }
+			title={ __( 'Application Performance Monitoring' ) }
+			density={ density }
+			decoration={ <Icon icon={ chartBar } /> }
+			badges={ getBadge() }
+		/>
+	);
+}

--- a/client/dashboard/sites/settings-apm/test/index.test.tsx
+++ b/client/dashboard/sites/settings-apm/test/index.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import ApmSettings from '../index';
+import type { Site } from '@automattic/api-core';
+
+const siteSlug = 'test-site.wordpress.com';
+const siteId = 1;
+
+const businessSite = ( apmEnabled: boolean ) =>
+	( {
+		ID: siteId,
+		slug: siteSlug,
+		is_wpcom_atomic: true,
+		plan: {
+			product_slug: 'business-bundle',
+			product_name_short: 'Business',
+			is_free: false,
+			features: { active: [ 'atomic', 'apm' ] },
+		},
+		options: { apm_enabled: apmEnabled },
+	} ) as unknown as Site;
+
+const personalSite = {
+	ID: siteId,
+	slug: siteSlug,
+	is_wpcom_atomic: false,
+	plan: {
+		product_slug: 'personal-bundle',
+		product_name_short: 'Personal',
+		is_free: false,
+		features: { active: [] },
+	},
+} as unknown as Site;
+
+function mockSite( site: Site ) {
+	nock( 'https://public-api.wordpress.com' )
+		.get( `/rest/v1.1/sites/${ site.slug }` )
+		.query( true )
+		.reply( 200, site );
+}
+
+function mockApmToggle( expectedActive: boolean ) {
+	return nock( 'https://public-api.wordpress.com' )
+		.post( `/wpcom/v2/sites/${ siteId }/hosting/apm`, ( body ) => {
+			expect( body ).toEqual( { active: expectedActive } );
+			return true;
+		} )
+		.reply( 200, JSON.stringify( expectedActive ), { 'Content-Type': 'application/json' } );
+}
+
+describe( '<ApmSettings>', () => {
+	test( 'shows Enable affordance when APM is disabled', async () => {
+		mockSite( businessSite( false ) );
+
+		render( <ApmSettings siteSlug={ siteSlug } /> );
+
+		expect( await screen.findByText( 'APM is disabled' ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Enable' } ) ).toBeVisible();
+	} );
+
+	test( 'shows Disable affordance when APM is enabled', async () => {
+		mockSite( businessSite( true ) );
+
+		render( <ApmSettings siteSlug={ siteSlug } /> );
+
+		expect( await screen.findByText( 'APM is enabled' ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Disable' } ) ).toBeVisible();
+	} );
+
+	test( 'clicking Disable POSTs { active: false }', async () => {
+		mockSite( businessSite( true ) );
+		const scope = mockApmToggle( false );
+
+		render( <ApmSettings siteSlug={ siteSlug } /> );
+
+		await userEvent.click( await screen.findByRole( 'button', { name: 'Disable' } ) );
+
+		await waitFor( () => {
+			expect( scope.isDone() ).toBe( true );
+		} );
+	} );
+
+	test( 'renders upsell on a plan below Business', async () => {
+		mockSite( personalSite );
+
+		render( <ApmSettings siteSlug={ siteSlug } /> );
+
+		expect( await screen.findByRole( 'button', { name: 'Upgrade plan' } ) ).toBeVisible();
+		expect( screen.queryByRole( 'button', { name: 'Enable' } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Disable' } ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -11,6 +11,7 @@ import { SummaryButtonList } from '../../components/summary-button-list';
 import { getSiteTypeFeatureSupports } from '../../utils/site-type-feature-support';
 import AgencySettingsSummary from '../settings-agency/summary';
 import AISiteToolsSettingsSummary from '../settings-ai-tools/summary';
+import ApmSettingsSummary from '../settings-apm/summary';
 import CachingSettingsSummary from '../settings-caching/summary';
 import CrontabSettingsSummary from '../settings-crontab/summary';
 import DatabaseSettingsSummary from '../settings-database/summary';
@@ -80,6 +81,7 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 						<PrimaryDataCenterSettingsSummary site={ site } />
 						<StaticFile404SettingsSummary site={ site } />
 						<CachingSettingsSummary site={ site } />
+						{ isEnabled( 'performance/apm' ) && <ApmSettingsSummary site={ site } /> }
 					</SummaryButtonList>
 				</VStack>
 			) }

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -81,7 +81,7 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 						<PrimaryDataCenterSettingsSummary site={ site } />
 						<StaticFile404SettingsSummary site={ site } />
 						<CachingSettingsSummary site={ site } />
-						{ isEnabled( 'performance/apm' ) && <ApmSettingsSummary site={ site } /> }
+						{ isEnabled( 'performance/apm' ) ? <ApmSettingsSummary site={ site } /> : null }
 					</SummaryButtonList>
 				</VStack>
 			) }


### PR DESCRIPTION
## Proposed Changes

* Add Settings → Server → **Application Performance Monitoring** entry, gated behind the `performance/apm` feature flag.
* New page (`/sites/<slug>/settings/apm`) renders an enable/disable toggle for sites with the APM hosting feature, and an upsell callout otherwise.

## Why are these changes being made?

First in a series of PRs adding the APM dashboard. This one adds only the toggle and its entry point so it can ship and be tested independently of the post-enable dashboard work.

## Testing Instructions

* Check out this branch and run `yarn start-dashboard`.
* Visit \`/sites/<slug>/settings\` on a Business+ site and confirm the **Application Performance Monitoring** entry appears under the Server section.
* Click in and toggle Enable/Disable; the badge in the summary should update.
* On a Personal/Free site, the page should render the upsell callout instead of the toggle.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?