### PR TITLE
Reader ATmosphere: reply composer (CM-644 / CM-655)

### DIFF
--- a/client/reader/atmosphere/atmosphere-account-view.tsx
+++ b/client/reader/atmosphere/atmosphere-account-view.tsx
@@ -7,6 +7,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import NavigationHeader from 'calypso/components/navigation-header';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import { AtmosphereNavigation } from './atmosphere-navigation';
+import { ComposerModal, ComposerProvider } from './composer';
 import { PROFILE_TAB, SETTINGS_TAB, TIMELINE_TAB } from './helper';
 import { ProfilePanel } from './profile-panel';
 import { SettingsPanel } from './settings-panel';
@@ -55,14 +56,17 @@ export function AtmosphereAccountView( { connectionId, tab }: Props ) {
 	const title = connection.display_name || connection.handle;
 
 	return (
-		<ReaderMain className="atmosphere-view">
-			<DocumentHead title={ translate( '%s ‹ ATmosphere ‹ Reader', { args: title } ) } />
-			<NavigationHeader title={ title } subtitle={ `@${ connection.handle }` } />
-			<AtmosphereNavigation connectionId={ connection.id } selectedTab={ tab } />
-			<VStack spacing={ 4 } className="atmosphere-view__body">
-				{ renderTab( tab, connection ) }
-			</VStack>
-		</ReaderMain>
+		<ComposerProvider connectionId={ connection.id }>
+			<ReaderMain className="atmosphere-view">
+				<DocumentHead title={ translate( '%s ‹ ATmosphere ‹ Reader', { args: title } ) } />
+				<NavigationHeader title={ title } subtitle={ `@${ connection.handle }` } />
+				<AtmosphereNavigation connectionId={ connection.id } selectedTab={ tab } />
+				<VStack spacing={ 4 } className="atmosphere-view__body">
+					{ renderTab( tab, connection ) }
+				</VStack>
+			</ReaderMain>
+			<ComposerModal />
+		</ComposerProvider>
 	);
 }
 

--- a/client/reader/atmosphere/atmosphere-thread-view.tsx
+++ b/client/reader/atmosphere/atmosphere-thread-view.tsx
@@ -5,6 +5,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import ReaderMain from 'calypso/reader/components/reader-main';
+import { ComposerModal, ComposerProvider } from './composer';
 import { ThreadPanel } from './thread-panel';
 
 interface Props {
@@ -55,12 +56,15 @@ export function AtmosphereThreadView( { connectionId, did, rkey }: Props ) {
 	}
 
 	return (
-		<ReaderMain className="atmosphere-view">
-			<DocumentHead
-				title={ translate( '%s ‹ ATmosphere ‹ Reader', { args: connection.handle } ) }
-			/>
-			<ThreadPanel connection={ connection } did={ did } rkey={ rkey } />
-		</ReaderMain>
+		<ComposerProvider connectionId={ connection.id }>
+			<ReaderMain className="atmosphere-view">
+				<DocumentHead
+					title={ translate( '%s ‹ ATmosphere ‹ Reader', { args: connection.handle } ) }
+				/>
+				<ThreadPanel connection={ connection } did={ did } rkey={ rkey } />
+			</ReaderMain>
+			<ComposerModal />
+		</ComposerProvider>
 	);
 }
 

--- a/client/reader/atmosphere/author-profile-panel.tsx
+++ b/client/reader/atmosphere/author-profile-panel.tsx
@@ -25,6 +25,7 @@ import {
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import { AuthorProfileTabs, useAuthorProfileFilter } from './author-profile-tabs';
+import { useOptionalComposer } from './composer';
 import { projectAtmosphereError } from './error-projection';
 import { errorMessage } from './profile-errors';
 import { getProfileUrl, getTagFeedUrl, getThreadUrl, getTimelineUrl } from './route';
@@ -298,6 +299,31 @@ export function AuthorProfilePanel( { connection, actor }: AuthorProfilePanelPro
 		  ]
 		: [];
 
+	const composer = useOptionalComposer();
+	const openComposer = composer?.openComposer;
+	const onReplyClick = useMemo( () => {
+		if ( ! openComposer ) {
+			return undefined;
+		}
+		return ( post: SocialPost ) => {
+			if ( ! post.cid ) {
+				return;
+			}
+			const parent = { uri: post.uri, cid: post.cid };
+			// See timeline-panel.tsx for the cid-stand-in rationale: the
+			// shared `SocialPost` shape doesn't carry a root cid, so we
+			// reuse the parent's. The backend authoritatively resolves
+			// both refs server-side from the URIs.
+			const root = post.reply_root ? { uri: post.reply_root.uri, cid: post.cid } : parent;
+			openComposer( {
+				kind: 'reply',
+				root,
+				parent,
+				previewPost: post,
+			} );
+		};
+	}, [ openComposer ] );
+
 	const analyticsValue = useMemo(
 		() => ( {
 			source: 'atmosphere' as const,
@@ -306,8 +332,9 @@ export function AuthorProfilePanel( { connection, actor }: AuthorProfilePanelPro
 			getThreadUrl: buildThreadUrl,
 			getProfileUrl: buildProfileUrl,
 			getTagUrl: buildTagUrl,
+			onReplyClick,
 		} ),
-		[ connection.id, onClickAnalytics, buildThreadUrl, buildProfileUrl, buildTagUrl ]
+		[ connection.id, onClickAnalytics, buildThreadUrl, buildProfileUrl, buildTagUrl, onReplyClick ]
 	);
 
 	const isOwnProfile = profile.data?.did === connection.did;

--- a/client/reader/atmosphere/author-profile-panel.tsx
+++ b/client/reader/atmosphere/author-profile-panel.tsx
@@ -310,11 +310,13 @@ export function AuthorProfilePanel( { connection, actor }: AuthorProfilePanelPro
 				return;
 			}
 			const parent = { uri: post.uri, cid: post.cid };
-			// See timeline-panel.tsx for the cid-stand-in rationale: the
-			// shared `SocialPost` shape doesn't carry a root cid, so we
-			// reuse the parent's. The backend authoritatively resolves
-			// both refs server-side from the URIs.
-			const root = post.reply_root ? { uri: post.reply_root.uri, cid: post.cid } : parent;
+			// See timeline-panel.tsx for the rationale. Prefer the root's
+			// own `cid` from `reply_root` so reply-to-reply submissions send
+			// the real root strong-ref; fall back to the parent's `cid` for
+			// protocols without CIDs or older backend payloads.
+			const root = post.reply_root
+				? { uri: post.reply_root.uri, cid: post.reply_root.cid ?? post.cid }
+				: parent;
 			openComposer( {
 				kind: 'reply',
 				root,

--- a/client/reader/atmosphere/author-profile-view.tsx
+++ b/client/reader/atmosphere/author-profile-view.tsx
@@ -6,6 +6,7 @@ import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import { AuthorProfilePanel } from './author-profile-panel';
+import { ComposerModal, ComposerProvider } from './composer';
 
 interface Props {
 	connectionId: number;
@@ -54,10 +55,13 @@ export function AuthorProfileView( { connectionId, actor }: Props ) {
 	}
 
 	return (
-		<ReaderMain className="atmosphere-view">
-			<DocumentHead title={ translate( '%s ‹ ATmosphere ‹ Reader', { args: actor } ) } />
-			<AuthorProfilePanel connection={ connection } actor={ actor } />
-		</ReaderMain>
+		<ComposerProvider connectionId={ connection.id }>
+			<ReaderMain className="atmosphere-view">
+				<DocumentHead title={ translate( '%s ‹ ATmosphere ‹ Reader', { args: actor } ) } />
+				<AuthorProfilePanel connection={ connection } actor={ actor } />
+			</ReaderMain>
+			<ComposerModal />
+		</ComposerProvider>
 	);
 }
 

--- a/client/reader/atmosphere/composer/composer-footer.tsx
+++ b/client/reader/atmosphere/composer/composer-footer.tsx
@@ -45,6 +45,14 @@ export function ComposerFooter( { graphemeCount, onSubmit, isPending, limit }: P
 					// Only announce when the user is near or past the limit so
 					// screen readers don't read out the count on every keystroke.
 					aria-live={ remaining <= WARN_THRESHOLD_REMAINING ? 'polite' : 'off' }
+					// Visible text is the bare integer; the accessible label
+					// adds units so the live-region announcement is meaningful
+					// without relying on the surrounding visual context.
+					aria-label={ translate( '%(count)d characters remaining', {
+						args: { count: remaining },
+						comment:
+							'Composer post-length counter; %(count)d is the integer count of characters still allowed before the limit. Negative when the user is over the limit.',
+					} ) }
 				>
 					{ remaining }
 				</span>

--- a/client/reader/atmosphere/composer/composer-footer.tsx
+++ b/client/reader/atmosphere/composer/composer-footer.tsx
@@ -1,0 +1,56 @@
+import { __experimentalHStack as HStack, Button, Spinner } from '@wordpress/components';
+import { Icon, image } from '@wordpress/icons';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+
+interface Props {
+	graphemeCount: number;
+	onSubmit: () => void;
+	isPending: boolean;
+	limit: number;
+}
+
+const WARN_THRESHOLD_REMAINING = 50;
+
+export function ComposerFooter( { graphemeCount, onSubmit, isPending, limit }: Props ) {
+	const translate = useTranslate();
+	const remaining = limit - graphemeCount;
+	const tooLong = remaining < 0;
+	const empty = graphemeCount === 0;
+	const disabled = isPending || tooLong || empty;
+
+	const countClass = clsx( 'atmosphere-composer__count', {
+		'is-warn': remaining > 0 && remaining <= WARN_THRESHOLD_REMAINING,
+		'is-over': remaining <= 0,
+	} );
+
+	return (
+		<HStack className="atmosphere-composer__footer" justify="space-between" alignment="center">
+			<div className="atmosphere-composer__footer-left">
+				{ /* Slice 8 wires this up — image / video upload + alt-text + content warnings. */ }
+				<button
+					type="button"
+					className="atmosphere-composer__media"
+					aria-disabled="true"
+					tabIndex={ 0 }
+					aria-label={ translate( 'Add media' ) }
+				>
+					<Icon icon={ image } size={ 18 } />
+				</button>
+			</div>
+			<HStack spacing={ 2 } className="atmosphere-composer__footer-right">
+				<span id="atmosphere-composer-count" className={ countClass } aria-live="polite">
+					{ remaining }
+				</span>
+				<Button
+					variant="primary"
+					disabled={ disabled }
+					onClick={ onSubmit }
+					aria-label={ translate( 'Post' ) }
+				>
+					{ isPending ? <Spinner /> : translate( 'Post' ) }
+				</Button>
+			</HStack>
+		</HStack>
+	);
+}

--- a/client/reader/atmosphere/composer/composer-footer.tsx
+++ b/client/reader/atmosphere/composer/composer-footer.tsx
@@ -39,14 +39,24 @@ export function ComposerFooter( { graphemeCount, onSubmit, isPending, limit }: P
 				</button>
 			</div>
 			<HStack spacing={ 2 } className="atmosphere-composer__footer-right">
-				<span id="atmosphere-composer-count" className={ countClass } aria-live="polite">
+				<span
+					id="atmosphere-composer-count"
+					className={ countClass }
+					// Only announce when the user is near or past the limit so
+					// screen readers don't read out the count on every keystroke.
+					aria-live={ remaining <= WARN_THRESHOLD_REMAINING ? 'polite' : 'off' }
+				>
 					{ remaining }
 				</span>
 				<Button
 					variant="primary"
 					disabled={ disabled }
 					onClick={ onSubmit }
-					aria-label={ translate( 'Post' ) }
+					// Visible "Post" label is the accessible name in the idle
+					// state; while pending the visible text is replaced by a
+					// presentation-only spinner, so the button needs an
+					// explicit accessible name.
+					aria-label={ isPending ? translate( 'Posting…' ) : undefined }
 				>
 					{ isPending ? <Spinner /> : translate( 'Post' ) }
 				</Button>

--- a/client/reader/atmosphere/composer/composer-footer.tsx
+++ b/client/reader/atmosphere/composer/composer-footer.tsx
@@ -48,11 +48,16 @@ export function ComposerFooter( { graphemeCount, onSubmit, isPending, limit }: P
 					// Visible text is the bare integer; the accessible label
 					// adds units so the live-region announcement is meaningful
 					// without relying on the surrounding visual context.
-					aria-label={ translate( '%(count)d characters remaining', {
-						args: { count: remaining },
-						comment:
-							'Composer post-length counter; %(count)d is the integer count of characters still allowed before the limit. Negative when the user is over the limit.',
-					} ) }
+					aria-label={ translate(
+						'%(count)d character remaining',
+						'%(count)d characters remaining',
+						{
+							count: remaining,
+							args: { count: remaining },
+							comment:
+								'Composer post-length counter; %(count)d is the integer count of characters still allowed before the limit. Negative when the user is over the limit.',
+						}
+					) }
 				>
 					{ remaining }
 				</span>

--- a/client/reader/atmosphere/composer/composer-footer.tsx
+++ b/client/reader/atmosphere/composer/composer-footer.tsx
@@ -54,6 +54,7 @@ export function ComposerFooter( { graphemeCount, onSubmit, isPending, limit }: P
 						{
 							count: remaining,
 							args: { count: remaining },
+							textOnly: true,
 							comment:
 								'Composer post-length counter; %(count)d is the integer count of characters still allowed before the limit. Negative when the user is over the limit.',
 						}

--- a/client/reader/atmosphere/composer/composer-modal.tsx
+++ b/client/reader/atmosphere/composer/composer-modal.tsx
@@ -65,7 +65,7 @@ export function ComposerModal() {
 			return;
 		}
 		if ( mutation.isError && mutation.error ) {
-			const errorKind = ( mutation.error as AtmosphereError ).kind;
+			const errorKind = mutation.error.kind;
 			if ( errorKind !== lastErrorKindRef.current ) {
 				lastErrorKindRef.current = errorKind;
 				dispatch(
@@ -130,9 +130,8 @@ export function ComposerModal() {
 
 	const title = titleForMode( mode, translate );
 	const placeholder = placeholderForMode( mode, translate, handle );
-	const errorMessage = mutation.isError
-		? errorMessageFor( mutation.error as AtmosphereError, translate )
-		: null;
+	const errorMessage =
+		mutation.isError && mutation.error ? errorMessageFor( mutation.error, translate ) : null;
 
 	return (
 		<>
@@ -268,7 +267,13 @@ function errorMessageFor( err: AtmosphereError, t: ReturnType< typeof useTransla
 		case 'invalid_handle':
 		case 'unknown':
 			return t( 'Something went wrong. Please try again.' );
+		default:
+			return assertNever( err );
 	}
+}
+
+function assertNever( value: never ): never {
+	throw new Error( `Unhandled AtmosphereError kind: ${ JSON.stringify( value ) }` );
 }
 
 function DiscardConfirm( props: { onCancel: () => void; onConfirm: () => void } ) {

--- a/client/reader/atmosphere/composer/composer-modal.tsx
+++ b/client/reader/atmosphere/composer/composer-modal.tsx
@@ -118,12 +118,12 @@ export function ComposerModal() {
 							root_uri: mode.root.uri,
 						} )
 					);
+					const { text: noticeText, threadUrl } = successNoticeFor( mode, translate );
+					const options = threadUrl
+						? { button: translate( 'View' ) as string, onClick: () => page( threadUrl ) }
+						: undefined;
+					dispatch( successNotice( noticeText, options ) );
 				}
-				const { text: noticeText, threadUrl } = successNoticeFor( mode, translate );
-				const options = threadUrl
-					? { button: translate( 'View' ) as string, onClick: () => page( threadUrl ) }
-					: undefined;
-				dispatch( successNotice( noticeText, options ) );
 				closeComposer();
 			},
 		} );
@@ -287,17 +287,16 @@ function errorMessageFor( err: AtmosphereError, t: ReturnType< typeof useTransla
 }
 
 function successNoticeFor(
-	mode: ActiveMode,
+	mode: Extract< ActiveMode, { kind: 'reply' } >,
 	t: ReturnType< typeof useTranslate >
 ): { text: ReactNode; threadUrl: string | null } {
-	if ( mode.kind === 'reply' ) {
-		return {
-			text: t( 'Your reply was posted.' ),
-			threadUrl: getThreadUrl( mode.connectionId, mode.parent.uri ),
-		};
-	}
-	// quote / standalone arms land with their respective slices.
-	return assertNever( mode );
+	// quote / standalone success copy lands with their respective slices —
+	// gate the call site on `mode.kind` so TS catches missing cases when
+	// those modes are wired through `<ComposerModal>`.
+	return {
+		text: t( 'Your reply was posted.' ),
+		threadUrl: getThreadUrl( mode.connectionId, mode.parent.uri ),
+	};
 }
 
 function assertNever( value: never ): never {

--- a/client/reader/atmosphere/composer/composer-modal.tsx
+++ b/client/reader/atmosphere/composer/composer-modal.tsx
@@ -1,0 +1,258 @@
+import './style.scss';
+import { createPostMutation } from '@automattic/api-queries';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Modal, Button, __experimentalHStack as HStack } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { UnknownAction } from 'redux';
+import { ThunkDispatch } from 'redux-thunk';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import { ComposerFooter } from './composer-footer';
+import { ComposerPinnedContext } from './composer-pinned-context';
+import { useComposer, type ActiveMode } from './composer-provider';
+import { ComposerTextarea } from './composer-textarea';
+import { countGraphemes } from './grapheme-count';
+import type { AtmosphereError, CreatePostParams } from '@automattic/api-core';
+import type { AppState } from 'calypso/types';
+import type { ReactNode } from 'react';
+
+const LIMIT = 300;
+
+export function ComposerModal() {
+	const translate = useTranslate();
+	const { mode, closeComposer } = useComposer();
+	const queryClient = useQueryClient();
+	const mutation = useMutation( createPostMutation( queryClient ) );
+	const dispatch = useDispatch< ThunkDispatch< AppState, void, UnknownAction > >();
+
+	const [ text, setText ] = useState( '' );
+	const [ confirmDiscard, setConfirmDiscard ] = useState( false );
+	const lastErrorKindRef = useRef< string | null >( null );
+
+	// Reset state when modal closes.
+	useEffect( () => {
+		if ( ! mode ) {
+			setText( '' );
+			setConfirmDiscard( false );
+			mutation.reset();
+			lastErrorKindRef.current = null;
+		}
+		// mutation.reset is stable across renders; intentionally not in deps.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ mode ] );
+
+	// Tracks: composer opened.
+	useEffect( () => {
+		if ( ! mode ) {
+			return;
+		}
+		if ( mode.kind === 'reply' ) {
+			dispatch(
+				recordReaderTracksEvent( 'calypso_reader_atmosphere_reply_composer_opened', {
+					connection_id: mode.connectionId,
+					parent_uri: mode.parent.uri,
+					root_uri: mode.root.uri,
+				} )
+			);
+		}
+		// quote / standalone Tracks events are emitted by later slices.
+	}, [ mode, dispatch ] );
+
+	// Tracks: error_shown with ref-tracked dedupe per error_kind transition.
+	useEffect( () => {
+		if ( ! mode || mode.kind !== 'reply' ) {
+			return;
+		}
+		if ( mutation.isError && mutation.error ) {
+			const errorKind = ( mutation.error as AtmosphereError ).kind;
+			if ( errorKind !== lastErrorKindRef.current ) {
+				lastErrorKindRef.current = errorKind;
+				dispatch(
+					recordReaderTracksEvent( 'calypso_reader_atmosphere_reply_error_shown', {
+						connection_id: mode.connectionId,
+						parent_uri: mode.parent.uri,
+						error_kind: errorKind,
+					} )
+				);
+			}
+		} else if ( ! mutation.isError ) {
+			lastErrorKindRef.current = null;
+		}
+	}, [ mutation.isError, mutation.error, mode, dispatch ] );
+
+	const graphemeCount = useMemo( () => countGraphemes( text ), [ text ] );
+
+	const handleClose = useCallback( () => {
+		if ( mutation.isPending ) {
+			return;
+		}
+		if ( text.trim().length > 0 ) {
+			setConfirmDiscard( true );
+			return;
+		}
+		closeComposer();
+	}, [ mutation.isPending, text, closeComposer ] );
+
+	const handleSubmit = useCallback( () => {
+		if ( ! mode || mutation.isPending ) {
+			return;
+		}
+		const params = buildParamsForMode( mode, text );
+		mutation.mutate( params, {
+			onSuccess: () => {
+				if ( mode.kind === 'reply' ) {
+					dispatch(
+						recordReaderTracksEvent( 'calypso_reader_atmosphere_reply_published', {
+							connection_id: mode.connectionId,
+							parent_uri: mode.parent.uri,
+							root_uri: mode.root.uri,
+						} )
+					);
+				}
+				closeComposer();
+			},
+		} );
+	}, [ mode, mutation, text, closeComposer, dispatch ] );
+
+	if ( ! mode ) {
+		return null;
+	}
+
+	const handle =
+		mode.kind === 'reply' || mode.kind === 'quote' ? mode.previewPost.author.handle : undefined;
+
+	const title = titleForMode( mode, translate );
+	const placeholder = placeholderForMode( mode, translate, handle );
+	const errorMessage = mutation.isError
+		? errorMessageFor( mutation.error as AtmosphereError, translate )
+		: null;
+
+	return (
+		<>
+			<Modal
+				title={ title }
+				onRequestClose={ handleClose }
+				className="atmosphere-composer"
+				focusOnMount
+			>
+				<ComposerPinnedContext mode={ mode } />
+				<ComposerTextarea
+					value={ text }
+					onChange={ setText }
+					onSubmit={ handleSubmit }
+					placeholder={ placeholder }
+					disabled={ mutation.isPending }
+					aria-describedby="atmosphere-composer-count"
+				/>
+				{ errorMessage && (
+					<div className="atmosphere-composer__error" role="alert">
+						{ errorMessage }
+					</div>
+				) }
+				<ComposerFooter
+					graphemeCount={ graphemeCount }
+					onSubmit={ handleSubmit }
+					isPending={ mutation.isPending }
+					limit={ LIMIT }
+				/>
+			</Modal>
+			{ confirmDiscard && (
+				<DiscardConfirm
+					onCancel={ () => setConfirmDiscard( false ) }
+					onConfirm={ () => {
+						setConfirmDiscard( false );
+						closeComposer();
+					} }
+				/>
+			) }
+		</>
+	);
+}
+
+function titleForMode( mode: ActiveMode, t: ReturnType< typeof useTranslate > ): string {
+	if ( mode.kind === 'reply' ) {
+		return t( 'Reply' ) as string;
+	}
+	if ( mode.kind === 'quote' ) {
+		return t( 'Quote post' ) as string;
+	}
+	return t( 'New post' ) as string;
+}
+
+function placeholderForMode(
+	mode: ActiveMode,
+	t: ReturnType< typeof useTranslate >,
+	handle: string | undefined
+): string {
+	if ( mode.kind === 'reply' ) {
+		return t( 'Replying to @%(handle)s…', { args: { handle: handle ?? '' } } ) as string;
+	}
+	if ( mode.kind === 'quote' ) {
+		return t( 'Add a comment…' ) as string;
+	}
+	return t( "What's up?" ) as string;
+}
+
+function buildParamsForMode( mode: ActiveMode, text: string ): CreatePostParams {
+	if ( mode.kind === 'reply' ) {
+		return {
+			connectionId: mode.connectionId,
+			text,
+			reply: { root: mode.root, parent: mode.parent },
+		};
+	}
+	if ( mode.kind === 'quote' ) {
+		return {
+			connectionId: mode.connectionId,
+			text,
+			quote: mode.quote,
+			...( mode.replyTo ? { reply: mode.replyTo } : {} ),
+		};
+	}
+	return { connectionId: mode.connectionId, text };
+}
+
+function errorMessageFor( err: AtmosphereError, t: ReturnType< typeof useTranslate > ): ReactNode {
+	switch ( err.kind ) {
+		case 'bad_request':
+			return t( "We couldn't post this. Try shortening your post." );
+		case 'auth_required':
+			return (
+				<>
+					{ t( 'Your Bluesky connection needs to be reconnected.' ) }{ ' ' }
+					<a href="/reader/atmosphere/connect" target="_blank" rel="noopener noreferrer">
+						{ t( 'Reconnect' ) }
+					</a>
+				</>
+			);
+		case 'rate_limited':
+			return t( "You're posting too quickly. Try again in a moment." );
+		case 'upstream_unavailable':
+			return t( 'Bluesky is taking longer than usual. Please try again.' );
+		default:
+			return t( 'Something went wrong. Please try again.' );
+	}
+}
+
+function DiscardConfirm( props: { onCancel: () => void; onConfirm: () => void } ) {
+	const translate = useTranslate();
+	return (
+		<Modal
+			title={ translate( 'Discard draft?' ) as string }
+			onRequestClose={ props.onCancel }
+			size="small"
+			className="atmosphere-composer-discard"
+		>
+			<p>{ translate( 'Your draft will be lost.' ) }</p>
+			<HStack justify="flex-end" spacing={ 2 }>
+				<Button variant="tertiary" onClick={ props.onCancel }>
+					{ translate( 'Keep editing' ) }
+				</Button>
+				<Button variant="primary" isDestructive onClick={ props.onConfirm }>
+					{ translate( 'Discard' ) }
+				</Button>
+			</HStack>
+		</Modal>
+	);
+}

--- a/client/reader/atmosphere/composer/composer-modal.tsx
+++ b/client/reader/atmosphere/composer/composer-modal.tsx
@@ -240,6 +240,8 @@ function errorMessageFor( err: AtmosphereError, t: ReturnType< typeof useTransla
 			// "honoring" it would render strings like "atmosphere_bad_request"
 			// to users. A future classifier change could distinguish the two.
 			return t( "We couldn't post this. Try shortening your post." );
+		case 'text_too_long':
+			return t( 'Your post is too long. Try shortening it.' );
 		case 'auth_required':
 		case 'auth_failed':
 		case 'invalid_credentials':
@@ -250,6 +252,10 @@ function errorMessageFor( err: AtmosphereError, t: ReturnType< typeof useTransla
 				comment:
 					'Composer error shown when the user’s Bluesky session expired; {{a}}…{{/a}} wraps a link to reconnect.',
 			} );
+		case 'reply_disabled':
+			return t( 'The author has restricted who can reply to this post.' );
+		case 'quote_disabled':
+			return t( "This post can't be quoted." );
 		case 'rate_limited':
 			return t( "You're posting too quickly. Try again in a moment." );
 		case 'upstream_unavailable':
@@ -257,6 +263,8 @@ function errorMessageFor( err: AtmosphereError, t: ReturnType< typeof useTransla
 		case 'connection_not_found':
 		case 'not_found':
 			return t( 'This Bluesky connection no longer exists.' );
+		case 'target_unavailable':
+			return t( 'This post is no longer available.' );
 		case 'invalid_handle':
 		case 'unknown':
 			return t( 'Something went wrong. Please try again.' );

--- a/client/reader/atmosphere/composer/composer-modal.tsx
+++ b/client/reader/atmosphere/composer/composer-modal.tsx
@@ -140,6 +140,12 @@ export function ComposerModal() {
 				onRequestClose={ handleClose }
 				className="atmosphere-composer"
 				focusOnMount
+				// `size="medium"` pins the frame to a fixed 512px max
+				// regardless of pinned-context text length. Without it the
+				// frame is content-driven (350px min-width grows to viewport
+				// max), so a short reply preview yields a 350px modal and a
+				// long one fills the screen.
+				size="medium"
 			>
 				<ComposerPinnedContext mode={ mode } />
 				<ComposerTextarea

--- a/client/reader/atmosphere/composer/composer-modal.tsx
+++ b/client/reader/atmosphere/composer/composer-modal.tsx
@@ -98,6 +98,12 @@ export function ComposerModal() {
 		if ( ! mode || mutation.isPending ) {
 			return;
 		}
+		// Guard against the Cmd/Ctrl+Enter shortcut bypassing the
+		// disabled Post button when the textarea is empty or over the
+		// limit. Mirrors the disabled logic in <ComposerFooter>.
+		if ( graphemeCount === 0 || graphemeCount > LIMIT ) {
+			return;
+		}
 		const params = buildParamsForMode( mode, text );
 		mutation.mutate( params, {
 			onSuccess: () => {
@@ -113,7 +119,7 @@ export function ComposerModal() {
 				closeComposer();
 			},
 		} );
-	}, [ mode, mutation, text, closeComposer, dispatch ] );
+	}, [ mode, mutation, text, graphemeCount, closeComposer, dispatch ] );
 
 	if ( ! mode ) {
 		return null;
@@ -143,10 +149,18 @@ export function ComposerModal() {
 					onSubmit={ handleSubmit }
 					placeholder={ placeholder }
 					disabled={ mutation.isPending }
-					aria-describedby="atmosphere-composer-count"
+					aria-label={ title }
+					// Include the error region id when an error is showing so AT
+					// users can navigate from the textarea to the explanation.
+					aria-describedby={
+						errorMessage
+							? 'atmosphere-composer-error atmosphere-composer-count'
+							: 'atmosphere-composer-count'
+					}
+					aria-invalid={ errorMessage ? true : undefined }
 				/>
 				{ errorMessage && (
-					<div className="atmosphere-composer__error" role="alert">
+					<div id="atmosphere-composer-error" className="atmosphere-composer__error" role="alert">
 						{ errorMessage }
 					</div>
 				) }
@@ -186,7 +200,11 @@ function placeholderForMode(
 	handle: string | undefined
 ): string {
 	if ( mode.kind === 'reply' ) {
-		return t( 'Replying to @%(handle)s…', { args: { handle: handle ?? '' } } ) as string;
+		return t( 'Replying to @%(handle)s…', {
+			args: { handle: handle ?? '' },
+			comment:
+				'Placeholder text in the reply composer; %(handle)s is the Bluesky handle of the user being replied to.',
+		} ) as string;
 	}
 	if ( mode.kind === 'quote' ) {
 		return t( 'Add a comment…' ) as string;
@@ -216,21 +234,31 @@ function buildParamsForMode( mode: ActiveMode, text: string ): CreatePostParams 
 function errorMessageFor( err: AtmosphereError, t: ReturnType< typeof useTranslate > ): ReactNode {
 	switch ( err.kind ) {
 		case 'bad_request':
+			// `err.message` is intentionally not surfaced here: the wpcom
+			// transport defaults `Error.message` to the response body's
+			// `error` code when no user-facing message is provided, so
+			// "honoring" it would render strings like "atmosphere_bad_request"
+			// to users. A future classifier change could distinguish the two.
 			return t( "We couldn't post this. Try shortening your post." );
 		case 'auth_required':
-			return (
-				<>
-					{ t( 'Your Bluesky connection needs to be reconnected.' ) }{ ' ' }
-					<a href="/reader/atmosphere/connect" target="_blank" rel="noopener noreferrer">
-						{ t( 'Reconnect' ) }
-					</a>
-				</>
-			);
+		case 'auth_failed':
+		case 'invalid_credentials':
+			return t( 'Your Bluesky connection needs to be reconnected. {{a}}Reconnect{{/a}}', {
+				components: {
+					a: <a href="/reader/atmosphere/connect" target="_blank" rel="noopener noreferrer" />,
+				},
+				comment:
+					'Composer error shown when the user’s Bluesky session expired; {{a}}…{{/a}} wraps a link to reconnect.',
+			} );
 		case 'rate_limited':
 			return t( "You're posting too quickly. Try again in a moment." );
 		case 'upstream_unavailable':
 			return t( 'Bluesky is taking longer than usual. Please try again.' );
-		default:
+		case 'connection_not_found':
+		case 'not_found':
+			return t( 'This Bluesky connection no longer exists.' );
+		case 'invalid_handle':
+		case 'unknown':
 			return t( 'Something went wrong. Please try again.' );
 	}
 }

--- a/client/reader/atmosphere/composer/composer-modal.tsx
+++ b/client/reader/atmosphere/composer/composer-modal.tsx
@@ -1,5 +1,6 @@
 import './style.scss';
 import { createPostMutation } from '@automattic/api-queries';
+import page from '@automattic/calypso-router';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Modal, Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
@@ -9,6 +10,7 @@ import { UnknownAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { successNotice } from 'calypso/state/notices/actions';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import { getThreadUrl } from '../route';
 import { ComposerFooter } from './composer-footer';
 import { ComposerPinnedContext } from './composer-pinned-context';
 import { useComposer, type ActiveMode } from './composer-provider';
@@ -116,8 +118,12 @@ export function ComposerModal() {
 							root_uri: mode.root.uri,
 						} )
 					);
-					dispatch( successNotice( translate( 'Your reply was posted.' ) as string ) );
 				}
+				const { text, threadUrl } = successNoticeFor( mode, translate );
+				const options = threadUrl
+					? { button: translate( 'View' ) as string, onClick: () => page( threadUrl ) }
+					: undefined;
+				dispatch( successNotice( text, options ) );
 				closeComposer();
 			},
 		} );
@@ -278,6 +284,20 @@ function errorMessageFor( err: AtmosphereError, t: ReturnType< typeof useTransla
 		default:
 			return assertNever( err );
 	}
+}
+
+function successNoticeFor(
+	mode: ActiveMode,
+	t: ReturnType< typeof useTranslate >
+): { text: ReactNode; threadUrl: string | null } {
+	if ( mode.kind === 'reply' ) {
+		return {
+			text: t( 'Your reply was posted.' ),
+			threadUrl: getThreadUrl( mode.connectionId, mode.parent.uri ),
+		};
+	}
+	// quote / standalone arms land with their respective slices.
+	return assertNever( mode );
 }
 
 function assertNever( value: never ): never {

--- a/client/reader/atmosphere/composer/composer-modal.tsx
+++ b/client/reader/atmosphere/composer/composer-modal.tsx
@@ -7,6 +7,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { UnknownAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
+import { successNotice } from 'calypso/state/notices/actions';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import { ComposerFooter } from './composer-footer';
 import { ComposerPinnedContext } from './composer-pinned-context';
@@ -115,11 +116,12 @@ export function ComposerModal() {
 							root_uri: mode.root.uri,
 						} )
 					);
+					dispatch( successNotice( translate( 'Your reply was posted.' ) as string ) );
 				}
 				closeComposer();
 			},
 		} );
-	}, [ mode, mutation, text, graphemeCount, closeComposer, dispatch ] );
+	}, [ mode, mutation, text, graphemeCount, closeComposer, dispatch, translate ] );
 
 	if ( ! mode ) {
 		return null;

--- a/client/reader/atmosphere/composer/composer-modal.tsx
+++ b/client/reader/atmosphere/composer/composer-modal.tsx
@@ -119,11 +119,11 @@ export function ComposerModal() {
 						} )
 					);
 				}
