### PR TITLE
Push notifications: replace require() with ESM import

### DIFF
--- a/client/state/push-notifications/actions.js
+++ b/client/state/push-notifications/actions.js
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import debugFactory from 'debug';
 import { registerServerWorker } from 'calypso/lib/service-worker';
+import { isSupportSession } from 'calypso/lib/user/support-user-interop';
 import wpcom from 'calypso/lib/wp';
 import {
 	PUSH_NOTIFICATIONS_API_READY,
@@ -33,13 +34,9 @@ const serviceWorkerOptions = {
 
 export function init() {
 	return ( dispatch ) => {
-		// require `lib/user/support-user-interop` here so that unit tests don't
-		// fail because of lack of `window` global when importing this module
-		// from test (before a chance to mock things is possible)
 		// TODO: read the `isSupportSession` flag with a Redux selector instead. That requires
 		// reorganizing the `configureReduxStore` function so that the flag is set *before* this
 		// init function is called. That currently happens too late, in a promise resolution callback.
-		const { isSupportSession } = require( 'calypso/lib/user/support-user-interop' );
 		if ( isSupportSession() ) {
 			debug( 'Push Notifications are not supported when SU is active' );
 			dispatch( apiNotReady() );


### PR DESCRIPTION
## Proposed Changes

* Replace the late `require( 'calypso/lib/user/support-user-interop' )` inside `init()` with a top-level static `import`, making `client/state/push-notifications/actions.js` pure ESM.

## Why are these changes being made?

The `require()` was added in 619e446b687 (#7746) back in 2016 as a workaround for unit tests failing due to a missing `window` global at import time. Enough has changed in our test setup since then that the workaround is no longer needed — tests pass with a normal ESM import — and removing it lets this module be pure ESM.

## Testing Instructions

* Run `yarn test-client --findRelatedTests client/state/push-notifications/actions.js`.
* Smoke-test push notifications init in the browser (no regressions when SU session is / isn't active).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?