### PR TITLE
TimeSince: fix locale-dependent unit test; drop unused locale prop

### DIFF
--- a/packages/components/src/time-since/index.tsx
+++ b/packages/components/src/time-since/index.tsx
@@ -17,10 +17,6 @@ interface TimeSinceProps {
 	 * CSS class for the <time> element.
 	 */
 	className?: string;
-	/**
-	 * BCP 47 locale string (e.g., "en", "es-ES"). Defaults to the user's locale.
-	 */
-	locale?: string;
 }
 
 /**
@@ -29,6 +25,7 @@ interface TimeSinceProps {
 function useRelativeTime( date: string, dateFormat = 'll' ) {
 	const [ now, setNow ] = useState( () => new Date() );
 	const translate = useTranslate();
+	const { localeSlug } = translate;
 
 	useEffect( () => {
 		const intervalId = setInterval( () => setNow( new Date() ), 10000 );
@@ -41,7 +38,7 @@ function useRelativeTime( date: string, dateFormat = 'll' ) {
 
 		// Handle invalid or future dates
 		if ( isNaN( dateObj.getTime() ) || millisAgo < 0 ) {
-			return formatDate( dateObj, dateFormat );
+			return formatDate( dateObj, dateFormat, localeSlug );
 		}
 
 		const secondsAgo = Math.floor( millisAgo / 1000 );
@@ -79,8 +76,8 @@ function useRelativeTime( date: string, dateFormat = 'll' ) {
 		}
 
 		// For older dates, use the date format
-		return formatDate( dateObj, dateFormat, translate.localeSlug );
-	}, [ now, date, dateFormat, translate ] );
+		return formatDate( dateObj, dateFormat, localeSlug );
+	}, [ now, date, dateFormat, translate, localeSlug ] );
 }
 
 /**

--- a/packages/components/src/time-since/test/time-since.test.tsx
+++ b/packages/components/src/time-since/test/time-since.test.tsx
@@ -113,13 +113,4 @@ describe( 'TimeSince', () => {
 		} ).format( d );
 		expect( screen.getByText( formatted ) ).toBeInTheDocument();
 	} );
-
-	it( 'uses locale prop', () => {
-		const date = new Date( FIXED_NOW.getTime() - 10 * 24 * 60 * 60 * 1000 ).toISOString();
-		render( <TimeSince date={ date } locale="es-ES" /> );
-		const formatted = new Intl.DateTimeFormat( 'en', { dateStyle: 'medium' } ).format(
-			new Date( date )
-		);
-		expect( screen.getByText( formatted ) ).toBeInTheDocument();
-	} );
 } );


### PR DESCRIPTION
## Proposed Changes

* Fix the future-date branch in `useRelativeTime` to pass `localeSlug` to `formatDate`, matching the past-date branch. Without this, `Intl.DateTimeFormat` falls back to the system locale.
* Remove `TimeSinceProps.locale` — declared but never destructured by the component, so the prop has been dead since it was added in #102334. No production callers pass it.
* Remove the corresponding `uses locale prop` unit test (it asserted the en-US result regardless of the input locale, so it was masking the dead prop).

## Why are these changes being made?

The unit test ``renders formatted date for future date`` fails on any non-en-US machine, because:
* The test computes the expected string with `Intl.DateTimeFormat( 'en', ... )` → ``Jun 12, 2024``.
* The component's future-date branch called ``formatDate( dateObj, dateFormat )`` with no locale arg, so `Intl.DateTimeFormat( undefined, ... )` used the OS locale (e.g. en-GB → ``12 Jun 2024``).

CI runs en-US so this slipped through.

While investigating I found `TimeSinceProps.locale` was added in #102334 alongside the `translate.localeSlug` plumbing, but the component function never destructured it. A grep across the repo confirms no caller passes it. The single test that exercised it was constructed to pass regardless (it expected the en result while passing `locale=\"es-ES\"`), so it never caught the dead-code issue.

## Testing Instructions

* `yarn test-packages packages/components/src/time-since` passes on machines with non-en-US locales.
* Browser smoke test (verifies the past-date branch is still locale-aware end-to-end):
  1. Set your WordPress.com interface language to a non-English locale (e.g. Español) at https://wordpress.com/me/account.
  2. Open the Reader (https://wordpress.com/read) and find any post older than a week.
  3. The ``<TimeSince>`` text under the post byline should render in the chosen locale (e.g. ``12 jun 2024``), and the hover tooltip (title attribute) should also be localised.
  4. Switch back to English and confirm dates render in English again.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?