### PR TITLE
Writing prompt cleanup

### DIFF
--- a/client/components/blogging-prompt-card/prompts-navigation.jsx
+++ b/client/components/blogging-prompt-card/prompts-navigation.jsx
@@ -1,4 +1,5 @@
 import { Button, Gridicon } from '@automattic/components';
+import { decodeEntities } from '@wordpress/html-entities';
 import { addQueryArgs } from '@wordpress/url';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -150,7 +151,9 @@ const PromptsNavigation = ( { siteId, prompts, tracksPrefix, index, menu } ) => 
 					>
 						<Gridicon icon={ backIcon } size={ 18 } />
 					</Button>
-					<p className="blogging-prompt__prompt-text">{ getPrompt()?.text }</p>
+					<p className="blogging-prompt__prompt-text">
+						{ decodeEntities( getPrompt()?.text ?? '' ) }
+					</p>
 					<Button
 						aria-label={ translate( 'Show next prompt' ) }
 						borderless={ false }


### PR DESCRIPTION
Part of RSM-2161

## Proposed Changes

* I inserted new writing prompts but today's prompt has a single quote. It came html encoded. 
* I fixed it on the backend but the responses get cached for 24h

## Why are these changes being made?

* Fix &#039; visible on the front-end

## Testing Instructions

On a blog with writing prompts active and launched, ensure no encoded single quote appears:

<img width="720" height="245" alt="Screenshot 2026-05-04 at 15 36 56" src="https://github.com/user-attachments/assets/eb8dd826-ce46-4a7f-a25d-57a7f321c212" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
