### PR TITLE
Checkout: side-by-side subscription length picker + form/trust card alignment

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -2370,11 +2370,18 @@ const WPCheckoutMainContent = styled.div`
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		margin-top: calc( var( --masterbar-checkout-height ) + 24px );
 		max-width: 688px;
-		padding: 0 64px 0 24px;
+		padding-block: 0;
+		padding-inline-start: 24px;
+		padding-inline-end: 64px;
+	}
 
-		.rtl & {
-			padding: 0 24px 0 64px;
-		}
+	/* On narrower desktops the 64px between form and sidebar is too tight
+	   when stacked with the sidebar's own 64px left padding. Drop the form's
+	   right padding so its content reaches col-2's right edge, matching the
+	   trust cards row beneath. Restored above 1024px where the layout has
+	   room to breathe. */
+	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) and ( max-width: 1024px ) {
+		padding-inline-end: 0;
 	}
 	${ ( props ) => css`
 		.checkout-line-item .checkout-line-item__remove-product {

--- a/client/my-sites/checkout/src/components/checkout-trust-cards.tsx
+++ b/client/my-sites/checkout/src/components/checkout-trust-cards.tsx
@@ -22,6 +22,14 @@ const TrustCardsRow = styled.div`
 		padding-inline-start: 64px;
 		margin-block-end: 48px;
 	}
+
+	/* Above 1024px the form column restores its 64px right padding for
+	   breathing room from the sidebar; mirror it here so the trust cards'
+	   right edge stays aligned with the form's step content. Below 1024px
+	   both extend to col-2's right edge with no right padding. */
+	@media ( min-width: 1025px ) {
+		padding-inline-end: 64px;
+	}
 `;
 
 const TrustCard = styled.div`

--- a/client/my-sites/checkout/src/components/checkout-trust-cards.tsx
+++ b/client/my-sites/checkout/src/components/checkout-trust-cards.tsx
@@ -15,10 +15,11 @@ const TrustCardsRow = styled.div`
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
 		grid-template-columns: repeat( 2, minmax( 0, 1fr ) );
 		gap: 12px;
-		/* Mirror StepContentWrapper's left inset (composite-checkout
-		   checkout-steps.tsx) so the cards line up with the form selectors
-		   above instead of the green step icons in the gutter. */
-		padding-inline-start: 40px;
+		/* Mirror WPCheckoutMainContent's 24px padding-inline-start +
+		   StepContentWrapper's 40px inset so the cards line up with the
+		   form's step content above (line items, contact form, payment),
+		   not with the green step icons in the gutter. */
+		padding-inline-start: 64px;
 		margin-block-end: 48px;
 	}
 `;

--- a/client/my-sites/checkout/src/components/item-variation-picker/index.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/index.tsx
@@ -1,5 +1,7 @@
 import { isWpComPlan } from '@automattic/calypso-products';
+import { useViewportMatch } from '@wordpress/compose';
 import { FunctionComponent } from 'react';
+import { ItemVariationButtonRow } from './item-variation-button-row';
 import { ItemVariationDropDown } from './item-variation-dropdown';
 import { ItemVariationRadioButtons } from './item-variation-radio-buttons';
 import type { ItemVariationPickerProps } from './types';
@@ -10,8 +12,12 @@ import type { ItemVariationPickerProps } from './types';
  */
 export const ItemVariationPicker: FunctionComponent< ItemVariationPickerProps > = ( props ) => {
 	const { selectedItem } = props;
+	const isLargeViewport = useViewportMatch( 'large', '>=' );
 
 	if ( isWpComPlan( selectedItem.product_slug ) ) {
+		if ( isLargeViewport ) {
+			return <ItemVariationButtonRow { ...props } />;
+		}
 		return <ItemVariationRadioButtons { ...props } />;
 	}
 

--- a/client/my-sites/checkout/src/components/item-variation-picker/item-variation-button-row.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/item-variation-button-row.tsx
@@ -9,17 +9,19 @@ import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
 const Row = styled.div< { count: number } >`
 	display: grid;
-	grid-template-columns: repeat( ${ ( props ) => props.count }, 1fr );
+	grid-template-columns: repeat( ${ ( props ) => props.count }, minmax( 0, 1fr ) );
 	gap: 10px;