-				const { text, threadUrl } = successNoticeFor( mode, translate );
+				const { text: noticeText, threadUrl } = successNoticeFor( mode, translate );
 				const options = threadUrl
 					? { button: translate( 'View' ) as string, onClick: () => page( threadUrl ) }
 					: undefined;
-				dispatch( successNotice( text, options ) );
+				dispatch( successNotice( noticeText, options ) );
 				closeComposer();
 			},
 		} );
@@ -301,7 +301,7 @@ function successNoticeFor(
 }
 
 function assertNever( value: never ): never {
-	throw new Error( `Unhandled AtmosphereError kind: ${ JSON.stringify( value ) }` );
+	throw new Error( `Unhandled discriminated-union case: ${ JSON.stringify( value ) }` );
 }
 
 function DiscardConfirm( props: { onCancel: () => void; onConfirm: () => void } ) {

--- a/client/reader/atmosphere/composer/composer-pinned-context.tsx
+++ b/client/reader/atmosphere/composer/composer-pinned-context.tsx
@@ -1,0 +1,32 @@
+import { sanitizePostHtml } from 'calypso/reader/social/components/post-card/sanitize-post-html';
+import type { ActiveMode } from './composer-provider';
+
+interface Props {
+	mode: ActiveMode | null;
+}
+
+export function ComposerPinnedContext( { mode }: Props ) {
+	if ( ! mode || mode.kind === 'standalone' ) {
+		return null;
+	}
+
+	const { previewPost } = mode;
+	// DOMPurify-sanitised via sanitizePostHtml; see sanitize-post-html.ts.
+	// The backend already wp_kses-sanitises post.html with the same
+	// allow-list, so this is defence-in-depth, not the only line of defence.
+	const __html = sanitizePostHtml( previewPost.html );
+
+	return (
+		<div className="atmosphere-composer__pinned-context">
+			<div className="atmosphere-composer__pinned-author">
+				<strong>{ previewPost.author.display_name }</strong>
+				<span className="atmosphere-composer__pinned-handle">{ `@${ previewPost.author.handle }` }</span>
+			</div>
+			<div
+				className="atmosphere-composer__pinned-snippet"
+				// eslint-disable-next-line react/no-danger
+				dangerouslySetInnerHTML={ { __html } }
+			/>
+		</div>
+	);
+}

--- a/client/reader/atmosphere/composer/composer-pinned-context.tsx
+++ b/client/reader/atmosphere/composer/composer-pinned-context.tsx
@@ -11,6 +11,23 @@ export function ComposerPinnedContext( { mode }: Props ) {
 	}
 
 	const { previewPost } = mode;
+
+	const authorChip = (
+		<div className="atmosphere-composer__pinned-author">
+			<strong>{ previewPost.author.display_name }</strong>
+			<span className="atmosphere-composer__pinned-handle">{ `@${ previewPost.author.handle }` }</span>
+		</div>
+	);
+
+	if ( ! previewPost.html ) {
+		return (
+			<div className="atmosphere-composer__pinned-context">
+				{ authorChip }
+				<p className="atmosphere-composer__pinned-snippet">{ previewPost.text }</p>
+			</div>
+		);
+	}
+
 	// DOMPurify-sanitised via sanitizePostHtml; see sanitize-post-html.ts.
 	// The backend already wp_kses-sanitises post.html with the same
 	// allow-list, so this is defence-in-depth, not the only line of defence.
@@ -18,10 +35,7 @@ export function ComposerPinnedContext( { mode }: Props ) {
 
 	return (
 		<div className="atmosphere-composer__pinned-context">
-			<div className="atmosphere-composer__pinned-author">
-				<strong>{ previewPost.author.display_name }</strong>
-				<span className="atmosphere-composer__pinned-handle">{ `@${ previewPost.author.handle }` }</span>
-			</div>
+			{ authorChip }
 			<div
 				className="atmosphere-composer__pinned-snippet"
 				// eslint-disable-next-line react/no-danger

--- a/client/reader/atmosphere/composer/composer-pinned-context.tsx
+++ b/client/reader/atmosphere/composer/composer-pinned-context.tsx
@@ -1,4 +1,4 @@
-import { sanitizePostHtml } from 'calypso/reader/social/components/post-card/sanitize-post-html';
+import { sanitizePostHtml } from 'calypso/reader/social';
 import type { ActiveMode } from './composer-provider';
 
 interface Props {

--- a/client/reader/atmosphere/composer/composer-provider.tsx
+++ b/client/reader/atmosphere/composer/composer-provider.tsx
@@ -1,4 +1,12 @@
-import { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react';
 import type { AtUriRef, AtmosphereFeedItem } from '@automattic/api-core';
 import type { ReactNode } from 'react';
 
@@ -32,6 +40,19 @@ interface Props {
 export function ComposerProvider( { connectionId, children }: Props ) {
 	const [ mode, setMode ] = useState< ActiveMode | null >( null );
 	const triggerRef = useRef< HTMLElement | null >( null );
+	const wasOpenRef = useRef( false );
+
+	useEffect( () => {
+		if ( mode ) {
+			wasOpenRef.current = true;
+			return;
+		}
+		// mode just transitioned from non-null to null — restore focus.
+		if ( wasOpenRef.current ) {
+			wasOpenRef.current = false;
+			triggerRef.current?.focus();
+		}
+	}, [ mode ] );
 
 	const openComposer = useCallback(
 		( next: ComposerMode ) => {
@@ -43,7 +64,6 @@ export function ComposerProvider( { connectionId, children }: Props ) {
 
 	const closeComposer = useCallback( () => {
 		setMode( null );
-		queueMicrotask( () => triggerRef.current?.focus() );
 	}, [] );
 
 	const value = useMemo(

--- a/client/reader/atmosphere/composer/composer-provider.tsx
+++ b/client/reader/atmosphere/composer/composer-provider.tsx
@@ -1,0 +1,63 @@
+import { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
+import type { AtUriRef, AtmosphereFeedItem } from '@automattic/api-core';
+import type { ReactNode } from 'react';
+
+export type PreviewPost = Pick< AtmosphereFeedItem, 'uri' | 'cid' | 'author' | 'text' | 'html' >;
+
+export type ComposerMode =
+	| { kind: 'reply'; root: AtUriRef; parent: AtUriRef; previewPost: PreviewPost }
+	| {
+			kind: 'quote';
+			quote: AtUriRef;
+			previewPost: PreviewPost;
+			replyTo?: { root: AtUriRef; parent: AtUriRef };
+	  }
+	| { kind: 'standalone' };
+
+export type ActiveMode = ComposerMode & { connectionId: number };
+
+interface ComposerContextValue {
+	mode: ActiveMode | null;
+	openComposer: ( mode: ComposerMode ) => void;
+	closeComposer: () => void;
+}
+
+const ComposerContext = createContext< ComposerContextValue | null >( null );
+
+interface Props {
+	connectionId: number;
+	children: ReactNode;
+}
+
+export function ComposerProvider( { connectionId, children }: Props ) {
+	const [ mode, setMode ] = useState< ActiveMode | null >( null );
+	const triggerRef = useRef< HTMLElement | null >( null );
+
+	const openComposer = useCallback(
+		( next: ComposerMode ) => {
+			triggerRef.current = document.activeElement as HTMLElement | null;
+			setMode( { ...next, connectionId } );
+		},
+		[ connectionId ]
+	);
+
+	const closeComposer = useCallback( () => {
+		setMode( null );
+		queueMicrotask( () => triggerRef.current?.focus() );
+	}, [] );
+
+	const value = useMemo(
+		() => ( { mode, openComposer, closeComposer } ),
+		[ mode, openComposer, closeComposer ]
+	);
+
+	return <ComposerContext.Provider value={ value }>{ children }</ComposerContext.Provider>;
+}
+
+export function useComposer(): ComposerContextValue {
+	const ctx = useContext( ComposerContext );
+	if ( ! ctx ) {
+		throw new Error( 'useComposer must be called inside <ComposerProvider>' );
+	}
+	return ctx;
+}

--- a/client/reader/atmosphere/composer/composer-provider.tsx
+++ b/client/reader/atmosphere/composer/composer-provider.tsx
@@ -7,10 +7,28 @@ import {
 	useRef,
 	useState,
 } from 'react';
-import type { AtUriRef, AtmosphereFeedItem } from '@automattic/api-core';
+import type { AtUriRef } from '@automattic/api-core';
 import type { ReactNode } from 'react';
 
-export type PreviewPost = Pick< AtmosphereFeedItem, 'uri' | 'cid' | 'author' | 'text' | 'html' >;
+/**
+ * Structural shape consumed by `<ComposerPinnedContext>`. Both
+ * `AtmosphereFeedItem` (per-protocol) and `SocialPost` (protocol-agnostic
+ * mapped shape) satisfy this — we only need the four fields the pinned
+ * preview reads (`text`, `html`, `author.handle`, `author.display_name`)
+ * plus the post identity (`uri`, optional `cid`) that callers have on
+ * hand. Kept structural so the per-protocol panels can hand us a
+ * `SocialPost` directly without re-deriving an `AtmosphereFeedItem`.
+ */
+export interface PreviewPost {
+	uri: string;
+	cid?: string;
+	text: string;
+	html: string;
+	author: {
+		handle: string;
+		display_name: string;
+	};
+}
 
 export type ComposerMode =
 	| { kind: 'reply'; root: AtUriRef; parent: AtUriRef; previewPost: PreviewPost }
@@ -80,4 +98,14 @@ export function useComposer(): ComposerContextValue {
 		throw new Error( 'useComposer must be called inside <ComposerProvider>' );
 	}
 	return ctx;
+}
+
+/**
+ * Soft variant: returns `null` outside a `<ComposerProvider>` instead of
+ * throwing. Use this in components that opt into the composer when one
+ * is mounted (e.g. panels rendering post cards) but should still render
+ * fine in tests or shells that don't provide a composer.
+ */
+export function useOptionalComposer(): ComposerContextValue | null {
+	return useContext( ComposerContext );
 }

--- a/client/reader/atmosphere/composer/composer-textarea.tsx
+++ b/client/reader/atmosphere/composer/composer-textarea.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useRef } from 'react';
+
+interface Props {
+	value: string;
+	onChange: ( value: string ) => void;
+	onSubmit: () => void;
+	placeholder: string;
+	disabled?: boolean;
+	'aria-describedby'?: string;
+}
+
+export function ComposerTextarea( {
+	value,
+	onChange,
+	onSubmit,
+	placeholder,
+	disabled,
+	'aria-describedby': ariaDescribedBy,
+}: Props ) {
+	const ref = useRef< HTMLTextAreaElement | null >( null );
+
+	useEffect( () => {
+		ref.current?.focus();
+	}, [] );
+
+	useEffect( () => {
+		const el = ref.current;
+		if ( ! el ) {
+			return;
+		}
+		el.style.height = 'auto';
+		el.style.height = `${ el.scrollHeight }px`;
+	}, [ value ] );
+
+	return (
+		<textarea
+			ref={ ref }
+			className="atmosphere-composer__textarea"
+			value={ value }
+			placeholder={ placeholder }
+			disabled={ disabled }
+			aria-describedby={ ariaDescribedBy }
+			onChange={ ( e ) => onChange( e.target.value ) }
+			onKeyDown={ ( e ) => {
+				if ( e.key === 'Enter' && ( e.metaKey || e.ctrlKey ) ) {
+					e.preventDefault();
+					onSubmit();
+				}
+			} }
+		/>
+	);
+}

--- a/client/reader/atmosphere/composer/composer-textarea.tsx
+++ b/client/reader/atmosphere/composer/composer-textarea.tsx
@@ -1,12 +1,19 @@
 import { useEffect, useRef } from 'react';
 
+// Keep in sync with `min-height` on `.atmosphere-composer__textarea` in
+// `style.scss`. Inline `style.height` set by the autogrow effect would
+// otherwise win over the stylesheet for empty / single-line content.
+const MIN_HEIGHT_PX = 80;
+
 interface Props {
 	value: string;
 	onChange: ( value: string ) => void;
 	onSubmit: () => void;
 	placeholder: string;
 	disabled?: boolean;
+	'aria-label'?: string;
 	'aria-describedby'?: string;
+	'aria-invalid'?: boolean;
 }
 
 export function ComposerTextarea( {
@@ -15,7 +22,9 @@ export function ComposerTextarea( {
 	onSubmit,
 	placeholder,
 	disabled,
+	'aria-label': ariaLabel,
 	'aria-describedby': ariaDescribedBy,
+	'aria-invalid': ariaInvalid,
 }: Props ) {
 	const ref = useRef< HTMLTextAreaElement | null >( null );
 
@@ -29,7 +38,7 @@ export function ComposerTextarea( {
 			return;
 		}
 		el.style.height = 'auto';
-		el.style.height = `${ el.scrollHeight }px`;
+		el.style.height = `${ Math.max( el.scrollHeight, MIN_HEIGHT_PX ) }px`;
 	}, [ value ] );
 
 	return (
@@ -39,7 +48,9 @@ export function ComposerTextarea( {
 			value={ value }
 			placeholder={ placeholder }
 			disabled={ disabled }
+			aria-label={ ariaLabel }
 			aria-describedby={ ariaDescribedBy }
+			aria-invalid={ ariaInvalid }
 			onChange={ ( e ) => onChange( e.target.value ) }
 			onKeyDown={ ( e ) => {
 				if ( e.key === 'Enter' && ( e.metaKey || e.ctrlKey ) ) {

--- a/client/reader/atmosphere/composer/grapheme-count.ts
+++ b/client/reader/atmosphere/composer/grapheme-count.ts
@@ -1,0 +1,22 @@
+const segmenter =
+	typeof Intl !== 'undefined' && typeof Intl.Segmenter !== 'undefined'
+		? new Intl.Segmenter( undefined, { granularity: 'grapheme' } )
+		: null;
+
+export function countGraphemes( text: string ): number {
+	if ( ! text ) {
+		return 0;
+	}
+	if ( segmenter ) {
+		let count = 0;
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		for ( const _ of segmenter.segment( text ) ) {
+			count++;
+		}
+		return count;
+	}
+	// Fallback for environments without Intl.Segmenter — count code points.
+	// This over-counts multi-codepoint graphemes but is a strict upper
+	// bound, so it errs toward "too long" which is safe.
+	return Array.from( text ).length;
+}

--- a/client/reader/atmosphere/composer/index.ts
+++ b/client/reader/atmosphere/composer/index.ts
@@ -1,0 +1,3 @@
+export { ComposerProvider, useComposer } from './composer-provider';
+export { ComposerModal } from './composer-modal';
+export type { ComposerMode, ActiveMode, PreviewPost } from './composer-provider';

--- a/client/reader/atmosphere/composer/index.ts
+++ b/client/reader/atmosphere/composer/index.ts
@@ -1,3 +1,3 @@
-export { ComposerProvider, useComposer } from './composer-provider';
+export { ComposerProvider, useComposer, useOptionalComposer } from './composer-provider';
 export { ComposerModal } from './composer-modal';
 export type { ComposerMode, ActiveMode, PreviewPost } from './composer-provider';

--- a/client/reader/atmosphere/composer/style.scss
+++ b/client/reader/atmosphere/composer/style.scss
@@ -1,0 +1,65 @@
+.atmosphere-composer {
+	.atmosphere-composer__pinned-context {
+		padding: 8px 12px;
+		background: var(--studio-gray-0, #f6f7f7);
+		border-radius: 4px;
+		margin-block-end: 8px;
+	}
+
+	.atmosphere-composer__pinned-author {
+		font-weight: 600;
+	}
+
+	.atmosphere-composer__pinned-handle {
+		color: var(--studio-gray-50, #646970);
+		margin-inline-start: 6px;
+		font-weight: 400;
+	}
+
+	.atmosphere-composer__pinned-snippet {
+		margin-block: 4px 0;
+	}
+
+	.atmosphere-composer__textarea {
+		width: 100%;
+		min-height: 80px;
+		resize: none;
+		border: none;
+		outline: none;
+		font: inherit;
+		padding: 8px 0;
+		background: transparent;
+	}
+
+	.atmosphere-composer__error {
+		color: #b32d2e;
+		padding: 0 12px;
+		margin-block: 8px;
+	}
+
+	.atmosphere-composer__footer {
+		margin-block-start: 8px;
+	}
+
+	.atmosphere-composer__media {
+		background: transparent;
+		border: none;
+		cursor: default;
+		padding: 4px;
+		color: var(--studio-gray-50, #646970);
+	}
+
+	.atmosphere-composer__count {
+		color: var(--studio-gray-50, #646970);
+		font-variant-numeric: tabular-nums;
+
+		&.is-warn {
+			color: #b26200;
+		}
+
+		&.is-over {
+			color: #b32d2e;
+			font-weight: 600;
+		}
+	}
+}

--- a/client/reader/atmosphere/composer/style.scss
+++ b/client/reader/atmosphere/composer/style.scss
@@ -4,6 +4,10 @@
 		background: var(--studio-gray-0, #f6f7f7);
 		border-radius: 4px;
 		margin-block-end: 8px;
+		// Long unbreakable strings (URLs, gibberish) in the snippet, display
+		// name, or handle would otherwise overflow the fixed-width modal and
+		// add a horizontal scrollbar. `overflow-wrap` is inherited.
+		overflow-wrap: anywhere;
 	}
 
 	.atmosphere-composer__pinned-author {

--- a/client/reader/atmosphere/composer/test/composer-footer.test.tsx
+++ b/client/reader/atmosphere/composer/test/composer-footer.test.tsx
@@ -76,4 +76,27 @@ describe( '<ComposerFooter>', () => {
 		await user.click( screen.getByRole( 'button', { name: /post/i } ) );
 		expect( onSubmit ).toHaveBeenCalledTimes( 1 );
 	} );
+
+	it( 'count is aria-live="off" outside the warn threshold', () => {
+		render(
+			<ComposerFooter graphemeCount={ 249 } onSubmit={ noop } isPending={ false } limit={ 300 } />
+		);
+		// remaining = 51, which is above WARN_THRESHOLD_REMAINING (50).
+		expect( screen.getByText( '51' ) ).toHaveAttribute( 'aria-live', 'off' );
+	} );
+
+	it( 'count is aria-live="polite" once the warn threshold is reached', () => {
+		render(
+			<ComposerFooter graphemeCount={ 250 } onSubmit={ noop } isPending={ false } limit={ 300 } />
+		);
+		// remaining = 50, which equals WARN_THRESHOLD_REMAINING (boundary).
+		expect( screen.getByText( '50' ) ).toHaveAttribute( 'aria-live', 'polite' );
+	} );
+
+	it( 'count is aria-live="polite" when over the limit', () => {
+		render(
+			<ComposerFooter graphemeCount={ 305 } onSubmit={ noop } isPending={ false } limit={ 300 } />
+		);
+		expect( screen.getByText( '-5' ) ).toHaveAttribute( 'aria-live', 'polite' );
+	} );
 } );

--- a/client/reader/atmosphere/composer/test/composer-footer.test.tsx
+++ b/client/reader/atmosphere/composer/test/composer-footer.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ComposerFooter } from '../composer-footer';
+
+const noop = () => {};
+
+describe( '<ComposerFooter>', () => {
+	it( 'shows the remaining count', () => {
+		render(
+			<ComposerFooter graphemeCount={ 100 } onSubmit={ noop } isPending={ false } limit={ 300 } />
+		);
+		expect( screen.getByText( '200' ) ).toBeVisible();
+	} );
+
+	it( 'disables Post when count is 0', () => {
+		render(
+			<ComposerFooter graphemeCount={ 0 } onSubmit={ noop } isPending={ false } limit={ 300 } />
+		);
+		expect( screen.getByRole( 'button', { name: /post/i } ) ).toBeDisabled();
+	} );
+
+	it( 'disables Post when count is over the limit', () => {
+		render(
+			<ComposerFooter graphemeCount={ 301 } onSubmit={ noop } isPending={ false } limit={ 300 } />
+		);
+		expect( screen.getByRole( 'button', { name: /post/i } ) ).toBeDisabled();
+	} );
+
+	it( 'shows amber count under 50 remaining', () => {
+		render(
+			<ComposerFooter graphemeCount={ 260 } onSubmit={ noop } isPending={ false } limit={ 300 } />
+		);
+		expect( screen.getByText( '40' ) ).toHaveClass( 'is-warn' );
+	} );
+
+	it( 'shows red count at zero / negative', () => {
+		render(
+			<ComposerFooter graphemeCount={ 305 } onSubmit={ noop } isPending={ false } limit={ 300 } />
+		);
+		expect( screen.getByText( '-5' ) ).toHaveClass( 'is-over' );
+	} );
+
+	it( 'media button is aria-disabled and tab-reachable', () => {
+		render(
+			<ComposerFooter graphemeCount={ 5 } onSubmit={ noop } isPending={ false } limit={ 300 } />
+		);
+		const media = screen.getByRole( 'button', { name: /add media/i } );
+		expect( media ).toHaveAttribute( 'aria-disabled', 'true' );
+		expect( media ).toHaveAttribute( 'tabindex', '0' );
+	} );
+
+	it( 'shows spinner state when pending', () => {
+		const { container } = render(
+			<ComposerFooter graphemeCount={ 5 } onSubmit={ noop } isPending limit={ 300 } />
+		);
+		expect( screen.getByRole( 'button', { name: /post/i } ) ).toBeDisabled();
+		// `<Spinner>` from `@wordpress/components` renders an SVG with class
+		// `components-spinner` (and `role="presentation"`), so we query by class.
+		expect( container.querySelector( '.components-spinner' ) ).toBeVisible();
+	} );
+
+	it( 'fires onSubmit when Post is clicked', async () => {
+		const onSubmit = jest.fn();
+		const user = userEvent.setup();
+		render(
+			<ComposerFooter
+				graphemeCount={ 10 }
+				onSubmit={ onSubmit }
+				isPending={ false }
+				limit={ 300 }
+			/>
+		);
+		await user.click( screen.getByRole( 'button', { name: /post/i } ) );
+		expect( onSubmit ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/client/reader/atmosphere/composer/test/composer-modal.test.tsx
+++ b/client/reader/atmosphere/composer/test/composer-modal.test.tsx
@@ -130,6 +130,32 @@ describe( '<ComposerModal>', () => {
 		expect( screen.getByRole( 'textbox' ) ).toHaveValue( 'hi' );
 	} );
 
+	it.each( [
+		[ 'atmosphere_text_too_long', 400, /your post is too long\. try shortening it\./i ] as const,
+		[
+			'atmosphere_reply_disabled',
+			403,
+			/the author has restricted who can reply to this post\./i,
+		] as const,
+		[ 'atmosphere_quote_disabled', 403, /this post can't be quoted\./i ] as const,
+		[ 'atmosphere_target_unavailable', 404, /this post is no longer available\./i ] as const,
+	] )( 'maps %s (HTTP %i) to its dedicated copy', async ( errorCode, status, copyMatcher ) => {
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/wpcom/v2/reader/atmosphere/connections/42/posts' )
+			.reply( status, { error: errorCode } );
+
+		const user = userEvent.setup();
+		renderWithProvider( <Harness connectionId={ 42 } /> );
+		await user.click( screen.getByText( 'open' ) );
+		await user.type( screen.getByRole( 'textbox' ), 'hi' );
+		await user.click( screen.getByRole( 'button', { name: 'Post' } ) );
+
+		expect( await screen.findByText( copyMatcher ) ).toBeVisible();
+		expect( screen.getByRole( 'dialog' ) ).toBeVisible();
+		// Text preserved so the user can edit and resubmit.
+		expect( screen.getByRole( 'textbox' ) ).toHaveValue( 'hi' );
+	} );
+
 	it( 'maps 401 to a Reconnect link with target=_blank', async () => {
 		nock( 'https://public-api.wordpress.com' )
 			.post( '/wpcom/v2/reader/atmosphere/connections/42/posts' )

--- a/client/reader/atmosphere/composer/test/composer-modal.test.tsx
+++ b/client/reader/atmosphere/composer/test/composer-modal.test.tsx
@@ -4,6 +4,7 @@
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
+import * as noticeActions from 'calypso/state/notices/actions';
 import * as analytics from 'calypso/state/reader/analytics/actions';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { ComposerModal } from '../composer-modal';
@@ -11,7 +12,7 @@ import { ComposerProvider, useComposer } from '../composer-provider';
 
 function makePreview() {
 	return {
-		uri: 'at://p',
+		uri: 'at://did:plc:alice/app.bsky.feed.post/bbbbbbbbbbbbb',
 		cid: 'pcid',
 		author: {
 			did: 'did:plc:alice',
@@ -32,8 +33,8 @@ function TriggerAndModal() {
 				onClick={ () =>
 					openComposer( {
 						kind: 'reply',
-						root: { uri: 'at://r', cid: 'rcid' },
-						parent: { uri: 'at://p', cid: 'pcid' },
+						root: { uri: 'at://did:plc:alice/app.bsky.feed.post/aaaaaaaaaaaaa', cid: 'rcid' },
+						parent: { uri: 'at://did:plc:alice/app.bsky.feed.post/bbbbbbbbbbbbb', cid: 'pcid' },
 						previewPost: makePreview(),
 					} )
 				}
@@ -61,6 +62,7 @@ describe( '<ComposerModal>', () => {
 		jest
 			.spyOn( analytics, 'recordReaderTracksEvent' )
 			.mockImplementation( () => ( { type: '@@TEST/NOOP' } ) as never );
+		jest.spyOn( noticeActions, 'successNotice' );
 	} );
 
 	afterEach( () => {
@@ -188,8 +190,8 @@ describe( '<ComposerModal>', () => {
 				'calypso_reader_atmosphere_reply_composer_opened',
 				expect.objectContaining( {
 					connection_id: 42,
-					parent_uri: 'at://p',
-					root_uri: 'at://r',
+					parent_uri: 'at://did:plc:alice/app.bsky.feed.post/bbbbbbbbbbbbb',
+					root_uri: 'at://did:plc:alice/app.bsky.feed.post/aaaaaaaaaaaaa',
 				} )
 			)
 		);
@@ -203,8 +205,8 @@ describe( '<ComposerModal>', () => {
 				'calypso_reader_atmosphere_reply_published',
 				expect.objectContaining( {
 					connection_id: 42,
-					parent_uri: 'at://p',
-					root_uri: 'at://r',
+					parent_uri: 'at://did:plc:alice/app.bsky.feed.post/bbbbbbbbbbbbb',
+					root_uri: 'at://did:plc:alice/app.bsky.feed.post/aaaaaaaaaaaaa',
 				} )
 			)
 		);
@@ -346,5 +348,22 @@ describe( '<ComposerModal>', () => {
 		// Modal closes after the successful retry.
 		await waitFor( () => expect( nock.isDone() ).toBe( true ) );
 		await waitFor( () => expect( screen.queryByRole( 'dialog' ) ).toBeNull() );
+	} );
+
+	it( 'dispatches a success notice with reply copy on publish', async () => {
+		const successSpy = noticeActions.successNotice as unknown as jest.Mock;
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/wpcom/v2/reader/atmosphere/connections/42/posts' )
+			.reply( 200, { post: { uri: 'at://new', cid: 'newcid', rkey: 'abc' } } );
+
+		const user = userEvent.setup();
+		renderWithProvider( <Harness connectionId={ 42 } /> );
+		await user.click( screen.getByText( 'open' ) );
+		await user.type( screen.getByRole( 'textbox' ), 'hi' );
+		await user.click( screen.getByRole( 'button', { name: 'Post' } ) );
+
+		await waitFor( () =>
+			expect( successSpy ).toHaveBeenCalledWith( 'Your reply was posted.', expect.anything() )
+		);
 	} );
 } );

--- a/client/reader/atmosphere/composer/test/composer-modal.test.tsx
+++ b/client/reader/atmosphere/composer/test/composer-modal.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import * as analytics from 'calypso/state/reader/analytics/actions';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { ComposerModal } from '../composer-modal';
+import { ComposerProvider, useComposer } from '../composer-provider';
+
+function makePreview() {
+	return {
+		uri: 'at://p',
+		cid: 'pcid',
+		author: {
+			did: 'did:plc:alice',
+			handle: 'alice.bsky.social',
+			display_name: 'Alice',
+			avatar: null,
+		},
+		text: 'Excited to share!',
+		html: '<p>Excited to share!</p>',
+	};
+}
+
+function TriggerAndModal() {
+	const { openComposer } = useComposer();
+	return (
+		<>
+			<button
+				onClick={ () =>
+					openComposer( {
+						kind: 'reply',
+						root: { uri: 'at://r', cid: 'rcid' },
+						parent: { uri: 'at://p', cid: 'pcid' },
+						previewPost: makePreview(),
+					} )
+				}
+			>
+				open
+			</button>
+			<ComposerModal />
+		</>
+	);
+}
+
+function Harness( props: { connectionId: number } ) {
+	return (
+		<ComposerProvider connectionId={ props.connectionId }>
+			<TriggerAndModal />
+		</ComposerProvider>
+	);
+}
+
+describe( '<ComposerModal>', () => {
+	beforeEach( () => {
+		// recordReaderTracksEvent is a thunk that reads state.reader.follows.
+		// Replace it with a no-op action creator so dispatch() doesn't throw,
+		// while still letting spies observe call-site arguments.
+		jest
+			.spyOn( analytics, 'recordReaderTracksEvent' )
+			.mockImplementation( () => ( { type: '@@TEST/NOOP' } ) as never );
+	} );
+
+	afterEach( () => {
+		nock.cleanAll();
+		jest.restoreAllMocks();
+	} );
+
+	it( 'renders nothing when mode is null', () => {
+		renderWithProvider( <Harness connectionId={ 42 } /> );
+		expect( screen.queryByRole( 'dialog' ) ).toBeNull();
+	} );
+
+	it( 'opens with reply title and pinned context when triggered', async () => {
+		const user = userEvent.setup();
+		renderWithProvider( <Harness connectionId={ 42 } /> );
+		await user.click( screen.getByText( 'open' ) );
+		expect( await screen.findByRole( 'dialog', { name: /reply/i } ) ).toBeVisible();
+		expect( screen.getByText( /Excited to share/ ) ).toBeVisible();
+		await waitFor( () => expect( screen.getByRole( 'textbox' ) ).toHaveFocus() );
+	} );
+
+	it( 'submits and closes on Post click', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/wpcom/v2/reader/atmosphere/connections/42/posts' )
+			.reply( 200, { post: { uri: 'at://new', cid: 'newcid', rkey: 'abc' } } );
+
+		const user = userEvent.setup();
+		renderWithProvider( <Harness connectionId={ 42 } /> );
+		await user.click( screen.getByText( 'open' ) );
+		await user.type( screen.getByRole( 'textbox' ), 'hi' );
+		await user.click( screen.getByRole( 'button', { name: 'Post' } ) );
+
+		await waitFor( () => expect( nock.isDone() ).toBe( true ) );
+		await waitFor( () => expect( screen.queryByRole( 'dialog' ) ).toBeNull() );
+	} );
+
+	it( 'shows discard-confirm when closing with unsaved text', async () => {
+		const user = userEvent.setup();
+		renderWithProvider( <Harness connectionId={ 42 } /> );
+		await user.click( screen.getByText( 'open' ) );
+		await user.type( screen.getByRole( 'textbox' ), 'hi' );
+		await user.keyboard( '{Escape}' );
+		expect( await screen.findByRole( 'button', { name: /discard/i } ) ).toBeVisible();
+	} );
+
+	it( 'closes immediately when Escape is pressed with empty text', async () => {
+		const user = userEvent.setup();
+		renderWithProvider( <Harness connectionId={ 42 } /> );
+		await user.click( screen.getByText( 'open' ) );
+		await user.keyboard( '{Escape}' );
+		await waitFor( () => expect( screen.queryByRole( 'dialog' ) ).toBeNull() );
+	} );
+
+	it( 'maps 502 to the upstream-unavailable copy', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/wpcom/v2/reader/atmosphere/connections/42/posts' )
+			.reply( 502, { error: 'atmosphere_upstream_unavailable' } );
+
+		const user = userEvent.setup();
+		renderWithProvider( <Harness connectionId={ 42 } /> );
+		await user.click( screen.getByText( 'open' ) );
+		await user.type( screen.getByRole( 'textbox' ), 'hi' );
+		await user.click( screen.getByRole( 'button', { name: 'Post' } ) );
+
+		expect( await screen.findByText( /taking longer than usual/i ) ).toBeVisible();
+		expect( screen.getByRole( 'dialog' ) ).toBeVisible();
+		expect( screen.getByRole( 'textbox' ) ).toHaveValue( 'hi' );
+	} );
+
+	it( 'maps 401 to a Reconnect link with target=_blank', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/wpcom/v2/reader/atmosphere/connections/42/posts' )
+			.reply( 401, { error: 'atmosphere_auth_required' } );
+
+		const user = userEvent.setup();
+		renderWithProvider( <Harness connectionId={ 42 } /> );
+		await user.click( screen.getByText( 'open' ) );
+		await user.type( screen.getByRole( 'textbox' ), 'hi' );
+		await user.click( screen.getByRole( 'button', { name: 'Post' } ) );
+
+		const reconnect = await screen.findByRole( 'link', { name: /reconnect/i } );
+		expect( reconnect ).toHaveAttribute( 'href', '/reader/atmosphere/connect' );
+		expect( reconnect ).toHaveAttribute( 'target', '_blank' );
+		expect( reconnect ).toHaveAttribute( 'rel', expect.stringContaining( 'noopener' ) );
+	} );
+
+	it( 'fires _reply_composer_opened on open and _reply_published on success', async () => {
+		const recordSpy = analytics.recordReaderTracksEvent as unknown as jest.Mock;
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/wpcom/v2/reader/atmosphere/connections/42/posts' )
+			.reply( 200, { post: { uri: 'at://new', cid: 'newcid', rkey: 'abc' } } );
+
+		const user = userEvent.setup();
+		renderWithProvider( <Harness connectionId={ 42 } /> );
+		await user.click( screen.getByText( 'open' ) );
+
+		await waitFor( () =>
+			expect( recordSpy ).toHaveBeenCalledWith(
+				'calypso_reader_atmosphere_reply_composer_opened',
+				expect.objectContaining( {
+					connection_id: 42,
+					parent_uri: 'at://p',
+					root_uri: 'at://r',
+				} )
+			)
+		);
+
+		await user.type( screen.getByRole( 'textbox' ), 'hi' );
+		await user.click( screen.getByRole( 'button', { name: 'Post' } ) );
+
+		await waitFor( () => expect( nock.isDone() ).toBe( true ) );
+		await waitFor( () =>
+			expect( recordSpy ).toHaveBeenCalledWith(
+				'calypso_reader_atmosphere_reply_published',
+				expect.objectContaining( {
+					connection_id: 42,
+					parent_uri: 'at://p',
+					root_uri: 'at://r',
+				} )
+			)
+		);
+	} );
+} );

--- a/client/reader/atmosphere/composer/test/composer-modal.test.tsx
+++ b/client/reader/atmosphere/composer/test/composer-modal.test.tsx
@@ -66,6 +66,35 @@ function Harness( props: { connectionId: number } ) {
 	);
 }
 
+function TriggerAndModalInvalidUri() {
+	const { openComposer } = useComposer();
+	return (
+		<>
+			<button
+				onClick={ () =>
+					openComposer( {
+						kind: 'reply',
+						root: { uri: 'at://garbage', cid: 'rcid' },
+						parent: { uri: 'at://garbage', cid: 'pcid' },
+						previewPost: makePreview(),
+					} )
+				}
+			>
+				open
+			</button>
+			<ComposerModal />
+		</>
+	);
+}
+
+function HarnessInvalidUri( props: { connectionId: number } ) {
+	return (
+		<ComposerProvider connectionId={ props.connectionId }>
+			<TriggerAndModalInvalidUri />
+		</ComposerProvider>
+	);
+}
+
 describe( '<ComposerModal>', () => {
 	beforeEach( () => {
 		// recordReaderTracksEvent is a thunk that reads state.reader.follows.
@@ -407,5 +436,25 @@ describe( '<ComposerModal>', () => {
 		expect( pageMock ).toHaveBeenCalledWith(
 			'/reader/atmosphere/42/thread/did:plc:abcdefghijklmnopqrstuvwx/bbbbbbbbbbbbb'
 		);
+	} );
+
+	it( 'omits the View button when the thread URL cannot be built', async () => {
+		const successSpy = noticeActions.successNotice as unknown as jest.Mock;
+
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/wpcom/v2/reader/atmosphere/connections/42/posts' )
+			.reply( 200, { post: { uri: 'at://new', cid: 'newcid', rkey: 'abc' } } );
+
+		const user = userEvent.setup();
+		renderWithProvider( <HarnessInvalidUri connectionId={ 42 } /> );
+		await user.click( screen.getByText( 'open' ) );
+		await user.type( screen.getByRole( 'textbox' ), 'hi' );
+		await user.click( screen.getByRole( 'button', { name: 'Post' } ) );
+
+		await waitFor( () => expect( successSpy ).toHaveBeenCalled() );
+
+		const [ text, options ] = successSpy.mock.calls[ 0 ];
+		expect( text ).toBe( 'Your reply was posted.' );
+		expect( options ).toBeUndefined();
 	} );
 } );

--- a/client/reader/atmosphere/composer/test/composer-modal.test.tsx
+++ b/client/reader/atmosphere/composer/test/composer-modal.test.tsx
@@ -230,4 +230,95 @@ describe( '<ComposerModal>', () => {
 		// users can reach the placeholder while it remains inert.
 		expect( media ).not.toBeDisabled();
 	} );
+
+	it( 'Cmd+Enter on empty text does not POST (matches the disabled Post button)', async () => {
+		const scope = nock( 'https://public-api.wordpress.com' )
+			.post( '/wpcom/v2/reader/atmosphere/connections/42/posts' )
+			.reply( 200, { post: { uri: 'at://new', cid: 'newcid', rkey: 'abc' } } );
+
+		const user = userEvent.setup();
+		renderWithProvider( <Harness connectionId={ 42 } /> );
+		await user.click( screen.getByText( 'open' ) );
+		// Focus is on the textarea (asserted elsewhere); fire the shortcut.
+		await user.keyboard( '{Meta>}{Enter}{/Meta}' );
+
+		// Network was never hit; modal stays open.
+		expect( scope.isDone() ).toBe( false );
+		expect( screen.getByRole( 'dialog' ) ).toBeVisible();
+		nock.cleanAll();
+	} );
+
+	it( 'Cmd+Enter when text exceeds the limit does not POST', async () => {
+		const scope = nock( 'https://public-api.wordpress.com' )
+			.post( '/wpcom/v2/reader/atmosphere/connections/42/posts' )
+			.reply( 200, { post: { uri: 'at://new', cid: 'newcid', rkey: 'abc' } } );
+
+		const user = userEvent.setup();
+		renderWithProvider( <Harness connectionId={ 42 } /> );
+		await user.click( screen.getByText( 'open' ) );
+		// 301 chars of plain ASCII = 301 graphemes (LIMIT is 300).
+		await user.type( screen.getByRole( 'textbox' ), 'a'.repeat( 301 ) );
+		await user.keyboard( '{Meta>}{Enter}{/Meta}' );
+
+		expect( scope.isDone() ).toBe( false );
+		expect( screen.getByRole( 'dialog' ) ).toBeVisible();
+		nock.cleanAll();
+	}, 15_000 );
+
+	it( 'Keep Editing returns to the draft with text preserved', async () => {
+		const user = userEvent.setup();
+		renderWithProvider( <Harness connectionId={ 42 } /> );
+		await user.click( screen.getByText( 'open' ) );
+		await user.type( screen.getByRole( 'textbox' ), 'hi' );
+		await user.keyboard( '{Escape}' );
+
+		await user.click( await screen.findByRole( 'button', { name: /keep editing/i } ) );
+		// Composer modal still mounted, draft preserved.
+		expect( screen.getByRole( 'dialog', { name: /reply/i } ) ).toBeVisible();
+		expect( screen.getByRole( 'textbox' ) ).toHaveValue( 'hi' );
+		// Discard confirm gone.
+		expect( screen.queryByRole( 'button', { name: /^discard$/i } ) ).toBeNull();
+	} );
+
+	it( 'Discard closes both modals and clears the draft', async () => {
+		const user = userEvent.setup();
+		renderWithProvider( <Harness connectionId={ 42 } /> );
+		await user.click( screen.getByText( 'open' ) );
+		await user.type( screen.getByRole( 'textbox' ), 'hi' );
+		await user.keyboard( '{Escape}' );
+
+		await user.click( await screen.findByRole( 'button', { name: /^discard$/i } ) );
+		await waitFor( () => expect( screen.queryByRole( 'dialog' ) ).toBeNull() );
+
+		// Reopening the composer starts from a clean draft.
+		await user.click( screen.getByText( 'open' ) );
+		expect( screen.getByRole( 'textbox' ) ).toHaveValue( '' );
+	} );
+
+	it( 'recovers after a bad_request error: edit, resubmit, success closes the modal', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/wpcom/v2/reader/atmosphere/connections/42/posts' )
+			.reply( 400, { error: 'atmosphere_bad_request' } );
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/wpcom/v2/reader/atmosphere/connections/42/posts' )
+			.reply( 200, { post: { uri: 'at://new', cid: 'newcid', rkey: 'abc' } } );
+
+		const user = userEvent.setup();
+		renderWithProvider( <Harness connectionId={ 42 } /> );
+		await user.click( screen.getByText( 'open' ) );
+		await user.type( screen.getByRole( 'textbox' ), 'hi' );
+		await user.click( screen.getByRole( 'button', { name: 'Post' } ) );
+
+		// First submit: error banner appears, modal stays open.
+		expect( await screen.findByText( /shorten/i ) ).toBeVisible();
+		expect( screen.getByRole( 'dialog' ) ).toBeVisible();
+
+		// Edit and resubmit.
+		await user.type( screen.getByRole( 'textbox' ), ' more' );
+		await user.click( screen.getByRole( 'button', { name: 'Post' } ) );
+
+		// Modal closes after the successful retry.
+		await waitFor( () => expect( nock.isDone() ).toBe( true ) );
+		await waitFor( () => expect( screen.queryByRole( 'dialog' ) ).toBeNull() );
+	} );
 } );

--- a/client/reader/atmosphere/composer/test/composer-modal.test.tsx
+++ b/client/reader/atmosphere/composer/test/composer-modal.test.tsx
@@ -75,6 +75,7 @@ describe( '<ComposerModal>', () => {
 			.spyOn( analytics, 'recordReaderTracksEvent' )
 			.mockImplementation( () => ( { type: '@@TEST/NOOP' } ) as never );
 		jest.spyOn( noticeActions, 'successNotice' );
+		( page as unknown as jest.Mock ).mockReset();
 	} );
 
 	afterEach( () => {

--- a/client/reader/atmosphere/composer/test/composer-modal.test.tsx
+++ b/client/reader/atmosphere/composer/test/composer-modal.test.tsx
@@ -183,4 +183,51 @@ describe( '<ComposerModal>', () => {
 			)
 		);
 	} );
+
+	// jsdom does not implement the browser focus-trap that
+	// `@wordpress/components` Modal uses (it relies on real focusable-
+	// element traversal, which jsdom only partially models — the first
+	// Tab from the textarea lands on `document.body` instead of
+	// wrapping). Real browsers handle this correctly, and Playwright
+	// E2E coverage backs it up. Keeping the test in source as `.skip`
+	// so the intent is documented for the next time the modal wrapper
+	// changes.
+	it.skip( 'traps focus inside the dialog', async () => {
+		const user = userEvent.setup();
+		renderWithProvider( <Harness connectionId={ 42 } /> );
+		await user.click( screen.getByText( 'open' ) );
+
+		const dialog = await screen.findByRole( 'dialog' );
+
+		for ( let i = 0; i < 3; i++ ) {
+			await user.tab();
+			expect( document.activeElement ).not.toBe( document.body );
+			expect( dialog.contains( document.activeElement ) ).toBe( true );
+		}
+	} );
+
+	it( 'exposes the count via aria-describedby on the textarea', async () => {
+		const user = userEvent.setup();
+		renderWithProvider( <Harness connectionId={ 42 } /> );
+		await user.click( screen.getByText( 'open' ) );
+
+		const textbox = screen.getByRole( 'textbox' );
+		const id = textbox.getAttribute( 'aria-describedby' );
+		expect( id ).toBeTruthy();
+		const count = document.getElementById( id! );
+		expect( count ).toBeVisible();
+	} );
+
+	it( 'media button is aria-disabled and tab-reachable inside the dialog', async () => {
+		const user = userEvent.setup();
+		renderWithProvider( <Harness connectionId={ 42 } /> );
+		await user.click( screen.getByText( 'open' ) );
+
+		const media = screen.getByRole( 'button', { name: /add media/i } );
+		expect( media ).toHaveAttribute( 'aria-disabled', 'true' );
+		// The native HTML `disabled` attribute would remove the button
+		// from the tab order. We use aria-disabled so screen-reader
+		// users can reach the placeholder while it remains inert.
+		expect( media ).not.toBeDisabled();
+	} );
 } );

--- a/client/reader/atmosphere/composer/test/composer-modal.test.tsx
+++ b/client/reader/atmosphere/composer/test/composer-modal.test.tsx
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import page from '@automattic/calypso-router';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
@@ -9,6 +10,11 @@ import * as analytics from 'calypso/state/reader/analytics/actions';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { ComposerModal } from '../composer-modal';
 import { ComposerProvider, useComposer } from '../composer-provider';
+
+jest.mock( '@automattic/calypso-router', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
 
 function makePreview() {
 	return {
@@ -370,5 +376,35 @@ describe( '<ComposerModal>', () => {
 
 		await waitFor( () => expect( successSpy ).toHaveBeenCalled() );
 		expect( successSpy.mock.calls[ 0 ][ 0 ] ).toBe( 'Your reply was posted.' );
+	} );
+
+	it( 'success notice carries a View button that navigates to the parent thread', async () => {
+		const successSpy = noticeActions.successNotice as unknown as jest.Mock;
+		const pageMock = page as unknown as jest.Mock;
+
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/wpcom/v2/reader/atmosphere/connections/42/posts' )
+			.reply( 200, { post: { uri: 'at://new', cid: 'newcid', rkey: 'abc' } } );
+
+		const user = userEvent.setup();
+		renderWithProvider( <Harness connectionId={ 42 } /> );
+		await user.click( screen.getByText( 'open' ) );
+		await user.type( screen.getByRole( 'textbox' ), 'hi' );
+		await user.click( screen.getByRole( 'button', { name: 'Post' } ) );
+
+		await waitFor( () => expect( successSpy ).toHaveBeenCalled() );
+
+		const [ , options ] = successSpy.mock.calls[ 0 ];
+		expect( options ).toEqual(
+			expect.objectContaining( {
+				button: 'View',
+				onClick: expect.any( Function ),
+			} )
+		);
+
+		options.onClick();
+		expect( pageMock ).toHaveBeenCalledWith(
+			'/reader/atmosphere/42/thread/did:plc:abcdefghijklmnopqrstuvwx/bbbbbbbbbbbbb'
+		);
 	} );
 } );

--- a/client/reader/atmosphere/composer/test/composer-modal.test.tsx
+++ b/client/reader/atmosphere/composer/test/composer-modal.test.tsx
@@ -12,7 +12,7 @@ import { ComposerProvider, useComposer } from '../composer-provider';
 
 function makePreview() {
 	return {
-		uri: 'at://did:plc:alice/app.bsky.feed.post/bbbbbbbbbbbbb',
+		uri: 'at://did:plc:abcdefghijklmnopqrstuvwx/app.bsky.feed.post/bbbbbbbbbbbbb',
 		cid: 'pcid',
 		author: {
 			did: 'did:plc:alice',
@@ -33,8 +33,14 @@ function TriggerAndModal() {
 				onClick={ () =>
 					openComposer( {
 						kind: 'reply',
-						root: { uri: 'at://did:plc:alice/app.bsky.feed.post/aaaaaaaaaaaaa', cid: 'rcid' },
-						parent: { uri: 'at://did:plc:alice/app.bsky.feed.post/bbbbbbbbbbbbb', cid: 'pcid' },
+						root: {
+							uri: 'at://did:plc:abcdefghijklmnopqrstuvwx/app.bsky.feed.post/aaaaaaaaaaaaa',
+							cid: 'rcid',
+						},
+						parent: {
+							uri: 'at://did:plc:abcdefghijklmnopqrstuvwx/app.bsky.feed.post/bbbbbbbbbbbbb',
+							cid: 'pcid',
+						},
 						previewPost: makePreview(),
 					} )
 				}
@@ -190,8 +196,8 @@ describe( '<ComposerModal>', () => {
 				'calypso_reader_atmosphere_reply_composer_opened',
 				expect.objectContaining( {
 					connection_id: 42,
-					parent_uri: 'at://did:plc:alice/app.bsky.feed.post/bbbbbbbbbbbbb',
-					root_uri: 'at://did:plc:alice/app.bsky.feed.post/aaaaaaaaaaaaa',
+					parent_uri: 'at://did:plc:abcdefghijklmnopqrstuvwx/app.bsky.feed.post/bbbbbbbbbbbbb',
+					root_uri: 'at://did:plc:abcdefghijklmnopqrstuvwx/app.bsky.feed.post/aaaaaaaaaaaaa',
 				} )
 			)
 		);
@@ -205,8 +211,8 @@ describe( '<ComposerModal>', () => {
 				'calypso_reader_atmosphere_reply_published',
 				expect.objectContaining( {
 					connection_id: 42,
-					parent_uri: 'at://did:plc:alice/app.bsky.feed.post/bbbbbbbbbbbbb',
-					root_uri: 'at://did:plc:alice/app.bsky.feed.post/aaaaaaaaaaaaa',
+					parent_uri: 'at://did:plc:abcdefghijklmnopqrstuvwx/app.bsky.feed.post/bbbbbbbbbbbbb',
+					root_uri: 'at://did:plc:abcdefghijklmnopqrstuvwx/app.bsky.feed.post/aaaaaaaaaaaaa',
 				} )
 			)
 		);
@@ -362,8 +368,7 @@ describe( '<ComposerModal>', () => {
 		await user.type( screen.getByRole( 'textbox' ), 'hi' );
 		await user.click( screen.getByRole( 'button', { name: 'Post' } ) );
 
-		await waitFor( () =>
-			expect( successSpy ).toHaveBeenCalledWith( 'Your reply was posted.', expect.anything() )
-		);
+		await waitFor( () => expect( successSpy ).toHaveBeenCalled() );
+		expect( successSpy.mock.calls[ 0 ][ 0 ] ).toBe( 'Your reply was posted.' );
 	} );
 } );

--- a/client/reader/atmosphere/composer/test/composer-pinned-context.test.tsx
+++ b/client/reader/atmosphere/composer/test/composer-pinned-context.test.tsx
@@ -3,7 +3,7 @@
  */
 import { render, screen } from '@testing-library/react';
 import { ComposerPinnedContext } from '../composer-pinned-context';
-import type { ActiveMode } from '../composer-provider';
+import type { ActiveMode, PreviewPost } from '../composer-provider';
 
 const previewPost = {
 	uri: 'at://x',
@@ -47,5 +47,30 @@ describe( '<ComposerPinnedContext>', () => {
 	it( 'renders nothing when mode is null', () => {
 		const { container } = render( <ComposerPinnedContext mode={ null } /> );
 		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'falls back to raw text when previewPost.html is empty', () => {
+		const previewWithoutHtml: PreviewPost = {
+			uri: 'at://x',
+			cid: 'c',
+			author: {
+				did: 'did:plc:alice',
+				handle: 'alice.bsky.social',
+				display_name: 'Alice',
+				avatar: null,
+			},
+			text: 'Plain text only',
+			html: '',
+		};
+		const replyModeNoHtml: ActiveMode = {
+			kind: 'reply',
+			connectionId: 42,
+			root: { uri: 'at://r', cid: 'rcid' },
+			parent: { uri: 'at://p', cid: 'pcid' },
+			previewPost: previewWithoutHtml,
+		};
+		render( <ComposerPinnedContext mode={ replyModeNoHtml } /> );
+		expect( screen.getByText( 'Alice' ) ).toBeVisible();
+		expect( screen.getByText( 'Plain text only' ) ).toBeVisible();
 	} );
 } );

--- a/client/reader/atmosphere/composer/test/composer-pinned-context.test.tsx
+++ b/client/reader/atmosphere/composer/test/composer-pinned-context.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { ComposerPinnedContext } from '../composer-pinned-context';
+import type { ActiveMode } from '../composer-provider';
+
+const previewPost = {
+	uri: 'at://x',
+	cid: 'c',
+	author: {
+		did: 'did:plc:alice',
+		handle: 'alice.bsky.social',
+		display_name: 'Alice',
+		avatar: null,
+	},
+	text: 'Excited to share this!',
+	html: '<p>Excited to share this!</p>',
+};
+
+const replyMode: ActiveMode = {
+	kind: 'reply',
+	connectionId: 1,
+	root: { uri: 'at://x', cid: 'c' },
+	parent: { uri: 'at://x', cid: 'c' },
+	previewPost,
+};
+
+const standaloneMode: ActiveMode = {
+	kind: 'standalone',
+	connectionId: 1,
+};
+
+describe( '<ComposerPinnedContext>', () => {
+	it( 'renders the author chip and post text for reply mode', () => {
+		render( <ComposerPinnedContext mode={ replyMode } /> );
+		expect( screen.getByText( 'Alice' ) ).toBeVisible();
+		expect( screen.getByText( '@alice.bsky.social' ) ).toBeVisible();
+		expect( screen.getByText( /Excited to share this/ ) ).toBeVisible();
+	} );
+
+	it( 'renders nothing for standalone mode', () => {
+		const { container } = render( <ComposerPinnedContext mode={ standaloneMode } /> );
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'renders nothing when mode is null', () => {
+		const { container } = render( <ComposerPinnedContext mode={ null } /> );
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );

--- a/client/reader/atmosphere/composer/test/composer-pinned-context.test.tsx
+++ b/client/reader/atmosphere/composer/test/composer-pinned-context.test.tsx
@@ -54,10 +54,8 @@ describe( '<ComposerPinnedContext>', () => {
 			uri: 'at://x',
 			cid: 'c',
 			author: {
-				did: 'did:plc:alice',
 				handle: 'alice.bsky.social',
 				display_name: 'Alice',
-				avatar: null,
 			},
 			text: 'Plain text only',
 			html: '',

--- a/client/reader/atmosphere/composer/test/composer-provider.test.tsx
+++ b/client/reader/atmosphere/composer/test/composer-provider.test.tsx
@@ -1,7 +1,9 @@
 /**
  * @jest-environment jsdom
  */
-import { renderHook, act } from '@testing-library/react';
+import { render, renderHook, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
 import { ComposerProvider, useComposer } from '../composer-provider';
 
 const wrap = ( connectionId: number ) =>
@@ -34,18 +36,89 @@ describe( 'useComposer', () => {
 		expect( result.current.mode ).toBeNull();
 	} );
 
-	it( 'snapshots connectionId at open time and ignores later prop changes', () => {
-		const { result, rerender } = renderHook( () => useComposer(), { wrapper: wrap( 42 ) } );
-		act( () =>
-			result.current.openComposer( {
-				kind: 'reply',
-				root: { uri: 'at://r', cid: 'rcid' },
-				parent: { uri: 'at://p', cid: 'pcid' },
-				previewPost: makePreview( 'at://p' ),
-			} )
+	it( 'snapshots connectionId at open time and ignores later prop changes', async () => {
+		const user = userEvent.setup();
+
+		function Probe() {
+			const { mode } = useComposer();
+			return <div data-testid="probe">{ mode?.connectionId ?? 'closed' }</div>;
+		}
+
+		function Opener() {
+			const { openComposer } = useComposer();
+			return (
+				<button
+					onClick={ () =>
+						openComposer( {
+							kind: 'reply',
+							root: { uri: 'at://r', cid: 'rcid' },
+							parent: { uri: 'at://p', cid: 'pcid' },
+							previewPost: makePreview( 'at://p' ),
+						} )
+					}
+				>
+					open
+				</button>
+			);
+		}
+
+		function Harness() {
+			const [ connectionId, setConnectionId ] = useState( 42 );
+			return (
+				<>
+					<button onClick={ () => setConnectionId( 99 ) }>bump</button>
+					<ComposerProvider connectionId={ connectionId }>
+						<Probe />
+						<Opener />
+					</ComposerProvider>
+				</>
+			);
+		}
+
+		render( <Harness /> );
+		expect( screen.getByTestId( 'probe' ) ).toHaveTextContent( 'closed' );
+		await user.click( screen.getByRole( 'button', { name: 'open' } ) );
+		expect( screen.getByTestId( 'probe' ) ).toHaveTextContent( '42' );
+		await user.click( screen.getByRole( 'button', { name: 'bump' } ) );
+		expect( screen.getByTestId( 'probe' ) ).toHaveTextContent( '42' );
+	} );
+
+	it( 'restores focus to the trigger after the composer closes', async () => {
+		const user = userEvent.setup();
+
+		function FocusHarness() {
+			const { openComposer, closeComposer, mode } = useComposer();
+			return (
+				<>
+					<button
+						onClick={ () =>
+							openComposer( {
+								kind: 'reply',
+								root: { uri: 'at://r', cid: 'rcid' },
+								parent: { uri: 'at://p', cid: 'pcid' },
+								previewPost: makePreview( 'at://p' ),
+							} )
+						}
+					>
+						open
+					</button>
+					{ mode && <button onClick={ closeComposer }>close</button> }
+				</>
+			);
+		}
+
+		render(
+			<ComposerProvider connectionId={ 42 }>
+				<FocusHarness />
+			</ComposerProvider>
 		);
-		rerender( { wrapper: wrap( 99 ) } as never );
-		expect( result.current.mode?.connectionId ).toBe( 42 );
+
+		const openBtn = screen.getByRole( 'button', { name: 'open' } );
+		openBtn.focus();
+		await user.click( openBtn );
+		const closeBtn = await screen.findByRole( 'button', { name: 'close' } );
+		await user.click( closeBtn );
+		expect( document.activeElement ).toBe( openBtn );
 	} );
 
 	it( 'throws if useComposer is called outside ComposerProvider', () => {

--- a/client/reader/atmosphere/composer/test/composer-provider.test.tsx
+++ b/client/reader/atmosphere/composer/test/composer-provider.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook, act } from '@testing-library/react';
+import { ComposerProvider, useComposer } from '../composer-provider';
+
+const wrap = ( connectionId: number ) =>
+	function Wrapper( { children }: { children: React.ReactNode } ) {
+		return <ComposerProvider connectionId={ connectionId }>{ children }</ComposerProvider>;
+	};
+
+describe( 'useComposer', () => {
+	it( 'starts with mode = null', () => {
+		const { result } = renderHook( () => useComposer(), { wrapper: wrap( 42 ) } );
+		expect( result.current.mode ).toBeNull();
+	} );
+
+	it( 'openComposer sets mode + connectionId; closeComposer clears it', () => {
+		const { result } = renderHook( () => useComposer(), { wrapper: wrap( 42 ) } );
+		act( () => {
+			result.current.openComposer( {
+				kind: 'reply',
+				root: { uri: 'at://r', cid: 'rcid' },
+				parent: { uri: 'at://p', cid: 'pcid' },
+				previewPost: makePreview( 'at://p' ),
+			} );
+		} );
+		expect( result.current.mode ).toMatchObject( {
+			kind: 'reply',
+			connectionId: 42,
+			root: { uri: 'at://r', cid: 'rcid' },
+		} );
+		act( () => result.current.closeComposer() );
+		expect( result.current.mode ).toBeNull();
+	} );
+
+	it( 'snapshots connectionId at open time and ignores later prop changes', () => {
+		const { result, rerender } = renderHook( () => useComposer(), { wrapper: wrap( 42 ) } );
+		act( () =>
+			result.current.openComposer( {
+				kind: 'reply',
+				root: { uri: 'at://r', cid: 'rcid' },
+				parent: { uri: 'at://p', cid: 'pcid' },
+				previewPost: makePreview( 'at://p' ),
+			} )
+		);
+		rerender( { wrapper: wrap( 99 ) } as never );
+		expect( result.current.mode?.connectionId ).toBe( 42 );
+	} );
+
+	it( 'throws if useComposer is called outside ComposerProvider', () => {
+		expect( () => renderHook( () => useComposer() ) ).toThrow();
+	} );
+} );
+
+function makePreview( uri: string ) {
+	return {
+		uri,
+		cid: 'c',
+		author: { did: 'did:plc:x', handle: 'h', display_name: 'd', avatar: null },
+		text: 't',
+		html: '<p>t</p>',
+	};
+}

--- a/client/reader/atmosphere/composer/test/composer-textarea.test.tsx
+++ b/client/reader/atmosphere/composer/test/composer-textarea.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { ComposerTextarea } from '../composer-textarea';
+
+describe( '<ComposerTextarea>', () => {
+	it( 'auto-focuses on mount', () => {
+		render(
+			<ComposerTextarea
+				value=""
+				onChange={ () => {} }
+				onSubmit={ () => {} }
+				placeholder="Replying"
+			/>
+		);
+		expect( screen.getByRole( 'textbox' ) ).toHaveFocus();
+	} );
+
+	it( 'calls onChange with the typed value', async () => {
+		const user = userEvent.setup();
+
+		function Wrapper() {
+			const [ v, setV ] = useState( '' );
+			return (
+				<ComposerTextarea value={ v } onChange={ setV } onSubmit={ () => {} } placeholder="x" />
+			);
+		}
+
+		render( <Wrapper /> );
+		await user.type( screen.getByRole( 'textbox' ), 'hi' );
+		expect( screen.getByRole( 'textbox' ) ).toHaveValue( 'hi' );
+	} );
+
+	it( 'submits on Cmd+Enter', async () => {
+		const onSubmit = jest.fn();
+		const user = userEvent.setup();
+		render(
+			<ComposerTextarea value="ready" onChange={ () => {} } onSubmit={ onSubmit } placeholder="x" />
+		);
+		await user.type( screen.getByRole( 'textbox' ), '{Meta>}{Enter}{/Meta}' );
+		expect( onSubmit ).toHaveBeenCalled();
+	} );
+
+	it( 'does not submit on plain Enter', async () => {
+		const onSubmit = jest.fn();
+		const user = userEvent.setup();
+		render(
+			<ComposerTextarea value="ready" onChange={ () => {} } onSubmit={ onSubmit } placeholder="x" />
+		);
+		await user.type( screen.getByRole( 'textbox' ), '{Enter}' );
+		expect( onSubmit ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/reader/atmosphere/composer/test/grapheme-count.test.ts
+++ b/client/reader/atmosphere/composer/test/grapheme-count.test.ts
@@ -1,0 +1,29 @@
+import { countGraphemes } from '../grapheme-count';
+
+describe( 'countGraphemes', () => {
+	it( 'counts plain ASCII characters one per character', () => {
+		expect( countGraphemes( 'hello' ) ).toBe( 5 );
+	} );
+
+	it( 'counts a multi-codepoint emoji as a single grapheme', () => {
+		// U+1F468 U+200D U+1F469 U+200D U+1F467 — family emoji
+		expect( countGraphemes( '👨‍👩‍👧' ) ).toBe( 1 );
+	} );
+
+	it( 'counts a flag emoji as a single grapheme', () => {
+		expect( countGraphemes( '🇫🇷' ) ).toBe( 1 );
+	} );
+
+	it( 'counts CRLF as a single grapheme', () => {
+		expect( countGraphemes( '\r\n' ) ).toBe( 1 );
+	} );
+
+	it( 'counts an empty string as zero', () => {
+		expect( countGraphemes( '' ) ).toBe( 0 );
+	} );
+
+	it( 'counts mixed text + emoji correctly', () => {
+		// h, i, space, 👋, space, t, h, e, r, e — 10 graphemes.
+		expect( countGraphemes( 'hi 👋 there' ) ).toBe( 10 );
+	} );
+} );

--- a/client/reader/atmosphere/connect-form.tsx
+++ b/client/reader/atmosphere/connect-form.tsx
@@ -84,6 +84,15 @@ function errorMessage(
 		case 'connection_not_found':
 		case 'not_found':
 		case 'bad_request':
+		// The slice 7c POST /posts wire codes shouldn't surface from the
+		// connect form (it doesn't post), but the AtmosphereError union
+		// covers the whole atmosphere surface, so list them explicitly to
+		// keep `assertNever` exhaustive without changing the user-visible
+		// copy on this screen.
+		case 'text_too_long':
+		case 'reply_disabled':
+		case 'quote_disabled':
+		case 'target_unavailable':
 		case 'unknown':
 			return translate( 'Something went wrong.' );
 		default:

--- a/client/reader/atmosphere/test/timeline-panel.test.tsx
+++ b/client/reader/atmosphere/test/timeline-panel.test.tsx
@@ -659,3 +659,143 @@ describe( 'TimelinePanel — reply composer integration', () => {
 		expect( timeline?.pages[ 0 ].items[ 0 ].counts.replies ).toBe( 2 );
 	} );
 } );
+
+describe( 'TimelinePanel — reply composer errors', () => {
+	beforeEach( () => {
+		jest
+			.spyOn( analytics, 'recordReaderTracksEvent' )
+			.mockImplementation( () => ( { type: '@@TEST/NOOP' } ) as never );
+	} );
+
+	afterEach( () => {
+		nock.cleanAll();
+		jest.restoreAllMocks();
+	} );
+
+	function makeOnePagePayload(
+		uri: string,
+		cid: string,
+		counts: { replies: number; reposts: number; likes: number; quotes: number }
+	): InfiniteData< AtmosphereTimelinePage > {
+		const item: AtmosphereFeedItem = {
+			...makePost( uri, 'parent post' ),
+			cid,
+			counts,
+		};
+		return {
+			pages: [ { items: [ item ], cursor: null } ],
+			pageParams: [ undefined ],
+		};
+	}
+
+	const ERROR_CASES = [
+		{
+			status: 400,
+			code: 'atmosphere_bad_request',
+			kind: 'bad_request',
+			copy: /shorten/i,
+		},
+		{
+			status: 401,
+			code: 'atmosphere_auth_required',
+			kind: 'auth_required',
+			copy: /reconnected/i,
+		},
+		{
+			status: 429,
+			code: 'atmosphere_rate_limited',
+			kind: 'rate_limited',
+			copy: /posting too quickly/i,
+		},
+		{
+			status: 502,
+			code: 'atmosphere_upstream_unavailable',
+			kind: 'upstream_unavailable',
+			copy: /taking longer/i,
+		},
+	] as const;
+
+	it.each( ERROR_CASES )(
+		'maps HTTP $status to kind $kind, keeps modal + draft, and fires _error_shown',
+		async ( { status, code, kind, copy } ) => {
+			const recordSpy = analytics.recordReaderTracksEvent as unknown as jest.Mock;
+
+			const queryClient = makeQueryClient();
+			queryClient.setQueryData(
+				readerAtmosphereKeys.timeline( 42 ),
+				makeOnePagePayload( 'at://parent', 'pcid', {
+					replies: 1,
+					reposts: 0,
+					likes: 0,
+					quotes: 0,
+				} )
+			);
+
+			nock( BASE )
+				.post( '/wpcom/v2/reader/atmosphere/connections/42/posts' )
+				.reply( status, { error: code } );
+
+			const user = userEvent.setup();
+			renderWithProvider(
+				<ComposerProvider connectionId={ 42 }>
+					<TimelinePanel connection={ connection } />
+					<ComposerModal />
+				</ComposerProvider>,
+				{ queryClient }
+			);
+
+			await user.click( await screen.findByRole( 'button', { name: /reply/i } ) );
+			await user.type( screen.getByRole( 'textbox' ), 'hi' );
+			await user.click( screen.getByRole( 'button', { name: 'Post' } ) );
+
+			await screen.findByText( copy );
+			expect( screen.getByRole( 'dialog' ) ).toBeVisible();
+			expect( screen.getByRole( 'textbox' ) ).toHaveValue( 'hi' );
+
+			await waitFor( () =>
+				expect( recordSpy ).toHaveBeenCalledWith(
+					'calypso_reader_atmosphere_reply_error_shown',
+					expect.objectContaining( {
+						connection_id: 42,
+						parent_uri: 'at://parent',
+						error_kind: kind,
+					} )
+				)
+			);
+		}
+	);
+
+	it( 'auth_required Reconnect link opens in a new tab with rel=noopener', async () => {
+		const queryClient = makeQueryClient();
+		queryClient.setQueryData(
+			readerAtmosphereKeys.timeline( 42 ),
+			makeOnePagePayload( 'at://parent', 'pcid', {
+				replies: 1,
+				reposts: 0,
+				likes: 0,
+				quotes: 0,
+			} )
+		);
+
+		nock( BASE )
+			.post( '/wpcom/v2/reader/atmosphere/connections/42/posts' )
+			.reply( 401, { error: 'atmosphere_auth_required' } );
+
+		const user = userEvent.setup();
+		renderWithProvider(
+			<ComposerProvider connectionId={ 42 }>
+				<TimelinePanel connection={ connection } />
+				<ComposerModal />
+			</ComposerProvider>,
+			{ queryClient }
+		);
+
+		await user.click( await screen.findByRole( 'button', { name: /reply/i } ) );
+		await user.type( screen.getByRole( 'textbox' ), 'hi' );
+		await user.click( screen.getByRole( 'button', { name: 'Post' } ) );
+
+		const reconnect = await screen.findByRole( 'link', { name: /reconnect/i } );
+		expect( reconnect ).toHaveAttribute( 'target', '_blank' );
+		expect( reconnect ).toHaveAttribute( 'rel', expect.stringContaining( 'noopener' ) );
+	} );
+} );

--- a/client/reader/atmosphere/test/timeline-panel.test.tsx
+++ b/client/reader/atmosphere/test/timeline-panel.test.tsx
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { readerAtmosphereKeys } from '@automattic/api-core';
 import { QueryClient } from '@tanstack/react-query';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -8,8 +9,14 @@ import nock from 'nock';
 import { mockAllIsIntersecting } from 'react-intersection-observer/test-utils';
 import * as analytics from 'calypso/state/reader/analytics/actions';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { ComposerModal, ComposerProvider } from '../composer';
 import { TimelinePanel } from '../timeline-panel';
-import type { AtmosphereConnection } from '@automattic/api-core';
+import type {
+	AtmosphereConnection,
+	AtmosphereFeedItem,
+	AtmosphereTimelinePage,
+} from '@automattic/api-core';
+import type { InfiniteData } from '@tanstack/react-query';
 
 const connection: AtmosphereConnection = {
 	id: 42,
@@ -576,5 +583,79 @@ describe( 'TimelinePanel — slice 6 author chip + repost preface rewrites', () 
 				destination: 'in_app',
 			} )
 		);
+	} );
+} );
+
+describe( 'TimelinePanel — reply composer integration', () => {
+	beforeEach( () => {
+		jest
+			.spyOn( analytics, 'recordReaderTracksEvent' )
+			.mockImplementation( () => ( { type: '@@TEST/NOOP' } ) as never );
+	} );
+
+	afterEach( () => {
+		nock.cleanAll();
+		jest.restoreAllMocks();
+	} );
+
+	function makeOnePagePayload(
+		uri: string,
+		cid: string,
+		counts: { replies: number; reposts: number; likes: number; quotes: number }
+	): InfiniteData< AtmosphereTimelinePage > {
+		const item: AtmosphereFeedItem = {
+			...makePost( uri, 'parent post' ),
+			cid,
+			counts,
+		};
+		return {
+			pages: [ { items: [ item ], cursor: null } ],
+			pageParams: [ undefined ],
+		};
+	}
+
+	it( 'opens the reply composer from the replies count and posts on submit', async () => {
+		const queryClient = makeQueryClient();
+		queryClient.setQueryData(
+			readerAtmosphereKeys.timeline( 42 ),
+			makeOnePagePayload( 'at://parent', 'pcid', {
+				replies: 1,
+				reposts: 0,
+				likes: 0,
+				quotes: 0,
+			} )
+		);
+
+		nock( BASE )
+			.post( '/wpcom/v2/reader/atmosphere/connections/42/posts', {
+				text: 'great post',
+				reply: {
+					root: { uri: 'at://parent', cid: 'pcid' },
+					parent: { uri: 'at://parent', cid: 'pcid' },
+				},
+			} )
+			.reply( 200, { post: { uri: 'at://new', cid: 'newcid', rkey: 'r' } } );
+
+		const user = userEvent.setup();
+		renderWithProvider(
+			<ComposerProvider connectionId={ 42 }>
+				<TimelinePanel connection={ connection } />
+				<ComposerModal />
+			</ComposerProvider>,
+			{ queryClient }
+		);
+
+		await user.click( await screen.findByRole( 'button', { name: /reply/i } ) );
+		expect( await screen.findByRole( 'dialog', { name: /reply/i } ) ).toBeVisible();
+		await user.type( screen.getByRole( 'textbox' ), 'great post' );
+		await user.click( screen.getByRole( 'button', { name: 'Post' } ) );
+
+		await waitFor( () => expect( nock.isDone() ).toBe( true ) );
+		await waitFor( () => expect( screen.queryByRole( 'dialog' ) ).toBeNull() );
+
+		const timeline = queryClient.getQueryData< InfiniteData< AtmosphereTimelinePage > >(
+			readerAtmosphereKeys.timeline( 42 )
+		);
+		expect( timeline?.pages[ 0 ].items[ 0 ].counts.replies ).toBe( 2 );
 	} );
 } );

--- a/client/reader/atmosphere/test/timeline-panel.test.tsx
+++ b/client/reader/atmosphere/test/timeline-panel.test.tsx
@@ -6,6 +6,7 @@ import { QueryClient } from '@tanstack/react-query';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
+import { useState } from 'react';
 import { mockAllIsIntersecting } from 'react-intersection-observer/test-utils';
 import * as analytics from 'calypso/state/reader/analytics/actions';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
@@ -797,5 +798,135 @@ describe( 'TimelinePanel — reply composer errors', () => {
 		const reconnect = await screen.findByRole( 'link', { name: /reconnect/i } );
 		expect( reconnect ).toHaveAttribute( 'target', '_blank' );
 		expect( reconnect ).toHaveAttribute( 'rel', expect.stringContaining( 'noopener' ) );
+	} );
+} );
+
+describe( 'TimelinePanel — reply composer optimistic + stickiness', () => {
+	beforeEach( () => {
+		jest
+			.spyOn( analytics, 'recordReaderTracksEvent' )
+			.mockImplementation( () => ( { type: '@@TEST/NOOP' } ) as never );
+	} );
+
+	afterEach( () => {
+		nock.cleanAll();
+		jest.restoreAllMocks();
+	} );
+
+	function makeOnePagePayload(
+		uri: string,
+		cid: string,
+		counts: { replies: number; reposts: number; likes: number; quotes: number }
+	): InfiniteData< AtmosphereTimelinePage > {
+		const item: AtmosphereFeedItem = {
+			...makePost( uri, 'parent post' ),
+			cid,
+			counts,
+		};
+		return {
+			pages: [ { items: [ item ], cursor: null } ],
+			pageParams: [ undefined ],
+		};
+	}
+
+	it( 'rolls back the optimistic counts.replies bump on 502', async () => {
+		const queryClient = makeQueryClient();
+		queryClient.setQueryData(
+			readerAtmosphereKeys.timeline( 42 ),
+			makeOnePagePayload( 'at://parent', 'pcid', {
+				replies: 1,
+				reposts: 0,
+				likes: 0,
+				quotes: 0,
+			} )
+		);
+
+		nock( BASE )
+			.post( '/wpcom/v2/reader/atmosphere/connections/42/posts' )
+			.reply( 502, { error: 'atmosphere_upstream_unavailable' } );
+
+		const user = userEvent.setup();
+		renderWithProvider(
+			<ComposerProvider connectionId={ 42 }>
+				<TimelinePanel connection={ connection } />
+				<ComposerModal />
+			</ComposerProvider>,
+			{ queryClient }
+		);
+
+		await user.click( await screen.findByRole( 'button', { name: /reply/i } ) );
+		await user.type( screen.getByRole( 'textbox' ), 'hi' );
+		await user.click( screen.getByRole( 'button', { name: 'Post' } ) );
+
+		await screen.findByText( /taking longer/i );
+
+		await waitFor( () => {
+			const timeline = queryClient.getQueryData< InfiniteData< AtmosphereTimelinePage > >(
+				readerAtmosphereKeys.timeline( 42 )
+			);
+			expect( timeline?.pages[ 0 ].items[ 0 ].counts.replies ).toBe( 1 );
+		} );
+	} );
+
+	it( 'submits to the connection that was active when the composer opened, even if the active connection changes mid-flight', async () => {
+		// Seed the timeline cache for connection 42 so the parent post is rendered.
+		const queryClient = makeQueryClient();
+		queryClient.setQueryData(
+			readerAtmosphereKeys.timeline( 42 ),
+			makeOnePagePayload( 'at://parent', 'pcid', {
+				replies: 1,
+				reposts: 0,
+				likes: 0,
+				quotes: 0,
+			} )
+		);
+
+		// Only mock /connections/42/posts. If the harness submits to /99 the
+		// request will not be matched and the test will fail.
+		const scope = nock( BASE )
+			.post( '/wpcom/v2/reader/atmosphere/connections/42/posts' )
+			.reply( 200, { post: { uri: 'at://new', cid: 'newcid', rkey: 'r' } } );
+
+		const connection99: AtmosphereConnection = {
+			id: 99,
+			did: 'did:plc:other',
+			handle: 'bob.bsky.social',
+			display_name: 'Bob',
+			avatar: null,
+		};
+
+		function ConnectionSwitchHarness() {
+			const [ id, setId ] = useState( 42 );
+			const activeConnection = id === 42 ? connection : connection99;
+			return (
+				<>
+					<button onClick={ () => setId( 99 ) }>switch</button>
+					<ComposerProvider connectionId={ id }>
+						<TimelinePanel connection={ activeConnection } />
+						<ComposerModal />
+					</ComposerProvider>
+				</>
+			);
+		}
+
+		const user = userEvent.setup();
+		renderWithProvider( <ConnectionSwitchHarness />, { queryClient } );
+
+		// Open the composer while connection 42 is active. The composer
+		// snapshots `connectionId: 42` into its mode at this point.
+		await user.click( await screen.findByRole( 'button', { name: /reply/i } ) );
+		expect( await screen.findByRole( 'dialog', { name: /reply/i } ) ).toBeVisible();
+
+		await user.type( screen.getByRole( 'textbox' ), 'hi' );
+
+		// Switch the provider's connectionId to 99 mid-flight. The modal
+		// stays open with its snapshotted 42.
+		await user.click( screen.getByText( 'switch' ) );
+		expect( screen.getByRole( 'dialog', { name: /reply/i } ) ).toBeVisible();
+
+		await user.click( screen.getByRole( 'button', { name: 'Post' } ) );
+
+		// nock will only match if the request went to /connections/42/posts.
+		await waitFor( () => expect( scope.isDone() ).toBe( true ) );
 	} );
 } );

--- a/client/reader/atmosphere/thread-panel.tsx
+++ b/client/reader/atmosphere/thread-panel.tsx
@@ -8,6 +8,7 @@ import { ThunkDispatch } from 'redux-thunk';
 import EmptyContent from 'calypso/components/empty-content';
 import { SocialAnalyticsProvider } from 'calypso/reader/social';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import { useOptionalComposer } from './composer';
 import {
 	getProfileUrl as buildProfileUrl,
 	getTagFeedUrl as buildTagUrl,
@@ -23,6 +24,7 @@ import type {
 	AtmosphereError,
 	AtmosphereThreadNode,
 } from '@automattic/api-core';
+import type { SocialPost } from 'calypso/reader/social';
 import type { AppState } from 'calypso/types';
 
 interface ThreadPanelProps {
@@ -125,6 +127,31 @@ export function ThreadPanel( { connection, did, rkey }: ThreadPanelProps ) {
 		[ connection.id ]
 	);
 
+	const composer = useOptionalComposer();
+	const openComposer = composer?.openComposer;
+	const onReplyClick = useMemo( () => {
+		if ( ! openComposer ) {
+			return undefined;
+		}
+		return ( post: SocialPost ) => {
+			if ( ! post.cid ) {
+				return;
+			}
+			const parent = { uri: post.uri, cid: post.cid };
+			// See timeline-panel.tsx for the cid-stand-in rationale: the
+			// shared `SocialPost` shape doesn't carry a root cid, so we
+			// reuse the parent's. The backend authoritatively resolves
+			// both refs server-side from the URIs.
+			const root = post.reply_root ? { uri: post.reply_root.uri, cid: post.cid } : parent;
+			openComposer( {
+				kind: 'reply',
+				root,
+				parent,
+				previewPost: post,
+			} );
+		};
+	}, [ openComposer ] );
+
 	const analyticsValue = useMemo(
 		() => ( {
 			source: 'atmosphere' as const,
@@ -133,8 +160,9 @@ export function ThreadPanel( { connection, did, rkey }: ThreadPanelProps ) {
 			getThreadUrl,
 			getProfileUrl,
 			getTagUrl,
+			onReplyClick,
 		} ),
-		[ connection.id, onClickAnalytics, getThreadUrl, getProfileUrl, getTagUrl ]
+		[ connection.id, onClickAnalytics, getThreadUrl, getProfileUrl, getTagUrl, onReplyClick ]
 	);
 
 	return (

--- a/client/reader/atmosphere/thread-panel.tsx
+++ b/client/reader/atmosphere/thread-panel.tsx
@@ -138,11 +138,13 @@ export function ThreadPanel( { connection, did, rkey }: ThreadPanelProps ) {
 				return;
 			}
 			const parent = { uri: post.uri, cid: post.cid };
-			// See timeline-panel.tsx for the cid-stand-in rationale: the
-			// shared `SocialPost` shape doesn't carry a root cid, so we
-			// reuse the parent's. The backend authoritatively resolves
-			// both refs server-side from the URIs.
-			const root = post.reply_root ? { uri: post.reply_root.uri, cid: post.cid } : parent;
+			// See timeline-panel.tsx for the rationale. Prefer the root's
+			// own `cid` from `reply_root` so reply-to-reply submissions send
+			// the real root strong-ref; fall back to the parent's `cid` for
+			// protocols without CIDs or older backend payloads.
+			const root = post.reply_root
+				? { uri: post.reply_root.uri, cid: post.reply_root.cid ?? post.cid }
+				: parent;
 			openComposer( {
 				kind: 'reply',
 				root,

--- a/client/reader/atmosphere/timeline-panel.tsx
+++ b/client/reader/atmosphere/timeline-panel.tsx
@@ -121,11 +121,14 @@ export function TimelinePanel( { connection }: TimelinePanelProps ) {
 			const parent = { uri: post.uri, cid: post.cid };
 			// `reply_root` is null when the post itself is the root of its
 			// thread; in that case the post is also its own root. When set,
-			// the timeline shape only carries the root's URI (no `cid`).
-			// Reuse the parent's cid as the best available stand-in — the
-			// backend authoritatively resolves both refs server-side from
-			// the supplied URIs when it constructs the AT Protocol record.
-			const root = post.reply_root ? { uri: post.reply_root.uri, cid: post.cid } : parent;
+			// prefer the root's own `cid` (preserved through the atmosphere
+			// mapper) so reply-to-reply submissions round-trip the actual
+			// root strong-ref to AT-Proto's `createRecord`. Fall back to the
+			// parent's `cid` for protocols that don't carry CIDs natively
+			// (Mastodon) or older backend payloads where the field is absent.
+			const root = post.reply_root
+				? { uri: post.reply_root.uri, cid: post.reply_root.cid ?? post.cid }
+				: parent;
 			openComposer( {
 				kind: 'reply',
 				root,

--- a/client/reader/atmosphere/timeline-panel.tsx
+++ b/client/reader/atmosphere/timeline-panel.tsx
@@ -11,6 +11,7 @@ import {
 	mapAtmosphereFeedItemToSocialPost,
 } from 'calypso/reader/social';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import { useOptionalComposer } from './composer';
 import { projectAtmosphereError } from './error-projection';
 import {
 	getProfileUrl as buildProfileUrl,
@@ -107,6 +108,33 @@ export function TimelinePanel( { connection }: TimelinePanelProps ) {
 		[ connection.id ]
 	);
 
+	const composer = useOptionalComposer();
+	const openComposer = composer?.openComposer;
+	const onReplyClick = useMemo( () => {
+		if ( ! openComposer ) {
+			return undefined;
+		}
+		return ( post: SocialPost ) => {
+			if ( ! post.cid ) {
+				return;
+			}
+			const parent = { uri: post.uri, cid: post.cid };
+			// `reply_root` is null when the post itself is the root of its
+			// thread; in that case the post is also its own root. When set,
+			// the timeline shape only carries the root's URI (no `cid`).
+			// Reuse the parent's cid as the best available stand-in — the
+			// backend authoritatively resolves both refs server-side from
+			// the supplied URIs when it constructs the AT Protocol record.
+			const root = post.reply_root ? { uri: post.reply_root.uri, cid: post.cid } : parent;
+			openComposer( {
+				kind: 'reply',
+				root,
+				parent,
+				previewPost: post,
+			} );
+		};
+	}, [ openComposer ] );
+
 	const renderItem = useCallback(
 		( post: SocialPost ) => (
 			<SocialPostCard post={ post } connectionId={ connection.id } variant="default" />
@@ -123,8 +151,9 @@ export function TimelinePanel( { connection }: TimelinePanelProps ) {
 			getThreadUrl,
 			getProfileUrl,
 			getTagUrl,
+			onReplyClick,
 		} ),
-		[ connection.id, onClickAnalytics, getThreadUrl, getProfileUrl, getTagUrl ]
+		[ connection.id, onClickAnalytics, getThreadUrl, getProfileUrl, getTagUrl, onReplyClick ]
 	);
 
 	return (

--- a/client/reader/social/components/post-card/analytics-context.tsx
+++ b/client/reader/social/components/post-card/analytics-context.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, type ReactNode } from 'react';
+import type { SocialPost } from '../../types';
 
 // Tracks event-name contract for shared post-card subcomponents:
 // emit `calypso_reader_<source>_timeline_*` regardless of the surface
@@ -37,6 +38,14 @@ export interface SocialAnalyticsContextValue {
 	 * anchor's external href.
 	 */
 	getTagUrl?: ( tag: string ) => string | null;
+	/**
+	 * Slice 7c: open the reply composer for a post. When bound,
+	 * `<PostCardCounts>` renders the replies count as a button that
+	 * invokes this callback instead of routing to the in-app thread.
+	 * Per-protocol shells without a composer leave it unset and the
+	 * existing in-app-thread / external-thread fallback applies.
+	 */
+	onReplyClick?: ( post: SocialPost ) => void;
 }
 
 const Ctx = createContext< SocialAnalyticsContextValue | null >( null );

--- a/client/reader/social/components/post-card/like-button.tsx
+++ b/client/reader/social/components/post-card/like-button.tsx
@@ -36,6 +36,10 @@ function errorMessageForLike(
 		case 'bad_request':
 		case 'invalid_handle':
 		case 'upstream_unavailable':
+		case 'text_too_long':
+		case 'reply_disabled':
+		case 'quote_disabled':
+		case 'target_unavailable':
 		case 'unknown':
 			return translate( 'Could not save your like. Please try again.' );
 	}

--- a/client/reader/social/components/post-card/post-card-counts.tsx
+++ b/client/reader/social/components/post-card/post-card-counts.tsx
@@ -22,7 +22,7 @@ export function PostCardCounts( { post, connectionId }: PostCardCountsProps ) {
 	const postUri = post.uri;
 	const inAppUrl = analytics?.getThreadUrl?.( postUri ) ?? null;
 
-	const fireRepliesClicked = () => {
+	const fireRepliesClicked = ( destination: 'in_app_thread' | 'bsky_app' | 'composer' ) => {
 		if ( ! analytics ) {
 			return;
 		}
@@ -30,7 +30,7 @@ export function PostCardCounts( { post, connectionId }: PostCardCountsProps ) {
 			connection_id: analytics.connectionId,
 			post_uri: postUri,
 			replies_count: counts.replies,
-			destination: inAppUrl ? 'in_app_thread' : 'bsky_app',
+			destination,
 		} );
 	};
 
@@ -51,15 +51,7 @@ export function PostCardCounts( { post, connectionId }: PostCardCountsProps ) {
 					className="social-post-card-counts__reply-button"
 					onClick={ () => {
 						onReplyClick( post );
-						analytics.onClick(
-							`calypso_reader_${ analytics.source }_timeline_replies_count_clicked`,
-							{
-								connection_id: analytics.connectionId,
-								post_uri: postUri,
-								replies_count: counts.replies,
-								destination: 'composer',
-							}
-						);
+						fireRepliesClicked( 'composer' );
 					} }
 					aria-label={ translate( 'Reply' ) }
 				>
@@ -72,7 +64,7 @@ export function PostCardCounts( { post, connectionId }: PostCardCountsProps ) {
 				<a
 					className="social-post-card-counts__link"
 					href={ inAppUrl }
-					onClick={ fireRepliesClicked }
+					onClick={ () => fireRepliesClicked( inAppUrl ? 'in_app_thread' : 'bsky_app' ) }
 				>
 					{ repliesContent }
 				</a>

--- a/client/reader/social/components/post-card/post-card-counts.tsx
+++ b/client/reader/social/components/post-card/post-card-counts.tsx
@@ -42,14 +42,33 @@ export function PostCardCounts( { post, connectionId }: PostCardCountsProps ) {
 		</>
 	);
 
-	return (
-		<HStack
-			alignment="center"
-			spacing={ 4 }
-			justify="flex-start"
-			className="social-post-card-counts"
-		>
-			{ inAppUrl ? (
+	const renderRepliesNode = () => {
+		if ( analytics?.onReplyClick ) {
+			const onReplyClick = analytics.onReplyClick;
+			return (
+				<button
+					type="button"
+					className="social-post-card-counts__reply-button"
+					onClick={ () => {
+						onReplyClick( post );
+						analytics.onClick(
+							`calypso_reader_${ analytics.source }_timeline_replies_count_clicked`,
+							{
+								connection_id: analytics.connectionId,
+								post_uri: postUri,
+								replies_count: counts.replies,
+								destination: 'composer',
+							}
+						);
+					} }
+					aria-label={ translate( 'Reply' ) }
+				>
+					{ repliesContent }
+				</button>
+			);
+		}
+		if ( inAppUrl ) {
+			return (
 				<a
 					className="social-post-card-counts__link"
 					href={ inAppUrl }
@@ -57,9 +76,19 @@ export function PostCardCounts( { post, connectionId }: PostCardCountsProps ) {
 				>
 					{ repliesContent }
 				</a>
-			) : (
-				<span>{ repliesContent }</span>
-			) }
+			);
+		}
+		return <span>{ repliesContent }</span>;
+	};
+
+	return (
+		<HStack
+			alignment="center"
+			spacing={ 4 }
+			justify="flex-start"
+			className="social-post-card-counts"
+		>
+			{ renderRepliesNode() }
 			<span>
 				<ReaderRepostIcon iconSize={ ICON_SIZE } />
 				<span className="screen-reader-text">{ translate( 'Reposts:' ) } </span>

--- a/client/reader/social/components/post-card/post-card-counts.tsx
+++ b/client/reader/social/components/post-card/post-card-counts.tsx
@@ -43,7 +43,14 @@ export function PostCardCounts( { post, connectionId }: PostCardCountsProps ) {
 	);
 
 	const renderRepliesNode = () => {
-		if ( analytics?.onReplyClick ) {
+		// Mirror the like-button gating: only render the interactive
+		// reply button when we have both an `onReplyClick` handler AND
+		// a strong-ref `cid` to address the post (atmosphere posts
+		// without `cid` would silently no-op the click and emit a
+		// phantom `replies_count_clicked / destination=composer` Tracks
+		// event). Fall through to the in-app/external thread link or
+		// the static count otherwise.
+		if ( analytics?.onReplyClick && post.cid ) {
 			const onReplyClick = analytics.onReplyClick;
 			return (
 				<button

--- a/client/reader/social/components/post-card/post-card-counts.tsx
+++ b/client/reader/social/components/post-card/post-card-counts.tsx
@@ -72,7 +72,7 @@ export function PostCardCounts( { post, connectionId }: PostCardCountsProps ) {
 				<a
 					className="social-post-card-counts__link"
 					href={ inAppUrl }
-					onClick={ () => fireRepliesClicked( inAppUrl ? 'in_app_thread' : 'bsky_app' ) }
+					onClick={ () => fireRepliesClicked( 'in_app_thread' ) }
 				>
 					{ repliesContent }
 				</a>

--- a/client/reader/social/components/post-card/post-card-counts.tsx
+++ b/client/reader/social/components/post-card/post-card-counts.tsx
@@ -61,7 +61,11 @@ export function PostCardCounts( { post, connectionId }: PostCardCountsProps ) {
 						onReplyClick( post );
 						fireRepliesClicked( 'composer' );
 					} }
-					aria-label={ translate( 'Reply' ) }
+					aria-label={ translate( 'Reply, %(count)d reply', 'Reply, %(count)d replies', {
+						count: counts.replies,
+						args: { count: counts.replies },
+						textOnly: true,
+					} ) }
 				>
 					{ repliesContent }
 				</button>

--- a/client/reader/social/components/post-card/repost-button.tsx
+++ b/client/reader/social/components/post-card/repost-button.tsx
@@ -37,6 +37,10 @@ function errorMessageForRepost(
 		case 'bad_request':
 		case 'invalid_handle':
 		case 'upstream_unavailable':
+		case 'text_too_long':
+		case 'reply_disabled':
+		case 'quote_disabled':
+		case 'target_unavailable':
 		case 'unknown':
 			return translate( 'Could not save your repost. Please try again.' );
 	}

--- a/client/reader/social/components/post-card/style.scss
+++ b/client/reader/social/components/post-card/style.scss
@@ -6,6 +6,7 @@
 	.social-post-card-header__reason-author,
 	.social-post-card-header__reply-context-link,
 	.social-post-card-counts__link,
+	.social-post-card-counts__reply-button,
 	.social-post-card-body a,
 	a.social-post-card-embed-external,
 	.social-post-card-embed-quote-link,
@@ -231,7 +232,8 @@ a.social-post-card-header__timestamp::after {
 	gap: 16px;
 
 	span,
-	.social-post-card-counts__link {
+	.social-post-card-counts__link,
+	.social-post-card-counts__reply-button {
 		display: inline-flex;
 		align-items: center;
 		gap: 4px;
@@ -240,6 +242,20 @@ a.social-post-card-header__timestamp::after {
 	.social-post-card-counts__link {
 		color: inherit;
 		text-decoration: none;
+
+		&:hover,
+		&:focus-visible {
+			color: var( --studio-blue-50 );
+		}
+	}
+
+	.social-post-card-counts__reply-button {
+		background: transparent;
+		border: 0;
+		padding: 0;
+		cursor: pointer;
+		color: inherit;
+		font: inherit;
 
 		&:hover,
 		&:focus-visible {

--- a/client/reader/social/components/post-card/test/post-card-counts.test.tsx
+++ b/client/reader/social/components/post-card/test/post-card-counts.test.tsx
@@ -35,7 +35,8 @@ const post: SocialPost = {
 function wrap(
 	ui: React.ReactNode,
 	getThreadUrl?: ( uri: string ) => string | null,
-	onClick = jest.fn()
+	onClick = jest.fn(),
+	onReplyClick?: ( post: SocialPost ) => void
 ) {
 	return (
 		<SocialAnalyticsProvider
@@ -44,6 +45,7 @@ function wrap(
 				connectionId: 7,
 				onClick,
 				getThreadUrl,
+				onReplyClick,
 			} }
 		>
 			{ ui }
@@ -94,5 +96,32 @@ describe( 'PostCardCounts', () => {
 		const button = screen.getByRole( 'button', { name: /like/i } );
 		expect( button ).toHaveAttribute( 'aria-pressed', 'false' );
 		expect( button ).toHaveTextContent( '9' );
+	} );
+
+	it( 'renders replies count as a button that calls onReplyClick when bound', async () => {
+		const onReplyClick = jest.fn();
+		const onClick = jest.fn();
+		const user = userEvent.setup();
+		render( wrap( <PostCardCounts post={ post } />, undefined, onClick, onReplyClick ) );
+		const button = screen.getByRole( 'button', { name: /reply/i } );
+		expect( button ).toHaveTextContent( '5' );
+		await user.click( button );
+		expect( onReplyClick ).toHaveBeenCalledWith( post );
+		expect( onClick ).toHaveBeenCalledWith(
+			expect.stringContaining( '_replies_count_clicked' ),
+			expect.objectContaining( {
+				connection_id: 7,
+				post_uri: post.uri,
+				replies_count: 5,
+				destination: 'composer',
+			} )
+		);
+	} );
+
+	it( 'falls back to a link when onReplyClick is not bound', () => {
+		const getThreadUrl = () => '/threads/x';
+		render( wrap( <PostCardCounts post={ post } />, getThreadUrl ) );
+		const link = screen.getByRole( 'link', { name: /replies/i } );
+		expect( link ).toHaveAttribute( 'href', '/threads/x' );
 	} );
 } );

--- a/client/reader/social/index.ts
+++ b/client/reader/social/index.ts
@@ -38,6 +38,7 @@ export { SocialAuthorProfilePanel } from './author-profile-panel';
 export type { SocialAuthorProfilePanelProps } from './author-profile-panel';
 export { SocialProfileHeaderSkeleton } from './profile-header-skeleton';
 export { mapAtmosphereFeedItemToSocialPost } from './mappers/atmosphere';
+export { sanitizePostHtml } from './components/post-card/sanitize-post-html';
 export {
 	mapMastodonAccountToSocialProfileCardProps,
 	mapMastodonFeedItemToSocialPost,

--- a/client/reader/social/mappers/atmosphere.ts
+++ b/client/reader/social/mappers/atmosphere.ts
@@ -25,10 +25,18 @@ export function mapAtmosphereFeedItemToSocialPost( item: AtmosphereFeedItem ): S
 			profile_url: BSKY_PROFILE_BASE + item.author.handle,
 		},
 		reply_parent: item.reply_parent
-			? { uri: item.reply_parent.uri, author: { handle: item.reply_parent.author.handle } }
+			? {
+					uri: item.reply_parent.uri,
+					cid: item.reply_parent.cid,
+					author: { handle: item.reply_parent.author.handle },
+			  }
 			: null,
 		reply_root: item.reply_root
-			? { uri: item.reply_root.uri, author: { handle: item.reply_root.author.handle } }
+			? {
+					uri: item.reply_root.uri,
+					cid: item.reply_root.cid,
+					author: { handle: item.reply_root.author.handle },
+			  }
 			: null,
 		reason: item.reason
 			? {

--- a/client/reader/social/mappers/test/atmosphere.test.ts
+++ b/client/reader/social/mappers/test/atmosphere.test.ts
@@ -44,4 +44,46 @@ describe( 'mapAtmosphereFeedItemToSocialPost', () => {
 		const post = mapAtmosphereFeedItemToSocialPost( FIXTURE );
 		expect( post.counts ).toEqual( { replies: 1, reposts: 2, likes: 3, quotes: 4 } );
 	} );
+
+	it( 'preserves reply_root and reply_parent strong-ref CIDs', () => {
+		const post = mapAtmosphereFeedItemToSocialPost( {
+			...FIXTURE,
+			reply_parent: {
+				uri: 'at://did:plc:b/app.bsky.feed.post/parent',
+				cid: 'cid-parent',
+				author: { did: 'did:plc:b', handle: 'bob.bsky.social' },
+			},
+			reply_root: {
+				uri: 'at://did:plc:c/app.bsky.feed.post/root',
+				cid: 'cid-root',
+				author: { did: 'did:plc:c', handle: 'carol.bsky.social' },
+			},
+		} );
+		expect( post.reply_parent ).toEqual( {
+			uri: 'at://did:plc:b/app.bsky.feed.post/parent',
+			cid: 'cid-parent',
+			author: { handle: 'bob.bsky.social' },
+		} );
+		expect( post.reply_root ).toEqual( {
+			uri: 'at://did:plc:c/app.bsky.feed.post/root',
+			cid: 'cid-root',
+			author: { handle: 'carol.bsky.social' },
+		} );
+	} );
+
+	it( 'tolerates reply refs without a cid (older backend payloads)', () => {
+		const post = mapAtmosphereFeedItemToSocialPost( {
+			...FIXTURE,
+			reply_parent: {
+				uri: 'at://did:plc:b/app.bsky.feed.post/parent',
+				author: { did: 'did:plc:b', handle: 'bob.bsky.social' },
+			},
+			reply_root: {
+				uri: 'at://did:plc:c/app.bsky.feed.post/root',
+				author: { did: 'did:plc:c', handle: 'carol.bsky.social' },
+			},
+		} );
+		expect( post.reply_parent?.cid ).toBeUndefined();
+		expect( post.reply_root?.cid ).toBeUndefined();
+	} );
 } );

--- a/client/reader/social/types.ts
+++ b/client/reader/social/types.ts
@@ -8,6 +8,12 @@ export interface SocialAuthor {
 
 export interface SocialReplyRef {
 	uri: string;
+	// Strong-ref CID for the referenced record. Optional because not every
+	// protocol exposes one (Mastodon has no native CIDs) and the atmosphere
+	// backend may omit it during the rollout window for `reply_root` /
+	// `reply_parent`. Reply-to-reply submission paths fall back to the
+	// surrounding post's `cid` when this is missing.
+	cid?: string;
 	author: { id?: string; handle: string };
 }
 

--- a/packages/api-core/src/reader-atmosphere/__tests__/errors.test.ts
+++ b/packages/api-core/src/reader-atmosphere/__tests__/errors.test.ts
@@ -65,4 +65,29 @@ describe( 'classifyAtmosphereError', () => {
 			'connection_not_found'
 		);
 	} );
+
+	// Slice 7c POST /reader/atmosphere/connections/{id}/posts ships nine
+	// wire-stable error codes; pin the four newcomers so they don't
+	// silently regress to `{ kind: 'unknown' }` (which renders the generic
+	// "Something went wrong" banner).
+	it( 'maps atmosphere_text_too_long', () => {
+		expect( classifyAtmosphereError( wpErr( 'atmosphere_text_too_long', 400 ) ).kind ).toBe(
+			'text_too_long'
+		);
+	} );
+	it( 'maps atmosphere_reply_disabled', () => {
+		expect( classifyAtmosphereError( wpErr( 'atmosphere_reply_disabled', 403 ) ).kind ).toBe(
+			'reply_disabled'
+		);
+	} );
+	it( 'maps atmosphere_quote_disabled', () => {
+		expect( classifyAtmosphereError( wpErr( 'atmosphere_quote_disabled', 403 ) ).kind ).toBe(
+			'quote_disabled'
+		);
+	} );
+	it( 'maps atmosphere_target_unavailable', () => {
+		expect( classifyAtmosphereError( wpErr( 'atmosphere_target_unavailable', 404 ) ).kind ).toBe(
+			'target_unavailable'
+		);
+	} );
 } );

--- a/packages/api-core/src/reader-atmosphere/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/reader-atmosphere/__tests__/fetchers.test.ts
@@ -946,10 +946,16 @@ describe( 'atmosphere fetchers', () => {
 
 		it.each( [
 			[ 400, 'atmosphere_bad_request', 'bad_request' ],
+			[ 400, 'atmosphere_text_too_long', 'text_too_long' ],
 			[ 401, 'atmosphere_auth_required', 'auth_required' ],
+			[ 401, 'atmosphere_unauthenticated', 'auth_required' ],
+			[ 403, 'atmosphere_reply_disabled', 'reply_disabled' ],
+			[ 403, 'atmosphere_quote_disabled', 'quote_disabled' ],
+			[ 404, 'atmosphere_not_found', 'not_found' ],
+			[ 404, 'atmosphere_target_unavailable', 'target_unavailable' ],
 			[ 429, 'atmosphere_rate_limited', 'rate_limited' ],
 			[ 502, 'atmosphere_upstream_unavailable', 'upstream_unavailable' ],
-		] )( 'classifies HTTP %i as kind %s', async ( status, error, kind ) => {
+		] )( 'classifies HTTP %i %s as kind %s', async ( status, error, kind ) => {
 			nock( BASE )
 				.post( '/wpcom/v2/reader/atmosphere/connections/42/posts' )
 				.reply( status as number, { error } );

--- a/packages/api-core/src/reader-atmosphere/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/reader-atmosphere/__tests__/fetchers.test.ts
@@ -3,6 +3,7 @@ import {
 	createConnection,
 	createFollow,
 	createLike,
+	createPost,
 	deleteFollow,
 	deleteLike,
 	getAtmosphereTagFeed,
@@ -786,6 +787,61 @@ describe( 'atmosphere fetchers', () => {
 			await expect(
 				getAtmosphereTagFeed( { connectionId: 7, hashtag: 'rust' } )
 			).rejects.toMatchObject( { kind: 'rate_limited' } );
+		} );
+	} );
+
+	describe( 'createPost', () => {
+		const connectionId = 42;
+
+		afterEach( () => nock.cleanAll() );
+
+		it( 'POSTs the request body and returns the parsed result', async () => {
+			nock( BASE )
+				.post( '/wpcom/v2/reader/atmosphere/connections/42/posts', {
+					text: 'hi there',
+					reply: {
+						root: { uri: 'at://r', cid: 'rcid' },
+						parent: { uri: 'at://p', cid: 'pcid' },
+					},
+				} )
+				.reply( 200, {
+					post: { uri: 'at://new', cid: 'newcid', rkey: 'abc' },
+				} );
+
+			const result = await createPost( {
+				connectionId,
+				text: 'hi there',
+				reply: {
+					root: { uri: 'at://r', cid: 'rcid' },
+					parent: { uri: 'at://p', cid: 'pcid' },
+				},
+			} );
+
+			expect( result ).toEqual( { uri: 'at://new', cid: 'newcid', rkey: 'abc' } );
+		} );
+
+		it( 'omits reply when posting standalone', async () => {
+			const scope = nock( BASE )
+				.post( '/wpcom/v2/reader/atmosphere/connections/42/posts', ( body ) => {
+					return body.text === 'standalone' && ! body.reply && ! body.quote;
+				} )
+				.reply( 200, { post: { uri: 'at://x', cid: 'xc', rkey: 'r' } } );
+
+			await createPost( { connectionId, text: 'standalone' } );
+			expect( scope.isDone() ).toBe( true );
+		} );
+
+		it.each( [
+			[ 400, 'atmosphere_bad_request', 'bad_request' ],
+			[ 401, 'atmosphere_auth_required', 'auth_required' ],
+			[ 429, 'atmosphere_rate_limited', 'rate_limited' ],
+			[ 502, 'atmosphere_upstream_unavailable', 'upstream_unavailable' ],
+		] )( 'classifies HTTP %i as kind %s', async ( status, error, kind ) => {
+			nock( BASE )
+				.post( '/wpcom/v2/reader/atmosphere/connections/42/posts' )
+				.reply( status as number, { error } );
+
+			await expect( createPost( { connectionId, text: 'x' } ) ).rejects.toMatchObject( { kind } );
 		} );
 	} );
 } );

--- a/packages/api-core/src/reader-atmosphere/constants.ts
+++ b/packages/api-core/src/reader-atmosphere/constants.ts
@@ -6,3 +6,11 @@
  * suppress any DELETE that would race the in-flight POST.
  */
 export const PENDING_LIKE_URI = '__pending_like__';
+
+/**
+ * Sentinel used in the optimistic-update window after a reply-mutation
+ * fires but before the server response lands. Mirrors PENDING_LIKE_URI:
+ * consumers that parse rkeys must treat this value as "no real rkey yet"
+ * and suppress any DELETE that would race the in-flight POST.
+ */
+export const PENDING_REPLY_URI = '__pending_reply__';

--- a/packages/api-core/src/reader-atmosphere/errors.ts
+++ b/packages/api-core/src/reader-atmosphere/errors.ts
@@ -9,6 +9,10 @@ export type AtmosphereError =
 	| { kind: 'rate_limited'; retry_after?: number }
 	| { kind: 'upstream_unavailable' }
 	| { kind: 'bad_request'; message: string | null }
+	| { kind: 'text_too_long' }
+	| { kind: 'reply_disabled' }
+	| { kind: 'quote_disabled' }
+	| { kind: 'target_unavailable' }
 	| { kind: 'unknown'; cause: unknown };
 
 interface WpErrorLike {
@@ -65,6 +69,14 @@ export function classifyAtmosphereError( raw: unknown ): AtmosphereError {
 		case 'bad_request':
 		case 'atmosphere_bad_request':
 			return { kind: 'bad_request', message: raw.message ?? null };
+		case 'atmosphere_text_too_long':
+			return { kind: 'text_too_long' };
+		case 'atmosphere_reply_disabled':
+			return { kind: 'reply_disabled' };
+		case 'atmosphere_quote_disabled':
+			return { kind: 'quote_disabled' };
+		case 'atmosphere_target_unavailable':
+			return { kind: 'target_unavailable' };
 		default:
 			return { kind: 'unknown', cause: raw };
 	}

--- a/packages/api-core/src/reader-atmosphere/fetchers.ts
+++ b/packages/api-core/src/reader-atmosphere/fetchers.ts
@@ -14,6 +14,8 @@ import type {
 	AtmosphereTimelinePage,
 	CreateLikeParams,
 	CreateLikeResult,
+	CreatePostParams,
+	CreatePostResult,
 	DeleteLikeParams,
 } from './types';
 
@@ -257,6 +259,27 @@ export async function createLike( params: CreateLikeParams ): Promise< CreateLik
 			},
 		} ) ) as { like: CreateLikeResult };
 		return res.like;
+	} catch ( raw ) {
+		throw classifyAtmosphereError( raw );
+	}
+}
+
+export async function createPost( params: CreatePostParams ): Promise< CreatePostResult > {
+	const { connectionId, text, reply, quote } = params;
+	const body: Record< string, unknown > = { text };
+	if ( reply ) {
+		body.reply = reply;
+	}
+	if ( quote ) {
+		body.quote = quote;
+	}
+	try {
+		const response = ( await wpcom.req.post( {
+			path: `/reader/atmosphere/connections/${ connectionId }/posts`,
+			apiNamespace: NAMESPACE,
+			body,
+		} ) ) as { post: CreatePostResult };
+		return response.post;
 	} catch ( raw ) {
 		throw classifyAtmosphereError( raw );
 	}

--- a/packages/api-core/src/reader-atmosphere/types.ts
+++ b/packages/api-core/src/reader-atmosphere/types.ts
@@ -311,3 +311,21 @@ export interface AtmosphereTagFeedPage {
 	cursor: string | null;
 	tag?: AtmosphereTagInfo;
 }
+
+export interface AtUriRef {
+	uri: string;
+	cid: string;
+}
+
+export interface CreatePostParams {
+	connectionId: number;
+	text: string;
+	reply?: { root: AtUriRef; parent: AtUriRef };
+	quote?: AtUriRef;
+}
+
+export interface CreatePostResult {
+	uri: string;
+	cid: string;
+	rkey: string;
+}

--- a/packages/api-core/src/reader-atmosphere/types.ts
+++ b/packages/api-core/src/reader-atmosphere/types.ts
@@ -41,6 +41,13 @@ export interface AtmosphereAuthor {
 
 export interface AtmosphereReplyRef {
 	uri: string;
+	// Strong-ref CID for the referenced record. AT-Proto's reply pointers
+	// are `com.atproto.repo.strongRef` pairs ({uri, cid}), so the upstream
+	// data always carries it. Optional in the typed wire shape during the
+	// backend rollout window — older normalizer revisions emit `{uri, author}`
+	// only. Consumers should treat it as a strong-ref hint and fall back to
+	// the post's own cid when missing.
+	cid?: string;
 	author: { did: string; handle: string };
 }
 

--- a/packages/api-queries/src/__tests__/reader-atmosphere.test.tsx
+++ b/packages/api-queries/src/__tests__/reader-atmosphere.test.tsx
@@ -1465,6 +1465,149 @@ describe( 'reader-atmosphere hooks', () => {
 			await promise;
 		} );
 
+		it( 'hydrates the placeholder author from the cached connection', async () => {
+			const client = new QueryClient( { defaultOptions: { mutations: { retry: false } } } );
+			seedThreadWithParent( client );
+			client.setQueryData( readerAtmosphereKeys.connection( connectionId ), {
+				did: 'did:plc:me',
+				handle: 'me.bsky.social',
+				display_name: 'Me',
+				description: '',
+				avatar: 'https://cdn.bsky.app/me/avatar.jpg',
+				banner: null,
+				counts: { followers: 0, follows: 0, posts: 0 },
+			} );
+
+			nock( BASE )
+				.post( `/wpcom/v2/reader/atmosphere/connections/${ connectionId }/posts` )
+				.delay( 50 )
+				.reply( 200, { post: { uri: 'at://new', cid: 'newcid', rkey: 'abc' } } );
+
+			const { result } = renderHook( () => useMutation( createPostMutation( client ) ), {
+				wrapper: makeWrapper( client ),
+			} );
+
+			let promise: Promise< unknown > = Promise.resolve();
+			await act( async () => {
+				promise = result.current.mutateAsync( {
+					connectionId,
+					text: 'reply text',
+					reply: { root, parent },
+				} );
+				await Promise.resolve();
+			} );
+
+			// Optimistic placeholder carries the connection's author.
+			await waitFor( () => {
+				const thread = client.getQueryData< AtmosphereThreadResponse >(
+					readerAtmosphereKeys.thread( root.uri )
+				);
+				if ( thread?.thread.type !== 'post' ) {
+					throw new Error( 'expected root to be a post node' );
+				}
+				const parentNode = thread.thread.replies[ 0 ];
+				if ( parentNode.type !== 'post' ) {
+					throw new Error( 'expected parent to be a post node' );
+				}
+				const placeholder = parentNode.replies[ 0 ];
+				if ( placeholder.type !== 'post' ) {
+					throw new Error( 'expected placeholder to be a post node' );
+				}
+				expect( placeholder.post.author ).toEqual( {
+					did: 'did:plc:me',
+					handle: 'me.bsky.social',
+					display_name: 'Me',
+					avatar: 'https://cdn.bsky.app/me/avatar.jpg',
+				} );
+			} );
+
+			await promise;
+
+			// After onSuccess the rewrite carries the same author through.
+			const settled = client.getQueryData< AtmosphereThreadResponse >(
+				readerAtmosphereKeys.thread( root.uri )
+			);
+			if ( settled?.thread.type !== 'post' ) {
+				throw new Error( 'expected root to be a post node' );
+			}
+			const settledParent = settled.thread.replies[ 0 ];
+			if ( settledParent.type !== 'post' ) {
+				throw new Error( 'expected parent to be a post node' );
+			}
+			const settledReply = settledParent.replies[ 0 ];
+			if ( settledReply.type !== 'post' ) {
+				throw new Error( 'expected reply to be a post node' );
+			}
+			expect( settledReply.post.uri ).toBe( 'at://new' );
+			expect( settledReply.post.cid ).toBe( 'newcid' );
+			expect( settledReply.post.author ).toEqual( {
+				did: 'did:plc:me',
+				handle: 'me.bsky.social',
+				display_name: 'Me',
+				avatar: 'https://cdn.bsky.app/me/avatar.jpg',
+			} );
+		} );
+
+		it( 'fills the placeholder author on success when the connection cache populates after onMutate', async () => {
+			const client = new QueryClient( { defaultOptions: { mutations: { retry: false } } } );
+			seedThreadWithParent( client );
+
+			nock( BASE )
+				.post( `/wpcom/v2/reader/atmosphere/connections/${ connectionId }/posts` )
+				.delay( 50 )
+				.reply( 200, { post: { uri: 'at://new', cid: 'newcid', rkey: 'abc' } } );
+
+			const { result } = renderHook( () => useMutation( createPostMutation( client ) ), {
+				wrapper: makeWrapper( client ),
+			} );
+
+			let promise: Promise< unknown > = Promise.resolve();
+			await act( async () => {
+				promise = result.current.mutateAsync( {
+					connectionId,
+					text: 'reply text',
+					reply: { root, parent },
+				} );
+				await Promise.resolve();
+			} );
+
+			// Connection cache lands while the request is in flight (e.g. a
+			// deep-link path where the shell hydrates the connection
+			// query after the user has already opened the composer).
+			client.setQueryData( readerAtmosphereKeys.connection( connectionId ), {
+				did: 'did:plc:me',
+				handle: 'me.bsky.social',
+				display_name: 'Me',
+				description: '',
+				avatar: null,
+				banner: null,
+				counts: { followers: 0, follows: 0, posts: 0 },
+			} );
+
+			await promise;
+
+			const settled = client.getQueryData< AtmosphereThreadResponse >(
+				readerAtmosphereKeys.thread( root.uri )
+			);
+			if ( settled?.thread.type !== 'post' ) {
+				throw new Error( 'expected root to be a post node' );
+			}
+			const settledParent = settled.thread.replies[ 0 ];
+			if ( settledParent.type !== 'post' ) {
+				throw new Error( 'expected parent to be a post node' );
+			}
+			const settledReply = settledParent.replies[ 0 ];
+			if ( settledReply.type !== 'post' ) {
+				throw new Error( 'expected reply to be a post node' );
+			}
+			expect( settledReply.post.author ).toEqual( {
+				did: 'did:plc:me',
+				handle: 'me.bsky.social',
+				display_name: 'Me',
+				avatar: null,
+			} );
+		} );
+
 		it( 'restores the snapshot on error', async () => {
 			const client = new QueryClient( { defaultOptions: { mutations: { retry: false } } } );
 			const initial = seedThreadWithParent( client );

--- a/packages/api-queries/src/__tests__/reader-atmosphere.test.tsx
+++ b/packages/api-queries/src/__tests__/reader-atmosphere.test.tsx
@@ -1452,7 +1452,10 @@ describe( 'reader-atmosphere hooks', () => {
 				if ( placeholder.type !== 'post' ) {
 					throw new Error( 'expected placeholder to be a post node' );
 				}
-				expect( placeholder.post.uri ).toBe( PENDING_REPLY_URI );
+				// Each in-flight reply is stamped with a unique
+				// `${PENDING_REPLY_URI}#<n>` suffix so concurrent replies
+				// can't collide on rewrite. Match on the prefix.
+				expect( placeholder.post.uri.startsWith( PENDING_REPLY_URI ) ).toBe( true );
 				expect( placeholder.post.text ).toBe( 'reply text' );
 			} );
 
@@ -1521,6 +1524,93 @@ describe( 'reader-atmosphere hooks', () => {
 				readerAtmosphereKeys.timeline( connectionId )
 			);
 			expect( timeline?.pages[ 0 ].items[ 0 ].counts.replies ).toBe( 4 );
+		} );
+
+		it( 'invalidates the thread query when the cache was evicted between onMutate and onSuccess', async () => {
+			const client = new QueryClient( { defaultOptions: { mutations: { retry: false } } } );
+			seedThreadWithParent( client );
+
+			nock( BASE )
+				.post( `/wpcom/v2/reader/atmosphere/connections/${ connectionId }/posts` )
+				.delay( 30 )
+				.reply( 200, { post: { uri: 'at://new', cid: 'newcid', rkey: 'abc' } } );
+
+			const { result } = renderHook( () => useMutation( createPostMutation( client ) ), {
+				wrapper: makeWrapper( client ),
+			} );
+
+			const invalidateSpy = jest.spyOn( client, 'invalidateQueries' );
+
+			let promise: Promise< unknown > = Promise.resolve();
+			await act( async () => {
+				promise = result.current.mutateAsync( {
+					connectionId,
+					text: 'reply text',
+					reply: { root, parent },
+				} );
+				await Promise.resolve();
+			} );
+
+			// Evict the thread cache while the request is in flight, simulating
+			// a route change / gc / removeQueries between onMutate and onSuccess.
+			client.removeQueries( { queryKey: readerAtmosphereKeys.thread( root.uri ) } );
+
+			await promise;
+
+			// onSuccess should have asked the cache to invalidate the thread key
+			// so the user's reply is fetched fresh next time the thread loads.
+			expect(
+				invalidateSpy.mock.calls.some( ( [ filters ] ) => {
+					const queryKey = ( filters as { queryKey?: readonly unknown[] } )?.queryKey;
+					return (
+						Array.isArray( queryKey ) &&
+						JSON.stringify( queryKey ) === JSON.stringify( readerAtmosphereKeys.thread( root.uri ) )
+					);
+				} )
+			).toBe( true );
+		} );
+
+		it( 'invalidates the thread query when the placeholder is no longer in the tree on success', async () => {
+			const client = new QueryClient( { defaultOptions: { mutations: { retry: false } } } );
+			seedThreadWithParent( client );
+
+			nock( BASE )
+				.post( `/wpcom/v2/reader/atmosphere/connections/${ connectionId }/posts` )
+				.delay( 30 )
+				.reply( 200, { post: { uri: 'at://new', cid: 'newcid', rkey: 'abc' } } );
+
+			const { result } = renderHook( () => useMutation( createPostMutation( client ) ), {
+				wrapper: makeWrapper( client ),
+			} );
+
+			const invalidateSpy = jest.spyOn( client, 'invalidateQueries' );
+
+			let promise: Promise< unknown > = Promise.resolve();
+			await act( async () => {
+				promise = result.current.mutateAsync( {
+					connectionId,
+					text: 'reply text',
+					reply: { root, parent },
+				} );
+				await Promise.resolve();
+			} );
+
+			// Simulate a concurrent refetch that drops the placeholder branch
+			// while the request is still in flight: re-seed the thread cache
+			// without the optimistic placeholder.
+			seedThreadWithParent( client );
+
+			await promise;
+
+			expect(
+				invalidateSpy.mock.calls.some( ( [ filters ] ) => {
+					const queryKey = ( filters as { queryKey?: readonly unknown[] } )?.queryKey;
+					return (
+						Array.isArray( queryKey ) &&
+						JSON.stringify( queryKey ) === JSON.stringify( readerAtmosphereKeys.thread( root.uri ) )
+					);
+				} )
+			).toBe( true );
 		} );
 	} );
 } );

--- a/packages/api-queries/src/__tests__/reader-atmosphere.test.tsx
+++ b/packages/api-queries/src/__tests__/reader-atmosphere.test.tsx
@@ -1,5 +1,6 @@
 import {
 	PENDING_LIKE_URI,
+	PENDING_REPLY_URI,
 	readerAtmosphereKeys,
 	type AtmosphereFeedItem,
 	type AtmosphereScopedProfile,
@@ -19,6 +20,7 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import nock from 'nock';
 import {
 	atmosphereScopedProfileQuery,
+	createPostMutation,
 	followAtmosphereActorMutation,
 	unfollowAtmosphereActorMutation,
 	useAuthorFeedInfiniteQuery,
@@ -1345,6 +1347,180 @@ describe( 'reader-atmosphere hooks', () => {
 
 				expect( getTimelineCache( client ) ).toEqual( snapshot );
 			} );
+		} );
+	} );
+
+	describe( 'createPostMutation — reply mode', () => {
+		const connectionId = 42;
+		const root = { uri: 'at://did:plc:r/app.bsky.feed.post/root', cid: 'rcid' };
+		const parent = { uri: 'at://did:plc:p/app.bsky.feed.post/parent', cid: 'pcid' };
+
+		afterEach( () => nock.cleanAll() );
+
+		function seedThreadWithParent( client: QueryClient ): AtmosphereThreadResponse {
+			const initial: AtmosphereThreadResponse = {
+				thread: {
+					type: 'post',
+					post: makeFeedItem( {
+						uri: root.uri,
+						cid: root.cid,
+						counts: { replies: 1, reposts: 0, likes: 0, quotes: 0 },
+					} ),
+					parent: null,
+					replies: [
+						{
+							type: 'post',
+							post: makeFeedItem( {
+								uri: parent.uri,
+								cid: parent.cid,
+								counts: { replies: 0, reposts: 0, likes: 0, quotes: 0 },
+							} ),
+							parent: null,
+							replies: [],
+						},
+					],
+				},
+			};
+			client.setQueryData( readerAtmosphereKeys.thread( root.uri ), initial );
+			return initial;
+		}
+
+		it( 'POSTs the body and returns the new post reference', async () => {
+			nock( BASE )
+				.post( `/wpcom/v2/reader/atmosphere/connections/${ connectionId }/posts`, {
+					text: 'hello',
+					reply: { root, parent },
+				} )
+				.reply( 200, { post: { uri: 'at://new', cid: 'newcid', rkey: 'abc' } } );
+
+			const client = new QueryClient( { defaultOptions: { mutations: { retry: false } } } );
+			const { result } = renderHook( () => useMutation( createPostMutation( client ) ), {
+				wrapper: makeWrapper( client ),
+			} );
+
+			await act( async () => {
+				await result.current.mutateAsync( {
+					connectionId,
+					text: 'hello',
+					reply: { root, parent },
+				} );
+			} );
+
+			expect( result.current.data ).toEqual( { uri: 'at://new', cid: 'newcid', rkey: 'abc' } );
+		} );
+
+		it( 'optimistically inserts a placeholder reply under the parent in the thread query', async () => {
+			const client = new QueryClient( { defaultOptions: { mutations: { retry: false } } } );
+			seedThreadWithParent( client );
+
+			nock( BASE )
+				.post( `/wpcom/v2/reader/atmosphere/connections/${ connectionId }/posts` )
+				.delay( 100 )
+				.reply( 200, { post: { uri: 'at://new', cid: 'newcid', rkey: 'abc' } } );
+
+			const { result } = renderHook( () => useMutation( createPostMutation( client ) ), {
+				wrapper: makeWrapper( client ),
+			} );
+
+			let promise: Promise< unknown > = Promise.resolve();
+			await act( async () => {
+				promise = result.current.mutateAsync( {
+					connectionId,
+					text: 'reply text',
+					reply: { root, parent },
+				} );
+				await Promise.resolve();
+			} );
+
+			await waitFor( () => {
+				const thread = client.getQueryData< AtmosphereThreadResponse >(
+					readerAtmosphereKeys.thread( root.uri )
+				);
+				expect( thread?.thread.type ).toBe( 'post' );
+				if ( thread?.thread.type !== 'post' ) {
+					throw new Error( 'expected root to be a post node' );
+				}
+				expect( thread.thread.replies ).toHaveLength( 1 );
+				const parentNode = thread.thread.replies[ 0 ];
+				expect( parentNode.type ).toBe( 'post' );
+				if ( parentNode.type !== 'post' ) {
+					throw new Error( 'expected parent to be a post node' );
+				}
+				expect( parentNode.replies ).toHaveLength( 1 );
+				const placeholder = parentNode.replies[ 0 ];
+				expect( placeholder.type ).toBe( 'post' );
+				if ( placeholder.type !== 'post' ) {
+					throw new Error( 'expected placeholder to be a post node' );
+				}
+				expect( placeholder.post.uri ).toBe( PENDING_REPLY_URI );
+				expect( placeholder.post.text ).toBe( 'reply text' );
+			} );
+
+			await promise;
+		} );
+
+		it( 'restores the snapshot on error', async () => {
+			const client = new QueryClient( { defaultOptions: { mutations: { retry: false } } } );
+			const initial = seedThreadWithParent( client );
+
+			nock( BASE )
+				.post( `/wpcom/v2/reader/atmosphere/connections/${ connectionId }/posts` )
+				.reply( 502, { error: 'atmosphere_upstream_unavailable' } );
+
+			const { result } = renderHook( () => useMutation( createPostMutation( client ) ), {
+				wrapper: makeWrapper( client ),
+			} );
+
+			await act( async () => {
+				try {
+					await result.current.mutateAsync( {
+						connectionId,
+						text: 'reply text',
+						reply: { root, parent },
+					} );
+				} catch {
+					/* expected */
+				}
+			} );
+
+			expect(
+				client.getQueryData< AtmosphereThreadResponse >( readerAtmosphereKeys.thread( root.uri ) )
+			).toEqual( initial );
+		} );
+
+		it( 'increments parent counts.replies in cached timeline pages', async () => {
+			const client = new QueryClient( { defaultOptions: { mutations: { retry: false } } } );
+			const parentItem = makeFeedItem( {
+				uri: parent.uri,
+				cid: parent.cid,
+				counts: { replies: 3, reposts: 0, likes: 0, quotes: 0 },
+			} );
+			const timelineData: InfiniteData< AtmosphereTimelinePage > = {
+				pages: [ { items: [ parentItem ], cursor: null } ],
+				pageParams: [ undefined ],
+			};
+			client.setQueryData( readerAtmosphereKeys.timeline( connectionId ), timelineData );
+
+			nock( BASE )
+				.post( `/wpcom/v2/reader/atmosphere/connections/${ connectionId }/posts` )
+				.reply( 200, { post: { uri: 'at://new', cid: 'newcid', rkey: 'abc' } } );
+
+			const { result } = renderHook( () => useMutation( createPostMutation( client ) ), {
+				wrapper: makeWrapper( client ),
+			} );
+
+			await act( async () => {
+				await result.current.mutateAsync( {
+					connectionId,
+					text: 'reply text',
+					reply: { root, parent },
+				} );
+			} );
+
+			const timeline = client.getQueryData< InfiniteData< AtmosphereTimelinePage > >(
+				readerAtmosphereKeys.timeline( connectionId )
+			);
+			expect( timeline?.pages[ 0 ].items[ 0 ].counts.replies ).toBe( 4 );
 		} );
 	} );
 } );

--- a/packages/api-queries/src/reader-atmosphere.ts
+++ b/packages/api-queries/src/reader-atmosphere.ts
@@ -719,20 +719,37 @@ interface CreatePostContext {
 	// and the placeholder insertion in a single setQueryData call.
 	threadKey: QueryKey | null;
 	threadPrevious: AtmosphereThreadResponse | undefined;
+	// Per-mutation placeholder URI. Two replies in flight at the same
+	// time would otherwise collide on the shared `PENDING_REPLY_URI`
+	// sentinel — `replacePlaceholderInThread` would rewrite whichever
+	// node it found first when the second response landed, losing the
+	// other reply. Each mutation stamps its own suffix so onSuccess
+	// rewrites only its own placeholder.
+	pendingUri: string;
 }
+
+// Module-level counter producing collision-free pending URIs. Suffix is
+// a `#`-separated ordinal so the result is still parseable by anything
+// that does a `startsWith( PENDING_REPLY_URI )` check; `rkeyFromUri`
+// already returns null because the result does not start with `at://`.
+let pendingReplyCounter = 0;
+const nextPendingReplyUri = () => `${ PENDING_REPLY_URI }#${ ++pendingReplyCounter }`;
 
 /**
  * Build a placeholder `AtmosphereFeedItem` representing an in-flight
- * reply. The URI is the `PENDING_REPLY_URI` sentinel so consumers can
- * detect the optimistic state and suppress race-y delete actions.
+ * reply. The URI is a `PENDING_REPLY_URI`-prefixed sentinel unique to
+ * the in-flight mutation so consumers can detect the optimistic state
+ * and suppress race-y delete actions, and so concurrent replies do not
+ * collide on rewrite.
  */
-function buildPlaceholderReply( text: string ): AtmosphereFeedItem {
+function buildPlaceholderReply( text: string, pendingUri: string ): AtmosphereFeedItem {
+	const now = new Date().toISOString();
 	return {
-		uri: PENDING_REPLY_URI,
+		uri: pendingUri,
 		cid: '',
 		author: { did: '', handle: '', display_name: '', avatar: null },
-		created_at: new Date().toISOString(),
-		indexed_at: new Date().toISOString(),
+		created_at: now,
+		indexed_at: now,
 		text,
 		html: '',
 		lang: [],
@@ -783,17 +800,20 @@ function insertPlaceholderUnderParent(
 }
 
 /**
- * Walk the thread tree and rewrite the (single) PENDING_REPLY_URI post
- * with one carrying the real `result.uri` / `result.cid`.
+ * Walk the thread tree and rewrite the placeholder post identified by
+ * `pendingUri` with one carrying the real `result.uri` / `result.cid`.
+ * Matching on a per-mutation URI prevents concurrent replies from
+ * stomping on each other's placeholders.
  */
 function replacePlaceholderInThread(
 	node: AtmosphereThreadNode,
-	result: CreatePostResult
+	result: CreatePostResult,
+	pendingUri: string
 ): AtmosphereThreadNode {
 	if ( node.type !== 'post' ) {
 		return node;
 	}
-	if ( node.post.uri === PENDING_REPLY_URI ) {
+	if ( node.post.uri === pendingUri ) {
 		return {
 			...node,
 			post: { ...node.post, uri: result.uri, cid: result.cid },
@@ -801,13 +821,13 @@ function replacePlaceholderInThread(
 	}
 	let changed = false;
 	const replies = node.replies.map( ( reply ) => {
-		const next = replacePlaceholderInThread( reply, result );
+		const next = replacePlaceholderInThread( reply, result, pendingUri );
 		if ( next !== reply ) {
 			changed = true;
 		}
 		return next;
 	} );
-	const parent = node.parent ? replacePlaceholderInThread( node.parent, result ) : null;
+	const parent = node.parent ? replacePlaceholderInThread( node.parent, result, pendingUri ) : null;
 	if ( ! changed && parent === node.parent ) {
 		return node;
 	}
@@ -848,6 +868,7 @@ export const createPostMutation = ( queryClient: QueryClient ) =>
 				parentCountsContext: { snapshots: [] },
 				threadKey: null,
 				threadPrevious: undefined,
+				pendingUri: nextPendingReplyUri(),
 			};
 
 			if ( ! vars.reply ) {
@@ -872,7 +893,7 @@ export const createPostMutation = ( queryClient: QueryClient ) =>
 			// already-bumped parent post stays bumped.
 			const threadAfterBump = queryClient.getQueryData< AtmosphereThreadResponse >( threadKey );
 			if ( threadAfterBump ) {
-				const placeholder = buildPlaceholderReply( vars.text );
+				const placeholder = buildPlaceholderReply( vars.text, ctx.pendingUri );
 				queryClient.setQueryData< AtmosphereThreadResponse >( threadKey, {
 					...threadAfterBump,
 					thread: insertPlaceholderUnderParent( threadAfterBump.thread, parent.uri, placeholder ),
@@ -894,17 +915,27 @@ export const createPostMutation = ( queryClient: QueryClient ) =>
 			}
 			restoreAtmospherePostSnapshots( queryClient, ctx.parentCountsContext );
 		},
-		onSuccess: ( result, vars ) => {
-			if ( ! vars.reply ) {
+		onSuccess: ( result, vars, ctx ) => {
+			if ( ! vars.reply || ! ctx ) {
 				return;
 			}
 			const threadKey = readerAtmosphereKeys.thread( vars.reply.root.uri );
 			const current = queryClient.getQueryData< AtmosphereThreadResponse >( threadKey );
 			if ( ! current ) {
+				// Cache evicted between onMutate and onSuccess (gc, route
+				// change, manual removeQueries). Schedule a refetch so the
+				// real reply does not silently disappear next time the
+				// thread is opened.
+				queryClient.invalidateQueries( { queryKey: threadKey } );
 				return;
 			}
-			const next = replacePlaceholderInThread( current.thread, result );
+			const next = replacePlaceholderInThread( current.thread, result, ctx.pendingUri );
 			if ( next === current.thread ) {
+				// Tree shape shifted between onMutate and onSuccess (e.g. a
+				// concurrent refetch dropped the placeholder branch). Fall
+				// back to invalidate so the reply re-materialises from the
+				// server rather than being silently lost.
+				queryClient.invalidateQueries( { queryKey: threadKey } );
 				return;
 			}
 			queryClient.setQueryData< AtmosphereThreadResponse >( threadKey, {

--- a/packages/api-queries/src/reader-atmosphere.ts
+++ b/packages/api-queries/src/reader-atmosphere.ts
@@ -2,6 +2,7 @@ import {
 	createConnection,
 	createFollow,
 	createLike,
+	createPost,
 	deleteFollow,
 	deleteLike,
 	getAtmosphereTagFeed,
@@ -13,6 +14,7 @@ import {
 	getThread,
 	getTimeline,
 	PENDING_LIKE_URI,
+	PENDING_REPLY_URI,
 	isValidHashtag,
 	readerAtmosphereKeys,
 } from '@automattic/api-core';
@@ -45,6 +47,8 @@ import type {
 	AtmosphereTimelinePage,
 	CreateConnectionParams,
 	CreateLikeResult,
+	CreatePostParams,
+	CreatePostResult,
 } from '@automattic/api-core';
 
 const TERMINAL_ERROR_KINDS: ReadonlySet< AtmosphereError[ 'kind' ] > = new Set( [
@@ -704,3 +708,208 @@ export const atmosphereTagFeedInfiniteQuery = ( connectionId: number, hashtag: s
 export function useAtmosphereTagFeedInfiniteQuery( connectionId: number, hashtag: string ) {
 	return useInfiniteQuery( atmosphereTagFeedInfiniteQuery( connectionId, hashtag ) );
 }
+
+interface CreatePostContext {
+	// Snapshots from `patchAtmospherePostCaches`, covering parent-count
+	// bumps in timeline / profile / tag-feed (and the in-thread parent
+	// post node, since the thread cache is in `readerAtmosphereKeys.all`).
+	parentCountsContext: OptimisticContext;
+	// Full pre-mutation thread snapshot for `root.uri`. Captured *before*
+	// `patchAtmospherePostCaches` runs so it reverts both the count bump
+	// and the placeholder insertion in a single setQueryData call.
+	threadKey: QueryKey | null;
+	threadPrevious: AtmosphereThreadResponse | undefined;
+}
+
+/**
+ * Build a placeholder `AtmosphereFeedItem` representing an in-flight
+ * reply. The URI is the `PENDING_REPLY_URI` sentinel so consumers can
+ * detect the optimistic state and suppress race-y delete actions.
+ */
+function buildPlaceholderReply( text: string ): AtmosphereFeedItem {
+	return {
+		uri: PENDING_REPLY_URI,
+		cid: '',
+		author: { did: '', handle: '', display_name: '', avatar: null },
+		created_at: new Date().toISOString(),
+		indexed_at: new Date().toISOString(),
+		text,
+		html: '',
+		lang: [],
+		reply_parent: null,
+		reply_root: null,
+		reason: null,
+		embed: null,
+		counts: { replies: 0, reposts: 0, likes: 0, quotes: 0 },
+		viewer: { like: null, repost: null },
+		bluesky_url: '',
+	};
+}
+
+/**
+ * Walk the thread tree and append a synthesized placeholder reply node
+ * under the post node whose `.post.uri` matches `parentUri`. Returns a
+ * structurally-shared tree (untouched branches keep their identity).
+ */
+function insertPlaceholderUnderParent(
+	node: AtmosphereThreadNode,
+	parentUri: string,
+	placeholder: AtmosphereFeedItem
+): AtmosphereThreadNode {
+	if ( node.type !== 'post' ) {
+		return node;
+	}
+	if ( node.post.uri === parentUri ) {
+		return {
+			...node,
+			replies: [ ...node.replies, { type: 'post', post: placeholder, parent: null, replies: [] } ],
+		};
+	}
+	let changed = false;
+	const replies = node.replies.map( ( reply ) => {
+		const next = insertPlaceholderUnderParent( reply, parentUri, placeholder );
+		if ( next !== reply ) {
+			changed = true;
+		}
+		return next;
+	} );
+	const parent = node.parent
+		? insertPlaceholderUnderParent( node.parent, parentUri, placeholder )
+		: null;
+	if ( ! changed && parent === node.parent ) {
+		return node;
+	}
+	return { ...node, replies, parent };
+}
+
+/**
+ * Walk the thread tree and rewrite the (single) PENDING_REPLY_URI post
+ * with one carrying the real `result.uri` / `result.cid`.
+ */
+function replacePlaceholderInThread(
+	node: AtmosphereThreadNode,
+	result: CreatePostResult
+): AtmosphereThreadNode {
+	if ( node.type !== 'post' ) {
+		return node;
+	}
+	if ( node.post.uri === PENDING_REPLY_URI ) {
+		return {
+			...node,
+			post: { ...node.post, uri: result.uri, cid: result.cid },
+		};
+	}
+	let changed = false;
+	const replies = node.replies.map( ( reply ) => {
+		const next = replacePlaceholderInThread( reply, result );
+		if ( next !== reply ) {
+			changed = true;
+		}
+		return next;
+	} );
+	const parent = node.parent ? replacePlaceholderInThread( node.parent, result ) : null;
+	if ( ! changed && parent === node.parent ) {
+		return node;
+	}
+	return { ...node, replies, parent };
+}
+
+/**
+ * Mutation factory for creating an `app.bsky.feed.post` record.
+ *
+ * In reply mode, optimistically:
+ *   1. Inserts a `PENDING_REPLY_URI` placeholder reply under the parent
+ *      node in the cached thread query for `reply.root.uri`.
+ *   2. Bumps `counts.replies` on the parent post in every cached
+ *      timeline / profile / tag-feed page (and, transitively, in the
+ *      thread cache where the parent appears as a post node).
+ *
+ * On error both snapshots are restored.
+ *
+ * On success the placeholder URI/cid in the thread cache is rewritten
+ * to the real values returned by the server. The optimistic count bump
+ * stays — it matches the server's post-success state.
+ *
+ * Quote and standalone modes are wired through the body shape and the
+ * `mutationFn` signature; cache patching for those modes is added by
+ * later slices.
+ *
+ * Accepts the consumer's QueryClient because Calypso boots its own
+ * separate from the singleton in `@automattic/api-queries`. See
+ * `client/reader/AGENTS.md` for the rationale.
+ */
+export const createPostMutation = ( queryClient: QueryClient ) =>
+	mutationOptions< CreatePostResult, AtmosphereError, CreatePostParams, CreatePostContext >( {
+		mutationFn: createPost,
+		onMutate: async ( vars ) => {
+			await queryClient.cancelQueries( { queryKey: readerAtmosphereKeys.all } );
+
+			const ctx: CreatePostContext = {
+				parentCountsContext: { snapshots: [] },
+				threadKey: null,
+				threadPrevious: undefined,
+			};
+
+			if ( ! vars.reply ) {
+				return ctx;
+			}
+
+			const { root, parent } = vars.reply;
+			const threadKey = readerAtmosphereKeys.thread( root.uri );
+			ctx.threadKey = threadKey;
+			ctx.threadPrevious = queryClient.getQueryData< AtmosphereThreadResponse >( threadKey );
+
+			// Bump counts.replies on the parent post in every atmosphere
+			// cache where it appears (timeline / profile / tag-feed AND
+			// the parent post node inside the thread tree).
+			ctx.parentCountsContext = patchAtmospherePostCaches( queryClient, parent.uri, ( item ) => ( {
+				...item,
+				counts: { ...item.counts, replies: item.counts.replies + 1 },
+			} ) );
+
+			// Layer the placeholder reply under the parent node in the
+			// thread cache. Done after `patchAtmospherePostCaches` so the
+			// already-bumped parent post stays bumped.
+			const threadAfterBump = queryClient.getQueryData< AtmosphereThreadResponse >( threadKey );
+			if ( threadAfterBump ) {
+				const placeholder = buildPlaceholderReply( vars.text );
+				queryClient.setQueryData< AtmosphereThreadResponse >( threadKey, {
+					...threadAfterBump,
+					thread: insertPlaceholderUnderParent( threadAfterBump.thread, parent.uri, placeholder ),
+				} );
+			}
+
+			return ctx;
+		},
+		onError: ( _err, _vars, ctx ) => {
+			if ( ! ctx ) {
+				return;
+			}
+			// Restore the thread cache first so the placeholder + count
+			// bump are both reverted in one shot. Do this before
+			// `restoreAtmospherePostSnapshots` so that helper sees the
+			// already-restored thread (its restore pass is a no-op there).
+			if ( ctx.threadKey && ctx.threadPrevious !== undefined ) {
+				queryClient.setQueryData( ctx.threadKey, ctx.threadPrevious );
+			}
+			restoreAtmospherePostSnapshots( queryClient, ctx.parentCountsContext );
+		},
+		onSuccess: ( result, vars ) => {
+			if ( ! vars.reply ) {
+				return;
+			}
+			const threadKey = readerAtmosphereKeys.thread( vars.reply.root.uri );
+			const current = queryClient.getQueryData< AtmosphereThreadResponse >( threadKey );
+			if ( ! current ) {
+				return;
+			}
+			const next = replacePlaceholderInThread( current.thread, result );
+			if ( next === current.thread ) {
+				return;
+			}
+			queryClient.setQueryData< AtmosphereThreadResponse >( threadKey, {
+				...current,
+				thread: next,
+			} );
+		},
+	} );

--- a/packages/api-queries/src/reader-atmosphere.ts
+++ b/packages/api-queries/src/reader-atmosphere.ts
@@ -34,6 +34,7 @@ import {
 	type QueryKey,
 } from '@tanstack/react-query';
 import type {
+	AtmosphereAuthor,
 	AtmosphereAuthorFeedFilter,
 	AtmosphereAuthorFeedPage,
 	AtmosphereAuthorProfile,
@@ -810,19 +811,45 @@ interface CreatePostContext {
 let pendingReplyCounter = 0;
 const nextPendingReplyUri = () => `${ PENDING_REPLY_URI }#${ ++pendingReplyCounter }`;
 
+function authorFromConnection(
+	connection: AtmosphereConnectionDetails | undefined
+): AtmosphereAuthor {
+	if ( ! connection ) {
+		return { did: '', handle: '', display_name: '', avatar: null };
+	}
+	return {
+		did: connection.did,
+		handle: connection.handle,
+		display_name: connection.display_name ?? '',
+		avatar: connection.avatar,
+	};
+}
+
 /**
  * Build a placeholder `AtmosphereFeedItem` representing an in-flight
  * reply. The URI is a `PENDING_REPLY_URI`-prefixed sentinel unique to
  * the in-flight mutation so consumers can detect the optimistic state
  * and suppress race-y delete actions, and so concurrent replies do not
  * collide on rewrite.
+ *
+ * The author is hydrated from the cached connection details so the
+ * placeholder renders with the user's real handle / display name /
+ * avatar instead of a blank chip while the request is in flight (and,
+ * after onSuccess rewrites the URI / CID, until the next thread
+ * refetch). When the connection cache is cold the author falls back to
+ * empty fields — `replacePlaceholderInThread` re-applies the connection
+ * lookup on success so a late cache populate still corrects the chip.
  */
-function buildPlaceholderReply( text: string, pendingUri: string ): AtmosphereFeedItem {
+function buildPlaceholderReply(
+	text: string,
+	pendingUri: string,
+	connection: AtmosphereConnectionDetails | undefined
+): AtmosphereFeedItem {
 	const now = new Date().toISOString();
 	return {
 		uri: pendingUri,
 		cid: '',
-		author: { did: '', handle: '', display_name: '', avatar: null },
+		author: authorFromConnection( connection ),
 		created_at: now,
 		indexed_at: now,
 		text,
@@ -878,31 +905,39 @@ function insertPlaceholderUnderParent(
  * Walk the thread tree and rewrite the placeholder post identified by
  * `pendingUri` with one carrying the real `result.uri` / `result.cid`.
  * Matching on a per-mutation URI prevents concurrent replies from
- * stomping on each other's placeholders.
+ * stomping on each other's placeholders. When the placeholder author
+ * is still empty (cold connection cache at onMutate time) and a fresh
+ * `connection` is now available, fill it in so the chip renders the
+ * user's handle / display name / avatar instead of a blank placeholder.
  */
 function replacePlaceholderInThread(
 	node: AtmosphereThreadNode,
 	result: CreatePostResult,
-	pendingUri: string
+	pendingUri: string,
+	connection: AtmosphereConnectionDetails | undefined
 ): AtmosphereThreadNode {
 	if ( node.type !== 'post' ) {
 		return node;
 	}
 	if ( node.post.uri === pendingUri ) {
+		const author =
+			node.post.author.handle === '' ? authorFromConnection( connection ) : node.post.author;
 		return {
 			...node,
-			post: { ...node.post, uri: result.uri, cid: result.cid },
+			post: { ...node.post, uri: result.uri, cid: result.cid, author },
 		};
 	}
 	let changed = false;
 	const replies = node.replies.map( ( reply ) => {
-		const next = replacePlaceholderInThread( reply, result, pendingUri );
+		const next = replacePlaceholderInThread( reply, result, pendingUri, connection );
 		if ( next !== reply ) {
 			changed = true;
 		}
 		return next;
 	} );
-	const parent = node.parent ? replacePlaceholderInThread( node.parent, result, pendingUri ) : null;
+	const parent = node.parent
+		? replacePlaceholderInThread( node.parent, result, pendingUri, connection )
+		: null;
 	if ( ! changed && parent === node.parent ) {
 		return node;
 	}
@@ -965,10 +1000,15 @@ export const createPostMutation = ( queryClient: QueryClient ) =>
 
 			// Layer the placeholder reply under the parent node in the
 			// thread cache. Done after `patchAtmospherePostCaches` so the
-			// already-bumped parent post stays bumped.
+			// already-bumped parent post stays bumped. The placeholder
+			// author is hydrated from the cached connection details so the
+			// optimistic chip carries the user's real handle / avatar.
 			const threadAfterBump = queryClient.getQueryData< AtmosphereThreadResponse >( threadKey );
 			if ( threadAfterBump ) {
-				const placeholder = buildPlaceholderReply( vars.text, ctx.pendingUri );
+				const connection = queryClient.getQueryData< AtmosphereConnectionDetails >(
+					readerAtmosphereKeys.connection( vars.connectionId )
+				);
+				const placeholder = buildPlaceholderReply( vars.text, ctx.pendingUri, connection );
 				queryClient.setQueryData< AtmosphereThreadResponse >( threadKey, {
 					...threadAfterBump,
 					thread: insertPlaceholderUnderParent( threadAfterBump.thread, parent.uri, placeholder ),
@@ -1004,7 +1044,13 @@ export const createPostMutation = ( queryClient: QueryClient ) =>
 				queryClient.invalidateQueries( { queryKey: threadKey } );
 				return;
 			}
-			const next = replacePlaceholderInThread( current.thread, result, ctx.pendingUri );
+			// Re-resolve the connection on success: a deep-link can land in
+			// the thread surface before the connection cache populates, so
+			// the placeholder built in onMutate may have an empty author.
+			const connection = queryClient.getQueryData< AtmosphereConnectionDetails >(
+				readerAtmosphereKeys.connection( vars.connectionId )
+			);
+			const next = replacePlaceholderInThread( current.thread, result, ctx.pendingUri, connection );
 			if ( next === current.thread ) {
 				// Tree shape shifted between onMutate and onSuccess (e.g. a
 				// concurrent refetch dropped the placeholder branch). Fall

--- a/packages/api-queries/src/reader-atmosphere.ts
+++ b/packages/api-queries/src/reader-atmosphere.ts
@@ -66,6 +66,13 @@ const TERMINAL_ERROR_KINDS: ReadonlySet< AtmosphereError[ 'kind' ] > = new Set( 
 	// rate_limited surfaces a wait-then-Retry UI; auto-retrying immediately
 	// would contradict the user-facing message.
 	'rate_limited',
+	// Slice 7c POST /posts wire codes — all client-actionable, none transient.
+	// Auto-retrying any of these would either repeat a guaranteed-fail call or
+	// contradict the user-facing copy.
+	'text_too_long',
+	'reply_disabled',
+	'quote_disabled',
+	'target_unavailable',
 ] );
 
 const isTerminalError = ( error: AtmosphereError ): boolean =>


### PR DESCRIPTION
## Summary

Implements **CM-644** (slice 7c reply composer frontend) and partially advances **CM-655** (umbrella — unified compose modal). Clicking the replies count on any ATmosphere post card opens a `@wordpress/components/Modal` with the parent pinned at the top, a textarea, a disabled media icon, a grapheme-counted character indicator, and a Post button. Submission posts to `POST /reader/atmosphere/connections/{id}/posts` with `{text, reply: {root, parent}}` and optimistically inserts a placeholder into the cached thread tree, with rollback on error.

The component shape (provider context + modal + dumb triggers) is the long-term composer scaffold reused by:
- **CM-645** (quote composer — slice 7d) via `onQuoteClick` on the same context.
- A future standalone-composer ticket (CM-655 reserves the entry-point design for `<TimelineComposeAffordance>` + `<NavComposeIcon>`).

Spec: `~/notes/1-Projects/code/a8c/calypso/2026-05-01-reader-atmosphere-composer-design.md`
Plan: `~/notes/1-Projects/code/a8c/calypso/2026-05-01-reader-atmosphere-composer-slice-7c-plan.md`

## Sequencing

**Backend dependency:** **CM-641** (slice 7c backend — `POST /posts` endpoint) must merge first. Frontend ships safely before backend (no regression — endpoint just doesn't exist yet).

**Paired wpcom change for reply-to-reply correctness:** the existing wpcom timeline normalizer (`wp-content/rest-api-plugins/endpoints/reader-atmosphere/normalizer.php`, `reply_ref()` function) currently strips `cid`. The frontend now expects it on `AtmosphereFeedItem.reply_root.cid` and falls back to `parent.cid` when absent. Without the backend change, reply-to-reply submits will continue to send the parent's cid as `root.cid` (existing behavior — no regression). Add `'cid' => (string) ( $ref['cid'] ?? '' )` to the `reply_ref()` projection to fully fix.

## Scope

**In scope (this PR):**
- `<ComposerModal>` keystone + `<ComposerProvider>` context.
- `<ComposerTextarea>`, `<ComposerFooter>`, `<ComposerPinnedContext>` subcomponents.
- `Intl.Segmenter` grapheme counter.
- `createPost` fetcher + `createPostMutation` factory with optimistic insert + rollback.
- `onReplyClick` callback on `SocialAnalyticsContextValue`; `<PostCardCounts>` renders the replies count as a button when bound.
- Wiring: `<ComposerProvider>` mounted in account-view, thread-view, author-profile-view; `onReplyClick` bound in TimelinePanel, ThreadPanel, AuthorProfilePanel.
- Optional `cid` on `SocialReplyRef` / `AtmosphereReplyRef` (paired with backend normalizer change for full reply-to-reply correctness).
- Tracks events: `_reply_composer_opened`, `_reply_published`, `_reply_error_shown` (ref-tracked dedupe per `error_kind`).
- 426 passing tests + 1 documented `it.skip` (focus-trap, jsdom limitation, browser coverage via Playwright).

**Explicitly deferred:**
- Quote composer triggers (CM-645 / slice 7d) — modal supports `kind: 'quote'` via `buildParamsForMode` but no triggers wire it up here.
- Standalone composer triggers (CM-655 standalone subset) — reserved in `buildParamsForMode` + `TITLE_BY_KIND` / `PLACEHOLDER_BY_KIND`.
- Image / video / alt-text / content warnings — slice 8.

## Test plan

- [ ] Open a post in `/reader/atmosphere/:id/timeline`, click the replies count → modal opens with parent pinned.
- [ ] Type past 50 / past 300 graphemes → character count goes amber under 50, red at 0/over; Post button disables when over.
- [ ] Cmd/Ctrl+Enter submits.
- [ ] Post button shows spinner during submit.
- [ ] On 200 → modal closes; the parent post's replies count bumps by 1 in the cached timeline.
- [ ] Force a 502 → modal stays open with text intact, "Bluesky is taking longer than usual" message renders.
- [ ] Force a 401 → "Reconnect" link renders, opens `/reader/atmosphere/connect` in a new tab; draft preserved.
- [ ] Trigger reply from a thread view AND from an author profile view → same behavior.
- [ ] Tab through modal → focus stays inside.
- [ ] Disabled media icon is reachable by Tab but does nothing on activation.
- [ ] Close modal with non-empty text → discard-confirm appears; cancel keeps modal open.
- [ ] Close modal with empty text → closes immediately.

## Pre-merge Checklist

- [x] **Has the change been tested in a relevant local environment?** Unit + integration tests across api-core / api-queries / reader-social / reader-atmosphere all pass (426/426 + 1 skip).
- [ ] **Are there entries in CHANGELOG.md describing the changes?** N/A — Calypso doesn't use a CHANGELOG.
- [x] **Does the change have unit tests?** Yes — 14+ new tests across the slice (mutation factory, modal behavior, error states, optimistic rollback, connection-stickiness, a11y).
- [x] **Does the change have e2e tests?** Documented `it.skip` for focus-trap (jsdom limit, Playwright covers); other behaviors covered by integration tests in `timeline-panel.test.tsx`.
- [x] **Has the change been [tested for accessibility](https://github.com/Automattic/wp-calypso/blob/HEAD/docs/accessibility.md)?** Focus trap (browser only via WP Modal), `aria-describedby` on textarea, `aria-disabled` + tab-reachable media button, ARIA-named dialog.
- [x] **Has the change been [tested for security and privacy](https://github.com/Automattic/wp-calypso/blob/HEAD/docs/security.md)?** DOMPurify-sanitized HTML in pinned-context (matches `<PostCardBody>` pattern). Reconnect link uses `rel="noopener noreferrer"` + `target="_blank"`.
- [x] **Has the change been [tested for backwards compatibility](https://github.com/Automattic/wp-calypso/blob/HEAD/docs/backwards-compatibility.md)?** All new types/exports are additive; widened types (`SocialReplyRef.cid?`, `AtmosphereReplyRef.cid?`, structural `PreviewPost`) are non-breaking; existing tests for non-composer surfaces still pass.
