### PR TITLE
Me: convert profile controller require() to dynamic import() for ESM

### DIFF
--- a/client/me/controller.jsx
+++ b/client/me/controller.jsx
@@ -25,8 +25,8 @@ export function sidebar( context, next ) {
 	next();
 }
 
-export function profile( context, next ) {
-	const ProfileComponent = require( 'calypso/me/profile' ).default;
+export async function profile( context, next ) {
+	const { default: ProfileComponent } = await import( 'calypso/me/profile' );
 	const ProfileTitle = () => {
 		const translate = useTranslate();
 


### PR DESCRIPTION
## Proposed Changes

* Replace `require( 'calypso/me/profile' )` in the `profile` controller with `await import( 'calypso/me/profile' )`.

## Why are these changes being made?

CommonJS `require()` calls block migration to ESM (and ultimately Vite 8).

The `require()` was originally introduced in #22319 (2018) to defer module initialization of `calypso/me/profile`. That module imports the `twoStepAuthorization` singleton (`client/lib/two-step-authorization/index.js`), which runs `new TwoStepAuthorization()` at module load — its constructor immediately calls `this.fetch()` against `/me/two-step/`. Eager loading caused premature reauths and extra 2FA SMSes, so the import had to be deferred until the route actually ran.

Dynamic `import()` preserves that lazy behavior while being ESM-compatible.

## Testing Instructions

* Run `yarn start` and log in.
* Navigate to `/me` (the profile page) — it should render normally with no console errors.
* Try each profile field (display name, location, about) and confirm Save still works.
* Navigate away to e.g. `/read`, then back to `/me` — page should re-render cleanly.
* In the network panel, confirm `/me/two-step/` is **not** requested while on a non-`/me` route, and **is** requested once you land on `/me/profile`. This verifies the lazy-load behavior is preserved.
* Confirm no extra 2FA SMS / reauth prompts appear when navigating around the app.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?