### PR TITLE
Replace cancel-flow snackbar with inline success notice

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -32,7 +32,6 @@ import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { _n, sprintf, __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { intlFormat } from 'date-fns';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useAnalytics } from '../../../app/analytics';
 import Breadcrumbs from '../../../app/breadcrumbs';
@@ -53,7 +52,6 @@ import {
 	hasAmountAvailableToRefund,
 	hasMarketplaceProduct,
 	isAgencyPartnerType,
-	isAkismetHoldingSitePurchase,
 	isExpired,
 	isGSuiteOrGoogleWorkspaceProductSlug,
 	isJetpackHoldingSitePurchase,
@@ -143,36 +141,6 @@ function renderTopNotice( args: TopNoticeArgs ) {
 			displayVariant={ displayVariant }
 			intent={ intent }
 		/>
-	);
-}
-
-// Build the success-snackbar message after a Remove mutation. Three shapes:
-// 1. Default: "%(productName)s was removed from %(siteName)s."
-// 2. Akismet/Jetpack holding-site purchase: drops the siteless.* domain.
-// 3. Domain registration: addresses the domain by name.
-function getRemoveSuccessMessage( purchase: Purchase ): string {
-	const purchaseName = purchase.is_domain ? purchase.meta : purchase.product_name;
-	if ( isAkismetHoldingSitePurchase( purchase ) || isJetpackHoldingSitePurchase( purchase ) ) {
-		return sprintf(
-			/* translators: %(productName)s is the name of a product (e.g., "WordPress.com Premium") */
-			__( '%(productName)s was removed from your account.' ),
-			{ productName: purchaseName }
-		);
-	}
-	if ( purchase.is_domain_registration ) {
-		return sprintf(
-			/* translators: %(domain)s is a domain name */
-			__( 'The domain %(domain)s was removed from your account.' ),
-			{ domain: purchaseName }
-		);
-	}
-	return sprintf(
-		/* translators: %(productName)s is the name of a product (e.g., "WordPress.com Premium") and %(siteName)s is a domain name */
-		__( '%(productName)s was removed from %(siteName)s.' ),
-		{
-			productName: purchaseName,
-			siteName: purchase.domain,
-		}
 	);
 }
 
@@ -888,29 +856,6 @@ function CancelPurchaseInner() {
 		}
 	};
 
-	// Snackbar copy shown on the destination screen after the user finishes (or
-	// skips) the survey on the cancel-intent path. Only CANCEL_AUTORENEW and
-	// CANCEL_WITH_REFUND can reach here — the cancel-intent gate excludes
-	// REMOVE flows.
-	const getCancelSuccessMessage = ( effectiveFlowType: CancelFlowType ): string => {
-		if ( effectiveFlowType === CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND ) {
-			return __( 'Your refund has been processed and your purchase removed.' );
-		}
-		const purchaseName = purchase.is_domain ? purchase.meta : purchase.product_name;
-		const subscriptionEndDate = intlFormat(
-			purchase.expiry_date,
-			{ dateStyle: 'medium' },
-			{ locale: 'en-US' }
-		);
-		return sprintf(
-			/* translators: %(purchaseName)s is the name of the product that was purchased, %(subscriptionEndDate)s is the date the product will no longer be available because the subscription has ended */
-			__(
-				'%(purchaseName)s was successfully cancelled. It will be available for use until it expires on %(subscriptionEndDate)s.'
-			),
-			{ purchaseName, subscriptionEndDate }
-		);
-	};
-
 	// Fire-on-confirm applies to the URL-intent Cancel path only — the user
 	// clicked "Cancel" on Purchase Settings and we want their cancellation to
 	// settle before the survey appears (so the heading can read "Cancellation
