### PR TITLE
Fix remove flow: navigate to purchases list with dismissible notice

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -242,6 +242,7 @@ export const purchasesIndexRoute = createRoute( {
 		site?: number;
 		removed?: string;
 		removedDomain?: string;
+		removedId?: number;
 	} => {
 		return {
 			page: typeof search.page === 'number' ? search.page : undefined,
@@ -249,6 +250,7 @@ export const purchasesIndexRoute = createRoute( {
 			site: typeof search.site === 'number' ? search.site : undefined,
 			removed: typeof search.removed === 'string' ? search.removed : undefined,
 			removedDomain: typeof search.removedDomain === 'string' ? search.removedDomain : undefined,
+			removedId: typeof search.removedId === 'number' ? search.removedId : undefined,
 		};
 	},
 } ).lazy( () =>

--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -242,7 +242,6 @@ export const purchasesIndexRoute = createRoute( {
 		site?: number;
 		removed?: string;
 		removedDomain?: string;
-		removedSendsEmail?: boolean;
 	} => {
 		return {
 			page: typeof search.page === 'number' ? search.page : undefined,
@@ -250,7 +249,6 @@ export const purchasesIndexRoute = createRoute( {
 			site: typeof search.site === 'number' ? search.site : undefined,
 			removed: typeof search.removed === 'string' ? search.removed : undefined,
 			removedDomain: typeof search.removedDomain === 'string' ? search.removedDomain : undefined,
-			removedSendsEmail: search.removedSendsEmail === true ? true : undefined,
 		};
 	},
 } ).lazy( () =>

--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -234,11 +234,21 @@ export const purchasesIndexRoute = createRoute( {
 		queryClient.prefetchQuery( userPaymentMethodsQuery( {} ) );
 		queryClient.prefetchQuery( allSitesQuery() );
 	},
-	validateSearch: ( search ): { page?: number; search?: string; site?: number } => {
+	validateSearch: (
+		search
+	): {
+		page?: number;
+		search?: string;
+		site?: number;
+		removed?: string;
+		removedDomain?: string;
+	} => {
 		return {
 			page: typeof search.page === 'number' ? search.page : undefined,
 			search: typeof search.search === 'string' ? search.search : undefined,
 			site: typeof search.site === 'number' ? search.site : undefined,
+			removed: typeof search.removed === 'string' ? search.removed : undefined,
+			removedDomain: typeof search.removedDomain === 'string' ? search.removedDomain : undefined,
 		};
 	},
 } ).lazy( () =>

--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -242,6 +242,7 @@ export const purchasesIndexRoute = createRoute( {
 		site?: number;
 		removed?: string;
 		removedDomain?: string;
+		removedSendsEmail?: boolean;
 	} => {
 		return {
 			page: typeof search.page === 'number' ? search.page : undefined,
@@ -249,6 +250,7 @@ export const purchasesIndexRoute = createRoute( {
 			site: typeof search.site === 'number' ? search.site : undefined,
 			removed: typeof search.removed === 'string' ? search.removed : undefined,
 			removedDomain: typeof search.removedDomain === 'string' ? search.removedDomain : undefined,
+			removedSendsEmail: search.removedSendsEmail === true ? true : undefined,
 		};
 	},
 } ).lazy( () =>

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -27,7 +27,13 @@ import {
 } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import { invokeSurvicateEvent } from '@automattic/survicate';
-import { useSuspenseQuery, useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+	useSuspenseQuery,
+	useQuery,
+	useMutation,
+	useQueryClient,
+	type QueryCacheNotifyEvent,
+} from '@tanstack/react-query';
 import { useNavigate, useSearch } from '@tanstack/react-router';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
@@ -1125,14 +1131,60 @@ function CancelPurchaseInner() {
 			return;
 		}
 
-		// Delay everything for tactile feedback (button stays busy for 1.5s)
 		setTimeout( () => {
-			// 1. Strip purchase from cache optimistically
-			queryClient.setQueryData( userPurchasesQuery().queryKey, ( old: Purchase[] | undefined ) =>
-				( old ?? [] ).filter( ( p ) => p.ID !== purchase.ID )
-			);
+			// 1. Optimistic cache strip
+			const stripPurchaseFromList = () => {
+				queryClient.setQueryData( userPurchasesQuery().queryKey, ( old: Purchase[] | undefined ) =>
+					( old ?? [] ).filter( ( p ) => p.ID !== purchase.ID )
+				);
+			};
 
-			// 2. Navigate with notice params
+			stripPurchaseFromList();
+
+			// 2. Cache guard — re-strip if a stale refetch brings the purchase back.
+			// Pattern: packages/api-queries/src/site-collision-listener.ts
+			let guardActive = true;
+			let processing = false;
+
+			const unsubscribeGuard = queryClient
+				.getQueryCache()
+				.subscribe( ( event: QueryCacheNotifyEvent ) => {
+					if (
+						! guardActive ||
+						processing ||
+						event.type !== 'updated' ||
+						event.action.type !== 'success' ||
+						event.query.queryKey[ 0 ] !== 'upgrades'
+					) {
+						return;
+					}
+
+					const data = event.query.state.data as Purchase[] | undefined;
+					if ( data?.some( ( p ) => p.ID === purchase.ID ) ) {
+						processing = true;
+						try {
+							stripPurchaseFromList();
+						} finally {
+							processing = false;
+						}
+					}
+				} );
+
+			const cleanupGuard = () => {
+				if ( ! guardActive ) {
+					return;
+				}
+				guardActive = false;
+				unsubscribeGuard();
+			};
+
+			// Self-terminate after 15s with a final authoritative fetch
+			setTimeout( () => {
+				cleanupGuard();
+				queryClient.invalidateQueries( { queryKey: userPurchasesQuery().queryKey } );
+			}, 15_000 );
+
+			// 3. Navigate with notice params
 			invokeSurvicateEvent( 'purchaseRemoved' );
 			const productNoun = getProductNounForCategory( classifyPurchaseForCopy( purchase ) );
 			navigate( {
@@ -1145,12 +1197,14 @@ function CancelPurchaseInner() {
 				},
 			} );
 
-			// 3. Fire mutation in background — built-in onSuccess at the package
-			//    level still fires invalidateQueries for eventual consistency
+			// 4. Fire mutation in background
 			removePurchaseMutator.mutateAsync( purchase.ID ).catch( () => {
+				// Mutation failed — stop guarding and roll back the optimistic strip
+				cleanupGuard();
 				createErrorNotice( __( 'There was a problem removing your purchase. Please try again.' ), {
 					type: 'snackbar',
 				} );
+				queryClient.invalidateQueries( { queryKey: userPurchasesQuery().queryKey } );
 			} );
 		}, 1500 );
 	};

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -1186,14 +1186,11 @@ function CancelPurchaseInner() {
 
 			// 3. Navigate with notice params
 			invokeSurvicateEvent( 'purchaseRemoved' );
-			const category = classifyPurchaseForCopy( purchase );
-			const productNoun = getProductNounForCategory( category );
-			const sendsEmail = category === 'plan' || category === 'domain';
+			const productNoun = getProductNounForCategory( classifyPurchaseForCopy( purchase ) );
 			navigate( {
 				to: purchasesRoute.to,
 				search: {
 					removed: productNoun,
-					...( sendsEmail ? { removedSendsEmail: true } : {} ),
 					...( purchase.will_atomic_revert_after_removal
 						? { removedDomain: purchase.domain }
 						: {} ),

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -1205,7 +1205,7 @@ function CancelPurchaseInner() {
 				// Mutation failed — stop guarding and roll back the optimistic strip
 				cleanupGuard();
 				window.dispatchEvent( new CustomEvent( 'purchase-remove-failed' ) );
-				createErrorNotice( __( 'There was a problem removing your purchase. Please try again.' ), {
+				createErrorNotice( __( 'Failed to remove your purchase. Please try again.' ), {
 					type: 'snackbar',
 				} );
 				queryClient.invalidateQueries( { queryKey: userPurchasesQuery().queryKey } );

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -1191,17 +1191,27 @@ function CancelPurchaseInner() {
 				to: purchasesRoute.to,
 				search: {
 					removed: productNoun,
+					removedId: purchase.ID,
 					...( purchase.will_atomic_revert_after_removal
 						? { removedDomain: purchase.domain }
 						: {} ),
 				},
 			} );
 
-			// 4. Fire mutation in background
+			// 4. Fire mutation in background. On failure, restore the purchase to
+			//    the cache — the list watches userPurchasesQuery for reappearance
+			//    and self-dismisses its notice. The cache guard's re-strip happens
+			//    synchronously inside the QueryCache notify callback, so the list's
+			//    useEffect never observes transient successes-path reappearances.
 			removePurchaseMutator.mutateAsync( purchase.ID ).catch( () => {
-				// Mutation failed — stop guarding and roll back the optimistic strip
 				cleanupGuard();
-				window.dispatchEvent( new CustomEvent( 'purchase-remove-failed' ) );
+				queryClient.setQueryData(
+					userPurchasesQuery().queryKey,
+					( old: Purchase[] | undefined ) => {
+						const list = old ?? [];
+						return list.some( ( p ) => p.ID === purchase.ID ) ? list : [ ...list, purchase ];
+					}
+				);
 				createErrorNotice( __( 'Failed to remove your purchase. Please try again.' ), {
 					type: 'snackbar',
 				} );

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -1201,6 +1201,7 @@ function CancelPurchaseInner() {
 			removePurchaseMutator.mutateAsync( purchase.ID ).catch( () => {
 				// Mutation failed — stop guarding and roll back the optimistic strip
 				cleanupGuard();
+				window.dispatchEvent( new CustomEvent( 'purchase-remove-failed' ) );
 				createErrorNotice( __( 'There was a problem removing your purchase. Please try again.' ), {
 					type: 'snackbar',
 				} );

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -1121,12 +1121,34 @@ function CancelPurchaseInner() {
 
 		removePurchaseMutator.mutate( purchase.ID, {
 			onSuccess: () => {
+				if ( purchase.will_atomic_revert_after_removal ) {
+					createSuccessNotice(
+						/* translators: Shown after removing a product from an Atomic site */
+						__( 'Your site has been removed. Download a backup to save your themes and plugins.' ),
+						{
+							type: 'snackbar',
+							actions: [
+								{
+									label: __( 'Download a backup' ),
+									url: `//${ purchase.domain }/wp-admin/export.php`,
+								},
+							],
+						}
+					);
+				} else {
+					createSuccessNotice(
+						sprintf(
+							/* translators: %(productName)s is the name of a product (e.g., "WordPress.com Premium") */
+							__( '%(productName)s was removed.' ),
+							{
+								productName: purchase.is_domain ? purchase.meta : purchase.product_name,
+							}
+						),
+						{ type: 'snackbar' }
+					);
+				}
 				invokeSurvicateEvent( 'purchaseRemoved' );
-				navigate( {
-					to: purchaseSettingsRoute.fullPath,
-					params: { purchaseId: purchase.ID },
-					search: { cancelled: true },
-				} );
+				navigate( { to: purchasesRoute.to } );
 			},
 			onError: () => {
 				const purchaseName = purchase.is_domain ? purchase.meta : purchase.product_name;

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -1186,11 +1186,14 @@ function CancelPurchaseInner() {
 
 			// 3. Navigate with notice params
 			invokeSurvicateEvent( 'purchaseRemoved' );
-			const productNoun = getProductNounForCategory( classifyPurchaseForCopy( purchase ) );
+			const category = classifyPurchaseForCopy( purchase );
+			const productNoun = getProductNounForCategory( category );
+			const sendsEmail = category === 'plan' || category === 'domain';
 			navigate( {
 				to: purchasesRoute.to,
 				search: {
 					removed: productNoun,
+					...( sendsEmail ? { removedSendsEmail: true } : {} ),
 					...( purchase.will_atomic_revert_after_removal
 						? { removedDomain: purchase.domain }
 						: {} ),

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -23,10 +23,11 @@ import {
 	siteFeaturesQuery,
 	removePurchaseMutation,
 	userPreferenceQuery,
+	userPurchasesQuery,
 } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import { invokeSurvicateEvent } from '@automattic/survicate';
-import { useSuspenseQuery, useQuery, useMutation } from '@tanstack/react-query';
+import { useSuspenseQuery, useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useSearch } from '@tanstack/react-router';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
@@ -59,6 +60,10 @@ import {
 	isPartnerPurchase,
 	isOneTimePurchase,
 } from '../../../utils/purchase';
+import {
+	classifyPurchaseForCopy,
+	getProductNounForCategory,
+} from '../purchase-settings/classify-purchase-for-copy';
 import CancelHeaderTitle from './cancel-header-title';
 import CancelPurchaseForm from './cancel-purchase-form';
 import {
@@ -326,6 +331,7 @@ export default function CancelPurchase() {
 }
 
 function CancelPurchaseInner() {
+	const queryClient = useQueryClient();
 	const { createSuccessNotice, removeNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { recordTracksEvent } = useAnalytics();
 	const locale = useLocale();
@@ -1119,52 +1125,34 @@ function CancelPurchaseInner() {
 			return;
 		}
 
-		removePurchaseMutator.mutate( purchase.ID, {
-			onSuccess: () => {
-				if ( purchase.will_atomic_revert_after_removal ) {
-					createSuccessNotice(
-						/* translators: Shown after removing a product from an Atomic site */
-						__( 'Your site has been removed. Download a backup to save your themes and plugins.' ),
-						{
-							type: 'snackbar',
-							actions: [
-								{
-									label: __( 'Download a backup' ),
-									url: `//${ purchase.domain }/wp-admin/export.php`,
-								},
-							],
-						}
-					);
-				} else {
-					createSuccessNotice(
-						sprintf(
-							/* translators: %(productName)s is the name of a product (e.g., "WordPress.com Premium") */
-							__( '%(productName)s was removed.' ),
-							{
-								productName: purchase.is_domain ? purchase.meta : purchase.product_name,
-							}
-						),
-						{ type: 'snackbar' }
-					);
-				}
-				invokeSurvicateEvent( 'purchaseRemoved' );
-				navigate( { to: purchasesRoute.to } );
-			},
-			onError: () => {
-				const purchaseName = purchase.is_domain ? purchase.meta : purchase.product_name;
-				createErrorNotice(
-					sprintf(
-						/* translators: %(purchaseName)s is the name of the product that was purchased. */
-						__(
-							'There was a problem removing %(purchaseName)s. Please try again later or contact support.'
-						),
-						{ purchaseName }
-					),
-					{ type: 'snackbar' }
-				);
-				setState( ( state ) => ( { ...state, surveyShown: false, isLoading: false } ) );
-			},
-		} );
+		// Delay everything for tactile feedback (button stays busy for 1.5s)
+		setTimeout( () => {
+			// 1. Strip purchase from cache optimistically
+			queryClient.setQueryData( userPurchasesQuery().queryKey, ( old: Purchase[] | undefined ) =>
+				( old ?? [] ).filter( ( p ) => p.ID !== purchase.ID )
+			);
+
+			// 2. Navigate with notice params
+			invokeSurvicateEvent( 'purchaseRemoved' );
+			const productNoun = getProductNounForCategory( classifyPurchaseForCopy( purchase ) );
+			navigate( {
+				to: purchasesRoute.to,
+				search: {
+					removed: productNoun,
+					...( purchase.will_atomic_revert_after_removal
+						? { removedDomain: purchase.domain }
+						: {} ),
+				},
+			} );
+
+			// 3. Fire mutation in background — built-in onSuccess at the package
+			//    level still fires invalidateQueries for eventual consistency
+			removePurchaseMutator.mutateAsync( purchase.ID ).catch( () => {
+				createErrorNotice( __( 'There was a problem removing your purchase. Please try again.' ), {
+					type: 'snackbar',
+				} );
+			} );
+		}, 1500 );
 	};
 
 	const submitTurnOffAutoRenew = ( purchase: Purchase ) => {

--- a/client/dashboard/me/billing-purchases/index.tsx
+++ b/client/dashboard/me/billing-purchases/index.tsx
@@ -31,11 +31,13 @@ import { PurchaseRemovedNotice } from './purchase-removed-notice';
 
 export default function PurchasesList() {
 	const currentSearchParams = purchasesRoute.useSearch();
-	const { removed, removedDomain } = purchasesIndexRoute.useSearch();
+	const { removed, removedDomain, removedId } = purchasesIndexRoute.useSearch();
 	// Capture notice data on first render — useSearch() may lose the values
 	// after replaceState strips the URL params.
 	const [ removedNoticeData ] = useState( () =>
-		removed ? { productNoun: removed, atomicDomain: removedDomain } : null
+		removed
+			? { productNoun: removed, atomicDomain: removedDomain, purchaseId: removedId ?? null }
+			: null
 	);
 	const [ showRemovedNotice, setShowRemovedNotice ] = useState( Boolean( removedNoticeData ) );
 
@@ -46,16 +48,10 @@ export default function PurchasesList() {
 			const url = new URL( window.location.href );
 			url.searchParams.delete( 'removed' );
 			url.searchParams.delete( 'removedDomain' );
+			url.searchParams.delete( 'removedId' );
 			window.history.replaceState( window.history.state, '', url.toString() );
 		}
 	}, [ removed ] );
-
-	// Dismiss the success notice if the background mutation fails.
-	useEffect( () => {
-		const dismiss = () => setShowRemovedNotice( false );
-		window.addEventListener( 'purchase-remove-failed', dismiss );
-		return () => window.removeEventListener( 'purchase-remove-failed', dismiss );
-	}, [] );
 
 	const { data: purchases = [], isLoading: isLoadingPurchases } = useQuery( userPurchasesQuery() );
 	const { data: transferredPurchases = [], isLoading: isLoadingTransferredPurchases } = useQuery(
@@ -63,6 +59,20 @@ export default function PurchasesList() {
 	);
 	const { data: sites = [], isLoading: isLoadingSites } = useQuery( allSitesQuery() );
 	const isLoading = isLoadingPurchases || isLoadingTransferredPurchases || isLoadingSites;
+
+	// Dismiss the success notice when the background mutation rolls back —
+	// detected by the captured purchase reappearing in the userPurchasesQuery
+	// cache. The cancel page's 15s cache guard re-strips transient stale
+	// refetches synchronously inside the QueryCache notify callback, so this
+	// effect never observes transient success-path reappearances.
+	useEffect( () => {
+		if ( ! removedNoticeData?.purchaseId ) {
+			return;
+		}
+		if ( purchases.some( ( p ) => p.ID === removedNoticeData.purchaseId ) ) {
+			setShowRemovedNotice( false );
+		}
+	}, [ purchases, removedNoticeData ] );
 
 	const [ defaultView, setDefaultView ] = useState( DEFAULT_VIEW );
 	const { view, updateView, resetView } = usePersistentView( {

--- a/client/dashboard/me/billing-purchases/index.tsx
+++ b/client/dashboard/me/billing-purchases/index.tsx
@@ -31,11 +31,13 @@ import { PurchaseRemovedNotice } from './purchase-removed-notice';
 
 export default function PurchasesList() {
 	const currentSearchParams = purchasesRoute.useSearch();
-	const { removed, removedDomain } = purchasesIndexRoute.useSearch();
+	const { removed, removedDomain, removedSendsEmail } = purchasesIndexRoute.useSearch();
 	// Capture notice data on first render — useSearch() may lose the values
 	// after replaceState strips the URL params.
 	const [ removedNoticeData ] = useState( () =>
-		removed ? { productNoun: removed, atomicDomain: removedDomain } : null
+		removed
+			? { productNoun: removed, atomicDomain: removedDomain, sendsEmail: removedSendsEmail }
+			: null
 	);
 	const [ showRemovedNotice, setShowRemovedNotice ] = useState( Boolean( removedNoticeData ) );
 
@@ -46,6 +48,7 @@ export default function PurchasesList() {
 			const url = new URL( window.location.href );
 			url.searchParams.delete( 'removed' );
 			url.searchParams.delete( 'removedDomain' );
+			url.searchParams.delete( 'removedSendsEmail' );
 			window.history.replaceState( window.history.state, '', url.toString() );
 		}
 	}, [ removed ] );
@@ -120,6 +123,7 @@ export default function PurchasesList() {
 				<PurchaseRemovedNotice
 					productNoun={ removedNoticeData?.productNoun ?? '' }
 					atomicDomain={ removedNoticeData?.atomicDomain }
+					sendsEmail={ removedNoticeData?.sendsEmail }
 					onClose={ () => setShowRemovedNotice( false ) }
 				/>
 			) }

--- a/client/dashboard/me/billing-purchases/index.tsx
+++ b/client/dashboard/me/billing-purchases/index.tsx
@@ -4,15 +4,16 @@ import {
 	allSitesQuery,
 	userTransferredPurchasesQuery,
 } from '@automattic/api-queries';
+import config from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
 import { useResizeObserver } from '@wordpress/compose';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { usePersistentView } from '../../app/hooks/use-persistent-view';
 import { PerformanceTrackerStop } from '../../app/performance-tracking';
-import { purchasesRoute } from '../../app/router/me';
+import { purchasesIndexRoute, purchasesRoute } from '../../app/router/me';
 import { DataViews, DataViewsCard } from '../../components/dataviews';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
@@ -26,9 +27,29 @@ import {
 	getItemId,
 	usePurchasesListActions,
 } from './dataviews';
+import { PurchaseRemovedNotice } from './purchase-removed-notice';
 
 export default function PurchasesList() {
 	const currentSearchParams = purchasesRoute.useSearch();
+	const { removed, removedDomain } = purchasesIndexRoute.useSearch();
+	// Capture notice data on first render — useSearch() may lose the values
+	// after replaceState strips the URL params.
+	const [ removedNoticeData ] = useState( () =>
+		removed ? { productNoun: removed, atomicDomain: removedDomain } : null
+	);
+	const [ showRemovedNotice, setShowRemovedNotice ] = useState( Boolean( removedNoticeData ) );
+
+	useEffect( () => {
+		if ( removed ) {
+			// Strip notice params from the URL without triggering a TanStack Router
+			// re-navigation — avoids a route loader re-run and layout shift.
+			const url = new URL( window.location.href );
+			url.searchParams.delete( 'removed' );
+			url.searchParams.delete( 'removedDomain' );
+			window.history.replaceState( window.history.state, '', url.toString() );
+		}
+	}, [ removed ] );
+
 	const { data: purchases = [], isLoading: isLoadingPurchases } = useQuery( userPurchasesQuery() );
 	const { data: transferredPurchases = [], isLoading: isLoadingTransferredPurchases } = useQuery(
 		userTransferredPurchasesQuery()
@@ -88,6 +109,13 @@ export default function PurchasesList() {
 				/>
 			}
 		>
+			{ config.isEnabled( 'purchases/split-cancel-remove' ) && showRemovedNotice && (
+				<PurchaseRemovedNotice
+					productNoun={ removedNoticeData?.productNoun ?? '' }
+					atomicDomain={ removedNoticeData?.atomicDomain }
+					onClose={ () => setShowRemovedNotice( false ) }
+				/>
+			) }
 			<div ref={ ref }>
 				<DataViewsCard className="purchases-list__wrapper">
 					{ ! isLoading && <PerformanceTrackerStop /> }

--- a/client/dashboard/me/billing-purchases/index.tsx
+++ b/client/dashboard/me/billing-purchases/index.tsx
@@ -31,13 +31,11 @@ import { PurchaseRemovedNotice } from './purchase-removed-notice';
 
 export default function PurchasesList() {
 	const currentSearchParams = purchasesRoute.useSearch();
-	const { removed, removedDomain, removedSendsEmail } = purchasesIndexRoute.useSearch();
+	const { removed, removedDomain } = purchasesIndexRoute.useSearch();
 	// Capture notice data on first render — useSearch() may lose the values
 	// after replaceState strips the URL params.
 	const [ removedNoticeData ] = useState( () =>
-		removed
-			? { productNoun: removed, atomicDomain: removedDomain, sendsEmail: removedSendsEmail }
-			: null
+		removed ? { productNoun: removed, atomicDomain: removedDomain } : null
 	);
 	const [ showRemovedNotice, setShowRemovedNotice ] = useState( Boolean( removedNoticeData ) );
 
@@ -48,7 +46,6 @@ export default function PurchasesList() {
 			const url = new URL( window.location.href );
 			url.searchParams.delete( 'removed' );
 			url.searchParams.delete( 'removedDomain' );
-			url.searchParams.delete( 'removedSendsEmail' );
 			window.history.replaceState( window.history.state, '', url.toString() );
 		}
 	}, [ removed ] );
@@ -123,7 +120,6 @@ export default function PurchasesList() {
 				<PurchaseRemovedNotice
 					productNoun={ removedNoticeData?.productNoun ?? '' }
 					atomicDomain={ removedNoticeData?.atomicDomain }
-					sendsEmail={ removedNoticeData?.sendsEmail }
 					onClose={ () => setShowRemovedNotice( false ) }
 				/>
 			) }

--- a/client/dashboard/me/billing-purchases/index.tsx
+++ b/client/dashboard/me/billing-purchases/index.tsx
@@ -50,6 +50,13 @@ export default function PurchasesList() {
 		}
 	}, [ removed ] );
 
+	// Dismiss the success notice if the background mutation fails.
+	useEffect( () => {
+		const dismiss = () => setShowRemovedNotice( false );
+		window.addEventListener( 'purchase-remove-failed', dismiss );
+		return () => window.removeEventListener( 'purchase-remove-failed', dismiss );
+	}, [] );
+
 	const { data: purchases = [], isLoading: isLoadingPurchases } = useQuery( userPurchasesQuery() );
 	const { data: transferredPurchases = [], isLoading: isLoadingTransferredPurchases } = useQuery(
 		userTransferredPurchasesQuery()

--- a/client/dashboard/me/billing-purchases/purchase-removed-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-removed-notice.tsx
@@ -1,0 +1,54 @@
+import { Button } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import Notice from '../../components/notice';
+
+/**
+ * Dismissible success notice shown on the purchases list after a remove.
+ * Driven by `?removed` and `?removedDomain` URL search params set by the
+ * cancel-purchase remove flow. The caller handles reading + stripping the
+ * params and controlling visibility via `onClose`.
+ */
+export function PurchaseRemovedNotice( {
+	productNoun,
+	atomicDomain,
+	onClose,
+}: {
+	productNoun: string;
+	atomicDomain?: string;
+	onClose: () => void;
+} ) {
+	if ( atomicDomain ) {
+		const exportUrl = `https://${ atomicDomain }/wp-admin/export.php`;
+		return (
+			<Notice
+				variant="success"
+				onClose={ onClose }
+				actions={
+					<Button variant="primary" href={ exportUrl } target="_blank" rel="noreferrer">
+						{ __( 'Download backup' ) }
+					</Button>
+				}
+			>
+				{ sprintf(
+					/* translators: %(productNoun)s is plan/domain/email/theme/plugin/subscription. */
+					__(
+						'Your %(productNoun)s has been removed. Your site will revert to its previous state \u2014 download a backup to save your content, themes, and plugins. You\u2019ll receive a confirmation email shortly.'
+					),
+					{ productNoun }
+				) }
+			</Notice>
+		);
+	}
+
+	return (
+		<Notice variant="success" onClose={ onClose }>
+			{ sprintf(
+				/* translators: %(productNoun)s is plan/domain/email/theme/plugin/subscription. */
+				__(
+					'Your %(productNoun)s has been removed. You\u2019ll receive a confirmation email shortly.'
+				),
+				{ productNoun }
+			) }
+		</Notice>
+	);
+}

--- a/client/dashboard/me/billing-purchases/purchase-removed-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-removed-notice.tsx
@@ -11,12 +11,10 @@ import Notice from '../../components/notice';
 export function PurchaseRemovedNotice( {
 	productNoun,
 	atomicDomain,
-	sendsEmail,
 	onClose,
 }: {
 	productNoun: string;
 	atomicDomain?: string;
-	sendsEmail?: boolean;
 	onClose: () => void;
 } ) {
 	if ( atomicDomain ) {
@@ -31,40 +29,26 @@ export function PurchaseRemovedNotice( {
 					</Button>
 				}
 			>
-				{ sendsEmail
-					? sprintf(
-							/* translators: %(productNoun)s is plan/domain/email/theme/plugin/subscription. */
-							__(
-								'Your %(productNoun)s has been removed. Your site will revert to its previous state \u2014 download a backup to save your content, themes, and plugins. You\u2019ll receive a confirmation email shortly.'
-							),
-							{ productNoun }
-					  )
-					: sprintf(
-							/* translators: %(productNoun)s is plan/domain/email/theme/plugin/subscription. */
-							__(
-								'Your %(productNoun)s has been removed. Your site will revert to its previous state \u2014 download a backup to save your content, themes, and plugins.'
-							),
-							{ productNoun }
-					  ) }
+				{ sprintf(
+					/* translators: %(productNoun)s is plan/domain/email/theme/plugin/subscription. */
+					__(
+						'Your %(productNoun)s has been removed. Your site will revert to its previous state \u2014 download a backup to save your content, themes, and plugins. You\u2019ll receive a confirmation email shortly.'
+					),
+					{ productNoun }
+				) }
 			</Notice>
 		);
 	}
 
 	return (
 		<Notice variant="success" onClose={ onClose }>
-			{ sendsEmail
-				? sprintf(
-						/* translators: %(productNoun)s is plan/domain/email/theme/plugin/subscription. */
-						__(
-							'Your %(productNoun)s has been removed. You\u2019ll receive a confirmation email shortly.'
-						),
-						{ productNoun }
-				  )
-				: sprintf(
-						/* translators: %(productNoun)s is plan/domain/email/theme/plugin/subscription. */
-						__( 'Your %(productNoun)s has been removed.' ),
-						{ productNoun }
-				  ) }
+			{ sprintf(
+				/* translators: %(productNoun)s is plan/domain/email/theme/plugin/subscription. */
+				__(
+					'Your %(productNoun)s has been removed. You\u2019ll receive a confirmation email shortly.'
+				),
+				{ productNoun }
+			) }
 		</Notice>
 	);
 }

--- a/client/dashboard/me/billing-purchases/purchase-removed-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-removed-notice.tsx
@@ -11,10 +11,12 @@ import Notice from '../../components/notice';
 export function PurchaseRemovedNotice( {
 	productNoun,
 	atomicDomain,
+	sendsEmail,
 	onClose,
 }: {
 	productNoun: string;
 	atomicDomain?: string;
+	sendsEmail?: boolean;
 	onClose: () => void;
 } ) {
 	if ( atomicDomain ) {
@@ -29,26 +31,40 @@ export function PurchaseRemovedNotice( {
 					</Button>
 				}
 			>
-				{ sprintf(
-					/* translators: %(productNoun)s is plan/domain/email/theme/plugin/subscription. */
-					__(
-						'Your %(productNoun)s has been removed. Your site will revert to its previous state \u2014 download a backup to save your content, themes, and plugins. You\u2019ll receive a confirmation email shortly.'
-					),
-					{ productNoun }
-				) }
+				{ sendsEmail
+					? sprintf(
+							/* translators: %(productNoun)s is plan/domain/email/theme/plugin/subscription. */
+							__(
+								'Your %(productNoun)s has been removed. Your site will revert to its previous state \u2014 download a backup to save your content, themes, and plugins. You\u2019ll receive a confirmation email shortly.'
+							),
+							{ productNoun }
+					  )
+					: sprintf(
+							/* translators: %(productNoun)s is plan/domain/email/theme/plugin/subscription. */
+							__(
+								'Your %(productNoun)s has been removed. Your site will revert to its previous state \u2014 download a backup to save your content, themes, and plugins.'
+							),
+							{ productNoun }
+					  ) }
 			</Notice>
 		);
 	}
 
 	return (
 		<Notice variant="success" onClose={ onClose }>
-			{ sprintf(
-				/* translators: %(productNoun)s is plan/domain/email/theme/plugin/subscription. */
-				__(
-					'Your %(productNoun)s has been removed. You\u2019ll receive a confirmation email shortly.'
-				),
-				{ productNoun }
-			) }
+			{ sendsEmail
+				? sprintf(
+						/* translators: %(productNoun)s is plan/domain/email/theme/plugin/subscription. */
+						__(
+							'Your %(productNoun)s has been removed. You\u2019ll receive a confirmation email shortly.'
+						),
+						{ productNoun }
+				  )
+				: sprintf(
+						/* translators: %(productNoun)s is plan/domain/email/theme/plugin/subscription. */
+						__( 'Your %(productNoun)s has been removed.' ),
+						{ productNoun }
+				  ) }
 		</Notice>
 	);
 }

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -38,6 +38,7 @@ import {
 	getButtonLabels,
 } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy';
 import { useIsSplitCancelRemoveEnabled } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/use-is-split-cancel-remove-enabled';
+import { getProductNounForCategory } from 'calypso/dashboard/me/billing-purchases/purchase-settings/classify-purchase-for-copy';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import {
 	getName,
@@ -54,6 +55,7 @@ import {
 } from 'calypso/lib/purchases/actions';
 import { getMutationFlowType, getPurchaseCancellationFlowType } from 'calypso/lib/purchases/utils';
 import CancelPurchaseLoadingPlaceholder from 'calypso/me/purchases/cancel-purchase/loading-placeholder';
+import { classifyPurchaseForCopy } from 'calypso/me/purchases/manage-purchase/classify-purchase-for-copy';
 import { managePurchase, purchasesRoot } from 'calypso/me/purchases/paths';
 import PurchaseSiteHeader from 'calypso/me/purchases/purchases-site/header';
 import TrackPurchasePageView from 'calypso/me/purchases/track-purchase-page-view';
@@ -61,7 +63,7 @@ import { isDataLoading } from 'calypso/me/purchases/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
-import { clearPurchases } from 'calypso/state/purchases/actions';
+import { clearPurchases, removePurchaseFromState } from 'calypso/state/purchases/actions';
 import {
 	getByPurchaseId,
 	getSitePurchases,
@@ -160,6 +162,7 @@ export interface CancelPurchaseActions {
 	) => void;
 	clearPurchases: () => void;
 	refreshSitePlans: ( siteId: string | number ) => void;
+	removePurchaseFromState: ( purchaseId: string | number ) => void;
 	successNotice: (
 		message: string | ReactNode,
 		properties: {
@@ -555,9 +558,39 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		// Set loading state to show busy button
 		this.setState( { isLoading: true } );
 
+		const isAutoRenewIntent = this.state.cancelIntent === 'autorenew';
+		const isRemoveDeleteFlow = this.isLegacyRemoveDeleteFlow( this.props.purchase );
+
+		// Optimistic path: strip cache → navigate → fire mutation in background
+		if ( isRemoveDeleteFlow ) {
+			// Capture props before the timeout — connect() + useSyncExternalStore
+			// may update this.props synchronously when the Redux store changes.
+			const { purchase, purchaseId, atomicTransfer, purchaseListUrl } = this.props;
+			const productNoun = getProductNounForCategory( classifyPurchaseForCopy( purchase ) );
+			const isAtomic = Boolean( atomicTransfer?.created_at );
+			const backupRedirect = purchaseListUrl ?? purchasesRoot;
+
+			// Delay everything for tactile feedback (button stays busy for 1.5s)
+			setTimeout( () => {
+				// 1. Strip purchase from Redux store (preserves loaded flags — no refetch cascade)
+				this.props.removePurchaseFromState( purchaseId );
+
+				// 2. Navigate with notice params
+				invokeSurvicateEvent( 'purchaseRemoved' );
+				const params = new URLSearchParams();
+				params.set( 'removed', productNoun );
+				if ( isAtomic ) {
+					params.set( 'removedDomain', purchase.domain );
+				}
+				page.redirect( `${ backupRedirect }?${ params.toString() }` );
+
+				// 3. Fire mutation in background (fire-and-forget)
+				removePurchaseRequest( purchase.id ).catch( () => {} );
+			}, 1500 );
+			return;
+		}
+
 		try {
-			const isAutoRenewIntent = this.state.cancelIntent === 'autorenew';
-			const isRemoveDeleteFlow = this.isLegacyRemoveDeleteFlow( this.props.purchase );
 			const result = isAutoRenewIntent
 				? await this.cancelPurchase( this.props.purchase )
 				: await this.submitCancelAndRefundPurchase( this.props.purchase );
@@ -568,51 +601,22 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 				await this.handleMarketplaceSubscriptions( refundable );
 				this.props.refreshSitePlans( this.props.purchase.siteId );
 				this.props.clearPurchases();
-				if ( isRemoveDeleteFlow && this.props.atomicTransfer?.created_at ) {
-					this.props.successNotice(
-						this.props.translate(
-							'Your site has been removed. Download a backup to save your themes and plugins.'
-						),
-						{
-							displayOnNextPage: true,
-							duration: 10000,
-							button: this.props.translate( 'Download a backup' ),
-							href: `//${ this.props.purchase.domain }/wp-admin/export.php`,
-						}
-					);
-				} else {
-					this.props.successNotice( result.message, {
-						displayOnNextPage: true,
-						duration: 10000,
-					} );
-				}
-				if ( isRemoveDeleteFlow ) {
-					invokeSurvicateEvent( 'purchaseRemoved' );
-				} else if ( refundable ) {
+				this.props.successNotice( result.message, {
+					displayOnNextPage: true,
+					duration: 10000,
+				} );
+				if ( refundable ) {
 					invokeSurvicateEvent( 'purchaseRefunded' );
 				} else {
 					invokeSurvicateEvent( 'purchaseCancelled' );
 				}
-				// After DELETE the purchase row no longer exists, so manage-purchase
-				// would 404. Redirect straight to the purchases list instead.
+				const managePurchaseUrl = ( this.props.getManagePurchaseUrlFor ?? managePurchase )(
+					this.props.siteSlug,
+					this.props.purchaseId
+				);
 				const backupRedirect = this.props.purchaseListUrl ?? purchasesRoot;
-				if ( isRemoveDeleteFlow ) {
-					this.props.successNotice( result.message, { displayOnNextPage: true, duration: 10000 } );
-					page.redirect( backupRedirect );
-				} else if ( refundable ) {
-					this.props.successNotice( result.message, { displayOnNextPage: true, duration: 10000 } );
-					const managePurchaseUrl = ( this.props.getManagePurchaseUrlFor ?? managePurchase )(
-						this.props.siteSlug,
-						this.props.purchaseId
-					);
-					page.redirect( managePurchaseUrl ?? backupRedirect );
-				} else {
-					const managePurchaseUrl = ( this.props.getManagePurchaseUrlFor ?? managePurchase )(
-						this.props.siteSlug,
-						this.props.purchaseId
-					);
-					page.redirect( ( managePurchaseUrl ?? backupRedirect ) + '?cancelled=true' );
-				}
+				const redirectUrl = managePurchaseUrl ?? backupRedirect;
+				page.redirect( refundable ? redirectUrl : redirectUrl + '?cancelled=true' );
 			} else {
 				this.props.errorNotice( result.error );
 			}
@@ -1244,7 +1248,14 @@ const ConnectedCancelPurchase = connect(
 			atomicTransfer: getAtomicTransfer( state, purchase?.siteId ),
 		};
 	},
-	{ recordTracksEvent, clearPurchases, refreshSitePlans, successNotice, errorNotice }
+	{
+		recordTracksEvent,
+		clearPurchases,
+		refreshSitePlans,
+		removePurchaseFromState,
+		successNotice,
+		errorNotice,
+	}
 )( localize( withLocalizedMoment( CancelPurchase ) ) );
 
 function CancelPurchaseWithExperiment( props: CancelPurchaseProps ) {

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -565,7 +565,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		if ( isRemoveDeleteFlow ) {
 			// Capture props before the timeout — connect() + useSyncExternalStore
 			// may update this.props synchronously when the Redux store changes.
-			const { purchase, purchaseId, atomicTransfer, purchaseListUrl } = this.props;
+			const { purchase, purchaseId, atomicTransfer, purchaseListUrl, translate } = this.props;
 			const productNoun = getProductNounForCategory( classifyPurchaseForCopy( purchase ) );
 			const isAtomic = Boolean( atomicTransfer?.created_at );
 			const backupRedirect = purchaseListUrl ?? purchasesRoot;
@@ -584,8 +584,12 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 				}
 				page.redirect( `${ backupRedirect }?${ params.toString() }` );
 
-				// 3. Fire mutation in background (fire-and-forget)
-				removePurchaseRequest( purchase.id ).catch( () => {} );
+				// 3. Fire mutation in background
+				removePurchaseRequest( purchase.id ).catch( () => {
+					this.props.errorNotice(
+						translate( 'There was a problem removing your purchase. Please try again.' )
+					);
+				} );
 			}, 1500 );
 			return;
 		}

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -586,6 +586,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 
 				// 3. Fire mutation in background
 				removePurchaseRequest( purchase.id ).catch( () => {
+					window.dispatchEvent( new CustomEvent( 'purchase-remove-failed' ) );
 					this.props.errorNotice(
 						translate( 'There was a problem removing your purchase. Please try again.' )
 					);

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -162,7 +162,12 @@ export interface CancelPurchaseActions {
 	refreshSitePlans: ( siteId: string | number ) => void;
 	successNotice: (
 		message: string | ReactNode,
-		properties: { displayOnNextPage?: boolean; duration?: number }
+		properties: {
+			displayOnNextPage?: boolean;
+			duration?: number;
+			button?: string;
+			href?: string;
+		}
 	) => void;
 	errorNotice: ( message: string | ReactNode ) => void;
 }
@@ -563,6 +568,24 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 				await this.handleMarketplaceSubscriptions( refundable );
 				this.props.refreshSitePlans( this.props.purchase.siteId );
 				this.props.clearPurchases();
+				if ( isRemoveDeleteFlow && this.props.atomicTransfer?.created_at ) {
+					this.props.successNotice(
+						this.props.translate(
+							'Your site has been removed. Download a backup to save your themes and plugins.'
+						),
+						{
+							displayOnNextPage: true,
+							duration: 10000,
+							button: this.props.translate( 'Download a backup' ),
+							href: `//${ this.props.purchase.domain }/wp-admin/export.php`,
+						}
+					);
+				} else {
+					this.props.successNotice( result.message, {
+						displayOnNextPage: true,
+						duration: 10000,
+					} );
+				}
 				if ( isRemoveDeleteFlow ) {
 					invokeSurvicateEvent( 'purchaseRemoved' );
 				} else if ( refundable ) {

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -566,7 +566,9 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			// Capture props before the timeout — connect() + useSyncExternalStore
 			// may update this.props synchronously when the Redux store changes.
 			const { purchase, purchaseId, atomicTransfer, purchaseListUrl, translate } = this.props;
-			const productNoun = getProductNounForCategory( classifyPurchaseForCopy( purchase ) );
+			const category = classifyPurchaseForCopy( purchase );
+			const productNoun = getProductNounForCategory( category );
+			const sendsEmail = category === 'plan' || category === 'domain';
 			const isAtomic = Boolean( atomicTransfer?.created_at );
 			const backupRedirect = purchaseListUrl ?? purchasesRoot;
 
@@ -579,6 +581,9 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 				invokeSurvicateEvent( 'purchaseRemoved' );
 				const params = new URLSearchParams();
 				params.set( 'removed', productNoun );
+				if ( sendsEmail ) {
+					params.set( 'removedSendsEmail', '1' );
+				}
 				if ( isAtomic ) {
 					params.set( 'removedDomain', purchase.domain );
 				}

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -566,9 +566,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			// Capture props before the timeout — connect() + useSyncExternalStore
 			// may update this.props synchronously when the Redux store changes.
 			const { purchase, purchaseId, atomicTransfer, purchaseListUrl, translate } = this.props;
-			const category = classifyPurchaseForCopy( purchase );
-			const productNoun = getProductNounForCategory( category );
-			const sendsEmail = category === 'plan' || category === 'domain';
+			const productNoun = getProductNounForCategory( classifyPurchaseForCopy( purchase ) );
 			const isAtomic = Boolean( atomicTransfer?.created_at );
 			const backupRedirect = purchaseListUrl ?? purchasesRoot;
 
@@ -581,9 +579,6 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 				invokeSurvicateEvent( 'purchaseRemoved' );
 				const params = new URLSearchParams();
 				params.set( 'removed', productNoun );
-				if ( sendsEmail ) {
-					params.set( 'removedSendsEmail', '1' );
-				}
 				if ( isAtomic ) {
 					params.set( 'removedDomain', purchase.domain );
 				}

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -63,7 +63,11 @@ import { isDataLoading } from 'calypso/me/purchases/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
-import { clearPurchases, removePurchaseFromState } from 'calypso/state/purchases/actions';
+import {
+	clearPurchases,
+	removePurchaseFromState,
+	restorePurchaseToState,
+} from 'calypso/state/purchases/actions';
 import {
 	getByPurchaseId,
 	getSitePurchases,
@@ -162,7 +166,8 @@ export interface CancelPurchaseActions {
 	) => void;
 	clearPurchases: () => void;
 	refreshSitePlans: ( siteId: string | number ) => void;
-	removePurchaseFromState: ( purchaseId: string | number ) => void;
+	removePurchaseFromState: ( purchaseId: string | number ) => Purchases.RawPurchase | null;
+	restorePurchaseToState: ( purchase: Purchases.RawPurchase ) => void;
 	successNotice: (
 		message: string | ReactNode,
 		properties: {
@@ -572,21 +577,28 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 
 			// Delay everything for tactile feedback (button stays busy for 1.5s)
 			setTimeout( () => {
-				// 1. Strip purchase from Redux store (preserves loaded flags — no refetch cascade)
-				this.props.removePurchaseFromState( purchaseId );
+				// 1. Strip purchase from Redux store (preserves loaded flags — no refetch cascade).
+				//    Capture the raw form so we can restore it if the mutation fails.
+				const rawPurchase = this.props.removePurchaseFromState( purchaseId );
 
-				// 2. Navigate with notice params
+				// 2. Navigate with notice params (removedId enables the list to dismiss
+				//    the success notice if the background mutation rolls back.)
 				invokeSurvicateEvent( 'purchaseRemoved' );
 				const params = new URLSearchParams();
 				params.set( 'removed', productNoun );
+				params.set( 'removedId', String( purchase.id ) );
 				if ( isAtomic ) {
 					params.set( 'removedDomain', purchase.domain );
 				}
 				page.redirect( `${ backupRedirect }?${ params.toString() }` );
 
-				// 3. Fire mutation in background
+				// 3. Fire mutation in background. On failure, restore the purchase to
+				//    Redux — the list watches getUserPurchases for reappearance and
+				//    self-dismisses its notice.
 				removePurchaseRequest( purchase.id ).catch( () => {
-					window.dispatchEvent( new CustomEvent( 'purchase-remove-failed' ) );
+					if ( rawPurchase ) {
+						this.props.restorePurchaseToState( rawPurchase );
+					}
 					this.props.errorNotice(
 						translate( 'There was a problem removing your purchase. Please try again.' )
 					);
@@ -1258,6 +1270,7 @@ const ConnectedCancelPurchase = connect(
 		clearPurchases,
 		refreshSitePlans,
 		removePurchaseFromState,
+		restorePurchaseToState,
 		successNotice,
 		errorNotice,
 	}

--- a/client/me/purchases/purchases-list-in-dataviews/index.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/index.tsx
@@ -5,7 +5,7 @@ import { SiteDetails } from '@automattic/data-stores';
 import useGetJetpackTransferredLicensePurchases from '@automattic/data-stores/src/purchases/queries/use-get-jetpack-transferred-license-purchases';
 import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { connect } from 'react-redux';
 import noSitesIllustration from 'calypso/assets/images/illustrations/illustration-nosites.svg';
 import QueryConciergeInitial from 'calypso/components/data/query-concierge-initial';
@@ -117,6 +117,13 @@ const PurchasesListDataView: React.FC<
 		return { productNoun: removed, atomicDomain: removedDomain };
 	} );
 	const [ showRemovedNotice, setShowRemovedNotice ] = useState( Boolean( removedNoticeData ) );
+
+	// Dismiss the success notice if the background mutation fails.
+	useEffect( () => {
+		const dismiss = () => setShowRemovedNotice( false );
+		window.addEventListener( 'purchase-remove-failed', dismiss );
+		return () => window.removeEventListener( 'purchase-remove-failed', dismiss );
+	}, [] );
 
 	const {
 		data: transferredOwnershipPurchases = [],

--- a/client/me/purchases/purchases-list-in-dataviews/index.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/index.tsx
@@ -108,13 +108,15 @@ const PurchasesListDataView: React.FC<
 			return null;
 		}
 		const removedDomain = params.get( 'removedDomain' );
+		const sendsEmail = params.get( 'removedSendsEmail' ) === '1';
 		params.delete( 'removed' );
 		params.delete( 'removedDomain' );
+		params.delete( 'removedSendsEmail' );
 		const newSearch = params.toString();
 		const newUrl =
 			window.location.pathname + ( newSearch ? '?' + newSearch : '' ) + window.location.hash;
 		window.history.replaceState( window.history.state, '', newUrl );
-		return { productNoun: removed, atomicDomain: removedDomain };
+		return { productNoun: removed, atomicDomain: removedDomain, sendsEmail };
 	} );
 	const [ showRemovedNotice, setShowRemovedNotice ] = useState( Boolean( removedNoticeData ) );
 
@@ -184,28 +186,53 @@ const PurchasesListDataView: React.FC<
 						onDismissClick={ () => setShowRemovedNotice( false ) }
 						status="is-success"
 					>
-						{ removedNoticeData.atomicDomain
-							? translate(
-									'Your %(productNoun)s has been removed. Your site will revert to its previous state \u2014 {{a}}download a backup{{/a}} to save your content, themes, and plugins. You\u2019ll receive a confirmation email shortly.',
-									{
-										args: { productNoun: removedNoticeData.productNoun },
-										components: {
-											a: (
-												<a
-													href={ `https://${ removedNoticeData.atomicDomain }/wp-admin/export.php` }
-													target="_blank"
-													rel="noreferrer"
-												/>
-											),
-										},
-									}
-							  )
-							: translate(
-									'Your %(productNoun)s has been removed. You\u2019ll receive a confirmation email shortly.',
-									{
-										args: { productNoun: removedNoticeData.productNoun },
-									}
-							  ) }
+						{ removedNoticeData.atomicDomain &&
+							removedNoticeData.sendsEmail &&
+							translate(
+								'Your %(productNoun)s has been removed. Your site will revert to its previous state \u2014 {{a}}download a backup{{/a}} to save your content, themes, and plugins. You\u2019ll receive a confirmation email shortly.',
+								{
+									args: { productNoun: removedNoticeData.productNoun },
+									components: {
+										a: (
+											<a
+												href={ `https://${ removedNoticeData.atomicDomain }/wp-admin/export.php` }
+												target="_blank"
+												rel="noreferrer"
+											/>
+										),
+									},
+								}
+							) }
+						{ removedNoticeData.atomicDomain &&
+							! removedNoticeData.sendsEmail &&
+							translate(
+								'Your %(productNoun)s has been removed. Your site will revert to its previous state \u2014 {{a}}download a backup{{/a}} to save your content, themes, and plugins.',
+								{
+									args: { productNoun: removedNoticeData.productNoun },
+									components: {
+										a: (
+											<a
+												href={ `https://${ removedNoticeData.atomicDomain }/wp-admin/export.php` }
+												target="_blank"
+												rel="noreferrer"
+											/>
+										),
+									},
+								}
+							) }
+						{ ! removedNoticeData.atomicDomain &&
+							removedNoticeData.sendsEmail &&
+							translate(
+								'Your %(productNoun)s has been removed. You\u2019ll receive a confirmation email shortly.',
+								{
+									args: { productNoun: removedNoticeData.productNoun },
+								}
+							) }
+						{ ! removedNoticeData.atomicDomain &&
+							! removedNoticeData.sendsEmail &&
+							translate( 'Your %(productNoun)s has been removed.', {
+								args: { productNoun: removedNoticeData.productNoun },
+							} ) }
 					</Notice>
 				) }
 			<PurchasesContent

--- a/client/me/purchases/purchases-list-in-dataviews/index.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/index.tsx
@@ -97,7 +97,7 @@ const PurchasesListDataView: React.FC<
 } ) => {
 	const translate = useTranslate();
 
-	// Read ?removed and ?removedDomain from URL on mount, then strip params.
+	// Read ?removed, ?removedDomain, and ?removedId from URL on mount, then strip params.
 	const [ removedNoticeData ] = useState( () => {
 		if ( typeof window === 'undefined' ) {
 			return null;
@@ -108,22 +108,30 @@ const PurchasesListDataView: React.FC<
 			return null;
 		}
 		const removedDomain = params.get( 'removedDomain' );
+		const removedIdStr = params.get( 'removedId' );
+		const purchaseId = removedIdStr ? Number( removedIdStr ) : null;
 		params.delete( 'removed' );
 		params.delete( 'removedDomain' );
+		params.delete( 'removedId' );
 		const newSearch = params.toString();
 		const newUrl =
 			window.location.pathname + ( newSearch ? '?' + newSearch : '' ) + window.location.hash;
 		window.history.replaceState( window.history.state, '', newUrl );
-		return { productNoun: removed, atomicDomain: removedDomain };
+		return { productNoun: removed, atomicDomain: removedDomain, purchaseId };
 	} );
 	const [ showRemovedNotice, setShowRemovedNotice ] = useState( Boolean( removedNoticeData ) );
 
-	// Dismiss the success notice if the background mutation fails.
+	// Dismiss the success notice when the background mutation rolls back —
+	// detected by the captured purchase reappearing in the user's purchase list.
+	// `purchases` is camelCase via getUserPurchases → createPurchasesArray.
 	useEffect( () => {
-		const dismiss = () => setShowRemovedNotice( false );
-		window.addEventListener( 'purchase-remove-failed', dismiss );
-		return () => window.removeEventListener( 'purchase-remove-failed', dismiss );
-	}, [] );
+		if ( ! removedNoticeData?.purchaseId ) {
+			return;
+		}
+		if ( purchases?.some( ( p ) => String( p.id ) === String( removedNoticeData.purchaseId ) ) ) {
+			setShowRemovedNotice( false );
+		}
+	}, [ purchases, removedNoticeData ] );
 
 	const {
 		data: transferredOwnershipPurchases = [],

--- a/client/me/purchases/purchases-list-in-dataviews/index.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/index.tsx
@@ -1,10 +1,11 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import config from '@automattic/calypso-config';
 import { CompactCard } from '@automattic/components';
 import { SiteDetails } from '@automattic/data-stores';
 import useGetJetpackTransferredLicensePurchases from '@automattic/data-stores/src/purchases/queries/use-get-jetpack-transferred-license-purchases';
 import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { connect } from 'react-redux';
 import noSitesIllustration from 'calypso/assets/images/illustrations/illustration-nosites.svg';
 import QueryConciergeInitial from 'calypso/components/data/query-concierge-initial';
@@ -15,6 +16,7 @@ import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
+import Notice from 'calypso/components/notice';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import {
@@ -94,6 +96,28 @@ const PurchasesListDataView: React.FC<
 	userId,
 } ) => {
 	const translate = useTranslate();
+
+	// Read ?removed and ?removedDomain from URL on mount, then strip params.
+	const [ removedNoticeData ] = useState( () => {
+		if ( typeof window === 'undefined' ) {
+			return null;
+		}
+		const params = new URLSearchParams( window.location.search );
+		const removed = params.get( 'removed' );
+		if ( ! removed ) {
+			return null;
+		}
+		const removedDomain = params.get( 'removedDomain' );
+		params.delete( 'removed' );
+		params.delete( 'removedDomain' );
+		const newSearch = params.toString();
+		const newUrl =
+			window.location.pathname + ( newSearch ? '?' + newSearch : '' ) + window.location.hash;
+		window.history.replaceState( window.history.state, '', newUrl );
+		return { productNoun: removed, atomicDomain: removedDomain };
+	} );
+	const [ showRemovedNotice, setShowRemovedNotice ] = useState( Boolean( removedNoticeData ) );
+
 	const {
 		data: transferredOwnershipPurchases = [],
 		isLoading,
@@ -145,6 +169,38 @@ const PurchasesListDataView: React.FC<
 				) }
 			/>
 			<PurchasesNavigation section="activeUpgrades" />
+			{ config.isEnabled( 'purchases/split-cancel-remove' ) &&
+				showRemovedNotice &&
+				removedNoticeData && (
+					<Notice
+						showDismiss
+						onDismissClick={ () => setShowRemovedNotice( false ) }
+						status="is-success"
+					>
+						{ removedNoticeData.atomicDomain
+							? translate(
+									'Your %(productNoun)s has been removed. Your site will revert to its previous state \u2014 {{a}}download a backup{{/a}} to save your content, themes, and plugins. You\u2019ll receive a confirmation email shortly.',
+									{
+										args: { productNoun: removedNoticeData.productNoun },
+										components: {
+											a: (
+												<a
+													href={ `https://${ removedNoticeData.atomicDomain }/wp-admin/export.php` }
+													target="_blank"
+													rel="noreferrer"
+												/>
+											),
+										},
+									}
+							  )
+							: translate(
+									'Your %(productNoun)s has been removed. You\u2019ll receive a confirmation email shortly.',
+									{
+										args: { productNoun: removedNoticeData.productNoun },
+									}
+							  ) }
+					</Notice>
+				) }
 			<PurchasesContent
 				isDataLoading={ isDataLoading() }
 				allPurchases={ allPurchases }

--- a/client/me/purchases/purchases-list-in-dataviews/index.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/index.tsx
@@ -108,15 +108,13 @@ const PurchasesListDataView: React.FC<
 			return null;
 		}
 		const removedDomain = params.get( 'removedDomain' );
-		const sendsEmail = params.get( 'removedSendsEmail' ) === '1';
 		params.delete( 'removed' );
 		params.delete( 'removedDomain' );
-		params.delete( 'removedSendsEmail' );
 		const newSearch = params.toString();
 		const newUrl =
 			window.location.pathname + ( newSearch ? '?' + newSearch : '' ) + window.location.hash;
 		window.history.replaceState( window.history.state, '', newUrl );
-		return { productNoun: removed, atomicDomain: removedDomain, sendsEmail };
+		return { productNoun: removed, atomicDomain: removedDomain };
 	} );
 	const [ showRemovedNotice, setShowRemovedNotice ] = useState( Boolean( removedNoticeData ) );
 
@@ -186,53 +184,28 @@ const PurchasesListDataView: React.FC<
 						onDismissClick={ () => setShowRemovedNotice( false ) }
 						status="is-success"
 					>
-						{ removedNoticeData.atomicDomain &&
-							removedNoticeData.sendsEmail &&
-							translate(
-								'Your %(productNoun)s has been removed. Your site will revert to its previous state \u2014 {{a}}download a backup{{/a}} to save your content, themes, and plugins. You\u2019ll receive a confirmation email shortly.',
-								{
-									args: { productNoun: removedNoticeData.productNoun },
-									components: {
-										a: (
-											<a
-												href={ `https://${ removedNoticeData.atomicDomain }/wp-admin/export.php` }
-												target="_blank"
-												rel="noreferrer"
-											/>
-										),
-									},
-								}
-							) }
-						{ removedNoticeData.atomicDomain &&
-							! removedNoticeData.sendsEmail &&
-							translate(
-								'Your %(productNoun)s has been removed. Your site will revert to its previous state \u2014 {{a}}download a backup{{/a}} to save your content, themes, and plugins.',
-								{
-									args: { productNoun: removedNoticeData.productNoun },
-									components: {
-										a: (
-											<a
-												href={ `https://${ removedNoticeData.atomicDomain }/wp-admin/export.php` }
-												target="_blank"
-												rel="noreferrer"
-											/>
-										),
-									},
-								}
-							) }
-						{ ! removedNoticeData.atomicDomain &&
-							removedNoticeData.sendsEmail &&
-							translate(
-								'Your %(productNoun)s has been removed. You\u2019ll receive a confirmation email shortly.',
-								{
-									args: { productNoun: removedNoticeData.productNoun },
-								}
-							) }
-						{ ! removedNoticeData.atomicDomain &&
-							! removedNoticeData.sendsEmail &&
-							translate( 'Your %(productNoun)s has been removed.', {
-								args: { productNoun: removedNoticeData.productNoun },
-							} ) }
+						{ removedNoticeData.atomicDomain
+							? translate(
+									'Your %(productNoun)s has been removed. Your site will revert to its previous state \u2014 {{a}}download a backup{{/a}} to save your content, themes, and plugins. You\u2019ll receive a confirmation email shortly.',
+									{
+										args: { productNoun: removedNoticeData.productNoun },
+										components: {
+											a: (
+												<a
+													href={ `https://${ removedNoticeData.atomicDomain }/wp-admin/export.php` }
+													target="_blank"
+													rel="noreferrer"
+												/>
+											),
+										},
+									}
+							  )
+							: translate(
+									'Your %(productNoun)s has been removed. You\u2019ll receive a confirmation email shortly.',
+									{
+										args: { productNoun: removedNoticeData.productNoun },
+									}
+							  ) }
 					</Notice>
 				) }
 			<PurchasesContent

--- a/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
+++ b/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
@@ -1,11 +1,13 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import config from '@automattic/calypso-config';
 import { CompactCard } from '@automattic/components';
 import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import EmptyContent from 'calypso/components/empty-content';
 import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
 import JetpackRnaActionCard from 'calypso/components/jetpack/card/jetpack-rna-action-card';
+import Notice from 'calypso/components/notice';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { PurchasesDataViews } from 'calypso/me/purchases/purchases-list-in-dataviews/purchases-data-view';
@@ -24,6 +26,7 @@ import type { GetManagePurchaseUrlFor } from 'calypso/lib/purchases/types';
 import './style.scss';
 
 export default function SubscriptionsContentWrapper() {
+	const translate = useTranslate();
 	const isFetchingPurchases = useSelector( isFetchingSitePurchases );
 	const hasLoadedPurchases = useSelector( hasLoadedSitePurchasesFromServer );
 	const selectedSiteId = useSelector( getSelectedSiteId );
@@ -34,6 +37,27 @@ export default function SubscriptionsContentWrapper() {
 		( siteSlug, purchaseId ) => `/purchases/subscriptions/${ siteSlug }/${ purchaseId }`,
 		[]
 	);
+
+	// Read ?removed and ?removedDomain from URL on mount, then strip params.
+	const [ removedNoticeData ] = useState( () => {
+		if ( typeof window === 'undefined' ) {
+			return null;
+		}
+		const params = new URLSearchParams( window.location.search );
+		const removed = params.get( 'removed' );
+		if ( ! removed ) {
+			return null;
+		}
+		const removedDomain = params.get( 'removedDomain' );
+		params.delete( 'removed' );
+		params.delete( 'removedDomain' );
+		const newSearch = params.toString();
+		const newUrl =
+			window.location.pathname + ( newSearch ? '?' + newSearch : '' ) + window.location.hash;
+		window.history.replaceState( window.history.state, '', newUrl );
+		return { productNoun: removed, atomicDomain: removedDomain };
+	} );
+	const [ showRemovedNotice, setShowRemovedNotice ] = useState( Boolean( removedNoticeData ) );
 
 	if ( ! selectedSiteId ) {
 		return <NoSitesMessage />;
@@ -56,12 +80,50 @@ export default function SubscriptionsContentWrapper() {
 	if ( purchases.length < 1 ) {
 		return <NoPurchasesMessage />;
 	}
+
+	const removedNotice =
+		config.isEnabled( 'purchases/split-cancel-remove' ) &&
+		showRemovedNotice &&
+		removedNoticeData ? (
+			<Notice
+				showDismiss
+				onDismissClick={ () => setShowRemovedNotice( false ) }
+				status="is-success"
+			>
+				{ removedNoticeData.atomicDomain
+					? translate(
+							'Your %(productNoun)s has been removed. Your site will revert to its previous state \u2014 {{a}}download a backup{{/a}} to save your content, themes, and plugins. You\u2019ll receive a confirmation email shortly.',
+							{
+								args: { productNoun: removedNoticeData.productNoun },
+								components: {
+									a: (
+										<a
+											href={ `https://${ removedNoticeData.atomicDomain }/wp-admin/export.php` }
+											target="_blank"
+											rel="noreferrer"
+										/>
+									),
+								},
+							}
+					  )
+					: translate(
+							'Your %(productNoun)s has been removed. You\u2019ll receive a confirmation email shortly.',
+							{
+								args: { productNoun: removedNoticeData.productNoun },
+							}
+					  ) }
+			</Notice>
+		) : null;
+
 	return (
-		<PurchasesDataViews
-			purchases={ purchases }
-			sites={ sites }
-			getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
-		/>
+		<>
+			{ removedNotice }
+			<PurchasesDataViews
+				purchases={ purchases }
+				sites={ sites }
+				getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
+			/>
+		</>
 	);
 }
 

--- a/client/state/purchases/actions.js
+++ b/client/state/purchases/actions.js
@@ -71,6 +71,7 @@ export const removePurchaseFromState = ( purchaseId ) => ( dispatch, getState ) 
 	trackRemovedPurchase( purchaseId );
 	const state = getState();
 	const currentData = state.purchases.data ?? [];
+	const captured = currentData.find( ( p ) => String( p.ID ) === String( purchaseId ) ) ?? null;
 	const siteId = getSelectedSiteId( state );
 	dispatch( {
 		type: PURCHASE_REMOVE_COMPLETED,
@@ -79,6 +80,23 @@ export const removePurchaseFromState = ( purchaseId ) => ( dispatch, getState ) 
 	if ( siteId ) {
 		dispatch( requestAdminMenu( siteId ) );
 	}
+	return captured;
+};
+
+/**
+ * Reverses a previous removePurchaseFromState by re-adding the purchase to
+ * Redux state and clearing it from recentlyRemovedPurchaseIds so a subsequent
+ * fetch result is not filtered out. Idempotent.
+ */
+export const restorePurchaseToState = ( purchase ) => ( dispatch, getState ) => {
+	recentlyRemovedPurchaseIds.delete( String( purchase.ID ) );
+	const state = getState();
+	const currentData = state.purchases.data ?? [];
+	const exists = currentData.some( ( p ) => String( p.ID ) === String( purchase.ID ) );
+	dispatch( {
+		type: PURCHASE_REMOVE_COMPLETED,
+		purchases: exists ? currentData : [ ...currentData, purchase ],
+	} );
 };
 
 export const fetchSitePurchases = ( siteId ) => ( dispatch ) => {

--- a/client/state/purchases/actions.js
+++ b/client/state/purchases/actions.js
@@ -19,6 +19,26 @@ import 'calypso/state/purchases/init';
 const PURCHASES_FETCH_ERROR_MESSAGE = i18n.translate( 'There was an error retrieving purchases.' );
 const PURCHASE_REMOVE_ERROR_MESSAGE = i18n.translate( 'There was an error removing the purchase.' );
 
+/**
+ * Tracks purchase IDs that were recently removed via removePurchaseFromState.
+ * fetchSitePurchases filters these from the API response to prevent stale
+ * server data from re-inserting a removed purchase into Redux (the server
+ * may still return it due to replication lag / eventual consistency).
+ * Each entry self-clears after 15 seconds.
+ */
+const recentlyRemovedPurchaseIds = new Set();
+
+function trackRemovedPurchase( purchaseId ) {
+	const id = String( purchaseId );
+	recentlyRemovedPurchaseIds.add( id );
+	setTimeout( () => {
+		recentlyRemovedPurchaseIds.delete( id );
+	}, 15_000 );
+}
+
+// Exported for test teardown only.
+export const __resetRecentlyRemovedPurchaseIds = () => recentlyRemovedPurchaseIds.clear();
+
 export const clearPurchases = () => ( dispatch, getState ) => {
 	const siteId = getSelectedSiteId( getState() );
 
@@ -48,6 +68,7 @@ export const clearPurchases = () => ( dispatch, getState ) => {
  * migrates to `useQuery`, this helper can be removed.
  */
 export const removePurchaseFromState = ( purchaseId ) => ( dispatch, getState ) => {
+	trackRemovedPurchase( purchaseId );
 	const state = getState();
 	const currentData = state.purchases.data ?? [];
 	const siteId = getSelectedSiteId( state );
@@ -72,10 +93,13 @@ export const fetchSitePurchases = ( siteId ) => ( dispatch ) => {
 			apiVersion: '1.2',
 		} )
 		.then( ( data ) => {
+			const purchases = recentlyRemovedPurchaseIds.size
+				? data.filter( ( p ) => ! recentlyRemovedPurchaseIds.has( String( p.ID ) ) )
+				: data;
 			dispatch( {
 				type: PURCHASES_SITE_FETCH_COMPLETED,
 				siteId,
-				purchases: data,
+				purchases,
 			} );
 		} )
 		.catch( () => {

--- a/client/state/purchases/test/actions.js
+++ b/client/state/purchases/test/actions.js
@@ -8,13 +8,15 @@ import {
 	PURCHASE_REMOVE_FAILED,
 } from 'calypso/state/action-types';
 import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
-import useNock from 'calypso/test-helpers/use-nock';
+import useNock, { nock as nockInstance } from 'calypso/test-helpers/use-nock';
 import {
 	clearPurchases,
 	fetchSitePurchases,
 	fetchUserPurchases,
 	removePurchase,
 	removePurchaseFromState,
+	restorePurchaseToState,
+	__resetRecentlyRemovedPurchaseIds,
 } from '../actions';
 
 describe( 'actions', () => {
@@ -193,6 +195,111 @@ describe( 'actions', () => {
 				( [ action ] ) => action?.type === requestAdminMenu( siteId ).type
 			);
 			expect( adminMenuCall ).toBeUndefined();
+		} );
+	} );
+
+	describe( '#removePurchaseFromState (return value)', () => {
+		beforeEach( () => {
+			dispatch.mockClear();
+		} );
+
+		test( 'returns the captured raw purchase that was stripped', () => {
+			const target = { ID: 2, product_name: 'Plan' };
+			const data = [ { ID: 1 }, target, { ID: 3 } ];
+			getState.mockReturnValueOnce( { purchases: { data } } );
+
+			const captured = removePurchaseFromState( 2 )( dispatch, getState );
+
+			expect( captured ).toEqual( target );
+		} );
+
+		test( 'returns null when the target ID is not in state', () => {
+			getState.mockReturnValueOnce( { purchases: { data: [ { ID: 1 } ] } } );
+
+			const captured = removePurchaseFromState( 999 )( dispatch, getState );
+
+			expect( captured ).toBeNull();
+		} );
+
+		test( 'returns null when state has not been loaded yet', () => {
+			getState.mockReturnValueOnce( { purchases: { data: null } } );
+
+			const captured = removePurchaseFromState( 1 )( dispatch, getState );
+
+			expect( captured ).toBeNull();
+		} );
+	} );
+
+	describe( '#restorePurchaseToState', () => {
+		beforeEach( () => {
+			dispatch.mockClear();
+			__resetRecentlyRemovedPurchaseIds();
+		} );
+
+		test( 'dispatches PURCHASE_REMOVE_COMPLETED with the purchase re-added when it is missing', () => {
+			const restored = { ID: 2, product_name: 'Plan' };
+			getState.mockReturnValueOnce( { purchases: { data: [ { ID: 1 } ] } } );
+
+			restorePurchaseToState( restored )( dispatch, getState );
+
+			expect( dispatch ).toHaveBeenCalledWith( {
+				type: PURCHASE_REMOVE_COMPLETED,
+				purchases: [ { ID: 1 }, restored ],
+			} );
+		} );
+
+		test( 'is idempotent when the purchase is already in state', () => {
+			const existing = { ID: 2, product_name: 'Plan' };
+			getState.mockReturnValueOnce( { purchases: { data: [ { ID: 1 }, existing ] } } );
+
+			restorePurchaseToState( existing )( dispatch, getState );
+
+			expect( dispatch ).toHaveBeenCalledWith( {
+				type: PURCHASE_REMOVE_COMPLETED,
+				purchases: [ { ID: 1 }, existing ],
+			} );
+		} );
+
+		test( 'tolerates an empty purchases data set', () => {
+			const restored = { ID: 2 };
+			getState.mockReturnValueOnce( { purchases: { data: null } } );
+
+			restorePurchaseToState( restored )( dispatch, getState );
+
+			expect( dispatch ).toHaveBeenCalledWith( {
+				type: PURCHASE_REMOVE_COMPLETED,
+				purchases: [ restored ],
+			} );
+		} );
+
+		test( 'clears the recentlyRemovedPurchaseIds tracker so subsequent fetches keep the purchase', () => {
+			const restored = { ID: 2 };
+			// Mark as recently removed (the strip path normally does this).
+			getState.mockReturnValueOnce( { purchases: { data: [ { ID: 1 }, restored ] } } );
+			removePurchaseFromState( 2 )( dispatch, getState );
+			dispatch.mockClear();
+
+			getState.mockReturnValueOnce( { purchases: { data: [ { ID: 1 } ] } } );
+			restorePurchaseToState( restored )( dispatch, getState );
+
+			// Now simulate a fetch result containing the restored purchase.
+			// The fetch path (fetchSitePurchases) filters out IDs in
+			// recentlyRemovedPurchaseIds. After restore, the ID should no longer
+			// be in that set, so the fetch dispatches the purchase through
+			// unfiltered.
+			const apiResponse = [ { ID: 1 }, { ID: 2 } ];
+			nockInstance( 'https://public-api.wordpress.com:443' )
+				.get( `/rest/v1.2/sites/${ siteId }/purchases` )
+				.reply( 200, apiResponse );
+
+			return fetchSitePurchases( siteId )( dispatch ).then( () => {
+				expect( dispatch ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						type: PURCHASES_SITE_FETCH_COMPLETED,
+						purchases: apiResponse,
+					} )
+				);
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
Related to: https://linear.app/a8c/issue/CHE-478

## Proposed Changes

This PR improves the removal flow by swapping out snacks for inline notices, cleans up the communication, and optimistically redirecting people to the right location so they don't have to wait an eternity for the removal to complete. 

Failure to remove is extremely rare but in the event that it happens, we will inform people in the interface, with a snack notice, and I'm planning on a follow up email to notify people.

More details about what was changed:

- **Navigate to purchases list** after remove — was navigating to the now-dead purchase-settings page
- **Dismissible notice** replaces transient snackbar — persists until user dismisses, with Atomic backup download link when applicable
- **Optimistic navigation** — 1.5s busy state on button, then navigate + strip from cache before firing mutation
- **Error notice on failure** — legacy remove mutation now shows an error notice instead of silently swallowing server errors

Both surfaces (legacy + dashboard). Gated behind `purchases/split-cancel-remove`.

## Why are these changes being made?

After a purchase removal, the previous flow navigated back to the purchase-settings page — which would either 404 or show stale data for a deleted purchase. The snackbar notice was too transient for users to read. These changes land the user on the purchases list with a persistent dismissible notice confirming the removal.

## Testing Instructions

- [ ] Remove a plan on dashboard (`my.localhost:3000`) — verify notice appears on purchases list, dismisses on click
- [ ] Remove a plan on legacy (`calypso.localhost:3000`) — same verification
- [ ] Remove on Atomic site — verify backup download link appears in notice
- [ ] Refresh after remove — notice should be gone (URL params stripped)
- [ ] Flag off — verify no behavior change

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)