### PR TITLE
Notifications app: replace require() with ESM imports

### DIFF
--- a/apps/notifications/src/panel/Notifications.jsx
+++ b/apps/notifications/src/panel/Notifications.jsx
@@ -1,3 +1,4 @@
+import debugFactory from 'debug';
 import PropTypes from 'prop-types';
 import { createContext, PureComponent } from 'react';
 import { Provider } from 'react-redux';
@@ -9,9 +10,10 @@ import { SET_IS_SHOWING } from './state/action-types';
 import actions from './state/actions';
 import { addListeners, removeListeners } from './state/create-listener-middleware';
 import Layout from './templates';
-const debug = require( 'debug' )( 'notifications:panel' );
 
 import './boot/stylesheets/style.scss';
+
+const debug = debugFactory( 'notifications:panel' );
 
 let client;
 

--- a/apps/notifications/src/panel/comment-replies-cache/index.js
+++ b/apps/notifications/src/panel/comment-replies-cache/index.js
@@ -2,7 +2,9 @@
  * @module comment-replies-cache/index
  */
 
-const debug = require( 'debug' )( 'notifications:note' );
+import debugFactory from 'debug';
+
+const debug = debugFactory( 'notifications:note' );
 
 function getItem( key ) {
 	let item;

--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -1,9 +1,11 @@
+import debugFactory from 'debug';
 import repliesCache from '../comment-replies-cache';
 import { store } from '../state';
 import actions from '../state/actions';
 import getAllNotes from '../state/selectors/get-all-notes';
 import { fetchNote, listNotes, sendLastSeenTime, subscribeToNoteStream } from './wpcom';
-const debug = require( 'debug' )( 'notifications:rest-client' );
+
+const debug = debugFactory( 'notifications:rest-client' );
 
 const settings = {
 	max_refresh_ms: 180000,

--- a/apps/notifications/src/panel/templates/comment-reply-input.jsx
+++ b/apps/notifications/src/panel/templates/comment-reply-input.jsx
@@ -1,8 +1,10 @@
+import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
 import { createRef, Component } from 'react';
 import { connect } from 'react-redux';
 import repliesCache from '../comment-replies-cache';
 import { modifierKeyIsActive } from '../helpers/input';
+import { recordTracksEvent } from '../helpers/stats';
 import { bumpStat } from '../rest-client/bump-stat';
 import { wpcom } from '../rest-client/wpcom';
 import actions from '../state/actions';
@@ -10,8 +12,8 @@ import getKeyboardShortcutsEnabled from '../state/selectors/get-keyboard-shortcu
 import Suggestions from '../suggestions';
 import { formatString, validURL } from './functions';
 import Spinner from './spinner';
-const debug = require( 'debug' )( 'notifications:reply' );
-const { recordTracksEvent } = require( '../helpers/stats' );
+
+const debug = debugFactory( 'notifications:reply' );
 
 function stopEvent( event ) {
 	event.stopPropagation();

--- a/apps/notifications/src/panel/templates/undo-list-item.jsx
+++ b/apps/notifications/src/panel/templates/undo-list-item.jsx
@@ -2,13 +2,13 @@ import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import { modifierKeyIsActive } from '../helpers/input';
+import { recordTracksEvent } from '../helpers/stats';
 import { bumpStat } from '../rest-client/bump-stat';
 import { wpcom } from '../rest-client/wpcom';
 import actions from '../state/actions';
 import getKeyboardShortcutsEnabled from '../state/selectors/get-keyboard-shortcuts-enabled';
 import getSelectedNoteId from '../state/selectors/get-selected-note-id';
 import Gridicon from './gridicons';
-const { recordTracksEvent } = require( '../helpers/stats' );
 
 const KEY_U = 85;
 

--- a/apps/notifications/src/standalone/index.jsx
+++ b/apps/notifications/src/standalone/index.jsx
@@ -1,14 +1,16 @@
 import '@automattic/calypso-polyfills';
 import { setLocaleData } from '@wordpress/i18n';
+import debugFactory from 'debug';
 import { setLocale } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import Notifications, { refreshNotes } from '../panel/Notifications';
 import { createClient } from './client';
 import { receiveMessage, sendMessage } from './messaging';
-const debug = require( 'debug' )( 'notifications:standalone' );
 
 import '../panel/boot/stylesheets/style.scss';
+
+const debug = debugFactory( 'notifications:standalone' );
 
 const localePattern = /[&?]locale=([\w_-]+)/;
 const match = localePattern.exec( document.location.search );


### PR DESCRIPTION
## Proposed Changes

* Replace `require()` calls in `apps/notifications/src/` with standard ESM imports.
* `debug` initialisations switched from `require('debug')(...)` to `import debugFactory from 'debug'` followed by `debugFactory(...)`, matching the existing pattern in `src/standalone/messaging.js`.

## Why are these changes being made?

Pure ESM source enables Vite bundling. Config files (`webpack.config.js`, `.eslintrc.js`, `postcss.config.js`, `jest.config.js`) are loaded by Node tooling and not bundled, so they remain CJS.

## Testing Instructions

* `yarn eslint apps/notifications/src` — clean
* `yarn run -T test-apps apps/notifications` — 3 suites, 9 tests pass
* `cd apps/notifications && yarn build:notifications` — webpack build succeeds

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?