@@ -1153,12 +1098,6 @@ function CancelPurchaseInner() {
 						if ( purchase.is_plan ) {
 							cancelAllMarketplaceSubscriptions();
 						}
-						createSuccessNotice(
-							__( 'Your refund has been processed and your purchase removed.' ),
-							{
-								type: 'snackbar',
-							}
-						);
 						invokeSurvicateEvent( 'purchaseRefunded' );
 						navigate( {
 							to: purchaseSettingsRoute.fullPath,
@@ -1178,28 +1117,10 @@ function CancelPurchaseInner() {
 			{ purchaseId: purchase.ID, autoRenew: false },
 			{
 				onSuccess: () => {
-					const purchaseName = purchase.is_domain ? purchase.meta : purchase.product_name;
-					const subscriptionEndDate = intlFormat(
-						purchase.expiry_date,
-						{ dateStyle: 'medium' },
-						{ locale: 'en-US' }
-					);
-					createSuccessNotice(
-						sprintf(
-							/* translators: %(purchaseName)s is the name of the product that was purchased, %(subscriptionEndDate)s is the date the product will no longer be available because the subscription has ended */
-							__(
-								'%(purchaseName)s was successfully cancelled. It will be available for use until it expires on %(subscriptionEndDate)s.'
-							),
-							{
-								purchaseName,
-								subscriptionEndDate,
-							}
-						),
-						{ type: 'snackbar' }
-					);
 					navigate( {
 						to: purchaseSettingsRoute.fullPath,
 						params: { purchaseId: purchase.ID },
+						search: { cancelled: true },
 					} );
 				},
 				onError: () => {
@@ -1227,11 +1148,11 @@ function CancelPurchaseInner() {
 
 		removePurchaseMutator.mutate( purchase.ID, {
 			onSuccess: () => {
-				createSuccessNotice( getRemoveSuccessMessage( purchase ), { type: 'snackbar' } );
 				invokeSurvicateEvent( 'purchaseRemoved' );
 				navigate( {
 					to: purchaseSettingsRoute.fullPath,
 					params: { purchaseId: purchase.ID },
+					search: { cancelled: true },
 				} );
 			},
 			onError: () => {
@@ -1256,29 +1177,11 @@ function CancelPurchaseInner() {
 			{ purchaseId: purchase.ID, autoRenew: false },
 			{
 				onSuccess: () => {
-					const purchaseName = purchase.is_domain ? purchase.meta : purchase.product_name;
-					const subscriptionEndDate = intlFormat(
-						purchase.expiry_date,
-						{ dateStyle: 'medium' },
-						{ locale: 'en-US' }
-					);
-					createSuccessNotice(
-						sprintf(
-							/* translators: %(purchaseName)s is the name of the product that was purchased, %(subscriptionEndDate)s is the date the product will no longer be available because the subscription has ended */
-							__(
-								'%(purchaseName)s was successfully cancelled. It will be available for use until it expires on %(subscriptionEndDate)s.'
-							),
-							{
-								purchaseName,
-								subscriptionEndDate,
-							}
-						),
-						{ type: 'snackbar' }
-					);
 					invokeSurvicateEvent( 'purchaseCancelled' );
 					navigate( {
 						to: purchaseSettingsRoute.fullPath,
 						params: { purchaseId: purchase.ID },
+						search: { cancelled: true },
 					} );
 				},
 				onError: () => {
@@ -1307,12 +1210,15 @@ function CancelPurchaseInner() {
 
 		if ( shouldFireMutationOnConfirm() ) {
 			// Cancel intent: the mutation already fired at confirm-click via
-			// fireMutationFromConfirm. Show the deferred success snackbar on the
-			// destination (purchase management) screen, then navigate.
-			createSuccessNotice( getCancelSuccessMessage( effectiveFlowType ), { type: 'snackbar' } );
+			// fireMutationFromConfirm. Navigate with the appropriate search param
+			// so the inline notice renders on the destination screen.
 			navigate( {
 				to: purchaseSettingsRoute.fullPath,
 				params: { purchaseId: purchase.ID },
+				search:
+					effectiveFlowType === CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND
+						? { refunded: true }
+						: { cancelled: true },
 			} );
 			return;
 		}

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -153,6 +153,7 @@ export interface CancelPurchaseState {
 	showDomainOptionsStep: boolean;
 	showDialog: boolean;
 	cancelIntent: 'refund' | 'autorenew' | null;
+	fireMutationWasRefund: boolean;
 }
 
 export interface CancelPurchaseActions {
@@ -218,6 +219,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		// Cancellation state moved from button component
 		showDialog: false,
 		cancelIntent: null,
+		fireMutationWasRefund: false,
 	};
 
 	onCustomerConfirmedUnderstandingChange = ( checked: boolean ) => {
@@ -380,12 +382,14 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 				if ( ! isAutoRenewIntent ) {
 					await this.handleMarketplaceSubscriptions( refundable );
 				}
-				this.props.successNotice( result.message, {
-					displayOnNextPage: true,
-					duration: 10000,
-				} );
+				if ( refundable ) {
+					this.props.successNotice( result.message, {
+						displayOnNextPage: true,
+						duration: 10000,
+					} );
+				}
 				invokeSurvicateEvent( refundable ? 'purchaseRefunded' : 'purchaseCancelled' );
-				this.setState( { surveyShown: true, isLoading: false } );
+				this.setState( { surveyShown: true, isLoading: false, fireMutationWasRefund: refundable } );
 			} else {
 				this.props.errorNotice( result.error );
 				this.setState( { isLoading: false } );
@@ -538,7 +542,10 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 				this.props.purchaseId
 			);
 			const backupRedirect = this.props.purchaseListUrl ?? purchasesRoot;
-			page.redirect( managePurchaseUrl ?? backupRedirect );
+			const redirectUrl = managePurchaseUrl ?? backupRedirect;
+			page.redirect(
+				this.state.fireMutationWasRefund ? redirectUrl : redirectUrl + '?cancelled=true'
+			);
 			return;
 		}
 
@@ -558,7 +565,6 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 				await this.handleMarketplaceSubscriptions( refundable );
 				this.props.refreshSitePlans( this.props.purchase.siteId );
 				this.props.clearPurchases();
-				this.props.successNotice( result.message, { displayOnNextPage: true, duration: 10000 } );
 				if ( isRemoveDeleteFlow ) {
 					invokeSurvicateEvent( 'purchaseRemoved' );
 				} else if ( refundable ) {
@@ -570,13 +576,21 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 				// would 404. Redirect straight to the purchases list instead.
 				const backupRedirect = this.props.purchaseListUrl ?? purchasesRoot;
 				if ( isRemoveDeleteFlow ) {
+					this.props.successNotice( result.message, { displayOnNextPage: true, duration: 10000 } );
 					page.redirect( backupRedirect );
-				} else {
+				} else if ( refundable ) {
+					this.props.successNotice( result.message, { displayOnNextPage: true, duration: 10000 } );
 					const managePurchaseUrl = ( this.props.getManagePurchaseUrlFor ?? managePurchase )(
 						this.props.siteSlug,
 						this.props.purchaseId
 					);
 					page.redirect( managePurchaseUrl ?? backupRedirect );
+				} else {
+					const managePurchaseUrl = ( this.props.getManagePurchaseUrlFor ?? managePurchase )(
+						this.props.siteSlug,
+						this.props.purchaseId
+					);
+					page.redirect( ( managePurchaseUrl ?? backupRedirect ) + '?cancelled=true' );
 				}
 			} else {
 				this.props.errorNotice( result.error );


### PR DESCRIPTION
Related to: https://linear.app/a8c/issue/CHE-478

## Summary

This PR fixes the success message when you cancel. It was previously showing as a snack. Now it shows as an inline, dismissible, success message. It goes away if you dismiss it, navigate away, or refresh.

<img width="1839" height="1196" alt="image" src="https://github.com/user-attachments/assets/3becbadb-717b-48b0-89e4-4ddd262a7cea" />

**More details:**
- Remove snackbar toasts from all cancel/remove success paths on both dashboard and legacy surfaces
- Navigate with `?cancelled=true` (or `?refunded=true` for refund paths) so the existing `PurchaseCancelledNotice` inline notice renders on the destination screen instead
- Delete now-unused `getCancelSuccessMessage` and `getRemoveSuccessMessage` helpers plus stale `intlFormat` / `isAkismetHoldingSitePurchase` imports
- Legacy surface keeps snackbar for remove-DELETE and refund paths (no inline notice infrastructure for those on legacy)

## Test plan

- [ ] Dashboard: cancel a non-refundable plan → Purchase Settings shows green inline dismissable notice, no snackbar
- [ ] Dashboard: cancel-and-refund a refundable plan → Purchase Settings shows existing refund inline notice via `?refunded=true`, no snackbar
- [ ] Dashboard: remove a purchase → Purchase Settings shows green inline notice via `?cancelled=true`, no snackbar
- [ ] Dashboard: turn off auto-renew via cancel flow → Purchase Settings shows inline notice, no snackbar
- [ ] Legacy: cancel a non-refundable plan → Purchase Settings shows inline notice via `?cancelled=true`, no snackbar
- [ ] Legacy: cancel-and-refund a refundable plan → snackbar still shows (kept intentionally)
- [ ] Legacy: remove-DELETE a purchase → snackbar still shows, redirects to purchases list (kept intentionally)
- [ ] Dismiss the inline notice → it disappears; refresh → it does not reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)