-	margin: 20px 0;
+	margin: 16px 0;
 	width: 100%;
 `;
 
 const Tile = styled.button< { active: boolean } >`
 	display: flex;
-	align-items: center;
-	gap: 14px;
-	padding: ${ ( props ) => ( props.active ? '12px 17px' : '13px 18px' ) };
+	flex-direction: column;
+	align-items: stretch;
+	justify-content: center;
+	gap: 6px;
+	padding: ${ ( props ) => ( props.active ? '15px 12px' : '16px 13px' ) };
 	border: ${ ( props ) =>
 		props.active
 			? `2px solid ${ colorStudio.colors[ 'Blue 50' ] }`
@@ -27,7 +29,6 @@ const Tile = styled.button< { active: boolean } >`
 	border-radius: 3px;
 	background: #fff;
 	cursor: pointer;
-	text-align: start;
 	font: inherit;
 
 	&:disabled {
@@ -42,24 +43,20 @@ const Tile = styled.button< { active: boolean } >`
 `;
 
 const Label = styled.span`
-	flex: 1;
 	font-size: 15px;
 	font-weight: 500;
+	line-height: 20px;
 	color: ${ colorStudio.colors[ 'Black' ] };
-`;
-
-const PriceColumn = styled.span`
-	display: flex;
-	flex-direction: column;
-	align-items: flex-end;
-	gap: 4px;
+	text-align: start;
 `;
 
 const Price = styled.span`
 	font-size: 15px;
 	font-weight: 500;
+	line-height: 20px;
 	font-variant-numeric: tabular-nums;
 	color: ${ colorStudio.colors[ 'Black' ] };
+	text-align: start;
 `;
 
 const PriceSuffix = styled.span`
@@ -67,6 +64,8 @@ const PriceSuffix = styled.span`
 `;
 
 const SavePill = styled.span`
+	align-self: flex-start;
+	width: fit-content;
 	font-size: 11px;
 	font-weight: 500;
 	line-height: 16px;
@@ -75,6 +74,15 @@ const SavePill = styled.span`
 	padding: 1px 7px;
 	border-radius: 3px;
 	white-space: nowrap;
+`;
+
+const SavePillPlaceholder = styled.span`
+	align-self: flex-start;
+	width: fit-content;
+	font-size: 11px;
+	line-height: 16px;
+	padding: 1px 7px;
+	visibility: hidden;
 `;
 
 interface TileProps {
@@ -126,19 +134,19 @@ const ButtonTile: FunctionComponent< TileProps > = ( {
 			} }
 		>
 			<Label>{ label }</Label>
-			<PriceColumn>
-				<Price>
-					{ pricePerMonthFormatted }
-					<PriceSuffix>{ translate( '/mo' ) }</PriceSuffix>
-				</Price>
-				{ discountPercentage > 0 && (
-					<SavePill>
-						{ translate( 'Save %(percent)s%%', {
-							args: { percent: discountPercentage },
-						} ) }
-					</SavePill>
-				) }
-			</PriceColumn>
+			<Price>
+				{ pricePerMonthFormatted }
+				<PriceSuffix>{ translate( '/mo' ) }</PriceSuffix>
+			</Price>
+			{ discountPercentage > 0 ? (
+				<SavePill>
+					{ translate( 'Save %(percent)s%%', {
+						args: { percent: discountPercentage },
+					} ) }
+				</SavePill>
+			) : (
+				<SavePillPlaceholder aria-hidden="true">&nbsp;</SavePillPlaceholder>
+			) }
 		</Tile>
 	);
 };

--- a/client/my-sites/checkout/src/components/item-variation-picker/item-variation-button-row.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/item-variation-button-row.tsx
@@ -2,7 +2,16 @@ import colorStudio from '@automattic/color-studio';
 import { formatCurrency } from '@automattic/number-formatters';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useState, type FunctionComponent } from 'react';
+import {
+	forwardRef,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+	type ForwardedRef,
+	type FunctionComponent,
+	type KeyboardEvent,
+} from 'react';
 import { getItemVariantDiscount } from './util';
 import type { ItemVariationPickerProps, WPCOMProductVariant, OnChangeItemVariant } from './types';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
@@ -59,10 +68,6 @@ const Price = styled.span`
 	text-align: start;
 `;
 
-const PriceSuffix = styled.span`
-	color: ${ colorStudio.colors[ 'Gray 60' ] };
-`;
-
 const SavePill = styled.span`
 	align-self: flex-start;
 	width: fit-content;
@@ -92,64 +97,76 @@ interface TileProps {
 	isDisabled: boolean;
 	compareTo?: WPCOMProductVariant;
 	isActive: boolean;
+	tabIndex: number;
 }
 
-const ButtonTile: FunctionComponent< TileProps > = ( {
-	productVariant,
-	selectedItem,
-	onChangeItemVariant,
-	isDisabled,
-	compareTo,
-	isActive,
-} ) => {
-	const translate = useTranslate();
-	const { variantLabel, productSlug, productId, termIntervalInMonths } = productVariant;
+const ButtonTile = forwardRef(
+	(
+		{
+			productVariant,
+			selectedItem,
+			onChangeItemVariant,
+			isDisabled,
+			compareTo,
+			isActive,
+			tabIndex,
+		}: TileProps,
+		ref: ForwardedRef< HTMLButtonElement >
+	) => {
+		const translate = useTranslate();
+		const { variantLabel, productSlug, productId, termIntervalInMonths } = productVariant;
 
-	let priceTermIntervalInMonths = termIntervalInMonths;
-	if ( productVariant.introductoryTerm === 'month' ) {
-		priceTermIntervalInMonths = productVariant.introductoryInterval ?? 1;
-	}
-	const pricePerMonth = Math.round( productVariant.priceInteger / priceTermIntervalInMonths );
-	const pricePerMonthFormatted = formatCurrency( pricePerMonth, productVariant.currency, {
-		stripZeros: true,
-		isSmallestUnit: true,
-	} );
+		let priceTermIntervalInMonths = termIntervalInMonths;
+		if ( productVariant.introductoryTerm === 'month' ) {
+			priceTermIntervalInMonths = productVariant.introductoryInterval ?? 1;
+		}
+		const pricePerMonth = Math.round( productVariant.priceInteger / priceTermIntervalInMonths );
+		const pricePerMonthFormatted = formatCurrency( pricePerMonth, productVariant.currency, {
+			stripZeros: true,
+			isSmallestUnit: true,
+		} );
 
-	const label = termIntervalInMonths === 1 ? translate( 'Month' ) : variantLabel.noun;
-	const discountPercentage = getItemVariantDiscount( productVariant, compareTo );
+		const label = termIntervalInMonths === 1 ? translate( 'Month' ) : variantLabel.noun;
+		const discountPercentage = getItemVariantDiscount( productVariant, compareTo );
 
-	return (
-		<Tile
-			type="button"
-			role="radio"
-			aria-checked={ isActive }
-			active={ isActive }
-			disabled={ isDisabled }
-			data-product-slug={ productSlug }
-			onClick={ () => {
-				if ( isDisabled || isActive ) {
-					return;
-				}
-				onChangeItemVariant( selectedItem.uuid, productSlug, productId );
-			} }
-		>
-			<Label>{ label }</Label>
-			<Price>
-				{ pricePerMonthFormatted }
-				<PriceSuffix>{ translate( '/mo' ) }</PriceSuffix>
-			</Price>
-			{ discountPercentage > 0 ? (
-				<SavePill>
-					{ translate( 'Save %(percent)s%%', {
-						args: { percent: discountPercentage },
+		return (
+			<Tile
+				ref={ ref }
+				type="button"
+				role="radio"
+				aria-checked={ isActive }
+				active={ isActive }
+				disabled={ isDisabled }
+				tabIndex={ tabIndex }
+				data-product-slug={ productSlug }
+				onClick={ () => {
+					if ( isDisabled || isActive ) {
+						return;
+					}
+					onChangeItemVariant( selectedItem.uuid, productSlug, productId );
+				} }
+			>
+				<Label>{ label }</Label>
+				<Price>
+					{ translate( '%(pricePerMonth)s/mo', {
+						args: { pricePerMonth: pricePerMonthFormatted },
 					} ) }
-				</SavePill>
-			) : (
-				<SavePillPlaceholder aria-hidden="true">&nbsp;</SavePillPlaceholder>
-			) }
-		</Tile>
-	);
-};
+				</Price>
+				{ discountPercentage > 0 ? (
+					<SavePill>
+						{ translate( 'Save %(percent)s%%', {
+							args: { percent: discountPercentage },
+						} ) }
+					</SavePill>
+				) : (
+					<SavePillPlaceholder aria-hidden="true">&nbsp;</SavePillPlaceholder>
+				) }
+			</Tile>
+		);
+	}
+);
+
+ButtonTile.displayName = 'ButtonTile';
 
 export const ItemVariationButtonRow: FunctionComponent< ItemVariationPickerProps > = ( {
 	selectedItem,
@@ -161,21 +178,78 @@ export const ItemVariationButtonRow: FunctionComponent< ItemVariationPickerProps
 	const [ optimisticSelectedItem, setOptimisticSelectedItem ] = useState(
 		selectedItem.product_slug
 	);
+	const tileRefs = useRef< Array< HTMLButtonElement | null > >( [] );
 
 	useEffect( () => {
 		setOptimisticSelectedItem( selectedItem.product_slug );
 	}, [ selectedItem ] );
+
+	const selectedIndex = variants.findIndex(
+		( variant ) => variant.productSlug === optimisticSelectedItem
+	);
+
+	const handleChange: OnChangeItemVariant = useCallback(
+		( uuid, productSlug, productId, volume ) => {
+			setOptimisticSelectedItem( productSlug );
+			onChangeItemVariant( uuid, productSlug, productId, volume );
+		},
+		[ onChangeItemVariant ]
+	);
+
+	const moveSelection = useCallback(
+		( newIndex: number ) => {
+			const variant = variants[ newIndex ];
+			if ( ! variant ) {
+				return;
+			}
+			tileRefs.current[ newIndex ]?.focus();
+			if ( variant.productSlug !== optimisticSelectedItem ) {
+				handleChange( selectedItem.uuid, variant.productSlug, variant.productId, variant.volume );
+			}
+		},
+		[ variants, optimisticSelectedItem, selectedItem.uuid, handleChange ]
+	);
+
+	const handleKeyDown = useCallback(
+		( event: KeyboardEvent< HTMLDivElement > ) => {
+			if ( isDisabled ) {
+				return;
+			}
+			const last = variants.length - 1;
+			const current = selectedIndex >= 0 ? selectedIndex : 0;
+			let next: number | null = null;
+			switch ( event.key ) {
+				case 'ArrowRight':
+				case 'ArrowDown':
+					next = current === last ? 0 : current + 1;
+					break;
+				case 'ArrowLeft':
+				case 'ArrowUp':
+					next = current === 0 ? last : current - 1;
+					break;
+				case 'Home':
+					next = 0;
+					break;
+				case 'End':
+					next = last;
+					break;
+			}
+			if ( next !== null ) {
+				event.preventDefault();
+				moveSelection( next );
+			}
+		},
+		[ isDisabled, variants.length, selectedIndex, moveSelection ]
+	);
 
 	if ( variants.length < 2 ) {
 		return null;
 	}
 
 	const compareTo = variants[ 0 ];
-
-	const handleChange: OnChangeItemVariant = ( uuid, productSlug, productId, volume ) => {
-		setOptimisticSelectedItem( productSlug );
-		onChangeItemVariant( uuid, productSlug, productId, volume );
-	};
+	// If nothing matches the cart's selected slug, make the first tile the
+	// keyboard entry point so the radiogroup is still focusable.
+	const focusableIndex = selectedIndex >= 0 ? selectedIndex : 0;
 
 	return (
 		<Row
@@ -183,16 +257,21 @@ export const ItemVariationButtonRow: FunctionComponent< ItemVariationPickerProps
 			aria-label={ translate( 'Pick a product term' ) }
 			className="item-variation-picker"
 			count={ variants.length }
+			onKeyDown={ handleKeyDown }
 		>
-			{ variants.map( ( variant ) => (
+			{ variants.map( ( variant, index ) => (
 				<ButtonTile
 					key={ variant.productSlug + variant.variantLabel.noun }
+					ref={ ( el ) => {
+						tileRefs.current[ index ] = el;
+					} }
 					productVariant={ variant }
 					selectedItem={ selectedItem }
 					onChangeItemVariant={ handleChange }
 					isDisabled={ isDisabled }
 					compareTo={ compareTo }
 					isActive={ variant.productSlug === optimisticSelectedItem }
+					tabIndex={ index === focusableIndex ? 0 : -1 }
 				/>
 			) ) }
 		</Row>

--- a/client/my-sites/checkout/src/components/item-variation-picker/item-variation-button-row.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/item-variation-button-row.tsx
@@ -1,0 +1,192 @@
+import colorStudio from '@automattic/color-studio';
+import { formatCurrency } from '@automattic/number-formatters';
+import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useState, type FunctionComponent } from 'react';
+import { getItemVariantDiscount } from './util';
+import type { ItemVariationPickerProps, WPCOMProductVariant, OnChangeItemVariant } from './types';
+import type { ResponseCartProduct } from '@automattic/shopping-cart';
+
+const Row = styled.div< { count: number } >`
+	display: grid;
+	grid-template-columns: repeat( ${ ( props ) => props.count }, 1fr );
+	gap: 10px;
+	margin: 20px 0;
+	width: 100%;
+`;
+
+const Tile = styled.button< { active: boolean } >`
+	display: flex;
+	align-items: center;
+	gap: 14px;
+	padding: ${ ( props ) => ( props.active ? '12px 17px' : '13px 18px' ) };
+	border: ${ ( props ) =>
+		props.active
+			? `2px solid ${ colorStudio.colors[ 'Blue 50' ] }`
+			: `1px solid ${ colorStudio.colors[ 'Gray 5' ] }` };
+	border-radius: 3px;
+	background: #fff;
+	cursor: pointer;
+	text-align: start;
+	font: inherit;
+
+	&:disabled {
+		cursor: default;
+		opacity: 0.5;
+	}
+
+	&:focus-visible {
+		outline: 2px solid ${ colorStudio.colors[ 'Blue 50' ] };
+		outline-offset: 2px;
+	}
+`;
+
+const Label = styled.span`
+	flex: 1;
+	font-size: 15px;
+	font-weight: 500;
+	color: ${ colorStudio.colors[ 'Black' ] };
+`;
+
+const PriceColumn = styled.span`
+	display: flex;
+	flex-direction: column;
+	align-items: flex-end;
+	gap: 4px;
+`;
+
+const Price = styled.span`
+	font-size: 15px;
+	font-weight: 500;
+	font-variant-numeric: tabular-nums;
+	color: ${ colorStudio.colors[ 'Black' ] };
+`;
+
+const PriceSuffix = styled.span`
+	color: ${ colorStudio.colors[ 'Gray 60' ] };
+`;
+
+const SavePill = styled.span`
+	font-size: 11px;
+	font-weight: 500;
+	line-height: 16px;
+	color: ${ colorStudio.colors[ 'Green 80' ] };
+	background: ${ colorStudio.colors[ 'Green 5' ] };
+	padding: 1px 7px;
+	border-radius: 3px;
+	white-space: nowrap;
+`;
+
+interface TileProps {
+	productVariant: WPCOMProductVariant;
+	selectedItem: ResponseCartProduct;
+	onChangeItemVariant: OnChangeItemVariant;
+	isDisabled: boolean;
+	compareTo?: WPCOMProductVariant;
+	isActive: boolean;
+}
+
+const ButtonTile: FunctionComponent< TileProps > = ( {
+	productVariant,
+	selectedItem,
+	onChangeItemVariant,
+	isDisabled,
+	compareTo,
+	isActive,
+} ) => {
+	const translate = useTranslate();
+	const { variantLabel, productSlug, productId, termIntervalInMonths } = productVariant;
+
+	let priceTermIntervalInMonths = termIntervalInMonths;
+	if ( productVariant.introductoryTerm === 'month' ) {
+		priceTermIntervalInMonths = productVariant.introductoryInterval ?? 1;
+	}
+	const pricePerMonth = Math.round( productVariant.priceInteger / priceTermIntervalInMonths );
+	const pricePerMonthFormatted = formatCurrency( pricePerMonth, productVariant.currency, {
+		stripZeros: true,
+		isSmallestUnit: true,
+	} );
+
+	const label = termIntervalInMonths === 1 ? translate( 'Month' ) : variantLabel.noun;
+	const discountPercentage = getItemVariantDiscount( productVariant, compareTo );
+
+	return (
+		<Tile
+			type="button"
+			role="radio"
+			aria-checked={ isActive }
+			active={ isActive }
+			disabled={ isDisabled }
+			data-product-slug={ productSlug }
+			onClick={ () => {
+				if ( isDisabled || isActive ) {
+					return;
+				}
+				onChangeItemVariant( selectedItem.uuid, productSlug, productId );
+			} }
+		>
+			<Label>{ label }</Label>
+			<PriceColumn>
+				<Price>
+					{ pricePerMonthFormatted }
+					<PriceSuffix>{ translate( '/mo' ) }</PriceSuffix>
+				</Price>
+				{ discountPercentage > 0 && (
+					<SavePill>
+						{ translate( 'Save %(percent)s%%', {
+							args: { percent: discountPercentage },
+						} ) }
+					</SavePill>
+				) }
+			</PriceColumn>
+		</Tile>
+	);
+};
+
+export const ItemVariationButtonRow: FunctionComponent< ItemVariationPickerProps > = ( {
+	selectedItem,
+	onChangeItemVariant,
+	isDisabled,
+	variants,
+} ) => {
+	const translate = useTranslate();
+	const [ optimisticSelectedItem, setOptimisticSelectedItem ] = useState(
+		selectedItem.product_slug
+	);
+
+	useEffect( () => {
+		setOptimisticSelectedItem( selectedItem.product_slug );
+	}, [ selectedItem ] );
+
+	if ( variants.length < 2 ) {
+		return null;
+	}
+
+	const compareTo = variants[ 0 ];
+
+	const handleChange: OnChangeItemVariant = ( uuid, productSlug, productId, volume ) => {
+		setOptimisticSelectedItem( productSlug );
+		onChangeItemVariant( uuid, productSlug, productId, volume );
+	};
+
+	return (
+		<Row
+			role="radiogroup"
+			aria-label={ translate( 'Pick a product term' ) }
+			className="item-variation-picker"
+			count={ variants.length }
+		>
+			{ variants.map( ( variant ) => (
+				<ButtonTile
+					key={ variant.productSlug + variant.variantLabel.noun }
+					productVariant={ variant }
+					selectedItem={ selectedItem }
+					onChangeItemVariant={ handleChange }
+					isDisabled={ isDisabled }
+					compareTo={ compareTo }
+					isActive={ variant.productSlug === optimisticSelectedItem }
+				/>
+			) ) }
+		</Row>
+	);
+};


### PR DESCRIPTION
Part of #

## Proposed Changes

* Replace the stacked subscription-length radio variants with a side-by-side button row for WordPress.com plans on large viewports. Each tile stacks the term label, the per-month price, and a "Save X%" pill, all left-aligned.
* On narrow desktops (≤1024px), drop the form column's right padding so step content reaches column 2's right edge, matching the trust cards row beneath. Bump the trust cards' left inset to 64px so they line up with the form's line items above.

## Why are these changes being made?

The stacked radio picker put each subscription term on its own full-width row. Side-by-side tiles fit all four into one row, with the per-month price and "Save X%" pill on every tile so customers can compare term-by-term without scrolling.

At narrower desktop widths the trust cards extended further right than the form's step content above them, with the gutter between form and sidebar already tight. Lining the two up makes the form, picker, and trust cards read as one column.

## Testing Instructions

* Open a checkout for a WordPress.com plan with multiple term variants (e.g., Premium: month / 1 year / 2 years / 3 years).
* On a large desktop (≥1024px), confirm the side-by-side tile picker replaces the stacked radios.
* Each tile shows the term label, the per-month price, and a green "Save X%" pill (when applicable), all left-aligned.
* The "Month" tile (no discount) reserves vertical space where the Save pill would sit, so all four tiles are the same height.
* The active tile gets a blue border.
* Between 960px and 1024px, the form column reaches column 2's right edge and aligns with the trust cards beneath.
* Above 1024px, the form column reverts to its original 64px right padding.
* On a non-WordPress.com cart (e.g., a domain-only purchase), the dropdown picker still renders.
* Below 960px, the stacked radio picker still renders.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?