### PR TITLE
Purcahses: fix cancellation flow polish

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -11,6 +11,7 @@ import {
 	monetizeSubscriptionsQuery,
 	plansQuery,
 	productsQuery,
+	purchaseCancelFeaturesQuery,
 	purchaseQuery,
 	queryClient,
 	rawUserPreferencesQuery,
@@ -420,6 +421,7 @@ export const cancelPurchaseRoute = createRoute( {
 			queryClient.ensureQueryData( productsQuery() ),
 			queryClient.ensureQueryData( siteFeaturesQuery( purchase.blog_id ) ),
 			queryClient.ensureQueryData( plansQuery() ),
+			queryClient.ensureQueryData( purchaseCancelFeaturesQuery( purchase.ID ) ),
 		] );
 		return { purchase, intent };
 	},

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-button.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-button.tsx
@@ -53,12 +53,10 @@ export default function CancelButton( {
 
 	return (
 		<Button
+			className="cancel-purchase__cancel-button"
 			disabled={ isDisabled }
 			isBusy={ isBusy ?? state.isLoading ?? false }
-			onClick={ ( event: React.MouseEvent< HTMLButtonElement > ) => {
-				event.currentTarget.blur();
-				onClick?.();
-			} }
+			onClick={ onClick }
 			isDestructive
 			variant="primary"
 		>

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-button.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-button.tsx
@@ -55,7 +55,10 @@ export default function CancelButton( {
 		<Button
 			disabled={ isDisabled }
 			isBusy={ isBusy ?? state.isLoading ?? false }
-			onClick={ onClick }
+			onClick={ ( event: React.MouseEvent< HTMLButtonElement > ) => {
+				event.currentTarget.blur();
+				onClick?.();
+			} }
 			isDestructive
 			variant="primary"
 		>

--- a/client/dashboard/me/billing-purchases/cancel-purchase/confirm-checkbox.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/confirm-checkbox.tsx
@@ -82,12 +82,14 @@ export default function ConfirmCheckbox( {
 						label={ __( 'I understand that canceling means that I may lose this domain forever.' ) }
 						checked={ state.domainConfirmationConfirmed }
 						onChange={ onDomainConfirmationChange }
+						disabled={ state.isLoading }
 					/>
 				) }
 
 				<CheckboxControl
 					label={ planConfirmationLabel }
 					checked={ state.customerConfirmedUnderstanding }
+					disabled={ state.isLoading }
 					onChange={ ( checked ) => {
 						if ( atomicTransfer?.created_at ) {
 							onCustomerConfirmedUnderstandingChange( checked );

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -379,7 +379,7 @@ function CancelPurchaseInner() {
 	// The route loader pre-fetches via `ensureQueryData`, so first paint is
 	// instant — `livePurchase` is defined on first render.
 	const { data: livePurchase, isPending: purchaseQueryIsPending } = useQuery(
-		purchaseQuery( parseInt( purchaseId ) )
+		purchaseQuery( parseInt( purchaseId, 10 ) )
 	);
 
 	// Mutations consumed by useCancelMutationOnConfirm
@@ -409,7 +409,7 @@ function CancelPurchaseInner() {
 	);
 	const { data: plans } = useSuspenseQuery( plansQuery() );
 	const { data: purchaseCancelFeatures } = useQuery(
-		purchaseCancelFeaturesQuery( parseInt( purchaseId ) )
+		purchaseCancelFeaturesQuery( parseInt( purchaseId, 10 ) )
 	);
 
 	const lastSiteQueryIsError = useRef< boolean >( false );
@@ -990,7 +990,6 @@ function CancelPurchaseInner() {
 		setState( ( state ) => ( {
 			...state,
 			domainConfirmationConfirmed: checked,
-			// customerConfirmedUnderstanding: checked,
 		} ) );
 
 		// Record tracks event for domain confirmation checkbox

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -929,10 +929,7 @@ function CancelPurchaseInner() {
 		} ) );
 	};
 
-	const onCancellationStart = (
-		cancelIntent: CancelPurchaseState[ 'cancelIntent' ] = null,
-		customerConfirmedUnderstanding?: boolean
-	) => {
+	const onCancellationStart = ( cancelIntent: CancelPurchaseState[ 'cancelIntent' ] = null ) => {
 		// When the eligibility notice is active and the user clicks the default cancel button
 		// (not the refund link), they're opting for an auto-renew cancellation — no refund, so
 		// no need to ask about the domain. Skip straight to the survey.
@@ -948,8 +945,6 @@ function CancelPurchaseInner() {
 			setState( ( state ) => ( {
 				...state,
 				cancelIntent,
-				customerConfirmedUnderstanding:
-					customerConfirmedUnderstanding ?? state.customerConfirmedUnderstanding,
 				siteId: purchase.blog_id,
 				showDomainOptionsStep: true,
 			} ) );
@@ -967,8 +962,6 @@ function CancelPurchaseInner() {
 				setState( ( state ) => ( {
 					...state,
 					cancelIntent,
-					customerConfirmedUnderstanding:
-						customerConfirmedUnderstanding ?? state.customerConfirmedUnderstanding,
 					siteId: purchase.blog_id,
 				} ) );
 				fireMutationFromConfirm( effectiveFlowType );
@@ -978,8 +971,6 @@ function CancelPurchaseInner() {
 				...state,
 				cancelIntent,
 				confirmationPassed: true,
-				customerConfirmedUnderstanding:
-					customerConfirmedUnderstanding ?? state.customerConfirmedUnderstanding,
 				siteId: purchase.blog_id,
 				surveyShown: true,
 			} ) );

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -408,7 +408,9 @@ function CancelPurchaseInner() {
 		siteFeaturesQuery( purchase.blog_id )
 	);
 	const { data: plans } = useSuspenseQuery( plansQuery() );
-	const { data: purchaseCancelFeatures } = useQuery( purchaseCancelFeaturesQuery( purchaseId ) );
+	const { data: purchaseCancelFeatures } = useQuery(
+		purchaseCancelFeaturesQuery( parseInt( purchaseId ) )
+	);
 
 	const lastSiteQueryIsError = useRef< boolean >( false );
 	const { data: hasBeenExtended } = useQuery( hasPurchaseBeenExtendedQuery( purchase.blog_id ) );
@@ -929,7 +931,7 @@ function CancelPurchaseInner() {
 
 	const onCancellationStart = (
 		cancelIntent: CancelPurchaseState[ 'cancelIntent' ] = null,
-		customerConfirmedUnderstanding = false
+		customerConfirmedUnderstanding?: boolean
 	) => {
 		// When the eligibility notice is active and the user clicks the default cancel button
 		// (not the refund link), they're opting for an auto-renew cancellation — no refund, so
@@ -946,7 +948,8 @@ function CancelPurchaseInner() {
 			setState( ( state ) => ( {
 				...state,
 				cancelIntent,
-				customerConfirmedUnderstanding,
+				customerConfirmedUnderstanding:
+					customerConfirmedUnderstanding ?? state.customerConfirmedUnderstanding,
 				siteId: purchase.blog_id,
 				showDomainOptionsStep: true,
 			} ) );
@@ -964,7 +967,8 @@ function CancelPurchaseInner() {
 				setState( ( state ) => ( {
 					...state,
 					cancelIntent,
-					customerConfirmedUnderstanding,
+					customerConfirmedUnderstanding:
+						customerConfirmedUnderstanding ?? state.customerConfirmedUnderstanding,
 					siteId: purchase.blog_id,
 				} ) );
 				fireMutationFromConfirm( effectiveFlowType );
@@ -974,7 +978,8 @@ function CancelPurchaseInner() {
 				...state,
 				cancelIntent,
 				confirmationPassed: true,
-				customerConfirmedUnderstanding,
+				customerConfirmedUnderstanding:
+					customerConfirmedUnderstanding ?? state.customerConfirmedUnderstanding,
 				siteId: purchase.blog_id,
 				surveyShown: true,
 			} ) );

--- a/client/dashboard/me/billing-purchases/cancel-purchase/keep-subscription-button.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/keep-subscription-button.tsx
@@ -22,7 +22,7 @@ export default function KeepSubscriptionButton( {
 
 	return (
 		<Button
-			variant="secondary"
+			variant="tertiary"
 			onClick={ () => {
 				navigate( { to: purchaseSettingsRoute.fullPath, params: { purchaseId: purchase.ID } } );
 				onKeepSubscriptionClick();

--- a/client/dashboard/me/billing-purchases/cancel-purchase/style.scss
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/style.scss
@@ -14,6 +14,12 @@
 	font-size: 0.875rem;
 }
 
+// Suppress focus ring on mouse click; keyboard navigation still shows it via :focus-visible.
+// @wordpress/components Button uses :focus:not(:active) which doesn't distinguish mouse vs keyboard.
+.cancel-purchase__cancel-button.components-button.is-primary:focus:not(:focus-visible) {
+	box-shadow: none;
+}
+
 /* Vertically center the icon (decoration) in solutions cards */
 .cancel-purchase-form__solution-card.summary-button {
 	> * {

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -11,7 +11,7 @@ import {
 	getMonthlyPlanByYearly,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
-import { Card } from '@automattic/components';
+import { Button, Card } from '@automattic/components';
 import { HelpCenter } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { formatCurrency } from '@automattic/number-formatters';
@@ -27,7 +27,6 @@ import BackupRetentionOptionOnCancelPurchase from 'calypso/components/backup-ret
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import FormattedHeader from 'calypso/components/formatted-header';
-import FormButton from 'calypso/components/forms/form-button';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import HeaderCakeBack from 'calypso/components/header-cake/back';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
@@ -195,6 +194,7 @@ export interface CancelPurchaseProps {
 	siteSlug: string;
 	intent?: 'cancel' | 'remove' | null;
 	purchaseCancelFeatures?: UpgradesCancelFeaturesResponse;
+	isPurchaseCancelFeaturesLoading?: boolean;
 }
 
 export type CancelPurchaseAllProps = CancelPurchaseProps &
@@ -847,8 +847,8 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		} ).secondary;
 
 		return (
-			<FormButton
-				isPrimary={ false }
+			<Button
+				borderless
 				href={ ( this.props.getManagePurchaseUrlFor ?? managePurchase )(
 					siteSlug,
 					this.props.purchaseId
@@ -856,7 +856,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 				onClick={ this.onKeepSubscriptionClick }
 			>
 				{ label }
-			</FormButton>
+			</Button>
 		);
 	};
 
@@ -975,6 +975,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 							<label className="cancel-purchase__confirm-checkbox">
 								<FormCheckbox
 									checked={ this.state.customerConfirmedUnderstanding ?? false }
+									disabled={ this.state.isLoading }
 									onChange={ ( event: { target: { checked: boolean } } ) =>
 										this.onCustomerConfirmedUnderstandingChange( event.target.checked )
 									}
@@ -1061,7 +1062,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			return null;
 		}
 
-		if ( isDataLoading( this.props ) ) {
+		if ( isDataLoading( this.props ) || this.props.isPurchaseCancelFeaturesLoading ) {
 			return (
 				<div>
 					<QueryUserPurchases />

--- a/client/me/purchases/cancel-purchase/style.scss
+++ b/client/me/purchases/cancel-purchase/style.scss
@@ -145,6 +145,7 @@
 			span {
 				margin: auto 0;
 				flex: 1;
+				min-width: 0;
 			}
 
 			.gridicon {
@@ -184,10 +185,7 @@
 
 .cancel-purchase__confirm-buttons {
 	display: flex;
-
-	.form-button {
-		margin-left: 8px;
-	}
+	gap: 16px;
 }
 
 .cancel-purchase__purchase-name {
@@ -316,6 +314,7 @@
 			span {
 				margin: auto 0;
 				flex: 1;
+				min-width: 0;
 			}
 
 			.gridicon {

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -1,4 +1,4 @@
-import { purchaseCancelFeaturesQuery } from '@automattic/api-queries';
+import { purchaseCancelFeaturesQuery, queryClient } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
 import { useQuery } from '@tanstack/react-query';
@@ -103,12 +103,18 @@ export function cancelPurchase( context, next ) {
 
 	const purchaseId = parseInt( context.params.purchaseId, 10 );
 
+	// Start fetching cancel features immediately — the useQuery inside
+	// CancelPurchaseWrapper will reuse this in-flight promise.
+	queryClient.prefetchQuery( purchaseCancelFeaturesQuery( purchaseId ) );
+
 	const CancelPurchaseWrapper = localize( () => {
 		// React Query owns the cancellation-features fetch: cancel-on-unmount,
 		// cross-purchase cache invalidation, and error state come for free. The
 		// dashboard side uses the same query at
 		// client/dashboard/me/billing-purchases/cancel-purchase/index.tsx.
-		const { data: purchaseCancelFeatures } = useQuery( purchaseCancelFeaturesQuery( purchaseId ) );
+		const { data: purchaseCancelFeatures, isLoading: isPurchaseCancelFeaturesLoading } = useQuery(
+			purchaseCancelFeaturesQuery( purchaseId )
+		);
 		return (
 			<PurchasesWrapper title={ pageTitle }>
 				<Main wideLayout className="purchases__cancel">
@@ -117,6 +123,7 @@ export function cancelPurchase( context, next ) {
 						siteSlug={ context.params.site }
 						intent={ intent }
 						purchaseCancelFeatures={ purchaseCancelFeatures }
+						isPurchaseCancelFeaturesLoading={ isPurchaseCancelFeaturesLoading }
 					/>
 				</Main>
 			</PurchasesWrapper>


### PR DESCRIPTION
Related to: https://linear.app/a8c/issue/CHE-478

## Summary

This PR makes some quality improvements to our cancel/remove confirmation screen:

- **Dashboard**: preserve checkbox state on cancel start (optional param + `??` nullish coalescing), disable checkboxes during loading, tertiary "Keep subscription" button, prefetch `purchaseCancelFeaturesQuery` in route loader, `parseInt(purchaseId)` for cache key match, blur cancel button on click
- **Legacy**: disable checkbox during loading, borderless "Keep subscription" button with 16px gap, prefetch cancel features in page.js controller via `queryClient.prefetchQuery`, gate skeleton on `isPurchaseCancelFeaturesLoading` (not data existence — prevents stuck skeleton on slow/errored API), `min-width: 0` on feature list spans for long domain overflow

## Test plan

- [ ] Dashboard cancel page: check the confirmation checkbox, click "Cancel subscription" — checkbox stays checked and becomes disabled
- [ ] Dashboard cancel page: "Keep subscription" button renders as tertiary (no border/background)
- [ ] Dashboard cancel page: feature list loads without layout shift (prefetched in route loader)
- [ ] Dashboard cancel page: cancel button focus ring clears after mouse click
- [ ] Legacy cancel page: same checkbox behavior (stays checked, becomes disabled)
- [ ] Legacy cancel page: "Keep subscription" button renders borderless with spacing from cancel button
- [ ] Legacy cancel page: feature list loads without layout shift (prefetched in controller)
- [ ] Legacy cancel page: long domain names wrap inside feature list items instead of overflowing

🤖 Generated with [Claude Code](https://claude.com/claude-code)